### PR TITLE
Economy system, shared channel/tournament utils, ChannelCog UI

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -11,6 +11,7 @@ import aiohttp
 import config  # Ensure config.py exists and contains PREFIX & DISCORD_BOT_TOKEN
 from discord.ext import commands
 from utils import db
+from utils.synonyms import find_command as _find_synonym
 
 # ==========================
 # Webhook Log Handler
@@ -203,7 +204,16 @@ async def on_command_error(ctx, error):
     if isinstance(error, commands.MissingPermissions):
         await ctx.send("❌ You do not have permission to use this command.", delete_after=10)
     elif isinstance(error, commands.CommandNotFound):
-        await ctx.send("❌ Command not found. Use `!help` for available commands.", delete_after=10)
+        # Try synonym lookup before giving up
+        raw = ctx.invoked_with or ""
+        suggestion = _find_synonym(raw)
+        if suggestion:
+            await ctx.send(
+                f"❓ Unknown command `{raw}`. Did you mean `{config.PREFIX}{suggestion}`?",
+                delete_after=15,
+            )
+        else:
+            await ctx.send("❌ Command not found. Use `!help` for available commands.", delete_after=10)
     elif isinstance(error, commands.MissingRequiredArgument):
         await ctx.send("⚠️ Missing argument. Check `!help` for usage.", delete_after=10)
     else:

--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -6,6 +6,7 @@ import os
 import json
 import datetime
 import urllib.request
+import threading
 import aiohttp
 import config  # Ensure config.py exists and contains PREFIX & DISCORD_BOT_TOKEN
 from discord.ext import commands
@@ -40,6 +41,12 @@ class WebhookLogHandler(logging.Handler):
                 data=payload,
                 headers={"Content-Type": "application/json"},
             )
+            threading.Thread(target=self._send, args=(req,), daemon=True).start()
+        except Exception:
+            pass
+
+    def _send(self, req):
+        try:
             urllib.request.urlopen(req, timeout=5)
         except Exception:
             pass

--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -10,6 +10,7 @@ import threading
 import aiohttp
 import config  # Ensure config.py exists and contains PREFIX & DISCORD_BOT_TOKEN
 from discord.ext import commands
+from utils import db
 
 # ==========================
 # Webhook Log Handler
@@ -233,10 +234,14 @@ async def load_cogs():
 # Bot Startup
 # ==========================
 async def main():
-    async with bot:
-        await load_cogs()
-        logger.info("🚀 Starting bot...")
-        await bot.start(config.DISCORD_BOT_TOKEN)
+    await db.init()
+    try:
+        async with bot:
+            await load_cogs()
+            logger.info("🚀 Starting bot...")
+            await bot.start(config.DISCORD_BOT_TOKEN)
+    finally:
+        await db.close()
 
 if __name__ == "__main__":
     try:

