### PR TITLE
Add core services and bot bootstrap

### DIFF
--- a/superbot/.env.example
+++ b/superbot/.env.example
@@ -1,0 +1,4 @@
+DISCORD_TOKEN=your_token_here
+LOG_LEVEL=INFO
+DB_PATH=superbot/data/db/superbot.sqlite3
+GUILD_ID=

--- a/superbot/config.py
+++ b/superbot/config.py
@@ -1,0 +1,69 @@
+"""Application settings management."""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+from pydantic import BaseModel, Field, ValidationError
+
+BASE_DIR = Path(__file__).resolve().parent
+
+
+class Settings(BaseModel):
+    """Application settings loaded from environment and configuration files."""
+
+    discord_token: str = Field(alias="DISCORD_TOKEN")
+    log_level: str = Field(default="INFO", alias="LOG_LEVEL")
+    db_path: str = Field(default="superbot/data/db/superbot.sqlite3", alias="DB_PATH")
+    guild_id: int | None = Field(default=None, alias="GUILD_ID")
+
+    model_config = {"populate_by_name": True}
+
+
+def _read_env_file(path: Path) -> Dict[str, str]:
+    data: Dict[str, str] = {}
+    if not path.is_file():
+        return data
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        data[key.strip()] = value.strip()
+    return data
+
+
+def _read_yaml_file(path: Path) -> Dict[str, Any]:
+    if not path.is_file():
+        return {}
+    with path.open("r", encoding="utf-8") as f:
+        loaded = yaml.safe_load(f) or {}
+    if not isinstance(loaded, dict):
+        return {}
+    return {str(k): v for k, v in loaded.items()}
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    """Return application settings.
+
+    Raises:
+        RuntimeError: If required settings are missing.
+    """
+
+    env_data = _read_env_file(BASE_DIR / ".env")
+    yaml_data = _read_yaml_file(BASE_DIR / "settings.yml")
+    data = {**env_data, **yaml_data, **os.environ}
+    try:
+        settings = Settings(**data)
+    except ValidationError as exc:
+        raise RuntimeError("Invalid configuration") from exc
+
+    if not settings.discord_token:
+        raise RuntimeError("DISCORD_TOKEN is required")
+
+    return settings

