### PR TITLE
feat(s5): Settings Manager cog shell + read-only views + help hook

### DIFF
--- a/disbot/cogs/settings/__init__.py
+++ b/disbot/cogs/settings/__init__.py
@@ -1,0 +1,13 @@
+"""Settings subsystem package — S5.
+
+Empty package marker.  The S5 Settings Manager cog does not declare
+any ``SettingSpec``/``BindingSpec``/``ResourceRequirement`` of its
+own; it is a read-only browser over the *other* subsystems' schemas.
+A future PR may add a small ``SubsystemSchema`` here for cog-local
+preferences (e.g. ``hub_page_size``), gated on whether that scope is
+ever needed.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/disbot/cogs/settings_cog.py
+++ b/disbot/cogs/settings_cog.py
@@ -1,0 +1,170 @@
+"""Settings Manager cog — S5 of the Global Settings & Customization Manager.
+
+Lands the long-term Settings Manager navigation shape (hub +
+subsystem dropdown + four diagnostic sub-panels) in **strictly
+read-only** form.  Future milestones add edit / reset / mutate
+flows (S6+), the logging create-or-select flow (S7), cleanup
+expansion (S8), the access-policy manager (S9), and per-subsystem
+setup packs (S10).
+
+Hard limits for S5:
+
+* No edit modals, no reset buttons that write, no resource
+  creation, no binding mutation, no access-policy mutation, no
+  cleanup-policy mutation, no setup wizard, no slash commands.
+* The cog ALWAYS loads and registers in
+  :data:`utils.subsystem_registry.SUBSYSTEMS` so help / admin /
+  menu discoverability stays stable.
+* The :data:`core.runtime.feature_flags.SETTINGS_MANAGER_COG_ENABLED`
+  flag (default OFF) gates the runtime *behaviour* of ``!settings``
+  and the ``build_help_menu_view`` hook.  When OFF, invocations
+  return a clearly-worded disabled embed describing how to enable
+  it.  This avoids the "command exists but mysteriously hidden"
+  discoverability bug.
+
+Pinned by ``tests/unit/invariants/test_settings_cog_read_only.py``:
+no imports of mutation pipelines in ``disbot/cogs/settings*`` or
+``disbot/views/settings/**``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+from discord.ext import commands
+
+from views.base import send_panel
+
+logger = logging.getLogger("bot")
+
+
+_FLAG_NAME = "settings.manager_cog.enabled"
+
+
+def _disabled_embed() -> discord.Embed:
+    """Return the embed shown when the feature flag is OFF.
+
+    Surfaces the exact command an operator would run to flip the
+    flag (via the rollout pipeline, when that command exists) so the
+    discoverability gap can be closed in one step.
+    """
+    embed = discord.Embed(
+        title="⚙️ Settings Manager — disabled",
+        description=(
+            "The Settings Manager cog is registered for discoverability, "
+            "but its runtime behaviour is gated behind the "
+            f"`{_FLAG_NAME}` feature flag, which defaults to **OFF**.\n\n"
+            "When this flag is ON the `!settings` command opens the "
+            "Settings hub (read-only browsing of every subsystem's "
+            "scalar settings, bindings, resource requirements, and "
+            "recent audit history).\n\n"
+            "Flip the flag via the feature-flag mutation pipeline "
+            "(future `!platform flags set …` command) or the "
+            "`SUPERBOT_FF_SETTINGS__MANAGER_COG__ENABLED=on` env "
+            "override."
+        ),
+        color=discord.Color.greyple(),
+    )
+    embed.set_footer(text="S5 — read-only Settings Manager shell (default OFF).")
+    return embed
+
+
+async def _is_enabled(guild_id: int | None) -> bool:
+    """Resolve the gate flag for the given guild.
+
+    Failures fall back to ``False`` (closed) — a flag-evaluator
+    outage must not open a UI that is supposed to default OFF.
+    """
+    try:
+        from core.runtime import feature_flags
+
+        return await feature_flags.is_enabled(_FLAG_NAME, guild_id)
+    except Exception as exc:  # noqa: BLE001 — gate is closed on any failure
+        logger.warning(
+            "settings_cog: feature_flag resolution raised %s; treating "
+            "%s as OFF (gate closed).",
+            exc,
+            _FLAG_NAME,
+        )
+        return False
+
+
+class SettingsCog(commands.Cog):
+    """Read-only Settings Manager surface (S5).
+
+    Public commands:
+
+    * ``!settings`` — open the Settings hub.
+
+    Public hooks:
+
+    * ``build_help_menu_view`` — direct-navigation entry from
+      :class:`cogs.help_cog.HelpPanelView` so picking *Settings
+      Manager* from the help dropdown opens the hub in place.
+    """
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @commands.cooldown(rate=2, per=10, type=commands.BucketType.user)
+    @commands.command(
+        name="settings",
+        help="Open the Settings Manager hub (read-only).",
+    )
+    @commands.has_permissions(administrator=True)
+    async def settings_root(self, ctx: commands.Context) -> None:
+        """Entry-point command for the Settings Manager subsystem.
+
+        When the gate flag is OFF, returns the standard disabled
+        embed.  When ON, opens the hub view.
+        """
+        guild_id = ctx.guild.id if ctx.guild else None
+        if not await _is_enabled(guild_id):
+            await ctx.send(embed=_disabled_embed())
+            return
+        from views.settings.hub import SettingsHubView
+
+        view = SettingsHubView(ctx.author)
+        await send_panel(ctx, embed=SettingsHubView.build_embed(), view=view)
+
+    async def build_help_menu_view(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        """Help-menu direct-navigation hook.
+
+        Called by ``HelpPanelView._on_select`` when the operator
+        picks *Settings Manager* from the help dropdown.  Returns
+        the same ``(embed, view)`` shape that ``!settings`` would
+        produce, with one exception: when the gate flag is OFF the
+        returned view is a tiny "disabled" view with only a
+        back-to-help button, so users see a coherent explanation
+        instead of an interactive hub that does nothing.
+        """
+        guild_id = interaction.guild_id
+        if not await _is_enabled(guild_id):
+            return _disabled_embed(), _DisabledHelpHookView(interaction.user)
+        from views.settings.hub import SettingsHubView
+
+        view = SettingsHubView(interaction.user)
+        return SettingsHubView.build_embed(), view
+
+
+class _DisabledHelpHookView(discord.ui.View):
+    """No-controls view shown in the help direct-nav path when the
+    gate flag is OFF.  The help cog appends its own "↩ Back to Help"
+    button to this view, so we deliberately ship an empty container
+    rather than reach into the help view machinery from here.
+    """
+
+    def __init__(self, _author) -> None:  # noqa: ARG002 — kept for parity
+        super().__init__(timeout=60)
+
+
+async def setup(bot: commands.Bot) -> None:
+    """discord.py extension entry point."""
+    await bot.add_cog(SettingsCog(bot))
+
+
+__all__ = ["SettingsCog", "setup"]

--- a/disbot/config.py
+++ b/disbot/config.py
@@ -51,6 +51,7 @@ INITIAL_EXTENSIONS = [
     "cogs.chain_cog",
     "cogs.general_cog",
     "cogs.leaderboard_cog",
+    "cogs.settings_cog",
 ]
 
 # ==========================

--- a/disbot/core/runtime/feature_flags.py
+++ b/disbot/core/runtime/feature_flags.py
@@ -262,6 +262,27 @@ SETTINGS_MUTATION_PRIMARY = FeatureFlag(
     removal_target="S5+ stable",
 )
 
+# S5 flag — gates the user-facing Settings Manager cog (!settings).
+# The cog ALWAYS loads and registers in SUBSYSTEMS so help/admin/menu
+# discoverability stays stable; the flag gates the runtime *behaviour*
+# of the !settings command and the build_help_menu_view hook so
+# operators can disable the cog without breaking the registry.  When
+# the flag is OFF (default), invocations return an explanatory
+# embed describing how to enable it.
+SETTINGS_MANAGER_COG_ENABLED = FeatureFlag(
+    name="settings.manager_cog.enabled",
+    description=(
+        "Gates the runtime behaviour of the user-facing Settings Manager "
+        "cog (!settings) introduced in S5.  Default OFF — the cog still "
+        "loads and registers so help discoverability stays stable, but "
+        "invocations return a clearly-worded 'disabled' embed until the "
+        "flag is flipped."
+    ),
+    default_value=False,
+    owner="platform",
+    removal_target="S11 stable",
+)
+
 
 def _register_builtins() -> None:
     """Register Phase 1d platform-level flags at import time."""
@@ -270,6 +291,7 @@ def _register_builtins() -> None:
     register(PARTICIPATION_ENABLED)
     register(FEATURE_FLAG_PRIMARY)
     register(SETTINGS_MUTATION_PRIMARY)
+    register(SETTINGS_MANAGER_COG_ENABLED)
 
 
 _register_builtins()
@@ -695,6 +717,7 @@ __all__ = [
     "PARTICIPATION_ENABLED",
     "RESOURCES_UNIFIED",
     "RolloutPolicy",
+    "SETTINGS_MANAGER_COG_ENABLED",
     "SETTINGS_MUTATION_PRIMARY",
     "all_flags",
     "bootstrap_fallback_count",

--- a/disbot/utils/subsystem_registry.py
+++ b/disbot/utils/subsystem_registry.py
@@ -497,6 +497,30 @@ SUBSYSTEMS: dict[str, dict] = {
             "diagnostic.latency.check",
         ],
     },
+    "settings": {
+        "display_name": "Settings Manager",
+        "description": (
+            "Read-only browsing of platform settings, bindings, and audit "
+            "history (S5)"
+        ),
+        "emoji": "⚙️",
+        "color": ADMIN_COLOR.value,
+        "visibility_tier": "administrator",
+        "visibility_mode": "normal",
+        "category": "admin",
+        "tags": ["settings", "configuration", "audit", "platform"],
+        "entry_points": ["settings"],
+        "default_channels": ["staff", "bot-admin"],
+        "related_subsystems": ["admin", "diagnostic"],
+        "dependencies": [],
+        "soft_dependencies": [],
+        "supports_dm": False,
+        "has_cleanup_rules": False,
+        "ui_priority": 92,
+        "capabilities": [
+            "settings.manager.view",
+        ],
+    },
 }
 
 # ---------------------------------------------------------------------------

--- a/disbot/views/settings/__init__.py
+++ b/disbot/views/settings/__init__.py
@@ -1,0 +1,20 @@
+"""Settings Manager views — S5.
+
+Read-only browsing surface for the platform's settings, bindings,
+resource requirements, and recent audit history.  Mirrors the
+long-term UX shape documented in
+``docs/operator-settings-presets.md``: a hub with a subsystem
+dropdown, an overview/status header, and four diagnostic
+sub-panels (Needs setup / Invalid settings / Missing bindings /
+Recent changes).
+
+S5 is strictly read-only — no edit modals, no reset buttons that
+write, no resource creation, no binding mutation, no
+access-policy mutation.  S6 onward adds the write surfaces, gated
+on the existing :class:`services.settings_mutation.SettingsMutationPipeline`
+and :class:`services.binding_mutation.BindingMutationPipeline`.
+"""
+
+from __future__ import annotations
+
+__all__ = []

--- a/disbot/views/settings/audit_view.py
+++ b/disbot/views/settings/audit_view.py
@@ -1,0 +1,135 @@
+"""RecentChangesView — recent rows from the settings audit log (S5).
+
+Read-only view over the ``settings_mutation_audit`` table populated
+by :class:`services.settings_mutation.SettingsMutationPipeline`
+(S4).  Up to 10 most recent rows for the calling guild are
+rendered.
+
+Gracefully degrades when:
+
+* The migration has not been applied yet (no table) — the view
+  reports the table as absent rather than raising.
+* The pipeline has never been called — the table exists but is
+  empty.  The view renders an empty-state message.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+from views.base import HubView
+
+logger = logging.getLogger("bot.views.settings.audit_view")
+
+
+_RECENT_LIMIT = 10
+
+
+async def build_audit_embed(
+    interaction: discord.Interaction,
+) -> discord.Embed:
+    embed = discord.Embed(
+        title="🕒 Recent settings changes",
+        description=(
+            "Most recent rows from `settings_mutation_audit` (S4).  "
+            "Until the S6 edit flow lands, this table is populated only "
+            "by REPL or scripted writes; production cogs still call "
+            "`db.set_setting` directly (allowlisted per the AST invariant).\n"
+            "_Read-only · S5._"
+        ),
+        color=discord.Color.blurple(),
+    )
+
+    guild_id = interaction.guild_id
+    if guild_id is None:
+        embed.add_field(
+            name="Result",
+            value="*Run this from within a guild — DM has no audit history.*",
+            inline=False,
+        )
+        return embed
+
+    try:
+        from utils.db import settings_audit
+
+        rows = await settings_audit.list_recent_for_guild(
+            guild_id,
+            limit=_RECENT_LIMIT,
+        )
+    except Exception as exc:  # noqa: BLE001 — soft-fail; usually missing table
+        logger.warning(
+            "RecentChangesView: settings_audit query raised %s",
+            exc,
+            exc_info=True,
+        )
+        embed.add_field(
+            name="Audit table",
+            value=(
+                f"*Could not read `settings_mutation_audit` — "
+                f"`{type(exc).__name__}: {exc!s:.100}`.  "
+                "Migration 029 may not have been applied yet.*"
+            ),
+            inline=False,
+        )
+        return embed
+
+    if not rows:
+        embed.add_field(
+            name="Result",
+            value="*No audit rows for this guild yet.*",
+            inline=False,
+        )
+        return embed
+
+    lines: list[str] = []
+    for row in rows:
+        ts = row.get("at")
+        ts_str = ts.strftime("%Y-%m-%d %H:%M:%SZ") if ts is not None else "—"
+        prev = row.get("prev_value_raw")
+        new = row.get("new_value_raw")
+        actor = row.get("actor_id")
+        actor_type = row.get("actor_type", "user")
+        lines.append(
+            f"`{ts_str}` `{row['subsystem']}.{row['name']}` "
+            f"= `{new!r}` (was `{prev!r}`) "
+            f"by `{actor_type}` `{actor}`",
+        )
+    embed.add_field(
+        name=f"Last {len(rows)} change(s)",
+        value="\n".join(lines)[:1024],
+        inline=False,
+    )
+    embed.set_footer(text=f"settings_mutation_audit · guild_id={guild_id}")
+    return embed
+
+
+class _BackToHubButton(discord.ui.Button):
+    def __init__(self) -> None:
+        super().__init__(
+            label="Back to Hub",
+            style=discord.ButtonStyle.secondary,
+            emoji="↩",
+            custom_id="settings_audit.back",
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.settings.hub import SettingsHubView
+
+        view = SettingsHubView(interaction.user)
+        await interaction.response.edit_message(
+            embed=SettingsHubView.build_embed(),
+            view=view,
+        )
+
+
+class RecentChangesView(HubView):
+    """Read-only diagnostic panel rendering the last N audit rows."""
+
+    def __init__(self, author) -> None:
+        super().__init__(author)
+        self.add_item(_BackToHubButton())
+
+
+__all__ = ["RecentChangesView", "build_audit_embed"]

--- a/disbot/views/settings/hub.py
+++ b/disbot/views/settings/hub.py
@@ -1,0 +1,271 @@
+"""SettingsHubView — top-level navigation for ``!settings`` (S5).
+
+Hub-and-spoke navigation:
+
+* Header embed shows global counters (registered subsystems, declared
+  settings, declared bindings, declared resource requirements,
+  customization findings).
+* A Discord ``Select`` lists every subsystem whose schema is
+  registered, sorted by ``ui_priority``.  Picking a subsystem
+  replaces the panel with a :class:`~views.settings.subsystem_view.SubsystemSettingsView`.
+* Four buttons open diagnostic sub-panels:
+  Needs setup / Invalid settings / Missing bindings / Recent changes.
+
+Strictly read-only — no edit / reset / mutate buttons.  S6 onward
+introduces the write surfaces.
+
+The hub depends on three S0–S4 catalogues:
+
+* :mod:`core.runtime.settings_registry` (S1) for declared settings
+* :mod:`services.customization_catalogue` (S2) for help/panel
+  cross-discoverability findings
+* :mod:`core.runtime.subsystem_schema` for declared bindings and
+  resource requirements
+
+Each is read-only and already cached at startup; the hub never
+mutates them.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+from utils.subsystem_registry import SUBSYSTEMS
+from views.base import HubView
+
+logger = logging.getLogger("bot.views.settings.hub")
+
+
+_DISCORD_SELECT_OPTION_LIMIT = 25
+
+
+def _candidate_subsystems() -> list[tuple[str, dict]]:
+    """Return subsystems sorted by ``ui_priority`` then name.
+
+    Includes every subsystem with a registered schema *or* declared
+    capabilities; excludes ``visibility_mode='internal'`` entries
+    because they should not surface in operator-facing UI.
+    """
+    from core.runtime.subsystem_schema import all_schemas
+
+    schemas = all_schemas()
+    out: list[tuple[str, dict]] = []
+    for name, meta in SUBSYSTEMS.items():
+        if meta.get("visibility_mode", "normal") == "internal":
+            continue
+        # Show every subsystem.  Even those without a schema are
+        # surfaced so the operator sees the gap explicitly; the
+        # subsystem page renders an empty-state message.
+        out.append((name, meta))
+    # Sort: subsystems with schemas first, then by ui_priority ascending,
+    # then alphabetically by display_name.
+    out.sort(
+        key=lambda kv: (
+            kv[0] not in schemas,
+            kv[1].get("ui_priority", 99),
+            kv[1].get("display_name", kv[0]),
+        ),
+    )
+    return out
+
+
+def _build_header_embed() -> discord.Embed:
+    """Build the hub header embed with global counters."""
+    from core.runtime.settings_registry import get_cached_registry
+    from core.runtime.subsystem_schema import all_schemas
+    from services.customization_catalogue import get_cached_catalogue
+
+    schemas = all_schemas()
+    registry = get_cached_registry()
+    catalogue = get_cached_catalogue()
+
+    bindings_total = sum(len(s.bindings) for s in schemas.values())
+    resources_total = sum(len(s.resource_requirements) for s in schemas.values())
+    settings_total = len(registry.entries) if registry is not None else 0
+    findings_total = catalogue.findings.total if catalogue is not None else 0
+
+    embed = discord.Embed(
+        title="⚙️ Settings Manager",
+        description=(
+            "Read-only browsing of platform settings, bindings, resource "
+            "requirements, and recent audit history.  Use the dropdown to "
+            "drill into a subsystem; use the buttons for cross-cutting "
+            "diagnostics.\n"
+            "_Edit and reset flows arrive in S6; this is the read-only "
+            "navigation shell._"
+        ),
+        color=discord.Color.blurple(),
+    )
+    embed.add_field(
+        name="Inventory",
+        value=(
+            f"`subsystems`: {len(SUBSYSTEMS)}  ·  "
+            f"`schemas`: {len(schemas)}\n"
+            f"`settings`: {settings_total}  ·  "
+            f"`bindings`: {bindings_total}  ·  "
+            f"`resources`: {resources_total}"
+        ),
+        inline=False,
+    )
+    embed.add_field(
+        name="Customization findings",
+        value=(
+            f"`total`: {findings_total}"
+            if catalogue is not None
+            else "*catalogue not built yet*"
+        ),
+        inline=False,
+    )
+    embed.set_footer(
+        text=(
+            "Tip: `!platform customization` and `!platform settings-registry` "
+            "expose the underlying catalogues."
+        ),
+    )
+    return embed
+
+
+class _SubsystemSelect(discord.ui.Select):
+    """Drop-down listing every subsystem.  Picking one swaps the panel."""
+
+    def __init__(self, options: list[tuple[str, dict]]):
+        select_options: list[discord.SelectOption] = []
+        for name, meta in options[:_DISCORD_SELECT_OPTION_LIMIT]:
+            select_options.append(
+                discord.SelectOption(
+                    label=meta.get("display_name", name)[:100],
+                    value=name,
+                    description=str(meta.get("description", ""))[:100] or None,
+                    emoji=meta.get("emoji") or None,
+                ),
+            )
+        super().__init__(
+            placeholder="Open a subsystem…",
+            min_values=1,
+            max_values=1,
+            options=select_options
+            or [discord.SelectOption(label="(no subsystems)", value="_none")],
+            custom_id="settings_hub.subsystem_select",
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        name = self.values[0]
+        if name == "_none":
+            await interaction.response.send_message(
+                "No subsystems registered.",
+                ephemeral=True,
+            )
+            return
+        # Defer the heavy import until selection so the hub stays cheap
+        # to build.
+        from views.settings.subsystem_view import (
+            SubsystemSettingsView,
+            build_subsystem_embed,
+        )
+
+        view = SubsystemSettingsView(interaction.user, name)
+        embed = await build_subsystem_embed(interaction, name)
+        await interaction.response.edit_message(embed=embed, view=view)
+
+
+class _OpenNeedsSetup(discord.ui.Button):
+    def __init__(self):
+        super().__init__(
+            label="Needs setup",
+            style=discord.ButtonStyle.secondary,
+            emoji="📋",
+            custom_id="settings_hub.needs_setup",
+            row=1,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.settings.needs_setup import NeedsSetupView, build_needs_setup_embed
+
+        view = NeedsSetupView(interaction.user)
+        embed = await build_needs_setup_embed(interaction)
+        await interaction.response.edit_message(embed=embed, view=view)
+
+
+class _OpenInvalid(discord.ui.Button):
+    def __init__(self):
+        super().__init__(
+            label="Invalid settings",
+            style=discord.ButtonStyle.secondary,
+            emoji="⚠️",
+            custom_id="settings_hub.invalid",
+            row=1,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.settings.invalid_settings import (
+            InvalidSettingsView,
+            build_invalid_embed,
+        )
+
+        view = InvalidSettingsView(interaction.user)
+        embed = await build_invalid_embed(interaction)
+        await interaction.response.edit_message(embed=embed, view=view)
+
+
+class _OpenMissingBindings(discord.ui.Button):
+    def __init__(self):
+        super().__init__(
+            label="Missing bindings",
+            style=discord.ButtonStyle.secondary,
+            emoji="🔗",
+            custom_id="settings_hub.missing_bindings",
+            row=1,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.settings.missing_bindings import (
+            MissingBindingsView,
+            build_missing_bindings_embed,
+        )
+
+        view = MissingBindingsView(interaction.user)
+        embed = await build_missing_bindings_embed(interaction)
+        await interaction.response.edit_message(embed=embed, view=view)
+
+
+class _OpenAudit(discord.ui.Button):
+    def __init__(self):
+        super().__init__(
+            label="Recent changes",
+            style=discord.ButtonStyle.secondary,
+            emoji="🕒",
+            custom_id="settings_hub.audit",
+            row=1,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.settings.audit_view import (
+            RecentChangesView,
+            build_audit_embed,
+        )
+
+        view = RecentChangesView(interaction.user)
+        embed = await build_audit_embed(interaction)
+        await interaction.response.edit_message(embed=embed, view=view)
+
+
+class SettingsHubView(HubView):
+    """Top-level navigation for the Settings Manager (S5)."""
+
+    def __init__(self, author: discord.Member | discord.User):
+        super().__init__(author)
+        self.add_item(_SubsystemSelect(_candidate_subsystems()))
+        self.add_item(_OpenNeedsSetup())
+        self.add_item(_OpenInvalid())
+        self.add_item(_OpenMissingBindings())
+        self.add_item(_OpenAudit())
+
+    @staticmethod
+    def build_embed() -> discord.Embed:
+        """Static helper used by the cog + tests."""
+        return _build_header_embed()
+
+
+__all__ = ["SettingsHubView"]

--- a/disbot/views/settings/invalid_settings.py
+++ b/disbot/views/settings/invalid_settings.py
@@ -1,0 +1,117 @@
+"""InvalidSettingsView — settings whose current value fails coercion (S5).
+
+Walks every declared ``SettingSpec`` for the calling guild and reports
+the ones that
+:func:`services.settings_resolution.resolve_setting` flags as
+``valid=False``.  In v1 that covers two cases:
+
+* The KV row contains a value that cannot be coerced to the declared
+  ``value_type`` (e.g. ``"abc"`` for an ``int`` spec).
+* The KV row's coerced value is rejected by the spec's
+  ``validator`` (raised ``ValueError`` or ``TypeError``).
+
+Both cases fall back to the declared default at the resolver layer,
+so production behaviour is safe.  This view surfaces the gap so an
+operator can fix it.
+"""
+
+from __future__ import annotations
+
+import discord
+
+from views.base import HubView
+
+
+async def build_invalid_embed(
+    interaction: discord.Interaction,
+) -> discord.Embed:
+    embed = discord.Embed(
+        title="⚠️ Invalid settings",
+        description=(
+            "Settings whose current KV value failed coercion or "
+            "validation.  Resolver fell back to the declared default "
+            "for runtime safety; the underlying KV row needs an edit "
+            "(S6 introduces the edit flow).\n"
+            "_Read-only · S5._"
+        ),
+        color=discord.Color.orange(),
+    )
+
+    guild_id = interaction.guild_id
+    if guild_id is None:
+        embed.add_field(
+            name="Result",
+            value="*Run this from within a guild — DM has no scalar values to resolve.*",
+            inline=False,
+        )
+        return embed
+
+    from core.runtime.subsystem_schema import all_schemas
+    from services.settings_resolution import resolve_setting
+
+    invalid: list[str] = []
+    scanned = 0
+    for sub_name, schema in sorted(all_schemas().items()):
+        for spec in schema.settings:
+            scanned += 1
+            try:
+                resolution = await resolve_setting(guild_id, sub_name, spec.name)
+            except Exception as exc:  # noqa: BLE001 — soft-fail per row
+                invalid.append(
+                    f"`{sub_name}.{spec.name}` — resolver raised "
+                    f"{type(exc).__name__}",
+                )
+                continue
+            if resolution is None or resolution.valid:
+                continue
+            diag = f" ({resolution.diagnostics[0]})" if resolution.diagnostics else ""
+            invalid.append(
+                f"`{sub_name}.{spec.name}` = `{resolution.raw!r}` "
+                f"→ fallback to `{resolution.default!r}`{diag}",
+            )
+
+    if not invalid:
+        embed.add_field(
+            name="Result",
+            value=f"*✅ No invalid settings.  ({scanned} setting(s) scanned.)*",
+            inline=False,
+        )
+        return embed
+
+    embed.add_field(
+        name=f"Invalid settings ({len(invalid)} of {scanned} scanned)",
+        value="\n".join(invalid)[:1024],
+        inline=False,
+    )
+    embed.set_footer(text="S6 introduces the edit flow that fixes these in place.")
+    return embed
+
+
+class _BackToHubButton(discord.ui.Button):
+    def __init__(self) -> None:
+        super().__init__(
+            label="Back to Hub",
+            style=discord.ButtonStyle.secondary,
+            emoji="↩",
+            custom_id="settings_invalid.back",
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.settings.hub import SettingsHubView
+
+        view = SettingsHubView(interaction.user)
+        await interaction.response.edit_message(
+            embed=SettingsHubView.build_embed(),
+            view=view,
+        )
+
+
+class InvalidSettingsView(HubView):
+    """Read-only diagnostic panel listing invalid resolutions."""
+
+    def __init__(self, author) -> None:
+        super().__init__(author)
+        self.add_item(_BackToHubButton())
+
+
+__all__ = ["InvalidSettingsView", "build_invalid_embed"]

--- a/disbot/views/settings/missing_bindings.py
+++ b/disbot/views/settings/missing_bindings.py
@@ -1,0 +1,108 @@
+"""MissingBindingsView — bindings whose status is not ``bound`` (S5).
+
+Read-only diagnostic that surfaces every declared :class:`BindingSpec`
+for the calling guild whose runtime status is anything other than
+``bound`` — typically ``unresolved`` (no binding row yet),
+``missing`` (the target disappeared from Discord), or ``invalid``
+(kind drift).
+"""
+
+from __future__ import annotations
+
+import discord
+
+from views.base import HubView
+
+
+async def build_missing_bindings_embed(
+    interaction: discord.Interaction,
+) -> discord.Embed:
+    embed = discord.Embed(
+        title="🔗 Missing bindings",
+        description=(
+            "Declared bindings whose runtime status is not `bound`.  "
+            "Includes unresolved slots (no row yet), targets that "
+            "disappeared from Discord, and kind-drift cases.\n"
+            "_Read-only · S5.  The S7 logging UI introduces the bind "
+            "flow that fixes these in place._"
+        ),
+        color=discord.Color.gold(),
+    )
+
+    guild_id = interaction.guild_id
+    if guild_id is None:
+        embed.add_field(
+            name="Result",
+            value="*Run this from within a guild — DM has no per-guild binding state.*",
+            inline=False,
+        )
+        return embed
+
+    from core.runtime.bindings import get_binding
+    from core.runtime.subsystem_schema import all_schemas
+
+    rows: list[str] = []
+    scanned = 0
+    for sub_name, schema in sorted(all_schemas().items()):
+        for spec in schema.bindings:
+            scanned += 1
+            try:
+                value = await get_binding(guild_id, sub_name, spec.name)
+            except Exception as exc:  # noqa: BLE001 — soft-fail per row
+                rows.append(
+                    f"`{sub_name}.{spec.name}` — get_binding raised "
+                    f"{type(exc).__name__}",
+                )
+                continue
+            if value.is_bound:
+                continue
+            required_marker = "**required**" if spec.required else "optional"
+            rows.append(
+                f"`{sub_name}.{spec.name}` ({required_marker}) — "
+                f"status=`{value.status.value}` kind=`{spec.kind.value}`",
+            )
+
+    if not rows:
+        embed.add_field(
+            name="Result",
+            value=f"*✅ Every binding is bound.  ({scanned} binding(s) scanned.)*",
+            inline=False,
+        )
+        return embed
+
+    embed.add_field(
+        name=f"Unbound or invalid bindings ({len(rows)} of {scanned} scanned)",
+        value="\n".join(rows)[:1024],
+        inline=False,
+    )
+    return embed
+
+
+class _BackToHubButton(discord.ui.Button):
+    def __init__(self) -> None:
+        super().__init__(
+            label="Back to Hub",
+            style=discord.ButtonStyle.secondary,
+            emoji="↩",
+            custom_id="settings_missing_bindings.back",
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.settings.hub import SettingsHubView
+
+        view = SettingsHubView(interaction.user)
+        await interaction.response.edit_message(
+            embed=SettingsHubView.build_embed(),
+            view=view,
+        )
+
+
+class MissingBindingsView(HubView):
+    """Read-only diagnostic panel listing unbound + invalid bindings."""
+
+    def __init__(self, author) -> None:
+        super().__init__(author)
+        self.add_item(_BackToHubButton())
+
+
+__all__ = ["MissingBindingsView", "build_missing_bindings_embed"]

--- a/disbot/views/settings/needs_setup.py
+++ b/disbot/views/settings/needs_setup.py
@@ -1,0 +1,137 @@
+"""NeedsSetupView — subsystems whose declared shape is missing setup (S5).
+
+Read-only diagnostic that lists subsystems whose
+:class:`SubsystemSchema` declares required bindings or required
+resource requirements.  In v1 the "needs setup" signal is the set
+of declared *required* binding slots — the actual binding-row
+status (bound vs unresolved) lives on the
+:class:`MissingBindingsView`.  This panel is the planning view: it
+shows what each subsystem *expects* to be configured before it
+can fully function.
+"""
+
+from __future__ import annotations
+
+import discord
+
+from utils.subsystem_registry import SUBSYSTEMS
+from views.base import HubView
+
+
+def _gather_required_bindings() -> dict[str, list[str]]:
+    """Return ``{subsystem: [required binding names]}``."""
+    from core.runtime.subsystem_schema import all_schemas
+
+    out: dict[str, list[str]] = {}
+    for name, schema in sorted(all_schemas().items()):
+        required = [b.name for b in schema.bindings if b.required]
+        if required:
+            out[name] = required
+    return out
+
+
+def _gather_required_resources() -> dict[str, list[str]]:
+    """Return ``{subsystem: [required resource intents]}``."""
+    from core.runtime.resource_specs import ProvisioningPriority
+    from core.runtime.subsystem_schema import all_schemas
+
+    out: dict[str, list[str]] = {}
+    for name, schema in sorted(all_schemas().items()):
+        required = [
+            r.intent
+            for r in schema.resource_requirements
+            if r.provisioning.priority == ProvisioningPriority.REQUIRED
+        ]
+        if required:
+            out[name] = required
+    return out
+
+
+async def build_needs_setup_embed(
+    interaction: discord.Interaction,
+) -> discord.Embed:
+    del interaction  # guild-independent view — uses declarations only
+    embed = discord.Embed(
+        title="📋 Needs setup",
+        description=(
+            "Subsystems whose schema declares **required** bindings or "
+            "resource requirements.  This shows what _should_ be "
+            "configured; the *bound vs unresolved* status of each slot "
+            "lives in the **Missing bindings** view.\n"
+            "_Read-only · S5._"
+        ),
+        color=discord.Color.gold(),
+    )
+    bindings = _gather_required_bindings()
+    resources = _gather_required_resources()
+
+    if not bindings and not resources:
+        embed.add_field(
+            name="Result",
+            value="*No subsystem declares any required bindings or resources.*",
+            inline=False,
+        )
+        return embed
+
+    if bindings:
+        lines = [
+            f"`{sub}` — required: {', '.join(f'`{b}`' for b in names)}"
+            for sub, names in sorted(bindings.items())
+        ]
+        embed.add_field(
+            name=f"Required bindings ({sum(len(v) for v in bindings.values())})",
+            value="\n".join(lines)[:1024],
+            inline=False,
+        )
+
+    if resources:
+        lines = [
+            f"`{sub}` — required: {', '.join(f'`{r}`' for r in names)}"
+            for sub, names in sorted(resources.items())
+        ]
+        embed.add_field(
+            name=f"Required resources ({sum(len(v) for v in resources.values())})",
+            value="\n".join(lines)[:1024],
+            inline=False,
+        )
+
+    # Display-only count to give an at-a-glance read of subsystem coverage.
+    declared_subs = {s for s in SUBSYSTEMS}
+    embed.set_footer(
+        text=(
+            f"{len(bindings)} subsystem(s) with required bindings · "
+            f"{len(resources)} with required resources · "
+            f"{len(declared_subs)} subsystems total."
+        ),
+    )
+    return embed
+
+
+class _BackToHubButton(discord.ui.Button):
+    def __init__(self) -> None:
+        super().__init__(
+            label="Back to Hub",
+            style=discord.ButtonStyle.secondary,
+            emoji="↩",
+            custom_id="settings_needs_setup.back",
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.settings.hub import SettingsHubView
+
+        view = SettingsHubView(interaction.user)
+        await interaction.response.edit_message(
+            embed=SettingsHubView.build_embed(),
+            view=view,
+        )
+
+
+class NeedsSetupView(HubView):
+    """Read-only diagnostic panel listing required bindings + resources."""
+
+    def __init__(self, author) -> None:
+        super().__init__(author)
+        self.add_item(_BackToHubButton())
+
+
+__all__ = ["NeedsSetupView", "build_needs_setup_embed"]

--- a/disbot/views/settings/subsystem_view.py
+++ b/disbot/views/settings/subsystem_view.py
@@ -1,0 +1,249 @@
+"""SubsystemSettingsView — per-subsystem read-only drill-down (S5).
+
+Renders the long-term subsystem-page shape:
+
+* Header: subsystem display name + visibility tier + emoji.
+* Scalar settings — pulled from :mod:`services.settings_resolution`
+  per-guild so the panel shows the *current* effective value, its
+  provenance, validity, and declared default.
+* Bindings — declared :class:`BindingSpec`s with kind + required +
+  hint.  The S5 view does NOT call into bindings runtime — it just
+  shows the declared shape.  S7 onward consumes
+  :func:`core.runtime.bindings.get_binding` to surface the current
+  bound resource.
+* Resource requirements — declared :class:`ResourceRequirement`s with
+  priority + suggested name.
+* Related cog panel — if the subsystem declares panel-shaped
+  ``entry_points`` (anything ending in ``menu``), they are listed
+  for quick reference.
+* "↩ Back to Hub" button.
+
+S5 is strictly read-only.  No edit / reset / mutate controls.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import discord
+
+from utils.subsystem_registry import SUBSYSTEMS
+from views.base import HubView
+
+logger = logging.getLogger("bot.views.settings.subsystem_view")
+
+
+_FIELD_VALUE_CAP = 1000
+
+
+def _truncate(text: str, *, limit: int = _FIELD_VALUE_CAP) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "…"
+
+
+async def _resolve_settings_block(
+    guild_id: int | None,
+    subsystem: str,
+) -> list[str]:
+    """Return one rendered line per declared SettingSpec.
+
+    Uses :func:`services.settings_resolution.resolve_setting` so the
+    rendered value reflects current cache / KV state, the
+    provenance, and the validity flag.  When ``guild_id`` is None
+    (DM invocation) the value column shows the declared default.
+    """
+    from core.runtime.subsystem_schema import get_schema
+
+    schema = get_schema(subsystem)
+    if schema is None or not schema.settings:
+        return []
+    lines: list[str] = []
+    if guild_id is None:
+        for spec in schema.settings:
+            lines.append(
+                f"`{spec.name}` — type=`{spec.value_type.__name__}` "
+                f"default=`{spec.default!r}` *(no guild context)*",
+            )
+        return lines
+    from services.settings_resolution import resolve_setting
+
+    for spec in schema.settings:
+        try:
+            resolution = await resolve_setting(guild_id, subsystem, spec.name)
+        except Exception as exc:  # noqa: BLE001 — fail-soft per panel field
+            lines.append(
+                f"`{spec.name}` — ❌ resolver raised: "
+                f"{type(exc).__name__}: {exc!s:.80}",
+            )
+            continue
+        if resolution is None:
+            lines.append(f"`{spec.name}` — *(resolver returned None)*")
+            continue
+        validity = "valid" if resolution.valid else "**invalid**"
+        prov = resolution.provenance
+        lines.append(
+            f"`{spec.name}` = `{resolution.value!r}` "
+            f"(`{prov}`, default=`{resolution.default!r}`, {validity})",
+        )
+    return lines
+
+
+def _bindings_block(subsystem: str) -> list[str]:
+    from core.runtime.subsystem_schema import get_schema
+
+    schema = get_schema(subsystem)
+    if schema is None or not schema.bindings:
+        return []
+    out: list[str] = []
+    for spec in schema.bindings:
+        required = "required" if spec.required else "optional"
+        cap = f"cap=`{spec.capability_required}`" if spec.capability_required else ""
+        out.append(
+            f"`{spec.name}` — kind=`{spec.kind.value}` ({required}) {cap}".rstrip(),
+        )
+    return out
+
+
+def _resources_block(subsystem: str) -> list[str]:
+    from core.runtime.subsystem_schema import get_schema
+
+    schema = get_schema(subsystem)
+    if schema is None or not schema.resource_requirements:
+        return []
+    out: list[str] = []
+    for req in schema.resource_requirements:
+        suggested = (
+            f" → `{req.provisioning.suggested_name}`"
+            if req.provisioning.suggested_name
+            else ""
+        )
+        out.append(
+            f"`{req.intent}` — kind=`{req.kind.value}` "
+            f"priority=`{req.provisioning.priority.value}`"
+            f"{suggested} (binding=`{req.binding_name}`)",
+        )
+    return out
+
+
+def _related_commands_block(subsystem: str) -> list[str]:
+    """List the subsystem's entry_points so the operator can jump to
+    the existing cog panel (e.g. ``!xpmenu``).  Read-only — this is
+    just a documentation aid.
+    """
+    meta = SUBSYSTEMS.get(subsystem)
+    if not meta:
+        return []
+    entry_points = meta.get("entry_points") or ()
+    if not entry_points:
+        return []
+    return [f"`!{ep}`" for ep in entry_points]
+
+
+async def build_subsystem_embed(
+    interaction: discord.Interaction,
+    subsystem: str,
+) -> discord.Embed:
+    """Build the per-subsystem read-only embed for ``!settings``.
+
+    Args:
+        interaction: The interaction whose ``guild_id`` drives
+            per-guild value resolution.  ``None`` (DM) renders the
+            schema declaration only.
+        subsystem: The SUBSYSTEMS key.
+    """
+    meta = SUBSYSTEMS.get(subsystem) or {}
+    title_emoji = meta.get("emoji", "⚙️")
+    display = meta.get("display_name", subsystem)
+    tier = meta.get("visibility_tier", "—")
+    desc = meta.get("description", "")
+
+    guild_id = interaction.guild_id
+
+    embed = discord.Embed(
+        title=f"{title_emoji} {display}",
+        description=(
+            f"_{desc}_\n"
+            f"visibility tier: `{tier}`  ·  "
+            f"subsystem key: `{subsystem}`"
+        ),
+        color=discord.Color.blurple(),
+    )
+
+    setting_lines = await _resolve_settings_block(guild_id, subsystem)
+    if setting_lines:
+        embed.add_field(
+            name="Scalar settings",
+            value=_truncate("\n".join(setting_lines)),
+            inline=False,
+        )
+    else:
+        embed.add_field(
+            name="Scalar settings",
+            value="*none declared*",
+            inline=False,
+        )
+
+    binding_lines = _bindings_block(subsystem)
+    if binding_lines:
+        embed.add_field(
+            name="Bindings",
+            value=_truncate("\n".join(binding_lines)),
+            inline=False,
+        )
+
+    resource_lines = _resources_block(subsystem)
+    if resource_lines:
+        embed.add_field(
+            name="Provisionable resources",
+            value=_truncate("\n".join(resource_lines)),
+            inline=False,
+        )
+
+    related = _related_commands_block(subsystem)
+    if related:
+        embed.add_field(
+            name="Existing command panels",
+            value=", ".join(related),
+            inline=False,
+        )
+
+    embed.set_footer(
+        text=(
+            f"Read-only · S5.  Edit / reset arrive in S6.  "
+            f"guild_id={guild_id if guild_id is not None else 'DM'}"
+        ),
+    )
+    return embed
+
+
+class _BackToHubButton(discord.ui.Button):
+    def __init__(self) -> None:
+        super().__init__(
+            label="Back to Hub",
+            style=discord.ButtonStyle.secondary,
+            emoji="↩",
+            custom_id="settings_subsystem.back_to_hub",
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.settings.hub import SettingsHubView
+
+        view = SettingsHubView(interaction.user)
+        await interaction.response.edit_message(
+            embed=SettingsHubView.build_embed(),
+            view=view,
+        )
+
+
+class SubsystemSettingsView(HubView):
+    """Per-subsystem read-only drill-down panel."""
+
+    def __init__(self, author: Any, subsystem: str) -> None:
+        super().__init__(author)
+        self.subsystem = subsystem
+        self.add_item(_BackToHubButton())
+
+
+__all__ = ["SubsystemSettingsView", "build_subsystem_embed"]

--- a/docs/settings-customization-command-map.md
+++ b/docs/settings-customization-command-map.md
@@ -867,6 +867,66 @@ Subsystems (21): `admin`, `moderation`, `economy`, `inventory`, `mining`,
     (`!platform resources`).
 
 
+### settings
+
+1. **cog_module**: `disbot/cogs/settings_cog.py` (added in S5).
+2. **subsystem**: `settings`
+3. **current_commands**: `!settings` (group root that opens the Settings
+   Manager hub).
+4. **current_command_groups**: `!settings` (administrator-tier; entry
+   point declared in `SUBSYSTEMS["settings"].entry_points`).
+5. **current_command_panel_or_menu**: `!settings` IS the panel command;
+   no `*menu` alias.
+6. **help_menu_discoverable**: Yes via SUBSYSTEMS — registered in
+   `utils.subsystem_registry.SUBSYSTEMS` at admin tier with
+   `entry_points=["settings"]`.
+7. **dedicated_panel_command**: `!settings` (the cog's only command).
+8. **help_menu_direct_navigation_hook**: Yes — `SettingsCog.build_help_menu_view`
+   returns the same `(embed, view)` the `!settings` command produces, so
+   the help dropdown navigates straight into the hub.
+9. **existing_SettingSpec_declarations**: none. The cog itself does not
+   declare scalar settings; it is a read-only browser over the *other*
+   subsystems' schemas.  A future PR may add cog-local preferences
+   (e.g. `hub_page_size`) if needed.
+10. **existing_settings_keys**: none.
+11. **existing_BindingSpec_entries**: none.
+12. **existing_ResourceRequirement_entries**: none.
+13. **current_access_policy_behavior**: `visibility_tier=administrator`;
+    capabilities `settings.manager.view`.  Runtime behaviour gated on
+    the `settings.manager_cog.enabled` feature flag (default OFF) —
+    when OFF, invocations return a clearly-worded disabled embed.
+14. **hardcoded_or_env_only_behavior**: none.  The S5 view module
+    composes S1 (`SettingsRegistry`), S2 (`CustomizationCatalogue`),
+    S3 (`SettingsResolution`), S4 (`settings_mutation_audit`), and
+    `core.runtime.bindings.get_binding` for read-only rendering.
+15. **missing_customization_commands**: none.  The hub already
+    surfaces every subsystem's settings/bindings/resources page.
+16. **missing_settings_pages**: edit / reset flows (S6); logging
+    create-or-select flow (S7); cleanup expansion (S8); access policy
+    manager (S9); per-subsystem setup packs (S10).
+17. **missing_menu_buttons_selects_modals**: scalar-edit modals (S6);
+    binding-select views (S7+); reset buttons (S6); setup-pack
+    confirmation modals (S10).
+18. **setting_class_per_value**: n/a — this subsystem is the
+    *management surface* for every other subsystem's settings, not a
+    settings consumer itself.
+19. **target_Settings_Manager_page**: `!settings` (this cog hosts the
+    hub).
+20. **target_mutation_path**: read-only in S5; consumes
+    `SettingsMutationPipeline` (S4) for S6+, `BindingMutationPipeline`
+    + `ResourceProvisioningPipeline` (S4.5) for S7+,
+    `GovernanceMutationPipeline` for S9.
+21. **target_help_or_menu_route**: Help direct-nav (already wired);
+    `!adminmenu` and `!platform` deep-links land in S11.
+22. **provisionable_resources**: none.  The Settings Manager UI runs
+    in any text channel; it does not require dedicated channels or
+    roles.
+23. **priority**: `P0` — gates discoverability for every other
+    subsystem's settings page.
+24. **recommended_PR_phase**: S5 (this cog) + S6 (edit/reset) + S7+
+    (per-subsystem write surfaces).
+
+
 ## Setting class summary
 
 Cross-cut by class, this is the work distribution implied by the per-cog

--- a/tests/unit/cogs/test_settings_cog.py
+++ b/tests/unit/cogs/test_settings_cog.py
@@ -1,0 +1,182 @@
+"""Unit tests for cogs.settings_cog — S5.
+
+Covers cog registration, the SUBSYSTEMS entry, the feature-flag
+gate (ON / OFF), the !settings command behaviour, and the
+build_help_menu_view direct-navigation hook.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cogs import settings_cog
+from core.runtime import feature_flags
+from utils.subsystem_registry import SUBSYSTEMS
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeGuild:
+    def __init__(self, guild_id: int = 1):
+        self.id = guild_id
+
+
+class _FakeMember:
+    def __init__(self, member_id: int = 7):
+        self.id = member_id
+
+
+class _FakeContext:
+    def __init__(self, guild: _FakeGuild | None = None):
+        self.guild = guild
+        self.author = _FakeMember()
+        self.sent_embeds: list = []
+        self.channel = self
+
+    async def send(self, *args, **kwargs):
+        embed = kwargs.get("embed")
+        if embed is not None:
+            self.sent_embeds.append(embed)
+
+        class _Msg:
+            id = 1
+
+        return _Msg()
+
+
+class _FakeInteraction:
+    def __init__(self, guild_id: int | None = 1):
+        self.guild_id = guild_id
+        self.user = _FakeMember()
+
+
+# ---------------------------------------------------------------------------
+# SUBSYSTEMS entry
+# ---------------------------------------------------------------------------
+
+
+def test_settings_subsystem_registered():
+    assert "settings" in SUBSYSTEMS
+    meta = SUBSYSTEMS["settings"]
+    assert meta["visibility_tier"] == "administrator"
+    assert "settings" in meta["entry_points"]
+    assert "settings.manager.view" in meta["capabilities"]
+
+
+def test_settings_subsystem_emoji_and_display_name():
+    meta = SUBSYSTEMS["settings"]
+    assert meta["emoji"] == "⚙️"
+    assert meta["display_name"] == "Settings Manager"
+
+
+# ---------------------------------------------------------------------------
+# Feature flag
+# ---------------------------------------------------------------------------
+
+
+def test_feature_flag_declared_default_off():
+    flag = feature_flags.get("settings.manager_cog.enabled")
+    assert flag is not None
+    assert flag.default_value is False
+    assert flag.owner == "platform"
+
+
+# ---------------------------------------------------------------------------
+# !settings command — gate behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_settings_command_returns_disabled_embed_when_flag_off(
+    monkeypatch,
+):
+    async def _flag_off(_name, _guild_id):
+        return False
+
+    monkeypatch.setattr(feature_flags, "is_enabled", _flag_off)
+    cog = settings_cog.SettingsCog(bot=None)  # type: ignore[arg-type]
+    ctx = _FakeContext(guild=_FakeGuild())
+    await cog.settings_root.callback(cog, ctx)
+    assert len(ctx.sent_embeds) == 1
+    embed = ctx.sent_embeds[0]
+    assert "disabled" in (embed.title or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_settings_command_opens_hub_when_flag_on(monkeypatch):
+    async def _flag_on(_name, _guild_id):
+        return True
+
+    monkeypatch.setattr(feature_flags, "is_enabled", _flag_on)
+    cog = settings_cog.SettingsCog(bot=None)  # type: ignore[arg-type]
+    ctx = _FakeContext(guild=_FakeGuild())
+    await cog.settings_root.callback(cog, ctx)
+    assert len(ctx.sent_embeds) == 1
+    embed = ctx.sent_embeds[0]
+    # The hub embed title is the settings emoji + name.
+    assert "Settings Manager" in (embed.title or "")
+
+
+@pytest.mark.asyncio
+async def test_settings_gate_treats_flag_failure_as_off(monkeypatch):
+    async def _flag_raises(_name, _guild_id):
+        raise RuntimeError("flag eval failure")
+
+    monkeypatch.setattr(feature_flags, "is_enabled", _flag_raises)
+    cog = settings_cog.SettingsCog(bot=None)  # type: ignore[arg-type]
+    ctx = _FakeContext(guild=_FakeGuild())
+    await cog.settings_root.callback(cog, ctx)
+    # Closed gate on failure — returns the disabled embed, not the hub.
+    assert len(ctx.sent_embeds) == 1
+    assert "disabled" in (ctx.sent_embeds[0].title or "").lower()
+
+
+# ---------------------------------------------------------------------------
+# build_help_menu_view direct-nav hook
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_help_hook_returns_hub_when_flag_on(monkeypatch):
+    async def _flag_on(_name, _guild_id):
+        return True
+
+    monkeypatch.setattr(feature_flags, "is_enabled", _flag_on)
+    cog = settings_cog.SettingsCog(bot=None)  # type: ignore[arg-type]
+    interaction = _FakeInteraction()
+    embed, view = await cog.build_help_menu_view(interaction)  # type: ignore[arg-type]
+    assert "Settings Manager" in (embed.title or "")
+    # The hub view contains a Select for subsystems + four buttons; total >= 5.
+    assert len(view.children) >= 5
+
+
+@pytest.mark.asyncio
+async def test_help_hook_returns_disabled_view_when_flag_off(monkeypatch):
+    async def _flag_off(_name, _guild_id):
+        return False
+
+    monkeypatch.setattr(feature_flags, "is_enabled", _flag_off)
+    cog = settings_cog.SettingsCog(bot=None)  # type: ignore[arg-type]
+    interaction = _FakeInteraction()
+    embed, view = await cog.build_help_menu_view(interaction)  # type: ignore[arg-type]
+    assert "disabled" in (embed.title or "").lower()
+    # The disabled-hook view ships empty (help cog appends its back button).
+    assert len(view.children) == 0
+
+
+# ---------------------------------------------------------------------------
+# Static helpers
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_embed_mentions_flag_name():
+    embed = settings_cog._disabled_embed()
+    description = embed.description or ""
+    assert "settings.manager_cog.enabled" in description
+
+
+def test_setup_function_exists_and_adds_cog():
+    """The discord.py extension entry point must exist."""
+    assert callable(settings_cog.setup)

--- a/tests/unit/invariants/test_settings_cog_read_only.py
+++ b/tests/unit/invariants/test_settings_cog_read_only.py
@@ -1,0 +1,179 @@
+"""S5 invariant — Settings Manager cog + views are strictly read-only.
+
+The S5 directive is explicit: the cog and its views must not edit,
+reset, mutate, create, or otherwise change platform state.  S6
+introduces the first write surface (scalar edit/reset flows) and
+will explicitly add the mutation imports the AST scan below
+forbids.
+
+This test fails CI if any file under:
+
+  * ``disbot/cogs/settings*``
+  * ``disbot/views/settings/**``
+
+imports any mutation pipeline or directly invokes a mutation
+method.  When S6 lands, this invariant tightens to allow the
+expected mutation imports inside an allowlist of edit-flow files.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DISBOT = _REPO_ROOT / "disbot"
+
+
+# Modules and functions whose presence inside Settings Manager UI
+# would imply a write path.  These are not exhaustive; they cover
+# the four mutation pipelines + a few common write-shape callables.
+_FORBIDDEN_IMPORT_PREFIXES: frozenset[str] = frozenset(
+    {
+        "services.settings_mutation",
+        "services.binding_mutation",
+        "services.resource_provisioning",  # creator/binder of Discord resources
+        "services.participation_mutation",
+        "services.rollout_mutation",
+        "governance.writes",
+    },
+)
+
+# Discord-API resource-create methods.  Any reference inside the
+# settings UI surface would be a violation regardless of how they
+# are invoked.
+_FORBIDDEN_DIRECT_METHODS: frozenset[str] = frozenset(
+    {
+        "create_text_channel",
+        "create_voice_channel",
+        "create_category",
+        "create_category_channel",
+        "create_role",
+        "create_thread",
+    },
+)
+
+# Mutation methods on the four canonical pipelines.  Catches the
+# case where someone imports the pipeline by another name and then
+# calls these via attribute access — defense-in-depth above the
+# import-level scan.
+_FORBIDDEN_METHOD_CALLS: frozenset[str] = frozenset(
+    {
+        "set_value",  # SettingsMutationPipeline.set_value
+        "set_binding",  # BindingMutationPipeline.set_binding
+        "clear_binding",  # BindingMutationPipeline.clear_binding
+        "set_visibility",  # GovernanceMutationPipeline.set_visibility
+        "set_cleanup_policy",
+        "set_cleanup_policy_for_scope",
+        "provision",  # ResourceProvisioningPipeline.provision
+    },
+)
+
+
+def _settings_ui_paths() -> list[Path]:
+    """Return every production .py file inside the Settings Manager UI surface."""
+    out: list[Path] = []
+    for candidate in [
+        _DISBOT / "cogs" / "settings_cog.py",
+        *(_DISBOT / "cogs" / "settings").rglob("*.py"),
+        *(_DISBOT / "views" / "settings").rglob("*.py"),
+    ]:
+        if "__pycache__" in candidate.parts:
+            continue
+        if candidate.exists():
+            out.append(candidate)
+    return out
+
+
+def _module_imports_offenders(tree: ast.AST) -> list[str]:
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            for needle in _FORBIDDEN_IMPORT_PREFIXES:
+                if node.module == needle or node.module.startswith(needle + "."):
+                    offenders.append(
+                        f"from {node.module} import "
+                        f"{', '.join(a.name for a in node.names)}",
+                    )
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                for needle in _FORBIDDEN_IMPORT_PREFIXES:
+                    if alias.name == needle or alias.name.startswith(needle + "."):
+                        offenders.append(f"import {alias.name}")
+    return offenders
+
+
+def _attribute_call_offenders(tree: ast.AST) -> list[str]:
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        attr = node.func.attr
+        if attr in _FORBIDDEN_DIRECT_METHODS or attr in _FORBIDDEN_METHOD_CALLS:
+            offenders.append(attr)
+    return offenders
+
+
+def test_settings_ui_has_no_mutation_imports():
+    """No file under the Settings Manager UI surface may import a
+    mutation pipeline.
+    """
+    paths = _settings_ui_paths()
+    assert paths, "settings UI paths empty — sanity check failed"
+    violations: list[tuple[str, list[str]]] = []
+    for path in paths:
+        tree = ast.parse(path.read_text(), filename=str(path))
+        offenders = _module_imports_offenders(tree)
+        if offenders:
+            violations.append((str(path.relative_to(_REPO_ROOT)), offenders))
+    assert not violations, (
+        "S5 invariant violation: Settings Manager UI surface imports a "
+        "mutation pipeline.  S5 is strictly read-only; S6 introduces the "
+        "first edit/reset flow.\n\n"
+        + "\n".join(f"  {p}: {imps}" for p, imps in violations)
+    )
+
+
+def test_settings_ui_does_not_call_known_mutation_methods():
+    """No file under the Settings Manager UI surface may *call* any
+    of the canonical mutation methods (or any Discord-API create
+    method).  Defense-in-depth above the import scan.
+    """
+    paths = _settings_ui_paths()
+    violations: list[tuple[str, list[str]]] = []
+    for path in paths:
+        tree = ast.parse(path.read_text(), filename=str(path))
+        offenders = _attribute_call_offenders(tree)
+        if offenders:
+            violations.append((str(path.relative_to(_REPO_ROOT)), offenders))
+    assert not violations, (
+        "S5 invariant violation: Settings Manager UI calls a mutation "
+        "or resource-creation method.  S5 is strictly read-only.\n\n"
+        + "\n".join(f"  {p}: {calls}" for p, calls in violations)
+    )
+
+
+def test_settings_ui_paths_contain_expected_files():
+    """The scanner must actually find the S5 files we ship.
+
+    Otherwise a renamed-file refactor could weaken the invariant
+    silently.
+    """
+    paths = {p.relative_to(_REPO_ROOT) for p in _settings_ui_paths()}
+    expected_relpaths = {
+        Path("disbot/cogs/settings_cog.py"),
+        Path("disbot/cogs/settings/__init__.py"),
+        Path("disbot/views/settings/__init__.py"),
+        Path("disbot/views/settings/hub.py"),
+        Path("disbot/views/settings/subsystem_view.py"),
+        Path("disbot/views/settings/needs_setup.py"),
+        Path("disbot/views/settings/invalid_settings.py"),
+        Path("disbot/views/settings/missing_bindings.py"),
+        Path("disbot/views/settings/audit_view.py"),
+    }
+    missing = expected_relpaths - paths
+    assert (
+        not missing
+    ), "S5 invariant scanner did not pick up these expected files:\n" + "\n".join(
+        f"  {p}" for p in sorted(missing)
+    )

--- a/tests/unit/views/test_settings_diagnostic_subviews.py
+++ b/tests/unit/views/test_settings_diagnostic_subviews.py
@@ -1,0 +1,295 @@
+"""Unit tests for the four read-only diagnostic sub-panels — S5.
+
+Covers NeedsSetupView / InvalidSettingsView / MissingBindingsView /
+RecentChangesView: their embed shape, empty-state behaviour, and
+the "Back to Hub" navigation button.
+"""
+
+from __future__ import annotations
+
+import discord
+import pytest
+
+from core.runtime import settings_registry
+from core.runtime import subsystem_schema as schema_mod
+from core.runtime.resource_specs import (
+    ProvisioningHint,
+    ProvisioningPriority,
+    ResourceKind,
+    ResourceRequirement,
+)
+from core.runtime.subsystem_schema import (
+    BindingKind,
+    BindingSpec,
+    SettingSpec,
+    SubsystemSchema,
+)
+from utils.db import settings as settings_db
+from views.settings.audit_view import RecentChangesView, build_audit_embed
+from views.settings.invalid_settings import (
+    InvalidSettingsView,
+    build_invalid_embed,
+)
+from views.settings.missing_bindings import (
+    MissingBindingsView,
+    build_missing_bindings_embed,
+)
+from views.settings.needs_setup import NeedsSetupView, build_needs_setup_embed
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(monkeypatch):
+    saved_schemas = schema_mod.all_schemas()
+    schema_mod._reset_for_tests()
+    settings_registry._reset_for_tests()
+    from core.runtime import guild_config
+
+    guild_config._reset_for_tests()
+    _kv: dict[tuple[int, str], str] = {}
+
+    async def _fake_get_setting(
+        guild_id: int,
+        key: str,
+        default: str = "",
+    ) -> str:
+        return _kv.get((guild_id, key), default)
+
+    monkeypatch.setattr(settings_db, "get_setting", _fake_get_setting)
+    from utils import db as db_pkg
+
+    monkeypatch.setattr(db_pkg, "get_setting", _fake_get_setting)
+    yield {"kv": _kv}
+    schema_mod._reset_for_tests()
+    for schema in saved_schemas.values():
+        schema_mod.register(schema)
+    settings_registry._reset_for_tests()
+    guild_config._reset_for_tests()
+
+
+class _FakeInteraction:
+    def __init__(self, guild_id: int | None = 1):
+        self.guild_id = guild_id
+
+
+def _author():
+    class _M:
+        id = 1
+
+    return _M()
+
+
+# ---------------------------------------------------------------------------
+# Needs setup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_needs_setup_empty_state():
+    embed = await build_needs_setup_embed(_FakeInteraction())
+    assert "Needs setup" in (embed.title or "")
+    result = next(f.value for f in embed.fields if f.name == "Result")
+    assert "no subsystem" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_needs_setup_lists_required_bindings_and_resources():
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="moderation",
+            bindings=(
+                BindingSpec(
+                    name="mod_log",
+                    kind=BindingKind.CHANNEL,
+                    required=True,
+                    hint="x",
+                    capability_required="moderation.log.view",
+                ),
+            ),
+            resource_requirements=(
+                ResourceRequirement(
+                    kind=ResourceKind.CHANNEL,
+                    intent="mod_log",
+                    provisioning=ProvisioningHint(
+                        priority=ProvisioningPriority.REQUIRED,
+                        suggested_name="mod-logs",
+                    ),
+                    binding_name="mod_log",
+                ),
+            ),
+        ),
+    )
+    embed = await build_needs_setup_embed(_FakeInteraction())
+    field_names = [f.name for f in embed.fields]
+    binding_field = next(n for n in field_names if "Required bindings" in n)
+    resource_field = next(n for n in field_names if "Required resources" in n)
+    assert "moderation" in next(
+        f.value for f in embed.fields if f.name == binding_field
+    )
+    assert "moderation" in next(
+        f.value for f in embed.fields if f.name == resource_field
+    )
+
+
+def test_needs_setup_view_has_back_button():
+    view = NeedsSetupView(_author())
+    buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+    assert len(buttons) == 1
+    assert "Back" in (buttons[0].label or "")
+
+
+# ---------------------------------------------------------------------------
+# Invalid settings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalid_settings_dm_invocation_shows_helpful_message():
+    embed = await build_invalid_embed(_FakeInteraction(guild_id=None))
+    result = next(f.value for f in embed.fields if f.name == "Result")
+    assert "guild" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_invalid_settings_no_violations():
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="xp",
+            settings=(
+                SettingSpec(
+                    name="xp_min",
+                    value_type=int,
+                    default=1,
+                    settings_key="XP_MIN",
+                ),
+            ),
+        ),
+    )
+    embed = await build_invalid_embed(_FakeInteraction(guild_id=1))
+    result = next(f.value for f in embed.fields if f.name == "Result")
+    assert "no invalid" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_invalid_settings_flags_uncoerced_kv_row(_isolated_state):
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="xp",
+            settings=(
+                SettingSpec(
+                    name="xp_min",
+                    value_type=int,
+                    default=1,
+                    settings_key="XP_MIN",
+                ),
+            ),
+        ),
+    )
+    _isolated_state["kv"][(1, "XP_MIN")] = "garbage"
+    embed = await build_invalid_embed(_FakeInteraction(guild_id=1))
+    field_names = [f.name for f in embed.fields]
+    invalid_field = next(n for n in field_names if "Invalid settings" in n)
+    block = next(f.value for f in embed.fields if f.name == invalid_field)
+    assert "xp.xp_min" in block
+    assert "garbage" in block
+
+
+def test_invalid_view_has_back_button():
+    view = InvalidSettingsView(_author())
+    buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+    assert len(buttons) == 1
+
+
+# ---------------------------------------------------------------------------
+# Missing bindings — DM and no-bindings paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_bindings_dm_invocation_shows_helpful_message():
+    embed = await build_missing_bindings_embed(_FakeInteraction(guild_id=None))
+    result = next(f.value for f in embed.fields if f.name == "Result")
+    assert "guild" in result.lower()
+
+
+def test_missing_bindings_view_has_back_button():
+    view = MissingBindingsView(_author())
+    buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+    assert len(buttons) == 1
+
+
+# ---------------------------------------------------------------------------
+# Recent changes (audit view)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_audit_view_dm_invocation_shows_helpful_message():
+    embed = await build_audit_embed(_FakeInteraction(guild_id=None))
+    result = next(f.value for f in embed.fields if f.name == "Result")
+    assert "guild" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_audit_view_handles_missing_table_gracefully(monkeypatch):
+    """When the audit table query raises (e.g. migration not applied
+    yet), the embed surfaces a helpful message rather than blowing up.
+    """
+    from utils.db import settings_audit
+
+    async def _raises(*_a, **_kw):
+        raise RuntimeError('relation "settings_mutation_audit" does not exist')
+
+    monkeypatch.setattr(settings_audit, "list_recent_for_guild", _raises)
+    embed = await build_audit_embed(_FakeInteraction(guild_id=1))
+    block = next(f.value for f in embed.fields if f.name == "Audit table")
+    assert "Could not read" in block
+
+
+@pytest.mark.asyncio
+async def test_audit_view_empty_result(monkeypatch):
+    from utils.db import settings_audit
+
+    async def _empty(*_a, **_kw):
+        return []
+
+    monkeypatch.setattr(settings_audit, "list_recent_for_guild", _empty)
+    embed = await build_audit_embed(_FakeInteraction(guild_id=1))
+    result = next(f.value for f in embed.fields if f.name == "Result")
+    assert "no audit" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_audit_view_renders_recent_rows(monkeypatch):
+    from datetime import datetime, timezone
+
+    from utils.db import settings_audit
+
+    async def _two_rows(*_a, **_kw):
+        return [
+            {
+                "id": 2,
+                "mutation_id": "abc",
+                "guild_id": 1,
+                "subsystem": "xp",
+                "name": "xp_min",
+                "settings_key": "XP_MIN",
+                "prev_value_raw": "5",
+                "new_value_raw": "10",
+                "actor_id": 99,
+                "actor_type": "user",
+                "mutation_type": "set_value",
+                "at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+            },
+        ]
+
+    monkeypatch.setattr(settings_audit, "list_recent_for_guild", _two_rows)
+    embed = await build_audit_embed(_FakeInteraction(guild_id=1))
+    field = next(f for f in embed.fields if "change" in f.name.lower())
+    assert "xp.xp_min" in field.value
+    assert "`'10'`" in field.value or "10" in field.value
+
+
+def test_recent_changes_view_has_back_button():
+    view = RecentChangesView(_author())
+    buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+    assert len(buttons) == 1

--- a/tests/unit/views/test_settings_hub_view.py
+++ b/tests/unit/views/test_settings_hub_view.py
@@ -1,0 +1,132 @@
+"""Unit tests for the Settings Manager hub view — S5.
+
+The hub is the read-only navigation root: header counters + a
+subsystem dropdown + four diagnostic-panel buttons.
+"""
+
+from __future__ import annotations
+
+import discord
+import pytest
+
+from core.runtime import settings_registry
+from core.runtime import subsystem_schema as schema_mod
+from core.runtime.subsystem_schema import SettingSpec, SubsystemSchema
+from views.settings.hub import SettingsHubView, _candidate_subsystems
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state():
+    saved_schemas = schema_mod.all_schemas()
+    schema_mod._reset_for_tests()
+    settings_registry._reset_for_tests()
+    yield
+    schema_mod._reset_for_tests()
+    for schema in saved_schemas.values():
+        schema_mod.register(schema)
+    settings_registry._reset_for_tests()
+
+
+def _author():
+    class _M:
+        id = 1
+
+    return _M()
+
+
+def test_hub_embed_has_title_and_inventory_field():
+    embed = SettingsHubView.build_embed()
+    assert "Settings Manager" in (embed.title or "")
+    field_names = [f.name for f in embed.fields]
+    assert "Inventory" in field_names
+    assert "Customization findings" in field_names
+
+
+def test_hub_view_contains_subsystem_dropdown_and_four_buttons():
+    view = SettingsHubView(_author())
+    # 1 Select + 4 Buttons = 5 items.
+    assert len(view.children) == 5
+    selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
+    buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+    assert len(selects) == 1
+    assert len(buttons) == 4
+
+
+def test_hub_dropdown_lists_registered_subsystems():
+    # Register one schema so we know the dropdown sees it; do NOT clear
+    # SUBSYSTEMS — _candidate_subsystems shows every subsystem in
+    # SUBSYSTEMS, not only ones with schemas.
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="xp",
+            settings=(SettingSpec(name="xp_min", value_type=int, default=1),),
+        ),
+    )
+    candidates = _candidate_subsystems()
+    candidate_names = {c[0] for c in candidates}
+    assert "xp" in candidate_names
+    assert "moderation" in candidate_names  # in SUBSYSTEMS, no schema needed
+
+
+def test_hub_dropdown_options_capped_to_discord_limit():
+    view = SettingsHubView(_author())
+    select = next(c for c in view.children if isinstance(c, discord.ui.Select))
+    assert len(select.options) <= 25  # Discord's hard cap
+
+
+def test_button_labels_match_directive():
+    """The four sub-panel buttons must match the directive's vocabulary."""
+    view = SettingsHubView(_author())
+    buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+    labels = {b.label for b in buttons}
+    assert labels == {
+        "Needs setup",
+        "Invalid settings",
+        "Missing bindings",
+        "Recent changes",
+    }
+
+
+def test_hub_inventory_reflects_registered_settings():
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="xp",
+            settings=(
+                SettingSpec(name="xp_min", value_type=int, default=1),
+                SettingSpec(name="xp_max", value_type=int, default=10),
+            ),
+        ),
+    )
+    settings_registry.build_registry()
+    embed = SettingsHubView.build_embed()
+    inventory = next(f.value for f in embed.fields if f.name == "Inventory")
+    assert "`settings`: 2" in inventory
+
+
+def test_hub_inventory_reflects_registered_bindings():
+    from core.runtime.subsystem_schema import BindingKind, BindingSpec
+
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="moderation",
+            bindings=(
+                BindingSpec(
+                    name="mod_log",
+                    kind=BindingKind.CHANNEL,
+                    required=True,
+                    hint="mod log target",
+                    capability_required="moderation.log.view",
+                ),
+            ),
+        ),
+    )
+    embed = SettingsHubView.build_embed()
+    inventory = next(f.value for f in embed.fields if f.name == "Inventory")
+    assert "`bindings`: 1" in inventory
+
+
+def test_hub_handles_no_settings_registry_built():
+    """When SettingsRegistry has not been built, settings count is 0."""
+    embed = SettingsHubView.build_embed()
+    inventory = next(f.value for f in embed.fields if f.name == "Inventory")
+    assert "`settings`: 0" in inventory

--- a/tests/unit/views/test_subsystem_settings_view.py
+++ b/tests/unit/views/test_subsystem_settings_view.py
@@ -1,0 +1,286 @@
+"""Unit tests for the per-subsystem read-only drill-down view — S5."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.runtime import settings_registry
+from core.runtime import subsystem_schema as schema_mod
+from core.runtime.resource_specs import (
+    ProvisioningHint,
+    ProvisioningPriority,
+    ResourceKind,
+    ResourceRequirement,
+)
+from core.runtime.subsystem_schema import (
+    BindingKind,
+    BindingSpec,
+    SettingSpec,
+    SubsystemSchema,
+)
+from utils.db import settings as settings_db
+from views.settings.subsystem_view import (
+    SubsystemSettingsView,
+    build_subsystem_embed,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(monkeypatch):
+    saved_schemas = schema_mod.all_schemas()
+    schema_mod._reset_for_tests()
+    settings_registry._reset_for_tests()
+
+    # In-memory KV.  Tests pre-populate to drive resolver output.
+    _kv: dict[tuple[int, str], str] = {}
+
+    async def _fake_get_setting(
+        guild_id: int,
+        key: str,
+        default: str = "",
+    ) -> str:
+        return _kv.get((guild_id, key), default)
+
+    monkeypatch.setattr(settings_db, "get_setting", _fake_get_setting)
+    # Also patch the re-export at utils.db so the typed accessor sees it.
+    from utils import db as db_pkg
+
+    monkeypatch.setattr(db_pkg, "get_setting", _fake_get_setting)
+
+    # Reset guild_config cache between tests so resolutions reflect _kv.
+    from core.runtime import guild_config
+
+    guild_config._reset_for_tests()
+
+    yield {"kv": _kv}
+
+    schema_mod._reset_for_tests()
+    for schema in saved_schemas.values():
+        schema_mod.register(schema)
+    settings_registry._reset_for_tests()
+    guild_config._reset_for_tests()
+
+
+class _FakeInteraction:
+    def __init__(self, guild_id: int | None = 1):
+        self.guild_id = guild_id
+
+
+def _author():
+    class _M:
+        id = 1
+
+    return _M()
+
+
+# ---------------------------------------------------------------------------
+# Embed shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_embed_titles_with_subsystem_emoji_and_display_name():
+    embed = await build_subsystem_embed(_FakeInteraction(), "moderation")
+    # The moderation subsystem's emoji is 🔨 per SUBSYSTEMS.
+    assert "🔨" in (embed.title or "")
+    assert "Moderation" in (embed.title or "")
+
+
+@pytest.mark.asyncio
+async def test_embed_shows_visibility_tier_in_description():
+    embed = await build_subsystem_embed(_FakeInteraction(), "moderation")
+    assert "moderator" in (embed.description or "")
+
+
+@pytest.mark.asyncio
+async def test_embed_lists_scalar_settings_with_provenance(_isolated_state):
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="moderation",
+            settings=(
+                SettingSpec(
+                    name="warn_threshold",
+                    value_type=int,
+                    default=3,
+                    settings_key="WARN_THRESHOLD",
+                ),
+            ),
+        ),
+    )
+    _isolated_state["kv"][(1, "WARN_THRESHOLD")] = "5"
+    embed = await build_subsystem_embed(_FakeInteraction(guild_id=1), "moderation")
+    field_names = [f.name for f in embed.fields]
+    assert "Scalar settings" in field_names
+    block = next(f.value for f in embed.fields if f.name == "Scalar settings")
+    # legacy_kv provenance + the coerced value 5 should appear.
+    assert "warn_threshold" in block
+    assert "legacy_kv" in block
+    assert "valid" in block.lower()
+
+
+@pytest.mark.asyncio
+async def test_embed_lists_bindings_with_kind_and_required(_isolated_state):
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="logging",
+            bindings=(
+                BindingSpec(
+                    name="mod_channel",
+                    kind=BindingKind.CHANNEL,
+                    required=False,
+                    hint="The mod log channel.",
+                    capability_required="logging.settings.configure",
+                ),
+            ),
+        ),
+    )
+    embed = await build_subsystem_embed(_FakeInteraction(), "moderation")
+    # "logging" subsystem has the binding; but if we use "moderation" no field
+    # is shown.  Re-run with logging subsystem:
+    embed = await build_subsystem_embed(_FakeInteraction(), "logging")
+    # logging isn't in SUBSYSTEMS so the embed will still render — bindings
+    # field should still appear because the schema is registered for the key
+    # "logging".  This validates the binding renderer is data-driven.
+    field_names = [f.name for f in embed.fields]
+    assert "Bindings" in field_names
+    block = next(f.value for f in embed.fields if f.name == "Bindings")
+    assert "mod_channel" in block
+    assert "channel" in block
+    assert "optional" in block
+
+
+@pytest.mark.asyncio
+async def test_embed_lists_provisionable_resources(_isolated_state):
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="moderation",
+            bindings=(
+                BindingSpec(
+                    name="mod_log",
+                    kind=BindingKind.CHANNEL,
+                    required=False,
+                    hint="x",
+                    capability_required="moderation.log.view",
+                ),
+            ),
+            resource_requirements=(
+                ResourceRequirement(
+                    kind=ResourceKind.CHANNEL,
+                    intent="mod_log",
+                    provisioning=ProvisioningHint(
+                        priority=ProvisioningPriority.RECOMMENDED,
+                        suggested_name="mod-logs",
+                    ),
+                    binding_name="mod_log",
+                ),
+            ),
+        ),
+    )
+    embed = await build_subsystem_embed(_FakeInteraction(), "moderation")
+    field_names = [f.name for f in embed.fields]
+    assert "Provisionable resources" in field_names
+    block = next(f.value for f in embed.fields if f.name == "Provisionable resources")
+    assert "mod_log" in block
+    assert "mod-logs" in block
+    assert "recommended" in block
+
+
+@pytest.mark.asyncio
+async def test_embed_lists_existing_command_panels():
+    embed = await build_subsystem_embed(_FakeInteraction(), "moderation")
+    field_names = [f.name for f in embed.fields]
+    assert "Existing command panels" in field_names
+    block = next(f.value for f in embed.fields if f.name == "Existing command panels")
+    # SUBSYSTEMS["moderation"].entry_points includes "modmenu".
+    assert "modmenu" in block
+
+
+@pytest.mark.asyncio
+async def test_embed_dm_invocation_shows_no_guild_context():
+    """guild_id=None (DM) renders schema-declaration shape without
+    attempting to resolve per-guild values."""
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="moderation",
+            settings=(SettingSpec(name="x", value_type=int, default=42),),
+        ),
+    )
+    embed = await build_subsystem_embed(_FakeInteraction(guild_id=None), "moderation")
+    block = next(f.value for f in embed.fields if f.name == "Scalar settings")
+    assert "no guild context" in block.lower()
+
+
+@pytest.mark.asyncio
+async def test_embed_for_subsystem_with_no_schema_is_sparse():
+    """A subsystem that exists in SUBSYSTEMS but has no schema renders
+    an empty-state embed with the title and no scalar-settings rows."""
+    embed = await build_subsystem_embed(_FakeInteraction(), "blackjack")
+    title = embed.title or ""
+    assert "Blackjack" in title
+    block = next(f.value for f in embed.fields if f.name == "Scalar settings")
+    assert "none declared" in block.lower()
+
+
+# ---------------------------------------------------------------------------
+# View shape
+# ---------------------------------------------------------------------------
+
+
+def test_subsystem_view_has_back_button():
+    view = SubsystemSettingsView(_author(), "moderation")
+    import discord
+
+    buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+    assert len(buttons) == 1
+    assert "Back" in (buttons[0].label or "")
+
+
+def test_subsystem_view_carries_subsystem_key():
+    view = SubsystemSettingsView(_author(), "moderation")
+    assert view.subsystem == "moderation"
+
+
+# ---------------------------------------------------------------------------
+# Read-only invariant — view module surface has no mutation imports
+# ---------------------------------------------------------------------------
+
+
+def test_subsystem_view_does_not_import_mutation_pipelines():
+    """The view module must not import any mutation surface.  Pinned
+    here as a fast sanity check; the broader AST invariant lives in
+    tests/unit/invariants/test_settings_cog_read_only.py."""
+    import ast
+    from pathlib import Path
+
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "disbot"
+        / "views"
+        / "settings"
+        / "subsystem_view.py"
+    )
+    text = path.read_text()
+    tree = ast.parse(text)
+    forbidden = (
+        "settings_mutation",
+        "binding_mutation",
+        "resource_provisioning",
+        "governance.writes",
+        "participation_mutation",
+    )
+    offenders = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            for needle in forbidden:
+                if needle in node.module:
+                    offenders.append(node.module)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                for needle in forbidden:
+                    if needle in alias.name:
+                        offenders.append(alias.name)
+    assert not offenders, f"subsystem_view imports mutation surfaces: {offenders}"


### PR DESCRIPTION
## Summary

S5 of the **Global Settings & Customization Manager** roadmap.
Lands the long-term Settings Manager navigation shape — **Hub +
subsystem dropdown + four diagnostic sub-panels** — in **strictly
read-only** form.

Built on `main` at `7a9b0bc` (after S4 #97 merged and #99 presets
doc merged). Stands alone — independent of PR #98 (S4.5
`ResourceProvisioningPipeline`) because S5 is read-only and does
not invoke any mutation pipeline. S6+ extends these views with
the first edit / reset write surface.

## UX shape (per directive + `docs/operator-settings-presets.md`)

```
!settings
  -> SettingsHubView
      - overview / inventory counters
      - subsystem dropdown        (every subsystem in SUBSYSTEMS)
      - Needs setup     button -> NeedsSetupView
      - Invalid settings button -> InvalidSettingsView
      - Missing bindings button -> MissingBindingsView
      - Recent changes  button -> RecentChangesView

SubsystemSettingsView  (drill-down from the dropdown)
  - scalar settings via SettingsResolution
      (current value, provenance, default, valid flag)
  - declared BindingSpec entries  (kind / required / capability)
  - declared ResourceRequirement entries  (priority / suggested)
  - linked entry-point command panels   (e.g. !modmenu)
  - "Back to Hub" button
```

The hub is **deliberately not a flat list** — per your directive
that would not scale to 20+ subsystems. The subsystem drill-down
ships in S5 even when many pages are sparse; S6+ fills them in.

## Strict scope: read-only

S5 explicitly avoids every write surface, pinned by
`tests/unit/invariants/test_settings_cog_read_only.py`:

- No edit modals.
- No reset buttons that write.
- No resource creation.
- No binding mutation.
- No access-policy mutation.
- No cleanup-policy mutation.
- No setup wizard.
- No slash commands.

The invariant runs an AST scan over `disbot/cogs/settings*` and
`disbot/views/settings/**` and fails CI if any file imports a
mutation pipeline (`settings_mutation`, `binding_mutation`,
`resource_provisioning`, `participation_mutation`,
`rollout_mutation`, `governance.writes`) or calls a known
mutation method (`set_value`, `set_binding`, `clear_binding`,
`set_visibility`, `set_cleanup_policy*`, `provision`) or a
`guild.create_*` method.

## Discoverability + flag gating (per directive)

- **Cog always loads** and registers in
  `utils.subsystem_registry.SUBSYSTEMS` as an admin-tier entry
  with `entry_points=["settings"]` and capability
  `settings.manager.view`. Help / admin / menu discoverability
  stays stable regardless of the gate flag.
- **`settings.manager_cog.enabled` feature flag (default OFF)**
  gates runtime *behaviour*, not loading. When OFF:
  - `!settings` returns a clearly-worded disabled embed pointing
    at the flag name and how to flip it.
  - `build_help_menu_view` returns the same disabled embed with
    an empty view (Help cog appends its own "↩ Back to Help"
    button), so the help dropdown explains the gate rather than
    appearing broken.
  - Flag-evaluator failure closes the gate (fail-safe — a flag
    outage must not open a UI that defaults OFF).
- **`build_help_menu_view`** returns the same `(embed, view)`
  shape that `!settings` produces when the flag is ON, so the
  HelpPanelView dropdown navigates straight into the hub.

## Files changed (16 files, +2,400 lines)

- **`disbot/cogs/settings_cog.py`** *(new)* — the cog, the
  `!settings` command, the `build_help_menu_view` hook, the
  disabled-embed shared helper, and a small no-controls view
  shown in the help-hook path when the gate is closed.
- **`disbot/cogs/settings/__init__.py`** *(new)* — empty package
  marker. No `SettingSpec` / `BindingSpec` / `ResourceRequirement`
  of its own.
- **`disbot/views/settings/__init__.py`** *(new)* — package marker.
- **`disbot/views/settings/hub.py`** *(new)* —
  `SettingsHubView`. Header embed shows
  `subsystems / schemas / settings / bindings / resources` +
  customization findings count. Subsystem `Select` capped at
  Discord's 25-option limit; sorted by `(has_schema, ui_priority,
  display_name)`. Four buttons open the diagnostic sub-panels.
- **`disbot/views/settings/subsystem_view.py`** *(new)* —
  `SubsystemSettingsView` + `build_subsystem_embed`. Drives
  scalar-value resolution through
  `services.settings_resolution.resolve_setting` so the panel
  shows the current effective value, provenance, default, and
  validity. Read-only — no edit buttons.
- **`disbot/views/settings/needs_setup.py`** *(new)* — lists
  subsystems with required `BindingSpec`s or `REQUIRED`
  `ResourceRequirement`s.
- **`disbot/views/settings/invalid_settings.py`** *(new)* —
  walks every declared setting for the calling guild and reports
  resolutions where `valid=False` (with the raw value and the
  fallback default).
- **`disbot/views/settings/missing_bindings.py`** *(new)* —
  lists declared bindings whose runtime status is not `bound`
  (calls `core.runtime.bindings.get_binding`; read-only).
- **`disbot/views/settings/audit_view.py`** *(new)* — reads the
  last N rows from `settings_mutation_audit` (S4). Gracefully
  surfaces "migration not applied" when the table is missing.
- **`disbot/utils/subsystem_registry.py`** — register `"settings"`
  subsystem (admin tier, `entry_points=["settings"]`, capability
  `settings.manager.view`).
- **`disbot/core/runtime/feature_flags.py`** — declare and
  register `SETTINGS_MANAGER_COG_ENABLED` (default `False`,
  removal target `"S11 stable"`); add to `__all__`.
- **`disbot/config.py`** — add `cogs.settings_cog` to
  `INITIAL_EXTENSIONS` so the cog loads at startup.
- **`docs/settings-customization-command-map.md`** — new
  `### settings` section so the S0 doc-coverage test stays
  green now that `"settings"` is a SUBSYSTEMS entry.
- **`tests/unit/cogs/test_settings_cog.py`** *(new, 10 tests)* —
  SUBSYSTEMS entry shape, feature-flag declaration, `!settings`
  ON/OFF gate, gate-fails-closed, `build_help_menu_view` hook
  ON/OFF, disabled-embed content mentions the flag name, setup
  function exists.
- **`tests/unit/views/test_settings_hub_view.py`** *(new, 8
  tests)* — embed shape, view children count
  (1 Select + 4 Buttons), dropdown lists registered subsystems,
  Discord-limit cap, button labels match directive vocabulary,
  inventory reflects registered settings/bindings, no-registry
  built case.
- **`tests/unit/views/test_subsystem_settings_view.py`** *(new,
  11 tests)* — emoji + display-name title, visibility tier in
  description, scalar settings with provenance, bindings with
  kind/required, provisionable resources, existing command
  panels, DM invocation, sparse no-schema subsystem, back
  button, subsystem key carried, mutation-import sanity check.
- **`tests/unit/views/test_settings_diagnostic_subviews.py`**
  *(new, 14 tests)* — the four sub-panels' embed shapes, DM
  paths, empty states, populated states, audit-table-missing
  graceful degradation, back buttons across all four views.
- **`tests/unit/invariants/test_settings_cog_read_only.py`**
  *(new, 3 tests)* — AST scan forbidding mutation imports +
  mutation/create method calls inside the Settings UI surface,
  plus a sanity test that the scanner finds every S5 file we ship.

## No migrations

S5 ships zero migrations. The audit view reads `settings_mutation_audit`
(landed in S4 / migration 029) and gracefully handles the
"migration not applied yet" case.

## Tests run and exact results

- [x] `pytest tests/unit/cogs/test_settings_cog.py` — **10 passed**.
- [x] `pytest tests/unit/views/test_settings_hub_view.py` — **8 passed**.
- [x] `pytest tests/unit/views/test_subsystem_settings_view.py` — **11 passed**.
- [x] `pytest tests/unit/views/test_settings_diagnostic_subviews.py` — **14 passed**.
- [x] `pytest tests/unit/invariants/test_settings_cog_read_only.py` — **3 passed**.
- [x] `pytest tests/unit/docs/test_settings_customization_doc.py` — **21 passed** (S0 doc coverage stays green with the new `### settings` section).
- [x] `pytest tests/unit/` — full suite: **1808 passed, 0 failed, 12 warnings**.
- [x] `ruff check disbot/` — clean.
- [x] `black --check disbot/` — 246 files unchanged.
- [x] `isort --check-only disbot/ tests/` — clean.
- [x] `mypy disbot/` — no issues found in 246 source files.
- [x] Single-`git revert` safe (no migrations, no behaviour change
      when the gate flag stays at its default OFF).

## Manual smoke checklist (for the operator)

When `settings.manager_cog.enabled` is OFF (default):
- `!settings` returns the disabled embed and points at the flag
  name.
- `!help` → *Settings Manager* dropdown option opens the same
  disabled embed inside the help message.
- `!platform settings-registry`, `!platform customization`,
  `!platform schemas` all continue to render unchanged.

When `settings.manager_cog.enabled` is ON:
- `!settings` opens the hub. Dropdown lists ~21 subsystems,
  sorted with schema-bearing ones first.
- Picking `xp` (schema-bearing) shows scalar settings with
  provenance + default + validity; declared bindings (none for
  xp by default beyond `announce_channel`); resource intents;
  related `!xpmenu` panel link.
- Picking `blackjack` (no schema) shows the empty-state
  "Scalar settings: none declared" subsystem page — the
  drill-down shape still ships even when sparse.
- "Needs setup" lists every subsystem with required bindings
  (none in v1 — most are optional).
- "Invalid settings" lists settings whose KV row failed
  coercion / validation (typically empty).
- "Missing bindings" lists declared bindings whose runtime
  status is not `bound` (most slots are unresolved until S7).
- "Recent changes" reads `settings_mutation_audit` and renders
  the last 10 rows (empty until the S6 edit flow lands).
- "↩ Back to Hub" on every sub-panel returns to the hub view.
- `!help` → *Settings Manager* drop opens the hub in place.

## Risks and rollback plan

- **Risk:** none in production. The gate flag is default OFF,
  so the cog is registered for discoverability but inert. Even
  when ON, every code path is read-only and pinned by the
  invariant AST scan.
- **Rollback:** `git revert` of this commit removes the cog,
  the views, the SUBSYSTEMS entry, the feature flag, the
  `INITIAL_EXTENSIONS` entry, the doc section, and all five
  test files. No migrations to roll back.

## Deferred to a follow-up PR

- `services.platform_consistency` collector for the audit-view
  drift counters (matches the deferred-collector precedent
  from #93–#98).
- `!adminmenu` deep-link to `!settings` (planned in S11).
- `!platform settings-cog` admin command (informational; not
  required for v1).

## Next recommended PR

**S6 — Scalar edit/reset flows** on branch
`claude/settings-edit-flows`. Adds the first write surface to
the Settings Manager views: edit modals + reset buttons that
route through `SettingsMutationPipeline.set_value` (S4). Lifts
the S5 read-only AST invariant onto an allowlist (the edit-flow
views become the first allowlisted importers of the mutation
pipeline).

---
_Generated by [Claude Code](https://claude.ai/code/session_01U3sByR3PY3gobeB3jLFDFD)_