### PR TITLE
docs(roadmap): add command integration references

### DIFF
--- a/docs/building-roadmap/README.md
+++ b/docs/building-roadmap/README.md
@@ -1,0 +1,19 @@
+# SuperBot Building Roadmap
+
+Status: Reference only  
+Runtime impact: None
+
+This directory contains reference documents for future command, panel, help-menu, Settings Manager, and setup-wizard work.
+
+## Files
+
+- `command-integration-standard.md` — rules for adding commands, panels, help-menu hooks, settings links, and navigation behavior.
+- `command-expansion-backlog.md` — near-term command and panel ideas.
+
+Related reference:
+
+- `docs/operator-settings-presets.md`
+
+## Core principle
+
+SuperBot should feel like a Discord-native application, not a scattered list of commands. Every major feature should be reachable through `!help`, its subsystem panel, relevant Settings Manager pages, and relevant Admin/Platform surfaces where appropriate.

--- a/docs/building-roadmap/command-expansion-backlog.md
+++ b/docs/building-roadmap/command-expansion-backlog.md
@@ -1,0 +1,339 @@
+# Command Expansion Backlog
+
+Status: Reference only  
+Runtime impact: None  
+Scope: Near-term command, panel, and gameplay improvements
+
+This document lists command and panel ideas that should be considered during future implementation phases.
+
+Items here are not approved implementation by themselves. They should be implemented only through the standard command integration rules in `command-integration-standard.md`.
+
+## Priority themes
+
+1. Every major cog should have a clear command panel.
+2. Help should link to every major cog panel.
+3. Cog panels should link back to Help.
+4. Settings pages should link to related cog panels.
+5. Game cogs should support mode selection and replay from the same menu.
+6. Resource creation and settings changes must use platform pipelines.
+
+## Missing or incomplete command panels
+
+Future work should inspect all cogs and ensure each has a usable panel.
+
+High-priority panels:
+
+- Settings Manager panel
+- Cleanup panel
+- Logging panel
+- Access Policy panel
+- Role panel
+- Economy panel
+- Mining panel
+- Blackjack panel
+- RPS panel
+- Counting panel
+- Chain panel
+- Proof Channel panel
+- Leaderboard panel
+
+If a cog currently lacks a panel, add one instead of adding isolated commands.
+
+## Mining menu improvements
+
+Current issue to address:
+
+```text
+!minemenu
+  -> Mine button
+      -> MiningView
+          -> no clear path back to Help
+```
+
+Target flow:
+
+```text
+!minemenu
+  -> Mine
+      -> MiningView
+          -> Mine again
+          -> Back to Mining Menu
+          -> Back to Help
+          -> Open Settings, later if admin
+```
+
+Mining should eventually support:
+
+- mine once;
+- mine again;
+- mining stats;
+- mining cooldown display;
+- rewards preview;
+- inventory shortcut;
+- economy shortcut;
+- settings shortcut for admins;
+- back to Help.
+
+## Blackjack improvements
+
+Blackjack should become a panel-driven game instead of only a one-off command flow.
+
+Target entrypoint:
+
+```text
+!blackjack
+```
+
+or an existing cog panel route from Help.
+
+Target panel actions:
+
+- Start Classic Blackjack;
+- Choose game mode;
+- View rules;
+- View balance/economy status, if economy integration exists;
+- Replay same mode;
+- Change mode;
+- Back to Games panel;
+- Back to Help.
+
+Suggested game modes:
+
+### Classic
+
+Standard blackjack round.
+
+### Quick Hand
+
+Fast single-hand mode with minimal prompts.
+
+### Best of 3
+
+Short match format where the player and dealer play multiple hands.
+
+### High Stakes
+
+Higher minimum/maximum bet rules, if economy integration is enabled.
+
+### Practice
+
+No economy impact. Useful for testing and casual play.
+
+Implementation notes:
+
+- Economy-backed modes must validate balance and bet limits.
+- Practice mode should not mutate economy state.
+- Replay should preserve selected mode and default bet where safe.
+- All game state should be isolated to the view/session.
+
+## RPS improvements
+
+RPS should support multiple replayable modes from one panel.
+
+Target entrypoint:
+
+```text
+!rps
+```
+
+or Help -> Games -> RPS.
+
+Target panel actions:
+
+- Play vs bot;
+- Challenge user;
+- Choose mode;
+- View rules;
+- Replay same mode;
+- Change mode;
+- Back to Games panel;
+- Back to Help.
+
+Suggested game modes:
+
+### Single Round
+
+One rock-paper-scissors round.
+
+### Best of 3
+
+First to 2 wins.
+
+### Best of 5
+
+First to 3 wins.
+
+### Timed Match
+
+Players must choose within a time limit.
+
+### Challenge Mode
+
+Challenge another user directly.
+
+### Tournament Mode
+
+Bridge to the existing RPS tournament system where appropriate.
+
+Implementation notes:
+
+- Replay should not require retyping `!rps`.
+- Challenge mode should handle declined or expired challenges cleanly.
+- Tournament mode should reuse tournament services rather than duplicating tournament state.
+- Buttons should disable after a round ends or timeout.
+
+## General games panel
+
+A future Games panel should route to:
+
+- Blackjack;
+- RPS;
+- RPS Tournament;
+- Deathmatch;
+- other future games.
+
+Suggested actions:
+
+- Choose game;
+- View active games;
+- View tournaments;
+- View game settings, admin-only;
+- Back to Help.
+
+## Cleanup command expansion
+
+Cleanup should move from a narrow word-management panel to a full cleanup command panel.
+
+Target panel:
+
+```text
+!cleanup
+```
+
+or:
+
+```text
+!settings cleanup
+```
+
+Target pages:
+
+- Overview;
+- Prohibited words;
+- Scan history;
+- Warning behavior;
+- Exemptions;
+- Channel policies;
+- Test/preview cleanup rule;
+- Cleanup logging status;
+- Back to Settings;
+- Back to Help.
+
+Existing `!wordmenu` should become a subpage, not remain the only cleanup panel.
+
+## Logging command expansion
+
+Logging should have a dedicated panel.
+
+Target panel:
+
+```text
+!logging
+```
+
+Target actions:
+
+- Status;
+- Test log;
+- Choose existing mod log channel;
+- Choose existing cleanup log channel;
+- Create log channel later through ResourceProvisioningPipeline;
+- Logging settings shortcut;
+- Back to Settings;
+- Back to Help.
+
+## Access-policy command expansion
+
+Access policy should have a dedicated admin panel.
+
+Target panel:
+
+```text
+!settings access
+```
+
+Target actions:
+
+- Select subsystem;
+- Select channel/category;
+- Enable here;
+- Disable here;
+- Inherit from parent;
+- Preview effective policy;
+- Explain why a command is blocked.
+
+Access policy must reuse governance scope-chain logic.
+
+## Role command expansion
+
+Role system should expose a clear panel.
+
+Target panel:
+
+```text
+!roles
+```
+
+or existing role command panel.
+
+Target actions:
+
+- Self-role menu;
+- Reaction-role setup;
+- Default role settings;
+- Skip roles;
+- XP/time role settings later;
+- Role settings shortcut;
+- Back to Help.
+
+## Economy command expansion
+
+Economy should expose a clear panel.
+
+Target actions:
+
+- Balance;
+- Daily/work actions;
+- Shop;
+- Inventory;
+- Transfer;
+- Economy settings, admin-only;
+- Economy logs, admin-only;
+- Back to Help.
+
+## Proof channel command expansion
+
+Proof channel should expose a clear panel.
+
+Target actions:
+
+- Submit proof;
+- View proof requirements;
+- Staff review queue, admin/staff only;
+- Proof settings, admin-only;
+- Back to Help.
+
+## Command quality checklist
+
+Before adding a command to production, confirm:
+
+- It belongs to a subsystem.
+- It appears in Help or is intentionally internal.
+- It has a panel if it is a major feature.
+- It has a short, clear description.
+- It uses service-layer logic.
+- It does not directly mutate settings or bindings.
+- It does not directly create resources.
+- It has back navigation.
+- It has manual smoke notes.
+- It does not create duplicate abstractions.

