### PR TITLE
§3.2 close: bring counting/chain to main + INV gate

### DIFF
--- a/disbot/cogs/chain_cog.py
+++ b/disbot/cogs/chain_cog.py
@@ -9,10 +9,42 @@ from discord.ext.commands import MissingPermissions, has_permissions
 
 from core.runtime import resources
 from core.runtime.interaction_helpers import help_ctx_shim
+from core.runtime.message_pipeline import (
+    MessagePipelineContext,
+    StageResult,
+)
+from services import moderation_service
 from utils import db
 from views.base import HubView, send_panel
 
+CHAIN_STAGE_NAME = "chain"
+CHAIN_STAGE_ORDER = 10  # moderation tier per plan §3.2
+
 logger = logging.getLogger("bot.cogs.chain")
+
+
+class ChainStage:
+    """Message-pipeline stage enforcing chain rules + word limits.
+
+    Auto-mod tier (order=10).  Short-circuits the pipeline when a
+    message is deleted so xp / game_input stages skip a removed
+    message.
+
+    Holds a cog reference because the rule check requires the bot's
+    command-context lookup (so command messages aren't auto-deleted).
+    """
+
+    name = CHAIN_STAGE_NAME
+    order = CHAIN_STAGE_ORDER
+
+    def __init__(self, cog: ChainCog):
+        self.cog = cog
+
+    async def process(self, ctx: MessagePipelineContext) -> StageResult:
+        deleted = await self.cog._process_chain_message(ctx.message)
+        if deleted:
+            return StageResult(deleted=True, short_circuit=True)
+        return StageResult()
 
 
 class ChainCog(commands.Cog):
@@ -20,6 +52,16 @@ class ChainCog(commands.Cog):
 
     def __init__(self, bot):
         self.bot = bot
+
+    async def cog_load(self) -> None:
+        from core.runtime import message_pipeline
+
+        message_pipeline.register(ChainStage(self))
+
+    def cog_unload(self) -> None:
+        from core.runtime import message_pipeline
+
+        message_pipeline.unregister(CHAIN_STAGE_NAME)
 
     @commands.group(name="chain", invoke_without_command=True)
     async def chain(self, ctx):
@@ -249,65 +291,76 @@ class ChainCog(commands.Cog):
 
         await ctx.send(embed=embed)
 
-    @commands.Cog.listener()
-    async def on_message(self, message):
-        """Listener to enforce chain rules and word limits in specified channels."""
-        # Ignore messages from bots
-        if message.author.bot:
-            return
+    async def _process_chain_message(self, message) -> bool:
+        """Enforce chain rules and word limits.  Returns True iff deleted.
 
-        # Check if the message is invoking a command
+        Called by :class:`ChainStage` from the message pipeline.
+        The pipeline pre-filters bot authors so we don't re-check.
+
+        Command messages (resolved via ``bot.get_context``) are passed
+        through unchanged — chain rules apply only to plain content.
+        """
         ctx = await self.bot.get_context(message)
         if ctx.valid:
-            return  # Don't process command messages
+            return False  # Don't process command messages
 
         channel_data = await db.get_chain_channel(message.channel.id)
         if not channel_data:
-            return  # No chain or limit set for this channel
+            return False  # No chain or limit set for this channel
 
         allowed_word = channel_data.get("word")
         word_limit = channel_data.get("word_limit")
 
-        # Initialize a flag to determine if message should be deleted
         delete_message = False
-
-        # Check for allowed word
-        if allowed_word:
-            if message.content.strip().lower() != allowed_word.lower():
-                delete_message = True
-
-        # Check for word limit
-        if word_limit:
-            word_count = len(message.content.strip().split())
-            if word_count > word_limit:
-                delete_message = True
+        if allowed_word and message.content.strip().lower() != allowed_word.lower():
+            delete_message = True
+        if word_limit and len(message.content.strip().split()) > word_limit:
+            delete_message = True
 
         if not delete_message:
             await db.increment_chain_count(message.channel.id)
-            return  # Message is allowed
+            return False  # Message is allowed
 
