### PR TITLE
feat: dynamic governance platform — subsystem registry, visibility engine, policy service

### DIFF
--- a/disbot/migrations/004_governance_tables.sql
+++ b/disbot/migrations/004_governance_tables.sql
@@ -32,6 +32,3 @@ CREATE TABLE IF NOT EXISTS cleanup_policies (
     PRIMARY KEY (guild_id, scope_type, scope_id)
 );
 
-INSERT INTO schema_migrations (version, applied_at, description)
-VALUES (4, extract(epoch from now())::bigint, 'governance tables')
-ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary

Implements the full governance platform layer. All subsystem visibility, command policy, and cleanup enforcement decisions now route through a single orchestration service. Cogs are pure consumers — no governance logic lives inside them.

### New files

- **`migrations/004_governance_tables.sql`** — `subsystem_visibility` (tri-state `BOOLEAN NULL`) and `cleanup_policies` tables with indexes. Idempotent (`CREATE TABLE IF NOT EXISTS`). No self-insert into `schema_migrations` — the migration runner handles that.

- **`utils/subsystem_registry.py`** — Immutable manifest of all 20 subsystems. Defines capabilities (`{subsystem}.{resource}.{action}`), entry points, dependencies, and visibility tiers. Deep-frozen at startup via `MappingProxyType` + `tuple` + `frozenset` recursively. Includes `Capability` frozen dataclass. `validate_registry()` runs DFS cycle detection, topological sort, and O(1) compiled lookup tables before freezing.

- **`services/governance_exceptions.py`** — Typed exception hierarchy: `GovernanceError` → `RegistryValidationError` → `CircularDependencyError` / `CapabilityNamespaceError`, plus `GovernanceUpgradeError`.

- **`services/governance_service.py`** — Central orchestrator. Scope inheritance via generic `SCOPE_PARENT` loop (no hardcoded if/elif). Version-stamped cache keyed by `(guild_id, version, channel_id, tier)` with O(1) invalidation. Tri-state DB overrides (TRUE/FALSE/NULL=inherit). Full provenance via `PolicySource` enum and `ResolutionTrace`. Governance event hooks (DEBUG log). Feedback debouncing per `(channel_id, subsystem)`. Plugin isolation contract in module docstring.

- **`utils/visibility_rules.py`** — Pure sync tier logic (visibility only, not execution authorization).

- **`utils/onboarding_profiles.py`** — Static welcome data, stdlib only.

### Modified files

- **`utils/db.py`** — Added governance helpers: bulk visibility fetch, upsert overrides, cleanup policy read/write.
- **`utils/settings_keys.py`** — Added `GOVERNANCE_VERSION`.
- **`bot1.py`** — Calls `validate_registry()` before `db.init()`; catches `GovernanceError` → `SystemExit(1)`.
- **`cogs/help_cog.py`** — Rewritten as pure governance view. Tier-grouped overview (🟢 User / 🟠 Mod / 🔴 Admin), registry-driven emoji/color/ordering, dropdown with back button.
- **`cogs/cleanup_cog.py`** — Routes command policy through `governance_service.resolve_command_policy()`. Falls back to config whitelist for DMs/ungoverned guilds.
- **`cogs/channel_cog.py`** — Added "🔍 Subsystem Visibility" panel to `_ChannelManagerView` with per-channel toggle buttons (None→True→False→None) writing via `governance_service.set_subsystem_visibility()`.

### Bug fix included

Removed a double-insert in `004_governance_tables.sql`: the SQL file was inserting its own row into `schema_migrations`, but the migration runner in `db.py` already does that after executing each file — causing a `UniqueViolationError` crash on any re-deploy.

## Key architectural guarantees

| Guarantee | Implementation |
|-----------|----------------|
| Registry immutable after startup | Recursive deep-freeze: `MappingProxyType` + `tuple` + `frozenset` |
| Visibility ≠ Authorization | `resolve_visibility()` and `resolve_execution()` always separate |
| Generic scope traversal | `SCOPE_PARENT` loop — no hardcoded `if channel_id: elif category_id:` |
| Typed provenance | `PolicySource` enum internally; strings only in `to_dict()` |
| O(1) cache invalidation | Version-stamped keys — no key scanning on invalidation |
| Backwards compatibility | Ungoverned guilds: identical behavior to before |
| Fail-fast startup | `validate_registry()` aborts on any registry fault before DB init |

## Checks

- `ruff check .` → ✅ passes (disbot/ excluded per `pyproject.toml`)
- `black --check .` → ✅ passes
- `mypy` on all 11 changed files → ✅ no issues
- Registry validation tests → ✅ (20 subsystems, deep-freeze, topological order, capability parsing, wildcard matching)

https://claude.ai/code/session_01X2QVQJ9iA9caBH3bP3uoj3

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2QVQJ9iA9caBH3bP3uoj3)_