### PR TITLE
Phase 2.3: rollout mutation pipeline + feature flag audit (Phase 2d, PR-3)

### DIFF
--- a/disbot/core/events_catalogue.py
+++ b/disbot/core/events_catalogue.py
@@ -60,6 +60,14 @@ KNOWN_EVENTS: frozenset[str] = frozenset(
         "moderation.action_taken",
         # ── Bindings (services/binding_mutation.py, Phase 2b) ─────────────
         "bindings.changed",
+        # ── Feature flags (services/rollout_mutation.py, Phase 2d PR-3) ───
+        # Advisory events emitted after the DB commit + audit row land.
+        # Subscriber failure is logged with mutation_id and never raised
+        # — DB state is authoritative.  Payload contract is documented in
+        # docs/platform-consistency-ledger.md §4.
+        "feature_flags.changed",
+        "rollout.advanced",
+        "environment_tier.changed",
         # ── Future cog-emitted facts (uncomment when first emitter lands):
         # "economy.daily_claimed",
         # "mining.harvested",

--- a/disbot/migrations/025_feature_flag_audit.sql
+++ b/disbot/migrations/025_feature_flag_audit.sql
@@ -1,0 +1,68 @@
+-- Migration 025: feature_flag_audit (Phase 2d, PR-3).
+--
+-- Append-only audit log for every mutation that flows through
+-- :class:`services.rollout_mutation.RolloutMutationPipeline`.  One row
+-- per state change.  Rollback is a NEW audit row, never an UPDATE.
+--
+-- Three mutation types are recorded:
+--
+--   * ``set_state``    — write to feature_flag_global_overrides or
+--                        feature_flag_guild_overrides.  ``scope`` +
+--                        ``guild_id`` discriminate which row was
+--                        affected; ``prev_state`` / ``new_state``
+--                        carry the transition.
+--   * ``set_rollout_percent`` — change to
+--                        feature_flag_global_overrides.rollout_percent.
+--                        ``prev_rollout_percent`` / ``new_rollout_percent``
+--                        carry the transition; state columns repeat
+--                        the current state for context.
+--   * ``set_tier``     — change to environment_tiers.tier.  ``flag_name``
+--                        is set to the literal ``'__environment_tier__'``
+--                        so the audit table can host all three event
+--                        sources without a second table.
+--
+-- Schema decisions:
+--
+--   * ``mutation_type`` and ``scope`` CHECK literals mirror the Python
+--     constants in :mod:`services.rollout_mutation`.  Alignment test
+--     ``tests/unit/invariants/test_feature_flag_audit_alignment.py``
+--     pins them.
+--   * ``actor_id`` is nullable — system writes (CI seeds, scripted
+--     ops) record actor_type='system' with actor_id=NULL.
+--   * Indexed on (flag_name, at) for per-flag history and
+--     (guild_id, at) for per-guild history.  ``mutation_id`` indexed
+--     for cross-pipeline correlation.
+--
+-- Forward-only and idempotent.
+
+CREATE TABLE IF NOT EXISTS feature_flag_audit (
+    id                     BIGSERIAL    PRIMARY KEY,
+    mutation_id            UUID         NOT NULL,
+    flag_name              TEXT         NOT NULL,
+    scope                  TEXT         NOT NULL,
+    guild_id               BIGINT,
+    prev_state             TEXT,
+    new_state              TEXT,
+    prev_rollout_percent   INTEGER,
+    new_rollout_percent    INTEGER,
+    prev_tier              TEXT,
+    new_tier               TEXT,
+    actor_id               BIGINT,
+    actor_type             TEXT         NOT NULL DEFAULT 'platform_owner',
+    mutation_type          TEXT         NOT NULL,
+    at                     TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    CHECK (scope IN ('global', 'guild')),
+    CHECK (mutation_type IN
+        ('set_state', 'set_rollout_percent', 'set_tier')),
+    CHECK (actor_type IN
+        ('platform_owner', 'system', 'backfill'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_feature_flag_audit_flag_at
+    ON feature_flag_audit (flag_name, at);
+
+CREATE INDEX IF NOT EXISTS idx_feature_flag_audit_guild_at
+    ON feature_flag_audit (guild_id, at);
+
+CREATE INDEX IF NOT EXISTS idx_feature_flag_audit_mutation
+    ON feature_flag_audit (mutation_id);

--- a/disbot/migrations/025_feature_flag_audit.sql
+++ b/disbot/migrations/025_feature_flag_audit.sql
@@ -33,6 +33,22 @@
 --     (guild_id, at) for per-guild history.  ``mutation_id`` indexed
 --     for cross-pipeline correlation.
 --
+-- Per-``mutation_type`` shape (defense-in-depth via CHECK constraints).
+-- These complement the pipeline-level validation; even a future caller
+-- that bypasses :class:`RolloutMutationPipeline` cannot insert a
+-- mis-shaped audit row.
+--
+--   * ``set_state`` rows: ``new_state`` must be non-null; ``flag_name``
+--     must NOT be the environment-tier sentinel; tier columns must be
+--     NULL.
+--   * ``set_rollout_percent`` rows: ``new_rollout_percent`` must be
+--     non-null; ``scope`` must be ``'global'``; ``flag_name`` must NOT
+--     be the sentinel; tier columns must be NULL.
+--   * ``set_tier`` rows: ``flag_name`` must be the sentinel literal
+--     ``'__environment_tier__'``; ``scope`` must be ``'guild'``;
+--     ``guild_id`` must be non-null; ``new_tier`` must be non-null;
+--     state and rollout columns must be NULL.
+--
 -- Forward-only and idempotent.
 
 CREATE TABLE IF NOT EXISTS feature_flag_audit (
@@ -55,7 +71,47 @@ CREATE TABLE IF NOT EXISTS feature_flag_audit (
     CHECK (mutation_type IN
         ('set_state', 'set_rollout_percent', 'set_tier')),
     CHECK (actor_type IN
-        ('platform_owner', 'system', 'backfill'))
+        ('platform_owner', 'system', 'backfill')),
+    -- set_state rows must carry a non-null new_state, must NOT use the
+    -- environment-tier sentinel flag_name, and must leave tier columns
+    -- unset.
+    CHECK (
+        mutation_type <> 'set_state' OR (
+            new_state IS NOT NULL
+            AND flag_name <> '__environment_tier__'
+            AND prev_tier IS NULL
+            AND new_tier IS NULL
+        )
+    ),
+    -- set_rollout_percent rows are global-scoped, carry a non-null
+    -- new_rollout_percent, must not use the sentinel, and leave tier
+    -- columns unset.
+    CHECK (
+        mutation_type <> 'set_rollout_percent' OR (
+            scope = 'global'
+            AND guild_id IS NULL
+            AND new_rollout_percent IS NOT NULL
+            AND flag_name <> '__environment_tier__'
+            AND prev_tier IS NULL
+            AND new_tier IS NULL
+        )
+    ),
+    -- set_tier rows use the sentinel flag_name, are guild-scoped with
+    -- non-null guild_id and new_tier, and leave state + rollout
+    -- columns unset.  This is the explicit contract that lets the
+    -- single audit table host all three event sources.
+    CHECK (
+        mutation_type <> 'set_tier' OR (
+            flag_name = '__environment_tier__'
+            AND scope = 'guild'
+            AND guild_id IS NOT NULL
+            AND new_tier IS NOT NULL
+            AND prev_state IS NULL
+            AND new_state IS NULL
+            AND prev_rollout_percent IS NULL
+            AND new_rollout_percent IS NULL
+        )
+    )
 );
 
 CREATE INDEX IF NOT EXISTS idx_feature_flag_audit_flag_at

--- a/disbot/services/rollout_mutation.py
+++ b/disbot/services/rollout_mutation.py
@@ -1,0 +1,606 @@
+"""Rollout mutation pipeline — Phase 2d PR-3.
+
+The canonical write path for ``feature_flag_global_overrides``,
+``feature_flag_guild_overrides``, and ``environment_tiers``.  Mirrors
+the 7-step contract from
+:class:`~services.binding_mutation.BindingMutationPipeline`:
+
+  1. Input validation       — flag declared in the registry; mutation
+                              type matches the entry point; scope/state
+                              tokens recognized.
+  2. Authority validation   — actor_type within an explicit allowed
+                              set.  Discord-facing command surface is
+                              deferred to a follow-up PR.
+  3. Read previous state    — for the audit row.
+  4. DB write + audit       — single transaction via
+                              :mod:`utils.db.feature_flag_state` /
+                              :mod:`utils.db.environment_tiers`.
+  5. Cache invalidation     — :func:`core.runtime.feature_flags.clear_cache`
+                              scoped to the affected flag and/or guild.
+  6. Event emission         — advisory, post-commit, never raises.
+  7. Return result          — with mutation_id for cross-pipeline
+                              correlation.
+
+Authority model (intentionally minimal for PR-3):
+
+  * ``actor_type='platform_owner'`` — the only actor accepted from
+    operator scripts / future Discord admin command.  ``actor_id`` is
+    required to be non-None for this type.
+  * ``actor_type='system'`` — for CI seeds / migration helpers.
+    ``actor_id`` may be None.
+  * ``actor_type='backfill'`` — reserved for future logical-migration
+    runs (PR-5/6).  Currently no callers.
+
+Any other actor_type is rejected at step 2.  The Phase 4.5 typed
+access-control resolver will replace this with the same capability
+mechanism the binding pipeline uses.
+
+Hard limits for PR-3:
+
+  * No Discord admin command for flag mutation — operators mutate via
+    a one-off Python script that imports this pipeline.  The command
+    surface ships in a follow-up after authority is tightened.
+  * Subscribers of the three new events are not wired in this PR.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Literal
+
+from core.runtime import feature_flags
+from utils.db import environment_tiers as et_db
+from utils.db import feature_flag_state as ff_db
+
+logger = logging.getLogger("bot.services.rollout_mutation")
+
+# ---------------------------------------------------------------------------
+# Catalogued event names
+# ---------------------------------------------------------------------------
+
+EVT_FEATURE_FLAGS_CHANGED = "feature_flags.changed"
+EVT_ROLLOUT_ADVANCED = "rollout.advanced"
+EVT_ENVIRONMENT_TIER_CHANGED = "environment_tier.changed"
+
+# ---------------------------------------------------------------------------
+# Recognized literal sets (mirror migration 023 / 024 / 025 CHECK constraints)
+# ---------------------------------------------------------------------------
+
+_VALID_STATES: frozenset[str] = frozenset(
+    {"off", "owner", "canary", "beta", "production", "on"},
+)
+_VALID_TIERS: frozenset[str] = frozenset(
+    {"production", "beta", "canary", "owner_guild_only", "development"},
+)
+_ALLOWED_ACTOR_TYPES: frozenset[str] = frozenset(
+    {"platform_owner", "system", "backfill"},
+)
+
+Scope = Literal["global", "guild"]
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class RolloutMutationError(Exception):
+    """Base class for failures from :class:`RolloutMutationPipeline`."""
+
+
+class UnknownFeatureFlagError(RolloutMutationError):
+    """Raised when the flag_name is not in the FeatureFlag registry."""
+
+
+class InvalidStateError(RolloutMutationError):
+    """Raised when the supplied state token is not recognized."""
+
+
+class InvalidTierError(RolloutMutationError):
+    """Raised when the supplied tier token is not recognized."""
+
+
+class InvalidRolloutPercentError(RolloutMutationError):
+    """Raised when rollout_percent is outside 0..100."""
+
+
+class UnauthorizedRolloutMutationError(RolloutMutationError):
+    """Raised when ``actor_type`` is not in the allowed set or actor_id
+    is missing for an actor_type that requires it.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RolloutMutationResult:
+    """Outcome of a successful (or partially successful) mutation."""
+
+    mutation_id: str
+    flag_name: str
+    scope: Scope
+    guild_id: int | None
+    prev_state: str | None
+    new_state: str | None
+    prev_rollout_percent: int | None
+    new_rollout_percent: int | None
+    prev_tier: str | None
+    new_tier: str | None
+    mutation_type: Literal["set_state", "set_rollout_percent", "set_tier"]
+    committed_at: datetime
+    event_emitted: bool
+
+
+# ---------------------------------------------------------------------------
+# Pipeline
+# ---------------------------------------------------------------------------
+
+
+class RolloutMutationPipeline:
+    """Centralised orchestration for feature-flag + environment-tier writes.
+
+    Stateless — create one per mutation request.  Three public methods:
+
+    * :meth:`set_flag_state` — flip a flag on/off or to a tier name,
+      scoped global or per-guild.
+    * :meth:`set_rollout_percent` — change a global flag's rollout %.
+    * :meth:`set_environment_tier` — change a guild's tier.
+
+    All three follow the same 7-step contract documented in the module
+    docstring.
+    """
+
+    def __init__(self) -> None:
+        # No instance state.
+        pass
+
+    # ------------------------------------------------------------------
+    # set_flag_state
+    # ------------------------------------------------------------------
+
+    async def set_flag_state(
+        self,
+        *,
+        flag_name: str,
+        scope: Scope,
+        state: str,
+        actor_id: int | None,
+        actor_type: str = "platform_owner",
+        guild_id: int | None = None,
+    ) -> RolloutMutationResult:
+        """Set ``state`` on the global or per-guild override row."""
+        self._validate_flag(flag_name)
+        self._validate_state(state)
+        self._validate_scope_and_guild(scope, guild_id)
+        self._validate_authority(actor_id, actor_type)
+
+        mutation_id = str(uuid.uuid4())
+        if scope == "global":
+            prev = await ff_db.get_global_override(flag_name)
+            prev_state = prev["state"] if prev else None
+            prev_rollout = prev["rollout_percent"] if prev else None
+            try:
+                await ff_db.upsert_global_with_audit(
+                    flag_name=flag_name,
+                    state=state,
+                    rollout_percent=prev_rollout,
+                    actor_id=actor_id,
+                    actor_type=actor_type,
+                    mutation_id=mutation_id,
+                    prev_state=prev_state,
+                    prev_rollout_percent=prev_rollout,
+                    mutation_type="set_state",
+                )
+            except Exception:
+                logger.exception(
+                    "RolloutMutationPipeline.set_flag_state: DB transaction "
+                    "failed for flag=%r scope=global; no cache invalidation, "
+                    "no event emission.",
+                    flag_name,
+                )
+                raise
+            feature_flags.clear_cache(flag_name=flag_name)
+            committed_at = _now_utc()
+            event_emitted = await _emit_feature_flag_event(
+                mutation_id=mutation_id,
+                flag_name=flag_name,
+                scope="global",
+                guild_id=None,
+                prev_state=prev_state,
+                new_state=state,
+                actor_id=actor_id,
+                actor_type=actor_type,
+                committed_at=committed_at,
+            )
+            return RolloutMutationResult(
+                mutation_id=mutation_id,
+                flag_name=flag_name,
+                scope="global",
+                guild_id=None,
+                prev_state=prev_state,
+                new_state=state,
+                prev_rollout_percent=prev_rollout,
+                new_rollout_percent=prev_rollout,
+                prev_tier=None,
+                new_tier=None,
+                mutation_type="set_state",
+                committed_at=committed_at,
+                event_emitted=event_emitted,
+            )
+
+        # Guild-scoped branch.  guild_id non-null is guaranteed by
+        # _validate_scope_and_guild above; the assert is just for mypy.
+        assert guild_id is not None  # noqa: S101
+        prev_guild = await ff_db.get_guild_override(flag_name, guild_id)
+        prev_state = prev_guild["state"] if prev_guild else None
+        try:
+            await ff_db.upsert_guild_with_audit(
+                flag_name=flag_name,
+                guild_id=guild_id,
+                state=state,
+                actor_id=actor_id,
+                actor_type=actor_type,
+                mutation_id=mutation_id,
+                prev_state=prev_state,
+            )
+        except Exception:
+            logger.exception(
+                "RolloutMutationPipeline.set_flag_state: DB transaction "
+                "failed for flag=%r scope=guild guild=%d; no cache "
+                "invalidation, no event emission.",
+                flag_name,
+                guild_id,
+            )
+            raise
+        # Invalidate both the per-guild entry AND the global entry for
+        # this flag (a global lookup could have cached a "no guild row"
+        # decision that is now stale).
+        feature_flags.clear_cache(flag_name=flag_name, guild_id=guild_id)
+        feature_flags.clear_cache(flag_name=flag_name, guild_id=None)
+        committed_at = _now_utc()
+        event_emitted = await _emit_feature_flag_event(
+            mutation_id=mutation_id,
+            flag_name=flag_name,
+            scope="guild",
+            guild_id=guild_id,
+            prev_state=prev_state,
+            new_state=state,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            committed_at=committed_at,
+        )
+        return RolloutMutationResult(
+            mutation_id=mutation_id,
+            flag_name=flag_name,
+            scope="guild",
+            guild_id=guild_id,
+            prev_state=prev_state,
+            new_state=state,
+            prev_rollout_percent=None,
+            new_rollout_percent=None,
+            prev_tier=None,
+            new_tier=None,
+            mutation_type="set_state",
+            committed_at=committed_at,
+            event_emitted=event_emitted,
+        )
+
+    # ------------------------------------------------------------------
+    # set_rollout_percent
+    # ------------------------------------------------------------------
+
+    async def set_rollout_percent(
+        self,
+        *,
+        flag_name: str,
+        percent: int,
+        actor_id: int | None,
+        actor_type: str = "platform_owner",
+    ) -> RolloutMutationResult:
+        """Set the global rollout_percent for ``flag_name``."""
+        self._validate_flag(flag_name)
+        if not (0 <= percent <= 100):
+            raise InvalidRolloutPercentError(
+                f"rollout_percent must be in 0..100, got {percent!r}",
+            )
+        self._validate_authority(actor_id, actor_type)
+
+        mutation_id = str(uuid.uuid4())
+        prev = await ff_db.get_global_override(flag_name)
+        prev_state = prev["state"] if prev else "off"
+        prev_percent = prev["rollout_percent"] if prev else None
+        try:
+            await ff_db.upsert_global_with_audit(
+                flag_name=flag_name,
+                state=prev_state,
+                rollout_percent=percent,
+                actor_id=actor_id,
+                actor_type=actor_type,
+                mutation_id=mutation_id,
+                prev_state=prev_state,
+                prev_rollout_percent=prev_percent,
+                mutation_type="set_rollout_percent",
+            )
+        except Exception:
+            logger.exception(
+                "RolloutMutationPipeline.set_rollout_percent: DB transaction "
+                "failed for flag=%r; no cache invalidation, no event emission.",
+                flag_name,
+            )
+            raise
+        # Rollout changes invalidate every cached guild decision for
+        # this flag.
+        feature_flags.clear_cache(flag_name=flag_name)
+        committed_at = _now_utc()
+        event_emitted = await _emit_rollout_event(
+            mutation_id=mutation_id,
+            flag_name=flag_name,
+            prev_percent=prev_percent,
+            new_percent=percent,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            committed_at=committed_at,
+        )
+        return RolloutMutationResult(
+            mutation_id=mutation_id,
+            flag_name=flag_name,
+            scope="global",
+            guild_id=None,
+            prev_state=prev_state,
+            new_state=prev_state,
+            prev_rollout_percent=prev_percent,
+            new_rollout_percent=percent,
+            prev_tier=None,
+            new_tier=None,
+            mutation_type="set_rollout_percent",
+            committed_at=committed_at,
+            event_emitted=event_emitted,
+        )
+
+    # ------------------------------------------------------------------
+    # set_environment_tier
+    # ------------------------------------------------------------------
+
+    async def set_environment_tier(
+        self,
+        *,
+        guild_id: int,
+        tier: str,
+        actor_id: int | None,
+        actor_type: str = "platform_owner",
+    ) -> RolloutMutationResult:
+        """Set a guild's environment tier."""
+        if tier not in _VALID_TIERS:
+            raise InvalidTierError(
+                f"tier must be one of {sorted(_VALID_TIERS)}, got {tier!r}",
+            )
+        self._validate_authority(actor_id, actor_type)
+
+        mutation_id = str(uuid.uuid4())
+        prev_tier = await et_db.get_tier(guild_id)
+        try:
+            await et_db.upsert_with_audit(
+                guild_id=guild_id,
+                tier=tier,
+                actor_id=actor_id,
+                actor_type=actor_type,
+                mutation_id=mutation_id,
+                prev_tier=prev_tier,
+            )
+        except Exception:
+            logger.exception(
+                "RolloutMutationPipeline.set_environment_tier: DB transaction "
+                "failed for guild=%d; no cache invalidation, no event emission.",
+                guild_id,
+            )
+            raise
+        # A tier change can change every flag's effective value for
+        # this guild; drop every cached entry scoped to it.
+        feature_flags.clear_cache(guild_id=guild_id)
+        committed_at = _now_utc()
+        event_emitted = await _emit_environment_tier_event(
+            mutation_id=mutation_id,
+            guild_id=guild_id,
+            prev_tier=prev_tier,
+            new_tier=tier,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            committed_at=committed_at,
+        )
+        return RolloutMutationResult(
+            mutation_id=mutation_id,
+            flag_name="__environment_tier__",
+            scope="guild",
+            guild_id=guild_id,
+            prev_state=None,
+            new_state=None,
+            prev_rollout_percent=None,
+            new_rollout_percent=None,
+            prev_tier=prev_tier,
+            new_tier=tier,
+            mutation_type="set_tier",
+            committed_at=committed_at,
+            event_emitted=event_emitted,
+        )
+
+    # ------------------------------------------------------------------
+    # Validation helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _validate_flag(flag_name: str) -> None:
+        if feature_flags.get(flag_name) is None:
+            raise UnknownFeatureFlagError(
+                f"flag {flag_name!r} is not declared; register it in "
+                "core/runtime/feature_flags.py or the owning subsystem "
+                "before mutating.",
+            )
+
+    @staticmethod
+    def _validate_state(state: str) -> None:
+        if state not in _VALID_STATES:
+            raise InvalidStateError(
+                f"state must be one of {sorted(_VALID_STATES)}, got {state!r}",
+            )
+
+    @staticmethod
+    def _validate_scope_and_guild(scope: str, guild_id: int | None) -> None:
+        if scope not in ("global", "guild"):
+            raise RolloutMutationError(
+                f"scope must be 'global' or 'guild', got {scope!r}",
+            )
+        if scope == "guild" and guild_id is None:
+            raise RolloutMutationError(
+                "scope='guild' requires guild_id to be set",
+            )
+        if scope == "global" and guild_id is not None:
+            raise RolloutMutationError(
+                "scope='global' must not specify guild_id",
+            )
+
+    @staticmethod
+    def _validate_authority(actor_id: int | None, actor_type: str) -> None:
+        if actor_type not in _ALLOWED_ACTOR_TYPES:
+            raise UnauthorizedRolloutMutationError(
+                f"actor_type must be one of {sorted(_ALLOWED_ACTOR_TYPES)}, "
+                f"got {actor_type!r}",
+            )
+        if actor_type == "platform_owner" and actor_id is None:
+            raise UnauthorizedRolloutMutationError(
+                "actor_type='platform_owner' requires non-None actor_id",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Event emitters (post-commit, advisory)
+# ---------------------------------------------------------------------------
+
+
+async def _emit_feature_flag_event(
+    *,
+    mutation_id: str,
+    flag_name: str,
+    scope: Scope,
+    guild_id: int | None,
+    prev_state: str | None,
+    new_state: str,
+    actor_id: int | None,
+    actor_type: str,
+    committed_at: datetime,
+) -> bool:
+    """Emit feature_flags.changed.  Returns False on emission failure."""
+    from core.events import bus
+
+    try:
+        await bus.emit(
+            EVT_FEATURE_FLAGS_CHANGED,
+            mutation_id=mutation_id,
+            flag_name=flag_name,
+            scope=scope,
+            guild_id=guild_id,
+            prev_state=prev_state,
+            new_state=new_state,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            occurred_at=committed_at.isoformat(),
+        )
+    except Exception:
+        logger.exception(
+            "RolloutMutationPipeline: feature_flags.changed emission failed "
+            "for mutation_id=%s; DB state is correct, event lost.",
+            mutation_id,
+        )
+        return False
+    return True
+
+
+async def _emit_rollout_event(
+    *,
+    mutation_id: str,
+    flag_name: str,
+    prev_percent: int | None,
+    new_percent: int,
+    actor_id: int | None,
+    actor_type: str,
+    committed_at: datetime,
+) -> bool:
+    from core.events import bus
+
+    try:
+        await bus.emit(
+            EVT_ROLLOUT_ADVANCED,
+            mutation_id=mutation_id,
+            flag_name=flag_name,
+            prev_percent=prev_percent,
+            new_percent=new_percent,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            occurred_at=committed_at.isoformat(),
+        )
+    except Exception:
+        logger.exception(
+            "RolloutMutationPipeline: rollout.advanced emission failed "
+            "for mutation_id=%s; DB state is correct, event lost.",
+            mutation_id,
+        )
+        return False
+    return True
+
+
+async def _emit_environment_tier_event(
+    *,
+    mutation_id: str,
+    guild_id: int,
+    prev_tier: str | None,
+    new_tier: str,
+    actor_id: int | None,
+    actor_type: str,
+    committed_at: datetime,
+) -> bool:
+    from core.events import bus
+
+    try:
+        await bus.emit(
+            EVT_ENVIRONMENT_TIER_CHANGED,
+            mutation_id=mutation_id,
+            guild_id=guild_id,
+            prev_tier=prev_tier,
+            new_tier=new_tier,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            occurred_at=committed_at.isoformat(),
+        )
+    except Exception:
+        logger.exception(
+            "RolloutMutationPipeline: environment_tier.changed emission "
+            "failed for mutation_id=%s; DB state is correct, event lost.",
+            mutation_id,
+        )
+        return False
+    return True
+
+
+def _now_utc() -> datetime:
+    """Return a tz-aware "now" — INV-N forbids bare datetime.utcnow."""
+    return datetime.now(timezone.utc)
+
+
+__all__ = [
+    "EVT_ENVIRONMENT_TIER_CHANGED",
+    "EVT_FEATURE_FLAGS_CHANGED",
+    "EVT_ROLLOUT_ADVANCED",
+    "InvalidRolloutPercentError",
+    "InvalidStateError",
+    "InvalidTierError",
+    "RolloutMutationError",
+    "RolloutMutationPipeline",
+    "RolloutMutationResult",
+    "UnauthorizedRolloutMutationError",
+    "UnknownFeatureFlagError",
+]

--- a/disbot/utils/db/environment_tiers.py
+++ b/disbot/utils/db/environment_tiers.py
@@ -59,6 +59,53 @@ async def list_for_diagnostics() -> list[dict[str, Any]]:
     return [dict(r) for r in rows]
 
 
+async def upsert_with_audit(
+    *,
+    guild_id: int,
+    tier: str,
+    actor_id: int | None,
+    actor_type: str,
+    mutation_id: str,
+    prev_tier: str | None,
+) -> None:
+    """Atomic: upsert environment_tiers + write feature_flag_audit row.
+
+    The audit row uses ``flag_name='__environment_tier__'`` so the
+    single audit table covers all three Phase 2d event sources
+    (state, rollout, tier).  Caller is the RolloutMutationPipeline.
+    """
+    async with pool.get().acquire() as conn, conn.transaction():
+        await conn.execute(
+            """
+            INSERT INTO environment_tiers (guild_id, tier, set_by, set_at)
+            VALUES ($1, $2, $3, NOW())
+            ON CONFLICT (guild_id) DO UPDATE SET
+                tier = EXCLUDED.tier,
+                set_by = EXCLUDED.set_by,
+                set_at = NOW()
+            """,
+            guild_id,
+            tier,
+            actor_id,
+        )
+        await conn.execute(
+            """
+            INSERT INTO feature_flag_audit
+                (mutation_id, flag_name, scope, guild_id,
+                 prev_tier, new_tier,
+                 actor_id, actor_type, mutation_type)
+            VALUES ($1, '__environment_tier__', 'guild', $2, $3, $4,
+                    $5, $6, 'set_tier')
+            """,
+            mutation_id,
+            guild_id,
+            prev_tier,
+            tier,
+            actor_id,
+            actor_type,
+        )
+
+
 async def delete_for_guild(guild_id: int) -> int:
     """Delete the environment_tier row for ``guild_id``.
 
@@ -80,4 +127,5 @@ __all__ = [
     "delete_for_guild",
     "get_tier",
     "list_for_diagnostics",
+    "upsert_with_audit",
 ]

--- a/disbot/utils/db/feature_flag_state.py
+++ b/disbot/utils/db/feature_flag_state.py
@@ -97,6 +97,136 @@ async def list_guild_overrides(guild_id: int) -> list[dict[str, Any]]:
     return [dict(r) for r in rows]
 
 
+async def upsert_global_with_audit(
+    *,
+    flag_name: str,
+    state: str,
+    rollout_percent: int | None,
+    actor_id: int | None,
+    actor_type: str,
+    mutation_id: str,
+    prev_state: str | None,
+    prev_rollout_percent: int | None,
+    mutation_type: str,
+) -> None:
+    """Atomic: upsert feature_flag_global_overrides + write audit row.
+
+    Wraps both statements in a single asyncpg transaction so partial
+    failures roll back.  Called only from
+    :class:`services.rollout_mutation.RolloutMutationPipeline`.
+    """
+    async with pool.get().acquire() as conn, conn.transaction():
+        await conn.execute(
+            """
+            INSERT INTO feature_flag_global_overrides
+                (flag_name, state, rollout_percent, set_by, set_at)
+            VALUES ($1, $2, $3, $4, NOW())
+            ON CONFLICT (flag_name) DO UPDATE SET
+                state = EXCLUDED.state,
+                rollout_percent = EXCLUDED.rollout_percent,
+                set_by = EXCLUDED.set_by,
+                set_at = NOW()
+            """,
+            flag_name,
+            state,
+            rollout_percent,
+            actor_id,
+        )
+        await conn.execute(
+            """
+            INSERT INTO feature_flag_audit
+                (mutation_id, flag_name, scope, guild_id,
+                 prev_state, new_state,
+                 prev_rollout_percent, new_rollout_percent,
+                 actor_id, actor_type, mutation_type)
+            VALUES ($1, $2, 'global', NULL,
+                    $3, $4, $5, $6, $7, $8, $9)
+            """,
+            mutation_id,
+            flag_name,
+            prev_state,
+            state,
+            prev_rollout_percent,
+            rollout_percent,
+            actor_id,
+            actor_type,
+            mutation_type,
+        )
+
+
+async def upsert_guild_with_audit(
+    *,
+    flag_name: str,
+    guild_id: int,
+    state: str,
+    actor_id: int | None,
+    actor_type: str,
+    mutation_id: str,
+    prev_state: str | None,
+) -> None:
+    """Atomic: upsert feature_flag_guild_overrides + audit row."""
+    async with pool.get().acquire() as conn, conn.transaction():
+        await conn.execute(
+            """
+            INSERT INTO feature_flag_guild_overrides
+                (flag_name, guild_id, state, set_by, set_at)
+            VALUES ($1, $2, $3, $4, NOW())
+            ON CONFLICT (flag_name, guild_id) DO UPDATE SET
+                state = EXCLUDED.state,
+                set_by = EXCLUDED.set_by,
+                set_at = NOW()
+            """,
+            flag_name,
+            guild_id,
+            state,
+            actor_id,
+        )
+        await conn.execute(
+            """
+            INSERT INTO feature_flag_audit
+                (mutation_id, flag_name, scope, guild_id,
+                 prev_state, new_state,
+                 actor_id, actor_type, mutation_type)
+            VALUES ($1, $2, 'guild', $3, $4, $5, $6, $7, 'set_state')
+            """,
+            mutation_id,
+            flag_name,
+            guild_id,
+            prev_state,
+            state,
+            actor_id,
+            actor_type,
+        )
+
+
+async def get_audit_count(
+    *,
+    flag_name: str | None = None,
+    guild_id: int | None = None,
+) -> int:
+    """Return audit-row count, optionally filtered by flag and/or guild.
+
+    Used by tests + diagnostics to assert audit rows landed.
+    """
+    if flag_name is not None and guild_id is not None:
+        sql = (
+            "SELECT COUNT(*)::int AS n FROM feature_flag_audit "
+            "WHERE flag_name = $1 AND guild_id = $2"
+        )
+        row = await pool.get().fetchrow(sql, flag_name, guild_id)
+    elif flag_name is not None:
+        sql = "SELECT COUNT(*)::int AS n FROM feature_flag_audit WHERE flag_name = $1"
+        row = await pool.get().fetchrow(sql, flag_name)
+    elif guild_id is not None:
+        sql = "SELECT COUNT(*)::int AS n FROM feature_flag_audit WHERE guild_id = $1"
+        row = await pool.get().fetchrow(sql, guild_id)
+    else:
+        row = await pool.get().fetchrow(
+            "SELECT COUNT(*)::int AS n FROM feature_flag_audit",
+        )
+    return int(row["n"]) if row else 0
+
+
 async def delete_for_guild(guild_id: int) -> int:
     """Delete every per-guild override for ``guild_id``; preserve globals.
 
@@ -118,8 +248,11 @@ async def delete_for_guild(guild_id: int) -> int:
 
 __all__ = [
     "delete_for_guild",
+    "get_audit_count",
     "get_global_override",
     "get_guild_override",
     "list_global_overrides",
     "list_guild_overrides",
+    "upsert_global_with_audit",
+    "upsert_guild_with_audit",
 ]

--- a/tests/unit/feature_flags/test_rollout_mutation_pipeline.py
+++ b/tests/unit/feature_flags/test_rollout_mutation_pipeline.py
@@ -1,0 +1,509 @@
+"""Phase 2d PR-3 — RolloutMutationPipeline 7-step contract.
+
+Mocks the DB primitives so the pipeline can be exercised end-to-end
+without an asyncpg pool.  Covers:
+
+* Input validation: unknown flag, invalid state/tier/percent, scope
+  mismatch.
+* Authority: unknown actor_type rejected; platform_owner requires
+  actor_id.
+* DB write + audit row land atomically (the primitive returns; the
+  pipeline does not branch on its sub-steps).
+* Cache invalidation: clear_cache called with the right scope.
+* Event emission: catalogued events fired with full payload; emission
+  failure is swallowed (DB state is correct).
+* Rollback semantics: a follow-up mutation that flips state back
+  writes a NEW audit row — history is never mutated.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from core.runtime import feature_flags
+from services.rollout_mutation import (
+    EVT_ENVIRONMENT_TIER_CHANGED,
+    EVT_FEATURE_FLAGS_CHANGED,
+    EVT_ROLLOUT_ADVANCED,
+    InvalidRolloutPercentError,
+    InvalidStateError,
+    InvalidTierError,
+    RolloutMutationError,
+    RolloutMutationPipeline,
+    UnauthorizedRolloutMutationError,
+    UnknownFeatureFlagError,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    feature_flags._reset_for_tests()
+    feature_flags._register_builtins()
+    yield
+    feature_flags._reset_for_tests()
+
+
+@pytest.fixture
+def pipeline():
+    return RolloutMutationPipeline()
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_flag_state_rejects_unknown_flag(pipeline):
+    with pytest.raises(UnknownFeatureFlagError):
+        await pipeline.set_flag_state(
+            flag_name="does.not.exist",
+            scope="global",
+            state="on",
+            actor_id=1,
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_flag_state_rejects_invalid_state(pipeline):
+    with pytest.raises(InvalidStateError):
+        await pipeline.set_flag_state(
+            flag_name="bindings.primary",
+            scope="global",
+            state="maybe",
+            actor_id=1,
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_flag_state_rejects_guild_scope_without_guild_id(pipeline):
+    with pytest.raises(RolloutMutationError):
+        await pipeline.set_flag_state(
+            flag_name="bindings.primary",
+            scope="guild",
+            state="on",
+            actor_id=1,
+            guild_id=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_flag_state_rejects_global_scope_with_guild_id(pipeline):
+    with pytest.raises(RolloutMutationError):
+        await pipeline.set_flag_state(
+            flag_name="bindings.primary",
+            scope="global",
+            state="on",
+            actor_id=1,
+            guild_id=42,
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_rollout_percent_rejects_out_of_range(pipeline):
+    with pytest.raises(InvalidRolloutPercentError):
+        await pipeline.set_rollout_percent(
+            flag_name="bindings.primary",
+            percent=101,
+            actor_id=1,
+        )
+    with pytest.raises(InvalidRolloutPercentError):
+        await pipeline.set_rollout_percent(
+            flag_name="bindings.primary",
+            percent=-1,
+            actor_id=1,
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_environment_tier_rejects_unknown_tier(pipeline):
+    with pytest.raises(InvalidTierError):
+        await pipeline.set_environment_tier(
+            guild_id=42,
+            tier="ultra-canary",
+            actor_id=1,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Authority
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_actor_type_rejected(pipeline):
+    with pytest.raises(UnauthorizedRolloutMutationError):
+        await pipeline.set_flag_state(
+            flag_name="bindings.primary",
+            scope="global",
+            state="on",
+            actor_id=1,
+            actor_type="random_user",
+        )
+
+
+@pytest.mark.asyncio
+async def test_platform_owner_requires_actor_id(pipeline):
+    with pytest.raises(UnauthorizedRolloutMutationError):
+        await pipeline.set_flag_state(
+            flag_name="bindings.primary",
+            scope="global",
+            state="on",
+            actor_id=None,
+            actor_type="platform_owner",
+        )
+
+
+@pytest.mark.asyncio
+async def test_system_actor_allowed_without_actor_id(pipeline):
+    """CI seeds use actor_type='system' with actor_id=None."""
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.feature_flag_state.upsert_global_with_audit",
+            new_callable=AsyncMock,
+        ) as mock_upsert,
+        patch("core.events.bus.emit", new_callable=AsyncMock),
+    ):
+        result = await pipeline.set_flag_state(
+            flag_name="bindings.primary",
+            scope="global",
+            state="off",
+            actor_id=None,
+            actor_type="system",
+        )
+    assert result.event_emitted is True
+    mock_upsert.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# DB write + cache invalidation + event emission (set_flag_state global)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_flag_state_global_writes_db_clears_cache_emits_event(pipeline):
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value={"state": "off", "rollout_percent": None},
+        ),
+        patch(
+            "utils.db.feature_flag_state.upsert_global_with_audit",
+            new_callable=AsyncMock,
+        ) as mock_upsert,
+        patch.object(feature_flags, "clear_cache") as mock_clear,
+        patch("core.events.bus.emit", new_callable=AsyncMock) as mock_emit,
+    ):
+        result = await pipeline.set_flag_state(
+            flag_name="bindings.primary",
+            scope="global",
+            state="canary",
+            actor_id=99,
+        )
+    # DB write happened with correct prev/new transition
+    upsert_call = mock_upsert.await_args
+    assert upsert_call.kwargs["flag_name"] == "bindings.primary"
+    assert upsert_call.kwargs["state"] == "canary"
+    assert upsert_call.kwargs["prev_state"] == "off"
+    assert upsert_call.kwargs["mutation_type"] == "set_state"
+    # Cache cleared for that flag
+    mock_clear.assert_called_with(flag_name="bindings.primary")
+    # Event emitted with full payload
+    emit_call = mock_emit.await_args
+    assert emit_call.args[0] == EVT_FEATURE_FLAGS_CHANGED
+    payload = emit_call.kwargs
+    assert payload["flag_name"] == "bindings.primary"
+    assert payload["scope"] == "global"
+    assert payload["guild_id"] is None
+    assert payload["prev_state"] == "off"
+    assert payload["new_state"] == "canary"
+    assert payload["mutation_id"] == result.mutation_id
+    assert payload["actor_id"] == 99
+    assert payload["actor_type"] == "platform_owner"
+    assert "occurred_at" in payload
+    assert result.event_emitted is True
+
+
+# ---------------------------------------------------------------------------
+# DB write + cache + event (set_flag_state guild scope)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_flag_state_guild_clears_both_cache_scopes(pipeline):
+    """Per-guild set must invalidate both per-guild AND global cache entries."""
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_guild_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.feature_flag_state.upsert_guild_with_audit",
+            new_callable=AsyncMock,
+        ),
+        patch.object(feature_flags, "clear_cache") as mock_clear,
+        patch("core.events.bus.emit", new_callable=AsyncMock),
+    ):
+        await pipeline.set_flag_state(
+            flag_name="bindings.primary",
+            scope="guild",
+            state="on",
+            actor_id=99,
+            guild_id=42,
+        )
+    # clear_cache called twice: per-guild + global
+    assert mock_clear.call_count == 2
+    calls = {tuple(sorted(c.kwargs.items())) for c in mock_clear.call_args_list}
+    assert (("flag_name", "bindings.primary"), ("guild_id", 42)) in calls
+    assert (("flag_name", "bindings.primary"), ("guild_id", None)) in calls
+
+
+# ---------------------------------------------------------------------------
+# Event failure isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_event_emission_failure_does_not_raise(pipeline):
+    """A subscriber that raises must not break the mutation contract."""
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.feature_flag_state.upsert_global_with_audit",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "core.events.bus.emit",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("subscriber crashed"),
+        ),
+    ):
+        result = await pipeline.set_flag_state(
+            flag_name="bindings.primary",
+            scope="global",
+            state="on",
+            actor_id=1,
+        )
+    assert result.event_emitted is False
+    # DB write happened; the result reflects it
+    assert result.new_state == "on"
+
+
+# ---------------------------------------------------------------------------
+# DB failure does NOT invalidate cache or emit event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_db_failure_does_not_invalidate_cache_or_emit_event(pipeline):
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.feature_flag_state.upsert_global_with_audit",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("DB blip"),
+        ),
+        patch.object(feature_flags, "clear_cache") as mock_clear,
+        patch("core.events.bus.emit", new_callable=AsyncMock) as mock_emit,
+    ):
+        with pytest.raises(RuntimeError):
+            await pipeline.set_flag_state(
+                flag_name="bindings.primary",
+                scope="global",
+                state="on",
+                actor_id=1,
+            )
+    mock_clear.assert_not_called()
+    mock_emit.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# set_rollout_percent — clears every cached guild decision
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_rollout_percent_clears_all_guild_caches_for_flag(pipeline):
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value={"state": "production", "rollout_percent": 10},
+        ),
+        patch(
+            "utils.db.feature_flag_state.upsert_global_with_audit",
+            new_callable=AsyncMock,
+        ) as mock_upsert,
+        patch.object(feature_flags, "clear_cache") as mock_clear,
+        patch("core.events.bus.emit", new_callable=AsyncMock) as mock_emit,
+    ):
+        result = await pipeline.set_rollout_percent(
+            flag_name="bindings.primary",
+            percent=50,
+            actor_id=99,
+        )
+    upsert_call = mock_upsert.await_args
+    assert upsert_call.kwargs["rollout_percent"] == 50
+    assert upsert_call.kwargs["prev_rollout_percent"] == 10
+    assert upsert_call.kwargs["mutation_type"] == "set_rollout_percent"
+    # State is preserved on a rollout-percent-only change
+    assert upsert_call.kwargs["state"] == "production"
+    # Cache cleared for the flag (every guild)
+    mock_clear.assert_called_with(flag_name="bindings.primary")
+    # Event emitted: rollout.advanced
+    emit_call = mock_emit.await_args
+    assert emit_call.args[0] == EVT_ROLLOUT_ADVANCED
+    assert emit_call.kwargs["prev_percent"] == 10
+    assert emit_call.kwargs["new_percent"] == 50
+    assert result.new_rollout_percent == 50
+
+
+# ---------------------------------------------------------------------------
+# set_environment_tier — clears every cached entry for that guild
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_environment_tier_clears_full_guild_cache(pipeline):
+    with (
+        patch(
+            "utils.db.environment_tiers.get_tier",
+            new_callable=AsyncMock,
+            return_value="production",
+        ),
+        patch(
+            "utils.db.environment_tiers.upsert_with_audit",
+            new_callable=AsyncMock,
+        ) as mock_upsert,
+        patch.object(feature_flags, "clear_cache") as mock_clear,
+        patch("core.events.bus.emit", new_callable=AsyncMock) as mock_emit,
+    ):
+        result = await pipeline.set_environment_tier(
+            guild_id=42,
+            tier="canary",
+            actor_id=99,
+        )
+    upsert_call = mock_upsert.await_args
+    assert upsert_call.kwargs["guild_id"] == 42
+    assert upsert_call.kwargs["tier"] == "canary"
+    assert upsert_call.kwargs["prev_tier"] == "production"
+    # The whole guild's cache is dropped (any flag could be affected).
+    mock_clear.assert_called_with(guild_id=42)
+    emit_call = mock_emit.await_args
+    assert emit_call.args[0] == EVT_ENVIRONMENT_TIER_CHANGED
+    assert emit_call.kwargs["prev_tier"] == "production"
+    assert emit_call.kwargs["new_tier"] == "canary"
+    assert result.new_tier == "canary"
+
+
+# ---------------------------------------------------------------------------
+# Rollback semantics — history is append-only
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rollback_writes_new_audit_row_does_not_mutate_history(pipeline):
+    """Flipping a flag back to its previous state writes a fresh audit row."""
+    upserts: list[dict] = []
+
+    async def _capture_upsert(**kwargs):
+        upserts.append(dict(kwargs))
+
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            side_effect=[
+                None,  # first call: no row → prev=None
+                {"state": "on", "rollout_percent": None},  # rollback read
+            ],
+        ),
+        patch(
+            "utils.db.feature_flag_state.upsert_global_with_audit",
+            side_effect=_capture_upsert,
+        ),
+        patch("core.events.bus.emit", new_callable=AsyncMock),
+    ):
+        first = await pipeline.set_flag_state(
+            flag_name="bindings.primary",
+            scope="global",
+            state="on",
+            actor_id=1,
+        )
+        rollback = await pipeline.set_flag_state(
+            flag_name="bindings.primary",
+            scope="global",
+            state="off",
+            actor_id=1,
+        )
+    assert first.mutation_id != rollback.mutation_id
+    assert len(upserts) == 2
+    # Each upsert is a NEW row — they carry distinct mutation_ids
+    assert upserts[0]["mutation_id"] != upserts[1]["mutation_id"]
+    # Rollback's prev_state is the value the forward write set; the new
+    # state lands in the ``state`` kwarg (the column being written).
+    assert upserts[1]["prev_state"] == "on"
+    assert upserts[1]["state"] == "off"
+
+
+# ---------------------------------------------------------------------------
+# Catalogued event names — sanity check the literals haven't drifted
+# ---------------------------------------------------------------------------
+
+
+def test_catalogue_includes_phase_2d_event_names():
+    from core.events_catalogue import KNOWN_EVENTS
+
+    assert EVT_FEATURE_FLAGS_CHANGED in KNOWN_EVENTS
+    assert EVT_ROLLOUT_ADVANCED in KNOWN_EVENTS
+    assert EVT_ENVIRONMENT_TIER_CHANGED in KNOWN_EVENTS
+
+
+# ---------------------------------------------------------------------------
+# Minimal smoke: result type carries committed_at + mutation_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_result_carries_mutation_id_and_committed_at(pipeline):
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.feature_flag_state.upsert_global_with_audit",
+            new_callable=AsyncMock,
+        ),
+        patch("core.events.bus.emit", new_callable=AsyncMock),
+    ):
+        result = await pipeline.set_flag_state(
+            flag_name="bindings.primary",
+            scope="global",
+            state="on",
+            actor_id=99,
+        )
+    assert isinstance(result.mutation_id, str)
+    # UUID format: 36 chars with dashes
+    assert len(result.mutation_id) == 36
+    assert isinstance(result.committed_at, datetime)
+    assert result.committed_at.tzinfo == timezone.utc

--- a/tests/unit/invariants/test_feature_flag_audit_alignment.py
+++ b/tests/unit/invariants/test_feature_flag_audit_alignment.py
@@ -55,3 +55,90 @@ def test_actor_type_literals_match_pipeline_allowed_set():
     assert (
         db_check == python
     ), f"actor_type drift: db={sorted(db_check)} vs python={sorted(python)}"
+
+
+# ---------------------------------------------------------------------------
+# Per-mutation_type shape CHECK constraints
+# ---------------------------------------------------------------------------
+#
+# These tests pin the defense-in-depth invariants that make the single
+# ``feature_flag_audit`` table safe to host all three event sources.
+# They scan the migration for the specific CHECK clauses; a future
+# refactor that removes any of them fails CI here, signalling that the
+# corresponding pipeline contract no longer has DB-side enforcement.
+
+
+def _migration_text() -> str:
+    return _MIGRATION.read_text()
+
+
+def test_set_state_check_constraint_present():
+    """set_state rows must carry non-null new_state and avoid the sentinel."""
+    sql = _migration_text()
+    # Required clauses (independent of formatting)
+    assert "mutation_type <> 'set_state'" in sql
+    assert "new_state IS NOT NULL" in sql
+    assert "flag_name <> '__environment_tier__'" in sql
+
+
+def test_set_rollout_percent_check_constraint_present():
+    """set_rollout_percent rows must be global-scoped + carry new_rollout_percent."""
+    sql = _migration_text()
+    assert "mutation_type <> 'set_rollout_percent'" in sql
+    assert "scope = 'global'" in sql
+    assert "new_rollout_percent IS NOT NULL" in sql
+
+
+def test_set_tier_check_constraint_present():
+    """set_tier rows must use the sentinel + be guild-scoped + carry new_tier."""
+    sql = _migration_text()
+    assert "mutation_type <> 'set_tier'" in sql
+    assert "flag_name = '__environment_tier__'" in sql
+    assert "scope = 'guild'" in sql
+    assert "guild_id IS NOT NULL" in sql
+    assert "new_tier IS NOT NULL" in sql
+
+
+def test_set_tier_check_requires_unused_columns_to_be_null():
+    """set_tier rows must leave state + rollout columns NULL.
+
+    This is the contract that lets the single audit table host all
+    three event sources without ambiguity: a set_tier row never
+    accidentally looks like a state change.
+    """
+    sql = _migration_text()
+    # All five "leave-unused" assertions appear inside the set_tier CHECK
+    for null_clause in (
+        "prev_state IS NULL",
+        "new_state IS NULL",
+        "prev_rollout_percent IS NULL",
+        "new_rollout_percent IS NULL",
+    ):
+        assert null_clause in sql, f"missing CHECK clause: {null_clause}"
+
+
+# ---------------------------------------------------------------------------
+# Pipeline contract pins for the environment-tier sentinel
+# ---------------------------------------------------------------------------
+
+
+def test_environment_tier_audit_writes_sentinel_flag_name():
+    """utils.db.environment_tiers.upsert_with_audit hard-codes the sentinel.
+
+    Reads the SQL string in the Python primitive and asserts the
+    literal '__environment_tier__' appears in the INSERT.  A drift here
+    (sentinel renamed in Python but not SQL or vice versa) would let
+    set_tier rows escape the per-mutation_type CHECK constraint.
+    """
+    from pathlib import Path
+
+    src = (
+        Path(__file__).resolve().parents[3]
+        / "disbot"
+        / "utils"
+        / "db"
+        / "environment_tiers.py"
+    ).read_text()
+    assert "'__environment_tier__'" in src
+    assert "'set_tier'" in src
+    assert "'guild'" in src

--- a/tests/unit/invariants/test_feature_flag_audit_alignment.py
+++ b/tests/unit/invariants/test_feature_flag_audit_alignment.py
@@ -1,0 +1,57 @@
+"""Phase 2d PR-3 invariant — feature_flag_audit CHECK matches Python literals.
+
+Migration 025 ships CHECK constraints on
+``feature_flag_audit.scope``, ``mutation_type``, and ``actor_type``.
+The Python module :mod:`services.rollout_mutation` carries the
+corresponding constant sets.  This test pins both sides — extending
+one without the other should fail CI.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_MIGRATION = (
+    Path(__file__).resolve().parents[3]
+    / "disbot"
+    / "migrations"
+    / "025_feature_flag_audit.sql"
+)
+
+
+def _extract_check_literals(column: str) -> set[str]:
+    sql = _MIGRATION.read_text()
+    pattern = rf"CHECK\s*\(\s*{column}\s+IN\s*\(([^)]+)\)\s*\)"
+    match = re.search(pattern, sql)
+    assert match, f"could not locate {column} CHECK constraint in migration 025"
+    return {token.strip().strip("'\"") for token in match.group(1).split(",")}
+
+
+def test_scope_literals_match_python():
+    """``scope`` CHECK matches the Python ``Scope`` literal type."""
+    db_check = _extract_check_literals("scope")
+    expected = {"global", "guild"}
+    assert (
+        db_check == expected
+    ), f"scope CHECK drift: db={sorted(db_check)} vs expected={sorted(expected)}"
+
+
+def test_mutation_type_literals_match_python():
+    """``mutation_type`` CHECK matches the literal type used by the pipeline."""
+    db_check = _extract_check_literals("mutation_type")
+    expected = {"set_state", "set_rollout_percent", "set_tier"}
+    assert (
+        db_check == expected
+    ), f"mutation_type drift: db={sorted(db_check)} vs expected={sorted(expected)}"
+
+
+def test_actor_type_literals_match_pipeline_allowed_set():
+    """``actor_type`` CHECK matches RolloutMutationPipeline._ALLOWED_ACTOR_TYPES."""
+    from services.rollout_mutation import _ALLOWED_ACTOR_TYPES
+
+    db_check = _extract_check_literals("actor_type")
+    python = set(_ALLOWED_ACTOR_TYPES)
+    assert (
+        db_check == python
+    ), f"actor_type drift: db={sorted(db_check)} vs python={sorted(python)}"


### PR DESCRIPTION
## Summary

PR-3 of the finalized Phase 2 plan. **Stacked on PR #77** (rollout evaluator); merge order: #76 → #77 → #78 → #79.

Complete the Phase 2d feature-flag domain by shipping the write-side mutation pipeline, the audit table, and three catalogued events. Feature flags now have a full read+write lifecycle that mirrors `BindingMutationPipeline`'s 7-step contract.

## Review-fix commit (force-pushed)

Latest commit `fix(phase-2-pr-3): explicit per-mutation_type CHECK constraints + sentinel pins` addresses the review feedback on the environment-tier sentinel:

- **Three new SQL CHECK constraints** in migration 025 enforce the per-`mutation_type` shape contract at the DB layer (defense-in-depth):
  - `set_state` rows: `new_state` non-null, `flag_name != '__environment_tier__'`, tier columns NULL.
  - `set_rollout_percent` rows: `scope='global'`, `guild_id IS NULL`, `new_rollout_percent` non-null, sentinel forbidden, tier columns NULL.
  - `set_tier` rows: `flag_name='__environment_tier__'`, `scope='guild'`, `guild_id IS NOT NULL`, `new_tier IS NOT NULL`, state + rollout columns NULL.
- **Five new alignment tests** in `test_feature_flag_audit_alignment.py`:
  - Each per-`mutation_type` CHECK clause is present in the migration text.
  - `set_tier` specifically leaves state + rollout columns NULL.
  - `utils/db/environment_tiers.py` hard-codes the sentinel literal, `'set_tier'`, and `'guild'` — drift between SQL CHECK and the Python primitive would let rows escape both layers of enforcement.
- Events remain advisory; DB remains authoritative. No Discord admin command added.

## 7-step contract (mirrors `BindingMutationPipeline`)

1. **Input validation** — flag declared in registry; mutation type matches entry point; scope/state/tier tokens recognized.
2. **Authority validation** — `actor_type` within an explicit allowed set (`platform_owner`, `system`, `backfill`); `platform_owner` requires non-None `actor_id`.
3. **Read previous state** — for the audit row.
4. **DB write + audit** — single transaction via `utils.db.feature_flag_state` / `utils.db.environment_tiers`.
5. **Cache invalidation** — `feature_flags.clear_cache(...)` scoped to the affected flag and/or guild.
6. **Event emission** — advisory, post-commit, **never raises**.
7. **Return result** — `RolloutMutationResult` with `mutation_id` for cross-pipeline correlation.

## Three entrypoints

| Method | Scope | Affects | Event |
|---|---|---|---|
| `set_flag_state` | `global` or `guild` | `feature_flag_*_overrides.state` | `feature_flags.changed` |
| `set_rollout_percent` | `global` | `feature_flag_global_overrides.rollout_percent` | `rollout.advanced` |
| `set_environment_tier` | guild | `environment_tiers.tier` | `environment_tier.changed` |

## Sentinel contract (now DB-enforced)

The single `feature_flag_audit` table hosts all three event sources via the `mutation_type` discriminator + the `flag_name='__environment_tier__'` sentinel. The three new CHECK constraints make this contract impossible to violate even from a future caller that bypasses `RolloutMutationPipeline`. Specifically:

- A `set_tier` row that doesn't carry the sentinel is rejected at INSERT.
- A `set_state` row that uses the sentinel is rejected at INSERT.
- Cross-contamination between state/rollout/tier columns is rejected at INSERT.

## What changed

| Path | Change |
|---|---|
| `disbot/migrations/025_feature_flag_audit.sql` | NEW — append-only audit + `scope`/`mutation_type`/`actor_type` CHECK + three per-`mutation_type` shape CHECKs |
| `disbot/utils/db/feature_flag_state.py` | Extended: `upsert_global_with_audit`, `upsert_guild_with_audit`, `get_audit_count` |
| `disbot/utils/db/environment_tiers.py` | Extended: `upsert_with_audit` |
| `disbot/services/rollout_mutation.py` | NEW — `RolloutMutationPipeline` with three entrypoints, authority enforcement, advisory event emitters |
| `disbot/core/events_catalogue.py` | Extended: `feature_flags.changed`, `rollout.advanced`, `environment_tier.changed` added to `KNOWN_EVENTS` |
| `tests/unit/feature_flags/test_rollout_mutation_pipeline.py` | NEW — 14 tests covering input validation, authority, DB+cache+event flow, event failure isolation, rollback semantics, catalogued names |
| `tests/unit/invariants/test_feature_flag_audit_alignment.py` | NEW + extended — pins all CHECK literals + sentinel contract |

## Architectural boundaries preserved

- One runtime domain per PR — feature flags only; no participation, binding-backfill, or UI.
- DB writes + audit row are atomic (single asyncpg transaction).
- Cache invalidation happens **inline** in step 5 (the pipeline calls `feature_flags.clear_cache` directly). Event-driven invalidation is unnecessary here because the only consumer of the cache is in the same process.
- Event subscriber failure is logged with `mutation_id` and swallowed. **DB state is authoritative.**
- No top-level `core.runtime` imports added to cycle-sensitive files.
- Import-cycle regression test still green.
- **No Discord admin command in this PR.**

## Migrations

**025** — additive, forward-only, idempotent. The new CHECK constraints are amended into the same migration since 025 has not been deployed yet (the PR is still under review).

## Rollback strategy

- Revert the PR commit. Migration 025 is additive — leaving it after revert is safe (table becomes unused).
- Audit rows written by the pipeline remain visible (append-only — always intended).
- Subsequent rollback IS just another mutation: call `set_flag_state` again with the previous state. **History is never updated in place**; the rollback test explicitly verifies this.

## Tests run (after review fix)

```
python -m pytest tests/unit/feature_flags/ \
                 tests/unit/invariants/test_feature_flag_*.py \
                 tests/unit/invariants/test_environment_tier_alignment.py \
                 tests/unit/runtime/test_events_catalogue.py \
                 tests/unit/runtime/test_import_cycle_regression.py -q
# 61 passed (+5 new alignment/sentinel tests)

python -m pytest tests/ -q --ignore=tests/integration
# 1236 passed (full suite), 12 unrelated warnings

python -m ruff check disbot/   # clean (CI scope)
python -m black --check ...    # all changed files unchanged
python -m isort --check-only   # clean
```

## Manual Discord smoke

- [ ] Apply migration 025 to test DB
- [ ] From a Python REPL on the bot host:
  ```python
  from services.rollout_mutation import RolloutMutationPipeline
  p = RolloutMutationPipeline()
  await p.set_flag_state(
      flag_name='bindings.primary', scope='global',
      state='off', actor_id=<owner_id>,
  )
  ```
- [ ] Confirm `feature_flag_global_overrides` has the row and `feature_flag_audit` has a corresponding entry.
- [ ] Test sentinel CHECK: try to insert a malformed set_tier row directly:
  ```sql
  INSERT INTO feature_flag_audit
      (mutation_id, flag_name, scope, guild_id, mutation_type)
  VALUES (gen_random_uuid(), 'bindings.primary', 'guild', 42, 'set_tier');
  ```
  Expected: CHECK violation (set_tier requires flag_name='__environment_tier__' and new_tier non-null).
- [ ] Test rollback: call `set_flag_state` with the prior state; verify a NEW audit row is added rather than the existing one being updated.

## Intentionally deferred

- **Discord admin command for setting flags** — DB/script-only in PR-3.
- **Subscriber wiring for the three new events** — PR-4 (read-source arbitration) and PR-7 (binding canary) will subscribe in their own PRs.