### PR TITLE
Phase 2.7: bindings.primary canary support via arbitration accessors

### DIFF
--- a/disbot/core/runtime/config_arbitration.py
+++ b/disbot/core/runtime/config_arbitration.py
@@ -326,6 +326,141 @@ async def _read_legacy(settings_db, guild_id: int, legacy_key: str) -> Any | Non
 
 
 # ---------------------------------------------------------------------------
+# Type-coercion helpers for per-subsystem accessors
+# ---------------------------------------------------------------------------
+#
+# ``read_config`` returns ``int|None`` from the binding path and
+# ``str|None`` from the legacy path.  The per-subsystem accessors
+# below normalize to a single shape (matching what existing callers
+# expect) so cog read-sites don't have to branch on
+# ``isinstance(result.value, int)``.
+
+
+def _coerce_to_int(result: ConfigReadResult) -> ConfigReadResult:
+    """Return a new ``ConfigReadResult`` with ``value`` normalized to ``int|None``.
+
+    A legacy string that doesn't parse as an int is converted to
+    ``None`` and recorded in ``diagnostics`` — the caller treats it
+    as "missing" rather than crashing on the type mismatch.
+    """
+    value = result.value
+    if value is None:
+        return result
+    if isinstance(value, int):
+        return result
+    if isinstance(value, str):
+        try:
+            return ConfigReadResult(
+                value=int(value),
+                source=result.source,
+                binding_status=result.binding_status,
+                flag_state=result.flag_state,
+                diagnostics=result.diagnostics,
+            )
+        except ValueError:
+            return ConfigReadResult(
+                value=None,
+                source="missing",
+                binding_status=result.binding_status,
+                flag_state=result.flag_state,
+                diagnostics=[
+                    *result.diagnostics,
+                    f"legacy value {value!r} could not be parsed as int",
+                ],
+            )
+    # Unknown type — coerce to None.
+    return ConfigReadResult(
+        value=None,
+        source="missing",
+        binding_status=result.binding_status,
+        flag_state=result.flag_state,
+        diagnostics=[
+            *result.diagnostics,
+            f"unexpected value type {type(value).__name__}",
+        ],
+    )
+
+
+def _coerce_to_str(result: ConfigReadResult) -> ConfigReadResult:
+    """Return a new ``ConfigReadResult`` with ``value`` normalized to ``str|None``.
+
+    A legacy empty string is already filtered to ``None`` by
+    :func:`_read_legacy`, so this helper only needs to stringify
+    ints from the binding path.
+    """
+    value = result.value
+    if value is None or isinstance(value, str):
+        return result
+    return ConfigReadResult(
+        value=str(value),
+        source=result.source,
+        binding_status=result.binding_status,
+        flag_state=result.flag_state,
+        diagnostics=result.diagnostics,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-subsystem convenience accessors (PR-7).
+#
+# These are the ONLY legitimate read sites for migrated keys in cog/
+# service/governance code.  Direct calls to
+# ``is_enabled("bindings.primary", ...)`` outside this module are
+# forbidden by ``tests/unit/invariants/test_no_direct_bindings_primary_branch.py``.
+
+
+async def get_xp_announce_channel(guild_id: int) -> ConfigReadResult:
+    """Resolve the XP announce channel via the arbitration ladder.
+
+    Return shape: ``ConfigReadResult.value`` is ``str|None`` (matches
+    the existing ``XpConfig.announce_channel`` shape).  A binding-side
+    snowflake int is stringified; an unparseable legacy value is
+    returned as the raw string.
+    """
+    result = await read_config(
+        guild_id=guild_id,
+        subsystem="xp",
+        binding_name="announce_channel",
+        legacy_key="xp_announce_channel",
+        binding_kind="channel",
+    )
+    return _coerce_to_str(result)
+
+
+async def get_economy_log_channel(guild_id: int) -> ConfigReadResult:
+    """Resolve the economy log channel; value normalized to ``int|None``.
+
+    Consumers (``utils.helpers.post_log_embed``) then do
+    ``guild.get_channel(value)``.  An unparseable legacy value becomes
+    ``None`` with a diagnostic explaining the parse failure.
+    """
+    result = await read_config(
+        guild_id=guild_id,
+        subsystem="economy",
+        binding_name="log_channel",
+        legacy_key="economy_log_channel",
+        binding_kind="channel",
+    )
+    return _coerce_to_int(result)
+
+
+async def get_trusted_tier_role(guild_id: int) -> ConfigReadResult:
+    """Resolve the governance trusted-tier role; value normalized to ``int|None``.
+
+    Consumers (``governance.resolver._resolve_member_tier``) check
+    membership of this role id against ``ctx.role_ids``.
+    """
+    result = await read_config(
+        guild_id=guild_id,
+        subsystem="governance",
+        binding_name="trusted_role",
+        legacy_key="trusted_tier_role_id",
+        binding_kind="role",
+    )
+    return _coerce_to_int(result)
+
+
+# ---------------------------------------------------------------------------
 # Diagnostics provider registration (registers at import time)
 # ---------------------------------------------------------------------------
 
@@ -349,5 +484,8 @@ _register_diagnostics()
 __all__ = [
     "ConfigReadResult",
     "counters_snapshot",
+    "get_economy_log_channel",
+    "get_trusted_tier_role",
+    "get_xp_announce_channel",
     "read_config",
 ]

--- a/disbot/governance/resolver.py
+++ b/disbot/governance/resolver.py
@@ -25,7 +25,7 @@ from governance.models import (
     SubsystemState,
     VisibilityResult,
 )
-from utils import db, settings_keys
+from utils import db
 from utils.subsystem_registry import SUBSYSTEMS
 from utils.visibility_rules import get_member_visibility_tier, get_subsystems_for_tier
 
@@ -147,20 +147,29 @@ async def _resolve_member_tier(ctx: GovernanceContext) -> str:
         ctx.member.guild.owner_id if ctx.member.guild else 0,
     )
 
