### PR TITLE
Migrate to PostgreSQL, centralize helpers, and expand channel management UI

### DIFF
--- a/disbot/cogs/admin_cog.py
+++ b/disbot/cogs/admin_cog.py
@@ -7,10 +7,21 @@ import re
 import sys
 import ast
 import asyncio
-from utils import db
+from utils.helpers import CogMenuView
 
 COGS_DIR = os.path.dirname(os.path.abspath(__file__))
 PID_FILE = os.path.join(os.path.dirname(COGS_DIR), "bot.pid")
+
+_ADMIN_MENU_COMMANDS: list[tuple[str, str, str]] = [
+    ("adminmenu",   "!adminmenu",                        "Show this admin command menu."),
+    ("serverstats", "!serverstats",                      "Display server member and channel statistics."),
+    ("coglist",     "!coglist",                          "List all cogs with load status and syntax check."),
+    ("cog",         "!cog <load|unload|reload> <name>",  "Load, unload, or reload a specific cog."),
+    ("loadall",     "!loadall",                          "Load all unloaded cogs."),
+    ("reloadall",   "!reloadall",                        "Reload all currently loaded cogs."),
+    ("loglevel",    "!loglevel <DEBUG|INFO|WARNING|ERROR>","Change the webhook log level."),
+    ("restart",     "!restart",                          "Restart the bot process (owner only)."),
+]
 
 
 def _normalize(name: str) -> str:
@@ -52,99 +63,16 @@ class AdminCog(commands.Cog):
         self.bot = bot
 
     # ------------------------------------------------------------------
-    # Reaction Role System  (DB-backed — survives restarts)
+    # Admin menu
     # ------------------------------------------------------------------
 
-    @commands.Cog.listener()
-    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
-        if payload.user_id == self.bot.user.id:
-            return
-        guild = self.bot.get_guild(payload.guild_id)
-        if not guild:
-            return
-        member = guild.get_member(payload.user_id)
-        if not member or member.bot:
-            return
-        role_id = await db.get_reaction_role(
-            payload.guild_id, payload.message_id, str(payload.emoji)
-        )
-        if role_id:
-            role = guild.get_role(role_id)
-            if role:
-                try:
-                    await member.add_roles(role, reason="Reaction role")
-                except discord.Forbidden:
-                    pass
-
-    @commands.Cog.listener()
-    async def on_raw_reaction_remove(self, payload: discord.RawReactionActionEvent):
-        guild = self.bot.get_guild(payload.guild_id)
-        if not guild:
-            return
-        member = guild.get_member(payload.user_id)
-        if not member or member.bot:
-            return
-        role_id = await db.get_reaction_role(
-            payload.guild_id, payload.message_id, str(payload.emoji)
-        )
-        if role_id:
-            role = guild.get_role(role_id)
-            if role:
-                try:
-                    await member.remove_roles(role, reason="Reaction role removed")
-                except discord.Forbidden:
-                    pass
-
-    @commands.command(name='reactroles', aliases=['reaktionsrollen'])
-    @commands.has_permissions(manage_roles=True)
-    async def setup_reaction_roles(self, ctx, message_id: int, emoji: str, role: discord.Role):
-        """Attach a reaction role to a message. Usage: !reactroles <message_id> <emoji> <@role>"""
-        try:
-            message = await ctx.fetch_message(message_id)
-        except discord.NotFound:
-            await ctx.send("❌ Message not found in this channel.", delete_after=8)
-            return
-        except discord.Forbidden:
-            await ctx.send("❌ I can't read that message.", delete_after=8)
-            return
-
-        await db.add_reaction_role(ctx.guild.id, message_id, emoji, role.id)
-        try:
-            await message.add_reaction(emoji)
-        except discord.HTTPException:
-            await ctx.send("⚠️ Role saved, but I couldn't add the reaction (invalid emoji?).")
-            return
-        await ctx.send(
-            f"✅ Reaction role set: reacting with {emoji} on that message will assign **{role.name}**.",
-            delete_after=15,
-        )
-
-    @commands.command(name='removereactrole')
-    @commands.has_permissions(manage_roles=True)
-    async def remove_reaction_role(self, ctx, message_id: int, emoji: str):
-        """Remove a reaction role binding. Usage: !removereactrole <message_id> <emoji>"""
-        await db.remove_reaction_role(ctx.guild.id, message_id, emoji)
-        await ctx.send(f"✅ Reaction role for {emoji} on that message removed.", delete_after=10)
-
-    @commands.command(name='listreactroles')
-    @commands.has_permissions(manage_roles=True)
-    async def list_reaction_roles(self, ctx):
-        """List all active reaction roles in this server."""
-        rows = await db.get_all_reaction_roles(ctx.guild.id)
-        if not rows:
-            await ctx.send("No reaction roles configured.", delete_after=8)
-            return
-        lines = []
-        for r in rows:
-            role = ctx.guild.get_role(r["role_id"])
-            role_str = role.mention if role else f"<deleted role {r['role_id']}>"
-            lines.append(f"Message `{r['message_id']}` · {r['emoji']} → {role_str}")
-        embed = discord.Embed(
-            title="⚙️ Reaction Roles",
-            description="\n".join(lines),
-            color=discord.Color.blurple(),
-        )
-        await ctx.send(embed=embed)
+    @commands.command(name='adminmenu')
+    @commands.has_permissions(administrator=True)
+    async def admin_menu(self, ctx):
+        """Show a quick-reference menu for all admin commands."""
+        view = CogMenuView(ctx, "🛠️ Admin Commands", _ADMIN_MENU_COMMANDS)
+        msg = await ctx.send(embed=view.build_embed(), view=view)
+        view.message = msg
 
     # ------------------------------------------------------------------
     # Server Statistics
@@ -284,7 +212,6 @@ class AdminCog(commands.Cog):
         """Restart the bot process."""
         await ctx.send('♻️ Restarting bot...')
         logging.info('Restarting bot...')
-        # Remove PID file so the new process doesn't think another instance is running
         if os.path.exists(PID_FILE):
             os.remove(PID_FILE)
         await self.bot.close()

--- a/disbot/cogs/chain_cog.py
+++ b/disbot/cogs/chain_cog.py
@@ -1,45 +1,20 @@
 import discord
 from discord.ext import commands
-import json
-import os
 from discord.ext.commands import has_permissions, MissingPermissions
 import asyncio
 import logging
 from typing import Optional
+from utils import db
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-
-# Path to the JSON file for persistence
-DATA_FILE = "chain_data.json"
 
 class ChainCog(commands.Cog):
     """Cog for managing message chains and word limits in specified channels."""
 
     def __init__(self, bot):
         self.bot = bot
-        self.data = self.load_data()
-
-    def load_data(self):
-        """Load chain data from the JSON file."""
-        if not os.path.isfile(DATA_FILE):
-            logger.info(f"{DATA_FILE} not found. Creating a new one.")
-            return {"channels": {}}
-        with open(DATA_FILE, "r") as f:
-            try:
-                data = json.load(f)
-                logger.info("Chain data loaded successfully.")
-                return data
-            except json.JSONDecodeError:
-                logger.error(f"Failed to decode {DATA_FILE}. Initializing empty data.")
-                return {"channels": {}}
-
-    def save_data(self):
-        """Save chain data to the JSON file."""
-        with open(DATA_FILE, "w") as f:
-            json.dump(self.data, f, indent=4)
-        logger.info("Chain data saved successfully.")
 
     @commands.group(name="chain", invoke_without_command=True)
     async def chain(self, ctx):
@@ -48,7 +23,6 @@ class ChainCog(commands.Cog):
 
         Use subcommands to create, delete, set limits, or list chains.
         """
-        # Inform the user to use a subcommand
         await ctx.send(
             "❓ Please specify a subcommand. Use `?chain create`, `?chain delete`, `?chain setlimit`, `?chain removelimit`, or `?chain list`."
         )
@@ -76,18 +50,14 @@ class ChainCog(commands.Cog):
             return
 
         target_channel = channel or ctx.channel
+        channel_id = target_channel.id
 
-        channel_id_str = str(target_channel.id)
-
-        if channel_id_str in self.data["channels"] and self.data["channels"][channel_id_str].get("word"):
+        existing = await db.get_chain_channel(channel_id)
+        if existing and existing.get("word"):
             await ctx.send(f"❌ A chain is already active in {target_channel.mention}.")
             return
 
-        if channel_id_str not in self.data["channels"]:
-            self.data["channels"][channel_id_str] = {}
-
-        self.data["channels"][channel_id_str]["word"] = word.lower()
-        self.save_data()
+        await db.set_chain_channel(channel_id, ctx.guild.id, word.lower())
 
         await ctx.send(
             f"✅ Chain created in {target_channel.mention}. Only the word `{word}` is allowed in this channel."
@@ -115,15 +85,14 @@ class ChainCog(commands.Cog):
         **Usage:** `?chain delete [channel]`
         """
         target_channel = channel or ctx.channel
+        channel_id = target_channel.id
 
-        channel_id_str = str(target_channel.id)
-
-        if channel_id_str not in self.data["channels"]:
+        existing = await db.get_chain_channel(channel_id)
+        if not existing:
             await ctx.send(f"❌ No active chain found in {target_channel.mention}.")
             return
 
-        del self.data["channels"][channel_id_str]
-        self.save_data()
+        await db.delete_chain_channel(channel_id)
 
         await ctx.send(f"✅ Chain deleted from {target_channel.mention}.")
 
@@ -157,14 +126,16 @@ class ChainCog(commands.Cog):
             return
 
         target_channel = channel or ctx.channel
+        channel_id = target_channel.id
 
-        channel_id_str = str(target_channel.id)
+        existing = await db.get_chain_channel(channel_id)
+        if not existing:
+            await ctx.send(
+                f"❌ No active chain found in {target_channel.mention}. Create one first with `?chain create`."
+            )
+            return
 
-        if channel_id_str not in self.data["channels"]:
-            self.data["channels"][channel_id_str] = {}
-
-        self.data["channels"][channel_id_str]["limit"] = limit
-        self.save_data()
+        await db.set_chain_limit(channel_id, limit)
 
         await ctx.send(
             f"✅ Word limit of {limit} has been set in {target_channel.mention}."
@@ -192,18 +163,11 @@ class ChainCog(commands.Cog):
         **Usage:** `?chain removelimit [channel]`
         """
         target_channel = channel or ctx.channel
+        channel_id = target_channel.id
 
-        channel_id_str = str(target_channel.id)
-
-        if (
-            channel_id_str in self.data["channels"]
-            and "limit" in self.data["channels"][channel_id_str]
-        ):
-            del self.data["channels"][channel_id_str]["limit"]
-            # Remove channel entry if empty
-            if not self.data["channels"][channel_id_str]:
-                del self.data["channels"][channel_id_str]
-            self.save_data()
+        existing = await db.get_chain_channel(channel_id)
+        if existing and existing.get("word_limit"):
+            await db.set_chain_limit(channel_id, 0)
             await ctx.send(
                 f"✅ Word limit has been removed from {target_channel.mention}."
             )
@@ -230,28 +194,32 @@ class ChainCog(commands.Cog):
 
         **Usage:** `?chain list`
         """
-        if not self.data["channels"]:
+        channels = await db.get_all_chain_channels(ctx.guild.id)
+
+        if not channels:
             await ctx.send("ℹ️ There are no active chains or word limits in this server.")
             return
 
         embed = discord.Embed(title="Active Chains and Word Limits", color=discord.Color.green())
 
-        for channel_id, settings in self.data["channels"].items():
-            channel = self.bot.get_channel(int(channel_id))
+        for entry in channels:
+            channel = self.bot.get_channel(entry["channel_id"])
+            word = entry.get("word")
+            limit = entry.get("word_limit")
+            description = ""
+            if word:
+                description += f"Allowed Word: `{word}`\n"
+            if limit:
+                description += f"Word Limit: `{limit}` words\n"
+            if not description:
+                description = "No restrictions set."
             if channel:
-                word = settings.get("word")
-                limit = settings.get("limit")
-                description = ""
-                if word:
-                    description += f"Allowed Word: `{word}`\n"
-                if limit:
-                    description += f"Word Limit: `{limit}` words\n"
-                if not description:
-                    description = "No restrictions set."
                 embed.add_field(name=channel.name, value=description, inline=False)
             else:
                 embed.add_field(
-                    name="Unknown Channel", value=f"Channel ID: `{channel_id}`", inline=False
+                    name="Unknown Channel",
+                    value=f"Channel ID: `{entry['channel_id']}`\n{description}",
+                    inline=False,
                 )
 
         await ctx.send(embed=embed)
@@ -268,13 +236,12 @@ class ChainCog(commands.Cog):
         if ctx.valid:
             return  # Don't process command messages
 
-        channel_id_str = str(message.channel.id)
-        channel_data = self.data["channels"].get(channel_id_str)
+        channel_data = await db.get_chain_channel(message.channel.id)
         if not channel_data:
             return  # No chain or limit set for this channel
 
         allowed_word = channel_data.get("word")
-        word_limit = channel_data.get("limit")
+        word_limit = channel_data.get("word_limit")
 
         # Initialize a flag to determine if message should be deleted
         delete_message = False
@@ -291,6 +258,7 @@ class ChainCog(commands.Cog):
                 delete_message = True
 
         if not delete_message:
+            await db.increment_chain_count(message.channel.id)
             return  # Message is allowed
 
         # Delete the message and optionally warn the user

--- a/disbot/cogs/channel_cog.py
+++ b/disbot/cogs/channel_cog.py
@@ -3,8 +3,24 @@ import discord
 from discord.ext import commands
 import logging
 from utils.channels import safe_channel_name, get_or_create_category
+from utils.helpers import CogMenuView
 
 logger = logging.getLogger("bot")
+
+_CHANNEL_MENU_COMMANDS: list[tuple[str, str, str]] = [
+    ("channelmenu",   "!channelmenu",                              "Show this channel command menu."),
+    ("list",          "!list",                                     "List all categories and channels, including uncategorized."),
+    ("create",        "!create <name> <@role> <True/False> [cat]", "Create a channel with role access."),
+    ("channelcreator","!channelcreator",                           "Open the interactive channel creator UI."),
+    ("del",           "!del <name|id>",                            "Delete a specific channel."),
+    ("move",          "!move <channel> <category>",                "Move a channel into a category."),
+    ("lock",          "!lock <name|id>",                           "Lock a channel (no send messages)."),
+    ("unlock",        "!unlock <name|id>",                         "Unlock a previously locked channel."),
+    ("archive",       "!archive <name|id>",                        "Make a channel read-only."),
+    ("rename",        "!rename <old> <new>",                       "Rename a channel."),
+    ("channelinfo",   "!channelinfo <name|id>",                    "Show detailed info about a channel."),
+    ("clone",         "!clone <name|id> <new_name>",               "Clone a channel with a new name."),
+]
 
 # Keyword presets shown in the dropdown menus
 _NAME_PRESETS = [
@@ -77,6 +93,14 @@ class ChannelCog(commands.Cog):
     # -------------------
     # Commands
     # -------------------
+
+    @commands.command(name="channelmenu", help="Show the channel command quick-reference menu.")
+    @is_admin_or_owner()
+    async def channel_menu(self, ctx):
+        """Show a quick-reference menu for all channel commands."""
+        view = CogMenuView(ctx, "📋 Channel Commands", _CHANNEL_MENU_COMMANDS)
+        msg = await ctx.send(embed=view.build_embed(), view=view)
+        view.message = msg
 
     @commands.command(name="set", help="Set access for a channel/category. Usage: !set <name|id> <@role> <True/False>")
     @is_admin_or_owner()
@@ -192,13 +216,17 @@ class ChannelCog(commands.Cog):
         else:
             await ctx.send(f'Channel "{channel_name}" not found.')
 
-    @commands.command(name="list", help="List all categories and channels.")
+    @commands.command(name="list", help="List all categories and channels, including uncategorized.")
     @is_admin_or_owner()
     async def list_channels(self, ctx):
         embed = discord.Embed(title="Categories and Channels", color=discord.Color.blue())
         for category in ctx.guild.categories:
             channels = "\n".join(f" - {ch.name}" for ch in category.channels)
             embed.add_field(name=category.name, value=channels or "No channels", inline=False)
+        uncategorized = [ch for ch in ctx.guild.channels if ch.category is None and not isinstance(ch, discord.CategoryChannel)]
+        if uncategorized:
+            names = "\n".join(f" - {ch.name}" for ch in sorted(uncategorized, key=lambda c: c.position))
+            embed.add_field(name="— Uncategorized —", value=names, inline=False)
         await ctx.send(embed=embed)
 
     @commands.command(name="clone", help="Clone a channel. Usage: !clone <name|id> <new_name>")

--- a/disbot/cogs/channel_cog.py
+++ b/disbot/cogs/channel_cog.py
@@ -8,18 +8,18 @@ from utils.helpers import CogMenuView
 logger = logging.getLogger("bot")
 
 _CHANNEL_MENU_COMMANDS: list[tuple[str, str, str]] = [
-    ("channelmenu",   "!channelmenu",                              "Show this channel command menu."),
-    ("list",          "!list",                                     "List all categories and channels, including uncategorized."),
-    ("create",        "!create <name> <@role> <True/False> [cat]", "Create a channel with role access."),
-    ("channelcreator","!channelcreator",                           "Open the interactive channel creator UI."),
-    ("del",           "!del <name|id>",                            "Delete a specific channel."),
-    ("move",          "!move <channel> <category>",                "Move a channel into a category."),
-    ("lock",          "!lock <name|id>",                           "Lock a channel (no send messages)."),
-    ("unlock",        "!unlock <name|id>",                         "Unlock a previously locked channel."),
-    ("archive",       "!archive <name|id>",                        "Make a channel read-only."),
-    ("rename",        "!rename <old> <new>",                       "Rename a channel."),
-    ("channelinfo",   "!channelinfo <name|id>",                    "Show detailed info about a channel."),
-    ("clone",         "!clone <name|id> <new_name>",               "Clone a channel with a new name."),
+    ("channelmenu",    "!channelmenu",                              "Show this channel command menu."),
+    ("list",           "!list",                                     "List all categories and channels, including uncategorized."),
+    ("create",         "!create <name> <@role> <True/False> [cat]", "Create a channel with role access."),
+    ("channelcreator", "!channelcreator",                           "Open the interactive channel management panel."),
+    ("del",            "!del <name|id>",                            "Delete a specific channel."),
+    ("move",           "!move <channel> <category>",                "Move a channel into a category."),
+    ("lock",           "!lock <name|id>",                           "Lock a channel (no send messages)."),
+    ("unlock",         "!unlock <name|id>",                         "Unlock a previously locked channel."),
+    ("archive",        "!archive <name|id>",                        "Make a channel read-only."),
+    ("rename",         "!rename <old> <new>",                       "Rename a channel."),
+    ("channelinfo",    "!channelinfo <name|id>",                    "Show detailed info about a channel."),
+    ("clone",          "!clone <name|id> <new_name>",               "Clone a channel with a new name."),
 ]
 
 # Keyword presets shown in the dropdown menus
@@ -150,22 +150,12 @@ class ChannelCog(commands.Cog):
         await ctx.send(f'Channel "{safe_name}" created with {state} access for {role.name}!{suffix}')
 
     @commands.command(name="channelcreator", aliases=["ccreate"],
-                      help="Open the interactive channel creator UI.")
+                      help="Open the comprehensive channel management panel.")
     @is_admin_or_owner()
     async def channel_creator(self, ctx):
-        """Opens a button/dropdown panel for creating a channel."""
-        view = _ChannelCreatorView(ctx)
-        embed = discord.Embed(
-            title="📋 Channel Creator",
-            description=(
-                "Use the menus below to pick a name and category for the new channel.\n"
-                "You can also type a custom name via the **Custom Name** button."
-            ),
-            color=discord.Color.blurple(),
-        )
-        embed.add_field(name="Selected name",     value="*(none)*", inline=True)
-        embed.add_field(name="Selected category", value="*(none)*", inline=True)
-        msg = await ctx.send(embed=embed, view=view)
+        """Opens the comprehensive channel management panel."""
+        view = _ChannelManagerView(ctx)
+        msg = await ctx.send(embed=view.build_embed(), view=view)
         view.message = msg
 
     @commands.command(name="bulkdelete", help="Delete multiple channels. Usage: !bulkdelete <name|id> [name|id...] or <keyword>")
@@ -364,24 +354,153 @@ class ChannelCog(commands.Cog):
             await ctx.send(f'"{channel_name}" not found.')
 
 
-# -------------------
-# Channel Creator UI
-# -------------------
+# =====================================================================
+# Shared helpers
+# =====================================================================
 
-class _ChannelCreatorView(discord.ui.View):
-    """Interactive channel creation panel with dropdown name/category pickers."""
+def _build_channel_options(guild: discord.Guild) -> list[discord.SelectOption]:
+    """Return up to 25 SelectOptions for all text + voice channels, sorted by name."""
+    channels = sorted(
+        [ch for ch in guild.channels
+         if isinstance(ch, (discord.TextChannel, discord.VoiceChannel))],
+        key=lambda c: c.name,
+    )
+    options = []
+    for ch in channels[:25]:
+        emoji = "🔊" if isinstance(ch, discord.VoiceChannel) else "#"
+        cat_label = ch.category.name if ch.category else "No category"
+        options.append(discord.SelectOption(
+            label=ch.name[:100],
+            value=str(ch.id),
+            description=f"{cat_label}"[:100],
+            emoji=emoji,
+        ))
+    return options
+
+
+# =====================================================================
+# Top-level manager panel
+# =====================================================================
+
+class _ChannelManagerView(discord.ui.View):
+    """Top-level channel management panel with three action modes."""
 
     def __init__(self, ctx: commands.Context):
-        super().__init__(timeout=120)
-        self.ctx          = ctx
-        self.chosen_name: str | None  = None
-        self.chosen_cat:  str | None  = None
+        super().__init__(timeout=180)
+        self.ctx = ctx
         self.message: discord.Message | None = None
 
-        # Build category select: existing ones first, then presets not yet in guild
+    # ------------------------------------------------------------------
+    # Auth guard
+    # ------------------------------------------------------------------
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user != self.ctx.author:
+            await interaction.response.send_message("This panel isn't for you.", ephemeral=True)
+            return False
+        return True
+
+    _run_checks = interaction_check
+
+    async def on_error(
+        self,
+        interaction: discord.Interaction,
+        error: Exception,
+        item: discord.ui.Item,
+    ) -> None:
+        logger.error("ChannelManagerView error on %s: %s", item, error, exc_info=True)
+        msg = f"❌ {type(error).__name__}: {error}"
+        try:
+            if not interaction.response.is_done():
+                await interaction.response.send_message(msg, ephemeral=True)
+            else:
+                await interaction.followup.send(msg, ephemeral=True)
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # Embed
+    # ------------------------------------------------------------------
+
+    def build_embed(self) -> discord.Embed:
+        embed = discord.Embed(
+            title="🛠️ Channel Management Panel",
+            description=(
+                "Select an action below to manage your server's channels.\n\n"
+                "**➕ Create Channel** — interactive channel creator\n"
+                "**🗑️ Delete Channel** — select and delete a channel\n"
+                "**🔒 Manage Restrictions** — lock, unlock, archive, or unarchive"
+            ),
+            color=discord.Color.blurple(),
+        )
+        embed.set_footer(text="Only the command author can interact with this panel.")
+        return embed
+
+    # ------------------------------------------------------------------
+    # Buttons (row 0)
+    # ------------------------------------------------------------------
+
+    @discord.ui.button(label="Create Channel", style=discord.ButtonStyle.green,
+                       emoji="➕", row=0)
+    async def create_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        sub = _CreateSubView(self.ctx, manager_message=self.message)
+        await interaction.response.edit_message(embed=sub.build_embed(), view=sub)
+
+    @discord.ui.button(label="Delete Channel", style=discord.ButtonStyle.red,
+                       emoji="🗑️", row=0)
+    async def delete_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        options = _build_channel_options(interaction.guild)
+        if not options:
+            await interaction.response.send_message(
+                "No text or voice channels found on this server.", ephemeral=True)
+            return
+        sub = _DeleteSubView(self.ctx, options=options, manager_message=self.message)
+        await interaction.response.edit_message(embed=sub.build_embed(), view=sub)
+
+    @discord.ui.button(label="Manage Restrictions", style=discord.ButtonStyle.blurple,
+                       emoji="🔒", row=0)
+    async def restrict_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        options = _build_channel_options(interaction.guild)
+        if not options:
+            await interaction.response.send_message(
+                "No text or voice channels found on this server.", ephemeral=True)
+            return
+        sub = _RestrictSubView(self.ctx, options=options, manager_message=self.message)
+        await interaction.response.edit_message(embed=sub.build_embed(), view=sub)
+
+    # ------------------------------------------------------------------
+    # Timeout
+    # ------------------------------------------------------------------
+
+    async def on_timeout(self):
+        for item in self.children:
+            item.disabled = True
+        try:
+            await self.message.edit(content="Panel timed out.", view=self)
+        except Exception:
+            pass
+
+
+# =====================================================================
+# Create sub-panel  (same logic as the old _ChannelCreatorView)
+# =====================================================================
+
+class _CreateSubView(discord.ui.View):
+    """Channel-creation sub-panel — mirrors the old _ChannelCreatorView."""
+
+    def __init__(self, ctx: commands.Context, *, manager_message: discord.Message | None):
+        super().__init__(timeout=120)
+        self.ctx = ctx
+        self.manager_message = manager_message
+        self.chosen_name: str | None = None
+        self.chosen_cat:  str | None = None
+
+        # Category options: existing guild categories first, then presets
         existing_cats = [c.name for c in ctx.guild.categories]
-        cat_options = [discord.SelectOption(label=c, description="Existing category")
-                       for c in existing_cats[:15]]  # cap to avoid Discord limit
+        cat_options = [
+            discord.SelectOption(label=c, description="Existing category")
+            for c in existing_cats[:15]
+        ]
         for p in _CATEGORY_PRESETS:
             if p not in existing_cats and len(cat_options) < 24:
                 cat_options.append(discord.SelectOption(label=p, description="New category"))
@@ -393,13 +512,16 @@ class _ChannelCreatorView(discord.ui.View):
         self.add_item(self.name_select)
         self.add_item(self.cat_select)
 
+    # ------------------------------------------------------------------
+    # Auth guard
+    # ------------------------------------------------------------------
+
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         if interaction.user != self.ctx.author:
             await interaction.response.send_message("This panel isn't for you.", ephemeral=True)
             return False
         return True
 
-    # Some discord.py builds dispatch via _run_checks instead of interaction_check
     _run_checks = interaction_check
 
     async def on_error(
@@ -408,7 +530,7 @@ class _ChannelCreatorView(discord.ui.View):
         error: Exception,
         item: discord.ui.Item,
     ) -> None:
-        logger.error("ChannelCreatorView error on %s: %s", item, error, exc_info=True)
+        logger.error("CreateSubView error on %s: %s", item, error, exc_info=True)
         msg = f"❌ {type(error).__name__}: {error}"
         try:
             if not interaction.response.is_done():
@@ -418,14 +540,18 @@ class _ChannelCreatorView(discord.ui.View):
         except Exception:
             pass
 
-    def _build_embed(self) -> discord.Embed:
+    # ------------------------------------------------------------------
+    # Embed
+    # ------------------------------------------------------------------
+
+    def build_embed(self) -> discord.Embed:
         embed = discord.Embed(
-            title="📋 Channel Creator",
+            title="➕ Create Channel",
             description=(
                 "Use the menus below to pick a name and category.\n"
                 "Click **Custom Name** to type your own name."
             ),
-            color=discord.Color.blurple(),
+            color=discord.Color.green(),
         )
         embed.add_field(
             name="Selected name",
@@ -439,6 +565,10 @@ class _ChannelCreatorView(discord.ui.View):
         )
         return embed
 
+    # ------------------------------------------------------------------
+    # Buttons (row 2)
+    # ------------------------------------------------------------------
+
     @discord.ui.button(label="Custom Name", style=discord.ButtonStyle.grey, emoji="✏️", row=2)
     async def custom_name_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
         await interaction.response.send_modal(_CustomNameModal(self))
@@ -450,8 +580,6 @@ class _ChannelCreatorView(discord.ui.View):
                 "Please select or enter a channel name first.", ephemeral=True)
             return
 
