### PR TITLE
fix(help): always send fresh !help message instead of editing stale anchor

### DIFF
--- a/disbot/cogs/help_cog.py
+++ b/disbot/cogs/help_cog.py
@@ -4,7 +4,6 @@ import logging
 import math
 
 import discord
-from core.runtime import panel_manager
 from core.runtime.persistent_views import PersistentView, register
 from discord.ext import commands
 from services import governance_service
@@ -436,7 +435,28 @@ class HelpCog(commands.Cog):
 
         view = HelpPanelView(visible_list, page=0)
         embed = _build_page_embed(self.bot, visible_list, 0, member_tier)
-        await panel_manager.get_or_render_panel(ctx, "help", embed, view)
+
+        # The help panel is invoke-and-see, not a stable hub: each !help should
+        # appear at the bottom of the channel where the user just typed.
+        # Delete any prior anchored help message so the new one is the only
+        # active panel and the channel doesn't accumulate dead help embeds.
+        from core.runtime import message_anchor_manager
+
+        old_anchor = await message_anchor_manager.get(
+            ctx.author.id, ctx.channel.id, "help"
+        )
+        if old_anchor and not old_anchor["is_stale"]:
+            try:
+                old_msg = await ctx.channel.fetch_message(old_anchor["message_id"])
+                await old_msg.delete()
+            except (discord.NotFound, discord.Forbidden, discord.HTTPException):
+                pass
+            await message_anchor_manager.mark_stale(str(old_anchor["anchor_id"]))
+
+        msg = await ctx.send(embed=embed, view=view)
+        await message_anchor_manager.upsert(
+            ctx.author.id, ctx.guild.id, ctx.channel.id, "help", msg.id
+        )
 
 
 async def setup(bot: commands.Bot):

--- a/tests/unit/help/test_help_navigation.py
+++ b/tests/unit/help/test_help_navigation.py
@@ -196,6 +196,129 @@ async def test_help_on_select_handles_missing_cog():
     interaction.response.edit_message.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_help_command_deletes_stale_anchor_and_sends_new():
