### PR TITLE
Superbot minimal core with help and admin cogs

### DIFF
--- a/docs/minimal-foundation-plan.md
+++ b/docs/minimal-foundation-plan.md
@@ -1,0 +1,24 @@
+# Minimal Foundation Plan
+
+## Inventory
+
+- `superbot-start/helpers/config.py`: dataclass-based settings loader using `dotenv`. Provides inspiration for the new Pydantic settings module.
+- `superbot-start/helpers/logging.py`: simple logger initializer returning a named logger. Suitable to reuse with minimal changes.
+- `superbot-start/helpers/errors.py`: helper to log unexpected exceptions. Will be reused as-is.
+- `superbot-start/helpers/loader.py`: utility to discover and load extensions. Will inform the new cog loader.
+- No current implementations for `config.py`, `core/services/{logging_service.py, db.py, errors.py}`, or `loaders/cogs.py` under `superbot/src`—these will be introduced.
+
+## Plan
+
+- **Reuse unchanged**
+  - Exception reporting helper (`errors.py`).
+  - Basic logger initialization (`logging_service.py`).
+
+- **Extend**
+  - New `config.py` built on Pydantic v2 with robust `.env` discovery, ID parsing, directory creation, and predefined `PRELOAD_COGS` list.
+  - Cog loader in `loaders/cogs.py` that skips already loaded extensions and logs tracebacks on failure.
+
+- **Add**
+  - `main.py` that disables built-in help, initializes services, loads cogs, and syncs slash commands on startup.
+  - Feature cogs: `features/help/help_cog.py` and `features/admin/admin_core.py` implementing enhanced help and admin functionality.
+  - Minimal database service (`db.py`) using SQLite with optional migrations.

--- a/superbot/.env.example
+++ b/superbot/.env.example
@@ -1,0 +1,11 @@
+DISCORD_TOKEN=your-token
+COMMAND_PREFIX=!
+OWNER_IDS=[123456789012345678]      # or 123...,456...
+GUILD_IDS=[987654321098765432]      # leave empty [] for global sync
+STARTUP_CHANNEL_ID=0
+LOG_LEVEL=INFO
+LOG_WEBHOOK_URL=
+DB_PATH=superbot/data/superbot.db
+DATA_DIR=superbot/data
+LOG_DIR=superbot/logs
+TMP_DIR=superbot/tmp