-    # Trusted tier: if the guild has a TRUSTED_TIER_ROLE_ID setting and the
-    # member has that role, promote them to "trusted" (but only if they're
-    # currently "user" — higher tiers like staff/mod/admin take precedence).
+    # Trusted tier: if the guild has a trusted_role binding (or legacy
+    # TRUSTED_TIER_ROLE_ID setting) AND the member has that role,
+    # promote them to "trusted" (but only if they're currently "user"
+    # — higher tiers like staff/mod/admin take precedence).
+    #
+    # Read flows through the Phase 2 arbitration helper so the canary
+    # flip of ``bindings.primary`` is a single change in
+    # :mod:`core.runtime.config_arbitration`.  This function MUST NOT
+    # branch on ``is_enabled("bindings.primary", ...)`` directly —
+    # that is forbidden by the invariant test in PR-7.
     if tier == "user":
         try:
-            trusted_role_id = await db.get_setting(
-                ctx.guild_id,
-                settings_keys.TRUSTED_TIER_ROLE_ID,
-                default="",
-            )
+            # Local import — keep core.runtime out of governance/__init__'s
+            # module-load cycle (PR #74 protection).  resolver.py is a
+            # sibling of __init__.py but follows the same discipline.
+            from core.runtime.config_arbitration import get_trusted_tier_role
+
+            trusted_role_result = await get_trusted_tier_role(ctx.guild_id)
+            trusted_role_id = trusted_role_result.value
             if (
-                trusted_role_id
+                trusted_role_id is not None
                 and ctx.role_ids
-                and int(trusted_role_id) in ctx.role_ids
+                and trusted_role_id in ctx.role_ids
             ):
                 tier = "trusted"
         except Exception:

--- a/disbot/utils/guild_config_accessors.py
+++ b/disbot/utils/guild_config_accessors.py
@@ -38,7 +38,7 @@ from typing import Generic, TypeVar
 
 from core.runtime import guild_config
 from utils import db
-from utils.settings_keys import XP_ANNOUNCE_CHANNEL, XP_COOLDOWN, XP_MAX, XP_MIN
+from utils.settings_keys import XP_COOLDOWN, XP_MAX, XP_MIN
 
 T = TypeVar("T")
 
@@ -111,12 +111,19 @@ class XpConfig:
 
 def _xp_config_loader(guild_id: int) -> Callable[[], Awaitable[XpConfig]]:
     async def _load() -> XpConfig:
+        # XP min/max/cooldown remain on the legacy path — they are
+        # scalar settings, not bindings, and Phase 2 does not migrate
+        # them.  Only the announce-channel field flows through the
+        # bindings arbitration helper (PR-7).
+        from core.runtime.config_arbitration import get_xp_announce_channel
+
         mn = int(await db.get_setting(guild_id, XP_MIN, str(_XP_DEFAULT_MIN)))
         mx = int(await db.get_setting(guild_id, XP_MAX, str(_XP_DEFAULT_MAX)))
         cd = int(
             await db.get_setting(guild_id, XP_COOLDOWN, str(_XP_DEFAULT_COOLDOWN)),
         )
-        ann = await db.get_setting(guild_id, XP_ANNOUNCE_CHANNEL, "")
+        ann_result = await get_xp_announce_channel(guild_id)
+        ann = ann_result.value or ""
         return XpConfig(xp_min=mn, xp_max=mx, cooldown=cd, announce_channel=ann)
 
     return _load

--- a/disbot/utils/helpers.py
+++ b/disbot/utils/helpers.py
@@ -5,7 +5,6 @@ import re
 import discord
 from discord.ext import commands
 
-from utils.settings_keys import ECONOMY_LOG_CHANNEL
 from utils.ui_constants import INFO_COLOR, SUCCESS_COLOR
 
 # NOTE: ``from core.runtime import resources`` deliberately omitted at
@@ -71,18 +70,33 @@ async def post_log_embed(
     guild_id: int,
     embed: discord.Embed,
 ) -> None:
-    """Post an embed to the guild's configured economy_log_channel (if set)."""
-    from core.runtime import guild_resources
+    """Post an embed to the guild's configured economy_log_channel (if set).
+
+    Read flows through the Phase 2 arbitration helper so the canary
+    flip of ``bindings.primary`` is a single change in
+    :mod:`core.runtime.config_arbitration`.  This function MUST NOT
+    branch on ``is_enabled("bindings.primary", ...)`` directly —
+    that is forbidden by the invariant test in PR-7.
+    """
+    # Local imports preserve the PR #74 cycle-protection pattern:
+    # neither core.runtime.* nor core.resources.* lives at module
+    # scope in utils.helpers.
+    from core.runtime.config_arbitration import get_economy_log_channel
 
     guild = bot.get_guild(guild_id)
     if guild is None:
         return
-    ch = await guild_resources.resolve_settings_channel(guild, ECONOMY_LOG_CHANNEL)
-    if ch:
-        try:
-            await ch.send(embed=embed)  # type: ignore[union-attr]
-        except Exception:
-            pass
+    log_channel_result = await get_economy_log_channel(guild_id)
+    channel_id = log_channel_result.value
+    if channel_id is None:
+        return
+    ch = guild.get_channel(channel_id)
+    if ch is None:
+        return
+    try:
+        await ch.send(embed=embed)  # type: ignore[union-attr]
+    except Exception:
+        pass
 
 
 def normalize_name(name: str) -> str:

--- a/tests/unit/cogs/test_xp_cog_caching.py
+++ b/tests/unit/cogs/test_xp_cog_caching.py
@@ -36,17 +36,47 @@ def _make_message(*, guild_id: int = 99, user_id: int = 1) -> MagicMock:
 
 
 def _xp_settings_replies(get_setting: AsyncMock, *, min_=15, max_=25, cd=60, ann=""):
-    """Side-effect that mimics db.get_setting reading the 4 XP keys."""
+    """Side-effect that mimics db.get_setting reading the 3 scalar XP keys.
+
+    Phase 2 PR-7: the announce_channel field flows through the
+    arbitration helper, not direct db.get_setting from the loader.
+    Tests patch ``core.runtime.config_arbitration.get_xp_announce_channel``
+    separately via :func:`_patch_announce_channel`.
+    """
 
     async def reply(guild_id, key, default=""):  # noqa: ARG001 — signature parity
         return {
             "xp_min": str(min_),
             "xp_max": str(max_),
             "xp_cooldown": str(cd),
-            "xp_announce_channel": ann,
         }.get(key, default)
 
     get_setting.side_effect = reply
