### PR TITLE
feat: full UX modernization — interactive panels, BaseView consistency, unified inventory

### DIFF
--- a/disbot/cogs/chain_cog.py
+++ b/disbot/cogs/chain_cog.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 from typing import Optional
@@ -6,6 +8,7 @@ import discord
 from discord.ext import commands
 from discord.ext.commands import MissingPermissions, has_permissions
 from utils import db
+from views.base import BaseView
 
 logger = logging.getLogger(__name__)
 
@@ -187,6 +190,15 @@ class ChainCog(commands.Cog):
             await ctx.send(f"❌ An error occurred: {str(error)}")
             logger.error(f"Error in remove_limit command: {error}")
 
+    @commands.command(name="chainmenu")
+    @has_permissions(administrator=True)
+    async def chain_menu(self, ctx):
+        """Open the interactive chain management panel."""
+        view = _ChainMenuView(ctx, self)
+        embed = await view.build_embed()
+        msg = await ctx.send(embed=embed, view=view)
+        view.message = msg
+
     @chain.command(name="list")
     async def list_chains(self, ctx):
         """
@@ -292,6 +304,171 @@ class ChainCog(commands.Cog):
     async def on_ready(self):
         """Event handler when the cog is ready."""
         logger.info(f"{self.__class__.__name__} is ready and operational.")
+
+
+def _resolve_channel(
+    interaction: discord.Interaction, raw: str
+) -> discord.TextChannel | None:
+    raw = raw.strip()
+    if not raw:
+        return interaction.channel
+    stripped = raw.strip("<#>")
+    try:
+        return interaction.guild.get_channel(int(stripped))
+    except ValueError:
+        return discord.utils.get(interaction.guild.text_channels, name=raw)
+
+
+class _CreateChainModal(discord.ui.Modal, title="Create Chain"):  # type: ignore[call-arg]
+    channel_input = discord.ui.TextInput(
+        label="Channel (mention/ID, blank = current)", max_length=40, required=False
+    )
+    word_input = discord.ui.TextInput(label="Allowed word", max_length=100)
+
+    def __init__(self, cog: "ChainCog"):
+        super().__init__()
+        self.cog = cog
+
+    async def on_submit(self, interaction: discord.Interaction):
+        channel = _resolve_channel(interaction, self.channel_input.value)
+        if not channel:
+            await interaction.response.send_message(
+                "❌ Channel not found.", ephemeral=True
+            )
+            return
+        word = self.word_input.value.lower().strip()
+        existing = await db.get_chain_channel(channel.id)
+        if existing and existing.get("word"):
+            await interaction.response.send_message(
+                f"❌ A chain is already active in {channel.mention}.", ephemeral=True
+            )
+            return
+        await db.set_chain_channel(channel.id, interaction.guild_id, word)
+        await interaction.response.send_message(
+            f"✅ Chain created in {channel.mention}. Only `{word}` is allowed.",
+            ephemeral=True,
+        )
+
+
+class _DeleteChainModal(discord.ui.Modal, title="Delete Chain"):  # type: ignore[call-arg]
+    channel_input = discord.ui.TextInput(
+        label="Channel (mention/ID, blank = current)", max_length=40, required=False
+    )
+
+    def __init__(self, cog: "ChainCog"):
+        super().__init__()
+        self.cog = cog
+
+    async def on_submit(self, interaction: discord.Interaction):
+        channel = _resolve_channel(interaction, self.channel_input.value)
+        if not channel:
+            await interaction.response.send_message(
+                "❌ Channel not found.", ephemeral=True
+            )
+            return
+        existing = await db.get_chain_channel(channel.id)
+        if not existing:
+            await interaction.response.send_message(
+                f"❌ No active chain found in {channel.mention}.", ephemeral=True
+            )
+            return
+        await db.delete_chain_channel(channel.id)
+        await interaction.response.send_message(
+            f"✅ Chain deleted from {channel.mention}.", ephemeral=True
+        )
+
+
+class _SetLimitModal(discord.ui.Modal, title="Set Word Limit"):  # type: ignore[call-arg]
+    channel_input = discord.ui.TextInput(
+        label="Channel (mention/ID, blank = current)", max_length=40, required=False
+    )
+    limit_input = discord.ui.TextInput(
+        label="Word limit (0 = remove limit)", max_length=10
+    )
+
+    def __init__(self, cog: "ChainCog"):
+        super().__init__()
+        self.cog = cog
+
+    async def on_submit(self, interaction: discord.Interaction):
+        channel = _resolve_channel(interaction, self.channel_input.value)
+        if not channel:
+            await interaction.response.send_message(
+                "❌ Channel not found.", ephemeral=True
+            )
+            return
+        if not self.limit_input.value.strip().isdigit():
+            await interaction.response.send_message(
+                "❌ Limit must be a non-negative integer.", ephemeral=True
+            )
+            return
+        limit = int(self.limit_input.value.strip())
+        existing = await db.get_chain_channel(channel.id)
+        if not existing:
+            await interaction.response.send_message(
+                f"❌ No active chain in {channel.mention}. Create one first.",
+                ephemeral=True,
+            )
+            return
+        await db.set_chain_limit(channel.id, limit)
+        if limit == 0:
+            await interaction.response.send_message(
+                f"✅ Word limit removed from {channel.mention}.", ephemeral=True
+            )
+        else:
+            await interaction.response.send_message(
+                f"✅ Word limit set to {limit} words in {channel.mention}.",
+                ephemeral=True,
+            )
+
+
+class _ChainMenuView(BaseView):
+    """Interactive chain channel management panel."""
+
+    def __init__(self, ctx: commands.Context, cog: "ChainCog"):
+        super().__init__(ctx.author, timeout=180)
+        self.ctx = ctx
+        self.cog = cog
+
+    async def build_embed(self) -> discord.Embed:
+        channels = await db.get_all_chain_channels(self.ctx.guild.id)
+        embed = discord.Embed(title="⛓️ Chain Manager", color=discord.Color.blue())
+        if not channels:
+            embed.description = "No active chains in this server."
+        else:
+            lines = []
+            for entry in channels:
+                ch = self.cog.bot.get_channel(entry["channel_id"])
+                name = ch.mention if ch else f"<#{entry['channel_id']}>"
+                parts = []
+                if entry.get("word"):
+                    parts.append(f"word: `{entry['word']}`")
+                if entry.get("word_limit"):
+                    parts.append(f"limit: `{entry['word_limit']}`")
+                lines.append(f"{name} — {', '.join(parts) or 'no restrictions'}")
+            embed.description = "\n".join(lines)
+        embed.set_footer(text="Use buttons below to manage chains.")
+        return embed
+
+    @discord.ui.button(label="➕ Create Chain", style=discord.ButtonStyle.green, row=0)
+    async def btn_create(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await interaction.response.send_modal(_CreateChainModal(self.cog))
+
+    @discord.ui.button(label="🗑️ Delete Chain", style=discord.ButtonStyle.danger, row=0)
+    async def btn_delete(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await interaction.response.send_modal(_DeleteChainModal(self.cog))
+
+    @discord.ui.button(label="📏 Set Limit", style=discord.ButtonStyle.blurple, row=0)
+    async def btn_setlimit(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ):
+        await interaction.response.send_modal(_SetLimitModal(self.cog))
+
+    @discord.ui.button(label="🔄 Refresh", style=discord.ButtonStyle.secondary, row=1)
+    async def btn_refresh(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await interaction.response.edit_message(
+            embed=await self.build_embed(), view=self
+        )
 
 
 # Asynchronous setup for discord.py 2.x

--- a/disbot/cogs/cleanup_cog.py
+++ b/disbot/cogs/cleanup_cog.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 import re
@@ -6,6 +8,7 @@ import config as _config
 import discord
 from discord.ext import commands
 from utils import db
+from views.base import BaseView
 
 
 class Cleanup(commands.Cog):
@@ -193,6 +196,96 @@ class Cleanup(commands.Cog):
             await ctx.send(f"Prohibited words: {word_list}", delete_after=15)
         else:
             await ctx.send("No prohibited words are currently set.", delete_after=10)
+
+    @commands.command(name="wordmenu")
+    @commands.has_permissions(administrator=True)
+    async def word_menu(self, ctx):
+        """Open the interactive prohibited words management panel."""
+        if ctx.guild.id not in self._word_cache:
+            await self._load_guild(ctx.guild.id)
+        view = _WordMenuView(ctx, self)
+        msg = await ctx.send(embed=view.build_embed(), view=view)
+        view.message = msg
+
+
+class _AddWordModal(discord.ui.Modal, title="Add Prohibited Word"):  # type: ignore[call-arg]
+    word_input = discord.ui.TextInput(label="Word to prohibit", max_length=100)
+
+    def __init__(self, cog: "Cleanup"):
+        super().__init__()
+        self.cog = cog
+
+    async def on_submit(self, interaction: discord.Interaction):
+        word = self.word_input.value.lower().strip()
+        added = await db.add_prohibited_word(interaction.guild_id, word)
+        if added:
+            await self.cog._load_guild(interaction.guild_id)
+            await interaction.response.send_message(
+                f"✅ Added `{word}` to the prohibited list.", ephemeral=True
+            )
+        else:
+            await interaction.response.send_message(
+                f"❌ `{word}` is already in the prohibited list.", ephemeral=True
+            )
+
+
+class _RemoveWordModal(discord.ui.Modal, title="Remove Prohibited Word"):  # type: ignore[call-arg]
+    word_input = discord.ui.TextInput(label="Word to remove", max_length=100)
+
+    def __init__(self, cog: "Cleanup"):
+        super().__init__()
+        self.cog = cog
+
+    async def on_submit(self, interaction: discord.Interaction):
+        word = self.word_input.value.lower().strip()
+        removed = await db.remove_prohibited_word(interaction.guild_id, word)
+        if removed:
+            await self.cog._load_guild(interaction.guild_id)
+            await interaction.response.send_message(
+                f"✅ Removed `{word}` from the prohibited list.", ephemeral=True
+            )
+        else:
+            await interaction.response.send_message(
+                f"❌ `{word}` was not in the prohibited list.", ephemeral=True
+            )
+
+
+class _WordMenuView(BaseView):
+    """Interactive prohibited-words management panel."""
+
+    def __init__(self, ctx: commands.Context, cog: "Cleanup"):
+        super().__init__(ctx.author, timeout=180)
+        self.ctx = ctx
+        self.cog = cog
+
+    def build_embed(self) -> discord.Embed:
+        words = self.cog._word_cache.get(self.ctx.guild.id, [])
+        embed = discord.Embed(
+            title="🔤 Prohibited Words Manager", color=discord.Color.red()
+        )
+        if words:
+            embed.add_field(
+                name="Current Words",
+                value=", ".join(f"`{w}`" for w in sorted(words))[:1000],
+                inline=False,
+            )
+        else:
+            embed.description = "No prohibited words are currently set."
+        embed.set_footer(text="Use buttons below to manage prohibited words.")
+        return embed
+
+    @discord.ui.button(label="➕ Add Word", style=discord.ButtonStyle.green, row=0)
+    async def btn_add(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await interaction.response.send_modal(_AddWordModal(self.cog))
+
+    @discord.ui.button(label="➖ Remove Word", style=discord.ButtonStyle.danger, row=0)
+    async def btn_remove(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await interaction.response.send_modal(_RemoveWordModal(self.cog))
+
+    @discord.ui.button(label="🔄 Refresh", style=discord.ButtonStyle.secondary, row=0)
+    async def btn_refresh(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await self.cog._load_guild(self.ctx.guild.id)
+        await interaction.response.edit_message(embed=self.build_embed(), view=self)
 
 
 async def setup(bot):

--- a/disbot/cogs/counting_cog.py
+++ b/disbot/cogs/counting_cog.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 import asyncio
 import difflib
@@ -11,6 +13,7 @@ from datetime import datetime
 import discord
 from discord.ext import commands
 from utils import db
+from views.base import BaseView
 
 
 def _word_to_num(text: str) -> int | None:
@@ -311,6 +314,15 @@ class CountingCog(commands.Cog):
     # --------------------------------------------
     # Commands
     # --------------------------------------------
+
+    @commands.command(name="countingmenu", aliases=["cm"])
+    @staff_or_owner()
+    async def counting_menu(self, ctx):
+        """Open the interactive counting game management panel."""
+        view = _CountingHubView(ctx, self)
+        embed = await view.build_embed()
+        msg = await ctx.send(embed=embed, view=view)
+        view.message = msg
 
     @commands.command(name="start_match", aliases=["sm"])
     @staff_or_owner()
@@ -1212,6 +1224,138 @@ class CountingCog(commands.Cog):
     def cog_unload(self):
         """Handles cleanup when the cog is unloaded."""
         pass
+
+
+class _CountingHubView(BaseView):
+    """Admin hub for managing the counting game in the current channel."""
+
+    def __init__(self, ctx: commands.Context, cog: "CountingCog"):
+        super().__init__(ctx.author, timeout=180)
+        self.ctx = ctx
+        self.cog = cog
+
+    def _channel_data(self) -> dict | None:
+        gid = str(self.ctx.guild.id)
+        cid = str(self.ctx.channel.id)
+        return self.cog.count_data.get(gid, {}).get("channels", {}).get(cid)
+
+    async def build_embed(self) -> discord.Embed:
+        embed = discord.Embed(title="🔢 Counting Manager", color=discord.Color.blue())
+        ch_data = self._channel_data()
+        if ch_data:
+            mode = ch_data.get("mode", "normal").capitalize()
+            current = ch_data.get("current_count", 0)
+            turns = ch_data.get("taking_turns", False)
+            reset_wrong = ch_data.get("reset_on_wrong_count", False)
+            embed.description = f"Managing {self.ctx.channel.mention}"
+            embed.add_field(name="Mode", value=mode, inline=True)
+            embed.add_field(name="Current Count", value=str(current), inline=True)
+            embed.add_field(
+                name="Taking Turns", value="✅" if turns else "❌", inline=True
+            )
+            embed.add_field(
+                name="Reset on Wrong", value="✅" if reset_wrong else "❌", inline=True
+            )
+        else:
+            gid = str(self.ctx.guild.id)
+            active_ids = list(
+                self.cog.count_data.get(gid, {}).get("channels", {}).keys()
+            )
+            active_mentions = []
+            for cid in active_ids:
+                ch = self.ctx.guild.get_channel(int(cid))
+                if ch:
+                    active_mentions.append(ch.mention)
+            embed.description = (
+                f"{self.ctx.channel.mention} is not an active counting channel.\n\n"
+                "Start a new match with `!start_match <mode>`."
+            )
+            if active_mentions:
+                embed.add_field(
+                    name="Active Counting Channels",
+                    value="\n".join(active_mentions),
+                    inline=False,
+                )
+        embed.set_footer(text="Buttons below operate on the current channel.")
+        return embed
+
+    @discord.ui.button(
+        label="🔄 Toggle Turns", style=discord.ButtonStyle.blurple, row=0
+    )
+    async def btn_toggle_turns(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ):
+        gid = str(self.ctx.guild.id)
+        cid = str(self.ctx.channel.id)
+        async with self.cog.lock:
+            ch_data = self.cog.count_data.get(gid, {}).get("channels", {}).get(cid)
+            if not ch_data:
+                await interaction.response.send_message(
+                    "This channel is not an active counting channel.", ephemeral=True
+                )
+                return
+            ch_data["taking_turns"] = not ch_data.get("taking_turns", False)
+            asyncio.create_task(self.cog._save_guild(gid))
+        await interaction.response.edit_message(
+            embed=await self.build_embed(), view=self
+        )
+
+    @discord.ui.button(
+        label="♻️ Toggle Reset", style=discord.ButtonStyle.blurple, row=0
+    )
+    async def btn_toggle_reset(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ):
+        gid = str(self.ctx.guild.id)
+        cid = str(self.ctx.channel.id)
+        async with self.cog.lock:
+            ch_data = self.cog.count_data.get(gid, {}).get("channels", {}).get(cid)
+            if not ch_data:
+                await interaction.response.send_message(
+                    "This channel is not an active counting channel.", ephemeral=True
+                )
+                return
+            ch_data["reset_on_wrong_count"] = not ch_data.get(
+                "reset_on_wrong_count", False
+            )
+            asyncio.create_task(self.cog._save_guild(gid))
+        await interaction.response.edit_message(
+            embed=await self.build_embed(), view=self
+        )
+
+    @discord.ui.button(label="🔁 Reset Count", style=discord.ButtonStyle.danger, row=0)
+    async def btn_reset_count(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ):
+        gid = str(self.ctx.guild.id)
+        cid = str(self.ctx.channel.id)
+        async with self.cog.lock:
+            ch_data = self.cog.count_data.get(gid, {}).get("channels", {}).get(cid)
+            if not ch_data:
+                await interaction.response.send_message(
+                    "This channel is not an active counting channel.", ephemeral=True
+                )
+                return
+            mode = ch_data.get("mode", "normal")
+            start = 1000 if mode == "reverse" else 0
+            ch_data["current_count"] = start
+            ch_data["sequence_index"] = 0
+            ch_data["last_user"] = None
+            ch_data["leaderboard"] = {}
+            ch_data["last_count_time"] = datetime.utcnow().timestamp()
+            if mode == "random":
+                rand_range = ch_data.get("random_range", [1, 3])
+                ch_data["next_expected"] = start + random.randint(*rand_range)
+            asyncio.create_task(self.cog._save_guild(gid))
+        await interaction.response.edit_message(
+            embed=await self.build_embed(), view=self
+        )
+
+    @discord.ui.button(label="🔄 Refresh", style=discord.ButtonStyle.secondary, row=1)
+    async def btn_refresh(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await interaction.response.edit_message(
+            embed=await self.build_embed(), view=self
+        )
 
 
 async def setup(bot):

--- a/disbot/cogs/deathmatch_cog.py
+++ b/disbot/cogs/deathmatch_cog.py
@@ -1,6 +1,5 @@
-# cogs/deathmatch_cog.py
+from __future__ import annotations
 
-import asyncio
 import random
 
 import discord
@@ -9,56 +8,226 @@ from discord.ext.commands import BucketType, cooldown
 from utils import db
 
 
+class _Duel:
+    def __init__(self, player1: discord.Member, player2: discord.Member):
+        self.player1 = player1
+        self.player2 = player2
+        self.player1_hp = 100
+        self.player2_hp = 100
+        self.turn = player1
+        self.is_over = False
+        self.defense: dict[int, bool] = {player1.id: False, player2.id: False}
+
+    def attack(self, attacker_id: int, defender_id: int) -> tuple[int, bool]:
+        critical = random.random() < 0.1
+        damage = 30 if critical else 15
+        if self.defense.get(defender_id, False):
+            damage = damage // 2
+            self.defense[defender_id] = False
+        if defender_id == self.player1.id:
+            self.player1_hp -= damage
+        else:
+            self.player2_hp -= damage
+        return damage, critical
+
+    def defend(self, player_id: int) -> None:
+        self.defense[player_id] = True
+
+
+class _DuelView(discord.ui.View):
+    def __init__(
+        self,
+        cog: "Deathmatch",
+        duel: _Duel,
+        duel_key: tuple,
+        ctx: commands.Context,
+    ):
+        super().__init__(timeout=60.0)
+        self.cog = cog
+        self.duel = duel
+        self.duel_key = duel_key
+        self.ctx = ctx
+        self.message: discord.Message | None = None
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user != self.duel.turn:
+            await interaction.response.send_message(
+                "It's not your turn!", ephemeral=True
+            )
+            return False
+        return True
+
+    def build_embed(self, last_action: str = "") -> discord.Embed:
+        duel = self.duel
+        desc = (
+            f"**{duel.player1.display_name}** — {max(duel.player1_hp, 0)} HP\n"
+            f"**{duel.player2.display_name}** — {max(duel.player2_hp, 0)} HP\n\n"
+            f"It's **{duel.turn.display_name}**'s turn!"
+        )
+        if last_action:
+            desc += f"\n\n{last_action}"
+        return discord.Embed(
+            title="⚔️ Deathmatch In Progress",
+            description=desc,
+            color=discord.Color.dark_red(),
+        )
+
+    async def on_timeout(self) -> None:
+        duel = self.duel
+        if duel.is_over:
+            return
+        opponent = duel.player2 if duel.turn == duel.player1 else duel.player1
+        duel.is_over = True
+        self.cog.active_duels.pop(self.duel_key, None)
+        await self.cog.update_leaderboard(winner_id=opponent.id, loser_id=duel.turn.id)
+        for item in self.children:
+            item.disabled = True
+        embed = discord.Embed(
+            title="⚔️ Deathmatch — Timeout",
+            description=(
+                f"{duel.turn.mention} took too long to respond.\n"
+                f"🏆 {opponent.mention} wins by default!"
+            ),
+            color=discord.Color.orange(),
+        )
+        if self.message:
+            try:
+                await self.message.edit(embed=embed, view=self)
+            except Exception:
+                pass
+
+    @discord.ui.button(label="⚔️ Attack", style=discord.ButtonStyle.danger, row=0)
+    async def btn_attack(self, interaction: discord.Interaction, _: discord.ui.Button):
+        duel = self.duel
+        current = duel.turn
+        opponent = duel.player2 if current == duel.player1 else duel.player1
+        damage, critical = duel.attack(current.id, opponent.id)
+        result = f"**{current.display_name}** attacks for **{damage} damage**!"
+        if critical:
+            result += " ⚡ **Critical Hit!**"
+        await self._resolve(interaction, result)
+
+    @discord.ui.button(label="🛡️ Defend", style=discord.ButtonStyle.blurple, row=0)
+    async def btn_defend(self, interaction: discord.Interaction, _: discord.ui.Button):
+        duel = self.duel
+        current = duel.turn
+        duel.defend(current.id)
+        await self._resolve(
+            interaction, f"🛡️ **{current.display_name}** takes a defensive stance!"
+        )
+
+    async def _resolve(
+        self, interaction: discord.Interaction, action_text: str
+    ) -> None:
+        duel = self.duel
+        current = duel.turn
+        opponent = duel.player2 if current == duel.player1 else duel.player1
+        duel.turn = opponent
+
+        winner = loser = None
+        if duel.player1_hp <= 0:
+            winner, loser = duel.player2, duel.player1
+        elif duel.player2_hp <= 0:
+            winner, loser = duel.player1, duel.player2
+
+        if winner:
+            duel.is_over = True
+            self.cog.active_duels.pop(self.duel_key, None)
+            await self.cog.update_leaderboard(winner_id=winner.id, loser_id=loser.id)
+            for item in self.children:
+                item.disabled = True
+            embed = discord.Embed(
+                title="⚔️ Deathmatch Ended",
+                description=(
+                    f"{action_text}\n\n"
+                    f"**{duel.player1.display_name}** — {max(duel.player1_hp, 0)} HP\n"
+                    f"**{duel.player2.display_name}** — {max(duel.player2_hp, 0)} HP\n\n"
+                    f"🏆 {winner.mention} wins!"
+                ),
+                color=discord.Color.gold(),
+            )
+            await interaction.response.edit_message(embed=embed, view=self)
+        else:
+            await interaction.response.edit_message(
+                embed=self.build_embed(action_text), view=self
+            )
+
+
+class _ChallengeView(discord.ui.View):
+    def __init__(
+        self,
+        cog: "Deathmatch",
+        challenger: discord.Member,
+        opponent: discord.Member,
+        duel_key: tuple,
+        ctx: commands.Context,
+    ):
+        super().__init__(timeout=30.0)
+        self.cog = cog
+        self.challenger = challenger
+        self.opponent = opponent
+        self.duel_key = duel_key
+        self.ctx = ctx
+        self.message: discord.Message | None = None
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user != self.opponent:
+            await interaction.response.send_message(
+                "This challenge is not for you!", ephemeral=True
+            )
+            return False
+        return True
+
+    async def on_timeout(self) -> None:
+        for item in self.children:
+            item.disabled = True
+        embed = discord.Embed(
+            title="⚔️ Challenge Expired",
+            description=f"{self.opponent.mention} did not respond in time.",
+            color=discord.Color.greyple(),
+        )
+        if self.message:
+            try:
+                await self.message.edit(embed=embed, view=self)
+            except Exception:
+                pass
+
+    @discord.ui.button(label="✅ Accept", style=discord.ButtonStyle.green)
+    async def btn_accept(self, interaction: discord.Interaction, _: discord.ui.Button):
+        for item in self.children:
+            item.disabled = True
+        duel = _Duel(self.challenger, self.opponent)
+        self.cog.active_duels[self.duel_key] = duel
+        duel_view = _DuelView(self.cog, duel, self.duel_key, self.ctx)
+        await interaction.response.edit_message(
+            embed=duel_view.build_embed(), view=duel_view
+        )
+        duel_view.message = await interaction.original_response()
+
+    @discord.ui.button(label="❌ Decline", style=discord.ButtonStyle.danger)
+    async def btn_decline(self, interaction: discord.Interaction, _: discord.ui.Button):
+        for item in self.children:
+            item.disabled = True
+        embed = discord.Embed(
+            title="⚔️ Challenge Declined",
+            description=f"{self.opponent.mention} declined the duel.",
+            color=discord.Color.greyple(),
+        )
+        await interaction.response.edit_message(embed=embed, view=self)
+
+
 class Deathmatch(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-        # Active duels: {(user1_id, user2_id): Duel}
-        self.active_duels = {}
-
-    class Duel:
-        def __init__(self, player1, player2):
-            self.player1 = player1
-            self.player2 = player2
-            self.player1_hp = 100
-            self.player2_hp = 100
-            self.turn = player1  # Player1 starts
-            self.is_over = False
-            self.defense = {player1.id: False, player2.id: False}  # Defense status
-
-        def attack(self, attacker_id, defender_id):
-            base_damage = 15
-            critical_hit_chance = 0.1  # 10% chance
-            if random.random() < critical_hit_chance:
-                damage = base_damage * 2
-                critical = True
-            else:
-                damage = base_damage
-                critical = False
-
-            # Check if defender is defending
-            if self.defense.get(defender_id, False):
-                damage = int(damage / 2)
-                self.defense[defender_id] = False  # Reset defense
-
-            # Apply damage
-            if defender_id == self.player1.id:
-                self.player1_hp -= damage
-            else:
-                self.player2_hp -= damage
-
-            return damage, critical
-
-        def defend(self, player_id):
-            self.defense[player_id] = True
+        self.active_duels: dict[tuple, _Duel] = {}
 
     @commands.command(name="dm_challenge", aliases=["deathmatch", "challenge"])
-    @cooldown(1, 30, BucketType.user)  # 1 use per 30 seconds per user
-    async def challenge(self, ctx, opponent: discord.Member):
+    @cooldown(1, 30, BucketType.user)
+    async def challenge(self, ctx: commands.Context, opponent: discord.Member):
         """Challenge another user to a deathmatch duel."""
         if opponent == ctx.author:
             await ctx.send("You cannot challenge yourself!")
             return
-
         if opponent.bot:
             await ctx.send("You cannot challenge a bot!")
             return
@@ -69,163 +238,28 @@ class Deathmatch(commands.Cog):
                 "A duel between you and the opponent is already in progress."
             )
             return
-
-        # Prevent challenging users who are already in another duel
-        for existing_duel in self.active_duels.keys():
-            if ctx.author.id in existing_duel or opponent.id in existing_duel:
+        for existing_key in self.active_duels:
+            if ctx.author.id in existing_key or opponent.id in existing_key:
                 await ctx.send("Either you or the opponent is already in a duel.")
                 return
 
-        # Send a challenge message with reactions
         embed = discord.Embed(
-            title="Deathmatch Challenge",
-            description=f"{ctx.author.mention} has challenged {opponent.mention} to a duel!\n\nReact with ✅ to accept or ❌ to decline.",
+            title="⚔️ Deathmatch Challenge",
+            description=(
+                f"{ctx.author.mention} has challenged {opponent.mention} to a duel!\n\n"
+                "Press **Accept** or **Decline** below."
+            ),
             color=discord.Color.red(),
-            timestamp=ctx.message.created_at,
         )
         embed.set_footer(text="You have 30 seconds to respond.")
-        message = await ctx.send(embed=embed)
-        await message.add_reaction("✅")
-        await message.add_reaction("❌")
+        view = _ChallengeView(self, ctx.author, opponent, duel_key, ctx)
+        view.message = await ctx.send(embed=embed, view=view)
 
-        def check(reaction, user):
-            return (
-                user == opponent
-                and str(reaction.emoji) in ["✅", "❌"]
-                and reaction.message.id == message.id
-            )
-
-        try:
-            reaction, user = await self.bot.wait_for(
-                "reaction_add", timeout=30.0, check=check
-            )
-        except asyncio.TimeoutError:
-            await ctx.send(
-                f"{opponent.mention} did not respond in time. Challenge canceled."
-            )
-            await message.delete()
-            return
-
-        if str(reaction.emoji) == "✅":
-            await ctx.send(
-                f"{opponent.mention} accepted the duel! Let the battle begin!"
-            )
-            # Initialize and start the duel
-            duel = self.Duel(ctx.author, opponent)
-            self.active_duels[duel_key] = duel
-            await self.start_duel(ctx, duel)
-        else:
-            await ctx.send(f"{opponent.mention} declined the duel.")
-            await message.delete()
-
-    async def start_duel(self, ctx, duel):
-        """Manage the duel flow."""
-        embed = discord.Embed(
-            title="Deathmatch Started!",
-            description=f"{duel.player1.mention} vs {duel.player2.mention}\n\nBoth players have **100 HP**.\nIt's {duel.turn.mention}'s turn!",
-            color=discord.Color.dark_red(),
-            timestamp=ctx.message.created_at,
-        )
-        duel_message = await ctx.send(embed=embed)
-
-        while not duel.is_over:
-            current_player = duel.turn
-            opponent = duel.player2 if current_player == duel.player1 else duel.player1
-
-            # Update duel status
-            embed = discord.Embed(
-                title="Deathmatch In Progress",
-                description=(
-                    f"{duel.player1.mention}: **{duel.player1_hp} HP**\n"
-                    f"{duel.player2.mention}: **{duel.player2_hp} HP**\n\n"
-                    f"It's {current_player.mention}'s turn!\n\n"
-                    f"Choose your action: `attack` or `defend`."
-                ),
-                color=discord.Color.dark_red(),
-                timestamp=ctx.message.created_at,
-            )
-            await duel_message.edit(embed=embed)
-
-            def check(m):
-                return (
-                    m.author == current_player
-                    and m.channel == ctx.channel
-                    and m.content.lower() in ["attack", "defend"]
-                )
-
-            try:
-                await ctx.send(
-                    f"{current_player.mention}, choose your action (`attack` or `defend`):"
-                )
-                msg = await self.bot.wait_for("message", check=check, timeout=60.0)
-            except asyncio.TimeoutError:
-                await ctx.send(
-                    f"{current_player.mention} took too long to respond. {opponent.mention} wins by default!"
-                )
-                await self.update_leaderboard(
-                    winner_id=opponent.id, loser_id=current_player.id
-                )
-                duel.is_over = True
-                del self.active_duels[tuple(sorted([duel.player1.id, duel.player2.id]))]
-                return
-
-            action = msg.content.lower()
-            if action == "attack":
-                damage, critical = duel.attack(current_player.id, opponent.id)
-                attack_msg = f"{current_player.mention} attacks {opponent.mention} for **{damage} damage**!"
-                if critical:
-                    attack_msg += " **Critical Hit!**"
-                await ctx.send(attack_msg)
-            elif action == "defend":
-                duel.defend(current_player.id)
-                await ctx.send(
-                    f"{current_player.mention} is defending against the next attack!"
-                )
-
-            # Check for win condition
-            if duel.player1_hp <= 0:
-                await ctx.send(
-                    f"{duel.player1.mention} has been defeated! {duel.player2.mention} wins!"
-                )
-                await self.update_leaderboard(
-                    winner_id=duel.player2.id, loser_id=duel.player1.id
-                )
-                duel.is_over = True
-            elif duel.player2_hp <= 0:
-                await ctx.send(
-                    f"{duel.player2.mention} has been defeated! {duel.player1.mention} wins!"
-                )
-                await self.update_leaderboard(
-                    winner_id=duel.player1.id, loser_id=duel.player2.id
-                )
-                duel.is_over = True
-            else:
-                # Switch turn
-                duel.turn = opponent
-
-        # Final duel status
-        embed = discord.Embed(
-            title="Deathmatch Ended",
-            description=(
-                f"{duel.player1.mention}: **{max(duel.player1_hp, 0)} HP**\n"
-                f"{duel.player2.mention}: **{max(duel.player2_hp, 0)} HP**"
-            ),
-            color=(
-                discord.Color.green()
-                if duel.player1_hp > duel.player2_hp
-                else discord.Color.red()
-            ),
-            timestamp=ctx.message.created_at,
-        )
-        await duel_message.edit(embed=embed)
-
-    async def update_leaderboard(self, winner_id, loser_id):
-        """Update the leaderboard with the duel results."""
+    async def update_leaderboard(self, winner_id: int, loser_id: int) -> None:
         await db.update_deathmatch(winner_id, loser_id)
 
     @challenge.error
     async def challenge_error(self, ctx, error):
-        """Handle errors for the challenge command."""
         if isinstance(error, commands.CommandOnCooldown):
             await ctx.send(
                 f"You're on cooldown! Please try again in {int(error.retry_after)} seconds."
@@ -234,27 +268,24 @@ class Deathmatch(commands.Cog):
             await ctx.send("Couldn't find the user. Please mention a valid member.")
         else:
             await ctx.send("An error occurred while processing the command.")
-            raise error  # Re-raise the error for debugging purposes
+            raise error
 
     @commands.command(name="dm_help", aliases=["deathmatch_help"])
-    async def dm_help(self, ctx):
+    async def dm_help(self, ctx: commands.Context):
         """Display help information for Deathmatch commands."""
         embed = discord.Embed(
             title="Deathmatch Help",
             description=(
                 "**Commands:**\n"
-                "`!deathmatch @User` - Challenge a user to a duel.\n"
-                "`!board` - View the top duelists.\n\n"
+                "`!deathmatch @User` — Challenge a user to a duel.\n"
+                "`!leaderboard deathmatch` — View the top duelists.\n\n"
                 "**During a Duel:**\n"
-                "`attack` - Perform an attack on your opponent.\n"
-                "`defend` - Defend against your opponent's next attack."
+                "Use the **⚔️ Attack** and **🛡️ Defend** buttons in the duel message."
             ),
             color=discord.Color.blue(),
-            timestamp=ctx.message.created_at,
         )
         await ctx.send(embed=embed)
 
 
-# Asynchronous setup function for discord.py v2.x
 async def setup(bot):
     await bot.add_cog(Deathmatch(bot))

--- a/disbot/cogs/diagnostic_cog.py
+++ b/disbot/cogs/diagnostic_cog.py
@@ -71,14 +71,28 @@ class _DiagnosticsHubView(BaseView):
             ),
             color=discord.Color.blue(),
         )
-        embed.add_field(name="🤖 Bot Status", value="Health & performance metrics", inline=True)
+        embed.add_field(
+            name="🤖 Bot Status", value="Health & performance metrics", inline=True
+        )
         embed.add_field(name="📡 Latency", value="WebSocket ping", inline=True)
-        embed.add_field(name="💻 System Info", value="OS, disk & Python version", inline=True)
-        embed.add_field(name="🗄️ Check Database", value="Verify all DB tables exist", inline=True)
-        embed.add_field(name="📄 Validate JSON", value="Check data file integrity", inline=True)
-        embed.add_field(name="📋 Command List", value="Paginated command overview", inline=True)
-        embed.add_field(name="🔍 Recent Errors", value="Last 10 error log entries", inline=True)
-        embed.add_field(name="🔔 Test Notify", value="Fire a test webhook ping", inline=True)
+        embed.add_field(
+            name="💻 System Info", value="OS, disk & Python version", inline=True
+        )
+        embed.add_field(
+            name="🗄️ Check Database", value="Verify all DB tables exist", inline=True
+        )
+        embed.add_field(
+            name="📄 Validate JSON", value="Check data file integrity", inline=True
+        )
+        embed.add_field(
+            name="📋 Command List", value="Paginated command overview", inline=True
+        )
+        embed.add_field(
+            name="🔍 Recent Errors", value="Last 10 error log entries", inline=True
+        )
+        embed.add_field(
+            name="🔔 Test Notify", value="Fire a test webhook ping", inline=True
+        )
         embed.set_footer(text="Diagnostics Hub  •  Admin only")
         return embed
 
@@ -112,12 +126,16 @@ class _DiagnosticsHubView(BaseView):
         await interaction.response.defer()
         await self.ctx.invoke(self.cog.list_commands_detailed)
 
-    @discord.ui.button(label="🔍 Recent Errors", style=discord.ButtonStyle.danger, row=2)
+    @discord.ui.button(
+        label="🔍 Recent Errors", style=discord.ButtonStyle.danger, row=2
+    )
     async def btn_errors(self, interaction: discord.Interaction, _: discord.ui.Button):
         await interaction.response.defer()
         await self.ctx.invoke(self.cog.recent_errors)
 
-    @discord.ui.button(label="🔔 Test Notify", style=discord.ButtonStyle.secondary, row=2)
+    @discord.ui.button(
+        label="🔔 Test Notify", style=discord.ButtonStyle.secondary, row=2
+    )
     async def btn_notify(self, interaction: discord.Interaction, _: discord.ui.Button):
         await interaction.response.defer()
         await self.ctx.invoke(self.cog.test_notification)

--- a/disbot/cogs/diagnostic_cog.py
+++ b/disbot/cogs/diagnostic_cog.py
@@ -12,6 +12,7 @@ import discord
 import psutil
 from discord.ext import commands
 from utils import db
+from views.base import BaseView
 
 logger = logging.getLogger("bot")
 
@@ -21,37 +22,20 @@ DATA_DIR = os.path.join(
 JSON_DIR = os.path.join(DATA_DIR, "json")
 
 
-class _PaginatorView(discord.ui.View):
+class _PaginatorView(BaseView):
     """Simple prev/next paginator for multi-page embeds."""
 
     def __init__(
         self, pages: list[discord.Embed], author: discord.Member | discord.User
     ):
-        super().__init__(timeout=120)
+        super().__init__(author, timeout=120)
         self.pages = pages
-        self.author = author
         self.index = 0
-        self.message: discord.Message | None = None
         self._update_buttons()
 
     def _update_buttons(self):
         self.prev_btn.disabled = self.index == 0
         self.next_btn.disabled = self.index == len(self.pages) - 1
-
-    async def interaction_check(self, interaction: discord.Interaction) -> bool:
-        if interaction.user.id != self.author.id:
-            await interaction.response.send_message(
-                "This paginator isn't yours.", ephemeral=True
-            )
-            return False
-        return True
-
-    async def on_timeout(self):
-        if self.message:
-            try:
-                await self.message.edit(view=None)
-            except Exception:
-                pass
 
     @discord.ui.button(label="◀ Prev", style=discord.ButtonStyle.secondary)
     async def prev_btn(
@@ -70,11 +54,92 @@ class _PaginatorView(discord.ui.View):
         await interaction.response.edit_message(embed=self.pages[self.index], view=self)
 
 
+class _DiagnosticsHubView(BaseView):
+    """Interactive hub for all diagnostic tools."""
+
+    def __init__(self, ctx: commands.Context, cog: "DiagnosticCog"):
+        super().__init__(ctx.author, timeout=180)
+        self.ctx = ctx
+        self.cog = cog
+
+    def build_embed(self) -> discord.Embed:
+        embed = discord.Embed(
+            title="🔧 Diagnostics Hub",
+            description=(
+                "Select a diagnostic tool below.\n"
+                "All tools require Administrator permission."
+            ),
+            color=discord.Color.blue(),
+        )
+        embed.add_field(name="🤖 Bot Status", value="Health & performance metrics", inline=True)
+        embed.add_field(name="📡 Latency", value="WebSocket ping", inline=True)
+        embed.add_field(name="💻 System Info", value="OS, disk & Python version", inline=True)
+        embed.add_field(name="🗄️ Check Database", value="Verify all DB tables exist", inline=True)
+        embed.add_field(name="📄 Validate JSON", value="Check data file integrity", inline=True)
+        embed.add_field(name="📋 Command List", value="Paginated command overview", inline=True)
+        embed.add_field(name="🔍 Recent Errors", value="Last 10 error log entries", inline=True)
+        embed.add_field(name="🔔 Test Notify", value="Fire a test webhook ping", inline=True)
+        embed.set_footer(text="Diagnostics Hub  •  Admin only")
+        return embed
+
+    @discord.ui.button(label="🤖 Bot Status", style=discord.ButtonStyle.blurple, row=0)
+    async def btn_status(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await interaction.response.defer()
+        await self.ctx.invoke(self.cog.diagnostic_bot_status)
+
+    @discord.ui.button(label="📡 Latency", style=discord.ButtonStyle.blurple, row=0)
+    async def btn_latency(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await interaction.response.defer()
+        await self.ctx.invoke(self.cog.latency)
+
+    @discord.ui.button(label="💻 System Info", style=discord.ButtonStyle.blurple, row=0)
+    async def btn_sysinfo(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await interaction.response.defer()
+        await self.ctx.invoke(self.cog.system_info)
+
+    @discord.ui.button(label="🗄️ Database", style=discord.ButtonStyle.grey, row=1)
+    async def btn_db(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await interaction.response.defer()
+        await self.ctx.invoke(self.cog.check_database)
+
+    @discord.ui.button(label="📄 JSON Files", style=discord.ButtonStyle.grey, row=1)
+    async def btn_json(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await interaction.response.defer()
+        await self.ctx.invoke(self.cog.validate_json_files)
+
+    @discord.ui.button(label="📋 Commands", style=discord.ButtonStyle.grey, row=1)
+    async def btn_cmds(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await interaction.response.defer()
+        await self.ctx.invoke(self.cog.list_commands_detailed)
+
+    @discord.ui.button(label="🔍 Recent Errors", style=discord.ButtonStyle.danger, row=2)
+    async def btn_errors(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await interaction.response.defer()
+        await self.ctx.invoke(self.cog.recent_errors)
+
+    @discord.ui.button(label="🔔 Test Notify", style=discord.ButtonStyle.secondary, row=2)
+    async def btn_notify(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await interaction.response.defer()
+        await self.ctx.invoke(self.cog.test_notification)
+
+
 class DiagnosticCog(commands.Cog):
     """Advanced diagnostics and monitoring tools."""
 
     def __init__(self, bot):
         self.bot = bot
+
+    # ------------------------------------------------------------------
+    # Diagnostics hub
+    # ------------------------------------------------------------------
+
+    @commands.command(name="diagnostics", aliases=["diag"])
+    @commands.has_permissions(administrator=True)
+    async def diagnostics_hub(self, ctx):
+        """Open the interactive diagnostics hub panel."""
+        view = _DiagnosticsHubView(ctx, self)
+        msg = await ctx.send(embed=view.build_embed(), view=view)
+        view.message = msg
 
     # ------------------------------------------------------------------
     # Command overview

--- a/disbot/cogs/economy_cog.py
+++ b/disbot/cogs/economy_cog.py
@@ -9,6 +9,7 @@ from discord.ext import commands
 from utils import db
 from utils.cooldowns import check_cooldown, format_remaining
 from utils.helpers import post_log_embed
+from views.base import BaseView
 
 logger = logging.getLogger("bot")
 
@@ -494,21 +495,12 @@ class EconomyCog(commands.Cog):
 # ---------------------------------------------------------------------------
 
 
-class _EconomyPanelView(discord.ui.View):
+class _EconomyPanelView(BaseView):
     """Interactive economy control panel — hub for all economy actions."""
 
     def __init__(self, ctx: commands.Context):
-        super().__init__(timeout=180)
+        super().__init__(ctx.author, timeout=180)
         self.ctx = ctx
-        self.message: discord.Message | None = None
-
-    async def interaction_check(self, interaction: discord.Interaction) -> bool:
-        if interaction.user != self.ctx.author:
-            await interaction.response.send_message(
-                "This panel isn't for you.", ephemeral=True
-            )
-            return False
-        return True
 
     async def build_embed(self) -> discord.Embed:
         uid, gid = self.ctx.author.id, self.ctx.guild.id

--- a/disbot/cogs/economy_cog.py
+++ b/disbot/cogs/economy_cog.py
@@ -416,30 +416,6 @@ class EconomyCog(commands.Cog):
         msg = await ctx.send(embed=_shop_embed(), view=view)
         view.message = msg
 
-    # ------------------------------------------------------------------ !inventory
-
-    @commands.command(name="inventory", aliases=["inv"])
-    async def inventory(self, ctx: commands.Context, member: discord.Member = None):
-        """Show your (or another user's) inventory."""
-        target = member or ctx.author
-        inv = await db.get_inventory(target.id, ctx.guild.id)
-        embed = discord.Embed(
-            title=f"🎒 {target.display_name}'s Inventory",
-            color=discord.Color.blurple(),
-        )
-        if inv:
-            lines = []
-            for item_name, qty in inv.items():
-                data = SHOP_ITEMS.get(item_name, {})
-                emoji = data.get("emoji", "📦")
-                lines.append(
-                    f"{emoji} **{item_name.replace('_', ' ').title()}** × {qty}"
-                )
-            embed.description = "\n".join(lines)
-        else:
-            embed.description = "Empty — visit `!shop` to buy items!"
-        await ctx.send(embed=embed)
-
     # ------------------------------------------------------------------ !balance
 
     @commands.command(name="balance", aliases=["bal", "wallet"])
@@ -692,25 +668,13 @@ class _EconomyPanelView(discord.ui.View):
     async def inventory_btn(
         self, interaction: discord.Interaction, _: discord.ui.Button
     ):
+        from cogs.inventory_cog import UnifiedInventoryView, _build_combined_inventory
+
         uid, gid = self.ctx.author.id, self.ctx.guild.id
-        inv = await db.get_inventory(uid, gid)
-        embed = discord.Embed(
-            title=f"🎒 {self.ctx.author.display_name}'s Inventory",
-            color=discord.Color.blurple(),
-        )
-        if inv:
-            lines = []
-            for item_name, qty in inv.items():
-                data = SHOP_ITEMS.get(item_name, {})
-                emoji = data.get("emoji", "📦")
-                lines.append(
-                    f"{emoji} **{item_name.replace('_', ' ').title()}** × {qty}"
-                )
-            embed.description = "\n".join(lines)
-        else:
-            embed.description = "Empty — click 🛒 Shop to buy items!"
-        embed.set_footer(text="Click ↩ Overview to return.")
-        await interaction.response.edit_message(embed=embed, view=self)
+        grouped = await _build_combined_inventory(uid, gid)
+        view = UnifiedInventoryView(self.ctx.author, self.ctx, self.ctx.author, grouped)
+        await interaction.response.send_message(embed=view.build_hub_embed(), view=view)
+        view.message = await interaction.original_response()
 
     @discord.ui.button(label="📋 Jobs", style=discord.ButtonStyle.grey, row=1)
     async def jobs_btn(self, interaction: discord.Interaction, _: discord.ui.Button):

--- a/disbot/cogs/inventory_cog.py
+++ b/disbot/cogs/inventory_cog.py
@@ -5,7 +5,6 @@ import logging
 
 import discord
 from discord.ext import commands
-
 from utils import db
 from views.base import BaseView
 

--- a/disbot/cogs/inventory_cog.py
+++ b/disbot/cogs/inventory_cog.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+import functools
+import logging
+
+import discord
+from discord.ext import commands
+
+from utils import db
+from views.base import BaseView
+
+logger = logging.getLogger("bot")
+
+# ---------------------------------------------------------------------------
+# Item catalogue — static metadata, never written to DB
+# ---------------------------------------------------------------------------
+ITEM_CATALOGUE: dict[str, dict] = {
+    # Mining Materials (mining_inventory table)
+    "stone": {
+        "category": "Mining Materials",
+        "emoji": "🪨",
+        "type": "Ore",
+        "rarity": "Common",
+    },
+    "iron": {
+        "category": "Mining Materials",
+        "emoji": "⚙️",
+        "type": "Ore",
+        "rarity": "Uncommon",
+    },
+    "gold": {
+        "category": "Mining Materials",
+        "emoji": "🥇",
+        "type": "Ore",
+        "rarity": "Rare",
+    },
+    "diamond": {
+        "category": "Mining Materials",
+        "emoji": "💎",
+        "type": "Gem",
+        "rarity": "Epic",
+    },
+    "wood": {
+        "category": "Mining Materials",
+        "emoji": "🪵",
+        "type": "Resource",
+        "rarity": "Common",
+    },
+    # Crafted/built structures (mining_inventory after !build)
+    "stone hut": {
+        "category": "Crafted Items",
+        "emoji": "🏚️",
+        "type": "Structure",
+        "rarity": "Common",
+    },
+    "wooden house": {
+        "category": "Crafted Items",
+        "emoji": "🏠",
+        "type": "Structure",
+        "rarity": "Uncommon",
+    },
+    "gold statue": {
+        "category": "Crafted Items",
+        "emoji": "🗿",
+        "type": "Structure",
+        "rarity": "Rare",
+    },
+    "diamond throne": {
+        "category": "Crafted Items",
+        "emoji": "💺",
+        "type": "Structure",
+        "rarity": "Epic",
+    },
+    # Tools (mining_inventory + economy inventory)
+    "iron pickaxe": {
+        "category": "Tools",
+        "emoji": "⛏️",
+        "type": "Tool",
+        "rarity": "Uncommon",
+    },
+    "axe": {"category": "Tools", "emoji": "🪓", "type": "Tool", "rarity": "Uncommon"},
+    "toolkit": {
+        "category": "Tools",
+        "emoji": "🔧",
+        "type": "Job Unlock",
+        "rarity": "Uncommon",
+    },
+    # Economy items (inventory table, guild-scoped)
+    "car": {
+        "category": "Economy Items",
+        "emoji": "🚗",
+        "type": "Job Unlock",
+        "rarity": "Rare",
+    },
+    "suit": {
+        "category": "Economy Items",
+        "emoji": "👔",
+        "type": "Job Unlock",
+        "rarity": "Rare",
+    },
+}
+
+_CATEGORY_ORDER: tuple[str, ...] = (
+    "Mining Materials",
+    "Crafted Items",
+    "Tools",
+    "Economy Items",
+)
+
+_CATEGORY_META: dict[str, dict] = {
+    "Mining Materials": {"emoji": "⛏️", "color": discord.Color.dark_gold()},
+    "Crafted Items": {"emoji": "🏗️", "color": discord.Color.orange()},
+    "Tools": {"emoji": "🔧", "color": discord.Color.blurple()},
+    "Economy Items": {"emoji": "💼", "color": discord.Color.gold()},
+    "Other": {"emoji": "📦", "color": discord.Color.dark_grey()},
+}
+
+_RARITY_ORDER: dict[str, int] = {
+    "Epic": 0,
+    "Rare": 1,
+    "Uncommon": 2,
+    "Common": 3,
+}
+
+
+# ---------------------------------------------------------------------------
+# Shared async helper — used by both the cog command and economy_cog panel
+# ---------------------------------------------------------------------------
+async def _build_combined_inventory(
+    user_id: int, guild_id: int
+) -> dict[str, list[tuple[str, int, dict]]]:
+    """Fetch both inventory tables and return items grouped by category.
+
+    Returns {category_name: [(item_key, qty, meta_dict), ...]} with only
+    non-empty categories and items sorted rarest-first within each category.
+    """
+    eco_inv: dict[str, int] = await db.get_inventory(user_id, guild_id)
+    mine_inv: dict[str, int] = await db.get_mining_inventory(str(user_id))
+
+    combined: dict[str, int] = {}
+    for k, v in mine_inv.items():
+        combined[k.lower()] = v
+    for k, v in eco_inv.items():
+        key = k.lower()
+        combined[key] = combined.get(key, 0) + v
+
+    grouped: dict[str, list[tuple[str, int, dict]]] = {}
+    for item_key, qty in combined.items():
+        if qty <= 0:
+            continue
+        meta = ITEM_CATALOGUE.get(item_key, {})
+        cat = meta.get("category", "Other")
+        grouped.setdefault(cat, []).append((item_key, qty, meta))
+
+    for cat_items in grouped.values():
+        cat_items.sort(key=lambda x: _RARITY_ORDER.get(x[2].get("rarity", ""), 99))
+
+    return grouped
+
+
+# ---------------------------------------------------------------------------
+# Category detail view
+# ---------------------------------------------------------------------------
+class _CategoryView(BaseView):
+    """Paginated item list for a single inventory category."""
+
+    _PER_PAGE = 8
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        ctx: commands.Context,
+        category: str,
+        items: list[tuple[str, int, dict]],
+        hub: UnifiedInventoryView,
+    ) -> None:
+        super().__init__(author, timeout=180)
+        self._ctx = ctx
+        self._category = category
+        self._items = items
+        self._hub = hub
+        self._page = 0
+        self._total_pages = max(1, (len(items) + self._PER_PAGE - 1) // self._PER_PAGE)
+        self._rebuild_buttons()
+
+    def _rebuild_buttons(self) -> None:
+        self.clear_items()
+        if self._total_pages > 1:
+            prev_btn = discord.ui.Button(
+                label="◀ Prev",
+                style=discord.ButtonStyle.grey,
+                row=1,
+                disabled=self._page == 0,
+            )
+            prev_btn.callback = self._prev_page
+            self.add_item(prev_btn)
+
+            next_btn = discord.ui.Button(
+                label="Next ▶",
+                style=discord.ButtonStyle.grey,
+                row=1,
+                disabled=self._page >= self._total_pages - 1,
+            )
+            next_btn.callback = self._next_page
+            self.add_item(next_btn)
+
+        back_btn = discord.ui.Button(
+            label="↩ Back",
+            style=discord.ButtonStyle.secondary,
+            row=1,
+        )
+        back_btn.callback = self._back_to_hub
+        self.add_item(back_btn)
+
+    def build_embed(self) -> discord.Embed:
+        cat_meta = _CATEGORY_META.get(
+            self._category, {"emoji": "📦", "color": discord.Color.dark_grey()}
+        )
+        embed = discord.Embed(
+            title=f"{cat_meta['emoji']} {self._category}",
+            color=cat_meta["color"],
+        )
+        embed.set_author(
+            name=f"{self._hub.target.display_name}'s Inventory",
+            icon_url=self._hub.target.display_avatar.url,
+        )
+
+        start = self._page * self._PER_PAGE
+        page_items = self._items[start : start + self._PER_PAGE]
+
+        lines = []
+        for item_key, qty, meta in page_items:
+            emoji = meta.get("emoji", "📦")
+            rarity = meta.get("rarity", "Unknown")
+            itype = meta.get("type", "Item")
+            display_name = item_key.replace("_", " ").title()
+            lines.append(f"{emoji} **{display_name}** × {qty}  `{rarity}` · {itype}")
+
+        embed.description = "\n".join(lines) if lines else "Nothing here."
+        embed.set_footer(
+            text=f"Page {self._page + 1}/{self._total_pages}  •  Click ↩ Back to return."
+        )
+        return embed
+
+    async def _prev_page(self, interaction: discord.Interaction) -> None:
+        self._page = max(0, self._page - 1)
+        self._rebuild_buttons()
+        await interaction.response.edit_message(embed=self.build_embed(), view=self)
+
+    async def _next_page(self, interaction: discord.Interaction) -> None:
+        self._page = min(self._total_pages - 1, self._page + 1)
+        self._rebuild_buttons()
+        await interaction.response.edit_message(embed=self.build_embed(), view=self)
+
+    async def _back_to_hub(self, interaction: discord.Interaction) -> None:
+        self._hub.message = self.message
+        await interaction.response.edit_message(
+            embed=self._hub.build_hub_embed(), view=self._hub
+        )
+        self.stop()
+
+
+# ---------------------------------------------------------------------------
+# Unified inventory hub view
+# ---------------------------------------------------------------------------
+class UnifiedInventoryView(BaseView):
+    """Main inventory hub — one button per non-empty category."""
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        ctx: commands.Context,
+        target: discord.Member | discord.User,
+        grouped: dict[str, list[tuple[str, int, dict]]],
+    ) -> None:
+        super().__init__(author, timeout=180)
+        self.ctx = ctx
+        self.target = target
+        self._grouped = grouped
+        self._add_category_buttons()
+
+    def _add_category_buttons(self) -> None:
+        self.clear_items()
+        ordered = [c for c in _CATEGORY_ORDER if c in self._grouped]
+        if "Other" in self._grouped:
+            ordered.append("Other")
+
+        for cat in ordered:
+            cat_meta = _CATEGORY_META.get(cat, {"emoji": "📦"})
+            count = len(self._grouped[cat])
+            btn = discord.ui.Button(
+                label=f"{cat_meta['emoji']} {cat} ({count})",
+                style=discord.ButtonStyle.blurple,
+                row=0,
+            )
+            btn.callback = functools.partial(self._open_category, category=cat)
+            self.add_item(btn)
+
+    def build_hub_embed(self) -> discord.Embed:
+        embed = discord.Embed(
+            title=f"🎒 {self.target.display_name}'s Inventory",
+            color=discord.Color.blurple(),
+        )
+        embed.set_thumbnail(url=self.target.display_avatar.url)
+
+        if not self._grouped:
+            embed.description = (
+                "No items yet — go mining with `!mine` or visit `!shop`!"
+            )
+        else:
+            lines = []
+            ordered = [c for c in _CATEGORY_ORDER if c in self._grouped]
+            if "Other" in self._grouped:
+                ordered.append("Other")
+            for cat in ordered:
+                cat_meta = _CATEGORY_META.get(cat, {"emoji": "📦"})
+                items = self._grouped[cat]
+                preview_parts = [
+                    f"{m.get('emoji', '📦')} {n.replace('_', ' ').title()}"
+                    for n, _, m in items[:3]
+                ]
+                preview = ", ".join(preview_parts)
+                if len(items) > 3:
+                    preview += f" +{len(items) - 3} more"
+                lines.append(f"{cat_meta['emoji']} **{cat}** — {preview}")
+            embed.description = "\n".join(lines)
+
+        embed.set_footer(text="Select a category below to view details.")
+        return embed
+
+    async def _open_category(
+        self, interaction: discord.Interaction, *, category: str
+    ) -> None:
+        items = self._grouped.get(category, [])
+        view = _CategoryView(self.ctx.author, self.ctx, category, items, hub=self)
+        view.message = self.message
+        await interaction.response.edit_message(embed=view.build_embed(), view=view)
+
+
+# ---------------------------------------------------------------------------
+# Cog
+# ---------------------------------------------------------------------------
+class InventoryCog(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @commands.command(name="inventory", aliases=["inv"])
+    async def inventory(
+        self, ctx: commands.Context, member: discord.Member = None
+    ) -> None:
+        """Show your (or another user's) unified inventory hub."""
+        target = member or ctx.author
+        grouped = await _build_combined_inventory(target.id, ctx.guild.id)
+        view = UnifiedInventoryView(ctx.author, ctx, target, grouped)
+        msg = await ctx.send(embed=view.build_hub_embed(), view=view)
+        view.message = msg
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(InventoryCog(bot))
+    logger.info("InventoryCog loaded.")

--- a/disbot/cogs/leaderboard_cog.py
+++ b/disbot/cogs/leaderboard_cog.py
@@ -4,6 +4,7 @@ import discord
 from discord.ext import commands
 from utils import db
 from utils import embeds as em
+from views.base import BaseView
 
 MEDALS = ["🥇", "🥈", "🥉"]
 
@@ -111,7 +112,7 @@ async def _build_embed(
     return embed
 
 
-class LeaderboardView(discord.ui.View):
+class LeaderboardView(BaseView):
     """Category-selector view for the leaderboard panel."""
 
     def __init__(
@@ -120,26 +121,9 @@ class LeaderboardView(discord.ui.View):
         channel: discord.abc.GuildChannel,
         author: discord.Member | discord.User,
     ):
-        super().__init__(timeout=120)
+        super().__init__(author, timeout=120)
         self.guild = guild
         self.channel = channel
-        self.author = author
-        self.message: discord.Message | None = None
-
-    async def interaction_check(self, interaction: discord.Interaction) -> bool:
-        if interaction.user.id != self.author.id:
-            await interaction.response.send_message(
-                "This panel isn't yours.", ephemeral=True
-            )
-            return False
-        return True
-
-    async def on_timeout(self):
-        if self.message:
-            try:
-                await self.message.edit(view=None)
-            except Exception:
-                pass
 
     @discord.ui.select(
         placeholder="Choose a leaderboard category…",

--- a/disbot/cogs/mining_cog.py
+++ b/disbot/cogs/mining_cog.py
@@ -159,25 +159,13 @@ class MiningCog(commands.Cog):
         )
 
     @commands.command(name="mineinv", aliases=["mineinventory"])
-    async def inventory(self, ctx):
-        """Displays your mining inventory."""
-        user_id = str(ctx.author.id)
-        inventory = await db.get_mining_inventory(user_id)
-
-        if not inventory:
-            return await ctx.send(
-                "Your mining inventory is empty. Start mining with `!mine`!"
-            )
-
-        items_list = "\n".join(
-            [f"**{item}**: {count}" for item, count in inventory.items() if count > 0]
-        )
-        embed = discord.Embed(
-            title=f"{ctx.author.name}'s Mining Inventory",
-            description=items_list,
-            color=discord.Color.blue(),
-        )
-        await ctx.send(embed=embed)
+    async def mineinv(self, ctx):
+        """Show your unified inventory (compatibility alias for !inventory)."""
+        cmd = ctx.bot.get_command("inventory")
+        if cmd:
+            await ctx.invoke(cmd)
+        else:
+            await ctx.send("❌ Inventory system not loaded.", delete_after=10)
 
     @commands.command(name="minestats")
     async def stats(self, ctx):

--- a/disbot/cogs/moderation_cog.py
+++ b/disbot/cogs/moderation_cog.py
@@ -385,9 +385,7 @@ class _ModPanelView(discord.ui.View):
         await interaction.response.send_modal(_UnbanModal(self.cog))
 
     @discord.ui.button(label="📋 Mod Logs", style=discord.ButtonStyle.grey, row=1)
-    async def modlogs_btn(
-        self, interaction: discord.Interaction, _: discord.ui.Button
-    ):
+    async def modlogs_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
         await interaction.response.send_modal(_ModLogsModal(self.cog))
 
     @discord.ui.button(label="⬛ Clear Warnings", style=discord.ButtonStyle.grey, row=2)

--- a/disbot/cogs/moderation_cog.py
+++ b/disbot/cogs/moderation_cog.py
@@ -266,6 +266,64 @@ class _UnbanModal(discord.ui.Modal, title="Unban Member"):  # type: ignore[call-
             await interaction.followup.send(f"❌ Failed to unban: {e}")
 
 
+class _ModLogsModal(discord.ui.Modal, title="View Mod Logs"):  # type: ignore[call-arg]
+    member_input = discord.ui.TextInput(
+        label="User (mention, ID, or name)", max_length=100
+    )
+
+    def __init__(self, cog: "ModerationCog"):
+        super().__init__()
+        self.cog = cog
+
+    async def on_submit(self, interaction: discord.Interaction):
+        member = _parse_member(interaction.guild, self.member_input.value)
+        if not member:
+            await interaction.response.send_message(
+                "❌ Member not found.", ephemeral=True
+            )
+            return
+        logs = await db.get_mod_logs(member.id, interaction.guild_id, limit=10)
+        embed = discord.Embed(
+            title=f"📋 Mod Logs — {member.display_name}",
+            color=discord.Color.orange(),
+        )
+        if not logs:
+            embed.description = "No moderation history found."
+        else:
+            for entry in logs:
+                embed.add_field(
+                    name=f"{entry['action'].upper()} — {entry['timestamp']}",
+                    value=f"By <@{entry['moderator_id']}> | {entry['reason']}",
+                    inline=False,
+                )
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+
+
+class _ClearWarningsModal(discord.ui.Modal, title="Clear Warnings"):  # type: ignore[call-arg]
+    member_input = discord.ui.TextInput(
+        label="User (mention, ID, or name)", max_length=100
+    )
+
+    def __init__(self, cog: "ModerationCog"):
+        super().__init__()
+        self.cog = cog
+
+    async def on_submit(self, interaction: discord.Interaction):
+        member = _parse_member(interaction.guild, self.member_input.value)
+        if not member:
+            await interaction.response.send_message(
+                "❌ Member not found.", ephemeral=True
+            )
+            return
+        await db.clear_warnings(member.id, interaction.guild_id)
+        await db.log_mod_action(
+            interaction.guild_id, "clearwarnings", member.id, interaction.user.id, ""
+        )
+        await interaction.response.send_message(
+            f"✅ Warnings cleared for {member.mention}.", ephemeral=True
+        )
+
+
 # ---------------------------------------------------------------------------
 # Moderation action panel view
 # ---------------------------------------------------------------------------
@@ -288,9 +346,11 @@ class _ModPanelView(discord.ui.View):
         return True
 
     async def on_timeout(self):
+        for item in self.children:
+            item.disabled = True
         if self.message:
             try:
-                await self.message.edit(view=None)
+                await self.message.edit(view=self)
             except Exception:
                 pass
 
@@ -323,6 +383,18 @@ class _ModPanelView(discord.ui.View):
         self, interaction: discord.Interaction, button: discord.ui.Button
     ):
         await interaction.response.send_modal(_UnbanModal(self.cog))
+
+    @discord.ui.button(label="📋 Mod Logs", style=discord.ButtonStyle.grey, row=1)
+    async def modlogs_btn(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ):
+        await interaction.response.send_modal(_ModLogsModal(self.cog))
+
+    @discord.ui.button(label="⬛ Clear Warnings", style=discord.ButtonStyle.grey, row=2)
+    async def clearwarn_btn(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ):
+        await interaction.response.send_modal(_ClearWarningsModal(self.cog))
 
 
 # ---------------------------------------------------------------------------

--- a/disbot/cogs/proof_channel_cog.py
+++ b/disbot/cogs/proof_channel_cog.py
@@ -5,6 +5,7 @@ import logging
 
 import discord
 from discord.ext import commands
+from views.base import BaseView
 
 logger = logging.getLogger("discord_bot.prize_cog")
 
@@ -87,6 +88,14 @@ class ProofChannelCog(commands.Cog):
         )
         await ctx.send(embed=embed, delete_after=60)
 
