### PR TITLE
Fix channel UI, economy-log setup, game cleanup on restart, webhook logs

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -132,23 +132,48 @@ async def on_ready():
     bot._webhook_handler = _webhook_handler  # expose to cogs for !loglevel
     logger.info(f"✅ Logged in as {bot.user} (ID: {bot.user.id})")
     logger.info(f"🔗 Connected to {len(bot.guilds)} servers")
+    logger.info(f"📦 Loaded cogs: {', '.join(bot.cogs.keys())}")
     logger.info("🚀 Bot is ready!")
+
+    if not config.WEBHOOK_URL:
+        logger.warning("⚠️ DISCORD_WEBHOOK_URL is not set — webhook logging disabled.")
 
     for command_name, alias_list in aliases.items():
         cmd = bot.get_command(command_name)
         if cmd:
             cmd.aliases = alias_list
-            logger.info(f"🔄 Loaded aliases for {command_name}: {alias_list}")
 
     await _send_startup_message()
 
 @bot.event
 async def on_command(ctx):
-    logger.info(f"CMD | {ctx.author} | #{ctx.channel} | {ctx.message.content[:150]}")
+    logger.info(f"CMD | {ctx.author} ({ctx.author.id}) | #{ctx.channel} | {ctx.guild} | {ctx.message.content[:150]}")
 
 @bot.event
 async def on_command_completion(ctx):
-    logger.info(f"CMD ✅ | {ctx.command.qualified_name} completed for {ctx.author}")
+    logger.info(f"CMD ✅ | {ctx.command.qualified_name} | {ctx.author} | {ctx.guild}")
+
+@bot.event
+async def on_command_error(ctx, error):
+    if ctx.channel.id not in ALLOWED_CHANNELS and (ctx.command is None or ctx.command.name != "force"):
+        return
+    if isinstance(error, commands.MissingPermissions):
+        await ctx.send("❌ You do not have permission to use this command.", delete_after=10)
+    elif isinstance(error, commands.CommandNotFound):
+        raw = ctx.invoked_with or ""
+        suggestion = _find_synonym(raw)
+        if suggestion:
+            await ctx.send(
+                f"❓ Unknown command `{raw}`. Did you mean `{config.PREFIX}{suggestion}`?",
+                delete_after=15,
+            )
+        else:
+            await ctx.send("❌ Command not found. Use `!help` for available commands.", delete_after=10)
+    elif isinstance(error, commands.MissingRequiredArgument):
+        await ctx.send("⚠️ Missing argument. Check `!help` for usage.", delete_after=10)
+    else:
+        logger.error(f"CMD ❌ | {ctx.command} | {ctx.author} | {ctx.guild} | {type(error).__name__}: {error}", exc_info=True)
+        await ctx.send("⚠️ An unexpected error occurred. Please try again later.", delete_after=10)
 
 async def _send_startup_message():
     if not config.WEBHOOK_URL:
@@ -193,32 +218,6 @@ async def force(ctx, command_name: str, *args):
     else:
         await ctx.send("❌ Command not found.", delete_after=10)
 
-# ==========================
-# Event: Command Error Handling
-# ==========================
-@bot.event
-async def on_command_error(ctx, error):
-    if ctx.channel.id not in ALLOWED_CHANNELS and (ctx.command is None or ctx.command.name != "force"):
-        return  # Ignore errors for unauthorized channels unless using force
-
-    if isinstance(error, commands.MissingPermissions):
-        await ctx.send("❌ You do not have permission to use this command.", delete_after=10)
-    elif isinstance(error, commands.CommandNotFound):
-        # Try synonym lookup before giving up
-        raw = ctx.invoked_with or ""
-        suggestion = _find_synonym(raw)
-        if suggestion:
-            await ctx.send(
-                f"❓ Unknown command `{raw}`. Did you mean `{config.PREFIX}{suggestion}`?",
-                delete_after=15,
-            )
-        else:
-            await ctx.send("❌ Command not found. Use `!help` for available commands.", delete_after=10)
-    elif isinstance(error, commands.MissingRequiredArgument):
-        await ctx.send("⚠️ Missing argument. Check `!help` for usage.", delete_after=10)
-    else:
-        logger.error(f"CMD ❌ | {ctx.command} | {ctx.author} | {type(error).__name__}: {error}", exc_info=True)
-        await ctx.send("⚠️ An unexpected error occurred. Please try again later.", delete_after=10)
 
 # ==========================
 # Load Cogs (Extensions)

--- a/disbot/cogs/blackjack_cog.py
+++ b/disbot/cogs/blackjack_cog.py
@@ -626,6 +626,28 @@ class BlackjackCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
 
