### PR TITLE
Phase 2 PR-10: Unified Consistency & Readiness Diagnostics

### DIFF
--- a/disbot/cogs/diagnostic/_platform_embeds.py
+++ b/disbot/cogs/diagnostic/_platform_embeds.py
@@ -8,10 +8,11 @@ and/or ``utils.db.*``) and returns a single :class:`discord.Embed`
 ready to send.  The cog methods become thin wrappers that delegate
 here.
 
-Phase 2a + 2b builders covered:
+Phase 2a + 2b + 2.10 builders covered:
 
-* :func:`build_resources_embed` — ``!platform resources``
-* :func:`build_bindings_embed`  — ``!platform bindings``
+* :func:`build_resources_embed`     — ``!platform resources``
+* :func:`build_bindings_embed`      — ``!platform bindings``
+* :func:`build_consistency_embed`   — ``!platform consistency``
 
 Earlier-phase platform commands stay inline in the cog for now.  When
 the next batch of platform commands lands and pushes the cog back
@@ -21,6 +22,12 @@ toward the ceiling, those should migrate here too.
 from __future__ import annotations
 
 import discord
+
+from services.platform_consistency import (
+    ConsistencyReport,
+    SectionResult,
+    SectionStatus,
+)
 
 
 async def build_resources_embed(guild: discord.Guild | None) -> discord.Embed:
@@ -126,4 +133,161 @@ async def build_bindings_embed(guild: discord.Guild | None) -> discord.Embed:
     return embed
 
 
-__all__ = ["build_bindings_embed", "build_resources_embed"]
+# ---------------------------------------------------------------------------
+# Consistency embed — Phase 2 PR-10
+# ---------------------------------------------------------------------------
+
+_STATUS_COLOR: dict[SectionStatus, discord.Color] = {
+    SectionStatus.CLEAN: discord.Color.green(),
+    SectionStatus.WARNING: discord.Color.gold(),
+    SectionStatus.FATAL: discord.Color.red(),
+    SectionStatus.SKIPPED: discord.Color.light_grey(),
+}
+
+_STATUS_ICON: dict[SectionStatus, str] = {
+    SectionStatus.CLEAN: "🟢",
+    SectionStatus.WARNING: "🟡",
+    SectionStatus.FATAL: "🔴",
+    SectionStatus.SKIPPED: "⚪",
+}
+
+# Informational marker prefixed to the Setup readiness field value so
+# operators do not read its WARNING as a runtime degradation.
+_INFORMATIONAL_PREFIX = "ℹ️ Roadmap/informational — not a runtime health failure.\n"
+
+# Soft cap for total embed size; leaves headroom under Discord's 6000.
+_EMBED_SOFT_CAP = 5800
+# Per-field value cap; leaves headroom under Discord's 1024.
+_FIELD_VALUE_CAP = 1000
+# Hard cap on field count (Discord's limit is 25; reserve one for
+# truncation notes).
+_FIELD_HARD_CAP = 24
+
+
+def _format_field_value(section: SectionResult) -> str:
+    lines: list[str] = []
+    if section.informational:
+        lines.append(_INFORMATIONAL_PREFIX.rstrip())
+    lines.append(section.summary)
+    for bullet in section.details[:3]:
+        lines.append(f"• {bullet}")
+    for action in section.suggested_actions[:2]:
+        lines.append(f"→ {action}")
+    value = "\n".join(lines)
+    if len(value) > _FIELD_VALUE_CAP:
+        value = value[: _FIELD_VALUE_CAP - 1] + "…"
+    return value
+
+
+def _estimated_embed_size(embed: discord.Embed) -> int:
+    size = len(embed.title or "") + len(embed.description or "")
+    if embed.footer and embed.footer.text:
+        size += len(embed.footer.text)
+    for field in embed.fields:
+        size += len(field.name or "") + len(field.value or "")
+    return size
+
+
+def build_consistency_embed(report: ConsistencyReport) -> discord.Embed:
+    """Render a ConsistencyReport as a single Discord embed.
+
+    Bounds the rendered size to Discord's limits: per-field value
+    capped at ~1000 chars with a truncation marker; total embed size
+    bounded by collapsing the longest field, then dropping trailing
+    SKIPPED/CLEAN fields and appending a `_truncated` note.  Hard cap
+    of 24 fields.
+    """
+    overall = report.overall_status
+    counts = {s: 0 for s in SectionStatus}
+    informational_warnings = 0
+    runtime_warnings = 0
+    for section in report.sections:
+        counts[section.status] = counts.get(section.status, 0) + 1
+        if section.status == SectionStatus.WARNING:
+            if section.informational:
+                informational_warnings += 1
+            else:
+                runtime_warnings += 1
+
+    generated = report.generated_at.strftime("%Y-%m-%d %H:%M:%SZ")
+    embed = discord.Embed(
+        title=f"🛡 Platform consistency · {overall.value.upper()}",
+        description=(
+            f"{counts[SectionStatus.CLEAN]} clean · "
+            f"{counts[SectionStatus.WARNING]} warning · "
+            f"{counts[SectionStatus.FATAL]} fatal · "
+            f"{counts[SectionStatus.SKIPPED]} skipped · "
+            f"generated {generated}"
+        ),
+        color=_STATUS_COLOR.get(overall, discord.Color.light_grey()),
+    )
+
+    sections_for_embed = list(report.sections[:_FIELD_HARD_CAP])
+    for section in sections_for_embed:
+        icon = _STATUS_ICON.get(section.status, "•")
+        embed.add_field(
+            name=f"{icon} {section.name}",
+            value=_format_field_value(section),
+            inline=False,
+        )
+
+    # Bounded-size guard: collapse longest field value to summary line
+    # if the embed exceeds the soft cap.
+    while _estimated_embed_size(embed) > _EMBED_SOFT_CAP and embed.fields:
+        longest_idx = max(
+            range(len(embed.fields)),
+            key=lambda i: len(embed.fields[i].value or ""),
+        )
+        section = sections_for_embed[longest_idx]
+        collapsed = section.summary
+        if section.informational:
+            collapsed = _INFORMATIONAL_PREFIX.rstrip() + "\n" + collapsed
+        if len(collapsed) > _FIELD_VALUE_CAP:
+            collapsed = collapsed[: _FIELD_VALUE_CAP - 1] + "…"
+        if collapsed == embed.fields[longest_idx].value:
+            break
+        embed.set_field_at(
+            longest_idx,
+            name=embed.fields[longest_idx].name,
+            value=collapsed,
+            inline=False,
+        )
+
+    # Still over? Drop trailing SKIPPED/CLEAN runtime fields one by one.
+    dropped = 0
+    while _estimated_embed_size(embed) > _EMBED_SOFT_CAP and embed.fields:
+        idx_to_drop: int | None = None
+        for i in range(len(embed.fields) - 1, -1, -1):
+            section = sections_for_embed[i]
+            if not section.informational and section.status in (
+                SectionStatus.CLEAN,
+                SectionStatus.SKIPPED,
+            ):
+                idx_to_drop = i
+                break
+        if idx_to_drop is None:
+            break
+        embed.remove_field(idx_to_drop)
+        sections_for_embed.pop(idx_to_drop)
+        dropped += 1
+    if dropped:
+        embed.add_field(
+            name="… truncated",
+            value=f"{dropped} section(s) omitted to stay under embed limits.",
+            inline=False,
+        )
+
+    embed.set_footer(
+        text=(
+            f"{runtime_warnings} runtime warning · "
+            f"{informational_warnings} informational"
+        ),
+    )
+    return embed
+
+
+__all__ = [
+    "build_bindings_embed",
+    "build_consistency_embed",
+    "build_resources_embed",
+]

--- a/disbot/cogs/diagnostic_cog.py
+++ b/disbot/cogs/diagnostic_cog.py
@@ -192,17 +192,15 @@ class DiagnosticCog(commands.Cog):
             !platform schemas              · !platform participation-schemas
             !platform resource-requirements · !platform flags
 
