### PR TITLE
Phase 2 integration: land #77 + #78 + #79 onto main (repair stacked-PR delivery)

### DIFF
--- a/disbot/cogs/diagnostic_cog.py
+++ b/disbot/cogs/diagnostic_cog.py
@@ -670,31 +670,46 @@ class DiagnosticCog(commands.Cog):
     @platform_grp.command(name="flags")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def platform_flags(self, ctx):
-        """Declared FeatureFlag entries (Phase 1d declarations only)."""
+        """Feature flags: declarations + Phase 2d evaluator state per flag."""
+        from core.runtime import feature_flags
         from services import diagnostics_service
 
         snap = diagnostics_service.snapshot("feature_flags")
+        guild_id = ctx.guild.id if ctx.guild else None
+        rows: list[str] = []
+        for name in sorted(snap.get("by_name", {})):
+            info = snap["by_name"][name]
+            try:
+                decision = await feature_flags.resolve_with_provenance(
+                    name,
+                    guild_id,
+                )
+                effective = "on" if decision.value else "off"
+                source = decision.source
+            except Exception as exc:  # noqa: BLE001 — diagnostics must not raise
+                effective = "?"
+                source = f"error:{type(exc).__name__}"
+            rows.append(
+                f"`{name}` default={info['default_value']} "
+                f"effective={effective} src={source} owner=`{info['owner']}`",
+            )
         embed = discord.Embed(
-            title="🚩 Feature flags (declared)",
+            title="🚩 Feature flags",
             description=(
                 f"{snap['declared_total']} declared  ·  "
-                "Phase 2d will add runtime evaluation"
+                f"cache={snap.get('cache_size', 0)}  ·  "
+                f"bootstrap_fallback={snap.get('bootstrap_fallback_count', 0)}"
             ),
             color=discord.Color.blurple(),
         )
-        by_name = snap.get("by_name", {})
-        if by_name:
-            lines = [
-                f"`{name}` default={info['default_value']} owner=`{info['owner']}`"
-                for name, info in sorted(by_name.items())
-            ]
+        if rows:
             embed.add_field(
-                name="Declared",
-                value="\n".join(lines)[:1024],
+                name="Flags",
+                value="\n".join(rows)[:1024],
                 inline=False,
             )
         else:
-            embed.add_field(name="Declared", value="*(none)*", inline=False)
+            embed.add_field(name="Flags", value="*(none)*", inline=False)
         await ctx.send(embed=embed)
 
 

