### PR TITLE
PR S4.4.5: extract views/diagnostic/ from diagnostic_cog

### DIFF
--- a/disbot/cogs/diagnostic_cog.py
+++ b/disbot/cogs/diagnostic_cog.py
@@ -10,9 +10,10 @@ import discord
 import psutil
 from discord.ext import commands
 
-from core.runtime.interaction_helpers import help_ctx_shim, safe_defer
+from core.runtime.interaction_helpers import help_ctx_shim
 from utils import db
-from views.base import BaseView, HubView, send_panel
+from views.base import send_panel
+from views.diagnostic import _DiagnosticsHubView, _PaginatorView
 
 logger = logging.getLogger("bot")
 
@@ -21,157 +22,6 @@ DATA_DIR = os.path.join(
     "data",
 )
 JSON_DIR = os.path.join(DATA_DIR, "json")
-
-
-class _PaginatorView(BaseView):
-    """Simple prev/next paginator for multi-page embeds."""
-
-    def __init__(
-        self,
-        pages: list[discord.Embed],
-        author: discord.Member | discord.User,
-    ):
-        super().__init__(author, timeout=120)
-        self.pages = pages
-        self.index = 0
-        self._update_buttons()
-
-    def _update_buttons(self):
-        self.prev_btn.disabled = self.index == 0
-        self.next_btn.disabled = self.index == len(self.pages) - 1
-
-    @discord.ui.button(label="◀ Prev", style=discord.ButtonStyle.secondary)
-    async def prev_btn(
-        self,
-        interaction: discord.Interaction,
-        button: discord.ui.Button,
-    ):
-        self.index -= 1
-        self._update_buttons()
-        await interaction.response.edit_message(embed=self.pages[self.index], view=self)
-
-    @discord.ui.button(label="Next ▶", style=discord.ButtonStyle.secondary)
-    async def next_btn(
-        self,
-        interaction: discord.Interaction,
-        button: discord.ui.Button,
-    ):
-        self.index += 1
-        self._update_buttons()
-        await interaction.response.edit_message(embed=self.pages[self.index], view=self)
-
-
-class _DiagnosticsHubView(HubView):
-    """Interactive hub for all diagnostic tools."""
-
-    def __init__(self, ctx: commands.Context, cog: DiagnosticCog):
-        super().__init__(ctx.author)
-        self.ctx = ctx
-        self.cog = cog
-
-    def build_embed(self) -> discord.Embed:
-        embed = discord.Embed(
-            title="🔧 Diagnostics Hub",
-            description=(
-                "Select a diagnostic tool below.\n"
-                "All tools require Administrator permission."
-            ),
-            color=discord.Color.blue(),
-        )
-        embed.add_field(
-            name="🤖 Bot Status",
-            value="Health & performance metrics",
-            inline=True,
-        )
-        embed.add_field(name="📡 Latency", value="WebSocket ping", inline=True)
-        embed.add_field(
-            name="💻 System Info",
-            value="OS, disk & Python version",
-            inline=True,
-        )
-        embed.add_field(
-            name="🗄️ Check Database",
-            value="Verify all DB tables exist",
-            inline=True,
-        )
-        embed.add_field(
-            name="📄 Validate JSON",
-            value="Check data file integrity",
-            inline=True,
-        )
-        embed.add_field(
-            name="📋 Command List",
-            value="Paginated command overview",
-            inline=True,
-        )
-        embed.add_field(
-            name="🔍 Recent Errors",
-            value="Last 10 error log entries",
-            inline=True,
-        )
-        embed.add_field(
-            name="🔔 Test Notify",
-            value="Fire a test webhook ping",
-            inline=True,
-        )
-        embed.set_footer(text="Diagnostics Hub  •  Admin only")
-        return embed
-
-    @discord.ui.button(label="🤖 Bot Status", style=discord.ButtonStyle.blurple, row=0)
-    async def btn_status(self, interaction: discord.Interaction, _: discord.ui.Button):
-        if not await safe_defer(interaction):
-            return
-        await self.ctx.invoke(self.cog.diagnostic_bot_status)
-
-    @discord.ui.button(label="📡 Latency", style=discord.ButtonStyle.blurple, row=0)
-    async def btn_latency(self, interaction: discord.Interaction, _: discord.ui.Button):
-        if not await safe_defer(interaction):
-            return
-        await self.ctx.invoke(self.cog.latency)
-
-    @discord.ui.button(label="💻 System Info", style=discord.ButtonStyle.blurple, row=0)
-    async def btn_sysinfo(self, interaction: discord.Interaction, _: discord.ui.Button):
-        if not await safe_defer(interaction):
-            return
-        await self.ctx.invoke(self.cog.system_info)
-
-    @discord.ui.button(label="🗄️ Database", style=discord.ButtonStyle.grey, row=1)
-    async def btn_db(self, interaction: discord.Interaction, _: discord.ui.Button):
-        if not await safe_defer(interaction):
-            return
-        await self.ctx.invoke(self.cog.check_database)
-
-    @discord.ui.button(label="📄 JSON Files", style=discord.ButtonStyle.grey, row=1)
-    async def btn_json(self, interaction: discord.Interaction, _: discord.ui.Button):
-        if not await safe_defer(interaction):
-            return
-        await self.ctx.invoke(self.cog.validate_json_files)
-
-    @discord.ui.button(label="📋 Commands", style=discord.ButtonStyle.grey, row=1)
-    async def btn_cmds(self, interaction: discord.Interaction, _: discord.ui.Button):
-        if not await safe_defer(interaction):
-            return
-        await self.ctx.invoke(self.cog.list_commands_detailed)
-
-    @discord.ui.button(
-        label="🔍 Recent Errors",
-        style=discord.ButtonStyle.danger,
-        row=2,
-    )
-    async def btn_errors(self, interaction: discord.Interaction, _: discord.ui.Button):
-        if not await safe_defer(interaction):
-            return
-        await self.ctx.invoke(self.cog.recent_errors)
-
-    @discord.ui.button(
-        label="🔔 Test Notify",
-        style=discord.ButtonStyle.secondary,
-        row=2,
-    )
-    async def btn_notify(self, interaction: discord.Interaction, _: discord.ui.Button):
-        if not await safe_defer(interaction):
-            return
-        await self.ctx.invoke(self.cog.test_notification)
 
 
 class DiagnosticCog(commands.Cog):