--- a/disbot/cogs/blackjack_cog.py
+++ b/disbot/cogs/blackjack_cog.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+import random
+import discord
+from discord.ext import commands
+import logging
+from utils import db
+
+logger = logging.getLogger("bot")
+
+# ---------------------------------------------------------------------------
+# Card engine
+# ---------------------------------------------------------------------------
+
+SUITS = ("♠", "♥", "♦", "♣")
+RANKS = ("A", "2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K")
+FREE_WIN_COINS = 50
+
+
+def _rank_value(rank: str) -> int:
+    if rank in ("J", "Q", "K"):
+        return 10
+    if rank == "A":
+        return 11
+    return int(rank)
+
+
+def _hand_value(hand: list[str]) -> int:
+    total = sum(_rank_value(c.split()[0]) for c in hand)
+    aces = sum(1 for c in hand if c.startswith("A"))
+    while total > 21 and aces:
+        total -= 10
+        aces -= 1
+    return total
+
+
+def _new_deck() -> list[str]:
+    deck = [f"{r} {s}" for r in RANKS for s in SUITS]
+    random.shuffle(deck)
+    return deck
+
+
+def _hand_str(hand: list[str], hide_second: bool = False) -> str:
+    if hide_second:
+        return f"{hand[0]}  ||?||"
+    return "  ".join(hand)
+
+
+def _is_blackjack(hand: list[str]) -> bool:
+    return len(hand) == 2 and _hand_value(hand) == 21
+
+
+# ---------------------------------------------------------------------------
+# Game state
+# ---------------------------------------------------------------------------
+
+class _Game:
+    def __init__(self, user_id: int, guild_id: int, bet: int):
+        self.user_id = user_id
+        self.guild_id = guild_id
+        self.bet = bet           # 0 = free play
+        self.doubled = False
+        self.deck = _new_deck()
+        self.player: list[str] = [self.deck.pop(), self.deck.pop()]
+        self.dealer: list[str] = [self.deck.pop(), self.deck.pop()]
+
+    def hit(self) -> str:
+        card = self.deck.pop()
+        self.player.append(card)
+        return card
+
+    def dealer_play(self):
+        while _hand_value(self.dealer) < 17:
+            self.dealer.append(self.deck.pop())
+
+
+# Active games: (user_id, guild_id) → _Game
+_active: dict[tuple[int, int], _Game] = {}
+
+
+# ---------------------------------------------------------------------------
+# Embed builder
+# ---------------------------------------------------------------------------
+
+def _build_embed(game: _Game, reveal: bool = False) -> discord.Embed:
+    pv = _hand_value(game.player)
+    dv = _hand_value(game.dealer) if reveal else _rank_value(game.dealer[0].split()[0])
+
+    if reveal:
+        dealer_str = _hand_str(game.dealer)
+        dealer_label = f"Dealer ({dv})"
+    else:
+        dealer_str = _hand_str(game.dealer, hide_second=True)
+        dealer_label = f"Dealer ({_rank_value(game.dealer[0].split()[0])}+?)"
+
+    bet_str = f"**{game.bet}** 🪙" if game.bet else "Free play (win = +50 🪙)"
+    embed = discord.Embed(title="🃏 Blackjack", color=discord.Color.dark_green())
+    embed.add_field(name=dealer_label, value=dealer_str, inline=False)
+    embed.add_field(name=f"Your hand ({pv})", value=_hand_str(game.player), inline=False)
+    embed.add_field(name="Bet", value=bet_str, inline=True)
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# View
+# ---------------------------------------------------------------------------
+
+class BlackjackView(discord.ui.View):
+    def __init__(self, game: _Game):
+        super().__init__(timeout=120)
+        self.game = game
+        self.message: discord.Message | None = None
+        # Disable double-down if player can't afford 2× or game not at start
+        self.double_btn.disabled = game.bet == 0  # can't double a free game
+
+    async def _end(
+        self,
+        interaction: discord.Interaction,
+        *,
+        result: str,
+        color: discord.Color,
+        coin_delta: int,
+    ):
+        key = (self.game.user_id, self.game.guild_id)
+        _active.pop(key, None)
+        for item in self.children:
+            item.disabled = True
+
+        embed = _build_embed(self.game, reveal=True)
+        embed.color = color
+        new_bal = await db.add_coins(self.game.user_id, self.game.guild_id, coin_delta)
+        delta_str = f"+{coin_delta}" if coin_delta >= 0 else str(coin_delta)
+        embed.add_field(
+            name=result,
+            value=f"{delta_str} 🪙  |  Balance: **{new_bal}** 🪙",
+            inline=False,
+        )
+        await interaction.response.edit_message(embed=embed, view=self)
+        self.stop()
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.game.user_id:
+            await interaction.response.send_message(
+                "This game isn't yours.", ephemeral=True
+            )
+            return False
+        return True
+
+    async def on_timeout(self):
+        _active.pop((self.game.user_id, self.game.guild_id), None)
+        for item in self.children:
+            item.disabled = True
+        try:
+            await self.message.edit(content="Game timed out.", view=self)
+        except Exception:
+            pass
+
+    @discord.ui.button(label="Hit", style=discord.ButtonStyle.green, emoji="👊")
+    async def hit_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        self.game.hit()
+        pv = _hand_value(self.game.player)
+
+        if pv > 21:
+            bet = self.game.bet if not self.game.doubled else self.game.bet * 2
+            await self._end(
+                interaction,
+                result="💥 Bust — you lose!",
+                color=discord.Color.red(),
+                coin_delta=-bet if bet else 0,
+            )
+            return
+
+        # After a hit you can no longer double
+        self.double_btn.disabled = True
+        embed = _build_embed(self.game)
+        await interaction.response.edit_message(embed=embed, view=self)
+
+    @discord.ui.button(label="Stand", style=discord.ButtonStyle.grey, emoji="✋")
+    async def stand_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await self._resolve(interaction)
+
+    @discord.ui.button(label="Double Down", style=discord.ButtonStyle.blurple, emoji="✌️")
+    async def double_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        # Check player has enough coins
+        bal = await db.get_coins(self.game.user_id, self.game.guild_id)
+        if bal < self.game.bet * 2:
+            await interaction.response.send_message(
+                f"❌ Not enough coins to double down (need {self.game.bet * 2}, have {bal}).",
+                ephemeral=True,
+            )
+            return
+        self.game.hit()
+        self.game.doubled = True
+        pv = _hand_value(self.game.player)
+        if pv > 21:
+            await self._end(
+                interaction,
+                result="💥 Bust — you lose!",
+                color=discord.Color.red(),
+                coin_delta=-(self.game.bet * 2),
+            )
+            return
+        await self._resolve(interaction)
+
+    async def _resolve(self, interaction: discord.Interaction):
+        self.game.dealer_play()
+        pv = _hand_value(self.game.player)
+        dv = _hand_value(self.game.dealer)
+        effective_bet = self.game.bet * 2 if self.game.doubled else self.game.bet
+
+        if _is_blackjack(self.game.player) and len(self.game.dealer) == 2:
+            # Natural blackjack beats everything (pays 3:2, floor)
+            payout = int(effective_bet * 1.5) if effective_bet else FREE_WIN_COINS
+            await self._end(
+                interaction,
+                result="🎉 Blackjack! You win!",
+                color=discord.Color.gold(),
+                coin_delta=payout,
+            )
+        elif dv > 21:
+            payout = effective_bet if effective_bet else FREE_WIN_COINS
+            await self._end(
+                interaction,
+                result="🎉 Dealer busts — you win!",
+                color=discord.Color.green(),
+                coin_delta=payout,
+            )
+        elif pv > dv:
+            payout = effective_bet if effective_bet else FREE_WIN_COINS
+            await self._end(
+                interaction,
+                result="🎉 You win!",
+                color=discord.Color.green(),
+                coin_delta=payout,
+            )
+        elif pv == dv:
+            await self._end(
+                interaction,
+                result="🤝 Push — it's a tie.",
+                color=discord.Color.blurple(),
+                coin_delta=0,
+            )
+        else:
+            loss = -(effective_bet) if effective_bet else 0
+            await self._end(
+                interaction,
+                result="😞 Dealer wins.",
+                color=discord.Color.red(),
+                coin_delta=loss,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Cog
+# ---------------------------------------------------------------------------
+
+class BlackjackCog(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    @commands.command(name="blackjack", aliases=["bj"])
+    async def blackjack(self, ctx: commands.Context, bet: int = 0):
+        """Play blackjack.  !blackjack [bet]  (0 = free, win = +50 🪙)"""
+        key = (ctx.author.id, ctx.guild.id)
+        if key in _active:
+            await ctx.send(
+                "You already have a blackjack game running! Finish it first.",
+                delete_after=10,
+            )
+            return
+
+        if bet < 0:
+            await ctx.send("Bet must be 0 (free) or a positive number.", delete_after=5)
+            return
+
+        if bet > 0:
+            bal = await db.get_coins(ctx.author.id, ctx.guild.id)
+            if bet > bal:
+                await ctx.send(
+                    f"❌ You only have **{bal}** 🪙. You can't bet **{bet}**.",
+                    delete_after=10,
+                )
+                return
+
+        game = _Game(ctx.author.id, ctx.guild.id, bet)
+        _active[key] = game
+
+        # Instant blackjack on deal
+        if _is_blackjack(game.player):
+            payout = int(bet * 1.5) if bet else FREE_WIN_COINS
+            new_bal = await db.add_coins(ctx.author.id, ctx.guild.id, payout)
+            embed = _build_embed(game, reveal=True)
+            embed.color = discord.Color.gold()
+            embed.add_field(
+                name="🎉 Blackjack!",
+                value=f"+{payout} 🪙  |  Balance: **{new_bal}** 🪙",
+                inline=False,
+            )
+            _active.pop(key)
+            await ctx.send(embed=embed)
+            return
+
+        view = BlackjackView(game)
+        embed = _build_embed(game)
+        msg = await ctx.send(embed=embed, view=view)
+        view.message = msg
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(BlackjackCog(bot))
+    logger.info("BlackjackCog loaded.")

--- a/disbot/cogs/blackjack_cog.py
+++ b/disbot/cogs/blackjack_cog.py
@@ -5,6 +5,8 @@ import discord
 from discord.ext import commands
 import logging
 from utils import db
+from utils.channels import create_private_channel, cleanup_category
+from utils.tournaments import TournamentRegistration
 
 logger = logging.getLogger("bot")
 
@@ -104,25 +106,13 @@ _pvp: dict[frozenset, _PvPState] = {}        # frozenset({p1, p2}) → state
 # Tournament state
 # ---------------------------------------------------------------------------
 
-class _BjTournament:
+class _BjTournament(TournamentRegistration):
     def __init__(self, host_id: int, guild_id: int, announce_id: int,
                  entry_fee: int, rounds: int, duration_mins: int):
-        self.host_id         = host_id
-        self.guild_id        = guild_id
-        self.announce_id     = announce_id    # channel to post announcements
-        self.entry_fee       = entry_fee
+        super().__init__(host_id, guild_id, announce_id, entry_fee, duration_mins)
         self.rounds          = rounds
-        self.duration_mins   = duration_mins
-        self.players:   set[int]         = set()
         self.results:   dict[int, int]   = {}  # user_id → final chips
-        self.started         = False
-        self.reg_message:    discord.Message | None = None
         self.category:       discord.CategoryChannel | None = None
-        self.timer_task:     asyncio.Task | None = None
-
-    @property
-    def pot(self) -> int:
-        return self.entry_fee * len(self.players)
 
 
 _tournaments: dict[int, _BjTournament] = {}  # guild_id → tournament
@@ -421,27 +411,10 @@ class _TournRegistrationView(discord.ui.View):
 
     @discord.ui.button(label="Join Tournament", style=discord.ButtonStyle.green, emoji="🃏")
     async def join_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
-        t = self.tourn
-        if t.started:
-            await interaction.response.send_message(
-                "The tournament has already started.", ephemeral=True)
-            return
-        uid = interaction.user.id
-        if uid in t.players:
-            await interaction.response.send_message(
-                "You're already registered!", ephemeral=True)
-            return
-        if t.entry_fee > 0:
-            bal = await db.get_coins(uid, t.guild_id)
-            if bal < t.entry_fee:
-                await interaction.response.send_message(
-                    f"❌ Need **{t.entry_fee}** 🪙 to enter (you have {bal}).",
-                    ephemeral=True)
-                return
-        t.players.add(uid)
-        await interaction.response.send_message(
-            f"✅ You're registered! ({len(t.players)} player(s) so far)", ephemeral=True)
-        await _update_tourn_embed(t)
+        ok, msg = await self.tourn.try_join(interaction.user.id)
+        await interaction.response.send_message(msg, ephemeral=True)
+        if ok:
+            await _update_tourn_embed(self.tourn)
 
 
 async def _update_tourn_embed(t: _BjTournament):
@@ -639,16 +612,8 @@ async def _check_tourn_done(tourn: _BjTournament, bot: commands.Bot):
         await announce.send(embed=embed)
 
     # Clean up private channels
-    if tourn.category and guild:
-        for ch in tourn.category.channels:
-            try:
-                await ch.delete()
-            except Exception:
-                pass
-        try:
-            await tourn.category.delete()
-        except Exception:
-            pass
+    if tourn.category:
+        await cleanup_category(tourn.category)
 
     _tournaments.pop(tourn.guild_id, None)
 
@@ -675,14 +640,9 @@ class BlackjackCog(commands.Cog):
         guild = self.bot.get_guild(payload.guild_id)
         if guild and guild.get_member(uid) and guild.get_member(uid).bot:
             return
-        if uid in tourn.players:
-            return
-        if tourn.entry_fee > 0:
-            bal = await db.get_coins(uid, tourn.guild_id)
-            if bal < tourn.entry_fee:
-                return
-        tourn.players.add(uid)
-        await _update_tourn_embed(tourn)
+        ok, _ = await tourn.try_join(uid)
+        if ok:
+            await _update_tourn_embed(tourn)
 
     # ---- commands ----
 
@@ -816,14 +776,9 @@ async def _launch_tournament(tourn: _BjTournament, guild: discord.Guild,
         _tournaments.pop(tourn.guild_id, None)
         return
 
-    # Deduct entry fees
+    # Deduct entry fees (uses shared TournamentRegistration helper)
     if tourn.entry_fee:
-        for uid in list(tourn.players):
-            bal = await db.get_coins(uid, tourn.guild_id)
-            if bal < tourn.entry_fee:
-                tourn.players.discard(uid)
-                continue
-            await db.add_coins(uid, tourn.guild_id, -tourn.entry_fee)
+        await tourn.deduct_fees()
 
     if not tourn.players:
         if announce:
@@ -837,39 +792,32 @@ async def _launch_tournament(tourn: _BjTournament, guild: discord.Guild,
             "Check your private channel."
         )
 
-    # Create category + private channels
-    overwrites_default = {guild.default_role: discord.PermissionOverwrite(read_messages=False)}
-    try:
-        tourn.category = await guild.create_category(
-            "BJ Tournament", overwrites=overwrites_default
-        )
-    except discord.Forbidden:
-        if announce:
-            await announce.send("❌ I don't have permission to create channels.")
-        _tournaments.pop(tourn.guild_id, None)
-        return
-
+    # Create private channels via shared utility
     for uid in tourn.players:
         member = guild.get_member(uid)
         if not member:
             tourn.results[uid] = 0
             continue
-        overwrites = {
-            **overwrites_default,
-            member: discord.PermissionOverwrite(read_messages=True, send_messages=True),
-            guild.me: discord.PermissionOverwrite(read_messages=True, send_messages=True),
-        }
         try:
-            ch = await guild.create_text_channel(
-                f"bj-{member.display_name}", overwrites=overwrites,
-                category=tourn.category,
+            ch = await create_private_channel(
+                guild,
+                f"bj-{member.display_name}",
+                [member],
+                "BJ Tournament",
             )
+            if tourn.category is None:
+                tourn.category = ch.category
             ps = _TournPlayerState(uid, tourn.guild_id, tourn.rounds)
             await ch.send(
                 f"Welcome, {member.mention}! You have **{tourn.rounds}** rounds "
                 f"and start with **{TOURN_START_CHIPS}** chips. Good luck! 🃏"
             )
             await _start_tourn_round(ps, ch, tourn)
+        except discord.Forbidden:
+            if announce:
+                await announce.send("❌ I don't have permission to create channels.")
+            _tournaments.pop(tourn.guild_id, None)
+            return
         except Exception as e:
             logger.error("Failed to create tournament channel: %s", e)
             tourn.results[uid] = 0

--- a/disbot/cogs/blackjack_cog.py
+++ b/disbot/cogs/blackjack_cog.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import asyncio
 import random
 import discord
 from discord.ext import commands
@@ -13,23 +14,23 @@ logger = logging.getLogger("bot")
 
 SUITS = ("♠", "♥", "♦", "♣")
 RANKS = ("A", "2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K")
-FREE_WIN_COINS = 50
+FREE_WIN_COINS   = 50
+TOURN_START_CHIPS = 1000
+TOURN_BET_PER_ROUND = 200
 
 
 def _rank_value(rank: str) -> int:
-    if rank in ("J", "Q", "K"):
-        return 10
-    if rank == "A":
-        return 11
+    if rank in ("J", "Q", "K"): return 10
+    if rank == "A":              return 11
     return int(rank)
 
 
 def _hand_value(hand: list[str]) -> int:
     total = sum(_rank_value(c.split()[0]) for c in hand)
-    aces = sum(1 for c in hand if c.startswith("A"))
+    aces  = sum(1 for c in hand if c.startswith("A"))
     while total > 21 and aces:
         total -= 10
-        aces -= 1
+        aces  -= 1
     return total
 
 
@@ -54,14 +55,19 @@ def _is_blackjack(hand: list[str]) -> bool:
 # ---------------------------------------------------------------------------
 
 class _Game:
-    def __init__(self, user_id: int, guild_id: int, bet: int):
-        self.user_id = user_id
-        self.guild_id = guild_id
-        self.bet = bet           # 0 = free play
-        self.doubled = False
-        self.deck = _new_deck()
+    def __init__(self, user_id: int, guild_id: int, bet: int,
+                 tournament_chips: int | None = None):
+        self.user_id   = user_id
+        self.guild_id  = guild_id
+        self.bet       = bet
+        self.doubled   = False
+        self.tournament_chips = tournament_chips  # None = normal game
+        self.deck      = _new_deck()
         self.player: list[str] = [self.deck.pop(), self.deck.pop()]
         self.dealer: list[str] = [self.deck.pop(), self.deck.pop()]
+        # PvP linkage (set externally)
+        self.pvp_peer_id: int | None = None
+        self.pvp_state: _PvPState | None = None
 
     def hit(self) -> str:
         card = self.deck.pop()
@@ -73,75 +79,126 @@ class _Game:
             self.dealer.append(self.deck.pop())
 
 
-# Active games: (user_id, guild_id) → _Game
-_active: dict[tuple[int, int], _Game] = {}
+_active: dict[tuple[int, int], _Game] = {}   # (user_id, guild_id) → game
 
 
 # ---------------------------------------------------------------------------
-# Embed builder
+# PvP state
 # ---------------------------------------------------------------------------
 
-def _build_embed(game: _Game, reveal: bool = False) -> discord.Embed:
+class _PvPState:
+    def __init__(self, p1: int, p2: int, guild_id: int, bet: int, channel_id: int):
+        self.p1 = p1
+        self.p2 = p2
+        self.guild_id = guild_id
+        self.bet = bet
+        self.channel_id = channel_id
+        self.results: dict[int, int] = {}   # user_id → final hand value (-1 = bust)
+        self.messages: dict[int, discord.Message] = {}
+
+
+_pvp: dict[frozenset, _PvPState] = {}        # frozenset({p1, p2}) → state
+
+
+# ---------------------------------------------------------------------------
+# Tournament state
+# ---------------------------------------------------------------------------
+
+class _BjTournament:
+    def __init__(self, host_id: int, guild_id: int, announce_id: int,
+                 entry_fee: int, rounds: int, duration_mins: int):
+        self.host_id         = host_id
+        self.guild_id        = guild_id
+        self.announce_id     = announce_id    # channel to post announcements
+        self.entry_fee       = entry_fee
+        self.rounds          = rounds
+        self.duration_mins   = duration_mins
+        self.players:   set[int]         = set()
+        self.results:   dict[int, int]   = {}  # user_id → final chips
+        self.started         = False
+        self.reg_message:    discord.Message | None = None
+        self.category:       discord.CategoryChannel | None = None
+        self.timer_task:     asyncio.Task | None = None
+
+    @property
+    def pot(self) -> int:
+        return self.entry_fee * len(self.players)
+
+
+_tournaments: dict[int, _BjTournament] = {}  # guild_id → tournament
+
+
+# ---------------------------------------------------------------------------
+# Embed helpers
+# ---------------------------------------------------------------------------
+
+def _game_embed(game: _Game, reveal: bool = False,
+                title: str = "🃏 Blackjack") -> discord.Embed:
     pv = _hand_value(game.player)
-    dv = _hand_value(game.dealer) if reveal else _rank_value(game.dealer[0].split()[0])
-
     if reveal:
-        dealer_str = _hand_str(game.dealer)
-        dealer_label = f"Dealer ({dv})"
+        dv     = _hand_value(game.dealer)
+        d_str  = _hand_str(game.dealer)
+        d_lbl  = f"Dealer ({dv})"
     else:
-        dealer_str = _hand_str(game.dealer, hide_second=True)
-        dealer_label = f"Dealer ({_rank_value(game.dealer[0].split()[0])}+?)"
+        d_str  = _hand_str(game.dealer, hide_second=True)
+        d_lbl  = f"Dealer ({_rank_value(game.dealer[0].split()[0])}+?)"
 
-    bet_str = f"**{game.bet}** 🪙" if game.bet else "Free play (win = +50 🪙)"
-    embed = discord.Embed(title="🃏 Blackjack", color=discord.Color.dark_green())
-    embed.add_field(name=dealer_label, value=dealer_str, inline=False)
+    bet_str = (f"**{game.bet}** 🪙" if game.bet
+               else f"Free (win = +{FREE_WIN_COINS} 🪙)")
+    if game.tournament_chips is not None:
+        bet_str = f"Tournament chips: **{game.tournament_chips}** | Bet: {TOURN_BET_PER_ROUND}"
+
+    embed = discord.Embed(title=title, color=discord.Color.dark_green())
+    embed.add_field(name=d_lbl,             value=d_str,              inline=False)
     embed.add_field(name=f"Your hand ({pv})", value=_hand_str(game.player), inline=False)
-    embed.add_field(name="Bet", value=bet_str, inline=True)
+    embed.add_field(name="Bet",             value=bet_str,            inline=True)
     return embed
 
 
 # ---------------------------------------------------------------------------
-# View
+# Solo / PvP game view
 # ---------------------------------------------------------------------------
 
 class BlackjackView(discord.ui.View):
-    def __init__(self, game: _Game):
+    def __init__(self, game: _Game, on_finish=None):
         super().__init__(timeout=120)
-        self.game = game
+        self.game       = game
+        self.on_finish  = on_finish      # async callback(game, outcome_value)
         self.message: discord.Message | None = None
-        # Disable double-down if player can't afford 2× or game not at start
-        self.double_btn.disabled = game.bet == 0  # can't double a free game
+        self.double_btn.disabled = (game.bet == 0 or game.tournament_chips is not None)
 
-    async def _end(
-        self,
-        interaction: discord.Interaction,
-        *,
-        result: str,
-        color: discord.Color,
-        coin_delta: int,
-    ):
+    async def _finish(self, interaction: discord.Interaction,
+                      result: str, color: discord.Color, coin_delta: int,
+                      hand_value: int):
         key = (self.game.user_id, self.game.guild_id)
         _active.pop(key, None)
         for item in self.children:
             item.disabled = True
 
-        embed = _build_embed(self.game, reveal=True)
+        embed = _game_embed(self.game, reveal=True)
         embed.color = color
-        new_bal = await db.add_coins(self.game.user_id, self.game.guild_id, coin_delta)
-        delta_str = f"+{coin_delta}" if coin_delta >= 0 else str(coin_delta)
-        embed.add_field(
-            name=result,
-            value=f"{delta_str} 🪙  |  Balance: **{new_bal}** 🪙",
-            inline=False,
-        )
+
+        if self.game.tournament_chips is None:
+            new_bal = await db.add_coins(self.game.user_id, self.game.guild_id, coin_delta)
+            delta_str = f"+{coin_delta}" if coin_delta >= 0 else str(coin_delta)
+            embed.add_field(
+                name=result,
+                value=f"{delta_str} 🪙  |  Balance: **{new_bal}** 🪙",
+                inline=False,
+            )
+        else:
+            embed.add_field(name=result, value="​", inline=False)
+
         await interaction.response.edit_message(embed=embed, view=self)
         self.stop()
+
+        if self.on_finish:
+            await self.on_finish(self.game, hand_value)
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         if interaction.user.id != self.game.user_id:
             await interaction.response.send_message(
-                "This game isn't yours.", ephemeral=True
-            )
+                "This isn't your hand.", ephemeral=True)
             return False
         return True
 
@@ -153,26 +210,21 @@ class BlackjackView(discord.ui.View):
             await self.message.edit(content="Game timed out.", view=self)
         except Exception:
             pass
+        if self.on_finish:
+            await self.on_finish(self.game, -1)   # treat as bust on timeout
 
-    @discord.ui.button(label="Hit", style=discord.ButtonStyle.green, emoji="👊")
+    @discord.ui.button(label="Hit",   style=discord.ButtonStyle.green, emoji="👊")
     async def hit_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
         self.game.hit()
         pv = _hand_value(self.game.player)
-
         if pv > 21:
-            bet = self.game.bet if not self.game.doubled else self.game.bet * 2
-            await self._end(
-                interaction,
-                result="💥 Bust — you lose!",
-                color=discord.Color.red(),
-                coin_delta=-bet if bet else 0,
-            )
+            effective = (self.game.bet * 2 if self.game.doubled else self.game.bet)
+            await self._finish(interaction, "💥 Bust — you lose!",
+                               discord.Color.red(), -effective if effective else 0, -1)
             return
-
-        # After a hit you can no longer double
         self.double_btn.disabled = True
-        embed = _build_embed(self.game)
-        await interaction.response.edit_message(embed=embed, view=self)
+        await interaction.response.edit_message(
+            embed=_game_embed(self.game), view=self)
 
     @discord.ui.button(label="Stand", style=discord.ButtonStyle.grey, emoji="✋")
     async def stand_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
@@ -180,24 +232,17 @@ class BlackjackView(discord.ui.View):
 
     @discord.ui.button(label="Double Down", style=discord.ButtonStyle.blurple, emoji="✌️")
     async def double_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
-        # Check player has enough coins
         bal = await db.get_coins(self.game.user_id, self.game.guild_id)
         if bal < self.game.bet * 2:
             await interaction.response.send_message(
-                f"❌ Not enough coins to double down (need {self.game.bet * 2}, have {bal}).",
-                ephemeral=True,
-            )
+                f"❌ Need {self.game.bet * 2} 🪙 to double (you have {bal}).",
+                ephemeral=True)
             return
         self.game.hit()
         self.game.doubled = True
-        pv = _hand_value(self.game.player)
-        if pv > 21:
-            await self._end(
-                interaction,
-                result="💥 Bust — you lose!",
-                color=discord.Color.red(),
-                coin_delta=-(self.game.bet * 2),
-            )
+        if _hand_value(self.game.player) > 21:
+            await self._finish(interaction, "💥 Bust — you lose!",
+                               discord.Color.red(), -(self.game.bet * 2), -1)
             return
         await self._resolve(interaction)
 
@@ -205,48 +250,407 @@ class BlackjackView(discord.ui.View):
         self.game.dealer_play()
         pv = _hand_value(self.game.player)
         dv = _hand_value(self.game.dealer)
-        effective_bet = self.game.bet * 2 if self.game.doubled else self.game.bet
+        effective = self.game.bet * 2 if self.game.doubled else self.game.bet
 
-        if _is_blackjack(self.game.player) and len(self.game.dealer) == 2:
-            # Natural blackjack beats everything (pays 3:2, floor)
-            payout = int(effective_bet * 1.5) if effective_bet else FREE_WIN_COINS
-            await self._end(
-                interaction,
-                result="🎉 Blackjack! You win!",
-                color=discord.Color.gold(),
-                coin_delta=payout,
-            )
+        if _is_blackjack(self.game.player):
+            payout = int(effective * 1.5) if effective else FREE_WIN_COINS
+            await self._finish(interaction, "🎉 Blackjack!",
+                               discord.Color.gold(), payout, pv)
         elif dv > 21:
-            payout = effective_bet if effective_bet else FREE_WIN_COINS
-            await self._end(
-                interaction,
-                result="🎉 Dealer busts — you win!",
-                color=discord.Color.green(),
-                coin_delta=payout,
-            )
+            payout = effective if effective else FREE_WIN_COINS
+            await self._finish(interaction, "🎉 Dealer busts — you win!",
+                               discord.Color.green(), payout, pv)
         elif pv > dv:
-            payout = effective_bet if effective_bet else FREE_WIN_COINS
-            await self._end(
-                interaction,
-                result="🎉 You win!",
-                color=discord.Color.green(),
-                coin_delta=payout,
-            )
+            payout = effective if effective else FREE_WIN_COINS
+            await self._finish(interaction, "🎉 You win!",
+                               discord.Color.green(), payout, pv)
         elif pv == dv:
-            await self._end(
-                interaction,
-                result="🤝 Push — it's a tie.",
-                color=discord.Color.blurple(),
-                coin_delta=0,
-            )
+            await self._finish(interaction, "🤝 Push — tie.",
+                               discord.Color.blurple(), 0, pv)
         else:
-            loss = -(effective_bet) if effective_bet else 0
-            await self._end(
-                interaction,
-                result="😞 Dealer wins.",
-                color=discord.Color.red(),
-                coin_delta=loss,
+            loss = -effective if effective else 0
+            await self._finish(interaction, "😞 Dealer wins.",
+                               discord.Color.red(), loss, pv)
+
+
+# ---------------------------------------------------------------------------
+# PvP Challenge
+# ---------------------------------------------------------------------------
+
+class _ChallengeView(discord.ui.View):
+    def __init__(self, challenger: discord.Member, opponent: discord.Member,
+                 guild_id: int, bet: int):
+        super().__init__(timeout=60)
+        self.challenger = challenger
+        self.opponent   = opponent
+        self.guild_id   = guild_id
+        self.bet        = bet
+        self.message: discord.Message | None = None
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.opponent.id:
+            await interaction.response.send_message(
+                "This challenge isn't for you.", ephemeral=True)
+            return False
+        return True
+
+    @discord.ui.button(label="Accept", style=discord.ButtonStyle.green, emoji="✅")
+    async def accept(self, interaction: discord.Interaction, _: discord.ui.Button):
+        for item in self.children:
+            item.disabled = True
+        await interaction.response.edit_message(
+            content="✅ Challenge accepted — dealing hands…", view=self)
+        self.stop()
+        await _start_pvp(interaction, self.challenger, self.opponent,
+                         self.guild_id, self.bet)
+
+    @discord.ui.button(label="Decline", style=discord.ButtonStyle.red, emoji="❌")
+    async def decline(self, interaction: discord.Interaction, _: discord.ui.Button):
+        for item in self.children:
+            item.disabled = True
+        await interaction.response.edit_message(
+            content=f"❌ {self.opponent.display_name} declined the challenge.", view=self)
+        self.stop()
+
+    async def on_timeout(self):
+        for item in self.children:
+            item.disabled = True
+        try:
+            await self.message.edit(content="⏰ Challenge timed out.", view=self)
+        except Exception:
+            pass
+
+
+async def _start_pvp(interaction: discord.Interaction,
+                     p1: discord.Member, p2: discord.Member,
+                     guild_id: int, bet: int):
+    channel = interaction.channel
+    state = _PvPState(p1.id, p2.id, guild_id, bet, channel.id)
+    key   = frozenset({p1.id, p2.id})
+    _pvp[key] = state
+
+    for player in (p1, p2):
+        uid  = player.id
+        gid  = guild_id
+        game = _Game(uid, gid, bet)
+        game.pvp_peer_id = p2.id if uid == p1.id else p1.id
+        game.pvp_state   = state
+        _active[(uid, gid)] = game
+
+        if _is_blackjack(game.player):
+            embed = _game_embed(game, reveal=True, title=f"🃏 {player.display_name}'s hand")
+            embed.color = discord.Color.gold()
+            embed.add_field(name="Blackjack!", value="Waiting for opponent…", inline=False)
+            msg = await channel.send(content=player.mention, embed=embed)
+            state.messages[uid] = msg
+            state.results[uid]  = 21
+            _active.pop((uid, gid), None)
+        else:
+            async def _pvp_finish(g: _Game, hand_val: int, _player=player, _state=state):
+                _state.results[g.user_id] = hand_val
+                if len(_state.results) == 2:
+                    await _resolve_pvp(_state, channel)
+
+            view = BlackjackView(game, on_finish=_pvp_finish)
+            embed = _game_embed(game, title=f"🃏 {player.display_name}'s hand")
+            msg = await channel.send(content=player.mention, embed=embed, view=view)
+            view.message = msg
+            state.messages[uid] = msg
+
+    # If both got instant blackjack
+    if len(state.results) == 2:
+        await _resolve_pvp(state, channel)
+
+
+async def _resolve_pvp(state: _PvPState, channel: discord.TextChannel):
+    key = frozenset({state.p1, state.p2})
+    _pvp.pop(key, None)
+
+    v1 = state.results.get(state.p1, -1)
+    v2 = state.results.get(state.p2, -1)
+
+    if v1 == -1 and v2 == -1:
+        result = "🤝 Both busted — tie! No coins exchanged."
+        coin_change = 0
+        winner_id = None
+    elif v1 == -1:
+        winner_id = state.p2
+        result = f"<@{state.p2}> wins (opponent busted)!"
+        coin_change = state.bet
+    elif v2 == -1:
+        winner_id = state.p1
+        result = f"<@{state.p1}> wins (opponent busted)!"
+        coin_change = state.bet
+    elif v1 > v2:
+        winner_id = state.p1
+        result = f"<@{state.p1}> wins with **{v1}** vs **{v2}**!"
+        coin_change = state.bet
+    elif v2 > v1:
+        winner_id = state.p2
+        result = f"<@{state.p2}> wins with **{v2}** vs **{v1}**!"
+        coin_change = state.bet
+    else:
+        result = f"🤝 Tie — both had **{v1}**. No coins exchanged."
+        coin_change = 0
+        winner_id = None
+
+    if coin_change and winner_id:
+        loser_id = state.p2 if winner_id == state.p1 else state.p1
+        payout = coin_change if coin_change else FREE_WIN_COINS
+        await db.add_coins(winner_id, state.guild_id,  payout)
+        await db.add_coins(loser_id,  state.guild_id, -payout)
+
+    embed = discord.Embed(
+        title="🃏 Blackjack PvP Result",
+        description=result,
+        color=discord.Color.gold() if winner_id else discord.Color.blurple(),
+    )
+    embed.add_field(name=f"<@{state.p1}>", value=f"**{v1 if v1 >= 0 else 'Bust'}**", inline=True)
+    embed.add_field(name=f"<@{state.p2}>", value=f"**{v2 if v2 >= 0 else 'Bust'}**", inline=True)
+    await channel.send(embed=embed)
+
+
+# ---------------------------------------------------------------------------
+# Tournament registration
+# ---------------------------------------------------------------------------
+
+class _TournRegistrationView(discord.ui.View):
+    def __init__(self, tournament: _BjTournament):
+        super().__init__(timeout=tournament.duration_mins * 60 + 10)
+        self.tourn = tournament
+
+    @discord.ui.button(label="Join Tournament", style=discord.ButtonStyle.green, emoji="🃏")
+    async def join_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        t = self.tourn
+        if t.started:
+            await interaction.response.send_message(
+                "The tournament has already started.", ephemeral=True)
+            return
+        uid = interaction.user.id
+        if uid in t.players:
+            await interaction.response.send_message(
+                "You're already registered!", ephemeral=True)
+            return
+        if t.entry_fee > 0:
+            bal = await db.get_coins(uid, t.guild_id)
+            if bal < t.entry_fee:
+                await interaction.response.send_message(
+                    f"❌ Need **{t.entry_fee}** 🪙 to enter (you have {bal}).",
+                    ephemeral=True)
+                return
+        t.players.add(uid)
+        await interaction.response.send_message(
+            f"✅ You're registered! ({len(t.players)} player(s) so far)", ephemeral=True)
+        await _update_tourn_embed(t)
+
+
+async def _update_tourn_embed(t: _BjTournament):
+    if not t.reg_message:
+        return
+    embed = _tourn_embed(t)
+    try:
+        await t.reg_message.edit(embed=embed)
+    except Exception:
+        pass
+
+
+def _tourn_embed(t: _BjTournament) -> discord.Embed:
+    fee_str = f"**{t.entry_fee}** 🪙" if t.entry_fee else "Free"
+    embed = discord.Embed(
+        title="🃏 Blackjack Tournament — Registration Open",
+        color=discord.Color.dark_green(),
+    )
+    embed.add_field(name="Entry Fee",    value=fee_str,          inline=True)
+    embed.add_field(name="Rounds",       value=str(t.rounds),    inline=True)
+    embed.add_field(name="Duration",     value=f"{t.duration_mins} min", inline=True)
+    embed.add_field(name="Players",      value=str(len(t.players)), inline=True)
+    embed.add_field(name="Pot",          value=f"{t.pot} 🪙",    inline=True)
+    embed.set_footer(text="React ✅ or click Join to register.")
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# Tournament play
+# ---------------------------------------------------------------------------
+
+class _TournPlayerState:
+    def __init__(self, user_id: int, guild_id: int, rounds: int):
+        self.user_id  = user_id
+        self.guild_id = guild_id
+        self.chips    = TOURN_START_CHIPS
+        self.rounds_left = rounds
+        self.done     = False
+
+
+class _TournBlackjackView(discord.ui.View):
+    """One view per round per player in a tournament."""
+
+    def __init__(self, game: _Game, player_state: _TournPlayerState,
+                 channel: discord.TextChannel, tourn: _BjTournament):
+        super().__init__(timeout=120)
+        self.game         = game
+        self.ps           = player_state
+        self.channel      = channel
+        self.tourn        = tourn
+        self.message: discord.Message | None = None
+
+    async def _finish_round(self, interaction: discord.Interaction,
+                            result: str, color: discord.Color, chip_delta: int,
+                            reveal: bool = True):
+        _active.pop((self.game.user_id, self.game.guild_id), None)
+        for item in self.children:
+            item.disabled = True
+
+        self.ps.chips = max(0, self.ps.chips + chip_delta)
+        embed = _game_embed(self.game, reveal=reveal)
+        embed.color = color
+        embed.add_field(
+            name=result,
+            value=f"Chips: **{self.ps.chips}** | Rounds left: **{self.ps.rounds_left - 1}**",
+            inline=False,
+        )
+        await interaction.response.edit_message(embed=embed, view=self)
+        self.stop()
+        self.ps.rounds_left -= 1
+
+        if self.ps.chips == 0 or self.ps.rounds_left == 0:
+            self.ps.done = True
+            self.tourn.results[self.ps.user_id] = self.ps.chips
+            await self.channel.send(
+                f"✅ You finished the tournament with **{self.ps.chips}** chips!"
             )
+            await _check_tourn_done(self.tourn, interaction.client)
+        else:
+            await _start_tourn_round(self.ps, self.channel, self.tourn)
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.game.user_id:
+            await interaction.response.send_message("Not your game.", ephemeral=True)
+            return False
+        return True
+
+    async def on_timeout(self):
+        _active.pop((self.game.user_id, self.game.guild_id), None)
+        self.ps.chips = max(0, self.ps.chips - TOURN_BET_PER_ROUND)
+        self.ps.rounds_left -= 1
+        for item in self.children:
+            item.disabled = True
+        try:
+            await self.message.edit(content="⏰ Timed out — hand forfeited.", view=self)
+        except Exception:
+            pass
+        if self.ps.chips == 0 or self.ps.rounds_left == 0:
+            self.ps.done = True
+            self.tourn.results[self.ps.user_id] = self.ps.chips
+            try:
+                bot = self.message.channel.guild._state._get_client()
+                await _check_tourn_done(self.tourn, bot)
+            except Exception:
+                pass
+        else:
+            await _start_tourn_round(self.ps, self.channel, self.tourn)
+
+    @discord.ui.button(label="Hit",   style=discord.ButtonStyle.green, emoji="👊")
+    async def hit(self, interaction: discord.Interaction, _: discord.ui.Button):
+        self.game.hit()
+        if _hand_value(self.game.player) > 21:
+            await self._finish_round(
+                interaction, "💥 Bust!", discord.Color.red(), -TOURN_BET_PER_ROUND)
+            return
+        await interaction.response.edit_message(embed=_game_embed(self.game), view=self)
+
+    @discord.ui.button(label="Stand", style=discord.ButtonStyle.grey, emoji="✋")
+    async def stand(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await self._resolve(interaction)
+
+    async def _resolve(self, interaction: discord.Interaction):
+        self.game.dealer_play()
+        pv = _hand_value(self.game.player)
+        dv = _hand_value(self.game.dealer)
+        bet = TOURN_BET_PER_ROUND
+
+        if _is_blackjack(self.game.player):
+            await self._finish_round(interaction, "🎉 Blackjack!", discord.Color.gold(), int(bet * 1.5))
+        elif dv > 21:
+            await self._finish_round(interaction, "🎉 Dealer busts!", discord.Color.green(), bet)
+        elif pv > dv:
+            await self._finish_round(interaction, "🎉 You win!", discord.Color.green(), bet)
+        elif pv == dv:
+            await self._finish_round(interaction, "🤝 Push.", discord.Color.blurple(), 0)
+        else:
+            await self._finish_round(interaction, "😞 Dealer wins.", discord.Color.red(), -bet)
+
+
+async def _start_tourn_round(ps: _TournPlayerState, channel: discord.TextChannel,
+                              tourn: _BjTournament):
+    game = _Game(ps.user_id, ps.guild_id, 0, tournament_chips=ps.chips)
+    _active[(ps.user_id, ps.guild_id)] = game
+    member = channel.guild.get_member(ps.user_id)
+    mention = member.mention if member else f"<@{ps.user_id}>"
+
+    embed = _game_embed(game, title=f"🃏 Round {tourn.rounds - ps.rounds_left + 1}/{tourn.rounds}")
+    view  = _TournBlackjackView(game, ps, channel, tourn)
+    msg   = await channel.send(content=mention, embed=embed, view=view)
+    view.message = msg
+
+
+async def _check_tourn_done(tourn: _BjTournament, bot: commands.Bot):
+    if len(tourn.results) < len(tourn.players):
+        return   # not all players finished
+
+    announce = bot.get_channel(tourn.announce_id)
+    guild    = bot.get_guild(tourn.guild_id)
+
+    # Rank players
+    ranking = sorted(tourn.results.items(), key=lambda x: x[1], reverse=True)
+    lines   = []
+    medals  = ["🥇", "🥈", "🥉"]
+    for i, (uid, chips) in enumerate(ranking):
+        icon   = medals[i] if i < 3 else f"#{i+1}"
+        member = guild.get_member(uid) if guild else None
+        name   = member.display_name if member else f"<@{uid}>"
+        lines.append(f"{icon} **{name}** — {chips} chips")
+
+    winner_id = ranking[0][0] if ranking else None
+    pot = tourn.pot
+
+    embed = discord.Embed(
+        title="🏆 Blackjack Tournament Results",
+        description="\n".join(lines),
+        color=discord.Color.gold(),
+    )
+    if winner_id and pot:
+        new_bal = await db.add_coins(winner_id, tourn.guild_id, pot)
+        embed.add_field(
+            name="Winner's payout",
+            value=f"<@{winner_id}> receives **{pot}** 🪙 (Balance: {new_bal} 🪙)",
+            inline=False,
+        )
+    elif winner_id and not pot:
+        reward = 200
+        new_bal = await db.add_coins(winner_id, tourn.guild_id, reward)
+        embed.add_field(
+            name="Winner's reward",
+            value=f"<@{winner_id}> receives **{reward}** 🪙 (Balance: {new_bal} 🪙)",
+            inline=False,
+        )
+
+    if announce:
+        await announce.send(embed=embed)
+
+    # Clean up private channels
+    if tourn.category and guild:
+        for ch in tourn.category.channels:
+            try:
+                await ch.delete()
+            except Exception:
+                pass
+        try:
+            await tourn.category.delete()
+        except Exception:
+            pass
+
+    _tournaments.pop(tourn.guild_id, None)
 
 
 # ---------------------------------------------------------------------------
@@ -257,52 +661,220 @@ class BlackjackCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
 
+    # ---- reaction-based tournament registration ----
+    @commands.Cog.listener()
+    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
+        if payload.emoji.name != "✅":
+            return
+        tourn = _tournaments.get(payload.guild_id)
+        if not tourn or tourn.started or not tourn.reg_message:
+            return
+        if payload.message_id != tourn.reg_message.id:
+            return
+        uid = payload.user_id
+        guild = self.bot.get_guild(payload.guild_id)
+        if guild and guild.get_member(uid) and guild.get_member(uid).bot:
+            return
+        if uid in tourn.players:
+            return
+        if tourn.entry_fee > 0:
+            bal = await db.get_coins(uid, tourn.guild_id)
+            if bal < tourn.entry_fee:
+                return
+        tourn.players.add(uid)
+        await _update_tourn_embed(tourn)
+
+    # ---- commands ----
+
     @commands.command(name="blackjack", aliases=["bj"])
-    async def blackjack(self, ctx: commands.Context, bet: int = 0):
-        """Play blackjack.  !blackjack [bet]  (0 = free, win = +50 🪙)"""
+    async def blackjack(self, ctx: commands.Context,
+                        target: discord.Member | None = None, bet: int = 0):
+        """Play blackjack.  !bj [bet]  or  !bj @player [bet]"""
+        if bet < 0:
+            await ctx.send("Bet must be 0 or a positive number.", delete_after=5)
+            return
+
+        # PvP mode
+        if target and target != ctx.author:
+            if target.bot:
+                await ctx.send("You can't challenge a bot to PvP.", delete_after=5)
+                return
+            key = frozenset({ctx.author.id, target.id})
+            if key in _pvp:
+                await ctx.send("There's already a PvP game between these players.", delete_after=8)
+                return
+            if bet > 0:
+                bal = await db.get_coins(ctx.author.id, ctx.guild.id)
+                if bet > bal:
+                    await ctx.send(f"❌ You only have **{bal}** 🪙.", delete_after=8)
+                    return
+            bet_str = f"**{bet}** 🪙" if bet else "free play"
+            view  = _ChallengeView(ctx.author, target, ctx.guild.id, bet)
+            embed = discord.Embed(
+                title="🃏 Blackjack Challenge!",
+                description=(
+                    f"{ctx.author.mention} challenges {target.mention} to Blackjack "
+                    f"({bet_str}).\n{target.mention}, do you accept?"
+                ),
+                color=discord.Color.dark_green(),
+            )
+            msg = await ctx.send(embed=embed, view=view)
+            view.message = msg
+            return
+
+        # Solo vs bot
         key = (ctx.author.id, ctx.guild.id)
         if key in _active:
-            await ctx.send(
-                "You already have a blackjack game running! Finish it first.",
-                delete_after=10,
-            )
+            await ctx.send("You already have a game running!", delete_after=8)
             return
-
-        if bet < 0:
-            await ctx.send("Bet must be 0 (free) or a positive number.", delete_after=5)
-            return
-
         if bet > 0:
             bal = await db.get_coins(ctx.author.id, ctx.guild.id)
             if bet > bal:
-                await ctx.send(
-                    f"❌ You only have **{bal}** 🪙. You can't bet **{bet}**.",
-                    delete_after=10,
-                )
+                await ctx.send(f"❌ You only have **{bal}** 🪙.", delete_after=8)
                 return
 
         game = _Game(ctx.author.id, ctx.guild.id, bet)
         _active[key] = game
 
-        # Instant blackjack on deal
         if _is_blackjack(game.player):
-            payout = int(bet * 1.5) if bet else FREE_WIN_COINS
+            payout  = int(bet * 1.5) if bet else FREE_WIN_COINS
             new_bal = await db.add_coins(ctx.author.id, ctx.guild.id, payout)
-            embed = _build_embed(game, reveal=True)
+            embed = _game_embed(game, reveal=True)
             embed.color = discord.Color.gold()
-            embed.add_field(
-                name="🎉 Blackjack!",
-                value=f"+{payout} 🪙  |  Balance: **{new_bal}** 🪙",
-                inline=False,
-            )
+            embed.add_field(name="🎉 Blackjack!",
+                            value=f"+{payout} 🪙  |  Balance: **{new_bal}** 🪙",
+                            inline=False)
             _active.pop(key)
             await ctx.send(embed=embed)
             return
 
         view = BlackjackView(game)
-        embed = _build_embed(game)
-        msg = await ctx.send(embed=embed, view=view)
+        msg  = await ctx.send(embed=_game_embed(game), view=view)
         view.message = msg
+
+    @commands.command(name="bjtournament", aliases=["bjtourn"])
+    @commands.has_permissions(administrator=True)
+    async def bjtournament(self, ctx: commands.Context,
+                           entry_fee: int = 0, rounds: int = 5,
+                           duration_mins: int = 5):
+        """Start a Blackjack tournament.  !bjtournament [entry_fee] [rounds] [mins]"""
+        if _tournaments.get(ctx.guild.id):
+            await ctx.send("A tournament is already running.", delete_after=8)
+            return
+        if entry_fee < 0 or rounds < 1 or duration_mins < 1:
+            await ctx.send("Invalid parameters.", delete_after=5)
+            return
+
+        tourn = _BjTournament(ctx.author.id, ctx.guild.id, ctx.channel.id,
+                              entry_fee, rounds, duration_mins)
+        _tournaments[ctx.guild.id] = tourn
+
+        view = _TournRegistrationView(tourn)
+        msg  = await ctx.send(embed=_tourn_embed(tourn), view=view)
+        await msg.add_reaction("✅")
+        tourn.reg_message = msg
+
+        async def _auto_start():
+            await asyncio.sleep(duration_mins * 60)
+            if not tourn.started and tourn.guild_id in _tournaments:
+                await _launch_tournament(tourn, ctx.guild, ctx.bot)
+
+        tourn.timer_task = asyncio.ensure_future(_auto_start())
+
+    @commands.command(name="bjstart")
+    @commands.has_permissions(administrator=True)
+    async def bjstart(self, ctx: commands.Context):
+        """Manually start a pending Blackjack tournament early."""
+        tourn = _tournaments.get(ctx.guild.id)
+        if not tourn or tourn.started:
+            await ctx.send("No pending tournament.", delete_after=5)
+            return
+        if tourn.timer_task:
+            tourn.timer_task.cancel()
+        await _launch_tournament(tourn, ctx.guild, self.bot)
+
+    @commands.command(name="bjstatus")
+    async def bjstatus(self, ctx: commands.Context):
+        """Show the current tournament status."""
+        tourn = _tournaments.get(ctx.guild.id)
+        if not tourn:
+            await ctx.send("No active tournament.", delete_after=5)
+            return
+        await ctx.send(embed=_tourn_embed(tourn))
+
+
+async def _launch_tournament(tourn: _BjTournament, guild: discord.Guild,
+                              bot: commands.Bot):
+    if tourn.started:
+        return
+    tourn.started = True
+
+    announce = bot.get_channel(tourn.announce_id)
+    if not tourn.players:
+        if announce:
+            await announce.send("❌ Tournament cancelled — no players registered.")
+        _tournaments.pop(tourn.guild_id, None)
+        return
+
+    # Deduct entry fees
+    if tourn.entry_fee:
+        for uid in list(tourn.players):
+            bal = await db.get_coins(uid, tourn.guild_id)
+            if bal < tourn.entry_fee:
+                tourn.players.discard(uid)
+                continue
+            await db.add_coins(uid, tourn.guild_id, -tourn.entry_fee)
+
+    if not tourn.players:
+        if announce:
+            await announce.send("❌ Tournament cancelled — no players could afford the entry fee.")
+        _tournaments.pop(tourn.guild_id, None)
+        return
+
+    if announce:
+        await announce.send(
+            f"🃏 **Blackjack Tournament starting** with {len(tourn.players)} player(s)! "
+            "Check your private channel."
+        )
+
+    # Create category + private channels
+    overwrites_default = {guild.default_role: discord.PermissionOverwrite(read_messages=False)}
+    try:
+        tourn.category = await guild.create_category(
+            "BJ Tournament", overwrites=overwrites_default
+        )
+    except discord.Forbidden:
+        if announce:
+            await announce.send("❌ I don't have permission to create channels.")
+        _tournaments.pop(tourn.guild_id, None)
+        return
+
+    for uid in tourn.players:
+        member = guild.get_member(uid)
+        if not member:
+            tourn.results[uid] = 0
+            continue
+        overwrites = {
+            **overwrites_default,
+            member: discord.PermissionOverwrite(read_messages=True, send_messages=True),
+            guild.me: discord.PermissionOverwrite(read_messages=True, send_messages=True),
+        }
+        try:
+            ch = await guild.create_text_channel(
+                f"bj-{member.display_name}", overwrites=overwrites,
+                category=tourn.category,
+            )
+            ps = _TournPlayerState(uid, tourn.guild_id, tourn.rounds)
+            await ch.send(
+                f"Welcome, {member.mention}! You have **{tourn.rounds}** rounds "
+                f"and start with **{TOURN_START_CHIPS}** chips. Good luck! 🃏"
+            )
+            await _start_tourn_round(ps, ch, tourn)
+        except Exception as e:
+            logger.error("Failed to create tournament channel: %s", e)
+            tourn.results[uid] = 0
+
+    await _check_tourn_done(tourn, bot)
 
 
 async def setup(bot: commands.Bot):

--- a/disbot/cogs/channel_cog.py
+++ b/disbot/cogs/channel_cog.py
@@ -1,12 +1,23 @@
+from __future__ import annotations
 import discord
 from discord.ext import commands
 import logging
+from utils.channels import safe_channel_name, get_or_create_category
 
-# Retrieve the existing logger from the main bot script
-logger = logging.getLogger('discord_bot.channel_cog')
+logger = logging.getLogger("bot")
+
+# Keyword presets shown in the dropdown menus
+_NAME_PRESETS = [
+    "general", "gaming", "announcements", "events",
+    "tournament", "support", "bot-commands", "vc-lounge",
+]
+_CATEGORY_PRESETS = [
+    "Gaming", "Community", "Events", "Tournaments", "Staff",
+]
+
 
 class ChannelCog(commands.Cog):
-    """A cog for managing Discord channels and categories."""
+    """Cog for managing Discord channels and categories."""
 
     def __init__(self, bot):
         self.bot = bot
@@ -23,11 +34,9 @@ class ChannelCog(commands.Cog):
         return commands.check(predicate)
 
     def get_category_or_channel(self, guild, name):
-        """Retrieve a category or channel by name."""
         return discord.utils.get(guild.categories, name=name) or discord.utils.get(guild.channels, name=name)
 
     async def set_permissions(self, target, role, read_messages):
-        """Set read permissions for a role in a channel or category."""
         if isinstance(target, discord.CategoryChannel):
             for channel in target.channels:
                 await channel.set_permissions(role, read_messages=read_messages)
@@ -35,58 +44,40 @@ class ChannelCog(commands.Cog):
             await target.set_permissions(role, read_messages=read_messages)
 
     def format_overwrites(self, overwrites):
-        """Format channel permission overwrites into a readable string for embeds."""
         formatted = ""
         for target, perms in overwrites.items():
-            if isinstance(target, discord.Role):
-                name = target.name
-            elif isinstance(target, discord.Member):
-                name = target.display_name
-            else:
-                name = "Unknown"
-
-            allow = ", ".join([perm.replace("_", " ").title() for perm, value in perms if value])
-            deny = ", ".join([perm.replace("_", " ").title() for perm, value in perms if not value])
-
-            formatted += f"**{name}**\nAllowed: {allow if allow else 'None'}\nDenied: {deny if deny else 'None'}\n\n"
-
-        return formatted if formatted else "No overwrites."
+            name = (target.name if isinstance(target, discord.Role)
+                    else target.display_name if isinstance(target, discord.Member)
+                    else "Unknown")
+            allow = ", ".join([p.replace("_", " ").title() for p, v in perms if v])
+            deny  = ", ".join([p.replace("_", " ").title() for p, v in perms if not v])
+            formatted += f"**{name}**\nAllowed: {allow or 'None'}\nDenied: {deny or 'None'}\n\n"
+        return formatted or "No overwrites."
 
     # -------------------
     # Commands
     # -------------------
 
-    @commands.command(
-        name='set',
-        help='Set access for a channel or category. Usage: .set <target> <@role> <True/False>'
-    )
+    @commands.command(name="set", help="Set access for a channel/category. Usage: !set <target> <@role> <True/False>")
     @is_admin_or_owner()
     async def set_access(self, ctx, target: str, role: discord.Role, permission: bool):
         target_channel = self.get_category_or_channel(ctx.guild, target)
         if target_channel:
             await self.set_permissions(target_channel, role, read_messages=permission)
-            state = 'opened' if permission else 'closed'
-            await ctx.send(f'{target_channel.type.capitalize()} "{target}" {state} for {role.name}!')
+            state = "opened" if permission else "closed"
+            await ctx.send(f'{target_channel.type} "{target}" {state} for {role.name}!')
         else:
             await ctx.send(f'Channel or Category "{target}" not found.')
 
-    @commands.command(
-        name='evt',
-        help='Create or delete an event. Usage: .evt <event_name> <create/delete>'
-    )
+    @commands.command(name="evt", help="Create or delete an event channel. Usage: !evt <name> <create/delete>")
     @is_admin_or_owner()
     async def manage_event(self, ctx, evt: str, action: str):
-        category = discord.utils.get(ctx.guild.categories, name="Events")
-        if action.lower() == 'create':
-            if not category:
-                category = await ctx.guild.create_category("Events")
-            channel = discord.utils.get(ctx.guild.channels, name=evt)
-            if not channel:
-                await ctx.guild.create_text_channel(evt, category=category)
-                await ctx.send(f'Event "{evt}" created!')
-            else:
-                await ctx.send(f'Event "{evt}" already exists!')
-        elif action.lower() == 'delete':
+        if action.lower() == "create":
+            category = await get_or_create_category(ctx.guild, "Events")
+            name = await safe_channel_name(ctx.guild, evt)
+            await ctx.guild.create_text_channel(name, category=category)
+            await ctx.send(f'Event channel "{name}" created!')
+        elif action.lower() == "delete":
             channel = discord.utils.get(ctx.guild.channels, name=evt)
             if channel:
                 await channel.delete()
@@ -96,291 +87,383 @@ class ChannelCog(commands.Cog):
         else:
             await ctx.send('Invalid action. Use "create" or "delete".')
 
-    @commands.command(
-        name='create',
-        help='Create a channel with role access. Usage: .create <channel_name> <@role> <True/False> [category]'
-    )
+    @commands.command(name="create", help="Create a channel with role access. Usage: !create <name> <@role> <True/False> [category]")
     @is_admin_or_owner()
-    async def create_channel_with_role(
-        self,
-        ctx,
-        channel_name: str,
-        role: discord.Role,
-        permission: bool,
-        category_name: str = None
-    ):
-        existing_channel = discord.utils.get(ctx.guild.channels, name=channel_name)
-        if existing_channel:
-            await ctx.send(f'Channel "{channel_name}" already exists!')
-            return
+    async def create_channel_with_role(self, ctx, channel_name: str, role: discord.Role,
+                                       permission: bool, category_name: str = None):
+        safe_name = await safe_channel_name(ctx.guild, channel_name)
+        category = None
+        if category_name:
+            category = discord.utils.get(ctx.guild.categories, name=category_name)
+            if not category:
+                await ctx.send(f'Category "{category_name}" not found!')
+                return
 
-        category = self.get_category_or_channel(ctx.guild, category_name) if category_name else None
-        if category_name and not category:
-            await ctx.send(f'Category "{category_name}" not found!')
-            return
-
-        new_channel = await ctx.guild.create_text_channel(channel_name, category=category)
+        new_channel = await ctx.guild.create_text_channel(safe_name, category=category)
         await new_channel.set_permissions(role, read_messages=permission)
-        state = 'granted' if permission else 'restricted'
-        await ctx.send(f'Channel "{channel_name}" created with {state} access for {role.name}!')
+        state = "granted" if permission else "restricted"
+        suffix = f' (renamed to "{safe_name}")' if safe_name != channel_name else ""
+        await ctx.send(f'Channel "{safe_name}" created with {state} access for {role.name}!{suffix}')
 
-    @commands.command(
-        name='bulkdelete',
-        help='Delete multiple channels. Usage: .bulkdelete <channel_name1> <channel_name2> ... or <word>'
-    )
+    @commands.command(name="channelcreator", aliases=["ccreate"],
+                      help="Open the interactive channel creator UI.")
+    @is_admin_or_owner()
+    async def channel_creator(self, ctx):
+        """Opens a button/dropdown panel for creating a channel."""
+        view = _ChannelCreatorView(ctx)
+        embed = discord.Embed(
+            title="📋 Channel Creator",
+            description=(
+                "Use the menus below to pick a name and category for the new channel.\n"
+                "You can also type a custom name via the **Custom Name** button."
+            ),
+            color=discord.Color.blurple(),
+        )
+        embed.add_field(name="Selected name",     value="*(none)*", inline=True)
+        embed.add_field(name="Selected category", value="*(none)*", inline=True)
+        msg = await ctx.send(embed=embed, view=view)
+        view.message = msg
+
+    @commands.command(name="bulkdelete", help="Delete multiple channels. Usage: !bulkdelete <name1> [name2...] or <word>")
     @is_admin_or_owner()
     async def bulk_delete_channels(self, ctx, *channel_names_or_word: str):
         if not channel_names_or_word:
             await ctx.send("Please provide at least one channel name or a word.")
             return
 
-        deleted = []
-        failed = []
-
         if len(channel_names_or_word) == 1:
             word = channel_names_or_word[0]
-            channels_to_delete = [channel for channel in ctx.guild.channels if word in channel.name]
+            channels_to_delete = [ch for ch in ctx.guild.channels if word in ch.name]
             if not channels_to_delete:
-                await ctx.send(f"No channels found containing the word '{word}'.")
+                await ctx.send(f"No channels found containing '{word}'.")
                 return
         else:
-            channels_to_delete = [
-                discord.utils.get(ctx.guild.channels, name=name) for name in channel_names_or_word
-            ]
+            channels_to_delete = [discord.utils.get(ctx.guild.channels, name=n)
+                                   for n in channel_names_or_word]
 
+        deleted, failed = [], []
         for channel in channels_to_delete:
             if channel:
                 try:
                     await channel.delete()
                     deleted.append(channel.name)
-                except Exception as e:
+                except Exception:
                     failed.append(channel.name)
             else:
-                failed.append('Not found')
+                failed.append("Not found")
 
         response = ""
-        if deleted:
-            response += f'✅ Deleted channels: {", ".join(deleted)}.\n'
-        if failed:
-            response += f'❌ Failed to delete channels: {", ".join(failed)}.'
-
+        if deleted: response += f'✅ Deleted: {", ".join(deleted)}.\n'
+        if failed:  response += f'❌ Failed: {", ".join(failed)}.'
         await ctx.send(response)
 
-    @commands.command(
-        name='del',
-        help='Delete a specific channel. Usage: .del <channel_name>'
-    )
+    @commands.command(name="del", help="Delete a specific channel. Usage: !del <channel_name>")
     @is_admin_or_owner()
     async def delete_channel(self, ctx, channel_name: str):
         channel = discord.utils.get(ctx.guild.channels, name=channel_name)
         if channel:
             await channel.delete()
-            await ctx.send(f'Channel "{channel_name}" has been deleted.')
+            await ctx.send(f'Channel "{channel_name}" deleted.')
         else:
             await ctx.send(f'Channel "{channel_name}" not found.')
 
-    @commands.command(
-        name='list',
-        help='List all categories and channels. Usage: .list'
-    )
+    @commands.command(name="list", help="List all categories and channels.")
     @is_admin_or_owner()
     async def list_channels(self, ctx):
-        embed = discord.Embed(
-            title="Categories and Channels",
-            description="Here are all the categories and their channels:",
-            color=discord.Color.blue()
-        )
+        embed = discord.Embed(title="Categories and Channels", color=discord.Color.blue())
         for category in ctx.guild.categories:
-            channels = '\n'.join([f" - {channel.name}" for channel in category.channels])
-            embed.add_field(
-                name=category.name,
-                value=channels if channels else "No channels",
-                inline=False
-            )
+            channels = "\n".join(f" - {ch.name}" for ch in category.channels)
+            embed.add_field(name=category.name, value=channels or "No channels", inline=False)
         await ctx.send(embed=embed)
 
-    @commands.command(
-        name='clone',
-        help='Clone a channel. Usage: .clone <existing_channel_name> <new_channel_name>'
-    )
+    @commands.command(name="clone", help="Clone a channel. Usage: !clone <existing> <new_name>")
     @is_admin_or_owner()
     async def clone_channel(self, ctx, existing_channel_name: str, new_channel_name: str):
-        existing_channel = discord.utils.get(ctx.guild.channels, name=existing_channel_name)
-        if existing_channel:
-            await existing_channel.clone(name=new_channel_name)
-            await ctx.send(f'Channel "{existing_channel_name}" cloned as "{new_channel_name}".')
+        existing = discord.utils.get(ctx.guild.channels, name=existing_channel_name)
+        if existing:
+            await existing.clone(name=new_channel_name)
+            await ctx.send(f'"{existing_channel_name}" cloned as "{new_channel_name}".')
         else:
-            await ctx.send(f'Channel "{existing_channel_name}" not found.')
+            await ctx.send(f'"{existing_channel_name}" not found.')
 
-    @commands.command(
-        name='move',
-        help='Move a channel to a category. Usage: .move <channel_name> <category_name>'
-    )
+    @commands.command(name="move", help="Move a channel to a category. Usage: !move <channel> <category>")
     @is_admin_or_owner()
     async def move_channel(self, ctx, channel_name: str, category_name: str):
-        channel = discord.utils.get(ctx.guild.channels, name=channel_name)
-        category = discord.utils.get(ctx.guild.categories, name=category_name)
+        channel  = discord.utils.get(ctx.guild.channels,    name=channel_name)
+        category = discord.utils.get(ctx.guild.categories,  name=category_name)
         if channel and category:
             await channel.edit(category=category)
-            await ctx.send(f'Channel "{channel_name}" moved to category "{category_name}".')
+            await ctx.send(f'"{channel_name}" moved to "{category_name}".')
         else:
-            await ctx.send(f'Channel or Category not found.')
+            await ctx.send("Channel or Category not found.")
 
-    @commands.command(
-        name='lock',
-        help='Lock a channel (restrict send messages for @everyone). Usage: .lock <channel_name>'
-    )
+    @commands.command(name="lock", help="Lock a channel. Usage: !lock <channel_name>")
     @is_admin_or_owner()
     async def lock_channel(self, ctx, channel_name: str):
         channel = discord.utils.get(ctx.guild.channels, name=channel_name)
         if channel:
             await channel.set_permissions(ctx.guild.default_role, send_messages=False)
-            await ctx.send(f'Channel "{channel_name}" has been locked.')
+            await ctx.send(f'"{channel_name}" locked.')
         else:
-            await ctx.send(f'Channel "{channel_name}" not found.')
+            await ctx.send(f'"{channel_name}" not found.')
 
-    @commands.command(
-        name='unlock',
-        help='Unlock a channel (grant send messages for @everyone). Usage: .unlock <channel_name>'
-    )
+    @commands.command(name="unlock", help="Unlock a channel. Usage: !unlock <channel_name>")
     @is_admin_or_owner()
     async def unlock_channel(self, ctx, channel_name: str):
         channel = discord.utils.get(ctx.guild.channels, name=channel_name)
         if channel:
             await channel.set_permissions(ctx.guild.default_role, send_messages=True)
-            await ctx.send(f'Channel "{channel_name}" has been unlocked.')
+            await ctx.send(f'"{channel_name}" unlocked.')
         else:
-            await ctx.send(f'Channel "{channel_name}" not found.')
+            await ctx.send(f'"{channel_name}" not found.')
 
-    @commands.command(
-        name='channelinfo',
-        help='Provides detailed information about a specific channel. Usage: .channelinfo <channel_name>'
-    )
+    @commands.command(name="channelinfo", help="Channel details. Usage: !channelinfo <channel_name>")
     @is_admin_or_owner()
     async def channel_info(self, ctx, channel_name: str):
         channel = discord.utils.get(ctx.guild.channels, name=channel_name)
         if channel:
-            embed = discord.Embed(
-                title=f"Channel Information - {channel.name}",
-                color=discord.Color.orange()
-            )
-            embed.add_field(name="Type", value=channel.type.capitalize(), inline=True)
-            embed.add_field(name="Category", value=channel.category.name if channel.category else "None", inline=True)
-            embed.add_field(name="Position", value=str(channel.position), inline=True)
-            embed.add_field(name="Topic", value=channel.topic if channel.topic else "No topic set.", inline=False)
-            embed.add_field(name="Created At", value=channel.created_at.strftime("%Y-%m-%d %H:%M:%S"), inline=True)
-            embed.add_field(name="Permissions Overwrites", value=self.format_overwrites(channel.overwrites), inline=False)
+            embed = discord.Embed(title=f"Channel Info — {channel.name}", color=discord.Color.orange())
+            embed.add_field(name="Type",      value=str(channel.type),                    inline=True)
+            embed.add_field(name="Category",  value=channel.category.name if channel.category else "None", inline=True)
+            embed.add_field(name="Position",  value=str(channel.position),                inline=True)
+            embed.add_field(name="Topic",     value=channel.topic or "No topic set.",     inline=False)
+            embed.add_field(name="Created",   value=channel.created_at.strftime("%Y-%m-%d %H:%M:%S"), inline=True)
+            embed.add_field(name="Overwrites", value=self.format_overwrites(channel.overwrites), inline=False)
             await ctx.send(embed=embed)
         else:
-            await ctx.send(f'Channel "{channel_name}" not found.')
+            await ctx.send(f'"{channel_name}" not found.')
 
-    @commands.command(
-        name='rename',
-        help='Rename an existing channel. Usage: .rename <channel_name> <new_name>'
-    )
+    @commands.command(name="rename", help="Rename a channel. Usage: !rename <old> <new>")
     @is_admin_or_owner()
     async def rename_channel(self, ctx, old_name: str, new_name: str):
         channel = discord.utils.get(ctx.guild.channels, name=old_name)
         if channel:
             await channel.edit(name=new_name)
-            await ctx.send(f'Channel "{old_name}" has been renamed to "{new_name}".')
+            await ctx.send(f'"{old_name}" renamed to "{new_name}".')
         else:
-            await ctx.send(f'Channel "{old_name}" not found.')
+            await ctx.send(f'"{old_name}" not found.')
 
-    @commands.command(
-        name='permissions',
-        help='Modify permissions for a role in a channel. Usage: .permissions <channel_name> <@role> <allow/deny>'
-    )
+    @commands.command(name="permissions", help="Modify channel permissions. Usage: !permissions <channel> <@role> <allow/deny>")
     @is_admin_or_owner()
     async def modify_permissions(self, ctx, channel_name: str, role: discord.Role, action: str):
         channel = discord.utils.get(ctx.guild.channels, name=channel_name)
         if channel:
-            if action.lower() == 'allow':
+            if action.lower() == "allow":
                 await channel.set_permissions(role, send_messages=True)
-                await ctx.send(f'Send messages permission **allowed** for {role.name} in "{channel_name}".')
-            elif action.lower() == 'deny':
+                await ctx.send(f'Send messages **allowed** for {role.name} in "{channel_name}".')
+            elif action.lower() == "deny":
                 await channel.set_permissions(role, send_messages=False)
-                await ctx.send(f'Send messages permission **denied** for {role.name} in "{channel_name}".')
+                await ctx.send(f'Send messages **denied** for {role.name} in "{channel_name}".')
             else:
                 await ctx.send('Invalid action. Use "allow" or "deny".')
         else:
-            await ctx.send(f'Channel "{channel_name}" not found.')
+            await ctx.send(f'"{channel_name}" not found.')
 
-    @commands.command(
-        name='bulkcreate',
-        help='Create multiple channels at once. Usage: .bulkcreate <channel1> <channel2> ... [category]'
-    )
+    @commands.command(name="bulkcreate", help="Create multiple channels. Usage: !bulkcreate <ch1> [ch2...] [category]")
     @is_admin_or_owner()
     async def bulk_create_channels(self, ctx, *args):
         if not args:
             await ctx.send("Please provide at least one channel name.")
             return
 
-        category_name = None
         channel_names = list(args)
-        potential_category = self.get_category_or_channel(ctx.guild, args[-1])
-        if isinstance(potential_category, discord.CategoryChannel):
-            category_name = args[-1]
+        category = None
+        potential = self.get_category_or_channel(ctx.guild, args[-1])
+        if isinstance(potential, discord.CategoryChannel):
+            category = potential
             channel_names = list(args[:-1])
 
-        category = discord.utils.get(ctx.guild.categories, name=category_name) if category_name else None
-        if category_name and not category:
-            await ctx.send(f'Category "{category_name}" not found!')
-            return
-
-        created = []
-        failed = []
-
+        created, failed = [], []
         for ch in channel_names:
-            existing_channel = discord.utils.get(ctx.guild.channels, name=ch)
-            if existing_channel:
-                failed.append(f'"{ch}" already exists.')
-                continue
+            safe = await safe_channel_name(ctx.guild, ch)
             try:
-                await ctx.guild.create_text_channel(ch, category=category)
-                created.append(ch)
-            except Exception as e:
-                failed.append(f'"{ch}" failed to create.')
+                await ctx.guild.create_text_channel(safe, category=category)
+                suffix = f" (as {safe})" if safe != ch else ""
+                created.append(f"{ch}{suffix}")
+            except Exception:
+                failed.append(ch)
 
         response = ""
-        if created:
-            response += f'✅ Created channels: {", ".join(created)}.\n'
-        if failed:
-            response += f'❌ {", ".join(failed)}'
-
+        if created: response += f'✅ Created: {", ".join(created)}.\n'
+        if failed:  response += f'❌ Failed: {", ".join(failed)}.'
         await ctx.send(response)
 
-    @commands.command(
-        name='archive',
-        help='Archive a channel by making it read-only. Usage: .archive <channel_name>'
-    )
+    @commands.command(name="archive", help="Make a channel read-only. Usage: !archive <channel_name>")
     @is_admin_or_owner()
     async def archive_channel(self, ctx, channel_name: str):
         channel = discord.utils.get(ctx.guild.channels, name=channel_name)
         if channel:
             await channel.set_permissions(ctx.guild.default_role, send_messages=False)
-            await ctx.send(f'Channel "{channel_name}" has been archived and is now read-only.')
+            await ctx.send(f'"{channel_name}" archived (read-only).')
         else:
-            await ctx.send(f'Channel "{channel_name}" not found.')
+            await ctx.send(f'"{channel_name}" not found.')
 
-    @commands.command(
-        name='unarchive',
-        help='Unarchive a channel by allowing it to send messages. Usage: .unarchive <channel_name>'
-    )
+    @commands.command(name="unarchive", help="Restore send permissions for a channel. Usage: !unarchive <channel_name>")
     @is_admin_or_owner()
     async def unarchive_channel(self, ctx, channel_name: str):
         channel = discord.utils.get(ctx.guild.channels, name=channel_name)
         if channel:
             await channel.set_permissions(ctx.guild.default_role, send_messages=True)
-            await ctx.send(f'Channel "{channel_name}" has been unarchived and is now writable.')
+            await ctx.send(f'"{channel_name}" unarchived.')
         else:
-            await ctx.send(f'Channel "{channel_name}" not found.')
+            await ctx.send(f'"{channel_name}" not found.')
+
+
+# -------------------
+# Channel Creator UI
+# -------------------
+
+class _ChannelCreatorView(discord.ui.View):
+    """Interactive channel creation panel with dropdown name/category pickers."""
+
+    def __init__(self, ctx: commands.Context):
+        super().__init__(timeout=120)
+        self.ctx          = ctx
+        self.chosen_name: str | None  = None
+        self.chosen_cat:  str | None  = None
+        self.message: discord.Message | None = None
+
+        # Build category select: existing ones first, then presets not yet in guild
+        existing_cats = [c.name for c in ctx.guild.categories]
+        cat_options = [discord.SelectOption(label=c, description="Existing category")
+                       for c in existing_cats[:15]]  # cap to avoid Discord limit
+        for p in _CATEGORY_PRESETS:
+            if p not in existing_cats and len(cat_options) < 24:
+                cat_options.append(discord.SelectOption(label=p, description="New category"))
+        if not cat_options:
+            cat_options = [discord.SelectOption(label=p) for p in _CATEGORY_PRESETS]
+
+        self.name_select = _NameSelect(_NAME_PRESETS, self)
+        self.cat_select  = _CategorySelect(cat_options, self)
+        self.add_item(self.name_select)
+        self.add_item(self.cat_select)
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user != self.ctx.author:
+            await interaction.response.send_message("This panel isn't for you.", ephemeral=True)
+            return False
+        return True
+
+    async def _refresh_embed(self, interaction: discord.Interaction):
+        embed = discord.Embed(
+            title="📋 Channel Creator",
+            description=(
+                "Use the menus below to pick a name and category.\n"
+                "Click **Custom Name** to type your own name."
+            ),
+            color=discord.Color.blurple(),
+        )
+        embed.add_field(name="Selected name",     value=f"`{self.chosen_name}`" if self.chosen_name else "*(none)*", inline=True)
+        embed.add_field(name="Selected category", value=f"`{self.chosen_cat}`"  if self.chosen_cat  else "*(none)*", inline=True)
+        await interaction.message.edit(embed=embed, view=self)
+
+    @discord.ui.button(label="Custom Name", style=discord.ButtonStyle.grey, emoji="✏️", row=2)
+    async def custom_name_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await interaction.response.send_modal(_CustomNameModal(self))
+
+    @discord.ui.button(label="Create Channel", style=discord.ButtonStyle.green, emoji="✅", row=2)
+    async def create_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        if not self.chosen_name:
+            await interaction.response.send_message(
+                "Please select or enter a channel name first.", ephemeral=True)
+            return
+
+        guild = interaction.guild
+        safe  = await safe_channel_name(guild, self.chosen_name)
+        category = None
+        if self.chosen_cat:
+            category = await get_or_create_category(guild, self.chosen_cat)
+
+        try:
+            ch = await guild.create_text_channel(safe, category=category)
+        except discord.Forbidden:
+            await interaction.response.send_message(
+                "❌ I don't have permission to create channels.", ephemeral=True)
+            return
+
+        for item in self.children:
+            item.disabled = True
+
+        suffix = f' (renamed from "{self.chosen_name}")' if safe != self.chosen_name else ""
+        embed = discord.Embed(
+            title="✅ Channel Created",
+            description=f"{ch.mention} created" + (f" in **{self.chosen_cat}**" if self.chosen_cat else "") + suffix,
+            color=discord.Color.green(),
+        )
+        await interaction.response.edit_message(embed=embed, view=self)
+        self.stop()
+
+    @discord.ui.button(label="Cancel", style=discord.ButtonStyle.red, emoji="❌", row=2)
+    async def cancel_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        for item in self.children:
+            item.disabled = True
+        await interaction.response.edit_message(content="Cancelled.", embed=None, view=self)
+        self.stop()
+
+    async def on_timeout(self):
+        for item in self.children:
+            item.disabled = True
+        try:
+            await self.message.edit(content="Timed out.", view=self)
+        except Exception:
+            pass
+
+
+class _NameSelect(discord.ui.Select):
+    def __init__(self, presets: list[str], view: _ChannelCreatorView):
+        options = [discord.SelectOption(label=p, value=p) for p in presets]
+        super().__init__(
+            placeholder="Pick a channel name…",
+            min_values=1, max_values=1,
+            options=options,
+            row=0,
+        )
+        self._parent = view
+
+    async def callback(self, interaction: discord.Interaction):
+        self._parent.chosen_name = self.values[0]
+        await interaction.response.defer()
+        await self._parent._refresh_embed(interaction)
+
+
+class _CategorySelect(discord.ui.Select):
+    def __init__(self, options: list[discord.SelectOption], view: _ChannelCreatorView):
+        super().__init__(
+            placeholder="Pick a category…",
+            min_values=1, max_values=1,
+            options=options,
+            row=1,
+        )
+        self._parent = view
+
+    async def callback(self, interaction: discord.Interaction):
+        self._parent.chosen_cat = self.values[0]
+        await interaction.response.defer()
+        await self._parent._refresh_embed(interaction)
+
+
+class _CustomNameModal(discord.ui.Modal, title="Custom Channel Name"):
+    channel_name = discord.ui.TextInput(
+        label="Channel name",
+        placeholder="e.g. my-channel",
+        max_length=100,
+    )
+
+    def __init__(self, view: _ChannelCreatorView):
+        super().__init__()
+        self._view = view
+
+    async def on_submit(self, interaction: discord.Interaction):
+        name = self.channel_name.value.strip().lower().replace(" ", "-")
+        self._view.chosen_name = name
+        await interaction.response.defer()
+        await self._view._refresh_embed(interaction)
+
 
 # -------------------
 # Cog Setup
 # -------------------
 
 async def setup(bot):
-    """Asynchronous setup function to add the ChannelCog to the bot."""
     await bot.add_cog(ChannelCog(bot))
-    logger.info("ChannelCog has been successfully loaded and added to the bot.")
+    logger.info("ChannelCog loaded.")

--- a/disbot/cogs/economy_cog.py
+++ b/disbot/cogs/economy_cog.py
@@ -1,0 +1,557 @@
+from __future__ import annotations
+import time
+import random
+import discord
+from discord.ext import commands
+import logging
+from utils import db
+
+logger = logging.getLogger("bot")
+
+_WORK_COOLDOWN  = 3600   # 1 hour between work sessions
+_DAILY_COOLDOWN = 86400  # 24 hours between daily claims
+
+# ---------------------------------------------------------------------------
+# Daily reward tiers  (label, rarity_emoji, min, max, base_weight)
+# ---------------------------------------------------------------------------
+_DAILY_TIERS = [
+    ("Common",    "⬜", 500,  999,  45),
+    ("Uncommon",  "🟩", 1000, 1999, 25),
+    ("Rare",      "🟦", 2000, 2999, 15),
+    ("Epic",      "🟪", 3000, 3999,  8),
+    ("Legendary", "🟧", 4000, 4999,  5),
+    ("Mythic",    "🟥", 5000, 5000,  2),
+]
+
+
+def _daily_weights(streak: int) -> list[float]:
+    """Higher streak shifts weight toward better tiers (capped at 60 days of gain)."""
+    luck = min(streak, 60)
+    weights = [float(t[4]) for t in _DAILY_TIERS]
+    # Each day of streak moves 0.25 total weight from bottom tiers to top tiers
+    shift = luck * 0.25
+    take_c = min(weights[0] - 5, shift * 0.65)
+    take_u = min(weights[1] - 5, shift * 0.35)
+    taken  = take_c + take_u
+    weights[0] -= take_c
+    weights[1] -= take_u
+    per = taken / 4
+    for i in range(2, 6):
+        weights[i] += per
+    return weights
+
+
+def _pick_daily(streak: int) -> tuple[int, str, str]:
+    """Return (amount, tier_label, rarity_emoji)."""
+    weights = _daily_weights(streak)
+    tier    = random.choices(_DAILY_TIERS, weights=weights, k=1)[0]
+    label, emoji, low, high, _ = tier
+    return random.randint(low, high), label, emoji
+
+
+# ---------------------------------------------------------------------------
+# Job definitions  {name: {tier, pay, xp, level, items, emoji, desc}}
+# ---------------------------------------------------------------------------
+JOBS: dict[str, dict] = {
+    # Tier 1 — no requirements
+    "janitor":         {"tier": 1, "pay": 50,   "xp": 10,  "level": 0,  "items": [],              "emoji": "🧹",  "desc": "Sweep floors and empty bins."},
+    "cashier":         {"tier": 1, "pay": 75,   "xp": 15,  "level": 0,  "items": [],              "emoji": "🏪",  "desc": "Run the register at a store."},
+    "dishwasher":      {"tier": 1, "pay": 60,   "xp": 12,  "level": 0,  "items": [],              "emoji": "🍽️", "desc": "Wash dishes at a restaurant."},
+    # Tier 2 — level 5+
+    "security_guard":  {"tier": 2, "pay": 150,  "xp": 25,  "level": 5,  "items": [],              "emoji": "🔒",  "desc": "Guard an office building."},
+    "delivery_driver": {"tier": 2, "pay": 200,  "xp": 30,  "level": 5,  "items": ["car"],         "emoji": "🚗",  "desc": "Deliver packages around town."},
+    "chef":            {"tier": 2, "pay": 175,  "xp": 28,  "level": 5,  "items": [],              "emoji": "👨‍🍳", "desc": "Cook meals at a restaurant."},
+    # Tier 3 — level 15+
+    "programmer":      {"tier": 3, "pay": 400,  "xp": 50,  "level": 15, "items": [],              "emoji": "💻",  "desc": "Write software for clients."},
+    "mechanic":        {"tier": 3, "pay": 350,  "xp": 45,  "level": 15, "items": ["toolkit"],     "emoji": "🔧",  "desc": "Repair vehicles at the garage."},
+    "nurse":           {"tier": 3, "pay": 380,  "xp": 48,  "level": 15, "items": [],              "emoji": "👩‍⚕️", "desc": "Care for patients at the clinic."},
+    # Tier 4 — level 30+
+    "lawyer":          {"tier": 4, "pay": 800,  "xp": 80,  "level": 30, "items": ["suit"],        "emoji": "⚖️",  "desc": "Represent clients in court."},
+    "doctor":          {"tier": 4, "pay": 900,  "xp": 90,  "level": 30, "items": [],              "emoji": "👨‍⚕️", "desc": "Treat patients at the hospital."},
+    "ceo":             {"tier": 4, "pay": 1200, "xp": 100, "level": 50, "items": ["suit", "car"], "emoji": "👔",  "desc": "Run your own company."},
+}
+
+# ---------------------------------------------------------------------------
+# Shop items
+# ---------------------------------------------------------------------------
+SHOP_ITEMS: dict[str, dict] = {
+    "car":     {"price": 5000, "emoji": "🚗", "desc": "Required for delivery driver and CEO."},
+    "toolkit": {"price": 2000, "emoji": "🔧", "desc": "Required for mechanic work."},
+    "suit":    {"price": 3000, "emoji": "👔", "desc": "Required for lawyer and CEO roles."},
+}
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+def _job_pay(job_name: str, times_worked: int) -> int:
+    """Base pay × (1 + min(times_worked, 100) / 100)."""
+    base = JOBS[job_name]["pay"]
+    return int(base * (1 + min(times_worked, 100) / 100))
+
+
+async def _available_jobs(user_id: int, guild_id: int) -> list[str]:
+    """Return job names the user is currently eligible for."""
+    row   = await db.get_xp(user_id, guild_id)
+    level = row["level"]
+    inv   = await db.get_inventory(user_id, guild_id)
+    return [
+        name for name, data in JOBS.items()
+        if level >= data["level"] and all(item in inv for item in data["items"])
+    ]
+
+
+async def post_economy_log(bot: commands.Bot, guild_id: int, embed: discord.Embed) -> None:
+    """Post an economy event embed to the guild's configured log channel."""
+    cid = await db.get_setting(guild_id, "economy_log_channel", "")
+    if not cid:
+        return
+    ch = bot.get_channel(int(cid))
+    if ch:
+        try:
+            await ch.send(embed=embed)
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Cog
+# ---------------------------------------------------------------------------
+
+class EconomyCog(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    # ------------------------------------------------------------------ events
+
+    @commands.Cog.listener()
+    async def on_guild_join(self, guild: discord.Guild):
+        """Auto-create an economy-log channel when the bot joins a new guild."""
+        cid = await db.get_setting(guild.id, "economy_log_channel", "")
+        if cid:
+            ch = guild.get_channel(int(cid))
+            if ch:
+                return  # already set up
+
+        try:
+            # Prefer existing "Bot" or "General" category; else no category
+            cat = (discord.utils.get(guild.categories, name="Bot")
+                   or discord.utils.get(guild.categories, name="General"))
+            overwrites = {
+                guild.default_role: discord.PermissionOverwrite(
+                    read_messages=True, send_messages=False
+                ),
+                guild.me: discord.PermissionOverwrite(
+                    read_messages=True, send_messages=True
+                ),
+            }
+            ch = await guild.create_text_channel(
+                "economy-log",
+                overwrites=overwrites,
+                category=cat,
+                topic="Live feed of XP level-ups, daily rewards, work earnings, and shop purchases.",
+            )
+            await db.set_setting(guild.id, "economy_log_channel", str(ch.id))
+            embed = discord.Embed(
+                title="📊 Economy Log",
+                description=(
+                    "This channel will automatically log:\n"
+                    "🏆 Level-ups  •  🎁 Daily rewards  •  💼 Work earnings  •  🛒 Shop purchases\n\n"
+                    "Admins can move it with `!setlogchannel #channel`."
+                ),
+                color=discord.Color.gold(),
+            )
+            await ch.send(embed=embed)
+        except discord.Forbidden:
+            pass
+        except Exception as e:
+            logger.error("on_guild_join economy-log creation failed: %s", e)
+
+    # ------------------------------------------------------------------ !daily
+
+    @commands.command(name="daily")
+    async def daily(self, ctx: commands.Context):
+        """Claim your daily reward. Higher streaks unlock better odds!"""
+        uid, gid = ctx.author.id, ctx.guild.id
+        now  = int(time.time())
+        row  = await db.get_economy(uid, gid)
+        last = row["last_daily"]
+        streak = row["daily_streak"]
+
+        if now - last < _DAILY_COOLDOWN:
+            remaining = _DAILY_COOLDOWN - (now - last)
+            h, m = divmod(remaining // 60, 60)
+            await ctx.send(
+                f"⏰ Already claimed today! Come back in **{h}h {m}m**.",
+                delete_after=10,
+            )
+            return
+
+        # Reset streak if more than 48 h have passed since last claim
+        if last > 0 and now - last > _DAILY_COOLDOWN * 2:
+            streak = 0
+        streak += 1
+
+        amount, tier_label, tier_emoji = _pick_daily(streak)
+        new_count = row["daily_count"] + 1
+        new_bal   = await db.add_coins(uid, gid, amount)
+        await db.set_economy(uid, gid,
+                             last_daily=now,
+                             daily_streak=streak,
+                             daily_count=new_count)
+
+        weights = _daily_weights(streak)
+        chance_preview = " · ".join(
+            f"{t[0]}: {w:.1f}%" for t, w in zip(_DAILY_TIERS, weights)
+        )
+
+        embed = discord.Embed(
+            title="🎁 Daily Reward",
+            description=f"{tier_emoji} **{tier_label}** reward!",
+            color=discord.Color.gold(),
+        )
+        embed.set_author(name=ctx.author.display_name,
+                         icon_url=ctx.author.display_avatar.url)
+        embed.add_field(name="Coins earned",  value=f"**+{amount}** 🪙",    inline=True)
+        embed.add_field(name="Balance",       value=f"**{new_bal}** 🪙",    inline=True)
+        embed.add_field(name="Streak",        value=f"🔥 **{streak}** days", inline=True)
+        embed.add_field(name="Total claims",  value=str(new_count),          inline=True)
+        embed.set_footer(text=f"Current odds → {chance_preview}")
+        await ctx.send(embed=embed)
+
+        log_embed = discord.Embed(
+            title="🎁 Daily Claimed",
+            description=(
+                f"{ctx.author.mention} claimed **{tier_emoji} {tier_label}** "
+                f"— **+{amount}** 🪙  (streak: {streak})"
+            ),
+            color=discord.Color.gold(),
+        )
+        await post_economy_log(self.bot, gid, log_embed)
+
+    # ------------------------------------------------------------------ !work
+
+    @commands.command(name="work")
+    async def work(self, ctx: commands.Context):
+        """Open the job selector and earn coins + XP (1 h cooldown)."""
+        uid, gid = ctx.author.id, ctx.guild.id
+        now  = int(time.time())
+        row  = await db.get_economy(uid, gid)
+
+        if now - row["last_worked"] < _WORK_COOLDOWN:
+            remaining = (_WORK_COOLDOWN - (now - row["last_worked"])) // 60
+            await ctx.send(f"⏰ You're tired! Rest for **{remaining}m** more.", delete_after=10)
+            return
+
+        available = await _available_jobs(uid, gid)
+        if not available:
+            await ctx.send(
+                "❌ No jobs available yet. Earn XP to unlock higher-tier jobs "
+                "or buy required items from `!shop`.",
+                delete_after=12,
+            )
+            return
+
+        xp_row = await db.get_xp(uid, gid)
+        embed = discord.Embed(
+            title="💼 Job Center",
+            description=(
+                "Choose a job below.\n"
+                "Pay increases **+1%** each time you work the same job (max +100%)."
+            ),
+            color=discord.Color.blurple(),
+        )
+        embed.add_field(name="Level",  value=str(xp_row["level"]),             inline=True)
+        embed.add_field(name="Coins",  value=f"{xp_row.get('coins', 0)} 🪙",  inline=True)
+        embed.set_footer(text="Pick a job from the dropdown.")
+
+        view = _WorkView(ctx, available)
+        msg  = await ctx.send(embed=embed, view=view)
+        view.message = msg
+
+    # ------------------------------------------------------------------ !shop
+
+    @commands.command(name="shop")
+    async def shop(self, ctx: commands.Context):
+        """Browse and buy items from the shop."""
+        view = _ShopView(ctx)
+        msg  = await ctx.send(embed=_shop_embed(), view=view)
+        view.message = msg
+
+    # ------------------------------------------------------------------ !inventory
+
+    @commands.command(name="inventory", aliases=["inv"])
+    async def inventory(self, ctx: commands.Context, member: discord.Member = None):
+        """Show your (or another user's) inventory."""
+        target = member or ctx.author
+        inv = await db.get_inventory(target.id, ctx.guild.id)
+        embed = discord.Embed(
+            title=f"🎒 {target.display_name}'s Inventory",
+            color=discord.Color.blurple(),
+        )
+        if inv:
+            lines = []
+            for item_name, qty in inv.items():
+                data  = SHOP_ITEMS.get(item_name, {})
+                emoji = data.get("emoji", "📦")
+                lines.append(f"{emoji} **{item_name.replace('_', ' ').title()}** × {qty}")
+            embed.description = "\n".join(lines)
+        else:
+            embed.description = "Empty — visit `!shop` to buy items!"
+        await ctx.send(embed=embed)
+
+    # ------------------------------------------------------------------ !setlogchannel
+
+    @commands.command(name="setlogchannel")
+    @commands.has_permissions(administrator=True)
+    async def setlogchannel(self, ctx: commands.Context, channel: discord.TextChannel):
+        """Set the economy log channel. Usage: !setlogchannel #channel"""
+        await db.set_setting(ctx.guild.id, "economy_log_channel", str(channel.id))
+        await ctx.send(f"✅ Economy log channel set to {channel.mention}.")
+
+    # ------------------------------------------------------------------ !joblist
+
+    @commands.command(name="joblist", aliases=["jobs"])
+    async def joblist(self, ctx: commands.Context):
+        """Show all jobs, requirements, and your mastery for each."""
+        uid, gid = ctx.author.id, ctx.guild.id
+        xp_row   = await db.get_xp(uid, gid)
+        level    = xp_row["level"]
+        inv      = await db.get_inventory(uid, gid)
+
+        embed = discord.Embed(title="📋 All Jobs", color=discord.Color.blurple())
+        tiers: dict[int, list[str]] = {}
+        for name, data in JOBS.items():
+            tiers.setdefault(data["tier"], []).append(name)
+
+        for tier_num in sorted(tiers):
+            lines = []
+            for name in tiers[tier_num]:
+                data  = JOBS[name]
+                times = await db.get_job_times(uid, gid, name)
+                pay   = _job_pay(name, times)
+                unlocked = (level >= data["level"]
+                            and all(item in inv for item in data["items"]))
+                lock_str = "✅" if unlocked else "🔒"
+                req_parts = []
+                if data["level"]: req_parts.append(f"Lv{data['level']}")
+                if data["items"]: req_parts.append(", ".join(data["items"]))
+                req = f" *(req: {', '.join(req_parts)})*" if req_parts else ""
+                mastery = f" | mastery {times}/100" if times else ""
+                lines.append(
+                    f"{lock_str} {data['emoji']} **{name.replace('_', ' ').title()}** "
+                    f"— {pay} 🪙 / work{req}{mastery}"
+                )
+            embed.add_field(
+                name=f"Tier {tier_num}",
+                value="\n".join(lines),
+                inline=False,
+            )
+        embed.set_footer(text=f"Your level: {level}  |  Pay shown includes mastery bonus.")
+        await ctx.send(embed=embed)
+
+
+# ---------------------------------------------------------------------------
+# Work UI
+# ---------------------------------------------------------------------------
+
+class _WorkView(discord.ui.View):
+    def __init__(self, ctx: commands.Context, available: list[str]):
+        super().__init__(timeout=60)
+        self.ctx     = ctx
+        self.message: discord.Message | None = None
+        self.add_item(_JobSelect(ctx, available, self))
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user != self.ctx.author:
+            await interaction.response.send_message(
+                "This job menu isn't for you.", ephemeral=True)
+            return False
+        return True
+
+    async def on_timeout(self):
+        for item in self.children:
+            item.disabled = True
+        try:
+            await self.message.edit(view=self)
+        except Exception:
+            pass
+
+
+class _JobSelect(discord.ui.Select):
+    def __init__(self, ctx: commands.Context, available: list[str], view: _WorkView):
+        self._ctx        = ctx
+        self._work_view  = view
+        options = []
+        for name in available:
+            j = JOBS[name]
+            options.append(discord.SelectOption(
+                label=f"{j['emoji']} {name.replace('_', ' ').title()}",
+                value=name,
+                description=f"Base pay: {j['pay']} 🪙  |  +{j['xp']} XP  |  Tier {j['tier']}",
+            ))
+        super().__init__(
+            placeholder="Choose a job to work…",
+            min_values=1, max_values=1,
+            options=options,
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction):
+        job_name = self.values[0]
+        uid, gid = interaction.user.id, interaction.guild.id
+        now      = int(time.time())
+
+        # Re-check cooldown (guard against double-click)
+        eco = await db.get_economy(uid, gid)
+        if now - eco["last_worked"] < _WORK_COOLDOWN:
+            remaining = (_WORK_COOLDOWN - (now - eco["last_worked"])) // 60
+            await interaction.response.send_message(
+                f"⏰ Still on cooldown! {remaining}m left.", ephemeral=True)
+            return
+
+        times   = await db.get_job_times(uid, gid, job_name)
+        pay     = _job_pay(job_name, times)
+        job     = JOBS[job_name]
+        xp_gain = job["xp"]
+
+        new_times             = await db.increment_job(uid, gid, job_name)
+        new_bal               = await db.add_coins(uid, gid, pay)
+        new_xp, new_lv, lvup = await db.add_xp(uid, gid, xp_gain, now)
+        await db.set_economy(uid, gid, last_worked=now)
+
+        bonus_pct = min(times, 100)
+        embed = discord.Embed(
+            title=f"{job['emoji']} Work Complete — {job_name.replace('_', ' ').title()}",
+            description=job["desc"],
+            color=discord.Color.green(),
+        )
+        embed.add_field(name="Earned",      value=f"**+{pay}** 🪙",                  inline=True)
+        embed.add_field(name="XP gained",   value=f"**+{xp_gain}** XP",              inline=True)
+        embed.add_field(name="Balance",     value=f"**{new_bal}** 🪙",               inline=True)
+        embed.add_field(name="Job mastery", value=f"{new_times}× worked (+{bonus_pct}% pay)", inline=True)
+        embed.add_field(name="Level",       value=f"**{new_lv}**{'  🎉 Level up!' if lvup else ''}", inline=True)
+        embed.set_footer(text="Come back in 1 hour to work again!")
+
+        for item in self._work_view.children:
+            item.disabled = True
+        await interaction.response.edit_message(embed=embed, view=self._work_view)
+        self._work_view.stop()
+
+        log_embed = discord.Embed(
+            title="💼 Work Completed",
+            description=(
+                f"{interaction.user.mention} worked as "
+                f"**{job['emoji']} {job_name.replace('_', ' ').title()}**\n"
+                f"Earned **+{pay}** 🪙 and **+{xp_gain}** XP"
+                + ("  🎉 *Level up!*" if lvup else "")
+            ),
+            color=discord.Color.green(),
+        )
+        await post_economy_log(self._ctx.bot, gid, log_embed)
+
+
+# ---------------------------------------------------------------------------
+# Shop UI
+# ---------------------------------------------------------------------------
+
+def _shop_embed() -> discord.Embed:
+    embed = discord.Embed(
+        title="🛒 Item Shop",
+        description="Buy items to unlock higher-tier jobs.",
+        color=discord.Color.orange(),
+    )
+    for name, data in SHOP_ITEMS.items():
+        embed.add_field(
+            name=f"{data['emoji']} {name.replace('_', ' ').title()} — {data['price']:,} 🪙",
+            value=data["desc"],
+            inline=False,
+        )
+    embed.set_footer(text="Select an item from the dropdown to purchase.")
+    return embed
+
+
+class _ShopView(discord.ui.View):
+    def __init__(self, ctx: commands.Context):
+        super().__init__(timeout=120)
+        self.ctx     = ctx
+        self.message: discord.Message | None = None
+        options = [
+            discord.SelectOption(
+                label=f"{d['emoji']} {name.replace('_', ' ').title()} — {d['price']:,} 🪙",
+                value=name,
+                description=d["desc"],
+            )
+            for name, d in SHOP_ITEMS.items()
+        ]
+        self.add_item(_ShopSelect(ctx, options, self))
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user != self.ctx.author:
+            await interaction.response.send_message(
+                "This shop isn't for you.", ephemeral=True)
+            return False
+        return True
+
+    async def on_timeout(self):
+        for item in self.children:
+            item.disabled = True
+        try:
+            await self.message.edit(view=self)
+        except Exception:
+            pass
+
+
+class _ShopSelect(discord.ui.Select):
+    def __init__(self, ctx: commands.Context, options, view: _ShopView):
+        self._ctx        = ctx
+        self._shop_view  = view
+        super().__init__(
+            placeholder="Select an item to buy…",
+            options=options,
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction):
+        item_name = self.values[0]
+        uid, gid  = interaction.user.id, interaction.guild.id
+        data      = SHOP_ITEMS[item_name]
+
+        if await db.has_item(uid, gid, item_name):
+            await interaction.response.send_message(
+                f"You already own a **{item_name}**!", ephemeral=True)
+            return
+
+        bal = await db.get_coins(uid, gid)
+        if bal < data["price"]:
+            await interaction.response.send_message(
+                f"❌ Need **{data['price']:,}** 🪙 — you only have **{bal:,}** 🪙.",
+                ephemeral=True)
+            return
+
+        new_bal = await db.add_coins(uid, gid, -data["price"])
+        await db.add_item(uid, gid, item_name)
+
+        embed = discord.Embed(
+            title=f"✅ Purchased: {data['emoji']} {item_name.replace('_', ' ').title()}",
+            description=f"**-{data['price']:,}** 🪙  |  New balance: **{new_bal:,}** 🪙",
+            color=discord.Color.green(),
+        )
+        await interaction.response.send_message(embed=embed)
+
+        log_embed = discord.Embed(
+            title="🛒 Shop Purchase",
+            description=(
+                f"{interaction.user.mention} bought "
+                f"**{data['emoji']} {item_name.replace('_', ' ').title()}** "
+                f"for **{data['price']:,}** 🪙"
+            ),
+            color=discord.Color.orange(),
+        )
+        await post_economy_log(self._ctx.bot, gid, log_embed)
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(EconomyCog(bot))
+    logger.info("EconomyCog loaded.")

--- a/disbot/cogs/moderation_cog.py
+++ b/disbot/cogs/moderation_cog.py
@@ -1,26 +1,26 @@
+from __future__ import annotations
 import discord
 from discord.ext import commands
 from discord import Member
 from datetime import timedelta
 import logging
-import asyncio
-import sqlite3
 import os
+import sqlite3
 
 DB_PATH = os.path.join(os.path.dirname(__file__), "../data/moderation.db")
 LOG_PATH = os.path.join(os.path.dirname(__file__), "../data/json/mod_logs.json")
 
+
 class ModerationCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-        self.logger = logging.getLogger(__name__)
+        self.logger = logging.getLogger("bot")
         os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
         self.conn = sqlite3.connect(DB_PATH)
         self.cursor = self.conn.cursor()
         self._setup_database()
 
     def _setup_database(self):
-        """Create tables if they don't exist."""
         self.cursor.execute('''CREATE TABLE IF NOT EXISTS warnings (
             user_id INTEGER,
             guild_id INTEGER,
@@ -29,95 +29,157 @@ class ModerationCog(commands.Cog):
         )''')
         self.conn.commit()
 
-    async def log_action(self, ctx, action: str, member: Member, reason: str = "No reason provided"):
-        """Logs actions in a JSON file."""
+    async def log_action(self, ctx, action: str, member, reason: str = "No reason provided"):
         log_data = {
             "guild": ctx.guild.name,
             "action": action,
             "member": member.id,
             "moderator": ctx.author.id,
-            "reason": reason
+            "reason": reason,
         }
         os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
-        with open(LOG_PATH, "a") as log_file:
-            log_file.write(str(log_data) + "\n")
+        with open(LOG_PATH, "a") as f:
+            f.write(str(log_data) + "\n")
+        self.logger.info(f"MOD | {action.upper()} | {member} | by {ctx.author} | {reason}")
 
+    def _can_act_on(self, ctx, member: Member) -> str | None:
+        """Returns an error message if the action is not allowed, else None."""
+        if member == ctx.guild.owner:
+            return "❌ You cannot perform this action on the server owner."
+        if member.top_role >= ctx.author.top_role:
+            return "❌ You cannot perform this action on someone with an equal or higher role."
+        if member.top_role >= ctx.guild.me.top_role:
+            return "❌ I cannot perform this action — that member has a higher role than me."
+        return None
+
+    # ------------------------------------------------------------------
+    # Warn
+    # ------------------------------------------------------------------
     @commands.command(name='warn')
     @commands.has_permissions(manage_roles=True)
     async def warn(self, ctx, member: Member, *, reason='No reason provided'):
-        """Warn a user and track warnings in the database."""
-        if member == ctx.guild.owner or member.top_role >= ctx.author.top_role:
-            await ctx.send(f"❌ You cannot warn this user.")
+        """Warn a user. Three warnings result in a 10-minute timeout."""
+        err = self._can_act_on(ctx, member)
+        if err:
+            await ctx.send(err)
             return
 
-        self.cursor.execute("SELECT count FROM warnings WHERE user_id = ? AND guild_id = ?", (member.id, ctx.guild.id))
+        self.cursor.execute(
+            "SELECT count FROM warnings WHERE user_id = ? AND guild_id = ?",
+            (member.id, ctx.guild.id)
+        )
         result = self.cursor.fetchone()
-        warning_count = (result[0] + 1) if result else 1
+        count = (result[0] + 1) if result else 1
 
         if result:
-            self.cursor.execute("UPDATE warnings SET count = ? WHERE user_id = ? AND guild_id = ?", (warning_count, member.id, ctx.guild.id))
+            self.cursor.execute(
+                "UPDATE warnings SET count = ? WHERE user_id = ? AND guild_id = ?",
+                (count, member.id, ctx.guild.id)
+            )
         else:
-            self.cursor.execute("INSERT INTO warnings (user_id, guild_id, count) VALUES (?, ?, ?)", (member.id, ctx.guild.id, warning_count))
+            self.cursor.execute(
+                "INSERT INTO warnings (user_id, guild_id, count) VALUES (?, ?, ?)",
+                (member.id, ctx.guild.id, count)
+            )
         self.conn.commit()
 
-        await ctx.send(f"⚠️ {member.mention} has been warned. Reason: {reason}. Warning count: {warning_count}")
+        await ctx.send(f"⚠️ {member.mention} warned ({count}/3). Reason: {reason}")
         await self.log_action(ctx, "warn", member, reason)
 
-        if warning_count >= 3:
-            await self.timeout(ctx, member, 10)
-            self.cursor.execute("DELETE FROM warnings WHERE user_id = ? AND guild_id = ?", (member.id, ctx.guild.id))
-            self.conn.commit()
+        if count >= 3:
+            try:
+                until = discord.utils.utcnow() + timedelta(minutes=10)
+                await member.timeout(until, reason="3 warnings reached.")
+                await ctx.send(f"⏳ {member.mention} timed out for 10 minutes (3 warnings).")
+                self.cursor.execute(
+                    "DELETE FROM warnings WHERE user_id = ? AND guild_id = ?",
+                    (member.id, ctx.guild.id)
+                )
+                self.conn.commit()
+            except discord.Forbidden:
+                await ctx.send("⚠️ Reached 3 warnings but I lack permission to timeout this user.")
 
+    # ------------------------------------------------------------------
+    # Timeout
+    # ------------------------------------------------------------------
     @commands.command(name='timeout')
     @commands.has_permissions(moderate_members=True)
     async def timeout(self, ctx, member: Member, duration: int):
-        """Timeout a member for a specific duration (minutes)."""
-        if member.top_role >= ctx.author.top_role:
-            await ctx.send("❌ You cannot timeout this user.")
+        """Timeout a member for a given number of minutes."""
+        err = self._can_act_on(ctx, member)
+        if err:
+            await ctx.send(err)
             return
+        try:
+            until = discord.utils.utcnow() + timedelta(minutes=duration)
+            await member.timeout(until, reason=f"Timeout by {ctx.author}")
+            await ctx.send(f"⏳ {member.mention} timed out for {duration} minute(s).")
+            await self.log_action(ctx, "timeout", member, f"{duration} minutes")
+        except discord.Forbidden:
+            await ctx.send("❌ I don't have permission to timeout that user.")
+        except discord.HTTPException as e:
+            await ctx.send(f"❌ Failed to timeout: {e}")
 
-        await member.timeout(discord.utils.utcnow() + timedelta(minutes=duration), reason="Timeout issued by a moderator.")
-        await ctx.send(f"⏳ {member.mention} has been timed out for {duration} minutes.")
-        await self.log_action(ctx, "timeout", member, f"Timed out for {duration} minutes")
-
+    # ------------------------------------------------------------------
+    # Kick
+    # ------------------------------------------------------------------
     @commands.command(name='kick')
     @commands.has_permissions(kick_members=True)
     async def kick(self, ctx, member: Member, *, reason='No reason provided'):
         """Kick a member from the server."""
-        if member.top_role >= ctx.author.top_role:
-            await ctx.send("❌ You cannot kick this user.")
+        err = self._can_act_on(ctx, member)
+        if err:
+            await ctx.send(err)
             return
+        try:
+            await member.kick(reason=reason)
+            await ctx.send(f"👢 {member.mention} kicked. Reason: {reason}")
+            await self.log_action(ctx, "kick", member, reason)
+        except discord.Forbidden:
+            await ctx.send("❌ I don't have permission to kick that user.")
+        except discord.HTTPException as e:
+            await ctx.send(f"❌ Failed to kick: {e}")
 
-        await member.kick(reason=reason)
-        await ctx.send(f"👢 {member.mention} has been kicked. Reason: {reason}")
-        await self.log_action(ctx, "kick", member, reason)
-
+    # ------------------------------------------------------------------
+    # Ban
+    # ------------------------------------------------------------------
     @commands.command(name='ban')
     @commands.has_permissions(ban_members=True)
     async def ban(self, ctx, member: Member, *, reason='No reason provided'):
-        """Ban a user."""
-        if member.top_role >= ctx.author.top_role:
-            await ctx.send("❌ You cannot ban this user.")
+        """Ban a member from the server."""
+        err = self._can_act_on(ctx, member)
+        if err:
+            await ctx.send(err)
             return
+        try:
+            await member.ban(reason=reason)
+            await ctx.send(f"🚫 {member.mention} banned. Reason: {reason}")
+            await self.log_action(ctx, "ban", member, reason)
+        except discord.Forbidden:
+            await ctx.send("❌ I don't have permission to ban that user.")
+        except discord.HTTPException as e:
+            await ctx.send(f"❌ Failed to ban: {e}")
 
-        await member.ban(reason=reason)
-        await ctx.send(f"🚫 {member.mention} has been banned. Reason: {reason}")
-        await self.log_action(ctx, "ban", member, reason)
-
+    # ------------------------------------------------------------------
+    # Unban
+    # ------------------------------------------------------------------
     @commands.command(name='unban')
     @commands.has_permissions(ban_members=True)
-    async def unban(self, ctx, *, member_name):
-        """Unban a previously banned user."""
-        banned_users = await ctx.guild.bans()
-        for entry in banned_users:
-            user = entry.user
-            if user.name == member_name:
-                await ctx.guild.unban(user)
-                await ctx.send(f"✅ {user.mention} has been unbanned.")
-                await self.log_action(ctx, "unban", user)
+    async def unban(self, ctx, *, member_name: str):
+        """Unban a user by their username."""
+        try:
+            bans = [entry async for entry in ctx.guild.bans()]
+        except discord.Forbidden:
+            await ctx.send("❌ I don't have permission to view the ban list.")
+            return
+        for entry in bans:
+            if entry.user.name == member_name:
+                await ctx.guild.unban(entry.user)
+                await ctx.send(f"✅ {entry.user.mention} unbanned.")
+                await self.log_action(ctx, "unban", entry.user)
                 return
-        await ctx.send("❌ User not found in ban list.")
+        await ctx.send(f"❌ No banned user found with name `{member_name}`.")
 
-# Function to load this cog
+
 async def setup(bot):
     await bot.add_cog(ModerationCog(bot))

--- a/disbot/cogs/moderation_cog.py
+++ b/disbot/cogs/moderation_cog.py
@@ -4,43 +4,18 @@ from discord.ext import commands
 from discord import Member
 from datetime import timedelta
 import logging
-import os
-import sqlite3
+from utils import db
 
-DB_PATH = os.path.join(os.path.dirname(__file__), "../data/moderation.db")
-LOG_PATH = os.path.join(os.path.dirname(__file__), "../data/json/mod_logs.json")
+logger = logging.getLogger("bot")
 
 
 class ModerationCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-        self.logger = logging.getLogger("bot")
-        os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
-        self.conn = sqlite3.connect(DB_PATH)
-        self.cursor = self.conn.cursor()
-        self._setup_database()
-
-    def _setup_database(self):
-        self.cursor.execute('''CREATE TABLE IF NOT EXISTS warnings (
-            user_id INTEGER,
-            guild_id INTEGER,
-            count INTEGER DEFAULT 0,
-            PRIMARY KEY (user_id, guild_id)
-        )''')
-        self.conn.commit()
 
     async def log_action(self, ctx, action: str, member, reason: str = "No reason provided"):
-        log_data = {
-            "guild": ctx.guild.name,
-            "action": action,
-            "member": member.id,
-            "moderator": ctx.author.id,
-            "reason": reason,
-        }
-        os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
-        with open(LOG_PATH, "a") as f:
-            f.write(str(log_data) + "\n")
-        self.logger.info(f"MOD | {action.upper()} | {member} | by {ctx.author} | {reason}")
+        await db.log_mod_action(ctx.guild.id, action, member.id, ctx.author.id, reason)
+        logger.info("MOD | %s | %s | by %s | %s", action.upper(), member, ctx.author, reason)
 
     def _can_act_on(self, ctx, member: Member) -> str | None:
         """Returns an error message if the action is not allowed, else None."""
@@ -64,25 +39,7 @@ class ModerationCog(commands.Cog):
             await ctx.send(err)
             return
 
-        self.cursor.execute(
-            "SELECT count FROM warnings WHERE user_id = ? AND guild_id = ?",
-            (member.id, ctx.guild.id)
-        )
-        result = self.cursor.fetchone()
-        count = (result[0] + 1) if result else 1
-
-        if result:
-            self.cursor.execute(
-                "UPDATE warnings SET count = ? WHERE user_id = ? AND guild_id = ?",
-                (count, member.id, ctx.guild.id)
-            )
-        else:
-            self.cursor.execute(
-                "INSERT INTO warnings (user_id, guild_id, count) VALUES (?, ?, ?)",
-                (member.id, ctx.guild.id, count)
-            )
-        self.conn.commit()
-
+        count = await db.add_warning(member.id, ctx.guild.id)
         await ctx.send(f"⚠️ {member.mention} warned ({count}/3). Reason: {reason}")
         await self.log_action(ctx, "warn", member, reason)
 
@@ -91,11 +48,7 @@ class ModerationCog(commands.Cog):
                 until = discord.utils.utcnow() + timedelta(minutes=10)
                 await member.timeout(until, reason="3 warnings reached.")
                 await ctx.send(f"⏳ {member.mention} timed out for 10 minutes (3 warnings).")
-                self.cursor.execute(
-                    "DELETE FROM warnings WHERE user_id = ? AND guild_id = ?",
-                    (member.id, ctx.guild.id)
-                )
-                self.conn.commit()
+                await db.clear_warnings(member.id, ctx.guild.id)
             except discord.Forbidden:
                 await ctx.send("⚠️ Reached 3 warnings but I lack permission to timeout this user.")
 

--- a/disbot/cogs/role_cog.py
+++ b/disbot/cogs/role_cog.py
@@ -1,180 +1,487 @@
+from __future__ import annotations
 import discord
 from discord.ext import commands, tasks
 from datetime import datetime
 import logging
+from utils import db
 
 logger = logging.getLogger("bot")
 
-class RoleCog(commands.Cog):
-    """
-    RoleCog automatically assigns roles based on time in the server
-    and provides commands to check and manage role assignments.
-    """
+# Default time-based thresholds seeded into the DB when a guild has none.
+_DEFAULT_THRESHOLDS: list[tuple[str, int]] = [
+    ("Neu",       0),
+    ("Normal",    1),
+    ("Iron",      7),
+    ("Gold",      30),
+    ("Diamand",   365),
+    ("Netherite", 730),
+    ("Beacon",    1825),
+]
 
-    def __init__(self, bot):
+SKIP_ROLES = {"Admin"}   # role names that are never auto-assigned / removed
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _ensure_defaults(guild_id: int) -> None:
+    """Seed default thresholds for a guild that has none yet."""
+    existing = await db.get_role_thresholds(guild_id)
+    if not existing:
+        for name, days in _DEFAULT_THRESHOLDS:
+            await db.set_role_threshold(guild_id, name, days)
+
+
+def _parse_color(value: str) -> discord.Color:
+    """Parse a hex string like '#ff0000' or 'ff0000' into a discord.Color."""
+    value = value.strip().lstrip("#")
+    return discord.Color(int(value, 16))
+
+
+_COLOR_OPTIONS = [
+    ("Red",    "#e74c3c"),
+    ("Blue",   "#3498db"),
+    ("Green",  "#2ecc71"),
+    ("Yellow", "#f1c40f"),
+    ("Purple", "#9b59b6"),
+    ("Orange", "#e67e22"),
+    ("White",  "#ffffff"),
+    ("Black",  "#000000"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Cog
+# ---------------------------------------------------------------------------
+
+class RoleCog(commands.Cog):
+    def __init__(self, bot: commands.Bot):
         self.bot = bot
         self.role_check.start()
 
     def cog_unload(self):
         self.role_check.cancel()
 
+    # ------------------------------------------------------------------ loop
+
     @tasks.loop(hours=24)
     async def role_check(self):
-        """Periodically checks and assigns roles."""
-        await self.assign_roles()
+        for guild in self.bot.guilds:
+            await self._assign_roles(guild)
 
     @role_check.before_loop
     async def before_role_check(self):
         await self.bot.wait_until_ready()
 
-    async def assign_roles(self, ctx=None):
-        """Assigns roles based on join time while keeping the highest role and removing outdated progression roles."""
-        guild = self.bot.get_guild(1403818012812775506)
-        if not guild:
-            logger.error("❌ Guild not found!")
-            return
+    # ------------------------------------------------------------------ core role assignment
 
-        role_mapping = {
-            "Neu": 0,
-            "Normal": 1,
-            "Iron": 7,
-            "Gold": 30,
-            "Diamand": 365,
-            "Netherite": 730,
-            "Beacon": 1825,
-        }
+    async def _assign_roles(self, guild: discord.Guild, ctx: commands.Context = None) -> int:
+        """Assign time-based roles to all members. Returns count of assignments made."""
+        await _ensure_defaults(guild.id)
+        thresholds = await db.get_role_thresholds(guild.id)
+        if not thresholds:
+            return 0
 
-        progression_roles = list(role_mapping.keys())  # Ordered list of progression roles
-        assigned_roles = 0
-        admin_role = discord.utils.get(guild.roles, name="Admin")  # Exclude Admins
+        # Build ordered mapping: role_name -> days_required
+        role_map = {row["role_name"]: row["days_required"] for row in thresholds}
+        progression = sorted(role_map, key=lambda r: role_map[r])
+
+        admin_role = discord.utils.get(guild.roles, name="Admin")
+        assigned = 0
 
         for member in guild.members:
-            if member.bot or (admin_role and admin_role in member.roles):
-                if admin_role in member.roles:
-                    logger.info(f"⏩ Skipping {member.display_name} (Admin role detected)")
-                continue  # Skip bots and admins
-
+            if member.bot:
+                continue
+            if admin_role and admin_role in member.roles:
+                continue
             if not member.joined_at:
-                logger.warning(f"⚠️ {member.display_name} has no join date, skipping...")
                 continue
 
-            # Convert to naive datetime for correct calculations
-            join_date = member.joined_at.replace(tzinfo=None)
-            days_in_server = (datetime.utcnow() - join_date).days
+            days = (datetime.utcnow() - member.joined_at.replace(tzinfo=None)).days
 
-            # Determine the highest role the member qualifies for
-            new_role = None
-            for role_name, required_days in role_mapping.items():
-                if days_in_server >= required_days:
-                    new_role = role_name  # Member qualifies for this role
+            # Find the highest qualifying role
+            target_name = None
+            for name in progression:
+                if days >= role_map[name]:
+                    target_name = name
 
-            role_to_add = discord.utils.get(guild.roles, name=new_role) if new_role else None
+            target_role = discord.utils.get(guild.roles, name=target_name) if target_name else None
 
-            # Check if the member already has a **higher** role
-            current_highest_role = None
+            # Current highest progression role this member holds
+            current_highest: str | None = None
             for role in member.roles:
-                if role.name in progression_roles:
-                    if current_highest_role is None or progression_roles.index(role.name) > progression_roles.index(current_highest_role):
-                        current_highest_role = role.name
+                if role.name in role_map:
+                    if current_highest is None or progression.index(role.name) > progression.index(current_highest):
+                        current_highest = role.name
 
-            # Prevent assigning a lower role if they already have a higher one
-            if current_highest_role and role_to_add and progression_roles.index(current_highest_role) > progression_roles.index(new_role):
-                logger.info(f"⏩ Skipping {member.display_name} (Already has higher role: {current_highest_role})")
-                continue  # Skip further processing for this member
+            # Don't downgrade
+            if current_highest and target_name and progression.index(current_highest) > progression.index(target_name):
+                continue
 
-            # Identify outdated progression roles to remove (ONLY from progression list, except the highest one)
-            roles_to_remove = [
-                role for role in member.roles
-                if role.name in progression_roles and role != role_to_add and role.name != current_highest_role
+            # Remove outdated progression roles (keep target only)
+            to_remove = [
+                r for r in member.roles
+                if r.name in role_map and r != target_role
             ]
-
-            if roles_to_remove:
+            if to_remove:
                 try:
-                    await member.remove_roles(*roles_to_remove)
-                    logger.info(f"✅ Removed outdated roles from {member.display_name}: {[r.name for r in roles_to_remove]}")
-                except discord.Forbidden:
-                    logger.error(f"❌ Cannot remove roles from {member.display_name} (Missing permissions)")
-                except discord.HTTPException as e:
-                    logger.error(f"❌ Failed to remove roles from {member.display_name}: {e}")
+                    await member.remove_roles(*to_remove)
+                except (discord.Forbidden, discord.HTTPException):
+                    pass
 
-            # Assign new role if necessary
-            if role_to_add and role_to_add not in member.roles:
+            if target_role and target_role not in member.roles:
                 try:
-                    await member.add_roles(role_to_add)
-                    assigned_roles += 1
-                    logger.info(f"✅ Assigned {role_to_add.name} to {member.display_name}")
-
-                except discord.Forbidden:
-                    logger.error(f"❌ Cannot assign {role_to_add.name} to {member.display_name} (Missing permissions)")
-                except discord.HTTPException as e:
-                    logger.error(f"❌ Failed to assign {role_to_add.name} to {member.display_name}: {e}")
+                    await member.add_roles(target_role)
+                    assigned += 1
+                    logger.info("Assigned %s to %s", target_role.name, member.display_name)
+                except (discord.Forbidden, discord.HTTPException):
+                    pass
 
         if ctx:
-            await ctx.send(f"✅ Assigned roles to {assigned_roles} members.")
+            await ctx.send(f"✅ Role check complete — {assigned} assignment(s) made.")
+        return assigned
 
-    @commands.command(name="assignroles", help="Manually assigns roles based on member join time.")
+    # ------------------------------------------------------------------ commands
+
+    @commands.command(name="assignroles")
     @commands.has_permissions(administrator=True)
-    async def assign_roles_command(self, ctx):
-        """Triggers role assignment manually with detailed error logging."""
-        await ctx.send("🔄 Checking and assigning roles...")
-        try:
-            await self.assign_roles(ctx)
-        except Exception as e:
-            logger.error(f"❌ Error in assign_roles: {e}", exc_info=True)
-            await ctx.send(f"⚠️ An error occurred: `{e}`")
+    async def assign_roles_cmd(self, ctx: commands.Context):
+        """Manually run the time-based role assignment for all members."""
+        await ctx.send("🔄 Running role assignment…")
+        await self._assign_roles(ctx.guild, ctx)
 
-    @commands.command(name="roles", help="Displays all roles in the server with member counts.")
-    async def roles(self, ctx):
-        """Lists roles and the number of members assigned to each."""
-        logger.info(f"Bot can see {len(ctx.guild.members)} members.")
-
-        roles = ctx.guild.roles
-        roles_list = "\n".join([
-            f"{role.name} - {sum(1 for member in ctx.guild.members if role in member.roles)} members"
-            for role in roles if role != ctx.guild.default_role
-        ])
-
+    @commands.command(name="roles")
+    async def roles(self, ctx: commands.Context):
+        """List all server roles with member counts."""
+        lines = [
+            f"**{role.name}** — {sum(1 for m in ctx.guild.members if role in m.roles)} members"
+            for role in reversed(ctx.guild.roles)
+            if role != ctx.guild.default_role
+        ]
         embed = discord.Embed(
             title=f"Roles in {ctx.guild.name}",
-            description=roles_list or "No roles found.",
-            color=discord.Color.purple()
+            description="\n".join(lines) or "No roles found.",
+            color=discord.Color.purple(),
         )
         await ctx.send(embed=embed)
 
     @commands.command(name="debugroles")
-    async def debug_roles(self, ctx):
-        """Prints all role names for verification."""
-        roles = [role.name for role in ctx.guild.roles]
-        await ctx.send(f"Available Roles: {', '.join(roles)}")
+    @commands.has_permissions(administrator=True)
+    async def debug_roles(self, ctx: commands.Context):
+        """Print all role names for verification."""
+        names = [r.name for r in ctx.guild.roles]
+        await ctx.send(f"Roles: {', '.join(names)}")
 
     @commands.command(name="refreshmembers")
-    async def refresh_members(self, ctx):
-        """Forces the bot to fetch all members."""
+    @commands.has_permissions(administrator=True)
+    async def refresh_members(self, ctx: commands.Context):
+        """Force-fetch all members from Discord."""
         await ctx.guild.chunk()
-        await ctx.send("✅ Fetched all members from the server.")
+        await ctx.send("✅ Member list refreshed.")
+
+    # ------------------------------------------------------------------ role creation commands
+
+    @commands.command(name="createrole")
+    @commands.has_permissions(manage_roles=True)
+    async def createrole(self, ctx: commands.Context, name: str, color: str = "000000", hoist: str = "no"):
+        """Create a new role.  Usage: !createrole <name> [hex_color] [hoist yes/no]"""
+        try:
+            col = _parse_color(color)
+        except (ValueError, OverflowError):
+            await ctx.send("❌ Invalid color — use a hex code like `#3498db`.", delete_after=10)
+            return
+        do_hoist = hoist.lower() in ("yes", "true", "1", "y")
+        try:
+            role = await ctx.guild.create_role(name=name, color=col, hoist=do_hoist)
+            await ctx.send(f"✅ Created role **{role.name}** (color `{color}`, hoist={do_hoist}).")
+        except discord.Forbidden:
+            await ctx.send("❌ I don't have permission to create roles.")
+        except discord.HTTPException as e:
+            await ctx.send(f"❌ Failed: {e}")
+
+    @commands.command(name="deleterole")
+    @commands.has_permissions(manage_roles=True)
+    async def deleterole(self, ctx: commands.Context, *, role: discord.Role):
+        """Delete a role by name or mention."""
+        if role >= ctx.guild.me.top_role:
+            await ctx.send("❌ That role is higher than or equal to my top role.")
+            return
+        name = role.name
+        try:
+            await role.delete()
+            await ctx.send(f"🗑️ Deleted role **{name}**.")
+        except discord.Forbidden:
+            await ctx.send("❌ I don't have permission to delete that role.")
+        except discord.HTTPException as e:
+            await ctx.send(f"❌ Failed: {e}")
+
+    @commands.command(name="rolecreator")
+    @commands.has_permissions(manage_roles=True)
+    async def rolecreator(self, ctx: commands.Context):
+        """Open the interactive role creator."""
+        view = RoleCreatorView(ctx)
+        embed = discord.Embed(
+            title="🎨 Role Creator",
+            description="Click **Create Role** to open the creation form.",
+            color=discord.Color.blurple(),
+        )
+        msg = await ctx.send(embed=embed, view=view)
+        view.message = msg
+
+    @commands.command(name="rolesettings")
+    @commands.has_permissions(administrator=True)
+    async def rolesettings(self, ctx: commands.Context):
+        """Open the time-based role threshold manager."""
+        await _ensure_defaults(ctx.guild.id)
+        view = RoleSettingsView(ctx)
+        msg = await ctx.send(embed=await view.build_embed(), view=view)
+        view.message = msg
+
+    @commands.command(name="setrole")
+    @commands.has_permissions(administrator=True)
+    async def setrole(self, ctx: commands.Context, days: int, *, role_name: str):
+        """Add or update a time-based role threshold.  Usage: !setrole <days> <role name>"""
+        if days < 0:
+            await ctx.send("Days must be 0 or greater.", delete_after=5)
+            return
+        await db.set_role_threshold(ctx.guild.id, role_name, days)
+        await ctx.send(f"✅ Role **{role_name}** will be assigned after **{days}** day(s).")
+
+    @commands.command(name="unsetrole")
+    @commands.has_permissions(administrator=True)
+    async def unsetrole(self, ctx: commands.Context, *, role_name: str):
+        """Remove a role from the time-based assignment system."""
+        await db.remove_role_threshold(ctx.guild.id, role_name)
+        await ctx.send(f"✅ Removed **{role_name}** from the auto-assignment system.")
+
+    # ------------------------------------------------------------------ on_member_join
 
     @commands.Cog.listener()
-    async def on_member_join(self, member):
-        """Automatically assigns the 'Neu' role when a new member joins, unless they are an Admin or already have a higher role."""
+    async def on_member_join(self, member: discord.Member):
         if member.bot:
-            return  # Ignore bots
-
-        guild = member.guild
-        neu_role = discord.utils.get(guild.roles, name="Neu")
-        admin_role = discord.utils.get(guild.roles, name="Admin")  # Exclude Admins
-
-        if admin_role and admin_role in member.roles:
-            logger.info(f"⏩ Skipping {member.display_name} (Admin role detected on join)")
             return
-
-        if neu_role and not any(role.name in ["Normal", "Iron", "Gold", "Diamand", "Netherite", "Beacon"] for role in member.roles):
+        await _ensure_defaults(member.guild.id)
+        thresholds = await db.get_role_thresholds(member.guild.id)
+        # Assign the 0-day role (Neu by default)
+        zero_day = next(
+            (r["role_name"] for r in thresholds if r["days_required"] == 0), None
+        )
+        if not zero_day:
+            return
+        role = discord.utils.get(member.guild.roles, name=zero_day)
+        if role:
             try:
-                await member.add_roles(neu_role)
-                logger.info(f"✅ Assigned 'Neu' role to {member.display_name} upon joining.")
-            except discord.Forbidden:
-                logger.error(f"❌ Cannot assign 'Neu' role to {member.display_name} (Missing permissions)")
-            except discord.HTTPException as e:
-                logger.error(f"❌ Failed to assign 'Neu' role to {member.display_name}: {e}")
+                await member.add_roles(role)
+                logger.info("Assigned '%s' to %s on join.", zero_day, member.display_name)
+            except (discord.Forbidden, discord.HTTPException):
+                pass
 
-async def setup(bot):
+
+# ---------------------------------------------------------------------------
+# Role Creator UI
+# ---------------------------------------------------------------------------
+
+class RoleCreatorView(discord.ui.View):
+    def __init__(self, ctx: commands.Context):
+        super().__init__(timeout=300)
+        self.ctx = ctx
+        self.message: discord.Message | None = None
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user != self.ctx.author:
+            await interaction.response.send_message("This panel isn't for you.", ephemeral=True)
+            return False
+        return True
+
+    @discord.ui.button(label="Create Role", style=discord.ButtonStyle.green)
+    async def create_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await interaction.response.send_modal(_RoleCreateModal(self.ctx))
+
+    async def on_timeout(self):
+        for item in self.children:
+            item.disabled = True
+        try:
+            await self.message.edit(view=self)
+        except Exception:
+            pass
+
+
+class _RoleCreateModal(discord.ui.Modal, title="Create Role"):
+    name = discord.ui.TextInput(label="Role name", max_length=100)
+    color = discord.ui.TextInput(
+        label="Color (hex, e.g. #3498db)", placeholder="#000000",
+        required=False, max_length=7,
+    )
+    hoist = discord.ui.TextInput(
+        label="Show separately in member list? (yes/no)",
+        placeholder="no", required=False, max_length=3,
+    )
+    mentionable = discord.ui.TextInput(
+        label="Mentionable by everyone? (yes/no)",
+        placeholder="no", required=False, max_length=3,
+    )
+
+    def __init__(self, ctx: commands.Context):
+        super().__init__()
+        self.ctx = ctx
+
+    async def on_submit(self, interaction: discord.Interaction):
+        col = discord.Color.default()
+        if self.color.value.strip():
+            try:
+                col = _parse_color(self.color.value)
+            except (ValueError, OverflowError):
+                await interaction.response.send_message(
+                    "❌ Invalid color — use hex like `#3498db`.", ephemeral=True
+                )
+                return
+
+        do_hoist = self.hoist.value.strip().lower() in ("yes", "y", "true", "1")
+        do_mention = self.mentionable.value.strip().lower() in ("yes", "y", "true", "1")
+
+        try:
+            role = await interaction.guild.create_role(
+                name=self.name.value,
+                color=col,
+                hoist=do_hoist,
+                mentionable=do_mention,
+            )
+            await interaction.response.send_message(
+                f"✅ Created role **{role.name}**.", ephemeral=True
+            )
+        except discord.Forbidden:
+            await interaction.response.send_message(
+                "❌ I don't have permission to create roles.", ephemeral=True
+            )
+        except discord.HTTPException as e:
+            await interaction.response.send_message(f"❌ Failed: {e}", ephemeral=True)
+
+
+# ---------------------------------------------------------------------------
+# Role Settings UI (time thresholds)
+# ---------------------------------------------------------------------------
+
+class RoleSettingsView(discord.ui.View):
+    def __init__(self, ctx: commands.Context):
+        super().__init__(timeout=300)
+        self.ctx = ctx
+        self.message: discord.Message | None = None
+
+    async def build_embed(self) -> discord.Embed:
+        thresholds = await db.get_role_thresholds(self.ctx.guild.id)
+        embed = discord.Embed(
+            title="⏱️ Time-Based Role Thresholds",
+            color=discord.Color.blurple(),
+        )
+        if thresholds:
+            lines = [f"**{r['role_name']}** — {r['days_required']} day(s)" for r in thresholds]
+            embed.description = "\n".join(lines)
+        else:
+            embed.description = "No thresholds configured."
+        embed.set_footer(text="Add / Edit / Remove thresholds using the buttons below.")
+        return embed
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user != self.ctx.author:
+            await interaction.response.send_message("This panel isn't for you.", ephemeral=True)
+            return False
+        return True
+
+    async def _refresh(self, interaction: discord.Interaction):
+        await interaction.message.edit(embed=await self.build_embed(), view=self)
+
+    @discord.ui.button(label="Add / Edit", style=discord.ButtonStyle.green, row=0)
+    async def add_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await interaction.response.send_modal(_ThresholdAddModal(self))
+
+    @discord.ui.button(label="Remove", style=discord.ButtonStyle.red, row=0)
+    async def remove_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        thresholds = await db.get_role_thresholds(self.ctx.guild.id)
+        if not thresholds:
+            await interaction.response.send_message("No thresholds to remove.", ephemeral=True)
+            return
+        view = _RemoveThresholdView(self, thresholds)
+        await interaction.response.send_message(
+            "Select a role threshold to remove:", view=view, ephemeral=True
+        )
+
+    @discord.ui.button(label="Reset to Defaults", style=discord.ButtonStyle.grey, row=0)
+    async def reset_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        for name, days in _DEFAULT_THRESHOLDS:
+            await db.set_role_threshold(self.ctx.guild.id, name, days)
+        await interaction.response.defer()
+        await self._refresh(interaction)
+
+    @discord.ui.button(label="Run Assignment Now", style=discord.ButtonStyle.blurple, row=1)
+    async def run_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await interaction.response.defer(ephemeral=True)
+        cog: RoleCog = interaction.client.get_cog("RoleCog")
+        if cog:
+            count = await cog._assign_roles(interaction.guild)
+            await interaction.followup.send(
+                f"✅ Assignment complete — {count} role(s) assigned.", ephemeral=True
+            )
+
+    async def on_timeout(self):
+        for item in self.children:
+            item.disabled = True
+        try:
+            await self.message.edit(view=self)
+        except Exception:
+            pass
+
+
+class _ThresholdAddModal(discord.ui.Modal, title="Add / Edit Threshold"):
+    role_name = discord.ui.TextInput(label="Role name (must exist in server)", max_length=100)
+    days = discord.ui.TextInput(label="Days in server required", placeholder="0", max_length=5)
+
+    def __init__(self, parent: RoleSettingsView):
+        super().__init__()
+        self.parent = parent
+
+    async def on_submit(self, interaction: discord.Interaction):
+        try:
+            d = int(self.days.value)
+            if d < 0:
+                raise ValueError
+        except ValueError:
+            await interaction.response.send_message(
+                "Days must be a non-negative integer.", ephemeral=True
+            )
+            return
+        await db.set_role_threshold(interaction.guild.id, self.role_name.value.strip(), d)
+        await interaction.response.defer()
+        await self.parent._refresh(interaction)
+
+
+class _RemoveSelect(discord.ui.Select):
+    def __init__(self, parent: RoleSettingsView, thresholds: list[dict]):
+        self.parent = parent
+        options = [
+            discord.SelectOption(
+                label=r["role_name"],
+                value=r["role_name"],
+                description=f"{r['days_required']} day(s)",
+            )
+            for r in thresholds
+        ][:25]
+        super().__init__(placeholder="Choose a threshold to remove…", options=options)
+
+    async def callback(self, interaction: discord.Interaction):
+        await db.remove_role_threshold(interaction.guild.id, self.values[0])
+        await interaction.response.send_message(
+            f"✅ Removed **{self.values[0]}** from auto-assignment.", ephemeral=True
+        )
+        await self.parent._refresh(interaction)
+
+
+class _RemoveThresholdView(discord.ui.View):
+    def __init__(self, parent: RoleSettingsView, thresholds: list[dict]):
+        super().__init__(timeout=60)
+        self.add_item(_RemoveSelect(parent, thresholds))
+
+
+async def setup(bot: commands.Bot):
     await bot.add_cog(RoleCog(bot))
+    logger.info("RoleCog loaded.")

--- a/disbot/cogs/rps_tournament_cog.py
+++ b/disbot/cogs/rps_tournament_cog.py
@@ -8,6 +8,8 @@ import os
 import sqlite3
 from datetime import datetime, timedelta
 from utils import db as global_db
+from utils.channels import create_private_channel, get_or_create_category, cleanup_category
+from utils.tournaments import TournamentRegistration
 
 logger = logging.getLogger("bot")
 
@@ -176,9 +178,6 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):
             if reaction:
                 users = [u async for u in reaction.users()]
                 for user in users:
-                    if user.bot:
-                        continue
-                            for user in users:
                     if not user.bot:
                         await self.try_register_player(user, ctx.guild.id)
                 await ctx.send(f"{len(self.players)} players have registered for the tournament.")
@@ -304,25 +303,15 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):
 
     async def create_bot_match_channel(self, guild, player, ctx):
         """Creates a private channel for a match against the bot."""
-        overwrites = {
-            guild.default_role: discord.PermissionOverwrite(read_messages=False),
-            player: discord.PermissionOverwrite(read_messages=True, send_messages=True),
-            self.bot.user: discord.PermissionOverwrite(read_messages=True, send_messages=True)
-        }
-        channel_name = f"rps-{player.display_name}-vs-bot"
-        category = discord.utils.get(guild.categories, name="RPS Bot Matches")
-        if category is None:
-            try:
-                category = await guild.create_category("RPS Bot Matches")
-            except discord.Forbidden:
-                await ctx.send("I do not have permission to create categories.")
-                return None
-
         try:
-            channel = await guild.create_text_channel(channel_name, overwrites=overwrites, category=category)
-            return channel
+            return await create_private_channel(
+                guild,
+                f"rps-{player.display_name}-vs-bot",
+                [player],
+                "RPS Bot Matches",
+            )
         except discord.Forbidden:
-            await ctx.send("I do not have permission to create text channels.")
+            await ctx.send("I do not have permission to create channels.")
             return None
         except Exception as e:
             logger.exception(f"Error creating bot match channel: {e}")
@@ -428,26 +417,15 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):
 
     async def create_match_channel(self, guild, player1, player2, ctx):
         """Creates a private channel for the match."""
-        overwrites = {
-            guild.default_role: discord.PermissionOverwrite(read_messages=False),
-            player1: discord.PermissionOverwrite(read_messages=True, send_messages=True),
-            player2: discord.PermissionOverwrite(read_messages=True, send_messages=True),
-            self.bot.user: discord.PermissionOverwrite(read_messages=True, send_messages=True)
-        }
-        channel_name = f"rps-{player1.display_name}-vs-{player2.display_name}"
-        category = discord.utils.get(guild.categories, name="RPS Tournaments")
-        if category is None:
-            try:
-                category = await guild.create_category("RPS Tournaments")
-            except discord.Forbidden:
-                await ctx.send("I do not have permission to create categories.")
-                return None
-
         try:
-            channel = await guild.create_text_channel(channel_name, overwrites=overwrites, category=category)
-            return channel
+            return await create_private_channel(
+                guild,
+                f"rps-{player1.display_name}-vs-{player2.display_name}",
+                [player1, player2],
+                "RPS Tournaments",
+            )
         except discord.Forbidden:
-            await ctx.send("I do not have permission to create text channels.")
+            await ctx.send("I do not have permission to create channels.")
             return None
         except Exception as e:
             logger.exception(f"Error creating match channel: {e}")
@@ -762,14 +740,10 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):
             await self.start_round(last_channel, self.settings["default_best_of"])
 
     async def delete_all_match_channels(self, guild):
-        """Deletes all match channels."""
+        """Deletes all RPS tournament match channels and their category."""
         category = discord.utils.get(guild.categories, name="RPS Tournaments")
         if category:
-            for channel in category.channels:
-                try:
-                    await channel.delete()
-                except Exception as e:
-                    logger.exception(f"Error deleting match channel {channel.name}: {e}")
+            await cleanup_category(category)
 
     @tasks.loop(minutes=10)
     async def clean_up_expired_matches(self):

--- a/disbot/cogs/rps_tournament_cog.py
+++ b/disbot/cogs/rps_tournament_cog.py
@@ -432,7 +432,7 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):
             await ctx.send(f"An error occurred while creating the match channel: {e}")
             return None
 
-    @commands.command(name="rpslb", aliases=["rpslb"])
+    @commands.command(name="rpslb")
     async def rps_leaderboard(self, ctx):
         """Displays the current leaderboard."""
         try:

--- a/disbot/cogs/rps_tournament_cog.py
+++ b/disbot/cogs/rps_tournament_cog.py
@@ -51,6 +51,8 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):
             "default_mode": "classic",
             "default_best_of": 3
         }
+        self.entry_fee = 0
+        self.paid_players: set[int] = set()   # players who paid the entry fee
         os.makedirs(os.path.dirname(_RPS_DB), exist_ok=True)
         self.db_connection = sqlite3.connect(_RPS_DB)
         self.db_cursor = self.db_connection.cursor()
@@ -99,8 +101,9 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):
 
     @commands.command(name="rpsregister", aliases=["rpsreg"])
     @commands.has_permissions(administrator=True)
-    async def rps_register(self, ctx, role: discord.Role = None):
-        """Starts the registration period with a reaction role message."""
+    async def rps_register(self, ctx, role: discord.Role = None, entry_fee: int = 0):
+        """Starts the registration period with a reaction role message.  !rpsregister [@role] [entry_fee]"""
+        self.entry_fee = max(0, entry_fee)
         if self.tournament_active:
             await ctx.send("Cannot start registration after the tournament has started.")
             return
@@ -113,18 +116,22 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):
         self.registration_role = role
 
         # Send the registration message
