### PR TITLE
docs(phase-2): add completion-readiness punch list

### DIFF
--- a/docs/phase-2-completion-readiness.md
+++ b/docs/phase-2-completion-readiness.md
@@ -1,0 +1,178 @@
+# Phase 2 — Completion readiness
+
+> **Status:** working snapshot.  Updated whenever a Phase 2 PR
+> changes the picture.  Treat this file as a punch-list, not a plan
+> document; the consistency ledger
+> (`docs/platform-consistency-ledger.md`) remains the long-form
+> ownership map.
+
+This page captures **what is done**, **what is open**, and **what
+should NOT start yet** as Phase 2 reaches completion.  It exists to
+help the next contributor avoid:
+
+* re-deriving status from `git log`,
+* duplicating in-flight runtime work,
+* starting a large UI / settings phase before the substrate is stable.
+
+---
+
+## Done on `main`
+
+| PR | Title | Notes |
+|---|---|---|
+| #70 | Phase 0/1 ownership protocols + roadmap |
+| #71 / #72 | Phase 2a unified resource runtime |
+| #73 / #74 | Phase 2b subsystem bindings + circular-import hotfix |
+| #75 | Platform consistency ledger + stale-doc classification |
+| #76 | Guild teardown cleanup; binding cleanup primitive split |
+| #77 | Feature flag evaluator foundation (Phase 2d) |
+| #78 | Rollout mutation pipeline + feature flag audit |
+| #79 | Central config arbitration (`ConfigReadResult`) |
+| #80 | Integration: land #77 + #78 + #79 onto `main` |
+| #81 | Binding backfill dry-run + reconciliation + checkpoints (migration 026) |
+| #82 | Binding backfill write phase (idempotent apply, advisory lock) |
+| #83 | `bindings.primary` canary support via arbitration accessors |
+| #84 | Participation storage + cache foundation (migration 027) |
+| #85 | Integration: land #82 + #83 + #84 onto `main` |
+
+Migration ladder on `main` after PR #85: `022` → `027`.
+
+## Open right now
+
+| PR | Title | State |
+|---|---|---|
+| **#86** | **Phase 2.9: participation mutation pipeline + XP opt-out proof** | open, ready for review.  Migration 028 (participation audit).  `participation.enabled` stays default OFF. |
+
+---
+
+## Behavior defaults preserved on `main` today
+
+These guarantees hold without operator action:
+
+* `bindings.primary` — default **OFF**.  XP, Economy, Governance reads
+  resolve via the legacy `guild_settings` path; the arbitration helper
+  short-circuits to legacy.
+* `participation.enabled` — default **OFF**.  After #86 merges, the
+  XP listener gate falls through to the legacy behaviour without
+  consulting the participation accessors.
+* `feature_flag.primary` — default **OFF**.  The evaluator returns
+  declared defaults without touching the DB.
+* All Phase 2 audit tables (`binding_audit_log`, `feature_flag_audit`,
+  `user_participation_audit`) are **preserved** on guild leave.
+* All Phase 2 active-state tables for departed guilds are purged on
+  guild leave; the same user's data in OTHER guilds is preserved.
+
+---
+
+## Still pending — recommended next PRs
+
+### PR-10 — diagnostics consistency surface (recommended next)
+
+Goal: unify the platform's diagnostics providers behind one shape so
+`!platform consistency` / `!platform migrations` / `!platform health`
+can render reliably.
+
+What it should surface in one place:
+
+* Binding drift — bindings pointing at MISSING/INVALID resources.
+* Config arbitration counters — `by_source` / `by_binding_status` /
+  `by_flag_state` / fallback rate.
+* Participation cache health — hits / misses / evictions / size.
+* Participation audit pulse — recent mutation counts by `mutation_type`.
+* Feature flag fallback usage — bootstrap fallback counter.
+* Missing settings / bindings — per-subsystem readiness rollup.
+* Setup-readiness blockers (see below).
+
+Scope discipline for PR-10:
+
+* No new domain.  No new migration.
+* Read-only — providers never mutate.
+* Use the existing `services.diagnostics_service` registry; do not
+  build a parallel registry.
+* Keep the rendering simple (text embeds).  Anything fancier is its
+  own PR.
+
+### Setup-readiness blockers (informational)
+
+For the wizard / setup phase to start, these must be in place:
+
+* Diagnostics consistency surface (PR-10).
+* A documented "command surface ledger" — the catalogue of slash /
+  prefix entrypoints that the wizard / panels would link from.
+* A panel registry — version-stamped persistent-view registration.
+* A settings registry — typed setting metadata for the wizard's
+  preview/commit flow.
+* `governance` `SubsystemSchema` declaration for `trusted_role` so the
+  binding backfill can complete for that key (currently
+  `BLOCKED_NO_SCHEMA`).
+
+None of these are in scope for the current Phase 2 plan.  They are
+listed here so PR-10 reviewers can sequence work afterwards.
+
+---
+
+## Do NOT start yet
+
+These are explicit lock-boxes — opening any of them before the
+substrate is stable will re-introduce the duplicate-systems risk that
+the consistency ledger exists to prevent:
+
+* `/myprofile` or participation hub UI
+* Setup wizard
+* Resource provisioning runtime (channel/role auto-creation)
+* Notification routing / DMs / reminders
+* Slash-command entrypoints for setting feature flags or participation
+* Component registry implementation (planning is fine)
+* Settings registry implementation
+* Role / cleanup service extraction
+* Production flip of `bindings.primary`
+* Legacy `guild_settings` row removal for migrated keys
+* Any "user settings" generic blob that collapses participation /
+  subscriptions / preferences / visibility into one entity
+* XP threshold role binding (the 1:N shape does not fit
+  `subsystem_bindings`; a dedicated `xp_threshold_roles` table is the
+  right shape, in a separate small PR motivated by admin-UX needs)
+
+---
+
+## Migration numbering ladder
+
+| Migration | Source PR | Status |
+|---|---|---|
+| `022_subsystem_bindings.sql` | #73 | on main |
+| `023_feature_flag_state.sql` | #77 | on main |
+| `024_environment_tiers.sql` | #77 | on main |
+| `025_feature_flag_audit.sql` | #78 | on main |
+| `026_platform_migration_checkpoints.sql` | #81 | on main |
+| `027_user_participation.sql` | #84 | on main |
+| `028_user_participation_audit.sql` | #86 | **open** |
+| 029 | next free number | — |
+
+---
+
+## Stable-stack hygiene reminders
+
+Two recent integration PRs (#80 and #85) repaired stacked-PR delivery
+problems where intermediate PRs were merged into stack branches
+instead of `main`.  To avoid a third occurrence:
+
+* **Branch each new PR off `main` directly** unless there is an
+  unavoidable dependency on an unmerged PR.
+* If you must stack, set the PR's base to the upstream stack
+  branch AND make sure merges go to `main` in order.  The simplest
+  rule: if a PR's diff makes no sense without unmerged work, do not
+  merge it into anything other than `main`.
+* The cherry-pick recipe for the integration PRs is in #80 and #85's
+  bodies — re-usable verbatim if it happens again.
+
+---
+
+## How to update this file
+
+* When a PR merges: move its row from "Open right now" to "Done on
+  `main`", and bump the migration ladder.
+* When a recommended next PR ships: replace its planning bullet with
+  the merged-PR row.
+* When a "do not start yet" item is unlocked by a substrate PR: move
+  it to a new "in flight" section and add the PR link.
+* Keep this file short — it is a punch-list, not a design doc.


### PR DESCRIPTION
## Summary

Small docs-only follow-up to PR #86. Adds `docs/phase-2-completion-readiness.md` as a working-snapshot punch list capturing where Phase 2 stands today and what should and should NOT start next.

Targets `main` directly (off post-#85 HEAD). No code touched, no migration, no runtime impact.

## Why

After two stacked-PR delivery problems (#80 and #85 repair) and several large overlapping PRs, the project needs a single page that answers:

- Which PRs are merged?
- Which one is open right now?
- What behavior defaults hold without operator action?
- What's the next safe PR to start?
- What must NOT start yet?
- Where do we stand on migrations?

This page is **a punch list, not a design doc**. The consistency ledger (`docs/platform-consistency-ledger.md`) remains the long-form ownership map.

## Contents

| Section | Purpose |
|---|---|
| **Done on `main`** | 15 PRs from #70 through #85 mapped to their effect |
| **Open right now** | PR #86 (participation pipeline) |
| **Behavior defaults preserved** | `bindings.primary` OFF, `participation.enabled` OFF, `feature_flag.primary` OFF, audit-retention policy |
| **Recommended next PR** | PR-10 diagnostics consistency surface, with scope guardrails |
| **Setup-readiness blockers** | informational list of what must precede any wizard / settings / panel work |
| **Do NOT start yet** | explicit lock-boxes including `/myprofile`, setup wizard, resource provisioning, slash-command flag setters, generic "user settings" blob, XP threshold role binding |
| **Migration numbering ladder** | `022` → `028` with `028` open |
| **Stable-stack hygiene** | reminders citing PR #80 + #85 as the cherry-pick template if the stack-merge problem recurs |

## Architectural boundaries preserved

- No code touched.
- No new domain, migration, schema, or behavior change.
- Highest migration on `main` remains `027_user_participation.sql`; this PR does not add 028 (#86 does).
- Import-cycle regression: not relevant (docs only).

## Rollback strategy

`git revert` this PR. Pure docs.

## Tests run

None required (docs only). Manual verification:
- [x] Markdown renders correctly on GitHub
- [x] All cross-references (`docs/platform-consistency-ledger.md`) resolve to existing files
- [x] PR numbers cited match the actual merged/open PRs

## Manual Discord smoke

None applicable — docs only.

## Intentionally deferred

Everything the punch list flags as "Do NOT start yet" is for **later** Phase 2 PRs (PR-10 first) or for the next phase entirely.

## How to maintain

A short "How to update this file" section at the bottom of the doc explains the punch-list workflow: as PRs merge, move their bullets, bump the ladder, and update the open-PR row. Keep it short.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgFk12CkWs1uiPZk8AA5fR)_