--- a/disbot/core/events_catalogue.py
+++ b/disbot/core/events_catalogue.py
@@ -60,6 +60,14 @@ KNOWN_EVENTS: frozenset[str] = frozenset(
         "moderation.action_taken",
         # ── Bindings (services/binding_mutation.py, Phase 2b) ─────────────
         "bindings.changed",
+        # ── Feature flags (services/rollout_mutation.py, Phase 2d PR-3) ───
+        # Advisory events emitted after the DB commit + audit row land.
+        # Subscriber failure is logged with mutation_id and never raised
+        # — DB state is authoritative.  Payload contract is documented in
+        # docs/platform-consistency-ledger.md §4.
+        "feature_flags.changed",
+        "rollout.advanced",
+        "environment_tier.changed",
         # ── Future cog-emitted facts (uncomment when first emitter lands):
         # "economy.daily_claimed",
         # "mining.harvested",

--- a/disbot/core/runtime/config_arbitration.py
+++ b/disbot/core/runtime/config_arbitration.py
@@ -1,0 +1,289 @@
+"""Central read-source arbitration — Phase 2 PR-4.
+
+The seam between subsystems and "legacy settings vs typed bindings".
+Every config read for a migrated key flows through :func:`read_config`,
+which consults the feature flag evaluator to decide whether to serve
+the binding or the legacy setting, and returns a typed
+:class:`ConfigReadResult` that carries the full provenance.
+
+Why one central helper:
+
+* Per-cog branching on ``is_enabled("bindings.primary", ...)`` would
+  scatter the transition logic and make rollback a per-cog change.
+  Collapsing it into one helper means the canary flip (PR-7) and the
+  eventual production flip are single-line changes in one place.
+* Provenance (``source``, ``binding_status``, ``flag_state``,
+  ``diagnostics``) is essential for setup-wizard previews, migration
+  debugging, and the ``!platform consistency`` view that PR-10 will
+  unify.
+
+Hard rules:
+
+* **No cog branches directly on ``is_enabled("bindings.primary", ...)``.**
+  Only this module is allowed to.  An AST scan will pin this once
+  there are real callers (the scan is deferred until PR-7's
+  read-site swaps so there is something to enforce against).
+* This module does NOT mutate state.  Reads only.
+* This module does NOT cache; it leans on the binding and feature-flag
+  layers' caches.  Adding a third cache here would multiply
+  invalidation paths for no benefit.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+logger = logging.getLogger("bot.config_arbitration")
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+Source = Literal["legacy", "binding", "fallback", "missing"]
+BindingStatus = Literal["bound", "unresolved", "missing", "invalid", "n/a"]
+FlagState = Literal["on", "off", "n/a"]
+
+
+@dataclass(frozen=True)
+class ConfigReadResult:
+    """Typed snapshot of a single arbitrated config read.
+
+    Fields:
+
+    value:
+        The resolved value (typically an ``int`` for channel/role IDs,
+        or ``str`` for free-form settings, or ``None`` when missing).
+    source:
+        Where ``value`` came from in the arbitration ladder.
+    binding_status:
+        Binding-side status if the binding was consulted.  ``n/a`` when
+        flag was OFF (binding never consulted).
+    flag_state:
+        Effective state of ``bindings.primary`` for this guild.
+    diagnostics:
+        Free-form short strings explaining notable transitions
+        (e.g. ``"binding MISSING, fell back to legacy"``).  Surfaced in
+        ``!platform consistency`` in PR-10.
+    """
+
+    value: Any
+    source: Source
+    binding_status: BindingStatus
+    flag_state: FlagState
+    diagnostics: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Counters — used by the diagnostics provider
+# ---------------------------------------------------------------------------
+
+# Tallied per-call so the consistency view can show "fallback rate ≠ 0
+# means a canary guild has a binding that's MISSING or INVALID".  Three
+# parallel dimensions:
+#   * by_source: where the value actually came from
+#   * by_binding_status: the binding row's last-known status
+#   * by_flag_state: the feature-flag evaluator's decision for this guild
+_BY_SOURCE: dict[str, int] = {"legacy": 0, "binding": 0, "fallback": 0, "missing": 0}
+_BY_BINDING_STATUS: dict[str, int] = {
+    "bound": 0,
+    "unresolved": 0,
+    "missing": 0,
+    "invalid": 0,
+    "n/a": 0,
+}
+_BY_FLAG_STATE: dict[str, int] = {"on": 0, "off": 0, "n/a": 0}
+_CALLS_TOTAL = 0
+
+
+def _bump_counters(result: ConfigReadResult) -> None:
+    global _CALLS_TOTAL
+    _CALLS_TOTAL += 1
+    _BY_SOURCE[result.source] = _BY_SOURCE.get(result.source, 0) + 1
+    _BY_BINDING_STATUS[result.binding_status] = (
+        _BY_BINDING_STATUS.get(result.binding_status, 0) + 1
+    )
+    _BY_FLAG_STATE[result.flag_state] = _BY_FLAG_STATE.get(result.flag_state, 0) + 1
+
+
+def _reset_counters_for_tests() -> None:
+    """Test helper — zero all counters."""
+    global _CALLS_TOTAL
+    _CALLS_TOTAL = 0
+    for d in (_BY_SOURCE, _BY_BINDING_STATUS, _BY_FLAG_STATE):
+        for k in list(d):
+            d[k] = 0
+
+
+def counters_snapshot() -> dict[str, Any]:
+    """Snapshot of the arbitration counters; called by the diag provider."""
+    return {
+        "calls_total": _CALLS_TOTAL,
+        "by_source": dict(_BY_SOURCE),
+        "by_binding_status": dict(_BY_BINDING_STATUS),
+        "by_flag_state": dict(_BY_FLAG_STATE),
+    }
+
+
+# ---------------------------------------------------------------------------
+# read_config — the central arbiter
+# ---------------------------------------------------------------------------
+
+
+async def read_config(
+    guild_id: int,
+    subsystem: str,
+    binding_name: str,
+    legacy_key: str,
+    *,
+    binding_kind: str | None = None,
+) -> ConfigReadResult:
+    """Resolve a config value via the bindings → legacy ladder.
+
+    Resolution:
+
+    1. Consult ``is_enabled("bindings.primary", guild_id)``:
+       - If **OFF** → read legacy directly, source=``"legacy"``.
+       - If **ON**  → fall through to step 2.
+    2. Read the binding via :func:`core.runtime.bindings.get_binding`.
+       - If ``status == BOUND`` and a target is present → return the
+         binding's ``target_id``, source=``"binding"``.
+       - Else → fall through to step 3 (fallback).
+    3. Read legacy as a fallback; return it with source=``"fallback"``
+       and the binding's actual status in ``binding_status``.
+    4. If neither legacy nor binding produced a value → source=``"missing"``.
+
+    Failure handling:
+
+    * If ``is_enabled`` raises, treat as flag OFF (safest default —
+      reads continue from legacy).  Logged once per call.
+    * If the binding read raises, log and fall through to legacy.
+    * Legacy read failures propagate (the legacy DB layer is allowed
+      to surface its own errors — arbitration only catches binding /
+      flag failures because those are the new code).
+    """
+    # Local imports to keep this file out of any module-load cycles.
+    from core.runtime import bindings as bindings_runtime
+    from core.runtime import feature_flags
+    from utils.db import settings as settings_db
+
+    diagnostics: list[str] = []
+
+    # Step 1: feature flag gate.
+    try:
+        primary_on = await feature_flags.is_enabled(
+            "bindings.primary",
+            guild_id,
+        )
+    except Exception as exc:  # noqa: BLE001 — arbitration must not raise
+        logger.warning(
+            "config_arbitration: is_enabled raised for guild=%d (%r); "
+            "treating bindings.primary as OFF",
+            guild_id,
+            exc,
+        )
+        primary_on = False
+        diagnostics.append(f"is_enabled raised: {type(exc).__name__}")
+
+    if not primary_on:
+        legacy_value = await _read_legacy(settings_db, guild_id, legacy_key)
+        result = ConfigReadResult(
+            value=legacy_value,
+            source="legacy",
+            binding_status="n/a",
+            flag_state="off",
+            diagnostics=diagnostics,
+        )
+        _bump_counters(result)
+        return result
+
+    # Step 2: binding read.
+    binding_value = None
+    binding_status: BindingStatus = "n/a"
+    try:
+        bv = await bindings_runtime.get_binding(guild_id, subsystem, binding_name)
+        binding_status = bv.status.value  # type: ignore[assignment]
+        if bv.is_bound and bv.target_id is not None:
+            result = ConfigReadResult(
+                value=bv.target_id,
+                source="binding",
+                binding_status=binding_status,
+                flag_state="on",
+                diagnostics=diagnostics,
+            )
+            _bump_counters(result)
+            return result
+        binding_value = bv.target_id
+        diagnostics.append(f"binding not bound (status={binding_status})")
+    except Exception as exc:  # noqa: BLE001 — arbitration must not raise
+        logger.warning(
+            "config_arbitration: get_binding raised for "
+            "guild=%d subsystem=%r binding=%r (%r); falling back to legacy",
+            guild_id,
+            subsystem,
+            binding_name,
+            exc,
+        )
+        diagnostics.append(f"get_binding raised: {type(exc).__name__}")
+    del binding_value  # currently unused, reserved for future provenance
+
+    # Step 3: fallback to legacy.
+    legacy_value = await _read_legacy(settings_db, guild_id, legacy_key)
+    if legacy_value is None:
+        result = ConfigReadResult(
+            value=None,
+            source="missing",
+            binding_status=binding_status,
+            flag_state="on",
+            diagnostics=diagnostics,
+        )
+    else:
+        result = ConfigReadResult(
+            value=legacy_value,
+            source="fallback",
+            binding_status=binding_status,
+            flag_state="on",
+            diagnostics=diagnostics,
+        )
+    _bump_counters(result)
+    return result
+
+
+async def _read_legacy(settings_db, guild_id: int, legacy_key: str) -> Any | None:
+    """Best-effort legacy read; returns ``None`` for missing/empty."""
+    # binding_kind is reserved for the future case where legacy keys
+    # encode parsing rules (channel IDs vs comma-separated lists);
+    # current callers all want a simple string-or-None.
+    raw = await settings_db.get_setting(guild_id, legacy_key, default="")
+    if not raw:
+        return None
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics provider registration (registers at import time)
+# ---------------------------------------------------------------------------
+
+
+def _consistency_snapshot() -> dict[str, Any]:
+    """Snapshot for ``!platform consistency`` (full surface lands in PR-10)."""
+    return {
+        "arbitration": counters_snapshot(),
+    }
+
+
+def _register_diagnostics() -> None:
+    from services import diagnostics_service
+
+    diagnostics_service.register("config_arbitration", _consistency_snapshot)
+
+
+_register_diagnostics()
+
+
+__all__ = [
+    "ConfigReadResult",
+    "counters_snapshot",
+    "read_config",
+]

--- a/disbot/core/runtime/config_arbitration.py
+++ b/disbot/core/runtime/config_arbitration.py
@@ -17,6 +17,42 @@ Why one central helper:
   debugging, and the ``!platform consistency`` view that PR-10 will
   unify.
 
+Return value typing — read carefully:
+
+* The **binding** path returns ``BindingValue.target_id``
+  (``int | None``).  Binding rows store typed snowflakes for
+  channel/role/etc.
+* The **legacy** and **fallback** paths return the raw legacy string
+  (``str``) from ``guild_settings``.  This is intentional — the
+  legacy KV table stores everything as strings.
+* PR-7's per-subsystem wrappers (e.g. ``get_xp_announce_channel``)
+  will coerce ``str`` → ``int`` (or whatever the binding kind
+  requires) so callers receive a uniform type.  Callers of
+  :func:`read_config` directly MUST handle both shapes (or wait for
+  the per-subsystem wrappers in PR-7).
+
+Source semantics (used by ``!platform consistency``):
+
+* ``source='legacy'`` — value came from legacy KV.  Flag was OFF.
+* ``source='binding'`` — value came from a bound subsystem_bindings
+  row.  Flag was ON and the binding was BOUND.
+* ``source='fallback'`` — flag ON but binding not BOUND; legacy
+  fallback supplied a non-empty value.
+* ``source='missing'`` — neither side produced a value.  Returned
+  whenever the resolved value is ``None``, regardless of flag state;
+  ``flag_state`` and ``binding_status`` carry the distinguishing
+  context.  This makes "how many of my guilds have neither legacy
+  nor binding configured?" a single counter query.
+
+Binding-kind verification (PR-4 enhancement):
+
+* When ``binding_kind`` is provided, ``read_config`` verifies that the
+  resolved binding's kind matches.  A mismatch (schema drift) is
+  treated as if the binding were INVALID — the result short-circuits
+  to fallback / missing and ``diagnostics`` records the drift.  This
+  surfaces wrong-kind bindings early instead of silently returning
+  the wrong shape of value.
+
 Hard rules:
 
 * **No cog branches directly on ``is_enabled("bindings.primary", ...)``.**
@@ -144,20 +180,22 @@ async def read_config(
     Resolution:
 
     1. Consult ``is_enabled("bindings.primary", guild_id)``:
-       - If **OFF** → read legacy directly, source=``"legacy"``.
+       - If **OFF** → read legacy.  Return ``source='legacy'`` if a
+         value is present; ``source='missing'`` if not.
        - If **ON**  → fall through to step 2.
     2. Read the binding via :func:`core.runtime.bindings.get_binding`.
-       - If ``status == BOUND`` and a target is present → return the
-         binding's ``target_id``, source=``"binding"``.
-       - Else → fall through to step 3 (fallback).
-    3. Read legacy as a fallback; return it with source=``"fallback"``
-       and the binding's actual status in ``binding_status``.
-    4. If neither legacy nor binding produced a value → source=``"missing"``.
+       - If ``status == BOUND`` and a target is present AND (when
+         ``binding_kind`` was supplied) the binding's declared kind
+         matches → return ``target_id`` with ``source='binding'``.
+       - If kinds mismatch → treat as INVALID; record a diagnostic
+         and fall through to fallback.
+       - Else → fall through to step 3.
+    3. Read legacy as a fallback.  ``source='fallback'`` if legacy
+       supplies a value, ``source='missing'`` if not.
 
     Failure handling:
 
-    * If ``is_enabled`` raises, treat as flag OFF (safest default —
-      reads continue from legacy).  Logged once per call.
+    * If ``is_enabled`` raises, treat as flag OFF.  Logged.
     * If the binding read raises, log and fall through to legacy.
     * Legacy read failures propagate (the legacy DB layer is allowed
       to surface its own errors — arbitration only catches binding /
@@ -188,9 +226,14 @@ async def read_config(
 
     if not primary_on:
         legacy_value = await _read_legacy(settings_db, guild_id, legacy_key)
+        # source='missing' when the resolved value is None, regardless of
+        # which side we consulted — this makes the !platform consistency
+        # "how many guilds have nothing configured?" query a single
+        # counter read.
+        source: Source = "missing" if legacy_value is None else "legacy"
         result = ConfigReadResult(
             value=legacy_value,
-            source="legacy",
+            source=source,
             binding_status="n/a",
             flag_state="off",
             diagnostics=diagnostics,
@@ -199,12 +242,31 @@ async def read_config(
         return result
 
     # Step 2: binding read.
-    binding_value = None
     binding_status: BindingStatus = "n/a"
     try:
         bv = await bindings_runtime.get_binding(guild_id, subsystem, binding_name)
         binding_status = bv.status.value  # type: ignore[assignment]
-        if bv.is_bound and bv.target_id is not None:
+        # Verify kind matches if the caller declared an expected kind.
+        # Schema drift here is rare but high-impact (a "channel" caller
+        # would otherwise get a role snowflake) so we surface it
+        # explicitly rather than silently returning the wrong shape.
+        kind_mismatch = False
+        if binding_kind is not None and bv.kind.value != binding_kind:
+            kind_mismatch = True
+            diagnostics.append(
+                f"binding kind drift: expected={binding_kind} "
+                f"actual={bv.kind.value}",
+            )
+            logger.warning(
+                "config_arbitration: binding kind drift for "
+                "guild=%d subsystem=%r binding=%r — expected=%s actual=%s",
+                guild_id,
+                subsystem,
+                binding_name,
+                binding_kind,
+                bv.kind.value,
+            )
+        if bv.is_bound and bv.target_id is not None and not kind_mismatch:
             result = ConfigReadResult(
                 value=bv.target_id,
                 source="binding",
@@ -214,8 +276,8 @@ async def read_config(
             )
             _bump_counters(result)
             return result
-        binding_value = bv.target_id
-        diagnostics.append(f"binding not bound (status={binding_status})")
+        if not kind_mismatch:
+            diagnostics.append(f"binding not bound (status={binding_status})")
     except Exception as exc:  # noqa: BLE001 — arbitration must not raise
         logger.warning(
             "config_arbitration: get_binding raised for "
@@ -226,7 +288,6 @@ async def read_config(
             exc,
         )
         diagnostics.append(f"get_binding raised: {type(exc).__name__}")
-    del binding_value  # currently unused, reserved for future provenance
 
     # Step 3: fallback to legacy.
     legacy_value = await _read_legacy(settings_db, guild_id, legacy_key)
@@ -251,10 +312,13 @@ async def read_config(
 
 
 async def _read_legacy(settings_db, guild_id: int, legacy_key: str) -> Any | None:
-    """Best-effort legacy read; returns ``None`` for missing/empty."""
-    # binding_kind is reserved for the future case where legacy keys
-    # encode parsing rules (channel IDs vs comma-separated lists);
-    # current callers all want a simple string-or-None.
+    """Best-effort legacy read; returns ``None`` for missing/empty.
+
+    The legacy KV table stores everything as strings; this function
+    returns the raw string (or ``None`` for an empty/missing row).
+    PR-7's per-subsystem wrappers will coerce ``str`` → typed values
+    so callers do not have to know the storage format.
+    """
     raw = await settings_db.get_setting(guild_id, legacy_key, default="")
     if not raw:
         return None

--- a/disbot/core/runtime/feature_flags.py
+++ b/disbot/core/runtime/feature_flags.py
@@ -415,12 +415,25 @@ async def _resolve_from_db(
             flag=flag,
             guild_tier=guild_tier,
         )
-        if value or _normalize_state(global_row["state"]) in ("on", "off"):
-            # A hard 'on' / matching tier wins.  A hard 'off' / unmatched
-            # tier means "no override fires" — fall through to the
-            # declared rollout policy.  We only short-circuit on 'on' so
-            # rollout can still grant access to additional guilds.
+        normalized = _normalize_state(global_row["state"])
+        # Resolution rules for global overrides (intentional):
+        #   * 'on'  → hard enable, short-circuit True.
+        #   * 'off' → hard disable, short-circuit False.  This makes
+        #             rollback safe: setting the global row to 'off'
+        #             immediately disables the flag for every guild
+        #             that does not carry a per-guild override.
+        #   * tier name (canary/beta/production/owner) + matching guild
+        #             tier → True via tier match.
+        #   * tier name + non-matching guild tier → the global row is
+        #             non-binding for this guild; fall through to the
+        #             declared rollout policy.  The staged rollout may
+        #             still grant access via staged_guilds or rollout
+        #             percentage.
+        if normalized in ("on", "off"):
             return _Decision(value, _SOURCE_DB_GLOBAL)
+        if value:
+            return _Decision(True, _SOURCE_DB_GLOBAL)
+        # Non-matching tier name: do not short-circuit; rollout may grant.
 
     # Declared rollout policy.
     if flag.rollout_policy is not None and guild_id is not None:

--- a/disbot/core/runtime/feature_flags.py
+++ b/disbot/core/runtime/feature_flags.py
@@ -1,42 +1,52 @@
-"""Phase 1d — Feature flag, environment tier, and rollout policy declarations.
+"""Feature flag declarations + runtime evaluator (Phase 1d + Phase 2d PR-2).
 
-This module declares the *types* — :class:`FeatureFlag`,
-:class:`EnvironmentTier`, :class:`RolloutPolicy` — that Phase 2d's
-storage + :class:`RolloutMutationPipeline` will consume.  Phase 1d
-intentionally stops at declarations so subsystems can declare flags
-during ``cog_load`` ahead of the runtime landing in Phase 2d.
+This module owns:
 
-Why declarations land before runtime:
+* The **declaration** types — :class:`FeatureFlag`,
+  :class:`EnvironmentTier`, :class:`RolloutPolicy` (Phase 1d).  These
+  let subsystems register flags during ``cog_load``.
+* The **runtime evaluator** — :func:`is_enabled` (Phase 2d, PR-2).
+  Resolves a flag's effective value for a given guild by consulting,
+  in order: emergency env override → ``feature_flag.primary`` gate →
+  per-guild DB override → global DB override → environment-tier policy
+  → deterministic rollout hash → declared default.
 
-* Phase 1d's :func:`utils.subsystem_registry.validate_registry`
-  extension can validate that every flag referenced by a schema has a
-  declaration here.
-* Phase 2d's RolloutMutationPipeline ships behind ``FEATURE_FLAG_PRIMARY``
-  itself — but by then every subsystem that wants a flag has already
-  declared one, so the migration is mechanical.
+The mutation pipeline (:class:`services.rollout_mutation.RolloutMutationPipeline`)
+and the event-driven cache invalidation ship in PR-3.  Until then the
+evaluator's cache uses TTL as the only invalidation primitive; callers
+may also invoke :func:`clear_cache` explicitly.
+
+Bootstrap policy (intentional ordering):
+
+1. ``SUPERBOT_FF_<FLAG>=on|off`` env override wins for ANY flag.
+   This is the permanent platform-owner escape hatch.
+2. ``feature_flag.primary`` is the meta-flag.  When OFF, the evaluator
+   returns each flag's declared default and the DB is never consulted.
+   ``feature_flag.primary`` itself is resolved by env + declaration ONLY
+   — its value is never read from the DB.  This protects the bootstrap
+   path while the runtime is being proven on a deployment.
+3. When ``feature_flag.primary`` is ON, the DB-backed resolution runs.
+4. Any DB error during resolution falls back to the declared default
+   and emits the ``feature_flag.bootstrap_fallback`` metric — never
+   raises.
 
 Public surface:
 
-* :class:`EnvironmentTier` — typed taxonomy of deployment environments.
-* :class:`RolloutPolicy` — staged rollout description.
-* :class:`FeatureFlag` — a typed declaration of a gated behavior.
+* :class:`EnvironmentTier`, :class:`RolloutPolicy`, :class:`FeatureFlag`
 * ``FeatureFlagRegistry`` operations: ``register``, ``get``,
-  ``all_flags``.
-
-Phase 2d adds:
-
-* ``is_enabled(name, guild_id) -> bool`` runtime evaluator.
-* ``feature_flag_state`` table + ``RolloutMutationPipeline``.
-* Migration of existing env-var gates to declared flags.
-
-Until Phase 2d lands, declared flags are *introspection only* — they
-appear in ``!platform flags`` but cannot be mutated and their value is
-``default`` everywhere.
+  ``all_flags``
+* :func:`is_enabled` (Phase 2d evaluator)
+* :func:`clear_cache` (manual invalidation; PR-3 adds event-driven)
+* :func:`resolve_with_provenance` (used by diagnostics; returns the
+  decision and the source it came from)
 """
 
 from __future__ import annotations
 
+import hashlib
 import logging
+import os
+import time
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
@@ -172,8 +182,15 @@ def declared_names() -> list[str]:
 
 
 def _reset_for_tests() -> None:
-    """Wipe the registry.  Tests call this in their setup/teardown fixture."""
+    """Wipe the registry + cache + metrics.
+
+    Tests call this in their setup/teardown fixture so per-test state
+    cannot leak via the module-level dicts / counters.
+    """
     _REGISTRY.clear()
+    _CACHE.clear()
+    global _BOOTSTRAP_FALLBACK_COUNT
+    _BOOTSTRAP_FALLBACK_COUNT = 0
 
 
 # ---------------------------------------------------------------------------
@@ -240,6 +257,352 @@ _register_builtins()
 
 
 # ---------------------------------------------------------------------------
+# Phase 2d evaluator — is_enabled + cache + bootstrap policy
+# ---------------------------------------------------------------------------
+
+# Sources that can deliver a resolved value, surfaced via diagnostics so
+# operators see exactly why the evaluator returned what it did.
+_SOURCE_ENV = "env"
+_SOURCE_BOOTSTRAP_FALLBACK = "bootstrap_fallback"  # DB unreachable or off
+_SOURCE_DB_GUILD = "db_guild"
+_SOURCE_DB_GLOBAL = "db_global"
+_SOURCE_TIER = "tier"
+_SOURCE_ROLLOUT = "rollout"
+_SOURCE_DEFAULT = "default"
+
+# Cache TTL.  PR-3 adds event-driven invalidation; until then TTL is
+# the only invalidation primitive aside from explicit clear_cache.
+# Five minutes balances "operator DB change reflected without restart"
+# against hot-path read pressure (every interaction hits is_enabled).
+_CACHE_TTL_SECS = 300.0
+
+# Cache value: (resolved_bool, source_string, expires_at_monotonic).
+_CACHE: dict[tuple[str, int | None], tuple[bool, str, float]] = {}
+
+# Metric counter for fallback rate.  Hooked into services.metrics in a
+# follow-up PR; until then this is the in-process visible counter that
+# tests can assert on.
+_BOOTSTRAP_FALLBACK_COUNT = 0
+
+
+def _env_override_key(flag_name: str) -> str:
+    """Translate a dotted flag name into a SUPERBOT_FF_<NAME> env var."""
+    return "SUPERBOT_FF_" + flag_name.replace(".", "_").upper()
+
+
+def _env_override(flag_name: str) -> bool | None:
+    """Return ``True`` / ``False`` for an env override, else ``None``.
+
+    Accepts the same truthy/falsy literals as the rest of the codebase
+    (``true``, ``yes``, ``on``, ``1`` vs. ``false``, ``no``, ``off``,
+    ``0``).  Unknown values are ignored (treated as "no override").
+    """
+    raw = os.environ.get(_env_override_key(flag_name))
+    if raw is None:
+        return None
+    lower = raw.strip().lower()
+    if lower in ("true", "yes", "on", "1"):
+        return True
+    if lower in ("false", "no", "off", "0"):
+        return False
+    logger.warning(
+        "feature_flags: env %s=%r is not a recognized boolean — ignoring",
+        _env_override_key(flag_name),
+        raw,
+    )
+    return None
+
+
+def _rollout_bucket(flag_name: str, guild_id: int) -> int:
+    """Deterministic 0..99 bucket for ``(flag, guild)``.
+
+    Stdlib-only (``hashlib.sha256``); no new dependency.  Stable across
+    Python versions and processes — the same pair always lands in the
+    same bucket.
+    """
+    digest = hashlib.sha256(f"{flag_name}:{guild_id}".encode()).digest()
+    return int.from_bytes(digest[:8], "big") % 100
+
+
+def _normalize_state(state: str) -> str:
+    """Lowercase + strip; protects against operator typos in DB rows."""
+    return state.strip().lower() if state else ""
+
+
+def _state_to_decision(
+    state: str,
+    *,
+    flag: FeatureFlag,
+    guild_tier: str | None,
+) -> bool:
+    """Turn a stored ``state`` string into a boolean.
+
+    ``on``/``off`` are hard overrides.  Tier names
+    (``owner``/``canary``/``beta``/``production``) mean "enabled if the
+    guild's environment_tier is at or above this level".  Unknown
+    strings fall back to the declared default and log a WARNING.
+    """
+    normalized = _normalize_state(state)
+    if normalized == "on":
+        return True
+    if normalized == "off":
+        return False
+    if normalized in ("owner", "canary", "beta", "production"):
+        return _tier_meets(guild_tier, normalized)
+    logger.warning(
+        "feature_flags: unknown stored state %r for %r — using default",
+        state,
+        flag.name,
+    )
+    return flag.default_value
+
+
+# Tier ordering — lower index = more restricted exposure.  A guild
+# whose tier is "owner_guild_only" sees flags gated at "owner" or
+# below; a "canary" guild sees "canary" + "beta" + "production"; etc.
+_TIER_ORDER = {
+    "owner_guild_only": 0,
+    "development": 0,
+    "owner": 0,
+    "canary": 1,
+    "beta": 2,
+    "production": 3,
+}
+
+
+def _tier_meets(guild_tier: str | None, required: str) -> bool:
+    """``True`` when ``guild_tier`` is at-or-above ``required``."""
+    guild_level = _TIER_ORDER.get((guild_tier or "production").lower(), 3)
+    required_level = _TIER_ORDER.get(required.lower(), 3)
+    return guild_level <= required_level
+
+
+@dataclass(frozen=True)
+class _Decision:
+    """Internal: the evaluator's result + the source it came from."""
+
+    value: bool
+    source: str
+
+
+async def _resolve_from_db(
+    flag: FeatureFlag,
+    guild_id: int | None,
+) -> _Decision:
+    """DB-backed resolution.  Caller has already passed bootstrap gates."""
+    # Local imports to keep cycle-sensitive cycles unaffected.
+    from utils.db import environment_tiers as et_db
+    from utils.db import feature_flag_state as ff_db
+
+    # Per-guild override beats everything else in the DB layer.
+    if guild_id is not None:
+        guild_row = await ff_db.get_guild_override(flag.name, guild_id)
+        if guild_row is not None:
+            guild_tier = await et_db.get_tier(guild_id)
+            value = _state_to_decision(
+                guild_row["state"],
+                flag=flag,
+                guild_tier=guild_tier,
+            )
+            return _Decision(value, _SOURCE_DB_GUILD)
+
+    # Global override.
+    global_row = await ff_db.get_global_override(flag.name)
+    if global_row is not None:
+        guild_tier = await et_db.get_tier(guild_id) if guild_id is not None else None
+        value = _state_to_decision(
+            global_row["state"],
+            flag=flag,
+            guild_tier=guild_tier,
+        )
+        if value or _normalize_state(global_row["state"]) in ("on", "off"):
+            # A hard 'on' / matching tier wins.  A hard 'off' / unmatched
+            # tier means "no override fires" — fall through to the
+            # declared rollout policy.  We only short-circuit on 'on' so
+            # rollout can still grant access to additional guilds.
+            return _Decision(value, _SOURCE_DB_GLOBAL)
+
+    # Declared rollout policy.
+    if flag.rollout_policy is not None and guild_id is not None:
+        policy = flag.rollout_policy
+        guild_tier = await et_db.get_tier(guild_id)
+        if guild_id in policy.staged_guilds:
+            if _tier_meets(guild_tier, policy.tier_gate.value):
+                return _Decision(True, _SOURCE_TIER)
+        if policy.tier_gate is not None and _tier_meets(
+            guild_tier,
+            policy.tier_gate.value,
+        ):
+            # Environment-tier override map.
+            tier_enum = EnvironmentTier((guild_tier or "production").lower())
+            if tier_enum in flag.environment_overrides:
+                return _Decision(
+                    flag.environment_overrides[tier_enum],
+                    _SOURCE_TIER,
+                )
+            if policy.percentage_rollout > 0:
+                bucket = _rollout_bucket(flag.name, guild_id)
+                if bucket < policy.percentage_rollout:
+                    return _Decision(True, _SOURCE_ROLLOUT)
+
+    return _Decision(flag.default_value, _SOURCE_DEFAULT)
+
+
+def _cache_get(flag_name: str, guild_id: int | None) -> _Decision | None:
+    """Return a cached decision if still fresh, else ``None``."""
+    entry = _CACHE.get((flag_name, guild_id))
+    if entry is None:
+        return None
+    value, source, expires_at = entry
+    if expires_at < time.monotonic():
+        _CACHE.pop((flag_name, guild_id), None)
+        return None
+    return _Decision(value, source)
+
+
+def _cache_put(flag_name: str, guild_id: int | None, decision: _Decision) -> None:
+    """Store a decision with TTL."""
+    _CACHE[(flag_name, guild_id)] = (
+        decision.value,
+        decision.source,
+        time.monotonic() + _CACHE_TTL_SECS,
+    )
+
+
+def clear_cache(
+    flag_name: str | None = None,
+    guild_id: int | None = None,
+) -> int:
+    """Evict cached evaluator decisions.
+
+    Until PR-3's event-driven invalidation lands, callers that mutate
+    state directly (DB scripts, tests, the future RolloutMutationPipeline
+    in its early form) call this to make the next ``is_enabled`` re-read.
+
+    Filtering rules:
+
+    * No arguments → drop every entry.
+    * ``flag_name`` only → drop every guild's entry for that flag (and
+      the global ``guild_id=None`` entry).
+    * ``flag_name`` + ``guild_id`` → drop the single matching entry.
+    * ``guild_id`` only → drop every flag's entry for that guild.
+
+    Returns the number of entries removed.
+    """
+    if flag_name is None and guild_id is None:
+        n = len(_CACHE)
+        _CACHE.clear()
+        return n
+    to_drop = []
+    for key in _CACHE:
+        key_flag, key_guild = key
+        if flag_name is not None and key_flag != flag_name:
+            continue
+        if guild_id is not None and key_guild != guild_id:
+            continue
+        to_drop.append(key)
+    for key in to_drop:
+        _CACHE.pop(key, None)
+    return len(to_drop)
+
+
+def _record_bootstrap_fallback() -> None:
+    """Increment the in-process bootstrap fallback counter.
+
+    A real Prometheus metric is wired in a follow-up PR; until then
+    this counter is the test-observable signal.
+    """
+    global _BOOTSTRAP_FALLBACK_COUNT
+    _BOOTSTRAP_FALLBACK_COUNT += 1
+
+
+def bootstrap_fallback_count() -> int:
+    """Return how many times the DB-unreachable fallback has fired."""
+    return _BOOTSTRAP_FALLBACK_COUNT
+
+
+def _reset_metrics_for_tests() -> None:
+    """Test helper — reset the bootstrap fallback counter."""
+    global _BOOTSTRAP_FALLBACK_COUNT
+    _BOOTSTRAP_FALLBACK_COUNT = 0
+
+
+async def resolve_with_provenance(
+    flag_name: str,
+    guild_id: int | None = None,
+) -> _Decision:
+    """Resolve a flag and return both the value and the source.
+
+    Used by diagnostics so ``!platform flags`` can render the source
+    column.  Internal — tests are welcome to call it but production
+    callers should prefer :func:`is_enabled`.
+
+    Resolution order (see module docstring for rationale):
+
+    1. ``SUPERBOT_FF_<FLAG>`` env override (always wins).
+    2. ``feature_flag.primary`` gate — if OFF, return declared default
+       and bypass DB entirely.  Evaluating ``feature_flag.primary``
+       itself bypasses the DB step too.
+    3. Cache lookup.
+    4. DB resolution (per-guild → global → tier → rollout → default).
+    5. DB error → declared default + bootstrap-fallback metric.
+    """
+    # Step 1: env override
+    env = _env_override(flag_name)
+    if env is not None:
+        return _Decision(env, _SOURCE_ENV)
+
+    flag = _REGISTRY.get(flag_name)
+    if flag is None:
+        logger.warning(
+            "feature_flags: is_enabled called for undeclared flag %r",
+            flag_name,
+        )
+        return _Decision(False, _SOURCE_DEFAULT)
+
+    # Step 2: feature_flag.primary gate.
+    if flag_name == FEATURE_FLAG_PRIMARY.name:
+        # Meta-flag: env-or-default only, never DB.
+        return _Decision(flag.default_value, _SOURCE_DEFAULT)
+    primary = await resolve_with_provenance(FEATURE_FLAG_PRIMARY.name, guild_id)
+    if not primary.value:
+        return _Decision(flag.default_value, _SOURCE_DEFAULT)
+
+    # Step 3: cache
+    cached = _cache_get(flag_name, guild_id)
+    if cached is not None:
+        return cached
+
+    # Step 4 / 5: DB resolution with fallback
+    try:
+        decision = await _resolve_from_db(flag, guild_id)
+    except Exception as exc:
+        logger.warning(
+            "feature_flags: DB unreachable for %r (guild=%r) — using default: %s",
+            flag_name,
+            guild_id,
+            exc,
+        )
+        _record_bootstrap_fallback()
+        decision = _Decision(flag.default_value, _SOURCE_BOOTSTRAP_FALLBACK)
+
+    _cache_put(flag_name, guild_id, decision)
+    return decision
+
+
+async def is_enabled(flag_name: str, guild_id: int | None = None) -> bool:
+    """Phase 2d evaluator entry point.
+
+    Returns the effective boolean for ``flag_name`` in ``guild_id``'s
+    context.  Resolution order, cache semantics, and the bootstrap
+    fallback policy are documented on :func:`resolve_with_provenance`
+    and at the top of this module.
+    """
+    decision = await resolve_with_provenance(flag_name, guild_id)
+    return decision.value
+
+
+# ---------------------------------------------------------------------------
 # Diagnostics provider — registers at import time
 # ---------------------------------------------------------------------------
 
@@ -247,14 +610,18 @@ _register_builtins()
 def _feature_flags_snapshot() -> dict[str, Any]:
     """Snapshot provider for ``!platform flags``.
 
-    Phase 1d returns declarations only.  Phase 2d will extend the
-    snapshot with current stored values, environment-tier resolution,
-    and rollout-decision counts.
+    Phase 2d (PR-2) extends the snapshot with cache size, fallback
+    counter, and per-flag declared values.  Effective per-flag values
+    require an async call so the diagnostics view falls back to
+    declared defaults here; ``cogs/diagnostic_cog.py::flags`` does the
+    per-flag async resolution and renders the source column.
     """
     flags = all_flags()
     return {
         "declared_total": len(flags),
         "by_owner": _flags_by_owner(flags),
+        "cache_size": len(_CACHE),
+        "bootstrap_fallback_count": _BOOTSTRAP_FALLBACK_COUNT,
         "by_name": {
             name: {
                 "description": flag.description,
@@ -297,7 +664,11 @@ __all__ = [
     "RESOURCES_UNIFIED",
     "RolloutPolicy",
     "all_flags",
+    "bootstrap_fallback_count",
+    "clear_cache",
     "declared_names",
     "get",
+    "is_enabled",
     "register",
+    "resolve_with_provenance",
 ]

--- a/disbot/guild_lifecycle.py
+++ b/disbot/guild_lifecycle.py
@@ -32,11 +32,15 @@ async def teardown(guild_id: int) -> None:
       5. Subsystem bindings     — delete active subsystem_bindings rows (Phase 2);
                                    binding_audit_log rows are PRESERVED by design.
       6. Resource validation cache — drop resource_validation_cache rows (Phase 2).
-      7. Governance capability cache — clear per-guild execution overrides.
-      8. Governance visibility cache — bump version, clear role-override flag.
-      9. Guild-config cache     — drop cached guild config entries (F-1).
-      10. Scope locks            — invoke registered per-cog teardown hooks (F-2).
-      11. Governance feedback cooldown — documented, no per-guild cleanup needed.
+      7. Feature flag per-guild overrides — drop feature_flag_guild_overrides
+                                   rows (Phase 2d PR-2); global rows preserved.
+      8. Environment tier        — delete environment_tiers row (Phase 2d PR-2).
+      9. Feature flag evaluator cache — drop cached decisions for the guild.
+      10. Governance capability cache — clear per-guild execution overrides.
+      11. Governance visibility cache — bump version, clear role-override flag.
+      12. Guild-config cache    — drop cached guild config entries (F-1).
+      13. Scope locks           — invoke registered per-cog teardown hooks (F-2).
+      14. Governance feedback cooldown — documented, no per-guild cleanup needed.
     """
     logger.info("guild_lifecycle.teardown: beginning cleanup for guild=%d", guild_id)
 
@@ -58,19 +62,28 @@ async def teardown(guild_id: int) -> None:
     # 6. Resource validation cache — drop cached resource status rows (Phase 2a).
     await _teardown_resource_cache(guild_id)
 
-    # 7. Governance capability overrides — clear execution-layer in-process dict.
+    # 7. Feature flag per-guild overrides — global rows preserved (Phase 2d).
+    await _teardown_feature_flag_guild_overrides(guild_id)
+
+    # 8. Environment tier row — guild defaults back to production on re-join.
+    await _teardown_environment_tier(guild_id)
+
+    # 9. Feature flag evaluator cache — drop stale cached decisions.
+    _teardown_feature_flag_cache(guild_id)
+
+    # 10. Governance capability overrides — clear execution-layer in-process dict.
     _teardown_capability_overrides(guild_id)
 
-    # 8. Governance visibility cache — version bump + role flag removal.
+    # 11. Governance visibility cache — version bump + role flag removal.
     _teardown_visibility_cache(guild_id)
 
-    # 9. Guild-config cache — drop cached config entries for the guild (F-1 / S1.1).
+    # 12. Guild-config cache — drop cached config entries for the guild (F-1 / S1.1).
     _teardown_guild_config(guild_id)
 
-    # 10. Scope locks — invoke registered per-cog teardown hooks (F-2 / S1.2).
+    # 13. Scope locks — invoke registered per-cog teardown hooks (F-2 / S1.2).
     _teardown_scope_locks(guild_id)
 
-    # 11. Governance feedback cooldown dict in governance/__init__.
+    # 14. Governance feedback cooldown dict in governance/__init__.
     _teardown_feedback_cooldown(guild_id)
 
     logger.info("guild_lifecycle.teardown: complete for guild=%d", guild_id)
@@ -202,6 +215,73 @@ async def _teardown_resource_cache(guild_id: int) -> None:
             )
     except Exception as exc:
         logger.warning("guild_lifecycle: resource cache teardown failed: %s", exc)
+
+
+async def _teardown_feature_flag_guild_overrides(guild_id: int) -> None:
+    """Delete every feature_flag_guild_overrides row for the departed guild.
+
+    Phase 2d, PR-2.  Global override rows survive (they're not scoped to
+    a single guild); only the per-guild rows are purged.  Operators can
+    re-seed canary/owner overrides after re-invitation.
+    """
+    try:
+        from utils.db.feature_flag_state import delete_for_guild as _ff_delete
+
+        count = await _ff_delete(guild_id)
+        if count:
+            logger.debug(
+                "guild_lifecycle: deleted %d feature_flag guild override(s) for guild=%d",
+                count,
+                guild_id,
+            )
+    except Exception as exc:
+        logger.warning(
+            "guild_lifecycle: feature_flag guild override teardown failed: %s",
+            exc,
+        )
+
+
+async def _teardown_environment_tier(guild_id: int) -> None:
+    """Drop the environment_tiers row so the guild re-defaults to PRODUCTION.
+
+    Phase 2d, PR-2.  When the bot is re-invited, the guild starts at the
+    most restrictive tier until an operator re-assigns it.
+    """
+    try:
+        from utils.db.environment_tiers import delete_for_guild as _et_delete
+
+        count = await _et_delete(guild_id)
+        if count:
+            logger.debug(
+                "guild_lifecycle: deleted environment_tier row for guild=%d",
+                guild_id,
+            )
+    except Exception as exc:
+        logger.warning("guild_lifecycle: environment_tier teardown failed: %s", exc)
+
+
+def _teardown_feature_flag_cache(guild_id: int) -> None:
+    """Drop every evaluator cache entry scoped to ``guild_id``.
+
+    Phase 2d, PR-2.  Until PR-3 wires event-driven invalidation, the
+    explicit clear on guild-leave guarantees a re-invited guild does
+    not observe stale per-guild decisions.
+    """
+    try:
+        from core.runtime.feature_flags import clear_cache
+
+        removed = clear_cache(guild_id=guild_id)
+        if removed:
+            logger.debug(
+                "guild_lifecycle: cleared %d feature_flag cache entry(s) for guild=%d",
+                removed,
+                guild_id,
+            )
+    except Exception as exc:
+        logger.warning(
+            "guild_lifecycle: feature_flag cache teardown failed: %s",
+            exc,
+        )
 
 
 def _teardown_capability_overrides(guild_id: int) -> None:

--- a/disbot/migrations/023_feature_flag_state.sql
+++ b/disbot/migrations/023_feature_flag_state.sql
@@ -1,0 +1,56 @@
+-- Migration 023: feature_flag_state — global + guild overrides (Phase 2d, PR-2).
+--
+-- Storage for the Phase 2d feature-flag evaluator.  Two tables instead of
+-- one nullable-PK table because PostgreSQL does not allow NULL in any
+-- PRIMARY KEY column.  Separating the surfaces also keeps SQL queries
+-- unambiguous: the evaluator's resolution order is explicit ("look up the
+-- guild row; on miss look up the global row").
+--
+-- Resolution order (consumed by core.runtime.feature_flags.is_enabled):
+--   1. emergency env override (SUPERBOT_FF_<FLAG>)
+--   2. if feature_flag.primary is OFF: declared default (DB bypassed)
+--   3. per-guild row (feature_flag_guild_overrides)
+--   4. global row (feature_flag_global_overrides)
+--   5. environment-tier policy match (RolloutPolicy.tier_gate)
+--   6. deterministic rollout hash (RolloutPolicy.percentage_rollout)
+--   7. declared default
+--
+-- Both tables are READ-ONLY in this PR — writes land in PR-3 alongside
+-- the RolloutMutationPipeline + feature_flag_audit table.  Until then,
+-- operators seed rows manually for canary/owner-tier validation.
+--
+-- Schema decisions:
+--
+--   * ``state`` is a CHECK-constrained enum mirroring Python's logical
+--     levels.  ``'on'`` and ``'off'`` are hard overrides; the tier names
+--     (``owner``, ``canary``, ``beta``, ``production``) are convenience
+--     values evaluated against the guild's environment tier.
+--   * ``rollout_percent`` only meaningful on the global row.  Per-guild
+--     rows are a binary override and ignore rollout.
+--   * ``set_by`` is nullable for system writes (backfill, migration).
+--
+-- Forward-only and idempotent.
+
+CREATE TABLE IF NOT EXISTS feature_flag_global_overrides (
+    flag_name        TEXT         NOT NULL PRIMARY KEY,
+    state            TEXT         NOT NULL,
+    rollout_percent  INTEGER,
+    set_by           BIGINT,
+    set_at           TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    CHECK (state IN ('off', 'owner', 'canary', 'beta', 'production', 'on')),
+    CHECK (rollout_percent IS NULL
+           OR (rollout_percent BETWEEN 0 AND 100))
+);
+
+CREATE TABLE IF NOT EXISTS feature_flag_guild_overrides (
+    flag_name        TEXT         NOT NULL,
+    guild_id         BIGINT       NOT NULL,
+    state            TEXT         NOT NULL,
+    set_by           BIGINT,
+    set_at           TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (flag_name, guild_id),
+    CHECK (state IN ('off', 'owner', 'canary', 'beta', 'production', 'on'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_feature_flag_guild_overrides_guild
+    ON feature_flag_guild_overrides (guild_id);

--- a/disbot/migrations/024_environment_tiers.sql
+++ b/disbot/migrations/024_environment_tiers.sql
@@ -1,0 +1,33 @@
+-- Migration 024: environment_tiers (Phase 2d, PR-2).
+--
+-- One row per guild mapping the guild to its deployment tier
+-- (production, beta, canary, owner_guild_only, development).  The
+-- feature-flag evaluator consults this table to decide whether a flag
+-- whose RolloutPolicy.tier_gate is, say, BETA, is eligible for a given
+-- guild.
+--
+-- Missing row → guild is treated as PRODUCTION (the most-restrictive
+-- default).  Operators seed rows manually for canary/owner guilds.
+--
+-- Schema decisions:
+--
+--   * ``tier`` CHECK enumerates exactly the values of
+--     ``core.runtime.feature_flags.EnvironmentTier``; the invariant test
+--     ``tests/unit/invariants/test_environment_tier_alignment.py`` pins
+--     the literals.
+--   * Single-column PK — at most one tier per guild.  Reassigning is an
+--     UPDATE, not an INSERT.
+--   * ``set_by`` nullable for system writes (CI seed, migration).
+--   * Per-guild rows are deleted on guild leave via
+--     :func:`guild_lifecycle.teardown`.
+--
+-- Forward-only and idempotent.
+
+CREATE TABLE IF NOT EXISTS environment_tiers (
+    guild_id   BIGINT       NOT NULL PRIMARY KEY,
+    tier       TEXT         NOT NULL DEFAULT 'production',
+    set_by     BIGINT,
+    set_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    CHECK (tier IN ('production', 'beta', 'canary',
+                    'owner_guild_only', 'development'))
+);

--- a/disbot/migrations/025_feature_flag_audit.sql
+++ b/disbot/migrations/025_feature_flag_audit.sql
@@ -1,0 +1,68 @@
+-- Migration 025: feature_flag_audit (Phase 2d, PR-3).
+--
+-- Append-only audit log for every mutation that flows through
+-- :class:`services.rollout_mutation.RolloutMutationPipeline`.  One row
+-- per state change.  Rollback is a NEW audit row, never an UPDATE.
+--
+-- Three mutation types are recorded:
+--
+--   * ``set_state``    — write to feature_flag_global_overrides or
+--                        feature_flag_guild_overrides.  ``scope`` +
+--                        ``guild_id`` discriminate which row was
+--                        affected; ``prev_state`` / ``new_state``
+--                        carry the transition.
+--   * ``set_rollout_percent`` — change to
+--                        feature_flag_global_overrides.rollout_percent.
+--                        ``prev_rollout_percent`` / ``new_rollout_percent``
+--                        carry the transition; state columns repeat
+--                        the current state for context.
+--   * ``set_tier``     — change to environment_tiers.tier.  ``flag_name``
+--                        is set to the literal ``'__environment_tier__'``
+--                        so the audit table can host all three event
+--                        sources without a second table.
+--
+-- Schema decisions:
+--
+--   * ``mutation_type`` and ``scope`` CHECK literals mirror the Python
+--     constants in :mod:`services.rollout_mutation`.  Alignment test
+--     ``tests/unit/invariants/test_feature_flag_audit_alignment.py``
+--     pins them.
+--   * ``actor_id`` is nullable — system writes (CI seeds, scripted
+--     ops) record actor_type='system' with actor_id=NULL.
+--   * Indexed on (flag_name, at) for per-flag history and
+--     (guild_id, at) for per-guild history.  ``mutation_id`` indexed
+--     for cross-pipeline correlation.
+--
+-- Forward-only and idempotent.
+
+CREATE TABLE IF NOT EXISTS feature_flag_audit (
+    id                     BIGSERIAL    PRIMARY KEY,
+    mutation_id            UUID         NOT NULL,
+    flag_name              TEXT         NOT NULL,
+    scope                  TEXT         NOT NULL,
+    guild_id               BIGINT,
+    prev_state             TEXT,
+    new_state              TEXT,
+    prev_rollout_percent   INTEGER,
+    new_rollout_percent    INTEGER,
+    prev_tier              TEXT,
+    new_tier               TEXT,
+    actor_id               BIGINT,
+    actor_type             TEXT         NOT NULL DEFAULT 'platform_owner',
+    mutation_type          TEXT         NOT NULL,
+    at                     TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    CHECK (scope IN ('global', 'guild')),
+    CHECK (mutation_type IN
+        ('set_state', 'set_rollout_percent', 'set_tier')),
+    CHECK (actor_type IN
+        ('platform_owner', 'system', 'backfill'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_feature_flag_audit_flag_at
+    ON feature_flag_audit (flag_name, at);
+
+CREATE INDEX IF NOT EXISTS idx_feature_flag_audit_guild_at
+    ON feature_flag_audit (guild_id, at);
+
+CREATE INDEX IF NOT EXISTS idx_feature_flag_audit_mutation
+    ON feature_flag_audit (mutation_id);

--- a/disbot/migrations/025_feature_flag_audit.sql
+++ b/disbot/migrations/025_feature_flag_audit.sql
@@ -33,6 +33,22 @@
 --     (guild_id, at) for per-guild history.  ``mutation_id`` indexed
 --     for cross-pipeline correlation.
 --
+-- Per-``mutation_type`` shape (defense-in-depth via CHECK constraints).
+-- These complement the pipeline-level validation; even a future caller
+-- that bypasses :class:`RolloutMutationPipeline` cannot insert a
+-- mis-shaped audit row.
+--
+--   * ``set_state`` rows: ``new_state`` must be non-null; ``flag_name``
+--     must NOT be the environment-tier sentinel; tier columns must be
+--     NULL.
+--   * ``set_rollout_percent`` rows: ``new_rollout_percent`` must be
+--     non-null; ``scope`` must be ``'global'``; ``flag_name`` must NOT
+--     be the sentinel; tier columns must be NULL.
+--   * ``set_tier`` rows: ``flag_name`` must be the sentinel literal
+--     ``'__environment_tier__'``; ``scope`` must be ``'guild'``;
+--     ``guild_id`` must be non-null; ``new_tier`` must be non-null;
+--     state and rollout columns must be NULL.
+--
 -- Forward-only and idempotent.
 
 CREATE TABLE IF NOT EXISTS feature_flag_audit (
@@ -55,7 +71,47 @@ CREATE TABLE IF NOT EXISTS feature_flag_audit (
     CHECK (mutation_type IN
         ('set_state', 'set_rollout_percent', 'set_tier')),
     CHECK (actor_type IN
-        ('platform_owner', 'system', 'backfill'))
+        ('platform_owner', 'system', 'backfill')),
+    -- set_state rows must carry a non-null new_state, must NOT use the
+    -- environment-tier sentinel flag_name, and must leave tier columns
+    -- unset.
+    CHECK (
+        mutation_type <> 'set_state' OR (
+            new_state IS NOT NULL
+            AND flag_name <> '__environment_tier__'
+            AND prev_tier IS NULL
+            AND new_tier IS NULL
+        )
+    ),
+    -- set_rollout_percent rows are global-scoped, carry a non-null
+    -- new_rollout_percent, must not use the sentinel, and leave tier
+    -- columns unset.
+    CHECK (
+        mutation_type <> 'set_rollout_percent' OR (
+            scope = 'global'
+            AND guild_id IS NULL
+            AND new_rollout_percent IS NOT NULL
+            AND flag_name <> '__environment_tier__'
+            AND prev_tier IS NULL
+            AND new_tier IS NULL
+        )
+    ),
+    -- set_tier rows use the sentinel flag_name, are guild-scoped with
+    -- non-null guild_id and new_tier, and leave state + rollout
+    -- columns unset.  This is the explicit contract that lets the
+    -- single audit table host all three event sources.
+    CHECK (
+        mutation_type <> 'set_tier' OR (
+            flag_name = '__environment_tier__'
+            AND scope = 'guild'
+            AND guild_id IS NOT NULL
+            AND new_tier IS NOT NULL
+            AND prev_state IS NULL
+            AND new_state IS NULL
+            AND prev_rollout_percent IS NULL
+            AND new_rollout_percent IS NULL
+        )
+    )
 );
 
 CREATE INDEX IF NOT EXISTS idx_feature_flag_audit_flag_at

--- a/disbot/services/rollout_mutation.py
+++ b/disbot/services/rollout_mutation.py
@@ -1,0 +1,606 @@
+"""Rollout mutation pipeline — Phase 2d PR-3.
+
+The canonical write path for ``feature_flag_global_overrides``,
+``feature_flag_guild_overrides``, and ``environment_tiers``.  Mirrors
+the 7-step contract from
+:class:`~services.binding_mutation.BindingMutationPipeline`:
+
+  1. Input validation       — flag declared in the registry; mutation
+                              type matches the entry point; scope/state
+                              tokens recognized.
+  2. Authority validation   — actor_type within an explicit allowed
+                              set.  Discord-facing command surface is
+                              deferred to a follow-up PR.
+  3. Read previous state    — for the audit row.
+  4. DB write + audit       — single transaction via
+                              :mod:`utils.db.feature_flag_state` /
+                              :mod:`utils.db.environment_tiers`.
+  5. Cache invalidation     — :func:`core.runtime.feature_flags.clear_cache`
+                              scoped to the affected flag and/or guild.
+  6. Event emission         — advisory, post-commit, never raises.
+  7. Return result          — with mutation_id for cross-pipeline
+                              correlation.
+
+Authority model (intentionally minimal for PR-3):
+
+  * ``actor_type='platform_owner'`` — the only actor accepted from
+    operator scripts / future Discord admin command.  ``actor_id`` is
+    required to be non-None for this type.
+  * ``actor_type='system'`` — for CI seeds / migration helpers.
+    ``actor_id`` may be None.
+  * ``actor_type='backfill'`` — reserved for future logical-migration
+    runs (PR-5/6).  Currently no callers.
+
+Any other actor_type is rejected at step 2.  The Phase 4.5 typed
+access-control resolver will replace this with the same capability
+mechanism the binding pipeline uses.
+
+Hard limits for PR-3:
+
+  * No Discord admin command for flag mutation — operators mutate via
+    a one-off Python script that imports this pipeline.  The command
+    surface ships in a follow-up after authority is tightened.
+  * Subscribers of the three new events are not wired in this PR.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Literal
+
+from core.runtime import feature_flags
+from utils.db import environment_tiers as et_db
+from utils.db import feature_flag_state as ff_db
+
+logger = logging.getLogger("bot.services.rollout_mutation")
+
+# ---------------------------------------------------------------------------
+# Catalogued event names
+# ---------------------------------------------------------------------------
+
+EVT_FEATURE_FLAGS_CHANGED = "feature_flags.changed"
+EVT_ROLLOUT_ADVANCED = "rollout.advanced"
+EVT_ENVIRONMENT_TIER_CHANGED = "environment_tier.changed"
+
+# ---------------------------------------------------------------------------
+# Recognized literal sets (mirror migration 023 / 024 / 025 CHECK constraints)
+# ---------------------------------------------------------------------------
+
+_VALID_STATES: frozenset[str] = frozenset(
+    {"off", "owner", "canary", "beta", "production", "on"},
+)
+_VALID_TIERS: frozenset[str] = frozenset(
+    {"production", "beta", "canary", "owner_guild_only", "development"},
+)
+_ALLOWED_ACTOR_TYPES: frozenset[str] = frozenset(
+    {"platform_owner", "system", "backfill"},
+)
+
+Scope = Literal["global", "guild"]
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class RolloutMutationError(Exception):
+    """Base class for failures from :class:`RolloutMutationPipeline`."""
+
+
+class UnknownFeatureFlagError(RolloutMutationError):
+    """Raised when the flag_name is not in the FeatureFlag registry."""
+
+
+class InvalidStateError(RolloutMutationError):
+    """Raised when the supplied state token is not recognized."""
+
+
+class InvalidTierError(RolloutMutationError):
+    """Raised when the supplied tier token is not recognized."""
+
+
+class InvalidRolloutPercentError(RolloutMutationError):
+    """Raised when rollout_percent is outside 0..100."""
+
+
+class UnauthorizedRolloutMutationError(RolloutMutationError):
+    """Raised when ``actor_type`` is not in the allowed set or actor_id
+    is missing for an actor_type that requires it.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RolloutMutationResult:
+    """Outcome of a successful (or partially successful) mutation."""
+
+    mutation_id: str
+    flag_name: str
+    scope: Scope
+    guild_id: int | None
+    prev_state: str | None
+    new_state: str | None
+    prev_rollout_percent: int | None
+    new_rollout_percent: int | None
+    prev_tier: str | None
+    new_tier: str | None
+    mutation_type: Literal["set_state", "set_rollout_percent", "set_tier"]
+    committed_at: datetime
+    event_emitted: bool
+
+
+# ---------------------------------------------------------------------------
+# Pipeline
+# ---------------------------------------------------------------------------
+
+
+class RolloutMutationPipeline:
+    """Centralised orchestration for feature-flag + environment-tier writes.
+
+    Stateless — create one per mutation request.  Three public methods:
+
+    * :meth:`set_flag_state` — flip a flag on/off or to a tier name,
+      scoped global or per-guild.
+    * :meth:`set_rollout_percent` — change a global flag's rollout %.
+    * :meth:`set_environment_tier` — change a guild's tier.
+
+    All three follow the same 7-step contract documented in the module
+    docstring.
+    """
+
+    def __init__(self) -> None:
+        # No instance state.
+        pass
+
+    # ------------------------------------------------------------------
+    # set_flag_state
+    # ------------------------------------------------------------------
+
+    async def set_flag_state(
+        self,
+        *,
+        flag_name: str,
+        scope: Scope,
+        state: str,
+        actor_id: int | None,
+        actor_type: str = "platform_owner",
+        guild_id: int | None = None,
+    ) -> RolloutMutationResult:
+        """Set ``state`` on the global or per-guild override row."""
+        self._validate_flag(flag_name)
+        self._validate_state(state)
+        self._validate_scope_and_guild(scope, guild_id)
+        self._validate_authority(actor_id, actor_type)
+
+        mutation_id = str(uuid.uuid4())
+        if scope == "global":
+            prev = await ff_db.get_global_override(flag_name)
+            prev_state = prev["state"] if prev else None
+            prev_rollout = prev["rollout_percent"] if prev else None
+            try:
+                await ff_db.upsert_global_with_audit(
+                    flag_name=flag_name,
+                    state=state,
+                    rollout_percent=prev_rollout,
+                    actor_id=actor_id,
+                    actor_type=actor_type,
+                    mutation_id=mutation_id,
+                    prev_state=prev_state,
+                    prev_rollout_percent=prev_rollout,
+                    mutation_type="set_state",
+                )
+            except Exception:
+                logger.exception(
+                    "RolloutMutationPipeline.set_flag_state: DB transaction "
+                    "failed for flag=%r scope=global; no cache invalidation, "
+                    "no event emission.",
+                    flag_name,
+                )
+                raise
+            feature_flags.clear_cache(flag_name=flag_name)
+            committed_at = _now_utc()
+            event_emitted = await _emit_feature_flag_event(
+                mutation_id=mutation_id,
+                flag_name=flag_name,
+                scope="global",
+                guild_id=None,
+                prev_state=prev_state,
+                new_state=state,
+                actor_id=actor_id,
+                actor_type=actor_type,
+                committed_at=committed_at,
+            )
+            return RolloutMutationResult(
+                mutation_id=mutation_id,
+                flag_name=flag_name,
+                scope="global",
+                guild_id=None,
+                prev_state=prev_state,
+                new_state=state,
+                prev_rollout_percent=prev_rollout,
+                new_rollout_percent=prev_rollout,
+                prev_tier=None,
+                new_tier=None,
+                mutation_type="set_state",
+                committed_at=committed_at,
+                event_emitted=event_emitted,
+            )
+
+        # Guild-scoped branch.  guild_id non-null is guaranteed by
+        # _validate_scope_and_guild above; the assert is just for mypy.
+        assert guild_id is not None  # noqa: S101
+        prev_guild = await ff_db.get_guild_override(flag_name, guild_id)
+        prev_state = prev_guild["state"] if prev_guild else None
+        try:
+            await ff_db.upsert_guild_with_audit(
+                flag_name=flag_name,
+                guild_id=guild_id,
+                state=state,
+                actor_id=actor_id,
+                actor_type=actor_type,
+                mutation_id=mutation_id,
+                prev_state=prev_state,
+            )
+        except Exception:
+            logger.exception(
+                "RolloutMutationPipeline.set_flag_state: DB transaction "
+                "failed for flag=%r scope=guild guild=%d; no cache "
+                "invalidation, no event emission.",
+                flag_name,
+                guild_id,
+            )
+            raise
+        # Invalidate both the per-guild entry AND the global entry for
+        # this flag (a global lookup could have cached a "no guild row"
+        # decision that is now stale).
+        feature_flags.clear_cache(flag_name=flag_name, guild_id=guild_id)
+        feature_flags.clear_cache(flag_name=flag_name, guild_id=None)
+        committed_at = _now_utc()
+        event_emitted = await _emit_feature_flag_event(
+            mutation_id=mutation_id,
+            flag_name=flag_name,
+            scope="guild",
+            guild_id=guild_id,
+            prev_state=prev_state,
+            new_state=state,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            committed_at=committed_at,
+        )
+        return RolloutMutationResult(
+            mutation_id=mutation_id,
+            flag_name=flag_name,
+            scope="guild",
+            guild_id=guild_id,
+            prev_state=prev_state,
+            new_state=state,
+            prev_rollout_percent=None,
+            new_rollout_percent=None,
+            prev_tier=None,
+            new_tier=None,
+            mutation_type="set_state",
+            committed_at=committed_at,
+            event_emitted=event_emitted,
+        )
+
+    # ------------------------------------------------------------------
+    # set_rollout_percent
+    # ------------------------------------------------------------------
+
+    async def set_rollout_percent(
+        self,
+        *,
+        flag_name: str,
+        percent: int,
+        actor_id: int | None,
+        actor_type: str = "platform_owner",
+    ) -> RolloutMutationResult:
+        """Set the global rollout_percent for ``flag_name``."""
+        self._validate_flag(flag_name)
+        if not (0 <= percent <= 100):
+            raise InvalidRolloutPercentError(
+                f"rollout_percent must be in 0..100, got {percent!r}",
+            )
+        self._validate_authority(actor_id, actor_type)
+
+        mutation_id = str(uuid.uuid4())
+        prev = await ff_db.get_global_override(flag_name)
+        prev_state = prev["state"] if prev else "off"
+        prev_percent = prev["rollout_percent"] if prev else None
+        try:
+            await ff_db.upsert_global_with_audit(
+                flag_name=flag_name,
+                state=prev_state,
+                rollout_percent=percent,
+                actor_id=actor_id,
+                actor_type=actor_type,
+                mutation_id=mutation_id,
+                prev_state=prev_state,
+                prev_rollout_percent=prev_percent,
+                mutation_type="set_rollout_percent",
+            )
+        except Exception:
+            logger.exception(
+                "RolloutMutationPipeline.set_rollout_percent: DB transaction "
+                "failed for flag=%r; no cache invalidation, no event emission.",
+                flag_name,
+            )
+            raise
+        # Rollout changes invalidate every cached guild decision for
+        # this flag.
+        feature_flags.clear_cache(flag_name=flag_name)
+        committed_at = _now_utc()
+        event_emitted = await _emit_rollout_event(
+            mutation_id=mutation_id,
+            flag_name=flag_name,
+            prev_percent=prev_percent,
+            new_percent=percent,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            committed_at=committed_at,
+        )
+        return RolloutMutationResult(
+            mutation_id=mutation_id,
+            flag_name=flag_name,
+            scope="global",
+            guild_id=None,
+            prev_state=prev_state,
+            new_state=prev_state,
+            prev_rollout_percent=prev_percent,
+            new_rollout_percent=percent,
+            prev_tier=None,
+            new_tier=None,
+            mutation_type="set_rollout_percent",
+            committed_at=committed_at,
+            event_emitted=event_emitted,
+        )
+
+    # ------------------------------------------------------------------
+    # set_environment_tier
+    # ------------------------------------------------------------------
+
+    async def set_environment_tier(
+        self,
+        *,
+        guild_id: int,
+        tier: str,
+        actor_id: int | None,
+        actor_type: str = "platform_owner",
+    ) -> RolloutMutationResult:
+        """Set a guild's environment tier."""
+        if tier not in _VALID_TIERS:
+            raise InvalidTierError(
+                f"tier must be one of {sorted(_VALID_TIERS)}, got {tier!r}",
+            )
+        self._validate_authority(actor_id, actor_type)
+
+        mutation_id = str(uuid.uuid4())
+        prev_tier = await et_db.get_tier(guild_id)
+        try:
+            await et_db.upsert_with_audit(
+                guild_id=guild_id,
+                tier=tier,
+                actor_id=actor_id,
+                actor_type=actor_type,
+                mutation_id=mutation_id,
+                prev_tier=prev_tier,
+            )
+        except Exception:
+            logger.exception(
+                "RolloutMutationPipeline.set_environment_tier: DB transaction "
+                "failed for guild=%d; no cache invalidation, no event emission.",
+                guild_id,
+            )
+            raise
+        # A tier change can change every flag's effective value for
+        # this guild; drop every cached entry scoped to it.
+        feature_flags.clear_cache(guild_id=guild_id)
+        committed_at = _now_utc()
+        event_emitted = await _emit_environment_tier_event(
+            mutation_id=mutation_id,
+            guild_id=guild_id,
+            prev_tier=prev_tier,
+            new_tier=tier,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            committed_at=committed_at,
+        )
+        return RolloutMutationResult(
+            mutation_id=mutation_id,
+            flag_name="__environment_tier__",
+            scope="guild",
+            guild_id=guild_id,
+            prev_state=None,
+            new_state=None,
+            prev_rollout_percent=None,
+            new_rollout_percent=None,
+            prev_tier=prev_tier,
+            new_tier=tier,
+            mutation_type="set_tier",
+            committed_at=committed_at,
+            event_emitted=event_emitted,
+        )
+
+    # ------------------------------------------------------------------
+    # Validation helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _validate_flag(flag_name: str) -> None:
+        if feature_flags.get(flag_name) is None:
+            raise UnknownFeatureFlagError(
+                f"flag {flag_name!r} is not declared; register it in "
+                "core/runtime/feature_flags.py or the owning subsystem "
+                "before mutating.",
+            )
+
+    @staticmethod
+    def _validate_state(state: str) -> None:
+        if state not in _VALID_STATES:
+            raise InvalidStateError(
+                f"state must be one of {sorted(_VALID_STATES)}, got {state!r}",
+            )
+
+    @staticmethod
+    def _validate_scope_and_guild(scope: str, guild_id: int | None) -> None:
+        if scope not in ("global", "guild"):
+            raise RolloutMutationError(
+                f"scope must be 'global' or 'guild', got {scope!r}",
+            )
+        if scope == "guild" and guild_id is None:
+            raise RolloutMutationError(
+                "scope='guild' requires guild_id to be set",
+            )
+        if scope == "global" and guild_id is not None:
+            raise RolloutMutationError(
+                "scope='global' must not specify guild_id",
+            )
+
+    @staticmethod
+    def _validate_authority(actor_id: int | None, actor_type: str) -> None:
+        if actor_type not in _ALLOWED_ACTOR_TYPES:
+            raise UnauthorizedRolloutMutationError(
+                f"actor_type must be one of {sorted(_ALLOWED_ACTOR_TYPES)}, "
+                f"got {actor_type!r}",
+            )
+        if actor_type == "platform_owner" and actor_id is None:
+            raise UnauthorizedRolloutMutationError(
+                "actor_type='platform_owner' requires non-None actor_id",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Event emitters (post-commit, advisory)
+# ---------------------------------------------------------------------------
+
+
+async def _emit_feature_flag_event(
+    *,
+    mutation_id: str,
+    flag_name: str,
+    scope: Scope,
+    guild_id: int | None,
+    prev_state: str | None,
+    new_state: str,
+    actor_id: int | None,
+    actor_type: str,
+    committed_at: datetime,
+) -> bool:
+    """Emit feature_flags.changed.  Returns False on emission failure."""
+    from core.events import bus
+
+    try:
+        await bus.emit(
+            EVT_FEATURE_FLAGS_CHANGED,
+            mutation_id=mutation_id,
+            flag_name=flag_name,
+            scope=scope,
+            guild_id=guild_id,
+            prev_state=prev_state,
+            new_state=new_state,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            occurred_at=committed_at.isoformat(),
+        )
+    except Exception:
+        logger.exception(
+            "RolloutMutationPipeline: feature_flags.changed emission failed "
+            "for mutation_id=%s; DB state is correct, event lost.",
+            mutation_id,
+        )
+        return False
+    return True
+
+
+async def _emit_rollout_event(
+    *,
+    mutation_id: str,
+    flag_name: str,
+    prev_percent: int | None,
+    new_percent: int,
+    actor_id: int | None,
+    actor_type: str,
+    committed_at: datetime,
+) -> bool:
+    from core.events import bus
+
+    try:
+        await bus.emit(
+            EVT_ROLLOUT_ADVANCED,
+            mutation_id=mutation_id,
+            flag_name=flag_name,
+            prev_percent=prev_percent,
+            new_percent=new_percent,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            occurred_at=committed_at.isoformat(),
+        )
+    except Exception:
+        logger.exception(
+            "RolloutMutationPipeline: rollout.advanced emission failed "
+            "for mutation_id=%s; DB state is correct, event lost.",
+            mutation_id,
+        )
+        return False
+    return True
+
+
+async def _emit_environment_tier_event(
+    *,
+    mutation_id: str,
+    guild_id: int,
+    prev_tier: str | None,
+    new_tier: str,
+    actor_id: int | None,
+    actor_type: str,
+    committed_at: datetime,
+) -> bool:
+    from core.events import bus
+
+    try:
+        await bus.emit(
+            EVT_ENVIRONMENT_TIER_CHANGED,
+            mutation_id=mutation_id,
+            guild_id=guild_id,
+            prev_tier=prev_tier,
+            new_tier=new_tier,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            occurred_at=committed_at.isoformat(),
+        )
+    except Exception:
+        logger.exception(
+            "RolloutMutationPipeline: environment_tier.changed emission "
+            "failed for mutation_id=%s; DB state is correct, event lost.",
+            mutation_id,
+        )
+        return False
+    return True
+
+
+def _now_utc() -> datetime:
+    """Return a tz-aware "now" — INV-N forbids bare datetime.utcnow."""
+    return datetime.now(timezone.utc)
+
+
+__all__ = [
+    "EVT_ENVIRONMENT_TIER_CHANGED",
+    "EVT_FEATURE_FLAGS_CHANGED",
+    "EVT_ROLLOUT_ADVANCED",
+    "InvalidRolloutPercentError",
+    "InvalidStateError",
+    "InvalidTierError",
+    "RolloutMutationError",
+    "RolloutMutationPipeline",
+    "RolloutMutationResult",
+    "UnauthorizedRolloutMutationError",
+    "UnknownFeatureFlagError",
+]

--- a/disbot/utils/db/environment_tiers.py
+++ b/disbot/utils/db/environment_tiers.py
@@ -59,6 +59,53 @@ async def list_for_diagnostics() -> list[dict[str, Any]]:
     return [dict(r) for r in rows]
 
 
+async def upsert_with_audit(
+    *,
+    guild_id: int,
+    tier: str,
+    actor_id: int | None,
+    actor_type: str,
+    mutation_id: str,
+    prev_tier: str | None,
+) -> None:
+    """Atomic: upsert environment_tiers + write feature_flag_audit row.
+
+    The audit row uses ``flag_name='__environment_tier__'`` so the
+    single audit table covers all three Phase 2d event sources
+    (state, rollout, tier).  Caller is the RolloutMutationPipeline.
+    """
+    async with pool.get().acquire() as conn, conn.transaction():
+        await conn.execute(
+            """
+            INSERT INTO environment_tiers (guild_id, tier, set_by, set_at)
+            VALUES ($1, $2, $3, NOW())
+            ON CONFLICT (guild_id) DO UPDATE SET
+                tier = EXCLUDED.tier,
+                set_by = EXCLUDED.set_by,
+                set_at = NOW()
+            """,
+            guild_id,
+            tier,
+            actor_id,
+        )
+        await conn.execute(
+            """
+            INSERT INTO feature_flag_audit
+                (mutation_id, flag_name, scope, guild_id,
+                 prev_tier, new_tier,
+                 actor_id, actor_type, mutation_type)
+            VALUES ($1, '__environment_tier__', 'guild', $2, $3, $4,
+                    $5, $6, 'set_tier')
+            """,
+            mutation_id,
+            guild_id,
+            prev_tier,
+            tier,
+            actor_id,
+            actor_type,
+        )
+
+
 async def delete_for_guild(guild_id: int) -> int:
     """Delete the environment_tier row for ``guild_id``.
 
@@ -80,4 +127,5 @@ __all__ = [
     "delete_for_guild",
     "get_tier",
     "list_for_diagnostics",
+    "upsert_with_audit",
 ]

--- a/disbot/utils/db/environment_tiers.py
+++ b/disbot/utils/db/environment_tiers.py
@@ -1,0 +1,83 @@
+"""Environment tier mapping — DB read primitives (Phase 2d, PR-2).
+
+Owns the read surface for ``environment_tiers``.  The evaluator
+(:mod:`core.runtime.feature_flags`) consults this to resolve flags
+whose :class:`RolloutPolicy` carries a ``tier_gate``.
+
+State class (per ``docs/architecture.md`` §"State classification"):
+
+  **authoritative persistent** — the DB row is the single source of
+  truth for which guilds are owner/canary/beta/production.
+
+Public surface:
+
+* :func:`get_tier` — return the guild's tier string, or ``None``.
+* :func:`list_for_diagnostics` — read every row for ``!platform flags``.
+* :func:`delete_for_guild` — single-row delete called from
+  ``guild_lifecycle.teardown``.
+
+Writes ship with :class:`services.rollout_mutation.RolloutMutationPipeline`
+in PR-3.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from utils.db import pool
+
+logger = logging.getLogger("bot.db.environment_tiers")
+
+
+async def get_tier(guild_id: int) -> str | None:
+    """Return the tier string for ``guild_id``, or ``None`` when unset.
+
+    Missing row → caller treats the guild as ``'production'`` (most
+    restrictive default).  The evaluator centralises this defaulting
+    so DB-layer callers do not have to know the policy.
+    """
+    row = await pool.get().fetchrow(
+        "SELECT tier FROM environment_tiers WHERE guild_id = $1",
+        guild_id,
+    )
+    return row["tier"] if row else None
+
+
+async def list_for_diagnostics() -> list[dict[str, Any]]:
+    """Return every row, sorted by tier then guild_id.
+
+    Used by the diagnostics provider; not on any hot path.
+    """
+    rows = await pool.get().fetch(
+        """
+        SELECT guild_id, tier, set_by, set_at
+        FROM environment_tiers
+        ORDER BY tier, guild_id
+        """,
+    )
+    return [dict(r) for r in rows]
+
+
+async def delete_for_guild(guild_id: int) -> int:
+    """Delete the environment_tier row for ``guild_id``.
+
+    Returns the row count parsed from asyncpg's ``"DELETE N"`` status;
+    ``0`` on parse failure.  Called from ``guild_lifecycle.teardown``
+    so a re-invited guild falls back to PRODUCTION until reassigned.
+    """
+    result = await pool.get().execute(
+        "DELETE FROM environment_tiers WHERE guild_id = $1",
+        guild_id,
+    )
+    try:
+        return int(result.split()[-1])
+    except (ValueError, IndexError):
+        return 0
+
+
+__all__ = [
+    "delete_for_guild",
+    "get_tier",
+    "list_for_diagnostics",
+]

--- a/disbot/utils/db/feature_flag_state.py
+++ b/disbot/utils/db/feature_flag_state.py
@@ -97,6 +97,136 @@ async def list_guild_overrides(guild_id: int) -> list[dict[str, Any]]:
     return [dict(r) for r in rows]
 
 
+async def upsert_global_with_audit(
+    *,
+    flag_name: str,
+    state: str,
+    rollout_percent: int | None,
+    actor_id: int | None,
+    actor_type: str,
+    mutation_id: str,
+    prev_state: str | None,
+    prev_rollout_percent: int | None,
+    mutation_type: str,
+) -> None:
+    """Atomic: upsert feature_flag_global_overrides + write audit row.
+
+    Wraps both statements in a single asyncpg transaction so partial
+    failures roll back.  Called only from
+    :class:`services.rollout_mutation.RolloutMutationPipeline`.
+    """
+    async with pool.get().acquire() as conn, conn.transaction():
+        await conn.execute(
+            """
+            INSERT INTO feature_flag_global_overrides
+                (flag_name, state, rollout_percent, set_by, set_at)
+            VALUES ($1, $2, $3, $4, NOW())
+            ON CONFLICT (flag_name) DO UPDATE SET
+                state = EXCLUDED.state,
+                rollout_percent = EXCLUDED.rollout_percent,
+                set_by = EXCLUDED.set_by,
+                set_at = NOW()
+            """,
+            flag_name,
+            state,
+            rollout_percent,
+            actor_id,
+        )
+        await conn.execute(
+            """
+            INSERT INTO feature_flag_audit
+                (mutation_id, flag_name, scope, guild_id,
+                 prev_state, new_state,
+                 prev_rollout_percent, new_rollout_percent,
+                 actor_id, actor_type, mutation_type)
+            VALUES ($1, $2, 'global', NULL,
+                    $3, $4, $5, $6, $7, $8, $9)
+            """,
+            mutation_id,
+            flag_name,
+            prev_state,
+            state,
+            prev_rollout_percent,
+            rollout_percent,
+            actor_id,
+            actor_type,
+            mutation_type,
+        )
+
+
+async def upsert_guild_with_audit(
+    *,
+    flag_name: str,
+    guild_id: int,
+    state: str,
+    actor_id: int | None,
+    actor_type: str,
+    mutation_id: str,
+    prev_state: str | None,
+) -> None:
+    """Atomic: upsert feature_flag_guild_overrides + audit row."""
+    async with pool.get().acquire() as conn, conn.transaction():
+        await conn.execute(
+            """
+            INSERT INTO feature_flag_guild_overrides
+                (flag_name, guild_id, state, set_by, set_at)
+            VALUES ($1, $2, $3, $4, NOW())
+            ON CONFLICT (flag_name, guild_id) DO UPDATE SET
+                state = EXCLUDED.state,
+                set_by = EXCLUDED.set_by,
+                set_at = NOW()
+            """,
+            flag_name,
+            guild_id,
+            state,
+            actor_id,
+        )
+        await conn.execute(
+            """
+            INSERT INTO feature_flag_audit
+                (mutation_id, flag_name, scope, guild_id,
+                 prev_state, new_state,
+                 actor_id, actor_type, mutation_type)
+            VALUES ($1, $2, 'guild', $3, $4, $5, $6, $7, 'set_state')
+            """,
+            mutation_id,
+            flag_name,
+            guild_id,
+            prev_state,
+            state,
+            actor_id,
+            actor_type,
+        )
+
+
+async def get_audit_count(
+    *,
+    flag_name: str | None = None,
+    guild_id: int | None = None,
+) -> int:
+    """Return audit-row count, optionally filtered by flag and/or guild.
+
+    Used by tests + diagnostics to assert audit rows landed.
+    """
+    if flag_name is not None and guild_id is not None:
+        sql = (
+            "SELECT COUNT(*)::int AS n FROM feature_flag_audit "
+            "WHERE flag_name = $1 AND guild_id = $2"
+        )
+        row = await pool.get().fetchrow(sql, flag_name, guild_id)
+    elif flag_name is not None:
+        sql = "SELECT COUNT(*)::int AS n FROM feature_flag_audit WHERE flag_name = $1"
+        row = await pool.get().fetchrow(sql, flag_name)
+    elif guild_id is not None:
+        sql = "SELECT COUNT(*)::int AS n FROM feature_flag_audit WHERE guild_id = $1"
+        row = await pool.get().fetchrow(sql, guild_id)
+    else:
+        row = await pool.get().fetchrow(
+            "SELECT COUNT(*)::int AS n FROM feature_flag_audit",
+        )
+    return int(row["n"]) if row else 0
+
+
 async def delete_for_guild(guild_id: int) -> int:
     """Delete every per-guild override for ``guild_id``; preserve globals.
 
@@ -118,8 +248,11 @@ async def delete_for_guild(guild_id: int) -> int:
 
 __all__ = [
     "delete_for_guild",
+    "get_audit_count",
     "get_global_override",
     "get_guild_override",
     "list_global_overrides",
     "list_guild_overrides",
+    "upsert_global_with_audit",
+    "upsert_guild_with_audit",
 ]

--- a/disbot/utils/db/feature_flag_state.py
+++ b/disbot/utils/db/feature_flag_state.py
@@ -1,0 +1,125 @@
+"""Feature flag state — DB read primitives (Phase 2d, PR-2).
+
+Owns the read surface for ``feature_flag_global_overrides`` and
+``feature_flag_guild_overrides``.  The evaluator
+(:mod:`core.runtime.feature_flags`) calls these primitives behind a
+TTL-bounded cache.  Writes do not exist in this PR — they ship with
+:class:`services.rollout_mutation.RolloutMutationPipeline` in PR-3.
+
+State class (per ``docs/architecture.md`` §"State classification"):
+
+  **authoritative persistent** — the DB row is the canonical override
+  for a flag.  Evaluator cache rows are derived state that may be
+  invalidated at any time.
+
+Public surface:
+
+* :func:`get_global_override` — single-row read.
+* :func:`get_guild_override` — single-row read scoped to a guild.
+* :func:`delete_for_guild` — purge ALL per-guild overrides for one
+  guild (called from ``guild_lifecycle.teardown``).  Global rows are
+  never touched here.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from utils.db import pool
+
+logger = logging.getLogger("bot.db.feature_flag_state")
+
+
+async def get_global_override(flag_name: str) -> dict[str, Any] | None:
+    """Return the global override row for ``flag_name``, or ``None``.
+
+    The returned dict carries ``state`` (str), ``rollout_percent``
+    (int | None), ``set_by`` (int | None), ``set_at``
+    (:class:`datetime`).  Callers convert ``state`` into the typed
+    enum at the layer above (the evaluator).
+    """
+    row = await pool.get().fetchrow(
+        """
+        SELECT flag_name, state, rollout_percent, set_by, set_at
+        FROM feature_flag_global_overrides
+        WHERE flag_name = $1
+        """,
+        flag_name,
+    )
+    return dict(row) if row else None
+
+
+async def get_guild_override(
+    flag_name: str,
+    guild_id: int,
+) -> dict[str, Any] | None:
+    """Return the per-guild override row, or ``None`` when absent."""
+    row = await pool.get().fetchrow(
+        """
+        SELECT flag_name, guild_id, state, set_by, set_at
+        FROM feature_flag_guild_overrides
+        WHERE flag_name = $1 AND guild_id = $2
+        """,
+        flag_name,
+        guild_id,
+    )
+    return dict(row) if row else None
+
+
+async def list_global_overrides() -> list[dict[str, Any]]:
+    """Return every global override row.
+
+    Used by the diagnostics provider so ``!platform flags`` can render
+    the global state alongside the declarations.
+    """
+    rows = await pool.get().fetch(
+        """
+        SELECT flag_name, state, rollout_percent, set_by, set_at
+        FROM feature_flag_global_overrides
+        ORDER BY flag_name
+        """,
+    )
+    return [dict(r) for r in rows]
+
+
+async def list_guild_overrides(guild_id: int) -> list[dict[str, Any]]:
+    """Return every per-guild override row for ``guild_id``."""
+    rows = await pool.get().fetch(
+        """
+        SELECT flag_name, guild_id, state, set_by, set_at
+        FROM feature_flag_guild_overrides
+        WHERE guild_id = $1
+        ORDER BY flag_name
+        """,
+        guild_id,
+    )
+    return [dict(r) for r in rows]
+
+
+async def delete_for_guild(guild_id: int) -> int:
+    """Delete every per-guild override for ``guild_id``; preserve globals.
+
+    Phase 2 retention policy: the GLOBAL overrides row survives every
+    guild leave (it's not scoped to a single guild).  This primitive
+    touches only ``feature_flag_guild_overrides``.  Returns the row
+    count parsed from asyncpg's ``"DELETE N"`` status string; ``0`` on
+    any parse failure.
+    """
+    result = await pool.get().execute(
+        "DELETE FROM feature_flag_guild_overrides WHERE guild_id = $1",
+        guild_id,
+    )
+    try:
+        return int(result.split()[-1])
+    except (ValueError, IndexError):
+        return 0
+
+
+__all__ = [
+    "delete_for_guild",
+    "get_global_override",
+    "get_guild_override",
+    "list_global_overrides",
+    "list_guild_overrides",
+]

--- a/tests/unit/config_arbitration/test_read_config.py
+++ b/tests/unit/config_arbitration/test_read_config.py
@@ -92,6 +92,18 @@ async def test_flag_off_returns_legacy_value_binding_not_consulted():
 
 @pytest.mark.asyncio
 async def test_flag_off_legacy_missing_returns_none_with_missing_source():
+    """Flag OFF + legacy empty → source='missing' (PR-4 review correction).
+
+    The earlier behavior returned ``source='legacy'`` because legacy
+    was where the ``None`` came from.  The review pointed out that
+    this makes the ``!platform consistency`` "how many guilds have
+    nothing configured?" query painful — operators would have to
+    filter by ``(source=='legacy' AND value is None)`` instead of a
+    single counter.  ``source='missing'`` is now returned whenever
+    the resolved value is ``None``, regardless of which side produced
+    it; ``flag_state`` and ``binding_status`` carry the distinguishing
+    context.
+    """
     with (
         patch(
             "core.runtime.feature_flags.is_enabled",
@@ -111,11 +123,114 @@ async def test_flag_off_legacy_missing_returns_none_with_missing_source():
             legacy_key="xp_announce_channel",
         )
     assert result.value is None
-    # With flag OFF + legacy empty, source is legacy (we still consulted
-    # legacy and that's where the "none" came from).  source='missing'
-    # is reserved for the flag-ON path where neither side produced a
-    # value — semantically the distinction matters for diagnostics.
-    assert result.source == "legacy"
+    assert result.source == "missing"
+    assert result.flag_state == "off"
+    assert result.binding_status == "n/a"
+
+
+# ---------------------------------------------------------------------------
+# Binding-kind verification (PR-4 enhancement)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_binding_kind_match_returns_binding_source():
+    """Caller-declared kind matches the binding's declared kind → binding wins."""
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "core.runtime.bindings.get_binding",
+            new_callable=AsyncMock,
+            return_value=_bv(target_id=999, status=ResourceStatus.BOUND),
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+        ) as mock_legacy,
+    ):
+        result = await read_config(
+            guild_id=1,
+            subsystem="xp",
+            binding_name="announce_channel",
+            legacy_key="xp_announce_channel",
+            binding_kind="channel",
+        )
+    assert result.value == 999
+    assert result.source == "binding"
+    assert result.binding_status == "bound"
+    mock_legacy.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_binding_kind_mismatch_falls_back_with_drift_diagnostic():
+    """Caller asked for 'role' but the binding declares 'channel' → fallback.
+
+    A kind drift means schema and runtime disagree (a future schema
+    change reshaped the binding); the safest behavior is to treat the
+    binding as INVALID and fall back to legacy.  The drift is recorded
+    in ``diagnostics`` so ``!platform consistency`` can surface it.
+    """
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "core.runtime.bindings.get_binding",
+            new_callable=AsyncMock,
+            return_value=_bv(target_id=999, status=ResourceStatus.BOUND),
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="legacy-value",
+        ),
+    ):
+        result = await read_config(
+            guild_id=1,
+            subsystem="xp",
+            binding_name="announce_channel",
+            legacy_key="xp_announce_channel",
+            binding_kind="role",
+        )
+    assert result.value == "legacy-value"
+    assert result.source == "fallback"
+    assert any("binding kind drift" in d for d in result.diagnostics)
+
+
+@pytest.mark.asyncio
+async def test_binding_kind_omitted_does_not_verify():
+    """When no expected kind is supplied, the binding wins as before."""
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "core.runtime.bindings.get_binding",
+            new_callable=AsyncMock,
+            return_value=_bv(target_id=999, status=ResourceStatus.BOUND),
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+        ),
+    ):
+        result = await read_config(
+            guild_id=1,
+            subsystem="xp",
+            binding_name="announce_channel",
+            legacy_key="xp_announce_channel",
+            # binding_kind intentionally omitted
+        )
+    assert result.source == "binding"
+    assert not any("kind drift" in d for d in result.diagnostics)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/config_arbitration/test_read_config.py
+++ b/tests/unit/config_arbitration/test_read_config.py
@@ -1,0 +1,343 @@
+"""Phase 2 PR-4 — central read-source arbitration.
+
+Verifies the resolution ladder for ``read_config``:
+
+* flag OFF → legacy (binding never consulted)
+* flag ON + binding BOUND → binding value
+* flag ON + binding MISSING/INVALID/UNRESOLVED → legacy fallback
+* flag ON + neither legacy nor binding produced a value → missing
+* failure isolation: ``is_enabled`` raising falls back to legacy;
+  ``get_binding`` raising falls back to legacy.
+
+Also pins:
+* No cache layer added by the arbitration helper itself.
+* Counters accumulate for the diagnostics provider.
+* ``ConfigReadResult`` carries provenance fields needed by setup-wizard
+  previews and the future ``!platform consistency`` view.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from core.resources.status import ResourceStatus
+from core.runtime import config_arbitration
+from core.runtime.bindings import BindingValue
+from core.runtime.config_arbitration import ConfigReadResult, read_config
+from core.runtime.subsystem_schema import BindingKind
+
+
+@pytest.fixture(autouse=True)
+def _reset_counters():
+    config_arbitration._reset_counters_for_tests()
+    yield
+    config_arbitration._reset_counters_for_tests()
+
+
+def _bv(*, target_id: int | None, status: ResourceStatus) -> BindingValue:
+    return BindingValue(
+        guild_id=1,
+        subsystem="xp",
+        binding_name="announce_channel",
+        kind=BindingKind.CHANNEL,
+        target_id=target_id,
+        status=status,
+        last_validated_at=datetime.now(timezone.utc),
+        last_updated_at=datetime.now(timezone.utc),
+        version=1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Flag OFF → legacy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_flag_off_returns_legacy_value_binding_not_consulted():
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "core.runtime.bindings.get_binding",
+            new_callable=AsyncMock,
+        ) as mock_binding,
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="12345",
+        ),
+    ):
+        result = await read_config(
+            guild_id=1,
+            subsystem="xp",
+            binding_name="announce_channel",
+            legacy_key="xp_announce_channel",
+        )
+    assert result == ConfigReadResult(
+        value="12345",
+        source="legacy",
+        binding_status="n/a",
+        flag_state="off",
+        diagnostics=[],
+    )
+    mock_binding.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_flag_off_legacy_missing_returns_none_with_missing_source():
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="",
+        ),
+    ):
+        result = await read_config(
+            guild_id=1,
+            subsystem="xp",
+            binding_name="announce_channel",
+            legacy_key="xp_announce_channel",
+        )
+    assert result.value is None
+    # With flag OFF + legacy empty, source is legacy (we still consulted
+    # legacy and that's where the "none" came from).  source='missing'
+    # is reserved for the flag-ON path where neither side produced a
+    # value — semantically the distinction matters for diagnostics.
+    assert result.source == "legacy"
+
+
+# ---------------------------------------------------------------------------
+# Flag ON + binding BOUND
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_flag_on_binding_bound_returns_binding_value():
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "core.runtime.bindings.get_binding",
+            new_callable=AsyncMock,
+            return_value=_bv(target_id=999, status=ResourceStatus.BOUND),
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+        ) as mock_legacy,
+    ):
+        result = await read_config(
+            guild_id=1,
+            subsystem="xp",
+            binding_name="announce_channel",
+            legacy_key="xp_announce_channel",
+        )
+    assert result.value == 999
+    assert result.source == "binding"
+    assert result.binding_status == "bound"
+    assert result.flag_state == "on"
+    # Legacy must not be consulted when binding is BOUND
+    mock_legacy.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Flag ON + binding MISSING/INVALID/UNRESOLVED → fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "binding_status",
+    [
+        ResourceStatus.MISSING,
+        ResourceStatus.INVALID,
+        ResourceStatus.UNRESOLVED,
+    ],
+)
+@pytest.mark.asyncio
+async def test_flag_on_binding_not_bound_falls_back_to_legacy(binding_status):
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "core.runtime.bindings.get_binding",
+            new_callable=AsyncMock,
+            return_value=_bv(target_id=None, status=binding_status),
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="legacy-value",
+        ),
+    ):
+        result = await read_config(
+            guild_id=1,
+            subsystem="xp",
+            binding_name="announce_channel",
+            legacy_key="xp_announce_channel",
+        )
+    assert result.value == "legacy-value"
+    assert result.source == "fallback"
+    assert result.binding_status == binding_status.value
+    assert result.flag_state == "on"
+    assert any("binding not bound" in d for d in result.diagnostics)
+
+
+@pytest.mark.asyncio
+async def test_flag_on_both_empty_returns_missing():
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "core.runtime.bindings.get_binding",
+            new_callable=AsyncMock,
+            return_value=_bv(target_id=None, status=ResourceStatus.UNRESOLVED),
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="",
+        ),
+    ):
+        result = await read_config(
+            guild_id=1,
+            subsystem="xp",
+            binding_name="announce_channel",
+            legacy_key="xp_announce_channel",
+        )
+    assert result.value is None
+    assert result.source == "missing"
+
+
+# ---------------------------------------------------------------------------
+# Failure isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_is_enabled_failure_falls_back_to_legacy_off_path():
+    """If is_enabled raises, arbitration treats the flag as OFF."""
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("evaluator crashed"),
+        ),
+        patch(
+            "core.runtime.bindings.get_binding",
+            new_callable=AsyncMock,
+        ) as mock_binding,
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="legacy-value",
+        ),
+    ):
+        result = await read_config(
+            guild_id=1,
+            subsystem="xp",
+            binding_name="announce_channel",
+            legacy_key="xp_announce_channel",
+        )
+    assert result.source == "legacy"
+    assert result.flag_state == "off"
+    assert any("is_enabled raised" in d for d in result.diagnostics)
+    mock_binding.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_binding_failure_falls_back_to_legacy():
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "core.runtime.bindings.get_binding",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("DB blip"),
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="legacy-value",
+        ),
+    ):
+        result = await read_config(
+            guild_id=1,
+            subsystem="xp",
+            binding_name="announce_channel",
+            legacy_key="xp_announce_channel",
+        )
+    assert result.value == "legacy-value"
+    assert result.source == "fallback"
+    assert result.flag_state == "on"
+    assert any("get_binding raised" in d for d in result.diagnostics)
+
+
+# ---------------------------------------------------------------------------
+# Counters + diagnostics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_counters_increment_per_call():
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="x",
+        ),
+    ):
+        await read_config(
+            guild_id=1,
+            subsystem="xp",
+            binding_name="announce_channel",
+            legacy_key="xp_announce_channel",
+        )
+        await read_config(
+            guild_id=2,
+            subsystem="economy",
+            binding_name="log_channel",
+            legacy_key="economy_log_channel",
+        )
+    snap = config_arbitration.counters_snapshot()
+    assert snap["calls_total"] == 2
+    assert snap["by_source"]["legacy"] == 2
+    assert snap["by_flag_state"]["off"] == 2
+
+
+def test_diagnostics_provider_registered():
+    """!platform consistency consumer reads the counters via this provider."""
+    from services import diagnostics_service
+
+    snap = diagnostics_service.snapshot("config_arbitration")
+    assert "arbitration" in snap
+    assert "calls_total" in snap["arbitration"]
+    assert "by_source" in snap["arbitration"]

--- a/tests/unit/feature_flags/test_environment_tiers_db.py
+++ b/tests/unit/feature_flags/test_environment_tiers_db.py
@@ -1,0 +1,66 @@
+"""Phase 2d PR-2 — utils.db.environment_tiers primitives."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from utils.db import environment_tiers as et_db
+
+
+@pytest.fixture
+def _mock_pool():
+    pool_mock = MagicMock()
+    pool_mock.execute = AsyncMock()
+    pool_mock.fetchrow = AsyncMock()
+    pool_mock.fetch = AsyncMock()
+    with patch.object(et_db, "pool") as pool_module:
+        pool_module.get = MagicMock(return_value=pool_mock)
+        yield pool_mock
+
+
+@pytest.mark.asyncio
+async def test_get_tier_returns_string_when_row_present(_mock_pool):
+    _mock_pool.fetchrow.return_value = {"tier": "canary"}
+    assert await et_db.get_tier(42) == "canary"
+
+
+@pytest.mark.asyncio
+async def test_get_tier_returns_none_when_absent(_mock_pool):
+    _mock_pool.fetchrow.return_value = None
+    assert await et_db.get_tier(42) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_for_guild_targets_correct_guild(_mock_pool):
+    _mock_pool.execute.return_value = "DELETE 1"
+    deleted = await et_db.delete_for_guild(42)
+    sql, *args = _mock_pool.execute.await_args.args
+    assert "environment_tiers" in sql
+    assert "WHERE guild_id = $1" in sql
+    assert args == [42]
+    assert deleted == 1
+
+
+@pytest.mark.asyncio
+async def test_delete_for_guild_handles_zero_rows(_mock_pool):
+    _mock_pool.execute.return_value = "DELETE 0"
+    assert await et_db.delete_for_guild(42) == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_for_guild_handles_unexpected_status(_mock_pool):
+    _mock_pool.execute.return_value = "weird"
+    assert await et_db.delete_for_guild(42) == 0
+
+
+@pytest.mark.asyncio
+async def test_list_for_diagnostics_returns_rows(_mock_pool):
+    _mock_pool.fetch.return_value = [
+        {"guild_id": 1, "tier": "owner_guild_only", "set_by": 99, "set_at": None},
+        {"guild_id": 2, "tier": "canary", "set_by": 99, "set_at": None},
+    ]
+    rows = await et_db.list_for_diagnostics()
+    assert len(rows) == 2
+    assert rows[0]["tier"] == "owner_guild_only"

