### PR TITLE
feat(s4): SettingsMutationPipeline + audit table + invariants

### DIFF
--- a/disbot/core/events_catalogue.py
+++ b/disbot/core/events_catalogue.py
@@ -60,6 +60,14 @@ KNOWN_EVENTS: frozenset[str] = frozenset(
         "moderation.action_taken",
         # ── Bindings (services/binding_mutation.py, Phase 2b) ─────────────
         "bindings.changed",
+        # ── Settings (services/settings_mutation.py, S4) ──────────────────
+        # Advisory. Cache invalidation is inline (the pipeline calls
+        # utils.guild_config_accessors.invalidate_setting_value synchronously
+        # w.r.t. the mutation result), NOT event-driven — this event is
+        # for downstream consumers (audit dashboards, future
+        # platform_consistency collector) and never for cache consistency.
+        # Subscriber failure logged + swallowed.
+        "settings.changed",
         # ── Feature flags (services/rollout_mutation.py, Phase 2d PR-3) ───
         # Advisory events emitted after the DB commit + audit row land.
         # Subscriber failure is logged with mutation_id and never raised

--- a/disbot/core/runtime/feature_flags.py
+++ b/disbot/core/runtime/feature_flags.py
@@ -244,6 +244,24 @@ FEATURE_FLAG_PRIMARY = FeatureFlag(
     removal_target="Phase 2d stable",
 )
 
+# S4 flag — kill-switch infrastructure for future Settings Manager UI
+# (S5+) consumers of :class:`services.settings_mutation.SettingsMutationPipeline`.
+# The pipeline itself does NOT consult this flag — it writes whenever
+# it is called.  Mirrors how BINDINGS_PRIMARY is declared centrally
+# but only :mod:`core.runtime.config_arbitration` consumes it.
+SETTINGS_MUTATION_PRIMARY = FeatureFlag(
+    name="settings.mutation.primary",
+    description=(
+        "services.settings_mutation.SettingsMutationPipeline is the primary "
+        "write path for scalar SettingSpec values; future S5+ UI consumers "
+        "gate their routing on this flag.  The pipeline itself does not "
+        "consult the flag — its existence alone changes no behaviour."
+    ),
+    default_value=False,
+    owner="platform",
+    removal_target="S5+ stable",
+)
+
 
 def _register_builtins() -> None:
     """Register Phase 1d platform-level flags at import time."""
@@ -251,6 +269,7 @@ def _register_builtins() -> None:
     register(BINDINGS_PRIMARY)
     register(PARTICIPATION_ENABLED)
     register(FEATURE_FLAG_PRIMARY)
+    register(SETTINGS_MUTATION_PRIMARY)
 
 
 _register_builtins()
@@ -676,6 +695,7 @@ __all__ = [
     "PARTICIPATION_ENABLED",
     "RESOURCES_UNIFIED",
     "RolloutPolicy",
+    "SETTINGS_MUTATION_PRIMARY",
     "all_flags",
     "bootstrap_fallback_count",
     "clear_cache",

--- a/disbot/migrations/029_settings_mutation_audit.sql
+++ b/disbot/migrations/029_settings_mutation_audit.sql
@@ -1,0 +1,83 @@
+-- Migration 029: settings_mutation_audit (S4).
+--
+-- Append-only audit log for every mutation that flows through
+-- :class:`services.settings_mutation.SettingsMutationPipeline`.
+-- One row per state change.  Rollback is a NEW audit row, never an
+-- UPDATE.
+--
+-- The pipeline is the canonical write path for scalar guild settings
+-- declared by :class:`core.runtime.subsystem_schema.SettingSpec`.
+-- Existing direct callers of ``db.set_setting`` are allowlisted by
+-- ``tests/unit/invariants/test_no_direct_settings_keys_writes.py`` and
+-- will migrate to the pipeline per-subsystem in S10.
+--
+-- Audit shape:
+--
+--   * ``mutation_type='set_value'`` — writes a scalar SettingSpec value.
+--     Keys: ``(subsystem, name)`` identifies the SettingSpec;
+--     ``settings_key`` is the canonical key string from
+--     :mod:`utils.settings_keys`.  The redundant ``settings_key`` is
+--     retained so the audit table is queryable without joining the
+--     schema registry.
+--     Values: ``prev_value_raw`` / ``new_value_raw`` carry the
+--     transition as strings (the legacy KV is string-typed); typed
+--     coercion lives in the pipeline.
+--
+-- Schema decisions:
+--
+--   * ``mutation_type`` and ``actor_type`` CHECK literals mirror the
+--     Python constants in :mod:`services.settings_mutation`.  An
+--     alignment test pins them.
+--   * ``actor_id`` is nullable — ``actor_type='system'`` records
+--     CI / scripted writes with ``actor_id=NULL``.
+--   * Indexed on ``(settings_key, at)`` and ``(guild_id, at)`` for the
+--     two common query shapes ("history of this setting" and "recent
+--     changes for this guild").  ``mutation_id`` indexed for
+--     cross-pipeline correlation.
+--
+-- Actor model (mirrors user_participation_audit / migration 028):
+--
+--   * ``actor_type='user'``      — a Discord member initiated the
+--                                  change (typically admin-tier).
+--   * ``actor_type='moderator'`` — moderator-initiated.  Reserved for
+--                                  future moderation tooling.
+--   * ``actor_type='admin'``     — admin-initiated.  Reserved for
+--                                  future admin tooling that wants to
+--                                  distinguish from ``'user'``.
+--   * ``actor_type='system'``    — CI seeds, scripted ops.
+--                                  ``actor_id`` may be NULL.
+--   * ``actor_type='backfill'``  — reserved for future logical
+--                                  migrations.  Currently no callers.
+--
+-- Rollback: ``DROP TABLE IF EXISTS settings_mutation_audit`` removes
+-- this audit history.  The legacy ``guild_settings`` KV table is
+-- untouched by this migration and remains the authoritative store.
+--
+-- Forward-only and idempotent.
+
+CREATE TABLE IF NOT EXISTS settings_mutation_audit (
+    id                  BIGSERIAL    PRIMARY KEY,
+    mutation_id         UUID         NOT NULL,
+    guild_id            BIGINT       NOT NULL,
+    subsystem           TEXT         NOT NULL,
+    name                TEXT         NOT NULL,
+    settings_key        TEXT         NOT NULL,
+    prev_value_raw      TEXT,
+    new_value_raw       TEXT         NOT NULL,
+    actor_id            BIGINT,
+    actor_type          TEXT         NOT NULL DEFAULT 'user',
+    mutation_type       TEXT         NOT NULL,
+    at                  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    CHECK (mutation_type IN ('set_value')),
+    CHECK (actor_type IN
+        ('user', 'moderator', 'admin', 'system', 'backfill'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_settings_mutation_audit_key_at
+    ON settings_mutation_audit (settings_key, at);
+
+CREATE INDEX IF NOT EXISTS idx_settings_mutation_audit_guild_at
+    ON settings_mutation_audit (guild_id, at);
+
+CREATE INDEX IF NOT EXISTS idx_settings_mutation_audit_mutation
+    ON settings_mutation_audit (mutation_id);

--- a/disbot/services/settings_mutation.py
+++ b/disbot/services/settings_mutation.py
@@ -1,0 +1,512 @@
+"""Settings mutation pipeline — S4 of the Global Settings & Customization Manager.
+
+The canonical write path for scalar guild settings declared by
+:class:`core.runtime.subsystem_schema.SettingSpec`.  Mirrors the
+contract of :class:`services.binding_mutation.BindingMutationPipeline`
+and :class:`services.participation_mutation.ParticipationMutationPipeline`.
+
+Eleven-step contract per :meth:`SettingsMutationPipeline.set_value`:
+
+  1. Resolve subsystem + ``SettingSpec``.
+  2. Reject unknown subsystem / setting / unmigrateable setting.
+  3. Validate actor / capability.
+  4. Coerce the incoming value to the declared ``SettingSpec.value_type``.
+  5. Run the ``SettingSpec.validator`` (if any).
+  6. Read the previous value through :func:`services.settings_resolution.resolve_setting`.
+  7. Serialise the coerced value to the legacy-KV string form.
+  8. DB write + audit insert in a single asyncpg transaction.
+  9. Invalidate the per-guild cache key via
+     :func:`utils.guild_config_accessors.invalidate_setting_value`.
+ 10. Emit advisory ``"settings.changed"`` event after commit (best-effort).
+ 11. Return typed :class:`SettingsMutationResult`.
+
+If event emission raises **after** a successful DB commit, the error
+is logged but not re-raised; the DB state is correct.  Matches the
+best-effort emission contract used by every sibling mutation pipeline.
+
+Hard limits for S4:
+
+  * No Settings Manager UI integration — that is S5.
+  * No bindings, no resource provisioning, no access-policy writes,
+    no participation writes, no list-setting writes.
+  * Authority check is a placeholder; Phase 4.5 swaps for typed
+    capability resolution via :data:`SettingSpec.capability_required`.
+  * The :data:`core.runtime.feature_flags.SETTINGS_MUTATION_PRIMARY`
+    flag is declared but **NOT consulted** by this pipeline — it is
+    kill-switch infrastructure for future S5+ consumers.
+
+Cycle discipline (mirrors
+:mod:`services.platform_consistency` and
+:mod:`services.settings_resolution`): all cross-package imports are
+function-local.  Top-level imports are stdlib only.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger("bot.services.settings_mutation")
+
+
+# ---------------------------------------------------------------------------
+# Catalogued event name (registered in core/events_catalogue.py).
+# ---------------------------------------------------------------------------
+
+EVT_SETTINGS_CHANGED = "settings.changed"
+
+
+# ---------------------------------------------------------------------------
+# Recognized literal sets — mirror migration 029 CHECK constraints.
+# Alignment tests in tests/unit/invariants/ pin these to the SQL CHECK
+# literals so a drift on either side fails CI.
+# ---------------------------------------------------------------------------
+
+_ALLOWED_ACTOR_TYPES: frozenset[str] = frozenset(
+    {"user", "moderator", "admin", "system", "backfill"},
+)
+_ALLOWED_MUTATION_TYPES: frozenset[str] = frozenset({"set_value"})
+
+# Phase 2b authority floor — placeholder.  Phase 4.5 swaps this for
+# the typed access-control resolver consuming
+# ``SettingSpec.capability_required``.
+_WRITE_AUTHORITY_TIER = "administrator"
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class SettingsMutationError(Exception):
+    """Base class for failures from :class:`SettingsMutationPipeline`."""
+
+
+class UnknownSubsystemError(SettingsMutationError):
+    """Raised when the mutation targets a subsystem not in SUBSYSTEMS."""
+
+
+class UndeclaredSettingError(SettingsMutationError):
+    """Raised when ``name`` is not declared as a ``SettingSpec`` for the
+    given subsystem.
+    """
+
+
+class UnmigrateableSettingError(SettingsMutationError):
+    """Raised when the ``SettingSpec`` has no ``settings_key``.
+
+    The pipeline refuses to mutate settings without a canonical key
+    because there is no authoritative storage location yet.  Such
+    settings are surfaced by
+    :data:`core.runtime.settings_registry.RegistryFindings.settings_without_settings_key`.
+    """
+
+
+class SettingsCoercionError(SettingsMutationError):
+    """Raised when the incoming value cannot be coerced to the declared
+    ``SettingSpec.value_type``.
+    """
+
+
+class SettingsValidationError(SettingsMutationError):
+    """Raised when ``SettingSpec.validator`` rejects the coerced value."""
+
+
+class UnauthorizedSettingsMutationError(SettingsMutationError):
+    """Raised when the actor lacks administrator-tier authority.
+
+    Phase 4.5 replaces this with typed capability resolution against
+    :data:`SettingSpec.capability_required`.
+    """
+
+
+class InvalidActorTypeError(SettingsMutationError):
+    """Raised when ``actor_type`` is not in :data:`_ALLOWED_ACTOR_TYPES`."""
+
+
+# ---------------------------------------------------------------------------
+# Typed result
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SettingsMutationResult:
+    """Outcome of a successful (or partially successful) mutation.
+
+    ``event_emitted`` is ``False`` when the post-commit ``settings.changed``
+    emission raised; the DB state is still correct.
+    """
+
+    mutation_id: str
+    guild_id: int
+    subsystem: str
+    name: str
+    settings_key: str
+    old_value: Any
+    new_value: Any
+    old_value_raw: str | None
+    new_value_raw: str
+    committed_at: datetime
+    event_emitted: bool
+
+
+# ---------------------------------------------------------------------------
+# Coercion + serialisation helpers
+# ---------------------------------------------------------------------------
+
+
+def _coerce_for_write(value: Any, value_type: type) -> tuple[Any, bool, str]:
+    """Coerce an incoming value to ``value_type``.
+
+    Accepts either a string (the legacy-KV shape) or an already-typed
+    value.  Returns ``(coerced, ok, diagnostic)``.  When ``ok`` is
+    ``False`` the caller raises :class:`SettingsCoercionError` with
+    the diagnostic.
+    """
+    # Fast paths for already-typed values.  ``bool`` is checked before
+    # ``int`` because ``True/False`` are ``int`` subclasses in Python.
+    if value_type is bool and isinstance(value, bool):
+        return value, True, ""
+    if value_type is int and isinstance(value, int) and not isinstance(value, bool):
+        return value, True, ""
+    if (
+        value_type is float
+        and isinstance(value, (int, float))
+        and not isinstance(value, bool)
+    ):
+        return float(value), True, ""
+    if value_type is str and isinstance(value, str):
+        return value, True, ""
+
+    # Fall back to the read-path string coercer for consistency with
+    # services.settings_resolution.
+    from services.settings_resolution import _coerce as _resolution_coerce
+
+    return _resolution_coerce(str(value), value_type)
+
+
+def _serialise(value: Any, value_type: type) -> str:
+    """Convert a coerced typed value to its legacy-KV string form.
+
+    Mirrors the read-path inverse — :func:`services.settings_resolution._coerce`
+    reads ``"true"`` / ``"false"`` for booleans, so the writer must
+    emit those exact spellings.
+    """
+    if value_type is bool:
+        return "true" if value else "false"
+    return str(value)
+
+
+# ---------------------------------------------------------------------------
+# Pipeline
+# ---------------------------------------------------------------------------
+
+
+class SettingsMutationPipeline:
+    """Centralised orchestration for scalar ``SettingSpec`` writes.
+
+    Instances are stateless — create one per mutation request.  The
+    single public method :meth:`set_value` follows the 11-step contract
+    documented in the module docstring.  Callers MUST NOT touch
+    :mod:`utils.db.settings_audit`'s mutation primitive directly nor
+    invoke ``db.set_setting`` for keys declared by a ``SettingSpec``;
+    the pipeline is the only legitimate writer.
+    """
+
+    def __init__(self) -> None:
+        # No instance state.
+        pass
+
+    async def set_value(
+        self,
+        guild: Any,
+        subsystem: str,
+        name: str,
+        value: Any,
+        actor: Any,
+        *,
+        actor_type: str = "user",
+    ) -> SettingsMutationResult:
+        """Write ``value`` to ``(subsystem, name)`` on ``guild``.
+
+        Args:
+            guild: A ``discord.Guild`` (typed as ``Any`` so this module
+                does not import ``discord``).
+            subsystem: Subsystem name from ``SUBSYSTEMS``.
+            name: ``SettingSpec.name``.
+            value: Incoming value (string or already-typed).  The
+                pipeline coerces and validates it.
+            actor: A ``discord.Member`` representing the caller, or
+                ``None`` for ``actor_type='system'`` writes.
+            actor_type: One of the literals in
+                :data:`_ALLOWED_ACTOR_TYPES`.
+
+        Raises:
+            UnknownSubsystemError: ``subsystem`` is not in
+                ``SUBSYSTEMS``.
+            UndeclaredSettingError: ``name`` is not declared as a
+                ``SettingSpec`` for ``subsystem``.
+            UnmigrateableSettingError: The ``SettingSpec`` has no
+                ``settings_key`` — no canonical storage exists.
+            SettingsCoercionError: ``value`` cannot be coerced to the
+                declared type.
+            SettingsValidationError: ``SettingSpec.validator`` rejected
+                the coerced value.
+            UnauthorizedSettingsMutationError: ``actor`` lacks
+                administrator-tier authority and ``actor_type`` is
+                ``'user'`` / ``'moderator'`` / ``'admin'``.
+            InvalidActorTypeError: ``actor_type`` is not in the
+                allowed set.
+        """
+        spec = self._resolve_spec(subsystem, name)
+        self._validate_actor_type(actor_type)
+        self._validate_authority(actor, actor_type)
+
+        coerced, ok, coerce_diag = _coerce_for_write(value, spec.value_type)
+        if not ok:
+            raise SettingsCoercionError(
+                f"cannot coerce value={value!r} to {spec.value_type.__name__}: "
+                f"{coerce_diag}",
+            )
+        if spec.validator is not None:
+            try:
+                spec.validator(coerced)
+            except (ValueError, TypeError) as exc:
+                raise SettingsValidationError(
+                    f"validator rejected value={coerced!r} for "
+                    f"{subsystem}.{name}: {exc}",
+                ) from exc
+
+        new_value_raw = _serialise(coerced, spec.value_type)
+        old_value, old_value_raw = await self._read_previous(guild, subsystem, name)
+
+        mutation_id = str(uuid.uuid4())
+        actor_id = getattr(actor, "id", None) if actor is not None else None
+
+        # Steps 8-9: DB write + audit + cache invalidate.
+        try:
+            from utils.db import settings_audit
+
+            await settings_audit.set_value_with_audit(
+                guild_id=guild.id,
+                subsystem=subsystem,
+                name=name,
+                settings_key=spec.settings_key,
+                prev_value_raw=old_value_raw,
+                new_value_raw=new_value_raw,
+                actor_id=actor_id,
+                actor_type=actor_type,
+                mutation_id=mutation_id,
+                mutation_type="set_value",
+            )
+        except Exception:
+            logger.exception(
+                "SettingsMutationPipeline.set_value: DB transaction "
+                "failed for (guild=%d, subsystem=%r, name=%r); no cache "
+                "invalidation, no event emission.",
+                guild.id,
+                subsystem,
+                name,
+            )
+            raise
+
+        committed_at = _now_utc()
+        self._invalidate_cache(guild.id, spec.settings_key)
+
+        # Step 10: best-effort event emission.
+        event_emitted = await self._emit_event(
+            mutation_id=mutation_id,
+            guild_id=guild.id,
+            subsystem=subsystem,
+            name=name,
+            settings_key=spec.settings_key,
+            old_value_raw=old_value_raw,
+            new_value_raw=new_value_raw,
+            committed_at=committed_at,
+        )
+
+        return SettingsMutationResult(
+            mutation_id=mutation_id,
+            guild_id=guild.id,
+            subsystem=subsystem,
+            name=name,
+            settings_key=spec.settings_key,
+            old_value=old_value,
+            new_value=coerced,
+            old_value_raw=old_value_raw,
+            new_value_raw=new_value_raw,
+            committed_at=committed_at,
+            event_emitted=event_emitted,
+        )
+
+    # ------------------------------------------------------------------
+    # Step helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_spec(self, subsystem: str, name: str) -> Any:
+        """Steps 1-2: subsystem declared, setting declared, migrateable."""
+        from core.runtime.subsystem_schema import get_schema
+        from utils.subsystem_registry import SUBSYSTEMS
+
+        if subsystem not in SUBSYSTEMS:
+            raise UnknownSubsystemError(
+                f"unknown subsystem {subsystem!r}; "
+                f"not in utils.subsystem_registry.SUBSYSTEMS",
+            )
+
+        schema = get_schema(subsystem)
+        if schema is None:
+            raise UndeclaredSettingError(
+                f"subsystem {subsystem!r} has no registered SubsystemSchema; "
+                f"register one in the cog's cog_load() before mutating",
+            )
+
+        for spec in schema.settings:
+            if spec.name == name:
+                if not spec.settings_key:
+                    raise UnmigrateableSettingError(
+                        f"setting {subsystem!r}/{name!r} has no settings_key "
+                        "declared; cannot be mutated until migrated to a "
+                        "canonical key",
+                    )
+                return spec
+
+        declared_names = [s.name for s in schema.settings]
+        raise UndeclaredSettingError(
+            f"setting {name!r} not declared in SubsystemSchema for "
+            f"{subsystem!r}; declared settings: {declared_names}",
+        )
+
+    def _validate_actor_type(self, actor_type: str) -> None:
+        if actor_type not in _ALLOWED_ACTOR_TYPES:
+            raise InvalidActorTypeError(
+                f"actor_type={actor_type!r} not in {sorted(_ALLOWED_ACTOR_TYPES)}",
+            )
+
+    def _validate_authority(self, actor: Any, actor_type: str) -> None:
+        """Step 3: placeholder administrator-tier floor.
+
+        ``actor_type='system'`` and ``'backfill'`` bypass the authority
+        check (they represent scripted ops and migrations).  All other
+        actor types require an administrator-tier Discord member.
+        Phase 4.5 replaces this with typed capability resolution via
+        :data:`SettingSpec.capability_required`.
+        """
+        if actor_type in ("system", "backfill"):
+            return
+        if actor is None or getattr(actor, "guild", None) is None:
+            raise UnauthorizedSettingsMutationError(
+                "settings mutation requires a guild-member actor context "
+                f"(actor_type={actor_type!r})",
+            )
+        from utils.visibility_rules import (
+            get_member_visibility_tier,
+            is_tier_sufficient,
+        )
+
+        guild_owner_id = actor.guild.owner_id if actor.guild else 0
+        tier = get_member_visibility_tier(actor, guild_owner_id)
+        if not is_tier_sufficient(tier, _WRITE_AUTHORITY_TIER):
+            raise UnauthorizedSettingsMutationError(
+                f"member {actor.id!r} (tier={tier!r}) requires at least "
+                f"{_WRITE_AUTHORITY_TIER!r} to mutate settings "
+                "(Phase 4.5 will replace this with typed capability check)",
+            )
+
+    async def _read_previous(
+        self,
+        guild: Any,
+        subsystem: str,
+        name: str,
+    ) -> tuple[Any, str | None]:
+        """Step 6: read the previous value via the canonical resolver.
+
+        Returns ``(typed_value, raw_string_or_None)``.  ``None`` raw
+        indicates no KV row existed before this mutation; the typed
+        value is the spec default in that case.
+        """
+        from services.settings_resolution import resolve_setting
+
+        resolution = await resolve_setting(guild.id, subsystem, name)
+        if resolution is None:
+            # Defensive — _resolve_spec already verified the spec exists.
+            return None, None
+        # resolution.raw is "" when the resolver served the default
+        # because the KV row was absent.  Map that to None so the audit
+        # row distinguishes "no row existed" from "row was empty string".
+        raw = resolution.raw if resolution.raw else None
+        return resolution.value, raw
+
+    def _invalidate_cache(self, guild_id: int, settings_key: str) -> None:
+        """Step 9: drop the cached KV value for this specific key.
+
+        Routes through the typed accessor introduced in S3 so the F-1
+        invariant (`test_guild_config_typed_accessors`) stays green.
+        """
+        from utils.guild_config_accessors import invalidate_setting_value
+
+        invalidate_setting_value(guild_id, settings_key)
+
+    async def _emit_event(
+        self,
+        *,
+        mutation_id: str,
+        guild_id: int,
+        subsystem: str,
+        name: str,
+        settings_key: str,
+        old_value_raw: str | None,
+        new_value_raw: str,
+        committed_at: datetime,
+    ) -> bool:
+        """Step 10: best-effort ``settings.changed`` emission.
+
+        Returns ``True`` on success, ``False`` when emission raised.
+        Emission failure after a successful DB commit is logged with
+        the ``mutation_id`` and swallowed — DB state is authoritative.
+        """
+        from core.events import bus
+
+        try:
+            await bus.emit(
+                EVT_SETTINGS_CHANGED,
+                mutation_id=mutation_id,
+                guild_id=guild_id,
+                subsystem=subsystem,
+                name=name,
+                settings_key=settings_key,
+                old_value_raw=old_value_raw,
+                new_value_raw=new_value_raw,
+                occurred_at=committed_at.isoformat(),
+            )
+        except Exception:
+            logger.exception(
+                "SettingsMutationPipeline._emit_event: emission failed for "
+                "mutation_id=%s; DB state is correct, event lost.",
+                mutation_id,
+            )
+            return False
+        return True
+
+
+def _now_utc() -> datetime:
+    """Return a tz-aware "now" — INV-N forbids bare datetime.utcnow."""
+    return datetime.now(timezone.utc)
+
+
+__all__ = [
+    "EVT_SETTINGS_CHANGED",
+    "InvalidActorTypeError",
+    "SettingsCoercionError",
+    "SettingsMutationError",
+    "SettingsMutationPipeline",
+    "SettingsMutationResult",
+    "SettingsValidationError",
+    "UnauthorizedSettingsMutationError",
+    "UndeclaredSettingError",
+    "UnknownSubsystemError",
+    "UnmigrateableSettingError",
+]

--- a/disbot/utils/db/settings_audit.py
+++ b/disbot/utils/db/settings_audit.py
@@ -1,0 +1,187 @@
+"""Settings mutation audit — DB CRUD primitives (S4).
+
+Owns the read/write surface for ``settings_mutation_audit`` (migration
+029) and the combined-transaction write that lands both the legacy
+``guild_settings`` row and the audit row atomically.
+
+Higher-level callers route through
+:class:`services.settings_mutation.SettingsMutationPipeline`; nothing
+outside this module + the pipeline issues raw SQL against the audit
+table.
+
+Transaction model:
+The pipeline calls :func:`set_value_with_audit`, which opens a single
+asyncpg transaction so the KV upsert + audit insert land atomically.
+Read primitives are autocommit.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from utils.db import pool
+
+logger = logging.getLogger("bot.db.settings_audit")
+
+
+# ---------------------------------------------------------------------------
+# Mutation primitive — used only by SettingsMutationPipeline
+# ---------------------------------------------------------------------------
+
+
+async def set_value_with_audit(
+    *,
+    guild_id: int,
+    subsystem: str,
+    name: str,
+    settings_key: str,
+    prev_value_raw: str | None,
+    new_value_raw: str,
+    actor_id: int | None,
+    actor_type: str,
+    mutation_id: str,
+    mutation_type: str = "set_value",
+) -> None:
+    """Atomic write: upsert the ``guild_settings`` row + insert one audit row.
+
+    Both statements run inside a single asyncpg transaction.  If either
+    fails the entire mutation is rolled back; the pipeline only
+    invalidates caches and emits events after this returns
+    successfully.
+
+    Args:
+        guild_id: Discord guild snowflake.
+        subsystem: Owning subsystem name (``SUBSYSTEMS`` key).
+        name: ``SettingSpec.name`` (unique within the subsystem).
+        settings_key: Canonical key from :mod:`utils.settings_keys`
+            (the legacy KV row's ``key`` column).
+        prev_value_raw: The previous raw KV value, or ``None`` if no
+            row existed before this mutation.
+        new_value_raw: The new raw KV value (already serialized to a
+            string by the pipeline).
+        actor_id: Discord snowflake of the actor, or ``None`` for
+            ``actor_type='system'`` writes.
+        actor_type: One of ``user`` / ``moderator`` / ``admin`` /
+            ``system`` / ``backfill`` (matches the CHECK constraint
+            in migration 029).
+        mutation_id: Caller-generated UUID for cross-pipeline
+            correlation.  Same value lands in the audit row.
+        mutation_type: ``set_value`` for v1.  Reserved to extend in
+            S6 when ``reset_value`` lands.
+    """
+    async with pool.get().acquire() as conn, conn.transaction():
+        await conn.execute(
+            """
+            INSERT INTO guild_settings (guild_id, key, value)
+            VALUES ($1, $2, $3)
+            ON CONFLICT (guild_id, key)
+            DO UPDATE SET value = EXCLUDED.value
+            """,
+            guild_id,
+            settings_key,
+            new_value_raw,
+        )
+        await conn.execute(
+            """
+            INSERT INTO settings_mutation_audit
+                (mutation_id, guild_id, subsystem, name, settings_key,
+                 prev_value_raw, new_value_raw,
+                 actor_id, actor_type, mutation_type)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            """,
+            mutation_id,
+            guild_id,
+            subsystem,
+            name,
+            settings_key,
+            prev_value_raw,
+            new_value_raw,
+            actor_id,
+            actor_type,
+            mutation_type,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Read primitives — diagnostic / future !platform consistency surface
+# ---------------------------------------------------------------------------
+
+
+async def count_for_guild(guild_id: int) -> int:
+    """Return the audit row count for ``guild_id``.
+
+    Used by the future ``_collect_settings_mutation`` collector in
+    :mod:`services.platform_consistency` (deferred to a follow-up PR,
+    matching the S1 / S2 / S2.5 / S3 deferred-collector precedent).
+    """
+    row = await pool.get().fetchrow(
+        "SELECT COUNT(*) AS n FROM settings_mutation_audit WHERE guild_id = $1",
+        guild_id,
+    )
+    return int(row["n"]) if row else 0
+
+
+async def count_total() -> int:
+    """Return the total audit row count across all guilds."""
+    row = await pool.get().fetchrow(
+        "SELECT COUNT(*) AS n FROM settings_mutation_audit",
+    )
+    return int(row["n"]) if row else 0
+
+
+async def list_recent_for_guild(
+    guild_id: int,
+    *,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """Return up to ``limit`` most recent audit rows for ``guild_id``."""
+    rows = await pool.get().fetch(
+        """
+        SELECT id, mutation_id, guild_id, subsystem, name, settings_key,
+               prev_value_raw, new_value_raw,
+               actor_id, actor_type, mutation_type, at
+        FROM settings_mutation_audit
+        WHERE guild_id = $1
+        ORDER BY at DESC
+        LIMIT $2
+        """,
+        guild_id,
+        limit,
+    )
+    return [dict(r) for r in rows]
+
+
+async def list_recent_for_key(
+    settings_key: str,
+    *,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """Return up to ``limit`` most recent audit rows for ``settings_key``.
+
+    Useful for "show me every mutation that touched WARN_THRESHOLD
+    across all guilds".
+    """
+    rows = await pool.get().fetch(
+        """
+        SELECT id, mutation_id, guild_id, subsystem, name, settings_key,
+               prev_value_raw, new_value_raw,
+               actor_id, actor_type, mutation_type, at
+        FROM settings_mutation_audit
+        WHERE settings_key = $1
+        ORDER BY at DESC
+        LIMIT $2
+        """,
+        settings_key,
+        limit,
+    )
+    return [dict(r) for r in rows]
+
+
+__all__ = [
+    "count_for_guild",
+    "count_total",
+    "list_recent_for_guild",
+    "list_recent_for_key",
+    "set_value_with_audit",
+]

--- a/tests/unit/invariants/test_no_direct_settings_keys_writes.py
+++ b/tests/unit/invariants/test_no_direct_settings_keys_writes.py
@@ -1,0 +1,174 @@
+"""S4 invariant — every ``db.set_setting`` caller is on the allowlist.
+
+The Settings Manager roadmap (S4) introduces
+:class:`services.settings_mutation.SettingsMutationPipeline` as the
+canonical write path for scalar ``SettingSpec`` values backed by the
+legacy ``guild_settings`` KV.  New code MUST route through the
+pipeline; existing call sites are allowlisted and will migrate
+per-subsystem in S10.
+
+Why bare ``db.set_setting`` callers are dangerous in the new world:
+
+  * The pipeline performs typed coercion, validation, audit, cache
+    invalidation, and event emission.  Bypassing it loses every
+    one of those guarantees.
+  * Audit history is incomplete if some writers skip the pipeline.
+
+This test parses every ``disbot/**/*.py`` file via AST and fails if
+any node references ``set_setting`` outside the allowlist.  The
+allowlist documents the migration target — each entry is a candidate
+for routing through the pipeline in a later milestone (typically the
+per-subsystem S10 work).
+
+Allowlist structure:
+
+  * The DB primitive itself (``utils/db/settings.py``) and its
+    re-export module (``utils/db/__init__.py``) — they DEFINE the
+    function.
+  * The new pipeline service and its DB layer — they implement the
+    canonical write path.
+  * Pre-existing callers — frozen here so a new caller cannot slip
+    in without a discussion.  Each entry is paired with a comment
+    naming the future migration milestone.
+
+A new caller wanting to bypass the pipeline must either:
+
+  * Migrate to ``SettingsMutationPipeline.set_value(...)``; or
+  * Add itself to the allowlist with a comment explaining why
+    bypassing the pipeline is correct for this caller.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DISBOT = _REPO_ROOT / "disbot"
+
+# Files ALLOWED to reference ``set_setting`` (call or import).
+# Adding to this list weakens the invariant; do not extend casually.
+_ALLOWED_PATHS = {
+    # The primitive itself.
+    _DISBOT / "utils" / "db" / "settings.py",
+    # Re-export module (re-exports ``set_setting`` from ``utils.db.settings``).
+    _DISBOT / "utils" / "db" / "__init__.py",
+    # Pre-existing callers — migrate to SettingsMutationPipeline in S10.
+    # Each entry below corresponds to a per-subsystem S10 sub-PR
+    # ("settings/<subsystem>") that will route the call through the
+    # pipeline and remove the entry.
+    _DISBOT / "cogs" / "blackjack_cog.py",        # ACTIVE_TOURNAMENT writes
+    _DISBOT / "cogs" / "economy_cog.py",          # ECONOMY_LOG_CHANNEL writes
+    _DISBOT / "cogs" / "rps_tournament_cog.py",   # ACTIVE_TOURNAMENT writes
+    _DISBOT / "cogs" / "rps_tournament" / "_helpers.py",  # ACTIVE_TOURNAMENT
+    _DISBOT / "governance" / "writes.py",         # internal governance writes
+    _DISBOT / "views" / "blackjack" / "tournament_views.py",
+    _DISBOT / "views" / "xp" / "modals.py",       # XP_MIN/MAX/COOLDOWN/ANNOUNCE
+    # Documentation reference (string literal in a module docstring,
+    # not a call) — kept on the allowlist so the docstring is not
+    # forced to rephrase.
+    _DISBOT / "utils" / "settings_keys" / "__init__.py",
+}
+
+_FORBIDDEN_NAME = "set_setting"
+
+
+def _iter_production_py_files() -> list[Path]:
+    return [p for p in _DISBOT.rglob("*.py") if "__pycache__" not in p.parts]
+
+
+def _attribute_calls(tree: ast.AST) -> list[str]:
+    """Return ``"<receiver>.set_setting"`` for any ``<receiver>.set_setting(...)``
+    call where ``<receiver>`` ends in ``db`` or ``settings``.
+    """
+    found: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr != _FORBIDDEN_NAME:
+            continue
+        rcv = node.func.value
+        parts: list[str] = []
+        while isinstance(rcv, ast.Attribute):
+            parts.append(rcv.attr)
+            rcv = rcv.value
+        if isinstance(rcv, ast.Name):
+            parts.append(rcv.id)
+        receiver = ".".join(reversed(parts))
+        # Receiver's final segment must be "db" or "settings" to count
+        # (filters out unrelated attributes named ``set_setting`` on
+        # objects that are not the legacy-KV primitive).
+        last = receiver.split(".")[-1]
+        if last in {"db", "settings"}:
+            found.append(f"{receiver}.{node.func.attr}")
+    return found
+
+
+def _direct_imports(tree: ast.AST) -> list[str]:
+    """Return forbidden names directly imported via ``from ... import set_setting``."""
+    found: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom) or node.module is None:
+            continue
+        # Match utils.db, utils.db.settings, and any submodule path
+        # ending in those.
+        if not (
+            node.module == "utils.db"
+            or node.module == "utils.db.settings"
+            or node.module.endswith(".utils.db")
+            or node.module.endswith(".utils.db.settings")
+        ):
+            continue
+        for alias in node.names:
+            if alias.name == _FORBIDDEN_NAME:
+                found.append(f"from {node.module} import {alias.name}")
+    return found
+
+
+def test_no_bare_set_setting_outside_allowlist():
+    """No production file outside the allowlist may call
+    ``db.set_setting`` directly or import it from the primitive
+    module.
+    """
+    violations: list[tuple[str, list[str]]] = []
+    for path in _iter_production_py_files():
+        if path in _ALLOWED_PATHS:
+            continue
+        tree = ast.parse(path.read_text(), filename=str(path))
+        offenders = _attribute_calls(tree) + _direct_imports(tree)
+        if offenders:
+            violations.append((str(path.relative_to(_REPO_ROOT)), offenders))
+    assert not violations, (
+        "S4 invariant violation: bare db.set_setting access outside "
+        "the SettingsMutationPipeline allowlist.\n"
+        "Route new writes through "
+        "services.settings_mutation.SettingsMutationPipeline.set_value(...) "
+        "or extend the allowlist explicitly with a justification.\n\n"
+        + "\n".join(f"  {p}: {calls}" for p, calls in violations)
+    )
+
+
+def test_allowlist_entries_exist():
+    """Every allowlisted file must still exist on disk.
+
+    A renamed file would silently relax the invariant.
+    """
+    missing = [
+        str(p.relative_to(_REPO_ROOT)) for p in _ALLOWED_PATHS if not p.exists()
+    ]
+    assert not missing, (
+        "S4 allowlist references files that no longer exist:\n"
+        + "\n".join(f"  {p}" for p in missing)
+    )
+
+
+def test_pipeline_does_not_call_set_setting_directly():
+    """The pipeline service must NOT call ``db.set_setting`` — it
+    writes via ``utils.db.settings_audit.set_value_with_audit`` so
+    the legacy-KV write and the audit insert land atomically.
+    """
+    pipeline_path = _DISBOT / "services" / "settings_mutation.py"
+    text = pipeline_path.read_text()
+    assert (
+        ".set_setting(" not in text
+    ), "services.settings_mutation must not call db.set_setting directly"

--- a/tests/unit/invariants/test_settings_mutation_audit_alignment.py
+++ b/tests/unit/invariants/test_settings_mutation_audit_alignment.py
@@ -1,0 +1,110 @@
+"""S4 invariant — settings_mutation_audit CHECK literals align with Python.
+
+Migration 029 ships CHECK constraints on
+``settings_mutation_audit``:
+
+* ``mutation_type``  — pipeline entrypoint name(s)
+* ``actor_type``     — actor model
+
+The Python pipeline carries matching ``frozenset``s in
+:mod:`services.settings_mutation`.  This test pins both sides so a
+drift on either fails CI before the next migration ships.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_MIGRATION = (
+    Path(__file__).resolve().parents[3]
+    / "disbot"
+    / "migrations"
+    / "029_settings_mutation_audit.sql"
+)
+
+
+def _read() -> str:
+    return _MIGRATION.read_text()
+
+
+def _extract_in_set(column: str) -> set[str]:
+    sql = _read()
+    pattern = rf"CHECK\s*\(\s*{column}\s+IN\s*\(([^)]+)\)\s*\)"
+    match = re.search(pattern, sql)
+    assert match, f"could not locate {column} CHECK constraint in migration 029"
+    return {
+        tok.strip().strip("'\"") for tok in match.group(1).split(",") if tok.strip()
+    }
+
+
+def test_mutation_type_literals_match_pipeline():
+    """``mutation_type`` CHECK matches
+    :data:`services.settings_mutation._ALLOWED_MUTATION_TYPES`.
+    """
+    from services.settings_mutation import _ALLOWED_MUTATION_TYPES
+
+    db_check = _extract_in_set("mutation_type")
+    python = set(_ALLOWED_MUTATION_TYPES)
+    assert db_check == python, (
+        "mutation_type drift:\n"
+        f"  in Python but not DB CHECK: {sorted(python - db_check)}\n"
+        f"  in DB CHECK but not Python: {sorted(db_check - python)}\n"
+        "Fix: extend the CHECK constraint via a new migration AND "
+        "update _ALLOWED_MUTATION_TYPES in services/settings_mutation.py."
+    )
+
+
+def test_actor_type_literals_match_pipeline_allowed_set():
+    """``actor_type`` CHECK matches
+    :data:`services.settings_mutation._ALLOWED_ACTOR_TYPES`.
+    """
+    from services.settings_mutation import _ALLOWED_ACTOR_TYPES
+
+    db_check = _extract_in_set("actor_type")
+    python = set(_ALLOWED_ACTOR_TYPES)
+    assert db_check == python, (
+        "actor_type drift:\n"
+        f"  in Python but not DB CHECK: {sorted(python - db_check)}\n"
+        f"  in DB CHECK but not Python: {sorted(db_check - python)}"
+    )
+
+
+def test_migration_file_exists():
+    """Sanity: the migration referenced by this alignment test exists."""
+    assert _MIGRATION.exists(), f"migration file missing: {_MIGRATION}"
+
+
+def _strip_sql_comments(sql: str) -> str:
+    """Drop ``--`` line comments before scanning for forbidden statements."""
+    out_lines: list[str] = []
+    for line in sql.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("--"):
+            continue
+        # Inline trailing comment.
+        if "--" in line:
+            line = line.split("--", 1)[0]
+        out_lines.append(line)
+    return "\n".join(out_lines)
+
+
+def test_migration_is_forward_only_and_idempotent():
+    """The migration must not contain destructive statements.
+
+    Idempotency is provided by ``CREATE TABLE IF NOT EXISTS`` and
+    ``CREATE INDEX IF NOT EXISTS``.  Forward-only excludes DROP /
+    DELETE / TRUNCATE / ALTER on existing tables.  SQL ``--``
+    comments are stripped before scanning so a comment that
+    *describes* the rollback (``-- Rollback: DROP TABLE ...``) does
+    not trip the check.
+    """
+    sql = _strip_sql_comments(_read()).upper()
+    forbidden = ("DROP ", "TRUNCATE ", "DELETE FROM ", "ALTER TABLE GUILD_SETTINGS")
+    for needle in forbidden:
+        assert (
+            needle not in sql
+        ), f"migration 029 contains forbidden destructive statement: {needle!r}"
+    # Idempotency markers must be on real (non-comment) statements.
+    assert "CREATE TABLE IF NOT EXISTS" in sql
+    assert "CREATE INDEX IF NOT EXISTS" in sql

--- a/tests/unit/services/test_settings_mutation_pipeline.py
+++ b/tests/unit/services/test_settings_mutation_pipeline.py
@@ -1,0 +1,728 @@
+"""Unit tests for services.settings_mutation — S4.
+
+Covers the 11-step pipeline contract: spec resolution, every error
+class, actor / authority validation, coercion + validator hooks,
+read-previous-value integration with S3's resolver, the
+DB-write + audit transaction, cache invalidation, best-effort
+event emission, and the typed result type.
+
+The DB layer (utils.db.settings_audit) is monkeypatched to an
+in-memory store so the tests never touch a real database.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.runtime import guild_config
+from core.runtime import subsystem_schema as schema_mod
+from core.runtime.subsystem_schema import SettingSpec, SubsystemSchema
+from services import settings_mutation as sm_mod
+from services import settings_resolution as sr_mod
+from services.settings_mutation import (
+    EVT_SETTINGS_CHANGED,
+    InvalidActorTypeError,
+    SettingsCoercionError,
+    SettingsMutationPipeline,
+    SettingsMutationResult,
+    SettingsValidationError,
+    UnauthorizedSettingsMutationError,
+    UndeclaredSettingError,
+    UnknownSubsystemError,
+    UnmigrateableSettingError,
+)
+from utils import db as db_pkg
+from utils.db import settings as settings_db
+from utils.db import settings_audit as audit_db
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeGuild:
+    def __init__(self, guild_id: int, *, owner_id: int = 0):
+        self.id = guild_id
+        self.owner_id = owner_id
+
+
+class _FakeGuildPermissions:
+    def __init__(
+        self,
+        *,
+        administrator: bool = False,
+        moderate_members: bool = False,
+        manage_guild: bool = False,
+    ):
+        self.administrator = administrator
+        self.moderate_members = moderate_members
+        self.manage_guild = manage_guild
+
+
+class _FakeMember:
+    def __init__(
+        self,
+        member_id: int,
+        *,
+        guild: _FakeGuild,
+        tier: str = "administrator",
+    ):
+        self.id = member_id
+        self.guild = guild
+        perms = _FakeGuildPermissions()
+        if tier == "administrator":
+            perms.administrator = True
+        elif tier == "moderator":
+            perms.moderate_members = True
+        elif tier == "staff":
+            perms.manage_guild = True
+        # "user" — no perms; matches Discord default member
+        self.guild_permissions = perms
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(monkeypatch):
+    """Snapshot live schema registry and DB stubs around each test."""
+    saved_schemas = schema_mod.all_schemas()
+    schema_mod._reset_for_tests()
+    sr_mod._reset_counters_for_tests()
+    guild_config._reset_for_tests()
+
+    # In-memory legacy KV store.  Tests pre-populate `_kv` to seed
+    # previous values; the pipeline's DB-write stub also pushes here.
+    _kv: dict[tuple[int, str], str] = {}
+
+    async def _fake_get_setting(
+        guild_id: int,
+        key: str,
+        default: str = "",
+    ) -> str:
+        return _kv.get((guild_id, key), default)
+
+    monkeypatch.setattr(settings_db, "get_setting", _fake_get_setting)
+    monkeypatch.setattr(db_pkg, "get_setting", _fake_get_setting)
+
+    # Audit DB stub: record every set_value_with_audit call AND
+    # update the in-memory KV so resolve_setting reflects post-write
+    # state on the next call.
+    audit_log: list[dict] = []
+
+    async def _fake_set_value_with_audit(
+        *,
+        guild_id: int,
+        subsystem: str,
+        name: str,
+        settings_key: str,
+        prev_value_raw: str | None,
+        new_value_raw: str,
+        actor_id: int | None,
+        actor_type: str,
+        mutation_id: str,
+        mutation_type: str = "set_value",
+    ) -> None:
+        _kv[(guild_id, settings_key)] = new_value_raw
+        audit_log.append(
+            {
+                "guild_id": guild_id,
+                "subsystem": subsystem,
+                "name": name,
+                "settings_key": settings_key,
+                "prev_value_raw": prev_value_raw,
+                "new_value_raw": new_value_raw,
+                "actor_id": actor_id,
+                "actor_type": actor_type,
+                "mutation_id": mutation_id,
+                "mutation_type": mutation_type,
+            },
+        )
+
+    monkeypatch.setattr(audit_db, "set_value_with_audit", _fake_set_value_with_audit)
+
+    # Cache invalidation tracker.
+    invalidations: list[tuple[int, str]] = []
+    from utils import guild_config_accessors
+
+    real_invalidate = guild_config_accessors.invalidate_setting_value
+
+    def _tracked_invalidate(guild_id: int, settings_key: str) -> None:
+        invalidations.append((guild_id, settings_key))
+        real_invalidate(guild_id, settings_key)
+
+    monkeypatch.setattr(
+        guild_config_accessors,
+        "invalidate_setting_value",
+        _tracked_invalidate,
+    )
+
+    # Event bus stub.
+    emitted: list[dict] = []
+    bus_raises: dict[str, bool] = {"flag": False}
+
+    async def _fake_emit(event: str, /, **payload):
+        if bus_raises["flag"]:
+            raise RuntimeError("simulated bus failure")
+        emitted.append({"event": event, **payload})
+
+    from core.events import bus
+
+    monkeypatch.setattr(bus, "emit", _fake_emit)
+
+    yield {
+        "kv": _kv,
+        "audit_log": audit_log,
+        "invalidations": invalidations,
+        "emitted": emitted,
+        "bus_raises": bus_raises,
+    }
+
+    schema_mod._reset_for_tests()
+    for schema in saved_schemas.values():
+        schema_mod.register(schema)
+    sr_mod._reset_counters_for_tests()
+    guild_config._reset_for_tests()
+
+
+def _register(subsystem: str, *specs: SettingSpec) -> None:
+    schema_mod.register(SubsystemSchema(subsystem=subsystem, settings=specs))
+
+
+# ---------------------------------------------------------------------------
+# Step 1-2: spec resolution + unknown subsystem / setting / unmigrateable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_subsystem_raises():
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = SettingsMutationPipeline()
+    with pytest.raises(UnknownSubsystemError):
+        await pipeline.set_value(guild, "no_such_subsystem", "x", 1, actor)
+
+
+@pytest.mark.asyncio
+async def test_undeclared_setting_raises_when_subsystem_has_no_schema():
+    """When the subsystem exists in SUBSYSTEMS but has no SubsystemSchema
+    registered, the pipeline raises UndeclaredSettingError."""
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = SettingsMutationPipeline()
+    with pytest.raises(UndeclaredSettingError):
+        await pipeline.set_value(guild, "xp", "whatever", 1, actor)
+
+
+@pytest.mark.asyncio
+async def test_undeclared_setting_raises_when_name_not_in_schema():
+    _register("xp", SettingSpec(name="xp_min", value_type=int, default=1))
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = SettingsMutationPipeline()
+    with pytest.raises(UndeclaredSettingError):
+        await pipeline.set_value(guild, "xp", "no_such_setting", 1, actor)
+
+
+@pytest.mark.asyncio
+async def test_unmigrateable_setting_raises_when_settings_key_empty():
+    _register(
+        "xp",
+        SettingSpec(name="xp_min", value_type=int, default=1),
+        # No settings_key — transitional state.
+    )
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = SettingsMutationPipeline()
+    with pytest.raises(UnmigrateableSettingError):
+        await pipeline.set_value(guild, "xp", "xp_min", 5, actor)
+
+
+# ---------------------------------------------------------------------------
+# Step 3: actor / authority validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalid_actor_type_raises():
+    _register(
+        "xp",
+        SettingSpec(name="xp_min", value_type=int, default=1, settings_key="XP_MIN"),
+    )
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = SettingsMutationPipeline()
+    with pytest.raises(InvalidActorTypeError):
+        await pipeline.set_value(
+            guild,
+            "xp",
+            "xp_min",
+            5,
+            actor,
+            actor_type="god_mode",
+        )
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_when_actor_missing_for_user_actor_type():
+    _register(
+        "xp",
+        SettingSpec(name="xp_min", value_type=int, default=1, settings_key="XP_MIN"),
+    )
+    guild = _FakeGuild(1)
+    pipeline = SettingsMutationPipeline()
+    with pytest.raises(UnauthorizedSettingsMutationError):
+        await pipeline.set_value(guild, "xp", "xp_min", 5, None)
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_when_actor_below_admin_tier():
+    _register(
+        "xp",
+        SettingSpec(name="xp_min", value_type=int, default=1, settings_key="XP_MIN"),
+    )
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild, tier="staff")
+    pipeline = SettingsMutationPipeline()
+    with pytest.raises(UnauthorizedSettingsMutationError):
+        await pipeline.set_value(guild, "xp", "xp_min", 5, actor)
+
+
+@pytest.mark.asyncio
+async def test_admin_tier_actor_allowed():
+    _register(
+        "xp",
+        SettingSpec(name="xp_min", value_type=int, default=1, settings_key="XP_MIN"),
+    )
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild, tier="administrator")
+    pipeline = SettingsMutationPipeline()
+    result = await pipeline.set_value(guild, "xp", "xp_min", 5, actor)
+    assert result.new_value == 5
+
+
+@pytest.mark.asyncio
+async def test_system_actor_bypasses_authority_check():
+    _register(
+        "xp",
+        SettingSpec(name="xp_min", value_type=int, default=1, settings_key="XP_MIN"),
+    )
+    guild = _FakeGuild(1)
+    pipeline = SettingsMutationPipeline()
+    # No member — system writes are allowed without an actor.
+    result = await pipeline.set_value(
+        guild,
+        "xp",
+        "xp_min",
+        5,
+        None,
+        actor_type="system",
+    )
+    assert result.new_value == 5
+    assert result.event_emitted is True
+
+
+@pytest.mark.asyncio
+async def test_backfill_actor_bypasses_authority_check():
+    _register(
+        "xp",
+        SettingSpec(name="xp_min", value_type=int, default=1, settings_key="XP_MIN"),
+    )
+    guild = _FakeGuild(1)
+    pipeline = SettingsMutationPipeline()
+    result = await pipeline.set_value(
+        guild,
+        "xp",
+        "xp_min",
+        5,
+        None,
+        actor_type="backfill",
+    )
+    assert result.new_value == 5
+
+
+# ---------------------------------------------------------------------------
+# Steps 4-5: coercion + validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_int_coercion_from_string():
+    _register(
+        "xp",
+        SettingSpec(name="xp_min", value_type=int, default=1, settings_key="XP_MIN"),
+    )
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = SettingsMutationPipeline()
+    result = await pipeline.set_value(guild, "xp", "xp_min", "42", actor)
+    assert result.new_value == 42
+    assert result.new_value_raw == "42"
+
+
+@pytest.mark.asyncio
+async def test_int_coercion_from_already_typed():
+    _register(
+        "xp",
+        SettingSpec(name="xp_min", value_type=int, default=1, settings_key="XP_MIN"),
+    )
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = SettingsMutationPipeline()
+    result = await pipeline.set_value(guild, "xp", "xp_min", 42, actor)
+    assert result.new_value == 42
+    assert result.new_value_raw == "42"
+
+
+@pytest.mark.asyncio
+async def test_bool_coercion_serialises_to_true_false():
+    _register(
+        "moderation",
+        SettingSpec(
+            name="dm_on_action",
+            value_type=bool,
+            default=False,
+            settings_key="MOD_DM_ON_ACTION",
+        ),
+    )
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = SettingsMutationPipeline()
+    result = await pipeline.set_value(guild, "moderation", "dm_on_action", True, actor)
+    assert result.new_value is True
+    assert result.new_value_raw == "true"
+
+
+@pytest.mark.asyncio
+async def test_bool_coercion_from_string_synonym():
+    _register(
+        "moderation",
+        SettingSpec(
+            name="dm_on_action",
+            value_type=bool,
+            default=False,
+            settings_key="MOD_DM_ON_ACTION",
+        ),
+    )
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = SettingsMutationPipeline()
+    result = await pipeline.set_value(guild, "moderation", "dm_on_action", "yes", actor)
+    assert result.new_value is True
+    assert result.new_value_raw == "true"
+
+
+@pytest.mark.asyncio
+async def test_coercion_failure_raises():
+    _register(
+        "xp",
+        SettingSpec(name="xp_min", value_type=int, default=1, settings_key="XP_MIN"),
+    )
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = SettingsMutationPipeline()
+    with pytest.raises(SettingsCoercionError):
+        await pipeline.set_value(guild, "xp", "xp_min", "abc", actor)
+
+
+@pytest.mark.asyncio
+async def test_validator_value_error_raises():
+    def _v(value):
+        if value < 0:
+            raise ValueError("must be non-negative")
+
+    _register(
+        "xp",
+        SettingSpec(
+            name="xp_min",
+            value_type=int,
+            default=1,
+            settings_key="XP_MIN",
+            validator=_v,
+        ),
+    )
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = SettingsMutationPipeline()
+    with pytest.raises(SettingsValidationError):
+        await pipeline.set_value(guild, "xp", "xp_min", -5, actor)
+
+
+@pytest.mark.asyncio
+async def test_validator_type_error_raises():
+    def _v(value):  # noqa: ARG001
+        raise TypeError("bad shape")
+
+    _register(
+        "xp",
+        SettingSpec(
+            name="xp_min",
+            value_type=int,
+            default=1,
+            settings_key="XP_MIN",
+            validator=_v,
+        ),
+    )
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = SettingsMutationPipeline()
+    with pytest.raises(SettingsValidationError):
+        await pipeline.set_value(guild, "xp", "xp_min", 5, actor)
+
+
+# ---------------------------------------------------------------------------
+# Step 6: read-previous-value integration with S3 resolver
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_previous_value_captured_when_no_kv_row(_isolated_state):
+    _register(
+        "xp",
+        SettingSpec(name="xp_min", value_type=int, default=15, settings_key="XP_MIN"),
+    )
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = SettingsMutationPipeline()
+    result = await pipeline.set_value(guild, "xp", "xp_min", 42, actor)
+    # No prior KV row, so old_value is the default and old_value_raw is None.
+    assert result.old_value == 15
+    assert result.old_value_raw is None
+    # Audit row records None for prev_value_raw.
+    audit = _isolated_state["audit_log"][0]
+    assert audit["prev_value_raw"] is None
+    assert audit["new_value_raw"] == "42"
+
+
+@pytest.mark.asyncio
+async def test_previous_value_captured_from_existing_kv_row(_isolated_state):
+    _register(
+        "xp",
+        SettingSpec(name="xp_min", value_type=int, default=15, settings_key="XP_MIN"),
+    )
+    _isolated_state["kv"][(1, "XP_MIN")] = "20"
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = SettingsMutationPipeline()
+    result = await pipeline.set_value(guild, "xp", "xp_min", 42, actor)
+    assert result.old_value == 20
+    assert result.old_value_raw == "20"
+    assert result.new_value == 42
+    audit = _isolated_state["audit_log"][0]
+    assert audit["prev_value_raw"] == "20"
+    assert audit["new_value_raw"] == "42"
+
+
+# ---------------------------------------------------------------------------
+# Steps 7-9: DB write + audit + cache invalidation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_audit_row_records_subsystem_name_settings_key(_isolated_state):
+    _register(
+        "moderation",
+        SettingSpec(
+            name="warn_threshold",
+            value_type=int,
+            default=3,
+            settings_key="WARN_THRESHOLD",
+            capability_required="moderation.settings.configure",
+        ),
+    )
+    guild = _FakeGuild(42)
+    actor = _FakeMember(99, guild=guild)
+    pipeline = SettingsMutationPipeline()
+    await pipeline.set_value(guild, "moderation", "warn_threshold", 5, actor)
+    audit = _isolated_state["audit_log"][0]
+    assert audit["guild_id"] == 42
+    assert audit["subsystem"] == "moderation"
+    assert audit["name"] == "warn_threshold"
+    assert audit["settings_key"] == "WARN_THRESHOLD"
+    assert audit["actor_id"] == 99
+    assert audit["actor_type"] == "user"
+    assert audit["mutation_type"] == "set_value"
+    # mutation_id is a UUID string.
+    assert len(audit["mutation_id"]) == 36
+
+
+@pytest.mark.asyncio
+async def test_audit_row_actor_id_is_none_for_system(_isolated_state):
+    _register(
+        "xp",
+        SettingSpec(name="xp_min", value_type=int, default=1, settings_key="XP_MIN"),
+    )
+    guild = _FakeGuild(1)
+    pipeline = SettingsMutationPipeline()
+    await pipeline.set_value(guild, "xp", "xp_min", 5, None, actor_type="system")
+    audit = _isolated_state["audit_log"][0]
+    assert audit["actor_id"] is None
+    assert audit["actor_type"] == "system"
+
+
+@pytest.mark.asyncio
+async def test_cache_invalidated_with_settings_key(_isolated_state):
+    _register(
+        "xp",
+        SettingSpec(name="xp_min", value_type=int, default=1, settings_key="XP_MIN"),
+    )
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = SettingsMutationPipeline()
+    await pipeline.set_value(guild, "xp", "xp_min", 5, actor)
+    assert (1, "XP_MIN") in _isolated_state["invalidations"]
+
+
+@pytest.mark.asyncio
+async def test_db_failure_skips_cache_and_event(_isolated_state, monkeypatch):
+    _register(
+        "xp",
+        SettingSpec(name="xp_min", value_type=int, default=1, settings_key="XP_MIN"),
+    )
+
+    async def _raises(**_kw):
+        raise RuntimeError("DB unavailable")
+
+    monkeypatch.setattr(audit_db, "set_value_with_audit", _raises)
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = SettingsMutationPipeline()
+    with pytest.raises(RuntimeError):
+        await pipeline.set_value(guild, "xp", "xp_min", 5, actor)
+    # Neither side effect should fire when the DB write fails.
+    assert _isolated_state["invalidations"] == []
+    assert _isolated_state["emitted"] == []
+
+
+# ---------------------------------------------------------------------------
+# Step 10: event emission (best-effort)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_event_emitted_with_full_payload(_isolated_state):
+    _register(
+        "xp",
+        SettingSpec(name="xp_min", value_type=int, default=1, settings_key="XP_MIN"),
+    )
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = SettingsMutationPipeline()
+    result = await pipeline.set_value(guild, "xp", "xp_min", 5, actor)
+    assert len(_isolated_state["emitted"]) == 1
+    payload = _isolated_state["emitted"][0]
+    assert payload["event"] == EVT_SETTINGS_CHANGED
+    assert payload["guild_id"] == 1
+    assert payload["subsystem"] == "xp"
+    assert payload["name"] == "xp_min"
+    assert payload["settings_key"] == "XP_MIN"
+    assert payload["old_value_raw"] is None
+    assert payload["new_value_raw"] == "5"
+    assert payload["mutation_id"] == result.mutation_id
+    assert "occurred_at" in payload
+    assert result.event_emitted is True
+
+
+@pytest.mark.asyncio
+async def test_event_emission_failure_swallowed(_isolated_state):
+    _register(
+        "xp",
+        SettingSpec(name="xp_min", value_type=int, default=1, settings_key="XP_MIN"),
+    )
+    _isolated_state["bus_raises"]["flag"] = True
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = SettingsMutationPipeline()
+    # Mutation must still succeed; only event_emitted=False.
+    result = await pipeline.set_value(guild, "xp", "xp_min", 5, actor)
+    assert result.event_emitted is False
+    assert result.new_value == 5
+    # DB write + cache invalidation still happened.
+    assert len(_isolated_state["audit_log"]) == 1
+    assert (1, "XP_MIN") in _isolated_state["invalidations"]
+
+
+# ---------------------------------------------------------------------------
+# Step 11: typed result + invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_result_is_frozen():
+    _register(
+        "xp",
+        SettingSpec(name="xp_min", value_type=int, default=1, settings_key="XP_MIN"),
+    )
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = SettingsMutationPipeline()
+    result = await pipeline.set_value(guild, "xp", "xp_min", 5, actor)
+    assert isinstance(result, SettingsMutationResult)
+    with pytest.raises(Exception):
+        result.new_value = 99  # type: ignore[misc]
+
+
+@pytest.mark.asyncio
+async def test_each_mutation_gets_distinct_id(_isolated_state):
+    _register(
+        "xp",
+        SettingSpec(name="xp_min", value_type=int, default=1, settings_key="XP_MIN"),
+    )
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = SettingsMutationPipeline()
+    r1 = await pipeline.set_value(guild, "xp", "xp_min", 5, actor)
+    r2 = await pipeline.set_value(guild, "xp", "xp_min", 10, actor)
+    assert r1.mutation_id != r2.mutation_id
+    assert len(_isolated_state["audit_log"]) == 2
+    # Second mutation captures the first as old_value_raw.
+    assert _isolated_state["audit_log"][1]["prev_value_raw"] == "5"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_is_stateless():
+    _register(
+        "xp",
+        SettingSpec(name="xp_min", value_type=int, default=1, settings_key="XP_MIN"),
+    )
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    # Two separate instances behave identically.
+    r1 = await SettingsMutationPipeline().set_value(guild, "xp", "xp_min", 5, actor)
+    r2 = await SettingsMutationPipeline().set_value(guild, "xp", "xp_min", 10, actor)
+    assert r1.new_value == 5
+    assert r2.new_value == 10
+
+
+# ---------------------------------------------------------------------------
+# Catalogue + event invariants
+# ---------------------------------------------------------------------------
+
+
+def test_event_name_registered_in_catalogue():
+    from core.events_catalogue import KNOWN_EVENTS
+
+    assert EVT_SETTINGS_CHANGED in KNOWN_EVENTS
+
+
+def test_feature_flag_is_declared_and_default_off():
+    from core.runtime.feature_flags import SETTINGS_MUTATION_PRIMARY
+
+    assert SETTINGS_MUTATION_PRIMARY.name == "settings.mutation.primary"
+    assert SETTINGS_MUTATION_PRIMARY.default_value is False
+
+
+def test_actor_type_allowlist_matches_documented_set():
+    """The pipeline's allowed actor_type set must match the migration's
+    CHECK constraint.  The alignment test does the SQL side; this test
+    pins the Python side to a fixed shape so future changes are
+    intentional."""
+    assert sm_mod._ALLOWED_ACTOR_TYPES == frozenset(
+        {"user", "moderator", "admin", "system", "backfill"},
+    )
+
+
+def test_mutation_type_allowlist_is_set_value_only_in_v1():
+    assert sm_mod._ALLOWED_MUTATION_TYPES == frozenset({"set_value"})

--- a/tests/unit/services/test_settings_mutation_pipeline_import_cycle.py
+++ b/tests/unit/services/test_settings_mutation_pipeline_import_cycle.py
@@ -1,0 +1,102 @@
+"""Import-cycle regression for services.settings_mutation — S4.
+
+The pipeline composes ``core.runtime.subsystem_schema``,
+``core.events.bus``, ``utils.db.settings_audit``,
+``utils.guild_config_accessors``, ``utils.subsystem_registry``, and
+``services.settings_resolution``.  Each of those transitively touches
+runtime primitives whose ``__init__`` modules walk ``core.runtime``;
+importing any at module scope risks re-entering partially loaded
+packages during startup.
+
+Discipline mirrors :mod:`services.platform_consistency`,
+:mod:`services.customization_catalogue`,
+:mod:`services.resource_provisioning_catalogue`, and
+:mod:`services.settings_resolution`: top-level imports are stdlib
+only; every cross-package import is function-local.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MODULE_PATH = _REPO_ROOT / "disbot" / "services" / "settings_mutation.py"
+
+_FORBIDDEN_TOP_LEVEL_PREFIXES = (
+    "cogs",
+    "core",
+    "discord",
+    "services.customization_catalogue",
+    "services.diagnostics_service",
+    "services.platform_consistency",
+    "services.resource_provisioning_catalogue",
+    "services.settings_resolution",
+    "utils",
+    "views",
+)
+
+
+def _module_level_imports(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    offenders: list[str] = []
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for prefix in _FORBIDDEN_TOP_LEVEL_PREFIXES:
+                if module == prefix or module.startswith(prefix + "."):
+                    offenders.append(
+                        f"from {module} import "
+                        f"{', '.join(a.name for a in node.names)}",
+                    )
+                    break
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                for prefix in _FORBIDDEN_TOP_LEVEL_PREFIXES:
+                    if alias.name == prefix or alias.name.startswith(prefix + "."):
+                        offenders.append(f"import {alias.name}")
+                        break
+    return offenders
+
+
+def test_settings_mutation_no_top_level_cycle_imports():
+    offenders = _module_level_imports(_MODULE_PATH)
+    assert not offenders, (
+        "services.settings_mutation has cycle-sensitive top-level imports:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_settings_mutation_imports_in_fresh_interpreter():
+    script = textwrap.dedent(
+        """
+        import sys
+        sys.path.insert(0, "disbot")
+        import services.settings_mutation as sm  # noqa: F401
+
+        assert sm.EVT_SETTINGS_CHANGED == "settings.changed"
+        assert sm.SettingsMutationPipeline is not None
+        # Catalogue + flag wired up at import time of the sibling modules.
+        from core.events_catalogue import KNOWN_EVENTS
+        assert sm.EVT_SETTINGS_CHANGED in KNOWN_EVENTS
+        from core.runtime.feature_flags import SETTINGS_MUTATION_PRIMARY
+        assert SETTINGS_MUTATION_PRIMARY.default_value is False
+        print("ok")
+        """,
+    )
+    result = subprocess.run(  # noqa: S603 — script literal under our control
+        [sys.executable, "-c", script],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"services.settings_mutation import failed in subprocess.\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary

S4 of the **Global Settings & Customization Manager** roadmap. First
write-path milestone — canonical writer for scalar `SettingSpec`
values backed by the legacy `guild_settings` KV table.

S0 (#92), S1 (#93), S2 (#94), S2.5 (#95), and S3 (#96) are all
merged.  This PR builds on current `main` at `81d6435` and stands
alone — every consumer that lights it up arrives in S5+.

## Why S4 is safe despite being the first write path

1. **Pipeline has zero production callers.** Like S3's resolver, it
   sits dormant until S5+ wires consumers. Adding the pipeline
   alone changes no runtime behaviour.
2. **Migration 029 is purely additive.** One new audit table, no
   backfill, no schema changes to existing tables. Rollback is a
   single `DROP TABLE IF EXISTS settings_mutation_audit`.
3. **Append-only audit.** The pipeline only `INSERT`s into the audit
   table; no `DELETE` / `UPDATE`. Even if the pipeline runs, the
   audit row is immutable.
4. **Existing `db.set_setting` callers are untouched.** The AST
   invariant (`test_no_direct_settings_keys_writes.py`) allowlists
   every pre-existing caller. Migration of each call site to the
   pipeline is per-subsystem **S10** work; no behaviour change in
   this PR.
5. **Feature flag is declared but NOT consulted by the pipeline.**
   `SETTINGS_MUTATION_PRIMARY` (default OFF) is pure kill-switch
   infrastructure for future S5+ UI consumers, mirroring how
   `BINDINGS_PRIMARY` is declared centrally but only
   `config_arbitration` reads it.
6. **Single-`git revert` safe.** The 9-file changeset, the
   migration, and the audit table all revert cleanly because no
   existing production code routes through them yet.

## Pipeline contract (11 steps)

Mirrors `services.binding_mutation.BindingMutationPipeline` and
`services.participation_mutation.ParticipationMutationPipeline`:

1. Resolve subsystem + `SettingSpec`.
2. Reject unknown subsystem / setting / unmigrateable setting (no
   `settings_key`).
3. Validate actor / capability (administrator-tier placeholder;
   Phase 4.5 swaps for typed capability resolution).
4. Coerce incoming value to declared `SettingSpec.value_type`
   (accepts string or already-typed).
5. Run `SettingSpec.validator` (if any).
6. Read previous value via
   `services.settings_resolution.resolve_setting` (S3).
7. Serialise coerced value to legacy-KV string form (`"true"` /
   `"false"` for bool; `str(value)` otherwise).
8. DB write + audit `INSERT` in one asyncpg transaction.
9. Invalidate `guild_config` cache via
   `utils.guild_config_accessors.invalidate_setting_value` (S3).
10. Emit advisory `"settings.changed"` event (best-effort, post-commit).
11. Return typed `SettingsMutationResult`.

Best-effort emission: if `bus.emit` raises after a successful DB
commit, the error is logged with the `mutation_id` and swallowed —
DB state is authoritative.

## Public surface

```python
@dataclass(frozen=True)
class SettingsMutationResult:
    mutation_id: str
    guild_id: int
    subsystem: str
    name: str
    settings_key: str
    old_value: Any
    new_value: Any
    old_value_raw: str | None
    new_value_raw: str
    committed_at: datetime
    event_emitted: bool


class SettingsMutationPipeline:
    async def set_value(
        self,
        guild,
        subsystem: str,
        name: str,
        value: Any,
        actor,
        *,
        actor_type: str = "user",
    ) -> SettingsMutationResult: ...


# Errors
class SettingsMutationError(Exception): ...
class UnknownSubsystemError(SettingsMutationError): ...
class UndeclaredSettingError(SettingsMutationError): ...
class UnmigrateableSettingError(SettingsMutationError): ...
class SettingsCoercionError(SettingsMutationError): ...
class SettingsValidationError(SettingsMutationError): ...
class UnauthorizedSettingsMutationError(SettingsMutationError): ...
class InvalidActorTypeError(SettingsMutationError): ...

EVT_SETTINGS_CHANGED = "settings.changed"
```

## Files changed

- **`disbot/migrations/029_settings_mutation_audit.sql`** *(new)* —
  one new audit table with CHECK constraints on `mutation_type`
  (`set_value` in v1) and `actor_type`
  (`user|moderator|admin|system|backfill`), indexed on
  `(settings_key, at)`, `(guild_id, at)`, `(mutation_id)`.
  Forward-only and idempotent (`CREATE … IF NOT EXISTS`).
- **`disbot/utils/db/settings_audit.py`** *(new)* —
  `set_value_with_audit` (atomic `guild_settings` UPSERT + audit
  INSERT in one transaction); read primitives `count_for_guild`,
  `count_total`, `list_recent_for_guild`, `list_recent_for_key` for
  the future `platform_consistency` collector.
- **`disbot/services/settings_mutation.py`** *(new, 519 LOC)* — the
  pipeline. Cycle-safe: top-level imports are stdlib only; every
  cross-package access is function-local.
- **`disbot/core/events_catalogue.py`** — register
  `"settings.changed"` in `KNOWN_EVENTS`.
- **`disbot/core/runtime/feature_flags.py`** — declare and register
  `SETTINGS_MUTATION_PRIMARY` (default `False`); add to `__all__`.
- **`tests/unit/services/test_settings_mutation_pipeline.py`**
  *(new, 32 tests)* — every error class, actor / authority
  validation including the `system` and `backfill` bypass, every
  coercion path (`int` / `str` / `bool` / `float`, bool synonyms,
  already-typed shortcuts), validator `ValueError`/`TypeError`,
  previous-value capture from existing KV row, audit-row
  contents (`subsystem` / `name` / `settings_key` / `actor_id` /
  `actor_type` / `mutation_id`), cache invalidation, event
  emission with full payload, emission failure swallowed,
  DB failure skips side effects, frozen result, distinct
  `mutation_id` per call, stateless pipeline, catalogue + flag
  registration, allowlist sanity.
- **`tests/unit/services/test_settings_mutation_pipeline_import_cycle.py`**
  *(new, 2 tests)* — pins the cycle discipline (no top-level
  imports of `core.*`, `cogs.*`, `discord`, `services.*`
  cross-package, `utils.*`, `views.*`) and verifies the module
  imports cleanly in a fresh interpreter.
- **`tests/unit/invariants/test_no_direct_settings_keys_writes.py`**
  *(new, 3 tests)* — AST scan forbidding direct `db.set_setting`
  calls outside an allowlist of the primitive + the pipeline DB
  layer + 7 pre-existing callers that will migrate per-subsystem
  in S10. Also pins that the pipeline service itself never calls
  `db.set_setting` directly (it writes via
  `settings_audit.set_value_with_audit`).
- **`tests/unit/invariants/test_settings_mutation_audit_alignment.py`**
  *(new, 4 tests)* — pins migration 029 CHECK literals
  (`mutation_type`, `actor_type`) against the Python `frozenset`s
  in `services.settings_mutation`; pins that the migration is
  forward-only and idempotent (strips SQL comments first so the
  rollback note describing `-- Rollback: DROP TABLE IF EXISTS ...`
  does not trip the destructive-statement scan).

## Migration details

- **Number:** 029 (next after `028_user_participation_audit.sql`).
- **Type:** additive, forward-only, idempotent.
- **What it creates:** one new table `settings_mutation_audit` + 3
  indexes. No changes to `guild_settings` or any other existing
  table.
- **Backfill:** none.
- **CHECK constraints:** `mutation_type IN ('set_value')` and
  `actor_type IN ('user', 'moderator', 'admin', 'system',
  'backfill')`. Both pinned by an alignment test against the Python
  `frozenset`s.
- **Indexes:** `(settings_key, at)`, `(guild_id, at)`,
  `(mutation_id)` — the three common query shapes.
- **Rollback safety:** `DROP TABLE IF EXISTS settings_mutation_audit;`
  removes the audit history with no downstream impact. The pipeline
  is unused in production, so dropping the table breaks no live
  read path. An aborted operator could also simply skip the
  migration; the rest of `bot1.py` boots unchanged because nothing
  depends on the table at startup.

## Tests run and exact results

- [x] `python3 -m pytest tests/unit/services/test_settings_mutation_pipeline.py` — **32 passed**
- [x] `python3 -m pytest tests/unit/services/test_settings_mutation_pipeline_import_cycle.py` — **2 passed**
- [x] `python3 -m pytest tests/unit/invariants/test_no_direct_settings_keys_writes.py` — **3 passed**
- [x] `python3 -m pytest tests/unit/invariants/test_settings_mutation_audit_alignment.py` — **4 passed**
- [x] `python3 -m pytest tests/unit/services/test_settings_resolution.py tests/unit/runtime/test_settings_registry.py` — **48 passed** (S3 + S1 still green)
- [x] `python3 -m pytest tests/unit/` — full suite: **1759 passed, 0 failed, 12 warnings**
- [x] `ruff check disbot/` — all checks passed
- [x] `black --check disbot/` — 237 files unchanged
- [x] `isort --check-only disbot/ tests/` — clean
- [x] `mypy disbot/` — no issues found in 237 source files
- [x] Single-`git revert` safe (additive migration, no behaviour change in existing flows)

## Manual smoke checklist (for the operator)

- The pipeline is wired into nothing in production today. REPL
  verification once the migration has run:
  - `await SettingsMutationPipeline().set_value(guild, "moderation",
    "warn_threshold", 5, actor)` returns a typed
    `SettingsMutationResult` with `event_emitted=True`.
  - `SELECT * FROM settings_mutation_audit WHERE guild_id = <id>
    ORDER BY at DESC LIMIT 1` shows the row with `mutation_type =
    'set_value'`, `prev_value_raw` / `new_value_raw` populated.
  - The next `resolve_setting(guild_id, "moderation",
    "warn_threshold")` returns the new value (cache invalidation
    works).
  - Invalid input (`"abc"` for an int spec) raises
    `SettingsCoercionError`; nothing is written and no event is
    emitted.
  - Bypassing the pipeline by typing
    `await db.set_setting(guild.id, "WARN_THRESHOLD", "9")`
    still works (legacy callers are allowlisted) but the audit row
    is **not** written — exactly the behaviour S10 will migrate
    away from.
- Every other `!platform <subcommand>` still renders unchanged.
- `bot1.py` boots even if the migration has not been applied
  (nothing at startup queries the new table).

## Risks and rollback plan

- **Risks:** none in production — the pipeline is dormant and
  the migration is purely additive. The only failure modes are:
  - **Migration not applied** → no impact at startup; calling the
    pipeline would raise from the DB layer with a clear error.
  - **Existing `db.set_setting` caller modified** → would trip
    the new AST invariant; the test message points to the
    pipeline as the remedy.
- **Rollback:** `git revert` of commit `e2824f5` removes the
  pipeline, the audit table SQL file, the new feature flag, the
  event catalogue entry, and the four test files. The migration
  table itself can be dropped with
  `DROP TABLE IF EXISTS settings_mutation_audit;` — no existing
  code depends on it.

## Deferred work

Matches the S1/S2/S2.5/S3 precedent — every prior milestone in the
roadmap explicitly deferred its `services.platform_consistency`
collector to a follow-up PR. S4 follows the same pattern:

- `disbot/services/platform_consistency.py` —
  `_collect_settings_mutation` collector surfacing the audit-row
  count (per-guild and total) as informational. Tiny follow-up
  that can bundle with the deferred collectors from #93, #94, #95,
  #96.

S5+ will then add the first consumers of the pipeline (Settings
Manager UI shell, scalar edit / reset flows, etc.).

## PR sequencing — built on `main`, stands alone

This PR is built on `main` at `81d6435` (with PR #96 merged) and
stands alone. The next milestone you may start in parallel:

- **S4.5 — ResourceProvisioningPipeline** can start independently
  from `main` because it depends on S2.5 (`ResourceProvisioningCatalogue`,
  merged in #95) and the existing `BindingMutationPipeline`, not on
  this PR.
- **S5 / S6** (Settings Manager UI shell + scalar edit/reset
  flows) likely depend on S4 being merged because the UI must call
  `SettingsMutationPipeline.set_value(...)`. If S4 is not merged
  when S5/S6 are ready, those PRs should either pause or
  intentionally stack on this branch with explicit dependency
  documentation.

## Next recommended PR

**S4.5 — `ResourceProvisioningPipeline`** on branch
`claude/resource-provisioning-pipeline`. Canonical creator/binder
of Discord resources; calls `BindingMutationPipeline.set_binding`
at step 8 of its 11-step contract. Independent of this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U3sByR3PY3gobeB3jLFDFD)_