### PR TITLE
Phase 2.1: wire binding+resource teardown; split binding cleanup primitive

### DIFF
--- a/disbot/guild_lifecycle.py
+++ b/disbot/guild_lifecycle.py
@@ -29,11 +29,14 @@ async def teardown(guild_id: int) -> None:
       2. Runtime sessions       — delete DB sessions + cascade session_state rows.
       3. Session state store    — remaining orphan state rows for the guild.
       4. Panel anchors          — delete all panel_anchors rows for the guild.
-      5. Governance capability cache — clear per-guild execution overrides.
-      6. Governance visibility cache — bump version, clear role-override flag.
-      7. Guild-config cache      — drop cached guild config entries (F-1).
-      8. Scope locks             — invoke registered per-cog teardown hooks (F-2).
-      9. Governance feedback cooldown — documented, no per-guild cleanup needed.
+      5. Subsystem bindings     — delete active subsystem_bindings rows (Phase 2);
+                                   binding_audit_log rows are PRESERVED by design.
+      6. Resource validation cache — drop resource_validation_cache rows (Phase 2).
+      7. Governance capability cache — clear per-guild execution overrides.
+      8. Governance visibility cache — bump version, clear role-override flag.
+      9. Guild-config cache     — drop cached guild config entries (F-1).
+      10. Scope locks            — invoke registered per-cog teardown hooks (F-2).
+      11. Governance feedback cooldown — documented, no per-guild cleanup needed.
     """
     logger.info("guild_lifecycle.teardown: beginning cleanup for guild=%d", guild_id)
 
@@ -49,19 +52,25 @@ async def teardown(guild_id: int) -> None:
     # 4. Panel anchors — delete all panel_anchors rows for the guild (GAP-001).
     await _teardown_panel_anchors(guild_id)
 
-    # 5. Governance capability overrides — clear execution-layer in-process dict.
+    # 5. Subsystem bindings active rows — audit log preserved (Phase 2 retention).
+    await _teardown_subsystem_bindings(guild_id)
+
+    # 6. Resource validation cache — drop cached resource status rows (Phase 2a).
+    await _teardown_resource_cache(guild_id)
+
+    # 7. Governance capability overrides — clear execution-layer in-process dict.
     _teardown_capability_overrides(guild_id)
 
-    # 6. Governance visibility cache — version bump + role flag removal.
+    # 8. Governance visibility cache — version bump + role flag removal.
     _teardown_visibility_cache(guild_id)
 
-    # 7. Guild-config cache — drop cached config entries for the guild (F-1 / S1.1).
+    # 9. Guild-config cache — drop cached config entries for the guild (F-1 / S1.1).
     _teardown_guild_config(guild_id)
 
-    # 8. Scope locks — invoke registered per-cog teardown hooks (F-2 / S1.2).
+    # 10. Scope locks — invoke registered per-cog teardown hooks (F-2 / S1.2).
     _teardown_scope_locks(guild_id)
 
-    # 9. Governance feedback cooldown dict in governance/__init__.
+    # 11. Governance feedback cooldown dict in governance/__init__.
     _teardown_feedback_cooldown(guild_id)
 
     logger.info("guild_lifecycle.teardown: complete for guild=%d", guild_id)
@@ -147,6 +156,52 @@ async def _teardown_panel_anchors(guild_id: int) -> None:
             )
     except Exception as exc:
         logger.warning("guild_lifecycle: panel anchor teardown failed: %s", exc)
+
+
+async def _teardown_subsystem_bindings(guild_id: int) -> None:
+    """Delete active subsystem_bindings rows for the departed guild.
+
+    Phase 2 retention policy: ``binding_audit_log`` is **preserved** on
+    guild leave so the historical trail survives re-invitation.  This
+    teardown step calls ``delete_active_bindings_for_guild`` — the
+    deliberately-split primitive that touches only the active table.
+    A separate ``purge_binding_audit_for_guild`` primitive exists for
+    explicit forensic cleanup but is NOT invoked here.
+    """
+    try:
+        from utils.db.bindings import delete_active_bindings_for_guild
+
+        count = await delete_active_bindings_for_guild(guild_id)
+        if count:
+            logger.debug(
+                "guild_lifecycle: deleted %d active binding(s) for guild=%d",
+                count,
+                guild_id,
+            )
+    except Exception as exc:
+        logger.warning("guild_lifecycle: bindings teardown failed: %s", exc)
+
+
+async def _teardown_resource_cache(guild_id: int) -> None:
+    """Drop resource_validation_cache rows for the departed guild.
+
+    Phase 2a hardening shipped the ``delete_for_guild`` primitive; this
+    step wires it into the lifecycle.  Resource cache rows are pure
+    derived state (recomputable from Discord), so deletion is safe and
+    avoids unbounded growth across re-invitations.
+    """
+    try:
+        from utils.db.resource_cache import delete_for_guild as _resource_delete
+
+        count = await _resource_delete(guild_id)
+        if count:
+            logger.debug(
+                "guild_lifecycle: deleted %d resource cache row(s) for guild=%d",
+                count,
+                guild_id,
+            )
+    except Exception as exc:
+        logger.warning("guild_lifecycle: resource cache teardown failed: %s", exc)
 
 
 def _teardown_capability_overrides(guild_id: int) -> None:

--- a/disbot/utils/db/bindings.py
+++ b/disbot/utils/db/bindings.py
@@ -261,31 +261,47 @@ async def clear_with_audit(
 # ---------------------------------------------------------------------------
 
 
-async def delete_for_guild(guild_id: int) -> int:
-    """Remove every binding row + every audit row for ``guild_id``.
+def _parse_delete_count(result: str) -> int:
+    """Best-effort parse of asyncpg's ``"DELETE N"`` status string."""
+    try:
+        return int(result.split()[-1])
+    except (ValueError, IndexError):
+        return 0
 
