### PR TITLE
Phase 2a hardening — DB constraints, enum drift guard, structural-vs-permission split, role assignability, cleanup primitive

### DIFF
--- a/disbot/core/resources/discovery.py
+++ b/disbot/core/resources/discovery.py
@@ -80,7 +80,14 @@ def channel_to_snapshot(channel: discord.abc.GuildChannel) -> ChannelResource:
 
 
 def role_to_snapshot(role: discord.Role) -> RoleResource:
-    """Build a :class:`RoleResource` snapshot of ``role``."""
+    """Build a :class:`RoleResource` snapshot of ``role``.
+
+    Phase 2a hardening split ``is_managed`` from ``is_assignable`` —
+    the former is the intrinsic Discord ``role.managed`` flag, the
+    latter is the contextual "bot can assign" check that also factors
+    in hierarchy + permissions.  See :class:`RoleResource` for why the
+    two are tracked separately.
+    """
     return RoleResource(
         id=role.id,
         name=role.name,
@@ -90,7 +97,8 @@ def role_to_snapshot(role: discord.Role) -> RoleResource:
         permissions_bitfield=role.permissions.value,
         mentionable=role.mentionable,
         hoist=role.hoist,
-        is_managed=role.is_assignable() is False or role.managed,
+        is_managed=role.managed,
+        is_assignable=role.is_assignable(),
     )
 
 
