### PR TITLE
Phase 2 PR-11: Server Logging Foundation (default OFF)

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -559,6 +559,14 @@ async def main() -> None:
 
     await runtime.setup()
     message_pipeline.setup(bot)
+    # Phase 2 PR-11 — Server logging foundation.  Subscribes to
+    # ``moderation.action_taken`` and posts structured embeds to the
+    # configured per-guild log channel.  Default policy is OFF; the
+    # service is inert until an operator opts in via
+    # ``!logging enable`` / ``!logging set mod #channel``.
+    from services import server_logging
+
+    server_logging.setup(bot)
     if reporter:
         await reporter.start()
     try:

--- a/disbot/cogs/admin_cog.py
+++ b/disbot/cogs/admin_cog.py
@@ -206,6 +206,100 @@ class AdminCog(commands.Cog):
         await ctx.send(f"✅ Log level set to `{level.upper()}`.")
 
     # ------------------------------------------------------------------
+    # Server logging admin (Phase 2 PR-11)
+    # ------------------------------------------------------------------
+    @commands.group(name="logging", invoke_without_command=True)
+    @commands.has_permissions(administrator=True)
+    async def logging_grp(self, ctx):
+        """Server-logging admin commands.
+
+        Usage: `!logging status` · `!logging test`
+        """
+        await ctx.send(
+            "Usage: `!logging <status|test>` — see `docs/server-logging.md`.",
+            delete_after=20,
+        )
+
+    @logging_grp.command(name="status")  # type: ignore[arg-type]
+    @commands.has_permissions(administrator=True)
+    async def logging_status(self, ctx):
+        """Show this guild's server-logging configuration + counters."""
+        from services import server_logging
+
+        enabled = await server_logging.is_enabled(ctx.guild.id) if ctx.guild else False
+        auto_create = (
+            await server_logging.auto_create_enabled(ctx.guild.id)
+            if ctx.guild
+            else False
+        )
+        mod_channel = cleanup_channel = None
+        if ctx.guild:
+            mod_channel = await server_logging.resolve_log_channel(ctx.guild, "mod")
+            cleanup_channel = await server_logging.resolve_log_channel(
+                ctx.guild,
+                "cleanup",
+            )
+        counters = server_logging.counters_snapshot()["counters"]
+
+        embed = discord.Embed(
+            title="📝 Server logging — status",
+            color=SUCCESS_COLOR if enabled else INFO_COLOR,
+        )
+        embed.add_field(
+            name="Enabled",
+            value="✅ on" if enabled else "⚪ off",
+            inline=True,
+        )
+        embed.add_field(
+            name="Auto-create channels",
+            value="✅ on" if auto_create else "⚪ off",
+            inline=True,
+        )
+        embed.add_field(
+            name="Mod channel",
+            value=mod_channel.mention if mod_channel else "*(unset)*",
+            inline=False,
+        )
+        cleanup_value = (
+            cleanup_channel.mention if cleanup_channel else "*(falls back to mod)*"
+        )
+        embed.add_field(
+            name="Cleanup channel",
+            value=cleanup_value,
+            inline=False,
+        )
+        embed.add_field(
+            name="Counters (process-local)",
+            value="\n".join(f"`{k}` = {v}" for k, v in sorted(counters.items())),
+            inline=False,
+        )
+        await ctx.send(embed=embed)
+
+    @logging_grp.command(name="test")  # type: ignore[arg-type]
+    @commands.has_permissions(administrator=True)
+    async def logging_test(self, ctx):
+        """Send a synthetic warn embed to the configured log channel."""
+        from services import server_logging
+
+        if ctx.guild is None:
+            await ctx.send("This command requires a guild context.")
+            return
+        sent = await server_logging.log_event(
+            ctx.guild,
+            action="warn",
+            target_id=ctx.author.id,
+            actor_id=ctx.author.id,
+            reason="server_logging test event from !logging test",
+        )
+        if sent:
+            await ctx.send("✅ Test embed delivered to the configured log channel.")
+        else:
+            await ctx.send(
+                "ℹ️ No embed sent — see `!logging status` for the cause "
+                "(disabled / missing channel / send error counted).",
+            )
+
+    # ------------------------------------------------------------------
     # Startup message
     # ------------------------------------------------------------------
     @commands.Cog.listener()

