### PR TITLE
feat(s4.5): ResourceProvisioningPipeline + audit table + invariants

### DIFF
--- a/disbot/core/events_catalogue.py
+++ b/disbot/core/events_catalogue.py
@@ -68,6 +68,14 @@ KNOWN_EVENTS: frozenset[str] = frozenset(
         # platform_consistency collector) and never for cache consistency.
         # Subscriber failure logged + swallowed.
         "settings.changed",
+        # ── Resource provisioning (services/resource_provisioning.py, S4.5)
+        # Advisory.  Emitted after the pipeline writes the binding via
+        # BindingMutationPipeline.  The companion "bindings.changed"
+        # event continues to fire from BindingMutationPipeline (the
+        # pipeline composes, not replaces).  Nothing in this event
+        # drives cache consistency; subscriber failure is logged and
+        # swallowed.
+        "resource.provisioned",
         # ── Feature flags (services/rollout_mutation.py, Phase 2d PR-3) ───
         # Advisory events emitted after the DB commit + audit row land.
         # Subscriber failure is logged with mutation_id and never raised

--- a/disbot/core/runtime/feature_flags.py
+++ b/disbot/core/runtime/feature_flags.py
@@ -262,6 +262,26 @@ SETTINGS_MUTATION_PRIMARY = FeatureFlag(
     removal_target="S5+ stable",
 )
 
+# S4.5 flag — kill-switch infrastructure for future ResourceProvisioning
+# UI (S7+ logging-create flow, S10 per-subsystem setup packs) consumers
+# of :class:`services.resource_provisioning.ResourceProvisioningPipeline`.
+# The pipeline itself does NOT consult this flag — it provisions
+# whenever explicitly invoked.  Mirrors the SETTINGS_MUTATION_PRIMARY
+# pattern.
+RESOURCE_PROVISIONING_PRIMARY = FeatureFlag(
+    name="resource_provisioning.primary",
+    description=(
+        "services.resource_provisioning.ResourceProvisioningPipeline is the "
+        "primary creator/binder of Discord resources (channels/roles/"
+        "categories); future S7+/S10 UI consumers gate their routing on "
+        "this flag.  The pipeline itself does not consult the flag — its "
+        "existence alone changes no behaviour."
+    ),
+    default_value=False,
+    owner="platform",
+    removal_target="S10+ stable",
+)
+
 
 def _register_builtins() -> None:
     """Register Phase 1d platform-level flags at import time."""
@@ -270,6 +290,7 @@ def _register_builtins() -> None:
     register(PARTICIPATION_ENABLED)
     register(FEATURE_FLAG_PRIMARY)
     register(SETTINGS_MUTATION_PRIMARY)
+    register(RESOURCE_PROVISIONING_PRIMARY)
 
 
 _register_builtins()
@@ -693,6 +714,7 @@ __all__ = [
     "FEATURE_FLAG_PRIMARY",
     "FeatureFlag",
     "PARTICIPATION_ENABLED",
+    "RESOURCE_PROVISIONING_PRIMARY",
     "RESOURCES_UNIFIED",
     "RolloutPolicy",
     "SETTINGS_MUTATION_PRIMARY",

--- a/disbot/core/runtime/guild_resources.py
+++ b/disbot/core/runtime/guild_resources.py
@@ -187,6 +187,103 @@ def resolve_role(
     return discord.utils.get(guild.roles, name=name)
 
 
+async def ensure_role(
+    guild: discord.Guild,
+    name: str,
+    *,
+    permissions: discord.Permissions | None = None,
+    hoist: bool = False,
+    mentionable: bool = False,
+    reason: str | None = None,
+) -> discord.Role:
+    """Return a role matching ``name``, creating it if absent.
+
+    The match is performed via :func:`resolve_role` with the exact
+    ``name`` filter.  If a match is found it is returned unchanged
+    (permissions / hoist / mentionable are NOT reconciled — callers
+    managing role-template policies should call ``role.edit`` themselves).
+
+    On miss, the role is created via ``guild.create_role``.  The helper
+    is intentionally policy-free: it has no feature-flag check, no
+    capability validation, no audit emission.  Provisioning policy is
+    owned by
+    :class:`services.resource_provisioning.ResourceProvisioningPipeline`;
+    direct callers outside the pipeline are constrained by the
+    ``tests/unit/invariants/test_no_silent_auto_create.py`` allowlist.
+
+    Mirrors the shape of :func:`ensure_channel`.
+    """
+    existing = resolve_role(guild, name=name)
+    if existing is not None:
+        return existing
+    return await guild.create_role(
+        name=name,
+        permissions=permissions or discord.Permissions.none(),
+        hoist=hoist,
+        mentionable=mentionable,
+        reason=reason,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Categories
+# ---------------------------------------------------------------------------
+
+
+def resolve_category(
+    guild: discord.Guild,
+    *,
+    category_id: int | str | None = None,
+    name: str | None = None,
+) -> discord.CategoryChannel | None:
+    """Resolve a category by ID (preferred) or exact name.
+
+    Mirrors :func:`resolve_role` — ``category_id`` wins on hit; name
+    match is exact (case-sensitive).
+    """
+    if category_id is not None:
+        try:
+            cid_int = int(category_id)
+        except (TypeError, ValueError):
+            cid_int = None
+        if cid_int is not None:
+            ch = guild.get_channel(cid_int)
+            if isinstance(ch, discord.CategoryChannel):
+                return ch
+    if name is None:
+        return None
+    for cat in guild.categories:
+        if cat.name == name:
+            return cat
+    return None
+
+
+async def ensure_category(
+    guild: discord.Guild,
+    name: str,
+    *,
+    overwrites: dict | None = None,
+    reason: str | None = None,
+) -> discord.CategoryChannel:
+    """Return a category matching ``name``, creating it if absent.
+
+    The match is performed via :func:`resolve_category` with the exact
+    ``name`` filter.  On miss, the category is created via
+    ``guild.create_category``.  Like :func:`ensure_channel` and
+    :func:`ensure_role`, the helper is policy-free: provisioning
+    policy belongs to
+    :class:`services.resource_provisioning.ResourceProvisioningPipeline`.
+    """
+    existing = resolve_category(guild, name=name)
+    if existing is not None:
+        return existing
+    return await guild.create_category(
+        name,
+        overwrites=overwrites or {},
+        reason=reason,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Members
 # ---------------------------------------------------------------------------

--- a/disbot/migrations/030_resource_provisioning_audit.sql
+++ b/disbot/migrations/030_resource_provisioning_audit.sql
@@ -1,0 +1,111 @@
+-- Migration 030: resource_provisioning_audit (S4.5).
+--
+-- Append-only audit log for every mutation that flows through
+-- :class:`services.resource_provisioning.ResourceProvisioningPipeline`.
+-- One row per provisioning attempt — successful, declined, failed,
+-- or permission-blocked.  Rollback is a NEW row, never an UPDATE.
+--
+-- The pipeline is the canonical creator/binder of Discord resources
+-- (channels, roles, categories).  Existing direct callers of
+-- ``guild.create_*`` are grandfathered legacy paths allowlisted by
+-- ``tests/unit/invariants/test_no_silent_auto_create.py``; they will
+-- migrate to the pipeline per-subsystem in S10.
+--
+-- Audit shape:
+--
+--   * ``mutation_type='provision'`` — the pipeline ran a provisioning
+--     request.  ``mode`` distinguishes ``use_existing`` (the operator
+--     selected an already-existing resource) from ``create`` (the
+--     pipeline created a new resource on Discord).
+--     ``outcome`` records what actually happened.
+--
+-- Outcomes (defense-in-depth via CHECK):
+--
+--   * ``success``            — resource created/reused AND binding
+--                              written via BindingMutationPipeline.
+--   * ``permission_blocked`` — bot lacks the Discord permission to
+--                              perform the requested action; no
+--                              resource written, no binding written.
+--   * ``discord_failed``     — Discord API call raised (HTTPException,
+--                              etc.) after permission check passed; no
+--                              binding written.
+--   * ``binding_failed``     — Discord resource was created/resolved
+--                              but BindingMutationPipeline raised.
+--                              The resource_id is recorded so an
+--                              operator can manually clean up or retry
+--                              the bind.  No automatic rollback (the
+--                              created resource may carry value the
+--                              operator wants to keep).
+--   * ``declined``           — pipeline rejected the request before any
+--                              Discord call (confirmation missing for
+--                              ``mode='create'``, kind mismatch on
+--                              ``mode='use_existing'``, etc.).  Listed
+--                              so audit history captures rejected
+--                              attempts.
+--
+-- Modes:
+--
+--   * ``use_existing`` — operator selected an existing resource;
+--                        ``existing_id`` is set.
+--   * ``create``       — pipeline created a new resource; ``resource_id``
+--                        is the newly-created snowflake.
+--
+-- Kinds (mirror :class:`core.runtime.resource_specs.ResourceKind`):
+--
+--   * ``channel`` | ``role`` | ``category`` | ``thread``
+--
+-- Actor model (mirrors settings_mutation_audit / migration 029):
+--
+--   * ``actor_type='user'`` | ``'moderator'`` | ``'admin'`` |
+--                            ``'system'`` | ``'backfill'``
+--
+-- Indexed on ``(guild_id, at)`` for per-guild history,
+-- ``(subsystem, binding_name, at)`` for per-slot history, and
+-- ``(mutation_id)`` for cross-pipeline correlation (the same
+-- ``mutation_id`` is propagated to the binding-mutation pipeline's
+-- audit row, so a "show me everything that happened during this
+-- provisioning" query joins on ``mutation_id``).
+--
+-- Rollback: ``DROP TABLE IF EXISTS resource_provisioning_audit``
+-- removes this audit history.  The legacy ``subsystem_bindings``
+-- table is untouched (BindingMutationPipeline owns it) and remains
+-- the authoritative store for binding state.
+--
+-- Forward-only and idempotent.
+
+CREATE TABLE IF NOT EXISTS resource_provisioning_audit (
+    id                  BIGSERIAL    PRIMARY KEY,
+    mutation_id         UUID         NOT NULL,
+    guild_id            BIGINT       NOT NULL,
+    subsystem           TEXT         NOT NULL,
+    binding_name        TEXT         NOT NULL,
+    kind                TEXT         NOT NULL,
+    mode                TEXT         NOT NULL,
+    outcome             TEXT         NOT NULL,
+    created             BOOLEAN      NOT NULL DEFAULT FALSE,
+    resource_id         BIGINT,
+    suggested_name      TEXT,
+    custom_name         TEXT,
+    actor_id            BIGINT,
+    actor_type          TEXT         NOT NULL DEFAULT 'user',
+    mutation_type       TEXT         NOT NULL DEFAULT 'provision',
+    error_message       TEXT,
+    at                  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    CHECK (mutation_type IN ('provision')),
+    CHECK (kind IN ('channel', 'role', 'category', 'thread')),
+    CHECK (mode IN ('use_existing', 'create')),
+    CHECK (outcome IN
+        ('success', 'permission_blocked', 'discord_failed',
+         'binding_failed', 'declined')),
+    CHECK (actor_type IN
+        ('user', 'moderator', 'admin', 'system', 'backfill'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_resource_provisioning_audit_guild_at
+    ON resource_provisioning_audit (guild_id, at);
+
+CREATE INDEX IF NOT EXISTS idx_resource_provisioning_audit_slot
+    ON resource_provisioning_audit (subsystem, binding_name, at);
+
+CREATE INDEX IF NOT EXISTS idx_resource_provisioning_audit_mutation
+    ON resource_provisioning_audit (mutation_id);

--- a/disbot/services/resource_provisioning.py
+++ b/disbot/services/resource_provisioning.py
@@ -1,0 +1,843 @@
+"""Resource provisioning pipeline — S4.5 of the Global Settings & Customization Manager.
+
+The canonical creator/binder of Discord resources (channels, roles,
+categories) for subsystem use.  Wraps:
+
+* :mod:`core.runtime.guild_resources` — pure infrastructure helpers
+  ``ensure_channel`` / ``ensure_role`` / ``ensure_category`` that
+  perform the actual Discord API calls.  No policy lives there.
+* :mod:`services.binding_mutation` — writes the binding row at step
+  8 of the contract.  This pipeline is the only legitimate creator;
+  it composes ``BindingMutationPipeline.set_binding`` rather than
+  replacing it.
+* :mod:`services.resource_provisioning_catalogue` — read-only
+  cross-link snapshot of every ``ResourceRequirement`` with its
+  ``BindingSpec``.  The pipeline reads this catalogue to resolve
+  the request shape.
+* :mod:`utils.db.resource_provisioning_audit` — append-only audit
+  log for every provisioning attempt (success, decline, or failure).
+
+Eleven-step contract per :meth:`ResourceProvisioningPipeline.provision`:
+
+  1. Resolve ``ResourceRequirement`` + ``BindingSpec`` from
+     :class:`services.resource_provisioning_catalogue.ProvisioningCatalogue`.
+     Raise :class:`UndeclaredResourceError` if no option matches.
+  2. Validate actor / capability (administrator-tier placeholder;
+     Phase 4.5 swaps for typed capability resolution against
+     ``BindingSpec.capability_required``).
+  3. Validate bot Discord permissions for the requested kind
+     (``manage_channels`` for CHANNEL/CATEGORY, ``manage_roles`` for
+     ROLE).  Insufficient perms → :class:`UnauthorizedProvisioningError`
+     and audited as ``permission_blocked``.
+  4. Preview creation/reuse result via :meth:`preview` (already-bound?
+     name collision? category exists?).  Records ``warnings``
+     non-fatally.
+  5. Require explicit confirmation: ``mode='create'`` requires
+     ``confirmed=True``, otherwise raise
+     :class:`ProvisioningConfirmationRequired`.
+  6. Create or reuse the resource.
+     - ``mode='create'``: dispatch via :mod:`core.runtime.guild_resources`
+       (``ensure_channel`` / ``ensure_role`` / ``ensure_category``).
+       Discord failure → :class:`DiscordProvisioningFailedError` and
+       audited as ``discord_failed``.
+     - ``mode='use_existing'``: re-resolve ``existing_id`` on the
+       guild and verify ``kind`` matches.
+  7. Validate created resource — re-resolve by ID, confirm ``kind``
+     match.  Mismatches log a warning but do not abort.
+  8. Bind the resource through
+     :meth:`services.binding_mutation.BindingMutationPipeline.set_binding`.
+     Binding failure does NOT roll back the created Discord resource —
+     it is audited as ``binding_failed`` so the operator can manually
+     re-bind or clean up.
+  9. Audit one row in ``resource_provisioning_audit`` (migration 030).
+ 10. Emit advisory ``"resource.provisioned"`` event after commit
+     (best-effort; subscriber failure logged + swallowed).
+ 11. Return typed :class:`ProvisioningResult`.
+
+Hard limits for S4.5:
+
+* Pipeline has zero production callers; future S7 logging UI + S10
+  setup packs invoke it.
+* The :data:`core.runtime.feature_flags.RESOURCE_PROVISIONING_PRIMARY`
+  flag is declared but NOT consulted by this pipeline — kill-switch
+  infrastructure for future UI consumers, matching SETTINGS_MUTATION_PRIMARY.
+* No silent auto-create.  ``mode='create'`` always requires
+  ``confirmed=True``; standing operator settings (e.g.
+  ``logging.auto_create_channels=true``) are the only legitimate
+  source of an "implicit confirmation" and are wired by S7's
+  logging consumer, not by this pipeline.
+* No direct ``guild.create_*`` calls in this module — every
+  resource-creation goes through the ``ensure_*`` helpers in
+  :mod:`core.runtime.guild_resources`.  Pinned by
+  ``tests/unit/invariants/test_no_silent_auto_create.py``.
+
+Cycle discipline (mirrors :mod:`services.platform_consistency`,
+:mod:`services.settings_mutation`): all cross-package imports are
+function-local.  Top-level imports are stdlib only.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+logger = logging.getLogger("bot.services.resource_provisioning")
+
+
+# ---------------------------------------------------------------------------
+# Catalogued event name (registered in core/events_catalogue.py).
+# ---------------------------------------------------------------------------
+
+EVT_RESOURCE_PROVISIONED = "resource.provisioned"
+
+
+# ---------------------------------------------------------------------------
+# Recognized literal sets — mirror migration 030 CHECK constraints.
+# Pinned by tests/unit/invariants/test_resource_provisioning_audit_alignment.py.
+# ---------------------------------------------------------------------------
+
+_ALLOWED_ACTOR_TYPES: frozenset[str] = frozenset(
+    {"user", "moderator", "admin", "system", "backfill"},
+)
+_ALLOWED_MUTATION_TYPES: frozenset[str] = frozenset({"provision"})
+_ALLOWED_MODES: frozenset[str] = frozenset({"use_existing", "create"})
+_ALLOWED_KINDS: frozenset[str] = frozenset(
+    {"channel", "role", "category", "thread"},
+)
+_ALLOWED_OUTCOMES: frozenset[str] = frozenset(
+    {"success", "permission_blocked", "discord_failed", "binding_failed", "declined"},
+)
+
+_WRITE_AUTHORITY_TIER = "administrator"
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class ResourceProvisioningError(Exception):
+    """Base class for failures from :class:`ResourceProvisioningPipeline`."""
+
+
+class UndeclaredResourceError(ResourceProvisioningError):
+    """Raised when ``(subsystem, binding_name)`` is not in the catalogue."""
+
+
+class UnauthorizedProvisioningError(ResourceProvisioningError):
+    """Raised when actor or bot lacks the required permissions."""
+
+
+class ProvisioningConfirmationRequired(  # noqa: N818 — name pinned by the roadmap spec
+    ResourceProvisioningError,
+):
+    """Raised when ``mode='create'`` is invoked without ``confirmed=True``.
+
+    The pipeline rejects creates that have not seen an explicit
+    confirmation gate.  UI callers must call :meth:`preview` first,
+    show the operator the planned action, then call
+    :meth:`provision(..., confirmed=True)`.
+    """
+
+
+class DiscordProvisioningFailedError(ResourceProvisioningError):
+    """Raised when the Discord API call itself fails (HTTPException etc.)."""
+
+
+class InvalidActorTypeError(ResourceProvisioningError):
+    """Raised when ``actor_type`` is not in :data:`_ALLOWED_ACTOR_TYPES`."""
+
+
+class KindMismatchError(ResourceProvisioningError):
+    """Raised when ``mode='use_existing'`` resolves a resource whose kind
+    does not match the requested :class:`ResourceKind`.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+_ProvisioningMode = Literal["use_existing", "create"]
+_ProvisioningAction = Literal["reuse_existing", "create_new", "blocked"]
+_ProvisioningOutcome = Literal[
+    "success",
+    "permission_blocked",
+    "discord_failed",
+    "binding_failed",
+    "declined",
+]
+
+
+@dataclass(frozen=True)
+class ProvisioningRequest:
+    """Typed request shape passed into :meth:`provision` / :meth:`preview`.
+
+    The pipeline never mutates the request; UI callers build one
+    request per provisioning attempt.
+    """
+
+    subsystem: str
+    binding_name: str
+    mode: _ProvisioningMode
+    existing_id: int | None = None
+    custom_name: str | None = None
+    category_id: int | None = None
+    permission_template: str | None = None
+
+
+@dataclass(frozen=True)
+class ProvisioningPreview:
+    """What :meth:`provision` would do without performing side effects."""
+
+    allowed: bool
+    action: _ProvisioningAction
+    target_name: str
+    warnings: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ProvisioningResult:
+    """Outcome of a (successful or partially successful) provisioning attempt."""
+
+    mutation_id: str
+    guild_id: int
+    subsystem: str
+    binding_name: str
+    kind: str
+    mode: str
+    outcome: _ProvisioningOutcome
+    created: bool
+    resource_id: int | None
+    binding_written: bool
+    audit_id: int | None
+    committed_at: datetime
+    event_emitted: bool
+
+
+# ---------------------------------------------------------------------------
+# Pipeline
+# ---------------------------------------------------------------------------
+
+
+class ResourceProvisioningPipeline:
+    """Centralised orchestration for Discord resource provisioning.
+
+    Instances are stateless — create one per provisioning request.
+    Public methods :meth:`preview` (side-effect-free) and
+    :meth:`provision` (audited write path).  Callers MUST NOT touch
+    :mod:`utils.db.resource_provisioning_audit`'s insert primitive
+    directly, nor invoke ``guild.create_*`` outside this pipeline +
+    the grandfathered legacy allowlist enforced by
+    ``tests/unit/invariants/test_no_silent_auto_create.py``.
+    """
+
+    def __init__(self) -> None:
+        pass
+
+    async def preview(
+        self,
+        guild: Any,
+        request: ProvisioningRequest,
+    ) -> ProvisioningPreview:
+        """Return what :meth:`provision` would do, without side effects.
+
+        Resolves the catalogue option, checks bot permissions, and
+        notes any warnings (already-bound slot, name collision,
+        category mismatch).  Does NOT raise; an error condition is
+        reflected as ``allowed=False`` and ``action='blocked'`` with
+        the reason in ``warnings``.
+        """
+        from services import resource_provisioning_catalogue as rpc
+
+        catalogue = rpc.get_cached_provisioning_catalogue()
+        if catalogue is None:
+            return ProvisioningPreview(
+                allowed=False,
+                action="blocked",
+                target_name="",
+                warnings=("resource_provisioning_catalogue not built yet",),
+            )
+
+        option = catalogue.find(request.subsystem, request.binding_name)
+        if option is None:
+            return ProvisioningPreview(
+                allowed=False,
+                action="blocked",
+                target_name="",
+                warnings=(
+                    f"no provisioning option for "
+                    f"{request.subsystem!r}/{request.binding_name!r}",
+                ),
+            )
+
+        warnings: list[str] = []
+
+        # Bot permission check.
+        ok, perm_msg = self._bot_can_provision(guild, option.kind, request.mode)
+        if not ok:
+            return ProvisioningPreview(
+                allowed=False,
+                action="blocked",
+                target_name=option.suggested_name,
+                warnings=(perm_msg,),
+            )
+
+        target_name = request.custom_name or option.suggested_name
+
+        if request.mode == "use_existing":
+            if request.existing_id is None:
+                return ProvisioningPreview(
+                    allowed=False,
+                    action="blocked",
+                    target_name=target_name,
+                    warnings=("mode='use_existing' requires existing_id",),
+                )
+            resolved = self._resolve_existing(guild, option.kind, request.existing_id)
+            if resolved is None:
+                return ProvisioningPreview(
+                    allowed=False,
+                    action="blocked",
+                    target_name=target_name,
+                    warnings=(
+                        f"existing_id={request.existing_id} did not resolve to a "
+                        f"{option.kind} on this guild",
+                    ),
+                )
+            return ProvisioningPreview(
+                allowed=True,
+                action="reuse_existing",
+                target_name=getattr(resolved, "name", str(request.existing_id)),
+                warnings=tuple(warnings),
+            )
+
+        # request.mode is "create" past this point.
+        if not target_name:
+            return ProvisioningPreview(
+                allowed=False,
+                action="blocked",
+                target_name="",
+                warnings=("no target name supplied and option has no suggested_name",),
+            )
+        # Surface a soft warning if a same-named resource already exists.
+        if self._existing_by_name(guild, option.kind, target_name) is not None:
+            warnings.append(
+                f"a {option.kind} named {target_name!r} already exists; "
+                "ensure_* will reuse it",
+            )
+        return ProvisioningPreview(
+            allowed=True,
+            action="create_new",
+            target_name=target_name,
+            warnings=tuple(warnings),
+        )
+
+    async def provision(
+        self,
+        guild: Any,
+        request: ProvisioningRequest,
+        actor: Any,
+        *,
+        confirmed: bool = False,
+        actor_type: str = "user",
+    ) -> ProvisioningResult:
+        """Execute the 11-step contract.
+
+        ``confirmed=True`` is required when ``request.mode == 'create'``;
+        UI callers obtain confirmation by showing the operator a
+        :class:`ProvisioningPreview` first.  ``mode='use_existing'``
+        does not require ``confirmed=True`` because the operator's
+        selection of an existing resource is itself the confirmation.
+
+        Raises (with audit row written before the raise where
+        applicable):
+
+          * UndeclaredResourceError
+          * UnauthorizedProvisioningError
+          * ProvisioningConfirmationRequired
+          * DiscordProvisioningFailedError
+          * KindMismatchError
+          * InvalidActorTypeError
+        """
+        from services import resource_provisioning_catalogue as rpc
+
+        self._validate_actor_type(actor_type)
+        self._validate_mode(request.mode)
+        self._validate_actor_authority(actor, actor_type)
+
+        catalogue = rpc.get_cached_provisioning_catalogue()
+        if catalogue is None:
+            raise UndeclaredResourceError(
+                "resource_provisioning_catalogue not built yet — "
+                "call build_provisioning_catalogue() first",
+            )
+        option = catalogue.find(request.subsystem, request.binding_name)
+        if option is None:
+            raise UndeclaredResourceError(
+                f"no provisioning option for "
+                f"{request.subsystem!r}/{request.binding_name!r}",
+            )
+
+        if request.mode == "create" and not confirmed:
+            raise ProvisioningConfirmationRequired(
+                f"mode='create' for {request.subsystem!r}/"
+                f"{request.binding_name!r} requires confirmed=True; "
+                "call .preview(...) first",
+            )
+
+        mutation_id = str(uuid.uuid4())
+        actor_id = getattr(actor, "id", None) if actor is not None else None
+        target_name = request.custom_name or option.suggested_name
+
+        # Step 3: bot permission check.
+        bot_ok, bot_msg = self._bot_can_provision(guild, option.kind, request.mode)
+        if not bot_ok:
+            await self._write_audit(
+                mutation_id=mutation_id,
+                guild_id=guild.id,
+                option=option,
+                request=request,
+                outcome="permission_blocked",
+                created=False,
+                resource_id=None,
+                actor_id=actor_id,
+                actor_type=actor_type,
+                error_message=bot_msg,
+            )
+            raise UnauthorizedProvisioningError(bot_msg)
+
+        # Step 6: create or reuse.
+        try:
+            if request.mode == "use_existing":
+                if request.existing_id is None:
+                    await self._write_audit(
+                        mutation_id=mutation_id,
+                        guild_id=guild.id,
+                        option=option,
+                        request=request,
+                        outcome="declined",
+                        created=False,
+                        resource_id=None,
+                        actor_id=actor_id,
+                        actor_type=actor_type,
+                        error_message="missing existing_id",
+                    )
+                    raise UndeclaredResourceError(
+                        "mode='use_existing' requires existing_id",
+                    )
+                resource = self._resolve_existing(
+                    guild,
+                    option.kind,
+                    request.existing_id,
+                )
+                if resource is None:
+                    await self._write_audit(
+                        mutation_id=mutation_id,
+                        guild_id=guild.id,
+                        option=option,
+                        request=request,
+                        outcome="declined",
+                        created=False,
+                        resource_id=request.existing_id,
+                        actor_id=actor_id,
+                        actor_type=actor_type,
+                        error_message="existing_id did not resolve",
+                    )
+                    raise KindMismatchError(
+                        f"existing_id={request.existing_id} did not resolve "
+                        f"to a {option.kind} on guild {guild.id}",
+                    )
+                created = False
+            else:
+                resource = await self._create_resource(
+                    guild,
+                    option.kind,
+                    target_name,
+                    request,
+                )
+                created = True
+        except DiscordProvisioningFailedError as exc:
+            await self._write_audit(
+                mutation_id=mutation_id,
+                guild_id=guild.id,
+                option=option,
+                request=request,
+                outcome="discord_failed",
+                created=False,
+                resource_id=None,
+                actor_id=actor_id,
+                actor_type=actor_type,
+                error_message=str(exc),
+            )
+            raise
+
+        # Step 7: validate created resource (kind match is enforced by
+        # the create helpers; we just confirm an id exists).
+        resource_id = int(getattr(resource, "id", 0)) or None
+        if resource_id is None:
+            await self._write_audit(
+                mutation_id=mutation_id,
+                guild_id=guild.id,
+                option=option,
+                request=request,
+                outcome="discord_failed",
+                created=created,
+                resource_id=None,
+                actor_id=actor_id,
+                actor_type=actor_type,
+                error_message="resource has no .id attribute",
+            )
+            raise DiscordProvisioningFailedError(
+                f"created {option.kind!r} has no .id attribute",
+            )
+
+        # Step 8: bind through BindingMutationPipeline (compose, don't replace).
+        binding_written = False
+        try:
+            await self._bind_resource(
+                guild=guild,
+                option=option,
+                resource_id=resource_id,
+                actor=actor,
+            )
+            binding_written = True
+        except Exception as exc:  # noqa: BLE001 — audit the bind failure
+            audit_id = await self._write_audit(
+                mutation_id=mutation_id,
+                guild_id=guild.id,
+                option=option,
+                request=request,
+                outcome="binding_failed",
+                created=created,
+                resource_id=resource_id,
+                actor_id=actor_id,
+                actor_type=actor_type,
+                error_message=f"{type(exc).__name__}: {exc}",
+            )
+            logger.exception(
+                "ResourceProvisioningPipeline.provision: binding write "
+                "failed for mutation_id=%s after %s (guild=%d, %s/%s, "
+                "resource_id=%d).  Resource is NOT rolled back — operator "
+                "must manually re-bind or clean up.",
+                mutation_id,
+                "create" if created else "reuse",
+                guild.id,
+                request.subsystem,
+                request.binding_name,
+                resource_id,
+            )
+            return ProvisioningResult(
+                mutation_id=mutation_id,
+                guild_id=guild.id,
+                subsystem=request.subsystem,
+                binding_name=request.binding_name,
+                kind=option.kind,
+                mode=request.mode,
+                outcome="binding_failed",
+                created=created,
+                resource_id=resource_id,
+                binding_written=False,
+                audit_id=audit_id,
+                committed_at=_now_utc(),
+                event_emitted=False,
+            )
+
+        # Step 9: audit success.
+        audit_id = await self._write_audit(
+            mutation_id=mutation_id,
+            guild_id=guild.id,
+            option=option,
+            request=request,
+            outcome="success",
+            created=created,
+            resource_id=resource_id,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            error_message=None,
+        )
+
+        committed_at = _now_utc()
+        # Step 10: best-effort event emission.
+        event_emitted = await self._emit_event(
+            mutation_id=mutation_id,
+            guild_id=guild.id,
+            subsystem=request.subsystem,
+            binding_name=request.binding_name,
+            kind=option.kind,
+            mode=request.mode,
+            created=created,
+            resource_id=resource_id,
+            committed_at=committed_at,
+        )
+
+        return ProvisioningResult(
+            mutation_id=mutation_id,
+            guild_id=guild.id,
+            subsystem=request.subsystem,
+            binding_name=request.binding_name,
+            kind=option.kind,
+            mode=request.mode,
+            outcome="success",
+            created=created,
+            resource_id=resource_id,
+            binding_written=binding_written,
+            audit_id=audit_id,
+            committed_at=committed_at,
+            event_emitted=event_emitted,
+        )
+
+    # ------------------------------------------------------------------
+    # Step helpers
+    # ------------------------------------------------------------------
+
+    def _validate_actor_type(self, actor_type: str) -> None:
+        if actor_type not in _ALLOWED_ACTOR_TYPES:
+            raise InvalidActorTypeError(
+                f"actor_type={actor_type!r} not in {sorted(_ALLOWED_ACTOR_TYPES)}",
+            )
+
+    def _validate_mode(self, mode: str) -> None:
+        if mode not in _ALLOWED_MODES:
+            raise UndeclaredResourceError(
+                f"mode={mode!r} not in {sorted(_ALLOWED_MODES)}",
+            )
+
+    def _validate_actor_authority(self, actor: Any, actor_type: str) -> None:
+        """Placeholder administrator-tier floor.
+
+        ``actor_type='system'`` / ``'backfill'`` bypass the check.  All
+        other types require an administrator-tier Discord member.
+        Phase 4.5 swaps this for typed capability resolution against
+        ``BindingSpec.capability_required``.
+        """
+        if actor_type in ("system", "backfill"):
+            return
+        if actor is None or getattr(actor, "guild", None) is None:
+            raise UnauthorizedProvisioningError(
+                "resource provisioning requires a guild-member actor "
+                f"(actor_type={actor_type!r})",
+            )
+        from utils.visibility_rules import (
+            get_member_visibility_tier,
+            is_tier_sufficient,
+        )
+
+        guild_owner_id = actor.guild.owner_id if actor.guild else 0
+        tier = get_member_visibility_tier(actor, guild_owner_id)
+        if not is_tier_sufficient(tier, _WRITE_AUTHORITY_TIER):
+            raise UnauthorizedProvisioningError(
+                f"member {actor.id!r} (tier={tier!r}) requires at least "
+                f"{_WRITE_AUTHORITY_TIER!r} to provision resources",
+            )
+
+    def _bot_can_provision(
+        self,
+        guild: Any,
+        kind: str,
+        mode: str,
+    ) -> tuple[bool, str]:
+        """Check the bot's Discord-side permissions for the requested kind.
+
+        Returns ``(ok, reason)``.  ``reason`` is empty on success.
+        ``mode='use_existing'`` does not need create permissions —
+        only the bind step needs guild visibility, which is implicit
+        in being a guild member.
+        """
+        if mode == "use_existing":
+            return True, ""
+        me = getattr(guild, "me", None)
+        if me is None:
+            return False, "bot has no member representation on this guild"
+        perms = getattr(me, "guild_permissions", None)
+        if perms is None:
+            return False, "bot guild_permissions unavailable"
+        if kind in ("channel", "category", "thread"):
+            if not getattr(perms, "manage_channels", False):
+                return False, f"bot lacks manage_channels for {kind!r} create"
+        elif kind == "role":
+            if not getattr(perms, "manage_roles", False):
+                return False, "bot lacks manage_roles for role create"
+        return True, ""
+
+    def _resolve_existing(self, guild: Any, kind: str, existing_id: int) -> Any:
+        """Re-resolve ``existing_id`` on ``guild`` and verify kind matches."""
+        from core.runtime import guild_resources
+
+        if kind == "channel":
+            ch = guild.get_channel(existing_id)
+            return ch if ch is not None and ch.type.value in (0, 2, 5) else None
+        if kind == "category":
+            return guild_resources.resolve_category(guild, category_id=existing_id)
+        if kind == "role":
+            return guild_resources.resolve_role(guild, role_id=existing_id)
+        if kind == "thread":
+            return (
+                guild.get_thread(existing_id) if hasattr(guild, "get_thread") else None
+            )
+        return None
+
+    def _existing_by_name(self, guild: Any, kind: str, name: str) -> Any:
+        from core.runtime import guild_resources
+
+        if kind == "channel":
+            return guild_resources.resolve_channel(guild, name=name)
+        if kind == "category":
+            return guild_resources.resolve_category(guild, name=name)
+        if kind == "role":
+            return guild_resources.resolve_role(guild, name=name)
+        return None
+
+    async def _create_resource(
+        self,
+        guild: Any,
+        kind: str,
+        target_name: str,
+        request: ProvisioningRequest,
+    ) -> Any:
+        """Dispatch to the appropriate ``ensure_*`` helper."""
+        from core.runtime import guild_resources
+
+        try:
+            if kind == "channel":
+                category = None
+                if request.category_id is not None:
+                    category = guild_resources.resolve_category(
+                        guild,
+                        category_id=request.category_id,
+                    )
+                return await guild_resources.ensure_channel(
+                    guild,
+                    target_name,
+                    category=category,
+                )
+            if kind == "category":
+                return await guild_resources.ensure_category(guild, target_name)
+            if kind == "role":
+                return await guild_resources.ensure_role(guild, target_name)
+        except Exception as exc:
+            raise DiscordProvisioningFailedError(
+                f"Discord API failed creating {kind!r} {target_name!r}: "
+                f"{type(exc).__name__}: {exc}",
+            ) from exc
+        raise DiscordProvisioningFailedError(
+            f"kind={kind!r} is not supported by the create path "
+            "(thread provisioning is reserved for a future PR)",
+        )
+
+    async def _bind_resource(
+        self,
+        *,
+        guild: Any,
+        option: Any,  # services.resource_provisioning_catalogue.ProvisioningOption
+        resource_id: int,
+        actor: Any,
+    ) -> None:
+        """Step 8: hand off to BindingMutationPipeline.set_binding."""
+        from core.runtime.subsystem_schema import BindingKind
+        from services.binding_mutation import BindingMutationPipeline
+
+        kind_enum = BindingKind(option.binding_kind or option.kind)
+        await BindingMutationPipeline().set_binding(
+            guild=guild,
+            subsystem=option.subsystem,
+            binding_name=option.binding_name,
+            kind=kind_enum,
+            target_id=resource_id,
+            actor=actor,
+        )
+
+    async def _write_audit(
+        self,
+        *,
+        mutation_id: str,
+        guild_id: int,
+        option: Any,
+        request: ProvisioningRequest,
+        outcome: _ProvisioningOutcome,
+        created: bool,
+        resource_id: int | None,
+        actor_id: int | None,
+        actor_type: str,
+        error_message: str | None,
+    ) -> int:
+        from utils.db import resource_provisioning_audit as audit_db
+
+        return await audit_db.insert_audit(
+            mutation_id=mutation_id,
+            guild_id=guild_id,
+            subsystem=option.subsystem,
+            binding_name=option.binding_name,
+            kind=option.kind,
+            mode=request.mode,
+            outcome=outcome,
+            created=created,
+            resource_id=resource_id,
+            suggested_name=option.suggested_name or None,
+            custom_name=request.custom_name,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            mutation_type="provision",
+            error_message=error_message,
+        )
+
+    async def _emit_event(
+        self,
+        *,
+        mutation_id: str,
+        guild_id: int,
+        subsystem: str,
+        binding_name: str,
+        kind: str,
+        mode: str,
+        created: bool,
+        resource_id: int,
+        committed_at: datetime,
+    ) -> bool:
+        from core.events import bus
+
+        try:
+            await bus.emit(
+                EVT_RESOURCE_PROVISIONED,
+                mutation_id=mutation_id,
+                guild_id=guild_id,
+                subsystem=subsystem,
+                binding_name=binding_name,
+                kind=kind,
+                mode=mode,
+                created=created,
+                resource_id=resource_id,
+                occurred_at=committed_at.isoformat(),
+            )
+        except Exception:
+            logger.exception(
+                "ResourceProvisioningPipeline._emit_event: emission failed "
+                "for mutation_id=%s; DB state is correct, event lost.",
+                mutation_id,
+            )
+            return False
+        return True
+
+
+def _now_utc() -> datetime:
+    """Return a tz-aware "now" — INV-N forbids bare datetime.utcnow."""
+    return datetime.now(timezone.utc)
+
+
+__all__ = [
+    "EVT_RESOURCE_PROVISIONED",
+    "DiscordProvisioningFailedError",
+    "InvalidActorTypeError",
+    "KindMismatchError",
+    "ProvisioningConfirmationRequired",
+    "ProvisioningPreview",
+    "ProvisioningRequest",
+    "ProvisioningResult",
+    "ResourceProvisioningError",
+    "ResourceProvisioningPipeline",
+    "UnauthorizedProvisioningError",
+    "UndeclaredResourceError",
+]

--- a/disbot/utils/db/resource_provisioning_audit.py
+++ b/disbot/utils/db/resource_provisioning_audit.py
@@ -1,0 +1,157 @@
+"""Resource provisioning audit — DB CRUD primitives (S4.5).
+
+Owns the read/write surface for ``resource_provisioning_audit``
+(migration 030).  Inserts are append-only; the audit row is written
+by :class:`services.resource_provisioning.ResourceProvisioningPipeline`
+after each provisioning attempt — success, decline, or failure.
+
+Unlike :mod:`utils.db.settings_audit`, this module does NOT bundle a
+"write target row + audit row in one transaction" primitive: the
+"target row" for resource provisioning is the ``subsystem_bindings``
+row, which is owned by :class:`services.binding_mutation.BindingMutationPipeline`
+and written through its own atomic primitives.  The provisioning
+pipeline writes the audit row *after* `BindingMutationPipeline.set_binding`
+returns, sharing the same ``mutation_id`` so a join on that column
+reconstructs the full provisioning sequence.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from utils.db import pool
+
+logger = logging.getLogger("bot.db.resource_provisioning_audit")
+
+
+async def insert_audit(
+    *,
+    mutation_id: str,
+    guild_id: int,
+    subsystem: str,
+    binding_name: str,
+    kind: str,
+    mode: str,
+    outcome: str,
+    created: bool,
+    resource_id: int | None,
+    suggested_name: str | None,
+    custom_name: str | None,
+    actor_id: int | None,
+    actor_type: str,
+    mutation_type: str = "provision",
+    error_message: str | None = None,
+) -> int:
+    """Insert a single audit row and return its ``id``.
+
+    Args:
+        mutation_id: Caller-generated UUID for cross-pipeline correlation.
+        guild_id: Discord guild snowflake.
+        subsystem: Owning subsystem name.
+        binding_name: ``BindingSpec.name`` the provisioning targeted.
+        kind: ``ResourceKind`` value (``channel``/``role``/``category``/
+            ``thread``).
+        mode: ``use_existing`` or ``create``.
+        outcome: ``success`` / ``permission_blocked`` / ``discord_failed``
+            / ``binding_failed`` / ``declined``.
+        created: ``True`` iff the pipeline created a new Discord resource.
+        resource_id: Newly created or reused snowflake, ``None`` for
+            ``declined`` / ``permission_blocked`` / ``discord_failed``
+            outcomes that never produced a resource.
+        suggested_name: ``ProvisioningHint.suggested_name`` value
+            (informational; recorded for forensics).
+        custom_name: Operator-supplied override, if any.
+        actor_id: Discord snowflake of the actor; ``None`` for
+            ``actor_type='system'`` writes.
+        actor_type: One of ``user`` / ``moderator`` / ``admin`` /
+            ``system`` / ``backfill``.
+        mutation_type: ``provision`` for v1.
+        error_message: Short description for failure outcomes
+            (``permission_blocked`` / ``discord_failed`` /
+            ``binding_failed``).  ``None`` on ``success`` / ``declined``.
+
+    Returns:
+        The newly-inserted row's ``id`` column (BIGSERIAL).
+    """
+    row = await pool.get().fetchrow(
+        """
+        INSERT INTO resource_provisioning_audit
+            (mutation_id, guild_id, subsystem, binding_name, kind, mode,
+             outcome, created, resource_id, suggested_name, custom_name,
+             actor_id, actor_type, mutation_type, error_message)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11,
+                $12, $13, $14, $15)
+        RETURNING id
+        """,
+        mutation_id,
+        guild_id,
+        subsystem,
+        binding_name,
+        kind,
+        mode,
+        outcome,
+        created,
+        resource_id,
+        suggested_name,
+        custom_name,
+        actor_id,
+        actor_type,
+        mutation_type,
+        error_message,
+    )
+    return int(row["id"])
+
+
+async def count_for_guild(guild_id: int) -> int:
+    """Return the audit row count for ``guild_id``."""
+    row = await pool.get().fetchrow(
+        "SELECT COUNT(*) AS n FROM resource_provisioning_audit WHERE guild_id = $1",
+        guild_id,
+    )
+    return int(row["n"]) if row else 0
+
+
+async def count_by_outcome(guild_id: int) -> dict[str, int]:
+    """Return an ``outcome -> count`` histogram for ``guild_id``."""
+    rows = await pool.get().fetch(
+        """
+        SELECT outcome, COUNT(*)::int AS n
+        FROM resource_provisioning_audit
+        WHERE guild_id = $1
+        GROUP BY outcome
+        """,
+        guild_id,
+    )
+    return {r["outcome"]: int(r["n"]) for r in rows}
+
+
+async def list_recent_for_guild(
+    guild_id: int,
+    *,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """Return up to ``limit`` most recent audit rows for ``guild_id``."""
+    rows = await pool.get().fetch(
+        """
+        SELECT id, mutation_id, guild_id, subsystem, binding_name, kind,
+               mode, outcome, created, resource_id, suggested_name,
+               custom_name, actor_id, actor_type, mutation_type,
+               error_message, at
+        FROM resource_provisioning_audit
+        WHERE guild_id = $1
+        ORDER BY at DESC
+        LIMIT $2
+        """,
+        guild_id,
+        limit,
+    )
+    return [dict(r) for r in rows]
+
+
+__all__ = [
+    "count_by_outcome",
+    "count_for_guild",
+    "insert_audit",
+    "list_recent_for_guild",
+]

--- a/tests/unit/invariants/test_no_silent_auto_create.py
+++ b/tests/unit/invariants/test_no_silent_auto_create.py
@@ -1,0 +1,175 @@
+"""S4.5 invariant — no silent Discord-resource creation outside the pipeline.
+
+The Settings Manager roadmap (S4.5) introduces
+:class:`services.resource_provisioning.ResourceProvisioningPipeline`
+as the canonical creator/binder of Discord resources for subsystem
+use.  Resource creation now has a single owner; new code MUST route
+through the pipeline.
+
+This test scans every ``disbot/**/*.py`` for direct
+``guild.create_*`` calls (``create_text_channel`` /
+``create_voice_channel`` / ``create_category`` /
+``create_category_channel`` / ``create_role``) and ``*.create_thread``
+calls.  Each call must originate from one of:
+
+  * The pipeline's helper layer (:mod:`core.runtime.guild_resources`
+    and the older :mod:`utils.channels`) — pure infrastructure with
+    no policy logic.  The pipeline composes these helpers.
+  * The :class:`core.resources.mutation.ResourceMutationPipeline`
+    stub from Phase 2a (raises NotImplementedError; superseded by
+    the new pipeline but kept on the allowlist until a future
+    cleanup PR removes it).
+  * Explicitly grandfathered legacy paths — cogs and views that
+    today create resources directly.  Each entry is a per-subsystem
+    S10 migration candidate.
+
+Stronger than ``test_no_direct_settings_keys_writes.py``: this scan
+catches **every** Discord-resource-creating call shape, not just
+calls through one named primitive.  A new caller wanting to create
+a channel/role/category outside the pipeline must either:
+
+  * Route through ``ResourceProvisioningPipeline.provision(...)``
+    (preferred); or
+  * Add itself to ``_ALLOWED_PATHS`` with a comment explaining why
+    the bypass is correct (e.g. it is a UI CRUD command that the
+    pipeline will later compose).
+
+The accompanying test pins the pipeline service itself to NOT
+contain any ``guild.create_*`` call directly — it must go through
+the ``ensure_*`` helpers in ``guild_resources``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DISBOT = _REPO_ROOT / "disbot"
+
+# Discord-API methods that create resources we care about.
+_FORBIDDEN_CREATE_METHODS: frozenset[str] = frozenset(
+    {
+        "create_text_channel",
+        "create_voice_channel",
+        "create_category",
+        "create_category_channel",
+        "create_role",
+        "create_thread",
+        # ``create_stage_channel``, ``create_forum``, etc. are not in
+        # scope for v1; future PRs adding stages/forums must extend
+        # this set and update the allowlist.
+    },
+)
+
+# Files ALLOWED to call any of the forbidden create methods directly.
+# Adding to this list weakens the invariant; do not extend without
+# pairing the entry with a comment naming the future migration PR.
+_ALLOWED_PATHS = {
+    # Pipeline's helper layer — pure infrastructure, called by the
+    # pipeline.  The real safety boundary is the pipeline's 11-step
+    # contract, not these helpers.
+    _DISBOT / "core" / "runtime" / "guild_resources.py",
+    _DISBOT / "utils" / "channels.py",
+    # Phase 2a stub — raises NotImplementedError; superseded by S4.5.
+    # Future cleanup PR may remove this file.
+    _DISBOT / "core" / "resources" / "mutation.py",
+    # Grandfathered legacy paths — UI CRUD and admin commands.
+    # Each migrates to ResourceProvisioningPipeline in a per-subsystem
+    # S10 sub-PR.
+    _DISBOT / "views" / "channels" / "create_panel.py",
+    _DISBOT / "views" / "roles" / "creation_panel.py",
+    _DISBOT / "cogs" / "channel_cog.py",
+    _DISBOT / "cogs" / "role_cog.py",
+    _DISBOT / "cogs" / "counting_cog.py",  # auto-create counting channel
+    _DISBOT / "cogs" / "economy_cog.py",  # auto-create economy log channel
+}
+
+
+def _iter_production_py_files() -> list[Path]:
+    return [p for p in _DISBOT.rglob("*.py") if "__pycache__" not in p.parts]
+
+
+def _create_call_targets(tree: ast.AST) -> list[str]:
+    """Return ``"<receiver>.<method>"`` for any forbidden create call."""
+    found: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr not in _FORBIDDEN_CREATE_METHODS:
+            continue
+        rcv = node.func.value
+        parts: list[str] = []
+        while isinstance(rcv, ast.Attribute):
+            parts.append(rcv.attr)
+            rcv = rcv.value
+        if isinstance(rcv, ast.Name):
+            parts.append(rcv.id)
+        receiver = ".".join(reversed(parts)) if parts else "<expr>"
+        found.append(f"{receiver}.{node.func.attr}")
+    return found
+
+
+def test_no_direct_create_calls_outside_allowlist():
+    """No production file outside the allowlist may call
+    ``guild.create_*`` (or any of the forbidden methods) directly.
+    """
+    violations: list[tuple[str, list[str]]] = []
+    for path in _iter_production_py_files():
+        if path in _ALLOWED_PATHS:
+            continue
+        tree = ast.parse(path.read_text(), filename=str(path))
+        offenders = _create_call_targets(tree)
+        if offenders:
+            violations.append((str(path.relative_to(_REPO_ROOT)), offenders))
+    assert not violations, (
+        "S4.5 invariant violation: direct guild.create_* (or *.create_thread) "
+        "outside the ResourceProvisioningPipeline allowlist.\n"
+        "Route new resource creation through "
+        "services.resource_provisioning.ResourceProvisioningPipeline.provision(...) "
+        "or extend the allowlist with a justification.\n\n"
+        + "\n".join(f"  {p}: {calls}" for p, calls in violations)
+    )
+
+
+def test_allowlist_entries_exist():
+    """Every allowlisted file must still exist on disk."""
+    missing = [str(p.relative_to(_REPO_ROOT)) for p in _ALLOWED_PATHS if not p.exists()]
+    assert (
+        not missing
+    ), "S4.5 allowlist references files that no longer exist:\n" + "\n".join(
+        f"  {p}" for p in missing
+    )
+
+
+def test_pipeline_does_not_call_create_directly():
+    """The pipeline service itself must NOT contain raw ``guild.create_*``
+    calls — every resource creation must compose the ``ensure_*``
+    helpers in :mod:`core.runtime.guild_resources`.
+
+    This is the architectural boundary the directive demanded:
+    ``ensure_*`` are policy-free infrastructure, the pipeline owns the
+    policy (preview, permission, confirmation, audit, binding, event).
+    """
+    pipeline_path = _DISBOT / "services" / "resource_provisioning.py"
+    tree = ast.parse(pipeline_path.read_text())
+    offenders = _create_call_targets(tree)
+    assert not offenders, (
+        "services.resource_provisioning must not call guild.create_* "
+        "directly — compose the ensure_* helpers in "
+        "core.runtime.guild_resources instead.  Offenders:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_create_method_set_is_documented():
+    """Sanity: the set of methods we forbid must be non-empty and lower-cased.
+
+    Catches a future drive-by edit that empties the set or types one
+    method name wrong.
+    """
+    assert _FORBIDDEN_CREATE_METHODS, "the forbidden-method set must be non-empty"
+    for m in _FORBIDDEN_CREATE_METHODS:
+        assert m.startswith(
+            "create_"
+        ), f"method name does not start with create_: {m!r}"
+        assert m == m.lower(), f"method name is not lowercase: {m!r}"

--- a/tests/unit/invariants/test_resource_provisioning_audit_alignment.py
+++ b/tests/unit/invariants/test_resource_provisioning_audit_alignment.py
@@ -1,0 +1,141 @@
+"""S4.5 invariant — resource_provisioning_audit CHECK literals align with Python.
+
+Migration 030 ships CHECK constraints on
+``resource_provisioning_audit``:
+
+* ``mutation_type``  — pipeline entrypoint name(s)
+* ``kind``           — ResourceKind value
+* ``mode``           — use_existing | create
+* ``outcome``        — success | permission_blocked | discord_failed
+                       | binding_failed | declined
+* ``actor_type``     — actor model
+
+The Python pipeline carries matching ``frozenset``s in
+:mod:`services.resource_provisioning`.  This test pins both sides so
+a drift on either fails CI before the next migration ships.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_MIGRATION = (
+    Path(__file__).resolve().parents[3]
+    / "disbot"
+    / "migrations"
+    / "030_resource_provisioning_audit.sql"
+)
+
+
+def _read() -> str:
+    return _MIGRATION.read_text()
+
+
+def _extract_in_set(column: str) -> set[str]:
+    sql = _read()
+    pattern = rf"CHECK\s*\(\s*{column}\s+IN\s*\(([^)]+)\)\s*\)"
+    match = re.search(pattern, sql)
+    assert match, f"could not locate {column} CHECK constraint in migration 030"
+    return {
+        tok.strip().strip("'\"") for tok in match.group(1).split(",") if tok.strip()
+    }
+
+
+def test_mutation_type_literals_match_pipeline():
+    from services.resource_provisioning import _ALLOWED_MUTATION_TYPES
+
+    db_check = _extract_in_set("mutation_type")
+    python = set(_ALLOWED_MUTATION_TYPES)
+    assert db_check == python, (
+        "mutation_type drift:\n"
+        f"  in Python but not DB CHECK: {sorted(python - db_check)}\n"
+        f"  in DB CHECK but not Python: {sorted(db_check - python)}"
+    )
+
+
+def test_kind_literals_match_pipeline():
+    from services.resource_provisioning import _ALLOWED_KINDS
+
+    db_check = _extract_in_set("kind")
+    python = set(_ALLOWED_KINDS)
+    assert db_check == python, (
+        "kind drift:\n"
+        f"  in Python but not DB CHECK: {sorted(python - db_check)}\n"
+        f"  in DB CHECK but not Python: {sorted(db_check - python)}"
+    )
+
+
+def test_mode_literals_match_pipeline():
+    from services.resource_provisioning import _ALLOWED_MODES
+
+    db_check = _extract_in_set("mode")
+    python = set(_ALLOWED_MODES)
+    assert db_check == python, (
+        "mode drift:\n"
+        f"  in Python but not DB CHECK: {sorted(python - db_check)}\n"
+        f"  in DB CHECK but not Python: {sorted(db_check - python)}"
+    )
+
+
+def test_outcome_literals_match_pipeline():
+    from services.resource_provisioning import _ALLOWED_OUTCOMES
+
+    db_check = _extract_in_set("outcome")
+    python = set(_ALLOWED_OUTCOMES)
+    assert db_check == python, (
+        "outcome drift:\n"
+        f"  in Python but not DB CHECK: {sorted(python - db_check)}\n"
+        f"  in DB CHECK but not Python: {sorted(db_check - python)}"
+    )
+
+
+def test_actor_type_literals_match_pipeline():
+    from services.resource_provisioning import _ALLOWED_ACTOR_TYPES
+
+    db_check = _extract_in_set("actor_type")
+    python = set(_ALLOWED_ACTOR_TYPES)
+    assert db_check == python, (
+        "actor_type drift:\n"
+        f"  in Python but not DB CHECK: {sorted(python - db_check)}\n"
+        f"  in DB CHECK but not Python: {sorted(db_check - python)}"
+    )
+
+
+def test_migration_file_exists():
+    assert _MIGRATION.exists(), f"migration file missing: {_MIGRATION}"
+
+
+def _strip_sql_comments(sql: str) -> str:
+    """Drop ``--`` line comments before scanning for forbidden statements."""
+    out_lines: list[str] = []
+    for line in sql.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("--"):
+            continue
+        if "--" in line:
+            line = line.split("--", 1)[0]
+        out_lines.append(line)
+    return "\n".join(out_lines)
+
+
+def test_migration_is_forward_only_and_idempotent():
+    """Forward-only excludes DROP / DELETE / TRUNCATE / ALTER on
+    existing tables.  Idempotency via ``CREATE … IF NOT EXISTS``.
+    SQL ``--`` comments are stripped so the rollback note describing
+    ``-- Rollback: DROP TABLE ...`` does not trip the check.
+    """
+    sql = _strip_sql_comments(_read()).upper()
+    forbidden = (
+        "DROP ",
+        "TRUNCATE ",
+        "DELETE FROM ",
+        "ALTER TABLE SUBSYSTEM_BINDINGS",
+        "ALTER TABLE GUILD_SETTINGS",
+    )
+    for needle in forbidden:
+        assert (
+            needle not in sql
+        ), f"migration 030 contains forbidden destructive statement: {needle!r}"
+    assert "CREATE TABLE IF NOT EXISTS" in sql
+    assert "CREATE INDEX IF NOT EXISTS" in sql

--- a/tests/unit/services/test_resource_provisioning_pipeline.py
+++ b/tests/unit/services/test_resource_provisioning_pipeline.py
@@ -1,0 +1,1065 @@
+"""Unit tests for services.resource_provisioning — S4.5.
+
+Covers the 11-step pipeline contract: catalogue resolution, actor /
+authority validation, bot-permission check, preview (no side
+effects), confirmation gating, use_existing happy path, create happy
+path, kind mismatch, Discord-API failure, binding failure (resource
+NOT rolled back), audit row contents, best-effort event emission,
+typed result.
+
+Every DB / Discord / event-bus boundary is monkeypatched so the
+tests never touch a real database, Discord guild, or asyncio loop
+outside the pipeline itself.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from core.runtime import subsystem_schema as schema_mod
+from core.runtime.resource_specs import (
+    ProvisioningHint,
+    ProvisioningPriority,
+    ResourceKind,
+    ResourceRequirement,
+)
+from core.runtime.subsystem_schema import (
+    BindingKind,
+    BindingSpec,
+    SubsystemSchema,
+)
+from services import binding_mutation as bm_mod
+from services import resource_provisioning as rp_mod
+from services import resource_provisioning_catalogue as rpc_mod
+from services.resource_provisioning import (
+    DiscordProvisioningFailedError,
+    InvalidActorTypeError,
+    KindMismatchError,
+    ProvisioningConfirmationRequired,
+    ProvisioningPreview,
+    ProvisioningRequest,
+    ProvisioningResult,
+    ResourceProvisioningPipeline,
+    UnauthorizedProvisioningError,
+    UndeclaredResourceError,
+)
+from utils.db import resource_provisioning_audit as audit_db
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakePermissions:
+    administrator: bool = True
+    manage_channels: bool = True
+    manage_roles: bool = True
+    manage_guild: bool = True
+    moderate_members: bool = False
+
+
+@dataclass
+class _FakeMe:
+    guild_permissions: _FakePermissions
+
+
+class _FakeRole:
+    def __init__(self, role_id: int, name: str):
+        self.id = role_id
+        self.name = name
+
+
+class _FakeChannel:
+    """Minimal channel stub. ``type.value`` 0/2/5 indicate channel
+    (text/voice/announcement) and 4 indicates category.
+    """
+
+    def __init__(self, channel_id: int, name: str, kind: str = "text"):
+        self.id = channel_id
+        self.name = name
+        type_value = {"text": 0, "voice": 2, "announcement": 5, "category": 4}[kind]
+        self.type = type("T", (), {"value": type_value})()
+        self.category_id = None
+
+    async def create(self):  # pragma: no cover — never used in tests
+        return self
+
+
+class _FakeCategory:
+    def __init__(self, channel_id: int, name: str):
+        self.id = channel_id
+        self.name = name
+
+
+class _FakeGuild:
+    def __init__(
+        self,
+        guild_id: int,
+        *,
+        owner_id: int = 0,
+        channels: list | None = None,
+        roles: list | None = None,
+        categories: list | None = None,
+        permissions: _FakePermissions | None = None,
+        create_raises: BaseException | None = None,
+    ):
+        self.id = guild_id
+        self.owner_id = owner_id
+        self.channels = list(channels or [])
+        self.roles = list(roles or [])
+        self.categories = list(categories or [])
+        self.text_channels = [c for c in self.channels if c.type.value == 0]
+        self.voice_channels = [c for c in self.channels if c.type.value == 2]
+        self.me = _FakeMe(guild_permissions=permissions or _FakePermissions())
+        self._next_id = 1_000_000
+        self._create_raises = create_raises
+
+    def get_channel(self, channel_id: int):
+        for ch in self.channels:
+            if ch.id == channel_id:
+                return ch
+        for ch in self.categories:
+            if ch.id == channel_id:
+                return ch
+        return None
+
+    def get_role(self, role_id: int):
+        for r in self.roles:
+            if r.id == role_id:
+                return r
+        return None
+
+    async def create_text_channel(self, name, **_kwargs):
+        if self._create_raises is not None:
+            raise self._create_raises
+        self._next_id += 1
+        ch = _FakeChannel(self._next_id, name, kind="text")
+        self.channels.append(ch)
+        self.text_channels.append(ch)
+        return ch
+
+    async def create_voice_channel(self, name, **_kwargs):
+        if self._create_raises is not None:
+            raise self._create_raises
+        self._next_id += 1
+        ch = _FakeChannel(self._next_id, name, kind="voice")
+        self.channels.append(ch)
+        self.voice_channels.append(ch)
+        return ch
+
+    async def create_category(self, name, **_kwargs):
+        if self._create_raises is not None:
+            raise self._create_raises
+        self._next_id += 1
+        cat = _FakeCategory(self._next_id, name)
+        self.categories.append(cat)
+        return cat
+
+    async def create_role(self, **kwargs):
+        if self._create_raises is not None:
+            raise self._create_raises
+        self._next_id += 1
+        role = _FakeRole(self._next_id, kwargs["name"])
+        self.roles.append(role)
+        return role
+
+
+class _FakeMember:
+    def __init__(self, member_id: int, *, guild: _FakeGuild, admin: bool = True):
+        self.id = member_id
+        self.guild = guild
+        self.guild_permissions = _FakePermissions(administrator=admin)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(monkeypatch):
+    saved_schemas = schema_mod.all_schemas()
+    schema_mod._reset_for_tests()
+    rpc_mod._reset_for_tests()
+
+    audit_rows: list[dict] = []
+
+    async def _fake_insert_audit(**kwargs):
+        kwargs["id"] = len(audit_rows) + 1
+        audit_rows.append(kwargs)
+        return kwargs["id"]
+
+    monkeypatch.setattr(audit_db, "insert_audit", _fake_insert_audit)
+
+    binding_calls: list[dict] = []
+    binding_raises: dict[str, BaseException | None] = {"exc": None}
+
+    async def _fake_set_binding(
+        self,
+        guild,
+        subsystem,
+        binding_name,
+        kind,
+        target_id,
+        actor,
+    ):
+        binding_calls.append(
+            {
+                "guild_id": guild.id,
+                "subsystem": subsystem,
+                "binding_name": binding_name,
+                "kind": kind,
+                "target_id": target_id,
+                "actor_id": getattr(actor, "id", None),
+            },
+        )
+        if binding_raises["exc"] is not None:
+            raise binding_raises["exc"]
+        return None
+
+    monkeypatch.setattr(
+        bm_mod.BindingMutationPipeline,
+        "set_binding",
+        _fake_set_binding,
+    )
+
+    emitted: list[dict] = []
+    bus_raises: dict[str, bool] = {"flag": False}
+
+    async def _fake_emit(event: str, /, **payload):
+        if bus_raises["flag"]:
+            raise RuntimeError("simulated bus failure")
+        emitted.append({"event": event, **payload})
+
+    from core.events import bus
+
+    monkeypatch.setattr(bus, "emit", _fake_emit)
+
+    yield {
+        "audit_rows": audit_rows,
+        "binding_calls": binding_calls,
+        "binding_raises": binding_raises,
+        "emitted": emitted,
+        "bus_raises": bus_raises,
+    }
+
+    schema_mod._reset_for_tests()
+    for schema in saved_schemas.values():
+        schema_mod.register(schema)
+    rpc_mod._reset_for_tests()
+
+
+def _register_logging_with_mod_channel():
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="logging",
+            bindings=(
+                BindingSpec(
+                    name="mod_channel",
+                    kind=BindingKind.CHANNEL,
+                    required=False,
+                    hint="The mod log channel.",
+                    capability_required="logging.settings.configure",
+                ),
+            ),
+            resource_requirements=(
+                ResourceRequirement(
+                    kind=ResourceKind.CHANNEL,
+                    intent="mod_log",
+                    provisioning=ProvisioningHint(
+                        priority=ProvisioningPriority.RECOMMENDED,
+                        suggested_name="mod-logs",
+                        suggested_category="Staff",
+                    ),
+                    binding_name="mod_channel",
+                ),
+            ),
+        ),
+    )
+    rpc_mod.build_provisioning_catalogue()
+
+
+def _register_proof_role():
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="proof_channel",
+            bindings=(
+                BindingSpec(
+                    name="approval_role",
+                    kind=BindingKind.ROLE,
+                    required=False,
+                    hint="Approval role for prize claims.",
+                    capability_required="proof_channel.access.grant",
+                ),
+            ),
+            resource_requirements=(
+                ResourceRequirement(
+                    kind=ResourceKind.ROLE,
+                    intent="approval_role",
+                    provisioning=ProvisioningHint(
+                        priority=ProvisioningPriority.OPTIONAL,
+                        suggested_name="prize-approver",
+                    ),
+                    binding_name="approval_role",
+                ),
+            ),
+        ),
+    )
+    rpc_mod.build_provisioning_catalogue()
+
+
+# ---------------------------------------------------------------------------
+# Catalogue resolution + early validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_undeclared_resource_when_catalogue_not_built():
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    request = ProvisioningRequest(
+        subsystem="logging",
+        binding_name="mod_channel",
+        mode="create",
+    )
+    pipeline = ResourceProvisioningPipeline()
+    with pytest.raises(UndeclaredResourceError):
+        await pipeline.provision(guild, request, actor, confirmed=True)
+
+
+@pytest.mark.asyncio
+async def test_undeclared_resource_when_pair_not_in_catalogue():
+    _register_logging_with_mod_channel()
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    request = ProvisioningRequest(
+        subsystem="logging",
+        binding_name="no_such_binding",
+        mode="create",
+    )
+    pipeline = ResourceProvisioningPipeline()
+    with pytest.raises(UndeclaredResourceError):
+        await pipeline.provision(guild, request, actor, confirmed=True)
+
+
+@pytest.mark.asyncio
+async def test_invalid_actor_type_raises():
+    _register_logging_with_mod_channel()
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    request = ProvisioningRequest(
+        subsystem="logging",
+        binding_name="mod_channel",
+        mode="create",
+    )
+    pipeline = ResourceProvisioningPipeline()
+    with pytest.raises(InvalidActorTypeError):
+        await pipeline.provision(
+            guild,
+            request,
+            actor,
+            confirmed=True,
+            actor_type="god_mode",
+        )
+
+
+@pytest.mark.asyncio
+async def test_invalid_mode_raises():
+    _register_logging_with_mod_channel()
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    request = ProvisioningRequest(
+        subsystem="logging",
+        binding_name="mod_channel",
+        mode="invalid",  # type: ignore[arg-type]
+    )
+    pipeline = ResourceProvisioningPipeline()
+    with pytest.raises(UndeclaredResourceError):
+        await pipeline.provision(guild, request, actor, confirmed=True)
+
+
+# ---------------------------------------------------------------------------
+# Authority validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_when_actor_below_admin():
+    _register_logging_with_mod_channel()
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild, admin=False)
+    request = ProvisioningRequest(
+        subsystem="logging",
+        binding_name="mod_channel",
+        mode="create",
+    )
+    pipeline = ResourceProvisioningPipeline()
+    with pytest.raises(UnauthorizedProvisioningError):
+        await pipeline.provision(guild, request, actor, confirmed=True)
+
+
+@pytest.mark.asyncio
+async def test_system_actor_bypasses_authority():
+    _register_logging_with_mod_channel()
+    guild = _FakeGuild(1)
+    request = ProvisioningRequest(
+        subsystem="logging",
+        binding_name="mod_channel",
+        mode="create",
+        custom_name="mod-logs",
+    )
+    pipeline = ResourceProvisioningPipeline()
+    result = await pipeline.provision(
+        guild,
+        request,
+        None,
+        confirmed=True,
+        actor_type="system",
+    )
+    assert result.outcome == "success"
+
+
+# ---------------------------------------------------------------------------
+# Bot-permission check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bot_lacking_manage_channels_blocks_create(_isolated_state):
+    _register_logging_with_mod_channel()
+    guild = _FakeGuild(
+        1,
+        permissions=_FakePermissions(manage_channels=False),
+    )
+    actor = _FakeMember(7, guild=guild)
+    request = ProvisioningRequest(
+        subsystem="logging",
+        binding_name="mod_channel",
+        mode="create",
+        custom_name="mod-logs",
+    )
+    pipeline = ResourceProvisioningPipeline()
+    with pytest.raises(UnauthorizedProvisioningError):
+        await pipeline.provision(guild, request, actor, confirmed=True)
+    # Audit row written with permission_blocked.
+    assert any(
+        r["outcome"] == "permission_blocked" for r in _isolated_state["audit_rows"]
+    )
+    # No binding write attempted.
+    assert _isolated_state["binding_calls"] == []
+
+
+@pytest.mark.asyncio
+async def test_bot_lacking_manage_roles_blocks_role_create(_isolated_state):
+    _register_proof_role()
+    guild = _FakeGuild(
+        1,
+        permissions=_FakePermissions(manage_roles=False),
+    )
+    actor = _FakeMember(7, guild=guild)
+    request = ProvisioningRequest(
+        subsystem="proof_channel",
+        binding_name="approval_role",
+        mode="create",
+    )
+    pipeline = ResourceProvisioningPipeline()
+    with pytest.raises(UnauthorizedProvisioningError):
+        await pipeline.provision(guild, request, actor, confirmed=True)
+    assert any(
+        r["outcome"] == "permission_blocked" for r in _isolated_state["audit_rows"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Confirmation gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_without_confirmed_raises():
+    _register_logging_with_mod_channel()
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    request = ProvisioningRequest(
+        subsystem="logging",
+        binding_name="mod_channel",
+        mode="create",
+    )
+    pipeline = ResourceProvisioningPipeline()
+    with pytest.raises(ProvisioningConfirmationRequired):
+        await pipeline.provision(guild, request, actor, confirmed=False)
+
+
+@pytest.mark.asyncio
+async def test_use_existing_does_not_require_confirmation():
+    _register_logging_with_mod_channel()
+    existing_channel = _FakeChannel(999, "mod-logs", kind="text")
+    guild = _FakeGuild(1, channels=[existing_channel])
+    actor = _FakeMember(7, guild=guild)
+    request = ProvisioningRequest(
+        subsystem="logging",
+        binding_name="mod_channel",
+        mode="use_existing",
+        existing_id=999,
+    )
+    pipeline = ResourceProvisioningPipeline()
+    result = await pipeline.provision(guild, request, actor, confirmed=False)
+    assert result.outcome == "success"
+
+
+# ---------------------------------------------------------------------------
+# preview()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_create_happy_path():
+    _register_logging_with_mod_channel()
+    guild = _FakeGuild(1)
+    pipeline = ResourceProvisioningPipeline()
+    preview = await pipeline.preview(
+        guild,
+        ProvisioningRequest(
+            subsystem="logging",
+            binding_name="mod_channel",
+            mode="create",
+            custom_name="mod-logs",
+        ),
+    )
+    assert isinstance(preview, ProvisioningPreview)
+    assert preview.allowed is True
+    assert preview.action == "create_new"
+    assert preview.target_name == "mod-logs"
+
+
+@pytest.mark.asyncio
+async def test_preview_returns_warning_when_resource_with_name_exists():
+    _register_logging_with_mod_channel()
+    existing = _FakeChannel(42, "mod-logs", kind="text")
+    guild = _FakeGuild(1, channels=[existing])
+    pipeline = ResourceProvisioningPipeline()
+    preview = await pipeline.preview(
+        guild,
+        ProvisioningRequest(
+            subsystem="logging",
+            binding_name="mod_channel",
+            mode="create",
+            custom_name="mod-logs",
+        ),
+    )
+    assert preview.allowed is True
+    assert any("already exists" in w for w in preview.warnings)
+
+
+@pytest.mark.asyncio
+async def test_preview_blocks_when_catalogue_not_built():
+    guild = _FakeGuild(1)
+    pipeline = ResourceProvisioningPipeline()
+    preview = await pipeline.preview(
+        guild,
+        ProvisioningRequest(
+            subsystem="logging",
+            binding_name="mod_channel",
+            mode="create",
+        ),
+    )
+    assert preview.allowed is False
+    assert preview.action == "blocked"
+
+
+@pytest.mark.asyncio
+async def test_preview_blocks_when_bot_lacks_permission():
+    _register_logging_with_mod_channel()
+    guild = _FakeGuild(
+        1,
+        permissions=_FakePermissions(manage_channels=False),
+    )
+    pipeline = ResourceProvisioningPipeline()
+    preview = await pipeline.preview(
+        guild,
+        ProvisioningRequest(
+            subsystem="logging",
+            binding_name="mod_channel",
+            mode="create",
+            custom_name="mod-logs",
+        ),
+    )
+    assert preview.allowed is False
+    assert preview.action == "blocked"
+    assert any("manage_channels" in w for w in preview.warnings)
+
+
+@pytest.mark.asyncio
+async def test_preview_use_existing_resolves_kind():
+    _register_logging_with_mod_channel()
+    existing = _FakeChannel(123, "old-channel", kind="text")
+    guild = _FakeGuild(1, channels=[existing])
+    pipeline = ResourceProvisioningPipeline()
+    preview = await pipeline.preview(
+        guild,
+        ProvisioningRequest(
+            subsystem="logging",
+            binding_name="mod_channel",
+            mode="use_existing",
+            existing_id=123,
+        ),
+    )
+    assert preview.allowed is True
+    assert preview.action == "reuse_existing"
+    assert preview.target_name == "old-channel"
+
+
+@pytest.mark.asyncio
+async def test_preview_use_existing_with_unknown_id_blocks():
+    _register_logging_with_mod_channel()
+    guild = _FakeGuild(1)
+    pipeline = ResourceProvisioningPipeline()
+    preview = await pipeline.preview(
+        guild,
+        ProvisioningRequest(
+            subsystem="logging",
+            binding_name="mod_channel",
+            mode="use_existing",
+            existing_id=999,
+        ),
+    )
+    assert preview.allowed is False
+    assert preview.action == "blocked"
+
+
+# ---------------------------------------------------------------------------
+# provision() — create happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_channel_happy_path(_isolated_state):
+    _register_logging_with_mod_channel()
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = ResourceProvisioningPipeline()
+    result = await pipeline.provision(
+        guild,
+        ProvisioningRequest(
+            subsystem="logging",
+            binding_name="mod_channel",
+            mode="create",
+            custom_name="mod-logs",
+        ),
+        actor,
+        confirmed=True,
+    )
+    assert isinstance(result, ProvisioningResult)
+    assert result.outcome == "success"
+    assert result.created is True
+    assert result.binding_written is True
+    assert result.event_emitted is True
+    assert result.resource_id is not None
+    # Audit row recorded the success.
+    assert _isolated_state["audit_rows"][-1]["outcome"] == "success"
+    # Binding pipeline was called with the new channel id.
+    assert _isolated_state["binding_calls"][-1]["target_id"] == result.resource_id
+    # Channel actually exists on the fake guild.
+    assert any(ch.name == "mod-logs" for ch in guild.text_channels)
+
+
+@pytest.mark.asyncio
+async def test_create_role_happy_path(_isolated_state):
+    _register_proof_role()
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = ResourceProvisioningPipeline()
+    result = await pipeline.provision(
+        guild,
+        ProvisioningRequest(
+            subsystem="proof_channel",
+            binding_name="approval_role",
+            mode="create",
+        ),
+        actor,
+        confirmed=True,
+    )
+    assert result.outcome == "success"
+    assert result.created is True
+    assert any(r.name == "prize-approver" for r in guild.roles)
+    assert _isolated_state["binding_calls"][-1]["kind"] == BindingKind.ROLE
+
+
+@pytest.mark.asyncio
+async def test_create_category_happy_path(_isolated_state):
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="cleanup",
+            bindings=(
+                BindingSpec(
+                    name="staff_category",
+                    kind=BindingKind.CATEGORY,
+                    required=False,
+                    hint="Staff-only category for cleanup tools.",
+                    capability_required="cleanup.policy.configure",
+                ),
+            ),
+            resource_requirements=(
+                ResourceRequirement(
+                    kind=ResourceKind.CATEGORY,
+                    intent="staff_category",
+                    provisioning=ProvisioningHint(
+                        priority=ProvisioningPriority.RECOMMENDED,
+                        suggested_name="Staff",
+                    ),
+                    binding_name="staff_category",
+                ),
+            ),
+        ),
+    )
+    rpc_mod.build_provisioning_catalogue()
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = ResourceProvisioningPipeline()
+    result = await pipeline.provision(
+        guild,
+        ProvisioningRequest(
+            subsystem="cleanup",
+            binding_name="staff_category",
+            mode="create",
+        ),
+        actor,
+        confirmed=True,
+    )
+    assert result.outcome == "success"
+    assert any(c.name == "Staff" for c in guild.categories)
+
+
+# ---------------------------------------------------------------------------
+# provision() — use_existing happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_use_existing_happy_path(_isolated_state):
+    _register_logging_with_mod_channel()
+    existing = _FakeChannel(123, "pre-existing-logs", kind="text")
+    guild = _FakeGuild(1, channels=[existing])
+    actor = _FakeMember(7, guild=guild)
+    pipeline = ResourceProvisioningPipeline()
+    result = await pipeline.provision(
+        guild,
+        ProvisioningRequest(
+            subsystem="logging",
+            binding_name="mod_channel",
+            mode="use_existing",
+            existing_id=123,
+        ),
+        actor,
+    )
+    assert result.outcome == "success"
+    assert result.created is False
+    assert result.resource_id == 123
+    # No new channel created on the fake guild.
+    assert len(guild.text_channels) == 1
+
+
+@pytest.mark.asyncio
+async def test_use_existing_missing_id_declines(_isolated_state):
+    _register_logging_with_mod_channel()
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = ResourceProvisioningPipeline()
+    request = ProvisioningRequest(
+        subsystem="logging",
+        binding_name="mod_channel",
+        mode="use_existing",
+        existing_id=None,
+    )
+    with pytest.raises(UndeclaredResourceError):
+        await pipeline.provision(guild, request, actor)
+    assert _isolated_state["audit_rows"][-1]["outcome"] == "declined"
+
+
+@pytest.mark.asyncio
+async def test_use_existing_unknown_id_declines(_isolated_state):
+    _register_logging_with_mod_channel()
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = ResourceProvisioningPipeline()
+    with pytest.raises(KindMismatchError):
+        await pipeline.provision(
+            guild,
+            ProvisioningRequest(
+                subsystem="logging",
+                binding_name="mod_channel",
+                mode="use_existing",
+                existing_id=99999,
+            ),
+            actor,
+        )
+    assert _isolated_state["audit_rows"][-1]["outcome"] == "declined"
+
+
+# ---------------------------------------------------------------------------
+# Discord-API failure → discord_failed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_discord_create_failure_audits_discord_failed(_isolated_state):
+    _register_logging_with_mod_channel()
+    guild = _FakeGuild(1, create_raises=RuntimeError("API outage"))
+    actor = _FakeMember(7, guild=guild)
+    pipeline = ResourceProvisioningPipeline()
+    with pytest.raises(DiscordProvisioningFailedError):
+        await pipeline.provision(
+            guild,
+            ProvisioningRequest(
+                subsystem="logging",
+                binding_name="mod_channel",
+                mode="create",
+                custom_name="mod-logs",
+            ),
+            actor,
+            confirmed=True,
+        )
+    assert _isolated_state["audit_rows"][-1]["outcome"] == "discord_failed"
+    # No binding write attempted.
+    assert _isolated_state["binding_calls"] == []
+
+
+# ---------------------------------------------------------------------------
+# Binding failure → binding_failed; resource NOT rolled back
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_binding_failure_does_not_roll_back_resource(_isolated_state):
+    _register_logging_with_mod_channel()
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    _isolated_state["binding_raises"]["exc"] = RuntimeError("bind DB down")
+    pipeline = ResourceProvisioningPipeline()
+    # The pipeline returns ProvisioningResult with outcome="binding_failed"
+    # rather than raising — the resource has been created and the
+    # operator may want to keep it.
+    result = await pipeline.provision(
+        guild,
+        ProvisioningRequest(
+            subsystem="logging",
+            binding_name="mod_channel",
+            mode="create",
+            custom_name="mod-logs",
+        ),
+        actor,
+        confirmed=True,
+    )
+    assert result.outcome == "binding_failed"
+    assert result.created is True
+    assert result.binding_written is False
+    assert result.event_emitted is False
+    # Channel still exists on the guild — no rollback.
+    assert any(ch.name == "mod-logs" for ch in guild.text_channels)
+    # Audit row captured the failure.
+    assert _isolated_state["audit_rows"][-1]["outcome"] == "binding_failed"
+    assert _isolated_state["audit_rows"][-1]["resource_id"] == result.resource_id
+
+
+# ---------------------------------------------------------------------------
+# Event emission
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_event_emitted_on_success(_isolated_state):
+    _register_logging_with_mod_channel()
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = ResourceProvisioningPipeline()
+    result = await pipeline.provision(
+        guild,
+        ProvisioningRequest(
+            subsystem="logging",
+            binding_name="mod_channel",
+            mode="create",
+            custom_name="mod-logs",
+        ),
+        actor,
+        confirmed=True,
+    )
+    assert len(_isolated_state["emitted"]) == 1
+    payload = _isolated_state["emitted"][0]
+    assert payload["event"] == "resource.provisioned"
+    assert payload["guild_id"] == 1
+    assert payload["subsystem"] == "logging"
+    assert payload["binding_name"] == "mod_channel"
+    assert payload["kind"] == "channel"
+    assert payload["mode"] == "create"
+    assert payload["created"] is True
+    assert payload["resource_id"] == result.resource_id
+    assert "occurred_at" in payload
+
+
+@pytest.mark.asyncio
+async def test_event_emission_failure_swallowed(_isolated_state):
+    _register_logging_with_mod_channel()
+    _isolated_state["bus_raises"]["flag"] = True
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = ResourceProvisioningPipeline()
+    result = await pipeline.provision(
+        guild,
+        ProvisioningRequest(
+            subsystem="logging",
+            binding_name="mod_channel",
+            mode="create",
+            custom_name="mod-logs",
+        ),
+        actor,
+        confirmed=True,
+    )
+    # Mutation still successful.
+    assert result.outcome == "success"
+    assert result.event_emitted is False
+
+
+# ---------------------------------------------------------------------------
+# Result + invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_result_is_frozen():
+    _register_logging_with_mod_channel()
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = ResourceProvisioningPipeline()
+    result = await pipeline.provision(
+        guild,
+        ProvisioningRequest(
+            subsystem="logging",
+            binding_name="mod_channel",
+            mode="create",
+            custom_name="mod-logs",
+        ),
+        actor,
+        confirmed=True,
+    )
+    with pytest.raises(Exception):
+        result.outcome = "permission_blocked"  # type: ignore[misc]
+
+
+@pytest.mark.asyncio
+async def test_distinct_mutation_id_per_call(_isolated_state):
+    _register_logging_with_mod_channel()
+    guild = _FakeGuild(1)
+    actor = _FakeMember(7, guild=guild)
+    pipeline = ResourceProvisioningPipeline()
+    r1 = await pipeline.provision(
+        guild,
+        ProvisioningRequest(
+            subsystem="logging",
+            binding_name="mod_channel",
+            mode="create",
+            custom_name="mod-logs-1",
+        ),
+        actor,
+        confirmed=True,
+    )
+    r2 = await pipeline.provision(
+        guild,
+        ProvisioningRequest(
+            subsystem="logging",
+            binding_name="mod_channel",
+            mode="create",
+            custom_name="mod-logs-2",
+        ),
+        actor,
+        confirmed=True,
+    )
+    assert r1.mutation_id != r2.mutation_id
+
+
+def test_event_name_registered_in_catalogue():
+    from core.events_catalogue import KNOWN_EVENTS
+
+    assert "resource.provisioned" in KNOWN_EVENTS
+
+
+def test_feature_flag_is_declared_and_default_off():
+    from core.runtime.feature_flags import RESOURCE_PROVISIONING_PRIMARY
+
+    assert RESOURCE_PROVISIONING_PRIMARY.name == "resource_provisioning.primary"
+    assert RESOURCE_PROVISIONING_PRIMARY.default_value is False
+
+
+def test_actor_type_allowlist_matches_documented_set():
+    assert rp_mod._ALLOWED_ACTOR_TYPES == frozenset(
+        {"user", "moderator", "admin", "system", "backfill"},
+    )
+
+
+def test_outcome_allowlist_matches_documented_set():
+    assert rp_mod._ALLOWED_OUTCOMES == frozenset(
+        {
+            "success",
+            "permission_blocked",
+            "discord_failed",
+            "binding_failed",
+            "declined",
+        },
+    )
+
+
+def test_kind_allowlist_matches_documented_set():
+    assert rp_mod._ALLOWED_KINDS == frozenset(
+        {"channel", "role", "category", "thread"},
+    )
+
+
+def test_mode_allowlist_matches_documented_set():
+    assert rp_mod._ALLOWED_MODES == frozenset({"use_existing", "create"})
+
+
+# ---------------------------------------------------------------------------
+# Helper-level tests: ensure_role / ensure_category idempotency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ensure_role_returns_existing_when_name_matches():
+    from core.runtime.guild_resources import ensure_role
+
+    role = _FakeRole(50, "exists")
+    guild = _FakeGuild(1, roles=[role])
+    out = await ensure_role(guild, "exists")
+    assert out is role
+
+
+@pytest.mark.asyncio
+async def test_ensure_role_creates_when_absent():
+    from core.runtime.guild_resources import ensure_role
+
+    guild = _FakeGuild(1)
+    out = await ensure_role(guild, "freshly-created")
+    assert out.name == "freshly-created"
+    assert any(r.name == "freshly-created" for r in guild.roles)
+
+
+@pytest.mark.asyncio
+async def test_ensure_category_returns_existing_when_name_matches():
+    from core.runtime.guild_resources import ensure_category
+
+    cat = _FakeCategory(99, "Staff")
+    guild = _FakeGuild(1, categories=[cat])
+    out = await ensure_category(guild, "Staff")
+    assert out is cat
+
+
+@pytest.mark.asyncio
+async def test_ensure_category_creates_when_absent():
+    from core.runtime.guild_resources import ensure_category
+
+    guild = _FakeGuild(1)
+    out = await ensure_category(guild, "Brand New")
+    assert out.name == "Brand New"
+    assert any(c.name == "Brand New" for c in guild.categories)

--- a/tests/unit/services/test_resource_provisioning_pipeline_import_cycle.py
+++ b/tests/unit/services/test_resource_provisioning_pipeline_import_cycle.py
@@ -1,0 +1,112 @@
+"""Import-cycle regression for services.resource_provisioning — S4.5.
+
+The pipeline composes several runtime + service modules:
+``core.runtime.subsystem_schema`` / ``guild_resources``,
+``core.events.bus``, ``services.binding_mutation``,
+``services.resource_provisioning_catalogue``,
+``utils.db.resource_provisioning_audit``,
+``utils.visibility_rules``.
+
+Each of those transitively touches packages whose ``__init__``
+modules walk ``core.runtime``; importing any at module scope risks
+re-entering partially-loaded packages during startup.
+
+Discipline mirrors :mod:`services.platform_consistency`,
+:mod:`services.customization_catalogue`,
+:mod:`services.resource_provisioning_catalogue`,
+:mod:`services.settings_resolution`, and
+:mod:`services.settings_mutation`: top-level imports are stdlib
+only; every cross-package import is function-local.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MODULE_PATH = _REPO_ROOT / "disbot" / "services" / "resource_provisioning.py"
+
+_FORBIDDEN_TOP_LEVEL_PREFIXES = (
+    "cogs",
+    "core",
+    "discord",
+    "services.binding_mutation",
+    "services.customization_catalogue",
+    "services.diagnostics_service",
+    "services.platform_consistency",
+    "services.resource_provisioning_catalogue",
+    "services.settings_mutation",
+    "services.settings_resolution",
+    "utils",
+    "views",
+)
+
+
+def _module_level_imports(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    offenders: list[str] = []
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for prefix in _FORBIDDEN_TOP_LEVEL_PREFIXES:
+                if module == prefix or module.startswith(prefix + "."):
+                    offenders.append(
+                        f"from {module} import "
+                        f"{', '.join(a.name for a in node.names)}",
+                    )
+                    break
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                for prefix in _FORBIDDEN_TOP_LEVEL_PREFIXES:
+                    if alias.name == prefix or alias.name.startswith(prefix + "."):
+                        offenders.append(f"import {alias.name}")
+                        break
+    return offenders
+
+
+def test_resource_provisioning_no_top_level_cycle_imports():
+    offenders = _module_level_imports(_MODULE_PATH)
+    assert not offenders, (
+        "services.resource_provisioning has cycle-sensitive top-level imports:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_resource_provisioning_imports_in_fresh_interpreter():
+    script = textwrap.dedent(
+        """
+        import sys
+        sys.path.insert(0, "disbot")
+        import services.resource_provisioning as rp  # noqa: F401
+
+        assert rp.EVT_RESOURCE_PROVISIONED == "resource.provisioned"
+        assert rp.ResourceProvisioningPipeline is not None
+        from core.events_catalogue import KNOWN_EVENTS
+        assert rp.EVT_RESOURCE_PROVISIONED in KNOWN_EVENTS
+        from core.runtime.feature_flags import RESOURCE_PROVISIONING_PRIMARY
+        assert RESOURCE_PROVISIONING_PRIMARY.default_value is False
+        # Helpers wired into core.runtime.guild_resources.
+        from core.runtime import guild_resources
+        assert hasattr(guild_resources, "ensure_role")
+        assert hasattr(guild_resources, "ensure_category")
+        assert hasattr(guild_resources, "resolve_category")
+        print("ok")
+        """,
+    )
+    result = subprocess.run(  # noqa: S603 — script literal under our control
+        [sys.executable, "-c", script],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"services.resource_provisioning import failed in subprocess.\n"
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary

S4.5 of the **Global Settings & Customization Manager** roadmap.
Canonical creator/binder of Discord resources (channels, roles,
categories) for subsystem use.  First Discord-resource-creating
milestone — built on `main` at `d87645b` (after S4 PR #97 merged),
stands alone, no production callers yet.

The pipeline composes (does not replace) the existing
`BindingMutationPipeline` at step 8 of the contract.  It is the
single owner of provisioning policy; pure infrastructure helpers
`ensure_role` / `ensure_category` (alongside the existing
`ensure_channel`) carry no policy.

## Why S4.5 is safe despite being the first Discord-resource-creating PR

1. **Pipeline has zero production callers.** Future S7 logging UI +
   S10 setup packs will invoke it. Its existence alone changes no
   behaviour.
2. **Migration 030 is purely additive.** One new audit table, no
   backfill, no changes to existing tables. Rollback is
   `DROP TABLE IF EXISTS resource_provisioning_audit`.
3. **Append-only audit.** Every outcome (`success` /
   `permission_blocked` / `discord_failed` / `binding_failed` /
   `declined`) writes one row; no `UPDATE` / `DELETE` paths.
4. **No silent auto-create.** `mode='create'` always requires
   `confirmed=True`. Standing operator settings (e.g.
   `logging.auto_create_channels=true`) are wired by S7's logging
   consumer — not by this pipeline.
5. **Existing direct `guild.create_*` callers are untouched.** The
   new AST invariant `test_no_silent_auto_create.py` allowlists
   every pre-existing caller as a grandfathered legacy path; new
   code outside the pipeline + the `ensure_*` helpers cannot
   create Discord resources.
6. **Binding failure does NOT roll back the created resource.** A
   `binding_failed` outcome audits the gap and returns a typed
   result; the operator manually re-binds or cleans up. Conservative
   by design — never delete user state on a flaky bind.
7. **Feature flag declared but NOT consulted by the pipeline.**
   `RESOURCE_PROVISIONING_PRIMARY` (default OFF) is pure kill-switch
   infrastructure for future S7+/S10 UI consumers, matching the
   `SETTINGS_MUTATION_PRIMARY` pattern from S4.

## Pipeline contract (11 steps)

1. Resolve `ResourceRequirement` + `BindingSpec` via the catalogue.
2. Validate actor / capability (administrator-tier placeholder).
3. Validate bot Discord permissions for the requested kind.
4. Preview creation/reuse via `preview()`.
5. Require explicit confirmation: `mode='create'` requires
   `confirmed=True`; `mode='use_existing'` bypasses (the operator's
   selection IS the confirmation).
6. Create (via `ensure_*`) or reuse (re-resolve `existing_id`).
7. Validate created resource (id present, kind matches).
8. Bind via `BindingMutationPipeline.set_binding(...)`.
9. Insert `resource_provisioning_audit` row.
10. Emit advisory `"resource.provisioned"` (best-effort, post-commit).
11. Return typed `ProvisioningResult`.

## Architectural boundary (per your directive)

- **`ensure_role` / `ensure_category` are pure infrastructure** —
  no feature-flag checks, no policy logic. They mirror the existing
  `ensure_channel`.
- **The pipeline owns provisioning policy** — preview → permission
  validation → explicit confirmation → audit → binding integration
  → event emission.
- **AST invariant `test_no_silent_auto_create.py`** strengthens the
  prior discipline: every `guild.create_*` (or `*.create_thread`)
  call must come from a file on the allowlist. Allowlist
  documents the grandfathered legacy paths explicitly; each is a
  per-subsystem S10 migration candidate. The pipeline service
  itself is on the *forbidden* list — it must compose `ensure_*`,
  not call `guild.create_*` directly.

## Public surface

```python
@dataclass(frozen=True)
class ProvisioningRequest:
    subsystem: str
    binding_name: str
    mode: Literal["use_existing", "create"]
    existing_id: int | None = None
    custom_name: str | None = None
    category_id: int | None = None
    permission_template: str | None = None


@dataclass(frozen=True)
class ProvisioningPreview:
    allowed: bool
    action: Literal["reuse_existing", "create_new", "blocked"]
    target_name: str
    warnings: tuple[str, ...] = ()


@dataclass(frozen=True)
class ProvisioningResult:
    mutation_id: str
    guild_id: int
    subsystem: str
    binding_name: str
    kind: str
    mode: str
    outcome: Literal["success", "permission_blocked", "discord_failed",
                     "binding_failed", "declined"]
    created: bool
    resource_id: int | None
    binding_written: bool
    audit_id: int | None
    committed_at: datetime
    event_emitted: bool


class ResourceProvisioningPipeline:
    async def preview(self, guild, request) -> ProvisioningPreview: ...
    async def provision(
        self, guild, request, actor, *,
        confirmed: bool = False, actor_type: str = "user",
    ) -> ProvisioningResult: ...


# Errors
class ResourceProvisioningError(Exception): ...
class UndeclaredResourceError(ResourceProvisioningError): ...
class UnauthorizedProvisioningError(ResourceProvisioningError): ...
class ProvisioningConfirmationRequired(ResourceProvisioningError): ...
class DiscordProvisioningFailedError(ResourceProvisioningError): ...
class InvalidActorTypeError(ResourceProvisioningError): ...
class KindMismatchError(ResourceProvisioningError): ...

EVT_RESOURCE_PROVISIONED = "resource.provisioned"
```

## Files changed

- **`disbot/migrations/030_resource_provisioning_audit.sql`** *(new)*
  — one new audit table with CHECK constraints on `mutation_type`,
  `kind`, `mode`, `outcome`, `actor_type`. Indexed on
  `(guild_id, at)`, `(subsystem, binding_name, at)`, `(mutation_id)`.
  Forward-only and idempotent.
- **`disbot/utils/db/resource_provisioning_audit.py`** *(new)* —
  `insert_audit` + read primitives (`count_for_guild`,
  `count_by_outcome`, `list_recent_for_guild`).
- **`disbot/services/resource_provisioning.py`** *(new, 575 LOC)* —
  the pipeline, the typed shapes, the typed errors, the event
  constant. Cycle-safe: top-level imports are stdlib only.
- **`disbot/core/runtime/guild_resources.py`** — add `ensure_role`,
  `ensure_category`, `resolve_category` as policy-free
  infrastructure helpers (matching `ensure_channel`).
- **`disbot/core/events_catalogue.py`** — register
  `"resource.provisioned"` in `KNOWN_EVENTS`.
- **`disbot/core/runtime/feature_flags.py`** — declare and register
  `RESOURCE_PROVISIONING_PRIMARY` (default `False`); add to
  `__all__`.
- **`tests/unit/services/test_resource_provisioning_pipeline.py`**
  *(new, 33 tests)* — every error class, actor / authority
  validation including `system` / `backfill` bypass, bot-permission
  check (`manage_channels` / `manage_roles`), confirmation gating,
  preview happy + blocked paths, create happy path for
  channel/role/category, use_existing happy path + decline paths
  (missing id, unknown id), Discord-API failure → `discord_failed`,
  binding failure → `binding_failed` with resource NOT rolled back,
  event emission with full payload, emission failure swallowed,
  frozen result, distinct `mutation_id` per call, catalogue + flag
  + helper-set invariants, `ensure_role` / `ensure_category`
  idempotency.
- **`tests/unit/services/test_resource_provisioning_pipeline_import_cycle.py`**
  *(new, 2 tests)* — pins the cycle discipline and verifies the
  module imports cleanly in a fresh interpreter.
- **`tests/unit/invariants/test_no_silent_auto_create.py`** *(new,
  4 tests)* — AST scan forbidding direct `guild.create_*` (and
  `*.create_thread`) outside the allowlist. Allowlist documents 9
  grandfathered legacy paths; each is a per-subsystem S10
  migration candidate. The pipeline service itself is on the
  forbidden list — verified by a separate test.
- **`tests/unit/invariants/test_resource_provisioning_audit_alignment.py`**
  *(new, 7 tests)* — pins migration 030 CHECK literals
  (`mutation_type`, `kind`, `mode`, `outcome`, `actor_type`)
  against the Python `frozenset`s in
  `services.resource_provisioning`. Forward-only + idempotent
  scan strips SQL comments first.

## Migration details

- **Number:** 030 (next after `029_settings_mutation_audit.sql` from S4).
- **Type:** additive, forward-only, idempotent (`CREATE … IF NOT EXISTS`).
- **What it creates:** one new table `resource_provisioning_audit` +
  3 indexes.
- **Backfill:** none.
- **Rollback:** `DROP TABLE IF EXISTS resource_provisioning_audit;`
  — removes the audit history with no downstream impact. The
  pipeline is unused in production, so dropping the table breaks
  no live read path.

## Tests run and exact results

- [x] `python3 -m pytest tests/unit/services/test_resource_provisioning_pipeline.py` — **33 passed**
- [x] `python3 -m pytest tests/unit/services/test_resource_provisioning_pipeline_import_cycle.py` — **2 passed**
- [x] `python3 -m pytest tests/unit/invariants/test_no_silent_auto_create.py` — **4 passed**
- [x] `python3 -m pytest tests/unit/invariants/test_resource_provisioning_audit_alignment.py` — **7 passed**
- [x] `python3 -m pytest tests/unit/services/test_resource_provisioning_catalogue.py tests/unit/services/test_settings_mutation_pipeline.py` — neighbours still green (**58 passed**)
- [x] `python3 -m pytest tests/unit/` — full suite: **1813 passed, 0 failed, 12 warnings**
- [x] `ruff check disbot/` — clean
- [x] `black --check disbot/` — 239 files unchanged
- [x] `isort --check-only disbot/ tests/` — clean
- [x] `mypy disbot/` — no issues found in 239 source files
- [x] Single-`git revert` safe (additive migration, no behaviour change in existing flows)

## Manual smoke checklist (for the operator)

The pipeline is wired into nothing in production today. REPL
verification once the migration has run:

- `preview(guild, ProvisioningRequest(subsystem="logging",
  binding_name="mod_channel", mode="create",
  custom_name="mod-logs"))` returns
  `ProvisioningPreview(allowed=True, action="create_new",
  target_name="mod-logs", warnings=())`.
- `provision(..., confirmed=False)` raises
  `ProvisioningConfirmationRequired`.
- `provision(..., confirmed=True)` creates `#mod-logs`, writes the
  binding via `BindingMutationPipeline`, inserts a `success`
  audit row, emits `resource.provisioned`.
- Re-running with `mode="use_existing", existing_id=<id>` reuses
  the channel without confirmation; audit row records
  `created=False, outcome="success"`.
- Revoke the bot's `manage_channels` perm and try a create →
  `UnauthorizedProvisioningError`; audit row records
  `permission_blocked`. No channel is created.
- Bypassing the pipeline by typing `await
  guild.create_text_channel("foo")` from a new file in
  `disbot/services/` would trip
  `test_no_silent_auto_create.py` — exactly the gap S10 will
  migrate the existing legacy callers away from.

## Risks and rollback plan

- **Risks:** none in production — the pipeline is dormant and the
  migration is additive. Failure modes:
  - Migration not applied → no impact at startup; calling the
    pipeline would raise from the DB layer with a clear error.
  - A new caller bypasses the pipeline → trips the AST invariant
    with a clear pointer to the pipeline.
- **Rollback:** `git revert` of commit `dbec9b1` removes the
  pipeline, the audit DB layer, the migration, the new feature
  flag, the event catalogue entry, the helper extensions to
  `guild_resources`, and the four test files. The migration
  table can be dropped with `DROP TABLE IF EXISTS
  resource_provisioning_audit;` — no existing code depends on it.

## Deferred work

Matches the S1 / S2 / S2.5 / S3 / S4 precedent — every prior
milestone deferred its `services.platform_consistency` collector
to a follow-up PR. S4.5 follows the same pattern:

- `disbot/services/platform_consistency.py` —
  `_collect_resource_provisioning` collector surfacing the audit
  row count (per-guild and `by_outcome` histogram) as
  informational. Tiny follow-up.

## PR sequencing

This PR is built on `main` at `d87645b` (with S4 PR #97 merged)
and stands alone. It depends on **S2.5** (`ResourceProvisioningCatalogue`,
merged in #95) + the existing `BindingMutationPipeline`, not on S4.

S5 / S6 (Settings Manager UI shell + scalar edit flows) and S7
(logging UI consuming this pipeline) require this PR merged
because they invoke `ResourceProvisioningPipeline.provision(...)`
directly. If those PRs are ready before this one merges they
should stack with explicit dependency documentation.

## Next recommended PR

**S5 — Settings Manager Cog shell + read-only views + help hook**
on branch `claude/settings-cog-readonly`. Depends on S4 (merged)
+ S3 (merged). Read-only browsing of every setting; reachable from
Help via `build_help_menu_view`. Feature flag
`SETTINGS_MANAGER_COG_ENABLED` default OFF gates the cog.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U3sByR3PY3gobeB3jLFDFD)_