### PR TITLE
Phase 2.8: participation storage + cache foundation (Phase 2c)

### DIFF
--- a/disbot/core/runtime/user_config.py
+++ b/disbot/core/runtime/user_config.py
@@ -1,0 +1,254 @@
+"""Per-user participation cache — Phase 2c (PR-8).
+
+Process-local cache over the four participation tables shipped in
+migration 027.  Mirrors the design of ``core.runtime.guild_config``:
+TTL-bounded entries with explicit invalidation primitives so PR-9's
+``ParticipationMutationPipeline`` can drop the stale entry after every
+write.
+
+State class (per ``docs/architecture.md`` §"State classification"):
+
+  **cached config (derived)** — the DB row is the canonical state.
+  Cache entries may be evicted at any time.
+
+Cache key shape: ``(user_id, guild_id)``.  One entry caches the full
+four-table bundle for that ``(user, guild)`` pair so subsystem
+accessors (``get_participation``, ``is_subscribed``, etc.) hit the
+cache once and dispatch internally.
+
+Cache eviction:
+
+* **TTL** — each entry expires after ``_CACHE_TTL_SECS`` (default 300s,
+  same window as the feature-flag evaluator).
+* **Max size** — at most ``_CACHE_MAX_ENTRIES`` entries (default 50_000).
+  Hit the cap → drop the oldest entries by ``inserted_at`` ordering.
+  This is a coarse LRU-ish approximation; a real LRU is unnecessary
+  because the working set is dominated by recently active users.
+* **Explicit invalidation** — :func:`forget_user`,
+  :func:`invalidate_user_guild`, :func:`forget_guild`,
+  :func:`forget_all`.  PR-9 calls ``invalidate_user_guild`` after every
+  mutation.
+* **Guild teardown** — :func:`forget_guild` is the hook called from
+  ``guild_lifecycle.teardown``.
+
+This module is read-only against the DB.  Writes live in PR-9's
+mutation pipeline; the pipeline calls back into this module's
+invalidation primitives.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger("bot.user_config")
+
+# 5-minute TTL matches the feature-flag evaluator default — close
+# enough that a user's mutation is reflected within one cache cycle
+# even without explicit invalidation, but long enough to absorb the
+# read pressure from any single interaction.
+_CACHE_TTL_SECS = 300.0
+
+# Soft upper bound on cache size.  Each entry holds the JSON-decoded
+# bundle for one (user, guild) pair.  50k entries × ~1 KB each is
+# ~50 MB, comfortably within process memory for any practical
+# deployment.
+_CACHE_MAX_ENTRIES = 50_000
+
+
+@dataclass(frozen=True)
+class CachedUserConfig:
+    """One cached (user, guild) bundle.
+
+    The fields mirror what ``utils.db.user_participation.list_for_user``
+    returns.  Stored as plain dicts so the cache is JSON-friendly
+    (and so the diagnostics provider can render them).
+    """
+
+    user_id: int
+    guild_id: int
+    participation: tuple[dict[str, Any], ...] = field(default_factory=tuple)
+    subscriptions: tuple[dict[str, Any], ...] = field(default_factory=tuple)
+    preferences: tuple[dict[str, Any], ...] = field(default_factory=tuple)
+    visibility_overrides: tuple[dict[str, Any], ...] = field(default_factory=tuple)
+
+
+# Cache value: (CachedUserConfig, expires_at_monotonic, inserted_at_monotonic).
+_CACHE: dict[tuple[int, int], tuple[CachedUserConfig, float, float]] = {}
+
+# Metric counters — diagnostics provider snapshots these.
+_HITS = 0
+_MISSES = 0
+_EVICTIONS = 0
+
+
+def _evict_for_capacity() -> None:
+    """Drop the oldest entries when ``_CACHE`` exceeds the soft cap.
+
+    Coarse, not strict LRU — drops the bottom decile by
+    ``inserted_at`` whenever the cap trips.  Cheaper than maintaining
+    an ordered structure and good enough for participation, which is
+    a low-volume read pattern compared to hot-path message dispatch.
+    """
+    global _EVICTIONS
+    if len(_CACHE) <= _CACHE_MAX_ENTRIES:
+        return
+    sorted_keys = sorted(
+        _CACHE.keys(),
+        key=lambda k: _CACHE[k][2],  # inserted_at
+    )
+    drop_count = max(1, len(_CACHE) // 10)
+    for key in sorted_keys[:drop_count]:
+        _CACHE.pop(key, None)
+        _EVICTIONS += 1
+
+
+async def get(user_id: int, guild_id: int) -> CachedUserConfig:
+    """Return the cached bundle for ``(user, guild)``; load on miss.
+
+    Returns an empty :class:`CachedUserConfig` (all tuples empty) when
+    the user has no rows in any of the four tables — that's the
+    "not yet configured anything" state.  Typed accessors in
+    :mod:`utils.user_config_accessors` interpret an empty bundle as
+    "every concern returns its declared default".
+    """
+    global _HITS, _MISSES
+    key = (user_id, guild_id)
+    entry = _CACHE.get(key)
+    now = time.monotonic()
+    if entry is not None:
+        cached, expires_at, _ = entry
+        if expires_at >= now:
+            _HITS += 1
+            return cached
+        # Expired — fall through to reload.
+        _CACHE.pop(key, None)
+
+    # Cache miss — load from DB.
+    _MISSES += 1
+    from utils.db import user_participation as up_db
+
+    try:
+        bundle = await up_db.list_for_user(user_id, guild_id)
+    except Exception as exc:  # noqa: BLE001 — read path must not raise
+        logger.warning(
+            "user_config: list_for_user raised for user=%d guild=%d (%r); "
+            "returning empty bundle",
+            user_id,
+            guild_id,
+            exc,
+        )
+        bundle = {
+            "participation": [],
+            "subscriptions": [],
+            "preferences": [],
+            "visibility_overrides": [],
+        }
+
+    cached = CachedUserConfig(
+        user_id=user_id,
+        guild_id=guild_id,
+        participation=tuple(bundle["participation"]),
+        subscriptions=tuple(bundle["subscriptions"]),
+        preferences=tuple(bundle["preferences"]),
+        visibility_overrides=tuple(bundle["visibility_overrides"]),
+    )
+    _CACHE[key] = (cached, now + _CACHE_TTL_SECS, now)
+    _evict_for_capacity()
+    return cached
+
+
+# ---------------------------------------------------------------------------
+# Invalidation primitives.  PR-9's ParticipationMutationPipeline calls
+# ``invalidate_user_guild`` after every write so subsequent reads see
+# the new state.
+# ---------------------------------------------------------------------------
+
+
+def invalidate_user_guild(user_id: int, guild_id: int) -> bool:
+    """Drop the cache entry for ``(user, guild)`` if present.
+
+    Returns ``True`` when an entry was dropped, ``False`` otherwise.
+    """
+    return _CACHE.pop((user_id, guild_id), None) is not None
+
+
+def forget_user(user_id: int) -> int:
+    """Drop every cache entry for ``user_id`` (across all guilds).
+
+    Returns the number of entries removed.
+    """
+    keys = [k for k in _CACHE if k[0] == user_id]
+    for k in keys:
+        _CACHE.pop(k, None)
+    return len(keys)
+
+
+def forget_guild(guild_id: int) -> int:
+    """Drop every cache entry whose guild matches ``guild_id``.
+
+    Called from ``guild_lifecycle.teardown`` so a re-invited guild
+    does not observe stale per-user decisions.
+    """
+    keys = [k for k in _CACHE if k[1] == guild_id]
+    for k in keys:
+        _CACHE.pop(k, None)
+    return len(keys)
+
+
+def forget_all() -> int:
+    """Drop the entire cache.  Returns the number of entries removed."""
+    n = len(_CACHE)
+    _CACHE.clear()
+    return n
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics
+# ---------------------------------------------------------------------------
+
+
+def _snapshot() -> dict[str, Any]:
+    """Snapshot for the diagnostics provider.
+
+    Returns counts only — the bundle content is not surfaced via
+    diagnostics for privacy.
+    """
+    return {
+        "cache_size": len(_CACHE),
+        "cache_capacity": _CACHE_MAX_ENTRIES,
+        "ttl_secs": _CACHE_TTL_SECS,
+        "hits": _HITS,
+        "misses": _MISSES,
+        "evictions": _EVICTIONS,
+    }
+
+
+def _reset_for_tests() -> None:
+    """Test helper — clear cache + reset counters."""
+    global _HITS, _MISSES, _EVICTIONS
+    _CACHE.clear()
+    _HITS = 0
+    _MISSES = 0
+    _EVICTIONS = 0
+
+
+def _register_diagnostics() -> None:
+    from services import diagnostics_service
+
+    diagnostics_service.register("user_config", _snapshot)
+
+
+_register_diagnostics()
+
+
+__all__ = [
+    "CachedUserConfig",
+    "forget_all",
+    "forget_guild",
+    "forget_user",
+    "get",
+    "invalidate_user_guild",
+]

--- a/disbot/guild_lifecycle.py
+++ b/disbot/guild_lifecycle.py
@@ -38,11 +38,18 @@ async def teardown(guild_id: int) -> None:
       9. Feature flag evaluator cache — drop cached decisions for the guild.
       10. Platform migration checkpoints — drop per-guild checkpoint rows
                                    (Phase 2 PR-5); global rows preserved.
-      11. Governance capability cache — clear per-guild execution overrides.
-      12. Governance visibility cache — bump version, clear role-override flag.
-      13. Guild-config cache    — drop cached guild config entries (F-1).
-      14. Scope locks           — invoke registered per-cog teardown hooks (F-2).
-      15. Governance feedback cooldown — documented, no per-guild cleanup needed.
+      11. Per-user participation tables — delete user_participation /
+                                   user_subscriptions / user_preferences /
+                                   user_visibility_overrides rows scoped to
+                                   this guild (Phase 2c PR-8).  Same user's
+                                   rows in OTHER guilds are preserved.
+      12. User-config cache      — drop cached per-(user, guild) bundles
+                                   (Phase 2c PR-8).
+      13. Governance capability cache — clear per-guild execution overrides.
+      14. Governance visibility cache — bump version, clear role-override flag.
+      15. Guild-config cache    — drop cached guild config entries (F-1).
+      16. Scope locks           — invoke registered per-cog teardown hooks (F-2).
+      17. Governance feedback cooldown — documented, no per-guild cleanup needed.
     """
     logger.info("guild_lifecycle.teardown: beginning cleanup for guild=%d", guild_id)
 
