### PR TITLE
Governance consolidation + runtime stabilization + help-menu navigation

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -325,7 +325,9 @@ async def _governance_guard(ctx: commands.Context) -> None:
     # Send user-facing feedback before raising so the message arrives.
     if policy.feedback:
         try:
-            await ctx.send(policy.feedback, delete_after=policy.cleanup.delete_after_seconds or 10)
+            await ctx.send(
+                policy.feedback, delete_after=policy.cleanup.delete_after_seconds or 10
+            )
         except Exception:
             pass
     if policy.cleanup.delete_message and ctx.message:
@@ -429,7 +431,9 @@ async def main() -> None:
 
             # Track app-owned tasks so shutdown only cancels OUR tasks,
             # not discord.py-internal ones (OPS-001 fix).
-            _APP_TASKS.append(asyncio.create_task(start_health_server(bot), name="health_server"))
+            _APP_TASKS.append(
+                asyncio.create_task(start_health_server(bot), name="health_server")
+            )
             _APP_TASKS.append(session_gc.start())
             await _load_cogs()
             logger.info("Starting bot...")

--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -79,7 +79,6 @@ def _remove_pid() -> None:
         pass
 
 
-check_existing_instance()
 atexit.register(_remove_pid)
 
 # ---------------------------------------------------------------------------
@@ -99,6 +98,10 @@ ALLOWED_CHANNELS = config.ALLOWED_CHANNELS
 
 # Set by SIGTERM handler — channel guard rejects new commands during drain.
 _shutting_down = False
+
+# Application-owned background tasks.  Only these are cancelled on shutdown —
+# discord.py-internal tasks are left alone to avoid library-level errors.
+_APP_TASKS: list[asyncio.Task] = []
 
 
 def _begin_shutdown(*_) -> None:
@@ -131,9 +134,9 @@ async def on_ready() -> None:
 
 @bot.event
 async def on_guild_remove(guild: discord.Guild) -> None:
-    from services import governance_service
+    from guild_lifecycle import teardown
 
-    governance_service.forget_guild(guild.id)
+    await teardown(guild.id)
 
 
 @bot.event
@@ -195,12 +198,37 @@ async def on_command_error(ctx: commands.Context, error: commands.CommandError) 
     if reporter:
         await reporter.on_command_error(ctx, error)
 
-    in_allowed = ctx.channel.id in ALLOWED_CHANNELS
-    is_force = ctx.command is not None and ctx.command.name == "force"
-    if not in_allowed and not is_force:
+    if isinstance(error, commands.CheckFailure):
+        # Governance check failures produce their own user-facing message.
         return
 
-    if isinstance(error, commands.CheckFailure):
+    in_allowed = ctx.channel.id in ALLOWED_CHANNELS
+    is_force = ctx.command is not None and ctx.command.name == "force"
+
+    # Log ALL non-check errors regardless of channel so bugs are never invisible.
+    if not isinstance(
+        error,
+        (
+            commands.MissingPermissions,
+            commands.BotMissingPermissions,
+            commands.CommandNotFound,
+            commands.MissingRequiredArgument,
+            commands.BadArgument,
+            commands.CommandOnCooldown,
+        ),
+    ):
+        logger.error(
+            "CMD ❌ | %s | %s | %s | %s: %s",
+            ctx.command,
+            ctx.author,
+            ctx.guild,
+            type(error).__name__,
+            error,
+            exc_info=True,
+        )
+
+    # Only send user-facing replies in allowed channels.
+    if not in_allowed and not is_force:
         return
 
     if isinstance(error, commands.MissingPermissions):
@@ -238,15 +266,6 @@ async def on_command_error(ctx: commands.Context, error: commands.CommandError) 
             delete_after=8,
         )
     else:
-        logger.error(
-            "CMD ❌ | %s | %s | %s | %s: %s",
-            ctx.command,
-            ctx.author,
-            ctx.guild,
-            type(error).__name__,
-            error,
-            exc_info=True,
-        )
         await ctx.send(
             "⚠️ An unexpected error occurred. Please try again.", delete_after=10
         )
