### PR TITLE
Phase 2.4: central read-source arbitration with ConfigReadResult

### DIFF
--- a/disbot/core/runtime/config_arbitration.py
+++ b/disbot/core/runtime/config_arbitration.py
@@ -1,0 +1,289 @@
+"""Central read-source arbitration — Phase 2 PR-4.
+
+The seam between subsystems and "legacy settings vs typed bindings".
+Every config read for a migrated key flows through :func:`read_config`,
+which consults the feature flag evaluator to decide whether to serve
+the binding or the legacy setting, and returns a typed
+:class:`ConfigReadResult` that carries the full provenance.
+
+Why one central helper:
+
+* Per-cog branching on ``is_enabled("bindings.primary", ...)`` would
+  scatter the transition logic and make rollback a per-cog change.
+  Collapsing it into one helper means the canary flip (PR-7) and the
+  eventual production flip are single-line changes in one place.
+* Provenance (``source``, ``binding_status``, ``flag_state``,
+  ``diagnostics``) is essential for setup-wizard previews, migration
+  debugging, and the ``!platform consistency`` view that PR-10 will
+  unify.
+
+Hard rules:
+
+* **No cog branches directly on ``is_enabled("bindings.primary", ...)``.**
+  Only this module is allowed to.  An AST scan will pin this once
+  there are real callers (the scan is deferred until PR-7's
+  read-site swaps so there is something to enforce against).
+* This module does NOT mutate state.  Reads only.
+* This module does NOT cache; it leans on the binding and feature-flag
+  layers' caches.  Adding a third cache here would multiply
+  invalidation paths for no benefit.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+logger = logging.getLogger("bot.config_arbitration")
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+Source = Literal["legacy", "binding", "fallback", "missing"]
+BindingStatus = Literal["bound", "unresolved", "missing", "invalid", "n/a"]
+FlagState = Literal["on", "off", "n/a"]
+
+
+@dataclass(frozen=True)
+class ConfigReadResult:
+    """Typed snapshot of a single arbitrated config read.
+
+    Fields:
+
+    value:
+        The resolved value (typically an ``int`` for channel/role IDs,
+        or ``str`` for free-form settings, or ``None`` when missing).
+    source:
+        Where ``value`` came from in the arbitration ladder.
+    binding_status:
+        Binding-side status if the binding was consulted.  ``n/a`` when
+        flag was OFF (binding never consulted).
+    flag_state:
+        Effective state of ``bindings.primary`` for this guild.
+    diagnostics:
+        Free-form short strings explaining notable transitions
+        (e.g. ``"binding MISSING, fell back to legacy"``).  Surfaced in
+        ``!platform consistency`` in PR-10.
+    """
+
+    value: Any
+    source: Source
+    binding_status: BindingStatus
+    flag_state: FlagState
+    diagnostics: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Counters — used by the diagnostics provider
+# ---------------------------------------------------------------------------
+
+# Tallied per-call so the consistency view can show "fallback rate ≠ 0
+# means a canary guild has a binding that's MISSING or INVALID".  Three
+# parallel dimensions:
+#   * by_source: where the value actually came from
+#   * by_binding_status: the binding row's last-known status
+#   * by_flag_state: the feature-flag evaluator's decision for this guild
+_BY_SOURCE: dict[str, int] = {"legacy": 0, "binding": 0, "fallback": 0, "missing": 0}
+_BY_BINDING_STATUS: dict[str, int] = {
+    "bound": 0,
+    "unresolved": 0,
+    "missing": 0,
+    "invalid": 0,
+    "n/a": 0,
+}
+_BY_FLAG_STATE: dict[str, int] = {"on": 0, "off": 0, "n/a": 0}
+_CALLS_TOTAL = 0
+
+
+def _bump_counters(result: ConfigReadResult) -> None:
+    global _CALLS_TOTAL
+    _CALLS_TOTAL += 1
+    _BY_SOURCE[result.source] = _BY_SOURCE.get(result.source, 0) + 1
+    _BY_BINDING_STATUS[result.binding_status] = (
+        _BY_BINDING_STATUS.get(result.binding_status, 0) + 1
+    )
+    _BY_FLAG_STATE[result.flag_state] = _BY_FLAG_STATE.get(result.flag_state, 0) + 1
+
+
+def _reset_counters_for_tests() -> None:
+    """Test helper — zero all counters."""
+    global _CALLS_TOTAL
+    _CALLS_TOTAL = 0
+    for d in (_BY_SOURCE, _BY_BINDING_STATUS, _BY_FLAG_STATE):
+        for k in list(d):
+            d[k] = 0
+
+
+def counters_snapshot() -> dict[str, Any]:
+    """Snapshot of the arbitration counters; called by the diag provider."""
+    return {
+        "calls_total": _CALLS_TOTAL,
+        "by_source": dict(_BY_SOURCE),
+        "by_binding_status": dict(_BY_BINDING_STATUS),
+        "by_flag_state": dict(_BY_FLAG_STATE),
+    }
+
+
+# ---------------------------------------------------------------------------
+# read_config — the central arbiter
+# ---------------------------------------------------------------------------
+
+
+async def read_config(
+    guild_id: int,
+    subsystem: str,
+    binding_name: str,
+    legacy_key: str,
+    *,
+    binding_kind: str | None = None,
+) -> ConfigReadResult:
+    """Resolve a config value via the bindings → legacy ladder.
+
+    Resolution:
+
+    1. Consult ``is_enabled("bindings.primary", guild_id)``:
+       - If **OFF** → read legacy directly, source=``"legacy"``.
+       - If **ON**  → fall through to step 2.
+    2. Read the binding via :func:`core.runtime.bindings.get_binding`.
+       - If ``status == BOUND`` and a target is present → return the
+         binding's ``target_id``, source=``"binding"``.
+       - Else → fall through to step 3 (fallback).
+    3. Read legacy as a fallback; return it with source=``"fallback"``
+       and the binding's actual status in ``binding_status``.
+    4. If neither legacy nor binding produced a value → source=``"missing"``.
+
+    Failure handling:
+
+    * If ``is_enabled`` raises, treat as flag OFF (safest default —
+      reads continue from legacy).  Logged once per call.
+    * If the binding read raises, log and fall through to legacy.
+    * Legacy read failures propagate (the legacy DB layer is allowed
+      to surface its own errors — arbitration only catches binding /
+      flag failures because those are the new code).
+    """
+    # Local imports to keep this file out of any module-load cycles.
+    from core.runtime import bindings as bindings_runtime
+    from core.runtime import feature_flags
+    from utils.db import settings as settings_db
+
+    diagnostics: list[str] = []
+
+    # Step 1: feature flag gate.
+    try:
+        primary_on = await feature_flags.is_enabled(
+            "bindings.primary",
+            guild_id,
+        )
+    except Exception as exc:  # noqa: BLE001 — arbitration must not raise
+        logger.warning(
+            "config_arbitration: is_enabled raised for guild=%d (%r); "
+            "treating bindings.primary as OFF",
+            guild_id,
+            exc,
+        )
+        primary_on = False
+        diagnostics.append(f"is_enabled raised: {type(exc).__name__}")
+
+    if not primary_on:
+        legacy_value = await _read_legacy(settings_db, guild_id, legacy_key)
+        result = ConfigReadResult(
+            value=legacy_value,
+            source="legacy",
+            binding_status="n/a",
+            flag_state="off",
+            diagnostics=diagnostics,
+        )
+        _bump_counters(result)
+        return result
+
+    # Step 2: binding read.
+    binding_value = None
+    binding_status: BindingStatus = "n/a"
+    try:
+        bv = await bindings_runtime.get_binding(guild_id, subsystem, binding_name)
+        binding_status = bv.status.value  # type: ignore[assignment]
+        if bv.is_bound and bv.target_id is not None:
+            result = ConfigReadResult(
+                value=bv.target_id,
+                source="binding",
+                binding_status=binding_status,
+                flag_state="on",
+                diagnostics=diagnostics,
+            )
+            _bump_counters(result)
+            return result
+        binding_value = bv.target_id
+        diagnostics.append(f"binding not bound (status={binding_status})")
+    except Exception as exc:  # noqa: BLE001 — arbitration must not raise
+        logger.warning(
+            "config_arbitration: get_binding raised for "
+            "guild=%d subsystem=%r binding=%r (%r); falling back to legacy",
+            guild_id,
+            subsystem,
+            binding_name,
+            exc,
+        )
+        diagnostics.append(f"get_binding raised: {type(exc).__name__}")
+    del binding_value  # currently unused, reserved for future provenance
+
+    # Step 3: fallback to legacy.
+    legacy_value = await _read_legacy(settings_db, guild_id, legacy_key)
+    if legacy_value is None:
+        result = ConfigReadResult(
+            value=None,
+            source="missing",
+            binding_status=binding_status,
+            flag_state="on",
+            diagnostics=diagnostics,
+        )
+    else:
+        result = ConfigReadResult(
+            value=legacy_value,
+            source="fallback",
+            binding_status=binding_status,
+            flag_state="on",
+            diagnostics=diagnostics,
+        )
+    _bump_counters(result)
+    return result
+
+
+async def _read_legacy(settings_db, guild_id: int, legacy_key: str) -> Any | None:
+    """Best-effort legacy read; returns ``None`` for missing/empty."""
+    # binding_kind is reserved for the future case where legacy keys
+    # encode parsing rules (channel IDs vs comma-separated lists);
+    # current callers all want a simple string-or-None.
+    raw = await settings_db.get_setting(guild_id, legacy_key, default="")
+    if not raw:
+        return None
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics provider registration (registers at import time)
+# ---------------------------------------------------------------------------
+
+
+def _consistency_snapshot() -> dict[str, Any]:
+    """Snapshot for ``!platform consistency`` (full surface lands in PR-10)."""
+    return {
+        "arbitration": counters_snapshot(),
+    }
+
+
+def _register_diagnostics() -> None:
+    from services import diagnostics_service
+
+    diagnostics_service.register("config_arbitration", _consistency_snapshot)
+
+
+_register_diagnostics()
+
+
+__all__ = [
+    "ConfigReadResult",
+    "counters_snapshot",
+    "read_config",
+]

--- a/disbot/core/runtime/config_arbitration.py
+++ b/disbot/core/runtime/config_arbitration.py
@@ -17,6 +17,42 @@ Why one central helper:
   debugging, and the ``!platform consistency`` view that PR-10 will
   unify.
 
+Return value typing — read carefully:
+
+* The **binding** path returns ``BindingValue.target_id``
+  (``int | None``).  Binding rows store typed snowflakes for
+  channel/role/etc.
+* The **legacy** and **fallback** paths return the raw legacy string
+  (``str``) from ``guild_settings``.  This is intentional — the
+  legacy KV table stores everything as strings.
+* PR-7's per-subsystem wrappers (e.g. ``get_xp_announce_channel``)
+  will coerce ``str`` → ``int`` (or whatever the binding kind
+  requires) so callers receive a uniform type.  Callers of
+  :func:`read_config` directly MUST handle both shapes (or wait for
+  the per-subsystem wrappers in PR-7).
+
+Source semantics (used by ``!platform consistency``):
+
+* ``source='legacy'`` — value came from legacy KV.  Flag was OFF.
+* ``source='binding'`` — value came from a bound subsystem_bindings
+  row.  Flag was ON and the binding was BOUND.
+* ``source='fallback'`` — flag ON but binding not BOUND; legacy
+  fallback supplied a non-empty value.
+* ``source='missing'`` — neither side produced a value.  Returned
+  whenever the resolved value is ``None``, regardless of flag state;
+  ``flag_state`` and ``binding_status`` carry the distinguishing
+  context.  This makes "how many of my guilds have neither legacy
+  nor binding configured?" a single counter query.
+
+Binding-kind verification (PR-4 enhancement):
+
+* When ``binding_kind`` is provided, ``read_config`` verifies that the
+  resolved binding's kind matches.  A mismatch (schema drift) is
+  treated as if the binding were INVALID — the result short-circuits
+  to fallback / missing and ``diagnostics`` records the drift.  This
+  surfaces wrong-kind bindings early instead of silently returning
+  the wrong shape of value.
+
 Hard rules:
 
 * **No cog branches directly on ``is_enabled("bindings.primary", ...)``.**
@@ -144,20 +180,22 @@ async def read_config(
     Resolution:
 
     1. Consult ``is_enabled("bindings.primary", guild_id)``:
-       - If **OFF** → read legacy directly, source=``"legacy"``.
+       - If **OFF** → read legacy.  Return ``source='legacy'`` if a
+         value is present; ``source='missing'`` if not.
        - If **ON**  → fall through to step 2.
     2. Read the binding via :func:`core.runtime.bindings.get_binding`.
-       - If ``status == BOUND`` and a target is present → return the
-         binding's ``target_id``, source=``"binding"``.
-       - Else → fall through to step 3 (fallback).
-    3. Read legacy as a fallback; return it with source=``"fallback"``
-       and the binding's actual status in ``binding_status``.
-    4. If neither legacy nor binding produced a value → source=``"missing"``.
+       - If ``status == BOUND`` and a target is present AND (when
+         ``binding_kind`` was supplied) the binding's declared kind
+         matches → return ``target_id`` with ``source='binding'``.
+       - If kinds mismatch → treat as INVALID; record a diagnostic
+         and fall through to fallback.
+       - Else → fall through to step 3.
+    3. Read legacy as a fallback.  ``source='fallback'`` if legacy
+       supplies a value, ``source='missing'`` if not.
 
     Failure handling:
 
-    * If ``is_enabled`` raises, treat as flag OFF (safest default —
-      reads continue from legacy).  Logged once per call.
+    * If ``is_enabled`` raises, treat as flag OFF.  Logged.
     * If the binding read raises, log and fall through to legacy.
     * Legacy read failures propagate (the legacy DB layer is allowed
       to surface its own errors — arbitration only catches binding /
@@ -188,9 +226,14 @@ async def read_config(
 
     if not primary_on:
         legacy_value = await _read_legacy(settings_db, guild_id, legacy_key)
+        # source='missing' when the resolved value is None, regardless of
+        # which side we consulted — this makes the !platform consistency
+        # "how many guilds have nothing configured?" query a single
+        # counter read.
+        source: Source = "missing" if legacy_value is None else "legacy"
         result = ConfigReadResult(
             value=legacy_value,
-            source="legacy",
+            source=source,
             binding_status="n/a",
             flag_state="off",
             diagnostics=diagnostics,
@@ -199,12 +242,31 @@ async def read_config(
         return result
 
     # Step 2: binding read.
-    binding_value = None
     binding_status: BindingStatus = "n/a"
     try:
         bv = await bindings_runtime.get_binding(guild_id, subsystem, binding_name)
         binding_status = bv.status.value  # type: ignore[assignment]
-        if bv.is_bound and bv.target_id is not None:
+        # Verify kind matches if the caller declared an expected kind.
+        # Schema drift here is rare but high-impact (a "channel" caller
+        # would otherwise get a role snowflake) so we surface it
+        # explicitly rather than silently returning the wrong shape.
+        kind_mismatch = False
+        if binding_kind is not None and bv.kind.value != binding_kind:
+            kind_mismatch = True
+            diagnostics.append(
+                f"binding kind drift: expected={binding_kind} "
+                f"actual={bv.kind.value}",
+            )
+            logger.warning(
+                "config_arbitration: binding kind drift for "
+                "guild=%d subsystem=%r binding=%r — expected=%s actual=%s",
+                guild_id,
+                subsystem,
+                binding_name,
+                binding_kind,
+                bv.kind.value,
+            )
+        if bv.is_bound and bv.target_id is not None and not kind_mismatch:
             result = ConfigReadResult(
                 value=bv.target_id,
                 source="binding",
@@ -214,8 +276,8 @@ async def read_config(
             )
             _bump_counters(result)
             return result
-        binding_value = bv.target_id
-        diagnostics.append(f"binding not bound (status={binding_status})")
+        if not kind_mismatch:
+            diagnostics.append(f"binding not bound (status={binding_status})")
     except Exception as exc:  # noqa: BLE001 — arbitration must not raise
         logger.warning(
             "config_arbitration: get_binding raised for "
@@ -226,7 +288,6 @@ async def read_config(
             exc,
         )
         diagnostics.append(f"get_binding raised: {type(exc).__name__}")
-    del binding_value  # currently unused, reserved for future provenance
 
     # Step 3: fallback to legacy.
     legacy_value = await _read_legacy(settings_db, guild_id, legacy_key)
@@ -251,10 +312,13 @@ async def read_config(
 
 
 async def _read_legacy(settings_db, guild_id: int, legacy_key: str) -> Any | None:
-    """Best-effort legacy read; returns ``None`` for missing/empty."""
-    # binding_kind is reserved for the future case where legacy keys
-    # encode parsing rules (channel IDs vs comma-separated lists);
-    # current callers all want a simple string-or-None.
+    """Best-effort legacy read; returns ``None`` for missing/empty.
+
+    The legacy KV table stores everything as strings; this function
+    returns the raw string (or ``None`` for an empty/missing row).
+    PR-7's per-subsystem wrappers will coerce ``str`` → typed values
+    so callers do not have to know the storage format.
+    """
     raw = await settings_db.get_setting(guild_id, legacy_key, default="")
     if not raw:
         return None

--- a/tests/unit/config_arbitration/test_read_config.py
+++ b/tests/unit/config_arbitration/test_read_config.py
@@ -92,6 +92,18 @@ async def test_flag_off_returns_legacy_value_binding_not_consulted():
 
 @pytest.mark.asyncio
 async def test_flag_off_legacy_missing_returns_none_with_missing_source():
+    """Flag OFF + legacy empty → source='missing' (PR-4 review correction).
+
+    The earlier behavior returned ``source='legacy'`` because legacy
+    was where the ``None`` came from.  The review pointed out that
+    this makes the ``!platform consistency`` "how many guilds have
+    nothing configured?" query painful — operators would have to
+    filter by ``(source=='legacy' AND value is None)`` instead of a
+    single counter.  ``source='missing'`` is now returned whenever
+    the resolved value is ``None``, regardless of which side produced
+    it; ``flag_state`` and ``binding_status`` carry the distinguishing
+    context.
+    """
     with (
         patch(
             "core.runtime.feature_flags.is_enabled",
@@ -111,11 +123,114 @@ async def test_flag_off_legacy_missing_returns_none_with_missing_source():
             legacy_key="xp_announce_channel",
         )
     assert result.value is None
-    # With flag OFF + legacy empty, source is legacy (we still consulted
-    # legacy and that's where the "none" came from).  source='missing'
-    # is reserved for the flag-ON path where neither side produced a
-    # value — semantically the distinction matters for diagnostics.
-    assert result.source == "legacy"
+    assert result.source == "missing"
+    assert result.flag_state == "off"
+    assert result.binding_status == "n/a"
+
+
+# ---------------------------------------------------------------------------
+# Binding-kind verification (PR-4 enhancement)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_binding_kind_match_returns_binding_source():
+    """Caller-declared kind matches the binding's declared kind → binding wins."""
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "core.runtime.bindings.get_binding",
+            new_callable=AsyncMock,
+            return_value=_bv(target_id=999, status=ResourceStatus.BOUND),
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+        ) as mock_legacy,
+    ):
+        result = await read_config(
+            guild_id=1,
+            subsystem="xp",
+            binding_name="announce_channel",
+            legacy_key="xp_announce_channel",
+            binding_kind="channel",
+        )
+    assert result.value == 999
+    assert result.source == "binding"
+    assert result.binding_status == "bound"
+    mock_legacy.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_binding_kind_mismatch_falls_back_with_drift_diagnostic():
+    """Caller asked for 'role' but the binding declares 'channel' → fallback.
+
+    A kind drift means schema and runtime disagree (a future schema
+    change reshaped the binding); the safest behavior is to treat the
+    binding as INVALID and fall back to legacy.  The drift is recorded
+    in ``diagnostics`` so ``!platform consistency`` can surface it.
+    """
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "core.runtime.bindings.get_binding",
+            new_callable=AsyncMock,
+            return_value=_bv(target_id=999, status=ResourceStatus.BOUND),
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="legacy-value",
+        ),
+    ):
+        result = await read_config(
+            guild_id=1,
+            subsystem="xp",
+            binding_name="announce_channel",
+            legacy_key="xp_announce_channel",
+            binding_kind="role",
+        )
+    assert result.value == "legacy-value"
+    assert result.source == "fallback"
+    assert any("binding kind drift" in d for d in result.diagnostics)
+
+
+@pytest.mark.asyncio
+async def test_binding_kind_omitted_does_not_verify():
+    """When no expected kind is supplied, the binding wins as before."""
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "core.runtime.bindings.get_binding",
+            new_callable=AsyncMock,
+            return_value=_bv(target_id=999, status=ResourceStatus.BOUND),
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+        ),
+    ):
+        result = await read_config(
+            guild_id=1,
+            subsystem="xp",
+            binding_name="announce_channel",
+            legacy_key="xp_announce_channel",
+            # binding_kind intentionally omitted
+        )
+    assert result.source == "binding"
+    assert not any("kind drift" in d for d in result.diagnostics)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/config_arbitration/test_read_config.py
+++ b/tests/unit/config_arbitration/test_read_config.py
@@ -1,0 +1,343 @@
+"""Phase 2 PR-4 — central read-source arbitration.
+
+Verifies the resolution ladder for ``read_config``:
+
+* flag OFF → legacy (binding never consulted)
+* flag ON + binding BOUND → binding value
+* flag ON + binding MISSING/INVALID/UNRESOLVED → legacy fallback
+* flag ON + neither legacy nor binding produced a value → missing
+* failure isolation: ``is_enabled`` raising falls back to legacy;
+  ``get_binding`` raising falls back to legacy.
+
+Also pins:
+* No cache layer added by the arbitration helper itself.
+* Counters accumulate for the diagnostics provider.
+* ``ConfigReadResult`` carries provenance fields needed by setup-wizard
+  previews and the future ``!platform consistency`` view.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from core.resources.status import ResourceStatus
+from core.runtime import config_arbitration
+from core.runtime.bindings import BindingValue
+from core.runtime.config_arbitration import ConfigReadResult, read_config
+from core.runtime.subsystem_schema import BindingKind
+
+
+@pytest.fixture(autouse=True)
+def _reset_counters():
+    config_arbitration._reset_counters_for_tests()
+    yield
+    config_arbitration._reset_counters_for_tests()
+
+
+def _bv(*, target_id: int | None, status: ResourceStatus) -> BindingValue:
+    return BindingValue(
+        guild_id=1,
+        subsystem="xp",
+        binding_name="announce_channel",
+        kind=BindingKind.CHANNEL,
+        target_id=target_id,
+        status=status,
+        last_validated_at=datetime.now(timezone.utc),
+        last_updated_at=datetime.now(timezone.utc),
+        version=1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Flag OFF → legacy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_flag_off_returns_legacy_value_binding_not_consulted():
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "core.runtime.bindings.get_binding",
+            new_callable=AsyncMock,
+        ) as mock_binding,
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="12345",
+        ),
+    ):
+        result = await read_config(
+            guild_id=1,
+            subsystem="xp",
+            binding_name="announce_channel",
+            legacy_key="xp_announce_channel",
+        )
+    assert result == ConfigReadResult(
+        value="12345",
+        source="legacy",
+        binding_status="n/a",
+        flag_state="off",
+        diagnostics=[],
+    )
+    mock_binding.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_flag_off_legacy_missing_returns_none_with_missing_source():
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="",
+        ),
+    ):
+        result = await read_config(
+            guild_id=1,
+            subsystem="xp",
+            binding_name="announce_channel",
+            legacy_key="xp_announce_channel",
+        )
+    assert result.value is None
+    # With flag OFF + legacy empty, source is legacy (we still consulted
+    # legacy and that's where the "none" came from).  source='missing'
+    # is reserved for the flag-ON path where neither side produced a
+    # value — semantically the distinction matters for diagnostics.
+    assert result.source == "legacy"
+
+
+# ---------------------------------------------------------------------------
+# Flag ON + binding BOUND
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_flag_on_binding_bound_returns_binding_value():
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "core.runtime.bindings.get_binding",
+            new_callable=AsyncMock,
+            return_value=_bv(target_id=999, status=ResourceStatus.BOUND),
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+        ) as mock_legacy,
+    ):
+        result = await read_config(
+            guild_id=1,
+            subsystem="xp",
+            binding_name="announce_channel",
+            legacy_key="xp_announce_channel",
+        )
+    assert result.value == 999
+    assert result.source == "binding"
+    assert result.binding_status == "bound"
+    assert result.flag_state == "on"
+    # Legacy must not be consulted when binding is BOUND
+    mock_legacy.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Flag ON + binding MISSING/INVALID/UNRESOLVED → fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "binding_status",
+    [
+        ResourceStatus.MISSING,
+        ResourceStatus.INVALID,
+        ResourceStatus.UNRESOLVED,
+    ],
+)
+@pytest.mark.asyncio
+async def test_flag_on_binding_not_bound_falls_back_to_legacy(binding_status):
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "core.runtime.bindings.get_binding",
+            new_callable=AsyncMock,
+            return_value=_bv(target_id=None, status=binding_status),
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="legacy-value",
+        ),
+    ):
+        result = await read_config(
+            guild_id=1,
+            subsystem="xp",
+            binding_name="announce_channel",
+            legacy_key="xp_announce_channel",
+        )
+    assert result.value == "legacy-value"
+    assert result.source == "fallback"
+    assert result.binding_status == binding_status.value
+    assert result.flag_state == "on"
+    assert any("binding not bound" in d for d in result.diagnostics)
+
+
+@pytest.mark.asyncio
+async def test_flag_on_both_empty_returns_missing():
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "core.runtime.bindings.get_binding",
+            new_callable=AsyncMock,
+            return_value=_bv(target_id=None, status=ResourceStatus.UNRESOLVED),
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="",
+        ),
+    ):
+        result = await read_config(
+            guild_id=1,
+            subsystem="xp",
+            binding_name="announce_channel",
+            legacy_key="xp_announce_channel",
+        )
+    assert result.value is None
+    assert result.source == "missing"
+
+
+# ---------------------------------------------------------------------------
+# Failure isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_is_enabled_failure_falls_back_to_legacy_off_path():
+    """If is_enabled raises, arbitration treats the flag as OFF."""
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("evaluator crashed"),
+        ),
+        patch(
+            "core.runtime.bindings.get_binding",
+            new_callable=AsyncMock,
+        ) as mock_binding,
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="legacy-value",
+        ),
+    ):
+        result = await read_config(
+            guild_id=1,
+            subsystem="xp",
+            binding_name="announce_channel",
+            legacy_key="xp_announce_channel",
+        )
+    assert result.source == "legacy"
+    assert result.flag_state == "off"
+    assert any("is_enabled raised" in d for d in result.diagnostics)
+    mock_binding.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_binding_failure_falls_back_to_legacy():
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "core.runtime.bindings.get_binding",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("DB blip"),
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="legacy-value",
+        ),
+    ):
+        result = await read_config(
+            guild_id=1,
+            subsystem="xp",
+            binding_name="announce_channel",
+            legacy_key="xp_announce_channel",
+        )
+    assert result.value == "legacy-value"
+    assert result.source == "fallback"
+    assert result.flag_state == "on"
+    assert any("get_binding raised" in d for d in result.diagnostics)
+
+
+# ---------------------------------------------------------------------------
+# Counters + diagnostics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_counters_increment_per_call():
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="x",
+        ),
+    ):
+        await read_config(
+            guild_id=1,
+            subsystem="xp",
+            binding_name="announce_channel",
+            legacy_key="xp_announce_channel",
+        )
+        await read_config(
+            guild_id=2,
+            subsystem="economy",
+            binding_name="log_channel",
+            legacy_key="economy_log_channel",
+        )
+    snap = config_arbitration.counters_snapshot()
+    assert snap["calls_total"] == 2
+    assert snap["by_source"]["legacy"] == 2
+    assert snap["by_flag_state"]["off"] == 2
+
+
+def test_diagnostics_provider_registered():
+    """!platform consistency consumer reads the counters via this provider."""
+    from services import diagnostics_service
+
+    snap = diagnostics_service.snapshot("config_arbitration")
+    assert "arbitration" in snap
+    assert "calls_total" in snap["arbitration"]
+    assert "by_source" in snap["arbitration"]


### PR DESCRIPTION
## Summary

PR-4 of the finalized Phase 2 plan. **Stacked on PR #78** (rollout mutation pipeline); merge order: #76 → #77 → #78 → #79.

Ship the seam between subsystems and "legacy settings vs typed bindings" so the binding canary flip in PR-7 is a **single-line change in one place**. No cog read site touched in this PR.

## Review-fix commit (force-pushed)

Latest commit `fix(phase-2-pr-4): verify binding_kind, document coercion, missing-source semantics` addresses the three review items:

1. **`binding_kind` is now used** to surface schema drift early. When the caller supplies an expected kind, `read_config` verifies it against the binding's declared kind; a mismatch is treated as INVALID, falls back to legacy, and records a `"binding kind drift: expected=X actual=Y"` diagnostic. A `'role'` caller against a `'channel'` binding will no longer silently return the wrong shape of value.
2. **Type asymmetry documented.** The module docstring now states explicitly that the binding path returns `int|None` (`BindingValue.target_id`) while the legacy/fallback path returns the raw legacy `str`. PR-7's per-subsystem wrappers will coerce `str` → typed values; callers of `read_config` directly must handle both shapes until then.
3. **`source='missing'` semantics sharpened.** Previously: flag OFF + legacy empty returned `source='legacy'` with `value=None`. Now: `source='missing'` whenever the resolved value is `None`, regardless of flag state. This makes `!platform consistency`'s "how many guilds have nothing configured?" query a single counter read.

Updated tests:
- 3 new tests: `test_binding_kind_match_returns_binding_source`, `test_binding_kind_mismatch_falls_back_with_drift_diagnostic`, `test_binding_kind_omitted_does_not_verify`.
- 1 existing test updated: `test_flag_off_legacy_missing_returns_none_with_missing_source` now asserts `source='missing'` (was `source='legacy'`).

## Why this PR is small and risk-free

- Adds one helper file + one test file + one diagnostics provider.
- No subsystem read site touched. PR-7 swaps cog calls to this helper in one diff; until then the helper is unused.
- No new domain. Pure compatibility layer over feature_flags + bindings + legacy settings.

## Architectural decision

Collapse `if bindings.primary then read binding else read legacy` into ONE central helper. Per-cog branching would scatter transition logic and turn rollback into N changes. The arbitration helper makes rollback a flag flip in one place.

## Resolution ladder

1. `is_enabled("bindings.primary", guild_id)` — **OFF** → legacy (`source='legacy'` if a value is present, `source='missing'` if not)
2. `get_binding(...)` — `BOUND` and (if supplied) declared kind matches expected `binding_kind` → binding `target_id` (`source='binding'`)
3. kind mismatch OR not bound → fall through to step 4
4. legacy as fallback (`source='fallback'` if non-empty, `source='missing'` if empty)

## Failure handling (intentional)

- `is_enabled` raising → treated as flag OFF (safest). Diagnostics records `"is_enabled raised: <ExceptionType>"`.
- `get_binding` raising → fall through to legacy. Same diagnostic marker.
- Legacy read errors propagate — the legacy DB layer is allowed to surface its own errors.
- **Binding-kind drift** → treated as INVALID, falls back to legacy, records `"binding kind drift: expected=X actual=Y"`.

## `ConfigReadResult` provenance

```python
@dataclass(frozen=True)
class ConfigReadResult:
    value: Any                 # int|None from binding, str|None from legacy/fallback
    source: Literal["legacy", "binding", "fallback", "missing"]
    binding_status: Literal["bound", "unresolved", "missing", "invalid", "n/a"]
    flag_state: Literal["on", "off", "n/a"]
    diagnostics: list[str]
```

## Source semantics (clarified per review)

| `source` | When |
|---|---|
| `'legacy'` | Flag OFF and legacy had a value |
| `'binding'` | Flag ON, binding BOUND, kind match |
| `'fallback'` | Flag ON, binding not BOUND (or kind drift), legacy had a value |
| `'missing'` | Resolved value is `None` regardless of flag state |

## Hard rule (will be AST-enforced in PR-7 once there are real callers)

**NO cog branches directly on `is_enabled("bindings.primary", ...)`.** Only `core/runtime/config_arbitration` may.

## Architectural boundaries preserved

- No new domain. No migration. No schema change.
- No cache layer added by arbitration; it leans on the binding + feature-flag layers' caches.
- No cog/view/service read sites touched.
- Imports of `utils.db.settings` and `core.runtime.{bindings, feature_flags}` happen INSIDE `read_config` (local) to keep cycle sensitivity minimal.
- Import-cycle regression test still green.
- No AST scan added yet — PR-7 lands the scan with the first real read-site swap so there is something to enforce against.

## What changed

| Path | Change |
|---|---|
| `disbot/core/runtime/config_arbitration.py` | NEW — `ConfigReadResult`, `read_config` with `binding_kind` verification, counters, diagnostics provider registered as `config_arbitration` |
| `tests/unit/config_arbitration/` | NEW — 17 tests covering full resolution ladder, kind verification, failure isolation, counters, diagnostics provider registration |

## Migrations

None.

## Rollback strategy

Single revert. No cog uses the helper yet, so revert has **zero behavioral effect on production**.

## Tests run (after review fix)

```
python -m pytest tests/unit/config_arbitration/ \
                 tests/unit/runtime/test_import_cycle_regression.py -q
# 17 passed

python -m pytest tests/ -q --ignore=tests/integration
# 1257 passed, 12 unrelated warnings

python -m ruff check disbot/   # clean
python -m black --check        # clean
python -m isort --check-only   # clean
```

## Manual Discord smoke

- [ ] `!platform runtime` should show `config_arbitration` provider with `calls_total=0` (no consumer yet)
- [ ] A REPL invocation exercises the read end-to-end:
  ```python
  from core.runtime.config_arbitration import read_config
  r = await read_config(
      guild_id=<test_guild>, subsystem='xp',
      binding_name='announce_channel',
      legacy_key='xp_announce_channel',
      binding_kind='channel',
  )
  print(r.source, r.value, r.binding_status, r.flag_state, r.diagnostics)
  ```
- [ ] Force a kind drift by binding `announce_channel` to a role ID; verify `read_config(..., binding_kind='channel')` returns `source='fallback'` with the `"binding kind drift"` diagnostic.

## Intentionally deferred

- **Per-subsystem convenience accessors** (`get_xp_announce_channel` etc.) — PR-7 adds them at the same time it swaps the cog read sites.
- **AST scan forbidding direct `is_enabled("bindings.primary")` branches outside this module** — PR-7 lands the scan with the first real read-site swap.