+        fee_str = f"**{self.entry_fee}** 🪙" if self.entry_fee else "Free"
         embed = discord.Embed(
             title="🎮 Rock-Paper-Scissors Tournament Registration 🎮",
             description=(
-                "React with ✅ to sign up for the tournament!\n"
+                "React ✅ or click **Join** to sign up!\n"
                 f"Registration ends in {self.registration_timer // 60} minutes."
             ),
-            color=discord.Color.blue()
+            color=discord.Color.blue(),
         )
+        embed.add_field(name="Entry Fee", value=fee_str, inline=True)
+        embed.add_field(name="Game Mode", value=self.settings["default_mode"].capitalize(), inline=True)
         if role:
             embed.add_field(name="Attention", value=f"{role.mention}", inline=False)
 
-        self.registration_message = await ctx.send(embed=embed)
+        reg_view = _RpsRegistrationView(self)
+        self.registration_message = await ctx.send(embed=embed, view=reg_view)
         await self.registration_message.add_reaction(self.registration_emoji)
 
         # Start the registration timer
@@ -171,10 +178,9 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):
                 for user in users:
                     if user.bot:
                         continue
-                    if user not in self.players:
-                        self.players.append(user)
-                        self.scores[user] = 0
-                        self.add_player_to_db(user)
+                            for user in users:
+                    if not user.bot:
+                        await self.try_register_player(user, ctx.guild.id)
                 await ctx.send(f"{len(self.players)} players have registered for the tournament.")
             else:
                 await ctx.send("No participants registered.")