-        # Delete the message and optionally warn the user
+        # Compose the human-readable warning + audit reason.
+        warning_message = f"{message.author.mention}, your message was deleted."
+        if allowed_word and word_limit:
+            warning_message += (
+                f" Only the word `{allowed_word}` is allowed, and messages must "
+                f"be at most {word_limit} words."
+            )
+        elif allowed_word:
+            warning_message += (
+                f" Only the word `{allowed_word}` is allowed in this channel."
+            )
+        elif word_limit:
+            warning_message += f" Messages must be at most {word_limit} words."
+
+        # Route through moderation_service so the removal lands in
+        # mod_logs + emits EVT_MOD_ACTION (§2.2 gap closed).
+        ok = await moderation_service.auto_delete(
+            message,
+            reason=warning_message,
+            rule="chain.violation",
+        )
+        if not ok:
+            return False
+
         try:
-            await message.delete()
-            warning_message = f"{message.author.mention}, your message was deleted."
-            if allowed_word and word_limit:
-                warning_message += f" Only the word `{allowed_word}` is allowed, and messages must be at most {word_limit} words."
-            elif allowed_word:
-                warning_message += (
-                    f" Only the word `{allowed_word}` is allowed in this channel."
-                )
-            elif word_limit:
-                warning_message += f" Messages must be at most {word_limit} words."
             warning = await message.channel.send(warning_message)
-            # Delete the warning after 5 seconds
             await asyncio.sleep(5)
             await warning.delete()
         except discord.Forbidden:
             logger.warning(
-                f"Missing permissions to delete messages in {message.channel}.",
+                "Missing permissions to post chain warning in %s.",
+                message.channel,
             )
-        except discord.HTTPException as e:
-            logger.error(f"Failed to delete message in {message.channel}: {e}")
+        except discord.HTTPException as exc:
+            logger.error(
+                "Failed to post chain warning in %s: %s",
+                message.channel,
+                exc,
+            )
+        return True
 
     @commands.Cog.listener()
     async def on_ready(self):

--- a/disbot/cogs/counting/_stage.py
+++ b/disbot/cogs/counting/_stage.py
@@ -1,0 +1,55 @@
+"""Counting MessageStage — §3.2 migration of counting_cog.on_message.
+
+Wraps the V/M/A coordinator body (renamed to
+``CountingCog._process_counting_message``) as a
+:class:`core.runtime.message_pipeline.MessageStage`.  The cog
+registers an instance in ``cog_load`` and unregisters on
+``cog_unload`` for hot-reload safety.
+
+Order: 10.  Per plan §3.2, counting sits in the *moderation* tier
+alongside cleanup and chain.  Each can short-circuit the pipeline
+on delete — once the message is gone, downstream stages (XP,
+rps_tournament) skip it.
+
+The stage holds a cog reference because the counting state
+(``count_data``, the per-channel scope locks) is per-instance.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from core.runtime.message_pipeline import (
+    MessagePipelineContext,
+    StageResult,
+)
+
+if TYPE_CHECKING:
+    from cogs.counting_cog import CountingCog
+
+
+COUNTING_STAGE_NAME = "counting"
+COUNTING_STAGE_ORDER = 10
+
+
+class CountingStage:
+    """Validate counts in active channels; short-circuit on rule violation.
+
+    Auto-mod tier (order=10).  Returns
+    ``StageResult(deleted=True, short_circuit=True)`` when the count
+    was invalid and the message was deleted, so XP/game stages skip
+    a message that's gone.  Returns an empty result for valid counts
+    and for messages outside any active counting channel.
+    """
+
+    name = COUNTING_STAGE_NAME
+    order = COUNTING_STAGE_ORDER
+
+    def __init__(self, cog: CountingCog):
+        self.cog = cog
+
+    async def process(self, ctx: MessagePipelineContext) -> StageResult:
+        deleted = await self.cog._process_counting_message(ctx.message)
+        if deleted:
+            return StageResult(deleted=True, short_circuit=True)
+        return StageResult()

--- a/disbot/cogs/counting/handler.py
+++ b/disbot/cogs/counting/handler.py
@@ -30,6 +30,7 @@ from typing import Any
 import discord
 
 from cogs.counting import game_logic, parsing
+from services import moderation_service
 
 logger = logging.getLogger("bot.counting.handler")
 
@@ -192,12 +193,18 @@ async def apply_decision(
     Each Discord call is independently guarded with try/except so a
     single ``Forbidden`` (e.g. missing manage_messages perm) does not
     skip the remaining steps.
+
+    Deletions route through ``moderation_service.auto_delete`` so the
+    ``mod_logs`` audit table and ``EVT_MOD_ACTION`` event bus see
+    every counting-rule removal — closing the §2.2 gap (CountingCog
+    deletes were previously invisible to moderation audit).
     """
     if decision.delete_message:
-        try:
-            await message.delete()
-        except discord.Forbidden:
-            pass
+        await moderation_service.auto_delete(
+            message,
+            reason=decision.reply or "Invalid count",
+            rule="counting.invalid",
+        )
     if decision.reply:
         try:
             await message.channel.send(decision.reply, delete_after=5)

--- a/disbot/cogs/counting_cog.py
+++ b/disbot/cogs/counting_cog.py
@@ -26,6 +26,7 @@ import discord
 from discord.ext import commands
 
 from cogs.counting import handler
+from cogs.counting._stage import COUNTING_STAGE_NAME, CountingStage
 from core.runtime import resources, scope_locks, tasks
 from core.runtime.interaction_helpers import help_ctx_shim
 from utils import db
@@ -56,9 +57,14 @@ class CountingCog(commands.Cog):
         self.count_data: dict = {}
 
     async def cog_load(self):
-        """Schedule DB state load + register scope_locks teardown hook (S2.1)."""
+        """Schedule DB state load, register scope_locks teardown hook (S2.1),
+        and register the message-pipeline CountingStage (§3.2).
+        """
+        from core.runtime import message_pipeline
+
         tasks.spawn("counting:load_when_ready", self._load_when_ready())
         scope_locks.register_guild_teardown_hook(self._drop_scope_locks_for_guild)
+        message_pipeline.register(CountingStage(self))
 
     def _drop_scope_locks_for_guild(self, guild_id: int) -> int:
         """guild_lifecycle teardown hook — drop counting scope_locks for the guild.
@@ -584,31 +590,17 @@ class CountingCog(commands.Cog):
     # Event Listeners
     # --------------------------------------------
 
-    @commands.Cog.listener()
-    async def on_message(self, message):
-        """Validate counts in active channels — V/M/A coordinator (S2.1).
+    async def _process_counting_message(self, message) -> bool:
+        """Validate counts in active channels — V/M/A coordinator (§3.2).
 
-        H-2 fix: the previous implementation held a cog-wide ``self.lock``
-        across every Discord I/O call, serialising counting across every
-        channel + every guild + every mode through one critical section.
+        Called by :class:`CountingStage` from the message pipeline.
+        Returns ``True`` if the message was deleted (caller short-circuits
+        the pipeline), ``False`` otherwise.
 
-        After S2.1 this is the thin V/M/A coordinator:
-
-          1. Quick existence check (no lock — CPython dict reads atomic).
-          2. compute_decision under per-channel ``scope_locks`` — pure
-             validation + in-place state mutation + spawn save.
-          3. apply_decision OUTSIDE the lock — all Discord I/O happens
-             with no lock held, so a slow API roundtrip on channel A
-             cannot stall channel B.
-
-        The compute/apply split lives in ``cogs/counting/handler.py``.
-        Admin commands still use ``self.lock`` for now (rare paths;
-        race window is benign per the docstring on _drop_scope_locks_for_guild).
+        The pipeline pre-filters bot authors so we don't re-check.
         """
-        if message.author.bot:
-            return
         if not isinstance(message.channel, discord.TextChannel):
-            return
+            return False
 
         guild_id = str(message.guild.id)
         channel_id = str(message.channel.id)
@@ -622,7 +614,7 @@ class CountingCog(commands.Cog):
             self.count_data.get(guild_id, {}).get("channels", {}).get(channel_id)
         )
         if channel_data is None:
-            return
+            return False
 
         # ---- VALIDATE + MUTATE under per-channel scope_lock ----
         scope_id = _scope_id_for_channel(channel_id)
@@ -640,14 +632,18 @@ class CountingCog(commands.Cog):
 
         # ---- APPLY OUTSIDE the lock (Discord I/O) ----
         await handler.apply_decision(decision, message)
+        return decision.delete_message
 
     # --------------------------------------------
     # Cog Unload
     # --------------------------------------------
 
     def cog_unload(self):