-        # Defer immediately — Discord requires acknowledgement within 3 seconds.
-        # ephemeral=True keeps the follow-up visible only to the invoker.
         await interaction.response.defer(ephemeral=True)
 
         guild = interaction.guild
@@ -486,37 +614,510 @@ class _ChannelCreatorView(discord.ui.View):
         suffix = f' (renamed from "{self.chosen_name}")' if safe != self.chosen_name else ""
         embed = discord.Embed(
             title="✅ Channel Created",
-            description=f"{ch.mention} created" + (f" in **{self.chosen_cat}**" if self.chosen_cat else "") + suffix,
+            description=(
+                f"{ch.mention} created"
+                + (f" in **{self.chosen_cat}**" if self.chosen_cat else "")
+                + suffix
+                + "\n\nReturning to the management panel…"
+            ),
             color=discord.Color.green(),
         )
-        # Update the panel embed; if it fails (e.g. message deleted) still confirm via followup
         try:
-            await self.message.edit(embed=embed, view=self)
+            await self.manager_message.edit(embed=embed, view=self)
         except Exception:
             await interaction.followup.send(
-                f"✅ Channel {ch.mention} created!" + (f" in **{self.chosen_cat}**" if self.chosen_cat else ""),
+                f"✅ Channel {ch.mention} created!"
+                + (f" in **{self.chosen_cat}**" if self.chosen_cat else ""),
                 ephemeral=True,
             )
+
         self.stop()
+
+        # After a brief visual pause, restore the manager panel
+        import asyncio
+        await asyncio.sleep(2)
+        manager = _ChannelManagerView(self.ctx)
+        manager.message = self.manager_message
+        try:
+            await self.manager_message.edit(embed=manager.build_embed(), view=manager)
+        except Exception:
+            pass
 
     @discord.ui.button(label="Cancel", style=discord.ButtonStyle.red, emoji="❌", row=2)
     async def cancel_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        manager = _ChannelManagerView(self.ctx)
+        manager.message = self.manager_message
+        await interaction.response.edit_message(embed=manager.build_embed(), view=manager)
+        self.stop()
+
+    @discord.ui.button(label="↩️ Back", style=discord.ButtonStyle.grey, row=2)
+    async def back_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        manager = _ChannelManagerView(self.ctx)
+        manager.message = self.manager_message
+        await interaction.response.edit_message(embed=manager.build_embed(), view=manager)
+        self.stop()
+
+    # ------------------------------------------------------------------
+    # Timeout
+    # ------------------------------------------------------------------
+
+    async def on_timeout(self):
         for item in self.children:
             item.disabled = True
-        await interaction.response.edit_message(content="Cancelled.", embed=None, view=self)
+        try:
+            await self.manager_message.edit(content="Panel timed out.", view=self)
+        except Exception:
+            pass
+
+
+# =====================================================================
+# Delete sub-panel
+# =====================================================================
+
+class _DeleteSubView(discord.ui.View):
+    """Channel-deletion sub-panel with a select menu and confirmation flow."""
+
+    def __init__(
+        self,
+        ctx: commands.Context,
+        *,
+        options: list[discord.SelectOption],
+        manager_message: discord.Message | None,
+    ):
+        super().__init__(timeout=120)
+        self.ctx = ctx
+        self.manager_message = manager_message
+        self.selected_channel_id: int | None = None
+        self.selected_channel_name: str | None = None
+
+        self.channel_select = _ChannelSelect(options, self, placeholder="Select a channel to delete…")
+        self.add_item(self.channel_select)
+
+    # ------------------------------------------------------------------
+    # Auth guard
+    # ------------------------------------------------------------------
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user != self.ctx.author:
+            await interaction.response.send_message("This panel isn't for you.", ephemeral=True)
+            return False
+        return True
+
+    _run_checks = interaction_check
+
+    async def on_error(
+        self,
+        interaction: discord.Interaction,
+        error: Exception,
+        item: discord.ui.Item,
+    ) -> None:
+        logger.error("DeleteSubView error on %s: %s", item, error, exc_info=True)
+        msg = f"❌ {type(error).__name__}: {error}"
+        try:
+            if not interaction.response.is_done():
+                await interaction.response.send_message(msg, ephemeral=True)
+            else:
+                await interaction.followup.send(msg, ephemeral=True)
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # Embed
+    # ------------------------------------------------------------------
+
+    def build_embed(self) -> discord.Embed:
+        embed = discord.Embed(
+            title="🗑️ Delete Channel",
+            description="Select the channel you want to delete, then press **Delete Selected**.",
+            color=discord.Color.red(),
+        )
+        embed.add_field(
+            name="Selected channel",
+            value=f"`{self.selected_channel_name}`" if self.selected_channel_name else "*(none)*",
+            inline=False,
+        )
+        return embed
+
+    def _confirm_embed(self) -> discord.Embed:
+        return discord.Embed(
+            title="⚠️ Confirm Deletion",
+            description=(
+                f"Are you sure you want to delete **`{self.selected_channel_name}`**?\n"
+                "**This action cannot be undone.**"
+            ),
+            color=discord.Color.dark_red(),
+        )
+
+    # ------------------------------------------------------------------
+    # Buttons (row 1)
+    # ------------------------------------------------------------------
+
+    @discord.ui.button(label="Delete Selected", style=discord.ButtonStyle.red, emoji="🗑️", row=1)
+    async def delete_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        if not self.selected_channel_id:
+            await interaction.response.send_message(
+                "Please select a channel first.", ephemeral=True)
+            return
+        confirm_view = _DeleteConfirmView(
+            self.ctx,
+            channel_id=self.selected_channel_id,
+            channel_name=self.selected_channel_name,
+            manager_message=self.manager_message,
+        )
+        await interaction.response.edit_message(embed=self._confirm_embed(), view=confirm_view)
+        self.stop()
+
+    @discord.ui.button(label="↩️ Back", style=discord.ButtonStyle.grey, row=1)
+    async def back_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        manager = _ChannelManagerView(self.ctx)
+        manager.message = self.manager_message
+        await interaction.response.edit_message(embed=manager.build_embed(), view=manager)
+        self.stop()
+
+    # ------------------------------------------------------------------
+    # Timeout
+    # ------------------------------------------------------------------
+
+    async def on_timeout(self):
+        for item in self.children:
+            item.disabled = True
+        try:
+            await self.manager_message.edit(content="Panel timed out.", view=self)
+        except Exception:
+            pass
+
+
+class _DeleteConfirmView(discord.ui.View):
+    """Confirmation step before actually deleting a channel."""
+
+    def __init__(
+        self,
+        ctx: commands.Context,
+        *,
+        channel_id: int,
+        channel_name: str,
+        manager_message: discord.Message | None,
+    ):
+        super().__init__(timeout=60)
+        self.ctx = ctx
+        self.channel_id = channel_id
+        self.channel_name = channel_name
+        self.manager_message = manager_message
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user != self.ctx.author:
+            await interaction.response.send_message("This panel isn't for you.", ephemeral=True)
+            return False
+        return True
+
+    _run_checks = interaction_check
+
+    async def on_error(
+        self,
+        interaction: discord.Interaction,
+        error: Exception,
+        item: discord.ui.Item,
+    ) -> None:
+        logger.error("DeleteConfirmView error on %s: %s", item, error, exc_info=True)
+        msg = f"❌ {type(error).__name__}: {error}"
+        try:
+            if not interaction.response.is_done():
+                await interaction.response.send_message(msg, ephemeral=True)
+            else:
+                await interaction.followup.send(msg, ephemeral=True)
+        except Exception:
+            pass
+
+    @discord.ui.button(label="Confirm Delete", style=discord.ButtonStyle.red, emoji="🗑️", row=0)
+    async def confirm_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        channel = interaction.guild.get_channel(self.channel_id)
+        if channel is None:
+            result_embed = discord.Embed(
+                title="❌ Channel Not Found",
+                description=f"Channel `{self.channel_name}` could not be found — it may have already been deleted.",
+                color=discord.Color.orange(),
+            )
+        else:
+            try:
+                await channel.delete()
+                result_embed = discord.Embed(
+                    title="✅ Channel Deleted",
+                    description=f"`{self.channel_name}` has been deleted.",
+                    color=discord.Color.green(),
+                )
+            except discord.Forbidden:
+                result_embed = discord.Embed(
+                    title="❌ Permission Denied",
+                    description="I don't have permission to delete that channel.",
+                    color=discord.Color.red(),
+                )
+            except discord.HTTPException as exc:
+                result_embed = discord.Embed(
+                    title="❌ Error",
+                    description=f"Failed to delete channel: {exc}",
+                    color=discord.Color.red(),
+                )
+
+        for item in self.children:
+            item.disabled = True
+        result_embed.set_footer(text="Returning to the management panel…")
+        await interaction.response.edit_message(embed=result_embed, view=self)
+        self.stop()
+
+        import asyncio
+        await asyncio.sleep(2)
+        manager = _ChannelManagerView(self.ctx)
+        manager.message = self.manager_message
+        try:
+            await self.manager_message.edit(embed=manager.build_embed(), view=manager)
+        except Exception:
+            pass
+
+    @discord.ui.button(label="Cancel", style=discord.ButtonStyle.grey, emoji="❌", row=0)
+    async def cancel_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        # Go back to the delete sub-panel
+        options = _build_channel_options(interaction.guild)
+        sub = _DeleteSubView(self.ctx, options=options, manager_message=self.manager_message)
+        await interaction.response.edit_message(embed=sub.build_embed(), view=sub)
         self.stop()
 
     async def on_timeout(self):
         for item in self.children:
             item.disabled = True
         try:
-            await self.message.edit(content="Timed out.", view=self)
+            await self.manager_message.edit(content="Panel timed out.", view=self)
         except Exception:
             pass
 
 