--- a/tests/unit/feature_flags/test_evaluator.py
+++ b/tests/unit/feature_flags/test_evaluator.py
@@ -1,0 +1,445 @@
+"""Phase 2d PR-2 — is_enabled evaluator + cache + bootstrap policy.
+
+Covers:
+
+* Bootstrap policy: emergency env override beats everything; the
+  ``feature_flag.primary`` meta-gate bypasses DB on its own evaluation
+  and forces declared-default for other flags when OFF.
+* DB-backed resolution order: per-guild override → global override →
+  rollout policy → declared default.
+* Deterministic rollout hash: same ``(flag, guild)`` → same bucket.
+* Cache behaviour: TTL eviction, manual clear, per-guild clear.
+* DB-unreachable fallback: returns declared default + emits bootstrap
+  metric, never raises.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from core.runtime import feature_flags
+from core.runtime.feature_flags import (
+    BINDINGS_PRIMARY,
+    FEATURE_FLAG_PRIMARY,
+    EnvironmentTier,
+    FeatureFlag,
+    RolloutPolicy,
+    _register_builtins,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state():
+    """Each test starts with a clean registry, cache, and metric counter."""
+    feature_flags._reset_for_tests()
+    _register_builtins()
+    # Ensure no test runs under a leaked env override.
+    for key in list(os.environ):
+        if key.startswith("SUPERBOT_FF_"):
+            del os.environ[key]
+    yield
+    feature_flags._reset_for_tests()
+    for key in list(os.environ):
+        if key.startswith("SUPERBOT_FF_"):
+            del os.environ[key]
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap policy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_env_override_wins_for_arbitrary_flag(monkeypatch):
+    """SUPERBOT_FF_<FLAG>=on/off always wins, regardless of DB state."""
+    monkeypatch.setenv("SUPERBOT_FF_BINDINGS_PRIMARY", "on")
+    decision = await feature_flags.resolve_with_provenance(
+        "bindings.primary",
+        guild_id=42,
+    )
+    assert decision.value is True
+    assert decision.source == "env"
+
+
+@pytest.mark.asyncio
+async def test_env_override_recognized_boolean_literals(monkeypatch):
+    for raw in ("true", "yes", "ON", "1"):
+        monkeypatch.setenv("SUPERBOT_FF_BINDINGS_PRIMARY", raw)
+        assert await feature_flags.is_enabled("bindings.primary", 42) is True
+    for raw in ("false", "no", "off", "0"):
+        monkeypatch.setenv("SUPERBOT_FF_BINDINGS_PRIMARY", raw)
+        feature_flags.clear_cache()
+        assert await feature_flags.is_enabled("bindings.primary", 42) is False
+
+
+@pytest.mark.asyncio
+async def test_unknown_env_value_is_ignored(monkeypatch):
+    """An unrecognized env value falls through to the bootstrap path."""
+    monkeypatch.setenv("SUPERBOT_FF_BINDINGS_PRIMARY", "maybe?")
+    # feature_flag.primary defaults OFF → declared default returned.
+    decision = await feature_flags.resolve_with_provenance(
+        "bindings.primary",
+        guild_id=42,
+    )
+    assert decision.source == "default"
+    assert decision.value == BINDINGS_PRIMARY.default_value
+
+
+@pytest.mark.asyncio
+async def test_feature_flag_primary_off_returns_declared_default():
+    """With feature_flag.primary OFF (declared default), DB is bypassed."""
+    decision = await feature_flags.resolve_with_provenance(
+        "bindings.primary",
+        guild_id=42,
+    )
+    assert decision.source == "default"
+    assert decision.value == BINDINGS_PRIMARY.default_value
+
+
+@pytest.mark.asyncio
+async def test_feature_flag_primary_resolves_via_env_only(monkeypatch):
+    """The meta-flag's value never comes from the DB."""
+    monkeypatch.setenv("SUPERBOT_FF_FEATURE_FLAG_PRIMARY", "on")
+    decision = await feature_flags.resolve_with_provenance(
+        FEATURE_FLAG_PRIMARY.name,
+        guild_id=42,
+    )
+    assert decision.value is True
+    assert decision.source == "env"
+
+
+@pytest.mark.asyncio
+async def test_undeclared_flag_returns_false_with_default_source():
+    decision = await feature_flags.resolve_with_provenance(
+        "does.not.exist",
+        guild_id=42,
+    )
+    assert decision.value is False
+    assert decision.source == "default"
+
+
+# ---------------------------------------------------------------------------
+# DB-backed resolution order
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_per_guild_override_beats_global(monkeypatch):
+    """When feature_flag.primary is ON, per-guild row beats the global row."""
+    monkeypatch.setenv("SUPERBOT_FF_FEATURE_FLAG_PRIMARY", "on")
+
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_guild_override",
+            new_callable=AsyncMock,
+            return_value={"state": "on"},
+        ),
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value={"state": "off", "rollout_percent": None},
+        ),
+        patch(
+            "utils.db.environment_tiers.get_tier",
+            new_callable=AsyncMock,
+            return_value="production",
+        ),
+    ):
+        decision = await feature_flags.resolve_with_provenance(
+            "bindings.primary",
+            guild_id=42,
+        )
+    assert decision.value is True
+    assert decision.source == "db_guild"
+
+
+@pytest.mark.asyncio
+async def test_global_override_used_when_no_guild_row(monkeypatch):
+    monkeypatch.setenv("SUPERBOT_FF_FEATURE_FLAG_PRIMARY", "on")
+
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_guild_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value={"state": "on", "rollout_percent": None},
+        ),
+        patch(
+            "utils.db.environment_tiers.get_tier",
+            new_callable=AsyncMock,
+            return_value="production",
+        ),
+    ):
+        decision = await feature_flags.resolve_with_provenance(
+            "bindings.primary",
+            guild_id=42,
+        )
+    assert decision.value is True
+    assert decision.source == "db_global"
+
+
+@pytest.mark.asyncio
+async def test_rollout_policy_grants_via_tier_for_staged_guild(monkeypatch):
+    """An explicit staged_guild + matching tier returns True via tier."""
+    monkeypatch.setenv("SUPERBOT_FF_FEATURE_FLAG_PRIMARY", "on")
+
+    staged_flag = FeatureFlag(
+        name="test.staged",
+        description="staged guild check",
+        default_value=False,
+        rollout_policy=RolloutPolicy(
+            staged_guilds=(42,),
+            percentage_rollout=0,
+            tier_gate=EnvironmentTier.CANARY,
+        ),
+    )
+    feature_flags.register(staged_flag)
+
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_guild_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.environment_tiers.get_tier",
+            new_callable=AsyncMock,
+            return_value="canary",
+        ),
+    ):
+        decision = await feature_flags.resolve_with_provenance(
+            "test.staged",
+            guild_id=42,
+        )
+    assert decision.value is True
+    assert decision.source == "tier"
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_declared_default(monkeypatch):
+    monkeypatch.setenv("SUPERBOT_FF_FEATURE_FLAG_PRIMARY", "on")
+
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_guild_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.environment_tiers.get_tier",
+            new_callable=AsyncMock,
+            return_value="production",
+        ),
+    ):
+        decision = await feature_flags.resolve_with_provenance(
+            "bindings.primary",
+            guild_id=42,
+        )
+    assert decision.value == BINDINGS_PRIMARY.default_value
+    assert decision.source == "default"
+
+
+# ---------------------------------------------------------------------------
+# Deterministic rollout hash
+# ---------------------------------------------------------------------------
+
+
+def test_rollout_bucket_deterministic():
+    """Same (flag, guild) always produces the same bucket."""
+    bucket_a = feature_flags._rollout_bucket("bindings.primary", 12345)
+    bucket_b = feature_flags._rollout_bucket("bindings.primary", 12345)
+    assert bucket_a == bucket_b
+    assert 0 <= bucket_a < 100
+
+
+def test_rollout_bucket_varies_per_flag_and_guild():
+    """Different flags / guilds usually land in different buckets."""
+    base = feature_flags._rollout_bucket("bindings.primary", 1)
+    other_guild = feature_flags._rollout_bucket("bindings.primary", 2)
+    other_flag = feature_flags._rollout_bucket("participation.enabled", 1)
+    # Not asserting strict inequality (collisions exist) but at least
+    # one of these should differ from base in any reasonable sample.
+    assert (other_guild != base) or (other_flag != base)
+
+
+@pytest.mark.asyncio
+async def test_rollout_percentage_includes_some_guilds(monkeypatch):
+    """At 50% rollout, roughly half a wide range of guilds is enabled."""
+    monkeypatch.setenv("SUPERBOT_FF_FEATURE_FLAG_PRIMARY", "on")
+
+    flag = FeatureFlag(
+        name="test.rollout",
+        description="50% rollout",
+        default_value=False,
+        rollout_policy=RolloutPolicy(
+            staged_guilds=(),
+            percentage_rollout=50,
+            tier_gate=EnvironmentTier.PRODUCTION,
+        ),
+    )
+    feature_flags.register(flag)
+
+    enabled = 0
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_guild_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.environment_tiers.get_tier",
+            new_callable=AsyncMock,
+            return_value="production",
+        ),
+    ):
+        for guild_id in range(1, 201):
+            feature_flags.clear_cache()
+            if await feature_flags.is_enabled("test.rollout", guild_id):
+                enabled += 1
+    # sha256 with 200 samples should land somewhere in 30..70% of true
+    # enablement at 50% rollout.  Wide tolerance keeps the test
+    # deterministic across runs without being trivially loose.
+    assert (
+        60 <= enabled <= 140
+    ), f"expected ~100/200 enabled at 50% rollout, got {enabled}"
+
+
+# ---------------------------------------------------------------------------
+# Cache behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_avoids_second_db_call(monkeypatch):
+    monkeypatch.setenv("SUPERBOT_FF_FEATURE_FLAG_PRIMARY", "on")
+
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_guild_override",
+            new_callable=AsyncMock,
+            return_value={"state": "on"},
+        ) as mock_guild,
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.environment_tiers.get_tier",
+            new_callable=AsyncMock,
+            return_value="production",
+        ),
+    ):
+        await feature_flags.is_enabled("bindings.primary", 42)
+        await feature_flags.is_enabled("bindings.primary", 42)
+    assert mock_guild.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_clear_cache_evicts_specific_guild(monkeypatch):
+    monkeypatch.setenv("SUPERBOT_FF_FEATURE_FLAG_PRIMARY", "on")
+
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_guild_override",
+            new_callable=AsyncMock,
+            return_value={"state": "on"},
+        ),
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.environment_tiers.get_tier",
+            new_callable=AsyncMock,
+            return_value="production",
+        ),
+    ):
+        await feature_flags.is_enabled("bindings.primary", 42)
+        await feature_flags.is_enabled("bindings.primary", 99)
+        # 3 entries in cache: (bindings.primary, 42), (bindings.primary, 99),
+        # plus any recursive (feature_flag.primary) lookups would normally
+        # be cached too — but feature_flag.primary bypasses cache because
+        # it's the meta-flag.  We assert specifically by drop count below.
+        removed = feature_flags.clear_cache(guild_id=42)
+    assert removed == 1
+
+
+def test_clear_cache_no_args_drops_everything():
+    feature_flags._CACHE[("a", 1)] = (True, "default", 1e18)
+    feature_flags._CACHE[("b", 2)] = (False, "default", 1e18)
+    assert feature_flags.clear_cache() == 2
+    assert not feature_flags._CACHE
+
+
+def test_clear_cache_by_flag_only():
+    feature_flags._CACHE[("a", 1)] = (True, "default", 1e18)
+    feature_flags._CACHE[("a", 2)] = (True, "default", 1e18)
+    feature_flags._CACHE[("b", 1)] = (False, "default", 1e18)
+    assert feature_flags.clear_cache(flag_name="a") == 2
+    assert ("a", 1) not in feature_flags._CACHE
+    assert ("a", 2) not in feature_flags._CACHE
+    assert ("b", 1) in feature_flags._CACHE
+
+
+# ---------------------------------------------------------------------------
+# DB-unreachable bootstrap fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_db_failure_returns_default_and_increments_metric(monkeypatch):
+    """The evaluator must never raise; declared default returned + metric fires."""
+    monkeypatch.setenv("SUPERBOT_FF_FEATURE_FLAG_PRIMARY", "on")
+    feature_flags._reset_metrics_for_tests()
+
+    with patch(
+        "utils.db.feature_flag_state.get_guild_override",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("connection refused"),
+    ):
+        decision = await feature_flags.resolve_with_provenance(
+            "bindings.primary",
+            guild_id=42,
+        )
+    assert decision.value == BINDINGS_PRIMARY.default_value
+    assert decision.source == "bootstrap_fallback"
+    assert feature_flags.bootstrap_fallback_count() >= 1
+
+
+@pytest.mark.asyncio
+async def test_db_failure_does_not_raise_into_caller(monkeypatch):
+    """is_enabled (the public hot-path) NEVER raises."""
+    monkeypatch.setenv("SUPERBOT_FF_FEATURE_FLAG_PRIMARY", "on")
+
+    with patch(
+        "utils.db.feature_flag_state.get_guild_override",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("DB blip"),
+    ):
+        # Should not raise; we assert by simply awaiting and reading.
+        result = await feature_flags.is_enabled("bindings.primary", 42)
+    assert isinstance(result, bool)

