### PR TITLE
§3.2 migration 2: cleanup_cog + moderation_service.auto_delete

### DIFF
--- a/disbot/cogs/cleanup_cog.py
+++ b/disbot/cogs/cleanup_cog.py
@@ -9,11 +9,18 @@ from discord.ext import commands
 
 import config as _config
 from core.runtime.interaction_helpers import help_ctx_shim, safe_defer
-from services import governance_service
+from core.runtime.message_pipeline import (
+    MessagePipelineContext,
+    StageResult,
+)
+from services import governance_service, moderation_service
 from services.governance_service import GovernanceContext
 from utils import db
 from utils.ui_constants import ADMIN_COLOR
 from views.base import HubView, send_panel
+
+CLEANUP_STAGE_NAME = "cleanup"
+CLEANUP_STAGE_ORDER = 10  # moderation tier per plan §3.2
 
 
 def _extract_command_name(content: str, prefixes: list[str]) -> str | None:
@@ -27,6 +34,31 @@ def _extract_command_name(content: str, prefixes: list[str]) -> str | None:
             )
             return rest.lower() if rest else None
     return None
+
+
+class CleanupStage:
+    """Message-pipeline stage wrapping the existing remove_unwanted_message logic.
+
+    Auto-mod tier (order=10).  Short-circuits the pipeline when a deletion
+    happens so downstream stages (XP reward, RPS input) skip a message
+    that's already been removed.
+
+    The stage holds a reference to the cog because the auto-mod rules
+    depend on per-cog state (compiled command pattern, whitelisted
+    channels, per-guild prohibited-word caches).
+    """
+
+    name = CLEANUP_STAGE_NAME
+    order = CLEANUP_STAGE_ORDER
+
+    def __init__(self, cog: Cleanup):
+        self.cog = cog
+
+    async def process(self, ctx: MessagePipelineContext) -> StageResult:
+        deleted = await self.cog.remove_unwanted_message(ctx.message)
+        if deleted:
+            return StageResult(deleted=True, short_circuit=True)
+        return StageResult()
 
 
 class Cleanup(commands.Cog):
@@ -46,6 +78,16 @@ class Cleanup(commands.Cog):
 
         self.whitelisted_channels = _config.CLEANUP_WHITELIST_CHANNELS
 
+    async def cog_load(self) -> None:
+        from core.runtime import message_pipeline
+
+        message_pipeline.register(CleanupStage(self))
+
+    async def cog_unload(self) -> None:
+        from core.runtime import message_pipeline
+
+        message_pipeline.unregister(CLEANUP_STAGE_NAME)
+
     async def _load_guild(self, guild_id: int) -> None:
         words = await db.get_prohibited_words(guild_id)
         self._word_cache[guild_id] = words
@@ -59,7 +101,13 @@ class Cleanup(commands.Cog):
         return self._pattern_cache[guild_id]
 
     async def remove_unwanted_message(self, message):
-        """Delete message if it is a command in a governed channel or contains prohibited content."""
+        """Delete message if it is a command in a governed channel or contains prohibited content.
+
+        Deletions route through :func:`moderation_service.auto_delete` so the
+        ``mod_logs`` audit table and ``EVT_MOD_ACTION`` event bus see every
+        auto-mod removal — closing the gap §2.2 of the plan called out
+        (CleanupCog deletes were previously invisible to moderation audit).
+        """
         if message.author.bot:
             return False
 
@@ -76,50 +124,50 @@ class Cleanup(commands.Cog):
                     command_name,
                 )
                 if not policy.allowed:
-                    try:
-                        if policy.cleanup.delete_message:
-                            await message.delete()
-                            self.logger.info(
-                                "Deleted blocked command from %s: %s",
-                                message.author,
-                                message.content,
-                            )
-                        if policy.feedback:
+                    if policy.cleanup.delete_message:
+                        await moderation_service.auto_delete(
+                            message,
+                            reason=f"Blocked command: {command_name}",
+                            rule="cleanup.command_policy",
+                        )
+                    if policy.feedback:
+                        try:
                             warn = await message.channel.send(policy.feedback)
