### PR TITLE
Phase 2.5: binding backfill dry-run + reconciliation + migration checkpoints

### DIFF
--- a/disbot/cogs/diagnostic_cog.py
+++ b/disbot/cogs/diagnostic_cog.py
@@ -712,6 +712,76 @@ class DiagnosticCog(commands.Cog):
             embed.add_field(name="Flags", value="*(none)*", inline=False)
         await ctx.send(embed=embed)
 
+    @platform_grp.command(name="migrations")  # type: ignore[arg-type]
+    @commands.has_permissions(administrator=True)
+    async def platform_migrations(self, ctx):
+        """Platform migration checkpoints (Phase 2 PR-5) — status + summary.
+
+        Read-only.  Lists every checkpoint row in
+        ``platform_migration_checkpoints`` for this guild (and global
+        rows), grouped by migration name.  Dry-run / backfill /
+        reconciliation runs are invoked from a Python REPL on the bot
+        host; this command just surfaces their state.
+        """
+        from utils.db import platform_migration_checkpoints as checkpoint_db
+
+        # Counts (global view) + per-guild rows.
+        counts = await checkpoint_db.count_by_status()
+        guild_rows = (
+            await checkpoint_db.list_checkpoints(guild_id=ctx.guild.id)
+            if ctx.guild
+            else []
+        )
+        embed = discord.Embed(
+            title="🛠 Platform migrations",
+            description=(
+                "Generic logical-migration checkpoint table; first "
+                "consumer is the binding backfill (Phase 2 PR-5)."
+            ),
+            color=discord.Color.gold(),
+        )
+        if counts:
+            status_line = " · ".join(
+                f"{status}={n}" for status, n in sorted(counts.items())
+            )
+            embed.add_field(name="Global counts", value=status_line, inline=False)
+        else:
+            embed.add_field(
+                name="Global counts",
+                value="*(no rows)*",
+                inline=False,
+            )
+        if guild_rows:
+            rows: list[str] = []
+            for row in guild_rows[:20]:
+                summary = row.get("summary_json") or {}
+                inner_counts = (
+                    summary.get("counts") if isinstance(summary, dict) else None
+                )
+                count_str = (
+                    " ".join(
+                        f"{k}={v}" for k, v in sorted((inner_counts or {}).items())
+                    )
+                    if inner_counts
+                    else ""
+                )
+                rows.append(
+                    f"`{row['name']}` status={row['status']} v={row['version']} "
+                    f"{count_str}".strip(),
+                )
+            embed.add_field(
+                name=f"This guild ({len(guild_rows)} row{'s' if len(guild_rows) != 1 else ''})",
+                value="\n".join(rows)[:1024],
+                inline=False,
+            )
+        else:
+            embed.add_field(
+                name="This guild",
+                value="*(no checkpoints)*",
+                inline=False,
+            )
+        await ctx.send(embed=embed)
+
 
 async def setup(bot):
     await bot.add_cog(DiagnosticCog(bot))

--- a/disbot/guild_lifecycle.py
+++ b/disbot/guild_lifecycle.py
@@ -36,11 +36,13 @@ async def teardown(guild_id: int) -> None:
                                    rows (Phase 2d PR-2); global rows preserved.
       8. Environment tier        — delete environment_tiers row (Phase 2d PR-2).
       9. Feature flag evaluator cache — drop cached decisions for the guild.