+# =====================================================================
+# Restrict sub-panel
+# =====================================================================
+
+class _RestrictSubView(discord.ui.View):
+    """Restriction management: pick a channel, then choose lock/unlock/archive/unarchive."""
+
+    def __init__(
+        self,
+        ctx: commands.Context,
+        *,
+        options: list[discord.SelectOption],
+        manager_message: discord.Message | None,
+    ):
+        super().__init__(timeout=120)
+        self.ctx = ctx
+        self.manager_message = manager_message
+        self.selected_channel_id: int | None = None
+        self.selected_channel_name: str | None = None
+
+        self.channel_select = _ChannelSelect(options, self, placeholder="Select a channel to manage…")
+        self.add_item(self.channel_select)
+
+    # ------------------------------------------------------------------
+    # Auth guard
+    # ------------------------------------------------------------------
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user != self.ctx.author:
+            await interaction.response.send_message("This panel isn't for you.", ephemeral=True)
+            return False
+        return True
+
+    _run_checks = interaction_check
+
+    async def on_error(
+        self,
+        interaction: discord.Interaction,
+        error: Exception,
+        item: discord.ui.Item,
+    ) -> None:
+        logger.error("RestrictSubView error on %s: %s", item, error, exc_info=True)
+        msg = f"❌ {type(error).__name__}: {error}"
+        try:
+            if not interaction.response.is_done():
+                await interaction.response.send_message(msg, ephemeral=True)
+            else:
+                await interaction.followup.send(msg, ephemeral=True)
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # Embed
+    # ------------------------------------------------------------------
+
+    def build_embed(self) -> discord.Embed:
+        embed = discord.Embed(
+            title="🔒 Manage Restrictions",
+            description=(
+                "Select a channel, then choose a restriction action.\n\n"
+                "**🔒 Lock** — disable send messages for @everyone\n"
+                "**🔓 Unlock** — restore send messages for @everyone\n"
+                "**📁 Archive** — make the channel read-only\n"
+                "**📂 Unarchive** — restore send messages (same as unlock)"
+            ),
+            color=discord.Color.blurple(),
+        )
+        embed.add_field(
+            name="Selected channel",
+            value=f"`{self.selected_channel_name}`" if self.selected_channel_name else "*(none)*",
+            inline=False,
+        )
+        return embed
+
+    # ------------------------------------------------------------------
+    # Action buttons (row 1) — shown only after a channel is selected
+    # ------------------------------------------------------------------
+
+    async def _apply_restriction(
+        self,
+        interaction: discord.Interaction,
+        *,
+        send_messages: bool,
+        action_label: str,
+        past_tense: str,
+        embed_color: discord.Color,
+    ) -> None:
+        if not self.selected_channel_id:
+            await interaction.response.send_message(
+                "Please select a channel first.", ephemeral=True)
+            return
+
+        channel = interaction.guild.get_channel(self.selected_channel_id)
+        if channel is None:
+            await interaction.response.send_message(
+                f"Channel `{self.selected_channel_name}` not found.", ephemeral=True)
+            return
+
+        await interaction.response.defer(ephemeral=True)
+        try:
+            await channel.set_permissions(interaction.guild.default_role, send_messages=send_messages)
+        except discord.Forbidden:
+            await interaction.followup.send(
+                "❌ I don't have permission to change that channel's permissions.", ephemeral=True)
+            return
+        except discord.HTTPException as exc:
+            await interaction.followup.send(
+                f"❌ Failed to update permissions: {exc}", ephemeral=True)
+            return
+
+        result_embed = discord.Embed(
+            title=f"{action_label} Applied",
+            description=f"`{self.selected_channel_name}` has been {past_tense}.",
+            color=embed_color,
+        )
+        result_embed.set_footer(text="Returning to the management panel…")
+
+        for item in self.children:
+            item.disabled = True
+
+        try:
+            await self.manager_message.edit(embed=result_embed, view=self)
+        except Exception:
+            pass
+        self.stop()
+
+        import asyncio
+        await asyncio.sleep(2)
+        manager = _ChannelManagerView(self.ctx)
+        manager.message = self.manager_message
+        try:
+            await self.manager_message.edit(embed=manager.build_embed(), view=manager)
+        except Exception:
+            pass
+
+    @discord.ui.button(label="Lock", style=discord.ButtonStyle.red, emoji="🔒", row=1)
+    async def lock_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await self._apply_restriction(
+            interaction,
+            send_messages=False,
+            action_label="🔒 Lock",
+            past_tense="locked (send messages disabled for @everyone)",
+            embed_color=discord.Color.red(),
+        )
+
+    @discord.ui.button(label="Unlock", style=discord.ButtonStyle.green, emoji="🔓", row=1)
+    async def unlock_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await self._apply_restriction(
+            interaction,
+            send_messages=True,
+            action_label="🔓 Unlock",
+            past_tense="unlocked (send messages restored for @everyone)",
+            embed_color=discord.Color.green(),
+        )
+
+    @discord.ui.button(label="Archive", style=discord.ButtonStyle.grey, emoji="📁", row=1)
+    async def archive_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await self._apply_restriction(
+            interaction,
+            send_messages=False,
+            action_label="📁 Archive",
+            past_tense="archived (read-only)",
+            embed_color=discord.Color.greyple(),
+        )
+
+    @discord.ui.button(label="Unarchive", style=discord.ButtonStyle.grey, emoji="📂", row=1)
+    async def unarchive_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await self._apply_restriction(
+            interaction,
+            send_messages=True,
+            action_label="📂 Unarchive",
+            past_tense="unarchived (send messages restored for @everyone)",
+            embed_color=discord.Color.green(),
+        )
+
+    @discord.ui.button(label="↩️ Back", style=discord.ButtonStyle.grey, row=2)
+    async def back_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        manager = _ChannelManagerView(self.ctx)
+        manager.message = self.manager_message
+        await interaction.response.edit_message(embed=manager.build_embed(), view=manager)
+        self.stop()
+
+    # ------------------------------------------------------------------
+    # Timeout
+    # ------------------------------------------------------------------
+
+    async def on_timeout(self):
+        for item in self.children:
+            item.disabled = True
+        try:
+            await self.manager_message.edit(content="Panel timed out.", view=self)
+        except Exception:
+            pass
+
+
+# =====================================================================
+# Shared Select components
+# =====================================================================
+
+class _ChannelSelect(discord.ui.Select):
+    """Generic channel select used by Delete and Restrict sub-panels."""
+
+    def __init__(self, options: list[discord.SelectOption], parent_view, *, placeholder: str):
+        super().__init__(
+            placeholder=placeholder,
+            min_values=1, max_values=1,
+            options=options,
+            row=0,
+        )
+        self._parent = parent_view
+
+    async def callback(self, interaction: discord.Interaction):
+        self._parent.selected_channel_id = int(self.values[0])
+        # Resolve the display name from the options list
+        chosen_opt = next((o for o in self.options if o.value == self.values[0]), None)
+        self._parent.selected_channel_name = chosen_opt.label if chosen_opt else self.values[0]
+        try:
+            await interaction.response.edit_message(
+                embed=self._parent.build_embed(), view=self._parent)
+        except discord.HTTPException:
+            if not interaction.response.is_done():
+                await interaction.response.defer()
+
+
 class _NameSelect(discord.ui.Select):
-    def __init__(self, presets: list[str], view: _ChannelCreatorView):
+    """Name preset picker used by _CreateSubView."""
+
+    def __init__(self, presets: list[str], view):
         options = [discord.SelectOption(label=p, value=p) for p in presets]
         super().__init__(
             placeholder="Pick a channel name…",
@@ -530,14 +1131,16 @@ class _NameSelect(discord.ui.Select):
         self._parent.chosen_name = self.values[0]
         try:
             await interaction.response.edit_message(
-                embed=self._parent._build_embed(), view=self._parent)
+                embed=self._parent.build_embed(), view=self._parent)
         except discord.HTTPException:
             if not interaction.response.is_done():
                 await interaction.response.defer()
 
 
 class _CategorySelect(discord.ui.Select):
-    def __init__(self, options: list[discord.SelectOption], view: _ChannelCreatorView):
+    """Category picker used by _CreateSubView."""
+
+    def __init__(self, options: list[discord.SelectOption], view):
         super().__init__(
             placeholder="Pick a category…",
             min_values=1, max_values=1,
@@ -550,7 +1153,7 @@ class _CategorySelect(discord.ui.Select):
         self._parent.chosen_cat = self.values[0]
         try:
             await interaction.response.edit_message(
-                embed=self._parent._build_embed(), view=self._parent)
+                embed=self._parent.build_embed(), view=self._parent)
         except discord.HTTPException:
             if not interaction.response.is_done():
                 await interaction.response.defer()
@@ -563,7 +1166,7 @@ class _CustomNameModal(discord.ui.Modal, title="Custom Channel Name"):
         max_length=100,
     )
 
-    def __init__(self, view: _ChannelCreatorView):
+    def __init__(self, view: _CreateSubView):
         super().__init__()
         self._view = view
 
@@ -571,14 +1174,14 @@ class _CustomNameModal(discord.ui.Modal, title="Custom Channel Name"):
         name = self.channel_name.value.strip().lower().replace(" ", "-")
         self._view.chosen_name = name
         await interaction.response.defer()
-        if self._view.message:
-            await self._view.message.edit(
-                embed=self._view._build_embed(), view=self._view)
+        if self._view.manager_message:
+            await self._view.manager_message.edit(
+                embed=self._view.build_embed(), view=self._view)
 
 
-# -------------------
+# =====================================================================
 # Cog Setup
-# -------------------
+# =====================================================================
 
 async def setup(bot):
     await bot.add_cog(ChannelCog(bot))

--- a/disbot/cogs/cleanup_cog.py
+++ b/disbot/cogs/cleanup_cog.py
@@ -3,21 +3,16 @@ import discord
 from discord.ext import commands
 import logging
 import asyncio
-import json
-import os
 import config as _config
+from utils import db
 
 class Cleanup(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.logger = logging.getLogger(__name__)
 
-        self.prohibited_words_file = os.path.join(os.path.dirname(__file__), "../data/json/prohibited_words.json")
-        self.prohibited_words = self.load_prohibited_words()
-        self.prohibited_patterns = [
-            re.compile(rf'\b{re.escape(word)}\b', re.IGNORECASE)
-            for word in self.prohibited_words
-        ]
+        self.prohibited_words = []
+        self.prohibited_patterns = []
 
         self.command_prefixes = ['?', '!']
         self.command_pattern = re.compile(
@@ -27,21 +22,15 @@ class Cleanup(commands.Cog):
 
         self.whitelisted_channels = _config.CLEANUP_WHITELIST_CHANNELS
 
-    def load_prohibited_words(self):
-        try:
-            with open(self.prohibited_words_file, 'r') as f:
-                return json.load(f)
-        except (FileNotFoundError, json.JSONDecodeError):
-            self.logger.info("No prohibited words file found. Starting with an empty list.")
-            return []
+    async def cog_load(self):
+        await self._reload_words()
 
-    def save_prohibited_words(self):
-        try:
-            os.makedirs(os.path.dirname(self.prohibited_words_file), exist_ok=True)
-            with open(self.prohibited_words_file, 'w') as f:
-                json.dump(self.prohibited_words, f, indent=4)
-        except Exception as e:
-            self.logger.error(f"Error saving prohibited words: {e}")
+    async def _reload_words(self):
+        self.prohibited_words = await db.get_prohibited_words(0)
+        self.prohibited_patterns = [
+            re.compile(rf'\b{re.escape(word)}\b', re.IGNORECASE)
+            for word in self.prohibited_words
+        ]
 
     async def remove_unwanted_message(self, message):
         """Deletes the message if it is a command in a non-whitelisted channel or contains prohibited content."""
@@ -127,38 +116,53 @@ class Cleanup(commands.Cog):
             await ctx.message.delete()
             await confirmation_msg.delete()
 
-    @commands.command(name='addword')
+    @commands.group(name='word', invoke_without_command=True)
     @commands.has_permissions(administrator=True)
-    async def add_prohibited_word(self, ctx, *, word: str):
+    async def word_cmd(self, ctx):
+        """Manage prohibited words. Subcommands: add, remove, list."""
+        words = self.prohibited_words
+        if words:
+            word_list = ', '.join(f'`{w}`' for w in sorted(words))
+            await ctx.send(f"Prohibited words: {word_list}", delete_after=15)
+        else:
+            await ctx.send("No prohibited words are currently set.", delete_after=10)
+
+    @word_cmd.command(name='add')
+    @commands.has_permissions(administrator=True)
+    async def word_add(self, ctx, *, word: str):
         """Adds a word to the prohibited words list."""
         word = word.lower()
-        if word in self.prohibited_words:
-            await ctx.send(f"The word '{word}' is already in the prohibited list.", delete_after=5)
-        else:
-            self.prohibited_words.append(word)
-            self.prohibited_patterns.append(
-                re.compile(rf'\b{re.escape(word)}\b', re.IGNORECASE)
-            )
-            self.save_prohibited_words()
+        added = await db.add_prohibited_word(0, word)
+        if added:
+            await self._reload_words()
             await ctx.send(f"Added '{word}' to the prohibited words list.", delete_after=5)
             self.logger.info(f"Added prohibited word: {word}")
+        else:
+            await ctx.send(f"The word '{word}' is already in the prohibited list.", delete_after=5)
 
-    @commands.command(name='removeword')
+    @word_cmd.command(name='remove')
     @commands.has_permissions(administrator=True)
-    async def remove_prohibited_word(self, ctx, *, word: str):
+    async def word_remove(self, ctx, *, word: str):
         """Removes a word from the prohibited words list."""
         word = word.lower()
-        if word in self.prohibited_words:
-            self.prohibited_words.remove(word)
-            self.prohibited_patterns = [
-                re.compile(rf'\b{re.escape(w)}\b', re.IGNORECASE)
-                for w in self.prohibited_words
-            ]
-            self.save_prohibited_words()
+        removed = await db.remove_prohibited_word(0, word)
+        if removed:
+            await self._reload_words()
             await ctx.send(f"Removed '{word}' from the prohibited words list.", delete_after=5)
             self.logger.info(f"Removed prohibited word: {word}")
         else:
             await ctx.send(f"The word '{word}' is not in the prohibited list.", delete_after=5)
+
+    @word_cmd.command(name='list')
+    @commands.has_permissions(administrator=True)
+    async def word_list(self, ctx):
+        """Shows all prohibited words."""
+        words = self.prohibited_words
+        if words:
+            word_list = ', '.join(f'`{w}`' for w in sorted(words))
+            await ctx.send(f"Prohibited words: {word_list}", delete_after=15)
+        else:
+            await ctx.send("No prohibited words are currently set.", delete_after=10)
 
 async def setup(bot):
     await bot.add_cog(Cleanup(bot))

--- a/disbot/cogs/counting_cog.py
+++ b/disbot/cogs/counting_cog.py
@@ -1,9 +1,8 @@
 import discord
 from discord.ext import commands
-import json
-import os
 import logging
 import asyncio
+from utils import db
 from datetime import datetime
 import re
 import random
@@ -21,13 +20,8 @@ class CountingCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.logger = logger
-        self.data_file = os.path.join(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-            "data", "count_data.json"
-        )
         self.lock = asyncio.Lock()
         self.count_data = {}
-        self.load_data()
 
         # Precompile regex for performance
         self.number_pattern = re.compile(r'\d+')
@@ -158,29 +152,17 @@ class CountingCog(commands.Cog):
             'and': '+',  # Sometimes 'and' is used in numbers
         }
 
-    def load_data(self):
-        """Load counting data from a JSON file."""
-        if os.path.exists(self.data_file):
-            try:
-                with open(self.data_file, 'r') as f:
-                    self.count_data = json.load(f)
-                self.logger.info("Counting data loaded successfully.")
-            except json.JSONDecodeError:
-                self.logger.error(f"JSON decode error in {self.data_file}. Initializing empty data.")
-                self.count_data = {}
-        else:
-            self.count_data = {}
-            self.save_data()
-            self.logger.info("No existing data file found. Created new data file.")
+    async def cog_load(self):
+        """Load counting state for all guilds from the database."""
+        for guild in self.bot.guilds:
+            self.count_data[str(guild.id)] = await db.get_counting_state(guild.id)
 
-    def save_data(self):
-        """Save counting data to a JSON file."""
+    async def _save_guild(self, guild_id_str: str):
         try:
-            with open(self.data_file, 'w') as f:
-                json.dump(self.count_data, f, indent=4)
-            self.logger.info("Counting data saved successfully.")
-        except Exception as e:
-            self.logger.error(f"Failed to save data: {e}")
+            guild_id = int(guild_id_str)
+            await db.set_counting_state(guild_id, self.count_data.get(guild_id_str, {}))
+        except Exception:
+            pass
 
     # --------------------------------------------
     # Permission Helpers
@@ -314,7 +296,7 @@ class CountingCog(commands.Cog):
                 channel_config['prime_numbers'] = []  # Optional: Track prime numbers if needed
 
             self.count_data[guild_id]['channels'][channel_id] = channel_config
-            self.save_data()
+            asyncio.ensure_future(self._save_guild(guild_id))
 
         await ctx.send(f"Started a **{mode.capitalize()}** counting match in {channel.mention}!", delete_after=10)
 
@@ -346,7 +328,7 @@ class CountingCog(commands.Cog):
 
             # Remove channel data
             del self.count_data[guild_id]['channels'][channel_id]
-            self.save_data()
+            asyncio.ensure_future(self._save_guild(guild_id))
 
         await ctx.send(f"Ended and deleted the counting match in {channel.name}.", delete_after=10)
 
@@ -381,7 +363,7 @@ class CountingCog(commands.Cog):
             if mode == 'random':
                 rand_range = channel_data.get('random_range', [1, 3])
                 channel_data['next_expected'] = start + random.randint(*rand_range)
-            self.save_data()
+            asyncio.ensure_future(self._save_guild(guild_id))
 
         await ctx.send(f"The count has been reset in {channel.mention}.", delete_after=10)
 
@@ -404,7 +386,7 @@ class CountingCog(commands.Cog):
 
             channel_data = self.count_data[guild_id]['channels'][channel_id]
             channel_data['taking_turns'] = not channel_data.get('taking_turns', False)
-            self.save_data()
+            asyncio.ensure_future(self._save_guild(guild_id))
 
             status = "enabled" if channel_data['taking_turns'] else "disabled"
         await ctx.send(f"'Taking turns' mode has been {status} in {channel.mention}.", delete_after=10)
@@ -515,7 +497,7 @@ class CountingCog(commands.Cog):
             try:
                 skip_numbers = [int(num.strip()) for num in numbers.split(',')]
                 channel_data['skip_numbers'] = skip_numbers
-                self.save_data()
+                asyncio.ensure_future(self._save_guild(guild_id))
                 await ctx.send(f"Skip numbers updated to: {skip_numbers}", delete_after=10)
             except ValueError:
                 await ctx.send("Invalid input. Please provide a comma-separated list of integers.", delete_after=10)
@@ -541,7 +523,7 @@ class CountingCog(commands.Cog):
 
             channel_data = self.count_data[guild_id]['channels'][channel_id]
             channel_data['reset_on_wrong_count'] = not channel_data.get('reset_on_wrong_count', False)
-            self.save_data()
+            asyncio.ensure_future(self._save_guild(guild_id))
 
             status = "enabled" if channel_data['reset_on_wrong_count'] else "disabled"
         await ctx.send(f"'Reset on wrong count' has been {status} in {channel.mention}.", delete_after=10)
@@ -619,7 +601,7 @@ class CountingCog(commands.Cog):
                     channel_data['last_user'] = None
                     channel_data['leaderboard'] = {}
                     channel_data['last_count_time'] = datetime.utcnow().timestamp()
-                    self.save_data()
+                    asyncio.ensure_future(self._save_guild(guild_id))
 
                     await message.channel.send(
                         f"{message.author.mention}, incorrect count! The count has been reset.",
@@ -683,7 +665,7 @@ class CountingCog(commands.Cog):
             leaderboard = channel_data.get('leaderboard', {})
             leaderboard[user_id] = leaderboard.get(user_id, 0) + 1
             channel_data['leaderboard'] = leaderboard
-            self.save_data()
+            asyncio.ensure_future(self._save_guild(guild_id))
 
         # Add reaction to acknowledge correct count
         try:

--- a/disbot/cogs/deathmatch_cog.py
+++ b/disbot/cogs/deathmatch_cog.py
@@ -4,41 +4,15 @@ import discord
 from discord.ext import commands
 from discord.ext.commands import cooldown, BucketType
 import asyncio
-import json
-import os
 import random
 
-LEADERBOARD_FILE = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-    "data", "leaderboard.json",
-)
+from utils import db
 
 class Deathmatch(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         # Active duels: {(user1_id, user2_id): Duel}
         self.active_duels = {}
-        # Load or initialize leaderboard
-        self.leaderboard = self.load_leaderboard()
-
-    def load_leaderboard(self):
-        # Ensure the 'data/' directory exists
-        os.makedirs(os.path.dirname(LEADERBOARD_FILE), exist_ok=True)
-        
-        if not os.path.exists(LEADERBOARD_FILE):
-            with open(LEADERBOARD_FILE, 'w') as f:
-                json.dump({}, f)
-            return {}
-        with open(LEADERBOARD_FILE, 'r') as f:
-            try:
-                return json.load(f)
-            except json.JSONDecodeError:
-                # Handle corrupted JSON file
-                return {}
-
-    def save_leaderboard(self):
-        with open(LEADERBOARD_FILE, 'w') as f:
-            json.dump(self.leaderboard, f, indent=4)
 
     class Duel:
         def __init__(self, player1, player2):
@@ -113,8 +87,8 @@ class Deathmatch(commands.Cog):
 
         def check(reaction, user):
             return (
-                user == opponent and 
-                str(reaction.emoji) in ["✅", "❌"] and 
+                user == opponent and
+                str(reaction.emoji) in ["✅", "❌"] and
                 reaction.message.id == message.id
             )
 
@@ -138,23 +112,23 @@ class Deathmatch(commands.Cog):
     @commands.command(name='dm_leaderboard', aliases=['dm_lb', 'board'])
     async def leaderboard_cmd(self, ctx):
         """Display the Deathmatch leaderboard."""
-        if not self.leaderboard:
+        rows = await db.get_deathmatch_leaderboard()
+        if not rows:
             await ctx.send("No battles have been recorded yet.")
             return
 
-        sorted_lb = sorted(self.leaderboard.items(), key=lambda x: x[1]['wins'], reverse=True)
         embed = discord.Embed(
             title="Deathmatch Leaderboard",
             description="Top players by wins",
             color=discord.Color.gold(),
             timestamp=ctx.message.created_at
         )
-        for idx, (user_id, stats) in enumerate(sorted_lb, start=1):
-            user = self.bot.get_user(int(user_id))
+        for idx, row in enumerate(rows, start=1):
+            user = self.bot.get_user(row['user_id'])
             if user:
                 embed.add_field(
                     name=f"{idx}. {user.name}",
-                    value=f"Wins: {stats['wins']} | Losses: {stats['losses']}",
+                    value=f"Wins: {row['wins']} | Losses: {row['losses']}",
                     inline=False
                 )
         await ctx.send(embed=embed)
@@ -189,8 +163,8 @@ class Deathmatch(commands.Cog):
 
             def check(m):
                 return (
-                    m.author == current_player and 
-                    m.channel == ctx.channel and 
+                    m.author == current_player and
+                    m.channel == ctx.channel and
                     m.content.lower() in ['attack', 'defend']
                 )
 
@@ -199,7 +173,7 @@ class Deathmatch(commands.Cog):
                 msg = await self.bot.wait_for('message', check=check, timeout=60.0)
             except asyncio.TimeoutError:
                 await ctx.send(f"{current_player.mention} took too long to respond. {opponent.mention} wins by default!")
-                self.update_leaderboard(winner=opponent.id, loser=current_player.id)
+                await self.update_leaderboard(winner_id=opponent.id, loser_id=current_player.id)
                 duel.is_over = True
                 del self.active_duels[tuple(sorted([duel.player1.id, duel.player2.id]))]
                 return
@@ -218,11 +192,11 @@ class Deathmatch(commands.Cog):
             # Check for win condition
             if duel.player1_hp <= 0:
                 await ctx.send(f"{duel.player1.mention} has been defeated! {duel.player2.mention} wins!")
-                self.update_leaderboard(winner=duel.player2.id, loser=duel.player1.id)
+                await self.update_leaderboard(winner_id=duel.player2.id, loser_id=duel.player1.id)
                 duel.is_over = True
             elif duel.player2_hp <= 0:
                 await ctx.send(f"{duel.player2.mention} has been defeated! {duel.player1.mention} wins!")
-                self.update_leaderboard(winner=duel.player1.id, loser=duel.player2.id)
+                await self.update_leaderboard(winner_id=duel.player1.id, loser_id=duel.player2.id)
                 duel.is_over = True
             else:
                 # Switch turn
@@ -239,17 +213,10 @@ class Deathmatch(commands.Cog):
             timestamp=ctx.message.created_at
         )
         await duel_message.edit(embed=embed)
-        self.save_leaderboard()
 
-    def update_leaderboard(self, winner_id, loser_id):
+    async def update_leaderboard(self, winner_id, loser_id):
         """Update the leaderboard with the duel results."""
-        if str(winner_id) not in self.leaderboard:
-            self.leaderboard[str(winner_id)] = {"wins": 0, "losses": 0}
-        if str(loser_id) not in self.leaderboard:
-            self.leaderboard[str(loser_id)] = {"wins": 0, "losses": 0}
-
-        self.leaderboard[str(winner_id)]['wins'] += 1
-        self.leaderboard[str(loser_id)]['losses'] += 1
+        await db.update_deathmatch(winner_id, loser_id)
 
     @challenge.error
     async def challenge_error(self, ctx, error):

--- a/disbot/cogs/economy_cog.py
+++ b/disbot/cogs/economy_cog.py
@@ -5,7 +5,8 @@ import discord
 from discord.ext import commands
 import logging
 from utils import db
-from utils.helpers import CogMenuView
+from utils.helpers import CogMenuView, post_log_embed
+from utils.cooldowns import check_cooldown, format_remaining
 
 logger = logging.getLogger("bot")
 
@@ -113,17 +114,7 @@ async def _available_jobs(user_id: int, guild_id: int) -> list[str]:
     ]
 
 
