### PR TITLE
feat(s2.5): ResourceProvisioningCatalogue + !platform provisioning

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -735,6 +735,21 @@ async def main() -> None:
             except Exception as exc:
                 logger.warning("Settings registry build skipped: %s", exc)
 
+            # S2.5 — Resource provisioning catalogue. Frozen, read-only
+            # cross-link of every ResourceRequirement with its
+            # BindingSpec. Pure schema walk — no bot reference needed.
+            # Failure is non-fatal: the bot boots without the catalogue
+            # and `!platform provisioning` reports it as not-built.
+            try:
+                from services import resource_provisioning_catalogue
+
+                resource_provisioning_catalogue.build_provisioning_catalogue()
+            except Exception as exc:
+                logger.warning(
+                    "Resource provisioning catalogue build skipped: %s",
+                    exc,
+                )
+
             logger.info("Starting bot...")
             await bot.start(config.DISCORD_BOT_TOKEN)
     finally:

--- a/disbot/cogs/diagnostic/_platform_embeds.py
+++ b/disbot/cogs/diagnostic/_platform_embeds.py
@@ -364,9 +364,81 @@ def build_settings_registry_embed() -> discord.Embed:
     return embed
 
 
+def build_provisioning_embed() -> discord.Embed:
+    """Build the embed for ``!platform provisioning`` (S2.5)."""
+    from services import diagnostics_service
+
+    snap = diagnostics_service.snapshot("resource_provisioning_catalogue")
+    if snap.get("status") == "not_built":
+        return discord.Embed(
+            title="🧰 Resource provisioning catalogue",
+            description=(
+                "*(not built — call resource_provisioning_catalogue."
+                "build_provisioning_catalogue())*"
+            ),
+            color=discord.Color.greyple(),
+        )
+    embed = discord.Embed(
+        title="🧰 Resource provisioning catalogue",
+        description=(
+            f"v{snap['version']}  ·  {snap['option_count']} option(s)  ·  "
+            f"{snap['subsystem_count']} subsystem(s)  ·  "
+            f"findings={snap['findings_total']}"
+        ),
+        color=discord.Color.blurple(),
+    )
+    by_priority = snap.get("by_priority") or {}
+    if by_priority:
+        priority_order = {"required": 0, "recommended": 1, "optional": 2}
+        lines = [
+            f"`{p}` — {count}"
+            for p, count in sorted(
+                by_priority.items(),
+                key=lambda kv: priority_order.get(kv[0], 99),
+            )
+        ]
+        embed.add_field(
+            name="By priority",
+            value="\n".join(lines)[:1024],
+            inline=True,
+        )
+    by_kind = snap.get("by_kind") or {}
+    if by_kind:
+        lines = [f"`{k}` — {count}" for k, count in sorted(by_kind.items())]
+        embed.add_field(
+            name="By kind",
+            value="\n".join(lines)[:1024],
+            inline=True,
+        )
+    by_subsystem = snap.get("by_subsystem") or {}
+    if by_subsystem:
+        lines = [
+            f"`{name}` — {count} option(s)"
+            for name, count in sorted(by_subsystem.items())
+        ]
+        embed.add_field(
+            name="By subsystem",
+            value="\n".join(lines)[:1024],
+            inline=False,
+        )
+    findings = snap.get("findings") or {}
+    if findings and snap.get("findings_total"):
+        finding_lines = [
+            f"`{key}`: {count}" for key, count in sorted(findings.items()) if count
+        ]
+        if finding_lines:
+            embed.add_field(
+                name="Findings",
+                value="\n".join(finding_lines)[:1024],
+                inline=False,
+            )
+    return embed
+
+
 __all__ = [
     "build_bindings_embed",
     "build_consistency_embed",
+    "build_provisioning_embed",
     "build_resources_embed",
     "build_schemas_embed",
     "build_settings_registry_embed",

--- a/disbot/cogs/diagnostic_cog.py
+++ b/disbot/cogs/diagnostic_cog.py
@@ -568,6 +568,14 @@ class DiagnosticCog(commands.Cog):
 
         await ctx.send(embed=build_settings_registry_embed())
 
+    @platform_grp.command(name="provisioning")  # type: ignore[arg-type]
+    @commands.has_permissions(administrator=True)
+    async def platform_provisioning(self, ctx):
+        """Cross-linked ResourceRequirement × BindingSpec catalogue (S2.5)."""
+        from cogs.diagnostic._platform_embeds import build_provisioning_embed
+
+        await ctx.send(embed=build_provisioning_embed())
+
     @platform_grp.command(name="participation-schemas")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def platform_participation_schemas(self, ctx):

--- a/disbot/services/resource_provisioning_catalogue.py
+++ b/disbot/services/resource_provisioning_catalogue.py
@@ -1,0 +1,329 @@
+"""Resource provisioning catalogue — S2.5 of the Global Settings & Customization Manager.
+
+A frozen, read-only catalogue of every :class:`ResourceRequirement`
+declared across all subsystem schemas, cross-linked with the
+:class:`BindingSpec` that owns the runtime value of the resource.
+
+Mirrors the shape of :mod:`core.runtime.settings_registry` and
+:mod:`services.customization_catalogue`: the builder walks
+:func:`core.runtime.subsystem_schema.all_schemas` once, returns a
+frozen :class:`ProvisioningCatalogue`, and caches it for diagnostics.
+
+Why this is its own catalogue:
+
+* `ResourceRequirement` lives in :mod:`core.runtime.resource_specs`
+  (Phase 1c). It carries the *creation* metadata an operator needs to
+  decide what to create — kind, intent, suggested name/category/
+  permissions, priority — separately from the binding row that stores
+  the runtime value.
+* `BindingSpec` (Phase 1a) owns the *binding* metadata — the
+  capability required to mutate, whether the slot is required, and a
+  human-readable hint.
+* Cross-linking them at catalogue build time means future
+  ``ResourceProvisioningPipeline`` (S4.5) and setup-pack UX (S10) can
+  consume a single source: "for each provisionable resource, here's
+  the suggested creation parameters AND the canonical binding to write
+  through."
+
+Cross-cutting findings:
+
+* ``orphan_requirements`` — a :class:`ResourceRequirement` with no
+  ``binding_name`` cross-link. Such requirements describe a resource
+  but no slot exists for it. Flagged so subsystems can declare an
+  explicit binding.
+* ``binding_targets_unknown`` — the ``binding_name`` does not match
+  any :class:`BindingSpec` declared in the same schema. Likely a typo
+  or a removed binding.
+* ``duplicate_options`` — the same ``(subsystem, binding_name)`` pair
+  is declared more than once. Either two requirements point at the
+  same binding (legal but worth surfacing) or a real duplicate.
+* ``kind_mismatch`` — the :class:`ResourceKind` of the requirement
+  doesn't equal the :class:`BindingKind` of the cross-linked binding.
+
+Public surface:
+
+* :class:`ProvisioningOption` — frozen dataclass per option.
+* :class:`ProvisioningFindings` — frozen findings buckets.
+* :class:`ProvisioningCatalogue` — frozen aggregate snapshot.
+* :func:`build_provisioning_catalogue` — walks schemas, caches,
+  returns snapshot.
+* :func:`get_cached_provisioning_catalogue` — last-built snapshot or
+  ``None``.
+
+Diagnostics provider name: ``"resource_provisioning_catalogue"``.
+
+Cycle discipline (mirrors :mod:`services.platform_consistency`): all
+cross-package imports are function-local. Top-level imports are
+stdlib only.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger("bot.services.resource_provisioning_catalogue")
+
+
+_CATALOGUE_VERSION = 1
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProvisioningOption:
+    """A single provisionable resource — the cross-link of a
+    :class:`ResourceRequirement` with its :class:`BindingSpec`.
+
+    ``binding_kind`` is ``None`` when no matching :class:`BindingSpec`
+    was found in the schema (a ``binding_targets_unknown`` finding).
+    The other ``binding_*`` fields are empty/default in that case.
+    """
+
+    subsystem: str
+    binding_name: str
+    kind: str  # ResourceKind value (channel/role/category/thread)
+    binding_kind: str | None
+    priority: str  # ProvisioningPriority value
+    suggested_name: str
+    suggested_category: str
+    suggested_permissions: tuple[str, ...]
+    intent: str
+    description: str
+    capability_required: str
+    binding_required: bool
+    binding_hint: str
+
+
+@dataclass(frozen=True)
+class ProvisioningFindings:
+    """Cross-cutting checks computed at build time."""
+
+    orphan_requirements: tuple[str, ...] = ()
+    binding_targets_unknown: tuple[str, ...] = ()
+    duplicate_options: tuple[str, ...] = ()
+    kind_mismatch: tuple[str, ...] = ()
+
+    @property
+    def total(self) -> int:
+        return (
+            len(self.orphan_requirements)
+            + len(self.binding_targets_unknown)
+            + len(self.duplicate_options)
+            + len(self.kind_mismatch)
+        )
+
+
+@dataclass(frozen=True)
+class ProvisioningCatalogue:
+    """An immutable snapshot of every cross-linked provisioning option."""
+
+    version: int
+    built_at: datetime.datetime
+    options: tuple[ProvisioningOption, ...]
+    findings: ProvisioningFindings
+
+    def by_subsystem(self, subsystem: str) -> tuple[ProvisioningOption, ...]:
+        return tuple(o for o in self.options if o.subsystem == subsystem)
+
+    def find(
+        self,
+        subsystem: str,
+        binding_name: str,
+    ) -> ProvisioningOption | None:
+        for option in self.options:
+            if option.subsystem == subsystem and option.binding_name == binding_name:
+                return option
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Module state — cached last-built catalogue
+# ---------------------------------------------------------------------------
+
+
+_CACHED: ProvisioningCatalogue | None = None
+
+
+def _reset_for_tests() -> None:
+    global _CACHED
+    _CACHED = None
+
+
+# ---------------------------------------------------------------------------
+# Builder
+# ---------------------------------------------------------------------------
+
+
+def _build_option(
+    subsystem: str,
+    req: Any,  # core.runtime.resource_specs.ResourceRequirement
+    binding: Any | None,  # core.runtime.subsystem_schema.BindingSpec | None
+) -> ProvisioningOption:
+    """Construct a :class:`ProvisioningOption` from a requirement and an
+    optional cross-linked binding.
+    """
+    return ProvisioningOption(
+        subsystem=subsystem,
+        binding_name=req.binding_name,
+        kind=req.kind.value,
+        binding_kind=binding.kind.value if binding is not None else None,
+        priority=req.provisioning.priority.value,
+        suggested_name=req.provisioning.suggested_name,
+        suggested_category=req.provisioning.suggested_category,
+        suggested_permissions=tuple(req.provisioning.suggested_permissions),
+        intent=req.intent,
+        description=req.description,
+        capability_required=(
+            binding.capability_required if binding is not None else ""
+        ),
+        binding_required=binding.required if binding is not None else False,
+        binding_hint=binding.hint if binding is not None else "",
+    )
+
+
+def build_provisioning_catalogue() -> ProvisioningCatalogue:
+    """Walk every registered :class:`SubsystemSchema` and return a frozen
+    snapshot of every ``ResourceRequirement`` × ``BindingSpec`` pair.
+
+    Caches the result for diagnostics access; call again to refresh
+    after a hot-reload. Sync — no I/O.
+    """
+    from core.runtime.subsystem_schema import all_schemas
+
+    schemas = all_schemas()
+    options: list[ProvisioningOption] = []
+    orphan: list[str] = []
+    unknown: list[str] = []
+    duplicate: list[str] = []
+    kind_mismatch: list[str] = []
+    seen: set[tuple[str, str]] = set()
+
+    for subsystem_name in sorted(schemas):
+        schema = schemas[subsystem_name]
+        bindings_by_name = {b.name: b for b in schema.bindings}
+
+        for req in schema.resource_requirements:
+            if not req.binding_name:
+                orphan.append(f"{subsystem_name}/{req.intent}")
+                continue
+
+            binding = bindings_by_name.get(req.binding_name)
+            key = (subsystem_name, req.binding_name)
+            if key in seen:
+                duplicate.append(f"{subsystem_name}.{req.binding_name}")
+                continue
+            seen.add(key)
+
+            if binding is None:
+                unknown.append(f"{subsystem_name}.{req.binding_name}")
+                options.append(_build_option(subsystem_name, req, None))
+                continue
+
+            if binding.kind.value != req.kind.value:
+                kind_mismatch.append(
+                    f"{subsystem_name}.{req.binding_name} "
+                    f"(req={req.kind.value} binding={binding.kind.value})",
+                )
+
+            options.append(_build_option(subsystem_name, req, binding))
+
+    findings = ProvisioningFindings(
+        orphan_requirements=tuple(sorted(orphan)),
+        binding_targets_unknown=tuple(sorted(unknown)),
+        duplicate_options=tuple(sorted(duplicate)),
+        kind_mismatch=tuple(sorted(kind_mismatch)),
+    )
+
+    cat = ProvisioningCatalogue(
+        version=_CATALOGUE_VERSION,
+        built_at=datetime.datetime.now(tz=datetime.timezone.utc),
+        options=tuple(options),
+        findings=findings,
+    )
+    global _CACHED
+    _CACHED = cat
+    logger.info(
+        "resource_provisioning_catalogue: built v%d — %d options across "
+        "%d subsystem(s), %d findings",
+        cat.version,
+        len(cat.options),
+        len({o.subsystem for o in cat.options}),
+        findings.total,
+    )
+    return cat
+
+
+def get_cached_provisioning_catalogue() -> ProvisioningCatalogue | None:
+    """Return the last-built catalogue, or ``None`` if not yet built."""
+    return _CACHED
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics provider — registers at import time
+# ---------------------------------------------------------------------------
+
+
+def _snapshot() -> dict[str, Any]:
+    """Stable diagnostics snapshot for ``!platform provisioning``.
+
+    Returns counts + findings counts only. Operators wanting the full
+    options list call :func:`get_cached_provisioning_catalogue` from a
+    REPL or a future admin command.
+    """
+    cat = _CACHED
+    if cat is None:
+        return {
+            "status": "not_built",
+            "hint": (
+                "call resource_provisioning_catalogue."
+                "build_provisioning_catalogue() after schemas register."
+            ),
+        }
+    by_priority: dict[str, int] = {}
+    by_kind: dict[str, int] = {}
+    by_subsystem: dict[str, int] = {}
+    for option in cat.options:
+        by_priority[option.priority] = by_priority.get(option.priority, 0) + 1
+        by_kind[option.kind] = by_kind.get(option.kind, 0) + 1
+        by_subsystem[option.subsystem] = by_subsystem.get(option.subsystem, 0) + 1
+    return {
+        "status": "built",
+        "version": cat.version,
+        "built_at": cat.built_at.isoformat(),
+        "option_count": len(cat.options),
+        "subsystem_count": len(by_subsystem),
+        "by_priority": by_priority,
+        "by_kind": by_kind,
+        "by_subsystem": by_subsystem,
+        "findings_total": cat.findings.total,
+        "findings": {
+            "orphan_requirements": len(cat.findings.orphan_requirements),
+            "binding_targets_unknown": len(cat.findings.binding_targets_unknown),
+            "duplicate_options": len(cat.findings.duplicate_options),
+            "kind_mismatch": len(cat.findings.kind_mismatch),
+        },
+    }
+
+
+def _register_diagnostics() -> None:
+    from services import diagnostics_service
+
+    diagnostics_service.register("resource_provisioning_catalogue", _snapshot)
+
+
+_register_diagnostics()
+
+
+__all__ = [
+    "ProvisioningCatalogue",
+    "ProvisioningFindings",
+    "ProvisioningOption",
+    "build_provisioning_catalogue",
+    "get_cached_provisioning_catalogue",
+]

--- a/tests/unit/services/test_resource_provisioning_catalogue.py
+++ b/tests/unit/services/test_resource_provisioning_catalogue.py
@@ -1,0 +1,583 @@
+"""Unit tests for services.resource_provisioning_catalogue — S2.5.
+
+Covers the builder, cross-link logic, every findings bucket, query
+API, immutability, cache replacement, the diagnostics provider, and
+the round-trip of suggested-name/category/permissions/description.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.runtime import subsystem_schema as schema_mod
+from core.runtime.resource_specs import (
+    ProvisioningHint,
+    ProvisioningPriority,
+    ResourceKind,
+    ResourceRequirement,
+)
+from core.runtime.subsystem_schema import (
+    BindingKind,
+    BindingSpec,
+    SubsystemSchema,
+)
+from services import resource_provisioning_catalogue as rpc_mod
+from services.resource_provisioning_catalogue import (
+    ProvisioningCatalogue,
+    ProvisioningFindings,
+    ProvisioningOption,
+    build_provisioning_catalogue,
+    get_cached_provisioning_catalogue,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures — snapshot live module state around each test to stay isolated.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    saved_schemas = schema_mod.all_schemas()
+    schema_mod._reset_for_tests()
+    rpc_mod._reset_for_tests()
+    yield
+    schema_mod._reset_for_tests()
+    for schema in saved_schemas.values():
+        schema_mod.register(schema)
+    rpc_mod._reset_for_tests()
+
+
+def _binding(
+    name: str,
+    *,
+    kind: BindingKind = BindingKind.CHANNEL,
+    required: bool = False,
+    hint: str = "",
+    capability_required: str = "",
+) -> BindingSpec:
+    return BindingSpec(
+        name=name,
+        kind=kind,
+        required=required,
+        hint=hint,
+        capability_required=capability_required,
+    )
+
+
+def _requirement(
+    *,
+    kind: ResourceKind = ResourceKind.CHANNEL,
+    intent: str = "log_destination",
+    priority: ProvisioningPriority = ProvisioningPriority.RECOMMENDED,
+    suggested_name: str = "",
+    suggested_category: str = "",
+    suggested_permissions: tuple[str, ...] = (),
+    binding_name: str = "",
+    description: str = "",
+) -> ResourceRequirement:
+    return ResourceRequirement(
+        kind=kind,
+        intent=intent,
+        provisioning=ProvisioningHint(
+            priority=priority,
+            suggested_name=suggested_name,
+            suggested_category=suggested_category,
+            suggested_permissions=suggested_permissions,
+        ),
+        binding_name=binding_name,
+        description=description,
+    )
+
+
+def _register(
+    subsystem: str,
+    *,
+    bindings: tuple[BindingSpec, ...] = (),
+    resources: tuple[ResourceRequirement, ...] = (),
+) -> None:
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem=subsystem,
+            bindings=bindings,
+            resource_requirements=resources,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Empty inputs
+# ---------------------------------------------------------------------------
+
+
+def test_build_returns_empty_snapshot_when_no_schemas():
+    cat = build_provisioning_catalogue()
+    assert isinstance(cat, ProvisioningCatalogue)
+    assert cat.version == 1
+    assert cat.options == ()
+    assert cat.findings.total == 0
+
+
+def test_get_cached_returns_none_before_first_build():
+    assert get_cached_provisioning_catalogue() is None
+
+
+def test_get_cached_returns_last_built():
+    cat = build_provisioning_catalogue()
+    assert get_cached_provisioning_catalogue() is cat
+
+
+def test_build_schema_with_no_resource_requirements_yields_no_options():
+    _register("xp", bindings=(_binding("announce_channel"),))
+    cat = build_provisioning_catalogue()
+    assert cat.options == ()
+    assert cat.findings.total == 0
+
+
+# ---------------------------------------------------------------------------
+# Cross-link happy path
+# ---------------------------------------------------------------------------
+
+
+def test_requirement_with_matching_binding_produces_option():
+    _register(
+        "logging",
+        bindings=(
+            _binding(
+                "mod_channel",
+                kind=BindingKind.CHANNEL,
+                required=True,
+                hint="The mod log channel.",
+                capability_required="logging.settings.configure",
+            ),
+        ),
+        resources=(
+            _requirement(
+                kind=ResourceKind.CHANNEL,
+                intent="mod_log",
+                priority=ProvisioningPriority.RECOMMENDED,
+                suggested_name="mod-logs",
+                suggested_category="Staff",
+                suggested_permissions=("view_channel", "send_messages"),
+                binding_name="mod_channel",
+                description="Operator-visible mod-action audit.",
+            ),
+        ),
+    )
+    cat = build_provisioning_catalogue()
+    assert len(cat.options) == 1
+    option = cat.options[0]
+    assert option.subsystem == "logging"
+    assert option.binding_name == "mod_channel"
+    assert option.kind == "channel"
+    assert option.binding_kind == "channel"
+    assert option.priority == "recommended"
+    assert option.suggested_name == "mod-logs"
+    assert option.suggested_category == "Staff"
+    assert option.suggested_permissions == ("view_channel", "send_messages")
+    assert option.intent == "mod_log"
+    assert option.description == "Operator-visible mod-action audit."
+    assert option.capability_required == "logging.settings.configure"
+    assert option.binding_required is True
+    assert option.binding_hint == "The mod log channel."
+
+
+def test_role_kind_cross_link():
+    _register(
+        "proof_channel",
+        bindings=(
+            _binding(
+                "approval_role",
+                kind=BindingKind.ROLE,
+                required=False,
+                capability_required="proof_channel.access.grant",
+            ),
+        ),
+        resources=(
+            _requirement(
+                kind=ResourceKind.ROLE,
+                intent="approval_role",
+                priority=ProvisioningPriority.OPTIONAL,
+                suggested_name="prize-approver",
+                binding_name="approval_role",
+            ),
+        ),
+    )
+    cat = build_provisioning_catalogue()
+    assert len(cat.options) == 1
+    option = cat.options[0]
+    assert option.kind == "role"
+    assert option.binding_kind == "role"
+    assert option.priority == "optional"
+
+
+def test_category_kind_cross_link():
+    _register(
+        "cleanup",
+        bindings=(_binding("staff_category", kind=BindingKind.CATEGORY),),
+        resources=(
+            _requirement(
+                kind=ResourceKind.CATEGORY,
+                intent="staff_category",
+                suggested_name="Staff",
+                binding_name="staff_category",
+            ),
+        ),
+    )
+    cat = build_provisioning_catalogue()
+    assert cat.options[0].kind == "category"
+    assert cat.options[0].binding_kind == "category"
+
+
+def test_thread_kind_cross_link():
+    _register(
+        "moderation",
+        bindings=(_binding("triage_thread", kind=BindingKind.THREAD),),
+        resources=(
+            _requirement(
+                kind=ResourceKind.THREAD,
+                intent="triage_thread",
+                binding_name="triage_thread",
+            ),
+        ),
+    )
+    cat = build_provisioning_catalogue()
+    assert cat.options[0].kind == "thread"
+    assert cat.options[0].binding_kind == "thread"
+
+
+def test_options_sorted_by_subsystem_alphabetically():
+    _register(
+        "xp",
+        bindings=(_binding("announce_channel"),),
+        resources=(
+            _requirement(intent="announce", binding_name="announce_channel"),
+        ),
+    )
+    _register(
+        "economy",
+        bindings=(_binding("log_channel"),),
+        resources=(_requirement(intent="economy_log", binding_name="log_channel"),),
+    )
+    _register(
+        "moderation",
+        bindings=(_binding("mod_log"),),
+        resources=(_requirement(intent="mod_log", binding_name="mod_log"),),
+    )
+    cat = build_provisioning_catalogue()
+    subsystems = [o.subsystem for o in cat.options]
+    assert subsystems == sorted(subsystems)
+
+
+# ---------------------------------------------------------------------------
+# Findings: orphan_requirements
+# ---------------------------------------------------------------------------
+
+
+def test_requirement_without_binding_name_is_orphan():
+    _register(
+        "xp",
+        resources=(
+            _requirement(
+                kind=ResourceKind.CHANNEL,
+                intent="future_channel",
+                # binding_name="" — orphan
+            ),
+        ),
+    )
+    cat = build_provisioning_catalogue()
+    assert "xp/future_channel" in cat.findings.orphan_requirements
+    # Orphans do NOT produce options.
+    assert cat.options == ()
+
+
+# ---------------------------------------------------------------------------
+# Findings: binding_targets_unknown
+# ---------------------------------------------------------------------------
+
+
+def test_requirement_with_unknown_binding_name_is_flagged():
+    _register(
+        "xp",
+        bindings=(_binding("announce_channel"),),
+        resources=(
+            _requirement(
+                intent="ghost_intent",
+                binding_name="ghost_binding",  # not in bindings
+            ),
+        ),
+    )
+    cat = build_provisioning_catalogue()
+    assert "xp.ghost_binding" in cat.findings.binding_targets_unknown
+    # An option IS still recorded so operators see the gap.
+    assert len(cat.options) == 1
+    option = cat.options[0]
+    assert option.binding_kind is None
+    assert option.binding_required is False
+    assert option.binding_hint == ""
+    assert option.capability_required == ""
+
+
+# ---------------------------------------------------------------------------
+# Findings: kind_mismatch
+# ---------------------------------------------------------------------------
+
+
+def test_kind_mismatch_between_requirement_and_binding_is_flagged():
+    _register(
+        "moderation",
+        bindings=(_binding("mod_log", kind=BindingKind.ROLE),),  # ROLE, not CHANNEL
+        resources=(
+            _requirement(
+                kind=ResourceKind.CHANNEL,
+                intent="mod_log",
+                binding_name="mod_log",
+            ),
+        ),
+    )
+    cat = build_provisioning_catalogue()
+    flagged = cat.findings.kind_mismatch
+    assert any("moderation.mod_log" in s for s in flagged)
+    # The option is still emitted (with the mismatched binding_kind).
+    assert len(cat.options) == 1
+    option = cat.options[0]
+    assert option.kind == "channel"
+    assert option.binding_kind == "role"
+
+
+# ---------------------------------------------------------------------------
+# Findings: duplicate_options
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_subsystem_binding_pair_is_flagged():
+    _register(
+        "logging",
+        bindings=(_binding("mod_channel"),),
+        resources=(
+            _requirement(intent="mod_log", binding_name="mod_channel"),
+            _requirement(intent="audit_log", binding_name="mod_channel"),
+        ),
+    )
+    cat = build_provisioning_catalogue()
+    assert "logging.mod_channel" in cat.findings.duplicate_options
+    # Only the first one becomes an option; the duplicate is skipped.
+    assert len(cat.options) == 1
+    assert cat.options[0].intent == "mod_log"
+
+
+# ---------------------------------------------------------------------------
+# Findings: total
+# ---------------------------------------------------------------------------
+
+
+def test_findings_total_sums_all_buckets():
+    findings = ProvisioningFindings(
+        orphan_requirements=("a",),
+        binding_targets_unknown=("b", "c"),
+        duplicate_options=("d",),
+        kind_mismatch=("e", "f", "g"),
+    )
+    assert findings.total == 7
+
+
+def test_findings_total_zero_on_clean_schema():
+    _register(
+        "logging",
+        bindings=(_binding("mod_channel"),),
+        resources=(_requirement(intent="mod_log", binding_name="mod_channel"),),
+    )
+    cat = build_provisioning_catalogue()
+    assert cat.findings.total == 0
+
+
+# ---------------------------------------------------------------------------
+# Query API
+# ---------------------------------------------------------------------------
+
+
+def test_by_subsystem_returns_only_options_for_that_subsystem():
+    _register(
+        "logging",
+        bindings=(_binding("mod_channel"), _binding("cleanup_channel")),
+        resources=(
+            _requirement(intent="mod_log", binding_name="mod_channel"),
+            _requirement(intent="cleanup_log", binding_name="cleanup_channel"),
+        ),
+    )
+    _register(
+        "xp",
+        bindings=(_binding("announce_channel"),),
+        resources=(_requirement(intent="announce", binding_name="announce_channel"),),
+    )
+    cat = build_provisioning_catalogue()
+    logging_options = cat.by_subsystem("logging")
+    assert {o.binding_name for o in logging_options} == {
+        "mod_channel",
+        "cleanup_channel",
+    }
+    xp_options = cat.by_subsystem("xp")
+    assert {o.binding_name for o in xp_options} == {"announce_channel"}
+    assert cat.by_subsystem("no_such_subsystem") == ()
+
+
+def test_find_returns_option_for_known_pair():
+    _register(
+        "logging",
+        bindings=(_binding("mod_channel"),),
+        resources=(_requirement(intent="mod_log", binding_name="mod_channel"),),
+    )
+    cat = build_provisioning_catalogue()
+    option = cat.find("logging", "mod_channel")
+    assert option is not None
+    assert option.intent == "mod_log"
+
+
+def test_find_returns_none_on_miss():
+    _register(
+        "logging",
+        bindings=(_binding("mod_channel"),),
+        resources=(_requirement(intent="mod_log", binding_name="mod_channel"),),
+    )
+    cat = build_provisioning_catalogue()
+    assert cat.find("logging", "no_such") is None
+    assert cat.find("no_such_subsystem", "mod_channel") is None
+
+
+# ---------------------------------------------------------------------------
+# Round-trip of provisioning hint fields
+# ---------------------------------------------------------------------------
+
+
+def test_suggested_name_category_permissions_round_trip():
+    _register(
+        "logging",
+        bindings=(_binding("mod_channel"),),
+        resources=(
+            _requirement(
+                intent="mod_log",
+                binding_name="mod_channel",
+                suggested_name="mod-logs",
+                suggested_category="Staff",
+                suggested_permissions=("view_channel", "send_messages", "embed_links"),
+                description="Operator-visible mod-action audit channel.",
+            ),
+        ),
+    )
+    cat = build_provisioning_catalogue()
+    option = cat.options[0]
+    assert option.suggested_name == "mod-logs"
+    assert option.suggested_category == "Staff"
+    assert option.suggested_permissions == (
+        "view_channel",
+        "send_messages",
+        "embed_links",
+    )
+    assert option.description == "Operator-visible mod-action audit channel."
+
+
+# ---------------------------------------------------------------------------
+# Immutability
+# ---------------------------------------------------------------------------
+
+
+def test_provisioning_option_is_frozen():
+    _register(
+        "logging",
+        bindings=(_binding("mod_channel"),),
+        resources=(_requirement(intent="mod_log", binding_name="mod_channel"),),
+    )
+    cat = build_provisioning_catalogue()
+    option = cat.options[0]
+    with pytest.raises(Exception):
+        option.subsystem = "other"  # type: ignore[misc]
+
+
+def test_provisioning_findings_is_frozen():
+    cat = build_provisioning_catalogue()
+    with pytest.raises(Exception):
+        cat.findings.orphan_requirements = ()  # type: ignore[misc]
+
+
+def test_provisioning_catalogue_is_frozen():
+    cat = build_provisioning_catalogue()
+    with pytest.raises(Exception):
+        cat.version = 99  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Caching
+# ---------------------------------------------------------------------------
+
+
+def test_rebuild_replaces_cached_snapshot():
+    _register(
+        "logging",
+        bindings=(_binding("mod_channel"),),
+        resources=(_requirement(intent="mod_log", binding_name="mod_channel"),),
+    )
+    first = build_provisioning_catalogue()
+    schema_mod._reset_for_tests()
+    _register(
+        "logging",
+        bindings=(_binding("mod_channel"), _binding("cleanup_channel")),
+        resources=(
+            _requirement(intent="mod_log", binding_name="mod_channel"),
+            _requirement(intent="cleanup_log", binding_name="cleanup_channel"),
+        ),
+    )
+    second = build_provisioning_catalogue()
+    assert second is not first
+    assert get_cached_provisioning_catalogue() is second
+    assert len(second.options) == 2
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics provider
+# ---------------------------------------------------------------------------
+
+
+def test_diagnostics_provider_returns_not_built_before_first_build():
+    from services import diagnostics_service
+
+    snap = diagnostics_service.snapshot("resource_provisioning_catalogue")
+    assert snap["status"] == "not_built"
+    assert "hint" in snap
+
+
+def test_diagnostics_provider_returns_counts_after_build():
+    _register(
+        "logging",
+        bindings=(_binding("mod_channel"), _binding("cleanup_channel")),
+        resources=(
+            _requirement(
+                kind=ResourceKind.CHANNEL,
+                intent="mod_log",
+                priority=ProvisioningPriority.RECOMMENDED,
+                binding_name="mod_channel",
+            ),
+            _requirement(
+                kind=ResourceKind.CHANNEL,
+                intent="cleanup_log",
+                priority=ProvisioningPriority.OPTIONAL,
+                binding_name="cleanup_channel",
+            ),
+        ),
+    )
+    build_provisioning_catalogue()
+    from services import diagnostics_service
+
+    snap = diagnostics_service.snapshot("resource_provisioning_catalogue")
+    assert snap["status"] == "built"
+    assert snap["version"] == 1
+    assert snap["option_count"] == 2
+    assert snap["subsystem_count"] == 1
+    assert snap["by_priority"] == {"recommended": 1, "optional": 1}
+    assert snap["by_kind"] == {"channel": 2}
+    assert snap["by_subsystem"] == {"logging": 2}
+    assert snap["findings_total"] == 0
+
+
+def test_diagnostics_provider_is_registered_at_import_time():
+    from services import diagnostics_service
+
+    assert "resource_provisioning_catalogue" in diagnostics_service.registered_names()

--- a/tests/unit/services/test_resource_provisioning_catalogue_import_cycle.py
+++ b/tests/unit/services/test_resource_provisioning_catalogue_import_cycle.py
@@ -1,0 +1,110 @@
+"""Import-cycle regression for services.resource_provisioning_catalogue — S2.5.
+
+The catalogue reads :func:`core.runtime.subsystem_schema.all_schemas`
+once per build, and the diagnostics provider registers with
+:mod:`services.diagnostics_service` at import time. Importing either
+at module scope would re-enter partially-loaded packages during
+startup. The discipline mirrors
+:mod:`services.platform_consistency` and
+:mod:`services.customization_catalogue`: top-level imports are
+stdlib only; every cross-package import is function-local.
+
+Mirrors:
+
+* tests/unit/runtime/test_command_surface_ledger_import_cycle.py
+* tests/unit/runtime/test_settings_registry_import_cycle.py
+* tests/unit/services/test_customization_catalogue_import_cycle.py
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_CATALOGUE_PATH = (
+    _REPO_ROOT
+    / "disbot"
+    / "services"
+    / "resource_provisioning_catalogue.py"
+)
+
+# Forbidden top-level imports — any cross-package access must be
+# function-local. ``services.diagnostics_service`` and other siblings
+# are also kept function-local to match the platform_consistency and
+# customization_catalogue pattern and keep the cycle test stable as
+# new sources are added.
+_FORBIDDEN_TOP_LEVEL_PREFIXES = (
+    "cogs",
+    "core",
+    "discord",
+    "services.customization_catalogue",
+    "services.diagnostics_service",
+    "services.platform_consistency",
+    "utils",
+    "views",
+)
+
+
+def _module_level_imports(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    offenders: list[str] = []
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for prefix in _FORBIDDEN_TOP_LEVEL_PREFIXES:
+                if module == prefix or module.startswith(prefix + "."):
+                    offenders.append(
+                        f"from {module} import "
+                        f"{', '.join(a.name for a in node.names)}",
+                    )
+                    break
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                for prefix in _FORBIDDEN_TOP_LEVEL_PREFIXES:
+                    if alias.name == prefix or alias.name.startswith(prefix + "."):
+                        offenders.append(f"import {alias.name}")
+                        break
+    return offenders
+
+
+def test_resource_provisioning_catalogue_no_top_level_cycle_imports():
+    offenders = _module_level_imports(_CATALOGUE_PATH)
+    assert not offenders, (
+        "services.resource_provisioning_catalogue has cycle-sensitive "
+        "top-level imports:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_resource_provisioning_catalogue_imports_in_fresh_interpreter():
+    script = textwrap.dedent(
+        """
+        import sys
+        sys.path.insert(0, "disbot")
+        import services.resource_provisioning_catalogue  # noqa: F401
+        from services import diagnostics_service
+
+        assert (
+            "resource_provisioning_catalogue" in diagnostics_service.registered_names()
+        )
+        snap = diagnostics_service.snapshot("resource_provisioning_catalogue")
+        assert snap["status"] == "not_built"
+        print("ok")
+        """,
+    )
+    result = subprocess.run(  # noqa: S603 — script literal under our control
+        [sys.executable, "-c", script],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"services.resource_provisioning_catalogue import failed in subprocess.\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary

S2.5 of the **Global Settings & Customization Manager** roadmap. PR
#92 (S0), #93 (S1), and #94 (S2) have all merged; this PR has been
**rebased onto current `main`** (which now includes the merged S2
catalogue) and the three expected conflicts have been resolved
without removing S2 functionality.

Lands a frozen, read-only catalogue of every `ResourceRequirement`
declared across all `SubsystemSchema`s, cross-linked with the
`BindingSpec` that owns the runtime value of the resource. Future
`ResourceProvisioningPipeline` (S4.5) and per-subsystem setup-pack
UX (S10) consume this snapshot so **"what to create" and "where to
write the binding" come from a single declarative source**.

## Reconciliation with merged S2 (PR #94)

PR #94 (`!platform customization` + `customization_catalogue`)
merged while this branch was open. Three files conflicted because
S2 and S2.5 both extended the same surfaces with additive entries.
The merge commit `db74f6b` resolved them as follows — both surfaces
remain fully present:

- **`disbot/bot1.py`** — both `try/except` build_*_catalogue(bot)
  blocks sit side-by-side right after `build_registry()`. Order:
  S2's `build_catalogue()` first, then S2.5's
  `build_provisioning_catalogue()`. Both remain non-fatal on
  failure so the bot still boots if either catalogue cannot build.
- **`disbot/cogs/diagnostic_cog.py`** — both new `!platform`
  subcommands sit side-by-side after `!platform settings-registry`.
  Order: `!platform customization` (S2) then `!platform provisioning`
  (S2.5). Diagnostic cog now at 795 LOC — under the 800-LOC
  `test_cog_size` FAIL threshold.
- **`disbot/cogs/diagnostic/_platform_embeds.py`** — both new
  builder functions sit side-by-side. Order:
  `build_customization_embed` then `build_provisioning_embed`. Both
  appear in `__all__`.

No S2 functionality was removed; both `!platform customization` and
`!platform provisioning` remain wired and import-safe.

## Cross-link logic

For each subsystem schema, every `ResourceRequirement` with a
`binding_name` field is matched against the schema's `BindingSpec`
entries. The resulting `ProvisioningOption` carries both:

- **Requirement-side metadata**: `kind`, `intent`, `priority`,
  `suggested_name`, `suggested_category`, `suggested_permissions`,
  `description`.
- **Binding-side metadata**: `capability_required`,
  `binding_required`, `binding_hint`, `binding_kind`.

`ProvisioningOption.binding_kind` is `None` when no matching
`BindingSpec` was found in the schema (a `binding_targets_unknown`
finding). The other binding-side fields stay empty/default in that
case, but the option is still emitted so the operator can see the
gap.

## Findings buckets

- `orphan_requirements` — `ResourceRequirement` with no
  `binding_name` cross-link.
- `binding_targets_unknown` — `binding_name` does not match any
  `BindingSpec` in the same schema.
- `duplicate_options` — same `(subsystem, binding_name)` pair
  declared more than once. First occurrence becomes the option;
  duplicates are dropped.
- `kind_mismatch` — `ResourceKind` of the requirement does not
  equal the `BindingKind` of the cross-linked binding.

## Changes

- **`disbot/services/resource_provisioning_catalogue.py`** (new, 326
  LOC) — public surface: `ProvisioningOption`,
  `ProvisioningFindings`, `ProvisioningCatalogue`,
  `build_provisioning_catalogue()`,
  `get_cached_provisioning_catalogue()`. Read-only — no mutation
  surface, no resource creation, no UI.
- **`disbot/bot1.py`** — call `build_provisioning_catalogue()` after
  `build_catalogue()` (S2) and `build_registry()` (S1).
- **`disbot/cogs/diagnostic_cog.py`** — `!platform provisioning`
  subcommand (administrator-only).
- **`disbot/cogs/diagnostic/_platform_embeds.py`** —
  `build_provisioning_embed()`.
- **`tests/unit/services/test_resource_provisioning_catalogue.py`**
  (new, 26 tests) — covers every cross-link path and every findings
  bucket.
- **`tests/unit/services/test_resource_provisioning_catalogue_import_cycle.py`**
  (new, 2 tests) — pins the cycle discipline.

## Test plan (re-run after merging current main)

- [x] `python3 -m pytest tests/unit/services/test_resource_provisioning_catalogue.py` — **26 passed**
- [x] `python3 -m pytest tests/unit/services/test_resource_provisioning_catalogue_import_cycle.py` — **2 passed**
- [x] `python3 -m pytest tests/unit/services/test_customization_catalogue.py` — **44 passed** (S2 catalogue still green after the merge)
- [x] `python3 -m pytest tests/unit/services/test_customization_catalogue_import_cycle.py` — **2 passed**
- [x] `python3 -m pytest tests/unit/invariants/test_cog_size.py` — **41 passed** (`diagnostic_cog.py` at 795 LOC, under the 800 fail threshold)
- [x] `python3 -m pytest tests/unit/` — full suite: **1681 passed**
- [x] `ruff check disbot/` — clean
- [x] `black --check disbot/` — 234 files unchanged
- [x] `isort --check-only disbot/ tests/` — clean
- [x] `mypy disbot/` — no issues found in 234 source files

## Manual smoke checklist

- `!platform provisioning` renders the catalogue with priority / kind / by-subsystem histograms and findings counts.
- `!platform customization` (S2) continues to render — both commands coexist on the diagnostic cog.
- `!platform resource-requirements` (Phase 1c flat view) and `!platform settings-registry`, `!platform schemas`, `!platform consistency` continue to render unchanged.
- `bot1.py` boots even if either catalogue build raises (try/except → WARNING log; each catalogue command reports `not_built`).

## Risks and rollback

- **Risk:** none — module is read-only; `!platform provisioning` is administrator-only; the startup wiring is non-fatal on failure.
- **Rollback:** revert this branch's two commits (`851599b` + the merge `db74f6b`); main keeps S2 untouched.

## Deferred work

Matches the S1 / S2 precedent — a `services.platform_consistency`
collector (`_collect_resource_provisioning_catalogue`) surfacing
`findings_total > 0` as INFO will land in a follow-up PR that bundles
the deferred collectors from #93, #94, and this PR.

## Next recommended PR

**S3 — `SettingsResolution`** (PR #96, already open) — scalar-only
read path with provenance. Built on `main` and stands alone.