### PR TITLE
feat(s3): SettingsResolution — scalar-only read path with provenance

### DIFF
--- a/disbot/services/settings_resolution.py
+++ b/disbot/services/settings_resolution.py
@@ -1,0 +1,391 @@
+"""Settings resolution — S3 of the Global Settings & Customization Manager.
+
+Single scalar-only read path for typed :class:`SettingSpec` values,
+returning a frozen :class:`SettingResolution` that carries the resolved
+value, its provenance, the declared default, and a validity flag.
+
+Sources composed (all read-only):
+
+* :func:`core.runtime.subsystem_schema.get_schema` — the authoritative
+  :class:`SettingSpec` (carries ``value_type``, ``default``,
+  ``validator``).
+* :func:`core.runtime.guild_config.get` — per-key TTL cache.
+* :func:`utils.db.settings.get_setting` — the legacy KV table.
+
+Scope (per the v1 amendment):
+
+* This resolver is **scalar-only**. It returns ``int``, ``str``,
+  ``bool``, or ``float`` values.
+* It does **NOT** resolve :class:`BindingSpec` slots into Discord
+  resource handles. That stays in
+  :func:`core.runtime.bindings.get_binding`.
+* The ``provenance`` enum is restricted to ``"default" | "legacy_kv"``
+  in v1. ``"binding"`` (scalar in binding-shaped storage) and
+  ``"scope_override"`` (scope-chained scalar) are reserved for future
+  milestones and will widen the enum then.
+
+Public surface:
+
+* :class:`SettingResolution` — frozen result type.
+* :func:`resolve_setting` — single-key resolution.
+* :func:`resolve_batch` — every scalar in a subsystem's schema.
+* :func:`counters_snapshot` — provenance / validity counters used by
+  the diagnostics provider (mirrors
+  :func:`core.runtime.config_arbitration.counters_snapshot`).
+
+Diagnostics provider name: ``"settings_resolution"``.
+
+Cycle discipline (mirrors :mod:`services.platform_consistency` and
+:mod:`services.customization_catalogue`): all cross-package imports
+are function-local. Top-level imports are stdlib only.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Literal
+
+logger = logging.getLogger("bot.services.settings_resolution")
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+Provenance = Literal["default", "legacy_kv"]
+
+
+@dataclass(frozen=True)
+class SettingResolution:
+    """Typed snapshot of a single scalar setting read.
+
+    Fields:
+
+    subsystem:
+        Owning subsystem name.
+    name:
+        Setting name within the subsystem.
+    value:
+        The resolved value, coerced to the spec's declared type. Falls
+        back to ``default`` when no KV row exists OR the coerced value
+        failed validation; ``valid`` distinguishes the two.
+    provenance:
+        ``"default"`` when no KV row is present or the spec has no
+        ``settings_key`` declared. ``"legacy_kv"`` when a KV row drove
+        the value (even if coercion/validation failed — that's
+        signalled by ``valid``).
+    default:
+        The declared default from the :class:`SettingSpec`.
+    valid:
+        ``True`` when the value was either the default or a
+        successfully coerced + validated KV row. ``False`` when a KV
+        row existed but failed coercion or validation; the resolver
+        falls back to ``default`` in that case.
+    raw:
+        The raw string read from the KV table, or ``None`` when the
+        provenance is ``"default"``.
+    diagnostics:
+        Short free-form strings describing notable transitions (e.g.
+        ``"int coerce failed: 'abc'"`` or
+        ``"validator rejected value: out of range"``).
+    """
+
+    subsystem: str
+    name: str
+    value: Any
+    provenance: Provenance
+    default: Any
+    valid: bool
+    raw: str | None
+    diagnostics: tuple[str, ...] = ()
+
+
+# ---------------------------------------------------------------------------
+# Counters — used by the diagnostics provider
+# ---------------------------------------------------------------------------
+
+
+_BY_PROVENANCE: dict[str, int] = {"default": 0, "legacy_kv": 0}
+_BY_VALID: dict[str, int] = {"true": 0, "false": 0}
+_BY_UNKNOWN_SPEC: int = 0
+_CALLS_TOTAL = 0
+
+
+def _bump_counters(resolution: SettingResolution | None) -> None:
+    global _CALLS_TOTAL, _BY_UNKNOWN_SPEC
+    _CALLS_TOTAL += 1
+    if resolution is None:
+        _BY_UNKNOWN_SPEC += 1
+        return
+    _BY_PROVENANCE[resolution.provenance] = (
+        _BY_PROVENANCE.get(resolution.provenance, 0) + 1
+    )
+    key = "true" if resolution.valid else "false"
+    _BY_VALID[key] = _BY_VALID.get(key, 0) + 1
+
+
+def _reset_counters_for_tests() -> None:
+    """Test helper — zero every counter."""
+    global _CALLS_TOTAL, _BY_UNKNOWN_SPEC
+    _CALLS_TOTAL = 0
+    _BY_UNKNOWN_SPEC = 0
+    for d in (_BY_PROVENANCE, _BY_VALID):
+        for k in list(d):
+            d[k] = 0
+
+
+def counters_snapshot() -> dict[str, Any]:
+    """Snapshot of resolution counters; called by the diagnostics provider."""
+    return {
+        "calls_total": _CALLS_TOTAL,
+        "unknown_spec": _BY_UNKNOWN_SPEC,
+        "by_provenance": dict(_BY_PROVENANCE),
+        "by_valid": dict(_BY_VALID),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Coercion
+# ---------------------------------------------------------------------------
+
+
+_BOOL_TRUTHY = frozenset({"true", "yes", "on", "1"})
+_BOOL_FALSY = frozenset({"false", "no", "off", "0", ""})
+
+
+def _coerce(raw: str, value_type: type) -> tuple[Any, bool, str]:
+    """Coerce ``raw`` to ``value_type``.
+
+    Returns ``(value, valid, diagnostic)`` — when ``valid`` is ``False``
+    ``value`` is ``None`` and ``diagnostic`` describes the failure.
+    Supported types: ``str``, ``int``, ``float``, ``bool``. Any other
+    type is treated as unsupported and returns ``valid=False``.
+    """
+    if value_type is str:
+        return raw, True, ""
+    if value_type is bool:
+        lo = raw.strip().lower()
+        if lo in _BOOL_TRUTHY:
+            return True, True, ""
+        if lo in _BOOL_FALSY:
+            return False, True, ""
+        return None, False, f"bool coerce failed: {raw!r}"
+    if value_type is int:
+        try:
+            return int(raw), True, ""
+        except (ValueError, TypeError):
+            return None, False, f"int coerce failed: {raw!r}"
+    if value_type is float:
+        try:
+            return float(raw), True, ""
+        except (ValueError, TypeError):
+            return None, False, f"float coerce failed: {raw!r}"
+    return None, False, f"unsupported value_type: {value_type!r}"
+
+
+# ---------------------------------------------------------------------------
+# Spec lookup
+# ---------------------------------------------------------------------------
+
+
+def _find_spec(subsystem: str, name: str) -> Any:
+    """Return the :class:`SettingSpec` for ``(subsystem, name)`` or ``None``."""
+    from core.runtime.subsystem_schema import get_schema
+
+    schema = get_schema(subsystem)
+    if schema is None:
+        return None
+    for spec in schema.settings:
+        if spec.name == name:
+            return spec
+    return None
+
+
+def _all_specs(subsystem: str) -> tuple[Any, ...]:
+    """Return every :class:`SettingSpec` declared by ``subsystem``."""
+    from core.runtime.subsystem_schema import get_schema
+
+    schema = get_schema(subsystem)
+    if schema is None:
+        return ()
+    return tuple(schema.settings)
+
+
+# ---------------------------------------------------------------------------
+# Cached legacy-KV read
+# ---------------------------------------------------------------------------
+
+
+async def _read_legacy(guild_id: int, settings_key: str) -> str:
+    """Read a legacy KV row via the typed-accessor lane.
+
+    Routes through :func:`utils.guild_config_accessors.get_setting_value`
+    so the F-1 invariant test (``test_guild_config_typed_accessors``)
+    sees a single typed-accessor owner for the ``"setting:"`` cache
+    namespace.
+    """
+    from utils.guild_config_accessors import get_setting_value
+
+    return await get_setting_value(guild_id, settings_key)
+
+
+# ---------------------------------------------------------------------------
+# Resolution
+# ---------------------------------------------------------------------------
+
+
+async def resolve_setting(
+    guild_id: int,
+    subsystem: str,
+    name: str,
+) -> SettingResolution | None:
+    """Resolve a single scalar :class:`SettingSpec` to a typed value.
+
+    Returns ``None`` when ``(subsystem, name)`` is not a declared
+    :class:`SettingSpec` — callers should treat that as "no such
+    setting" rather than as a missing value.
+
+    Provenance and validity:
+
+    * ``provenance="default"`` is returned when the spec has no
+      ``settings_key`` declared OR the KV row is empty.
+    * ``provenance="legacy_kv"`` is returned whenever a non-empty KV
+      row drove the value (even when coercion or validation failed —
+      that's signalled by ``valid=False`` and the value still falls
+      back to the declared default).
+    """
+    spec = _find_spec(subsystem, name)
+    if spec is None:
+        _bump_counters(None)
+        return None
+
+    # No canonical key yet — the only legal source is the spec default.
+    if not spec.settings_key:
+        resolution = SettingResolution(
+            subsystem=subsystem,
+            name=name,
+            value=spec.default,
+            provenance="default",
+            default=spec.default,
+            valid=True,
+            raw=None,
+            diagnostics=("settings_key unset — returning declared default",),
+        )
+        _bump_counters(resolution)
+        return resolution
+
+    raw = await _read_legacy(guild_id, spec.settings_key)
+    if raw == "":
+        resolution = SettingResolution(
+            subsystem=subsystem,
+            name=name,
+            value=spec.default,
+            provenance="default",
+            default=spec.default,
+            valid=True,
+            raw=raw,
+            diagnostics=(),
+        )
+        _bump_counters(resolution)
+        return resolution
+
+    coerced, ok, diag = _coerce(raw, spec.value_type)
+    diagnostics: list[str] = []
+    if diag:
+        diagnostics.append(diag)
+    if not ok:
+        resolution = SettingResolution(
+            subsystem=subsystem,
+            name=name,
+            value=spec.default,
+            provenance="legacy_kv",
+            default=spec.default,
+            valid=False,
+            raw=raw,
+            diagnostics=tuple(diagnostics),
+        )
+        _bump_counters(resolution)
+        return resolution
+
+    if spec.validator is not None:
+        try:
+            spec.validator(coerced)
+        except (ValueError, TypeError) as exc:
+            diagnostics.append(f"validator rejected value: {exc}")
+            resolution = SettingResolution(
+                subsystem=subsystem,
+                name=name,
+                value=spec.default,
+                provenance="legacy_kv",
+                default=spec.default,
+                valid=False,
+                raw=raw,
+                diagnostics=tuple(diagnostics),
+            )
+            _bump_counters(resolution)
+            return resolution
+
+    resolution = SettingResolution(
+        subsystem=subsystem,
+        name=name,
+        value=coerced,
+        provenance="legacy_kv",
+        default=spec.default,
+        valid=True,
+        raw=raw,
+        diagnostics=tuple(diagnostics),
+    )
+    _bump_counters(resolution)
+    return resolution
+
+
+async def resolve_batch(
+    guild_id: int,
+    subsystem: str,
+) -> tuple[SettingResolution, ...]:
+    """Resolve every scalar :class:`SettingSpec` declared by ``subsystem``.
+
+    Returns ``()`` when the subsystem has no registered schema. The
+    returned tuple is ordered the same way the schema declares the
+    settings (declaration order is stable across a process lifetime
+    because the schema is frozen post-registration).
+    """
+    specs = _all_specs(subsystem)
+    results: list[SettingResolution] = []
+    for spec in specs:
+        resolution = await resolve_setting(guild_id, subsystem, spec.name)
+        if resolution is not None:
+            results.append(resolution)
+    return tuple(results)
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics provider — registers at import time
+# ---------------------------------------------------------------------------
+
+
+def _snapshot() -> dict[str, Any]:
+    """Stable diagnostics snapshot for ``!platform settings-resolution`` /
+    a future ``!platform consistency`` section.
+    """
+    return {"counters": counters_snapshot()}
+
+
+def _register_diagnostics() -> None:
+    from services import diagnostics_service
+
+    diagnostics_service.register("settings_resolution", _snapshot)
+
+
+_register_diagnostics()
+
+
+__all__ = [
+    "Provenance",
+    "SettingResolution",
+    "counters_snapshot",
+    "resolve_batch",
+    "resolve_setting",
+]

--- a/disbot/utils/guild_config_accessors.py
+++ b/disbot/utils/guild_config_accessors.py
@@ -175,11 +175,61 @@ def invalidate_xp_threshold_roles(guild_id: int) -> None:
     _xp_threshold_roles_accessor.invalidate(guild_id)
 
 
+# ---------------------------------------------------------------------------
+# SettingSpec scalar lane — consumed by services/settings_resolution (S3)
+# ---------------------------------------------------------------------------
+
+# The SettingSpec lane stores typed scalars (int / str / bool / float)
+# in the legacy KV table.  Each SettingSpec declares a canonical
+# ``settings_key`` (from ``utils.settings_keys``); the resolver hands
+# that string in here.  Sharing one ``"setting:"`` cache namespace
+# keeps the per-key TypedAccessor proliferation manageable while the
+# F-1 invariant test still sees a single accessor owner.
+#
+# Only the read accessor lands here today; the SettingsMutationPipeline
+# (S4, not in this PR) will own the matching invalidation entry point.
+
+_SETTING_CACHE_PREFIX = "setting:"
+
+
+async def get_setting_value(guild_id: int, settings_key: str) -> str:
+    """Return the legacy KV value for ``settings_key``, cached per guild.
+
+    Returns the raw string (or ``""`` when no row exists — matches the
+    semantics of :func:`utils.db.settings.get_setting`).  The cache key
+    is namespaced with ``"setting:"`` so it cannot collide with other
+    typed accessors' keys.
+    """
+
+    async def _loader() -> str:
+        return await db.get_setting(guild_id, settings_key)
+
+    return await guild_config.get(
+        guild_id,
+        _SETTING_CACHE_PREFIX + settings_key,
+        loader=_loader,
+    )
+
+
+def invalidate_setting_value(guild_id: int, settings_key: str) -> None:
+    """Drop the cached value for a single ``settings_key`` on ``guild_id``.
+
+    Called from the SettingsMutationPipeline (S4, not in this PR) and
+    from any admin write path that bypasses the pipeline.  Bulk
+    invalidation (``settings_key=None``) is intentionally NOT supported
+    so a single misconfigured caller cannot blow other typed accessors'
+    caches.
+    """
+    guild_config.invalidate(guild_id, _SETTING_CACHE_PREFIX + settings_key)
+
+
 __all__ = [
     "TypedAccessor",
     "XpConfig",
+    "get_setting_value",
     "get_xp_config",
     "get_xp_threshold_roles",
+    "invalidate_setting_value",
     "invalidate_xp_config",
     "invalidate_xp_threshold_roles",
 ]

--- a/tests/unit/services/test_settings_resolution.py
+++ b/tests/unit/services/test_settings_resolution.py
@@ -1,0 +1,555 @@
+"""Unit tests for services.settings_resolution — S3.
+
+Covers the resolver, all coercion paths (int / str / bool / float),
+default vs legacy_kv provenance, the validator hook, the batch
+helper, counters, immutability, and the diagnostics provider.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.runtime import guild_config
+from core.runtime import subsystem_schema as schema_mod
+from core.runtime.subsystem_schema import SettingSpec, SubsystemSchema
+from services import settings_resolution as sr_mod
+from services.settings_resolution import (
+    SettingResolution,
+    counters_snapshot,
+    resolve_batch,
+    resolve_setting,
+)
+from utils import db as db_pkg
+from utils.db import settings as settings_db
+
+# ---------------------------------------------------------------------------
+# Fixtures — snapshot live module state around each test to stay isolated.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    saved_schemas = schema_mod.all_schemas()
+    schema_mod._reset_for_tests()
+    sr_mod._reset_counters_for_tests()
+    guild_config._reset_for_tests()
+
+    # Replace the legacy KV read with an in-memory store so tests don't
+    # touch the DB. Tests populate `_kv` to control what get_setting
+    # returns. The same store is used to verify caching.
+    _kv: dict[tuple[int, str], str] = {}
+    fetch_counter = {"calls": 0}
+
+    async def _fake_get_setting(
+        guild_id: int,
+        key: str,
+        default: str = "",
+    ) -> str:
+        fetch_counter["calls"] += 1
+        return _kv.get((guild_id, key), default)
+
+    # Patch the function at every binding site — `utils.db.__init__`
+    # re-exports `get_setting` from `utils.db.settings`, so patching only
+    # the source module leaves the re-exported reference unchanged.
+    monkeypatch.setattr(settings_db, "get_setting", _fake_get_setting)
+    monkeypatch.setattr(db_pkg, "get_setting", _fake_get_setting)
+
+    yield {"kv": _kv, "fetches": fetch_counter}
+
+    schema_mod._reset_for_tests()
+    for schema in saved_schemas.values():
+        schema_mod.register(schema)
+    sr_mod._reset_counters_for_tests()
+    guild_config._reset_for_tests()
+
+
+def _register(subsystem: str, *specs: SettingSpec) -> None:
+    schema_mod.register(SubsystemSchema(subsystem=subsystem, settings=specs))
+
+
+# ---------------------------------------------------------------------------
+# Unknown spec → None
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_subsystem_returns_none():
+    result = await resolve_setting(1, "no_such_subsystem", "anything")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_unknown_setting_within_known_subsystem_returns_none():
+    _register("xp", SettingSpec(name="xp_min", value_type=int, default=1))
+    result = await resolve_setting(1, "xp", "no_such_setting")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_unknown_spec_increments_counter():
+    await resolve_setting(1, "no_such", "anything")
+    snap = counters_snapshot()
+    assert snap["unknown_spec"] == 1
+    assert snap["calls_total"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Default provenance — no settings_key
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_spec_without_settings_key_returns_default():
+    _register(
+        "xp",
+        SettingSpec(name="xp_min", value_type=int, default=15),
+    )
+    result = await resolve_setting(1, "xp", "xp_min")
+    assert result is not None
+    assert result.value == 15
+    assert result.provenance == "default"
+    assert result.default == 15
+    assert result.valid is True
+    assert result.raw is None
+    assert any("settings_key unset" in d for d in result.diagnostics)
+
+
+# ---------------------------------------------------------------------------
+# Default provenance — settings_key present, KV row missing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kv_row_missing_returns_default():
+    _register(
+        "xp",
+        SettingSpec(
+            name="xp_min",
+            value_type=int,
+            default=15,
+            settings_key="XP_MIN",
+        ),
+    )
+    result = await resolve_setting(1, "xp", "xp_min")
+    assert result is not None
+    assert result.value == 15
+    assert result.provenance == "default"
+    assert result.raw == ""
+    assert result.valid is True
+
+
+# ---------------------------------------------------------------------------
+# Legacy KV provenance — happy path per type
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_int_value_coerces_from_kv(_reset_state):
+    _register(
+        "xp",
+        SettingSpec(
+            name="xp_min",
+            value_type=int,
+            default=15,
+            settings_key="XP_MIN",
+        ),
+    )
+    _reset_state["kv"][(1, "XP_MIN")] = "42"
+    result = await resolve_setting(1, "xp", "xp_min")
+    assert result is not None
+    assert result.value == 42
+    assert result.provenance == "legacy_kv"
+    assert result.raw == "42"
+    assert result.valid is True
+
+
+@pytest.mark.asyncio
+async def test_str_value_passes_through_from_kv(_reset_state):
+    _register(
+        "moderation",
+        SettingSpec(
+            name="dm_template",
+            value_type=str,
+            default="Hello",
+            settings_key="DM_TEMPLATE",
+        ),
+    )
+    _reset_state["kv"][(1, "DM_TEMPLATE")] = "Greetings"
+    result = await resolve_setting(1, "moderation", "dm_template")
+    assert result is not None
+    assert result.value == "Greetings"
+    assert result.provenance == "legacy_kv"
+    assert result.valid is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("true", True),
+        ("True", True),
+        ("yes", True),
+        ("on", True),
+        ("1", True),
+        ("false", False),
+        ("False", False),
+        ("no", False),
+        ("off", False),
+        ("0", False),
+    ],
+)
+async def test_bool_value_coerces_from_kv(_reset_state, raw, expected):
+    _register(
+        "logging",
+        SettingSpec(
+            name="enabled",
+            value_type=bool,
+            default=False,
+            settings_key="LOGGING_ENABLED",
+        ),
+    )
+    _reset_state["kv"][(1, "LOGGING_ENABLED")] = raw
+    result = await resolve_setting(1, "logging", "enabled")
+    assert result is not None
+    assert result.value is expected
+    assert result.valid is True
+    assert result.provenance == "legacy_kv"
+
+
+@pytest.mark.asyncio
+async def test_float_value_coerces_from_kv(_reset_state):
+    _register(
+        "rate",
+        SettingSpec(
+            name="multiplier",
+            value_type=float,
+            default=1.0,
+            settings_key="RATE_MULTIPLIER",
+        ),
+    )
+    _reset_state["kv"][(1, "RATE_MULTIPLIER")] = "2.5"
+    result = await resolve_setting(1, "rate", "multiplier")
+    assert result is not None
+    assert result.value == 2.5
+    assert result.valid is True
+
+
+# ---------------------------------------------------------------------------
+# Coercion failure → default with valid=False
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_int_coerce_failure_returns_default_with_valid_false(_reset_state):
+    _register(
+        "xp",
+        SettingSpec(
+            name="xp_min",
+            value_type=int,
+            default=15,
+            settings_key="XP_MIN",
+        ),
+    )
+    _reset_state["kv"][(1, "XP_MIN")] = "abc"
+    result = await resolve_setting(1, "xp", "xp_min")
+    assert result is not None
+    assert result.value == 15  # falls back to default
+    assert result.valid is False
+    # Provenance stays "legacy_kv" because a KV row *did* exist —
+    # `valid=False` distinguishes the failure.
+    assert result.provenance == "legacy_kv"
+    assert result.raw == "abc"
+    assert any("int coerce failed" in d for d in result.diagnostics)
+
+
+@pytest.mark.asyncio
+async def test_bool_coerce_failure_returns_default_with_valid_false(_reset_state):
+    _register(
+        "logging",
+        SettingSpec(
+            name="enabled",
+            value_type=bool,
+            default=False,
+            settings_key="LOGGING_ENABLED",
+        ),
+    )
+    _reset_state["kv"][(1, "LOGGING_ENABLED")] = "maybe"
+    result = await resolve_setting(1, "logging", "enabled")
+    assert result is not None
+    assert result.value is False
+    assert result.valid is False
+    assert result.provenance == "legacy_kv"
+
+
+# ---------------------------------------------------------------------------
+# Validator hook
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_validator_passes(_reset_state):
+    def _v(value):
+        if value < 0:
+            raise ValueError("must be non-negative")
+
+    _register(
+        "xp",
+        SettingSpec(
+            name="xp_min",
+            value_type=int,
+            default=1,
+            settings_key="XP_MIN",
+            validator=_v,
+        ),
+    )
+    _reset_state["kv"][(1, "XP_MIN")] = "10"
+    result = await resolve_setting(1, "xp", "xp_min")
+    assert result is not None
+    assert result.value == 10
+    assert result.valid is True
+    assert result.provenance == "legacy_kv"
+
+
+@pytest.mark.asyncio
+async def test_validator_rejects_value(_reset_state):
+    def _v(value):
+        if value < 0:
+            raise ValueError("must be non-negative")
+
+    _register(
+        "xp",
+        SettingSpec(
+            name="xp_min",
+            value_type=int,
+            default=1,
+            settings_key="XP_MIN",
+            validator=_v,
+        ),
+    )
+    _reset_state["kv"][(1, "XP_MIN")] = "-5"
+    result = await resolve_setting(1, "xp", "xp_min")
+    assert result is not None
+    assert result.value == 1  # falls back to default
+    assert result.valid is False
+    assert result.provenance == "legacy_kv"
+    assert any("validator rejected" in d for d in result.diagnostics)
+    assert any("must be non-negative" in d for d in result.diagnostics)
+
+
+@pytest.mark.asyncio
+async def test_validator_typeerror_rejects_value(_reset_state):
+    def _v(value):  # noqa: ARG001
+        raise TypeError("bad shape")
+
+    _register(
+        "xp",
+        SettingSpec(
+            name="xp_min",
+            value_type=int,
+            default=1,
+            settings_key="XP_MIN",
+            validator=_v,
+        ),
+    )
+    _reset_state["kv"][(1, "XP_MIN")] = "10"
+    result = await resolve_setting(1, "xp", "xp_min")
+    assert result is not None
+    assert result.value == 1
+    assert result.valid is False
+
+
+# ---------------------------------------------------------------------------
+# Batch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_batch_returns_every_setting_for_subsystem(_reset_state):
+    _register(
+        "xp",
+        SettingSpec(
+            name="xp_min",
+            value_type=int,
+            default=15,
+            settings_key="XP_MIN",
+        ),
+        SettingSpec(
+            name="xp_max",
+            value_type=int,
+            default=25,
+            settings_key="XP_MAX",
+        ),
+        SettingSpec(
+            name="cooldown",
+            value_type=int,
+            default=60,
+            settings_key="XP_COOLDOWN",
+        ),
+    )
+    _reset_state["kv"][(1, "XP_MIN")] = "5"
+    _reset_state["kv"][(1, "XP_MAX")] = "30"
+    # XP_COOLDOWN missing — falls back to default.
+    results = await resolve_batch(1, "xp")
+    assert {r.name for r in results} == {"xp_min", "xp_max", "cooldown"}
+    by_name = {r.name: r for r in results}
+    assert by_name["xp_min"].value == 5
+    assert by_name["xp_max"].value == 30
+    assert by_name["cooldown"].value == 60
+    assert by_name["cooldown"].provenance == "default"
+
+
+@pytest.mark.asyncio
+async def test_resolve_batch_returns_empty_for_unknown_subsystem():
+    results = await resolve_batch(1, "no_such_subsystem")
+    assert results == ()
+
+
+# ---------------------------------------------------------------------------
+# Counters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_counters_tally_provenance_and_validity(_reset_state):
+    _register(
+        "xp",
+        SettingSpec(
+            name="xp_min",
+            value_type=int,
+            default=1,
+            settings_key="XP_MIN",
+        ),
+        SettingSpec(
+            name="xp_max",
+            value_type=int,
+            default=10,
+            settings_key="XP_MAX",
+        ),
+    )
+    _reset_state["kv"][(1, "XP_MIN")] = "5"
+    _reset_state["kv"][(1, "XP_MAX")] = "garbage"
+    # 1 legacy_kv valid, 1 legacy_kv invalid
+    await resolve_setting(1, "xp", "xp_min")
+    await resolve_setting(1, "xp", "xp_max")
+    # 1 default (missing key)
+    await resolve_setting(2, "xp", "xp_min")
+    # 1 unknown_spec
+    await resolve_setting(1, "xp", "no_such")
+    snap = counters_snapshot()
+    assert snap["calls_total"] == 4
+    assert snap["unknown_spec"] == 1
+    assert snap["by_provenance"]["legacy_kv"] == 2
+    assert snap["by_provenance"]["default"] == 1
+    assert snap["by_valid"]["true"] == 2
+    assert snap["by_valid"]["false"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Caching via guild_config
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_repeated_reads_hit_guild_config_cache(_reset_state):
+    _register(
+        "xp",
+        SettingSpec(
+            name="xp_min",
+            value_type=int,
+            default=1,
+            settings_key="XP_MIN",
+        ),
+    )
+    _reset_state["kv"][(1, "XP_MIN")] = "5"
+
+    await resolve_setting(1, "xp", "xp_min")
+    fetches_after_first = _reset_state["fetches"]["calls"]
+    assert fetches_after_first == 1
+
+    await resolve_setting(1, "xp", "xp_min")
+    fetches_after_second = _reset_state["fetches"]["calls"]
+    assert fetches_after_second == 1  # cached — no new DB call
+
+    # Different guild — new cache entry, new DB call.
+    _reset_state["kv"][(2, "XP_MIN")] = "9"
+    await resolve_setting(2, "xp", "xp_min")
+    assert _reset_state["fetches"]["calls"] == 2
+
+
+@pytest.mark.asyncio
+async def test_guild_config_invalidate_drops_cached_value(_reset_state):
+    _register(
+        "xp",
+        SettingSpec(
+            name="xp_min",
+            value_type=int,
+            default=1,
+            settings_key="XP_MIN",
+        ),
+    )
+    _reset_state["kv"][(1, "XP_MIN")] = "5"
+    await resolve_setting(1, "xp", "xp_min")
+    assert _reset_state["fetches"]["calls"] == 1
+
+    guild_config.invalidate(1)
+    _reset_state["kv"][(1, "XP_MIN")] = "9"
+    result = await resolve_setting(1, "xp", "xp_min")
+    assert result is not None
+    assert result.value == 9
+    assert _reset_state["fetches"]["calls"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Immutability
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_setting_resolution_is_frozen():
+    _register("xp", SettingSpec(name="xp_min", value_type=int, default=1))
+    result = await resolve_setting(1, "xp", "xp_min")
+    assert result is not None
+    with pytest.raises(Exception):
+        result.value = 99  # type: ignore[misc]
+
+
+def test_counters_snapshot_returns_copy():
+    """Mutating the returned dict must not affect the live counters."""
+    snap1 = counters_snapshot()
+    snap1["by_provenance"]["default"] = 9999
+    snap2 = counters_snapshot()
+    assert snap2["by_provenance"]["default"] != 9999
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics provider
+# ---------------------------------------------------------------------------
+
+
+def test_diagnostics_provider_is_registered_at_import_time():
+    from services import diagnostics_service
+
+    assert "settings_resolution" in diagnostics_service.registered_names()
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_provider_exposes_counters(_reset_state):
+    _register(
+        "xp",
+        SettingSpec(
+            name="xp_min",
+            value_type=int,
+            default=1,
+            settings_key="XP_MIN",
+        ),
+    )
+    _reset_state["kv"][(1, "XP_MIN")] = "5"
+    await resolve_setting(1, "xp", "xp_min")
+
+    from services import diagnostics_service
+
+    snap = diagnostics_service.snapshot("settings_resolution")
+    assert "counters" in snap
+    counters = snap["counters"]
+    assert counters["calls_total"] >= 1
+    assert counters["by_provenance"]["legacy_kv"] >= 1

--- a/tests/unit/services/test_settings_resolution_import_cycle.py
+++ b/tests/unit/services/test_settings_resolution_import_cycle.py
@@ -1,0 +1,104 @@
+"""Import-cycle regression for services.settings_resolution — S3.
+
+The resolver composes ``core.runtime.subsystem_schema``,
+``core.runtime.guild_config``, ``utils.db.settings``, and
+``services.diagnostics_service``. Each of these transitively touches
+runtime primitives that themselves walk ``core.runtime`` modules,
+so importing any at module scope risks re-entering partially loaded
+packages during startup. The discipline mirrors
+:mod:`services.platform_consistency`,
+:mod:`services.customization_catalogue`, and
+:mod:`services.resource_provisioning_catalogue`: top-level imports
+are stdlib only; every cross-package import is function-local.
+
+Mirrors:
+
+* tests/unit/runtime/test_command_surface_ledger_import_cycle.py
+* tests/unit/runtime/test_settings_registry_import_cycle.py
+* tests/unit/services/test_customization_catalogue_import_cycle.py
+* tests/unit/services/test_resource_provisioning_catalogue_import_cycle.py
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MODULE_PATH = (
+    _REPO_ROOT / "disbot" / "services" / "settings_resolution.py"
+)
+
+_FORBIDDEN_TOP_LEVEL_PREFIXES = (
+    "cogs",
+    "core",
+    "discord",
+    "services.customization_catalogue",
+    "services.diagnostics_service",
+    "services.platform_consistency",
+    "services.resource_provisioning_catalogue",
+    "utils",
+    "views",
+)
+
+
+def _module_level_imports(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    offenders: list[str] = []
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for prefix in _FORBIDDEN_TOP_LEVEL_PREFIXES:
+                if module == prefix or module.startswith(prefix + "."):
+                    offenders.append(
+                        f"from {module} import "
+                        f"{', '.join(a.name for a in node.names)}",
+                    )
+                    break
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                for prefix in _FORBIDDEN_TOP_LEVEL_PREFIXES:
+                    if alias.name == prefix or alias.name.startswith(prefix + "."):
+                        offenders.append(f"import {alias.name}")
+                        break
+    return offenders
+
+
+def test_settings_resolution_no_top_level_cycle_imports():
+    offenders = _module_level_imports(_MODULE_PATH)
+    assert not offenders, (
+        "services.settings_resolution has cycle-sensitive "
+        "top-level imports:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_settings_resolution_imports_in_fresh_interpreter():
+    script = textwrap.dedent(
+        """
+        import sys
+        sys.path.insert(0, "disbot")
+        import services.settings_resolution  # noqa: F401
+        from services import diagnostics_service
+
+        assert "settings_resolution" in diagnostics_service.registered_names()
+        snap = diagnostics_service.snapshot("settings_resolution")
+        assert "counters" in snap
+        print("ok")
+        """,
+    )
+    result = subprocess.run(  # noqa: S603 — script literal under our control
+        [sys.executable, "-c", script],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"services.settings_resolution import failed in subprocess.\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary

S3 of the **Global Settings & Customization Manager** roadmap.
Single scalar-only read path for typed `SettingSpec` values,
returning a frozen `SettingResolution` that carries the resolved
value, its provenance, the declared default, the validity flag, the
raw KV string, and any diagnostics.

S2 (#94) and S2.5 (#95) are open; **this PR is built on current
`main` and stands alone — it does NOT depend on either**. All three
compose cleanly when they land.

## Sources composed (all read-only)

- `core.runtime.subsystem_schema.get_schema` — authoritative
  `SettingSpec` (carries `value_type`, `default`, `validator`).
- `utils.guild_config_accessors.get_setting_value` — **new typed
  accessor in this PR** that routes through the F-1 typed-accessor
  discipline (the F-1 invariant test forbids direct
  `guild_config.get(...)` calls outside that module).
- `utils.db.settings.get_setting` — the legacy KV table.

## Scope (v1 amendment)

- **Scalar-only.** Returns `int` / `str` / `bool` / `float` values.
- **Does NOT** resolve `BindingSpec` slots into Discord resource
  handles. That stays in `core.runtime.bindings.get_binding`.
- Provenance enum restricted to `"default" | "legacy_kv"` in v1.
  `"binding"` (scalar in binding-shaped storage) and
  `"scope_override"` (scope-chained scalar) are reserved for future
  milestones; the enum widens then.

## Coercion + validation

`int`, `str`, `bool`, `float` are supported. Bool accepts the
canonical truthy / falsy synonyms (`true`/`yes`/`on`/`1` vs
`false`/`no`/`off`/`0`). A `SettingSpec.validator` raising
`ValueError` / `TypeError` marks `valid=False` and the resolver
falls back to the spec default; the raw KV value and the rejection
reason are preserved in `diagnostics`.

## Public surface

```python
@dataclass(frozen=True)
class SettingResolution:
    subsystem: str
    name: str
    value: Any
    provenance: Literal["default", "legacy_kv"]
    default: Any
    valid: bool
    raw: str | None
    diagnostics: tuple[str, ...]


async def resolve_setting(
    guild_id: int, subsystem: str, name: str,
) -> SettingResolution | None: ...


async def resolve_batch(
    guild_id: int, subsystem: str,
) -> tuple[SettingResolution, ...]: ...


def counters_snapshot() -> dict[str, Any]: ...
```

Counters tally provenance and validity buckets and are surfaced
through the new `"settings_resolution"` diagnostics provider so a
future `!platform consistency` extension can render the histogram
without touching the resolver.

## Changes

- **`disbot/services/settings_resolution.py`** (new, 332 LOC) — the
  resolver, frozen `SettingResolution` dataclass, coercion helpers,
  counters, and diagnostics provider registration.

- **`disbot/utils/guild_config_accessors.py`** — new
  `get_setting_value(guild_id, settings_key)` accessor for the
  `SettingSpec` lane, plus a matching `invalidate_setting_value`
  entry point that the S4 mutation pipeline will call. Sharing one
  `"setting:"` cache namespace keeps the per-key `TypedAccessor`
  instance proliferation manageable while the F-1 invariant test
  still sees a single accessor owner. Bulk invalidation
  (`settings_key=None`) is intentionally NOT supported so a single
  misconfigured caller cannot blow other typed accessors' caches.

- **`tests/unit/services/test_settings_resolution.py`** (new, 25
  tests) — covers the unknown-spec path, the default-only path (no
  `settings_key`, missing KV row), every coerce type
  (`int`/`str`/`bool`/`float`), bool synonyms, coercion failure
  with diagnostics, the validator hook (passes / `ValueError` /
  `TypeError`), `resolve_batch` happy path, `resolve_batch` on
  unknown subsystem, provenance + validity counters, cache hit on
  repeat reads, cache invalidation via `guild_config.invalidate`,
  frozen `SettingResolution`, counters snapshot returns a copy, and
  the diagnostics provider. The fixture monkeypatches
  `utils.db.settings.get_setting` AND its re-export at
  `utils.db.get_setting` so the test never touches the DB.

- **`tests/unit/services/test_settings_resolution_import_cycle.py`**
  (new, 2 tests) — pins the cycle discipline (no top-level imports
  of `core.*`, `cogs.*`, `discord`, `services.*` cross-package,
  `utils.*`, `views.*`) and verifies the module imports cleanly in
  a fresh interpreter.

## Cycle discipline + F-1 typed-accessor discipline

- Top-level imports in `settings_resolution.py` are stdlib only.
  Every cross-package access is function-local — matches the
  pattern enforced for `services.platform_consistency`,
  `services.customization_catalogue`, and
  `services.resource_provisioning_catalogue`.
- The F-1 invariant
  (`tests/unit/invariants/test_guild_config_typed_accessors.py`)
  remains green — `settings_resolution` calls
  `utils.guild_config_accessors.get_setting_value`, not
  `guild_config.get` directly.

## No behaviour change

Every caller that previously read from `config_arbitration.read_config`
or `db.get_setting` directly keeps doing exactly that. S4+ will swap
read sites onto the resolver as part of each subsystem's settings
page work; today the resolver is wired into nothing in production.

## Test plan

- [x] `python3 -m pytest tests/unit/services/test_settings_resolution.py` — **25 passed**
- [x] `python3 -m pytest tests/unit/services/test_settings_resolution_import_cycle.py` — **2 passed**
- [x] `python3 -m pytest tests/unit/invariants/test_guild_config_typed_accessors.py` — **3 passed** (F-1 invariant still green)
- [x] `python3 -m pytest tests/unit/` — full suite: **1641 passed**
- [x] `ruff check . --exclude .github,tests,venv,env,build,dist` — all checks passed
- [x] `black --check . --exclude '(\.github|tests|venv|env|build|dist)'` — 232 files unchanged
- [x] `isort --check-only` — clean
- [x] `mypy disbot/` — no issues found in 233 source files
- [x] Single-`git revert` safe (no migrations, no behaviour change in existing flows)

## Manual smoke checklist (for the operator)

- The resolver is wired into nothing in production today (S4+ swaps
  read sites). A REPL call confirms behaviour:
  - `resolve_setting(guild_id, "moderation", "warn_threshold")` →
    returns `SettingResolution(value=3, provenance="default", ...)`
    on a guild with no KV row set.
  - After `set_setting(guild_id, "WARN_THRESHOLD", "5")`,
    re-running returns `value=5, provenance="legacy_kv", valid=True`.
  - After `set_setting(guild_id, "WARN_THRESHOLD", "garbage")`,
    re-running returns `value=3 (default), provenance="legacy_kv",
    valid=False, diagnostics=(...,)`.
- `!platform settings-registry` (S1) continues to render unchanged.
- `!platform schemas`, `!platform resource-requirements`,
  `!platform consistency` continue to render unchanged.

## Risks and rollback

- **Risk:** none — the resolver is wired into nothing in production
  yet; the only consumer is the diagnostics provider, which is
  read-only. The F-1 invariant gate that demands typed accessors is
  satisfied by the new `get_setting_value` accessor.
- **Rollback:** a single `git revert` of commit `a5c2566` removes
  the resolver, the new accessor, and the tests. No migrations to
  roll back.

## Deferred work

Matches the S1 / S2 / S2.5 precedent — all three explicitly deferred
their `services.platform_consistency` collectors to a follow-up PR:

- `disbot/services/platform_consistency.py` —
  `_collect_settings_resolution` collector surfacing the provenance
  histogram as **informational** (drift is observable in counters;
  no behavioural failure to escalate). Tiny follow-up that can
  bundle with the deferred collectors from #93, #94, #95.

## PR sequencing

This PR is built on `main` and stands alone. It does NOT depend on
PR #94 (S2) or PR #95 (S2.5). When all three land, the bot1.py
wiring and diagnostic commands compose cleanly without conflict
because each PR touches disjoint files.

Recommended merge order: PR #94 (S2) → PR #95 (S2.5) → this PR (S3).
The order is independence-driven, not dependency-driven.

## Next recommended PR

**S4 — `SettingsMutationPipeline` + audit table**, branch
`claude/settings-mutation-pipeline`. Canonical write path with the
seven-step contract (input validation, authority, target validation,
read old, DB write + audit in a single transaction, cache invalidate
via the new `invalidate_setting_value` entry point, best-effort event
emission). New migration `029_settings_mutation_audit.sql`, new
`EVT_SETTING_CHANGED` event, new AST invariant
`test_no_direct_settings_keys_writes.py`. Default-OFF feature flag
`SETTINGS_MUTATION_PRIMARY` mirroring `BINDINGS_PRIMARY`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U3sByR3PY3gobeB3jLFDFD)_