### PR TITLE
Fix coin deduction SQL bug and channel creator interaction failures

### DIFF
--- a/disbot/cogs/channel_cog.py
+++ b/disbot/cogs/channel_cog.py
@@ -377,15 +377,15 @@ class _ChannelCreatorView(discord.ui.View):
         error: Exception,
         item: discord.ui.Item,
     ) -> None:
-        logger.error("ChannelCreatorView unhandled error on %s: %s", item, error, exc_info=True)
-        msg = "❌ An unexpected error occurred."
-        if not interaction.response.is_done():
-            await interaction.response.send_message(msg, ephemeral=True)
-        else:
-            try:
+        logger.error("ChannelCreatorView error on %s: %s", item, error, exc_info=True)
+        msg = f"❌ {type(error).__name__}: {error}"
+        try:
+            if not interaction.response.is_done():
+                await interaction.response.send_message(msg, ephemeral=True)
+            else:
                 await interaction.followup.send(msg, ephemeral=True)
-            except Exception:
-                pass
+        except Exception:
+            pass
 
     def _build_embed(self) -> discord.Embed:
         embed = discord.Embed(
@@ -419,9 +419,9 @@ class _ChannelCreatorView(discord.ui.View):
                 "Please select or enter a channel name first.", ephemeral=True)
             return
 
-        # Acknowledge immediately — Discord requires a response within 3 seconds,
-        # and the API calls below can exceed that under load.
-        await interaction.response.defer()
+        # Defer immediately — Discord requires acknowledgement within 3 seconds.
+        # ephemeral=True keeps the follow-up visible only to the invoker.
+        await interaction.response.defer(ephemeral=True)
 
         guild = interaction.guild
         safe  = await safe_channel_name(guild, self.chosen_name)
@@ -458,7 +458,14 @@ class _ChannelCreatorView(discord.ui.View):
             description=f"{ch.mention} created" + (f" in **{self.chosen_cat}**" if self.chosen_cat else "") + suffix,
             color=discord.Color.green(),
         )
-        await interaction.edit_original_response(embed=embed, view=self)
+        # Update the panel embed; if it fails (e.g. message deleted) still confirm via followup
+        try:
+            await self.message.edit(embed=embed, view=self)
+        except Exception:
+            await interaction.followup.send(
+                f"✅ Channel {ch.mention} created!" + (f" in **{self.chosen_cat}**" if self.chosen_cat else ""),
+                ephemeral=True,
+            )
         self.stop()
 
     @discord.ui.button(label="Cancel", style=discord.ButtonStyle.red, emoji="❌", row=2)
@@ -490,8 +497,12 @@ class _NameSelect(discord.ui.Select):
 
     async def callback(self, interaction: discord.Interaction):
         self._parent.chosen_name = self.values[0]
-        await interaction.response.edit_message(
-            embed=self._parent._build_embed(), view=self._parent)
+        try:
+            await interaction.response.edit_message(
+                embed=self._parent._build_embed(), view=self._parent)
+        except discord.HTTPException:
+            if not interaction.response.is_done():
+                await interaction.response.defer()
 
 
 class _CategorySelect(discord.ui.Select):
@@ -506,8 +517,12 @@ class _CategorySelect(discord.ui.Select):
 
     async def callback(self, interaction: discord.Interaction):
         self._parent.chosen_cat = self.values[0]
-        await interaction.response.edit_message(
-            embed=self._parent._build_embed(), view=self._parent)
+        try:
+            await interaction.response.edit_message(
+                embed=self._parent._build_embed(), view=self._parent)
+        except discord.HTTPException:
+            if not interaction.response.is_done():
+                await interaction.response.defer()
 
 
 class _CustomNameModal(discord.ui.Modal, title="Custom Channel Name"):

--- a/disbot/utils/db.py
+++ b/disbot/utils/db.py
@@ -313,11 +313,13 @@ async def get_coins(user_id: int, guild_id: int) -> int:
 
 async def add_coins(user_id: int, guild_id: int, amount: int) -> int:
     """Add (or subtract if negative) coins; clamps to 0. Returns new balance."""