@@ -221,17 +229,26 @@ def resolve_resource(
 # ---------------------------------------------------------------------------
 
 
-def _compute_status(
+def _compute_structural_status(
     guild: discord.Guild,
     kind: ResourceKind,
     resource_id: int,
 ) -> ResourceStatus:
-    """Pure status computation; no DB writes.
+    """Structural-only status computation; no DB writes.
 
-    Returns :class:`ResourceStatus.BOUND` if the resource exists and is
-    the right type, :class:`ResourceStatus.MISSING` if it does not
-    exist, :class:`ResourceStatus.INVALID` if it exists but with the
-    wrong type (e.g. caller asked for CHANNEL, ID points at a category).
+    Phase 2a scope:
+
+    * ``BOUND`` — resource exists in the guild **and** matches the
+      expected :class:`ResourceKind`.  Does *not* assert the bot has
+      sufficient permissions to operate on the resource.
+    * ``MISSING`` — guild's discord.py cache has no entry for the id.
+    * ``INVALID`` — entry exists but is the wrong shape (channel id
+      points at a category, thread is archived/locked, etc.).
+
+    Phase 4.5 adds the sibling permission-aware path
+    (:func:`validate_resource_permissions`).  Treat ``BOUND`` from this
+    function as "structurally valid", **not** "ready for every
+    capability the bot might attempt".
     """
     if kind is ResourceKind.CHANNEL:
         candidate = guild.get_channel(resource_id)
@@ -272,13 +289,19 @@ async def validate_resource(
     *,
     persist: bool = True,
 ) -> ResourceStatus:
-    """Compute the live status for a resource and (optionally) persist it.
+    """Compute the live **structural** status for a resource and persist it.
+
+    Returns the result of :func:`_compute_structural_status` — Phase 2a
+    scope is "does the resource exist with the right shape?".  A
+    ``BOUND`` result does NOT assert the bot has sufficient permissions
+    to operate on the resource; that is Phase 4.5 work, surfaced via
+    :func:`validate_resource_permissions`.
 
     ``persist=False`` is for read-only diagnostics that should not write
     the cache (e.g. dry-run completeness checks).  Default is to upsert
     the row so subsequent ``get_status`` calls see the fresh value.
     """
-    status = _compute_status(guild, kind, resource_id)
+    status = _compute_structural_status(guild, kind, resource_id)
     if persist:
         try:
             await resource_cache.upsert_status(
@@ -318,7 +341,7 @@ async def validate_resources(
     results: dict[tuple[ResourceKind, int], ResourceStatus] = {}
     rows_to_write: list[tuple[int, str, int, str]] = []
     for kind, resource_id in materialised:
-        status = _compute_status(guild, kind, resource_id)
+        status = _compute_structural_status(guild, kind, resource_id)
         results[(kind, resource_id)] = status
         rows_to_write.append((guild.id, kind.value, resource_id, status.value))
     try:
@@ -353,6 +376,51 @@ def find_role_by_name(guild: discord.Guild, name: str) -> discord.Role | None:
     )
 
 
+# ---------------------------------------------------------------------------
+# Phase 4.5 permission-aware validation hook
+# ---------------------------------------------------------------------------
+
+
+async def validate_resource_permissions(
+    guild: discord.Guild,
+    kind: ResourceKind,
+    resource_id: int,
+    capability: str,
+) -> ResourceStatus:
+    """Phase 4.5 hook — permission-aware resource validation.
+
+    Companion to :func:`validate_resource`.  Where ``validate_resource``
+    answers "does this resource exist with the right shape?", this
+    function answers "can the bot exercise *capability* against this
+    resource?" — e.g. can it post in the channel, edit the role,
+    archive the thread.
+
+    Phase 2a ships the signature only; the implementation lands in
+    Phase 4.5 alongside the governance access-control runtime.  Until
+    then this raises :exc:`NotImplementedError` so callers cannot
+    silently treat a missing implementation as ``BOUND``.
+
+    The Phase 4.5 implementation will:
+
+    * Resolve the live discord object via the same paths
+      :func:`_compute_structural_status` uses.
+    * Cross-reference :data:`governance.permission_tiers.PermissionTier`
+      and the relevant bitfield checks for the resource kind.
+    * Return :class:`ResourceStatus.BOUND` only when both structural
+      AND permission preconditions hold.
+    * Cache the permission-aware result alongside the structural
+      result (separate column or sibling table TBD in Phase 4.5).
+    """
+    del guild, kind, resource_id, capability
+    msg = (
+        "validate_resource_permissions is not yet implemented — Phase "
+        "4.5 of the platform roadmap fills in permission-aware "
+        "resource validation.  Use validate_resource() for structural "
+        "checks until then."
+    )
+    raise NotImplementedError(msg)
+
+
 __all__ = [
     "category_to_snapshot",
     "channel_to_snapshot",
@@ -366,5 +434,6 @@ __all__ = [
     "role_to_snapshot",
     "thread_to_snapshot",
     "validate_resource",
+    "validate_resource_permissions",
     "validate_resources",
 ]

--- a/disbot/core/resources/status.py
+++ b/disbot/core/resources/status.py
@@ -24,11 +24,19 @@ from enum import Enum
 class ResourceStatus(Enum):
     """Validation state for a guild resource.
 
+    Phase 2a ships **structural** validation only — Phase 4.5 adds the
+    permission-aware companion path (see
+    :func:`core.resources.discovery.validate_resource_permissions`).
+    The terms below reflect that scope:
+
     Members:
 
     BOUND:
-        The resource exists in the guild and the bot can interact with
-        it as expected.  This is the steady state.
+        The resource exists in the guild and matches the expected
+        :class:`ResourceKind`.  This is a *structural* "found and the
+        right shape" claim; it does **not** assert the bot has
+        sufficient permissions to operate on the resource.  Phase 4.5
+        adds the permission-readiness check.
     UNRESOLVED:
         The resource has not been validated yet (e.g. recently bound,
         cache miss after restart).  The next probe will transition to
@@ -38,10 +46,11 @@ class ResourceStatus(Enum):
         existed, or out of cache).  Phase 7.5's repair flow may offer
         to recreate it from the subsystem's resource requirement.
     INVALID:
-        The resource exists but the bot cannot operate on it
-        (permission gap, wrong type, archived thread, etc.).  Phase 4c
-        diagnostics surface the specific reason; this enum value just
-        says "exists, unusable".
+        The resource exists but is the wrong type for the caller's
+        request (channel ID points at a category; thread is archived or
+        locked).  ``INVALID`` is *structural unusability*; permission
+        gaps are a separate concern Phase 4.5 will surface through a
+        sibling status path.  Phase 4c diagnostics consume both.
     """
 
     BOUND = "bound"

--- a/disbot/core/resources/types.py
+++ b/disbot/core/resources/types.py
@@ -108,6 +108,24 @@ class RoleResource(GuildResource):
     :class:`discord.Permissions` object exposes via ``.value``; consumers
     that need named permission flags should reconstruct the Permissions
     object on demand rather than serializing them here.
+
+    Phase 2a hardening split ``is_managed`` into two distinct fields:
+
+    * ``is_managed`` — *intrinsic* property of the role.  ``True`` only
+      for integration-managed roles (bot roles, Nitro booster roles,
+      Twitch subscriber roles) where Discord forbids assignment by any
+      member.  Mirrors :attr:`discord.Role.managed`.
+    * ``is_assignable`` — *contextual* property answering "can the
+      currently-running bot assign this role?".  ``False`` when the bot
+      is below the role in the hierarchy, lacks ``manage_roles``, or
+      the role is integration-managed.  Mirrors
+      :meth:`discord.Role.is_assignable`.
+
+    Keeping the two separate matters for Phase 4.5's role-mapping flow:
+    a non-managed role the bot cannot assign (hierarchy issue) is
+    operator-repairable; an integration-managed role is not.  Conflating
+    them as a single ``is_managed`` would force the wizard to treat both
+    as un-fixable.
     """
 
     color: int = 0
@@ -115,7 +133,8 @@ class RoleResource(GuildResource):
     permissions_bitfield: int = 0
     mentionable: bool = False
     hoist: bool = False
-    is_managed: bool = False  # True for bot-managed / integration roles
+    is_managed: bool = False  # Discord-managed integration role
+    is_assignable: bool = True  # Bot can assign this role (hierarchy + perms)
     kind: ResourceKind = ResourceKind.ROLE
 
 

--- a/disbot/migrations/021_resource_validation_cache_constraints.sql
+++ b/disbot/migrations/021_resource_validation_cache_constraints.sql
@@ -1,0 +1,44 @@
+-- Migration 021: CHECK constraints for resource_validation_cache.
+--
+-- Migration 020 created the table with TEXT columns for ``kind`` and
+-- ``status`` so the application's enum values land as strings.  This
+-- migration adds DB-level CHECK constraints so type-confusion writes
+-- (a typo, a future enum drift) fail at the database boundary
+-- instead of producing a corrupt cache row the platform later treats
+-- as "unknown".
+--
+-- Forward-only and idempotent: the ``IF NOT EXISTS``-style guard
+-- around each ALTER tolerates re-application on databases where the
+-- constraint already exists (e.g. a re-run after a migration replay).
+--
+-- The constraint values match the Python enums:
+--   ``core.resources.types.ResourceKind``    — channel, role, category, thread
+--   ``core.resources.status.ResourceStatus`` — bound, unresolved, missing, invalid
+-- The Phase 2a-hardening invariant test
+-- ``tests/unit/invariants/test_resource_kind_alignment.py`` guards
+-- the Python-side enums from drift.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM   information_schema.table_constraints
+        WHERE  constraint_name = 'resource_validation_cache_kind_check'
+        AND    table_name      = 'resource_validation_cache'
+    ) THEN
+        ALTER TABLE resource_validation_cache
+            ADD CONSTRAINT resource_validation_cache_kind_check
+            CHECK (kind IN ('channel', 'role', 'category', 'thread'));
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM   information_schema.table_constraints
+        WHERE  constraint_name = 'resource_validation_cache_status_check'
+        AND    table_name      = 'resource_validation_cache'
+    ) THEN
+        ALTER TABLE resource_validation_cache
+            ADD CONSTRAINT resource_validation_cache_status_check
+            CHECK (status IN ('bound', 'unresolved', 'missing', 'invalid'));
+    END IF;
+END$$;

--- a/disbot/utils/db/resource_cache.py
+++ b/disbot/utils/db/resource_cache.py
@@ -160,6 +160,30 @@ async def delete_status(guild_id: int, kind: str, resource_id: int) -> None:
     )
 
 
+async def delete_for_guild(guild_id: int) -> int:
+    """Remove every cached row for ``guild_id``.
+
+    Returns the number of rows deleted (best-effort — parsed from the
+    ``"DELETE N"`` status string asyncpg returns; falls back to ``0``
+    if the format ever changes).
+
+    Phase 2a hardening introduced this primitive so the wiring change
+    that adds it to :mod:`disbot.guild_lifecycle`'s teardown sequence is
+    a one-line addition rather than a refactor.  The wiring itself
+    lands as a follow-up (the lifecycle module's nine-step cleanup
+    sequence has its own ordering rules + tests; mixing them with
+    Phase 2a expanded the review surface unnecessarily).
+    """
+    result = await pool.get().execute(
+        "DELETE FROM resource_validation_cache WHERE guild_id = $1",
+        guild_id,
+    )
+    try:
+        return int(result.split()[-1])
+    except (ValueError, IndexError):
+        return 0
+
+
 async def count_by_status(
     guild_id: int,
     *,
@@ -196,6 +220,7 @@ async def count_by_status(
 
 __all__ = [
     "count_by_status",
+    "delete_for_guild",
     "delete_status",
     "get_status",
     "get_statuses_for_guild",

--- a/docs/phase_2b_bindings_plan.md
+++ b/docs/phase_2b_bindings_plan.md
@@ -1,0 +1,201 @@
+# Phase 2b — Guild Bindings (next-PR plan)
+
+> **Status:** plan, not implementation.  Phase 2a hardening (PR #72)
+> lands first; this document describes what the *next* PR should
+> contain, in scope.  It is intentionally narrow — bindings only.  The
+> sibling Phase 2 sub-phases (participation, feature flags) ship in
+> separate PRs.
+
+## Goal
+
+Replace the raw-string `channel_id` / `role_id` pattern in
+`guild_settings` with a typed `subsystem_bindings` table backed by a
+mutation pipeline.  Every later phase (4c diagnostics, 6.5 routing, 7
+wizard, 7.5 provisioning) reads bindings, never raw IDs.
+
+## Scope (hard limits)
+
+| In scope                                              | Out of scope                          |
+|-------------------------------------------------------|---------------------------------------|
+| `subsystem_bindings` table + migration                | Setup wizard UI                        |
+| `BindingMutationPipeline` (6-step contract)           | Resource provisioning (Phase 7.5)      |
+| `BindingValue` typed model + `get_binding` accessor   | Participation tables (Phase 2c)        |
+| Legacy `db.get_setting` fallback for migrated keys    | Feature flag runtime (Phase 2d)        |
+| Backfill plan for ≥6 raw-id keys                      | Command behavior changes               |
+| Diagnostics provider + `!platform bindings`           | Cross-guild template support           |
+| Tests for missing / wrong-kind / unknown subsystem    |                                        |
+
+## Storage shape (migration 022)
+
+```sql
+CREATE TABLE IF NOT EXISTS subsystem_bindings (
+    guild_id          BIGINT      NOT NULL,
+    subsystem         TEXT        NOT NULL,
+    binding_name      TEXT        NOT NULL,
+    kind              TEXT        NOT NULL,
+    target_id         BIGINT,         -- NULL for unbound slots
+    status            TEXT        NOT NULL DEFAULT 'unresolved',
+    last_validated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    version           INTEGER     NOT NULL DEFAULT 1,
+    PRIMARY KEY (guild_id, subsystem, binding_name),
+    CHECK (kind   IN ('channel', 'role', 'category', 'thread', 'member')),
+    CHECK (status IN ('bound', 'unresolved', 'missing', 'invalid'))
+);
+CREATE INDEX IF NOT EXISTS idx_subsystem_bindings_guild_status
+    ON subsystem_bindings (guild_id, status);
+```
+
+The `kind` and `status` CHECK constraints reuse the Phase 2a taxonomy
+(plus `member` — bindings can target users; Phase 2a resources do not
+include members because they are not provisionable).
+
+## Modules to add
+
+```
+disbot/core/runtime/bindings.py        — BindingStore + typed read API
+disbot/services/binding_mutation.py    — BindingMutationPipeline (6-step)
+disbot/utils/db/bindings.py            — CRUD primitives
+```
+
+## Read path
+
+`disbot/utils/guild_config_accessors.py` gets a new `get_binding`:
+
+```python
+async def get_binding(
+    guild_id: int,
+    subsystem: str,
+    binding_name: str,
+) -> BindingValue:
+    ...
+```
+
+`BindingValue` exposes `target_id: int | None`, `status: ResourceStatus`,
+`last_validated_at: datetime`.  Consumers never touch raw target IDs;
+the resolver path is always `get_binding(...) → BindingValue →
+core.resources.channel_service.get_channel(target_id)` etc.
+
+## Write path
+
+`BindingMutationPipeline` mirrors `GovernanceMutationPipeline`'s
+contract.  The six steps:
+
+1. **Input validation** — kind matches a declared `BindingSpec`, target
+   exists per `core.resources.discovery.resolve_resource`.
+2. **Authority validation** — `capability_required` from the
+   `BindingSpec` resolved through Phase 4.5's `access_control_service`
+   shell.  Phase 2b accepts a placeholder that requires `administrator`
+   tier; Phase 4.5 swaps in the typed capability check.
+3. **Read old value** — fetched via `bindings.get_binding`.  Used by
+   the audit row.
+4. **DB write + audit** — single transaction.  Audit row carries
+   `mutation_id`, actor, before/after target IDs.
+5. **Cache invalidation** — `guild_config` invalidation for the
+   binding namespace key (`subsystem.binding_name`); resource cache
+   not touched.
+6. **Event emission** — `EVT_BINDING_CHANGED` with the audit
+   `mutation_id`.
+
+## Legacy fallback + backfill strategy
+
+Keys to migrate (initial set):
+
+| Key                       | Subsystem    | Binding name        | Kind    |
+|---------------------------|--------------|---------------------|---------|
+| `XP_ANNOUNCE_CHANNEL`     | xp           | `announce_channel`  | channel |
+| `ECONOMY_LOG_CHANNEL`     | economy      | `log_channel`       | channel |
+| `TRUSTED_TIER_ROLE_ID`    | governance   | `trusted_role`      | role    |
+| `XP_THRESHOLD_ROLES` ids  | xp           | (per-threshold)     | role    |
+| `WARN_*` (no resource id) | moderation   | n/a — settings, not bindings | —  |
+
+Backfill runs once at startup behind a feature flag
+(`bindings.primary` from Phase 1d declarations — Phase 2b reads it
+directly until Phase 2d's runtime evaluator lands):
+
+* **Pre-flip release** (`bindings.primary = false`):
+  reads come from `guild_settings` (legacy); writes go to *both*
+  tables (legacy + `subsystem_bindings`) so a flag flip is reversible.
+* **Flip release** (`bindings.primary = true`):
+  reads from `subsystem_bindings`; legacy `guild_settings` rows kept
+  as fallback for one full release.
+* **Cleanup release**:
+  legacy `db.set_setting` calls for migrated keys are AST-blocked;
+  the legacy rows can be archived.
+
+The backfill itself runs under `pg_advisory_lock` (mirrors migration
+runner's safety primitive) and writes are tagged
+`actor_type='backfill_v1'` in the audit table so the inflation is
+distinguishable from operator writes.
+
+## Diagnostics + observability
+
+* `!platform bindings` admin command — per-subsystem binding count
+  histogram + status counts (`bound`/`missing`/`unresolved`/`invalid`).
+* Prometheus metrics:
+    * `subsystem_bindings_status_total{subsystem,status}`
+    * `binding_mutation_total{subsystem,outcome}`
+* EventBus event `EVT_BINDING_CHANGED` in
+  `core.events_catalogue.KNOWN_EVENTS` (Phase 4c subscribes for
+  cache-status updates; Phase 6.5 will subscribe for notification
+  routing once it lands).
+
+## Identity contract
+
+No new surface added in Phase 2b — the schema-side identity contract
+extension lands in Phase 6.  Phase 2b only adds soft validation: the
+`BindingMutationPipeline` rejects a `binding_name` not declared in
+the corresponding `SubsystemSchema` from Phase 1a.
+
+## Test plan (target ≥ 30 tests)
+
+Required coverage:
+
+| Area                               | Test |
+|------------------------------------|------|
+| Pipeline rejects unknown subsystem | binding for `unknown_subsystem.foo` fails at step 1 |
+| Pipeline rejects undeclared name   | binding for declared subsystem but unknown name fails |
+| Pipeline rejects wrong kind        | channel-kind binding gets a role id → INVALID, audit row written, no write to bindings table |
+| Pipeline rejects below-tier actor  | non-administrator caller raises UnauthorizedBindingMutation |
+| Pipeline commits + emits event     | audit row written; cache invalidated; event emitted with `mutation_id` |
+| Pipeline rollback on event failure | audit + DB row stays; emit failure logged but does not raise |
+| `get_binding` returns BindingValue with status, target_id, timestamp |
+| `get_binding` UNRESOLVED when row missing |
+| Legacy fallback ON: reads from `guild_settings` |
+| Legacy fallback OFF: reads from `subsystem_bindings` |
+| Backfill writes `actor_type='backfill_v1'` audit row |
+| Backfill is idempotent under repeat |
+
+## Behavior impact
+
+Zero command-facing changes in Phase 2b.  Existing cogs continue to
+read via their typed accessors (`get_xp_config`, etc.); the only
+visible difference is the new `!platform bindings` admin surface and
+the `bindings.primary` flag declaration becoming queryable through
+the Phase 4 diagnostics path once 2d ships.
+
+## What's blocked until Phase 2b lands
+
+* Phase 4c resource diagnostics needs `subsystem_bindings` to compute
+  "which binding does this missing resource belong to?".  Phase 4c
+  can ship a subset (purely resource-side findings) without 2b, but
+  the binding-aware findings are blocked.
+* Phase 7 wizard cannot persist binding writes until the pipeline
+  exists.  The wizard's screen primitives (Phase 5b) can still be
+  built; the commit path is the blocker.
+* Phase 7.5 setup packs need a binding to point at the resource they
+  provisioned.  Until 2b, packs would have to write raw IDs to
+  `guild_settings` — exactly the regression 2b is designed to prevent.
+* Phase 6.5 notification routing reads
+  `binding_value.target_id` for "where to deliver" — blocked.
+
+Phases 2c (participation), 2d (feature flags), 4c (resource
+diagnostics in isolation), and 4.5 (governance access-control,
+including the role-template surfaces) are *not* blocked by 2b and
+can be sequenced in any order relative to it.
+
+---
+
+**Next-PR shape:**
+single PR titled "Phase 2b — Guild Bindings + BindingMutationPipeline",
+roughly 1500–2000 LOC including migration + tests, no behavior
+changes for existing flows.

--- a/tests/unit/invariants/test_resource_kind_alignment.py
+++ b/tests/unit/invariants/test_resource_kind_alignment.py
@@ -1,0 +1,90 @@
+"""Phase 2a hardening — ResourceKind enum drift protection.
+
+Two enums spell out the resource taxonomy:
+
+* :class:`core.runtime.resource_specs.ResourceKind` — the *declaration*
+  side.  Phase 1c subsystem schemas use it to declare what kinds of
+  resources they need.
+* :class:`core.resources.types.ResourceKind` — the *snapshot* side.
+  Phase 2a's discovery layer produces snapshots tagged with this enum.
+
+The two layers are independent (a snapshot may exist for a kind a
+schema hasn't declared yet — an orphan; a schema may declare a kind
+before any guild has that resource), so they live in separate modules.
+That independence creates a drift risk: if someone adds ``FORUM`` to
+one enum and not the other, Phase 2b's binding pipeline would either
+reject a valid declaration or accept a snapshot whose kind it doesn't
+understand.
+
+This invariant test pins the two enums to the same ``.value`` set so
+the drift fails fast at CI time rather than silently in production.
+The migration-021 CHECK constraints + this Python invariant together
+prevent drift in either direction (Python vs Python; Python vs DB).
+"""
+
+from __future__ import annotations
+
+
+def test_resource_kind_enum_values_match():
+    """Snapshot-side and declaration-side ResourceKind agree on members."""
+    from core.resources.types import ResourceKind as SnapshotKind
+    from core.runtime.resource_specs import ResourceKind as DeclKind
+
+    snap_values = {k.value for k in SnapshotKind}
+    decl_values = {k.value for k in DeclKind}
+
+    extra_in_snap = snap_values - decl_values
+    extra_in_decl = decl_values - snap_values
+
+    assert not extra_in_snap and not extra_in_decl, (
+        "ResourceKind drift detected — Phase 2a snapshot enum and Phase "
+        "1c declaration enum must agree on member values.\n"
+        f"  in snapshot but not declaration: {sorted(extra_in_snap)}\n"
+        f"  in declaration but not snapshot: {sorted(extra_in_decl)}\n"
+        "Fix: update both enums in lockstep; Phase 2b's binding "
+        "pipeline routes by kind and cannot tolerate a one-sided "
+        "addition.",
+    )
+
+
+def test_resource_kind_values_match_migration_021_check():
+    """Python enum values match the DB-level CHECK constraint in migration 021.
+
+    If a new kind is added to the Python enum, this test fails until
+    migration 02X is added that extends the CHECK constraint.  That is
+    the desired forcing function — DB and Python stay aligned.
+    """
+    from core.resources.types import ResourceKind
+
+    # Mirror of migration 021's CHECK constraint value list.  Update
+    # *both* when adding a new kind: this list and the migration.
+    db_check_values = {"channel", "role", "category", "thread"}
+
+    python_values = {k.value for k in ResourceKind}
+    missing_in_db = python_values - db_check_values
+    missing_in_python = db_check_values - python_values
+
+    assert not missing_in_db and not missing_in_python, (
+        "ResourceKind / DB CHECK-constraint drift detected.\n"
+        f"  in Python but not DB CHECK: {sorted(missing_in_db)}\n"
+        f"  in DB CHECK but not Python: {sorted(missing_in_python)}\n"
+        "Fix: ship a new migration that ALTERs the CHECK constraint, "
+        "and update the literal in this test.",
+    )
+
+
+def test_resource_status_values_match_migration_021_check():
+    """Python ResourceStatus enum matches the DB CHECK constraint values."""
+    from core.resources.status import ResourceStatus
+
+    db_check_values = {"bound", "unresolved", "missing", "invalid"}
+    python_values = {s.value for s in ResourceStatus}
+
+    missing_in_db = python_values - db_check_values
+    missing_in_python = db_check_values - python_values
+
+    assert not missing_in_db and not missing_in_python, (
+        "ResourceStatus / DB CHECK-constraint drift detected.\n"
+        f"  in Python but not DB CHECK: {sorted(missing_in_db)}\n"
+        f"  in DB CHECK but not Python: {sorted(missing_in_python)}",
+    )

--- a/tests/unit/resources/test_discovery.py
+++ b/tests/unit/resources/test_discovery.py
@@ -57,7 +57,22 @@ def _mk_category(category_id: int, name: str, *, channels=()):
     return cat
 
 
-def _mk_role(role_id: int, name: str, *, is_default=False, managed=False):
+def _mk_role(
+    role_id: int,
+    name: str,
+    *,
+    is_default=False,
+    managed=False,
+    is_assignable=None,
+):
+    """Mock a :class:`discord.Role` for snapshot tests.
+
+    Phase 2a hardening split ``is_managed`` (intrinsic) from
+    ``is_assignable`` (contextual).  Callers can supply either
+    independently; default behavior is "managed roles aren't assignable;
+    non-managed roles are" which matches the historical conflated
+    semantics for existing tests.
+    """
     role = MagicMock(spec=discord.Role)
     role.id = role_id
     role.name = name
@@ -68,7 +83,10 @@ def _mk_role(role_id: int, name: str, *, is_default=False, managed=False):
     role.hoist = False
     role.managed = managed
     role.is_default = MagicMock(return_value=is_default)
-    role.is_assignable = MagicMock(return_value=not managed)
+    effective_assignable = (
+        is_assignable if is_assignable is not None else not managed
+    )
+    role.is_assignable = MagicMock(return_value=effective_assignable)
     return role
 
 
@@ -133,6 +151,30 @@ def test_role_to_snapshot():
     assert snap.id == 42
     assert snap.name == "Moderator"
     assert snap.kind is ResourceKind.ROLE
+
+
+def test_role_to_snapshot_managed_and_assignable_split():
+    """Phase 2a hardening: snapshot factory must populate both fields
+    from their respective discord.py attributes, not conflate them."""
+    integration = _mk_role(1, "Bot", managed=True, is_assignable=False)
+    hierarchy_blocked = _mk_role(2, "Above", managed=False, is_assignable=False)
+    normal = _mk_role(3, "Member", managed=False, is_assignable=True)
+
+    snap_integration = discovery.role_to_snapshot(integration)
+    snap_blocked = discovery.role_to_snapshot(hierarchy_blocked)
+    snap_normal = discovery.role_to_snapshot(normal)
+
+    assert snap_integration.is_managed is True
+    assert snap_integration.is_assignable is False
+
+    # Hierarchy-blocked: NOT managed (Discord doesn't mark it so) but
+    # NOT assignable by the bot.  The conflated semantics from before
+    # P2a hardening incorrectly reported is_managed=True for this case.
+    assert snap_blocked.is_managed is False
+    assert snap_blocked.is_assignable is False
+
+    assert snap_normal.is_managed is False
+    assert snap_normal.is_assignable is True
 
 
 def test_category_to_snapshot():
@@ -370,6 +412,24 @@ async def test_validate_resource_cache_failure_swallowed():
             42,
         )
     assert status is ResourceStatus.BOUND
+
+
+@pytest.mark.asyncio
+async def test_validate_resource_permissions_is_phase_4_5_stub():
+    """Phase 2a ships the signature; Phase 4.5 fills in the implementation.
+
+    The hook MUST raise NotImplementedError rather than silently return
+    BOUND — Phase 2b's bindings could otherwise treat a missing
+    implementation as a green light to skip permission gating.
+    """
+    guild = _mk_guild()
+    with pytest.raises(NotImplementedError, match="Phase 4.5"):
+        await discovery.validate_resource_permissions(
+            guild,
+            ResourceKind.CHANNEL,
+            42,
+            "moderation.warn.apply",
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/resources/test_resource_cache.py
+++ b/tests/unit/resources/test_resource_cache.py
@@ -1,0 +1,116 @@
+"""Phase 2a hardening — resource_cache primitive tests.
+
+Tests cover only the *pure* shape of each primitive — DB integration
+tests would require a live Postgres instance, which the unit-test
+suite does not assume.  We mock :mod:`utils.db.pool` and assert each
+primitive issues the expected SQL with the expected parameters.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from utils.db import resource_cache
+
+
+@pytest.fixture
+def _mock_pool():
+    """Patch ``utils.db.pool.get()`` to return a mocked connection."""
+    pool_mock = MagicMock()
+    pool_mock.execute = AsyncMock()
+    pool_mock.fetchrow = AsyncMock()
+    pool_mock.fetch = AsyncMock()
+    with patch.object(resource_cache, "pool") as pool_module:
+        pool_module.get = MagicMock(return_value=pool_mock)
+        yield pool_mock
+
+
+# ---------------------------------------------------------------------------
+# delete_for_guild — Phase 2a hardening primitive
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_for_guild_issues_correct_sql(_mock_pool):
+    """delete_for_guild scopes the DELETE to (guild_id,)."""
+    _mock_pool.execute.return_value = "DELETE 5"
+    deleted = await resource_cache.delete_for_guild(42)
+    assert deleted == 5
+    _mock_pool.execute.assert_awaited_once()
+    sql, *args = _mock_pool.execute.await_args.args
+    assert "DELETE FROM resource_validation_cache" in sql
+    assert "WHERE guild_id = $1" in sql
+    assert args == [42]
+
+
+@pytest.mark.asyncio
+async def test_delete_for_guild_zero_rows(_mock_pool):
+    """delete_for_guild returns 0 when nothing matched."""
+    _mock_pool.execute.return_value = "DELETE 0"
+    assert await resource_cache.delete_for_guild(42) == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_for_guild_handles_unexpected_status(_mock_pool):
+    """If asyncpg ever returns a non-numeric tail, we return 0 rather
+    than raise — the caller's invariant is "cleanup attempted", not
+    "exact row count"."""
+    _mock_pool.execute.return_value = "UNEXPECTED STATUS"
+    assert await resource_cache.delete_for_guild(42) == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_for_guild_handles_empty_status(_mock_pool):
+    _mock_pool.execute.return_value = ""
+    assert await resource_cache.delete_for_guild(42) == 0
+
+
+# ---------------------------------------------------------------------------
+# Existing primitives — light coverage to verify SQL shape did not
+# regress when delete_for_guild landed.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_status_scopes_correctly(_mock_pool):
+    _mock_pool.execute.return_value = "DELETE 1"
+    await resource_cache.delete_status(42, "channel", 99)
+    _mock_pool.execute.assert_awaited_once()
+    sql, *args = _mock_pool.execute.await_args.args
+    assert "DELETE FROM resource_validation_cache" in sql
+    assert "guild_id = $1" in sql
+    assert "kind = $2" in sql
+    assert "resource_id = $3" in sql
+    assert args == [42, "channel", 99]
+
+
+@pytest.mark.asyncio
+async def test_upsert_status_writes_now_timestamp(_mock_pool):
+    _mock_pool.execute.return_value = "INSERT 0 1"
+    await resource_cache.upsert_status(42, "channel", 99, "bound")
+    sql, *args = _mock_pool.execute.await_args.args
+    assert "INSERT INTO resource_validation_cache" in sql
+    assert "ON CONFLICT (guild_id, kind, resource_id)" in sql
+    assert "DO UPDATE SET" in sql
+    assert args == [42, "channel", 99, "bound"]
+
+
+@pytest.mark.asyncio
+async def test_count_by_status_unfiltered(_mock_pool):
+    _mock_pool.fetch.return_value = [
+        {"status": "bound", "n": 5},
+        {"status": "missing", "n": 2},
+    ]
+    result = await resource_cache.count_by_status(42)
+    assert result == {"bound": 5, "missing": 2}
+
+
+@pytest.mark.asyncio
+async def test_count_by_status_filtered_by_kind(_mock_pool):
+    _mock_pool.fetch.return_value = []
+    await resource_cache.count_by_status(42, kind="channel")
+    sql, *args = _mock_pool.fetch.await_args.args
+    assert "kind = $2" in sql
+    assert args == [42, "channel"]

--- a/tests/unit/resources/test_types.py
+++ b/tests/unit/resources/test_types.py
@@ -79,6 +79,39 @@ def test_role_resource_carries_role_fields():
     assert snap.permissions_bitfield == 8
     assert snap.mentionable is True
     assert snap.kind is ResourceKind.ROLE
+    # Phase 2a hardening: managed vs assignable are independent.
+    assert snap.is_managed is False  # default
+    assert snap.is_assignable is True  # default
+
+
+def test_role_resource_managed_and_assignable_are_independent():
+    """An integration-managed role is managed but not assignable; a
+    hierarchy-blocked role is assignable=False yet managed=False.  The
+    two fields encode different facts and must vary independently."""
+    integration = RoleResource(
+        id=1,
+        name="Bot",
+        kind=ResourceKind.ROLE,
+        is_managed=True,
+        is_assignable=False,
+    )
+    hierarchy_blocked = RoleResource(
+        id=2,
+        name="Above the bot",
+        kind=ResourceKind.ROLE,
+        is_managed=False,
+        is_assignable=False,
+    )
+    normal = RoleResource(
+        id=3,
+        name="Member",
+        kind=ResourceKind.ROLE,
+        is_managed=False,
+        is_assignable=True,
+    )
+    assert integration.is_managed and not integration.is_assignable
+    assert not hierarchy_blocked.is_managed and not hierarchy_blocked.is_assignable
+    assert not normal.is_managed and normal.is_assignable
 
 
 def test_category_resource_carries_category_fields():


### PR DESCRIPTION
## Summary

Five small hardening fixes to Phase 2a (PR #71) before Phase 2b bindings depend on it. **No behavior changes for existing flows.** No new runtime semantics introduced. The goal is to close gaps the reviewer raised so the Phase 2b PR can focus purely on bindings rather than re-litigating Phase 2a's foundations.

## Changes

### 1. DB CHECK constraints (migration 021)

Forward-only, idempotent migration adds CHECK constraints to `resource_validation_cache` pinning `kind` and `status` to the Python-side enum values:

```sql
ALTER TABLE resource_validation_cache
    ADD CONSTRAINT resource_validation_cache_kind_check
    CHECK (kind IN ('channel', 'role', 'category', 'thread'));

ALTER TABLE resource_validation_cache
    ADD CONSTRAINT resource_validation_cache_status_check
    CHECK (status IN ('bound', 'unresolved', 'missing', 'invalid'));
```

Wrapped in `DO $$ ... END$$` blocks with `information_schema.table_constraints` guards so re-application is a no-op. **Migration 020 is unchanged.**

### 2. `ResourceKind` enum drift protection

New invariant test `tests/unit/invariants/test_resource_kind_alignment.py`:

- Pins `core.resources.types.ResourceKind` (snapshot) and `core.runtime.resource_specs.ResourceKind` (declaration) to the same `.value` set. Drift in either direction fails CI.
- Two companion tests pin the Python enums to migration 021's CHECK-constraint literals. Adding a new kind requires updating both Python enums AND landing a CHECK-altering migration — the test is the forcing function.

### 3. Structural-vs-permission validation semantics

The Phase 2a `ResourceStatus.BOUND` previously implied "the bot can interact with the resource as expected" — but `_compute_status` only validates existence + type + archived-thread state, not permissions. That mismatch would let Phase 2b mistakenly treat `BOUND` as a green light for capability gating.

Changes:
- `ResourceStatus.BOUND` docstring now says "**structurally** valid" with an explicit note that permission-readiness is separate.
- `_compute_status` renamed to `_compute_structural_status` with explicit Phase-2a-scope docstring.
- New `validate_resource_permissions(guild, kind, resource_id, capability)` hook ships the **signature** for Phase 4.5's permission-aware path; raises `NotImplementedError("Phase 4.5 ...")` today so callers cannot silently treat the missing path as a green light.

### 4. `RoleResource`: split `is_managed` from `is_assignable`

Phase 2a's `RoleResource.is_managed` conflated two facts:
- `discord.Role.managed` — intrinsic integration-managed flag (bot roles, Nitro booster roles)
- `discord.Role.is_assignable()` — contextual hierarchy + permissions check ("can the bot assign this role?")

These are different repair surfaces: an integration-managed role is un-fixable; a hierarchy-blocked role is operator-repairable. Conflating them would force Phase 4.5's role-mapping wizard to treat both as un-fixable.

Now:
- `is_managed: bool = False` — mirrors `role.managed` exclusively.
- `is_assignable: bool = True` (NEW) — mirrors `role.is_assignable()`.
- `role_to_snapshot` populates both fields independently.
- New tests cover the three meaningful shapes: integration-managed (managed=True, assignable=False), hierarchy-blocked (managed=False, assignable=False), normal (managed=False, assignable=True).
- `_mk_role` test factory accepts both flags with defaults preserving existing test expectations.

### 5. `resource_cache.delete_for_guild` primitive

Added with tests; returns the parsed row count from asyncpg's `"DELETE N"` status string, falling back to `0` on unexpected shape.

**NOT yet wired into `disbot/guild_lifecycle` teardown** — that's a one-line follow-up, but mixing it with hardening would expand the review surface unnecessarily and the lifecycle module's 9-step cleanup sequence has its own ordering rules. The docstring explicitly marks the follow-up.

## Phase 2b plan

`docs/phase_2b_bindings_plan.md` documents the next PR's scope:
- `subsystem_bindings` table + migration 022
- `BindingMutationPipeline` (6-step contract mirroring `GovernanceMutationPipeline`)
- Typed `BindingValue` + `get_binding` accessor
- Legacy `db.get_setting` fallback + backfill strategy under `bindings.primary` flag
- Diagnostics + `!platform bindings` admin command
- ≥30 tests covering missing / wrong-kind / unknown-subsystem / legacy-fallback / authority rejection / event emission

The plan explicitly excludes: setup wizard UI, resource provisioning, participation tables, feature flag runtime, command behavior changes.

## Branch shape

- **Fast-forward**: 1 commit ahead of `main`, 0 behind.
- **No conflicts**: branched directly from current `main` (merge of PR #71).

## Behavior impact

| Surface | Change |
|---|---|
| Existing channel/role panels | No change (legacy `_resource_helpers` shim untouched) |
| `!platform resources` admin | No change |
| `validate_resource()` signature + return | No change |
| `RoleResource.is_managed` semantics | **More accurate**: now matches `discord.Role.managed` directly, not the OR of managed + non-assignable. Downstream code that checked `is_managed` to mean "the bot can't touch this" should use the new `is_assignable` field. No production code currently reads `is_managed`. |
| `_compute_status` function name | Renamed to `_compute_structural_status` (private; no external callers) |
| `core.resources.discovery.__all__` | Adds `validate_resource_permissions` |
| DB schema | Migration 021 adds CHECK constraints; no row migration |

## Safety & compatibility checklist

| Check | Result |
|---|---|
| **Merge cleanliness** | Fast-forward; no conflicts |
| **Tests** | 1106 pytest passes (up from 1089; +17 new tests across invariants/, resources/test_resource_cache.py, resources/test_types.py, resources/test_discovery.py) |
| **Ruff** | Clean across `disbot/` |
| **Black** | Clean across `disbot/` |
| **isort** | Clean across `disbot/` |
| **mypy** | Clean across `disbot/` (213 source files) |
| **DB migration** | Forward-only and idempotent; migration 020 unchanged |
| **No removed APIs** | All public surfaces preserved; `is_managed` field retained with a more precise (narrower) semantic |
| **No new mutations** | All five fixes are additive or documentation-level |
| **No new identity surfaces** | Phase 6 still adds the 6th surface |

## What remains blocked before Phase 2b

Nothing — that's the point of this PR. The five hardening fixes close the gaps that would have forced Phase 2b to either litigate them inline or accept the foundation as-is. After this lands:

- `BindingMutationPipeline` can call `validate_resource()` knowing its return semantics are well-defined.
- The new `subsystem_bindings` table can be defined with the same CHECK-constraint pattern.
- The enum drift invariant catches any taxonomy expansion before it produces silent binding failures.
- Phase 4.5's role-mapping wizard has the precise `is_assignable` field it needs.
- The teardown wiring (1-line) can land as a follow-up without re-touching the hardening work.

## Test plan

- [x] `python -m pytest tests/ -q` — 1106 passed
- [x] `black --check . --exclude '(\.github|tests|venv|env|build|dist)'` — clean
- [x] `isort --check-only .` — clean
- [x] `ruff check . --exclude .github,tests,venv,env,build,dist` — clean
- [x] `mypy disbot/` — clean
- [x] Migration 021 parses (filename `021_resource_validation_cache_constraints.sql` matches `int(filename.split("_")[0])` convention)
- [x] All existing Phase 2a tests still pass (no semantic regressions)
- [x] New drift-protection invariant tests fail loudly if either enum is mutated independently
- [ ] Smoke-test in staging: migration 021 applies idempotently against an existing populated `resource_validation_cache`

https://claude.ai/code/session_01XPi9m92B5mdR4JDNyXKC1C

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPi9m92B5mdR4JDNyXKC1C)_