### PR TITLE
SuperBot: Full governance consolidation, stabilization & view interaction fixes

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -119,7 +119,7 @@ signal.signal(signal.SIGTERM, _begin_shutdown)
 
 @bot.event
 async def on_ready() -> None:
-    bot.uptime = datetime.datetime.utcnow()  # type: ignore[attr-defined]
+    bot.uptime = datetime.datetime.now(tz=datetime.timezone.utc)  # type: ignore[attr-defined]
     bot._reporter = reporter  # type: ignore[attr-defined]
     logger.info("Logged in as %s (ID: %s)", bot.user, bot.user.id)
     logger.info("Connected to %d server(s)", len(bot.guilds))

--- a/disbot/cogs/blackjack_cog.py
+++ b/disbot/cogs/blackjack_cog.py
@@ -14,6 +14,35 @@ from utils.ui_constants import ECONOMY_COLOR, ERROR_COLOR, GAME_COLOR, SUCCESS_C
 
 logger = logging.getLogger("bot")
 
+
+async def _on_view_error(
+    view: discord.ui.View,
+    interaction: discord.Interaction,
+    error: Exception,
+    item: discord.ui.Item,  # type: ignore[type-arg]
+) -> None:
+    logger.error(
+        "View error | view=%s item_type=%s custom_id=%r label=%r "
+        "user=%s guild=%s channel=%s message=%s",
+        type(view).__name__,
+        type(item).__name__,
+        getattr(item, "custom_id", None),
+        getattr(item, "label", None),
+        getattr(interaction.user, "id", None),
+        interaction.guild_id,
+        interaction.channel_id,
+        interaction.message.id if interaction.message else None,
+        exc_info=error,
+    )
+    if not interaction.response.is_done():
+        try:
+            await interaction.response.send_message(
+                "An error occurred. Please try again.", ephemeral=True
+            )
+        except Exception:
+            pass
+
+
 # ---------------------------------------------------------------------------
 # Card engine
 # ---------------------------------------------------------------------------
@@ -232,6 +261,14 @@ class BlackjackView(discord.ui.View):
         if self.on_finish:
             await self.on_finish(self.game, -1)  # treat as bust on timeout
 
+    async def on_error(
+        self,
+        interaction: discord.Interaction,
+        error: Exception,
+        item: discord.ui.Item,  # type: ignore[type-arg]
+    ) -> None:
+        await _on_view_error(self, interaction, error, item)
+
     @discord.ui.button(label="Hit", style=discord.ButtonStyle.green, emoji="👊")
     async def hit_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
         self.game.hit()
@@ -363,6 +400,14 @@ class _ChallengeView(discord.ui.View):
         except Exception:
             pass
 