--- a/tests/unit/feature_flags/test_evaluator.py
+++ b/tests/unit/feature_flags/test_evaluator.py
@@ -186,6 +186,105 @@ async def test_global_override_used_when_no_guild_row(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_global_override_off_is_hard_disable(monkeypatch):
+    """state='off' on the global row hard-disables the flag for every guild.
+
+    This is the rollback contract: flipping the global row to 'off'
+    must immediately turn the flag off without falling through to the
+    rollout policy.  Without this guarantee, an in-flight canary
+    rollout could keep granting access after rollback.
+    """
+    monkeypatch.setenv("SUPERBOT_FF_FEATURE_FLAG_PRIMARY", "on")
+
+    rollout_flag = FeatureFlag(
+        name="test.rollout_active",
+        description="flag with rollout policy that would grant access",
+        default_value=False,
+        rollout_policy=RolloutPolicy(
+            staged_guilds=(42,),
+            percentage_rollout=100,
+            tier_gate=EnvironmentTier.PRODUCTION,
+        ),
+    )
+    feature_flags.register(rollout_flag)
+
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_guild_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value={"state": "off", "rollout_percent": None},
+        ),
+        patch(
+            "utils.db.environment_tiers.get_tier",
+            new_callable=AsyncMock,
+            return_value="production",
+        ),
+    ):
+        decision = await feature_flags.resolve_with_provenance(
+            "test.rollout_active",
+            guild_id=42,
+        )
+    # Global 'off' must win even when staged_guilds + 100% rollout
+    # would otherwise grant access.
+    assert decision.value is False
+    assert decision.source == "db_global"
+
+
+@pytest.mark.asyncio
+async def test_global_tier_state_falls_through_to_rollout_when_unmatched(monkeypatch):
+    """A tier-named global state that doesn't match the guild's tier falls through.
+
+    Example: global state='canary', guild tier='production'.  The
+    global row is non-binding for this guild — the declared rollout
+    policy may still grant access via staged_guilds.
+    """
+    monkeypatch.setenv("SUPERBOT_FF_FEATURE_FLAG_PRIMARY", "on")
+
+    staged_flag = FeatureFlag(
+        name="test.tier_fallthrough",
+        description="tier-named global state, staged_guilds rollout",
+        default_value=False,
+        rollout_policy=RolloutPolicy(
+            staged_guilds=(42,),
+            percentage_rollout=0,
+            tier_gate=EnvironmentTier.PRODUCTION,
+        ),
+    )
+    feature_flags.register(staged_flag)
+
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_guild_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value={"state": "canary", "rollout_percent": None},
+        ),
+        patch(
+            "utils.db.environment_tiers.get_tier",
+            new_callable=AsyncMock,
+            return_value="production",
+        ),
+    ):
+        decision = await feature_flags.resolve_with_provenance(
+            "test.tier_fallthrough",
+            guild_id=42,
+        )
+    # Guild is 'production' < 'canary'; the global row does not bind.
+    # The rollout policy still grants because guild 42 is staged.
+    assert decision.value is True
+    assert decision.source == "tier"
+
+
+@pytest.mark.asyncio
 async def test_rollout_policy_grants_via_tier_for_staged_guild(monkeypatch):
     """An explicit staged_guild + matching tier returns True via tier."""
     monkeypatch.setenv("SUPERBOT_FF_FEATURE_FLAG_PRIMARY", "on")