+    """!help must always send a fresh message; old anchor message must be deleted.
+
+    Regression: after bot restart, the help anchor may point to an old message
+    that has scrolled out of view. The bot was editing that off-screen message
+    so the user saw nothing appear. The fix deletes the old message and posts
+    a new one at the bottom of the channel.
+    """
+    from unittest.mock import patch
+
+    from cogs.help_cog import HelpCog
+
+    bot = MagicMock()
+    bot.command_prefix = "!"
+    cog = HelpCog(bot)
+
+    ctx = MagicMock()
+    ctx.author.id = 111
+    ctx.guild.id = 222
+    ctx.channel.id = 333
+    ctx.message.id = 99999
+    ctx.send = AsyncMock(return_value=MagicMock(id=88888))
+    ctx.prefix = "!"
+
+    vis_result = MagicMock()
+    vis_result.visible_subsystems = {"general"}
+    vis_result.member_tier = "user"
+
+    old_msg = MagicMock()
+    old_msg.delete = AsyncMock()
+    ctx.channel.fetch_message = AsyncMock(return_value=old_msg)
+
+    old_anchor = {
+        "anchor_id": "abc-123",
+        "message_id": 55555,
+        "is_stale": False,
+    }
+
+    with (
+        patch(
+            "cogs.help_cog.governance_service.resolve_visibility",
+            new_callable=AsyncMock,
+            return_value=vis_result,
+        ),
+        patch(
+            "cogs.help_cog.GovernanceContext.from_ctx",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "core.runtime.message_anchor_manager.get",
+            new_callable=AsyncMock,
+            return_value=old_anchor,
+        ),
+        patch(
+            "core.runtime.message_anchor_manager.mark_stale",
+            new_callable=AsyncMock,
+        ) as mark_stale,
+        patch(
+            "core.runtime.message_anchor_manager.upsert",
+            new_callable=AsyncMock,
+        ) as upsert,
+    ):
+        await cog.help_command.callback(cog, ctx)
+
+    old_msg.delete.assert_awaited_once()
+    mark_stale.assert_awaited_once_with("abc-123")
+    ctx.send.assert_awaited_once()
+    upsert.assert_awaited_once_with(111, 222, 333, "help", 88888)
+
+
+@pytest.mark.asyncio
+async def test_help_command_no_stale_anchor_sends_new_directly():
+    """When no prior anchor exists, !help sends new without trying to delete."""
+    from unittest.mock import patch
+
+    from cogs.help_cog import HelpCog
+
+    bot = MagicMock()
+    cog = HelpCog(bot)
+
+    ctx = MagicMock()
+    ctx.author.id = 111
+    ctx.guild.id = 222
+    ctx.channel.id = 333
+    ctx.send = AsyncMock(return_value=MagicMock(id=77777))
+    ctx.prefix = "!"
+
+    vis_result = MagicMock()
+    vis_result.visible_subsystems = set()
+    vis_result.member_tier = "user"
+
+    with (
+        patch(
+            "cogs.help_cog.governance_service.resolve_visibility",
+            new_callable=AsyncMock,
+            return_value=vis_result,
+        ),
+        patch(
+            "cogs.help_cog.GovernanceContext.from_ctx",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "core.runtime.message_anchor_manager.get",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "core.runtime.message_anchor_manager.mark_stale",
+            new_callable=AsyncMock,
+        ) as mark_stale,
+        patch(
+            "core.runtime.message_anchor_manager.upsert",
+            new_callable=AsyncMock,
+        ) as upsert,
+    ):
+        await cog.help_command.callback(cog, ctx)
+
+    mark_stale.assert_not_awaited()
+    ctx.send.assert_awaited_once()
+    upsert.assert_awaited_once_with(111, 222, 333, "help", 77777)
+
+
 # ---------------------------------------------------------------------------
 # INV-003 verification: apply_template routes through the pipeline
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

After the PR #43 merge, `!help` still wasn't visibly appearing — deployment logs showed `CMD ✅ HelpCog/help` (command succeeded) but no message landed in the channel.

**Root cause:** `!help` was going through `panel_manager.get_or_render_panel`, which edits the previously-anchored help message in place. After a bot restart, `restore_anchors` restored the old help anchor pointing to a message that had since scrolled out of view in the channel. Each `!help` then silently updated that off-screen embed — server-side success, user-side nothing.

**Fix:** Help is invoke-and-see, not a stable hub. The command now:
1. Looks up any prior help anchor for `(user, channel)`
2. Deletes that old message (best-effort) and marks the anchor stale
3. Sends a fresh message at the bottom of the channel
4. Stores the new anchor

This preserves the one-help-panel-per-(user,channel) invariant (no spam, no orphaned dead embeds) while guaranteeing `!help` always lands where the user is looking. Other anchored panels (inventory, economy, blackjack) keep their edit-in-place behavior since they represent active session state.

## Test plan

- [x] 172 unit tests pass (`pytest tests/ -v`)
- [x] `black`, `isort`, `ruff`, `mypy` all clean
- [x] Two regression tests added:
  - `test_help_command_deletes_stale_anchor_and_sends_new` — verifies old message is deleted, anchor marked stale, new message sent, new anchor upserted
  - `test_help_command_no_stale_anchor_sends_new_directly` — cold-start path: no prior anchor, sends fresh and stores anchor

## Manual verification

- [ ] Run `!help` → menu appears at bottom of channel
- [ ] Scroll up past the help message; run `!help` again → new menu at bottom; old one gone
- [ ] Restart bot → run `!help` → fresh menu (not editing a pre-restart message)

https://claude.ai/code/session_01JfMNj8xCCrbSb3ihrWQFDy

---
_Generated by [Claude Code](https://claude.ai/code/session_01JfMNj8xCCrbSb3ihrWQFDy)_