@@ -76,19 +83,26 @@ async def teardown(guild_id: int) -> None:
     # 10. Platform migration checkpoints — per-guild rows only (Phase 2 PR-5).
     await _teardown_platform_migration_checkpoints(guild_id)
 
-    # 11. Governance capability overrides — clear execution-layer in-process dict.
+    # 11. Per-user participation tables — drop user_*/visibility rows scoped
+    #     to this guild only (Phase 2c PR-8).
+    await _teardown_user_participation(guild_id)
+
+    # 12. User-config cache — drop cached (user, guild) bundles for this guild.
+    _teardown_user_config_cache(guild_id)
+
+    # 13. Governance capability overrides — clear execution-layer in-process dict.
     _teardown_capability_overrides(guild_id)
 
-    # 12. Governance visibility cache — version bump + role flag removal.
+    # 14. Governance visibility cache — version bump + role flag removal.
     _teardown_visibility_cache(guild_id)
 
-    # 13. Guild-config cache — drop cached config entries for the guild (F-1 / S1.1).
+    # 15. Guild-config cache — drop cached config entries for the guild (F-1 / S1.1).
     _teardown_guild_config(guild_id)
 
-    # 14. Scope locks — invoke registered per-cog teardown hooks (F-2 / S1.2).
+    # 16. Scope locks — invoke registered per-cog teardown hooks (F-2 / S1.2).
     _teardown_scope_locks(guild_id)
 
-    # 15. Governance feedback cooldown dict in governance/__init__.
+    # 17. Governance feedback cooldown dict in governance/__init__.
     _teardown_feedback_cooldown(guild_id)
 
     logger.info("guild_lifecycle.teardown: complete for guild=%d", guild_id)
@@ -312,6 +326,56 @@ async def _teardown_platform_migration_checkpoints(guild_id: int) -> None:
     except Exception as exc:
         logger.warning(
             "guild_lifecycle: platform migration checkpoint teardown failed: %s",
+            exc,
+        )
+
+
+async def _teardown_user_participation(guild_id: int) -> None:
+    """Delete per-user participation rows scoped to the departed guild.
+
+    Phase 2c PR-8.  Drops rows in user_participation, user_subscriptions,
+    user_preferences, and user_visibility_overrides whose ``guild_id``
+    matches.  The same user's rows in OTHER guilds are preserved.
+    """
+    try:
+        from utils.db.user_participation import (
+            delete_for_guild as _participation_delete,
+        )
+
+        count = await _participation_delete(guild_id)
+        if count:
+            logger.debug(
+                "guild_lifecycle: deleted %d user participation row(s) for guild=%d",
+                count,
+                guild_id,
+            )
+    except Exception as exc:
+        logger.warning(
+            "guild_lifecycle: user participation teardown failed: %s",
+            exc,
+        )
+
+
+def _teardown_user_config_cache(guild_id: int) -> None:
+    """Drop cached per-(user, guild) participation bundles for ``guild_id``.
+
+    Phase 2c PR-8.  Symmetric to ``_teardown_feature_flag_cache`` —
+    keeps cache and DB consistent on guild leave.
+    """
+    try:
+        from core.runtime.user_config import forget_guild as _user_cache_forget
+
+        dropped = _user_cache_forget(guild_id)
+        if dropped:
+            logger.debug(
+                "guild_lifecycle: dropped %d user_config cache entry(s) "
+                "for guild=%d",
+                dropped,
+                guild_id,
+            )
+    except Exception as exc:
+        logger.warning(
+            "guild_lifecycle: user_config cache teardown failed: %s",
             exc,
         )
 

