### PR TITLE
Add XP-based role auto-assignment on level-up

### DIFF
--- a/disbot/cogs/channel_cog.py
+++ b/disbot/cogs/channel_cog.py
@@ -472,7 +472,9 @@ def _build_channel_options(guild: discord.Guild) -> list[discord.SelectOption]:
     )
     options = []
     for ch in channels[:25]:
-        emoji = safe_select_emoji("🔊" if isinstance(ch, discord.VoiceChannel) else "💬")
+        emoji = safe_select_emoji(
+            "🔊" if isinstance(ch, discord.VoiceChannel) else "💬"
+        )
         cat_label = ch.category.name if ch.category else "No category"
         options.append(
             discord.SelectOption(

--- a/disbot/cogs/channel_cog.py
+++ b/disbot/cogs/channel_cog.py
@@ -5,6 +5,7 @@ import logging
 import discord
 from discord.ext import commands
 from utils.channels import get_or_create_category, safe_channel_name
+from utils.helpers import safe_select_emoji
 
 logger = logging.getLogger("bot")
 
@@ -192,10 +193,8 @@ class ChannelCog(commands.Cog):
     )
     @is_admin_or_owner()
     async def channel_creator(self, ctx):
-        """Opens the comprehensive channel management panel."""
-        view = _ChannelManagerView(ctx)
-        msg = await ctx.send(embed=view.build_embed(), view=view)
-        view.message = msg
+        """Opens the comprehensive channel management panel (alias for !channelmenu)."""
+        await ctx.invoke(self.channel_menu)
 
     @commands.command(
         name="bulkdelete",
@@ -443,12 +442,8 @@ class ChannelCog(commands.Cog):
     )
     @is_admin_or_owner()
     async def archive_channel(self, ctx, channel_name: str):
-        channel = self._resolve_channel(ctx.guild, channel_name)
-        if channel:
-            await channel.set_permissions(ctx.guild.default_role, send_messages=False)
-            await ctx.send(f'"{channel.name}" archived (read-only).')
-        else:
-            await ctx.send(f'"{channel_name}" not found.')
+        """Alias for !lock — sets send_messages=False for @everyone."""
+        await ctx.invoke(self.lock_channel, channel_name=channel_name)
 
     @commands.command(
         name="unarchive",
@@ -456,12 +451,8 @@ class ChannelCog(commands.Cog):
     )
     @is_admin_or_owner()
     async def unarchive_channel(self, ctx, channel_name: str):
-        channel = self._resolve_channel(ctx.guild, channel_name)
-        if channel:
-            await channel.set_permissions(ctx.guild.default_role, send_messages=True)
-            await ctx.send(f'"{channel.name}" unarchived.')
-        else:
-            await ctx.send(f'"{channel_name}" not found.')
+        """Alias for !unlock — sets send_messages=True for @everyone."""
+        await ctx.invoke(self.unlock_channel, channel_name=channel_name)
 
 
 # =====================================================================
@@ -481,7 +472,7 @@ def _build_channel_options(guild: discord.Guild) -> list[discord.SelectOption]:
     )
     options = []
     for ch in channels[:25]:
-        emoji = "🔊" if isinstance(ch, discord.VoiceChannel) else "#"
+        emoji = safe_select_emoji("🔊" if isinstance(ch, discord.VoiceChannel) else "💬")
         cat_label = ch.category.name if ch.category else "No category"
         options.append(
             discord.SelectOption(

--- a/disbot/cogs/role_cog.py
+++ b/disbot/cogs/role_cog.py
@@ -548,6 +548,119 @@ class _RolePanelView(discord.ui.View):
                 pass
 
 
+class _RoleAutomationView(discord.ui.View):
+    """Offered after role creation: configure XP-based auto-assignment or skip."""
+
+    def __init__(self, ctx: commands.Context, role_name: str):
+        super().__init__(timeout=120)
+        self.ctx = ctx
+        self.role_name = role_name
+        self.message: discord.Message | None = None
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user != self.ctx.author:
+            await interaction.response.send_message(
+                "This panel isn't for you.", ephemeral=True
+            )
+            return False
+        return True
+
+    @discord.ui.button(
+        label="⚙️ Configure Automation", style=discord.ButtonStyle.blurple, row=0
+    )
+    async def configure_btn(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ):
+        await interaction.response.send_modal(
+            _RoleAutomationModal(self.ctx, self.role_name, self)
+        )
+
+    @discord.ui.button(label="⏭️ Skip", style=discord.ButtonStyle.secondary, row=0)
+    async def skip_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        for item in self.children:
+            item.disabled = True
+        await interaction.response.edit_message(
+            content=f"✅ Role **{self.role_name}** created. No automation configured.",
+            view=self,
+        )
+        self.stop()
+
+    async def on_timeout(self) -> None:
+        for item in self.children:
+            item.disabled = True
+        if self.message:
+            try:
+                await self.message.edit(view=self)
+            except Exception:
+                pass
+
+
+class _RoleAutomationModal(discord.ui.Modal, title="Configure XP Automation"):  # type: ignore[call-arg]
+    level_threshold = discord.ui.TextInput(
+        label="XP level required (e.g. 5)",
+        placeholder="e.g. 5",
+        required=True,
+        max_length=4,
+    )
+    auto_assign_enabled = discord.ui.TextInput(
+        label="Enable auto-assign? (yes/no)",
+        placeholder="yes",
+        required=False,
+        max_length=3,
+    )
+
+    def __init__(
+        self,
+        ctx: commands.Context,
+        role_name: str,
+        parent_view: _RoleAutomationView,
+    ):
+        super().__init__()
+        self.ctx = ctx
+        self.role_name = role_name
+        self._parent_view = parent_view
+
+    async def on_submit(self, interaction: discord.Interaction):
+        raw_level = self.level_threshold.value.strip()
+        try:
+            level = int(raw_level)
+            if level < 0:
+                raise ValueError
+        except ValueError:
+            await interaction.response.send_message(
+                "❌ Level threshold must be a non-negative integer (e.g. `5`).",
+                ephemeral=True,
+            )
+            return
+
+        raw_auto = self.auto_assign_enabled.value.strip().lower()
+        auto_assign = raw_auto not in ("no", "n", "false", "0")
+
+        try:
+            await db.set_role_xp_threshold(
+                interaction.guild.id, self.role_name, level, auto_assign
+            )
+        except Exception as exc:
+            logger.error("set_role_xp_threshold failed: %s", exc, exc_info=True)
+            await interaction.response.send_message(
+                f"❌ Failed to save automation config: {exc}", ephemeral=True
+            )
+            return
+
+        for item in self._parent_view.children:
+            item.disabled = True
+        status = "enabled" if auto_assign else "saved (auto-assign disabled)"
+        await interaction.response.edit_message(
+            content=(
+                f"✅ Role **{self.role_name}** XP automation {status}.\n"
+                f"Level threshold: **{level}** | "
+                f"Auto-assign: **{'yes' if auto_assign else 'no'}**"
+            ),
+            view=self._parent_view,
+        )
+        self._parent_view.stop()
+
+
 class _RoleCreateModal(discord.ui.Modal, title="Create Role"):  # type: ignore[call-arg]
     name = discord.ui.TextInput(label="Role name", max_length=100)
     color = discord.ui.TextInput(
@@ -594,9 +707,14 @@ class _RoleCreateModal(discord.ui.Modal, title="Create Role"):  # type: ignore[c
                 hoist=do_hoist,
                 mentionable=do_mention,
             )
+            automation_view = _RoleAutomationView(self.ctx, role.name)
             await interaction.response.send_message(
-                f"✅ Created role **{role.name}**.", ephemeral=True
+                f"✅ Created role **{role.name}**.\n"
+                "Would you like to configure XP-based auto-assignment for this role?",
+                ephemeral=True,
+                view=automation_view,
             )
+            automation_view.message = await interaction.original_response()
         except discord.Forbidden:
             await interaction.response.send_message(
                 "❌ I don't have permission to create roles.", ephemeral=True

--- a/disbot/cogs/xp_cog.py
+++ b/disbot/cogs/xp_cog.py
@@ -186,7 +186,10 @@ class XpCog(commands.Cog):
                                     discord_role.name,
                                     new_level,
                                 )
-                            except (discord.Forbidden, discord.HTTPException) as role_err:
+                            except (
+                                discord.Forbidden,
+                                discord.HTTPException,
+                            ) as role_err:
                                 logger.warning(
                                     "Could not assign XP role %s to %s: %s",
                                     discord_role.name,

--- a/disbot/cogs/xp_cog.py
+++ b/disbot/cogs/xp_cog.py
@@ -166,6 +166,40 @@ class XpCog(commands.Cog):
             )
             await post_log_embed(self.bot, guild_id, log_embed)
 
+            # XP threshold role assignment
+            try:
+                xp_roles = await db.get_xp_threshold_roles(guild_id)
+                for role_cfg in xp_roles:
+                    if role_cfg["level_required"] <= new_level:
+                        discord_role = discord.utils.get(
+                            message.guild.roles, name=role_cfg["role_name"]
+                        )
+                        if discord_role and discord_role not in message.author.roles:
+                            try:
+                                await message.author.add_roles(
+                                    discord_role,
+                                    reason=f"XP level-up: reached level {new_level}",
+                                )
+                                logger.info(
+                                    "XP role assigned: %s → %s (level %d)",
+                                    message.author.display_name,
+                                    discord_role.name,
+                                    new_level,
+                                )
+                            except (discord.Forbidden, discord.HTTPException) as role_err:
+                                logger.warning(
+                                    "Could not assign XP role %s to %s: %s",
+                                    discord_role.name,
+                                    message.author.display_name,
+                                    role_err,
+                                )
+            except Exception:
+                logger.error(
+                    "XP role assignment check failed for guild %d",
+                    guild_id,
+                    exc_info=True,
+                )
+
     # ------------------------------------------------------------------ commands
 
     @commands.command(name="rank")

--- a/disbot/migrations/003_role_xp_thresholds.sql
+++ b/disbot/migrations/003_role_xp_thresholds.sql
@@ -1,0 +1,6 @@
+-- Migration 003: Add XP-based auto-assignment columns to role_thresholds
+-- Additive-only: no DROP, no data loss, existing rows keep NULL/FALSE defaults.
+
+ALTER TABLE role_thresholds
+    ADD COLUMN IF NOT EXISTS level_required INTEGER DEFAULT NULL,
+    ADD COLUMN IF NOT EXISTS xp_auto_assign BOOLEAN NOT NULL DEFAULT FALSE;

--- a/disbot/utils/db.py
+++ b/disbot/utils/db.py
@@ -334,8 +334,8 @@ async def set_setting(guild_id: int, key: str, value: str) -> None:
 
 async def get_role_thresholds(guild_id: int) -> list[dict]:
     return await fetchall(
-        "SELECT role_name, days_required FROM role_thresholds "
-        "WHERE guild_id=$1 ORDER BY days_required",
+        "SELECT role_name, days_required, level_required, xp_auto_assign "
+        "FROM role_thresholds WHERE guild_id=$1 ORDER BY days_required",
         (guild_id,),
     )
 
@@ -353,6 +353,38 @@ async def remove_role_threshold(guild_id: int, role_name: str) -> None:
     await execute(
         "DELETE FROM role_thresholds WHERE guild_id=$1 AND role_name=$2",
         (guild_id, role_name),
+    )
+
+
+async def get_xp_threshold_roles(guild_id: int) -> list[dict]:
+    """Return rows with xp_auto_assign=TRUE and a configured level_required."""
+    return await fetchall(
+        "SELECT role_name, level_required FROM role_thresholds "
+        "WHERE guild_id=$1 AND xp_auto_assign=TRUE AND level_required IS NOT NULL "
+        "ORDER BY level_required",
+        (guild_id,),
+    )
+
+
+async def set_role_xp_threshold(
+    guild_id: int,
+    role_name: str,
+    level_required: int | None,
+    auto_assign: bool,
+) -> None:
+    """Upsert the XP automation columns for a role threshold row.
+
+    If no row exists for (guild_id, role_name), inserts one with days_required=0.
+    Only updates the XP columns; existing days_required is preserved on conflict.
+    """
+    await execute(
+        """INSERT INTO role_thresholds
+               (guild_id, role_name, days_required, level_required, xp_auto_assign)
+           VALUES ($1, $2, 0, $3, $4)
+           ON CONFLICT (guild_id, role_name) DO UPDATE SET
+               level_required = EXCLUDED.level_required,
+               xp_auto_assign = EXCLUDED.xp_auto_assign""",
+        (guild_id, role_name, level_required, auto_assign),
     )
 
 

--- a/disbot/utils/helpers.py
+++ b/disbot/utils/helpers.py
@@ -1,7 +1,38 @@
 from __future__ import annotations
 
+import re
+
 import discord
 from discord.ext import commands
+
+_CUSTOM_EMOJI_RE = re.compile(r"<a?:(\w+):(\d+)>")
+
+
+def safe_select_emoji(
+    value: str | discord.PartialEmoji | None,
+) -> str | discord.PartialEmoji | None:
+    """Return a valid SelectOption emoji or None if the value cannot be used.
+
+    Handles unicode emoji strings, <:name:id> custom emoji, and PartialEmoji
+    objects. Rejects plain ASCII characters that Discord rejects.
+    """
+    if value is None:
+        return None
+    if isinstance(value, discord.PartialEmoji):
+        return value
+    if not isinstance(value, str) or not value.strip():
+        return None
+    stripped = value.strip()
+    m = _CUSTOM_EMOJI_RE.match(stripped)
+    if m:
+        animated = stripped.startswith("<a:")
+        return discord.PartialEmoji(
+            name=m.group(1), id=int(m.group(2)), animated=animated
+        )
+    # Reject single plain ASCII characters (e.g. "#") — not valid Discord emoji
+    if len(stripped) == 1 and ord(stripped) < 128:
+        return None
+    return stripped
 
 
 async def post_log_embed(


### PR DESCRIPTION
## Summary
This PR adds XP-based automatic role assignment functionality. When users reach a configured XP level, they are automatically assigned a corresponding role. Role creators can now configure this automation immediately after role creation via a modal dialog.

## Key Changes

- **Role Creation Flow**: Added `_RoleAutomationView` and `_RoleAutomationModal` to the role creation process, allowing users to configure XP thresholds and auto-assignment settings immediately after creating a role
- **XP Role Assignment**: Implemented automatic role assignment in `xp_cog.py` that triggers when a user's XP level reaches or exceeds a configured threshold
- **Database Schema**: Added migration `003_role_xp_thresholds.sql` with two new columns to `role_thresholds` table:
  - `level_required`: The XP level threshold for role assignment
  - `xp_auto_assign`: Boolean flag to enable/disable auto-assignment
- **Database Functions**: Added `get_xp_threshold_roles()` to fetch roles with active XP automation and `set_role_xp_threshold()` to upsert XP configuration
- **Helper Utility**: Added `safe_select_emoji()` function to validate and normalize emoji values for Discord SelectOption components
- **Channel Cog Refactoring**: Simplified `archive_channel` and `unarchive_channel` commands to delegate to existing `lock_channel` and `unlock_channel` commands; updated channel selector to use `safe_select_emoji()` and replaced "#" with "💬" emoji

## Implementation Details

- The XP role assignment check runs after each XP gain and only assigns roles the user doesn't already have
- The modal accepts level thresholds as non-negative integers and auto-assign preference as yes/no/true/false
- Role assignment includes proper error handling and logging for permission issues
- The automation view has a 120-second timeout with graceful UI cleanup
- Database upsert preserves existing `days_required` values when updating XP columns

https://claude.ai/code/session_01VoQWydqbD5Po3K2Po9QKAF