### PR TITLE
Phase 2b — Subsystem Bindings + BindingMutationPipeline

### DIFF
--- a/disbot/cogs/diagnostic/_platform_embeds.py
+++ b/disbot/cogs/diagnostic/_platform_embeds.py
@@ -1,0 +1,129 @@
+"""Embed builders for the ``!platform <subcommand>`` admin surface.
+
+Extracted from ``cogs/diagnostic_cog.py`` to keep the cog under the
+800-LOC fail threshold enforced by
+``tests/unit/invariants/test_cog_size.py``.  Each builder is a pure
+async function that fetches its data (via ``services.diagnostics_service``
+and/or ``utils.db.*``) and returns a single :class:`discord.Embed`
+ready to send.  The cog methods become thin wrappers that delegate
+here.
+
+Phase 2a + 2b builders covered:
+
+* :func:`build_resources_embed` — ``!platform resources``
+* :func:`build_bindings_embed`  — ``!platform bindings``
+
+Earlier-phase platform commands stay inline in the cog for now.  When
+the next batch of platform commands lands and pushes the cog back
+toward the ceiling, those should migrate here too.
+"""
+
+from __future__ import annotations
+
+import discord
+
+
+async def build_resources_embed(guild: discord.Guild | None) -> discord.Embed:
+    """Build the embed for ``!platform resources`` (Phase 2a)."""
+    from services import diagnostics_service
+    from utils.db import resource_cache
+
+    snap = diagnostics_service.snapshot("resources")
+    embed = discord.Embed(
+        title="🧱 Resources",
+        description=(
+            f"package: `{snap['package']}`  ·  "
+            f"kinds: {', '.join(f'`{k}`' for k in snap['kinds'])}"
+        ),
+        color=discord.Color.blurple(),
+    )
+    embed.add_field(
+        name="Submodules",
+        value=", ".join(f"`{m}`" for m in snap["submodules"]),
+        inline=False,
+    )
+    if guild is not None:
+        try:
+            histogram = await resource_cache.count_by_status(guild.id)
+        except Exception as exc:  # noqa: BLE001 — DB outage shouldn't crash command
+            embed.add_field(
+                name="Cached status",
+                value=f"❌ {exc}",
+                inline=False,
+            )
+        else:
+            if histogram:
+                lines = [
+                    f"`{status}` — {count}"
+                    for status, count in sorted(histogram.items())
+                ]
+                embed.add_field(
+                    name=f"Cached status (guild {guild.id})",
+                    value="\n".join(lines),
+                    inline=False,
+                )
+            else:
+                embed.add_field(
+                    name=f"Cached status (guild {guild.id})",
+                    value="*(no cached rows)*",
+                    inline=False,
+                )
+    return embed
+
+
+async def build_bindings_embed(guild: discord.Guild | None) -> discord.Embed:
+    """Build the embed for ``!platform bindings`` (Phase 2b)."""
+    from services import diagnostics_service
+    from utils.db import bindings as bindings_db
+
+    snap = diagnostics_service.snapshot("bindings")
+    embed = discord.Embed(
+        title="🔗 Subsystem bindings",
+        description=f"kinds: {', '.join(f'`{k}`' for k in snap['kinds'])}",
+        color=discord.Color.blurple(),
+    )
+    dispatch_lines = [
+        f"`{kind}` → `{validator}`"
+        for kind, validator in sorted(snap["validator_dispatch"].items())
+    ]
+    embed.add_field(
+        name="Validator dispatch",
+        value="\n".join(dispatch_lines),
+        inline=False,
+    )
+    if guild is not None:
+        try:
+            by_status = await bindings_db.count_by_status(guild.id)
+            by_sub = await bindings_db.count_by_subsystem(guild.id)
+        except Exception as exc:  # noqa: BLE001 — DB outage shouldn't crash command
+            embed.add_field(
+                name="Per-guild counts",
+                value=f"❌ DB query failed: {exc}",
+                inline=False,
+            )
+            return embed
+
+        status_lines = (
+            "\n".join(
+                f"`{status}` — {count}" for status, count in sorted(by_status.items())
+            )
+            or "*(no bindings)*"
+        )
+        embed.add_field(
+            name=f"Status (guild {guild.id})",
+            value=status_lines,
+            inline=False,
+        )
+        sub_lines = (
+            "\n".join(f"`{sub}` — {count}" for sub, count in sorted(by_sub.items()))
+            or "*(no bindings)*"
+        )
+        embed.add_field(
+            name=f"By subsystem (guild {guild.id})",
+            value=sub_lines,
+            inline=False,
+        )
+    return embed
+
+
+__all__ = ["build_bindings_embed", "build_resources_embed"]

--- a/disbot/cogs/diagnostic_cog.py
+++ b/disbot/cogs/diagnostic_cog.py
@@ -194,12 +194,15 @@ class DiagnosticCog(commands.Cog):
 
         Added in Phase 2a (unified resource runtime):
             !platform resources
+
+        Added in Phase 2b (subsystem bindings):
+            !platform bindings
         """
         await ctx.send(
             "Usage: `!platform <status|anchors|identity|"
             "runtime|caches|locks|tasks|views|sessions|slow|"
             "schemas|participation-schemas|resource-requirements|flags|"
-            "resources>`",
+            "resources|bindings>`",
             delete_after=20,
         )
 
@@ -648,60 +651,21 @@ class DiagnosticCog(commands.Cog):
             embed.add_field(name="Requirements", value="*(none)*", inline=False)
         await ctx.send(embed=embed)
 
+    @platform_grp.command(name="bindings")  # type: ignore[arg-type]
+    @commands.has_permissions(administrator=True)
+    async def platform_bindings(self, ctx):
+        """Subsystem bindings (Phase 2b) — taxonomy + per-guild histograms."""
+        from cogs.diagnostic._platform_embeds import build_bindings_embed
+
+        await ctx.send(embed=await build_bindings_embed(ctx.guild))
+
     @platform_grp.command(name="resources")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def platform_resources(self, ctx):
-        """Resource runtime (Phase 2a) — taxonomy + cached status histogram.
+        """Resource runtime (Phase 2a) — taxonomy + cached status histogram."""
+        from cogs.diagnostic._platform_embeds import build_resources_embed
 
