### PR TITLE
Phase 2.2: feature flag evaluator foundation (Phase 2d, PR-2)

### DIFF
--- a/disbot/cogs/diagnostic_cog.py
+++ b/disbot/cogs/diagnostic_cog.py
@@ -670,31 +670,46 @@ class DiagnosticCog(commands.Cog):
     @platform_grp.command(name="flags")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def platform_flags(self, ctx):
-        """Declared FeatureFlag entries (Phase 1d declarations only)."""
+        """Feature flags: declarations + Phase 2d evaluator state per flag."""
+        from core.runtime import feature_flags
         from services import diagnostics_service
 
         snap = diagnostics_service.snapshot("feature_flags")
+        guild_id = ctx.guild.id if ctx.guild else None
+        rows: list[str] = []
+        for name in sorted(snap.get("by_name", {})):
+            info = snap["by_name"][name]
+            try:
+                decision = await feature_flags.resolve_with_provenance(
+                    name,
+                    guild_id,
+                )
+                effective = "on" if decision.value else "off"
+                source = decision.source
+            except Exception as exc:  # noqa: BLE001 — diagnostics must not raise
+                effective = "?"
+                source = f"error:{type(exc).__name__}"
+            rows.append(
+                f"`{name}` default={info['default_value']} "
+                f"effective={effective} src={source} owner=`{info['owner']}`",
+            )
         embed = discord.Embed(
-            title="🚩 Feature flags (declared)",
+            title="🚩 Feature flags",
             description=(
                 f"{snap['declared_total']} declared  ·  "
-                "Phase 2d will add runtime evaluation"
+                f"cache={snap.get('cache_size', 0)}  ·  "
+                f"bootstrap_fallback={snap.get('bootstrap_fallback_count', 0)}"
             ),
             color=discord.Color.blurple(),
         )
-        by_name = snap.get("by_name", {})
-        if by_name:
-            lines = [
-                f"`{name}` default={info['default_value']} owner=`{info['owner']}`"
-                for name, info in sorted(by_name.items())
-            ]
+        if rows:
             embed.add_field(
-                name="Declared",
-                value="\n".join(lines)[:1024],
+                name="Flags",
+                value="\n".join(rows)[:1024],
                 inline=False,
             )
         else:
-            embed.add_field(name="Declared", value="*(none)*", inline=False)
+            embed.add_field(name="Flags", value="*(none)*", inline=False)
         await ctx.send(embed=embed)
 
 

--- a/disbot/core/runtime/feature_flags.py
+++ b/disbot/core/runtime/feature_flags.py
@@ -415,12 +415,25 @@ async def _resolve_from_db(
             flag=flag,
             guild_tier=guild_tier,
         )
-        if value or _normalize_state(global_row["state"]) in ("on", "off"):
-            # A hard 'on' / matching tier wins.  A hard 'off' / unmatched
-            # tier means "no override fires" — fall through to the
-            # declared rollout policy.  We only short-circuit on 'on' so
-            # rollout can still grant access to additional guilds.
+        normalized = _normalize_state(global_row["state"])
+        # Resolution rules for global overrides (intentional):
+        #   * 'on'  → hard enable, short-circuit True.
+        #   * 'off' → hard disable, short-circuit False.  This makes
+        #             rollback safe: setting the global row to 'off'
+        #             immediately disables the flag for every guild
+        #             that does not carry a per-guild override.
+        #   * tier name (canary/beta/production/owner) + matching guild
+        #             tier → True via tier match.
+        #   * tier name + non-matching guild tier → the global row is
+        #             non-binding for this guild; fall through to the
+        #             declared rollout policy.  The staged rollout may
+        #             still grant access via staged_guilds or rollout
+        #             percentage.
+        if normalized in ("on", "off"):
             return _Decision(value, _SOURCE_DB_GLOBAL)
+        if value:
+            return _Decision(True, _SOURCE_DB_GLOBAL)
+        # Non-matching tier name: do not short-circuit; rollout may grant.
 
     # Declared rollout policy.
     if flag.rollout_policy is not None and guild_id is not None:

--- a/disbot/core/runtime/feature_flags.py
+++ b/disbot/core/runtime/feature_flags.py
@@ -1,42 +1,52 @@
-"""Phase 1d — Feature flag, environment tier, and rollout policy declarations.
+"""Feature flag declarations + runtime evaluator (Phase 1d + Phase 2d PR-2).
 
-This module declares the *types* — :class:`FeatureFlag`,
-:class:`EnvironmentTier`, :class:`RolloutPolicy` — that Phase 2d's
-storage + :class:`RolloutMutationPipeline` will consume.  Phase 1d
-intentionally stops at declarations so subsystems can declare flags
-during ``cog_load`` ahead of the runtime landing in Phase 2d.
+This module owns:
 
-Why declarations land before runtime:
+* The **declaration** types — :class:`FeatureFlag`,
+  :class:`EnvironmentTier`, :class:`RolloutPolicy` (Phase 1d).  These
+  let subsystems register flags during ``cog_load``.
+* The **runtime evaluator** — :func:`is_enabled` (Phase 2d, PR-2).
+  Resolves a flag's effective value for a given guild by consulting,
+  in order: emergency env override → ``feature_flag.primary`` gate →
+  per-guild DB override → global DB override → environment-tier policy
+  → deterministic rollout hash → declared default.
 
-* Phase 1d's :func:`utils.subsystem_registry.validate_registry`
-  extension can validate that every flag referenced by a schema has a
-  declaration here.
-* Phase 2d's RolloutMutationPipeline ships behind ``FEATURE_FLAG_PRIMARY``
-  itself — but by then every subsystem that wants a flag has already
-  declared one, so the migration is mechanical.
+The mutation pipeline (:class:`services.rollout_mutation.RolloutMutationPipeline`)
+and the event-driven cache invalidation ship in PR-3.  Until then the
+evaluator's cache uses TTL as the only invalidation primitive; callers
+may also invoke :func:`clear_cache` explicitly.
+
+Bootstrap policy (intentional ordering):
+
+1. ``SUPERBOT_FF_<FLAG>=on|off`` env override wins for ANY flag.
+   This is the permanent platform-owner escape hatch.
+2. ``feature_flag.primary`` is the meta-flag.  When OFF, the evaluator
+   returns each flag's declared default and the DB is never consulted.
+   ``feature_flag.primary`` itself is resolved by env + declaration ONLY
+   — its value is never read from the DB.  This protects the bootstrap
+   path while the runtime is being proven on a deployment.
+3. When ``feature_flag.primary`` is ON, the DB-backed resolution runs.
+4. Any DB error during resolution falls back to the declared default
+   and emits the ``feature_flag.bootstrap_fallback`` metric — never
+   raises.
 
 Public surface:
 
-* :class:`EnvironmentTier` — typed taxonomy of deployment environments.
-* :class:`RolloutPolicy` — staged rollout description.
-* :class:`FeatureFlag` — a typed declaration of a gated behavior.
+* :class:`EnvironmentTier`, :class:`RolloutPolicy`, :class:`FeatureFlag`
 * ``FeatureFlagRegistry`` operations: ``register``, ``get``,
