### PR TITLE
§3.2 message_pipeline foundation + xp migration

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -555,8 +555,10 @@ async def main() -> None:
 
     await db.init()
     from core import runtime
+    from core.runtime import message_pipeline
 
     await runtime.setup()
+    message_pipeline.setup(bot)
     if reporter:
         await reporter.start()
     try:

--- a/disbot/cogs/xp/stage.py
+++ b/disbot/cogs/xp/stage.py
@@ -1,0 +1,43 @@
+"""XP MessageStage — §3.2 migration of xp_cog.on_message.
+
+Wraps the existing ``cogs.xp.listener.handle_message`` body as a
+:class:`core.runtime.message_pipeline.MessageStage`.  The cog
+registers an instance of this class in ``cog_load`` and unregisters
+on ``cog_unload`` so hot reloads remain clean.
+
+Order: 20.  Per the plan §3.2, XP runs in the *rewards* tier (after
+*moderation* at order=10).  This means once auto-mod stages migrate,
+XP will no longer reward a message that was deleted by an upstream
+stage in the same dispatch — that's the intended behavior shift.
+
+In this PR only XP has migrated, so order=20 has no other neighbors;
+the value is set per the plan so future migrations slot in without
+re-numbering.
+"""
+
+from __future__ import annotations
+
+from core.runtime.message_pipeline import (
+    MessagePipelineContext,
+    StageResult,
+)
+
+XP_STAGE_NAME = "xp"
+XP_STAGE_ORDER = 20
+
+
+class XpStage:
+    """Awards XP for non-bot guild messages.
+
+    No deletion, no short-circuit, no moderation_action — XP is a
+    pure reward stage.
+    """
+
+    name = XP_STAGE_NAME
+    order = XP_STAGE_ORDER
+
+    async def process(self, ctx: MessagePipelineContext) -> StageResult:
+        from cogs.xp.listener import handle_message
+
+        await handle_message(ctx.bot, ctx.message)
+        return StageResult()

--- a/disbot/cogs/xp_cog.py
+++ b/disbot/cogs/xp_cog.py
@@ -21,6 +21,18 @@ class XpCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
 
+    async def cog_load(self) -> None:
+        from cogs.xp.stage import XpStage
+        from core.runtime import message_pipeline
+
+        message_pipeline.register(XpStage())
+
+    async def cog_unload(self) -> None:
+        from cogs.xp.stage import XP_STAGE_NAME
+        from core.runtime import message_pipeline
+
+        message_pipeline.unregister(XP_STAGE_NAME)
+
     @commands.command(name="xpmenu")
     async def xp_menu(self, ctx: commands.Context):
         """Open the XP panel showing your rank and quick admin actions."""
@@ -36,15 +48,6 @@ class XpCog(commands.Cog):
         view = _XpHubView(help_ctx_shim(interaction))
         embed = await view.build_embed()
         return embed, view
-
-    # ------------------------------------------------------------------ events
-
-    @commands.Cog.listener()
-    async def on_message(self, message: discord.Message):
-        # S4.2: handler body lives in cogs/xp/listener.py per F-3 convention.
-        from cogs.xp.listener import handle_message
-
-        await handle_message(self.bot, message)
 
     # ------------------------------------------------------------------ commands
 

--- a/disbot/core/runtime/__init__.py
+++ b/disbot/core/runtime/__init__.py
@@ -13,6 +13,8 @@ Public aliases:
     nav          — navigation_stack module
     surfaces     — ephemeral_surface_manager module
     scheduler    — live_update_scheduler module
+    pipeline     — message_pipeline module (§3.2 — single platform
+                   on_message orchestrator)
     tasks        — managed background-task helper (see CRIT-1 fix)
     interaction  — safe_defer / safe_followup / safe_edit (see CRIT-2 fix)
     guild_config — F-1 cached-config primitive (Phase S1.1) — use the
@@ -42,6 +44,7 @@ from core.runtime import interaction_helpers as interaction  # noqa: F401 — re
 from core.runtime import interaction_router as router  # noqa: F401 — re-exported
 from core.runtime import live_update_scheduler as scheduler  # noqa: F401 — re-exported
 from core.runtime import message_anchor_manager as anchors  # noqa: F401 — re-exported
+from core.runtime import message_pipeline as pipeline  # noqa: F401 — re-exported
 from core.runtime import navigation_stack as nav  # noqa: F401 — re-exported
 from core.runtime import panel_manager as panels  # noqa: F401 — re-exported
 from core.runtime import session_gc as gc  # noqa: F401 — re-exported