+
+
+def _patch_announce_channel(value: str = ""):
+    """Patch the per-subsystem accessor used by ``_xp_config_loader``.
+
+    Returns a ``ConfigReadResult`` so the loader's downstream code path
+    (``ann_result.value or ""``) keeps working.
+    """
+    from core.runtime.config_arbitration import ConfigReadResult
+
+    # Patch the source of the accessor.  ``_xp_config_loader`` does
+    # ``from core.runtime.config_arbitration import get_xp_announce_channel``
+    # inside the function body each time it runs, so patching the
+    # source module's attribute is what intercepts the call.
+    return patch(
+        "core.runtime.config_arbitration.get_xp_announce_channel",
+        new_callable=AsyncMock,
+        return_value=ConfigReadResult(
+            value=value or None,
+            source="legacy" if value else "missing",
+            binding_status="n/a",
+            flag_state="off",
+            diagnostics=[],
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -77,15 +107,21 @@ async def test_handle_message_calls_db_get_setting_at_most_once_per_guild_over_a
             "utils.guild_config_accessors.db.get_setting",
             new_callable=AsyncMock,
         ) as get_setting,
+        _patch_announce_channel() as announce_accessor,
         patch("cogs.xp.listener.check_cooldown", return_value=(True, 0)),
     ):
         _xp_settings_replies(get_setting)
         for _ in range(5):
             await handle_message(bot, message)
 
-    # Cache fill reads each of 4 keys exactly once on the first message;
-    # subsequent 4 messages all hit the cache → no further DB reads.
-    assert get_setting.await_count == 4
+    # Cache fill reads each of 3 scalar XP keys exactly once on the
+    # first message; subsequent 4 messages all hit the cache → no
+    # further DB reads.  The announce_channel field flows through
+    # the arbitration accessor (PR-7) — its call count is the same
+    # 1-per-window because the per-guild XpConfig cache covers the
+    # whole tuple.
+    assert get_setting.await_count == 3
+    assert announce_accessor.await_count == 1
 
 
 @pytest.mark.asyncio
@@ -104,6 +140,7 @@ async def test_handle_message_caches_per_guild_independently():
             "utils.guild_config_accessors.db.get_setting",
             new_callable=AsyncMock,
         ) as get_setting,
+        _patch_announce_channel() as announce_accessor,
         patch("cogs.xp.listener.check_cooldown", return_value=(True, 0)),
     ):
         _xp_settings_replies(get_setting)
@@ -112,7 +149,11 @@ async def test_handle_message_caches_per_guild_independently():
         await handle_message(bot, _make_message(guild_id=1))  # cached
         await handle_message(bot, _make_message(guild_id=2))  # cached
 
-    assert get_setting.await_count == 8  # 4 per guild × 2 guilds
+    # 3 scalar keys per guild × 2 guilds = 6 db.get_setting calls.
+    # Announce accessor called once per guild (also cached at the
+    # XpConfig level).
+    assert get_setting.await_count == 6
+    assert announce_accessor.await_count == 2
 
 
 # ---------------------------------------------------------------------------
@@ -125,15 +166,20 @@ async def test_invalidate_xp_config_forces_reload_on_next_read():
     """After invalidation, the next get_xp_config call re-runs the loader."""
     from utils.guild_config_accessors import get_xp_config, invalidate_xp_config
 
-    with patch(
-        "utils.guild_config_accessors.db.get_setting",
-        new_callable=AsyncMock,
-    ) as get_setting:
+    with (
+        patch(
+            "utils.guild_config_accessors.db.get_setting",
+            new_callable=AsyncMock,
+        ) as get_setting,
+        _patch_announce_channel(),
+    ):
         _xp_settings_replies(get_setting, min_=10)
         first = await get_xp_config(42)
         assert first.xp_min == 10
         await get_xp_config(42)  # cached
-        assert get_setting.await_count == 4
+        # 3 scalar keys (min/max/cooldown) — announce_channel flows
+        # through the arbitration accessor patched above.
+        assert get_setting.await_count == 3
 
         # Simulate an admin write: new value in DB + explicit invalidation.
         _xp_settings_replies(get_setting, min_=99)
@@ -141,7 +187,7 @@ async def test_invalidate_xp_config_forces_reload_on_next_read():
 
         second = await get_xp_config(42)
         assert second.xp_min == 99