@@ -185,13 +191,28 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):
     def add_player_to_db(self, user):
         """Adds a player to the database."""
         try:
-            self.db_cursor.execute('''
-                INSERT OR IGNORE INTO players (id, name)
-                VALUES (?, ?)
-            ''', (user.id, user.display_name))
+            self.db_cursor.execute(
+                "INSERT OR IGNORE INTO players (id, name) VALUES (?, ?)",
+                (user.id, user.display_name)
+            )
             self.db_connection.commit()
         except Exception as e:
             logger.exception(f"Error adding player to database: {e}")
+
+    async def try_register_player(self, user, guild_id: int) -> bool:
+        """Check entry fee, deduct if needed, register player. Returns success."""
+        if user.id in self.paid_players or user in self.players:
+            return False  # already registered
+        if self.entry_fee > 0:
+            bal = await global_db.get_coins(user.id, guild_id)
+            if bal < self.entry_fee:
+                return False
+            await global_db.add_coins(user.id, guild_id, -self.entry_fee)
+            self.paid_players.add(user.id)
+        self.players.append(user)
+        self.scores[user] = 0
+        self.add_player_to_db(user)
+        return True
 
     @commands.command(name="rpsstart", aliases=["rpsbegin"])
     @commands.has_permissions(administrator=True)
