### PR TITLE
fix: apply configurable warn threshold to mod panel warn button

### DIFF
--- a/disbot/cogs/moderation_cog.py
+++ b/disbot/cogs/moderation_cog.py
@@ -58,24 +58,32 @@ class _WarnModal(discord.ui.Modal, title="Warn Member"):  # type: ignore[call-ar
         if err:
             await interaction.response.send_message(err, ephemeral=True)
             return
+        threshold = int(
+            await db.get_setting(interaction.guild_id, "warn_threshold", "3")
+        )
+        timeout_minutes = int(
+            await db.get_setting(interaction.guild_id, "warn_timeout_minutes", "10")
+        )
         count = await db.add_warning(member.id, interaction.guild_id)
         await interaction.response.send_message(
-            f"⚠️ {member.mention} warned ({count}/3). Reason: {reason}", ephemeral=False
+            f"⚠️ {member.mention} warned ({count}/{threshold}). Reason: {reason}",
+            ephemeral=False,
         )
         await db.log_mod_action(
             interaction.guild_id, "warn", member.id, interaction.user.id, reason
         )
-        if count >= 3:
+        if count >= threshold:
             try:
-                until = discord.utils.utcnow() + timedelta(minutes=10)
-                await member.timeout(until, reason="3 warnings reached.")
+                until = discord.utils.utcnow() + timedelta(minutes=timeout_minutes)
+                await member.timeout(until, reason=f"{threshold} warnings reached.")
                 await interaction.followup.send(
-                    f"⏳ {member.mention} timed out for 10 minutes (3 warnings)."
+                    f"⏳ {member.mention} timed out for {timeout_minutes} minutes "
+                    f"({threshold} warnings)."
                 )
                 await db.clear_warnings(member.id, interaction.guild_id)
             except discord.Forbidden:
                 await interaction.followup.send(
-                    "⚠️ 3 warnings reached but I lack permission to timeout.",
+                    f"⚠️ {threshold} warnings reached but I lack permission to timeout.",
                     ephemeral=True,
                 )
 


### PR DESCRIPTION
## Summary

Caught during the Tier 1 verification audit. The `!warn` text command was correctly updated to read `warn_threshold` and `warn_timeout_minutes` from `guild_settings`, but the `_WarnModal` used by the **moderation panel button** still had hardcoded values (`3` warnings, `10` minutes). Both code paths now use the same guild-configurable settings.

- `_WarnModal.on_submit` now reads `warn_threshold` from `guild_settings` (default `"3"`)
- `_WarnModal.on_submit` now reads `warn_timeout_minutes` from `guild_settings` (default `"10"`)
- Warn progress display (`1/3`) and timeout messages reflect the configured threshold
- Behavior is identical to the `!warn` text command path

## Test Plan

- [x] Verified `!warn` text command reads threshold from `guild_settings`
- [x] Verified `_WarnModal` (mod panel button) now reads the same `warn_threshold` setting
- [x] Verified `_WarnModal` now reads `warn_timeout_minutes` instead of hardcoding 10
- [x] Confirmed warn count display uses `{count}/{threshold}` (not hardcoded `/3`)
- [x] Confirmed timeout reason string uses configurable threshold value
- [x] Confirmed followup message uses configurable `timeout_minutes` value
- [x] `PermissionDenied` message uses configurable threshold (not hardcoded `"3 warnings reached"`)
- [x] Default behavior unchanged when guild has no custom settings (still 3 warnings → 10 min timeout)
- [x] `black --check` passes — no formatting violations
- [x] `python -m compileall disbot` passes — zero syntax errors
- [x] All 89 Tier 1 verification checks pass

https://claude.ai/code/session_016snZd5xgW3i9mmAB1BGKZi

---
_Generated by [Claude Code](https://claude.ai/code/session_016snZd5xgW3i9mmAB1BGKZi)_