-                            await warn.delete(delay=policy.cleanup.delete_after_seconds)
-                    except discord.DiscordException as e:
-                        self.logger.error("Cleanup error: %s", e)
+                            await warn.delete(
+                                delay=policy.cleanup.delete_after_seconds,
+                            )
+                        except discord.DiscordException as e:
+                            self.logger.error("Cleanup feedback error: %s", e)
                     return True
                 return False
             # DM or unknown guild — fall back to whitelist behavior
             if message.channel.id not in self.whitelisted_channels:
-                try:
-                    await message.delete()
-                    self.logger.info(
-                        "Deleted command message from %s in non-whitelisted channel: %s",
-                        message.author,
-                        message.content,
-                    )
-                except discord.DiscordException as e:
-                    self.logger.error("Failed to delete command message: %s", e)
+                await moderation_service.auto_delete(
+                    message,
+                    reason="Command-style message in non-whitelisted channel",
+                    rule="cleanup.whitelist",
+                )
                 return True
             return False
 
         guild_id = message.guild.id if message.guild else 0
         for pattern in await self._get_patterns(guild_id):
             if pattern.search(message.content):
+                await moderation_service.auto_delete(
+                    message,
+                    reason="Prohibited word match",
+                    rule="cleanup.prohibited_words",
+                )
                 try:
-                    await message.delete()
                     warning_msg = await message.channel.send(
-                        f"A message from {message.author.mention} was deleted because it contained prohibited content.",
-                    )
-                    self.logger.info(
-                        f"Deleted message from {message.author}: {message.content}",
+                        f"A message from {message.author.mention} was deleted "
+                        "because it contained prohibited content.",
                     )
                     await warning_msg.delete(delay=10)
                 except discord.DiscordException as e:
                     self.logger.error(
-                        f"Failed to delete message from {message.author}: {e}",
+                        "Failed to post prohibited-word warning: %s",
+                        e,
                     )
                 return True
 
@@ -129,10 +177,6 @@ class Cleanup(commands.Cog):
     async def on_guild_remove(self, guild: discord.Guild) -> None:
         self._word_cache.pop(guild.id, None)
         self._pattern_cache.pop(guild.id, None)
-
-    @commands.Cog.listener()
-    async def on_message(self, message):
-        await self.remove_unwanted_message(message)
 
     @commands.command(name="cleanuphistory")
     @commands.has_permissions(manage_messages=True)

--- a/disbot/core/runtime/message_pipeline.py
+++ b/disbot/core/runtime/message_pipeline.py
@@ -60,11 +60,16 @@ Moderation routing
 ------------------
 
 When a stage returns ``StageResult(moderation_action=...)`` the
-orchestrator calls :func:`_route_moderation_action`.  This is a
-plumbing hook — no current consumer.  When the first auto-mod
-stage migrates (CleanupCog / ChainCog / CountingCog), this function
-will route to ``moderation_service.auto_delete`` (or equivalent) to
-record the action in ``mod_logs`` + emit ``EVT_MOD_ACTION``.
+orchestrator awaits :func:`_route_moderation_action`, which routes
+the descriptor to ``moderation_service.auto_delete``.  The stage may
+already have deleted the message itself — ``auto_delete`` catches
+the resulting ``NotFound`` and still records the rule trigger so the
+audit row exists either way.
+
+If a stage prefers the imperative form (call ``moderation_service``
+directly inside ``process``), that also works — see CleanupStage for
+an example.  Both paths land in the same ``mod_logs`` row + emit the
+same ``EVT_MOD_ACTION``.
 
 Public surface
 --------------
@@ -246,27 +251,41 @@ async def dispatch(bot: commands.Bot, message: discord.Message) -> None:
             continue
 
         if result.moderation_action is not None:
-            _route_moderation_action(message, result.moderation_action)
+            await _route_moderation_action(message, result.moderation_action)
 
         if result.short_circuit:
             return
 
 