--- a/disbot/core/runtime/message_pipeline.py
+++ b/disbot/core/runtime/message_pipeline.py
@@ -1,0 +1,301 @@
+"""Message-pipeline orchestrator — §3.2 of the foundational plan.
+
+Provides a single platform-level ``on_message`` that dispatches to
+registered :class:`MessageStage` handlers in defined order, with
+error isolation, latency metrics, and a routing hook for auto-mod
+stages to emit through ``moderation_service``.
+
+The previous architecture had five concurrent ``on_message``
+listeners (counting, chain, cleanup, xp, rps_tournament) racing on
+every message: XP could award before CleanupCog deleted, ChainCog
+could delete a message CountingCog was mid-validating.  The
+pipeline fixes that by running stages sequentially in ``order`` and
+honouring ``short_circuit`` on early termination.
+
+Stage contract (Protocol)
+-------------------------
+
+::
+
+    class MessageStage(Protocol):
+        name: str       # stable identifier (used as the metric label)
+        order: int      # smaller order runs first; ties run in
+                        # registration order
+
+        async def process(
+            self, ctx: MessagePipelineContext,
+        ) -> StageResult: ...
+
+Stages should be pure-Python objects (a dataclass or hand-rolled
+class).  The orchestrator never instantiates them — register an
+already-constructed instance via :func:`register`.
+
+Built-in pre-filter
+-------------------
+
+The orchestrator drops two categories of messages before any stage
+runs:
+
+  - ``message.author.bot`` is True (bot-emitted messages)
+  - ``message.guild`` is ``None`` (DMs)
+
+Stages can therefore assume a guild-bound, non-bot author.
+
+Error isolation
+---------------
+
+An exception raised by ``stage.process`` is logged with the stage
+name + message id and the pipeline continues to the next stage.  A
+stage cannot crash the platform listener.
+
+Latency metrics
+---------------
+
+``message_pipeline_stage_seconds{stage=...}`` (Prometheus Histogram)
+records per-stage ``process`` time including any I/O the stage did.
+The metric is emitted in a ``finally`` clause so exceptions still
+contribute a measurement.
+
+Moderation routing
+------------------
+
+When a stage returns ``StageResult(moderation_action=...)`` the
+orchestrator calls :func:`_route_moderation_action`.  This is a
+plumbing hook — no current consumer.  When the first auto-mod
+stage migrates (CleanupCog / ChainCog / CountingCog), this function
+will route to ``moderation_service.auto_delete`` (or equivalent) to
+record the action in ``mod_logs`` + emit ``EVT_MOD_ACTION``.
+
+Public surface
+--------------
+
+::
+
+    register(stage)         — add a stage (deduplicates by name)
+    unregister(name)        — remove a stage by name
+    clear()                 — test-only: drop all stages
+    stages_snapshot()       — defensive copy of current stages
+    setup(bot)              — install the platform listener (idempotent)
+    dispatch(bot, message)  — orchestrator (exposed for unit tests)
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+import discord
+from discord.ext import commands
+
+from services import metrics
+
+logger = logging.getLogger("bot.runtime.message_pipeline")
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ModerationActionDescriptor:
+    """Describes an auto-mod action for unified audit.
+
+    The originating stage has already performed the action (e.g.
+    deleted the message); the descriptor tells the orchestrator to
+    log + emit it through ``moderation_service``.
+
+    Plumbing only in this PR — no current consumer.  Future auto-mod
+    stage migrations (counting / chain / cleanup) will return a
+    populated descriptor and the routing hook will dispatch it.
+    """
+
+    action: str  # e.g. "auto_delete:counting"
+    target_id: int  # message author id
+    reason: str  # human-readable
+    rule: str = ""  # optional machine-readable rule id
+
+
+@dataclass
+class MessagePipelineContext:
+    """Per-message context threaded through every stage.
+
+    ``metadata`` is mutable scratch — stages can stash derived state
+    (parsed command context, expensive lookups) under stable keys
+    so downstream stages avoid re-computation.
+    """
+
+    bot: commands.Bot
+    message: discord.Message
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class StageResult:
+    """Stage return value.
+
+    Fields:
+        deleted: stage deleted the message.  Advisory — set
+                 ``short_circuit=True`` if downstream stages should
+                 skip.  (We keep them separate so a stage can delete
+                 *and* let downstream observability stages still run
+                 if appropriate.)
+        short_circuit: stop the pipeline; no downstream stages run.
+        moderation_action: when non-None, the orchestrator routes
+                 this descriptor through ``moderation_service`` for
+                 unified audit.  Currently a no-op hook (see plan
+                 §3.2 — wired up by future auto-mod migrations).
+    """
+
+    deleted: bool = False
+    short_circuit: bool = False
+    moderation_action: ModerationActionDescriptor | None = None
+
+
+@runtime_checkable
+class MessageStage(Protocol):
+    """Protocol every stage must satisfy.
+
+    A stage's ``name`` is its stable identifier — used as the
+    Prometheus label and as the dedup key for :func:`register`.
+    """
+
+    name: str
+    order: int
+
+    async def process(self, ctx: MessagePipelineContext) -> StageResult: ...
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+_STAGES: list[MessageStage] = []
+
+
+def register(stage: MessageStage) -> None:
+    """Register a stage; deduplicates by name.
+
+    A subsequent ``register`` with the same ``name`` replaces the
+    earlier entry — this makes cog reload safe (the old stage is
+    dropped and the new instance takes its place).  Stages are
+    re-sorted by ``order`` on every registration so :func:`dispatch`
+    can iterate in run order without re-sorting per message.
+    """
+    global _STAGES
+    _STAGES = [s for s in _STAGES if s.name != stage.name]
+    _STAGES.append(stage)
+    _STAGES.sort(key=lambda s: s.order)
+    logger.debug("Registered stage %r (order=%d)", stage.name, stage.order)
+
+
+def unregister(name: str) -> None:
+    """Remove a stage by name.  No-op if not registered."""
+    global _STAGES
+    _STAGES = [s for s in _STAGES if s.name != name]
+
+
+def clear() -> None:
+    """Test-only: drop all registered stages."""
+    global _STAGES
+    _STAGES = []
+
+
+def stages_snapshot() -> list[MessageStage]:
+    """Return a defensive copy of the current stages in run order."""
+    return list(_STAGES)
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+async def dispatch(bot: commands.Bot, message: discord.Message) -> None:
+    """Run every registered stage for one message, in order.
+
+    See module docstring for the pre-filter rules, error-isolation
+    semantics, and moderation-routing hook.
+    """
+    if message.author.bot:
+        return
+    if message.guild is None:
+        return
+
+    ctx = MessagePipelineContext(bot=bot, message=message)
+    for stage in _STAGES:
+        t0 = time.perf_counter()
+        result: StageResult | None = None
+        try:
+            result = await stage.process(ctx)
+        except Exception:
+            logger.exception(
+                "message pipeline stage %r raised on message %s",
+                stage.name,
+                message.id,
+            )
+        finally:
+            metrics.message_pipeline_stage_seconds.labels(
+                stage=stage.name,
+            ).observe(time.perf_counter() - t0)
+
+        if result is None:
+            # Stage raised — error already logged.  Continue to next.
+            continue
+
+        if result.moderation_action is not None:
+            _route_moderation_action(message, result.moderation_action)
+
+        if result.short_circuit:
+            return
+
+
+def _route_moderation_action(
+    message: discord.Message,
+    action: ModerationActionDescriptor,
+) -> None:
+    """Route an auto-mod descriptor to ``moderation_service``.
+
+    Plumbing only in this PR.  Future auto-mod migrations will
+    extend ``moderation_service`` with an ``auto_delete`` function
+    and this hook will call it, so the audit + EVT_MOD_ACTION emit
+    happens through one path regardless of which stage detected the
+    rule violation.
+    """
+    logger.warning(
+        "ModerationActionDescriptor returned but routing not yet implemented: "
+        "action=%s target=%d reason=%r message=%d",
+        action.action,
+        action.target_id,
+        action.reason,
+        message.id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Wire-up
+# ---------------------------------------------------------------------------
+
+_PLATFORM_LISTENER_INSTALLED = False
+
+
+def setup(bot: commands.Bot) -> None:
+    """Install the platform-level ``on_message`` listener.  Idempotent.
+
+    Call once during bot startup, before ``bot.start()``.  Subsequent
+    calls are no-ops — discord.py's ``bot.listen`` would otherwise
+    register duplicate handlers on hot-reload.
+    """
+    global _PLATFORM_LISTENER_INSTALLED
+    if _PLATFORM_LISTENER_INSTALLED:
+        logger.debug("message_pipeline.setup() called again — skipping.")
+        return
+    _PLATFORM_LISTENER_INSTALLED = True
+
+    @bot.listen("on_message")
+    async def _platform_on_message(message: discord.Message) -> None:
+        await dispatch(bot, message)
+
+    logger.info("message_pipeline platform listener installed.")

--- a/disbot/services/metrics.py
+++ b/disbot/services/metrics.py
@@ -236,6 +236,15 @@ interaction_handler_seconds = Histogram(
     buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0),
 )
 
+message_pipeline_stage_seconds = Histogram(
+    "message_pipeline_stage_seconds",
+    "Per-stage process() time inside the core/runtime/message_pipeline "
+    "orchestrator (§3.2).  One observation per (stage, message) pair "
+    "regardless of stage outcome.",
+    ["stage"],
+    buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0),
+)
+
 # ---------------------------------------------------------------------------
 # Process memory RSS — Phase S3.3 / O-4
 # Sampled every PROCESS_MEMORY_SAMPLE_INTERVAL seconds by a supervised

--- a/tests/unit/cogs/test_xp_cog_admin_routes.py
+++ b/tests/unit/cogs/test_xp_cog_admin_routes.py
@@ -211,12 +211,18 @@ async def test_resetxp_command_calls_xp_service_reset():
 
 
 @pytest.mark.asyncio
-async def test_on_message_routes_through_xp_service():
-    """The on_message hot path must call xp_service.award (PR-4)."""
-    from cogs.xp_cog import XpCog
+async def test_handle_message_routes_through_xp_service():
+    """The XP listener hot path must call xp_service.award (PR-4).
+
+    Post-§3.2 the cog's on_message no longer exists — the platform-level
+    message_pipeline orchestrator invokes XpStage.process, which calls
+    handle_message.  This test exercises handle_message directly, which
+    is what the stage wraps.
+    """
+    from cogs.xp.listener import handle_message
     from utils.guild_config_accessors import XpConfig
 
-    cog = XpCog(bot=MagicMock())
+    bot = MagicMock()
 
     message = MagicMock()
     message.author = MagicMock()
@@ -253,7 +259,7 @@ async def test_on_message_routes_through_xp_service():
             return_value=award_result,
         ) as award,
     ):
-        await cog.on_message(message)
+        await handle_message(bot, message)
 
     award.assert_awaited_once()
     call = award.await_args

--- a/tests/unit/cogs/test_xp_cog_caching.py
+++ b/tests/unit/cogs/test_xp_cog_caching.py
@@ -55,11 +55,17 @@ def _xp_settings_replies(get_setting: AsyncMock, *, min_=15, max_=25, cd=60, ann
 
 
 @pytest.mark.asyncio
-async def test_on_message_calls_db_get_setting_at_most_once_per_guild_over_a_window():
-    """Five rapid messages from the same guild → one cache fill, then hits."""
-    from cogs.xp_cog import XpCog
+async def test_handle_message_calls_db_get_setting_at_most_once_per_guild_over_a_window():
+    """Five rapid messages from the same guild → one cache fill, then hits.
 