--- a/disbot/migrations/027_user_participation.sql
+++ b/disbot/migrations/027_user_participation.sql
@@ -1,0 +1,110 @@
+-- Migration 027: per-user participation tables (Phase 2c, PR-8).
+--
+-- Four structurally-separated tables — one per concern — owned by
+-- :class:`core.runtime.participation_schema.ParticipationSchema`.  The
+-- schema docstring explicitly forbids collapsing these into a single
+-- "user settings" object; this migration enforces that separation at
+-- the storage layer.
+--
+--   * user_participation         — opt-in / opt-out toggles
+--   * user_subscriptions         — topic-level subscription state
+--   * user_preferences           — JSONB UX preferences
+--   * user_visibility_overrides  — public / hidden surface toggles
+--
+-- All four tables include ``guild_id`` so guild-leave teardown can
+-- purge the rows for a single guild without touching the same user's
+-- participation in OTHER guilds.  The composite PK on every table is
+-- ``(user_id, guild_id, ...)`` so per-(user, guild) lookups are
+-- O(1) index reads.
+--
+-- Missing-row semantics (consumed by :mod:`utils.user_config_accessors`):
+--
+--   user_participation         → 'not_set'        (caller interprets)
+--   user_subscriptions         → schema default
+--   user_preferences           → preference default
+--   user_visibility_overrides  → schema default
+--
+-- Mutation contract (Phase 2c PR-9 adds the ParticipationMutationPipeline):
+--
+--   * Writes flow through :class:`services.participation_mutation.
+--     ParticipationMutationPipeline` (NOT this migration).
+--   * actor_id is recorded on every row so audit / authority checks
+--     can resolve later.  Nullable because system writes (CI seeds,
+--     future PR-9 backfills) use NULL with actor_type='system' in
+--     the associated audit table (PR-9).
+--
+-- Forward-only and idempotent.
+
+-- ---------------------------------------------------------------------------
+-- user_participation — opt-in / opt-out per (user, guild, subsystem)
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS user_participation (
+    user_id     BIGINT       NOT NULL,
+    guild_id    BIGINT       NOT NULL,
+    subsystem   TEXT         NOT NULL,
+    state       TEXT         NOT NULL,
+    set_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    set_by      BIGINT,
+    PRIMARY KEY (user_id, guild_id, subsystem),
+    CHECK (state IN ('opted_in', 'opted_out'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_participation_guild
+    ON user_participation (guild_id);
+
+
+-- ---------------------------------------------------------------------------
+-- user_subscriptions — topic-level subscription toggles
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS user_subscriptions (
+    user_id     BIGINT       NOT NULL,
+    guild_id    BIGINT       NOT NULL,
+    subsystem   TEXT         NOT NULL,
+    topic       TEXT         NOT NULL,
+    enabled     BOOLEAN      NOT NULL,
+    set_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    set_by      BIGINT,
+    PRIMARY KEY (user_id, guild_id, subsystem, topic)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_subscriptions_guild
+    ON user_subscriptions (guild_id);
+
+
+-- ---------------------------------------------------------------------------
+-- user_preferences — JSONB UX / UI preferences
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS user_preferences (
+    user_id     BIGINT       NOT NULL,
+    guild_id    BIGINT       NOT NULL,
+    key         TEXT         NOT NULL,
+    value       JSONB        NOT NULL,
+    set_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    set_by      BIGINT,
+    PRIMARY KEY (user_id, guild_id, key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_preferences_guild
+    ON user_preferences (guild_id);
+
+
+-- ---------------------------------------------------------------------------
+-- user_visibility_overrides — public / hidden surface toggles
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS user_visibility_overrides (
+    user_id     BIGINT       NOT NULL,
+    guild_id    BIGINT       NOT NULL,
+    subsystem   TEXT         NOT NULL,
+    visibility  TEXT         NOT NULL,
+    set_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    set_by      BIGINT,
+    PRIMARY KEY (user_id, guild_id, subsystem),
+    CHECK (visibility IN ('public', 'hidden'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_visibility_overrides_guild
+    ON user_visibility_overrides (guild_id);

--- a/disbot/utils/db/user_participation.py
+++ b/disbot/utils/db/user_participation.py
@@ -1,0 +1,311 @@
+"""Per-user participation — DB read primitives (Phase 2c, PR-8).
+
+Owns the read surface for the four participation tables shipped in
+migration 027.  Writes ship with
+:class:`services.participation_mutation.ParticipationMutationPipeline`
+in PR-9.
+
+The four tables are intentionally separated — see
+:mod:`core.runtime.participation_schema` for the structural rationale.
+Each table has its own dedicated read primitive here; nothing combines
+them into a single "user settings" blob.
+
+Public surface:
+
+* :func:`get_participation`   — single-row read on ``user_participation``.
+* :func:`get_subscription`    — single-row read on ``user_subscriptions``.
+* :func:`get_preference`      — single-row read on ``user_preferences``.
+* :func:`get_visibility`      — single-row read on ``user_visibility_overrides``.
+* :func:`list_for_user`       — bundle reader returning every row for
+  one ``(user, guild)`` pair across the four tables.  Used by the
+  ``core.runtime.user_config`` cache loader.
+* :func:`delete_for_guild`    — guild-leave teardown; deletes every
+  row whose ``guild_id`` matches.  Per the consistency-ledger
+  retention policy, **per-guild participation rows ARE deleted on
+  guild leave** so the same user's participation in other guilds is
+  preserved.
+
+Status / visibility literals (mirror migration 027 CHECK constraints):
+
+  user_participation.state         IN ('opted_in', 'opted_out')
+  user_visibility_overrides.visibility IN ('public', 'hidden')
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from utils.db import pool
+
+logger = logging.getLogger("bot.db.user_participation")
+
+# Mirror migration 027 CHECK constraints.  Alignment tests pin these.
+PARTICIPATION_STATES: frozenset[str] = frozenset({"opted_in", "opted_out"})
+VISIBILITY_STATES: frozenset[str] = frozenset({"public", "hidden"})
+
+
+def _deserialise(raw: Any | None) -> Any | None:
+    """Decode a JSONB value (accepts str or already-decoded dict/list)."""
+    if raw is None or isinstance(raw, (dict, list)):
+        return raw
+    try:
+        return json.loads(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "user_participation: failed to JSON-decode preference value; "
+            "returning raw",
+        )
+        return raw
+
+
+# ---------------------------------------------------------------------------
+# Single-row reads
+# ---------------------------------------------------------------------------
+
+
+async def get_participation(
+    user_id: int,
+    guild_id: int,
+    subsystem: str,
+) -> dict[str, Any] | None:
+    """Return the participation row, or ``None`` for a missing row.
+
+    Missing-row semantics (consumed by the typed accessor in
+    :mod:`utils.user_config_accessors`): caller interprets ``None`` as
+    ``ParticipationState.NOT_SET``.
+    """
+    row = await pool.get().fetchrow(
+        """
+        SELECT user_id, guild_id, subsystem, state, set_at, set_by
+        FROM user_participation
+        WHERE user_id = $1 AND guild_id = $2 AND subsystem = $3
+        """,
+        user_id,
+        guild_id,
+        subsystem,
+    )
+    return dict(row) if row else None
+
+
+async def get_subscription(
+    user_id: int,
+    guild_id: int,
+    subsystem: str,
+    topic: str,
+) -> dict[str, Any] | None:
+    """Return the subscription row, or ``None`` for missing.
+
+    Missing-row semantics: caller interprets ``None`` as the schema's
+    declared default for that topic.
+    """
+    row = await pool.get().fetchrow(
+        """
+        SELECT user_id, guild_id, subsystem, topic, enabled, set_at, set_by
+        FROM user_subscriptions
+        WHERE user_id = $1 AND guild_id = $2
+          AND subsystem = $3 AND topic = $4
+        """,
+        user_id,
+        guild_id,
+        subsystem,
+        topic,
+    )
+    return dict(row) if row else None
+
+
+async def get_preference(
+    user_id: int,
+    guild_id: int,
+    key: str,
+) -> dict[str, Any] | None:
+    """Return the preference row with value JSON-decoded, or ``None``."""
+    row = await pool.get().fetchrow(
+        """
+        SELECT user_id, guild_id, key, value, set_at, set_by
+        FROM user_preferences
+        WHERE user_id = $1 AND guild_id = $2 AND key = $3
+        """,
+        user_id,
+        guild_id,
+        key,
+    )
+    if row is None:
+        return None
+    out = dict(row)
+    out["value"] = _deserialise(out.get("value"))
+    return out
+
+
+async def get_visibility(
+    user_id: int,
+    guild_id: int,
+    subsystem: str,
+) -> dict[str, Any] | None:
+    """Return the visibility override, or ``None`` for missing."""
+    row = await pool.get().fetchrow(
+        """
+        SELECT user_id, guild_id, subsystem, visibility, set_at, set_by
+        FROM user_visibility_overrides
+        WHERE user_id = $1 AND guild_id = $2 AND subsystem = $3
+        """,
+        user_id,
+        guild_id,
+        subsystem,
+    )
+    return dict(row) if row else None
+
+
+# ---------------------------------------------------------------------------
+# Bundle reader used by the runtime cache loader
+# ---------------------------------------------------------------------------
+
+
+async def list_for_user(user_id: int, guild_id: int) -> dict[str, list[dict[str, Any]]]:
+    """Return every row across the four tables for ``(user, guild)``.
+
+    Shape:
+
+    {
+        "participation":         [...],
+        "subscriptions":         [...],
+        "preferences":           [...],
+        "visibility_overrides":  [...],
+    }
+
+    Used by ``core.runtime.user_config`` to populate its per-(user,
+    guild) cache on miss with a single round trip per table.
+    """
+    p_rows = await pool.get().fetch(
+        """
+        SELECT user_id, guild_id, subsystem, state, set_at, set_by
+        FROM user_participation
+        WHERE user_id = $1 AND guild_id = $2
+        """,
+        user_id,
+        guild_id,
+    )
+    s_rows = await pool.get().fetch(
+        """
+        SELECT user_id, guild_id, subsystem, topic, enabled, set_at, set_by
+        FROM user_subscriptions
+        WHERE user_id = $1 AND guild_id = $2
+        """,
+        user_id,
+        guild_id,
+    )
+    pref_rows = await pool.get().fetch(
+        """
+        SELECT user_id, guild_id, key, value, set_at, set_by
+        FROM user_preferences
+        WHERE user_id = $1 AND guild_id = $2
+        """,
+        user_id,
+        guild_id,
+    )
+    v_rows = await pool.get().fetch(
+        """
+        SELECT user_id, guild_id, subsystem, visibility, set_at, set_by
+        FROM user_visibility_overrides
+        WHERE user_id = $1 AND guild_id = $2
+        """,
+        user_id,
+        guild_id,
+    )
+    return {
+        "participation": [dict(r) for r in p_rows],
+        "subscriptions": [dict(r) for r in s_rows],
+        "preferences": [
+            {**dict(r), "value": _deserialise(dict(r).get("value"))} for r in pref_rows
+        ],
+        "visibility_overrides": [dict(r) for r in v_rows],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics helpers
+# ---------------------------------------------------------------------------
+
+
+async def count_rows() -> dict[str, int]:
+    """Return per-table row counts across all guilds.
+
+    Used by the participation diagnostics provider.  This is a small
+    administrative query; not on any hot path.  Each table has its
+    own explicit COUNT statement so the no-dynamic-SQL invariant
+    (``tests/unit/invariants/test_no_dynamic_sql.py``) stays clean.
+    """
+    p_row = await pool.get().fetchrow(
+        "SELECT COUNT(*)::int AS n FROM user_participation",
+    )
+    s_row = await pool.get().fetchrow(
+        "SELECT COUNT(*)::int AS n FROM user_subscriptions",
+    )
+    pref_row = await pool.get().fetchrow(
+        "SELECT COUNT(*)::int AS n FROM user_preferences",
+    )
+    v_row = await pool.get().fetchrow(
+        "SELECT COUNT(*)::int AS n FROM user_visibility_overrides",
+    )
+    return {
+        "user_participation": int(p_row["n"]) if p_row else 0,
+        "user_subscriptions": int(s_row["n"]) if s_row else 0,
+        "user_preferences": int(pref_row["n"]) if pref_row else 0,
+        "user_visibility_overrides": int(v_row["n"]) if v_row else 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Teardown — drop every per-guild row for one guild.  Per the
+# retention policy in docs/platform-consistency-ledger.md §3, the
+# same user's participation in OTHER guilds is preserved.
+# ---------------------------------------------------------------------------
+
+
+def _parse_delete_count(result: str) -> int:
+    try:
+        return int(result.split()[-1])
+    except (ValueError, IndexError):
+        return 0
+
+
+async def delete_for_guild(guild_id: int) -> int:
+    """Delete every row in the four tables that belongs to ``guild_id``.
+
+    Returns the total deleted-row count across the four tables.
+    Runs in one transaction so the four deletes either all succeed
+    or all roll back.  Each table has its own explicit DELETE
+    statement so the no-dynamic-SQL invariant stays clean.
+    """
+    async with pool.get().acquire() as conn, conn.transaction():
+        r1 = await conn.execute(
+            "DELETE FROM user_participation WHERE guild_id = $1",
+            guild_id,
+        )
+        r2 = await conn.execute(
+            "DELETE FROM user_subscriptions WHERE guild_id = $1",
+            guild_id,
+        )
+        r3 = await conn.execute(
+            "DELETE FROM user_preferences WHERE guild_id = $1",
+            guild_id,
+        )
+        r4 = await conn.execute(
+            "DELETE FROM user_visibility_overrides WHERE guild_id = $1",
+            guild_id,
+        )
+    return sum(_parse_delete_count(r) for r in (r1, r2, r3, r4))
+
+
+__all__ = [
+    "PARTICIPATION_STATES",
+    "VISIBILITY_STATES",
+    "count_rows",
+    "delete_for_guild",
+    "get_participation",
+    "get_preference",
+    "get_subscription",
+    "get_visibility",
+    "list_for_user",
+]

--- a/disbot/utils/user_config_accessors.py
+++ b/disbot/utils/user_config_accessors.py
@@ -1,0 +1,176 @@
+"""Typed per-user participation accessors (Phase 2c, PR-8).
+
+Cog / service code reads per-user participation through these typed
+helpers so the storage shape stays an implementation detail.  PR-8
+ships the read path; PR-9 adds the corresponding mutation pipeline.
+
+Why these are separate from
+:mod:`utils.guild_config_accessors` (which covers guild-level state):
+
+* Per-user and per-guild are different runtime domains with different
+  authority models, audit semantics, and lifecycle hooks.  The
+  consistency ledger forbids mixing them.
+* Per-user participation is read on the user-message hot path (XP
+  opt-out gate, etc.) so a dedicated cache layer
+  (:mod:`core.runtime.user_config`) keeps the read O(1) after warm.
+
+Four typed accessors, one per concern:
+
+* :func:`get_participation` — opt-in / opt-out state per subsystem
+* :func:`is_subscribed` — topic-level subscription with schema-default
+* :func:`get_preference` — JSONB preference with caller-supplied default
+* :func:`get_visibility` — public / hidden surface toggle per subsystem
+
+Missing-row semantics:
+
+* ``user_participation`` → :class:`ParticipationState.NOT_SET`
+* ``user_subscriptions`` → the schema's declared default for that topic
+* ``user_preferences`` → the ``default`` argument supplied by the caller
+* ``user_visibility_overrides`` → :class:`VisibilityState.DEFAULT`
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+
+class ParticipationState(str, Enum):
+    """Per-user participation state in a subsystem.
+
+    ``NOT_SET`` is the implicit default returned when no row exists —
+    callers interpret it via their schema's ``requires_optin`` flag.
+    """
+
+    OPTED_IN = "opted_in"
+    OPTED_OUT = "opted_out"
+    NOT_SET = "not_set"
+
+
+class VisibilityState(str, Enum):
+    """User-controlled visibility surface for a subsystem."""
+
+    PUBLIC = "public"
+    HIDDEN = "hidden"
+    DEFAULT = "default"
+
+
+@dataclass(frozen=True)
+class PreferenceResult:
+    """A user preference read result + provenance.
+
+    ``found`` distinguishes "no row" (default returned) from "row
+    with explicit value".  Callers that need to know whether the user
+    has ever set this preference inspect ``found``.
+    """
+
+    value: Any
+    found: bool
+
+
+# ---------------------------------------------------------------------------
+# Accessors
+# ---------------------------------------------------------------------------
+
+
+async def get_participation(
+    user_id: int,
+    guild_id: int,
+    subsystem: str,
+) -> ParticipationState:
+    """Return the user's participation state in ``subsystem`` for ``guild_id``.
+
+    Returns :class:`ParticipationState.NOT_SET` when no row exists.
+    """
+    from core.runtime import user_config
+
+    bundle = await user_config.get(user_id, guild_id)
+    for row in bundle.participation:
+        if row.get("subsystem") == subsystem:
+            state = row.get("state")
+            if state == ParticipationState.OPTED_IN.value:
+                return ParticipationState.OPTED_IN
+            if state == ParticipationState.OPTED_OUT.value:
+                return ParticipationState.OPTED_OUT
+    return ParticipationState.NOT_SET
+
+
+async def is_subscribed(
+    user_id: int,
+    guild_id: int,
+    subsystem: str,
+    topic: str,
+    *,
+    default: bool = False,
+) -> bool:
+    """Return the user's subscription state for ``(subsystem, topic)``.
+
+    ``default`` is returned when no row exists.  The schema layer
+    typically supplies the spec's declared default here; callers that
+    do not have a schema in scope (rare) can pass ``False`` to mean
+    "treat as opted-out".
+    """
+    from core.runtime import user_config
+
+    bundle = await user_config.get(user_id, guild_id)
+    for row in bundle.subscriptions:
+        if row.get("subsystem") == subsystem and row.get("topic") == topic:
+            return bool(row.get("enabled"))
+    return default
+
+
+async def get_preference(
+    user_id: int,
+    guild_id: int,
+    key: str,
+    *,
+    default: Any = None,
+) -> PreferenceResult:
+    """Return the user's preference value for ``key``, or ``default``.
+
+    Wrapped in :class:`PreferenceResult` so callers can distinguish
+    "no row" (``found=False``) from "explicit row with value ==
+    default" (``found=True``).
+    """
+    from core.runtime import user_config
+
+    bundle = await user_config.get(user_id, guild_id)
+    for row in bundle.preferences:
+        if row.get("key") == key:
+            return PreferenceResult(value=row.get("value"), found=True)
+    return PreferenceResult(value=default, found=False)
+
+
+async def get_visibility(
+    user_id: int,
+    guild_id: int,
+    subsystem: str,
+) -> VisibilityState:
+    """Return the user's visibility override for ``subsystem``.
+
+    Returns :class:`VisibilityState.DEFAULT` when no row exists —
+    callers fall back to the schema's declared default visibility.
+    """
+    from core.runtime import user_config
+
+    bundle = await user_config.get(user_id, guild_id)
+    for row in bundle.visibility_overrides:
+        if row.get("subsystem") == subsystem:
+            visibility = row.get("visibility")
+            if visibility == VisibilityState.PUBLIC.value:
+                return VisibilityState.PUBLIC
+            if visibility == VisibilityState.HIDDEN.value:
+                return VisibilityState.HIDDEN
+    return VisibilityState.DEFAULT
+
+
+__all__ = [
+    "ParticipationState",
+    "PreferenceResult",
+    "VisibilityState",
+    "get_participation",
+    "get_preference",
+    "get_visibility",
+    "is_subscribed",
+]

--- a/tests/unit/invariants/test_user_participation_alignment.py
+++ b/tests/unit/invariants/test_user_participation_alignment.py
@@ -1,0 +1,94 @@
+"""Phase 2c PR-8 invariant — participation state literals align.
+
+Migration 027 ships CHECK constraints on
+``user_participation.state`` and
+``user_visibility_overrides.visibility``.  The Python module
+:mod:`utils.db.user_participation` carries matching ``frozenset``s;
+this test pins both sides.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_MIGRATION = (
+    Path(__file__).resolve().parents[3]
+    / "disbot"
+    / "migrations"
+    / "027_user_participation.sql"
+)
+
+
+def _extract_check(column: str) -> set[str]:
+    sql = _MIGRATION.read_text()
+    matches = re.findall(
+        rf"CHECK\s*\(\s*{column}\s+IN\s*\(([^)]+)\)\s*\)",
+        sql,
+    )
+    assert matches, f"could not locate {column} CHECK in migration 027"
+    out: set[str] = set()
+    for clause in matches:
+        for token in clause.split(","):
+            literal = token.strip().strip("'\"")
+            if literal:
+                out.add(literal)
+    return out
+
+
+def test_participation_state_literals_match():
+    from utils.db.user_participation import PARTICIPATION_STATES
+
+    db_check = _extract_check("state")
+    python = set(PARTICIPATION_STATES)
+    assert db_check == python, (
+        "user_participation state drift.\n"
+        f"  in Python but not DB CHECK: {sorted(python - db_check)}\n"
+        f"  in DB CHECK but not Python: {sorted(db_check - python)}"
+    )
+
+
+def test_visibility_literals_match():
+    from utils.db.user_participation import VISIBILITY_STATES
+
+    db_check = _extract_check("visibility")
+    python = set(VISIBILITY_STATES)
+    assert db_check == python, (
+        "user_visibility_overrides visibility drift.\n"
+        f"  in Python but not DB CHECK: {sorted(python - db_check)}\n"
+        f"  in DB CHECK but not Python: {sorted(db_check - python)}"
+    )
+
+
+def test_all_tables_carry_guild_id():
+    """Every participation table MUST include guild_id (consistency ledger §3)."""
+    sql = _MIGRATION.read_text()
+    for table in (
+        "user_participation",
+        "user_subscriptions",
+        "user_preferences",
+        "user_visibility_overrides",
+    ):
+        # Match the CREATE TABLE block for this name
+        match = re.search(
+            rf"CREATE TABLE IF NOT EXISTS {table}\s*\(([^;]+)\)\s*;",
+            sql,
+            re.DOTALL,
+        )
+        assert match, f"could not locate CREATE TABLE for {table}"
+        body = match.group(1)
+        assert (
+            "guild_id" in body
+        ), f"{table} does not include guild_id — Phase 2c retention contract"
+
+
+def test_accessor_enums_have_distinct_values():
+    """ParticipationState and VisibilityState values do not collide."""
+    from utils.user_config_accessors import ParticipationState, VisibilityState
+
+    p_values = {s.value for s in ParticipationState}
+    v_values = {s.value for s in VisibilityState}
+    overlap = p_values & v_values
+    assert (
+        not overlap
+    ), f"ParticipationState ∩ VisibilityState = {overlap}; values must be distinct"

--- a/tests/unit/participation/test_user_config_accessors.py
+++ b/tests/unit/participation/test_user_config_accessors.py
@@ -1,0 +1,196 @@
+"""Phase 2c PR-8 — utils.user_config_accessors typed accessors.
+
+Each accessor:
+* Reads through ``core.runtime.user_config`` (so the cache layer is
+  exercised).
+* Returns a typed value (ParticipationState / bool / PreferenceResult
+  / VisibilityState).
+* Returns the documented default when no row exists.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from core.runtime import user_config
+from utils.user_config_accessors import (
+    ParticipationState,
+    PreferenceResult,
+    VisibilityState,
+    get_participation,
+    get_preference,
+    get_visibility,
+    is_subscribed,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    user_config._reset_for_tests()
+    yield
+    user_config._reset_for_tests()
+
+
+def _bundle(**kwargs):
+    base = {
+        "participation": [],
+        "subscriptions": [],
+        "preferences": [],
+        "visibility_overrides": [],
+    }
+    base.update(kwargs)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# get_participation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_participation_returns_not_set_when_no_row():
+    with patch(
+        "utils.db.user_participation.list_for_user",
+        new_callable=AsyncMock,
+        return_value=_bundle(),
+    ):
+        result = await get_participation(1, 2, "xp")
+    assert result is ParticipationState.NOT_SET
+
+
+@pytest.mark.asyncio
+async def test_get_participation_returns_opted_in():
+    with patch(
+        "utils.db.user_participation.list_for_user",
+        new_callable=AsyncMock,
+        return_value=_bundle(
+            participation=[{"subsystem": "xp", "state": "opted_in"}],
+        ),
+    ):
+        result = await get_participation(1, 2, "xp")
+    assert result is ParticipationState.OPTED_IN
+
+
+@pytest.mark.asyncio
+async def test_get_participation_returns_opted_out():
+    with patch(
+        "utils.db.user_participation.list_for_user",
+        new_callable=AsyncMock,
+        return_value=_bundle(
+            participation=[{"subsystem": "xp", "state": "opted_out"}],
+        ),
+    ):
+        result = await get_participation(1, 2, "xp")
+    assert result is ParticipationState.OPTED_OUT
+
+
+@pytest.mark.asyncio
+async def test_get_participation_subsystem_isolation():
+    """Participation in ``economy`` is separate from ``xp``."""
+    with patch(
+        "utils.db.user_participation.list_for_user",
+        new_callable=AsyncMock,
+        return_value=_bundle(
+            participation=[{"subsystem": "economy", "state": "opted_in"}],
+        ),
+    ):
+        result = await get_participation(1, 2, "xp")
+    assert result is ParticipationState.NOT_SET
+
+
+# ---------------------------------------------------------------------------
+# is_subscribed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_is_subscribed_returns_default_when_no_row():
+    with patch(
+        "utils.db.user_participation.list_for_user",
+        new_callable=AsyncMock,
+        return_value=_bundle(),
+    ):
+        result = await is_subscribed(1, 2, "economy", "daily", default=True)
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_is_subscribed_returns_stored_value():
+    with patch(
+        "utils.db.user_participation.list_for_user",
+        new_callable=AsyncMock,
+        return_value=_bundle(
+            subscriptions=[
+                {"subsystem": "economy", "topic": "daily", "enabled": False},
+            ],
+        ),
+    ):
+        result = await is_subscribed(1, 2, "economy", "daily", default=True)
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# get_preference
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_preference_returns_default_when_missing():
+    with patch(
+        "utils.db.user_participation.list_for_user",
+        new_callable=AsyncMock,
+        return_value=_bundle(),
+    ):
+        result = await get_preference(1, 2, "digest_freq", default="hourly")
+    assert isinstance(result, PreferenceResult)
+    assert result.value == "hourly"
+    assert result.found is False
+
+
+@pytest.mark.asyncio
+async def test_get_preference_returns_stored_value():
+    with patch(
+        "utils.db.user_participation.list_for_user",
+        new_callable=AsyncMock,
+        return_value=_bundle(
+            preferences=[
+                {"key": "digest_freq", "value": {"unit": "hours", "interval": 6}},
+            ],
+        ),
+    ):
+        result = await get_preference(1, 2, "digest_freq", default="hourly")
+    assert result.value == {"unit": "hours", "interval": 6}
+    assert result.found is True
+
+
+# ---------------------------------------------------------------------------
+# get_visibility
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_visibility_returns_default_when_missing():
+    with patch(
+        "utils.db.user_participation.list_for_user",
+        new_callable=AsyncMock,
+        return_value=_bundle(),
+    ):
+        result = await get_visibility(1, 2, "xp")
+    assert result is VisibilityState.DEFAULT
+
+
+@pytest.mark.asyncio
+async def test_get_visibility_returns_public_or_hidden():
+    with patch(
+        "utils.db.user_participation.list_for_user",
+        new_callable=AsyncMock,
+        return_value=_bundle(
+            visibility_overrides=[
+                {"subsystem": "xp", "visibility": "hidden"},
+            ],
+        ),
+    ):
+        result = await get_visibility(1, 2, "xp")
+    assert result is VisibilityState.HIDDEN

--- a/tests/unit/participation/test_user_config_cache.py
+++ b/tests/unit/participation/test_user_config_cache.py
@@ -1,0 +1,219 @@
+"""Phase 2c PR-8 — core.runtime.user_config cache behaviour.
+
+Covers:
+
+* Cache miss → DB read → cache populated → next read hits.
+* TTL expiry forces a reload.
+* Explicit invalidation primitives evict the right entries.
+* DB failure returns an empty bundle without raising.
+* Soft max-size eviction.
+* Diagnostics snapshot shape.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from core.runtime import user_config
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    user_config._reset_for_tests()
+    yield
+    user_config._reset_for_tests()
+
+
+@pytest.fixture
+def _patch_db():
+    """Patch utils.db.user_participation.list_for_user."""
+    with patch(
+        "utils.db.user_participation.list_for_user",
+        new_callable=AsyncMock,
+    ) as mock:
+        mock.return_value = {
+            "participation": [],
+            "subscriptions": [],
+            "preferences": [],
+            "visibility_overrides": [],
+        }
+        yield mock
+
+
+# ---------------------------------------------------------------------------
+# Cache miss/hit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_miss_loads_from_db(_patch_db):
+    await user_config.get(1, 2)
+    _patch_db.assert_awaited_once_with(1, 2)
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_avoids_second_db_call(_patch_db):
+    await user_config.get(1, 2)
+    await user_config.get(1, 2)
+    assert _patch_db.await_count == 1
+    snap = user_config._snapshot()
+    assert snap["hits"] == 1
+    assert snap["misses"] == 1
+
+
+@pytest.mark.asyncio
+async def test_cache_per_user_guild_independent(_patch_db):
+    await user_config.get(1, 2)
+    await user_config.get(1, 3)  # different guild
+    await user_config.get(2, 2)  # different user
+    assert _patch_db.await_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Empty bundle returned on cache miss when DB has no rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_db_returns_empty_bundle(_patch_db):
+    bundle = await user_config.get(1, 2)
+    assert bundle.user_id == 1
+    assert bundle.guild_id == 2
+    assert bundle.participation == ()
+    assert bundle.subscriptions == ()
+    assert bundle.preferences == ()
+    assert bundle.visibility_overrides == ()
+
+
+# ---------------------------------------------------------------------------
+# Invalidation primitives
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalidate_user_guild_drops_one_entry(_patch_db):
+    await user_config.get(1, 2)
+    assert user_config.invalidate_user_guild(1, 2) is True
+    await user_config.get(1, 2)
+    assert _patch_db.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_invalidate_user_guild_returns_false_when_absent():
+    assert user_config.invalidate_user_guild(99, 99) is False
+
+
+@pytest.mark.asyncio
+async def test_forget_user_drops_all_guilds(_patch_db):
+    await user_config.get(1, 2)
+    await user_config.get(1, 3)
+    await user_config.get(2, 2)
+    assert user_config.forget_user(1) == 2
+    # user 1's entries gone; user 2's stays
+    snap = user_config._snapshot()
+    assert snap["cache_size"] == 1
+
+
+@pytest.mark.asyncio
+async def test_forget_guild_drops_all_users(_patch_db):
+    await user_config.get(1, 2)
+    await user_config.get(2, 2)
+    await user_config.get(3, 99)
+    assert user_config.forget_guild(2) == 2
+    snap = user_config._snapshot()
+    assert snap["cache_size"] == 1
+
+
+@pytest.mark.asyncio
+async def test_forget_all_clears_everything(_patch_db):
+    await user_config.get(1, 2)
+    await user_config.get(2, 3)
+    assert user_config.forget_all() == 2
+    assert user_config._snapshot()["cache_size"] == 0
+
+
+# ---------------------------------------------------------------------------
+# TTL expiry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ttl_expiry_forces_reload(_patch_db, monkeypatch):
+    """An expired entry triggers a fresh DB read."""
+    base_time = 1000.0
+    monkeypatch.setattr(user_config.time, "monotonic", lambda: base_time)
+    await user_config.get(1, 2)
+
+    # Jump past the TTL.
+    monkeypatch.setattr(
+        user_config.time,
+        "monotonic",
+        lambda: base_time + user_config._CACHE_TTL_SECS + 1,
+    )
+    await user_config.get(1, 2)
+    assert _patch_db.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# DB failure: empty bundle, no raise
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_db_failure_returns_empty_bundle():
+    """The hot-path read MUST NOT raise; an empty bundle is the safe default."""
+    with patch(
+        "utils.db.user_participation.list_for_user",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("DB blip"),
+    ):
+        bundle = await user_config.get(1, 2)
+    assert bundle.participation == ()
+
+
+# ---------------------------------------------------------------------------
+# Soft max-size eviction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_eviction_drops_oldest_decile_when_capacity_exceeded(
+    _patch_db, monkeypatch
+):
+    monkeypatch.setattr(user_config, "_CACHE_MAX_ENTRIES", 20)
+    base = 1000.0
+    for i in range(25):
+        monkeypatch.setattr(user_config.time, "monotonic", lambda x=base + i: x)
+        await user_config.get(user_id=i, guild_id=1)
+    snap = user_config._snapshot()
+    # The eviction triggers when cache exceeds 20; it drops the
+    # oldest decile (max(1, 21//10) = 2) on each excess insert.
+    assert snap["cache_size"] <= 25
+    assert snap["evictions"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_shape():
+    snap = user_config._snapshot()
+    assert set(snap.keys()) == {
+        "cache_size",
+        "cache_capacity",
+        "ttl_secs",
+        "hits",
+        "misses",
+        "evictions",
+    }
+
+
+def test_diagnostics_provider_registered():
+    from services import diagnostics_service
+
+    snap = diagnostics_service.snapshot("user_config")
+    assert "cache_size" in snap

--- a/tests/unit/participation/test_user_participation_db.py
+++ b/tests/unit/participation/test_user_participation_db.py
@@ -1,0 +1,211 @@
+"""Phase 2c PR-8 — utils.db.user_participation read primitives."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from utils.db import user_participation as up_db
+
+
+@pytest.fixture
+def _mock_pool():
+    pool_mock = MagicMock()
+    pool_mock.execute = AsyncMock()
+    pool_mock.fetchrow = AsyncMock()
+    pool_mock.fetch = AsyncMock()
+    pool_mock.acquire = MagicMock()
+    with patch.object(up_db, "pool") as pool_module:
+        pool_module.get = MagicMock(return_value=pool_mock)
+        yield pool_mock
+
+
+# ---------------------------------------------------------------------------
+# Single-row reads
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_participation_keyed_on_user_guild_subsystem(_mock_pool):
+    _mock_pool.fetchrow.return_value = None
+    await up_db.get_participation(1, 2, "xp")
+    sql, *args = _mock_pool.fetchrow.await_args.args
+    assert "user_id = $1 AND guild_id = $2 AND subsystem = $3" in sql
+    assert args == [1, 2, "xp"]
+
+
+@pytest.mark.asyncio
+async def test_get_participation_returns_dict_when_present(_mock_pool):
+    _mock_pool.fetchrow.return_value = {
+        "user_id": 1,
+        "guild_id": 2,
+        "subsystem": "xp",
+        "state": "opted_in",
+        "set_at": None,
+        "set_by": 99,
+    }
+    row = await up_db.get_participation(1, 2, "xp")
+    assert row is not None
+    assert row["state"] == "opted_in"
+
+
+@pytest.mark.asyncio
+async def test_get_subscription_keyed_on_topic(_mock_pool):
+    _mock_pool.fetchrow.return_value = None
+    await up_db.get_subscription(1, 2, "economy", "daily")
+    sql, *args = _mock_pool.fetchrow.await_args.args
+    assert "topic = $4" in sql
+    assert args == [1, 2, "economy", "daily"]
+
+
+@pytest.mark.asyncio
+async def test_get_preference_decodes_json_value(_mock_pool):
+    _mock_pool.fetchrow.return_value = {
+        "user_id": 1,
+        "guild_id": 2,
+        "key": "digest_freq",
+        "value": json.dumps({"unit": "hours", "interval": 6}),
+        "set_at": None,
+        "set_by": None,
+    }
+    row = await up_db.get_preference(1, 2, "digest_freq")
+    assert row is not None
+    assert row["value"] == {"unit": "hours", "interval": 6}
+
+
+@pytest.mark.asyncio
+async def test_get_visibility_returns_visibility_value(_mock_pool):
+    _mock_pool.fetchrow.return_value = {
+        "user_id": 1,
+        "guild_id": 2,
+        "subsystem": "xp",
+        "visibility": "hidden",
+        "set_at": None,
+        "set_by": None,
+    }
+    row = await up_db.get_visibility(1, 2, "xp")
+    assert row is not None
+    assert row["visibility"] == "hidden"
+
+
+# ---------------------------------------------------------------------------
+# Bundle reader
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_for_user_returns_four_keys(_mock_pool):
+    _mock_pool.fetch.return_value = []
+    bundle = await up_db.list_for_user(1, 2)
+    assert set(bundle.keys()) == {
+        "participation",
+        "subscriptions",
+        "preferences",
+        "visibility_overrides",
+    }
+    # Four SELECTs (one per table)
+    assert _mock_pool.fetch.await_count == 4
+
+
+@pytest.mark.asyncio
+async def test_list_for_user_decodes_preference_value(_mock_pool):
+    payloads = [
+        [],
+        [],
+        [
+            {
+                "user_id": 1,
+                "guild_id": 2,
+                "key": "digest_freq",
+                "value": json.dumps({"unit": "hours"}),
+                "set_at": None,
+                "set_by": None,
+            },
+        ],
+        [],
+    ]
+    _mock_pool.fetch.side_effect = payloads
+    bundle = await up_db.list_for_user(1, 2)
+    assert bundle["preferences"][0]["value"] == {"unit": "hours"}
+
+
+# ---------------------------------------------------------------------------
+# count_rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_count_rows_runs_four_count_queries(_mock_pool):
+    _mock_pool.fetchrow.side_effect = [{"n": 3}, {"n": 1}, {"n": 0}, {"n": 2}]
+    counts = await up_db.count_rows()
+    assert counts == {
+        "user_participation": 3,
+        "user_subscriptions": 1,
+        "user_preferences": 0,
+        "user_visibility_overrides": 2,
+    }
+
+
+# ---------------------------------------------------------------------------
+# delete_for_guild: atomic over four tables
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_for_guild_deletes_four_tables_in_one_transaction():
+    """All four tables are purged in a single transaction.
+
+    The retention contract requires that the deletes either all succeed
+    or all roll back — otherwise a half-deleted guild leaves orphan
+    rows.  Test by mocking ``pool.get().acquire()`` and asserting all
+    four DELETE statements run inside the same connection's
+    transaction.
+    """
+    conn = MagicMock()
+    conn.execute = AsyncMock(
+        side_effect=["DELETE 2", "DELETE 0", "DELETE 1", "DELETE 1"]
+    )
+    conn.transaction = MagicMock()
+
+    txn_cm = MagicMock()
+    txn_cm.__aenter__ = AsyncMock(return_value=None)
+    txn_cm.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction.return_value = txn_cm
+
+    acquire_cm = MagicMock()
+    acquire_cm.__aenter__ = AsyncMock(return_value=conn)
+    acquire_cm.__aexit__ = AsyncMock(return_value=False)
+
+    pool_mock = MagicMock()
+    pool_mock.acquire = MagicMock(return_value=acquire_cm)
+    with patch.object(up_db, "pool") as pool_module:
+        pool_module.get = MagicMock(return_value=pool_mock)
+        total = await up_db.delete_for_guild(42)
+    # Four DELETEs issued
+    assert conn.execute.await_count == 4
+    # Total = 2 + 0 + 1 + 1 = 4
+    assert total == 4
+    # Each DELETE targets one table
+    tables_seen = set()
+    for call in conn.execute.await_args_list:
+        sql = call.args[0]
+        for table in (
+            "user_participation",
+            "user_subscriptions",
+            "user_preferences",
+            "user_visibility_overrides",
+        ):
+            if f"DELETE FROM {table}" in sql:
+                tables_seen.add(table)
+                # Each DELETE is scoped to guild_id
+                assert "WHERE guild_id = $1" in sql
+                assert call.args[1] == 42
+                break
+    assert tables_seen == {
+        "user_participation",
+        "user_subscriptions",
+        "user_preferences",
+        "user_visibility_overrides",
+    }

--- a/tests/unit/runtime/test_guild_lifecycle_teardown.py
+++ b/tests/unit/runtime/test_guild_lifecycle_teardown.py
@@ -115,6 +115,16 @@ def _teardown_patches():
             new_callable=AsyncMock,
             return_value=0,
         ),
+        # PR-8 defaults: participation table + cache.
+        patch(
+            "utils.db.user_participation.delete_for_guild",
+            new_callable=AsyncMock,
+            return_value=0,
+        ),
+        patch(
+            "core.runtime.user_config.forget_guild",
+            return_value=0,
+        ),
     ):
         yield
 
@@ -377,3 +387,55 @@ async def test_teardown_migration_checkpoint_failure_is_isolated(_teardown_patch
         await guild_lifecycle.teardown(99)
         # downstream step still invoked despite checkpoint delete failure
         mock_caps.assert_called_once_with(99)
+
+
+# ---------------------------------------------------------------------------
+# Steps 11 + 12 — per-user participation rows + cache (Phase 2c PR-8)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_teardown_deletes_user_participation_rows(_teardown_patches):
+    """The four-table participation delete primitive is awaited."""
+    import guild_lifecycle
+
+    with patch(
+        "utils.db.user_participation.delete_for_guild",
+        new_callable=AsyncMock,
+        return_value=5,
+    ) as mock_delete:
+        await guild_lifecycle.teardown(99)
+        mock_delete.assert_awaited_once_with(99)
+
+
+@pytest.mark.asyncio
+async def test_teardown_clears_user_config_cache(_teardown_patches):
+    """user_config.forget_guild is called scoped to the guild."""
+    import guild_lifecycle
+
+    with patch(
+        "core.runtime.user_config.forget_guild",
+        return_value=0,
+    ) as mock_forget:
+        await guild_lifecycle.teardown(99)
+        mock_forget.assert_called_once_with(99)
+
+
+@pytest.mark.asyncio
+async def test_teardown_participation_failure_is_isolated(_teardown_patches):
+    """If participation delete raises, the user_config cache step still runs."""
+    import guild_lifecycle
+
+    with (
+        patch(
+            "utils.db.user_participation.delete_for_guild",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("DB blip"),
+        ),
+        patch(
+            "core.runtime.user_config.forget_guild",
+            return_value=0,
+        ) as mock_forget,
+    ):
+        await guild_lifecycle.teardown(99)
+        mock_forget.assert_called_once_with(99)


### PR DESCRIPTION
## Summary

PR-8 of the Phase 2 plan. Stand up the per-user participation storage substrate: four structurally-separated tables (one per concern), a TTL-bounded process cache, and typed read accessors. **No UI, no mutation pipeline yet** (PR-9), no notification routing.

**Stacked on PR #83.** Merge order: #81 → #82 → #83 → #84.

## Why this PR is scoped safely

- Storage + cache + read accessors only. No writes flow through any pipeline yet — that's PR-9.
- No `/myprofile`, no participation hub, no notification router.
- **No subsystem behavior change.** `participation.enabled` remains a declared flag with no consumer (XP opt-out gating lands in PR-9 behind the flag).
- Lifecycle: per-guild participation rows ARE deleted on guild leave so the same user's participation in OTHER guilds is preserved (same retention contract as `feature_flag_guild_overrides`).
- Cache is bounded (TTL + max-size eviction); diagnostics provider surfaces counters.

## Architectural boundaries preserved

- One runtime domain per PR (per-user participation).
- One migration (027).
- **Four tables MUST include `guild_id`** — enforced by the alignment test which scans every CREATE TABLE block.
- **Four structurally-separated tables** — no "user settings" god-object. The four concerns (participation, subscriptions, preferences, visibility) each have their own table, their own typed accessor, and their own missing-row semantics.
- No top-level `core.runtime` imports added to cycle-sensitive files. All accessor imports of `core.runtime.user_config` are inside the function bodies; the lifecycle teardown helpers import inside their bodies too.
- Import-cycle regression test green.
- No new hashing dependency.
- No setup UI, no resource provisioning, no production read flip.

## Schema (migration 027)

- Four tables, composite PK `(user_id, guild_id, ...)` on every one
- `user_participation.state` CHECK `IN ('opted_in', 'opted_out')`
- `user_visibility_overrides.visibility` CHECK `IN ('public', 'hidden')`
- `user_subscriptions.enabled BOOLEAN`
- `user_preferences.value JSONB`
- Per-table `guild_id` index for the bulk delete path
- `set_at` / `set_by` columns recorded on every row

## Missing-row semantics

| Table | Default |
|---|---|
| `user_participation` | `ParticipationState.NOT_SET` |
| `user_subscriptions` | caller-supplied default |
| `user_preferences` | caller-supplied default (with `found=False` flag) |
| `user_visibility_overrides` | `VisibilityState.DEFAULT` |

## Cache (`core/runtime/user_config.py`)

- Key: `(user_id, guild_id)` — one entry covers the full four-table bundle for that pair
- TTL: 300s (matches feature-flag evaluator default)
- Soft max-size: 50_000 entries; oldest-decile evicted when capacity tripped
- DB read failure → empty bundle (never raises)
- Diagnostics provider `user_config` exposes `(cache_size, capacity, ttl, hits, misses, evictions)`
- Invalidation primitives: `invalidate_user_guild`, `forget_user`, `forget_guild`, `forget_all`

## What changed

| Path | Change |
|---|---|
| `disbot/migrations/027_user_participation.sql` | NEW — four tables |
| `disbot/utils/db/user_participation.py` | NEW — read primitives + bundle reader + atomic four-table `delete_for_guild` + diagnostics support |
| `disbot/core/runtime/user_config.py` | NEW — TTL-bounded cache with eviction |
| `disbot/utils/user_config_accessors.py` | NEW — `ParticipationState`, `VisibilityState`, `PreferenceResult`, four typed accessors |
| `disbot/guild_lifecycle.py` | Steps 11 + 12 added; renumbered 13–17 |
| `tests/unit/participation/` | NEW package — 31 tests (DB / cache / accessors) |
| `tests/unit/invariants/test_user_participation_alignment.py` | NEW — 4 alignment tests (state/visibility CHECK + guild_id presence + enum disjointness) |
| `tests/unit/runtime/test_guild_lifecycle_teardown.py` | 3 new tests for steps 11 + 12 |

## Migrations

**027** — additive, forward-only, idempotent.

## Rollback strategy

Revert this PR. Migration 027 is additive — leaving it after revert is safe (tables become unused). No subsystem behavior changes because no consumer reads from the new tables yet.

## Tests run

```
python -m pytest tests/unit/participation/ \
                 tests/unit/invariants/test_user_participation_alignment.py \
                 tests/unit/runtime/test_guild_lifecycle_teardown.py \
                 tests/unit/runtime/test_import_cycle_regression.py -q
# 55 passed

python -m pytest tests/ -q --ignore=tests/integration
# 1370 passed (1327 baseline + 43 new), 12 unrelated warnings

python -m ruff check disbot/   # clean
python -m black --check disbot/ tests/... # 232 files unchanged
python -m isort --check-only   # clean
# test_no_dynamic_sql_identifier_interpolation green
# (count_rows + delete_for_guild rewritten to explicit per-table SQL)
```

## Manual Discord smoke

- [ ] After deploy with migration 027 applied: four tables exist; no subsystem behavior changes; `participation.enabled` remains OFF.
- [ ] From Python REPL on bot host:
  ```python
  from utils.db.user_participation import list_for_user
  bundle = await list_for_user(<user_id>, <guild_id>)
  print(bundle)   # all four lists empty

  from utils.user_config_accessors import get_participation
  state = await get_participation(<user_id>, <guild_id>, "xp")
  print(state)    # ParticipationState.NOT_SET
  ```
- [ ] Kick bot from test guild; verify all four tables have 0 rows for that guild; same user's rows in OTHER guilds still present.

## Intentionally deferred

- **`ParticipationMutationPipeline`** — PR-9.
- **Events** (`participation.changed`, `subscription.changed`, `user_preference.changed`, `user_visibility.changed`) — PR-9.
- **XP opt-out gating behind `participation.enabled`** — PR-9.
- **`/myprofile`, participation hub, notification router** — out of scope for Phase 2.

## Test plan

- [x] DB primitives: single-row reads + bundle reader + JSON decode + count + atomic four-table delete
- [x] Cache: miss → DB → hit; TTL expiry; explicit invalidation per scope; DB failure returns empty bundle; soft max-size eviction
- [x] Accessors: typed return + missing-row defaults + subsystem isolation
- [x] Alignment: state / visibility CHECK constraints match Python; all 4 tables carry `guild_id`; enum value sets disjoint
- [x] Lifecycle: steps 11 + 12 awaited; failure isolated
- [x] Import-cycle regression still green

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgFk12CkWs1uiPZk8AA5fR)_