@@ -468,11 +489,12 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):
         if str(reaction.emoji) != self.registration_emoji:
             return
 
-        if user not in self.players:
-            self.players.append(user)
-            self.scores[user] = 0
-            self.add_player_to_db(user)
-            await reaction.message.channel.send(f"{user.display_name} has registered for the tournament.")
+        guild_id = reaction.message.guild.id if reaction.message.guild else 0
+        ok = await self.try_register_player(user, guild_id)
+        if ok:
+            await reaction.message.channel.send(
+                f"{user.display_name} has registered for the tournament."
+            )
 
     @commands.Cog.listener()
     async def on_message(self, message):
@@ -717,16 +739,17 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):
         """Checks if the tournament is over or starts a new round."""
         if len(self.current_round) == 1:
             winner = self.current_round[0]
-            # Try to send the message to the system channel
-            if guild.system_channel:
-                await guild.system_channel.send(
-                    f"🏆 **{winner.display_name}** has won the Rock-Paper-Scissors Tournament! 🏆"
-                )
-            else:
-                # Fallback to the channel where the last match was played
-                await last_channel.send(
-                    f"🏆 **{winner.display_name}** has won the Rock-Paper-Scissors Tournament! 🏆"
-                )
+            pot = self.entry_fee * len(self.paid_players)
+            msg_lines = [f"🏆 **{winner.display_name}** has won the RPS Tournament! 🏆"]
+            if pot:
+                new_bal = await global_db.add_coins(winner.id, guild.id, pot)
+                msg_lines.append(f"💰 Payout: **{pot}** 🪙 (Balance: {new_bal} 🪙)")
+            elif self.entry_fee == 0:
+                reward = 100
+                new_bal = await global_db.add_coins(winner.id, guild.id, reward)
+                msg_lines.append(f"🎁 Free tournament reward: **{reward}** 🪙")
+            announce = guild.system_channel or last_channel
+            await announce.send("\n".join(msg_lines))
             self.tournament_active = False
             self.players.clear()
             self.scores.clear()
