### PR TITLE
Phase 2.6: binding backfill write phase (idempotent apply, advisory lock)

### DIFF
--- a/disbot/services/binding_backfill.py
+++ b/disbot/services/binding_backfill.py
@@ -55,6 +55,7 @@ without touching DB or Discord.
 from __future__ import annotations
 
 import logging
+import uuid
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from enum import Enum
@@ -526,15 +527,396 @@ async def dry_run(guild: discord.Guild) -> DryRunSummary:
     return summary
 
 
+# ---------------------------------------------------------------------------
+# Apply phase — PR-6.  Writes CANDIDATE_VALID candidates from a fresh
+# dry-run through ``utils.db.bindings.upsert_with_audit`` with
+# ``actor_type='backfill'``.  Legacy reads remain authoritative.
+# ---------------------------------------------------------------------------
+
+
+class BindingBackfillError(Exception):
+    """Base class for binding-backfill write-phase failures."""
+
+
+class BackfillLockHeldError(BindingBackfillError):
+    """Raised when another session holds the advisory lock for this guild."""
+
+
+# Result statuses recorded per candidate during the write phase.
+WRITE_STATUS_WRITTEN = "written"
+WRITE_STATUS_SKIPPED_IDEMPOTENT = "skipped_idempotent"
+WRITE_STATUS_SKIPPED_NOT_CANDIDATE = "skipped_not_candidate"
+WRITE_STATUS_FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class WriteResult:
+    """One candidate's write outcome.
+
+    ``mutation_id`` is non-empty for ``written`` rows (the UUID that
+    was passed to ``upsert_with_audit``).  For skipped/failed rows it
+    is empty so the operator can immediately tell which audit rows
+    are theirs.
+    """
+
+    legacy_key: str
+    subsystem: str
+    binding_name: str
+    target_id: int | None
+    write_status: str
+    classification: str
+    mutation_id: str
+    error: str | None
+
+    def to_summary_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ApplyResult:
+    """Aggregate write-phase outcome for one guild."""
+
+    guild_id: int
+    started_at: datetime
+    completed_at: datetime
+    actor_id: int
+    summary_version: int
+    pre_counts: dict[str, int]
+    post_counts: dict[str, int]
+    writes: tuple[WriteResult, ...]
+    write_status_counts: dict[str, int]
+    error: str | None  # populated for status='failed' runs
+
+    @property
+    def is_failure(self) -> bool:
+        return self.error is not None or self.write_status_counts.get(
+            WRITE_STATUS_FAILED,
+            0,
+        )
+
+    def to_summary_dict(self) -> dict[str, Any]:
+        return {
+            "summary_version": self.summary_version,
+            "started_at": self.started_at.isoformat(),
+            "completed_at": self.completed_at.isoformat(),
+            "actor_id": self.actor_id,
+            "pre_counts": dict(self.pre_counts),
+            "post_counts": dict(self.post_counts),
+            "writes": [w.to_summary_dict() for w in self.writes],
+            "write_status_counts": dict(self.write_status_counts),
+            "error": self.error,
+        }
+
+
+def _advisory_lock_key(guild_id: int) -> int:
+    """Stable signed-int64 advisory-lock key for ``(MIGRATION_NAME, guild_id)``.
+
+    PostgreSQL's ``pg_try_advisory_lock(int8)`` takes one signed 64-bit
+    integer.  We derive a stable key from a sha256 of
+    ``"binding_backfill:<guild_id>"`` so concurrent runs across the
+    same (migration, guild) collide deterministically, while different
+    guilds never collide with each other.
+    """
+    import hashlib
+
+    digest = hashlib.sha256(
+        f"{MIGRATION_NAME}:{guild_id}".encode(),
+    ).digest()
+    return int.from_bytes(digest[:8], "big", signed=True)
+
+
+async def apply_backfill(
+    guild: discord.Guild,
+    *,
+    actor_id: int,
+    advisory_lock: bool = True,
+) -> ApplyResult:
+    """Write every ``CANDIDATE_VALID`` candidate for ``guild``.
+
+    Steps:
+
+    1. If ``advisory_lock`` is True, acquire a session-scoped
+       ``pg_try_advisory_lock`` keyed on ``(MIGRATION_NAME, guild_id)``.
+       Refuse to run if another session holds the lock.
+    2. Mark the per-guild checkpoint as ``in_progress``.
+    3. Run :func:`dry_run` (fresh classification — the operator's
+       previous dry-run may be stale).
+    4. For each ``CANDIDATE_VALID`` candidate:
+         - **Pre-check**: read the current binding row.  If the row
+           already matches the intended ``target_id`` AND is BOUND,
+           record ``skipped_idempotent`` and continue.  This makes
+           re-running ``apply_backfill`` truly idempotent — no extra
+           audit rows on a no-op re-run.
+         - Otherwise call ``utils.db.bindings.upsert_with_audit`` with
+           ``actor_type='backfill'`` and ``action='backfill'`` (the
+           DB primitive picks the action from actor_type).
+         - Record ``written`` with the new mutation_id.
+       Other classifications are recorded as
+       ``skipped_not_candidate``.
+    5. Re-run :func:`dry_run` to compute ``post_counts``.
+    6. Upsert the checkpoint with status ``complete`` (or ``failed``
+       if any write raised).  ``failed`` rows record their exception
+       in the per-write ``error`` field; the operator can re-run
+       after investigating.
+    7. Release the advisory lock.
+
+    Args:
+        guild: target guild.
+        actor_id: snowflake of the operator authorising the backfill.
+            REQUIRED — the schema enforces ``actor_id NOT NULL`` on
+            ``binding_audit_log``, so the operator's identity is
+            recorded against every audit row.
+        advisory_lock: set False only for tests that drive
+            ``pool.get()`` themselves.  Production callers leave the
+            default ``True``.
+
+    Raises:
+        BackfillLockHeldError: another session is mid-backfill for
+            this guild.  Wait and retry, or investigate the stalled
+            session.
+    """
+    # Local imports keep this module out of any module-load cycles.
+    from utils.db import bindings as bindings_db
+    from utils.db import platform_migration_checkpoints as checkpoint_db
+    from utils.db import pool
+
+    started_at = _now_utc()
+    error_message: str | None = None
+    writes: list[WriteResult] = []
+    lock_acquired = False
+    lock_conn = None
+
+    try:
+        # 1) Advisory lock.
+        if advisory_lock:
+            lock_key = _advisory_lock_key(guild.id)
+            lock_conn = await pool.get().acquire()
+            acquired = await lock_conn.fetchval(
+                "SELECT pg_try_advisory_lock($1)",
+                lock_key,
+            )
+            if not acquired:
+                await pool.get().release(lock_conn)
+                msg = (
+                    f"another session holds the binding_backfill advisory "
+                    f"lock for guild_id={guild.id}; wait and retry"
+                )
+                raise BackfillLockHeldError(msg)
+            lock_acquired = True
+
+        # 2) Mark in_progress so observers can see a backfill is live.
+        await checkpoint_db.upsert_checkpoint(
+            name=MIGRATION_NAME,
+            guild_id=guild.id,
+            status="in_progress",
+            version=SUMMARY_VERSION,
+            summary_json={"phase": "in_progress", "actor_id": actor_id},
+        )
+
+        # 3) Fresh dry-run.
+        pre = await dry_run(guild)
+        pre_counts = dict(pre.counts)
+
+        # 4) Write each CANDIDATE_VALID candidate.
+        for candidate in pre.candidates:
+            if candidate.classification != Classification.CANDIDATE_VALID.value:
+                writes.append(
+                    WriteResult(
+                        legacy_key=candidate.legacy_key,
+                        subsystem=candidate.subsystem,
+                        binding_name=candidate.binding_name,
+                        target_id=candidate.legacy_target_id,
+                        write_status=WRITE_STATUS_SKIPPED_NOT_CANDIDATE,
+                        classification=candidate.classification,
+                        mutation_id="",
+                        error=None,
+                    ),
+                )
+                continue
+
+            target_id = candidate.legacy_target_id
+            if target_id is None:
+                # Belt-and-braces: CANDIDATE_VALID implies a parseable
+                # legacy id, but defend against a future classifier
+                # change.
+                writes.append(
+                    WriteResult(
+                        legacy_key=candidate.legacy_key,
+                        subsystem=candidate.subsystem,
+                        binding_name=candidate.binding_name,
+                        target_id=None,
+                        write_status=WRITE_STATUS_FAILED,
+                        classification=candidate.classification,
+                        mutation_id="",
+                        error="legacy_target_id missing on CANDIDATE_VALID",
+                    ),
+                )
+                continue
+
+            # Pre-check idempotency.
+            current = await bindings_db.get_one(
+                guild.id,
+                candidate.subsystem,
+                candidate.binding_name,
+            )
+            if (
+                current is not None
+                and current.get("target_id") == target_id
+                and current.get("status") == ResourceStatus.BOUND.value
+            ):
+                writes.append(
+                    WriteResult(
+                        legacy_key=candidate.legacy_key,
+                        subsystem=candidate.subsystem,
+                        binding_name=candidate.binding_name,
+                        target_id=target_id,
+                        write_status=WRITE_STATUS_SKIPPED_IDEMPOTENT,
+                        classification=candidate.classification,
+                        mutation_id="",
+                        error=None,
+                    ),
+                )
+                continue
+
+            mutation_id = str(uuid.uuid4())
+            try:
+                await bindings_db.upsert_with_audit(
+                    guild_id=guild.id,
+                    subsystem=candidate.subsystem,
+                    binding_name=candidate.binding_name,
+                    kind=candidate.kind,
+                    target_id=target_id,
+                    status=ResourceStatus.BOUND.value,
+                    actor_id=actor_id,
+                    actor_type="backfill",
+                    mutation_id=mutation_id,
+                    old_target_id=(current.get("target_id") if current else None),
+                    old_status=(current.get("status") if current else None),
+                )
+            except Exception as exc:  # noqa: BLE001 — record per-candidate
+                logger.exception(
+                    "binding_backfill.apply_backfill: write failed "
+                    "for guild=%d subsystem=%r binding=%r",
+                    guild.id,
+                    candidate.subsystem,
+                    candidate.binding_name,
+                )
+                writes.append(
+                    WriteResult(
+                        legacy_key=candidate.legacy_key,
+                        subsystem=candidate.subsystem,
+                        binding_name=candidate.binding_name,
+                        target_id=target_id,
+                        write_status=WRITE_STATUS_FAILED,
+                        classification=candidate.classification,
+                        mutation_id="",
+                        error=f"{type(exc).__name__}: {exc}",
+                    ),
+                )
+                continue
+            writes.append(
+                WriteResult(
+                    legacy_key=candidate.legacy_key,
+                    subsystem=candidate.subsystem,
+                    binding_name=candidate.binding_name,
+                    target_id=target_id,
+                    write_status=WRITE_STATUS_WRITTEN,
+                    classification=candidate.classification,
+                    mutation_id=mutation_id,
+                    error=None,
+                ),
+            )
+
+        # 5) Re-classify post-write.
+        post = await dry_run(guild)
+        post_counts = dict(post.counts)
+
+    except BindingBackfillError:
+        raise
+    except Exception as exc:  # noqa: BLE001 — top-level safety net
+        logger.exception(
+            "binding_backfill.apply_backfill: unexpected failure for guild=%d",
+            guild.id,
+        )
+        error_message = f"{type(exc).__name__}: {exc}"
+        pre_counts = {}
+        post_counts = {}
+
+    completed_at = _now_utc()
+    write_status_counts: dict[str, int] = {}
+    for w in writes:
+        write_status_counts[w.write_status] = (
+            write_status_counts.get(w.write_status, 0) + 1
+        )
+
+    result = ApplyResult(
+        guild_id=guild.id,
+        started_at=started_at,
+        completed_at=completed_at,
+        actor_id=actor_id,
+        summary_version=SUMMARY_VERSION,
+        pre_counts=pre_counts,
+        post_counts=post_counts,
+        writes=tuple(writes),
+        write_status_counts=write_status_counts,
+        error=error_message,
+    )
+
+    # 6) Terminal checkpoint upsert.  Failed if any write raised OR
+    #    the top-level safety-net fired.
+    terminal_status = (
+        "failed"
+        if error_message or write_status_counts.get(WRITE_STATUS_FAILED, 0) > 0
+        else "complete"
+    )
+    try:
+        await checkpoint_db.upsert_checkpoint(
+            name=MIGRATION_NAME,
+            guild_id=guild.id,
+            status=terminal_status,
+            version=SUMMARY_VERSION,
+            summary_json=result.to_summary_dict(),
+            mark_completed=True,
+        )
+    except Exception:
+        logger.exception(
+            "binding_backfill.apply_backfill: terminal checkpoint "
+            "upsert failed for guild=%d (write phase already %s)",
+            guild.id,
+            terminal_status,
+        )
+
+    # 7) Release advisory lock.
+    if lock_acquired and lock_conn is not None:
+        try:
+            await lock_conn.execute(
+                "SELECT pg_advisory_unlock($1)",
+                _advisory_lock_key(guild.id),
+            )
+        finally:
+            await pool.get().release(lock_conn)
+
+    return result
+
+
 __all__ = [
     "MIGRATED_KEYS",
     "MIGRATION_NAME",
     "SUMMARY_VERSION",
     "WRITABLE_CLASSIFICATIONS",
+    "WRITE_STATUS_FAILED",
+    "WRITE_STATUS_SKIPPED_IDEMPOTENT",
+    "WRITE_STATUS_SKIPPED_NOT_CANDIDATE",
+    "WRITE_STATUS_WRITTEN",
+    "ApplyResult",
+    "BackfillLockHeldError",
+    "BindingBackfillError",
     "CandidateResult",
     "Classification",
     "DryRunSummary",
     "MigratedKey",
+    "WriteResult",
+    "apply_backfill",
     "classify_candidate",
     "dry_run",
 ]