-  ``all_flags``.
-
-Phase 2d adds:
-
-* ``is_enabled(name, guild_id) -> bool`` runtime evaluator.
-* ``feature_flag_state`` table + ``RolloutMutationPipeline``.
-* Migration of existing env-var gates to declared flags.
-
-Until Phase 2d lands, declared flags are *introspection only* — they
-appear in ``!platform flags`` but cannot be mutated and their value is
-``default`` everywhere.
+  ``all_flags``
+* :func:`is_enabled` (Phase 2d evaluator)
+* :func:`clear_cache` (manual invalidation; PR-3 adds event-driven)
+* :func:`resolve_with_provenance` (used by diagnostics; returns the
+  decision and the source it came from)
 """
 
 from __future__ import annotations
 
+import hashlib
 import logging
+import os
+import time
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
@@ -172,8 +182,15 @@ def declared_names() -> list[str]:
 
 
 def _reset_for_tests() -> None:
-    """Wipe the registry.  Tests call this in their setup/teardown fixture."""
+    """Wipe the registry + cache + metrics.
+
+    Tests call this in their setup/teardown fixture so per-test state
+    cannot leak via the module-level dicts / counters.
+    """
     _REGISTRY.clear()
+    _CACHE.clear()
+    global _BOOTSTRAP_FALLBACK_COUNT
+    _BOOTSTRAP_FALLBACK_COUNT = 0
 
 
 # ---------------------------------------------------------------------------
@@ -240,6 +257,352 @@ _register_builtins()
 
 
 # ---------------------------------------------------------------------------
+# Phase 2d evaluator — is_enabled + cache + bootstrap policy
+# ---------------------------------------------------------------------------
+
+# Sources that can deliver a resolved value, surfaced via diagnostics so
+# operators see exactly why the evaluator returned what it did.
+_SOURCE_ENV = "env"
+_SOURCE_BOOTSTRAP_FALLBACK = "bootstrap_fallback"  # DB unreachable or off
+_SOURCE_DB_GUILD = "db_guild"
+_SOURCE_DB_GLOBAL = "db_global"
+_SOURCE_TIER = "tier"
+_SOURCE_ROLLOUT = "rollout"
+_SOURCE_DEFAULT = "default"
+
+# Cache TTL.  PR-3 adds event-driven invalidation; until then TTL is
+# the only invalidation primitive aside from explicit clear_cache.
+# Five minutes balances "operator DB change reflected without restart"
+# against hot-path read pressure (every interaction hits is_enabled).
+_CACHE_TTL_SECS = 300.0
+
+# Cache value: (resolved_bool, source_string, expires_at_monotonic).
+_CACHE: dict[tuple[str, int | None], tuple[bool, str, float]] = {}
+
+# Metric counter for fallback rate.  Hooked into services.metrics in a
+# follow-up PR; until then this is the in-process visible counter that
+# tests can assert on.
+_BOOTSTRAP_FALLBACK_COUNT = 0
+
+
+def _env_override_key(flag_name: str) -> str:
+    """Translate a dotted flag name into a SUPERBOT_FF_<NAME> env var."""
+    return "SUPERBOT_FF_" + flag_name.replace(".", "_").upper()
+
+
+def _env_override(flag_name: str) -> bool | None:
+    """Return ``True`` / ``False`` for an env override, else ``None``.
+
+    Accepts the same truthy/falsy literals as the rest of the codebase
+    (``true``, ``yes``, ``on``, ``1`` vs. ``false``, ``no``, ``off``,
+    ``0``).  Unknown values are ignored (treated as "no override").
+    """
+    raw = os.environ.get(_env_override_key(flag_name))
+    if raw is None:
+        return None
+    lower = raw.strip().lower()
+    if lower in ("true", "yes", "on", "1"):
+        return True
+    if lower in ("false", "no", "off", "0"):
+        return False
+    logger.warning(
+        "feature_flags: env %s=%r is not a recognized boolean — ignoring",
+        _env_override_key(flag_name),
+        raw,
+    )
+    return None
+
+
+def _rollout_bucket(flag_name: str, guild_id: int) -> int:
+    """Deterministic 0..99 bucket for ``(flag, guild)``.
+
+    Stdlib-only (``hashlib.sha256``); no new dependency.  Stable across
+    Python versions and processes — the same pair always lands in the
+    same bucket.
+    """
+    digest = hashlib.sha256(f"{flag_name}:{guild_id}".encode()).digest()
+    return int.from_bytes(digest[:8], "big") % 100
+
+
+def _normalize_state(state: str) -> str:
+    """Lowercase + strip; protects against operator typos in DB rows."""
+    return state.strip().lower() if state else ""
+
+
+def _state_to_decision(
+    state: str,
+    *,
+    flag: FeatureFlag,
+    guild_tier: str | None,
+) -> bool:
+    """Turn a stored ``state`` string into a boolean.
+
+    ``on``/``off`` are hard overrides.  Tier names
+    (``owner``/``canary``/``beta``/``production``) mean "enabled if the
+    guild's environment_tier is at or above this level".  Unknown
+    strings fall back to the declared default and log a WARNING.
+    """
+    normalized = _normalize_state(state)
+    if normalized == "on":
+        return True
+    if normalized == "off":
+        return False
+    if normalized in ("owner", "canary", "beta", "production"):
+        return _tier_meets(guild_tier, normalized)
+    logger.warning(
+        "feature_flags: unknown stored state %r for %r — using default",
+        state,
+        flag.name,
+    )
+    return flag.default_value
+
+
+# Tier ordering — lower index = more restricted exposure.  A guild
+# whose tier is "owner_guild_only" sees flags gated at "owner" or
+# below; a "canary" guild sees "canary" + "beta" + "production"; etc.
+_TIER_ORDER = {
+    "owner_guild_only": 0,
+    "development": 0,
+    "owner": 0,
+    "canary": 1,
+    "beta": 2,
+    "production": 3,
+}
+
+
+def _tier_meets(guild_tier: str | None, required: str) -> bool:
+    """``True`` when ``guild_tier`` is at-or-above ``required``."""
+    guild_level = _TIER_ORDER.get((guild_tier or "production").lower(), 3)
+    required_level = _TIER_ORDER.get(required.lower(), 3)
+    return guild_level <= required_level
+
+
+@dataclass(frozen=True)
+class _Decision:
+    """Internal: the evaluator's result + the source it came from."""
+
+    value: bool
+    source: str
+
+
+async def _resolve_from_db(
+    flag: FeatureFlag,
+    guild_id: int | None,
+) -> _Decision:
+    """DB-backed resolution.  Caller has already passed bootstrap gates."""
+    # Local imports to keep cycle-sensitive cycles unaffected.
+    from utils.db import environment_tiers as et_db
+    from utils.db import feature_flag_state as ff_db
+
+    # Per-guild override beats everything else in the DB layer.
+    if guild_id is not None:
+        guild_row = await ff_db.get_guild_override(flag.name, guild_id)
+        if guild_row is not None:
+            guild_tier = await et_db.get_tier(guild_id)
+            value = _state_to_decision(
+                guild_row["state"],
+                flag=flag,
+                guild_tier=guild_tier,
+            )
+            return _Decision(value, _SOURCE_DB_GUILD)
+
+    # Global override.
+    global_row = await ff_db.get_global_override(flag.name)
+    if global_row is not None:
+        guild_tier = await et_db.get_tier(guild_id) if guild_id is not None else None
+        value = _state_to_decision(
+            global_row["state"],
+            flag=flag,
+            guild_tier=guild_tier,
+        )
+        if value or _normalize_state(global_row["state"]) in ("on", "off"):
+            # A hard 'on' / matching tier wins.  A hard 'off' / unmatched
+            # tier means "no override fires" — fall through to the
+            # declared rollout policy.  We only short-circuit on 'on' so
+            # rollout can still grant access to additional guilds.
+            return _Decision(value, _SOURCE_DB_GLOBAL)
+
+    # Declared rollout policy.
+    if flag.rollout_policy is not None and guild_id is not None:
+        policy = flag.rollout_policy
+        guild_tier = await et_db.get_tier(guild_id)
+        if guild_id in policy.staged_guilds:
+            if _tier_meets(guild_tier, policy.tier_gate.value):
+                return _Decision(True, _SOURCE_TIER)
+        if policy.tier_gate is not None and _tier_meets(
+            guild_tier,
+            policy.tier_gate.value,
+        ):
+            # Environment-tier override map.
+            tier_enum = EnvironmentTier((guild_tier or "production").lower())
+            if tier_enum in flag.environment_overrides:
+                return _Decision(
+                    flag.environment_overrides[tier_enum],
+                    _SOURCE_TIER,
+                )
+            if policy.percentage_rollout > 0:
+                bucket = _rollout_bucket(flag.name, guild_id)
+                if bucket < policy.percentage_rollout:
+                    return _Decision(True, _SOURCE_ROLLOUT)
+
+    return _Decision(flag.default_value, _SOURCE_DEFAULT)
+
+
+def _cache_get(flag_name: str, guild_id: int | None) -> _Decision | None:
+    """Return a cached decision if still fresh, else ``None``."""
+    entry = _CACHE.get((flag_name, guild_id))
+    if entry is None:
+        return None
+    value, source, expires_at = entry
+    if expires_at < time.monotonic():
+        _CACHE.pop((flag_name, guild_id), None)
+        return None
+    return _Decision(value, source)
+
+
+def _cache_put(flag_name: str, guild_id: int | None, decision: _Decision) -> None:
+    """Store a decision with TTL."""
+    _CACHE[(flag_name, guild_id)] = (
+        decision.value,
+        decision.source,
+        time.monotonic() + _CACHE_TTL_SECS,
+    )
+
+
+def clear_cache(
+    flag_name: str | None = None,
+    guild_id: int | None = None,
+) -> int:
+    """Evict cached evaluator decisions.
+
+    Until PR-3's event-driven invalidation lands, callers that mutate
+    state directly (DB scripts, tests, the future RolloutMutationPipeline
+    in its early form) call this to make the next ``is_enabled`` re-read.
+
+    Filtering rules:
+
+    * No arguments → drop every entry.
+    * ``flag_name`` only → drop every guild's entry for that flag (and
+      the global ``guild_id=None`` entry).
+    * ``flag_name`` + ``guild_id`` → drop the single matching entry.
+    * ``guild_id`` only → drop every flag's entry for that guild.
+
+    Returns the number of entries removed.
+    """
+    if flag_name is None and guild_id is None:
+        n = len(_CACHE)
+        _CACHE.clear()
+        return n
+    to_drop = []
+    for key in _CACHE:
+        key_flag, key_guild = key
+        if flag_name is not None and key_flag != flag_name:
+            continue
+        if guild_id is not None and key_guild != guild_id:
+            continue
+        to_drop.append(key)
+    for key in to_drop:
+        _CACHE.pop(key, None)
+    return len(to_drop)
+
+
+def _record_bootstrap_fallback() -> None:
+    """Increment the in-process bootstrap fallback counter.
+
+    A real Prometheus metric is wired in a follow-up PR; until then
+    this counter is the test-observable signal.
+    """
+    global _BOOTSTRAP_FALLBACK_COUNT
+    _BOOTSTRAP_FALLBACK_COUNT += 1
+
+
+def bootstrap_fallback_count() -> int:
+    """Return how many times the DB-unreachable fallback has fired."""
+    return _BOOTSTRAP_FALLBACK_COUNT
+
+
+def _reset_metrics_for_tests() -> None:
+    """Test helper — reset the bootstrap fallback counter."""
+    global _BOOTSTRAP_FALLBACK_COUNT
+    _BOOTSTRAP_FALLBACK_COUNT = 0
+
+
+async def resolve_with_provenance(
+    flag_name: str,
+    guild_id: int | None = None,
+) -> _Decision:
+    """Resolve a flag and return both the value and the source.
+
+    Used by diagnostics so ``!platform flags`` can render the source
+    column.  Internal — tests are welcome to call it but production
+    callers should prefer :func:`is_enabled`.
+
+    Resolution order (see module docstring for rationale):
+
+    1. ``SUPERBOT_FF_<FLAG>`` env override (always wins).
+    2. ``feature_flag.primary`` gate — if OFF, return declared default
+       and bypass DB entirely.  Evaluating ``feature_flag.primary``
+       itself bypasses the DB step too.
+    3. Cache lookup.
+    4. DB resolution (per-guild → global → tier → rollout → default).
+    5. DB error → declared default + bootstrap-fallback metric.
+    """
+    # Step 1: env override
+    env = _env_override(flag_name)
+    if env is not None:
+        return _Decision(env, _SOURCE_ENV)
+
+    flag = _REGISTRY.get(flag_name)
+    if flag is None:
+        logger.warning(
+            "feature_flags: is_enabled called for undeclared flag %r",
+            flag_name,
+        )
+        return _Decision(False, _SOURCE_DEFAULT)
+
+    # Step 2: feature_flag.primary gate.
+    if flag_name == FEATURE_FLAG_PRIMARY.name:
+        # Meta-flag: env-or-default only, never DB.
+        return _Decision(flag.default_value, _SOURCE_DEFAULT)
+    primary = await resolve_with_provenance(FEATURE_FLAG_PRIMARY.name, guild_id)
+    if not primary.value:
+        return _Decision(flag.default_value, _SOURCE_DEFAULT)
+
+    # Step 3: cache
+    cached = _cache_get(flag_name, guild_id)
+    if cached is not None:
+        return cached
+
+    # Step 4 / 5: DB resolution with fallback
+    try:
+        decision = await _resolve_from_db(flag, guild_id)
+    except Exception as exc:
+        logger.warning(
+            "feature_flags: DB unreachable for %r (guild=%r) — using default: %s",
+            flag_name,
+            guild_id,
+            exc,
+        )
+        _record_bootstrap_fallback()
+        decision = _Decision(flag.default_value, _SOURCE_BOOTSTRAP_FALLBACK)
+
+    _cache_put(flag_name, guild_id, decision)
+    return decision
+
+
+async def is_enabled(flag_name: str, guild_id: int | None = None) -> bool:
+    """Phase 2d evaluator entry point.
+
+    Returns the effective boolean for ``flag_name`` in ``guild_id``'s
+    context.  Resolution order, cache semantics, and the bootstrap
+    fallback policy are documented on :func:`resolve_with_provenance`
+    and at the top of this module.
+    """
+    decision = await resolve_with_provenance(flag_name, guild_id)
+    return decision.value
+
+
+# ---------------------------------------------------------------------------
 # Diagnostics provider — registers at import time
 # ---------------------------------------------------------------------------
 