-        The package-level snapshot is augmented with a per-guild status
-        histogram from ``resource_validation_cache``.  Phase 4c
-        extends this with per-kind diagnostics + repair recommendations.
-        """
-        from services import diagnostics_service
-        from utils.db import resource_cache
-
-        snap = diagnostics_service.snapshot("resources")
-        embed = discord.Embed(
-            title="🧱 Resources",
-            description=(
-                f"package: `{snap['package']}`  ·  "
-                f"kinds: {', '.join(f'`{k}`' for k in snap['kinds'])}"
-            ),
-            color=discord.Color.blurple(),
-        )
-        embed.add_field(
-            name="Submodules",
-            value=", ".join(f"`{m}`" for m in snap["submodules"]),
-            inline=False,
-        )
-        if ctx.guild is not None:
-            try:
-                histogram = await resource_cache.count_by_status(ctx.guild.id)
-            except Exception as exc:
-                histogram = {"_error": str(exc)}
-            if histogram and "_error" not in histogram:
-                lines = [
-                    f"`{status}` — {count}"
-                    for status, count in sorted(histogram.items())
-                ]
-                embed.add_field(
-                    name=f"Cached status (guild {ctx.guild.id})",
-                    value="\n".join(lines) or "*(empty)*",
-                    inline=False,
-                )
-            elif "_error" in histogram:
-                embed.add_field(
-                    name="Cached status",
-                    value=f"❌ {histogram['_error']}",
-                    inline=False,
-                )
-            else:
-                embed.add_field(
-                    name=f"Cached status (guild {ctx.guild.id})",
-                    value="*(no cached rows)*",
-                    inline=False,
-                )
-        await ctx.send(embed=embed)
+        await ctx.send(embed=await build_resources_embed(ctx.guild))
 
     @platform_grp.command(name="flags")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)

--- a/disbot/core/events_catalogue.py
+++ b/disbot/core/events_catalogue.py
@@ -58,6 +58,8 @@ KNOWN_EVENTS: frozenset[str] = frozenset(
         "xp.reset",
         # ── Moderation (services/moderation_service.py) ──────────────────
         "moderation.action_taken",
+        # ── Bindings (services/binding_mutation.py, Phase 2b) ─────────────
+        "bindings.changed",
         # ── Future cog-emitted facts (uncomment when first emitter lands):
         # "economy.daily_claimed",
         # "mining.harvested",

--- a/disbot/core/runtime/__init__.py
+++ b/disbot/core/runtime/__init__.py
@@ -34,14 +34,17 @@ import logging
 # Phase 1 — Subsystem ownership protocols.  Importing here ensures the
 # self-registering schema + capability + feature-flag registries are
 # wired into the runtime before cogs load and start declaring schemas.
-from core.runtime import component_registry as components  # noqa: F401 — re-exported
-from core.runtime import (  # noqa: F401 — re-exported
-    ephemeral_surface_manager as surfaces,
-)
 from core.runtime import guild_config  # noqa: F401 — re-exported
 from core.runtime import persistent_views  # noqa: F401 — re-exported
 from core.runtime import scope_locks  # noqa: F401 — re-exported
 from core.runtime import tasks  # noqa: F401 — re-exported
+from core.runtime import (  # noqa: F401 — re-exported
+    bindings,
+)
+from core.runtime import component_registry as components  # noqa: F401 — re-exported
+from core.runtime import (  # noqa: F401 — re-exported
+    ephemeral_surface_manager as surfaces,
+)
 from core.runtime import (  # noqa: F401 — re-exported
     feature_flags,
 )

--- a/disbot/core/runtime/bindings.py
+++ b/disbot/core/runtime/bindings.py
@@ -1,0 +1,280 @@
+"""Subsystem bindings — typed runtime layer (Phase 2b).
+
+The platform's read surface for ``subsystem_bindings``.  Wraps
+:mod:`utils.db.bindings` with a typed :class:`BindingValue` so callers
+never touch raw target IDs outside the binding/resource validation
+layer, and adds the small dispatch abstraction that routes binding
+targets to the right validator (resource kinds → ``core.resources``;
+member kind → ``core.runtime.guild_resources.resolve_member``).
+
+Public surface:
+
+* :class:`BindingValue` — frozen typed read result.
+* :func:`get_binding` — typed accessor; returns ``UNRESOLVED`` on miss.
+* :func:`validate_binding_target` — dispatch by kind to the appropriate
+  validator.  Resolves the long-standing question raised in
+  ``docs/phase_2b_bindings_plan.md`` about member bindings.
+
+Phase 2b does NOT add a ``set_binding`` write here — writes go through
+:class:`~services.binding_mutation.BindingMutationPipeline` which
+calls into :mod:`utils.db.bindings` directly.  Keeping the write path
+out of the read module preserves the layering rule that callers can
+import the read API without pulling in the mutation pipeline.
+
+Diagnostics: this module self-registers a snapshot provider named
+``bindings`` so ``!platform bindings`` can display per-guild histograms.
+The provider returns module-level state only (registered taxonomies,
+counts of known events); per-guild histograms are fetched by the admin
+command directly from :mod:`utils.db.bindings`.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+import discord
+
+from core.resources import discovery
+from core.resources.status import ResourceStatus
+from core.resources.types import ResourceKind
+from core.runtime import guild_resources
+from core.runtime.subsystem_schema import BindingKind
+from utils.db import bindings as bindings_db
+
+logger = logging.getLogger("bot.bindings")
+
+
+# ---------------------------------------------------------------------------
+# Typed read result
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BindingValue:
+    """Typed snapshot of a subsystem binding's runtime state.
+
+    A binding always has a slot identity (subsystem + binding_name +
+    kind); the ``target_id`` is the runtime value the operator filled
+    in (or ``None`` for an unbound slot).
+
+    Status semantics match :class:`core.resources.status.ResourceStatus`
+    — Phase 2a's structural-only validation applies to bindings too.
+    Phase 4.5 will add a permission-aware sibling field.
+
+    Fields:
+
+    guild_id, subsystem, binding_name:
+        Composite identity.
+    kind:
+        The expected target type.  Must match the corresponding
+        :class:`~core.runtime.subsystem_schema.BindingSpec.kind`.
+    target_id:
+        The discord snowflake the slot points at, or ``None`` when
+        unbound.
+    status:
+        Last-known validation status.  ``UNRESOLVED`` for slots that
+        have never been validated (including those returned by
+        :func:`get_binding` when no DB row exists).
+    last_validated_at / last_updated_at:
+        Audit timestamps.  ``None`` when no row exists.
+    version:
+        Row-level revision counter; bumped on every mutation.  Zero
+        when no row exists.
+    """
+
+    guild_id: int
+    subsystem: str
+    binding_name: str
+    kind: BindingKind
+    target_id: int | None = None
+    status: ResourceStatus = ResourceStatus.UNRESOLVED
+    last_validated_at: datetime | None = None
+    last_updated_at: datetime | None = None
+    version: int = 0
+
+    @property
+    def is_bound(self) -> bool:
+        """True iff a target is bound and structurally valid."""
+        return self.target_id is not None and self.status is ResourceStatus.BOUND
+
+
+# ---------------------------------------------------------------------------
+# Binding-target validator dispatch
+# ---------------------------------------------------------------------------
+
+# Resource-kind aliases for the dispatch.  Phase 2b's design decision
+# (see docs/phase_2b_bindings_plan.md): resource kinds use
+# ``core.resources.discovery``; member kind uses ``guild_resources``.
+_RESOURCE_KIND_MAP: dict[BindingKind, ResourceKind] = {
+    BindingKind.CHANNEL: ResourceKind.CHANNEL,
+    BindingKind.ROLE: ResourceKind.ROLE,
+    BindingKind.CATEGORY: ResourceKind.CATEGORY,
+    BindingKind.THREAD: ResourceKind.THREAD,
+}
+
+
+async def validate_binding_target(
+    guild: discord.Guild,
+    kind: BindingKind,
+    target_id: int,
+) -> ResourceStatus:
+    """Validate that ``target_id`` exists in ``guild`` for ``kind``.
+
+    Dispatches by kind:
+
+    * ``CHANNEL`` / ``ROLE`` / ``CATEGORY`` / ``THREAD`` →
+      :func:`core.resources.discovery.validate_resource`
+      (``persist=False`` — Phase 2b does not write to the resource
+      cache; the binding row tracks its own status).
+    * ``MEMBER`` →
+      :func:`core.runtime.guild_resources.resolve_member`
+      (sync; returns ``None`` for missing members).
+
+    Returns :class:`ResourceStatus.BOUND` when the target is found,
+    :class:`ResourceStatus.MISSING` otherwise.  Resource-kind validation
+    may also return :class:`ResourceStatus.INVALID` for wrong-type IDs
+    (channel ID pointing at a category, etc.).
+    """
+    if kind is BindingKind.MEMBER:
+        member = guild_resources.resolve_member(guild, target_id)
+        return ResourceStatus.BOUND if member is not None else ResourceStatus.MISSING
+
+    resource_kind = _RESOURCE_KIND_MAP.get(kind)
+    if resource_kind is None:
+        # Defensive — should not happen because BindingKind is exhaustive
+        # over the dispatch table, but a future enum addition without a
+        # validator update would land here.
+        logger.warning(
+            "validate_binding_target: no validator for kind=%r; "
+            "returning UNRESOLVED.  Add the kind to _RESOURCE_KIND_MAP "
+            "or extend the MEMBER branch.",
+            kind,
+        )
+        return ResourceStatus.UNRESOLVED
+
+    return await discovery.validate_resource(
+        guild,
+        resource_kind,
+        target_id,
+        persist=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Typed accessor
+# ---------------------------------------------------------------------------
+
+
+async def get_binding(
+    guild_id: int,
+    subsystem: str,
+    binding_name: str,
+    *,
+    expected_kind: BindingKind | None = None,
+) -> BindingValue:
+    """Return the typed :class:`BindingValue` for a slot.
+
+    ``expected_kind`` lets the caller assert what kind the slot should
+    be; if the DB row's kind disagrees, this function logs a warning
+    and uses the DB-stored kind in the returned value.  The caller can
+    treat that as an invariant violation (a schema migration is needed).
+
+    If no row exists, returns ``BindingValue`` with ``target_id=None``,
+    ``status=UNRESOLVED``, and ``version=0``.  Callers that need to
+    distinguish "slot never bound" from "slot cleared" should consult
+    :data:`BindingValue.last_updated_at` (``None`` for never-bound).
+    """
+    row = await bindings_db.get_one(guild_id, subsystem, binding_name)
+    if row is None:
+        return BindingValue(
+            guild_id=guild_id,
+            subsystem=subsystem,
+            binding_name=binding_name,
+            kind=expected_kind or BindingKind.CHANNEL,
+            status=ResourceStatus.UNRESOLVED,
+        )
+
+    try:
+        kind = BindingKind(row["kind"])
+    except ValueError:
+        logger.error(
+            "get_binding: row carries unknown kind=%r for "
+            "(guild=%d, subsystem=%r, binding=%r); using fallback.",
+            row["kind"],
+            guild_id,
+            subsystem,
+            binding_name,
+        )
+        kind = expected_kind or BindingKind.CHANNEL
+
+    if expected_kind is not None and kind != expected_kind:
+        logger.warning(
+            "get_binding: stored kind=%r differs from expected_kind=%r "
+            "for (guild=%d, subsystem=%r, binding=%r) — schema drift.",
+            kind,
+            expected_kind,
+            guild_id,
+            subsystem,
+            binding_name,
+        )
+
+    try:
+        status = ResourceStatus(row["status"])
+    except ValueError:
+        logger.error(
+            "get_binding: row carries unknown status=%r; using UNRESOLVED.",
+            row["status"],
+        )
+        status = ResourceStatus.UNRESOLVED
+
+    return BindingValue(
+        guild_id=row["guild_id"],
+        subsystem=row["subsystem"],
+        binding_name=row["binding_name"],
+        kind=kind,
+        target_id=row["target_id"],
+        status=status,
+        last_validated_at=row["last_validated_at"],
+        last_updated_at=row["last_updated_at"],
+        version=row["version"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics provider — registers at import time
+# ---------------------------------------------------------------------------
+
+
+def _bindings_snapshot() -> dict[str, Any]:
+    """Snapshot provider for ``!platform bindings``.
+
+    Returns *process-local* state only — per-guild histograms come from
+    :mod:`utils.db.bindings` via the admin command, since the
+    diagnostics provider contract is synchronous and DB-free.
+    """
+    return {
+        "kinds": [k.value for k in BindingKind],
+        "validator_dispatch": {
+            **{k.value: "resource" for k in _RESOURCE_KIND_MAP},
+            BindingKind.MEMBER.value: "member",
+        },
+    }
+
+
+def _register_diagnostics_providers() -> None:
+    from services import diagnostics_service
+
+    diagnostics_service.register("bindings", _bindings_snapshot)
+
+
+_register_diagnostics_providers()
+
+
+__all__ = [
+    "BindingValue",
+    "get_binding",
+    "validate_binding_target",
+]

--- a/disbot/migrations/022_subsystem_bindings.sql
+++ b/disbot/migrations/022_subsystem_bindings.sql
@@ -1,0 +1,74 @@
+-- Migration 022: subsystem_bindings + binding_audit_log (Phase 2b).
+--
+-- Replaces the raw-string `channel_id` / `role_id` pattern in
+-- `guild_settings` with a typed binding table.  Phase 2b ships the
+-- table + audit log; Phase 4c diagnostics + Phase 6.5 routing + Phase
+-- 7 wizard all read from here.  Settings-KV legacy fallback stays in
+-- place until `bindings.primary` (Phase 1d declared flag) flips,
+-- which is gated on Phase 2d's feature-flag runtime.
+--
+-- Schema decisions:
+--
+--   * Composite PK on (guild_id, subsystem, binding_name) — bindings
+--     are scope-aware from day one.  Same channel can be a different
+--     binding in different subsystems.
+--   * CHECK constraints on `kind` and `status` mirror the Python enums
+--     (core.runtime.subsystem_schema.BindingKind +
+--     core.resources.status.ResourceStatus).  Phase 2b's invariant
+--     test `tests/unit/invariants/test_binding_constraints_alignment.py`
+--     pins the literals.
+--   * `target_id` is nullable — clearing a binding sets it to NULL
+--     and writes an audit row; the table row is retained so the
+--     subsystem's slot is still declared.
+--   * `binding_audit_log` is append-only.  Indexed on
+--     `(guild_id, at)` for time-range queries and `(mutation_id)` for
+--     cross-pipeline correlation.
+--
+-- Forward-only and idempotent.
+
+CREATE TABLE IF NOT EXISTS subsystem_bindings (
+    guild_id           BIGINT       NOT NULL,
+    subsystem          TEXT         NOT NULL,
+    binding_name       TEXT         NOT NULL,
+    kind               TEXT         NOT NULL,
+    target_id          BIGINT,
+    status             TEXT         NOT NULL DEFAULT 'unresolved',
+    last_validated_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    last_updated_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    version            INTEGER      NOT NULL DEFAULT 1,
+    PRIMARY KEY (guild_id, subsystem, binding_name),
+    CHECK (kind IN ('channel', 'role', 'category', 'thread', 'member')),
+    CHECK (status IN ('bound', 'unresolved', 'missing', 'invalid'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_subsystem_bindings_guild_status
+    ON subsystem_bindings (guild_id, status);
+
+CREATE INDEX IF NOT EXISTS idx_subsystem_bindings_guild_subsystem
+    ON subsystem_bindings (guild_id, subsystem);
+
+-- Append-only audit log.  One row per mutation (set or clear).
+-- ``actor_type`` discriminator distinguishes user-initiated mutations
+-- (``'user'``) from system-driven ones (``'backfill'``, ``'system'``).
+CREATE TABLE IF NOT EXISTS binding_audit_log (
+    id              BIGSERIAL    PRIMARY KEY,
+    mutation_id     UUID         NOT NULL,
+    guild_id        BIGINT       NOT NULL,
+    subsystem       TEXT         NOT NULL,
+    binding_name    TEXT         NOT NULL,
+    actor_id        BIGINT       NOT NULL,
+    actor_type      TEXT         NOT NULL DEFAULT 'user',
+    action          TEXT         NOT NULL,
+    old_target_id   BIGINT,
+    new_target_id   BIGINT,
+    old_status      TEXT,
+    new_status      TEXT,
+    at              TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    CHECK (action IN ('set', 'clear', 'backfill'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_binding_audit_guild_at
+    ON binding_audit_log (guild_id, at);
+
+CREATE INDEX IF NOT EXISTS idx_binding_audit_mutation
+    ON binding_audit_log (mutation_id);

--- a/disbot/services/binding_mutation.py
+++ b/disbot/services/binding_mutation.py
@@ -1,0 +1,465 @@
+"""Binding mutation pipeline — Phase 2b.
+
+The canonical write path for ``subsystem_bindings``.  Mirrors the
+6-step contract from :class:`~governance.writes.GovernanceMutationPipeline`:
+
+  1. Input validation       — subsystem declared, binding declared,
+                              kind matches the declared ``BindingSpec``
+  2. Authority validation   — administrator-tier (PLACEHOLDER for
+                              Phase 4.5 typed access-control)
+  3. Target validation      — dispatch via
+                              :func:`core.runtime.bindings.validate_binding_target`
+                              (resource kinds vs MEMBER kind)
+  4. Read old value         — for the audit row
+  5. DB write + audit       — single transaction via
+                              :mod:`utils.db.bindings`
+  6. Cache invalidation     — guild_config namespace for this binding
+  7. Event emission         — EVT_BINDING_CHANGED
+
+If event emission raises **after** a successful DB commit, the error
+is logged but not re-raised; the DB state is correct and the next
+event consumer will reconcile on its next read (mirrors
+:class:`GovernanceMutationPipeline`'s best-effort emission contract).
+
+Hard limits for Phase 2b:
+
+  * No setup wizard UI integration — that is Phase 7.
+  * No resource provisioning — :class:`~core.resources.mutation.ResourceMutationPipeline`
+    handles channel/role creation in Phase 7.5.
+  * No permission-aware target validation — Phase 4.5 hook
+    (:func:`core.resources.discovery.validate_resource_permissions`)
+    is still NotImplementedError.
+  * Authority check is a placeholder; Phase 4.5 replaces it with the
+    typed :class:`~services.access_control_service` resolver.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import discord
+
+from core.resources.status import ResourceStatus
+from core.runtime.bindings import BindingValue, get_binding, validate_binding_target
+from core.runtime.subsystem_schema import (
+    BindingKind,
+    BindingSpec,
+    SubsystemSchema,
+    get_schema,
+)
+from utils.db import bindings as bindings_db
+from utils.subsystem_registry import SUBSYSTEMS
+from utils.visibility_rules import get_member_visibility_tier, is_tier_sufficient
+
+logger = logging.getLogger("bot.services.binding_mutation")
+
+# ---------------------------------------------------------------------------
+# Canonical event name + result type
+# ---------------------------------------------------------------------------
+
+EVT_BINDING_CHANGED = "bindings.changed"
+
+# Phase 2b authority floor — placeholder.  Phase 4.5 swaps this for
+# the typed access-control resolver consuming
+# ``BindingSpec.capability_required``.
+_WRITE_AUTHORITY_TIER = "administrator"
+
+
+class BindingMutationError(Exception):
+    """Base class for failures from :class:`BindingMutationPipeline`."""
+
+
+class UnknownSubsystemError(BindingMutationError):
+    """Raised when the mutation targets a subsystem not in SUBSYSTEMS."""
+
+
+class UndeclaredBindingError(BindingMutationError):
+    """Raised when the binding_name is not declared in the SubsystemSchema."""
+
+
+class BindingKindMismatchError(BindingMutationError):
+    """Raised when the declared kind disagrees with the caller's kind."""
+
+
+class UnauthorizedBindingMutationError(BindingMutationError):
+    """Raised when the calling member does not hold sufficient authority."""
+
+
+@dataclass(frozen=True)
+class BindingMutationResult:
+    """Outcome of a successful (or partially successful) mutation."""
+
+    mutation_id: str
+    guild_id: int
+    subsystem: str
+    binding_name: str
+    old_target_id: int | None
+    new_target_id: int | None
+    old_status: ResourceStatus
+    new_status: ResourceStatus
+    committed_at: datetime
+    event_emitted: bool
+
+
+# ---------------------------------------------------------------------------
+# Pipeline
+# ---------------------------------------------------------------------------
+
+
+class BindingMutationPipeline:
+    """Centralized orchestration for ``subsystem_bindings`` writes.
+
+    Instances are stateless — create one per mutation request.  Two
+    public methods:
+
+    * :meth:`set_binding` — bind a target to a slot (or rebind).
+    * :meth:`clear_binding` — clear an existing binding back to
+      ``UNRESOLVED``.
+
+    Both methods follow the same 7-step contract documented in the
+    module docstring.  Callers MUST NOT touch
+    :mod:`utils.db.bindings`'s mutation primitives directly; the
+    pipeline is the only legitimate writer.
+    """
+
+    def __init__(self) -> None:
+        # No instance state.
+        pass
+
+    # ------------------------------------------------------------------
+    # Public surface
+    # ------------------------------------------------------------------
+
+    async def set_binding(
+        self,
+        guild: discord.Guild,
+        subsystem: str,
+        binding_name: str,
+        kind: BindingKind,
+        target_id: int,
+        actor: discord.Member,
+    ) -> BindingMutationResult:
+        """Bind ``target_id`` to ``(subsystem, binding_name)``.
+
+        Raises:
+            UnknownSubsystemError: ``subsystem`` not in SUBSYSTEMS.
+            UndeclaredBindingError: schema does not declare ``binding_name``.
+            BindingKindMismatchError: declared kind disagrees with ``kind``.
+            UnauthorizedBindingMutationError: actor below the authority floor.
+        """
+        spec = self._resolve_spec(subsystem, binding_name, kind)
+        self._validate_authority(actor)
+
+        new_status = await validate_binding_target(guild, kind, target_id)
+        old = await get_binding(guild.id, subsystem, binding_name)
+        return await self._commit(
+            guild=guild,
+            subsystem=subsystem,
+            binding_name=spec.name,
+            kind=kind,
+            new_target_id=target_id,
+            new_status=new_status,
+            old=old,
+            actor=actor,
+            action_label="set",
+        )
+
+    async def clear_binding(
+        self,
+        guild: discord.Guild,
+        subsystem: str,
+        binding_name: str,
+        kind: BindingKind,
+        actor: discord.Member,
+    ) -> BindingMutationResult:
+        """Clear the binding at ``(subsystem, binding_name)``.
+
+        The slot row remains so the schema-declared binding stays
+        discoverable; ``target_id`` is set to NULL and ``status`` to
+        ``unresolved``.
+        """
+        self._resolve_spec(subsystem, binding_name, kind)
+        self._validate_authority(actor)
+
+        old = await get_binding(guild.id, subsystem, binding_name)
+        if old.target_id is None and old.last_updated_at is None:
+            # Nothing to clear; treat as a no-op success rather than
+            # raise — clearing an already-unbound slot is idempotent.
+            return BindingMutationResult(
+                mutation_id=str(uuid.uuid4()),
+                guild_id=guild.id,
+                subsystem=subsystem,
+                binding_name=binding_name,
+                old_target_id=None,
+                new_target_id=None,
+                old_status=ResourceStatus.UNRESOLVED,
+                new_status=ResourceStatus.UNRESOLVED,
+                committed_at=_now_utc(),
+                event_emitted=False,
+            )
+
+        mutation_id = str(uuid.uuid4())
+        try:
+            await bindings_db.clear_with_audit(
+                guild_id=guild.id,
+                subsystem=subsystem,
+                binding_name=binding_name,
+                actor_id=actor.id,
+                actor_type="user",
+                mutation_id=mutation_id,
+                old_target_id=old.target_id,
+                old_status=old.status.value,
+            )
+        except Exception:
+            logger.exception(
+                "BindingMutationPipeline.clear_binding: DB transaction "
+                "failed for (guild=%d, subsystem=%r, binding=%r); "
+                "no cache invalidation, no event emission.",
+                guild.id,
+                subsystem,
+                binding_name,
+            )
+            raise
+
+        committed_at = _now_utc()
+        event_emitted = await self._emit_event(
+            mutation_id=mutation_id,
+            guild_id=guild.id,
+            subsystem=subsystem,
+            binding_name=binding_name,
+            old_target_id=old.target_id,
+            new_target_id=None,
+            old_status=old.status.value,
+            new_status=ResourceStatus.UNRESOLVED.value,
+            committed_at=committed_at,
+        )
+        self._invalidate_cache(guild.id, subsystem, binding_name)
+        return BindingMutationResult(
+            mutation_id=mutation_id,
+            guild_id=guild.id,
+            subsystem=subsystem,
+            binding_name=binding_name,
+            old_target_id=old.target_id,
+            new_target_id=None,
+            old_status=old.status,
+            new_status=ResourceStatus.UNRESOLVED,
+            committed_at=committed_at,
+            event_emitted=event_emitted,
+        )
+
+    # ------------------------------------------------------------------
+    # Step helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_spec(
+        self,
+        subsystem: str,
+        binding_name: str,
+        kind: BindingKind,
+    ) -> BindingSpec:
+        """Steps 1: subsystem declared, binding declared, kind matches."""
+        if subsystem not in SUBSYSTEMS:
+            msg = (
+                f"unknown subsystem {subsystem!r}; "
+                f"not in utils.subsystem_registry.SUBSYSTEMS"
+            )
+            raise UnknownSubsystemError(msg)
+
+        schema: SubsystemSchema | None = get_schema(subsystem)
+        if schema is None:
+            msg = (
+                f"subsystem {subsystem!r} has no registered SubsystemSchema; "
+                f"register one in the cog's cog_load() before binding"
+            )
+            raise UndeclaredBindingError(msg)
+
+        for spec in schema.bindings:
+            if spec.name == binding_name:
+                if spec.kind != kind:
+                    msg = (
+                        f"binding {subsystem!r}/{binding_name!r} declared "
+                        f"kind={spec.kind!r} but caller supplied kind={kind!r}"
+                    )
+                    raise BindingKindMismatchError(msg)
+                return spec
+
+        msg = (
+            f"binding {binding_name!r} not declared in SubsystemSchema "
+            f"for {subsystem!r}; declared bindings: "
+            f"{[s.name for s in schema.bindings]}"
+        )
+        raise UndeclaredBindingError(msg)
+
+    def _validate_authority(self, actor: discord.Member) -> None:
+        """Step 2: placeholder administrator-tier floor.
+
+        Phase 4.5 replaces with typed capability resolution via
+        :data:`~core.runtime.subsystem_schema.BindingSpec.capability_required`.
+        """
+        if actor is None or getattr(actor, "guild", None) is None:
+            msg = "binding mutation requires a guild member context"
+            raise UnauthorizedBindingMutationError(msg)
+        guild_owner_id = actor.guild.owner_id if actor.guild else 0
+        tier = get_member_visibility_tier(actor, guild_owner_id)
+        if not is_tier_sufficient(tier, _WRITE_AUTHORITY_TIER):
+            msg = (
+                f"member {actor.id!r} (tier={tier!r}) requires at least "
+                f"{_WRITE_AUTHORITY_TIER!r} to mutate bindings "
+                "(Phase 4.5 will replace this with typed capability check)"
+            )
+            raise UnauthorizedBindingMutationError(msg)
+
+    async def _commit(
+        self,
+        *,
+        guild: discord.Guild,
+        subsystem: str,
+        binding_name: str,
+        kind: BindingKind,
+        new_target_id: int,
+        new_status: ResourceStatus,
+        old: BindingValue,
+        actor: discord.Member,
+        action_label: str,
+    ) -> BindingMutationResult:
+        """Steps 4-7: read-old, write+audit, invalidate, emit."""
+        del action_label  # currently single shape; reserved for future actions
+        mutation_id = str(uuid.uuid4())
+        try:
+            await bindings_db.upsert_with_audit(
+                guild_id=guild.id,
+                subsystem=subsystem,
+                binding_name=binding_name,
+                kind=kind.value,
+                target_id=new_target_id,
+                status=new_status.value,
+                actor_id=actor.id,
+                actor_type="user",
+                mutation_id=mutation_id,
+                old_target_id=old.target_id,
+                old_status=old.status.value,
+            )
+        except Exception:
+            logger.exception(
+                "BindingMutationPipeline._commit: DB transaction "
+                "failed for (guild=%d, subsystem=%r, binding=%r); "
+                "no cache invalidation, no event emission.",
+                guild.id,
+                subsystem,
+                binding_name,
+            )
+            raise
+
+        committed_at = _now_utc()
+        event_emitted = await self._emit_event(
+            mutation_id=mutation_id,
+            guild_id=guild.id,
+            subsystem=subsystem,
+            binding_name=binding_name,
+            old_target_id=old.target_id,
+            new_target_id=new_target_id,
+            old_status=old.status.value,
+            new_status=new_status.value,
+            committed_at=committed_at,
+        )
+        self._invalidate_cache(guild.id, subsystem, binding_name)
+        return BindingMutationResult(
+            mutation_id=mutation_id,
+            guild_id=guild.id,
+            subsystem=subsystem,
+            binding_name=binding_name,
+            old_target_id=old.target_id,
+            new_target_id=new_target_id,
+            old_status=old.status,
+            new_status=new_status,
+            committed_at=committed_at,
+            event_emitted=event_emitted,
+        )
+
+    def _invalidate_cache(
+        self,
+        guild_id: int,
+        subsystem: str,
+        binding_name: str,
+    ) -> None:
+        """Step 6: invalidate the guild_config namespace for this binding.
+
+        Phase 2b does not write to ``guild_config`` for bindings yet —
+        that wiring lands in Phase 4c when binding values are read via
+        typed accessors instead of direct DB reads.  This method exists
+        as the documented hook so the wiring change is a one-line
+        addition.
+        """
+        logger.debug(
+            "BindingMutationPipeline: cache invalidation hook for "
+            "guild=%d subsystem=%r binding=%r (no-op until Phase 4c)",
+            guild_id,
+            subsystem,
+            binding_name,
+        )
+
+    async def _emit_event(
+        self,
+        *,
+        mutation_id: str,
+        guild_id: int,
+        subsystem: str,
+        binding_name: str,
+        old_target_id: int | None,
+        new_target_id: int | None,
+        old_status: str,
+        new_status: str,
+        committed_at: datetime,
+    ) -> bool:
+        """Step 7: best-effort event emission.
+
+        Returns ``True`` if the event was emitted successfully; ``False``
+        if emission raised.  Emission failures after a successful DB
+        commit are logged and swallowed — the DB state is correct, and
+        Phase 4c's event-driven reconciliation will catch up on the
+        next emit (mirrors :class:`GovernanceMutationPipeline`'s
+        best-effort contract).
+        """
+        from core.events import bus
+
+        try:
+            await bus.emit(
+                EVT_BINDING_CHANGED,
+                mutation_id=mutation_id,
+                guild_id=guild_id,
+                subsystem=subsystem,
+                binding_name=binding_name,
+                old_target_id=old_target_id,
+                new_target_id=new_target_id,
+                old_status=old_status,
+                new_status=new_status,
+                occurred_at=committed_at.isoformat(),
+            )
+        except Exception:
+            logger.exception(
+                "BindingMutationPipeline._emit_event: emission failed for "
+                "mutation_id=%s; DB state is correct, event lost.",
+                mutation_id,
+            )
+            return False
+        return True
+
+
+def _now_utc() -> datetime:
+    """Return a tz-aware "now" — INV-N forbids bare datetime.utcnow."""
+    return datetime.now(timezone.utc)
+
+
+__all__ = [
+    "EVT_BINDING_CHANGED",
+    "BindingKindMismatchError",
+    "BindingMutationError",
+    "BindingMutationPipeline",
+    "BindingMutationResult",
+    "UnauthorizedBindingMutationError",
+    "UndeclaredBindingError",
+    "UnknownSubsystemError",
+]

--- a/disbot/utils/db/bindings.py
+++ b/disbot/utils/db/bindings.py
@@ -1,0 +1,331 @@
+"""Subsystem bindings — DB CRUD primitives (Phase 2b).
+
+Owns the read/write surface for ``subsystem_bindings`` and the audit
+inserts into ``binding_audit_log``.  Higher-level callers (the
+:class:`~services.binding_mutation.BindingMutationPipeline`, the
+diagnostics provider, the typed ``get_binding`` accessor) wrap these
+primitives; nothing outside this module + the mutation pipeline issues
+raw SQL against the binding tables.
+
+Transaction model:
+The pipeline calls :func:`upsert_with_audit` / :func:`clear_with_audit`
+which open a single asyncpg transaction so the row write + audit row
+land atomically.  Read primitives are autocommit.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+from utils.db import pool
+
+logger = logging.getLogger("bot.db.bindings")
+
+# ---------------------------------------------------------------------------
+# Read primitives
+# ---------------------------------------------------------------------------
+
+
+async def get_one(
+    guild_id: int,
+    subsystem: str,
+    binding_name: str,
+) -> dict[str, Any] | None:
+    """Return the binding row, or ``None`` when the slot has no row.
+
+    Caller is responsible for converting the dict's ``kind`` / ``status``
+    strings into the corresponding enums.
+    """
+    row = await pool.get().fetchrow(
+        """
+        SELECT guild_id, subsystem, binding_name, kind, target_id, status,
+               last_validated_at, last_updated_at, version
+        FROM subsystem_bindings
+        WHERE guild_id = $1 AND subsystem = $2 AND binding_name = $3
+        """,
+        guild_id,
+        subsystem,
+        binding_name,
+    )
+    return dict(row) if row else None
+
+
+async def list_for_guild(
+    guild_id: int,
+    *,
+    subsystem: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return every binding row for ``guild_id`` (optionally one subsystem)."""
+    if subsystem is None:
+        rows = await pool.get().fetch(
+            """
+            SELECT guild_id, subsystem, binding_name, kind, target_id, status,
+                   last_validated_at, last_updated_at, version
+            FROM subsystem_bindings
+            WHERE guild_id = $1
+            ORDER BY subsystem, binding_name
+            """,
+            guild_id,
+        )
+    else:
+        rows = await pool.get().fetch(
+            """
+            SELECT guild_id, subsystem, binding_name, kind, target_id, status,
+                   last_validated_at, last_updated_at, version
+            FROM subsystem_bindings
+            WHERE guild_id = $1 AND subsystem = $2
+            ORDER BY binding_name
+            """,
+            guild_id,
+            subsystem,
+        )
+    return [dict(r) for r in rows]
+
+
+async def count_by_status(
+    guild_id: int,
+    *,
+    subsystem: str | None = None,
+) -> dict[str, int]:
+    """Return a ``status -> count`` histogram for the guild."""
+    if subsystem is None:
+        rows = await pool.get().fetch(
+            """
+            SELECT status, COUNT(*)::int AS n
+            FROM subsystem_bindings
+            WHERE guild_id = $1
+            GROUP BY status
+            """,
+            guild_id,
+        )
+    else:
+        rows = await pool.get().fetch(
+            """
+            SELECT status, COUNT(*)::int AS n
+            FROM subsystem_bindings
+            WHERE guild_id = $1 AND subsystem = $2
+            GROUP BY status
+            """,
+            guild_id,
+            subsystem,
+        )
+    return {r["status"]: r["n"] for r in rows}
+
+
+async def count_by_subsystem(guild_id: int) -> dict[str, int]:
+    """Return a ``subsystem -> count`` histogram for the guild."""
+    rows = await pool.get().fetch(
+        """
+        SELECT subsystem, COUNT(*)::int AS n
+        FROM subsystem_bindings
+        WHERE guild_id = $1
+        GROUP BY subsystem
+        ORDER BY subsystem
+        """,
+        guild_id,
+    )
+    return {r["subsystem"]: r["n"] for r in rows}
+
+
+# ---------------------------------------------------------------------------
+# Mutation primitives — used only by BindingMutationPipeline
+# ---------------------------------------------------------------------------
+
+
+async def upsert_with_audit(
+    *,
+    guild_id: int,
+    subsystem: str,
+    binding_name: str,
+    kind: str,
+    target_id: int | None,
+    status: str,
+    actor_id: int,
+    actor_type: str,
+    mutation_id: str,
+    old_target_id: int | None,
+    old_status: str | None,
+) -> None:
+    """Atomic write: upsert the binding row + insert one audit row.
+
+    Runs both statements in a single asyncpg transaction.  If either
+    fails the entire mutation is rolled back; the caller (the mutation
+    pipeline) only invalidates caches and emits events after this
+    returns successfully.
+    """
+    async with pool.get().acquire() as conn, conn.transaction():
+        await conn.execute(
+            """
+                INSERT INTO subsystem_bindings
+                    (guild_id, subsystem, binding_name, kind, target_id,
+                     status, last_validated_at, last_updated_at, version)
+                VALUES ($1, $2, $3, $4, $5, $6, NOW(), NOW(), 1)
+                ON CONFLICT (guild_id, subsystem, binding_name)
+                DO UPDATE SET
+                    kind              = EXCLUDED.kind,
+                    target_id         = EXCLUDED.target_id,
+                    status            = EXCLUDED.status,
+                    last_validated_at = NOW(),
+                    last_updated_at   = NOW(),
+                    version           = subsystem_bindings.version + 1
+                """,
+            guild_id,
+            subsystem,
+            binding_name,
+            kind,
+            target_id,
+            status,
+        )
+        await conn.execute(
+            """
+                INSERT INTO binding_audit_log
+                    (mutation_id, guild_id, subsystem, binding_name,
+                     actor_id, actor_type, action,
+                     old_target_id, new_target_id,
+                     old_status, new_status)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+                """,
+            mutation_id,
+            guild_id,
+            subsystem,
+            binding_name,
+            actor_id,
+            actor_type,
+            "backfill" if actor_type == "backfill" else "set",
+            old_target_id,
+            target_id,
+            old_status,
+            status,
+        )
+
+
+async def clear_with_audit(
+    *,
+    guild_id: int,
+    subsystem: str,
+    binding_name: str,
+    actor_id: int,
+    actor_type: str,
+    mutation_id: str,
+    old_target_id: int | None,
+    old_status: str | None,
+) -> None:
+    """Atomic clear: set target_id NULL + status='unresolved' + audit row.
+
+    The row is retained (not deleted) so the slot stays declared.
+    Phase 4c diagnostics rely on the row to surface "this binding
+    exists but is unbound" rather than "this binding was never
+    declared".
+    """
+    async with pool.get().acquire() as conn, conn.transaction():
+        await conn.execute(
+            """
+                UPDATE subsystem_bindings
+                SET target_id        = NULL,
+                    status           = 'unresolved',
+                    last_updated_at  = NOW(),
+                    version          = version + 1
+                WHERE guild_id = $1
+                  AND subsystem = $2
+                  AND binding_name = $3
+                """,
+            guild_id,
+            subsystem,
+            binding_name,
+        )
+        await conn.execute(
+            """
+                INSERT INTO binding_audit_log
+                    (mutation_id, guild_id, subsystem, binding_name,
+                     actor_id, actor_type, action,
+                     old_target_id, new_target_id,
+                     old_status, new_status)
+                VALUES ($1, $2, $3, $4, $5, $6, 'clear',
+                        $7, NULL, $8, 'unresolved')
+                """,
+            mutation_id,
+            guild_id,
+            subsystem,
+            binding_name,
+            actor_id,
+            actor_type,
+            old_target_id,
+            old_status,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Maintenance primitives
+# ---------------------------------------------------------------------------
+
+
+async def delete_for_guild(guild_id: int) -> int:
+    """Remove every binding row + every audit row for ``guild_id``.
+
+    Returns the combined deleted-row count (best-effort parse of
+    asyncpg's ``"DELETE N"`` status).  Phase 2b ships the primitive;
+    teardown wiring lands as a follow-up alongside the
+    :func:`utils.db.resource_cache.delete_for_guild` wiring.
+    """
+    async with pool.get().acquire() as conn, conn.transaction():
+        r1 = await conn.execute(
+            "DELETE FROM binding_audit_log WHERE guild_id = $1",
+            guild_id,
+        )
+        r2 = await conn.execute(
+            "DELETE FROM subsystem_bindings WHERE guild_id = $1",
+            guild_id,
+        )
+
+    def _parse(result: str) -> int:
+        try:
+            return int(result.split()[-1])
+        except (ValueError, IndexError):
+            return 0
+
+    return _parse(r1) + _parse(r2)
+
+
+async def get_audit_count(guild_id: int) -> int:
+    """Return the number of audit rows for ``guild_id``."""
+    row = await pool.get().fetchrow(
+        "SELECT COUNT(*)::int AS n FROM binding_audit_log WHERE guild_id = $1",
+        guild_id,
+    )
+    return int(row["n"]) if row else 0
+
+
+# ---------------------------------------------------------------------------
+# Convenience converter used by typed accessors
+# ---------------------------------------------------------------------------
+
+
+def row_to_summary(row: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a DB row into the shape callers want.
+
+    Coerces ``last_validated_at`` / ``last_updated_at`` to UTC-aware
+    :class:`datetime` (asyncpg returns tz-aware values already; this
+    function is here so callers can override timezone handling without
+    touching SQL).
+    """
+    out = dict(row)
+    for field in ("last_validated_at", "last_updated_at"):
+        value = out.get(field)
+        if isinstance(value, datetime) and value.tzinfo is None:
+            out[field] = value
+    return out
+
+
+__all__ = [
+    "clear_with_audit",
+    "count_by_status",
+    "count_by_subsystem",
+    "delete_for_guild",
+    "get_audit_count",
+    "get_one",
+    "list_for_guild",
+    "row_to_summary",
+    "upsert_with_audit",
+]

--- a/tests/unit/bindings/test_binding_mutation_pipeline.py
+++ b/tests/unit/bindings/test_binding_mutation_pipeline.py
@@ -1,0 +1,514 @@
+"""Phase 2b unit tests — BindingMutationPipeline contract."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from core.resources.status import ResourceStatus
+from core.runtime.bindings import BindingValue
+from core.runtime.subsystem_schema import (
+    BindingKind,
+    BindingSpec,
+    SubsystemSchema,
+)
+from services.binding_mutation import (
+    EVT_BINDING_CHANGED,
+    BindingKindMismatchError,
+    BindingMutationPipeline,
+    UnauthorizedBindingMutationError,
+    UndeclaredBindingError,
+    UnknownSubsystemError,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _xp_schema():
+    """Register a minimal XP schema for the duration of one test."""
+    from core.runtime import subsystem_schema
+
+    subsystem_schema._reset_for_tests()
+    schema = SubsystemSchema(
+        subsystem="xp",
+        bindings=(
+            BindingSpec(
+                name="announce_channel",
+                kind=BindingKind.CHANNEL,
+                required=False,
+                hint="",
+                capability_required="xp.settings.configure",
+            ),
+            BindingSpec(
+                name="moderator_target",
+                kind=BindingKind.MEMBER,
+                required=False,
+                hint="",
+                capability_required="xp.settings.configure",
+            ),
+        ),
+        version=1,
+    )
+    subsystem_schema.register(schema)
+    yield schema
+    subsystem_schema._reset_for_tests()
+
+
+def _admin_actor(member_id: int = 1):
+    """Build a Member mock that passes the administrator-tier check."""
+    member = MagicMock()
+    member.id = member_id
+    guild = MagicMock()
+    guild.owner_id = member_id  # Owner trivially satisfies administrator tier
+    member.guild = guild
+    return member
+
+
+def _below_tier_actor(member_id: int = 2):
+    """A member with no elevated permissions."""
+    member = MagicMock()
+    member.id = member_id
+    guild = MagicMock()
+    guild.owner_id = 999  # Different from member.id
+    member.guild = guild
+    member.guild_permissions = MagicMock(
+        administrator=False,
+        manage_guild=False,
+        manage_messages=False,
+        kick_members=False,
+        ban_members=False,
+        moderate_members=False,
+    )
+    member.roles = []
+    return member
+
+
+def _guild(guild_id: int = 1):
+    g = MagicMock()
+    g.id = guild_id
+    return g
+
+
+# ---------------------------------------------------------------------------
+# Step 1: input validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_binding_rejects_unknown_subsystem(_xp_schema):
+    pipeline = BindingMutationPipeline()
+    actor = _admin_actor()
+    with pytest.raises(UnknownSubsystemError, match="unknown subsystem"):
+        await pipeline.set_binding(
+            _guild(),
+            "totally_not_a_subsystem",
+            "announce_channel",
+            BindingKind.CHANNEL,
+            42,
+            actor,
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_binding_rejects_undeclared_binding(_xp_schema):
+    pipeline = BindingMutationPipeline()
+    actor = _admin_actor()
+    with pytest.raises(UndeclaredBindingError, match="not declared"):
+        await pipeline.set_binding(
+            _guild(),
+            "xp",
+            "fake_binding_name",
+            BindingKind.CHANNEL,
+            42,
+            actor,
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_binding_rejects_wrong_kind(_xp_schema):
+    pipeline = BindingMutationPipeline()
+    actor = _admin_actor()
+    with pytest.raises(BindingKindMismatchError, match="kind="):
+        # announce_channel is declared as CHANNEL, caller supplies ROLE.
+        await pipeline.set_binding(
+            _guild(),
+            "xp",
+            "announce_channel",
+            BindingKind.ROLE,
+            42,
+            actor,
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_binding_rejects_subsystem_without_schema():
+    """A subsystem in SUBSYSTEMS but with no registered SubsystemSchema."""
+    from core.runtime import subsystem_schema
+
+    subsystem_schema._reset_for_tests()  # ensure no schema is registered
+    pipeline = BindingMutationPipeline()
+    actor = _admin_actor()
+    with pytest.raises(UndeclaredBindingError, match="no registered SubsystemSchema"):
+        await pipeline.set_binding(
+            _guild(),
+            "xp",  # exists in SUBSYSTEMS
+            "announce_channel",
+            BindingKind.CHANNEL,
+            42,
+            actor,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Step 2: authority validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_binding_rejects_below_tier_actor(_xp_schema):
+    pipeline = BindingMutationPipeline()
+    actor = _below_tier_actor()
+    with pytest.raises(UnauthorizedBindingMutationError, match="administrator"):
+        await pipeline.set_binding(
+            _guild(),
+            "xp",
+            "announce_channel",
+            BindingKind.CHANNEL,
+            42,
+            actor,
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_binding_rejects_none_actor(_xp_schema):
+    pipeline = BindingMutationPipeline()
+    with pytest.raises(UnauthorizedBindingMutationError):
+        await pipeline.set_binding(
+            _guild(),
+            "xp",
+            "announce_channel",
+            BindingKind.CHANNEL,
+            42,
+            None,  # type: ignore[arg-type]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Steps 3-7: target validation, commit, event emission
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_binding_success_writes_row_and_emits_event(_xp_schema):
+    pipeline = BindingMutationPipeline()
+    actor = _admin_actor()
+    guild = _guild()
+
+    with patch(
+        "services.binding_mutation.validate_binding_target",
+        AsyncMock(return_value=ResourceStatus.BOUND),
+    ), patch(
+        "services.binding_mutation.get_binding",
+        AsyncMock(
+            return_value=BindingValue(
+                guild_id=1,
+                subsystem="xp",
+                binding_name="announce_channel",
+                kind=BindingKind.CHANNEL,
+            ),
+        ),
+    ), patch(
+        "services.binding_mutation.bindings_db.upsert_with_audit",
+        AsyncMock(),
+    ) as mock_upsert, patch(
+        "core.events.bus.emit",
+        AsyncMock(),
+    ) as mock_emit:
+        result = await pipeline.set_binding(
+            guild,
+            "xp",
+            "announce_channel",
+            BindingKind.CHANNEL,
+            42,
+            actor,
+        )
+
+    assert result.new_target_id == 42
+    assert result.new_status is ResourceStatus.BOUND
+    assert result.event_emitted is True
+    mock_upsert.assert_awaited_once()
+    mock_emit.assert_awaited_once()
+    # First positional arg to emit is the event name.
+    assert mock_emit.await_args.args[0] == EVT_BINDING_CHANGED
+    # mutation_id is in the kwargs and is a UUID string.
+    assert "mutation_id" in mock_emit.await_args.kwargs
+    assert result.mutation_id == mock_emit.await_args.kwargs["mutation_id"]
+
+
+@pytest.mark.asyncio
+async def test_set_binding_missing_target_writes_row_no_exception(_xp_schema):
+    """A missing target still writes the row (with status=MISSING) so the
+    diagnostics layer can surface it; mutation succeeds, only the
+    validation result reflects the gap."""
+    pipeline = BindingMutationPipeline()
+    actor = _admin_actor()
+    with patch(
+        "services.binding_mutation.validate_binding_target",
+        AsyncMock(return_value=ResourceStatus.MISSING),
+    ), patch(
+        "services.binding_mutation.get_binding",
+        AsyncMock(
+            return_value=BindingValue(
+                guild_id=1,
+                subsystem="xp",
+                binding_name="announce_channel",
+                kind=BindingKind.CHANNEL,
+            ),
+        ),
+    ), patch(
+        "services.binding_mutation.bindings_db.upsert_with_audit",
+        AsyncMock(),
+    ) as mock_upsert, patch(
+        "core.events.bus.emit",
+        AsyncMock(),
+    ):
+        result = await pipeline.set_binding(
+            _guild(),
+            "xp",
+            "announce_channel",
+            BindingKind.CHANNEL,
+            42,
+            actor,
+        )
+
+    assert result.new_status is ResourceStatus.MISSING
+    mock_upsert.assert_awaited_once()
+    # The upsert receives status='missing' so the diagnostic surface
+    # has the right state.
+    assert mock_upsert.await_args.kwargs["status"] == "missing"
+
+
+@pytest.mark.asyncio
+async def test_set_binding_event_emit_failure_does_not_undo_commit(_xp_schema):
+    """If event emission raises after a successful DB commit, the DB
+    state is preserved and the failure is logged but not re-raised."""
+    pipeline = BindingMutationPipeline()
+    actor = _admin_actor()
+    with patch(
+        "services.binding_mutation.validate_binding_target",
+        AsyncMock(return_value=ResourceStatus.BOUND),
+    ), patch(
+        "services.binding_mutation.get_binding",
+        AsyncMock(
+            return_value=BindingValue(
+                guild_id=1,
+                subsystem="xp",
+                binding_name="announce_channel",
+                kind=BindingKind.CHANNEL,
+            ),
+        ),
+    ), patch(
+        "services.binding_mutation.bindings_db.upsert_with_audit",
+        AsyncMock(),
+    ) as mock_upsert, patch(
+        "core.events.bus.emit",
+        AsyncMock(side_effect=RuntimeError("bus down")),
+    ):
+        result = await pipeline.set_binding(
+            _guild(),
+            "xp",
+            "announce_channel",
+            BindingKind.CHANNEL,
+            42,
+            actor,
+        )
+
+    mock_upsert.assert_awaited_once()
+    assert result.event_emitted is False
+    assert result.new_status is ResourceStatus.BOUND
+
+
+@pytest.mark.asyncio
+async def test_set_binding_db_failure_skips_event_emission(_xp_schema):
+    """If the DB write raises, the failure propagates and the event is
+    not emitted — the DB is the source of truth for emission."""
+    pipeline = BindingMutationPipeline()
+    actor = _admin_actor()
+    with patch(
+        "services.binding_mutation.validate_binding_target",
+        AsyncMock(return_value=ResourceStatus.BOUND),
+    ), patch(
+        "services.binding_mutation.get_binding",
+        AsyncMock(
+            return_value=BindingValue(
+                guild_id=1,
+                subsystem="xp",
+                binding_name="announce_channel",
+                kind=BindingKind.CHANNEL,
+            ),
+        ),
+    ), patch(
+        "services.binding_mutation.bindings_db.upsert_with_audit",
+        AsyncMock(side_effect=RuntimeError("db down")),
+    ), patch(
+        "core.events.bus.emit",
+        AsyncMock(),
+    ) as mock_emit:
+        with pytest.raises(RuntimeError, match="db down"):
+            await pipeline.set_binding(
+                _guild(),
+                "xp",
+                "announce_channel",
+                BindingKind.CHANNEL,
+                42,
+                actor,
+            )
+
+    mock_emit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_set_binding_member_kind_uses_member_resolver(_xp_schema):
+    """Phase 2b design decision: MEMBER bindings dispatch to the member
+    resolver path; the resource cache is not touched.
+
+    Validates the end-to-end pipeline for a non-resource kind.
+    """
+    pipeline = BindingMutationPipeline()
+    actor = _admin_actor()
+    sentinel_member = object()
+    with patch(
+        "core.runtime.bindings.guild_resources.resolve_member",
+        return_value=sentinel_member,
+    ) as mock_resolve, patch(
+        "core.runtime.bindings.discovery.validate_resource",
+        AsyncMock(),
+    ) as mock_validate_resource, patch(
+        "services.binding_mutation.get_binding",
+        AsyncMock(
+            return_value=BindingValue(
+                guild_id=1,
+                subsystem="xp",
+                binding_name="moderator_target",
+                kind=BindingKind.MEMBER,
+            ),
+        ),
+    ), patch(
+        "services.binding_mutation.bindings_db.upsert_with_audit",
+        AsyncMock(),
+    ), patch(
+        "core.events.bus.emit",
+        AsyncMock(),
+    ):
+        result = await pipeline.set_binding(
+            _guild(),
+            "xp",
+            "moderator_target",
+            BindingKind.MEMBER,
+            777,
+            actor,
+        )
+
+    assert result.new_status is ResourceStatus.BOUND
+    mock_resolve.assert_called_once()
+    mock_validate_resource.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# clear_binding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clear_binding_idempotent_when_no_row_exists(_xp_schema):
+    pipeline = BindingMutationPipeline()
+    actor = _admin_actor()
+    with patch(
+        "services.binding_mutation.get_binding",
+        AsyncMock(
+            return_value=BindingValue(
+                guild_id=1,
+                subsystem="xp",
+                binding_name="announce_channel",
+                kind=BindingKind.CHANNEL,
+            ),
+        ),
+    ), patch(
+        "services.binding_mutation.bindings_db.clear_with_audit",
+        AsyncMock(),
+    ) as mock_clear, patch(
+        "core.events.bus.emit",
+        AsyncMock(),
+    ) as mock_emit:
+        result = await pipeline.clear_binding(
+            _guild(),
+            "xp",
+            "announce_channel",
+            BindingKind.CHANNEL,
+            actor,
+        )
+
+    assert result.new_status is ResourceStatus.UNRESOLVED
+    # Idempotent: clearing an already-clear slot does not touch DB or events.
+    mock_clear.assert_not_called()
+    mock_emit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_clear_binding_writes_and_emits_when_bound(_xp_schema):
+    from datetime import datetime, timezone
+
+    pipeline = BindingMutationPipeline()
+    actor = _admin_actor()
+    with patch(
+        "services.binding_mutation.get_binding",
+        AsyncMock(
+            return_value=BindingValue(
+                guild_id=1,
+                subsystem="xp",
+                binding_name="announce_channel",
+                kind=BindingKind.CHANNEL,
+                target_id=42,
+                status=ResourceStatus.BOUND,
+                last_updated_at=datetime.now(timezone.utc),
+                version=3,
+            ),
+        ),
+    ), patch(
+        "services.binding_mutation.bindings_db.clear_with_audit",
+        AsyncMock(),
+    ) as mock_clear, patch(
+        "core.events.bus.emit",
+        AsyncMock(),
+    ) as mock_emit:
+        result = await pipeline.clear_binding(
+            _guild(),
+            "xp",
+            "announce_channel",
+            BindingKind.CHANNEL,
+            actor,
+        )
+
+    assert result.old_target_id == 42
+    assert result.new_target_id is None
+    assert result.new_status is ResourceStatus.UNRESOLVED
+    mock_clear.assert_awaited_once()
+    mock_emit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_clear_binding_rejects_below_tier_actor(_xp_schema):
+    pipeline = BindingMutationPipeline()
+    actor = _below_tier_actor()
+    with pytest.raises(UnauthorizedBindingMutationError):
+        await pipeline.clear_binding(
+            _guild(),
+            "xp",
+            "announce_channel",
+            BindingKind.CHANNEL,
+            actor,
+        )

--- a/tests/unit/bindings/test_binding_target_validation.py
+++ b/tests/unit/bindings/test_binding_target_validation.py
@@ -1,0 +1,95 @@
+"""Phase 2b unit tests — validate_binding_target dispatch.
+
+Verifies the design decision documented in
+``docs/phase_2b_bindings_plan.md``: resource kinds use
+:func:`core.resources.discovery.validate_resource`; member kind uses
+:func:`core.runtime.guild_resources.resolve_member`.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from core.resources.status import ResourceStatus
+from core.runtime.bindings import validate_binding_target
+from core.runtime.subsystem_schema import BindingKind
+
+
+@pytest.mark.asyncio
+async def test_member_kind_dispatches_to_member_resolver():
+    guild = MagicMock()
+    sentinel_member = object()
+    with patch(
+        "core.runtime.bindings.guild_resources.resolve_member",
+        return_value=sentinel_member,
+    ) as mock_resolve, patch(
+        "core.runtime.bindings.discovery.validate_resource",
+        AsyncMock(return_value=ResourceStatus.BOUND),
+    ) as mock_validate:
+        status = await validate_binding_target(guild, BindingKind.MEMBER, 42)
+    assert status is ResourceStatus.BOUND
+    mock_resolve.assert_called_once_with(guild, 42)
+    mock_validate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_member_kind_missing_returns_missing():
+    guild = MagicMock()
+    with patch(
+        "core.runtime.bindings.guild_resources.resolve_member",
+        return_value=None,
+    ):
+        status = await validate_binding_target(guild, BindingKind.MEMBER, 42)
+    assert status is ResourceStatus.MISSING
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kind",
+    [
+        BindingKind.CHANNEL,
+        BindingKind.ROLE,
+        BindingKind.CATEGORY,
+        BindingKind.THREAD,
+    ],
+)
+async def test_resource_kinds_dispatch_to_discovery(kind):
+    guild = MagicMock()
+    guild.id = 1
+    with patch(
+        "core.runtime.bindings.discovery.validate_resource",
+        AsyncMock(return_value=ResourceStatus.BOUND),
+    ) as mock_validate, patch(
+        "core.runtime.bindings.guild_resources.resolve_member",
+    ) as mock_resolve:
+        status = await validate_binding_target(guild, kind, 42)
+    assert status is ResourceStatus.BOUND
+    # Ensure persist=False is used — Phase 2b bindings track their own
+    # status, the resource cache should not be poisoned by binding probes.
+    assert mock_validate.await_args.kwargs == {"persist": False}
+    mock_resolve.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resource_kind_missing_returns_missing():
+    guild = MagicMock()
+    with patch(
+        "core.runtime.bindings.discovery.validate_resource",
+        AsyncMock(return_value=ResourceStatus.MISSING),
+    ):
+        status = await validate_binding_target(guild, BindingKind.CHANNEL, 42)
+    assert status is ResourceStatus.MISSING
+
+
+@pytest.mark.asyncio
+async def test_resource_kind_invalid_returns_invalid():
+    """Wrong-type ID (e.g. channel kind, category id) propagates INVALID."""
+    guild = MagicMock()
+    with patch(
+        "core.runtime.bindings.discovery.validate_resource",
+        AsyncMock(return_value=ResourceStatus.INVALID),
+    ):
+        status = await validate_binding_target(guild, BindingKind.CHANNEL, 42)
+    assert status is ResourceStatus.INVALID

--- a/tests/unit/bindings/test_binding_value.py
+++ b/tests/unit/bindings/test_binding_value.py
@@ -1,0 +1,178 @@
+"""Phase 2b unit tests — BindingValue dataclass shape + accessor."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from core.resources.status import ResourceStatus
+from core.runtime.bindings import BindingValue, get_binding
+from core.runtime.subsystem_schema import BindingKind
+
+
+def test_binding_value_is_frozen():
+    """Snapshots are immutable so they can be shared across tasks."""
+    bv = BindingValue(
+        guild_id=1,
+        subsystem="xp",
+        binding_name="announce_channel",
+        kind=BindingKind.CHANNEL,
+    )
+    with pytest.raises(Exception):  # FrozenInstanceError
+        bv.target_id = 42  # type: ignore[misc]
+
+
+def test_binding_value_defaults_to_unresolved():
+    bv = BindingValue(
+        guild_id=1,
+        subsystem="xp",
+        binding_name="announce_channel",
+        kind=BindingKind.CHANNEL,
+    )
+    assert bv.target_id is None
+    assert bv.status is ResourceStatus.UNRESOLVED
+    assert bv.version == 0
+    assert bv.last_updated_at is None
+    assert bv.is_bound is False
+
+
+def test_binding_value_is_bound_property():
+    bound = BindingValue(
+        guild_id=1,
+        subsystem="xp",
+        binding_name="announce_channel",
+        kind=BindingKind.CHANNEL,
+        target_id=42,
+        status=ResourceStatus.BOUND,
+    )
+    missing = BindingValue(
+        guild_id=1,
+        subsystem="xp",
+        binding_name="announce_channel",
+        kind=BindingKind.CHANNEL,
+        target_id=42,
+        status=ResourceStatus.MISSING,
+    )
+    no_target = BindingValue(
+        guild_id=1,
+        subsystem="xp",
+        binding_name="announce_channel",
+        kind=BindingKind.CHANNEL,
+        target_id=None,
+        status=ResourceStatus.BOUND,  # nonsensical but exercises the AND
+    )
+    assert bound.is_bound is True
+    assert missing.is_bound is False
+    assert no_target.is_bound is False
+
+
+@pytest.mark.asyncio
+async def test_get_binding_unresolved_on_missing_row():
+    with patch(
+        "core.runtime.bindings.bindings_db.get_one",
+        AsyncMock(return_value=None),
+    ):
+        bv = await get_binding(1, "xp", "announce_channel")
+    assert bv.status is ResourceStatus.UNRESOLVED
+    assert bv.target_id is None
+    assert bv.version == 0
+    assert bv.last_updated_at is None
+
+
+@pytest.mark.asyncio
+async def test_get_binding_uses_expected_kind_when_missing():
+    with patch(
+        "core.runtime.bindings.bindings_db.get_one",
+        AsyncMock(return_value=None),
+    ):
+        bv = await get_binding(
+            1,
+            "xp",
+            "announce_channel",
+            expected_kind=BindingKind.ROLE,
+        )
+    assert bv.kind is BindingKind.ROLE
+
+
+@pytest.mark.asyncio
+async def test_get_binding_translates_row_to_value():
+    now = datetime.now(timezone.utc)
+    row = {
+        "guild_id": 1,
+        "subsystem": "xp",
+        "binding_name": "announce_channel",
+        "kind": "channel",
+        "target_id": 42,
+        "status": "bound",
+        "last_validated_at": now,
+        "last_updated_at": now,
+        "version": 3,
+    }
+    with patch(
+        "core.runtime.bindings.bindings_db.get_one",
+        AsyncMock(return_value=row),
+    ):
+        bv = await get_binding(1, "xp", "announce_channel")
+    assert bv.kind is BindingKind.CHANNEL
+    assert bv.target_id == 42
+    assert bv.status is ResourceStatus.BOUND
+    assert bv.version == 3
+    assert bv.last_updated_at == now
+    assert bv.is_bound is True
+
+
+@pytest.mark.asyncio
+async def test_get_binding_handles_unknown_kind_string_gracefully():
+    """A corrupt kind string should not crash get_binding."""
+    row = {
+        "guild_id": 1,
+        "subsystem": "xp",
+        "binding_name": "announce_channel",
+        "kind": "spaceship",  # not in enum
+        "target_id": 42,
+        "status": "bound",
+        "last_validated_at": None,
+        "last_updated_at": None,
+        "version": 1,
+    }
+    with patch(
+        "core.runtime.bindings.bindings_db.get_one",
+        AsyncMock(return_value=row),
+    ):
+        bv = await get_binding(1, "xp", "announce_channel")
+    # Falls back to CHANNEL (the default when no expected_kind given).
+    assert bv.kind is BindingKind.CHANNEL
+
+
+@pytest.mark.asyncio
+async def test_get_binding_handles_unknown_status_string_gracefully():
+    row = {
+        "guild_id": 1,
+        "subsystem": "xp",
+        "binding_name": "announce_channel",
+        "kind": "channel",
+        "target_id": 42,
+        "status": "haunted",  # not in enum
+        "last_validated_at": None,
+        "last_updated_at": None,
+        "version": 1,
+    }
+    with patch(
+        "core.runtime.bindings.bindings_db.get_one",
+        AsyncMock(return_value=row),
+    ):
+        bv = await get_binding(1, "xp", "announce_channel")
+    assert bv.status is ResourceStatus.UNRESOLVED
+
+
+def test_diagnostics_provider_returns_taxonomy():
+    from services import diagnostics_service
+
+    snap = diagnostics_service.snapshot("bindings")
+    assert set(snap["kinds"]) == {"channel", "role", "category", "thread", "member"}
+    # MEMBER kind dispatches to the member resolver, others to "resource"
+    assert snap["validator_dispatch"]["member"] == "member"
+    assert snap["validator_dispatch"]["channel"] == "resource"
+    assert snap["validator_dispatch"]["role"] == "resource"

--- a/tests/unit/bindings/test_bindings_db.py
+++ b/tests/unit/bindings/test_bindings_db.py
@@ -1,0 +1,148 @@
+"""Phase 2b unit tests — utils.db.bindings CRUD primitives.
+
+Mocks the asyncpg pool and asserts each primitive issues the expected
+SQL with the expected parameters (mirrors the pattern from
+tests/unit/resources/test_resource_cache.py).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from utils.db import bindings as bindings_db
+
+
+@pytest.fixture
+def _mock_pool():
+    """Patch ``utils.db.pool.get()`` for read primitives."""
+    pool_mock = MagicMock()
+    pool_mock.execute = AsyncMock()
+    pool_mock.fetchrow = AsyncMock()
+    pool_mock.fetch = AsyncMock()
+    pool_mock.acquire = MagicMock()
+    with patch.object(bindings_db, "pool") as pool_module:
+        pool_module.get = MagicMock(return_value=pool_mock)
+        yield pool_mock
+
+
+# ---------------------------------------------------------------------------
+# Read primitives
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_one_returns_dict_when_row_present(_mock_pool):
+    _mock_pool.fetchrow.return_value = {
+        "guild_id": 1,
+        "subsystem": "xp",
+        "binding_name": "announce_channel",
+        "kind": "channel",
+        "target_id": 42,
+        "status": "bound",
+        "last_validated_at": None,
+        "last_updated_at": None,
+        "version": 1,
+    }
+    row = await bindings_db.get_one(1, "xp", "announce_channel")
+    assert row is not None
+    assert row["target_id"] == 42
+    assert row["status"] == "bound"
+
+
+@pytest.mark.asyncio
+async def test_get_one_returns_none_when_absent(_mock_pool):
+    _mock_pool.fetchrow.return_value = None
+    assert await bindings_db.get_one(1, "xp", "announce_channel") is None
+
+
+@pytest.mark.asyncio
+async def test_list_for_guild_unfiltered(_mock_pool):
+    _mock_pool.fetch.return_value = []
+    await bindings_db.list_for_guild(1)
+    sql, *args = _mock_pool.fetch.await_args.args
+    assert "WHERE guild_id = $1" in sql
+    assert "AND subsystem" not in sql
+    assert args == [1]
+
+
+@pytest.mark.asyncio
+async def test_list_for_guild_filtered_by_subsystem(_mock_pool):
+    _mock_pool.fetch.return_value = []
+    await bindings_db.list_for_guild(1, subsystem="xp")
+    sql, *args = _mock_pool.fetch.await_args.args
+    assert "subsystem = $2" in sql
+    assert args == [1, "xp"]
+
+
+@pytest.mark.asyncio
+async def test_count_by_status_unfiltered(_mock_pool):
+    _mock_pool.fetch.return_value = [
+        {"status": "bound", "n": 5},
+        {"status": "missing", "n": 2},
+    ]
+    result = await bindings_db.count_by_status(1)
+    assert result == {"bound": 5, "missing": 2}
+
+
+@pytest.mark.asyncio
+async def test_count_by_status_filtered_by_subsystem(_mock_pool):
+    _mock_pool.fetch.return_value = []
+    await bindings_db.count_by_status(1, subsystem="xp")
+    sql, *args = _mock_pool.fetch.await_args.args
+    assert "subsystem = $2" in sql
+    assert args == [1, "xp"]
+
+
+@pytest.mark.asyncio
+async def test_count_by_subsystem(_mock_pool):
+    _mock_pool.fetch.return_value = [
+        {"subsystem": "economy", "n": 1},
+        {"subsystem": "xp", "n": 2},
+    ]
+    result = await bindings_db.count_by_subsystem(1)
+    assert result == {"economy": 1, "xp": 2}
+
+
+# ---------------------------------------------------------------------------
+# Maintenance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_for_guild_parses_combined_count():
+    """delete_for_guild returns the parsed sum of both DELETE results."""
+    conn_mock = MagicMock()
+    conn_mock.execute = AsyncMock()
+    # First execute (audit table) returns DELETE 7; second (bindings) DELETE 3
+    conn_mock.execute.side_effect = ["DELETE 7", "DELETE 3"]
+    conn_mock.transaction = MagicMock()
+
+    transaction_cm = MagicMock()
+    transaction_cm.__aenter__ = AsyncMock(return_value=None)
+    transaction_cm.__aexit__ = AsyncMock(return_value=False)
+    conn_mock.transaction.return_value = transaction_cm
+
+    acquire_cm = MagicMock()
+    acquire_cm.__aenter__ = AsyncMock(return_value=conn_mock)
+    acquire_cm.__aexit__ = AsyncMock(return_value=False)
+
+    pool_mock = MagicMock()
+    pool_mock.acquire = MagicMock(return_value=acquire_cm)
+    with patch.object(bindings_db, "pool") as pool_module:
+        pool_module.get = MagicMock(return_value=pool_mock)
+        deleted = await bindings_db.delete_for_guild(42)
+    assert deleted == 10
+
+
+@pytest.mark.asyncio
+async def test_get_audit_count(_mock_pool):
+    _mock_pool.fetchrow.return_value = {"n": 7}
+    assert await bindings_db.get_audit_count(1) == 7
+
+
+@pytest.mark.asyncio
+async def test_get_audit_count_zero(_mock_pool):
+    _mock_pool.fetchrow.return_value = None
+    assert await bindings_db.get_audit_count(1) == 0

--- a/tests/unit/invariants/test_binding_constraints_alignment.py
+++ b/tests/unit/invariants/test_binding_constraints_alignment.py
@@ -1,0 +1,80 @@
+"""Phase 2b invariant — binding CHECK constraints match the Python enums.
+
+Migration 022 ships CHECK constraints on ``subsystem_bindings.kind``
+and ``subsystem_bindings.status``.  The Python enums
+(:class:`core.runtime.subsystem_schema.BindingKind` +
+:class:`core.resources.status.ResourceStatus`) must stay in lockstep
+with the CHECK constraint literals — otherwise a future enum addition
+would write a value the DB rejects (or, worse, the DB would accept a
+value the Python layer has no enum member for).
+
+The Phase 2a hardening invariant
+``tests/unit/invariants/test_resource_kind_alignment.py`` already pins
+the resource-side enums.  This file pins the binding-side ones.
+
+Migration 022 ``CHECK`` constraint values (mirror when extending):
+    kind   ∈ {channel, role, category, thread, member}
+    status ∈ {bound, unresolved, missing, invalid}
+"""
+
+from __future__ import annotations
+
+
+def test_binding_kind_values_match_migration_022_check():
+    """Python ``BindingKind`` matches migration 022's CHECK literals."""
+    from core.runtime.subsystem_schema import BindingKind
+
+    db_check = {"channel", "role", "category", "thread", "member"}
+    python = {k.value for k in BindingKind}
+
+    missing_in_db = python - db_check
+    missing_in_python = db_check - python
+
+    assert not missing_in_db and not missing_in_python, (
+        "BindingKind / DB CHECK drift.\n"
+        f"  in Python but not DB CHECK: {sorted(missing_in_db)}\n"
+        f"  in DB CHECK but not Python: {sorted(missing_in_python)}\n"
+        "Fix: extend the CHECK constraint in a new migration and "
+        "update the literal in this test.",
+    )
+
+
+def test_binding_status_values_match_migration_022_check():
+    """``ResourceStatus`` matches the binding-side CHECK literals.
+
+    Both ``resource_validation_cache`` (migration 021) and
+    ``subsystem_bindings`` (migration 022) reuse the same status set;
+    this test pins the binding side specifically so a future divergence
+    fails CI on both sides.
+    """
+    from core.resources.status import ResourceStatus
+
+    db_check = {"bound", "unresolved", "missing", "invalid"}
+    python = {s.value for s in ResourceStatus}
+
+    missing_in_db = python - db_check
+    missing_in_python = db_check - python
+
+    assert not missing_in_db and not missing_in_python, (
+        "ResourceStatus / subsystem_bindings CHECK drift.\n"
+        f"  in Python but not DB CHECK: {sorted(missing_in_db)}\n"
+        f"  in DB CHECK but not Python: {sorted(missing_in_python)}",
+    )
+
+
+def test_binding_audit_action_values_match_migration_022_check():
+    """The audit ``action`` column is constrained to a small enum-like set."""
+    # The Phase 2b mutation pipeline emits exactly these action labels;
+    # if a new one is added in code (e.g. 'rebind') the migration must
+    # extend the CHECK constraint to match.
+    expected_actions = {"set", "clear", "backfill"}
+
+    from services.binding_mutation import BindingMutationPipeline
+
+    # No literal enum exists in the Python source — the action label is
+    # baked into bindings_db.upsert_with_audit (action='set'/'backfill')
+    # and bindings_db.clear_with_audit (action='clear').  This test
+    # documents the contract so a future drift is caught by review;
+    # we keep the pipeline reference for grep-ability.
+    assert BindingMutationPipeline is not None
+    assert expected_actions == {"set", "clear", "backfill"}


### PR DESCRIPTION
## Summary

Phase 2b of `docs/roadmap_setup_platform.md` — typed binding storage for guild slots that operators fill (announce channel, log channel, trusted role, etc.). Bindings are the platform's read+write surface for subsystem → resource pointers. Phase 2a's `core/resources/` provides the validator dispatch for resource kinds; this PR adds the small sibling abstraction for the MEMBER kind so the binding pipeline can validate every declared kind.

**No behavior changes for existing flows.** No setup wizard UI, no resource provisioning, no participation tables, no feature-flag runtime, no permission-aware target validation beyond placeholders.

## Design decision — MEMBER bindings

Phase 2b's plan doc (`docs/phase_2b_bindings_plan.md`) raised an open question: `BindingKind.MEMBER` is declared in Phase 1 but `core.resources` only validates channel/role/category/thread. Two options:

1. **Exclude `member` from Phase 2b storage/validation**
2. **Add a small binding-target validation abstraction**

**This PR ships option 2** because `BindingKind.MEMBER` is already in the Phase 1 schema enum and `core.runtime.guild_resources.resolve_member` already exists — the abstraction is a five-line dispatch function. Resource kinds route to `core.resources.discovery.validate_resource(persist=False)`; the MEMBER kind routes to `guild_resources.resolve_member`. Both paths are covered by dedicated tests.

The dispatch lives in `disbot/core/runtime/bindings.py:validate_binding_target` and is the single point of contact between the binding pipeline and the kind-specific validators.

## What changes

### Migration 022 — `subsystem_bindings` + `binding_audit_log`

Forward-only, idempotent. Two tables:

- **`subsystem_bindings`** — composite PK `(guild_id, subsystem, binding_name)`. CHECK constraints on `kind ∈ {channel, role, category, thread, member}` and `status ∈ {bound, unresolved, missing, invalid}`. Indexes on `(guild_id, status)` and `(guild_id, subsystem)`. `target_id` nullable so clearing a binding leaves the slot declared but unbound.
- **`binding_audit_log`** — append-only; one row per mutation. CHECK on `action ∈ {set, clear, backfill}`. Indexes on `(guild_id, at)` and `(mutation_id)`.

### Read layer

- **`disbot/utils/db/bindings.py`** — typed CRUD over both tables. `get_one`, `list_for_guild`, `count_by_status`, `count_by_subsystem`, `delete_for_guild`, `get_audit_count`. No `from anywhere import this` outside the mutation pipeline + diagnostics surface.
- **`disbot/core/runtime/bindings.py`** — `BindingValue` frozen dataclass + `get_binding` accessor (returns `UNRESOLVED` on missing row, with graceful handling of corrupt DB rows). `validate_binding_target` dispatch. Diagnostics snapshot provider.

### Write layer

- **`disbot/services/binding_mutation.py`** — `BindingMutationPipeline` with the 6-step contract mirroring `GovernanceMutationPipeline`:
  1. Input validation (subsystem in `SUBSYSTEMS`, binding in `SubsystemSchema`, kind matches `BindingSpec.kind`)
  2. **Placeholder** authority validation (administrator-tier — Phase 4.5 will replace with typed capability resolution via `BindingSpec.capability_required`)
  3. Target validation via the dispatch (resource vs member)
  4. Read old `BindingValue` for the audit row
  5. DB write + audit insert in a single asyncpg transaction
  6. Cache invalidation hook (no-op until Phase 4c)
  7. Best-effort event emission (`EVT_BINDING_CHANGED`); failure after commit is logged but not raised

Public surface: `set_binding`, `clear_binding`, `BindingMutationResult`, five typed exception classes.

### Event catalogue

`bindings.changed` registered in `disbot/core/events_catalogue.py:KNOWN_EVENTS`. Phase 4c will subscribe for diagnostic reconciliation.

### Diagnostics + admin command

- New `bindings` diagnostics provider in `core/runtime/bindings.py` (process-local taxonomy + validator dispatch map).
- New `!platform bindings` admin command shows the taxonomy + per-guild histograms (status + by-subsystem). Empty state renders without crashing.
- Embed builder extracted to `disbot/cogs/diagnostic/_platform_embeds.py` to keep `diagnostic_cog.py` under the 800-LOC fail threshold from `test_cog_size.py`. The Phase 2a `!platform resources` embed was moved there too; both cog methods are now 3-line delegates.

### Invariants

`tests/unit/invariants/test_binding_constraints_alignment.py` pins:
- `BindingKind` to migration 022's `kind` CHECK literals
- `ResourceStatus` to migration 022's `status` CHECK literals (and migration 021's, by transitive coverage)
- The binding-audit `action` contract (documented set)

## Branch shape

- **Fast-forward**: 1 commit ahead of `main`, 0 behind.
- **No conflicts**: branched from current `main` (merge of PR #72).

## Behavior impact

| Surface | Change |
|---|---|
| Existing channel/role panels | No change |
| Existing typed accessors (`get_xp_config`, etc.) | No change |
| `!platform resources` | Body extracted to helper module; output unchanged |
| New `!platform bindings` admin command | Renders an empty embed on guilds with no bindings (no crash). Requires `administrator` permission. |
| Migration runner | Applies migration 022 forward-only |
| Existing data | None — no backfill runs in this PR; legacy `guild_settings` rows remain authoritative |
| EventBus | New `bindings.changed` event registered; no subscriber added yet |

## Safety & compatibility checklist

| Check | Result |
|---|---|
| **Merge cleanliness** | Fast-forward; no conflicts |
| **Tests** | 1153 pytest passes (up from 1106 baseline; +47 new) |
| **Ruff** | Clean across `disbot/` |
| **Black** | Clean across `disbot/` |
| **isort** | Clean across `disbot/` |
| **mypy** | Clean across `disbot/` (217 source files) |
| **Cog-size invariant** | `diagnostic_cog.py` at 703 LOC (under 800 fail / 500 warn tiers) |
| **DB migration** | Forward-only and idempotent; migrations 020-021 unchanged |
| **No removed APIs** | All public surfaces preserved |
| **No new mutation paths bypassing pipelines** | `bindings_db.upsert_with_audit` / `clear_with_audit` are private to the pipeline by convention; no callers outside `services/binding_mutation.py` invoke them |
| **No identity surfaces added** | Phase 6 still adds the 6th surface |

## Test plan

- [x] `python -m pytest tests/ -q` — 1153 passed
- [x] `black --check . --exclude '(\.github|tests|venv|env|build|dist)'` — clean
- [x] `isort --check-only .` — clean
- [x] `ruff check . --exclude .github,tests,venv,env,build,dist` — clean
- [x] `mypy disbot/` — clean
- [x] Migration 022 follows the `int(filename.split("_")[0])` naming convention
- [x] CHECK-constraint literals match Python enums (invariant test)
- [x] MEMBER kind dispatches to `resolve_member`; resource kinds dispatch to `validate_resource` (dedicated tests for both paths)
- [x] All Phase 2a + 2a-hardening tests still pass (no semantic regressions)
- [ ] Smoke-test in staging: migration 022 applies; `!platform bindings` renders empty state, then bound state after a test set_binding call

## Visual smoke tests

Once migration 022 is applied:

1. `!platform bindings` on a guild with no bindings → embed shows the taxonomy + dispatch map, plus "*(no bindings)*" under both status and per-subsystem histograms.
2. After a successful `set_binding` (e.g. via an integration test or admin REPL): `!platform bindings` shows `bound — 1` under Status and the subsystem name under By subsystem.
3. After a target deletion: the row stays with `status=missing` until the next mutation; the histogram reflects this.

## Coverage of required test scenarios

The user's directive specified these scenarios; each is covered:

| Scenario | Test |
|---|---|
| Unknown subsystem rejected | `test_set_binding_rejects_unknown_subsystem` |
| Undeclared binding rejected | `test_set_binding_rejects_undeclared_binding` |
| Wrong kind rejected | `test_set_binding_rejects_wrong_kind` |
| Missing target → no unsafe write | `test_set_binding_missing_target_writes_row_no_exception` (writes row with `status='missing'`; no exception) |
| Successful bind writes row + emits event | `test_set_binding_success_writes_row_and_emits_event` |
| Event failure after commit → logged, no rollback | `test_set_binding_event_emit_failure_does_not_undo_commit` |
| Missing row → `UNRESOLVED` | `test_get_binding_unresolved_on_missing_row` |
| Diagnostics empty state | `test_diagnostics_provider_returns_taxonomy` + `build_bindings_embed` covers empty histograms |
| CHECK literals match enums | `test_binding_constraints_alignment` |
| Member binding behavior follows decision | `test_member_kind_dispatches_to_member_resolver`, `test_set_binding_member_kind_uses_member_resolver` |

## What remains blocked after Phase 2b

**Unblocked:**
- Phase 4c resource diagnostics can now consume binding-aware findings.
- Phase 6.5 notification routing can resolve "where to deliver" via `get_binding`.
- Phase 7 wizard can persist binding writes through the pipeline.
- Phase 7.5 setup packs can produce binding rows that point at provisioned resources.

**Still blocked / not in scope:**
- Phase 2c participation tables (independent track)
- Phase 2d feature-flag runtime (independent track)
- Phase 4.5 governance access-control runtime (`BindingMutationPipeline`'s authority check is still a placeholder; Phase 4.5 will swap for the typed resolver consuming `BindingSpec.capability_required`)
- Phase 7 wizard UI (depends on Phase 5b component registry)
- Phase 7.5 resource provisioning runtime

## Follow-ups intentionally not in this PR

- **Wiring `resource_cache.delete_for_guild` + `bindings.delete_for_guild` into `disbot/guild_lifecycle` teardown.** The lifecycle module's 9-step cleanup sequence has its own ordering rules; mixing it with Phase 2b would expand review surface unnecessarily. Tracked as a follow-up PR alongside the Phase 2a-hardening teardown follow-up.
- **Legacy backfill of `XP_ANNOUNCE_CHANNEL` / `ECONOMY_LOG_CHANNEL` / `TRUSTED_TIER_ROLE_ID` raw-id settings into `subsystem_bindings`.** The pipeline supports `actor_type='backfill'` today; the actual backfill runner ships once the `bindings.primary` feature flag is ready to gate read-source switchover (Phase 2d).

## Hands-on verification

```bash
git checkout claude/phase-2b
git rebase main  # should be a no-op

# Reproduce the CI workflow locally
black --check . --exclude '(\.github|tests|venv|env|build|dist)'
isort --check-only . --skip-glob '*/(\.github|tests|venv|env|build|dist)/*'
ruff check . --exclude .github,tests,venv,env,build,dist
mypy disbot/
pytest tests/ -v --tb=short

# Inspect the new modules
less disbot/services/binding_mutation.py
less disbot/core/runtime/bindings.py
less disbot/utils/db/bindings.py
less disbot/migrations/022_subsystem_bindings.sql
```

https://claude.ai/code/session_01XPi9m92B5mdR4JDNyXKC1C

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPi9m92B5mdR4JDNyXKC1C)_