-async def post_economy_log(bot: commands.Bot, guild_id: int, embed: discord.Embed) -> None:
-    """Post an economy event embed to the guild's configured log channel."""
-    cid = await db.get_setting(guild_id, "economy_log_channel", "")
-    if not cid:
-        return
-    ch = bot.get_channel(int(cid))
-    if ch:
-        try:
-            await ch.send(embed=embed)
-        except Exception:
-            pass
+# post_economy_log is now helpers.post_log_embed — imported above
 
 
 # ---------------------------------------------------------------------------
@@ -213,11 +204,10 @@ class EconomyCog(commands.Cog):
         last = row["last_daily"]
         streak = row["daily_streak"]
 
-        if now - last < _DAILY_COOLDOWN:
-            remaining = _DAILY_COOLDOWN - (now - last)
-            h, m = divmod(remaining // 60, 60)
+        on_cd, secs = check_cooldown(last, _DAILY_COOLDOWN)
+        if on_cd:
             await ctx.send(
-                f"⏰ Already claimed today! Come back in **{h}h {m}m**.",
+                f"⏰ Already claimed today! Come back in **{format_remaining(secs)}**.",
                 delete_after=10,
             )
             return
@@ -262,7 +252,7 @@ class EconomyCog(commands.Cog):
             ),
             color=discord.Color.gold(),
         )
-        await post_economy_log(self.bot, gid, log_embed)
+        await post_log_embed(self.bot, gid, log_embed)
 
     # ------------------------------------------------------------------ !work
 
@@ -273,9 +263,9 @@ class EconomyCog(commands.Cog):
         now  = int(time.time())
         row  = await db.get_economy(uid, gid)
 
-        if now - row["last_worked"] < _WORK_COOLDOWN:
-            remaining = (_WORK_COOLDOWN - (now - row["last_worked"])) // 60
-            await ctx.send(f"⏰ You're tired! Rest for **{remaining}m** more.", delete_after=10)
+        on_cd, secs = check_cooldown(row["last_worked"], _WORK_COOLDOWN)
+        if on_cd:
+            await ctx.send(f"⏰ You're tired! Rest for **{format_remaining(secs)}** more.", delete_after=10)
             return
 
         available = await _available_jobs(uid, gid)
@@ -458,10 +448,10 @@ class _JobSelect(discord.ui.Select):
 
         # Re-check cooldown (guard against double-click)
         eco = await db.get_economy(uid, gid)
-        if now - eco["last_worked"] < _WORK_COOLDOWN:
-            remaining = (_WORK_COOLDOWN - (now - eco["last_worked"])) // 60
+        on_cd, secs = check_cooldown(eco["last_worked"], _WORK_COOLDOWN)
+        if on_cd:
             await interaction.response.send_message(
-                f"⏰ Still on cooldown! {remaining}m left.", ephemeral=True)
+                f"⏰ Still on cooldown! {format_remaining(secs)} left.", ephemeral=True)
             return
 
         times   = await db.get_job_times(uid, gid, job_name)
@@ -502,7 +492,7 @@ class _JobSelect(discord.ui.Select):
             ),
             color=discord.Color.green(),
         )
-        await post_economy_log(self._ctx.bot, gid, log_embed)
+        await post_log_embed(self._ctx.bot, gid, log_embed)
 
 
 # ---------------------------------------------------------------------------
@@ -604,7 +594,7 @@ class _ShopSelect(discord.ui.Select):
             ),
             color=discord.Color.orange(),
         )
-        await post_economy_log(self._ctx.bot, gid, log_embed)
+        await post_log_embed(self._ctx.bot, gid, log_embed)
 
 
 async def setup(bot: commands.Bot):

--- a/disbot/cogs/economy_cog.py
+++ b/disbot/cogs/economy_cog.py
@@ -5,8 +5,19 @@ import discord
 from discord.ext import commands
 import logging
 from utils import db
+from utils.helpers import CogMenuView
 
 logger = logging.getLogger("bot")
+
+_ECONOMY_MENU_COMMANDS: list[tuple[str, str, str]] = [
+    ("economymenu", "!economymenu",              "Show this economy command menu."),
+    ("daily",       "!daily",                    "Claim your daily coin reward (streak-based)."),
+    ("work",        "!work",                     "Pick a job and earn coins + XP (1h cooldown)."),
+    ("balance",     "!balance [@user]",          "Check your or another user's coin balance."),
+    ("shop",        "!shop",                     "Browse and buy items needed for higher-tier jobs."),
+    ("inventory",   "!inventory [@user]",        "View your or another user's inventory."),
+    ("joblist",     "!joblist",                  "See all jobs, requirements, and your mastery."),
+]
 
 _WORK_COOLDOWN  = 3600   # 1 hour between work sessions
 _DAILY_COOLDOWN = 86400  # 24 hours between daily claims
@@ -122,6 +133,13 @@ async def post_economy_log(bot: commands.Bot, guild_id: int, embed: discord.Embe
 class EconomyCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
+
+    @commands.command(name="economymenu")
+    async def economy_menu(self, ctx: commands.Context):
+        """Show a quick-reference menu for all economy commands."""
+        view = CogMenuView(ctx, "💰 Economy Commands", _ECONOMY_MENU_COMMANDS)
+        msg = await ctx.send(embed=view.build_embed(), view=view)
+        view.message = msg
 
     # ------------------------------------------------------------------ events
 

--- a/disbot/cogs/mining_cog.py
+++ b/disbot/cogs/mining_cog.py
@@ -4,33 +4,14 @@ import random
 import json
 import os
 
-DATA_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "data", "json")
-DATA_FILE = os.path.join(DATA_DIR, "mining_data.json")
-RECIPES_FILE = os.path.join(DATA_DIR, "recipes.json")
+from utils import db
+
+RECIPES_FILE = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "data", "json", "recipes.json")
 
 
 #
 # ===== HELPER FUNCTIONS (Outside the Cog) =====
 #
-
-def load_data():
-    """Loads mining data from the JSON file or creates an empty dictionary if missing/invalid."""
-    if not os.path.exists(DATA_FILE):
-        return {}
-    try:
-        with open(DATA_FILE, "r", encoding="utf-8") as f:
-            data = json.load(f)
-            return data if isinstance(data, dict) else {}
-    except (json.JSONDecodeError, ValueError):
-        return {}
-
-
-def save_data(data):
-    """Saves the given inventory data to mining_data.json, ensuring the directory exists."""
-    os.makedirs(os.path.dirname(DATA_FILE), exist_ok=True)
-    with open(DATA_FILE, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=4)
-
 
 def load_recipes():
     """
@@ -79,28 +60,17 @@ def load_recipes():
 class MiningCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-        self.mining_data = load_data()
         self.recipes = load_recipes()
 
     #
     # ====== INTERNAL HELPER METHOD ======
     #
-    def update_inventory(self, user_id, item, amount=1, save=True):
+    async def update_inventory(self, user_id, item, amount=1):
         """
         Updates a user's inventory by 'amount' of 'item'.
-        Prevents negative totals.
-        The optional 'save' parameter reduces frequent file writes if set to False.
+        Delegates to the DB helper which clamps to 0 automatically.
         """
-        user_id = str(user_id)
-        if user_id not in self.mining_data:
-            self.mining_data[user_id] = {}
-
-        self.mining_data[user_id][item] = self.mining_data[user_id].get(item, 0) + amount
-        if self.mining_data[user_id][item] < 0:
-            self.mining_data[user_id][item] = 0
-
-        if save:
-            save_data(self.mining_data)
+        await db.update_mining_item(str(user_id), item, amount)
 
     #
     # ====== VIEW FOR MINING BUTTONS ======
@@ -132,14 +102,14 @@ class MiningCog(commands.Cog):
             await interaction.response.defer()
 
             user_id = str(self.user_id)
-            pickaxe_bonus = 2 if self.cog.mining_data.get(user_id, {}).get("pickaxe", 0) > 0 else 1
+            inventory = await db.get_mining_inventory(user_id)
+            pickaxe_bonus = 2 if inventory.get("pickaxe", 0) > 0 else 1
             # Weighted random resource
             ores = {"stone": 3, "iron": 2, "gold": 1, "diamond": 0.5}
             found = random.choices(list(ores.keys()), weights=ores.values(), k=1)[0]
             amount = random.randint(1, 3) * pickaxe_bonus
 
-            self.cog.update_inventory(user_id, found, amount, save=False)
-            save_data(self.cog.mining_data)
+            await self.cog.update_inventory(user_id, found, amount)
 
             new_content = f"{interaction.user.mention} mined {amount}x **{found}** by going {direction}!"
             await interaction.message.edit(
@@ -168,17 +138,17 @@ class MiningCog(commands.Cog):
     async def chop(self, ctx):
         """Chop wood. If you have an 'axe', you'll collect double."""
         user_id = str(ctx.author.id)
-        inventory = self.mining_data.get(user_id, {})
+        inventory = await db.get_mining_inventory(user_id)
         multiplier = 2 if inventory.get("axe", 0) > 0 else 1
         wood_amount = random.randint(1, 3) * multiplier
-        self.update_inventory(ctx.author.id, "wood", wood_amount)
+        await self.update_inventory(ctx.author.id, "wood", wood_amount)
         await ctx.send(f"{ctx.author.mention} chopped wood and collected {wood_amount}x wood!")
 
     @commands.command()
     async def inventory(self, ctx):
         """Displays your inventory."""
         user_id = str(ctx.author.id)
-        inventory = self.mining_data.get(user_id, {})
+        inventory = await db.get_mining_inventory(user_id)
 
         if not inventory:
             return await ctx.send("Your inventory is empty. Start mining with `!mine`!")
@@ -195,7 +165,7 @@ class MiningCog(commands.Cog):
     async def stats(self, ctx):
         """Shows your total items and number of unique items."""
         user_id = str(ctx.author.id)
-        inventory = self.mining_data.get(user_id, {})
+        inventory = await db.get_mining_inventory(user_id)
         total_items = sum(inventory.values())
         unique_items = len(inventory)
 
@@ -207,15 +177,14 @@ class MiningCog(commands.Cog):
     @commands.command()
     async def leaderboard(self, ctx):
         """Shows top miners by total item count."""
-        if not self.mining_data:
+        rows = await db.get_all_mining_totals()
+        if not rows:
             return await ctx.send("No data available yet!")
 
-        sorted_users = sorted(self.mining_data.items(), key=lambda x: sum(x[1].values()), reverse=True)
         embed = discord.Embed(title="Top Miners", color=discord.Color.gold())
 
-        for i, (user, inventory) in enumerate(sorted_users[:10], 1):
-            total = sum(inventory.values())
-            embed.add_field(name=f"{i}. <@{user}>", value=f"{total} items", inline=False)
+        for i, (user_id, total) in enumerate(rows, 1):
+            embed.add_field(name=f"{i}. <@{user_id}>", value=f"{total} items", inline=False)
 
         await ctx.send(embed=embed)
 
@@ -234,7 +203,7 @@ class MiningCog(commands.Cog):
                 return await ctx.invoke(self.bot.get_command("buildlist"))
 
             user_id = str(ctx.author.id)
-            inventory = self.mining_data.get(user_id, {})
+            inventory = await db.get_mining_inventory(user_id)
 
             structure_lower = structure.lower()
             required_items = self.recipes.get(structure_lower)
@@ -249,9 +218,8 @@ class MiningCog(commands.Cog):
 
             # Subtract cost and give the user the new buildable item
             for item, amount_needed in required_items.items():
-                self.update_inventory(ctx.author.id, item, -amount_needed, save=False)
-            self.update_inventory(ctx.author.id, structure_lower, 1, save=False)
-            save_data(self.mining_data)
+                await self.update_inventory(ctx.author.id, item, -amount_needed)
+            await self.update_inventory(ctx.author.id, structure_lower, 1)
 
             await ctx.send(f"{ctx.author.mention} successfully built a **{structure}**!")
         except Exception as e:
@@ -288,7 +256,7 @@ class MiningCog(commands.Cog):
         Lists only what the user can currently build based on their inventory.
         """
         user_id = str(ctx.author.id)
-        inventory = self.mining_data.get(user_id, {})
+        inventory = await db.get_mining_inventory(user_id)
 
         can_build = []
         for structure_name, requirements in self.recipes.items():
@@ -323,13 +291,13 @@ class MiningCog(commands.Cog):
         result = random.choice(outcomes)
 
         if "found 1 gold" in result:
-            self.update_inventory(user_id, "gold", 1)
+            await self.update_inventory(user_id, "gold", 1)
         elif "1 diamond" in result:
-            self.update_inventory(user_id, "diamond", 1)
+            await self.update_inventory(user_id, "diamond", 1)
         elif "lost 2 stone" in result:
-            self.update_inventory(user_id, "stone", -2)
+            await self.update_inventory(user_id, "stone", -2)
         elif "3 wood" in result:
-            self.update_inventory(user_id, "wood", 3)
+            await self.update_inventory(user_id, "wood", 3)
 
         await ctx.send(f"{ctx.author.mention} {result}")
 
@@ -342,7 +310,8 @@ class MiningCog(commands.Cog):
         user_id = str(ctx.author.id)
         item = item.lower()
 
-        if self.mining_data.get(user_id, {}).get(item, 0) < 1:
+        inventory = await db.get_mining_inventory(user_id)
+        if inventory.get(item, 0) < 1:
             return await ctx.send(f"You don't have **{item}** to use.")
 
         if item == "torch":
@@ -352,7 +321,7 @@ class MiningCog(commands.Cog):
         else:
             message = f"You used **{item}**, but nothing special happened."
 
-        self.update_inventory(user_id, item, -1)
+        await self.update_inventory(user_id, item, -1)
         await ctx.send(f"{ctx.author.mention} {message}")
 
     #
@@ -365,9 +334,7 @@ class MiningCog(commands.Cog):
         if not ctx.author.guild_permissions.administrator:
             return await ctx.send("You don't have permission to do that.")
 
-        user_id = str(member.id)
-        self.mining_data[user_id] = {}
-        save_data(self.mining_data)
+        await db.set_mining_inventory(str(member.id), {})
         await ctx.send(f"{member.name}'s inventory has been reset.")
 
     @commands.command()
@@ -377,7 +344,7 @@ class MiningCog(commands.Cog):
             return await ctx.send("You don't have permission to do that.")
 
         item = item.lower()
-        self.update_inventory(member.id, item, amount)
+        await db.update_mining_item(str(member.id), item, amount)
         await ctx.send(f"Gave {amount}x **{item}** to {member.name}.")
 
 

--- a/disbot/cogs/moderation_cog.py
+++ b/disbot/cogs/moderation_cog.py
@@ -5,13 +5,31 @@ from discord import Member
 from datetime import timedelta
 import logging
 from utils import db
+from utils.helpers import CogMenuView
 
 logger = logging.getLogger("bot")
+
+_MOD_MENU_COMMANDS: list[tuple[str, str, str]] = [
+    ("modmenu",  "!modmenu",                              "Show this moderation command menu."),
+    ("warn",     "!warn <@user> [reason]",                "Issue a warning to a member."),
+    ("timeout",  "!timeout <@user> <minutes> [reason]",   "Temporarily mute a member."),
+    ("kick",     "!kick <@user> [reason]",                "Kick a member from the server."),
+    ("ban",      "!ban <@user> [reason]",                 "Ban a member from the server."),
+    ("unban",    "!unban <user#0000>",                    "Unban a previously banned user."),
+]
 
 
 class ModerationCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
+
+    @commands.command(name="modmenu")
+    @commands.has_permissions(moderate_members=True)
+    async def mod_menu(self, ctx):
+        """Show a quick-reference menu for all moderation commands."""
+        view = CogMenuView(ctx, "🔨 Moderation Commands", _MOD_MENU_COMMANDS)
+        msg = await ctx.send(embed=view.build_embed(), view=view)
+        view.message = msg
 
     async def log_action(self, ctx, action: str, member, reason: str = "No reason provided"):
         await db.log_mod_action(ctx.guild.id, action, member.id, ctx.author.id, reason)

--- a/disbot/cogs/proof_channel_cog.py
+++ b/disbot/cogs/proof_channel_cog.py
@@ -1,132 +1,122 @@
+from __future__ import annotations
 import discord
 from discord.ext import commands
 import logging
 import asyncio
 
-# Retrieve the logger from the main bot
-logger = logging.getLogger('discord_bot.prize_cog')
+logger = logging.getLogger("discord_bot.prize_cog")
 
 
 class ProofChannelCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
+        # track timed prize tasks so they can be cancelled if needed
+        self._timed_tasks: dict[int, asyncio.Task] = {}
 
-    # Helper: Retrieve the proof channel
-    def get_proof_channel(self, guild):
-        """Find the #proof channel in the guild."""
-        return discord.utils.get(guild.text_channels, name='proof')
+    def get_proof_channel(self, guild: discord.Guild) -> discord.TextChannel | None:
+        return discord.utils.get(guild.text_channels, name="proof")
 
