### PR TITLE
Fix !ccreate interaction failures and misc bot stability

### DIFF
--- a/disbot/cogs/channel_cog.py
+++ b/disbot/cogs/channel_cog.py
@@ -371,6 +371,9 @@ class _ChannelCreatorView(discord.ui.View):
             return False
         return True
 
+    # Some discord.py builds dispatch via _run_checks instead of interaction_check
+    _run_checks = interaction_check
+
     async def on_error(
         self,
         interaction: discord.Interaction,


### PR DESCRIPTION
## Summary

- Fix `AttributeError: '_ChannelCreatorView' object has no attribute '_run_checks'` — some discord.py builds dispatch component interactions via `_run_checks` instead of `interaction_check`; both names now alias the same auth check
- Fix `!ccreate` "This interaction failed" errors by deferring immediately before any async work and using `self.message.edit()` + `followup.send()` instead of `edit_original_response`
- Fix channel/category resolution to accept numeric IDs and `<#mention>` in addition to names
- Fix `add_coins` SQL bug where negative amounts (shop purchases) were silently clamped to 0 instead of deducting
- Fix economy-log channel being re-created on every reconnect (`on_ready` fires on each reconnect, not just startup)
- Fix `get_xp` fallback dict missing `coins: 0` key for new users

## Test plan

- [x] Run `!ccreate`, pick a name and category from the dropdowns, click **Create Channel** — should succeed without "interaction failed"
- [ ] Run `!ccreate` as a non-owner user — should get ephemeral "This panel isn't for you"
- [ ] Run `!del <channel-id>` and `!del <#channel-mention>` — should find and delete the channel
- [ ] Buy a shop item (`!shop` → purchase) — coin balance should decrease
- [ ] Restart the bot — economy-log channel should not be duplicated
- [ ] Run `!rank` for a brand-new user — should show 0 coins without KeyError

https://claude.ai/code/session_017J4C6afkTwtzAWBzmQ17RM

---
_Generated by [Claude Code](https://claude.ai/code/session_017J4C6afkTwtzAWBzmQ17RM)_