### PR TITLE
Fix cog load failures caused by reserved method name prefixes

### DIFF
--- a/disbot/cogs/admin_cog.py
+++ b/disbot/cogs/admin_cog.py
@@ -127,7 +127,7 @@ class AdminCog(commands.Cog):
 
     @commands.command(name='coglist')
     @commands.has_permissions(administrator=True)
-    async def cog_list(self, ctx):
+    async def list_cogs(self, ctx):
         """List all cog files with load status and syntax check."""
         loaded = set(self.bot.extensions.keys())
         lines = []

--- a/disbot/cogs/cog_manager_cog.py
+++ b/disbot/cogs/cog_manager_cog.py
@@ -148,7 +148,7 @@ class CogManagerCog(commands.Cog):
 
     @commands.command(name="cogs")
     @commands.has_permissions(administrator=True)
-    async def cog_manager(self, ctx: commands.Context):
+    async def open_cog_manager(self, ctx: commands.Context):
         """Opens the interactive cog manager. (Admin only)"""
         view = CogManagerView(self.bot, ctx)
         await ctx.send(embed=build_status_embed(self.bot), view=view)


### PR DESCRIPTION
## Summary

- **Fix `cogs.admin_cog` load failure** — method `cog_list` renamed to `list_cogs` (Discord.py forbids method names starting with `cog_` or `bot_`)
- **Fix `cogs.cog_manager_cog` load failure** — method `cog_manager` renamed to `open_cog_manager` for the same reason
- Command names are unchanged: `!coglist` and `!cogs` still work as before
- Also includes previous PR #17 changes: command renames, serverinfo/avatar crash fixes, remind rate-limit fix

## Test plan

- [ ] Bot starts without any cog load failure webhooks
- [ ] `!coglist` lists all cogs with load/syntax status
- [ ] `!cogs` opens the interactive cog manager UI
- [ ] Admin cog and Cog Manager cog both appear in `!help`

https://claude.ai/code/session_018cQYsrB4iy5EoiVy6S9vGt

---
_Generated by [Claude Code](https://claude.ai/code/session_018cQYsrB4iy5EoiVy6S9vGt)_