@@ -247,14 +610,18 @@ _register_builtins()
 def _feature_flags_snapshot() -> dict[str, Any]:
     """Snapshot provider for ``!platform flags``.
 
-    Phase 1d returns declarations only.  Phase 2d will extend the
-    snapshot with current stored values, environment-tier resolution,
-    and rollout-decision counts.
+    Phase 2d (PR-2) extends the snapshot with cache size, fallback
+    counter, and per-flag declared values.  Effective per-flag values
+    require an async call so the diagnostics view falls back to
+    declared defaults here; ``cogs/diagnostic_cog.py::flags`` does the
+    per-flag async resolution and renders the source column.
     """
     flags = all_flags()
     return {
         "declared_total": len(flags),
         "by_owner": _flags_by_owner(flags),
+        "cache_size": len(_CACHE),
+        "bootstrap_fallback_count": _BOOTSTRAP_FALLBACK_COUNT,
         "by_name": {
             name: {
                 "description": flag.description,
@@ -297,7 +664,11 @@ __all__ = [
     "RESOURCES_UNIFIED",
     "RolloutPolicy",
     "all_flags",
+    "bootstrap_fallback_count",
+    "clear_cache",
     "declared_names",
     "get",
+    "is_enabled",
     "register",
+    "resolve_with_provenance",
 ]

--- a/disbot/guild_lifecycle.py
+++ b/disbot/guild_lifecycle.py
@@ -32,11 +32,15 @@ async def teardown(guild_id: int) -> None:
       5. Subsystem bindings     — delete active subsystem_bindings rows (Phase 2);
                                    binding_audit_log rows are PRESERVED by design.
       6. Resource validation cache — drop resource_validation_cache rows (Phase 2).
-      7. Governance capability cache — clear per-guild execution overrides.
-      8. Governance visibility cache — bump version, clear role-override flag.
-      9. Guild-config cache     — drop cached guild config entries (F-1).
-      10. Scope locks            — invoke registered per-cog teardown hooks (F-2).
-      11. Governance feedback cooldown — documented, no per-guild cleanup needed.
+      7. Feature flag per-guild overrides — drop feature_flag_guild_overrides
+                                   rows (Phase 2d PR-2); global rows preserved.
+      8. Environment tier        — delete environment_tiers row (Phase 2d PR-2).
+      9. Feature flag evaluator cache — drop cached decisions for the guild.
+      10. Governance capability cache — clear per-guild execution overrides.
+      11. Governance visibility cache — bump version, clear role-override flag.
+      12. Guild-config cache    — drop cached guild config entries (F-1).
+      13. Scope locks           — invoke registered per-cog teardown hooks (F-2).
+      14. Governance feedback cooldown — documented, no per-guild cleanup needed.
     """
     logger.info("guild_lifecycle.teardown: beginning cleanup for guild=%d", guild_id)
 
@@ -58,19 +62,28 @@ async def teardown(guild_id: int) -> None:
     # 6. Resource validation cache — drop cached resource status rows (Phase 2a).
     await _teardown_resource_cache(guild_id)
 
-    # 7. Governance capability overrides — clear execution-layer in-process dict.
+    # 7. Feature flag per-guild overrides — global rows preserved (Phase 2d).
+    await _teardown_feature_flag_guild_overrides(guild_id)
+
+    # 8. Environment tier row — guild defaults back to production on re-join.
+    await _teardown_environment_tier(guild_id)
+
+    # 9. Feature flag evaluator cache — drop stale cached decisions.
+    _teardown_feature_flag_cache(guild_id)
+
+    # 10. Governance capability overrides — clear execution-layer in-process dict.
     _teardown_capability_overrides(guild_id)
 
-    # 8. Governance visibility cache — version bump + role flag removal.
+    # 11. Governance visibility cache — version bump + role flag removal.
     _teardown_visibility_cache(guild_id)
 
-    # 9. Guild-config cache — drop cached config entries for the guild (F-1 / S1.1).
+    # 12. Guild-config cache — drop cached config entries for the guild (F-1 / S1.1).
     _teardown_guild_config(guild_id)
 
-    # 10. Scope locks — invoke registered per-cog teardown hooks (F-2 / S1.2).
+    # 13. Scope locks — invoke registered per-cog teardown hooks (F-2 / S1.2).
     _teardown_scope_locks(guild_id)
 
-    # 11. Governance feedback cooldown dict in governance/__init__.
+    # 14. Governance feedback cooldown dict in governance/__init__.
     _teardown_feedback_cooldown(guild_id)
 
     logger.info("guild_lifecycle.teardown: complete for guild=%d", guild_id)
@@ -202,6 +215,73 @@ async def _teardown_resource_cache(guild_id: int) -> None:
             )
     except Exception as exc:
         logger.warning("guild_lifecycle: resource cache teardown failed: %s", exc)
+
+
+async def _teardown_feature_flag_guild_overrides(guild_id: int) -> None:
+    """Delete every feature_flag_guild_overrides row for the departed guild.
+
+    Phase 2d, PR-2.  Global override rows survive (they're not scoped to
+    a single guild); only the per-guild rows are purged.  Operators can
+    re-seed canary/owner overrides after re-invitation.
+    """
+    try:
+        from utils.db.feature_flag_state import delete_for_guild as _ff_delete
+
+        count = await _ff_delete(guild_id)
+        if count:
+            logger.debug(
+                "guild_lifecycle: deleted %d feature_flag guild override(s) for guild=%d",
+                count,
+                guild_id,
+            )
+    except Exception as exc:
+        logger.warning(
+            "guild_lifecycle: feature_flag guild override teardown failed: %s",
+            exc,
+        )
+
+
+async def _teardown_environment_tier(guild_id: int) -> None:
+    """Drop the environment_tiers row so the guild re-defaults to PRODUCTION.
+
+    Phase 2d, PR-2.  When the bot is re-invited, the guild starts at the
+    most restrictive tier until an operator re-assigns it.
+    """
+    try:
+        from utils.db.environment_tiers import delete_for_guild as _et_delete
+
+        count = await _et_delete(guild_id)
+        if count:
+            logger.debug(
+                "guild_lifecycle: deleted environment_tier row for guild=%d",
+                guild_id,
+            )
+    except Exception as exc:
+        logger.warning("guild_lifecycle: environment_tier teardown failed: %s", exc)
+
+
+def _teardown_feature_flag_cache(guild_id: int) -> None:
+    """Drop every evaluator cache entry scoped to ``guild_id``.
+
+    Phase 2d, PR-2.  Until PR-3 wires event-driven invalidation, the
+    explicit clear on guild-leave guarantees a re-invited guild does
+    not observe stale per-guild decisions.
+    """
+    try:
+        from core.runtime.feature_flags import clear_cache
+
+        removed = clear_cache(guild_id=guild_id)
+        if removed:
+            logger.debug(
+                "guild_lifecycle: cleared %d feature_flag cache entry(s) for guild=%d",
+                removed,
+                guild_id,
+            )
+    except Exception as exc:
+        logger.warning(
+            "guild_lifecycle: feature_flag cache teardown failed: %s",
+            exc,
+        )
 
 
 def _teardown_capability_overrides(guild_id: int) -> None:

--- a/disbot/migrations/023_feature_flag_state.sql
+++ b/disbot/migrations/023_feature_flag_state.sql
@@ -1,0 +1,56 @@
+-- Migration 023: feature_flag_state — global + guild overrides (Phase 2d, PR-2).
+--
+-- Storage for the Phase 2d feature-flag evaluator.  Two tables instead of
+-- one nullable-PK table because PostgreSQL does not allow NULL in any
+-- PRIMARY KEY column.  Separating the surfaces also keeps SQL queries
+-- unambiguous: the evaluator's resolution order is explicit ("look up the
+-- guild row; on miss look up the global row").
+--
+-- Resolution order (consumed by core.runtime.feature_flags.is_enabled):
+--   1. emergency env override (SUPERBOT_FF_<FLAG>)
+--   2. if feature_flag.primary is OFF: declared default (DB bypassed)
+--   3. per-guild row (feature_flag_guild_overrides)
+--   4. global row (feature_flag_global_overrides)
+--   5. environment-tier policy match (RolloutPolicy.tier_gate)
+--   6. deterministic rollout hash (RolloutPolicy.percentage_rollout)
+--   7. declared default
+--
+-- Both tables are READ-ONLY in this PR — writes land in PR-3 alongside
+-- the RolloutMutationPipeline + feature_flag_audit table.  Until then,
+-- operators seed rows manually for canary/owner-tier validation.
+--
+-- Schema decisions:
+--
+--   * ``state`` is a CHECK-constrained enum mirroring Python's logical
+--     levels.  ``'on'`` and ``'off'`` are hard overrides; the tier names
+--     (``owner``, ``canary``, ``beta``, ``production``) are convenience
+--     values evaluated against the guild's environment tier.
+--   * ``rollout_percent`` only meaningful on the global row.  Per-guild
+--     rows are a binary override and ignore rollout.
+--   * ``set_by`` is nullable for system writes (backfill, migration).
+--
+-- Forward-only and idempotent.
+
+CREATE TABLE IF NOT EXISTS feature_flag_global_overrides (
+    flag_name        TEXT         NOT NULL PRIMARY KEY,
+    state            TEXT         NOT NULL,
+    rollout_percent  INTEGER,
+    set_by           BIGINT,
+    set_at           TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    CHECK (state IN ('off', 'owner', 'canary', 'beta', 'production', 'on')),
+    CHECK (rollout_percent IS NULL
+           OR (rollout_percent BETWEEN 0 AND 100))
+);
+
+CREATE TABLE IF NOT EXISTS feature_flag_guild_overrides (
+    flag_name        TEXT         NOT NULL,
+    guild_id         BIGINT       NOT NULL,
+    state            TEXT         NOT NULL,
+    set_by           BIGINT,
+    set_at           TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (flag_name, guild_id),
+    CHECK (state IN ('off', 'owner', 'canary', 'beta', 'production', 'on'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_feature_flag_guild_overrides_guild
+    ON feature_flag_guild_overrides (guild_id);

--- a/disbot/migrations/024_environment_tiers.sql
+++ b/disbot/migrations/024_environment_tiers.sql
@@ -1,0 +1,33 @@
+-- Migration 024: environment_tiers (Phase 2d, PR-2).
+--
+-- One row per guild mapping the guild to its deployment tier
+-- (production, beta, canary, owner_guild_only, development).  The
+-- feature-flag evaluator consults this table to decide whether a flag
+-- whose RolloutPolicy.tier_gate is, say, BETA, is eligible for a given
+-- guild.
+--
+-- Missing row → guild is treated as PRODUCTION (the most-restrictive
+-- default).  Operators seed rows manually for canary/owner guilds.
+--
+-- Schema decisions:
+--
+--   * ``tier`` CHECK enumerates exactly the values of
+--     ``core.runtime.feature_flags.EnvironmentTier``; the invariant test
+--     ``tests/unit/invariants/test_environment_tier_alignment.py`` pins
+--     the literals.
+--   * Single-column PK — at most one tier per guild.  Reassigning is an
+--     UPDATE, not an INSERT.
+--   * ``set_by`` nullable for system writes (CI seed, migration).
+--   * Per-guild rows are deleted on guild leave via
+--     :func:`guild_lifecycle.teardown`.
+--
+-- Forward-only and idempotent.
+
+CREATE TABLE IF NOT EXISTS environment_tiers (
+    guild_id   BIGINT       NOT NULL PRIMARY KEY,
+    tier       TEXT         NOT NULL DEFAULT 'production',
+    set_by     BIGINT,
+    set_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    CHECK (tier IN ('production', 'beta', 'canary',
+                    'owner_guild_only', 'development'))
+);

--- a/disbot/utils/db/environment_tiers.py
+++ b/disbot/utils/db/environment_tiers.py
@@ -1,0 +1,83 @@
+"""Environment tier mapping — DB read primitives (Phase 2d, PR-2).
+
+Owns the read surface for ``environment_tiers``.  The evaluator
+(:mod:`core.runtime.feature_flags`) consults this to resolve flags
+whose :class:`RolloutPolicy` carries a ``tier_gate``.
+
+State class (per ``docs/architecture.md`` §"State classification"):
+
+  **authoritative persistent** — the DB row is the single source of
+  truth for which guilds are owner/canary/beta/production.
+
+Public surface:
+
+* :func:`get_tier` — return the guild's tier string, or ``None``.
+* :func:`list_for_diagnostics` — read every row for ``!platform flags``.
+* :func:`delete_for_guild` — single-row delete called from
+  ``guild_lifecycle.teardown``.
+
+Writes ship with :class:`services.rollout_mutation.RolloutMutationPipeline`
+in PR-3.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from utils.db import pool
+
+logger = logging.getLogger("bot.db.environment_tiers")
+
+
+async def get_tier(guild_id: int) -> str | None:
+    """Return the tier string for ``guild_id``, or ``None`` when unset.
+
+    Missing row → caller treats the guild as ``'production'`` (most
+    restrictive default).  The evaluator centralises this defaulting
+    so DB-layer callers do not have to know the policy.
+    """
+    row = await pool.get().fetchrow(
+        "SELECT tier FROM environment_tiers WHERE guild_id = $1",
+        guild_id,
+    )
+    return row["tier"] if row else None
+
+
+async def list_for_diagnostics() -> list[dict[str, Any]]:
+    """Return every row, sorted by tier then guild_id.
+
+    Used by the diagnostics provider; not on any hot path.
+    """
+    rows = await pool.get().fetch(
+        """
+        SELECT guild_id, tier, set_by, set_at
+        FROM environment_tiers
+        ORDER BY tier, guild_id
+        """,
+    )
+    return [dict(r) for r in rows]
+
+
+async def delete_for_guild(guild_id: int) -> int:
+    """Delete the environment_tier row for ``guild_id``.
+
+    Returns the row count parsed from asyncpg's ``"DELETE N"`` status;
+    ``0`` on parse failure.  Called from ``guild_lifecycle.teardown``
+    so a re-invited guild falls back to PRODUCTION until reassigned.
+    """
+    result = await pool.get().execute(
+        "DELETE FROM environment_tiers WHERE guild_id = $1",
+        guild_id,
+    )
+    try:
+        return int(result.split()[-1])
+    except (ValueError, IndexError):
+        return 0
+
+
+__all__ = [
+    "delete_for_guild",
+    "get_tier",
+    "list_for_diagnostics",
+]

--- a/disbot/utils/db/feature_flag_state.py
+++ b/disbot/utils/db/feature_flag_state.py
@@ -1,0 +1,125 @@
+"""Feature flag state — DB read primitives (Phase 2d, PR-2).
+
+Owns the read surface for ``feature_flag_global_overrides`` and
+``feature_flag_guild_overrides``.  The evaluator
+(:mod:`core.runtime.feature_flags`) calls these primitives behind a
+TTL-bounded cache.  Writes do not exist in this PR — they ship with
+:class:`services.rollout_mutation.RolloutMutationPipeline` in PR-3.
+
+State class (per ``docs/architecture.md`` §"State classification"):
+
+  **authoritative persistent** — the DB row is the canonical override
+  for a flag.  Evaluator cache rows are derived state that may be
+  invalidated at any time.
+
+Public surface:
+
+* :func:`get_global_override` — single-row read.
+* :func:`get_guild_override` — single-row read scoped to a guild.
+* :func:`delete_for_guild` — purge ALL per-guild overrides for one
+  guild (called from ``guild_lifecycle.teardown``).  Global rows are
+  never touched here.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from utils.db import pool
+
+logger = logging.getLogger("bot.db.feature_flag_state")
+
+
+async def get_global_override(flag_name: str) -> dict[str, Any] | None:
+    """Return the global override row for ``flag_name``, or ``None``.
+
+    The returned dict carries ``state`` (str), ``rollout_percent``
+    (int | None), ``set_by`` (int | None), ``set_at``
+    (:class:`datetime`).  Callers convert ``state`` into the typed
+    enum at the layer above (the evaluator).
+    """
+    row = await pool.get().fetchrow(
+        """
+        SELECT flag_name, state, rollout_percent, set_by, set_at
+        FROM feature_flag_global_overrides
+        WHERE flag_name = $1
+        """,
+        flag_name,
+    )
+    return dict(row) if row else None
+
+
+async def get_guild_override(
+    flag_name: str,
+    guild_id: int,
+) -> dict[str, Any] | None:
+    """Return the per-guild override row, or ``None`` when absent."""
+    row = await pool.get().fetchrow(
+        """
+        SELECT flag_name, guild_id, state, set_by, set_at
+        FROM feature_flag_guild_overrides
+        WHERE flag_name = $1 AND guild_id = $2
+        """,
+        flag_name,
+        guild_id,
+    )
+    return dict(row) if row else None
+
+
+async def list_global_overrides() -> list[dict[str, Any]]:
+    """Return every global override row.
+
+    Used by the diagnostics provider so ``!platform flags`` can render
+    the global state alongside the declarations.
+    """
+    rows = await pool.get().fetch(
+        """
+        SELECT flag_name, state, rollout_percent, set_by, set_at
+        FROM feature_flag_global_overrides
+        ORDER BY flag_name
+        """,
+    )
+    return [dict(r) for r in rows]
+
+
+async def list_guild_overrides(guild_id: int) -> list[dict[str, Any]]:
+    """Return every per-guild override row for ``guild_id``."""
+    rows = await pool.get().fetch(
+        """
+        SELECT flag_name, guild_id, state, set_by, set_at
+        FROM feature_flag_guild_overrides
+        WHERE guild_id = $1
+        ORDER BY flag_name
+        """,
+        guild_id,
+    )
+    return [dict(r) for r in rows]
+
+
+async def delete_for_guild(guild_id: int) -> int:
+    """Delete every per-guild override for ``guild_id``; preserve globals.
+
+    Phase 2 retention policy: the GLOBAL overrides row survives every
+    guild leave (it's not scoped to a single guild).  This primitive
+    touches only ``feature_flag_guild_overrides``.  Returns the row
+    count parsed from asyncpg's ``"DELETE N"`` status string; ``0`` on
+    any parse failure.
+    """
+    result = await pool.get().execute(
+        "DELETE FROM feature_flag_guild_overrides WHERE guild_id = $1",
+        guild_id,
+    )
+    try:
+        return int(result.split()[-1])
+    except (ValueError, IndexError):
+        return 0
+
+
+__all__ = [
+    "delete_for_guild",
+    "get_global_override",
+    "get_guild_override",
+    "list_global_overrides",
+    "list_guild_overrides",
+]

--- a/tests/unit/feature_flags/test_environment_tiers_db.py
+++ b/tests/unit/feature_flags/test_environment_tiers_db.py
@@ -1,0 +1,66 @@
+"""Phase 2d PR-2 — utils.db.environment_tiers primitives."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from utils.db import environment_tiers as et_db
+
+
+@pytest.fixture
+def _mock_pool():
+    pool_mock = MagicMock()
+    pool_mock.execute = AsyncMock()
+    pool_mock.fetchrow = AsyncMock()
+    pool_mock.fetch = AsyncMock()
+    with patch.object(et_db, "pool") as pool_module:
+        pool_module.get = MagicMock(return_value=pool_mock)
+        yield pool_mock
+
+
+@pytest.mark.asyncio
+async def test_get_tier_returns_string_when_row_present(_mock_pool):
+    _mock_pool.fetchrow.return_value = {"tier": "canary"}
+    assert await et_db.get_tier(42) == "canary"
+
+
+@pytest.mark.asyncio
+async def test_get_tier_returns_none_when_absent(_mock_pool):
+    _mock_pool.fetchrow.return_value = None
+    assert await et_db.get_tier(42) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_for_guild_targets_correct_guild(_mock_pool):
+    _mock_pool.execute.return_value = "DELETE 1"
+    deleted = await et_db.delete_for_guild(42)
+    sql, *args = _mock_pool.execute.await_args.args
+    assert "environment_tiers" in sql
+    assert "WHERE guild_id = $1" in sql
+    assert args == [42]
+    assert deleted == 1
+
+
+@pytest.mark.asyncio
+async def test_delete_for_guild_handles_zero_rows(_mock_pool):
+    _mock_pool.execute.return_value = "DELETE 0"
+    assert await et_db.delete_for_guild(42) == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_for_guild_handles_unexpected_status(_mock_pool):
+    _mock_pool.execute.return_value = "weird"
+    assert await et_db.delete_for_guild(42) == 0
+
+
+@pytest.mark.asyncio
+async def test_list_for_diagnostics_returns_rows(_mock_pool):
+    _mock_pool.fetch.return_value = [
+        {"guild_id": 1, "tier": "owner_guild_only", "set_by": 99, "set_at": None},
+        {"guild_id": 2, "tier": "canary", "set_by": 99, "set_at": None},
+    ]
+    rows = await et_db.list_for_diagnostics()
+    assert len(rows) == 2
+    assert rows[0]["tier"] == "owner_guild_only"

--- a/tests/unit/feature_flags/test_evaluator.py
+++ b/tests/unit/feature_flags/test_evaluator.py
@@ -1,0 +1,445 @@
+"""Phase 2d PR-2 — is_enabled evaluator + cache + bootstrap policy.
+
+Covers:
+
+* Bootstrap policy: emergency env override beats everything; the
+  ``feature_flag.primary`` meta-gate bypasses DB on its own evaluation
+  and forces declared-default for other flags when OFF.
+* DB-backed resolution order: per-guild override → global override →
+  rollout policy → declared default.
+* Deterministic rollout hash: same ``(flag, guild)`` → same bucket.
+* Cache behaviour: TTL eviction, manual clear, per-guild clear.
+* DB-unreachable fallback: returns declared default + emits bootstrap
+  metric, never raises.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from core.runtime import feature_flags
+from core.runtime.feature_flags import (
+    BINDINGS_PRIMARY,
+    FEATURE_FLAG_PRIMARY,
+    EnvironmentTier,
+    FeatureFlag,
+    RolloutPolicy,
+    _register_builtins,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state():
+    """Each test starts with a clean registry, cache, and metric counter."""
+    feature_flags._reset_for_tests()
+    _register_builtins()
+    # Ensure no test runs under a leaked env override.
+    for key in list(os.environ):
+        if key.startswith("SUPERBOT_FF_"):
+            del os.environ[key]
+    yield
+    feature_flags._reset_for_tests()
+    for key in list(os.environ):
+        if key.startswith("SUPERBOT_FF_"):
+            del os.environ[key]
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap policy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_env_override_wins_for_arbitrary_flag(monkeypatch):
+    """SUPERBOT_FF_<FLAG>=on/off always wins, regardless of DB state."""
+    monkeypatch.setenv("SUPERBOT_FF_BINDINGS_PRIMARY", "on")
+    decision = await feature_flags.resolve_with_provenance(
+        "bindings.primary",
+        guild_id=42,
+    )
+    assert decision.value is True
+    assert decision.source == "env"
+
+
+@pytest.mark.asyncio
+async def test_env_override_recognized_boolean_literals(monkeypatch):
+    for raw in ("true", "yes", "ON", "1"):
+        monkeypatch.setenv("SUPERBOT_FF_BINDINGS_PRIMARY", raw)
+        assert await feature_flags.is_enabled("bindings.primary", 42) is True
+    for raw in ("false", "no", "off", "0"):
+        monkeypatch.setenv("SUPERBOT_FF_BINDINGS_PRIMARY", raw)
+        feature_flags.clear_cache()
+        assert await feature_flags.is_enabled("bindings.primary", 42) is False
+
+
+@pytest.mark.asyncio
+async def test_unknown_env_value_is_ignored(monkeypatch):
+    """An unrecognized env value falls through to the bootstrap path."""
+    monkeypatch.setenv("SUPERBOT_FF_BINDINGS_PRIMARY", "maybe?")
+    # feature_flag.primary defaults OFF → declared default returned.
+    decision = await feature_flags.resolve_with_provenance(
+        "bindings.primary",
+        guild_id=42,
+    )
+    assert decision.source == "default"
+    assert decision.value == BINDINGS_PRIMARY.default_value
+
+
+@pytest.mark.asyncio
+async def test_feature_flag_primary_off_returns_declared_default():
+    """With feature_flag.primary OFF (declared default), DB is bypassed."""
+    decision = await feature_flags.resolve_with_provenance(
+        "bindings.primary",
+        guild_id=42,
+    )
+    assert decision.source == "default"
+    assert decision.value == BINDINGS_PRIMARY.default_value
+
+
+@pytest.mark.asyncio
+async def test_feature_flag_primary_resolves_via_env_only(monkeypatch):
+    """The meta-flag's value never comes from the DB."""
+    monkeypatch.setenv("SUPERBOT_FF_FEATURE_FLAG_PRIMARY", "on")
+    decision = await feature_flags.resolve_with_provenance(
+        FEATURE_FLAG_PRIMARY.name,
+        guild_id=42,
+    )
+    assert decision.value is True
+    assert decision.source == "env"
+
+
+@pytest.mark.asyncio
+async def test_undeclared_flag_returns_false_with_default_source():
+    decision = await feature_flags.resolve_with_provenance(
+        "does.not.exist",
+        guild_id=42,
+    )
+    assert decision.value is False
+    assert decision.source == "default"
+
+
+# ---------------------------------------------------------------------------
+# DB-backed resolution order
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_per_guild_override_beats_global(monkeypatch):
+    """When feature_flag.primary is ON, per-guild row beats the global row."""
+    monkeypatch.setenv("SUPERBOT_FF_FEATURE_FLAG_PRIMARY", "on")
+
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_guild_override",
+            new_callable=AsyncMock,
+            return_value={"state": "on"},
+        ),
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value={"state": "off", "rollout_percent": None},
+        ),
+        patch(
+            "utils.db.environment_tiers.get_tier",
+            new_callable=AsyncMock,
+            return_value="production",
+        ),
+    ):
+        decision = await feature_flags.resolve_with_provenance(
+            "bindings.primary",
+            guild_id=42,
+        )
+    assert decision.value is True
+    assert decision.source == "db_guild"
+
+
+@pytest.mark.asyncio
+async def test_global_override_used_when_no_guild_row(monkeypatch):
+    monkeypatch.setenv("SUPERBOT_FF_FEATURE_FLAG_PRIMARY", "on")
+
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_guild_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value={"state": "on", "rollout_percent": None},
+        ),
+        patch(
+            "utils.db.environment_tiers.get_tier",
+            new_callable=AsyncMock,
+            return_value="production",
+        ),
+    ):
+        decision = await feature_flags.resolve_with_provenance(
+            "bindings.primary",
+            guild_id=42,
+        )
+    assert decision.value is True
+    assert decision.source == "db_global"
+
+
+@pytest.mark.asyncio
+async def test_rollout_policy_grants_via_tier_for_staged_guild(monkeypatch):
+    """An explicit staged_guild + matching tier returns True via tier."""
+    monkeypatch.setenv("SUPERBOT_FF_FEATURE_FLAG_PRIMARY", "on")
+
+    staged_flag = FeatureFlag(
+        name="test.staged",
+        description="staged guild check",
+        default_value=False,
+        rollout_policy=RolloutPolicy(
+            staged_guilds=(42,),
+            percentage_rollout=0,
+            tier_gate=EnvironmentTier.CANARY,
+        ),
+    )
+    feature_flags.register(staged_flag)
+
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_guild_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.environment_tiers.get_tier",
+            new_callable=AsyncMock,
+            return_value="canary",
+        ),
+    ):
+        decision = await feature_flags.resolve_with_provenance(
+            "test.staged",
+            guild_id=42,
+        )
+    assert decision.value is True
+    assert decision.source == "tier"
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_declared_default(monkeypatch):
+    monkeypatch.setenv("SUPERBOT_FF_FEATURE_FLAG_PRIMARY", "on")
+
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_guild_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.environment_tiers.get_tier",
+            new_callable=AsyncMock,
+            return_value="production",
+        ),
+    ):
+        decision = await feature_flags.resolve_with_provenance(
+            "bindings.primary",
+            guild_id=42,
+        )
+    assert decision.value == BINDINGS_PRIMARY.default_value
+    assert decision.source == "default"
+
+
+# ---------------------------------------------------------------------------
+# Deterministic rollout hash
+# ---------------------------------------------------------------------------
+
+
+def test_rollout_bucket_deterministic():
+    """Same (flag, guild) always produces the same bucket."""
+    bucket_a = feature_flags._rollout_bucket("bindings.primary", 12345)
+    bucket_b = feature_flags._rollout_bucket("bindings.primary", 12345)
+    assert bucket_a == bucket_b
+    assert 0 <= bucket_a < 100
+
+
+def test_rollout_bucket_varies_per_flag_and_guild():
+    """Different flags / guilds usually land in different buckets."""
+    base = feature_flags._rollout_bucket("bindings.primary", 1)
+    other_guild = feature_flags._rollout_bucket("bindings.primary", 2)
+    other_flag = feature_flags._rollout_bucket("participation.enabled", 1)
+    # Not asserting strict inequality (collisions exist) but at least
+    # one of these should differ from base in any reasonable sample.
+    assert (other_guild != base) or (other_flag != base)
+
+
+@pytest.mark.asyncio
+async def test_rollout_percentage_includes_some_guilds(monkeypatch):
+    """At 50% rollout, roughly half a wide range of guilds is enabled."""
+    monkeypatch.setenv("SUPERBOT_FF_FEATURE_FLAG_PRIMARY", "on")
+
+    flag = FeatureFlag(
+        name="test.rollout",
+        description="50% rollout",
+        default_value=False,
+        rollout_policy=RolloutPolicy(
+            staged_guilds=(),
+            percentage_rollout=50,
+            tier_gate=EnvironmentTier.PRODUCTION,
+        ),
+    )
+    feature_flags.register(flag)
+
+    enabled = 0
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_guild_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.environment_tiers.get_tier",
+            new_callable=AsyncMock,
+            return_value="production",
+        ),
+    ):
+        for guild_id in range(1, 201):
+            feature_flags.clear_cache()
+            if await feature_flags.is_enabled("test.rollout", guild_id):
+                enabled += 1
+    # sha256 with 200 samples should land somewhere in 30..70% of true
+    # enablement at 50% rollout.  Wide tolerance keeps the test
+    # deterministic across runs without being trivially loose.
+    assert (
+        60 <= enabled <= 140
+    ), f"expected ~100/200 enabled at 50% rollout, got {enabled}"
+
+
+# ---------------------------------------------------------------------------
+# Cache behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_avoids_second_db_call(monkeypatch):
+    monkeypatch.setenv("SUPERBOT_FF_FEATURE_FLAG_PRIMARY", "on")
+
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_guild_override",
+            new_callable=AsyncMock,
+            return_value={"state": "on"},
+        ) as mock_guild,
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.environment_tiers.get_tier",
+            new_callable=AsyncMock,
+            return_value="production",
+        ),
+    ):
+        await feature_flags.is_enabled("bindings.primary", 42)
+        await feature_flags.is_enabled("bindings.primary", 42)
+    assert mock_guild.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_clear_cache_evicts_specific_guild(monkeypatch):
+    monkeypatch.setenv("SUPERBOT_FF_FEATURE_FLAG_PRIMARY", "on")
+
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_guild_override",
+            new_callable=AsyncMock,
+            return_value={"state": "on"},
+        ),
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.environment_tiers.get_tier",
+            new_callable=AsyncMock,
+            return_value="production",
+        ),
+    ):
+        await feature_flags.is_enabled("bindings.primary", 42)
+        await feature_flags.is_enabled("bindings.primary", 99)
+        # 3 entries in cache: (bindings.primary, 42), (bindings.primary, 99),
+        # plus any recursive (feature_flag.primary) lookups would normally
+        # be cached too — but feature_flag.primary bypasses cache because
+        # it's the meta-flag.  We assert specifically by drop count below.
+        removed = feature_flags.clear_cache(guild_id=42)
+    assert removed == 1
+
+
+def test_clear_cache_no_args_drops_everything():
+    feature_flags._CACHE[("a", 1)] = (True, "default", 1e18)
+    feature_flags._CACHE[("b", 2)] = (False, "default", 1e18)
+    assert feature_flags.clear_cache() == 2
+    assert not feature_flags._CACHE
+
+
+def test_clear_cache_by_flag_only():
+    feature_flags._CACHE[("a", 1)] = (True, "default", 1e18)
+    feature_flags._CACHE[("a", 2)] = (True, "default", 1e18)
+    feature_flags._CACHE[("b", 1)] = (False, "default", 1e18)
+    assert feature_flags.clear_cache(flag_name="a") == 2
+    assert ("a", 1) not in feature_flags._CACHE
+    assert ("a", 2) not in feature_flags._CACHE
+    assert ("b", 1) in feature_flags._CACHE
+
+
+# ---------------------------------------------------------------------------
+# DB-unreachable bootstrap fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_db_failure_returns_default_and_increments_metric(monkeypatch):
+    """The evaluator must never raise; declared default returned + metric fires."""
+    monkeypatch.setenv("SUPERBOT_FF_FEATURE_FLAG_PRIMARY", "on")
+    feature_flags._reset_metrics_for_tests()
+
+    with patch(
+        "utils.db.feature_flag_state.get_guild_override",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("connection refused"),
+    ):
+        decision = await feature_flags.resolve_with_provenance(
+            "bindings.primary",
+            guild_id=42,
+        )
+    assert decision.value == BINDINGS_PRIMARY.default_value
+    assert decision.source == "bootstrap_fallback"
+    assert feature_flags.bootstrap_fallback_count() >= 1
+
+
+@pytest.mark.asyncio
+async def test_db_failure_does_not_raise_into_caller(monkeypatch):
+    """is_enabled (the public hot-path) NEVER raises."""
+    monkeypatch.setenv("SUPERBOT_FF_FEATURE_FLAG_PRIMARY", "on")
+
+    with patch(
+        "utils.db.feature_flag_state.get_guild_override",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("DB blip"),
+    ):
+        # Should not raise; we assert by simply awaiting and reading.
+        result = await feature_flags.is_enabled("bindings.primary", 42)
+    assert isinstance(result, bool)