-        """Cancel in-flight save / load tasks so a reload doesn't leak them."""
+        """Cancel in-flight save / load tasks; unregister the pipeline stage."""
+        from core.runtime import message_pipeline
+
         tasks.cancel_by_prefix("counting:")
+        message_pipeline.unregister(COUNTING_STAGE_NAME)
 
 
 async def setup(bot):

--- a/tests/unit/cogs/test_chain_stage.py
+++ b/tests/unit/cogs/test_chain_stage.py
@@ -1,0 +1,192 @@
+"""Tests for the ChainStage migration (§3.2).
+
+Stage wrapper contract + _process_chain_message routing through
+moderation_service.auto_delete on rule violations.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cogs.chain_cog import (
+    CHAIN_STAGE_NAME,
+    CHAIN_STAGE_ORDER,
+    ChainCog,
+    ChainStage,
+)
+from core.runtime.message_pipeline import MessagePipelineContext
+
+
+def _make_cog():
+    bot = MagicMock()
+    # Default: not a command — chain validation should proceed.
+    fake_ctx = MagicMock()
+    fake_ctx.valid = False
+    bot.get_context = AsyncMock(return_value=fake_ctx)
+    return ChainCog(bot=bot)
+
+
+def _make_message(*, content="hello", channel_id=1, author_id=42, guild_id=99):
+    msg = MagicMock()
+    msg.content = content
+    msg.id = 555
+    msg.guild = MagicMock()
+    msg.guild.id = guild_id
+    msg.guild.name = "test-guild"
+    msg.channel = MagicMock()
+    msg.channel.id = channel_id
+    msg.channel.send = AsyncMock()
+    msg.author = MagicMock()
+    msg.author.id = author_id
+    msg.author.bot = False
+    msg.author.mention = f"<@{author_id}>"
+    return msg
+
+
+class TestChainStageContract:
+    def test_metadata(self):
+        stage = ChainStage(_make_cog())
+        assert stage.name == CHAIN_STAGE_NAME == "chain"
+        assert stage.order == CHAIN_STAGE_ORDER == 10
+
+    @pytest.mark.asyncio
+    async def test_delete_short_circuits(self):
+        cog = _make_cog()
+        cog._process_chain_message = AsyncMock(return_value=True)
+        stage = ChainStage(cog)
+        ctx = MessagePipelineContext(bot=MagicMock(), message=MagicMock())
+        result = await stage.process(ctx)
+        assert result.deleted is True
+        assert result.short_circuit is True
+
+    @pytest.mark.asyncio
+    async def test_no_delete_passes_through(self):
+        cog = _make_cog()
+        cog._process_chain_message = AsyncMock(return_value=False)
+        stage = ChainStage(cog)
+        ctx = MessagePipelineContext(bot=MagicMock(), message=MagicMock())
+        result = await stage.process(ctx)
+        assert result.deleted is False
+        assert result.short_circuit is False
+
+
+class TestProcessChainMessage:
+    @pytest.mark.asyncio
+    async def test_command_messages_pass_through(self):
+        """ctx.valid → True means it's a command; chain rules don't apply."""
+        cog = _make_cog()
+        cog.bot.get_context.return_value = MagicMock(valid=True)
+        msg = _make_message()
+
+        with (
+            patch(
+                "cogs.chain_cog.db.get_chain_channel",
+                new_callable=AsyncMock,
+            ) as get_chain,
+            patch(
+                "cogs.chain_cog.moderation_service.auto_delete",
+                new_callable=AsyncMock,
+            ) as auto_delete,
+        ):
+            handled = await cog._process_chain_message(msg)
+
+        assert handled is False
+        get_chain.assert_not_awaited()
+        auto_delete.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unchained_channel_passes_through(self):
+        cog = _make_cog()
+        msg = _make_message()
+
+        with (
+            patch(
+                "cogs.chain_cog.db.get_chain_channel",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "cogs.chain_cog.moderation_service.auto_delete",
+                new_callable=AsyncMock,
+            ) as auto_delete,
+        ):
+            handled = await cog._process_chain_message(msg)
+
+        assert handled is False
+        auto_delete.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_disallowed_word_routes_through_auto_delete(self):
+        cog = _make_cog()
+        msg = _make_message(content="bad")
+
+        with (
+            patch(
+                "cogs.chain_cog.db.get_chain_channel",
+                new_callable=AsyncMock,
+                return_value={"word": "good", "word_limit": 0},
+            ),
+            patch(
+                "cogs.chain_cog.moderation_service.auto_delete",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as auto_delete,
+        ):
+            handled = await cog._process_chain_message(msg)
+
+        assert handled is True
+        auto_delete.assert_awaited_once()
+        assert auto_delete.call_args.kwargs["rule"] == "chain.violation"
+        assert "good" in auto_delete.call_args.kwargs["reason"]
+
+    @pytest.mark.asyncio
+    async def test_word_limit_exceeded_routes_through_auto_delete(self):
+        cog = _make_cog()
+        msg = _make_message(content="one two three four")
+
+        with (
+            patch(
+                "cogs.chain_cog.db.get_chain_channel",
+                new_callable=AsyncMock,
+                return_value={"word": "", "word_limit": 2},
+            ),
+            patch(
+                "cogs.chain_cog.moderation_service.auto_delete",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as auto_delete,
+        ):
+            handled = await cog._process_chain_message(msg)
+
+        assert handled is True
+        auto_delete.assert_awaited_once()
+        assert auto_delete.call_args.kwargs["rule"] == "chain.violation"
+        assert "2 words" in auto_delete.call_args.kwargs["reason"]
+
+    @pytest.mark.asyncio
+    async def test_allowed_word_match_increments_count(self):
+        cog = _make_cog()
+        msg = _make_message(content="good")
+
+        with (
+            patch(
+                "cogs.chain_cog.db.get_chain_channel",
+                new_callable=AsyncMock,
+                return_value={"word": "good", "word_limit": 0},
+            ),
+            patch(
+                "cogs.chain_cog.db.increment_chain_count",
+                new_callable=AsyncMock,
+            ) as inc,
+            patch(
+                "cogs.chain_cog.moderation_service.auto_delete",
+                new_callable=AsyncMock,
+            ) as auto_delete,
+        ):
+            handled = await cog._process_chain_message(msg)
+
+        assert handled is False
+        inc.assert_awaited_once_with(msg.channel.id)
+        auto_delete.assert_not_awaited()

--- a/tests/unit/cogs/test_counting_handler.py
+++ b/tests/unit/cogs/test_counting_handler.py
@@ -225,13 +225,22 @@ def test_sequence_mode_advances_index_on_success():
 
 
 @pytest.mark.asyncio
-async def test_apply_decision_delete_calls_message_delete():
+async def test_apply_decision_delete_calls_auto_delete():
+    """Post-§3.2 the delete path routes through moderation_service.auto_delete
+    so the removal is recorded in mod_logs + emits EVT_MOD_ACTION."""
+    from unittest.mock import patch as _patch
+
     msg = _make_message()
     decision = CountingDecision(accepted=False, delete_message=True)
 
-    await handler.apply_decision(decision, msg)
+    with _patch(
+        "cogs.counting.handler.moderation_service.auto_delete",
+        new_callable=AsyncMock,
+    ) as auto_delete:
+        await handler.apply_decision(decision, msg)
 
-    msg.delete.assert_awaited_once()
+    auto_delete.assert_awaited_once()
+    assert auto_delete.call_args.kwargs["rule"] == "counting.invalid"
     msg.channel.send.assert_not_awaited()
     msg.add_reaction.assert_not_awaited()
 
@@ -318,7 +327,7 @@ async def test_on_message_releases_scope_lock_before_discord_io():
         "cogs.counting_cog.handler.apply_decision",
         side_effect=_spy_apply,
     ):
-        await cog.on_message(msg)
+        await cog._process_counting_message(msg)
 
     assert locked_at_apply["value"] is False, (
         "apply_decision was invoked while the scope_lock was still held — "
@@ -341,7 +350,7 @@ async def test_on_message_skips_when_channel_not_in_state():
     msg.channel.id = 999
     msg.channel.send = AsyncMock()
 
-    await cog.on_message(msg)
+    await cog._process_counting_message(msg)
 
     msg.delete.assert_not_awaited()
     msg.channel.send.assert_not_awaited()
@@ -349,8 +358,15 @@ async def test_on_message_skips_when_channel_not_in_state():
 
 
 @pytest.mark.asyncio
-async def test_on_message_skips_bot_authors():
+async def test_dispatch_skips_bot_authors_before_counting_stage():
+    """Bot messages never reach CountingStage — the pipeline pre-filter
+    drops them before any stage runs.  Post-§3.2 the counting hot path
+    no longer re-checks ``message.author.bot``; the pre-filter is the
+    single source of truth (covered by test_message_pipeline.py).
+    """
+    from cogs.counting._stage import CountingStage
     from cogs.counting_cog import CountingCog
+    from core.runtime import message_pipeline
 
     cog = CountingCog(bot=MagicMock())
     cog.count_data = {
@@ -364,9 +380,14 @@ async def test_on_message_skips_bot_authors():
     msg.channel = MagicMock(spec=discord.TextChannel)
     msg.channel.id = 1
 
-    await cog.on_message(msg)
+    message_pipeline.clear()
+    message_pipeline.register(CountingStage(cog))
+    try:
+        await message_pipeline.dispatch(MagicMock(), msg)
+    finally:
+        message_pipeline.clear()
 
-    # State unchanged.
+    # State unchanged — the pre-filter dropped the bot message.
     assert cog.count_data["1"]["channels"]["1"]["current_count"] == 0
 
 
@@ -410,8 +431,8 @@ async def test_two_channels_can_process_concurrently():
         return msg
 
     await asyncio.gather(
-        cog.on_message(make_msg(1, "A")),
-        cog.on_message(make_msg(2, "B")),
+        cog._process_counting_message(make_msg(1, "A")),
+        cog._process_counting_message(make_msg(2, "B")),
     )
 
     # Both succeeded (their scope_locks did not contend).

--- a/tests/unit/cogs/test_counting_stage.py
+++ b/tests/unit/cogs/test_counting_stage.py
@@ -1,0 +1,64 @@
+"""Tests for the CountingStage migration (§3.2).
+
+Stage wrapper contract:
+  - delete → short_circuit + deleted flags
+  - no-delete → empty result
+  - delegates to cog._process_counting_message
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from cogs.counting._stage import (
+    COUNTING_STAGE_NAME,
+    COUNTING_STAGE_ORDER,
+    CountingStage,
+)
+from core.runtime.message_pipeline import MessagePipelineContext
+
+
+class TestCountingStage:
+    def test_metadata(self):
+        stage = CountingStage(MagicMock())
+        assert stage.name == COUNTING_STAGE_NAME == "counting"
+        assert stage.order == COUNTING_STAGE_ORDER == 10
+
+    @pytest.mark.asyncio
+    async def test_delete_short_circuits(self):
+        cog = MagicMock()
+        cog._process_counting_message = AsyncMock(return_value=True)
+        stage = CountingStage(cog)
+        ctx = MessagePipelineContext(bot=MagicMock(), message=MagicMock())
+
+        result = await stage.process(ctx)
+
+        assert result.deleted is True
+        assert result.short_circuit is True
+        assert result.moderation_action is None
+
+    @pytest.mark.asyncio
+    async def test_no_delete_passes_through(self):
+        cog = MagicMock()
+        cog._process_counting_message = AsyncMock(return_value=False)
+        stage = CountingStage(cog)
+        ctx = MessagePipelineContext(bot=MagicMock(), message=MagicMock())
+
+        result = await stage.process(ctx)
+
+        assert result.deleted is False
+        assert result.short_circuit is False
+
+    @pytest.mark.asyncio
+    async def test_delegates_message_to_cog(self):
+        cog = MagicMock()
+        cog._process_counting_message = AsyncMock(return_value=False)
+        stage = CountingStage(cog)
+        message = MagicMock()
+        ctx = MessagePipelineContext(bot=MagicMock(), message=message)
+
+        await stage.process(ctx)
+
+        cog._process_counting_message.assert_awaited_once_with(message)