@@ -824,11 +847,38 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):
     # ------------------------------------------------------------------
 
     @commands.command(name="rps")
-    async def quickrps(self, ctx: commands.Context, bet: int = 0):
-        """Quick Rock-Paper-Scissors vs the bot.  !rps [bet]  (0 = free, win = +30 🪙)"""
+    async def quickrps(self, ctx: commands.Context,
+                       target: discord.Member | None = None, bet: int = 0):
+        """Quick RPS.  !rps [bet]  or  !rps @player [bet]"""
         if bet < 0:
             await ctx.send("Bet must be 0 or a positive number.", delete_after=5)
             return
+
+        # PvP challenge
+        if target and target != ctx.author:
+            if target.bot:
+                await ctx.send("You can't challenge a bot to PvP.", delete_after=5)
+                return
+            if bet > 0:
+                bal = await global_db.get_coins(ctx.author.id, ctx.guild.id)
+                if bet > bal:
+                    await ctx.send(f"❌ You only have **{bal}** 🪙.", delete_after=8)
+                    return
+            bet_str = f"**{bet}** 🪙" if bet else "free play"
+            view    = _RpsPvpChallengeView(ctx.author, target, ctx.guild.id, bet)
+            embed   = discord.Embed(
+                title="✂️ RPS Challenge!",
+                description=(
+                    f"{ctx.author.mention} challenges {target.mention} to Rock-Paper-Scissors "
+                    f"({bet_str}).\n{target.mention}, do you accept?"
+                ),
+                color=discord.Color.blurple(),
+            )
+            msg = await ctx.send(embed=embed, view=view)
+            view.message = msg
+            return
+
+        # vs bot
         if bet > 0:
             bal = await global_db.get_coins(ctx.author.id, ctx.guild.id)
             if bet > bal:
@@ -921,6 +971,223 @@ class _RpsView(discord.ui.View):
             await self.message.edit(content="Game timed out.", view=self)
         except Exception:
             pass
+
+
+# ---------------------------------------------------------------------------
+# RPS Registration View (button-based join)
+# ---------------------------------------------------------------------------
+
+class _RpsRegistrationView(discord.ui.View):
+    def __init__(self, cog: RPSTournamentCog):
+        super().__init__(timeout=None)   # lives until tournament starts
+        self.cog = cog
+
+    @discord.ui.button(label="Join Tournament", style=discord.ButtonStyle.green, emoji="✅")
+    async def join_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        cog = self.cog
+        if not cog.registration_active:
+            await interaction.response.send_message(
+                "Registration is no longer open.", ephemeral=True)
+            return
+        guild_id = interaction.guild_id or 0
+        ok = await cog.try_register_player(interaction.user, guild_id)
+        if ok:
+            await interaction.response.send_message(
+                f"✅ Registered! ({len(cog.players)} player(s) so far)", ephemeral=True)
+        else:
+            bal = await global_db.get_coins(interaction.user.id, guild_id)
+            if cog.entry_fee > 0 and bal < cog.entry_fee:
+                await interaction.response.send_message(
+                    f"❌ Need **{cog.entry_fee}** 🪙 to enter (you have {bal}).",
+                    ephemeral=True)
+            else:
+                await interaction.response.send_message(
+                    "You're already registered!", ephemeral=True)
+
+
+# ---------------------------------------------------------------------------
+# RPS PvP Challenge
+# ---------------------------------------------------------------------------
+
+_rps_pvp_pending: dict[frozenset, dict] = {}   # {p1,p2} → {choices, guild_id, bet, channel_id}
+
+
+class _RpsPvpChallengeView(discord.ui.View):
+    def __init__(self, challenger: discord.Member, opponent: discord.Member,
+                 guild_id: int, bet: int):
+        super().__init__(timeout=60)
+        self.challenger = challenger
+        self.opponent   = opponent
+        self.guild_id   = guild_id
+        self.bet        = bet
+        self.message: discord.Message | None = None
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.opponent.id:
+            await interaction.response.send_message(
+                "This challenge isn't for you.", ephemeral=True)
+            return False
+        return True
+
+    @discord.ui.button(label="Accept", style=discord.ButtonStyle.green, emoji="✅")
+    async def accept(self, interaction: discord.Interaction, _: discord.ui.Button):
+        for item in self.children:
+            item.disabled = True
+        await interaction.response.edit_message(
+            content="✅ Challenge accepted — both players, choose your move!",
+            view=self,
+        )
+        key = frozenset({self.challenger.id, self.opponent.id})
+        _rps_pvp_pending[key] = {
+            "choices":    {},
+            "guild_id":   self.guild_id,
+            "bet":        self.bet,
+            "channel_id": interaction.channel_id,
+        }
+        # Send ephemeral choose-views to both players
+        ch = interaction.channel
+        play_view = _RpsPvpPlayView(
+            self.challenger, self.opponent, self.guild_id, self.bet, ch
+        )
+        await ch.send(
+            f"{self.challenger.mention} {self.opponent.mention} — click below to pick your move (only you can see your choice):",
+            view=play_view,
+        )
+        self.stop()
+
+    @discord.ui.button(label="Decline", style=discord.ButtonStyle.red, emoji="❌")
+    async def decline(self, interaction: discord.Interaction, _: discord.ui.Button):
+        for item in self.children:
+            item.disabled = True
+        await interaction.response.edit_message(
+            content=f"❌ {self.opponent.display_name} declined the challenge.", view=self)
+        self.stop()
+
+    async def on_timeout(self):
+        for item in self.children:
+            item.disabled = True
+        try:
+            await self.message.edit(content="⏰ Challenge timed out.", view=self)
+        except Exception:
+            pass
+
+
+class _RpsPvpPlayView(discord.ui.View):
+    """Visible to the channel; each player clicks to get their ephemeral move picker."""
+
+    def __init__(self, p1: discord.Member, p2: discord.Member,
+                 guild_id: int, bet: int, channel: discord.TextChannel):
+        super().__init__(timeout=60)
+        self.p1       = p1
+        self.p2       = p2
+        self.guild_id = guild_id
+        self.bet      = bet
+        self.channel  = channel
+        self.choices: dict[int, str] = {}
+        self.message: discord.Message | None = None
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id not in (self.p1.id, self.p2.id):
+            await interaction.response.send_message(
+                "You're not part of this match.", ephemeral=True)
+            return False
+        return True
+
+    @discord.ui.button(label="Pick your move", style=discord.ButtonStyle.blurple, emoji="✂️")
+    async def pick(self, interaction: discord.Interaction, _: discord.ui.Button):
+        if interaction.user.id in self.choices:
+            await interaction.response.send_message(
+                "You already picked!", ephemeral=True)
+            return
+        picker_view = _RpsMovePickerView(interaction.user.id, self)
+        await interaction.response.send_message(
+            "Choose your move — only you can see this:", view=picker_view, ephemeral=True)
+
+    async def record_choice(self, user_id: int, move: str):
+        self.choices[user_id] = move
+        if len(self.choices) == 2:
+            await self._resolve()
+
+    async def _resolve(self):
+        for item in self.children:
+            item.disabled = True
+        try:
+            await self.message.edit(view=self)
+        except Exception:
+            pass
+        self.stop()
+
+        m1 = self.choices.get(self.p1.id, "forfeit")
+        m2 = self.choices.get(self.p2.id, "forfeit")
+
+        def _wins(a, b):
+            return {"rock": "scissors", "scissors": "paper", "paper": "rock"}.get(a) == b
+
+        e = {"rock": "🪨", "paper": "📄", "scissors": "✂️", "forfeit": "❌"}
+
+        if m1 == "forfeit" and m2 == "forfeit":
+            result, coin_delta, winner_id = "🤝 Both forfeited.", 0, None
+        elif m1 == "forfeit":
+            result, coin_delta, winner_id = f"{self.p2.mention} wins (opponent forfeited)!", self.bet, self.p2.id
+        elif m2 == "forfeit":
+            result, coin_delta, winner_id = f"{self.p1.mention} wins (opponent forfeited)!", self.bet, self.p1.id
+        elif m1 == m2:
+            result, coin_delta, winner_id = "🤝 Tie! No coins exchanged.", 0, None
+        elif _wins(m1, m2):
+            result, coin_delta, winner_id = f"🎉 {self.p1.mention} wins!", self.bet, self.p1.id
+        else:
+            result, coin_delta, winner_id = f"🎉 {self.p2.mention} wins!", self.bet, self.p2.id
+
+        if coin_delta and winner_id:
+            loser_id = self.p2.id if winner_id == self.p1.id else self.p1.id
+            payout   = coin_delta if coin_delta else _FREE_WIN
+            await global_db.add_coins(winner_id, self.guild_id,  payout)
+            await global_db.add_coins(loser_id,  self.guild_id, -payout)
+
+        embed = discord.Embed(
+            title="✂️ RPS PvP Result",
+            description=(
+                f"{self.p1.mention}: **{m1}** {e.get(m1, '')}\n"
+                f"{self.p2.mention}: **{m2}** {e.get(m2, '')}\n\n"
+                f"{result}"
+            ),
+            color=discord.Color.green() if winner_id else discord.Color.blurple(),
+        )
+        await self.channel.send(embed=embed)
+
+    async def on_timeout(self):
+        # Anyone who didn't choose forfeits
+        for pid in (self.p1.id, self.p2.id):
+            if pid not in self.choices:
+                self.choices[pid] = "forfeit"
+        if len(self.choices) == 2:
+            await self._resolve()
+
+
+class _RpsMovePickerView(discord.ui.View):
+    """Ephemeral view for picking a move in PvP."""
+
+    def __init__(self, user_id: int, parent: _RpsPvpPlayView):
+        super().__init__(timeout=55)
+        self.user_id = user_id
+        self.parent  = parent
+
+    @discord.ui.button(label="Rock",     emoji="🪨", style=discord.ButtonStyle.grey)
+    async def rock(self, i: discord.Interaction, _): await self._pick(i, "rock")
+
+    @discord.ui.button(label="Paper",    emoji="📄", style=discord.ButtonStyle.grey)
+    async def paper(self, i: discord.Interaction, _): await self._pick(i, "paper")
+
+    @discord.ui.button(label="Scissors", emoji="✂️", style=discord.ButtonStyle.grey)
+    async def scissors(self, i: discord.Interaction, _): await self._pick(i, "scissors")
+
+    async def _pick(self, interaction: discord.Interaction, move: str):
+        for item in self.children:
+            item.disabled = True
+        await interaction.response.edit_message(
+            content=f"You chose **{move}** — waiting for opponent…", view=self)
+        self.stop()
+        await self.parent.record_choice(self.user_id, move)
 
 
 async def setup(bot):

