### PR TITLE
Phase 2.9: participation mutation pipeline + XP opt-out proof

### DIFF
--- a/disbot/cogs/xp/listener.py
+++ b/disbot/cogs/xp/listener.py
@@ -36,6 +36,60 @@ from utils.ui_constants import ECONOMY_COLOR
 logger = logging.getLogger("bot.cogs.xp.listener")
 
 
+async def _xp_participation_allowed(user_id: int, guild_id: int) -> bool:
+    """Return True when the XP award should proceed for this user/guild.
+
+    Phase 2c PR-9 gate.  Centralised here so any future XP entry path
+    can call the same helper; the rule is NOT duplicated across XP
+    commands.
+
+    Resolution:
+
+    * If ``participation.enabled`` is OFF (declared default), return
+      True unconditionally — pre-PR-9 behavior is preserved exactly.
+    * If ON, consult the typed ``get_participation`` accessor.  Only
+      :class:`ParticipationState.OPTED_OUT` blocks the award; OPTED_IN
+      and NOT_SET both allow it.
+    * Any exception from the flag evaluator or the accessor is logged
+      and the gate falls open (returns True).  XP is never blocked
+      because of a transient runtime fault; the operator can flip the
+      flag off if the gate misbehaves.
+    """
+    # Local imports — keep the cog/listener module light at import time
+    # and out of any module-load cycles.
+    from core.runtime import feature_flags
+    from utils.user_config_accessors import ParticipationState, get_participation
+
+    try:
+        flag_on = await feature_flags.is_enabled(
+            "participation.enabled",
+            guild_id,
+        )
+    except Exception as exc:  # noqa: BLE001 — gate must fall open on flag error
+        logger.warning(
+            "xp.listener: is_enabled(participation.enabled) raised for "
+            "guild=%d (%r); fall open",
+            guild_id,
+            exc,
+        )
+        return True
+    if not flag_on:
+        return True
+
+    try:
+        state = await get_participation(user_id, guild_id, "xp")
+    except Exception as exc:  # noqa: BLE001 — gate must fall open on accessor error
+        logger.warning(
+            "xp.listener: get_participation raised for user=%d guild=%d (%r); "
+            "fall open",
+            user_id,
+            guild_id,
+            exc,
+        )
+        return True
+    return state is not ParticipationState.OPTED_OUT
+
+
 async def handle_message(bot: commands.Bot, message: discord.Message) -> None:
     """The XP on_message hot path.  Bot/no-guild messages are dropped early.
 
@@ -54,6 +108,18 @@ async def handle_message(bot: commands.Bot, message: discord.Message) -> None:
     row = await db.get_xp(user_id, guild_id)
     on_cd, _ = check_cooldown(row["last_xp"], cfg.cooldown)
     if on_cd:
+        return
+
+    # Phase 2c PR-9 participation gate.  When ``participation.enabled``
+    # is OFF (the declared default), behavior is identical to pre-PR-9
+    # — every non-cooldown'd message awards XP.  When the flag is ON,
+    # a user who has opted out of the ``"xp"`` subsystem skips the
+    # award path entirely.  Opted-in / NOT_SET continue normally.
+    #
+    # Local imports preserve cycle-safety: ``core.runtime.feature_flags``
+    # and ``utils.user_config_accessors`` are only touched when this
+    # listener actually runs.
+    if not await _xp_participation_allowed(user_id, guild_id):
         return
 
     amount = random.randint(cfg.xp_min, cfg.xp_max)

--- a/disbot/core/events_catalogue.py
+++ b/disbot/core/events_catalogue.py
@@ -68,6 +68,16 @@ KNOWN_EVENTS: frozenset[str] = frozenset(
         "feature_flags.changed",
         "rollout.advanced",
         "environment_tier.changed",
+        # ── Participation (services/participation_mutation.py, Phase 2c PR-9) ─
+        # Advisory.  Cache invalidation is inline (synchronous w.r.t. the
+        # mutation result), NOT event-driven — these events are for
+        # downstream consumers (audit dashboards, future notification
+        # router) and never for cache consistency.  Subscriber failure
+        # logged + swallowed.
+        "participation.changed",
+        "subscription.changed",
+        "user_preference.changed",
+        "user_visibility.changed",
         # ── Future cog-emitted facts (uncomment when first emitter lands):
         # "economy.daily_claimed",
         # "mining.harvested",

--- a/disbot/migrations/028_user_participation_audit.sql
+++ b/disbot/migrations/028_user_participation_audit.sql
@@ -1,0 +1,142 @@
+-- Migration 028: user_participation_audit (Phase 2c PR-9).
+--
+-- Append-only audit log for every mutation that flows through
+-- :class:`services.participation_mutation.ParticipationMutationPipeline`.
+-- One row per mutation; rollback is a NEW row, never an UPDATE.
+--
+-- The single audit table hosts all four participation concerns via
+-- a ``mutation_type`` discriminator:
+--
+--   * ``set_participation``  — writes ``user_participation`` row.
+--                              Keys: ``subsystem``.
+--                              Values: ``prev_state`` / ``new_state``.
+--   * ``set_subscription``   — writes ``user_subscriptions`` row.
+--                              Keys: ``subsystem`` + ``topic``.
+--                              Values: ``prev_enabled`` / ``new_enabled``.
+--   * ``set_preference``     — writes ``user_preferences`` row.
+--                              Keys: ``key``.
+--                              Values: ``prev_value`` / ``new_value`` (JSONB).
+--   * ``set_visibility``     — writes ``user_visibility_overrides`` row.
+--                              Keys: ``subsystem``.
+--                              Values: ``prev_visibility`` / ``new_visibility``.
+--
+-- Per-``mutation_type`` shape CHECK constraints (defense-in-depth,
+-- mirrors the feature_flag_audit pattern from PR-3): a future
+-- caller that bypasses ``ParticipationMutationPipeline`` cannot
+-- insert a mis-shaped row.  ``mutation_type='set_subscription'``
+-- with a NULL ``topic`` is rejected at INSERT, etc.
+--
+-- Retention policy (per ``docs/platform-consistency-ledger.md`` §3):
+-- audit rows are **preserved** on guild leave, matching
+-- ``binding_audit_log`` and ``feature_flag_audit``.  The same user
+-- re-joining a guild sees the historical trail of their prior
+-- participation decisions.  Active participation rows (in the four
+-- migration-027 tables) ARE purged on guild leave so re-joining
+-- starts with the implicit default state.
+--
+-- Actor model:
+--
+--   * ``actor_type='user'`` — the user mutating their own state
+--     (self-authorised).  ``actor_id`` MUST equal ``user_id``.
+--   * ``actor_type='moderator'`` / ``'admin'`` — privileged
+--     override.  Modeled here so future PRs (Discord-facing
+--     commands, audit tooling) can land without a migration.
+--     ``actor_id`` is the moderator/admin's snowflake.
+--   * ``actor_type='system'`` — CI seeds, scripted ops.
+--     ``actor_id`` may be NULL.
+--   * ``actor_type='backfill'`` — reserved for future logical
+--     migrations.  Currently no callers.
+--
+-- Forward-only and idempotent.
+
+CREATE TABLE IF NOT EXISTS user_participation_audit (
+    id                  BIGSERIAL    PRIMARY KEY,
+    mutation_id         UUID         NOT NULL,
+    user_id             BIGINT       NOT NULL,
+    guild_id            BIGINT       NOT NULL,
+    mutation_type       TEXT         NOT NULL,
+    -- Per-concern key fields (vary by mutation_type)
+    subsystem           TEXT,
+    topic               TEXT,
+    key                 TEXT,
+    -- Per-concern value transitions (vary by mutation_type)
+    prev_state          TEXT,
+    new_state           TEXT,
+    prev_enabled        BOOLEAN,
+    new_enabled         BOOLEAN,
+    prev_value          JSONB,
+    new_value           JSONB,
+    prev_visibility     TEXT,
+    new_visibility      TEXT,
+    actor_id            BIGINT,
+    actor_type          TEXT         NOT NULL DEFAULT 'user',
+    at                  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    CHECK (mutation_type IN
+        ('set_participation', 'set_subscription', 'set_preference', 'set_visibility')),
+    CHECK (actor_type IN
+        ('user', 'moderator', 'admin', 'system', 'backfill')),
+    -- set_participation rows carry subsystem + state transition;
+    -- topic/key/enabled/value/visibility columns must be NULL.
+    CHECK (
+        mutation_type <> 'set_participation' OR (
+            subsystem IS NOT NULL
+            AND new_state IS NOT NULL
+            AND topic IS NULL
+            AND key IS NULL
+            AND prev_enabled IS NULL AND new_enabled IS NULL
+            AND prev_value IS NULL AND new_value IS NULL
+            AND prev_visibility IS NULL AND new_visibility IS NULL
+        )
+    ),
+    -- set_subscription rows carry subsystem + topic + enabled transition.
+    CHECK (
+        mutation_type <> 'set_subscription' OR (
+            subsystem IS NOT NULL
+            AND topic IS NOT NULL
+            AND new_enabled IS NOT NULL
+            AND key IS NULL
+            AND prev_state IS NULL AND new_state IS NULL
+            AND prev_value IS NULL AND new_value IS NULL
+            AND prev_visibility IS NULL AND new_visibility IS NULL
+        )
+    ),
+    -- set_preference rows carry key + JSONB value transition.
+    CHECK (
+        mutation_type <> 'set_preference' OR (
+            key IS NOT NULL
+            AND new_value IS NOT NULL
+            AND subsystem IS NULL
+            AND topic IS NULL
+            AND prev_state IS NULL AND new_state IS NULL
+            AND prev_enabled IS NULL AND new_enabled IS NULL
+            AND prev_visibility IS NULL AND new_visibility IS NULL
+        )
+    ),
+    -- set_visibility rows carry subsystem + visibility transition.
+    CHECK (
+        mutation_type <> 'set_visibility' OR (
+            subsystem IS NOT NULL
+            AND new_visibility IS NOT NULL
+            AND topic IS NULL
+            AND key IS NULL
+            AND prev_state IS NULL AND new_state IS NULL
+            AND prev_enabled IS NULL AND new_enabled IS NULL
+            AND prev_value IS NULL AND new_value IS NULL
+        )
+    ),
+    -- prev_state / new_state literals match user_participation CHECK.
+    CHECK (prev_state IS NULL OR prev_state IN ('opted_in', 'opted_out')),
+    CHECK (new_state IS NULL OR new_state IN ('opted_in', 'opted_out')),
+    -- prev_visibility / new_visibility literals match user_visibility_overrides CHECK.
+    CHECK (prev_visibility IS NULL OR prev_visibility IN ('public', 'hidden')),
+    CHECK (new_visibility IS NULL OR new_visibility IN ('public', 'hidden'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_participation_audit_user_guild_at
+    ON user_participation_audit (user_id, guild_id, at);
+
+CREATE INDEX IF NOT EXISTS idx_user_participation_audit_guild_at
+    ON user_participation_audit (guild_id, at);
+
+CREATE INDEX IF NOT EXISTS idx_user_participation_audit_mutation
+    ON user_participation_audit (mutation_id);

--- a/disbot/services/participation_mutation.py
+++ b/disbot/services/participation_mutation.py
@@ -1,0 +1,622 @@
+"""Participation mutation pipeline — Phase 2c PR-9.
+
+The canonical write path for the four per-user participation tables:
+
+  * ``user_participation``
+  * ``user_subscriptions``
+  * ``user_preferences``
+  * ``user_visibility_overrides``
+
+Mirrors the 7-step contract from
+:class:`services.binding_mutation.BindingMutationPipeline` and
+:class:`services.rollout_mutation.RolloutMutationPipeline`:
+
+  1. Input validation   — value shapes, enum literals
+  2. Authority          — actor_type in allowed set; self-write
+                          requires actor_id == user_id
+  3. Read previous      — for the audit row
+  4. DB write + audit   — single transaction via
+                          :mod:`utils.db.user_participation`
+  5. Cache invalidation — :func:`core.runtime.user_config.invalidate_user_guild`
+                          called inline AFTER the DB commit and
+                          BEFORE event emission
+  6. Event emission     — advisory, post-commit, never raises
+  7. Return result      — typed :class:`ParticipationMutationResult`
+                          carrying mutation_id for cross-pipeline
+                          correlation
+
+Authority model:
+
+* ``actor_type='user'`` — self-update.  ``actor_id`` MUST equal
+  ``user_id``; otherwise :class:`UnauthorizedParticipationMutationError`.
+* ``actor_type='moderator'`` / ``'admin'`` — privileged override.
+  ``actor_id`` required non-None and need not equal ``user_id``.
+  No Discord-facing surface invokes these in PR-9; they exist so a
+  future moderation tool can land without a migration.
+* ``actor_type='system'`` — CI seeds / scripted ops.  ``actor_id``
+  may be NULL.
+* ``actor_type='backfill'`` — reserved for future logical migrations.
+  Currently no callers.
+
+Events (catalogued in ``core/events_catalogue.py``, advisory):
+
+* ``participation.changed``      — set_participation
+* ``subscription.changed``       — set_subscription
+* ``user_preference.changed``    — set_preference (value intentionally
+                                    omitted from payload)
+* ``user_visibility.changed``    — set_visibility
+
+Cache invalidation happens INLINE in step 5 (synchronous w.r.t. the
+mutation result), not via event subscription.  This matches the
+pattern in :class:`RolloutMutationPipeline` and keeps the user_config
+cache consistent with DB state even if the event bus subscriber
+crashes.
+
+Subscriber failure semantics: any exception from
+``core.events.bus.emit`` is logged with the ``mutation_id`` and
+swallowed.  DB state is authoritative; the event is best-effort.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from utils.db import user_participation as up_db
+
+logger = logging.getLogger("bot.services.participation_mutation")
+
+# ---------------------------------------------------------------------------
+# Catalogued event names (registered in core/events_catalogue.py).
+# ---------------------------------------------------------------------------
+
+EVT_PARTICIPATION_CHANGED = "participation.changed"
+EVT_SUBSCRIPTION_CHANGED = "subscription.changed"
+EVT_USER_PREFERENCE_CHANGED = "user_preference.changed"
+EVT_USER_VISIBILITY_CHANGED = "user_visibility.changed"
+
+# ---------------------------------------------------------------------------
+# Recognized literal sets (mirror migration 027 + 028 CHECK constraints).
+# Alignment tests pin these to the SQL CHECK literals.
+# ---------------------------------------------------------------------------
+
+_VALID_PARTICIPATION_STATES: frozenset[str] = frozenset({"opted_in", "opted_out"})
+_VALID_VISIBILITY_STATES: frozenset[str] = frozenset({"public", "hidden"})
+_ALLOWED_ACTOR_TYPES: frozenset[str] = frozenset(
+    {"user", "moderator", "admin", "system", "backfill"},
+)
+
+MutationType = Literal[
+    "set_participation",
+    "set_subscription",
+    "set_preference",
+    "set_visibility",
+]
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class ParticipationMutationError(Exception):
+    """Base class for failures from :class:`ParticipationMutationPipeline`."""
+
+
+class InvalidParticipationStateError(ParticipationMutationError):
+    """Raised when the supplied participation state is not recognised."""
+
+
+class InvalidVisibilityStateError(ParticipationMutationError):
+    """Raised when the supplied visibility state is not recognised."""
+
+
+class InvalidPreferenceValueError(ParticipationMutationError):
+    """Raised when the preference value is not JSON-serialisable."""
+
+
+class UnauthorizedParticipationMutationError(ParticipationMutationError):
+    """Raised when the actor is not allowed to perform this mutation."""
+
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ParticipationMutationResult:
+    """Outcome of a successful (or partially successful) mutation."""
+
+    mutation_id: str
+    user_id: int
+    guild_id: int
+    mutation_type: MutationType
+    subsystem: str | None
+    topic: str | None
+    key: str | None
+    prev_state: str | None
+    new_state: str | None
+    prev_enabled: bool | None
+    new_enabled: bool | None
+    prev_value: Any
+    new_value: Any
+    prev_visibility: str | None
+    new_visibility: str | None
+    actor_id: int | None
+    actor_type: str
+    committed_at: datetime
+    event_emitted: bool
+
+
+# ---------------------------------------------------------------------------
+# Pipeline
+# ---------------------------------------------------------------------------
+
+
+class ParticipationMutationPipeline:
+    """Centralised orchestration for per-user participation writes.
+
+    Stateless — create one per mutation request.  Four public methods,
+    one per concern.  All follow the same 7-step contract documented
+    in the module docstring.
+    """
+
+    def __init__(self) -> None:
+        # No instance state.
+        pass
+
+    # ------------------------------------------------------------------
+    # set_participation
+    # ------------------------------------------------------------------
+
+    async def set_participation(
+        self,
+        *,
+        user_id: int,
+        guild_id: int,
+        subsystem: str,
+        state: str,
+        actor_id: int | None,
+        actor_type: str = "user",
+    ) -> ParticipationMutationResult:
+        """Opt the user in/out of ``subsystem`` for this guild."""
+        if state not in _VALID_PARTICIPATION_STATES:
+            raise InvalidParticipationStateError(
+                f"state must be one of {sorted(_VALID_PARTICIPATION_STATES)}, "
+                f"got {state!r}",
+            )
+        self._validate_authority(user_id, actor_id, actor_type)
+
+        mutation_id = str(uuid.uuid4())
+        prev_row = await up_db.get_participation(user_id, guild_id, subsystem)
+        prev_state = prev_row["state"] if prev_row else None
+        try:
+            await up_db.upsert_participation_with_audit(
+                user_id=user_id,
+                guild_id=guild_id,
+                subsystem=subsystem,
+                state=state,
+                actor_id=actor_id,
+                actor_type=actor_type,
+                mutation_id=mutation_id,
+                prev_state=prev_state,
+            )
+        except Exception:
+            logger.exception(
+                "ParticipationMutationPipeline.set_participation: DB transaction "
+                "failed for user=%d guild=%d subsystem=%r; no cache invalidation, "
+                "no event emission.",
+                user_id,
+                guild_id,
+                subsystem,
+            )
+            raise
+        _invalidate_cache(user_id, guild_id)
+        committed_at = _now_utc()
+        event_emitted = await _emit(
+            EVT_PARTICIPATION_CHANGED,
+            mutation_id=mutation_id,
+            user_id=user_id,
+            guild_id=guild_id,
+            subsystem=subsystem,
+            prev_state=prev_state,
+            new_state=state,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            committed_at=committed_at,
+        )
+        return ParticipationMutationResult(
+            mutation_id=mutation_id,
+            user_id=user_id,
+            guild_id=guild_id,
+            mutation_type="set_participation",
+            subsystem=subsystem,
+            topic=None,
+            key=None,
+            prev_state=prev_state,
+            new_state=state,
+            prev_enabled=None,
+            new_enabled=None,
+            prev_value=None,
+            new_value=None,
+            prev_visibility=None,
+            new_visibility=None,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            committed_at=committed_at,
+            event_emitted=event_emitted,
+        )
+
+    # ------------------------------------------------------------------
+    # set_subscription
+    # ------------------------------------------------------------------
+
+    async def set_subscription(
+        self,
+        *,
+        user_id: int,
+        guild_id: int,
+        subsystem: str,
+        topic: str,
+        enabled: bool,
+        actor_id: int | None,
+        actor_type: str = "user",
+    ) -> ParticipationMutationResult:
+        """Set the user's topic-level subscription for ``(subsystem, topic)``."""
+        if not isinstance(enabled, bool):
+            raise ParticipationMutationError(
+                f"enabled must be bool, got {type(enabled).__name__}",
+            )
+        self._validate_authority(user_id, actor_id, actor_type)
+
+        mutation_id = str(uuid.uuid4())
+        prev_row = await up_db.get_subscription(user_id, guild_id, subsystem, topic)
+        prev_enabled = prev_row["enabled"] if prev_row else None
+        try:
+            await up_db.upsert_subscription_with_audit(
+                user_id=user_id,
+                guild_id=guild_id,
+                subsystem=subsystem,
+                topic=topic,
+                enabled=enabled,
+                actor_id=actor_id,
+                actor_type=actor_type,
+                mutation_id=mutation_id,
+                prev_enabled=prev_enabled,
+            )
+        except Exception:
+            logger.exception(
+                "ParticipationMutationPipeline.set_subscription: DB transaction "
+                "failed for user=%d guild=%d subsystem=%r topic=%r; no cache "
+                "invalidation, no event emission.",
+                user_id,
+                guild_id,
+                subsystem,
+                topic,
+            )
+            raise
+        _invalidate_cache(user_id, guild_id)
+        committed_at = _now_utc()
+        event_emitted = await _emit(
+            EVT_SUBSCRIPTION_CHANGED,
+            mutation_id=mutation_id,
+            user_id=user_id,
+            guild_id=guild_id,
+            subsystem=subsystem,
+            topic=topic,
+            prev_enabled=prev_enabled,
+            new_enabled=enabled,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            committed_at=committed_at,
+        )
+        return ParticipationMutationResult(
+            mutation_id=mutation_id,
+            user_id=user_id,
+            guild_id=guild_id,
+            mutation_type="set_subscription",
+            subsystem=subsystem,
+            topic=topic,
+            key=None,
+            prev_state=None,
+            new_state=None,
+            prev_enabled=prev_enabled,
+            new_enabled=enabled,
+            prev_value=None,
+            new_value=None,
+            prev_visibility=None,
+            new_visibility=None,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            committed_at=committed_at,
+            event_emitted=event_emitted,
+        )
+
+    # ------------------------------------------------------------------
+    # set_preference
+    # ------------------------------------------------------------------
+
+    async def set_preference(
+        self,
+        *,
+        user_id: int,
+        guild_id: int,
+        key: str,
+        value: Any,
+        actor_id: int | None,
+        actor_type: str = "user",
+    ) -> ParticipationMutationResult:
+        """Set a JSONB preference for the user."""
+        if value is None:
+            raise InvalidPreferenceValueError(
+                "preference value must not be None; use a clear primitive "
+                "later if needed",
+            )
+        # JSON-serialisability check.  The DB layer will encode again,
+        # but failing fast here is friendlier than asyncpg's error.
+        import json as _json
+
+        try:
+            _json.dumps(value, default=str)
+        except (TypeError, ValueError) as exc:
+            raise InvalidPreferenceValueError(
+                f"preference value is not JSON-serialisable: {exc}",
+            ) from exc
+        self._validate_authority(user_id, actor_id, actor_type)
+
+        mutation_id = str(uuid.uuid4())
+        prev_row = await up_db.get_preference(user_id, guild_id, key)
+        prev_value = prev_row["value"] if prev_row else None
+        try:
+            await up_db.upsert_preference_with_audit(
+                user_id=user_id,
+                guild_id=guild_id,
+                key=key,
+                value=value,
+                actor_id=actor_id,
+                actor_type=actor_type,
+                mutation_id=mutation_id,
+                prev_value=prev_value,
+            )
+        except Exception:
+            logger.exception(
+                "ParticipationMutationPipeline.set_preference: DB transaction "
+                "failed for user=%d guild=%d key=%r; no cache invalidation, "
+                "no event emission.",
+                user_id,
+                guild_id,
+                key,
+            )
+            raise
+        _invalidate_cache(user_id, guild_id)
+        committed_at = _now_utc()
+        # Event payload deliberately omits the value (could contain PII).
+        event_emitted = await _emit(
+            EVT_USER_PREFERENCE_CHANGED,
+            mutation_id=mutation_id,
+            user_id=user_id,
+            guild_id=guild_id,
+            key=key,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            committed_at=committed_at,
+        )
+        return ParticipationMutationResult(
+            mutation_id=mutation_id,
+            user_id=user_id,
+            guild_id=guild_id,
+            mutation_type="set_preference",
+            subsystem=None,
+            topic=None,
+            key=key,
+            prev_state=None,
+            new_state=None,
+            prev_enabled=None,
+            new_enabled=None,
+            prev_value=prev_value,
+            new_value=value,
+            prev_visibility=None,
+            new_visibility=None,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            committed_at=committed_at,
+            event_emitted=event_emitted,
+        )
+
+    # ------------------------------------------------------------------
+    # set_visibility
+    # ------------------------------------------------------------------
+
+    async def set_visibility(
+        self,
+        *,
+        user_id: int,
+        guild_id: int,
+        subsystem: str,
+        visibility: str,
+        actor_id: int | None,
+        actor_type: str = "user",
+    ) -> ParticipationMutationResult:
+        """Set the user's visibility override for ``subsystem``."""
+        if visibility not in _VALID_VISIBILITY_STATES:
+            raise InvalidVisibilityStateError(
+                f"visibility must be one of {sorted(_VALID_VISIBILITY_STATES)}, "
+                f"got {visibility!r}",
+            )
+        self._validate_authority(user_id, actor_id, actor_type)
+
+        mutation_id = str(uuid.uuid4())
+        prev_row = await up_db.get_visibility(user_id, guild_id, subsystem)
+        prev_visibility = prev_row["visibility"] if prev_row else None
+        try:
+            await up_db.upsert_visibility_with_audit(
+                user_id=user_id,
+                guild_id=guild_id,
+                subsystem=subsystem,
+                visibility=visibility,
+                actor_id=actor_id,
+                actor_type=actor_type,
+                mutation_id=mutation_id,
+                prev_visibility=prev_visibility,
+            )
+        except Exception:
+            logger.exception(
+                "ParticipationMutationPipeline.set_visibility: DB transaction "
+                "failed for user=%d guild=%d subsystem=%r; no cache "
+                "invalidation, no event emission.",
+                user_id,
+                guild_id,
+                subsystem,
+            )
+            raise
+        _invalidate_cache(user_id, guild_id)
+        committed_at = _now_utc()
+        event_emitted = await _emit(
+            EVT_USER_VISIBILITY_CHANGED,
+            mutation_id=mutation_id,
+            user_id=user_id,
+            guild_id=guild_id,
+            subsystem=subsystem,
+            prev_visibility=prev_visibility,
+            new_visibility=visibility,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            committed_at=committed_at,
+        )
+        return ParticipationMutationResult(
+            mutation_id=mutation_id,
+            user_id=user_id,
+            guild_id=guild_id,
+            mutation_type="set_visibility",
+            subsystem=subsystem,
+            topic=None,
+            key=None,
+            prev_state=None,
+            new_state=None,
+            prev_enabled=None,
+            new_enabled=None,
+            prev_value=None,
+            new_value=None,
+            prev_visibility=prev_visibility,
+            new_visibility=visibility,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            committed_at=committed_at,
+            event_emitted=event_emitted,
+        )
+
+    # ------------------------------------------------------------------
+    # Validation helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _validate_authority(
+        user_id: int,
+        actor_id: int | None,
+        actor_type: str,
+    ) -> None:
+        """Authority rules (PR-9 minimum surface).
+
+        * 'user' → actor_id MUST equal user_id (self-update only).
+        * 'moderator' / 'admin' → actor_id required non-None and may
+          differ from user_id (privileged override).
+        * 'system' / 'backfill' → actor_id may be None.
+        """
+        if actor_type not in _ALLOWED_ACTOR_TYPES:
+            raise UnauthorizedParticipationMutationError(
+                f"actor_type must be one of {sorted(_ALLOWED_ACTOR_TYPES)}, "
+                f"got {actor_type!r}",
+            )
+        if actor_type == "user":
+            if actor_id is None or actor_id != user_id:
+                raise UnauthorizedParticipationMutationError(
+                    f"actor_type='user' requires actor_id == user_id "
+                    f"({actor_id!r} != {user_id!r})",
+                )
+        elif actor_type in ("moderator", "admin"):
+            if actor_id is None:
+                raise UnauthorizedParticipationMutationError(
+                    f"actor_type={actor_type!r} requires non-None actor_id",
+                )
+        # 'system' / 'backfill' may have None actor_id
+
+
+# ---------------------------------------------------------------------------
+# Step 5 helper: cache invalidation (synchronous w.r.t. the result).
+# ---------------------------------------------------------------------------
+
+
+def _invalidate_cache(user_id: int, guild_id: int) -> None:
+    """Drop the cached bundle for ``(user, guild)`` so the next read reloads.
+
+    Local import keeps this module light at import time and matches
+    the existing cycle-safety discipline.
+    """
+    try:
+        from core.runtime import user_config
+
+        user_config.invalidate_user_guild(user_id, guild_id)
+    except Exception:
+        # Cache invalidation MUST NOT raise into the mutation flow.
+        # Worst case: a stale read for up to TTL_SECS until the
+        # entry expires naturally.  Log and continue.
+        logger.exception(
+            "ParticipationMutationPipeline: cache invalidation raised for "
+            "user=%d guild=%d; DB state is correct, cache will expire via TTL",
+            user_id,
+            guild_id,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Step 6 helper: advisory event emission.  Failures swallowed.
+# ---------------------------------------------------------------------------
+
+
+async def _emit(event_name: str, *, committed_at: datetime, **payload: Any) -> bool:
+    """Emit a catalogued event with the standard payload shape.
+
+    Returns ``True`` on success, ``False`` if emission raised.  The
+    DB state is correct in both cases.
+    """
+    from core.events import bus
+
+    try:
+        await bus.emit(
+            event_name,
+            occurred_at=committed_at.isoformat(),
+            **payload,
+        )
+    except Exception:
+        logger.exception(
+            "ParticipationMutationPipeline._emit: emission failed for "
+            "event=%r mutation_id=%s; DB state is correct, event lost.",
+            event_name,
+            payload.get("mutation_id"),
+        )
+        return False
+    return True
+
+
+def _now_utc() -> datetime:
+    """Return a tz-aware "now" — INV-N forbids bare datetime.utcnow."""
+    return datetime.now(timezone.utc)
+
+
+__all__ = [
+    "EVT_PARTICIPATION_CHANGED",
+    "EVT_SUBSCRIPTION_CHANGED",
+    "EVT_USER_PREFERENCE_CHANGED",
+    "EVT_USER_VISIBILITY_CHANGED",
+    "InvalidParticipationStateError",
+    "InvalidPreferenceValueError",
+    "InvalidVisibilityStateError",
+    "ParticipationMutationError",
+    "ParticipationMutationPipeline",
+    "ParticipationMutationResult",
+    "UnauthorizedParticipationMutationError",
+]

--- a/disbot/utils/db/user_participation.py
+++ b/disbot/utils/db/user_participation.py
@@ -298,14 +298,261 @@ async def delete_for_guild(guild_id: int) -> int:
     return sum(_parse_delete_count(r) for r in (r1, r2, r3, r4))
 
 
+# ---------------------------------------------------------------------------
+# Atomic write + audit primitives (Phase 2c PR-9)
+#
+# Every mutation is one transaction: target row UPSERT + audit row INSERT.
+# Called only by services.participation_mutation.ParticipationMutationPipeline;
+# direct invocation from cog/service code is forbidden by the
+# pipeline-write-authority invariant.
+# ---------------------------------------------------------------------------
+
+
+async def upsert_participation_with_audit(
+    *,
+    user_id: int,
+    guild_id: int,
+    subsystem: str,
+    state: str,
+    actor_id: int | None,
+    actor_type: str,
+    mutation_id: str,
+    prev_state: str | None,
+) -> None:
+    """Atomic: upsert ``user_participation`` row + write audit row."""
+    async with pool.get().acquire() as conn, conn.transaction():
+        await conn.execute(
+            """
+            INSERT INTO user_participation
+                (user_id, guild_id, subsystem, state, set_at, set_by)
+            VALUES ($1, $2, $3, $4, NOW(), $5)
+            ON CONFLICT (user_id, guild_id, subsystem) DO UPDATE SET
+                state = EXCLUDED.state,
+                set_at = NOW(),
+                set_by = EXCLUDED.set_by
+            """,
+            user_id,
+            guild_id,
+            subsystem,
+            state,
+            actor_id,
+        )
+        await conn.execute(
+            """
+            INSERT INTO user_participation_audit
+                (mutation_id, user_id, guild_id, mutation_type,
+                 subsystem, prev_state, new_state,
+                 actor_id, actor_type)
+            VALUES ($1, $2, $3, 'set_participation', $4, $5, $6, $7, $8)
+            """,
+            mutation_id,
+            user_id,
+            guild_id,
+            subsystem,
+            prev_state,
+            state,
+            actor_id,
+            actor_type,
+        )
+
+
+async def upsert_subscription_with_audit(
+    *,
+    user_id: int,
+    guild_id: int,
+    subsystem: str,
+    topic: str,
+    enabled: bool,
+    actor_id: int | None,
+    actor_type: str,
+    mutation_id: str,
+    prev_enabled: bool | None,
+) -> None:
+    """Atomic: upsert ``user_subscriptions`` row + write audit row."""
+    async with pool.get().acquire() as conn, conn.transaction():
+        await conn.execute(
+            """
+            INSERT INTO user_subscriptions
+                (user_id, guild_id, subsystem, topic, enabled, set_at, set_by)
+            VALUES ($1, $2, $3, $4, $5, NOW(), $6)
+            ON CONFLICT (user_id, guild_id, subsystem, topic) DO UPDATE SET
+                enabled = EXCLUDED.enabled,
+                set_at = NOW(),
+                set_by = EXCLUDED.set_by
+            """,
+            user_id,
+            guild_id,
+            subsystem,
+            topic,
+            enabled,
+            actor_id,
+        )
+        await conn.execute(
+            """
+            INSERT INTO user_participation_audit
+                (mutation_id, user_id, guild_id, mutation_type,
+                 subsystem, topic, prev_enabled, new_enabled,
+                 actor_id, actor_type)
+            VALUES ($1, $2, $3, 'set_subscription', $4, $5, $6, $7, $8, $9)
+            """,
+            mutation_id,
+            user_id,
+            guild_id,
+            subsystem,
+            topic,
+            prev_enabled,
+            enabled,
+            actor_id,
+            actor_type,
+        )
+
+
+async def upsert_preference_with_audit(
+    *,
+    user_id: int,
+    guild_id: int,
+    key: str,
+    value: Any,
+    actor_id: int | None,
+    actor_type: str,
+    mutation_id: str,
+    prev_value: Any,
+) -> None:
+    """Atomic: upsert ``user_preferences`` row + write audit row.
+
+    Both ``value`` and ``prev_value`` are JSON-encoded for the JSONB
+    columns.  ``None`` for ``prev_value`` is treated as SQL NULL.
+    """
+    serialised_new = json.dumps(value, default=str)
+    serialised_prev = (
+        None if prev_value is None else json.dumps(prev_value, default=str)
+    )
+    async with pool.get().acquire() as conn, conn.transaction():
+        await conn.execute(
+            """
+            INSERT INTO user_preferences
+                (user_id, guild_id, key, value, set_at, set_by)
+            VALUES ($1, $2, $3, $4, NOW(), $5)
+            ON CONFLICT (user_id, guild_id, key) DO UPDATE SET
+                value = EXCLUDED.value,
+                set_at = NOW(),
+                set_by = EXCLUDED.set_by
+            """,
+            user_id,
+            guild_id,
+            key,
+            serialised_new,
+            actor_id,
+        )
+        await conn.execute(
+            """
+            INSERT INTO user_participation_audit
+                (mutation_id, user_id, guild_id, mutation_type,
+                 key, prev_value, new_value,
+                 actor_id, actor_type)
+            VALUES ($1, $2, $3, 'set_preference', $4, $5, $6, $7, $8)
+            """,
+            mutation_id,
+            user_id,
+            guild_id,
+            key,
+            serialised_prev,
+            serialised_new,
+            actor_id,
+            actor_type,
+        )
+
+
+async def upsert_visibility_with_audit(
+    *,
+    user_id: int,
+    guild_id: int,
+    subsystem: str,
+    visibility: str,
+    actor_id: int | None,
+    actor_type: str,
+    mutation_id: str,
+    prev_visibility: str | None,
+) -> None:
+    """Atomic: upsert ``user_visibility_overrides`` row + write audit row."""
+    async with pool.get().acquire() as conn, conn.transaction():
+        await conn.execute(
+            """
+            INSERT INTO user_visibility_overrides
+                (user_id, guild_id, subsystem, visibility, set_at, set_by)
+            VALUES ($1, $2, $3, $4, NOW(), $5)
+            ON CONFLICT (user_id, guild_id, subsystem) DO UPDATE SET
+                visibility = EXCLUDED.visibility,
+                set_at = NOW(),
+                set_by = EXCLUDED.set_by
+            """,
+            user_id,
+            guild_id,
+            subsystem,
+            visibility,
+            actor_id,
+        )
+        await conn.execute(
+            """
+            INSERT INTO user_participation_audit
+                (mutation_id, user_id, guild_id, mutation_type,
+                 subsystem, prev_visibility, new_visibility,
+                 actor_id, actor_type)
+            VALUES ($1, $2, $3, 'set_visibility', $4, $5, $6, $7, $8)
+            """,
+            mutation_id,
+            user_id,
+            guild_id,
+            subsystem,
+            prev_visibility,
+            visibility,
+            actor_id,
+            actor_type,
+        )
+
+
+async def get_audit_count(
+    *,
+    user_id: int | None = None,
+    guild_id: int | None = None,
+    mutation_type: str | None = None,
+) -> int:
+    """Return audit-row count, optionally filtered.
+
+    Used by tests + future diagnostics to assert audit rows landed.
+    """
+    clauses: list[str] = []
+    args: list[Any] = []
+    if user_id is not None:
+        args.append(user_id)
+        clauses.append(f"user_id = ${len(args)}")
+    if guild_id is not None:
+        args.append(guild_id)
+        clauses.append(f"guild_id = ${len(args)}")
+    if mutation_type is not None:
+        args.append(mutation_type)
+        clauses.append(f"mutation_type = ${len(args)}")
+    where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+    row = await pool.get().fetchrow(
+        f"SELECT COUNT(*)::int AS n FROM user_participation_audit {where}",
+        *args,
+    )
+    return int(row["n"]) if row else 0
+
+
 __all__ = [
     "PARTICIPATION_STATES",
     "VISIBILITY_STATES",
     "count_rows",
     "delete_for_guild",
+    "get_audit_count",
     "get_participation",
     "get_preference",
     "get_subscription",
     "get_visibility",
     "list_for_user",
+    "upsert_participation_with_audit",
+    "upsert_preference_with_audit",
+    "upsert_subscription_with_audit",
+    "upsert_visibility_with_audit",
 ]

--- a/tests/unit/cogs/test_xp_participation_gate.py
+++ b/tests/unit/cogs/test_xp_participation_gate.py
@@ -1,0 +1,296 @@
+"""Phase 2c PR-9 — XP opt-out gate in cogs.xp.listener.
+
+Verifies the gate's behavior matrix:
+
+* ``participation.enabled`` OFF (declared default) → XP awarded
+  regardless of participation state (pre-PR-9 parity).
+* ``participation.enabled`` ON + user OPTED_OUT → XP NOT awarded.
+* ``participation.enabled`` ON + user OPTED_IN → XP awarded.
+* ``participation.enabled`` ON + user NOT_SET → XP awarded.
+* Flag evaluator failure → gate falls open (XP awarded).
+* Participation accessor failure → gate falls open (XP awarded).
+
+The gate is the only PR-9 mutation to the XP hot path; the rest of
+``handle_message`` (cooldown, cache, level-up announce) is exercised
+by the existing ``tests/unit/cogs/test_xp_cog_caching.py`` suite.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from utils.user_config_accessors import ParticipationState
+
+
+def _make_message(*, guild_id: int = 99, user_id: int = 1):
+    msg = MagicMock()
+    msg.author = MagicMock()
+    msg.author.bot = False
+    msg.author.id = user_id
+    msg.guild = MagicMock()
+    msg.guild.id = guild_id
+    return msg
+
+
+def _patch_xp_pipeline(*, on_cooldown: bool = False):
+    """Patch the XP message-handling dependencies.
+
+    Returns a context manager that yields the mocked
+    ``xp_service.award`` so tests can assert whether it was awaited.
+    """
+    from contextlib import contextmanager
+
+    from core.runtime import guild_config
+    from core.runtime.config_arbitration import ConfigReadResult
+
+    @contextmanager
+    def _ctx():
+        guild_config._reset_for_tests()
+        last_xp = 0 if not on_cooldown else 9999999999  # far future on cooldown
+        db_row = {"last_xp": last_xp, "messages": 1}
+        with (
+            patch(
+                "cogs.xp.listener.db.get_xp",
+                new_callable=AsyncMock,
+                return_value=db_row,
+            ),
+            patch(
+                "utils.guild_config_accessors.db.get_setting",
+                new_callable=AsyncMock,
+            ) as get_setting,
+            patch(
+                "core.runtime.config_arbitration.get_xp_announce_channel",
+                new_callable=AsyncMock,
+                return_value=ConfigReadResult(
+                    value=None,
+                    source="missing",
+                    binding_status="n/a",
+                    flag_state="off",
+                    diagnostics=[],
+                ),
+            ),
+            patch(
+                "cogs.xp.listener.check_cooldown",
+                return_value=(on_cooldown, 0),
+            ),
+            patch(
+                "cogs.xp.listener.xp_service.award",
+                new_callable=AsyncMock,
+            ) as mock_award,
+        ):
+
+            async def reply(guild_id, key, default=""):  # noqa: ARG001
+                return {
+                    "xp_min": "15",
+                    "xp_max": "25",
+                    "xp_cooldown": "60",
+                }.get(key, default)
+
+            get_setting.side_effect = reply
+            mock_award.return_value = MagicMock(
+                new_xp=100,
+                new_level=1,
+                leveled_up=False,
+            )
+            yield mock_award
+        guild_config._reset_for_tests()
+
+    return _ctx()
+
+
+# ---------------------------------------------------------------------------
+# Flag OFF: behavior unchanged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_flag_off_awards_xp_regardless_of_participation_state():
+    """Default state: ``participation.enabled`` OFF.
+
+    XP behaves exactly as it did pre-PR-9; the gate never blocks.
+    """
+    from cogs.xp.listener import handle_message
+
+    with (
+        _patch_xp_pipeline() as mock_award,
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        # Even if get_participation returns OPTED_OUT, the gate must
+        # not consult it when the flag is OFF — we verify by asserting
+        # XP was awarded regardless.
+        patch(
+            "utils.user_config_accessors.get_participation",
+            new_callable=AsyncMock,
+            return_value=ParticipationState.OPTED_OUT,
+        ),
+    ):
+        bot = MagicMock()
+        await handle_message(bot, _make_message())
+    mock_award.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_flag_off_does_not_call_get_participation():
+    """With the flag OFF, the accessor must never be invoked (perf + correctness)."""
+    from cogs.xp.listener import handle_message
+
+    with (
+        _patch_xp_pipeline() as mock_award,
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "utils.user_config_accessors.get_participation",
+            new_callable=AsyncMock,
+        ) as mock_get,
+    ):
+        bot = MagicMock()
+        await handle_message(bot, _make_message())
+    mock_get.assert_not_awaited()
+    mock_award.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Flag ON
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_flag_on_opted_out_blocks_xp():
+    from cogs.xp.listener import handle_message
+
+    with (
+        _patch_xp_pipeline() as mock_award,
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "utils.user_config_accessors.get_participation",
+            new_callable=AsyncMock,
+            return_value=ParticipationState.OPTED_OUT,
+        ),
+    ):
+        bot = MagicMock()
+        await handle_message(bot, _make_message())
+    mock_award.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_flag_on_opted_in_awards_xp():
+    from cogs.xp.listener import handle_message
+
+    with (
+        _patch_xp_pipeline() as mock_award,
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "utils.user_config_accessors.get_participation",
+            new_callable=AsyncMock,
+            return_value=ParticipationState.OPTED_IN,
+        ),
+    ):
+        bot = MagicMock()
+        await handle_message(bot, _make_message())
+    mock_award.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_flag_on_not_set_awards_xp():
+    """NOT_SET treats the user as not-opted-out (default-allow)."""
+    from cogs.xp.listener import handle_message
+
+    with (
+        _patch_xp_pipeline() as mock_award,
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "utils.user_config_accessors.get_participation",
+            new_callable=AsyncMock,
+            return_value=ParticipationState.NOT_SET,
+        ),
+    ):
+        bot = MagicMock()
+        await handle_message(bot, _make_message())
+    mock_award.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Fail-open: a transient error in the gate never blocks XP
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_flag_evaluator_failure_falls_open():
+    """If is_enabled raises, treat as flag OFF — XP is awarded."""
+    from cogs.xp.listener import handle_message
+
+    with (
+        _patch_xp_pipeline() as mock_award,
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("evaluator crashed"),
+        ),
+        patch(
+            "utils.user_config_accessors.get_participation",
+            new_callable=AsyncMock,
+            return_value=ParticipationState.OPTED_OUT,
+        ),
+    ):
+        bot = MagicMock()
+        await handle_message(bot, _make_message())
+    mock_award.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_participation_accessor_failure_falls_open():
+    """If get_participation raises, treat as not-opted-out — XP is awarded."""
+    from cogs.xp.listener import handle_message
+
+    with (
+        _patch_xp_pipeline() as mock_award,
+        patch(
+            "core.runtime.feature_flags.is_enabled",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "utils.user_config_accessors.get_participation",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("DB blip"),
+        ),
+    ):
+        bot = MagicMock()
+        await handle_message(bot, _make_message())
+    mock_award.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Centralisation invariant — the gate lives in one helper, not scattered
+# across the listener body.
+# ---------------------------------------------------------------------------
+
+
+def test_xp_listener_has_centralised_gate_helper():
+    """The gate is a single named helper, not inlined into handle_message."""
+    import cogs.xp.listener as listener_module
+
+    assert hasattr(
+        listener_module,
+        "_xp_participation_allowed",
+    ), "XP participation gate must be a named helper for testability + reuse"

--- a/tests/unit/invariants/test_user_participation_audit_alignment.py
+++ b/tests/unit/invariants/test_user_participation_audit_alignment.py
@@ -1,0 +1,166 @@
+"""Phase 2c PR-9 invariant — user_participation_audit literals align.
+
+Migration 028 ships CHECK constraints on
+``user_participation_audit``:
+
+* ``mutation_type`` — one of the four pipeline entrypoints
+* ``actor_type`` — actor model
+* ``prev_state`` / ``new_state`` — participation enum
+* ``prev_visibility`` / ``new_visibility`` — visibility enum
+* Per-``mutation_type`` shape clauses (set_participation /
+  set_subscription / set_preference / set_visibility) enforcing
+  which key/value columns must be NULL or NOT NULL.
+
+The Python pipeline carries matching ``frozenset``s in
+:mod:`services.participation_mutation`.  This test pins both
+sides so a drift on either fails CI.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_MIGRATION = (
+    Path(__file__).resolve().parents[3]
+    / "disbot"
+    / "migrations"
+    / "028_user_participation_audit.sql"
+)
+
+
+def _read() -> str:
+    return _MIGRATION.read_text()
+
+
+def _extract_in_set(column: str) -> set[str]:
+    sql = _read()
+    pattern = rf"CHECK\s*\(\s*{column}\s+IN\s*\(([^)]+)\)\s*\)"
+    match = re.search(pattern, sql)
+    assert match, f"could not locate {column} CHECK constraint"
+    return {
+        tok.strip().strip("'\"") for tok in match.group(1).split(",") if tok.strip()
+    }
+
+
+# ---------------------------------------------------------------------------
+# Top-level literal CHECK constraints
+# ---------------------------------------------------------------------------
+
+
+def test_mutation_type_literals_match_pipeline():
+    """``mutation_type`` CHECK matches the four pipeline entrypoint names."""
+    db_check = _extract_in_set("mutation_type")
+    expected = {
+        "set_participation",
+        "set_subscription",
+        "set_preference",
+        "set_visibility",
+    }
+    assert (
+        db_check == expected
+    ), f"mutation_type drift: db={sorted(db_check)} vs expected={sorted(expected)}"
+
+
+def test_actor_type_literals_match_pipeline_allowed_set():
+    from services.participation_mutation import _ALLOWED_ACTOR_TYPES
+
+    db_check = _extract_in_set("actor_type")
+    python = set(_ALLOWED_ACTOR_TYPES)
+    assert (
+        db_check == python
+    ), f"actor_type drift: db={sorted(db_check)} vs python={sorted(python)}"
+
+
+def test_state_literals_match_migration_027():
+    """audit ``prev_state`` / ``new_state`` literals match
+    user_participation.state from migration 027."""
+    from utils.db.user_participation import PARTICIPATION_STATES
+
+    sql = _read()
+    # Both prev_state and new_state share the same allow-list
+    state_clauses = re.findall(
+        r"prev_state IS NULL OR prev_state IN \(([^)]+)\)",
+        sql,
+    )
+    state_clauses += re.findall(
+        r"new_state IS NULL OR new_state IN \(([^)]+)\)",
+        sql,
+    )
+    assert (
+        len(state_clauses) == 2
+    ), "expected one CHECK clause for each of prev_state/new_state"
+    literals = {tok.strip().strip("'\"") for tok in state_clauses[0].split(",")}
+    assert literals == set(
+        PARTICIPATION_STATES
+    ), f"state CHECK drift: audit={sorted(literals)} vs python={sorted(PARTICIPATION_STATES)}"
+
+
+def test_visibility_literals_match_migration_027():
+    from utils.db.user_participation import VISIBILITY_STATES
+
+    sql = _read()
+    vis_clauses = re.findall(
+        r"prev_visibility IS NULL OR prev_visibility IN \(([^)]+)\)",
+        sql,
+    )
+    vis_clauses += re.findall(
+        r"new_visibility IS NULL OR new_visibility IN \(([^)]+)\)",
+        sql,
+    )
+    assert len(vis_clauses) == 2
+    literals = {tok.strip().strip("'\"") for tok in vis_clauses[0].split(",")}
+    assert literals == set(VISIBILITY_STATES)
+
+
+# ---------------------------------------------------------------------------
+# Per-mutation_type shape CHECK clauses
+# ---------------------------------------------------------------------------
+
+
+def test_set_participation_shape_check_present():
+    sql = _read()
+    assert "mutation_type <> 'set_participation'" in sql
+    assert "subsystem IS NOT NULL" in sql
+    assert "new_state IS NOT NULL" in sql
+
+
+def test_set_subscription_shape_check_present():
+    sql = _read()
+    assert "mutation_type <> 'set_subscription'" in sql
+    assert "topic IS NOT NULL" in sql
+    assert "new_enabled IS NOT NULL" in sql
+
+
+def test_set_preference_shape_check_present():
+    sql = _read()
+    assert "mutation_type <> 'set_preference'" in sql
+    assert "key IS NOT NULL" in sql
+    assert "new_value IS NOT NULL" in sql
+
+
+def test_set_visibility_shape_check_present():
+    sql = _read()
+    assert "mutation_type <> 'set_visibility'" in sql
+    assert "new_visibility IS NOT NULL" in sql
+
+
+def test_unused_columns_required_null_per_mutation_type():
+    """Each shape clause forces the unused concern columns to NULL.
+
+    Without these, a malformed row (e.g. set_preference with a
+    subsystem set) could escape the per-mutation_type contract.
+    """
+    sql = _read()
+    # Spot-check a few "must be NULL" assertions
+    for null_clause in (
+        # set_participation excludes topic + key + value/enabled/visibility
+        "topic IS NULL",
+        "key IS NULL",
+        "prev_enabled IS NULL AND new_enabled IS NULL",
+        "prev_value IS NULL AND new_value IS NULL",
+        "prev_visibility IS NULL AND new_visibility IS NULL",
+        # set_subscription excludes key + state + value + visibility
+        "prev_state IS NULL AND new_state IS NULL",
+    ):
+        assert null_clause in sql, f"missing NULL CHECK clause: {null_clause}"

--- a/tests/unit/participation/test_participation_mutation_pipeline.py
+++ b/tests/unit/participation/test_participation_mutation_pipeline.py
@@ -1,0 +1,576 @@
+"""Phase 2c PR-9 — ParticipationMutationPipeline 7-step contract.
+
+Mocks the DB primitives + the event bus so the pipeline can be
+exercised end-to-end without a real DB.  Covers:
+
+* Input validation per entrypoint (invalid state, invalid visibility,
+  invalid preference value, non-bool enabled).
+* Authority: actor_type allow-list; 'user' requires actor_id ==
+  user_id; 'moderator' / 'admin' require non-None actor_id; 'system'
+  may have None.
+* DB write happens in step 4; cache invalidation (step 5) happens
+  inline AFTER successful write; event (step 6) emits AFTER cache.
+* Event subscriber failure logged + swallowed; result.event_emitted
+  reflects it without rolling back the DB write.
+* DB failure → no cache invalidation, no event emission, exception
+  propagates.
+* Rollback semantics — flipping back writes a NEW audit row.
+* Each catalogued event name is registered in KNOWN_EVENTS.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services.participation_mutation import (
+    EVT_PARTICIPATION_CHANGED,
+    EVT_SUBSCRIPTION_CHANGED,
+    EVT_USER_PREFERENCE_CHANGED,
+    EVT_USER_VISIBILITY_CHANGED,
+    InvalidParticipationStateError,
+    InvalidPreferenceValueError,
+    InvalidVisibilityStateError,
+    ParticipationMutationError,
+    ParticipationMutationPipeline,
+    UnauthorizedParticipationMutationError,
+)
+
+
+@pytest.fixture
+def pipeline():
+    return ParticipationMutationPipeline()
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_participation_rejects_invalid_state(pipeline):
+    with pytest.raises(InvalidParticipationStateError):
+        await pipeline.set_participation(
+            user_id=1,
+            guild_id=2,
+            subsystem="xp",
+            state="maybe",
+            actor_id=1,
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_visibility_rejects_invalid_state(pipeline):
+    with pytest.raises(InvalidVisibilityStateError):
+        await pipeline.set_visibility(
+            user_id=1,
+            guild_id=2,
+            subsystem="xp",
+            visibility="indeterminate",
+            actor_id=1,
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_subscription_rejects_non_bool_enabled(pipeline):
+    with pytest.raises(ParticipationMutationError):
+        await pipeline.set_subscription(
+            user_id=1,
+            guild_id=2,
+            subsystem="economy",
+            topic="daily",
+            enabled="yes",  # type: ignore[arg-type]
+            actor_id=1,
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_preference_rejects_none_value(pipeline):
+    with pytest.raises(InvalidPreferenceValueError):
+        await pipeline.set_preference(
+            user_id=1,
+            guild_id=2,
+            key="digest_freq",
+            value=None,
+            actor_id=1,
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_preference_rejects_non_serialisable_value(pipeline):
+    """A truly non-serialisable value (circular reference) is rejected.
+
+    ``json.dumps`` with ``default=str`` tolerates almost any object,
+    but a circular structure still raises ``ValueError`` (max recursion).
+    The pipeline catches that as :class:`InvalidPreferenceValueError`.
+    """
+    cyclic: dict = {}
+    cyclic["self"] = cyclic
+    with pytest.raises(InvalidPreferenceValueError):
+        await pipeline.set_preference(
+            user_id=1,
+            guild_id=2,
+            key="weird",
+            value=cyclic,
+            actor_id=1,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Authority
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_user_actor_must_be_self(pipeline):
+    """actor_type='user' with actor_id != user_id is rejected."""
+    with pytest.raises(UnauthorizedParticipationMutationError):
+        await pipeline.set_participation(
+            user_id=1,
+            guild_id=2,
+            subsystem="xp",
+            state="opted_out",
+            actor_id=999,  # not self
+            actor_type="user",
+        )
+
+
+@pytest.mark.asyncio
+async def test_user_actor_requires_actor_id(pipeline):
+    with pytest.raises(UnauthorizedParticipationMutationError):
+        await pipeline.set_participation(
+            user_id=1,
+            guild_id=2,
+            subsystem="xp",
+            state="opted_out",
+            actor_id=None,
+            actor_type="user",
+        )
+
+
+@pytest.mark.asyncio
+async def test_unknown_actor_type_rejected(pipeline):
+    with pytest.raises(UnauthorizedParticipationMutationError):
+        await pipeline.set_participation(
+            user_id=1,
+            guild_id=2,
+            subsystem="xp",
+            state="opted_out",
+            actor_id=1,
+            actor_type="hacker",
+        )
+
+
+@pytest.mark.asyncio
+async def test_moderator_actor_requires_actor_id(pipeline):
+    with pytest.raises(UnauthorizedParticipationMutationError):
+        await pipeline.set_participation(
+            user_id=1,
+            guild_id=2,
+            subsystem="xp",
+            state="opted_out",
+            actor_id=None,
+            actor_type="moderator",
+        )
+
+
+@pytest.mark.asyncio
+async def test_system_actor_allowed_without_actor_id(pipeline):
+    """CI seeds use actor_type='system' with actor_id=None."""
+    with (
+        patch(
+            "utils.db.user_participation.get_participation",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.user_participation.upsert_participation_with_audit",
+            new_callable=AsyncMock,
+        ),
+        patch("core.events.bus.emit", new_callable=AsyncMock),
+        patch("core.runtime.user_config.invalidate_user_guild"),
+    ):
+        result = await pipeline.set_participation(
+            user_id=1,
+            guild_id=2,
+            subsystem="xp",
+            state="opted_in",
+            actor_id=None,
+            actor_type="system",
+        )
+    assert result.actor_type == "system"
+    assert result.actor_id is None
+
+
+# ---------------------------------------------------------------------------
+# Happy path: DB write → cache invalidate → event emit (in that order)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_participation_writes_db_invalidates_cache_emits_event(pipeline):
+    with (
+        patch(
+            "utils.db.user_participation.get_participation",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.user_participation.upsert_participation_with_audit",
+            new_callable=AsyncMock,
+        ) as mock_upsert,
+        patch(
+            "core.runtime.user_config.invalidate_user_guild",
+        ) as mock_invalidate,
+        patch("core.events.bus.emit", new_callable=AsyncMock) as mock_emit,
+    ):
+        result = await pipeline.set_participation(
+            user_id=42,
+            guild_id=99,
+            subsystem="xp",
+            state="opted_out",
+            actor_id=42,
+        )
+
+    # DB write with prev_state=None (no previous row)
+    upsert_call = mock_upsert.await_args
+    assert upsert_call.kwargs["user_id"] == 42
+    assert upsert_call.kwargs["guild_id"] == 99
+    assert upsert_call.kwargs["subsystem"] == "xp"
+    assert upsert_call.kwargs["state"] == "opted_out"
+    assert upsert_call.kwargs["prev_state"] is None
+    assert upsert_call.kwargs["actor_type"] == "user"
+
+    # Cache invalidated for this (user, guild)
+    mock_invalidate.assert_called_once_with(42, 99)
+
+    # Event emitted with full payload
+    emit_call = mock_emit.await_args
+    assert emit_call.args[0] == EVT_PARTICIPATION_CHANGED
+    assert emit_call.kwargs["user_id"] == 42
+    assert emit_call.kwargs["guild_id"] == 99
+    assert emit_call.kwargs["subsystem"] == "xp"
+    assert emit_call.kwargs["prev_state"] is None
+    assert emit_call.kwargs["new_state"] == "opted_out"
+    assert emit_call.kwargs["mutation_id"] == result.mutation_id
+    assert "occurred_at" in emit_call.kwargs
+
+    assert result.event_emitted is True
+    assert result.mutation_type == "set_participation"
+    assert isinstance(result.committed_at, datetime)
+    assert result.committed_at.tzinfo == timezone.utc
+
+
+@pytest.mark.asyncio
+async def test_set_subscription_emits_correct_event(pipeline):
+    with (
+        patch(
+            "utils.db.user_participation.get_subscription",
+            new_callable=AsyncMock,
+            return_value={"enabled": True},
+        ),
+        patch(
+            "utils.db.user_participation.upsert_subscription_with_audit",
+            new_callable=AsyncMock,
+        ) as mock_upsert,
+        patch("core.runtime.user_config.invalidate_user_guild"),
+        patch("core.events.bus.emit", new_callable=AsyncMock) as mock_emit,
+    ):
+        result = await pipeline.set_subscription(
+            user_id=1,
+            guild_id=2,
+            subsystem="economy",
+            topic="daily",
+            enabled=False,
+            actor_id=1,
+        )
+    assert mock_emit.await_args.args[0] == EVT_SUBSCRIPTION_CHANGED
+    assert mock_emit.await_args.kwargs["prev_enabled"] is True
+    assert mock_emit.await_args.kwargs["new_enabled"] is False
+    assert mock_upsert.await_args.kwargs["prev_enabled"] is True
+    assert result.mutation_type == "set_subscription"
+
+
+@pytest.mark.asyncio
+async def test_set_preference_event_omits_value(pipeline):
+    """Privacy: preference value MUST NOT appear in the event payload."""
+    with (
+        patch(
+            "utils.db.user_participation.get_preference",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.user_participation.upsert_preference_with_audit",
+            new_callable=AsyncMock,
+        ),
+        patch("core.runtime.user_config.invalidate_user_guild"),
+        patch("core.events.bus.emit", new_callable=AsyncMock) as mock_emit,
+    ):
+        result = await pipeline.set_preference(
+            user_id=1,
+            guild_id=2,
+            key="digest_freq",
+            value={"unit": "hours", "interval": 6},
+            actor_id=1,
+        )
+    emit_call = mock_emit.await_args
+    assert emit_call.args[0] == EVT_USER_PREFERENCE_CHANGED
+    assert "value" not in emit_call.kwargs
+    assert "prev_value" not in emit_call.kwargs
+    assert "new_value" not in emit_call.kwargs
+    # The result still carries the value for caller use
+    assert result.new_value == {"unit": "hours", "interval": 6}
+
+
+@pytest.mark.asyncio
+async def test_set_visibility_emits_correct_event(pipeline):
+    with (
+        patch(
+            "utils.db.user_participation.get_visibility",
+            new_callable=AsyncMock,
+            return_value={"visibility": "public"},
+        ),
+        patch(
+            "utils.db.user_participation.upsert_visibility_with_audit",
+            new_callable=AsyncMock,
+        ),
+        patch("core.runtime.user_config.invalidate_user_guild"),
+        patch("core.events.bus.emit", new_callable=AsyncMock) as mock_emit,
+    ):
+        await pipeline.set_visibility(
+            user_id=1,
+            guild_id=2,
+            subsystem="xp",
+            visibility="hidden",
+            actor_id=1,
+        )
+    assert mock_emit.await_args.args[0] == EVT_USER_VISIBILITY_CHANGED
+    assert mock_emit.await_args.kwargs["prev_visibility"] == "public"
+    assert mock_emit.await_args.kwargs["new_visibility"] == "hidden"
+
+
+# ---------------------------------------------------------------------------
+# Cache invalidation contract: synchronous, inline, BEFORE event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_invalidation_called_inline_after_write(pipeline):
+    """Cache is invalidated in the mutation flow, not via event subscription.
+
+    This is the architectural contract: even if no event subscriber is
+    listening (or the bus is down), the cache stays consistent with DB.
+    """
+    call_order: list[str] = []
+
+    async def fake_upsert(**_):
+        call_order.append("upsert")
+
+    def fake_invalidate(*_):
+        call_order.append("invalidate")
+
+    async def fake_emit(*_, **__):
+        call_order.append("emit")
+
+    with (
+        patch(
+            "utils.db.user_participation.get_participation",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.user_participation.upsert_participation_with_audit",
+            side_effect=fake_upsert,
+        ),
+        patch(
+            "core.runtime.user_config.invalidate_user_guild",
+            side_effect=fake_invalidate,
+        ),
+        patch(
+            "core.events.bus.emit",
+            side_effect=fake_emit,
+        ),
+    ):
+        await pipeline.set_participation(
+            user_id=1,
+            guild_id=2,
+            subsystem="xp",
+            state="opted_out",
+            actor_id=1,
+        )
+    assert call_order == ["upsert", "invalidate", "emit"]
+
+
+# ---------------------------------------------------------------------------
+# Event failure isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_event_failure_does_not_roll_back_db_write(pipeline):
+    """Subscriber failure logged + swallowed; result reflects but DB persists."""
+    with (
+        patch(
+            "utils.db.user_participation.get_participation",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.user_participation.upsert_participation_with_audit",
+            new_callable=AsyncMock,
+        ) as mock_upsert,
+        patch("core.runtime.user_config.invalidate_user_guild"),
+        patch(
+            "core.events.bus.emit",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("subscriber crashed"),
+        ),
+    ):
+        result = await pipeline.set_participation(
+            user_id=1,
+            guild_id=2,
+            subsystem="xp",
+            state="opted_out",
+            actor_id=1,
+        )
+    # DB write happened
+    mock_upsert.assert_awaited_once()
+    # Event flagged as not emitted
+    assert result.event_emitted is False
+    # But the mutation result itself is returned successfully
+    assert result.new_state == "opted_out"
+
+
+# ---------------------------------------------------------------------------
+# DB failure rolls back the entire flow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_db_failure_skips_cache_and_event(pipeline):
+    with (
+        patch(
+            "utils.db.user_participation.get_participation",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.user_participation.upsert_participation_with_audit",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("DB blip"),
+        ),
+        patch(
+            "core.runtime.user_config.invalidate_user_guild",
+        ) as mock_invalidate,
+        patch("core.events.bus.emit", new_callable=AsyncMock) as mock_emit,
+    ):
+        with pytest.raises(RuntimeError):
+            await pipeline.set_participation(
+                user_id=1,
+                guild_id=2,
+                subsystem="xp",
+                state="opted_out",
+                actor_id=1,
+            )
+    mock_invalidate.assert_not_called()
+    mock_emit.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Rollback semantics: new audit row, not in-place update
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rollback_writes_new_audit_row_not_in_place_update(pipeline):
+    upserts: list[dict] = []
+
+    async def capture(**kwargs):
+        upserts.append(kwargs)
+
+    with (
+        patch(
+            "utils.db.user_participation.get_participation",
+            new_callable=AsyncMock,
+            side_effect=[
+                None,
+                {"state": "opted_out"},
+            ],
+        ),
+        patch(
+            "utils.db.user_participation.upsert_participation_with_audit",
+            side_effect=capture,
+        ),
+        patch("core.runtime.user_config.invalidate_user_guild"),
+        patch("core.events.bus.emit", new_callable=AsyncMock),
+    ):
+        first = await pipeline.set_participation(
+            user_id=1,
+            guild_id=2,
+            subsystem="xp",
+            state="opted_out",
+            actor_id=1,
+        )
+        rollback = await pipeline.set_participation(
+            user_id=1,
+            guild_id=2,
+            subsystem="xp",
+            state="opted_in",
+            actor_id=1,
+        )
+    assert first.mutation_id != rollback.mutation_id
+    assert len(upserts) == 2
+    # Each write has its own mutation_id (UUID-shaped)
+    assert upserts[0]["mutation_id"] != upserts[1]["mutation_id"]
+    # Rollback captured the prior state correctly
+    assert upserts[1]["prev_state"] == "opted_out"
+    assert upserts[1]["state"] == "opted_in"
+
+
+# ---------------------------------------------------------------------------
+# Catalogue check
+# ---------------------------------------------------------------------------
+
+
+def test_phase_2c_pr9_events_in_catalogue():
+    from core.events_catalogue import KNOWN_EVENTS
+
+    assert EVT_PARTICIPATION_CHANGED in KNOWN_EVENTS
+    assert EVT_SUBSCRIPTION_CHANGED in KNOWN_EVENTS
+    assert EVT_USER_PREFERENCE_CHANGED in KNOWN_EVENTS
+    assert EVT_USER_VISIBILITY_CHANGED in KNOWN_EVENTS
+
+
+# ---------------------------------------------------------------------------
+# Result type carries UUID + tz-aware committed_at
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_result_carries_uuid_mutation_id_and_tz_aware_committed_at(pipeline):
+    with (
+        patch(
+            "utils.db.user_participation.get_participation",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "utils.db.user_participation.upsert_participation_with_audit",
+            new_callable=AsyncMock,
+        ),
+        patch("core.runtime.user_config.invalidate_user_guild"),
+        patch("core.events.bus.emit", new_callable=AsyncMock),
+    ):
+        result = await pipeline.set_participation(
+            user_id=1,
+            guild_id=2,
+            subsystem="xp",
+            state="opted_in",
+            actor_id=1,
+        )
+    assert isinstance(result.mutation_id, str)
+    assert len(result.mutation_id) == 36  # UUID standard format
+    assert result.committed_at.tzinfo == timezone.utc

--- a/tests/unit/participation/test_user_participation_write_db.py
+++ b/tests/unit/participation/test_user_participation_write_db.py
@@ -1,0 +1,242 @@
+"""Phase 2c PR-9 — utils.db.user_participation write primitives.
+
+The PR-8 read primitives are covered in
+``test_user_participation_db.py``.  This file adds the four new
+PR-9 atomic write+audit primitives:
+
+* ``upsert_participation_with_audit``
+* ``upsert_subscription_with_audit``
+* ``upsert_preference_with_audit``
+* ``upsert_visibility_with_audit``
+* ``get_audit_count``
+
+Each must issue both statements (target table UPSERT + audit row
+INSERT) inside the SAME transaction so partial failures roll back.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from utils.db import user_participation as up_db
+
+
+@pytest.fixture
+def _mock_pool_with_transaction():
+    """Pool fixture providing both autocommit AND transactional contexts.
+
+    Returns ``(pool_mock, conn_mock)``.  ``conn_mock.execute`` records
+    every statement issued inside the transaction in the order it ran;
+    tests assert against ``conn_mock.execute.await_args_list``.
+    """
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+
+    txn_cm = MagicMock()
+    txn_cm.__aenter__ = AsyncMock(return_value=None)
+    txn_cm.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction = MagicMock(return_value=txn_cm)
+
+    acquire_cm = MagicMock()
+    acquire_cm.__aenter__ = AsyncMock(return_value=conn)
+    acquire_cm.__aexit__ = AsyncMock(return_value=False)
+
+    pool_mock = MagicMock()
+    pool_mock.acquire = MagicMock(return_value=acquire_cm)
+    pool_mock.fetchrow = AsyncMock()
+    with patch.object(up_db, "pool") as pool_module:
+        pool_module.get = MagicMock(return_value=pool_mock)
+        yield pool_mock, conn
+
+
+# ---------------------------------------------------------------------------
+# upsert_participation_with_audit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_participation_issues_two_statements_in_transaction(
+    _mock_pool_with_transaction,
+):
+    _pool, conn = _mock_pool_with_transaction
+    await up_db.upsert_participation_with_audit(
+        user_id=1,
+        guild_id=2,
+        subsystem="xp",
+        state="opted_out",
+        actor_id=1,
+        actor_type="user",
+        mutation_id="abc-mutation",
+        prev_state=None,
+    )
+    # Two statements: UPSERT + audit INSERT
+    assert conn.execute.await_count == 2
+    upsert_sql = conn.execute.await_args_list[0].args[0]
+    audit_sql = conn.execute.await_args_list[1].args[0]
+    assert "INSERT INTO user_participation" in upsert_sql
+    assert "ON CONFLICT (user_id, guild_id, subsystem)" in upsert_sql
+    assert "INSERT INTO user_participation_audit" in audit_sql
+    assert "'set_participation'" in audit_sql
+    # Transaction was opened
+    conn.transaction.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_upsert_participation_records_prev_state_in_audit(
+    _mock_pool_with_transaction,
+):
+    _pool, conn = _mock_pool_with_transaction
+    await up_db.upsert_participation_with_audit(
+        user_id=1,
+        guild_id=2,
+        subsystem="xp",
+        state="opted_in",
+        actor_id=1,
+        actor_type="user",
+        mutation_id="abc",
+        prev_state="opted_out",
+    )
+    audit_call = conn.execute.await_args_list[1]
+    # Args: $1=mutation_id $2=user_id $3=guild_id $4=subsystem
+    #       $5=prev_state $6=new_state $7=actor_id $8=actor_type
+    args = audit_call.args[1:]
+    assert args[0] == "abc"
+    assert args[1] == 1
+    assert args[2] == 2
+    assert args[3] == "xp"
+    assert args[4] == "opted_out"  # prev_state
+    assert args[5] == "opted_in"  # new_state
+
+
+# ---------------------------------------------------------------------------
+# upsert_subscription_with_audit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_subscription_issues_two_statements(
+    _mock_pool_with_transaction,
+):
+    _pool, conn = _mock_pool_with_transaction
+    await up_db.upsert_subscription_with_audit(
+        user_id=1,
+        guild_id=2,
+        subsystem="economy",
+        topic="daily",
+        enabled=False,
+        actor_id=1,
+        actor_type="user",
+        mutation_id="abc",
+        prev_enabled=True,
+    )
+    assert conn.execute.await_count == 2
+    upsert_sql = conn.execute.await_args_list[0].args[0]
+    audit_sql = conn.execute.await_args_list[1].args[0]
+    assert "INSERT INTO user_subscriptions" in upsert_sql
+    assert "INSERT INTO user_participation_audit" in audit_sql
+    assert "'set_subscription'" in audit_sql
+
+
+# ---------------------------------------------------------------------------
+# upsert_preference_with_audit — JSON encoding of value
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_preference_json_encodes_value(_mock_pool_with_transaction):
+    _pool, conn = _mock_pool_with_transaction
+    payload = {"unit": "hours", "interval": 6}
+    await up_db.upsert_preference_with_audit(
+        user_id=1,
+        guild_id=2,
+        key="digest_freq",
+        value=payload,
+        actor_id=1,
+        actor_type="user",
+        mutation_id="abc",
+        prev_value=None,
+    )
+    upsert_call = conn.execute.await_args_list[0]
+    # value is positional arg index 4 in the upsert statement
+    serialised_value = upsert_call.args[4]
+    assert json.loads(serialised_value) == payload
+
+
+@pytest.mark.asyncio
+async def test_upsert_preference_none_prev_passed_as_null(_mock_pool_with_transaction):
+    _pool, conn = _mock_pool_with_transaction
+    await up_db.upsert_preference_with_audit(
+        user_id=1,
+        guild_id=2,
+        key="digest_freq",
+        value={"x": 1},
+        actor_id=1,
+        actor_type="user",
+        mutation_id="abc",
+        prev_value=None,
+    )
+    audit_call = conn.execute.await_args_list[1]
+    # prev_value is the 6th positional arg (index 5 after sql)
+    assert audit_call.args[5] is None
+
+
+# ---------------------------------------------------------------------------
+# upsert_visibility_with_audit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_visibility_issues_two_statements(_mock_pool_with_transaction):
+    _pool, conn = _mock_pool_with_transaction
+    await up_db.upsert_visibility_with_audit(
+        user_id=1,
+        guild_id=2,
+        subsystem="xp",
+        visibility="hidden",
+        actor_id=1,
+        actor_type="user",
+        mutation_id="abc",
+        prev_visibility="public",
+    )
+    assert conn.execute.await_count == 2
+    upsert_sql = conn.execute.await_args_list[0].args[0]
+    audit_sql = conn.execute.await_args_list[1].args[0]
+    assert "INSERT INTO user_visibility_overrides" in upsert_sql
+    assert "INSERT INTO user_participation_audit" in audit_sql
+    assert "'set_visibility'" in audit_sql
+
+
+# ---------------------------------------------------------------------------
+# get_audit_count
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_audit_count_no_filter(_mock_pool_with_transaction):
+    pool_mock, _ = _mock_pool_with_transaction
+    pool_mock.fetchrow.return_value = {"n": 7}
+    assert await up_db.get_audit_count() == 7
+    sql, *args = pool_mock.fetchrow.await_args.args
+    assert "FROM user_participation_audit" in sql
+    assert "WHERE" not in sql
+    assert args == []
+
+
+@pytest.mark.asyncio
+async def test_get_audit_count_filtered(_mock_pool_with_transaction):
+    pool_mock, _ = _mock_pool_with_transaction
+    pool_mock.fetchrow.return_value = {"n": 3}
+    n = await up_db.get_audit_count(
+        user_id=42,
+        guild_id=99,
+        mutation_type="set_participation",
+    )
+    assert n == 3
+    sql, *args = pool_mock.fetchrow.await_args.args
+    assert "user_id = $1" in sql
+    assert "guild_id = $2" in sql
+    assert "mutation_type = $3" in sql
+    assert args == [42, 99, "set_participation"]