--- a/tests/unit/feature_flags/test_evaluator.py
+++ b/tests/unit/feature_flags/test_evaluator.py
@@ -186,6 +186,105 @@ async def test_global_override_used_when_no_guild_row(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_global_override_off_is_hard_disable(monkeypatch):
+    """state='off' on the global row hard-disables the flag for every guild.
+
+    This is the rollback contract: flipping the global row to 'off'
+    must immediately turn the flag off without falling through to the
+    rollout policy.  Without this guarantee, an in-flight canary
+    rollout could keep granting access after rollback.
+    """
+    monkeypatch.setenv("SUPERBOT_FF_FEATURE_FLAG_PRIMARY", "on")
+
+    rollout_flag = FeatureFlag(
+        name="test.rollout_active",
+        description="flag with rollout policy that would grant access",
+        default_value=False,
+        rollout_policy=RolloutPolicy(
+            staged_guilds=(42,),
+            percentage_rollout=100,
+            tier_gate=EnvironmentTier.PRODUCTION,
+        ),
+    )
+    feature_flags.register(rollout_flag)
+
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_guild_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value={"state": "off", "rollout_percent": None},
+        ),
+        patch(
+            "utils.db.environment_tiers.get_tier",
+            new_callable=AsyncMock,
+            return_value="production",
+        ),
+    ):
+        decision = await feature_flags.resolve_with_provenance(
+            "test.rollout_active",
+            guild_id=42,
+        )
+    # Global 'off' must win even when staged_guilds + 100% rollout
+    # would otherwise grant access.
+    assert decision.value is False
+    assert decision.source == "db_global"
+
+
+@pytest.mark.asyncio
+async def test_global_tier_state_falls_through_to_rollout_when_unmatched(monkeypatch):
+    """A tier-named global state that doesn't match the guild's tier falls through.
+
+    Example: global state='canary', guild tier='production'.  The
+    global row is non-binding for this guild — the declared rollout
+    policy may still grant access via staged_guilds.
+    """
+    monkeypatch.setenv("SUPERBOT_FF_FEATURE_FLAG_PRIMARY", "on")
+
+    staged_flag = FeatureFlag(
+        name="test.tier_fallthrough",
+        description="tier-named global state, staged_guilds rollout",
+        default_value=False,
+        rollout_policy=RolloutPolicy(
+            staged_guilds=(42,),
+            percentage_rollout=0,
+            tier_gate=EnvironmentTier.PRODUCTION,
+        ),
+    )
+    feature_flags.register(staged_flag)
+
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_guild_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value={"state": "canary", "rollout_percent": None},
+        ),
+        patch(
+            "utils.db.environment_tiers.get_tier",
+            new_callable=AsyncMock,
+            return_value="production",
+        ),
+    ):
+        decision = await feature_flags.resolve_with_provenance(
+            "test.tier_fallthrough",
+            guild_id=42,
+        )
+    # Guild is 'production' < 'canary'; the global row does not bind.
+    # The rollout policy still grants because guild 42 is staged.
+    assert decision.value is True
+    assert decision.source == "tier"
+
+
+@pytest.mark.asyncio
 async def test_rollout_policy_grants_via_tier_for_staged_guild(monkeypatch):
     """An explicit staged_guild + matching tier returns True via tier."""
     monkeypatch.setenv("SUPERBOT_FF_FEATURE_FLAG_PRIMARY", "on")