@@ -264,6 +283,59 @@ async def _channel_guard(ctx: commands.Context) -> bool:
     return ctx.guild is not None and (
         ctx.channel.id in ALLOWED_CHANNELS
         or (ctx.command is not None and ctx.command.name == "force")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Governance enforcement guard (Phase 1.3 — ARCH-001 fix)
+#
+# Runs AFTER _channel_guard passes, BEFORE the cog handler is invoked.
+# Every command that reaches this hook has already passed the channel whitelist
+# check.  We resolve the subsystem for the command and gate on visibility.
+#
+# This converts governance from advisory (help-menu-only) to infrastructure:
+# disabling a subsystem now blocks its commands, not just hides them.
+# ---------------------------------------------------------------------------
+
+
+@bot.before_invoke
+async def _governance_guard(ctx: commands.Context) -> None:
+    """Enforce subsystem visibility before every command invocation.
+
+    Raises commands.CheckFailure (caught by on_command_error) when the
+    command's owning subsystem is disabled for the invoking member.
+    The !force admin override and unknown commands are exempted.
+    """
+    if ctx.command is None:
+        return
+    # !force is an explicit admin channel-restriction bypass — leave it alone.
+    if ctx.command.name == "force":
+        return
+    # DM contexts have no guild governance.
+    if ctx.guild is None:
+        return
+
+    from governance import GovernanceContext, resolve_command_policy
+
+    gov_ctx = GovernanceContext.from_ctx(ctx)
+    policy = await resolve_command_policy(gov_ctx, ctx.command.qualified_name)
+    if policy.allowed:
+        return
+
+    # Send user-facing feedback before raising so the message arrives.
+    if policy.feedback:
+        try:
+            await ctx.send(policy.feedback, delete_after=policy.cleanup.delete_after_seconds or 10)
+        except Exception:
+            pass
+    if policy.cleanup.delete_message and ctx.message:
+        try:
+            await ctx.message.delete(delay=policy.cleanup.delete_after_seconds or 5)
+        except Exception:
+            pass
+
+    raise commands.CheckFailure(
+        f"Subsystem disabled for command {ctx.command.qualified_name!r}"
     )
 
 
@@ -331,6 +403,9 @@ async def _load_cogs() -> None:
 
 
 async def main() -> None:
+    # PID guard moved here from module level so test imports don't trigger it.
+    check_existing_instance()
+
     from services.governance_exceptions import GovernanceError
     from utils.subsystem_registry import validate_registry
 
@@ -347,27 +422,26 @@ async def main() -> None:
     await runtime.setup()
     if reporter:
         await reporter.start()
-    health_task: asyncio.Task | None = None
-    gc_task: asyncio.Task | None = None
     try:
         async with bot:
             from core.runtime import session_gc
             from healthserver import start_health_server
 
-            health_task = asyncio.create_task(start_health_server(bot))
-            gc_task = session_gc.start()
+            # Track app-owned tasks so shutdown only cancels OUR tasks,
+            # not discord.py-internal ones (OPS-001 fix).
+            _APP_TASKS.append(asyncio.create_task(start_health_server(bot), name="health_server"))
+            _APP_TASKS.append(session_gc.start())
             await _load_cogs()
             logger.info("Starting bot...")
             await bot.start(config.DISCORD_BOT_TOKEN)
     finally:
-        if health_task and not health_task.done():
-            health_task.cancel()
-        if gc_task and not gc_task.done():
-            gc_task.cancel()
-        # Graceful drain: allow up to 5 s for in-flight coroutines to finish.
-        if _shutting_down:
-            pending = {t for t in asyncio.all_tasks() if not t.done()}
-            pending.discard(asyncio.current_task())
+        # Cancel only application-owned tasks — never asyncio.all_tasks().
+        for task in _APP_TASKS:
+            if not task.done():
+                task.cancel()
+        # Graceful drain: give in-flight app coroutines up to 5 s to finish.
+        if _shutting_down and _APP_TASKS:
+            pending = {t for t in _APP_TASKS if not t.done()}
             if pending:
                 _, still_pending = await asyncio.wait(pending, timeout=5.0)
                 for t in still_pending:

--- a/disbot/cogs/general_cog.py
+++ b/disbot/cogs/general_cog.py
@@ -216,7 +216,7 @@ class _TriviaRevealView(BaseView):
 
 
 class _EightBallModal(discord.ui.Modal, title="🎱 Magic 8-Ball"):  # type: ignore[call-arg]
-    question = discord.ui.TextInput(
+    question = discord.ui.TextInput(  # type: ignore[var-annotated]
         label="Ask a yes/no question",
         placeholder="Will I win the lottery?",
         max_length=200,

--- a/disbot/cogs/general_cog.py
+++ b/disbot/cogs/general_cog.py
@@ -47,6 +47,23 @@ def _load_content() -> dict:
         return {}
 
 
+def _overview_embed() -> discord.Embed:
+    """Build the General subsystem panel overview embed."""
+    return discord.Embed(
+        title="💬 General",
+        description=(
+            "**💡 Fact** — random interesting fact\n"
+            "**😄 Joke** — random joke\n"
+            "**💬 Quote** — famous quote\n"
+            "**🧠 Trivia** — trivia question with reveal\n"
+            "**💪 Motivate** — motivational message\n"
+            "**🎱 8-Ball** — yes/no question modal\n"
+            "**👋 Greet** — random greeting"
+        ),
+        color=GENERAL_COLOR,
+    )
+
+
 class General(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
@@ -55,6 +72,37 @@ class General(commands.Cog):
         self._jokes: list[str] = content.get("jokes", [])
         self._quotes: list[str] = content.get("quotes", [])
         self._trivia: list[str] = content.get("trivia", [])
+
+    @commands.command(
+        name="generalmenu",
+        aliases=["gmenu"],
+        help="Open the interactive General panel.",
+    )
+    async def general_menu(self, ctx: commands.Context) -> None:
+        """Entry-point command for the General subsystem panel.
+
+        The subsystem_registry's entry_points list must contain at least one
+        actually-registered command — this command is that anchor (the help
+        menu uses it to map "general" → this cog).
+        """
+        view = _GeneralPanelView(ctx.author, self)
+        msg = await ctx.send(embed=_overview_embed(), view=view)
+        view.message = msg
+
+    async def build_help_menu_view(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        """Help-menu direct-navigation hook.
+
+        Called by HelpPanelView._on_select when the user picks "General" from
+        the help dropdown.  Returns the same (embed, view) pair that
+        !generalmenu would produce, so the help message can be replaced in
+        place with the General panel — no secondary navigation step required.
+        Governance has already been resolved at the help layer.
+        """
+        view = _GeneralPanelView(interaction.user, self)  # type: ignore[arg-type]
+        return _overview_embed(), view
 
     @commands.command(name="fact", help="Sends a random interesting fact.")
     async def fact(self, ctx):
@@ -160,6 +208,137 @@ class _TriviaRevealView(BaseView):
     ):
         text = self._answer.strip() if self._answer else "No answer recorded."
         await interaction.response.send_message(f"**Answer:** {text}", ephemeral=True)
+
+
+# ---------------------------------------------------------------------------
+# General Panel View
+# ---------------------------------------------------------------------------
+
+
+class _EightBallModal(discord.ui.Modal, title="🎱 Magic 8-Ball"):
+    question = discord.ui.TextInput(
+        label="Ask a yes/no question",
+        placeholder="Will I win the lottery?",
+        max_length=200,
+        required=True,
+    )
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        embed = discord.Embed(title="🎱 Magic 8-Ball", color=GENERAL_COLOR)
+        embed.add_field(name="Question", value=str(self.question), inline=False)
+        embed.add_field(name="Answer", value=random.choice(EIGHTBALL), inline=False)
+        await interaction.response.send_message(embed=embed, ephemeral=False)
+
+
+class _GeneralPanelView(BaseView):
+    """Interactive panel for the General subsystem.
+
+    Mirrors the pattern of _UtilityPanelView in utility_cog.py: each button
+    edits the same message in place with a result embed.  Public=True so the
+    panel can be shared in a channel context.
+    """
+
+    def __init__(self, author: discord.Member | discord.User, cog: General):
+        super().__init__(author, public=True, timeout=300)
+        self._cog = cog
+
+    def _build_overview(self) -> discord.Embed:
+        return _overview_embed()
+
+    def _random_or_empty(self, pool: list[str], label: str) -> str:
+        return random.choice(pool) if pool else f"No {label} available."
+
+    @discord.ui.button(label="💡 Fact", style=discord.ButtonStyle.blurple, row=0)
+    async def fact_btn(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ) -> None:
+        embed = discord.Embed(
+            title="💡 Random Fact",
+            description=self._random_or_empty(self._cog._facts, "facts"),
+            color=GENERAL_COLOR,
+        )
+        embed.set_footer(text="Click ↩ Overview to return.")
+        await interaction.response.edit_message(embed=embed, view=self)
+
+    @discord.ui.button(label="😄 Joke", style=discord.ButtonStyle.blurple, row=0)
+    async def joke_btn(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ) -> None:
+        embed = discord.Embed(
+            title="😄 Random Joke",
+            description=self._random_or_empty(self._cog._jokes, "jokes"),
+            color=GENERAL_COLOR,
+        )
+        embed.set_footer(text="Click ↩ Overview to return.")
+        await interaction.response.edit_message(embed=embed, view=self)
+
+    @discord.ui.button(label="💬 Quote", style=discord.ButtonStyle.blurple, row=0)
+    async def quote_btn(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ) -> None:
+        embed = discord.Embed(
+            title="💬 Quote",
+            description=self._random_or_empty(self._cog._quotes, "quotes"),
+            color=GENERAL_COLOR,
+        )
+        embed.set_footer(text="Click ↩ Overview to return.")
+        await interaction.response.edit_message(embed=embed, view=self)
+
+    @discord.ui.button(label="🧠 Trivia", style=discord.ButtonStyle.grey, row=1)
+    async def trivia_btn(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ) -> None:
+        if not self._cog._trivia:
+            await interaction.response.send_message(
+                "No trivia available.", ephemeral=True
+            )
+            return
+        raw = random.choice(self._cog._trivia)
+        question, answer = (raw.split(" || ", 1) + [None])[:2] if " || " in raw else (raw, None)
+        embed = discord.Embed(
+            title="🧠 Trivia",
+            description=question.strip(),
+            color=GENERAL_COLOR,
+        )
+        embed.set_footer(text="Click 'Reveal Answer' below.")
+        reveal_view = _TriviaRevealView(self._author, answer)  # type: ignore[arg-type]
+        await interaction.response.send_message(embed=embed, view=reveal_view)
+
+    @discord.ui.button(label="💪 Motivate", style=discord.ButtonStyle.grey, row=1)
+    async def motivate_btn(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ) -> None:
+        embed = discord.Embed(
+            title="💪 Motivation",
+            description=random.choice(MOTIVATIONS),
+            color=SUCCESS_COLOR,
+        )
+        embed.set_footer(text="Click ↩ Overview to return.")
+        await interaction.response.edit_message(embed=embed, view=self)
+
+    @discord.ui.button(label="🎱 8-Ball", style=discord.ButtonStyle.grey, row=1)
+    async def eightball_btn(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ) -> None:
+        await interaction.response.send_modal(_EightBallModal())
+
+    @discord.ui.button(label="👋 Greet", style=discord.ButtonStyle.green, row=2)
+    async def greet_btn(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ) -> None:
+        embed = discord.Embed(
+            title="👋 Greeting",
+            description=f"{random.choice(GREETINGS)} {interaction.user.mention}",
+            color=GENERAL_COLOR,
+        )
+        embed.set_footer(text="Click ↩ Overview to return.")
+        await interaction.response.edit_message(embed=embed, view=self)
+
+    @discord.ui.button(label="↩ Overview", style=discord.ButtonStyle.secondary, row=2)
+    async def overview_btn(
+        self, interaction: discord.Interaction, _: discord.ui.Button
+    ) -> None:
+        await interaction.response.edit_message(embed=self._build_overview(), view=self)
 
 
 async def setup(bot):

--- a/disbot/cogs/general_cog.py
+++ b/disbot/cogs/general_cog.py
@@ -215,7 +215,7 @@ class _TriviaRevealView(BaseView):
 # ---------------------------------------------------------------------------
 
 
-class _EightBallModal(discord.ui.Modal, title="🎱 Magic 8-Ball"):
+class _EightBallModal(discord.ui.Modal, title="🎱 Magic 8-Ball"):  # type: ignore[call-arg]
     question = discord.ui.TextInput(
         label="Ask a yes/no question",
         placeholder="Will I win the lottery?",
@@ -294,7 +294,9 @@ class _GeneralPanelView(BaseView):
             )
             return
         raw = random.choice(self._cog._trivia)
-        question, answer = (raw.split(" || ", 1) + [None])[:2] if " || " in raw else (raw, None)
+        question, answer = (
+            (raw.split(" || ", 1) + [None])[:2] if " || " in raw else (raw, None)
+        )
         embed = discord.Embed(
             title="🧠 Trivia",
             description=question.strip(),

--- a/disbot/cogs/help_cog.py
+++ b/disbot/cogs/help_cog.py
@@ -126,6 +126,52 @@ def _build_help_page_view(visible_list: list[str], page: int) -> "HelpPanelView"
     return HelpPanelView(visible_list, page)
 
 
+def _attach_back_to_help_button(
+    view: discord.ui.View,
+    visible_list: list[str],
+    page: int,
+) -> None:
+    """Add a "↩ Back to Help" control to a subsystem panel surfaced from help.
+
+    Does not mutate the cog's panel class — adds the button to the live view
+    instance only.  No-op if the view already has 25 components (Discord cap).
+    Governance is not re-resolved here: the visible_list captured at help-menu
+    open time is the same set the user is allowed to see for the duration of
+    the panel session.  If governance changes mid-session, EVT_VISIBILITY_CHANGED
+    will invalidate the underlying session state through the normal pipeline.
+    """
+    if len(view.children) >= 25:
+        return
+
+    back_btn = discord.ui.Button(  # type: ignore[var-annotated]
+        label="↩ Back to Help",
+        custom_id="help:back",
+        style=discord.ButtonStyle.secondary,
+        row=4,
+    )
+
+    async def _back_callback(interaction: discord.Interaction) -> None:
+        # Recompute visible list at click time — governance may have changed.
+        gctx = GovernanceContext.from_interaction(interaction)
+        vis_result = await governance_service.resolve_visibility(gctx)
+        fresh_visible = [
+            name for name, _ in all_subsystems_sorted()
+            if name in vis_result.visible_subsystems
+        ]
+        new_page = min(page, max(0, math.ceil(len(fresh_visible) / _PAGE_SIZE) - 1))
+        new_view = HelpPanelView(fresh_visible, new_page)
+        embed = _build_page_embed(
+            interaction.client,  # type: ignore[arg-type]
+            fresh_visible,
+            new_page,
+            vis_result.member_tier,
+        )
+        await interaction.response.edit_message(embed=embed, view=new_view)
+
+    back_btn.callback = _back_callback  # type: ignore[method-assign]
+    view.add_item(back_btn)
+
+
 def _build_page_embed(
     bot: commands.Bot,
     visible_list: list[str],
@@ -251,6 +297,16 @@ class HelpPanelView(PersistentView):
         return visible_list, vis_result.member_tier
 
     async def _on_select(self, interaction: discord.Interaction) -> None:
+        """Open the chosen subsystem in place — direct navigation, no extra clicks.
+
+        Resolution order:
+          1. If the cog exposes ``build_help_menu_view(interaction)``, call it
+             and replace the help message with the subsystem's actual panel
+             (with a "↩ Back to Help" button appended so the user can return).
+          2. Otherwise, fall back to the inline command-list embed.  This
+             preserves backwards compatibility for cogs that have not yet
+             adopted the direct-navigation hook.
+        """
         subsystem_name = interaction.data["values"][0]  # type: ignore[typeddict-item]
         cog = _cog_for_subsystem(interaction.client, subsystem_name)  # type: ignore[arg-type]
         if not cog:
@@ -258,6 +314,25 @@ class HelpPanelView(PersistentView):
                 "That category is no longer loaded.", ephemeral=True
             )
             return
+
+        # Direct-navigation hook (Phase 5 — help UX completion).
+        build_panel = getattr(cog, "build_help_menu_view", None)
+        if callable(build_panel):
+            try:
+                embed, sub_view = await build_panel(interaction)
+                _attach_back_to_help_button(sub_view, self._visible, self._page)
+                await interaction.response.edit_message(embed=embed, view=sub_view)
+                return
+            except Exception as exc:
+                logger.warning(
+                    "build_help_menu_view failed for subsystem=%r — falling back "
+                    "to inline command list: %s",
+                    subsystem_name,
+                    exc,
+                    exc_info=True,
+                )
+
+        # Fallback: inline cog command list, keep help view's nav controls.
         prefix = getattr(interaction.client, "command_prefix", "!")
         if callable(prefix):
             prefix = "!"

--- a/disbot/cogs/help_cog.py
+++ b/disbot/cogs/help_cog.py
@@ -155,7 +155,8 @@ def _attach_back_to_help_button(
         gctx = GovernanceContext.from_interaction(interaction)
         vis_result = await governance_service.resolve_visibility(gctx)
         fresh_visible = [
-            name for name, _ in all_subsystems_sorted()
+            name
+            for name, _ in all_subsystems_sorted()
             if name in vis_result.visible_subsystems
         ]
         new_page = min(page, max(0, math.ceil(len(fresh_visible) / _PAGE_SIZE) - 1))

--- a/disbot/core/events.py
+++ b/disbot/core/events.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections import defaultdict
 from collections.abc import Callable, Coroutine
@@ -9,6 +10,10 @@ logger = logging.getLogger("core.events")
 
 Handler = Callable[..., Coroutine[Any, Any, None]]
 
+# Maximum seconds a single handler may block before it is cancelled.
+# Prevents a slow or hung subscriber from delaying all downstream handlers.
+_HANDLER_TIMEOUT: float = 5.0
+
 
 class EventBus:
     """Lightweight in-process async event bus.
@@ -16,6 +21,19 @@ class EventBus:
     Events represent facts that already occurred — they are not commands.
     Use domain.action naming (e.g. "user.level_up", "economy.daily_claimed").
     Handlers respond independently; failures are isolated.
+
+    Phase 2.5 hardening
+    ────────────────────
+    Each handler executes under a timeout (_HANDLER_TIMEOUT = 5 s).  A timed-out
+    handler is logged at ERROR level and subsequent handlers continue normally.
+    This prevents a hung subscriber from cascading into a full event-bus stall.
+
+    Future sharding note
+    ─────────────────────
+    The bus is currently in-process only.  All module-level process-local state
+    (handler registrations, etc.) must be migrated to a shared backend
+    (e.g. Redis pub/sub) before multi-process sharding is introduced.
+    The emit() signature is kept stable for that transition.
     """
 
     def __init__(self) -> None:
@@ -30,7 +48,15 @@ class EventBus:
     async def emit(self, event: str, **payload: Any) -> None:
         for handler in list(self._handlers.get(event, [])):
             try:
-                await handler(**payload)
+                await asyncio.wait_for(handler(**payload), timeout=_HANDLER_TIMEOUT)
+            except asyncio.TimeoutError:
+                logger.error(
+                    "Handler %r timed out (>%.1fs) for event %r — "
+                    "handler detached for this emission; bus continues.",
+                    handler,
+                    _HANDLER_TIMEOUT,
+                    event,
+                )
             except Exception as exc:
                 logger.error(
                     "Handler %r failed for event %r: %s",

--- a/disbot/core/runtime/__init__.py
+++ b/disbot/core/runtime/__init__.py
@@ -63,6 +63,7 @@ async def setup() -> None:
     from core.events import bus
     from services.governance_service import (
         EVT_CACHE_INVALIDATED,
+        EVT_CLEANUP_CHANGED,
         EVT_VISIBILITY_CHANGED,
     )
 
@@ -93,7 +94,34 @@ async def setup() -> None:
     async def _on_cache_invalidated(guild_id: int, **_: object) -> None:
         await store.invalidate_guild_state(guild_id)
 
+    async def _on_cleanup_changed(
+        guild_id: int,
+        scope_type: str = "guild",
+        scope_id: int | None = None,
+        **_: object,
+    ) -> None:
+        """Subscription hook for EVT_CLEANUP_CHANGED (DEBT-003).
+
+        Cleanup policy is currently resolved uncached (governance/cleanup.py
+        queries the DB on every call).  This handler exists so any future
+        cleanup-policy cache MUST register its invalidation here rather than
+        introducing a parallel invalidation path.
+
+        The GovernanceMutationPipeline already calls invalidate_guild_cache()
+        and emits EVT_CACHE_INVALIDATED inside set_cleanup_policy, so the
+        in-process visibility cache is already coherent — this hook covers
+        only future cleanup-specific caching.
+        """
+        logger.debug(
+            "EVT_CLEANUP_CHANGED received | guild=%d scope=%s/%s — "
+            "no cleanup cache present, hook reserved for future use",
+            guild_id,
+            scope_type,
+            scope_id,
+        )
+
     bus.on(EVT_VISIBILITY_CHANGED, _on_visibility_changed)
     bus.on(EVT_CACHE_INVALIDATED, _on_cache_invalidated)
+    bus.on(EVT_CLEANUP_CHANGED, _on_cleanup_changed)
 
     logger.info("Runtime layer initialised — EventBus subscriptions active.")

--- a/disbot/core/runtime/__init__.py
+++ b/disbot/core/runtime/__init__.py
@@ -41,14 +41,25 @@ from core.runtime import ui_permissions as perms  # noqa: F401 — re-exported
 
 logger = logging.getLogger("bot.runtime")
 
+# Guard: setup() must be idempotent.  A second call (e.g. hot-reload or test
+# re-entry) must not register duplicate EventBus handlers — inner functions are
+# closures and have distinct object identities on every call, so bus.on() would
+# append them as separate handlers, causing double-execution.
+_SETUP_DONE: bool = False
+
 
 async def setup() -> None:
     """Wire EventBus subscriptions for the runtime layer.
 
     Must be called once during bot startup, after db.init() has run.
-    Idempotent — safe to call more than once (handlers accumulate but are
-    scoped to this module's functions, not lambdas, so duplication is benign).
+    Subsequent calls are no-ops (idempotency guard prevents double registration).
     """
+    global _SETUP_DONE
+    if _SETUP_DONE:
+        logger.debug("runtime.setup() called again — skipping (already initialised).")
+        return
+    _SETUP_DONE = True
+
     from core.events import bus
     from services.governance_service import (
         EVT_CACHE_INVALIDATED,
@@ -56,9 +67,28 @@ async def setup() -> None:
     )
 
     async def _on_visibility_changed(
-        guild_id: int, subsystem: str, **_: object
+        guild_id: int,
+        subsystem: str,
+        scope_type: str = "guild",
+        scope_id: int | None = None,
+        **_: object,
     ) -> None:
-        await sessions.invalidate_subsystem_sessions(guild_id, subsystem)
+        """Scope-aware session invalidation (Phase 2.3).
+
+        For channel-scoped changes we only invalidate sessions in the affected
+        channel.  For guild-scoped (or unknown scope) we fall back to full
+        guild-subsystem invalidation to be safe.
+        """
+        channel_id: int | None = None
+        if scope_type == "channel" and scope_id is not None:
+            channel_id = scope_id
+        # thread-scoped: the thread_id IS the channel_id in Discord's model
+        elif scope_type == "thread" and scope_id is not None:
+            channel_id = scope_id
+
+        await sessions.invalidate_subsystem_sessions(
+            guild_id, subsystem, channel_id=channel_id
+        )
 
     async def _on_cache_invalidated(guild_id: int, **_: object) -> None:
         await store.invalidate_guild_state(guild_id)

--- a/disbot/core/runtime/interaction_router.py
+++ b/disbot/core/runtime/interaction_router.py
@@ -95,6 +95,38 @@ async def dispatch(interaction: discord.Interaction) -> None:
         interaction.guild_id,
     )
 
+    # Governance gate (Phase 1.3 — centralized enforcement).
+    # Check subsystem visibility BEFORE resolving a session or calling the handler.
+    # This ensures that disabling a subsystem blocks interactions (button presses,
+    # modal submissions) just as it blocks command invocations.
+    if interaction.guild_id:
+        try:
+            from governance import GovernanceContext, get_visible_subsystems
+
+            gov_ctx = GovernanceContext.from_interaction(interaction)
+            visible = await get_visible_subsystems(gov_ctx)
+            if prefix not in visible:
+                logger.debug(
+                    "INTERACTION DENIED | req=%s | subsystem=%s | user=%s | "
+                    "reason=subsystem_disabled",
+                    request_id,
+                    prefix,
+                    getattr(interaction.user, "id", None),
+                )
+                if not interaction.response.is_done():
+                    await interaction.response.send_message(
+                        "❌ This feature is currently disabled here.",
+                        ephemeral=True,
+                    )
+                return
+        except Exception as exc:
+            logger.warning(
+                "Governance gate failed for req=%s | prefix=%s: %s — allowing (fail-open fallback)",
+                request_id,
+                prefix,
+                exc,
+            )
+
     # Resolve the session for this user+channel+subsystem (subsystem = prefix).
     session: session_manager.Session | None = None
     if interaction.guild_id and interaction.channel_id:

--- a/disbot/core/runtime/live_update_scheduler.py
+++ b/disbot/core/runtime/live_update_scheduler.py
@@ -41,8 +41,10 @@ logger = logging.getLogger("bot.runtime.scheduler")
 # Minimum seconds between edits to the same Discord channel.
 _MIN_EDIT_INTERVAL: float = 1.0
 
-# channel_id → monotonic timestamp of last edit
-_last_edit: dict[int, float] = {}
+# (guild_id, channel_id) → monotonic timestamp of last edit.
+# Keyed by (guild_id, channel_id) so guild_lifecycle.teardown() can drop entries
+# deterministically for a departed guild without touching other guilds' state.
+_last_edit: dict[tuple[int, int], float] = {}
 
 # subsystem → [(event_name, refresh_fn), ...]
 _REGISTRATIONS: dict[str, list[tuple[str, Callable]]] = {}
@@ -144,7 +146,7 @@ async def _refresh_panel(
 ) -> None:
     """Fetch a new embed/view and edit the panel message, respecting rate limits."""
     now = time.monotonic()
-    wait = _MIN_EDIT_INTERVAL - (now - _last_edit.get(channel_id, 0.0))
+    wait = _MIN_EDIT_INTERVAL - (now - _last_edit.get((guild_id, channel_id), 0.0))
     if wait > 0:
         await asyncio.sleep(wait)
 
@@ -167,7 +169,7 @@ async def _refresh_panel(
     try:
         message = await channel.fetch_message(message_id)
         await message.edit(embed=embed, view=view)
-        _last_edit[channel_id] = time.monotonic()
+        _last_edit[(guild_id, channel_id)] = time.monotonic()
         _metrics.panel_refresh_total.labels(subsystem=subsystem).inc()
         logger.debug(
             "Panel refreshed | user=%d | channel=%d | message=%d",
@@ -190,3 +192,17 @@ def setup(bot: commands.Bot) -> None:
         sum(len(v) for v in _REGISTRATIONS.values()),
         len(_SUBSCRIBED_EVENTS),
     )
+
+
+def forget_guild(guild_id: int) -> int:
+    """Drop _last_edit throttle entries owned by a departed guild.
+
+    Cleanup is deterministic and always occurs regardless of dict size — there
+    is no size-gated bypass.  The (guild_id, channel_id) keying makes this O(n)
+    over _last_edit but bounded by the number of channels the guild ever
+    refreshed.  Returns the number of entries removed.
+    """
+    stale = [k for k in _last_edit if k[0] == guild_id]
+    for k in stale:
+        _last_edit.pop(k, None)
+    return len(stale)

--- a/disbot/core/runtime/session_manager.py
+++ b/disbot/core/runtime/session_manager.py
@@ -84,17 +84,28 @@ async def remove(session_id: str) -> None:
     logger.debug("Removed session %s", session_id)
 
 
-async def invalidate_subsystem_sessions(guild_id: int, subsystem: str) -> None:
-    """Remove all sessions for a subsystem across a guild.
+async def invalidate_subsystem_sessions(
+    guild_id: int,
+    subsystem: str,
+    channel_id: int | None = None,
+) -> None:
+    """Remove sessions for a subsystem, optionally scoped to one channel.
 
     Called when EVT_VISIBILITY_CHANGED fires — affected users must re-open
     their panel to get fresh governance context.
+
+    Scope-aware behaviour (Phase 2.3):
+    - channel_id provided → only invalidate sessions in that channel.
+    - channel_id=None → invalidate all sessions for the subsystem guild-wide
+      (used for guild-scoped and category-scoped changes).
     """
-    removed_ids = await db.delete_sessions_for_subsystem(guild_id, subsystem)
+    removed_ids = await db.delete_sessions_for_scope(guild_id, subsystem, channel_id)
     if removed_ids:
+        scope_label = f"channel={channel_id}" if channel_id else "guild-wide"
         logger.info(
-            "Invalidated %d session(s) for subsystem=%r in guild=%d",
+            "Invalidated %d session(s) for subsystem=%r in guild=%d (%s)",
             len(removed_ids),
             subsystem,
             guild_id,
+            scope_label,
         )

--- a/disbot/governance/__init__.py
+++ b/disbot/governance/__init__.py
@@ -63,11 +63,15 @@ from governance.templates import (  # noqa: F401
     save_template,
 )
 from governance.writes import (  # noqa: F401
+    GovernanceMutationPipeline,
     check_governance_version,
     set_cleanup_policy_for_scope,
     set_subsystem_visibility,
 )
-from services.governance_exceptions import GovernanceError  # noqa: F401
+from services.governance_exceptions import (  # noqa: F401
+    GovernanceError,
+    UnauthorizedGovernanceWriteError,
+)
 from utils.subsystem_registry import (
     CAPABILITY_TO_SUBSYSTEM,
     SUBSYSTEMS,
@@ -276,6 +280,8 @@ __all__ = [
     # health
     "run_governance_healthcheck",
     # writes
+    "GovernanceMutationPipeline",
+    "UnauthorizedGovernanceWriteError",
     "check_governance_version",
     "set_cleanup_policy_for_scope",
     "set_subsystem_visibility",

--- a/disbot/governance/cache.py
+++ b/disbot/governance/cache.py
@@ -35,10 +35,10 @@ _CACHE: dict[tuple, tuple[float, Any]] = {}
 _CACHE_VERSION: dict[int, int] = {}  # guild_id → version counter
 _CACHE_LOCK = asyncio.Lock()
 _CACHE_TTL = 60.0
-_NO_OVERRIDE = object()  # sentinel for negative cache entries
+# Raised from 2000 to 50000 to avoid O(n) scan on large multi-guild deployments.
+_CACHE_CLEANUP_THRESHOLD = 50_000
 
 # Tracks guilds that have at least one role-scoped visibility override in DB.
-# Set to True by set_subsystem_visibility() when scope_type='role'.
 # Cleared by forget_guild() when bot leaves the guild.
 _guild_has_role_overrides: dict[int, bool] = {}
 
@@ -63,8 +63,14 @@ def _cache_key(
     tier: str,
     role_ids: frozenset[int] = frozenset(),
 ) -> tuple:
-    if _guild_has_role_overrides.get(guild_id, False):
-        return (guild_id, _cache_ver(guild_id), channel_id, tier, role_ids)
+    if _guild_has_role_overrides.get(guild_id, False) and role_ids:
+        # Phase 3.1: Include only the stable hash of role IDs rather than the raw
+        # frozenset.  Two users with different role sets but identical governance-
+        # relevant visibility will still get separate entries (hash collisions are
+        # benign — a miss just triggers a fresh resolution).  This keeps keys small
+        # and prevents combinatorial cache explosion in large guilds.
+        role_fingerprint = hash(role_ids)
+        return (guild_id, _cache_ver(guild_id), channel_id, tier, role_fingerprint)
     return (guild_id, _cache_ver(guild_id), channel_id, tier)
 
 
@@ -80,8 +86,9 @@ def _cache_get(key: tuple) -> Any:
 
 def _cache_set(key: tuple, value: Any) -> None:
     _CACHE[key] = (time.monotonic(), value)
-    # Lazy cleanup: remove entries from previous versions (unreachable anyway)
-    if len(_CACHE) > 2000:
+    # Lazy cleanup: remove TTL-expired entries.  Threshold raised to 50k to avoid
+    # frequent O(n) scans on large multi-guild deployments (Phase 3.1).
+    if len(_CACHE) > _CACHE_CLEANUP_THRESHOLD:
         cutoff = time.monotonic() - _CACHE_TTL
         stale = [k for k, (ts, _) in _CACHE.items() if ts < cutoff]
         for k in stale:
@@ -99,10 +106,12 @@ def invalidate_guild_cache(guild_id: int) -> None:
 
 
 def forget_guild(guild_id: int) -> None:
-    """Remove all module-level state for a guild.
+    """Remove visibility cache state for a guild.
 
-    Call this from an on_guild_remove event handler so that per-guild dicts
-    do not grow unbounded as the bot joins and leaves servers.
+    Called from guild_lifecycle.teardown() when the bot leaves a guild.
+    Note: capability execution override state lives in governance.execution and
+    must be cleared via execution.forget_guild_capabilities() separately —
+    see guild_lifecycle.py for the complete teardown sequence.
     """
     _CACHE_VERSION.pop(guild_id, None)
     _guild_has_role_overrides.pop(guild_id, None)

--- a/disbot/governance/execution.py
+++ b/disbot/governance/execution.py
@@ -7,6 +7,7 @@ Imports from governance.models, governance.events, governance.resolver.
 from __future__ import annotations
 
 import logging
+import time
 
 from governance.events import (
     EVT_EXECUTION_ALLOWED,
@@ -35,12 +36,28 @@ except Exception:
 _capability_execution_overrides: dict[tuple[int, str], bool] = {}
 _loaded_guilds: set[int] = set()
 
+# Guild → monotonic timestamp of last successful override load (DEBT-001).
+# Used to bound staleness: long-running processes will never serve overrides
+# older than _OVERRIDE_TTL without a deterministic refresh from DB.  Cache TTL
+# is intentionally coarse because capability_execution_overrides is rarely
+# mutated; the goal is bounded drift, not zero drift.
+_loaded_guilds_at: dict[int, float] = {}
+_OVERRIDE_TTL: float = 600.0  # 10 minutes
+
 
 async def _load_capability_overrides(guild_id: int) -> None:
     """Load capability overrides from DB for a guild.
 
-    Fails gracefully if the capability_execution_overrides table does not exist yet.
+    Reloads are deterministic: any prior entries for this guild are cleared
+    before the fresh row set is inserted, so stale rows cannot survive a
+    refresh.  Fails gracefully if the capability_execution_overrides table
+    does not yet exist (legacy deployments).
     """
+    # Clear any existing entries so a reload cannot leave stale rows behind.
+    stale_keys = [k for k in _capability_execution_overrides if k[0] == guild_id]
+    for k in stale_keys:
+        _capability_execution_overrides.pop(k, None)
+
     try:
         rows = await db.get().fetch(
             """SELECT capability, allowed
@@ -56,10 +73,20 @@ async def _load_capability_overrides(guild_id: int) -> None:
         # Table may not exist yet — fail gracefully
         logger.debug("capability_execution_overrides table not available: %s", exc)
 
+    _loaded_guilds_at[guild_id] = time.monotonic()
+
 
 def _check_capability_override(guild_id: int, capability: str) -> bool | None:
     """Return explicit override (True/False) or None if no override set."""
     return _capability_execution_overrides.get((guild_id, capability))
+
+
+def _overrides_stale(guild_id: int) -> bool:
+    """True if this guild's override cache is older than _OVERRIDE_TTL."""
+    loaded_at = _loaded_guilds_at.get(guild_id)
+    if loaded_at is None:
+        return True
+    return (time.monotonic() - loaded_at) > _OVERRIDE_TTL
 
 
 def forget_guild_capabilities(guild_id: int) -> None:
@@ -74,10 +101,52 @@ def forget_guild_capabilities(guild_id: int) -> None:
     The guild_lifecycle module coordinates both calls in the correct order.
     """
     _loaded_guilds.discard(guild_id)
+    _loaded_guilds_at.pop(guild_id, None)
     stale_keys = [k for k in _capability_execution_overrides if k[0] == guild_id]
     for k in stale_keys:
         _capability_execution_overrides.pop(k, None)
     logger.debug("Cleared capability overrides for guild=%d", guild_id)
+
+
+async def _audit_internal_bypass(
+    ctx: GovernanceContext,
+    capability: str,
+    subsystem_name: str,
+) -> None:
+    """Persist a DB audit row for an internal/AI-triggered execution bypass.
+
+    Internal bypasses skip the visibility gate; without a durable audit row the
+    only record is the EVT_EXECUTION_ALLOWED event (in-process, non-persistent).
+    This function writes a fact row to governance_audit_log so AI/scheduled
+    invocations remain reconstructable from the DB alone.
+
+    Best-effort: an audit failure must not prevent the legitimate execution
+    from proceeding (the bypass decision is already made).  Errors are logged
+    at WARNING and swallowed.
+    """
+    try:
+        await db.write_governance_audit(
+            guild_id=ctx.guild_id,
+            actor_id=ctx.member.id if ctx.member else 0,
+            action="execution_bypass",
+            scope_type=None,
+            scope_id=None,
+            subsystem=subsystem_name,
+            old_value=None,
+            new_value={
+                "capability": capability,
+                "subsystem": subsystem_name,
+                "reason": "internal_or_ai_invocation",
+                "visibility_check_skipped": True,
+            },
+        )
+    except Exception as exc:
+        logger.warning(
+            "internal bypass audit write failed (capability=%r guild=%d): %s",
+            capability,
+            ctx.guild_id,
+            exc,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -103,7 +172,10 @@ async def resolve_execution(
         When False (internal/AI-triggered): skip the visibility gate.
         An explicit denial in capability_execution_overrides always wins.
     """
-    if ctx.guild_id not in _loaded_guilds:
+    # Deterministic refresh: first access OR cache older than _OVERRIDE_TTL.
+    # _load_capability_overrides() clears stale rows before reloading so a
+    # refresh cannot leave drift behind.
+    if ctx.guild_id not in _loaded_guilds or _overrides_stale(ctx.guild_id):
         await _load_capability_overrides(ctx.guild_id)
         _loaded_guilds.add(ctx.guild_id)
 
@@ -163,7 +235,9 @@ async def resolve_execution(
         )
 
     # When check_visibility=False (internal/AI-triggered): skip visibility gate.
-    # The "bypass": True flag in the event payload marks this for audit trail.
+    # The "bypass": True flag in the event payload marks the event stream; the
+    # accompanying audit row makes the bypass reconstructable from the DB alone
+    # (DEBT-002 — required before AI/plugin expansion).
     if not check_visibility:
         logger.info(
             "resolve_execution: internal bypass for capability=%r subsystem=%r guild=%d",
@@ -171,6 +245,7 @@ async def resolve_execution(
             subsystem_name,
             ctx.guild_id,
         )
+        await _audit_internal_bypass(ctx, capability, subsystem_name)
         await _emit_governance_event(
             EVT_EXECUTION_ALLOWED,
             {

--- a/disbot/governance/execution.py
+++ b/disbot/governance/execution.py
@@ -62,6 +62,24 @@ def _check_capability_override(guild_id: int, capability: str) -> bool | None:
     return _capability_execution_overrides.get((guild_id, capability))
 
 
+def forget_guild_capabilities(guild_id: int) -> None:
+    """Clear all capability override state for a guild.
+
+    Called from guild_lifecycle.teardown() when the bot leaves a guild so
+    that _loaded_guilds and _capability_execution_overrides do not hold stale
+    data if the bot later rejoins the same guild.
+
+    This function is intentionally not called from governance.cache.forget_guild()
+    to avoid a backward import (cache layer must not import execution layer).
+    The guild_lifecycle module coordinates both calls in the correct order.
+    """
+    _loaded_guilds.discard(guild_id)
+    stale_keys = [k for k in _capability_execution_overrides if k[0] == guild_id]
+    for k in stale_keys:
+        _capability_execution_overrides.pop(k, None)
+    logger.debug("Cleared capability overrides for guild=%d", guild_id)
+
+
 # ---------------------------------------------------------------------------
 # Public resolve_execution
 # ---------------------------------------------------------------------------
@@ -92,15 +110,22 @@ async def resolve_execution(
     subsystem_name = CAPABILITY_TO_SUBSYSTEM.get(capability)
 
     if not subsystem_name:
+        # Unknown capabilities fail CLOSED (Phase 1.4 — ARCH-005 fix).
+        # A typo in a capability string must never silently grant access.
+        logger.warning(
+            "resolve_execution: unknown capability %r — denying (fail-closed). "
+            "Check CAPABILITY_TO_SUBSYSTEM in subsystem_registry.",
+            capability,
+        )
         return ExecutionResult(
-            allowed=True,
-            reason="Unknown capability — no governance restriction",
+            allowed=False,
+            reason="Unknown capability — denied (fail-closed)",
             trace=ExecutionTrace(
                 capability=capability,
                 checked_scopes=[],
                 matched_scope=None,
-                denied_by=None,
-                final_result=True,
+                denied_by="unknown_capability",
+                final_result=False,
             ),
         )
 
@@ -137,14 +162,22 @@ async def resolve_execution(
             ),
         )
 
-    # When check_visibility=False (internal/AI-triggered): skip visibility gate
+    # When check_visibility=False (internal/AI-triggered): skip visibility gate.
+    # The "bypass": True flag in the event payload marks this for audit trail.
     if not check_visibility:
+        logger.info(
+            "resolve_execution: internal bypass for capability=%r subsystem=%r guild=%d",
+            capability,
+            subsystem_name,
+            ctx.guild_id,
+        )
         await _emit_governance_event(
             EVT_EXECUTION_ALLOWED,
             {
                 "guild_id": ctx.guild_id,
                 "capability": capability,
                 "subsystem": subsystem_name,
+                "bypass": True,
             },
         )
         return ExecutionResult(

--- a/disbot/governance/models.py
+++ b/disbot/governance/models.py
@@ -1,6 +1,28 @@
 """Governance dataclasses, enums, and scope constants.
 
 Layer: bottom — no imports from other governance submodules.
+
+Phase 3.2 — Visibility / Execution / Exposure separation
+─────────────────────────────────────────────────────────
+The current implementation combines three logically distinct concepts.  Future
+platform evolution should separate them explicitly:
+
+  Visibility  — Should the subsystem appear in help menus and navigation UIs?
+                Resolved by resolve_visibility() via scope chain.
+
+  Execution   — May the member invoke the subsystem's commands and interactions?
+                Currently derived from visibility, but independently overridable
+                via capability_execution_overrides (resolve_execution()).
+
+  Exposure    — Should the subsystem be discoverable at all (e.g. in public
+                listings, diagnostics, or AI reasoning)?
+                Currently conflated with visibility_mode == "internal".
+
+Architectural direction: these three are intentionally unified in the current
+implementation for simplicity.  As subsystem count and permission complexity
+grow, they should be split into distinct resolution paths with independent DB
+override tables.  The GovernanceContext and resolution interfaces are already
+designed to support this split without breaking changes to callers.
 """
 
 from __future__ import annotations

--- a/disbot/governance/resolver.py
+++ b/disbot/governance/resolver.py
@@ -12,7 +12,6 @@ import logging
 from governance.cache import (
     _CACHE_LOCK,
     _FAILED_SUBSYSTEMS,
-    _NO_OVERRIDE,
     _cache_get,
     _cache_key,
     _cache_set,
@@ -278,7 +277,7 @@ async def resolve_visibility(ctx: GovernanceContext) -> VisibilityResult:
 
     async with _CACHE_LOCK:
         cached = _cache_get(cache_key)
-        if cached is not None and cached is not _NO_OVERRIDE:
+        if cached is not None:
             if _metrics:
                 _metrics.governance_cache_hits.labels(guild_id=_guild_label).inc()
             return cached

--- a/disbot/governance/templates.py
+++ b/disbot/governance/templates.py
@@ -6,10 +6,14 @@ Templates store a named set of visibility overrides that can be:
   - Stored in the DB for reuse via save_template()
 
 Public surface:
-    export_template(guild_id) → GovernanceTemplate
-    apply_template(guild_id, template) → int (overrides applied)
-    save_template(template, name, description) → int (template_id)
+    export_template(guild_id, name="", description="") → GovernanceTemplate
+    apply_template(ctx, template) → int (overrides applied via pipeline)
+    save_template(template, created_by_guild_id=None) → int (template_id)
     load_template(template_id) → GovernanceTemplate | None
+
+apply_template() routes every override through GovernanceMutationPipeline so
+authority validation, transactional audit writes, and event emission happen
+per entry — see INV-003.
 """
 
 from __future__ import annotations
@@ -105,9 +109,7 @@ async def export_template(
     return template
 
 
-async def apply_template(
-    ctx: GovernanceContext, template: GovernanceTemplate
-) -> int:
+async def apply_template(ctx: GovernanceContext, template: GovernanceTemplate) -> int:
     """Apply a template's overrides to a guild via GovernanceMutationPipeline.
 
     INV-003: every mutation routes through the pipeline.  This guarantees

--- a/disbot/governance/templates.py
+++ b/disbot/governance/templates.py
@@ -18,6 +18,8 @@ import json
 import logging
 from dataclasses import dataclass, field
 
+from governance.models import GovernanceContext
+from governance.writes import GovernanceMutationPipeline
 from utils import db
 
 logger = logging.getLogger("bot.governance.templates")
@@ -103,12 +105,28 @@ async def export_template(
     return template
 
 
-async def apply_template(guild_id: int, template: GovernanceTemplate) -> int:
-    """Apply a template's overrides to a guild. Returns number of records written."""
+async def apply_template(
+    ctx: GovernanceContext, template: GovernanceTemplate
+) -> int:
+    """Apply a template's overrides to a guild via GovernanceMutationPipeline.
+
+    INV-003: every mutation routes through the pipeline.  This guarantees
+    per-override authority validation (SEC-001), transactional DB+audit writes,
+    deterministic cache invalidation, and EVT_VISIBILITY_CHANGED /
+    EVT_CLEANUP_CHANGED / EVT_CACHE_INVALIDATED event emission for each entry.
+    A template apply with N entries produces N audit rows, one per mutation.
+
+    Returns the number of records successfully written.  Individual entries
+    that fail validation (unknown scope, unknown subsystem, insufficient
+    authority) raise the relevant GovernanceError without rolling back earlier
+    successful writes — callers wanting all-or-nothing semantics should wrap
+    this call in their own transaction boundary.
+    """
+    pipeline = GovernanceMutationPipeline()
     count = 0
     for override in template.visibility_overrides:
-        await db.set_subsystem_visibility(
-            guild_id,
+        await pipeline.set_visibility(
+            ctx,
             override["scope_type"],
             override["scope_id"],
             override["subsystem"],
@@ -117,8 +135,8 @@ async def apply_template(guild_id: int, template: GovernanceTemplate) -> int:
         count += 1
 
     for policy in template.cleanup_overrides:
-        await db.set_cleanup_policy(
-            guild_id,
+        await pipeline.set_cleanup_policy(
+            ctx,
             policy["scope_type"],
             policy["scope_id"],
             delete_invalid_commands=policy.get("delete_invalid_commands", True),
@@ -127,13 +145,10 @@ async def apply_template(guild_id: int, template: GovernanceTemplate) -> int:
         )
         count += 1
 
-    from governance.cache import invalidate_guild_cache
-
-    invalidate_guild_cache(guild_id)
     logger.info(
-        "Applied governance template %r to guild=%d: %d overrides",
+        "Applied governance template %r to guild=%d: %d overrides via pipeline",
         template.name,
-        guild_id,
+        ctx.guild_id,
         count,
     )
     return count

--- a/disbot/governance/writes.py
+++ b/disbot/governance/writes.py
@@ -37,7 +37,10 @@ from governance.events import (
     _emit_governance_event,
 )
 from governance.models import GovernanceContext
-from services.governance_exceptions import GovernanceError, UnauthorizedGovernanceWriteError
+from services.governance_exceptions import (
+    GovernanceError,
+    UnauthorizedGovernanceWriteError,
+)
 from utils import db, settings_keys
 from utils.subsystem_registry import REGISTRY_VERSION, SUBSYSTEMS
 from utils.visibility_rules import get_member_visibility_tier, is_tier_sufficient
@@ -46,7 +49,9 @@ logger = logging.getLogger("bot")
 
 # Scope types accepted by the pipeline.
 # "thread" is supported since migration 009 added it to subsystem_visibility.
-_VALID_SCOPE_TYPES: frozenset[str] = frozenset({"channel", "category", "guild", "thread"})
+_VALID_SCOPE_TYPES: frozenset[str] = frozenset(
+    {"channel", "category", "guild", "thread"}
+)
 
 # Minimum tier required to mutate governance state.
 _WRITE_AUTHORITY_TIER = "moderator"

--- a/disbot/governance/writes.py
+++ b/disbot/governance/writes.py
@@ -1,27 +1,272 @@
-"""Governance write operations — all cogs must route through here.
+"""Governance write operations — all mutations flow through GovernanceMutationPipeline.
 
 Layer: models → ... → health → writes.
 Imports from governance.models, governance.events, governance.cache.
+
+Architecture
+────────────
+All governance state changes must pass through GovernanceMutationPipeline, which
+enforces a deterministic sequence:
+
+  1. Input validation
+  2. Authority validation (SEC-001 — infrastructure boundary, not cog-level)
+  3. Read old value from DB (for full audit trail)
+  4. DB write + audit in a single transaction
+  5. In-memory cache invalidation
+  6. Event emission (EVT_VISIBILITY_CHANGED + EVT_CACHE_INVALIDATED)
+
+Ad-hoc governance writes that bypass the pipeline are prohibited.  The pipeline
+is the single orchestration point — partial or out-of-order side effects are not
+permitted.
+
+Phase 3.3 — Structured event payloads
+Each event payload includes mutation_id and occurred_at for replay-readiness.
 """
 
 from __future__ import annotations
 
 import logging
+import uuid
+from datetime import datetime, timezone
 
 from governance.cache import invalidate_guild_cache
 from governance.events import (
+    EVT_CACHE_INVALIDATED,
     EVT_CLEANUP_CHANGED,
     EVT_VISIBILITY_CHANGED,
     _emit_governance_event,
 )
 from governance.models import GovernanceContext
-from services.governance_exceptions import GovernanceError
+from services.governance_exceptions import GovernanceError, UnauthorizedGovernanceWriteError
 from utils import db, settings_keys
-from utils.subsystem_registry import REGISTRY_VERSION
+from utils.subsystem_registry import REGISTRY_VERSION, SUBSYSTEMS
+from utils.visibility_rules import get_member_visibility_tier, is_tier_sufficient
 
 logger = logging.getLogger("bot")
 
-_VALID_SCOPE_TYPES: frozenset[str] = frozenset({"channel", "category", "guild"})
+# Scope types accepted by the pipeline.
+# "thread" is supported since migration 009 added it to subsystem_visibility.
+_VALID_SCOPE_TYPES: frozenset[str] = frozenset({"channel", "category", "guild", "thread"})
+
+# Minimum tier required to mutate governance state.
+_WRITE_AUTHORITY_TIER = "moderator"
+
+
+def _validate_authority(ctx: GovernanceContext) -> None:
+    """Assert the calling member has sufficient authority for governance writes.
+
+    This is an infrastructure boundary check — it runs even if the cog layer
+    has already validated permissions.  The governance pipeline must never rely
+    solely on caller discipline.
+
+    Raises UnauthorizedGovernanceWriteError on insufficient authority.
+    """
+    if ctx.member is None:
+        raise UnauthorizedGovernanceWriteError(
+            "Governance writes require a guild member context (member is None)."
+        )
+    guild_owner_id = ctx.member.guild.owner_id if ctx.member.guild else 0
+    tier = get_member_visibility_tier(ctx.member, guild_owner_id)
+    if not is_tier_sufficient(tier, _WRITE_AUTHORITY_TIER):
+        raise UnauthorizedGovernanceWriteError(
+            f"Member {ctx.member.id!r} (tier={tier!r}) requires at least "
+            f"{_WRITE_AUTHORITY_TIER!r} to mutate governance state."
+        )
+
+
+class GovernanceMutationPipeline:
+    """Centralized orchestration for all governance state mutations.
+
+    Instances are stateless — create one per mutation request.
+
+    All public write functions (set_subsystem_visibility,
+    set_cleanup_policy_for_scope) delegate to this class so the complete
+    side-effect sequence is executed exactly once, in order, with proper
+    error handling.
+
+    Transaction model
+    ─────────────────
+    DB writes (visibility/cleanup upsert + audit log insert) occur inside a
+    single asyncpg transaction.  In-memory cache invalidation and event
+    emission happen after a successful commit.  If the commit fails, no
+    in-process state is mutated and no events are emitted.
+
+    If event emission raises after a successful commit, the DB state is correct
+    and the error is logged but not re-raised (best-effort propagation).
+    """
+
+    async def set_visibility(
+        self,
+        ctx: GovernanceContext,
+        scope_type: str,
+        scope_id: int,
+        subsystem: str,
+        enabled: bool | None,
+    ) -> None:
+        """Set a subsystem visibility override.  enabled=None clears the override.
+
+        scope_type must be one of: channel, category, guild, thread.
+        Role-scoped overrides are not yet resolvable (ISSUE-007) and are
+        explicitly rejected to prevent silent misconfiguration.
+        """
+        # 1. Validate inputs
+        if scope_type not in _VALID_SCOPE_TYPES:
+            raise GovernanceError(
+                f"Invalid scope_type {scope_type!r}. "
+                f"Must be one of: {sorted(_VALID_SCOPE_TYPES)}. "
+                "Role-scoped overrides are not yet supported."
+            )
+        if subsystem not in SUBSYSTEMS:
+            raise GovernanceError(
+                f"Unknown subsystem {subsystem!r}.  "
+                "Only registered subsystems may have visibility overrides."
+            )
+
+        # 2. Validate authority (infrastructure boundary — always enforced)
+        _validate_authority(ctx)
+
+        # 3. Read old value for full audit trail
+        old_enabled = await db.get_visibility_override(
+            ctx.guild_id, scope_type, scope_id, subsystem
+        )
+
+        mutation_id = str(uuid.uuid4())
+        occurred_at = datetime.now(tz=timezone.utc).isoformat()
+
+        # 4. DB write + audit in a single transaction
+        async with db.get().transaction():
+            await db.set_subsystem_visibility(
+                ctx.guild_id, scope_type, scope_id, subsystem, enabled
+            )
+            await db.write_governance_audit(
+                guild_id=ctx.guild_id,
+                actor_id=ctx.member.id if ctx.member else 0,
+                action="set_visibility",
+                scope_type=scope_type,
+                scope_id=scope_id,
+                subsystem=subsystem,
+                old_value={"enabled": old_enabled},
+                new_value={"enabled": enabled},
+                mutation_id=mutation_id,
+            )
+
+        # 5. In-memory cache invalidation (after successful commit)
+        invalidate_guild_cache(ctx.guild_id)
+
+        # 6. Event emission (best-effort; DB state is already correct)
+        event_payload = {
+            "guild_id": ctx.guild_id,
+            "scope_type": scope_type,
+            "scope_id": scope_id,
+            "subsystem": subsystem,
+            "enabled": enabled,
+            "mutation_id": mutation_id,
+            "occurred_at": occurred_at,
+            "actor_id": ctx.member.id if ctx.member else 0,
+        }
+        try:
+            await _emit_governance_event(EVT_VISIBILITY_CHANGED, event_payload)
+            await _emit_governance_event(
+                EVT_CACHE_INVALIDATED,
+                {
+                    "guild_id": ctx.guild_id,
+                    "mutation_id": mutation_id,
+                    "occurred_at": occurred_at,
+                },
+            )
+        except Exception as exc:
+            logger.error(
+                "Governance event emission failed after successful DB commit "
+                "(mutation_id=%s): %s",
+                mutation_id,
+                exc,
+                exc_info=True,
+            )
+
+    async def set_cleanup_policy(
+        self,
+        ctx: GovernanceContext,
+        scope_type: str,
+        scope_id: int,
+        delete_invalid_commands: bool = True,
+        delete_failed_commands: bool = True,
+        delete_after_seconds: int = 5,
+    ) -> None:
+        """Set a cleanup policy override for a scope."""
+        if scope_type not in _VALID_SCOPE_TYPES:
+            raise GovernanceError(
+                f"Invalid scope_type {scope_type!r}. "
+                f"Must be one of: {sorted(_VALID_SCOPE_TYPES)}."
+            )
+
+        _validate_authority(ctx)
+
+        mutation_id = str(uuid.uuid4())
+        occurred_at = datetime.now(tz=timezone.utc).isoformat()
+
+        async with db.get().transaction():
+            await db.set_cleanup_policy(
+                ctx.guild_id,
+                scope_type,
+                scope_id,
+                delete_invalid_commands=delete_invalid_commands,
+                delete_failed_commands=delete_failed_commands,
+                delete_after_seconds=delete_after_seconds,
+            )
+            await db.write_governance_audit(
+                guild_id=ctx.guild_id,
+                actor_id=ctx.member.id if ctx.member else 0,
+                action="set_cleanup",
+                scope_type=scope_type,
+                scope_id=scope_id,
+                subsystem=None,
+                old_value=None,
+                new_value={
+                    "delete_invalid_commands": delete_invalid_commands,
+                    "delete_failed_commands": delete_failed_commands,
+                    "delete_after_seconds": delete_after_seconds,
+                },
+                mutation_id=mutation_id,
+            )
+
+        invalidate_guild_cache(ctx.guild_id)
+
+        try:
+            await _emit_governance_event(
+                EVT_CLEANUP_CHANGED,
+                {
+                    "guild_id": ctx.guild_id,
+                    "scope_type": scope_type,
+                    "scope_id": scope_id,
+                    "mutation_id": mutation_id,
+                    "occurred_at": occurred_at,
+                    "actor_id": ctx.member.id if ctx.member else 0,
+                },
+            )
+            await _emit_governance_event(
+                EVT_CACHE_INVALIDATED,
+                {
+                    "guild_id": ctx.guild_id,
+                    "mutation_id": mutation_id,
+                    "occurred_at": occurred_at,
+                },
+            )
+        except Exception as exc:
+            logger.error(
+                "Governance event emission failed after successful DB commit "
+                "(mutation_id=%s): %s",
+                mutation_id,
+                exc,
+                exc_info=True,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience functions (thin wrappers around the pipeline)
+# Kept for backward compatibility with existing call sites.
+# ---------------------------------------------------------------------------
+
+_pipeline = GovernanceMutationPipeline()
 
 
 async def set_subsystem_visibility(
@@ -31,41 +276,8 @@ async def set_subsystem_visibility(
     subsystem: str,
     enabled: bool | None,
 ) -> None:
-    """Set a subsystem visibility override. enabled=None clears the override (inherit).
-
-    scope_type must be one of 'channel', 'category', 'guild'.
-    Role-scoped overrides are not yet resolvable (ISSUE-007) and are explicitly
-    rejected here to prevent silent misconfiguration.
-    """
-    if scope_type not in _VALID_SCOPE_TYPES:
-        raise GovernanceError(
-            f"Invalid scope_type {scope_type!r}. "
-            f"Must be one of: {sorted(_VALID_SCOPE_TYPES)}. "
-            "Role-scoped overrides are not yet supported."
-        )
-    await db.set_subsystem_visibility(
-        ctx.guild_id, scope_type, scope_id, subsystem, enabled
-    )
-    await db.write_governance_audit(
-        guild_id=ctx.guild_id,
-        actor_id=ctx.member.id if ctx.member else 0,
-        action="set_visibility",
-        scope_type=scope_type,
-        scope_id=scope_id,
-        subsystem=subsystem,
-        new_value={"enabled": enabled},
-    )
-    invalidate_guild_cache(ctx.guild_id)
-    await _emit_governance_event(
-        EVT_VISIBILITY_CHANGED,
-        {
-            "guild_id": ctx.guild_id,
-            "scope_type": scope_type,
-            "scope_id": scope_id,
-            "subsystem": subsystem,
-            "enabled": enabled,
-        },
-    )
+    """Set a subsystem visibility override.  Delegates to GovernanceMutationPipeline."""
+    await _pipeline.set_visibility(ctx, scope_type, scope_id, subsystem, enabled)
 
 
 async def set_cleanup_policy_for_scope(
@@ -76,36 +288,14 @@ async def set_cleanup_policy_for_scope(
     delete_failed_commands: bool = True,
     delete_after_seconds: int = 5,
 ) -> None:
-    """Set a cleanup policy override for a scope."""
-    await db.set_cleanup_policy(
-        ctx.guild_id,
+    """Set a cleanup policy override for a scope.  Delegates to GovernanceMutationPipeline."""
+    await _pipeline.set_cleanup_policy(
+        ctx,
         scope_type,
         scope_id,
         delete_invalid_commands=delete_invalid_commands,
         delete_failed_commands=delete_failed_commands,
         delete_after_seconds=delete_after_seconds,
-    )
-    await db.write_governance_audit(
-        guild_id=ctx.guild_id,
-        actor_id=ctx.member.id if ctx.member else 0,
-        action="set_cleanup",
-        scope_type=scope_type,
-        scope_id=scope_id,
-        subsystem=None,
-        new_value={
-            "delete_invalid_commands": delete_invalid_commands,
-            "delete_failed_commands": delete_failed_commands,
-            "delete_after_seconds": delete_after_seconds,
-        },
-    )
-    invalidate_guild_cache(ctx.guild_id)
-    await _emit_governance_event(
-        EVT_CLEANUP_CHANGED,
-        {
-            "guild_id": ctx.guild_id,
-            "scope_type": scope_type,
-            "scope_id": scope_id,
-        },
     )
 
 
@@ -125,6 +315,26 @@ async def _run_governance_upgrade(guild_id: int, from_version: int) -> None:
         from_version,
         REGISTRY_VERSION,
     )
+    # Clean up orphaned overrides for subsystems no longer in the registry.
+    known = set(SUBSYSTEMS.keys())
+    all_rows = await db.get_all_visibility_for_guild(guild_id)
+    orphans = [r for r in all_rows if r["subsystem"] not in known]
+    if orphans:
+        logger.warning(
+            "governance upgrade: removing %d orphan override(s) for guild=%d",
+            len(orphans),
+            guild_id,
+        )
+        for o in orphans:
+            await db.get().execute(
+                """DELETE FROM subsystem_visibility
+                   WHERE guild_id=$1 AND scope_type=$2 AND scope_id=$3 AND subsystem=$4""",
+                guild_id,
+                o["scope_type"],
+                o["scope_id"],
+                o["subsystem"],
+            )
+
     await db.set_setting(
         guild_id, settings_keys.GOVERNANCE_VERSION, str(REGISTRY_VERSION)
     )

--- a/disbot/guild_lifecycle.py
+++ b/disbot/guild_lifecycle.py
@@ -25,12 +25,13 @@ async def teardown(guild_id: int) -> None:
     fully initialised (all operations are no-ops on missing keys).
 
     Teardown order (high-level → low-level):
-      1. Live update scheduler — stop sending edits for the guild's channels.
-      2. Runtime sessions      — delete DB sessions + cascade session_state rows.
-      3. Session state store   — any remaining orphan state rows for the guild.
-      4. Governance capability cache — clear per-guild execution overrides.
-      5. Governance visibility cache — bump version, clear role-override flag.
-      6. Governance feedback cooldown — clear governance/__init__ rate-limit dict.
+      1. Live update scheduler  — drop _last_edit throttle entries for the guild.
+      2. Runtime sessions       — delete DB sessions + cascade session_state rows.
+      3. Session state store    — remaining orphan state rows for the guild.
+      4. Panel anchors          — delete all panel_anchors rows for the guild.
+      5. Governance capability cache — clear per-guild execution overrides.
+      6. Governance visibility cache — bump version, clear role-override flag.
+      7. Governance feedback cooldown — documented, no per-guild cleanup needed.
     """
     logger.info("guild_lifecycle.teardown: beginning cleanup for guild=%d", guild_id)
 
@@ -43,13 +44,16 @@ async def teardown(guild_id: int) -> None:
     # 3. Session state store — purge any orphan state rows not caught by cascade.
     await _teardown_session_state(guild_id)
 
-    # 4. Governance capability overrides — clear execution-layer in-process dict.
+    # 4. Panel anchors — delete all panel_anchors rows for the guild (GAP-001).
+    await _teardown_panel_anchors(guild_id)
+
+    # 5. Governance capability overrides — clear execution-layer in-process dict.
     _teardown_capability_overrides(guild_id)
 
-    # 5. Governance visibility cache — version bump + role flag removal.
+    # 6. Governance visibility cache — version bump + role flag removal.
     _teardown_visibility_cache(guild_id)
 
-    # 6. Governance feedback cooldown dict in governance/__init__.
+    # 7. Governance feedback cooldown dict in governance/__init__.
     _teardown_feedback_cooldown(guild_id)
 
     logger.info("guild_lifecycle.teardown: complete for guild=%d", guild_id)
@@ -61,26 +65,22 @@ async def teardown(guild_id: int) -> None:
 
 
 def _teardown_scheduler(guild_id: int) -> None:
-    """Remove _last_edit rate-limit entries for all channels in the guild.
+    """Drop _last_edit rate-limit entries for the departed guild.
 
-    We do not have a guild→channels mapping in memory, so we cannot enumerate
-    channels directly.  Instead, we rely on the GC / on_guild_remove pattern:
-    next time a panel refresh is attempted for a stale channel it will fail
-    gracefully.  We reset the _last_edit dict entirely if the entry count is
-    small; for large deployments the scheduled panel edits will simply produce
-    no-ops (channel not found / bot not in guild).
-
-    A future improvement: track guild_id in the scheduler's _last_edit dict
-    keyed as (guild_id, channel_id) to allow precise cleanup.
+    Always runs — no size-gated bypass (DEBT-006).  The scheduler keys
+    _last_edit by (guild_id, channel_id) so cleanup is deterministic and
+    isolated to the departed guild's channels.
     """
     try:
-        from core.runtime.live_update_scheduler import _last_edit
+        from core.runtime.live_update_scheduler import forget_guild as _sched_forget
 
-        # Purge all entries; the dict will refill only for active channels.
-        # This is safe because _last_edit is only a rate-limit hint.
-        if len(_last_edit) < 5_000:
-            _last_edit.clear()
-            logger.debug("Scheduler _last_edit cleared for guild=%d", guild_id)
+        removed = _sched_forget(guild_id)
+        if removed:
+            logger.debug(
+                "Scheduler _last_edit purged %d entries for guild=%d",
+                removed,
+                guild_id,
+            )
     except Exception as exc:
         logger.warning("guild_lifecycle: scheduler teardown failed: %s", exc)
 
@@ -110,6 +110,27 @@ async def _teardown_session_state(guild_id: int) -> None:
         await db.delete_guild_session_state(guild_id)
     except Exception as exc:
         logger.warning("guild_lifecycle: session state teardown failed: %s", exc)
+
+
+async def _teardown_panel_anchors(guild_id: int) -> None:
+    """Delete all panel_anchors rows for the departed guild (GAP-001).
+
+    Without this step, panel anchors for departed guilds accumulate
+    indefinitely in the DB.  Index idx_panel_anchors_guild (migration 013)
+    supports the DELETE.
+    """
+    try:
+        from utils import db
+
+        count = await db.delete_guild_panel_anchors(guild_id)
+        if count:
+            logger.debug(
+                "guild_lifecycle: deleted %d panel anchor(s) for guild=%d",
+                count,
+                guild_id,
+            )
+    except Exception as exc:
+        logger.warning("guild_lifecycle: panel anchor teardown failed: %s", exc)
 
 
 def _teardown_capability_overrides(guild_id: int) -> None:

--- a/disbot/guild_lifecycle.py
+++ b/disbot/guild_lifecycle.py
@@ -1,0 +1,150 @@
+"""Unified guild lifecycle management.
+
+Centralises all cleanup that must happen when the bot leaves a guild, so that
+no module accumulates permanent per-guild state indefinitely.
+
+Every module that owns guild-scoped in-process state must be represented here.
+The teardown sequence is ordered to clear higher-level state before lower-level
+dependencies (runtime before governance cache before DB-level cleanup).
+
+Public surface:
+    teardown(guild_id) → None  — call from bot1.on_guild_remove
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("bot.guild_lifecycle")
+
+
+async def teardown(guild_id: int) -> None:
+    """Purge ALL in-process and DB state owned by a guild.
+
+    Called from on_guild_remove.  Safe to call even if the guild was never
+    fully initialised (all operations are no-ops on missing keys).
+
+    Teardown order (high-level → low-level):
+      1. Live update scheduler — stop sending edits for the guild's channels.
+      2. Runtime sessions      — delete DB sessions + cascade session_state rows.
+      3. Session state store   — any remaining orphan state rows for the guild.
+      4. Governance capability cache — clear per-guild execution overrides.
+      5. Governance visibility cache — bump version, clear role-override flag.
+      6. Governance feedback cooldown — clear governance/__init__ rate-limit dict.
+    """
+    logger.info("guild_lifecycle.teardown: beginning cleanup for guild=%d", guild_id)
+
+    # 1. Live update scheduler — remove _last_edit throttle entries for the guild.
+    _teardown_scheduler(guild_id)
+
+    # 2. Runtime sessions — delete from DB (cascades to runtime_session_state).
+    await _teardown_sessions(guild_id)
+
+    # 3. Session state store — purge any orphan state rows not caught by cascade.
+    await _teardown_session_state(guild_id)
+
+    # 4. Governance capability overrides — clear execution-layer in-process dict.
+    _teardown_capability_overrides(guild_id)
+
+    # 5. Governance visibility cache — version bump + role flag removal.
+    _teardown_visibility_cache(guild_id)
+
+    # 6. Governance feedback cooldown dict in governance/__init__.
+    _teardown_feedback_cooldown(guild_id)
+
+    logger.info("guild_lifecycle.teardown: complete for guild=%d", guild_id)
+
+
+# ---------------------------------------------------------------------------
+# Individual teardown steps
+# ---------------------------------------------------------------------------
+
+
+def _teardown_scheduler(guild_id: int) -> None:
+    """Remove _last_edit rate-limit entries for all channels in the guild.
+
+    We do not have a guild→channels mapping in memory, so we cannot enumerate
+    channels directly.  Instead, we rely on the GC / on_guild_remove pattern:
+    next time a panel refresh is attempted for a stale channel it will fail
+    gracefully.  We reset the _last_edit dict entirely if the entry count is
+    small; for large deployments the scheduled panel edits will simply produce
+    no-ops (channel not found / bot not in guild).
+
+    A future improvement: track guild_id in the scheduler's _last_edit dict
+    keyed as (guild_id, channel_id) to allow precise cleanup.
+    """
+    try:
+        from core.runtime.live_update_scheduler import _last_edit
+
+        # Purge all entries; the dict will refill only for active channels.
+        # This is safe because _last_edit is only a rate-limit hint.
+        if len(_last_edit) < 5_000:
+            _last_edit.clear()
+            logger.debug("Scheduler _last_edit cleared for guild=%d", guild_id)
+    except Exception as exc:
+        logger.warning("guild_lifecycle: scheduler teardown failed: %s", exc)
+
+
+async def _teardown_sessions(guild_id: int) -> None:
+    """Delete all runtime sessions for the guild from the DB."""
+    try:
+        from utils import db
+
+        result = await db.get().execute(
+            "DELETE FROM runtime_sessions WHERE guild_id = $1", guild_id
+        )
+        count = _parse_pg_count(result)
+        if count:
+            logger.debug(
+                "guild_lifecycle: deleted %d session(s) for guild=%d", count, guild_id
+            )
+    except Exception as exc:
+        logger.warning("guild_lifecycle: session teardown failed: %s", exc)
+
+
+async def _teardown_session_state(guild_id: int) -> None:
+    """Purge orphan session state rows for the guild."""
+    try:
+        from utils import db
+
+        await db.delete_guild_session_state(guild_id)
+    except Exception as exc:
+        logger.warning("guild_lifecycle: session state teardown failed: %s", exc)
+
+
+def _teardown_capability_overrides(guild_id: int) -> None:
+    """Clear execution-layer capability override cache for the guild."""
+    try:
+        from governance.execution import forget_guild_capabilities
+
+        forget_guild_capabilities(guild_id)
+    except Exception as exc:
+        logger.warning("guild_lifecycle: capability override teardown failed: %s", exc)
+
+
+def _teardown_visibility_cache(guild_id: int) -> None:
+    """Clear governance visibility cache for the guild."""
+    try:
+        from governance.cache import forget_guild
+
+        forget_guild(guild_id)
+    except Exception as exc:
+        logger.warning("guild_lifecycle: visibility cache teardown failed: %s", exc)
+
+
+def _teardown_feedback_cooldown(guild_id: int) -> None:
+    """Clear governance command-feedback rate-limit entries for the guild.
+
+    governance/__init__._FEEDBACK_COOLDOWN is keyed by (channel_id, subsystem).
+    We cannot enumerate guild→channel IDs here so we skip targeted cleanup;
+    entries expire naturally after _FEEDBACK_COOLDOWN_SECS (10 s).
+    The dict's own size guard (>500 entries → purge expired) handles unbounded
+    growth without per-guild teardown.
+    """
+
+
+def _parse_pg_count(result: str) -> int:
+    try:
+        return int(result.split()[-1])
+    except (IndexError, ValueError):
+        return 0

--- a/disbot/migrations/012_fix_session_state_encoding.sql
+++ b/disbot/migrations/012_fix_session_state_encoding.sql
@@ -1,0 +1,27 @@
+-- Migration 012: Repair double-encoded JSONB values.
+--
+-- Prior to the BUG-001 fix, db.set_session_state() and db.write_governance_audit()
+-- manually called json.dumps() before handing values to asyncpg.  asyncpg then
+-- applied the registered JSONB codec (also json.dumps), resulting in values stored as
+-- JSON strings wrapping JSON objects: '"{\\"key\\":\\"val\\"}"' instead of '{"key":"val"}'.
+--
+-- This migration re-parses those string values into proper JSONB objects.
+-- It is idempotent: rows already storing valid JSONB objects have
+-- jsonb_typeof(value) != 'string' and are left completely untouched.
+
+-- Repair runtime_session_state
+UPDATE runtime_session_state
+SET value = value::text::jsonb
+WHERE jsonb_typeof(value) = 'string';
+
+-- Repair governance_audit_log new_value column
+UPDATE governance_audit_log
+SET new_value = new_value::text::jsonb
+WHERE new_value IS NOT NULL
+  AND jsonb_typeof(new_value) = 'string';
+
+-- Repair governance_audit_log old_value column
+UPDATE governance_audit_log
+SET old_value = old_value::text::jsonb
+WHERE old_value IS NOT NULL
+  AND jsonb_typeof(old_value) = 'string';

--- a/disbot/migrations/013_governance_indexes.sql
+++ b/disbot/migrations/013_governance_indexes.sql
@@ -1,0 +1,19 @@
+-- Migration 013: Governance audit and panel anchor index improvements.
+--
+-- Adds query-pattern indexes for future admin dashboards and audit tools:
+--   "what did actor X change?"  → idx_governance_audit_actor
+--   "what changed for subsystem Y?" → idx_governance_audit_subsystem
+--   "fetch active anchors for guild" → idx_panel_anchors_guild
+
+CREATE INDEX IF NOT EXISTS idx_governance_audit_actor
+    ON governance_audit_log (guild_id, actor_id, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_governance_audit_subsystem
+    ON governance_audit_log (guild_id, subsystem, occurred_at DESC)
+    WHERE subsystem IS NOT NULL;
+
+-- Supports db.get_user_subsystem_anchors() which filters by guild_id + subsystem
+-- in addition to the existing UNIQUE(user_id, channel_id, subsystem) index.
+CREATE INDEX IF NOT EXISTS idx_panel_anchors_guild
+    ON panel_anchors (guild_id, subsystem)
+    WHERE NOT is_stale;

--- a/disbot/services/governance_exceptions.py
+++ b/disbot/services/governance_exceptions.py
@@ -31,3 +31,12 @@ class CapabilityNamespaceError(RegistryValidationError):
 
 class GovernanceUpgradeError(GovernanceError):
     """Governance schema version upgrade failed."""
+
+
+class UnauthorizedGovernanceWriteError(GovernanceError):
+    """Caller lacks the authority tier required to mutate governance state.
+
+    Governance writes are an infrastructure boundary: even if the cog layer
+    has already validated the user's Discord permissions, the governance
+    pipeline re-validates to prevent authority escalation from coding mistakes.
+    """

--- a/disbot/utils/db.py
+++ b/disbot/utils/db.py
@@ -901,6 +901,29 @@ async def get_all_visibility_for_guild(guild_id: int):
     )
 
 
+async def get_visibility_override(
+    guild_id: int,
+    scope_type: str,
+    scope_id: int,
+    subsystem: str,
+) -> bool | None:
+    """Return the current enabled value for a specific visibility override, or None.
+
+    Used by GovernanceMutationPipeline to read the old value before writing,
+    so the governance audit log captures both before and after state.
+    """
+    row = await get().fetchrow(
+        """SELECT enabled FROM subsystem_visibility
+           WHERE guild_id = $1 AND scope_type = $2
+             AND scope_id = $3 AND subsystem = $4""",
+        guild_id,
+        scope_type,
+        scope_id,
+        subsystem,
+    )
+    return bool(row["enabled"]) if row is not None and row["enabled"] is not None else None
+
+
 async def set_subsystem_visibility(
     guild_id: int,
     scope_type: str,
@@ -1050,6 +1073,57 @@ async def delete_sessions_for_subsystem(guild_id: int, subsystem: str) -> list[s
     return [r["session_id"] for r in rows]
 
 
+async def delete_sessions_for_scope(
+    guild_id: int,
+    subsystem: str,
+    channel_id: int | None = None,
+) -> list[str]:
+    """Delete sessions for a subsystem, optionally scoped to a specific channel.
+
+    Used for scope-aware invalidation: a channel-scoped governance change
+    should only invalidate sessions in that channel, not guild-wide.
+    Falls back to guild-wide deletion when channel_id is None.
+
+    Returns the list of deleted session_ids.
+    """
+    if channel_id is not None:
+        rows = await get().fetch(
+            """DELETE FROM runtime_sessions
+               WHERE guild_id = $1 AND subsystem = $2 AND channel_id = $3
+               RETURNING session_id::text""",
+            guild_id,
+            subsystem,
+            channel_id,
+        )
+    else:
+        rows = await get().fetch(
+            """DELETE FROM runtime_sessions
+               WHERE guild_id = $1 AND subsystem = $2
+               RETURNING session_id::text""",
+            guild_id,
+            subsystem,
+        )
+    return [r["session_id"] for r in rows]
+
+
+def _maybe_decode_legacy(value: object) -> object:
+    """Transparently decode double-encoded legacy session state values.
+
+    Before migration 012 was applied, set_session_state() manually called
+    json.dumps() before asyncpg, so JSONB rows contain a JSON string wrapping
+    the real payload.  After the migration repairs existing rows this shim is
+    a no-op (asyncpg decodes JSONB objects directly into Python dicts).
+    """
+    if isinstance(value, str):
+        try:
+            import json as _json
+
+            return _json.loads(value)
+        except (ValueError, TypeError):
+            return value
+    return value
+
+
 async def get_session_state(session_id: str, key: str) -> object | None:
     """Read a single typed value from session state (returns Python object or None)."""
     row = await get().fetchrow(
@@ -1057,20 +1131,18 @@ async def get_session_state(session_id: str, key: str) -> object | None:
         session_id,
         key,
     )
-    return row["value"] if row else None
+    return _maybe_decode_legacy(row["value"]) if row else None
 
 
 async def set_session_state(session_id: str, key: str, value: object) -> None:
     """Write a single typed value to session state (upsert)."""
-    import json as _json
-
     await get().execute(
         """INSERT INTO runtime_session_state (session_id, key, value)
            VALUES ($1, $2, $3)
            ON CONFLICT (session_id, key) DO UPDATE SET value = EXCLUDED.value""",
         session_id,
         key,
-        _json.dumps(value),
+        value,  # asyncpg JSONB codec handles encoding via _init_conn
     )
 
 
@@ -1089,7 +1161,7 @@ async def get_all_session_state(session_id: str) -> dict:
         "SELECT key, value FROM runtime_session_state WHERE session_id = $1",
         session_id,
     )
-    return {r["key"]: r["value"] for r in rows}
+    return {r["key"]: _maybe_decode_legacy(r["value"]) for r in rows}
 
 
 async def delete_guild_session_state(guild_id: int) -> None:
@@ -1112,10 +1184,9 @@ async def write_governance_audit(
     subsystem: str | None,
     new_value: dict | None,
     old_value: dict | None = None,
+    mutation_id: str | None = None,
 ) -> None:
     """Append a row to governance_audit_log (fire-and-forget; non-blocking)."""
-    import json as _json
-
     await get().execute(
         """INSERT INTO governance_audit_log
                (guild_id, actor_id, action, scope_type, scope_id,
@@ -1127,8 +1198,8 @@ async def write_governance_audit(
         scope_type,
         scope_id,
         subsystem,
-        _json.dumps(old_value) if old_value is not None else None,
-        _json.dumps(new_value) if new_value is not None else None,
+        old_value,   # asyncpg JSONB codec handles encoding via _init_conn
+        new_value,   # asyncpg JSONB codec handles encoding via _init_conn
     )
 
 

--- a/disbot/utils/db.py
+++ b/disbot/utils/db.py
@@ -921,7 +921,9 @@ async def get_visibility_override(
         scope_id,
         subsystem,
     )
-    return bool(row["enabled"]) if row is not None and row["enabled"] is not None else None
+    return (
+        bool(row["enabled"]) if row is not None and row["enabled"] is not None else None
+    )
 
 
 async def set_subsystem_visibility(
@@ -1198,8 +1200,8 @@ async def write_governance_audit(
         scope_type,
         scope_id,
         subsystem,
-        old_value,   # asyncpg JSONB codec handles encoding via _init_conn
-        new_value,   # asyncpg JSONB codec handles encoding via _init_conn
+        old_value,  # asyncpg JSONB codec handles encoding via _init_conn
+        new_value,  # asyncpg JSONB codec handles encoding via _init_conn
     )
 
 

--- a/disbot/utils/db.py
+++ b/disbot/utils/db.py
@@ -1287,6 +1287,21 @@ async def delete_stale_panel_anchors() -> int:
         return 0
 
 
+async def delete_guild_panel_anchors(guild_id: int) -> int:
+    """Delete every panel anchor for a guild. Returns count removed.
+
+    Called from guild_lifecycle.teardown() so departed guilds leave no orphan
+    rows in panel_anchors.  Index on (guild_id, subsystem) supports this query.
+    """
+    result = await get().execute(
+        "DELETE FROM panel_anchors WHERE guild_id = $1", guild_id
+    )
+    try:
+        return int(result.split()[-1])
+    except (IndexError, ValueError):
+        return 0
+
+
 async def get_user_subsystem_anchors(
     user_id: int, guild_id: int, subsystem: str
 ) -> list[dict]:

--- a/disbot/utils/subsystem_registry.py
+++ b/disbot/utils/subsystem_registry.py
@@ -408,7 +408,7 @@ SUBSYSTEMS: dict[str, dict] = {
         "visibility_mode": "normal",
         "category": "moderation",
         "tags": ["proof", "events", "access"],
-        "entry_points": ["prize"],
+        "entry_points": ["prizemenu", "prizestatus", "timedprize"],
         "default_channels": ["staff", "proof"],
         "related_subsystems": ["moderation"],
         "dependencies": [],

--- a/tests/unit/governance/test_bug_fixes.py
+++ b/tests/unit/governance/test_bug_fixes.py
@@ -19,7 +19,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # BUG-001 — double JSON encoding shim
 # ---------------------------------------------------------------------------
@@ -400,8 +399,8 @@ class TestCapabilityOverrideTTL:
         import time as _time
 
         from governance.execution import (
-            _loaded_guilds_at,
             _OVERRIDE_TTL,
+            _loaded_guilds_at,
             _overrides_stale,
         )
 

--- a/tests/unit/governance/test_bug_fixes.py
+++ b/tests/unit/governance/test_bug_fixes.py
@@ -1,0 +1,304 @@
+"""Regression tests for confirmed bug fixes.
+
+Covers:
+  BUG-001  double JSON encoding in session state and audit log
+  BUG-002  EVT_CACHE_INVALIDATED emission from mutation pipeline
+  BUG-003  thread scope writes accepted
+  BUG-004  capability overrides cleared on guild forget
+  BUG-005  runtime.setup() idempotency
+  BUG-006  _NO_OVERRIDE sentinel removed from cache
+  BUG-007  check_existing_instance not called at module level
+  BUG-008  error logging before channel guard return
+  ARCH-005 unknown capability fails closed
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# BUG-001 — double JSON encoding shim
+# ---------------------------------------------------------------------------
+
+
+class TestMaybeDecodeLegacy:
+    """_maybe_decode_legacy must transparently decode double-encoded values."""
+
+    def test_dict_passthrough(self):
+        from utils.db import _maybe_decode_legacy
+
+        value = {"key": "val", "nested": [1, 2]}
+        assert _maybe_decode_legacy(value) == value
+
+    def test_string_decoded(self):
+        from utils.db import _maybe_decode_legacy
+
+        # A double-encoded value stored as a JSON string
+        assert _maybe_decode_legacy('{"key": "val"}') == {"key": "val"}
+
+    def test_array_decoded(self):
+        from utils.db import _maybe_decode_legacy
+
+        assert _maybe_decode_legacy("[1, 2, 3]") == [1, 2, 3]
+
+    def test_non_json_string_passthrough(self):
+        from utils.db import _maybe_decode_legacy
+
+        assert _maybe_decode_legacy("not-json") == "not-json"
+
+    def test_int_passthrough(self):
+        from utils.db import _maybe_decode_legacy
+
+        assert _maybe_decode_legacy(42) == 42
+
+    def test_none_passthrough(self):
+        from utils.db import _maybe_decode_legacy
+
+        assert _maybe_decode_legacy(None) is None
+
+
+# ---------------------------------------------------------------------------
+# BUG-003 — thread scope write accepted
+# ---------------------------------------------------------------------------
+
+
+class TestThreadScopeAccepted:
+    """set_subsystem_visibility must accept scope_type='thread'."""
+
+    @pytest.mark.asyncio
+    async def test_thread_scope_not_rejected(self):
+        from governance.writes import _VALID_SCOPE_TYPES
+
+        assert "thread" in _VALID_SCOPE_TYPES, (
+            "Thread scope must be in _VALID_SCOPE_TYPES — "
+            "migration 009 added DB support for it."
+        )
+
+    @pytest.mark.asyncio
+    async def test_role_scope_still_rejected(self):
+        from governance.writes import _VALID_SCOPE_TYPES
+
+        assert "role" not in _VALID_SCOPE_TYPES, "Role scope is not yet supported."
+
+
+# ---------------------------------------------------------------------------
+# BUG-004 — capability overrides cleared on guild forget
+# ---------------------------------------------------------------------------
+
+
+class TestForgetGuildCapabilities:
+    def test_forget_clears_overrides(self):
+        from governance.execution import (
+            _capability_execution_overrides,
+            _loaded_guilds,
+            forget_guild_capabilities,
+        )
+
+        guild_id = 99999
+        _capability_execution_overrides[(guild_id, "test.cap.do")] = True
+        _loaded_guilds.add(guild_id)
+
+        forget_guild_capabilities(guild_id)
+
+        assert guild_id not in _loaded_guilds
+        assert (guild_id, "test.cap.do") not in _capability_execution_overrides
+
+    def test_forget_other_guilds_unaffected(self):
+        from governance.execution import (
+            _capability_execution_overrides,
+            _loaded_guilds,
+            forget_guild_capabilities,
+        )
+
+        guild_a, guild_b = 11111, 22222
+        _capability_execution_overrides[(guild_a, "test.x.y")] = True
+        _capability_execution_overrides[(guild_b, "test.x.y")] = False
+        _loaded_guilds.add(guild_a)
+        _loaded_guilds.add(guild_b)
+
+        forget_guild_capabilities(guild_a)
+
+        assert guild_a not in _loaded_guilds
+        assert (guild_a, "test.x.y") not in _capability_execution_overrides
+        # Guild B must be completely untouched
+        assert guild_b in _loaded_guilds
+        assert (guild_b, "test.x.y") in _capability_execution_overrides
+
+        # Cleanup
+        _loaded_guilds.discard(guild_b)
+        _capability_execution_overrides.pop((guild_b, "test.x.y"), None)
+
+
+# ---------------------------------------------------------------------------
+# BUG-005 — setup() idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestSetupIdempotency:
+    @pytest.mark.asyncio
+    async def test_double_setup_registers_one_handler_per_event(self):
+        import importlib
+
+        # Re-import a clean copy of the module to test against.
+        import core.runtime as rt
+
+        # Reset the guard for testing purposes
+        rt._SETUP_DONE = False
+
+        mock_bus = MagicMock()
+        mock_bus.on = MagicMock()
+
+        with patch("core.events.bus", mock_bus):
+            with patch("services.governance_service.EVT_VISIBILITY_CHANGED", "vis"):
+                with patch("services.governance_service.EVT_CACHE_INVALIDATED", "inv"):
+                    await rt.setup()
+                    first_call_count = mock_bus.on.call_count
+
+                    await rt.setup()  # second call — must be a no-op
+                    second_call_count = mock_bus.on.call_count
+
+        assert first_call_count == second_call_count, (
+            f"setup() called bus.on {second_call_count} times on second invocation; "
+            "expected 0 (idempotency violation)."
+        )
+
+        # Reset for other tests
+        rt._SETUP_DONE = False
+
+
+# ---------------------------------------------------------------------------
+# BUG-006 — _NO_OVERRIDE sentinel removed
+# ---------------------------------------------------------------------------
+
+
+class TestNoOverrideSentinelRemoved:
+    def test_no_override_not_exported(self):
+        import governance.cache as cache_module
+
+        assert not hasattr(cache_module, "_NO_OVERRIDE"), (
+            "_NO_OVERRIDE was removed as dead code — it should not exist in cache.py"
+        )
+
+    def test_resolver_does_not_import_no_override(self):
+        import inspect
+
+        import governance.resolver as resolver_module
+
+        source = inspect.getsource(resolver_module)
+        assert "_NO_OVERRIDE" not in source, (
+            "resolver.py must not reference the removed _NO_OVERRIDE sentinel"
+        )
+
+
+# ---------------------------------------------------------------------------
+# ARCH-005 — unknown capabilities fail closed
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownCapabilityFailsClosed:
+    @pytest.mark.asyncio
+    async def test_unknown_capability_denied(self):
+        from governance.execution import resolve_execution
+        from governance.models import GovernanceContext
+
+        ctx = GovernanceContext(guild_id=1, channel_id=1)
+
+        # Patch _load_capability_overrides to no-op and CAPABILITY_TO_SUBSYSTEM
+        # to return nothing for a made-up capability.
+        with patch("governance.execution._loaded_guilds", {1}):
+            with patch(
+                "governance.execution.CAPABILITY_TO_SUBSYSTEM",
+                {},  # empty — capability is unknown
+            ):
+                result = await resolve_execution(ctx, "totally.fake.capability")
+
+        assert result.allowed is False
+        assert "unknown" in (result.reason or "").lower()
+
+    @pytest.mark.asyncio
+    async def test_known_capability_uses_visibility(self):
+        """A known capability is gated on visibility (not unconditionally allowed)."""
+        from governance.execution import resolve_execution
+        from governance.models import GovernanceContext, VisibilityResult
+
+        ctx = GovernanceContext(guild_id=2, channel_id=2)
+
+        mock_visibility = VisibilityResult(
+            visible_subsystems=set(),  # everything disabled
+            member_tier="user",
+            resolved_from={},
+            traces={},
+        )
+
+        with patch("governance.execution._loaded_guilds", {2}):
+            with patch(
+                "governance.execution.CAPABILITY_TO_SUBSYSTEM",
+                {"economy.coins.claim": "economy"},
+            ):
+                with patch(
+                    "governance.execution.resolve_visibility",
+                    AsyncMock(return_value=mock_visibility),
+                ):
+                    result = await resolve_execution(ctx, "economy.coins.claim")
+
+        assert result.allowed is False
+
+
+# ---------------------------------------------------------------------------
+# BUG-002 — EVT_CACHE_INVALIDATED is emitted (via mutation pipeline)
+# ---------------------------------------------------------------------------
+
+
+class TestCacheInvalidatedEmitted:
+    @pytest.mark.asyncio
+    async def test_set_visibility_emits_cache_invalidated(self):
+        from governance.models import GovernanceContext
+
+        # Build a mock member with sufficient authority
+        member = MagicMock()
+        member.id = 1
+        member.guild_permissions.administrator = True
+        member.guild_permissions.moderate_members = True
+        member.guild.owner_id = 0
+        member.guild_permissions.manage_guild = True
+
+        ctx = GovernanceContext(
+            guild_id=777, channel_id=1, member=member
+        )
+
+        emitted_events: list[str] = []
+
+        async def mock_emit(event_name, payload):
+            emitted_events.append(event_name)
+
+        with patch("governance.writes.db") as mock_db:
+            mock_db.get_visibility_override = AsyncMock(return_value=None)
+            mock_db.set_subsystem_visibility = AsyncMock()
+            mock_db.write_governance_audit = AsyncMock()
+            # Simulate transaction context manager
+            txn = MagicMock()
+            txn.__aenter__ = AsyncMock(return_value=txn)
+            txn.__aexit__ = AsyncMock(return_value=False)
+            mock_pool = MagicMock()
+            mock_pool.transaction = MagicMock(return_value=txn)
+            mock_db.get = MagicMock(return_value=mock_pool)
+            with patch("governance.writes.invalidate_guild_cache"):
+                with patch("governance.writes._emit_governance_event", side_effect=mock_emit):
+                    with patch("governance.writes.SUBSYSTEMS", {"economy": {}}):
+                        from governance.writes import GovernanceMutationPipeline
+
+                        pipeline = GovernanceMutationPipeline()
+                        await pipeline.set_visibility(ctx, "guild", 777, "economy", False)
+
+        from governance.events import EVT_CACHE_INVALIDATED, EVT_VISIBILITY_CHANGED
+
+        assert EVT_VISIBILITY_CHANGED in emitted_events, (
+            "EVT_VISIBILITY_CHANGED must be emitted from set_visibility"
+        )
+        assert EVT_CACHE_INVALIDATED in emitted_events, (
+            "EVT_CACHE_INVALIDATED must be emitted from set_visibility (BUG-002 fix)"
+        )

--- a/tests/unit/governance/test_bug_fixes.py
+++ b/tests/unit/governance/test_bug_fixes.py
@@ -302,3 +302,245 @@ class TestCacheInvalidatedEmitted:
         assert EVT_CACHE_INVALIDATED in emitted_events, (
             "EVT_CACHE_INVALIDATED must be emitted from set_visibility (BUG-002 fix)"
         )
+
+
+# ---------------------------------------------------------------------------
+# GAP-001 — panel anchors deleted from DB on guild teardown
+# ---------------------------------------------------------------------------
+
+
+class TestPanelAnchorTeardown:
+    @pytest.mark.asyncio
+    async def test_guild_lifecycle_deletes_panel_anchors(self):
+        """guild_lifecycle.teardown() must call db.delete_guild_panel_anchors."""
+        import guild_lifecycle
+
+        guild_id = 4242
+        with patch("utils.db.delete_guild_panel_anchors", new_callable=AsyncMock) as mock_del:
+            mock_del.return_value = 3
+            # Patch the other DB-touching steps so we isolate the anchor path.
+            with patch("utils.db.get") as mock_get:
+                pool = MagicMock()
+                pool.execute = AsyncMock(return_value="DELETE 0")
+                mock_get.return_value = pool
+                with patch(
+                    "utils.db.delete_guild_session_state", new_callable=AsyncMock
+                ):
+                    await guild_lifecycle.teardown(guild_id)
+
+            mock_del.assert_awaited_once_with(guild_id)
+
+    def test_db_function_signature(self):
+        from utils import db as db_module
+
+        assert hasattr(db_module, "delete_guild_panel_anchors"), (
+            "db.delete_guild_panel_anchors must exist (GAP-001)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# DEBT-001 — capability override cache has a TTL refresh
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilityOverrideTTL:
+    @pytest.mark.asyncio
+    async def test_stale_cache_triggers_reload(self, monkeypatch):
+        """Once _OVERRIDE_TTL elapses, the next resolve_execution reloads."""
+        import time as _time
+
+        from governance import execution as exec_module
+        from governance.models import GovernanceContext
+
+        exec_module._loaded_guilds.add(5555)
+        exec_module._loaded_guilds_at[5555] = _time.monotonic() - 9999.0  # stale
+        exec_module._capability_execution_overrides[(5555, "test.cap.do")] = True
+
+        load_calls: list[int] = []
+
+        async def fake_load(guild_id: int) -> None:
+            load_calls.append(guild_id)
+            # Simulate DB returning nothing (clears prior entry).
+            exec_module._loaded_guilds_at[guild_id] = _time.monotonic()
+
+        monkeypatch.setattr(exec_module, "_load_capability_overrides", fake_load)
+        monkeypatch.setattr(
+            exec_module,
+            "CAPABILITY_TO_SUBSYSTEM",
+            {"test.cap.do": "test_subsystem"},
+        )
+        monkeypatch.setattr(
+            exec_module,
+            "resolve_visibility",
+            AsyncMock(
+                return_value=type(
+                    "V",
+                    (),
+                    {
+                        "visible_subsystems": {"test_subsystem"},
+                        "traces": {},
+                    },
+                )()
+            ),
+        )
+
+        # Prior override existed, but a refresh is forced because cache is stale.
+        await exec_module.resolve_execution(
+            GovernanceContext(guild_id=5555, channel_id=1),
+            "test.cap.do",
+        )
+        assert load_calls == [5555], "stale cache must trigger a reload"
+
+        # Cleanup
+        exec_module._loaded_guilds.discard(5555)
+        exec_module._loaded_guilds_at.pop(5555, None)
+        exec_module._capability_execution_overrides.pop((5555, "test.cap.do"), None)
+
+    def test_overrides_stale_detection(self):
+        import time as _time
+
+        from governance.execution import (
+            _loaded_guilds_at,
+            _OVERRIDE_TTL,
+            _overrides_stale,
+        )
+
+        _loaded_guilds_at[7777] = _time.monotonic()
+        assert not _overrides_stale(7777)
+        _loaded_guilds_at[7777] = _time.monotonic() - (_OVERRIDE_TTL + 1.0)
+        assert _overrides_stale(7777)
+        # Cleanup
+        _loaded_guilds_at.pop(7777, None)
+
+    def test_load_clears_prior_entries(self):
+        """_load_capability_overrides must purge stale rows before reloading."""
+        import inspect
+
+        from governance import execution as exec_module
+
+        source = inspect.getsource(exec_module._load_capability_overrides)
+        assert "stale_keys" in source or "pop" in source, (
+            "_load_capability_overrides must clear prior entries before insert"
+        )
+
+
+# ---------------------------------------------------------------------------
+# DEBT-002 — internal bypass persists a DB audit row
+# ---------------------------------------------------------------------------
+
+
+class TestInternalBypassAudit:
+    @pytest.mark.asyncio
+    async def test_bypass_writes_audit_row(self, monkeypatch):
+        from governance import execution as exec_module
+        from governance.models import GovernanceContext
+
+        # Ensure the guild's overrides skip the DB load path.
+        exec_module._loaded_guilds.add(8888)
+        import time as _time
+
+        exec_module._loaded_guilds_at[8888] = _time.monotonic()
+
+        captured: dict = {}
+
+        async def fake_audit(**kwargs):
+            captured.update(kwargs)
+
+        monkeypatch.setattr("utils.db.write_governance_audit", fake_audit)
+        monkeypatch.setattr(
+            exec_module,
+            "CAPABILITY_TO_SUBSYSTEM",
+            {"moderation.member.ban": "moderation"},
+        )
+
+        result = await exec_module.resolve_execution(
+            GovernanceContext(guild_id=8888, channel_id=1),
+            "moderation.member.ban",
+            check_visibility=False,
+        )
+
+        assert result.allowed is True
+        assert captured.get("action") == "execution_bypass"
+        assert captured.get("guild_id") == 8888
+        assert captured.get("subsystem") == "moderation"
+        nv = captured.get("new_value") or {}
+        assert nv.get("capability") == "moderation.member.ban"
+        assert nv.get("visibility_check_skipped") is True
+
+        # Cleanup
+        exec_module._loaded_guilds.discard(8888)
+        exec_module._loaded_guilds_at.pop(8888, None)
+
+
+# ---------------------------------------------------------------------------
+# DEBT-003 — runtime subscribes to EVT_CLEANUP_CHANGED
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupChangedSubscription:
+    @pytest.mark.asyncio
+    async def test_setup_subscribes_to_cleanup_changed(self):
+        import core.runtime as rt
+
+        rt._SETUP_DONE = False
+        mock_bus = MagicMock()
+        mock_bus.on = MagicMock()
+
+        subscribed_events: list[str] = []
+
+        def capture_on(event_name, handler):
+            subscribed_events.append(event_name)
+
+        mock_bus.on.side_effect = capture_on
+
+        with patch("core.events.bus", mock_bus):
+            with patch("services.governance_service.EVT_VISIBILITY_CHANGED", "vis"):
+                with patch("services.governance_service.EVT_CACHE_INVALIDATED", "inv"):
+                    with patch(
+                        "services.governance_service.EVT_CLEANUP_CHANGED", "cleanup"
+                    ):
+                        await rt.setup()
+
+        assert "cleanup" in subscribed_events, (
+            "runtime.setup() must subscribe to EVT_CLEANUP_CHANGED (DEBT-003)"
+        )
+        rt._SETUP_DONE = False
+
+
+# ---------------------------------------------------------------------------
+# DEBT-006 — _last_edit cleanup is unconditional and per-guild
+# ---------------------------------------------------------------------------
+
+
+class TestLastEditTeardown:
+    def test_keying_is_guild_scoped(self):
+        from core.runtime import live_update_scheduler as sched
+
+        sched._last_edit[(111, 1001)] = 1.0
+        sched._last_edit[(111, 1002)] = 2.0
+        sched._last_edit[(222, 2001)] = 3.0
+
+        removed = sched.forget_guild(111)
+
+        assert removed == 2
+        assert (111, 1001) not in sched._last_edit
+        assert (111, 1002) not in sched._last_edit
+        # Guild 222 untouched.
+        assert (222, 2001) in sched._last_edit
+
+        # Cleanup
+        sched._last_edit.pop((222, 2001), None)
+
+    def test_no_size_gate_in_teardown(self):
+        """Cleanup must always run regardless of dict size (DEBT-006)."""
+        import inspect
+
+        import guild_lifecycle
+
+        src = inspect.getsource(guild_lifecycle._teardown_scheduler)
+        assert "5_000" not in src and "5000" not in src, (
+            "guild_lifecycle._teardown_scheduler must not size-gate cleanup"
+        )
+        assert "_sched_forget" in src or "forget_guild" in src, (
+            "_teardown_scheduler must call scheduler.forget_guild(guild_id)"
+        )

--- a/tests/unit/help/test_help_navigation.py
+++ b/tests/unit/help/test_help_navigation.py
@@ -1,0 +1,223 @@
+"""Regression tests for help menu direct navigation and the General cog fix.
+
+Covers:
+  - Every subsystem entry_point declared in SUBSYSTEMS must be defined as a
+    @commands.command(name=...) somewhere under disbot/cogs/ (prevents a recurrence
+    of the General cog `generalmenu` mismatch that hid General from the help menu).
+  - General cog exposes generalmenu and build_help_menu_view for direct navigation.
+  - help_cog._on_select dispatches to build_help_menu_view when present.
+  - help_cog still falls back to inline cog embed when build_help_menu_view is absent.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_DISBOT = Path(__file__).parents[3] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+from utils.subsystem_registry import SUBSYSTEMS  # noqa: E402
+
+_COGS_DIR = _DISBOT / "cogs"
+
+
+def _commands_declared_in_cogs() -> set[str]:
+    """Return every command name+alias declared via @commands.command(...) decorators
+    across disbot/cogs/.  Static scan via AST — no cog loading required."""
+    names: set[str] = set()
+    for py in _COGS_DIR.glob("*.py"):
+        tree = ast.parse(py.read_text(), filename=str(py))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            for dec in node.decorator_list:
+                if not isinstance(dec, ast.Call):
+                    continue
+                func = dec.func
+                if not (
+                    isinstance(func, ast.Attribute)
+                    and func.attr in ("command", "group")
+                ):
+                    continue
+                # Resolve primary name.
+                primary_name: str | None = None
+                aliases: list[str] = []
+                for kw in dec.keywords:
+                    if kw.arg == "name" and isinstance(kw.value, ast.Constant):
+                        primary_name = kw.value.value
+                    elif kw.arg == "aliases" and isinstance(kw.value, ast.List):
+                        for elt in kw.value.elts:
+                            if isinstance(elt, ast.Constant) and isinstance(
+                                elt.value, str
+                            ):
+                                aliases.append(elt.value)
+                if primary_name is None:
+                    primary_name = node.name
+                names.add(primary_name)
+                names.update(aliases)
+    return names
+
+
+def test_every_subsystem_has_at_least_one_matching_command():
+    """Every user-facing subsystem must have ≥1 entry_point matching a real command.
+
+    This is the functional requirement for the help menu — _cog_for_subsystem()
+    uses set intersection between cog commands and registry entry_points; if
+    the intersection is empty, the subsystem cannot be located and clicking
+    it in the help dropdown yields "category no longer loaded".
+
+    Regression guard for the General cog bug where entry_points=["generalmenu"]
+    had NO matching command in general_cog.py, causing General to vanish from
+    the help menu entirely.
+    """
+    cog_commands = _commands_declared_in_cogs()
+    orphan_subsystems: list[tuple[str, list[str]]] = []
+    for name, meta in SUBSYSTEMS.items():
+        # Internal-mode subsystems are exempt — they are not user-facing.
+        if meta.get("visibility_mode") == "internal":
+            continue
+        entry_points = meta.get("entry_points", [])
+        if not entry_points:
+            continue  # other tests enforce non-empty entry_points
+        if not (set(entry_points) & cog_commands):
+            orphan_subsystems.append((name, entry_points))
+    assert not orphan_subsystems, (
+        "These subsystems have entry_points but NONE map to a real "
+        "@commands.command() — the help menu cannot find them: "
+        f"{orphan_subsystems}"
+    )
+
+
+def test_general_cog_has_generalmenu():
+    """The General cog must register the generalmenu command (registry contract)."""
+    cog_commands = _commands_declared_in_cogs()
+    assert "generalmenu" in cog_commands, (
+        "general_cog.py must define @commands.command(name='generalmenu')"
+    )
+
+
+def test_general_cog_has_build_help_menu_view():
+    """General cog must expose build_help_menu_view for direct help navigation."""
+    import cogs.general_cog as gc
+
+    assert hasattr(gc.General, "build_help_menu_view"), (
+        "General cog must define build_help_menu_view(interaction) for "
+        "direct navigation from the help menu"
+    )
+
+
+@pytest.mark.asyncio
+async def test_help_on_select_uses_build_help_menu_view_when_available():
+    """help_cog._on_select must dispatch to cog.build_help_menu_view if present."""
+    from unittest.mock import patch
+
+    import discord  # noqa: F401  (ensures import path is healthy)
+
+    from cogs.help_cog import HelpPanelView
+
+    view = HelpPanelView(visible_list=["general"], page=0)
+
+    # Stub cog with build_help_menu_view
+    stub_view = MagicMock(spec=["children", "add_item", "add_to"])
+    stub_view.children = []  # so _attach_back_to_help_button can add to it
+    stub_view.add_item = MagicMock()
+    stub_embed = MagicMock()
+    fake_cog = MagicMock()
+    fake_cog.build_help_menu_view = AsyncMock(return_value=(stub_embed, stub_view))
+
+    interaction = MagicMock()
+    interaction.data = {"values": ["general"]}
+    interaction.response.edit_message = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.client = MagicMock()
+
+    with patch("cogs.help_cog._cog_for_subsystem", return_value=fake_cog):
+        await view._on_select(interaction)
+
+    fake_cog.build_help_menu_view.assert_awaited_once_with(interaction)
+    interaction.response.edit_message.assert_awaited_once()
+    # Back button must have been attached.
+    stub_view.add_item.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_help_on_select_falls_back_to_inline_embed_without_hook():
+    """When a cog has no build_help_menu_view, falls back to build_cog_embed."""
+    from unittest.mock import patch
+
+    from cogs.help_cog import HelpPanelView
+
+    view = HelpPanelView(visible_list=["something"], page=0)
+
+    # Cog has no build_help_menu_view attribute at all.
+    fake_cog = MagicMock(spec=["get_commands"])
+    fake_cog.get_commands.return_value = []
+
+    interaction = MagicMock()
+    interaction.data = {"values": ["something"]}
+    interaction.response.edit_message = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.client = MagicMock()
+    interaction.client.command_prefix = "!"
+
+    with patch("cogs.help_cog._cog_for_subsystem", return_value=fake_cog):
+        with patch("cogs.help_cog.build_cog_embed") as build:
+            build.return_value = MagicMock()
+            await view._on_select(interaction)
+
+    build.assert_called_once()
+    interaction.response.edit_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_help_on_select_handles_missing_cog():
+    """When _cog_for_subsystem returns None the user gets a friendly ephemeral."""
+    from unittest.mock import patch
+
+    from cogs.help_cog import HelpPanelView
+
+    view = HelpPanelView(visible_list=["ghost"], page=0)
+
+    interaction = MagicMock()
+    interaction.data = {"values": ["ghost"]}
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    interaction.client = MagicMock()
+
+    with patch("cogs.help_cog._cog_for_subsystem", return_value=None):
+        await view._on_select(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    interaction.response.edit_message.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# INV-003 verification: apply_template routes through the pipeline
+# ---------------------------------------------------------------------------
+
+
+def test_apply_template_uses_pipeline():
+    """governance/templates.apply_template must route via GovernanceMutationPipeline."""
+    import inspect
+
+    from governance import templates as templates_module
+
+    src = inspect.getsource(templates_module.apply_template)
+    assert "GovernanceMutationPipeline" in src or "pipeline." in src, (
+        "apply_template must route through GovernanceMutationPipeline (INV-003)"
+    )
+    # Must NOT bypass pipeline with direct db.set_* calls.
+    assert "db.set_subsystem_visibility" not in src, (
+        "apply_template must not call db.set_subsystem_visibility directly — "
+        "use GovernanceMutationPipeline.set_visibility"
+    )
+    assert "db.set_cleanup_policy" not in src, (
+        "apply_template must not call db.set_cleanup_policy directly — "
+        "use GovernanceMutationPipeline.set_cleanup_policy"
+    )

--- a/tests/unit/help/test_help_navigation.py
+++ b/tests/unit/help/test_help_navigation.py
@@ -118,7 +118,6 @@ async def test_help_on_select_uses_build_help_menu_view_when_available():
     from unittest.mock import patch
 
     import discord  # noqa: F401  (ensures import path is healthy)
-
     from cogs.help_cog import HelpPanelView
 
     view = HelpPanelView(visible_list=["general"], page=0)


### PR DESCRIPTION
## Summary

Full-system stabilization migration covering state-corruption repair, governance as infrastructure, runtime lifecycle coherence, Phase 4 gap closures, and help-menu navigation completion. Architecture is now suitable for the ~200-guild scale tier; the documented path to multi-process/shard readiness is in place.

This branch implements the **Final Implementation Doctrine** (in `/root/.claude/plans/`) end-to-end. Every change closes a numbered finding from the forensic audit (BUG-001…BUG-009, ARCH-001/005, NEW-001/002/003, SEC-001, OPS-001, DB-002/003, INV-003, GAP-001, DEBT-001/002/003/006) or strengthens an existing invariant.

---

## Architectural summary

**Governance is now infrastructure-level.** Every command and every interaction passes the governance gate before any subsystem code runs:

- `@bot.before_invoke _governance_guard` in `bot1.py` blocks command dispatch for disabled subsystems and emits the configured cleanup-policy feedback.
- `core/runtime/interaction_router.dispatch()` checks `get_visible_subsystems()` before resolving a session or calling the handler. Subsystem-disabled buttons get a fail-closed ephemeral; gateway exceptions fail open (documented).
- Unknown capabilities in `governance/execution.py` now fail **closed** with a WARNING log (ARCH-005). Typos in capability strings no longer silently grant access.

**All governance mutations route through `GovernanceMutationPipeline`** (`governance/writes.py`):

1. Input validation (scope_type in {channel, category, guild, thread}, subsystem in registry)
2. `_validate_authority(ctx)` — moderator+ tier required (SEC-001 — infrastructure boundary, never optional)
3. Old-value read via `db.get_visibility_override()`
4. Single `db.get().transaction()` wraps `set_subsystem_visibility` + `write_governance_audit`
5. Post-commit in-memory `invalidate_guild_cache()`
6. `EVT_VISIBILITY_CHANGED` + `EVT_CACHE_INVALIDATED` emitted with `mutation_id`, `occurred_at`, `actor_id`

`set_subsystem_visibility()`, `set_cleanup_policy_for_scope()`, and `templates.apply_template()` are thin wrappers — no other code path may mutate governance state.

**Cache invalidation is event-driven and ordering-deterministic.** Cache version bump happens after DB commit; events fire after invalidation. Event emission failure is logged but non-fatal.

**Guild teardown is unified** in `disbot/guild_lifecycle.py`. `on_guild_remove` runs the full sequence: scheduler `_last_edit` cleanup → DB sessions → session state → panel anchors → capability override cache → visibility cache. Each step is error-isolated; one failure does not block the rest.

**Help menu has direct-navigation.** When a user selects a subsystem in the help dropdown, the help message is replaced in place with the subsystem's actual panel (via the new `cog.build_help_menu_view(interaction)` hook). A "↩ Back to Help" button is appended automatically. Cogs without the hook fall back to the inline command-list embed — backwards compatible.

---

## What changed (by audit finding)

### Tier 0 — state-corruption repair
- **BUG-001 / DB-002** — removed manual `_json.dumps()` from `set_session_state` and `write_governance_audit`; asyncpg's JSONB codec now handles encoding. Added `_maybe_decode_legacy()` shim for pre-migration reads. Migration `012_fix_session_state_encoding.sql` repairs existing double-encoded rows.
- **BUG-002 / NEW-003** — `EVT_CACHE_INVALIDATED` is now emitted from `GovernanceMutationPipeline` after every governance write. The previously dead subscriber in `core/runtime/__init__.py` now purges session state on visibility changes.
- **ARCH-001** — `bot1._governance_guard` (before_invoke) + `interaction_router` governance gate enforce subsystem visibility globally. Governance went from advisory (help-menu-only) to infrastructure (commands and interactions both gated).

### Tier 1 — production safety
- **BUG-003** — added `"thread"` to `_VALID_SCOPE_TYPES`.
- **BUG-004** — added `forget_guild_capabilities()` in `governance/execution.py`; called from `guild_lifecycle.teardown()`.
- **BUG-005** — `_SETUP_DONE` guard in `core/runtime/__init__.py` makes `setup()` idempotent.
- **BUG-006** — removed `_NO_OVERRIDE` sentinel from `governance/cache.py` and all references in `governance/resolver.py`.
- **BUG-007** — `check_existing_instance()` moved from module level into `main()` so test imports don't trigger the PID guard.
- **BUG-008** — `on_command_error` now logs ALL non-`CheckFailure` errors at ERROR regardless of channel.
- **ARCH-005** — unknown capability strings return `allowed=False` with a WARNING log (fail-closed).
- **SEC-001** — `_validate_authority()` inside `GovernanceMutationPipeline` enforces `tier >= "moderator"` at the infrastructure boundary.
- **NEW-001** — `disbot/guild_lifecycle.py` provides unified `teardown(guild_id)`. `on_guild_remove` calls it.
- **NEW-002** — `core/events.py` `emit()` wraps each handler in `asyncio.wait_for(timeout=5.0)`. Timeouts/exceptions are logged at ERROR; the bus continues to subsequent handlers.

### Tier 2 — observability / atomicity
- Audit log captures full old/new value via `write_governance_audit(... mutation_id=...)` in one DB transaction with the write.
- `_validate_authority` raises `UnauthorizedGovernanceWriteError` (new in `services/governance_exceptions.py`).
- `EventBus.emit()` ordering: handlers execute sequentially in registration order; failure isolation preserves remaining handlers.

### Tier 3 — operational hardening
- **OPS-001** — `_APP_TASKS` in `bot1.py` tracks `health_server` and `session_gc` tasks; shutdown cancels only these (never `asyncio.all_tasks()`). discord.py-internal tasks survive shutdown.
- **DB-003** — migration `013_governance_indexes.sql` adds `idx_governance_audit_actor`, `idx_governance_audit_subsystem`, `idx_panel_anchors_guild`.
- Visibility cache `_CACHE_CLEANUP_THRESHOLD` raised from 2000 → 50000 (50ms scan cost acceptable).
- Visibility cache key now uses `hash(role_ids)` instead of raw frozenset for compact, collision-safe keys (Phase 3.1).
- Scope-aware session invalidation: channel-scoped governance changes invalidate only the affected channel's sessions, not the entire guild.

### Phase 4 — gap closure
- **GAP-001** — `db.delete_guild_panel_anchors(guild_id)` added; `guild_lifecycle.teardown()` calls it. Departed guilds leave no orphan rows in `panel_anchors`.
- **DEBT-001** — `_OVERRIDE_TTL = 600s` added to `governance/execution.py`. `resolve_execution()` checks `_overrides_stale(guild_id)` and reloads when TTL expires. `_load_capability_overrides()` clears prior rows before inserting — refresh cannot leave drift behind.
- **DEBT-002** — `_audit_internal_bypass()` writes a `governance_audit_log` row with `action="execution_bypass"` whenever `resolve_execution(check_visibility=False)` is taken. AI/scheduled bypasses are now reconstructable from the DB alone.
- **DEBT-003** — `core/runtime/__init__.setup()` subscribes `_on_cleanup_changed` to `EVT_CLEANUP_CHANGED`. Currently a documented no-op (cleanup policy is uncached) — registered so any future cleanup-policy cache must wire its invalidation here rather than spawning a parallel path.
- **DEBT-006** — `_last_edit` re-keyed from `{channel_id: ts}` to `{(guild_id, channel_id): ts}`; new `live_update_scheduler.forget_guild()` API; `guild_lifecycle._teardown_scheduler()` runs unconditionally (no size gate).

---

## Help menu navigation improvements

`HelpPanelView._on_select` in `cogs/help_cog.py` now:

1. Resolves the cog via `_cog_for_subsystem()` (governance has already been resolved at the help layer).
2. If `cog.build_help_menu_view(interaction)` exists, calls it and edits the help message with the subsystem's actual panel. Appends a "↩ Back to Help" button (`help:back`) via `_attach_back_to_help_button()`.
3. On Back click, recomputes the visible-subsystems list (governance may have changed mid-session) and re-renders the help dropdown.
4. If the cog has no `build_help_menu_view`, falls back to the existing `build_cog_embed()` inline command list — backwards compatible.

`build_help_menu_view` is opt-in. The General cog is the reference implementation; other cogs can adopt the hook incrementally without changes to `help_cog.py`.

### General cog fix

`SUBSYSTEMS["general"]` declared `entry_points=["generalmenu"]` but `cogs/general_cog.py` had no command by that name. `_cog_for_subsystem()` uses set intersection between cog commands and registry entry_points; an empty intersection produced the ephemeral *"That category is no longer loaded."* response when a user clicked **General** in the help dropdown — the subsystem was effectively invisible.

Fix:
- Added `@commands.command(name="generalmenu")` in `general_cog.py`, backed by `_GeneralPanelView` (mirrors `_UtilityPanelView` in `utility_cog.py`).
- Added `build_help_menu_view(interaction)` async method that returns the same `(embed, view)` pair as `!generalmenu`.
- The panel exposes the existing General commands (fact / joke / quote / trivia / motivate / 8-ball / greet) as inline buttons with an Overview button.

### proof_channel cog (same bug pattern)

`SUBSYSTEMS["proof_channel"]` declared `entry_points=["prize"]` but the cog only registered `+prize`, `-prize`, `prizemenu`, `prizestatus`, `timedprize` — no `prize`. Fixed registry entry_points to `["prizemenu", "prizestatus", "timedprize"]` (all real commands).

### Regression test

`tests/unit/help/test_help_navigation.py` adds a static AST scan that enforces: **every user-facing subsystem must have ≥1 entry_point that matches a real `@commands.command()` / `@commands.group()` name or alias declared under `disbot/cogs/`.** This is the functional requirement for `_cog_for_subsystem()` — empty intersection = subsystem invisible to help.

---

## INV-003 violation found and fixed (apply_template)

The architectural verification pass identified `governance/templates.apply_template()` calling `db.set_subsystem_visibility()` and `db.set_cleanup_policy()` directly, bypassing `GovernanceMutationPipeline`. This skipped authority validation, transactional audit log writes, and event emission.

Fix: `apply_template(ctx, template)` now delegates each override to `pipeline.set_visibility()` / `pipeline.set_cleanup_policy()`. Every template entry produces an audit row. Signature changed from `(guild_id, template)` → `(ctx, template)`; there are no existing callers.

---

## Regression verification (148 → 157 tests)

```
tests/unit/governance/test_bug_fixes.py            25 passed
tests/unit/governance/test_cache.py                15 passed
tests/unit/governance/test_dependency_propagation.py  8 passed
tests/unit/governance/test_scope_resolution.py     21 passed
tests/unit/governance/test_snapshot.py             14 passed
tests/unit/governance/test_startup_validation.py   17 passed
tests/unit/help/test_help_navigation.py             7 passed
tests/unit/registry/test_entrypoints.py            48 passed
                                                  ─────────
                                                  157 passed
```

New regression coverage:
- `_maybe_decode_legacy` shim (6 cases) — BUG-001
- Thread scope in `_VALID_SCOPE_TYPES` (2 cases) — BUG-003
- `forget_guild_capabilities()` (2 cases) — BUG-004
- `setup()` idempotency (1 case) — BUG-005
- `_NO_OVERRIDE` sentinel removed (2 cases) — BUG-006
- Unknown capability fail-closed (2 cases) — ARCH-005
- `EVT_CACHE_INVALIDATED` emitted from pipeline (1 case) — BUG-002
- Panel anchor teardown (2 cases) — GAP-001
- Capability override TTL refresh (3 cases) — DEBT-001
- Internal bypass DB audit (1 case) — DEBT-002
- `EVT_CLEANUP_CHANGED` subscription (1 case) — DEBT-003
- `_last_edit` guild-scoped teardown (2 cases) — DEBT-006
- Registry entry_points must map to real commands (1 case)
- General cog has `generalmenu` + `build_help_menu_view` (2 cases)
- `_on_select` dispatch behavior (3 cases) — help nav
- `apply_template` routes through pipeline (1 case) — INV-003

---

## Doctrine compliance confirmation

| Invariant | Status | Location |
|---|---|---|
| INV-001 — Governance before subsystem code | ✓ | `bot1.py:301` (`_governance_guard`) + `interaction_router.dispatch():102-121` |
| INV-002 — Visibility ≠ execution | ✓ | `resolve_visibility()` and `resolve_execution()` independent |
| INV-003 — Mutations only via `GovernanceMutationPipeline` | ✓ | `set_subsystem_visibility`, `set_cleanup_policy_for_scope`, `apply_template` all delegate |
| INV-004 — Cache invalidation is event-driven post-commit | ✓ | `writes.py:153-184` |
| INV-005 — Unknown capabilities fail closed | ✓ | `execution.py:184-193` |
| INV-006 — Authority at infrastructure boundary | ✓ | `_validate_authority()` mandatory in pipeline |
| INV-007 — Guild teardown clears all per-guild state | ✓ | `guild_lifecycle.teardown()` covers all dicts |
| INV-008 — Session ownership per (user, channel, subsystem) | ✓ | DB UNIQUE constraint |
| INV-009 — Registry immutable after startup | ✓ | `MappingProxyType` deep-freeze in `validate_registry()` |
| INV-010 — EventBus 5s handler timeout | ✓ | `core/events.py` `_HANDLER_TIMEOUT=5.0` |
| INV-011 — Single scope chain implementation | ✓ | `resolver._build_scope_chain()` only |
| INV-012 — Capability string validation at startup | ✓ | `subsystem_registry.validate_registry()` |

## Remaining known debt

Documented in the doctrine but not closed in this PR — none are blockers for the ~200-guild scale tier.

- **TECH-001** — In-process caches are not shard-safe. `GovernanceCacheBackend` Protocol provides the documented Redis migration path.
- **TECH-003** — Panel ownership is not platform-enforced for non-`PersistentView` panels. Required before third-party plugin support.
- **OPS-001 (partial)** — `live_update_scheduler` spawns panel-refresh tasks via `asyncio.create_task()` without `_APP_TASKS` registration. Documented as acceptable for single-process; will need tracking before sharding.
- **DEBT-004** — `_guild_has_role_overrides` loading path opaque; flag is read in `_cache_key` but population path is implicit.
- **DEBT-005** — `resolve_command_policy` allows commands not owned by any subsystem (documented exception, not a security hole).

## Test plan

- [x] `pytest tests/ -v` — 157 / 157 passed
- [x] Static invariant audit — all 12 INV checks pass against committed code
- [ ] Apply migration 012 on a staging DB; verify `SELECT COUNT(*) FROM runtime_session_state WHERE jsonb_typeof(value) = 'string'` returns 0
- [ ] Apply migration 013 on staging; verify indexes present
- [ ] Disable "economy" subsystem via governance; verify `!daily` denied with feedback, Economy interaction button denied with ephemeral, Economy hidden from help menu
- [ ] Call `runtime.setup()` twice during boot; verify handler count unchanged
- [ ] Leave a guild; verify `_loaded_guilds` empty, `_CACHE_VERSION` cleared, panel anchors deleted, `_last_edit` purged
- [ ] Click each subsystem in `!help` dropdown; verify panel opens (or inline embed renders) — General must work
- [ ] Click "↩ Back to Help" from a subsystem panel; verify help dropdown re-renders with fresh visibility

https://claude.ai/code/session_01JfMNj8xCCrbSb3ihrWQFDy

---
_Generated by [Claude Code](https://claude.ai/code/session_01JfMNj8xCCrbSb3ihrWQFDy)_