--- a/tests/unit/runtime/test_message_pipeline_invariant.py
+++ b/tests/unit/runtime/test_message_pipeline_invariant.py
@@ -1,0 +1,127 @@
+"""INV gate: no raw ``on_message`` listeners outside the message pipeline.
+
+Phase §3.2 consolidated five concurrent ``@commands.Cog.listener()
+on_message`` handlers (counting / chain / cleanup / xp / rps_tournament)
+into one platform-level listener in ``core/runtime/message_pipeline.py``
+that dispatches to registered :class:`MessageStage` handlers in
+defined order.
+
+Once the migration is complete this test guards the invariant so a
+new raw ``on_message`` listener can't sneak back in.  The catch is
+strict — it covers every decorator form that registers an
+``on_message`` listener with discord.py:
+
+  * ``@commands.Cog.listener()`` over ``async def on_message``
+  * ``@bot.event`` over ``async def on_message``
+  * ``@bot.listen("on_message")`` over any async function
+
+The lone permitted site is ``core/runtime/message_pipeline.py``,
+which intentionally registers the single platform listener via
+``@bot.listen("on_message")`` inside :func:`setup`.
+
+If you need to extend message handling, **register a MessageStage**
+with the pipeline (see XpStage / CleanupStage / CountingStage /
+ChainStage / RpsTournamentStage for examples).  Adding a new raw
+listener brings back the ordering bugs §2.2 was created to fix.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCAN_ROOT = REPO_ROOT / "disbot"
+
+ALLOW_LIST = {
+    "disbot/core/runtime/message_pipeline.py",
+}
+
+
+def _decorator_targets_on_message(dec: ast.expr) -> bool:
+    """Return True if ``dec`` is one of the three on_message-registration forms."""
+    # @bot.listen("on_message")  /  @SOMETHING.listen("on_message")
+    if isinstance(dec, ast.Call):
+        func = dec.func
+        # x.listen("on_message")
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "listen"
+            and dec.args
+            and isinstance(dec.args[0], ast.Constant)
+            and dec.args[0].value == "on_message"
+        ):
+            return True
+        # commands.Cog.listener() — caller still checks function name == on_message
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "listener"
+            and isinstance(func.value, ast.Attribute)
+            and func.value.attr == "Cog"
+        ):
+            return True
+        # bot.event() with no args (rare; @bot.event without parens is the common form)
+        if isinstance(func, ast.Attribute) and func.attr == "event":
+            return True
+    # @bot.event  (attribute, not call)
+    if isinstance(dec, ast.Attribute) and dec.attr == "event":
+        return True
+    return False
+
+
+def _scan_file(path: Path) -> list[tuple[int, str]]:
+    """Return [(lineno, decorator-form)] for every on_message registration."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return []
+    out: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef):
+            continue
+        for dec in node.decorator_list:
+            if not _decorator_targets_on_message(dec):
+                continue
+            # commands.Cog.listener() requires the function NAME to be on_message
+            # for it to register as that event.  bot.listen("on_message") and
+            # bot.event don't care about the function name — the name is set by
+            # the decorator args / event field.  Be conservative and report only
+            # when the function name is on_message OR the listen("on_message")
+            # form is present.
+            if isinstance(dec, ast.Call) and isinstance(dec.func, ast.Attribute):
+                if (
+                    dec.func.attr == "listen"
+                    and dec.args
+                    and isinstance(dec.args[0], ast.Constant)
+                    and dec.args[0].value == "on_message"
+                ):
+                    out.append((node.lineno, '@x.listen("on_message")'))
+                    break
+                if dec.func.attr == "listener" and node.name == "on_message":
+                    out.append((node.lineno, "@commands.Cog.listener() on_message"))
+                    break
+                if dec.func.attr == "event" and node.name == "on_message":
+                    out.append((node.lineno, "@bot.event on_message"))
+                    break
+            elif isinstance(dec, ast.Attribute) and dec.attr == "event":
+                if node.name == "on_message":
+                    out.append((node.lineno, "@bot.event on_message"))
+                    break
+    return out
+
+
+def test_no_raw_on_message_listeners_outside_pipeline() -> None:
+    violations: list[str] = []
+    for path in SCAN_ROOT.rglob("*.py"):
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        if rel in ALLOW_LIST:
+            continue
+        for lineno, form in _scan_file(path):
+            violations.append(
+                f"{rel}:{lineno}: {form} — register a MessageStage with "
+                "core.runtime.message_pipeline instead",
+            )
+    assert not violations, (
+        "raw on_message listeners found outside "
+        "core/runtime/message_pipeline.py:\n\n" + "\n".join(violations)
+    )