-    # Helper: Lock the proof channel for everyone except the winner
-    async def lock_channel_for_winner(self, proof_channel, winner):
-        """Lock the proof channel for everyone except the winner."""
+    async def _lock_for_winner(self, proof_channel: discord.TextChannel, winner: discord.Member) -> None:
         overwrites = {
             proof_channel.guild.default_role: discord.PermissionOverwrite(view_channel=False),
             winner: discord.PermissionOverwrite(view_channel=True, send_messages=True),
-            proof_channel.guild.me: discord.PermissionOverwrite(view_channel=True)
+            proof_channel.guild.me: discord.PermissionOverwrite(view_channel=True),
         }
         await proof_channel.edit(overwrites=overwrites)
-        logger.info(f"Proof channel locked for winner: {winner.display_name}")
+        logger.info("Proof channel locked for winner: %s", winner.display_name)
 
-    # Helper: Unlock the proof channel after prize claim
-    async def unlock_channel_after_claim(self, proof_channel):
-        """Unlock the proof channel for everyone (read-only)."""
+    async def _unlock(self, proof_channel: discord.TextChannel) -> None:
         overwrites = {
             proof_channel.guild.default_role: discord.PermissionOverwrite(view_channel=True, send_messages=False),
-            proof_channel.guild.me: discord.PermissionOverwrite(view_channel=True)
+            proof_channel.guild.me: discord.PermissionOverwrite(view_channel=True),
         }
         await proof_channel.edit(overwrites=overwrites)
-        logger.info("Proof channel unlocked for viewing (read-only).")
+        logger.info("Proof channel unlocked (read-only).")
 
-    # Command: +prize (grant access to the winner)
-    @commands.command(
-        name='+prize',
-        help="Start a prize claim session. Usage: +prize @winner"
-    )
+    @commands.command(name="+prize")
     @commands.has_permissions(manage_channels=True)
     async def start_prize_claim(self, ctx, winner: discord.Member):
-        """Start a prize claim session by locking the proof channel for the winner."""
-        proof_channel = self.get_proof_channel(ctx.guild)
-        if proof_channel:
-            await self.lock_channel_for_winner(proof_channel, winner)
-            await ctx.send(f"{winner.mention} has been granted access to {proof_channel.mention} to claim their prize!", delete_after=10)
-        else:
+        """Grant a winner exclusive access to #proof.  Usage: +prize @winner"""
+        ch = self.get_proof_channel(ctx.guild)
+        if not ch:
             await ctx.send("Channel '#proof' not found. Please create one first.", delete_after=10)
+            return
+        await self._lock_for_winner(ch, winner)
+        await ctx.send(f"{winner.mention} has been granted access to {ch.mention}!", delete_after=10)
 
-    # Command: -prize (revoke access and make the channel read-only)
-    @commands.command(
-        name='-prize',
-        help="End a prize claim session and lock the proof channel. Usage: -prize"
-    )
+    @commands.command(name="-prize")
     @commands.has_permissions(manage_channels=True)
     async def end_prize_claim(self, ctx):
-        """End the prize claim session and lock the proof channel (read-only for everyone)."""
-        proof_channel = self.get_proof_channel(ctx.guild)
-        if proof_channel:
-            await self.unlock_channel_after_claim(proof_channel)
-            await ctx.send(f"{proof_channel.mention} is now visible to everyone (read-only).", delete_after=10)
-        else:
-            await ctx.send("Channel '#proof' not found. Please create one first.", delete_after=10)
+        """End the prize session and make #proof read-only again.  Usage: -prize"""
+        ch = self.get_proof_channel(ctx.guild)
+        if not ch:
+            await ctx.send("Channel '#proof' not found.", delete_after=10)
+            return
+        # Cancel any pending timed task for this guild
+        if task := self._timed_tasks.pop(ctx.guild.id, None):
+            task.cancel()
+        await self._unlock(ch)
+        await ctx.send(f"{ch.mention} is now read-only for everyone.", delete_after=10)
 
-    # Command: prizestatus (check current proof channel status)
-    @commands.command(
-        name='prizestatus',
-        help="Check the current status of the proof channel. Usage: prizestatus"
-    )
+    @commands.command(name="prizestatus")
     @commands.has_permissions(manage_channels=True)
     async def prize_status(self, ctx):
-        """Check the current status of the proof channel."""
-        proof_channel = self.get_proof_channel(ctx.guild)
-        if proof_channel:
-            overwrites = proof_channel.overwrites
-            permissions = self.format_overwrites(overwrites)
-            embed = discord.Embed(
-                title=f"Proof Channel Status - {proof_channel.name}",
-                description=f"Access and permissions for {proof_channel.mention}:",
-                color=discord.Color.green()
-            )
-            embed.add_field(name="Permissions", value=permissions, inline=False)
-            await ctx.send(embed=embed, delete_after=60)
-        else:
-            await ctx.send("Channel '#proof' not found. Please create one first.", delete_after=10)
+        """Show current #proof channel permissions."""
+        ch = self.get_proof_channel(ctx.guild)
+        if not ch:
+            await ctx.send("Channel '#proof' not found.", delete_after=10)
+            return
+        formatted = _format_overwrites(ch.overwrites)
+        embed = discord.Embed(
+            title=f"Proof Channel Status — #{ch.name}",
+            description=formatted,
+            color=discord.Color.green(),
+        )
+        await ctx.send(embed=embed, delete_after=60)
 
-    # Command: timedprize (grant temporary access to the winner)
-    @commands.command(
-        name='timedprize',
-        help="Start a timed prize claim session. Usage: timedprize @winner <duration_in_minutes>"
-    )
+    @commands.command(name="timedprize")
     @commands.has_permissions(manage_channels=True)
     async def start_timed_prize_claim(self, ctx, winner: discord.Member, duration: int):
-        """Start a timed prize claim session for the winner."""
-        proof_channel = self.get_proof_channel(ctx.guild)
-        if proof_channel:
-            await self.lock_channel_for_winner(proof_channel, winner)
-            await ctx.send(f"{winner.mention} has been granted access to {proof_channel.mention} for {duration} minutes to claim their prize!", delete_after=10)
-            
-            # Unlock the channel after the duration expires
+        """Grant timed access to #proof; auto-unlocks after duration minutes.  Usage: timedprize @winner <minutes>"""
+        ch = self.get_proof_channel(ctx.guild)
+        if not ch:
+            await ctx.send("Channel '#proof' not found.", delete_after=10)
+            return
+
+        # Cancel any existing timed task for this guild
+        if old_task := self._timed_tasks.pop(ctx.guild.id, None):
+            old_task.cancel()
+
+        await self._lock_for_winner(ch, winner)
+        await ctx.send(
+            f"{winner.mention} has been granted access to {ch.mention} for **{duration}** minute(s)!",
+            delete_after=10,
+        )
+
+        async def _auto_unlock():
             await asyncio.sleep(duration * 60)
-            await self.unlock_channel_after_claim(proof_channel)
-            await ctx.send(f"Time is up! {proof_channel.mention} is now visible to everyone (read-only).", delete_after=10)
-        else:
-            await ctx.send("Channel '#proof' not found. Please create one first.", delete_after=10)
+            try:
+                await self._unlock(ch)
+                await ctx.send(f"Time is up! {ch.mention} is now read-only again.", delete_after=10)
+            except Exception:
+                pass
+            finally:
+                self._timed_tasks.pop(ctx.guild.id, None)
 
-    # Helper: Format overwrites for display
-    def format_overwrites(self, overwrites):
-        """Format channel permission overwrites into a readable string for embeds."""
-        formatted = ""
-        for target, perms in overwrites.items():
-            if isinstance(target, discord.Role):
-                name = target.name
-            elif isinstance(target, discord.Member):
-                name = target.display_name
-            else:
-                name = "Unknown"
-            allow = ", ".join([perm.replace("_", " ").title() for perm, value in perms if value])
-            deny = ", ".join([perm.replace("_", " ").title() for perm, value in perms if not value])
-            formatted += f"**{name}**\nAllowed: {allow if allow else 'None'}\nDenied: {deny if deny else 'None'}\n\n"
-        return formatted if formatted else "No overwrites."
+        task = asyncio.ensure_future(_auto_unlock())
+        self._timed_tasks[ctx.guild.id] = task
 
 
-# Cog setup function
+def _format_overwrites(overwrites: dict) -> str:
+    lines = []
+    for target, perms in overwrites.items():
+        name = target.name if isinstance(target, discord.Role) else getattr(target, "display_name", "Unknown")
+        allow = ", ".join(p.replace("_", " ").title() for p, v in iter(perms) if v is True)
+        deny  = ", ".join(p.replace("_", " ").title() for p, v in iter(perms) if v is False)
+        lines.append(f"**{name}**\nAllowed: {allow or 'None'}\nDenied: {deny or 'None'}")
+    return "\n\n".join(lines) or "No overwrites."
+
+
 async def setup(bot):
     await bot.add_cog(ProofChannelCog(bot))
-    logger.info("ProofChannelCog has been successfully loaded and added to the bot.")
+    logger.info("ProofChannelCog loaded.")

--- a/disbot/cogs/role_cog.py
+++ b/disbot/cogs/role_cog.py
@@ -4,6 +4,7 @@ from discord.ext import commands, tasks
 from datetime import datetime
 import logging
 from utils import db
+from utils.helpers import normalize_name, CogMenuView
 
 logger = logging.getLogger("bot")
 
@@ -19,6 +20,21 @@ _DEFAULT_THRESHOLDS: list[tuple[str, int]] = [
 ]
 
 SKIP_ROLES = {"Admin"}   # role names that are never auto-assigned / removed
+
+_ROLE_MENU_COMMANDS: list[tuple[str, str, str]] = [
+    ("rolemenu",    "!rolemenu",                         "Show this role command menu."),
+    ("roles",       "!roles",                            "List all server roles with member counts."),
+    ("assignroles", "!assignroles",                      "Manually run time-based role assignment."),
+    ("createrole",  "!createrole <name> [color] [hoist]","Create a new role with optional hex color."),
+    ("deleterole",  "!deleterole <@role>",               "Delete a role from the server."),
+    ("rolecreator", "!rolecreator",                      "Open the interactive role creator UI."),
+    ("rolesettings","!rolesettings",                     "Manage time-based role thresholds (admin UI)."),
+    ("setrole",     "!setrole <days> <role name>",       "Add/update a time-based role threshold."),
+    ("unsetrole",   "!unsetrole <role name>",            "Remove a role from auto-assignment."),
+    ("reactroles",  "!reactroles <msg_id> <emoji> <@role>","Attach a reaction→role mapping to a message."),
+    ("removereactrole","!removereactrole <msg_id> <emoji>","Remove a reaction role binding."),
+    ("listreactroles","!listreactroles",                 "List all active reaction roles in this server."),
+]
 
 
 # ---------------------------------------------------------------------------
@@ -37,6 +53,12 @@ def _parse_color(value: str) -> discord.Color:
     """Parse a hex string like '#ff0000' or 'ff0000' into a discord.Color."""
     value = value.strip().lstrip("#")
     return discord.Color(int(value, 16))
+
+
+def _find_role_normalized(guild: discord.Guild, name: str) -> discord.Role | None:
+    """Case-insensitive, space-insensitive role lookup."""
+    key = normalize_name(name)
+    return discord.utils.find(lambda r: normalize_name(r.name) == key, guild.roles)
 
 
 _COLOR_OPTIONS = [
@@ -87,7 +109,7 @@ class RoleCog(commands.Cog):
         role_map = {row["role_name"]: row["days_required"] for row in thresholds}
         progression = sorted(role_map, key=lambda r: role_map[r])
 
-        admin_role = discord.utils.get(guild.roles, name="Admin")
+        admin_role = _find_role_normalized(guild, "Admin")
         assigned = 0
 
         for member in guild.members:
@@ -106,14 +128,18 @@ class RoleCog(commands.Cog):
                 if days >= role_map[name]:
                     target_name = name
 
-            target_role = discord.utils.get(guild.roles, name=target_name) if target_name else None
+            target_role = _find_role_normalized(guild, target_name) if target_name else None
 
             # Current highest progression role this member holds
             current_highest: str | None = None
             for role in member.roles:
-                if role.name in role_map:
-                    if current_highest is None or progression.index(role.name) > progression.index(current_highest):
-                        current_highest = role.name
+                matched = next(
+                    (n for n in role_map if normalize_name(n) == normalize_name(role.name)),
+                    None,
+                )
+                if matched:
+                    if current_highest is None or progression.index(matched) > progression.index(current_highest):
+                        current_highest = matched
 
             # Don't downgrade
             if current_highest and target_name and progression.index(current_highest) > progression.index(target_name):
@@ -122,7 +148,8 @@ class RoleCog(commands.Cog):
             # Remove outdated progression roles (keep target only)
             to_remove = [
                 r for r in member.roles
-                if r.name in role_map and r != target_role
+                if any(normalize_name(r.name) == normalize_name(n) for n in role_map)
+                and r != target_role
             ]
             if to_remove:
                 try:
@@ -143,6 +170,13 @@ class RoleCog(commands.Cog):
         return assigned
 
     # ------------------------------------------------------------------ commands
+
+    @commands.command(name="rolemenu")
+    async def rolemenu(self, ctx: commands.Context):
+        """Show a quick-reference menu for all role commands."""
+        view = CogMenuView(ctx, "🎭 Role Commands", _ROLE_MENU_COMMANDS)
+        msg = await ctx.send(embed=view.build_embed(), view=view)
+        view.message = msg
 
     @commands.command(name="assignroles")
     @commands.has_permissions(administrator=True)
@@ -245,15 +279,116 @@ class RoleCog(commands.Cog):
         if days < 0:
             await ctx.send("Days must be 0 or greater.", delete_after=5)
             return
-        await db.set_role_threshold(ctx.guild.id, role_name, days)
-        await ctx.send(f"✅ Role **{role_name}** will be assigned after **{days}** day(s).")
+        normalized = normalize_name(role_name)
+        # Store the original Discord role name (case-preserved) if the role exists
+        discord_role = _find_role_normalized(ctx.guild, role_name)
+        store_name = discord_role.name if discord_role else role_name
+        await db.set_role_threshold(ctx.guild.id, store_name, days)
+        await ctx.send(f"✅ Role **{store_name}** will be assigned after **{days}** day(s).")
 
     @commands.command(name="unsetrole")
     @commands.has_permissions(administrator=True)
     async def unsetrole(self, ctx: commands.Context, *, role_name: str):
         """Remove a role from the time-based assignment system."""
-        await db.remove_role_threshold(ctx.guild.id, role_name)
-        await ctx.send(f"✅ Removed **{role_name}** from the auto-assignment system.")
+        # Try exact match first, then normalized match against stored thresholds
+        thresholds = await db.get_role_thresholds(ctx.guild.id)
+        key = normalize_name(role_name)
+        match = next((r["role_name"] for r in thresholds if normalize_name(r["role_name"]) == key), role_name)
+        await db.remove_role_threshold(ctx.guild.id, match)
+        await ctx.send(f"✅ Removed **{match}** from the auto-assignment system.")
+
+    # ------------------------------------------------------------------ Reaction Role System (DB-backed)
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
+        if payload.user_id == self.bot.user.id:
+            return
+        guild = self.bot.get_guild(payload.guild_id)
+        if not guild:
+            return
+        member = guild.get_member(payload.user_id)
+        if not member or member.bot:
+            return
+        role_id = await db.get_reaction_role(
+            payload.guild_id, payload.message_id, str(payload.emoji)
+        )
+        if role_id:
+            role = guild.get_role(role_id)
+            if role:
+                try:
+                    await member.add_roles(role, reason="Reaction role")
+                except discord.Forbidden:
+                    pass
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_remove(self, payload: discord.RawReactionActionEvent):
+        guild = self.bot.get_guild(payload.guild_id)
+        if not guild:
+            return
+        member = guild.get_member(payload.user_id)
+        if not member or member.bot:
+            return
+        role_id = await db.get_reaction_role(
+            payload.guild_id, payload.message_id, str(payload.emoji)
+        )
+        if role_id:
+            role = guild.get_role(role_id)
+            if role:
+                try:
+                    await member.remove_roles(role, reason="Reaction role removed")
+                except discord.Forbidden:
+                    pass
+
+    @commands.command(name='reactroles', aliases=['reaktionsrollen'])
+    @commands.has_permissions(manage_roles=True)
+    async def setup_reaction_roles(self, ctx, message_id: int, emoji: str, role: discord.Role):
+        """Attach a reaction role to a message. Usage: !reactroles <message_id> <emoji> <@role>"""
+        try:
+            message = await ctx.fetch_message(message_id)
+        except discord.NotFound:
+            await ctx.send("❌ Message not found in this channel.", delete_after=8)
+            return
+        except discord.Forbidden:
+            await ctx.send("❌ I can't read that message.", delete_after=8)
+            return
+
+        await db.add_reaction_role(ctx.guild.id, message_id, emoji, role.id)
+        try:
+            await message.add_reaction(emoji)
+        except discord.HTTPException:
+            await ctx.send("⚠️ Role saved, but I couldn't add the reaction (invalid emoji?).")
+            return
+        await ctx.send(
+            f"✅ Reaction role set: reacting with {emoji} on that message will assign **{role.name}**.",
+            delete_after=15,
+        )
+
+    @commands.command(name='removereactrole')
+    @commands.has_permissions(manage_roles=True)
+    async def remove_reaction_role(self, ctx, message_id: int, emoji: str):
+        """Remove a reaction role binding. Usage: !removereactrole <message_id> <emoji>"""
+        await db.remove_reaction_role(ctx.guild.id, message_id, emoji)
+        await ctx.send(f"✅ Reaction role for {emoji} on that message removed.", delete_after=10)
+
+    @commands.command(name='listreactroles')
+    @commands.has_permissions(manage_roles=True)
+    async def list_reaction_roles(self, ctx):
+        """List all active reaction roles in this server."""
+        rows = await db.get_all_reaction_roles(ctx.guild.id)
+        if not rows:
+            await ctx.send("No reaction roles configured.", delete_after=8)
+            return
+        lines = []
+        for r in rows:
+            role = ctx.guild.get_role(r["role_id"])
+            role_str = role.mention if role else f"<deleted role {r['role_id']}>"
+            lines.append(f"Message `{r['message_id']}` · {r['emoji']} → {role_str}")
+        embed = discord.Embed(
+            title="⚙️ Reaction Roles",
+            description="\n".join(lines),
+            color=discord.Color.blurple(),
+        )
+        await ctx.send(embed=embed)
 
     # ------------------------------------------------------------------ on_member_join
 
@@ -263,13 +398,12 @@ class RoleCog(commands.Cog):
             return
         await _ensure_defaults(member.guild.id)
         thresholds = await db.get_role_thresholds(member.guild.id)
-        # Assign the 0-day role (Neu by default)
         zero_day = next(
             (r["role_name"] for r in thresholds if r["days_required"] == 0), None
         )
         if not zero_day:
             return
-        role = discord.utils.get(member.guild.roles, name=zero_day)
+        role = _find_role_normalized(member.guild, zero_day)
         if role:
             try:
                 await member.add_roles(role)
@@ -450,7 +584,10 @@ class _ThresholdAddModal(discord.ui.Modal, title="Add / Edit Threshold"):
                 "Days must be a non-negative integer.", ephemeral=True
             )
             return
