### PR TITLE
Phase 2 PR-12: Command Surface Ledger (read-only catalogue)

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -707,6 +707,19 @@ async def main() -> None:
             except Exception as exc:
                 logger.warning("Identity-contract validation skipped: %s", exc)
 
+            # Phase 2 PR-12 — Command Surface Ledger.  Walks the live
+            # command surface (cogs + router prefixes) once and caches
+            # the immutable snapshot for diagnostics / future
+            # PanelRegistry consumers.  Failure is non-fatal: the bot
+            # boots without the ledger and `!platform consistency`
+            # reports the section as not-built.
+            try:
+                from core.runtime import command_surface_ledger
+
+                command_surface_ledger.build_ledger(bot)
+            except Exception as exc:
+                logger.warning("Command-surface ledger build skipped: %s", exc)
+
             logger.info("Starting bot...")
             await bot.start(config.DISCORD_BOT_TOKEN)
     finally:

--- a/disbot/core/runtime/command_surface_ledger.py
+++ b/disbot/core/runtime/command_surface_ledger.py
@@ -108,12 +108,25 @@ class CommandSurfaceLedger:
         return tuple(e for e in self.entries if e.subsystem == subsystem)
 
     def find(self, name: str) -> CommandSurfaceEntry | None:
+        """Return the entry whose primary ``name`` matches, or the first
+        entry that declares ``name`` as an alias.  Primary names take
+        precedence over aliases so a command's canonical entry always
+        wins when both forms collide (the collision itself is reported
+        as a ``duplicate_alias_names`` finding).
+        """
         for entry in self.entries:
             if entry.name == name:
+                return entry
+        for entry in self.entries:
+            if name in entry.aliases:
                 return entry
         return None
 
     def subsystem_for_command(self, name: str) -> str | None:
+        """Return the owning subsystem for *name*; alias-aware via
+        :meth:`find`.  Returns ``None`` when neither a primary name
+        nor an alias matches.
+        """
         entry = self.find(name)
         return entry.subsystem if entry is not None else None
 
@@ -178,7 +191,11 @@ def _walk_commands(bot: object) -> list[CommandSurfaceEntry]:
         parent = getattr(cmd, "parent", None)
         parent_name = parent.qualified_name if parent is not None else None
         aliases = tuple(getattr(cmd, "aliases", ()) or ())