### PR DESCRIPTION
## Summary

PR-9 of the Phase 2 plan. Ship the **write path** for per-user participation, plus the **XP opt-out proof** gated by `participation.enabled`. The flag stays **OFF by default** — every guild's XP behavior is identical to pre-PR-9 until an operator explicitly canary-enables it.

Branches directly from `main` (post #85). No stacking.

## Why this PR is scoped safely

- **`participation.enabled` stays default OFF.** XP behavior is unchanged on every existing guild.
- **Four-concern separation preserved.** Each entrypoint writes ONE table; no "user settings" god-object.
- **Rollback is a single flag flip** — toggling `participation.enabled` OFF restores legacy XP behavior immediately.
- **Fail-open gate:** the XP gate falls open on any flag/accessor error so a transient runtime fault never blocks XP.
- **Inline cache invalidation:** synchronous after DB commit, BEFORE event emission. Event subscribers are best-effort; they never affect cache/DB consistency.
- **Gate is centralised** in one helper (`_xp_participation_allowed`) so future XP entry points can reuse it without scattering `is_enabled()` calls.

## What changed

| Path | Change |
|---|---|
| `disbot/migrations/028_user_participation_audit.sql` | NEW — append-only audit table; single table hosts all four mutation types via discriminator + per-mutation_type shape CHECK constraints |
| `disbot/services/participation_mutation.py` | NEW — `ParticipationMutationPipeline` with four entrypoints, typed exceptions, `ParticipationMutationResult` |
| `disbot/utils/db/user_participation.py` | Extended — four `upsert_*_with_audit` atomic primitives, `get_audit_count` |
| `disbot/core/events_catalogue.py` | Extended — `participation.changed`, `subscription.changed`, `user_preference.changed`, `user_visibility.changed` |
| `disbot/cogs/xp/listener.py` | Extended — `_xp_participation_allowed` gate between cooldown check and `xp_service.award` |
| `tests/unit/participation/test_participation_mutation_pipeline.py` | NEW — 18 tests: validation, authority, atomic flow, cache-before-event ordering, event failure isolation, DB failure rollback, rollback semantics, catalogue check |
| `tests/unit/participation/test_user_participation_write_db.py` | NEW — 9 tests for the four upsert primitives |
| `tests/unit/cogs/test_xp_participation_gate.py` | NEW — 9 tests for the full XP gate behavior matrix + fail-open + centralisation invariant |
| `tests/unit/invariants/test_user_participation_audit_alignment.py` | NEW — 9 alignment tests pinning every CHECK clause in migration 028 |

## 7-step pipeline contract (mirrors `BindingMutationPipeline` / `RolloutMutationPipeline`)

1. **Input validation** — enum literals, JSON-serialisable preference values
2. **Authority** — `user` → actor_id MUST equal user_id; `moderator`/`admin` → actor_id non-None; `system`/`backfill` → actor_id may be None
3. **Read previous value** for audit
4. **DB write + audit row** (atomic in one transaction via `utils.db.user_participation`)
5. **Cache invalidation** — `core.runtime.user_config.invalidate_user_guild`, inline + synchronous, BEFORE event emission
6. **Event emission** — advisory, post-commit; subscriber failure logged + swallowed; `result.event_emitted` reflects it
7. **Return** typed `ParticipationMutationResult` with `mutation_id`

## Four entrypoints

| Method | Affects | Event |
|---|---|---|
| `set_participation(user_id, guild_id, subsystem, state, ...)` | `user_participation` | `participation.changed` |
| `set_subscription(user_id, guild_id, subsystem, topic, enabled, ...)` | `user_subscriptions` | `subscription.changed` |
| `set_preference(user_id, guild_id, key, value, ...)` | `user_preferences` | `user_preference.changed` (**value omitted from payload** — privacy) |
| `set_visibility(user_id, guild_id, subsystem, visibility, ...)` | `user_visibility_overrides` | `user_visibility.changed` |

## XP gate behavior matrix

| `participation.enabled` | participation state | XP awarded? |
|---|---|---|
| OFF (default) | any | ✅ awarded (legacy parity) |
| ON | `OPTED_OUT` | ❌ blocked |
| ON | `OPTED_IN` | ✅ awarded |
| ON | `NOT_SET` | ✅ awarded |
| flag evaluator raises | any | ✅ awarded (fail-open) |
| `get_participation` raises | any | ✅ awarded (fail-open) |

When the flag is OFF, the accessor is **never** called (verified by a test) — no performance cost in the default state.

## Architectural boundaries preserved

- One runtime domain per PR.
- One migration domain per PR (028 only).
- **Four structurally-separated participation concerns** — never collapsed.
- DB writes flow through `ParticipationMutationPipeline` (or its narrowly scoped DB primitives). No raw upsert calls outside the pipeline.
- **DB state authoritative; events advisory.**
- Local imports in cycle-sensitive files (`cogs/xp/listener.py`, the pipeline's cache + event helpers).
- Import-cycle regression test green.
- No Redis, no multi-process assumptions.
- Standard library only.

## Migration 028

Schema decisions:
- Single audit table hosts all four mutation types via `mutation_type` discriminator (mirrors `feature_flag_audit`'s pattern).
- **Per-`mutation_type` shape CHECK constraints** enforce defense-in-depth: `set_subscription` with NULL `topic` is rejected at INSERT; `set_preference` with a `subsystem` is rejected; etc.
- `prev_state` / `new_state` / `prev_visibility` / `new_visibility` CHECK constraints mirror the enum literals from migration 027.
- `actor_type` CHECK: `user` / `moderator` / `admin` / `system` / `backfill`.
- `mutation_id` UUID NOT NULL; `actor_id` BIGINT (nullable for system).
- **Retention: audit rows PRESERVED on guild leave** (matches `binding_audit_log` + `feature_flag_audit` policy). Active rows in migration-027 tables ARE purged on guild leave.

Additive, forward-only, idempotent.

## Rollback strategy

Layered:

1. **Flag flip:** set `participation.enabled` OFF (env override or DB). XP behavior reverts to legacy immediately. **No code change needed.**
2. **Code revert:** single `git revert`. Migration 028 is additive (table becomes unused). Audit rows already written remain visible (append-only by design).

Mutation rollback IS another mutation: call `set_participation` with the prior state. History is append-only; a test pins this contract.

## Tests run

```
python -m pytest tests/unit/participation/ \
                 tests/unit/cogs/test_xp_participation_gate.py \
                 tests/unit/cogs/test_xp_cog_caching.py \
                 tests/unit/invariants/test_user_participation_audit_alignment.py \
                 tests/unit/runtime/test_import_cycle_regression.py \
                 tests/unit/runtime/test_events_catalogue.py -q
# 95 passed

python -m pytest tests/ -q --ignore=tests/integration
# 1418 passed (1370 baseline + 48 new), 12 unrelated deprecation warnings

python -m ruff check disbot/                       # clean
python -m mypy disbot/                             # Success: no issues found in 227 source files
python -m black --check (changed .py files)        # 8 files unchanged
python -m isort --check-only (changed .py files)   # clean
```

## Manual Discord smoke

- [ ] Apply migration 028 to test DB
- [ ] Bot boots; `!platform status` reports healthy
- [ ] **With `participation.enabled` OFF (default):** send messages in test channel; XP accrues exactly as before
- [ ] From Python REPL on bot host:
  ```python
  from services.participation_mutation import ParticipationMutationPipeline
  p = ParticipationMutationPipeline()
  await p.set_participation(
      user_id=<test_user>, guild_id=<test_guild>,
      subsystem="xp", state="opted_out", actor_id=<test_user>,
  )
  ```
- [ ] Verify `user_participation` has a new row; `user_participation_audit` has a corresponding row with `mutation_type='set_participation'`, `prev_state=NULL`, `new_state='opted_out'`
- [ ] With `participation.enabled` still OFF: send messages → XP still accrues (gate respects the flag)
- [ ] **Enable `participation.enabled` for test guild** via DB override:
  ```sql
  INSERT INTO feature_flag_guild_overrides
    (flag_name, guild_id, state, set_by)
  VALUES ('participation.enabled', <test_guild>, 'on', <owner_id>);
  ```
- [ ] Send messages as the opted-out user → **no XP accrues**
- [ ] Send messages as a different (unconfigured / opted-in) user → XP accrues
- [ ] Disable `participation.enabled` → XP behavior reverts to legacy
- [ ] Kick bot from test guild → `user_participation` rows for that guild drop; `user_participation_audit` rows preserved (per retention policy)

## Intentionally deferred

- **`/myprofile` UI** — out of scope.
- **Participation hub** — out of scope.
- **Notification routing** — out of scope.
- **Discord slash command for users to opt out** — out of scope; owners invoke the pipeline via REPL/script for the canary phase.
- **Moderator/admin override UI** — the pipeline models the actor types but no Discord-facing surface invokes them.
- **Diagnostics consistency surface (PR-10)** — still pending.

## Test plan

- [x] Pipeline 7-step contract for each entrypoint
- [x] Authority matrix (user/moderator/admin/system/backfill, self-update enforcement)
- [x] Atomic DB write + audit (two statements per transaction)
- [x] Cache invalidation happens BEFORE event emission (call-order test)
- [x] Event subscriber failure does NOT roll back DB write
- [x] DB failure skips cache invalidation + event emission
- [x] Rollback writes a NEW audit row (history append-only)
- [x] All four event names registered in `KNOWN_EVENTS`
- [x] `user_preference.changed` event payload OMITS the value (privacy)
- [x] XP gate behavior matrix (6 cases)
- [x] XP gate fail-open on flag/accessor error
- [x] XP gate is centralised (named helper exists)
- [x] All migration 028 CHECK clauses pinned by alignment tests
- [x] `mypy disbot/` clean
- [x] Import-cycle regression green

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgFk12CkWs1uiPZk8AA5fR)_