### PR TITLE
Refactor XpConfigView to inherit from BaseView

### DIFF
--- a/disbot/cogs/diagnostic/_helpers.py
+++ b/disbot/cogs/diagnostic/_helpers.py
@@ -26,9 +26,6 @@ import discord
 from discord.ext import commands
 
 from utils import db
-from utils.settings_keys import (  # noqa: F401 — kept for potential future use
-    WARN_THRESHOLD,
-)
 
 # ---------------------------------------------------------------------------
 # Data directories (mirror the cog's pre-stabilization layout exactly)

--- a/disbot/views/base.py
+++ b/disbot/views/base.py
@@ -7,6 +7,18 @@ from discord.ext import commands
 
 logger = logging.getLogger("bot.views")
 
+# Canonical interaction lifecycle doctrine:
+#
+# - General interactive panels should inherit BaseView.
+# - Ephemeral hub/navigation panels should inherit HubView.
+# - Persistent cross-restart views should inherit PersistentView
+#   (defined in core/runtime/persistent_views.py).
+# - Game-state views may extend discord.ui.View directly when
+#   specialized timeout cleanup, state coupling, or gameplay
+#   lifecycle ownership is required.
+#
+# Divergence from these patterns should be intentional and documented.
+
 
 async def send_panel(
     ctx: commands.Context,

--- a/disbot/views/xp/config_panel.py
+++ b/disbot/views/xp/config_panel.py
@@ -16,13 +16,13 @@ from core.runtime.interaction_helpers import safe_edit
 from utils import db
 from utils.settings_keys import XP_ANNOUNCE_CHANNEL
 from utils.ui_constants import UTILITY_COLOR
+from views.base import BaseView
 
 
-class XpConfigView(discord.ui.View):
+class XpConfigView(BaseView):
     def __init__(self, ctx: commands.Context):
-        super().__init__(timeout=300)
+        super().__init__(ctx.author, timeout=300)
         self.ctx = ctx
-        self.message: discord.Message | None = None
 
     async def build_embed(self) -> discord.Embed:
         gid = self.ctx.guild.id
@@ -36,17 +36,6 @@ class XpConfigView(discord.ui.View):
         embed.add_field(name="Level-up channel", value=channel_str, inline=True)
         embed.set_footer(text="Click a button below to change a setting.")
         return embed
-
-    async def interaction_check(self, interaction: discord.Interaction) -> bool:
-        if interaction.user != self.ctx.author:
-            await interaction.response.send_message(
-                "This panel isn't for you.",
-                ephemeral=True,
-            )
-            return False
-        return True
-
-    _run_checks = interaction_check
 
     async def _refresh(self, interaction: discord.Interaction):  # type: ignore[override]
         await safe_edit(interaction, embed=await self.build_embed(), view=self)
@@ -80,11 +69,3 @@ class XpConfigView(discord.ui.View):
         from views.xp.modals import _XpChannelModal
 
         await interaction.response.send_modal(_XpChannelModal(self))
-
-    async def on_timeout(self):
-        for item in self.children:
-            item.disabled = True  # type: ignore[attr-defined]
-        try:
-            await self.message.edit(view=self)
-        except Exception:
-            pass


### PR DESCRIPTION
## Summary
Refactored `XpConfigView` to inherit from `BaseView` instead of directly from `discord.ui.View`, eliminating duplicate interaction permission checking and timeout handling logic.

## Key Changes
- **XpConfigView inheritance**: Changed from `discord.ui.View` to `BaseView` to leverage shared view functionality
- **Removed duplicate code**: Eliminated `interaction_check()` method and `_run_checks` assignment, as `BaseView` handles user permission validation
- **Removed timeout handler**: Deleted `on_timeout()` method since `BaseView` provides this functionality
- **Simplified initialization**: Updated `super().__init__()` call to pass `ctx.author` to `BaseView` for automatic permission checking
- **Removed instance variable**: Deleted `self.message` attribute as it's no longer needed with the base class implementation
- **Documentation**: Added canonical interaction lifecycle doctrine to `views/base.py` documenting the proper inheritance patterns for different view types
- **Cleanup**: Removed unused import `WARN_THRESHOLD` from `cogs/diagnostic/_helpers.py`

## Implementation Details
The refactoring consolidates common view patterns into the `BaseView` base class:
- User permission validation is now handled automatically by `BaseView.interaction_check()`
- Timeout cleanup (disabling buttons and updating the message) is managed by `BaseView.on_timeout()`
- The view now requires passing the authorized user (`ctx.author`) during initialization for proper permission enforcement

https://claude.ai/code/session_01FuuCnXTg7FWygNZN5T2DKB