--- a/disbot/cogs/rps_tournament_cog.py
+++ b/disbot/cogs/rps_tournament_cog.py
@@ -1,16 +1,21 @@
-# rps_cog.py
-
+from __future__ import annotations
 import discord
 from discord.ext import commands, tasks
 import asyncio
 import random
 import logging
+import os
 import sqlite3
 from datetime import datetime, timedelta
+from utils import db as global_db
 
-# Configure logging
-logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("bot")
+
+_RPS_DB = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "data", "rps_tournament.db"
+)
+_FREE_WIN = 30  # coins for free-play win
 
 class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):
     """Cog for managing Rock-Paper-Scissors tournaments with multiple game modes."""
@@ -46,10 +51,11 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):
             "default_mode": "classic",
             "default_best_of": 3
         }
-        self.db_connection = sqlite3.connect('rps_tournament.db')
+        os.makedirs(os.path.dirname(_RPS_DB), exist_ok=True)
+        self.db_connection = sqlite3.connect(_RPS_DB)
         self.db_cursor = self.db_connection.cursor()
         self.create_tables()
-        self.clean_up_task = self.bot.loop.create_task(self.clean_up_expired_matches())
+        self.clean_up_task = None  # started in cog_load after bot is ready
 
     def create_tables(self):
         """Creates necessary tables in the database."""
@@ -91,7 +97,7 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):
             "grass": ["grass", "leaf", "🌿", "🍃"]
         }
 
-    @commands.command(name="rps_register", aliases=["rpsreg"])
+    @commands.command(name="rpsregister", aliases=["rpsreg"])
     @commands.has_permissions(administrator=True)
     async def rps_register(self, ctx, role: discord.Role = None):
         """Starts the registration period with a reaction role message."""
@@ -161,7 +167,7 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):
             registration_message = await ctx.fetch_message(self.registration_message.id)
             reaction = discord.utils.get(registration_message.reactions, emoji=self.registration_emoji)
             if reaction:
-                users = await reaction.users().flatten()
+                users = [u async for u in reaction.users()]
                 for user in users:
                     if user.bot:
                         continue
@@ -187,7 +193,7 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):
         except Exception as e:
             logger.exception(f"Error adding player to database: {e}")
 
-    @commands.command(name="rps_start", aliases=["rpsbegin"])
+    @commands.command(name="rpsstart", aliases=["rpsbegin"])
     @commands.has_permissions(administrator=True)
     async def rps_start(self, ctx, mode=None, best_of: int = None):
         """Starts the RPS tournament. Usage: !rps_start [mode] [best_of]"""
@@ -222,7 +228,7 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):
         await ctx.send(f"Tournament started with game mode: {self.game_mode}, Best of {best_of}")
         await self.start_round(ctx, best_of)
 
-    @commands.command(name="rps_bot")
+    @commands.command(name="rpsbot")
     async def rps_bot(self, ctx, mode=None, best_of: int = None, *members_or_roles):
         """Starts matches against the bot."""
         if mode is None:
@@ -302,7 +308,7 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):
             await ctx.send(f"An error occurred while creating the match channel: {e}")
             return None
 
-    @commands.command(name="rps_matchup")
+    @commands.command(name="rpsmatchup")
     @commands.has_permissions(administrator=True)
     async def rps_matchup(self, ctx, player1: discord.Member, player2: discord.Member):
         """Manually creates a match between two specific members."""
@@ -427,7 +433,7 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):
             await ctx.send(f"An error occurred while creating the match channel: {e}")
             return None
 
-    @commands.command(name="rps_leaderboard", aliases=["rpslb"])
+    @commands.command(name="rpslb", aliases=["rpslb"])
     async def rps_leaderboard(self, ctx):
         """Displays the current leaderboard."""
         try:
@@ -764,7 +770,7 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):
             await ctx.send(f"An error occurred: {str(error)}")
         logger.exception(f"Error in rps_start command: {error}")
 
-    @commands.command(name="rps_help")
+    @commands.command(name="rpshelp")
     async def rps_help(self, ctx):
         """Displays help information for RPS tournament commands."""
         help_text = (
@@ -780,7 +786,7 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):
         )
         await ctx.send(help_text)
 
-    @commands.command(name="rps_settings")
+    @commands.command(name="rpssettings")
     @commands.has_permissions(administrator=True)
     async def rps_settings(self, ctx, setting: str, value):
         """Updates bot settings."""
@@ -802,17 +808,121 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):
         self.settings[setting] = value
         await ctx.send(f"Setting `{setting}` updated to `{value}`.")
 
+    async def cog_load(self):
+        self.clean_up_task = asyncio.ensure_future(self.clean_up_expired_matches())
+
     def cog_unload(self):
         """Cleanup when the cog is unloaded."""
-        if self.clean_up_task:
+        if self.clean_up_task and not self.clean_up_task.done():
             self.clean_up_task.cancel()
         if self.reminder_task and not self.reminder_task.done():
             self.reminder_task.cancel()
         self.db_connection.close()
 
-# Update the setup function according to your discord.py version
+    # ------------------------------------------------------------------
+    # Quick-play RPS with coins (button-based, single-player vs bot)
+    # ------------------------------------------------------------------
 
-# For discord.py version 2.x
+    @commands.command(name="rps")
+    async def quickrps(self, ctx: commands.Context, bet: int = 0):
+        """Quick Rock-Paper-Scissors vs the bot.  !rps [bet]  (0 = free, win = +30 🪙)"""
+        if bet < 0:
+            await ctx.send("Bet must be 0 or a positive number.", delete_after=5)
+            return
+        if bet > 0:
+            bal = await global_db.get_coins(ctx.author.id, ctx.guild.id)
+            if bet > bal:
+                await ctx.send(f"❌ You only have **{bal}** 🪙.", delete_after=10)
+                return
+        view = _RpsView(ctx.author, ctx.guild.id, bet)
+        bet_str = f"**{bet}** 🪙" if bet else f"Free play (win = +{_FREE_WIN} 🪙)"
+        embed = discord.Embed(
+            title="✂️ Rock · Paper · Scissors",
+            description=f"Bet: {bet_str}\nChoose your move!",
+            color=discord.Color.blurple(),
+        )
+        msg = await ctx.send(embed=embed, view=view)
+        view.message = msg
+
+
+# ---------------------------------------------------------------------------
+# Quick-play RPS View
+# ---------------------------------------------------------------------------
+
+_RPS_WINS = {"rock": "scissors", "scissors": "paper", "paper": "rock"}
+_RPS_EMOJI = {"rock": "🪨", "paper": "📄", "scissors": "✂️"}
+
+
+class _RpsView(discord.ui.View):
+    def __init__(self, user: discord.Member, guild_id: int, bet: int):
+        super().__init__(timeout=60)
+        self.user = user
+        self.guild_id = guild_id
+        self.bet = bet
+        self.message: discord.Message | None = None
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.user.id:
+            await interaction.response.send_message("This game isn't yours.", ephemeral=True)
+            return False
+        return True
+
+    async def _play(self, interaction: discord.Interaction, player_move: str):
+        for item in self.children:
+            item.disabled = True
+
+        bot_move = random.choice(["rock", "paper", "scissors"])
+        pe, be = _RPS_EMOJI[player_move], _RPS_EMOJI[bot_move]
+
+        if player_move == bot_move:
+            result = "🤝 Tie!"
+            coin_delta = 0
+            color = discord.Color.blurple()
+        elif _RPS_WINS[player_move] == bot_move:
+            payout = self.bet if self.bet else _FREE_WIN
+            result = f"🎉 You win! +{payout} 🪙"
+            coin_delta = payout
+            color = discord.Color.green()
+        else:
+            loss = -self.bet if self.bet else 0
+            result = f"😞 Bot wins. {loss} 🪙" if self.bet else "😞 Bot wins."
+            coin_delta = loss
+            color = discord.Color.red()
+
+        new_bal = await global_db.add_coins(self.user.id, self.guild_id, coin_delta)
+        embed = discord.Embed(
+            title="✂️ Rock · Paper · Scissors",
+            description=(
+                f"You: **{player_move}** {pe}  vs  Bot: **{bot_move}** {be}\n\n"
+                f"{result}\n"
+                f"Balance: **{new_bal}** 🪙"
+            ),
+            color=color,
+        )
+        await interaction.response.edit_message(embed=embed, view=self)
+        self.stop()
+
+    @discord.ui.button(label="Rock",     emoji="🪨", style=discord.ButtonStyle.grey)
+    async def rock(self, i: discord.Interaction, _: discord.ui.Button):
+        await self._play(i, "rock")
+
+    @discord.ui.button(label="Paper",    emoji="📄", style=discord.ButtonStyle.grey)
+    async def paper(self, i: discord.Interaction, _: discord.ui.Button):
+        await self._play(i, "paper")
+
+    @discord.ui.button(label="Scissors", emoji="✂️", style=discord.ButtonStyle.grey)
+    async def scissors(self, i: discord.Interaction, _: discord.ui.Button):
+        await self._play(i, "scissors")
+
+    async def on_timeout(self):
+        for item in self.children:
+            item.disabled = True
+        try:
+            await self.message.edit(content="Game timed out.", view=self)
+        except Exception:
+            pass
+
+
 async def setup(bot):
     await bot.add_cog(RPSTournamentCog(bot))
 

--- a/disbot/cogs/xp_cog.py
+++ b/disbot/cogs/xp_cog.py
@@ -12,6 +12,9 @@ _XP_MIN = 15
 _XP_MAX = 25
 _COOLDOWN = 60  # seconds
 
+# Stat types recognised by !rank and !leaderboard.  Add future stats here.
+_STAT_TYPES: set[str] = {"xp", "coins", "both"}
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -78,52 +81,93 @@ class XpCog(commands.Cog):
     # ------------------------------------------------------------------ commands
 
     @commands.command(name="rank")
-    async def rank(self, ctx: commands.Context, member: discord.Member = None):
-        """Show your (or another user's) XP rank."""
-        member = member or ctx.author
+    async def rank(self, ctx: commands.Context, *args):
+        """Show XP/coin rank.  !rank [user] [xp|coins]"""
+        # Parse optional member and optional stat type from positional args
+        member: discord.Member = ctx.author
+        stat: str = "both"
+        for arg in args:
+            if arg.lower() in _STAT_TYPES:
+                stat = arg.lower()
+            else:
+                try:
+                    member = await commands.MemberConverter().convert(ctx, arg)
+                except commands.BadArgument:
+                    pass
+
         row = await db.get_xp(member.id, ctx.guild.id)
         level, current, needed = db.level_progress(row["xp"])
 