+    # Pass amount twice: once for the INSERT default (clamped for new users),
+    # once for the UPDATE so negative values actually subtract from existing balance.
     await execute(
         """INSERT INTO xp (user_id, guild_id, coins) VALUES (?, ?, MAX(0, ?))
            ON CONFLICT(user_id, guild_id) DO UPDATE SET
-               coins=MAX(0, coins + excluded.coins)""",
-        (user_id, guild_id, amount),
+               coins=MAX(0, coins + ?)""",
+        (user_id, guild_id, amount, amount),
     )
     return await get_coins(user_id, guild_id)
 


### PR DESCRIPTION
## Summary

Two bugs fixed across `db.py` and `channel_cog.py`.

### Bug 1 — Coins could never decrease (`db.py`)

**Root cause:** `add_coins` used `MAX(0, amount)` in the INSERT values. For any negative `amount` (e.g. `-5000` when buying a shop item), this produced `0`. The `ON CONFLICT DO UPDATE` then did `coins = MAX(0, coins + 0)` — adding nothing. Shop purchases silently succeeded without deducting any coins, so user balances only ever grew.

**Fix:** Pass `amount` a second time as a raw parameter so the UPDATE expression is `MAX(0, coins + ?)` using the real (potentially negative) value:

```python
# Before — deductions silently did nothing
await execute(
    """INSERT INTO xp (user_id, guild_id, coins) VALUES (?, ?, MAX(0, ?))
       ON CONFLICT(user_id, guild_id) DO UPDATE SET
           coins=MAX(0, coins + excluded.coins)""",   # excluded.coins = MAX(0,amount) = 0
    (user_id, guild_id, amount),
)

# After — deductions work correctly
await execute(
    """INSERT INTO xp (user_id, guild_id, coins) VALUES (?, ?, MAX(0, ?))
       ON CONFLICT(user_id, guild_id) DO UPDATE SET
           coins=MAX(0, coins + ?)""",   # raw amount, can be negative
    (user_id, guild_id, amount, amount),
)
```

### Bug 2 — Channel creator interaction failures (`channel_cog.py`)

Three separate fixes:

**a) Select callbacks not handling `edit_message` failure**
`_NameSelect` and `_CategorySelect` callbacks called `interaction.response.edit_message(...)` with no error handling. Any `discord.HTTPException` (rate limit, stale message, etc.) propagated to `View.on_error`, which showed "❌ An unexpected error occurred." — and the interaction was left unacknowledged from Discord's perspective. Fixed by wrapping in try/except and falling back to `defer()` to always acknowledge.

**b) `create_btn` editing the wrong message after defer**
`defer()` without arguments sends a `DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE` response (type 5) — a new "thinking…" message separate from the panel. `interaction.edit_original_response()` then edited *that* new message, leaving the original panel unchanged. Fixed by using `defer(ephemeral=True)` and editing the panel via the stored `self.message` reference directly.

**c) Opaque error messages**
`on_error` showed a generic "❌ An unexpected error occurred." making failures impossible to diagnose. Now shows `❌ ExceptionType: message` so any future Discord API errors are immediately identifiable.

## Test plan

- [ ] Run `!shop`, buy an item — confirm coins are deducted from balance
- [ ] Run `!daily` then `!work` — confirm coins are added correctly
- [ ] Run `!ccreate`, select a name from the dropdown — embed updates to show the selected name, no error
- [ ] Run `!ccreate`, select a name and category, click **Create Channel** — channel is created, panel updates to show success
- [ ] Run `!ccreate`, click **Create Channel** without selecting a name — ephemeral "please select a name first" message appears

https://claude.ai/code/session_017J4C6afkTwtzAWBzmQ17RM

---
_Generated by [Claude Code](https://claude.ai/code/session_017J4C6afkTwtzAWBzmQ17RM)_