-        await db.set_role_threshold(interaction.guild.id, self.role_name.value.strip(), d)
+        # Store with Discord's original casing if the role exists
+        discord_role = _find_role_normalized(interaction.guild, self.role_name.value.strip())
+        store_name = discord_role.name if discord_role else self.role_name.value.strip()
+        await db.set_role_threshold(interaction.guild.id, store_name, d)
         await interaction.response.defer()
         await self.parent._refresh(interaction)
 

--- a/disbot/cogs/utility_cog.py
+++ b/disbot/cogs/utility_cog.py
@@ -1,113 +1,139 @@
+from __future__ import annotations
 from discord.ext import commands
 import discord
 import asyncio
+from utils.helpers import CogMenuView
+
+_UTILITY_MENU_COMMANDS: list[tuple[str, str, str]] = [
+    ("utilitymenu", "!utilitymenu",              "Show this utility command menu."),
+    ("info",        "!info [server|user] [@user]","Server or user info (defaults to server)."),
+    ("avatar",      "!avatar [@user]",           "Display a user's full-size avatar."),
+    ("poll",        "!poll <question> opt1 opt2…","Create a reaction poll with up to 10 options."),
+    ("clear",       "!clear [amount]",           "Purge up to 100 messages (default: 5)."),
+    ("invite",      "!invite",                   "Generate a one-use server invite link."),
+    ("remind",      "!remind <minutes> <message>","Set a reminder (bot DMs/pings you after delay)."),
+]
+
 
 class UtilityCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    ### Clear Command to Delete Messages (with limit) ###
-    @commands.command(name='clear', aliases=['purge'])
+    @commands.command(name="utilitymenu")
+    async def utility_menu(self, ctx):
+        """Show a quick-reference menu for all utility commands."""
+        view = CogMenuView(ctx, "🔧 Utility Commands", _UTILITY_MENU_COMMANDS)
+        msg = await ctx.send(embed=view.build_embed(), view=view)
+        view.message = msg
+
+    @commands.command(name="clear", aliases=["purge"])
     @commands.has_permissions(manage_messages=True)
     async def clear(self, ctx, amount: int = 5):
-        """Clears a specified number of messages (default is 5, maximum is 100)."""
+        """Purge messages. Max 100."""
         if amount <= 0:
             await ctx.send("Please specify a number greater than 0.", delete_after=5)
             return
         if amount > 100:
             await ctx.send("You can only clear up to 100 messages at a time.", delete_after=5)
             return
-
         deleted = await ctx.channel.purge(limit=amount)
-        confirmation_message = await ctx.send(f'Cleared {len(deleted)} messages.')
-        await confirmation_message.delete(delay=5)
+        msg = await ctx.send(f"Cleared {len(deleted)} messages.")
+        await msg.delete(delay=5)
 
-    ### Server Info Command ###
-    @commands.command(name='serverinfo')
+    @commands.command(name="info")
+    async def info(self, ctx, target: str = "server", member: discord.Member = None):
+        """Show server or user info.  !info [server|user] [@mention]"""
+        if target.lower() in ("user", "u") or member:
+            member = member or ctx.author
+            embed = discord.Embed(
+                title=f"User Info — {member}",
+                color=discord.Color.green(),
+            )
+            embed.set_thumbnail(url=member.display_avatar.url)
+            embed.add_field(name="Username",      value=member.name,                                    inline=True)
+            embed.add_field(name="User ID",       value=str(member.id),                                 inline=True)
+            embed.add_field(name="Joined Server", value=member.joined_at.strftime("%Y-%m-%d"),          inline=True)
+            embed.add_field(name="Joined Discord",value=member.created_at.strftime("%Y-%m-%d"),         inline=True)
+            embed.add_field(name="Status",        value=str(member.status).capitalize(),                inline=True)
+            embed.add_field(name="Activity",      value=member.activity.name if member.activity else "None", inline=True)
+            embed.set_footer(text=f"Requested by {ctx.author}")
+        else:
+            guild = ctx.guild
+            embed = discord.Embed(
+                title=f"{guild.name}",
+                description="Server Information",
+                color=discord.Color.blue(),
+            )
+            embed.add_field(name="Owner",        value=guild.owner.mention,                      inline=True)
+            embed.add_field(name="Members",      value=str(guild.member_count),                  inline=True)
+            embed.add_field(name="Boost Level",  value=str(guild.premium_tier),                  inline=True)
+            embed.add_field(name="Created",      value=guild.created_at.strftime("%Y-%m-%d"),    inline=True)
+            embed.add_field(name="Text Channels",value=str(len(guild.text_channels)),            inline=True)
+            embed.add_field(name="Voice Channels",value=str(len(guild.voice_channels)),          inline=True)
+            if guild.icon:
+                embed.set_thumbnail(url=guild.icon.url)
+        await ctx.send(embed=embed)
+
+    # Keep !serverinfo and !userinfo as thin aliases for backwards compatibility
+    @commands.command(name="serverinfo")
     async def serverinfo(self, ctx):
-        """Displays detailed information about the server."""
-        guild = ctx.guild
-        embed = discord.Embed(title=f"{guild.name} Info", description="Server Information", color=discord.Color.blue())
-        embed.add_field(name="Server Name", value=guild.name, inline=True)
-        embed.add_field(name="Owner", value=guild.owner.mention, inline=True)
-        embed.add_field(name="Member Count", value=guild.member_count, inline=True)
-        embed.add_field(name="Boost Level", value=guild.premium_tier, inline=True)
-        embed.add_field(name="Created At", value=guild.created_at.strftime('%Y-%m-%d'), inline=True)
-        if guild.icon:
-            embed.set_thumbnail(url=guild.icon.url)
-        await ctx.send(embed=embed)
+        """Alias for !info server."""
+        await ctx.invoke(self.info, target="server")
 
-    ### User Info Command ###
-    @commands.command(name='userinfo')
+    @commands.command(name="userinfo")
     async def userinfo(self, ctx, member: discord.Member = None):
-        """Displays detailed information about a user."""
-        member = member or ctx.author
-        status = str(member.status).capitalize()  # Online, Offline, etc.
-        activity = member.activity.name if member.activity else "None"  # Current activity if available
-        embed = discord.Embed(title=f"User Info - {member}", color=discord.Color.green())
-        embed.set_thumbnail(url=member.display_avatar.url)
-        embed.add_field(name="Username", value=member.name, inline=True)
-        embed.add_field(name="Discriminator", value=f"#{member.discriminator}", inline=True)
-        embed.add_field(name="User ID", value=member.id, inline=True)
-        embed.add_field(name="Joined Server", value=member.joined_at.strftime('%Y-%m-%d'), inline=True)
-        embed.add_field(name="Joined Discord", value=member.created_at.strftime('%Y-%m-%d'), inline=True)
-        embed.add_field(name="Status", value=status, inline=True)
-        embed.add_field(name="Activity", value=activity, inline=True)
-        embed.set_footer(text=f"Requested by {ctx.author}")
-        await ctx.send(embed=embed)
+        """Alias for !info user [@member]."""
+        await ctx.invoke(self.info, target="user", member=member)
 
-    ### Reminder Command with Minute.Second Countdown ###
-    @commands.command(name='remind')
-    async def remind(self, ctx, time: int, *, message: str):
-        """
-        Sends an initial reminder with a countdown and a final reminder at the end.
-
-        Parameters:
-        - time: Delay in minutes before the second reminder.
-        - message: Content of the reminder.
-        """
-        if time <= 0:
-            await ctx.send("Please specify a time greater than 0 minutes.")
-            return
-
-        await ctx.send(f"⏳ Reminder set for {time} minute(s): {message}")
-        await asyncio.sleep(time * 60)
-        await ctx.send(f"⏰ Time's up! {ctx.author.mention} — Reminder: {message}")
-
-    ### Create Server Invite Command ###
-    @commands.command(name='invite')
-    @commands.has_permissions(create_instant_invite=True)
-    async def invite(self, ctx):
-        """Generates a server invite link."""
-        invite = await ctx.channel.create_invite(max_uses=1, unique=True)
-        await ctx.send(f"Here is your invite link (valid for 1 use): {invite.url}")
-
-    ### Avatar Command ###
-    @commands.command(name='avatar')
+    @commands.command(name="avatar")
     async def avatar(self, ctx, member: discord.Member = None):
-        """Displays a user's avatar."""
+        """Display a user's avatar."""
         member = member or ctx.author
         embed = discord.Embed(title=f"{member}'s Avatar", color=discord.Color.blue())
         embed.set_image(url=member.display_avatar.url)
         await ctx.send(embed=embed)
 
-    ### Poll Command ###
-    @commands.command(name='poll')
+    @commands.command(name="remind")
+    async def remind(self, ctx, time: int, *, message: str):
+        """Set a reminder.  !remind <minutes> <message>"""
+        if time <= 0:
+            await ctx.send("Please specify a time greater than 0 minutes.")
+            return
+        await ctx.send(f"⏳ Reminder set for **{time}** minute(s): {message}")
+        task = asyncio.ensure_future(self._remind_after(ctx, time * 60, message))
+
+    async def _remind_after(self, ctx: commands.Context, delay: float, message: str) -> None:
+        await asyncio.sleep(delay)
+        try:
+            await ctx.send(f"⏰ {ctx.author.mention} — Reminder: {message}")
+        except Exception:
+            pass
+
+    @commands.command(name="invite")
+    @commands.has_permissions(create_instant_invite=True)
+    async def invite(self, ctx):
+        """Generate a one-use server invite."""
+        invite = await ctx.channel.create_invite(max_uses=1, unique=True)
+        await ctx.send(f"Here is your invite link (valid for 1 use): {invite.url}")
+
+    @commands.command(name="poll")
     async def poll(self, ctx, question: str, *options):
-        """Create a simple poll with options."""
+        """Create a simple reaction poll."""
         if len(options) < 2:
             await ctx.send("You need at least two options for a poll.")
             return
         if len(options) > 10:
             await ctx.send("You can only provide up to 10 options.")
             return
-
-        embed = discord.Embed(title=f"Poll: {question}", description="\n".join(f"{i+1}. {option}" for i, option in enumerate(options)), color=discord.Color.blue())
-        poll_message = await ctx.send(embed=embed)
-
+        embed = discord.Embed(
+            title=f"Poll: {question}",
+            description="\n".join(f"{i+1}. {opt}" for i, opt in enumerate(options)),
+            color=discord.Color.blue(),
+        )
+        poll_msg = await ctx.send(embed=embed)
         for i in range(len(options)):
-            await poll_message.add_reaction(f"{i+1}\N{COMBINING ENCLOSING KEYCAP}")
+            await poll_msg.add_reaction(f"{i+1}\N{COMBINING ENCLOSING KEYCAP}")
 
-# Function required to load this cog
+
 async def setup(bot):
     await bot.add_cog(UtilityCog(bot))

--- a/disbot/cogs/xp_cog.py
+++ b/disbot/cogs/xp_cog.py
@@ -5,8 +5,18 @@ import discord
 from discord.ext import commands
 import logging
 from utils import db
+from utils.helpers import CogMenuView
 
 logger = logging.getLogger("bot")
+
+_XP_MENU_COMMANDS: list[tuple[str, str, str]] = [
+    ("xpmenu",       "!xpmenu",                    "Show this XP command menu."),
+    ("rank",         "!rank [@user] [xp|coins]",   "Show XP/coin rank card for a user."),
+    ("leaderboard",  "!leaderboard [xp|coins]",    "Show the top-10 XP or coin leaderboard."),
+    ("xpconfig",     "!xpconfig",                  "Configure XP gain range, cooldown, and announce channel (admin)."),
+    ("givexp",       "!givexp <@user> <amount>",   "Give XP to a user (admin only)."),
+    ("resetxp",      "!resetxp <@user>",           "Reset a user's XP to zero (admin only)."),
+]
 
 
 async def _post_log(bot: commands.Bot, guild_id: int, embed: discord.Embed) -> None:
@@ -52,6 +62,13 @@ def _progress_bar(current: int, needed: int, width: int = 10) -> str:
 class XpCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
+
+    @commands.command(name="xpmenu")
+    async def xp_menu(self, ctx: commands.Context):
+        """Show a quick-reference menu for all XP commands."""
+        view = CogMenuView(ctx, "🏆 XP Commands", _XP_MENU_COMMANDS)
+        msg = await ctx.send(embed=view.build_embed(), view=view)
+        view.message = msg
 
     # ------------------------------------------------------------------ events
 

--- a/disbot/cogs/xp_cog.py
+++ b/disbot/cogs/xp_cog.py
@@ -5,7 +5,8 @@ import discord
 from discord.ext import commands
 import logging
 from utils import db
-from utils.helpers import CogMenuView
+from utils.helpers import CogMenuView, post_log_embed
+from utils.cooldowns import check_cooldown, format_remaining
 
 logger = logging.getLogger("bot")
 
@@ -18,17 +19,6 @@ _XP_MENU_COMMANDS: list[tuple[str, str, str]] = [
     ("resetxp",      "!resetxp <@user>",           "Reset a user's XP to zero (admin only)."),
 ]
 
-
-async def _post_log(bot: commands.Bot, guild_id: int, embed: discord.Embed) -> None:
-    cid = await db.get_setting(guild_id, "economy_log_channel", "")
-    if not cid:
-        return
-    ch = bot.get_channel(int(cid))
-    if ch:
-        try:
-            await ch.send(embed=embed)
-        except Exception:
-            pass
 
 _XP_MIN = 15
 _XP_MAX = 25
@@ -84,7 +74,8 @@ class XpCog(commands.Cog):
         row = await db.get_xp(user_id, guild_id)
         xp_min, xp_max, cooldown = await _guild_xp_settings(guild_id)
 
-        if now - row["last_xp"] < cooldown:
+        on_cd, _ = check_cooldown(row["last_xp"], cooldown)
+        if on_cd:
             return
 
         amount = random.randint(xp_min, xp_max)
@@ -115,7 +106,7 @@ class XpCog(commands.Cog):
                 ),
                 color=discord.Color.gold(),
             )
-            await _post_log(self.bot, guild_id, log_embed)
+            await post_log_embed(self.bot, guild_id, log_embed)
 
     # ------------------------------------------------------------------ commands
 

--- a/disbot/config.py
+++ b/disbot/config.py
@@ -6,6 +6,13 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # ==========================
+# Database
+# ==========================
+# Required: postgres://user:password@host:5432/dbname
+# Set via DATABASE_URL environment variable (Railway / Render standard).
+# db.py will raise a clear RuntimeError at startup if this is missing.
+
+# ==========================
 # Discord Bot Token
 # ==========================
 DISCORD_BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN_PRODUCTION")

--- a/disbot/utils/cooldowns.py
+++ b/disbot/utils/cooldowns.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+import time
+
+
+def check_cooldown(last_ts: int, cooldown_seconds: int) -> tuple[bool, int]:
+    """
+    Check whether a unix-timestamp cooldown has expired.
+
+    Returns (on_cooldown: bool, remaining_seconds: int).
+    remaining_seconds is 0 when not on cooldown.
+    """
+    elapsed = int(time.time()) - last_ts
+    if elapsed < cooldown_seconds:
+        return True, cooldown_seconds - elapsed
+    return False, 0
+
+
+def format_remaining(seconds: int) -> str:
+    """Human-readable representation of a cooldown duration, e.g. '1h 30m' or '45s'."""
+    if seconds <= 0:
+        return "0s"
+    h, remainder = divmod(seconds, 3600)
+    m, s = divmod(remainder, 60)
+    parts: list[str] = []
+    if h:
+        parts.append(f"{h}h")
+    if m:
+        parts.append(f"{m}m")
+    if s and not h:
+        parts.append(f"{s}s")
+    return " ".join(parts)

--- a/disbot/utils/db.py
+++ b/disbot/utils/db.py
@@ -1,179 +1,197 @@
 from __future__ import annotations
-import aiosqlite
+import asyncpg
+import json
 import os
 import logging
 
 logger = logging.getLogger("bot")
 