--- a/superbot/main.py
+++ b/superbot/main.py
@@ -1,0 +1,70 @@
+"""Bot entrypoint."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+import discord
+from discord.ext import commands
+
+# Ensure src package on path
+ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from superbot.config import Settings  # noqa: E402
+from superbot.core.services.db import init_db  # noqa: E402
+from superbot.core.services.errors import report  # noqa: E402
+from superbot.core.services.logging_service import init_logging  # noqa: E402
+from superbot.loaders import cogs as cog_loader  # noqa: E402
+
+
+async def start_bot() -> None:
+    settings = Settings()
+    logger = init_logging(settings.log_level)
+    intents = discord.Intents.default()
+    intents.message_content = True
+    bot = commands.Bot(
+        command_prefix=settings.command_prefix,
+        intents=intents,
+        help_command=None,
+    )
+    bot.settings = settings  # type: ignore[attr-defined]
+    bot.logger = logger  # type: ignore[attr-defined]
+
+    @bot.event
+    async def on_error(event: str, *args: object, **kwargs: object) -> None:  # noqa: ANN401
+        logger.exception("Unhandled event %s", event)
+
+    @bot.event
+    async def on_ready() -> None:
+        logger.info("startup complete")
+        if settings.startup_channel_id:
+            channel = bot.get_channel(settings.startup_channel_id)
+            if channel:
+                await channel.send("Bot started")
+
+    async with bot:
+        await init_db(settings.db_path)
+        await cog_loader.load_all_cogs(bot, settings.preload_cogs)
+        if settings.guild_ids:
+            for gid in settings.guild_ids:
+                cmds = await bot.tree.sync(guild=discord.Object(id=gid))
+                logger.info("synced %s commands", len(cmds), extra={"guild": gid})
+        else:
+            cmds = await bot.tree.sync()
+            logger.info("synced %s global commands", len(cmds))
+        await bot.start(settings.discord_token)
+
+
+def main() -> None:
+    try:
+        asyncio.run(start_bot())
+    except Exception as exc:  # pragma: no cover
+        report(exc, "main")
+
+
+if __name__ == "__main__":
+    main()

--- a/superbot/src/superbot/config.py
+++ b/superbot/src/superbot/config.py
@@ -1,0 +1,78 @@
+"""Runtime configuration for the bot."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+def _load_env() -> None:
+    """Load .env files from common locations."""
+    project_root = Path(__file__).resolve().parents[2]
+    repo_root = Path(__file__).resolve().parents[3]
+    locations = [
+        project_root / ".env",  # superbot/.env
+        repo_root / ".env",  # repo root .env
+        Path.cwd() / ".env",  # cwd fallback
+    ]
+    for path in locations:
+        if path.is_file():
+            load_dotenv(path, override=False)
+
+
+_load_env()
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables."""
+
+    model_config = SettingsConfigDict(env_file=None, extra="ignore")
+
+    discord_token: str = Field(alias="DISCORD_TOKEN")
+    command_prefix: str = Field("!", alias="COMMAND_PREFIX")
+    owner_ids: list[int] = Field(default_factory=list, alias="OWNER_IDS")
+    guild_ids: list[int] = Field(default_factory=list, alias="GUILD_IDS")
+    startup_channel_id: int = Field(0, alias="STARTUP_CHANNEL_ID")
+    log_level: str = Field("INFO", alias="LOG_LEVEL")
+    log_webhook_url: str = Field("", alias="LOG_WEBHOOK_URL")
+    db_path: Path = Field(Path("superbot/data/superbot.db"), alias="DB_PATH")
+    data_dir: Path = Field(Path("superbot/data"), alias="DATA_DIR")
+    log_dir: Path = Field(Path("superbot/logs"), alias="LOG_DIR")
+    tmp_dir: Path = Field(Path("superbot/tmp"), alias="TMP_DIR")
+    preload_cogs: list[str] = [
+        "superbot.features.admin.admin_core",
+        "superbot.features.help.help_cog",
+    ]
+
+    @field_validator("owner_ids", "guild_ids", mode="before")
+    @classmethod
+    def _parse_ids(cls: type[Settings], value: object) -> list[int]:
+        """Normalize IDs from JSON array, CSV, or single int."""
+        if value in (None, "", [], ()):
+            return []
+        if isinstance(value, list):
+            items = value
+        elif isinstance(value, int):
+            items = [value]
+        elif isinstance(value, str):
+            value = value.strip()
+            if not value:
+                return []
+            try:
+                parsed = json.loads(value)
+            except json.JSONDecodeError:
+                parsed = value.split(",")
+            items = parsed if isinstance(parsed, list) else [parsed]
+        else:
+            return []
+        return [int(v) for v in items]
+
+    def model_post_init(self: Settings, __context: object) -> None:
+        """Create required directories after validation."""
+        for path in (self.data_dir, self.log_dir, self.tmp_dir):
+            os.makedirs(path, exist_ok=True)

--- a/superbot/src/superbot/core/services/db.py
+++ b/superbot/src/superbot/core/services/db.py
@@ -1,0 +1,26 @@
+"""SQLite database helper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import aiosqlite
+
+MIGRATIONS_DIR = Path(__file__).resolve().parent / "migrations"
+
+
+async def init_db(path: Path) -> aiosqlite.Connection:
+    """Open a database connection and run migrations."""
+    conn = await aiosqlite.connect(path)
+    await conn.execute("PRAGMA journal_mode=WAL;")
+    await _run_migrations(conn)
+    await conn.commit()
+    return conn
+
+
+async def _run_migrations(conn: aiosqlite.Connection) -> None:
+    """Apply SQL migration files in order."""
+    if not MIGRATIONS_DIR.exists():
+        return
+    for file in sorted(MIGRATIONS_DIR.glob("*.sql")):
+        await conn.executescript(file.read_text())

