### PR TITLE
chore(closure): port server_logging extras-cap hardening from stale PR-11 branch

### DIFF
--- a/disbot/services/server_logging.py
+++ b/disbot/services/server_logging.py
@@ -241,6 +241,14 @@ def _root_action(action: str) -> str:
     return action.split(":", 1)[0]
 
 
+# Defensive caps so a malformed event payload cannot push the embed
+# past Discord's 25-field / 6000-char limits.  Target / Actor / Guild
+# / Reason already use 4 slots; capping extras at 6 keeps comfortable
+# headroom for future fields without re-tuning.
+_MAX_EXTRA_FIELDS = 6
+_EXTRA_VALUE_CAP = 500
+
+
 def format_log_embed(
     *,
     action: str,
@@ -252,9 +260,13 @@ def format_log_embed(
 ) -> discord.Embed:
     """Render a moderation/cleanup payload as a Discord embed.
 
-    Unknown actions render with the generic dark-grey style + a
-    ``• action: <name>`` field so subscribers never blank-render a new
-    moderation action type the service hasn't seen.
+    Unknown actions render with the generic dark-grey style so
+    subscribers never blank-render a new moderation action type the
+    service hasn't seen.  ``extras`` is capped at
+    :data:`_MAX_EXTRA_FIELDS` slots and each value is truncated to
+    :data:`_EXTRA_VALUE_CAP` chars; if more keys are supplied, a
+    single ``"... truncated"`` field reports the count so the embed
+    stays under Discord's 25-field / 6000-char limits.
     """
     root = _root_action(action)
     color = _ACTION_COLOR.get(root, discord.Color.dark_grey())
@@ -272,8 +284,20 @@ def format_log_embed(
     if reason:
         embed.add_field(name="Reason", value=reason[:1000], inline=False)
     if extras:
-        for k, v in extras.items():
-            embed.add_field(name=k, value=str(v)[:500], inline=False)
+        items = list(extras.items())
+        for k, v in items[:_MAX_EXTRA_FIELDS]:
+            embed.add_field(
+                name=str(k)[:256],
+                value=str(v)[:_EXTRA_VALUE_CAP],
+                inline=False,
+            )
+        if len(items) > _MAX_EXTRA_FIELDS:
+            dropped = len(items) - _MAX_EXTRA_FIELDS
+            embed.add_field(
+                name="… truncated",
+                value=f"{dropped} extra field(s) omitted to stay under embed limits.",
+                inline=False,
+            )
     return embed
 
 

--- a/tests/unit/services/test_server_logging.py
+++ b/tests/unit/services/test_server_logging.py
@@ -197,6 +197,51 @@ def test_format_log_embed_reason_truncated_at_1000_chars():
     assert len(reason_field.value) <= 1000
 
 
+def test_format_log_embed_caps_extras_at_max_fields():
+    """A malformed event payload must not push the embed past Discord's
+    25-field cap; extras beyond _MAX_EXTRA_FIELDS are replaced with a
+    single '... truncated' summary field."""
+    big_extras = {f"k{i}": f"v{i}" for i in range(20)}
+    embed = format_log_embed(
+        action="warn",
+        guild_id=1,
+        target_id=2,
+        actor_id=3,
+        reason="r",
+        extras=big_extras,
+    )
+    truncated_fields = [f for f in embed.fields if f.name == "… truncated"]
+    assert len(truncated_fields) == 1
+    # 4 base fields (Target/Actor/Guild/Reason) + 6 capped extras + 1 truncation note.
+    assert len(embed.fields) == 11
+    assert "14" in truncated_fields[0].value  # 20 - 6 = 14 dropped
+
+
+def test_format_log_embed_no_truncation_field_when_under_cap():
+    embed = format_log_embed(
+        action="warn",
+        guild_id=1,
+        target_id=2,
+        actor_id=3,
+        reason="r",
+        extras={"until": "2026-12-31T00:00:00+00:00"},
+    )
+    assert all(f.name != "… truncated" for f in embed.fields)
+
+
+def test_format_log_embed_extra_value_truncated_at_cap():
+    embed = format_log_embed(
+        action="warn",
+        guild_id=1,
+        target_id=2,
+        actor_id=3,
+        reason="r",
+        extras={"context": "z" * 5000},
+    )
+    ctx_field = next(f for f in embed.fields if f.name == "context")
+    assert len(ctx_field.value) <= 500
+
+
 # ---------------------------------------------------------------------------
 # resolve_log_channel
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why this PR exists

Session-closure reconciliation. PR #88 (PR-10 Consistency
Diagnostics), PR #89 (PR-11 Server Logging Foundation), and PR #90
(PR-12 Command Surface Ledger) are all merged into `main`. One small
hardening commit on the old PR-11 branch
(`claude/phase-2-pr-11-server-logging`) did not make it into the
merge of #89: the `extras`-field cap in `format_log_embed`. This PR
ports just that commit so the reconciliation between branch and
`main` is complete.

The commit was originally pushed as `675577e fix(phase-2-pr-11): cap
extras fields in format_log_embed` and is cherry-picked verbatim
here.

## What this PR changes

`services/server_logging.format_log_embed` now defends against
malformed event payloads pushing the embed past Discord's 25-field /
6000-char limits:

- `extras` is capped at **6 fields** (constant `_MAX_EXTRA_FIELDS`).
- Each extra value is truncated to **500 chars** (constant
  `_EXTRA_VALUE_CAP`).
- Extra key names are truncated to 256 chars defensively.
- When the cap is exceeded, a single `… truncated` field reports
  the dropped count so operators see the overflow rather than
  silently losing fields.

Three regression tests cover the new behaviour:

- `test_format_log_embed_caps_extras_at_max_fields`
- `test_format_log_embed_no_truncation_field_when_under_cap`
- `test_format_log_embed_extra_value_truncated_at_cap`

## What this PR does NOT change

- No migration.
- No feature flag.
- No behavior change for normal-sized payloads (a moderation event
  with one or two extras renders identically).
- No setup wizard.
- No PanelRegistry implementation or planning.
- No SettingsRegistry implementation or planning.
- No new admin commands.
- No changes to channel routing, fail-safe rules, or counters.
- No changes to any other module — diff is exactly
  `disbot/services/server_logging.py` (+34 / -5) and
  `tests/unit/services/test_server_logging.py` (+45 / -0).

## Tests run (local)

| Command | Result |
|---|---|
| `pytest tests/unit/services/test_server_logging.py tests/unit/runtime/test_server_logging_import_cycle.py` | **46 passed** |
| `pytest tests/unit/invariants/` | **107 passed** |
| `pytest tests/unit` | **1563 passed** |
| `ruff check . --exclude .github,tests,venv,env,build,dist` | All checks passed |
| `black --check . --exclude '(\.github\|tests\|venv\|env\|build\|dist)'` | 230 files unchanged |
| `isort --check-only disbot/ tests/` | clean |
| `mypy disbot/` | 231 files, 0 issues |

## Earlier PR status

All three earlier session PRs are merged into `main`:

- ✅ #88 Phase 2 PR-10: Unified Consistency & Readiness Diagnostics
- ✅ #89 Phase 2 PR-11: Server Logging Foundation (default OFF)
- ✅ #90 Phase 2 PR-12: Command Surface Ledger (read-only catalogue)

## Reconciliation re-check (after this PR's cherry-pick is applied)

| Session-scope branch | Commits ahead of `main` (pre-PR) | Commits ahead of `main` (post-PR) |
|---|---|---|
| `claude/phase-2-pr-10-platform-consistency` | 0 | 0 |
| `claude/phase-2-pr-11-server-logging` | 1 (the cherry-picked commit) | 0 |
| `claude/phase-2-pr-12-command-surface-ledger` | 0 | 0 |

This PR's cherry-pick brings the only outstanding diff onto `main`.
Once merged, every session-scope branch will be fully equivalent to
`main`. (Older non-session Claude branches still differ — that's
historical work outside this session's scope.)

https://claude.ai/code/session_01TgXKzat6grWjupChjL4g5A

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgXKzat6grWjupChjL4g5A)_