--- a/tests/unit/feature_flags/test_feature_flag_state_db.py
+++ b/tests/unit/feature_flags/test_feature_flag_state_db.py
@@ -1,0 +1,138 @@
+"""Phase 2d PR-2 — utils.db.feature_flag_state primitives.
+
+Mocks the asyncpg pool and asserts each primitive issues the expected
+SQL with the expected parameters (mirrors
+``tests/unit/bindings/test_bindings_db.py``).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from utils.db import feature_flag_state as ff_db
+
+
+@pytest.fixture
+def _mock_pool():
+    pool_mock = MagicMock()
+    pool_mock.execute = AsyncMock()
+    pool_mock.fetchrow = AsyncMock()
+    pool_mock.fetch = AsyncMock()
+    with patch.object(ff_db, "pool") as pool_module:
+        pool_module.get = MagicMock(return_value=pool_mock)
+        yield pool_mock
+
+
+# ---------------------------------------------------------------------------
+# get_global_override
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_global_override_returns_dict_when_row_present(_mock_pool):
+    now = datetime.now(timezone.utc)
+    _mock_pool.fetchrow.return_value = {
+        "flag_name": "bindings.primary",
+        "state": "canary",
+        "rollout_percent": 25,
+        "set_by": 99,
+        "set_at": now,
+    }
+    row = await ff_db.get_global_override("bindings.primary")
+    assert row == {
+        "flag_name": "bindings.primary",
+        "state": "canary",
+        "rollout_percent": 25,
+        "set_by": 99,
+        "set_at": now,
+    }
+    sql, *args = _mock_pool.fetchrow.await_args.args
+    assert "feature_flag_global_overrides" in sql
+    assert args == ["bindings.primary"]
+
+
+@pytest.mark.asyncio
+async def test_get_global_override_returns_none(_mock_pool):
+    _mock_pool.fetchrow.return_value = None
+    assert await ff_db.get_global_override("missing.flag") is None
+
+
+# ---------------------------------------------------------------------------
+# get_guild_override
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_guild_override_scoped_to_guild(_mock_pool):
+    _mock_pool.fetchrow.return_value = None
+    await ff_db.get_guild_override("bindings.primary", 42)
+    sql, *args = _mock_pool.fetchrow.await_args.args
+    assert "feature_flag_guild_overrides" in sql
+    assert "guild_id = $2" in sql
+    assert args == ["bindings.primary", 42]
+
+
+# ---------------------------------------------------------------------------
+# delete_for_guild — preserves global rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_for_guild_targets_only_guild_overrides(_mock_pool):
+    """Phase 2 retention: the GLOBAL override row must survive guild leave.
+
+    This test guards against a regression that would re-introduce a
+    cascade or accidentally touch ``feature_flag_global_overrides``.
+    """
+    _mock_pool.execute.return_value = "DELETE 4"
+    deleted = await ff_db.delete_for_guild(42)
+    sql, *args = _mock_pool.execute.await_args.args
+    assert "feature_flag_guild_overrides" in sql
+    assert "feature_flag_global_overrides" not in sql
+    assert args == [42]
+    assert deleted == 4
+
+
+@pytest.mark.asyncio
+async def test_delete_for_guild_handles_zero_rows(_mock_pool):
+    _mock_pool.execute.return_value = "DELETE 0"
+    assert await ff_db.delete_for_guild(42) == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_for_guild_handles_unexpected_status(_mock_pool):
+    _mock_pool.execute.return_value = "unexpected"
+    assert await ff_db.delete_for_guild(42) == 0
+
+
+# ---------------------------------------------------------------------------
+# list helpers (used by diagnostics)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_global_overrides_returns_list(_mock_pool):
+    _mock_pool.fetch.return_value = [
+        {
+            "flag_name": "bindings.primary",
+            "state": "off",
+            "rollout_percent": None,
+            "set_by": None,
+            "set_at": datetime.now(timezone.utc),
+        },
+    ]
+    result = await ff_db.list_global_overrides()
+    assert len(result) == 1
+    assert result[0]["flag_name"] == "bindings.primary"
+
+
+@pytest.mark.asyncio
+async def test_list_guild_overrides_scoped_to_guild(_mock_pool):
+    _mock_pool.fetch.return_value = []
+    await ff_db.list_guild_overrides(42)
+    sql, *args = _mock_pool.fetch.await_args.args
+    assert "guild_id = $1" in sql
+    assert args == [42]

--- a/tests/unit/feature_flags/test_rollout_mutation_pipeline.py
+++ b/tests/unit/feature_flags/test_rollout_mutation_pipeline.py
@@ -1,0 +1,509 @@
+"""Phase 2d PR-3 — RolloutMutationPipeline 7-step contract.
+
+Mocks the DB primitives so the pipeline can be exercised end-to-end
+without an asyncpg pool.  Covers:
+
+* Input validation: unknown flag, invalid state/tier/percent, scope
+  mismatch.
+* Authority: unknown actor_type rejected; platform_owner requires
+  actor_id.
+* DB write + audit row land atomically (the primitive returns; the
+  pipeline does not branch on its sub-steps).
+* Cache invalidation: clear_cache called with the right scope.
+* Event emission: catalogued events fired with full payload; emission
+  failure is swallowed (DB state is correct).
+* Rollback semantics: a follow-up mutation that flips state back
+  writes a NEW audit row — history is never mutated.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from core.runtime import feature_flags
+from services.rollout_mutation import (
+    EVT_ENVIRONMENT_TIER_CHANGED,
+    EVT_FEATURE_FLAGS_CHANGED,
+    EVT_ROLLOUT_ADVANCED,
+    InvalidRolloutPercentError,
+    InvalidStateError,
+    InvalidTierError,
+    RolloutMutationError,
+    RolloutMutationPipeline,
+    UnauthorizedRolloutMutationError,
+    UnknownFeatureFlagError,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    feature_flags._reset_for_tests()
+    feature_flags._register_builtins()
+    yield
+    feature_flags._reset_for_tests()
+
+
+@pytest.fixture
+def pipeline():
+    return RolloutMutationPipeline()
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_flag_state_rejects_unknown_flag(pipeline):
+    with pytest.raises(UnknownFeatureFlagError):
+        await pipeline.set_flag_state(
+            flag_name="does.not.exist",
+            scope="global",
+            state="on",
+            actor_id=1,
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_flag_state_rejects_invalid_state(pipeline):
+    with pytest.raises(InvalidStateError):
+        await pipeline.set_flag_state(
+            flag_name="bindings.primary",
+            scope="global",
+            state="maybe",
+            actor_id=1,
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_flag_state_rejects_guild_scope_without_guild_id(pipeline):
+    with pytest.raises(RolloutMutationError):
+        await pipeline.set_flag_state(
+            flag_name="bindings.primary",
+            scope="guild",
+            state="on",
+            actor_id=1,
+            guild_id=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_flag_state_rejects_global_scope_with_guild_id(pipeline):
+    with pytest.raises(RolloutMutationError):
+        await pipeline.set_flag_state(
+            flag_name="bindings.primary",
+            scope="global",
+            state="on",
+            actor_id=1,
+            guild_id=42,
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_rollout_percent_rejects_out_of_range(pipeline):
+    with pytest.raises(InvalidRolloutPercentError):
+        await pipeline.set_rollout_percent(
+            flag_name="bindings.primary",
+            percent=101,
+            actor_id=1,
+        )
+    with pytest.raises(InvalidRolloutPercentError):
+        await pipeline.set_rollout_percent(
+            flag_name="bindings.primary",
+            percent=-1,
+            actor_id=1,
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_environment_tier_rejects_unknown_tier(pipeline):
+    with pytest.raises(InvalidTierError):
+        await pipeline.set_environment_tier(
+            guild_id=42,
+            tier="ultra-canary",
+            actor_id=1,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Authority
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_actor_type_rejected(pipeline):
+    with pytest.raises(UnauthorizedRolloutMutationError):
+        await pipeline.set_flag_state(
+            flag_name="bindings.primary",
+            scope="global",
+            state="on",
+            actor_id=1,
+            actor_type="random_user",
+        )
+
+
+@pytest.mark.asyncio
+async def test_platform_owner_requires_actor_id(pipeline):
+    with pytest.raises(UnauthorizedRolloutMutationError):
+        await pipeline.set_flag_state(
+            flag_name="bindings.primary",
+            scope="global",
+            state="on",
+            actor_id=None,
+            actor_type="platform_owner",
+        )
+
+
+@pytest.mark.asyncio
+async def test_system_actor_allowed_without_actor_id(pipeline):
+    """CI seeds use actor_type='system' with actor_id=None."""
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.feature_flag_state.upsert_global_with_audit",
+            new_callable=AsyncMock,
+        ) as mock_upsert,
+        patch("core.events.bus.emit", new_callable=AsyncMock),
+    ):
+        result = await pipeline.set_flag_state(
+            flag_name="bindings.primary",
+            scope="global",
+            state="off",
+            actor_id=None,
+            actor_type="system",
+        )
+    assert result.event_emitted is True
+    mock_upsert.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# DB write + cache invalidation + event emission (set_flag_state global)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_flag_state_global_writes_db_clears_cache_emits_event(pipeline):
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value={"state": "off", "rollout_percent": None},
+        ),
+        patch(
+            "utils.db.feature_flag_state.upsert_global_with_audit",
+            new_callable=AsyncMock,
+        ) as mock_upsert,
+        patch.object(feature_flags, "clear_cache") as mock_clear,
+        patch("core.events.bus.emit", new_callable=AsyncMock) as mock_emit,
+    ):
+        result = await pipeline.set_flag_state(
+            flag_name="bindings.primary",
+            scope="global",
+            state="canary",
+            actor_id=99,
+        )
+    # DB write happened with correct prev/new transition
+    upsert_call = mock_upsert.await_args
+    assert upsert_call.kwargs["flag_name"] == "bindings.primary"
+    assert upsert_call.kwargs["state"] == "canary"
+    assert upsert_call.kwargs["prev_state"] == "off"
+    assert upsert_call.kwargs["mutation_type"] == "set_state"
+    # Cache cleared for that flag
+    mock_clear.assert_called_with(flag_name="bindings.primary")
+    # Event emitted with full payload
+    emit_call = mock_emit.await_args
+    assert emit_call.args[0] == EVT_FEATURE_FLAGS_CHANGED
+    payload = emit_call.kwargs
+    assert payload["flag_name"] == "bindings.primary"
+    assert payload["scope"] == "global"
+    assert payload["guild_id"] is None
+    assert payload["prev_state"] == "off"
+    assert payload["new_state"] == "canary"
+    assert payload["mutation_id"] == result.mutation_id
+    assert payload["actor_id"] == 99
+    assert payload["actor_type"] == "platform_owner"
+    assert "occurred_at" in payload
+    assert result.event_emitted is True
+
+
+# ---------------------------------------------------------------------------
+# DB write + cache + event (set_flag_state guild scope)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_flag_state_guild_clears_both_cache_scopes(pipeline):
+    """Per-guild set must invalidate both per-guild AND global cache entries."""
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_guild_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.feature_flag_state.upsert_guild_with_audit",
+            new_callable=AsyncMock,
+        ),
+        patch.object(feature_flags, "clear_cache") as mock_clear,
+        patch("core.events.bus.emit", new_callable=AsyncMock),
+    ):
+        await pipeline.set_flag_state(
+            flag_name="bindings.primary",
+            scope="guild",
+            state="on",
+            actor_id=99,
+            guild_id=42,
+        )
+    # clear_cache called twice: per-guild + global
+    assert mock_clear.call_count == 2
+    calls = {tuple(sorted(c.kwargs.items())) for c in mock_clear.call_args_list}
+    assert (("flag_name", "bindings.primary"), ("guild_id", 42)) in calls
+    assert (("flag_name", "bindings.primary"), ("guild_id", None)) in calls
+
+
+# ---------------------------------------------------------------------------
+# Event failure isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_event_emission_failure_does_not_raise(pipeline):
+    """A subscriber that raises must not break the mutation contract."""
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.feature_flag_state.upsert_global_with_audit",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "core.events.bus.emit",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("subscriber crashed"),
+        ),
+    ):
+        result = await pipeline.set_flag_state(
+            flag_name="bindings.primary",
+            scope="global",
+            state="on",
+            actor_id=1,
+        )
+    assert result.event_emitted is False
+    # DB write happened; the result reflects it
+    assert result.new_state == "on"
+
+
+# ---------------------------------------------------------------------------
+# DB failure does NOT invalidate cache or emit event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_db_failure_does_not_invalidate_cache_or_emit_event(pipeline):
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.feature_flag_state.upsert_global_with_audit",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("DB blip"),
+        ),
+        patch.object(feature_flags, "clear_cache") as mock_clear,
+        patch("core.events.bus.emit", new_callable=AsyncMock) as mock_emit,
+    ):
+        with pytest.raises(RuntimeError):
+            await pipeline.set_flag_state(
+                flag_name="bindings.primary",
+                scope="global",
+                state="on",
+                actor_id=1,
+            )
+    mock_clear.assert_not_called()
+    mock_emit.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# set_rollout_percent — clears every cached guild decision
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_rollout_percent_clears_all_guild_caches_for_flag(pipeline):
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value={"state": "production", "rollout_percent": 10},
+        ),
+        patch(
+            "utils.db.feature_flag_state.upsert_global_with_audit",
+            new_callable=AsyncMock,
+        ) as mock_upsert,
+        patch.object(feature_flags, "clear_cache") as mock_clear,
+        patch("core.events.bus.emit", new_callable=AsyncMock) as mock_emit,
+    ):
+        result = await pipeline.set_rollout_percent(
+            flag_name="bindings.primary",
+            percent=50,
+            actor_id=99,
+        )
+    upsert_call = mock_upsert.await_args
+    assert upsert_call.kwargs["rollout_percent"] == 50
+    assert upsert_call.kwargs["prev_rollout_percent"] == 10
+    assert upsert_call.kwargs["mutation_type"] == "set_rollout_percent"
+    # State is preserved on a rollout-percent-only change
+    assert upsert_call.kwargs["state"] == "production"
+    # Cache cleared for the flag (every guild)
+    mock_clear.assert_called_with(flag_name="bindings.primary")
+    # Event emitted: rollout.advanced
+    emit_call = mock_emit.await_args
+    assert emit_call.args[0] == EVT_ROLLOUT_ADVANCED
+    assert emit_call.kwargs["prev_percent"] == 10
+    assert emit_call.kwargs["new_percent"] == 50
+    assert result.new_rollout_percent == 50
+
+
+# ---------------------------------------------------------------------------
+# set_environment_tier — clears every cached entry for that guild
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_environment_tier_clears_full_guild_cache(pipeline):
+    with (
+        patch(
+            "utils.db.environment_tiers.get_tier",
+            new_callable=AsyncMock,
+            return_value="production",
+        ),
+        patch(
+            "utils.db.environment_tiers.upsert_with_audit",
+            new_callable=AsyncMock,
+        ) as mock_upsert,
+        patch.object(feature_flags, "clear_cache") as mock_clear,
+        patch("core.events.bus.emit", new_callable=AsyncMock) as mock_emit,
+    ):
+        result = await pipeline.set_environment_tier(
+            guild_id=42,
+            tier="canary",
+            actor_id=99,
+        )
+    upsert_call = mock_upsert.await_args
+    assert upsert_call.kwargs["guild_id"] == 42
+    assert upsert_call.kwargs["tier"] == "canary"
+    assert upsert_call.kwargs["prev_tier"] == "production"
+    # The whole guild's cache is dropped (any flag could be affected).
+    mock_clear.assert_called_with(guild_id=42)
+    emit_call = mock_emit.await_args
+    assert emit_call.args[0] == EVT_ENVIRONMENT_TIER_CHANGED
+    assert emit_call.kwargs["prev_tier"] == "production"
+    assert emit_call.kwargs["new_tier"] == "canary"
+    assert result.new_tier == "canary"
+
+
+# ---------------------------------------------------------------------------
+# Rollback semantics — history is append-only
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rollback_writes_new_audit_row_does_not_mutate_history(pipeline):
+    """Flipping a flag back to its previous state writes a fresh audit row."""
+    upserts: list[dict] = []
+
+    async def _capture_upsert(**kwargs):
+        upserts.append(dict(kwargs))
+
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            side_effect=[
+                None,  # first call: no row → prev=None
+                {"state": "on", "rollout_percent": None},  # rollback read
+            ],
+        ),
+        patch(
+            "utils.db.feature_flag_state.upsert_global_with_audit",
+            side_effect=_capture_upsert,
+        ),
+        patch("core.events.bus.emit", new_callable=AsyncMock),
+    ):
+        first = await pipeline.set_flag_state(
+            flag_name="bindings.primary",
+            scope="global",
+            state="on",
+            actor_id=1,
+        )
+        rollback = await pipeline.set_flag_state(
+            flag_name="bindings.primary",
+            scope="global",
+            state="off",
+            actor_id=1,
+        )
+    assert first.mutation_id != rollback.mutation_id
+    assert len(upserts) == 2
+    # Each upsert is a NEW row — they carry distinct mutation_ids
+    assert upserts[0]["mutation_id"] != upserts[1]["mutation_id"]
+    # Rollback's prev_state is the value the forward write set; the new
+    # state lands in the ``state`` kwarg (the column being written).
+    assert upserts[1]["prev_state"] == "on"
+    assert upserts[1]["state"] == "off"
+
+
+# ---------------------------------------------------------------------------
+# Catalogued event names — sanity check the literals haven't drifted
+# ---------------------------------------------------------------------------
+
+
+def test_catalogue_includes_phase_2d_event_names():
+    from core.events_catalogue import KNOWN_EVENTS
+
+    assert EVT_FEATURE_FLAGS_CHANGED in KNOWN_EVENTS
+    assert EVT_ROLLOUT_ADVANCED in KNOWN_EVENTS
+    assert EVT_ENVIRONMENT_TIER_CHANGED in KNOWN_EVENTS
+
+
+# ---------------------------------------------------------------------------
+# Minimal smoke: result type carries committed_at + mutation_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_result_carries_mutation_id_and_committed_at(pipeline):
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.feature_flag_state.upsert_global_with_audit",
+            new_callable=AsyncMock,
+        ),
+        patch("core.events.bus.emit", new_callable=AsyncMock),
+    ):
+        result = await pipeline.set_flag_state(
+            flag_name="bindings.primary",
+            scope="global",
+            state="on",
+            actor_id=99,
+        )
+    assert isinstance(result.mutation_id, str)
+    # UUID format: 36 chars with dashes
+    assert len(result.mutation_id) == 36
+    assert isinstance(result.committed_at, datetime)
+    assert result.committed_at.tzinfo == timezone.utc