### PR DESCRIPTION
## Summary

Closes **§3.2**. Two things:

### 1. Brings the counting + chain migrations to main

**Heads-up — stacked-PR gotcha:** PRs #66 (counting) and #67 (chain)
were merged into PR #64's branch (`claude/message-pipeline-cleanup`)
rather than into `main`. When #64 merged via merge-commit, the
cleanup branch wasn't deleted, so the stacked PRs' bases didn't
auto-retarget to `main`. Their merges landed on the orphaned cleanup
branch instead, leaving `main` with only the cleanup migration.

This PR cherry-picks the two underlying commits onto a fresh branch
from current `main`. Diff matches exactly what reviewers approved on
#66 and #67 — no new functional changes from those commits.

### 2. Adds the §3.2 INV gate

`tests/unit/runtime/test_message_pipeline_invariant.py` forbids raw
`on_message` listeners outside `core/runtime/message_pipeline.py`.
Uses AST (not regex) so all three discord.py registration forms are
caught reliably:

```
@commands.Cog.listener() over async def on_message
@bot.event over async def on_message
@bot.listen("on_message") over any async function
```

Allow-list: a single entry, `message_pipeline.py` itself, which
intentionally registers the platform listener via `@bot.listen`
inside `setup(bot)`.

## After this PR merges

