### PR TITLE
Phase 2 integration: land #82 + #83 + #84 onto main

### DIFF
--- a/disbot/core/runtime/config_arbitration.py
+++ b/disbot/core/runtime/config_arbitration.py
@@ -326,6 +326,141 @@ async def _read_legacy(settings_db, guild_id: int, legacy_key: str) -> Any | Non
 
 
 # ---------------------------------------------------------------------------
+# Type-coercion helpers for per-subsystem accessors
+# ---------------------------------------------------------------------------
+#
+# ``read_config`` returns ``int|None`` from the binding path and
+# ``str|None`` from the legacy path.  The per-subsystem accessors
+# below normalize to a single shape (matching what existing callers
+# expect) so cog read-sites don't have to branch on
+# ``isinstance(result.value, int)``.
+
+
+def _coerce_to_int(result: ConfigReadResult) -> ConfigReadResult:
+    """Return a new ``ConfigReadResult`` with ``value`` normalized to ``int|None``.
+
+    A legacy string that doesn't parse as an int is converted to
+    ``None`` and recorded in ``diagnostics`` — the caller treats it
+    as "missing" rather than crashing on the type mismatch.
+    """
+    value = result.value
+    if value is None:
+        return result
+    if isinstance(value, int):
+        return result
+    if isinstance(value, str):
+        try:
+            return ConfigReadResult(
+                value=int(value),
+                source=result.source,
+                binding_status=result.binding_status,
+                flag_state=result.flag_state,
+                diagnostics=result.diagnostics,
+            )
+        except ValueError:
+            return ConfigReadResult(
+                value=None,
+                source="missing",
+                binding_status=result.binding_status,
+                flag_state=result.flag_state,
+                diagnostics=[
+                    *result.diagnostics,
+                    f"legacy value {value!r} could not be parsed as int",
+                ],
+            )
+    # Unknown type — coerce to None.
+    return ConfigReadResult(
+        value=None,
+        source="missing",
+        binding_status=result.binding_status,
+        flag_state=result.flag_state,
+        diagnostics=[
+            *result.diagnostics,
+            f"unexpected value type {type(value).__name__}",
+        ],
+    )
+
+
+def _coerce_to_str(result: ConfigReadResult) -> ConfigReadResult:
+    """Return a new ``ConfigReadResult`` with ``value`` normalized to ``str|None``.
+
+    A legacy empty string is already filtered to ``None`` by
+    :func:`_read_legacy`, so this helper only needs to stringify
+    ints from the binding path.
+    """
+    value = result.value
+    if value is None or isinstance(value, str):
+        return result
+    return ConfigReadResult(
+        value=str(value),
+        source=result.source,
+        binding_status=result.binding_status,
+        flag_state=result.flag_state,
+        diagnostics=result.diagnostics,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-subsystem convenience accessors (PR-7).
+#
+# These are the ONLY legitimate read sites for migrated keys in cog/
+# service/governance code.  Direct calls to
+# ``is_enabled("bindings.primary", ...)`` outside this module are
+# forbidden by ``tests/unit/invariants/test_no_direct_bindings_primary_branch.py``.
+
+
+async def get_xp_announce_channel(guild_id: int) -> ConfigReadResult:
+    """Resolve the XP announce channel via the arbitration ladder.
+
+    Return shape: ``ConfigReadResult.value`` is ``str|None`` (matches
+    the existing ``XpConfig.announce_channel`` shape).  A binding-side
+    snowflake int is stringified; an unparseable legacy value is
+    returned as the raw string.
+    """
+    result = await read_config(
+        guild_id=guild_id,
+        subsystem="xp",
+        binding_name="announce_channel",
+        legacy_key="xp_announce_channel",
+        binding_kind="channel",
+    )
+    return _coerce_to_str(result)
+
+
+async def get_economy_log_channel(guild_id: int) -> ConfigReadResult:
+    """Resolve the economy log channel; value normalized to ``int|None``.
+
+    Consumers (``utils.helpers.post_log_embed``) then do
+    ``guild.get_channel(value)``.  An unparseable legacy value becomes
+    ``None`` with a diagnostic explaining the parse failure.
+    """
+    result = await read_config(
+        guild_id=guild_id,
+        subsystem="economy",
+        binding_name="log_channel",
+        legacy_key="economy_log_channel",
+        binding_kind="channel",
+    )
+    return _coerce_to_int(result)
+
+
+async def get_trusted_tier_role(guild_id: int) -> ConfigReadResult:
+    """Resolve the governance trusted-tier role; value normalized to ``int|None``.
+
+    Consumers (``governance.resolver._resolve_member_tier``) check
+    membership of this role id against ``ctx.role_ids``.
+    """
+    result = await read_config(
+        guild_id=guild_id,
+        subsystem="governance",
+        binding_name="trusted_role",
+        legacy_key="trusted_tier_role_id",
+        binding_kind="role",
+    )
+    return _coerce_to_int(result)
+
+
+# ---------------------------------------------------------------------------
 # Diagnostics provider registration (registers at import time)
 # ---------------------------------------------------------------------------
 
@@ -349,5 +484,8 @@ _register_diagnostics()
 __all__ = [
     "ConfigReadResult",
     "counters_snapshot",
+    "get_economy_log_channel",
+    "get_trusted_tier_role",
+    "get_xp_announce_channel",
     "read_config",
 ]

--- a/disbot/core/runtime/user_config.py
+++ b/disbot/core/runtime/user_config.py
@@ -1,0 +1,254 @@
+"""Per-user participation cache — Phase 2c (PR-8).
+
+Process-local cache over the four participation tables shipped in
+migration 027.  Mirrors the design of ``core.runtime.guild_config``:
+TTL-bounded entries with explicit invalidation primitives so PR-9's
+``ParticipationMutationPipeline`` can drop the stale entry after every
+write.
+
+State class (per ``docs/architecture.md`` §"State classification"):
+
+  **cached config (derived)** — the DB row is the canonical state.
+  Cache entries may be evicted at any time.
+
+Cache key shape: ``(user_id, guild_id)``.  One entry caches the full
+four-table bundle for that ``(user, guild)`` pair so subsystem
+accessors (``get_participation``, ``is_subscribed``, etc.) hit the
+cache once and dispatch internally.
+
+Cache eviction:
+
+* **TTL** — each entry expires after ``_CACHE_TTL_SECS`` (default 300s,
+  same window as the feature-flag evaluator).
+* **Max size** — at most ``_CACHE_MAX_ENTRIES`` entries (default 50_000).
+  Hit the cap → drop the oldest entries by ``inserted_at`` ordering.
+  This is a coarse LRU-ish approximation; a real LRU is unnecessary
+  because the working set is dominated by recently active users.
+* **Explicit invalidation** — :func:`forget_user`,
+  :func:`invalidate_user_guild`, :func:`forget_guild`,
+  :func:`forget_all`.  PR-9 calls ``invalidate_user_guild`` after every
+  mutation.
+* **Guild teardown** — :func:`forget_guild` is the hook called from
+  ``guild_lifecycle.teardown``.
+
+This module is read-only against the DB.  Writes live in PR-9's
+mutation pipeline; the pipeline calls back into this module's
+invalidation primitives.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger("bot.user_config")
+
+# 5-minute TTL matches the feature-flag evaluator default — close
+# enough that a user's mutation is reflected within one cache cycle
+# even without explicit invalidation, but long enough to absorb the
+# read pressure from any single interaction.
+_CACHE_TTL_SECS = 300.0
+
+# Soft upper bound on cache size.  Each entry holds the JSON-decoded
+# bundle for one (user, guild) pair.  50k entries × ~1 KB each is
+# ~50 MB, comfortably within process memory for any practical
+# deployment.
+_CACHE_MAX_ENTRIES = 50_000
+
+
+@dataclass(frozen=True)
+class CachedUserConfig:
+    """One cached (user, guild) bundle.
+
+    The fields mirror what ``utils.db.user_participation.list_for_user``
+    returns.  Stored as plain dicts so the cache is JSON-friendly
+    (and so the diagnostics provider can render them).
+    """
+
+    user_id: int
+    guild_id: int
+    participation: tuple[dict[str, Any], ...] = field(default_factory=tuple)
+    subscriptions: tuple[dict[str, Any], ...] = field(default_factory=tuple)
+    preferences: tuple[dict[str, Any], ...] = field(default_factory=tuple)
+    visibility_overrides: tuple[dict[str, Any], ...] = field(default_factory=tuple)
+
+
+# Cache value: (CachedUserConfig, expires_at_monotonic, inserted_at_monotonic).
+_CACHE: dict[tuple[int, int], tuple[CachedUserConfig, float, float]] = {}
+
+# Metric counters — diagnostics provider snapshots these.
+_HITS = 0
+_MISSES = 0
+_EVICTIONS = 0
+
+
+def _evict_for_capacity() -> None:
+    """Drop the oldest entries when ``_CACHE`` exceeds the soft cap.
+
+    Coarse, not strict LRU — drops the bottom decile by
+    ``inserted_at`` whenever the cap trips.  Cheaper than maintaining
+    an ordered structure and good enough for participation, which is
+    a low-volume read pattern compared to hot-path message dispatch.
+    """
+    global _EVICTIONS
+    if len(_CACHE) <= _CACHE_MAX_ENTRIES:
+        return
+    sorted_keys = sorted(
+        _CACHE.keys(),
+        key=lambda k: _CACHE[k][2],  # inserted_at
+    )
+    drop_count = max(1, len(_CACHE) // 10)
+    for key in sorted_keys[:drop_count]:
+        _CACHE.pop(key, None)
+        _EVICTIONS += 1
+
+
+async def get(user_id: int, guild_id: int) -> CachedUserConfig:
+    """Return the cached bundle for ``(user, guild)``; load on miss.
+
+    Returns an empty :class:`CachedUserConfig` (all tuples empty) when
+    the user has no rows in any of the four tables — that's the
+    "not yet configured anything" state.  Typed accessors in
+    :mod:`utils.user_config_accessors` interpret an empty bundle as
+    "every concern returns its declared default".
+    """
+    global _HITS, _MISSES
+    key = (user_id, guild_id)
+    entry = _CACHE.get(key)
+    now = time.monotonic()
+    if entry is not None:
+        cached, expires_at, _ = entry
+        if expires_at >= now:
+            _HITS += 1
+            return cached
+        # Expired — fall through to reload.
+        _CACHE.pop(key, None)
+
+    # Cache miss — load from DB.
+    _MISSES += 1
+    from utils.db import user_participation as up_db
+
+    try:
+        bundle = await up_db.list_for_user(user_id, guild_id)
+    except Exception as exc:  # noqa: BLE001 — read path must not raise
+        logger.warning(
+            "user_config: list_for_user raised for user=%d guild=%d (%r); "
+            "returning empty bundle",
+            user_id,
+            guild_id,
+            exc,
+        )
+        bundle = {
+            "participation": [],
+            "subscriptions": [],
+            "preferences": [],
+            "visibility_overrides": [],
+        }
+
+    cached = CachedUserConfig(
+        user_id=user_id,
+        guild_id=guild_id,
+        participation=tuple(bundle["participation"]),
+        subscriptions=tuple(bundle["subscriptions"]),
+        preferences=tuple(bundle["preferences"]),
+        visibility_overrides=tuple(bundle["visibility_overrides"]),
+    )
+    _CACHE[key] = (cached, now + _CACHE_TTL_SECS, now)
+    _evict_for_capacity()
+    return cached
+
+
+# ---------------------------------------------------------------------------
+# Invalidation primitives.  PR-9's ParticipationMutationPipeline calls
+# ``invalidate_user_guild`` after every write so subsequent reads see
+# the new state.
+# ---------------------------------------------------------------------------
+
+
+def invalidate_user_guild(user_id: int, guild_id: int) -> bool:
+    """Drop the cache entry for ``(user, guild)`` if present.
+
+    Returns ``True`` when an entry was dropped, ``False`` otherwise.
+    """
+    return _CACHE.pop((user_id, guild_id), None) is not None
+
+
+def forget_user(user_id: int) -> int:
+    """Drop every cache entry for ``user_id`` (across all guilds).
+
+    Returns the number of entries removed.
+    """
+    keys = [k for k in _CACHE if k[0] == user_id]
+    for k in keys:
+        _CACHE.pop(k, None)
+    return len(keys)
+
+
+def forget_guild(guild_id: int) -> int:
+    """Drop every cache entry whose guild matches ``guild_id``.
+
+    Called from ``guild_lifecycle.teardown`` so a re-invited guild
+    does not observe stale per-user decisions.
+    """
+    keys = [k for k in _CACHE if k[1] == guild_id]
+    for k in keys:
+        _CACHE.pop(k, None)
+    return len(keys)
+
+
+def forget_all() -> int:
+    """Drop the entire cache.  Returns the number of entries removed."""
+    n = len(_CACHE)
+    _CACHE.clear()
+    return n
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics
+# ---------------------------------------------------------------------------
+
+
+def _snapshot() -> dict[str, Any]:
+    """Snapshot for the diagnostics provider.
+
+    Returns counts only — the bundle content is not surfaced via
+    diagnostics for privacy.
+    """
+    return {
+        "cache_size": len(_CACHE),
+        "cache_capacity": _CACHE_MAX_ENTRIES,
+        "ttl_secs": _CACHE_TTL_SECS,
+        "hits": _HITS,
+        "misses": _MISSES,
+        "evictions": _EVICTIONS,
+    }
+
+
+def _reset_for_tests() -> None:
+    """Test helper — clear cache + reset counters."""
+    global _HITS, _MISSES, _EVICTIONS
+    _CACHE.clear()
+    _HITS = 0
+    _MISSES = 0
+    _EVICTIONS = 0
+
+
+def _register_diagnostics() -> None:
+    from services import diagnostics_service
+
+    diagnostics_service.register("user_config", _snapshot)
+
+
+_register_diagnostics()
+
+
+__all__ = [
+    "CachedUserConfig",
+    "forget_all",
+    "forget_guild",
+    "forget_user",
+    "get",
+    "invalidate_user_guild",
+]

--- a/disbot/governance/resolver.py
+++ b/disbot/governance/resolver.py
@@ -25,7 +25,7 @@ from governance.models import (
     SubsystemState,
     VisibilityResult,
 )
-from utils import db, settings_keys
+from utils import db
 from utils.subsystem_registry import SUBSYSTEMS
 from utils.visibility_rules import get_member_visibility_tier, get_subsystems_for_tier
 
@@ -147,20 +147,29 @@ async def _resolve_member_tier(ctx: GovernanceContext) -> str:
         ctx.member.guild.owner_id if ctx.member.guild else 0,
     )
 
-    # Trusted tier: if the guild has a TRUSTED_TIER_ROLE_ID setting and the
-    # member has that role, promote them to "trusted" (but only if they're
-    # currently "user" — higher tiers like staff/mod/admin take precedence).
+    # Trusted tier: if the guild has a trusted_role binding (or legacy
+    # TRUSTED_TIER_ROLE_ID setting) AND the member has that role,
+    # promote them to "trusted" (but only if they're currently "user"
+    # — higher tiers like staff/mod/admin take precedence).
+    #
+    # Read flows through the Phase 2 arbitration helper so the canary
+    # flip of ``bindings.primary`` is a single change in
+    # :mod:`core.runtime.config_arbitration`.  This function MUST NOT
+    # branch on ``is_enabled("bindings.primary", ...)`` directly —
+    # that is forbidden by the invariant test in PR-7.
     if tier == "user":
         try:
-            trusted_role_id = await db.get_setting(
-                ctx.guild_id,
-                settings_keys.TRUSTED_TIER_ROLE_ID,
-                default="",
-            )
+            # Local import — keep core.runtime out of governance/__init__'s
+            # module-load cycle (PR #74 protection).  resolver.py is a
+            # sibling of __init__.py but follows the same discipline.
+            from core.runtime.config_arbitration import get_trusted_tier_role
+
+            trusted_role_result = await get_trusted_tier_role(ctx.guild_id)
+            trusted_role_id = trusted_role_result.value
             if (
-                trusted_role_id
+                trusted_role_id is not None
                 and ctx.role_ids
-                and int(trusted_role_id) in ctx.role_ids
+                and trusted_role_id in ctx.role_ids
             ):
                 tier = "trusted"
         except Exception:

--- a/disbot/guild_lifecycle.py
+++ b/disbot/guild_lifecycle.py
@@ -38,11 +38,18 @@ async def teardown(guild_id: int) -> None:
       9. Feature flag evaluator cache — drop cached decisions for the guild.
       10. Platform migration checkpoints — drop per-guild checkpoint rows
                                    (Phase 2 PR-5); global rows preserved.
-      11. Governance capability cache — clear per-guild execution overrides.
-      12. Governance visibility cache — bump version, clear role-override flag.
-      13. Guild-config cache    — drop cached guild config entries (F-1).
-      14. Scope locks           — invoke registered per-cog teardown hooks (F-2).
-      15. Governance feedback cooldown — documented, no per-guild cleanup needed.
+      11. Per-user participation tables — delete user_participation /
+                                   user_subscriptions / user_preferences /
+                                   user_visibility_overrides rows scoped to
+                                   this guild (Phase 2c PR-8).  Same user's
+                                   rows in OTHER guilds are preserved.
+      12. User-config cache      — drop cached per-(user, guild) bundles
+                                   (Phase 2c PR-8).
+      13. Governance capability cache — clear per-guild execution overrides.
+      14. Governance visibility cache — bump version, clear role-override flag.
+      15. Guild-config cache    — drop cached guild config entries (F-1).
+      16. Scope locks           — invoke registered per-cog teardown hooks (F-2).
+      17. Governance feedback cooldown — documented, no per-guild cleanup needed.
     """
     logger.info("guild_lifecycle.teardown: beginning cleanup for guild=%d", guild_id)
 
@@ -76,19 +83,26 @@ async def teardown(guild_id: int) -> None:
     # 10. Platform migration checkpoints — per-guild rows only (Phase 2 PR-5).
     await _teardown_platform_migration_checkpoints(guild_id)
 
-    # 11. Governance capability overrides — clear execution-layer in-process dict.
+    # 11. Per-user participation tables — drop user_*/visibility rows scoped
+    #     to this guild only (Phase 2c PR-8).
+    await _teardown_user_participation(guild_id)
+
+    # 12. User-config cache — drop cached (user, guild) bundles for this guild.
+    _teardown_user_config_cache(guild_id)
+
+    # 13. Governance capability overrides — clear execution-layer in-process dict.
     _teardown_capability_overrides(guild_id)
 
-    # 12. Governance visibility cache — version bump + role flag removal.
+    # 14. Governance visibility cache — version bump + role flag removal.
     _teardown_visibility_cache(guild_id)
 
-    # 13. Guild-config cache — drop cached config entries for the guild (F-1 / S1.1).
+    # 15. Guild-config cache — drop cached config entries for the guild (F-1 / S1.1).
     _teardown_guild_config(guild_id)
 
-    # 14. Scope locks — invoke registered per-cog teardown hooks (F-2 / S1.2).
+    # 16. Scope locks — invoke registered per-cog teardown hooks (F-2 / S1.2).
     _teardown_scope_locks(guild_id)
 
-    # 15. Governance feedback cooldown dict in governance/__init__.
+    # 17. Governance feedback cooldown dict in governance/__init__.
     _teardown_feedback_cooldown(guild_id)
 
     logger.info("guild_lifecycle.teardown: complete for guild=%d", guild_id)
@@ -312,6 +326,56 @@ async def _teardown_platform_migration_checkpoints(guild_id: int) -> None:
     except Exception as exc:
         logger.warning(
             "guild_lifecycle: platform migration checkpoint teardown failed: %s",
+            exc,
+        )
+
+
+async def _teardown_user_participation(guild_id: int) -> None:
+    """Delete per-user participation rows scoped to the departed guild.
+
+    Phase 2c PR-8.  Drops rows in user_participation, user_subscriptions,
+    user_preferences, and user_visibility_overrides whose ``guild_id``
+    matches.  The same user's rows in OTHER guilds are preserved.
+    """
+    try:
+        from utils.db.user_participation import (
+            delete_for_guild as _participation_delete,
+        )
+
+        count = await _participation_delete(guild_id)
+        if count:
+            logger.debug(
+                "guild_lifecycle: deleted %d user participation row(s) for guild=%d",
+                count,
+                guild_id,
+            )
+    except Exception as exc:
+        logger.warning(
+            "guild_lifecycle: user participation teardown failed: %s",
+            exc,
+        )
+
+
+def _teardown_user_config_cache(guild_id: int) -> None:
+    """Drop cached per-(user, guild) participation bundles for ``guild_id``.
+
+    Phase 2c PR-8.  Symmetric to ``_teardown_feature_flag_cache`` —
+    keeps cache and DB consistent on guild leave.
+    """
+    try:
+        from core.runtime.user_config import forget_guild as _user_cache_forget
+
+        dropped = _user_cache_forget(guild_id)
+        if dropped:
+            logger.debug(
+                "guild_lifecycle: dropped %d user_config cache entry(s) "
+                "for guild=%d",
+                dropped,
+                guild_id,
+            )
+    except Exception as exc:
+        logger.warning(
+            "guild_lifecycle: user_config cache teardown failed: %s",
             exc,
         )
 

--- a/disbot/migrations/027_user_participation.sql
+++ b/disbot/migrations/027_user_participation.sql
@@ -1,0 +1,110 @@
+-- Migration 027: per-user participation tables (Phase 2c, PR-8).
+--
+-- Four structurally-separated tables — one per concern — owned by
+-- :class:`core.runtime.participation_schema.ParticipationSchema`.  The
+-- schema docstring explicitly forbids collapsing these into a single
+-- "user settings" object; this migration enforces that separation at
+-- the storage layer.
+--
+--   * user_participation         — opt-in / opt-out toggles
+--   * user_subscriptions         — topic-level subscription state
+--   * user_preferences           — JSONB UX preferences
+--   * user_visibility_overrides  — public / hidden surface toggles
+--
+-- All four tables include ``guild_id`` so guild-leave teardown can
+-- purge the rows for a single guild without touching the same user's
+-- participation in OTHER guilds.  The composite PK on every table is
+-- ``(user_id, guild_id, ...)`` so per-(user, guild) lookups are
+-- O(1) index reads.
+--
+-- Missing-row semantics (consumed by :mod:`utils.user_config_accessors`):
+--
+--   user_participation         → 'not_set'        (caller interprets)
+--   user_subscriptions         → schema default
+--   user_preferences           → preference default
+--   user_visibility_overrides  → schema default
+--
+-- Mutation contract (Phase 2c PR-9 adds the ParticipationMutationPipeline):
+--
+--   * Writes flow through :class:`services.participation_mutation.
+--     ParticipationMutationPipeline` (NOT this migration).
+--   * actor_id is recorded on every row so audit / authority checks
+--     can resolve later.  Nullable because system writes (CI seeds,
+--     future PR-9 backfills) use NULL with actor_type='system' in
+--     the associated audit table (PR-9).
+--
+-- Forward-only and idempotent.
+
+-- ---------------------------------------------------------------------------
+-- user_participation — opt-in / opt-out per (user, guild, subsystem)
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS user_participation (
+    user_id     BIGINT       NOT NULL,
+    guild_id    BIGINT       NOT NULL,
+    subsystem   TEXT         NOT NULL,
+    state       TEXT         NOT NULL,
+    set_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    set_by      BIGINT,
+    PRIMARY KEY (user_id, guild_id, subsystem),
+    CHECK (state IN ('opted_in', 'opted_out'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_participation_guild
+    ON user_participation (guild_id);
+
+
+-- ---------------------------------------------------------------------------
+-- user_subscriptions — topic-level subscription toggles
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS user_subscriptions (
+    user_id     BIGINT       NOT NULL,
+    guild_id    BIGINT       NOT NULL,
+    subsystem   TEXT         NOT NULL,
+    topic       TEXT         NOT NULL,
+    enabled     BOOLEAN      NOT NULL,
+    set_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    set_by      BIGINT,
+    PRIMARY KEY (user_id, guild_id, subsystem, topic)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_subscriptions_guild
+    ON user_subscriptions (guild_id);
+
+
+-- ---------------------------------------------------------------------------
+-- user_preferences — JSONB UX / UI preferences
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS user_preferences (
+    user_id     BIGINT       NOT NULL,
+    guild_id    BIGINT       NOT NULL,
+    key         TEXT         NOT NULL,
+    value       JSONB        NOT NULL,
+    set_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    set_by      BIGINT,
+    PRIMARY KEY (user_id, guild_id, key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_preferences_guild
+    ON user_preferences (guild_id);
+
+
+-- ---------------------------------------------------------------------------
+-- user_visibility_overrides — public / hidden surface toggles
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS user_visibility_overrides (
+    user_id     BIGINT       NOT NULL,
+    guild_id    BIGINT       NOT NULL,
+    subsystem   TEXT         NOT NULL,
+    visibility  TEXT         NOT NULL,
+    set_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    set_by      BIGINT,
+    PRIMARY KEY (user_id, guild_id, subsystem),
+    CHECK (visibility IN ('public', 'hidden'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_visibility_overrides_guild
+    ON user_visibility_overrides (guild_id);

--- a/disbot/services/binding_backfill.py
+++ b/disbot/services/binding_backfill.py
@@ -589,9 +589,9 @@ class ApplyResult:
 
     @property
     def is_failure(self) -> bool:
-        return self.error is not None or self.write_status_counts.get(
-            WRITE_STATUS_FAILED,
-            0,
+        return (
+            self.error is not None
+            or self.write_status_counts.get(WRITE_STATUS_FAILED, 0) > 0
         )
 
     def to_summary_dict(self) -> dict[str, Any]:

--- a/disbot/services/binding_backfill.py
+++ b/disbot/services/binding_backfill.py
@@ -55,6 +55,7 @@ without touching DB or Discord.
 from __future__ import annotations
 
 import logging
+import uuid
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from enum import Enum
@@ -526,15 +527,396 @@ async def dry_run(guild: discord.Guild) -> DryRunSummary:
     return summary
 
 
+# ---------------------------------------------------------------------------
+# Apply phase — PR-6.  Writes CANDIDATE_VALID candidates from a fresh
+# dry-run through ``utils.db.bindings.upsert_with_audit`` with
+# ``actor_type='backfill'``.  Legacy reads remain authoritative.
+# ---------------------------------------------------------------------------
+
+
+class BindingBackfillError(Exception):
+    """Base class for binding-backfill write-phase failures."""
+
+
+class BackfillLockHeldError(BindingBackfillError):
+    """Raised when another session holds the advisory lock for this guild."""
+
+
+# Result statuses recorded per candidate during the write phase.
+WRITE_STATUS_WRITTEN = "written"
+WRITE_STATUS_SKIPPED_IDEMPOTENT = "skipped_idempotent"
+WRITE_STATUS_SKIPPED_NOT_CANDIDATE = "skipped_not_candidate"
+WRITE_STATUS_FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class WriteResult:
+    """One candidate's write outcome.
+
+    ``mutation_id`` is non-empty for ``written`` rows (the UUID that
+    was passed to ``upsert_with_audit``).  For skipped/failed rows it
+    is empty so the operator can immediately tell which audit rows
+    are theirs.
+    """
+
+    legacy_key: str
+    subsystem: str
+    binding_name: str
+    target_id: int | None
+    write_status: str
+    classification: str
+    mutation_id: str
+    error: str | None
+
+    def to_summary_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ApplyResult:
+    """Aggregate write-phase outcome for one guild."""
+
+    guild_id: int
+    started_at: datetime
+    completed_at: datetime
+    actor_id: int
+    summary_version: int
+    pre_counts: dict[str, int]
+    post_counts: dict[str, int]
+    writes: tuple[WriteResult, ...]
+    write_status_counts: dict[str, int]
+    error: str | None  # populated for status='failed' runs
+
+    @property
+    def is_failure(self) -> bool:
+        return self.error is not None or self.write_status_counts.get(
+            WRITE_STATUS_FAILED,
+            0,
+        )
+
+    def to_summary_dict(self) -> dict[str, Any]:
+        return {
+            "summary_version": self.summary_version,
+            "started_at": self.started_at.isoformat(),
+            "completed_at": self.completed_at.isoformat(),
+            "actor_id": self.actor_id,
+            "pre_counts": dict(self.pre_counts),
+            "post_counts": dict(self.post_counts),
+            "writes": [w.to_summary_dict() for w in self.writes],
+            "write_status_counts": dict(self.write_status_counts),
+            "error": self.error,
+        }
+
+
+def _advisory_lock_key(guild_id: int) -> int:
+    """Stable signed-int64 advisory-lock key for ``(MIGRATION_NAME, guild_id)``.
+
+    PostgreSQL's ``pg_try_advisory_lock(int8)`` takes one signed 64-bit
+    integer.  We derive a stable key from a sha256 of
+    ``"binding_backfill:<guild_id>"`` so concurrent runs across the
+    same (migration, guild) collide deterministically, while different
+    guilds never collide with each other.
+    """
+    import hashlib
+
+    digest = hashlib.sha256(
+        f"{MIGRATION_NAME}:{guild_id}".encode(),
+    ).digest()
+    return int.from_bytes(digest[:8], "big", signed=True)
+
+
+async def apply_backfill(
+    guild: discord.Guild,
+    *,
+    actor_id: int,
+    advisory_lock: bool = True,
+) -> ApplyResult:
+    """Write every ``CANDIDATE_VALID`` candidate for ``guild``.
+
+    Steps:
+
+    1. If ``advisory_lock`` is True, acquire a session-scoped
+       ``pg_try_advisory_lock`` keyed on ``(MIGRATION_NAME, guild_id)``.
+       Refuse to run if another session holds the lock.
+    2. Mark the per-guild checkpoint as ``in_progress``.
+    3. Run :func:`dry_run` (fresh classification — the operator's
+       previous dry-run may be stale).
+    4. For each ``CANDIDATE_VALID`` candidate:
+         - **Pre-check**: read the current binding row.  If the row
+           already matches the intended ``target_id`` AND is BOUND,
+           record ``skipped_idempotent`` and continue.  This makes
+           re-running ``apply_backfill`` truly idempotent — no extra
+           audit rows on a no-op re-run.
+         - Otherwise call ``utils.db.bindings.upsert_with_audit`` with
+           ``actor_type='backfill'`` and ``action='backfill'`` (the
+           DB primitive picks the action from actor_type).
+         - Record ``written`` with the new mutation_id.
+       Other classifications are recorded as
+       ``skipped_not_candidate``.
+    5. Re-run :func:`dry_run` to compute ``post_counts``.
+    6. Upsert the checkpoint with status ``complete`` (or ``failed``
+       if any write raised).  ``failed`` rows record their exception
+       in the per-write ``error`` field; the operator can re-run
+       after investigating.
+    7. Release the advisory lock.
+
+    Args:
+        guild: target guild.
+        actor_id: snowflake of the operator authorising the backfill.
+            REQUIRED — the schema enforces ``actor_id NOT NULL`` on
+            ``binding_audit_log``, so the operator's identity is
+            recorded against every audit row.
+        advisory_lock: set False only for tests that drive
+            ``pool.get()`` themselves.  Production callers leave the
+            default ``True``.
+
+    Raises:
+        BackfillLockHeldError: another session is mid-backfill for
+            this guild.  Wait and retry, or investigate the stalled
+            session.
+    """
+    # Local imports keep this module out of any module-load cycles.
+    from utils.db import bindings as bindings_db
+    from utils.db import platform_migration_checkpoints as checkpoint_db
+    from utils.db import pool
+
+    started_at = _now_utc()
+    error_message: str | None = None
+    writes: list[WriteResult] = []
+    lock_acquired = False
+    lock_conn = None
+
+    try:
+        # 1) Advisory lock.
+        if advisory_lock:
+            lock_key = _advisory_lock_key(guild.id)
+            lock_conn = await pool.get().acquire()
+            acquired = await lock_conn.fetchval(
+                "SELECT pg_try_advisory_lock($1)",
+                lock_key,
+            )
+            if not acquired:
+                await pool.get().release(lock_conn)
+                msg = (
+                    f"another session holds the binding_backfill advisory "
+                    f"lock for guild_id={guild.id}; wait and retry"
+                )
+                raise BackfillLockHeldError(msg)
+            lock_acquired = True
+
+        # 2) Mark in_progress so observers can see a backfill is live.
+        await checkpoint_db.upsert_checkpoint(
+            name=MIGRATION_NAME,
+            guild_id=guild.id,
+            status="in_progress",
+            version=SUMMARY_VERSION,
+            summary_json={"phase": "in_progress", "actor_id": actor_id},
+        )
+
+        # 3) Fresh dry-run.
+        pre = await dry_run(guild)
+        pre_counts = dict(pre.counts)
+
+        # 4) Write each CANDIDATE_VALID candidate.
+        for candidate in pre.candidates:
+            if candidate.classification != Classification.CANDIDATE_VALID.value:
+                writes.append(
+                    WriteResult(
+                        legacy_key=candidate.legacy_key,
+                        subsystem=candidate.subsystem,
+                        binding_name=candidate.binding_name,
+                        target_id=candidate.legacy_target_id,
+                        write_status=WRITE_STATUS_SKIPPED_NOT_CANDIDATE,
+                        classification=candidate.classification,
+                        mutation_id="",
+                        error=None,
+                    ),
+                )
+                continue
+
+            target_id = candidate.legacy_target_id
+            if target_id is None:
+                # Belt-and-braces: CANDIDATE_VALID implies a parseable
+                # legacy id, but defend against a future classifier
+                # change.
+                writes.append(
+                    WriteResult(
+                        legacy_key=candidate.legacy_key,
+                        subsystem=candidate.subsystem,
+                        binding_name=candidate.binding_name,
+                        target_id=None,
+                        write_status=WRITE_STATUS_FAILED,
+                        classification=candidate.classification,
+                        mutation_id="",
+                        error="legacy_target_id missing on CANDIDATE_VALID",
+                    ),
+                )
+                continue
+
+            # Pre-check idempotency.
+            current = await bindings_db.get_one(
+                guild.id,
+                candidate.subsystem,
+                candidate.binding_name,
+            )
+            if (
+                current is not None
+                and current.get("target_id") == target_id
+                and current.get("status") == ResourceStatus.BOUND.value
+            ):
+                writes.append(
+                    WriteResult(
+                        legacy_key=candidate.legacy_key,
+                        subsystem=candidate.subsystem,
+                        binding_name=candidate.binding_name,
+                        target_id=target_id,
+                        write_status=WRITE_STATUS_SKIPPED_IDEMPOTENT,
+                        classification=candidate.classification,
+                        mutation_id="",
+                        error=None,
+                    ),
+                )
+                continue
+
+            mutation_id = str(uuid.uuid4())
+            try:
+                await bindings_db.upsert_with_audit(
+                    guild_id=guild.id,
+                    subsystem=candidate.subsystem,
+                    binding_name=candidate.binding_name,
+                    kind=candidate.kind,
+                    target_id=target_id,
+                    status=ResourceStatus.BOUND.value,
+                    actor_id=actor_id,
+                    actor_type="backfill",
+                    mutation_id=mutation_id,
+                    old_target_id=(current.get("target_id") if current else None),
+                    old_status=(current.get("status") if current else None),
+                )
+            except Exception as exc:  # noqa: BLE001 — record per-candidate
+                logger.exception(
+                    "binding_backfill.apply_backfill: write failed "
+                    "for guild=%d subsystem=%r binding=%r",
+                    guild.id,
+                    candidate.subsystem,
+                    candidate.binding_name,
+                )
+                writes.append(
+                    WriteResult(
+                        legacy_key=candidate.legacy_key,
+                        subsystem=candidate.subsystem,
+                        binding_name=candidate.binding_name,
+                        target_id=target_id,
+                        write_status=WRITE_STATUS_FAILED,
+                        classification=candidate.classification,
+                        mutation_id="",
+                        error=f"{type(exc).__name__}: {exc}",
+                    ),
+                )
+                continue
+            writes.append(
+                WriteResult(
+                    legacy_key=candidate.legacy_key,
+                    subsystem=candidate.subsystem,
+                    binding_name=candidate.binding_name,
+                    target_id=target_id,
+                    write_status=WRITE_STATUS_WRITTEN,
+                    classification=candidate.classification,
+                    mutation_id=mutation_id,
+                    error=None,
+                ),
+            )
+
+        # 5) Re-classify post-write.
+        post = await dry_run(guild)
+        post_counts = dict(post.counts)
+
+    except BindingBackfillError:
+        raise
+    except Exception as exc:  # noqa: BLE001 — top-level safety net
+        logger.exception(
+            "binding_backfill.apply_backfill: unexpected failure for guild=%d",
+            guild.id,
+        )
+        error_message = f"{type(exc).__name__}: {exc}"
+        pre_counts = {}
+        post_counts = {}
+
+    completed_at = _now_utc()
+    write_status_counts: dict[str, int] = {}
+    for w in writes:
+        write_status_counts[w.write_status] = (
+            write_status_counts.get(w.write_status, 0) + 1
+        )
+
+    result = ApplyResult(
+        guild_id=guild.id,
+        started_at=started_at,
+        completed_at=completed_at,
+        actor_id=actor_id,
+        summary_version=SUMMARY_VERSION,
+        pre_counts=pre_counts,
+        post_counts=post_counts,
+        writes=tuple(writes),
+        write_status_counts=write_status_counts,
+        error=error_message,
+    )
+
+    # 6) Terminal checkpoint upsert.  Failed if any write raised OR
+    #    the top-level safety-net fired.
+    terminal_status = (
+        "failed"
+        if error_message or write_status_counts.get(WRITE_STATUS_FAILED, 0) > 0
+        else "complete"
+    )
+    try:
+        await checkpoint_db.upsert_checkpoint(
+            name=MIGRATION_NAME,
+            guild_id=guild.id,
+            status=terminal_status,
+            version=SUMMARY_VERSION,
+            summary_json=result.to_summary_dict(),
+            mark_completed=True,
+        )
+    except Exception:
+        logger.exception(
+            "binding_backfill.apply_backfill: terminal checkpoint "
+            "upsert failed for guild=%d (write phase already %s)",
+            guild.id,
+            terminal_status,
+        )
+
+    # 7) Release advisory lock.
+    if lock_acquired and lock_conn is not None:
+        try:
+            await lock_conn.execute(
+                "SELECT pg_advisory_unlock($1)",
+                _advisory_lock_key(guild.id),
+            )
+        finally:
+            await pool.get().release(lock_conn)
+
+    return result
+
+
 __all__ = [
     "MIGRATED_KEYS",
     "MIGRATION_NAME",
     "SUMMARY_VERSION",
     "WRITABLE_CLASSIFICATIONS",
+    "WRITE_STATUS_FAILED",
+    "WRITE_STATUS_SKIPPED_IDEMPOTENT",
+    "WRITE_STATUS_SKIPPED_NOT_CANDIDATE",
+    "WRITE_STATUS_WRITTEN",
+    "ApplyResult",
+    "BackfillLockHeldError",
+    "BindingBackfillError",
     "CandidateResult",
     "Classification",
     "DryRunSummary",
     "MigratedKey",
+    "WriteResult",
+    "apply_backfill",
     "classify_candidate",
     "dry_run",
 ]

--- a/disbot/utils/db/user_participation.py
+++ b/disbot/utils/db/user_participation.py
@@ -1,0 +1,311 @@
+"""Per-user participation — DB read primitives (Phase 2c, PR-8).
+
+Owns the read surface for the four participation tables shipped in
+migration 027.  Writes ship with
+:class:`services.participation_mutation.ParticipationMutationPipeline`
+in PR-9.
+
+The four tables are intentionally separated — see
+:mod:`core.runtime.participation_schema` for the structural rationale.
+Each table has its own dedicated read primitive here; nothing combines
+them into a single "user settings" blob.
+
+Public surface:
+
+* :func:`get_participation`   — single-row read on ``user_participation``.
+* :func:`get_subscription`    — single-row read on ``user_subscriptions``.
+* :func:`get_preference`      — single-row read on ``user_preferences``.
+* :func:`get_visibility`      — single-row read on ``user_visibility_overrides``.
+* :func:`list_for_user`       — bundle reader returning every row for
+  one ``(user, guild)`` pair across the four tables.  Used by the
+  ``core.runtime.user_config`` cache loader.
+* :func:`delete_for_guild`    — guild-leave teardown; deletes every
+  row whose ``guild_id`` matches.  Per the consistency-ledger
+  retention policy, **per-guild participation rows ARE deleted on
+  guild leave** so the same user's participation in other guilds is
+  preserved.
+
+Status / visibility literals (mirror migration 027 CHECK constraints):
+
+  user_participation.state         IN ('opted_in', 'opted_out')
+  user_visibility_overrides.visibility IN ('public', 'hidden')
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from utils.db import pool
+
+logger = logging.getLogger("bot.db.user_participation")
+
+# Mirror migration 027 CHECK constraints.  Alignment tests pin these.
+PARTICIPATION_STATES: frozenset[str] = frozenset({"opted_in", "opted_out"})
+VISIBILITY_STATES: frozenset[str] = frozenset({"public", "hidden"})
+
+
+def _deserialise(raw: Any | None) -> Any | None:
+    """Decode a JSONB value (accepts str or already-decoded dict/list)."""
+    if raw is None or isinstance(raw, (dict, list)):
+        return raw
+    try:
+        return json.loads(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "user_participation: failed to JSON-decode preference value; "
+            "returning raw",
+        )
+        return raw
+
+
+# ---------------------------------------------------------------------------
+# Single-row reads
+# ---------------------------------------------------------------------------
+
+
+async def get_participation(
+    user_id: int,
+    guild_id: int,
+    subsystem: str,
+) -> dict[str, Any] | None:
+    """Return the participation row, or ``None`` for a missing row.
+
+    Missing-row semantics (consumed by the typed accessor in
+    :mod:`utils.user_config_accessors`): caller interprets ``None`` as
+    ``ParticipationState.NOT_SET``.
+    """
+    row = await pool.get().fetchrow(
+        """
+        SELECT user_id, guild_id, subsystem, state, set_at, set_by
+        FROM user_participation
+        WHERE user_id = $1 AND guild_id = $2 AND subsystem = $3
+        """,
+        user_id,
+        guild_id,
+        subsystem,
+    )
+    return dict(row) if row else None
+
+
+async def get_subscription(
+    user_id: int,
+    guild_id: int,
+    subsystem: str,
+    topic: str,
+) -> dict[str, Any] | None:
+    """Return the subscription row, or ``None`` for missing.
+
+    Missing-row semantics: caller interprets ``None`` as the schema's
+    declared default for that topic.
+    """
+    row = await pool.get().fetchrow(
+        """
+        SELECT user_id, guild_id, subsystem, topic, enabled, set_at, set_by
+        FROM user_subscriptions
+        WHERE user_id = $1 AND guild_id = $2
+          AND subsystem = $3 AND topic = $4
+        """,
+        user_id,
+        guild_id,
+        subsystem,
+        topic,
+    )
+    return dict(row) if row else None
+
+
+async def get_preference(
+    user_id: int,
+    guild_id: int,
+    key: str,
+) -> dict[str, Any] | None:
+    """Return the preference row with value JSON-decoded, or ``None``."""
+    row = await pool.get().fetchrow(
+        """
+        SELECT user_id, guild_id, key, value, set_at, set_by
+        FROM user_preferences
+        WHERE user_id = $1 AND guild_id = $2 AND key = $3
+        """,
+        user_id,
+        guild_id,
+        key,
+    )
+    if row is None:
+        return None
+    out = dict(row)
+    out["value"] = _deserialise(out.get("value"))
+    return out
+
+
+async def get_visibility(
+    user_id: int,
+    guild_id: int,
+    subsystem: str,
+) -> dict[str, Any] | None:
+    """Return the visibility override, or ``None`` for missing."""
+    row = await pool.get().fetchrow(
+        """
+        SELECT user_id, guild_id, subsystem, visibility, set_at, set_by
+        FROM user_visibility_overrides
+        WHERE user_id = $1 AND guild_id = $2 AND subsystem = $3
+        """,
+        user_id,
+        guild_id,
+        subsystem,
+    )
+    return dict(row) if row else None
+
+
+# ---------------------------------------------------------------------------
+# Bundle reader used by the runtime cache loader
+# ---------------------------------------------------------------------------
+
+
+async def list_for_user(user_id: int, guild_id: int) -> dict[str, list[dict[str, Any]]]:
+    """Return every row across the four tables for ``(user, guild)``.
+
+    Shape:
+
+    {
+        "participation":         [...],
+        "subscriptions":         [...],
+        "preferences":           [...],
+        "visibility_overrides":  [...],
+    }
+
+    Used by ``core.runtime.user_config`` to populate its per-(user,
+    guild) cache on miss with a single round trip per table.
+    """
+    p_rows = await pool.get().fetch(
+        """
+        SELECT user_id, guild_id, subsystem, state, set_at, set_by
+        FROM user_participation
+        WHERE user_id = $1 AND guild_id = $2
+        """,
+        user_id,
+        guild_id,
+    )
+    s_rows = await pool.get().fetch(
+        """
+        SELECT user_id, guild_id, subsystem, topic, enabled, set_at, set_by
+        FROM user_subscriptions
+        WHERE user_id = $1 AND guild_id = $2
+        """,
+        user_id,
+        guild_id,
+    )
+    pref_rows = await pool.get().fetch(
+        """
+        SELECT user_id, guild_id, key, value, set_at, set_by
+        FROM user_preferences
+        WHERE user_id = $1 AND guild_id = $2
+        """,
+        user_id,
+        guild_id,
+    )
+    v_rows = await pool.get().fetch(
+        """
+        SELECT user_id, guild_id, subsystem, visibility, set_at, set_by
+        FROM user_visibility_overrides
+        WHERE user_id = $1 AND guild_id = $2
+        """,
+        user_id,
+        guild_id,
+    )
+    return {
+        "participation": [dict(r) for r in p_rows],
+        "subscriptions": [dict(r) for r in s_rows],
+        "preferences": [
+            {**dict(r), "value": _deserialise(dict(r).get("value"))} for r in pref_rows
+        ],
+        "visibility_overrides": [dict(r) for r in v_rows],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics helpers
+# ---------------------------------------------------------------------------
+
+
+async def count_rows() -> dict[str, int]:
+    """Return per-table row counts across all guilds.
+
+    Used by the participation diagnostics provider.  This is a small
+    administrative query; not on any hot path.  Each table has its
+    own explicit COUNT statement so the no-dynamic-SQL invariant
+    (``tests/unit/invariants/test_no_dynamic_sql.py``) stays clean.
+    """
+    p_row = await pool.get().fetchrow(
+        "SELECT COUNT(*)::int AS n FROM user_participation",
+    )
+    s_row = await pool.get().fetchrow(
+        "SELECT COUNT(*)::int AS n FROM user_subscriptions",
+    )
+    pref_row = await pool.get().fetchrow(
+        "SELECT COUNT(*)::int AS n FROM user_preferences",
+    )
+    v_row = await pool.get().fetchrow(
+        "SELECT COUNT(*)::int AS n FROM user_visibility_overrides",
+    )
+    return {
+        "user_participation": int(p_row["n"]) if p_row else 0,
+        "user_subscriptions": int(s_row["n"]) if s_row else 0,
+        "user_preferences": int(pref_row["n"]) if pref_row else 0,
+        "user_visibility_overrides": int(v_row["n"]) if v_row else 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Teardown — drop every per-guild row for one guild.  Per the
+# retention policy in docs/platform-consistency-ledger.md §3, the
+# same user's participation in OTHER guilds is preserved.
+# ---------------------------------------------------------------------------
+
+
+def _parse_delete_count(result: str) -> int:
+    try:
+        return int(result.split()[-1])
+    except (ValueError, IndexError):
+        return 0
+
+
+async def delete_for_guild(guild_id: int) -> int:
+    """Delete every row in the four tables that belongs to ``guild_id``.
+
+    Returns the total deleted-row count across the four tables.
+    Runs in one transaction so the four deletes either all succeed
+    or all roll back.  Each table has its own explicit DELETE
+    statement so the no-dynamic-SQL invariant stays clean.
+    """
+    async with pool.get().acquire() as conn, conn.transaction():
+        r1 = await conn.execute(
+            "DELETE FROM user_participation WHERE guild_id = $1",
+            guild_id,
+        )
+        r2 = await conn.execute(
+            "DELETE FROM user_subscriptions WHERE guild_id = $1",
+            guild_id,
+        )
+        r3 = await conn.execute(
+            "DELETE FROM user_preferences WHERE guild_id = $1",
+            guild_id,
+        )
+        r4 = await conn.execute(
+            "DELETE FROM user_visibility_overrides WHERE guild_id = $1",
+            guild_id,
+        )
+    return sum(_parse_delete_count(r) for r in (r1, r2, r3, r4))
+
+
+__all__ = [
+    "PARTICIPATION_STATES",
+    "VISIBILITY_STATES",
+    "count_rows",
+    "delete_for_guild",
+    "get_participation",
+    "get_preference",
+    "get_subscription",
+    "get_visibility",
+    "list_for_user",
+]

--- a/disbot/utils/guild_config_accessors.py
+++ b/disbot/utils/guild_config_accessors.py
@@ -38,7 +38,7 @@ from typing import Generic, TypeVar
 
 from core.runtime import guild_config
 from utils import db
-from utils.settings_keys import XP_ANNOUNCE_CHANNEL, XP_COOLDOWN, XP_MAX, XP_MIN
+from utils.settings_keys import XP_COOLDOWN, XP_MAX, XP_MIN
 
 T = TypeVar("T")
 
@@ -111,12 +111,19 @@ class XpConfig:
 
 def _xp_config_loader(guild_id: int) -> Callable[[], Awaitable[XpConfig]]:
     async def _load() -> XpConfig:
+        # XP min/max/cooldown remain on the legacy path — they are
+        # scalar settings, not bindings, and Phase 2 does not migrate
+        # them.  Only the announce-channel field flows through the
+        # bindings arbitration helper (PR-7).
+        from core.runtime.config_arbitration import get_xp_announce_channel
+
         mn = int(await db.get_setting(guild_id, XP_MIN, str(_XP_DEFAULT_MIN)))
         mx = int(await db.get_setting(guild_id, XP_MAX, str(_XP_DEFAULT_MAX)))
         cd = int(
             await db.get_setting(guild_id, XP_COOLDOWN, str(_XP_DEFAULT_COOLDOWN)),
         )
-        ann = await db.get_setting(guild_id, XP_ANNOUNCE_CHANNEL, "")
+        ann_result = await get_xp_announce_channel(guild_id)
+        ann = ann_result.value or ""
         return XpConfig(xp_min=mn, xp_max=mx, cooldown=cd, announce_channel=ann)
 
     return _load

--- a/disbot/utils/helpers.py
+++ b/disbot/utils/helpers.py
@@ -5,7 +5,6 @@ import re
 import discord
 from discord.ext import commands
 
-from utils.settings_keys import ECONOMY_LOG_CHANNEL
 from utils.ui_constants import INFO_COLOR, SUCCESS_COLOR
 
 # NOTE: ``from core.runtime import resources`` deliberately omitted at
@@ -71,18 +70,33 @@ async def post_log_embed(
     guild_id: int,
     embed: discord.Embed,
 ) -> None:
-    """Post an embed to the guild's configured economy_log_channel (if set)."""
-    from core.runtime import guild_resources
+    """Post an embed to the guild's configured economy_log_channel (if set).
+
+    Read flows through the Phase 2 arbitration helper so the canary
+    flip of ``bindings.primary`` is a single change in
+    :mod:`core.runtime.config_arbitration`.  This function MUST NOT
+    branch on ``is_enabled("bindings.primary", ...)`` directly —
+    that is forbidden by the invariant test in PR-7.
+    """
+    # Local imports preserve the PR #74 cycle-protection pattern:
+    # neither core.runtime.* nor core.resources.* lives at module
+    # scope in utils.helpers.
+    from core.runtime.config_arbitration import get_economy_log_channel
 
     guild = bot.get_guild(guild_id)
     if guild is None:
         return
-    ch = await guild_resources.resolve_settings_channel(guild, ECONOMY_LOG_CHANNEL)
-    if ch:
-        try:
-            await ch.send(embed=embed)  # type: ignore[union-attr]
-        except Exception:
-            pass
+    log_channel_result = await get_economy_log_channel(guild_id)
+    channel_id = log_channel_result.value
+    if channel_id is None:
+        return
+    ch = guild.get_channel(channel_id)
+    if ch is None:
+        return
+    try:
+        await ch.send(embed=embed)  # type: ignore[union-attr]
+    except Exception:
+        pass
 
 
 def normalize_name(name: str) -> str:

--- a/disbot/utils/user_config_accessors.py
+++ b/disbot/utils/user_config_accessors.py
@@ -1,0 +1,176 @@
+"""Typed per-user participation accessors (Phase 2c, PR-8).
+
+Cog / service code reads per-user participation through these typed
+helpers so the storage shape stays an implementation detail.  PR-8
+ships the read path; PR-9 adds the corresponding mutation pipeline.
+
+Why these are separate from
+:mod:`utils.guild_config_accessors` (which covers guild-level state):
+
+* Per-user and per-guild are different runtime domains with different
+  authority models, audit semantics, and lifecycle hooks.  The
+  consistency ledger forbids mixing them.
+* Per-user participation is read on the user-message hot path (XP
+  opt-out gate, etc.) so a dedicated cache layer
+  (:mod:`core.runtime.user_config`) keeps the read O(1) after warm.
+
+Four typed accessors, one per concern:
+
+* :func:`get_participation` — opt-in / opt-out state per subsystem
+* :func:`is_subscribed` — topic-level subscription with schema-default
+* :func:`get_preference` — JSONB preference with caller-supplied default
+* :func:`get_visibility` — public / hidden surface toggle per subsystem
+
+Missing-row semantics:
+
+* ``user_participation`` → :class:`ParticipationState.NOT_SET`
+* ``user_subscriptions`` → the schema's declared default for that topic
+* ``user_preferences`` → the ``default`` argument supplied by the caller
+* ``user_visibility_overrides`` → :class:`VisibilityState.DEFAULT`
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+
+class ParticipationState(str, Enum):
+    """Per-user participation state in a subsystem.
+
+    ``NOT_SET`` is the implicit default returned when no row exists —
+    callers interpret it via their schema's ``requires_optin`` flag.
+    """
+
+    OPTED_IN = "opted_in"
+    OPTED_OUT = "opted_out"
+    NOT_SET = "not_set"
+
+
+class VisibilityState(str, Enum):
+    """User-controlled visibility surface for a subsystem."""
+
+    PUBLIC = "public"
+    HIDDEN = "hidden"
+    DEFAULT = "default"
+
+
+@dataclass(frozen=True)
+class PreferenceResult:
+    """A user preference read result + provenance.
+
+    ``found`` distinguishes "no row" (default returned) from "row
+    with explicit value".  Callers that need to know whether the user
+    has ever set this preference inspect ``found``.
+    """
+
+    value: Any
+    found: bool
+
+
+# ---------------------------------------------------------------------------
+# Accessors
+# ---------------------------------------------------------------------------
+
+
+async def get_participation(
+    user_id: int,
+    guild_id: int,
+    subsystem: str,
+) -> ParticipationState:
+    """Return the user's participation state in ``subsystem`` for ``guild_id``.
+
+    Returns :class:`ParticipationState.NOT_SET` when no row exists.
+    """
+    from core.runtime import user_config
+
+    bundle = await user_config.get(user_id, guild_id)
+    for row in bundle.participation:
+        if row.get("subsystem") == subsystem:
+            state = row.get("state")
+            if state == ParticipationState.OPTED_IN.value:
+                return ParticipationState.OPTED_IN
+            if state == ParticipationState.OPTED_OUT.value:
+                return ParticipationState.OPTED_OUT
+    return ParticipationState.NOT_SET
+
+
+async def is_subscribed(
+    user_id: int,
+    guild_id: int,
+    subsystem: str,
+    topic: str,
+    *,
+    default: bool = False,
+) -> bool:
+    """Return the user's subscription state for ``(subsystem, topic)``.
+
+    ``default`` is returned when no row exists.  The schema layer
+    typically supplies the spec's declared default here; callers that
+    do not have a schema in scope (rare) can pass ``False`` to mean
+    "treat as opted-out".
+    """
+    from core.runtime import user_config
+
+    bundle = await user_config.get(user_id, guild_id)
+    for row in bundle.subscriptions:
+        if row.get("subsystem") == subsystem and row.get("topic") == topic:
+            return bool(row.get("enabled"))
+    return default
+
+
+async def get_preference(
+    user_id: int,
+    guild_id: int,
+    key: str,
+    *,
+    default: Any = None,
+) -> PreferenceResult:
+    """Return the user's preference value for ``key``, or ``default``.
+
+    Wrapped in :class:`PreferenceResult` so callers can distinguish
+    "no row" (``found=False``) from "explicit row with value ==
+    default" (``found=True``).
+    """
+    from core.runtime import user_config
+
+    bundle = await user_config.get(user_id, guild_id)
+    for row in bundle.preferences:
+        if row.get("key") == key:
+            return PreferenceResult(value=row.get("value"), found=True)
+    return PreferenceResult(value=default, found=False)
+
+
+async def get_visibility(
+    user_id: int,
+    guild_id: int,
+    subsystem: str,
+) -> VisibilityState:
+    """Return the user's visibility override for ``subsystem``.
+
+    Returns :class:`VisibilityState.DEFAULT` when no row exists —
+    callers fall back to the schema's declared default visibility.
+    """
+    from core.runtime import user_config
+
+    bundle = await user_config.get(user_id, guild_id)
+    for row in bundle.visibility_overrides:
+        if row.get("subsystem") == subsystem:
+            visibility = row.get("visibility")
+            if visibility == VisibilityState.PUBLIC.value:
+                return VisibilityState.PUBLIC
+            if visibility == VisibilityState.HIDDEN.value:
+                return VisibilityState.HIDDEN
+    return VisibilityState.DEFAULT
+
+
+__all__ = [
+    "ParticipationState",
+    "PreferenceResult",
+    "VisibilityState",
+    "get_participation",
+    "get_preference",
+    "get_visibility",
+    "is_subscribed",
+]

--- a/tests/unit/binding_backfill/test_apply_backfill.py
+++ b/tests/unit/binding_backfill/test_apply_backfill.py
@@ -1,0 +1,418 @@
+"""Phase 2 PR-6 — services.binding_backfill.apply_backfill end-to-end.
+
+Verifies the write phase:
+
+* Calls dry_run() to get fresh classification.
+* Writes only CANDIDATE_VALID candidates through
+  utils.db.bindings.upsert_with_audit with actor_type='backfill'.
+* Pre-check: skips writes when the binding already matches
+  (idempotent re-run).
+* Records per-candidate WriteResult.
+* Re-classifies after write for the operator's review.
+* Updates the checkpoint to 'complete' or 'failed' depending on
+  whether any write raised.
+* Acquires + releases the advisory lock (when enabled).
+* Refuses to run if the advisory lock is held.
+* NEVER calls BindingMutationPipeline (the backfill bypasses
+  user-facing authority by using a dedicated 'backfill' actor_type
+  recorded in the audit log; the operator's actor_id is required).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from core.resources.status import ResourceStatus
+from core.runtime.bindings import BindingValue
+from core.runtime.subsystem_schema import BindingKind
+from services import binding_backfill
+from services.binding_backfill import (
+    WRITE_STATUS_FAILED,
+    WRITE_STATUS_SKIPPED_IDEMPOTENT,
+    WRITE_STATUS_SKIPPED_NOT_CANDIDATE,
+    WRITE_STATUS_WRITTEN,
+    BackfillLockHeldError,
+    apply_backfill,
+)
+
+
+def _bv(*, target_id, status, last_updated_at=None):
+    return BindingValue(
+        guild_id=42,
+        subsystem="xp",
+        binding_name="announce_channel",
+        kind=BindingKind.CHANNEL,
+        target_id=target_id,
+        status=status,
+        last_validated_at=last_updated_at,
+        last_updated_at=last_updated_at,
+        version=1 if last_updated_at is not None else 0,
+    )
+
+
+@pytest.fixture
+def _mock_guild():
+    guild = MagicMock()
+    guild.id = 42
+    return guild
+
+
+@pytest.fixture
+def _patches(_mock_guild):
+    """Patch every external touchpoint the write phase relies on.
+
+    Three layers:
+      * dry_run() — patched at the binding_backfill module level to
+        give the test full control over the classification.
+      * utils.db.bindings primitives — get_one (pre-check) and
+        upsert_with_audit (the actual write).
+      * utils.db.platform_migration_checkpoints.upsert_checkpoint —
+        called at in_progress + terminal phases.
+      * Advisory lock is disabled by default (advisory_lock=False in
+        tests); a separate fixture exercises it.
+    """
+    with (
+        patch.object(
+            binding_backfill,
+            "dry_run",
+            new_callable=AsyncMock,
+        ) as mock_dry_run,
+        patch(
+            "utils.db.bindings.get_one",
+            new_callable=AsyncMock,
+        ) as mock_get_one,
+        patch(
+            "utils.db.bindings.upsert_with_audit",
+            new_callable=AsyncMock,
+        ) as mock_upsert,
+        patch(
+            "utils.db.platform_migration_checkpoints.upsert_checkpoint",
+            new_callable=AsyncMock,
+        ) as mock_checkpoint,
+    ):
+        yield {
+            "dry_run": mock_dry_run,
+            "get_one": mock_get_one,
+            "upsert": mock_upsert,
+            "checkpoint": mock_checkpoint,
+            "guild": _mock_guild,
+        }
+
+
+def _summary_with(candidates):
+    """Build a DryRunSummary stand-in returned by the mocked dry_run."""
+    counts: dict[str, int] = {}
+    for c in candidates:
+        counts[c.classification] = counts.get(c.classification, 0) + 1
+    return binding_backfill.DryRunSummary(
+        guild_id=42,
+        started_at=datetime.now(),
+        completed_at=datetime.now(),
+        summary_version=binding_backfill.SUMMARY_VERSION,
+        candidates=tuple(candidates),
+        counts=counts,
+    )
+
+
+def _candidate(
+    *,
+    legacy_key="xp_announce_channel",
+    subsystem="xp",
+    binding_name="announce_channel",
+    kind="channel",
+    legacy_target_id=999,
+    binding_target_id=None,
+    binding_status=None,
+    classification=binding_backfill.Classification.CANDIDATE_VALID.value,
+):
+    return binding_backfill.CandidateResult(
+        legacy_key=legacy_key,
+        subsystem=subsystem,
+        binding_name=binding_name,
+        kind=kind,
+        legacy_target_id=legacy_target_id,
+        legacy_raw=str(legacy_target_id) if legacy_target_id else None,
+        binding_target_id=binding_target_id,
+        binding_status=binding_status,
+        classification=classification,
+        reason="test",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path: one CANDIDATE_VALID written, others skipped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_writes_only_candidate_valid(_patches):
+    p = _patches
+    # Three candidates: one valid, one already-bound, one blocked
+    candidates = [
+        _candidate(legacy_target_id=999),  # CANDIDATE_VALID
+        _candidate(
+            subsystem="economy",
+            binding_name="log_channel",
+            legacy_target_id=111,
+            classification=binding_backfill.Classification.MATCH.value,
+        ),
+        _candidate(
+            subsystem="governance",
+            binding_name="trusted_role",
+            kind="role",
+            legacy_target_id=222,
+            classification=binding_backfill.Classification.BLOCKED_NO_SCHEMA.value,
+        ),
+    ]
+    p["dry_run"].return_value = _summary_with(candidates)
+    p["get_one"].return_value = None  # no binding row yet
+
+    result = await apply_backfill(p["guild"], actor_id=7777, advisory_lock=False)
+
+    # Exactly one upsert call (the CANDIDATE_VALID candidate)
+    p["upsert"].assert_awaited_once()
+    upsert_call = p["upsert"].await_args
+    assert upsert_call.kwargs["subsystem"] == "xp"
+    assert upsert_call.kwargs["binding_name"] == "announce_channel"
+    assert upsert_call.kwargs["target_id"] == 999
+    assert upsert_call.kwargs["actor_type"] == "backfill"
+    assert upsert_call.kwargs["actor_id"] == 7777
+    # mutation_id is a valid UUID (36 chars)
+    assert len(upsert_call.kwargs["mutation_id"]) == 36
+    # WriteResult shape
+    assert len(result.writes) == 3
+    statuses = {w.write_status for w in result.writes}
+    assert statuses == {
+        WRITE_STATUS_WRITTEN,
+        WRITE_STATUS_SKIPPED_NOT_CANDIDATE,
+    }
+    assert result.write_status_counts[WRITE_STATUS_WRITTEN] == 1
+    assert result.write_status_counts[WRITE_STATUS_SKIPPED_NOT_CANDIDATE] == 2
+    assert result.actor_id == 7777
+    assert result.error is None
+
+
+# ---------------------------------------------------------------------------
+# Idempotency: re-running on an already-correct binding skips the write
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_idempotent_skips_already_matching_binding(_patches):
+    """A second apply_backfill run on an already-backfilled guild produces no writes."""
+    p = _patches
+    p["dry_run"].return_value = _summary_with(
+        [_candidate(legacy_target_id=999)],
+    )
+    # Existing row already matches what backfill wants to write
+    p["get_one"].return_value = {
+        "guild_id": 42,
+        "subsystem": "xp",
+        "binding_name": "announce_channel",
+        "kind": "channel",
+        "target_id": 999,
+        "status": ResourceStatus.BOUND.value,
+        "last_validated_at": None,
+        "last_updated_at": None,
+        "version": 1,
+    }
+
+    result = await apply_backfill(p["guild"], actor_id=7777, advisory_lock=False)
+
+    p["upsert"].assert_not_awaited()
+    assert result.write_status_counts[WRITE_STATUS_SKIPPED_IDEMPOTENT] == 1
+
+
+# ---------------------------------------------------------------------------
+# Re-binds when target changed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_rebinds_when_existing_row_has_different_target(_patches):
+    p = _patches
+    p["dry_run"].return_value = _summary_with(
+        [_candidate(legacy_target_id=999)],
+    )
+    # Existing row has the SAME slot but a DIFFERENT target_id
+    p["get_one"].return_value = {
+        "guild_id": 42,
+        "subsystem": "xp",
+        "binding_name": "announce_channel",
+        "kind": "channel",
+        "target_id": 111,
+        "status": ResourceStatus.BOUND.value,
+        "last_validated_at": None,
+        "last_updated_at": None,
+        "version": 1,
+    }
+
+    await apply_backfill(p["guild"], actor_id=7777, advisory_lock=False)
+
+    p["upsert"].assert_awaited_once()
+    call = p["upsert"].await_args
+    # Old target captured in the audit
+    assert call.kwargs["old_target_id"] == 111
+    assert call.kwargs["target_id"] == 999
+
+
+# ---------------------------------------------------------------------------
+# Apply records pre/post counts via two dry_run calls
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_calls_dry_run_twice_for_pre_and_post(_patches):
+    p = _patches
+    p["dry_run"].side_effect = [
+        _summary_with([_candidate(legacy_target_id=999)]),
+        _summary_with(
+            [
+                _candidate(
+                    legacy_target_id=999,
+                    binding_target_id=999,
+                    binding_status="bound",
+                    classification=binding_backfill.Classification.MATCH.value,
+                )
+            ],
+        ),
+    ]
+    p["get_one"].return_value = None
+
+    result = await apply_backfill(p["guild"], actor_id=7777, advisory_lock=False)
+
+    assert p["dry_run"].await_count == 2
+    assert result.pre_counts == {
+        binding_backfill.Classification.CANDIDATE_VALID.value: 1,
+    }
+    assert result.post_counts == {
+        binding_backfill.Classification.MATCH.value: 1,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint lifecycle: in_progress → terminal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_writes_in_progress_then_complete_checkpoints(_patches):
+    p = _patches
+    p["dry_run"].return_value = _summary_with(
+        [_candidate(legacy_target_id=999)],
+    )
+    p["get_one"].return_value = None
+
+    await apply_backfill(p["guild"], actor_id=7777, advisory_lock=False)
+
+    # Two checkpoint upsert calls: 'in_progress' and 'complete'
+    statuses = [call.kwargs["status"] for call in p["checkpoint"].await_args_list]
+    assert statuses[0] == "in_progress"
+    assert statuses[-1] == "complete"
+    # Terminal checkpoint carries the full result summary
+    final_call = p["checkpoint"].await_args_list[-1]
+    assert final_call.kwargs["mark_completed"] is True
+    summary = final_call.kwargs["summary_json"]
+    assert summary["pre_counts"]
+    assert summary["post_counts"]
+    assert summary["actor_id"] == 7777
+
+
+# ---------------------------------------------------------------------------
+# Failure path: upsert raises → terminal status='failed' + per-write error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_marks_failed_when_upsert_raises(_patches):
+    p = _patches
+    p["dry_run"].return_value = _summary_with(
+        [_candidate(legacy_target_id=999)],
+    )
+    p["get_one"].return_value = None
+    p["upsert"].side_effect = RuntimeError("DB blip")
+
+    result = await apply_backfill(p["guild"], actor_id=7777, advisory_lock=False)
+
+    assert result.write_status_counts[WRITE_STATUS_FAILED] == 1
+    write = result.writes[0]
+    assert write.write_status == WRITE_STATUS_FAILED
+    assert "RuntimeError" in write.error
+    # Terminal checkpoint marked failed
+    final_call = p["checkpoint"].await_args_list[-1]
+    assert final_call.kwargs["status"] == "failed"
+
+
+# ---------------------------------------------------------------------------
+# Backfill does NOT call BindingMutationPipeline
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_does_not_use_binding_mutation_pipeline(_patches):
+    """Backfill bypasses the user-facing pipeline.
+
+    Discord-actor authority does not apply: backfill uses a dedicated
+    'backfill' actor_type recorded in the audit, with the operator's
+    actor_id.  This test pins the contract by asserting the user-facing
+    pipeline's primitive is never invoked.
+    """
+    p = _patches
+    p["dry_run"].return_value = _summary_with(
+        [_candidate(legacy_target_id=999)],
+    )
+    p["get_one"].return_value = None
+
+    with patch(
+        "services.binding_mutation.BindingMutationPipeline",
+    ) as mock_pipeline_cls:
+        await apply_backfill(p["guild"], actor_id=7777, advisory_lock=False)
+    mock_pipeline_cls.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Advisory lock: refuses to run when held
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_raises_when_advisory_lock_held(_mock_guild):
+    """A concurrent backfill on the same guild must fail loudly."""
+    # Mock the pool: pg_try_advisory_lock returns False
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value=False)
+    conn.execute = AsyncMock()
+
+    pool_mock = MagicMock()
+    pool_mock.acquire = AsyncMock(return_value=conn)
+    pool_mock.release = AsyncMock()
+
+    with patch("utils.db.pool.get", return_value=pool_mock):
+        with pytest.raises(BackfillLockHeldError):
+            await apply_backfill(_mock_guild, actor_id=7777, advisory_lock=True)
+
+
+# ---------------------------------------------------------------------------
+# Advisory lock key is deterministic and per-guild
+# ---------------------------------------------------------------------------
+
+
+def test_advisory_lock_key_deterministic():
+    a1 = binding_backfill._advisory_lock_key(42)
+    a2 = binding_backfill._advisory_lock_key(42)
+    assert a1 == a2
+
+
+def test_advisory_lock_key_differs_per_guild():
+    a = binding_backfill._advisory_lock_key(42)
+    b = binding_backfill._advisory_lock_key(43)
+    assert a != b
+
+
+def test_advisory_lock_key_fits_signed_int64():
+    """pg_advisory_lock(int8) takes a signed 64-bit integer."""
+    key = binding_backfill._advisory_lock_key(2**62)
+    assert -(2**63) <= key < 2**63

--- a/tests/unit/cogs/test_xp_cog_caching.py
+++ b/tests/unit/cogs/test_xp_cog_caching.py
@@ -36,17 +36,47 @@ def _make_message(*, guild_id: int = 99, user_id: int = 1) -> MagicMock:
 
 
 def _xp_settings_replies(get_setting: AsyncMock, *, min_=15, max_=25, cd=60, ann=""):
-    """Side-effect that mimics db.get_setting reading the 4 XP keys."""
+    """Side-effect that mimics db.get_setting reading the 3 scalar XP keys.
+
+    Phase 2 PR-7: the announce_channel field flows through the
+    arbitration helper, not direct db.get_setting from the loader.
+    Tests patch ``core.runtime.config_arbitration.get_xp_announce_channel``
+    separately via :func:`_patch_announce_channel`.
+    """
 
     async def reply(guild_id, key, default=""):  # noqa: ARG001 — signature parity
         return {
             "xp_min": str(min_),
             "xp_max": str(max_),
             "xp_cooldown": str(cd),
-            "xp_announce_channel": ann,
         }.get(key, default)
 
     get_setting.side_effect = reply
+
+
+def _patch_announce_channel(value: str = ""):
+    """Patch the per-subsystem accessor used by ``_xp_config_loader``.
+
+    Returns a ``ConfigReadResult`` so the loader's downstream code path
+    (``ann_result.value or ""``) keeps working.
+    """
+    from core.runtime.config_arbitration import ConfigReadResult
+
+    # Patch the source of the accessor.  ``_xp_config_loader`` does
+    # ``from core.runtime.config_arbitration import get_xp_announce_channel``
+    # inside the function body each time it runs, so patching the
+    # source module's attribute is what intercepts the call.
+    return patch(
+        "core.runtime.config_arbitration.get_xp_announce_channel",
+        new_callable=AsyncMock,
+        return_value=ConfigReadResult(
+            value=value or None,
+            source="legacy" if value else "missing",
+            binding_status="n/a",
+            flag_state="off",
+            diagnostics=[],
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -77,15 +107,21 @@ async def test_handle_message_calls_db_get_setting_at_most_once_per_guild_over_a
             "utils.guild_config_accessors.db.get_setting",
             new_callable=AsyncMock,
         ) as get_setting,
+        _patch_announce_channel() as announce_accessor,
         patch("cogs.xp.listener.check_cooldown", return_value=(True, 0)),
     ):
         _xp_settings_replies(get_setting)
         for _ in range(5):
             await handle_message(bot, message)
 
-    # Cache fill reads each of 4 keys exactly once on the first message;
-    # subsequent 4 messages all hit the cache → no further DB reads.
-    assert get_setting.await_count == 4
+    # Cache fill reads each of 3 scalar XP keys exactly once on the
+    # first message; subsequent 4 messages all hit the cache → no
+    # further DB reads.  The announce_channel field flows through
+    # the arbitration accessor (PR-7) — its call count is the same
+    # 1-per-window because the per-guild XpConfig cache covers the
+    # whole tuple.
+    assert get_setting.await_count == 3
+    assert announce_accessor.await_count == 1
 
 
 @pytest.mark.asyncio
@@ -104,6 +140,7 @@ async def test_handle_message_caches_per_guild_independently():
             "utils.guild_config_accessors.db.get_setting",
             new_callable=AsyncMock,
         ) as get_setting,
+        _patch_announce_channel() as announce_accessor,
         patch("cogs.xp.listener.check_cooldown", return_value=(True, 0)),
     ):
         _xp_settings_replies(get_setting)
@@ -112,7 +149,11 @@ async def test_handle_message_caches_per_guild_independently():
         await handle_message(bot, _make_message(guild_id=1))  # cached
         await handle_message(bot, _make_message(guild_id=2))  # cached
 
-    assert get_setting.await_count == 8  # 4 per guild × 2 guilds
+    # 3 scalar keys per guild × 2 guilds = 6 db.get_setting calls.
+    # Announce accessor called once per guild (also cached at the
+    # XpConfig level).
+    assert get_setting.await_count == 6
+    assert announce_accessor.await_count == 2
 
 
 # ---------------------------------------------------------------------------
@@ -125,15 +166,20 @@ async def test_invalidate_xp_config_forces_reload_on_next_read():
     """After invalidation, the next get_xp_config call re-runs the loader."""
     from utils.guild_config_accessors import get_xp_config, invalidate_xp_config
 
-    with patch(
-        "utils.guild_config_accessors.db.get_setting",
-        new_callable=AsyncMock,
-    ) as get_setting:
+    with (
+        patch(
+            "utils.guild_config_accessors.db.get_setting",
+            new_callable=AsyncMock,
+        ) as get_setting,
+        _patch_announce_channel(),
+    ):
         _xp_settings_replies(get_setting, min_=10)
         first = await get_xp_config(42)
         assert first.xp_min == 10
         await get_xp_config(42)  # cached
-        assert get_setting.await_count == 4
+        # 3 scalar keys (min/max/cooldown) — announce_channel flows
+        # through the arbitration accessor patched above.
+        assert get_setting.await_count == 3
 
         # Simulate an admin write: new value in DB + explicit invalidation.
         _xp_settings_replies(get_setting, min_=99)
@@ -141,7 +187,7 @@ async def test_invalidate_xp_config_forces_reload_on_next_read():
 
         second = await get_xp_config(42)
         assert second.xp_min == 99
-        assert get_setting.await_count == 8  # 4 more reads on the reload
+        assert get_setting.await_count == 6  # 3 more reads on the reload
 
 
 @pytest.mark.asyncio

--- a/tests/unit/config_arbitration/test_subsystem_accessors.py
+++ b/tests/unit/config_arbitration/test_subsystem_accessors.py
@@ -1,0 +1,270 @@
+"""Phase 2 PR-7 — per-subsystem convenience accessors.
+
+The accessors collapse the migrated-key arguments to ``read_config``
+into a single call.  Tests verify:
+
+* Each accessor passes the correct subsystem / binding_name /
+  legacy_key / binding_kind to ``read_config``.
+* The value is normalized to the expected type (``str`` for XP
+  announce channel, ``int`` for economy log channel and trusted-tier
+  role).
+* Unparseable legacy strings on int-valued accessors become
+  ``source='missing'`` with a diagnostic explaining the parse failure.
+* Counters from ``read_config`` continue to accumulate.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from core.resources.status import ResourceStatus
+from core.runtime import config_arbitration
+from core.runtime.bindings import BindingValue
+from core.runtime.config_arbitration import (
+    get_economy_log_channel,
+    get_trusted_tier_role,
+    get_xp_announce_channel,
+)
+from core.runtime.subsystem_schema import BindingKind
+
+
+@pytest.fixture(autouse=True)
+def _reset_counters():
+    config_arbitration._reset_counters_for_tests()
+    yield
+    config_arbitration._reset_counters_for_tests()
+
+
+def _bv(*, kind, target_id, status):
+    return BindingValue(
+        guild_id=1,
+        subsystem="x",
+        binding_name="y",
+        kind=kind,
+        target_id=target_id,
+        status=status,
+        last_validated_at=datetime.now(timezone.utc),
+        last_updated_at=datetime.now(timezone.utc),
+        version=1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_xp_announce_channel — legacy str pass-through; binding int stringified
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_xp_announce_channel_flag_off_returns_legacy_string():
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="123456",
+        ),
+    ):
+        result = await get_xp_announce_channel(guild_id=1)
+    assert result.value == "123456"
+    assert isinstance(result.value, str)
+    assert result.source == "legacy"
+
+
+@pytest.mark.asyncio
+async def test_xp_announce_channel_flag_on_binding_stringifies_int():
+    """When the binding returns an int, the accessor stringifies it.
+
+    XP callers expect a string (``XpConfig.announce_channel: str``).
+    """
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "core.runtime.bindings.get_binding",
+            new_callable=AsyncMock,
+            return_value=_bv(
+                kind=BindingKind.CHANNEL,
+                target_id=999999,
+                status=ResourceStatus.BOUND,
+            ),
+        ),
+    ):
+        result = await get_xp_announce_channel(guild_id=1)
+    assert result.value == "999999"
+    assert isinstance(result.value, str)
+    assert result.source == "binding"
+
+
+@pytest.mark.asyncio
+async def test_xp_announce_channel_missing_returns_none():
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="",
+        ),
+    ):
+        result = await get_xp_announce_channel(guild_id=1)
+    assert result.value is None
+    assert result.source == "missing"
+
+
+# ---------------------------------------------------------------------------
+# get_economy_log_channel — value coerced to int|None
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_economy_log_channel_flag_off_parses_legacy_to_int():
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="777777",
+        ),
+    ):
+        result = await get_economy_log_channel(guild_id=1)
+    assert result.value == 777777
+    assert isinstance(result.value, int)
+    assert result.source == "legacy"
+
+
+@pytest.mark.asyncio
+async def test_economy_log_channel_flag_on_returns_binding_int():
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "core.runtime.bindings.get_binding",
+            new_callable=AsyncMock,
+            return_value=_bv(
+                kind=BindingKind.CHANNEL,
+                target_id=999,
+                status=ResourceStatus.BOUND,
+            ),
+        ),
+    ):
+        result = await get_economy_log_channel(guild_id=1)
+    assert result.value == 999
+    assert result.source == "binding"
+
+
+@pytest.mark.asyncio
+async def test_economy_log_channel_unparseable_legacy_becomes_missing():
+    """A legacy KV holding junk that can't be int-parsed should not crash."""
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="not-a-number",
+        ),
+    ):
+        result = await get_economy_log_channel(guild_id=1)
+    assert result.value is None
+    assert result.source == "missing"
+    assert any("could not be parsed as int" in d for d in result.diagnostics)
+
+
+# ---------------------------------------------------------------------------
+# get_trusted_tier_role — value coerced to int|None, kind=role
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_trusted_tier_role_passes_role_kind_to_read_config():
+    """The accessor MUST declare binding_kind='role' so kind drift is caught.
+
+    The XP/economy accessors declare 'channel'; this one must declare
+    'role' or a future schema mistake (binding declared as channel)
+    would be silently accepted.
+    """
+    with patch(
+        "core.runtime.config_arbitration.read_config",
+        new_callable=AsyncMock,
+    ) as mock_read:
+        mock_read.return_value = config_arbitration.ConfigReadResult(
+            value=None,
+            source="missing",
+            binding_status="n/a",
+            flag_state="off",
+            diagnostics=[],
+        )
+        await get_trusted_tier_role(guild_id=1)
+    call = mock_read.await_args
+    assert call.kwargs["subsystem"] == "governance"
+    assert call.kwargs["binding_name"] == "trusted_role"
+    assert call.kwargs["legacy_key"] == "trusted_tier_role_id"
+    assert call.kwargs["binding_kind"] == "role"
+
+
+@pytest.mark.asyncio
+async def test_trusted_tier_role_legacy_int_returned():
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="111222333",
+        ),
+    ):
+        result = await get_trusted_tier_role(guild_id=1)
+    assert result.value == 111222333
+
+
+# ---------------------------------------------------------------------------
+# Counters accumulate across accessors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_counters_increment_across_accessors():
+    with (
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="123",
+        ),
+    ):
+        await get_xp_announce_channel(guild_id=1)
+        await get_economy_log_channel(guild_id=1)
+        await get_trusted_tier_role(guild_id=1)
+    snap = config_arbitration.counters_snapshot()
+    assert snap["calls_total"] == 3
+    assert snap["by_flag_state"]["off"] == 3

--- a/tests/unit/invariants/test_no_direct_bindings_primary_branch.py
+++ b/tests/unit/invariants/test_no_direct_bindings_primary_branch.py
@@ -1,0 +1,107 @@
+"""Phase 2 PR-7 invariant — no direct branching on ``bindings.primary``.
+
+The Phase 2 plan forbids per-cog (or per-service / per-governance)
+branching on ``is_enabled("bindings.primary", ...)``.  Only
+:mod:`core.runtime.config_arbitration` may consult that flag; all
+other consumers route reads through the typed per-subsystem
+accessors (``get_xp_announce_channel`` etc.) which encapsulate the
+flag check.
+
+Why this matters:
+* The canary flip of ``bindings.primary`` is a single change in
+  the arbitration module; scattered branches would multiply the
+  rollback surface.
+* Provenance (``ConfigReadResult.source``, ``binding_status``,
+  ``flag_state``, ``diagnostics``) is only captured by the central
+  helper — per-cog branches would lose it.
+
+This test parses every ``disbot/**/*.py`` file via AST and fails if
+any node references the string literal ``"bindings.primary"`` outside
+the allowlist below.
+
+Allowlist:
+* ``disbot/core/runtime/config_arbitration.py`` — the only legitimate
+  consumer.
+* ``disbot/core/runtime/feature_flags.py`` — declares the flag.
+* ``disbot/services/binding_backfill.py`` — uses the literal as the
+  migration name and in checkpoint payloads, not as a flag check.
+* ``disbot/services/rollout_mutation.py`` — error messages reference
+  ``"bindings.primary"`` as an example.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCAN_ROOT = _REPO_ROOT / "disbot"
+_FLAG_LITERAL = "bindings.primary"
+
+# Files allowed to reference the literal.  Add to this list with care
+# — every entry weakens the invariant.
+_ALLOWLIST = {
+    _SCAN_ROOT / "core" / "runtime" / "config_arbitration.py",
+    _SCAN_ROOT / "core" / "runtime" / "feature_flags.py",
+    _SCAN_ROOT / "services" / "binding_backfill.py",
+    _SCAN_ROOT / "services" / "rollout_mutation.py",
+}
+
+
+def _iter_python_files() -> list[Path]:
+    return [p for p in _SCAN_ROOT.rglob("*.py") if "__pycache__" not in p.parts]
+
+
+def _file_references_literal(path: Path) -> bool:
+    """True if the AST contains a ``str`` constant equal to ``bindings.primary``."""
+    try:
+        tree = ast.parse(path.read_text())
+    except SyntaxError:
+        # Not a valid python module — skip rather than crash the test
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and node.value == _FLAG_LITERAL:
+            return True
+    return False
+
+
+def test_no_direct_bindings_primary_outside_allowlist():
+    """Every reference to ``"bindings.primary"`` lives in the allowlist."""
+    violations: list[str] = []
+    for path in _iter_python_files():
+        if path in _ALLOWLIST:
+            continue
+        if _file_references_literal(path):
+            violations.append(str(path.relative_to(_REPO_ROOT)))
+    assert not violations, (
+        "These files reference the literal 'bindings.primary' but are "
+        "not in the allowlist — route reads through "
+        "core.runtime.config_arbitration's per-subsystem accessors "
+        "(get_xp_announce_channel, get_economy_log_channel, "
+        "get_trusted_tier_role) instead.\n\n"
+        + "\n".join(f"  {v}" for v in sorted(violations))
+    )
+
+
+def test_allowlist_entries_exist():
+    """Every file in the allowlist must still exist on disk.
+
+    Otherwise a renamed file would silently relax the invariant.
+    """
+    missing = [str(p.relative_to(_REPO_ROOT)) for p in _ALLOWLIST if not p.exists()]
+    assert (
+        not missing
+    ), "Allowlist references files that no longer exist:\n" + "\n".join(
+        f"  {p}" for p in missing
+    )
+
+
+def test_arbitration_module_actually_references_literal():
+    """If the allowlist target itself stops referencing the flag, the
+    invariant is meaningless.  Pin that config_arbitration still
+    consumes the literal.
+    """
+    arbitration = _SCAN_ROOT / "core" / "runtime" / "config_arbitration.py"
+    assert _file_references_literal(
+        arbitration,
+    ), "core/runtime/config_arbitration.py must reference 'bindings.primary'"

--- a/tests/unit/invariants/test_user_participation_alignment.py
+++ b/tests/unit/invariants/test_user_participation_alignment.py
@@ -1,0 +1,94 @@
+"""Phase 2c PR-8 invariant — participation state literals align.
+
+Migration 027 ships CHECK constraints on
+``user_participation.state`` and
+``user_visibility_overrides.visibility``.  The Python module
+:mod:`utils.db.user_participation` carries matching ``frozenset``s;
+this test pins both sides.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_MIGRATION = (
+    Path(__file__).resolve().parents[3]
+    / "disbot"
+    / "migrations"
+    / "027_user_participation.sql"
+)
+
+
+def _extract_check(column: str) -> set[str]:
+    sql = _MIGRATION.read_text()
+    matches = re.findall(
+        rf"CHECK\s*\(\s*{column}\s+IN\s*\(([^)]+)\)\s*\)",
+        sql,
+    )
+    assert matches, f"could not locate {column} CHECK in migration 027"
+    out: set[str] = set()
+    for clause in matches:
+        for token in clause.split(","):
+            literal = token.strip().strip("'\"")
+            if literal:
+                out.add(literal)
+    return out
+
+
+def test_participation_state_literals_match():
+    from utils.db.user_participation import PARTICIPATION_STATES
+
+    db_check = _extract_check("state")
+    python = set(PARTICIPATION_STATES)
+    assert db_check == python, (
+        "user_participation state drift.\n"
+        f"  in Python but not DB CHECK: {sorted(python - db_check)}\n"
+        f"  in DB CHECK but not Python: {sorted(db_check - python)}"
+    )
+
+
+def test_visibility_literals_match():
+    from utils.db.user_participation import VISIBILITY_STATES
+
+    db_check = _extract_check("visibility")
+    python = set(VISIBILITY_STATES)
+    assert db_check == python, (
+        "user_visibility_overrides visibility drift.\n"
+        f"  in Python but not DB CHECK: {sorted(python - db_check)}\n"
+        f"  in DB CHECK but not Python: {sorted(db_check - python)}"
+    )
+
+
+def test_all_tables_carry_guild_id():
+    """Every participation table MUST include guild_id (consistency ledger §3)."""
+    sql = _MIGRATION.read_text()
+    for table in (
+        "user_participation",
+        "user_subscriptions",
+        "user_preferences",
+        "user_visibility_overrides",
+    ):
+        # Match the CREATE TABLE block for this name
+        match = re.search(
+            rf"CREATE TABLE IF NOT EXISTS {table}\s*\(([^;]+)\)\s*;",
+            sql,
+            re.DOTALL,
+        )
+        assert match, f"could not locate CREATE TABLE for {table}"
+        body = match.group(1)
+        assert (
+            "guild_id" in body
+        ), f"{table} does not include guild_id — Phase 2c retention contract"
+
+
+def test_accessor_enums_have_distinct_values():
+    """ParticipationState and VisibilityState values do not collide."""
+    from utils.user_config_accessors import ParticipationState, VisibilityState
+
+    p_values = {s.value for s in ParticipationState}
+    v_values = {s.value for s in VisibilityState}
+    overlap = p_values & v_values
+    assert (
+        not overlap
+    ), f"ParticipationState ∩ VisibilityState = {overlap}; values must be distinct"

--- a/tests/unit/participation/test_user_config_accessors.py
+++ b/tests/unit/participation/test_user_config_accessors.py
@@ -1,0 +1,196 @@
+"""Phase 2c PR-8 — utils.user_config_accessors typed accessors.
+
+Each accessor:
+* Reads through ``core.runtime.user_config`` (so the cache layer is
+  exercised).
+* Returns a typed value (ParticipationState / bool / PreferenceResult
+  / VisibilityState).
+* Returns the documented default when no row exists.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from core.runtime import user_config
+from utils.user_config_accessors import (
+    ParticipationState,
+    PreferenceResult,
+    VisibilityState,
+    get_participation,
+    get_preference,
+    get_visibility,
+    is_subscribed,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    user_config._reset_for_tests()
+    yield
+    user_config._reset_for_tests()
+
+
+def _bundle(**kwargs):
+    base = {
+        "participation": [],
+        "subscriptions": [],
+        "preferences": [],
+        "visibility_overrides": [],
+    }
+    base.update(kwargs)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# get_participation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_participation_returns_not_set_when_no_row():
+    with patch(
+        "utils.db.user_participation.list_for_user",
+        new_callable=AsyncMock,
+        return_value=_bundle(),
+    ):
+        result = await get_participation(1, 2, "xp")
+    assert result is ParticipationState.NOT_SET
+
+
+@pytest.mark.asyncio
+async def test_get_participation_returns_opted_in():
+    with patch(
+        "utils.db.user_participation.list_for_user",
+        new_callable=AsyncMock,
+        return_value=_bundle(
+            participation=[{"subsystem": "xp", "state": "opted_in"}],
+        ),
+    ):
+        result = await get_participation(1, 2, "xp")
+    assert result is ParticipationState.OPTED_IN
+
+
+@pytest.mark.asyncio
+async def test_get_participation_returns_opted_out():
+    with patch(
+        "utils.db.user_participation.list_for_user",
+        new_callable=AsyncMock,
+        return_value=_bundle(
+            participation=[{"subsystem": "xp", "state": "opted_out"}],
+        ),
+    ):
+        result = await get_participation(1, 2, "xp")
+    assert result is ParticipationState.OPTED_OUT
+
+
+@pytest.mark.asyncio
+async def test_get_participation_subsystem_isolation():
+    """Participation in ``economy`` is separate from ``xp``."""
+    with patch(
+        "utils.db.user_participation.list_for_user",
+        new_callable=AsyncMock,
+        return_value=_bundle(
+            participation=[{"subsystem": "economy", "state": "opted_in"}],
+        ),
+    ):
+        result = await get_participation(1, 2, "xp")
+    assert result is ParticipationState.NOT_SET
+
+
+# ---------------------------------------------------------------------------
+# is_subscribed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_is_subscribed_returns_default_when_no_row():
+    with patch(
+        "utils.db.user_participation.list_for_user",
+        new_callable=AsyncMock,
+        return_value=_bundle(),
+    ):
+        result = await is_subscribed(1, 2, "economy", "daily", default=True)
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_is_subscribed_returns_stored_value():
+    with patch(
+        "utils.db.user_participation.list_for_user",
+        new_callable=AsyncMock,
+        return_value=_bundle(
+            subscriptions=[
+                {"subsystem": "economy", "topic": "daily", "enabled": False},
+            ],
+        ),
+    ):
+        result = await is_subscribed(1, 2, "economy", "daily", default=True)
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# get_preference
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_preference_returns_default_when_missing():
+    with patch(
+        "utils.db.user_participation.list_for_user",
+        new_callable=AsyncMock,
+        return_value=_bundle(),
+    ):
+        result = await get_preference(1, 2, "digest_freq", default="hourly")
+    assert isinstance(result, PreferenceResult)
+    assert result.value == "hourly"
+    assert result.found is False
+
+
+@pytest.mark.asyncio
+async def test_get_preference_returns_stored_value():
+    with patch(
+        "utils.db.user_participation.list_for_user",
+        new_callable=AsyncMock,
+        return_value=_bundle(
+            preferences=[
+                {"key": "digest_freq", "value": {"unit": "hours", "interval": 6}},
+            ],
+        ),
+    ):
+        result = await get_preference(1, 2, "digest_freq", default="hourly")
+    assert result.value == {"unit": "hours", "interval": 6}
+    assert result.found is True
+
+
+# ---------------------------------------------------------------------------
+# get_visibility
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_visibility_returns_default_when_missing():
+    with patch(
+        "utils.db.user_participation.list_for_user",
+        new_callable=AsyncMock,
+        return_value=_bundle(),
+    ):
+        result = await get_visibility(1, 2, "xp")
+    assert result is VisibilityState.DEFAULT
+
+
+@pytest.mark.asyncio
+async def test_get_visibility_returns_public_or_hidden():
+    with patch(
+        "utils.db.user_participation.list_for_user",
+        new_callable=AsyncMock,
+        return_value=_bundle(
+            visibility_overrides=[
+                {"subsystem": "xp", "visibility": "hidden"},
+            ],
+        ),
+    ):
+        result = await get_visibility(1, 2, "xp")
+    assert result is VisibilityState.HIDDEN

--- a/tests/unit/participation/test_user_config_cache.py
+++ b/tests/unit/participation/test_user_config_cache.py
@@ -1,0 +1,219 @@
+"""Phase 2c PR-8 — core.runtime.user_config cache behaviour.
+
+Covers:
+
+* Cache miss → DB read → cache populated → next read hits.
+* TTL expiry forces a reload.
+* Explicit invalidation primitives evict the right entries.
+* DB failure returns an empty bundle without raising.
+* Soft max-size eviction.
+* Diagnostics snapshot shape.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from core.runtime import user_config
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    user_config._reset_for_tests()
+    yield
+    user_config._reset_for_tests()
+
+
+@pytest.fixture
+def _patch_db():
+    """Patch utils.db.user_participation.list_for_user."""
+    with patch(
+        "utils.db.user_participation.list_for_user",
+        new_callable=AsyncMock,
+    ) as mock:
+        mock.return_value = {
+            "participation": [],
+            "subscriptions": [],
+            "preferences": [],
+            "visibility_overrides": [],
+        }
+        yield mock
+
+
+# ---------------------------------------------------------------------------
+# Cache miss/hit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_miss_loads_from_db(_patch_db):
+    await user_config.get(1, 2)
+    _patch_db.assert_awaited_once_with(1, 2)
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_avoids_second_db_call(_patch_db):
+    await user_config.get(1, 2)
+    await user_config.get(1, 2)
+    assert _patch_db.await_count == 1
+    snap = user_config._snapshot()
+    assert snap["hits"] == 1
+    assert snap["misses"] == 1
+
+
+@pytest.mark.asyncio
+async def test_cache_per_user_guild_independent(_patch_db):
+    await user_config.get(1, 2)
+    await user_config.get(1, 3)  # different guild
+    await user_config.get(2, 2)  # different user
+    assert _patch_db.await_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Empty bundle returned on cache miss when DB has no rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_db_returns_empty_bundle(_patch_db):
+    bundle = await user_config.get(1, 2)
+    assert bundle.user_id == 1
+    assert bundle.guild_id == 2
+    assert bundle.participation == ()
+    assert bundle.subscriptions == ()
+    assert bundle.preferences == ()
+    assert bundle.visibility_overrides == ()
+
+
+# ---------------------------------------------------------------------------
+# Invalidation primitives
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalidate_user_guild_drops_one_entry(_patch_db):
+    await user_config.get(1, 2)
+    assert user_config.invalidate_user_guild(1, 2) is True
+    await user_config.get(1, 2)
+    assert _patch_db.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_invalidate_user_guild_returns_false_when_absent():
+    assert user_config.invalidate_user_guild(99, 99) is False
+
+
+@pytest.mark.asyncio
+async def test_forget_user_drops_all_guilds(_patch_db):
+    await user_config.get(1, 2)
+    await user_config.get(1, 3)
+    await user_config.get(2, 2)
+    assert user_config.forget_user(1) == 2
+    # user 1's entries gone; user 2's stays
+    snap = user_config._snapshot()
+    assert snap["cache_size"] == 1
+
+
+@pytest.mark.asyncio
+async def test_forget_guild_drops_all_users(_patch_db):
+    await user_config.get(1, 2)
+    await user_config.get(2, 2)
+    await user_config.get(3, 99)
+    assert user_config.forget_guild(2) == 2
+    snap = user_config._snapshot()
+    assert snap["cache_size"] == 1
+
+
+@pytest.mark.asyncio
+async def test_forget_all_clears_everything(_patch_db):
+    await user_config.get(1, 2)
+    await user_config.get(2, 3)
+    assert user_config.forget_all() == 2
+    assert user_config._snapshot()["cache_size"] == 0
+
+
+# ---------------------------------------------------------------------------
+# TTL expiry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ttl_expiry_forces_reload(_patch_db, monkeypatch):
+    """An expired entry triggers a fresh DB read."""
+    base_time = 1000.0
+    monkeypatch.setattr(user_config.time, "monotonic", lambda: base_time)
+    await user_config.get(1, 2)
+
+    # Jump past the TTL.
+    monkeypatch.setattr(
+        user_config.time,
+        "monotonic",
+        lambda: base_time + user_config._CACHE_TTL_SECS + 1,
+    )
+    await user_config.get(1, 2)
+    assert _patch_db.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# DB failure: empty bundle, no raise
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_db_failure_returns_empty_bundle():
+    """The hot-path read MUST NOT raise; an empty bundle is the safe default."""
+    with patch(
+        "utils.db.user_participation.list_for_user",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("DB blip"),
+    ):
+        bundle = await user_config.get(1, 2)
+    assert bundle.participation == ()
+
+
+# ---------------------------------------------------------------------------
+# Soft max-size eviction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_eviction_drops_oldest_decile_when_capacity_exceeded(
+    _patch_db, monkeypatch
+):
+    monkeypatch.setattr(user_config, "_CACHE_MAX_ENTRIES", 20)
+    base = 1000.0
+    for i in range(25):
+        monkeypatch.setattr(user_config.time, "monotonic", lambda x=base + i: x)
+        await user_config.get(user_id=i, guild_id=1)
+    snap = user_config._snapshot()
+    # The eviction triggers when cache exceeds 20; it drops the
+    # oldest decile (max(1, 21//10) = 2) on each excess insert.
+    assert snap["cache_size"] <= 25
+    assert snap["evictions"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_shape():
+    snap = user_config._snapshot()
+    assert set(snap.keys()) == {
+        "cache_size",
+        "cache_capacity",
+        "ttl_secs",
+        "hits",
+        "misses",
+        "evictions",
+    }
+
+
+def test_diagnostics_provider_registered():
+    from services import diagnostics_service
+
+    snap = diagnostics_service.snapshot("user_config")
+    assert "cache_size" in snap

--- a/tests/unit/participation/test_user_participation_db.py
+++ b/tests/unit/participation/test_user_participation_db.py
@@ -1,0 +1,211 @@
+"""Phase 2c PR-8 — utils.db.user_participation read primitives."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from utils.db import user_participation as up_db
+
+
+@pytest.fixture
+def _mock_pool():
+    pool_mock = MagicMock()
+    pool_mock.execute = AsyncMock()
+    pool_mock.fetchrow = AsyncMock()
+    pool_mock.fetch = AsyncMock()
+    pool_mock.acquire = MagicMock()
+    with patch.object(up_db, "pool") as pool_module:
+        pool_module.get = MagicMock(return_value=pool_mock)
+        yield pool_mock
+
+
+# ---------------------------------------------------------------------------
+# Single-row reads
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_participation_keyed_on_user_guild_subsystem(_mock_pool):
+    _mock_pool.fetchrow.return_value = None
+    await up_db.get_participation(1, 2, "xp")
+    sql, *args = _mock_pool.fetchrow.await_args.args
+    assert "user_id = $1 AND guild_id = $2 AND subsystem = $3" in sql
+    assert args == [1, 2, "xp"]
+
+
+@pytest.mark.asyncio
+async def test_get_participation_returns_dict_when_present(_mock_pool):
+    _mock_pool.fetchrow.return_value = {
+        "user_id": 1,
+        "guild_id": 2,
+        "subsystem": "xp",
+        "state": "opted_in",
+        "set_at": None,
+        "set_by": 99,
+    }
+    row = await up_db.get_participation(1, 2, "xp")
+    assert row is not None
+    assert row["state"] == "opted_in"
+
+
+@pytest.mark.asyncio
+async def test_get_subscription_keyed_on_topic(_mock_pool):
+    _mock_pool.fetchrow.return_value = None
+    await up_db.get_subscription(1, 2, "economy", "daily")
+    sql, *args = _mock_pool.fetchrow.await_args.args
+    assert "topic = $4" in sql
+    assert args == [1, 2, "economy", "daily"]
+
+
+@pytest.mark.asyncio
+async def test_get_preference_decodes_json_value(_mock_pool):
+    _mock_pool.fetchrow.return_value = {
+        "user_id": 1,
+        "guild_id": 2,
+        "key": "digest_freq",
+        "value": json.dumps({"unit": "hours", "interval": 6}),
+        "set_at": None,
+        "set_by": None,
+    }
+    row = await up_db.get_preference(1, 2, "digest_freq")
+    assert row is not None
+    assert row["value"] == {"unit": "hours", "interval": 6}
+
+
+@pytest.mark.asyncio
+async def test_get_visibility_returns_visibility_value(_mock_pool):
+    _mock_pool.fetchrow.return_value = {
+        "user_id": 1,
+        "guild_id": 2,
+        "subsystem": "xp",
+        "visibility": "hidden",
+        "set_at": None,
+        "set_by": None,
+    }
+    row = await up_db.get_visibility(1, 2, "xp")
+    assert row is not None
+    assert row["visibility"] == "hidden"
+
+
+# ---------------------------------------------------------------------------
+# Bundle reader
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_for_user_returns_four_keys(_mock_pool):
+    _mock_pool.fetch.return_value = []
+    bundle = await up_db.list_for_user(1, 2)
+    assert set(bundle.keys()) == {
+        "participation",
+        "subscriptions",
+        "preferences",
+        "visibility_overrides",
+    }
+    # Four SELECTs (one per table)
+    assert _mock_pool.fetch.await_count == 4
+
+
+@pytest.mark.asyncio
+async def test_list_for_user_decodes_preference_value(_mock_pool):
+    payloads = [
+        [],
+        [],
+        [
+            {
+                "user_id": 1,
+                "guild_id": 2,
+                "key": "digest_freq",
+                "value": json.dumps({"unit": "hours"}),
+                "set_at": None,
+                "set_by": None,
+            },
+        ],
+        [],
+    ]
+    _mock_pool.fetch.side_effect = payloads
+    bundle = await up_db.list_for_user(1, 2)
+    assert bundle["preferences"][0]["value"] == {"unit": "hours"}
+
+
+# ---------------------------------------------------------------------------
+# count_rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_count_rows_runs_four_count_queries(_mock_pool):
+    _mock_pool.fetchrow.side_effect = [{"n": 3}, {"n": 1}, {"n": 0}, {"n": 2}]
+    counts = await up_db.count_rows()
+    assert counts == {
+        "user_participation": 3,
+        "user_subscriptions": 1,
+        "user_preferences": 0,
+        "user_visibility_overrides": 2,
+    }
+
+
+# ---------------------------------------------------------------------------
+# delete_for_guild: atomic over four tables
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_for_guild_deletes_four_tables_in_one_transaction():
+    """All four tables are purged in a single transaction.
+
+    The retention contract requires that the deletes either all succeed
+    or all roll back — otherwise a half-deleted guild leaves orphan
+    rows.  Test by mocking ``pool.get().acquire()`` and asserting all
+    four DELETE statements run inside the same connection's
+    transaction.
+    """
+    conn = MagicMock()
+    conn.execute = AsyncMock(
+        side_effect=["DELETE 2", "DELETE 0", "DELETE 1", "DELETE 1"]
+    )
+    conn.transaction = MagicMock()
+
+    txn_cm = MagicMock()
+    txn_cm.__aenter__ = AsyncMock(return_value=None)
+    txn_cm.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction.return_value = txn_cm
+
+    acquire_cm = MagicMock()
+    acquire_cm.__aenter__ = AsyncMock(return_value=conn)
+    acquire_cm.__aexit__ = AsyncMock(return_value=False)
+
+    pool_mock = MagicMock()
+    pool_mock.acquire = MagicMock(return_value=acquire_cm)
+    with patch.object(up_db, "pool") as pool_module:
+        pool_module.get = MagicMock(return_value=pool_mock)
+        total = await up_db.delete_for_guild(42)
+    # Four DELETEs issued
+    assert conn.execute.await_count == 4
+    # Total = 2 + 0 + 1 + 1 = 4
+    assert total == 4
+    # Each DELETE targets one table
+    tables_seen = set()
+    for call in conn.execute.await_args_list:
+        sql = call.args[0]
+        for table in (
+            "user_participation",
+            "user_subscriptions",
+            "user_preferences",
+            "user_visibility_overrides",
+        ):
+            if f"DELETE FROM {table}" in sql:
+                tables_seen.add(table)
+                # Each DELETE is scoped to guild_id
+                assert "WHERE guild_id = $1" in sql
+                assert call.args[1] == 42
+                break
+    assert tables_seen == {
+        "user_participation",
+        "user_subscriptions",
+        "user_preferences",
+        "user_visibility_overrides",
+    }

--- a/tests/unit/runtime/test_guild_lifecycle_teardown.py
+++ b/tests/unit/runtime/test_guild_lifecycle_teardown.py
@@ -115,6 +115,16 @@ def _teardown_patches():
             new_callable=AsyncMock,
             return_value=0,
         ),
+        # PR-8 defaults: participation table + cache.
+        patch(
+            "utils.db.user_participation.delete_for_guild",
+            new_callable=AsyncMock,
+            return_value=0,
+        ),
+        patch(
+            "core.runtime.user_config.forget_guild",
+            return_value=0,
+        ),
     ):
         yield
 
@@ -377,3 +387,55 @@ async def test_teardown_migration_checkpoint_failure_is_isolated(_teardown_patch
         await guild_lifecycle.teardown(99)
         # downstream step still invoked despite checkpoint delete failure
         mock_caps.assert_called_once_with(99)
+
+
+# ---------------------------------------------------------------------------
+# Steps 11 + 12 — per-user participation rows + cache (Phase 2c PR-8)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_teardown_deletes_user_participation_rows(_teardown_patches):
+    """The four-table participation delete primitive is awaited."""
+    import guild_lifecycle
+
+    with patch(
+        "utils.db.user_participation.delete_for_guild",
+        new_callable=AsyncMock,
+        return_value=5,
+    ) as mock_delete:
+        await guild_lifecycle.teardown(99)
+        mock_delete.assert_awaited_once_with(99)
+
+
+@pytest.mark.asyncio
+async def test_teardown_clears_user_config_cache(_teardown_patches):
+    """user_config.forget_guild is called scoped to the guild."""
+    import guild_lifecycle
+
+    with patch(
+        "core.runtime.user_config.forget_guild",
+        return_value=0,
+    ) as mock_forget:
+        await guild_lifecycle.teardown(99)
+        mock_forget.assert_called_once_with(99)
+
+
+@pytest.mark.asyncio
+async def test_teardown_participation_failure_is_isolated(_teardown_patches):
+    """If participation delete raises, the user_config cache step still runs."""
+    import guild_lifecycle
+
+    with (
+        patch(
+            "utils.db.user_participation.delete_for_guild",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("DB blip"),
+        ),
+        patch(
+            "core.runtime.user_config.forget_guild",
+            return_value=0,
+        ) as mock_forget,
+    ):
+        await guild_lifecycle.teardown(99)
+        mock_forget.assert_called_once_with(99)


### PR DESCRIPTION
## Why this PR exists

This is the **second occurrence of the stacked-PR delivery problem** — same pattern as PR #80.

PRs #82, #83, #84 were set up with each base pointing at the previous PR's branch so a reviewer could see clean per-PR diffs. PR #81 merged cleanly into `main`, but the three subsequent PRs were merged into their **stack branches** instead of into `main`:

- PR #84 (participation storage) merged into `claude/phase-2-pr-7-bindings-canary`
- PR #83 (`bindings.primary` canary) merged into `claude/phase-2-pr-6-backfill-write`
- PR #82 (binding backfill write phase) — never reached `main` directly

Result: `main` is currently at `89f552d` (PR #81 merge commit) with highest migration `026_platform_migration_checkpoints.sql`. The binding-backfill write path, the read-site swaps for XP/Economy/Governance, the participation tables, and migration 027 are **all missing from `main`**.

## What this PR does

Repairs the delivery by cherry-picking the three feature commits directly onto a branch off `origin/main` in their intended order. **No new scope is added** — the diff is exactly the combined contents of #82 + #83 + #84.

```
6a8f087 feat(phase-2-pr-8): participation storage + cache foundation (Phase 2c)
35fc692 feat(phase-2-pr-7): bindings.primary canary support via arbitration accessors
11e3cc4 feat(phase-2-pr-6): binding backfill write phase with idempotent apply
89f552d Merge pull request #81 from menno420/claude/phase-2-pr-5-backfill-dryrun  ← current main
```

Each commit retains its original message and authorship for review traceability.

## Wrongly merged source PRs

| # | Title | Source branch |
|---|---|---|
| #82 | Phase 2.6: binding backfill write phase (idempotent apply, advisory lock) | `claude/phase-2-pr-6-backfill-write` |
| #83 | Phase 2.7: bindings.primary canary support via arbitration accessors | `claude/phase-2-pr-7-bindings-canary` |
| #84 | Phase 2.8: participation storage + cache foundation (Phase 2c) | `claude/phase-2-pr-8-participation-storage` |

## Behavior safety guarantees (preserved from the source PRs)

- **`bindings.primary` remains OFF by default.** The canary read-site swap is dormant on every guild until an operator explicitly enables the flag (env override or per-guild DB override).
- **`participation.enabled` remains OFF / has no consumer yet.** The participation tables, cache, and read accessors exist but no subsystem reads from them. The XP opt-out gate lands in PR-9, not in this integration.
- **Legacy reads remain authoritative.** When `bindings.primary` is OFF (default), XP/Economy/Governance reads resolve via the legacy `guild_settings` path. When ON, the binding value is consulted with legacy as a fallback.
- **No setup wizard UI.**
- **No resource provisioning.**
- **No participation mutation pipeline.** PR-9 adds it; this integration does not include any write path against the participation tables.
- **No `/myprofile`.**
- **No notification router.**
- **No production read flip.**
- **Import-cycle protections preserved.** Every new accessor in `utils/helpers.py`, `governance/resolver.py`, and `utils/guild_config_accessors.py` imports `core.runtime.config_arbitration` inside the function body — never at module scope. Verified by the existing `test_import_cycle_regression.py`.
- **No `BindingMutationPipeline` invocation from the backfill write phase.** Backfill uses a dedicated `actor_type='backfill'` against the existing audit-table CHECK; user-facing authority is not consulted.
- **Advisory lock prevents concurrent backfill runs** on the same guild.

## Migrations

| Migration | Status | Source |
|---|---|---|
| `022_subsystem_bindings.sql` | on main | PR #73 |
| `023_feature_flag_state.sql` | on main | PR #77 |
| `024_environment_tiers.sql` | on main | PR #77 |
| `025_feature_flag_audit.sql` | on main | PR #78 |
| `026_platform_migration_checkpoints.sql` | on main | PR #81 |
| **`027_user_participation.sql`** | **new in this PR** | from #84 |

Numbering ladder preserved exactly: 026 stays the PR-5 checkpoints migration; 027 stays the PR-8 participation migration.

## Files changed (19 .py + 1 .sql)

From #82 (backfill write phase):
- `disbot/services/binding_backfill.py` (extended with `apply_backfill`, `BackfillLockHeldError`, advisory lock, idempotent pre-check)
- `tests/unit/binding_backfill/test_apply_backfill.py` (NEW)

From #83 (canary read-site swap):
- `disbot/core/runtime/config_arbitration.py` (per-subsystem accessors + coercion helpers)
- `disbot/utils/guild_config_accessors.py` (XP loader read-site swap)
- `disbot/utils/helpers.py` (economy log channel read-site swap)
- `disbot/governance/resolver.py` (trusted-tier role read-site swap)
- `tests/unit/config_arbitration/test_subsystem_accessors.py` (NEW)
- `tests/unit/invariants/test_no_direct_bindings_primary_branch.py` (NEW — AST scan)
- `tests/unit/cogs/test_xp_cog_caching.py` (updated to patch the arbitration accessor)

From #84 (participation storage):
- `disbot/migrations/027_user_participation.sql` (NEW)
- `disbot/utils/db/user_participation.py` (NEW)
- `disbot/core/runtime/user_config.py` (NEW)
- `disbot/utils/user_config_accessors.py` (NEW)
- `disbot/guild_lifecycle.py` (extended with 2 new steps; renumbered 13–17)
- `tests/unit/participation/` (NEW package, 3 test files)
- `tests/unit/invariants/test_user_participation_alignment.py` (NEW)
- `tests/unit/runtime/test_guild_lifecycle_teardown.py` (extended)

## Rollback strategy

Single `git revert -m 1 <merge-sha>` after this PR merges. The three cherry-picked commits are linear (no merge commits inside the integration branch), so revert produces a clean reverse-diff.

Layered rollback options if a full revert is overkill:
1. **`bindings.primary` reads behaving wrong** → `SUPERBOT_FF_BINDINGS_PRIMARY=off` (env override) instantly returns every read to legacy. No code change needed.
2. **Backfill produced bad rows** → `services/binding_backfill.apply_backfill` is idempotent and stamps `actor_type='backfill'` on audit rows; `BindingMutationPipeline.clear_binding` can correct individual rows, or `DELETE FROM subsystem_bindings WHERE ...` (the audit log retains the trail).
3. **Migration 027 is empty / unused** until PR-9 ships, so even a partial revert that keeps the table is safe.

## Tests run

```
python -m pytest tests/unit/binding_backfill/ -q                                          # 52 passed
python -m pytest tests/unit/config_arbitration/ -q                                        # 23 passed
python -m pytest tests/unit/participation/ -q                                             # 33 passed
python -m pytest tests/unit/invariants/test_no_direct_bindings_primary_branch.py -q       # 3 passed
python -m pytest tests/unit/invariants/test_user_participation_alignment.py -q            # 4 passed
python -m pytest tests/unit/runtime/test_guild_lifecycle_teardown.py -q                   # 15 passed
python -m pytest tests/unit/runtime/test_import_cycle_regression.py -q                    # 3 passed

python -m pytest tests/ -q --ignore=tests/integration
# 1370 passed (1304 from main + 66 new), 12 unrelated deprecation warnings

python -m ruff check disbot/                                                              # clean
python -m isort --check-only disbot/ tests/                                               # clean
python -m black --check (the 19 PR-changed .py files + migration 027)                     # clean
```

### Note on `black --check disbot/ tests/`

Running `black --check` against the whole repo reports 30 unrelated test files that need reformatting (e.g., `tests/unit/services/test_blackjack_engine.py`, `tests/unit/views/test_selectors.py`). **None of those files are touched by this PR** — confirmed via `git diff --name-only origin/main..HEAD | xargs python -m black --check` which reports all 19 PR-changed `.py` files clean. This is the same pre-existing repo-wide drift that PR #80 noted; intentionally not addressed here to keep the integration PR focused.

## Manual smoke-test checklist

### After deploy, with all flags at their declared defaults

- [ ] Bot starts cleanly on Railway with migration 027 applied
- [ ] `!platform status` reports up; no startup errors related to imports
- [ ] `!platform migrations` shows the existing binding_backfill checkpoint from PR-5 (if any) without errors
- [ ] `!platform flags` continues to render the runtime evaluator output (per the PR-2/3 contract)
- [ ] XP level-up announcements land in the same channel as before
- [ ] Economy log embeds land in the same channel as before
- [ ] Trusted-tier role promotion works as before

### Backfill smoke (operator REPL)

- [ ] `from services.binding_backfill import dry_run, apply_backfill`
- [ ] `summary = await dry_run(test_guild)` returns classification counts
- [ ] `result = await apply_backfill(test_guild, actor_id=<your_id>)` writes binding rows tagged `actor_type='backfill'`
- [ ] Re-run `apply_backfill` → `SKIPPED_IDEMPOTENT` count == previous `WRITTEN` count (no extra audit rows)

### Canary smoke (per-guild flag flip)

- [ ] `SUPERBOT_FF_BINDINGS_PRIMARY=on` on a test guild → XP/Economy/Governance reads switch to binding values
- [ ] Force a binding to MISSING (delete the channel) → reads fall back to legacy with `source='fallback'`
- [ ] Disable the env flag → reads revert to legacy path immediately

### Participation smoke (REPL only — no UI consumer yet)

- [ ] `from utils.db.user_participation import list_for_user`
- [ ] `await list_for_user(<user_id>, <test_guild>)` returns empty bundles for all four tables
- [ ] `from utils.user_config_accessors import get_participation; await get_participation(<user>, <guild>, "xp")` returns `ParticipationState.NOT_SET`
- [ ] `!platform runtime` (or wherever `user_config` is registered) shows `cache_size`, `hits`, `misses` counters
- [ ] Kick bot from test guild → all four participation tables drop that guild's rows; same user's rows in OTHER guilds preserved

## What ships next

Once this PR merges:
- Next session can start **PR-9** (`ParticipationMutationPipeline` + XP opt-out proof gated by `participation.enabled`) directly off `main`.
- Migration numbering ladder: next free number is **028** (PR-9 audit table).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgFk12CkWs1uiPZk8AA5fR)_