-        assert get_setting.await_count == 8  # 4 more reads on the reload
+        assert get_setting.await_count == 6  # 3 more reads on the reload
 
 
 @pytest.mark.asyncio

--- a/tests/unit/config_arbitration/test_subsystem_accessors.py
+++ b/tests/unit/config_arbitration/test_subsystem_accessors.py
@@ -1,0 +1,270 @@
+"""Phase 2 PR-7 — per-subsystem convenience accessors.
+
+The accessors collapse the migrated-key arguments to ``read_config``
+into a single call.  Tests verify:
+
+* Each accessor passes the correct subsystem / binding_name /
+  legacy_key / binding_kind to ``read_config``.
+* The value is normalized to the expected type (``str`` for XP
+  announce channel, ``int`` for economy log channel and trusted-tier
+  role).
+* Unparseable legacy strings on int-valued accessors become
+  ``source='missing'`` with a diagnostic explaining the parse failure.
+* Counters from ``read_config`` continue to accumulate.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from core.resources.status import ResourceStatus
+from core.runtime import config_arbitration
+from core.runtime.bindings import BindingValue
+from core.runtime.config_arbitration import (
+    get_economy_log_channel,
+    get_trusted_tier_role,
+    get_xp_announce_channel,
+)
+from core.runtime.subsystem_schema import BindingKind
+
+
+@pytest.fixture(autouse=True)
+def _reset_counters():
+    config_arbitration._reset_counters_for_tests()
+    yield
+    config_arbitration._reset_counters_for_tests()
+
+
+def _bv(*, kind, target_id, status):
+    return BindingValue(
+        guild_id=1,
+        subsystem="x",
+        binding_name="y",
+        kind=kind,
+        target_id=target_id,
+        status=status,
+        last_validated_at=datetime.now(timezone.utc),
+        last_updated_at=datetime.now(timezone.utc),
+        version=1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_xp_announce_channel — legacy str pass-through; binding int stringified
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_xp_announce_channel_flag_off_returns_legacy_string():
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="123456",
+        ),
+    ):
+        result = await get_xp_announce_channel(guild_id=1)
+    assert result.value == "123456"
+    assert isinstance(result.value, str)
+    assert result.source == "legacy"
+
+
+@pytest.mark.asyncio
+async def test_xp_announce_channel_flag_on_binding_stringifies_int():
+    """When the binding returns an int, the accessor stringifies it.
+
+    XP callers expect a string (``XpConfig.announce_channel: str``).
+    """
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "core.runtime.bindings.get_binding",
+            new_callable=AsyncMock,
+            return_value=_bv(
+                kind=BindingKind.CHANNEL,
+                target_id=999999,
+                status=ResourceStatus.BOUND,
+            ),
+        ),
+    ):
+        result = await get_xp_announce_channel(guild_id=1)
+    assert result.value == "999999"
+    assert isinstance(result.value, str)
+    assert result.source == "binding"
+
+
+@pytest.mark.asyncio
+async def test_xp_announce_channel_missing_returns_none():
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="",
+        ),
+    ):
+        result = await get_xp_announce_channel(guild_id=1)
+    assert result.value is None
+    assert result.source == "missing"
+
+
+# ---------------------------------------------------------------------------
+# get_economy_log_channel — value coerced to int|None
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_economy_log_channel_flag_off_parses_legacy_to_int():
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="777777",
+        ),
+    ):
+        result = await get_economy_log_channel(guild_id=1)
+    assert result.value == 777777
+    assert isinstance(result.value, int)
+    assert result.source == "legacy"
+
+
+@pytest.mark.asyncio
+async def test_economy_log_channel_flag_on_returns_binding_int():
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "core.runtime.bindings.get_binding",
+            new_callable=AsyncMock,
+            return_value=_bv(
+                kind=BindingKind.CHANNEL,
+                target_id=999,
+                status=ResourceStatus.BOUND,
+            ),
+        ),
+    ):
+        result = await get_economy_log_channel(guild_id=1)
+    assert result.value == 999
+    assert result.source == "binding"
+
+
+@pytest.mark.asyncio
+async def test_economy_log_channel_unparseable_legacy_becomes_missing():
+    """A legacy KV holding junk that can't be int-parsed should not crash."""
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="not-a-number",
+        ),
+    ):
+        result = await get_economy_log_channel(guild_id=1)
+    assert result.value is None
+    assert result.source == "missing"
+    assert any("could not be parsed as int" in d for d in result.diagnostics)
+
+
+# ---------------------------------------------------------------------------
+# get_trusted_tier_role — value coerced to int|None, kind=role
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_trusted_tier_role_passes_role_kind_to_read_config():
+    """The accessor MUST declare binding_kind='role' so kind drift is caught.
+
+    The XP/economy accessors declare 'channel'; this one must declare
+    'role' or a future schema mistake (binding declared as channel)
+    would be silently accepted.
+    """
+    with patch(
+        "core.runtime.config_arbitration.read_config",
+        new_callable=AsyncMock,
+    ) as mock_read:
+        mock_read.return_value = config_arbitration.ConfigReadResult(
+            value=None,
+            source="missing",
+            binding_status="n/a",
+            flag_state="off",
+            diagnostics=[],
+        )
+        await get_trusted_tier_role(guild_id=1)
+    call = mock_read.await_args
+    assert call.kwargs["subsystem"] == "governance"
+    assert call.kwargs["binding_name"] == "trusted_role"
+    assert call.kwargs["legacy_key"] == "trusted_tier_role_id"
+    assert call.kwargs["binding_kind"] == "role"
+
+
+@pytest.mark.asyncio
+async def test_trusted_tier_role_legacy_int_returned():
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="111222333",
+        ),
+    ):
+        result = await get_trusted_tier_role(guild_id=1)
+    assert result.value == 111222333
+
+
+# ---------------------------------------------------------------------------
+# Counters accumulate across accessors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_counters_increment_across_accessors():
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="123",
+        ),
+    ):
+        await get_xp_announce_channel(guild_id=1)
+        await get_economy_log_channel(guild_id=1)
+        await get_trusted_tier_role(guild_id=1)
+    snap = config_arbitration.counters_snapshot()
+    assert snap["calls_total"] == 3
+    assert snap["by_flag_state"]["off"] == 3