--- a/tests/unit/invariants/test_environment_tier_alignment.py
+++ b/tests/unit/invariants/test_environment_tier_alignment.py
@@ -1,0 +1,48 @@
+"""Phase 2d PR-2 invariant — environment_tiers.tier matches EnvironmentTier.
+
+Migration 024 ships a CHECK constraint enumerating exactly the values
+of :class:`core.runtime.feature_flags.EnvironmentTier`.  Adding a
+member to the enum without extending the CHECK constraint would let
+the evaluator return a value the DB then rejects on the next write.
+Adding to the CHECK without an enum member would let an operator
+insert a tier the evaluator silently ignores.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_MIGRATION = (
+    Path(__file__).resolve().parents[3]
+    / "disbot"
+    / "migrations"
+    / "024_environment_tiers.sql"
+)
+
+
+def _extract_tier_literals() -> set[str]:
+    sql = _MIGRATION.read_text()
+    match = re.search(r"CHECK\s*\(\s*tier\s+IN\s*\(([^)]+)\)\s*\)", sql)
+    assert match, "could not locate tier CHECK constraint in migration 024"
+    literals = {token.strip().strip("'\"") for token in match.group(1).split(",")}
+    return literals
+
+
+def test_environment_tier_values_match_migration_024_check():
+    """Python ``EnvironmentTier`` matches migration 024's CHECK literals."""
+    from core.runtime.feature_flags import EnvironmentTier
+
+    db_check = _extract_tier_literals()
+    python = {t.value for t in EnvironmentTier}
+
+    missing_in_db = python - db_check
+    missing_in_python = db_check - python
+
+    assert not missing_in_db and not missing_in_python, (
+        "EnvironmentTier / DB CHECK drift.\n"
+        f"  in Python but not DB CHECK: {sorted(missing_in_db)}\n"
+        f"  in DB CHECK but not Python: {sorted(missing_in_python)}\n"
+        "Fix: extend the CHECK constraint in a new migration AND "
+        "update the EnvironmentTier enum.",
+    )