--- a/tests/unit/binding_backfill/test_apply_backfill.py
+++ b/tests/unit/binding_backfill/test_apply_backfill.py
@@ -1,0 +1,418 @@
+"""Phase 2 PR-6 — services.binding_backfill.apply_backfill end-to-end.
+
+Verifies the write phase:
+
+* Calls dry_run() to get fresh classification.
+* Writes only CANDIDATE_VALID candidates through
+  utils.db.bindings.upsert_with_audit with actor_type='backfill'.
+* Pre-check: skips writes when the binding already matches
+  (idempotent re-run).
+* Records per-candidate WriteResult.
+* Re-classifies after write for the operator's review.
+* Updates the checkpoint to 'complete' or 'failed' depending on
+  whether any write raised.
+* Acquires + releases the advisory lock (when enabled).
+* Refuses to run if the advisory lock is held.
+* NEVER calls BindingMutationPipeline (the backfill bypasses
+  user-facing authority by using a dedicated 'backfill' actor_type
+  recorded in the audit log; the operator's actor_id is required).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from core.resources.status import ResourceStatus
+from core.runtime.bindings import BindingValue
+from core.runtime.subsystem_schema import BindingKind
+from services import binding_backfill
+from services.binding_backfill import (
+    WRITE_STATUS_FAILED,
+    WRITE_STATUS_SKIPPED_IDEMPOTENT,
+    WRITE_STATUS_SKIPPED_NOT_CANDIDATE,
+    WRITE_STATUS_WRITTEN,
+    BackfillLockHeldError,
+    apply_backfill,
+)
+
+
+def _bv(*, target_id, status, last_updated_at=None):
+    return BindingValue(
+        guild_id=42,
+        subsystem="xp",
+        binding_name="announce_channel",
+        kind=BindingKind.CHANNEL,
+        target_id=target_id,
+        status=status,
+        last_validated_at=last_updated_at,
+        last_updated_at=last_updated_at,
+        version=1 if last_updated_at is not None else 0,
+    )
+
+
+@pytest.fixture
+def _mock_guild():
+    guild = MagicMock()
+    guild.id = 42
+    return guild
+
+
+@pytest.fixture
+def _patches(_mock_guild):
+    """Patch every external touchpoint the write phase relies on.
+
+    Three layers:
+      * dry_run() — patched at the binding_backfill module level to
+        give the test full control over the classification.
+      * utils.db.bindings primitives — get_one (pre-check) and
+        upsert_with_audit (the actual write).
+      * utils.db.platform_migration_checkpoints.upsert_checkpoint —
+        called at in_progress + terminal phases.
+      * Advisory lock is disabled by default (advisory_lock=False in
+        tests); a separate fixture exercises it.
+    """
+    with (
+        patch.object(
+            binding_backfill,
+            "dry_run",
+            new_callable=AsyncMock,
+        ) as mock_dry_run,
+        patch(
+            "utils.db.bindings.get_one",
+            new_callable=AsyncMock,
+        ) as mock_get_one,
+        patch(
+            "utils.db.bindings.upsert_with_audit",
+            new_callable=AsyncMock,
+        ) as mock_upsert,
+        patch(
+            "utils.db.platform_migration_checkpoints.upsert_checkpoint",
+            new_callable=AsyncMock,
+        ) as mock_checkpoint,
+    ):
+        yield {
+            "dry_run": mock_dry_run,
+            "get_one": mock_get_one,
+            "upsert": mock_upsert,
+            "checkpoint": mock_checkpoint,
+            "guild": _mock_guild,
+        }
+
+
+def _summary_with(candidates):
+    """Build a DryRunSummary stand-in returned by the mocked dry_run."""
+    counts: dict[str, int] = {}
+    for c in candidates:
+        counts[c.classification] = counts.get(c.classification, 0) + 1
+    return binding_backfill.DryRunSummary(
+        guild_id=42,
+        started_at=datetime.now(),
+        completed_at=datetime.now(),
+        summary_version=binding_backfill.SUMMARY_VERSION,
+        candidates=tuple(candidates),
+        counts=counts,
+    )
+
+
+def _candidate(
+    *,
+    legacy_key="xp_announce_channel",
+    subsystem="xp",
+    binding_name="announce_channel",
+    kind="channel",
+    legacy_target_id=999,
+    binding_target_id=None,
+    binding_status=None,
+    classification=binding_backfill.Classification.CANDIDATE_VALID.value,
+):
+    return binding_backfill.CandidateResult(
+        legacy_key=legacy_key,
+        subsystem=subsystem,
+        binding_name=binding_name,
+        kind=kind,
+        legacy_target_id=legacy_target_id,
+        legacy_raw=str(legacy_target_id) if legacy_target_id else None,
+        binding_target_id=binding_target_id,
+        binding_status=binding_status,
+        classification=classification,
+        reason="test",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path: one CANDIDATE_VALID written, others skipped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_writes_only_candidate_valid(_patches):
+    p = _patches
+    # Three candidates: one valid, one already-bound, one blocked
+    candidates = [
+        _candidate(legacy_target_id=999),  # CANDIDATE_VALID
+        _candidate(
+            subsystem="economy",
+            binding_name="log_channel",
+            legacy_target_id=111,
+            classification=binding_backfill.Classification.MATCH.value,
+        ),
+        _candidate(
+            subsystem="governance",
+            binding_name="trusted_role",
+            kind="role",
+            legacy_target_id=222,
+            classification=binding_backfill.Classification.BLOCKED_NO_SCHEMA.value,
+        ),
+    ]
+    p["dry_run"].return_value = _summary_with(candidates)
+    p["get_one"].return_value = None  # no binding row yet
+
+    result = await apply_backfill(p["guild"], actor_id=7777, advisory_lock=False)
+
+    # Exactly one upsert call (the CANDIDATE_VALID candidate)
+    p["upsert"].assert_awaited_once()
+    upsert_call = p["upsert"].await_args
+    assert upsert_call.kwargs["subsystem"] == "xp"
+    assert upsert_call.kwargs["binding_name"] == "announce_channel"
+    assert upsert_call.kwargs["target_id"] == 999
+    assert upsert_call.kwargs["actor_type"] == "backfill"
+    assert upsert_call.kwargs["actor_id"] == 7777
+    # mutation_id is a valid UUID (36 chars)
+    assert len(upsert_call.kwargs["mutation_id"]) == 36
+    # WriteResult shape
+    assert len(result.writes) == 3
+    statuses = {w.write_status for w in result.writes}
+    assert statuses == {
+        WRITE_STATUS_WRITTEN,
+        WRITE_STATUS_SKIPPED_NOT_CANDIDATE,
+    }
+    assert result.write_status_counts[WRITE_STATUS_WRITTEN] == 1
+    assert result.write_status_counts[WRITE_STATUS_SKIPPED_NOT_CANDIDATE] == 2
+    assert result.actor_id == 7777
+    assert result.error is None
+
+
+# ---------------------------------------------------------------------------
+# Idempotency: re-running on an already-correct binding skips the write
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_idempotent_skips_already_matching_binding(_patches):
+    """A second apply_backfill run on an already-backfilled guild produces no writes."""
+    p = _patches
+    p["dry_run"].return_value = _summary_with(
+        [_candidate(legacy_target_id=999)],
+    )
+    # Existing row already matches what backfill wants to write
+    p["get_one"].return_value = {
+        "guild_id": 42,
+        "subsystem": "xp",
+        "binding_name": "announce_channel",
+        "kind": "channel",
+        "target_id": 999,
+        "status": ResourceStatus.BOUND.value,
+        "last_validated_at": None,
+        "last_updated_at": None,
+        "version": 1,
+    }
+
+    result = await apply_backfill(p["guild"], actor_id=7777, advisory_lock=False)
+
+    p["upsert"].assert_not_awaited()
+    assert result.write_status_counts[WRITE_STATUS_SKIPPED_IDEMPOTENT] == 1
+
+
+# ---------------------------------------------------------------------------
+# Re-binds when target changed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_rebinds_when_existing_row_has_different_target(_patches):
+    p = _patches
+    p["dry_run"].return_value = _summary_with(
+        [_candidate(legacy_target_id=999)],
+    )
+    # Existing row has the SAME slot but a DIFFERENT target_id
+    p["get_one"].return_value = {
+        "guild_id": 42,
+        "subsystem": "xp",
+        "binding_name": "announce_channel",
+        "kind": "channel",
+        "target_id": 111,
+        "status": ResourceStatus.BOUND.value,
+        "last_validated_at": None,
+        "last_updated_at": None,
+        "version": 1,
+    }
+
+    await apply_backfill(p["guild"], actor_id=7777, advisory_lock=False)
+
+    p["upsert"].assert_awaited_once()
+    call = p["upsert"].await_args
+    # Old target captured in the audit
+    assert call.kwargs["old_target_id"] == 111
+    assert call.kwargs["target_id"] == 999
+
+
+# ---------------------------------------------------------------------------
+# Apply records pre/post counts via two dry_run calls
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_calls_dry_run_twice_for_pre_and_post(_patches):
+    p = _patches
+    p["dry_run"].side_effect = [
+        _summary_with([_candidate(legacy_target_id=999)]),
+        _summary_with(
+            [
+                _candidate(
+                    legacy_target_id=999,
+                    binding_target_id=999,
+                    binding_status="bound",
+                    classification=binding_backfill.Classification.MATCH.value,
+                )
+            ],
+        ),
+    ]
+    p["get_one"].return_value = None
+
+    result = await apply_backfill(p["guild"], actor_id=7777, advisory_lock=False)
+
+    assert p["dry_run"].await_count == 2
+    assert result.pre_counts == {
+        binding_backfill.Classification.CANDIDATE_VALID.value: 1,
+    }
+    assert result.post_counts == {
+        binding_backfill.Classification.MATCH.value: 1,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint lifecycle: in_progress → terminal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_writes_in_progress_then_complete_checkpoints(_patches):
+    p = _patches
+    p["dry_run"].return_value = _summary_with(
+        [_candidate(legacy_target_id=999)],
+    )
+    p["get_one"].return_value = None
+
+    await apply_backfill(p["guild"], actor_id=7777, advisory_lock=False)
+
+    # Two checkpoint upsert calls: 'in_progress' and 'complete'
+    statuses = [call.kwargs["status"] for call in p["checkpoint"].await_args_list]
+    assert statuses[0] == "in_progress"
+    assert statuses[-1] == "complete"
+    # Terminal checkpoint carries the full result summary
+    final_call = p["checkpoint"].await_args_list[-1]
+    assert final_call.kwargs["mark_completed"] is True
+    summary = final_call.kwargs["summary_json"]
+    assert summary["pre_counts"]
+    assert summary["post_counts"]
+    assert summary["actor_id"] == 7777
+
+
+# ---------------------------------------------------------------------------
+# Failure path: upsert raises → terminal status='failed' + per-write error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_marks_failed_when_upsert_raises(_patches):
+    p = _patches
+    p["dry_run"].return_value = _summary_with(
+        [_candidate(legacy_target_id=999)],
+    )
+    p["get_one"].return_value = None
+    p["upsert"].side_effect = RuntimeError("DB blip")
+
+    result = await apply_backfill(p["guild"], actor_id=7777, advisory_lock=False)
+
+    assert result.write_status_counts[WRITE_STATUS_FAILED] == 1
+    write = result.writes[0]
+    assert write.write_status == WRITE_STATUS_FAILED
+    assert "RuntimeError" in write.error
+    # Terminal checkpoint marked failed
+    final_call = p["checkpoint"].await_args_list[-1]
+    assert final_call.kwargs["status"] == "failed"
+
+
+# ---------------------------------------------------------------------------
+# Backfill does NOT call BindingMutationPipeline
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_does_not_use_binding_mutation_pipeline(_patches):
+    """Backfill bypasses the user-facing pipeline.
+
+    Discord-actor authority does not apply: backfill uses a dedicated
+    'backfill' actor_type recorded in the audit, with the operator's
+    actor_id.  This test pins the contract by asserting the user-facing
+    pipeline's primitive is never invoked.
+    """
+    p = _patches
+    p["dry_run"].return_value = _summary_with(
+        [_candidate(legacy_target_id=999)],
+    )
+    p["get_one"].return_value = None
+
+    with patch(
+        "services.binding_mutation.BindingMutationPipeline",
+    ) as mock_pipeline_cls:
+        await apply_backfill(p["guild"], actor_id=7777, advisory_lock=False)
+    mock_pipeline_cls.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Advisory lock: refuses to run when held
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_raises_when_advisory_lock_held(_mock_guild):
+    """A concurrent backfill on the same guild must fail loudly."""
+    # Mock the pool: pg_try_advisory_lock returns False
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value=False)
+    conn.execute = AsyncMock()
+
+    pool_mock = MagicMock()
+    pool_mock.acquire = AsyncMock(return_value=conn)
+    pool_mock.release = AsyncMock()
+
+    with patch("utils.db.pool.get", return_value=pool_mock):
+        with pytest.raises(BackfillLockHeldError):
+            await apply_backfill(_mock_guild, actor_id=7777, advisory_lock=True)
+
+
+# ---------------------------------------------------------------------------
+# Advisory lock key is deterministic and per-guild
+# ---------------------------------------------------------------------------
+
+
+def test_advisory_lock_key_deterministic():
+    a1 = binding_backfill._advisory_lock_key(42)
+    a2 = binding_backfill._advisory_lock_key(42)
+    assert a1 == a2
+
+
+def test_advisory_lock_key_differs_per_guild():
+    a = binding_backfill._advisory_lock_key(42)
+    b = binding_backfill._advisory_lock_key(43)
+    assert a != b
+
+
+def test_advisory_lock_key_fits_signed_int64():
+    """pg_advisory_lock(int8) takes a signed 64-bit integer."""
+    key = binding_backfill._advisory_lock_key(2**62)
+    assert -(2**63) <= key < 2**63


### PR DESCRIPTION
## Summary

PR-6 of the Phase 2 plan. Stand up the **write phase** that consumes `CANDIDATE_VALID` candidates produced by PR-5's dry-run. Writes go through `utils.db.bindings.upsert_with_audit` with `actor_type='backfill'` (the action label is automatically set to `'backfill'` by the existing primitive). **Legacy reads remain authoritative** — no `bindings.primary` flip in this PR.

**Stacked on PR #81** — merge after PR-5 lands on `main`. When PR #81 merges, the base of this PR will track automatically.

## Why this PR is scoped safely

- Writes ONLY happen for classification == `CANDIDATE_VALID`.
- **Pre-check makes re-runs truly idempotent**: if the current binding row already matches the intended target AND is `BOUND`, the write is skipped (no extra audit row).
- **Advisory lock** (`pg_try_advisory_lock`) prevents concurrent runs on the same guild; the lock key is a stable sha256 of `(MIGRATION_NAME, guild_id)`.
- The backfill **bypasses `BindingMutationPipeline`** (which enforces user-facing Discord-member authority). Instead it uses a dedicated `'backfill'` actor_type that the existing `binding_audit_log` CHECK constraint already accepts. `actor_id` is REQUIRED (the schema forbids null) — the operator passes their own snowflake.
- Pre/post `dry_run` captures the count delta in the checkpoint summary so post-write reconciliation is recorded for the operator.
- Per-candidate failures (DB blip on a single write) are caught and recorded as `WRITE_STATUS_FAILED`; other candidates still proceed.
- Terminal checkpoint status: `complete` on a clean run, `failed` if any per-candidate write raised or the top-level safety net fired.

## What changed

| Path | Change |
|---|---|
| `disbot/services/binding_backfill.py` | Extended with apply phase: `BindingBackfillError` + `BackfillLockHeldError` exceptions; `WriteResult` + `ApplyResult` dataclasses; `WRITE_STATUS_{WRITTEN, SKIPPED_IDEMPOTENT, SKIPPED_NOT_CANDIDATE, FAILED}` constants; `_advisory_lock_key()` returning a deterministic signed int64; `apply_backfill(guild, *, actor_id, advisory_lock=True)` |
| `tests/unit/binding_backfill/test_apply_backfill.py` | NEW — 11 tests |

## Apply phase contract

1. Acquire `pg_try_advisory_lock` keyed on `(MIGRATION_NAME, guild_id)`. Refuse to run if held.
2. Mark checkpoint `in_progress`.
3. Fresh `dry_run` for pre_counts.
4. For each `CANDIDATE_VALID`:
   - Pre-check `bindings_db.get_one`. If already at the intended target + BOUND → `skipped_idempotent`.
   - Otherwise call `upsert_with_audit` with `actor_type='backfill'`, fresh UUID `mutation_id`, captured `old_target_id` / `old_status`.
   - On exception, record `failed` with the error string. Don't abort the run.
5. Fresh `dry_run` for post_counts.
6. Terminal checkpoint upsert: `complete` or `failed`.
7. Release advisory lock.

## Architectural boundaries preserved

- One runtime domain per PR (binding backfill write).
- No new migration.
- No `bindings.primary` flip.
- No cog read-path changes.
- No setup UI.
- `BindingMutationPipeline` is NOT invoked (test pins this).
- No top-level `core.runtime` imports added; all DB primitives are imported inside `apply_backfill()`.
- Import-cycle regression test still green.

## Migrations

None.

## Rollback strategy

- Revert this PR. The dry-run / checkpoint primitives from PR-5 remain in place.
- If a backfill run produced wrong rows:
  1. Identify the `mutation_id` from `binding_audit_log` (WHERE `actor_type='backfill'`).
  2. Use `BindingMutationPipeline.clear_binding` or `set_binding` to correct the row through the user-facing pipeline.
  3. Or `DELETE FROM subsystem_bindings WHERE ...` and re-run `apply_backfill` after fixing the legacy value.
- The advisory lock auto-releases on connection drop, so a crashed backfill does not permanently hold the lock.

## Tests run

```
python -m pytest tests/unit/binding_backfill/ \
                 tests/unit/runtime/test_import_cycle_regression.py -q
# 55 passed (44 PR-5 baseline + 11 new)

python -m pytest tests/ -q --ignore=tests/integration
# 1315 passed (1304 baseline + 11 new), 12 unrelated warnings

python -m ruff check disbot/   # clean
python -m black --check (changed files)  # clean
python -m isort --check-only (changed files)  # clean
```

## Manual Discord smoke

- [ ] After PR-5 + PR-6 are deployed and migration 026 is applied:
- [ ] Run `dry_run` via Python REPL.
- [ ] Inspect `platform_migration_checkpoints.summary_json` for CANDIDATE_VALID counts.
- [ ] Run `apply_backfill(guild, actor_id=<your_id>)`.
- [ ] Verify `subsystem_bindings` has new rows tagged `actor_type='backfill'` in `binding_audit_log`.
- [ ] `!platform migrations` shows `status=complete`.
- [ ] Re-run `apply_backfill` — verify `SKIPPED_IDEMPOTENT` count = number of previously written candidates (no new audit rows).
- [ ] `!platform bindings` shows the new rows.
- [ ] `bindings.primary` remains OFF; cog reads remain on legacy paths.

## Intentionally deferred

- **`bindings.primary` canary flip** — PR-7.
- **`governance.trusted_role` BindingSpec** — governance SubsystemSchema has not been declared yet, so its candidate is `BLOCKED_NO_SCHEMA` and skipped by `apply_backfill`. PR-7 (or a precursor) declares the schema.
- **Reconciliation drift surface in `!platform consistency`** — PR-10.
- Setup wizard, participation runtime, resource provisioning, production read flip — all out of scope.

## Test plan

- [x] Writes CANDIDATE_VALID only; other classifications skipped
- [x] Idempotent re-run produces 0 new audit rows
- [x] Re-bind path captures old_target_id correctly
- [x] Pre/post dry_run runs both invoked
- [x] Checkpoint lifecycle: in_progress → complete or failed
- [x] Per-write failure recorded; other writes still proceed
- [x] `BindingMutationPipeline` NEVER invoked
- [x] Advisory lock held → `BackfillLockHeldError`
- [x] Lock key deterministic, per-guild, fits signed int64
- [x] Actor ID required and captured in audit row

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgFk12CkWs1uiPZk8AA5fR)_