+    async def cog_load(self):
+        asyncio.ensure_future(self._cleanup_orphaned_tournaments())
+
+    async def _cleanup_orphaned_tournaments(self):
+        """On startup, find leftover BJ Tournament categories and notify players."""
+        await self.bot.wait_until_ready()
+        for guild in self.bot.guilds:
+            cat = discord.utils.get(guild.categories, name="BJ Tournament")
+            if not cat or not cat.channels:
+                continue
+            for ch in cat.channels:
+                try:
+                    await ch.send(
+                        "⚠️ The bot restarted and this tournament was interrupted. "
+                        "This channel will be deleted in 5 minutes. "
+                        "Use `!bjtournament` to start a new one."
+                    )
+                except Exception:
+                    pass
+            await asyncio.sleep(300)
+            await cleanup_category(cat)
+
     # ---- reaction-based tournament registration ----
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):

--- a/disbot/cogs/channel_cog.py
+++ b/disbot/cogs/channel_cog.py
@@ -344,7 +344,7 @@ class _ChannelCreatorView(discord.ui.View):
             return False
         return True
 
-    async def _refresh_embed(self, interaction: discord.Interaction):
+    def _build_embed(self) -> discord.Embed:
         embed = discord.Embed(
             title="📋 Channel Creator",
             description=(
@@ -353,9 +353,17 @@ class _ChannelCreatorView(discord.ui.View):
             ),
             color=discord.Color.blurple(),
         )
-        embed.add_field(name="Selected name",     value=f"`{self.chosen_name}`" if self.chosen_name else "*(none)*", inline=True)
-        embed.add_field(name="Selected category", value=f"`{self.chosen_cat}`"  if self.chosen_cat  else "*(none)*", inline=True)
-        await interaction.message.edit(embed=embed, view=self)
+        embed.add_field(
+            name="Selected name",
+            value=f"`{self.chosen_name}`" if self.chosen_name else "*(none)*",
+            inline=True,
+        )
+        embed.add_field(
+            name="Selected category",
+            value=f"`{self.chosen_cat}`" if self.chosen_cat else "*(none)*",
+            inline=True,
+        )
+        return embed
 
     @discord.ui.button(label="Custom Name", style=discord.ButtonStyle.grey, emoji="✏️", row=2)
     async def custom_name_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
@@ -422,8 +430,8 @@ class _NameSelect(discord.ui.Select):
 
     async def callback(self, interaction: discord.Interaction):
         self._parent.chosen_name = self.values[0]
-        await interaction.response.defer()
-        await self._parent._refresh_embed(interaction)
+        await interaction.response.edit_message(
+            embed=self._parent._build_embed(), view=self._parent)
 
 
 class _CategorySelect(discord.ui.Select):
@@ -438,8 +446,8 @@ class _CategorySelect(discord.ui.Select):
 
     async def callback(self, interaction: discord.Interaction):
         self._parent.chosen_cat = self.values[0]
-        await interaction.response.defer()
-        await self._parent._refresh_embed(interaction)
+        await interaction.response.edit_message(
+            embed=self._parent._build_embed(), view=self._parent)
 
 
 class _CustomNameModal(discord.ui.Modal, title="Custom Channel Name"):
@@ -456,8 +464,11 @@ class _CustomNameModal(discord.ui.Modal, title="Custom Channel Name"):
     async def on_submit(self, interaction: discord.Interaction):
         name = self.channel_name.value.strip().lower().replace(" ", "-")
         self._view.chosen_name = name
+        # Modals can't use edit_message — defer and update the stored message reference
         await interaction.response.defer()
-        await self._view._refresh_embed(interaction)
+        if self._view.message:
+            await self._view.message.edit(
+                embed=self._view._build_embed(), view=self._view)
 
 
 # -------------------

--- a/disbot/cogs/counting_cog.py
+++ b/disbot/cogs/counting_cog.py
@@ -21,7 +21,10 @@ class CountingCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.logger = logger
-        self.data_file = 'count_data.json'
+        self.data_file = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "data", "count_data.json"
+        )
         self.lock = asyncio.Lock()  # To ensure thread-safe operations on count_data
         self.count_data = {}  # Initialize count_data
         self.load_data()

--- a/disbot/cogs/economy_cog.py
+++ b/disbot/cogs/economy_cog.py
@@ -126,16 +126,24 @@ class EconomyCog(commands.Cog):
     # ------------------------------------------------------------------ events
 
     @commands.Cog.listener()
+    async def on_ready(self):
+        """Ensure every guild the bot is in has an economy-log channel."""
+        for guild in self.bot.guilds:
+            await self._ensure_log_channel(guild)
+
+    @commands.Cog.listener()
     async def on_guild_join(self, guild: discord.Guild):
         """Auto-create an economy-log channel when the bot joins a new guild."""
+        await self._ensure_log_channel(guild)
+
+    async def _ensure_log_channel(self, guild: discord.Guild) -> None:
+        """Create #economy-log for *guild* if it doesn't already exist."""
         cid = await db.get_setting(guild.id, "economy_log_channel", "")
         if cid:
             ch = guild.get_channel(int(cid))
             if ch:
-                return  # already set up
-
+                return  # channel still exists, nothing to do
         try:
-            # Prefer existing "Bot" or "General" category; else no category
             cat = (discord.utils.get(guild.categories, name="Bot")
                    or discord.utils.get(guild.categories, name="General"))
             overwrites = {
@@ -163,10 +171,11 @@ class EconomyCog(commands.Cog):
                 color=discord.Color.gold(),
             )
             await ch.send(embed=embed)
+            logger.info("Created economy-log channel in %s", guild.name)
         except discord.Forbidden:
             pass
         except Exception as e:
-            logger.error("on_guild_join economy-log creation failed: %s", e)
+            logger.error("economy-log creation failed in %s: %s", guild.name, e)
 
     # ------------------------------------------------------------------ !daily
 

--- a/disbot/cogs/rps_tournament_cog.py
+++ b/disbot/cogs/rps_tournament_cog.py
@@ -807,6 +807,26 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):
 
     async def cog_load(self):
         self.clean_up_task = asyncio.ensure_future(self.clean_up_expired_matches())
+        asyncio.ensure_future(self._cleanup_orphaned_channels())
+
+    async def _cleanup_orphaned_channels(self):
+        """On startup, clean up any leftover RPS tournament/bot-match channels."""
+        await self.bot.wait_until_ready()
+        for guild in self.bot.guilds:
+            for cat_name in ("RPS Tournaments", "RPS Bot Matches"):
+                cat = discord.utils.get(guild.categories, name=cat_name)
+                if not cat or not cat.channels:
+                    continue
+                for ch in cat.channels:
+                    try:
+                        await ch.send(
+                            "⚠️ The bot restarted and this match was interrupted. "
+                            "This channel will be deleted in 5 minutes."
+                        )
+                    except Exception:
+                        pass
+                await asyncio.sleep(300)
+                await cleanup_category(cat)
 
     def cog_unload(self):
         """Cleanup when the cog is unloaded."""

--- a/disbot/config.py
+++ b/disbot/config.py
@@ -36,6 +36,8 @@ INITIAL_EXTENSIONS = [
     "cogs.cleanup_cog",
     "cogs.channel_cog",
     "cogs.economy_cog",
+    "cogs.counting_cog",
+    "cogs.deathmatch_cog",
 ]
 
 # ==========================


### PR DESCRIPTION
## Summary

- **`!channelcreator` dropdown error fixed** — Select callbacks were calling `interaction.response.defer()` then `interaction.message.edit()`, which is the wrong pattern for component interactions. Select callbacks now use `interaction.response.edit_message()` directly. The custom-name modal (which can't use `edit_message`) uses `defer()` + `view.message.edit()` via the stored message reference. `_refresh_embed` replaced with `_build_embed()` that returns an embed without touching the interaction.

- **`#economy-log` now created on startup for existing guilds** — `on_guild_join` only fires for new guilds. Added `on_ready` listener that calls the extracted `_ensure_log_channel(guild)` helper for every guild the bot is already in. Channel is only created if not already configured.

- **Game state cleanup after restart (BJ + RPS)** — On `cog_load`, both `BlackjackCog` and `RPSTournamentCog` schedule a post-ready task that scans all guilds for orphaned tournament categories (`BJ Tournament`, `RPS Tournaments`, `RPS Bot Matches`). If found, it posts a restart notification in each channel then deletes them after 5 minutes.

- **Counting state now persists across restarts** — `counting_cog` was saving `count_data.json` to the process root directory. Fixed to `data/count_data.json`, consistent with all other data files.

- **Webhook logging improvements** — Logs now include guild name in CMD lines for easier per-guild filtering. Added warning at startup if `DISCORD_WEBHOOK_URL` is not set. Removed duplicate `on_command_error` handler.

- **New cogs registered** — `counting_cog` and `deathmatch_cog` added to `INITIAL_EXTENSIONS` in `config.py`.

## Test plan

- [ ] `!channelcreator` — name and category dropdowns update the embed without error; custom name button opens modal and updates embed; Create button makes the channel
- [ ] On bot restart, `#economy-log` channel appears in guilds that didn't have one
- [ ] BJ tournament channels deleted within 5 min after bot restart with a notification message
- [ ] RPS tournament / bot-match channels same
- [ ] `!count` / `!counting` state survives bot restart (count number preserved)
- [ ] `DISCORD_WEBHOOK_URL` warning visible in bot.log if env var is unset
- [ ] CMD log lines include guild name
- [ ] `!deathmatch` and counting commands load without error

https://claude.ai/code/session_018cQYsrB4iy5EoiVy6S9vGt

---
_Generated by [Claude Code](https://claude.ai/code/session_018cQYsrB4iy5EoiVy6S9vGt)_