+    @commands.command(name="prizemenu")
+    @commands.has_permissions(manage_channels=True)
+    async def prize_menu(self, ctx):
+        """Open the interactive prize channel management panel."""
+        view = _PrizeManagerView(ctx, self)
+        msg = await ctx.send(embed=view.build_embed(), view=view)
+        view.message = msg
+
     @commands.command(name="timedprize")
     @commands.has_permissions(manage_channels=True)
     async def start_timed_prize_claim(self, ctx, winner: discord.Member, duration: int):
@@ -120,6 +129,147 @@ class ProofChannelCog(commands.Cog):
 
         task = asyncio.create_task(_auto_unlock())
         self._timed_tasks[ctx.guild.id] = task
+
+
+class _PrizeWinnerModal(discord.ui.Modal, title="Grant Prize Access"):  # type: ignore[call-arg]
+    winner_input = discord.ui.TextInput(
+        label="Winner (mention, ID, or name)", max_length=100
+    )
+
+    def __init__(self, cog: "ProofChannelCog", timed: bool = False):
+        super().__init__()
+        self.cog = cog
+        self.timed = timed
+
+    async def on_submit(self, interaction: discord.Interaction):
+        from cogs.moderation_cog import _parse_member
+
+        member = _parse_member(interaction.guild, self.winner_input.value)
+        if not member:
+            await interaction.response.send_message(
+                "❌ Member not found.", ephemeral=True
+            )
+            return
+        ch = self.cog.get_proof_channel(interaction.guild)
+        if not ch:
+            await interaction.response.send_message(
+                "Channel '#proof' not found.", ephemeral=True
+            )
+            return
+        if self.timed:
+            await interaction.response.send_modal(_TimedPrizeModal(self.cog, member))
+        else:
+            await self.cog._lock_for_winner(ch, member)
+            await interaction.response.send_message(
+                f"✅ {member.mention} has been granted access to {ch.mention}!",
+                ephemeral=True,
+            )
+
+
+class _TimedPrizeModal(discord.ui.Modal, title="Timed Prize Access"):  # type: ignore[call-arg]
+    duration_input = discord.ui.TextInput(
+        label="Duration (minutes)", placeholder="e.g. 10", max_length=5
+    )
+
+    def __init__(self, cog: "ProofChannelCog", winner: discord.Member):
+        super().__init__()
+        self.cog = cog
+        self.winner = winner
+
+    async def on_submit(self, interaction: discord.Interaction):
+        if not self.duration_input.value.isdigit():
+            await interaction.response.send_message(
+                "❌ Duration must be a whole number of minutes.", ephemeral=True
+            )
+            return
+        duration = int(self.duration_input.value)
+        ch = self.cog.get_proof_channel(interaction.guild)
+        if not ch:
+            await interaction.response.send_message(
+                "Channel '#proof' not found.", ephemeral=True
+            )
+            return
+
+        if old_task := self.cog._timed_tasks.pop(interaction.guild_id, None):
+            old_task.cancel()
+
+        await self.cog._lock_for_winner(ch, self.winner)
+
+        async def _auto_unlock():
+            await asyncio.sleep(duration * 60)
+            try:
+                await self.cog._unlock(ch)
+            except Exception:
+                pass
+            finally:
+                self.cog._timed_tasks.pop(interaction.guild_id, None)
+
+        self.cog._timed_tasks[interaction.guild_id] = asyncio.create_task(
+            _auto_unlock()
+        )
+        await interaction.response.send_message(
+            f"✅ {self.winner.mention} has access to {ch.mention} for **{duration}** minute(s).",
+            ephemeral=True,
+        )
+
+
+class _PrizeManagerView(BaseView):
+    """Interactive prize channel management panel."""
+
+    def __init__(self, ctx: commands.Context, cog: "ProofChannelCog"):
+        super().__init__(ctx.author, timeout=180)
+        self.ctx = ctx
+        self.cog = cog
+
+    def build_embed(self) -> discord.Embed:
+        ch = self.cog.get_proof_channel(self.ctx.guild)
+        embed = discord.Embed(
+            title="🏆 Prize Channel Manager",
+            color=discord.Color.gold(),
+        )
+        if ch:
+            embed.description = f"Managing {ch.mention}"
+            formatted = _format_overwrites(ch.overwrites)
+            embed.add_field(
+                name="Current Permissions",
+                value=formatted[:1000] or "Default",
+                inline=False,
+            )
+        else:
+            embed.description = "⚠️ No `#proof` channel found. Create one first."
+        embed.set_footer(text="Use buttons below to manage prize access.")
+        return embed
+
+    @discord.ui.button(label="🏆 Grant Access", style=discord.ButtonStyle.green, row=0)
+    async def btn_grant(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await interaction.response.send_modal(_PrizeWinnerModal(self.cog, timed=False))
+
+    @discord.ui.button(
+        label="⏱️ Timed Access", style=discord.ButtonStyle.blurple, row=0
+    )
+    async def btn_timed(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await interaction.response.send_modal(_PrizeWinnerModal(self.cog, timed=True))
+
+    @discord.ui.button(label="🔒 End Session", style=discord.ButtonStyle.danger, row=0)
+    async def btn_end(self, interaction: discord.Interaction, _: discord.ui.Button):
+        ch = self.cog.get_proof_channel(interaction.guild)
+        if not ch:
+            await interaction.response.send_message(
+                "Channel '#proof' not found.", ephemeral=True
+            )
+            return
+        if task := self.cog._timed_tasks.pop(interaction.guild_id, None):
+            task.cancel()
+        await self.cog._unlock(ch)
+        embed = self.build_embed()
+        embed.description = f"✅ {ch.mention} is now read-only for everyone."
+        await interaction.response.edit_message(embed=embed, view=self)
+
+    @discord.ui.button(
+        label="🔄 Refresh Status", style=discord.ButtonStyle.secondary, row=1
+    )
+    async def btn_refresh(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await interaction.response.edit_message(embed=self.build_embed(), view=self)
 
 
 def _format_overwrites(overwrites: dict) -> str:

--- a/disbot/cogs/xp_cog.py
+++ b/disbot/cogs/xp_cog.py
@@ -180,9 +180,7 @@ class _XpHubView(BaseView):
 
 
 class _GiveXpModal(discord.ui.Modal, title="Give XP"):  # type: ignore[call-arg]
-    member_input = discord.ui.TextInput(
-        label="User (mention or ID)", max_length=100
-    )
+    member_input = discord.ui.TextInput(label="User (mention or ID)", max_length=100)
     amount_input = discord.ui.TextInput(
         label="XP amount", placeholder="e.g. 100", max_length=10
     )
@@ -196,16 +194,22 @@ class _GiveXpModal(discord.ui.Modal, title="Give XP"):  # type: ignore[call-arg]
 
         member = _parse_member(interaction.guild, self.member_input.value)
         if not member:
-            await interaction.response.send_message("❌ Member not found.", ephemeral=True)
+            await interaction.response.send_message(
+                "❌ Member not found.", ephemeral=True
+            )
             return
         try:
             amount = int(self.amount_input.value)
             if amount <= 0:
                 raise ValueError
         except ValueError:
-            await interaction.response.send_message("❌ Amount must be a positive integer.", ephemeral=True)
+            await interaction.response.send_message(
+                "❌ Amount must be a positive integer.", ephemeral=True
+            )
             return
-        new_xp, new_level, _ = await db.add_xp(member.id, interaction.guild_id, amount, 0)
+        new_xp, new_level, _ = await db.add_xp(
+            member.id, interaction.guild_id, amount, 0
+        )
         await interaction.response.send_message(
             f"✅ Gave **{amount}** XP to {member.mention}. "
             f"Now **{new_xp}** XP (Level **{new_level}**).",
@@ -214,9 +218,7 @@ class _GiveXpModal(discord.ui.Modal, title="Give XP"):  # type: ignore[call-arg]
 
 
 class _ResetXpModal(discord.ui.Modal, title="Reset XP"):  # type: ignore[call-arg]
-    member_input = discord.ui.TextInput(
-        label="User (mention or ID)", max_length=100
-    )
+    member_input = discord.ui.TextInput(label="User (mention or ID)", max_length=100)
     confirm_input = discord.ui.TextInput(
         label='Type "CONFIRM" to reset', placeholder="CONFIRM", max_length=10
     )
@@ -227,19 +229,25 @@ class _ResetXpModal(discord.ui.Modal, title="Reset XP"):  # type: ignore[call-ar
 
     async def on_submit(self, interaction: discord.Interaction):
         if self.confirm_input.value.strip().upper() != "CONFIRM":
-            await interaction.response.send_message("❌ Reset cancelled — type CONFIRM to proceed.", ephemeral=True)
+            await interaction.response.send_message(
+                "❌ Reset cancelled — type CONFIRM to proceed.", ephemeral=True
+            )
             return
         from cogs.moderation_cog import _parse_member
 
         member = _parse_member(interaction.guild, self.member_input.value)
         if not member:
-            await interaction.response.send_message("❌ Member not found.", ephemeral=True)
+            await interaction.response.send_message(
+                "❌ Member not found.", ephemeral=True
+            )
             return
         await db.execute(
             "DELETE FROM xp WHERE user_id=$1 AND guild_id=$2",
             (member.id, interaction.guild_id),
         )
-        await interaction.response.send_message(f"✅ Reset XP for {member.mention}.", ephemeral=True)
+        await interaction.response.send_message(
+            f"✅ Reset XP for {member.mention}.", ephemeral=True
+        )
 
 
 class XpCog(commands.Cog):

--- a/disbot/cogs/xp_cog.py
+++ b/disbot/cogs/xp_cog.py
@@ -9,7 +9,8 @@ from discord.ext import commands
 from utils import db
 from utils import embeds as em
 from utils.cooldowns import check_cooldown, format_remaining
-from utils.helpers import CogMenuView, post_log_embed
+from utils.helpers import post_log_embed
+from views.base import BaseView
 
 logger = logging.getLogger("bot")
 
@@ -107,15 +108,150 @@ async def _build_rank_embed(
 # ---------------------------------------------------------------------------
 
 
+class _XpHubView(BaseView):
+    """Interactive XP hub — shows rank card with quick admin actions."""
+
+    def __init__(self, ctx: commands.Context):
+        super().__init__(ctx.author, timeout=180)
+        self.ctx = ctx
+
+    async def build_embed(self) -> discord.Embed:
+        embed = await _build_rank_embed(self.ctx.author, self.ctx.guild, "both")
+        embed.title = f"🏆 XP Panel — {self.ctx.author.display_name}"
+        is_admin = self.ctx.author.guild_permissions.administrator
+        lines = ["Use the buttons below to switch stat views."]
+        if is_admin:
+            lines.append("Admin controls: ⚙️ Configure · 🎁 Give XP · 🔄 Reset XP")
+        embed.set_footer(text=" · ".join(lines))
+        # Show or hide admin buttons based on permissions
+        for item in self.children:
+            if hasattr(item, "_admin_only"):
+                item.disabled = not is_admin
+        return embed
+
+    @discord.ui.button(label="📊 Both", style=discord.ButtonStyle.blurple, row=0)
+    async def btn_both(self, interaction: discord.Interaction, _: discord.ui.Button):
+        embed = await _build_rank_embed(self.ctx.author, self.ctx.guild, "both")
+        embed.title = f"🏆 XP Panel — {self.ctx.author.display_name}"
+        await interaction.response.edit_message(embed=embed, view=self)
+
+    @discord.ui.button(label="🏆 XP", style=discord.ButtonStyle.blurple, row=0)
+    async def btn_xp(self, interaction: discord.Interaction, _: discord.ui.Button):
+        embed = await _build_rank_embed(self.ctx.author, self.ctx.guild, "xp")
+        embed.title = f"🏆 XP Panel — {self.ctx.author.display_name}"
+        await interaction.response.edit_message(embed=embed, view=self)
+
+    @discord.ui.button(label="🪙 Coins", style=discord.ButtonStyle.blurple, row=0)
+    async def btn_coins(self, interaction: discord.Interaction, _: discord.ui.Button):
+        embed = await _build_rank_embed(self.ctx.author, self.ctx.guild, "coins")
+        embed.title = f"🏆 XP Panel — {self.ctx.author.display_name}"
+        await interaction.response.edit_message(embed=embed, view=self)
+
+    @discord.ui.button(label="⚙️ Configure", style=discord.ButtonStyle.grey, row=1)
+    async def btn_config(self, interaction: discord.Interaction, _: discord.ui.Button):
+        if not interaction.user.guild_permissions.administrator:
+            await interaction.response.send_message(
+                "❌ Administrator permission required.", ephemeral=True
+            )
+            return
+        config_view = XpConfigView(self.ctx)
+        config_view.message = self.message
+        await interaction.response.edit_message(
+            embed=await config_view.build_embed(), view=config_view
+        )
+
+    @discord.ui.button(label="🎁 Give XP", style=discord.ButtonStyle.grey, row=1)
+    async def btn_givexp(self, interaction: discord.Interaction, _: discord.ui.Button):
+        if not interaction.user.guild_permissions.administrator:
+            await interaction.response.send_message(
+                "❌ Administrator permission required.", ephemeral=True
+            )
+            return
+        await interaction.response.send_modal(_GiveXpModal(self))
+
+    @discord.ui.button(label="🔄 Reset XP", style=discord.ButtonStyle.danger, row=1)
+    async def btn_resetxp(self, interaction: discord.Interaction, _: discord.ui.Button):
+        if not interaction.user.guild_permissions.administrator:
+            await interaction.response.send_message(
+                "❌ Administrator permission required.", ephemeral=True
+            )
+            return
+        await interaction.response.send_modal(_ResetXpModal(self))
+
+
+class _GiveXpModal(discord.ui.Modal, title="Give XP"):  # type: ignore[call-arg]
+    member_input = discord.ui.TextInput(
+        label="User (mention or ID)", max_length=100
+    )
+    amount_input = discord.ui.TextInput(
+        label="XP amount", placeholder="e.g. 100", max_length=10
+    )
+
+    def __init__(self, hub: _XpHubView):
+        super().__init__()
+        self._hub = hub
+
+    async def on_submit(self, interaction: discord.Interaction):
+        from cogs.moderation_cog import _parse_member
+
+        member = _parse_member(interaction.guild, self.member_input.value)
+        if not member:
+            await interaction.response.send_message("❌ Member not found.", ephemeral=True)
+            return
+        try:
+            amount = int(self.amount_input.value)
+            if amount <= 0:
+                raise ValueError
+        except ValueError:
+            await interaction.response.send_message("❌ Amount must be a positive integer.", ephemeral=True)
+            return
+        new_xp, new_level, _ = await db.add_xp(member.id, interaction.guild_id, amount, 0)
+        await interaction.response.send_message(
+            f"✅ Gave **{amount}** XP to {member.mention}. "
+            f"Now **{new_xp}** XP (Level **{new_level}**).",
+            ephemeral=True,
+        )
+
+
+class _ResetXpModal(discord.ui.Modal, title="Reset XP"):  # type: ignore[call-arg]
+    member_input = discord.ui.TextInput(
+        label="User (mention or ID)", max_length=100
+    )
+    confirm_input = discord.ui.TextInput(
+        label='Type "CONFIRM" to reset', placeholder="CONFIRM", max_length=10
+    )
+
+    def __init__(self, hub: _XpHubView):
+        super().__init__()
+        self._hub = hub
+
+    async def on_submit(self, interaction: discord.Interaction):
+        if self.confirm_input.value.strip().upper() != "CONFIRM":
+            await interaction.response.send_message("❌ Reset cancelled — type CONFIRM to proceed.", ephemeral=True)
+            return
+        from cogs.moderation_cog import _parse_member
+
+        member = _parse_member(interaction.guild, self.member_input.value)
+        if not member:
+            await interaction.response.send_message("❌ Member not found.", ephemeral=True)
+            return
+        await db.execute(
+            "DELETE FROM xp WHERE user_id=$1 AND guild_id=$2",
+            (member.id, interaction.guild_id),
+        )
+        await interaction.response.send_message(f"✅ Reset XP for {member.mention}.", ephemeral=True)
+
+
 class XpCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
 
     @commands.command(name="xpmenu")
     async def xp_menu(self, ctx: commands.Context):
-        """Show a quick-reference menu for all XP commands."""
-        view = CogMenuView(ctx, "🏆 XP Commands", _XP_MENU_COMMANDS)
-        msg = await ctx.send(embed=view.build_embed(), view=view)
+        """Open the XP panel showing your rank and quick admin actions."""
+        view = _XpHubView(ctx)
+        embed = await view.build_embed()
+        msg = await ctx.send(embed=embed, view=view)
         view.message = msg
 
     # ------------------------------------------------------------------ events

--- a/disbot/config.py
+++ b/disbot/config.py
@@ -42,6 +42,7 @@ INITIAL_EXTENSIONS = [
     "cogs.utility_cog",
     "cogs.cleanup_cog",
     "cogs.channel_cog",
+    "cogs.inventory_cog",
     "cogs.economy_cog",
     "cogs.counting_cog",
     "cogs.deathmatch_cog",


### PR DESCRIPTION
## Summary

Comprehensive UX modernization pass across all cogs, moving the bot from a mix of legacy text commands and partial view usage to a consistent, interactive platform.

### What changed

**New interactive hubs (previously text-command-only):**
- `!diagnostics` / `!diag` — hub with 8 action buttons (Bot Status, Latency, System Info, DB, JSON Files, Commands, Recent Errors, Test Notify)
- `!prizemenu` — prize channel management panel (Grant Access, Timed Access, End Session, Refresh)
- `!wordmenu` — prohibited words panel (Add Word / Remove Word modals + Refresh)
- `!chainmenu` — chain management panel (Create / Delete / Set Limit modals + Refresh)
- `!countingmenu` / `!cm` — counting game hub for current channel (Toggle Turns, Toggle Reset on Wrong, Reset Count, Refresh)
- `!xpmenu` — functional XP hub replacing the old command-list-only view (rank display, Give XP modal, Reset XP modal, admin config button)

**Unified inventory system:**
- New `inventory_cog.py` with `UnifiedInventoryView` aggregating both economy and mining items
- `!inventory` / `!inv` — single entry point with category buttons and paginated detail views
- `!mineinv` delegates to unified inventory; economy panel button uses the same view

**BaseView adoption (consistent timeout/auth):**
- `_EconomyPanelView` now inherits `BaseView` (removed duplicated `interaction_check` / `on_timeout`)
- `LeaderboardView` now inherits `BaseView` (timeout disables buttons instead of removing view)
- `_PaginatorView` in diagnostic_cog now inherits `BaseView`
- `_ModPanelView` timeout fixed to disable buttons in-place

**Deathmatch modernization:**
- Replaced `wait_for("reaction_add")` challenge acceptance with `_ChallengeView` (Accept/Decline buttons, opponent-restricted)
- Replaced `wait_for("message")` turn system while-loop with `_DuelView` (Attack/Defend buttons, current-player-restricted, auto-timeout declares winner)

**Moderation enhancements:**
- Added `📋 Mod Logs` button → modal to look up a member's moderation history
- Added `⬛ Clear Warnings` button → modal to clear a member's warnings (with audit log entry)

## Test plan

- [ ] `!inventory` → hub embed with category buttons → click category → items listed → `↩ Back` returns to hub
- [ ] `!mineinv` → same unified hub
- [ ] `!economymenu` → Economy Panel → 🎒 Inventory → unified hub with `↩ Overview`
- [ ] `!diagnostics` → panel → click each diagnostic button → result appears
- [ ] `!prizemenu` → panel → Grant Access / Timed Access → modals work → End Session locks channel
- [ ] `!wordmenu` → panel → Add Word modal → word appears in list → Remove Word → gone
- [ ] `!chainmenu` → panel → Create Chain modal → chain listed → Delete Chain → removed
- [ ] `!countingmenu` in a counting channel → stats shown → Toggle Turns updates embed
- [ ] `!xpmenu` → hub embed with rank info → Give XP modal → XP added → Reset XP modal with CONFIRM
- [ ] `!deathmatch @user` → embed with Accept/Decline buttons → Accept → Attack/Defend buttons → duel resolves
- [ ] Duel timeout (60s inactivity) → opponent wins, message updated, disabled buttons
- [ ] Challenge timeout (30s) → embed shows "expired", buttons disabled
- [ ] `!leaderboard` → embed → category select → embed updates in-place (no new message)
- [ ] `!leaderboard deathmatch` → correct embed direct
- [ ] `!modmenu` → Mod Logs button → modal → member history shown ephemerally

https://claude.ai/code/session_01UiBEApTjQHTxe2xDYrqNZ1

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiBEApTjQHTxe2xDYrqNZ1)_