### PR TITLE
feat: dynamic governance platform — subsystem registry, visibility engine, policy service

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -433,8 +433,9 @@ async def _load_cogs() -> None:
 async def main() -> None:
     # Validate registry integrity before touching the DB or loading cogs.
     # Raises GovernanceError (subclass) and aborts on any registry fault.
-    from utils.subsystem_registry import validate_registry
     from services.governance_exceptions import GovernanceError
+    from utils.subsystem_registry import validate_registry
+
     try:
         validate_registry()
         logger.info("Registry validated and frozen.")

--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -431,6 +431,17 @@ async def _load_cogs() -> None:
 # Entry point
 # ---------------------------------------------------------------------------
 async def main() -> None:
+    # Validate registry integrity before touching the DB or loading cogs.
+    # Raises GovernanceError (subclass) and aborts on any registry fault.
+    from utils.subsystem_registry import validate_registry
+    from services.governance_exceptions import GovernanceError
+    try:
+        validate_registry()
+        logger.info("Registry validated and frozen.")
+    except GovernanceError as exc:
+        logger.critical("Registry validation failed — aborting startup: %s", exc)
+        raise SystemExit(1) from exc
+
     await db.init()
     if reporter:
         await reporter.start()

--- a/disbot/cogs/channel_cog.py
+++ b/disbot/cogs/channel_cog.py
@@ -5,8 +5,11 @@ import logging
 
 import discord
 from discord.ext import commands
+from services import governance_service
+from services.governance_service import GovernanceContext
 from utils.channels import get_or_create_category, safe_channel_name
 from utils.helpers import safe_select_emoji
+from utils.subsystem_registry import SUBSYSTEMS, all_subsystems_sorted
 from utils.ui_constants import (
     CHANNEL_COLOR,
     ERROR_COLOR,
@@ -553,6 +556,18 @@ class _ChannelManagerView(BaseView):
             )
             return
         sub = _RestrictSubView(self.ctx, options=options, manager_message=self.message)
+        await interaction.response.edit_message(embed=sub.build_embed(), view=sub)
+
+    @discord.ui.button(
+        label="Subsystem Visibility",
+        style=discord.ButtonStyle.grey,
+        emoji="🔍",
+        row=1,
+    )
+    async def visibility_btn(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ):
+        sub = _VisibilitySubView(self.ctx, manager_message=self.message)
         await interaction.response.edit_message(embed=sub.build_embed(), view=sub)
 
 
@@ -1206,6 +1221,162 @@ class _CustomNameModal(discord.ui.Modal, title="Custom Channel Name"):  # type: 
             await self._view.manager_message.edit(
                 embed=self._view.build_embed(), view=self._view
             )
+
+
+# =====================================================================
+# Subsystem Visibility sub-panel
+# =====================================================================
+
+
+class _ChannelSelectForVisibility(discord.ui.Select):
+    def __init__(self, guild: discord.Guild):
+        channels = guild.text_channels[:25]
+        options = [
+            discord.SelectOption(
+                label=f"#{ch.name}"[:100],
+                value=str(ch.id),
+                description=f"ID: {ch.id}",
+            )
+            for ch in channels
+        ]
+        super().__init__(
+            placeholder="Select a channel to configure…",
+            min_values=1,
+            max_values=1,
+            options=options,
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction):
+        channel_id = int(self.values[0])
+        channel = interaction.guild.get_channel(channel_id)
+        if not channel:
+            await interaction.response.send_message(
+                "Channel not found.", ephemeral=True
+            )
+            return
+        sub = _SubsystemToggleView(
+            self.view.ctx,
+            channel=channel,
+            manager_message=self.view.manager_message,
+        )
+        await sub.load(interaction.guild_id)
+        await interaction.response.edit_message(embed=sub.build_embed(), view=sub)
+
+
+class _VisibilitySubView(BaseView):
+    def __init__(self, ctx: commands.Context, *, manager_message: discord.Message | None):
+        super().__init__(ctx.author, timeout=180)
+        self.ctx = ctx
+        self.manager_message = manager_message
+        self.add_item(_ChannelSelectForVisibility(ctx.guild))
+
+    def build_embed(self) -> discord.Embed:
+        embed = discord.Embed(
+            title="🔍 Subsystem Visibility",
+            description=(
+                "Select a channel below to configure which subsystems are visible there.\n\n"
+                "**Green** = enabled  •  **Red** = disabled  •  **Grey** = inheriting from parent scope\n\n"
+                "_Showing up to 25 channels. Category and guild-scope controls coming soon._"
+            ),
+            color=CHANNEL_COLOR,
+        )
+        return embed
+
+    @discord.ui.button(label="↩ Back", style=discord.ButtonStyle.grey, row=1)
+    async def back_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        from cogs.channel_cog import _ChannelManagerView
+        view = _ChannelManagerView(self.ctx)
+        view.message = self.manager_message
+        await interaction.response.edit_message(embed=view.build_embed(), view=view)
+
+
+class _SubsystemToggleView(BaseView):
+    """Per-channel subsystem toggle panel."""
+
+    def __init__(
+        self,
+        ctx: commands.Context,
+        *,
+        channel: discord.TextChannel,
+        manager_message: discord.Message | None,
+    ):
+        super().__init__(ctx.author, timeout=180)
+        self.ctx = ctx
+        self.channel = channel
+        self.manager_message = manager_message
+        self._visibility: dict[str, bool | None] = {}
+
+    async def load(self, guild_id: int) -> None:
+        from utils import db
+        rows = await db.get_subsystem_visibility(guild_id, "channel", self.channel.id)
+        self._visibility = rows
+        self._rebuild_buttons()
+
+    def _rebuild_buttons(self) -> None:
+        # Remove all items except the static back button
+        for item in list(self.children):
+            self.remove_item(item)
+
+        visible_subsystems = [
+            (name, meta)
+            for name, meta in all_subsystems_sorted()
+            if meta.get("visibility_mode", "normal") not in ("internal",)
+        ][:20]  # max 20 toggles to stay within Discord's 25-item limit
+
+        for i, (name, meta) in enumerate(visible_subsystems):
+            state = self._visibility.get(name)  # None = inherit
+            if state is True:
+                style = discord.ButtonStyle.green
+                label = f"✓ {meta.get('display_name', name)}"
+            elif state is False:
+                style = discord.ButtonStyle.red
+                label = f"✗ {meta.get('display_name', name)}"
+            else:
+                style = discord.ButtonStyle.grey
+                label = f"~ {meta.get('display_name', name)}"
+
+            btn = discord.ui.Button(
+                label=label[:80],
+                style=style,
+                row=min(1 + i // 5, 4),
+                custom_id=f"toggle_{name}",
+            )
+            btn.callback = self._make_toggle_callback(name)
+            self.add_item(btn)
+
+    def _make_toggle_callback(self, subsystem_name: str):
+        async def callback(interaction: discord.Interaction):
+            current = self._visibility.get(subsystem_name)
+            # Cycle: None (inherit) → True (force on) → False (force off) → None
+            if current is None:
+                new_val: bool | None = True
+            elif current is True:
+                new_val = False
+            else:
+                new_val = None
+
+            gctx = GovernanceContext.from_interaction(interaction)
+            await governance_service.set_subsystem_visibility(
+                gctx, "channel", self.channel.id, subsystem_name, new_val
+            )
+            self._visibility[subsystem_name] = new_val
+            self._rebuild_buttons()
+            await interaction.response.edit_message(embed=self.build_embed(), view=self)
+
+        return callback
+
+    def build_embed(self) -> discord.Embed:
+        embed = discord.Embed(
+            title=f"🔍 #{self.channel.name} — Subsystem Visibility",
+            description=(
+                "Toggle subsystem visibility for this channel.\n"
+                "**✓ Green** = force enabled  •  **✗ Red** = force disabled  "
+                "•  **~ Grey** = inherit from guild/category"
+            ),
+            color=CHANNEL_COLOR,
+        )
+        return embed
 
 
 # =====================================================================

--- a/disbot/cogs/channel_cog.py
+++ b/disbot/cogs/channel_cog.py
@@ -1265,7 +1265,9 @@ class _ChannelSelectForVisibility(discord.ui.Select):
 
 
 class _VisibilitySubView(BaseView):
-    def __init__(self, ctx: commands.Context, *, manager_message: discord.Message | None):
+    def __init__(
+        self, ctx: commands.Context, *, manager_message: discord.Message | None
+    ):
         super().__init__(ctx.author, timeout=180)
         self.ctx = ctx
         self.manager_message = manager_message
@@ -1286,6 +1288,7 @@ class _VisibilitySubView(BaseView):
     @discord.ui.button(label="↩ Back", style=discord.ButtonStyle.grey, row=1)
     async def back_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
         from cogs.channel_cog import _ChannelManagerView
+
         view = _ChannelManagerView(self.ctx)
         view.message = self.manager_message
         await interaction.response.edit_message(embed=view.build_embed(), view=view)
@@ -1309,6 +1312,7 @@ class _SubsystemToggleView(BaseView):
 
     async def load(self, guild_id: int) -> None:
         from utils import db
+
         rows = await db.get_subsystem_visibility(guild_id, "channel", self.channel.id)
         self._visibility = rows
         self._rebuild_buttons()
@@ -1322,7 +1326,9 @@ class _SubsystemToggleView(BaseView):
             (name, meta)
             for name, meta in all_subsystems_sorted()
             if meta.get("visibility_mode", "normal") not in ("internal",)
-        ][:20]  # max 20 toggles to stay within Discord's 25-item limit
+        ][
+            :20
+        ]  # max 20 toggles to stay within Discord's 25-item limit
 
         for i, (name, meta) in enumerate(visible_subsystems):
             state = self._visibility.get(name)  # None = inherit

--- a/disbot/cogs/cleanup_cog.py
+++ b/disbot/cogs/cleanup_cog.py
@@ -7,9 +7,20 @@ import re
 import config as _config
 import discord
 from discord.ext import commands
+from services import governance_service
+from services.governance_service import GovernanceContext
 from utils import db
 from utils.ui_constants import ADMIN_COLOR
 from views.base import BaseView
+
+
+def _extract_command_name(content: str, prefixes: list[str]) -> str | None:
+    """Extract the bare command name from a prefixed message."""
+    for prefix in prefixes:
+        if content.startswith(prefix):
+            rest = content[len(prefix):].split()[0] if content[len(prefix):].strip() else ""
+            return rest.lower() if rest else None
+    return None
 
 
 class Cleanup(commands.Cog):
@@ -42,19 +53,43 @@ class Cleanup(commands.Cog):
         return self._pattern_cache[guild_id]
 
     async def remove_unwanted_message(self, message):
-        """Deletes the message if it is a command in a non-whitelisted channel or contains prohibited content."""
+        """Delete message if it is a command in a governed channel or contains prohibited content."""
         if message.author.bot:
             return False
 
         if self.command_pattern.match(message.content):
+            command_name = _extract_command_name(message.content.strip(), self.command_prefixes)
+            if message.guild and command_name:
+                # Route through governance_service for policy-driven decision
+                gctx = GovernanceContext.from_message(message)
+                policy = await governance_service.resolve_command_policy(gctx, command_name)
+                if not policy.allowed:
+                    try:
+                        if policy.cleanup.delete_message:
+                            await message.delete()
+                            self.logger.info(
+                                "Deleted blocked command from %s: %s",
+                                message.author,
+                                message.content,
+                            )
+                        if policy.feedback:
+                            warn = await message.channel.send(policy.feedback)
+                            await warn.delete(delay=policy.cleanup.delete_after_seconds)
+                    except discord.DiscordException as e:
+                        self.logger.error("Cleanup error: %s", e)
+                    return True
+                return False
+            # DM or unknown guild — fall back to whitelist behavior
             if message.channel.id not in self.whitelisted_channels:
                 try:
                     await message.delete()
                     self.logger.info(
-                        f"Deleted command message from {message.author} in non-whitelisted channel: {message.content}"
+                        "Deleted command message from %s in non-whitelisted channel: %s",
+                        message.author,
+                        message.content,
                     )
                 except discord.DiscordException as e:
-                    self.logger.error(f"Failed to delete command message: {e}")
+                    self.logger.error("Failed to delete command message: %s", e)
                 return True
             return False
 

--- a/disbot/cogs/cleanup_cog.py
+++ b/disbot/cogs/cleanup_cog.py
@@ -18,7 +18,11 @@ def _extract_command_name(content: str, prefixes: list[str]) -> str | None:
     """Extract the bare command name from a prefixed message."""
     for prefix in prefixes:
         if content.startswith(prefix):
-            rest = content[len(prefix):].split()[0] if content[len(prefix):].strip() else ""
+            rest = (
+                content[len(prefix) :].split()[0]
+                if content[len(prefix) :].strip()
+                else ""
+            )
             return rest.lower() if rest else None
     return None
 
@@ -58,11 +62,15 @@ class Cleanup(commands.Cog):
             return False
 
         if self.command_pattern.match(message.content):
-            command_name = _extract_command_name(message.content.strip(), self.command_prefixes)
+            command_name = _extract_command_name(
+                message.content.strip(), self.command_prefixes
+            )
             if message.guild and command_name:
                 # Route through governance_service for policy-driven decision
                 gctx = GovernanceContext.from_message(message)
-                policy = await governance_service.resolve_command_policy(gctx, command_name)
+                policy = await governance_service.resolve_command_policy(
+                    gctx, command_name
+                )
                 if not policy.allowed:
                     try:
                         if policy.cleanup.delete_message:

--- a/disbot/cogs/help_cog.py
+++ b/disbot/cogs/help_cog.py
@@ -5,67 +5,130 @@ import logging
 import discord
 from discord.ext import commands
 
+from services import governance_service
+from services.governance_service import GovernanceContext
+from utils.subsystem_registry import SUBSYSTEMS, all_subsystems_sorted
+from utils.ui_constants import ADMIN_COLOR, GENERAL_COLOR, MOD_COLOR, UTILITY_COLOR
+from utils.visibility_rules import VISIBILITY_TIERS, is_tier_sufficient
+
 logger = logging.getLogger("bot")
 
+# Tier group display configuration
+_TIER_GROUPS = [
+    {
+        "label": "🟢 User Commands",
+        "tiers": {"user", "trusted"},
+        "color": GENERAL_COLOR,
+    },
+    {
+        "label": "🟠 Moderation",
+        "tiers": {"staff", "moderator"},
+        "color": MOD_COLOR,
+    },
+    {
+        "label": "🔴 Administration",
+        "tiers": {"administrator", "owner"},
+        "color": ADMIN_COLOR,
+    },
+]
 
-def _clean_name(cog: commands.Cog) -> str:
-    return cog.qualified_name.replace("Cog", "").strip()
+
+def _cog_for_subsystem(bot: commands.Bot, subsystem_name: str) -> commands.Cog | None:
+    """Find the cog that corresponds to a subsystem by checking entry_points."""
+    meta = SUBSYSTEMS.get(subsystem_name)
+    if not meta:
+        return None
+    for cog in bot.cogs.values():
+        cog_cmds = {cmd.name for cmd in cog.get_commands()}
+        entry_points = set(meta.get("entry_points", []))
+        if cog_cmds & entry_points:
+            return cog
+    return None
 
 
 def _get_visible_commands(cog: commands.Cog) -> list[commands.Command]:
     return [cmd for cmd in cog.get_commands() if not cmd.hidden and cmd.enabled]
 
 
-def build_overview_embed(bot: commands.Bot) -> discord.Embed:
+async def build_overview_embed(
+    bot: commands.Bot, ctx: commands.Context, visible: set[str], member_tier: str
+) -> discord.Embed:
+    """Build a governance-aware overview embed grouped by visibility tier."""
     embed = discord.Embed(
         title="📚 Help Menu",
-        description="Select a category from the dropdown to see its commands.",
-        color=discord.Color.blue(),
+        description="Select a category from the dropdown below.",
+        color=UTILITY_COLOR,
     )
-    for cog in bot.cogs.values():
-        cmds = _get_visible_commands(cog)
-        if not cmds:
-            continue
-        names = " ".join(f"`{c.name}`" for c in cmds)
-        embed.add_field(name=_clean_name(cog), value=names, inline=False)
+
+    subsystems_by_name = dict(all_subsystems_sorted())
+
+    for group in _TIER_GROUPS:
+        group_tiers: set[str] = group["tiers"]
+        entries: list[str] = []
+
+        for name, meta in subsystems_by_name.items():
+            if name not in visible:
+                continue
+            if meta.get("visibility_tier") not in group_tiers:
+                continue
+            emoji = meta.get("emoji", "•")
+            display = meta.get("display_name", name)
+            desc = meta.get("description", "")
+            entries.append(f"{emoji} **{display}** — {desc}")
+
+        if entries:
+            embed.add_field(
+                name=group["label"],
+                value="\n".join(entries),
+                inline=False,
+            )
+
     if not embed.fields:
-        embed.description = "No commands currently loaded."
+        embed.description = "No commands are available in this channel."
     return embed
 
 