--- a/disbot/views/diagnostic/__init__.py
+++ b/disbot/views/diagnostic/__init__.py
@@ -1,0 +1,23 @@
+"""views.diagnostic — diagnostics hub + paginated views.
+
+Extracted from ``cogs/diagnostic_cog.py`` during S4.4.5.
+
+Modules:
+    paginator  — ``_PaginatorView`` (generic prev/next embed paginator)
+    hub_panel  — ``_DiagnosticsHubView`` (admin diagnostic dashboard)
+
+Neither view is a PersistentView — both are ephemeral, timeout-based.
+The hub view takes a reference to the owning ``DiagnosticCog`` so its
+buttons can ``ctx.invoke`` the corresponding text commands rather than
+re-implementing each diagnostic flow.
+"""
+
+from __future__ import annotations
+
+from views.diagnostic.hub_panel import _DiagnosticsHubView
+from views.diagnostic.paginator import _PaginatorView
+
+__all__ = [
+    "_DiagnosticsHubView",
+    "_PaginatorView",
+]

--- a/disbot/views/diagnostic/hub_panel.py
+++ b/disbot/views/diagnostic/hub_panel.py
@@ -1,0 +1,137 @@
+"""Diagnostics hub view (S4.4.5 extraction).
+
+``_DiagnosticsHubView`` is the ephemeral admin dashboard opened by
+``!diagnostics`` (and reachable via the help-menu direct-navigation
+hook).  Each button delegates back to the owning ``DiagnosticCog``
+text command via ``ctx.invoke`` — this avoids re-implementing each
+diagnostic flow inside the view.
+
+The cog reference is held on the view instance (constructor argument)
+so the button callbacks have access without a global lookup.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import discord
+from discord.ext import commands
+
+from core.runtime.interaction_helpers import safe_defer
+from views.base import HubView
+
+if TYPE_CHECKING:
+    from cogs.diagnostic_cog import DiagnosticCog
+
+
+class _DiagnosticsHubView(HubView):
+    """Interactive hub for all diagnostic tools."""
+
+    def __init__(self, ctx: commands.Context, cog: DiagnosticCog):
+        super().__init__(ctx.author)
+        self.ctx = ctx
+        self.cog = cog
+
+    def build_embed(self) -> discord.Embed:
+        embed = discord.Embed(
+            title="🔧 Diagnostics Hub",
+            description=(
+                "Select a diagnostic tool below.\n"
+                "All tools require Administrator permission."
+            ),
+            color=discord.Color.blue(),
+        )
+        embed.add_field(
+            name="🤖 Bot Status",
+            value="Health & performance metrics",
+            inline=True,
+        )
+        embed.add_field(name="📡 Latency", value="WebSocket ping", inline=True)
+        embed.add_field(
+            name="💻 System Info",
+            value="OS, disk & Python version",
+            inline=True,
+        )
+        embed.add_field(
+            name="🗄️ Check Database",
+            value="Verify all DB tables exist",
+            inline=True,
+        )
+        embed.add_field(
+            name="📄 Validate JSON",
+            value="Check data file integrity",
+            inline=True,
+        )
+        embed.add_field(
+            name="📋 Command List",
+            value="Paginated command overview",
+            inline=True,
+        )
+        embed.add_field(
+            name="🔍 Recent Errors",
+            value="Last 10 error log entries",
+            inline=True,
+        )
+        embed.add_field(
+            name="🔔 Test Notify",
+            value="Fire a test webhook ping",
+            inline=True,
+        )
+        embed.set_footer(text="Diagnostics Hub  •  Admin only")
+        return embed
+
+    @discord.ui.button(label="🤖 Bot Status", style=discord.ButtonStyle.blurple, row=0)
+    async def btn_status(self, interaction: discord.Interaction, _: discord.ui.Button):
+        if not await safe_defer(interaction):
+            return
+        await self.ctx.invoke(self.cog.diagnostic_bot_status)
+
+    @discord.ui.button(label="📡 Latency", style=discord.ButtonStyle.blurple, row=0)
+    async def btn_latency(self, interaction: discord.Interaction, _: discord.ui.Button):
+        if not await safe_defer(interaction):
+            return
+        await self.ctx.invoke(self.cog.latency)
+
+    @discord.ui.button(label="💻 System Info", style=discord.ButtonStyle.blurple, row=0)
+    async def btn_sysinfo(self, interaction: discord.Interaction, _: discord.ui.Button):
+        if not await safe_defer(interaction):
+            return
+        await self.ctx.invoke(self.cog.system_info)
+
+    @discord.ui.button(label="🗄️ Database", style=discord.ButtonStyle.grey, row=1)
+    async def btn_db(self, interaction: discord.Interaction, _: discord.ui.Button):
+        if not await safe_defer(interaction):
+            return
+        await self.ctx.invoke(self.cog.check_database)
+
+    @discord.ui.button(label="📄 JSON Files", style=discord.ButtonStyle.grey, row=1)
+    async def btn_json(self, interaction: discord.Interaction, _: discord.ui.Button):
+        if not await safe_defer(interaction):
+            return
+        await self.ctx.invoke(self.cog.validate_json_files)
+
+    @discord.ui.button(label="📋 Commands", style=discord.ButtonStyle.grey, row=1)
+    async def btn_cmds(self, interaction: discord.Interaction, _: discord.ui.Button):
+        if not await safe_defer(interaction):
+            return
+        await self.ctx.invoke(self.cog.list_commands_detailed)
+
+    @discord.ui.button(
+        label="🔍 Recent Errors",
+        style=discord.ButtonStyle.danger,
+        row=2,
+    )
+    async def btn_errors(self, interaction: discord.Interaction, _: discord.ui.Button):
+        if not await safe_defer(interaction):
+            return
+        await self.ctx.invoke(self.cog.recent_errors)
+
+    @discord.ui.button(
+        label="🔔 Test Notify",
+        style=discord.ButtonStyle.secondary,
+        row=2,
+    )
+    async def btn_notify(self, interaction: discord.Interaction, _: discord.ui.Button):
+        if not await safe_defer(interaction):
+            return
+        await self.ctx.invoke(self.cog.test_notification)

--- a/disbot/views/diagnostic/paginator.py
+++ b/disbot/views/diagnostic/paginator.py
@@ -1,0 +1,52 @@
+"""Simple prev/next embed paginator (S4.4.5 extraction).
+
+Extracted from ``cogs/diagnostic_cog.py`` unchanged.  Future stage C2
+(audit §5.2 item 4) will lift this shape into a shared
+``views/paginated.py PaginatedView`` base class consumed by both
+``HelpPanelView`` (cogs/help_cog.py) and this paginator.  Until then,
+the diagnostic paginator stays here.
+"""
+
+from __future__ import annotations
+
+import discord
+
+from views.base import BaseView
+
+
+class _PaginatorView(BaseView):
+    """Simple prev/next paginator for multi-page embeds."""
+
+    def __init__(
+        self,
+        pages: list[discord.Embed],
+        author: discord.Member | discord.User,
+    ):
+        super().__init__(author, timeout=120)
+        self.pages = pages
+        self.index = 0
+        self._update_buttons()
+
+    def _update_buttons(self):
+        self.prev_btn.disabled = self.index == 0
+        self.next_btn.disabled = self.index == len(self.pages) - 1
+
+    @discord.ui.button(label="◀ Prev", style=discord.ButtonStyle.secondary)
+    async def prev_btn(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ):
+        self.index -= 1
+        self._update_buttons()
+        await interaction.response.edit_message(embed=self.pages[self.index], view=self)
+
+    @discord.ui.button(label="Next ▶", style=discord.ButtonStyle.secondary)
+    async def next_btn(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ):
+        self.index += 1
+        self._update_buttons()
+        await interaction.response.edit_message(embed=self.pages[self.index], view=self)


### PR DESCRIPTION
## Summary

Applies the F-3 view-extraction pattern to `cogs/diagnostic_cog.py`. Cog drops **913 → 763 LOC**, now under S4.6's ≤800 LOC fail threshold. Same shape as PR #52 (xp) and PR #53 (moderation); no PersistentView in this subsystem so Pattern A applies — no Pattern-B re-export needed.

This is the audit's addendum §10.3 follow-on (`diagnostic_cog` was flagged as a cog that would otherwise FAIL S4.6's size invariant after the rest of Phase A landed).

## Why this stage, not S4.5 (blackjack)

A4 (blackjack_cog, 1702 LOC) was assessed and found to require deeper test-invariant migration than fits a controlled-mode mini-release. `blackjack_cog` has 12+ tests that import module-level persistence functions (`_save_solo_game`, `_clear_solo_game`, `_save_pvp_match`, `_clear_pvp_match`, `_save_tournament_entry`, `_clear_tournament_entry`, `_Game`, the three `BLACKJACK_*_SUBSYSTEM` constants) and patch `cogs.blackjack_cog.game_state_service.save` directly. Moving the persistence helpers to a sub-package forces a test-update PR bundled with the move. That work is real but it's its own stage — and best done with attention to the persistence invariants while you're not actively testing other PRs.

S4.4.5 was the next-lowest-risk decomposition remaining: two ephemeral views, three call sites in the cog, zero test references to the view classes themselves.

## New layout (mirrors `views/economy/`, `views/moderation/`)

```
views/diagnostic/__init__.py    — re-exports
views/diagnostic/paginator.py   — _PaginatorView (BaseView)
views/diagnostic/hub_panel.py   — _DiagnosticsHubView (HubView)
```

## Behavior preserved end-to-end

- `!diagnostics` opens the same hub panel with the same 8 buttons, each one `ctx.invoke`-ing the corresponding command
- `!platform <subsystem>` group commands all work — they live on `DiagnosticCog`, not in the extracted views
- Help-menu direct navigation (`build_help_menu_view`) still returns a working `_DiagnosticsHubView` via `help_ctx_shim`
- `_PaginatorView` is used by `list_commands_detailed`; same call site, same behavior
- No PersistentView in this subsystem, so identity contract surface unchanged (no `@register`, no `panel_anchors` row)

## Cog-side cleanup

- Removed unused imports: `BaseView`, `HubView` (moved with the views), `safe_defer` (only the extracted hub view used it)
- `send_panel` and `help_ctx_shim` retained — still consumed by the `diagnostics_hub` command and `build_help_menu_view` hook

## Validation

| Gate | Result |
|---|---|
| `pytest tests/unit/` | 837 / 837 pass |
| `test_platform_commands.py` + `test_platform_diagnostics_commands.py` | pass unchanged (they reference `DiagnosticCog`, not the views) |
| Identity contract STRICT mode | green |
| `INV-A` through `INV-N` | green |
| `black` / `isort` / `ruff` / `mypy` (whole tree) | clean across 168 source files |

## Phase A cog-size scoreboard after this PR

| Cog | LOC | Status |
|---|---|---|
| `blackjack_cog.py` | 1702 | ⚠ S4.5 work |
| `rps_tournament_cog.py` | 1182 | ⚠ further extraction needed |
| **`diagnostic_cog.py`** | **763** | ✓ now under S4.6 fail threshold |
| `counting_cog.py` | 654 | warn-tier (acceptable per audit §3.5) |
| `role_cog.py` | 620 | warn-tier (acceptable) |
| `xp_cog.py` | 110 | ✓ clean (S4.2-followup, PR #52) |
| `moderation_cog.py` | 212 | ✓ clean (S4.3, PR #53) |
| `help_cog.py` | 506 | warn-tier (acceptable) |
| `chain_cog.py` | 504 | warn-tier (acceptable) |

S4.6 (soft cog size invariant test) can land once blackjack and the remaining rps_tournament refactor are done.

## Test plan

- [ ] Pull and start the bot locally against a test guild
- [ ] `!diagnostics` — confirm the hub panel renders with all 8 buttons in the same layout (Bot Status, Latency, System Info on row 0; Database, JSON Files, Commands on row 1; Recent Errors, Test Notify on row 2)
- [ ] Click each of the 8 buttons; confirm each invokes its corresponding text-command flow with the same output as before
- [ ] `!platform status`, `!platform anchors`, `!platform identity`, `!platform caches`, `!platform locks`, `!platform tasks`, `!platform views`, `!platform slow`, `!platform sessions`, `!platform runtime` — all the platform group commands still work
- [ ] `!commands` — confirm the paginator opens with prev/next buttons, paging works across multiple pages
- [ ] Help-menu → Diagnostics direct nav — confirm hub opens correctly through the help system

## Note on branch lineage

This branch was cut fresh from `main` after PR #53 merged, with the A5 commit cherry-picked onto it. The original work branch (`claude/audit-bot-architecture-pXnTm`) had this commit pushed onto it before PR #53 merged — that branch is now stale and can be deleted after this PR lands.

https://claude.ai/code/session_01NgPyBFU77jy5jY55ABNwgn

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgPyBFU77jy5jY55ABNwgn)_