### PR TITLE
PR S4.6: decompose rps_tournament_cog + land soft cog-size invariant — Phase A complete

### DIFF
--- a/disbot/cogs/rps_tournament/__init__.py
+++ b/disbot/cogs/rps_tournament/__init__.py
@@ -1,12 +1,22 @@
-"""RPS tournament subsystem — pure-rules + future domain modules (S4.4).
+"""RPS tournament subsystem — pure rules + helpers + persistence (S4.4 + S4.6).
 
 See ``docs/architecture.md`` §"Subsystem decomposition" for the layout
-convention.  Modules in this package are pure-ish: they do not own
-cog state and do not perform Discord-API I/O.
+convention.  Modules in this package are pure-ish (no cog state, no
+Discord-API I/O) except where noted.
 
 Modules:
-    rules  — move alias map, game-mode whitelist, win-condition table,
-             ``normalize_move``, ``determine_winner``
-             (consumed by the cog's on_message + handle_bot_match_move +
-              resolve_match paths)
+    rules         — move alias map, game-mode whitelist, win-condition
+                    table, ``normalize_move``, ``determine_winner``
+                    (S4.4; consumed by handle_bot_match_move + on_message
+                    + resolve_match)
+    _persistence  — game_state_service writers and recovery helpers for
+                    rps_pvp_pending + rps_tournament subsystems (S4.6)
+    _helpers      — channel-creation + stat-update + lifecycle-task
+                    helpers shared between bot-match and tournament
+                    code paths (S4.6)
+    _bot_matches  — module-level state (_bot_matches, _bot_match_channels)
+                    + bot-vs-player command/handler bodies (S4.6).
+                    State is initialised by the cog's __init__ and
+                    cleared by cog_unload so reload semantics match
+                    the pre-extraction layout.
 """

--- a/disbot/cogs/rps_tournament/_bot_matches.py
+++ b/disbot/cogs/rps_tournament/_bot_matches.py
@@ -1,0 +1,194 @@
+"""RPS bot-match command + on-message handler (S4.6).
+
+Extracted from ``cogs/rps_tournament_cog.py``.  Module-level state
+(``_bot_matches``, ``_bot_match_channels``) is initialised by the
+cog's ``__init__`` (via :func:`reset_state`) and cleared by
+``cog_unload`` so cog-reload semantics match the pre-extraction
+layout — a reload starts with empty bot-match state, same as before.
+
+The functions take the discord.py ctx/message/bot as parameters
+rather than the cog instance so they're testable without a fully-
+initialised RPSTournamentCog.  The cog method bodies that delegate
+here pass through the inputs they receive from discord.py.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+
+import discord
+
+from cogs.rps_tournament._helpers import (
+    create_bot_match_channel,
+    schedule_channel_deletion,
+    update_player_stats,
+)
+from cogs.rps_tournament.rules import GAME_MODES, determine_winner, normalize_move
+
+logger = logging.getLogger("bot")
+
+
+# ---------------------------------------------------------------------------
+# Module-level state (cog lifecycle owns initialization + teardown)
+# ---------------------------------------------------------------------------
+
+_bot_matches: dict[discord.Member, dict] = {}
+_bot_match_channels: set[int] = set()
+
+
+def reset_state() -> None:
+    """Clear bot-match state.  Called from cog ``__init__`` and ``cog_unload``.
+
+    Preserves the pre-extraction "reload wipes state" behavior.
+    """
+    _bot_matches.clear()
+    _bot_match_channels.clear()
+
+
+# ---------------------------------------------------------------------------
+# !rpsbot — start bot matches for one or more players
+# ---------------------------------------------------------------------------
+
+
+async def run_rps_bot_command(
+    ctx,
+    default_mode: str,
+    default_best_of: int,
+    mode: str | None,
+    best_of: int | None,
+    members_or_roles: tuple,
+) -> None:
+    """Body of the ``!rpsbot`` command.
+
+    Resolves players from the provided members/roles (or ``ctx.author``
+    if empty), creates one private channel per player, and seeds the
+    in-memory bot-match state.
+    """
+    if mode is None:
+        mode = default_mode
+    if mode not in GAME_MODES:
+        await ctx.send(
+            f"Invalid game mode. Available modes: {', '.join(GAME_MODES.keys())}",
+        )
+        return
+
+    if best_of is None:
+        best_of = default_best_of
+    if best_of % 2 == 0 or best_of < 1:
+        await ctx.send(
+            "Please provide an odd positive integer for the number of rounds.",
+        )
+        return
+
+    players = []
+    if members_or_roles:
+        for item in members_or_roles:
+            member = None
+            if isinstance(item, discord.Member):
+                member = item
+            elif isinstance(item, str):
+                # Try to get member by ID or mention
+                member = ctx.guild.get_member_named(item)
+            elif isinstance(item, discord.Role):
+                players.extend(item.members)
+                continue
+            if member:
+                players.append(member)
+    else:
+        players.append(ctx.author)
+
+    for player in players:
+        match_channel = await create_bot_match_channel(ctx.guild, player, ctx)
+        if match_channel is None:
+            await ctx.send(
+                f"Failed to create match channel for {player.display_name}.",
+            )
+            continue
+
+        _bot_matches[player] = {
+            "channel": match_channel.id,
+            "wins": 0,
+            "bot_wins": 0,
+            "best_of": best_of,
+            "mode": mode,
+        }
+        _bot_match_channels.add(match_channel.id)
+
+        await match_channel.send(
+            f"{player.mention} vs **Bot**\n"
+            f"Game mode: {mode.capitalize()}, Best of {best_of}\n"
+            "Please enter your move.",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bot-match move handler (called from cog.on_message)
+# ---------------------------------------------------------------------------
+
+
+def channel_is_bot_match(channel_id: int) -> bool:
+    """Whether the given channel hosts an active bot match."""
+    return channel_id in _bot_match_channels
+
+
+async def handle_bot_match_move(message: discord.Message) -> None:
+    """Handle a move typed in a bot-match channel.
+
+    Mirrors the pre-extraction ``handle_bot_match_move`` body — pulls
+    the player's match record, normalises the move, plays the bot,
+    updates wins/losses, and ends the match when either side hits the
+    required win count.
+    """
+    player = message.author
+    match = _bot_matches.get(player)
+    if not match:
+        return
+
+    # Check if the match is already over
+    required_wins = (match["best_of"] // 2) + 1
+    if match["wins"] >= required_wins or match["bot_wins"] >= required_wins:
+        # Match is over; inform the player and return
+        await message.channel.send("The match is already over.")
+        return
+
+    move = message.content.lower().strip()
+    move = normalize_move(move, match["mode"])
+    if move is None:
+        await message.channel.send(
+            f"{player.mention}, invalid move. Please try again.",
+        )
+        return
+
+    bot_move = random.choice(GAME_MODES[match["mode"]])
+    await message.channel.send(f"Bot played: {bot_move.capitalize()}.")
+
+    winner = determine_winner(move, bot_move, match["mode"])
+    if winner == 0:
+        await message.channel.send("It's a tie!")
+        update_player_stats(player, "tie")
+    elif winner == 1:
+        match["wins"] += 1
+        await message.channel.send(f"{player.mention} wins this round!")
+        update_player_stats(player, "win")
+    else:
+        match["bot_wins"] += 1
+        await message.channel.send("Bot wins this round!")
+        update_player_stats(player, "loss")
+
+    # Check if someone has won the match
+    if match["wins"] >= required_wins:
+        await message.channel.send(
+            f"{player.mention} wins the match against the bot!",
+        )
+        await schedule_channel_deletion(message.channel)
+        del _bot_matches[player]
+        _bot_match_channels.discard(message.channel.id)
+        return  # Prevent further execution
+    if match["bot_wins"] >= required_wins:
+        await message.channel.send("Bot wins the match!")
+        await schedule_channel_deletion(message.channel)
+        del _bot_matches[player]
+        _bot_match_channels.discard(message.channel.id)
+        return  # Prevent further execution
+    await message.channel.send("Please enter your next move.")

--- a/disbot/cogs/rps_tournament/_bot_matches.py
+++ b/disbot/cogs/rps_tournament/_bot_matches.py
@@ -139,8 +139,16 @@ async def handle_bot_match_move(message: discord.Message) -> None:
     the player's match record, normalises the move, plays the bot,
     updates wins/losses, and ends the match when either side hits the
     required win count.
+
+    Bot matches only run in guild text channels (the channel id is
+    in ``_bot_match_channels``, populated by ``create_bot_match_channel``
+    which always creates a guild channel).  The isinstance narrow is
+    defensive — a DM cannot have its channel id in the set, so this
+    is also a static-type narrow for mypy.
     """
     player = message.author
+    if not isinstance(player, discord.Member):
+        return
     match = _bot_matches.get(player)
     if not match:
         return

--- a/disbot/cogs/rps_tournament/_helpers.py
+++ b/disbot/cogs/rps_tournament/_helpers.py
@@ -174,6 +174,10 @@ async def cleanup_orphaned_channels(bot: commands.Bot) -> None:
             if not cat or not cat.channels:
                 continue
             for ch in cat.channels:
+                # Match channels are TextChannel; voice/stage/forum slots
+                # can't receive a "match interrupted" notice.
+                if not isinstance(ch, discord.TextChannel):
+                    continue
                 try:
                     await ch.send(
                         "⚠️ The bot restarted and this match was interrupted. "

--- a/disbot/cogs/rps_tournament/_helpers.py
+++ b/disbot/cogs/rps_tournament/_helpers.py
@@ -1,0 +1,185 @@
+"""RPS tournament helper functions (S4.6).
+
+Module-level helpers extracted from ``cogs/rps_tournament_cog.py``:
+
+  add_player_to_db        — idempotent rps_players row insert
+  update_player_stats     — schedule async stat update
+  create_match_channel    — PvP tournament private channel
+  create_bot_match_channel — bot-vs-player private channel
+  schedule_channel_deletion — 5-minute delayed delete
+  delete_all_match_channels — full RPS Tournaments category cleanup
+  clear_stale_tournament_flag — on-startup ACTIVE_TOURNAMENT sweep
+  cleanup_orphaned_channels — on-startup match-channel cleanup
+
+None reference cog instance state — they take what they need as
+arguments.  Failure-handling logs and swallows so the cog's
+high-level flow is not interrupted by transient Discord errors.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import discord
+from discord.ext import commands
+
+from core.runtime import tasks
+from utils import db as global_db
+from utils.channels import cleanup_category, create_private_channel
+from utils.settings_keys import ACTIVE_TOURNAMENT
+
+logger = logging.getLogger("bot")
+
+
+# ---------------------------------------------------------------------------
+# Player stat helpers
+# ---------------------------------------------------------------------------
+
+
+async def add_player_to_db(user, guild_id: int) -> None:
+    """Idempotent insert into the rps_players stats table.
+
+    PR R1: ``guild_id`` required.  rps_players' PK is
+    ``(user_id, guild_id)`` since migration 005; defaulting to 0 made
+    every guild's stats collide at the same row.
+    """
+    try:
+        await global_db.rps_ensure_player(user.id, guild_id, user.display_name)
+    except Exception as e:
+        logger.exception("Error adding RPS player to database: %s", e)
+
+
+def update_player_stats(player, result: str) -> None:
+    """Schedule an async stats update without blocking the event loop.
+
+    PR R1: derives ``guild_id`` from ``player.guild`` and passes it
+    through so ``rps_update_stat`` writes to the correct guild row.
+    Players passed in here always come from a guild context (bot
+    matches and tournament matches both originate in guild channels)
+    so ``player.guild`` is non-None.
+    """
+    guild = getattr(player, "guild", None)
+    if guild is None:
+        logger.warning(
+            "update_player_stats: player=%s has no guild context; "
+            "skipping stat update",
+            player.id,
+        )
+        return
+    tasks.spawn(
+        f"rps:stat:{player.id}",
+        _async_update_stat(player.id, guild.id, result),
+    )
+
+
+async def _async_update_stat(user_id: int, guild_id: int, result: str) -> None:
+    try:
+        await global_db.rps_update_stat(user_id, guild_id, result)
+    except Exception as e:
+        logger.exception("Error updating RPS player stats: %s", e)
+
+
+# ---------------------------------------------------------------------------
+# Channel helpers
+# ---------------------------------------------------------------------------
+
+
+async def create_match_channel(guild, player1, player2, ctx):
+    """Create a private channel for a PvP tournament match."""
+    try:
+        return await create_private_channel(
+            guild,
+            f"rps-{player1.display_name}-vs-{player2.display_name}",
+            [player1, player2],
+            "RPS Tournaments",
+        )
+    except discord.Forbidden:
+        await ctx.send("I do not have permission to create channels.")
+        return None
+    except Exception as e:
+        logger.exception(f"Error creating match channel: {e}")
+        await ctx.send(f"An error occurred while creating the match channel: {e}")
+        return None
+
+
+async def create_bot_match_channel(guild, player, ctx):
+    """Create a private channel for a bot-vs-player match."""
+    try:
+        return await create_private_channel(
+            guild,
+            f"rps-{player.display_name}-vs-bot",
+            [player],
+            "RPS Bot Matches",
+        )
+    except discord.Forbidden:
+        await ctx.send("I do not have permission to create channels.")
+        return None
+    except Exception as e:
+        logger.exception(f"Error creating bot match channel: {e}")
+        await ctx.send(f"An error occurred while creating the match channel: {e}")
+        return None
+
+
+async def schedule_channel_deletion(channel) -> None:
+    """Delete a match channel after a 5-minute delay (post-match cleanup)."""
+    await asyncio.sleep(300)
+    try:
+        await channel.delete()
+    except discord.Forbidden:
+        logger.warning(
+            f"Failed to delete channel {channel.name}: insufficient permissions.",
+        )
+    except Exception as e:
+        logger.exception(
+            f"An error occurred while deleting channel {channel.name}: {e}",
+        )
+
+
+async def delete_all_match_channels(guild) -> None:
+    """Delete all RPS tournament match channels and the parent category."""
+    category = discord.utils.get(guild.categories, name="RPS Tournaments")
+    if category:
+        await cleanup_category(category)
+
+
+# ---------------------------------------------------------------------------
+# Startup tasks
+# ---------------------------------------------------------------------------
+
+
+async def clear_stale_tournament_flag(bot: commands.Bot) -> None:
+    """Reset ACTIVE_TOURNAMENT for any guild where it was left as 'rps'.
+
+    Called once at cog_load to recover from a crash that left the
+    flag set without an active in-memory tournament.
+    """
+    await bot.wait_until_ready()
+    for guild in bot.guilds:
+        flag = await global_db.get_setting(guild.id, ACTIVE_TOURNAMENT, "")
+        if flag == "rps":
+            await global_db.set_setting(guild.id, ACTIVE_TOURNAMENT, "")
+
+
+async def cleanup_orphaned_channels(bot: commands.Bot) -> None:
+    """At startup, drop leftover RPS Tournament + RPS Bot Match channels.
+
+    Sends a 5-min warning to each channel first, then deletes the
+    parent categories.  Called once at cog_load.
+    """
+    await bot.wait_until_ready()
+    for guild in bot.guilds:
+        for cat_name in ("RPS Tournaments", "RPS Bot Matches"):
+            cat = discord.utils.get(guild.categories, name=cat_name)
+            if not cat or not cat.channels:
+                continue
+            for ch in cat.channels:
+                try:
+                    await ch.send(
+                        "⚠️ The bot restarted and this match was interrupted. "
+                        "This channel will be deleted in 5 minutes.",
+                    )
+                except Exception:
+                    pass
+            await asyncio.sleep(300)
+            await cleanup_category(cat)

--- a/disbot/cogs/rps_tournament/_persistence.py
+++ b/disbot/cogs/rps_tournament/_persistence.py
@@ -1,0 +1,282 @@
+"""RPS tournament persistence + recovery helpers (S4.6).
+
+Each function corresponds to one of the two persisted RPS subsystems:
+
+  rps_pvp_pending     — pending PvP-challenge match state (cleared
+                        on recovery, no refund — match never pre-debits)
+  rps_tournament      — per-player tournament entry rows (refund on
+                        recovery, entries are pre-debited at registration)
+
+Test patches that previously targeted
+``cogs.rps_tournament_cog.<thing>`` should now target the function-
+defining module (``cogs.rps_tournament._persistence``).  See A1 and
+A4 for the same migration pattern in xp and blackjack.
+
+The cog methods (_recover_rps_tournament, _recover_rps_pvp_pending,
+on_guild_remove, try_register_player) are preserved as thin
+delegators so existing tests that call them via cog.<method>() keep
+working.  The inspect.getsource test for try_register_player was
+migrated to inspect ``save_tournament_entry`` instead — the literal
+strings (``game_state_service.save``, ``RPS_TOURNAMENT_SUBSYSTEM``,
+``RPS_TOURNAMENT_VERSION``, ``"bet":``) now live here.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from services import economy_service, game_state_service
+
+logger = logging.getLogger("bot")
+
+# PR G6 — RPS tournament persistence constants.  Kept in this module
+# so the inspect.getsource(save_tournament_entry) invariant has a
+# stable target.  The cog re-exports them for back-compat imports.
+RPS_TOURNAMENT_SUBSYSTEM = "rps_tournament"
+RPS_TOURNAMENT_VERSION = 1
+
+
+# ---------------------------------------------------------------------------
+# rps_tournament — paid entry-fee persistence
+# ---------------------------------------------------------------------------
+
+
+async def save_tournament_entry(
+    *,
+    guild_id: int,
+    user_id: int,
+    entry_fee: int,
+) -> None:
+    """Persist a registered player's paid-entry row.
+
+    Channel_id sentinel (0) because an RPS tournament is guild-wide,
+    not channel-local — the natural game_state UNIQUE constraint on
+    ``(guild_id, user_id, channel_id, subsystem)`` then enforces
+    "one tournament entry per user per guild".
+
+    The ``bet`` payload key matches the G0 GC convention so even if
+    the bot loses both the cog_load recovery AND the on_guild_remove
+    listener, the 24 h sweep still issues the refund.
+
+    Failures are logged WARN and swallowed — the cog's in-memory
+    state is authoritative while the bot is alive.
+    """
+    try:
+        await game_state_service.save(
+            guild_id=guild_id,
+            user_id=user_id,
+            channel_id=0,  # sentinel — tournament is guild-wide, not channel-local
+            subsystem=RPS_TOURNAMENT_SUBSYSTEM,
+            state={"bet": entry_fee},
+            version=RPS_TOURNAMENT_VERSION,
+        )
+    except Exception as exc:
+        logger.warning(
+            "rps_tournament save failed (user=%d guild=%d): %s",
+            user_id,
+            guild_id,
+            exc,
+        )
+
+
+async def recover_rps_tournament() -> None:
+    """Refund every stranded RPS tournament entry then clear the row.
+
+    Same shape as ``BlackjackCog._recover_blackjack_tournament``:
+    entry fees were debited at registration, never paid back if the
+    bot crashed before ``check_tournament_progress`` settled the pot.
+    Refund failures are logged WARN but the row is still cleared to
+    avoid an infinite retry loop.
+    """
+    try:
+        rows = await game_state_service.list_active_for_subsystem(
+            RPS_TOURNAMENT_SUBSYSTEM,
+        )
+    except Exception as exc:
+        logger.warning("rps_tournament recovery skipped: %s", exc)
+        return
+    if not rows:
+        return
+    cleared = 0
+    refunded = 0
+    for row in rows:
+        try:
+            version = row.get("version")
+            if version != RPS_TOURNAMENT_VERSION:
+                logger.info(
+                    "rps_tournament recovery: dropping version-"
+                    "mismatch row id=%s (saved=%s, current=%s)",
+                    row["id"],
+                    version,
+                    RPS_TOURNAMENT_VERSION,
+                )
+                await game_state_service.clear_by_id(row["id"])
+                cleared += 1
+                continue
+            state = row.get("state") or {}
+            bet = state.get("bet")
+            if isinstance(bet, int) and bet > 0:
+                try:
+                    await economy_service.refund(
+                        guild_id=row["guild_id"],
+                        user_id=row["user_id"],
+                        amount=bet,
+                        reason="rps_tournament:restart_refund",
+                    )
+                    refunded += 1
+                except Exception as exc:
+                    logger.warning(
+                        "rps_tournament refund failed for user=%d guild=%d: %s",
+                        row.get("user_id"),
+                        row.get("guild_id"),
+                        exc,
+                    )
+            await game_state_service.clear_by_id(row["id"])
+            cleared += 1
+        except Exception as exc:
+            logger.warning(
+                "rps_tournament recovery: row id=%s failed: %s",
+                row.get("id"),
+                exc,
+            )
+    if cleared or refunded:
+        logger.info(
+            "rps_tournament recovery: cleared %d row(s), issued %d refund(s)",
+            cleared,
+            refunded,
+        )
+
+
+# ---------------------------------------------------------------------------
+# rps_pvp_pending — pending PvP-challenge persistence (clear-only)
+# ---------------------------------------------------------------------------
+
+
+async def recover_rps_pvp_pending() -> None:
+    """Drop every stranded rps_pvp_pending row.
+
+    Live views cannot be re-attached after a process bounce, so the
+    only safe action is to clear.  No coins are refunded — RPS PvP
+    does not pre-debit (the bet is exchanged at resolve time).
+
+    The 24 h GC sweep would handle this anyway; acting at cog_load
+    is just faster recovery.
+    """
+    try:
+        from views.rps._helpers import (
+            RPS_PVP_PENDING_SUBSYSTEM,
+            RPS_PVP_PENDING_VERSION,
+        )
+
+        rows = await game_state_service.list_active_for_subsystem(
+            RPS_PVP_PENDING_SUBSYSTEM,
+        )
+    except Exception as exc:
+        logger.warning("rps pvp_pending recovery skipped: %s", exc)
+        return
+    if not rows:
+        return
+    cleared = 0
+    for row in rows:
+        try:
+            # Drop both up-to-date and version-mismatched payloads.
+            # The view cannot be resumed either way.
+            version = row.get("version")
+            if version != RPS_PVP_PENDING_VERSION:
+                logger.info(
+                    "rps_pvp_pending recovery: dropping version-mismatch "
+                    "row id=%s (saved=%s, current=%s)",
+                    row["id"],
+                    version,
+                    RPS_PVP_PENDING_VERSION,
+                )
+            await game_state_service.clear_by_id(row["id"])
+            cleared += 1
+        except Exception as exc:
+            logger.warning(
+                "rps_pvp_pending recovery: clear failed for id=%s: %s",
+                row.get("id"),
+                exc,
+            )
+    if cleared:
+        logger.info(
+            "rps_pvp_pending recovery: cleared %d stranded match(es)",
+            cleared,
+        )
+
+
+# ---------------------------------------------------------------------------
+# on_guild_remove — clear both subsystems for a departed guild
+# ---------------------------------------------------------------------------
+
+
+async def on_guild_remove_rps(guild_id: int) -> None:
+    """Wipe rps subsystem rows for a departed guild.
+
+    rps_pvp_pending rows clear without refund (no pre-debit).
+    rps_tournament rows trigger refunds — guild removal mid-
+    tournament is equivalent to a crash from the player's
+    perspective.
+    """
+    # rps_pvp_pending — clear, no refund.
+    try:
+        from views.rps._helpers import RPS_PVP_PENDING_SUBSYSTEM
+
+        rows = await game_state_service.list_active_for_subsystem(
+            RPS_PVP_PENDING_SUBSYSTEM,
+            guild_id=guild_id,
+        )
+        for row in rows:
+            try:
+                await game_state_service.clear_by_id(row["id"])
+            except Exception as exc:
+                logger.warning(
+                    "rps_pvp_pending on_guild_remove: clear id=%s failed: %s",
+                    row.get("id"),
+                    exc,
+                )
+    except Exception as exc:
+        logger.warning(
+            "rps_pvp_pending on_guild_remove failed for guild=%d: %s",
+            guild_id,
+            exc,
+        )
+
+    # rps_tournament — refund + clear.
+    try:
+        rows = await game_state_service.list_active_for_subsystem(
+            RPS_TOURNAMENT_SUBSYSTEM,
+            guild_id=guild_id,
+        )
+        for row in rows:
+            state = row.get("state") or {}
+            bet = state.get("bet")
+            if isinstance(bet, int) and bet > 0:
+                try:
+                    await economy_service.refund(
+                        guild_id=row["guild_id"],
+                        user_id=row["user_id"],
+                        amount=bet,
+                        reason="rps_tournament:guild_remove_refund",
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "rps_tournament on_guild_remove refund "
+                        "failed for user=%d: %s",
+                        row.get("user_id"),
+                        exc,
+                    )
+            try:
+                await game_state_service.clear_by_id(row["id"])
+            except Exception as exc:
+                logger.warning(
+                    "rps_tournament on_guild_remove: clear id=%s failed: %s",
+                    row.get("id"),
+                    exc,
+                )
+    except Exception as exc:
+        logger.warning(
+            "rps_tournament on_guild_remove failed for guild=%d: %s",
+            guild_id,
+            exc,
+        )

--- a/disbot/cogs/rps_tournament/_quickplay.py
+++ b/disbot/cogs/rps_tournament/_quickplay.py
@@ -1,0 +1,73 @@
+"""RPS quick-play command body (S4.6).
+
+``!rps`` (and the PvP shape ``!rps @user [bet]``) is a one-shot
+view-spawning command — no tournament state, no cog state.  Extracted
+from the cog so the cog file fits under the S4.6 size ceiling.
+
+The cog command stub delegates here with just ``ctx``, ``target``, and
+``bet``.
+"""
+
+from __future__ import annotations
+
+import discord
+from discord.ext import commands
+
+from utils import db as global_db
+from utils.ui_constants import GAME_COLOR
+from views.rps import (
+    _FREE_WIN,
+    _RpsPvpChallengeView,
+    _RpsView,
+)
+
+
+async def run_quickrps_command(
+    ctx: commands.Context,
+    target: discord.Member | None,
+    bet: int,
+) -> None:
+    """Body of ``!rps [target] [bet]``."""
+    if bet < 0:
+        await ctx.send("Bet must be 0 or a positive number.", delete_after=5)
+        return
+
+    # PvP challenge
+    if target and target != ctx.author:
+        if target.bot:
+            await ctx.send("You can't challenge a bot to PvP.", delete_after=5)
+            return
+        if bet > 0:
+            bal = await global_db.get_coins(ctx.author.id, ctx.guild.id)
+            if bet > bal:
+                await ctx.send(f"❌ You only have **{bal}** 🪙.", delete_after=8)
+                return
+        bet_str = f"**{bet}** 🪙" if bet else "free play"
+        view = _RpsPvpChallengeView(ctx.author, target, ctx.guild.id, bet)  # type: ignore[arg-type]
+        embed = discord.Embed(
+            title="✂️ RPS Challenge!",
+            description=(
+                f"{ctx.author.mention} challenges {target.mention} to Rock-Paper-Scissors "
+                f"({bet_str}).\n{target.mention}, do you accept?"
+            ),
+            color=GAME_COLOR,
+        )
+        msg = await ctx.send(embed=embed, view=view)
+        view.message = msg
+        return
+
+    # vs bot
+    if bet > 0:
+        bal = await global_db.get_coins(ctx.author.id, ctx.guild.id)
+        if bet > bal:
+            await ctx.send(f"❌ You only have **{bal}** 🪙.", delete_after=10)
+            return
+    view = _RpsView(ctx.author, ctx.guild.id, bet)  # type: ignore[assignment, arg-type]
+    bet_str = f"**{bet}** 🪙" if bet else f"Free play (win = +{_FREE_WIN} 🪙)"
+    embed = discord.Embed(
+        title="✂️ Rock · Paper · Scissors",
+        description=f"Bet: {bet_str}\nChoose your move!",
+        color=GAME_COLOR,
+    )
+    msg = await ctx.send(embed=embed, view=view)
+    view.message = msg

--- a/disbot/cogs/rps_tournament_cog.py
+++ b/disbot/cogs/rps_tournament_cog.py
@@ -1,3 +1,25 @@
+"""RPS tournament cog — commands + tournament flow (S4.6).
+
+Persistence, recovery, channel helpers, stat helpers, lifecycle tasks,
+and bot-match handling have been extracted to ``cogs/rps_tournament/``
+submodules.  This file is now the cog itself — commands, the
+tournament registration / round flow that holds per-instance state
+(``self.players`` / ``self.scores`` / ``self.matches`` /
+``self.match_channels`` / ``self.current_round``), and listeners.
+
+Symbols re-exported for back-compat with existing tests:
+
+  RPS_TOURNAMENT_SUBSYSTEM, RPS_TOURNAMENT_VERSION
+        — moved to cogs.rps_tournament._persistence (the
+          ``inspect.getsource(save_tournament_entry)`` invariant has
+          a stable home there).
+
+The ``inspect.getsource(RPSTournamentCog.try_register_player)`` test
+was migrated to inspect ``save_tournament_entry`` — see
+``tests/unit/cogs/test_rps_tournament_persistence.py`` for the
+updated assertion.
+"""
+
 from __future__ import annotations
 
 import asyncio
@@ -7,6 +29,32 @@ import random
 import discord
 from discord.ext import commands
 
+from cogs.rps_tournament._bot_matches import (
+    channel_is_bot_match,
+    handle_bot_match_move,
+)
+from cogs.rps_tournament._bot_matches import reset_state as _reset_bot_match_state
+from cogs.rps_tournament._bot_matches import (
+    run_rps_bot_command,
+)
+from cogs.rps_tournament._helpers import (
+    add_player_to_db,
+    cleanup_orphaned_channels,
+    clear_stale_tournament_flag,
+    create_match_channel,
+    delete_all_match_channels,
+    schedule_channel_deletion,
+    update_player_stats,
+)
+from cogs.rps_tournament._persistence import (  # noqa: F401 — re-exported for back-compat with tests
+    RPS_TOURNAMENT_SUBSYSTEM,
+    RPS_TOURNAMENT_VERSION,
+    on_guild_remove_rps,
+    recover_rps_pvp_pending,
+    recover_rps_tournament,
+    save_tournament_entry,
+)
+from cogs.rps_tournament._quickplay import run_quickrps_command
 from cogs.rps_tournament.rules import (
     GAME_MODES,
     MOVE_ALIASES,
@@ -15,15 +63,18 @@ from cogs.rps_tournament.rules import (
 )
 from core.runtime import tasks
 from core.runtime.component_registry import stats_block
-from services import economy_service, game_state_service
+from services import (  # noqa: F401 — game_state_service kept for back-compat patch sites
+    economy_service,
+    game_state_service,
+)
 from utils import db as global_db
-from utils.channels import cleanup_category, create_private_channel
+from utils.channels import (  # noqa: F401 — re-exported for back-compat
+    create_private_channel,
+)
 from utils.settings_keys import ACTIVE_TOURNAMENT
 from utils.ui_constants import GAME_COLOR, INFO_COLOR
 
-# Views + shared constants moved to views/rps/ during D4 — re-exported
-# below for backward compatibility with any external import of these
-# private names.
+# Re-exports of view classes that historically lived in this file (D4).
 from views.rps import (  # noqa: F401 — re-exported for back-compat
     _FREE_WIN,
     _RPS_EMOJI,
@@ -37,16 +88,6 @@ from views.rps import (  # noqa: F401 — re-exported for back-compat
 )
 
 logger = logging.getLogger("bot")
-
-# PR G6 — RPS tournament persistence (entry-fee refund on restart).
-# Mirrors PR G5's per-player row design: one row per registered
-# participant.  channel_id=0 sentinel because the tournament is
-# guild-wide, not tied to one channel; the natural game_state UNIQUE
-# constraint on (guild_id, user_id, channel_id, subsystem) already
-# enforces "one entry per user per guild", which is exactly what the
-# cog's ``tournament_active`` flag also enforces.
-RPS_TOURNAMENT_SUBSYSTEM = "rps_tournament"
-RPS_TOURNAMENT_VERSION = 1
 
 
 class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # type: ignore[call-arg]
@@ -74,8 +115,11 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # 
         self.inactivity_limit = 300  # 5 minutes inactivity limit
         self.reminder_task = None
         self.registration_role = None  # Role to mention in reminders
-        self.bot_matches = {}
-        self.bot_match_channels = set()
+        # Bot-match state lives at module level in
+        # ``cogs/rps_tournament/_bot_matches.py``; reset on cog init/
+        # unload to preserve the pre-extraction "reload wipes state"
+        # semantics.
+        _reset_bot_match_state()
         self.settings = {"default_mode": "classic", "default_best_of": 3}
         self.entry_fee = 0
         self.paid_players: set[int] = set()  # players who paid the entry fee
@@ -118,14 +162,15 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # 
         )
         return embed, discord.ui.View(timeout=300)
 
+    # ------------------------------------------------------------------
+    # Lifecycle + recovery (delegators preserve test invariants)
+    # ------------------------------------------------------------------
+
     async def cog_load(self) -> None:
-        tasks.spawn("rps:clear_stale_flag", self._clear_stale_tournament_flag())
-        tasks.spawn("rps:cleanup_orphaned", self._cleanup_orphaned_channels())
+        tasks.spawn("rps:clear_stale_flag", clear_stale_tournament_flag(self.bot))
+        tasks.spawn("rps:cleanup_orphaned", cleanup_orphaned_channels(self.bot))
         # PR G1 — drop any rps_pvp_pending game_state rows left over
-        # from a previous process.  Live views cannot be re-attached, so
-        # the only safe action is to clear; the GC sweep would handle
-        # this after 24h but acting at cog_load is faster.  No coins
-        # are refunded — RPS PvP does not pre-debit.
+        # from a previous process.
         tasks.spawn("rps:recover_pvp_pending", self._recover_rps_pvp_pending())
         # PR G6 — refund stranded tournament entries.  Same shape as
         # blackjack tournament: entry fees were debited at registration
@@ -133,194 +178,29 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # 
         # payout in ``check_tournament_progress``.
         tasks.spawn("rps:recover_tournament", self._recover_rps_tournament())
 
-    async def _recover_rps_pvp_pending(self) -> None:
-        try:
-            from views.rps._helpers import (
-                RPS_PVP_PENDING_SUBSYSTEM,
-                RPS_PVP_PENDING_VERSION,
-            )
+    def cog_unload(self):
+        """Cancel reminder + all spawned RPS tasks; clear bot-match state."""
+        if self.reminder_task and not self.reminder_task.done():
+            self.reminder_task.cancel()
+        tasks.cancel_by_prefix("rps:")
+        _reset_bot_match_state()
 
-            rows = await game_state_service.list_active_for_subsystem(
-                RPS_PVP_PENDING_SUBSYSTEM,
-            )
-        except Exception as exc:
-            logger.warning("rps pvp_pending recovery skipped: %s", exc)
-            return
-        if not rows:
-            return
-        cleared = 0
-        for row in rows:
-            try:
-                # Drop both up-to-date and version-mismatched payloads.
-                # The view cannot be resumed either way.
-                version = row.get("version")
-                if version != RPS_PVP_PENDING_VERSION:
-                    logger.info(
-                        "rps_pvp_pending recovery: dropping version-mismatch "
-                        "row id=%s (saved=%s, current=%s)",
-                        row["id"],
-                        version,
-                        RPS_PVP_PENDING_VERSION,
-                    )
-                await game_state_service.clear_by_id(row["id"])
-                cleared += 1
-            except Exception as exc:
-                logger.warning(
-                    "rps_pvp_pending recovery: clear failed for id=%s: %s",
-                    row.get("id"),
-                    exc,
-                )
-        if cleared:
-            logger.info(
-                "rps_pvp_pending recovery: cleared %d stranded match(es)",
-                cleared,
-            )
+    async def _recover_rps_pvp_pending(self) -> None:
+        """Delegator — see ``cogs.rps_tournament._persistence``."""
+        await recover_rps_pvp_pending()
 
     async def _recover_rps_tournament(self) -> None:
-        """Refund every stranded RPS tournament entry then clear the row.
-
-        Same shape as ``BlackjackCog._recover_blackjack_tournament``:
-        entry fees were debited at registration, never paid back if the
-        bot crashed before ``check_tournament_progress`` settled the
-        pot.  Refund failures are logged WARN but the row is still
-        cleared to avoid an infinite retry loop.
-        """
-        try:
-            rows = await game_state_service.list_active_for_subsystem(
-                RPS_TOURNAMENT_SUBSYSTEM,
-            )
-        except Exception as exc:
-            logger.warning("rps_tournament recovery skipped: %s", exc)
-            return
-        if not rows:
-            return
-        cleared = 0
-        refunded = 0
-        for row in rows:
-            try:
-                version = row.get("version")
-                if version != RPS_TOURNAMENT_VERSION:
-                    logger.info(
-                        "rps_tournament recovery: dropping version-"
-                        "mismatch row id=%s (saved=%s, current=%s)",
-                        row["id"],
-                        version,
-                        RPS_TOURNAMENT_VERSION,
-                    )
-                    await game_state_service.clear_by_id(row["id"])
-                    cleared += 1
-                    continue
-                state = row.get("state") or {}
-                bet = state.get("bet")
-                if isinstance(bet, int) and bet > 0:
-                    try:
-                        await economy_service.refund(
-                            guild_id=row["guild_id"],
-                            user_id=row["user_id"],
-                            amount=bet,
-                            reason="rps_tournament:restart_refund",
-                        )
-                        refunded += 1
-                    except Exception as exc:
-                        logger.warning(
-                            "rps_tournament refund failed for user=%d guild=%d: %s",
-                            row.get("user_id"),
-                            row.get("guild_id"),
-                            exc,
-                        )
-                await game_state_service.clear_by_id(row["id"])
-                cleared += 1
-            except Exception as exc:
-                logger.warning(
-                    "rps_tournament recovery: row id=%s failed: %s",
-                    row.get("id"),
-                    exc,
-                )
-        if cleared or refunded:
-            logger.info(
-                "rps_tournament recovery: cleared %d row(s), issued %d refund(s)",
-                cleared,
-                refunded,
-            )
+        """Delegator — see ``cogs.rps_tournament._persistence``."""
+        await recover_rps_tournament()
 
     @commands.Cog.listener()
     async def on_guild_remove(self, guild) -> None:
-        """PR G1/G6 — wipe rps subsystem rows for a departed guild.
+        """Wipe rps subsystem rows for a departed guild (delegator)."""
+        await on_guild_remove_rps(guild.id)
 
-        rps_pvp_pending rows clear without refund (no pre-debit).
-        rps_tournament rows trigger refunds — guild removal mid-
-        tournament is equivalent to a crash from the player's
-        perspective.
-        """
-        # rps_pvp_pending — clear, no refund.
-        try:
-            from views.rps._helpers import RPS_PVP_PENDING_SUBSYSTEM
-
-            rows = await game_state_service.list_active_for_subsystem(
-                RPS_PVP_PENDING_SUBSYSTEM,
-                guild_id=guild.id,
-            )
-            for row in rows:
-                try:
-                    await game_state_service.clear_by_id(row["id"])
-                except Exception as exc:
-                    logger.warning(
-                        "rps_pvp_pending on_guild_remove: clear id=%s failed: %s",
-                        row.get("id"),
-                        exc,
-                    )
-        except Exception as exc:
-            logger.warning(
-                "rps_pvp_pending on_guild_remove failed for guild=%d: %s",
-                guild.id,
-                exc,
-            )
-
-        # rps_tournament — refund + clear.
-        try:
-            rows = await game_state_service.list_active_for_subsystem(
-                RPS_TOURNAMENT_SUBSYSTEM,
-                guild_id=guild.id,
-            )
-            for row in rows:
-                state = row.get("state") or {}
-                bet = state.get("bet")
-                if isinstance(bet, int) and bet > 0:
-                    try:
-                        await economy_service.refund(
-                            guild_id=row["guild_id"],
-                            user_id=row["user_id"],
-                            amount=bet,
-                            reason="rps_tournament:guild_remove_refund",
-                        )
-                    except Exception as exc:
-                        logger.warning(
-                            "rps_tournament on_guild_remove refund "
-                            "failed for user=%d: %s",
-                            row.get("user_id"),
-                            exc,
-                        )
-                try:
-                    await game_state_service.clear_by_id(row["id"])
-                except Exception as exc:
-                    logger.warning(
-                        "rps_tournament on_guild_remove: clear id=%s failed: %s",
-                        row.get("id"),
-                        exc,
-                    )
-        except Exception as exc:
-            logger.warning(
-                "rps_tournament on_guild_remove failed for guild=%d: %s",
-                guild.id,
-                exc,
-            )
-
-    async def _clear_stale_tournament_flag(self) -> None:
-        await self.bot.wait_until_ready()
-        for guild in self.bot.guilds:
-            flag = await global_db.get_setting(guild.id, ACTIVE_TOURNAMENT, "")
-            if flag == "rps":
-                await global_db.set_setting(guild.id, ACTIVE_TOURNAMENT, "")
+    # ------------------------------------------------------------------
+    # Tournament registration
+    # ------------------------------------------------------------------
 
     @commands.command(name="rpsregister", aliases=["rpsreg"])
     async def rps_register(self, ctx, role: discord.Role = None, entry_fee: int = 0):
@@ -436,20 +316,13 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # 
         if len(self.players) < 2:
             await global_db.set_setting(ctx.guild.id, ACTIVE_TOURNAMENT, "")
 
-    async def add_player_to_db(self, user, guild_id: int) -> None:
-        """Ensures the player exists in the async RPS stats table.
-
-        PR R1: ``guild_id`` is now required.  rps_players' PK is
-        (user_id, guild_id) since migration 005; defaulting to 0 made
-        every guild's stats collide at the same row.
-        """
-        try:
-            await global_db.rps_ensure_player(user.id, guild_id, user.display_name)
-        except Exception as e:
-            logger.exception("Error adding RPS player to database: %s", e)
-
     async def try_register_player(self, user, guild_id: int) -> bool:
-        """Check entry fee, deduct if needed, register player. Returns success."""
+        """Check entry fee, deduct if needed, register player. Returns success.
+
+        The persistence call lives in
+        ``cogs.rps_tournament._persistence.save_tournament_entry`` — the
+        ``inspect.getsource`` test invariant moved with it.
+        """
         if user.id in self.paid_players or user in self.players:
             return False  # already registered
         if self.entry_fee > 0:
@@ -466,28 +339,20 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # 
             self.paid_players.add(user.id)
         self.players.append(user)
         self.scores[user] = 0
-        await self.add_player_to_db(user, guild_id)
+        await add_player_to_db(user, guild_id)
         # PR G6 — persist the paid-entry state so a crash before the
         # final payout in ``check_tournament_progress`` can refund this
-        # player on cog_load.  ``bet=entry_fee`` matches the G0 GC
-        # convention so the 24 h sweep is a secondary safety net.
-        try:
-            await game_state_service.save(
-                guild_id=guild_id,
-                user_id=user.id,
-                channel_id=0,  # sentinel — tournament is guild-wide, not channel-local
-                subsystem=RPS_TOURNAMENT_SUBSYSTEM,
-                state={"bet": self.entry_fee},
-                version=RPS_TOURNAMENT_VERSION,
-            )
-        except Exception as exc:
-            logger.warning(
-                "rps_tournament save failed (user=%d guild=%d): %s",
-                user.id,
-                guild_id,
-                exc,
-            )
+        # player on cog_load.
+        await save_tournament_entry(
+            guild_id=guild_id,
+            user_id=user.id,
+            entry_fee=self.entry_fee,
+        )
         return True
+
+    # ------------------------------------------------------------------
+    # Tournament start + bracket scheduling
+    # ------------------------------------------------------------------
 
     @commands.command(name="rpsstart", aliases=["rpsbegin"])
     @commands.has_permissions(administrator=True)
@@ -534,79 +399,15 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # 
 
     @commands.command(name="rpsbot")
     async def rps_bot(self, ctx, mode=None, best_of: int = None, *members_or_roles):
-        """Starts matches against the bot."""
-        if mode is None:
-            mode = self.settings["default_mode"]
-        if mode not in self.game_modes:
-            await ctx.send(
-                f"Invalid game mode. Available modes: {', '.join(self.game_modes.keys())}",
-            )
-            return
-
-        if best_of is None:
-            best_of = self.settings["default_best_of"]
-        if best_of % 2 == 0 or best_of < 1:
-            await ctx.send(
-                "Please provide an odd positive integer for the number of rounds.",
-            )
-            return
-
-        players = []
-        if members_or_roles:
-            for item in members_or_roles:
-                member = None
-                if isinstance(item, discord.Member):
-                    member = item
-                elif isinstance(item, str):
-                    # Try to get member by ID or mention
-                    member = ctx.guild.get_member_named(item)
-                elif isinstance(item, discord.Role):
-                    players.extend(item.members)
-                    continue
-                if member:
-                    players.append(member)
-        else:
-            players.append(ctx.author)
-
-        for player in players:
-            match_channel = await self.create_bot_match_channel(ctx.guild, player, ctx)
-            if match_channel is None:
-                await ctx.send(
-                    f"Failed to create match channel for {player.display_name}.",
-                )
-                continue
-
-            self.bot_matches[player] = {
-                "channel": match_channel.id,
-                "wins": 0,
-                "bot_wins": 0,
-                "best_of": best_of,
-                "mode": mode,
-            }
-            self.bot_match_channels.add(match_channel.id)
-
-            await match_channel.send(
-                f"{player.mention} vs **Bot**\n"
-                f"Game mode: {mode.capitalize()}, Best of {best_of}\n"
-                "Please enter your move.",
-            )
-
-    async def create_bot_match_channel(self, guild, player, ctx):
-        """Creates a private channel for a match against the bot."""
-        try:
-            return await create_private_channel(
-                guild,
-                f"rps-{player.display_name}-vs-bot",
-                [player],
-                "RPS Bot Matches",
-            )
-        except discord.Forbidden:
-            await ctx.send("I do not have permission to create channels.")
-            return None
-        except Exception as e:
-            logger.exception(f"Error creating bot match channel: {e}")
-            await ctx.send(f"An error occurred while creating the match channel: {e}")
-            return None
+        """Starts matches against the bot.  Delegator — see _bot_matches."""
+        await run_rps_bot_command(
+            ctx,
+            self.settings["default_mode"],
+            self.settings["default_best_of"],
+            mode,
+            best_of,
+            members_or_roles,
+        )
 
     @commands.command(name="rpsmatchup")
     @commands.has_permissions(administrator=True)
@@ -620,8 +421,7 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # 
             await ctx.send("Both players must be registered in the tournament.")
             return
 
-        # Create a match between the two players
-        match_channel = await self.create_match_channel(
+        match_channel = await create_match_channel(
             ctx.guild,
             player1,
             player2,
@@ -674,7 +474,7 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # 
         while len(round_players) >= 2:
             player1 = round_players.pop()
             player2 = round_players.pop()
-            match_channel = await self.create_match_channel(
+            match_channel = await create_match_channel(
                 ctx.guild,
                 player1,
                 player2,
@@ -717,22 +517,9 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # 
                 f"{player.display_name} advances to the next round by default.",
             )
 
-    async def create_match_channel(self, guild, player1, player2, ctx):
-        """Creates a private channel for the match."""
-        try:
-            return await create_private_channel(
-                guild,
-                f"rps-{player1.display_name}-vs-{player2.display_name}",
-                [player1, player2],
-                "RPS Tournaments",
-            )
-        except discord.Forbidden:
-            await ctx.send("I do not have permission to create channels.")
-            return None
-        except Exception as e:
-            logger.exception(f"Error creating match channel: {e}")
-            await ctx.send(f"An error occurred while creating the match channel: {e}")
-            return None
+    # ------------------------------------------------------------------
+    # Listeners
+    # ------------------------------------------------------------------
 
     @commands.Cog.listener()
     async def on_reaction_add(self, reaction, user):
@@ -765,8 +552,8 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # 
         channel = message.channel
 
         # Check for player vs bot matches
-        if channel.id in self.bot_match_channels:
-            await self.handle_bot_match_move(message)
+        if channel_is_bot_match(channel.id):
+            await handle_bot_match_move(message)
             return
 
         # Check for player vs player matches
@@ -800,61 +587,6 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # 
             # Both players have made their moves
             await self.resolve_match(player, opponent, channel)
 
-    async def handle_bot_match_move(self, message):
-        """Handles moves in player vs bot matches."""
-        player = message.author
-        match = self.bot_matches.get(player)
-        if not match:
-            return
-
-        # Check if the match is already over
-        required_wins = (match["best_of"] // 2) + 1
-        if match["wins"] >= required_wins or match["bot_wins"] >= required_wins:
-            # Match is over; inform the player and return
-            await message.channel.send("The match is already over.")
-            return
-
-        move = message.content.lower().strip()
-        move = normalize_move(move, match["mode"])
-        if move is None:
-            await message.channel.send(
-                f"{player.mention}, invalid move. Please try again.",
-            )
-            return
-
-        bot_move = random.choice(self.game_modes[match["mode"]])
-        await message.channel.send(f"Bot played: {bot_move.capitalize()}.")
-
-        winner = determine_winner(move, bot_move, match["mode"])
-        if winner == 0:
-            await message.channel.send("It's a tie!")
-            self.update_player_stats(player, "tie")
-        elif winner == 1:
-            match["wins"] += 1
-            await message.channel.send(f"{player.mention} wins this round!")
-            self.update_player_stats(player, "win")
-        else:
-            match["bot_wins"] += 1
-            await message.channel.send("Bot wins this round!")
-            self.update_player_stats(player, "loss")
-
-        # Check if someone has won the match
-        if match["wins"] >= required_wins:
-            await message.channel.send(
-                f"{player.mention} wins the match against the bot!",
-            )
-            await self.schedule_channel_deletion(message.channel)
-            del self.bot_matches[player]
-            self.bot_match_channels.discard(message.channel.id)
-            return  # Prevent further execution
-        if match["bot_wins"] >= required_wins:
-            await message.channel.send("Bot wins the match!")
-            await self.schedule_channel_deletion(message.channel)
-            del self.bot_matches[player]
-            self.bot_match_channels.discard(message.channel.id)
-            return  # Prevent further execution
-        await message.channel.send("Please enter your next move.")
-
     async def resolve_match(self, player1, player2, channel):
         """Determines the match outcome and advances the tournament."""
         match1 = self.matches[player1]
@@ -867,21 +599,21 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # 
             await channel.send("It's a tie! Please both select your moves again.")
             match1["move"] = None
             match2["move"] = None
-            self.update_player_stats(player1, "tie")
-            self.update_player_stats(player2, "tie")
+            update_player_stats(player1, "tie")
+            update_player_stats(player2, "tie")
             return
         if winner == 1:
             match1["wins"] += 1
             match2["opponent_wins"] += 1
             winning_player = player1
-            self.update_player_stats(player1, "win")
-            self.update_player_stats(player2, "loss")
+            update_player_stats(player1, "win")
+            update_player_stats(player2, "loss")
         else:
             match2["wins"] += 1
             match1["opponent_wins"] += 1
             winning_player = player2
-            self.update_player_stats(player2, "win")
-            self.update_player_stats(player1, "loss")
+            update_player_stats(player2, "win")
+            update_player_stats(player1, "loss")
 
         await channel.send(
             f"{winning_player.mention} wins this round!\n"
@@ -897,7 +629,7 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # 
             await channel.send(
                 f"{player1.mention} wins the match and advances to the next round!",
             )
-            await self.schedule_channel_deletion(channel)
+            await schedule_channel_deletion(channel)
             del self.matches[player1]
             del self.matches[player2]
             self.match_channels.pop(channel.id, None)
@@ -910,7 +642,7 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # 
             await channel.send(
                 f"{player2.mention} wins the match and advances to the next round!",
             )
-            await self.schedule_channel_deletion(channel)
+            await schedule_channel_deletion(channel)
             del self.matches[player1]
             del self.matches[player2]
             self.match_channels.pop(channel.id, None)
@@ -922,53 +654,6 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # 
             match1["move"] = None
             match2["move"] = None
             await channel.send("Next round! Please enter your move.")
-
-    def update_player_stats(self, player, result: str) -> None:
-        """Schedule an async stats update without blocking the event loop.
-
-        PR R1: derives ``guild_id`` from ``player.guild`` and passes it
-        through so ``rps_update_stat`` writes to the correct guild row.
-        Players passed in here always come from a guild context (bot
-        matches and tournament matches both originate in guild channels)
-        so ``player.guild`` is non-None.
-        """
-        guild = getattr(player, "guild", None)
-        if guild is None:
-            logger.warning(
-                "update_player_stats: player=%s has no guild context; "
-                "skipping stat update",
-                player.id,
-            )
-            return
-        tasks.spawn(
-            f"rps:stat:{player.id}",
-            self._async_update_stat(player.id, guild.id, result),
-        )
-
-    async def _async_update_stat(
-        self,
-        user_id: int,
-        guild_id: int,
-        result: str,
-    ) -> None:
-        try:
-            await global_db.rps_update_stat(user_id, guild_id, result)
-        except Exception as e:
-            logger.exception("Error updating RPS player stats: %s", e)
-
-    async def schedule_channel_deletion(self, channel):
-        """Schedules the deletion of a match channel after a delay."""
-        await asyncio.sleep(300)  # Wait for 5 minutes
-        try:
-            await channel.delete()
-        except discord.Forbidden:
-            logger.warning(
-                f"Failed to delete channel {channel.name}: insufficient permissions.",
-            )
-        except Exception as e:
-            logger.exception(
-                f"An error occurred while deleting channel {channel.name}: {e}",
-            )
 
     async def check_tournament_progress(self, guild, last_channel):
         """Checks if the tournament is over or starts a new round."""
@@ -1027,15 +712,13 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # 
                     exc,
                 )
             # Clean up any remaining match channels
-            await self.delete_all_match_channels(guild)
+            await delete_all_match_channels(guild)
         else:
             await self.start_round(last_channel, self.settings["default_best_of"])
 
-    async def delete_all_match_channels(self, guild):
-        """Deletes all RPS tournament match channels and their category."""
-        category = discord.utils.get(guild.categories, name="RPS Tournaments")
-        if category:
-            await cleanup_category(category)
+    # ------------------------------------------------------------------
+    # Error handlers + help/settings + quickplay
+    # ------------------------------------------------------------------
 
     @rps_register.error
     async def rps_register_error(self, ctx, error):
@@ -1096,31 +779,6 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # 
         self.settings[setting] = value
         await ctx.send(f"Setting `{setting}` updated to `{value}`.")
 
-    async def _cleanup_orphaned_channels(self):
-        """On startup, clean up any leftover RPS tournament/bot-match channels."""
-        await self.bot.wait_until_ready()
-        for guild in self.bot.guilds:
-            for cat_name in ("RPS Tournaments", "RPS Bot Matches"):
-                cat = discord.utils.get(guild.categories, name=cat_name)
-                if not cat or not cat.channels:
-                    continue
-                for ch in cat.channels:
-                    try:
-                        await ch.send(
-                            "⚠️ The bot restarted and this match was interrupted. "
-                            "This channel will be deleted in 5 minutes.",
-                        )
-                    except Exception:
-                        pass
-                await asyncio.sleep(300)
-                await cleanup_category(cat)
-
-    def cog_unload(self):
-        """Cancel reminder + all spawned RPS tasks so a reload doesn't leak them."""
-        if self.reminder_task and not self.reminder_task.done():
-            self.reminder_task.cancel()
-        tasks.cancel_by_prefix("rps:")
-
     # ------------------------------------------------------------------
     # Quick-play RPS with coins (button-based, single-player vs bot)
     # ------------------------------------------------------------------
@@ -1133,49 +791,7 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # 
         bet: int = 0,
     ):
         """Quick RPS.  !rps [bet]  or  !rps @player [bet]"""
-        if bet < 0:
-            await ctx.send("Bet must be 0 or a positive number.", delete_after=5)
-            return
-
-        # PvP challenge
-        if target and target != ctx.author:
-            if target.bot:
-                await ctx.send("You can't challenge a bot to PvP.", delete_after=5)
-                return
-            if bet > 0:
-                bal = await global_db.get_coins(ctx.author.id, ctx.guild.id)
-                if bet > bal:
-                    await ctx.send(f"❌ You only have **{bal}** 🪙.", delete_after=8)
-                    return
-            bet_str = f"**{bet}** 🪙" if bet else "free play"
-            view = _RpsPvpChallengeView(ctx.author, target, ctx.guild.id, bet)  # type: ignore[arg-type]
-            embed = discord.Embed(
-                title="✂️ RPS Challenge!",
-                description=(
-                    f"{ctx.author.mention} challenges {target.mention} to Rock-Paper-Scissors "
-                    f"({bet_str}).\n{target.mention}, do you accept?"
-                ),
-                color=GAME_COLOR,
-            )
-            msg = await ctx.send(embed=embed, view=view)
-            view.message = msg
-            return
-
-        # vs bot
-        if bet > 0:
-            bal = await global_db.get_coins(ctx.author.id, ctx.guild.id)
-            if bet > bal:
-                await ctx.send(f"❌ You only have **{bal}** 🪙.", delete_after=10)
-                return
-        view = _RpsView(ctx.author, ctx.guild.id, bet)  # type: ignore[assignment, arg-type]
-        bet_str = f"**{bet}** 🪙" if bet else f"Free play (win = +{_FREE_WIN} 🪙)"
-        embed = discord.Embed(
-            title="✂️ Rock · Paper · Scissors",
-            description=f"Bet: {bet_str}\nChoose your move!",
-            color=GAME_COLOR,
-        )
-        msg = await ctx.send(embed=embed, view=view)
-        view.message = msg
+        await run_quickrps_command(ctx, target, bet)
 
 
 async def setup(bot):

--- a/tests/unit/cogs/test_rps_tournament_persistence.py
+++ b/tests/unit/cogs/test_rps_tournament_persistence.py
@@ -44,17 +44,21 @@ def test_rps_tournament_subsystem_constants_exist():
 
 
 def test_try_register_player_wires_through_save():
-    """Source-level check that ``try_register_player`` calls
-    ``game_state_service.save`` with the documented payload shape.
-    Direct invocation requires a fully-initialised cog + economy
-    service patching that exceeds unit-test scope; source-grep here
-    matches the same pattern PR G1 used for the pvp_challenge wiring.
+    """Source-level check that the rps_tournament persistence helper
+    calls ``game_state_service.save`` with the documented payload shape.
+
+    Pre-S4.6: the literal strings (``game_state_service.save``,
+    ``RPS_TOURNAMENT_SUBSYSTEM``, ``RPS_TOURNAMENT_VERSION``, ``"bet":``)
+    lived inside ``RPSTournamentCog.try_register_player``.  S4.6 moved
+    the save call into ``cogs.rps_tournament._persistence.save_tournament_entry``
+    so the invariant moves with it — same intent, same literal-string
+    check, new location.
     """
     import inspect
 
-    from cogs import rps_tournament_cog
+    from cogs.rps_tournament._persistence import save_tournament_entry
 
-    src = inspect.getsource(rps_tournament_cog.RPSTournamentCog.try_register_player)
+    src = inspect.getsource(save_tournament_entry)
     assert "game_state_service.save" in src
     assert "RPS_TOURNAMENT_SUBSYSTEM" in src
     assert "RPS_TOURNAMENT_VERSION" in src

--- a/tests/unit/invariants/test_cog_size.py
+++ b/tests/unit/invariants/test_cog_size.py
@@ -1,0 +1,116 @@
+"""S4.6 — soft cog-size invariant.
+
+After Phase A's decomposition work (PRs S4.2-followup, S4.3, S4.4
+rules, S4.4.5 + stabilization, S4.5, S4.6 rps), every cog file under
+``disbot/cogs/*_cog.py`` is under 800 LOC.  This test pins that floor
+so a future regression — re-inlining a large surface back into a cog
+— surfaces in CI rather than gradually re-creating the god-cog
+problem the decomposition resolved.
+
+Thresholds match the audit's §3.5 proposal:
+
+  WARN_LOC = 500     — emits a ``UserWarning`` (visible in pytest -W)
+  FAIL_LOC = 800     — hard ``pytest.fail``
+
+The warning tier is intentional: several cogs in the codebase (role,
+counting, help, chain) sit between 500 and 700 LOC and are accepted
+in their current shape per the audit (§3.5).  Pushing them under 500
+would force premature extraction; failing them would block CI without
+architectural cause.  The warning surfaces the trend without blocking.
+
+Per-cog exclusions
+------------------
+
+There are intentionally none.  Every cog at the time of S4.6 landing
+fits under 800.  If a new cog legitimately needs to exceed the ceiling
+(e.g. a future game subsystem with irreducible state), the right move
+is to land its decomposition stage BEFORE growing past the ceiling,
+not to add it to an allow-list here.
+"""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_COG_DIR = _REPO_ROOT / "disbot" / "cogs"
+
+WARN_LOC = 500
+FAIL_LOC = 800
+
+
+def _cog_files() -> list[Path]:
+    """All cog files at the top of ``disbot/cogs/`` — excludes subpackages.
+
+    The convention from F-3 is that ``cogs/<sub>_cog.py`` is the Discord-
+    facing surface and ``cogs/<sub>/`` holds the helpers.  Helper modules
+    are not subject to the 800-LOC ceiling — they're called from the cog,
+    not registered with discord.py — so this test only looks at the
+    cog files themselves.
+    """
+    return sorted(_COG_DIR.glob("*_cog.py"))
+
+
+def _line_count(path: Path) -> int:
+    """Lines-of-code for *path*.  Matches what ``wc -l`` reports."""
+    with path.open(encoding="utf-8") as f:
+        return sum(1 for _ in f)
+
+
+@pytest.mark.parametrize("cog_path", _cog_files(), ids=lambda p: p.name)
+def test_cog_size_under_fail_threshold(cog_path: Path):
+    """Hard ceiling: cog files must stay under 800 LOC.
+
+    Re-inlining 100+ LOC of view/persistence/helper code back into a
+    cog after Phase A's decomposition is an architectural regression.
+    The fix is to follow the F-3 convention and extract the new
+    surface into the cog's helpers subpackage (or its ``views/<sub>/``
+    sibling) rather than growing the cog file.
+    """
+    loc = _line_count(cog_path)
+    if loc >= FAIL_LOC:
+        pytest.fail(
+            f"{cog_path.name} is {loc} LOC — over the {FAIL_LOC}-LOC fail "
+            f"threshold set by S4.6.  Decompose the cog before adding to "
+            f"it: move view code to ``views/<sub>/``, persistence helpers "
+            f"to ``cogs/<sub>/_persistence.py``, etc.  See docs/architecture.md "
+            f"§\"Subsystem decomposition\" and the Phase A PRs for the "
+            f"established pattern.",
+        )
+
+
+@pytest.mark.parametrize("cog_path", _cog_files(), ids=lambda p: p.name)
+def test_cog_size_warn_threshold(cog_path: Path):
+    """Soft tier: cogs ≥500 LOC emit a UserWarning (informational).
+
+    Not a failure — several cogs in the audit's §3.5 inventory sit
+    between 500 and 700 LOC by design (role, counting, help, chain).
+    This warning surfaces drift over time so reviewers see when a
+    formerly-clean cog crosses into warn-tier.
+    """
+    loc = _line_count(cog_path)
+    if loc >= WARN_LOC:
+        warnings.warn(
+            f"{cog_path.name} is {loc} LOC — in the {WARN_LOC}..{FAIL_LOC} "
+            f"warn-tier.  Not a failure, but watch for further growth.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+
+def test_at_least_one_cog_exists():
+    """Sanity: glob finds cog files (catches a broken CWD or path).
+
+    If this fails, ``_cog_files()`` returned an empty list — likely
+    because someone changed the cog directory layout.  The
+    per-cog parametrized tests would silently produce zero cases
+    without this guard.
+    """
+    cogs = _cog_files()
+    assert cogs, (
+        f"No cog files found under {_COG_DIR}.  Path resolution broken "
+        f"or directory layout changed."
+    )


### PR DESCRIPTION
## Summary

**Capstone of Phase A.** Brings the last remaining over-800-LOC cog (`rps_tournament_cog.py`, 1182 LOC) under the size ceiling AND lands the structural CI gate (`tests/unit/invariants/test_cog_size.py`) that the entire phase was building toward.

Two changes in one PR because the gate cannot land before the rps cog is ready, and there's no value in landing rps just under the wire without the gate to protect it from regression.

## Part 1 — RPS tournament decomposition

Cog drops **1182 → 798 LOC** (33% reduction, under the 800 ceiling). Pattern matches the F-3 + helpers-package convention used by xp / moderation / diagnostic / blackjack.

### New layout

```
cogs/rps_tournament_cog.py          — cog + tournament flow methods
cogs/rps_tournament/__init__.py     — package docstring (updated)
cogs/rps_tournament/rules.py        — pure rules (S4.4, unchanged)
cogs/rps_tournament/_persistence.py — save_tournament_entry, recover_*,
                                       on_guild_remove_rps,
                                       RPS_TOURNAMENT_SUBSYSTEM/VERSION
cogs/rps_tournament/_helpers.py     — channel/stat/lifecycle helpers
cogs/rps_tournament/_bot_matches.py — module-level state + bot-match
                                       command body + handler
cogs/rps_tournament/_quickplay.py   — run_quickrps_command (!rps body)
```

### Behavior preserved

- Every command works unchanged (`!rpsregister`, `!rpsstart`, `!rpsbot`, `!rpsmatchup`, `!rpshelp`, `!rpssettings`, `!rps`)
- Tournament flow operates on the same cog-instance state (`self.players`, `self.scores`, `self.matches`, `self.current_round`, `self.match_channels`)
- Bot-match state moved to module level in `_bot_matches.py`; **reload semantics preserved** — cog's `__init__` and `cog_unload` call `_reset_bot_match_state()` so a reload still wipes bot-match state exactly as before
- Recovery flows (`_recover_rps_pvp_pending`, `_recover_rps_tournament`, `on_guild_remove`) preserved as thin delegators on the cog so `cog._recover_*()` test calls keep working
- `RPS_TOURNAMENT_SUBSYSTEM` / `RPS_TOURNAMENT_VERSION` re-exported via cog so existing `from cogs.rps_tournament_cog import ...` paths resolve
- View classes from `views/rps/` remain re-exported by cog (PR D4)

### Test changes

**No `mock.patch` path updates required.** RPS persistence tests use `patch("services.game_state_service.X")` — that targets the attribute on the services module, which is the SAME object whether imported into the cog or into `_persistence` (Python import cache). The patch propagates correctly.

**One test invariant migrated:** `inspect.getsource(RPSTournamentCog.try_register_player)` moved to inspect `save_tournament_entry` — same intent, same literal-string check (`game_state_service.save`, `RPS_TOURNAMENT_SUBSYSTEM`, `RPS_TOURNAMENT_VERSION`, `"bet":`), new location.

## Part 2 — S4.6 soft cog-size invariant

Two-tier check parametrized across every `disbot/cogs/*_cog.py`:

| Threshold | Action |
|---|---|
| ≥ 500 LOC | `UserWarning` (informational, visible in `pytest -W`) |
| ≥ 800 LOC | hard `pytest.fail` |

Helper modules inside `cogs/<sub>/` packages are intentionally exempt — they're called from the cog, not registered with discord.py, and the F-3 convention places them outside the size constraint.

### Post-merge scoreboard

| Cog | LOC | Tier |
|---|---|---|
| `rps_tournament_cog.py` | 798 | ⚠ warn (acceptable per §3.5) |
| `counting_cog.py` | 654 | ⚠ warn (acceptable) |
| `blackjack_cog.py` | 650 | ⚠ warn |
| `role_cog.py` | 620 | ⚠ warn (acceptable) |
| `diagnostic_cog.py` | 544 | ⚠ warn |
| `help_cog.py` | 506 | ⚠ warn (acceptable) |
| `chain_cog.py` | 504 | ⚠ warn (acceptable) |
| `channel_cog.py` | 474 | ✓ |
| ...all others | < 500 | ✓ |

**All 20 cog files under 800 LOC. No exclusions.** If a future cog needs to grow past the ceiling, the right move is to land its decomposition stage BEFORE growing — not to allow-list it here.

## Validation

| Gate | Result |
|---|---|
| `pytest tests/unit/` (878 tests, +41 new) | all pass |
| `test_cog_size.py` (41 tests, 8 informational warnings) | all pass |
| `test_rps_tournament_persistence.py` (5 tests) | pass |
| `test_rps_pvp_pending_persistence.py` (6 tests) | pass |
| Identity contract STRICT mode | green |
| `INV-A` through `INV-N` | green |
| `black` / `isort` / `ruff` / `mypy` (whole tree, 182 source files) | clean |

## Phase A status: ✅ COMPLETE

All Phase A roadmap items merged after this PR:

| Stage | PR | What |
|---|---|---|
| S4.2-followup | #52 | `views/xp/` extraction |
| S4.3 | #53 | `moderation_cog` decomp + RPS rules |
| S4.4.5 | #54 | `views/diagnostic/` extraction |
| S4.4.5 stabilization | #55 | Diagnostic hub canonical panel architecture |
| S4.5 | #56 | Blackjack decomposition |
| **S4.6** | **this** | **RPS + size invariant gate** |

## Intentionally deferred from this PR

- **`tournament_lock_service` + `tournament_registration_service`** (audit §6.5 / §6.2(a)) — cross-subsystem services with two consumers (rps + blackjack) that would deduplicate the `ACTIVE_TOURNAMENT` flag + entry-fee registration patterns. Defer to a focused stage with both consumers in scope.
- **`services/blackjack_engine.py` extension** (audit §3.4) — `GameState` / `PvPState` / `TournamentRoundState` dataclass extraction is its own design exercise, not a relocation.

## Next phases (per audit roadmap §11)

- **Phase B** — `tests/integration/` directory + mypy cleanup (S5.3 + mypy cleanup)
- **Phase C** — `views/paginated.py PaginatedView` + `utils/cooldown_feedback.py` (audit §5.2 items 4-5)
- **Phase D** — `SUBSYSTEMS` metadata extensions + `IntentService` + `ProvisioningService` (audit §4.2, §6.3, §6.4)
- **Phase E** — Dynamic onboarding (depends on Phase D)
- **Phase F** — Governance policy composition

## Test plan

- [ ] Pull and start the bot locally against a test guild
- [ ] **Quick-play:** `!rps`, `!rps rock`, `!rps paper`, `!rps scissors` — confirm solo game works
- [ ] **Quick-play PvP:** `!rps @testuser 50` — accept/decline both paths, confirm bet swap
- [ ] **Bot match:** `!rpsbot classic 3` — confirm private channel created, play a full best-of-3
- [ ] **Tournament registration:** `!rpsregister @testrole 100` — confirm reaction-role registration with entry fee
- [ ] **Tournament reaction join:** react ✅ on the registration message — confirm player count increments
- [ ] **Tournament button join:** click "Join Tournament" — confirm via the persistent view
- [ ] **Tournament start:** `!rpsstart classic 3` — confirm bracket starts, match channels created
- [ ] **Tournament match play:** play through to a winner — confirm pot payout
- [ ] **Recovery flow:** kill bot mid-tournament, restart — confirm refund hits `economy_audit_log` with `rps_tournament:restart_refund`
- [ ] **No regression on `!help → Rock-Paper-Scissors`:** unchanged informational embed
- [ ] **No regression on bot lifecycle:** cog_unload + reload still works

https://claude.ai/code/session_01NgPyBFU77jy5jY55ABNwgn

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgPyBFU77jy5jY55ABNwgn)_