### PR TITLE
Fix channel creator errors, economy-log deduplication, and data correctness

### DIFF
--- a/disbot/cogs/channel_cog.py
+++ b/disbot/cogs/channel_cog.py
@@ -49,8 +49,8 @@ class ChannelCog(commands.Cog):
             name = (target.name if isinstance(target, discord.Role)
                     else target.display_name if isinstance(target, discord.Member)
                     else "Unknown")
-            allow = ", ".join([p.replace("_", " ").title() for p, v in perms if v])
-            deny  = ", ".join([p.replace("_", " ").title() for p, v in perms if not v])
+            allow = ", ".join([p.replace("_", " ").title() for p, v in iter(perms) if v is True])
+            deny  = ", ".join([p.replace("_", " ").title() for p, v in iter(perms) if v is False])
             formatted += f"**{name}**\nAllowed: {allow or 'None'}\nDenied: {deny or 'None'}\n\n"
         return formatted or "No overwrites."
 
@@ -380,13 +380,26 @@ class _ChannelCreatorView(discord.ui.View):
         safe  = await safe_channel_name(guild, self.chosen_name)
         category = None
         if self.chosen_cat:
-            category = await get_or_create_category(guild, self.chosen_cat)
+            try:
+                category = await get_or_create_category(guild, self.chosen_cat)
+            except discord.Forbidden:
+                await interaction.response.send_message(
+                    "❌ I don't have permission to create categories.", ephemeral=True)
+                return
+            except discord.HTTPException as exc:
+                await interaction.response.send_message(
+                    f"❌ Failed to create category: {exc}", ephemeral=True)
+                return
 
         try:
             ch = await guild.create_text_channel(safe, category=category)
         except discord.Forbidden:
             await interaction.response.send_message(
                 "❌ I don't have permission to create channels.", ephemeral=True)
+            return
+        except discord.HTTPException as exc:
+            await interaction.response.send_message(
+                f"❌ Failed to create channel: {exc}", ephemeral=True)
             return
 
         for item in self.children:

--- a/disbot/cogs/economy_cog.py
+++ b/disbot/cogs/economy_cog.py
@@ -143,6 +143,13 @@ class EconomyCog(commands.Cog):
             ch = guild.get_channel(int(cid))
             if ch:
                 return  # channel still exists, nothing to do
+
+        # on_ready can fire on every reconnect — check by name before creating
+        existing = discord.utils.get(guild.text_channels, name="economy-log")
+        if existing:
+            await db.set_setting(guild.id, "economy_log_channel", str(existing.id))
+            return
+
         try:
             cat = (discord.utils.get(guild.categories, name="Bot")
                    or discord.utils.get(guild.categories, name="General"))

--- a/disbot/cogs/xp_cog.py
+++ b/disbot/cogs/xp_cog.py
@@ -154,21 +154,21 @@ class XpCog(commands.Cog):
     async def leaderboard(self, ctx: commands.Context, stat: str = "xp"):
         """Show the top 10.  !leaderboard [xp|coins]"""
         stat = stat.lower()
-        if stat not in _STAT_TYPES:
+        if stat not in ("xp", "coins"):
             await ctx.send(
-                f"Unknown stat `{stat}`. Choose from: {', '.join(_STAT_TYPES)}.",
+                f"Unknown stat `{stat}`. Choose from: `xp`, `coins`.",
                 delete_after=8,
             )
             return
 
+        medals = ["🥇", "🥈", "🥉"]
+        lines = []
         if stat == "xp":
             rows = await db.fetchall(
                 "SELECT user_id, xp, level FROM xp WHERE guild_id=? ORDER BY xp DESC LIMIT 10",
                 (ctx.guild.id,),
             )
             title = "🏆 XP Leaderboard"
-            medals = ["🥇", "🥈", "🥉"]
-            lines = []
             for i, row in enumerate(rows):
                 m = ctx.guild.get_member(row["user_id"])
                 name = m.display_name if m else f"<@{row['user_id']}>"