-      10. Governance capability cache — clear per-guild execution overrides.
-      11. Governance visibility cache — bump version, clear role-override flag.
-      12. Guild-config cache    — drop cached guild config entries (F-1).
-      13. Scope locks           — invoke registered per-cog teardown hooks (F-2).
-      14. Governance feedback cooldown — documented, no per-guild cleanup needed.
+      10. Platform migration checkpoints — drop per-guild checkpoint rows
+                                   (Phase 2 PR-5); global rows preserved.
+      11. Governance capability cache — clear per-guild execution overrides.
+      12. Governance visibility cache — bump version, clear role-override flag.
+      13. Guild-config cache    — drop cached guild config entries (F-1).
+      14. Scope locks           — invoke registered per-cog teardown hooks (F-2).
+      15. Governance feedback cooldown — documented, no per-guild cleanup needed.
     """
     logger.info("guild_lifecycle.teardown: beginning cleanup for guild=%d", guild_id)
 
@@ -71,19 +73,22 @@ async def teardown(guild_id: int) -> None:
     # 9. Feature flag evaluator cache — drop stale cached decisions.
     _teardown_feature_flag_cache(guild_id)
 
-    # 10. Governance capability overrides — clear execution-layer in-process dict.
+    # 10. Platform migration checkpoints — per-guild rows only (Phase 2 PR-5).
+    await _teardown_platform_migration_checkpoints(guild_id)
+
+    # 11. Governance capability overrides — clear execution-layer in-process dict.
     _teardown_capability_overrides(guild_id)
 
-    # 11. Governance visibility cache — version bump + role flag removal.
+    # 12. Governance visibility cache — version bump + role flag removal.
     _teardown_visibility_cache(guild_id)
 
-    # 12. Guild-config cache — drop cached config entries for the guild (F-1 / S1.1).
+    # 13. Guild-config cache — drop cached config entries for the guild (F-1 / S1.1).
     _teardown_guild_config(guild_id)
 
-    # 13. Scope locks — invoke registered per-cog teardown hooks (F-2 / S1.2).
+    # 14. Scope locks — invoke registered per-cog teardown hooks (F-2 / S1.2).
     _teardown_scope_locks(guild_id)
 
-    # 14. Governance feedback cooldown dict in governance/__init__.
+    # 15. Governance feedback cooldown dict in governance/__init__.
     _teardown_feedback_cooldown(guild_id)
 
     logger.info("guild_lifecycle.teardown: complete for guild=%d", guild_id)
@@ -280,6 +285,33 @@ def _teardown_feature_flag_cache(guild_id: int) -> None:
     except Exception as exc:
         logger.warning(
             "guild_lifecycle: feature_flag cache teardown failed: %s",
+            exc,
+        )
+
+
+async def _teardown_platform_migration_checkpoints(guild_id: int) -> None:
+    """Delete per-guild ``platform_migration_checkpoints`` rows.
+
+    Phase 2 PR-5.  Global rows (``guild_id IS NULL``) are preserved so
+    cross-guild migration metadata survives an individual guild leave.
+    A re-invited guild starts with no checkpoint history; running the
+    binding-backfill dry-run again will write a fresh row.
+    """
+    try:
+        from utils.db.platform_migration_checkpoints import (
+            delete_for_guild as _checkpoint_delete,
+        )
+
+        count = await _checkpoint_delete(guild_id)
+        if count:
+            logger.debug(
+                "guild_lifecycle: deleted %d migration checkpoint row(s) for guild=%d",
+                count,
+                guild_id,
+            )
+    except Exception as exc:
+        logger.warning(
+            "guild_lifecycle: platform migration checkpoint teardown failed: %s",
             exc,
         )
 

--- a/disbot/migrations/026_platform_migration_checkpoints.sql
+++ b/disbot/migrations/026_platform_migration_checkpoints.sql
@@ -1,0 +1,73 @@
+-- Migration 026: platform_migration_checkpoints (Phase 2, PR-5).
+--
+-- Generic logical-migration checkpoint table.  Records progress of any
+-- data migration / backfill / reconciliation that needs:
+--
+--   * a stable name (so re-runs can resume),
+--   * an optional guild scope (per-guild or global),
+--   * a status discriminator,
+--   * a JSONB summary the operator can inspect,
+--   * idempotency under repeat (same (name, guild_id) ⇒ upsert).
+--
+-- First consumer is :mod:`services.binding_backfill` (PR-5 dry-run +
+-- PR-6 write phase).  Subsequent logical migrations register their
+-- own ``name`` literals; the table is intentionally generic so a
+-- second backfill (e.g. participation data shape changes in PR-9) can
+-- reuse it without a new table.
+--
+-- Schema decisions:
+--
+--   * ``guild_id`` is nullable to allow a single GLOBAL checkpoint per
+--     migration ``name`` (e.g. "binding_backfill" overview row).
+--     PostgreSQL does not allow NULL in primary-key columns, so we
+--     use a serial ``id`` PK plus two partial unique indexes:
+--       - ``(name) WHERE guild_id IS NULL``
+--       - ``(name, guild_id) WHERE guild_id IS NOT NULL``
+--     This gives the same uniqueness guarantee as a composite PK
+--     would without the NULL-in-PK problem.
+--   * ``status`` is CHECK-constrained.  Alignment test
+--     ``tests/unit/invariants/test_migration_checkpoint_alignment.py``
+--     pins the literals to the Python ``Status`` enum.
+--   * ``version`` is an explicit counter so a migration can be re-run
+--     with a bumped version without losing the previous attempt's
+--     summary (PR-6 may bump from 1 → 2 if the dry-run schema
+--     changes).
+--   * Indexed on (name, started_at) for time-range queries and
+--     (guild_id) for guild-scoped lookups.
+--
+-- Forward-only and idempotent.
+
+CREATE TABLE IF NOT EXISTS platform_migration_checkpoints (
+    id              BIGSERIAL    PRIMARY KEY,
+    name            TEXT         NOT NULL,
+    guild_id        BIGINT,
+    status          TEXT         NOT NULL,
+    version         INTEGER      NOT NULL DEFAULT 1,
+    started_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    completed_at    TIMESTAMPTZ,
+    summary_json    JSONB,
+    CHECK (status IN (
+        'pending',
+        'dry_run_complete',
+        'in_progress',
+        'complete',
+        'failed',
+        'rolled_back'
+    ))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS
+    idx_platform_migration_checkpoints_global_unique
+    ON platform_migration_checkpoints (name)
+    WHERE guild_id IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS
+    idx_platform_migration_checkpoints_guild_unique
+    ON platform_migration_checkpoints (name, guild_id)
+    WHERE guild_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_platform_migration_checkpoints_name_started
+    ON platform_migration_checkpoints (name, started_at);
+
+CREATE INDEX IF NOT EXISTS idx_platform_migration_checkpoints_guild
+    ON platform_migration_checkpoints (guild_id);

--- a/disbot/services/binding_backfill.py
+++ b/disbot/services/binding_backfill.py
@@ -1,0 +1,540 @@
+"""Binding backfill — dry-run + reconciliation (Phase 2, PR-5).
+
+Read-only planner for the legacy → ``subsystem_bindings`` migration.
+This module **does not write** to ``subsystem_bindings``; PR-6 adds the
+write path through a dedicated ``BindingBackfillPipeline``.  PR-5
+exists so the operator can review what a real backfill would do
+*before* any rows are touched, and so the diagnostics surface can
+surface drift / disagreement / missing-target cases.
+
+Migrated key registry:
+
+The :data:`MIGRATED_KEYS` constant declares every legacy key the
+backfill plan covers, paired with the typed ``(subsystem,
+binding_name, kind)`` it should land at.  Initial set (per the Phase 2
+plan):
+
+* ``xp_announce_channel`` → ``(xp, announce_channel, CHANNEL)``
+* ``economy_log_channel`` → ``(economy, log_channel, CHANNEL)``
+* ``trusted_tier_role_id`` → ``(governance, trusted_role, ROLE)``
+
+XP threshold roles are intentionally excluded — the 1:N (level → role)
+shape does not fit ``subsystem_bindings``' 1:1 schema; a dedicated
+``xp_threshold_roles`` table is the right shape and will land in a
+future PR.
+
+Classifications:
+
+Every ``(guild, migrated_key)`` pair is classified into exactly one
+:class:`Classification` value.  The operator inspects the per-key
+results before authorising the PR-6 write phase.
+
+Dry-run output:
+
+The per-guild dry-run writes one row to
+``platform_migration_checkpoints`` with::
+
+    name        = "binding_backfill"
+    guild_id    = <guild>
+    status      = "dry_run_complete"
+    version     = 1
+    summary_json = {
+        "candidates": [...],
+        "counts": {<classification>: N, ...},
+    }
+
+Re-running a dry-run for the same guild upserts the row.  An operator
+can then ``SELECT summary_json FROM platform_migration_checkpoints
+WHERE name='binding_backfill' AND guild_id = X`` to review.
+
+The module also exposes the same primitives synchronously
+(``classify_candidate``) so unit tests can exercise the matrix
+without touching DB or Discord.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+import discord
+
+from core.resources.status import ResourceStatus
+from core.runtime.subsystem_schema import BindingKind, get_schema
+from utils.settings_keys.economy import ECONOMY_LOG_CHANNEL
+from utils.settings_keys.governance import TRUSTED_TIER_ROLE_ID
+from utils.settings_keys.xp import XP_ANNOUNCE_CHANNEL
+
+logger = logging.getLogger("bot.services.binding_backfill")
+
+# Migration name written to ``platform_migration_checkpoints.name``.
+MIGRATION_NAME = "binding_backfill"
+
+# Schema version of ``summary_json``.  Bump when the dict shape
+# changes so the operator can detect mixed runs.
+SUMMARY_VERSION = 1
+
+
+# ---------------------------------------------------------------------------
+# Migrated key registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MigratedKey:
+    """Declarative mapping from a legacy KV key to a typed binding slot."""
+
+    legacy_key: str
+    subsystem: str
+    binding_name: str
+    kind: BindingKind
+
+
+MIGRATED_KEYS: tuple[MigratedKey, ...] = (
+    MigratedKey(
+        legacy_key=XP_ANNOUNCE_CHANNEL,
+        subsystem="xp",
+        binding_name="announce_channel",
+        kind=BindingKind.CHANNEL,
+    ),
+    MigratedKey(
+        legacy_key=ECONOMY_LOG_CHANNEL,
+        subsystem="economy",
+        binding_name="log_channel",
+        kind=BindingKind.CHANNEL,
+    ),
+    MigratedKey(
+        legacy_key=TRUSTED_TIER_ROLE_ID,
+        subsystem="governance",
+        binding_name="trusted_role",
+        kind=BindingKind.ROLE,
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Classification taxonomy
+# ---------------------------------------------------------------------------
+
+
+class Classification(str, Enum):
+    """Outcome of classifying a single ``(guild, migrated_key)`` pair.
+
+    String-valued so the literal is JSON-friendly inside
+    ``summary_json``.
+    """
+
+    # Nothing to do — neither side has a value.
+    BOTH_ABSENT = "both_absent"
+
+    # Legacy has a value, no binding row yet, target validates.
+    # This is the primary backfill candidate.
+    CANDIDATE_VALID = "candidate_valid"
+
+    # Legacy has a value but the target is missing (channel/role
+    # deleted, or numeric junk).  Skip — operator must investigate.
+    CANDIDATE_INVALID_TARGET_MISSING = "candidate_invalid_target_missing"
+
+    # Legacy has a value but it's not a valid integer or otherwise
+    # cannot be parsed.
+    CANDIDATE_INVALID_UNPARSEABLE = "candidate_invalid_unparseable"
+
+    # Legacy has a value but its kind is wrong (e.g. legacy
+    # XP_ANNOUNCE_CHANNEL points at a role ID).  Skip — operator
+    # must investigate.
+    CANDIDATE_INVALID_WRONG_KIND = "candidate_invalid_wrong_kind"
+
+    # Binding row exists, legacy missing.  Rare; usually means a
+    # previous backfill already ran or the operator wrote bindings
+    # directly.
+    BINDING_ONLY = "binding_only"
+
+    # Both sides present and the target IDs match.
+    MATCH = "match"
+
+    # Both sides present but they disagree — operator must reconcile.
+    DISAGREE = "disagree"
+
+    # Binding row exists with status != BOUND (MISSING / INVALID /
+    # UNRESOLVED).  Recorded as a finding even when legacy is also
+    # present; the operator may decide to re-bind via the wizard.
+    BINDING_STATUS_NOT_BOUND = "binding_status_not_bound"
+
+    # Subsystem has no declared SubsystemSchema or no matching
+    # BindingSpec.  Backfill is blocked until the schema is declared.
+    BLOCKED_NO_SCHEMA = "blocked_no_schema"
+
+
+# Classifications that are safe candidates for the PR-6 write phase.
+WRITABLE_CLASSIFICATIONS: frozenset[Classification] = frozenset(
+    {Classification.CANDIDATE_VALID},
+)
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CandidateResult:
+    """One ``(guild, migrated_key)`` classification result.
+
+    Carries enough provenance that ``summary_json`` is operator-readable
+    without consulting source.
+    """
+
+    legacy_key: str
+    subsystem: str
+    binding_name: str
+    kind: str  # BindingKind.value
+    legacy_target_id: int | None
+    legacy_raw: str | None
+    binding_target_id: int | None
+    binding_status: str | None  # ResourceStatus.value or None
+    classification: str  # Classification.value
+    reason: str
+
+    def to_summary_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DryRunSummary:
+    """Outcome of :func:`dry_run` for one guild."""
+
+    guild_id: int
+    started_at: datetime
+    completed_at: datetime
+    summary_version: int
+    candidates: tuple[CandidateResult, ...]
+    counts: dict[str, int]
+
+    def to_summary_dict(self) -> dict[str, Any]:
+        return {
+            "summary_version": self.summary_version,
+            "started_at": self.started_at.isoformat(),
+            "completed_at": self.completed_at.isoformat(),
+            "candidates": [c.to_summary_dict() for c in self.candidates],
+            "counts": dict(self.counts),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Pure classification (synchronous; testable without DB or Discord)
+# ---------------------------------------------------------------------------
+
+
+def _parse_legacy_id(raw: str | None) -> tuple[int | None, str]:
+    """Best-effort parse of a legacy KV value into a snowflake.
+
+    Returns ``(parsed_id, reason)``.  ``parsed_id`` is ``None`` when
+    the value is missing, empty, or unparseable.
+    """
+    if raw is None or raw == "":
+        return None, "legacy value empty"
+    try:
+        return int(raw), "legacy value parsed"
+    except (TypeError, ValueError):
+        return None, f"legacy value {raw!r} is not a snowflake"
+
+
+def classify_candidate(
+    *,
+    migrated_key: MigratedKey,
+    legacy_raw: str | None,
+    legacy_validated_status: ResourceStatus | None,
+    binding_target_id: int | None,
+    binding_status: ResourceStatus | None,
+    schema_declared: bool,
+) -> tuple[Classification, str]:
+    """Pure classifier — no DB, no Discord.  Returns (classification, reason).
+
+    Inputs:
+
+    * ``migrated_key`` — declarative mapping for the key being checked.
+    * ``legacy_raw`` — the raw KV value (or ``None`` for missing).
+    * ``legacy_validated_status`` — the result of validating the
+      parsed legacy ID against the live guild.  ``None`` when no
+      legacy value exists or parsing failed.
+    * ``binding_target_id`` — current ``subsystem_bindings.target_id``
+      (``None`` when no row exists OR row exists with NULL target).
+    * ``binding_status`` — current ``subsystem_bindings.status``
+      (``None`` when no row exists).
+    * ``schema_declared`` — whether ``get_schema(subsystem)`` returns
+      a schema that declares this ``binding_name``.
+
+    Returns a ``(Classification, human-readable reason)`` tuple.
+    """
+    legacy_id, parse_reason = _parse_legacy_id(legacy_raw)
+
+    # Schema gate (applies regardless of side presence — backfill
+    # cannot proceed without a declared BindingSpec).
+    if not schema_declared:
+        return (
+            Classification.BLOCKED_NO_SCHEMA,
+            (
+                f"subsystem {migrated_key.subsystem!r} has no registered "
+                f"SubsystemSchema with binding {migrated_key.binding_name!r}; "
+                "register one before backfill"
+            ),
+        )
+
+    # Categorise the two sides.
+    legacy_present = legacy_raw is not None and legacy_raw != ""
+    binding_present = binding_target_id is not None or binding_status is not None
+
+    # 1) Both absent.
+    if not legacy_present and not binding_present:
+        return Classification.BOTH_ABSENT, "neither legacy nor binding has a value"
+
+    # 2) Binding only.
+    if not legacy_present and binding_present:
+        if binding_status is not None and binding_status is not ResourceStatus.BOUND:
+            return (
+                Classification.BINDING_STATUS_NOT_BOUND,
+                f"binding row present with status={binding_status.value!r}",
+            )
+        return (
+            Classification.BINDING_ONLY,
+            "binding row present, legacy missing (no backfill needed)",
+        )
+
+    # 3) Legacy only.
+    if legacy_present and not binding_present:
+        if legacy_id is None:
+            return (
+                Classification.CANDIDATE_INVALID_UNPARSEABLE,
+                parse_reason,
+            )
+        if legacy_validated_status is ResourceStatus.MISSING:
+            return (
+                Classification.CANDIDATE_INVALID_TARGET_MISSING,
+                f"legacy target id={legacy_id} does not exist in the guild",
+            )
+        if legacy_validated_status is ResourceStatus.INVALID:
+            return (
+                Classification.CANDIDATE_INVALID_WRONG_KIND,
+                (
+                    f"legacy target id={legacy_id} exists but does not match "
+                    f"declared kind={migrated_key.kind.value!r}"
+                ),
+            )
+        if legacy_validated_status is ResourceStatus.BOUND:
+            return (
+                Classification.CANDIDATE_VALID,
+                f"legacy id={legacy_id} validates; safe to backfill",
+            )
+        # UNRESOLVED — treat as missing for safety.
+        return (
+            Classification.CANDIDATE_INVALID_TARGET_MISSING,
+            f"legacy target id={legacy_id} could not be resolved",
+        )
+
+    # 4) Both present.  Reconcile.
+    if binding_status is not None and binding_status is not ResourceStatus.BOUND:
+        return (
+            Classification.BINDING_STATUS_NOT_BOUND,
+            (
+                f"both sides present; binding status={binding_status.value!r} "
+                f"(operator may want to re-bind via the wizard)"
+            ),
+        )
+    if legacy_id is None:
+        # Legacy unparseable but a binding exists — trust the binding.
+        return (
+            Classification.BINDING_ONLY,
+            f"legacy value unparseable ({parse_reason}); binding has a value",
+        )
+    if legacy_id == binding_target_id:
+        return Classification.MATCH, "legacy and binding agree"
+    return (
+        Classification.DISAGREE,
+        (
+            f"legacy id={legacy_id} disagrees with binding "
+            f"target_id={binding_target_id}; operator must reconcile"
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Async dry-run (reads DB + Discord; never writes to subsystem_bindings)
+# ---------------------------------------------------------------------------
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _schema_declares(subsystem: str, binding_name: str) -> bool:
+    schema = get_schema(subsystem)
+    if schema is None:
+        return False
+    return any(spec.name == binding_name for spec in schema.bindings)
+
+
+async def dry_run(guild: discord.Guild) -> DryRunSummary:
+    """Classify every migrated key for ``guild`` and persist a checkpoint.
+
+    Reads:
+
+    * Legacy KV via :func:`utils.db.settings.get_setting`.
+    * Current binding row via :func:`core.runtime.bindings.get_binding`.
+    * Live target validation via
+      :func:`core.runtime.bindings.validate_binding_target`.
+
+    Writes:
+
+    * One row to ``platform_migration_checkpoints`` with
+      ``name="binding_backfill"``, ``guild_id=<guild.id>``,
+      ``status="dry_run_complete"``, and the structured summary.
+
+    Does NOT write to ``subsystem_bindings``.  The PR-6 write phase
+    consumes the candidates with classification ``CANDIDATE_VALID``
+    from this summary.
+    """
+    # Local imports to keep this module out of any module-load cycles.
+    from core.runtime.bindings import get_binding, validate_binding_target
+    from utils.db import platform_migration_checkpoints as checkpoint_db
+    from utils.db import settings as settings_db
+
+    started_at = _now_utc()
+    candidates: list[CandidateResult] = []
+
+    for key in MIGRATED_KEYS:
+        legacy_raw = await settings_db.get_setting(
+            guild.id,
+            key.legacy_key,
+            default="",
+        )
+        legacy_raw_norm = legacy_raw or None
+        legacy_id, _ = _parse_legacy_id(legacy_raw_norm)
+
+        # Validate the legacy target (if parseable) so the classifier
+        # has the live-resource status.  Skip validation when the
+        # legacy value is empty/unparseable.
+        legacy_validated_status: ResourceStatus | None = None
+        if legacy_id is not None:
+            try:
+                legacy_validated_status = await validate_binding_target(
+                    guild,
+                    key.kind,
+                    legacy_id,
+                )
+            except Exception as exc:  # noqa: BLE001 — dry-run must not raise
+                logger.warning(
+                    "binding_backfill.dry_run: validate_binding_target raised "
+                    "for guild=%d key=%r (%r); treating as UNRESOLVED",
+                    guild.id,
+                    key.legacy_key,
+                    exc,
+                )
+                legacy_validated_status = ResourceStatus.UNRESOLVED
+
+        # Read the binding row.  ``get_binding`` returns a fresh
+        # ``BindingValue`` even when no DB row exists (with status
+        # UNRESOLVED + target_id None); the classifier distinguishes
+        # "no row" from "row with NULL target" via the presence of a
+        # ``last_updated_at``.
+        try:
+            bv = await get_binding(guild.id, key.subsystem, key.binding_name)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "binding_backfill.dry_run: get_binding raised for "
+                "guild=%d subsystem=%r binding=%r (%r); skipping",
+                guild.id,
+                key.subsystem,
+                key.binding_name,
+                exc,
+            )
+            classification, reason = (
+                Classification.BLOCKED_NO_SCHEMA,
+                f"get_binding raised: {type(exc).__name__}",
+            )
+            candidates.append(
+                CandidateResult(
+                    legacy_key=key.legacy_key,
+                    subsystem=key.subsystem,
+                    binding_name=key.binding_name,
+                    kind=key.kind.value,
+                    legacy_target_id=legacy_id,
+                    legacy_raw=legacy_raw_norm,
+                    binding_target_id=None,
+                    binding_status=None,
+                    classification=classification.value,
+                    reason=reason,
+                ),
+            )
+            continue
+
+        # Treat "row present" as "we have a last_updated_at OR a
+        # non-null target_id".  A row with NULL target_id is still a
+        # declared slot; in classify_candidate we treat it as
+        # binding_present so the operator sees BINDING_STATUS_NOT_BOUND.
+        binding_row_present = bv.last_updated_at is not None
+        classification, reason = classify_candidate(
+            migrated_key=key,
+            legacy_raw=legacy_raw_norm,
+            legacy_validated_status=legacy_validated_status,
+            binding_target_id=bv.target_id if binding_row_present else None,
+            binding_status=bv.status if binding_row_present else None,
+            schema_declared=_schema_declares(key.subsystem, key.binding_name),
+        )
+
+        candidates.append(
+            CandidateResult(
+                legacy_key=key.legacy_key,
+                subsystem=key.subsystem,
+                binding_name=key.binding_name,
+                kind=key.kind.value,
+                legacy_target_id=legacy_id,
+                legacy_raw=legacy_raw_norm,
+                binding_target_id=bv.target_id if binding_row_present else None,
+                binding_status=(bv.status.value if binding_row_present else None),
+                classification=classification.value,
+                reason=reason,
+            ),
+        )
+
+    completed_at = _now_utc()
+    counts: dict[str, int] = {}
+    for c in candidates:
+        counts[c.classification] = counts.get(c.classification, 0) + 1
+
+    summary = DryRunSummary(
+        guild_id=guild.id,
+        started_at=started_at,
+        completed_at=completed_at,
+        summary_version=SUMMARY_VERSION,
+        candidates=tuple(candidates),
+        counts=counts,
+    )
+
+    # Persist the checkpoint — idempotent upsert by (name, guild_id).
+    await checkpoint_db.upsert_checkpoint(
+        name=MIGRATION_NAME,
+        guild_id=guild.id,
+        status="dry_run_complete",
+        version=SUMMARY_VERSION,
+        summary_json=summary.to_summary_dict(),
+        mark_completed=True,
+    )
+
+    return summary
+
+
+__all__ = [
+    "MIGRATED_KEYS",
+    "MIGRATION_NAME",
+    "SUMMARY_VERSION",
+    "WRITABLE_CLASSIFICATIONS",
+    "CandidateResult",
+    "Classification",
+    "DryRunSummary",
+    "MigratedKey",
+    "classify_candidate",
+    "dry_run",
+]

--- a/disbot/utils/db/platform_migration_checkpoints.py
+++ b/disbot/utils/db/platform_migration_checkpoints.py
@@ -1,0 +1,301 @@
+"""Platform migration checkpoints — DB primitives (Phase 2, PR-5).
+
+Owns the read/write surface for ``platform_migration_checkpoints``.
+The first consumer is :mod:`services.binding_backfill`; the table is
+intentionally generic so future logical migrations (e.g. PR-9
+participation backfills) can reuse it without a new schema.
+
+Public surface:
+
+* :func:`get_checkpoint` — single-row read keyed by (name, guild_id).
+* :func:`list_checkpoints` — bulk read for diagnostics, optionally
+  filtered by name prefix and/or guild.
+* :func:`upsert_checkpoint` — insert or update by (name, guild_id);
+  idempotent.
+* :func:`delete_for_guild` — purge per-guild rows for one guild;
+  global rows (``guild_id IS NULL``) are preserved.
+
+Status semantics (mirror migration 026 CHECK constraint):
+
+  pending             — work registered but not started
+  dry_run_complete    — dry-run finished without writing target table
+  in_progress         — write phase running
+  complete            — all work finished successfully
+  failed              — write phase aborted; ``summary_json`` carries
+                        the error context
+  rolled_back         — a previous ``complete`` row was reverted; the
+                        same (name, guild_id) is updated in place
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from utils.db import pool
+
+logger = logging.getLogger("bot.db.platform_migration_checkpoints")
+
+# Recognized statuses (mirrors migration 026 CHECK).  An alignment test
+# pins this set to the SQL literals.
+KNOWN_STATUSES: frozenset[str] = frozenset(
+    {
+        "pending",
+        "dry_run_complete",
+        "in_progress",
+        "complete",
+        "failed",
+        "rolled_back",
+    },
+)
+
+
+def _serialise(summary_json: Any | None) -> str | None:
+    """JSON-encode ``summary_json`` for asyncpg.
+
+    asyncpg requires JSONB columns to be passed as ``json.dumps`` text
+    (it does not auto-encode Python dicts).  ``None`` passes through as
+    SQL NULL.
+    """
+    if summary_json is None:
+        return None
+    if isinstance(summary_json, str):
+        # Caller already serialised; trust them.
+        return summary_json
+    return json.dumps(summary_json, default=str)
+
+
+def _deserialise(raw: Any | None) -> Any | None:
+    """Decode the JSONB column for callers.
+
+    asyncpg can return either ``str`` (when the connection has no
+    JSONB codec installed) or a Python dict (when it does).  Handle
+    both shapes so callers always see a Python value.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, (dict, list)):
+        return raw
+    try:
+        return json.loads(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "platform_migration_checkpoints: failed to JSON-decode summary; "
+            "returning raw value",
+        )
+        return raw
+
+
+# ---------------------------------------------------------------------------
+# Reads
+# ---------------------------------------------------------------------------
+
+
+async def get_checkpoint(
+    name: str,
+    guild_id: int | None = None,
+) -> dict[str, Any] | None:
+    """Return the checkpoint row for ``(name, guild_id)``, or ``None``.
+
+    Uses ``IS NULL`` rather than ``= NULL`` so the global-checkpoint
+    row (where ``guild_id`` is null) is correctly resolved.
+    """
+    if guild_id is None:
+        row = await pool.get().fetchrow(
+            """
+            SELECT id, name, guild_id, status, version,
+                   started_at, completed_at, summary_json
+            FROM platform_migration_checkpoints
+            WHERE name = $1 AND guild_id IS NULL
+            """,
+            name,
+        )
+    else:
+        row = await pool.get().fetchrow(
+            """
+            SELECT id, name, guild_id, status, version,
+                   started_at, completed_at, summary_json
+            FROM platform_migration_checkpoints
+            WHERE name = $1 AND guild_id = $2
+            """,
+            name,
+            guild_id,
+        )
+    if row is None:
+        return None
+    out = dict(row)
+    out["summary_json"] = _deserialise(out.get("summary_json"))
+    return out
+
+
+async def list_checkpoints(
+    *,
+    name_prefix: str | None = None,
+    guild_id: int | None = None,
+) -> list[dict[str, Any]]:
+    """Return checkpoint rows for diagnostics.
+
+    Filters:
+
+    * ``name_prefix`` — match rows whose ``name`` starts with this
+      literal.  ``None`` returns every row.
+    * ``guild_id`` — restrict to one guild.  ``None`` returns rows
+      for every guild AND the global rows.
+    """
+    clauses: list[str] = []
+    args: list[Any] = []
+    if name_prefix is not None:
+        args.append(f"{name_prefix}%")
+        clauses.append(f"name LIKE ${len(args)}")
+    if guild_id is not None:
+        args.append(guild_id)
+        clauses.append(f"guild_id = ${len(args)}")
+    where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+    sql = (
+        "SELECT id, name, guild_id, status, version, "
+        "started_at, completed_at, summary_json "
+        f"FROM platform_migration_checkpoints {where} "
+        "ORDER BY name, started_at DESC"
+    )
+    rows = await pool.get().fetch(sql, *args)
+    out: list[dict[str, Any]] = []
+    for r in rows:
+        d = dict(r)
+        d["summary_json"] = _deserialise(d.get("summary_json"))
+        out.append(d)
+    return out
+
+
+async def count_by_status(
+    *,
+    name_prefix: str | None = None,
+) -> dict[str, int]:
+    """Return a ``status → count`` histogram for diagnostics."""
+    if name_prefix is None:
+        rows = await pool.get().fetch(
+            """
+            SELECT status, COUNT(*)::int AS n
+            FROM platform_migration_checkpoints
+            GROUP BY status
+            """,
+        )
+    else:
+        rows = await pool.get().fetch(
+            """
+            SELECT status, COUNT(*)::int AS n
+            FROM platform_migration_checkpoints
+            WHERE name LIKE $1
+            GROUP BY status
+            """,
+            f"{name_prefix}%",
+        )
+    return {r["status"]: r["n"] for r in rows}
+
+
+# ---------------------------------------------------------------------------
+# Writes
+# ---------------------------------------------------------------------------
+
+
+async def upsert_checkpoint(
+    *,
+    name: str,
+    guild_id: int | None,
+    status: str,
+    version: int = 1,
+    summary_json: Any | None = None,
+    mark_completed: bool = False,
+) -> None:
+    """Insert or update the checkpoint for ``(name, guild_id)``.
+
+    Idempotent: re-running with the same ``(name, guild_id)`` updates
+    the existing row in place (status, version, summary, optionally
+    ``completed_at``).  ``started_at`` is preserved on update so the
+    original run timestamp survives.
+
+    Args:
+        name: migration identifier (e.g. ``"binding_backfill"``).
+        guild_id: per-guild scope, or ``None`` for the global row.
+        status: must be in :data:`KNOWN_STATUSES`.
+        version: schema/version counter for the migration; bump when
+            the ``summary_json`` shape changes.
+        summary_json: arbitrary JSON-serialisable payload.  ``None``
+            passes through as SQL NULL.
+        mark_completed: if ``True``, set ``completed_at = NOW()`` on
+            this write.  Used by terminal statuses
+            (``complete``/``failed``/``rolled_back``).
+
+    Raises:
+        ValueError: if ``status`` is not in :data:`KNOWN_STATUSES`.
+    """
+    if status not in KNOWN_STATUSES:
+        msg = f"unknown status {status!r}; expected one of {sorted(KNOWN_STATUSES)}"
+        raise ValueError(msg)
+
+    completed_clause = "NOW()" if mark_completed else "completed_at"
+    serialised = _serialise(summary_json)
+
+    if guild_id is None:
+        sql = f"""
+            INSERT INTO platform_migration_checkpoints
+                (name, guild_id, status, version, summary_json)
+            VALUES ($1, NULL, $2, $3, $4)
+            ON CONFLICT (name) WHERE guild_id IS NULL DO UPDATE SET
+                status = EXCLUDED.status,
+                version = EXCLUDED.version,
+                summary_json = EXCLUDED.summary_json,
+                completed_at = {completed_clause}
+        """
+        await pool.get().execute(sql, name, status, version, serialised)
+    else:
+        sql = f"""
+            INSERT INTO platform_migration_checkpoints
+                (name, guild_id, status, version, summary_json)
+            VALUES ($1, $2, $3, $4, $5)
+            ON CONFLICT (name, guild_id) WHERE guild_id IS NOT NULL
+            DO UPDATE SET
+                status = EXCLUDED.status,
+                version = EXCLUDED.version,
+                summary_json = EXCLUDED.summary_json,
+                completed_at = {completed_clause}
+        """
+        await pool.get().execute(
+            sql,
+            name,
+            guild_id,
+            status,
+            version,
+            serialised,
+        )
+
+
+async def delete_for_guild(guild_id: int) -> int:
+    """Delete per-guild checkpoint rows for ``guild_id``.
+
+    Global checkpoint rows (``guild_id IS NULL``) are preserved.
+    Wired into ``guild_lifecycle.teardown`` so a re-invited guild
+    starts with a clean checkpoint history while the global migration
+    overview survives.
+
+    Returns the deleted-row count parsed from asyncpg's ``"DELETE N"``
+    status string; ``0`` on any parse failure.
+    """
+    result = await pool.get().execute(
+        "DELETE FROM platform_migration_checkpoints WHERE guild_id = $1",
+        guild_id,
+    )
+    try:
+        return int(result.split()[-1])
+    except (ValueError, IndexError):
+        return 0
+
+
+__all__ = [
+    "KNOWN_STATUSES",
+    "count_by_status",
+    "delete_for_guild",
+    "get_checkpoint",
+    "list_checkpoints",
+    "upsert_checkpoint",
+]

--- a/tests/unit/binding_backfill/test_classification.py
+++ b/tests/unit/binding_backfill/test_classification.py
@@ -1,0 +1,239 @@
+"""Phase 2 PR-5 — pure ``classify_candidate`` matrix.
+
+The classifier is intentionally synchronous so the full classification
+matrix can be exercised without DB or Discord mocking.  Each test
+covers one ``Classification`` value.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.resources.status import ResourceStatus
+from core.runtime.subsystem_schema import BindingKind
+from services.binding_backfill import (
+    Classification,
+    MigratedKey,
+    classify_candidate,
+)
+
+_KEY = MigratedKey(
+    legacy_key="xp_announce_channel",
+    subsystem="xp",
+    binding_name="announce_channel",
+    kind=BindingKind.CHANNEL,
+)
+
+
+# ---------------------------------------------------------------------------
+# Schema gate
+# ---------------------------------------------------------------------------
+
+
+def test_blocked_no_schema_short_circuits():
+    """Even when both sides have values, schema-undeclared bindings block."""
+    classification, reason = classify_candidate(
+        migrated_key=_KEY,
+        legacy_raw="123",
+        legacy_validated_status=ResourceStatus.BOUND,
+        binding_target_id=123,
+        binding_status=ResourceStatus.BOUND,
+        schema_declared=False,
+    )
+    assert classification is Classification.BLOCKED_NO_SCHEMA
+    assert "no registered SubsystemSchema" in reason
+
+
+# ---------------------------------------------------------------------------
+# Both absent
+# ---------------------------------------------------------------------------
+
+
+def test_both_absent():
+    classification, _ = classify_candidate(
+        migrated_key=_KEY,
+        legacy_raw=None,
+        legacy_validated_status=None,
+        binding_target_id=None,
+        binding_status=None,
+        schema_declared=True,
+    )
+    assert classification is Classification.BOTH_ABSENT
+
+
+def test_empty_legacy_treated_as_absent():
+    """Empty-string legacy is the legacy KV "missing" sentinel."""
+    classification, _ = classify_candidate(
+        migrated_key=_KEY,
+        legacy_raw="",
+        legacy_validated_status=None,
+        binding_target_id=None,
+        binding_status=None,
+        schema_declared=True,
+    )
+    assert classification is Classification.BOTH_ABSENT
+
+
+# ---------------------------------------------------------------------------
+# Binding only
+# ---------------------------------------------------------------------------
+
+
+def test_binding_only_bound():
+    classification, _ = classify_candidate(
+        migrated_key=_KEY,
+        legacy_raw=None,
+        legacy_validated_status=None,
+        binding_target_id=999,
+        binding_status=ResourceStatus.BOUND,
+        schema_declared=True,
+    )
+    assert classification is Classification.BINDING_ONLY
+
+
+def test_binding_only_status_not_bound():
+    """Binding row exists with status MISSING and no legacy."""
+    classification, _ = classify_candidate(
+        migrated_key=_KEY,
+        legacy_raw=None,
+        legacy_validated_status=None,
+        binding_target_id=None,
+        binding_status=ResourceStatus.MISSING,
+        schema_declared=True,
+    )
+    assert classification is Classification.BINDING_STATUS_NOT_BOUND
+
+
+# ---------------------------------------------------------------------------
+# Legacy only — every sub-case
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_only_candidate_valid():
+    classification, reason = classify_candidate(
+        migrated_key=_KEY,
+        legacy_raw="123",
+        legacy_validated_status=ResourceStatus.BOUND,
+        binding_target_id=None,
+        binding_status=None,
+        schema_declared=True,
+    )
+    assert classification is Classification.CANDIDATE_VALID
+    assert "validates" in reason
+
+
+def test_legacy_only_target_missing():
+    classification, _ = classify_candidate(
+        migrated_key=_KEY,
+        legacy_raw="123",
+        legacy_validated_status=ResourceStatus.MISSING,
+        binding_target_id=None,
+        binding_status=None,
+        schema_declared=True,
+    )
+    assert classification is Classification.CANDIDATE_INVALID_TARGET_MISSING
+
+
+def test_legacy_only_wrong_kind():
+    """Legacy value points at a Discord object whose kind doesn't match."""
+    classification, _ = classify_candidate(
+        migrated_key=_KEY,
+        legacy_raw="123",
+        legacy_validated_status=ResourceStatus.INVALID,
+        binding_target_id=None,
+        binding_status=None,
+        schema_declared=True,
+    )
+    assert classification is Classification.CANDIDATE_INVALID_WRONG_KIND
+
+
+def test_legacy_only_unparseable():
+    classification, _ = classify_candidate(
+        migrated_key=_KEY,
+        legacy_raw="not-a-number",
+        legacy_validated_status=None,
+        binding_target_id=None,
+        binding_status=None,
+        schema_declared=True,
+    )
+    assert classification is Classification.CANDIDATE_INVALID_UNPARSEABLE
+
+
+def test_legacy_only_unresolved_treated_as_missing():
+    classification, _ = classify_candidate(
+        migrated_key=_KEY,
+        legacy_raw="123",
+        legacy_validated_status=ResourceStatus.UNRESOLVED,
+        binding_target_id=None,
+        binding_status=None,
+        schema_declared=True,
+    )
+    assert classification is Classification.CANDIDATE_INVALID_TARGET_MISSING
+
+
+# ---------------------------------------------------------------------------
+# Both present — match / disagree / status-not-bound
+# ---------------------------------------------------------------------------
+
+
+def test_both_present_match():
+    classification, _ = classify_candidate(
+        migrated_key=_KEY,
+        legacy_raw="123",
+        legacy_validated_status=ResourceStatus.BOUND,
+        binding_target_id=123,
+        binding_status=ResourceStatus.BOUND,
+        schema_declared=True,
+    )
+    assert classification is Classification.MATCH
+
+
+def test_both_present_disagree():
+    classification, reason = classify_candidate(
+        migrated_key=_KEY,
+        legacy_raw="123",
+        legacy_validated_status=ResourceStatus.BOUND,
+        binding_target_id=456,
+        binding_status=ResourceStatus.BOUND,
+        schema_declared=True,
+    )
+    assert classification is Classification.DISAGREE
+    assert "operator must reconcile" in reason
+
+
+def test_both_present_binding_not_bound_wins_over_match():
+    """When the binding status is not BOUND, surface that instead of matching."""
+    classification, _ = classify_candidate(
+        migrated_key=_KEY,
+        legacy_raw="123",
+        legacy_validated_status=ResourceStatus.BOUND,
+        binding_target_id=123,
+        binding_status=ResourceStatus.MISSING,
+        schema_declared=True,
+    )
+    assert classification is Classification.BINDING_STATUS_NOT_BOUND
+
+
+def test_both_present_legacy_unparseable_keeps_binding():
+    """Junk legacy + valid binding row → trust the binding."""
+    classification, _ = classify_candidate(
+        migrated_key=_KEY,
+        legacy_raw="garbage",
+        legacy_validated_status=None,
+        binding_target_id=123,
+        binding_status=ResourceStatus.BOUND,
+        schema_declared=True,
+    )
+    assert classification is Classification.BINDING_ONLY
+
+
+# ---------------------------------------------------------------------------
+# WRITABLE_CLASSIFICATIONS — only the safe candidate survives
+# ---------------------------------------------------------------------------
+
+
+def test_only_candidate_valid_is_writable():
+    """The PR-6 write phase consumes ONLY ``CANDIDATE_VALID`` candidates."""
+    from services.binding_backfill import WRITABLE_CLASSIFICATIONS
+
+    assert WRITABLE_CLASSIFICATIONS == frozenset({Classification.CANDIDATE_VALID})

--- a/tests/unit/binding_backfill/test_dry_run.py
+++ b/tests/unit/binding_backfill/test_dry_run.py
@@ -1,0 +1,317 @@
+"""Phase 2 PR-5 — services.binding_backfill.dry_run end-to-end behaviour.
+
+Verifies the dry-run wrapper:
+
+* iterates every entry in :data:`MIGRATED_KEYS`,
+* reads legacy via ``utils.db.settings.get_setting``,
+* reads binding via ``core.runtime.bindings.get_binding``,
+* validates the legacy target via
+  ``core.runtime.bindings.validate_binding_target``,
+* writes a single ``platform_migration_checkpoints`` row with the
+  structured summary,
+* never writes to ``subsystem_bindings``.
+
+Discord ``Guild`` is mocked because the dry-run only reads guild.id;
+the actual validation calls are mocked so we can drive each
+classification deterministically.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from core.resources.status import ResourceStatus
+from core.runtime.bindings import BindingValue
+from core.runtime.subsystem_schema import BindingKind
+from services import binding_backfill
+from services.binding_backfill import Classification, dry_run
+
+
+def _bv(*, target_id, status, last_updated_at=None):
+    """Construct a BindingValue with the shape ``get_binding`` returns."""
+    return BindingValue(
+        guild_id=42,
+        subsystem="xp",
+        binding_name="announce_channel",
+        kind=BindingKind.CHANNEL,
+        target_id=target_id,
+        status=status,
+        last_validated_at=last_updated_at,
+        last_updated_at=last_updated_at,
+        version=1 if last_updated_at is not None else 0,
+    )
+
+
+@pytest.fixture
+def _mock_guild():
+    guild = MagicMock()
+    guild.id = 42
+    return guild
+
+
+@pytest.fixture
+def _patched_dry_run(_mock_guild):
+    """Patch the three DB/Discord touchpoints + the checkpoint writer."""
+    with (
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+        ) as mock_legacy,
+        patch(
+            "core.runtime.bindings.get_binding",
+            new_callable=AsyncMock,
+        ) as mock_binding,
+        patch(
+            "core.runtime.bindings.validate_binding_target",
+            new_callable=AsyncMock,
+        ) as mock_validate,
+        patch(
+            "utils.db.platform_migration_checkpoints.upsert_checkpoint",
+            new_callable=AsyncMock,
+        ) as mock_checkpoint,
+        patch.object(
+            binding_backfill,
+            "_schema_declares",
+            return_value=True,
+        ),
+    ):
+        yield {
+            "legacy": mock_legacy,
+            "binding": mock_binding,
+            "validate": mock_validate,
+            "checkpoint": mock_checkpoint,
+            "guild": _mock_guild,
+        }
+
+
+@pytest.mark.asyncio
+async def test_dry_run_iterates_every_migrated_key(_patched_dry_run):
+    """All three :data:`MIGRATED_KEYS` are classified — never short-circuit."""
+    p = _patched_dry_run
+    p["legacy"].return_value = ""  # all legacy values empty
+    p["binding"].side_effect = lambda gid, sub, name: _bv(
+        target_id=None,
+        status=ResourceStatus.UNRESOLVED,
+    )
+
+    summary = await dry_run(p["guild"])
+
+    # Three migrated keys today
+    assert len(summary.candidates) == 3
+    assert {c.subsystem for c in summary.candidates} == {"xp", "economy", "governance"}
+    # All classified BOTH_ABSENT because legacy is empty + no binding row
+    assert all(
+        c.classification == Classification.BOTH_ABSENT.value for c in summary.candidates
+    )
+    assert summary.counts == {Classification.BOTH_ABSENT.value: 3}
+
+
+@pytest.mark.asyncio
+async def test_dry_run_records_checkpoint(_patched_dry_run):
+    """One ``upsert_checkpoint`` call with status='dry_run_complete'."""
+    p = _patched_dry_run
+    p["legacy"].return_value = ""
+    p["binding"].side_effect = lambda gid, sub, name: _bv(
+        target_id=None,
+        status=ResourceStatus.UNRESOLVED,
+    )
+
+    await dry_run(p["guild"])
+
+    p["checkpoint"].assert_awaited_once()
+    call = p["checkpoint"].await_args
+    assert call.kwargs["name"] == "binding_backfill"
+    assert call.kwargs["guild_id"] == 42
+    assert call.kwargs["status"] == "dry_run_complete"
+    assert call.kwargs["mark_completed"] is True
+    # summary_json carries counts + candidates
+    summary = call.kwargs["summary_json"]
+    assert summary["counts"] == {Classification.BOTH_ABSENT.value: 3}
+    assert len(summary["candidates"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_dry_run_legacy_only_candidate_valid(_patched_dry_run):
+    """A legacy-only XP announce channel with a valid target → CANDIDATE_VALID."""
+    p = _patched_dry_run
+
+    async def legacy_lookup(guild_id, key, default=""):
+        if key == "xp_announce_channel":
+            return "999"
+        return ""
+
+    p["legacy"].side_effect = legacy_lookup
+    p["binding"].side_effect = lambda gid, sub, name: _bv(
+        target_id=None,
+        status=ResourceStatus.UNRESOLVED,
+    )
+    p["validate"].return_value = ResourceStatus.BOUND
+
+    summary = await dry_run(p["guild"])
+    xp = next(c for c in summary.candidates if c.subsystem == "xp")
+    assert xp.classification == Classification.CANDIDATE_VALID.value
+    assert xp.legacy_target_id == 999
+    assert xp.binding_target_id is None
+
+
+@pytest.mark.asyncio
+async def test_dry_run_legacy_with_missing_target(_patched_dry_run):
+    """Legacy points at a deleted channel → CANDIDATE_INVALID_TARGET_MISSING."""
+    p = _patched_dry_run
+
+    async def legacy_lookup(guild_id, key, default=""):
+        if key == "xp_announce_channel":
+            return "999"
+        return ""
+
+    p["legacy"].side_effect = legacy_lookup
+    p["binding"].side_effect = lambda gid, sub, name: _bv(
+        target_id=None,
+        status=ResourceStatus.UNRESOLVED,
+    )
+    p["validate"].return_value = ResourceStatus.MISSING
+
+    summary = await dry_run(p["guild"])
+    xp = next(c for c in summary.candidates if c.subsystem == "xp")
+    assert xp.classification == Classification.CANDIDATE_INVALID_TARGET_MISSING.value
+
+
+@pytest.mark.asyncio
+async def test_dry_run_both_present_match(_patched_dry_run):
+    """Legacy + binding agree → MATCH."""
+    p = _patched_dry_run
+    now = datetime.now()
+
+    async def legacy_lookup(guild_id, key, default=""):
+        if key == "xp_announce_channel":
+            return "999"
+        return ""
+
+    p["legacy"].side_effect = legacy_lookup
+    p["binding"].side_effect = lambda gid, sub, name: _bv(
+        target_id=999 if sub == "xp" else None,
+        status=ResourceStatus.BOUND if sub == "xp" else ResourceStatus.UNRESOLVED,
+        last_updated_at=now if sub == "xp" else None,
+    )
+    p["validate"].return_value = ResourceStatus.BOUND
+
+    summary = await dry_run(p["guild"])
+    xp = next(c for c in summary.candidates if c.subsystem == "xp")
+    assert xp.classification == Classification.MATCH.value
+
+
+@pytest.mark.asyncio
+async def test_dry_run_both_present_disagree(_patched_dry_run):
+    p = _patched_dry_run
+    now = datetime.now()
+
+    async def legacy_lookup(guild_id, key, default=""):
+        if key == "xp_announce_channel":
+            return "999"
+        return ""
+
+    p["legacy"].side_effect = legacy_lookup
+    p["binding"].side_effect = lambda gid, sub, name: _bv(
+        target_id=111 if sub == "xp" else None,
+        status=ResourceStatus.BOUND if sub == "xp" else ResourceStatus.UNRESOLVED,
+        last_updated_at=now if sub == "xp" else None,
+    )
+    p["validate"].return_value = ResourceStatus.BOUND
+
+    summary = await dry_run(p["guild"])
+    xp = next(c for c in summary.candidates if c.subsystem == "xp")
+    assert xp.classification == Classification.DISAGREE.value
+
+
+@pytest.mark.asyncio
+async def test_dry_run_blocked_when_schema_undeclared(_mock_guild):
+    """A subsystem with no SubsystemSchema registered → BLOCKED_NO_SCHEMA."""
+    with (
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="999",
+        ),
+        patch(
+            "core.runtime.bindings.get_binding",
+            new_callable=AsyncMock,
+            side_effect=lambda gid, sub, name: _bv(
+                target_id=None,
+                status=ResourceStatus.UNRESOLVED,
+            ),
+        ),
+        patch(
+            "core.runtime.bindings.validate_binding_target",
+            new_callable=AsyncMock,
+            return_value=ResourceStatus.BOUND,
+        ),
+        patch(
+            "utils.db.platform_migration_checkpoints.upsert_checkpoint",
+            new_callable=AsyncMock,
+        ),
+        # No patch on _schema_declares — use the real registry.  Governance
+        # has no schema registered so its candidate must be blocked.  XP and
+        # Economy schemas are registered at module import (cog_load) but in
+        # the test environment they may not be — the assertion below
+        # tolerates both outcomes by asserting "governance is at least
+        # blocked".
+    ):
+        summary = await dry_run(_mock_guild)
+    governance_results = [c for c in summary.candidates if c.subsystem == "governance"]
+    assert len(governance_results) == 1
+    assert (
+        governance_results[0].classification == Classification.BLOCKED_NO_SCHEMA.value
+    )
+
+
+@pytest.mark.asyncio
+async def test_dry_run_does_not_write_to_subsystem_bindings(_patched_dry_run):
+    """Dry-run is read-only against ``subsystem_bindings``.
+
+    Pin the contract by patching the two mutation primitives — they
+    must never be awaited during a dry-run.
+    """
+    p = _patched_dry_run
+    p["legacy"].return_value = "999"
+    p["binding"].side_effect = lambda gid, sub, name: _bv(
+        target_id=None,
+        status=ResourceStatus.UNRESOLVED,
+    )
+    p["validate"].return_value = ResourceStatus.BOUND
+
+    with (
+        patch(
+            "utils.db.bindings.upsert_with_audit",
+            new_callable=AsyncMock,
+        ) as mock_upsert,
+        patch(
+            "utils.db.bindings.clear_with_audit",
+            new_callable=AsyncMock,
+        ) as mock_clear,
+    ):
+        await dry_run(p["guild"])
+    mock_upsert.assert_not_awaited()
+    mock_clear.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dry_run_idempotent_upsert_uses_same_key(_patched_dry_run):
+    """Re-running dry-run for the same guild upserts the same checkpoint row."""
+    p = _patched_dry_run
+    p["legacy"].return_value = ""
+    p["binding"].side_effect = lambda gid, sub, name: _bv(
+        target_id=None,
+        status=ResourceStatus.UNRESOLVED,
+    )
+
+    await dry_run(p["guild"])
+    await dry_run(p["guild"])
+
+    assert p["checkpoint"].await_count == 2
+    # Both calls used the same (name, guild_id)
+    for call in p["checkpoint"].await_args_list:
+        assert call.kwargs["name"] == "binding_backfill"
+        assert call.kwargs["guild_id"] == 42

--- a/tests/unit/binding_backfill/test_platform_migration_checkpoints_db.py
+++ b/tests/unit/binding_backfill/test_platform_migration_checkpoints_db.py
@@ -1,0 +1,249 @@
+"""Phase 2 PR-5 — utils.db.platform_migration_checkpoints primitives."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from utils.db import platform_migration_checkpoints as checkpoint_db
+
+
+@pytest.fixture
+def _mock_pool():
+    pool_mock = MagicMock()
+    pool_mock.execute = AsyncMock()
+    pool_mock.fetchrow = AsyncMock()
+    pool_mock.fetch = AsyncMock()
+    with patch.object(checkpoint_db, "pool") as pool_module:
+        pool_module.get = MagicMock(return_value=pool_mock)
+        yield pool_mock
+
+
+# ---------------------------------------------------------------------------
+# get_checkpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_checkpoint_per_guild_uses_equality(_mock_pool):
+    _mock_pool.fetchrow.return_value = None
+    await checkpoint_db.get_checkpoint("binding_backfill", guild_id=42)
+    sql, *args = _mock_pool.fetchrow.await_args.args
+    assert "guild_id = $2" in sql
+    assert args == ["binding_backfill", 42]
+
+
+@pytest.mark.asyncio
+async def test_get_checkpoint_global_uses_is_null(_mock_pool):
+    """Global lookup MUST use ``IS NULL`` — equality with NULL never matches."""
+    _mock_pool.fetchrow.return_value = None
+    await checkpoint_db.get_checkpoint("binding_backfill")
+    sql, *args = _mock_pool.fetchrow.await_args.args
+    assert "guild_id IS NULL" in sql
+    assert args == ["binding_backfill"]
+
+
+@pytest.mark.asyncio
+async def test_get_checkpoint_decodes_summary_json(_mock_pool):
+    _mock_pool.fetchrow.return_value = {
+        "id": 1,
+        "name": "binding_backfill",
+        "guild_id": 42,
+        "status": "dry_run_complete",
+        "version": 1,
+        "started_at": None,
+        "completed_at": None,
+        "summary_json": json.dumps({"counts": {"match": 3}}),
+    }
+    row = await checkpoint_db.get_checkpoint("binding_backfill", guild_id=42)
+    assert row is not None
+    assert row["summary_json"] == {"counts": {"match": 3}}
+
+
+@pytest.mark.asyncio
+async def test_get_checkpoint_passes_through_dict_summary(_mock_pool):
+    """If asyncpg returns a dict (codec installed), pass-through unchanged."""
+    _mock_pool.fetchrow.return_value = {
+        "id": 1,
+        "name": "binding_backfill",
+        "guild_id": 42,
+        "status": "dry_run_complete",
+        "version": 1,
+        "started_at": None,
+        "completed_at": None,
+        "summary_json": {"counts": {"match": 3}},
+    }
+    row = await checkpoint_db.get_checkpoint("binding_backfill", guild_id=42)
+    assert row is not None
+    assert row["summary_json"] == {"counts": {"match": 3}}
+
+
+@pytest.mark.asyncio
+async def test_get_checkpoint_returns_none_when_absent(_mock_pool):
+    _mock_pool.fetchrow.return_value = None
+    assert await checkpoint_db.get_checkpoint("does_not_exist", guild_id=42) is None
+
+
+# ---------------------------------------------------------------------------
+# upsert_checkpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_global_uses_partial_index_clause(_mock_pool):
+    await checkpoint_db.upsert_checkpoint(
+        name="binding_backfill",
+        guild_id=None,
+        status="pending",
+        summary_json={"foo": 1},
+    )
+    sql, *args = _mock_pool.execute.await_args.args
+    assert "ON CONFLICT (name) WHERE guild_id IS NULL" in sql
+    assert args[0] == "binding_backfill"
+    # version default 1
+    assert args[2] == 1
+    # summary_json JSON-encoded
+    assert json.loads(args[3]) == {"foo": 1}
+
+
+@pytest.mark.asyncio
+async def test_upsert_guild_uses_partial_index_clause(_mock_pool):
+    await checkpoint_db.upsert_checkpoint(
+        name="binding_backfill",
+        guild_id=42,
+        status="dry_run_complete",
+        version=2,
+        summary_json={"counts": {"match": 1}},
+        mark_completed=True,
+    )
+    sql, *args = _mock_pool.execute.await_args.args
+    assert "ON CONFLICT (name, guild_id) WHERE guild_id IS NOT NULL" in sql
+    assert "completed_at = NOW()" in sql
+    assert args[0] == "binding_backfill"
+    assert args[1] == 42
+    assert args[2] == "dry_run_complete"
+    assert args[3] == 2
+    assert json.loads(args[4]) == {"counts": {"match": 1}}
+
+
+@pytest.mark.asyncio
+async def test_upsert_without_mark_completed_preserves_completed_at(_mock_pool):
+    await checkpoint_db.upsert_checkpoint(
+        name="binding_backfill",
+        guild_id=42,
+        status="in_progress",
+    )
+    sql, *_ = _mock_pool.execute.await_args.args
+    # NOT setting completed_at = NOW(); preserve previous value
+    assert "completed_at = completed_at" in sql
+
+
+@pytest.mark.asyncio
+async def test_upsert_rejects_unknown_status(_mock_pool):
+    with pytest.raises(ValueError, match="unknown status"):
+        await checkpoint_db.upsert_checkpoint(
+            name="binding_backfill",
+            guild_id=42,
+            status="weird_status",
+        )
+    _mock_pool.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_upsert_string_summary_passed_through(_mock_pool):
+    """If caller already serialised the summary, do not double-encode."""
+    payload = '{"already": "serialised"}'
+    await checkpoint_db.upsert_checkpoint(
+        name="binding_backfill",
+        guild_id=42,
+        status="pending",
+        summary_json=payload,
+    )
+    _, *args = _mock_pool.execute.await_args.args
+    assert args[4] == payload
+
+
+@pytest.mark.asyncio
+async def test_upsert_none_summary_becomes_sql_null(_mock_pool):
+    await checkpoint_db.upsert_checkpoint(
+        name="binding_backfill",
+        guild_id=42,
+        status="pending",
+        summary_json=None,
+    )
+    _, *args = _mock_pool.execute.await_args.args
+    assert args[4] is None
+
+
+# ---------------------------------------------------------------------------
+# list_checkpoints
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_checkpoints_no_filter(_mock_pool):
+    _mock_pool.fetch.return_value = []
+    await checkpoint_db.list_checkpoints()
+    sql, *args = _mock_pool.fetch.await_args.args
+    assert "WHERE" not in sql
+    assert args == []
+
+
+@pytest.mark.asyncio
+async def test_list_checkpoints_filtered_by_name_prefix(_mock_pool):
+    _mock_pool.fetch.return_value = []
+    await checkpoint_db.list_checkpoints(name_prefix="binding_")
+    sql, *args = _mock_pool.fetch.await_args.args
+    assert "name LIKE" in sql
+    assert args == ["binding_%"]
+
+
+@pytest.mark.asyncio
+async def test_list_checkpoints_filtered_by_guild(_mock_pool):
+    _mock_pool.fetch.return_value = []
+    await checkpoint_db.list_checkpoints(guild_id=42)
+    sql, *args = _mock_pool.fetch.await_args.args
+    assert "guild_id = $1" in sql
+    assert args == [42]
+
+
+# ---------------------------------------------------------------------------
+# count_by_status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_count_by_status_returns_histogram(_mock_pool):
+    _mock_pool.fetch.return_value = [
+        {"status": "pending", "n": 2},
+        {"status": "complete", "n": 5},
+    ]
+    assert await checkpoint_db.count_by_status() == {
+        "pending": 2,
+        "complete": 5,
+    }
+
+
+# ---------------------------------------------------------------------------
+# delete_for_guild
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_for_guild_only_touches_guild_rows(_mock_pool):
+    """Phase 2 retention: global rows (guild_id IS NULL) MUST survive."""
+    _mock_pool.execute.return_value = "DELETE 4"
+    deleted = await checkpoint_db.delete_for_guild(42)
+    sql, *args = _mock_pool.execute.await_args.args
+    assert "WHERE guild_id = $1" in sql
+    assert "IS NULL" not in sql
+    assert args == [42]
+    assert deleted == 4
+
+
+@pytest.mark.asyncio
+async def test_delete_for_guild_handles_unexpected_status(_mock_pool):
+    _mock_pool.execute.return_value = "junk"
+    assert await checkpoint_db.delete_for_guild(42) == 0

--- a/tests/unit/invariants/test_migration_checkpoint_alignment.py
+++ b/tests/unit/invariants/test_migration_checkpoint_alignment.py
@@ -1,0 +1,53 @@
+"""Phase 2 PR-5 invariant — migration_checkpoint status literals align.
+
+Migration 026 ships a CHECK constraint on
+``platform_migration_checkpoints.status``.  The Python module
+:mod:`utils.db.platform_migration_checkpoints` carries the matching
+:data:`KNOWN_STATUSES` set; an extension on one side without the
+other would either let an INSERT fail at runtime (Python writes a
+value the DB rejects) or let an operator INSERT a value Python never
+recognises.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_MIGRATION = (
+    Path(__file__).resolve().parents[3]
+    / "disbot"
+    / "migrations"
+    / "026_platform_migration_checkpoints.sql"
+)
+
+
+def _extract_status_literals() -> set[str]:
+    sql = _MIGRATION.read_text()
+    match = re.search(
+        r"CHECK\s*\(\s*status\s+IN\s*\(([^)]+)\)\s*\)",
+        sql,
+        re.DOTALL,
+    )
+    assert match, "could not locate status CHECK constraint in migration 026"
+    return {
+        token.strip().strip("'\"")
+        for token in match.group(1).split(",")
+        if token.strip()
+    }
+
+
+def test_status_literals_match_python_known_statuses():
+    """``status`` CHECK matches ``KNOWN_STATUSES`` exactly."""
+    from utils.db.platform_migration_checkpoints import KNOWN_STATUSES
+
+    db_check = _extract_status_literals()
+    python = set(KNOWN_STATUSES)
+    assert db_check == python, (
+        "platform_migration_checkpoints status drift.\n"
+        f"  in Python but not DB CHECK: {sorted(python - db_check)}\n"
+        f"  in DB CHECK but not Python: {sorted(db_check - python)}\n"
+        "Fix: extend the CHECK constraint via a new migration AND "
+        "update KNOWN_STATUSES in "
+        "utils/db/platform_migration_checkpoints.py.",
+    )

--- a/tests/unit/runtime/test_guild_lifecycle_teardown.py
+++ b/tests/unit/runtime/test_guild_lifecycle_teardown.py
@@ -22,6 +22,13 @@ PR-2 added three more (Phase 2d feature-flag substrate):
 * **Step 9** — :func:`core.runtime.feature_flags.clear_cache` purges
   cached evaluator decisions for the guild.
 
+PR-5 adds:
+
+* **Step 10** —
+  :func:`utils.db.platform_migration_checkpoints.delete_for_guild`
+  drops per-guild migration checkpoint rows; global rows are
+  preserved.
+
 These tests pin the contract:
 
 * Every new primitive is awaited (or called, for the sync one) during
@@ -100,6 +107,12 @@ def _teardown_patches():
         ),
         patch(
             "core.runtime.feature_flags.clear_cache",
+            return_value=0,
+        ),
+        # PR-5 default: migration checkpoint delete primitive.
+        patch(
+            "utils.db.platform_migration_checkpoints.delete_for_guild",
+            new_callable=AsyncMock,
             return_value=0,
         ),
     ):
@@ -325,3 +338,42 @@ async def test_teardown_clears_feature_flag_cache(_teardown_patches):
     ) as mock_clear:
         await guild_lifecycle.teardown(99)
         mock_clear.assert_called_once_with(guild_id=99)
+
+
+# ---------------------------------------------------------------------------
+# Step 10 — platform migration checkpoints (per-guild rows only)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_teardown_deletes_migration_checkpoints(_teardown_patches):
+    """Per-guild checkpoint delete primitive is awaited from teardown."""
+    import guild_lifecycle
+
+    with patch(
+        "utils.db.platform_migration_checkpoints.delete_for_guild",
+        new_callable=AsyncMock,
+        return_value=1,
+    ) as mock_delete:
+        await guild_lifecycle.teardown(99)
+        mock_delete.assert_awaited_once_with(99)
+
+
+@pytest.mark.asyncio
+async def test_teardown_migration_checkpoint_failure_is_isolated(_teardown_patches):
+    """If the checkpoint delete raises, downstream steps still run."""
+    import guild_lifecycle
+
+    with (
+        patch(
+            "utils.db.platform_migration_checkpoints.delete_for_guild",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("DB blip"),
+        ),
+        patch(
+            "governance.execution.forget_guild_capabilities",
+        ) as mock_caps,
+    ):
+        await guild_lifecycle.teardown(99)
+        # downstream step still invoked despite checkpoint delete failure
+        mock_caps.assert_called_once_with(99)


### PR DESCRIPTION
## Summary

PR-5 of the Phase 2 plan. Stand up the **dry-run + classification** infrastructure that PR-6's write phase will consume. **Read-only against `subsystem_bindings`** — operators review dry-run results in `platform_migration_checkpoints` before authorising any real writes.

Targets `main` directly (no stacking).

## Why this PR is scoped safely

- No writes to `subsystem_bindings`.
- No cog read-path changes.
- No `bindings.primary` flip.
- No new Discord-facing mutation commands.
- `platform_migration_checkpoints` is generic so future logical migrations (PR-9 participation backfill, etc.) reuse it without a new schema.

## What changed

| Path | Change |
|---|---|
| `disbot/migrations/026_platform_migration_checkpoints.sql` | NEW — generic checkpoint table with `BIGSERIAL` PK + two **partial unique indexes** (`(name) WHERE guild_id IS NULL`, `(name, guild_id) WHERE guild_id IS NOT NULL`). Works around PostgreSQL's no-NULL-in-PK rule without losing the `(name, guild_id)` uniqueness guarantee. CHECK on status; alignment test pins literals. |
| `disbot/utils/db/platform_migration_checkpoints.py` | NEW — `get_checkpoint`, `list_checkpoints`, `count_by_status`, `upsert_checkpoint` (idempotent via partial-index `ON CONFLICT`), `delete_for_guild` (per-guild rows only; preserves global) |
| `disbot/services/binding_backfill.py` | NEW — `MIGRATED_KEYS` registry (3 keys), `Classification` enum (10 values covering the full matrix), `WRITABLE_CLASSIFICATIONS = {CANDIDATE_VALID}` (what PR-6 consumes), pure-sync `classify_candidate()` + async `dry_run(guild)` |
| `disbot/guild_lifecycle.py` | New step 10: `_teardown_platform_migration_checkpoints` deletes per-guild rows; global rows preserved |
| `disbot/cogs/diagnostic_cog.py` | New `!platform migrations` subcommand — global counts by status + per-guild checkpoint rows with summary counts inline |
| `tests/unit/binding_backfill/` | NEW package: 35 tests (DB primitives, classification matrix, dry-run end-to-end) |
| `tests/unit/invariants/test_migration_checkpoint_alignment.py` | NEW — pins `KNOWN_STATUSES` to migration 026's CHECK literals |
| `tests/unit/runtime/test_guild_lifecycle_teardown.py` | Extended with 2 tests for step 10 |

## Classification taxonomy

Every `(guild, migrated_key)` pair lands in exactly one bucket:

| Classification | Meaning |
|---|---|
| `both_absent` | nothing to do |
| `candidate_valid` | legacy has value, no binding, target validates → **PR-6 write candidate** |
| `candidate_invalid_target_missing` | legacy points at deleted channel/role |
| `candidate_invalid_unparseable` | legacy value is not a snowflake |
| `candidate_invalid_wrong_kind` | legacy ID exists but is wrong kind |
| `binding_only` | binding row exists, legacy missing |
| `match` | both sides agree |
| `disagree` | both sides present but different — operator must reconcile |
| `binding_status_not_bound` | binding row present with status MISSING/INVALID/UNRESOLVED |
| `blocked_no_schema` | subsystem has no `SubsystemSchema` declaring this binding |

`WRITABLE_CLASSIFICATIONS = {CANDIDATE_VALID}` — the **only** classification PR-6 acts on.

## Architectural boundaries preserved

- One runtime domain per PR (binding backfill planner).
- One migration domain per PR (migration 026 only).
- No top-level `core.runtime` imports added to cycle-sensitive files; `binding_backfill` imports `core.runtime.bindings` inside `dry_run()` and `utils.db.*` inside their respective branches.
- Events advisory throughout (no new events added in this PR).
- Standard library only — no new hashing or JSON libraries.
- `ResourceStatus.BOUND` remains structural-only; classifier uses it exactly that way.

## Migrations

**026** — additive, forward-only, idempotent.

## Rollback strategy

- Revert this PR. Migration 026 is additive (table becomes unused on revert). No subsystem behavior changes; the new diagnostics subcommand and the dry-run module are unused outside of operator REPL.
- If the dry-run produced bad checkpoints, the operator can `DELETE FROM platform_migration_checkpoints WHERE name = 'binding_backfill'` to wipe and re-run.

## Tests run

```
python -m pytest tests/unit/binding_backfill/ \
                 tests/unit/invariants/test_migration_checkpoint_alignment.py \
                 tests/unit/runtime/test_guild_lifecycle_teardown.py \
                 tests/unit/runtime/test_import_cycle_regression.py -q
# 57 passed

python -m pytest tests/ -q --ignore=tests/integration
# 1304 passed (1257 baseline + 47 new), 12 unrelated warnings

python -m ruff check disbot/
# clean

python -m black --check (changed files)
# clean

python -m isort --check-only (changed files)
# clean
```

## Manual Discord smoke

- [ ] Apply migration 026 to test DB
- [ ] `!platform migrations` on test guild shows "(no checkpoints)" before any dry-run
- [ ] From Python REPL on bot host:
  ```python
  from services.binding_backfill import dry_run
  summary = await dry_run(<test_guild>)
  print(summary.counts)
  ```
- [ ] Re-run `!platform migrations`; verify one `binding_backfill` row appears with `status=dry_run_complete` and the counts visible inline
- [ ] Kick bot from test guild; verify per-guild checkpoint row is gone and re-running dry-run starts fresh

## Intentionally deferred

- **Real binding writes** — PR-6 adds the `BindingBackfillPipeline` that consumes `WRITABLE_CLASSIFICATIONS` candidates.
- **governance.trusted_role BindingSpec** — governance has no `SubsystemSchema` yet, so `dry_run` classifies it as `BLOCKED_NO_SCHEMA`. PR-6 (or a precursor) declares the schema before any backfill can proceed.
- **`bindings.primary` flip** — arrives in PR-7.
- **Reconciliation-after-write surface** — PR-6 will re-run the classifier post-write and assert zero `DISAGREE` rows.

## Test plan

- [x] DB primitives: get/upsert/list/count/delete behavior + partial-index `ON CONFLICT` clauses
- [x] JSON encode/decode round-trip for `summary_json`
- [x] Classification matrix: every value exercised
- [x] Schema gate: blocks even when both sides have valid data
- [x] Empty-string legacy treated as absent
- [x] Both-present `MATCH` / `DISAGREE` / `BINDING_STATUS_NOT_BOUND` resolution
- [x] Dry-run iterates all 3 migrated keys
- [x] Dry-run records exactly one checkpoint row per guild
- [x] Dry-run NEVER writes to `subsystem_bindings` (mutation primitives patched and asserted not-awaited)
- [x] Dry-run idempotent under re-run
- [x] Teardown deletes per-guild checkpoints; global rows preserved
- [x] Lifecycle step failure isolated

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgFk12CkWs1uiPZk8AA5fR)_