--- a/docs/building-roadmap/command-integration-standard.md
+++ b/docs/building-roadmap/command-integration-standard.md
@@ -1,0 +1,197 @@
+# Command Integration Standard
+
+Status: Reference only  
+Runtime impact: None  
+Scope: Future commands, panels, views, and cog menu integrations
+
+This document defines how new commands should be integrated so they remain discoverable, panel-driven, testable, and compatible with SuperBot's platform architecture.
+
+## Goals
+
+Every new user-facing command should be:
+
+- discoverable from `!help`;
+- owned by the correct subsystem or cog;
+- reachable from a cog command panel where appropriate;
+- documented with a clear short description;
+- routed through the correct service layer;
+- safe to test manually;
+- compatible with Settings Manager and future setup wizard flows.
+
+## Mandatory command integration rules
+
+### 1. Every user-facing cog should have a command panel
+
+Every existing and future cog should have a clear command panel unless it is intentionally internal.
+
+A cog command panel should:
+
+- summarize what the cog does;
+- list primary actions;
+- use buttons and selects where practical;
+- link to related settings where available;
+- link back to Help or the previous parent panel;
+- avoid dead-end views.
+
+Expected panel families include Admin, Help, Platform, Settings, Cleanup, Logging, XP, Role, Economy, Mining, Blackjack, RPS, Counting, Chain, Proof Channel, and Leaderboard.
+
+### 2. Help-menu discoverability is required
+
+Every new user-facing command must be discoverable through `!help`.
+
+Acceptable discovery paths:
+
+- direct listing in Help;
+- button from Help into the cog panel;
+- subsystem dropdown or category section;
+- admin-only section for admin commands;
+- disabled/unavailable indicator if feature-gated.
+
+A command should not exist as a hidden standalone command unless it is intentionally internal.
+
+### 3. Cog panels must support return navigation
+
+Every command panel and subview should include a clear navigation path.
+
+At minimum:
+
+- back to parent panel;
+- back to cog panel;
+- back to Help where appropriate.
+
+No feature view should trap the user in a dead-end state.
+
+Example target flow:
+
+```text
+!minemenu
+  -> Mine
+      -> MiningView
+          -> Mine again
+          -> Back to Mining Menu
+          -> Back to Help
+```
+
+The mining action view should be improved so it can return to the mining menu and Help.
+
+### 4. Commands should be thin entrypoints
+
+Commands should usually only:
+
+1. validate basic context;
+2. call shared service/runtime helpers;
+3. send a panel, view, or result embed.
+
+Commands should not directly own business logic that belongs in services, runtime modules, settings pipelines, binding pipelines, resource provisioning pipelines, or governance helpers.
+
+### 5. Settings changes must use the settings pipeline
+
+Future commands or buttons that change scalar settings must use `SettingsMutationPipeline`.
+
+They must not write directly to legacy setting storage.
+
+### 6. Binding changes must use the binding pipeline
+
+Commands or buttons that change channel, role, or resource pointers must use `BindingMutationPipeline`.
+
+They must not store Discord resource IDs as scalar settings.
+
+### 7. Resource creation must use provisioning
+
+Commands or buttons that create channels, roles, or categories must use `ResourceProvisioningPipeline`.
+
+They must not call Discord create APIs directly except through approved legacy paths being migrated.
+
+Resource creation must be previewed, explicitly confirmed, audited, and safely failed if permissions are missing.
+
+### 8. Access control must reuse governance
+
+Commands that control which cogs or features work in channels/categories must reuse governance scope-chain logic.
+
+Do not create a second command allowlist system.
+
+### 9. Slash command policy
+
+Slash commands should eventually be limited mostly to front doors:
+
+- `/help`
+- `/settings`
+- `/adminmenu`
+- `/platform`
+- `/minemenu`
+
+Most feature work should remain button/menu-driven after the front door opens.
+
+## Required metadata for new commands
+
+Every new command should define or document:
+
+- subsystem owner;
+- short description;
+- admin/user visibility;
+- whether it opens a panel;
+- related settings page, if any;
+- required capability or permission;
+- whether it mutates state;
+- whether it creates resources;
+- whether it is safe in DMs;
+- whether it should appear in Help;
+- whether it should appear in Admin/Platform menus.
+
+## Panel requirements
+
+A command panel should include:
+
+- title and short description;
+- primary actions;
+- settings shortcut when relevant;
+- help shortcut or back button;
+- disabled-state messaging for unavailable features;
+- clear error handling;
+- no silent state changes.
+
+## Game panel requirements
+
+Game cogs should be replayable and mode-driven.
+
+A game panel should generally include:
+
+- choose mode;
+- start game;
+- replay same mode;
+- change mode;
+- view rules;
+- back to game panel;
+- back to Help.
+
+Game flows should not require the user to retype commands after each round.
+
+## Testing requirements
+
+New commands and panels should include tests or manual smoke notes for:
+
+- command exists;
+- command appears in command surface ledger where applicable;
+- command is discoverable through Help;
+- panel opens without error;
+- buttons route correctly;
+- back buttons work;
+- admin-only commands reject unauthorized users;
+- state mutations go through the correct pipeline;
+- no direct resource creation outside provisioning;
+- no dead-end views.
+
+## Manual smoke checklist
+
+For a new command or panel, verify:
+
+```text
+!help
+  -> subsystem appears
+  -> opens cog panel
+  -> cog panel opens feature
+  -> feature can return to cog panel
+  -> cog panel can return to Help
+```
+
+For admin/settings commands, verify `!adminmenu`, `!settings`, `!platform`, and `!help` route consistently where relevant.


### PR DESCRIPTION
## Summary

Adds a lightweight `docs/building-roadmap/` reference area for future command, panel, help-menu, game-menu, and Settings Manager work.

Files added:

- `docs/building-roadmap/README.md`
- `docs/building-roadmap/command-integration-standard.md`
- `docs/building-roadmap/command-expansion-backlog.md`

The docs capture:

- how future commands should integrate with Help and cog panels;
- the expectation that every user-facing cog should have a clear command panel unless intentionally internal;
- requirements for back navigation and avoiding dead-end views;
- service-layer ownership rules for settings, bindings, resource provisioning, and access policy changes;
- game panel expectations for mode selection and replayability;
- near-term backlog notes for Mining, Blackjack, RPS, Cleanup, Logging, Access Policy, Role, Economy, and Proof Channel panels.

## Scope

Docs only.

No runtime files changed.  
No migrations.  
No feature flags.  
No behavior changes.  
No changes to active Settings Manager / provisioning implementation branches.

## Why

Future feature work needs an easy reference for adding commands safely without creating hidden commands, duplicate abstractions, dead-end views, or command panels that are disconnected from Help and Settings.

## Test plan

- [x] Markdown-only change.
- [x] No files under `disbot/` modified.
- [x] No migrations modified.