--- a/tests/unit/invariants/test_feature_flag_audit_alignment.py
+++ b/tests/unit/invariants/test_feature_flag_audit_alignment.py
@@ -55,3 +55,90 @@ def test_actor_type_literals_match_pipeline_allowed_set():
     assert (
         db_check == python
     ), f"actor_type drift: db={sorted(db_check)} vs python={sorted(python)}"
+
+
+# ---------------------------------------------------------------------------
+# Per-mutation_type shape CHECK constraints
+# ---------------------------------------------------------------------------
+#
+# These tests pin the defense-in-depth invariants that make the single
+# ``feature_flag_audit`` table safe to host all three event sources.
+# They scan the migration for the specific CHECK clauses; a future
+# refactor that removes any of them fails CI here, signalling that the
+# corresponding pipeline contract no longer has DB-side enforcement.
+
+
+def _migration_text() -> str:
+    return _MIGRATION.read_text()
+
+
+def test_set_state_check_constraint_present():
+    """set_state rows must carry non-null new_state and avoid the sentinel."""
+    sql = _migration_text()
+    # Required clauses (independent of formatting)
+    assert "mutation_type <> 'set_state'" in sql
+    assert "new_state IS NOT NULL" in sql
+    assert "flag_name <> '__environment_tier__'" in sql
+
+
+def test_set_rollout_percent_check_constraint_present():
+    """set_rollout_percent rows must be global-scoped + carry new_rollout_percent."""
+    sql = _migration_text()
+    assert "mutation_type <> 'set_rollout_percent'" in sql
+    assert "scope = 'global'" in sql
+    assert "new_rollout_percent IS NOT NULL" in sql
+
+
+def test_set_tier_check_constraint_present():
+    """set_tier rows must use the sentinel + be guild-scoped + carry new_tier."""
+    sql = _migration_text()
+    assert "mutation_type <> 'set_tier'" in sql
+    assert "flag_name = '__environment_tier__'" in sql
+    assert "scope = 'guild'" in sql
+    assert "guild_id IS NOT NULL" in sql
+    assert "new_tier IS NOT NULL" in sql
+
+
+def test_set_tier_check_requires_unused_columns_to_be_null():
+    """set_tier rows must leave state + rollout columns NULL.
+
+    This is the contract that lets the single audit table host all
+    three event sources without ambiguity: a set_tier row never
+    accidentally looks like a state change.
+    """
+    sql = _migration_text()
+    # All five "leave-unused" assertions appear inside the set_tier CHECK
+    for null_clause in (
+        "prev_state IS NULL",
+        "new_state IS NULL",
+        "prev_rollout_percent IS NULL",
+        "new_rollout_percent IS NULL",
+    ):
+        assert null_clause in sql, f"missing CHECK clause: {null_clause}"
+
+
+# ---------------------------------------------------------------------------
+# Pipeline contract pins for the environment-tier sentinel
+# ---------------------------------------------------------------------------
+
+
+def test_environment_tier_audit_writes_sentinel_flag_name():
+    """utils.db.environment_tiers.upsert_with_audit hard-codes the sentinel.
+
+    Reads the SQL string in the Python primitive and asserts the
+    literal '__environment_tier__' appears in the INSERT.  A drift here
+    (sentinel renamed in Python but not SQL or vice versa) would let
+    set_tier rows escape the per-mutation_type CHECK constraint.
+    """
+    from pathlib import Path
+
+    src = (
+        Path(__file__).resolve().parents[3]
+        / "disbot"
+        / "utils"
+        / "db"
+        / "environment_tiers.py"
+    ).read_text()
+    assert "'__environment_tier__'" in src
+    assert "'set_tier'" in src
+    assert "'guild'" in src

