### PR TITLE
SuperBot full architecture migration (Steps 1–10)

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -12,18 +12,23 @@ import uuid
 import config
 import discord
 from discord.ext import commands
-from pythonjsonlogger import jsonlogger
 from services.webhook_reporter import WebhookReporter
 from utils import db
 from utils.synonyms import find_command as _find_synonym
 
 # ---------------------------------------------------------------------------
-# Logging — structured JSON, rotating file (10 MB × 5 backups) + stderr
+# Logging — structured JSON when python-json-logger is available,
+# falling back to plain text so the bot boots in minimal environments.
 # ---------------------------------------------------------------------------
-_fmt = jsonlogger.JsonFormatter(
-    "%(asctime)s %(levelname)s %(name)s %(message)s",
-    rename_fields={"asctime": "timestamp", "levelname": "level", "name": "logger"},
-)
+try:
+    from pythonjsonlogger import jsonlogger as _jsonlogger
+
+    _fmt: logging.Formatter = _jsonlogger.JsonFormatter(
+        "%(asctime)s %(levelname)s %(name)s %(message)s",
+        rename_fields={"asctime": "timestamp", "levelname": "level", "name": "logger"},
+    )
+except ImportError:  # python-json-logger not installed — use stdlib formatter
+    _fmt = logging.Formatter("%(asctime)s | %(levelname)s | %(name)s | %(message)s")
 _root = logging.getLogger()
 _root.setLevel(logging.INFO)
 

--- a/disbot/healthserver.py
+++ b/disbot/healthserver.py
@@ -25,7 +25,18 @@ import os
 
 from aiohttp import web
 from discord.ext import commands
-from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+
+try:
+    from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+
+    _PROMETHEUS_AVAILABLE = True
+except ImportError:
+    _PROMETHEUS_AVAILABLE = False
+    CONTENT_TYPE_LATEST = "text/plain; version=0.0.4"
+
+    def generate_latest() -> bytes:  # type: ignore[misc]
+        return b"# prometheus_client not installed\n"
+
 
 logger = logging.getLogger("bot.health")
 

--- a/disbot/services/metrics.py
+++ b/disbot/services/metrics.py
@@ -3,6 +3,10 @@
 All metrics are module-level singletons created once on import.
 Collect and expose via the /metrics endpoint in healthserver.py.
 
+When prometheus_client is not installed the module still imports cleanly
+and all metric objects become silent no-ops, so callers never need to
+guard metric calls individually.
+
 Usage:
     from services import metrics
     metrics.governance_cache_hits.labels(guild_id=str(guild_id)).inc()
@@ -10,7 +14,37 @@ Usage:
 
 from __future__ import annotations
 