@@ -180,8 +180,6 @@ class XpCog(commands.Cog):
                 (ctx.guild.id,),
             )
             title = "🪙 Coin Leaderboard"
-            medals = ["🥇", "🥈", "🥉"]
-            lines = []
             for i, row in enumerate(rows):
                 m = ctx.guild.get_member(row["user_id"])
                 name = m.display_name if m else f"<@{row['user_id']}>"

--- a/disbot/utils/db.py
+++ b/disbot/utils/db.py
@@ -188,7 +188,7 @@ async def get_xp(user_id: int, guild_id: int) -> dict:
     )
     return row or {
         "user_id": user_id, "guild_id": guild_id,
-        "xp": 0, "level": 0, "messages": 0, "last_xp": 0,
+        "xp": 0, "level": 0, "messages": 0, "last_xp": 0, "coins": 0,
     }
 
 


### PR DESCRIPTION
## Summary

Quick-check pass across the full codebase. All persistence paths (XP, coins, economy, reaction roles, RPS stats) verified correct — data is written to SQLite with upsert patterns and survives restarts. Four targeted fixes applied:

### channel_cog — channel creator no longer silently fails
- `create_btn` previously only caught `discord.Forbidden` from `guild.create_text_channel`, leaving category creation errors and any `discord.HTTPException` (rate limit, invalid name, etc.) unhandled → Discord showed "This interaction failed"
- Now catches `Forbidden` and `HTTPException` from both category creation and channel creation separately, each returning a descriptive ephemeral message
- `format_overwrites` (used by `!channelinfo`) fixed: `if not v` incorrectly included `None` (neutral) overwrites in the deny list; changed to `if v is True` / `if v is False`

### economy_cog — economy-log no longer duplicated on reconnect
- `on_ready` fires on every Discord reconnect, not just startup
- `_ensure_log_channel` now checks for an existing `#economy-log` channel by name before creating a new one; if found, it adopts and records it rather than creating a duplicate

### db.py — `get_xp` fallback dict includes `coins`
- Default return for new users was missing `coins: 0`, inconsistent with the actual table schema; all callers used `.get("coins", 0)` defensively but this removes the inconsistency

### xp_cog — `!leaderboard both` no longer silently shows coins
- The `else` branch treated both `"coins"` and `"both"` identically, showing the coin leaderboard for `!leaderboard both` with no indication something was wrong
- Changed accepted values to `{"xp", "coins"}` — `"both"` now returns a clear error; it remains valid for `!rank` which genuinely shows both stats in one embed

## Persistence verification

| Data | Storage | Survives restart |
|---|---|---|
| XP & level | `xp` table (SQLite) | ✅ via `BOT_DB_PATH` env var |
| Coins | `xp.coins` column (SQLite) | ✅ |
| Daily streak / economy | `economy` table (SQLite) | ✅ |
| Job mastery | `job_progress` table (SQLite) | ✅ |
| Shop inventory | `inventory` table (SQLite) | ✅ |
| Reaction roles | `reaction_roles` table (SQLite) | ✅ |
| RPS stats | `rps_players` table (SQLite) | ✅ |
| Guild settings | `guild_settings` table (SQLite) | ✅ |
| Counting game state | `count_data.json` | ⚠️ ephemeral on Railway/Render unless volume mounted |

## Test plan

- [ ] Run `!channelcreator`, pick a name and existing category → channel created, no "interaction failed"
- [ ] Run `!channelcreator`, pick a name and a *new* category the bot can't create → descriptive ephemeral error appears
- [ ] Restart the bot → `#economy-log` is not duplicated; existing channel is reused
- [ ] Run `!leaderboard both` → clear error message, not coin leaderboard
- [ ] Run `!rank` → shows XP and coins for a fresh user (no KeyError on `coins`)
- [ ] Earn XP and coins, restart bot, run `!rank` → data persists

https://claude.ai/code/session_017J4C6afkTwtzAWBzmQ17RM

---
_Generated by [Claude Code](https://claude.ai/code/session_017J4C6afkTwtzAWBzmQ17RM)_