--- a/superbot/src/superbot/core/services/errors.py
+++ b/superbot/src/superbot/core/services/errors.py
@@ -1,0 +1,11 @@
+"""Centralized error reporting."""
+
+from __future__ import annotations
+
+import logging
+
+
+def report(exc: BaseException, context: str = "") -> None:
+    """Log an unexpected exception."""
+    logger = logging.getLogger("superbot")
+    logger.error("Unhandled exception in %s", context, exc_info=exc)

--- a/superbot/src/superbot/core/services/logging_service.py
+++ b/superbot/src/superbot/core/services/logging_service.py
@@ -1,0 +1,17 @@
+"""Logging service for the bot."""
+
+from __future__ import annotations
+
+import logging
+
+
+def init_logging(level: str) -> logging.Logger:
+    """Configure and return the application logger."""
+    logger = logging.getLogger("superbot")
+    if logger.handlers:
+        return logger
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+    )
+    return logger

--- a/superbot/src/superbot/features/admin/admin_core.py
+++ b/superbot/src/superbot/features/admin/admin_core.py
@@ -1,0 +1,171 @@
+"""Admin slash commands."""
+
+from __future__ import annotations
+
+import logging
+from time import perf_counter
+from typing import cast
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from superbot.config import Settings
+from superbot.loaders import cogs as cog_loader
+
+
+def _is_owner(interaction: discord.Interaction) -> bool:
+    """Return True if the interaction author is in OWNER_IDS."""
+    bot = cast(commands.Bot, interaction.client)
+    settings: Settings = bot.settings
+    return interaction.user and interaction.user.id in settings.owner_ids
+
+
+def owner_only() -> app_commands.Check:
+    """Decorator to restrict slash commands to owners."""
+    return app_commands.check(_is_owner)
+
+
+def _is_owner_ctx(ctx: commands.Context[commands.Bot]) -> bool:
+    """Return True if ctx.author is an owner."""
+    settings: Settings = ctx.bot.settings
+    return ctx.author.id in settings.owner_ids
+
+
+def owner_only_command() -> commands.Check:
+    """Decorator to restrict prefix commands to owners."""
+    return commands.check(_is_owner_ctx)
+
+
+class AdminCog(commands.Cog):
+    """Administrative commands for bot owners."""
+
+    def __init__(self: AdminCog, bot: commands.Bot) -> None:
+        """Store bot reference and logger."""
+        self.bot = bot
+        self.log = logging.getLogger("superbot")
+
+    admin = app_commands.Group(name="admin", description="Admin commands")
+
+    @admin.command(name="sync")
+    @owner_only()
+    @app_commands.describe(scope="guild or global")
+    async def sync(
+        self: AdminCog,
+        interaction: discord.Interaction,
+        scope: str = "guild",
+    ) -> None:
+        """Synchronize slash commands."""
+        start = perf_counter()
+        results: list[str] = []
+        if self.bot.settings.guild_ids and scope == "guild":
+            for gid in self.bot.settings.guild_ids:
+                cmds = await self.bot.tree.sync(guild=discord.Object(id=gid))
+                results.append(f"{gid}: {len(cmds)}")
+        else:
+            cmds = await self.bot.tree.sync()
+            results.append(f"global: {len(cmds)}")
+        duration = perf_counter() - start
+        embed = discord.Embed(title="Sync", description="\n".join(results))
+        embed.set_footer(text=f"{duration:.2f}s")
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+
+    @admin.command(name="cogs")
+    @owner_only()
+    async def list_cogs(self: AdminCog, interaction: discord.Interaction) -> None:
+        """List loaded extensions."""
+        names = cog_loader.list_loaded(self.bot)
+        embed = discord.Embed(
+            title="Loaded cogs",
+            description="\n".join(names) or "none",
+        )
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+
+    @admin.command(name="load")
+    @owner_only()
+    @app_commands.describe(name="Extension to load")
+    async def load(
+        self: AdminCog,
+        interaction: discord.Interaction,
+        name: str,
+    ) -> None:
+        """Load an extension."""
+        await cog_loader.load_one(self.bot, name)
+        await interaction.response.send_message(f"loaded {name}", ephemeral=True)
+
+    @admin.command(name="unload")
+    @owner_only()
+    @app_commands.describe(name="Extension to unload")
+    async def unload(
+        self: AdminCog,
+        interaction: discord.Interaction,
+        name: str,
+    ) -> None:
+        """Unload an extension."""
+        await cog_loader.unload_one(self.bot, name)
+        await interaction.response.send_message(f"unloaded {name}", ephemeral=True)
+
+    @admin.command(name="reload")
+    @owner_only()
+    @app_commands.describe(name="Extension to reload")
+    async def reload(
+        self: AdminCog,
+        interaction: discord.Interaction,
+        name: str,
+    ) -> None:
+        """Reload an extension."""
+        await cog_loader.reload_one(self.bot, name)
+        await interaction.response.send_message(f"reloaded {name}", ephemeral=True)
+
+    @admin.command(name="restart")
+    @owner_only()
+    async def restart(self: AdminCog, interaction: discord.Interaction) -> None:
+        """Restart the bot process."""
+        await interaction.response.send_message("Restarting...", ephemeral=True)
+        self.log.info("restart requested")
+        await self.bot.close()
+
+    @commands.group(name="cog", invoke_without_command=True)
+    @owner_only_command()
+    async def cog_group(self: AdminCog, ctx: commands.Context[commands.Bot]) -> None:
+        """Base command for cog management."""
+        if ctx.invoked_subcommand is None:
+            await ctx.send("Usage: !cog [load|unload|reload] <name>")
+
+    @cog_group.command(name="load")
+    @owner_only_command()
+    async def cog_load(
+        self: AdminCog,
+        ctx: commands.Context[commands.Bot],
+        name: str,
+    ) -> None:
+        """Load an extension via prefix command."""
+        await cog_loader.load_one(self.bot, name)
+        await ctx.send(f"loaded {name}")
+
+    @cog_group.command(name="unload")
+    @owner_only_command()
+    async def cog_unload(
+        self: AdminCog,
+        ctx: commands.Context[commands.Bot],
+        name: str,
+    ) -> None:
+        """Unload an extension via prefix command."""
+        await cog_loader.unload_one(self.bot, name)
+        await ctx.send(f"unloaded {name}")
+
+    @cog_group.command(name="reload")
+    @owner_only_command()
+    async def cog_reload(
+        self: AdminCog,
+        ctx: commands.Context[commands.Bot],
+        name: str,
+    ) -> None:
+        """Reload an extension via prefix command."""
+        await cog_loader.reload_one(self.bot, name)
+        await ctx.send(f"reloaded {name}")
+
+
+async def setup(bot: commands.Bot) -> None:
+    """Add the cog to the bot."""
+    await bot.add_cog(AdminCog(bot))

