### PR TITLE
Help-UX cleanup follow-up: alias-aware identity + helper layer + structural cleanup

### DIFF
--- a/disbot/cogs/admin_cog.py
+++ b/disbot/cogs/admin_cog.py
@@ -11,7 +11,7 @@ from discord.ext import commands
 
 from core.runtime.interaction_helpers import help_ctx_shim, safe_defer
 from utils.ui_constants import ADMIN_COLOR, INFO_COLOR, SUCCESS_COLOR
-from views.base import BaseView, send_panel
+from views.base import HubView, send_panel
 
 COGS_DIR = os.path.dirname(os.path.abspath(__file__))
 PID_FILE = os.path.join(os.path.dirname(COGS_DIR), "bot.pid")
@@ -225,11 +225,11 @@ class AdminCog(commands.Cog):
 # ---------------------------------------------------------------------------
 
 
-class _AdminPanelView(BaseView):
+class _AdminPanelView(HubView):
     """Interactive admin control panel."""
 
     def __init__(self, ctx: commands.Context, cog: AdminCog):
-        super().__init__(ctx.author, timeout=180)
+        super().__init__(ctx.author)
         self.ctx = ctx
         self.cog = cog
 

--- a/disbot/cogs/admin_cog.py
+++ b/disbot/cogs/admin_cog.py
@@ -11,7 +11,7 @@ from discord.ext import commands
 
 from core.runtime.interaction_helpers import help_ctx_shim, safe_defer
 from utils.ui_constants import ADMIN_COLOR, INFO_COLOR, SUCCESS_COLOR
-from views.base import BaseView
+from views.base import BaseView, send_panel
 
 COGS_DIR = os.path.dirname(os.path.abspath(__file__))
 PID_FILE = os.path.join(os.path.dirname(COGS_DIR), "bot.pid")
@@ -59,13 +59,13 @@ class AdminCog(commands.Cog):
     # Admin menu
     # ------------------------------------------------------------------
 
+    @commands.cooldown(rate=2, per=10, type=commands.BucketType.user)
     @commands.command(name="adminmenu")
     @commands.has_permissions(administrator=True)
     async def admin_menu(self, ctx):
         """Open the interactive admin control panel."""
         view = _AdminPanelView(ctx, self)
