### PR TITLE
§3.2 migration 4: counting_cog → CountingStage (stacked on #64)

### DIFF
--- a/disbot/cogs/counting/_stage.py
+++ b/disbot/cogs/counting/_stage.py
@@ -1,0 +1,55 @@
+"""Counting MessageStage — §3.2 migration of counting_cog.on_message.
+
+Wraps the V/M/A coordinator body (renamed to
+``CountingCog._process_counting_message``) as a
+:class:`core.runtime.message_pipeline.MessageStage`.  The cog
+registers an instance in ``cog_load`` and unregisters on
+``cog_unload`` for hot-reload safety.
+
+Order: 10.  Per plan §3.2, counting sits in the *moderation* tier
+alongside cleanup and chain.  Each can short-circuit the pipeline
+on delete — once the message is gone, downstream stages (XP,
+rps_tournament) skip it.
+
+The stage holds a cog reference because the counting state
+(``count_data``, the per-channel scope locks) is per-instance.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from core.runtime.message_pipeline import (
+    MessagePipelineContext,
+    StageResult,
+)
+
+if TYPE_CHECKING:
+    from cogs.counting_cog import CountingCog
+
+
+COUNTING_STAGE_NAME = "counting"
+COUNTING_STAGE_ORDER = 10
+
+
+class CountingStage:
+    """Validate counts in active channels; short-circuit on rule violation.
+
+    Auto-mod tier (order=10).  Returns
+    ``StageResult(deleted=True, short_circuit=True)`` when the count
+    was invalid and the message was deleted, so XP/game stages skip
+    a message that's gone.  Returns an empty result for valid counts
+    and for messages outside any active counting channel.
+    """
+
+    name = COUNTING_STAGE_NAME
+    order = COUNTING_STAGE_ORDER
+
+    def __init__(self, cog: CountingCog):
+        self.cog = cog
+
+    async def process(self, ctx: MessagePipelineContext) -> StageResult:
+        deleted = await self.cog._process_counting_message(ctx.message)
+        if deleted:
+            return StageResult(deleted=True, short_circuit=True)
+        return StageResult()

--- a/disbot/cogs/counting/handler.py
+++ b/disbot/cogs/counting/handler.py
@@ -30,6 +30,7 @@ from typing import Any
 import discord
 
 from cogs.counting import game_logic, parsing
+from services import moderation_service
 
 logger = logging.getLogger("bot.counting.handler")
 
@@ -192,12 +193,18 @@ async def apply_decision(
     Each Discord call is independently guarded with try/except so a
     single ``Forbidden`` (e.g. missing manage_messages perm) does not
     skip the remaining steps.
+
+    Deletions route through ``moderation_service.auto_delete`` so the
+    ``mod_logs`` audit table and ``EVT_MOD_ACTION`` event bus see
+    every counting-rule removal — closing the §2.2 gap (CountingCog
+    deletes were previously invisible to moderation audit).
     """
     if decision.delete_message:
-        try:
-            await message.delete()
-        except discord.Forbidden:
-            pass
+        await moderation_service.auto_delete(
+            message,
+            reason=decision.reply or "Invalid count",
+            rule="counting.invalid",
+        )
     if decision.reply:
         try:
             await message.channel.send(decision.reply, delete_after=5)

--- a/disbot/cogs/counting_cog.py
+++ b/disbot/cogs/counting_cog.py
@@ -26,6 +26,7 @@ import discord
 from discord.ext import commands
 
 from cogs.counting import handler
+from cogs.counting._stage import COUNTING_STAGE_NAME, CountingStage
 from core.runtime import resources, scope_locks, tasks
 from core.runtime.interaction_helpers import help_ctx_shim
 from utils import db
@@ -56,9 +57,14 @@ class CountingCog(commands.Cog):
         self.count_data: dict = {}
 
     async def cog_load(self):
-        """Schedule DB state load + register scope_locks teardown hook (S2.1)."""
+        """Schedule DB state load, register scope_locks teardown hook (S2.1),
+        and register the message-pipeline CountingStage (§3.2).
+        """
+        from core.runtime import message_pipeline
+
         tasks.spawn("counting:load_when_ready", self._load_when_ready())
         scope_locks.register_guild_teardown_hook(self._drop_scope_locks_for_guild)
+        message_pipeline.register(CountingStage(self))
 
     def _drop_scope_locks_for_guild(self, guild_id: int) -> int:
         """guild_lifecycle teardown hook — drop counting scope_locks for the guild.
@@ -584,31 +590,17 @@ class CountingCog(commands.Cog):
     # Event Listeners
     # --------------------------------------------
 
-    @commands.Cog.listener()
-    async def on_message(self, message):
-        """Validate counts in active channels — V/M/A coordinator (S2.1).
+    async def _process_counting_message(self, message) -> bool:
+        """Validate counts in active channels — V/M/A coordinator (§3.2).
 
-        H-2 fix: the previous implementation held a cog-wide ``self.lock``
-        across every Discord I/O call, serialising counting across every
-        channel + every guild + every mode through one critical section.
+        Called by :class:`CountingStage` from the message pipeline.
+        Returns ``True`` if the message was deleted (caller short-circuits
+        the pipeline), ``False`` otherwise.
 
-        After S2.1 this is the thin V/M/A coordinator:
-
-          1. Quick existence check (no lock — CPython dict reads atomic).
-          2. compute_decision under per-channel ``scope_locks`` — pure
-             validation + in-place state mutation + spawn save.
-          3. apply_decision OUTSIDE the lock — all Discord I/O happens
-             with no lock held, so a slow API roundtrip on channel A
-             cannot stall channel B.
-
-        The compute/apply split lives in ``cogs/counting/handler.py``.
-        Admin commands still use ``self.lock`` for now (rare paths;
-        race window is benign per the docstring on _drop_scope_locks_for_guild).
+        The pipeline pre-filters bot authors so we don't re-check.
         """
-        if message.author.bot:
-            return
         if not isinstance(message.channel, discord.TextChannel):
-            return
+            return False
 
         guild_id = str(message.guild.id)
         channel_id = str(message.channel.id)
@@ -622,7 +614,7 @@ class CountingCog(commands.Cog):
             self.count_data.get(guild_id, {}).get("channels", {}).get(channel_id)
         )
         if channel_data is None:
-            return
+            return False
 
         # ---- VALIDATE + MUTATE under per-channel scope_lock ----
         scope_id = _scope_id_for_channel(channel_id)
@@ -640,14 +632,18 @@ class CountingCog(commands.Cog):
 
         # ---- APPLY OUTSIDE the lock (Discord I/O) ----
         await handler.apply_decision(decision, message)
+        return decision.delete_message
 
     # --------------------------------------------
     # Cog Unload
     # --------------------------------------------
 
     def cog_unload(self):
-        """Cancel in-flight save / load tasks so a reload doesn't leak them."""
+        """Cancel in-flight save / load tasks; unregister the pipeline stage."""
+        from core.runtime import message_pipeline
+
         tasks.cancel_by_prefix("counting:")
+        message_pipeline.unregister(COUNTING_STAGE_NAME)
 
 
 async def setup(bot):

--- a/tests/unit/cogs/test_counting_handler.py
+++ b/tests/unit/cogs/test_counting_handler.py
@@ -225,13 +225,22 @@ def test_sequence_mode_advances_index_on_success():
 
 
 @pytest.mark.asyncio
-async def test_apply_decision_delete_calls_message_delete():
+async def test_apply_decision_delete_calls_auto_delete():
+    """Post-§3.2 the delete path routes through moderation_service.auto_delete
+    so the removal is recorded in mod_logs + emits EVT_MOD_ACTION."""
+    from unittest.mock import patch as _patch
+
     msg = _make_message()
     decision = CountingDecision(accepted=False, delete_message=True)
 