-def _route_moderation_action(
+async def _route_moderation_action(
     message: discord.Message,
     action: ModerationActionDescriptor,
 ) -> None:
     """Route an auto-mod descriptor to ``moderation_service``.
 
-    Plumbing only in this PR.  Future auto-mod migrations will
-    extend ``moderation_service`` with an ``auto_delete`` function
-    and this hook will call it, so the audit + EVT_MOD_ACTION emit
-    happens through one path regardless of which stage detected the
-    rule violation.
+    The originating stage typically already deleted the message;
+    ``moderation_service.auto_delete`` catches the resulting
+    ``NotFound`` and still records the rule trigger so the audit
+    row exists either way.
+
+    Currently only ``"auto_delete:..."`` actions are recognised.
+    Future descriptor types (e.g. ``"auto_timeout:..."``) extend
+    this dispatch with the matching ``moderation_service`` call.
     """
+    from services import moderation_service
+
+    if action.action.startswith("auto_delete"):
+        await moderation_service.auto_delete(
+            message,
+            reason=action.reason,
+            rule=action.rule or action.action,
+        )
+        return
+
     logger.warning(
-        "ModerationActionDescriptor returned but routing not yet implemented: "
-        "action=%s target=%d reason=%r message=%d",
+        "ModerationActionDescriptor with unrecognised action=%r reached "
+        "_route_moderation_action — extend the dispatch when adding new "
+        "descriptor types.  target=%d reason=%r message=%d",
         action.action,
         action.target_id,
         action.reason,

--- a/disbot/services/moderation_service.py
+++ b/disbot/services/moderation_service.py
@@ -26,9 +26,14 @@ Public API
 - :func:`ban(guild, user, *, reason, actor_id)`           — guild ban
 - :func:`unban(guild, user, *, reason, actor_id)`         — guild unban
 - :func:`clear_warnings(guild_id, user_id, *, actor_id)`  — reset warnings
+- :func:`auto_delete(message, *, reason, rule, actor_id)` — rule-based
+                                                            auto-mod delete
+                                                            (§3.2 hook)
 
 All functions emit ``EVT_MOD_ACTION`` with the same payload shape so
-subscribers can dispatch on the ``action`` field.
+subscribers can dispatch on the ``action`` field.  Auto-mod deletions
+prefix their rule id under ``"auto_delete:<rule>"`` so dashboards can
+filter per-rule.
 
 Discord-API exceptions (``discord.Forbidden``, ``discord.HTTPException``)
 are NOT caught here — callers handle them, since the appropriate
@@ -202,3 +207,86 @@ async def clear_warnings(
         action="clear_warnings",
         reason=reason,
     )
+
+
+async def auto_delete(
+    message: discord.Message,
+    *,
+    reason: str,
+    rule: str,
+    actor_id: int | None = None,
+) -> bool:
+    """Auto-mod message deletion; log + emit event.
+
+    System-initiated counterpart to :func:`warn` / :func:`timeout` / etc.
+    The action is rule-based (e.g. blocked-command policy, prohibited-words
+    list, counting violation), not authorized by a moderator — pass
+    ``actor_id=None`` so the audit row records ``actor_id=0``.
+
+    Discord-API exceptions are caught here (unlike the other functions in
+    this module) because rule-based moderation has no useful error surface
+    to escalate to: a single failed delete shouldn't crash the message
+    pipeline or block subsequent stages.  The exception is logged with the
+    rule id for triage.
+
+    Args:
+        message: target Discord message (must be in a guild).
+        reason: short human-readable attribution string surfaced to the
+                audit dashboard (e.g. "prohibited word: <redacted>").
+        rule: machine-readable rule id (e.g. ``"cleanup.command_policy"``
+              or ``"cleanup.prohibited_words"``).  Stored as the suffix on
+              the ``action`` column so dashboards can filter per-rule:
+              ``action == "auto_delete:cleanup.prohibited_words"``.
+        actor_id: invoking user's id, or ``None`` for system-initiated.
+
+    Returns:
+        True if the delete succeeded (or the message was already gone, in
+        which case the rule trigger is still logged for audit completeness);
+        False on Forbidden / HTTPException.
+    """
+    if message.guild is None:
+        # Can't audit a DM delete — the schema is keyed on guild_id.
+        return False
+
+    composite_action = f"auto_delete:{rule}"
+
+    try:
+        await message.delete()
+    except discord.NotFound:
+        # Already deleted by another stage or out-of-band — still record
+        # the rule trigger so the audit row exists.
+        pass
+    except discord.Forbidden:
+        logger.warning(
+            "auto_delete: missing permission to delete message %d in guild %s "
+            "(rule=%s)",
+            message.id,
+            message.guild.name,
+            rule,
+        )
+        return False
+    except discord.HTTPException as exc:
+        logger.warning(
+            "auto_delete: HTTP error deleting message %d (rule=%s): %s",
+            message.id,
+            rule,
+            exc,
+        )
+        return False
+
+    await db.log_mod_action(
+        message.guild.id,
+        composite_action,
+        message.author.id,
+        actor_id or 0,
+        reason,
+    )
+    await bus.emit(
+        EVT_MOD_ACTION,
+        guild_id=message.guild.id,
+        target_id=message.author.id,
+        actor_id=actor_id,
+        action=composite_action,
+        reason=reason,
+    )
+    return True

--- a/tests/unit/cogs/test_cleanup_stage.py
+++ b/tests/unit/cogs/test_cleanup_stage.py
@@ -1,0 +1,169 @@
+"""Tests for the CleanupStage migration (§3.2).
+
+Covers the stage wrapper contract:
+  - delete returns short-circuit + deleted flags
+  - no-delete returns empty result
+  - underlying remove_unwanted_message routes through moderation_service.auto_delete
+    for the three rule paths (command policy, whitelist fallback, prohibited words)
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cogs.cleanup_cog import (
+    CLEANUP_STAGE_NAME,
+    CLEANUP_STAGE_ORDER,
+    Cleanup,
+    CleanupStage,
+)
+from core.runtime.message_pipeline import MessagePipelineContext
+
+
+def _make_cog():
+    """Construct a Cleanup cog with isolated caches and a stub command pattern."""
+    cog = Cleanup(bot=MagicMock())
+    # Fresh per-test caches — avoid cross-test bleed.
+    cog._word_cache = {}
+    cog._pattern_cache = {}
+    return cog
+
+
+def _make_message(*, content: str, guild_id: int = 99, channel_id: int = 1, author_id: int = 42):
+    msg = MagicMock()
+    msg.content = content
+    msg.id = 555
+    msg.guild = MagicMock()
+    msg.guild.id = guild_id
+    msg.guild.name = "test-guild"
+    msg.channel = MagicMock()
+    msg.channel.id = channel_id
+    msg.channel.send = AsyncMock()
+    msg.author = MagicMock()
+    msg.author.id = author_id
+    msg.author.bot = False
+    msg.author.mention = f"<@{author_id}>"
+    return msg
+
+
+class TestStageContract:
+    def test_metadata(self):
+        cog = _make_cog()
+        stage = CleanupStage(cog)
+        assert stage.name == CLEANUP_STAGE_NAME == "cleanup"
+        assert stage.order == CLEANUP_STAGE_ORDER == 10
+
+    @pytest.mark.asyncio
+    async def test_delete_short_circuits(self):
+        cog = _make_cog()
+        cog.remove_unwanted_message = AsyncMock(return_value=True)
+        stage = CleanupStage(cog)
+        ctx = MessagePipelineContext(bot=MagicMock(), message=MagicMock())
+        result = await stage.process(ctx)
+        assert result.deleted is True
+        assert result.short_circuit is True
+        assert result.moderation_action is None
+
+    @pytest.mark.asyncio
+    async def test_no_delete_passes_through(self):
+        cog = _make_cog()
+        cog.remove_unwanted_message = AsyncMock(return_value=False)
+        stage = CleanupStage(cog)
+        ctx = MessagePipelineContext(bot=MagicMock(), message=MagicMock())
+        result = await stage.process(ctx)
+        assert result.deleted is False
+        assert result.short_circuit is False
+
+
+class TestRemoveUnwantedMessageRoutesToModerationService:
+    @pytest.mark.asyncio
+    async def test_prohibited_word_routes_through_auto_delete(self):
+        cog = _make_cog()
+        import re
+
+        cog._pattern_cache[99] = [re.compile(r"\bbadword\b", re.IGNORECASE)]
+        msg = _make_message(content="this has a badword in it")
+
+        with patch(
+            "cogs.cleanup_cog.moderation_service.auto_delete",
+            new_callable=AsyncMock,
+        ) as auto_delete:
+            handled = await cog.remove_unwanted_message(msg)
+
+        assert handled is True
+        auto_delete.assert_awaited_once()
+        assert auto_delete.call_args.args == (msg,)
+        assert auto_delete.call_args.kwargs["rule"] == "cleanup.prohibited_words"
+
+    @pytest.mark.asyncio
+    async def test_blocked_command_routes_through_auto_delete(self):
+        cog = _make_cog()
+        msg = _make_message(content="!banned_cmd")
+
+        # Stub governance to disallow the command and request a delete.
+        fake_policy = SimpleNamespace(
+            allowed=False,
+            feedback="",
+            cleanup=SimpleNamespace(
+                delete_message=True,
+                delete_after_seconds=5,
+            ),
+        )
+
+        with (
+            patch(
+                "cogs.cleanup_cog.governance_service.resolve_command_policy",
+                new_callable=AsyncMock,
+                return_value=fake_policy,
+            ),
+            patch(
+                "cogs.cleanup_cog.moderation_service.auto_delete",
+                new_callable=AsyncMock,
+            ) as auto_delete,
+        ):
+            handled = await cog.remove_unwanted_message(msg)
+
+        assert handled is True
+        auto_delete.assert_awaited_once()
+        assert auto_delete.call_args.kwargs["rule"] == "cleanup.command_policy"
+        assert "banned_cmd" in auto_delete.call_args.kwargs["reason"]
+
+    @pytest.mark.asyncio
+    async def test_whitelist_fallback_routes_through_auto_delete(self):
+        """The whitelist branch fires when command_pattern matches but the
+        governance path is skipped (guild None or command_name None).  Using
+        guild=None to force the fallthrough — equivalent in the unit-test
+        boundary, since the in-pipeline path doesn't reach DMs anyway.
+        """
+        cog = _make_cog()
+        cog.whitelisted_channels = set()  # empty → not whitelisted
+        msg = _make_message(content="!hello")
+        msg.guild = None  # forces the if-guild-and-command-name fallthrough
+
+        with patch(
+            "cogs.cleanup_cog.moderation_service.auto_delete",
+            new_callable=AsyncMock,
+        ) as auto_delete:
+            handled = await cog.remove_unwanted_message(msg)
+
+        assert handled is True
+        auto_delete.assert_awaited_once()
+        assert auto_delete.call_args.kwargs["rule"] == "cleanup.whitelist"
+
+    @pytest.mark.asyncio
+    async def test_clean_message_returns_false_no_delete(self):
+        cog = _make_cog()
+        cog._pattern_cache[99] = []  # no prohibited words
+        msg = _make_message(content="just chatting")
+
+        with patch(
+            "cogs.cleanup_cog.moderation_service.auto_delete",
+            new_callable=AsyncMock,
+        ) as auto_delete:
+            handled = await cog.remove_unwanted_message(msg)
+
+        assert handled is False
+        auto_delete.assert_not_awaited()

--- a/tests/unit/runtime/test_message_pipeline.py
+++ b/tests/unit/runtime/test_message_pipeline.py
@@ -231,9 +231,10 @@ class TestModerationRouting:
         with patch.object(
             message_pipeline,
             "_route_moderation_action",
+            new_callable=AsyncMock,
         ) as hook:
             await message_pipeline.dispatch(MagicMock(), _make_message())
-        hook.assert_called_once()
+        hook.assert_awaited_once()
         # First arg is the message, second is the descriptor.
         assert hook.call_args.args[1] is desc
 
@@ -245,9 +246,48 @@ class TestModerationRouting:
         with patch.object(
             message_pipeline,
             "_route_moderation_action",
+            new_callable=AsyncMock,
         ) as hook:
             await message_pipeline.dispatch(MagicMock(), _make_message())
-        hook.assert_not_called()
+        hook.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_route_dispatches_auto_delete_to_moderation_service(self):
+        """The actual hook (not mocked) routes auto_delete:* to moderation_service."""
+        message = _make_message()
+        desc = ModerationActionDescriptor(
+            action="auto_delete:cleanup.prohibited_words",
+            target_id=42,
+            reason="rule X",
+            rule="cleanup.prohibited_words",
+        )
+
+        with patch(
+            "services.moderation_service.auto_delete",
+            new_callable=AsyncMock,
+        ) as auto_delete:
+            await message_pipeline._route_moderation_action(message, desc)
+        auto_delete.assert_awaited_once_with(
+            message,
+            reason="rule X",
+            rule="cleanup.prohibited_words",
+        )
+
+    @pytest.mark.asyncio
+    async def test_route_logs_warning_for_unknown_action(self, caplog):
+        """Unknown descriptor action types log a warning instead of dispatching."""
+        message = _make_message()
+        desc = ModerationActionDescriptor(
+            action="unknown_kind",
+            target_id=42,
+            reason="x",
+        )
+        with patch(
+            "services.moderation_service.auto_delete",
+            new_callable=AsyncMock,
+        ) as auto_delete:
+            await message_pipeline._route_moderation_action(message, desc)
+        auto_delete.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_moderation_service.py
+++ b/tests/unit/services/test_moderation_service.py
@@ -193,3 +193,132 @@ async def test_discord_forbidden_propagates_unmodified():
 
     log_mod.assert_not_awaited()
     emit.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# auto_delete (§3.2 hook)
+# ---------------------------------------------------------------------------
+
+
+def _make_message(message_id: int = 555, guild_id: int = 99999, author_id: int = 42):
+    msg = MagicMock()
+    msg.id = message_id
+    msg.guild = MagicMock()
+    msg.guild.id = guild_id
+    msg.guild.name = "test-guild"
+    msg.author = MagicMock()
+    msg.author.id = author_id
+    msg.delete = AsyncMock()
+    return msg
+
+
+@pytest.mark.asyncio
+async def test_auto_delete_happy_path_logs_and_emits():
+    msg = _make_message()
+
+    with (
+        patch(
+            "services.moderation_service.db.log_mod_action",
+            new_callable=AsyncMock,
+        ) as log_mod,
+        patch(
+            "services.moderation_service.bus.emit",
+            new_callable=AsyncMock,
+        ) as emit,
+    ):
+        ok = await moderation_service.auto_delete(
+            msg,
+            reason="prohibited word match",
+            rule="cleanup.prohibited_words",
+        )
+
+    assert ok is True
+    msg.delete.assert_awaited_once()
+    log_mod.assert_awaited_once_with(
+        99999,
+        "auto_delete:cleanup.prohibited_words",
+        42,
+        0,
+        "prohibited word match",
+    )
+    emit.assert_awaited_once()
+    kwargs = emit.call_args.kwargs
+    assert kwargs["guild_id"] == 99999
+    assert kwargs["target_id"] == 42
+    assert kwargs["action"] == "auto_delete:cleanup.prohibited_words"
+
+
+@pytest.mark.asyncio
+async def test_auto_delete_already_gone_still_logs():
+    """NotFound shouldn't prevent the audit row — the rule still triggered."""
+    import discord
+
+    msg = _make_message()
+    msg.delete.side_effect = discord.NotFound(MagicMock(), "gone")
+
+    with (
+        patch(
+            "services.moderation_service.db.log_mod_action",
+            new_callable=AsyncMock,
+        ) as log_mod,
+        patch(
+            "services.moderation_service.bus.emit",
+            new_callable=AsyncMock,
+        ) as emit,
+    ):
+        ok = await moderation_service.auto_delete(
+            msg,
+            reason="x",
+            rule="r",
+        )
+
+    assert ok is True
+    log_mod.assert_awaited_once()
+    emit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_auto_delete_forbidden_returns_false_and_skips_audit():
+    import discord
+
+    msg = _make_message()
+    msg.delete.side_effect = discord.Forbidden(MagicMock(), "no perms")
+
+    with (
+        patch(
+            "services.moderation_service.db.log_mod_action",
+            new_callable=AsyncMock,
+        ) as log_mod,
+        patch(
+            "services.moderation_service.bus.emit",
+            new_callable=AsyncMock,
+        ) as emit,
+    ):
+        ok = await moderation_service.auto_delete(msg, reason="x", rule="r")
+
+    assert ok is False
+    log_mod.assert_not_awaited()
+    emit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auto_delete_no_guild_returns_false():
+    msg = _make_message()
+    msg.guild = None
+
+    with (
+        patch(
+            "services.moderation_service.db.log_mod_action",
+            new_callable=AsyncMock,
+        ) as log_mod,
+        patch(
+            "services.moderation_service.bus.emit",
+            new_callable=AsyncMock,
+        ) as emit,
+    ):
+        ok = await moderation_service.auto_delete(msg, reason="x", rule="r")
+
+    assert ok is False
+    msg.delete.assert_not_awaited()
+    log_mod.assert_not_awaited()
+    emit.assert_not_awaited()


### PR DESCRIPTION
## Summary

Second §3.2 cog migration. After this PR, **2 of 5 cogs run through the
pipeline** (xp from PR #63, cleanup here). Auto-mod deletes finally
land in the moderation audit log — closing the §2.2 gap where
CleanupCog deletions were invisible to `mod_logs` / `EVT_MOD_ACTION`.

## Changes

### 1. `moderation_service.auto_delete`

New system-initiated counterpart to `warn` / `timeout` / `kick` / `ban`.

```python
async def auto_delete(
    message: discord.Message,
    *,
    reason: str,
    rule: str,
    actor_id: int | None = None,
) -> bool
```

- Deletes the message
- Writes to `mod_logs` with `action="auto_delete:<rule>"` (so dashboards can filter per-rule)
- Emits the catalogued `EVT_MOD_ACTION` event
- Catches Discord-API exceptions (rule-based moderation has no useful escalation surface)
- `NotFound` still logs the rule trigger for audit completeness

### 2. `cleanup_cog` migrated

| Path | Before | After |
|---|---|---|
| Blocked command (governance policy) | `await message.delete()` + bare logger | `auto_delete(reason=f"Blocked command: {cmd}", rule="cleanup.command_policy")` |
| Whitelist fallback | `await message.delete()` + bare logger | `auto_delete(reason="...", rule="cleanup.whitelist")` |
| Prohibited word match | `await message.delete()` + bare logger | `auto_delete(reason="Prohibited word match", rule="cleanup.prohibited_words")` |

- `CleanupStage` (order=10, moderation tier per plan §3.2) wraps
  `remove_unwanted_message`; returns `StageResult(deleted=True,
  short_circuit=True)` on deletion so downstream XP/game stages skip
  a message that's gone
- `cog_load` / `cog_unload` register/unregister the stage
- `on_message` listener removed

Side benefit: manual `!cleanuphistory` and the scan-history modal also
go through `auto_delete` since they call `remove_unwanted_message` —
so every CleanupCog removal is now audited, not just auto-mod ones.

### 3. `_route_moderation_action` wired

The descriptor-routing hook (`StageResult.moderation_action`) was
plumbing-only in PR #63. Now async, dispatches `"auto_delete:*"`
descriptors to `moderation_service.auto_delete`.

CleanupStage uses the **imperative form** (calls `auto_delete` inside
the cog method). The **descriptor form** stays plumbed for future
stages that prefer that model. Both paths land in the same `mod_logs`
row + emit the same `EVT_MOD_ACTION`.

## Test plan

### 1. Static gates

- [ ] `ruff check`, `black --check`, `isort --check-only`, `mypy disbot/` → all clean

### 2. Unit tests

- [ ] `pytest tests/` → **946 / 946 pass** (+13 new vs. PR #63 baseline of 933)
- [ ] `pytest tests/unit/services/test_moderation_service.py -v -k auto_delete` → 4 pass:
  - happy path: logs + emits
  - NotFound still logs (rule still triggered)
  - Forbidden returns False, skips audit
  - no-guild returns False
- [ ] `pytest tests/unit/runtime/test_message_pipeline.py -v -k Route` → 2 new pass:
  - `auto_delete:*` descriptor dispatches to `moderation_service.auto_delete`
  - unknown descriptor action logs a warning, doesn't dispatch
- [ ] `pytest tests/unit/cogs/test_cleanup_stage.py -v` → 6 pass:
  - stage metadata (`name=="cleanup"`, `order==10`)
  - delete → short_circuit + deleted
  - no-delete → empty result
  - three `remove_unwanted_message` rule paths route through `auto_delete`

### 3. INV negative tests

Verify the hook actually dispatches by injecting a stage that returns
a descriptor:

```python
# In a Python shell with bot context
from core.runtime import message_pipeline as mp
from core.runtime.message_pipeline import StageResult, ModerationActionDescriptor

class _AutoDeleterStage:
    name = "test_auto"
    order = 9  # before xp
    async def process(self, ctx):
        return StageResult(
            short_circuit=True,
            moderation_action=ModerationActionDescriptor(
                action="auto_delete:test",
                target_id=ctx.message.author.id,
                reason="test rule",
                rule="test",
            ),
        )

mp.register(_AutoDeleterStage())
# Post a test message — it should be deleted and a mod_logs row should
# appear with action="auto_delete:test".
mp.unregister("test_auto")
```

### 4. Functional smoke (run against a dev guild)

#### Cleanup auto-mod

- [ ] Add a prohibited word via `!word add foo` → post a message containing "foo" → message deleted, warning posted, mod_logs row appears with `action="auto_delete:cleanup.prohibited_words"`
- [ ] Invoke a blocked command (per your governance policy) → message deleted, feedback shown if configured, mod_logs row with `action="auto_delete:cleanup.command_policy"`
- [ ] `!cleanuphistory 50` in a channel containing prohibited content → bulk deletions all appear in mod_logs

#### Pipeline ordering

- [ ] Post a message containing a prohibited word → it's deleted; verify **no XP is awarded** for that message (CleanupStage at order=10 short-circuits before XpStage at order=20) — confirm via `!rank` before/after
- [ ] Post a clean message → XP is awarded (cleanup doesn't fire, pipeline reaches xp)

#### Audit dashboard

- [ ] `SELECT action, COUNT(*) FROM mod_logs GROUP BY action` shows `auto_delete:cleanup.prohibited_words` / `auto_delete:cleanup.command_policy` / `auto_delete:cleanup.whitelist` rows
- [ ] Subscribers to `EVT_MOD_ACTION` (audit dashboards, future analytics) receive auto-mod events alongside admin warns/timeouts

#### Other cogs unaffected

- [ ] counting / chain / rps_tournament still process messages via their own (legacy) `on_message` listeners — they migrate next, one per PR

## Not in scope (next migrations)

Same shape as before — one cog per PR, each with its own behavior-shift
analysis:

- `counting_cog` → `CountingStage` (order=10; may short_circuit on validation delete)
- `chain_cog`    → `ChainStage`    (order=10; may short_circuit on chain-rule delete)
- `rps_tournament_cog` → `RpsTournamentStage` (order=30; game-input only fires in tournament channels)
- INV gate forbidding raw `@commands.Cog.listener() on_message` outside `message_pipeline.py` — deferred until all 5 cogs migrated so the allow-list isn't long

https://claude.ai/code/session_01FuuCnXTg7FWygNZN5T2DKB

---
_Generated by [Claude Code](https://claude.ai/code/session_01FuuCnXTg7FWygNZN5T2DKB)_