### PR TITLE
Phase D follow-up: resolve_member_by_name + tighten INV gate

### DIFF
--- a/disbot/cogs/rps_tournament/_bot_matches.py
+++ b/disbot/cogs/rps_tournament/_bot_matches.py
@@ -25,6 +25,7 @@ from cogs.rps_tournament._helpers import (
     update_player_stats,
 )
 from cogs.rps_tournament.rules import GAME_MODES, determine_winner, normalize_move
+from core.runtime import resources
 
 logger = logging.getLogger("bot")
 
@@ -88,8 +89,8 @@ async def run_rps_bot_command(
             if isinstance(item, discord.Member):
                 member = item
             elif isinstance(item, str):
-                # Try to get member by ID or mention
-                member = ctx.guild.get_member_named(item)
+                # Try to get member by username/nickname/display-name
+                member = resources.resolve_member_by_name(ctx.guild, item)
             elif isinstance(item, discord.Role):
                 players.extend(item.members)
                 continue

--- a/disbot/core/runtime/guild_resources.py
+++ b/disbot/core/runtime/guild_resources.py
@@ -37,6 +37,7 @@ Public surface:
     resolve_role(guild, *, role_id=None, name=None) → Role | None
     resolve_member(guild, member_id)          → Member | None
     resolve_members(guild, member_ids)        → dict[int, Member]
+    resolve_member_by_name(guild, name)       → Member | None
     member_display(guild, member_id)          → str
     resolve_settings_channel(guild, setting_key)
                                               → GuildChannel | None
@@ -232,6 +233,24 @@ def resolve_members(
         if m is not None:
             out[mid_int] = m
     return out
+
+
+def resolve_member_by_name(
+    guild: discord.Guild,
+    name: str,
+) -> discord.Member | None:
+    """Cache-only member lookup by username, nick, or display name.
+
+    Wraps ``guild.get_member_named`` (which matches against
+    ``Member.name``, the user's nickname, and ``Member.global_name``).
+    Distinct from :func:`resolve_member`, which takes an id; use this
+    when the caller has a free-form string from user input.
+
+    Returns ``None`` on empty input or no match.
+    """
+    if not name:
+        return None
+    return guild.get_member_named(name)
 
 
 def member_display(

--- a/tests/unit/runtime/test_guild_resources.py
+++ b/tests/unit/runtime/test_guild_resources.py
@@ -269,6 +269,25 @@ class TestResolveMember:
         assert guild_resources.resolve_member(guild, None) is None  # type: ignore[arg-type]
 
 
+class TestResolveMemberByName:
+    def test_found(self):
+        m = _make_member(42, "Alice")
+        guild = _make_guild()
+        guild.get_member_named = lambda name: m if name == "Alice" else None
+        assert guild_resources.resolve_member_by_name(guild, "Alice") is m
+
+    def test_missing(self):
+        guild = _make_guild()
+        guild.get_member_named = lambda name: None
+        assert guild_resources.resolve_member_by_name(guild, "Bob") is None
+
+    def test_empty_string_short_circuits(self):
+        guild = _make_guild()
+        guild.get_member_named = MagicMock()
+        assert guild_resources.resolve_member_by_name(guild, "") is None
+        guild.get_member_named.assert_not_called()
+
+
 class TestResolveMembers:
     def test_partial_batch(self):
         m1 = _make_member(1, "Alice")

--- a/tests/unit/runtime/test_guild_resources_invariant.py
+++ b/tests/unit/runtime/test_guild_resources_invariant.py
@@ -19,14 +19,6 @@ Allow-list rationale:
                               Migrating it would introduce an
                               upward dep on core/runtime that the
                               creation primitive doesn't need.
-  rps_tournament/_bot_matches.py
-                              Uses ``guild.get_member_named`` — a
-                              name-based lookup distinct from the
-                              id-based ``get_member``.  No equivalent
-                              in the resolver yet (resolve_member
-                              takes an id, not a username).  A
-                              future ``resolve_member_by_name`` could
-                              absorb it.
 """
 
 from __future__ import annotations
@@ -40,7 +32,6 @@ SCAN_ROOT = REPO_ROOT / "disbot"
 ALLOW_LIST = {
     "disbot/core/runtime/guild_resources.py",
     "disbot/utils/channels.py",
-    "disbot/cogs/rps_tournament/_bot_matches.py",
 }
 
 # Each pattern is (compiled-regex, human-readable label).  The regex
@@ -49,6 +40,10 @@ PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (
         re.compile(r"\bguild\.get_member\("),
         "guild.get_member — use resources.resolve_member",
+    ),
+    (
+        re.compile(r"\bguild\.get_member_named\("),
+        "guild.get_member_named — use resources.resolve_member_by_name",
     ),
     (
         re.compile(r"\bguild\.get_role\("),


### PR DESCRIPTION
## Summary

Small follow-up to PR #61.  Completes the Phase D resolver surface by
adding the name-based member lookup that was missing, then migrates
the one site that was on the INV allow-list and tightens the gate to
catch that pattern going forward.

**New helper:**

```python
resolve_member_by_name(guild, name) → Member | None
```

Wraps `guild.get_member_named` (matches against `Member.name`, the
user's nickname, and `Member.global_name`).  Distinct from
`resolve_member`, which takes an id — use this when the caller has a
free-form string from user input.  Returns `None` on empty input or
no match.

## Changes

| File | What |
|---|---|
| `disbot/core/runtime/guild_resources.py` | `resolve_member_by_name` added + public-surface docstring updated |
| `disbot/cogs/rps_tournament/_bot_matches.py` | one site migrated (bot-match player resolution from string args) |
| `tests/unit/runtime/test_guild_resources.py` | 3 new tests (`TestResolveMemberByName`): found, missing, empty-string short-circuit |
| `tests/unit/runtime/test_guild_resources_invariant.py` | `guild.get_member_named` added to forbidden patterns, `_bot_matches.py` removed from allow-list |

**Allow-list reduced to two entries**: `guild_resources.py` (the
canonical site) and `utils/channels.py` (creation helper; importing
core/runtime would be a layer reversal).

## Test plan

### 1. Static gates

- [ ] `ruff check`, `black --check`, `isort --check-only`, `mypy disbot/` → all clean

### 2. Unit tests

- [ ] `pytest tests/` → **918 / 918 pass** (+3 new vs. PR #61 baseline of 915)
- [ ] `pytest tests/unit/runtime/test_guild_resources.py::TestResolveMemberByName -v` → 3 pass

### 3. INV gate negative test

Verify the gate now catches `get_member_named`:

```bash
echo "    _ = guild.get_member_named('x')" >> disbot/cogs/admin_cog.py
pytest tests/unit/runtime/test_guild_resources_invariant.py -v
# Expected: FAIL with "guild.get_member_named — use resources.resolve_member_by_name"
git checkout -- disbot/cogs/admin_cog.py
```

Verified locally — gate fails as expected, then passes after revert.

### 4. Functional smoke

The migrated site is the bot-match player resolution in
`cogs/rps_tournament/_bot_matches.py`.  It only fires when the bot is
started with explicit string args (members/roles from `!rps_bot` or
similar):

- [ ] `!rps_bot @SomeMember rps3` → bot match starts (Member object path, unchanged)
- [ ] `!rps_bot SomeUsername rps3` → string arg resolves to the named member, bot match starts (the migrated path)
- [ ] `!rps_bot NonexistentName rps3` → name doesn't resolve, that arg silently dropped (same as previous behavior)

## Why a separate PR

PR #61 deliberately left this one site on the allow-list because
adding `resolve_member_by_name` is a small surface change distinct
from the bulk migration.  Splitting it out keeps each diff focused
and reviewable.

https://claude.ai/code/session_01FuuCnXTg7FWygNZN5T2DKB

---
_Generated by [Claude Code](https://claude.ai/code/session_01FuuCnXTg7FWygNZN5T2DKB)_