-        is_declared = _is_declared_entry_point(cmd.name, subsystem)
+        is_declared = _is_declared_entry_point(
+            cmd.name,
+            cmd.qualified_name,
+            subsystem,
+        )
         entries.append(
             CommandSurfaceEntry(
                 name=cmd.qualified_name,
@@ -206,7 +223,17 @@ def _visibility_for(subsystem: str | None) -> str | None:
     return str(tier) if tier is not None else None
 
 
-def _is_declared_entry_point(name: str, subsystem: str | None) -> bool:
+def _is_declared_entry_point(
+    bare_name: str,
+    qualified_name: str,
+    subsystem: str | None,
+) -> bool:
+    """A subsystem's ``entry_points`` list may use either bare command
+    names (``"daily"``) or qualified group-subcommand pairs
+    (``"platform consistency"``).  Match either form so subcommands
+    are correctly flagged as declared without forcing SUBSYSTEMS to
+    pick one convention.
+    """
     if subsystem is None:
         return False
     from utils.subsystem_registry import SUBSYSTEMS
@@ -215,7 +242,7 @@ def _is_declared_entry_point(name: str, subsystem: str | None) -> bool:
     if meta is None:
         return False
     declared = meta.get("entry_points") or ()
-    return name in declared
+    return bare_name in declared or qualified_name in declared
 
 
 def _walk_router_prefixes() -> list[RouterPrefixEntry]:

--- a/disbot/core/runtime/command_surface_ledger.py
+++ b/disbot/core/runtime/command_surface_ledger.py
@@ -1,0 +1,389 @@
+"""Command surface ledger — Phase 2 PR-12.
+
+An immutable, in-memory catalogue of every command entrypoint the bot
+exposes — prefix commands today, slash commands reserved for a future
+PR — together with their owner subsystem, visibility tier, and any
+group/alias relationships.
+
+The ledger is **read-only** and **builder-driven**: ``build_ledger(bot)``
+walks the live ``bot.commands`` surface and the interaction router's
+prefix registry once, returns a frozen ``CommandSurfaceLedger``, and
+caches it for later diagnostics access.  Tests and admin commands
+that want to inspect the surface ask the cache directly via
+``get_cached_ledger()``.
+
+This module does NOT duplicate
+:func:`utils.subsystem_registry.validate_identity_contract`.  The
+validator emits *findings* (action-oriented warnings); the ledger
+emits *data* (a queryable index).  Both consume the same source data
+(SUBSYSTEMS + bot.commands + router prefixes), so a future
+PanelRegistry can call ``ledger.by_subsystem("economy")`` without
+re-walking ``bot.commands``.
+
+Public surface:
+
+    CommandSurfaceEntry      — frozen dataclass per command
+    RouterPrefixEntry        — frozen dataclass per registered router prefix
+    LedgerFindings           — frozen dataclass with orphan/duplicate buckets
+    CommandSurfaceLedger     — frozen aggregate snapshot
+    build_ledger(bot)        — walks the live surface, caches, returns ledger
+    get_cached_ledger()      — last-built ledger, or None if not built
+    cog_name_to_subsystem(s) — normalise a cog class name to a SUBSYSTEMS key
+
+Diagnostics provider name: ``"command_surface_ledger"``.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger("bot.runtime.command_surface_ledger")
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CommandSurfaceEntry:
+    """A single command entrypoint registered with the bot."""
+
+    name: str
+    cog_name: str
+    subsystem: str | None
+    visibility_tier: str | None
+    aliases: tuple[str, ...] = ()
+    parent_group: str | None = None
+    is_declared: bool = False
+    kind: str = "prefix"  # reserved values: "prefix" | "slash"
+
+
+@dataclass(frozen=True)
+class RouterPrefixEntry:
+    """An interaction-router prefix → owner subsystem mapping."""
+
+    prefix: str
+    subsystem: str | None
+
+
+@dataclass(frozen=True)
+class LedgerFindings:
+    """Cross-cutting checks computed at build time."""
+
+    orphan_cog_subsystems: tuple[str, ...] = ()
+    duplicate_command_names: tuple[str, ...] = ()
+    duplicate_alias_names: tuple[str, ...] = ()
+    undeclared_entry_points: tuple[str, ...] = ()
+    router_prefix_unknown: tuple[str, ...] = ()
+
+    @property
+    def total(self) -> int:
+        return (
+            len(self.orphan_cog_subsystems)
+            + len(self.duplicate_command_names)
+            + len(self.duplicate_alias_names)
+            + len(self.undeclared_entry_points)
+            + len(self.router_prefix_unknown)
+        )
+
+
+@dataclass(frozen=True)
+class CommandSurfaceLedger:
+    """An immutable snapshot of the command surface at a point in time."""
+
+    version: int
+    built_at: datetime.datetime
+    entries: tuple[CommandSurfaceEntry, ...]
+    router_prefixes: tuple[RouterPrefixEntry, ...]
+    findings: LedgerFindings
+    # Reserved for a future PR that wires app_commands.
+    slash_entries: tuple[CommandSurfaceEntry, ...] = field(default_factory=tuple)
+
+    def by_subsystem(self, subsystem: str) -> tuple[CommandSurfaceEntry, ...]:
+        return tuple(e for e in self.entries if e.subsystem == subsystem)
+
+    def find(self, name: str) -> CommandSurfaceEntry | None:
+        for entry in self.entries:
+            if entry.name == name:
+                return entry
+        return None
+
+    def subsystem_for_command(self, name: str) -> str | None:
+        entry = self.find(name)
+        return entry.subsystem if entry is not None else None
+
+
+# ---------------------------------------------------------------------------
+# Module state — cached last-built ledger
+# ---------------------------------------------------------------------------
+
+_CACHED: CommandSurfaceLedger | None = None
+
+_LEDGER_VERSION = 1
+
+# Cog class name normalisation: trim "Cog" suffix + lowercase.
+# `EconomyCog` → `economy`; `ProofChannelCog` → `proofchannel`.
+_COG_SUFFIX_RE = re.compile(r"cog$", re.IGNORECASE)
+
+
+def cog_name_to_subsystem(cog_name: str) -> str | None:
+    """Normalise a cog class name to a SUBSYSTEMS key, or None on miss."""
+    if not cog_name:
+        return None
+    normalised = _COG_SUFFIX_RE.sub("", cog_name).lower()
+    # Function-local: utils.subsystem_registry transitively touches
+    # core.runtime, so we keep this import inside the function to
+    # match the cycle-sensitive discipline used by other runtime
+    # modules.
+    from utils.subsystem_registry import SUBSYSTEMS
+
+    return normalised if normalised in SUBSYSTEMS else None
+
+
+def _reset_for_tests() -> None:
+    global _CACHED
+    _CACHED = None
+
+
+# ---------------------------------------------------------------------------
+# Builder
+# ---------------------------------------------------------------------------
+
+
+def _walk_commands(bot: object) -> list[CommandSurfaceEntry]:
+    """Walk ``bot.commands`` and build one entry per command + alias.
+
+    Subcommands of a group are recorded with ``parent_group`` set to
+    the group's qualified name.  Aliases are recorded as separate
+    entries with ``is_alias=True`` semantics carried via the
+    ``aliases`` field of the primary entry rather than duplicated
+    entries — duplicates would confuse "subsystem_for_command" if a
+    cog happened to use the same string as an alias to a different
+    command (we detect that as ``duplicate_alias_names`` in findings).
+    """
+    entries: list[CommandSurfaceEntry] = []
+    walk = getattr(bot, "walk_commands", None)
+    if walk is None:
+        return entries
+    for cmd in walk():
+        cog = getattr(cmd, "cog", None)
+        cog_name = cog.__class__.__name__ if cog is not None else ""
+        subsystem = cog_name_to_subsystem(cog_name) if cog_name else None
+        visibility_tier = _visibility_for(subsystem)
+        parent = getattr(cmd, "parent", None)
+        parent_name = parent.qualified_name if parent is not None else None
+        aliases = tuple(getattr(cmd, "aliases", ()) or ())
+        is_declared = _is_declared_entry_point(cmd.name, subsystem)
+        entries.append(
+            CommandSurfaceEntry(
+                name=cmd.qualified_name,
+                cog_name=cog_name,
+                subsystem=subsystem,
+                visibility_tier=visibility_tier,
+                aliases=aliases,
+                parent_group=parent_name,
+                is_declared=is_declared,
+                kind="prefix",
+            ),
+        )
+    return entries
+
+
+def _visibility_for(subsystem: str | None) -> str | None:
+    if subsystem is None:
+        return None
+    from utils.subsystem_registry import SUBSYSTEMS
+
+    meta = SUBSYSTEMS.get(subsystem)
+    if meta is None:
+        return None
+    tier = meta.get("visibility_tier")
+    return str(tier) if tier is not None else None
+
+
+def _is_declared_entry_point(name: str, subsystem: str | None) -> bool:
+    if subsystem is None:
+        return False
+    from utils.subsystem_registry import SUBSYSTEMS
+
+    meta = SUBSYSTEMS.get(subsystem)
+    if meta is None:
+        return False
+    declared = meta.get("entry_points") or ()
+    return name in declared
+
+
+def _walk_router_prefixes() -> list[RouterPrefixEntry]:
+    """Snapshot the interaction-router prefix registry."""
+    from core.runtime import interaction_router
+    from utils.subsystem_registry import SUBSYSTEMS
+
+    prefixes = list(getattr(interaction_router, "_handlers", {}).keys())
+    return [
+        RouterPrefixEntry(
+            prefix=p,
+            subsystem=p if p in SUBSYSTEMS else None,
+        )
+        for p in sorted(prefixes)
+    ]
+
+
+def _compute_findings(
+    entries: list[CommandSurfaceEntry],
+    router_prefixes: list[RouterPrefixEntry],
+) -> LedgerFindings:
+    """Cross-cutting checks once the data is in hand."""
+    from utils.subsystem_registry import SUBSYSTEMS
+
+    # Orphan: cog name normalised to a key that does not exist in
+    # SUBSYSTEMS.  We surface the unique cog names that produced
+    # orphan entries so reviewers can rename or register them.
+    orphans: set[str] = set()
+    for e in entries:
+        if not e.cog_name:
+            continue
+        if e.subsystem is None:
+            orphans.add(e.cog_name)
+
+    # Duplicate names: same qualified_name registered by >1 cog.
+    name_counts: dict[str, set[str]] = {}
+    for e in entries:
+        name_counts.setdefault(e.name, set()).add(e.cog_name)
+    dup_names = tuple(sorted(n for n, cogs in name_counts.items() if len(cogs) > 1))
+
+    # Duplicate aliases: any alias that collides with a primary
+    # command name OR with another command's alias.
+    primary_names = {e.name for e in entries}
+    alias_to_owners: dict[str, set[str]] = {}
+    for e in entries:
+        for a in e.aliases:
+            alias_to_owners.setdefault(a, set()).add(e.name)
+    dup_aliases: set[str] = set()
+    for alias, owners in alias_to_owners.items():
+        if alias in primary_names:
+            dup_aliases.add(alias)
+        if len(owners) > 1:
+            dup_aliases.add(alias)
+
+    # Undeclared entry points: SUBSYSTEMS lists a command that has
+    # no live registration.  Mirrors the validator's
+    # entry_point_missing_command finding but as queryable data.
+    live_names = primary_names | {a for e in entries for a in e.aliases}
+    undeclared: list[str] = []
+    for sub, meta in SUBSYSTEMS.items():
+        for declared in meta.get("entry_points") or ():
+            if declared not in live_names:
+                undeclared.append(f"{sub}.{declared}")
+    undeclared.sort()
+
+    # Router prefix unknown: an interaction-router prefix that does
+    # not correspond to a declared subsystem.
+    unknown_prefixes = tuple(
+        sorted(p.prefix for p in router_prefixes if p.subsystem is None),
+    )
+
+    return LedgerFindings(
+        orphan_cog_subsystems=tuple(sorted(orphans)),
+        duplicate_command_names=dup_names,
+        duplicate_alias_names=tuple(sorted(dup_aliases)),
+        undeclared_entry_points=tuple(undeclared),
+        router_prefix_unknown=unknown_prefixes,
+    )
+
+
+def build_ledger(bot: object) -> CommandSurfaceLedger:
+    """Walk the live command surface and return a frozen ledger snapshot.
+
+    Caches the result for later diagnostics access; call again to
+    refresh after a hot-reload.  The function is sync-safe: it does
+    not perform I/O.
+    """
+    entries = _walk_commands(bot)
+    router_prefixes = _walk_router_prefixes()
+    findings = _compute_findings(entries, router_prefixes)
+    ledger = CommandSurfaceLedger(
+        version=_LEDGER_VERSION,
+        built_at=datetime.datetime.now(tz=datetime.timezone.utc),
+        entries=tuple(entries),
+        router_prefixes=tuple(router_prefixes),
+        findings=findings,
+    )
+    global _CACHED
+    _CACHED = ledger
+    logger.info(
+        "command_surface_ledger: built v%d — %d commands, %d router prefixes, "
+        "%d findings",
+        ledger.version,
+        len(ledger.entries),
+        len(ledger.router_prefixes),
+        findings.total,
+    )
+    return ledger
+
+
+def get_cached_ledger() -> CommandSurfaceLedger | None:
+    """Return the last built ledger, or None if :func:`build_ledger`
+    has not yet been called this process.
+    """
+    return _CACHED
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics provider
+# ---------------------------------------------------------------------------
+
+
+def _snapshot() -> dict[str, Any]:
+    """Stable diagnostics snapshot — counts + findings counts only.
+
+    Does NOT include the full entries list (which would explode the
+    diagnostics payload).  Operators wanting the full list call
+    :func:`get_cached_ledger` from a REPL or future admin command.
+    """
+    ledger = _CACHED
+    if ledger is None:
+        return {
+            "status": "not_built",
+            "hint": "call command_surface_ledger.build_ledger(bot) after cogs load.",
+        }
+    return {
+        "status": "built",
+        "version": ledger.version,
+        "built_at": ledger.built_at.isoformat(),
+        "command_count": len(ledger.entries),
+        "router_prefix_count": len(ledger.router_prefixes),
+        "slash_entry_count": len(ledger.slash_entries),
+        "findings_total": ledger.findings.total,
+        "findings": {
+            "orphan_cog_subsystems": len(ledger.findings.orphan_cog_subsystems),
+            "duplicate_command_names": len(ledger.findings.duplicate_command_names),
+            "duplicate_alias_names": len(ledger.findings.duplicate_alias_names),
+            "undeclared_entry_points": len(ledger.findings.undeclared_entry_points),
+            "router_prefix_unknown": len(ledger.findings.router_prefix_unknown),
+        },
+    }
+
+
+def _register_diagnostics() -> None:
+    from services import diagnostics_service
+
+    diagnostics_service.register("command_surface_ledger", _snapshot)
+
+
+_register_diagnostics()
+
+
+__all__ = [
+    "CommandSurfaceEntry",
+    "CommandSurfaceLedger",
+    "LedgerFindings",
+    "RouterPrefixEntry",
+    "build_ledger",
+    "cog_name_to_subsystem",
+    "get_cached_ledger",
+]

--- a/tests/unit/runtime/test_command_surface_ledger.py
+++ b/tests/unit/runtime/test_command_surface_ledger.py
@@ -1,0 +1,394 @@
+"""Unit tests for core.runtime.command_surface_ledger — Phase 2 PR-12."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from core.runtime import command_surface_ledger as ledger_mod
+from core.runtime.command_surface_ledger import (
+    CommandSurfaceEntry,
+    CommandSurfaceLedger,
+    LedgerFindings,
+    RouterPrefixEntry,
+    build_ledger,
+    cog_name_to_subsystem,
+    get_cached_ledger,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    ledger_mod._reset_for_tests()
+    yield
+    ledger_mod._reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# cog_name_to_subsystem
+# ---------------------------------------------------------------------------
+
+
+def test_cog_name_strips_cog_suffix_and_lowercases():
+    assert cog_name_to_subsystem("EconomyCog") == "economy"
+    assert cog_name_to_subsystem("ModerationCog") == "moderation"
+    assert cog_name_to_subsystem("AdminCog") == "admin"
+
+
+def test_cog_name_returns_none_when_no_matching_subsystem():
+    # "Bogus" → "bogus" — not a SUBSYSTEMS key.
+    assert cog_name_to_subsystem("BogusCog") is None
+
+
+def test_cog_name_returns_none_on_empty_input():
+    assert cog_name_to_subsystem("") is None
+
+
+def test_cog_name_handles_no_cog_suffix():
+    # "Economy" → "economy" — still matches SUBSYSTEMS.
+    assert cog_name_to_subsystem("Economy") == "economy"
+
+
+# ---------------------------------------------------------------------------
+# Builder
+# ---------------------------------------------------------------------------
+
+
+def _make_cmd(
+    name: str,
+    cog_name: str = "EconomyCog",
+    aliases: tuple[str, ...] = (),
+    parent: object | None = None,
+) -> MagicMock:
+    cmd = MagicMock()
+    cmd.name = name
+    cmd.qualified_name = f"{parent.qualified_name} {name}" if parent else name
+    cmd.aliases = list(aliases)
+    cmd.parent = parent
+    if cog_name:
+        cog = MagicMock()
+        cog.__class__.__name__ = cog_name
+        # Patch the class name so .__class__.__name__ returns cog_name.
+        cmd.cog = MagicMock()
+        cmd.cog.__class__ = type(cog_name, (), {})
+    else:
+        cmd.cog = None
+    return cmd
+
+
+def _make_bot(*commands) -> MagicMock:
+    bot = MagicMock()
+    bot.walk_commands = MagicMock(return_value=list(commands))
+    return bot
+
+
+def test_build_ledger_captures_basic_command_metadata():
+    bot = _make_bot(_make_cmd("daily", cog_name="EconomyCog"))
+    ledger = build_ledger(bot)
+    assert ledger.version == 1
+    assert len(ledger.entries) == 1
+    entry = ledger.entries[0]
+    assert entry.name == "daily"
+    assert entry.cog_name == "EconomyCog"
+    assert entry.subsystem == "economy"
+    assert entry.kind == "prefix"
+
+
+def test_build_ledger_records_aliases():
+    bot = _make_bot(
+        _make_cmd("daily", cog_name="EconomyCog", aliases=("d", "daily_claim")),
+    )
+    ledger = build_ledger(bot)
+    assert ledger.entries[0].aliases == ("d", "daily_claim")
+
+
+def test_build_ledger_records_subcommand_parent():
+    parent_grp = MagicMock()
+    parent_grp.qualified_name = "platform"
+    sub = _make_cmd("consistency", cog_name="DiagnosticCog", parent=parent_grp)
+    bot = _make_bot(sub)
+    ledger = build_ledger(bot)
+    assert ledger.entries[0].name == "platform consistency"
+    assert ledger.entries[0].parent_group == "platform"
+
+
+def test_build_ledger_marks_subsystem_none_for_orphan_cog():
+    bot = _make_bot(_make_cmd("bogus", cog_name="BogusCog"))
+    ledger = build_ledger(bot)
+    assert ledger.entries[0].subsystem is None
+    assert ledger.entries[0].visibility_tier is None
+    assert "BogusCog" in ledger.findings.orphan_cog_subsystems
+
+
+def test_build_ledger_visibility_tier_from_subsystems():
+    bot = _make_bot(_make_cmd("ban", cog_name="ModerationCog"))
+    ledger = build_ledger(bot)
+    # moderation tier is "moderator" per SUBSYSTEMS.
+    assert ledger.entries[0].visibility_tier == "moderator"
+
+
+def test_build_ledger_is_declared_flag_set_for_entry_points():
+    # "daily" is a declared entry_point of "economy" per SUBSYSTEMS.
+    bot = _make_bot(_make_cmd("daily", cog_name="EconomyCog"))
+    ledger = build_ledger(bot)
+    assert ledger.entries[0].is_declared is True
+
+
+def test_build_ledger_is_declared_false_for_undeclared_command():
+    # Random command name not in SUBSYSTEMS.entry_points for economy.
+    bot = _make_bot(_make_cmd("xyzzy_unknown", cog_name="EconomyCog"))
+    ledger = build_ledger(bot)
+    assert ledger.entries[0].is_declared is False
+
+
+def test_build_ledger_handles_bot_without_walk_commands():
+    bot = MagicMock(spec=[])  # no walk_commands attribute
+    ledger = build_ledger(bot)
+    assert ledger.entries == ()
+
+
+# ---------------------------------------------------------------------------
+# Findings
+# ---------------------------------------------------------------------------
+
+
+def test_findings_detect_duplicate_command_names():
+    # Same qualified_name registered by two different cogs.
+    cmd_a = _make_cmd("balance", cog_name="EconomyCog")
+    cmd_b = _make_cmd("balance", cog_name="ModerationCog")
+    bot = _make_bot(cmd_a, cmd_b)
+    ledger = build_ledger(bot)
+    assert "balance" in ledger.findings.duplicate_command_names
+
+
+def test_findings_detect_alias_collision_with_primary_name():
+    # 'd' is an alias of 'daily', but also a primary name elsewhere.
+    cmd_a = _make_cmd("daily", cog_name="EconomyCog", aliases=("d",))
+    cmd_b = _make_cmd("d", cog_name="EconomyCog")
+    bot = _make_bot(cmd_a, cmd_b)
+    ledger = build_ledger(bot)
+    assert "d" in ledger.findings.duplicate_alias_names
+
+
+def test_findings_detect_alias_collision_between_two_commands():
+    cmd_a = _make_cmd("foo", cog_name="EconomyCog", aliases=("xx",))
+    cmd_b = _make_cmd("bar", cog_name="EconomyCog", aliases=("xx",))
+    bot = _make_bot(cmd_a, cmd_b)
+    ledger = build_ledger(bot)
+    assert "xx" in ledger.findings.duplicate_alias_names
+
+
+def test_findings_detect_undeclared_entry_points():
+    # No commands registered → every SUBSYSTEMS.entry_points name is undeclared.
+    bot = _make_bot()
+    ledger = build_ledger(bot)
+    # economy.daily is declared in SUBSYSTEMS — should appear in undeclared.
+    assert "economy.daily" in ledger.findings.undeclared_entry_points
+
+
+def test_findings_orphan_cog_subsystems_empty_when_all_match():
+    bot = _make_bot(
+        _make_cmd("daily", cog_name="EconomyCog"),
+        _make_cmd("ban", cog_name="ModerationCog"),
+    )
+    ledger = build_ledger(bot)
+    assert ledger.findings.orphan_cog_subsystems == ()
+
+
+def test_findings_total_aggregates_all_buckets():
+    findings = LedgerFindings(
+        orphan_cog_subsystems=("BogusCog",),
+        duplicate_command_names=("balance",),
+        duplicate_alias_names=("d",),
+        undeclared_entry_points=("economy.daily",),
+        router_prefix_unknown=("xxx",),
+    )
+    assert findings.total == 5
+
+
+def test_router_prefixes_marked_unknown_when_not_in_subsystems():
+    fake_handlers = {"unknown_prefix_xyz": lambda: None}
+    bot = _make_bot()
+    with patch.object(
+        ledger_mod,
+        "_walk_router_prefixes",
+        return_value=[RouterPrefixEntry(prefix="unknown_prefix_xyz", subsystem=None)],
+    ):
+        ledger = build_ledger(bot)
+    assert "unknown_prefix_xyz" in ledger.findings.router_prefix_unknown
+
+
+def test_router_prefix_known_when_in_subsystems():
+    bot = _make_bot()
+    with patch.object(
+        ledger_mod,
+        "_walk_router_prefixes",
+        return_value=[RouterPrefixEntry(prefix="economy", subsystem="economy")],
+    ):
+        ledger = build_ledger(bot)
+    assert "economy" not in ledger.findings.router_prefix_unknown
+
+
+# ---------------------------------------------------------------------------
+# Query API
+# ---------------------------------------------------------------------------
+
+
+def test_ledger_by_subsystem_returns_matching_entries():
+    bot = _make_bot(
+        _make_cmd("daily", cog_name="EconomyCog"),
+        _make_cmd("balance", cog_name="EconomyCog"),
+        _make_cmd("ban", cog_name="ModerationCog"),
+    )
+    ledger = build_ledger(bot)
+    economy = ledger.by_subsystem("economy")
+    assert {e.name for e in economy} == {"daily", "balance"}
+    moderation = ledger.by_subsystem("moderation")
+    assert {e.name for e in moderation} == {"ban"}
+
+
+def test_ledger_find_returns_entry_by_name():
+    bot = _make_bot(_make_cmd("daily", cog_name="EconomyCog"))
+    ledger = build_ledger(bot)
+    found = ledger.find("daily")
+    assert found is not None
+    assert found.name == "daily"
+    assert ledger.find("nonexistent") is None
+
+
+def test_ledger_subsystem_for_command_returns_owner():
+    bot = _make_bot(_make_cmd("daily", cog_name="EconomyCog"))
+    ledger = build_ledger(bot)
+    assert ledger.subsystem_for_command("daily") == "economy"
+    assert ledger.subsystem_for_command("nonexistent") is None
+
+
+# ---------------------------------------------------------------------------
+# Cache + diagnostics
+# ---------------------------------------------------------------------------
+
+
+def test_get_cached_ledger_returns_none_before_first_build():
+    assert get_cached_ledger() is None
+
+
+def test_get_cached_ledger_returns_last_built_snapshot():
+    bot = _make_bot(_make_cmd("daily", cog_name="EconomyCog"))
+    built = build_ledger(bot)
+    cached = get_cached_ledger()
+    assert cached is built
+
+
+def test_diagnostics_snapshot_not_built_state():
+    snap = ledger_mod._snapshot()
+    assert snap["status"] == "not_built"
+    assert "hint" in snap
+
+
+def test_diagnostics_snapshot_built_state_includes_counts():
+    bot = _make_bot(
+        _make_cmd("daily", cog_name="EconomyCog"),
+        _make_cmd("ban", cog_name="ModerationCog"),
+    )
+    build_ledger(bot)
+    snap = ledger_mod._snapshot()
+    assert snap["status"] == "built"
+    assert snap["version"] == 1
+    assert snap["command_count"] == 2
+    assert "router_prefix_count" in snap
+    assert "slash_entry_count" in snap
+    assert snap["slash_entry_count"] == 0
+    assert "findings_total" in snap
+    assert isinstance(snap["findings"], dict)
+    # Per-bucket finding counts present.
+    for key in (
+        "orphan_cog_subsystems",
+        "duplicate_command_names",
+        "duplicate_alias_names",
+        "undeclared_entry_points",
+        "router_prefix_unknown",
+    ):
+        assert key in snap["findings"]
+
+
+def test_diagnostics_service_registers_provider():
+    from services import diagnostics_service
+
+    # Module-level _register_diagnostics() ran at import.
+    snap = diagnostics_service.snapshot("command_surface_ledger")
+    assert "status" in snap
+
+
+# ---------------------------------------------------------------------------
+# Immutability
+# ---------------------------------------------------------------------------
+
+
+def test_ledger_is_frozen():
+    bot = _make_bot()
+    ledger = build_ledger(bot)
+    with pytest.raises(Exception):
+        ledger.version = 99  # type: ignore[misc]
+
+
+def test_entry_is_frozen():
+    entry = CommandSurfaceEntry(
+        name="daily",
+        cog_name="EconomyCog",
+        subsystem="economy",
+        visibility_tier="user",
+    )
+    with pytest.raises(Exception):
+        entry.name = "other"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Source discipline (no cycle-sensitive top-level imports)
+# ---------------------------------------------------------------------------
+
+
+def test_module_source_keeps_subsystem_registry_function_local():
+    """utils.subsystem_registry imports must stay inside functions to
+    match the cycle-sensitive discipline used by sibling runtime
+    modules (PR-10 / PR-11 pattern)."""
+    src = Path(ledger_mod.__file__).read_text()
+    head = src.split("\n\nasync def", 1)[0].split("\n\ndef ", 1)[0]
+    assert "from utils.subsystem_registry" not in head, (
+        "Top-level import of utils.subsystem_registry would force the "
+        "core.runtime package to resolve subsystem_registry while it "
+        "is still loading; keep the import inside the functions that "
+        "need it."
+    )
+
+
+def test_does_not_call_validate_identity_contract():
+    """The ledger must NOT call validate_identity_contract — the two
+    pieces are deliberately complementary (validator = findings;
+    ledger = queryable data).  Calling the validator from the ledger
+    builder would duplicate work and risk circular semantics.
+
+    We check at the AST level so docstrings/comments mentioning the
+    validator (for context) don't trip the test."""
+    import ast
+
+    src = Path(ledger_mod.__file__).read_text()
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr == "validate_identity_contract"
+            ):
+                pytest.fail("Ledger calls validate_identity_contract (attribute call)")
+            if isinstance(func, ast.Name) and func.id == "validate_identity_contract":
+                pytest.fail("Ledger calls validate_identity_contract (bare call)")
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if alias.name == "validate_identity_contract":
+                    pytest.fail(
+                        "Ledger imports validate_identity_contract — "
+                        "complementary, not consumer",
+                    )

--- a/tests/unit/runtime/test_command_surface_ledger.py
+++ b/tests/unit/runtime/test_command_surface_ledger.py
@@ -143,6 +143,50 @@ def test_build_ledger_is_declared_false_for_undeclared_command():
     assert ledger.entries[0].is_declared is False
 
 
+def test_build_ledger_is_declared_matches_qualified_subcommand_name():
+    """When SUBSYSTEMS.entry_points declares a qualified group
+    subcommand like ``"economy stats"``, the ledger must flag the
+    matching subcommand as declared even though the bare name
+    (``"stats"``) does not appear in entry_points."""
+    parent = MagicMock()
+    parent.qualified_name = "economy"
+    sub = _make_cmd("stats", cog_name="EconomyCog", parent=parent)
+    bot = _make_bot(sub)
+    with patch(
+        "utils.subsystem_registry.SUBSYSTEMS",
+        {
+            "economy": {
+                "entry_points": ["economy stats"],
+                "visibility_tier": "user",
+            },
+        },
+    ):
+        ledger = build_ledger(bot)
+    assert ledger.entries[0].name == "economy stats"
+    assert ledger.entries[0].is_declared is True
+
+
+def test_build_ledger_is_declared_matches_bare_subcommand_name():
+    """Conversely, if SUBSYSTEMS lists a bare name like ``"stats"``
+    (the legacy convention), a subcommand whose qualified name is
+    ``"economy stats"`` is still flagged as declared."""
+    parent = MagicMock()
+    parent.qualified_name = "economy"
+    sub = _make_cmd("stats", cog_name="EconomyCog", parent=parent)
+    bot = _make_bot(sub)
+    with patch(
+        "utils.subsystem_registry.SUBSYSTEMS",
+        {
+            "economy": {
+                "entry_points": ["stats"],
+                "visibility_tier": "user",
+            },
+        },
+    ):
+        ledger = build_ledger(bot)
+    assert ledger.entries[0].is_declared is True
+
+
 def test_build_ledger_handles_bot_without_walk_commands():
     bot = MagicMock(spec=[])  # no walk_commands attribute
     ledger = build_ledger(bot)
@@ -258,11 +302,45 @@ def test_ledger_find_returns_entry_by_name():
     assert ledger.find("nonexistent") is None
 
 
+def test_ledger_find_returns_entry_by_alias():
+    """find() must resolve a command via its declared aliases so
+    callers (PanelRegistry, future help/wizard) don't have to walk
+    .aliases themselves."""
+    bot = _make_bot(_make_cmd("daily", cog_name="EconomyCog", aliases=("d",)))
+    ledger = build_ledger(bot)
+    found = ledger.find("d")
+    assert found is not None
+    assert found.name == "daily"
+
+
+def test_ledger_find_primary_name_wins_over_alias_collision():
+    """When a name is both a primary command and an alias of another,
+    the primary entry wins."""
+    primary = _make_cmd("d", cog_name="EconomyCog")
+    aliased = _make_cmd("daily", cog_name="EconomyCog", aliases=("d",))
+    bot = _make_bot(primary, aliased)
+    ledger = build_ledger(bot)
+    found = ledger.find("d")
+    assert found is not None
+    assert found.name == "d"  # the primary entry wins, not the aliased one
+
+
 def test_ledger_subsystem_for_command_returns_owner():
     bot = _make_bot(_make_cmd("daily", cog_name="EconomyCog"))
     ledger = build_ledger(bot)
     assert ledger.subsystem_for_command("daily") == "economy"
     assert ledger.subsystem_for_command("nonexistent") is None
+
+
+def test_ledger_subsystem_for_command_is_alias_aware():
+    """subsystem_for_command must resolve via aliases too — otherwise
+    PanelRegistry / help would mis-attribute alias invocations."""
+    bot = _make_bot(
+        _make_cmd("daily", cog_name="EconomyCog", aliases=("d", "claim")),
+    )
+    ledger = build_ledger(bot)
+    assert ledger.subsystem_for_command("d") == "economy"
+    assert ledger.subsystem_for_command("claim") == "economy"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/runtime/test_command_surface_ledger_import_cycle.py
+++ b/tests/unit/runtime/test_command_surface_ledger_import_cycle.py
@@ -1,0 +1,83 @@
+"""Import-cycle regression for core.runtime.command_surface_ledger — PR-12.
+
+The ledger module lives inside ``core.runtime`` and is loaded during
+runtime setup, so any top-level imports of cycle-sensitive packages
+would re-enter a partially-loaded ``core.runtime`` and break startup.
+
+Pattern mirrors:
+* tests/unit/runtime/test_consistency_import_cycle.py (PR-10)
+* tests/unit/runtime/test_server_logging_import_cycle.py (PR-11)
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_LEDGER_PATH = (
+    _REPO_ROOT / "disbot" / "core" / "runtime" / "command_surface_ledger.py"
+)
+
+# Within core.runtime, we forbid only utils.subsystem_registry at module
+# scope (its evaluator helpers reach back into core.runtime through
+# transitive chains).  Importing sibling core.runtime modules at top
+# level is fine because they share the same package.
+_FORBIDDEN_TOP_LEVEL_PREFIXES = ("utils.subsystem_registry",)
+
+
+def _module_level_imports(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    offenders: list[str] = []
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for prefix in _FORBIDDEN_TOP_LEVEL_PREFIXES:
+                if module == prefix or module.startswith(prefix + "."):
+                    offenders.append(
+                        f"from {module} import "
+                        f"{', '.join(a.name for a in node.names)}",
+                    )
+                    break
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                for prefix in _FORBIDDEN_TOP_LEVEL_PREFIXES:
+                    if alias.name == prefix or alias.name.startswith(prefix + "."):
+                        offenders.append(f"import {alias.name}")
+                        break
+    return offenders
+
+
+def test_command_surface_ledger_no_top_level_cycle_imports():
+    offenders = _module_level_imports(_LEDGER_PATH)
+    assert not offenders, (
+        "core.runtime.command_surface_ledger has cycle-sensitive "
+        "top-level imports:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_command_surface_ledger_imports_in_fresh_interpreter():
+    script = textwrap.dedent(
+        """
+        import sys
+        sys.path.insert(0, "disbot")
+        import core.runtime.command_surface_ledger  # noqa: F401
+        print("ok")
+        """,
+    )
+    result = subprocess.run(  # noqa: S603 — script literal under our control
+        [sys.executable, "-c", script],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"core.runtime.command_surface_ledger import failed in subprocess.\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary

Add `core/runtime/command_surface_ledger.py` — a frozen, in-memory
catalogue of every command entrypoint the bot exposes (prefix
commands today, slash reserved) together with their owner subsystem,
visibility tier, aliases, and group ancestry. The ledger drives
detection of orphan / duplicate / undeclared entrypoints and unblocks
PanelRegistry planning.

- **No migration.** Pure in-memory data structure.
- **No behavior changes.** No new commands; the ledger is read-only.
- **No flag flips.**
- **Branched directly from `main`.** Independent of PR-10 (#88) and PR-11 (#89).

The ledger is **complementary** to `validate_identity_contract` (the
validator emits findings; the ledger emits queryable data). Both
consume the same source data (SUBSYSTEMS + `bot.commands` +
interaction-router prefixes). An AST test pins that the ledger does
NOT call the validator.

## What's exposed

| Type | Purpose |
|---|---|
| `CommandSurfaceEntry` | One frozen row per command (name, cog, subsystem, visibility_tier, aliases, parent_group, is_declared, kind) |
| `RouterPrefixEntry` | Prefix → subsystem mapping for the interaction router |
| `LedgerFindings` | Frozen aggregate of orphan / duplicate / undeclared / unknown buckets + `total` property |
| `CommandSurfaceLedger` | Frozen snapshot with `by_subsystem(name)` / `find(name)` / `subsystem_for_command(name)` |
| `build_ledger(bot)` | Walks the live surface, caches, returns the snapshot |
| `get_cached_ledger()` | Last-built snapshot or `None` |
| `cog_name_to_subsystem(s)` | `EconomyCog → "economy"` |

## Findings computed at build time

| Bucket | Trigger |
|---|---|
| `orphan_cog_subsystems` | Cog whose normalised name is not a SUBSYSTEMS key |
| `duplicate_command_names` | Same `qualified_name` registered by >1 cog |
| `duplicate_alias_names` | Alias collides with a primary name OR another command's alias |
| `undeclared_entry_points` | `SUBSYSTEMS.entry_points` lists a name not registered live |
| `router_prefix_unknown` | Interaction-router prefix not in SUBSYSTEMS |

`LedgerFindings.total` aggregates across buckets so callers
(`!platform consistency`, future panel checks) can short-circuit on
zero.

## Why this lands now

Unblocks the larger UX phase:

* **PanelRegistry planning** needs `ledger.by_subsystem("economy")`
  to know what commands a subsystem owns without re-walking
  `bot.commands` on every render.
* **SettingsRegistry planning** needs
  `ledger.subsystem_for_command(name)` to attribute settings to
  commands.
* **Setup wizard** will use `ledger.find(name)` + `is_declared` to
  detect command/SUBSYSTEMS drift early.

Per the approved sequence, this is step 3 (after PR-10 and PR-11).
PanelRegistry / SettingsRegistry remain planning-only and gated on
this ledger's findings being clean.

## Files changed

| File | Purpose |
|---|---|
| `disbot/core/runtime/command_surface_ledger.py` (new) | The ledger module |
| `disbot/bot1.py` | Call `command_surface_ledger.build_ledger(bot)` once after `_load_cogs()` + identity validation, before `bot.start()`. Failure is non-fatal. |
| `tests/unit/runtime/test_command_surface_ledger.py` (new) | 32 tests across builder, findings, query API, cache, diagnostics, immutability, source discipline |
| `tests/unit/runtime/test_command_surface_ledger_import_cycle.py` (new) | AST scan + fresh-interpreter import |

## Diagnostics integration

Self-registers a snapshot provider under `"command_surface_ledger"`
exposing counts + per-bucket finding counts (not the full entries
list — operators wanting detail use `get_cached_ledger()` from a REPL
or a future admin command). `!platform consistency` (PR-10) picks it
up automatically through its Runtime providers section once both PRs
land.

## Test plan

- [x] `pytest tests/unit/runtime/test_command_surface_ledger.py` — 32 passed
- [x] `pytest tests/unit/runtime/test_command_surface_ledger_import_cycle.py` — 2 passed
- [x] `pytest tests/unit` — **1452 passed, 0 failed**
- [x] `ruff check` clean on new + modified files

### Test cases covered

- [x] Cog name normalisation (`EconomyCog → "economy"`, orphan returns None)
- [x] Builder captures basic metadata
- [x] Builder records aliases verbatim
- [x] Builder records subcommand `parent_group`
- [x] Builder marks `subsystem=None` + `visibility_tier=None` for orphans
- [x] Builder reads `visibility_tier` from SUBSYSTEMS
- [x] `is_declared` flag set/unset based on SUBSYSTEMS.entry_points
- [x] Builder handles bot without `walk_commands` attribute
- [x] Findings detect duplicate command names
- [x] Findings detect alias collision with primary name
- [x] Findings detect alias collision between commands
- [x] Findings detect undeclared entry points
- [x] Findings router prefix unknown / known
- [x] `LedgerFindings.total` aggregates correctly
- [x] Query API: `by_subsystem`, `find`, `subsystem_for_command`
- [x] Cache returns None before first build; returns last build after
- [x] Diagnostics snapshot has `not_built` and `built` shapes
- [x] Ledger + entries are frozen (cannot mutate)
- [x] AST: no top-level `utils.subsystem_registry` import
- [x] AST: ledger does NOT call `validate_identity_contract`

## Manual smoke

- [ ] Bot boots cleanly.
- [ ] `!platform runtime` includes `command_surface_ledger` provider; status `built`, sensible counts, findings_total ≥ 0.
- [ ] If a future change adds an orphan cog name, `findings.orphan_cog_subsystems` surfaces it without crashing startup.
- [ ] Hot-reload a cog and re-run `command_surface_ledger.build_ledger(bot)` from REPL — cached snapshot refreshes.

## Risks and rollback

- **Risk**: `bot.walk_commands()` raises during early startup (rare). **Mitigation**: `bot1.py` wraps the call in `try/except` and logs a warning; the bot starts without the ledger.
- **Risk**: a new cog naming convention breaks the `XxxCog → xxx` mapping. **Mitigation**: surfaces as `orphan_cog_subsystems`; the cog continues to function — only the ledger sees it as orphaned.
- **Risk**: stale cache after hot-reload. **Mitigation**: `build_ledger(bot)` can be re-called at any time to refresh.
- **Rollback**: single `git revert` of the PR-12 merge commit. No migration, no persisted state, no behavior change.

## Independence from PR-10 / PR-11

Branched directly from `main` (`2bcf82d`). Does NOT depend on PR-10
or PR-11; reviewable / mergeable in any order. When PR-10 lands, the
ledger's diagnostics provider surfaces automatically in `!platform
consistency`.

## Recommended next PR

**PanelRegistry planning** (gated on this ledger's findings). The
plan proceeds only if PR-12 lands clean and the ledger's
`findings.total` is acceptably low (or all findings are explainable
and won't be regressed by a registry). Otherwise, produce a planning
doc identifying remaining gaps and stop.

## Intentionally deferred

- Slash command (`app_commands`) catalogue — `slash_entries` field
  reserved; population deferred until any slash entrypoint actually
  exists.
- PanelRegistry / SettingsRegistry / SettingsMutationPipeline.
- Setup wizard / readiness bridge.
- Role / cleanup extraction.
- Admin command to dump the ledger (use `get_cached_ledger()` in a
  REPL for now).
- Dynamic refresh on hot-reload events (manual rebuild today).
- Any flag flips.

https://claude.ai/code/session_01TgXKzat6grWjupChjL4g5A

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgXKzat6grWjupChjL4g5A)_