-    await handler.apply_decision(decision, msg)
+    with _patch(
+        "cogs.counting.handler.moderation_service.auto_delete",
+        new_callable=AsyncMock,
+    ) as auto_delete:
+        await handler.apply_decision(decision, msg)
 
-    msg.delete.assert_awaited_once()
+    auto_delete.assert_awaited_once()
+    assert auto_delete.call_args.kwargs["rule"] == "counting.invalid"
     msg.channel.send.assert_not_awaited()
     msg.add_reaction.assert_not_awaited()
 
@@ -318,7 +327,7 @@ async def test_on_message_releases_scope_lock_before_discord_io():
         "cogs.counting_cog.handler.apply_decision",
         side_effect=_spy_apply,
     ):
-        await cog.on_message(msg)
+        await cog._process_counting_message(msg)
 
     assert locked_at_apply["value"] is False, (
         "apply_decision was invoked while the scope_lock was still held — "
@@ -341,7 +350,7 @@ async def test_on_message_skips_when_channel_not_in_state():
     msg.channel.id = 999
     msg.channel.send = AsyncMock()
 
-    await cog.on_message(msg)
+    await cog._process_counting_message(msg)
 
     msg.delete.assert_not_awaited()
     msg.channel.send.assert_not_awaited()
@@ -349,8 +358,15 @@ async def test_on_message_skips_when_channel_not_in_state():
 
 
 @pytest.mark.asyncio
-async def test_on_message_skips_bot_authors():
+async def test_dispatch_skips_bot_authors_before_counting_stage():
+    """Bot messages never reach CountingStage — the pipeline pre-filter
+    drops them before any stage runs.  Post-§3.2 the counting hot path
+    no longer re-checks ``message.author.bot``; the pre-filter is the
+    single source of truth (covered by test_message_pipeline.py).
+    """
+    from cogs.counting._stage import CountingStage
     from cogs.counting_cog import CountingCog
+    from core.runtime import message_pipeline
 
     cog = CountingCog(bot=MagicMock())
     cog.count_data = {
@@ -364,9 +380,14 @@ async def test_on_message_skips_bot_authors():
     msg.channel = MagicMock(spec=discord.TextChannel)
     msg.channel.id = 1
 
-    await cog.on_message(msg)
+    message_pipeline.clear()
+    message_pipeline.register(CountingStage(cog))
+    try:
+        await message_pipeline.dispatch(MagicMock(), msg)
+    finally:
+        message_pipeline.clear()
 
-    # State unchanged.
+    # State unchanged — the pre-filter dropped the bot message.
     assert cog.count_data["1"]["channels"]["1"]["current_count"] == 0
 
 
@@ -410,8 +431,8 @@ async def test_two_channels_can_process_concurrently():
         return msg
 
     await asyncio.gather(
-        cog.on_message(make_msg(1, "A")),
-        cog.on_message(make_msg(2, "B")),
+        cog._process_counting_message(make_msg(1, "A")),
+        cog._process_counting_message(make_msg(2, "B")),
     )
 
     # Both succeeded (their scope_locks did not contend).

--- a/tests/unit/cogs/test_counting_stage.py
+++ b/tests/unit/cogs/test_counting_stage.py
@@ -1,0 +1,64 @@
+"""Tests for the CountingStage migration (§3.2).
+
+Stage wrapper contract:
+  - delete → short_circuit + deleted flags
+  - no-delete → empty result
+  - delegates to cog._process_counting_message
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from cogs.counting._stage import (
+    COUNTING_STAGE_NAME,
+    COUNTING_STAGE_ORDER,
+    CountingStage,
+)
+from core.runtime.message_pipeline import MessagePipelineContext
+
+
+class TestCountingStage:
+    def test_metadata(self):
+        stage = CountingStage(MagicMock())
+        assert stage.name == COUNTING_STAGE_NAME == "counting"
+        assert stage.order == COUNTING_STAGE_ORDER == 10
+
+    @pytest.mark.asyncio
+    async def test_delete_short_circuits(self):
+        cog = MagicMock()
+        cog._process_counting_message = AsyncMock(return_value=True)
+        stage = CountingStage(cog)
+        ctx = MessagePipelineContext(bot=MagicMock(), message=MagicMock())
+
+        result = await stage.process(ctx)
+
+        assert result.deleted is True
+        assert result.short_circuit is True
+        assert result.moderation_action is None
+
+    @pytest.mark.asyncio
+    async def test_no_delete_passes_through(self):
+        cog = MagicMock()
+        cog._process_counting_message = AsyncMock(return_value=False)
+        stage = CountingStage(cog)
+        ctx = MessagePipelineContext(bot=MagicMock(), message=MagicMock())
+
+        result = await stage.process(ctx)
+
+        assert result.deleted is False
+        assert result.short_circuit is False
+
+    @pytest.mark.asyncio
+    async def test_delegates_message_to_cog(self):
+        cog = MagicMock()
+        cog._process_counting_message = AsyncMock(return_value=False)
+        stage = CountingStage(cog)
+        message = MagicMock()
+        ctx = MessagePipelineContext(bot=MagicMock(), message=message)
+
+        await stage.process(ctx)
+
+        cog._process_counting_message.assert_awaited_once_with(message)


### PR DESCRIPTION
## Summary

Fourth §3.2 cog migration. After this lands, **4 of 5 cogs** run through
the pipeline (xp from #63, rps from #65, cleanup from #64, counting here).
Only `chain_cog` remains.

## Stacked on PR #64

This PR **must merge after #64**. The counting auto-delete path calls
`moderation_service.auto_delete`, which is added in #64. To keep the
diff focused on counting-specific changes, this PR's base is set to
`claude/message-pipeline-cleanup` (PR #64's branch).

When #64 merges:
- GitHub auto-retargets this PR's base to `main`
- The diff narrows to exactly the counting changes shown below

## Changes

### 1. `cogs/counting/handler.py::apply_decision`

The delete path now routes through `moderation_service.auto_delete`
with `rule="counting.invalid"`. The decision's `reply` text (the
human-readable rule explanation) becomes the audit `reason`.

```python
# Before
if decision.delete_message:
    try:
        await message.delete()
    except discord.Forbidden:
        pass

# After
if decision.delete_message:
    await moderation_service.auto_delete(
        message,
        reason=decision.reply or "Invalid count",
        rule="counting.invalid",
    )
```

Counting deletes are now visible in `mod_logs` and emit
`EVT_MOD_ACTION`, closing the §2.2 gap.

### 2. `cogs/counting/_stage.py` (new)

Joins the existing decomposition layout. `CountingStage(cog)` at
order=10 (moderation tier) wraps `cog._process_counting_message`;
returns `StageResult(deleted=True, short_circuit=True)` when the
count was invalid so xp/rps stages skip a deleted message.

### 3. `cogs/counting_cog.py`

- `on_message` body renamed to `_process_counting_message`, now returns `bool`
- `@commands.Cog.listener()` decorator removed
- Bot-author pre-check removed — the pipeline pre-filter is the single source of truth
- `cog_load` registers `CountingStage(self)` alongside the existing scope_locks teardown hook
- `cog_unload` also unregisters the stage

### 4. Tests

- **4 new** (`test_counting_stage.py`):
  - Stage metadata (`name=="counting"`, `order==10`)
  - Delete → short_circuit + deleted
  - No-delete → empty result
  - Delegates to `_process_counting_message`
- **4 updated** in `test_counting_handler.py`:
  - Renamed `on_message` → `_process_counting_message` in V/M/A integration tests
- **1 repurposed**:
  - `test_dispatch_skips_bot_authors_before_counting_stage` — exercises the pipeline pre-filter end-to-end with the stage registered, since the cog no longer pre-checks bots
- **1 rewritten**:
  - `test_apply_decision_delete_calls_auto_delete` — mocks `moderation_service.auto_delete` and asserts the `rule` id, verifying no raw `message.delete` is called

## Test plan

### 1. Static gates

- [ ] `ruff check`, `black --check`, `isort --check-only`, `mypy disbot/` → all clean

### 2. Unit tests

- [ ] `pytest tests/` → **950 / 950 pass** (+9 net vs. #64 baseline of 941)
- [ ] `pytest tests/unit/cogs/test_counting_stage.py -v` → 4 pass
- [ ] `pytest tests/unit/cogs/test_counting_handler.py -v` → all green (incl. repurposed + rewritten tests)

### 3. Functional smoke (run against a dev guild after #64 + this merge)

#### Counting auto-mod through moderation_service

- [ ] Active counting channel in normal mode at count=0 → post "abc" (invalid number) → message deleted, warning posted ("send a valid number…"), `mod_logs` row appears with `action="auto_delete:counting.invalid"` and `reason="..., please send a valid number or mathematical expression."`
- [ ] At count=4, post "5" → accepted, ✅ reaction, no audit row
- [ ] At count=4, post "99" → message deleted, "should be 5" reply, audit row with `reason="..., incorrect count! The next number should be 5."`
- [ ] In `taking_turns` mode after user A posts → same user A posts again → deleted, "cannot count twice in a row" reply, audit row
- [ ] In `multiples` mode (multiple=3), at count=0 → post "4" → deleted, audit row
- [ ] In `prime` mode at count=2 → post "4" (composite) → deleted, audit row

#### Pipeline ordering

- [ ] Post a valid count in an active counting channel → count advances; **XP is awarded** (xp stage at order=20 runs after counting; counting returned `short_circuit=False`)
- [ ] Post an invalid count → message deleted; **XP is NOT awarded** for the deleted message (counting at order=10 returned `short_circuit=True` → xp skipped)
- [ ] Verify by checking `!rank` before/after each case

#### Bot pre-filter

- [ ] Bot's own messages in a counting channel → no count advance, no audit row (pipeline pre-filter, never reaches CountingStage)

#### Multi-channel isolation

- [ ] Two counting channels simultaneously processing — neither stalls the other (the H-2 per-channel scope_lock still applies; the migration didn't touch that)

#### Audit dashboard

- [ ] `SELECT DISTINCT action FROM mod_logs ORDER BY 1` shows `auto_delete:counting.invalid` alongside the cleanup variants (`cleanup.command_policy`, `cleanup.prohibited_words`, `cleanup.whitelist`)
- [ ] `EVT_MOD_ACTION` subscribers (audit dashboards, future analytics) receive counting events alongside admin warns/timeouts

## Behavior shift

Two real changes for in-pipeline messages:

1. **Counting deletes are audited.** Previously invisible to `mod_logs`; now appear with `action="auto_delete:counting.invalid"`.
2. **XP no longer rewards deleted messages.** Previously, the five concurrent listeners raced — `XpCog.on_message` could award XP before/while `CountingCog` deleted the message. Now `CountingStage` at order=10 short-circuits the pipeline on delete, so `XpStage` at order=20 never runs.

Both are intentional per the plan §3.2.

## Not in scope (final §3.2 work)

- `chain_cog` → `ChainStage` (also needs PR #64's `auto_delete`; same stacking pattern)
- INV gate forbidding raw `@commands.Cog.listener() on_message` outside `message_pipeline.py` — deferred until chain_cog migrates

https://claude.ai/code/session_01FuuCnXTg7FWygNZN5T2DKB

---
_Generated by [Claude Code](https://claude.ai/code/session_01FuuCnXTg7FWygNZN5T2DKB)_