--- a/tests/unit/invariants/test_feature_flag_audit_alignment.py
+++ b/tests/unit/invariants/test_feature_flag_audit_alignment.py
@@ -1,0 +1,57 @@
+"""Phase 2d PR-3 invariant — feature_flag_audit CHECK matches Python literals.
+
+Migration 025 ships CHECK constraints on
+``feature_flag_audit.scope``, ``mutation_type``, and ``actor_type``.
+The Python module :mod:`services.rollout_mutation` carries the
+corresponding constant sets.  This test pins both sides — extending
+one without the other should fail CI.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_MIGRATION = (
+    Path(__file__).resolve().parents[3]
+    / "disbot"
+    / "migrations"
+    / "025_feature_flag_audit.sql"
+)
+
+
+def _extract_check_literals(column: str) -> set[str]:
+    sql = _MIGRATION.read_text()
+    pattern = rf"CHECK\s*\(\s*{column}\s+IN\s*\(([^)]+)\)\s*\)"
+    match = re.search(pattern, sql)
+    assert match, f"could not locate {column} CHECK constraint in migration 025"
+    return {token.strip().strip("'\"") for token in match.group(1).split(",")}
+
+
+def test_scope_literals_match_python():
+    """``scope`` CHECK matches the Python ``Scope`` literal type."""
+    db_check = _extract_check_literals("scope")
+    expected = {"global", "guild"}
+    assert (
+        db_check == expected
+    ), f"scope CHECK drift: db={sorted(db_check)} vs expected={sorted(expected)}"
+
+
+def test_mutation_type_literals_match_python():
+    """``mutation_type`` CHECK matches the literal type used by the pipeline."""
+    db_check = _extract_check_literals("mutation_type")
+    expected = {"set_state", "set_rollout_percent", "set_tier"}
+    assert (
+        db_check == expected
+    ), f"mutation_type drift: db={sorted(db_check)} vs expected={sorted(expected)}"
+
+
+def test_actor_type_literals_match_pipeline_allowed_set():
+    """``actor_type`` CHECK matches RolloutMutationPipeline._ALLOWED_ACTOR_TYPES."""
+    from services.rollout_mutation import _ALLOWED_ACTOR_TYPES
+
+    db_check = _extract_check_literals("actor_type")
+    python = set(_ALLOWED_ACTOR_TYPES)
+    assert (
+        db_check == python
+    ), f"actor_type drift: db={sorted(db_check)} vs python={sorted(python)}"

--- a/tests/unit/invariants/test_feature_flag_state_alignment.py
+++ b/tests/unit/invariants/test_feature_flag_state_alignment.py
@@ -1,0 +1,96 @@
+"""Phase 2d PR-2 invariant — feature_flag state values match migration 023.
+
+Migration 023 ships CHECK constraints on
+``feature_flag_global_overrides.state`` and
+``feature_flag_guild_overrides.state``.  Both columns use the same
+constraint literal set: the union of the two hard overrides
+(``on``/``off``) and the four tier-equivalence values
+(``owner``/``canary``/``beta``/``production``).
+
+The Python evaluator
+(:mod:`core.runtime.feature_flags`.``_state_to_decision``) treats any
+value outside this set as "unknown — fall back to declared default".
+If the DB ever accepted a value that Python silently ignored, an
+operator override would appear successful but have no behavioural
+effect.  This test pins the literal set on both sides so the next
+addition (e.g. a future ``percent`` state) cannot land without an
+explicit, reviewed update.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_MIGRATION = (
+    Path(__file__).resolve().parents[3]
+    / "disbot"
+    / "migrations"
+    / "023_feature_flag_state.sql"
+)
+
+
+def _extract_state_literals() -> set[str]:
+    """Return the literals inside the migration's state CHECK constraint."""
+    sql = _MIGRATION.read_text()
+    matches = re.findall(
+        r"CHECK\s*\(\s*state\s+IN\s*\(([^)]+)\)\s*\)",
+        sql,
+    )
+    assert matches, "could not locate state CHECK constraint in migration 023"
+    # Both CHECK clauses must agree — collapse to one set
+    all_literals: set[str] = set()
+    for clause in matches:
+        for token in clause.split(","):
+            literal = token.strip().strip("'\"")
+            all_literals.add(literal)
+    return all_literals
+
+
+def test_feature_flag_state_literals_match_known_evaluator_set():
+    """The DB state set matches the evaluator's recognized state strings."""
+    db_literals = _extract_state_literals()
+    expected = {"off", "owner", "canary", "beta", "production", "on"}
+
+    missing_in_db = expected - db_literals
+    missing_in_python = db_literals - expected
+
+    assert not missing_in_db and not missing_in_python, (
+        "feature_flag state CHECK / evaluator drift.\n"
+        f"  in evaluator but not DB CHECK: {sorted(missing_in_db)}\n"
+        f"  in DB CHECK but not evaluator: {sorted(missing_in_python)}\n"
+        "Fix: extend the CHECK constraint via a new migration AND extend "
+        "``_state_to_decision`` in core/runtime/feature_flags.py.",
+    )
+
+
+def test_evaluator_recognizes_every_db_state_literal():
+    """Each DB literal maps to a defined behaviour in the evaluator.
+
+    This is a stronger guarantee than just "the sets are equal": even
+    if the set comparison passed, the evaluator might handle some
+    literal as a typo.  We exercise the mapping directly.
+    """
+    from core.runtime.feature_flags import FeatureFlag, _state_to_decision
+
+    flag = FeatureFlag(
+        name="t.test",
+        description="alignment test",
+        default_value=False,
+    )
+
+    # Hard overrides
+    assert _state_to_decision("on", flag=flag, guild_tier="production") is True
+    assert _state_to_decision("off", flag=flag, guild_tier="owner") is False
+
+    # Tier-equivalence values are accepted (their truthiness depends on
+    # the guild's tier; here we just exercise the mapping path).
+    for tier_state in ("owner", "canary", "beta", "production"):
+        result = _state_to_decision(
+            tier_state,
+            flag=flag,
+            guild_tier="production",
+        )
+        assert isinstance(
+            result, bool
+        ), f"_state_to_decision returned non-bool for state={tier_state!r}"

--- a/tests/unit/runtime/test_guild_lifecycle_teardown.py
+++ b/tests/unit/runtime/test_guild_lifecycle_teardown.py
@@ -1,6 +1,6 @@
 """Phase 2 — guild_lifecycle.teardown wires Phase 2 cleanup primitives.
 
-Two new steps were added to ``guild_lifecycle.teardown`` in this PR:
+PR-1 added two steps to ``guild_lifecycle.teardown``:
 
 * **Step 5** — :func:`utils.db.bindings.delete_active_bindings_for_guild`
   purges ``subsystem_bindings`` rows and **preserves**
@@ -9,13 +9,27 @@ Two new steps were added to ``guild_lifecycle.teardown`` in this PR:
   reserved for explicit forensic cleanup and is **never** called from
   teardown.
 * **Step 6** — :func:`utils.db.resource_cache.delete_for_guild` drops
-  cached resource validation rows (the primitive shipped in PR #72; the
-  wiring landed here).
+  cached resource validation rows (the primitive shipped in PR #72;
+  the wiring landed here).
 
-These tests pin the contract for both:
+PR-2 added three more (Phase 2d feature-flag substrate):
 
-* Both new primitives are awaited during teardown.
-* The audit-purge primitive is **not** awaited (retention guarantee).
+* **Step 7** — :func:`utils.db.feature_flag_state.delete_for_guild`
+  drops the per-guild override rows; global rows are preserved.
+* **Step 8** — :func:`utils.db.environment_tiers.delete_for_guild`
+  removes the environment-tier row so the guild re-defaults to
+  PRODUCTION on re-invite.
+* **Step 9** — :func:`core.runtime.feature_flags.clear_cache` purges
+  cached evaluator decisions for the guild.
+
+These tests pin the contract:
+
+* Every new primitive is awaited (or called, for the sync one) during
+  teardown.
+* The binding audit-purge primitive is **never** awaited (retention
+  guarantee).
+* Global feature-flag overrides are preserved — the primitive scopes
+  to guild rows only.
 * Per-step failure does not abort the rest of the teardown sequence
   (matches the existing try/except discipline in
   ``disbot/guild_lifecycle.py``).
@@ -69,6 +83,23 @@ def _teardown_patches():
         ),
         patch(
             "core.runtime.scope_locks.teardown_guild",
+            return_value=0,
+        ),
+        # Phase 2d defaults — patched here so individual tests can
+        # override via additional with patch(...) blocks when they need
+        # to assert against the new feature-flag/environment-tier steps.
+        patch(
+            "utils.db.feature_flag_state.delete_for_guild",
+            new_callable=AsyncMock,
+            return_value=0,
+        ),
+        patch(
+            "utils.db.environment_tiers.delete_for_guild",
+            new_callable=AsyncMock,
+            return_value=0,
+        ),
+        patch(
+            "core.runtime.feature_flags.clear_cache",
             return_value=0,
         ),
     ):
@@ -218,3 +249,79 @@ async def test_teardown_is_idempotent(_teardown_patches):
         await guild_lifecycle.teardown(99)
         assert mock_bindings_delete.await_count == 2
         assert mock_resource_delete.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Step 7 — feature_flag_state per-guild overrides deleted; globals preserved
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_teardown_deletes_feature_flag_guild_overrides(_teardown_patches):
+    """The feature_flag guild-override primitive is awaited from teardown."""
+    import guild_lifecycle
+
+    with patch(
+        "utils.db.feature_flag_state.delete_for_guild",
+        new_callable=AsyncMock,
+        return_value=2,
+    ) as mock_delete:
+        await guild_lifecycle.teardown(99)
+        mock_delete.assert_awaited_once_with(99)
+
+
+@pytest.mark.asyncio
+async def test_teardown_feature_flag_step_failure_is_isolated(_teardown_patches):
+    """If the feature-flag delete raises, downstream steps still run."""
+    import guild_lifecycle
+
+    with (
+        patch(
+            "utils.db.feature_flag_state.delete_for_guild",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("DB blip"),
+        ),
+        patch(
+            "utils.db.environment_tiers.delete_for_guild",
+            new_callable=AsyncMock,
+            return_value=0,
+        ) as mock_et,
+    ):
+        await guild_lifecycle.teardown(99)
+        mock_et.assert_awaited_once_with(99)
+
+
+# ---------------------------------------------------------------------------
+# Step 8 — environment_tier row deleted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_teardown_deletes_environment_tier(_teardown_patches):
+    import guild_lifecycle
+
+    with patch(
+        "utils.db.environment_tiers.delete_for_guild",
+        new_callable=AsyncMock,
+        return_value=1,
+    ) as mock_delete:
+        await guild_lifecycle.teardown(99)
+        mock_delete.assert_awaited_once_with(99)
+
+
+# ---------------------------------------------------------------------------
+# Step 9 — feature_flag cache cleared per guild
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_teardown_clears_feature_flag_cache(_teardown_patches):
+    """Cache clear is called scoped to the guild (guild_id kwarg)."""
+    import guild_lifecycle
+
+    with patch(
+        "core.runtime.feature_flags.clear_cache",
+        return_value=0,
+    ) as mock_clear:
+        await guild_lifecycle.teardown(99)
+        mock_clear.assert_called_once_with(guild_id=99)


### PR DESCRIPTION
## Why this PR exists

The Phase 2 stack #75 → #76 → #77 → #78 → #79 was set up with each PR's base pointing at the previous PR's branch. PRs #75 and #76 merged into `main` correctly, but PR #77 was merged into the **stack branch** (its base, `claude/phase-2-pr-1-teardown-cleanup`), not into `main`. PRs #78 and #79 are still open against stack branches and have not landed on `main` either.

Result: `main` is currently missing the feature-flag evaluator, the rollout pipeline, and the config-arbitration helper. `!platform flags` on Railway still renders the old "Phase 2d will add runtime evaluation" embed because `disbot/cogs/diagnostic_cog.py` on `main` has the pre-PR-77 code.

This integration PR repairs the delivery by landing the missing PR-2/3/4 work onto `main` in one merge.

## How it was built

Cherry-picked the 6 commits that constitute PRs #77 / #78 / #79 (with their review-fix follow-ups) directly onto a branch off `origin/main`. No squash, no rebase rewrite — each commit retains its original message and authorship for review traceability:

```
b5b05e9 fix(phase-2-pr-4): verify binding_kind, document coercion, missing-source semantics
efe0568 feat(phase-2-pr-4): central read-source arbitration with ConfigReadResult
bb44f44 fix(phase-2-pr-3): explicit per-mutation_type CHECK constraints + sentinel pins
2061ecd feat(phase-2-pr-3): rollout mutation pipeline + feature flag audit
1a98bff fix(phase-2-pr-2): clarify global override semantics; test hard-off rollback
87ca1a4 feat(phase-2-pr-2): feature flag evaluator foundation (Phase 2d)
```

## Scope

Three runtime domains delivered, in dependency order:

### From PR #77 — Phase 2d feature-flag evaluator (read side)

- Migrations **023** (`feature_flag_state`: split into `feature_flag_global_overrides` + `feature_flag_guild_overrides` for valid non-nullable PKs) and **024** (`environment_tiers`)
- `core/runtime/feature_flags.py`: `is_enabled()`, `resolve_with_provenance()`, TTL cache + `clear_cache()`, `hashlib.sha256` rollout hash, bootstrap fallback policy
- `utils/db/feature_flag_state.py` + `utils/db/environment_tiers.py`: read CRUD + guild-scoped `delete_for_guild`
- `cogs/diagnostic_cog.py`: `!platform flags` now renders per-flag `default=/effective=/src=/owner=` (replaces the old declared-only embed)
- `guild_lifecycle.py`: three new teardown steps (FF guild overrides, env tier, FF cache clear)
- Tests + enum drift alignment for both new tables

### From PR #78 — Rollout mutation pipeline (write side)

- Migration **025** (`feature_flag_audit`)
- `services/rollout_mutation.py`: `RolloutMutationPipeline` with 7-step contract; three entrypoints (`set_flag_state`, `set_rollout_percent`, `set_environment_tier`); authority enforcement; advisory event emission
- `core/events_catalogue.py`: registers `feature_flags.changed`, `rollout.advanced`, `environment_tier.changed`
- Cache invalidation happens inline in step 5; events are advisory; DB is authoritative
- Tests for input validation, authority, atomic DB+audit+event flow, event failure isolation, rollback semantics, catalogued names

### From PR #79 — Central read-source arbitration

- `core/runtime/config_arbitration.py`: `ConfigReadResult` + `read_config()` collapsing the legacy-vs-binding ladder into one helper
- Diagnostics provider `config_arbitration` registered for PR-10's unified `!platform consistency` view
- No cog read-site swap yet — PR-7 swaps cogs to use the helper in one diff

## Review fixes preserved

All four corrections requested during stack review are included:

| # | Fix | Where |
|---|---|---|
| 1 | Global `state='off'` is an explicit hard disable; rollback contract is pinned by tests | `core/runtime/feature_flags.py::_resolve_from_db`; `tests/unit/feature_flags/test_evaluator.py::test_global_override_off_is_hard_disable` |
| 2 | `feature_flag_audit` has per-`mutation_type` shape CHECK constraints (`set_state` / `set_rollout_percent` / `set_tier`); the `'__environment_tier__'` sentinel is enforced at the DB layer and the SQL primitive carries the literal | `disbot/migrations/025_feature_flag_audit.sql`; `tests/unit/invariants/test_feature_flag_audit_alignment.py` |
| 3 | `config_arbitration.read_config` accepts and verifies `binding_kind` — drift is treated as INVALID and surfaced in `diagnostics` | `disbot/core/runtime/config_arbitration.py`; `tests/unit/config_arbitration/test_read_config.py` |
| 4 | `source='missing'` returned whenever the resolved value is `None`, regardless of flag state — collapses `!platform consistency`'s "nothing configured" query to a single counter | same file/test as #3 |

## Migrations

Migrations **023**, **024**, **025** present **exactly once** in the integration branch — verified via `ls disbot/migrations/02[345]_*.sql` and `git diff --name-only origin/main..HEAD | grep migrations`. All additive, forward-only, idempotent.

## Out of scope / excluded

- **PR #69** (`docs: add AI project reference map`) is intentionally **not** included. It is based on a pre-Phase-2 commit (`25908e7`); its content is stale relative to the consistency ledger landed in PR #75. Recommend closing PR #69 after this PR merges.
- **Read-site swaps** for XP / Economy / Governance (PR-7) — the arbitration helper is unused by any cog in this PR.
- **AST scan forbidding direct `is_enabled("bindings.primary")` branches** — lands in PR-7 with the first real read-site swap.
- **Discord admin command for setting feature flags** — DB/script-only in this PR; command surface is a follow-up after canary observation.

## Architectural boundaries preserved

- One mutation per domain, all advisory events, DB authoritative throughout.
- Import-cycle regression test (`tests/unit/runtime/test_import_cycle_regression.py`) green — no top-level `core.runtime` imports added to cycle-sensitive files (`utils/helpers.py`, `governance/__init__.py`).
- `ResourceStatus.BOUND` remains structural-only.
- No setup wizard UI. No resource provisioning. No participation runtime. No binding backfill.
- `feature_flag.primary` defaults OFF; declared flags continue to return their declared defaults until the operator flips the env override.

## Tests run

```
python -m pytest tests/unit/feature_flags/ tests/unit/config_arbitration/ \
                 tests/unit/runtime/test_import_cycle_regression.py -q
# 70 passed

python -m pytest tests/ -q --ignore=tests/integration
# 1257 passed (1166 baseline + 91 new), 12 unrelated deprecation warnings

python -m ruff check disbot/
# All checks passed!

python -m black --check (PR-changed .py files)
# All 19 files unchanged

python -m isort --check-only disbot/ tests/
# clean
```

### Note on `black --check disbot/ tests/`

Running `black --check` against the whole repo reports 30 unrelated test files that need reformatting (e.g., `tests/unit/services/test_blackjack_engine.py`, `tests/unit/views/test_selectors.py`). **None of those files are touched by this PR** — confirmed via `git diff --name-only origin/main..HEAD | grep .py | xargs python -m black --check` which reports all 19 changed `.py` files unchanged. This is pre-existing repo-wide formatting drift and is intentionally not addressed here to keep the integration PR focused.

## Rollback strategy

Single `git revert -m 1 <merge-sha>` after this PR merges. Migrations 023/024/025 are additive — leaving them after revert is safe (tables become unused). The evaluator is read-only and `feature_flag.primary` defaults OFF, so no subsystem behavior changes if reverted: every flag returns its declared default.

## Manual Discord smoke after deploy

- [ ] After Railway deploys the merged commit, `!platform flags` shows each declared flag with the new `default=… effective=… src=… owner=…` rendering (replaces the old "Phase 2d will add runtime evaluation" embed)
- [ ] With `feature_flag.primary` left at its declared default (off), every flag shows `effective=off src=default`
- [ ] Set env `SUPERBOT_FF_FEATURE_FLAG_PRIMARY=on` on a test deploy and restart; `!platform flags` still shows declared defaults but `src` becomes `db_*` or `default` depending on seeded rows
- [ ] Seed a `feature_flag_global_overrides` row with `state='off'` for `bindings.primary` and verify `src=db_global` + `effective=off` — confirms the hard-disable rollback contract
- [ ] Kick the bot from a test guild; verify `feature_flag_guild_overrides` rows for that guild are deleted while the global row survives

## What ships next

Once this PR merges, the next session can start **PR-5** (binding backfill dry-run + reconciliation + `platform_migration_checkpoints`) directly from `main`. The stacking issue that produced this orphan stack will not recur — PR-5 onward will base each PR against `main` directly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgFk12CkWs1uiPZk8AA5fR)_