-def build_cog_embed(cog: commands.Cog, prefix: str) -> discord.Embed:
-    embed = discord.Embed(
-        title=f"📖 {_clean_name(cog)}",
-        color=discord.Color.blue(),
-    )
+def build_cog_embed(
+    cog: commands.Cog,
+    prefix: str,
+    subsystem_name: str | None = None,
+) -> discord.Embed:
+    """Build a detail embed for one cog/subsystem."""
+    meta = SUBSYSTEMS.get(subsystem_name) if subsystem_name else None
+    color = discord.Color(meta["color"]) if meta else UTILITY_COLOR
+    display = meta.get("display_name", cog.qualified_name.replace("Cog", "")) if meta else cog.qualified_name.replace("Cog", "")
+    emoji = meta.get("emoji", "📖") if meta else "📖"
+
+    embed = discord.Embed(title=f"{emoji} {display}", color=color)
     cmds = _get_visible_commands(cog)
     for cmd in cmds:
         aliases = f"  *(aliases: {', '.join(cmd.aliases)})*" if cmd.aliases else ""
         sig = f" {cmd.signature}".rstrip() if cmd.signature else ""
-        usage = f"`{prefix}{cmd.name}{sig}`"
-        desc = cmd.help or "No description."
         embed.add_field(
             name=f"`{prefix}{cmd.name}`{aliases}",
-            value=f"{desc}\nUsage: {usage}",
+            value=f"{cmd.help or 'No description.'}\nUsage: `{prefix}{cmd.name}{sig}`",
             inline=False,
         )
     if not embed.fields:
-        embed.description = "No commands in this category."
+        embed.description = "No commands available in this category."
     return embed
 
 