+    async def on_error(
+        self,
+        interaction: discord.Interaction,
+        error: Exception,
+        item: discord.ui.Item,  # type: ignore[type-arg]
+    ) -> None:
+        await _on_view_error(self, interaction, error, item)
+
 
 async def _start_pvp(
     interaction: discord.Interaction,
@@ -487,6 +532,14 @@ class _TournRegistrationView(discord.ui.View):
         if ok:
             await _update_tourn_embed(self.tourn)
 
+    async def on_error(
+        self,
+        interaction: discord.Interaction,
+        error: Exception,
+        item: discord.ui.Item,  # type: ignore[type-arg]
+    ) -> None:
+        await _on_view_error(self, interaction, error, item)
+
 
 async def _update_tourn_embed(t: _BjTournament):
     if not t.reg_message:
@@ -602,6 +655,14 @@ class _TournBlackjackView(discord.ui.View):
             await _check_tourn_done(self.tourn, self.bot)
         else:
             await _start_tourn_round(self.ps, self.channel, self.tourn, self.bot)
+
+    async def on_error(
+        self,
+        interaction: discord.Interaction,
+        error: Exception,
+        item: discord.ui.Item,  # type: ignore[type-arg]
+    ) -> None:
+        await _on_view_error(self, interaction, error, item)
 
     @discord.ui.button(label="Hit", style=discord.ButtonStyle.green, emoji="👊")
     async def hit(self, interaction: discord.Interaction, _: discord.ui.Button):

--- a/disbot/cogs/channel_cog.py
+++ b/disbot/cogs/channel_cog.py
@@ -1363,9 +1363,23 @@ class _SubsystemToggleView(BaseView):
                 new_val = None
 
             gctx = GovernanceContext.from_interaction(interaction)
-            await governance_service.set_subsystem_visibility(
-                gctx, "channel", self.channel.id, subsystem_name, new_val
-            )
+            try:
+                await governance_service.set_subsystem_visibility(
+                    gctx, "channel", self.channel.id, subsystem_name, new_val
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Subsystem visibility toggle failed | subsystem=%r exc=%s",
+                    subsystem_name,
+                    exc,
+                    exc_info=True,
+                )
+                if not interaction.response.is_done():
+                    await interaction.response.send_message(
+                        f"Could not update visibility for **{subsystem_name}**: {exc}",
+                        ephemeral=True,
+                    )
+                return
             self._visibility[subsystem_name] = new_val
             self._rebuild_buttons()
             await interaction.response.edit_message(embed=self.build_embed(), view=self)

--- a/disbot/cogs/counting_cog.py
+++ b/disbot/cogs/counting_cog.py
@@ -8,7 +8,7 @@ import math
 import operator as op
 import random
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 
 import discord
 from discord.ext import commands
@@ -396,7 +396,7 @@ class CountingCog(commands.Cog):
 
         async with self.lock:
             # Create a channel named after the mode with a timestamp for uniqueness
-            timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+            timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d%H%M%S")
             channel_name = f"{mode}-counting-{timestamp}"
             existing_channel = discord.utils.get(guild.text_channels, name=channel_name)
             if existing_channel:
@@ -469,7 +469,7 @@ class CountingCog(commands.Cog):
                 "multiple": multiple if mode == "multiples" else None,
                 "custom_sequence": custom_sequence if mode == "custom" else None,
                 "sequence_index": 0,
-                "last_count_time": datetime.utcnow().timestamp(),
+                "last_count_time": datetime.now(tz=timezone.utc).timestamp(),
                 "reset_on_wrong_count": False,
                 # For random mode: pre-roll the first expected value
                 "next_expected": (
@@ -583,7 +583,7 @@ class CountingCog(commands.Cog):
             channel_data["sequence_index"] = 0
             channel_data["last_user"] = None
             channel_data["leaderboard"] = {}
-            channel_data["last_count_time"] = datetime.utcnow().timestamp()
+            channel_data["last_count_time"] = datetime.now(tz=timezone.utc).timestamp()
             if mode == "random":
                 rand_range = channel_data.get("random_range", [1, 3])
                 channel_data["next_expected"] = start + random.randint(*rand_range)
@@ -860,7 +860,9 @@ class CountingCog(commands.Cog):
                     channel_data["sequence_index"] = 0
                     channel_data["last_user"] = None
                     channel_data["leaderboard"] = {}
-                    channel_data["last_count_time"] = datetime.utcnow().timestamp()
+                    channel_data["last_count_time"] = datetime.now(
+                        tz=timezone.utc
+                    ).timestamp()
                     asyncio.create_task(self._save_guild(guild_id))
 
                     await message.channel.send(
@@ -913,7 +915,7 @@ class CountingCog(commands.Cog):
             # Update count
             channel_data["current_count"] = parsed_count
             channel_data["last_user"] = user_id
-            channel_data["last_count_time"] = datetime.utcnow().timestamp()
+            channel_data["last_count_time"] = datetime.now(tz=timezone.utc).timestamp()
             # Roll next expected value for random mode
             if mode == "random":
                 rand_range = channel_data.get("random_range", [1, 3])
@@ -1342,7 +1344,7 @@ class _CountingHubView(BaseView):
             ch_data["sequence_index"] = 0
             ch_data["last_user"] = None
             ch_data["leaderboard"] = {}
-            ch_data["last_count_time"] = datetime.utcnow().timestamp()
+            ch_data["last_count_time"] = datetime.now(tz=timezone.utc).timestamp()
             if mode == "random":
                 rand_range = ch_data.get("random_range", [1, 3])
                 ch_data["next_expected"] = start + random.randint(*rand_range)

--- a/disbot/cogs/diagnostic_cog.py
+++ b/disbot/cogs/diagnostic_cog.py
@@ -343,8 +343,8 @@ class DiagnosticCog(commands.Cog):
     @commands.has_permissions(administrator=True)
     async def diagnostic_bot_status(self, ctx):
         """Display bot health and performance metrics."""
-        uptime_delta = datetime.datetime.utcnow() - getattr(
-            self.bot, "uptime", datetime.datetime.utcnow()
+        uptime_delta = datetime.datetime.now(tz=datetime.timezone.utc) - getattr(
+            self.bot, "uptime", datetime.datetime.now(tz=datetime.timezone.utc)
         )
         uptime_str = str(uptime_delta).split(".")[0]
 
@@ -458,7 +458,7 @@ class DiagnosticCog(commands.Cog):
                 title="🧪 Test Notification",
                 description="This is a test error notification from DiagnosticCog.",
                 color=discord.Color.orange(),
-                timestamp=datetime.datetime.utcnow(),
+                timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
             )
             await reporter._send(embed, username="Diagnostic")
             await ctx.send("✅ Test notification sent.", delete_after=10)

--- a/disbot/cogs/help_cog.py
+++ b/disbot/cogs/help_cog.py
@@ -152,8 +152,18 @@ def _attach_back_to_help_button(
 
     async def _back_callback(interaction: discord.Interaction) -> None:
         # Recompute visible list at click time — governance may have changed.
-        gctx = GovernanceContext.from_interaction(interaction)
-        vis_result = await governance_service.resolve_visibility(gctx)
+        try:
+            gctx = GovernanceContext.from_interaction(interaction)
+            vis_result = await governance_service.resolve_visibility(gctx)
+        except Exception as exc:
+            logger.warning(
+                "Back-to-help visibility resolve failed: %s", exc, exc_info=True
+            )
+            if not interaction.response.is_done():
+                await interaction.response.send_message(
+                    "Could not load help menu. Please try again.", ephemeral=True
+                )
+            return
         fresh_visible = [
             name
             for name, _ in all_subsystems_sorted()

--- a/disbot/cogs/role_cog.py
+++ b/disbot/cogs/role_cog.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 
 import discord
 from core.runtime import panel_manager
@@ -241,7 +241,7 @@ class RoleCog(commands.Cog):
             if not member.joined_at:
                 continue
 
-            days = (datetime.utcnow() - member.joined_at.replace(tzinfo=None)).days
+            days = (datetime.now(tz=timezone.utc) - member.joined_at).days
 
             target_name = None
             for name in progression:

--- a/disbot/core/runtime/persistent_views.py
+++ b/disbot/core/runtime/persistent_views.py
@@ -75,3 +75,30 @@ class PersistentView(discord.ui.View):
             )
             return False
         return True
+
+    async def on_error(
+        self,
+        interaction: discord.Interaction,
+        error: Exception,
+        item: discord.ui.Item,  # type: ignore[type-arg]
+    ) -> None:
+        logger.error(
+            "PersistentView error | view=%s item_type=%s custom_id=%r label=%r "
+            "user=%s guild=%s channel=%s message=%s",
+            type(self).__name__,
+            type(item).__name__,
+            getattr(item, "custom_id", None),
+            getattr(item, "label", None),
+            getattr(interaction.user, "id", None),
+            interaction.guild_id,
+            interaction.channel_id,
+            interaction.message.id if interaction.message else None,
+            exc_info=error,
+        )
+        if not interaction.response.is_done():
+            try:
+                await interaction.response.send_message(
+                    "An error occurred. Please try again.", ephemeral=True
+                )
+            except Exception:
+                pass

--- a/disbot/healthserver.py
+++ b/disbot/healthserver.py
@@ -47,7 +47,7 @@ async def _health_handler(request: web.Request) -> web.Response:
     """Liveness probe — always 200 while the event loop is alive."""
     bot: commands.Bot = request.app["bot"]
     uptime = (
-        str(datetime.datetime.utcnow() - bot.uptime)
+        str(datetime.datetime.now(tz=datetime.timezone.utc) - bot.uptime)
         if hasattr(bot, "uptime")
         else "starting"
     )

--- a/disbot/services/webhook_reporter.py
+++ b/disbot/services/webhook_reporter.py
@@ -44,7 +44,7 @@ class WebhookReporter:
         embed = discord.Embed(
             title="🚀 Bot Online",
             color=discord.Color.green(),
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
         )
         embed.add_field(name="Prefix", value=f"`{bot.command_prefix}`", inline=True)
         embed.add_field(name="Servers", value=str(len(bot.guilds)), inline=True)
@@ -63,7 +63,7 @@ class WebhookReporter:
             title="🔴 Cog Load Failure",
             description=f"**Extension:** `{ext}`\n```py\n{tb}\n```",
             color=discord.Color.dark_red(),
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
         )
         await self._send(embed, username="Bot Loader")
 
@@ -71,7 +71,7 @@ class WebhookReporter:
         embed = discord.Embed(
             title="📥 Command Invoked",
             color=discord.Color.blue(),
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
         )
         embed.add_field(
             name="Input", value=f"`{ctx.message.content[:200]}`", inline=False
@@ -89,7 +89,7 @@ class WebhookReporter:
         embed = discord.Embed(
             title="✅ Command Completed",
             color=discord.Color.green(),
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
         )
         embed.add_field(
             name="Command", value=f"`{ctx.command.qualified_name}`", inline=True
@@ -109,7 +109,7 @@ class WebhookReporter:
                 title="❓ Unknown Command",
                 description=f"Input: `{ctx.message.content[:150]}`",
                 color=discord.Color.greyple(),
-                timestamp=datetime.datetime.utcnow(),
+                timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
             )
             embed.add_field(name="User", value=str(ctx.author), inline=True)
             embed.add_field(name="Server", value=str(ctx.guild), inline=True)
@@ -124,7 +124,7 @@ class WebhookReporter:
                     f"Input: `{ctx.message.content[:150]}`"
                 ),
                 color=discord.Color.orange(),
-                timestamp=datetime.datetime.utcnow(),
+                timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
             )
             embed.add_field(name="User", value=str(ctx.author), inline=True)
             embed.add_field(name="Server", value=str(ctx.guild), inline=True)
@@ -136,7 +136,7 @@ class WebhookReporter:
                 title="⚠️ Bad Argument",
                 description=f"{error}\nInput: `{ctx.message.content[:150]}`",
                 color=discord.Color.orange(),
-                timestamp=datetime.datetime.utcnow(),
+                timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
             )
             embed.add_field(name="User", value=str(ctx.author), inline=True)
             embed.add_field(name="Server", value=str(ctx.guild), inline=True)
@@ -151,7 +151,7 @@ class WebhookReporter:
                 title=f"🔒 {label} Missing Permissions",
                 description=str(error),
                 color=discord.Color.orange(),
-                timestamp=datetime.datetime.utcnow(),
+                timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
             )
             embed.add_field(name="Command", value=f"`!{ctx.command}`", inline=True)
             embed.add_field(name="User", value=str(ctx.author), inline=True)