-        Added in Phase 2a (unified resource runtime):
-            !platform resources
-
-        Added in Phase 2b (subsystem bindings):
-            !platform bindings
+        Added in Phase 2a (unified resource runtime): !platform resources
+        Added in Phase 2b (subsystem bindings): !platform bindings
+        Added in Phase 2 PR-10: !platform consistency
         """
         await ctx.send(
             "Usage: `!platform <status|anchors|identity|"
             "runtime|caches|locks|tasks|views|sessions|slow|"
             "schemas|participation-schemas|resource-requirements|flags|"
-            "resources|bindings>`",
+            "resources|bindings|migrations|consistency>`",
             delete_after=20,
         )
 
@@ -781,6 +779,16 @@ class DiagnosticCog(commands.Cog):
                 inline=False,
             )
         await ctx.send(embed=embed)
+
+    @platform_grp.command(name="consistency")  # type: ignore[arg-type]
+    @commands.has_permissions(administrator=True)
+    async def platform_consistency(self, ctx):
+        """Unified platform readiness diagnostic — read-only (Phase 2 PR-10)."""
+        from cogs.diagnostic._platform_embeds import build_consistency_embed
+        from services.platform_consistency import collect_report
+
+        report = await collect_report(bot=self.bot, guild=ctx.guild)
+        await ctx.send(embed=build_consistency_embed(report))
 
 
 async def setup(bot):

--- a/disbot/services/platform_consistency.py
+++ b/disbot/services/platform_consistency.py
@@ -1,0 +1,807 @@
+"""Unified platform consistency & readiness diagnostics — Phase 2 PR-10.
+
+Pure-read collection service.  Reuses existing diagnostics providers
+and DB accessors; never mutates.  Each section collector catches its
+own exceptions and converts unknown failures into a FATAL section
+result so one broken collector cannot blank the report.
+
+Cross-module imports go **function-local** inside each collector to
+avoid re-entering partially-loaded ``core.runtime`` modules.  The
+companion regression test
+``tests/unit/runtime/test_consistency_import_cycle.py`` pins this
+discipline at module scope.
+
+Severity contract (binding):
+
+* ``CLEAN``    — section is healthy.
+* ``WARNING``  — drift, failed optional provider, missing/broken
+  *configured* resource, or recoverable degradation.  Also used for
+  the Setup readiness roadmap section, which is marked
+  ``informational=True`` so the embed can label it as roadmap-only.
+* ``FATAL``    — core unreadable / required surface broken.  Reserved
+  for things that block safe rollout (core DB table query raises,
+  identity contract emits a ``fatal``-tier finding).
+* ``SKIPPED``  — not applicable / no context / no data
+  (``guild is None``, optional table absent because its migration has
+  not been applied yet, provider not registered).
+
+Overall-status promotion:
+
+* any ``FATAL``                       → ``FATAL``
+* else any ``WARNING``                → ``WARNING``
+* else if every runtime section is ``SKIPPED`` → ``SKIPPED``
+* else                                → ``CLEAN``
+
+Informational sections never promote ``overall_status``.
+
+Public surface:
+
+    SectionStatus               — enum
+    SectionResult               — frozen dataclass per section
+    ConsistencyReport           — frozen dataclass: sections + overall_status
+    SETUP_READINESS_BLOCKERS    — tuple of roadmap blocker identifiers
+    collect_report(*, bot, guild) — async orchestrator
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import os
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+logger = logging.getLogger("bot.platform_consistency")
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+class SectionStatus(str, Enum):
+    CLEAN = "clean"
+    WARNING = "warning"
+    FATAL = "fatal"
+    SKIPPED = "skipped"
+
+
+@dataclass(frozen=True)
+class SectionResult:
+    name: str
+    status: SectionStatus
+    summary: str
+    details: tuple[str, ...] = ()
+    suggested_actions: tuple[str, ...] = ()
+    informational: bool = False
+
+
+@dataclass(frozen=True)
+class ConsistencyReport:
+    sections: tuple[SectionResult, ...]
+    generated_at: datetime.datetime
+
+    @property
+    def overall_status(self) -> SectionStatus:
+        runtime = tuple(s for s in self.sections if not s.informational)
+        if not runtime:
+            return SectionStatus.SKIPPED
+        statuses = {s.status for s in runtime}
+        if SectionStatus.FATAL in statuses:
+            return SectionStatus.FATAL
+        if SectionStatus.WARNING in statuses:
+            return SectionStatus.WARNING
+        if statuses == {SectionStatus.SKIPPED}:
+            return SectionStatus.SKIPPED
+        return SectionStatus.CLEAN
+
+
+SETUP_READINESS_BLOCKERS: tuple[str, ...] = (
+    "command_surface_ledger",
+    "panel_registry",
+    "settings_registry",
+    "settings_mutation_pipeline",
+    "governance_trusted_role_schema",
+    "role_service_extraction",
+    "cleanup_policy_extraction",
+    "logging_settings_integration",
+    "slash_panel_entrypoints",
+    "setup_wizard_readiness_bridge",
+    "setup_wizard",
+)
+
+
+# ---------------------------------------------------------------------------
+# Filesystem migration discovery
+# ---------------------------------------------------------------------------
+
+# Two dirname() calls from disbot/services/platform_consistency.py →
+# disbot/, then join "migrations" → disbot/migrations.  Same root the
+# migration runner uses (utils/db/migrations.py:25).
+_MIGRATIONS_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "migrations",
+)
+_MIGRATION_FILE_RE = re.compile(r"^(\d{3,})_.+\.sql$")
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+async def collect_report(
+    *,
+    bot: object | None = None,
+    guild: object | None = None,
+) -> ConsistencyReport:
+    """Collect every section and return a single immutable report.
+
+    The orchestrator runs each collector under ``try/except``; an
+    unexpected raise becomes a ``FATAL`` ``SectionResult`` so one
+    broken collector never blanks the report.
+
+    Keyword-only ``bot`` / ``guild`` make the API explicit at the
+    callsite (the DiagnosticCog passes ``ctx.guild``; tests can pass
+    ``None`` to exercise the SKIPPED paths).
+    """
+    collectors: tuple[tuple[str, object], ...] = (
+        ("Identity contract", _collect_identity_contract(bot)),
+        ("Feature flags", _collect_feature_flags()),
+        ("Rollout / audit", _collect_rollout_audit()),
+        ("Bindings", _collect_bindings(guild)),
+        ("Binding backfill", _collect_binding_backfill()),
+        ("Config arbitration", _collect_config_arbitration()),
+        ("Participation", _collect_participation()),
+        ("Migrations", _collect_migrations()),
+        ("Runtime providers", _collect_runtime_providers()),
+        ("Setup readiness", _collect_setup_readiness()),
+    )
+    sections: list[SectionResult] = []
+    for label, coro in collectors:
+        try:
+            result = await coro
+        except Exception as exc:  # noqa: BLE001 — fail-safe orchestrator
+            logger.warning(
+                "platform_consistency: collector %r raised %s",
+                label,
+                exc,
+                exc_info=True,
+            )
+            result = SectionResult(
+                name=label,
+                status=SectionStatus.FATAL,
+                summary=f"collector raised {type(exc).__name__}",
+                details=(str(exc)[:200],),
+            )
+        sections.append(result)
+    return ConsistencyReport(
+        sections=tuple(sections),
+        generated_at=datetime.datetime.now(tz=datetime.timezone.utc),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section collectors
+# ---------------------------------------------------------------------------
+
+
+async def _collect_identity_contract(bot: object | None) -> SectionResult:
+    """Section 1: SUBSYSTEMS vs commands vs persistent views vs prefixes."""
+    name = "Identity contract"
+    if bot is None:
+        return SectionResult(
+            name=name,
+            status=SectionStatus.SKIPPED,
+            summary="No bot context — invoked without a live bot.",
+        )
+    try:
+        # Function-local: utils.subsystem_registry transitively touches
+        # core.runtime, so importing at module scope would violate the
+        # cycle-sensitive contract pinned by
+        # tests/unit/runtime/test_consistency_import_cycle.py.
+        from utils.subsystem_registry import (
+            IDENTITY_FINDING_TIER,
+            validate_identity_contract,
+        )
+
+        findings = await validate_identity_contract(bot)
+    except Exception as exc:  # noqa: BLE001 — collector is fail-safe
+        return SectionResult(
+            name=name,
+            status=SectionStatus.FATAL,
+            summary=f"validator raised {type(exc).__name__}",
+            details=(str(exc)[:200],),
+            suggested_actions=(
+                "Inspect bot logs for the identity-contract validator stack trace.",
+            ),
+        )
+
+    total = sum(len(items) for items in findings.values())
+    if total == 0:
+        return SectionResult(
+            name=name,
+            status=SectionStatus.CLEAN,
+            summary="No identity-contract findings.",
+        )
+
+    fatal_kinds: list[str] = []
+    warn_kinds: list[str] = []
+    for kind, items in findings.items():
+        if not items:
+            continue
+        tier = IDENTITY_FINDING_TIER.get(kind, "fatal")
+        if tier == "fatal":
+            fatal_kinds.append(f"{kind}={len(items)}")
+        else:
+            warn_kinds.append(f"{kind}={len(items)}")
+
+    if fatal_kinds:
+        return SectionResult(
+            name=name,
+            status=SectionStatus.FATAL,
+            summary=f"{len(fatal_kinds)} fatal-tier finding kind(s).",
+            details=tuple(fatal_kinds + warn_kinds)[:8],
+            suggested_actions=("Run `!platform identity` to see per-kind detail.",),
+        )
+    return SectionResult(
+        name=name,
+        status=SectionStatus.WARNING,
+        summary=f"{total} non-fatal identity finding(s).",
+        details=tuple(warn_kinds)[:8],
+        suggested_actions=("Run `!platform identity --fix` to auto-heal.",),
+    )
+
+
+async def _collect_feature_flags() -> SectionResult:
+    """Section 2: declared flags resolvable; evaluator healthy."""
+    name = "Feature flags"
+    try:
+        from core.runtime import feature_flags
+
+        flags = feature_flags.all_flags()
+        if not flags:
+            return SectionResult(
+                name=name,
+                status=SectionStatus.SKIPPED,
+                summary="No flags declared (pre-bootstrap).",
+            )
+        # Resolve each declared flag at the global scope (guild_id=None).
+        # A raise here signals deep evaluator breakage and is FATAL.
+        for flag_name in sorted(flags):
+            await feature_flags.resolve_with_provenance(flag_name, None)
+        fallback = feature_flags.bootstrap_fallback_count()
+    except Exception as exc:  # noqa: BLE001 — collector is fail-safe
+        return SectionResult(
+            name=name,
+            status=SectionStatus.FATAL,
+            summary=f"evaluator raised {type(exc).__name__}",
+            details=(str(exc)[:200],),
+        )
+
+    if fallback > 0:
+        return SectionResult(
+            name=name,
+            status=SectionStatus.WARNING,
+            summary=(
+                f"{len(flags)} flag(s) declared; bootstrap fallback "
+                f"count = {fallback} (DB unreachable at some point)."
+            ),
+            details=(
+                "All flag reads since the last fallback fall back to the "
+                "declared default until the next successful DB resolve.",
+            ),
+            suggested_actions=(
+                "Verify DATABASE_URL reachability and re-run `!platform flags`.",
+            ),
+        )
+    return SectionResult(
+        name=name,
+        status=SectionStatus.CLEAN,
+        summary=f"{len(flags)} flag(s) declared; evaluator healthy.",
+    )
+
+
+async def _collect_rollout_audit() -> SectionResult:
+    """Section 3: feature_flag_audit table reachable if migration exists."""
+    name = "Rollout / audit"
+    try:
+        from utils.db import pool
+
+        oid = await pool.get().fetchval(
+            "SELECT to_regclass('feature_flag_audit')",
+        )
+    except Exception as exc:  # noqa: BLE001 — collector is fail-safe
+        return SectionResult(
+            name=name,
+            status=SectionStatus.WARNING,
+            summary=f"audit-table probe raised {type(exc).__name__}",
+            details=(str(exc)[:200],),
+        )
+
+    if oid is None:
+        return SectionResult(
+            name=name,
+            status=SectionStatus.SKIPPED,
+            summary="`feature_flag_audit` absent (migration 025 not applied).",
+        )
+
+    try:
+        from utils.db import pool
+
+        count = await pool.get().fetchval(
+            "SELECT COUNT(*) FROM feature_flag_audit",
+        )
+    except Exception as exc:  # noqa: BLE001 — collector is fail-safe
+        return SectionResult(
+            name=name,
+            status=SectionStatus.WARNING,
+            summary=(f"audit table present but COUNT(*) raised {type(exc).__name__}"),
+            details=(str(exc)[:200],),
+        )
+
+    return SectionResult(
+        name=name,
+        status=SectionStatus.CLEAN,
+        summary=f"audit table reachable; {int(count or 0)} row(s).",
+    )
+
+
+async def _collect_bindings(guild: object | None) -> SectionResult:
+    """Section 4: subsystem_bindings reachable; broken-configured rows."""
+    name = "Bindings"
+    if guild is None:
+        return SectionResult(
+            name=name,
+            status=SectionStatus.SKIPPED,
+            summary="No guild context (DM invocation).",
+        )
+    guild_id = getattr(guild, "id", None)
+    if guild_id is None:
+        return SectionResult(
+            name=name,
+            status=SectionStatus.SKIPPED,
+            summary="Guild context missing .id attribute.",
+        )
+
+    try:
+        from utils.db import bindings as bindings_db
+
+        histogram = await bindings_db.count_by_status(int(guild_id))
+    except Exception as exc:  # noqa: BLE001 — collector is fail-safe
+        return SectionResult(
+            name=name,
+            status=SectionStatus.FATAL,
+            summary=(
+                f"count_by_status raised {type(exc).__name__} — "
+                "subsystem_bindings table may be missing."
+            ),
+            details=(str(exc)[:200],),
+        )
+
+    missing = int(histogram.get("missing", 0))
+    invalid = int(histogram.get("invalid", 0))
+    unresolved = int(histogram.get("unresolved", 0))
+    bound = int(histogram.get("bound", 0))
+    total = sum(histogram.values())
+
+    # `unresolved` is reported informationally only — current schema
+    # has no metadata column separating "configured-but-not-yet-resolved"
+    # from "empty slot", so v1 does not promote status from `unresolved`.
+    info_line = (
+        f"bound={bound} unresolved={unresolved} "
+        f"missing={missing} invalid={invalid} (total={total})"
+    )
+
+    if missing or invalid:
+        return SectionResult(
+            name=name,
+            status=SectionStatus.WARNING,
+            summary=(
+                f"{missing + invalid} configured-but-broken binding(s) in "
+                f"guild {guild_id}."
+            ),
+            details=(
+                info_line,
+                "`unresolved` rows reported informationally; they may be "
+                "unconfigured slots, not broken bindings.",
+            ),
+            suggested_actions=(
+                "Run `!platform bindings` to see per-subsystem detail.",
+            ),
+        )
+    return SectionResult(
+        name=name,
+        status=SectionStatus.CLEAN,
+        summary=f"no broken bindings in guild {guild_id}.",
+        details=(info_line,),
+    )
+
+
+async def _collect_binding_backfill() -> SectionResult:
+    """Section 5: binding backfill checkpoints — failed / in-progress."""
+    name = "Binding backfill"
+    try:
+        from utils.db import platform_migration_checkpoints as ck
+
+        counts = await ck.count_by_status(name_prefix="binding_backfill")
+    except Exception as exc:  # noqa: BLE001 — collector is fail-safe
+        return SectionResult(
+            name=name,
+            status=SectionStatus.WARNING,
+            summary=(f"checkpoint count_by_status raised {type(exc).__name__}"),
+            details=(str(exc)[:200],),
+        )
+
+    if not counts:
+        return SectionResult(
+            name=name,
+            status=SectionStatus.SKIPPED,
+            summary="no `binding_backfill` checkpoint rows.",
+        )
+
+    failed = int(counts.get("failed", 0))
+    in_progress = int(counts.get("in_progress", 0))
+    line = " · ".join(f"{k}={v}" for k, v in sorted(counts.items()))
+
+    if failed:
+        return SectionResult(
+            name=name,
+            status=SectionStatus.FATAL,
+            summary=f"{failed} failed backfill checkpoint row(s).",
+            details=(line,),
+            suggested_actions=(
+                "Run `!platform migrations` for the failed checkpoint name "
+                "and inspect the bot host logs.",
+            ),
+        )
+    if in_progress:
+        return SectionResult(
+            name=name,
+            status=SectionStatus.WARNING,
+            summary=f"{in_progress} backfill checkpoint(s) in_progress.",
+            details=(line,),
+        )
+    recognised = {"complete", "dry_run_complete"}
+    unknown = {k for k in counts if k not in recognised and counts[k]}
+    if unknown:
+        return SectionResult(
+            name=name,
+            status=SectionStatus.WARNING,
+            summary=(
+                "backfill checkpoint(s) in unrecognised status: "
+                + ", ".join(sorted(unknown))
+            ),
+            details=(line,),
+        )
+    return SectionResult(
+        name=name,
+        status=SectionStatus.CLEAN,
+        summary="backfill checkpoints all complete.",
+        details=(line,),
+    )
+
+
+async def _collect_config_arbitration() -> SectionResult:
+    """Section 6: config arbitration counters — provider status."""
+    name = "Config arbitration"
+    try:
+        from services import diagnostics_service
+
+        snap = diagnostics_service.snapshot("config_arbitration")
+    except KeyError:
+        return SectionResult(
+            name=name,
+            status=SectionStatus.SKIPPED,
+            summary="`config_arbitration` provider not registered.",
+        )
+    except Exception as exc:  # noqa: BLE001 — collector is fail-safe
+        return SectionResult(
+            name=name,
+            status=SectionStatus.WARNING,
+            summary=f"snapshot raised {type(exc).__name__}",
+            details=(str(exc)[:200],),
+        )
+
+    if isinstance(snap, dict) and "_error" in snap:
+        return SectionResult(
+            name=name,
+            status=SectionStatus.WARNING,
+            summary="arbitration provider returned _error.",
+            details=(str(snap.get("_error"))[:200],),
+        )
+
+    arbitration = snap.get("arbitration") if isinstance(snap, dict) else None
+    if not isinstance(arbitration, dict):
+        return SectionResult(
+            name=name,
+            status=SectionStatus.CLEAN,
+            summary="arbitration counters reachable.",
+        )
+
+    calls = int(arbitration.get("calls_total", 0))
+    by_source = arbitration.get("by_source") or {}
+    fallback = int(by_source.get("fallback", 0)) if isinstance(by_source, dict) else 0
+    missing = int(by_source.get("missing", 0)) if isinstance(by_source, dict) else 0
+
+    summary = f"calls_total={calls}; fallback={fallback}; missing={missing}."
+    if fallback or missing:
+        return SectionResult(
+            name=name,
+            status=SectionStatus.WARNING,
+            summary=summary,
+            details=(
+                "Non-zero fallback/missing indicates the arbiter is degrading "
+                "to legacy reads — investigate per `!platform flags`.",
+            ),
+        )
+    return SectionResult(
+        name=name,
+        status=SectionStatus.CLEAN,
+        summary=summary,
+    )
+
+
+async def _collect_participation() -> SectionResult:
+    """Section 7: participation storage / cache / mutation / audit."""
+    name = "Participation"
+    try:
+        from utils.db import pool
+
+        part_oid = await pool.get().fetchval(
+            "SELECT to_regclass('user_participation')",
+        )
+        audit_oid = await pool.get().fetchval(
+            "SELECT to_regclass('user_participation_audit')",
+        )
+    except Exception as exc:  # noqa: BLE001 — collector is fail-safe
+        return SectionResult(
+            name=name,
+            status=SectionStatus.WARNING,
+            summary=f"table probe raised {type(exc).__name__}",
+            details=(str(exc)[:200],),
+        )
+
+    if part_oid is None and audit_oid is None:
+        return SectionResult(
+            name=name,
+            status=SectionStatus.SKIPPED,
+            summary=(
+                "`user_participation` + `user_participation_audit` absent "
+                "(migrations 027/028 not applied)."
+            ),
+        )
+
+    # Cross-check the 4 participation events declared in
+    # core.events_catalogue.KNOWN_EVENTS.
+    expected_events = frozenset(
+        {
+            "participation.changed",
+            "subscription.changed",
+            "user_preference.changed",
+            "user_visibility.changed",
+        },
+    )
+    try:
+        from core.events_catalogue import KNOWN_EVENTS
+
+        missing_events = expected_events - KNOWN_EVENTS
+    except Exception as exc:  # noqa: BLE001 — collector is fail-safe
+        missing_events = expected_events
+        events_err: str | None = f"{type(exc).__name__}: {exc}"
+    else:
+        events_err = None
+
+    snapshots: dict[str, object] = {}
+    try:
+        from services import diagnostics_service
+
+        for provider in ("participation_schemas", "user_capability_map"):
+            try:
+                snapshots[provider] = diagnostics_service.snapshot(provider)
+            except KeyError:
+                snapshots[provider] = {"_error": "provider not registered"}
+    except Exception as exc:  # noqa: BLE001 — collector is fail-safe
+        snapshots["__error__"] = f"{type(exc).__name__}: {exc}"
+
+    provider_errors = [
+        name
+        for name, snap in snapshots.items()
+        if isinstance(snap, dict) and "_error" in snap
+    ]
+
+    details = [
+        f"user_participation present={bool(part_oid)} "
+        f"user_participation_audit present={bool(audit_oid)}",
+        f"events present={sorted(expected_events - missing_events)}",
+    ]
+    if missing_events:
+        details.append(f"events missing={sorted(missing_events)}")
+    if events_err:
+        details.append(f"events catalogue error={events_err}")
+    if provider_errors:
+        details.append(f"provider errors={sorted(provider_errors)}")
+
+    if missing_events or provider_errors or events_err:
+        return SectionResult(
+            name=name,
+            status=SectionStatus.WARNING,
+            summary=(
+                f"participation surface degraded ({len(provider_errors)} "
+                f"provider error(s), {len(missing_events)} missing event(s))."
+            ),
+            details=tuple(details)[:8],
+        )
+    return SectionResult(
+        name=name,
+        status=SectionStatus.CLEAN,
+        summary="participation storage / providers / events all reachable.",
+        details=tuple(details)[:4],
+    )
+
+
+async def _collect_migrations() -> SectionResult:
+    """Section 8: filesystem migration ladder + DB-applied set."""
+    name = "Migrations"
+
+    # Authoritative source: filesystem.
+    if not os.path.isdir(_MIGRATIONS_DIR):
+        return SectionResult(
+            name=name,
+            status=SectionStatus.FATAL,
+            summary=f"migrations directory missing: {_MIGRATIONS_DIR}",
+        )
+
+    fs_versions: list[int] = []
+    for filename in sorted(os.listdir(_MIGRATIONS_DIR)):
+        m = _MIGRATION_FILE_RE.match(filename)
+        if m:
+            try:
+                fs_versions.append(int(m.group(1)))
+            except ValueError:
+                continue
+    if not fs_versions:
+        return SectionResult(
+            name=name,
+            status=SectionStatus.WARNING,
+            summary="no `NNN_*.sql` migration files found.",
+        )
+
+    fs_versions_sorted = sorted(fs_versions)
+    highest = fs_versions_sorted[-1]
+    lowest = fs_versions_sorted[0]
+    expected = set(range(lowest, highest + 1))
+    actual = set(fs_versions_sorted)
+    gaps = sorted(expected - actual)
+
+    # Secondary source: DB-applied set.  WARNING-only on mismatch.
+    db_versions: set[int] | None = None
+    db_error: str | None = None
+    try:
+        from utils.db import pool
+
+        rows = await pool.get().fetch(
+            "SELECT version FROM schema_migrations ORDER BY version",
+        )
+        db_versions = {int(r["version"]) for r in rows}
+    except Exception as exc:  # noqa: BLE001 — collector is fail-safe
+        db_error = f"{type(exc).__name__}: {exc}"
+
+    details = [
+        f"filesystem: lowest={lowest} highest={highest} count={len(actual)}",
+    ]
+    if db_versions is not None:
+        details.append(
+            f"db-applied: count={len(db_versions)} "
+            f"highest={max(db_versions) if db_versions else 0}",
+        )
+    if db_error:
+        details.append(f"db probe error: {db_error}")
+
+    warnings: list[str] = []
+    if gaps:
+        warnings.append(f"filesystem numbering gap(s): {gaps[:5]}")
+    if db_versions is not None and (actual - db_versions):
+        pending = sorted(actual - db_versions)
+        warnings.append(f"pending DB migrations: {pending[:5]}")
+    if db_error:
+        warnings.append("db probe failed (filesystem still authoritative)")
+
+    if warnings:
+        return SectionResult(
+            name=name,
+            status=SectionStatus.WARNING,
+            summary="; ".join(warnings)[:200],
+            details=tuple(details)[:6],
+        )
+    return SectionResult(
+        name=name,
+        status=SectionStatus.CLEAN,
+        summary=f"ladder contiguous {lowest:03d} → {highest:03d}; all applied.",
+        details=tuple(details)[:4],
+    )
+
+
+async def _collect_runtime_providers() -> SectionResult:
+    """Section 9: meta-health summary of the diagnostics provider registry.
+
+    Reports only provider counts and which (if any) returned ``_error``.
+    Domain analysis lives in the dedicated sections — this section does
+    not inspect provider contents.
+    """
+    name = "Runtime providers"
+    try:
+        from services import diagnostics_service
+
+        names = diagnostics_service.registered_names()
+        snap = diagnostics_service.snapshot_all()
+    except Exception as exc:  # noqa: BLE001 — collector is fail-safe
+        return SectionResult(
+            name=name,
+            status=SectionStatus.WARNING,
+            summary=f"registry walk raised {type(exc).__name__}",
+            details=(str(exc)[:200],),
+        )
+
+    if not names:
+        return SectionResult(
+            name=name,
+            status=SectionStatus.SKIPPED,
+            summary="no providers registered.",
+        )
+
+    errors = sorted(n for n, v in snap.items() if isinstance(v, dict) and "_error" in v)
+    if errors:
+        return SectionResult(
+            name=name,
+            status=SectionStatus.WARNING,
+            summary=(f"{len(errors)}/{len(names)} provider(s) reported _error."),
+            details=(f"errored: {', '.join(errors[:8])}",),
+        )
+    return SectionResult(
+        name=name,
+        status=SectionStatus.CLEAN,
+        summary=f"{len(names)} provider(s) registered; all returned OK.",
+    )
+
+
+async def _collect_setup_readiness() -> SectionResult:
+    """Section 10: roadmap blockers for the larger UX phase (informational).
+
+    v1 returns a static list from ``SETUP_READINESS_BLOCKERS``.  Dynamic
+    detection of each blocker's resolution state is deferred to a
+    follow-up PR.  The section is marked ``informational=True`` so the
+    embed labels it as roadmap-only and ``overall_status`` does not
+    promote on it.
+    """
+    name = "Setup readiness"
+    if not SETUP_READINESS_BLOCKERS:
+        return SectionResult(
+            name=name,
+            status=SectionStatus.CLEAN,
+            summary="No roadmap blockers.",
+            informational=True,
+        )
+    return SectionResult(
+        name=name,
+        status=SectionStatus.WARNING,
+        summary=(
+            f"{len(SETUP_READINESS_BLOCKERS)} roadmap blocker(s) "
+            "tracked (informational; not a runtime health failure)."
+        ),
+        details=tuple(SETUP_READINESS_BLOCKERS),
+        suggested_actions=(
+            "See `docs/phase-2-completion-readiness.md` for unlock order.",
+        ),
+        informational=True,
+    )
+
+
+__all__ = [
+    "ConsistencyReport",
+    "SETUP_READINESS_BLOCKERS",
+    "SectionResult",
+    "SectionStatus",
+    "collect_report",
+]

--- a/disbot/services/platform_consistency.py
+++ b/disbot/services/platform_consistency.py
@@ -49,6 +49,7 @@ import datetime
 import logging
 import os
 import re
+from collections.abc import Awaitable
 from dataclasses import dataclass
 from enum import Enum
 
@@ -146,7 +147,7 @@ async def collect_report(
     callsite (the DiagnosticCog passes ``ctx.guild``; tests can pass
     ``None`` to exercise the SKIPPED paths).
     """
-    collectors: tuple[tuple[str, object], ...] = (
+    collectors: tuple[tuple[str, Awaitable[SectionResult]], ...] = (
         ("Identity contract", _collect_identity_contract(bot)),
         ("Feature flags", _collect_feature_flags()),
         ("Rollout / audit", _collect_rollout_audit()),

--- a/docs/phase-2-completion-readiness.md
+++ b/docs/phase-2-completion-readiness.md
@@ -34,14 +34,16 @@ help the next contributor avoid:
 | #83 | `bindings.primary` canary support via arbitration accessors |
 | #84 | Participation storage + cache foundation (migration 027) |
 | #85 | Integration: land #82 + #83 + #84 onto `main` |
+| #86 | Phase 2.9: participation mutation pipeline + XP opt-out proof (migration 028) — merged 2026-05-18 |
+| #87 | Phase 2 completion-readiness punch list — merged 2026-05-18 |
 
-Migration ladder on `main` after PR #85: `022` → `027`.
+Migration ladder on `main` after PR #86: `022` → `028`.
 
 ## Open right now
 
 | PR | Title | State |
 |---|---|---|
-| **#86** | **Phase 2.9: participation mutation pipeline + XP opt-out proof** | open, ready for review.  Migration 028 (participation audit).  `participation.enabled` stays default OFF. |
+| **PR-10** | **Phase 2 PR-10: Unified Consistency & Readiness Diagnostics** | in progress — adds `!platform consistency` backed by `services/platform_consistency.py`.  No migration, no behavior changes, no flag flips. |
 
 ---
 
@@ -94,20 +96,40 @@ Scope discipline for PR-10:
 
 ### Setup-readiness blockers (informational)
 
-For the wizard / setup phase to start, these must be in place:
+For the wizard / setup phase to start, these must be in place.  The
+list below is mirrored verbatim in
+`services.platform_consistency.SETUP_READINESS_BLOCKERS` and
+surfaced by `!platform consistency` as an informational section.
+The doc test
+`tests/unit/docs/test_phase_2_readiness_doc.py` enforces that every
+constant entry appears here in humanised form, so adding a new
+blocker requires updating both this doc and the constant.
 
-* Diagnostics consistency surface (PR-10).
-* A documented "command surface ledger" — the catalogue of slash /
-  prefix entrypoints that the wizard / panels would link from.
-* A panel registry — version-stamped persistent-view registration.
-* A settings registry — typed setting metadata for the wizard's
+* **command surface ledger** — the catalogue of slash / prefix
+  entrypoints that the wizard / panels would link from.
+* **panel registry** — version-stamped persistent-view registration.
+* **settings registry** — typed setting metadata for the wizard's
   preview/commit flow.
-* `governance` `SubsystemSchema` declaration for `trusted_role` so the
-  binding backfill can complete for that key (currently
-  `BLOCKED_NO_SCHEMA`).
+* **settings mutation pipeline** — mirrors binding / rollout /
+  participation mutation services.
+* **governance trusted role schema** — `governance` `SubsystemSchema`
+  declaration for `trusted_role` so the binding backfill can
+  complete for that key (currently `BLOCKED_NO_SCHEMA`).
+* **role service extraction** — pull role-management primitives out of
+  the cog layer into a service.
+* **cleanup policy extraction** — pull cleanup policy out of
+  moderation_service / cog layer into a dedicated service.
+* **logging settings integration** — once PR-11's server-logging
+  foundation lands, surface its toggles through the settings
+  registry.
+* **slash panel entrypoints** — `/setup`, `/settings` etc. wired into
+  the panel registry.
+* **setup wizard readiness bridge** — gating signal published by the
+  consistency surface that the wizard can consume.
+* **setup wizard** — end-user-facing onboarding flow.
 
-None of these are in scope for the current Phase 2 plan.  They are
-listed here so PR-10 reviewers can sequence work afterwards.
+None of these are in scope for PR-10 itself; PR-10 only **reports**
+them as informational tracking.
 
 ---
 
@@ -145,7 +167,7 @@ the consistency ledger exists to prevent:
 | `025_feature_flag_audit.sql` | #78 | on main |
 | `026_platform_migration_checkpoints.sql` | #81 | on main |
 | `027_user_participation.sql` | #84 | on main |
-| `028_user_participation_audit.sql` | #86 | **open** |
+| `028_user_participation_audit.sql` | #86 | on main |
 | 029 | next free number | — |
 
 ---

--- a/tests/unit/cogs/test_diagnostic_consistency_embed.py
+++ b/tests/unit/cogs/test_diagnostic_consistency_embed.py
@@ -1,0 +1,243 @@
+"""Tests for cogs.diagnostic._platform_embeds.build_consistency_embed."""
+
+from __future__ import annotations
+
+import datetime
+
+import discord
+import pytest
+
+from cogs.diagnostic._platform_embeds import (
+    _EMBED_SOFT_CAP,
+    _FIELD_HARD_CAP,
+    _INFORMATIONAL_PREFIX,
+    build_consistency_embed,
+)
+from services.platform_consistency import (
+    ConsistencyReport,
+    SectionResult,
+    SectionStatus,
+)
+
+
+def _section(
+    name: str,
+    status: SectionStatus,
+    *,
+    summary: str = "summary",
+    details: tuple[str, ...] = (),
+    informational: bool = False,
+) -> SectionResult:
+    return SectionResult(
+        name=name,
+        status=status,
+        summary=summary,
+        details=details,
+        informational=informational,
+    )
+
+
+def _report(*sections: SectionResult) -> ConsistencyReport:
+    return ConsistencyReport(
+        sections=sections,
+        generated_at=datetime.datetime(2026, 5, 18, 17, 30, tzinfo=datetime.timezone.utc),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Color mapping
+# ---------------------------------------------------------------------------
+
+
+def test_build_embed_color_red_when_any_fatal():
+    embed = build_consistency_embed(
+        _report(
+            _section("a", SectionStatus.CLEAN),
+            _section("b", SectionStatus.FATAL),
+        ),
+    )
+    assert embed.color == discord.Color.red()
+    assert "FATAL" in embed.title
+
+
+def test_build_embed_color_gold_when_warning():
+    embed = build_consistency_embed(
+        _report(
+            _section("a", SectionStatus.CLEAN),
+            _section("b", SectionStatus.WARNING),
+        ),
+    )
+    assert embed.color == discord.Color.gold()
+    assert "WARNING" in embed.title
+
+
+def test_build_embed_color_green_when_clean():
+    embed = build_consistency_embed(
+        _report(
+            _section("a", SectionStatus.CLEAN),
+            _section("b", SectionStatus.CLEAN),
+        ),
+    )
+    assert embed.color == discord.Color.green()
+    assert "CLEAN" in embed.title
+
+
+def test_build_embed_color_grey_when_all_skipped():
+    embed = build_consistency_embed(
+        _report(
+            _section("a", SectionStatus.SKIPPED),
+            _section("b", SectionStatus.SKIPPED),
+        ),
+    )
+    assert embed.color == discord.Color.light_grey()
+    assert "SKIPPED" in embed.title
+
+
+# ---------------------------------------------------------------------------
+# Bounded size
+# ---------------------------------------------------------------------------
+
+
+def test_build_embed_bounded_under_6000_chars():
+    """Stress: 10 sections each with 4KB of details should not exceed
+    Discord's 6000-char embed limit."""
+    big = "x" * 4000
+    sections = tuple(
+        _section(
+            f"section-{i}",
+            SectionStatus.WARNING,
+            summary="s" * 200,
+            details=tuple([big] * 4),
+        )
+        for i in range(10)
+    )
+    embed = build_consistency_embed(_report(*sections))
+    # The Discord SDK exposes __len__ for Embed; use that as the source of truth.
+    assert len(embed) < 6000
+
+
+def test_build_embed_truncates_field_with_marker():
+    big = "y" * 5000
+    embed = build_consistency_embed(
+        _report(
+            _section(
+                "big",
+                SectionStatus.WARNING,
+                summary="overview",
+                details=(big,),
+            ),
+        ),
+    )
+    # The field value cap (≤1000) leaves a truncation marker on long
+    # fields.
+    overflow_fields = [
+        f for f in embed.fields if f.value and len(f.value) > 1024
+    ]
+    assert not overflow_fields
+    long_fields = [f for f in embed.fields if f.value and "…" in f.value]
+    assert long_fields, "Expected at least one truncated field with the … marker"
+
+
+def test_build_embed_field_cap_at_24():
+    sections = tuple(
+        _section(f"s{i}", SectionStatus.CLEAN, summary="ok")
+        for i in range(50)
+    )
+    embed = build_consistency_embed(_report(*sections))
+    assert len(embed.fields) <= _FIELD_HARD_CAP + 1  # +1 for optional `… truncated`
+
+
+# ---------------------------------------------------------------------------
+# Informational section labelling (clarification #4)
+# ---------------------------------------------------------------------------
+
+
+def test_build_embed_informational_section_labelled():
+    embed = build_consistency_embed(
+        _report(
+            _section("a", SectionStatus.CLEAN),
+            _section(
+                "Setup readiness",
+                SectionStatus.WARNING,
+                summary="3 roadmap blocker(s)",
+                details=("blocker_a", "blocker_b"),
+                informational=True,
+            ),
+        ),
+    )
+    # Find the Setup readiness field; its value must contain the
+    # informational marker so operators don't read it as runtime failure.
+    setup_field = next(
+        (f for f in embed.fields if "Setup readiness" in (f.name or "")),
+        None,
+    )
+    assert setup_field is not None
+    # The marker prefix lives at the start of the rendered value.
+    assert _INFORMATIONAL_PREFIX.strip() in (setup_field.value or "")
+
+
+def test_build_embed_footer_separates_informational_from_runtime_warnings():
+    """Footer must count informational and runtime warnings separately."""
+    embed = build_consistency_embed(
+        _report(
+            _section("runtime-a", SectionStatus.WARNING),
+            _section("runtime-b", SectionStatus.WARNING),
+            _section(
+                "Setup readiness",
+                SectionStatus.WARNING,
+                informational=True,
+            ),
+        ),
+    )
+    assert embed.footer is not None
+    footer_text = embed.footer.text or ""
+    assert "2 runtime warning" in footer_text
+    assert "1 informational" in footer_text
+
+
+def test_build_embed_informational_warning_does_not_force_fatal_title():
+    """If only the Setup readiness section is WARNING, the overall
+    status (and embed title) must remain CLEAN."""
+    embed = build_consistency_embed(
+        _report(
+            _section("a", SectionStatus.CLEAN),
+            _section(
+                "Setup readiness",
+                SectionStatus.WARNING,
+                informational=True,
+            ),
+        ),
+    )
+    assert "CLEAN" in embed.title
+
+
+# ---------------------------------------------------------------------------
+# Description content
+# ---------------------------------------------------------------------------
+
+
+def test_build_embed_description_includes_counts_and_timestamp():
+    embed = build_consistency_embed(
+        _report(
+            _section("a", SectionStatus.CLEAN),
+            _section("b", SectionStatus.WARNING),
+            _section("c", SectionStatus.FATAL),
+            _section("d", SectionStatus.SKIPPED),
+        ),
+    )
+    desc = embed.description or ""
+    assert "1 clean" in desc
+    assert "1 warning" in desc
+    assert "1 fatal" in desc
+    assert "1 skipped" in desc
+    assert "2026-05-18" in desc
+
+
+# ---------------------------------------------------------------------------
+# Embed soft cap constant sanity
+# ---------------------------------------------------------------------------
+
+
+def test_soft_cap_under_discord_hard_limit():
+    """Soft cap must leave headroom under Discord's 6000-char hard limit."""
+    assert _EMBED_SOFT_CAP < 6000

--- a/tests/unit/docs/test_phase_2_readiness_doc.py
+++ b/tests/unit/docs/test_phase_2_readiness_doc.py
@@ -1,0 +1,82 @@
+"""Stale-doc guard for docs/phase-2-completion-readiness.md (PR-10).
+
+Uses resilient marker-and-name assertions (case-insensitive substring
+matches; no exact markdown formatting pinning) so the doc can be
+re-styled without breaking CI.  The blocker-name check ties the doc to
+``services.platform_consistency.SETUP_READINESS_BLOCKERS`` so adding a
+new blocker requires updating both files.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from services.platform_consistency import SETUP_READINESS_BLOCKERS
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DOC_PATH = _REPO_ROOT / "docs" / "phase-2-completion-readiness.md"
+
+
+@pytest.fixture(scope="module")
+def doc_text() -> str:
+    return _DOC_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def doc_lines(doc_text: str) -> list[str]:
+    return doc_text.splitlines()
+
+
+def test_doc_file_exists():
+    assert _DOC_PATH.is_file(), f"Missing doc file: {_DOC_PATH}"
+
+
+def test_pr_86_marked_merged(doc_lines: list[str]):
+    """PR #86 must appear with 'merged' on the same line in the done
+    table (clarification #5 — substring assertion, no formatting pin)."""
+    matches = [
+        ln for ln in doc_lines
+        if "#86" in ln and "merged" in ln.lower()
+    ]
+    assert matches, (
+        "Expected a line mentioning PR #86 alongside 'merged' "
+        "to indicate PR #86 has landed on main."
+    )
+
+
+def test_migration_028_on_main(doc_lines: list[str]):
+    """Migration 028 must appear on a line that also mentions 'main'."""
+    matches = [
+        ln for ln in doc_lines
+        if "028_user_participation_audit.sql" in ln and "main" in ln.lower()
+    ]
+    assert matches, (
+        "Expected '028_user_participation_audit.sql' to appear on the "
+        "same line as 'main' (indicating it has landed on main)."
+    )
+
+
+def test_pr_10_listed_as_current_next_work(doc_text: str):
+    """PR-10 should be referenced as current next work in the doc."""
+    lowered = doc_text.lower()
+    assert "pr-10" in lowered or "unified consistency" in lowered, (
+        "Expected 'PR-10' or 'Unified Consistency' to appear so reviewers "
+        "can locate the current next-work item."
+    )
+
+
+def test_every_setup_readiness_blocker_appears_in_doc(doc_text: str):
+    """Every entry in SETUP_READINESS_BLOCKERS must appear in the doc in
+    humanised form (snake_case → space-separated, case-insensitive)."""
+    lowered = doc_text.lower()
+    missing: list[str] = []
+    for blocker in SETUP_READINESS_BLOCKERS:
+        humanised = blocker.replace("_", " ")
+        if humanised not in lowered:
+            missing.append(f"{blocker!r} (looked for {humanised!r})")
+    assert not missing, (
+        "Doc/SETUP_READINESS_BLOCKERS sync gap — add these to the "
+        "'Setup-readiness blockers' section:\n  " + "\n  ".join(missing)
+    )

--- a/tests/unit/runtime/test_consistency_import_cycle.py
+++ b/tests/unit/runtime/test_consistency_import_cycle.py
@@ -1,0 +1,91 @@
+"""Import-cycle regression for services.platform_consistency — PR-10.
+
+The collection service must keep all cycle-sensitive imports
+(core.runtime.*, utils.subsystem_registry, utils.db.*,
+core.events_catalogue) function-local.  Re-introducing them at module
+scope would re-enter partially-loaded core.runtime modules during
+startup and crash the bot with the same ImportError pattern the
+Phase 2b hotfix fixed.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SERVICE_PATH = (
+    _REPO_ROOT / "disbot" / "services" / "platform_consistency.py"
+)
+
+# Modules whose top-level import would re-enter a partially-loaded
+# parent package during startup.
+_FORBIDDEN_TOP_LEVEL_PREFIXES = (
+    "core.runtime",
+    "utils.subsystem_registry",
+    "utils.db",
+    "core.events_catalogue",
+)
+
+
+def _module_level_imports(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    offenders: list[str] = []
+    for node in tree.body:  # module-level only
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for prefix in _FORBIDDEN_TOP_LEVEL_PREFIXES:
+                if module == prefix or module.startswith(prefix + "."):
+                    offenders.append(
+                        f"from {module} import "
+                        f"{', '.join(a.name for a in node.names)}",
+                    )
+                    break
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                for prefix in _FORBIDDEN_TOP_LEVEL_PREFIXES:
+                    if alias.name == prefix or alias.name.startswith(prefix + "."):
+                        offenders.append(f"import {alias.name}")
+                        break
+    return offenders
+
+
+def test_platform_consistency_has_no_top_level_cycle_imports():
+    """services.platform_consistency must NOT carry top-level imports of
+    core.runtime / utils.subsystem_registry / utils.db /
+    core.events_catalogue.  Move them into the collector functions."""
+    offenders = _module_level_imports(_SERVICE_PATH)
+    assert not offenders, (
+        "services.platform_consistency has cycle-sensitive top-level "
+        "imports:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_platform_consistency_imports_in_fresh_interpreter():
+    """Run `python -c "import services.platform_consistency"` in a
+    fresh interpreter so cached modules in the pytest process cannot
+    mask a cycle introduced by the new module."""
+    script = textwrap.dedent(
+        """
+        import sys
+        sys.path.insert(0, "disbot")
+        import services.platform_consistency  # noqa: F401
+        print("ok")
+        """,
+    )
+    result = subprocess.run(  # noqa: S603 — script literal under our control
+        [sys.executable, "-c", script],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"services.platform_consistency import failed in subprocess.\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "ok" in result.stdout

--- a/tests/unit/runtime/test_import_cycle_regression.py
+++ b/tests/unit/runtime/test_import_cycle_regression.py
@@ -54,6 +54,10 @@ _HELPERS_PATH = _REPO_ROOT / "disbot" / "utils" / "helpers.py"
 _CYCLE_SENSITIVE_FILES: tuple[Path, ...] = (
     _REPO_ROOT / "disbot" / "utils" / "helpers.py",
     _REPO_ROOT / "disbot" / "governance" / "__init__.py",
+    # Phase 2 PR-10 — services.platform_consistency must keep its
+    # cross-package imports function-local; module-scope imports of
+    # core.runtime would re-introduce the partial-load cycle.
+    _REPO_ROOT / "disbot" / "services" / "platform_consistency.py",
 )
 
 

--- a/tests/unit/services/test_platform_consistency.py
+++ b/tests/unit/services/test_platform_consistency.py
@@ -11,7 +11,6 @@ import pytest
 
 from services import platform_consistency as pc
 
-
 # ---------------------------------------------------------------------------
 # Status promotion logic
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_platform_consistency.py
+++ b/tests/unit/services/test_platform_consistency.py
@@ -1,0 +1,600 @@
+"""Unit tests for services.platform_consistency — Phase 2 PR-10."""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services import platform_consistency as pc
+
+
+# ---------------------------------------------------------------------------
+# Status promotion logic
+# ---------------------------------------------------------------------------
+
+
+def _make_section(status: pc.SectionStatus, *, informational: bool = False) -> pc.SectionResult:
+    return pc.SectionResult(
+        name=f"section-{status.value}",
+        status=status,
+        summary="summary",
+        informational=informational,
+    )
+
+
+def _report(*statuses: pc.SectionStatus, informational: tuple[bool, ...] | None = None) -> pc.ConsistencyReport:
+    if informational is None:
+        informational = (False,) * len(statuses)
+    sections = tuple(
+        _make_section(s, informational=info)
+        for s, info in zip(statuses, informational, strict=False)
+    )
+    return pc.ConsistencyReport(
+        sections=sections,
+        generated_at=datetime.datetime.now(tz=datetime.timezone.utc),
+    )
+
+
+def test_overall_status_promotes_fatal_over_warning():
+    r = _report(pc.SectionStatus.WARNING, pc.SectionStatus.FATAL, pc.SectionStatus.CLEAN)
+    assert r.overall_status == pc.SectionStatus.FATAL
+
+
+def test_overall_status_warning_when_no_fatal():
+    r = _report(pc.SectionStatus.CLEAN, pc.SectionStatus.WARNING, pc.SectionStatus.SKIPPED)
+    assert r.overall_status == pc.SectionStatus.WARNING
+
+
+def test_overall_status_all_skipped_returns_skipped():
+    r = _report(pc.SectionStatus.SKIPPED, pc.SectionStatus.SKIPPED)
+    assert r.overall_status == pc.SectionStatus.SKIPPED
+
+
+def test_overall_status_skipped_does_not_demote_clean():
+    r = _report(pc.SectionStatus.CLEAN, pc.SectionStatus.SKIPPED, pc.SectionStatus.CLEAN)
+    assert r.overall_status == pc.SectionStatus.CLEAN
+
+
+def test_overall_status_ignores_informational_warning():
+    """Informational WARNING (Setup readiness) does not demote CLEAN."""
+    r = _report(
+        pc.SectionStatus.CLEAN,
+        pc.SectionStatus.WARNING,
+        informational=(False, True),
+    )
+    assert r.overall_status == pc.SectionStatus.CLEAN
+
+
+def test_overall_status_clean_when_only_informational_sections():
+    r = pc.ConsistencyReport(
+        sections=(_make_section(pc.SectionStatus.WARNING, informational=True),),
+        generated_at=datetime.datetime.now(tz=datetime.timezone.utc),
+    )
+    assert r.overall_status == pc.SectionStatus.SKIPPED
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator — collector exception isolation
+# ---------------------------------------------------------------------------
+
+
+def test_collect_report_isolates_collector_exception():
+    """If a section collector raises, the report still contains the section
+    with status=FATAL and summary identifying the exception class."""
+
+    async def bad_collector() -> pc.SectionResult:
+        raise RuntimeError("boom")
+
+    async def good_collector() -> pc.SectionResult:
+        return pc.SectionResult(
+            name="ok",
+            status=pc.SectionStatus.CLEAN,
+            summary="fine",
+        )
+
+    # Patch every collector except identity to a fast-CLEAN async stub so
+    # the orchestrator returns deterministically.
+    with patch.multiple(
+        pc,
+        _collect_identity_contract=lambda bot: bad_collector(),
+        _collect_feature_flags=lambda: good_collector(),
+        _collect_rollout_audit=lambda: good_collector(),
+        _collect_bindings=lambda guild: good_collector(),
+        _collect_binding_backfill=lambda: good_collector(),
+        _collect_config_arbitration=lambda: good_collector(),
+        _collect_participation=lambda: good_collector(),
+        _collect_migrations=lambda: good_collector(),
+        _collect_runtime_providers=lambda: good_collector(),
+        _collect_setup_readiness=lambda: good_collector(),
+    ):
+        report = asyncio.run(pc.collect_report(bot=object(), guild=None))
+
+    assert len(report.sections) == 10
+    identity = report.sections[0]
+    assert identity.status == pc.SectionStatus.FATAL
+    assert "RuntimeError" in identity.summary
+
+
+def test_collect_report_is_guild_aware_passes_guild_to_bindings():
+    """The bindings collector must receive the guild passed to collect_report."""
+    captured: dict[str, object] = {}
+
+    async def capturing_bindings(guild: object | None) -> pc.SectionResult:
+        captured["guild"] = guild
+        return pc.SectionResult(
+            name="Bindings",
+            status=pc.SectionStatus.SKIPPED,
+            summary="captured",
+        )
+
+    async def trivial(*args, **kwargs) -> pc.SectionResult:
+        return pc.SectionResult(name="x", status=pc.SectionStatus.SKIPPED, summary="x")
+
+    sentinel_guild = object()
+    with patch.multiple(
+        pc,
+        _collect_identity_contract=trivial,
+        _collect_feature_flags=trivial,
+        _collect_rollout_audit=trivial,
+        _collect_bindings=capturing_bindings,
+        _collect_binding_backfill=trivial,
+        _collect_config_arbitration=trivial,
+        _collect_participation=trivial,
+        _collect_migrations=trivial,
+        _collect_runtime_providers=trivial,
+        _collect_setup_readiness=trivial,
+    ):
+        asyncio.run(pc.collect_report(bot=None, guild=sentinel_guild))
+
+    assert captured["guild"] is sentinel_guild
+
+
+# ---------------------------------------------------------------------------
+# Identity contract collector — uses the live validate_identity_contract
+# ---------------------------------------------------------------------------
+
+
+def test_identity_contract_skipped_when_bot_is_none():
+    result = asyncio.run(pc._collect_identity_contract(None))
+    assert result.status == pc.SectionStatus.SKIPPED
+
+
+def test_identity_contract_clean_when_findings_empty():
+    async def stub(_bot):
+        return {}
+
+    with patch(
+        "utils.subsystem_registry.validate_identity_contract",
+        side_effect=stub,
+    ):
+        result = asyncio.run(pc._collect_identity_contract(object()))
+    assert result.status == pc.SectionStatus.CLEAN
+
+
+def test_identity_contract_warning_when_only_warn_only():
+    async def stub(_bot):
+        return {"schema_subsystem_unknown": ["x", "y"]}
+
+    with patch(
+        "utils.subsystem_registry.validate_identity_contract",
+        side_effect=stub,
+    ):
+        result = asyncio.run(pc._collect_identity_contract(object()))
+    assert result.status == pc.SectionStatus.WARNING
+
+
+def test_identity_contract_fatal_when_fatal_tier():
+    async def stub(_bot):
+        return {"entry_point_missing_command": ["zzz"]}
+
+    with patch(
+        "utils.subsystem_registry.validate_identity_contract",
+        side_effect=stub,
+    ):
+        result = asyncio.run(pc._collect_identity_contract(object()))
+    assert result.status == pc.SectionStatus.FATAL
+
+
+def test_identity_contract_no_wait_for_used():
+    """Clarification #1: collector must NOT wrap the validator in
+    asyncio.wait_for in v1.  Keeps the collector simple; a timeout
+    can be added in a follow-up PR if data justifies it."""
+    src = Path(pc.__file__).read_text()
+    assert "asyncio.wait_for" not in src
+
+
+# ---------------------------------------------------------------------------
+# Feature flags collector
+# ---------------------------------------------------------------------------
+
+
+def test_feature_flags_warning_when_bootstrap_fallback_positive():
+    fake_flags = {"foo": object(), "bar": object()}
+
+    async def fake_resolve(_name, _gid):
+        return ("decision", "source")
+
+    with patch("core.runtime.feature_flags.all_flags", return_value=fake_flags), patch(
+        "core.runtime.feature_flags.resolve_with_provenance",
+        side_effect=fake_resolve,
+    ), patch(
+        "core.runtime.feature_flags.bootstrap_fallback_count",
+        return_value=3,
+    ):
+        result = asyncio.run(pc._collect_feature_flags())
+    assert result.status == pc.SectionStatus.WARNING
+    assert "fallback" in result.summary.lower()
+
+
+def test_feature_flags_clean_when_no_fallback():
+    fake_flags = {"foo": object()}
+
+    async def fake_resolve(_name, _gid):
+        return ("decision", "source")
+
+    with patch("core.runtime.feature_flags.all_flags", return_value=fake_flags), patch(
+        "core.runtime.feature_flags.resolve_with_provenance",
+        side_effect=fake_resolve,
+    ), patch(
+        "core.runtime.feature_flags.bootstrap_fallback_count",
+        return_value=0,
+    ):
+        result = asyncio.run(pc._collect_feature_flags())
+    assert result.status == pc.SectionStatus.CLEAN
+
+
+def test_feature_flags_fatal_when_resolve_raises():
+    fake_flags = {"foo": object()}
+
+    async def fake_resolve(_name, _gid):
+        raise RuntimeError("evaluator dead")
+
+    with patch("core.runtime.feature_flags.all_flags", return_value=fake_flags), patch(
+        "core.runtime.feature_flags.resolve_with_provenance",
+        side_effect=fake_resolve,
+    ):
+        result = asyncio.run(pc._collect_feature_flags())
+    assert result.status == pc.SectionStatus.FATAL
+
+
+def test_feature_flags_does_not_assert_malformed_override():
+    """Clarification #2: collector must NOT claim to detect malformed
+    overrides, because resolve_with_provenance does not expose that
+    signal today.  Verified by reading the collector source: only the
+    API-exposed signals (all_flags, resolve_with_provenance,
+    bootstrap_fallback_count) are referenced."""
+    src = Path(pc.__file__).read_text()
+    # Find the feature flags collector body.
+    start = src.index("async def _collect_feature_flags")
+    end = src.index("async def _collect_rollout_audit", start)
+    body = src[start:end]
+    # The collector must not mention "malformed" anywhere — that
+    # would imply a signal we cannot read.
+    assert "malformed" not in body.lower()
+    # Sanity: it must use the API-exposed signals.
+    assert "bootstrap_fallback_count" in body
+    assert "resolve_with_provenance" in body
+
+
+# ---------------------------------------------------------------------------
+# Bindings collector
+# ---------------------------------------------------------------------------
+
+
+def test_bindings_warning_on_missing_or_invalid_only():
+    guild = type("G", (), {"id": 42})()
+    fake_histogram = {"bound": 5, "unresolved": 2, "missing": 1, "invalid": 0}
+    with patch(
+        "utils.db.bindings.count_by_status",
+        new_callable=AsyncMock,
+        return_value=fake_histogram,
+    ):
+        result = asyncio.run(pc._collect_bindings(guild))
+    assert result.status == pc.SectionStatus.WARNING
+    assert "broken" in result.summary.lower()
+
+
+def test_bindings_unresolved_does_not_promote_status():
+    """Regression: `unresolved` alone is unconfigured-by-default and
+    must not be reported as a broken binding in v1."""
+    guild = type("G", (), {"id": 42})()
+    fake_histogram = {"bound": 5, "unresolved": 10, "missing": 0, "invalid": 0}
+    with patch(
+        "utils.db.bindings.count_by_status",
+        new_callable=AsyncMock,
+        return_value=fake_histogram,
+    ):
+        result = asyncio.run(pc._collect_bindings(guild))
+    assert result.status == pc.SectionStatus.CLEAN
+
+
+def test_bindings_skipped_when_guild_is_none():
+    result = asyncio.run(pc._collect_bindings(None))
+    assert result.status == pc.SectionStatus.SKIPPED
+
+
+def test_bindings_fatal_when_db_raises():
+    guild = type("G", (), {"id": 42})()
+    with patch(
+        "utils.db.bindings.count_by_status",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("table missing"),
+    ):
+        result = asyncio.run(pc._collect_bindings(guild))
+    assert result.status == pc.SectionStatus.FATAL
+
+
+# ---------------------------------------------------------------------------
+# Binding backfill collector
+# ---------------------------------------------------------------------------
+
+
+def test_binding_backfill_warning_on_in_progress():
+    with patch(
+        "utils.db.platform_migration_checkpoints.count_by_status",
+        new_callable=AsyncMock,
+        return_value={"complete": 5, "in_progress": 1},
+    ):
+        result = asyncio.run(pc._collect_binding_backfill())
+    assert result.status == pc.SectionStatus.WARNING
+
+
+def test_binding_backfill_fatal_on_failed():
+    with patch(
+        "utils.db.platform_migration_checkpoints.count_by_status",
+        new_callable=AsyncMock,
+        return_value={"complete": 3, "failed": 2},
+    ):
+        result = asyncio.run(pc._collect_binding_backfill())
+    assert result.status == pc.SectionStatus.FATAL
+
+
+def test_binding_backfill_skipped_when_no_rows():
+    with patch(
+        "utils.db.platform_migration_checkpoints.count_by_status",
+        new_callable=AsyncMock,
+        return_value={},
+    ):
+        result = asyncio.run(pc._collect_binding_backfill())
+    assert result.status == pc.SectionStatus.SKIPPED
+
+
+def test_binding_backfill_clean_when_only_complete():
+    with patch(
+        "utils.db.platform_migration_checkpoints.count_by_status",
+        new_callable=AsyncMock,
+        return_value={"complete": 4, "dry_run_complete": 2},
+    ):
+        result = asyncio.run(pc._collect_binding_backfill())
+    assert result.status == pc.SectionStatus.CLEAN
+
+
+# ---------------------------------------------------------------------------
+# Migrations collector
+# ---------------------------------------------------------------------------
+
+
+def test_migrations_warning_on_numbering_gap(tmp_path, monkeypatch):
+    # Create a fake migrations directory with a gap (001, 002, 005).
+    for n in (1, 2, 5):
+        (tmp_path / f"{n:03d}_test.sql").write_text("-- noop")
+    monkeypatch.setattr(pc, "_MIGRATIONS_DIR", str(tmp_path))
+    # Stub the DB to return the full filesystem set so the only signal
+    # is the filesystem gap.
+    async def fake_fetch(*_args, **_kwargs):
+        return [{"version": n} for n in (1, 2, 5)]
+
+    fake_pool = type("P", (), {"fetch": staticmethod(fake_fetch)})()
+    with patch("utils.db.pool.get", return_value=fake_pool):
+        result = asyncio.run(pc._collect_migrations())
+    assert result.status == pc.SectionStatus.WARNING
+    assert "gap" in result.summary.lower()
+
+
+def test_migrations_warning_when_db_query_raises_but_files_clean(tmp_path, monkeypatch):
+    for n in (1, 2, 3):
+        (tmp_path / f"{n:03d}_test.sql").write_text("-- noop")
+    monkeypatch.setattr(pc, "_MIGRATIONS_DIR", str(tmp_path))
+
+    def boom():
+        raise RuntimeError("pool down")
+
+    with patch("utils.db.pool.get", side_effect=boom):
+        result = asyncio.run(pc._collect_migrations())
+    assert result.status == pc.SectionStatus.WARNING
+    assert "db probe" in result.summary.lower() or "db probe" in " ".join(result.details).lower()
+
+
+def test_migrations_fatal_when_directory_missing(monkeypatch):
+    monkeypatch.setattr(pc, "_MIGRATIONS_DIR", "/nonexistent/path/for/test")
+    result = asyncio.run(pc._collect_migrations())
+    assert result.status == pc.SectionStatus.FATAL
+
+
+def test_migrations_clean_when_contiguous_and_applied(tmp_path, monkeypatch):
+    for n in (1, 2, 3):
+        (tmp_path / f"{n:03d}_test.sql").write_text("-- noop")
+    monkeypatch.setattr(pc, "_MIGRATIONS_DIR", str(tmp_path))
+
+    async def fake_fetch(*_args, **_kwargs):
+        return [{"version": n} for n in (1, 2, 3)]
+
+    fake_pool = type("P", (), {"fetch": staticmethod(fake_fetch)})()
+    with patch("utils.db.pool.get", return_value=fake_pool):
+        result = asyncio.run(pc._collect_migrations())
+    assert result.status == pc.SectionStatus.CLEAN
+
+
+# ---------------------------------------------------------------------------
+# Runtime providers collector (meta-health only)
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_providers_marks_per_provider_error():
+    with patch(
+        "services.diagnostics_service.registered_names",
+        return_value=["a", "b"],
+    ), patch(
+        "services.diagnostics_service.snapshot_all",
+        return_value={
+            "a": {"ok": True},
+            "b": {"_error": "RuntimeError: boom"},
+        },
+    ):
+        result = asyncio.run(pc._collect_runtime_providers())
+    assert result.status == pc.SectionStatus.WARNING
+    assert "b" in " ".join(result.details)
+
+
+def test_runtime_providers_clean_when_all_ok():
+    with patch(
+        "services.diagnostics_service.registered_names",
+        return_value=["a", "b"],
+    ), patch(
+        "services.diagnostics_service.snapshot_all",
+        return_value={"a": {"ok": True}, "b": {"ok": True}},
+    ):
+        result = asyncio.run(pc._collect_runtime_providers())
+    assert result.status == pc.SectionStatus.CLEAN
+
+
+def test_runtime_providers_skipped_when_registry_empty():
+    with patch(
+        "services.diagnostics_service.registered_names",
+        return_value=[],
+    ), patch(
+        "services.diagnostics_service.snapshot_all",
+        return_value={},
+    ):
+        result = asyncio.run(pc._collect_runtime_providers())
+    assert result.status == pc.SectionStatus.SKIPPED
+
+
+def test_runtime_providers_is_meta_only():
+    """Clarification #3: this section reports counts + error names; it
+    does NOT inspect provider contents (domain analysis is in the
+    dedicated sections)."""
+    src = Path(pc.__file__).read_text()
+    start = src.index("async def _collect_runtime_providers")
+    end = src.index("async def _collect_setup_readiness", start)
+    body = src[start:end]
+    # Must NOT reach into domain-specific keys.
+    forbidden_terms = (
+        "by_source",
+        "by_binding_status",
+        "by_flag_state",
+        "calls_total",
+        "validator_dispatch",
+    )
+    for term in forbidden_terms:
+        assert term not in body, (
+            f"Runtime providers collector must stay meta-only — found {term!r} "
+            f"which suggests domain analysis."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Rollout / audit collector
+# ---------------------------------------------------------------------------
+
+
+def test_rollout_audit_skipped_when_table_absent():
+    async def fake_fetchval(query, *args):
+        return None  # to_regclass returns NULL when table missing
+
+    fake_pool = type("P", (), {"fetchval": staticmethod(fake_fetchval)})()
+    with patch("utils.db.pool.get", return_value=fake_pool):
+        result = asyncio.run(pc._collect_rollout_audit())
+    assert result.status == pc.SectionStatus.SKIPPED
+
+
+def test_rollout_audit_clean_when_table_present():
+    calls = {"n": 0}
+
+    async def fake_fetchval(query, *args):
+        calls["n"] += 1
+        if "to_regclass" in query:
+            return "feature_flag_audit"
+        return 42  # count
+
+    fake_pool = type("P", (), {"fetchval": staticmethod(fake_fetchval)})()
+    with patch("utils.db.pool.get", return_value=fake_pool):
+        result = asyncio.run(pc._collect_rollout_audit())
+    assert result.status == pc.SectionStatus.CLEAN
+    assert "42" in result.summary
+
+
+# ---------------------------------------------------------------------------
+# Participation collector
+# ---------------------------------------------------------------------------
+
+
+def test_participation_skipped_when_tables_absent():
+    async def fake_fetchval(query, *args):
+        return None
+
+    fake_pool = type("P", (), {"fetchval": staticmethod(fake_fetchval)})()
+    with patch("utils.db.pool.get", return_value=fake_pool):
+        result = asyncio.run(pc._collect_participation())
+    assert result.status == pc.SectionStatus.SKIPPED
+
+
+# ---------------------------------------------------------------------------
+# Setup readiness collector
+# ---------------------------------------------------------------------------
+
+
+def test_setup_readiness_lists_all_documented_blockers():
+    result = asyncio.run(pc._collect_setup_readiness())
+    assert result.status == pc.SectionStatus.WARNING
+    assert result.informational is True
+    # Every constant entry must appear verbatim in the details.
+    for blocker in pc.SETUP_READINESS_BLOCKERS:
+        assert blocker in result.details
+
+
+def test_setup_readiness_marked_informational():
+    result = asyncio.run(pc._collect_setup_readiness())
+    assert result.informational is True
+
+
+def test_setup_readiness_constant_is_nonempty_tuple():
+    assert isinstance(pc.SETUP_READINESS_BLOCKERS, tuple)
+    assert len(pc.SETUP_READINESS_BLOCKERS) > 0
+    # Spot-check a few well-known blocker names.
+    assert "command_surface_ledger" in pc.SETUP_READINESS_BLOCKERS
+    assert "setup_wizard" in pc.SETUP_READINESS_BLOCKERS
+    assert "panel_registry" in pc.SETUP_READINESS_BLOCKERS
+
+
+# ---------------------------------------------------------------------------
+# collect_report integration smoke
+# ---------------------------------------------------------------------------
+
+
+def test_collect_report_returns_ten_sections_in_order():
+    async def trivial(*args, **kwargs) -> pc.SectionResult:
+        return pc.SectionResult(name="x", status=pc.SectionStatus.SKIPPED, summary="x")
+
+    with patch.multiple(
+        pc,
+        _collect_identity_contract=trivial,
+        _collect_feature_flags=trivial,
+        _collect_rollout_audit=trivial,
+        _collect_bindings=trivial,
+        _collect_binding_backfill=trivial,
+        _collect_config_arbitration=trivial,
+        _collect_participation=trivial,
+        _collect_migrations=trivial,
+        _collect_runtime_providers=trivial,
+        # Real setup-readiness collector so we get the informational tag.
+    ):
+        report = asyncio.run(pc.collect_report(bot=object(), guild=None))
+    assert len(report.sections) == 10
+    # Last section must be Setup readiness, marked informational.
+    assert report.sections[-1].name == "Setup readiness"
+    assert report.sections[-1].informational is True


### PR DESCRIPTION
## Summary

Adds `!platform consistency` — one operator-facing readiness view that
answers "is the platform safe to continue into the larger
command/panel/settings/slash/setup phase?" Backed by a new pure-read
collection service.

- **No migration.** Ladder stays at 028.
- **No behavior changes.** `bindings.primary`, `participation.enabled`,
  `feature_flag.primary` defaults preserved.
- **No flag flips.** No mutations from any consistency code.
- Decision-tree branch: PR-9 merged → implement PR-10.

## Sections collected

1. Identity contract
2. Feature flags
3. Rollout / audit
4. Bindings (configured-broken vs unconfigured distinction)
5. Binding backfill
6. Config arbitration
7. Participation
8. Migrations (filesystem authoritative; DB best-effort WARNING-only)
9. Runtime providers (meta-health only)
10. Setup readiness (informational; tied to `SETUP_READINESS_BLOCKERS`
    constant via stale-doc test)

## Severity contract

- **FATAL** — core unreadable / required surface broken
- **WARNING** — drift, failed optional provider, configured-but-broken
  resource
- **SKIPPED** — not applicable / no context / no data
- `SKIPPED` never demotes `CLEAN`; informational WARNINGs never
  promote overall status

## Files changed

| File | Purpose |
|---|---|
| `disbot/services/platform_consistency.py` (new) | Collection service; 10 collectors; function-local imports for cycle safety |
| `disbot/cogs/diagnostic/_platform_embeds.py` | `build_consistency_embed`; bounded-size guard; informational labelling |
| `disbot/cogs/diagnostic_cog.py` | Thin `!platform consistency` subcommand; cog now 796 LOC (under 800 ceiling) |
| `tests/unit/runtime/test_import_cycle_regression.py` | Added new service to `_CYCLE_SENSITIVE_FILES` |
| `docs/phase-2-completion-readiness.md` | PR #86/#87 moved to "Done on main"; ladder bumped to 028; PR-10 listed as next work; Setup-readiness blocker list mirrors constant |
| `tests/unit/services/test_platform_consistency.py` (new) | 42 collector + orchestrator + status-promotion tests |
| `tests/unit/cogs/test_diagnostic_consistency_embed.py` (new) | 12 embed tests (color, bounded size, truncation, informational labelling, footer separation) |
| `tests/unit/runtime/test_consistency_import_cycle.py` (new) | AST scan + fresh-interpreter import |
| `tests/unit/docs/test_phase_2_readiness_doc.py` (new) | 5 resilient marker-and-name assertions tying doc to `SETUP_READINESS_BLOCKERS` |

## Test plan

- [x] `pytest tests/unit/services/test_platform_consistency.py` — 42 passed
- [x] `pytest tests/unit/cogs/test_diagnostic_consistency_embed.py` — 12 passed
- [x] `pytest tests/unit/runtime/test_consistency_import_cycle.py` — 2 passed
- [x] `pytest tests/unit/docs/test_phase_2_readiness_doc.py` — 5 passed
- [x] `pytest tests/unit/services/test_diagnostics_service.py` — 15 passed (regression)
- [x] `pytest tests/unit/runtime/test_platform_commands.py` — 4 passed (regression)
- [x] `pytest tests/unit/runtime/test_platform_diagnostics_commands.py` — 14 passed (regression)
- [x] `pytest tests/unit/runtime/test_import_cycle_regression.py` — 3 passed (regression)
- [x] `pytest tests/unit/invariants/` — 106 passed (incl. cog-size guardrail)
- [x] `pytest tests/unit` — **1477 passed, 0 failed**
- [x] `ruff check` clean on new + modified files

## Manual smoke

- [ ] Bot boots; `!platform consistency` returns a guild-aware embed.
- [ ] Healthy guild → overall CLEAN; Setup readiness shows
      informational WARNING with explicit roadmap marker.
- [ ] Pre-seed a `missing` binding row → Bindings WARNING;
      `unresolved`-only state stays CLEAN.
- [ ] Pre-seed a `failed` checkpoint row → Binding backfill FATAL.
- [ ] Unregister `bindings` provider → Runtime providers WARNING
      listing `bindings`; other sections unaffected.
- [ ] DM invocation (no `ctx.guild`) → guild-scoped sections SKIPPED;
      overall not FATAL.
- [ ] `!platform status`, `!platform flags`, `!platform migrations`,
      `!platform bindings` still work unchanged.

## Risks and rollback

- Read-only, additive. Single `git revert` removes the cog command,
  service, embed builder, doc edit, and tests.
- No DB writes; no persisted state changes.
- Identity validator timeout is intentionally not added in v1 (per
  scope clarification); a follow-up PR can add `wait_for` once
  operational data justifies it.

## Recommended next PR

**PR-11 — Server Logging Foundation**: `services/server_logging.py`,
subscribe to `moderation.action_taken`, optional auto-create log
channel via shared provisioning helper, default OFF.

## Intentionally deferred

`/myprofile`, setup wizard, PanelRegistry, SettingsRegistry,
SettingsMutationPipeline, Command Surface Ledger, role/cleanup
extraction, slash entrypoints, notification router, server logging
(PR-11), any flag flips, legacy `guild_settings` row removal,
resource provisioning runtime, dynamic detection of Setup-readiness
blockers (v1 static), unresolved-binding schema distinction.

https://claude.ai/code/session_01TgXKzat6grWjupChjL4g5A

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgXKzat6grWjupChjL4g5A)_