--- a/superbot/main.py
+++ b/superbot/main.py
@@ -1,0 +1,53 @@
+"""Application entrypoint for Superbot."""
+
+from __future__ import annotations
+
+import asyncio
+import signal
+import sys
+from pathlib import Path
+
+import discord
+from discord.ext import commands
+
+BASE_DIR = Path(__file__).resolve().parent
+sys.path.append(str(BASE_DIR / "src"))
+
+from config import get_settings
+
+from superbot.core.services.db import DB
+from superbot.core.services.errors import register_global_error_handler
+from superbot.core.services.logging_service import setup_logging
+from superbot.loaders.cogs import load_all
+
+
+async def main() -> None:
+    """Run the Discord bot."""
+    settings = get_settings()
+    setup_logging(settings.log_level)
+    await DB.init(settings.db_path)
+    await DB.run_migrations()
+
+    intents = discord.Intents.none()
+    intents.guilds = True
+    bot = commands.Bot(command_prefix="!", intents=intents)
+
+    register_global_error_handler(bot)
+    await load_all(bot)
+
+    loop = asyncio.get_running_loop()
+
+    def _handle_shutdown() -> None:
+        loop.create_task(bot.close())
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, _handle_shutdown)
+
+    try:
+        await bot.start(settings.discord_token)
+    finally:
+        await DB.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/superbot/src/superbot/core/services/db.py
+++ b/superbot/src/superbot/core/services/db.py
@@ -1,0 +1,84 @@
+"""Asynchronous database manager."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import aiosqlite
+
+
+class DB:
+    """Simple aiosqlite-based database manager."""
+
+    _conn: aiosqlite.Connection | None = None
+
+    @classmethod
+    async def init(cls, db_path: str) -> None:
+        """Initialize the database connection.
+
+        Args:
+            db_path: Path to the SQLite database file.
+        """
+        if cls._conn is not None:
+            return
+        path = Path(db_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        cls._conn = await aiosqlite.connect(path)
+        cls._conn.row_factory = aiosqlite.Row
+        await cls._conn.execute(
+            "CREATE TABLE IF NOT EXISTS schema_version (version INTEGER PRIMARY KEY)",
+        )
+        await cls._conn.commit()
+
+    @classmethod
+    @asynccontextmanager
+    async def acquire(cls) -> AsyncIterator[aiosqlite.Connection]:
+        """Acquire the database connection."""
+        if cls._conn is None:
+            raise RuntimeError("Database not initialized")
+        yield cls._conn
+
+    @classmethod
+    async def close(cls) -> None:
+        """Close the database connection."""
+        if cls._conn is not None:
+            await cls._conn.close()
+            cls._conn = None
+
+    @classmethod
+    async def run_migrations(cls) -> None:
+        """Run database migrations from numbered SQL files."""
+        if cls._conn is None:
+            raise RuntimeError("Database not initialized")
+        project_root = Path(__file__).resolve().parents[4]
+        migrations_dir = project_root / "migrations"
+        migrations_dir.mkdir(parents=True, exist_ok=True)
+
+        current_version = await cls._get_version()
+        for path in sorted(migrations_dir.glob("*.sql")):
+            try:
+                version = int(path.stem)
+            except ValueError:
+                continue
+            if version <= current_version:
+                continue
+            with path.open("r", encoding="utf-8") as f:
+                await cls._conn.executescript(f.read())
+            await cls._conn.execute(
+                "REPLACE INTO schema_version (version) VALUES (?)",
+                (version,),
+            )
+            await cls._conn.commit()
+            current_version = version
+
+    @classmethod
+    async def _get_version(cls) -> int:
+        if cls._conn is None:
+            return 0
+        async with cls._conn.execute(
+            "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1",
+        ) as cur:
+            row = await cur.fetchone()
+            return int(row["version"]) if row else 0

--- a/superbot/src/superbot/core/services/errors.py
+++ b/superbot/src/superbot/core/services/errors.py
@@ -1,0 +1,67 @@
+"""Global error handling utilities."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+logger = logging.getLogger(__name__)
+
+
+def register_global_error_handler(bot: commands.Bot) -> None:
+    """Register a global error handler on the bot."""
+
+    @bot.tree.error
+    async def on_app_command_error(
+        interaction: discord.Interaction,
+        error: app_commands.AppCommandError,
+    ) -> None:
+        message = _format_error(error)
+        logger.error(
+            "App command error in %s by %s: %s",
+            getattr(interaction.command, "name", "unknown"),
+            interaction.user,
+            error,
+            exc_info=error,
+        )
+        try:
+            if interaction.response.is_done():
+                await interaction.followup.send(message, ephemeral=True)
+            else:
+                await interaction.response.send_message(message, ephemeral=True)
+        except discord.HTTPException:
+            logger.warning("Failed to send error message for interaction")
+
+    @bot.event
+    async def on_command_error(
+        ctx: commands.Context[Any],
+        error: commands.CommandError,
+    ) -> None:
+        message = _format_error(error)
+        logger.error(
+            "Command error in %s by %s: %s",
+            getattr(ctx.command, "qualified_name", "unknown"),
+            getattr(ctx.author, "id", "unknown"),
+            error,
+            exc_info=error,
+        )
+        try:
+            await ctx.send(message)
+        except discord.HTTPException:
+            logger.warning("Failed to send error message for text command")
+
+
+def _format_error(error: Exception) -> str:
+    if isinstance(error, commands.CommandOnCooldown | app_commands.CommandOnCooldown):
+        return "This command is on cooldown."
+    if isinstance(error, commands.BadArgument):
+        return "Invalid argument provided."
+    if isinstance(error, discord.Forbidden):
+        return "I lack the required permissions."
+    if isinstance(error, discord.HTTPException):
+        return "A Discord API error occurred."
+    return "An unexpected error occurred."

