### PR TITLE
Fix post-migration bugs: SQL placeholders, missing cog, counting state load

### DIFF
--- a/disbot/cogs/counting_cog.py
+++ b/disbot/cogs/counting_cog.py
@@ -153,7 +153,11 @@ class CountingCog(commands.Cog):
         }
 
     async def cog_load(self):
-        """Load counting state for all guilds from the database."""
+        """Schedule DB state load for after the bot is connected."""
+        asyncio.ensure_future(self._load_when_ready())
+
+    async def _load_when_ready(self):
+        await self.bot.wait_until_ready()
         for guild in self.bot.guilds:
             self.count_data[str(guild.id)] = await db.get_counting_state(guild.id)
 

--- a/disbot/cogs/xp_cog.py
+++ b/disbot/cogs/xp_cog.py
@@ -129,10 +129,10 @@ class XpCog(commands.Cog):
         level, current, needed = db.level_progress(row["xp"])
 
         all_xp = await db.fetchall(
-            "SELECT user_id FROM xp WHERE guild_id=? ORDER BY xp DESC", (ctx.guild.id,)
+            "SELECT user_id FROM xp WHERE guild_id=$1 ORDER BY xp DESC", (ctx.guild.id,)
         )
         all_coins = await db.fetchall(
-            "SELECT user_id FROM xp WHERE guild_id=? ORDER BY coins DESC", (ctx.guild.id,)
+            "SELECT user_id FROM xp WHERE guild_id=$1 ORDER BY coins DESC", (ctx.guild.id,)
         )
         xp_rank = next((i + 1 for i, r in enumerate(all_xp)    if r["user_id"] == member.id), "?")
         co_rank = next((i + 1 for i, r in enumerate(all_coins)  if r["user_id"] == member.id), "?")
@@ -173,7 +173,7 @@ class XpCog(commands.Cog):
         lines = []
         if stat == "xp":
             rows = await db.fetchall(
-                "SELECT user_id, xp, level FROM xp WHERE guild_id=? ORDER BY xp DESC LIMIT 10",
+                "SELECT user_id, xp, level FROM xp WHERE guild_id=$1 ORDER BY xp DESC LIMIT 10",
                 (ctx.guild.id,),
             )
             title = "🏆 XP Leaderboard"
@@ -184,7 +184,7 @@ class XpCog(commands.Cog):
                 lines.append(f"{icon} **{name}** — Level {row['level']} ({row['xp']} XP)")
         else:  # coins
             rows = await db.fetchall(
-                "SELECT user_id, coins FROM xp WHERE guild_id=? ORDER BY coins DESC LIMIT 10",
+                "SELECT user_id, coins FROM xp WHERE guild_id=$1 ORDER BY coins DESC LIMIT 10",
                 (ctx.guild.id,),
             )
             title = "🪙 Coin Leaderboard"
@@ -216,7 +216,7 @@ class XpCog(commands.Cog):
     async def resetxp(self, ctx: commands.Context, member: discord.Member):
         """Reset a user's XP to zero (admin only)."""
         await db.execute(
-            "DELETE FROM xp WHERE user_id=? AND guild_id=?", (member.id, ctx.guild.id)
+            "DELETE FROM xp WHERE user_id=$1 AND guild_id=$2", (member.id, ctx.guild.id)
         )
         await ctx.send(f"✅ Reset XP for {member.mention}.")
 

--- a/disbot/config.py
+++ b/disbot/config.py
@@ -45,6 +45,7 @@ INITIAL_EXTENSIONS = [
     "cogs.economy_cog",
     "cogs.counting_cog",
     "cogs.deathmatch_cog",
+    "cogs.proof_channel_cog",
 ]
 
 # ==========================


### PR DESCRIPTION
## Summary

Three bugs found during post-migration audit that were not included in PR #27.

- **`xp_cog.py`** — 5 raw SQL queries (`!rank`, `!leaderboard`, `!resetxp`) still used SQLite-style `?` placeholders instead of asyncpg `$1`/`$2`. These would raise a runtime error on every call.
- **`config.py`** — `proof_channel_cog` was never added to `INITIAL_EXTENSIONS`, so `!+prize`, `!-prize`, and `!timedprize` were silently unavailable after startup.
- **`counting_cog.py`** — `cog_load()` iterated `self.bot.guilds` to restore counting state from the database, but cogs are loaded before `bot.start()` so the guild list is always empty. Replaced with `ensure_future(_load_when_ready())` which defers the DB fetch until `wait_until_ready()`.

## Test plan

- [ ] Run `!rank`, `!leaderboard`, `!resetxp` — confirm no asyncpg placeholder errors
- [ ] Restart bot and verify `!+prize @user` works (proof_channel_cog loaded)
- [ ] Start a counting match, restart the bot, verify the count resumes correctly

https://claude.ai/code/session_01RLZ6pYDqgix51GUjws4k15

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLZ6pYDqgix51GUjws4k15)_