-        all_rows = await db.fetchall(
+        all_xp = await db.fetchall(
             "SELECT user_id FROM xp WHERE guild_id=? ORDER BY xp DESC", (ctx.guild.id,)
         )
-        rank_pos = next(
-            (i + 1 for i, r in enumerate(all_rows) if r["user_id"] == member.id), "?"
+        all_coins = await db.fetchall(
+            "SELECT user_id FROM xp WHERE guild_id=? ORDER BY coins DESC", (ctx.guild.id,)
         )
+        xp_rank = next((i + 1 for i, r in enumerate(all_xp)    if r["user_id"] == member.id), "?")
+        co_rank = next((i + 1 for i, r in enumerate(all_coins)  if r["user_id"] == member.id), "?")
 
-        bar = _progress_bar(current, needed)
         embed = discord.Embed(title=f"📊 {member.display_name}", color=discord.Color.blue())
         embed.set_thumbnail(url=member.display_avatar.url)
-        embed.add_field(name="Rank",     value=f"#{rank_pos}",  inline=True)
-        embed.add_field(name="Level",    value=str(level),      inline=True)
-        embed.add_field(name="Total XP", value=str(row["xp"]),  inline=True)
-        embed.add_field(
-            name="Progress",
-            value=f"`{bar}` {current}/{needed} XP",
-            inline=False,
-        )
-        embed.add_field(name="Messages", value=str(row["messages"]), inline=True)
+
+        if stat in ("both", "xp"):
+            bar = _progress_bar(current, needed)
+            embed.add_field(name="XP Rank",  value=f"#{xp_rank}",    inline=True)
+            embed.add_field(name="Level",    value=str(level),        inline=True)
+            embed.add_field(name="Total XP", value=str(row["xp"]),   inline=True)
+            embed.add_field(
+                name="Progress",
+                value=f"`{bar}` {current}/{needed} XP",
+                inline=False,
+            )
+            embed.add_field(name="Messages", value=str(row["messages"]), inline=True)
+
+        if stat in ("both", "coins"):
+            embed.add_field(name="Coin Rank", value=f"#{co_rank}",         inline=True)
+            embed.add_field(name="🪙 Coins",  value=str(row.get("coins", 0)), inline=True)
+
         await ctx.send(embed=embed)
 
     @commands.command(name="leaderboard", aliases=["lb"])
-    async def leaderboard(self, ctx: commands.Context):
-        """Show the top 10 users by XP."""
-        rows = await db.fetchall(
-            "SELECT user_id, xp, level FROM xp WHERE guild_id=? ORDER BY xp DESC LIMIT 10",
-            (ctx.guild.id,),
-        )
-        embed = discord.Embed(title="🏆 XP Leaderboard", color=discord.Color.gold())
-        if not rows:
-            embed.description = "No XP data yet — start chatting!"
-        else:
+    async def leaderboard(self, ctx: commands.Context, stat: str = "xp"):
+        """Show the top 10.  !leaderboard [xp|coins]"""
+        stat = stat.lower()
+        if stat not in _STAT_TYPES:
+            await ctx.send(
+                f"Unknown stat `{stat}`. Choose from: {', '.join(_STAT_TYPES)}.",
+                delete_after=8,
+            )
+            return
+
+        if stat == "xp":
+            rows = await db.fetchall(
+                "SELECT user_id, xp, level FROM xp WHERE guild_id=? ORDER BY xp DESC LIMIT 10",
+                (ctx.guild.id,),
+            )
+            title = "🏆 XP Leaderboard"
             medals = ["🥇", "🥈", "🥉"]
             lines = []
             for i, row in enumerate(rows):
-                member = ctx.guild.get_member(row["user_id"])
-                name = member.display_name if member else f"<@{row['user_id']}>"
+                m = ctx.guild.get_member(row["user_id"])
+                name = m.display_name if m else f"<@{row['user_id']}>"
                 icon = medals[i] if i < 3 else f"`#{i+1}`"
                 lines.append(f"{icon} **{name}** — Level {row['level']} ({row['xp']} XP)")
-            embed.description = "\n".join(lines)
+        else:  # coins
+            rows = await db.fetchall(
+                "SELECT user_id, coins FROM xp WHERE guild_id=? ORDER BY coins DESC LIMIT 10",
+                (ctx.guild.id,),
+            )
+            title = "🪙 Coin Leaderboard"
+            medals = ["🥇", "🥈", "🥉"]
+            lines = []
+            for i, row in enumerate(rows):
+                m = ctx.guild.get_member(row["user_id"])
+                name = m.display_name if m else f"<@{row['user_id']}>"
+                icon = medals[i] if i < 3 else f"`#{i+1}`"
+                lines.append(f"{icon} **{name}** — {row['coins']} 🪙")
+
+        embed = discord.Embed(title=title, color=discord.Color.gold())
+        embed.description = "\n".join(lines) if lines else "No data yet!"
         await ctx.send(embed=embed)
 
     @commands.command(name="givexp")

--- a/disbot/cogs/xp_cog.py
+++ b/disbot/cogs/xp_cog.py
@@ -8,6 +8,18 @@ from utils import db
 
 logger = logging.getLogger("bot")
 
+
+async def _post_log(bot: commands.Bot, guild_id: int, embed: discord.Embed) -> None:
+    cid = await db.get_setting(guild_id, "economy_log_channel", "")
+    if not cid:
+        return
+    ch = bot.get_channel(int(cid))
+    if ch:
+        try:
+            await ch.send(embed=embed)
+        except Exception:
+            pass
+
 _XP_MIN = 15
 _XP_MAX = 25
 _COOLDOWN = 60  # seconds
@@ -63,10 +75,10 @@ class XpCog(commands.Cog):
 
         if leveled_up:
             channel_id = await db.get_setting(guild_id, "xp_announce_channel", "")
-            channel: discord.TextChannel | None = None
+            announce_ch: discord.TextChannel | None = None
             if channel_id:
-                channel = message.guild.get_channel(int(channel_id))
-            channel = channel or message.channel
+                announce_ch = message.guild.get_channel(int(channel_id))
+            announce_ch = announce_ch or message.channel
 
             embed = discord.Embed(
                 title="🎉 Level Up!",
@@ -74,9 +86,19 @@ class XpCog(commands.Cog):
                 color=discord.Color.gold(),
             )
             try:
-                await channel.send(embed=embed)
+                await announce_ch.send(embed=embed)
             except discord.Forbidden:
                 pass
+
+            log_embed = discord.Embed(
+                title="🏆 Level Up",
+                description=(
+                    f"{message.author.mention} reached **Level {new_level}**! "
+                    f"(Total XP: {new_xp})"
+                ),
+                color=discord.Color.gold(),
+            )
+            await _post_log(self.bot, guild_id, log_embed)
 
     # ------------------------------------------------------------------ commands
 

--- a/disbot/cogs/xp_cog.py
+++ b/disbot/cogs/xp_cog.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+import time
+import random
+import discord
+from discord.ext import commands
+import logging
+from utils import db
+
+logger = logging.getLogger("bot")
+
+_XP_MIN = 15
+_XP_MAX = 25
+_COOLDOWN = 60  # seconds
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _guild_xp_settings(guild_id: int) -> tuple[int, int, int]:
+    """Return (xp_min, xp_max, cooldown_seconds) for this guild."""
+    mn = int(await db.get_setting(guild_id, "xp_min", str(_XP_MIN)))
+    mx = int(await db.get_setting(guild_id, "xp_max", str(_XP_MAX)))
+    cd = int(await db.get_setting(guild_id, "xp_cooldown", str(_COOLDOWN)))
+    return mn, mx, cd
+
+
+def _progress_bar(current: int, needed: int, width: int = 10) -> str:
+    filled = int((current / needed) * width) if needed else width
+    return "█" * filled + "░" * (width - filled)
+
+
+# ---------------------------------------------------------------------------
+# Cog
+# ---------------------------------------------------------------------------
+
+class XpCog(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    # ------------------------------------------------------------------ events
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message):
+        if message.author.bot or not message.guild:
+            return
+
+        user_id = message.author.id
+        guild_id = message.guild.id
+        now = int(time.time())
+
+        row = await db.get_xp(user_id, guild_id)
+        xp_min, xp_max, cooldown = await _guild_xp_settings(guild_id)
+
+        if now - row["last_xp"] < cooldown:
+            return
+
+        amount = random.randint(xp_min, xp_max)
+        new_xp, new_level, leveled_up = await db.add_xp(user_id, guild_id, amount, now)
+
+        if leveled_up:
+            channel_id = await db.get_setting(guild_id, "xp_announce_channel", "")
+            channel: discord.TextChannel | None = None
+            if channel_id:
+                channel = message.guild.get_channel(int(channel_id))
+            channel = channel or message.channel
+
+            embed = discord.Embed(
+                title="🎉 Level Up!",
+                description=f"{message.author.mention} reached **Level {new_level}**!",
+                color=discord.Color.gold(),
+            )
+            try:
+                await channel.send(embed=embed)
+            except discord.Forbidden:
+                pass
+
+    # ------------------------------------------------------------------ commands
+
+    @commands.command(name="rank")
+    async def rank(self, ctx: commands.Context, member: discord.Member = None):
+        """Show your (or another user's) XP rank."""
+        member = member or ctx.author
+        row = await db.get_xp(member.id, ctx.guild.id)
+        level, current, needed = db.level_progress(row["xp"])
+
+        all_rows = await db.fetchall(
+            "SELECT user_id FROM xp WHERE guild_id=? ORDER BY xp DESC", (ctx.guild.id,)
+        )
+        rank_pos = next(
+            (i + 1 for i, r in enumerate(all_rows) if r["user_id"] == member.id), "?"
+        )
+
+        bar = _progress_bar(current, needed)
+        embed = discord.Embed(title=f"📊 {member.display_name}", color=discord.Color.blue())
+        embed.set_thumbnail(url=member.display_avatar.url)
+        embed.add_field(name="Rank",     value=f"#{rank_pos}",  inline=True)
+        embed.add_field(name="Level",    value=str(level),      inline=True)
+        embed.add_field(name="Total XP", value=str(row["xp"]),  inline=True)
+        embed.add_field(
+            name="Progress",
+            value=f"`{bar}` {current}/{needed} XP",
+            inline=False,
+        )
+        embed.add_field(name="Messages", value=str(row["messages"]), inline=True)
+        await ctx.send(embed=embed)
+
+    @commands.command(name="leaderboard", aliases=["lb"])
+    async def leaderboard(self, ctx: commands.Context):
+        """Show the top 10 users by XP."""
+        rows = await db.fetchall(
+            "SELECT user_id, xp, level FROM xp WHERE guild_id=? ORDER BY xp DESC LIMIT 10",
+            (ctx.guild.id,),
+        )
+        embed = discord.Embed(title="🏆 XP Leaderboard", color=discord.Color.gold())
+        if not rows:
+            embed.description = "No XP data yet — start chatting!"
+        else:
+            medals = ["🥇", "🥈", "🥉"]
+            lines = []
+            for i, row in enumerate(rows):
+                member = ctx.guild.get_member(row["user_id"])
+                name = member.display_name if member else f"<@{row['user_id']}>"
+                icon = medals[i] if i < 3 else f"`#{i+1}`"
+                lines.append(f"{icon} **{name}** — Level {row['level']} ({row['xp']} XP)")
+            embed.description = "\n".join(lines)
+        await ctx.send(embed=embed)
+
+    @commands.command(name="givexp")
+    @commands.has_permissions(administrator=True)
+    async def givexp(self, ctx: commands.Context, member: discord.Member, amount: int):
+        """Give XP to a user (admin only)."""
+        if amount <= 0:
+            await ctx.send("Amount must be positive.", delete_after=5)
+            return
+        new_xp, new_level, _ = await db.add_xp(member.id, ctx.guild.id, amount, 0)
+        await ctx.send(
+            f"✅ Gave **{amount}** XP to {member.mention}. "
+            f"They now have **{new_xp}** XP (Level **{new_level}**)."
+        )
+
+    @commands.command(name="resetxp")
+    @commands.has_permissions(administrator=True)
+    async def resetxp(self, ctx: commands.Context, member: discord.Member):
+        """Reset a user's XP to zero (admin only)."""
+        await db.execute(
+            "DELETE FROM xp WHERE user_id=? AND guild_id=?", (member.id, ctx.guild.id)
+        )
+        await ctx.send(f"✅ Reset XP for {member.mention}.")
+
+    @commands.command(name="xpconfig")
+    @commands.has_permissions(administrator=True)
+    async def xpconfig(self, ctx: commands.Context):
+        """Open the XP configuration panel (admin only)."""
+        view = XpConfigView(ctx)
+        msg = await ctx.send(embed=await view.build_embed(), view=view)
+        view.message = msg
+
+
+# ---------------------------------------------------------------------------
+# XP Config UI
+# ---------------------------------------------------------------------------
+
+class XpConfigView(discord.ui.View):
+    def __init__(self, ctx: commands.Context):
+        super().__init__(timeout=300)
+        self.ctx = ctx
+        self.message: discord.Message | None = None
+
+    async def build_embed(self) -> discord.Embed:
+        gid = self.ctx.guild.id
+        xp_min, xp_max, cooldown = await _guild_xp_settings(gid)
+        cid = await db.get_setting(gid, "xp_announce_channel", "")
+        channel_str = f"<#{cid}>" if cid else "Same channel as message"
+
+        embed = discord.Embed(title="⚙️ XP Configuration", color=discord.Color.blurple())
+        embed.add_field(name="XP per message", value=f"{xp_min}–{xp_max}",  inline=True)
+        embed.add_field(name="Cooldown",        value=f"{cooldown}s",        inline=True)
+        embed.add_field(name="Level-up channel", value=channel_str,          inline=True)
+        embed.set_footer(text="Click a button below to change a setting.")
+        return embed
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user != self.ctx.author:
+            await interaction.response.send_message("This panel isn't for you.", ephemeral=True)
+            return False
+        return True
+
+    async def _refresh(self, interaction: discord.Interaction):
+        await interaction.message.edit(embed=await self.build_embed(), view=self)
+
+    @discord.ui.button(label="XP Range", style=discord.ButtonStyle.blurple, row=0)
+    async def btn_xp_range(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await interaction.response.send_modal(_XpRangeModal(self))
+
+    @discord.ui.button(label="Cooldown", style=discord.ButtonStyle.blurple, row=0)
+    async def btn_cooldown(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await interaction.response.send_modal(_XpCooldownModal(self))
+
+    @discord.ui.button(label="Level-up Channel", style=discord.ButtonStyle.blurple, row=0)
+    async def btn_channel(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await interaction.response.send_modal(_XpChannelModal(self))
+
+    async def on_timeout(self):
+        for item in self.children:
+            item.disabled = True
+        try:
+            await self.message.edit(view=self)
+        except Exception:
+            pass
+
+
+class _XpRangeModal(discord.ui.Modal, title="Set XP Range"):
+    xp_min = discord.ui.TextInput(label="Min XP per message", placeholder="15", max_length=4)
+    xp_max = discord.ui.TextInput(label="Max XP per message", placeholder="25", max_length=4)
+
+    def __init__(self, view: XpConfigView):
+        super().__init__()
+        self.view = view
+
+    async def on_submit(self, interaction: discord.Interaction):
+        try:
+            mn, mx = int(self.xp_min.value), int(self.xp_max.value)
+            if mn <= 0 or mx < mn:
+                raise ValueError
+        except ValueError:
+            await interaction.response.send_message(
+                "Invalid values — min and max must be positive integers with min ≤ max.",
+                ephemeral=True,
+            )
+            return
+        gid = self.view.ctx.guild.id
+        await db.set_setting(gid, "xp_min", str(mn))
+        await db.set_setting(gid, "xp_max", str(mx))
+        await interaction.response.defer()
+        await self.view._refresh(interaction)
+
+
+class _XpCooldownModal(discord.ui.Modal, title="Set XP Cooldown"):
+    seconds = discord.ui.TextInput(label="Cooldown in seconds", placeholder="60", max_length=5)
+
+    def __init__(self, view: XpConfigView):
+        super().__init__()
+        self.view = view
+
+    async def on_submit(self, interaction: discord.Interaction):
+        try:
+            val = int(self.seconds.value)
+            if val < 0:
+                raise ValueError
+        except ValueError:
+            await interaction.response.send_message(
+                "Must be a non-negative integer.", ephemeral=True
+            )
+            return
+        await db.set_setting(self.view.ctx.guild.id, "xp_cooldown", str(val))
+        await interaction.response.defer()
+        await self.view._refresh(interaction)
+
+
+class _XpChannelModal(discord.ui.Modal, title="Level-up Announcement Channel"):
+    channel_id = discord.ui.TextInput(
+        label="Channel ID (leave blank = same channel)",
+        required=False,
+        max_length=25,
+    )
+
+    def __init__(self, view: XpConfigView):
+        super().__init__()
+        self.view = view
+
+    async def on_submit(self, interaction: discord.Interaction):
+        val = self.channel_id.value.strip()
+        if val and not val.isdigit():
+            await interaction.response.send_message(
+                "Enter a valid numeric channel ID, or leave blank.", ephemeral=True
+            )
+            return
+        await db.set_setting(self.view.ctx.guild.id, "xp_announce_channel", val)
+        await interaction.response.defer()
+        await self.view._refresh(interaction)
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(XpCog(bot))
+    logger.info("XpCog loaded.")

--- a/disbot/config.py
+++ b/disbot/config.py
@@ -29,6 +29,8 @@ INITIAL_EXTENSIONS = [
     "cogs.role_cog",
     "cogs.moderation_cog",
     "cogs.xp_cog",
+    "cogs.blackjack_cog",
+    "cogs.rps_tournament_cog",
     "cogs.German_cog",
     "cogs.utility_cog",
     "cogs.cleanup_cog",

--- a/disbot/config.py
+++ b/disbot/config.py
@@ -34,6 +34,7 @@ INITIAL_EXTENSIONS = [
     "cogs.German_cog",
     "cogs.utility_cog",
     "cogs.cleanup_cog",
+    "cogs.channel_cog",
 ]
 
 # ==========================

--- a/disbot/config.py
+++ b/disbot/config.py
@@ -35,6 +35,7 @@ INITIAL_EXTENSIONS = [
     "cogs.utility_cog",
     "cogs.cleanup_cog",
     "cogs.channel_cog",
+    "cogs.economy_cog",
 ]
 
 # ==========================

--- a/disbot/config.py
+++ b/disbot/config.py
@@ -28,6 +28,7 @@ INITIAL_EXTENSIONS = [
     "cogs.help_cog",
     "cogs.role_cog",
     "cogs.moderation_cog",
+    "cogs.xp_cog",
     "cogs.German_cog",
     "cogs.utility_cog",
     "cogs.cleanup_cog",

--- a/disbot/utils/channels.py
+++ b/disbot/utils/channels.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+import asyncio
+import discord
+
+
+async def safe_channel_name(guild: discord.Guild, base: str) -> str:
+    """Return `base` with an auto-incremented suffix if that name already exists."""
+    existing = {ch.name for ch in guild.channels}
+    if base not in existing:
+        return base
+    i = 2
+    while f"{base}-{i}" in existing:
+        i += 1
+    return f"{base}-{i}"
+
+
+async def get_or_create_category(
+    guild: discord.Guild,
+    name: str,
+    overwrites: dict | None = None,
+) -> discord.CategoryChannel:
+    """Return an existing category by name, or create one."""
+    cat = discord.utils.get(guild.categories, name=name)
+    if cat:
+        return cat
+    return await guild.create_category(name, overwrites=overwrites or {})
+
+
+async def create_private_channel(
+    guild: discord.Guild,
+    name: str,
+    members: list[discord.Member],
+    category_name: str,
+    *,
+    auto_increment: bool = True,
+) -> discord.TextChannel:
+    """Create a private text channel visible only to `members` and the bot.
+
+    The category is created if it doesn't exist yet.
+    If `auto_increment` is True, a numeric suffix is appended when the
+    channel name is already taken (e.g. match-1 → match-2).
+    """
+    if auto_increment:
+        name = await safe_channel_name(guild, name)
+
+    cat_overwrites = {guild.default_role: discord.PermissionOverwrite(read_messages=False)}
+    cat = await get_or_create_category(guild, category_name, overwrites=cat_overwrites)
+
+    overwrites: dict = {
+        guild.default_role: discord.PermissionOverwrite(read_messages=False),
+        guild.me: discord.PermissionOverwrite(read_messages=True, send_messages=True),
+    }
+    for m in members:
+        overwrites[m] = discord.PermissionOverwrite(read_messages=True, send_messages=True)
+
+    return await guild.create_text_channel(name, overwrites=overwrites, category=cat)
+
+
+async def cleanup_category(category: discord.CategoryChannel, delay: float = 0.0) -> None:
+    """Delete every channel in *category*, then delete the category itself."""
+    if delay:
+        await asyncio.sleep(delay)
+    for ch in list(category.channels):
+        try:
+            await ch.delete()
+        except Exception:
+            pass
+    try:
+        await category.delete()
+    except Exception:
+        pass

--- a/disbot/utils/db.py
+++ b/disbot/utils/db.py
@@ -39,6 +39,29 @@ def get() -> aiosqlite.Connection:
 async def _create_tables() -> None:
     conn = get()
     statements = [
+        """CREATE TABLE IF NOT EXISTS economy (
+            user_id      INTEGER NOT NULL,
+            guild_id     INTEGER NOT NULL,
+            last_daily   INTEGER NOT NULL DEFAULT 0,
+            daily_streak INTEGER NOT NULL DEFAULT 0,
+            daily_count  INTEGER NOT NULL DEFAULT 0,
+            last_worked  INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (user_id, guild_id)
+        )""",
+        """CREATE TABLE IF NOT EXISTS job_progress (
+            user_id      INTEGER NOT NULL,
+            guild_id     INTEGER NOT NULL,
+            job_name     TEXT    NOT NULL,
+            times_worked INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (user_id, guild_id, job_name)
+        )""",
+        """CREATE TABLE IF NOT EXISTS inventory (
+            user_id   INTEGER NOT NULL,
+            guild_id  INTEGER NOT NULL,
+            item_name TEXT    NOT NULL,
+            quantity  INTEGER NOT NULL DEFAULT 1,
+            PRIMARY KEY (user_id, guild_id, item_name)
+        )""",
         """CREATE TABLE IF NOT EXISTS xp (
             user_id  INTEGER NOT NULL,
             guild_id INTEGER NOT NULL,
@@ -281,3 +304,84 @@ async def set_coins(user_id: int, guild_id: int, amount: int) -> None:
            ON CONFLICT(user_id, guild_id) DO UPDATE SET coins=MAX(0, excluded.coins)""",
         (user_id, guild_id, amount),
     )
+
+
+# ---------------------------------------------------------------------------
+# Economy / daily helpers
+# ---------------------------------------------------------------------------
+
+async def get_economy(user_id: int, guild_id: int) -> dict:
+    await execute(
+        "INSERT OR IGNORE INTO economy (user_id, guild_id) VALUES (?,?)",
+        (user_id, guild_id),
+    )
+    row = await fetchone(
+        "SELECT * FROM economy WHERE user_id=? AND guild_id=?", (user_id, guild_id)
+    )
+    return dict(row)
+
+
+async def set_economy(user_id: int, guild_id: int, **kwargs) -> None:
+    allowed = {"last_daily", "daily_streak", "daily_count", "last_worked"}
+    cols = {k: v for k, v in kwargs.items() if k in allowed}
+    if not cols:
+        return
+    sets = ", ".join(f"{k}=?" for k in cols)
+    await execute(
+        f"UPDATE economy SET {sets} WHERE user_id=? AND guild_id=?",
+        (*cols.values(), user_id, guild_id),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Job progress helpers
+# ---------------------------------------------------------------------------
+
+async def get_job_times(user_id: int, guild_id: int, job_name: str) -> int:
+    row = await fetchone(
+        "SELECT times_worked FROM job_progress WHERE user_id=? AND guild_id=? AND job_name=?",
+        (user_id, guild_id, job_name),
+    )
+    return row["times_worked"] if row else 0
+
+
+async def increment_job(user_id: int, guild_id: int, job_name: str) -> int:
+    """Increment times_worked for a job and return the new count."""
+    await execute(
+        """INSERT INTO job_progress (user_id, guild_id, job_name, times_worked)
+           VALUES (?,?,?,1)
+           ON CONFLICT(user_id, guild_id, job_name)
+           DO UPDATE SET times_worked = times_worked + 1""",
+        (user_id, guild_id, job_name),
+    )
+    return await get_job_times(user_id, guild_id, job_name)
+
+
+# ---------------------------------------------------------------------------
+# Inventory helpers
+# ---------------------------------------------------------------------------
+
+async def get_inventory(user_id: int, guild_id: int) -> dict[str, int]:
+    rows = await fetchall(
+        "SELECT item_name, quantity FROM inventory WHERE user_id=? AND guild_id=?",
+        (user_id, guild_id),
+    )
+    return {r["item_name"]: r["quantity"] for r in rows}
+
+
+async def add_item(user_id: int, guild_id: int, item_name: str, quantity: int = 1) -> None:
+    await execute(
+        """INSERT INTO inventory (user_id, guild_id, item_name, quantity)
+           VALUES (?,?,?,?)
+           ON CONFLICT(user_id, guild_id, item_name)
+           DO UPDATE SET quantity = quantity + ?""",
+        (user_id, guild_id, item_name, quantity, quantity),
+    )
+
+
+async def has_item(user_id: int, guild_id: int, item_name: str) -> bool:
+    row = await fetchone(
+        "SELECT quantity FROM inventory WHERE user_id=? AND guild_id=? AND item_name=?",
+        (user_id, guild_id, item_name),
+    )
+    return bool(row and row["quantity"] > 0)

--- a/disbot/utils/db.py
+++ b/disbot/utils/db.py
@@ -46,6 +46,7 @@ async def _create_tables() -> None:
             level    INTEGER NOT NULL DEFAULT 0,
             messages INTEGER NOT NULL DEFAULT 0,
             last_xp  INTEGER NOT NULL DEFAULT 0,
+            coins    INTEGER NOT NULL DEFAULT 0,
             PRIMARY KEY (user_id, guild_id)
         )""",
         """CREATE TABLE IF NOT EXISTS warnings (
@@ -85,6 +86,12 @@ async def _create_tables() -> None:
     for stmt in statements:
         await conn.execute(stmt)
     await conn.commit()
+    # Migration: add coins column to existing xp tables that predate it
+    async with conn.execute("PRAGMA table_info(xp)") as cur:
+        cols = {row[1] async for row in cur}
+    if "coins" not in cols:
+        await conn.execute("ALTER TABLE xp ADD COLUMN coins INTEGER NOT NULL DEFAULT 0")
+        await conn.commit()
 
 
 # ---------------------------------------------------------------------------
@@ -243,4 +250,34 @@ async def log_mod_action(
         "INSERT INTO mod_logs (timestamp, guild_id, action, target_id, moderator_id, reason) "
         "VALUES (?, ?, ?, ?, ?, ?)",
         (ts, guild_id, action, target_id, moderator_id, reason),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Coin helpers
+# ---------------------------------------------------------------------------
+
+async def get_coins(user_id: int, guild_id: int) -> int:
+    row = await fetchone(
+        "SELECT coins FROM xp WHERE user_id=? AND guild_id=?", (user_id, guild_id)
+    )
+    return row["coins"] if row else 0
+
+
+async def add_coins(user_id: int, guild_id: int, amount: int) -> int:
+    """Add (or subtract if negative) coins; clamps to 0. Returns new balance."""
+    await execute(
+        """INSERT INTO xp (user_id, guild_id, coins) VALUES (?, ?, MAX(0, ?))
+           ON CONFLICT(user_id, guild_id) DO UPDATE SET
+               coins=MAX(0, coins + excluded.coins)""",
+        (user_id, guild_id, amount),
+    )
+    return await get_coins(user_id, guild_id)
+
+
+async def set_coins(user_id: int, guild_id: int, amount: int) -> None:
+    await execute(
+        """INSERT INTO xp (user_id, guild_id, coins) VALUES (?, ?, MAX(0, ?))
+           ON CONFLICT(user_id, guild_id) DO UPDATE SET coins=MAX(0, excluded.coins)""",
+        (user_id, guild_id, amount),
     )

--- a/disbot/utils/db.py
+++ b/disbot/utils/db.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+import aiosqlite
+import os
+import logging
+
+logger = logging.getLogger("bot")
+
+DB_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "data", "bot_data.db"
+)
+
+_db: aiosqlite.Connection | None = None
+
+
+async def init() -> None:
+    global _db
+    os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+    _db = await aiosqlite.connect(DB_PATH)
+    _db.row_factory = aiosqlite.Row
+    await _db.execute("PRAGMA journal_mode=WAL")
+    await _create_tables()
+    logger.info("Database initialised at %s", DB_PATH)
+
+
+async def close() -> None:
+    global _db
+    if _db:
+        await _db.close()
+        _db = None
+
+
+def get() -> aiosqlite.Connection:
+    if _db is None:
+        raise RuntimeError("Database not initialised — call db.init() first.")
+    return _db
+
+
+async def _create_tables() -> None:
+    conn = get()
+    statements = [
+        """CREATE TABLE IF NOT EXISTS xp (
+            user_id  INTEGER NOT NULL,
+            guild_id INTEGER NOT NULL,
+            xp       INTEGER NOT NULL DEFAULT 0,
+            level    INTEGER NOT NULL DEFAULT 0,
+            messages INTEGER NOT NULL DEFAULT 0,
+            last_xp  INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (user_id, guild_id)
+        )""",
+        """CREATE TABLE IF NOT EXISTS warnings (
+            user_id  INTEGER NOT NULL,
+            guild_id INTEGER NOT NULL,
+            count    INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (user_id, guild_id)
+        )""",
+        """CREATE TABLE IF NOT EXISTS mod_logs (
+            id           INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp    TEXT    NOT NULL,
+            guild_id     INTEGER NOT NULL,
+            action       TEXT    NOT NULL,
+            target_id    INTEGER NOT NULL,
+            moderator_id INTEGER NOT NULL,
+            reason       TEXT    NOT NULL DEFAULT 'No reason provided'
+        )""",
+        """CREATE TABLE IF NOT EXISTS role_thresholds (
+            guild_id      INTEGER NOT NULL,
+            role_name     TEXT    NOT NULL,
+            days_required INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (guild_id, role_name)
+        )""",
+        """CREATE TABLE IF NOT EXISTS guild_settings (
+            guild_id INTEGER NOT NULL,
+            key      TEXT    NOT NULL,
+            value    TEXT    NOT NULL,
+            PRIMARY KEY (guild_id, key)
+        )""",
+        """CREATE TABLE IF NOT EXISTS logs (
+            id        INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TEXT NOT NULL,
+            level     TEXT NOT NULL,
+            message   TEXT NOT NULL
+        )""",
+    ]
+    for stmt in statements:
+        await conn.execute(stmt)
+    await conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Generic helpers
+# ---------------------------------------------------------------------------
+
+async def fetchone(query: str, params: tuple = ()) -> dict | None:
+    async with get().execute(query, params) as cur:
+        row = await cur.fetchone()
+        return dict(row) if row else None
+
+
+async def fetchall(query: str, params: tuple = ()) -> list[dict]:
+    async with get().execute(query, params) as cur:
+        return [dict(r) for r in await cur.fetchall()]
+
+
+async def execute(query: str, params: tuple = ()) -> None:
+    await get().execute(query, params)
+    await get().commit()
+
+
+# ---------------------------------------------------------------------------
+# XP helpers
+# ---------------------------------------------------------------------------
+
+def xp_for_level(level: int) -> int:
+    """XP required to complete this level (MEE6-style formula)."""
+    return 5 * (level ** 2) + 50 * level + 100
+
+
+def level_progress(total_xp: int) -> tuple[int, int, int]:
+    """Return (level, xp_into_level, xp_needed_for_next_level)."""
+    level = 0
+    remaining = total_xp
+    while True:
+        needed = xp_for_level(level)
+        if remaining < needed:
+            return level, remaining, needed
+        remaining -= needed
+        level += 1
+
+
+async def get_xp(user_id: int, guild_id: int) -> dict:
+    row = await fetchone(
+        "SELECT * FROM xp WHERE user_id=? AND guild_id=?", (user_id, guild_id)
+    )
+    return row or {
+        "user_id": user_id, "guild_id": guild_id,
+        "xp": 0, "level": 0, "messages": 0, "last_xp": 0,
+    }
+
+
+async def add_xp(user_id: int, guild_id: int, amount: int, now: int) -> tuple[int, int, bool]:
+    """Add *amount* XP; return (total_xp, new_level, leveled_up)."""
+    row = await get_xp(user_id, guild_id)
+    new_xp = row["xp"] + amount
+    new_level, _, _ = level_progress(new_xp)
+    leveled_up = new_level > row["level"]
+    await execute(
+        """INSERT INTO xp (user_id, guild_id, xp, level, messages, last_xp)
+           VALUES (?, ?, ?, ?, 1, ?)
+           ON CONFLICT(user_id, guild_id) DO UPDATE SET
+               xp=excluded.xp, level=excluded.level,
+               messages=messages+1, last_xp=excluded.last_xp""",
+        (user_id, guild_id, new_xp, new_level, now),
+    )
+    return new_xp, new_level, leveled_up
+
+
+# ---------------------------------------------------------------------------
+# Guild settings helpers
+# ---------------------------------------------------------------------------
+
+async def get_setting(guild_id: int, key: str, default: str = "") -> str:
+    row = await fetchone(
+        "SELECT value FROM guild_settings WHERE guild_id=? AND key=?", (guild_id, key)
+    )
+    return row["value"] if row else default
+
+
+async def set_setting(guild_id: int, key: str, value: str) -> None:
+    await execute(
+        """INSERT INTO guild_settings (guild_id, key, value) VALUES (?, ?, ?)
+           ON CONFLICT(guild_id, key) DO UPDATE SET value=excluded.value""",
+        (guild_id, key, value),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Role threshold helpers
+# ---------------------------------------------------------------------------
+
+async def get_role_thresholds(guild_id: int) -> list[dict]:
+    return await fetchall(
+        "SELECT role_name, days_required FROM role_thresholds "
+        "WHERE guild_id=? ORDER BY days_required",
+        (guild_id,),
+    )
+
+
+async def set_role_threshold(guild_id: int, role_name: str, days: int) -> None:
+    await execute(
+        """INSERT INTO role_thresholds (guild_id, role_name, days_required)
+           VALUES (?, ?, ?)
+           ON CONFLICT(guild_id, role_name) DO UPDATE SET days_required=excluded.days_required""",
+        (guild_id, role_name, days),
+    )
+
+
+async def remove_role_threshold(guild_id: int, role_name: str) -> None:
+    await execute(
+        "DELETE FROM role_thresholds WHERE guild_id=? AND role_name=?",
+        (guild_id, role_name),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Warning helpers
+# ---------------------------------------------------------------------------
+
+async def get_warnings(user_id: int, guild_id: int) -> int:
+    row = await fetchone(
+        "SELECT count FROM warnings WHERE user_id=? AND guild_id=?", (user_id, guild_id)
+    )
+    return row["count"] if row else 0
+
+
+async def add_warning(user_id: int, guild_id: int) -> int:
+    count = await get_warnings(user_id, guild_id) + 1
+    await execute(
+        """INSERT INTO warnings (user_id, guild_id, count) VALUES (?, ?, ?)
+           ON CONFLICT(user_id, guild_id) DO UPDATE SET count=excluded.count""",
+        (user_id, guild_id, count),
+    )
+    return count
+
+
+async def clear_warnings(user_id: int, guild_id: int) -> None:
+    await execute(
+        "DELETE FROM warnings WHERE user_id=? AND guild_id=?", (user_id, guild_id)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mod log helpers
+# ---------------------------------------------------------------------------
+
+async def log_mod_action(
+    guild_id: int, action: str, target_id: int,
+    moderator_id: int, reason: str = "No reason provided",
+) -> None:
+    from datetime import datetime
+    ts = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+    await execute(
+        "INSERT INTO mod_logs (timestamp, guild_id, action, target_id, moderator_id, reason) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (ts, guild_id, action, target_id, moderator_id, reason),
+    )

--- a/disbot/utils/synonyms.py
+++ b/disbot/utils/synonyms.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+# Maps canonical command name → synonyms that should resolve to it.
+# Only add entries where genuine synonyms exist; skip commands with no
+# natural alternatives.
+COMMAND_SYNONYMS: dict[str, list[str]] = {
+    "help":         ["hilfe", "commands", "cmds", "cmd", "befehle"],
+    "rank":         ["level", "lvl", "xp", "stats", "score", "myscore", "mrank", "myrank", "progres", "progress"],
+    "leaderboard":  ["top", "rankings", "scores", "highscore", "highscores", "scoreboard"],
+    "blackjack":    ["bj", "21", "cards", "cardgame"],
+    "rps":          ["rockpaperscissors", "rock", "schere", "stein", "papier"],
+    "serverstats":  ["serverstat", "serv"],
+    "serverinfo":   ["sinfo"],
+    "userinfo":     ["uinfo", "whois", "user"],
+    "clear":        ["purge", "clean", "delete", "löschen"],
+    "warn":         ["warning", "verwarnen"],
+    "ban":          ["bannieren", "banish", "sperren"],
+    "kick":         ["rauswerfen", "boot", "entfernen"],
+    "timeout":      ["mute", "stumm", "stumschalten"],
+    "unban":        ["entbannen"],
+    "poll":         ["vote", "abstimmung", "umfrage"],
+    "assignroles":  ["updateroles", "roleupdate"],
+    "rolesettings": ["roleconfig", "rolethresholds"],
+    "createrole":   ["newrole", "addrole", "makerole"],
+    "deleterole":   ["removerole", "rmrole"],
+    "givexp":       ["addxp", "grantxp"],
+    "resetxp":      ["clearxp"],
+    "xpconfig":     ["xpsettings"],
+    "coglist":      ["listcogs", "cogslist"],
+    "restart":      ["reboot", "restar"],
+    "loglevel":     ["loglvl", "setloglevel"],
+    "remind":       ["reminder", "remindme", "erinnerung"],
+    "roles":        ["rolelist", "listroles"],
+    "invite":       ["einladen"],
+    "avatar":       ["pfp", "bild"],
+    "cleanuphistory": ["cleanhistory", "bereinigen"],
+    "addword":      ["prohibit", "blockword"],
+    "removeword":   ["unprohibit", "unblockword", "allowword"],
+}
+
+
+def find_command(query: str) -> str | None:
+    """Return the canonical command name if *query* matches a known synonym.
+
+    Returns None if no synonym matches (so the caller can fall through to
+    normal 'command not found' handling).
+    """
+    q = query.lower().strip()
+    # Direct synonym lookup
+    for cmd, aliases in COMMAND_SYNONYMS.items():
+        if q in aliases:
+            return cmd
+    return None

--- a/disbot/utils/tournaments.py
+++ b/disbot/utils/tournaments.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+import asyncio
+import discord
+from utils import db
+
+
+class TournamentRegistration:
+    """Shared registration state used by both BJ and RPS tournament cogs.
+
+    Handles: player tracking, entry-fee gating, pot calculation,
+    fee deduction at launch, and timer task bookkeeping.
+    """
+
+    def __init__(
+        self,
+        host_id: int,
+        guild_id: int,
+        announce_id: int,
+        entry_fee: int,
+        duration_mins: int,
+    ):
+        self.host_id       = host_id
+        self.guild_id      = guild_id
+        self.announce_id   = announce_id
+        self.entry_fee     = entry_fee
+        self.duration_mins = duration_mins
+        self.players:      set[int]              = set()
+        self.started:      bool                  = False
+        self.reg_message:  discord.Message | None = None
+        self.timer_task:   asyncio.Task | None    = None
+
+    @property
+    def pot(self) -> int:
+        return self.entry_fee * len(self.players)
+
+    async def try_join(self, user_id: int) -> tuple[bool, str]:
+        """Validate and register a player.  Returns (success, message)."""
+        if self.started:
+            return False, "The tournament has already started."
+        if user_id in self.players:
+            return False, "You're already registered!"
+        if self.entry_fee > 0:
+            bal = await db.get_coins(user_id, self.guild_id)
+            if bal < self.entry_fee:
+                return False, (
+                    f"❌ Need **{self.entry_fee}** 🪙 to enter (you have {bal})."
+                )
+        self.players.add(user_id)
+        return True, f"✅ Registered! ({len(self.players)} player(s) so far)"
+
+    async def deduct_fees(self) -> set[int]:
+        """Deduct entry fees from all registered players at tournament start.
+
+        Returns the set of player IDs who successfully paid.
+        Players who can no longer afford the fee are removed.
+        """
+        if not self.entry_fee:
+            return set(self.players)
+        paid: set[int] = set()
+        for uid in list(self.players):
+            bal = await db.get_coins(uid, self.guild_id)
+            if bal >= self.entry_fee:
+                await db.add_coins(uid, self.guild_id, -self.entry_fee)
+                paid.add(uid)
+        self.players = paid
+        return paid

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ discord.py>=2.3.0
 python-dotenv>=1.0.0
 psutil>=5.9.0
 word2number>=1.1
+aiosqlite>=0.19.0


### PR DESCRIPTION
## Summary

- **Shared utilities** — `utils/channels.py` (safe name auto-increment, get-or-create category, private channel creation, category cleanup) and `utils/tournaments.py` (TournamentRegistration base class with entry-fee gating and fee deduction)
- **Refactored BJ & RPS cogs** — duplicate channel creation/cleanup replaced with shared utilities; `_BjTournament` now extends `TournamentRegistration`; fixed a syntax error (duplicate for-loop) in RPS `end_registration`; removed self-referential `rpslb` alias that would crash at startup
- **ChannelCog** — new `!channelcreator` / `!ccreate` command with dropdown name picker (8 presets), category picker (existing server categories + 5 new presets), custom-name modal, auto-increment on name conflicts, and get-or-create category; all existing commands also updated to auto-increment names and reuse categories; cog now loaded at startup
- **Economy system** (`cogs/economy_cog.py`, `utils/db.py`):
  - `!daily` — 24 h cooldown, six rarity tiers (Common 500–999 🪙 → Mythic 5000 🪙), odds shift toward higher tiers as daily streak grows (up to 60 days)
  - `!work` — dropdown job selector, 1 h cooldown; 12 jobs across 4 tiers gated by XP level and inventory items; pay increases +1% per same-job work (max +100%); awards XP per job
  - `!shop` — dropdown to buy Car / Toolkit / Suit (required for tier-2–4 jobs)
  - `!inventory` / `!inv` — view owned items
  - `!joblist` / `!jobs` — full list with unlock status and mastery bonus
  - `!setlogchannel` — admin redirect for the log channel
  - `on_guild_join` — auto-creates `#economy-log` (read-only for members, bot can post) on every new guild join, stores ID in guild_settings
- **XP level-up logging** — level-up events now also post to the economy log channel

## Test plan

- [ ] All cogs load without errors (`!coglist`)
- [ ] `!daily` respects 24 h cooldown, streak increments, streak resets after 48 h gap
- [ ] `!work` shows only eligible jobs, pay bonus tracks correctly, 1 h cooldown enforced
- [ ] `!shop` deducts coins, adds item to inventory, rejects if already owned or insufficient funds
- [ ] `!inventory` shows correct items after purchase
- [ ] `!joblist` correctly marks jobs locked/unlocked based on level and inventory
- [ ] BJ tournament creates private channels via `utils/channels`, cleans up on finish
- [ ] RPS tournament match channels created and deleted via `utils/channels`
- [ ] `!channelcreator` creates channel in selected (or new) category, auto-increments name if taken
- [ ] `#economy-log` auto-created on guild join; level-ups, daily, work, shop all post there

https://claude.ai/code/session_018cQYsrB4iy5EoiVy6S9vGt

---
_Generated by [Claude Code](https://claude.ai/code/session_018cQYsrB4iy5EoiVy6S9vGt)_