-    Returns the combined deleted-row count (best-effort parse of
-    asyncpg's ``"DELETE N"`` status).  Phase 2b ships the primitive;
-    teardown wiring lands as a follow-up alongside the
-    :func:`utils.db.resource_cache.delete_for_guild` wiring.
+
+async def delete_active_bindings_for_guild(guild_id: int) -> int:
+    """Remove ``subsystem_bindings`` rows for ``guild_id``; preserve audit.
+
+    Phase 2 retention policy (see ``docs/platform-consistency-ledger.md``
+    §3) is to **preserve** ``binding_audit_log`` rows on guild leave so
+    the historical trail survives re-invitation.  This primitive is the
+    one ``guild_lifecycle.teardown`` calls; the audit purge is a
+    deliberately separate primitive (``purge_binding_audit_for_guild``)
+    that teardown never invokes.
+
+    Returns the number of active rows deleted.
     """
-    async with pool.get().acquire() as conn, conn.transaction():
-        r1 = await conn.execute(
-            "DELETE FROM binding_audit_log WHERE guild_id = $1",
-            guild_id,
-        )
-        r2 = await conn.execute(
-            "DELETE FROM subsystem_bindings WHERE guild_id = $1",
-            guild_id,
-        )
+    result = await pool.get().execute(
+        "DELETE FROM subsystem_bindings WHERE guild_id = $1",
+        guild_id,
+    )
+    return _parse_delete_count(result)
 
-    def _parse(result: str) -> int:
-        try:
-            return int(result.split()[-1])
-        except (ValueError, IndexError):
-            return 0
 
-    return _parse(r1) + _parse(r2)
+async def purge_binding_audit_for_guild(guild_id: int) -> int:
+    """Forensic primitive: delete ``binding_audit_log`` rows for a guild.
+
+    NOT called from ``guild_lifecycle.teardown`` — audit retention on
+    guild leave is by-design (see ``delete_active_bindings_for_guild``).
+    Reserved for explicit operator-driven cleanup (GDPR-style erasure,
+    test fixtures, manual archival).  Returns the number of audit rows
+    deleted.
+    """
+    result = await pool.get().execute(
+        "DELETE FROM binding_audit_log WHERE guild_id = $1",
+        guild_id,
+    )
+    return _parse_delete_count(result)
 
 
 async def get_audit_count(guild_id: int) -> int:
@@ -322,10 +338,11 @@ __all__ = [
     "clear_with_audit",
     "count_by_status",
     "count_by_subsystem",
-    "delete_for_guild",
+    "delete_active_bindings_for_guild",
     "get_audit_count",
     "get_one",
     "list_for_guild",
+    "purge_binding_audit_for_guild",
     "row_to_summary",
     "upsert_with_audit",
 ]

--- a/tests/unit/bindings/test_bindings_db.py
+++ b/tests/unit/bindings/test_bindings_db.py
@@ -111,29 +111,60 @@ async def test_count_by_subsystem(_mock_pool):
 
 
 @pytest.mark.asyncio
-async def test_delete_for_guild_parses_combined_count():
-    """delete_for_guild returns the parsed sum of both DELETE results."""
-    conn_mock = MagicMock()
-    conn_mock.execute = AsyncMock()
-    # First execute (audit table) returns DELETE 7; second (bindings) DELETE 3
-    conn_mock.execute.side_effect = ["DELETE 7", "DELETE 3"]
-    conn_mock.transaction = MagicMock()
+async def test_delete_active_bindings_for_guild_targets_active_table(_mock_pool):
+    """delete_active_bindings_for_guild deletes ONLY from subsystem_bindings.
 
-    transaction_cm = MagicMock()
-    transaction_cm.__aenter__ = AsyncMock(return_value=None)
-    transaction_cm.__aexit__ = AsyncMock(return_value=False)
-    conn_mock.transaction.return_value = transaction_cm
+    Phase 2 retention policy: audit rows MUST survive guild teardown so
+    the historical trail is preserved.  This test guards against a
+    regression that would re-introduce audit deletion via this primitive.
+    """
+    _mock_pool.execute.return_value = "DELETE 3"
+    deleted = await bindings_db.delete_active_bindings_for_guild(42)
+    sql, *args = _mock_pool.execute.await_args.args
+    assert "DELETE FROM subsystem_bindings" in sql
+    assert "binding_audit_log" not in sql
+    assert args == [42]
+    assert deleted == 3
 
-    acquire_cm = MagicMock()
-    acquire_cm.__aenter__ = AsyncMock(return_value=conn_mock)
-    acquire_cm.__aexit__ = AsyncMock(return_value=False)
 
-    pool_mock = MagicMock()
-    pool_mock.acquire = MagicMock(return_value=acquire_cm)
-    with patch.object(bindings_db, "pool") as pool_module:
-        pool_module.get = MagicMock(return_value=pool_mock)
-        deleted = await bindings_db.delete_for_guild(42)
-    assert deleted == 10
+@pytest.mark.asyncio
+async def test_delete_active_bindings_for_guild_handles_zero_rows(_mock_pool):
+    _mock_pool.execute.return_value = "DELETE 0"
+    assert await bindings_db.delete_active_bindings_for_guild(42) == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_active_bindings_for_guild_handles_unexpected_status(_mock_pool):
+    _mock_pool.execute.return_value = "unexpected"
+    assert await bindings_db.delete_active_bindings_for_guild(42) == 0
+
+
+@pytest.mark.asyncio
+async def test_purge_binding_audit_for_guild_targets_audit_table(_mock_pool):
+    """purge_binding_audit_for_guild deletes ONLY from binding_audit_log.
+
+    This is the forensic/GDPR primitive — explicitly NOT wired into
+    guild_lifecycle.teardown.  Kept separate so the active-row delete in
+    teardown can't accidentally cascade to audit data.
+    """
+    _mock_pool.execute.return_value = "DELETE 7"
+    deleted = await bindings_db.purge_binding_audit_for_guild(42)
+    sql, *args = _mock_pool.execute.await_args.args
+    assert "DELETE FROM binding_audit_log" in sql
+    assert "subsystem_bindings" not in sql
+    assert args == [42]
+    assert deleted == 7
+
+
+@pytest.mark.asyncio
+async def test_legacy_delete_for_guild_removed():
+    """The combined delete_for_guild primitive is intentionally gone.
+
+    Splitting active-row delete from audit purge is a binding retention
+    guarantee; restoring a combined primitive would re-open the silent
+    audit-deletion path.
+    """
+    assert not hasattr(bindings_db, "delete_for_guild")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/runtime/test_guild_lifecycle_teardown.py
+++ b/tests/unit/runtime/test_guild_lifecycle_teardown.py
@@ -1,0 +1,220 @@
+"""Phase 2 — guild_lifecycle.teardown wires Phase 2 cleanup primitives.
+
+Two new steps were added to ``guild_lifecycle.teardown`` in this PR:
+
+* **Step 5** — :func:`utils.db.bindings.delete_active_bindings_for_guild`
+  purges ``subsystem_bindings`` rows and **preserves**
+  ``binding_audit_log``.  The audit primitive is split into
+  :func:`utils.db.bindings.purge_binding_audit_for_guild` which is
+  reserved for explicit forensic cleanup and is **never** called from
+  teardown.
+* **Step 6** — :func:`utils.db.resource_cache.delete_for_guild` drops
+  cached resource validation rows (the primitive shipped in PR #72; the
+  wiring landed here).
+
+These tests pin the contract for both:
+
+* Both new primitives are awaited during teardown.
+* The audit-purge primitive is **not** awaited (retention guarantee).
+* Per-step failure does not abort the rest of the teardown sequence
+  (matches the existing try/except discipline in
+  ``disbot/guild_lifecycle.py``).
+* Repeated invocation of teardown is safe (idempotent — primitives are
+  ``DELETE WHERE`` statements that return zero on a second run).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def _teardown_patches():
+    """Patch every other teardown step so the test isolates Phase 2 wiring.
+
+    The lifecycle sequence touches scheduler / sessions / panel anchors /
+    governance caches / scope_locks / etc.  None of those are under test
+    here; mocking them keeps the test independent of cross-cutting
+    runtime imports.
+    """
+    with (
+        patch(
+            "utils.db.delete_sessions_for_guild",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "utils.db.delete_guild_session_state",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "utils.db.delete_guild_panel_anchors",
+            new_callable=AsyncMock,
+            return_value=0,
+        ),
+        patch(
+            "core.runtime.live_update_scheduler.forget_guild",
+            return_value=0,
+        ),
+        patch(
+            "governance.execution.forget_guild_capabilities",
+        ),
+        patch(
+            "governance.cache.forget_guild",
+        ),
+        patch(
+            "core.runtime.guild_config.forget_guild",
+        ),
+        patch(
+            "core.runtime.scope_locks.teardown_guild",
+            return_value=0,
+        ),
+    ):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Step 5 — subsystem bindings active rows deleted; audit preserved
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_teardown_deletes_active_bindings(_teardown_patches):
+    """The active-row delete primitive is awaited exactly once with guild_id."""
+    import guild_lifecycle
+
+    with patch(
+        "utils.db.bindings.delete_active_bindings_for_guild",
+        new_callable=AsyncMock,
+        return_value=2,
+    ) as mock_delete:
+        await guild_lifecycle.teardown(99)
+        mock_delete.assert_awaited_once_with(99)
+
+
+@pytest.mark.asyncio
+async def test_teardown_does_not_purge_binding_audit(_teardown_patches):
+    """Audit retention guarantee: teardown never calls the purge primitive.
+
+    If a future contributor wires the audit-purge primitive into the
+    teardown sequence, this test fails and they must update both the
+    retention policy (``docs/platform-consistency-ledger.md`` §3) AND
+    this assertion deliberately.
+    """
+    import guild_lifecycle
+
+    with (
+        patch(
+            "utils.db.bindings.delete_active_bindings_for_guild",
+            new_callable=AsyncMock,
+            return_value=0,
+        ),
+        patch(
+            "utils.db.bindings.purge_binding_audit_for_guild",
+            new_callable=AsyncMock,
+        ) as mock_purge,
+    ):
+        await guild_lifecycle.teardown(99)
+        mock_purge.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_teardown_binding_step_failure_is_isolated(_teardown_patches):
+    """If the binding-delete primitive raises, the resource-cache step still runs."""
+    import guild_lifecycle
+
+    with (
+        patch(
+            "utils.db.bindings.delete_active_bindings_for_guild",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("DB blip"),
+        ),
+        patch(
+            "utils.db.resource_cache.delete_for_guild",
+            new_callable=AsyncMock,
+            return_value=0,
+        ) as mock_resource_delete,
+    ):
+        await guild_lifecycle.teardown(99)
+        mock_resource_delete.assert_awaited_once_with(99)
+
+
+# ---------------------------------------------------------------------------
+# Step 6 — resource validation cache rows deleted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_teardown_deletes_resource_cache(_teardown_patches):
+    """The resource-cache delete primitive is awaited exactly once with guild_id."""
+    import guild_lifecycle
+
+    with (
+        patch(
+            "utils.db.bindings.delete_active_bindings_for_guild",
+            new_callable=AsyncMock,
+            return_value=0,
+        ),
+        patch(
+            "utils.db.resource_cache.delete_for_guild",
+            new_callable=AsyncMock,
+            return_value=3,
+        ) as mock_delete,
+    ):
+        await guild_lifecycle.teardown(99)
+        mock_delete.assert_awaited_once_with(99)
+
+
+@pytest.mark.asyncio
+async def test_teardown_resource_cache_step_failure_is_isolated(_teardown_patches):
+    """If resource-cache delete raises, the rest of teardown continues."""
+    import guild_lifecycle
+
+    with (
+        patch(
+            "utils.db.bindings.delete_active_bindings_for_guild",
+            new_callable=AsyncMock,
+            return_value=0,
+        ),
+        patch(
+            "utils.db.resource_cache.delete_for_guild",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("DB blip"),
+        ),
+        patch(
+            "governance.execution.forget_guild_capabilities",
+        ) as mock_caps,
+    ):
+        await guild_lifecycle.teardown(99)
+        # downstream step still invoked despite resource_cache failure
+        mock_caps.assert_called_once_with(99)
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — calling teardown twice produces no error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_teardown_is_idempotent(_teardown_patches):
+    """Re-running teardown for the same guild is a no-op safety net."""
+    import guild_lifecycle
+
+    with (
+        patch(
+            "utils.db.bindings.delete_active_bindings_for_guild",
+            new_callable=AsyncMock,
+            return_value=0,
+        ) as mock_bindings_delete,
+        patch(
+            "utils.db.resource_cache.delete_for_guild",
+            new_callable=AsyncMock,
+            return_value=0,
+        ) as mock_resource_delete,
+    ):
+        await guild_lifecycle.teardown(99)
+        await guild_lifecycle.teardown(99)
+        assert mock_bindings_delete.await_count == 2
+        assert mock_resource_delete.await_count == 2


### PR DESCRIPTION
## Summary

PR-1 of the finalized Phase 2 plan. Close the guild-leave data-leak hole by wiring the Phase 2a/2b cleanup primitives into `guild_lifecycle.teardown`, while **preserving `binding_audit_log`** as a deliberate retention guarantee (`docs/platform-consistency-ledger.md` §3).

Depends on: nothing on `main`. Stacks cleanly atop PR #75 (consistency ledger) — no shared files.

## What changed

### `disbot/utils/db/bindings.py` — primitive split

The existing combined `delete_for_guild(guild_id)` silently deleted both `subsystem_bindings` AND `binding_audit_log`. That violates the new retention policy. Replaced with two scoped primitives:

- **`delete_active_bindings_for_guild(guild_id)`** — deletes ONLY `subsystem_bindings` rows. This is what teardown calls.
- **`purge_binding_audit_for_guild(guild_id)`** — deletes ONLY `binding_audit_log` rows. Reserved for explicit forensic/GDPR cleanup; **never** called from teardown.

The old combined function is removed; a regression test asserts the attribute is gone.

### `disbot/guild_lifecycle.py` — two new teardown steps

Inserted between current step 4 (panel anchors) and current step 5 (governance capability overrides):

| New step | Helper | Calls |
|---|---|---|
| 5 | `_teardown_subsystem_bindings` | `delete_active_bindings_for_guild` |
| 6 | `_teardown_resource_cache` | `resource_cache.delete_for_guild` |

Both helpers import their `utils.db` dependencies **inside the function body** to preserve the PR #74 import-cycle fix pattern. Both wrap in `try/except` matching the existing isolation discipline.

Renumbered the existing steps 5–9 to 7–11 in the docstring.

### Tests

**`tests/unit/bindings/test_bindings_db.py`** — replaced the combined-count test with five focused tests:
- Active-row delete targets only `subsystem_bindings` (regression guard against audit being touched)
- Audit purge targets only `binding_audit_log`
- Both primitives handle `DELETE 0` / `DELETE N` / unexpected status
- Legacy `delete_for_guild` attribute is gone

**`tests/unit/runtime/test_guild_lifecycle_teardown.py`** (NEW) — pins the contract:
- Active-binding delete primitive is awaited from teardown
- `purge_binding_audit_for_guild` is **never** awaited from teardown (retention guarantee)
- Per-step failure is isolated (one broken step does not abort the rest)
- Teardown is idempotent

## Architectural boundaries preserved

- No new domain. No new migration. No schema change.
- Highest migration remains `022_subsystem_bindings.sql`.
- No top-level `core.runtime` imports added to cycle-sensitive modules — both new helpers import locally inside their bodies.
- Import-cycle regression test (`tests/unit/runtime/test_import_cycle_regression.py`) still green.
- No feature flag, participation, backfill, or setup-UI work.
- **No terminal lifecycle audit row written.** The current `binding_audit_log` schema requires UUID `mutation_id`, non-null `actor_id`, and `action IN ('set','clear','backfill')` — none of which fits a teardown event. Adding lifecycle actions to the audit log would require a future migration; that's out of scope for this small safety PR.
- **No new Discord command added.** This PR is teardown-only.

## Migrations

None. Highest remains `022_subsystem_bindings.sql`.

## Rollback strategy

Single `git revert`. No schema change. The cleanup absence is a slow leak, not a corruption — prior behavior is immediately restored on revert.

## Tests run

```
python -m pytest tests/unit/bindings/test_bindings_db.py \
                 tests/unit/runtime/test_guild_lifecycle_teardown.py \
                 tests/unit/runtime/test_import_cycle_regression.py -q
# 23 passed

python -m pytest tests/ -q --ignore=tests/integration
# 1166 passed, 12 unrelated deprecation warnings (full suite green)

python -m ruff check disbot/utils/db/bindings.py disbot/guild_lifecycle.py
# All checks passed!

python -m black --check disbot/... tests/...   # 4 files left unchanged
python -m isort --check-only disbot/... tests/...  # clean
```

## Manual Discord smoke (suggested before merge)

There is **no Discord command** in Phase 2b for setting bindings (`!platform bindings` is diagnostic-only). The realistic ways to seed and verify teardown are:

- [ ] **Seed rows directly in the test DB** (psql / asyncpg REPL):
  ```sql
  INSERT INTO subsystem_bindings
      (guild_id, subsystem, binding_name, kind, target_id, status)
  VALUES (<test_guild_id>, 'xp', 'announce_channel', 'channel',
          <channel_id>, 'bound');
  ```
- [ ] **OR invoke `BindingMutationPipeline` via a Python REPL** on the bot host:
  ```python
  from services.binding_mutation import BindingMutationPipeline
  from core.runtime.subsystem_schema import BindingKind
  p = BindingMutationPipeline()
  await p.set_binding(guild=<guild>, subsystem='xp',
                      binding_name='announce_channel',
                      kind=BindingKind.CHANNEL,
                      target_id=<channel_id>, actor=<admin_member>)
  ```
- [ ] Kick the bot from the test guild
- [ ] Verify `subsystem_bindings` rows for that guild are **gone**
- [ ] Verify `binding_audit_log` rows for that guild are **PRESERVED**
- [ ] Verify `resource_validation_cache` rows for that guild are **gone**
- [ ] Re-invite the bot; confirm `!platform bindings` shows clean state and prior audit context still queryable

## Intentionally deferred

- **Terminal lifecycle audit row** — would require a future migration to relax `binding_audit_log.action` CHECK and `actor_id NOT NULL`. Not worth coupling to this small safety PR.
- **Feature flag and participation table teardowns** — those tables don't exist yet; PR-2 (feature flags) and PR-8 (participation) will add their own teardown hooks following this same pattern.
- **`!platform consistency` surface** — drift detection across domains arrives in PR-10.

## Test plan

- [x] All linters and tests green locally
- [x] Import-cycle regression test still passes
- [x] Retention regression test added (audit purge NOT called from teardown)
- [x] Failure-isolation test added (one broken step doesn't abort sequence)
- [x] Idempotency test added