-    cog = XpCog(bot=MagicMock())
+    Post-§3.2 the XP hot path is reached via the message_pipeline XpStage,
+    which is a thin wrapper over handle_message.  We exercise
+    handle_message directly here since the caching is a property of the
+    listener body, not the cog/stage wrapper.
+    """
+    from cogs.xp.listener import handle_message
+
+    bot = MagicMock()
     message = _make_message()
     db_row = {"last_xp": 0, "messages": 1}
 
@@ -75,7 +81,7 @@ async def test_on_message_calls_db_get_setting_at_most_once_per_guild_over_a_win
     ):
         _xp_settings_replies(get_setting)
         for _ in range(5):
-            await cog.on_message(message)
+            await handle_message(bot, message)
 
     # Cache fill reads each of 4 keys exactly once on the first message;
     # subsequent 4 messages all hit the cache → no further DB reads.
@@ -83,11 +89,11 @@ async def test_on_message_calls_db_get_setting_at_most_once_per_guild_over_a_win
 
 
 @pytest.mark.asyncio
-async def test_on_message_caches_per_guild_independently():
+async def test_handle_message_caches_per_guild_independently():
     """Two guilds → 8 DB reads (4 per guild), not 4 (no cross-guild collision)."""
-    from cogs.xp_cog import XpCog
+    from cogs.xp.listener import handle_message
 
-    cog = XpCog(bot=MagicMock())
+    bot = MagicMock()
     db_row = {"last_xp": 0, "messages": 1}
 
     with (
@@ -101,10 +107,10 @@ async def test_on_message_caches_per_guild_independently():
         patch("cogs.xp.listener.check_cooldown", return_value=(True, 0)),
     ):
         _xp_settings_replies(get_setting)
-        await cog.on_message(_make_message(guild_id=1))
-        await cog.on_message(_make_message(guild_id=2))
-        await cog.on_message(_make_message(guild_id=1))  # cached
-        await cog.on_message(_make_message(guild_id=2))  # cached
+        await handle_message(bot, _make_message(guild_id=1))
+        await handle_message(bot, _make_message(guild_id=2))
+        await handle_message(bot, _make_message(guild_id=1))  # cached
+        await handle_message(bot, _make_message(guild_id=2))  # cached
 
     assert get_setting.await_count == 8  # 4 per guild × 2 guilds
 

--- a/tests/unit/runtime/test_message_pipeline.py
+++ b/tests/unit/runtime/test_message_pipeline.py
@@ -1,0 +1,301 @@
+"""Tests for core.runtime.message_pipeline (§3.2).
+
+Covers the orchestrator contract:
+
+  - register / unregister / clear (de-dup by name, sort by order)
+  - pre-filter (bot author, no-guild) short-circuits before stages run
+  - stages run sequentially in `order` (smaller first)
+  - short_circuit stops the pipeline
+  - exception in a stage is logged + isolated (downstream stages run)
+  - moderation_action triggers the routing hook
+  - latency metric is observed per (stage, message) regardless of outcome
+  - setup(bot) is idempotent
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from core.runtime import message_pipeline
+from core.runtime.message_pipeline import (
+    MessagePipelineContext,
+    ModerationActionDescriptor,
+    StageResult,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_message(*, is_bot: bool = False, has_guild: bool = True):
+    msg = SimpleNamespace()
+    msg.id = 12345
+    msg.author = SimpleNamespace(bot=is_bot)
+    msg.guild = SimpleNamespace(id=1) if has_guild else None
+    return msg
+
+
+@dataclass
+class _SpyStage:
+    """Hand-rolled stage that records calls + returns a configurable result."""
+
+    name: str
+    order: int
+    result: StageResult = field(default_factory=StageResult)
+    raises: BaseException | None = None
+    calls: list[MessagePipelineContext] = field(default_factory=list)
+
+    async def process(self, ctx: MessagePipelineContext) -> StageResult:
+        self.calls.append(ctx)
+        if self.raises is not None:
+            raise self.raises
+        return self.result
+
+
+@pytest.fixture(autouse=True)
+def _reset_pipeline_state():
+    """Reset module-level state between every test."""
+    message_pipeline.clear()
+    # Also reset the setup() idempotency flag so tests can rebind freely.
+    message_pipeline._PLATFORM_LISTENER_INSTALLED = False
+    yield
+    message_pipeline.clear()
+    message_pipeline._PLATFORM_LISTENER_INSTALLED = False
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_register_appends(self):
+        s = _SpyStage(name="a", order=10)
+        message_pipeline.register(s)
+        assert message_pipeline.stages_snapshot() == [s]
+
+    def test_register_dedupes_by_name(self):
+        s1 = _SpyStage(name="a", order=10)
+        s2 = _SpyStage(name="a", order=20)  # same name, new instance
+        message_pipeline.register(s1)
+        message_pipeline.register(s2)
+        assert message_pipeline.stages_snapshot() == [s2]
+
+    def test_register_sorts_by_order(self):
+        s30 = _SpyStage(name="rps", order=30)
+        s10 = _SpyStage(name="mod", order=10)
+        s20 = _SpyStage(name="xp", order=20)
+        message_pipeline.register(s30)
+        message_pipeline.register(s10)
+        message_pipeline.register(s20)
+        assert [s.name for s in message_pipeline.stages_snapshot()] == [
+            "mod",
+            "xp",
+            "rps",
+        ]
+
+    def test_unregister_removes(self):
+        s = _SpyStage(name="a", order=10)
+        message_pipeline.register(s)
+        message_pipeline.unregister("a")
+        assert message_pipeline.stages_snapshot() == []
+
+    def test_unregister_missing_is_noop(self):
+        message_pipeline.unregister("does-not-exist")  # no raise
+
+    def test_clear_drops_all(self):
+        message_pipeline.register(_SpyStage(name="a", order=10))
+        message_pipeline.register(_SpyStage(name="b", order=20))
+        message_pipeline.clear()
+        assert message_pipeline.stages_snapshot() == []
+
+
+# ---------------------------------------------------------------------------
+# Pre-filter
+# ---------------------------------------------------------------------------
+
+
+class TestPreFilter:
+    @pytest.mark.asyncio
+    async def test_bot_author_short_circuits(self):
+        s = _SpyStage(name="x", order=10)
+        message_pipeline.register(s)
+        await message_pipeline.dispatch(MagicMock(), _make_message(is_bot=True))
+        assert s.calls == []
+
+    @pytest.mark.asyncio
+    async def test_no_guild_short_circuits(self):
+        s = _SpyStage(name="x", order=10)
+        message_pipeline.register(s)
+        await message_pipeline.dispatch(MagicMock(), _make_message(has_guild=False))
+        assert s.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Stage iteration
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchOrdering:
+    @pytest.mark.asyncio
+    async def test_stages_run_in_order_smaller_first(self):
+        order_log: list[str] = []
+
+        @dataclass
+        class _Recorder:
+            name: str
+            order: int
+
+            async def process(self, ctx):
+                order_log.append(self.name)
+                return StageResult()
+
+        message_pipeline.register(_Recorder("c", 30))
+        message_pipeline.register(_Recorder("a", 10))
+        message_pipeline.register(_Recorder("b", 20))
+
+        await message_pipeline.dispatch(MagicMock(), _make_message())
+        assert order_log == ["a", "b", "c"]
+
+    @pytest.mark.asyncio
+    async def test_short_circuit_stops_downstream(self):
+        s10 = _SpyStage(name="a", order=10, result=StageResult(short_circuit=True))
+        s20 = _SpyStage(name="b", order=20)
+        message_pipeline.register(s10)
+        message_pipeline.register(s20)
+
+        await message_pipeline.dispatch(MagicMock(), _make_message())
+        assert len(s10.calls) == 1
+        assert s20.calls == []
+
+    @pytest.mark.asyncio
+    async def test_exception_is_isolated(self):
+        s10 = _SpyStage(name="a", order=10, raises=RuntimeError("boom"))
+        s20 = _SpyStage(name="b", order=20)
+        message_pipeline.register(s10)
+        message_pipeline.register(s20)
+
+        await message_pipeline.dispatch(MagicMock(), _make_message())
+        # Downstream stage still ran despite upstream raising.
+        assert len(s20.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_context_is_shared_across_stages(self):
+        seen_metadata: list[dict] = []
+
+        @dataclass
+        class _A:
+            name: str = "a"
+            order: int = 10
+
+            async def process(self, ctx):
+                ctx.metadata["from_a"] = "hello"
+                return StageResult()
+
+        @dataclass
+        class _B:
+            name: str = "b"
+            order: int = 20
+
+            async def process(self, ctx):
+                seen_metadata.append(dict(ctx.metadata))
+                return StageResult()
+
+        message_pipeline.register(_A())
+        message_pipeline.register(_B())
+        await message_pipeline.dispatch(MagicMock(), _make_message())
+        assert seen_metadata == [{"from_a": "hello"}]
+
+
+# ---------------------------------------------------------------------------
+# Moderation routing
+# ---------------------------------------------------------------------------
+
+
+class TestModerationRouting:
+    @pytest.mark.asyncio
+    async def test_moderation_action_triggers_hook(self):
+        desc = ModerationActionDescriptor(
+            action="auto_delete:test",
+            target_id=42,
+            reason="rule X",
+        )
+        s = _SpyStage(name="a", order=10, result=StageResult(moderation_action=desc))
+        message_pipeline.register(s)
+
+        with patch.object(
+            message_pipeline,
+            "_route_moderation_action",
+        ) as hook:
+            await message_pipeline.dispatch(MagicMock(), _make_message())
+        hook.assert_called_once()
+        # First arg is the message, second is the descriptor.
+        assert hook.call_args.args[1] is desc
+
+    @pytest.mark.asyncio
+    async def test_no_moderation_action_skips_hook(self):
+        s = _SpyStage(name="a", order=10)  # default result, no moderation_action
+        message_pipeline.register(s)
+
+        with patch.object(
+            message_pipeline,
+            "_route_moderation_action",
+        ) as hook:
+            await message_pipeline.dispatch(MagicMock(), _make_message())
+        hook.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+
+class TestMetrics:
+    @pytest.mark.asyncio
+    async def test_latency_observed_per_stage(self):
+        s = _SpyStage(name="my_stage", order=10)
+        message_pipeline.register(s)
+
+        with patch(
+            "core.runtime.message_pipeline.metrics.message_pipeline_stage_seconds",
+        ) as hist:
+            await message_pipeline.dispatch(MagicMock(), _make_message())
+        hist.labels.assert_called_once_with(stage="my_stage")
+        hist.labels.return_value.observe.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_latency_observed_even_on_exception(self):
+        s = _SpyStage(name="my_stage", order=10, raises=RuntimeError("x"))
+        message_pipeline.register(s)
+
+        with patch(
+            "core.runtime.message_pipeline.metrics.message_pipeline_stage_seconds",
+        ) as hist:
+            await message_pipeline.dispatch(MagicMock(), _make_message())
+        hist.labels.return_value.observe.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# setup(bot)
+# ---------------------------------------------------------------------------
+
+
+class TestSetup:
+    def test_registers_listener(self):
+        bot = MagicMock()
+        bot.listen.return_value = lambda fn: fn  # decorator passthrough
+        message_pipeline.setup(bot)
+        bot.listen.assert_called_once_with("on_message")
+
+    def test_idempotent(self):
+        bot = MagicMock()
+        bot.listen.return_value = lambda fn: fn
+        message_pipeline.setup(bot)
+        message_pipeline.setup(bot)
+        # Second call should be a no-op — listener registered only once.
+        assert bot.listen.call_count == 1


### PR DESCRIPTION
## Summary

Lands the **§3.2** track from `docs/foundational-infrastructure-plan.md` —
one platform-level `on_message` that dispatches to registered
`MessageStage` handlers in defined order, with error isolation,
latency metrics, and a routing hook for auto-mod stages to emit
through `moderation_service`.

The previous architecture had **5 concurrent `on_message` listeners**
(counting, chain, cleanup, xp, rps_tournament) racing per message:
XP could award before CleanupCog deleted, ChainCog could delete a
message CountingCog was mid-validating. The pipeline fixes that by
running stages sequentially in `order` and honouring `short_circuit`
on early termination.

**Module:** `disbot/core/runtime/message_pipeline.py` (re-exported
as `core.runtime.pipeline`).

**Stage contract:**

```python
class MessageStage(Protocol):
    name: str       # stable identifier (used as metric label)
    order: int      # smaller order runs first

    async def process(self, ctx: MessagePipelineContext) -> StageResult: ...
```

**Pre-filter (built-in):** bot messages + DMs short-circuit before any
stage runs. Stages can assume a guild-bound, non-bot author.

**Error isolation:** an exception in any stage is logged with stage
name + message id; downstream stages continue. A stage cannot crash
the platform listener.

**Latency metric:** `message_pipeline_stage_seconds{stage=...}`
(Prometheus Histogram, 1ms→1s bucketed). Observed in a `finally`
so exceptions still contribute a measurement.

## What's in this PR

| File | What |
|---|---|
| `disbot/core/runtime/message_pipeline.py` | Module — Protocol, dataclasses, registry, orchestrator, `setup(bot)` |
| `disbot/core/runtime/__init__.py` | Re-export as `pipeline` + docstring update |
| `disbot/services/metrics.py` | New `message_pipeline_stage_seconds` histogram |
| `disbot/cogs/xp/stage.py` | `XpStage` (order=20) wrapping `cogs/xp/listener:handle_message` |
| `disbot/cogs/xp_cog.py` | Remove `on_message` listener; `cog_load`/`cog_unload` register/unregister `XpStage` |
| `disbot/bot1.py` | Call `message_pipeline.setup(bot)` right after `runtime.setup()` |
| `tests/unit/runtime/test_message_pipeline.py` | 18 unit tests covering registry, pre-filter, ordering, short-circuit, error isolation, moderation hook, metric, setup idempotency |
| `tests/unit/cogs/test_xp_cog_caching.py` | 2 tests updated to call `handle_message` directly (was `cog.on_message`) |
| `tests/unit/cogs/test_xp_cog_admin_routes.py` | 1 test updated similarly |

**Behavior shift in this PR: none observable.** Only xp has migrated,
so the order=20 slot has no neighbors. The reordering benefit kicks
in when auto-mod stages migrate in follow-up PRs.

**Plumbing-only:** `StageResult.moderation_action` is wired through
the orchestrator and the `_route_moderation_action` hook exists, but
no current stage returns a non-None descriptor. Future auto-mod
migrations will populate it; the hook will be extended to call a new
`moderation_service.auto_delete` so deletions land in `mod_logs` +
emit `EVT_MOD_ACTION` through one path.

## Test plan

### 1. Static gates

- [ ] `ruff check . --exclude .github,tests,venv,env,build,dist` → 0 errors
- [ ] `black --check . --exclude '(\.github|tests|venv|env|build|dist)'` → 185 files unchanged
- [ ] `isort --check-only . --skip-glob '*/(\.github|tests|venv|env|build|dist)/*'` → clean
- [ ] `mypy disbot/` → 0 issues, 185 source files

### 2. Unit tests

- [ ] `pytest tests/` → **933 / 933 pass** (+18 new, 3 existing reworked)
- [ ] `pytest tests/unit/runtime/test_message_pipeline.py -v` → 18 pass covering:
  - `TestRegistry` × 6 — append, dedup by name, sort by order, unregister, unregister-missing-noop, clear
  - `TestPreFilter` × 2 — bot author short-circuits, no-guild short-circuits
  - `TestDispatchOrdering` × 4 — smaller order first, short-circuit stops downstream, exception isolation, context shared via metadata
  - `TestModerationRouting` × 2 — non-None descriptor triggers hook, None doesn't
  - `TestMetrics` × 2 — latency observed per (stage, message), observed even when stage raises
  - `TestSetup` × 2 — registers listener, idempotent

### 3. Functional smoke (run against a dev guild)

#### XP via the pipeline

- [ ] Post a non-bot message in a guild channel → XP increments (visible via `!rank`)
- [ ] Cooldown still works — rapid messages don't multi-award
- [ ] Level-up still triggers the announce embed
- [ ] XP threshold-role grant still works (caching unchanged)
- [ ] Bot's own messages don't award XP (pre-filter)
- [ ] DM to the bot doesn't crash (pre-filter)

#### Other cogs unaffected

- [ ] Counting still validates counts in active channels
- [ ] Cleanup still removes prohibited content
- [ ] Chain still enforces chain rules
- [ ] RPS tournament still captures moves in match channels

(These 4 still use their own `on_message` listeners — that's intentional,
they migrate one at a time in follow-up PRs.)

#### Metrics

- [ ] `curl <prometheus-endpoint>/metrics | grep message_pipeline_stage_seconds` → returns histogram with `stage="xp"` labels after some traffic

### 4. Pipeline-listener wiring

- [ ] Bot boots cleanly (no `ImportError`, no `AttributeError`)
- [ ] Log line "message_pipeline platform listener installed." appears at startup
- [ ] `XpStage` registers on cog load (debug log "Registered stage 'xp' (order=20)")
- [ ] Hot-reload `cogs.xp_cog` → re-registration replaces the existing stage by name; no duplicates in the snapshot

### 5. Error-isolation smoke

If you want to manually verify isolation:

```python
# In a Python shell with bot context loaded
from core.runtime import message_pipeline as mp

class _BoomStage:
    name = "boom"
    order = 5  # before xp
    async def process(self, ctx):
        raise RuntimeError("intentional")

mp.register(_BoomStage())
# Post a message — XP should still be awarded despite the upstream raise.
# Log line: "message pipeline stage 'boom' raised on message ..."
mp.unregister("boom")
```

## Not in scope (follow-up PRs, one cog each)

These migrations land separately because each has distinct semantics
and a real behavior shift to discuss in its own PR:

- `counting_cog`  → `CountingStage`  (order=10, may short_circuit on delete)
- `chain_cog`     → `ChainStage`     (order=10, may short_circuit on delete)
- `cleanup_cog`   → `CleanupStage`   (order=10, may short_circuit on delete)
- `rps_tournament_cog` → `RpsTournamentStage` (order=30, game-input only fires in tournament channels)
- `moderation_service.auto_delete` + wiring to `_route_moderation_action`
- INV gate forbidding `@commands.Cog.listener() on_message` outside
  `message_pipeline.py` (deferred until all 5 cogs are migrated)

## Why this is foundation + 1 migration

The plan describes a clean 5-cog migration. Doing all five in one PR
would mix five distinct behavior shifts in one diff — each cog has
its own pattern (counting holds per-channel locks, chain checks
command context, rps_tournament is channel-scoped). Splitting them
keeps each PR's behavior comparison tractable while the foundation
proves the orchestrator works end-to-end against the simplest
migration target (xp was already pre-extracted into a thin handler).

https://claude.ai/code/session_01FuuCnXTg7FWygNZN5T2DKB

---
_Generated by [Claude Code](https://claude.ai/code/session_01FuuCnXTg7FWygNZN5T2DKB)_