-        msg = await ctx.send(embed=view.build_embed(), view=view)
-        view.message = msg
+        await send_panel(ctx, embed=view.build_embed(), view=view)
 
     async def build_help_menu_view(
         self,

--- a/disbot/cogs/blackjack_cog.py
+++ b/disbot/cogs/blackjack_cog.py
@@ -7,6 +7,7 @@ import discord
 from discord.ext import commands
 
 from core.runtime import tasks
+from core.runtime.component_registry import stats_block
 from core.runtime.interaction_helpers import safe_defer, safe_edit, safe_followup
 from services import economy_service, game_state_service
 from services.blackjack_engine import hand_str as _hand_str
@@ -19,37 +20,9 @@ from utils.channels import cleanup_category, create_private_channel
 from utils.settings_keys import ACTIVE_TOURNAMENT
 from utils.tournaments import TournamentRegistration
 from utils.ui_constants import ECONOMY_COLOR, ERROR_COLOR, GAME_COLOR, SUCCESS_COLOR
+from views.base import handle_view_error as _on_view_error
 
 logger = logging.getLogger("bot")
-
-
-async def _on_view_error(
-    view: discord.ui.View,
-    interaction: discord.Interaction,
-    error: Exception,
-    item: discord.ui.Item,  # type: ignore[type-arg]
-) -> None:
-    logger.error(
-        "View error | view=%s item_type=%s custom_id=%r label=%r "
-        "user=%s guild=%s channel=%s message=%s",
-        type(view).__name__,
-        type(item).__name__,
-        getattr(item, "custom_id", None),
-        getattr(item, "label", None),
-        getattr(interaction.user, "id", None),
-        interaction.guild_id,
-        interaction.channel_id,
-        interaction.message.id if interaction.message else None,
-        exc_info=error,
-    )
-    if not interaction.response.is_done():
-        try:
-            await interaction.response.send_message(
-                "An error occurred. Please try again.",
-                ephemeral=True,
-            )
-        except Exception:
-            pass
 
 
 # ---------------------------------------------------------------------------
@@ -1187,30 +1160,20 @@ class BlackjackCog(commands.Cog):
         embed with no buttons. The help-cog appends the "↩ Back to Help"
         control automatically.
         """
-        embed = discord.Embed(
-            title="🃏 Blackjack",
+        embed = stats_block(
+            "🃏 Blackjack",
+            [
+                ("Solo vs bot", "`!blackjack <bet>` or `!bj <bet>`", False),
+                ("PvP challenge", "`!blackjack @user <bet>`", False),
+                ("Tournament", "`!bjtournament` — open registration", False),
+            ],
+            GAME_COLOR,
             description=(
                 "Classic 21 — play solo against the bot or challenge another "
                 "player. Tournament mode runs scheduled brackets."
             ),
-            color=GAME_COLOR,
+            footer="Bets are in 🪙 coins. Bet 0 for a free game.",
         )
-        embed.add_field(
-            name="Solo vs bot",
-            value="`!blackjack <bet>` or `!bj <bet>`",
-            inline=False,
-        )
-        embed.add_field(
-            name="PvP challenge",
-            value="`!blackjack @user <bet>`",
-            inline=False,
-        )
-        embed.add_field(
-            name="Tournament",
-            value="`!bjtournament` — open registration",
-            inline=False,
-        )
-        embed.set_footer(text="Bets are in 🪙 coins. Bet 0 for a free game.")
         return embed, discord.ui.View(timeout=300)
 
     async def cog_load(self):

--- a/disbot/cogs/blackjack_cog.py
+++ b/disbot/cogs/blackjack_cog.py
@@ -1176,6 +1176,43 @@ class BlackjackCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
 
+    async def build_help_menu_view(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        """Help-menu direct-navigation hook (returns a blackjack overview).
+
+        The blackjack subsystem has no hub panel — the entry command starts
+        a game with an optional bet/opponent — so we return an informational
+        embed with no buttons. The help-cog appends the "↩ Back to Help"
+        control automatically.
+        """
+        embed = discord.Embed(
+            title="🃏 Blackjack",
+            description=(
+                "Classic 21 — play solo against the bot or challenge another "
+                "player. Tournament mode runs scheduled brackets."
+            ),
+            color=GAME_COLOR,
+        )
+        embed.add_field(
+            name="Solo vs bot",
+            value="`!blackjack <bet>` or `!bj <bet>`",
+            inline=False,
+        )
+        embed.add_field(
+            name="PvP challenge",
+            value="`!blackjack @user <bet>`",
+            inline=False,
+        )
+        embed.add_field(
+            name="Tournament",
+            value="`!bjtournament` — open registration",
+            inline=False,
+        )
+        embed.set_footer(text="Bets are in 🪙 coins. Bet 0 for a free game.")
+        return embed, discord.ui.View(timeout=300)
+
     async def cog_load(self):
         tasks.spawn("blackjack:cleanup_orphaned", self._cleanup_orphaned_tournaments())
         # PR G2/G3 — drop blackjack solo + PvP game_state rows left

--- a/disbot/cogs/chain_cog.py
+++ b/disbot/cogs/chain_cog.py
@@ -9,7 +9,7 @@ from discord.ext.commands import MissingPermissions, has_permissions
 
 from core.runtime.interaction_helpers import help_ctx_shim
 from utils import db
-from views.base import BaseView, send_panel
+from views.base import HubView, send_panel
 
 logger = logging.getLogger("bot.cogs.chain")
 
@@ -446,11 +446,11 @@ class _SetLimitModal(discord.ui.Modal, title="Set Word Limit"):  # type: ignore[
             )
 
 
-class _ChainMenuView(BaseView):
+class _ChainMenuView(HubView):
     """Interactive chain channel management panel."""
 
     def __init__(self, ctx: commands.Context, cog: ChainCog):
-        super().__init__(ctx.author, timeout=180)
+        super().__init__(ctx.author)
         self.ctx = ctx
         self.cog = cog
 

--- a/disbot/cogs/chain_cog.py
+++ b/disbot/cogs/chain_cog.py
@@ -9,9 +9,9 @@ from discord.ext.commands import MissingPermissions, has_permissions
 
 from core.runtime.interaction_helpers import help_ctx_shim
 from utils import db
-from views.base import BaseView
+from views.base import BaseView, send_panel
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("bot.cogs.chain")
 
 
 class ChainCog(commands.Cog):
@@ -189,14 +189,14 @@ class ChainCog(commands.Cog):
             await ctx.send(f"❌ An error occurred: {str(error)}")
             logger.error(f"Error in remove_limit command: {error}")
 
+    @commands.cooldown(rate=2, per=10, type=commands.BucketType.user)
     @commands.command(name="chainmenu")
     @has_permissions(administrator=True)
     async def chain_menu(self, ctx):
         """Open the interactive chain management panel."""
         view = _ChainMenuView(ctx, self)
         embed = await view.build_embed()
-        msg = await ctx.send(embed=embed, view=view)
-        view.message = msg
+        await send_panel(ctx, embed=embed, view=view)
 
     async def build_help_menu_view(
         self,

--- a/disbot/cogs/channel_cog.py
+++ b/disbot/cogs/channel_cog.py
@@ -22,6 +22,7 @@ from discord.ext import commands
 from core.runtime.interaction_helpers import help_ctx_shim
 from utils.channels import get_or_create_category, safe_channel_name
 from utils.ui_constants import INFO_COLOR, WARNING_COLOR
+from views.base import send_panel
 
 # Re-exports for test backward-compat and any external consumers that
 # imported these names directly from cogs.channel_cog.
@@ -128,6 +129,7 @@ class ChannelCog(commands.Cog):
     # Commands
     # -------------------
 
+    @commands.cooldown(rate=2, per=10, type=commands.BucketType.user)
     @commands.command(
         name="channelmenu",
         help="Open the interactive channel management panel.",
@@ -136,8 +138,7 @@ class ChannelCog(commands.Cog):
     async def channel_menu(self, ctx):
         """Open the interactive channel management panel."""
         view = _ChannelManagerView(ctx)
-        msg = await ctx.send(embed=view.build_embed(), view=view)
-        view.message = msg
+        await send_panel(ctx, embed=view.build_embed(), view=view)
 
     async def build_help_menu_view(
         self,

--- a/disbot/cogs/cleanup_cog.py
+++ b/disbot/cogs/cleanup_cog.py
@@ -13,7 +13,7 @@ from services import governance_service
 from services.governance_service import GovernanceContext
 from utils import db
 from utils.ui_constants import ADMIN_COLOR
-from views.base import BaseView, send_panel
+from views.base import HubView, send_panel
 
 
 def _extract_command_name(content: str, prefixes: list[str]) -> str | None:
@@ -323,11 +323,11 @@ class _RemoveWordModal(discord.ui.Modal, title="Remove Prohibited Word"):  # typ
             )
 
 
-class _WordMenuView(BaseView):
+class _WordMenuView(HubView):
     """Interactive prohibited-words management panel."""
 
     def __init__(self, ctx: commands.Context, cog: Cleanup):
-        super().__init__(ctx.author, timeout=180)
+        super().__init__(ctx.author)
         self.ctx = ctx
         self.cog = cog
 

--- a/disbot/cogs/cleanup_cog.py
+++ b/disbot/cogs/cleanup_cog.py
@@ -13,7 +13,7 @@ from services import governance_service
 from services.governance_service import GovernanceContext
 from utils import db
 from utils.ui_constants import ADMIN_COLOR
-from views.base import BaseView
+from views.base import BaseView, send_panel
 
 
 def _extract_command_name(content: str, prefixes: list[str]) -> str | None:
@@ -264,8 +264,7 @@ class Cleanup(commands.Cog):
         if ctx.guild.id not in self._word_cache:
             await self._load_guild(ctx.guild.id)
         view = _WordMenuView(ctx, self)
-        msg = await ctx.send(embed=view.build_embed(), view=view)
-        view.message = msg
+        await send_panel(ctx, embed=view.build_embed(), view=view)
 
     async def build_help_menu_view(
         self,

--- a/disbot/cogs/counting_cog.py
+++ b/disbot/cogs/counting_cog.py
@@ -28,12 +28,13 @@ from cogs.counting._constants import word_to_num as _word_to_num  # noqa: F401
 from core.runtime import tasks
 from core.runtime.interaction_helpers import help_ctx_shim
 from utils import db
+from views.base import send_panel
 
 # Re-export the hub view so legacy ``from cogs.counting_cog import
 # _CountingHubView`` imports keep resolving.
 from views.counting import _CountingHubView  # noqa: F401
 
-logger = logging.getLogger("CountingCog")
+logger = logging.getLogger("bot.cogs.counting")
 
 
 class CountingCog(commands.Cog):
@@ -91,8 +92,7 @@ class CountingCog(commands.Cog):
         """Open the interactive counting game management panel."""
         view = _CountingHubView(ctx, self)
         embed = await view.build_embed()
-        msg = await ctx.send(embed=embed, view=view)
-        view.message = msg
+        await send_panel(ctx, embed=embed, view=view)
 
     async def build_help_menu_view(
         self,

--- a/disbot/cogs/deathmatch_cog.py
+++ b/disbot/cogs/deathmatch_cog.py
@@ -6,6 +6,7 @@ import discord
 from discord.ext import commands
 from discord.ext.commands import BucketType, cooldown
 
+from core.runtime.component_registry import stats_block
 from utils import db
 from utils.ui_constants import GAME_COLOR
 
@@ -240,25 +241,27 @@ class Deathmatch(commands.Cog):
         hub panel. The returned overview embed describes the flow; the
         help-cog appends the "↩ Back to Help" control automatically.
         """
-        embed = discord.Embed(
-            title="⚔️ Deathmatch",
+        embed = stats_block(
+            "⚔️ Deathmatch",
+            [
+                (
+                    "Challenge",
+                    "`!deathmatch @user`  (alias of `!dm_challenge @user`)",
+                    False,
+                ),
+                (
+                    "Stats",
+                    "`!leaderboard deathmatch` — top duelists",
+                    False,
+                ),
+            ],
+            GAME_COLOR,
             description=(
                 "Challenge another player to a 1v1 duel.  Attack and defend "
                 "via buttons on the duel message until one combatant falls."
             ),
-            color=GAME_COLOR,
+            footer="30-second cooldown between challenges.",
         )
-        embed.add_field(
-            name="Challenge",
-            value="`!deathmatch @user`  (alias of `!dm_challenge @user`)",
-            inline=False,
-        )
-        embed.add_field(
-            name="Stats",
-            value="`!leaderboard deathmatch` — top duelists",
-            inline=False,
-        )
-        embed.set_footer(text="30-second cooldown between challenges.")
         return embed, discord.ui.View(timeout=300)
 
     @commands.command(name="dm_challenge", aliases=["deathmatch", "challenge", "dm"])

--- a/disbot/cogs/deathmatch_cog.py
+++ b/disbot/cogs/deathmatch_cog.py
@@ -7,6 +7,7 @@ from discord.ext import commands
 from discord.ext.commands import BucketType, cooldown
 
 from utils import db
+from utils.ui_constants import GAME_COLOR
 
 
 class _Duel:
@@ -229,7 +230,38 @@ class Deathmatch(commands.Cog):
         self.bot = bot
         self.active_duels: dict[tuple, _Duel] = {}
 
-    @commands.command(name="dm_challenge", aliases=["deathmatch", "challenge"])
+    async def build_help_menu_view(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        """Help-menu direct-navigation hook (returns a deathmatch overview).
+
+        Deathmatch starts a 1v1 duel from the entry command — there's no
+        hub panel. The returned overview embed describes the flow; the
+        help-cog appends the "↩ Back to Help" control automatically.
+        """
+        embed = discord.Embed(
+            title="⚔️ Deathmatch",
+            description=(
+                "Challenge another player to a 1v1 duel.  Attack and defend "
+                "via buttons on the duel message until one combatant falls."
+            ),
+            color=GAME_COLOR,
+        )
+        embed.add_field(
+            name="Challenge",
+            value="`!deathmatch @user`  (alias of `!dm_challenge @user`)",
+            inline=False,
+        )
+        embed.add_field(
+            name="Stats",
+            value="`!leaderboard deathmatch` — top duelists",
+            inline=False,
+        )
+        embed.set_footer(text="30-second cooldown between challenges.")
+        return embed, discord.ui.View(timeout=300)
+
+    @commands.command(name="dm_challenge", aliases=["deathmatch", "challenge", "dm"])
     @cooldown(1, 30, BucketType.user)
     async def challenge(self, ctx: commands.Context, opponent: discord.Member):
         """Challenge another user to a deathmatch duel."""

--- a/disbot/cogs/diagnostic_cog.py
+++ b/disbot/cogs/diagnostic_cog.py
@@ -12,7 +12,7 @@ from discord.ext import commands
 
 from core.runtime.interaction_helpers import help_ctx_shim, safe_defer
 from utils import db
-from views.base import BaseView, send_panel
+from views.base import BaseView, HubView, send_panel
 
 logger = logging.getLogger("bot")
 
@@ -61,11 +61,11 @@ class _PaginatorView(BaseView):
         await interaction.response.edit_message(embed=self.pages[self.index], view=self)
 
 
-class _DiagnosticsHubView(BaseView):
+class _DiagnosticsHubView(HubView):
     """Interactive hub for all diagnostic tools."""
 
     def __init__(self, ctx: commands.Context, cog: DiagnosticCog):
-        super().__init__(ctx.author, timeout=180)
+        super().__init__(ctx.author)
         self.ctx = ctx
         self.cog = cog
 

--- a/disbot/cogs/diagnostic_cog.py
+++ b/disbot/cogs/diagnostic_cog.py
@@ -12,7 +12,7 @@ from discord.ext import commands
 
 from core.runtime.interaction_helpers import help_ctx_shim, safe_defer
 from utils import db
-from views.base import BaseView
+from views.base import BaseView, send_panel
 
 logger = logging.getLogger("bot")
 
@@ -190,8 +190,7 @@ class DiagnosticCog(commands.Cog):
     async def diagnostics_hub(self, ctx):
         """Open the interactive diagnostics hub panel."""
         view = _DiagnosticsHubView(ctx, self)
-        msg = await ctx.send(embed=view.build_embed(), view=view)
-        view.message = msg
+        await send_panel(ctx, embed=view.build_embed(), view=view)
 
     async def build_help_menu_view(
         self,

--- a/disbot/cogs/diagnostic_cog.py
+++ b/disbot/cogs/diagnostic_cog.py
@@ -10,7 +10,7 @@ import discord
 import psutil
 from discord.ext import commands
 
-from core.runtime.interaction_helpers import safe_defer
+from core.runtime.interaction_helpers import help_ctx_shim, safe_defer
 from utils import db
 from views.base import BaseView
 
@@ -192,6 +192,14 @@ class DiagnosticCog(commands.Cog):
         view = _DiagnosticsHubView(ctx, self)
         msg = await ctx.send(embed=view.build_embed(), view=view)
         view.message = msg
+
+    async def build_help_menu_view(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        """Help-menu direct-navigation hook (returns the diagnostics hub)."""
+        view = _DiagnosticsHubView(help_ctx_shim(interaction), self)
+        return view.build_embed(), view
 
     # ------------------------------------------------------------------
     # Command overview

--- a/disbot/cogs/general_cog.py
+++ b/disbot/cogs/general_cog.py
@@ -9,7 +9,7 @@ import discord
 from discord.ext import commands
 
 from utils.ui_constants import GENERAL_COLOR, SUCCESS_COLOR
-from views.base import BaseView
+from views.base import BaseView, send_panel
 
 logger = logging.getLogger("bot")
 
@@ -78,6 +78,7 @@ class General(commands.Cog):
         self._quotes: list[str] = content.get("quotes", [])
         self._trivia: list[str] = content.get("trivia", [])
 
+    @commands.cooldown(rate=3, per=10, type=commands.BucketType.user)
     @commands.command(
         name="generalmenu",
         aliases=["gmenu"],
@@ -91,8 +92,7 @@ class General(commands.Cog):
         menu uses it to map "general" → this cog).
         """
         view = _GeneralPanelView(ctx.author, self)
-        msg = await ctx.send(embed=_overview_embed(), view=view)
-        view.message = msg
+        await send_panel(ctx, embed=_overview_embed(), view=view)
 
     async def build_help_menu_view(
         self,
@@ -165,8 +165,7 @@ class General(commands.Cog):
             color=GENERAL_COLOR,
         )
         embed.set_footer(text="Click 'Reveal Answer' when ready.")
-        msg = await ctx.send(embed=embed, view=view)
-        view.message = msg
+        await send_panel(ctx, embed=embed, view=view)
 
     @commands.command(name="motivate", help="Sends a motivational message.")
     async def motivate(self, ctx):

--- a/disbot/cogs/help_cog.py
+++ b/disbot/cogs/help_cog.py
@@ -37,14 +37,22 @@ _TIER_GROUPS = [
 
 
 def _cog_for_subsystem(bot: commands.Bot, subsystem_name: str) -> commands.Cog | None:
-    """Find the cog that corresponds to a subsystem by checking entry_points."""
+    """Find the cog that corresponds to a subsystem by checking entry_points.
+
+    Matches against both ``cmd.name`` and ``cmd.aliases`` so registry entries
+    that reference an alias (e.g. ``"deathmatch"`` for ``dm_challenge``) still
+    resolve to the owning cog.
+    """
     meta = SUBSYSTEMS.get(subsystem_name)
     if not meta:
         return None
+    entry_points = set(meta.get("entry_points", []))
     for cog in bot.cogs.values():
-        cog_cmds = {cmd.name for cmd in cog.get_commands()}
-        entry_points = set(meta.get("entry_points", []))
-        if cog_cmds & entry_points:
+        cog_names: set[str] = set()
+        for cmd in cog.get_commands():
+            cog_names.add(cmd.name)
+            cog_names.update(cmd.aliases)
+        if cog_names & entry_points:
             return cog
     return None
 

--- a/disbot/cogs/help_cog.py
+++ b/disbot/cogs/help_cog.py
@@ -152,6 +152,11 @@ def _attach_back_to_help_button(
     will invalidate the underlying session state through the normal pipeline.
     """
     if len(view.children) >= 25:
+        logger.warning(
+            "Back-to-help button skipped — %s already has 25 children. "
+            "User cannot return to the help menu from this panel.",
+            type(view).__name__,
+        )
         return
 
     back_btn = discord.ui.Button(  # type: ignore[var-annotated]

--- a/disbot/cogs/inventory_cog.py
+++ b/disbot/cogs/inventory_cog.py
@@ -7,7 +7,7 @@ from discord.ext import commands
 
 from utils import db
 from utils.ui_constants import ECONOMY_COLOR, INFO_COLOR, MINING_COLOR, WARNING_COLOR
-from views.base import BaseView
+from views.base import BaseView, send_panel
 
 logger = logging.getLogger("bot")
 
@@ -371,8 +371,7 @@ class InventoryCog(commands.Cog):
         target = member or ctx.author
         grouped = await _build_combined_inventory(target.id, ctx.guild.id)
         view = UnifiedInventoryView(ctx.author, target, grouped)
-        msg = await ctx.send(embed=view.build_hub_embed(), view=view)
-        view.message = msg
+        await send_panel(ctx, embed=view.build_hub_embed(), view=view)
 
     async def build_help_menu_view(
         self,

--- a/disbot/cogs/inventory_cog.py
+++ b/disbot/cogs/inventory_cog.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import functools
 import logging
 
 import discord
@@ -171,13 +170,11 @@ class _CategoryView(BaseView):
     def __init__(
         self,
         author: discord.Member | discord.User,
-        ctx: commands.Context,
         category: str,
         items: list[tuple[str, int, dict]],
         hub: UnifiedInventoryView,
     ) -> None:
         super().__init__(author, timeout=180)
-        self._ctx = ctx
         self._category = category
         self._items = items
         self._hub = hub
@@ -273,12 +270,10 @@ class UnifiedInventoryView(BaseView):
     def __init__(
         self,
         author: discord.Member | discord.User,
-        ctx: commands.Context,
         target: discord.Member | discord.User,
         grouped: dict[str, list[tuple[str, int, dict]]],
     ) -> None:
         super().__init__(author, timeout=180)
-        self.ctx = ctx
         self.target = target
         self._grouped = grouped
         self._add_category_buttons()
@@ -297,8 +292,23 @@ class UnifiedInventoryView(BaseView):
                 style=discord.ButtonStyle.blurple,
                 row=0,
             )
-            btn.callback = functools.partial(self._open_category, category=cat)  # type: ignore[method-assign]
+            btn.callback = self._make_open_callback(cat)  # type: ignore[method-assign]
             self.add_item(btn)
+
+    def _make_open_callback(self, category: str):
+        # Closure instead of functools.partial — discord.py inspects the
+        # callback signature, and a partial with a kwonly arg can cause
+        # the dispatcher to surface "An error occurred" on click.
+        async def _callback(interaction: discord.Interaction) -> None:
+            items = self._grouped.get(category, [])
+            view = _CategoryView(self._author, category, items, hub=self)
+            view.message = self.message
+            await interaction.response.edit_message(
+                embed=view.build_embed(),
+                view=view,
+            )
+
+        return _callback
 
     def build_hub_embed(self) -> discord.Embed:
         embed = discord.Embed(
@@ -339,7 +349,7 @@ class UnifiedInventoryView(BaseView):
         category: str,
     ) -> None:
         items = self._grouped.get(category, [])
-        view = _CategoryView(self.ctx.author, self.ctx, category, items, hub=self)
+        view = _CategoryView(self._author, category, items, hub=self)
         view.message = self.message
         await interaction.response.edit_message(embed=view.build_embed(), view=view)
 
@@ -360,9 +370,19 @@ class InventoryCog(commands.Cog):
         """Show your (or another user's) unified inventory hub."""
         target = member or ctx.author
         grouped = await _build_combined_inventory(target.id, ctx.guild.id)
-        view = UnifiedInventoryView(ctx.author, ctx, target, grouped)
+        view = UnifiedInventoryView(ctx.author, target, grouped)
         msg = await ctx.send(embed=view.build_hub_embed(), view=view)
         view.message = msg
+
+    async def build_help_menu_view(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        """Help-menu direct-navigation hook (returns the inventory hub for the user)."""
+        target = interaction.user
+        grouped = await _build_combined_inventory(target.id, interaction.guild_id)
+        view = UnifiedInventoryView(target, target, grouped)
+        return view.build_hub_embed(), view
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/disbot/cogs/leaderboard_cog.py
+++ b/disbot/cogs/leaderboard_cog.py
@@ -190,6 +190,23 @@ class LeaderboardCog(commands.Cog, name="Leaderboard"):  # type: ignore[call-arg
 
         view.message = await ctx.send(embed=embed, view=view)
 
+    async def build_help_menu_view(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        """Help-menu direct-navigation hook (returns the leaderboard hub)."""
+        view = LeaderboardView(
+            interaction.guild,  # type: ignore[arg-type]
+            interaction.channel,  # type: ignore[arg-type]
+            interaction.user,  # type: ignore[arg-type]
+        )
+        embed = discord.Embed(
+            title="📊 Leaderboards",
+            description="Select a category below to view the leaderboard.",
+            color=UTILITY_COLOR,
+        )
+        return embed, view
+
 
 async def setup(bot: commands.Bot):
     await bot.add_cog(LeaderboardCog(bot))

--- a/disbot/cogs/proof_channel_cog.py
+++ b/disbot/cogs/proof_channel_cog.py
@@ -10,9 +10,9 @@ from core.runtime import tasks
 from core.runtime.interaction_helpers import help_ctx_shim
 from utils.helpers import _parse_member
 from utils.ui_constants import ECONOMY_COLOR, SUCCESS_COLOR
-from views.base import BaseView
+from views.base import BaseView, send_panel
 
-logger = logging.getLogger("discord_bot.prize_cog")
+logger = logging.getLogger("bot.cogs.proof_channel")
 
 
 class ProofChannelCog(commands.Cog):
@@ -102,13 +102,13 @@ class ProofChannelCog(commands.Cog):
         )
         await ctx.send(embed=embed, delete_after=60)
 
+    @commands.cooldown(rate=2, per=10, type=commands.BucketType.user)
     @commands.command(name="prizemenu")
     @commands.has_permissions(manage_channels=True)
     async def prize_menu(self, ctx):
         """Open the interactive prize channel management panel."""
         view = _PrizeManagerView(ctx, self)
-        msg = await ctx.send(embed=view.build_embed(), view=view)
-        view.message = msg
+        await send_panel(ctx, embed=view.build_embed(), view=view)
 
     async def build_help_menu_view(
         self,

--- a/disbot/cogs/proof_channel_cog.py
+++ b/disbot/cogs/proof_channel_cog.py
@@ -10,7 +10,7 @@ from core.runtime import tasks
 from core.runtime.interaction_helpers import help_ctx_shim
 from utils.helpers import _parse_member
 from utils.ui_constants import ECONOMY_COLOR, SUCCESS_COLOR
-from views.base import BaseView, send_panel
+from views.base import HubView, send_panel
 
 logger = logging.getLogger("bot.cogs.proof_channel")
 
@@ -242,11 +242,11 @@ class _TimedPrizeModal(discord.ui.Modal, title="Timed Prize Access"):  # type: i
         )
 
 
-class _PrizeManagerView(BaseView):
+class _PrizeManagerView(HubView):
     """Interactive prize channel management panel."""
 
     def __init__(self, ctx: commands.Context, cog: ProofChannelCog):
-        super().__init__(ctx.author, timeout=180)
+        super().__init__(ctx.author)
         self.ctx = ctx
         self.cog = cog
 

--- a/disbot/cogs/rps_tournament_cog.py
+++ b/disbot/cogs/rps_tournament_cog.py
@@ -76,6 +76,42 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # 
         self.entry_fee = 0
         self.paid_players: set[int] = set()  # players who paid the entry fee
 
+    async def build_help_menu_view(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        """Help-menu direct-navigation hook (returns an RPS overview).
+
+        RPS has no hub panel — the entry commands either start a quick
+        match (``!rps``) or open tournament registration (``!rpsregister``).
+        The returned overview embed describes both flows; the help-cog
+        appends the "↩ Back to Help" control automatically.
+        """
+        embed = discord.Embed(
+            title="✂️ Rock-Paper-Scissors",
+            description=(
+                "Quick matches vs the bot or another player, plus scheduled "
+                "tournaments with optional entry fees."
+            ),
+            color=GAME_COLOR,
+        )
+        embed.add_field(
+            name="Quick match",
+            value="`!rps` solo vs bot · `!rps @user` PvP · `!rps @user <bet>`",
+            inline=False,
+        )
+        embed.add_field(
+            name="Tournament",
+            value=(
+                "`!rpsregister` — open registration\n"
+                "`!rpsstart` — begin bracket\n"
+                "`!rpshelp` — full tournament help"
+            ),
+            inline=False,
+        )
+        embed.set_footer(text="Default mode: classic · best of 3.")
+        return embed, discord.ui.View(timeout=300)
+
     def create_move_aliases(self):
         """Creates a dictionary of move aliases for all game modes."""
         return {

--- a/disbot/cogs/rps_tournament_cog.py
+++ b/disbot/cogs/rps_tournament_cog.py
@@ -8,6 +8,7 @@ import discord
 from discord.ext import commands
 
 from core.runtime import tasks
+from core.runtime.component_registry import stats_block
 from services import economy_service, game_state_service
 from utils import db as global_db
 from utils.channels import cleanup_category, create_private_channel
@@ -87,29 +88,31 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # 
         The returned overview embed describes both flows; the help-cog
         appends the "↩ Back to Help" control automatically.
         """
-        embed = discord.Embed(
-            title="✂️ Rock-Paper-Scissors",
+        embed = stats_block(
+            "✂️ Rock-Paper-Scissors",
+            [
+                (
+                    "Quick match",
+                    "`!rps` solo vs bot · `!rps @user` PvP · `!rps @user <bet>`",
+                    False,
+                ),
+                (
+                    "Tournament",
+                    (
+                        "`!rpsregister` — open registration\n"
+                        "`!rpsstart` — begin bracket\n"
+                        "`!rpshelp` — full tournament help"
+                    ),
+                    False,
+                ),
+            ],
+            GAME_COLOR,
             description=(
                 "Quick matches vs the bot or another player, plus scheduled "
                 "tournaments with optional entry fees."
             ),
-            color=GAME_COLOR,
+            footer="Default mode: classic · best of 3.",
         )
-        embed.add_field(
-            name="Quick match",
-            value="`!rps` solo vs bot · `!rps @user` PvP · `!rps @user <bet>`",
-            inline=False,
-        )
-        embed.add_field(
-            name="Tournament",
-            value=(
-                "`!rpsregister` — open registration\n"
-                "`!rpsstart` — begin bracket\n"
-                "`!rpshelp` — full tournament help"
-            ),
-            inline=False,
-        )
-        embed.set_footer(text="Default mode: classic · best of 3.")
         return embed, discord.ui.View(timeout=300)
 
     def create_move_aliases(self):

--- a/disbot/cogs/utility_cog.py
+++ b/disbot/cogs/utility_cog.py
@@ -9,7 +9,7 @@ from core.runtime import tasks
 from core.runtime.interaction_helpers import help_ctx_shim
 from utils import embeds as em
 from utils.ui_constants import INFO_COLOR, SUCCESS_COLOR, UTILITY_COLOR
-from views.base import BaseView
+from views.base import BaseView, send_panel
 
 
 async def _remind_later(
@@ -37,12 +37,12 @@ class UtilityCog(commands.Cog):
         """
         tasks.cancel_by_prefix("utility:")
 
+    @commands.cooldown(rate=3, per=10, type=commands.BucketType.user)
     @commands.command(name="utilitymenu")
     async def utility_menu(self, ctx):
         """Open the interactive utility panel."""
         view = _UtilityPanelView(ctx)
-        msg = await ctx.send(embed=view.build_embed(), view=view)
-        view.message = msg
+        await send_panel(ctx, embed=view.build_embed(), view=view)
 
     async def build_help_menu_view(
         self,

--- a/disbot/cogs/utility_cog.py
+++ b/disbot/cogs/utility_cog.py
@@ -9,7 +9,7 @@ from core.runtime import tasks
 from core.runtime.interaction_helpers import help_ctx_shim
 from utils import embeds as em
 from utils.ui_constants import INFO_COLOR, SUCCESS_COLOR, UTILITY_COLOR
-from views.base import BaseView, send_panel
+from views.base import HubView, send_panel
 
 
 async def _remind_later(
@@ -201,11 +201,11 @@ class UtilityCog(commands.Cog):
 # ---------------------------------------------------------------------------
 
 
-class _UtilityPanelView(BaseView):
+class _UtilityPanelView(HubView):
     """Interactive utility panel — quick access to common utility actions."""
 
     def __init__(self, ctx: commands.Context):
-        super().__init__(ctx.author, public=True, timeout=180)
+        super().__init__(ctx.author, public=True)
         self.ctx = ctx
 
     def build_embed(self) -> discord.Embed:

--- a/disbot/cogs/xp_cog.py
+++ b/disbot/cogs/xp_cog.py
@@ -15,7 +15,7 @@ from utils.cooldowns import check_cooldown
 from utils.helpers import _parse_member, post_log_embed
 from utils.settings_keys import XP_ANNOUNCE_CHANNEL, XP_COOLDOWN, XP_MAX, XP_MIN
 from utils.ui_constants import ECONOMY_COLOR, UTILITY_COLOR
-from views.base import BaseView
+from views.base import BaseView, send_panel
 
 logger = logging.getLogger("bot")
 
@@ -281,8 +281,7 @@ class XpCog(commands.Cog):
         """Open the XP panel showing your rank and quick admin actions."""
         view = _XpHubView(ctx)
         embed = await view.build_embed()
-        msg = await ctx.send(embed=embed, view=view)
-        view.message = msg
+        await send_panel(ctx, embed=embed, view=view)
 
     async def build_help_menu_view(
         self,

--- a/disbot/cogs/xp_cog.py
+++ b/disbot/cogs/xp_cog.py
@@ -15,7 +15,7 @@ from utils.cooldowns import check_cooldown
 from utils.helpers import _parse_member, post_log_embed
 from utils.settings_keys import XP_ANNOUNCE_CHANNEL, XP_COOLDOWN, XP_MAX, XP_MIN
 from utils.ui_constants import ECONOMY_COLOR, UTILITY_COLOR
-from views.base import BaseView, send_panel
+from views.base import HubView, send_panel
 
 logger = logging.getLogger("bot")
 
@@ -116,11 +116,11 @@ async def _build_rank_embed(
 # ---------------------------------------------------------------------------
 
 
-class _XpHubView(BaseView):
+class _XpHubView(HubView):
     """Interactive XP hub — shows rank card with quick admin actions."""
 
     def __init__(self, ctx: commands.Context):
-        super().__init__(ctx.author, timeout=180)
+        super().__init__(ctx.author)
         self.ctx = ctx
 
     async def build_embed(self) -> discord.Embed:

--- a/disbot/core/runtime/persistent_views.py
+++ b/disbot/core/runtime/persistent_views.py
@@ -24,12 +24,9 @@ Public surface:
 
 from __future__ import annotations
 
-import logging
 from typing import ClassVar
 
 import discord
-
-logger = logging.getLogger("bot.runtime.views")
 
 _REGISTRY: dict[str, type[PersistentView]] = {}
 
@@ -83,24 +80,6 @@ class PersistentView(discord.ui.View):
         error: Exception,
         item: discord.ui.Item,  # type: ignore[type-arg]
     ) -> None:
-        logger.error(
-            "PersistentView error | view=%s item_type=%s custom_id=%r label=%r "
-            "user=%s guild=%s channel=%s message=%s",
-            type(self).__name__,
-            type(item).__name__,
-            getattr(item, "custom_id", None),
-            getattr(item, "label", None),
-            getattr(interaction.user, "id", None),
-            interaction.guild_id,
-            interaction.channel_id,
-            interaction.message.id if interaction.message else None,
-            exc_info=error,
-        )
-        if not interaction.response.is_done():
-            try:
-                await interaction.response.send_message(
-                    "An error occurred. Please try again.",
-                    ephemeral=True,
-                )
-            except Exception:
-                pass
+        from views.base import handle_view_error
+
+        await handle_view_error(self, interaction, error, item)

--- a/disbot/utils/subsystem_registry.py
+++ b/disbot/utils/subsystem_registry.py
@@ -125,7 +125,7 @@ SUBSYSTEMS: dict[str, dict] = {
         "visibility_mode": "normal",
         "category": "economy",
         "tags": ["inventory", "items", "crafting"],
-        "entry_points": ["inventorymenu", "inventory", "craft"],
+        "entry_points": ["inventory"],
         "default_channels": ["economy", "bot-commands"],
         "related_subsystems": ["economy", "mining"],
         "dependencies": ["economy"],
@@ -149,7 +149,7 @@ SUBSYSTEMS: dict[str, dict] = {
         "visibility_mode": "normal",
         "category": "economy",
         "tags": ["mining", "resources", "minigame"],
-        "entry_points": ["miningmenu", "mine"],
+        "entry_points": ["minemenu", "mine"],
         "default_channels": ["mining", "bot-commands"],
         "related_subsystems": ["economy", "inventory"],
         "dependencies": ["economy"],
@@ -172,7 +172,7 @@ SUBSYSTEMS: dict[str, dict] = {
         "visibility_mode": "normal",
         "category": "progression",
         "tags": ["xp", "levels", "progression", "leaderboard"],
-        "entry_points": ["xpmenu", "rank", "level"],
+        "entry_points": ["xpmenu", "rank"],
         "default_channels": ["bot-commands", "general"],
         "related_subsystems": ["role", "leaderboard"],
         "dependencies": [],
@@ -316,7 +316,7 @@ SUBSYSTEMS: dict[str, dict] = {
         "visibility_mode": "normal",
         "category": "games",
         "tags": ["games", "rps", "tournament"],
-        "entry_points": ["rpsmenu", "rps"],
+        "entry_points": ["rps"],
         "default_channels": ["games", "tournament"],
         "related_subsystems": [],
         "dependencies": [],
@@ -339,7 +339,7 @@ SUBSYSTEMS: dict[str, dict] = {
         "visibility_mode": "normal",
         "category": "games",
         "tags": ["games", "counting", "community"],
-        "entry_points": ["countingmenu", "counting"],
+        "entry_points": ["countingmenu"],
         "default_channels": ["counting", "games"],
         "related_subsystems": [],
         "dependencies": [],
@@ -501,7 +501,7 @@ SUBSYSTEMS: dict[str, dict] = {
         "visibility_mode": "normal",
         "category": "admin",
         "tags": ["diagnostics", "health", "latency", "debug"],
-        "entry_points": ["diagnosticmenu", "diagnostics", "ping", "platform"],
+        "entry_points": ["diagnostics", "ping", "platform"],
         "default_channels": ["staff", "bot-spam"],
         "related_subsystems": ["admin"],
         "dependencies": [],
@@ -897,8 +897,13 @@ async def validate_identity_contract(bot: object) -> dict[str, list[str]]:
         "db_anchor_subsystem_unknown": [],
     }
 
-    # Surface 2: bot commands.
-    loaded_commands: set[str] = {cmd.name for cmd in getattr(bot, "commands", ())}
+    # Surface 2: bot commands — include aliases so registry entries
+    # that reference an alias (e.g. "bj" for blackjack, "deathmatch" for
+    # dm_challenge) match without triggering a false drift finding.
+    loaded_commands: set[str] = set()
+    for cmd in getattr(bot, "commands", ()):
+        loaded_commands.add(cmd.name)
+        loaded_commands.update(cmd.aliases)
 
     # Surface 1 vs Surface 2.
     for sub_name, meta in SUBSYSTEMS.items():

--- a/disbot/views/base.py
+++ b/disbot/views/base.py
@@ -3,8 +3,30 @@ from __future__ import annotations
 import logging
 
 import discord
+from discord.ext import commands
 
 logger = logging.getLogger("bot.views")
+
+
+async def send_panel(
+    ctx: commands.Context,
+    *,
+    embed: discord.Embed,
+    view: BaseView,
+) -> discord.Message:
+    """Send ``embed`` + ``view`` in ``ctx.channel`` and bind the message to view.
+
+    Centralises the ``msg = await ctx.send(...); view.message = msg`` pattern
+    so panel commands stay one line.  Binding ``view.message`` is what lets
+    :meth:`BaseView.on_timeout` edit the message to disable the buttons when
+    the view expires.
+
+    Returns the sent message so callers that still need the reference can
+    use it directly.
+    """
+    msg = await ctx.send(embed=embed, view=view)
+    view.message = msg
+    return msg
 
 
 class BaseView(discord.ui.View):

--- a/disbot/views/base.py
+++ b/disbot/views/base.py
@@ -29,6 +29,43 @@ async def send_panel(
     return msg
 
 
+async def handle_view_error(
+    view: discord.ui.View,
+    interaction: discord.Interaction,
+    error: Exception,
+    item: discord.ui.Item,  # type: ignore[type-arg]
+) -> None:
+    """Standard view-error handler: rich-context log + generic ephemeral.
+
+    Used by :meth:`BaseView.on_error`, :meth:`PersistentView.on_error`, and
+    the blackjack view subclasses (which extend ``discord.ui.View`` directly).
+    Channel-management views in ``views/channels/`` keep their own
+    ``on_error`` because they intentionally surface ``type(error).__name__``
+    to admins for diagnosability.
+    """
+    logger.error(
+        "View error | view=%s item_type=%s custom_id=%r label=%r "
+        "user=%s guild=%s channel=%s message=%s",
+        type(view).__name__,
+        type(item).__name__,
+        getattr(item, "custom_id", None),
+        getattr(item, "label", None),
+        getattr(interaction.user, "id", None),
+        interaction.guild_id,
+        interaction.channel_id,
+        interaction.message.id if interaction.message else None,
+        exc_info=error,
+    )
+    if not interaction.response.is_done():
+        try:
+            await interaction.response.send_message(
+                "An error occurred. Please try again.",
+                ephemeral=True,
+            )
+        except Exception:
+            pass
+
+
 class BaseView(discord.ui.View):
     """Standard base for all SuperBot interactive panels.
 
@@ -81,24 +118,27 @@ class BaseView(discord.ui.View):
         error: Exception,
         item: discord.ui.Item,  # type: ignore[type-arg]
     ) -> None:
-        logger.error(
-            "View error | view=%s item_type=%s custom_id=%r label=%r "
-            "user=%s guild=%s channel=%s message=%s",
-            type(self).__name__,
-            type(item).__name__,
-            getattr(item, "custom_id", None),
-            getattr(item, "label", None),
-            getattr(interaction.user, "id", None),
-            interaction.guild_id,
-            interaction.channel_id,
-            interaction.message.id if interaction.message else None,
-            exc_info=error,
-        )
-        if not interaction.response.is_done():
-            try:
-                await interaction.response.send_message(
-                    "An error occurred. Please try again.",
-                    ephemeral=True,
-                )
-            except Exception:
-                pass
+        await handle_view_error(self, interaction, error, item)
+
+
+class HubView(BaseView):
+    """Interactive panel hub with the standard 180-second timeout.
+
+    Centralises the ``timeout=180`` default that every hub view duplicated.
+    Subclasses pass only ``author`` (or ``author, public=True`` for shared
+    panels) — the timeout no longer needs to be repeated per cog.
+
+    Use this for any view that anchors a panel command (e.g. ``!adminmenu``,
+    ``!channelmenu``).  For one-off views with different timeouts (e.g. a
+    20-second confirmation prompt) keep extending :class:`BaseView` directly.
+    """
+
+    DEFAULT_TIMEOUT = 180
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        *,
+        public: bool = False,
+    ) -> None:
+        super().__init__(author, public=public, timeout=self.DEFAULT_TIMEOUT)

--- a/disbot/views/channels/main_panel.py
+++ b/disbot/views/channels/main_panel.py
@@ -13,17 +13,17 @@ import discord
 from discord.ext import commands
 
 from utils.ui_constants import CHANNEL_COLOR
-from views.base import BaseView
+from views.base import HubView
 from views.channels._helpers import _build_channel_options
 
 logger = logging.getLogger("bot")
 
 
-class _ChannelManagerView(BaseView):
+class _ChannelManagerView(HubView):
     """Top-level channel management panel with three action modes."""
 
     def __init__(self, ctx: commands.Context):
-        super().__init__(ctx.author, timeout=180)
+        super().__init__(ctx.author)
         self.ctx = ctx
 
     async def on_error(

--- a/disbot/views/counting/hub_panel.py
+++ b/disbot/views/counting/hub_panel.py
@@ -15,14 +15,14 @@ import discord
 from discord.ext import commands
 
 from core.runtime import tasks
-from views.base import BaseView
+from views.base import HubView
 
 
-class _CountingHubView(BaseView):
+class _CountingHubView(HubView):
     """Admin hub for managing the counting game in the current channel."""
 
     def __init__(self, ctx: commands.Context, cog):
-        super().__init__(ctx.author, timeout=180)
+        super().__init__(ctx.author)
         self.ctx = ctx
         self.cog = cog
 

--- a/disbot/views/economy/main_panel.py
+++ b/disbot/views/economy/main_panel.py
@@ -207,7 +207,7 @@ class EconomyPanelView(PersistentView):
 
         uid, gid = interaction.user.id, interaction.guild_id
         grouped = await _build_combined_inventory(uid, gid)
-        view = UnifiedInventoryView(interaction.user, None, interaction.user, grouped)
+        view = UnifiedInventoryView(interaction.user, interaction.user, grouped)
         await interaction.response.send_message(embed=view.build_hub_embed(), view=view)
         view.message = await interaction.original_response()
 

--- a/tests/unit/help/test_help_direct_navigation.py
+++ b/tests/unit/help/test_help_direct_navigation.py
@@ -36,9 +36,11 @@ _COGS_DIR = _DISBOT / "cogs"
 def _scan_cog_classes() -> dict[str, dict]:
     """AST-scan ``disbot/cogs/*.py`` for ``commands.Cog`` subclasses.
 
-    Returns a mapping ``"<module>:<class>" -> {commands, methods, async_methods}``
-    so callers can ask: does this cog declare a command name ending in
-    ``menu``, and if so does it also declare an async ``build_help_menu_view``?
+    Returns a mapping ``"<module>:<class>" -> info`` where ``info`` contains:
+      * ``commands`` — set of command names (from ``name=`` kwarg or function name)
+      * ``aliases`` — set of alias strings from ``aliases=[...]`` kwargs
+      * ``methods`` — set of all method names on the class
+      * ``async_methods`` — subset of ``methods`` that are ``async def``
     """
     result: dict[str, dict] = {}
     for py in _COGS_DIR.glob("*.py"):
@@ -53,6 +55,7 @@ def _scan_cog_classes() -> dict[str, dict]:
                 continue
 
             commands_set: set[str] = set()
+            aliases_set: set[str] = set()
             methods_set: set[str] = set()
             async_methods: set[str] = set()
             for child in node.body:
@@ -74,6 +77,12 @@ def _scan_cog_classes() -> dict[str, dict]:
                     for kw in dec.keywords:
                         if kw.arg == "name" and isinstance(kw.value, ast.Constant):
                             cmd_name = kw.value.value
+                        elif kw.arg == "aliases" and isinstance(kw.value, ast.List):
+                            for elt in kw.value.elts:
+                                if isinstance(elt, ast.Constant) and isinstance(
+                                    elt.value, str
+                                ):
+                                    aliases_set.add(elt.value)
                     if cmd_name is None:
                         cmd_name = child.name
                     commands_set.add(cmd_name)
@@ -81,46 +90,72 @@ def _scan_cog_classes() -> dict[str, dict]:
             module_name = "cogs." + py.stem
             result[f"{module_name}:{node.name}"] = {
                 "commands": commands_set,
+                "aliases": aliases_set,
                 "methods": methods_set,
                 "async_methods": async_methods,
             }
     return result
 
 
-def test_every_panel_cog_has_build_help_menu_view():
-    """Every cog with a ``*menu`` command must expose ``build_help_menu_view``.
+def test_every_visible_subsystem_cog_has_build_help_menu_view():
+    """Every cog reachable from the help dropdown must expose ``build_help_menu_view``.
 
-    Regression guard for silent UX drift: if a new panel cog ships without
-    the direct-navigation hook, the help dropdown silently falls back to
-    the inline command list instead of opening the panel. Without this
-    test that omission would only surface as a runtime UX inconsistency.
+    Walks ``SUBSYSTEMS`` (skipping ``visibility_mode='internal'`` and the
+    help cog itself), resolves each subsystem to its owning cog by
+    intersecting the registered ``entry_points`` with the cog's command
+    names **and aliases**, and asserts the cog declares an async
+    ``build_help_menu_view`` method.
 
-    Heuristic: any ``@commands.command(name='*menu')`` (or method named
-    ``*menu`` with no explicit name) is a panel entry point. The owning
-    cog class must define ``async def build_help_menu_view`` so the
-    help-menu select can dispatch into the panel directly.
+    Regression guard: closes the silent UX drift where a new subsystem
+    ships without the direct-navigation hook and the help dropdown
+    silently falls back to the inline command list. Catches the case
+    even for game cogs that have no ``*menu`` command (blackjack, rps,
+    deathmatch), which the previous ``*menu``-only heuristic missed.
     """
+    from utils.subsystem_registry import SUBSYSTEMS
+
     classes = _scan_cog_classes()
 
     missing_hook: list[str] = []
     not_async: list[str] = []
-    for key, info in classes.items():
-        menu_cmds = {c for c in info["commands"] if c.endswith("menu")}
-        if not menu_cmds:
-            continue
-        if "build_help_menu_view" not in info["methods"]:
-            missing_hook.append(f"{key} (declares: {sorted(menu_cmds)})")
-            continue
-        if "build_help_menu_view" not in info["async_methods"]:
-            not_async.append(key)
+    unresolved: list[str] = []
 
+    for sub_name, meta in SUBSYSTEMS.items():
+        if meta.get("visibility_mode") == "internal":
+            continue
+        if sub_name == "help":  # help can't direct-navigate to itself
+            continue
+        entry_points = set(meta.get("entry_points", ()))
+        if not entry_points:
+            continue
+
+        # Find the cog whose commands (or aliases) intersect entry_points.
+        owning = [
+            key
+            for key, info in classes.items()
+            if (info["commands"] | info["aliases"]) & entry_points
+        ]
+        if not owning:
+            unresolved.append(f"{sub_name} (entry_points={sorted(entry_points)})")
+            continue
+
+        for key in owning:
+            info = classes[key]
+            if "build_help_menu_view" not in info["methods"]:
+                missing_hook.append(f"{sub_name} → {key}")
+            elif "build_help_menu_view" not in info["async_methods"]:
+                not_async.append(f"{sub_name} → {key}")
+
+    assert not unresolved, (
+        "Subsystems whose entry_points match no cog (likely registry "
+        "drift — entry_points reference a command that doesn't exist):\n  "
+        + "\n  ".join(unresolved)
+    )
     assert not missing_hook, (
-        "These cogs declare a *menu command but do not define "
-        "build_help_menu_view — the help dropdown will fall back to the "
-        "inline command list instead of opening the panel directly. Add "
-        "an async build_help_menu_view(self, interaction) method that "
-        "returns (embed, view), mirroring the *menu command body:\n  "
-        + "\n  ".join(missing_hook)
+        "Cogs reachable from the help dropdown must define an async "
+        "build_help_menu_view(self, interaction) so the dropdown navigates "
+        "directly to the panel instead of falling back to the inline "
+        "command list:\n  " + "\n  ".join(missing_hook)
     )
     assert not not_async, (
         "build_help_menu_view must be an async method (help_cog awaits "

--- a/tests/unit/help/test_help_direct_navigation.py
+++ b/tests/unit/help/test_help_direct_navigation.py
@@ -234,6 +234,40 @@ async def test_moderation_build_help_menu_view_returns_embed_and_view():
 
 
 @pytest.mark.asyncio
+async def test_blackjack_build_help_menu_view_returns_embed_and_view():
+    """Game cogs return a stats_block overview + empty view (back-btn appended later)."""
+    from cogs.blackjack_cog import BlackjackCog
+
+    cog = BlackjackCog(MagicMock())
+    embed, view = await cog.build_help_menu_view(_stub_interaction())
+    assert isinstance(embed, discord.Embed)
+    assert isinstance(view, discord.ui.View)
+    assert embed.title == "🃏 Blackjack"
+
+
+@pytest.mark.asyncio
+async def test_rps_build_help_menu_view_returns_embed_and_view():
+    from cogs.rps_tournament_cog import RPSTournamentCog
+
+    cog = RPSTournamentCog(MagicMock())
+    embed, view = await cog.build_help_menu_view(_stub_interaction())
+    assert isinstance(embed, discord.Embed)
+    assert isinstance(view, discord.ui.View)
+    assert embed.title == "✂️ Rock-Paper-Scissors"
+
+
+@pytest.mark.asyncio
+async def test_deathmatch_build_help_menu_view_returns_embed_and_view():
+    from cogs.deathmatch_cog import Deathmatch
+
+    cog = Deathmatch(MagicMock())
+    embed, view = await cog.build_help_menu_view(_stub_interaction())
+    assert isinstance(embed, discord.Embed)
+    assert isinstance(view, discord.ui.View)
+    assert embed.title == "⚔️ Deathmatch"
+
+
+@pytest.mark.asyncio
 async def test_help_ctx_shim_exposes_required_attrs():
     """The shim must expose author/guild/channel/bot — nothing else needed."""
     from core.runtime.interaction_helpers import help_ctx_shim

--- a/tests/unit/views/test_base_helpers.py
+++ b/tests/unit/views/test_base_helpers.py
@@ -1,0 +1,43 @@
+"""Contract tests for ``views.base`` helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from views.base import BaseView, send_panel
+
+
+@pytest.mark.asyncio
+async def test_send_panel_sends_and_binds_message():
+    """send_panel must call ctx.send(embed, view), assign view.message, return msg."""
+    ctx = MagicMock()
+    sent = MagicMock(spec=discord.Message)
+    ctx.send = AsyncMock(return_value=sent)
+
+    author = MagicMock(id=42)
+    view = BaseView(author)
+    embed = discord.Embed(title="hello")
+
+    returned = await send_panel(ctx, embed=embed, view=view)
+
+    ctx.send.assert_awaited_once_with(embed=embed, view=view)
+    assert view.message is sent
+    assert returned is sent
+
+
+@pytest.mark.asyncio
+async def test_send_panel_propagates_send_exception():
+    """If ctx.send raises, send_panel must re-raise and not silently bind."""
+    ctx = MagicMock()
+    ctx.send = AsyncMock(side_effect=discord.HTTPException(MagicMock(status=500), "x"))
+
+    author = MagicMock(id=42)
+    view = BaseView(author)
+
+    with pytest.raises(discord.HTTPException):
+        await send_panel(ctx, embed=discord.Embed(), view=view)
+
+    assert view.message is None

--- a/tests/unit/views/test_base_helpers.py
+++ b/tests/unit/views/test_base_helpers.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import discord
 import pytest
 
-from views.base import BaseView, send_panel
+from views.base import BaseView, HubView, handle_view_error, send_panel
 
 
 @pytest.mark.asyncio
@@ -41,3 +41,55 @@ async def test_send_panel_propagates_send_exception():
         await send_panel(ctx, embed=discord.Embed(), view=view)
 
     assert view.message is None
+
+
+def test_hub_view_defaults_to_180s_timeout():
+    """HubView freezes the 180s timeout so cog hubs stop repeating it."""
+    author = MagicMock(id=42)
+    view = HubView(author)
+    assert view.timeout == 180
+    assert view._author is author
+    assert view._public is False
+
+
+def test_hub_view_accepts_public_flag():
+    """HubView passes through public=True for shared panels like Utility."""
+    author = MagicMock(id=42)
+    view = HubView(author, public=True)
+    assert view.timeout == 180
+    assert view._public is True
+
+
+@pytest.mark.asyncio
+async def test_handle_view_error_logs_and_sends_generic_ephemeral():
+    """The shared error handler logs with context and sends a generic ephemeral."""
+    view = MagicMock(spec=discord.ui.View)
+    item = MagicMock(custom_id="cid", label="Click me")
+    interaction = MagicMock()
+    interaction.user = MagicMock(id=42)
+    interaction.guild_id = 99
+    interaction.channel_id = 100
+    interaction.message = MagicMock(id=200)
+    interaction.response.is_done.return_value = False
+    interaction.response.send_message = AsyncMock()
+
+    await handle_view_error(view, interaction, ValueError("boom"), item)
+
+    interaction.response.send_message.assert_awaited_once()
+    args, kwargs = interaction.response.send_message.call_args
+    assert "An error occurred" in args[0]
+    assert kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_handle_view_error_skips_send_when_response_done():
+    """If the interaction was already responded to, don't double-send."""
+    view = MagicMock(spec=discord.ui.View)
+    item = MagicMock(custom_id="cid", label=None)
+    interaction = MagicMock()
+    interaction.response.is_done.return_value = True
+    interaction.response.send_message = AsyncMock()
+
+    await handle_view_error(view, interaction, RuntimeError("x"), item)
+
+    interaction.response.send_message.assert_not_called()


### PR DESCRIPTION
## Summary

Follow-up to PR #48. Three commits that should have landed there but were pushed after the merge — covers the remaining cogs in the help dropdown, fixes the alias-aware identity contract, polishes the helper layer, and consolidates view-base duplication.

### `6f94cee` — PR M-help-complete: cover remaining cogs + alias-aware identity contract

User-facing follow-up from the first round of in-Discord testing.

- **Deathmatch "category no longer loaded"** — `_cog_for_subsystem` only checked `cmd.name`, not aliases, but `dm_challenge`'s entry-point is the `deathmatch` alias. Now alias-aware. Same fix in `validate_identity_contract` drops the bot-log's "12 fatal `entry_point_missing_command`" findings to 0.
- **Inventory clicks → "An error occurred"** — `UnifiedInventoryView` stored `ctx` but the economy-panel callsite passed `ctx=None`; the click handler then crashed on `self.ctx.author`. Dropped the dead `ctx` parameter; switched per-category callbacks from `functools.partial` to closures so discord.py's signature introspection can't trip on them.
- **Direct-navigation for the remaining cogs**: inventory, diagnostic, leaderboard, blackjack, rps_tournament, deathmatch now expose async `build_help_menu_view`. Game cogs return an overview embed (no buttons — help_cog appends "↩ Back to Help" automatically).
- **Registry drift cleanup** of genuinely-missing entry_points: `inventorymenu`, `craft`, `level`, `rpsmenu`, `counting`, `diagnosticmenu` removed; `miningmenu` → `minemenu`; `dm` added as a real alias on `dm_challenge`.
- **Discovery test strengthened** — now walks `SUBSYSTEMS` (skipping internal-mode and `help` itself), resolves each subsystem to its cog by `entry_points ∩ (commands ∪ aliases)`, and asserts the hook exists. Catches game cogs that the previous `*menu`-heuristic missed.

### `5d84935` — PR M-help-polish: send_panel helper, logger hierarchy, hub cooldowns

Small-fix sweep from a duplication + bug audit. No design change.

- **`views/base.send_panel(ctx, *, embed, view)`** collapses the recurring `msg = await ctx.send(...); view.message = msg` pair. 11 cog command bodies adopted. Two contract tests pin send-bind-reraise behaviour.
- **Logger orphan fixes**: `counting_cog` (`"CountingCog"` → `"bot.cogs.counting"`), `proof_channel_cog` (`"discord_bot.prize_cog"` → `"bot.cogs.proof_channel"`), `chain_cog` (`__name__` → `"bot.cogs.chain"`). Previous names didn't inherit handlers from the `"bot"` root, so log lines from those three cogs were silently dropped from the rotating file and stderr.
- **`_attach_back_to_help_button`** silent return at the 25-child cap → WARNING naming the view class.
- **Hub-command cooldowns**: added `@commands.cooldown` to `adminmenu`, `channelmenu`, `chainmenu`, `generalmenu`, `utilitymenu`, `prizemenu` (rates mirror `economymenu` / `diagnostics`).

### `54d895c` — PR M-help-structural: HubView base, on_error helper, stats_block adoption

Structural cleanup built on the polish layer. No behaviour change — collapses duplication that accreted across cogs.

- **`HubView(BaseView)`** — freezes the 180s timeout that every panel hub re-specified. Subclasses now pass only `ctx.author` (or `ctx.author, public=True` for shared panels). 9 hub views migrated.
- **`handle_view_error(view, interaction, error, item)`** — extracts the log-with-rich-context + generic-ephemeral pattern that was triplicated in `BaseView.on_error`, `PersistentView.on_error`, and `blackjack_cog._on_view_error`. All three route through the helper now. Channel-management views in `views/channels/` keep their own `on_error` because they intentionally surface `type(error).__name__` to admins.
- **`stats_block` adoption** — blackjack / rps_tournament / deathmatch overview embeds (added in M-help-complete) now use the existing `stats_block` helper. Same rendered layout; ~45 lines of `add_field` / `set_footer` boilerplate gone.
- **safe_* sweep** confirmed already complete — `grep -rn 'interaction.response.defer'` shows the only raw call is inside `safe_defer` itself.
- New tests pin HubView's 180s timeout, public-flag pass-through, and `handle_view_error`'s log + ephemeral + is_done()-skip paths. Help direct-nav smoke tests extended to cover blackjack/rps/deathmatch.

## Test plan

- [x] `pytest tests/` → 668 passed
- [x] `ruff check disbot` → clean
- [x] `black --check disbot` → clean
- [x] Negative-case verified — removing any cog's `build_help_menu_view` makes the AST discovery test fail with an actionable error
- [x] Inventory click smoke (without ctx) — no AttributeError
- [ ] Manual smoke (post-merge): `!help` opens each category directly (including blackjack/rps/deathmatch which previously hit inline fallback); panel commands produce a fresh message at channel bottom; `!dm @user` works (new alias); inventory hub click navigates without ephemeral error; identity-contract findings drop to 0 in the log channel.

https://claude.ai/code/session_017UVCWkBejRk326FvAyikrV

---
_Generated by [Claude Code](https://claude.ai/code/session_017UVCWkBejRk326FvAyikrV)_