--- a/disbot/services/server_logging.py
+++ b/disbot/services/server_logging.py
@@ -1,0 +1,446 @@
+"""Server-logging foundation — Phase 2 PR-11.
+
+Per-guild service that subscribes to the catalogued event
+``moderation.action_taken`` and posts a structured embed to a
+configured log channel.  Two channel slots:
+
+* ``logging.mod_channel``     — non-``auto_delete:*`` actions.
+* ``logging.cleanup_channel`` — ``auto_delete:*`` rule-based actions.
+  Falls back to the mod channel if unset.
+
+If ``logging.auto_create_channels`` is enabled and the configured
+channel id is missing or invalid, the service calls
+``core.runtime.guild_resources.ensure_channel`` to create a default
+channel (``bot-mod-log`` / ``bot-cleanup-log``).  Auto-creation is
+**OFF** by default so a fresh install does not surprise an admin with
+spontaneous channels.
+
+Fail-safe rules (every send path catches its own exceptions and
+increments a counter):
+
+* the event bus already swallows handler exceptions, so a logging
+  failure cannot crash the source moderation/cleanup action;
+* missing channel, missing permissions, Discord HTTP errors, and
+  auto-create failures all count their own bucket without
+  re-raising.
+
+Diagnostics counters are exposed via ``services.diagnostics_service``
+under the name ``"server_logging"``.  Counter shape is stable so
+``!platform consistency`` (PR-10) can read it without parsing
+internals.
+
+Default policy: **logging is OFF**.  Operators opt in per-guild via
+the keys declared in ``utils.settings_keys.logging``.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+from typing import Any
+
+import discord
+
+from core.events import bus
+from utils import db
+from utils.settings_keys import logging as _log_keys
+
+logger = logging.getLogger("bot.server_logging")
+
+EVT_MOD_ACTION = "moderation.action_taken"
+
+# ---------------------------------------------------------------------------
+# Counters (module-level; reset only via _reset_for_tests)
+# ---------------------------------------------------------------------------
+
+_COUNTERS: dict[str, int] = {
+    "sent_total": 0,
+    "skipped_disabled": 0,
+    "skipped_no_guild": 0,
+    "missing_channel": 0,
+    "created_channel": 0,
+    "permission_error": 0,
+    "send_error": 0,
+    "auto_create_error": 0,
+    "subscriber_errors": 0,
+}
+
+
+def _bump(name: str) -> None:
+    _COUNTERS[name] = _COUNTERS.get(name, 0) + 1
+
+
+def counters_snapshot() -> dict[str, Any]:
+    """Stable counter snapshot for diagnostics consumers."""
+    return {
+        "counters": dict(_COUNTERS),
+        "subscribed_events": [EVT_MOD_ACTION],
+    }
+
+
+def _reset_for_tests() -> None:
+    global _BOT, _SUBSCRIBED
+    for k in list(_COUNTERS):
+        _COUNTERS[k] = 0
+    _BOT = None
+    # Note: bus subscription is intentionally NOT cleared — tests that
+    # need to exercise the subscriber call it directly and assert on
+    # counters; the bus binding is registered once per process.
+
+
+# ---------------------------------------------------------------------------
+# Config accessors
+# ---------------------------------------------------------------------------
+
+_TRUE_LITERALS = frozenset({"1", "true", "yes", "on", "enabled"})
+
+
+def _truthy(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in _TRUE_LITERALS
+
+
+async def is_enabled(guild_id: int) -> bool:
+    """Return True if server logging is enabled for *guild_id*."""
+    raw = await db.get_setting(guild_id, _log_keys.LOGGING_ENABLED, "")
+    return _truthy(raw)
+
+
+async def auto_create_enabled(guild_id: int) -> bool:
+    """Return True if auto-creation of missing log channels is enabled."""
+    raw = await db.get_setting(guild_id, _log_keys.LOGGING_AUTO_CREATE_CHANNELS, "")
+    return _truthy(raw)
+
+
+def _channel_kind_for_action(action: str) -> str:
+    """Route the action to the mod or cleanup channel slot."""
+    if action.startswith("auto_delete"):
+        return "cleanup"
+    return "mod"
+
+
+# ---------------------------------------------------------------------------
+# Channel resolution / provisioning
+# ---------------------------------------------------------------------------
+
+
+async def resolve_log_channel(
+    guild: discord.Guild,
+    kind: str,
+) -> discord.TextChannel | None:
+    """Resolve the configured log channel for *kind* (``"mod"`` / ``"cleanup"``).
+
+    Returns ``None`` if the setting is unset or points at a channel
+    not currently in the guild cache.  Cleanup falls back to the mod
+    channel id when its own slot is unset.
+    """
+    # core.runtime imports stay function-local to avoid re-entering
+    # partially-loaded core.runtime during startup.
+    from core.runtime.guild_resources import resolve_settings_channel
+
+    keys: tuple[str, ...]
+    if kind == "cleanup":
+        keys = (_log_keys.LOGGING_CLEANUP_CHANNEL, _log_keys.LOGGING_MOD_CHANNEL)
+    else:
+        keys = (_log_keys.LOGGING_MOD_CHANNEL,)
+    for key in keys:
+        channel = await resolve_settings_channel(guild, key)
+        if isinstance(channel, discord.TextChannel):
+            return channel
+    return None
+
+
+async def ensure_log_channel(
+    guild: discord.Guild,
+    kind: str,
+) -> discord.TextChannel | None:
+    """Resolve or create the log channel for *kind*.
+
+    Returns the existing/created text channel, or ``None`` if creation
+    fails (caller may not have ``manage_channels`` permission, or
+    Discord rejected the request).  Counters increment to surface the
+    cause.
+    """
+    from core.runtime.guild_resources import ensure_channel
+
+    existing = await resolve_log_channel(guild, kind)
+    if existing is not None:
+        return existing
+    fallback_name = (
+        _log_keys.DEFAULT_CLEANUP_CHANNEL_NAME
+        if kind == "cleanup"
+        else _log_keys.DEFAULT_MOD_CHANNEL_NAME
+    )
+    try:
+        created = await ensure_channel(guild, fallback_name, kind="text")
+    except discord.Forbidden:
+        _bump("permission_error")
+        logger.warning(
+            "server_logging: missing manage_channels permission to create "
+            "%r log channel %r in guild %d",
+            kind,
+            fallback_name,
+            guild.id,
+        )
+        return None
+    except discord.HTTPException as exc:
+        _bump("auto_create_error")
+        logger.warning(
+            "server_logging: HTTP error creating %r log channel in guild %d: %s",
+            kind,
+            guild.id,
+            exc,
+        )
+        return None
+    except Exception as exc:  # noqa: BLE001 — fail-safe wrapper
+        _bump("auto_create_error")
+        logger.warning(
+            "server_logging: unexpected error creating %r log channel in guild %d: %s",
+            kind,
+            guild.id,
+            exc,
+            exc_info=True,
+        )
+        return None
+    if isinstance(created, discord.TextChannel):
+        _bump("created_channel")
+        return created
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Embed builder
+# ---------------------------------------------------------------------------
+
+# Distinct colour per action so dashboards (and human eyes) can
+# triangulate at a glance.  Unknown actions fall back to dark_grey.
+_ACTION_COLOR: dict[str, discord.Color] = {
+    "warn": discord.Color.gold(),
+    "timeout": discord.Color.orange(),
+    "kick": discord.Color.dark_orange(),
+    "ban": discord.Color.red(),
+    "unban": discord.Color.green(),
+    "clear_warnings": discord.Color.blurple(),
+    "auto_delete": discord.Color.dark_grey(),
+}
+
+_ACTION_ICON: dict[str, str] = {
+    "warn": "⚠️",
+    "timeout": "⏳",
+    "kick": "👢",
+    "ban": "🔨",
+    "unban": "🕊️",
+    "clear_warnings": "🧹",
+    "auto_delete": "🗑️",
+}
+
+
+def _root_action(action: str) -> str:
+    """``"auto_delete:cleanup.prohibited_words" → "auto_delete"`` etc."""
+    return action.split(":", 1)[0]
+
+
+def format_log_embed(
+    *,
+    action: str,
+    guild_id: int,
+    target_id: int,
+    actor_id: int | None,
+    reason: str,
+    extras: dict[str, Any] | None = None,
+) -> discord.Embed:
+    """Render a moderation/cleanup payload as a Discord embed.
+
+    Unknown actions render with the generic dark-grey style + a
+    ``• action: <name>`` field so subscribers never blank-render a new
+    moderation action type the service hasn't seen.
+    """
+    root = _root_action(action)
+    color = _ACTION_COLOR.get(root, discord.Color.dark_grey())
+    icon = _ACTION_ICON.get(root, "•")
+    title = f"{icon} {action}"
+    embed = discord.Embed(
+        title=title,
+        color=color,
+        timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
+    )
+    embed.add_field(name="Target", value=f"<@{target_id}> (`{target_id}`)", inline=True)
+    actor_display = f"<@{actor_id}>" if actor_id else "system"
+    embed.add_field(name="Actor", value=actor_display, inline=True)
+    embed.add_field(name="Guild", value=str(guild_id), inline=True)
+    if reason:
+        embed.add_field(name="Reason", value=reason[:1000], inline=False)
+    if extras:
+        for k, v in extras.items():
+            embed.add_field(name=k, value=str(v)[:500], inline=False)
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# Send + handler
+# ---------------------------------------------------------------------------
+
+
+async def log_event(
+    guild: discord.Guild,
+    *,
+    action: str,
+    target_id: int,
+    actor_id: int | None,
+    reason: str,
+    extras: dict[str, Any] | None = None,
+) -> bool:
+    """Send a structured log embed for *action* to the routed channel.
+
+    Returns True if the embed was sent; False on any other outcome.
+    Every failure path is fail-safe: counters bump, the caller never
+    sees the exception, and the next event proceeds normally.
+    """
+    if not await is_enabled(guild.id):
+        _bump("skipped_disabled")
+        return False
+
+    kind = _channel_kind_for_action(action)
+    channel = await resolve_log_channel(guild, kind)
+    if channel is None and await auto_create_enabled(guild.id):
+        channel = await ensure_log_channel(guild, kind)
+    if channel is None:
+        _bump("missing_channel")
+        return False
+
+    embed = format_log_embed(
+        action=action,
+        guild_id=guild.id,
+        target_id=target_id,
+        actor_id=actor_id,
+        reason=reason,
+        extras=extras,
+    )
+    try:
+        await channel.send(embed=embed)
+    except discord.Forbidden:
+        _bump("permission_error")
+        logger.warning(
+            "server_logging: missing send permission in #%s (guild %d)",
+            channel.name,
+            guild.id,
+        )
+        return False
+    except discord.HTTPException as exc:
+        _bump("send_error")
+        logger.warning(
+            "server_logging: HTTP error sending to #%s (guild %d): %s",
+            channel.name,
+            guild.id,
+            exc,
+        )
+        return False
+    except Exception as exc:  # noqa: BLE001 — fail-safe wrapper
+        _bump("send_error")
+        logger.warning(
+            "server_logging: unexpected error sending to #%s (guild %d): %s",
+            channel.name,
+            guild.id,
+            exc,
+            exc_info=True,
+        )
+        return False
+    _bump("sent_total")
+    return True
+
+
+async def _on_moderation_action(
+    *,
+    guild_id: int,
+    target_id: int,
+    actor_id: int | None,
+    action: str,
+    reason: str,
+    **extras: Any,
+) -> None:
+    """Bus subscriber for ``moderation.action_taken``.
+
+    Resolves the bot's view of the guild from the bot reference
+    captured at ``setup(bot)`` time, then delegates to
+    :func:`log_event`.  Any unexpected exception is caught + counted;
+    the event bus itself also swallows handler exceptions, so this is
+    a belt-and-braces safety net keeping ``subscriber_errors`` honest
+    independently of the bus's own error log.
+    """
+    try:
+        bot = _BOT
+        if bot is None:
+            _bump("skipped_no_guild")
+            return
+        guild = bot.get_guild(guild_id)
+        if guild is None:
+            _bump("skipped_no_guild")
+            return
+        await log_event(
+            guild,
+            action=action,
+            target_id=target_id,
+            actor_id=actor_id,
+            reason=reason,
+            extras=extras or None,
+        )
+    except Exception as exc:  # noqa: BLE001 — fail-safe subscriber
+        _bump("subscriber_errors")
+        logger.exception(
+            "server_logging: subscriber raised %s — counted and swallowed.",
+            type(exc).__name__,
+            exc_info=exc,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Setup / diagnostics registration
+# ---------------------------------------------------------------------------
+
+# Captured at setup(bot); used by the bus subscriber to resolve guilds
+# from guild_id payloads.  Module-level so subscribers don't have to
+# rely on a global registry.  Tests can call _reset_for_tests() or
+# pass a fake bot via setup() directly.
+_BOT: object | None = None
+_SUBSCRIBED = False
+
+
+def setup(bot: object | None = None) -> None:
+    """Register the bus subscriber + capture the bot reference.
+
+    Idempotent.  Called once from ``bot1.py`` after ``runtime.setup()``
+    so the captured bot reference matches the live event loop.
+    """
+    global _SUBSCRIBED, _BOT
+    _BOT = bot
+    if _SUBSCRIBED:
+        return
+    bus.on(EVT_MOD_ACTION, _on_moderation_action)
+    _SUBSCRIBED = True
+    logger.info(
+        "server_logging: subscribed to %r (default per-guild policy: OFF)",
+        EVT_MOD_ACTION,
+    )
+
+
+def _register_diagnostics() -> None:
+    from services import diagnostics_service
+
+    diagnostics_service.register("server_logging", counters_snapshot)
+
+
+_register_diagnostics()
+
+
+__all__ = [
+    "EVT_MOD_ACTION",
+    "auto_create_enabled",
+    "counters_snapshot",
+    "ensure_log_channel",
+    "format_log_embed",
+    "is_enabled",
+    "log_event",
+    "resolve_log_channel",
+    "setup",
+]

--- a/disbot/services/server_logging.py
+++ b/disbot/services/server_logging.py
@@ -401,8 +401,11 @@ async def _on_moderation_action(
 # Captured at setup(bot); used by the bus subscriber to resolve guilds
 # from guild_id payloads.  Module-level so subscribers don't have to
 # rely on a global registry.  Tests can call _reset_for_tests() or
-# pass a fake bot via setup() directly.
-_BOT: object | None = None
+# pass a fake bot via setup() directly.  Typed as ``Any`` (not
+# ``commands.Bot``) to avoid importing discord.ext.commands at module
+# load and to let tests pass MagicMock without satisfying the full
+# Bot interface.
+_BOT: Any = None
 _SUBSCRIBED = False
 
 

--- a/disbot/utils/settings_keys/__init__.py
+++ b/disbot/utils/settings_keys/__init__.py
@@ -16,6 +16,14 @@ this ``__init__``.
 from utils.settings_keys.economy import ECONOMY_LOG_CHANNEL
 from utils.settings_keys.games import ACTIVE_TOURNAMENT
 from utils.settings_keys.governance import GOVERNANCE_VERSION, TRUSTED_TIER_ROLE_ID
+from utils.settings_keys.logging import (
+    DEFAULT_CLEANUP_CHANNEL_NAME,
+    DEFAULT_MOD_CHANNEL_NAME,
+    LOGGING_AUTO_CREATE_CHANNELS,
+    LOGGING_CLEANUP_CHANNEL,
+    LOGGING_ENABLED,
+    LOGGING_MOD_CHANNEL,
+)
 from utils.settings_keys.moderation import WARN_THRESHOLD, WARN_TIMEOUT_MINS
 from utils.settings_keys.role import SKIP_ROLES
 from utils.settings_keys.xp import (
@@ -27,8 +35,14 @@ from utils.settings_keys.xp import (
 
 __all__ = [
     "ACTIVE_TOURNAMENT",
+    "DEFAULT_CLEANUP_CHANNEL_NAME",
+    "DEFAULT_MOD_CHANNEL_NAME",
     "ECONOMY_LOG_CHANNEL",
     "GOVERNANCE_VERSION",
+    "LOGGING_AUTO_CREATE_CHANNELS",
+    "LOGGING_CLEANUP_CHANNEL",
+    "LOGGING_ENABLED",
+    "LOGGING_MOD_CHANNEL",
     "SKIP_ROLES",
     "TRUSTED_TIER_ROLE_ID",
     "WARN_THRESHOLD",

--- a/disbot/utils/settings_keys/logging.py
+++ b/disbot/utils/settings_keys/logging.py
@@ -1,0 +1,27 @@
+"""Settings keys owned by the server-logging service (services.server_logging).
+
+These four keys live in the legacy ``guild_settings`` table.  All
+default to OFF / empty so the service is inert on a fresh install
+until an operator opts in.
+"""
+
+# Per-guild master switch.  String 'true' / 'false' / '1' / '0' — see
+# :func:`services.server_logging.is_enabled` for the parse contract.
+LOGGING_ENABLED = "logging_enabled"
+
+# Channel id (str-of-int) for moderation action embeds.
+LOGGING_MOD_CHANNEL = "logging_mod_channel"
+
+# Channel id (str-of-int) for cleanup auto-delete embeds.  Falls back
+# to the mod channel if unset.
+LOGGING_CLEANUP_CHANNEL = "logging_cleanup_channel"
+
+# When true and a configured channel id is missing/invalid, the
+# service calls ``guild_resources.ensure_channel`` to create a
+# fall-back channel named ``DEFAULT_LOG_CHANNEL_NAME``.
+LOGGING_AUTO_CREATE_CHANNELS = "logging_auto_create_channels"
+
+# Default channel name used by ``ensure_log_channel`` when
+# auto-creation is enabled.
+DEFAULT_MOD_CHANNEL_NAME = "bot-mod-log"
+DEFAULT_CLEANUP_CHANNEL_NAME = "bot-cleanup-log"

--- a/docs/server-logging.md
+++ b/docs/server-logging.md
@@ -1,0 +1,125 @@
+# Server logging foundation
+
+**Status:** shipped in Phase 2 PR-11.  Default: **OFF** per-guild.
+
+The server-logging service (`disbot/services/server_logging.py`)
+subscribes to the catalogued event `moderation.action_taken` emitted
+by `services/moderation_service.py` and posts a structured embed to a
+configured per-guild log channel.
+
+This is a small, fail-safe substrate for admin-facing audit visibility.
+It is **not** a full analytics or log-storage platform; the goal is to
+make every moderation/cleanup action visible in a channel without
+relying on Discord's built-in audit log.
+
+## Default behavior
+
+* `logging.enabled` — default OFF.  The service ignores every event.
+* `logging.auto_create_channels` — default OFF.  Missing/invalid log
+  channels do not cause spontaneous channel creation.
+* `logging.mod_channel` — unset.  Mod actions are not logged unless
+  set.
+* `logging.cleanup_channel` — unset.  Falls back to
+  `logging.mod_channel` when unset.
+
+These four keys live in the legacy `guild_settings` table; key
+constants live in `disbot/utils/settings_keys/logging.py`.
+
+## Action routing
+
+| Action | Channel slot |
+|---|---|
+| `warn` / `timeout` / `kick` / `ban` / `unban` / `clear_warnings` | `logging.mod_channel` |
+| `auto_delete:*` (cleanup auto-deletes) | `logging.cleanup_channel` → falls back to `logging.mod_channel` |
+
+## Embed style
+
+| Action | Color | Icon |
+|---|---|---|
+| `warn` | gold | ⚠️ |
+| `timeout` | orange | ⏳ |
+| `kick` | dark_orange | 👢 |
+| `ban` | red | 🔨 |
+| `unban` | green | 🕊️ |
+| `clear_warnings` | blurple | 🧹 |
+| `auto_delete:*` | dark_grey | 🗑️ |
+| anything else | dark_grey | • |
+
+Every embed includes Target (mention + id), Actor (mention or
+`"system"` for auto-delete), Guild id, Reason (truncated to 1000
+chars), and any extras from the bus payload (e.g. `until` for
+timeouts).
+
+## Fail-safe guarantees
+
+The event bus already swallows handler exceptions
+(`disbot/core/events.py` — 5-second timeout, ERROR log, no re-raise),
+so a logging failure cannot crash the source moderation/cleanup
+action.  Inside the service, each potential failure path is caught
+individually and counted:
+
+| Counter | When it increments |
+|---|---|
+| `sent_total` | Embed delivered successfully. |
+| `skipped_disabled` | `logging.enabled` is OFF for the guild. |
+| `skipped_no_guild` | Bot not connected, or `guild_id` not in cache. |
+| `missing_channel` | Configured channel unresolvable + auto-create OFF. |
+| `created_channel` | `ensure_channel` created the fallback channel. |
+| `permission_error` | `discord.Forbidden` on send or create. |
+| `send_error` | `discord.HTTPException` (or unexpected) on send. |
+| `auto_create_error` | `discord.HTTPException` (or unexpected) on create. |
+| `subscriber_errors` | The bus subscriber itself raised. |
+
+Counters are exposed via `services.diagnostics_service` under the
+name `"server_logging"` and surface in `!platform consistency`
+(PR-10) under the "Runtime providers" section.
+
+## Channel provisioning
+
+When auto-create is enabled and the configured channel id is
+missing/invalid, the service calls
+`core.runtime.guild_resources.ensure_channel(guild, name, kind="text")`
+to create one of:
+
+* `bot-mod-log` for the mod slot.
+* `bot-cleanup-log` for the cleanup slot.
+
+The service does NOT depend on `ChannelCog` — channel provisioning
+goes through the shared `guild_resources.ensure_channel` primitive
+that lives at the runtime layer, so the service and the cog both
+call the same code path.  No Cog→Cog dependency.
+
+## Operator workflow
+
+1. Decide which channel(s) you want logs posted to.
+2. Set `logging.mod_channel` (and optionally `logging.cleanup_channel`)
+   via your settings tool of choice (`!set`, future settings wizard,
+   or a direct `guild_settings` row insert).
+3. Set `logging.enabled` to `true`.
+4. Optionally set `logging.auto_create_channels` to `true` so the
+   service falls back to creating `bot-mod-log` / `bot-cleanup-log`
+   if your configured ids ever become invalid.
+5. Verify with `!logging status`.  Run `!logging test` to fire a
+   synthetic warn embed to the configured channel.
+
+## Admin commands
+
+| Command | Effect |
+|---|---|
+| `!logging status` | Shows enabled state, channel resolution, and counters. |
+| `!logging test`   | Sends a synthetic warn embed to the configured log channel. |
+
+Both require Administrator permission.
+
+## What's NOT in PR-11
+
+* No new migration; settings live in the legacy `guild_settings` table.
+* No SettingsRegistry / mutation pipeline integration.
+* No setup wizard.
+* No slash commands.
+* No per-event subscription toggles (`logging.enabled` is master switch).
+* No edit/delete/member-join logging.
+* No web dashboard / external log storage / Redis.
+
+These belong to the broader UX phase that comes after the Command
+Surface Ledger and SettingsRegistry land.

--- a/tests/unit/runtime/test_server_logging_import_cycle.py
+++ b/tests/unit/runtime/test_server_logging_import_cycle.py
@@ -1,0 +1,87 @@
+"""Import-cycle regression for services.server_logging — PR-11.
+
+The service is subscribed to ``moderation.action_taken`` at startup
+from ``bot1.py``.  It must keep ``core.runtime`` / ``utils.db`` /
+``utils.subsystem_registry`` imports inside function bodies so loading
+the service module never re-enters a partially-loaded ``core.runtime``
+during startup.
+
+This mirrors the platform-consistency / utils.helpers regression
+patterns.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SERVICE_PATH = _REPO_ROOT / "disbot" / "services" / "server_logging.py"
+
+# core.runtime / utils.subsystem_registry are the cycle-sensitive
+# paths.  utils.db is safe at module scope (it imports only
+# asyncpg / utils.db.pool which do not touch core.runtime).
+_FORBIDDEN_TOP_LEVEL_PREFIXES = (
+    "core.runtime",
+    "utils.subsystem_registry",
+)
+
+
+def _module_level_imports(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    offenders: list[str] = []
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for prefix in _FORBIDDEN_TOP_LEVEL_PREFIXES:
+                if module == prefix or module.startswith(prefix + "."):
+                    offenders.append(
+                        f"from {module} import "
+                        f"{', '.join(a.name for a in node.names)}",
+                    )
+                    break
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                for prefix in _FORBIDDEN_TOP_LEVEL_PREFIXES:
+                    if alias.name == prefix or alias.name.startswith(prefix + "."):
+                        offenders.append(f"import {alias.name}")
+                        break
+    return offenders
+
+
+def test_server_logging_has_no_top_level_cycle_imports():
+    offenders = _module_level_imports(_SERVICE_PATH)
+    assert not offenders, (
+        "services.server_logging has cycle-sensitive top-level imports:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_server_logging_imports_in_fresh_interpreter():
+    """`python -c "import services.server_logging"` in a fresh
+    interpreter, so cached modules in the pytest process cannot mask a
+    cycle introduced by the new module."""
+    script = textwrap.dedent(
+        """
+        import sys
+        sys.path.insert(0, "disbot")
+        import services.server_logging  # noqa: F401
+        print("ok")
+        """,
+    )
+    result = subprocess.run(  # noqa: S603 — script literal under our control
+        [sys.executable, "-c", script],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"services.server_logging import failed in subprocess.\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "ok" in result.stdout

--- a/tests/unit/services/test_server_logging.py
+++ b/tests/unit/services/test_server_logging.py
@@ -1,0 +1,757 @@
+"""Unit tests for services.server_logging — Phase 2 PR-11."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from services import server_logging
+from services.server_logging import (
+    _channel_kind_for_action,
+    _root_action,
+    auto_create_enabled,
+    counters_snapshot,
+    ensure_log_channel,
+    format_log_embed,
+    is_enabled,
+    log_event,
+    resolve_log_channel,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_counters():
+    server_logging._reset_for_tests()
+    yield
+    server_logging._reset_for_tests()
+
+
+def _make_guild(guild_id: int = 99999) -> MagicMock:
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = guild_id
+    guild.name = f"guild-{guild_id}"
+    guild.me = MagicMock()
+    return guild
+
+
+def _make_text_channel(channel_id: int = 12345, name: str = "logs") -> MagicMock:
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.id = channel_id
+    channel.name = name
+    channel.mention = f"<#{channel_id}>"
+    channel.send = AsyncMock()
+    return channel
+
+
+# ---------------------------------------------------------------------------
+# Config accessors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_is_enabled_reads_setting():
+    with patch(
+        "services.server_logging.db.get_setting",
+        new_callable=AsyncMock,
+        return_value="true",
+    ) as get_setting:
+        assert await is_enabled(123) is True
+    get_setting.assert_awaited_once()
+    assert get_setting.await_args.args[:2] == (123, "logging_enabled")
+
+
+@pytest.mark.asyncio
+async def test_is_enabled_defaults_to_false_when_unset():
+    with patch(
+        "services.server_logging.db.get_setting",
+        new_callable=AsyncMock,
+        return_value="",
+    ):
+        assert await is_enabled(123) is False
+
+
+@pytest.mark.asyncio
+async def test_is_enabled_accepts_truthy_literals():
+    for val in ("true", "1", "yes", "on", "enabled", "TRUE", "Yes"):
+        with patch(
+            "services.server_logging.db.get_setting",
+            new_callable=AsyncMock,
+            return_value=val,
+        ):
+            assert await is_enabled(123) is True, f"Expected truthy: {val!r}"
+
+
+@pytest.mark.asyncio
+async def test_auto_create_enabled_reads_setting():
+    with patch(
+        "services.server_logging.db.get_setting",
+        new_callable=AsyncMock,
+        return_value="true",
+    ) as get_setting:
+        assert await auto_create_enabled(123) is True
+    assert get_setting.await_args.args[:2] == (123, "logging_auto_create_channels")
+
+
+# ---------------------------------------------------------------------------
+# Action → channel routing
+# ---------------------------------------------------------------------------
+
+
+def test_channel_kind_for_action_routes_auto_delete_to_cleanup():
+    assert _channel_kind_for_action("auto_delete:cleanup.foo") == "cleanup"
+
+
+def test_channel_kind_for_action_routes_mod_actions_to_mod():
+    for action in ("warn", "timeout", "kick", "ban", "unban", "clear_warnings"):
+        assert _channel_kind_for_action(action) == "mod"
+
+
+def test_root_action_strips_composite_suffix():
+    assert _root_action("auto_delete:cleanup.prohibited_words") == "auto_delete"
+    assert _root_action("warn") == "warn"
+
+
+# ---------------------------------------------------------------------------
+# Embed builder
+# ---------------------------------------------------------------------------
+
+
+def test_format_log_embed_warn_uses_gold():
+    embed = format_log_embed(
+        action="warn",
+        guild_id=99,
+        target_id=42,
+        actor_id=7,
+        reason="spam",
+    )
+    assert embed.color == discord.Color.gold()
+    assert "warn" in (embed.title or "")
+    field_names = [f.name for f in embed.fields]
+    assert "Target" in field_names
+    assert "Actor" in field_names
+    assert "Reason" in field_names
+
+
+def test_format_log_embed_auto_delete_uses_dark_grey():
+    embed = format_log_embed(
+        action="auto_delete:cleanup.prohibited_words",
+        guild_id=99,
+        target_id=42,
+        actor_id=None,
+        reason="bad word",
+    )
+    assert embed.color == discord.Color.dark_grey()
+    # Action title preserves the composite form so dashboards can
+    # tell which rule triggered.
+    assert "auto_delete:cleanup.prohibited_words" in (embed.title or "")
+
+
+def test_format_log_embed_unknown_action_uses_generic_style():
+    embed = format_log_embed(
+        action="future_unknown_action",
+        guild_id=99,
+        target_id=42,
+        actor_id=7,
+        reason="reason",
+    )
+    assert embed.color == discord.Color.dark_grey()
+
+
+def test_format_log_embed_system_actor_displayed_when_actor_none():
+    embed = format_log_embed(
+        action="auto_delete:cleanup.x",
+        guild_id=1,
+        target_id=2,
+        actor_id=None,
+        reason="r",
+    )
+    actor_field = next(f for f in embed.fields if f.name == "Actor")
+    assert actor_field.value == "system"
+
+
+def test_format_log_embed_extras_rendered_as_fields():
+    embed = format_log_embed(
+        action="timeout",
+        guild_id=1,
+        target_id=2,
+        actor_id=3,
+        reason="r",
+        extras={"until": "2026-12-31T00:00:00+00:00"},
+    )
+    field_names = [f.name for f in embed.fields]
+    assert "until" in field_names
+
+
+def test_format_log_embed_reason_truncated_at_1000_chars():
+    embed = format_log_embed(
+        action="warn",
+        guild_id=1,
+        target_id=2,
+        actor_id=3,
+        reason="x" * 5000,
+    )
+    reason_field = next(f for f in embed.fields if f.name == "Reason")
+    assert len(reason_field.value) <= 1000
+
+
+# ---------------------------------------------------------------------------
+# resolve_log_channel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_log_channel_mod_returns_text_channel():
+    guild = _make_guild()
+    channel = _make_text_channel(name="mod-log")
+    with patch(
+        "core.runtime.guild_resources.resolve_settings_channel",
+        new_callable=AsyncMock,
+        return_value=channel,
+    ):
+        result = await resolve_log_channel(guild, "mod")
+    assert result is channel
+
+
+@pytest.mark.asyncio
+async def test_resolve_log_channel_cleanup_falls_back_to_mod():
+    guild = _make_guild()
+    mod_channel = _make_text_channel(name="mod-log")
+    calls: list[str] = []
+
+    async def fake_resolve(_guild, key: str):
+        calls.append(key)
+        if key == "logging_cleanup_channel":
+            return None
+        if key == "logging_mod_channel":
+            return mod_channel
+        return None
+
+    with patch(
+        "core.runtime.guild_resources.resolve_settings_channel",
+        side_effect=fake_resolve,
+    ):
+        result = await resolve_log_channel(guild, "cleanup")
+    assert result is mod_channel
+    # Looked at cleanup first, then mod.
+    assert calls == ["logging_cleanup_channel", "logging_mod_channel"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_log_channel_returns_none_when_setting_unset():
+    guild = _make_guild()
+    with patch(
+        "core.runtime.guild_resources.resolve_settings_channel",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        assert await resolve_log_channel(guild, "mod") is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_log_channel_skips_non_text_channel():
+    guild = _make_guild()
+    voice = MagicMock(spec=discord.VoiceChannel)
+    with patch(
+        "core.runtime.guild_resources.resolve_settings_channel",
+        new_callable=AsyncMock,
+        return_value=voice,
+    ):
+        assert await resolve_log_channel(guild, "mod") is None
+
+
+# ---------------------------------------------------------------------------
+# ensure_log_channel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ensure_log_channel_returns_existing_when_resolved():
+    guild = _make_guild()
+    channel = _make_text_channel()
+    with patch(
+        "services.server_logging.resolve_log_channel",
+        new_callable=AsyncMock,
+        return_value=channel,
+    ), patch(
+        "core.runtime.guild_resources.ensure_channel",
+        new_callable=AsyncMock,
+    ) as ensure:
+        result = await ensure_log_channel(guild, "mod")
+    assert result is channel
+    ensure.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ensure_log_channel_creates_when_resolve_fails():
+    guild = _make_guild()
+    created = _make_text_channel(name="bot-mod-log")
+    with patch(
+        "services.server_logging.resolve_log_channel",
+        new_callable=AsyncMock,
+        return_value=None,
+    ), patch(
+        "core.runtime.guild_resources.ensure_channel",
+        new_callable=AsyncMock,
+        return_value=created,
+    ):
+        result = await ensure_log_channel(guild, "mod")
+    assert result is created
+    assert counters_snapshot()["counters"]["created_channel"] == 1
+
+
+@pytest.mark.asyncio
+async def test_ensure_log_channel_counts_permission_error_on_forbidden():
+    guild = _make_guild()
+    with patch(
+        "services.server_logging.resolve_log_channel",
+        new_callable=AsyncMock,
+        return_value=None,
+    ), patch(
+        "core.runtime.guild_resources.ensure_channel",
+        new_callable=AsyncMock,
+        side_effect=discord.Forbidden(MagicMock(status=403), "no perms"),
+    ):
+        result = await ensure_log_channel(guild, "mod")
+    assert result is None
+    assert counters_snapshot()["counters"]["permission_error"] == 1
+
+
+@pytest.mark.asyncio
+async def test_ensure_log_channel_counts_auto_create_error_on_http():
+    guild = _make_guild()
+    with patch(
+        "services.server_logging.resolve_log_channel",
+        new_callable=AsyncMock,
+        return_value=None,
+    ), patch(
+        "core.runtime.guild_resources.ensure_channel",
+        new_callable=AsyncMock,
+        side_effect=discord.HTTPException(MagicMock(status=500), "bad"),
+    ):
+        result = await ensure_log_channel(guild, "mod")
+    assert result is None
+    assert counters_snapshot()["counters"]["auto_create_error"] == 1
+
+
+# ---------------------------------------------------------------------------
+# log_event — the main orchestrator
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_log_event_skipped_when_disabled():
+    guild = _make_guild()
+    with patch(
+        "services.server_logging.is_enabled",
+        new_callable=AsyncMock,
+        return_value=False,
+    ):
+        sent = await log_event(
+            guild,
+            action="warn",
+            target_id=1,
+            actor_id=2,
+            reason="r",
+        )
+    assert sent is False
+    assert counters_snapshot()["counters"]["skipped_disabled"] == 1
+
+
+@pytest.mark.asyncio
+async def test_log_event_sends_embed_when_configured():
+    guild = _make_guild()
+    channel = _make_text_channel()
+    with patch(
+        "services.server_logging.is_enabled",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "services.server_logging.resolve_log_channel",
+        new_callable=AsyncMock,
+        return_value=channel,
+    ):
+        sent = await log_event(
+            guild,
+            action="warn",
+            target_id=1,
+            actor_id=2,
+            reason="r",
+        )
+    assert sent is True
+    channel.send.assert_awaited_once()
+    embed = channel.send.await_args.kwargs["embed"]
+    assert isinstance(embed, discord.Embed)
+    assert counters_snapshot()["counters"]["sent_total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_log_event_missing_channel_when_auto_create_off():
+    guild = _make_guild()
+    with patch(
+        "services.server_logging.is_enabled",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "services.server_logging.resolve_log_channel",
+        new_callable=AsyncMock,
+        return_value=None,
+    ), patch(
+        "services.server_logging.auto_create_enabled",
+        new_callable=AsyncMock,
+        return_value=False,
+    ), patch(
+        "services.server_logging.ensure_log_channel",
+        new_callable=AsyncMock,
+    ) as ensure_lc:
+        sent = await log_event(
+            guild,
+            action="warn",
+            target_id=1,
+            actor_id=2,
+            reason="r",
+        )
+    assert sent is False
+    ensure_lc.assert_not_awaited()
+    assert counters_snapshot()["counters"]["missing_channel"] == 1
+
+
+@pytest.mark.asyncio
+async def test_log_event_missing_channel_calls_ensure_when_auto_create_on():
+    guild = _make_guild()
+    created = _make_text_channel(name="bot-mod-log")
+    with patch(
+        "services.server_logging.is_enabled",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "services.server_logging.resolve_log_channel",
+        new_callable=AsyncMock,
+        return_value=None,
+    ), patch(
+        "services.server_logging.auto_create_enabled",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "services.server_logging.ensure_log_channel",
+        new_callable=AsyncMock,
+        return_value=created,
+    ) as ensure_lc:
+        sent = await log_event(
+            guild,
+            action="warn",
+            target_id=1,
+            actor_id=2,
+            reason="r",
+        )
+    assert sent is True
+    ensure_lc.assert_awaited_once()
+    created.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_log_event_swallows_permission_error_on_send():
+    guild = _make_guild()
+    channel = _make_text_channel()
+    channel.send = AsyncMock(
+        side_effect=discord.Forbidden(MagicMock(status=403), "no perms"),
+    )
+    with patch(
+        "services.server_logging.is_enabled",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "services.server_logging.resolve_log_channel",
+        new_callable=AsyncMock,
+        return_value=channel,
+    ):
+        sent = await log_event(
+            guild,
+            action="warn",
+            target_id=1,
+            actor_id=2,
+            reason="r",
+        )
+    assert sent is False
+    assert counters_snapshot()["counters"]["permission_error"] == 1
+
+
+@pytest.mark.asyncio
+async def test_log_event_swallows_http_error_on_send():
+    guild = _make_guild()
+    channel = _make_text_channel()
+    channel.send = AsyncMock(
+        side_effect=discord.HTTPException(MagicMock(status=500), "boom"),
+    )
+    with patch(
+        "services.server_logging.is_enabled",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "services.server_logging.resolve_log_channel",
+        new_callable=AsyncMock,
+        return_value=channel,
+    ):
+        sent = await log_event(
+            guild,
+            action="warn",
+            target_id=1,
+            actor_id=2,
+            reason="r",
+        )
+    assert sent is False
+    assert counters_snapshot()["counters"]["send_error"] == 1
+
+
+@pytest.mark.asyncio
+async def test_log_event_swallows_unexpected_exception_on_send():
+    guild = _make_guild()
+    channel = _make_text_channel()
+    channel.send = AsyncMock(side_effect=RuntimeError("anything"))
+    with patch(
+        "services.server_logging.is_enabled",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "services.server_logging.resolve_log_channel",
+        new_callable=AsyncMock,
+        return_value=channel,
+    ):
+        sent = await log_event(
+            guild,
+            action="warn",
+            target_id=1,
+            actor_id=2,
+            reason="r",
+        )
+    assert sent is False
+    assert counters_snapshot()["counters"]["send_error"] == 1
+
+
+@pytest.mark.asyncio
+async def test_log_event_renders_unknown_action_safely():
+    guild = _make_guild()
+    channel = _make_text_channel()
+    with patch(
+        "services.server_logging.is_enabled",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "services.server_logging.resolve_log_channel",
+        new_callable=AsyncMock,
+        return_value=channel,
+    ):
+        sent = await log_event(
+            guild,
+            action="some_future_action",
+            target_id=1,
+            actor_id=2,
+            reason="r",
+        )
+    assert sent is True
+    channel.send.assert_awaited_once()
+    embed = channel.send.await_args.kwargs["embed"]
+    assert embed.color == discord.Color.dark_grey()
+
+
+# ---------------------------------------------------------------------------
+# Subscriber path — _on_moderation_action
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_subscriber_skipped_when_bot_unset():
+    server_logging._BOT = None
+    await server_logging._on_moderation_action(
+        guild_id=1,
+        target_id=2,
+        actor_id=3,
+        action="warn",
+        reason="r",
+    )
+    assert counters_snapshot()["counters"]["skipped_no_guild"] == 1
+
+
+@pytest.mark.asyncio
+async def test_subscriber_skipped_when_guild_not_cached():
+    fake_bot = MagicMock()
+    fake_bot.get_guild = MagicMock(return_value=None)
+    server_logging._BOT = fake_bot
+    await server_logging._on_moderation_action(
+        guild_id=999,
+        target_id=2,
+        actor_id=3,
+        action="warn",
+        reason="r",
+    )
+    assert counters_snapshot()["counters"]["skipped_no_guild"] == 1
+
+
+@pytest.mark.asyncio
+async def test_subscriber_delegates_to_log_event():
+    fake_bot = MagicMock()
+    guild = _make_guild()
+    fake_bot.get_guild = MagicMock(return_value=guild)
+    server_logging._BOT = fake_bot
+
+    with patch(
+        "services.server_logging.log_event",
+        new_callable=AsyncMock,
+    ) as log_event_mock:
+        await server_logging._on_moderation_action(
+            guild_id=guild.id,
+            target_id=42,
+            actor_id=7,
+            action="warn",
+            reason="spam",
+        )
+
+    log_event_mock.assert_awaited_once()
+    kwargs = log_event_mock.await_args.kwargs
+    assert kwargs["action"] == "warn"
+    assert kwargs["target_id"] == 42
+    assert kwargs["actor_id"] == 7
+    assert kwargs["reason"] == "spam"
+
+
+@pytest.mark.asyncio
+async def test_subscriber_passes_extras_through():
+    fake_bot = MagicMock()
+    guild = _make_guild()
+    fake_bot.get_guild = MagicMock(return_value=guild)
+    server_logging._BOT = fake_bot
+
+    with patch(
+        "services.server_logging.log_event",
+        new_callable=AsyncMock,
+    ) as log_event_mock:
+        await server_logging._on_moderation_action(
+            guild_id=guild.id,
+            target_id=42,
+            actor_id=7,
+            action="timeout",
+            reason="cooldown",
+            until="2026-12-31T00:00:00+00:00",
+        )
+
+    extras = log_event_mock.await_args.kwargs["extras"]
+    assert extras == {"until": "2026-12-31T00:00:00+00:00"}
+
+
+@pytest.mark.asyncio
+async def test_subscriber_counts_unexpected_exception():
+    fake_bot = MagicMock()
+    fake_bot.get_guild = MagicMock(side_effect=RuntimeError("kaboom"))
+    server_logging._BOT = fake_bot
+    await server_logging._on_moderation_action(
+        guild_id=1,
+        target_id=2,
+        actor_id=3,
+        action="warn",
+        reason="r",
+    )
+    assert counters_snapshot()["counters"]["subscriber_errors"] == 1
+
+
+# ---------------------------------------------------------------------------
+# setup() — bus subscription
+# ---------------------------------------------------------------------------
+
+
+def test_setup_registers_bus_handler_idempotently():
+    from core.events import bus
+
+    # Capture handler count before & after.  setup() may have been
+    # called by the module import via fixture autouse=False; we test
+    # the idempotency invariant from a known-zero state.
+    bus._handlers.get(server_logging.EVT_MOD_ACTION, []).clear()
+    server_logging._SUBSCRIBED = False
+    server_logging.setup(MagicMock())
+    server_logging.setup(MagicMock())  # second call must not re-register
+    handlers = bus._handlers.get(server_logging.EVT_MOD_ACTION, [])
+    assert len(handlers) == 1
+
+
+def test_setup_captures_bot_reference():
+    server_logging._SUBSCRIBED = False
+    server_logging._BOT = None
+    fake_bot = MagicMock()
+    server_logging.setup(fake_bot)
+    assert server_logging._BOT is fake_bot
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics
+# ---------------------------------------------------------------------------
+
+
+def test_counters_snapshot_has_stable_shape():
+    snap = counters_snapshot()
+    assert "counters" in snap
+    assert "subscribed_events" in snap
+    counters = snap["counters"]
+    expected_keys = {
+        "sent_total",
+        "skipped_disabled",
+        "skipped_no_guild",
+        "missing_channel",
+        "created_channel",
+        "permission_error",
+        "send_error",
+        "auto_create_error",
+        "subscriber_errors",
+    }
+    assert expected_keys <= set(counters)
+    for v in counters.values():
+        assert isinstance(v, int)
+    assert snap["subscribed_events"] == ["moderation.action_taken"]
+
+
+def test_diagnostics_service_registers_server_logging_provider():
+    from services import diagnostics_service
+
+    # The module-level _register_diagnostics() call runs at import.
+    snap = diagnostics_service.snapshot("server_logging")
+    assert "counters" in snap
+
+
+def test_counters_snapshot_returns_copy_not_live_dict():
+    snap = counters_snapshot()
+    snap["counters"]["sent_total"] = 999_999
+    again = counters_snapshot()
+    assert again["counters"]["sent_total"] != 999_999
+
+
+# ---------------------------------------------------------------------------
+# Event catalogue check
+# ---------------------------------------------------------------------------
+
+
+def test_subscribed_event_is_catalogued():
+    from core.events_catalogue import KNOWN_EVENTS
+
+    assert server_logging.EVT_MOD_ACTION in KNOWN_EVENTS
+
+
+# ---------------------------------------------------------------------------
+# No top-level core.runtime imports (cycle safety)
+# ---------------------------------------------------------------------------
+
+
+def test_module_source_has_no_top_level_cycle_imports():
+    """Server-logging service must keep core.runtime imports inside
+    function bodies so loading the service module during startup
+    never re-enters a partially-loaded core.runtime.  utils.db is
+    safe at module scope (mirrors moderation_service pattern)."""
+    src = Path(server_logging.__file__).read_text()
+    # Naive top-of-file scan — anything inside a def/class is fine.
+    head = src.split("\n\nasync def", 1)[0].split("\n\ndef ", 1)[0]
+    forbidden = ("from core.runtime", "from utils.subsystem_registry")
+    for token in forbidden:
+        assert token not in head, (
+            f"Top-level import of {token!r} would re-enter the "
+            f"partially-loaded core.runtime during startup; move it "
+            f"inside the function that needs it."
+        )


### PR DESCRIPTION
## Summary

Adds `services/server_logging.py` — a per-guild fail-safe service
that subscribes to `moderation.action_taken` and posts structured
embeds to a configured log channel. Default policy is **OFF**, no
migration, no flag flips. Architecturally clean: depends on the
shared `core.runtime.guild_resources.ensure_channel` primitive,
**not** ChannelCog.

- **No migration.** Four new settings keys live in legacy `guild_settings`.
- **No behavior changes** until an operator opts in (today: direct
  `guild_settings` row update, or `!set logging_enabled true` if your
  deploy already exposes `!set`; a dedicated `!logging enable` /
  `!logging set …` admin command set is intentionally NOT in this
  PR's scope and will land alongside SettingsRegistry later).
- **Default OFF** — `logging.enabled`, `logging.auto_create_channels`,
  both channel slots all default empty/false.
- **Branched directly from `main`.** Independent of PR-10 (#88) and PR-12 (#90).

## Channel routing

| Action | Channel slot |
|---|---|
| `warn`/`timeout`/`kick`/`ban`/`unban`/`clear_warnings` | `logging.mod_channel` |
| `auto_delete:*` (cleanup) | `logging.cleanup_channel` → falls back to mod |

## Embed style

Per-action color + icon (warn=gold⚠️, timeout=orange⏳, kick=dark_orange👢, ban=red🔨, unban=green🕊️, clear_warnings=blurple🧹, auto_delete=dark_grey🗑️). Unknown actions get a generic dark-grey embed so future action types render safely. Extras are capped at 6 fields (each value ≤ 500 chars); overflow emits a single `"… truncated"` field so a malformed payload can't push the embed past Discord's 25-field / 6000-char limits.

## Fail-safe rules

The event bus already swallows handler exceptions (5s timeout, ERROR log, no re-raise). Inside the service every potential failure is caught and counted:

| Counter | Trigger |
|---|---|
| `sent_total` | Embed delivered. |
| `skipped_disabled` | `logging.enabled` OFF for guild. |
| `skipped_no_guild` | Bot not connected, or `guild_id` not in cache. |
| `missing_channel` | Configured channel unresolvable + auto-create OFF. |
| `created_channel` | `ensure_channel` created the fallback channel. |
| `permission_error` | `discord.Forbidden` on send or create. |
| `send_error` | `discord.HTTPException` (or unexpected) on send. |
| `auto_create_error` | `discord.HTTPException` (or unexpected) on create. |
| `subscriber_errors` | The bus subscriber itself raised. |

Counters surface via `services.diagnostics_service` under `"server_logging"` and feed `!platform consistency` (PR-10) once PR-10 is merged.

## Channel provisioning

When auto-create is on, the service calls `core.runtime.guild_resources.ensure_channel(guild, name, kind="text")` to create `bot-mod-log` / `bot-cleanup-log`. This is the **same** primitive ChannelCog uses today — no Cog→Cog dependency, no duplication.

## Files changed

| File | Purpose |
|---|---|
| `disbot/services/server_logging.py` (new) | The service: config accessors, channel resolution / provisioning, embed builder (with extras cap), `log_event`, bus subscriber, `setup(bot)`, counters, diagnostics registration |
| `disbot/utils/settings_keys/logging.py` (new) | 4 setting keys + 2 default channel names |
| `disbot/utils/settings_keys/__init__.py` | Re-export logging constants (F-2 invariant) |
| `disbot/bot1.py` | Call `server_logging.setup(bot)` after `runtime.setup()` |
| `disbot/cogs/admin_cog.py` | Add `!logging status` + `!logging test` (cog now 462 LOC, well under 800 ceiling) |
| `docs/server-logging.md` (new) | Admin docs — channel routing, fail-safe rules, operator workflow |
| `tests/unit/services/test_server_logging.py` (new) | 44 tests covering every scope-spec case + extras cap |
| `tests/unit/runtime/test_server_logging_import_cycle.py` (new) | AST scan + fresh-interpreter import |

## Test plan

- [x] `pytest tests/unit/services/test_server_logging.py` — 44 passed
- [x] `pytest tests/unit/runtime/test_server_logging_import_cycle.py` — 2 passed
- [x] `pytest tests/unit/services/test_moderation_service.py` — regression passed
- [x] `pytest tests/unit/invariants/` — passed (incl. cog size + settings-keys re-export invariants)
- [x] `pytest tests/unit` — **1465 passed, 0 failed** (after extras-cap addition)
- [x] `ruff check` / `black --check` / `isort --check-only` / `mypy disbot/` — all clean

## Test cases covered (per spec)

- [x] event received while logging disabled → `skipped_disabled` bumped
- [x] event received with configured channel → embed sent
- [x] missing channel + auto_create OFF → `missing_channel` bumped, `ensure_channel` not called
- [x] missing channel + auto_create ON → `ensure_channel` called, channel created, embed sent
- [x] send permission failure → `permission_error` counted and swallowed
- [x] send HTTP failure → `send_error` counted and swallowed
- [x] send unexpected exception → `send_error` counted and swallowed
- [x] unknown action → generic dark-grey embed renders safely
- [x] subscriber failure → `subscriber_errors` counted and swallowed
- [x] diagnostics snapshot shape stable (keyset + int types)
- [x] cleanup action routes to `cleanup_channel` slot
- [x] setup() idempotent + captures bot reference
- [x] event name is catalogued
- [x] no top-level `core.runtime` / `utils.subsystem_registry` imports
- [x] extras capped at 6 fields + truncation marker on overflow
- [x] extras values truncated at 500 chars
- [x] under-cap extras render without truncation marker

## Manual smoke

- [ ] Bot boots.
- [ ] `!logging status` shows enabled=off, all channels unset, all counters zero.
- [ ] Set `logging.enabled=true` + `logging.mod_channel=<channel id>` via
      direct DB / `!set` row update.
- [ ] Run a moderation action (`!warn`, `!ban`, etc.). Verify the embed
      appears in the configured channel.
- [ ] Trigger a cleanup auto-delete (prohibited word). Verify the
      cleanup embed appears.
- [ ] Remove send permission from the bot in the log channel. Run
      another moderation action. Verify the original action succeeds
      and `!logging status` shows `permission_error` incremented.
- [ ] Set `logging.auto_create_channels=true`, clear
      `logging.mod_channel`. Run a moderation action. Verify
      `bot-mod-log` is created.
- [ ] Existing ChannelCog behavior (`!set`, `!create`, etc.) unchanged.

## Risks and rollback

- **Risk**: an over-eager subscriber could rate-limit the channel.
  Mitigation: `logging.enabled` is default OFF; events flow only when an
  admin opts in.
- **Risk**: subscriber crash blocks moderation.  Mitigation: the bus
  swallows handler exceptions, and the service has a belt-and-braces
  outer try/except.
- **Risk**: auto_create creates channels operators didn't want.
  Mitigation: `logging.auto_create_channels` is default OFF; the
  fallback names (`bot-mod-log` / `bot-cleanup-log`) are explicit.
- **Risk**: malformed event payload pushes the embed past Discord
  limits.  Mitigation: extras cap (6 fields, 500 chars/value) + base
  reason cap (1000 chars) — verified by tests.
- **Rollback**: single `git revert` of the PR-11 merge commit. No
  migration, no DB schema change, no persisted state added.

## Independence from PR-10 / PR-12

This branch is built directly from `main` (`2bcf82d`) and does NOT
depend on PR-10 (#88) or PR-12 (#90). All three are reviewable /
mergeable in any order. When all land, PR-10's `!platform consistency`
will pick up the `server_logging` diagnostics provider automatically
via its existing Runtime providers section.

## Recommended next PR

A small **SettingsRegistry-aligned admin command pack** for
`!logging enable` / `!logging set mod #channel` / `!logging set cleanup #channel`
that writes through the future SettingsMutationPipeline rather than
directly to `guild_settings`.  Intentionally deferred until
SettingsRegistry planning lands so it can be a single, registry-aware
PR rather than ad-hoc `!set`-style writes that would have to be
re-plumbed later.

## Intentionally deferred

- Dedicated `!logging enable` / `!logging set …` admin commands —
  see the "Recommended next PR" note above; until then operators use
  the existing `!set` mechanism or direct `guild_settings` row
  updates to flip `logging.enabled` and configure channels.
- SettingsRegistry / SettingsMutationPipeline integration (logging
  toggles will become first consumers once the registry lands).
- Setup wizard / PanelRegistry / slash commands.
- Role/cleanup service extraction (cleanup currently routes through
  `moderation_service.auto_delete`, which is the right shape).
- Per-event subscription toggles (`logging.enabled` is the master
  switch in v1).
- Message edit / delete / member join logging.
- Web dashboard / external log storage / Redis.
- Any flag flips.

https://claude.ai/code/session_01TgXKzat6grWjupChjL4g5A