### PR TITLE
Phase D: unified guild-resource resolver

### DIFF
--- a/disbot/cogs/admin_cog.py
+++ b/disbot/cogs/admin_cog.py
@@ -9,6 +9,7 @@ import sys
 import discord
 from discord.ext import commands
 
+from core.runtime import resources
 from core.runtime.interaction_helpers import help_ctx_shim, safe_defer
 from utils.ui_constants import ADMIN_COLOR, INFO_COLOR, SUCCESS_COLOR
 from views.base import HubView, send_panel
@@ -210,7 +211,7 @@ class AdminCog(commands.Cog):
     @commands.Cog.listener()
     async def on_ready(self):
         for guild in self.bot.guilds:
-            channel = discord.utils.get(guild.text_channels, name="bot_spam")
+            channel = resources.resolve_channel(guild, name="bot_spam")
             if channel and channel.permissions_for(guild.me).send_messages:
                 try:
                     await channel.send(

--- a/disbot/cogs/blackjack_cog.py
+++ b/disbot/cogs/blackjack_cog.py
@@ -64,7 +64,7 @@ from cogs.blackjack._state import (  # noqa: F401 — re-exported
     _tournaments,
     _TournPlayerState,
 )
-from core.runtime import tasks
+from core.runtime import resources, tasks
 from core.runtime.component_registry import stats_block
 from services import economy_service, game_state_service
 from services.blackjack_engine import is_blackjack as _is_blackjack
@@ -367,7 +367,11 @@ class BlackjackCog(commands.Cog):
             flag = await db.get_setting(guild.id, ACTIVE_TOURNAMENT, "")
             if flag == "blackjack":
                 await db.set_setting(guild.id, ACTIVE_TOURNAMENT, "")
-            cat = discord.utils.get(guild.categories, name="BJ Tournament")
+            cat = resources.resolve_channel(
+                guild,
+                name="BJ Tournament",
+                kind="category",
+            )
             if not cat or not cat.channels:
                 continue
             for ch in cat.channels:
@@ -399,8 +403,10 @@ class BlackjackCog(commands.Cog):
             return
         uid = payload.user_id
         guild = self.bot.get_guild(payload.guild_id)
-        if guild and guild.get_member(uid) and guild.get_member(uid).bot:
-            return
+        if guild:
+            member = resources.resolve_member(guild, uid)
+            if member and member.bot:
+                return
         ok, _ = await tourn.try_join(uid)
         if ok:
             await _update_tourn_embed(tourn)
@@ -602,7 +608,7 @@ async def _launch_tournament(
 
     # Create private channels via shared utility
     for uid in tourn.players:
-        member = guild.get_member(uid)
+        member = resources.resolve_member(guild, uid)
         if not member:
             tourn.results[uid] = 0
             continue

--- a/disbot/cogs/chain_cog.py
+++ b/disbot/cogs/chain_cog.py
@@ -7,6 +7,7 @@ import discord
 from discord.ext import commands
 from discord.ext.commands import MissingPermissions, has_permissions
 
+from core.runtime import resources
 from core.runtime.interaction_helpers import help_ctx_shim
 from utils import db
 from views.base import HubView, send_panel
@@ -322,10 +323,16 @@ def _resolve_channel(
     if not raw:
         return interaction.channel  # type: ignore[return-value]
     stripped = raw.strip("<#>")
-    try:
-        return interaction.guild.get_channel(int(stripped))  # type: ignore[return-value]
-    except ValueError:
-        return discord.utils.get(interaction.guild.text_channels, name=raw)
+    if stripped.isdigit():
+        return resources.resolve_channel(  # type: ignore[return-value]
+            interaction.guild,
+            channel_id=stripped,
+        )
+    return resources.resolve_channel(  # type: ignore[return-value]
+        interaction.guild,
+        name=raw,
+        kind="text",
+    )
 
 
 class _CreateChainModal(discord.ui.Modal, title="Create Chain"):  # type: ignore[call-arg]

--- a/disbot/cogs/channel_cog.py
+++ b/disbot/cogs/channel_cog.py
@@ -19,6 +19,7 @@ import logging
 import discord
 from discord.ext import commands
 
+from core.runtime import resources
 from core.runtime.interaction_helpers import help_ctx_shim
 from utils.channels import get_or_create_category, safe_channel_name
 from utils.ui_constants import INFO_COLOR, WARNING_COLOR
@@ -74,20 +75,20 @@ class ChannelCog(commands.Cog):
         if query.startswith("<#") and query.endswith(">"):
             query = query[2:-1]
         if query.isdigit():
-            ch = guild.get_channel(int(query))
+            ch = resources.resolve_channel(guild, channel_id=query)
             if ch:
                 return ch
-        return discord.utils.get(guild.channels, name=query)
+        return resources.resolve_channel(guild, name=query, kind="any")
 
     def _resolve_category(self, guild: discord.Guild, query: str):
         """Find a category by name, mention, or numeric ID."""
         if query.startswith("<#") and query.endswith(">"):
             query = query[2:-1]
         if query.isdigit():
-            ch = guild.get_channel(int(query))
+            ch = resources.resolve_channel(guild, channel_id=query)
             if isinstance(ch, discord.CategoryChannel):
                 return ch
-        return discord.utils.get(guild.categories, name=query)
+        return resources.resolve_channel(guild, name=query, kind="category")
 
     def get_category_or_channel(self, guild, query):
         return self._resolve_category(guild, query) or self._resolve_channel(

--- a/disbot/cogs/counting_cog.py
+++ b/disbot/cogs/counting_cog.py
@@ -26,7 +26,7 @@ import discord
 from discord.ext import commands
 
 from cogs.counting import handler
-from core.runtime import scope_locks, tasks
+from core.runtime import resources, scope_locks, tasks
 from core.runtime.interaction_helpers import help_ctx_shim
 from utils import db
 from views.base import send_panel
@@ -202,7 +202,7 @@ class CountingCog(commands.Cog):
         async with self.lock:
             timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d%H%M%S")
             channel_name = f"{mode}-counting-{timestamp}"
-            existing_channel = discord.utils.get(guild.text_channels, name=channel_name)
+            existing_channel = resources.resolve_channel(guild, name=channel_name)
             if existing_channel:
                 await ctx.send(
                     f"A channel named '{channel_name}' already exists.",

--- a/disbot/cogs/economy_cog.py
+++ b/disbot/cogs/economy_cog.py
@@ -31,7 +31,7 @@ from cogs.economy._helpers import (
     _pick_daily,
     _shop_embed,
 )
-from core.runtime import panel_manager
+from core.runtime import panel_manager, resources
 from services import economy_service
 from utils import db
 from utils.cooldowns import check_cooldown, format_remaining
@@ -86,22 +86,20 @@ class EconomyCog(commands.Cog):
 
     async def _ensure_log_channel(self, guild: discord.Guild) -> None:
         """Create #economy-log for *guild* if it doesn't already exist."""
-        cid = await db.get_setting(guild.id, ECONOMY_LOG_CHANNEL, "")
-        if cid:
-            ch = guild.get_channel(int(cid))
-            if ch:
-                return
+        if await resources.resolve_settings_channel(guild, ECONOMY_LOG_CHANNEL):
+            return
 
-        existing = discord.utils.get(guild.text_channels, name="economy-log")
+        existing = resources.resolve_channel(guild, name="economy-log")
         if existing:
             await db.set_setting(guild.id, ECONOMY_LOG_CHANNEL, str(existing.id))
             return
 
         try:
-            cat = discord.utils.get(guild.categories, name="Bot") or discord.utils.get(
-                guild.categories,
-                name="General",
-            )
+            cat = resources.resolve_channel(
+                guild,
+                name="Bot",
+                kind="category",
+            ) or resources.resolve_channel(guild, name="General", kind="category")
             overwrites = {
                 guild.default_role: discord.PermissionOverwrite(
                     read_messages=True,

--- a/disbot/cogs/leaderboard_cog.py
+++ b/disbot/cogs/leaderboard_cog.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import discord
 from discord.ext import commands
 
+from core.runtime import resources
 from core.runtime.interaction_helpers import safe_defer
 from utils import db
 from utils.ui_constants import ECONOMY_COLOR, UTILITY_COLOR
@@ -48,8 +49,7 @@ async def _build_embed(
         )
         lines = []
         for i, row in enumerate(rows):
-            m = guild.get_member(row["user_id"])
-            name = m.display_name if m else f"<@{row['user_id']}>"
+            name = resources.member_display(guild, row["user_id"])
             icon = MEDALS[i] if i < 3 else f"`#{i+1}`"
             lines.append(f"{icon} **{name}** — Level {row['level']} ({row['xp']} XP)")
         embed.description = "\n".join(lines) or "No data yet!"
@@ -61,8 +61,7 @@ async def _build_embed(
         )
         lines = []
         for i, row in enumerate(rows):
-            m = guild.get_member(row["user_id"])
-            name = m.display_name if m else f"<@{row['user_id']}>"
+            name = resources.member_display(guild, row["user_id"])
             icon = MEDALS[i] if i < 3 else f"`#{i+1}`"
             lines.append(f"{icon} **{name}** — {row['coins']} 🪙")
         embed.description = "\n".join(lines) or "No data yet!"
@@ -71,8 +70,7 @@ async def _build_embed(
         rows = await db.get_all_mining_totals(guild.id)
         lines = []
         for i, (user_id, total) in enumerate(rows):
-            m = guild.get_member(int(user_id)) if user_id.isdigit() else None
-            name = m.display_name if m else f"<@{user_id}>"
+            name = resources.member_display(guild, user_id)
             icon = MEDALS[i] if i < 3 else f"`#{i+1}`"
             lines.append(f"{icon} **{name}** — {total} items")
         embed.description = "\n".join(lines) or "No data yet!"
@@ -81,8 +79,7 @@ async def _build_embed(
         rows = await db.get_deathmatch_leaderboard()
         lines = []
         for i, row in enumerate(rows):
-            m = guild.get_member(row["user_id"])
-            name = m.display_name if m else f"<@{row['user_id']}>"
+            name = resources.member_display(guild, row["user_id"])
             icon = MEDALS[i] if i < 3 else f"`#{i+1}`"
             lines.append(f"{icon} **{name}** — {row['wins']}W / {row['losses']}L")
         embed.description = "\n".join(lines) or "No data yet!"
@@ -107,8 +104,7 @@ async def _build_embed(
         sorted_totals = sorted(totals.items(), key=lambda x: x[1], reverse=True)[:10]
         lines = []
         for i, (uid, cnt) in enumerate(sorted_totals):
-            m = guild.get_member(int(uid)) if uid.isdigit() else None
-            name = m.display_name if m else f"<@{uid}>"
+            name = resources.member_display(guild, uid)
             icon = MEDALS[i] if i < 3 else f"`#{i+1}`"
             lines.append(f"{icon} **{name}** — {cnt} counts")
         embed.description = "\n".join(lines) or "No counting data yet!"

--- a/disbot/cogs/moderation/_helpers.py
+++ b/disbot/cogs/moderation/_helpers.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import discord
 from discord import Member
 
+from core.runtime import resources
 from core.runtime.component_registry import stats_block
 from utils.ui_constants import MOD_COLOR
 
@@ -51,7 +52,7 @@ def _can_act_on_interaction(
     """Return an error string if the actor cannot moderate *member*, else None."""
     if member == interaction.guild.owner:
         return "❌ You cannot perform this action on the server owner."
-    actor = interaction.guild.get_member(interaction.user.id)
+    actor = resources.resolve_member(interaction.guild, interaction.user.id)
     if actor and member.top_role >= actor.top_role:
         return (
             "❌ You cannot perform this action on someone with an equal or higher role."

--- a/disbot/cogs/proof_channel_cog.py
+++ b/disbot/cogs/proof_channel_cog.py
@@ -6,7 +6,7 @@ import logging
 import discord
 from discord.ext import commands
 
-from core.runtime import tasks
+from core.runtime import resources, tasks
 from core.runtime.interaction_helpers import help_ctx_shim
 from utils.helpers import _parse_member
 from utils.ui_constants import ECONOMY_COLOR, SUCCESS_COLOR
@@ -27,7 +27,7 @@ class ProofChannelCog(commands.Cog):
         self._timed_tasks.clear()
 
     def get_proof_channel(self, guild: discord.Guild) -> discord.TextChannel | None:
-        return discord.utils.get(guild.text_channels, name="proof")
+        return resources.resolve_channel(guild, name="proof")  # type: ignore[return-value]
 
     async def _lock_for_winner(
         self,

--- a/disbot/cogs/role_cog.py
+++ b/disbot/cogs/role_cog.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 import discord
 from discord.ext import commands, tasks
 
-from core.runtime import panel_manager
+from core.runtime import panel_manager, resources
 from core.runtime.component_registry import stats_block
 from core.runtime.persistent_views import PersistentView, register
 from utils import db
@@ -481,7 +481,7 @@ class RoleCog(commands.Cog):
         guild = self.bot.get_guild(payload.guild_id)
         if not guild:
             return
-        member = guild.get_member(payload.user_id)
+        member = resources.resolve_member(guild, payload.user_id)
         if not member or member.bot:
             return
         role_id = await db.get_reaction_role(
@@ -490,7 +490,7 @@ class RoleCog(commands.Cog):
             str(payload.emoji),
         )
         if role_id:
-            role = guild.get_role(role_id)
+            role = resources.resolve_role(guild, role_id=role_id)
             if role:
                 try:
                     await member.add_roles(role, reason="Reaction role")
@@ -505,7 +505,7 @@ class RoleCog(commands.Cog):
         guild = self.bot.get_guild(payload.guild_id)
         if not guild:
             return
-        member = guild.get_member(payload.user_id)
+        member = resources.resolve_member(guild, payload.user_id)
         if not member or member.bot:
             return
         role_id = await db.get_reaction_role(
@@ -514,7 +514,7 @@ class RoleCog(commands.Cog):
             str(payload.emoji),
         )
         if role_id:
-            role = guild.get_role(role_id)
+            role = resources.resolve_role(guild, role_id=role_id)
             if role:
                 try:
                     await member.remove_roles(role, reason="Reaction role removed")
@@ -578,7 +578,7 @@ class RoleCog(commands.Cog):
             return
         lines = []
         for r in rows:
-            role = ctx.guild.get_role(r["role_id"])
+            role = resources.resolve_role(ctx.guild, role_id=r["role_id"])
             role_str = role.mention if role else f"<deleted role {r['role_id']}>"
             lines.append(f"Message `{r['message_id']}` · {r['emoji']} → {role_str}")
         embed = discord.Embed(

--- a/disbot/cogs/rps_tournament/_helpers.py
+++ b/disbot/cogs/rps_tournament/_helpers.py
@@ -24,7 +24,7 @@ import logging
 import discord
 from discord.ext import commands
 
-from core.runtime import tasks
+from core.runtime import resources, tasks
 from utils import db as global_db
 from utils.channels import cleanup_category, create_private_channel
 from utils.settings_keys import ACTIVE_TOURNAMENT
@@ -138,9 +138,13 @@ async def schedule_channel_deletion(channel) -> None:
 
 async def delete_all_match_channels(guild) -> None:
     """Delete all RPS tournament match channels and the parent category."""
-    category = discord.utils.get(guild.categories, name="RPS Tournaments")
+    category = resources.resolve_channel(
+        guild,
+        name="RPS Tournaments",
+        kind="category",
+    )
     if category:
-        await cleanup_category(category)
+        await cleanup_category(category)  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------
@@ -170,7 +174,7 @@ async def cleanup_orphaned_channels(bot: commands.Bot) -> None:
     await bot.wait_until_ready()
     for guild in bot.guilds:
         for cat_name in ("RPS Tournaments", "RPS Bot Matches"):
-            cat = discord.utils.get(guild.categories, name=cat_name)
+            cat = resources.resolve_channel(guild, name=cat_name, kind="category")
             if not cat or not cat.channels:
                 continue
             for ch in cat.channels:

--- a/disbot/cogs/xp/listener.py
+++ b/disbot/cogs/xp/listener.py
@@ -25,6 +25,7 @@ import time
 import discord
 from discord.ext import commands
 
+from core.runtime import resources
 from services import xp_service
 from utils import db
 from utils.cooldowns import check_cooldown
@@ -85,7 +86,10 @@ async def announce_level_up(
     """Post the level-up embed + log embed + apply XP threshold roles."""
     announce_ch: discord.TextChannel | None = None
     if announce_channel:
-        announce_ch = message.guild.get_channel(int(announce_channel))  # type: ignore[assignment]
+        announce_ch = resources.resolve_channel(  # type: ignore[assignment]
+            message.guild,
+            channel_id=announce_channel,
+        )
     announce_ch = announce_ch or message.channel  # type: ignore[assignment]
 
     embed = discord.Embed(
@@ -124,8 +128,8 @@ async def _apply_xp_threshold_roles(
         xp_roles = await get_xp_threshold_roles(message.guild.id)
         for role_cfg in xp_roles:
             if role_cfg["level_required"] <= new_level:
-                discord_role = discord.utils.get(
-                    message.guild.roles,
+                discord_role = resources.resolve_role(
+                    message.guild,
                     name=role_cfg["role_name"],
                 )
                 if (

--- a/disbot/core/runtime/__init__.py
+++ b/disbot/core/runtime/__init__.py
@@ -37,6 +37,7 @@ from core.runtime import guild_config  # noqa: F401 — re-exported
 from core.runtime import persistent_views  # noqa: F401 — re-exported
 from core.runtime import scope_locks  # noqa: F401 — re-exported
 from core.runtime import tasks  # noqa: F401 — re-exported
+from core.runtime import guild_resources as resources  # noqa: F401 — re-exported
 from core.runtime import interaction_helpers as interaction  # noqa: F401 — re-exported
 from core.runtime import interaction_router as router  # noqa: F401 — re-exported
 from core.runtime import live_update_scheduler as scheduler  # noqa: F401 — re-exported

--- a/disbot/core/runtime/guild_resources.py
+++ b/disbot/core/runtime/guild_resources.py
@@ -1,0 +1,280 @@
+"""Unified guild-resource resolver (Phase D extraction).
+
+Consolidates the fragmented ``guild.get_channel`` / ``get_role`` /
+``get_member`` call sites into a single typed surface so:
+
+- missing-resource handling is uniform (return ``None`` instead of
+  KeyError / AttributeError on ``int(None)`` casts);
+- settings-key → channel-id binding has one helper, not one per cog;
+- leaderboards can batch-fetch members instead of doing N individual
+  ``guild.get_member`` calls.
+
+This is a **pure-read primitive**. Mutations stay where they belong:
+
+- Channel / category / role *creation* lives in ``utils/channels.py``
+  (``safe_channel_name``, ``get_or_create_category``,
+  ``create_private_channel``, ``cleanup_category``).
+- Audited state mutations (coins, XP, moderation) stay in the
+  ``services/`` layer per ``docs/ownership.md``.
+
+Sync vs. async:
+    The cache-only resolvers (``resolve_channel``, ``resolve_role``,
+    ``resolve_member``, ``resolve_members``, ``member_display``) are
+    sync because the underlying discord.py calls are sync.  Functions
+    that perform I/O (``ensure_channel`` creates via the Discord API;
+    ``resolve_settings_channel`` reads from the DB) are async.
+
+    If a future migration adds ``guild.fetch_member`` fallback on
+    cache miss, the affected resolvers will become async — that is a
+    breaking change and will get its own ADR.
+
+Public surface:
+    resolve_channel(guild, *, channel_id=None, name=None, category=None,
+                    kind="text")             → GuildChannel | None
+    ensure_channel(guild, name, *, kind="text",
+                   category=None, overwrites=None)
+                                              → TextChannel | VoiceChannel
+    resolve_role(guild, *, role_id=None, name=None) → Role | None
+    resolve_member(guild, member_id)          → Member | None
+    resolve_members(guild, member_ids)        → dict[int, Member]
+    member_display(guild, member_id)          → str
+    resolve_settings_channel(guild, setting_key)
+                                              → GuildChannel | None
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from typing import Literal
+
+import discord
+
+logger = logging.getLogger("bot.runtime.guild_resources")
+
+ChannelKind = Literal["text", "voice", "category", "any"]
+
+
+# ---------------------------------------------------------------------------
+# Channels
+# ---------------------------------------------------------------------------
+
+
+def resolve_channel(
+    guild: discord.Guild,
+    *,
+    channel_id: int | str | None = None,
+    name: str | None = None,
+    category: str | discord.CategoryChannel | None = None,
+    kind: ChannelKind = "text",
+) -> discord.abc.GuildChannel | None:
+    """Resolve a channel by ID (preferred) or by name with optional filters.
+
+    Behavior:
+        - If ``channel_id`` is given, ``guild.get_channel(int(channel_id))``
+          is tried first. Returns ``None`` if not in cache or the int cast
+          fails.
+        - If ``name`` is given (and channel_id missed), the guild is scanned
+          for a channel matching name + kind + optional category.
+        - If both are given, ``channel_id`` wins on hit.
+
+    The ``category`` filter accepts either the category name (string) or a
+    ``CategoryChannel`` instance.
+
+    Returns ``None`` on any miss (cache absent, invalid id, no match).
+    """
+    if channel_id is not None:
+        try:
+            cid_int = int(channel_id)
+        except (TypeError, ValueError):
+            cid_int = None
+        if cid_int is not None:
+            ch = guild.get_channel(cid_int)
+            if ch is not None:
+                return ch
+
+    if name is None:
+        return None
+
+    if isinstance(category, str):
+        cat = discord.utils.get(guild.categories, name=category)
+    else:
+        cat = category
+
+    candidates: Iterable[discord.abc.GuildChannel]
+    if kind == "text":
+        candidates = guild.text_channels
+    elif kind == "voice":
+        candidates = guild.voice_channels
+    elif kind == "category":
+        candidates = guild.categories
+    else:  # "any"
+        candidates = guild.channels
+
+    for ch in candidates:
+        if ch.name != name:
+            continue
+        if cat is not None and getattr(ch, "category_id", None) != cat.id:
+            continue
+        return ch
+    return None
+
+
+async def ensure_channel(
+    guild: discord.Guild,
+    name: str,
+    *,
+    kind: Literal["text", "voice"] = "text",
+    category: discord.CategoryChannel | None = None,
+    overwrites: dict | None = None,
+) -> discord.TextChannel | discord.VoiceChannel:
+    """Return a channel matching ``name`` + ``kind``, creating it if absent.
+
+    The match is performed via :func:`resolve_channel` with ``kind`` and
+    ``category`` filters. If a match is found it is returned unchanged
+    (overwrites are NOT reconciled — callers managing permission templates
+    should call ``channel.edit`` themselves).
+
+    On miss, the channel is created via ``guild.create_text_channel`` or
+    ``guild.create_voice_channel``. ``overwrites`` defaults to empty.
+    """
+    existing = resolve_channel(guild, name=name, category=category, kind=kind)
+    if existing is not None:
+        return existing  # type: ignore[return-value]
+
+    if kind == "voice":
+        return await guild.create_voice_channel(
+            name,
+            category=category,
+            overwrites=overwrites or {},
+        )
+    return await guild.create_text_channel(
+        name,
+        category=category,
+        overwrites=overwrites or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Roles
+# ---------------------------------------------------------------------------
+
+
+def resolve_role(
+    guild: discord.Guild,
+    *,
+    role_id: int | str | None = None,
+    name: str | None = None,
+) -> discord.Role | None:
+    """Resolve a role by ID (preferred) or exact name.
+
+    ``role_id`` wins on hit. Name match is exact (case-sensitive); for
+    normalized lookup use ``views/roles/_helpers.py:_find_role_normalized``.
+    """
+    if role_id is not None:
+        try:
+            rid_int = int(role_id)
+        except (TypeError, ValueError):
+            rid_int = None
+        if rid_int is not None:
+            role = guild.get_role(rid_int)
+            if role is not None:
+                return role
+
+    if name is None:
+        return None
+    return discord.utils.get(guild.roles, name=name)
+
+
+# ---------------------------------------------------------------------------
+# Members
+# ---------------------------------------------------------------------------
+
+
+def resolve_member(
+    guild: discord.Guild,
+    member_id: int | str,
+) -> discord.Member | None:
+    """Cache-only member lookup.
+
+    Returns ``None`` on cache miss or invalid id. Does not fall back to
+    ``guild.fetch_member`` (that would be an I/O operation; callers who
+    need the slow path can fetch explicitly).
+    """
+    try:
+        mid_int = int(member_id)
+    except (TypeError, ValueError):
+        return None
+    return guild.get_member(mid_int)
+
+
+def resolve_members(
+    guild: discord.Guild,
+    member_ids: Iterable[int | str],
+) -> dict[int, discord.Member]:
+    """Batch cache-only member lookup.
+
+    Returns a dict mapping resolved IDs to ``Member`` objects. Missing or
+    invalid IDs are silently dropped — callers iterate over the input
+    list and use ``member_display`` for fallback strings.
+
+    Fixes the leaderboard N+1 pattern: one method call instead of N
+    individual ``guild.get_member`` calls scattered across an embed
+    builder.
+    """
+    out: dict[int, discord.Member] = {}
+    for raw in member_ids:
+        try:
+            mid_int = int(raw)
+        except (TypeError, ValueError):
+            continue
+        m = guild.get_member(mid_int)
+        if m is not None:
+            out[mid_int] = m
+    return out
+
+
+def member_display(
+    guild: discord.Guild,
+    member_id: int | str,
+) -> str:
+    """Return ``member.display_name`` if cached, else a mention fallback.
+
+    Mirrors the ad-hoc pattern used by leaderboard rendering today:
+    ``guild.get_member(id) or f"<@{id}>"`` — but typed and one-call.
+    """
+    try:
+        mid_int = int(member_id)
+    except (TypeError, ValueError):
+        return f"<@{member_id}>"
+    m = guild.get_member(mid_int)
+    if m is not None:
+        return m.display_name
+    return f"<@{mid_int}>"
+
+
+# ---------------------------------------------------------------------------
+# Settings-bound channel resolution
+# ---------------------------------------------------------------------------
+
+
+async def resolve_settings_channel(
+    guild: discord.Guild,
+    setting_key: str,
+) -> discord.abc.GuildChannel | None:
+    """Resolve the channel ID stored under ``setting_key`` for ``guild``.
+
+    Reads ``guild_settings(guild_id, setting_key)`` via ``utils.db``, then
+    looks the result up via :func:`resolve_channel`. Returns ``None`` if
+    the setting is unset, malformed, or points at a channel not in the
+    guild cache.
+
+    Replaces the ~6 inline ``cid = await db.get_setting(...);
+    bot.get_channel(int(cid))`` patterns scattered across cogs.
+    """
+    from utils import db
+
+    raw = await db.get_setting(guild.id, setting_key, "")
+    if not raw:
+        return None
+    return resolve_channel(guild, channel_id=raw)

--- a/disbot/governance/__init__.py
+++ b/disbot/governance/__init__.py
@@ -15,6 +15,7 @@ import time as _time
 
 import discord
 
+from core.runtime import resources
 from governance.cache import (  # noqa: F401
     GovernanceCacheBackend,
     forget_guild,
@@ -226,7 +227,7 @@ def _find_redirect_channel(
     if guild is None:
         return None
     for ch_name in subsystem_meta.get("default_channels", []):
-        ch = discord.utils.get(guild.text_channels, name=ch_name)
+        ch = resources.resolve_channel(guild, name=ch_name)
         if ch:
             return ch.mention
     return None

--- a/disbot/utils/helpers.py
+++ b/disbot/utils/helpers.py
@@ -5,6 +5,7 @@ import re
 import discord
 from discord.ext import commands
 
+from core.runtime import resources
 from utils.settings_keys import ECONOMY_LOG_CHANNEL
 from utils.ui_constants import INFO_COLOR, SUCCESS_COLOR
 
@@ -14,9 +15,9 @@ def _parse_member(guild: discord.Guild, text: str) -> discord.Member | None:
     text = text.strip()
     mention_match = re.match(r"<@!?(\d+)>", text)
     if mention_match:
-        return guild.get_member(int(mention_match.group(1)))
+        return resources.resolve_member(guild, mention_match.group(1))
     if text.isdigit():
-        return guild.get_member(int(text))
+        return resources.resolve_member(guild, text)
     return discord.utils.find(
         lambda m: m.name == text or m.display_name == text,
         guild.members,
@@ -61,12 +62,10 @@ async def post_log_embed(
     embed: discord.Embed,
 ) -> None:
     """Post an embed to the guild's configured economy_log_channel (if set)."""
-    from utils import db
-
-    cid = await db.get_setting(guild_id, ECONOMY_LOG_CHANNEL, "")
-    if not cid:
+    guild = bot.get_guild(guild_id)
+    if guild is None:
         return
-    ch = bot.get_channel(int(cid))
+    ch = await resources.resolve_settings_channel(guild, ECONOMY_LOG_CHANNEL)
     if ch:
         try:
             await ch.send(embed=embed)  # type: ignore[union-attr]

--- a/disbot/views/blackjack/tournament_views.py
+++ b/disbot/views/blackjack/tournament_views.py
@@ -27,6 +27,7 @@ from cogs.blackjack._state import (
     _tournaments,
     _TournPlayerState,
 )
+from core.runtime import resources
 from services import economy_service, game_state_service
 from services.blackjack_engine import hand_value as _hand_value
 from services.blackjack_engine import is_blackjack as _is_blackjack
@@ -208,7 +209,7 @@ async def _start_tourn_round(
         channel_id=channel.id,
     )
     _active[(ps.user_id, ps.guild_id)] = game
-    member = channel.guild.get_member(ps.user_id)
+    member = resources.resolve_member(channel.guild, ps.user_id)
     mention = member.mention if member else f"<@{ps.user_id}>"
 
     embed = _game_embed(
@@ -233,8 +234,7 @@ async def _check_tourn_done(tourn: _BjTournament, bot: commands.Bot):
     medals = ["🥇", "🥈", "🥉"]
     for i, (uid, chips) in enumerate(ranking):
         icon = medals[i] if i < 3 else f"#{i+1}"
-        member = guild.get_member(uid) if guild else None
-        name = member.display_name if member else f"<@{uid}>"
+        name = resources.member_display(guild, uid) if guild else f"<@{uid}>"
         lines.append(f"{icon} **{name}** — {chips} chips")
 
     winner_id = ranking[0][0] if ranking else None

--- a/disbot/views/channels/delete_panel.py
+++ b/disbot/views/channels/delete_panel.py
@@ -13,6 +13,7 @@ import logging
 import discord
 from discord.ext import commands
 
+from core.runtime import resources
 from core.runtime.panel_recovery import restore_parent_or_send_fresh
 from utils.ui_constants import ERROR_COLOR, SUCCESS_COLOR, WARNING_COLOR
 from views.base import BaseView
@@ -165,7 +166,11 @@ class _DeleteConfirmView(BaseView):
         row=0,
     )
     async def confirm_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
-        channel = interaction.guild.get_channel(self.channel_id)
+        channel = resources.resolve_channel(
+            interaction.guild,
+            channel_id=self.channel_id,
+            kind="any",
+        )
         if channel is None:
             result_embed = discord.Embed(
                 title="❌ Channel Not Found",

--- a/disbot/views/channels/restrict_panel.py
+++ b/disbot/views/channels/restrict_panel.py
@@ -13,6 +13,7 @@ import logging
 import discord
 from discord.ext import commands
 
+from core.runtime import resources
 from core.runtime.panel_recovery import restore_parent_or_send_fresh
 from utils.ui_constants import CHANNEL_COLOR, ERROR_COLOR, SUCCESS_COLOR
 from views.base import BaseView
@@ -97,7 +98,11 @@ class _RestrictSubView(BaseView):
             )
             return
 
-        channel = interaction.guild.get_channel(self.selected_channel_id)
+        channel = resources.resolve_channel(
+            interaction.guild,
+            channel_id=self.selected_channel_id,
+            kind="any",
+        )
         if channel is None:
             await interaction.response.send_message(
                 f"Channel `{self.selected_channel_name}` not found.",

--- a/disbot/views/channels/visibility_panel.py
+++ b/disbot/views/channels/visibility_panel.py
@@ -16,6 +16,7 @@ import logging
 import discord
 from discord.ext import commands
 
+from core.runtime import resources
 from services import governance_service
 from services.governance_service import GovernanceContext
 from utils.subsystem_registry import all_subsystems_sorted
@@ -46,7 +47,11 @@ class _ChannelSelectForVisibility(discord.ui.Select):
 
     async def callback(self, interaction: discord.Interaction):
         channel_id = int(self.values[0])
-        channel = interaction.guild.get_channel(channel_id)
+        channel = resources.resolve_channel(
+            interaction.guild,
+            channel_id=channel_id,
+            kind="any",
+        )
         if not channel:
             await interaction.response.send_message(
                 "Channel not found.",

--- a/disbot/views/counting/hub_panel.py
+++ b/disbot/views/counting/hub_panel.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 import discord
 from discord.ext import commands
 
-from core.runtime import tasks
+from core.runtime import resources, tasks
 from views.base import HubView
 
 
@@ -59,7 +59,7 @@ class _CountingHubView(HubView):
             )
             active_mentions = []
             for cid in active_ids:
-                ch = self.ctx.guild.get_channel(int(cid))
+                ch = resources.resolve_channel(self.ctx.guild, channel_id=cid)
                 if ch:
                     active_mentions.append(ch.mention)
             embed.description = (

--- a/disbot/views/roles/management_panel.py
+++ b/disbot/views/roles/management_panel.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import discord
 from discord.ext import commands
 
+from core.runtime import resources
 from core.runtime.interaction_helpers import safe_defer
 from utils.ui_constants import ROLE_COLOR
 from views.base import BaseView
@@ -175,7 +176,7 @@ class _DeleteRoleSelect(discord.ui.Select):
         super().__init__(placeholder="Choose a role to delete…", options=options)
 
     async def callback(self, interaction: discord.Interaction) -> None:
-        role = interaction.guild.get_role(int(self.values[0]))
+        role = resources.resolve_role(interaction.guild, role_id=self.values[0])
         if not role:
             await interaction.response.send_message(
                 "❌ Role no longer exists.",

--- a/disbot/views/roles/reaction_panel.py
+++ b/disbot/views/roles/reaction_panel.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import discord
 from discord.ext import commands
 
+from core.runtime import resources
 from utils import db
 from utils.ui_constants import ROLE_COLOR
 from views.base import BaseView
@@ -22,7 +23,7 @@ class ReactionRolesPanel(BaseView):
         if rows:
             lines = []
             for r in rows:
-                role = self.ctx.guild.get_role(r["role_id"])
+                role = resources.resolve_role(self.ctx.guild, role_id=r["role_id"])
                 role_str = role.mention if role else f"*(deleted role {r['role_id']})*"
                 lines.append(f"Message `{r['message_id']}` · {r['emoji']} → {role_str}")
             embed.description = "\n".join(lines)

--- a/tests/unit/runtime/test_guild_resources.py
+++ b/tests/unit/runtime/test_guild_resources.py
@@ -1,0 +1,356 @@
+"""Tests for core.runtime.guild_resources (Phase D extraction).
+
+The resolvers are pure-read primitives: they wrap ``guild.get_channel`` /
+``guild.get_role`` / ``guild.get_member`` plus the settings-channel
+binding pattern.  Tests verify:
+
+- ID-preferred resolution (id wins over name when both supplied)
+- name-with-kind/category filtering
+- malformed input (None, non-numeric, missing-from-cache) returns None
+- ``resolve_members`` batch behavior (no N+1)
+- ``member_display`` fallback formatting
+- ``resolve_settings_channel`` reads via ``utils.db.get_setting``
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from core.runtime import guild_resources
+
+# ---------------------------------------------------------------------------
+# Helpers — build minimal mock guilds without spinning up discord.py state
+# ---------------------------------------------------------------------------
+
+
+def _make_channel(channel_id: int, name: str, *, category_id: int | None = None):
+    ch = SimpleNamespace(id=channel_id, name=name, category_id=category_id)
+    return ch
+
+
+def _make_role(role_id: int, name: str):
+    return SimpleNamespace(id=role_id, name=name)
+
+
+def _make_member(member_id: int, display_name: str):
+    return SimpleNamespace(id=member_id, display_name=display_name)
+
+
+def _make_guild(
+    *,
+    text_channels=(),
+    voice_channels=(),
+    categories=(),
+    roles=(),
+    members_by_id=None,
+):
+    guild = MagicMock()
+    guild.id = 1
+    guild.text_channels = list(text_channels)
+    guild.voice_channels = list(voice_channels)
+    guild.categories = list(categories)
+    guild.channels = (
+        list(text_channels) + list(voice_channels) + list(categories)
+    )
+    guild.roles = list(roles)
+
+    id_to_channel = {ch.id: ch for ch in guild.channels}
+    guild.get_channel = lambda cid: id_to_channel.get(cid)
+
+    id_to_role = {r.id: r for r in guild.roles}
+    guild.get_role = lambda rid: id_to_role.get(rid)
+
+    members = members_by_id or {}
+    guild.get_member = lambda mid: members.get(mid)
+
+    return guild
+
+
+# ---------------------------------------------------------------------------
+# resolve_channel
+# ---------------------------------------------------------------------------
+
+
+class TestResolveChannel:
+    def test_by_id_hits_cache(self):
+        ch = _make_channel(100, "general")
+        guild = _make_guild(text_channels=[ch])
+        assert guild_resources.resolve_channel(guild, channel_id=100) is ch
+
+    def test_by_id_accepts_string(self):
+        ch = _make_channel(100, "general")
+        guild = _make_guild(text_channels=[ch])
+        assert guild_resources.resolve_channel(guild, channel_id="100") is ch
+
+    def test_by_id_invalid_falls_through_to_name(self):
+        ch = _make_channel(100, "general")
+        guild = _make_guild(text_channels=[ch])
+        # invalid id, but name matches
+        assert (
+            guild_resources.resolve_channel(
+                guild, channel_id="not-an-int", name="general"
+            )
+            is ch
+        )
+
+    def test_by_id_invalid_no_name_returns_none(self):
+        guild = _make_guild()
+        assert (
+            guild_resources.resolve_channel(guild, channel_id="not-an-int") is None
+        )
+
+    def test_by_id_missing_falls_through_to_name(self):
+        ch = _make_channel(100, "general")
+        guild = _make_guild(text_channels=[ch])
+        # id 999 not in cache; fall back to name
+        assert (
+            guild_resources.resolve_channel(guild, channel_id=999, name="general")
+            is ch
+        )
+
+    def test_by_name_text_only_default(self):
+        text_ch = _make_channel(100, "general")
+        voice_ch = _make_channel(200, "general")  # same name, voice channel
+        guild = _make_guild(text_channels=[text_ch], voice_channels=[voice_ch])
+        # default kind=text → returns text channel, not voice
+        result = guild_resources.resolve_channel(guild, name="general")
+        assert result is text_ch
+
+    def test_by_name_voice_kind(self):
+        voice_ch = _make_channel(200, "general")
+        guild = _make_guild(voice_channels=[voice_ch])
+        result = guild_resources.resolve_channel(guild, name="general", kind="voice")
+        assert result is voice_ch
+
+    def test_by_name_any_kind_picks_first(self):
+        text_ch = _make_channel(100, "general")
+        voice_ch = _make_channel(200, "general")
+        guild = _make_guild(text_channels=[text_ch], voice_channels=[voice_ch])
+        result = guild_resources.resolve_channel(guild, name="general", kind="any")
+        # iteration order = text_channels + voice_channels per _make_guild
+        assert result is text_ch
+
+    def test_by_name_with_category_filter(self):
+        cat_a = _make_channel(50, "Bot")
+        cat_b = _make_channel(60, "Other")
+        ch_in_a = _make_channel(100, "log", category_id=50)
+        ch_in_b = _make_channel(101, "log", category_id=60)
+        guild = _make_guild(
+            text_channels=[ch_in_a, ch_in_b], categories=[cat_a, cat_b]
+        )
+        result = guild_resources.resolve_channel(
+            guild, name="log", category="Bot"
+        )
+        assert result is ch_in_a
+
+    def test_by_name_category_obj_filter(self):
+        cat = SimpleNamespace(id=50, name="Bot")
+        ch = _make_channel(100, "log", category_id=50)
+        guild = _make_guild(text_channels=[ch], categories=[cat])
+        result = guild_resources.resolve_channel(
+            guild, name="log", category=cat
+        )
+        assert result is ch
+
+    def test_by_name_missing_returns_none(self):
+        guild = _make_guild()
+        assert guild_resources.resolve_channel(guild, name="missing") is None
+
+    def test_no_args_returns_none(self):
+        guild = _make_guild()
+        assert guild_resources.resolve_channel(guild) is None
+
+
+# ---------------------------------------------------------------------------
+# ensure_channel
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureChannel:
+    @pytest.mark.asyncio
+    async def test_returns_existing(self):
+        ch = _make_channel(100, "general")
+        guild = _make_guild(text_channels=[ch])
+        guild.create_text_channel = AsyncMock()
+        result = await guild_resources.ensure_channel(guild, "general")
+        assert result is ch
+        guild.create_text_channel.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_creates_when_absent(self):
+        guild = _make_guild()
+        created = _make_channel(999, "new-channel")
+        guild.create_text_channel = AsyncMock(return_value=created)
+        result = await guild_resources.ensure_channel(guild, "new-channel")
+        assert result is created
+        guild.create_text_channel.assert_awaited_once_with(
+            "new-channel", category=None, overwrites={}
+        )
+
+    @pytest.mark.asyncio
+    async def test_creates_voice(self):
+        guild = _make_guild()
+        created = SimpleNamespace(id=999, name="vc")
+        guild.create_voice_channel = AsyncMock(return_value=created)
+        result = await guild_resources.ensure_channel(guild, "vc", kind="voice")
+        assert result is created
+        guild.create_voice_channel.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# resolve_role
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRole:
+    def test_by_id(self):
+        role = _make_role(100, "Member")
+        guild = _make_guild(roles=[role])
+        assert guild_resources.resolve_role(guild, role_id=100) is role
+
+    def test_by_id_string(self):
+        role = _make_role(100, "Member")
+        guild = _make_guild(roles=[role])
+        assert guild_resources.resolve_role(guild, role_id="100") is role
+
+    def test_by_name_exact(self):
+        role = _make_role(100, "Member")
+        guild = _make_guild(roles=[role])
+        assert guild_resources.resolve_role(guild, name="Member") is role
+
+    def test_by_name_case_sensitive(self):
+        role = _make_role(100, "Member")
+        guild = _make_guild(roles=[role])
+        assert guild_resources.resolve_role(guild, name="member") is None
+
+    def test_by_id_falls_through_to_name(self):
+        role = _make_role(100, "Member")
+        guild = _make_guild(roles=[role])
+        assert (
+            guild_resources.resolve_role(guild, role_id=999, name="Member")
+            is role
+        )
+
+    def test_no_args_returns_none(self):
+        guild = _make_guild()
+        assert guild_resources.resolve_role(guild) is None
+
+    def test_missing_returns_none(self):
+        guild = _make_guild()
+        assert guild_resources.resolve_role(guild, role_id=100) is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_member / resolve_members / member_display
+# ---------------------------------------------------------------------------
+
+
+class TestResolveMember:
+    def test_found(self):
+        m = _make_member(42, "Alice")
+        guild = _make_guild(members_by_id={42: m})
+        assert guild_resources.resolve_member(guild, 42) is m
+
+    def test_str_id(self):
+        m = _make_member(42, "Alice")
+        guild = _make_guild(members_by_id={42: m})
+        assert guild_resources.resolve_member(guild, "42") is m
+
+    def test_missing(self):
+        guild = _make_guild()
+        assert guild_resources.resolve_member(guild, 42) is None
+
+    def test_invalid_id(self):
+        guild = _make_guild()
+        assert guild_resources.resolve_member(guild, "abc") is None
+        assert guild_resources.resolve_member(guild, None) is None  # type: ignore[arg-type]
+
+
+class TestResolveMembers:
+    def test_partial_batch(self):
+        m1 = _make_member(1, "Alice")
+        m3 = _make_member(3, "Carol")
+        guild = _make_guild(members_by_id={1: m1, 3: m3})
+        result = guild_resources.resolve_members(guild, [1, 2, 3])
+        assert result == {1: m1, 3: m3}
+
+    def test_empty(self):
+        guild = _make_guild()
+        assert guild_resources.resolve_members(guild, []) == {}
+
+    def test_drops_invalid_ids(self):
+        m = _make_member(1, "Alice")
+        guild = _make_guild(members_by_id={1: m})
+        result = guild_resources.resolve_members(guild, [1, "abc", None, 999])
+        assert result == {1: m}
+
+
+class TestMemberDisplay:
+    def test_cached_returns_display_name(self):
+        m = _make_member(42, "Alice")
+        guild = _make_guild(members_by_id={42: m})
+        assert guild_resources.member_display(guild, 42) == "Alice"
+
+    def test_missing_returns_mention(self):
+        guild = _make_guild()
+        assert guild_resources.member_display(guild, 42) == "<@42>"
+
+    def test_str_id(self):
+        m = _make_member(42, "Alice")
+        guild = _make_guild(members_by_id={42: m})
+        assert guild_resources.member_display(guild, "42") == "Alice"
+
+    def test_invalid_id_returns_raw_mention(self):
+        guild = _make_guild()
+        assert guild_resources.member_display(guild, "abc") == "<@abc>"
+
+
+# ---------------------------------------------------------------------------
+# resolve_settings_channel
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSettingsChannel:
+    @pytest.mark.asyncio
+    async def test_unset_setting_returns_none(self):
+        guild = _make_guild()
+        with patch(
+            "utils.db.get_setting",
+            new_callable=AsyncMock,
+            return_value="",
+        ) as m:
+            result = await guild_resources.resolve_settings_channel(
+                guild, "log_channel"
+            )
+            assert result is None
+            m.assert_awaited_once_with(guild.id, "log_channel", "")
+
+    @pytest.mark.asyncio
+    async def test_resolves_channel_by_id(self):
+        ch = _make_channel(123, "logs")
+        guild = _make_guild(text_channels=[ch])
+        with patch(
+            "utils.db.get_setting",
+            new_callable=AsyncMock,
+            return_value="123",
+        ):
+            result = await guild_resources.resolve_settings_channel(
+                guild, "log_channel"
+            )
+            assert result is ch
+
+    @pytest.mark.asyncio
+    async def test_setting_points_at_missing_channel(self):
+        guild = _make_guild()  # cache empty
+        with patch(
+            "utils.db.get_setting",
+            new_callable=AsyncMock,
+            return_value="999",
+        ):
+            result = await guild_resources.resolve_settings_channel(
+                guild, "log_channel"
+            )
+            assert result is None

--- a/tests/unit/runtime/test_guild_resources_invariant.py
+++ b/tests/unit/runtime/test_guild_resources_invariant.py
@@ -1,0 +1,103 @@
+"""INV gate: no raw guild-resource lookups outside core.runtime.guild_resources.
+
+Phase D enforces a single canonical site for all guild member / role /
+channel resolution.  Once the migration is complete this test guards
+the invariant so a new ``guild.get_member`` / ``discord.utils.get(
+guild.roles, ...)`` etc. can't sneak back in.
+
+The gate scans ``disbot/**/*.py`` (excluding tests + the allow-list
+below) for the patterns the resolver canonicalises.  If any new
+pattern lands, fix it by calling the matching helper in
+``core.runtime.guild_resources`` (re-exported as ``resources``).
+
+Allow-list rationale:
+
+  guild_resources.py          The resolver IS the canonical site.
+  utils/channels.py           Channel-creation helper; uses
+                              ``discord.utils.get`` internally to
+                              check existence before create.
+                              Migrating it would introduce an
+                              upward dep on core/runtime that the
+                              creation primitive doesn't need.
+  rps_tournament/_bot_matches.py
+                              Uses ``guild.get_member_named`` — a
+                              name-based lookup distinct from the
+                              id-based ``get_member``.  No equivalent
+                              in the resolver yet (resolve_member
+                              takes an id, not a username).  A
+                              future ``resolve_member_by_name`` could
+                              absorb it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCAN_ROOT = REPO_ROOT / "disbot"
+
+ALLOW_LIST = {
+    "disbot/core/runtime/guild_resources.py",
+    "disbot/utils/channels.py",
+    "disbot/cogs/rps_tournament/_bot_matches.py",
+}
+
+# Each pattern is (compiled-regex, human-readable label).  The regex
+# is matched line-by-line so the line number can be reported.
+PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (
+        re.compile(r"\bguild\.get_member\("),
+        "guild.get_member — use resources.resolve_member",
+    ),
+    (
+        re.compile(r"\bguild\.get_role\("),
+        "guild.get_role — use resources.resolve_role",
+    ),
+    (
+        re.compile(r"\bguild\.get_channel\(\s*int\("),
+        "guild.get_channel(int(...)) — use resources.resolve_channel",
+    ),
+    (
+        re.compile(r"\bbot\.get_channel\(\s*int\("),
+        "bot.get_channel(int(...)) — use resources.resolve_settings_channel",
+    ),
+    (
+        re.compile(r"discord\.utils\.get\([^)]*\.roles\s*,"),
+        "discord.utils.get(... .roles, ...) — use resources.resolve_role(name=...)",
+    ),
+    (
+        re.compile(r"discord\.utils\.get\([^)]*\.categories\s*,"),
+        "discord.utils.get(... .categories, ...) — use resources.resolve_channel(kind='category')",
+    ),
+    (
+        re.compile(r"discord\.utils\.get\([^)]*\.text_channels\s*,"),
+        "discord.utils.get(... .text_channels, ...) — use resources.resolve_channel(name=...)",
+    ),
+    (
+        re.compile(r"discord\.utils\.get\([^)]*\.voice_channels\s*,"),
+        "discord.utils.get(... .voice_channels, ...) — use resources.resolve_channel(kind='voice')",
+    ),
+]
+
+
+def _iter_py_files():
+    for path in SCAN_ROOT.rglob("*.py"):
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        if rel in ALLOW_LIST:
+            continue
+        yield path, rel
+
+
+def test_no_raw_guild_lookups_outside_resolver() -> None:
+    violations: list[str] = []
+    for path, rel in _iter_py_files():
+        text = path.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            for pattern, label in PATTERNS:
+                if pattern.search(line):
+                    violations.append(f"{rel}:{lineno}: {label}\n    > {line.strip()}")
+    assert not violations, (
+        "raw guild-resource lookups found outside core.runtime.guild_resources:\n\n"
+        + "\n\n".join(violations)
+    )


### PR DESCRIPTION
## Summary

Lands the **Phase D** track from `docs/foundational-infrastructure-plan.md` —
a single typed surface for resolving Discord guild resources (channels,
roles, members, settings-bound channels), replacing the ~38 inline
`guild.get_channel` / `get_role` / `get_member` / `discord.utils.get(...)`
patterns scattered across the codebase.

**Module:** `disbot/core/runtime/guild_resources.py` (re-exported as
`core.runtime.resources`).

**Public surface (7 functions):**

```
resolve_channel(guild, *, channel_id=None, name=None,
                category=None, kind="text") → GuildChannel | None
ensure_channel(guild, name, *, kind="text",
               category=None, overwrites=None) → TextChannel | VoiceChannel
resolve_role(guild, *, role_id=None, name=None) → Role | None
resolve_member(guild, member_id)                → Member | None
resolve_members(guild, member_ids)              → dict[int, Member]
member_display(guild, member_id)                → str
resolve_settings_channel(guild, setting_key)    → GuildChannel | None
```

**Sync vs. async:** sync where the underlying `discord.py` call is sync
(cache-only lookups); async only where real I/O happens
(`ensure_channel` creates via the API, `resolve_settings_channel` reads
from the DB).  No fake `async` on cache-only paths.

## Changes by commit

| # | Commit | What |
|---|---|---|
| 1 | `0a7d2a8` | Foundation: module + 36 unit tests |
| 2 | `db7463d` | `leaderboard_cog` — 5 inline `get_member` → `member_display` (kills the N+1) |
| 3 | `897acd4` | `economy_cog` — `_ensure_log_channel` settings + category lookups |
| 4 | `b2e1f9c` | `role_cog` + `blackjack_cog` + `tournament_views` — 9 sites |
| 5 | `ce7b947` | `rps_tournament` + `views/roles/*` — 4 sites |
| 6 | `2c45940` | `moderation/_helpers` + `utils/helpers` + `channel_cog` — 6 sites |
| 7 | `a348494` | `chain_cog` + `xp/listener` + `counting_cog` + `admin_cog` + `governance/__init__` — 8 sites |
| 8 | `755cef0` | `views/channels/*` + INV invariant gate — 3 sites + gate |

**Total: 38 call sites migrated across 18 files**, plus the resolver
module, 36 unit tests, and 1 INV invariant test.

## Invariant gate

`tests/unit/runtime/test_guild_resources_invariant.py` scans every
`disbot/**/*.py` (outside the allow-list) for the 8 raw lookup
patterns the resolver canonicalises, and fails with file:line +
suggested replacement helper on any violation.

**Allow-list:**

- `guild_resources.py` — the canonical site itself
- `utils/channels.py` — channel-creation helper; importing core/runtime
  would be a layer reversal
- `cogs/rps_tournament/_bot_matches.py` — uses `guild.get_member_named`
  (name-based lookup, no resolver equivalent yet)

## Test plan

### 1. Static analysis (CI gates) — must all pass

- [ ] `ruff check . --exclude .github,tests,venv,env,build,dist` → **0 errors**
- [ ] `black --check . --exclude '(\.github|tests|venv|env|build|dist)'` → **183 files unchanged**
- [ ] `isort --check-only . --skip-glob '*/(\.github|tests|venv|env|build|dist)/*'` → **clean**
- [ ] `mypy disbot/` → **0 issues, 183 source files**

### 2. Unit tests

- [ ] `pytest tests/` → **915 / 915 pass, 0 regressions vs. main**
- [ ] `pytest tests/unit/runtime/test_guild_resources.py -v` → **36 pass**
  - `TestResolveChannel` × 12 — id-preferred, name, category filter, kind filter, missing
  - `TestEnsureChannel` × 3 — existing returned, create text, create voice
  - `TestResolveRole` × 7 — id, string id, exact name, case-sensitive, fallthrough
  - `TestResolveMember` × 4 — found, str id, missing, invalid id
  - `TestResolveMembers` × 3 — partial batch, empty, drops invalid ids
  - `TestMemberDisplay` × 4 — cached display_name, mention fallback, str id, invalid
  - `TestResolveSettingsChannel` × 3 — unset, valid, missing channel
- [ ] `pytest tests/unit/runtime/test_guild_resources_invariant.py -v` → **1 pass** (no raw lookups outside allow-list)

### 3. INV gate negative test

Verify the gate catches regressions:

```bash
# Insert a raw lookup somewhere safe:
echo "    _ = guild.get_member(1)" >> disbot/cogs/admin_cog.py
pytest tests/unit/runtime/test_guild_resources_invariant.py -v
# Expected: FAIL with "disbot/cogs/admin_cog.py:NNN: guild.get_member — use resources.resolve_member"
git checkout -- disbot/cogs/admin_cog.py
```

### 4. Functional smoke tests (run against a dev guild)

#### Leaderboards (migration 1)

For each subcommand, verify rendered embeds show display names for cached
members and `<@id>` fallback for uncached:

- [ ] `!leaderboard xp` — rows show "🥇 **Alice** — Level 5 (1234 XP)"
- [ ] `!leaderboard coins`
- [ ] `!leaderboard mining` — confirm non-numeric user_ids in legacy data still render `<@…>` fallback
- [ ] `!leaderboard deathmatch`
- [ ] `!leaderboard rps` (this path uses pre-fetched names from DB; verify unchanged)
- [ ] `!leaderboard counting`
- [ ] `!leaderboard` (no arg) — opens the category-select view

#### Economy log channel (migration 2)

- [ ] **On-ready path**: restart bot in a guild **with** an existing `economy-log` channel and `ECONOMY_LOG_CHANNEL` setting → no new channel created, no spurious DB write
- [ ] **On-ready, channel exists but setting unset**: delete the setting, restart → existing channel is adopted, setting written
- [ ] **On-ready, neither exists**: delete the channel + setting, restart → channel auto-created under `Bot` or `General` category with welcome embed
- [ ] **On-guild-join**: bot joins a fresh guild → channel auto-created (same flow)
- [ ] `!daily` / `!work` afterwards → log embeds land in `economy-log`

#### Role / blackjack / tournament (migration 3)

- [ ] Add a reaction-role row via `!reactroles <msg_id> 🟢 @Member` → react with 🟢 → role granted
- [ ] Unreact → role removed
- [ ] `!reactroles` (list) → table shows configured rows with role mentions
- [ ] Start a blackjack tournament via `!bjtournament` → bot reactions are ignored (the previous double-call collision)
- [ ] Run a tournament to completion → final ranking embed shows display names for cached players and `<@…>` for uncached
- [ ] Tournament cleanup → category `BJ Tournament` channels removed on `on_ready`

#### RPS + role views (migration 4)

- [ ] Run an RPS tournament that creates a `RPS Tournaments` category, then restart bot → orphaned-channel cleanup loop sees the category and posts the 5-min warning
- [ ] Open the role-management hub → role-delete select shows roles, selecting one deletes it (or reports "Role no longer exists" if cache miss)
- [ ] Open the reaction-roles panel → rows render with role mentions; rows pointing at deleted roles render `*(deleted role 12345)*`

#### Moderation + utils (migration 5)

- [ ] Use a moderation slash command on a member of equal/higher role → "❌ You cannot perform this action…" appears (the `_can_act_on_interaction` actor lookup)
- [ ] Use a command that takes a member arg as mention, ID, or name → all three forms resolve (`_parse_member`)
- [ ] Trigger any economy event (`!daily`, etc.) → `post_log_embed` posts to `economy-log` (now goes through `bot.get_guild` + `resolve_settings_channel`)
- [ ] `!setupchannel #general` and similar channel-arg commands → resolves by mention, ID, and name

#### Chain / XP / counting / admin / governance (migration 6)

- [ ] `?chain create <channel> word` with channel as mention, ID, or name → all resolve via the new `_parse_channel`
- [ ] Earn XP to a level-up → announce embed posts (announce channel resolved via `resolve_channel(channel_id=...)`), XP threshold role assigned if configured
- [ ] `!start_match counting` → no collision when a channel with the auto-generated name doesn't already exist; collision warning when it does
- [ ] Bot restart in a guild with a `#bot_spam` channel → greeting posts
- [ ] Use a subsystem that has a `default_channels` setting → governance feedback string includes the mention

#### Channel-management views (migration 8)

- [ ] Open the channel-manager panel → **Delete** flow: select a channel → confirm → channel deletes (or "Channel Not Found" if it was deleted out of band)
- [ ] **Restrict** flow: select channel → Lock → permissions update → returns to manager
- [ ] **Visibility** flow: select channel → toggle buttons cycle Green/Red/Grey

### 5. Layering / import-cycle sanity

- [ ] Bot boots cleanly (no `ImportError`, no `ModuleNotFoundError`)
- [ ] `python -c "from core.runtime import resources; print(resources.resolve_channel.__doc__[:60])"` works
- [ ] No circular import introduced: `utils/helpers.py → core/runtime/resources`
  uses the lazy `from utils import db` inside `resolve_settings_channel` so
  the module-load order remains `utils → core.runtime → cogs/views`

### 6. Performance spot-check

The leaderboard N+1 was the headline win:

- [ ] `!leaderboard xp` in a guild with 10 leaderboard rows → no perceptible
      change (was already microsecond-scale cache lookups; the win is
      consolidation, not latency)
- [ ] If future migration adds `fetch_member` fallback for cache misses,
      the batch helper `resolve_members` becomes the single I/O choke
      point — guarded by the existing API

## Out of scope (deliberately deferred)

- `resolve_member_by_name` for `guild.get_member_named` (one site:
  `rps_tournament/_bot_matches.py:92`) — different surface, follow-up PR
- Migrating `utils/channels.py:get_or_create_category` to use the
  resolver internally — would require an upward dep on core/runtime
  that the creation primitive doesn't need
- TTL-bounded member-display cache (mentioned in the Phase D plan as a
  future enhancement) — adds new behavior, defer until a workload shows
  it matters

https://claude.ai/code/session_01FuuCnXTg7FWygNZN5T2DKB

---
_Generated by [Claude Code](https://claude.ai/code/session_01FuuCnXTg7FWygNZN5T2DKB)_