--- a/superbot/src/superbot/features/help/help_cog.py
+++ b/superbot/src/superbot/features/help/help_cog.py
@@ -1,0 +1,77 @@
+"""Help command implementation."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+
+class HelpCog(commands.Cog):
+    """Provide slash and prefix help commands."""
+
+    def __init__(self: HelpCog, bot: commands.Bot) -> None:
+        """Store bot reference."""
+        self.bot = bot
+
+    def _build_index(self: HelpCog) -> discord.Embed:
+        """Create an embed listing all commands."""
+        commands_by_cog: dict[str, list[str]] = defaultdict(list)
+        for cmd in self.bot.tree.walk_commands():
+            if cmd.parent is None:
+                commands_by_cog[cmd.cog_name or "slash"].append(f"/{cmd.name}")
+        for cmd in self.bot.commands:
+            if not cmd.hidden:
+                commands_by_cog[cmd.cog_name or "prefix"].append(
+                    f"{self.bot.command_prefix}{cmd.name}",
+                )
+        embed = discord.Embed(title="Commands")
+        for cog_name, names in sorted(commands_by_cog.items()):
+            embed.add_field(
+                name=cog_name,
+                value=", ".join(sorted(names)) or "-",
+                inline=False,
+            )
+        return embed
+
+    def _command_details(self: HelpCog, name: str) -> discord.Embed:
+        """Build detailed help for a single command."""
+        for cmd in self.bot.tree.walk_commands():
+            if cmd.name == name:
+                return discord.Embed(title=f"/{cmd.name}", description=cmd.description)
+        for cmd in self.bot.commands:
+            if cmd.name == name:
+                return discord.Embed(
+                    title=f"{self.bot.command_prefix}{cmd.name}",
+                    description=cmd.help or "",
+                )
+        return discord.Embed(title="Unknown command")
+
+    @app_commands.command(name="help", description="Show bot commands")
+    @app_commands.describe(command="Command to describe")
+    async def slash_help(
+        self: HelpCog,
+        interaction: discord.Interaction,
+        command: str | None = None,
+    ) -> None:
+        """Respond to the /help command."""
+        embed = self._command_details(command) if command else self._build_index()
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+
+    @commands.command(name="help")
+    async def prefix_help(
+        self: HelpCog,
+        ctx: commands.Context[commands.Bot],
+        *,
+        command: str | None = None,
+    ) -> None:
+        """Handle the !help command."""
+        embed = self._command_details(command) if command else self._build_index()
+        await ctx.send(embed=embed)
+
+
+async def setup(bot: commands.Bot) -> None:
+    """Add the cog to the bot."""
+    await bot.add_cog(HelpCog(bot))

--- a/superbot/src/superbot/loaders/cogs.py
+++ b/superbot/src/superbot/loaders/cogs.py
@@ -1,0 +1,79 @@
+"""Utilities for managing bot extensions."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from time import perf_counter
+
+from discord.ext import commands
+
+logger = logging.getLogger("superbot")
+
+
+def is_loaded(bot: commands.Bot, name: str) -> bool:
+    """Return True if the extension is currently loaded."""
+    return name in bot.extensions
+
+
+def list_loaded(bot: commands.Bot) -> list[str]:
+    """List the names of loaded extensions."""
+    return sorted(bot.extensions.keys())
+
+
+async def load_one(bot: commands.Bot, name: str) -> None:
+    """Load a single extension if not already loaded."""
+    if is_loaded(bot, name):
+        return
+    try:
+        await bot.load_extension(name)
+        logger.info("loaded %s", name)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("failed to load %s", name, exc_info=exc)
+
+
+async def unload_one(bot: commands.Bot, name: str) -> None:
+    """Unload a loaded extension."""
+    if not is_loaded(bot, name):
+        return
+    try:
+        await bot.unload_extension(name)
+        logger.info("unloaded %s", name)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("failed to unload %s", name, exc_info=exc)
+
+
+async def reload_one(bot: commands.Bot, name: str) -> None:
+    """Reload an extension, loading it first if needed."""
+    if not is_loaded(bot, name):
+        await load_one(bot, name)
+        return
+    try:
+        await bot.reload_extension(name)
+        logger.info("reloaded %s", name)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("failed to reload %s", name, exc_info=exc)
+
+
+async def load_all_cogs(bot: commands.Bot, names: Iterable[str]) -> None:
+    """Attempt to load all provided extensions and log a summary."""
+    start = perf_counter()
+    success = 0
+    failed = 0
+    for name in names:
+        if is_loaded(bot, name):
+            continue
+        try:
+            await bot.load_extension(name)
+            logger.info("loaded %s", name)
+            success += 1
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("failed to load %s", name, exc_info=exc)
+            failed += 1
+    duration = perf_counter() - start
+    logger.info(
+        "Cogs loaded: %s succeeded, %s failed in %.2fs",
+        success,
+        failed,
+        duration,
+    )


### PR DESCRIPTION
## Summary
- configure settings with robust .env loading and preload help/admin cogs
- add help cog exposing `/help` and `!help`
- add admin cog for command sync, cog management, and restart
- create startup script with logging, DB init, and guild-scoped sync
- fix dotenv discovery to load project and repo root files

## Testing
- `black superbot/src/superbot/config.py`
- `ruff check superbot/src/superbot/config.py`
- `mypy superbot/src/superbot/config.py`
- `pre-commit run --all-files` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.10')*

------
https://chatgpt.com/codex/tasks/task_e_689f3217b0c88322a2a05d5be762be25