### PR TITLE
Fix Python 3.9 compatibility across cogs and bot1

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import discord
 import asyncio
 import logging

--- a/disbot/cogs/admin_cog.py
+++ b/disbot/cogs/admin_cog.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from discord.ext import commands
 import discord
 import logging

--- a/disbot/cogs/cog_manager_cog.py
+++ b/disbot/cogs/cog_manager_cog.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import discord
 from discord.ext import commands
 import os

--- a/disbot/cogs/help_cog.py
+++ b/disbot/cogs/help_cog.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import discord
 from discord.ext import commands
 import logging

--- a/disbot/utils/data_manager.py
+++ b/disbot/utils/data_manager.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sqlite3
 import json
 import os


### PR DESCRIPTION
## Summary

- Added `from __future__ import annotations` to `admin_cog.py`, `cog_manager_cog.py`, `help_cog.py`, `data_manager.py`, and `bot1.py`
- `str | None` and `list[X]` type hint syntax requires Python 3.10+ at runtime — this fix makes them lazily evaluated as strings, restoring compatibility with Python 3.9 and earlier
- This was causing `admin_cog` (and other cogs) to silently fail to load on startup

## Test plan

- [ ] Bot starts without errors on Railway
- [ ] `admin_cog` loads and all admin commands are accessible
- [ ] `!cog_list` shows all cogs with correct status
- [ ] `!help` select menu works correctly

https://claude.ai/code/session_018cQYsrB4iy5EoiVy6S9vGt

---
_Generated by [Claude Code](https://claude.ai/code/session_018cQYsrB4iy5EoiVy6S9vGt)_