-def _resolve_db_path() -> str:
-    if env := os.environ.get("BOT_DB_PATH"):
-        return env
-    # Auto-use /data/ if it exists — Railway/Render persistent volume standard mount
-    if os.path.isdir("/data"):
-        return "/data/bot_data.db"
-    return os.path.join(
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-        "data", "bot_data.db",
+_pool: asyncpg.Pool | None = None
+
+
+def _get_dsn() -> str:
+    if dsn := os.environ.get("DATABASE_URL"):
+        return dsn
+    raise RuntimeError(
+        "DATABASE_URL environment variable is required. "
+        "Format: postgres://user:password@host:5432/dbname"
     )
 
 
-DB_PATH = _resolve_db_path()
-
-_db: aiosqlite.Connection | None = None
+async def _init_conn(conn: asyncpg.Connection) -> None:
+    """Register codecs so JSONB columns round-trip as Python dicts automatically."""
+    await conn.set_type_codec(
+        "jsonb",
+        encoder=json.dumps,
+        decoder=json.loads,
+        schema="pg_catalog",
+    )
 
 
 async def init() -> None:
-    global _db
-    is_new = not os.path.exists(DB_PATH)
-    os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
-    _db = await aiosqlite.connect(DB_PATH)
-    _db.row_factory = aiosqlite.Row
-    await _db.execute("PRAGMA journal_mode=WAL")
+    global _pool
+    dsn = _get_dsn()
+    _pool = await asyncpg.create_pool(dsn, min_size=2, max_size=10, init=_init_conn)
     await _create_tables()
-    if is_new:
-        logger.warning(
-            "Fresh database created at %s — set BOT_DB_PATH to a persistent volume "
-            "path so data survives deployments.", DB_PATH
-        )
-    else:
-        logger.info("Database opened at %s", DB_PATH)
+    logger.info("PostgreSQL pool initialised (%s)", dsn.split("@")[-1])
 
 
 async def close() -> None:
-    global _db
-    if _db:
-        await _db.close()
-        _db = None
+    global _pool
+    if _pool:
+        await _pool.close()
+        _pool = None
 
 
-def get() -> aiosqlite.Connection:
-    if _db is None:
+def get() -> asyncpg.Pool:
+    if _pool is None:
         raise RuntimeError("Database not initialised — call db.init() first.")
-    return _db
+    return _pool
 
 
 async def _create_tables() -> None:
-    conn = get()
+    pool = get()
     statements = [
+        # ---- existing tables (kept identical in semantics) ----
         """CREATE TABLE IF NOT EXISTS economy (
-            user_id      INTEGER NOT NULL,
-            guild_id     INTEGER NOT NULL,
-            last_daily   INTEGER NOT NULL DEFAULT 0,
+            user_id      BIGINT  NOT NULL,
+            guild_id     BIGINT  NOT NULL,
+            last_daily   BIGINT  NOT NULL DEFAULT 0,
             daily_streak INTEGER NOT NULL DEFAULT 0,
             daily_count  INTEGER NOT NULL DEFAULT 0,
-            last_worked  INTEGER NOT NULL DEFAULT 0,
+            last_worked  BIGINT  NOT NULL DEFAULT 0,
             PRIMARY KEY (user_id, guild_id)
         )""",
         """CREATE TABLE IF NOT EXISTS job_progress (
-            user_id      INTEGER NOT NULL,
-            guild_id     INTEGER NOT NULL,
+            user_id      BIGINT  NOT NULL,
+            guild_id     BIGINT  NOT NULL,
             job_name     TEXT    NOT NULL,
             times_worked INTEGER NOT NULL DEFAULT 0,
             PRIMARY KEY (user_id, guild_id, job_name)
         )""",
         """CREATE TABLE IF NOT EXISTS inventory (
-            user_id   INTEGER NOT NULL,
-            guild_id  INTEGER NOT NULL,
+            user_id   BIGINT  NOT NULL,
+            guild_id  BIGINT  NOT NULL,
             item_name TEXT    NOT NULL,
             quantity  INTEGER NOT NULL DEFAULT 1,
             PRIMARY KEY (user_id, guild_id, item_name)
         )""",
         """CREATE TABLE IF NOT EXISTS xp (
-            user_id  INTEGER NOT NULL,
-            guild_id INTEGER NOT NULL,
-            xp       INTEGER NOT NULL DEFAULT 0,
+            user_id  BIGINT  NOT NULL,
+            guild_id BIGINT  NOT NULL,
+            xp       BIGINT  NOT NULL DEFAULT 0,
             level    INTEGER NOT NULL DEFAULT 0,
-            messages INTEGER NOT NULL DEFAULT 0,
-            last_xp  INTEGER NOT NULL DEFAULT 0,
-            coins    INTEGER NOT NULL DEFAULT 0,
+            messages BIGINT  NOT NULL DEFAULT 0,
+            last_xp  BIGINT  NOT NULL DEFAULT 0,
+            coins    BIGINT  NOT NULL DEFAULT 0,
             PRIMARY KEY (user_id, guild_id)
         )""",
         """CREATE TABLE IF NOT EXISTS warnings (
-            user_id  INTEGER NOT NULL,
-            guild_id INTEGER NOT NULL,
+            user_id  BIGINT  NOT NULL,
+            guild_id BIGINT  NOT NULL,
             count    INTEGER NOT NULL DEFAULT 0,
             PRIMARY KEY (user_id, guild_id)
         )""",
         """CREATE TABLE IF NOT EXISTS mod_logs (
-            id           INTEGER PRIMARY KEY AUTOINCREMENT,
+            id           BIGINT  GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
             timestamp    TEXT    NOT NULL,
-            guild_id     INTEGER NOT NULL,
+            guild_id     BIGINT  NOT NULL,
             action       TEXT    NOT NULL,
-            target_id    INTEGER NOT NULL,
-            moderator_id INTEGER NOT NULL,
+            target_id    BIGINT  NOT NULL,
+            moderator_id BIGINT  NOT NULL,
             reason       TEXT    NOT NULL DEFAULT 'No reason provided'
         )""",
         """CREATE TABLE IF NOT EXISTS role_thresholds (
-            guild_id      INTEGER NOT NULL,
+            guild_id      BIGINT  NOT NULL,
             role_name     TEXT    NOT NULL,
             days_required INTEGER NOT NULL DEFAULT 0,
             PRIMARY KEY (guild_id, role_name)
         )""",
         """CREATE TABLE IF NOT EXISTS guild_settings (
-            guild_id INTEGER NOT NULL,
-            key      TEXT    NOT NULL,
-            value    TEXT    NOT NULL,
+            guild_id BIGINT NOT NULL,
+            key      TEXT   NOT NULL,
+            value    TEXT   NOT NULL,
             PRIMARY KEY (guild_id, key)
         )""",
         """CREATE TABLE IF NOT EXISTS logs (
-            id        INTEGER PRIMARY KEY AUTOINCREMENT,
-            timestamp TEXT NOT NULL,
-            level     TEXT NOT NULL,
-            message   TEXT NOT NULL
+            id        BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+            timestamp TEXT   NOT NULL,
+            level     TEXT   NOT NULL,
+            message   TEXT   NOT NULL
         )""",
         """CREATE TABLE IF NOT EXISTS reaction_roles (
-            guild_id    INTEGER NOT NULL,
-            message_id  INTEGER NOT NULL,
-            emoji       TEXT    NOT NULL,
-            role_id     INTEGER NOT NULL,
+            guild_id   BIGINT NOT NULL,
+            message_id BIGINT NOT NULL,
+            emoji      TEXT   NOT NULL,
+            role_id    BIGINT NOT NULL,
             PRIMARY KEY (guild_id, message_id, emoji)
         )""",
         """CREATE TABLE IF NOT EXISTS rps_players (
-            user_id INTEGER PRIMARY KEY,
+            user_id BIGINT PRIMARY KEY,
             name    TEXT    NOT NULL,
             wins    INTEGER NOT NULL DEFAULT 0,
             losses  INTEGER NOT NULL DEFAULT 0,
             ties    INTEGER NOT NULL DEFAULT 0
         )""",
         """CREATE TABLE IF NOT EXISTS rps_matches (
-            id         INTEGER PRIMARY KEY AUTOINCREMENT,
-            player1_id INTEGER NOT NULL,
-            player2_id INTEGER NOT NULL,
-            winner_id  INTEGER,
+            id         BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+            player1_id BIGINT  NOT NULL,
+            player2_id BIGINT  NOT NULL,
+            winner_id  BIGINT,
             mode       TEXT    NOT NULL DEFAULT 'classic',
             best_of    INTEGER NOT NULL DEFAULT 3,
             timestamp  TEXT    NOT NULL
         )""",
+        # ---- new tables replacing JSON files ----
+        """CREATE TABLE IF NOT EXISTS mining_inventory (
+            user_id   TEXT    NOT NULL,
+            item_name TEXT    NOT NULL,
+            quantity  INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (user_id, item_name)
+        )""",
+        """CREATE TABLE IF NOT EXISTS prohibited_words (
+            guild_id BIGINT NOT NULL,
+            word     TEXT   NOT NULL,
+            PRIMARY KEY (guild_id, word)
+        )""",
+        """CREATE TABLE IF NOT EXISTS deathmatch_stats (
+            user_id BIGINT  PRIMARY KEY,
+            wins    INTEGER NOT NULL DEFAULT 0,
+            losses  INTEGER NOT NULL DEFAULT 0
+        )""",
+        """CREATE TABLE IF NOT EXISTS chain_channels (
+            channel_id BIGINT PRIMARY KEY,
+            guild_id   BIGINT NOT NULL,
+            word       TEXT   NOT NULL DEFAULT '',
+            word_limit INTEGER NOT NULL DEFAULT 0,
+            chain_count INTEGER NOT NULL DEFAULT 0
+        )""",
+        """CREATE TABLE IF NOT EXISTS counting_state (
+            guild_id BIGINT PRIMARY KEY,
+            state    JSONB  NOT NULL DEFAULT '{}'
+        )""",
     ]
-    for stmt in statements:
-        await conn.execute(stmt)
-    await conn.commit()
-    # Migration: add coins column to existing xp tables that predate it
-    async with conn.execute("PRAGMA table_info(xp)") as cur:
-        cols = {row[1] async for row in cur}
-    if "coins" not in cols:
-        await conn.execute("ALTER TABLE xp ADD COLUMN coins INTEGER NOT NULL DEFAULT 0")
-        await conn.commit()
+    async with pool.acquire() as conn:
+        for stmt in statements:
+            await conn.execute(stmt)
 
 
 # ---------------------------------------------------------------------------
-# Generic helpers
+# Generic helpers  (same call signature as the old aiosqlite wrappers)
 # ---------------------------------------------------------------------------
 
 async def fetchone(query: str, params: tuple = ()) -> dict | None:
-    async with get().execute(query, params) as cur:
-        row = await cur.fetchone()
-        return dict(row) if row else None
+    row = await get().fetchrow(query, *params)
+    return dict(row) if row else None
 
 
 async def fetchall(query: str, params: tuple = ()) -> list[dict]:
-    async with get().execute(query, params) as cur:
-        return [dict(r) for r in await cur.fetchall()]
+    rows = await get().fetch(query, *params)
+    return [dict(r) for r in rows]
 
 
 async def execute(query: str, params: tuple = ()) -> None:
-    await get().execute(query, params)
-    await get().commit()
+    await get().execute(query, *params)
 
 
 # ---------------------------------------------------------------------------
@@ -181,12 +199,10 @@ async def execute(query: str, params: tuple = ()) -> None:
 # ---------------------------------------------------------------------------
 
 def xp_for_level(level: int) -> int:
-    """XP required to complete this level (MEE6-style formula)."""
     return 5 * (level ** 2) + 50 * level + 100
 
 
 def level_progress(total_xp: int) -> tuple[int, int, int]:
-    """Return (level, xp_into_level, xp_needed_for_next_level)."""
     level = 0
     remaining = total_xp
     while True:
@@ -199,7 +215,7 @@ def level_progress(total_xp: int) -> tuple[int, int, int]:
 
 async def get_xp(user_id: int, guild_id: int) -> dict:
     row = await fetchone(
-        "SELECT * FROM xp WHERE user_id=? AND guild_id=?", (user_id, guild_id)
+        "SELECT * FROM xp WHERE user_id=$1 AND guild_id=$2", (user_id, guild_id)
     )
     return row or {
         "user_id": user_id, "guild_id": guild_id,
@@ -208,17 +224,16 @@ async def get_xp(user_id: int, guild_id: int) -> dict:
 
 
 async def add_xp(user_id: int, guild_id: int, amount: int, now: int) -> tuple[int, int, bool]:
-    """Add *amount* XP; return (total_xp, new_level, leveled_up)."""
     row = await get_xp(user_id, guild_id)
     new_xp = row["xp"] + amount
     new_level, _, _ = level_progress(new_xp)
     leveled_up = new_level > row["level"]
     await execute(
         """INSERT INTO xp (user_id, guild_id, xp, level, messages, last_xp)
-           VALUES (?, ?, ?, ?, 1, ?)
-           ON CONFLICT(user_id, guild_id) DO UPDATE SET
-               xp=excluded.xp, level=excluded.level,
-               messages=messages+1, last_xp=excluded.last_xp""",
+           VALUES ($1, $2, $3, $4, 1, $5)
+           ON CONFLICT (user_id, guild_id) DO UPDATE SET
+               xp=EXCLUDED.xp, level=EXCLUDED.level,
+               messages=xp.messages+1, last_xp=EXCLUDED.last_xp""",
         (user_id, guild_id, new_xp, new_level, now),
     )
     return new_xp, new_level, leveled_up
@@ -230,15 +245,15 @@ async def add_xp(user_id: int, guild_id: int, amount: int, now: int) -> tuple[in
 
 async def get_setting(guild_id: int, key: str, default: str = "") -> str:
     row = await fetchone(
-        "SELECT value FROM guild_settings WHERE guild_id=? AND key=?", (guild_id, key)
+        "SELECT value FROM guild_settings WHERE guild_id=$1 AND key=$2", (guild_id, key)
     )
     return row["value"] if row else default
 
 
 async def set_setting(guild_id: int, key: str, value: str) -> None:
     await execute(
-        """INSERT INTO guild_settings (guild_id, key, value) VALUES (?, ?, ?)
-           ON CONFLICT(guild_id, key) DO UPDATE SET value=excluded.value""",
+        """INSERT INTO guild_settings (guild_id, key, value) VALUES ($1, $2, $3)
+           ON CONFLICT (guild_id, key) DO UPDATE SET value=EXCLUDED.value""",
         (guild_id, key, value),
     )
 
@@ -250,7 +265,7 @@ async def set_setting(guild_id: int, key: str, value: str) -> None:
 async def get_role_thresholds(guild_id: int) -> list[dict]:
     return await fetchall(
         "SELECT role_name, days_required FROM role_thresholds "
-        "WHERE guild_id=? ORDER BY days_required",
+        "WHERE guild_id=$1 ORDER BY days_required",
         (guild_id,),
     )
 
@@ -258,15 +273,15 @@ async def get_role_thresholds(guild_id: int) -> list[dict]:
 async def set_role_threshold(guild_id: int, role_name: str, days: int) -> None:
     await execute(
         """INSERT INTO role_thresholds (guild_id, role_name, days_required)
-           VALUES (?, ?, ?)
-           ON CONFLICT(guild_id, role_name) DO UPDATE SET days_required=excluded.days_required""",
+           VALUES ($1, $2, $3)
+           ON CONFLICT (guild_id, role_name) DO UPDATE SET days_required=EXCLUDED.days_required""",
         (guild_id, role_name, days),
     )
 
 
 async def remove_role_threshold(guild_id: int, role_name: str) -> None:
     await execute(
-        "DELETE FROM role_thresholds WHERE guild_id=? AND role_name=?",
+        "DELETE FROM role_thresholds WHERE guild_id=$1 AND role_name=$2",
         (guild_id, role_name),
     )
 
@@ -277,7 +292,7 @@ async def remove_role_threshold(guild_id: int, role_name: str) -> None:
 
 async def get_warnings(user_id: int, guild_id: int) -> int:
     row = await fetchone(
-        "SELECT count FROM warnings WHERE user_id=? AND guild_id=?", (user_id, guild_id)
+        "SELECT count FROM warnings WHERE user_id=$1 AND guild_id=$2", (user_id, guild_id)
     )
     return row["count"] if row else 0
 
@@ -285,8 +300,8 @@ async def get_warnings(user_id: int, guild_id: int) -> int:
 async def add_warning(user_id: int, guild_id: int) -> int:
     count = await get_warnings(user_id, guild_id) + 1
     await execute(
-        """INSERT INTO warnings (user_id, guild_id, count) VALUES (?, ?, ?)
-           ON CONFLICT(user_id, guild_id) DO UPDATE SET count=excluded.count""",
+        """INSERT INTO warnings (user_id, guild_id, count) VALUES ($1, $2, $3)
+           ON CONFLICT (user_id, guild_id) DO UPDATE SET count=EXCLUDED.count""",
         (user_id, guild_id, count),
     )
     return count
@@ -294,7 +309,7 @@ async def add_warning(user_id: int, guild_id: int) -> int:
 
 async def clear_warnings(user_id: int, guild_id: int) -> None:
     await execute(
-        "DELETE FROM warnings WHERE user_id=? AND guild_id=?", (user_id, guild_id)
+        "DELETE FROM warnings WHERE user_id=$1 AND guild_id=$2", (user_id, guild_id)
     )
 
 
@@ -310,7 +325,7 @@ async def log_mod_action(
     ts = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
     await execute(
         "INSERT INTO mod_logs (timestamp, guild_id, action, target_id, moderator_id, reason) "
-        "VALUES (?, ?, ?, ?, ?, ?)",
+        "VALUES ($1, $2, $3, $4, $5, $6)",
         (ts, guild_id, action, target_id, moderator_id, reason),
     )
 
@@ -321,28 +336,25 @@ async def log_mod_action(
 
 async def get_coins(user_id: int, guild_id: int) -> int:
     row = await fetchone(
-        "SELECT coins FROM xp WHERE user_id=? AND guild_id=?", (user_id, guild_id)
+        "SELECT coins FROM xp WHERE user_id=$1 AND guild_id=$2", (user_id, guild_id)
     )
     return row["coins"] if row else 0
 
 
 async def add_coins(user_id: int, guild_id: int, amount: int) -> int:
-    """Add (or subtract if negative) coins; clamps to 0. Returns new balance."""
-    # Pass amount twice: once for the INSERT default (clamped for new users),
-    # once for the UPDATE so negative values actually subtract from existing balance.
     await execute(
-        """INSERT INTO xp (user_id, guild_id, coins) VALUES (?, ?, MAX(0, ?))
-           ON CONFLICT(user_id, guild_id) DO UPDATE SET
-               coins=MAX(0, coins + ?)""",
-        (user_id, guild_id, amount, amount),
+        """INSERT INTO xp (user_id, guild_id, coins) VALUES ($1, $2, GREATEST(0, $3))
+           ON CONFLICT (user_id, guild_id) DO UPDATE SET
+               coins=GREATEST(0, xp.coins + $3)""",
+        (user_id, guild_id, amount),
     )
     return await get_coins(user_id, guild_id)
 
 
 async def set_coins(user_id: int, guild_id: int, amount: int) -> None:
     await execute(
-        """INSERT INTO xp (user_id, guild_id, coins) VALUES (?, ?, MAX(0, ?))
-           ON CONFLICT(user_id, guild_id) DO UPDATE SET coins=MAX(0, excluded.coins)""",
+        """INSERT INTO xp (user_id, guild_id, coins) VALUES ($1, $2, GREATEST(0, $3))
+           ON CONFLICT (user_id, guild_id) DO UPDATE SET coins=GREATEST(0, EXCLUDED.coins)""",
         (user_id, guild_id, amount),
     )
 
@@ -353,11 +365,11 @@ async def set_coins(user_id: int, guild_id: int, amount: int) -> None:
 
 async def get_economy(user_id: int, guild_id: int) -> dict:
     await execute(
-        "INSERT OR IGNORE INTO economy (user_id, guild_id) VALUES (?,?)",
+        "INSERT INTO economy (user_id, guild_id) VALUES ($1, $2) ON CONFLICT DO NOTHING",
         (user_id, guild_id),
     )
     row = await fetchone(
-        "SELECT * FROM economy WHERE user_id=? AND guild_id=?", (user_id, guild_id)
+        "SELECT * FROM economy WHERE user_id=$1 AND guild_id=$2", (user_id, guild_id)
     )
     return dict(row)
 
@@ -367,9 +379,11 @@ async def set_economy(user_id: int, guild_id: int, **kwargs) -> None:
     cols = {k: v for k, v in kwargs.items() if k in allowed}
     if not cols:
         return
-    sets = ", ".join(f"{k}=?" for k in cols)
+    keys = list(cols)
+    sets = ", ".join(f"{k}=${i + 1}" for i, k in enumerate(keys))
+    n = len(keys)
     await execute(
-        f"UPDATE economy SET {sets} WHERE user_id=? AND guild_id=?",
+        f"UPDATE economy SET {sets} WHERE user_id=${n + 1} AND guild_id=${n + 2}",
         (*cols.values(), user_id, guild_id),
     )
 
@@ -380,19 +394,18 @@ async def set_economy(user_id: int, guild_id: int, **kwargs) -> None:
 
 async def get_job_times(user_id: int, guild_id: int, job_name: str) -> int:
     row = await fetchone(
-        "SELECT times_worked FROM job_progress WHERE user_id=? AND guild_id=? AND job_name=?",
+        "SELECT times_worked FROM job_progress WHERE user_id=$1 AND guild_id=$2 AND job_name=$3",
         (user_id, guild_id, job_name),
     )
     return row["times_worked"] if row else 0
 
 
 async def increment_job(user_id: int, guild_id: int, job_name: str) -> int:
-    """Increment times_worked for a job and return the new count."""
     await execute(
         """INSERT INTO job_progress (user_id, guild_id, job_name, times_worked)
-           VALUES (?,?,?,1)
-           ON CONFLICT(user_id, guild_id, job_name)
-           DO UPDATE SET times_worked = times_worked + 1""",
+           VALUES ($1, $2, $3, 1)
+           ON CONFLICT (user_id, guild_id, job_name)
+           DO UPDATE SET times_worked=job_progress.times_worked + 1""",
         (user_id, guild_id, job_name),
     )
     return await get_job_times(user_id, guild_id, job_name)
@@ -404,7 +417,7 @@ async def increment_job(user_id: int, guild_id: int, job_name: str) -> int:
 
 async def get_inventory(user_id: int, guild_id: int) -> dict[str, int]:
     rows = await fetchall(
-        "SELECT item_name, quantity FROM inventory WHERE user_id=? AND guild_id=?",
+        "SELECT item_name, quantity FROM inventory WHERE user_id=$1 AND guild_id=$2",
         (user_id, guild_id),
     )
     return {r["item_name"]: r["quantity"] for r in rows}
@@ -413,16 +426,16 @@ async def get_inventory(user_id: int, guild_id: int) -> dict[str, int]:
 async def add_item(user_id: int, guild_id: int, item_name: str, quantity: int = 1) -> None:
     await execute(
         """INSERT INTO inventory (user_id, guild_id, item_name, quantity)
-           VALUES (?,?,?,?)
-           ON CONFLICT(user_id, guild_id, item_name)
-           DO UPDATE SET quantity = quantity + ?""",
-        (user_id, guild_id, item_name, quantity, quantity),
+           VALUES ($1, $2, $3, $4)
+           ON CONFLICT (user_id, guild_id, item_name)
+           DO UPDATE SET quantity=inventory.quantity + $4""",
+        (user_id, guild_id, item_name, quantity),
     )
 
 
 async def has_item(user_id: int, guild_id: int, item_name: str) -> bool:
     row = await fetchone(
-        "SELECT quantity FROM inventory WHERE user_id=? AND guild_id=? AND item_name=?",
+        "SELECT quantity FROM inventory WHERE user_id=$1 AND guild_id=$2 AND item_name=$3",
         (user_id, guild_id, item_name),
     )
     return bool(row and row["quantity"] > 0)
@@ -432,31 +445,25 @@ async def has_item(user_id: int, guild_id: int, item_name: str) -> bool:
 # Reaction role helpers
 # ---------------------------------------------------------------------------
 
-async def add_reaction_role(
-    guild_id: int, message_id: int, emoji: str, role_id: int
-) -> None:
+async def add_reaction_role(guild_id: int, message_id: int, emoji: str, role_id: int) -> None:
     await execute(
         """INSERT INTO reaction_roles (guild_id, message_id, emoji, role_id)
-           VALUES (?, ?, ?, ?)
-           ON CONFLICT(guild_id, message_id, emoji) DO UPDATE SET role_id=excluded.role_id""",
+           VALUES ($1, $2, $3, $4)
+           ON CONFLICT (guild_id, message_id, emoji) DO UPDATE SET role_id=EXCLUDED.role_id""",
         (guild_id, message_id, emoji, role_id),
     )
 
 
-async def remove_reaction_role(
-    guild_id: int, message_id: int, emoji: str
-) -> None:
+async def remove_reaction_role(guild_id: int, message_id: int, emoji: str) -> None:
     await execute(
-        "DELETE FROM reaction_roles WHERE guild_id=? AND message_id=? AND emoji=?",
+        "DELETE FROM reaction_roles WHERE guild_id=$1 AND message_id=$2 AND emoji=$3",
         (guild_id, message_id, emoji),
     )
 
 
-async def get_reaction_role(
-    guild_id: int, message_id: int, emoji: str
-) -> int | None:
+async def get_reaction_role(guild_id: int, message_id: int, emoji: str) -> int | None:
     row = await fetchone(
-        "SELECT role_id FROM reaction_roles WHERE guild_id=? AND message_id=? AND emoji=?",
+        "SELECT role_id FROM reaction_roles WHERE guild_id=$1 AND message_id=$2 AND emoji=$3",
         (guild_id, message_id, emoji),
     )
     return row["role_id"] if row else None
@@ -464,7 +471,7 @@ async def get_reaction_role(
 
 async def get_all_reaction_roles(guild_id: int) -> list[dict]:
     return await fetchall(
-        "SELECT message_id, emoji, role_id FROM reaction_roles WHERE guild_id=?",
+        "SELECT message_id, emoji, role_id FROM reaction_roles WHERE guild_id=$1",
         (guild_id,),
     )
 
@@ -475,7 +482,7 @@ async def get_all_reaction_roles(guild_id: int) -> list[dict]:
 
 async def rps_ensure_player(user_id: int, name: str) -> None:
     await execute(
-        "INSERT OR IGNORE INTO rps_players (user_id, name) VALUES (?, ?)",
+        "INSERT INTO rps_players (user_id, name) VALUES ($1, $2) ON CONFLICT DO NOTHING",
         (user_id, name),
     )
 
@@ -483,10 +490,180 @@ async def rps_ensure_player(user_id: int, name: str) -> None:
 async def rps_update_stat(user_id: int, result: str) -> None:
     col = {"win": "wins", "loss": "losses", "tie": "ties"}.get(result)
     if col:
-        await execute(f"UPDATE rps_players SET {col}={col}+1 WHERE user_id=?", (user_id,))
+        await execute(
+            f"UPDATE rps_players SET {col}={col}+1 WHERE user_id=$1", (user_id,)
+        )
 
 
 async def rps_get_leaderboard() -> list[dict]:
     return await fetchall(
         "SELECT name, wins, losses, ties FROM rps_players ORDER BY wins DESC LIMIT 15"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mining inventory helpers  (replaces mining_data.json)
+# ---------------------------------------------------------------------------
+
+async def get_mining_inventory(user_id: str) -> dict[str, int]:
+    rows = await fetchall(
+        "SELECT item_name, quantity FROM mining_inventory WHERE user_id=$1", (user_id,)
+    )
+    return {r["item_name"]: r["quantity"] for r in rows}
+
+
+async def update_mining_item(user_id: str, item_name: str, delta: int) -> None:
+    """Add or subtract *delta* of *item_name* for *user_id*. Clamps to 0."""
+    await execute(
+        """INSERT INTO mining_inventory (user_id, item_name, quantity)
+           VALUES ($1, $2, GREATEST(0, $3))
+           ON CONFLICT (user_id, item_name)
+           DO UPDATE SET quantity=GREATEST(0, mining_inventory.quantity + $3)""",
+        (user_id, item_name, delta),
+    )
+
+
+async def set_mining_inventory(user_id: str, inventory: dict[str, int]) -> None:
+    """Overwrite the entire inventory for a user (used for admin reset)."""
+    pool = get()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "DELETE FROM mining_inventory WHERE user_id=$1", user_id
+        )
+        if inventory:
+            await conn.executemany(
+                "INSERT INTO mining_inventory (user_id, item_name, quantity) VALUES ($1, $2, $3)",
+                [(user_id, k, v) for k, v in inventory.items() if v > 0],
+            )
+
+
+async def get_all_mining_totals() -> list[tuple[str, int]]:
+    """Return [(user_id, total_items)] sorted descending — for leaderboard."""
+    rows = await fetchall(
+        "SELECT user_id, SUM(quantity) AS total FROM mining_inventory GROUP BY user_id ORDER BY total DESC LIMIT 10"
+    )
+    return [(r["user_id"], r["total"]) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Prohibited word helpers  (replaces prohibited_words.json)
+# ---------------------------------------------------------------------------
+
+async def get_prohibited_words(guild_id: int) -> list[str]:
+    rows = await fetchall(
+        "SELECT word FROM prohibited_words WHERE guild_id=$1", (guild_id,)
+    )
+    return [r["word"] for r in rows]
+
+
+async def add_prohibited_word(guild_id: int, word: str) -> bool:
+    """Returns True if newly added, False if already present."""
+    result = await get().execute(
+        "INSERT INTO prohibited_words (guild_id, word) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+        guild_id, word,
+    )
+    return result == "INSERT 0 1"
+
+
+async def remove_prohibited_word(guild_id: int, word: str) -> bool:
+    """Returns True if removed, False if not found."""
+    result = await get().execute(
+        "DELETE FROM prohibited_words WHERE guild_id=$1 AND word=$2", guild_id, word
+    )
+    return result == "DELETE 1"
+
+
+# ---------------------------------------------------------------------------
+# Deathmatch helpers  (replaces leaderboard.json)
+# ---------------------------------------------------------------------------
+
+async def get_deathmatch_stats(user_id: int) -> dict:
+    row = await fetchone(
+        "SELECT wins, losses FROM deathmatch_stats WHERE user_id=$1", (user_id,)
+    )
+    return row or {"wins": 0, "losses": 0}
+
+
+async def update_deathmatch(winner_id: int, loser_id: int) -> None:
+    pool = get()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """INSERT INTO deathmatch_stats (user_id, wins) VALUES ($1, 1)
+               ON CONFLICT (user_id) DO UPDATE SET wins=deathmatch_stats.wins+1""",
+            winner_id,
+        )
+        await conn.execute(
+            """INSERT INTO deathmatch_stats (user_id, losses) VALUES ($1, 1)
+               ON CONFLICT (user_id) DO UPDATE SET losses=deathmatch_stats.losses+1""",
+            loser_id,
+        )
+
+
+async def get_deathmatch_leaderboard() -> list[dict]:
+    return await fetchall(
+        "SELECT user_id, wins, losses FROM deathmatch_stats ORDER BY wins DESC LIMIT 15"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Chain channel helpers  (replaces chain_data.json)
+# ---------------------------------------------------------------------------
+
+async def get_chain_channel(channel_id: int) -> dict | None:
+    return await fetchone(
+        "SELECT word, word_limit, chain_count FROM chain_channels WHERE channel_id=$1",
+        (channel_id,),
+    )
+
+
+async def set_chain_channel(channel_id: int, guild_id: int, word: str, limit: int = 0) -> None:
+    await execute(
+        """INSERT INTO chain_channels (channel_id, guild_id, word, word_limit, chain_count)
+           VALUES ($1, $2, $3, $4, 0)
+           ON CONFLICT (channel_id) DO UPDATE SET word=EXCLUDED.word, word_limit=EXCLUDED.word_limit""",
+        (channel_id, guild_id, word, limit),
+    )
+
+
+async def delete_chain_channel(channel_id: int) -> None:
+    await execute("DELETE FROM chain_channels WHERE channel_id=$1", (channel_id,))
+
+
+async def set_chain_limit(channel_id: int, limit: int) -> None:
+    await execute(
+        "UPDATE chain_channels SET word_limit=$1 WHERE channel_id=$2", (limit, channel_id)
+    )
+
+
+async def increment_chain_count(channel_id: int) -> int:
+    row = await fetchone(
+        "UPDATE chain_channels SET chain_count=chain_count+1 WHERE channel_id=$1 RETURNING chain_count",
+        (channel_id,),
+    )
+    return row["chain_count"] if row else 0
+
+
+async def get_all_chain_channels(guild_id: int) -> list[dict]:
+    return await fetchall(
+        "SELECT channel_id, word, word_limit, chain_count FROM chain_channels WHERE guild_id=$1",
+        (guild_id,),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Counting state helpers  (replaces count_data.json)
+# ---------------------------------------------------------------------------
+
+async def get_counting_state(guild_id: int) -> dict:
+    row = await fetchone(
+        "SELECT state FROM counting_state WHERE guild_id=$1", (guild_id,)
+    )
+    return row["state"] if row else {}
+
+
+async def set_counting_state(guild_id: int, state: dict) -> None:
+    await execute(
+        """INSERT INTO counting_state (guild_id, state) VALUES ($1, $2::jsonb)
+           ON CONFLICT (guild_id) DO UPDATE SET state=EXCLUDED.state""",
+        (guild_id, state),
     )

--- a/disbot/utils/embeds.py
+++ b/disbot/utils/embeds.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+import discord
+
+
+def success(title: str, description: str = "", **fields: str) -> discord.Embed:
+    """Green success embed with optional extra fields."""
+    embed = discord.Embed(title=title, description=description, color=discord.Color.green())
+    for name, value in fields.items():
+        embed.add_field(name=name.replace("_", " ").title(), value=value, inline=True)
+    return embed
+
+
+def error(message: str) -> discord.Embed:
+    """Red error embed for user-facing error messages."""
+    return discord.Embed(description=f"❌ {message}", color=discord.Color.red())
+
+
+def info(title: str, description: str = "", **fields: str) -> discord.Embed:
+    """Blue informational embed with optional extra fields."""
+    embed = discord.Embed(title=title, description=description, color=discord.Color.blue())
+    for name, value in fields.items():
+        embed.add_field(name=name.replace("_", " ").title(), value=value, inline=True)
+    return embed
+
+
+def warning(message: str) -> discord.Embed:
+    """Yellow warning embed."""
+    return discord.Embed(description=f"⚠️ {message}", color=discord.Color.yellow())

--- a/disbot/utils/helpers.py
+++ b/disbot/utils/helpers.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+import discord
+from discord.ext import commands
+
+
+def normalize_name(name: str) -> str:
+    """Normalize a name to lowercase with no spaces for consistent role matching."""
+    return name.lower().replace(" ", "")
+
+
+class CogMenuView(discord.ui.View):
+    """Reusable buttonized quick-reference menu for a cog's main commands."""
+
+    def __init__(
+        self,
+        ctx: commands.Context,
+        title: str,
+        commands_info: list[tuple[str, str, str]],
+    ):
+        """
+        commands_info: list of (command_name, usage, description) — max 25 entries.
+        """
+        super().__init__(timeout=120)
+        self.ctx = ctx
+        self.title = title
+        self.commands_info = commands_info
+        self.message: discord.Message | None = None
+
+        for name, usage, desc in commands_info[:25]:
+            self.add_item(_CmdButton(name, usage, desc))
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        return True  # anyone can browse help menus
+
+    def build_embed(self) -> discord.Embed:
+        embed = discord.Embed(
+            title=self.title,
+            description="Click a button to see usage details for that command.",
+            color=discord.Color.blurple(),
+        )
+        for name, _, desc in self.commands_info:
+            embed.add_field(name=f"`!{name}`", value=desc, inline=True)
+        return embed
+
+    async def on_timeout(self) -> None:
+        for item in self.children:
+            item.disabled = True
+        if self.message:
+            try:
+                await self.message.edit(view=self)
+            except Exception:
+                pass
+
+
+class _CmdButton(discord.ui.Button):
+    def __init__(self, name: str, usage: str, description: str):
+        super().__init__(label=f"!{name}", style=discord.ButtonStyle.blurple)
+        self._name = name
+        self._usage = usage
+        self._description = description
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        embed = discord.Embed(
+            title=f"!{self._name}",
+            color=discord.Color.green(),
+        )
+        embed.add_field(name="Usage", value=f"`{self._usage}`", inline=False)
+        embed.add_field(name="Description", value=self._description, inline=False)
+        await interaction.response.send_message(embed=embed, ephemeral=True)

--- a/disbot/utils/helpers.py
+++ b/disbot/utils/helpers.py
@@ -3,6 +3,20 @@ import discord
 from discord.ext import commands
 
 
+async def post_log_embed(bot: commands.Bot, guild_id: int, embed: discord.Embed) -> None:
+    """Post an embed to the guild's configured economy_log_channel (if set)."""
+    from utils import db
+    cid = await db.get_setting(guild_id, "economy_log_channel", "")
+    if not cid:
+        return
+    ch = bot.get_channel(int(cid))
+    if ch:
+        try:
+            await ch.send(embed=embed)
+        except Exception:
+            pass
+
+
 def normalize_name(name: str) -> str:
     """Normalize a name to lowercase with no spaces for consistent role matching."""
     return name.lower().replace(" ", "")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ discord.py>=2.3.0
 python-dotenv>=1.0.0
 psutil>=5.9.0
 word2number>=1.1
-aiosqlite>=0.19.0
+asyncpg>=0.29.0
+aiohttp>=3.9.0


### PR DESCRIPTION
## Summary

- **PostgreSQL migration**: Replaced `aiosqlite` with `asyncpg` (connection pool, JSONB support, `$1`/`$2` numbered placeholders). All dynamic JSON file storage (mining inventory, deathmatch leaderboard, chain channels, counting state, prohibited words) moved into PostgreSQL tables. No data migration needed — bot is not in active servers.
- **Shared helper consolidation**: Added `utils/cooldowns.py` (shared `check_cooldown()` + `format_remaining()`), `utils/embeds.py` (success/error/info/warning builders), and centralized the duplicate log-posting functions (`post_economy_log` in economy_cog + `_post_log` in xp_cog) into a single `helpers.post_log_embed()`.
- **Channel management UI overhaul**: `!channelcreator` / `!ccreate` now opens a full interactive Discord panel with three sub-panels — **Create Channel** (name/category pickers + custom name modal), **Delete Channel** (channel select + confirmation step), and **Manage Restrictions** (channel select + Lock / Unlock / Archive / Unarchive buttons). All transitions happen in-place via `edit_message`; each sub-panel has a Back button.
- **Session 1 fixes (already merged via previous commits)**: Role commands + reaction roles moved to `role_cog`; case/space-insensitive role normalization; `!list` shows uncategorized channels; every cog has a buttonized menu command.

## Detailed changes

| File | What changed |
|---|---|
| `requirements.txt` | `asyncpg>=0.29.0`, `aiohttp>=3.9.0` added; `aiosqlite` removed |
| `utils/db.py` | Full rewrite — asyncpg pool, JSONB codec, new tables + helpers for all migrated data |
| `utils/helpers.py` | Added `post_log_embed()` |
| `utils/cooldowns.py` | **New** — `check_cooldown()`, `format_remaining()` |
| `utils/embeds.py` | **New** — `success()`, `error()`, `info()`, `warning()` embed builders |
| `cogs/channel_cog.py` | `channelcreator` expanded into full 3-mode panel (`_ChannelManagerView` → `_CreateSubView` / `_DeleteSubView` / `_RestrictSubView`) |
| `cogs/economy_cog.py` | Uses `post_log_embed`, `check_cooldown`, `format_remaining` |
| `cogs/xp_cog.py` | Uses `post_log_embed`, `check_cooldown` |
| `cogs/mining_cog.py` | File-based storage replaced with `db.get/update/set_mining_inventory` |
| `cogs/deathmatch_cog.py` | File-based leaderboard replaced with `db.update_deathmatch` / `get_deathmatch_leaderboard` |
| `cogs/cleanup_cog.py` | File-based word list → DB; `addword`/`removeword` merged into `!word add/remove/list` group |
| `cogs/chain_cog.py` | File-based channel map → DB chain channel helpers |
| `cogs/counting_cog.py` | File-based state → DB JSONB; `cog_load()` populates in-memory cache from DB on startup |
| `cogs/utility_cog.py` | `!serverinfo`/`!userinfo` merged into `!info [server\|user]`; blocking `sleep` → `ensure_future` |
| `cogs/proof_channel_cog.py` | `timedprize` uses `ensure_future` + cancellable task tracking |
| `config.py` | `DATABASE_URL` documented |

## Test plan

- [ ] Set `DATABASE_URL` pointing at a PostgreSQL instance and start the bot — confirm all tables are created without errors
- [ ] Run `!channelcreator` and walk through all three sub-panels (create, delete, restrict)
- [ ] Send messages to verify XP gain, level-up announcements, and cooldowns work
- [ ] Test `!economy`, `!mine`, `!deathmatch` flows
- [ ] Test `!word add <word>`, `!word remove <word>`, `!word list` in cleanup cog
- [ ] Verify `!chain set`, `!chain start`, `!chain end` use DB-backed state
- [ ] Confirm `!count` counting game persists across restarts (loads from DB on startup)

https://claude.ai/code/session_01RLZ6pYDqgix51GUjws4k15

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLZ6pYDqgix51GUjws4k15)_