--- a/tests/unit/feature_flags/test_feature_flag_state_db.py
+++ b/tests/unit/feature_flags/test_feature_flag_state_db.py
@@ -1,0 +1,138 @@
+"""Phase 2d PR-2 — utils.db.feature_flag_state primitives.
+
+Mocks the asyncpg pool and asserts each primitive issues the expected
+SQL with the expected parameters (mirrors
+``tests/unit/bindings/test_bindings_db.py``).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from utils.db import feature_flag_state as ff_db
+
+
+@pytest.fixture
+def _mock_pool():
+    pool_mock = MagicMock()
+    pool_mock.execute = AsyncMock()
+    pool_mock.fetchrow = AsyncMock()
+    pool_mock.fetch = AsyncMock()
+    with patch.object(ff_db, "pool") as pool_module:
+        pool_module.get = MagicMock(return_value=pool_mock)
+        yield pool_mock
+
+
+# ---------------------------------------------------------------------------
+# get_global_override
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_global_override_returns_dict_when_row_present(_mock_pool):
+    now = datetime.now(timezone.utc)
+    _mock_pool.fetchrow.return_value = {
+        "flag_name": "bindings.primary",
+        "state": "canary",
+        "rollout_percent": 25,
+        "set_by": 99,
+        "set_at": now,
+    }
+    row = await ff_db.get_global_override("bindings.primary")
+    assert row == {
+        "flag_name": "bindings.primary",
+        "state": "canary",
+        "rollout_percent": 25,
+        "set_by": 99,
+        "set_at": now,
+    }
+    sql, *args = _mock_pool.fetchrow.await_args.args
+    assert "feature_flag_global_overrides" in sql
+    assert args == ["bindings.primary"]
+
+
+@pytest.mark.asyncio
+async def test_get_global_override_returns_none(_mock_pool):
+    _mock_pool.fetchrow.return_value = None
+    assert await ff_db.get_global_override("missing.flag") is None
+
+
+# ---------------------------------------------------------------------------
+# get_guild_override
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_guild_override_scoped_to_guild(_mock_pool):
+    _mock_pool.fetchrow.return_value = None
+    await ff_db.get_guild_override("bindings.primary", 42)
+    sql, *args = _mock_pool.fetchrow.await_args.args
+    assert "feature_flag_guild_overrides" in sql
+    assert "guild_id = $2" in sql
+    assert args == ["bindings.primary", 42]
+
+
+# ---------------------------------------------------------------------------
+# delete_for_guild — preserves global rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_for_guild_targets_only_guild_overrides(_mock_pool):
+    """Phase 2 retention: the GLOBAL override row must survive guild leave.
+
+    This test guards against a regression that would re-introduce a
+    cascade or accidentally touch ``feature_flag_global_overrides``.
+    """
+    _mock_pool.execute.return_value = "DELETE 4"
+    deleted = await ff_db.delete_for_guild(42)
+    sql, *args = _mock_pool.execute.await_args.args
+    assert "feature_flag_guild_overrides" in sql
+    assert "feature_flag_global_overrides" not in sql
+    assert args == [42]
+    assert deleted == 4
+
+
+@pytest.mark.asyncio
+async def test_delete_for_guild_handles_zero_rows(_mock_pool):
+    _mock_pool.execute.return_value = "DELETE 0"
+    assert await ff_db.delete_for_guild(42) == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_for_guild_handles_unexpected_status(_mock_pool):
+    _mock_pool.execute.return_value = "unexpected"
+    assert await ff_db.delete_for_guild(42) == 0
+
+
+# ---------------------------------------------------------------------------
+# list helpers (used by diagnostics)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_global_overrides_returns_list(_mock_pool):
+    _mock_pool.fetch.return_value = [
+        {
+            "flag_name": "bindings.primary",
+            "state": "off",
+            "rollout_percent": None,
+            "set_by": None,
+            "set_at": datetime.now(timezone.utc),
+        },
+    ]
+    result = await ff_db.list_global_overrides()
+    assert len(result) == 1
+    assert result[0]["flag_name"] == "bindings.primary"
+
+
+@pytest.mark.asyncio
+async def test_list_guild_overrides_scoped_to_guild(_mock_pool):
+    _mock_pool.fetch.return_value = []
+    await ff_db.list_guild_overrides(42)
+    sql, *args = _mock_pool.fetch.await_args.args
+    assert "guild_id = $1" in sql
+    assert args == [42]

--- a/tests/unit/invariants/test_environment_tier_alignment.py
+++ b/tests/unit/invariants/test_environment_tier_alignment.py
@@ -1,0 +1,48 @@
+"""Phase 2d PR-2 invariant — environment_tiers.tier matches EnvironmentTier.
+
+Migration 024 ships a CHECK constraint enumerating exactly the values
+of :class:`core.runtime.feature_flags.EnvironmentTier`.  Adding a
+member to the enum without extending the CHECK constraint would let
+the evaluator return a value the DB then rejects on the next write.
+Adding to the CHECK without an enum member would let an operator
+insert a tier the evaluator silently ignores.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_MIGRATION = (
+    Path(__file__).resolve().parents[3]
+    / "disbot"
+    / "migrations"
+    / "024_environment_tiers.sql"
+)
+
+
+def _extract_tier_literals() -> set[str]:
+    sql = _MIGRATION.read_text()
+    match = re.search(r"CHECK\s*\(\s*tier\s+IN\s*\(([^)]+)\)\s*\)", sql)
+    assert match, "could not locate tier CHECK constraint in migration 024"
+    literals = {token.strip().strip("'\"") for token in match.group(1).split(",")}
+    return literals
+
+
+def test_environment_tier_values_match_migration_024_check():
+    """Python ``EnvironmentTier`` matches migration 024's CHECK literals."""
+    from core.runtime.feature_flags import EnvironmentTier
+
+    db_check = _extract_tier_literals()
+    python = {t.value for t in EnvironmentTier}
+
+    missing_in_db = python - db_check
+    missing_in_python = db_check - python
+
+    assert not missing_in_db and not missing_in_python, (
+        "EnvironmentTier / DB CHECK drift.\n"
+        f"  in Python but not DB CHECK: {sorted(missing_in_db)}\n"
+        f"  in DB CHECK but not Python: {sorted(missing_in_python)}\n"
+        "Fix: extend the CHECK constraint in a new migration AND "
+        "update the EnvironmentTier enum.",
+    )

