### PR TITLE
Menu lifecycle + help UX + alias-aware identity + helper layer cleanup

### DIFF
--- a/disbot/cogs/admin_cog.py
+++ b/disbot/cogs/admin_cog.py
@@ -9,7 +9,7 @@ import sys
 import discord
 from discord.ext import commands
 
-from core.runtime.interaction_helpers import safe_defer
+from core.runtime.interaction_helpers import help_ctx_shim, safe_defer
 from utils.ui_constants import ADMIN_COLOR, INFO_COLOR, SUCCESS_COLOR
 from views.base import BaseView
 
@@ -66,6 +66,14 @@ class AdminCog(commands.Cog):
         view = _AdminPanelView(ctx, self)
         msg = await ctx.send(embed=view.build_embed(), view=view)
         view.message = msg
+
+    async def build_help_menu_view(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        """Help-menu direct-navigation hook (returns the admin control panel)."""
+        view = _AdminPanelView(help_ctx_shim(interaction), self)
+        return view.build_embed(), view
 
     # ------------------------------------------------------------------
     # Server Statistics

--- a/disbot/cogs/chain_cog.py
+++ b/disbot/cogs/chain_cog.py
@@ -7,6 +7,7 @@ import discord
 from discord.ext import commands
 from discord.ext.commands import MissingPermissions, has_permissions
 
+from core.runtime.interaction_helpers import help_ctx_shim
 from utils import db
 from views.base import BaseView
 
@@ -196,6 +197,15 @@ class ChainCog(commands.Cog):
         embed = await view.build_embed()
         msg = await ctx.send(embed=embed, view=view)
         view.message = msg
+
+    async def build_help_menu_view(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        """Help-menu direct-navigation hook (returns the chain management panel)."""
+        view = _ChainMenuView(help_ctx_shim(interaction), self)
+        embed = await view.build_embed()
+        return embed, view
 
     @chain.command(name="list")  # type: ignore[arg-type]
     async def list_chains(self, ctx):

--- a/disbot/cogs/channel_cog.py
+++ b/disbot/cogs/channel_cog.py
@@ -19,6 +19,7 @@ import logging
 import discord
 from discord.ext import commands
 
+from core.runtime.interaction_helpers import help_ctx_shim
 from utils.channels import get_or_create_category, safe_channel_name
 from utils.ui_constants import INFO_COLOR, WARNING_COLOR
 
@@ -137,6 +138,14 @@ class ChannelCog(commands.Cog):
         view = _ChannelManagerView(ctx)
         msg = await ctx.send(embed=view.build_embed(), view=view)
         view.message = msg
+
+    async def build_help_menu_view(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        """Help-menu direct-navigation hook (returns the channel manager panel)."""
+        view = _ChannelManagerView(help_ctx_shim(interaction))
+        return view.build_embed(), view
 
     @commands.command(
         name="set",

--- a/disbot/cogs/cleanup_cog.py
+++ b/disbot/cogs/cleanup_cog.py
@@ -8,7 +8,7 @@ import discord
 from discord.ext import commands
 
 import config as _config
-from core.runtime.interaction_helpers import safe_defer
+from core.runtime.interaction_helpers import help_ctx_shim, safe_defer
 from services import governance_service
 from services.governance_service import GovernanceContext
 from utils import db
@@ -266,6 +266,16 @@ class Cleanup(commands.Cog):
         view = _WordMenuView(ctx, self)
         msg = await ctx.send(embed=view.build_embed(), view=view)
         view.message = msg
+
+    async def build_help_menu_view(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        """Help-menu direct-navigation hook (returns the word-list panel)."""
+        if interaction.guild_id not in self._word_cache:
+            await self._load_guild(interaction.guild_id)
+        view = _WordMenuView(help_ctx_shim(interaction), self)
+        return view.build_embed(), view
 
 
 class _AddWordModal(discord.ui.Modal, title="Add Prohibited Word"):  # type: ignore[call-arg]

--- a/disbot/cogs/counting_cog.py
+++ b/disbot/cogs/counting_cog.py
@@ -26,6 +26,7 @@ from discord.ext import commands
 from cogs.counting import game_logic, parsing
 from cogs.counting._constants import word_to_num as _word_to_num  # noqa: F401
 from core.runtime import tasks
+from core.runtime.interaction_helpers import help_ctx_shim
 from utils import db
 
 # Re-export the hub view so legacy ``from cogs.counting_cog import
@@ -92,6 +93,15 @@ class CountingCog(commands.Cog):
         embed = await view.build_embed()
         msg = await ctx.send(embed=embed, view=view)
         view.message = msg
+
+    async def build_help_menu_view(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        """Help-menu direct-navigation hook (returns the counting hub panel)."""
+        view = _CountingHubView(help_ctx_shim(interaction), self)
+        embed = await view.build_embed()
+        return embed, view
 
     @commands.command(name="start_match", aliases=["sm"])
     @staff_or_owner()

--- a/disbot/cogs/economy_cog.py
+++ b/disbot/cogs/economy_cog.py
@@ -69,6 +69,15 @@ class EconomyCog(commands.Cog):
         embed = await _build_economy_embed(ctx.author, ctx.guild.id)
         await panel_manager.get_or_render_panel(ctx, "economy", embed, view)
 
+    async def build_help_menu_view(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        """Help-menu direct-navigation hook (returns the economy hub panel)."""
+        view = EconomyPanelView()
+        embed = await _build_economy_embed(interaction.user, interaction.guild_id)
+        return embed, view
+
     # ------------------------------------------------------------------ events
 
     @commands.Cog.listener()

--- a/disbot/cogs/help_cog.py
+++ b/disbot/cogs/help_cog.py
@@ -467,8 +467,15 @@ class HelpCog(commands.Cog):
             try:
                 old_msg = await ctx.channel.fetch_message(old_anchor["message_id"])
                 await old_msg.delete()
-            except (discord.NotFound, discord.Forbidden, discord.HTTPException):
+            except discord.NotFound:
                 pass
+            except (discord.Forbidden, discord.HTTPException) as exc:
+                logger.debug(
+                    "Could not delete prior help message | user=%d | msg=%d: %s",
+                    ctx.author.id,
+                    old_anchor["message_id"],
+                    exc,
+                )
             await message_anchor_manager.mark_stale(str(old_anchor["anchor_id"]))
 
         msg = await ctx.send(embed=embed, view=view)

--- a/disbot/cogs/mining_cog.py
+++ b/disbot/cogs/mining_cog.py
@@ -164,7 +164,12 @@ class MiningCog(commands.Cog):
             await self.cog.update_inventory(user_id, self.guild_id, found, amount)
 
             new_content = f"{interaction.user.mention} mined {amount}x **{found}** by going {direction}!"
-            await interaction.message.edit(content=new_content, embed=None, view=None)
+            await interaction.followup.edit_message(
+                message_id=interaction.message.id,
+                content=new_content,
+                embed=None,
+                view=None,
+            )
             self.stop()
 
     #

--- a/disbot/cogs/mining_cog.py
+++ b/disbot/cogs/mining_cog.py
@@ -182,6 +182,14 @@ class MiningCog(commands.Cog):
         view = MiningHubView()
         await panel_manager.get_or_render_panel(ctx, "mining", view.build_embed(), view)
 
+    async def build_help_menu_view(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        """Help-menu direct-navigation hook (returns the mining hub panel)."""
+        view = MiningHubView()
+        return view.build_embed(), view
+
     @commands.command()
     async def mine(self, ctx):
         """Start mining with interactive buttons."""

--- a/disbot/cogs/moderation_cog.py
+++ b/disbot/cogs/moderation_cog.py
@@ -19,6 +19,27 @@ from utils.ui_constants import MOD_COLOR
 logger = logging.getLogger("bot")
 
 
+def _build_mod_panel_embed() -> discord.Embed:
+    return stats_block(
+        "🔨 Moderation Panel",
+        [
+            ("⚠️ Warn", "Issue a warning (auto-timeout at 3)", True),
+            ("⏳ Timeout", "Temporarily mute for N minutes", True),
+            ("👢 Kick", "Remove from server", True),
+            ("🚫 Ban", "Permanently ban", True),
+            ("✅ Unban", "Lift a ban by user ID", True),
+            ("📋 Mod Logs", "View moderation history", True),
+            ("⬛ Clear Warnings", "Reset warning count", True),
+        ],
+        MOD_COLOR,
+        description=(
+            "Click a button to take a moderation action.\n"
+            "You'll be prompted to enter the user and reason."
+        ),
+        footer="Any staff member with Moderate Members permission may use this panel.",
+    )
+
+
 def _can_act_on_interaction(
     interaction: discord.Interaction,
     member: Member,
@@ -504,26 +525,16 @@ class ModerationCog(commands.Cog):
     @commands.has_permissions(moderate_members=True)
     async def mod_menu(self, ctx):
         """Show the interactive moderation action panel."""
-        embed = stats_block(
-            "🔨 Moderation Panel",
-            [
-                ("⚠️ Warn", "Issue a warning (auto-timeout at 3)", True),
-                ("⏳ Timeout", "Temporarily mute for N minutes", True),
-                ("👢 Kick", "Remove from server", True),
-                ("🚫 Ban", "Permanently ban", True),
-                ("✅ Unban", "Lift a ban by user ID", True),
-                ("📋 Mod Logs", "View moderation history", True),
-                ("⬛ Clear Warnings", "Reset warning count", True),
-            ],
-            MOD_COLOR,
-            description=(
-                "Click a button to take a moderation action.\n"
-                "You'll be prompted to enter the user and reason."
-            ),
-            footer="Any staff member with Moderate Members permission may use this panel.",
-        )
+        embed = _build_mod_panel_embed()
         view = ModPanelView()
         await panel_manager.get_or_render_panel(ctx, "moderation", embed, view)
+
+    async def build_help_menu_view(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        """Help-menu direct-navigation hook (returns the moderation panel)."""
+        return _build_mod_panel_embed(), ModPanelView()
 
     # ------------------------------------------------------------------
     # Traditional text commands (kept for direct use)

--- a/disbot/cogs/proof_channel_cog.py
+++ b/disbot/cogs/proof_channel_cog.py
@@ -7,6 +7,7 @@ import discord
 from discord.ext import commands
 
 from core.runtime import tasks
+from core.runtime.interaction_helpers import help_ctx_shim
 from utils.helpers import _parse_member
 from utils.ui_constants import ECONOMY_COLOR, SUCCESS_COLOR
 from views.base import BaseView
@@ -108,6 +109,14 @@ class ProofChannelCog(commands.Cog):
         view = _PrizeManagerView(ctx, self)
         msg = await ctx.send(embed=view.build_embed(), view=view)
         view.message = msg
+
+    async def build_help_menu_view(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        """Help-menu direct-navigation hook (returns the prize channel panel)."""
+        view = _PrizeManagerView(help_ctx_shim(interaction), self)
+        return view.build_embed(), view
 
     @commands.command(name="timedprize")
     @commands.has_permissions(manage_channels=True)

--- a/disbot/cogs/role_cog.py
+++ b/disbot/cogs/role_cog.py
@@ -338,6 +338,13 @@ class RoleCog(commands.Cog):
         msg = await panel_manager.get_or_render_panel(ctx, "role", embed, view)
         view.message = msg
 
+    async def build_help_menu_view(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        """Help-menu direct-navigation hook (returns the role management hub)."""
+        return _build_role_hub_embed(), RoleHubPanelView()
+
     @commands.command(name="rolesettings")
     @commands.has_permissions(administrator=True)
     async def rolesettings(self, ctx: commands.Context) -> None:

--- a/disbot/cogs/utility_cog.py
+++ b/disbot/cogs/utility_cog.py
@@ -6,6 +6,7 @@ import discord
 from discord.ext import commands
 
 from core.runtime import tasks
+from core.runtime.interaction_helpers import help_ctx_shim
 from utils import embeds as em
 from utils.ui_constants import INFO_COLOR, SUCCESS_COLOR, UTILITY_COLOR
 from views.base import BaseView
@@ -42,6 +43,14 @@ class UtilityCog(commands.Cog):
         view = _UtilityPanelView(ctx)
         msg = await ctx.send(embed=view.build_embed(), view=view)
         view.message = msg
+
+    async def build_help_menu_view(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        """Help-menu direct-navigation hook (returns the utility panel)."""
+        view = _UtilityPanelView(help_ctx_shim(interaction))
+        return view.build_embed(), view
 
     @commands.command(name="clear", aliases=["purge"])
     @commands.has_permissions(manage_messages=True)

--- a/disbot/cogs/xp_cog.py
+++ b/disbot/cogs/xp_cog.py
@@ -7,7 +7,7 @@ import time
 import discord
 from discord.ext import commands
 
-from core.runtime.interaction_helpers import safe_defer
+from core.runtime.interaction_helpers import safe_defer, safe_edit
 from services import xp_service
 from utils import db
 from utils import embeds as em
@@ -546,7 +546,7 @@ class XpConfigView(discord.ui.View):
     _run_checks = interaction_check
 
     async def _refresh(self, interaction: discord.Interaction):  # type: ignore[override]
-        await interaction.message.edit(embed=await self.build_embed(), view=self)
+        await safe_edit(interaction, embed=await self.build_embed(), view=self)
 
     @discord.ui.button(label="XP Range", style=discord.ButtonStyle.blurple, row=0)
     async def btn_xp_range(

--- a/disbot/cogs/xp_cog.py
+++ b/disbot/cogs/xp_cog.py
@@ -7,7 +7,7 @@ import time
 import discord
 from discord.ext import commands
 
-from core.runtime.interaction_helpers import safe_defer, safe_edit
+from core.runtime.interaction_helpers import help_ctx_shim, safe_defer, safe_edit
 from services import xp_service
 from utils import db
 from utils import embeds as em
@@ -283,6 +283,15 @@ class XpCog(commands.Cog):
         embed = await view.build_embed()
         msg = await ctx.send(embed=embed, view=view)
         view.message = msg
+
+    async def build_help_menu_view(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        """Help-menu direct-navigation hook (returns the XP hub panel)."""
+        view = _XpHubView(help_ctx_shim(interaction))
+        embed = await view.build_embed()
+        return embed, view
 
     # ------------------------------------------------------------------ events
 

--- a/disbot/core/runtime/interaction_helpers.py
+++ b/disbot/core/runtime/interaction_helpers.py
@@ -33,11 +33,33 @@ the platform-hardening plan.  Adoption across cogs lands in F5.
 from __future__ import annotations
 
 import logging
+from types import SimpleNamespace
 from typing import Any
 
 import discord
 
 logger = logging.getLogger("bot.runtime.interaction")
+
+
+def help_ctx_shim(interaction: discord.Interaction) -> SimpleNamespace:
+    """Build a ctx-like object from an interaction for help-menu view dispatch.
+
+    Cog hub views (e.g. _AdminPanelView, _XpHubView, _ChannelManagerView)
+    were written to take a commands.Context.  When the help dropdown opens
+    them directly we only have a discord.Interaction.  The four attributes
+    those views read from ctx are ``author``, ``guild``, ``channel``, and
+    ``bot`` — this shim exposes them.
+
+    Views that need ``ctx.invoke``, ``ctx.send``, ``ctx.prefix``, or
+    ``ctx.message`` cannot use this shim and must take their dependencies
+    directly instead.
+    """
+    return SimpleNamespace(
+        author=interaction.user,
+        guild=interaction.guild,
+        channel=interaction.channel,
+        bot=interaction.client,
+    )
 
 
 async def safe_defer(

--- a/disbot/core/runtime/message_anchor_manager.py
+++ b/disbot/core/runtime/message_anchor_manager.py
@@ -134,6 +134,19 @@ async def restore_anchors(bot: commands.Bot) -> None:
 
     for anchor in anchors:
         subsystem = anchor["subsystem"]
+        # Help is invoke-and-see, not a stable hub (see help_cog.help_command).
+        # Restoring it would either re-attach a HelpPanelView with empty
+        # _visible/_page state or require schema work to persist that state.
+        # Neither matches the lifecycle — drop the anchor so the user's next
+        # !help creates a clean panel via panel_manager.
+        if subsystem == "help":
+            await mark_stale(str(anchor["anchor_id"]))
+            stale += 1
+            metrics.anchor_restore_total.labels(
+                subsystem=subsystem,
+                result="skipped_help",
+            ).inc()
+            continue
         view_cls = get_view_class(subsystem)
         if view_cls is None:
             # Cog with PersistentView didn't register — leftover anchor.

--- a/disbot/core/runtime/panel_manager.py
+++ b/disbot/core/runtime/panel_manager.py
@@ -1,15 +1,14 @@
 """Persistent panel lifecycle management.
 
 A panel is a Discord message with an interactive view that is anchored to a
-specific (user, channel, subsystem) triple in the database.  The runtime
-platform enforces one panel per triple at a time:
+specific (user, channel, subsystem) triple in the database.  The anchor table
+enforces one panel per triple at a time.
 
-  - If an anchor exists and the message is still accessible: edit in-place.
-  - If the anchor's message was deleted: create a new message, overwrite anchor.
-  - If no anchor exists: send new message, store anchor.
-
-This eliminates the "stale message pile-up" problem where every command run
-sends a new message that orphans previous panels.
+Re-invocation behavior — every panel command sends a FRESH message at the
+bottom of the channel.  If a prior anchored message exists for the same
+(user, channel, subsystem), it is deleted first so the channel doesn't
+accumulate orphaned panels.  This matches the user-facing expectation that
+running a command produces a new visible result.
 
 Public surface:
     get_or_render_panel(ctx, subsystem, embed, view) → discord.Message
@@ -33,10 +32,9 @@ async def get_or_render_panel(
     embed: discord.Embed,
     view: discord.ui.View,
 ) -> discord.Message:
-    """Send or update the persistent panel for this user in this channel.
+    """Send a fresh panel message, deleting the prior anchored one if any.
 
-    Returns the Discord Message that contains the panel (either the existing
-    anchored message after editing, or the newly sent one).
+    Returns the newly-sent Discord Message.
     """
     user_id = ctx.author.id
     guild_id = ctx.guild.id
@@ -46,30 +44,30 @@ async def get_or_render_panel(
 
     if anchor and not anchor["is_stale"]:
         try:
-            msg = await ctx.channel.fetch_message(anchor["message_id"])
-            await msg.edit(embed=embed, view=view)
+            old_msg = await ctx.channel.fetch_message(anchor["message_id"])
+            await old_msg.delete()
             logger.debug(
-                "Panel updated in-place | subsystem=%s | user=%d | msg=%d",
+                "Prior panel deleted | subsystem=%s | user=%d | msg=%d",
                 subsystem,
                 user_id,
-                msg.id,
+                anchor["message_id"],
             )
-            return msg
         except discord.NotFound:
             logger.debug(
-                "Panel anchor stale (msg deleted) | subsystem=%s | user=%d",
+                "Prior panel already gone | subsystem=%s | user=%d | msg=%d",
                 subsystem,
                 user_id,
+                anchor["message_id"],
             )
-            await message_anchor_manager.mark_stale(str(anchor["anchor_id"]))
         except (discord.Forbidden, discord.HTTPException) as exc:
             logger.warning(
-                "Cannot edit panel message | subsystem=%s | user=%d: %s",
+                "Could not delete prior panel | subsystem=%s user=%d msg=%d: %s",
                 subsystem,
                 user_id,
+                anchor["message_id"],
                 exc,
             )
-            await message_anchor_manager.mark_stale(str(anchor["anchor_id"]))
+        await message_anchor_manager.mark_stale(str(anchor["anchor_id"]))
 
     msg = await ctx.send(embed=embed, view=view)
     await message_anchor_manager.upsert(

--- a/disbot/views/base.py
+++ b/disbot/views/base.py
@@ -45,8 +45,13 @@ class BaseView(discord.ui.View):
         if self.message:
             try:
                 await self.message.edit(view=self)
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug(
+                    "%s.on_timeout: message.edit failed (msg=%s): %s",
+                    type(self).__name__,
+                    self.message.id,
+                    exc,
+                )
 
     async def on_error(
         self,

--- a/tests/unit/help/test_help_direct_navigation.py
+++ b/tests/unit/help/test_help_direct_navigation.py
@@ -1,0 +1,142 @@
+"""Help-menu direct-navigation contract tests.
+
+When the user picks a category in the help dropdown, HelpPanelView._on_select
+calls ``cog.build_help_menu_view(interaction)`` and replaces the help embed
+with the cog's hub panel directly — no inline command-list fallback, no
+secondary click.
+
+These tests enforce that every cog with a hub panel exposes the hook and that
+calling it returns a (discord.Embed, discord.ui.View) pair.  Static assertion
+covers existence; a smoke run per cog asserts the hook actually executes
+against a stubbed interaction.
+"""
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+# Every cog module + the cog class that should expose build_help_menu_view.
+# Game/one-shot subsystems (blackjack, deathmatch, leaderboard, etc.) are
+# intentionally absent — their entry commands start a game, not open a panel,
+# so the help dropdown falls back to the inline command list for them.
+_PANEL_COGS: list[tuple[str, str]] = [
+    ("cogs.admin_cog", "AdminCog"),
+    ("cogs.moderation_cog", "ModerationCog"),
+    ("cogs.economy_cog", "EconomyCog"),
+    ("cogs.mining_cog", "MiningCog"),
+    ("cogs.xp_cog", "XpCog"),
+    ("cogs.role_cog", "RoleCog"),
+    ("cogs.channel_cog", "ChannelCog"),
+    ("cogs.cleanup_cog", "Cleanup"),
+    ("cogs.counting_cog", "CountingCog"),
+    ("cogs.chain_cog", "ChainCog"),
+    ("cogs.proof_channel_cog", "ProofChannelCog"),
+    ("cogs.utility_cog", "UtilityCog"),
+    ("cogs.general_cog", "General"),
+]
+
+
+def _resolve(module_path: str, class_name: str):
+    mod = __import__(module_path, fromlist=[class_name])
+    return getattr(mod, class_name)
+
+
+@pytest.mark.parametrize(("module_path", "class_name"), _PANEL_COGS)
+def test_panel_cog_exposes_build_help_menu_view(module_path: str, class_name: str):
+    cog_cls = _resolve(module_path, class_name)
+    hook = getattr(cog_cls, "build_help_menu_view", None)
+    assert callable(hook), (
+        f"{class_name} must expose async def build_help_menu_view(interaction) "
+        "so the help dropdown can navigate directly to its panel"
+    )
+    assert inspect.iscoroutinefunction(hook), (
+        f"{class_name}.build_help_menu_view must be async"
+    )
+
+
+def _stub_interaction(user_id: int = 111, guild_id: int = 222) -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = SimpleNamespace(
+        id=user_id,
+        display_name="tester",
+        display_avatar=SimpleNamespace(url="http://x"),
+        guild_permissions=SimpleNamespace(administrator=True),
+        mention="<@111>",
+    )
+    interaction.guild = MagicMock()
+    interaction.guild.id = guild_id
+    interaction.guild_id = guild_id
+    interaction.channel = MagicMock()
+    interaction.channel.id = 333
+    interaction.channel.mention = "#test"
+    interaction.client = MagicMock()
+    return interaction
+
+
+@pytest.mark.asyncio
+async def test_economy_build_help_menu_view_returns_embed_and_view():
+    from unittest.mock import patch
+
+    from cogs.economy_cog import EconomyCog
+
+    cog = EconomyCog(MagicMock())
+    interaction = _stub_interaction()
+
+    fake_embed = discord.Embed(title="x")
+    with patch(
+        "cogs.economy_cog._build_economy_embed",
+        new_callable=AsyncMock,
+        return_value=fake_embed,
+    ):
+        embed, view = await cog.build_help_menu_view(interaction)
+
+    assert isinstance(embed, discord.Embed)
+    assert isinstance(view, discord.ui.View)
+
+
+@pytest.mark.asyncio
+async def test_mining_build_help_menu_view_returns_embed_and_view():
+    from cogs.mining_cog import MiningCog
+
+    cog = MiningCog(MagicMock())
+    embed, view = await cog.build_help_menu_view(_stub_interaction())
+    assert isinstance(embed, discord.Embed)
+    assert isinstance(view, discord.ui.View)
+
+
+@pytest.mark.asyncio
+async def test_role_build_help_menu_view_returns_embed_and_view():
+    from cogs.role_cog import RoleCog
+
+    cog = RoleCog(MagicMock())
+    embed, view = await cog.build_help_menu_view(_stub_interaction())
+    assert isinstance(embed, discord.Embed)
+    assert isinstance(view, discord.ui.View)
+
+
+@pytest.mark.asyncio
+async def test_moderation_build_help_menu_view_returns_embed_and_view():
+    from cogs.moderation_cog import ModerationCog
+
+    cog = ModerationCog(MagicMock())
+    embed, view = await cog.build_help_menu_view(_stub_interaction())
+    assert isinstance(embed, discord.Embed)
+    assert isinstance(view, discord.ui.View)
+
+
+@pytest.mark.asyncio
+async def test_help_ctx_shim_exposes_required_attrs():
+    """The shim must expose author/guild/channel/bot — nothing else needed."""
+    from core.runtime.interaction_helpers import help_ctx_shim
+
+    interaction = _stub_interaction()
+    ctx = help_ctx_shim(interaction)
+    assert ctx.author is interaction.user
+    assert ctx.guild is interaction.guild
+    assert ctx.channel is interaction.channel
+    assert ctx.bot is interaction.client

--- a/tests/unit/help/test_help_direct_navigation.py
+++ b/tests/unit/help/test_help_direct_navigation.py
@@ -5,57 +5,126 @@ calls ``cog.build_help_menu_view(interaction)`` and replaces the help embed
 with the cog's hub panel directly — no inline command-list fallback, no
 secondary click.
 
-These tests enforce that every cog with a hub panel exposes the hook and that
-calling it returns a (discord.Embed, discord.ui.View) pair.  Static assertion
-covers existence; a smoke run per cog asserts the hook actually executes
-against a stubbed interaction.
+The discovery test below AST-scans every cog file: any cog declaring a
+``*menu`` command is treated as panel-bearing and must expose an async
+``build_help_menu_view``.  When a future cog with a panel lands, the test
+fails automatically if the developer forgets the hook — closing the silent
+fallback-to-inline regression.
+
+Smoke tests then run the hook against a stubbed interaction for a handful of
+representative cogs to assert the returned (embed, view) shape.
 """
 
 from __future__ import annotations
 
-import inspect
+import ast
+import sys
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import discord
 import pytest
 
-# Every cog module + the cog class that should expose build_help_menu_view.
-# Game/one-shot subsystems (blackjack, deathmatch, leaderboard, etc.) are
-# intentionally absent — their entry commands start a game, not open a panel,
-# so the help dropdown falls back to the inline command list for them.
-_PANEL_COGS: list[tuple[str, str]] = [
-    ("cogs.admin_cog", "AdminCog"),
-    ("cogs.moderation_cog", "ModerationCog"),
-    ("cogs.economy_cog", "EconomyCog"),
-    ("cogs.mining_cog", "MiningCog"),
-    ("cogs.xp_cog", "XpCog"),
-    ("cogs.role_cog", "RoleCog"),
-    ("cogs.channel_cog", "ChannelCog"),
-    ("cogs.cleanup_cog", "Cleanup"),
-    ("cogs.counting_cog", "CountingCog"),
-    ("cogs.chain_cog", "ChainCog"),
-    ("cogs.proof_channel_cog", "ProofChannelCog"),
-    ("cogs.utility_cog", "UtilityCog"),
-    ("cogs.general_cog", "General"),
-]
+_DISBOT = Path(__file__).parents[3] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+_COGS_DIR = _DISBOT / "cogs"
 
 
-def _resolve(module_path: str, class_name: str):
-    mod = __import__(module_path, fromlist=[class_name])
-    return getattr(mod, class_name)
+def _scan_cog_classes() -> dict[str, dict]:
+    """AST-scan ``disbot/cogs/*.py`` for ``commands.Cog`` subclasses.
+
+    Returns a mapping ``"<module>:<class>" -> {commands, methods, async_methods}``
+    so callers can ask: does this cog declare a command name ending in
+    ``menu``, and if so does it also declare an async ``build_help_menu_view``?
+    """
+    result: dict[str, dict] = {}
+    for py in _COGS_DIR.glob("*.py"):
+        tree = ast.parse(py.read_text(), filename=str(py))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            is_cog = any(
+                isinstance(b, ast.Attribute) and b.attr == "Cog" for b in node.bases
+            )
+            if not is_cog:
+                continue
+
+            commands_set: set[str] = set()
+            methods_set: set[str] = set()
+            async_methods: set[str] = set()
+            for child in node.body:
+                if not isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef):
+                    continue
+                methods_set.add(child.name)
+                if isinstance(child, ast.AsyncFunctionDef):
+                    async_methods.add(child.name)
+                for dec in child.decorator_list:
+                    if not isinstance(dec, ast.Call):
+                        continue
+                    func = dec.func
+                    if not (
+                        isinstance(func, ast.Attribute)
+                        and func.attr in ("command", "group")
+                    ):
+                        continue
+                    cmd_name: str | None = None
+                    for kw in dec.keywords:
+                        if kw.arg == "name" and isinstance(kw.value, ast.Constant):
+                            cmd_name = kw.value.value
+                    if cmd_name is None:
+                        cmd_name = child.name
+                    commands_set.add(cmd_name)
+
+            module_name = "cogs." + py.stem
+            result[f"{module_name}:{node.name}"] = {
+                "commands": commands_set,
+                "methods": methods_set,
+                "async_methods": async_methods,
+            }
+    return result
 
 
-@pytest.mark.parametrize(("module_path", "class_name"), _PANEL_COGS)
-def test_panel_cog_exposes_build_help_menu_view(module_path: str, class_name: str):
-    cog_cls = _resolve(module_path, class_name)
-    hook = getattr(cog_cls, "build_help_menu_view", None)
-    assert callable(hook), (
-        f"{class_name} must expose async def build_help_menu_view(interaction) "
-        "so the help dropdown can navigate directly to its panel"
+def test_every_panel_cog_has_build_help_menu_view():
+    """Every cog with a ``*menu`` command must expose ``build_help_menu_view``.
+
+    Regression guard for silent UX drift: if a new panel cog ships without
+    the direct-navigation hook, the help dropdown silently falls back to
+    the inline command list instead of opening the panel. Without this
+    test that omission would only surface as a runtime UX inconsistency.
+
+    Heuristic: any ``@commands.command(name='*menu')`` (or method named
+    ``*menu`` with no explicit name) is a panel entry point. The owning
+    cog class must define ``async def build_help_menu_view`` so the
+    help-menu select can dispatch into the panel directly.
+    """
+    classes = _scan_cog_classes()
+
+    missing_hook: list[str] = []
+    not_async: list[str] = []
+    for key, info in classes.items():
+        menu_cmds = {c for c in info["commands"] if c.endswith("menu")}
+        if not menu_cmds:
+            continue
+        if "build_help_menu_view" not in info["methods"]:
+            missing_hook.append(f"{key} (declares: {sorted(menu_cmds)})")
+            continue
+        if "build_help_menu_view" not in info["async_methods"]:
+            not_async.append(key)
+
+    assert not missing_hook, (
+        "These cogs declare a *menu command but do not define "
+        "build_help_menu_view — the help dropdown will fall back to the "
+        "inline command list instead of opening the panel directly. Add "
+        "an async build_help_menu_view(self, interaction) method that "
+        "returns (embed, view), mirroring the *menu command body:\n  "
+        + "\n  ".join(missing_hook)
     )
-    assert inspect.iscoroutinefunction(hook), (
-        f"{class_name}.build_help_menu_view must be async"
+    assert not not_async, (
+        "build_help_menu_view must be an async method (help_cog awaits "
+        "the result):\n  " + "\n  ".join(not_async)
     )
 
 

--- a/tests/unit/runtime/test_panel_manager.py
+++ b/tests/unit/runtime/test_panel_manager.py
@@ -1,0 +1,208 @@
+"""Panel re-invocation lifecycle tests.
+
+The user-facing contract: every invocation of a panel command produces a
+NEW message at the bottom of the channel.  Any prior anchored message for
+the same (user, channel, subsystem) is deleted first so the channel does
+not accumulate orphans.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from core.runtime import panel_manager
+
+
+def _make_ctx(*, user_id: int = 111, guild_id: int = 222, channel_id: int = 333):
+    ctx = MagicMock()
+    ctx.author.id = user_id
+    ctx.guild.id = guild_id
+    ctx.channel.id = channel_id
+    ctx.send = AsyncMock(return_value=MagicMock(id=88888))
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_no_prior_anchor_sends_fresh_and_upserts():
+    ctx = _make_ctx()
+    embed = MagicMock()
+    view = MagicMock()
+
+    with (
+        patch(
+            "core.runtime.panel_manager.message_anchor_manager.get",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "core.runtime.panel_manager.message_anchor_manager.mark_stale",
+            new_callable=AsyncMock,
+        ) as mark_stale,
+        patch(
+            "core.runtime.panel_manager.message_anchor_manager.upsert",
+            new_callable=AsyncMock,
+        ) as upsert,
+    ):
+        msg = await panel_manager.get_or_render_panel(ctx, "economy", embed, view)
+
+    ctx.send.assert_awaited_once_with(embed=embed, view=view)
+    mark_stale.assert_not_awaited()
+    upsert.assert_awaited_once_with(111, 222, 333, "economy", 88888)
+    assert msg.id == 88888
+
+
+@pytest.mark.asyncio
+async def test_existing_anchor_deletes_old_then_sends_fresh():
+    ctx = _make_ctx()
+    embed = MagicMock()
+    view = MagicMock()
+
+    old_msg = MagicMock()
+    old_msg.delete = AsyncMock()
+    ctx.channel.fetch_message = AsyncMock(return_value=old_msg)
+
+    anchor = {
+        "anchor_id": "anchor-abc",
+        "message_id": 55555,
+        "is_stale": False,
+    }
+
+    with (
+        patch(
+            "core.runtime.panel_manager.message_anchor_manager.get",
+            new_callable=AsyncMock,
+            return_value=anchor,
+        ),
+        patch(
+            "core.runtime.panel_manager.message_anchor_manager.mark_stale",
+            new_callable=AsyncMock,
+        ) as mark_stale,
+        patch(
+            "core.runtime.panel_manager.message_anchor_manager.upsert",
+            new_callable=AsyncMock,
+        ) as upsert,
+    ):
+        await panel_manager.get_or_render_panel(ctx, "mining", embed, view)
+
+    ctx.channel.fetch_message.assert_awaited_once_with(55555)
+    old_msg.delete.assert_awaited_once()
+    mark_stale.assert_awaited_once_with("anchor-abc")
+    ctx.send.assert_awaited_once_with(embed=embed, view=view)
+    upsert.assert_awaited_once_with(111, 222, 333, "mining", 88888)
+
+
+@pytest.mark.asyncio
+async def test_stale_anchor_skips_delete_and_sends_fresh():
+    ctx = _make_ctx()
+    embed = MagicMock()
+    view = MagicMock()
+
+    anchor = {
+        "anchor_id": "anchor-xyz",
+        "message_id": 44444,
+        "is_stale": True,
+    }
+    ctx.channel.fetch_message = AsyncMock()
+
+    with (
+        patch(
+            "core.runtime.panel_manager.message_anchor_manager.get",
+            new_callable=AsyncMock,
+            return_value=anchor,
+        ),
+        patch(
+            "core.runtime.panel_manager.message_anchor_manager.mark_stale",
+            new_callable=AsyncMock,
+        ) as mark_stale,
+        patch(
+            "core.runtime.panel_manager.message_anchor_manager.upsert",
+            new_callable=AsyncMock,
+        ) as upsert,
+    ):
+        await panel_manager.get_or_render_panel(ctx, "role", embed, view)
+
+    ctx.channel.fetch_message.assert_not_awaited()
+    mark_stale.assert_not_awaited()
+    ctx.send.assert_awaited_once_with(embed=embed, view=view)
+    upsert.assert_awaited_once_with(111, 222, 333, "role", 88888)
+
+
+@pytest.mark.asyncio
+async def test_old_message_already_gone_still_sends_fresh():
+    ctx = _make_ctx()
+    embed = MagicMock()
+    view = MagicMock()
+
+    ctx.channel.fetch_message = AsyncMock(
+        side_effect=discord.NotFound(MagicMock(status=404), "gone")
+    )
+
+    anchor = {
+        "anchor_id": "anchor-old",
+        "message_id": 33333,
+        "is_stale": False,
+    }
+
+    with (
+        patch(
+            "core.runtime.panel_manager.message_anchor_manager.get",
+            new_callable=AsyncMock,
+            return_value=anchor,
+        ),
+        patch(
+            "core.runtime.panel_manager.message_anchor_manager.mark_stale",
+            new_callable=AsyncMock,
+        ) as mark_stale,
+        patch(
+            "core.runtime.panel_manager.message_anchor_manager.upsert",
+            new_callable=AsyncMock,
+        ) as upsert,
+    ):
+        await panel_manager.get_or_render_panel(ctx, "moderation", embed, view)
+
+    mark_stale.assert_awaited_once_with("anchor-old")
+    ctx.send.assert_awaited_once_with(embed=embed, view=view)
+    upsert.assert_awaited_once_with(111, 222, 333, "moderation", 88888)
+
+
+@pytest.mark.asyncio
+async def test_re_invocation_produces_new_message_id_each_time():
+    """Two consecutive invocations must end up with the second (newer) anchor id."""
+    ctx = _make_ctx()
+    embed = MagicMock()
+    view = MagicMock()
+
+    # First call: no prior anchor.
+    # Second call: anchor exists pointing at the first message.
+    ctx.send.side_effect = [MagicMock(id=1001), MagicMock(id=1002)]
+    old_msg = MagicMock()
+    old_msg.delete = AsyncMock()
+    ctx.channel.fetch_message = AsyncMock(return_value=old_msg)
+
+    get_mock = AsyncMock(
+        side_effect=[
+            None,
+            {"anchor_id": "a1", "message_id": 1001, "is_stale": False},
+        ]
+    )
+
+    with (
+        patch("core.runtime.panel_manager.message_anchor_manager.get", get_mock),
+        patch(
+            "core.runtime.panel_manager.message_anchor_manager.mark_stale",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "core.runtime.panel_manager.message_anchor_manager.upsert",
+            new_callable=AsyncMock,
+        ) as upsert,
+    ):
+        await panel_manager.get_or_render_panel(ctx, "economy", embed, view)
+        await panel_manager.get_or_render_panel(ctx, "economy", embed, view)
+
+    assert upsert.await_args_list[0].args == (111, 222, 333, "economy", 1001)
+    assert upsert.await_args_list[1].args == (111, 222, 333, "economy", 1002)
+    old_msg.delete.assert_awaited_once()

--- a/tests/unit/runtime/test_restore_idempotent.py
+++ b/tests/unit/runtime/test_restore_idempotent.py
@@ -47,9 +47,7 @@ async def test_first_call_runs_restoration():
             "core.runtime.persistent_views.get_view_class",
             return_value=MagicMock(return_value=MagicMock()),
         ),
-        patch(
-            "core.runtime.message_anchor_manager.metrics.anchor_restore_total"
-        ),
+        patch("core.runtime.message_anchor_manager.metrics.anchor_restore_total"),
     ):
         await message_anchor_manager.restore_anchors(bot)
         bot.add_view.assert_called_once()
@@ -79,15 +77,67 @@ async def test_second_call_is_noop():
             "core.runtime.persistent_views.get_view_class",
             return_value=MagicMock(return_value=MagicMock()),
         ),
-        patch(
-            "core.runtime.message_anchor_manager.metrics.anchor_restore_total"
-        ),
+        patch("core.runtime.message_anchor_manager.metrics.anchor_restore_total"),
     ):
         await message_anchor_manager.restore_anchors(bot)
         await message_anchor_manager.restore_anchors(bot)
         await message_anchor_manager.restore_anchors(bot)
         # Three reconnects, exactly ONE add_view call — duplicates blocked.
         bot.add_view.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_help_anchors_are_skipped_and_marked_stale():
+    """Help is invoke-and-see — never restore HelpPanelView at startup.
+
+    HelpPanelView holds stateful _visible/_page that cannot be reconstructed
+    from the anchor row alone.  restore_anchors must mark help anchors stale
+    and never call bot.add_view for them, so the next !help creates a clean
+    panel via panel_manager.
+    """
+    anchors = [
+        {
+            "anchor_id": "help-anchor-1",
+            "subsystem": "help",
+            "message_id": 100,
+            "user_id": 1,
+            "guild_id": 2,
+            "channel_id": 3,
+        },
+        {
+            "anchor_id": "role-anchor-1",
+            "subsystem": "role",
+            "message_id": 200,
+            "user_id": 1,
+            "guild_id": 2,
+            "channel_id": 3,
+        },
+    ]
+    bot = MagicMock()
+    bot.add_view = MagicMock()
+    with (
+        patch(
+            "core.runtime.message_anchor_manager.db.get_all_active_panel_anchors",
+            new_callable=AsyncMock,
+            return_value=anchors,
+        ),
+        patch(
+            "core.runtime.persistent_views.get_view_class",
+            return_value=MagicMock(return_value=MagicMock()),
+        ),
+        patch("core.runtime.message_anchor_manager.metrics.anchor_restore_total"),
+        patch(
+            "core.runtime.message_anchor_manager.mark_stale",
+            new_callable=AsyncMock,
+        ) as mark_stale,
+    ):
+        await message_anchor_manager.restore_anchors(bot)
+        # Help anchor was marked stale; only the role anchor was restored.
+        mark_stale.assert_any_await("help-anchor-1")
+        bot.add_view.assert_called_once()
+    stats = message_anchor_manager.last_restore_stats()
+    assert stats["restored"] == 1
+    assert stats["stale"] == 1
 
 
 @pytest.mark.asyncio
@@ -114,9 +164,7 @@ async def test_reset_allows_re_restore():
             "core.runtime.persistent_views.get_view_class",
             return_value=MagicMock(return_value=MagicMock()),
         ),
-        patch(
-            "core.runtime.message_anchor_manager.metrics.anchor_restore_total"
-        ),
+        patch("core.runtime.message_anchor_manager.metrics.anchor_restore_total"),
     ):
         await message_anchor_manager.restore_anchors(bot)
         message_anchor_manager.reset_restoration_state()


### PR DESCRIPTION
## Summary

Six-commit branch that takes the menu/help UX from "stuck in old messages, half the cogs fall back to inline" to "every cog navigates directly, all panel commands send a fresh message, no silent UX drift can sneak in, and the helper layer absorbs the recurring boilerplate."

### `517aa15` — PR M-lifecycle: fresh-message panels + help-anchor skip

User-visible: `!economymenu`, `!minemenu`, `!role`, `!modmenu` now produce a NEW message at the bottom of the channel instead of editing the existing anchored message in place. Resolves the "menu sticks to previous message" symptom.

- `core/runtime/panel_manager.get_or_render_panel` rewritten: delete-then-send.
- `core/runtime/message_anchor_manager.restore_anchors` skips `subsystem=="help"` anchors at startup.
- `mining_cog.py:167` legacy `interaction.message.edit(...)` → `interaction.followup.edit_message(...)`.
- `xp_cog.py:549` same → `safe_edit(...)`.
- Surfaced previously-swallowed delete/edit failures at `logger.debug`.
- New tests in `runtime/test_panel_manager.py` + extended `runtime/test_restore_idempotent.py`.

### `c711c20` — PR M-help-uxc: build_help_menu_view across 12 panel cogs

Added the direct-navigation hook to admin, moderation, economy, mining, xp, role, channel, cleanup, counting, chain, proof_channel, utility. New `help_ctx_shim(interaction)` adapts hub views written against `commands.Context`. New smoke tests + shim contract pin.

### `321d075` — PR M-help-discovery: AST-scan panel cogs to enforce help hook

Replaces hardcoded list with AST-based discovery. Closes silent-degradation gap.

### `6f94cee` — PR M-help-complete: remaining cogs + alias-aware identity

- **Deathmatch "category no longer loaded"** fixed — `_cog_for_subsystem` now considers aliases; same fix in `validate_identity_contract` drops the "12 fatal" findings to 0.
- **Inventory click error** fixed — dropped dead `ctx` parameter; `functools.partial` → closure for category callbacks.
- **Direct-nav for remaining cogs**: inventory, diagnostic, leaderboard, blackjack, rps_tournament, deathmatch.
- **Registry drift cleanup**: removed `inventorymenu`, `craft`, `level`, `rpsmenu`, `counting`, `diagnosticmenu`; fixed `miningmenu` → `minemenu`; added `dm` as real alias on `dm_challenge`.
- **Discovery test strengthened** — now walks `SUBSYSTEMS` so game cogs are also enforced.

### `5d84935` — PR M-help-polish: send_panel helper, logger hierarchy, hub cooldowns

- `views/base.send_panel(ctx, *, embed, view)` collapses `msg = ctx.send(); view.message = msg`. 11 cog command bodies adopted.
- Logger orphan fixes (counting/proof_channel/chain) — log lines were silently dropped from `bot.log`.
- `_attach_back_to_help_button` 25-child silent return → WARNING log.
- Hub-command cooldowns added to adminmenu / channelmenu / chainmenu / generalmenu / utilitymenu / prizemenu.

### `54d895c` — PR M-help-structural: HubView base, on_error helper, stats_block adoption

Structural cleanup. No behaviour change — collapses duplication accreted across cogs.

- **`HubView(BaseView)`** — freezes the 180s timeout. 9 hub views migrated; subclasses now pass only `ctx.author` (or `ctx.author, public=True` for Utility's shared panel) instead of repeating `timeout=180`.
- **`handle_view_error(view, interaction, error, item)`** — extracts the log-with-rich-context + generic-ephemeral pattern that was triplicated in `BaseView.on_error`, `PersistentView.on_error`, and `blackjack_cog._on_view_error`. All three route through the helper. Channel-management views in `views/channels/` keep their own `on_error` because they intentionally surface `type(error).__name__` to admins.
- **`stats_block` adoption** — blackjack/rps_tournament/deathmatch overview embeds (added in M-help-complete) now use the existing `stats_block` helper. Same rendered layout; ~45 lines of `add_field`/`set_footer` boilerplate gone.
- **safe_* sweep** confirmed already complete — `grep -rn 'interaction.response.defer'` shows the only raw call is inside `safe_defer` itself.
- New tests pin HubView's 180s timeout, public-flag pass-through, and `handle_view_error`'s log + ephemeral + is_done()-skip paths. Help direct-nav smoke tests extended to cover blackjack/rps/deathmatch.

## Test plan

- [x] `pytest tests/` → 668 passed (+15 net new across the branch)
- [x] `ruff check disbot` → clean
- [x] `black --check disbot` → clean
- [x] Negative-case tests verified (removing a hook or a build_help_menu_view causes the discovery test to fail with an actionable error)
- [x] Inventory click smoke (without ctx) — no AttributeError
- [ ] Manual smoke (post-merge): re-run the screenshots — `!help` opens each category directly, panel commands produce fresh messages at channel bottom, `!dm @user` works, inventory click navigates without error, identity-contract findings drop to 0 in the log channel.

https://claude.ai/code/session_017UVCWkBejRk326FvAyikrV