### PR TITLE
feat(s2): CustomizationCatalogue + !platform customization

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -735,6 +735,18 @@ async def main() -> None:
             except Exception as exc:
                 logger.warning("Settings registry build skipped: %s", exc)
 
+            # S2 — Customization catalogue. Composes the command surface
+            # ledger, settings registry, subsystem schemas, and live cog
+            # help-hook signals into a frozen, read-only inventory.
+            # Failure is non-fatal: the bot boots without the catalogue
+            # and `!platform customization` reports it as not-built.
+            try:
+                from services import customization_catalogue
+
+                customization_catalogue.build_catalogue(bot)
+            except Exception as exc:
+                logger.warning("Customization catalogue build skipped: %s", exc)
+
             logger.info("Starting bot...")
             await bot.start(config.DISCORD_BOT_TOKEN)
     finally:

--- a/disbot/cogs/diagnostic/_platform_embeds.py
+++ b/disbot/cogs/diagnostic/_platform_embeds.py
@@ -364,9 +364,58 @@ def build_settings_registry_embed() -> discord.Embed:
     return embed
 
 
+def build_customization_embed() -> discord.Embed:
+    """Build the embed for ``!platform customization`` (S2)."""
+    from services import diagnostics_service
+
+    snap = diagnostics_service.snapshot("customization_catalogue")
+    if snap.get("status") == "not_built":
+        return discord.Embed(
+            title="🧭 Customization catalogue",
+            description=(
+                "*(not built — call customization_catalogue.build_catalogue(bot))*"
+            ),
+            color=discord.Color.greyple(),
+        )
+    embed = discord.Embed(
+        title="🧭 Customization catalogue",
+        description=(
+            f"v{snap['version']}  ·  {snap['subsystem_count']} subsystems  ·  "
+            f"{snap['panel_count']} panels  ·  "
+            f"schemas={snap['subsystems_with_schema']}  ·  "
+            f"help_hooks={snap['subsystems_with_help_hook']}  ·  "
+            f"findings={snap['findings_total']}"
+        ),
+        color=discord.Color.blurple(),
+    )
+    panels_by_source = snap.get("panels_by_source") or {}
+    if panels_by_source:
+        lines = [
+            f"`{src}` — {count}" for src, count in sorted(panels_by_source.items())
+        ]
+        embed.add_field(
+            name="Panels by detection source",
+            value="\n".join(lines)[:1024],
+            inline=False,
+        )
+    findings = snap.get("findings") or {}
+    if findings and snap.get("findings_total"):
+        finding_lines = [
+            f"`{key}`: {count}" for key, count in sorted(findings.items()) if count
+        ]
+        if finding_lines:
+            embed.add_field(
+                name="Findings",
+                value="\n".join(finding_lines)[:1024],
+                inline=False,
+            )
+    return embed
+
+
 __all__ = [
     "build_bindings_embed",
     "build_consistency_embed",
+    "build_customization_embed",
     "build_resources_embed",
     "build_schemas_embed",
     "build_settings_registry_embed",

--- a/disbot/cogs/diagnostic_cog.py
+++ b/disbot/cogs/diagnostic_cog.py
@@ -568,6 +568,14 @@ class DiagnosticCog(commands.Cog):
 
         await ctx.send(embed=build_settings_registry_embed())
 
+    @platform_grp.command(name="customization")  # type: ignore[arg-type]
+    @commands.has_permissions(administrator=True)
+    async def platform_customization(self, ctx):
+        """Customization catalogue across subsystems (S2)."""
+        from cogs.diagnostic._platform_embeds import build_customization_embed
+
+        await ctx.send(embed=build_customization_embed())
+
     @platform_grp.command(name="participation-schemas")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def platform_participation_schemas(self, ctx):

--- a/disbot/services/customization_catalogue.py
+++ b/disbot/services/customization_catalogue.py
@@ -1,0 +1,545 @@
+"""Customization catalogue — S2 of the Global Settings & Customization Manager.
+
+A read-only, frozen catalogue that composes existing platform primitives
+into one queryable inventory of every subsystem's customization surface.
+
+Sources combined (all read-only):
+
+* :mod:`core.runtime.command_surface_ledger` — live commands per subsystem.
+* :mod:`core.runtime.settings_registry` — declared :class:`SettingSpec`s.
+* :mod:`core.runtime.subsystem_schema` — :class:`BindingSpec` and
+  :class:`ResourceRequirement` declarations per subsystem.
+* :data:`utils.subsystem_registry.SUBSYSTEMS` — display metadata,
+  ``entry_points``, ``visibility_tier``, ``related_subsystems``.
+* :mod:`services.diagnostics_service` — registered diagnostics provider
+  names (cross-discoverability signal).
+* live ``bot.cogs`` — cogs implementing ``build_help_menu_view`` (the
+  canonical help direct-navigation hook).
+* live ``bot.walk_commands()`` — commands carrying ``extras["panel"] is
+  True`` (the :func:`panel_command` decorator landing alongside this
+  module).
+
+Panel-detection priority (authoritative first; regex is last-resort):
+
+1. ``ledger_extras`` — command tagged ``extras["panel"] = True`` via the
+   :func:`panel_command` decorator. Existing panel commands will gain
+   this tag in S5/S10; today no commands carry it.
+2. ``help_hook`` — cog implements ``build_help_menu_view``. A synthetic
+   panel record with ``command="<build_help_menu_view>"`` is created.
+3. ``known_list`` — entries in :data:`KNOWN_PANEL_COMMANDS`. Curated
+   tuple covering cogs that predate the ``@panel_command`` decorator.
+4. ``regex_fallback`` — command name matches ``r".+menu$"``. Always
+   surfaced as a ``regex_inferred_panels`` finding so operators can
+   migrate it to an explicit declaration.
+
+(A future ``panel_registry`` source slots between (3) and (4) once the
+PanelRegistry primitive lands; not in S2 scope.)
+
+Diagnostics provider name: ``"customization_catalogue"``.
+
+Cycle discipline (mirrors :mod:`services.platform_consistency`): all
+cross-package imports are function-local. Top-level imports are
+stdlib only. Verified by
+``tests/unit/services/test_customization_catalogue_import_cycle.py``.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any, TypeVar
+
+logger = logging.getLogger("bot.services.customization_catalogue")
+
+
+_CATALOGUE_VERSION = 1
+
+
+# A panel command's command name (bare or qualified). Applied to the
+# last whitespace-separated segment so subcommands like
+# ``platform schemas`` are evaluated against ``schemas`` rather than
+# the whole qualified name.
+_PANEL_REGEX = re.compile(r".+menu$")
+
+
+# Curated allowlist of (subsystem, command_name) pairs for cogs that
+# predate the ``@panel_command`` decorator. Newly-added panels SHOULD
+# use the decorator; this list is the floor.
+#
+# An entry here only counts as a panel when the command is actually
+# present in the live command surface ledger (i.e. the cog loaded
+# successfully). Stale entries are silently ignored.
+KNOWN_PANEL_COMMANDS: tuple[tuple[str, str], ...] = (
+    ("admin", "adminmenu"),
+    ("chain", "chainmenu"),
+    ("channel", "channelmenu"),
+    ("cleanup", "wordmenu"),
+    ("counting", "countingmenu"),
+    ("economy", "economymenu"),
+    ("general", "generalmenu"),
+    ("mining", "minemenu"),
+    ("moderation", "modmenu"),
+    ("proof_channel", "prizemenu"),
+    ("role", "rolemenu"),
+    ("utility", "utilitymenu"),
+    ("xp", "xpmenu"),
+)
+
+
+_C = TypeVar("_C")
+
+
+def panel_command(cmd: _C) -> _C:
+    """Decorator marking a command as a subsystem panel entry point.
+
+    Sets ``cmd.extras["panel"] = True`` on the underlying command so
+    :func:`build_catalogue` can detect it via the ``ledger_extras``
+    source. Future S5/S10 work tags existing panels with this; today
+    no commands carry it.
+
+    Usage — apply ABOVE ``@commands.command(...)`` so the decorator
+    receives the :class:`~discord.ext.commands.Command` instance::
+
+        @panel_command
+        @commands.command(name="mymenu")
+        async def mymenu(self, ctx):
+            ...
+
+    A best-effort attempt is made when applied below ``@commands.command``
+    (i.e. to a bare coroutine) — the panel flag is set on the function
+    but discord.py won't propagate it onto the resulting Command. Prefer
+    the documented order.
+    """
+    extras = getattr(cmd, "extras", None)
+    if extras is None:
+        try:
+            cmd.extras = {"panel": True}  # type: ignore[attr-defined]
+        except (AttributeError, TypeError):  # pragma: no cover - defensive
+            pass
+    else:
+        try:
+            extras["panel"] = True
+        except (AttributeError, TypeError):  # pragma: no cover - defensive
+            pass
+    return cmd
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PanelDeclaration:
+    """A single detected panel for a subsystem.
+
+    ``source`` is one of ``"ledger_extras" | "help_hook" | "known_list" |
+    "regex_fallback"`` and records the highest-priority detection source
+    that flagged the panel.
+    """
+
+    command: str
+    source: str
+
+
+@dataclass(frozen=True)
+class CustomizationEntry:
+    """A single subsystem's aggregated customization snapshot."""
+
+    subsystem: str
+    display_name: str
+    visibility_tier: str | None
+    has_schema: bool
+    has_help_hook: bool
+    has_diagnostics_provider: bool
+    panels: tuple[PanelDeclaration, ...]
+    setting_names: tuple[str, ...]
+    binding_names: tuple[str, ...]
+    resource_intents: tuple[str, ...]
+    command_count: int
+    related_subsystems: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CustomizationFindings:
+    """Cross-cutting findings computed at build time."""
+
+    subsystems_missing_panel: tuple[str, ...] = ()
+    subsystems_missing_help_hook: tuple[str, ...] = ()
+    subsystems_missing_schema: tuple[str, ...] = ()
+    panels_without_settings: tuple[str, ...] = ()
+    settings_without_panel: tuple[str, ...] = ()
+    regex_inferred_panels: tuple[str, ...] = ()
+    undiscoverable_surfaces: tuple[str, ...] = ()
+
+    @property
+    def total(self) -> int:
+        return (
+            len(self.subsystems_missing_panel)
+            + len(self.subsystems_missing_help_hook)
+            + len(self.subsystems_missing_schema)
+            + len(self.panels_without_settings)
+            + len(self.settings_without_panel)
+            + len(self.regex_inferred_panels)
+            + len(self.undiscoverable_surfaces)
+        )
+
+
+@dataclass(frozen=True)
+class CustomizationCatalogue:
+    """An immutable snapshot of the customization surface at build time."""
+
+    version: int
+    built_at: datetime.datetime
+    entries: tuple[CustomizationEntry, ...]
+    findings: CustomizationFindings
+
+    def get(self, subsystem: str) -> CustomizationEntry | None:
+        for entry in self.entries:
+            if entry.subsystem == subsystem:
+                return entry
+        return None
+
+    def panels(self) -> tuple[PanelDeclaration, ...]:
+        out: list[PanelDeclaration] = []
+        for entry in self.entries:
+            out.extend(entry.panels)
+        return tuple(out)
+
+    def by_panel_count(self) -> dict[str, int]:
+        return {entry.subsystem: len(entry.panels) for entry in self.entries}
+
+
+# ---------------------------------------------------------------------------
+# Module state — cached last-built catalogue
+# ---------------------------------------------------------------------------
+
+
+_CACHED: CustomizationCatalogue | None = None
+
+
+def _reset_for_tests() -> None:
+    global _CACHED
+    _CACHED = None
+
+
+# ---------------------------------------------------------------------------
+# Builder helpers
+# ---------------------------------------------------------------------------
+
+
+_KEYWORDS_UNDISCOVERABLE = ("settings", "config", "policy")
+
+
+def _walk_help_hooks(bot: object) -> set[str]:
+    """Return the set of subsystems whose cog implements
+    ``build_help_menu_view``.
+    """
+    from core.runtime.command_surface_ledger import cog_name_to_subsystem
+
+    out: set[str] = set()
+    cogs = getattr(bot, "cogs", None) or {}
+    for cog in cogs.values():
+        if not callable(getattr(cog, "build_help_menu_view", None)):
+            continue
+        sub = cog_name_to_subsystem(cog.__class__.__name__)
+        if sub:
+            out.add(sub)
+    return out
+
+
+def _walk_extras_panels(bot: object) -> set[tuple[str, str]]:
+    """Return ``{(subsystem, qualified_name)}`` for every command marked
+    ``extras["panel"] is True`` (i.e. tagged by :func:`panel_command`).
+    """
+    from core.runtime.command_surface_ledger import cog_name_to_subsystem
+
+    walk = getattr(bot, "walk_commands", None)
+    if walk is None:
+        return set()
+    out: set[tuple[str, str]] = set()
+    for cmd in walk():
+        extras = getattr(cmd, "extras", None) or {}
+        if extras.get("panel") is not True:
+            continue
+        cog = getattr(cmd, "cog", None)
+        cog_name = cog.__class__.__name__ if cog is not None else ""
+        sub = cog_name_to_subsystem(cog_name) if cog_name else None
+        if sub:
+            qualified = getattr(cmd, "qualified_name", None) or cmd.name
+            out.add((sub, qualified))
+    return out
+
+
+def _ledger_commands_by_subsystem(ledger: Any) -> dict[str, list[str]]:
+    """Group ledger entries by subsystem. ``ledger`` may be ``None``."""
+    if ledger is None:
+        return {}
+    out: dict[str, list[str]] = {}
+    for entry in getattr(ledger, "entries", ()):
+        sub = getattr(entry, "subsystem", None)
+        if sub is None:
+            continue
+        out.setdefault(sub, []).append(entry.name)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Builder
+# ---------------------------------------------------------------------------
+
+
+def build_catalogue(bot: object | None = None) -> CustomizationCatalogue:
+    """Walk every authoritative source and return a frozen snapshot.
+
+    ``bot`` is optional. When provided, the builder additionally walks
+    ``bot.cogs`` for ``build_help_menu_view`` hooks and
+    ``bot.walk_commands()`` for ``@panel_command`` ``extras["panel"]``
+    declarations. When ``bot is None`` those two signals are skipped
+    and ``subsystems_missing_help_hook`` stays empty (we have no
+    information rather than a false negative).
+
+    Caches the result for diagnostics access; call again to refresh
+    after a hot-reload. Sync — no I/O.
+    """
+    from core.runtime import command_surface_ledger as _cls
+    from core.runtime import settings_registry as _sr
+    from core.runtime import subsystem_schema as _ss
+    from services import diagnostics_service as _ds
+    from utils.subsystem_registry import SUBSYSTEMS
+
+    ledger = _cls.get_cached_ledger()
+    registry = _sr.get_cached_registry()
+    schemas = _ss.all_schemas()
+    diag_provider_names = set(_ds.registered_names())
+    ledger_cmds_by_sub = _ledger_commands_by_subsystem(ledger)
+
+    help_hook_subsystems = _walk_help_hooks(bot) if bot is not None else set()
+    extras_panel_pairs = _walk_extras_panels(bot) if bot is not None else set()
+
+    known_by_sub: dict[str, set[str]] = {}
+    for sub, cmd in KNOWN_PANEL_COMMANDS:
+        known_by_sub.setdefault(sub, set()).add(cmd)
+
+    entries: list[CustomizationEntry] = []
+    regex_inferred: list[str] = []
+    panels_without_settings: list[str] = []
+    settings_without_panel: list[str] = []
+    missing_panel: list[str] = []
+    missing_help_hook: list[str] = []
+    missing_schema: list[str] = []
+
+    for sub_name in sorted(SUBSYSTEMS):
+        meta = SUBSYSTEMS[sub_name]
+        schema = schemas.get(sub_name)
+
+        if registry is not None:
+            setting_names = tuple(e.name for e in registry.by_subsystem(sub_name))
+        else:
+            setting_names = tuple(s.name for s in (schema.settings if schema else ()))
+        binding_names = tuple(b.name for b in (schema.bindings if schema else ()))
+        resource_intents = tuple(
+            r.intent for r in (schema.resource_requirements if schema else ())
+        )
+
+        ledger_cmds = ledger_cmds_by_sub.get(sub_name, [])
+        command_count = len(ledger_cmds)
+        ledger_cmd_set = set(ledger_cmds)
+
+        # Panel detection — priority: ledger_extras > help_hook > known_list > regex.
+        panels: list[PanelDeclaration] = []
+        seen_commands: set[str] = set()
+
+        # (1) ledger_extras — @panel_command tagged commands
+        for s, cmd in sorted(extras_panel_pairs):
+            if s != sub_name or cmd in seen_commands:
+                continue
+            panels.append(PanelDeclaration(command=cmd, source="ledger_extras"))
+            seen_commands.add(cmd)
+
+        # (2) help_hook — synthetic panel for cogs implementing the hook
+        if sub_name in help_hook_subsystems:
+            panels.append(
+                PanelDeclaration(
+                    command="<build_help_menu_view>",
+                    source="help_hook",
+                ),
+            )
+
+        # (3) known_list — curated panel commands. Only count when the
+        # command actually appears in the live ledger; absence means the
+        # cog failed to load (or hasn't loaded yet at REPL/test time).
+        for cmd in sorted(known_by_sub.get(sub_name, ())):
+            if cmd in seen_commands:
+                continue
+            if ledger is not None and cmd in ledger_cmd_set:
+                panels.append(PanelDeclaration(command=cmd, source="known_list"))
+                seen_commands.add(cmd)
+
+        # (4) regex_fallback — commands ending in "menu" not already
+        # detected by a higher-priority source.
+        for cmd in sorted(ledger_cmds):
+            bare = cmd.split()[-1] if cmd else ""
+            if not _PANEL_REGEX.match(bare):
+                continue
+            if cmd in seen_commands:
+                continue
+            panels.append(PanelDeclaration(command=cmd, source="regex_fallback"))
+            seen_commands.add(cmd)
+            regex_inferred.append(f"{sub_name}.{cmd}")
+
+        if not panels:
+            missing_panel.append(sub_name)
+        if bot is not None and sub_name not in help_hook_subsystems:
+            missing_help_hook.append(sub_name)
+        if schema is None:
+            missing_schema.append(sub_name)
+        if panels and not setting_names and not binding_names and not resource_intents:
+            for p in panels:
+                panels_without_settings.append(f"{sub_name}.{p.command}")
+        if setting_names and not panels:
+            for s in setting_names:
+                settings_without_panel.append(f"{sub_name}.{s}")
+
+        entries.append(
+            CustomizationEntry(
+                subsystem=sub_name,
+                display_name=str(meta.get("display_name", sub_name)),
+                visibility_tier=meta.get("visibility_tier"),
+                has_schema=schema is not None,
+                has_help_hook=sub_name in help_hook_subsystems,
+                has_diagnostics_provider=sub_name in diag_provider_names,
+                panels=tuple(panels),
+                setting_names=setting_names,
+                binding_names=binding_names,
+                resource_intents=resource_intents,
+                command_count=command_count,
+                related_subsystems=tuple(meta.get("related_subsystems", ())),
+            ),
+        )
+
+    # Undiscoverable surfaces: settings/config/policy commands whose
+    # owning subsystem has neither a panel nor a help-hook AND whose
+    # name is not already an explicit entry_point. Identifies admin
+    # commands that ship without a route through help/admin/platform.
+    undiscoverable: list[str] = []
+    entries_by_sub = {e.subsystem: e for e in entries}
+    if ledger is not None:
+        for entry in getattr(ledger, "entries", ()):
+            sub = getattr(entry, "subsystem", None)
+            if sub is None:
+                continue
+            cat_entry = entries_by_sub.get(sub)
+            if cat_entry is None:
+                continue
+            name_lower = entry.name.lower()
+            if not any(tok in name_lower for tok in _KEYWORDS_UNDISCOVERABLE):
+                continue
+            if cat_entry.panels or cat_entry.has_help_hook:
+                continue
+            meta = SUBSYSTEMS.get(sub, {})
+            if entry.name in (meta.get("entry_points") or ()):
+                continue
+            undiscoverable.append(f"{sub}.{entry.name}")
+
+    findings = CustomizationFindings(
+        subsystems_missing_panel=tuple(sorted(missing_panel)),
+        subsystems_missing_help_hook=tuple(sorted(missing_help_hook)),
+        subsystems_missing_schema=tuple(sorted(missing_schema)),
+        panels_without_settings=tuple(sorted(panels_without_settings)),
+        settings_without_panel=tuple(sorted(settings_without_panel)),
+        regex_inferred_panels=tuple(sorted(regex_inferred)),
+        undiscoverable_surfaces=tuple(sorted(undiscoverable)),
+    )
+
+    cat = CustomizationCatalogue(
+        version=_CATALOGUE_VERSION,
+        built_at=datetime.datetime.now(tz=datetime.timezone.utc),
+        entries=tuple(entries),
+        findings=findings,
+    )
+    global _CACHED
+    _CACHED = cat
+    logger.info(
+        "customization_catalogue: built v%d — %d subsystems, %d panels, " "%d findings",
+        cat.version,
+        len(cat.entries),
+        sum(len(e.panels) for e in cat.entries),
+        findings.total,
+    )
+    return cat
+
+
+def get_cached_catalogue() -> CustomizationCatalogue | None:
+    """Return the last-built catalogue, or ``None`` if not yet built."""
+    return _CACHED
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics provider — registers at import time
+# ---------------------------------------------------------------------------
+
+
+def _snapshot() -> dict[str, Any]:
+    """Stable diagnostics snapshot for ``!platform customization``.
+
+    Returns counts + findings counts only. Operators wanting the full
+    entries list call :func:`get_cached_catalogue` from a REPL or a
+    future admin command.
+    """
+    cat = _CACHED
+    if cat is None:
+        return {
+            "status": "not_built",
+            "hint": "call customization_catalogue.build_catalogue(bot) after cogs load.",
+        }
+    panel_count = sum(len(e.panels) for e in cat.entries)
+    panels_by_source: dict[str, int] = {}
+    for entry in cat.entries:
+        for p in entry.panels:
+            panels_by_source[p.source] = panels_by_source.get(p.source, 0) + 1
+    return {
+        "status": "built",
+        "version": cat.version,
+        "built_at": cat.built_at.isoformat(),
+        "subsystem_count": len(cat.entries),
+        "panel_count": panel_count,
+        "panels_by_source": panels_by_source,
+        "subsystems_with_schema": sum(1 for e in cat.entries if e.has_schema),
+        "subsystems_with_help_hook": sum(1 for e in cat.entries if e.has_help_hook),
+        "findings_total": cat.findings.total,
+        "findings": {
+            "subsystems_missing_panel": len(cat.findings.subsystems_missing_panel),
+            "subsystems_missing_help_hook": len(
+                cat.findings.subsystems_missing_help_hook,
+            ),
+            "subsystems_missing_schema": len(cat.findings.subsystems_missing_schema),
+            "panels_without_settings": len(cat.findings.panels_without_settings),
+            "settings_without_panel": len(cat.findings.settings_without_panel),
+            "regex_inferred_panels": len(cat.findings.regex_inferred_panels),
+            "undiscoverable_surfaces": len(cat.findings.undiscoverable_surfaces),
+        },
+    }
+
+
+def _register_diagnostics() -> None:
+    from services import diagnostics_service
+
+    diagnostics_service.register("customization_catalogue", _snapshot)
+
+
+_register_diagnostics()
+
+
+__all__: list[str] = [
+    "CustomizationCatalogue",
+    "CustomizationEntry",
+    "CustomizationFindings",
+    "KNOWN_PANEL_COMMANDS",
+    "PanelDeclaration",
+    "build_catalogue",
+    "get_cached_catalogue",
+    "panel_command",
+]

--- a/disbot/services/customization_catalogue.py
+++ b/disbot/services/customization_catalogue.py
@@ -463,7 +463,7 @@ def build_catalogue(bot: object | None = None) -> CustomizationCatalogue:
     global _CACHED
     _CACHED = cat
     logger.info(
-        "customization_catalogue: built v%d — %d subsystems, %d panels, " "%d findings",
+        "customization_catalogue: built v%d — %d subsystems, %d panels, %d findings",
         cat.version,
         len(cat.entries),
         sum(len(e.panels) for e in cat.entries),

--- a/tests/unit/services/test_customization_catalogue.py
+++ b/tests/unit/services/test_customization_catalogue.py
@@ -1,0 +1,701 @@
+"""Unit tests for services.customization_catalogue — S2.
+
+Covers builder behavior, panel detection priority, findings buckets,
+immutability, query API, the diagnostics provider, and the
+``@panel_command`` decorator.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from core.runtime import command_surface_ledger as ledger_mod
+from core.runtime import settings_registry as registry_mod
+from core.runtime import subsystem_schema as schema_mod
+from core.runtime.command_surface_ledger import (
+    CommandSurfaceEntry,
+    CommandSurfaceLedger,
+    LedgerFindings,
+)
+from core.runtime.subsystem_schema import (
+    BindingKind,
+    BindingSpec,
+    SettingSpec,
+    SubsystemSchema,
+)
+from services import customization_catalogue as cat_mod
+from services.customization_catalogue import (
+    KNOWN_PANEL_COMMANDS,
+    CustomizationCatalogue,
+    CustomizationEntry,
+    CustomizationFindings,
+    PanelDeclaration,
+    build_catalogue,
+    get_cached_catalogue,
+    panel_command,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — snapshot live module state around each test to stay isolated.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    saved_schemas = schema_mod.all_schemas()
+    schema_mod._reset_for_tests()
+    registry_mod._reset_for_tests()
+    ledger_mod._reset_for_tests()
+    cat_mod._reset_for_tests()
+    yield
+    schema_mod._reset_for_tests()
+    for schema in saved_schemas.values():
+        schema_mod.register(schema)
+    registry_mod._reset_for_tests()
+    ledger_mod._reset_for_tests()
+    cat_mod._reset_for_tests()
+
+
+def _make_ledger(*entries: CommandSurfaceEntry) -> CommandSurfaceLedger:
+    return CommandSurfaceLedger(
+        version=1,
+        built_at=datetime.datetime.now(tz=datetime.timezone.utc),
+        entries=tuple(entries),
+        router_prefixes=(),
+        findings=LedgerFindings(),
+    )
+
+
+def _entry(name: str, cog_name: str, subsystem: str | None) -> CommandSurfaceEntry:
+    """Build a CommandSurfaceEntry with the visibility_tier required field."""
+    return CommandSurfaceEntry(
+        name=name,
+        cog_name=cog_name,
+        subsystem=subsystem,
+        visibility_tier=None,
+    )
+
+
+def _inject_ledger(ledger: CommandSurfaceLedger) -> None:
+    ledger_mod._CACHED = ledger
+
+
+class _FakeCog:
+    """Minimal stand-in for a Discord cog with optional help-hook + commands."""
+
+    def __init__(
+        self,
+        class_name: str,
+        *,
+        has_help_hook: bool = False,
+        commands_: tuple[object, ...] = (),
+    ) -> None:
+        self.__class__ = type(class_name, (object,), {})
+        if has_help_hook:
+            async def build_help_menu_view(_self, _interaction):  # noqa: ARG001
+                return None, None
+
+            self.build_help_menu_view = build_help_menu_view.__get__(  # type: ignore[attr-defined]
+                self,
+                self.__class__,
+            )
+        self._commands = commands_
+
+    def get_commands(self):  # pragma: no cover - parity with discord.py
+        return self._commands
+
+
+class _FakeCommand:
+    """Minimal stand-in for a discord.py Command."""
+
+    def __init__(self, name: str, *, extras: dict | None = None, cog=None) -> None:
+        self.name = name
+        self.qualified_name = name
+        self.extras = extras if extras is not None else {}
+        self.cog = cog
+        self.aliases: tuple[str, ...] = ()
+
+
+class _FakeBot:
+    """Minimal stand-in for a commands.Bot with .cogs and .walk_commands."""
+
+    def __init__(
+        self,
+        cogs: dict[str, _FakeCog] | None = None,
+        commands_: tuple[_FakeCommand, ...] = (),
+    ) -> None:
+        self.cogs = cogs or {}
+        self._commands = commands_
+
+    def walk_commands(self):
+        yield from self._commands
+
+
+# ---------------------------------------------------------------------------
+# Empty inputs
+# ---------------------------------------------------------------------------
+
+
+def test_build_catalogue_returns_frozen_snapshot():
+    cat = build_catalogue()
+    assert isinstance(cat, CustomizationCatalogue)
+    assert cat.version == 1
+    assert isinstance(cat.built_at, datetime.datetime)
+
+
+def test_build_catalogue_covers_every_subsystem():
+    """Even with no ledger/registry/schemas, every subsystem gets an entry."""
+    from utils.subsystem_registry import SUBSYSTEMS
+
+    cat = build_catalogue()
+    assert {e.subsystem for e in cat.entries} == set(SUBSYSTEMS)
+
+
+def test_get_cached_catalogue_returns_none_before_first_build():
+    assert get_cached_catalogue() is None
+
+
+def test_get_cached_catalogue_returns_last_built():
+    cat = build_catalogue()
+    assert get_cached_catalogue() is cat
+
+
+# ---------------------------------------------------------------------------
+# Composition with the existing primitives
+# ---------------------------------------------------------------------------
+
+
+def test_entries_carry_schema_signal_from_subsystem_schema():
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="economy",
+            settings=(SettingSpec(name="daily", value_type=int, default=86400),),
+        ),
+    )
+    cat = build_catalogue()
+    entry = cat.get("economy")
+    assert entry is not None
+    assert entry.has_schema is True
+    assert entry.setting_names == ("daily",)
+    # Subsystems without schemas keep has_schema=False.
+    assert cat.get("blackjack").has_schema is False  # type: ignore[union-attr]
+
+
+def test_setting_names_prefer_registry_over_schema_when_built():
+    """When SettingsRegistry has been built, the catalogue uses it as the
+    authoritative source for setting names."""
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="xp",
+            settings=(
+                SettingSpec(name="xp_min", value_type=int, default=1),
+                SettingSpec(name="xp_max", value_type=int, default=10),
+            ),
+        ),
+    )
+    registry_mod.build_registry()
+    cat = build_catalogue()
+    entry = cat.get("xp")
+    assert entry is not None
+    assert set(entry.setting_names) == {"xp_min", "xp_max"}
+
+
+def test_bindings_and_resource_intents_carried_from_schema():
+    from core.runtime.resource_specs import (
+        ProvisioningHint,
+        ProvisioningPriority,
+        ResourceKind,
+        ResourceRequirement,
+    )
+
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="moderation",
+            bindings=(
+                BindingSpec(
+                    name="mod_log",
+                    kind=BindingKind.CHANNEL,
+                    required=False,
+                    hint="mod log target",
+                    capability_required="moderation.log.view",
+                ),
+            ),
+            resource_requirements=(
+                ResourceRequirement(
+                    kind=ResourceKind.CHANNEL,
+                    intent="mod_log",
+                    provisioning=ProvisioningHint(
+                        priority=ProvisioningPriority.RECOMMENDED,
+                        suggested_name="mod-logs",
+                    ),
+                    binding_name="mod_log",
+                ),
+            ),
+        ),
+    )
+    cat = build_catalogue()
+    entry = cat.get("moderation")
+    assert entry is not None
+    assert entry.binding_names == ("mod_log",)
+    assert entry.resource_intents == ("mod_log",)
+
+
+def test_command_count_reflects_ledger():
+    _inject_ledger(
+        _make_ledger(
+            _entry("warn", "ModerationCog", "moderation"),
+            _entry("modmenu", "ModerationCog", "moderation"),
+            _entry("kick", "ModerationCog", "moderation"),
+        ),
+    )
+    cat = build_catalogue()
+    entry = cat.get("moderation")
+    assert entry is not None
+    assert entry.command_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Panel detection — priority order and source labels
+# ---------------------------------------------------------------------------
+
+
+def test_known_list_panel_detected_when_command_exists_in_ledger():
+    _inject_ledger(
+        _make_ledger(
+            _entry("modmenu", "ModerationCog", "moderation"),
+        ),
+    )
+    cat = build_catalogue()
+    entry = cat.get("moderation")
+    assert entry is not None
+    sources = [p.source for p in entry.panels]
+    assert "known_list" in sources
+    assert any(p.command == "modmenu" for p in entry.panels)
+
+
+def test_known_list_panel_skipped_when_command_absent_from_ledger():
+    _inject_ledger(_make_ledger())  # empty ledger
+    cat = build_catalogue()
+    entry = cat.get("moderation")
+    assert entry is not None
+    # No known list match since "modmenu" isn't in the ledger.
+    assert not any(p.source == "known_list" for p in entry.panels)
+
+
+def test_help_hook_synthetic_panel_added_when_cog_implements_hook():
+    cog = _FakeCog("ModerationCog", has_help_hook=True)
+    bot = _FakeBot(cogs={"ModerationCog": cog})
+    cat = build_catalogue(bot=bot)
+    entry = cat.get("moderation")
+    assert entry is not None
+    assert entry.has_help_hook is True
+    assert any(
+        p.source == "help_hook" and p.command == "<build_help_menu_view>"
+        for p in entry.panels
+    )
+
+
+def test_help_hook_skipped_when_cog_lacks_hook():
+    cog = _FakeCog("ModerationCog", has_help_hook=False)
+    bot = _FakeBot(cogs={"ModerationCog": cog})
+    cat = build_catalogue(bot=bot)
+    entry = cat.get("moderation")
+    assert entry is not None
+    assert entry.has_help_hook is False
+
+
+def test_ledger_extras_detected_for_panel_command_decorated_command():
+    cog = _FakeCog("ModerationCog")
+    cmd = _FakeCommand("modmenu", extras={"panel": True}, cog=cog)
+    bot = _FakeBot(cogs={"ModerationCog": cog}, commands_=(cmd,))
+    _inject_ledger(
+        _make_ledger(
+            _entry("modmenu", "ModerationCog", "moderation"),
+        ),
+    )
+    cat = build_catalogue(bot=bot)
+    entry = cat.get("moderation")
+    assert entry is not None
+    # Ledger_extras outranks the known_list — same command, higher priority.
+    panel_for_cmd = [p for p in entry.panels if p.command == "modmenu"]
+    assert len(panel_for_cmd) == 1
+    assert panel_for_cmd[0].source == "ledger_extras"
+
+
+def test_regex_fallback_for_menu_commands_not_in_known_list():
+    """A *menu command not in KNOWN_PANEL_COMMANDS triggers regex_fallback
+    and is recorded in regex_inferred_panels findings."""
+    _inject_ledger(
+        _make_ledger(
+            # mining is in known list but use a different name to exercise regex
+            _entry("oremenu", "MiningCog", "mining"),
+        ),
+    )
+    cat = build_catalogue()
+    entry = cat.get("mining")
+    assert entry is not None
+    sources = [p.source for p in entry.panels]
+    assert "regex_fallback" in sources
+    assert "mining.oremenu" in cat.findings.regex_inferred_panels
+
+
+def test_detection_priority_orders_sources_correctly():
+    """When the same command is eligible under multiple sources, the
+    higher-priority source wins and is recorded only once."""
+    cog = _FakeCog("ModerationCog", has_help_hook=True)
+    # Decorated panel command — ledger_extras source
+    cmd = _FakeCommand("modmenu", extras={"panel": True}, cog=cog)
+    bot = _FakeBot(cogs={"ModerationCog": cog}, commands_=(cmd,))
+    _inject_ledger(
+        _make_ledger(
+            _entry("modmenu", "ModerationCog", "moderation"),
+        ),
+    )
+    cat = build_catalogue(bot=bot)
+    entry = cat.get("moderation")
+    assert entry is not None
+    # modmenu should appear exactly once with the highest-priority source.
+    same_cmd_panels = [p for p in entry.panels if p.command == "modmenu"]
+    assert len(same_cmd_panels) == 1
+    assert same_cmd_panels[0].source == "ledger_extras"
+    # The help_hook synthetic panel is a different command name and still
+    # appears alongside.
+    assert any(
+        p.source == "help_hook" and p.command == "<build_help_menu_view>"
+        for p in entry.panels
+    )
+
+
+def test_regex_fallback_does_not_override_known_list():
+    """A *menu command that also appears in KNOWN_PANEL_COMMANDS is
+    classified as known_list, not regex_fallback."""
+    _inject_ledger(
+        _make_ledger(
+            _entry("xpmenu", "XPCog", "xp"),
+        ),
+    )
+    cat = build_catalogue()
+    entry = cat.get("xp")
+    assert entry is not None
+    panel_for_cmd = [p for p in entry.panels if p.command == "xpmenu"]
+    assert len(panel_for_cmd) == 1
+    assert panel_for_cmd[0].source == "known_list"
+    assert "xp.xpmenu" not in cat.findings.regex_inferred_panels
+
+
+def test_bot_none_skips_help_hook_signal():
+    """When bot is None, missing_help_hook stays empty (no information)."""
+    cat = build_catalogue(bot=None)
+    assert cat.findings.subsystems_missing_help_hook == ()
+    assert all(e.has_help_hook is False for e in cat.entries)
+
+
+def test_bot_with_help_hook_populates_missing_help_hook_finding():
+    """When some cogs have the hook and others don't, the missing-hook
+    finding lists the ones without it."""
+    cog_with = _FakeCog("ModerationCog", has_help_hook=True)
+    cog_without = _FakeCog("EconomyCog", has_help_hook=False)
+    bot = _FakeBot(cogs={"ModerationCog": cog_with, "EconomyCog": cog_without})
+    cat = build_catalogue(bot=bot)
+    missing = cat.findings.subsystems_missing_help_hook
+    assert "moderation" not in missing
+    assert "economy" in missing
+
+
+# ---------------------------------------------------------------------------
+# Findings buckets
+# ---------------------------------------------------------------------------
+
+
+def test_subsystems_missing_panel_finding_populated():
+    """No ledger entries + no help hooks → every subsystem missing a panel."""
+    from utils.subsystem_registry import SUBSYSTEMS
+
+    cat = build_catalogue(bot=None)
+    assert set(cat.findings.subsystems_missing_panel) == set(SUBSYSTEMS)
+
+
+def test_subsystems_missing_schema_finding_populated():
+    """No schemas registered → every subsystem missing a schema."""
+    from utils.subsystem_registry import SUBSYSTEMS
+
+    cat = build_catalogue()
+    assert set(cat.findings.subsystems_missing_schema) == set(SUBSYSTEMS)
+
+
+def test_panels_without_settings_finding_populated():
+    """A subsystem with a panel but no settings/bindings/resources is
+    surfaced — its panel doesn't link to any customization data."""
+    _inject_ledger(
+        _make_ledger(
+            _entry("adminmenu", "AdminCog", "admin"),
+        ),
+    )
+    cat = build_catalogue()
+    # admin has no schema → panels_without_settings flagged.
+    assert any(
+        s.startswith("admin.") for s in cat.findings.panels_without_settings
+    )
+
+
+def test_settings_without_panel_finding_populated():
+    """A subsystem with settings but no detected panels is surfaced."""
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="xp",
+            settings=(SettingSpec(name="xp_min", value_type=int, default=1),),
+        ),
+    )
+    # No ledger, no bot — XP has no panel detected.
+    cat = build_catalogue(bot=None)
+    assert "xp.xp_min" in cat.findings.settings_without_panel
+
+
+def test_settings_without_panel_cleared_when_panel_detected():
+    """When a known panel is detected, settings_without_panel does NOT
+    list the subsystem's settings."""
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="xp",
+            settings=(SettingSpec(name="xp_min", value_type=int, default=1),),
+        ),
+    )
+    _inject_ledger(
+        _make_ledger(
+            _entry("xpmenu", "XPCog", "xp"),
+        ),
+    )
+    cat = build_catalogue()
+    assert "xp.xp_min" not in cat.findings.settings_without_panel
+
+
+def test_regex_inferred_panels_finding_populated():
+    _inject_ledger(
+        _make_ledger(
+            _entry("ghostmenu", "MiningCog", "mining"),
+        ),
+    )
+    cat = build_catalogue()
+    assert "mining.ghostmenu" in cat.findings.regex_inferred_panels
+
+
+def test_undiscoverable_surfaces_finding_populated():
+    """A settings/config/policy command in a subsystem without a panel
+    AND without a help_hook is flagged as undiscoverable."""
+    _inject_ledger(
+        _make_ledger(
+            _entry("weirdsettings", "BlackjackCog", "blackjack"),
+        ),
+    )
+    cat = build_catalogue(bot=None)
+    assert "blackjack.weirdsettings" in cat.findings.undiscoverable_surfaces
+
+
+def test_undiscoverable_surfaces_excluded_when_help_hook_present():
+    cog = _FakeCog("BlackjackCog", has_help_hook=True)
+    bot = _FakeBot(cogs={"BlackjackCog": cog})
+    _inject_ledger(
+        _make_ledger(
+            _entry("weirdsettings", "BlackjackCog", "blackjack"),
+        ),
+    )
+    cat = build_catalogue(bot=bot)
+    assert "blackjack.weirdsettings" not in cat.findings.undiscoverable_surfaces
+
+
+def test_findings_total_sums_all_buckets():
+    findings = CustomizationFindings(
+        subsystems_missing_panel=("a",),
+        subsystems_missing_help_hook=("b", "c"),
+        subsystems_missing_schema=("d",),
+        panels_without_settings=("e",),
+        settings_without_panel=("f",),
+        regex_inferred_panels=("g",),
+        undiscoverable_surfaces=("h", "i"),
+    )
+    assert findings.total == 9
+
+
+# ---------------------------------------------------------------------------
+# Query API
+# ---------------------------------------------------------------------------
+
+
+def test_get_returns_entry_for_known_subsystem():
+    cat = build_catalogue()
+    entry = cat.get("admin")
+    assert entry is not None
+    assert entry.subsystem == "admin"
+
+
+def test_get_returns_none_for_unknown_subsystem():
+    cat = build_catalogue()
+    assert cat.get("no_such_subsystem") is None
+
+
+def test_panels_returns_all_panels_across_subsystems():
+    cog_a = _FakeCog("ModerationCog", has_help_hook=True)
+    cog_b = _FakeCog("EconomyCog", has_help_hook=True)
+    bot = _FakeBot(cogs={"ModerationCog": cog_a, "EconomyCog": cog_b})
+    cat = build_catalogue(bot=bot)
+    panels = cat.panels()
+    sources = {p.source for p in panels}
+    assert "help_hook" in sources
+    assert len(panels) >= 2
+
+
+def test_by_panel_count_returns_subsystem_keyed_counts():
+    cog = _FakeCog("ModerationCog", has_help_hook=True)
+    bot = _FakeBot(cogs={"ModerationCog": cog})
+    cat = build_catalogue(bot=bot)
+    counts = cat.by_panel_count()
+    assert counts["moderation"] >= 1
+    assert counts["admin"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Immutability
+# ---------------------------------------------------------------------------
+
+
+def test_panel_declaration_is_frozen():
+    panel = PanelDeclaration(command="modmenu", source="known_list")
+    with pytest.raises(Exception):
+        panel.command = "other"  # type: ignore[misc]
+
+
+def test_customization_entry_is_frozen():
+    cat = build_catalogue()
+    entry = cat.entries[0]
+    with pytest.raises(Exception):
+        entry.subsystem = "other"  # type: ignore[misc]
+
+
+def test_customization_catalogue_is_frozen():
+    cat = build_catalogue()
+    with pytest.raises(Exception):
+        cat.version = 99  # type: ignore[misc]
+
+
+def test_customization_findings_is_frozen():
+    cat = build_catalogue()
+    with pytest.raises(Exception):
+        cat.findings.subsystems_missing_panel = ()  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Caching
+# ---------------------------------------------------------------------------
+
+
+def test_rebuild_replaces_cached_snapshot():
+    first = build_catalogue()
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="xp",
+            settings=(SettingSpec(name="xp_min", value_type=int, default=1),),
+        ),
+    )
+    second = build_catalogue()
+    assert second is not first
+    assert get_cached_catalogue() is second
+    assert second.get("xp").has_schema is True  # type: ignore[union-attr]
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics provider
+# ---------------------------------------------------------------------------
+
+
+def test_diagnostics_provider_returns_not_built_before_first_build():
+    from services import diagnostics_service
+
+    snap = diagnostics_service.snapshot("customization_catalogue")
+    assert snap["status"] == "not_built"
+    assert "hint" in snap
+
+
+def test_diagnostics_provider_returns_counts_after_build():
+    from services import diagnostics_service
+
+    cog = _FakeCog("ModerationCog", has_help_hook=True)
+    bot = _FakeBot(cogs={"ModerationCog": cog})
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="moderation",
+            settings=(SettingSpec(name="warn_threshold", value_type=int, default=3),),
+        ),
+    )
+    build_catalogue(bot=bot)
+    snap = diagnostics_service.snapshot("customization_catalogue")
+    assert snap["status"] == "built"
+    assert snap["version"] == 1
+    assert snap["subsystem_count"] >= 1
+    assert "panels_by_source" in snap
+    assert snap["subsystems_with_help_hook"] >= 1
+    assert snap["subsystems_with_schema"] >= 1
+    assert "findings" in snap
+
+
+def test_diagnostics_provider_is_registered_at_import_time():
+    from services import diagnostics_service
+
+    assert "customization_catalogue" in diagnostics_service.registered_names()
+
+
+# ---------------------------------------------------------------------------
+# @panel_command decorator
+# ---------------------------------------------------------------------------
+
+
+def test_panel_command_sets_extras_on_command_like_object():
+    class _Cmd:
+        extras: dict = {}
+
+    cmd = _Cmd()
+    cmd.extras = {}
+    decorated = panel_command(cmd)
+    assert decorated is cmd
+    assert cmd.extras["panel"] is True
+
+
+def test_panel_command_initializes_extras_when_absent():
+    class _Cmd:
+        pass
+
+    cmd = _Cmd()
+    decorated = panel_command(cmd)
+    assert decorated is cmd
+    assert getattr(cmd, "extras", None) == {"panel": True}
+
+
+def test_panel_command_preserves_existing_extras():
+    class _Cmd:
+        pass
+
+    cmd = _Cmd()
+    cmd.extras = {"other": "value"}
+    panel_command(cmd)
+    assert cmd.extras == {"other": "value", "panel": True}
+
+
+# ---------------------------------------------------------------------------
+# KNOWN_PANEL_COMMANDS sanity
+# ---------------------------------------------------------------------------
+
+
+def test_known_panel_commands_subsystems_all_exist_in_registry():
+    from utils.subsystem_registry import SUBSYSTEMS
+
+    for sub, _cmd in KNOWN_PANEL_COMMANDS:
+        assert sub in SUBSYSTEMS, f"known panel sub {sub!r} not in SUBSYSTEMS"
+
+
+def test_known_panel_commands_have_no_duplicates():
+    seen: set[tuple[str, str]] = set()
+    for entry in KNOWN_PANEL_COMMANDS:
+        assert entry not in seen, f"duplicate KNOWN_PANEL_COMMANDS entry {entry!r}"
+        seen.add(entry)