--- a/tests/unit/invariants/test_no_direct_bindings_primary_branch.py
+++ b/tests/unit/invariants/test_no_direct_bindings_primary_branch.py
@@ -1,0 +1,107 @@
+"""Phase 2 PR-7 invariant — no direct branching on ``bindings.primary``.
+
+The Phase 2 plan forbids per-cog (or per-service / per-governance)
+branching on ``is_enabled("bindings.primary", ...)``.  Only
+:mod:`core.runtime.config_arbitration` may consult that flag; all
+other consumers route reads through the typed per-subsystem
+accessors (``get_xp_announce_channel`` etc.) which encapsulate the
+flag check.
+
+Why this matters:
+* The canary flip of ``bindings.primary`` is a single change in
+  the arbitration module; scattered branches would multiply the
+  rollback surface.
+* Provenance (``ConfigReadResult.source``, ``binding_status``,
+  ``flag_state``, ``diagnostics``) is only captured by the central
+  helper — per-cog branches would lose it.
+
+This test parses every ``disbot/**/*.py`` file via AST and fails if
+any node references the string literal ``"bindings.primary"`` outside
+the allowlist below.
+
+Allowlist:
+* ``disbot/core/runtime/config_arbitration.py`` — the only legitimate
+  consumer.
+* ``disbot/core/runtime/feature_flags.py`` — declares the flag.
+* ``disbot/services/binding_backfill.py`` — uses the literal as the
+  migration name and in checkpoint payloads, not as a flag check.
+* ``disbot/services/rollout_mutation.py`` — error messages reference
+  ``"bindings.primary"`` as an example.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCAN_ROOT = _REPO_ROOT / "disbot"
+_FLAG_LITERAL = "bindings.primary"
+
+# Files allowed to reference the literal.  Add to this list with care
+# — every entry weakens the invariant.
+_ALLOWLIST = {
+    _SCAN_ROOT / "core" / "runtime" / "config_arbitration.py",
+    _SCAN_ROOT / "core" / "runtime" / "feature_flags.py",
+    _SCAN_ROOT / "services" / "binding_backfill.py",
+    _SCAN_ROOT / "services" / "rollout_mutation.py",
+}
+
+
+def _iter_python_files() -> list[Path]:
+    return [p for p in _SCAN_ROOT.rglob("*.py") if "__pycache__" not in p.parts]
+
+
+def _file_references_literal(path: Path) -> bool:
+    """True if the AST contains a ``str`` constant equal to ``bindings.primary``."""
+    try:
+        tree = ast.parse(path.read_text())
+    except SyntaxError:
+        # Not a valid python module — skip rather than crash the test
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and node.value == _FLAG_LITERAL:
+            return True
+    return False
+
+
+def test_no_direct_bindings_primary_outside_allowlist():
+    """Every reference to ``"bindings.primary"`` lives in the allowlist."""
+    violations: list[str] = []
+    for path in _iter_python_files():
+        if path in _ALLOWLIST:
+            continue
+        if _file_references_literal(path):
+            violations.append(str(path.relative_to(_REPO_ROOT)))
+    assert not violations, (
+        "These files reference the literal 'bindings.primary' but are "
+        "not in the allowlist — route reads through "
+        "core.runtime.config_arbitration's per-subsystem accessors "
+        "(get_xp_announce_channel, get_economy_log_channel, "
+        "get_trusted_tier_role) instead.\n\n"
+        + "\n".join(f"  {v}" for v in sorted(violations))
+    )
+
+
+def test_allowlist_entries_exist():
+    """Every file in the allowlist must still exist on disk.
+
+    Otherwise a renamed file would silently relax the invariant.
+    """
+    missing = [str(p.relative_to(_REPO_ROOT)) for p in _ALLOWLIST if not p.exists()]
+    assert (
+        not missing
+    ), "Allowlist references files that no longer exist:\n" + "\n".join(
+        f"  {p}" for p in missing
+    )
+
+
+def test_arbitration_module_actually_references_literal():
+    """If the allowlist target itself stops referencing the flag, the
+    invariant is meaningless.  Pin that config_arbitration still
+    consumes the literal.
+    """
+    arbitration = _SCAN_ROOT / "core" / "runtime" / "config_arbitration.py"
+    assert _file_references_literal(
+        arbitration,
+    ), "core/runtime/config_arbitration.py must reference 'bindings.primary'"


### PR DESCRIPTION
## Summary

PR-7 of the Phase 2 plan. Swap the three migrated read sites (XP announce channel, Economy log channel, governance trusted-tier role) to use the central arbitration helper from PR-4. **`bindings.primary` remains OFF by default** — cog behavior is unchanged. When the operator flips `bindings.primary` to canary/owner via env or the DB override row, the reads start serving the binding value (with legacy as a fallback).

**Stacked on PR #82.** Merge order: #81 → #82 → #83.

## Why this PR is scoped safely

- `bindings.primary` stays default OFF. **No production flip.** Cog behavior is identical to `main` today until an operator deliberately enables the flag on a canary guild.
- Legacy fallback remains for every migrated key: with the flag on, if the binding is `UNRESOLVED` / `MISSING` / `INVALID`, `ConfigReadResult` falls back to legacy with `source='fallback'`.
- Rollback is a single feature-flag flip — set `bindings.primary` back to off and every read returns to legacy.
- New AST invariant test forbids direct branching on `is_enabled("bindings.primary", ...)` outside the arbitration module + the migration-name / declaration files (explicit allowlist).

## What changed

| Path | Change |
|---|---|
| `disbot/core/runtime/config_arbitration.py` | Type-coercion helpers (`_coerce_to_int`, `_coerce_to_str`) + three per-subsystem accessors: `get_xp_announce_channel` (str\|None), `get_economy_log_channel` (int\|None), `get_trusted_tier_role` (int\|None). All three pass `binding_kind` so PR-4's kind-drift detection surfaces wrong-kind bindings. |
| `disbot/utils/guild_config_accessors.py` | `_xp_config_loader` now calls `get_xp_announce_channel` instead of `db.get_setting(XP_ANNOUNCE_CHANNEL)`. Local import preserves cycle protection. |
| `disbot/utils/helpers.py` | `post_log_embed` now calls `get_economy_log_channel` + `guild.get_channel(int)`. Local import. |
| `disbot/governance/resolver.py` | `_resolve_member_tier`'s trusted-tier promotion now calls `get_trusted_tier_role`. Local import. |
| `tests/unit/invariants/test_no_direct_bindings_primary_branch.py` | NEW — AST scan asserting no string literal `'bindings.primary'` appears outside the explicit allowlist (4 files). Allowlist liveness check included. |
| `tests/unit/config_arbitration/test_subsystem_accessors.py` | NEW — 10 tests for accessor types, kind validation, unparseable coercion, counters. |
| `tests/unit/cogs/test_xp_cog_caching.py` | Updated F-1 cache tests: patch `core.runtime.config_arbitration.get_xp_announce_channel`; expected `db.get_setting` count drops from 4→3 per guild. |

## Architectural boundaries preserved

- One runtime domain per PR.
- No new migration.
- No setup UI, no participation, no resource provisioning.
- `BindingMutationPipeline` not invoked.
- Cycle-sensitive consumers (`utils.helpers`, `governance.resolver`) import `config_arbitration` INSIDE the function body — never at module scope. Import-cycle regression test still green.
- `ResourceStatus.BOUND` stays structural-only.
- Standard library only.

## Migrations

None.

## Rollback strategy

Two layers:

1. **Flag flip** — `SUPERBOT_FF_BINDINGS_PRIMARY=off` (or simply leaving the declared default off) returns every read to legacy. Single env change.
2. **Code revert** — single `git revert` of this PR. The three read sites return to their pre-PR-7 paths. Migration 026 + `binding_backfill` + `RolloutMutationPipeline` remain in place but unused.

## Tests run

```
python -m pytest tests/unit/config_arbitration/ \
                 tests/unit/invariants/test_no_direct_bindings_primary_branch.py \
                 tests/unit/runtime/test_import_cycle_regression.py \
                 tests/unit/binding_backfill/ -q
# 81 passed

python -m pytest tests/ -q --ignore=tests/integration
# 1327 passed (1315 baseline + 12 new), 12 unrelated warnings

python -m ruff check disbot/   # clean
python -m black --check (changed files)  # clean
python -m isort --check-only (changed files)  # clean
```

## Manual Discord smoke

- [ ] After deploy with `bindings.primary` OFF (default): XP level-up announcements land in the same channel as before (legacy path); Economy log embeds land in the same channel as before; Trusted-tier role promotion works as before.
- [ ] Enable canary via env `SUPERBOT_FF_BINDINGS_PRIMARY=on` for a test guild + seed a `subsystem_bindings` row pointing at the desired channel/role (via the backfill or via `BindingMutationPipeline`):
  - [ ] XP announce channel reads from the binding's `target_id`
  - [ ] Economy log channel reads from the binding's `target_id`
  - [ ] Trusted-tier role uses the binding's `target_id`
- [ ] Verify `ConfigReadResult.source` via the arbitration counters in `!platform runtime` (unified `!platform consistency` arrives in PR-10).
- [ ] Disable the env flag → reads revert to legacy path immediately.

## Intentionally deferred

- **Governance SubsystemSchema declaration for `trusted_role`** — the legacy fallback handles the case where no schema is declared, so the read-site swap is safe regardless. A follow-up PR can declare the schema so `apply_backfill` can fill the binding.
- **Production flip of `bindings.primary`** — explicitly NOT in PR-7.
- **Legacy setting deletion** — never in this phase.
- **New `!platform consistency` surface** — PR-10.

## Test plan

- [x] AST scan: no `is_enabled("bindings.primary", ...)` branch outside allowlist
- [x] Each accessor returns correct type (`str` / `int` / `int`)
- [x] Each accessor passes correct kind (`channel` / `channel` / `role`)
- [x] Unparseable legacy string on int-typed accessor → `source='missing'`
- [x] Counters accumulate across accessors
- [x] XP F-1 cache contract preserved
- [x] Import-cycle regression still green
- [x] `bindings.primary` OFF → reads use legacy
- [x] `bindings.primary` ON + binding BOUND → reads use binding

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgFk12CkWs1uiPZk8AA5fR)_