--- a/tests/unit/invariants/test_feature_flag_state_alignment.py
+++ b/tests/unit/invariants/test_feature_flag_state_alignment.py
@@ -1,0 +1,96 @@
+"""Phase 2d PR-2 invariant — feature_flag state values match migration 023.
+
+Migration 023 ships CHECK constraints on
+``feature_flag_global_overrides.state`` and
+``feature_flag_guild_overrides.state``.  Both columns use the same
+constraint literal set: the union of the two hard overrides
+(``on``/``off``) and the four tier-equivalence values
+(``owner``/``canary``/``beta``/``production``).
+
+The Python evaluator
+(:mod:`core.runtime.feature_flags`.``_state_to_decision``) treats any
+value outside this set as "unknown — fall back to declared default".
+If the DB ever accepted a value that Python silently ignored, an
+operator override would appear successful but have no behavioural
+effect.  This test pins the literal set on both sides so the next
+addition (e.g. a future ``percent`` state) cannot land without an
+explicit, reviewed update.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_MIGRATION = (
+    Path(__file__).resolve().parents[3]
+    / "disbot"
+    / "migrations"
+    / "023_feature_flag_state.sql"
+)
+
+
+def _extract_state_literals() -> set[str]:
+    """Return the literals inside the migration's state CHECK constraint."""
+    sql = _MIGRATION.read_text()
+    matches = re.findall(
+        r"CHECK\s*\(\s*state\s+IN\s*\(([^)]+)\)\s*\)",
+        sql,
+    )
+    assert matches, "could not locate state CHECK constraint in migration 023"
+    # Both CHECK clauses must agree — collapse to one set
+    all_literals: set[str] = set()
+    for clause in matches:
+        for token in clause.split(","):
+            literal = token.strip().strip("'\"")
+            all_literals.add(literal)
+    return all_literals
+
+
+def test_feature_flag_state_literals_match_known_evaluator_set():
+    """The DB state set matches the evaluator's recognized state strings."""
+    db_literals = _extract_state_literals()
+    expected = {"off", "owner", "canary", "beta", "production", "on"}
+
+    missing_in_db = expected - db_literals
+    missing_in_python = db_literals - expected
+
+    assert not missing_in_db and not missing_in_python, (
+        "feature_flag state CHECK / evaluator drift.\n"
+        f"  in evaluator but not DB CHECK: {sorted(missing_in_db)}\n"
+        f"  in DB CHECK but not evaluator: {sorted(missing_in_python)}\n"
+        "Fix: extend the CHECK constraint via a new migration AND extend "
+        "``_state_to_decision`` in core/runtime/feature_flags.py.",
+    )
+
+
+def test_evaluator_recognizes_every_db_state_literal():
+    """Each DB literal maps to a defined behaviour in the evaluator.
+
+    This is a stronger guarantee than just "the sets are equal": even
+    if the set comparison passed, the evaluator might handle some
+    literal as a typo.  We exercise the mapping directly.
+    """
+    from core.runtime.feature_flags import FeatureFlag, _state_to_decision
+
+    flag = FeatureFlag(
+        name="t.test",
+        description="alignment test",
+        default_value=False,
+    )
+
+    # Hard overrides
+    assert _state_to_decision("on", flag=flag, guild_tier="production") is True
+    assert _state_to_decision("off", flag=flag, guild_tier="owner") is False
+
+    # Tier-equivalence values are accepted (their truthiness depends on
+    # the guild's tier; here we just exercise the mapping path).
+    for tier_state in ("owner", "canary", "beta", "production"):
+        result = _state_to_decision(
+            tier_state,
+            flag=flag,
+            guild_tier="production",
+        )
+        assert isinstance(
+            result, bool
+        ), f"_state_to_decision returned non-bool for state={tier_state!r}"