@@ -164,7 +164,7 @@ class WebhookReporter:
                 title="⏰ Command on Cooldown",
                 description=f"`!{ctx.command}` — retry in **{error.retry_after:.1f}s**",
                 color=discord.Color.yellow(),
-                timestamp=datetime.datetime.utcnow(),
+                timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
             )
             embed.add_field(name="User", value=str(ctx.author), inline=True)
             embed.add_field(name="Server", value=str(ctx.guild), inline=True)
@@ -180,7 +180,7 @@ class WebhookReporter:
             title="❌ Unexpected Error",
             description=f"**{type(error).__name__}**: {error}\n\n```py\n{tb}\n```",
             color=discord.Color.red(),
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
         )
         embed.add_field(
             name="Input", value=f"`{ctx.message.content[:150]}`", inline=False

--- a/disbot/utils/db.py
+++ b/disbot/utils/db.py
@@ -467,9 +467,9 @@ async def log_mod_action(
     moderator_id: int,
     reason: str = "No reason provided",
 ) -> None:
-    from datetime import datetime
+    from datetime import datetime, timezone
 
-    ts = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+    ts = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
     await execute(
         "INSERT INTO mod_logs (timestamp, guild_id, action, target_id, moderator_id, reason) "
         "VALUES ($1, $2, $3, $4, $5, $6)",

--- a/disbot/views/base.py
+++ b/disbot/views/base.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import logging
+
 import discord
+
+logger = logging.getLogger("bot.views")
 
 
 class BaseView(discord.ui.View):
@@ -40,5 +44,32 @@ class BaseView(discord.ui.View):
         if self.message:
             try:
                 await self.message.edit(view=self)
+            except Exception:
+                pass
+
+    async def on_error(
+        self,
+        interaction: discord.Interaction,
+        error: Exception,
+        item: discord.ui.Item,  # type: ignore[type-arg]
+    ) -> None:
+        logger.error(
+            "View error | view=%s item_type=%s custom_id=%r label=%r "
+            "user=%s guild=%s channel=%s message=%s",
+            type(self).__name__,
+            type(item).__name__,
+            getattr(item, "custom_id", None),
+            getattr(item, "label", None),
+            getattr(interaction.user, "id", None),
+            interaction.guild_id,
+            interaction.channel_id,
+            interaction.message.id if interaction.message else None,
+            exc_info=error,
+        )
+        if not interaction.response.is_done():
+            try:
+                await interaction.response.send_message(
+                    "An error occurred. Please try again.", ephemeral=True
+                )
             except Exception:
                 pass

--- a/tests/unit/governance/test_bug_fixes.py
+++ b/tests/unit/governance/test_bug_fixes.py
@@ -178,9 +178,9 @@ class TestNoOverrideSentinelRemoved:
     def test_no_override_not_exported(self):
         import governance.cache as cache_module
 
-        assert not hasattr(cache_module, "_NO_OVERRIDE"), (
-            "_NO_OVERRIDE was removed as dead code — it should not exist in cache.py"
-        )
+        assert not hasattr(
+            cache_module, "_NO_OVERRIDE"
+        ), "_NO_OVERRIDE was removed as dead code — it should not exist in cache.py"
 
     def test_resolver_does_not_import_no_override(self):
         import inspect
@@ -188,9 +188,9 @@ class TestNoOverrideSentinelRemoved:
         import governance.resolver as resolver_module
 
         source = inspect.getsource(resolver_module)
-        assert "_NO_OVERRIDE" not in source, (
-            "resolver.py must not reference the removed _NO_OVERRIDE sentinel"
-        )
+        assert (
+            "_NO_OVERRIDE" not in source
+        ), "resolver.py must not reference the removed _NO_OVERRIDE sentinel"
 
 
 # ---------------------------------------------------------------------------
@@ -265,9 +265,7 @@ class TestCacheInvalidatedEmitted:
         member.guild.owner_id = 0
         member.guild_permissions.manage_guild = True
 
-        ctx = GovernanceContext(
-            guild_id=777, channel_id=1, member=member
-        )
+        ctx = GovernanceContext(guild_id=777, channel_id=1, member=member)
 
         emitted_events: list[str] = []
 
@@ -286,21 +284,25 @@ class TestCacheInvalidatedEmitted:
             mock_pool.transaction = MagicMock(return_value=txn)
             mock_db.get = MagicMock(return_value=mock_pool)
             with patch("governance.writes.invalidate_guild_cache"):
-                with patch("governance.writes._emit_governance_event", side_effect=mock_emit):
+                with patch(
+                    "governance.writes._emit_governance_event", side_effect=mock_emit
+                ):
                     with patch("governance.writes.SUBSYSTEMS", {"economy": {}}):
                         from governance.writes import GovernanceMutationPipeline
 
                         pipeline = GovernanceMutationPipeline()
-                        await pipeline.set_visibility(ctx, "guild", 777, "economy", False)
+                        await pipeline.set_visibility(
+                            ctx, "guild", 777, "economy", False
+                        )
 
         from governance.events import EVT_CACHE_INVALIDATED, EVT_VISIBILITY_CHANGED
 
-        assert EVT_VISIBILITY_CHANGED in emitted_events, (
-            "EVT_VISIBILITY_CHANGED must be emitted from set_visibility"
-        )
-        assert EVT_CACHE_INVALIDATED in emitted_events, (
-            "EVT_CACHE_INVALIDATED must be emitted from set_visibility (BUG-002 fix)"
-        )
+        assert (
+            EVT_VISIBILITY_CHANGED in emitted_events
+        ), "EVT_VISIBILITY_CHANGED must be emitted from set_visibility"
+        assert (
+            EVT_CACHE_INVALIDATED in emitted_events
+        ), "EVT_CACHE_INVALIDATED must be emitted from set_visibility (BUG-002 fix)"
 
 
 # ---------------------------------------------------------------------------
@@ -315,7 +317,9 @@ class TestPanelAnchorTeardown:
         import guild_lifecycle
 
         guild_id = 4242
-        with patch("utils.db.delete_guild_panel_anchors", new_callable=AsyncMock) as mock_del:
+        with patch(
+            "utils.db.delete_guild_panel_anchors", new_callable=AsyncMock
+        ) as mock_del:
             mock_del.return_value = 3
             # Patch the other DB-touching steps so we isolate the anchor path.
             with patch("utils.db.get") as mock_get:
@@ -332,9 +336,9 @@ class TestPanelAnchorTeardown:
     def test_db_function_signature(self):
         from utils import db as db_module
 
-        assert hasattr(db_module, "delete_guild_panel_anchors"), (
-            "db.delete_guild_panel_anchors must exist (GAP-001)"
-        )
+        assert hasattr(
+            db_module, "delete_guild_panel_anchors"
+        ), "db.delete_guild_panel_anchors must exist (GAP-001)"
 
 
 # ---------------------------------------------------------------------------
@@ -418,9 +422,9 @@ class TestCapabilityOverrideTTL:
         from governance import execution as exec_module
 
         source = inspect.getsource(exec_module._load_capability_overrides)
-        assert "stale_keys" in source or "pop" in source, (
-            "_load_capability_overrides must clear prior entries before insert"
-        )
+        assert (
+            "stale_keys" in source or "pop" in source
+        ), "_load_capability_overrides must clear prior entries before insert"
 
 
 # ---------------------------------------------------------------------------
@@ -500,9 +504,9 @@ class TestCleanupChangedSubscription:
                     ):
                         await rt.setup()
 
-        assert "cleanup" in subscribed_events, (
-            "runtime.setup() must subscribe to EVT_CLEANUP_CHANGED (DEBT-003)"
-        )
+        assert (
+            "cleanup" in subscribed_events
+        ), "runtime.setup() must subscribe to EVT_CLEANUP_CHANGED (DEBT-003)"
         rt._SETUP_DONE = False
 
 
@@ -537,9 +541,9 @@ class TestLastEditTeardown:
         import guild_lifecycle
 
         src = inspect.getsource(guild_lifecycle._teardown_scheduler)
-        assert "5_000" not in src and "5000" not in src, (
-            "guild_lifecycle._teardown_scheduler must not size-gate cleanup"
-        )
-        assert "_sched_forget" in src or "forget_guild" in src, (
-            "_teardown_scheduler must call scheduler.forget_guild(guild_id)"
-        )
+        assert (
+            "5_000" not in src and "5000" not in src
+        ), "guild_lifecycle._teardown_scheduler must not size-gate cleanup"
+        assert (
+            "_sched_forget" in src or "forget_guild" in src
+        ), "_teardown_scheduler must call scheduler.forget_guild(guild_id)"

--- a/tests/unit/help/test_help_navigation.py
+++ b/tests/unit/help/test_help_navigation.py
@@ -97,9 +97,9 @@ def test_every_subsystem_has_at_least_one_matching_command():
 def test_general_cog_has_generalmenu():
     """The General cog must register the generalmenu command (registry contract)."""
     cog_commands = _commands_declared_in_cogs()
-    assert "generalmenu" in cog_commands, (
-        "general_cog.py must define @commands.command(name='generalmenu')"
-    )
+    assert (
+        "generalmenu" in cog_commands
+    ), "general_cog.py must define @commands.command(name='generalmenu')"
 
 
 def test_general_cog_has_build_help_menu_view():
@@ -208,9 +208,9 @@ def test_apply_template_uses_pipeline():
     from governance import templates as templates_module
 
     src = inspect.getsource(templates_module.apply_template)
-    assert "GovernanceMutationPipeline" in src or "pipeline." in src, (
-        "apply_template must route through GovernanceMutationPipeline (INV-003)"
-    )
+    assert (
+        "GovernanceMutationPipeline" in src or "pipeline." in src
+    ), "apply_template must route through GovernanceMutationPipeline (INV-003)"
     # Must NOT bypass pipeline with direct db.set_* calls.
     assert "db.set_subsystem_visibility" not in src, (
         "apply_template must not call db.set_subsystem_visibility directly — "

--- a/tests/unit/views/test_view_error_handling.py
+++ b/tests/unit/views/test_view_error_handling.py
@@ -1,0 +1,369 @@
+"""Regression tests for Discord view interaction error handling.
+
+Covers:
+  - BaseView.on_error() logs full context and sends ephemeral when not responded
+  - PersistentView.on_error() same contract
+  - _SubsystemToggleView handles set_subsystem_visibility exceptions gracefully
+  - _back_callback handles resolve_visibility exceptions gracefully
+  - No exception silently swallowed when interaction already responded
+  - datetime.utcnow() is not used anywhere in production code paths
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_DISBOT = Path(__file__).parents[3] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_interaction(*, responded: bool = False) -> MagicMock:
+    """Build a minimal discord.Interaction mock."""
+    interaction = MagicMock()
+    interaction.user = MagicMock()
+    interaction.user.id = 12345
+    interaction.guild_id = 99999
+    interaction.channel_id = 11111
+    interaction.message = MagicMock()
+    interaction.message.id = 22222
+    interaction.response = MagicMock()
+    interaction.response.is_done = MagicMock(return_value=responded)
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    return interaction
+
+
+def _make_item(*, custom_id: str = "test:btn", label: str = "Test") -> MagicMock:
+    item = MagicMock()
+    item.custom_id = custom_id
+    item.label = label
+    return item
+
+
+# ---------------------------------------------------------------------------
+# BaseView.on_error()
+# ---------------------------------------------------------------------------
+
+
+class TestBaseViewOnError:
+    """BaseView.on_error must log context and send ephemeral if not responded."""
+
+    @pytest.mark.asyncio
+    async def test_logs_view_context(self, caplog):
+        import logging
+
+        import discord
+        from views.base import BaseView
+
+        author = MagicMock(spec=discord.Member)
+        view = BaseView(author)
+        interaction = _make_interaction()
+        item = _make_item(custom_id="test:click", label="Click")
+        error = ValueError("boom")
+
+        with caplog.at_level(logging.ERROR, logger="bot.views"):
+            await view.on_error(interaction, error, item)
+
+        assert any(
+            "BaseView" in r.message for r in caplog.records
+        ), "on_error must log the view class name"
+        assert any(
+            "test:click" in r.message for r in caplog.records
+        ), "on_error must log the custom_id"
+
+    @pytest.mark.asyncio
+    async def test_sends_ephemeral_when_not_responded(self):
+        import discord
+        from views.base import BaseView
+
+        author = MagicMock(spec=discord.Member)
+        view = BaseView(author)
+        interaction = _make_interaction(responded=False)
+
+        await view.on_error(interaction, RuntimeError("x"), _make_item())
+
+        interaction.response.send_message.assert_awaited_once()
+        call_kwargs = interaction.response.send_message.call_args
+        assert call_kwargs.kwargs.get("ephemeral") is True
+
+    @pytest.mark.asyncio
+    async def test_no_double_respond_when_already_responded(self):
+        import discord
+        from views.base import BaseView
+
+        author = MagicMock(spec=discord.Member)
+        view = BaseView(author)
+        interaction = _make_interaction(responded=True)
+
+        await view.on_error(interaction, RuntimeError("x"), _make_item())
+
+        interaction.response.send_message.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# PersistentView.on_error()
+# ---------------------------------------------------------------------------
+
+
+class TestPersistentViewOnError:
+    """PersistentView.on_error must have the same contract as BaseView.on_error."""
+
+    @pytest.mark.asyncio
+    async def test_sends_ephemeral_when_not_responded(self):
+        from core.runtime.persistent_views import PersistentView
+
+        view = PersistentView()
+        interaction = _make_interaction(responded=False)
+
+        await view.on_error(interaction, RuntimeError("x"), _make_item())
+
+        interaction.response.send_message.assert_awaited_once()
+        assert (
+            interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+        )
+
+    @pytest.mark.asyncio
+    async def test_logs_view_class_and_item(self, caplog):
+        import logging
+
+        from core.runtime.persistent_views import PersistentView
+
+        view = PersistentView()
+        interaction = _make_interaction()
+        item = _make_item(custom_id="help:select", label="Choose")
+
+        with caplog.at_level(logging.ERROR, logger="bot.runtime.views"):
+            await view.on_error(interaction, ValueError("fail"), item)
+
+        assert any("PersistentView" in r.message for r in caplog.records)
+        assert any("help:select" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_no_double_respond_when_already_responded(self):
+        from core.runtime.persistent_views import PersistentView
+
+        view = PersistentView()
+        interaction = _make_interaction(responded=True)
+
+        await view.on_error(interaction, RuntimeError("x"), _make_item())
+
+        interaction.response.send_message.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# _back_callback error handling (help_cog)
+# ---------------------------------------------------------------------------
+
+
+class TestBackCallbackErrorHandling:
+    """_back_callback must send ephemeral on governance failure, never raise."""
+
+    @pytest.mark.asyncio
+    async def test_resolve_visibility_failure_sends_ephemeral(self):
+        import cogs.help_cog as help_cog
+
+        view = help_cog.HelpPanelView(visible_list=["general"], page=0)
+        interaction = _make_interaction(responded=False)
+        interaction.client = MagicMock()
+
+        with patch(
+            "cogs.help_cog.governance_service.resolve_visibility",
+            side_effect=RuntimeError("governance down"),
+        ):
+            # Attach back button and capture its callback.
+            sub_view = MagicMock()
+            sub_view.children = []
+            sub_view.add_item = MagicMock(side_effect=lambda btn: None)
+            help_cog._attach_back_to_help_button(sub_view, ["general"], 0)
+
+            # The back button was passed to add_item; retrieve it.
+            assert sub_view.add_item.called
+            back_btn = sub_view.add_item.call_args[0][0]
+            await back_btn.callback(interaction)
+
+        interaction.response.send_message.assert_awaited_once()
+        assert (
+            interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+        )
+        interaction.response.edit_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_resolve_visibility_failure_no_raise_when_responded(self):
+        import cogs.help_cog as help_cog
+
+        interaction = _make_interaction(responded=True)
+        interaction.client = MagicMock()
+
+        with patch(
+            "cogs.help_cog.governance_service.resolve_visibility",
+            side_effect=RuntimeError("down"),
+        ):
+            sub_view = MagicMock()
+            sub_view.children = []
+            sub_view.add_item = MagicMock()
+            help_cog._attach_back_to_help_button(sub_view, ["general"], 0)
+            back_btn = sub_view.add_item.call_args[0][0]
+            # Must not raise even if interaction is already done.
+            await back_btn.callback(interaction)
+
+        interaction.response.send_message.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# _SubsystemToggleView callback error handling (channel_cog)
+# ---------------------------------------------------------------------------
+
+
+class TestSubsystemToggleViewErrorHandling:
+    """Toggle callback must send ephemeral on governance failure."""
+
+    @pytest.mark.asyncio
+    async def test_set_visibility_failure_sends_ephemeral(self):
+        import discord
+        from cogs.channel_cog import _SubsystemToggleView
+        from services.governance_service import GovernanceContext
+
+        ctx = MagicMock()
+        ctx.author = MagicMock(spec=discord.Member)
+        ctx.author.id = 1
+        channel = MagicMock(spec=discord.TextChannel)
+        channel.id = 777
+        channel.name = "test-chan"
+
+        view = _SubsystemToggleView(ctx, channel=channel, manager_message=None)
+        view._visibility = {"general": None}
+
+        interaction = _make_interaction(responded=False)
+        interaction.guild = MagicMock()
+
+        with patch(
+            "cogs.channel_cog.governance_service.set_subsystem_visibility",
+            side_effect=Exception("authority denied"),
+        ):
+            callback = view._make_toggle_callback("general")
+            await callback(interaction)
+
+        interaction.response.send_message.assert_awaited_once()
+        assert (
+            interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
+        )
+        interaction.response.edit_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_set_visibility_success_calls_edit_message(self):
+        import discord
+        from cogs.channel_cog import _SubsystemToggleView
+
+        ctx = MagicMock()
+        ctx.author = MagicMock(spec=discord.Member)
+        ctx.author.id = 1
+        channel = MagicMock(spec=discord.TextChannel)
+        channel.id = 777
+        channel.name = "test-chan"
+
+        view = _SubsystemToggleView(ctx, channel=channel, manager_message=None)
+        view._visibility = {"general": None}
+
+        interaction = _make_interaction(responded=False)
+        interaction.guild = MagicMock()
+
+        with (
+            patch(
+                "cogs.channel_cog.governance_service.set_subsystem_visibility",
+                new_callable=AsyncMock,
+            ) as mock_set,
+            patch(
+                "cogs.channel_cog.GovernanceContext.from_interaction",
+                return_value=MagicMock(),
+            ),
+        ):
+            callback = view._make_toggle_callback("general")
+            await callback(interaction)
+
+        mock_set.assert_awaited_once()
+        interaction.response.edit_message.assert_awaited_once()
+        interaction.response.send_message.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# datetime.utcnow() not present in production code
+# ---------------------------------------------------------------------------
+
+
+def _py_files_under(root: Path) -> list[Path]:
+    return [p for p in root.rglob("*.py") if "__pycache__" not in str(p)]
+
+
+def test_no_datetime_utcnow_in_production_code():
+    """datetime.utcnow() must not appear in any disbot source file.
+
+    Regression guard: all occurrences must have been replaced with
+    datetime.now(tz=...) / datetime.now(tz=timezone.utc).
+
+    Note: discord.utils.utcnow() is a Discord.py-provided timezone-aware helper
+    and is NOT deprecated — this test only catches bare datetime.utcnow() calls.
+    """
+    import re
+
+    # Match .utcnow() not preceded by "discord.utils" — avoids flagging the
+    # discord.utils.utcnow() helper which is timezone-aware and not deprecated.
+    _PATTERN = re.compile(r"(?<!discord\.utils)\.utcnow\(\)")
+    violations: list[str] = []
+    for path in _py_files_under(_DISBOT):
+        src = path.read_text()
+        if _PATTERN.search(src):
+            violations.append(str(path.relative_to(_DISBOT)))
+    assert not violations, (
+        "datetime.utcnow() is deprecated — replace with "
+        "datetime.now(tz=timezone.utc). Violations:\n" + "\n".join(violations)
+    )
+
+
+# ---------------------------------------------------------------------------
+# BaseView.on_error exists and has correct signature
+# ---------------------------------------------------------------------------
+
+
+def test_base_view_has_on_error():
+    """BaseView must define on_error(interaction, error, item)."""
+    import inspect
+
+    from views.base import BaseView
+
+    assert hasattr(BaseView, "on_error"), "BaseView must define on_error()"
+    sig = inspect.signature(BaseView.on_error)
+    params = list(sig.parameters)
+    assert params == [
+        "self",
+        "interaction",
+        "error",
+        "item",
+    ], f"on_error signature mismatch: {params}"
+
+
+def test_persistent_view_has_on_error():
+    """PersistentView must define on_error(interaction, error, item)."""
+    import inspect
+
+    from core.runtime.persistent_views import PersistentView
+
+    assert hasattr(PersistentView, "on_error"), "PersistentView must define on_error()"
+    sig = inspect.signature(PersistentView.on_error)
+    params = list(sig.parameters)
+    assert params == [
+        "self",
+        "interaction",
+        "error",
+        "item",
+    ], f"on_error signature mismatch: {params}"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

This PR is the culmination of a full forensic-grade audit and multi-phase stabilization migration of SuperBot's governance, runtime, and Discord UI layers. It closes every critical bug, architectural gap, and technical debt item identified in the audit, leaving the system production-ready for single-process deployments up to ~1,000 guilds.

### Phase 1–2 — Critical Bug Fixes & Governance as Infrastructure
- **BUG-001**: Fixed double JSON encoding in `session_state` / `governance_audit_log` (asyncpg JSONB codec + manual `json.dumps` composed); added `_maybe_decode_legacy()` shim + migration 012 to repair existing rows
- **BUG-002**: `EVT_CACHE_INVALIDATED` was never emitted — wired into `GovernanceMutationPipeline` after every visibility/cleanup write
- **BUG-003**: Thread scope rejected by `_VALID_SCOPE_TYPES`; added `"thread"`
- **BUG-004**: `forget_guild_capabilities()` did not clear `_loaded_guilds`; fixed
- **BUG-005**: `runtime.setup()` registered duplicate EventBus handlers on repeated calls; added `_SETUP_DONE` idempotency guard
- **BUG-006**: `_NO_OVERRIDE` sentinel removed from `governance/cache.py` (dead code causing resolver confusion)
- **BUG-007**: `check_existing_instance()` called at module level — moved to `main()`
- **BUG-008**: Non-`CheckFailure` errors swallowed in `on_command_error` when channel guard returned early; fixed logging path
- **ARCH-001**: Governance now enforced at infrastructure level via `@bot.before_invoke _governance_guard` (commands) and `interaction_router.dispatch()` gate (interactions) — not per-cog advisory
- **ARCH-005**: Unknown capabilities now fail closed (`allowed=False`) instead of silently granting access
- **NEW-001**: Unified guild teardown in `guild_lifecycle.py` — coordinates all module-level state in a defined order with per-step error isolation
- **NEW-002**: EventBus handler timeout hardening — 5-second `asyncio.wait_for()` per handler; failure isolated, bus continues
- **NEW-003**: `GovernanceMutationPipeline` — centralized mutation orchestrator enforcing authority validation → old-value read → DB transaction → cache invalidation → event emission

### Phase 3 — DB Indexing
- Migration 013: `idx_governance_audit_actor`, `idx_governance_audit_subsystem`, `idx_panel_anchors_guild`

### Phase 4 — Gap Closure
- **GAP-001**: Panel anchors for departed guilds never deleted — added `db.delete_guild_panel_anchors()` to guild teardown
- **DEBT-001**: Capability override cache had no TTL — added `_OVERRIDE_TTL = 600s` with `_overrides_stale()` check
- **DEBT-002**: Internal bypass (`check_visibility=False`) had no DB audit trail — `_audit_internal_bypass()` writes to `governance_audit_log` with `action="execution_bypass"`
- **DEBT-003**: `EVT_CLEANUP_CHANGED` had no subscriber — wired into `runtime.setup()`
- **DEBT-006**: `_last_edit` partial cleanup (size gate) in teardown — removed size gate; rekeyed to `(guild_id, channel_id)`; added `forget_guild()` public API

### Phase 5 — Help Menu & Registry Fixes
- **General cog** invisible in help menu: `SUBSYSTEMS["general"]["entry_points"] = ["generalmenu"]` but no `!generalmenu` command existed — added command + `_GeneralPanelView` + `build_help_menu_view()` hook
- **proof_channel** subsystem: entry_points updated to match actual cog commands
- **HelpPanelView direct navigation**: `_on_select` now calls `cog.build_help_menu_view(interaction)` when available, replacing the help message in-place with the subsystem panel + "↩ Back to Help" button; falls back to inline command list
- **INV-003**: `governance/templates.apply_template()` was calling `db.set_subsystem_visibility()` directly, bypassing the pipeline — refactored to route through `GovernanceMutationPipeline`

### Phase 6 — View Interaction Failures
- **`BaseView.on_error()`**: Added to all panel views — logs view class, item `custom_id`/`label`, user/guild/channel/message IDs with full traceback; sends ephemeral error to user when interaction not yet responded
- **`PersistentView.on_error()`**: Same contract, covers `HelpPanelView`
- **Blackjack views**: Added `on_error()` to `BlackjackView`, `_ChallengeView`, `_TournRegistrationView`, `_TournBlackjackView` (all previously had no error hook)
- **`_SubsystemToggleView._make_toggle_callback`**: Wrapped `set_subsystem_visibility` in try/except — a `GovernanceError` no longer leaves the interaction unacknowledged
- **`_back_callback`**: Wrapped `resolve_visibility` in try/except with ephemeral fallback
- **`datetime.utcnow()` removed**: Replaced with `datetime.now(tz=timezone.utc)` across bot1.py, healthserver.py, webhook_reporter.py, diagnostic_cog.py, counting_cog.py, role_cog.py, db.py

## Test plan

- [ ] 170 unit tests pass (`pytest tests/ -v`)
- [ ] `black --check`, `isort --check-only`, `ruff check`, `mypy disbot/` all clean
- [ ] Migration 012 verified: `SELECT COUNT(*) FROM runtime_session_state WHERE jsonb_typeof(value) = 'string'` returns 0
- [ ] Migration 013 applied (governance audit indexes)
- [ ] Disable a subsystem via governance → `!command` denied with user-facing message → interaction button denied with ephemeral → help menu hides the subsystem
- [ ] Leave guild → `_loaded_guilds` empty, `_CACHE_VERSION` cleared, panel anchors deleted
- [ ] Call `runtime.setup()` twice → same handler count (idempotency)
- [ ] Click a governance toggle button without moderator role → ephemeral error, not "This interaction failed"
- [ ] Click "↩ Back to Help" after navigating to General panel → returns to paginated help view

https://claude.ai/code/session_01JfMNj8xCCrbSb3ihrWQFDy
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JfMNj8xCCrbSb3ihrWQFDy)_