§3.2 is complete:

- ✅ All 5 cogs (xp / cleanup / counting / chain / rps_tournament) run through the message pipeline
- ✅ Auto-mod deletes (cleanup / counting / chain) route through `moderation_service.auto_delete` — audit rows in `mod_logs` + `EVT_MOD_ACTION` emission
- ✅ Pipeline ordering: XP no longer rewards deleted messages (moderation tier order=10 short-circuits XpStage at order=20)
- ✅ INV gate prevents the pattern from regressing

## Test plan

### 1. Static gates

- [ ] `ruff check`, `black --check`, `isort --check-only`, `mypy disbot/` → all clean

### 2. Unit tests

- [ ] `pytest tests/` → **964 / 964 pass** (+9 from cherry-picked counting, +7 from cherry-picked chain, +1 INV test)
- [ ] `pytest tests/unit/runtime/test_message_pipeline_invariant.py -v` → 1 pass

### 3. INV gate negative test

Verified locally — injecting

```python
class _Bad:
    @commands.Cog.listener()
    async def on_message(self, message):
        pass
```

into `disbot/cogs/admin_cog.py` triggers the gate with:

```
disbot/cogs/admin_cog.py:NNN: @commands.Cog.listener() on_message — register a MessageStage with core.runtime.message_pipeline instead
```