--- a/tests/unit/services/test_customization_catalogue.py
+++ b/tests/unit/services/test_customization_catalogue.py
@@ -37,7 +37,6 @@ from services.customization_catalogue import (
     panel_command,
 )
 
-
 # ---------------------------------------------------------------------------
 # Fixtures — snapshot live module state around each test to stay isolated.
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_customization_catalogue_import_cycle.py
+++ b/tests/unit/services/test_customization_catalogue_import_cycle.py
@@ -1,0 +1,100 @@
+"""Import-cycle regression for services.customization_catalogue — S2.
+
+The catalogue composes several ``core.runtime`` primitives and reads
+``utils.subsystem_registry``. Importing any of them at module scope
+would re-enter partially-loaded packages during startup. The
+discipline mirrors :mod:`services.platform_consistency`: top-level
+imports are stdlib only; every cross-package import is function-local.
+
+Mirrors:
+
+* tests/unit/runtime/test_command_surface_ledger_import_cycle.py
+* tests/unit/runtime/test_settings_registry_import_cycle.py
+* tests/unit/runtime/test_consistency_import_cycle.py
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_CATALOGUE_PATH = (
+    _REPO_ROOT / "disbot" / "services" / "customization_catalogue.py"
+)
+
+# Forbidden top-level imports — any cross-package access must be
+# function-local. ``services.diagnostics_service`` and other siblings
+# are also kept function-local to match the platform_consistency
+# pattern and keep the cycle test stable as new sources are added.
+_FORBIDDEN_TOP_LEVEL_PREFIXES = (
+    "core",
+    "cogs",
+    "discord",
+    "services.diagnostics_service",
+    "services.platform_consistency",
+    "utils",
+    "views",
+)
+
+
+def _module_level_imports(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    offenders: list[str] = []
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for prefix in _FORBIDDEN_TOP_LEVEL_PREFIXES:
+                if module == prefix or module.startswith(prefix + "."):
+                    offenders.append(
+                        f"from {module} import "
+                        f"{', '.join(a.name for a in node.names)}",
+                    )
+                    break
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                for prefix in _FORBIDDEN_TOP_LEVEL_PREFIXES:
+                    if alias.name == prefix or alias.name.startswith(prefix + "."):
+                        offenders.append(f"import {alias.name}")
+                        break
+    return offenders
+
+
+def test_customization_catalogue_no_top_level_cycle_imports():
+    offenders = _module_level_imports(_CATALOGUE_PATH)
+    assert not offenders, (
+        "services.customization_catalogue has cycle-sensitive "
+        "top-level imports:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_customization_catalogue_imports_in_fresh_interpreter():
+    script = textwrap.dedent(
+        """
+        import sys
+        sys.path.insert(0, "disbot")
+        import services.customization_catalogue  # noqa: F401
+        from services import diagnostics_service
+
+        assert "customization_catalogue" in diagnostics_service.registered_names()
+        snap = diagnostics_service.snapshot("customization_catalogue")
+        assert snap["status"] == "not_built"
+        print("ok")
+        """,
+    )
+    result = subprocess.run(  # noqa: S603 — script literal under our control
+        [sys.executable, "-c", script],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"services.customization_catalogue import failed in subprocess.\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary

S2 of the **Global Settings & Customization Manager** roadmap (see
[`docs/settings-customization-roadmap.md`](https://github.com/menno420/superbot/blob/main/docs/settings-customization-roadmap.md)
landed in #92, and [`SettingsRegistry`](https://github.com/menno420/superbot/blob/main/disbot/core/runtime/settings_registry.py)
landed in #93).

Lands a frozen, read-only catalogue that composes six existing
read-only platform sources into one queryable inventory of every
subsystem's customization surface:

1. `command_surface_ledger.get_cached_ledger()` — live commands per
   subsystem (PR-12).
2. `settings_registry.get_cached_registry()` — declared `SettingSpec`s
   (S1).
3. `subsystem_schema.all_schemas()` — `BindingSpec` +
   `ResourceRequirement` declarations.
4. `utils.subsystem_registry.SUBSYSTEMS` — display metadata,
   `entry_points`, `visibility_tier`, `related_subsystems`.
5. `services.diagnostics_service.registered_names()` — registered
   diagnostics providers.
6. Live `bot.cogs` walked for `build_help_menu_view` hooks; live
   `bot.walk_commands()` walked for `extras["panel"] is True`
   declarations.

**Read-only — no mutation surface, no migrations, no resource
provisioning writes, no setup wizard, no PanelRegistry
implementation, no slash commands.** The S3 resolver, S4 mutation
pipeline, and S5+ cog consumers will read this snapshot.

## Panel-detection priority

Authoritative first; regex is last-resort. Matches the architecture
rule from `docs/settings-customization-roadmap.md`:

1. **`ledger_extras`** — command tagged `extras["panel"] = True` via
   the new `@panel_command` decorator. Future S5/S10 work tags
   existing panels with this; today no commands carry it.
2. **`help_hook`** — cog implements `build_help_menu_view`. A
   synthetic panel record `command="<build_help_menu_view>"` is
   created so the help direct-nav primitive counts as a panel.
3. **`known_list`** — `KNOWN_PANEL_COMMANDS` for cogs that predate
   the `@panel_command` decorator (13 entries). Only counts when
   the command actually appears in the live ledger.
4. **`regex_fallback`** — name matches `r".+menu$"`. Always surfaced
   as a `regex_inferred_panels` finding so operators can promote
   regex-detected panels to explicit declarations.

(A future `panel_registry` source slots between (3) and (4) once
the PanelRegistry primitive lands; not in S2 scope.)

## Findings buckets

The catalogue surfaces seven cross-cutting findings:

- `subsystems_missing_panel` — subsystem has no panel detected by
  any source.
- `subsystems_missing_help_hook` — cog does not implement
  `build_help_menu_view` (only populated when a live bot is
  available).
- `subsystems_missing_schema` — no `SubsystemSchema` registered.
- `panels_without_settings` — panel exists but the subsystem
  declares no `SettingSpec` / `BindingSpec` / `ResourceRequirement`.
- `settings_without_panel` — `SettingSpec` declared but no panel
  detected.
- `regex_inferred_panels` — panel detected via regex fallback only;
  candidate for explicit `@panel_command` declaration.
- `undiscoverable_surfaces` — settings/config/policy commands whose
  owning subsystem has neither a panel nor a help-hook and whose
  name is not in `entry_points`.

## Changes

- **`disbot/services/customization_catalogue.py`** (new, 545 LOC) — public surface:
  - `PanelDeclaration` — frozen dataclass: `command`, `source`.
  - `CustomizationEntry` — frozen dataclass per subsystem
    (`subsystem`, `display_name`, `visibility_tier`, `has_schema`,
    `has_help_hook`, `has_diagnostics_provider`, `panels`,
    `setting_names`, `binding_names`, `resource_intents`,
    `command_count`, `related_subsystems`).
  - `CustomizationFindings` — frozen dataclass with the seven
    buckets above plus a `total` property.
  - `CustomizationCatalogue` — frozen aggregate with `get(subsystem)`,
    `panels()`, `by_panel_count()` query helpers.
  - `KNOWN_PANEL_COMMANDS` — curated tuple of 13
    `(subsystem, command_name)` pairs for cogs predating the
    `@panel_command` decorator.
  - `panel_command(cmd)` — decorator that sets
    `cmd.extras["panel"] = True` on a Command instance.
  - `build_catalogue(bot=None)` — walks every source once, caches,
    returns frozen snapshot. `bot is None` skips help-hook /
    extras-panel signals (used at REPL/test time).
  - `get_cached_catalogue()` — last-built snapshot or `None`.
  - Registers itself as the `"customization_catalogue"` diagnostics
    provider at import time.

- **`disbot/bot1.py`** — call `customization_catalogue.build_catalogue(bot)`
  right after `settings_registry.build_registry()`. Non-fatal on
  failure (matches the ledger and registry patterns).

- **`disbot/cogs/diagnostic_cog.py`** — new `!platform customization`
  subcommand (administrator-only). Diagnostic cog at **787 LOC** —
  under the 800-LOC `test_cog_size` fail threshold.

- **`disbot/cogs/diagnostic/_platform_embeds.py`** — new
  `build_customization_embed()` renders subsystem count, panel
  count, panels-by-source histogram, and findings counts.

- **`tests/unit/services/test_customization_catalogue.py`** (new, 46
  tests) — covers the builder, composition with each source,
  detection-priority ordering (`ledger_extras > help_hook >
  known_list > regex_fallback`), `build_help_menu_view` discovery,
  every findings bucket, query API, frozen-dataclass guards
  (`PanelDeclaration`, `CustomizationEntry`,
  `CustomizationCatalogue`, `CustomizationFindings`), cache
  replacement, diagnostics provider registration, the
  `@panel_command` decorator, and `KNOWN_PANEL_COMMANDS` sanity
  (subsystems exist; no duplicates). Uses a fixture that
  snapshots / restores the live schema registry, settings registry
  cache, and command-surface ledger cache around each test to
  avoid leaking state.

- **`tests/unit/services/test_customization_catalogue_import_cycle.py`**
  (new, 2 tests) — guards against cycle-sensitive top-level
  imports (forbids `core.*`, `cogs.*`, `discord`, `services.*`
  cross-package, `utils.*`, `views.*` at module scope) and
  verifies the module imports cleanly in a fresh interpreter.
  Mirrors the `services.platform_consistency` cycle discipline.

## Cycle discipline

Top-level imports are stdlib only. Every cross-package access is
function-local — matches the pattern enforced for
`services.platform_consistency` and verified by the new
import-cycle test.

## Deferred to a follow-up PR

Matches the S1 precedent (PR #93 explicitly deferred its
`_collect_settings_registry` collector to a follow-up):

- `disbot/services/platform_consistency.py` —
  `_collect_customization_catalogue` collector promoting findings
  to WARNING when non-empty. Tiny follow-up; isolated from this PR
  so the catalogue can be reviewed independently.

## Test plan

- [x] `python3 -m pytest tests/unit/services/test_customization_catalogue.py` — 44 passed
- [x] `python3 -m pytest tests/unit/services/test_customization_catalogue_import_cycle.py` — 2 passed
- [x] `python3 -m pytest tests/unit/invariants/test_cog_size.py` — 41 passed (`diagnostic_cog.py` now 787 LOC, still in warn-tier but safely under the 800 fail threshold)
- [x] `python3 -m pytest tests/unit/runtime/test_settings_registry.py tests/unit/runtime/test_command_surface_ledger.py` — neighbor primitives still green
- [x] `python3 -m pytest tests/unit/` — full suite: **1653 passed**
- [x] `ruff check disbot/` — all checks passed
- [x] `black --check disbot/` — 233 files unchanged
- [x] Single-`git revert` safe (no migrations, no behaviour change in existing flows)

## Manual smoke checklist (for the operator)

- `!platform customization` renders the catalogue: ~21 subsystems, ≥13 panels via `known_list`, ≥20 panels via `help_hook` (every loaded cog implements `build_help_menu_view`), findings count reflects current gaps (subsystems without schemas, settings without panels for migrated keys, etc.).
- `!platform settings-registry` still renders (S1 unaffected).
- `!platform schemas`, `!platform resource-requirements`, `!platform participation-schemas` still render (Phase 1 surfaces unaffected).
- `!platform consistency` still renders (no new collector wired yet — see Deferred section).

## Risks and rollback

- **Risk:** none — module is read-only, the `!platform customization` command is administrator-only, and `bot1.py` wraps `build_catalogue(bot)` in `try/except` so a builder failure does not block startup (matches the ledger and registry pattern).
- **Rollback:** single `git revert` of this commit removes the catalogue and the `!platform customization` command. No migrations to roll back.

## Next recommended PR

**S2.5 — `ResourceProvisioningCatalogue`**, branch
`claude/resource-provisioning-catalogue`. Read-only frozen
snapshot of every `ResourceRequirement` × `BindingSpec` pair,
surfaced via `!platform resources`. Companion to this PR for the
resource-provisioning lane.


---
_Generated by [Claude Code](https://claude.ai/code/session_01U3sByR3PY3gobeB3jLFDFD)_