--- a/tests/unit/runtime/test_guild_lifecycle_teardown.py
+++ b/tests/unit/runtime/test_guild_lifecycle_teardown.py
@@ -1,6 +1,6 @@
 """Phase 2 — guild_lifecycle.teardown wires Phase 2 cleanup primitives.
 
-Two new steps were added to ``guild_lifecycle.teardown`` in this PR:
+PR-1 added two steps to ``guild_lifecycle.teardown``:
 
 * **Step 5** — :func:`utils.db.bindings.delete_active_bindings_for_guild`
   purges ``subsystem_bindings`` rows and **preserves**
@@ -9,13 +9,27 @@ Two new steps were added to ``guild_lifecycle.teardown`` in this PR:
   reserved for explicit forensic cleanup and is **never** called from
   teardown.
 * **Step 6** — :func:`utils.db.resource_cache.delete_for_guild` drops
-  cached resource validation rows (the primitive shipped in PR #72; the
-  wiring landed here).
+  cached resource validation rows (the primitive shipped in PR #72;
+  the wiring landed here).
 
-These tests pin the contract for both:
+PR-2 added three more (Phase 2d feature-flag substrate):
 
-* Both new primitives are awaited during teardown.
-* The audit-purge primitive is **not** awaited (retention guarantee).
+* **Step 7** — :func:`utils.db.feature_flag_state.delete_for_guild`
+  drops the per-guild override rows; global rows are preserved.
+* **Step 8** — :func:`utils.db.environment_tiers.delete_for_guild`
+  removes the environment-tier row so the guild re-defaults to
+  PRODUCTION on re-invite.
+* **Step 9** — :func:`core.runtime.feature_flags.clear_cache` purges
+  cached evaluator decisions for the guild.
+
+These tests pin the contract:
+
+* Every new primitive is awaited (or called, for the sync one) during
+  teardown.
+* The binding audit-purge primitive is **never** awaited (retention
+  guarantee).
+* Global feature-flag overrides are preserved — the primitive scopes
+  to guild rows only.
 * Per-step failure does not abort the rest of the teardown sequence
   (matches the existing try/except discipline in
   ``disbot/guild_lifecycle.py``).
@@ -69,6 +83,23 @@ def _teardown_patches():
         ),
         patch(
             "core.runtime.scope_locks.teardown_guild",
+            return_value=0,
+        ),
+        # Phase 2d defaults — patched here so individual tests can
+        # override via additional with patch(...) blocks when they need
+        # to assert against the new feature-flag/environment-tier steps.
+        patch(
+            "utils.db.feature_flag_state.delete_for_guild",
+            new_callable=AsyncMock,
+            return_value=0,
+        ),
+        patch(
+            "utils.db.environment_tiers.delete_for_guild",
+            new_callable=AsyncMock,
+            return_value=0,
+        ),
+        patch(
+            "core.runtime.feature_flags.clear_cache",
             return_value=0,
         ),
     ):
@@ -218,3 +249,79 @@ async def test_teardown_is_idempotent(_teardown_patches):
         await guild_lifecycle.teardown(99)
         assert mock_bindings_delete.await_count == 2
         assert mock_resource_delete.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Step 7 — feature_flag_state per-guild overrides deleted; globals preserved
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_teardown_deletes_feature_flag_guild_overrides(_teardown_patches):
+    """The feature_flag guild-override primitive is awaited from teardown."""
+    import guild_lifecycle
+
+    with patch(
+        "utils.db.feature_flag_state.delete_for_guild",
+        new_callable=AsyncMock,
+        return_value=2,
+    ) as mock_delete:
+        await guild_lifecycle.teardown(99)
+        mock_delete.assert_awaited_once_with(99)
+
+
+@pytest.mark.asyncio
+async def test_teardown_feature_flag_step_failure_is_isolated(_teardown_patches):
+    """If the feature-flag delete raises, downstream steps still run."""
+    import guild_lifecycle
+
+    with (
+        patch(
+            "utils.db.feature_flag_state.delete_for_guild",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("DB blip"),
+        ),
+        patch(
+            "utils.db.environment_tiers.delete_for_guild",
+            new_callable=AsyncMock,
+            return_value=0,
+        ) as mock_et,
+    ):
+        await guild_lifecycle.teardown(99)
+        mock_et.assert_awaited_once_with(99)
+
+
+# ---------------------------------------------------------------------------
+# Step 8 — environment_tier row deleted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_teardown_deletes_environment_tier(_teardown_patches):
+    import guild_lifecycle
+
+    with patch(
+        "utils.db.environment_tiers.delete_for_guild",
+        new_callable=AsyncMock,
+        return_value=1,
+    ) as mock_delete:
+        await guild_lifecycle.teardown(99)
+        mock_delete.assert_awaited_once_with(99)
+
+
+# ---------------------------------------------------------------------------
+# Step 9 — feature_flag cache cleared per guild
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_teardown_clears_feature_flag_cache(_teardown_patches):
+    """Cache clear is called scoped to the guild (guild_id kwarg)."""
+    import guild_lifecycle
+
+    with patch(
+        "core.runtime.feature_flags.clear_cache",
+        return_value=0,
+    ) as mock_clear:
+        await guild_lifecycle.teardown(99)
+        mock_clear.assert_called_once_with(guild_id=99)


### PR DESCRIPTION
## Summary

PR-2 of the finalized Phase 2 plan. **Stacked on PR #76** (PR-1 teardown cleanup); merge against `main` after PR #76 is in.

Stand up the Phase 2d feature-flag runtime evaluator with an explicit bootstrap fallback policy. Tables and read-side evaluator land here; the `RolloutMutationPipeline` + event emission + audit log + Discord admin command ship in PR-3.

## Review-fix commit (force-pushed)

Latest commit `fix(phase-2-pr-2): clarify global override semantics; test hard-off rollback` addresses the review feedback:

- **Global `state='off'` is now an explicit hard disable** in code AND in comments. Previously the behavior was correct (the `value or normalized in ('on','off')` expression short-circuited correctly) but the comment was misleading. The conflated boolean is replaced with two explicit branches that mirror the documented resolution rules.
- Added two tests:
  - `test_global_override_off_is_hard_disable` — global `'off'` wins even when `staged_guilds` + 100% rollout would otherwise grant access. **Pins the rollback contract.**
  - `test_global_tier_state_falls_through_to_rollout_when_unmatched` — global `'canary'` on a `'production'` guild does NOT bind; declared rollout policy may still grant via `staged_guilds`.
- Confirmed `feature_flag.primary` is env/declaration-only, never DB-controlled.
- Confirmed no new hashing dependency; only `hashlib.sha256` (stdlib).

## Why this PR comes before participation (2c) and binding backfill

- `participation.enabled` and `bindings.primary` are declared but unevaluable today. Subsequent PRs that gate behavior on those flags need an evaluator that returns booleans.
- Per-cog branching on `bindings.primary` is forbidden by the plan; PR-4 (already open as #79) adds a central read-source arbitration layer that consumes `is_enabled`. **PR-2 is the dependency for both.**

## Bootstrap fallback policy

Documented in the module docstring and §3 of the consistency ledger:

1. **`SUPERBOT_FF_<FLAG>=on|off`** env override wins for ANY flag (permanent platform-owner escape hatch).
2. **`feature_flag.primary`** is the meta-gate. When OFF, the evaluator returns each flag's declared default and never reads the DB. `feature_flag.primary` itself is resolved by env + declaration ONLY (never DB) so the bootstrap path is safe while the runtime is being proven.
3. When `feature_flag.primary` is ON, DB-backed resolution runs.
4. DB errors fall back to the declared default and increment the `feature_flag.bootstrap_fallback` metric — **never raise**.

## Schema (correcting the original plan)

Two tables instead of one nullable-PK table, because PostgreSQL does not allow NULL in any PRIMARY KEY column:
- **`feature_flag_global_overrides(flag_name PK, state, rollout_percent, set_by, set_at)`**
- **`feature_flag_guild_overrides(flag_name, guild_id, PK(both), state, set_by, set_at)`**
- **`environment_tiers(guild_id PK, tier, set_by, set_at)`** — CHECK enumerates exactly `EnvironmentTier` values; alignment test pins it.

Both state tables CHECK `state IN ('off', 'owner', 'canary', 'beta', 'production', 'on')`; alignment test pins both sides and exercises the evaluator's `_state_to_decision` mapping.

## Global override resolution rules (now explicit in code + comments)

| State on global row | Guild tier | Result |
|---|---|---|
| `'on'` | any | hard enable, short-circuit True |
| `'off'` | any | **hard disable, short-circuit False (safe rollback)** |
| `'canary'` / `'beta'` / `'production'` / `'owner'` | matches required | True via `db_global` |
| `'canary'` / `'beta'` / `'production'` / `'owner'` | non-matching | **fall through to rollout policy** (staged_guilds may still grant) |

## Implementation details

- **Deterministic rollout hash** uses `hashlib.sha256` (stdlib) — no new dependency.
- **Evaluator cache uses TTL (5 minutes)** as the only invalidation primitive in this PR; `clear_cache(...)` is exposed for explicit invalidation. PR-3 adds event-driven invalidation.
- **All cycle-sensitive consumers** (`utils.db.feature_flag_state`, `utils.db.environment_tiers`) are imported INSIDE the helper bodies in `guild_lifecycle.py` — no new top-level `core.runtime` imports added to cycle-sensitive files.

## Architectural boundaries preserved

- One domain per PR. Feature flags only; no participation, no binding-backfill, no setup UI.
- `ResourceStatus.BOUND` remains structural-only.
- Import-cycle regression protections from PR #74 unchanged.
- No subsystem read-path flip; `bindings.primary` remains OFF by declared default and `feature_flag.primary` remains OFF unless explicitly enabled via env.

## Migrations

**023** + **024** — both additive, forward-only.

## Rollback strategy

- Revert the PR commit. Migrations are additive — leaving them in place after revert is safe.
- The evaluator is read-only and `feature_flag.primary` defaults OFF, so no subsystem behavior changes if PR-2 is reverted.

## Tests run (after review fix)

```
python -m pytest tests/unit/feature_flags/ \
                 tests/unit/invariants/test_feature_flag_state_alignment.py \
                 tests/unit/invariants/test_environment_tier_alignment.py \
                 tests/unit/runtime/test_import_cycle_regression.py -q
# 41 passed (+2 new rollback-contract tests)

python -m ruff check disbot/   # clean
python -m black --check        # clean
python -m isort --check-only   # clean
```

## Manual Discord smoke

- [ ] Apply migrations 023 + 024 to test DB
- [ ] `!platform flags` shows each declared flag with `effective=off`, `src=default` (because `feature_flag.primary` defaults OFF)
- [ ] Set env `SUPERBOT_FF_FEATURE_FLAG_PRIMARY=on`, restart; `!platform flags` now shows `src=default` or `src=db_*` depending on seeded rows
- [ ] Insert a `feature_flag_global_overrides` row with `state='off'` for `bindings.primary`; verify `!platform flags` reflects `src=db_global` and `effective=off` (hard rollback)
- [ ] Kick the bot from test guild; verify `feature_flag_guild_overrides` rows for that guild are gone and the global row survives

## Intentionally deferred (PR-3)

- `RolloutMutationPipeline` (write path with 7-step contract) — now open as PR #78
- `feature_flag_audit` table (migration 025) — PR #78
- `EVT_FEATURE_FLAGS_CHANGED` / `EVT_ROLLOUT_ADVANCED` / `EVT_ENVIRONMENT_TIER_CHANGED` catalogued events — PR #78
- Event-driven cache invalidation — PR #78
- Discord admin command for setting flags — follow-up after canary observation