-class CategorySelect(discord.ui.Select):
-    def __init__(self, bot: commands.Bot):
-        cogs_with_cmds = [
-            cog for cog in bot.cogs.values() if _get_visible_commands(cog)
+class _SubsystemSelect(discord.ui.Select):
+    def __init__(self, bot: commands.Bot, visible: set[str]):
+        subsystems_sorted = [
+            (name, meta)
+            for name, meta in all_subsystems_sorted()
+            if name in visible
         ]
         options = [
             discord.SelectOption(
-                label=_clean_name(cog),
-                value=cog.qualified_name,
-                description=f"{len(_get_visible_commands(cog))} command(s)",
+                label=meta.get("display_name", name),
+                value=name,
+                description=meta.get("description", "")[:100],
+                emoji=meta.get("emoji"),
             )
-            for cog in cogs_with_cmds
+            for name, meta in subsystems_sorted
         ][:25]
         super().__init__(
             placeholder="Choose a category…",
@@ -76,33 +139,36 @@ class CategorySelect(discord.ui.Select):
         )
 
     async def callback(self, interaction: discord.Interaction):
-        if interaction.user != self.view.ctx.author:
-            await interaction.response.send_message(
-                "This help menu is not for you.", ephemeral=True
-            )
-            return
-        cog = interaction.client.get_cog(self.values[0])
+        subsystem_name = self.values[0]
+        cog = _cog_for_subsystem(interaction.client, subsystem_name)
         if not cog:
             await interaction.response.send_message(
                 "That category is no longer loaded.", ephemeral=True
             )
             return
         prefix = self.view.prefix
-        embed = build_cog_embed(cog, prefix)
-        self.view.showing_cog = cog.qualified_name
+        embed = build_cog_embed(cog, prefix, subsystem_name)
         self.view.back_btn.disabled = False
         await interaction.response.edit_message(embed=embed, view=self.view)
 
 
 class HelpView(discord.ui.View):
-    def __init__(self, bot: commands.Bot, ctx: commands.Context):
+    def __init__(
+        self,
+        bot: commands.Bot,
+        ctx: commands.Context,
+        visible: set[str],
+        member_tier: str,
+    ):
         super().__init__(timeout=300)
         self.bot = bot
         self.ctx = ctx
-        self.showing_cog: str | None = None
+        self.visible = visible
+        self.member_tier = member_tier
         self.prefix = ctx.prefix or "!"
-        self._select = CategorySelect(bot)
+        self._select = _SubsystemSelect(bot, visible)
         self.add_item(self._select)
+        self.message: discord.Message | None = None
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         if interaction.user != self.ctx.author:
@@ -118,21 +184,21 @@ class HelpView(discord.ui.View):
     async def back_btn(
         self, interaction: discord.Interaction, button: discord.ui.Button
     ):
-        self.showing_cog = None
         button.disabled = True
-        # Rebuild select so it reflects currently loaded cogs
         self.remove_item(self._select)
-        self._select = CategorySelect(self.bot)
+        self._select = _SubsystemSelect(self.bot, self.visible)
         self.add_item(self._select)
-        await interaction.response.edit_message(
-            embed=build_overview_embed(self.bot), view=self
+        embed = await build_overview_embed(
+            self.bot, self.ctx, self.visible, self.member_tier
         )
+        await interaction.response.edit_message(embed=embed, view=self)
 
     async def on_timeout(self):
         for item in self.children:
-            item.disabled = True
+            item.disabled = True  # type: ignore[union-attr]
         try:
-            await self.message.edit(view=self)
+            if self.message:
+                await self.message.edit(view=self)
         except Exception:
             pass
 
@@ -143,24 +209,46 @@ class HelpCog(commands.Cog):
 
     @commands.command(name="help", aliases=["hilfe"])
     async def help_command(self, ctx: commands.Context, *, category: str = None):
-        """Shows all available commands. Pass a category name for details."""
+        """Shows available commands. Pass a category name for details."""
+        gctx = GovernanceContext.from_ctx(ctx)
+        vis_result = await governance_service.resolve_visibility(gctx)
+        visible = vis_result.visible_subsystems
+        member_tier = vis_result.member_tier
+
         if category:
+            # Try subsystem name lookup
+            for name, meta in SUBSYSTEMS.items():
+                if name not in visible:
+                    continue
+                if category.lower() in (name.lower(), meta.get("display_name", "").lower()):
+                    cog = _cog_for_subsystem(self.bot, name)
+                    if cog:
+                        await ctx.send(
+                            embed=build_cog_embed(cog, ctx.prefix or "!", name),
+                            delete_after=60,
+                        )
+                        return
+
+            # Try cog name or command name
             cog = self.bot.get_cog(category) or self.bot.get_cog(category + "Cog")
             cmd = self.bot.get_command(category)
             if cog:
-                embed = build_cog_embed(cog, ctx.prefix or "!")
-                await ctx.send(embed=embed, delete_after=60)
+                await ctx.send(
+                    embed=build_cog_embed(cog, ctx.prefix or "!"),
+                    delete_after=60,
+                )
                 return
             if cmd:
                 prefix = ctx.prefix or "!"
                 embed = discord.Embed(
                     title=f"`{prefix}{cmd.name}`",
                     description=cmd.help or "No description.",
-                    color=discord.Color.green(),
+                    color=UTILITY_COLOR,
                 )
                 if cmd.aliases:
                     embed.add_field(
-                        name="Aliases", value=", ".join(f"`{a}`" for a in cmd.aliases)
+                        name="Aliases",
+                        value=", ".join(f"`{a}`" for a in cmd.aliases),
                     )
                 embed.add_field(
                     name="Usage",
@@ -174,8 +262,8 @@ class HelpCog(commands.Cog):
             )
             return
 
-        view = HelpView(self.bot, ctx)
-        embed = build_overview_embed(self.bot)
+        embed = await build_overview_embed(self.bot, ctx, visible, member_tier)
+        view = HelpView(self.bot, ctx, visible, member_tier)
         msg = await ctx.send(embed=embed, view=view)
         view.message = msg
 

--- a/disbot/cogs/help_cog.py
+++ b/disbot/cogs/help_cog.py
@@ -4,7 +4,6 @@ import logging
 
 import discord
 from discord.ext import commands
-
 from services import governance_service
 from services.governance_service import GovernanceContext
 from utils.subsystem_registry import SUBSYSTEMS, all_subsystems_sorted
@@ -96,7 +95,11 @@ def build_cog_embed(
     """Build a detail embed for one cog/subsystem."""
     meta = SUBSYSTEMS.get(subsystem_name) if subsystem_name else None
     color = discord.Color(meta["color"]) if meta else UTILITY_COLOR
-    display = meta.get("display_name", cog.qualified_name.replace("Cog", "")) if meta else cog.qualified_name.replace("Cog", "")
+    display = (
+        meta.get("display_name", cog.qualified_name.replace("Cog", ""))
+        if meta
+        else cog.qualified_name.replace("Cog", "")
+    )
     emoji = meta.get("emoji", "📖") if meta else "📖"
 
     embed = discord.Embed(title=f"{emoji} {display}", color=color)
@@ -117,9 +120,7 @@ def build_cog_embed(
 class _SubsystemSelect(discord.ui.Select):
     def __init__(self, bot: commands.Bot, visible: set[str]):
         subsystems_sorted = [
-            (name, meta)
-            for name, meta in all_subsystems_sorted()
-            if name in visible
+            (name, meta) for name, meta in all_subsystems_sorted() if name in visible
         ]
         options = [
             discord.SelectOption(
@@ -220,7 +221,10 @@ class HelpCog(commands.Cog):
             for name, meta in SUBSYSTEMS.items():
                 if name not in visible:
                     continue
-                if category.lower() in (name.lower(), meta.get("display_name", "").lower()):
+                if category.lower() in (
+                    name.lower(),
+                    meta.get("display_name", "").lower(),
+                ):
                     cog = _cog_for_subsystem(self.bot, name)
                     if cog:
                         await ctx.send(

--- a/disbot/migrations/004_governance_tables.sql
+++ b/disbot/migrations/004_governance_tables.sql
@@ -1,0 +1,37 @@
+-- 004: governance subsystem visibility + cleanup policy tables
+--
+-- subsystem_visibility: per-scope (guild/category/channel/role) enabled overrides.
+--   enabled=TRUE  → force visible
+--   enabled=FALSE → force hidden
+--   enabled=NULL  → inherit from next-wider scope (tri-state)
+--
+-- cleanup_policies: per-scope cleanup behavior overrides.
+--   Scope resolution order: channel > category > guild > hardcoded default.
+
+CREATE TABLE IF NOT EXISTS subsystem_visibility (
+    guild_id    BIGINT  NOT NULL,
+    scope_type  TEXT    NOT NULL
+        CHECK (scope_type IN ('guild', 'category', 'channel', 'role')),
+    scope_id    BIGINT  NOT NULL,
+    subsystem   TEXT    NOT NULL,
+    enabled     BOOLEAN,           -- NULL = inherit from parent scope
+    PRIMARY KEY (guild_id, scope_type, scope_id, subsystem)
+);
+
+CREATE INDEX IF NOT EXISTS idx_sv_lookup
+    ON subsystem_visibility (guild_id, scope_type, scope_id);
+
+CREATE TABLE IF NOT EXISTS cleanup_policies (
+    guild_id                BIGINT  NOT NULL,
+    scope_type              TEXT    NOT NULL
+        CHECK (scope_type IN ('guild', 'category', 'channel')),
+    scope_id                BIGINT  NOT NULL,
+    delete_invalid_commands BOOLEAN NOT NULL DEFAULT TRUE,
+    delete_failed_commands  BOOLEAN NOT NULL DEFAULT TRUE,
+    delete_after_seconds    INTEGER NOT NULL DEFAULT 5,
+    PRIMARY KEY (guild_id, scope_type, scope_id)
+);
+
+INSERT INTO schema_migrations (version, applied_at, description)
+VALUES (4, extract(epoch from now())::bigint, 'governance tables')
+ON CONFLICT DO NOTHING;

--- a/disbot/services/governance_exceptions.py
+++ b/disbot/services/governance_exceptions.py
@@ -3,6 +3,7 @@
 All governance failures raise subclasses of GovernanceError.
 No bare ValueError or RuntimeError should originate from governance code.
 """
+
 from __future__ import annotations
 
 
@@ -18,9 +19,7 @@ class CircularDependencyError(RegistryValidationError):
     """Circular dependency detected in the subsystem dependency graph."""
 
     def __init__(self, node: str, neighbour: str) -> None:
-        super().__init__(
-            f"Circular dependency detected: '{node}' → '{neighbour}'"
-        )
+        super().__init__(f"Circular dependency detected: '{node}' → '{neighbour}'")
         self.node = node
         self.neighbour = neighbour
 

--- a/disbot/services/governance_exceptions.py
+++ b/disbot/services/governance_exceptions.py
@@ -1,0 +1,34 @@
+"""Typed exception hierarchy for the governance layer.
+
+All governance failures raise subclasses of GovernanceError.
+No bare ValueError or RuntimeError should originate from governance code.
+"""
+from __future__ import annotations
+
+
+class GovernanceError(Exception):
+    """Base class for all governance-layer errors."""
+
+
+class RegistryValidationError(GovernanceError):
+    """Registry integrity check failed during startup validation."""
+
+
+class CircularDependencyError(RegistryValidationError):
+    """Circular dependency detected in the subsystem dependency graph."""
+
+    def __init__(self, node: str, neighbour: str) -> None:
+        super().__init__(
+            f"Circular dependency detected: '{node}' → '{neighbour}'"
+        )
+        self.node = node
+        self.neighbour = neighbour
+
+
+class CapabilityNamespaceError(RegistryValidationError):
+    """Capability does not follow the required {subsystem}.{resource}.{action} format,
+    or uses a reserved namespace prefix (_internal, system, governance)."""
+
+
+class GovernanceUpgradeError(GovernanceError):
+    """Governance schema version upgrade failed."""

--- a/disbot/services/governance_service.py
+++ b/disbot/services/governance_service.py
@@ -1,0 +1,1073 @@
+"""Central governance orchestration service.
+
+Plugin Isolation Contract
+-------------------------
+Plugins MAY:
+  - call any public async function defined here
+  - register subsystems in subsystem_registry (before validate_registry())
+  - register capabilities following {subsystem}.{resource}.{action} namespace
+
+Plugins MAY NOT:
+  - mutate the registry after validate_registry() has been called (TypeError enforced)
+  - bypass this service and write governance DB tables (subsystem_visibility,
+    cleanup_policies) directly
+  - call db.set_subsystem_visibility / db.set_cleanup_policy directly
+  - emit governance.* events directly
+  - hold references to _CACHE, _CACHE_VERSION, or _CACHE_LOCK
+
+Architectural layer terminology:
+  registry   — immutable subsystem metadata (subsystem_registry.py)
+  visibility — UI/help discoverability (what appears in menus)
+  execution  — capability authorization (what can actually run)
+  cleanup    — moderation behavior (delete/feedback policies)
+  governance — orchestration: this file combines all layers into resolved policies
+
+Internal pipeline isolation: each concern lives in its own private function.
+No public function may inline more than one concern.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+import discord
+
+import config as _config
+from utils import db, settings_keys
+from utils.subsystem_registry import (
+    SUBSYSTEMS,
+    COMMAND_TO_SUBSYSTEM,
+    _COMPILED_DEPENDENTS,
+    _COMPILED_DEPENDENCY_ORDER,
+    REGISTRY_VERSION,
+    REGISTRY_SCHEMA_VERSION,
+    capability_matches,
+    get_subsystem_for_command,
+)
+from utils.visibility_rules import (
+    get_member_visibility_tier,
+    get_subsystems_for_tier,
+    is_tier_sufficient,
+)
+
+logger = logging.getLogger("bot")
+
+# ---------------------------------------------------------------------------
+# Canonical governance event names
+# Do NOT rename after v1 — external consumers may depend on these strings.
+# ---------------------------------------------------------------------------
+
+EVT_VISIBILITY_CHANGED = "governance.visibility.changed"
+EVT_CLEANUP_CHANGED    = "governance.cleanup.changed"
+EVT_EXECUTION_DENIED   = "governance.execution.denied"
+EVT_EXECUTION_ALLOWED  = "governance.execution.allowed"
+EVT_CACHE_INVALIDATED  = "governance.cache.invalidated"
+
+# ---------------------------------------------------------------------------
+# Scope resolution constants
+# ---------------------------------------------------------------------------
+
+SCOPE_PRIORITY: list[str] = ["channel", "category", "guild"]
+SCOPE_PARENT: dict[str, str | None] = {
+    "channel":  "category",
+    "category": "guild",
+    "guild":    None,
+    # Future: prepend "thread" → "channel"
+}
+
+# ---------------------------------------------------------------------------
+# Internal enums
+# ---------------------------------------------------------------------------
+
+
+class SubsystemState(Enum):
+    ENABLED              = "enabled"
+    DISABLED             = "disabled"
+    INHERITED            = "inherited"       # no override at this scope
+    BLOCKED_DEPENDENCY   = "blocked_dep"    # a hard dependency is disabled
+    INTERNAL             = "internal"       # visibility_mode == "internal"
+    EXPERIMENTAL_DISABLED = "exp_disabled"  # experimental, not opted in
+
+
+class PolicySource(Enum):
+    """Typed provenance for governance decisions.
+    Serialized to .value strings only in to_dict().
+    """
+    REGISTRY_DEFAULT  = "registry_default"   # derived from registry; no DB override
+    INHERITED_DEFAULT = "inherited_default"  # walked entire scope chain; no override
+    FALLBACK_DEFAULT  = "fallback_default"   # hardcoded compat (e.g. config whitelist)
+    DEPENDENCY_BLOCK  = "dependency_block"   # blocked by a disabled dependency
+    CHANNEL_OVERRIDE  = "channel"
+    CATEGORY_OVERRIDE = "category"
+    GUILD_OVERRIDE    = "guild"
+    ROLE_OVERRIDE     = "role"
+
+
+# ---------------------------------------------------------------------------
+# Public context + result dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class GovernanceContext:
+    """Carries all context needed for governance resolution.
+
+    Use from_ctx() / from_interaction() rather than constructing directly.
+    Future-proofs for threads, DMs, dashboards, AI agents, scheduled jobs.
+    """
+    guild_id: int
+    channel_id: int | None = None
+    category_id: int | None = None
+    thread_id: int | None = None
+    member: discord.Member | None = None
+    role_ids: set[int] = field(default_factory=set)
+
+    @classmethod
+    def from_ctx(cls, ctx) -> "GovernanceContext":
+        channel = ctx.channel
+        category_id = getattr(channel, "category_id", None)
+        member = ctx.author
+        return cls(
+            guild_id=ctx.guild.id,
+            channel_id=getattr(channel, "id", None),
+            category_id=category_id,
+            member=member,
+            role_ids={r.id for r in getattr(member, "roles", [])},
+        )
+
+    @classmethod
+    def from_interaction(cls, interaction: discord.Interaction) -> "GovernanceContext":
+        channel = interaction.channel
+        category_id = getattr(channel, "category_id", None)
+        member = interaction.user
+        return cls(
+            guild_id=interaction.guild_id,
+            channel_id=getattr(channel, "id", None),
+            category_id=category_id,
+            member=member,
+            role_ids={r.id for r in getattr(member, "roles", [])},
+        )
+
+    @classmethod
+    def from_message(cls, message: discord.Message) -> "GovernanceContext":
+        channel = message.channel
+        category_id = getattr(channel, "category_id", None)
+        member = message.author
+        return cls(
+            guild_id=message.guild.id if message.guild else 0,
+            channel_id=getattr(channel, "id", None),
+            category_id=category_id,
+            member=member,
+            role_ids={r.id for r in getattr(member, "roles", [])},
+        )
+
+
+@dataclass
+class ResolutionTrace:
+    subsystem: str
+    checked_scopes: list[str]
+    matched_scope: PolicySource | None
+    dependency_blocks: list[str]
+    final_state: SubsystemState
+
+    def to_dict(self) -> dict:
+        return {
+            "subsystem": self.subsystem,
+            "checked_scopes": sorted(self.checked_scopes),
+            "matched_scope": self.matched_scope.value if self.matched_scope else None,
+            "dependency_blocks": sorted(self.dependency_blocks),
+            "final_state": self.final_state.value,
+        }
+
+
+@dataclass
+class VisibilityResult:
+    visible_subsystems: set[str]
+    member_tier: str
+    resolved_from: dict[str, PolicySource]
+    traces: dict[str, ResolutionTrace]
+
+    def to_dict(self) -> dict:
+        return {
+            "visible_subsystems": sorted(self.visible_subsystems),
+            "member_tier": self.member_tier,
+            "resolved_from": {
+                k: v.value for k, v in sorted(self.resolved_from.items())
+            },
+            "traces": {
+                k: v.to_dict() for k, v in sorted(self.traces.items())
+            },
+        }
+
+
+@dataclass
+class ExecutionTrace:
+    capability: str
+    checked_scopes: list[str]
+    matched_scope: str | None
+    denied_by: str | None
+    final_result: bool
+
+    def to_dict(self) -> dict:
+        return {
+            "capability": self.capability,
+            "checked_scopes": sorted(self.checked_scopes),
+            "matched_scope": self.matched_scope,
+            "denied_by": self.denied_by,
+            "final_result": self.final_result,
+        }
+
+
+@dataclass
+class ExecutionResult:
+    allowed: bool
+    reason: str | None = None
+    resolved_scope: str | None = None
+    matched_capability: str | None = None
+    trace: ExecutionTrace | None = None
+
+
+@dataclass
+class CleanupPolicy:
+    delete_message: bool
+    delete_after_seconds: int
+    send_feedback: bool
+    resolved_from: PolicySource
+
+    def to_dict(self) -> dict:
+        return {
+            "delete_message": self.delete_message,
+            "delete_after_seconds": self.delete_after_seconds,
+            "send_feedback": self.send_feedback,
+            "resolved_from": self.resolved_from.value,
+        }
+
+
+@dataclass
+class CommandPolicy:
+    allowed: bool
+    cleanup: CleanupPolicy
+    feedback: str | None
+    redirect_channel_mention: str | None
+
+
+@dataclass
+class SubsystemEffectiveState:
+    """Complete resolved state for one subsystem in one context.
+    Powers /why, per-subsystem diagnostics, AI explanations.
+    """
+    name: str
+    state: SubsystemState
+    visibility_source: PolicySource
+    execution_allowed: bool
+    execution_source: PolicySource
+    dependency_blocks: list[str]
+    cleanup_policy: CleanupPolicy
+    trace: ResolutionTrace
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "state": self.state.value,
+            "visibility_source": self.visibility_source.value,
+            "execution_allowed": self.execution_allowed,
+            "execution_source": self.execution_source.value,
+            "dependency_blocks": sorted(self.dependency_blocks),
+            "cleanup_policy": self.cleanup_policy.to_dict(),
+            "trace": self.trace.to_dict(),
+        }
+
+
+@dataclass
+class GovernanceHealthReport:
+    orphan_overrides: list[dict]
+    stale_version_guilds: list[int]
+    invalid_cleanup_configs: list[dict]
+    summary: str
+
+
+@dataclass
+class GovernanceSnapshot:
+    """Complete governance state for a context.
+    Powers dashboards, /why, AI reasoning, export/import.
+    All fields JSON-safe. Use to_dict() for serialization.
+    """
+    visible_subsystems: set[str]
+    denied_subsystems: set[str]
+    dependency_blocks: dict[str, list[str]]
+    cleanup_policy: CleanupPolicy
+    member_tier: str
+    scope_provenance: dict[str, PolicySource]
+    capability_map: dict[str, bool]
+    registry_version: int
+    registry_schema_version: int
+
+    def to_dict(self) -> dict:
+        return {
+            "visible_subsystems": sorted(self.visible_subsystems),
+            "denied_subsystems": sorted(self.denied_subsystems),
+            "dependency_blocks": {
+                k: sorted(v)
+                for k, v in sorted(self.dependency_blocks.items())
+            },
+            "cleanup_policy": self.cleanup_policy.to_dict(),
+            "member_tier": self.member_tier,
+            "scope_provenance": {
+                k: v.value for k, v in sorted(self.scope_provenance.items())
+            },
+            "capability_map": {
+                k: v for k, v in sorted(self.capability_map.items())
+            },
+            "registry_version": self.registry_version,
+            "registry_schema_version": self.registry_schema_version,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Cache — version-stamped, tier-keyed (not member-keyed)
+# ---------------------------------------------------------------------------
+
+_CACHE: dict[tuple, tuple[float, Any]] = {}
+_CACHE_VERSION: dict[int, int] = {}    # guild_id → version counter
+_CACHE_LOCK = asyncio.Lock()
+_CACHE_TTL = 60.0
+_NO_OVERRIDE = object()               # sentinel for negative cache entries
+
+
+def _cache_ver(guild_id: int) -> int:
+    return _CACHE_VERSION.get(guild_id, 0)
+
+
+def _cache_key(guild_id: int, channel_id: int | None, tier: str) -> tuple:
+    return (guild_id, _cache_ver(guild_id), channel_id, tier)
+
+
+def _cache_get(key: tuple) -> Any:
+    entry = _CACHE.get(key)
+    if entry is None:
+        return None
+    ts, value = entry
+    if time.monotonic() - ts > _CACHE_TTL:
+        return None
+    return value
+
+
+def _cache_set(key: tuple, value: Any) -> None:
+    _CACHE[key] = (time.monotonic(), value)
+    # Lazy cleanup: remove entries from previous versions (unreachable anyway)
+    if len(_CACHE) > 2000:
+        cutoff = time.monotonic() - _CACHE_TTL
+        stale = [k for k, (ts, _) in _CACHE.items() if ts < cutoff]
+        for k in stale:
+            _CACHE.pop(k, None)
+
+
+def invalidate_guild_cache(guild_id: int) -> None:
+    """Increment version counter — old keys become unreachable (O(1))."""
+    _CACHE_VERSION[guild_id] = _cache_ver(guild_id) + 1
+
+
+# ---------------------------------------------------------------------------
+# Profiling hooks (no-op; wired for future metrics)
+# ---------------------------------------------------------------------------
+
+@asynccontextmanager
+async def _profile(operation: str):
+    start = time.monotonic()
+    try:
+        yield
+    finally:
+        elapsed = time.monotonic() - start
+        logger.debug("governance_profile op=%s elapsed=%.4f", operation, elapsed)
+
+
+# ---------------------------------------------------------------------------
+# Feedback debouncing
+# ---------------------------------------------------------------------------
+
+_FEEDBACK_COOLDOWN: dict[tuple[int, str], float] = {}
+_FEEDBACK_COOLDOWN_SECS = 10
+
+
+def _should_send_feedback(channel_id: int, subsystem: str) -> bool:
+    key = (channel_id, subsystem)
+    if time.monotonic() - _FEEDBACK_COOLDOWN.get(key, 0.0) > _FEEDBACK_COOLDOWN_SECS:
+        _FEEDBACK_COOLDOWN[key] = time.monotonic()
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Internal pipeline — scope chain traversal
+# ---------------------------------------------------------------------------
+
+def _build_scope_chain(ctx: GovernanceContext) -> list[tuple[str, int]]:
+    """Build ordered scope list via SCOPE_PARENT traversal.
+
+    Returns list from most-specific to least-specific, e.g.:
+      [("channel", 123), ("category", 456), ("guild", 789)]
+
+    Future: prepend ("thread", thread_id) before ("channel", channel_id).
+    This function is the ONLY place that knows the traversal order.
+    """
+    scope_id_map: dict[str, int | None] = {
+        "channel":  ctx.channel_id,
+        "category": ctx.category_id,
+        "guild":    ctx.guild_id,
+    }
+    chain: list[tuple[str, int]] = []
+    scope: str | None = "channel"
+    while scope is not None:
+        sid = scope_id_map.get(scope)
+        if sid is not None:
+            chain.append((scope, sid))
+        scope = SCOPE_PARENT.get(scope)
+    return chain
+
+
+# ---------------------------------------------------------------------------
+# Internal pipeline — DB override resolution
+# ---------------------------------------------------------------------------
+
+async def _fetch_all_visibility(
+    guild_id: int, chain: list[tuple[str, int]]
+) -> dict[tuple[str, int], dict[str, bool | None]]:
+    """Fetch all visibility rows for the scope chain in a single DB query."""
+    if not chain:
+        return {}
+    scope_types = [s for s, _ in chain]
+    scope_ids = [i for _, i in chain]
+    rows = await db.get().fetch(
+        """SELECT scope_type, scope_id, subsystem, enabled
+           FROM subsystem_visibility
+           WHERE guild_id=$1
+             AND scope_type = ANY($2::text[])
+             AND scope_id   = ANY($3::bigint[])""",
+        guild_id,
+        scope_types,
+        scope_ids,
+    )
+    result: dict[tuple[str, int], dict[str, bool | None]] = {
+        (s, i): {} for s, i in chain
+    }
+    for row in rows:
+        key = (row["scope_type"], row["scope_id"])
+        if key in result:
+            result[key][row["subsystem"]] = row["enabled"]
+    return result
+
+
+def _resolve_single_subsystem(
+    subsystem: str,
+    chain: list[tuple[str, int]],
+    scope_data: dict[tuple[str, int], dict[str, bool | None]],
+) -> tuple[bool | None, PolicySource, list[str]]:
+    """Walk the scope chain for one subsystem.
+
+    Returns (resolved_bool_or_None, source, checked_scope_labels).
+    None means "no override found anywhere" → caller uses registry default.
+    """
+    checked: list[str] = []
+    _SCOPE_TO_SOURCE: dict[str, PolicySource] = {
+        "channel":  PolicySource.CHANNEL_OVERRIDE,
+        "category": PolicySource.CATEGORY_OVERRIDE,
+        "guild":    PolicySource.GUILD_OVERRIDE,
+        "role":     PolicySource.ROLE_OVERRIDE,
+    }
+    for scope_type, scope_id in chain:
+        scope_map = scope_data.get((scope_type, scope_id), {})
+        checked.append(scope_type)
+        if subsystem in scope_map:
+            val = scope_map[subsystem]
+            if val is None:
+                # Explicit NULL = inherit from next scope
+                continue
+            return val, _SCOPE_TO_SOURCE[scope_type], checked
+    # No override found
+    return None, PolicySource.INHERITED_DEFAULT, checked
+
+
+# ---------------------------------------------------------------------------
+# Internal pipeline — dependency propagation
+# ---------------------------------------------------------------------------
+
+def _apply_dependency_rules(
+    states: dict[str, SubsystemState],
+    traces: dict[str, ResolutionTrace],
+    resolved_from: dict[str, PolicySource],
+) -> None:
+    """Propagate hard dependency blocking using topological order.
+
+    Modifies states, traces, and resolved_from in-place.
+    Uses _COMPILED_DEPENDENCY_ORDER so deps are always processed before dependents.
+    Soft dependencies are not propagated (future: UI hint only).
+    """
+    for subsystem in _COMPILED_DEPENDENCY_ORDER:
+        if subsystem not in states:
+            continue
+        meta = SUBSYSTEMS.get(subsystem)
+        if not meta:
+            continue
+        blocking_deps = [
+            dep for dep in meta.get("dependencies", [])
+            if states.get(dep) in (SubsystemState.DISABLED, SubsystemState.BLOCKED_DEPENDENCY)
+        ]
+        if blocking_deps and states[subsystem] == SubsystemState.ENABLED:
+            states[subsystem] = SubsystemState.BLOCKED_DEPENDENCY
+            resolved_from[subsystem] = PolicySource.DEPENDENCY_BLOCK
+            if subsystem in traces:
+                traces[subsystem].dependency_blocks.extend(blocking_deps)
+                traces[subsystem].final_state = SubsystemState.BLOCKED_DEPENDENCY
+                traces[subsystem].matched_scope = PolicySource.DEPENDENCY_BLOCK
+
+
+# ---------------------------------------------------------------------------
+# Internal pipeline — visibility resolution
+# ---------------------------------------------------------------------------
+
+async def _resolve_visibility_overrides(
+    ctx: GovernanceContext,
+    tier_accessible: set[str],
+) -> tuple[dict[str, SubsystemState], dict[str, ResolutionTrace], dict[str, PolicySource]]:
+    """Resolve visibility state for all subsystems via scope chain.
+
+    Returns (states, traces, resolved_from).
+    """
+    async with _profile("db.get_visibility"):
+        chain = _build_scope_chain(ctx)
+        scope_data = await _fetch_all_visibility(ctx.guild_id, chain)
+
+    states: dict[str, SubsystemState] = {}
+    traces: dict[str, ResolutionTrace] = {}
+    resolved_from: dict[str, PolicySource] = {}
+
+    for name, meta in SUBSYSTEMS.items():
+        # Tier gate — member doesn't have visibility tier for this subsystem
+        if name not in tier_accessible:
+            states[name] = SubsystemState.DISABLED
+            traces[name] = ResolutionTrace(
+                subsystem=name,
+                checked_scopes=[],
+                matched_scope=PolicySource.REGISTRY_DEFAULT,
+                dependency_blocks=[],
+                final_state=SubsystemState.DISABLED,
+            )
+            resolved_from[name] = PolicySource.REGISTRY_DEFAULT
+            continue
+
+        # Visibility mode gate
+        mode = meta.get("visibility_mode", "normal")
+        if mode == "internal":
+            states[name] = SubsystemState.INTERNAL
+            traces[name] = ResolutionTrace(
+                subsystem=name,
+                checked_scopes=[],
+                matched_scope=PolicySource.REGISTRY_DEFAULT,
+                dependency_blocks=[],
+                final_state=SubsystemState.INTERNAL,
+            )
+            resolved_from[name] = PolicySource.REGISTRY_DEFAULT
+            continue
+
+        # Scope chain resolution
+        override_val, source, checked = _resolve_single_subsystem(
+            name, chain, scope_data
+        )
+
+        if override_val is False:
+            final = SubsystemState.DISABLED
+        elif override_val is True:
+            final = SubsystemState.ENABLED
+        else:
+            # No override — default to enabled
+            final = SubsystemState.ENABLED
+            source = PolicySource.REGISTRY_DEFAULT
+
+        states[name] = final
+        traces[name] = ResolutionTrace(
+            subsystem=name,
+            checked_scopes=checked,
+            matched_scope=source if override_val is not None else None,
+            dependency_blocks=[],
+            final_state=final,
+        )
+        resolved_from[name] = source
+
+    return states, traces, resolved_from
+
+
+# ---------------------------------------------------------------------------
+# Internal pipeline — cleanup policy resolution
+# ---------------------------------------------------------------------------
+
+async def _resolve_cleanup_overrides(ctx: GovernanceContext) -> CleanupPolicy:
+    """Resolve cleanup policy with scope fallback: channel > guild > default.
+
+    Default preserves backwards-compatible behavior (config whitelist logic).
+    """
+    chain = _build_scope_chain(ctx)
+    for scope_type, scope_id in chain:
+        if scope_type == "role":
+            continue  # cleanup_policies doesn't support role scope
+        async with _profile("db.get_cleanup_policy"):
+            row = await db.get_cleanup_policy(ctx.guild_id, scope_type, scope_id)
+        if row is not None:
+            source_map = {
+                "channel":  PolicySource.CHANNEL_OVERRIDE,
+                "category": PolicySource.CATEGORY_OVERRIDE,
+                "guild":    PolicySource.GUILD_OVERRIDE,
+            }
+            return CleanupPolicy(
+                delete_message=row["delete_invalid_commands"],
+                delete_after_seconds=row["delete_after_seconds"],
+                send_feedback=True,
+                resolved_from=source_map.get(scope_type, PolicySource.GUILD_OVERRIDE),
+            )
+
+    # Backwards-compatible default: behave like config.CLEANUP_WHITELIST_CHANNELS
+    if ctx.channel_id and ctx.channel_id in _config.CLEANUP_WHITELIST_CHANNELS:
+        return CleanupPolicy(
+            delete_message=False,
+            delete_after_seconds=0,
+            send_feedback=False,
+            resolved_from=PolicySource.FALLBACK_DEFAULT,
+        )
+    return CleanupPolicy(
+        delete_message=True,
+        delete_after_seconds=5,
+        send_feedback=True,
+        resolved_from=PolicySource.FALLBACK_DEFAULT,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _find_redirect_channel(
+    guild: discord.Guild | None, subsystem_meta: dict
+) -> str | None:
+    if guild is None:
+        return None
+    for ch_name in subsystem_meta.get("default_channels", []):
+        ch = discord.utils.get(guild.text_channels, name=ch_name)
+        if ch:
+            return ch.mention
+    return None
+
+
+def _build_feedback(subsystem_meta: dict, redirect: str | None) -> str:
+    name = subsystem_meta.get("display_name", "This")
+    emoji = subsystem_meta.get("emoji", "❌")
+    if redirect:
+        return f"{emoji} **{name}** commands are disabled here. Use {redirect} instead."
+    return f"{emoji} **{name}** commands are disabled in this channel."
+
+
+# ---------------------------------------------------------------------------
+# Public API — visibility
+# ---------------------------------------------------------------------------
+
+async def resolve_visibility(ctx: GovernanceContext) -> VisibilityResult:
+    """Resolve which subsystems are visible to this member in this context.
+
+    Scope resolution: channel > category > guild > registry default.
+    Dependency rules applied after scope resolution (topological order).
+    Results are cached by (guild_id, version, channel_id, member_tier).
+    """
+    if ctx.member is None:
+        tier = "user"
+    else:
+        tier = get_member_visibility_tier(
+            ctx.member,
+            ctx.member.guild.owner_id if ctx.member.guild else 0,
+        )
+
+    cache_key = _cache_key(ctx.guild_id, ctx.channel_id, tier)
+    async with _CACHE_LOCK:
+        cached = _cache_get(cache_key)
+        if cached is not None and cached is not _NO_OVERRIDE:
+            return cached
+
+    tier_accessible = set(get_subsystems_for_tier(tier))
+
+    async with _profile("resolve_visibility"):
+        states, traces, resolved_from = await _resolve_visibility_overrides(
+            ctx, tier_accessible
+        )
+        _apply_dependency_rules(states, traces, resolved_from)
+
+    visible = {
+        name for name, state in states.items()
+        if state == SubsystemState.ENABLED
+    }
+
+    result = VisibilityResult(
+        visible_subsystems=visible,
+        member_tier=tier,
+        resolved_from=resolved_from,
+        traces=traces,
+    )
+
+    async with _CACHE_LOCK:
+        _cache_set(cache_key, result)
+
+    return result
+
+
+async def get_visible_subsystems(ctx: GovernanceContext) -> set[str]:
+    """Convenience wrapper — returns only the visible subsystem name set."""
+    result = await resolve_visibility(ctx)
+    return result.visible_subsystems
+
+
+# ---------------------------------------------------------------------------
+# Public API — execution
+# ---------------------------------------------------------------------------
+
+async def resolve_execution(
+    ctx: GovernanceContext, capability: str
+) -> ExecutionResult:
+    """Determine if a capability is executable in this context.
+
+    Separate from visibility — a subsystem can be hidden but still executable
+    (e.g. internal commands, AI-triggered actions, API calls).
+    Currently: delegates to visibility resolution for the capability's subsystem.
+    Future: independent execution policy layer.
+    """
+    async with _profile("resolve_execution"):
+        vis = await resolve_visibility(ctx)
+        from utils.subsystem_registry import CAPABILITY_TO_SUBSYSTEM
+        subsystem_name = CAPABILITY_TO_SUBSYSTEM.get(capability)
+
+        if not subsystem_name:
+            return ExecutionResult(
+                allowed=True,
+                reason="Unknown capability — no governance restriction",
+                trace=ExecutionTrace(
+                    capability=capability,
+                    checked_scopes=[],
+                    matched_scope=None,
+                    denied_by=None,
+                    final_result=True,
+                ),
+            )
+
+        allowed = subsystem_name in vis.visible_subsystems
+        trace_obj = vis.traces.get(subsystem_name)
+        denied_by = (
+            trace_obj.final_state.value
+            if trace_obj and not allowed
+            else None
+        )
+
+        if not allowed:
+            await _emit_governance_event(EVT_EXECUTION_DENIED, {
+                "guild_id": ctx.guild_id,
+                "capability": capability,
+                "subsystem": subsystem_name,
+                "denied_by": denied_by,
+            })
+        else:
+            await _emit_governance_event(EVT_EXECUTION_ALLOWED, {
+                "guild_id": ctx.guild_id,
+                "capability": capability,
+                "subsystem": subsystem_name,
+            })
+
+        return ExecutionResult(
+            allowed=allowed,
+            reason=denied_by,
+            resolved_scope=trace_obj.matched_scope.value if trace_obj and trace_obj.matched_scope else None,
+            matched_capability=capability if allowed else None,
+            trace=ExecutionTrace(
+                capability=capability,
+                checked_scopes=trace_obj.checked_scopes if trace_obj else [],
+                matched_scope=trace_obj.matched_scope.value if trace_obj and trace_obj.matched_scope else None,
+                denied_by=denied_by,
+                final_result=allowed,
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public API — cleanup policy
+# ---------------------------------------------------------------------------
+
+async def resolve_cleanup_policy(ctx: GovernanceContext) -> CleanupPolicy:
+    """Resolve cleanup behavior for this context."""
+    async with _profile("resolve_cleanup_policy"):
+        return await _resolve_cleanup_overrides(ctx)
+
+
+# ---------------------------------------------------------------------------
+# Public API — command policy (combines visibility + cleanup)
+# ---------------------------------------------------------------------------
+
+async def resolve_command_policy(
+    ctx: GovernanceContext, command_name: str
+) -> CommandPolicy:
+    """Full policy resolution for a message command invocation attempt.
+
+    Returns allowed=True for unknown commands (not a governance concern).
+    """
+    async with _profile("resolve_command_policy"):
+        found = get_subsystem_for_command(command_name)
+        if found is None:
+            # Unknown command — not a governance concern
+            return CommandPolicy(
+                allowed=True,
+                cleanup=CleanupPolicy(
+                    delete_message=False,
+                    delete_after_seconds=0,
+                    send_feedback=False,
+                    resolved_from=PolicySource.REGISTRY_DEFAULT,
+                ),
+                feedback=None,
+                redirect_channel_mention=None,
+            )
+
+        subsystem_name, subsystem_meta = found
+        visible = await get_visible_subsystems(ctx)
+
+        if subsystem_name in visible:
+            return CommandPolicy(
+                allowed=True,
+                cleanup=CleanupPolicy(
+                    delete_message=False,
+                    delete_after_seconds=0,
+                    send_feedback=False,
+                    resolved_from=PolicySource.REGISTRY_DEFAULT,
+                ),
+                feedback=None,
+                redirect_channel_mention=None,
+            )
+
+        # Blocked — build cleanup + feedback
+        cleanup = await _resolve_cleanup_overrides(ctx)
+        guild = ctx.member.guild if ctx.member else None
+        redirect = _find_redirect_channel(guild, subsystem_meta)
+
+        send_fb = cleanup.send_feedback and _should_send_feedback(
+            ctx.channel_id or 0, subsystem_name
+        )
+        feedback = _build_feedback(subsystem_meta, redirect) if send_fb else None
+
+        return CommandPolicy(
+            allowed=False,
+            cleanup=cleanup,
+            feedback=feedback,
+            redirect_channel_mention=redirect,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public API — bulk resolution
+# ---------------------------------------------------------------------------
+
+async def resolve_all_subsystem_visibility(
+    ctx: GovernanceContext,
+) -> dict[str, bool]:
+    """All subsystems with resolved enabled state. Single-trip through resolve_visibility."""
+    result = await resolve_visibility(ctx)
+    return {
+        name: (name in result.visible_subsystems)
+        for name in SUBSYSTEMS
+    }
+
+
+async def resolve_all_capabilities(ctx: GovernanceContext) -> dict[str, bool]:
+    """All capabilities with resolved allowed state."""
+    from utils.subsystem_registry import CAPABILITY_TO_SUBSYSTEM
+    visible = await get_visible_subsystems(ctx)
+    return {
+        cap: (subsystem in visible)
+        for cap, subsystem in CAPABILITY_TO_SUBSYSTEM.items()
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public API — effective state (single subsystem)
+# ---------------------------------------------------------------------------
+
+async def resolve_subsystem_state(
+    ctx: GovernanceContext, subsystem_name: str
+) -> SubsystemEffectiveState:
+    """Complete resolved state for one subsystem. Powers /why, admin diagnostics."""
+    vis = await resolve_visibility(ctx)
+    cleanup = await resolve_cleanup_policy(ctx)
+
+    state = SubsystemState.ENABLED if subsystem_name in vis.visible_subsystems else SubsystemState.DISABLED
+    trace = vis.traces.get(
+        subsystem_name,
+        ResolutionTrace(
+            subsystem=subsystem_name,
+            checked_scopes=[],
+            matched_scope=None,
+            dependency_blocks=[],
+            final_state=state,
+        ),
+    )
+    source = vis.resolved_from.get(subsystem_name, PolicySource.REGISTRY_DEFAULT)
+
+    return SubsystemEffectiveState(
+        name=subsystem_name,
+        state=trace.final_state,
+        visibility_source=source,
+        execution_allowed=subsystem_name in vis.visible_subsystems,
+        execution_source=source,
+        dependency_blocks=trace.dependency_blocks,
+        cleanup_policy=cleanup,
+        trace=trace,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API — governance snapshot
+# ---------------------------------------------------------------------------
+
+async def build_governance_snapshot(ctx: GovernanceContext) -> GovernanceSnapshot:
+    """Complete governance state for a context.
+    Powers dashboards, /why, AI reasoning, diagnostics.
+    """
+    vis = await resolve_visibility(ctx)
+    cleanup = await resolve_cleanup_policy(ctx)
+    cap_map = await resolve_all_capabilities(ctx)
+
+    all_names = set(SUBSYSTEMS.keys())
+    denied = all_names - vis.visible_subsystems
+    dep_blocks: dict[str, list[str]] = {}
+    for name, trace in vis.traces.items():
+        if trace.dependency_blocks:
+            dep_blocks[name] = trace.dependency_blocks
+
+    return GovernanceSnapshot(
+        visible_subsystems=vis.visible_subsystems,
+        denied_subsystems=denied,
+        dependency_blocks=dep_blocks,
+        cleanup_policy=cleanup,
+        member_tier=vis.member_tier,
+        scope_provenance=vis.resolved_from,
+        capability_map=cap_map,
+        registry_version=REGISTRY_VERSION,
+        registry_schema_version=REGISTRY_SCHEMA_VERSION,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API — health diagnostics
+# ---------------------------------------------------------------------------
+
+async def run_governance_healthcheck(guild_id: int) -> GovernanceHealthReport:
+    """Check for orphan overrides, stale versions, and invalid configs."""
+    known_subsystems = set(SUBSYSTEMS.keys())
+    rows = await db.get_all_visibility_for_guild(guild_id)
+    orphans = [
+        {"scope_type": r["scope_type"], "scope_id": r["scope_id"], "subsystem": r["subsystem"]}
+        for r in rows
+        if r["subsystem"] not in known_subsystems
+    ]
+
+    stored = await db.get_setting(guild_id, settings_keys.GOVERNANCE_VERSION, default=0)
+    stale = [guild_id] if int(stored) < REGISTRY_VERSION else []
+
+    summary = (
+        f"{len(orphans)} orphan override(s), "
+        f"{len(stale)} stale version guild(s)"
+    )
+    return GovernanceHealthReport(
+        orphan_overrides=orphans,
+        stale_version_guilds=stale,
+        invalid_cleanup_configs=[],
+        summary=summary,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API — governance writes (all cogs must route through here)
+# ---------------------------------------------------------------------------
+
+async def set_subsystem_visibility(
+    ctx: GovernanceContext,
+    scope_type: str,
+    scope_id: int,
+    subsystem: str,
+    enabled: bool | None,
+) -> None:
+    """Set a subsystem visibility override. enabled=None clears the override (inherit)."""
+    await db.set_subsystem_visibility(
+        ctx.guild_id, scope_type, scope_id, subsystem, enabled
+    )
+    invalidate_guild_cache(ctx.guild_id)
+    await _emit_governance_event(EVT_VISIBILITY_CHANGED, {
+        "guild_id": ctx.guild_id,
+        "scope_type": scope_type,
+        "scope_id": scope_id,
+        "subsystem": subsystem,
+        "enabled": enabled,
+    })
+
+
+async def set_cleanup_policy_for_scope(
+    ctx: GovernanceContext,
+    scope_type: str,
+    scope_id: int,
+    delete_invalid_commands: bool = True,
+    delete_failed_commands: bool = True,
+    delete_after_seconds: int = 5,
+) -> None:
+    await db.set_cleanup_policy(
+        ctx.guild_id,
+        scope_type,
+        scope_id,
+        delete_invalid_commands=delete_invalid_commands,
+        delete_failed_commands=delete_failed_commands,
+        delete_after_seconds=delete_after_seconds,
+    )
+    invalidate_guild_cache(ctx.guild_id)
+    await _emit_governance_event(EVT_CLEANUP_CHANGED, {
+        "guild_id": ctx.guild_id,
+        "scope_type": scope_type,
+        "scope_id": scope_id,
+    })
+
+
+# ---------------------------------------------------------------------------
+# Governance version management
+# ---------------------------------------------------------------------------
+
+async def check_governance_version(guild_id: int) -> None:
+    """Check and upgrade governance version for a guild if needed."""
+    stored = await db.get_setting(
+        guild_id, settings_keys.GOVERNANCE_VERSION, default=0
+    )
+    if int(stored) < REGISTRY_VERSION:
+        await _run_governance_upgrade(guild_id, from_version=int(stored))
+
+
+async def _run_governance_upgrade(guild_id: int, from_version: int) -> None:
+    logger.info(
+        "governance upgrade guild=%d from v%d to v%d",
+        guild_id,
+        from_version,
+        REGISTRY_VERSION,
+    )
+    await db.set_setting(guild_id, settings_keys.GOVERNANCE_VERSION, REGISTRY_VERSION)
+
+
+# ---------------------------------------------------------------------------
+# Internal event hook
+# ---------------------------------------------------------------------------
+
+async def _emit_governance_event(event_name: str, payload: dict) -> None:
+    """Internal hook. Currently DEBUG-logs only.
+    Future: route to core.events.EventBus — do NOT inline analytics here.
+    governance_service must not become an analytics service.
+    """
+    logger.debug("governance_event %s %s", event_name, payload)
+    # Future: await event_bus.publish(event_name, payload)

--- a/disbot/services/governance_service.py
+++ b/disbot/services/governance_service.py
@@ -25,6 +25,7 @@ Architectural layer terminology:
 Internal pipeline isolation: each concern lives in its own private function.
 No public function may inline more than one concern.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -35,17 +36,16 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
-import discord
-
 import config as _config
+import discord
 from utils import db, settings_keys
 from utils.subsystem_registry import (
-    SUBSYSTEMS,
-    COMMAND_TO_SUBSYSTEM,
-    _COMPILED_DEPENDENTS,
     _COMPILED_DEPENDENCY_ORDER,
-    REGISTRY_VERSION,
+    _COMPILED_DEPENDENTS,
+    COMMAND_TO_SUBSYSTEM,
     REGISTRY_SCHEMA_VERSION,
+    REGISTRY_VERSION,
+    SUBSYSTEMS,
     capability_matches,
     get_subsystem_for_command,
 )
@@ -63,10 +63,10 @@ logger = logging.getLogger("bot")
 # ---------------------------------------------------------------------------
 
 EVT_VISIBILITY_CHANGED = "governance.visibility.changed"
-EVT_CLEANUP_CHANGED    = "governance.cleanup.changed"
-EVT_EXECUTION_DENIED   = "governance.execution.denied"
-EVT_EXECUTION_ALLOWED  = "governance.execution.allowed"
-EVT_CACHE_INVALIDATED  = "governance.cache.invalidated"
+EVT_CLEANUP_CHANGED = "governance.cleanup.changed"
+EVT_EXECUTION_DENIED = "governance.execution.denied"
+EVT_EXECUTION_ALLOWED = "governance.execution.allowed"
+EVT_CACHE_INVALIDATED = "governance.cache.invalidated"
 
 # ---------------------------------------------------------------------------
 # Scope resolution constants
@@ -74,9 +74,9 @@ EVT_CACHE_INVALIDATED  = "governance.cache.invalidated"
 
 SCOPE_PRIORITY: list[str] = ["channel", "category", "guild"]
 SCOPE_PARENT: dict[str, str | None] = {
-    "channel":  "category",
+    "channel": "category",
     "category": "guild",
-    "guild":    None,
+    "guild": None,
     # Future: prepend "thread" → "channel"
 }
 
@@ -86,11 +86,11 @@ SCOPE_PARENT: dict[str, str | None] = {
 
 
 class SubsystemState(Enum):
-    ENABLED              = "enabled"
-    DISABLED             = "disabled"
-    INHERITED            = "inherited"       # no override at this scope
-    BLOCKED_DEPENDENCY   = "blocked_dep"    # a hard dependency is disabled
-    INTERNAL             = "internal"       # visibility_mode == "internal"
+    ENABLED = "enabled"
+    DISABLED = "disabled"
+    INHERITED = "inherited"  # no override at this scope
+    BLOCKED_DEPENDENCY = "blocked_dep"  # a hard dependency is disabled
+    INTERNAL = "internal"  # visibility_mode == "internal"
     EXPERIMENTAL_DISABLED = "exp_disabled"  # experimental, not opted in
 
 
@@ -98,14 +98,15 @@ class PolicySource(Enum):
     """Typed provenance for governance decisions.
     Serialized to .value strings only in to_dict().
     """
-    REGISTRY_DEFAULT  = "registry_default"   # derived from registry; no DB override
+
+    REGISTRY_DEFAULT = "registry_default"  # derived from registry; no DB override
     INHERITED_DEFAULT = "inherited_default"  # walked entire scope chain; no override
-    FALLBACK_DEFAULT  = "fallback_default"   # hardcoded compat (e.g. config whitelist)
-    DEPENDENCY_BLOCK  = "dependency_block"   # blocked by a disabled dependency
-    CHANNEL_OVERRIDE  = "channel"
+    FALLBACK_DEFAULT = "fallback_default"  # hardcoded compat (e.g. config whitelist)
+    DEPENDENCY_BLOCK = "dependency_block"  # blocked by a disabled dependency
+    CHANNEL_OVERRIDE = "channel"
     CATEGORY_OVERRIDE = "category"
-    GUILD_OVERRIDE    = "guild"
-    ROLE_OVERRIDE     = "role"
+    GUILD_OVERRIDE = "guild"
+    ROLE_OVERRIDE = "role"
 
 
 # ---------------------------------------------------------------------------
@@ -120,6 +121,7 @@ class GovernanceContext:
     Use from_ctx() / from_interaction() rather than constructing directly.
     Future-proofs for threads, DMs, dashboards, AI agents, scheduled jobs.
     """
+
     guild_id: int
     channel_id: int | None = None
     category_id: int | None = None
@@ -199,9 +201,7 @@ class VisibilityResult:
             "resolved_from": {
                 k: v.value for k, v in sorted(self.resolved_from.items())
             },
-            "traces": {
-                k: v.to_dict() for k, v in sorted(self.traces.items())
-            },
+            "traces": {k: v.to_dict() for k, v in sorted(self.traces.items())},
         }
 
 
@@ -261,6 +261,7 @@ class SubsystemEffectiveState:
     """Complete resolved state for one subsystem in one context.
     Powers /why, per-subsystem diagnostics, AI explanations.
     """
+
     name: str
     state: SubsystemState
     visibility_source: PolicySource
@@ -297,6 +298,7 @@ class GovernanceSnapshot:
     Powers dashboards, /why, AI reasoning, export/import.
     All fields JSON-safe. Use to_dict() for serialization.
     """
+
     visible_subsystems: set[str]
     denied_subsystems: set[str]
     dependency_blocks: dict[str, list[str]]
@@ -312,17 +314,14 @@ class GovernanceSnapshot:
             "visible_subsystems": sorted(self.visible_subsystems),
             "denied_subsystems": sorted(self.denied_subsystems),
             "dependency_blocks": {
-                k: sorted(v)
-                for k, v in sorted(self.dependency_blocks.items())
+                k: sorted(v) for k, v in sorted(self.dependency_blocks.items())
             },
             "cleanup_policy": self.cleanup_policy.to_dict(),
             "member_tier": self.member_tier,
             "scope_provenance": {
                 k: v.value for k, v in sorted(self.scope_provenance.items())
             },
-            "capability_map": {
-                k: v for k, v in sorted(self.capability_map.items())
-            },
+            "capability_map": {k: v for k, v in sorted(self.capability_map.items())},
             "registry_version": self.registry_version,
             "registry_schema_version": self.registry_schema_version,
         }
@@ -333,10 +332,10 @@ class GovernanceSnapshot:
 # ---------------------------------------------------------------------------
 
 _CACHE: dict[tuple, tuple[float, Any]] = {}
-_CACHE_VERSION: dict[int, int] = {}    # guild_id → version counter
+_CACHE_VERSION: dict[int, int] = {}  # guild_id → version counter
 _CACHE_LOCK = asyncio.Lock()
 _CACHE_TTL = 60.0
-_NO_OVERRIDE = object()               # sentinel for negative cache entries
+_NO_OVERRIDE = object()  # sentinel for negative cache entries
 
 
 def _cache_ver(guild_id: int) -> int:
@@ -376,6 +375,7 @@ def invalidate_guild_cache(guild_id: int) -> None:
 # Profiling hooks (no-op; wired for future metrics)
 # ---------------------------------------------------------------------------
 
+
 @asynccontextmanager
 async def _profile(operation: str):
     start = time.monotonic()
@@ -406,6 +406,7 @@ def _should_send_feedback(channel_id: int, subsystem: str) -> bool:
 # Internal pipeline — scope chain traversal
 # ---------------------------------------------------------------------------
 
+
 def _build_scope_chain(ctx: GovernanceContext) -> list[tuple[str, int]]:
     """Build ordered scope list via SCOPE_PARENT traversal.
 
@@ -416,9 +417,9 @@ def _build_scope_chain(ctx: GovernanceContext) -> list[tuple[str, int]]:
     This function is the ONLY place that knows the traversal order.
     """
     scope_id_map: dict[str, int | None] = {
-        "channel":  ctx.channel_id,
+        "channel": ctx.channel_id,
         "category": ctx.category_id,
-        "guild":    ctx.guild_id,
+        "guild": ctx.guild_id,
     }
     chain: list[tuple[str, int]] = []
     scope: str | None = "channel"
@@ -433,6 +434,7 @@ def _build_scope_chain(ctx: GovernanceContext) -> list[tuple[str, int]]:
 # ---------------------------------------------------------------------------
 # Internal pipeline — DB override resolution
 # ---------------------------------------------------------------------------
+
 
 async def _fetch_all_visibility(
     guild_id: int, chain: list[tuple[str, int]]
@@ -474,10 +476,10 @@ def _resolve_single_subsystem(
     """
     checked: list[str] = []
     _SCOPE_TO_SOURCE: dict[str, PolicySource] = {
-        "channel":  PolicySource.CHANNEL_OVERRIDE,
+        "channel": PolicySource.CHANNEL_OVERRIDE,
         "category": PolicySource.CATEGORY_OVERRIDE,
-        "guild":    PolicySource.GUILD_OVERRIDE,
-        "role":     PolicySource.ROLE_OVERRIDE,
+        "guild": PolicySource.GUILD_OVERRIDE,
+        "role": PolicySource.ROLE_OVERRIDE,
     }
     for scope_type, scope_id in chain:
         scope_map = scope_data.get((scope_type, scope_id), {})
@@ -495,6 +497,7 @@ def _resolve_single_subsystem(
 # ---------------------------------------------------------------------------
 # Internal pipeline — dependency propagation
 # ---------------------------------------------------------------------------
+
 
 def _apply_dependency_rules(
     states: dict[str, SubsystemState],
@@ -514,8 +517,10 @@ def _apply_dependency_rules(
         if not meta:
             continue
         blocking_deps = [
-            dep for dep in meta.get("dependencies", [])
-            if states.get(dep) in (SubsystemState.DISABLED, SubsystemState.BLOCKED_DEPENDENCY)
+            dep
+            for dep in meta.get("dependencies", [])
+            if states.get(dep)
+            in (SubsystemState.DISABLED, SubsystemState.BLOCKED_DEPENDENCY)
         ]
         if blocking_deps and states[subsystem] == SubsystemState.ENABLED:
             states[subsystem] = SubsystemState.BLOCKED_DEPENDENCY
@@ -530,10 +535,13 @@ def _apply_dependency_rules(
 # Internal pipeline — visibility resolution
 # ---------------------------------------------------------------------------
 
+
 async def _resolve_visibility_overrides(
     ctx: GovernanceContext,
     tier_accessible: set[str],
-) -> tuple[dict[str, SubsystemState], dict[str, ResolutionTrace], dict[str, PolicySource]]:
+) -> tuple[
+    dict[str, SubsystemState], dict[str, ResolutionTrace], dict[str, PolicySource]
+]:
     """Resolve visibility state for all subsystems via scope chain.
 
     Returns (states, traces, resolved_from).
@@ -605,6 +613,7 @@ async def _resolve_visibility_overrides(
 # Internal pipeline — cleanup policy resolution
 # ---------------------------------------------------------------------------
 
+
 async def _resolve_cleanup_overrides(ctx: GovernanceContext) -> CleanupPolicy:
     """Resolve cleanup policy with scope fallback: channel > guild > default.
 
@@ -618,9 +627,9 @@ async def _resolve_cleanup_overrides(ctx: GovernanceContext) -> CleanupPolicy:
             row = await db.get_cleanup_policy(ctx.guild_id, scope_type, scope_id)
         if row is not None:
             source_map = {
-                "channel":  PolicySource.CHANNEL_OVERRIDE,
+                "channel": PolicySource.CHANNEL_OVERRIDE,
                 "category": PolicySource.CATEGORY_OVERRIDE,
-                "guild":    PolicySource.GUILD_OVERRIDE,
+                "guild": PolicySource.GUILD_OVERRIDE,
             }
             return CleanupPolicy(
                 delete_message=row["delete_invalid_commands"],
@@ -649,6 +658,7 @@ async def _resolve_cleanup_overrides(ctx: GovernanceContext) -> CleanupPolicy:
 # Internal helpers
 # ---------------------------------------------------------------------------
 
+
 def _find_redirect_channel(
     guild: discord.Guild | None, subsystem_meta: dict
 ) -> str | None:
@@ -672,6 +682,7 @@ def _build_feedback(subsystem_meta: dict, redirect: str | None) -> str:
 # ---------------------------------------------------------------------------
 # Public API — visibility
 # ---------------------------------------------------------------------------
+
 
 async def resolve_visibility(ctx: GovernanceContext) -> VisibilityResult:
     """Resolve which subsystems are visible to this member in this context.
@@ -703,8 +714,7 @@ async def resolve_visibility(ctx: GovernanceContext) -> VisibilityResult:
         _apply_dependency_rules(states, traces, resolved_from)
 
     visible = {
-        name for name, state in states.items()
-        if state == SubsystemState.ENABLED
+        name for name, state in states.items() if state == SubsystemState.ENABLED
     }
 
     result = VisibilityResult(
@@ -730,9 +740,8 @@ async def get_visible_subsystems(ctx: GovernanceContext) -> set[str]:
 # Public API — execution
 # ---------------------------------------------------------------------------
 
-async def resolve_execution(
-    ctx: GovernanceContext, capability: str
-) -> ExecutionResult:
+
+async def resolve_execution(ctx: GovernanceContext, capability: str) -> ExecutionResult:
     """Determine if a capability is executable in this context.
 
     Separate from visibility — a subsystem can be hidden but still executable
@@ -743,6 +752,7 @@ async def resolve_execution(
     async with _profile("resolve_execution"):
         vis = await resolve_visibility(ctx)
         from utils.subsystem_registry import CAPABILITY_TO_SUBSYSTEM
+
         subsystem_name = CAPABILITY_TO_SUBSYSTEM.get(capability)
 
         if not subsystem_name:
@@ -760,35 +770,45 @@ async def resolve_execution(
 
         allowed = subsystem_name in vis.visible_subsystems
         trace_obj = vis.traces.get(subsystem_name)
-        denied_by = (
-            trace_obj.final_state.value
-            if trace_obj and not allowed
-            else None
-        )
+        denied_by = trace_obj.final_state.value if trace_obj and not allowed else None
 
         if not allowed:
-            await _emit_governance_event(EVT_EXECUTION_DENIED, {
-                "guild_id": ctx.guild_id,
-                "capability": capability,
-                "subsystem": subsystem_name,
-                "denied_by": denied_by,
-            })
+            await _emit_governance_event(
+                EVT_EXECUTION_DENIED,
+                {
+                    "guild_id": ctx.guild_id,
+                    "capability": capability,
+                    "subsystem": subsystem_name,
+                    "denied_by": denied_by,
+                },
+            )
         else:
-            await _emit_governance_event(EVT_EXECUTION_ALLOWED, {
-                "guild_id": ctx.guild_id,
-                "capability": capability,
-                "subsystem": subsystem_name,
-            })
+            await _emit_governance_event(
+                EVT_EXECUTION_ALLOWED,
+                {
+                    "guild_id": ctx.guild_id,
+                    "capability": capability,
+                    "subsystem": subsystem_name,
+                },
+            )
 
         return ExecutionResult(
             allowed=allowed,
             reason=denied_by,
-            resolved_scope=trace_obj.matched_scope.value if trace_obj and trace_obj.matched_scope else None,
+            resolved_scope=(
+                trace_obj.matched_scope.value
+                if trace_obj and trace_obj.matched_scope
+                else None
+            ),
             matched_capability=capability if allowed else None,
             trace=ExecutionTrace(
                 capability=capability,
                 checked_scopes=trace_obj.checked_scopes if trace_obj else [],
-                matched_scope=trace_obj.matched_scope.value if trace_obj and trace_obj.matched_scope else None,
+                matched_scope=(
+                    trace_obj.matched_scope.value
+                    if trace_obj and trace_obj.matched_scope
+                    else None
+                ),
                 denied_by=denied_by,
                 final_result=allowed,
             ),
@@ -799,6 +819,7 @@ async def resolve_execution(
 # Public API — cleanup policy
 # ---------------------------------------------------------------------------
 
+
 async def resolve_cleanup_policy(ctx: GovernanceContext) -> CleanupPolicy:
     """Resolve cleanup behavior for this context."""
     async with _profile("resolve_cleanup_policy"):
@@ -808,6 +829,7 @@ async def resolve_cleanup_policy(ctx: GovernanceContext) -> CleanupPolicy:
 # ---------------------------------------------------------------------------
 # Public API — command policy (combines visibility + cleanup)
 # ---------------------------------------------------------------------------
+
 
 async def resolve_command_policy(
     ctx: GovernanceContext, command_name: str
@@ -870,20 +892,19 @@ async def resolve_command_policy(
 # Public API — bulk resolution
 # ---------------------------------------------------------------------------
 
+
 async def resolve_all_subsystem_visibility(
     ctx: GovernanceContext,
 ) -> dict[str, bool]:
     """All subsystems with resolved enabled state. Single-trip through resolve_visibility."""
     result = await resolve_visibility(ctx)
-    return {
-        name: (name in result.visible_subsystems)
-        for name in SUBSYSTEMS
-    }
+    return {name: (name in result.visible_subsystems) for name in SUBSYSTEMS}
 
 
 async def resolve_all_capabilities(ctx: GovernanceContext) -> dict[str, bool]:
     """All capabilities with resolved allowed state."""
     from utils.subsystem_registry import CAPABILITY_TO_SUBSYSTEM
+
     visible = await get_visible_subsystems(ctx)
     return {
         cap: (subsystem in visible)
@@ -895,6 +916,7 @@ async def resolve_all_capabilities(ctx: GovernanceContext) -> dict[str, bool]:
 # Public API — effective state (single subsystem)
 # ---------------------------------------------------------------------------
 
+
 async def resolve_subsystem_state(
     ctx: GovernanceContext, subsystem_name: str
 ) -> SubsystemEffectiveState:
@@ -902,7 +924,11 @@ async def resolve_subsystem_state(
     vis = await resolve_visibility(ctx)
     cleanup = await resolve_cleanup_policy(ctx)
 
-    state = SubsystemState.ENABLED if subsystem_name in vis.visible_subsystems else SubsystemState.DISABLED
+    state = (
+        SubsystemState.ENABLED
+        if subsystem_name in vis.visible_subsystems
+        else SubsystemState.DISABLED
+    )
     trace = vis.traces.get(
         subsystem_name,
         ResolutionTrace(
@@ -930,6 +956,7 @@ async def resolve_subsystem_state(
 # ---------------------------------------------------------------------------
 # Public API — governance snapshot
 # ---------------------------------------------------------------------------
+
 
 async def build_governance_snapshot(ctx: GovernanceContext) -> GovernanceSnapshot:
     """Complete governance state for a context.
@@ -963,22 +990,28 @@ async def build_governance_snapshot(ctx: GovernanceContext) -> GovernanceSnapsho
 # Public API — health diagnostics
 # ---------------------------------------------------------------------------
 
+
 async def run_governance_healthcheck(guild_id: int) -> GovernanceHealthReport:
     """Check for orphan overrides, stale versions, and invalid configs."""
     known_subsystems = set(SUBSYSTEMS.keys())
     rows = await db.get_all_visibility_for_guild(guild_id)
     orphans = [
-        {"scope_type": r["scope_type"], "scope_id": r["scope_id"], "subsystem": r["subsystem"]}
+        {
+            "scope_type": r["scope_type"],
+            "scope_id": r["scope_id"],
+            "subsystem": r["subsystem"],
+        }
         for r in rows
         if r["subsystem"] not in known_subsystems
     ]
 
-    stored = await db.get_setting(guild_id, settings_keys.GOVERNANCE_VERSION, default=0)
+    stored = await db.get_setting(
+        guild_id, settings_keys.GOVERNANCE_VERSION, default="0"
+    )
     stale = [guild_id] if int(stored) < REGISTRY_VERSION else []
 
     summary = (
-        f"{len(orphans)} orphan override(s), "
-        f"{len(stale)} stale version guild(s)"
+        f"{len(orphans)} orphan override(s), " f"{len(stale)} stale version guild(s)"
     )
     return GovernanceHealthReport(
         orphan_overrides=orphans,
@@ -992,6 +1025,7 @@ async def run_governance_healthcheck(guild_id: int) -> GovernanceHealthReport:
 # Public API — governance writes (all cogs must route through here)
 # ---------------------------------------------------------------------------
 
+
 async def set_subsystem_visibility(
     ctx: GovernanceContext,
     scope_type: str,
@@ -1004,13 +1038,16 @@ async def set_subsystem_visibility(
         ctx.guild_id, scope_type, scope_id, subsystem, enabled
     )
     invalidate_guild_cache(ctx.guild_id)
-    await _emit_governance_event(EVT_VISIBILITY_CHANGED, {
-        "guild_id": ctx.guild_id,
-        "scope_type": scope_type,
-        "scope_id": scope_id,
-        "subsystem": subsystem,
-        "enabled": enabled,
-    })
+    await _emit_governance_event(
+        EVT_VISIBILITY_CHANGED,
+        {
+            "guild_id": ctx.guild_id,
+            "scope_type": scope_type,
+            "scope_id": scope_id,
+            "subsystem": subsystem,
+            "enabled": enabled,
+        },
+    )
 
 
 async def set_cleanup_policy_for_scope(
@@ -1030,21 +1067,25 @@ async def set_cleanup_policy_for_scope(
         delete_after_seconds=delete_after_seconds,
     )
     invalidate_guild_cache(ctx.guild_id)
-    await _emit_governance_event(EVT_CLEANUP_CHANGED, {
-        "guild_id": ctx.guild_id,
-        "scope_type": scope_type,
-        "scope_id": scope_id,
-    })
+    await _emit_governance_event(
+        EVT_CLEANUP_CHANGED,
+        {
+            "guild_id": ctx.guild_id,
+            "scope_type": scope_type,
+            "scope_id": scope_id,
+        },
+    )
 
 
 # ---------------------------------------------------------------------------
 # Governance version management
 # ---------------------------------------------------------------------------
 
+
 async def check_governance_version(guild_id: int) -> None:
     """Check and upgrade governance version for a guild if needed."""
     stored = await db.get_setting(
-        guild_id, settings_keys.GOVERNANCE_VERSION, default=0
+        guild_id, settings_keys.GOVERNANCE_VERSION, default="0"
     )
     if int(stored) < REGISTRY_VERSION:
         await _run_governance_upgrade(guild_id, from_version=int(stored))
@@ -1057,12 +1098,15 @@ async def _run_governance_upgrade(guild_id: int, from_version: int) -> None:
         from_version,
         REGISTRY_VERSION,
     )
-    await db.set_setting(guild_id, settings_keys.GOVERNANCE_VERSION, REGISTRY_VERSION)
+    await db.set_setting(
+        guild_id, settings_keys.GOVERNANCE_VERSION, str(REGISTRY_VERSION)
+    )
 
 
 # ---------------------------------------------------------------------------
 # Internal event hook
 # ---------------------------------------------------------------------------
+
 
 async def _emit_governance_event(event_name: str, payload: dict) -> None:
     """Internal hook. Currently DEBUG-logs only.

--- a/disbot/utils/db.py
+++ b/disbot/utils/db.py
@@ -801,3 +801,99 @@ async def set_counting_state(guild_id: int, state: dict) -> None:
            ON CONFLICT (guild_id) DO UPDATE SET state=EXCLUDED.state""",
         (guild_id, state),
     )
+
+
+# ---------------------------------------------------------------------------
+# Governance: subsystem_visibility
+# ---------------------------------------------------------------------------
+
+
+async def get_subsystem_visibility(
+    guild_id: int, scope_type: str, scope_id: int
+) -> dict[str, bool | None]:
+    """Return subsystem→enabled mapping for a scope. Missing rows = not in dict."""
+    rows = await get().fetch(
+        "SELECT subsystem, enabled FROM subsystem_visibility"
+        " WHERE guild_id=$1 AND scope_type=$2 AND scope_id=$3",
+        guild_id,
+        scope_type,
+        scope_id,
+    )
+    return {r["subsystem"]: r["enabled"] for r in rows}
+
+
+async def get_all_visibility_for_guild(guild_id: int):
+    """Fetch all visibility rows for a guild (all scopes) in one query."""
+    return await get().fetch(
+        "SELECT scope_type, scope_id, subsystem, enabled"
+        " FROM subsystem_visibility WHERE guild_id=$1",
+        guild_id,
+    )
+
+
+async def set_subsystem_visibility(
+    guild_id: int,
+    scope_type: str,
+    scope_id: int,
+    subsystem: str,
+    enabled: bool | None,
+) -> None:
+    """Upsert a visibility override. enabled=None clears the override (inherit)."""
+    await get().execute(
+        """INSERT INTO subsystem_visibility
+               (guild_id, scope_type, scope_id, subsystem, enabled)
+           VALUES ($1, $2, $3, $4, $5)
+           ON CONFLICT (guild_id, scope_type, scope_id, subsystem)
+           DO UPDATE SET enabled = EXCLUDED.enabled""",
+        guild_id,
+        scope_type,
+        scope_id,
+        subsystem,
+        enabled,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Governance: cleanup_policies
+# ---------------------------------------------------------------------------
+
+
+async def get_cleanup_policy(
+    guild_id: int, scope_type: str, scope_id: int
+) -> dict | None:
+    """Return cleanup policy for a scope, or None if no row exists."""
+    row = await get().fetchrow(
+        "SELECT delete_invalid_commands, delete_failed_commands, delete_after_seconds"
+        " FROM cleanup_policies WHERE guild_id=$1 AND scope_type=$2 AND scope_id=$3",
+        guild_id,
+        scope_type,
+        scope_id,
+    )
+    return dict(row) if row else None
+
+
+async def set_cleanup_policy(
+    guild_id: int,
+    scope_type: str,
+    scope_id: int,
+    delete_invalid_commands: bool = True,
+    delete_failed_commands: bool = True,
+    delete_after_seconds: int = 5,
+) -> None:
+    await get().execute(
+        """INSERT INTO cleanup_policies
+               (guild_id, scope_type, scope_id,
+                delete_invalid_commands, delete_failed_commands, delete_after_seconds)
+           VALUES ($1, $2, $3, $4, $5, $6)
+           ON CONFLICT (guild_id, scope_type, scope_id)
+           DO UPDATE SET
+               delete_invalid_commands = EXCLUDED.delete_invalid_commands,
+               delete_failed_commands  = EXCLUDED.delete_failed_commands,
+               delete_after_seconds    = EXCLUDED.delete_after_seconds""",
+        guild_id,
+        scope_type,
+        scope_id,
+        delete_invalid_commands,
+        delete_failed_commands,
+        delete_after_seconds,
+    )

--- a/disbot/utils/onboarding_profiles.py
+++ b/disbot/utils/onboarding_profiles.py
@@ -1,0 +1,21 @@
+"""Static onboarding profile templates.
+
+Pure data — no imports, no logic, no DB access.
+Future: profiles become configurable per-guild via governance DB.
+"""
+from __future__ import annotations
+
+WELCOME_PROFILES: dict[str, dict] = {
+    "default": {
+        "welcome_channel": "welcome",
+        "recommended_channels": ["bot-commands", "economy", "games", "roles"],
+        "beginner_commands": ["help", "daily", "work", "inventory"],
+        "description": (
+            "Welcome! Here are the channels and commands to get started."
+        ),
+    }
+}
+
+
+def get_profile(name: str = "default") -> dict:
+    return WELCOME_PROFILES.get(name, WELCOME_PROFILES["default"])

--- a/disbot/utils/onboarding_profiles.py
+++ b/disbot/utils/onboarding_profiles.py
@@ -3,6 +3,7 @@
 Pure data — no imports, no logic, no DB access.
 Future: profiles become configurable per-guild via governance DB.
 """
+
 from __future__ import annotations
 
 WELCOME_PROFILES: dict[str, dict] = {
@@ -10,9 +11,7 @@ WELCOME_PROFILES: dict[str, dict] = {
         "welcome_channel": "welcome",
         "recommended_channels": ["bot-commands", "economy", "games", "roles"],
         "beginner_commands": ["help", "daily", "work", "inventory"],
-        "description": (
-            "Welcome! Here are the channels and commands to get started."
-        ),
+        "description": ("Welcome! Here are the channels and commands to get started."),
     }
 }
 

--- a/disbot/utils/settings_keys.py
+++ b/disbot/utils/settings_keys.py
@@ -23,3 +23,7 @@ SKIP_ROLES = "skip_roles"
 
 # Games (shared write: rps_tournament_cog + blackjack_cog — see Section 8 of blueprint)
 ACTIVE_TOURNAMENT = "active_tournament"
+
+# Governance (owner: governance_service)
+# Stores the REGISTRY_VERSION int at which per-guild governance was last upgraded.
+GOVERNANCE_VERSION = "governance_version"

--- a/disbot/utils/subsystem_registry.py
+++ b/disbot/utils/subsystem_registry.py
@@ -9,8 +9,10 @@ Reserved prefixes: _internal.*, system.*, governance.*
 
 See services/governance_service.py for runtime policy resolution.
 """
+
 from __future__ import annotations
 
+from dataclasses import dataclass
 from types import MappingProxyType
 
 from utils.ui_constants import (
@@ -537,11 +539,11 @@ CAPABILITY_TO_SUBSYSTEM: dict[str, str] = {
 # Compiled lookup tables — populated by validate_registry(), O(1) access.
 # ---------------------------------------------------------------------------
 
-_COMPILED_DEPENDENTS: dict[str, list[str]] = {}   # subsystem → dependents list
+_COMPILED_DEPENDENTS: dict[str, list[str]] = {}  # subsystem → dependents list
 _COMPILED_TIERS: dict[str, str] = {}
 _COMPILED_CAPABILITIES: dict[str, list[str]] = {}
 _COMPILED_ENTRYPOINTS: dict[str, list[str]] = {}
-_COMPILED_DEPENDENCY_ORDER: list[str] = []         # topological order
+_COMPILED_DEPENDENCY_ORDER: list[str] = []  # topological order
 
 # ---------------------------------------------------------------------------
 # Reserved capability namespaces
@@ -557,8 +559,44 @@ def is_reserved_capability(cap: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Capability dataclass — centralises parsing, eliminates repeated .split(".")
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Capability:
+    """Immutable representation of a capability string.
+
+    Format: {subsystem}.{resource}.{action}
+    Raises CapabilityNamespaceError if the format is invalid.
+    """
+
+    subsystem: str
+    resource: str
+    action: str
+
+    @classmethod
+    def parse(cls, raw: str) -> "Capability":
+        from services.governance_exceptions import CapabilityNamespaceError
+
+        parts = raw.split(".")
+        if len(parts) != 3:
+            raise CapabilityNamespaceError(
+                f"'{raw}' must be {{subsystem}}.{{resource}}.{{action}}"
+            )
+        return cls(*parts)
+
+    def __str__(self) -> str:
+        return f"{self.subsystem}.{self.resource}.{self.action}"
+
+    def matches_pattern(self, pattern: str) -> bool:
+        return capability_matches(pattern, str(self))
+
+
+# ---------------------------------------------------------------------------
 # Deep freeze helper
 # ---------------------------------------------------------------------------
+
 
 def _deep_freeze(obj):
     """Recursively convert dicts→MappingProxyType, lists→tuple, sets→frozenset."""
@@ -574,6 +612,7 @@ def _deep_freeze(obj):
 # ---------------------------------------------------------------------------
 # Registry validation + compilation
 # ---------------------------------------------------------------------------
+
 
 def validate_registry() -> None:
     """Run once at bot startup. Populates compiled tables and deep-freezes registry.
@@ -598,7 +637,13 @@ def validate_registry() -> None:
     dep_graph: dict[str, list[str]] = {}
 
     for name, meta in SUBSYSTEMS.items():
-        for field in ("display_name", "description", "emoji", "visibility_tier", "visibility_mode"):
+        for field in (
+            "display_name",
+            "description",
+            "emoji",
+            "visibility_tier",
+            "visibility_mode",
+        ):
             if not meta.get(field):
                 raise RegistryValidationError(
                     f"subsystem '{name}': missing required field '{field}'"
@@ -682,9 +727,15 @@ def validate_registry() -> None:
         _topo(name)
 
     # Populate compiled lookup tables
-    compiled_tiers = {name: meta["visibility_tier"] for name, meta in SUBSYSTEMS.items()}
-    compiled_caps = {name: meta.get("capabilities", []) for name, meta in SUBSYSTEMS.items()}
-    compiled_eps = {name: meta.get("entry_points", []) for name, meta in SUBSYSTEMS.items()}
+    compiled_tiers = {
+        name: meta["visibility_tier"] for name, meta in SUBSYSTEMS.items()
+    }
+    compiled_caps = {
+        name: meta.get("capabilities", []) for name, meta in SUBSYSTEMS.items()
+    }
+    compiled_eps = {
+        name: meta.get("entry_points", []) for name, meta in SUBSYSTEMS.items()
+    }
     compiled_dependents: dict[str, list[str]] = {name: [] for name in SUBSYSTEMS}
     for name, deps in dep_graph.items():
         for dep in deps:
@@ -709,6 +760,7 @@ def validate_registry() -> None:
 # ---------------------------------------------------------------------------
 # Public accessors
 # ---------------------------------------------------------------------------
+
 
 def get_subsystem(name: str) -> dict | None:
     return SUBSYSTEMS.get(name)  # type: ignore[return-value]

--- a/disbot/utils/subsystem_registry.py
+++ b/disbot/utils/subsystem_registry.py
@@ -1,0 +1,749 @@
+"""Subsystem registry — immutable platform metadata manifest.
+
+This file is the single source of truth for all subsystem definitions.
+After validate_registry() runs at startup, every structure here is deep-frozen.
+Overrides (visibility, cleanup rules) belong in governance DB, never here.
+
+Capability namespace rule: {subsystem}.{resource}.{action} — three parts, enforced.
+Reserved prefixes: _internal.*, system.*, governance.*
+
+See services/governance_service.py for runtime policy resolution.
+"""
+from __future__ import annotations
+
+from types import MappingProxyType
+
+from utils.ui_constants import (
+    ADMIN_COLOR,
+    CHANNEL_COLOR,
+    ECONOMY_COLOR,
+    GAME_COLOR,
+    GENERAL_COLOR,
+    MINING_COLOR,
+    MOD_COLOR,
+    ROLE_COLOR,
+    UTILITY_COLOR,
+)
+
+# Incremented when subsystem content/metadata changes.
+REGISTRY_VERSION = 1
+
+# Incremented when the subsystem dict schema/shape itself changes.
+REGISTRY_SCHEMA_VERSION = 1
+
+# ---------------------------------------------------------------------------
+# Subsystem manifest
+# Immutable after validate_registry(). Do NOT mutate at runtime.
+# ---------------------------------------------------------------------------
+
+SUBSYSTEMS: dict[str, dict] = {
+    "admin": {
+        "display_name": "Administration",
+        "description": "Cog management, server stats, diagnostics",
+        "emoji": "⚙️",
+        "color": ADMIN_COLOR.value,
+        "visibility_tier": "owner",
+        "visibility_mode": "normal",
+        "category": "admin",
+        "tags": ["admin", "cogs", "management", "diagnostics"],
+        "entry_points": ["adminmenu"],
+        "default_channels": ["staff", "bot-spam"],
+        "related_subsystems": ["diagnostic"],
+        "dependencies": [],
+        "soft_dependencies": [],
+        "supports_dm": False,
+        "has_cleanup_rules": True,
+        "has_onboarding": False,
+        "ui_priority": 90,
+        "capabilities": [
+            "admin.cog.load",
+            "admin.cog.unload",
+            "admin.cog.reload",
+            "admin.server.stats",
+        ],
+    },
+    "moderation": {
+        "display_name": "Moderation",
+        "description": "Warnings, timeouts, bans, mod logs",
+        "emoji": "🔨",
+        "color": MOD_COLOR.value,
+        "visibility_tier": "moderator",
+        "visibility_mode": "normal",
+        "category": "moderation",
+        "tags": ["moderation", "safety", "logs", "warn", "ban"],
+        "entry_points": ["modmenu", "warn", "timeout", "kick", "ban", "unban"],
+        "default_channels": ["staff", "mod-logs"],
+        "related_subsystems": ["cleanup"],
+        "dependencies": [],
+        "soft_dependencies": [],
+        "supports_dm": False,
+        "has_cleanup_rules": True,
+        "has_onboarding": False,
+        "ui_priority": 80,
+        "capabilities": [
+            "moderation.warn.apply",
+            "moderation.timeout.apply",
+            "moderation.kick.apply",
+            "moderation.ban.apply",
+            "moderation.ban.remove",
+            "moderation.log.view",
+        ],
+    },
+    "economy": {
+        "display_name": "Economy",
+        "description": "Daily coins, work, shop, balance",
+        "emoji": "💰",
+        "color": ECONOMY_COLOR.value,
+        "visibility_tier": "user",
+        "visibility_mode": "normal",
+        "category": "economy",
+        "tags": ["economy", "currency", "coins", "progression"],
+        "entry_points": ["economymenu", "daily", "work", "balance"],
+        "default_channels": ["economy", "bot-commands"],
+        "related_subsystems": ["inventory", "mining"],
+        "dependencies": [],
+        "soft_dependencies": [],
+        "supports_dm": False,
+        "has_cleanup_rules": True,
+        "has_onboarding": True,
+        "ui_priority": 10,
+        "capabilities": [
+            "economy.currency.view",
+            "economy.currency.earn",
+            "economy.shop.browse",
+            "economy.shop.buy",
+        ],
+    },
+    "inventory": {
+        "display_name": "Inventory",
+        "description": "Item management and crafting",
+        "emoji": "🎒",
+        "color": ECONOMY_COLOR.value,
+        "visibility_tier": "user",
+        "visibility_mode": "normal",
+        "category": "economy",
+        "tags": ["inventory", "items", "crafting"],
+        "entry_points": ["inventorymenu", "inventory", "craft"],
+        "default_channels": ["economy", "bot-commands"],
+        "related_subsystems": ["economy", "mining"],
+        "dependencies": ["economy"],
+        "soft_dependencies": [],
+        "supports_dm": False,
+        "has_cleanup_rules": False,
+        "has_onboarding": False,
+        "ui_priority": 15,
+        "capabilities": [
+            "inventory.item.view",
+            "inventory.item.use",
+            "inventory.craft.recipe",
+        ],
+    },
+    "mining": {
+        "display_name": "Mining",
+        "description": "Mining minigame and resource collection",
+        "emoji": "⛏️",
+        "color": MINING_COLOR.value,
+        "visibility_tier": "user",
+        "visibility_mode": "normal",
+        "category": "economy",
+        "tags": ["mining", "resources", "minigame"],
+        "entry_points": ["miningmenu", "mine"],
+        "default_channels": ["mining", "bot-commands"],
+        "related_subsystems": ["economy", "inventory"],
+        "dependencies": ["economy"],
+        "soft_dependencies": [],
+        "supports_dm": False,
+        "has_cleanup_rules": False,
+        "has_onboarding": False,
+        "ui_priority": 20,
+        "capabilities": [
+            "mining.resource.mine",
+            "mining.resource.view",
+        ],
+    },
+    "xp": {
+        "display_name": "XP & Levels",
+        "description": "Experience points, levels, and leaderboards",
+        "emoji": "⭐",
+        "color": ROLE_COLOR.value,
+        "visibility_tier": "user",
+        "visibility_mode": "normal",
+        "category": "progression",
+        "tags": ["xp", "levels", "progression", "leaderboard"],
+        "entry_points": ["xpmenu", "rank", "level"],
+        "default_channels": ["bot-commands", "general"],
+        "related_subsystems": ["role", "leaderboard"],
+        "dependencies": [],
+        "soft_dependencies": [],
+        "supports_dm": False,
+        "has_cleanup_rules": False,
+        "has_onboarding": True,
+        "ui_priority": 25,
+        "capabilities": [
+            "xp.rank.view",
+            "xp.leaderboard.view",
+            "xp.settings.configure",
+        ],
+    },
+    "role": {
+        "display_name": "Roles",
+        "description": "Time-based and XP-based automatic role assignment",
+        "emoji": "🎭",
+        "color": ROLE_COLOR.value,
+        "visibility_tier": "administrator",
+        "visibility_mode": "normal",
+        "category": "management",
+        "tags": ["roles", "assignment", "automation"],
+        "entry_points": ["rolemenu"],
+        "default_channels": ["staff", "bot-commands"],
+        "related_subsystems": ["xp"],
+        "dependencies": [],
+        "soft_dependencies": [],
+        "supports_dm": False,
+        "has_cleanup_rules": True,
+        "has_onboarding": False,
+        "ui_priority": 70,
+        "capabilities": [
+            "role.threshold.configure",
+            "role.assignment.manage",
+            "role.reaction.manage",
+        ],
+    },
+    "channel": {
+        "display_name": "Channels",
+        "description": "Channel and category creation, deletion, and restrictions",
+        "emoji": "📐",
+        "color": CHANNEL_COLOR.value,
+        "visibility_tier": "administrator",
+        "visibility_mode": "normal",
+        "category": "management",
+        "tags": ["channels", "management", "permissions"],
+        "entry_points": ["channelmenu"],
+        "default_channels": ["staff"],
+        "related_subsystems": [],
+        "dependencies": [],
+        "soft_dependencies": [],
+        "supports_dm": False,
+        "has_cleanup_rules": True,
+        "has_onboarding": False,
+        "ui_priority": 75,
+        "capabilities": [
+            "channel.create.text",
+            "channel.create.voice",
+            "channel.delete.any",
+            "channel.restrict.apply",
+            "channel.visibility.configure",
+        ],
+    },
+    "cleanup": {
+        "display_name": "Cleanup",
+        "description": "Prohibited words, command deletion, channel hygiene",
+        "emoji": "🧹",
+        "color": ADMIN_COLOR.value,
+        "visibility_tier": "administrator",
+        "visibility_mode": "normal",
+        "category": "moderation",
+        "tags": ["cleanup", "words", "moderation", "hygiene"],
+        "entry_points": ["wordmenu", "cleanuphistory"],
+        "default_channels": ["staff"],
+        "related_subsystems": ["moderation"],
+        "dependencies": [],
+        "soft_dependencies": [],
+        "supports_dm": False,
+        "has_cleanup_rules": False,
+        "has_onboarding": False,
+        "ui_priority": 72,
+        "capabilities": [
+            "cleanup.word.add",
+            "cleanup.word.remove",
+            "cleanup.history.scan",
+            "cleanup.policy.configure",
+        ],
+    },
+    "blackjack": {
+        "display_name": "Blackjack",
+        "description": "Blackjack card game",
+        "emoji": "🃏",
+        "color": GAME_COLOR.value,
+        "visibility_tier": "user",
+        "visibility_mode": "normal",
+        "category": "games",
+        "tags": ["games", "blackjack", "cards"],
+        "entry_points": ["blackjack", "bj"],
+        "default_channels": ["games", "bot-commands"],
+        "related_subsystems": ["economy", "deathmatch"],
+        "dependencies": [],
+        "soft_dependencies": ["economy"],
+        "supports_dm": False,
+        "has_cleanup_rules": False,
+        "has_onboarding": False,
+        "ui_priority": 30,
+        "capabilities": [
+            "blackjack.game.play",
+        ],
+    },
+    "deathmatch": {
+        "display_name": "Deathmatch",
+        "description": "1v1 duel battles",
+        "emoji": "⚔️",
+        "color": GAME_COLOR.value,
+        "visibility_tier": "user",
+        "visibility_mode": "normal",
+        "category": "games",
+        "tags": ["games", "duel", "pvp", "deathmatch"],
+        "entry_points": ["deathmatch", "dm"],
+        "default_channels": ["games", "bot-commands"],
+        "related_subsystems": ["economy", "blackjack"],
+        "dependencies": [],
+        "soft_dependencies": [],
+        "supports_dm": False,
+        "has_cleanup_rules": False,
+        "has_onboarding": False,
+        "ui_priority": 32,
+        "capabilities": [
+            "deathmatch.game.challenge",
+            "deathmatch.stat.view",
+        ],
+    },
+    "rps_tournament": {
+        "display_name": "RPS Tournament",
+        "description": "Rock-Paper-Scissors tournament system",
+        "emoji": "✂️",
+        "color": GAME_COLOR.value,
+        "visibility_tier": "user",
+        "visibility_mode": "normal",
+        "category": "games",
+        "tags": ["games", "rps", "tournament"],
+        "entry_points": ["rpsmenu", "rps"],
+        "default_channels": ["games", "tournament"],
+        "related_subsystems": [],
+        "dependencies": [],
+        "soft_dependencies": [],
+        "supports_dm": False,
+        "has_cleanup_rules": False,
+        "has_onboarding": False,
+        "ui_priority": 34,
+        "capabilities": [
+            "rps_tournament.game.join",
+            "rps_tournament.tournament.manage",
+        ],
+    },
+    "counting": {
+        "display_name": "Counting",
+        "description": "Collaborative counting game",
+        "emoji": "🔢",
+        "color": GAME_COLOR.value,
+        "visibility_tier": "user",
+        "visibility_mode": "normal",
+        "category": "games",
+        "tags": ["games", "counting", "community"],
+        "entry_points": ["countingmenu", "counting"],
+        "default_channels": ["counting", "games"],
+        "related_subsystems": [],
+        "dependencies": [],
+        "soft_dependencies": [],
+        "supports_dm": False,
+        "has_cleanup_rules": False,
+        "has_onboarding": False,
+        "ui_priority": 36,
+        "capabilities": [
+            "counting.game.play",
+            "counting.game.configure",
+        ],
+    },
+    "chain": {
+        "display_name": "Word Chain",
+        "description": "Word-chaining game",
+        "emoji": "🔗",
+        "color": GAME_COLOR.value,
+        "visibility_tier": "user",
+        "visibility_mode": "normal",
+        "category": "games",
+        "tags": ["games", "words", "chain"],
+        "entry_points": ["chainmenu", "chain"],
+        "default_channels": ["games", "bot-commands"],
+        "related_subsystems": [],
+        "dependencies": [],
+        "soft_dependencies": [],
+        "supports_dm": False,
+        "has_cleanup_rules": False,
+        "has_onboarding": False,
+        "ui_priority": 38,
+        "capabilities": [
+            "chain.game.play",
+            "chain.game.configure",
+        ],
+    },
+    "leaderboard": {
+        "display_name": "Leaderboard",
+        "description": "Server leaderboards for XP, coins, and games",
+        "emoji": "🏆",
+        "color": UTILITY_COLOR.value,
+        "visibility_tier": "user",
+        "visibility_mode": "normal",
+        "category": "progression",
+        "tags": ["leaderboard", "rankings", "stats"],
+        "entry_points": ["leaderboard", "lb"],
+        "default_channels": ["bot-commands", "general"],
+        "related_subsystems": ["xp", "economy"],
+        "dependencies": [],
+        "soft_dependencies": [],
+        "supports_dm": False,
+        "has_cleanup_rules": False,
+        "has_onboarding": False,
+        "ui_priority": 40,
+        "capabilities": [
+            "leaderboard.xp.view",
+            "leaderboard.economy.view",
+        ],
+    },
+    "proof_channel": {
+        "display_name": "Proof Channel",
+        "description": "Proof submission and exclusive access sessions",
+        "emoji": "📋",
+        "color": MOD_COLOR.value,
+        "visibility_tier": "staff",
+        "visibility_mode": "normal",
+        "category": "moderation",
+        "tags": ["proof", "events", "access"],
+        "entry_points": ["prize"],
+        "default_channels": ["staff", "proof"],
+        "related_subsystems": ["moderation"],
+        "dependencies": [],
+        "soft_dependencies": [],
+        "supports_dm": False,
+        "has_cleanup_rules": False,
+        "has_onboarding": False,
+        "ui_priority": 65,
+        "capabilities": [
+            "proof_channel.access.grant",
+            "proof_channel.access.revoke",
+            "proof_channel.access.timed",
+        ],
+    },
+    "utility": {
+        "display_name": "Utility",
+        "description": "General utility commands",
+        "emoji": "🔧",
+        "color": UTILITY_COLOR.value,
+        "visibility_tier": "user",
+        "visibility_mode": "normal",
+        "category": "utility",
+        "tags": ["utility", "tools", "general"],
+        "entry_points": ["utilitymenu", "avatar", "serverinfo"],
+        "default_channels": ["bot-commands", "general"],
+        "related_subsystems": ["general"],
+        "dependencies": [],
+        "soft_dependencies": [],
+        "supports_dm": True,
+        "has_cleanup_rules": False,
+        "has_onboarding": False,
+        "ui_priority": 5,
+        "capabilities": [
+            "utility.info.server",
+            "utility.info.user",
+            "utility.tool.ping",
+        ],
+    },
+    "general": {
+        "display_name": "General",
+        "description": "General bot commands and information",
+        "emoji": "💬",
+        "color": GENERAL_COLOR.value,
+        "visibility_tier": "user",
+        "visibility_mode": "normal",
+        "category": "utility",
+        "tags": ["general", "info", "community"],
+        "entry_points": ["generalmenu"],
+        "default_channels": ["general", "bot-commands"],
+        "related_subsystems": ["utility"],
+        "dependencies": [],
+        "soft_dependencies": [],
+        "supports_dm": False,
+        "has_cleanup_rules": False,
+        "has_onboarding": False,
+        "ui_priority": 3,
+        "capabilities": [
+            "general.info.view",
+            "general.community.interact",
+        ],
+    },
+    "help": {
+        "display_name": "Help",
+        "description": "Interactive help menu and command discovery",
+        "emoji": "📚",
+        "color": UTILITY_COLOR.value,
+        "visibility_tier": "user",
+        "visibility_mode": "normal",
+        "category": "utility",
+        "tags": ["help", "commands", "discovery"],
+        "entry_points": ["help"],
+        "default_channels": ["bot-commands", "general"],
+        "related_subsystems": [],
+        "dependencies": [],
+        "soft_dependencies": [],
+        "supports_dm": True,
+        "has_cleanup_rules": False,
+        "has_onboarding": True,
+        "ui_priority": 1,
+        "capabilities": [
+            "help.menu.view",
+        ],
+    },
+    "diagnostic": {
+        "display_name": "Diagnostics",
+        "description": "Bot health, latency, and system diagnostics",
+        "emoji": "🩺",
+        "color": ADMIN_COLOR.value,
+        "visibility_tier": "administrator",
+        "visibility_mode": "normal",
+        "category": "admin",
+        "tags": ["diagnostics", "health", "latency", "debug"],
+        "entry_points": ["diagnosticmenu", "diagnostics", "ping"],
+        "default_channels": ["staff", "bot-spam"],
+        "related_subsystems": ["admin"],
+        "dependencies": [],
+        "soft_dependencies": [],
+        "supports_dm": False,
+        "has_cleanup_rules": True,
+        "has_onboarding": False,
+        "ui_priority": 95,
+        "capabilities": [
+            "diagnostic.health.view",
+            "diagnostic.latency.check",
+        ],
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Transitional command → subsystem map.
+# Future direction: command.extras["subsystem"] or @subsystem() decorator.
+# Do NOT add new features that depend on this dict being comprehensive.
+# ---------------------------------------------------------------------------
+
+COMMAND_TO_SUBSYSTEM: dict[str, str] = {
+    cmd: name
+    for name, meta in SUBSYSTEMS.items()
+    for cmd in meta.get("entry_points", [])
+}
+
+CAPABILITY_TO_SUBSYSTEM: dict[str, str] = {
+    cap: name
+    for name, meta in SUBSYSTEMS.items()
+    for cap in meta.get("capabilities", [])
+}
+
+# ---------------------------------------------------------------------------
+# Compiled lookup tables — populated by validate_registry(), O(1) access.
+# ---------------------------------------------------------------------------
+
+_COMPILED_DEPENDENTS: dict[str, list[str]] = {}   # subsystem → dependents list
+_COMPILED_TIERS: dict[str, str] = {}
+_COMPILED_CAPABILITIES: dict[str, list[str]] = {}
+_COMPILED_ENTRYPOINTS: dict[str, list[str]] = {}
+_COMPILED_DEPENDENCY_ORDER: list[str] = []         # topological order
+
+# ---------------------------------------------------------------------------
+# Reserved capability namespaces
+# ---------------------------------------------------------------------------
+
+_RESERVED_CAPABILITY_PREFIXES: frozenset[str] = frozenset(
+    {"_internal", "system", "governance"}
+)
+
+
+def is_reserved_capability(cap: str) -> bool:
+    return cap.split(".")[0] in _RESERVED_CAPABILITY_PREFIXES
+
+
+# ---------------------------------------------------------------------------
+# Deep freeze helper
+# ---------------------------------------------------------------------------
+
+def _deep_freeze(obj):
+    """Recursively convert dicts→MappingProxyType, lists→tuple, sets→frozenset."""
+    if isinstance(obj, dict):
+        return MappingProxyType({k: _deep_freeze(v) for k, v in obj.items()})
+    if isinstance(obj, list):
+        return tuple(_deep_freeze(v) for v in obj)
+    if isinstance(obj, set):
+        return frozenset(_deep_freeze(v) for v in obj)
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# Registry validation + compilation
+# ---------------------------------------------------------------------------
+
+def validate_registry() -> None:
+    """Run once at bot startup. Populates compiled tables and deep-freezes registry.
+
+    Raises:
+        RegistryValidationError subclasses on any integrity violation.
+    """
+    from services.governance_exceptions import (
+        CapabilityNamespaceError,
+        CircularDependencyError,
+        RegistryValidationError,
+    )
+
+    global _COMPILED_DEPENDENTS, _COMPILED_TIERS, _COMPILED_CAPABILITIES
+    global _COMPILED_ENTRYPOINTS
+
+    seen_caps: set[str] = set()
+    seen_entries: set[str] = set()
+    valid_tiers = {"user", "trusted", "staff", "moderator", "administrator", "owner"}
+    valid_modes = {"normal", "hidden", "internal", "deprecated", "experimental"}
+    all_names = set(SUBSYSTEMS)
+    dep_graph: dict[str, list[str]] = {}
+
+    for name, meta in SUBSYSTEMS.items():
+        for field in ("display_name", "description", "emoji", "visibility_tier", "visibility_mode"):
+            if not meta.get(field):
+                raise RegistryValidationError(
+                    f"subsystem '{name}': missing required field '{field}'"
+                )
+        if meta["visibility_tier"] not in valid_tiers:
+            raise RegistryValidationError(
+                f"subsystem '{name}': invalid visibility_tier '{meta['visibility_tier']}'"
+            )
+        if meta["visibility_mode"] not in valid_modes:
+            raise RegistryValidationError(
+                f"subsystem '{name}': invalid visibility_mode '{meta['visibility_mode']}'"
+            )
+        if not isinstance(meta.get("color", 0), int):
+            raise RegistryValidationError(
+                f"subsystem '{name}': color must be int (.value), not discord.Color"
+            )
+
+        for cap in meta.get("capabilities", []):
+            if is_reserved_capability(cap):
+                raise CapabilityNamespaceError(
+                    f"subsystem '{name}': capability '{cap}' uses reserved namespace"
+                )
+            if len(cap.split(".")) != 3:
+                raise CapabilityNamespaceError(
+                    f"subsystem '{name}': capability '{cap}' must be"
+                    " {subsystem}.{resource}.{action}"
+                )
+            if cap in seen_caps:
+                raise RegistryValidationError(f"Duplicate capability: '{cap}'")
+            seen_caps.add(cap)
+
+        for ep in meta.get("entry_points", []):
+            if ep in seen_entries:
+                raise RegistryValidationError(f"Duplicate entry_point: '{ep}'")
+            seen_entries.add(ep)
+
+        for dep in meta.get("dependencies", []):
+            if dep not in all_names:
+                raise RegistryValidationError(
+                    f"subsystem '{name}': unknown dependency '{dep}'"
+                )
+        for rel in meta.get("related_subsystems", []):
+            if rel not in all_names:
+                raise RegistryValidationError(
+                    f"subsystem '{name}': unknown related_subsystem '{rel}'"
+                )
+
+        dep_graph[name] = list(meta.get("dependencies", []))
+
+    # DFS cycle detection
+    visited: set[str] = set()
+    rec_stack: set[str] = set()
+
+    def _dfs(node: str) -> None:
+        visited.add(node)
+        rec_stack.add(node)
+        for neighbour in dep_graph.get(node, []):
+            if neighbour not in visited:
+                _dfs(neighbour)
+            elif neighbour in rec_stack:
+                raise CircularDependencyError(node, neighbour)
+        rec_stack.discard(node)
+
+    for name in SUBSYSTEMS:
+        if name not in visited:
+            _dfs(name)
+
+    # Topological sort — deps appear before their dependents
+    topo_order: list[str] = []
+    topo_visited: set[str] = set()
+
+    def _topo(node: str) -> None:
+        if node in topo_visited:
+            return
+        topo_visited.add(node)
+        for dep in dep_graph.get(node, []):
+            _topo(dep)
+        topo_order.append(node)
+
+    for name in SUBSYSTEMS:
+        _topo(name)
+
+    # Populate compiled lookup tables
+    compiled_tiers = {name: meta["visibility_tier"] for name, meta in SUBSYSTEMS.items()}
+    compiled_caps = {name: meta.get("capabilities", []) for name, meta in SUBSYSTEMS.items()}
+    compiled_eps = {name: meta.get("entry_points", []) for name, meta in SUBSYSTEMS.items()}
+    compiled_dependents: dict[str, list[str]] = {name: [] for name in SUBSYSTEMS}
+    for name, deps in dep_graph.items():
+        for dep in deps:
+            compiled_dependents[dep].append(name)
+
+    _COMPILED_DEPENDENCY_ORDER[:] = topo_order
+    _COMPILED_TIERS.update(compiled_tiers)
+    _COMPILED_CAPABILITIES.update(compiled_caps)
+    _COMPILED_ENTRYPOINTS.update(compiled_eps)
+    _COMPILED_DEPENDENTS.update(compiled_dependents)
+
+    # Deep-freeze — after this point any mutation attempt raises TypeError
+    globals()["SUBSYSTEMS"] = _deep_freeze(SUBSYSTEMS)
+    globals()["COMMAND_TO_SUBSYSTEM"] = MappingProxyType(COMMAND_TO_SUBSYSTEM)
+    globals()["CAPABILITY_TO_SUBSYSTEM"] = MappingProxyType(CAPABILITY_TO_SUBSYSTEM)
+    globals()["_COMPILED_DEPENDENTS"] = _deep_freeze(compiled_dependents)
+    globals()["_COMPILED_TIERS"] = MappingProxyType(compiled_tiers)
+    globals()["_COMPILED_CAPABILITIES"] = _deep_freeze(compiled_caps)
+    globals()["_COMPILED_ENTRYPOINTS"] = _deep_freeze(compiled_eps)
+
+
+# ---------------------------------------------------------------------------
+# Public accessors
+# ---------------------------------------------------------------------------
+
+def get_subsystem(name: str) -> dict | None:
+    return SUBSYSTEMS.get(name)  # type: ignore[return-value]
+
+
+def get_subsystem_for_command(command_name: str) -> tuple[str, dict] | None:
+    name = COMMAND_TO_SUBSYSTEM.get(command_name)
+    if name and name in SUBSYSTEMS:
+        return name, SUBSYSTEMS[name]  # type: ignore[return-value]
+    return None
+
+
+def get_subsystem_for_capability(capability: str) -> tuple[str, dict] | None:
+    name = CAPABILITY_TO_SUBSYSTEM.get(capability)
+    if name and name in SUBSYSTEMS:
+        return name, SUBSYSTEMS[name]  # type: ignore[return-value]
+    return None
+
+
+def all_subsystems_sorted() -> list[tuple[str, dict]]:
+    """All subsystems sorted by ui_priority (ascending)."""
+    return sorted(
+        SUBSYSTEMS.items(),  # type: ignore[arg-type]
+        key=lambda x: x[1].get("ui_priority", 99),
+    )
+
+
+def capability_matches(pattern: str, capability: str) -> bool:
+    """Wildcard capability matching for future declarative policy rules.
+
+    Patterns: 'economy.*.*', 'moderation.message.*', '*.shop.buy'
+    Both pattern and capability must have exactly 3 dot-separated parts.
+    """
+    p_parts = pattern.split(".")
+    c_parts = capability.split(".")
+    if len(p_parts) != len(c_parts) or len(p_parts) != 3:
+        return False
+    return all(p == "*" or p == c for p, c in zip(p_parts, c_parts))

--- a/disbot/utils/visibility_rules.py
+++ b/disbot/utils/visibility_rules.py
@@ -1,0 +1,78 @@
+"""Visibility tier definitions and synchronous member-tier resolution.
+
+IMPORTANT: This module governs UI/help discoverability only.
+Execution authorization is a separate concept resolved in governance_service.resolve_execution().
+Do NOT conflate visibility with permission to execute.
+
+Allowed imports: utils.subsystem_registry only.
+No async, no DB access, no Discord API calls.
+"""
+from __future__ import annotations
+
+from utils.subsystem_registry import SUBSYSTEMS
+
+# ---------------------------------------------------------------------------
+# Tier ordering
+# Named VISIBILITY_TIERS (not TIER_ORDER) to make its scope explicit:
+# this is about what appears in UI, not about what a member can execute.
+# ---------------------------------------------------------------------------
+
+VISIBILITY_TIERS: list[str] = [
+    "user",
+    "trusted",
+    "staff",
+    "moderator",
+    "administrator",
+    "owner",
+]
+
+# Maps tier → Discord guild_permissions attribute name.
+# None = no Discord permission required (all members qualify).
+TIER_DISCORD_PERMISSION: dict[str, str | None] = {
+    "user":          None,
+    "trusted":       None,           # reserved for future trust/progression system
+    "staff":         "manage_guild",
+    "moderator":     "moderate_members",
+    "administrator": "administrator",
+    "owner":         None,           # resolved by member.id == guild.owner_id
+}
+
+_TIER_INDEX: dict[str, int] = {tier: i for i, tier in enumerate(VISIBILITY_TIERS)}
+
+
+def get_member_visibility_tier(member, guild_owner_id: int) -> str:
+    """Return the highest VISIBILITY_TIER this member qualifies for (synchronous).
+
+    Checks from highest tier downward to find the first match.
+    """
+    if member.id == guild_owner_id:
+        return "owner"
+    p = member.guild_permissions
+    if p.administrator:
+        return "administrator"
+    if getattr(p, "moderate_members", False):
+        return "moderator"
+    if p.manage_guild:
+        return "staff"
+    return "user"
+
+
+def is_tier_sufficient(member_tier: str, required_tier: str) -> bool:
+    """Return True if member_tier is at least as high as required_tier."""
+    member_idx = _TIER_INDEX.get(member_tier, 0)
+    required_idx = _TIER_INDEX.get(required_tier, 0)
+    return member_idx >= required_idx
+
+
+def get_subsystems_for_tier(member_tier: str) -> list[str]:
+    """Return subsystem names whose visibility_tier ≤ member_tier.
+
+    Excludes subsystems with visibility_mode == 'internal' (never user-facing).
+    """
+    return [
+        name
+        for name, meta in SUBSYSTEMS.items()
+        if is_tier_sufficient(member_tier, meta.get("visibility_tier", "user"))
+        and meta.get("visibility_mode", "normal") != "internal"
+        and not meta.get("hidden", False)
+    ]

--- a/disbot/utils/visibility_rules.py
+++ b/disbot/utils/visibility_rules.py
@@ -7,6 +7,7 @@ Do NOT conflate visibility with permission to execute.
 Allowed imports: utils.subsystem_registry only.
 No async, no DB access, no Discord API calls.
 """
+
 from __future__ import annotations
 
 from utils.subsystem_registry import SUBSYSTEMS
@@ -29,12 +30,12 @@ VISIBILITY_TIERS: list[str] = [
 # Maps tier → Discord guild_permissions attribute name.
 # None = no Discord permission required (all members qualify).
 TIER_DISCORD_PERMISSION: dict[str, str | None] = {
-    "user":          None,
-    "trusted":       None,           # reserved for future trust/progression system
-    "staff":         "manage_guild",
-    "moderator":     "moderate_members",
+    "user": None,
+    "trusted": None,  # reserved for future trust/progression system
+    "staff": "manage_guild",
+    "moderator": "moderate_members",
     "administrator": "administrator",
-    "owner":         None,           # resolved by member.id == guild.owner_id
+    "owner": None,  # resolved by member.id == guild.owner_id
 }
 
 _TIER_INDEX: dict[str, int] = {tier: i for i, tier in enumerate(VISIBILITY_TIERS)}


### PR DESCRIPTION
## Summary

Implements the full governance platform layer as the single source of truth for all subsystem visibility, command policy, and cleanup enforcement decisions. All governance decisions now route through `governance_service.py` — cogs are pure consumers.

- **`utils/subsystem_registry.py`** — Immutable deep-frozen manifest of all 20 subsystems. Defines capabilities (`{subsystem}.{resource}.{action}`), entry points, dependencies, and visibility tiers. Frozen at startup via `MappingProxyType` + `tuple` + `frozenset` recursively. Includes `Capability` frozen dataclass for typed parsing. `validate_registry()` runs DFS cycle detection, topological sort, and compiles O(1) lookup tables before freezing.

- **`services/governance_exceptions.py`** — Typed exception hierarchy: `GovernanceError` → `RegistryValidationError` → `CircularDependencyError` / `CapabilityNamespaceError`, plus `GovernanceUpgradeError`.

- **`services/governance_service.py`** — Central orchestrator. Scope inheritance via `SCOPE_PARENT` traversal (no hardcoded if/elif). Version-stamped cache keyed by `(guild_id, version, channel_id, tier)` with O(1) invalidation. Tri-state DB overrides (TRUE/FALSE/NULL=inherit). Full provenance via `PolicySource` enum and `ResolutionTrace`. Governance event hooks (DEBUG log, future EventBus). Feedback debouncing per `(channel_id, subsystem)`. Plugin isolation contract in module docstring.

- **`utils/visibility_rules.py`** — Pure sync tier logic (visibility only, not execution authorization).

- **`utils/onboarding_profiles.py`** — Static welcome data, no imports.

- **`migrations/004_governance_tables.sql`** — `subsystem_visibility` (tri-state `BOOLEAN NULL`) and `cleanup_policies` tables with indexes.

- **`utils/db.py`** — Governance DB helpers: bulk visibility fetch, upsert overrides, cleanup policy read/write.

- **`utils/settings_keys.py`** — Added `GOVERNANCE_VERSION`.

- **`cogs/help_cog.py`** — Rewritten as pure governance view. Tier-grouped overview (🟢 User / 🟠 Mod / 🔴 Admin), registry-driven emoji/color/ordering, dropdown with back button.

- **`cogs/cleanup_cog.py`** — Routes command policy through `governance_service.resolve_command_policy()`. Fallback to config whitelist for ungoverned guilds/DMs.

- **`cogs/channel_cog.py`** — Added "🔍 Subsystem Visibility" panel to `_ChannelManagerView`. Per-channel toggle buttons cycling None→True→False→None with live DB writes via `governance_service.set_subsystem_visibility()`.

- **`bot1.py`** — Calls `validate_registry()` before DB init and cog loading; catches `GovernanceError` → `SystemExit(1)`.

## Key architectural guarantees

| Guarantee | Implementation |
|-----------|---------------|
| Registry immutable after startup | Deep-freeze via `MappingProxyType` + `tuple` + `frozenset` |
| Visibility ≠ Authorization | `resolve_visibility()` and `resolve_execution()` always separate |
| Generic scope traversal | `SCOPE_PARENT` loop — no hardcoded `if channel_id: elif category_id:` |
| Typed provenance | `PolicySource` enum internally; strings only in `to_dict()` |
| O(1) cache invalidation | Version-stamped keys — no key scanning |
| Backwards compatibility | Ungoverned guilds: identical behavior to before |
| Fail-fast startup | `validate_registry()` aborts on any registry fault |

## Test plan

- [ ] Verify `validate_registry()` passes on startup with all 20 subsystems
- [ ] Confirm registry is deeply frozen: `SUBSYSTEMS['economy']['tags']` is `tuple`, not `list`
- [ ] Confirm `Capability.parse('economy.daily')` raises `CapabilityNamespaceError`
- [ ] Confirm `!help` on ungoverned guild shows identical output to pre-PR (all normal-mode subsystems)
- [ ] Confirm tier grouping: regular user sees only 🟢 section; admin sees all three
- [ ] Confirm cleanup cog routes blocked commands through governance policy
- [ ] Confirm channel visibility panel opens and toggles cycle None→True→False→None
- [ ] `ruff check .` → passes (disbot/ excluded per pyproject.toml)
- [ ] `black --check .` → passes
- [ ] `mypy` on changed files → no errors

https://claude.ai/code/session_01X2QVQJ9iA9caBH3bP3uoj3

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2QVQJ9iA9caBH3bP3uoj3)_