Then reverting passes again.

### 4. Functional smoke

Since #66's and #67's commits are reproduced exactly here, the
existing smoke test plans from those PRs apply:

**Counting (from #66):**
- [ ] Invalid count in active counting channel → deleted, audit row appears with `action="auto_delete:counting.invalid"`
- [ ] Valid count → ✅ reaction, XP awarded
- [ ] Invalid count → deleted, **XP NOT awarded** (short_circuit at order=10)

**Chain (from #67):**
- [ ] Disallowed word in chained channel → deleted, audit row with `action="auto_delete:chain.violation"`
- [ ] Allowed word → `chain_count` increments, XP awarded
- [ ] `?chain list` (command in chained channel) → command runs, no deletion (command-context skip preserved)

**Pipeline integration:**
- [ ] Bot's own messages → never reach any stage (pre-filter)
- [ ] DM to bot → never reaches any stage (pre-filter)
- [ ] Hot-reload a cog → stage re-registers cleanly (no duplicates in `stages_snapshot()`)

### 5. Audit dashboard

- [ ] `SELECT DISTINCT action FROM mod_logs WHERE action LIKE 'auto_delete:%' ORDER BY 1` shows all five rule families:
  - `auto_delete:chain.violation`
  - `auto_delete:cleanup.command_policy`
  - `auto_delete:cleanup.prohibited_words`
  - `auto_delete:cleanup.whitelist`
  - `auto_delete:counting.invalid`

## What happened with the orphan branch

`claude/message-pipeline-cleanup` is now an orphan with the #66/#67
merge commits. It can be safely deleted from GitHub once this PR
merges — its meaningful content is here.

https://claude.ai/code/session_01FuuCnXTg7FWygNZN5T2DKB

---
_Generated by [Claude Code](https://claude.ai/code/session_01FuuCnXTg7FWygNZN5T2DKB)_