--- a/superbot/src/superbot/core/services/logging_service.py
+++ b/superbot/src/superbot/core/services/logging_service.py
@@ -1,0 +1,45 @@
+"""Logging configuration service."""
+
+from __future__ import annotations
+
+import logging
+import logging.handlers
+from pathlib import Path
+
+LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s %(message)s"
+
+
+def setup_logging(level: str | int) -> logging.Logger:
+    """Configure and return the application root logger.
+
+    Args:
+        level: Logging level as name or integer.
+
+    Returns:
+        Configured root logger.
+    """
+    log_level = logging.getLevelName(level) if isinstance(level, str) else level
+    root_logger = logging.getLogger()
+    root_logger.setLevel(log_level)
+    for handler in list(root_logger.handlers):
+        root_logger.removeHandler(handler)
+
+    project_root = Path(__file__).resolve().parents[4]
+    log_file = project_root / "data" / "logs" / "app.log"
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+
+    formatter = logging.Formatter(LOG_FORMAT)
+
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(formatter)
+    root_logger.addHandler(console_handler)
+
+    file_handler = logging.handlers.RotatingFileHandler(
+        log_file,
+        maxBytes=1_000_000,
+        backupCount=3,
+    )
+    file_handler.setFormatter(formatter)
+    root_logger.addHandler(file_handler)
+
+    return root_logger

--- a/superbot/src/superbot/features/basic/__init__.py
+++ b/superbot/src/superbot/features/basic/__init__.py
@@ -1,0 +1,1 @@
+"""Basic feature package."""

--- a/superbot/src/superbot/features/basic/ping.py
+++ b/superbot/src/superbot/features/basic/ping.py
@@ -1,0 +1,36 @@
+"""Basic ping command cog."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+logger = logging.getLogger(__name__)
+
+
+class Ping(commands.Cog):
+    """Provide a basic latency check command."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        """Initialize the cog."""
+        self.bot = bot
+
+    @app_commands.command(name="ping", description="Return bot latency.")
+    async def ping(self, interaction: discord.Interaction) -> None:
+        """Respond with bot latency and environment name."""
+        latency_ms = self.bot.latency * 1000
+        env_name = os.getenv("ENV_NAME", "development")
+        logger.info("Ping invoked by %s", interaction.user)
+        await interaction.response.send_message(
+            f"Pong! {latency_ms:.0f}ms | {env_name}",
+            ephemeral=True,
+        )
+
+
+async def setup(bot: commands.Bot) -> None:
+    """Load the ping cog."""
+    await bot.add_cog(Ping(bot))

--- a/superbot/src/superbot/loaders/cogs.py
+++ b/superbot/src/superbot/loaders/cogs.py
@@ -1,0 +1,43 @@
+"""Dynamic cog loader utilities."""
+
+from __future__ import annotations
+
+import logging
+from importlib import import_module
+from pathlib import Path
+
+from discord.ext import commands
+
+FEATURES_PATH = Path(__file__).resolve().parents[1] / "features"
+logger = logging.getLogger(__name__)
+
+
+def discover_feature_modules() -> list[str]:
+    """Discover feature modules containing a ``setup`` function."""
+    modules: list[str] = []
+    base_package = "superbot"
+    for path in FEATURES_PATH.rglob("*.py"):
+        if path.name == "__init__.py":
+            continue
+        rel = path.relative_to(FEATURES_PATH.parent)
+        module_name = ".".join((base_package, *rel.with_suffix("").parts))
+        try:
+            module = import_module(module_name)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Failed to import %s", module_name, exc_info=exc)
+            continue
+        if hasattr(module, "setup"):
+            modules.append(module_name)
+    return modules
+
+
+async def load_all(bot: commands.Bot) -> None:
+    """Load all discovered feature modules."""
+    for module in discover_feature_modules():
+        await bot.load_extension(module)
+
+
+async def unload_all(bot: commands.Bot) -> None:
+    """Unload all discovered feature modules."""
+    for module in discover_feature_modules():
+        await bot.unload_extension(module)


### PR DESCRIPTION
## Summary
- implement Pydantic settings loader
- add logging setup and async DB service with migrations
- wire up global error handling, cog loader, and basic ping command
- create bot entrypoint and sample env file

## Testing
- `ruff check superbot/src`
- `black --check superbot/src superbot/config.py superbot/main.py`
- `isort --check-only superbot/src superbot/config.py superbot/main.py`
- `mypy superbot/src superbot/config.py superbot/main.py`
- `python superbot/main.py` *(fails: Invalid configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689e53ac5a248322bcf826813ea9e452