-from prometheus_client import Counter, Gauge, Histogram
+try:
+    from prometheus_client import Counter, Gauge, Histogram
+
+    PROMETHEUS_AVAILABLE = True
+except ImportError:
+    PROMETHEUS_AVAILABLE = False
+
+    class _NoOp:
+        """Silent no-op that accepts any attribute access or call."""
+
+        def labels(self, **_: object) -> "_NoOp":
+            return self
+
+        def inc(self, *_: object, **__: object) -> None:
+            pass
+
+        def observe(self, *_: object, **__: object) -> None:
+            pass
+
+        def set(self, *_: object, **__: object) -> None:
+            pass
+
+    def Counter(name: str, doc: str, labelnames: object = (), **_: object) -> _NoOp:  # type: ignore[no-redef]
+        return _NoOp()
+
+    def Gauge(name: str, doc: str, labelnames: object = (), **_: object) -> _NoOp:  # type: ignore[no-redef]
+        return _NoOp()
+
+    def Histogram(name: str, doc: str, labelnames: object = (), buckets: object = (), **_: object) -> _NoOp:  # type: ignore[no-redef]
+        return _NoOp()
+
 
 governance_cache_hits = Counter(
     "governance_cache_hits_total",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ python-dotenv>=1.0.0
 psutil>=5.9.0
 asyncpg>=0.29.0
 aiohttp>=3.9.0
+python-json-logger>=2.0.7
+prometheus-client>=0.19.0


### PR DESCRIPTION
## Summary

Full 10-step architectural migration of SuperBot from a traditional command bot into a governance-driven persistent interaction platform. This PR completes all planned improvements from the architectural audit, fixes every known correctness bug, adds a full test suite, and resolves all deployment/runtime issues.

---

## What changed (14 commits, 91 files, +7982 / -906 lines)

### Step 1 — Correctness Foundations
- **Cache key bug (ISSUE-001):** Role-scoped overrides now included in governance cache key — prevents stale responses for members with role-specific governance
- **Atomic XP/economy writes (ISSUE-039):** XP increment rewritten as `UPDATE ... SET xp = xp + $n` (no read-modify-write race); daily double-claim protected with WHERE clause; deathmatch wrapped in `conn.transaction()`
- **Cleanup cache invalidation (ISSUE-040):** `on_guild_remove` handler evicts `_pattern_cache` and `_word_cache`; word add/remove commands immediately evict the cache
- **DB primary key bug (ISSUE-009):** `rps_players` and `deathmatch_stats` PKs migrated to `(user_id, guild_id)` — cross-guild stat contamination eliminated

### Step 2 — Architecture Clarification + EventBus
- **Deleted orphaned dead code (ISSUE-005/026):** `core/registry.py` and `core/permissions.py` removed — both fully superseded by the governance package
- **EventBus wired (ISSUE-006):** `_emit_governance_event()` now calls `core.events.bus.emit()` so any future consumer subscribes without modifying governance_service
- **Role scope declared (ISSUE-007):** `set_subsystem_visibility()` now explicitly rejects `scope_type='role'` with a `GovernanceError` instead of silently ignoring it
- **Cog load failures reflected in governance:** Failed cog subsystems marked `INTERNAL` so they don't appear in help menus

### Step 3 — Test Infrastructure
- **123 unit tests across 6 test files** covering: all governance scope resolution paths, dependency propagation, cache hit/miss/TTL/invalidation, startup validation (circular deps, bad registry → SystemExit), snapshot round-trip serialization, and registry entry-point integrity
- pytest + pytest-asyncio configured in `pyproject.toml`; CI step added to `.github/workflows/code-quality.yml`

### Step 4 — Operational Hardening
- **`WebhookReporter` extracted** from `bot1.py` → `services/webhook_reporter.py` (bot1.py now < 150 lines)
- **Governance audit log (ISSUE-011):** `governance_audit_log` table; every `set_subsystem_visibility()` and `set_cleanup_policy_for_scope()` call writes an actor-attributed record
- **HTTP health server (ISSUE-012):** `healthserver.py` — `GET /health` (liveness), `GET /ready` (readiness), `GET /metrics` on port 8080
- **`mod_logs.timestamp` migrated to `TIMESTAMPTZ` (ISSUE-010)**
- **Rotating file log handler (ISSUE-041):** 10 MB × 5 backups — unbounded log file growth eliminated
- **Graceful shutdown (ISSUE-022):** SIGTERM sets `_shutting_down` flag, drains in-flight coroutines with timeout, closes DB pool cleanly
- **Advisory lock on migrations (ISSUE-013):** `pg_try_advisory_lock` serializes concurrent container startup

### Step 5 — Runtime Architecture Foundation
- `core/runtime/interaction_router.py` — central interaction dispatcher; generates `request_id` UUID; calls governance gate before every action
- `core/runtime/session_manager.py` — session CRUD, last-active tracking, `runtime_sessions` DB table
- `core/runtime/state_store.py` — typed per-session key-value state, `runtime_session_state` DB table
- `core/runtime/ui_permissions.py` — single governance authorization gate for all runtime actions
- Migration 007: `runtime_sessions`, `runtime_session_state` tables

### Step 6 — Persistent Panel System
- `core/runtime/panel_manager.py` — one panel per (user, channel, subsystem); anti-duplication via DB UNIQUE constraint
- `core/runtime/message_anchor_manager.py` — Discord `(channel_id, message_id)` persistence; stale detection
- `core/runtime/persistent_views.py` — views re-attached to anchored messages on bot restart
- `core/runtime/session_gc.py` — background GC: expires idle sessions (TTL 2h), prunes stale anchors
- Migration 008: `panel_anchors` table

### Step 7 — Declarative UI Framework
- `core/runtime/component_registry.py` — `stats_block`, `progress_bar`, `paginated_list`, `ActionDef`, `resolve_action_states`, `add_actions_to_view`
- `core/runtime/navigation_stack.py` — per-session breadcrumb push/pop
- `core/runtime/live_update_scheduler.py` — EventBus-driven panel refresh; respects Discord's 5-edit/5s rate limit per channel
- `core/runtime/ephemeral_surface_manager.py` — ephemeral confirmation dialogs and alerts

### Step 8 — Governance Observability
- **Structured JSON logging** via `python-json-logger` with stdlib fallback
- **Prometheus metrics** (`services/metrics.py`): cache hits/misses, resolution latency histogram, command totals, session gauge, panel refresh counter, denial counter
- **Correlation IDs:** `request_id` UUID generated per command, propagated through `GovernanceContext` and `ResolutionTrace`
- **Snapshot diffing:** `diff_governance_snapshots()` returns `GovernanceDiff`

### Step 9 — Governance Package Split + Evolution
- `governance_service.py` (1118 lines) split into a 13-submodule package: `cache`, `resolver`, `dependency`, `cleanup`, `execution`, `snapshot`, `health`, `writes`, `events`, `models`, `templates`, `policy_engine`
- **Execution decoupled from visibility (ISSUE-008):** `resolve_execution()` now independent — internal/AI-triggered capabilities work without visibility grants
- **Thread scope (ISSUE-016):** `GovernanceContext` factory methods detect `discord.Thread`; `SCOPE_PRIORITY` extended; migration 009 adds 'thread' to scope_type CHECK constraint
- **`PolicySource.THREAD_OVERRIDE`** added to enum
- **`SubsystemDefinition` typed (ISSUE-025)**
- **`GovernanceTemplate`:** export/import/apply governance configuration across guilds
- `governance/__init__.py` re-exports full public API — all existing callers unchanged

### Step 10 — Scale Preparation
- **`GovernanceCacheBackend` Protocol:** `InProcessCache` implements it today; swap to `RedisCache` at sharding time with one env-var change
- **`PluginContract` Protocol:** `core/runtime/plugin_contract.py` — third-party cogs validated at load time
- **`governance/templates.py`:** multi-server governance template system
- **`governance/policy_engine.py`:** `PolicyRule` scaffold (DSL foundation)
- **Minimum Discord intents** (ISSUE-021): `Intents.all()` → `members + message_content` only
- **Governance JOIN optimization (ISSUE-037):** visibility + cleanup fetched in a single query on cache miss

---

## Bug fixes (real logic errors, not stubs)

- **`economy_cog.py`:** `_WorkView(ctx, available)` → `_WorkView(ctx.author.id, ctx.guild.id, available)` and `_ShopView(ctx)` → `_ShopView(ctx.author.id, ctx.guild.id)` — wrong positional arguments to view constructors
- **`get_panel_anchor()`** now filters `AND NOT is_stale` — stale anchors were being returned as active

---

## Static analysis

All checks pass against 82 source files:

| Check | Result |
|-------|--------|
| mypy | ✅ 0 errors |
| black | ✅ 82 files unchanged |
| isort | ✅ clean |
| ruff | ✅ all checks passed |
| pytest | ✅ 123 passed |

---

## Deployment fixes

- **`requirements.txt`:** added `python-json-logger>=2.0.7` and `prometheus-client>=0.19.0` (both were introduced by Steps 7–8 but missing from the manifest, causing `ModuleNotFoundError` on fresh deployments)
- **Graceful fallbacks:** bot boots in minimal environments without either package — `pythonjsonlogger` absence → stdlib formatter; `prometheus_client` absence → no-op metric stubs + empty `/metrics` response

---

## Test plan

- [ ] Verify CI passes on this PR (mypy, black, isort, ruff, pytest)
- [ ] Deploy to staging and confirm `GET /health` → `{"status": "ok"}`
- [ ] Confirm `GET /ready` → 503 before login, 200 after
- [ ] Run `!economymenu` and `!shop` — verify persistent panels appear and buttons work
- [ ] Confirm bot restart re-attaches persistent views (buttons remain functional)
- [ ] Run `!governance set economy channel disabled` and verify audit log row written
- [ ] Confirm SIGTERM drains cleanly (no "connection abandoned" in logs)

https://claude.ai/code/session_01CK7YkFbbPxGcmPUjFdQE5X

---
_Generated by [Claude Code](https://claude.ai/code/session_01CK7YkFbbPxGcmPUjFdQE5X)_