### PR TITLE
feat(s6): scalar edit/reset flows for SubsystemSettingsView

### DIFF
--- a/disbot/core/runtime/subsystem_schema.py
+++ b/disbot/core/runtime/subsystem_schema.py
@@ -134,6 +134,14 @@ class SettingSpec:
         Short human-readable description rendered by the wizard.
     validator:
         Optional callable raising ``ValueError`` on invalid input.
+    allowed_values:
+        Optional tuple of accepted values.  When non-empty, the S6
+        edit-flow renders a :class:`discord.ui.Select` widget whose
+        options are these values, instead of a free-form text input.
+        Useful for enum-shaped scalar settings (e.g. cleanup
+        strictness ``"off"``/``"light"``/``"normal"``/``"strict"``).
+        Empty tuple (default) preserves backward compatibility — the
+        widget is a free-form modal text input.
     """
 
     name: str
@@ -143,6 +151,7 @@ class SettingSpec:
     capability_required: str = ""
     hint: str = ""
     validator: Callable[[Any], None] | None = None
+    allowed_values: tuple[Any, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/disbot/views/settings/edit_boolean.py
+++ b/disbot/views/settings/edit_boolean.py
@@ -1,0 +1,107 @@
+"""BooleanSettingToggle — S6 edit widget for ``bool`` SettingSpecs.
+
+Single-click toggle that reads the current value via S3's resolver
+and writes the inverted value via S4's
+:class:`services.settings_mutation.SettingsMutationPipeline`.
+
+Lives under the S5 read-only-invariant allowlist: this is one of
+the five edit-flow files permitted to import the mutation pipeline.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+logger = logging.getLogger("bot.views.settings.edit_boolean")
+
+
+async def toggle_setting(
+    interaction: discord.Interaction,
+    subsystem: str,
+    setting_name: str,
+    parent_message: discord.Message | None = None,
+) -> None:
+    """Read the current value and write the inverted value.
+
+    Sends an ephemeral confirmation on success and best-effort
+    refreshes the parent subsystem-view embed.  Errors from the
+    mutation pipeline are reported ephemerally.
+    """
+    from services.settings_mutation import (
+        SettingsMutationError,
+        SettingsMutationPipeline,
+    )
+    from services.settings_resolution import resolve_setting
+
+    guild = interaction.guild
+    if guild is None:
+        await interaction.response.send_message(
+            "❌ Toggle requires a guild context.",
+            ephemeral=True,
+        )
+        return
+
+    resolution = await resolve_setting(guild.id, subsystem, setting_name)
+    if resolution is None:
+        await interaction.response.send_message(
+            f"❌ Unknown setting `{subsystem}.{setting_name}`.",
+            ephemeral=True,
+        )
+        return
+
+    new_value = not bool(resolution.value)
+    try:
+        result = await SettingsMutationPipeline().set_value(
+            guild,
+            subsystem,
+            setting_name,
+            new_value,
+            interaction.user,
+        )
+    except SettingsMutationError as exc:
+        await interaction.response.send_message(
+            f"❌ `{type(exc).__name__}`: {exc}",
+            ephemeral=True,
+        )
+        return
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.exception(
+            "BooleanSettingToggle: pipeline raised for %s.%s",
+            subsystem,
+            setting_name,
+        )
+        await interaction.response.send_message(
+            f"❌ Unexpected error: {type(exc).__name__}: {exc}",
+            ephemeral=True,
+        )
+        return
+
+    await interaction.response.send_message(
+        f"✅ Toggled `{subsystem}.{setting_name}` → `{result.new_value!r}`.",
+        ephemeral=True,
+    )
+    await _refresh_parent(interaction, subsystem, parent_message)
+
+
+async def _refresh_parent(
+    interaction: discord.Interaction,
+    subsystem: str,
+    parent_message: discord.Message | None,
+) -> None:
+    if parent_message is None:
+        return
+    try:
+        from views.settings.subsystem_view import build_subsystem_embed
+
+        embed = await build_subsystem_embed(interaction, subsystem)
+        await parent_message.edit(embed=embed)
+    except Exception as exc:  # noqa: BLE001 — soft-fail; user already confirmed
+        logger.debug(
+            "BooleanSettingToggle: parent-message refresh failed: %s",
+            exc,
+        )
+
+
+__all__ = ["toggle_setting"]

--- a/disbot/views/settings/edit_enum.py
+++ b/disbot/views/settings/edit_enum.py
@@ -1,0 +1,149 @@
+"""EnumSettingSelectView — S6 edit widget for ``str`` settings with
+``allowed_values``.
+
+Discord modals can only host text inputs (no Select component), so
+the enum widget is a follow-up *view* with a single Select.  The
+flow is:
+
+  1. Operator picks a setting in the SubsystemSettingsView's edit
+     dropdown.
+  2. The dispatcher sees ``SettingSpec.allowed_values`` is non-empty
+     and replies with an ephemeral message that hosts an
+     :class:`EnumSettingSelectView`.
+  3. Operator picks the new value from the enum select.
+  4. The select's callback writes via
+     :class:`services.settings_mutation.SettingsMutationPipeline`
+     and confirms ephemerally.
+
+Allowlisted by the S5/S6 read-only invariant scan.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+logger = logging.getLogger("bot.views.settings.edit_enum")
+
+
+class _EnumSelect(discord.ui.Select):
+    def __init__(
+        self,
+        subsystem: str,
+        setting_name: str,
+        allowed_values: tuple,
+        current_value,
+        parent_message: discord.Message | None,
+    ) -> None:
+        self.subsystem = subsystem
+        self.setting_name = setting_name
+        self.parent_message = parent_message
+        # Discord caps a Select at 25 options.
+        options: list[discord.SelectOption] = []
+        for value in allowed_values[:25]:
+            label = str(value)[:100]
+            is_current = value == current_value
+            options.append(
+                discord.SelectOption(
+                    label=label,
+                    value=label,
+                    default=is_current,
+                    description="current" if is_current else None,
+                ),
+            )
+        super().__init__(
+            placeholder=f"Pick a new value for {setting_name}…"[:150],
+            min_values=1,
+            max_values=1,
+            options=options,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        new_value = self.values[0]
+        from services.settings_mutation import (
+            SettingsMutationError,
+            SettingsMutationPipeline,
+        )
+
+        guild = interaction.guild
+        if guild is None:
+            await interaction.response.send_message(
+                "❌ Edit requires a guild context.",
+                ephemeral=True,
+            )
+            return
+        try:
+            result = await SettingsMutationPipeline().set_value(
+                guild,
+                self.subsystem,
+                self.setting_name,
+                new_value,
+                interaction.user,
+            )
+        except SettingsMutationError as exc:
+            await interaction.response.send_message(
+                f"❌ {type(exc).__name__}: {exc}",
+                ephemeral=True,
+            )
+            return
+        except Exception as exc:  # noqa: BLE001 — defensive
+            logger.exception(
+                "EnumSettingSelect: pipeline raised for %s.%s",
+                self.subsystem,
+                self.setting_name,
+            )
+            await interaction.response.send_message(
+                f"❌ Unexpected error: {type(exc).__name__}: {exc}",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.response.send_message(
+            f"✅ Updated `{self.subsystem}.{self.setting_name}` "
+            f"= `{result.new_value!r}`.",
+            ephemeral=True,
+        )
+        await _refresh_parent(interaction, self.subsystem, self.parent_message)
+
+
+class EnumSettingSelectView(discord.ui.View):
+    """Ephemeral follow-up view hosting the enum-select widget."""
+
+    def __init__(
+        self,
+        subsystem: str,
+        setting_name: str,
+        allowed_values: tuple,
+        current_value,
+        parent_message: discord.Message | None = None,
+    ) -> None:
+        super().__init__(timeout=180)
+        self.add_item(
+            _EnumSelect(
+                subsystem,
+                setting_name,
+                allowed_values,
+                current_value,
+                parent_message,
+            ),
+        )
+
+
+async def _refresh_parent(
+    interaction: discord.Interaction,
+    subsystem: str,
+    parent_message: discord.Message | None,
+) -> None:
+    if parent_message is None:
+        return
+    try:
+        from views.settings.subsystem_view import build_subsystem_embed
+
+        embed = await build_subsystem_embed(interaction, subsystem)
+        await parent_message.edit(embed=embed)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("EnumSettingSelect: parent-message refresh failed: %s", exc)
+
+
+__all__ = ["EnumSettingSelectView"]

--- a/disbot/views/settings/edit_number.py
+++ b/disbot/views/settings/edit_number.py
@@ -1,0 +1,127 @@
+"""NumberSettingModal — S6 edit widget for ``int`` / ``float`` SettingSpecs.
+
+Pops a one-input :class:`discord.ui.Modal` so the operator types a
+new value.  ``on_submit`` coerces the input, runs the spec's
+validator (via the pipeline), writes through
+:class:`services.settings_mutation.SettingsMutationPipeline`, and
+sends an ephemeral confirmation.
+
+Allowlisted by the S5/S6 read-only invariant scan.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+logger = logging.getLogger("bot.views.settings.edit_number")
+
+
+class NumberSettingModal(discord.ui.Modal):
+    """Free-form numeric input for ``int`` / ``float`` settings."""
+
+    def __init__(
+        self,
+        subsystem: str,
+        setting_name: str,
+        value_type: type,
+        current_value,
+        default_value,
+        parent_message: discord.Message | None = None,
+    ) -> None:
+        super().__init__(
+            title=f"Edit {subsystem}.{setting_name}"[:45],
+            timeout=180,
+        )
+        self.subsystem = subsystem
+        self.setting_name = setting_name
+        self.value_type = value_type
+        self.parent_message = parent_message
+        self.input: discord.ui.TextInput = discord.ui.TextInput(
+            label=f"New value (type: {value_type.__name__})"[:45],
+            placeholder=(f"current={current_value!r} · default={default_value!r}")[
+                :100
+            ],
+            default=str(current_value) if current_value is not None else "",
+            required=True,
+            max_length=64,
+        )
+        self.add_item(self.input)
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        raw = self.input.value.strip()
+        from services.settings_mutation import (
+            SettingsCoercionError,
+            SettingsMutationError,
+            SettingsMutationPipeline,
+            SettingsValidationError,
+        )
+
+        guild = interaction.guild
+        if guild is None:
+            await interaction.response.send_message(
+                "❌ Edit requires a guild context.",
+                ephemeral=True,
+            )
+            return
+        try:
+            result = await SettingsMutationPipeline().set_value(
+                guild,
+                self.subsystem,
+                self.setting_name,
+                raw,
+                interaction.user,
+            )
+        except (SettingsCoercionError, SettingsValidationError) as exc:
+            await interaction.response.send_message(
+                f"❌ {type(exc).__name__}: {exc}",
+                ephemeral=True,
+            )
+            return
+        except SettingsMutationError as exc:
+            await interaction.response.send_message(
+                f"❌ {type(exc).__name__}: {exc}",
+                ephemeral=True,
+            )
+            return
+        except Exception as exc:  # noqa: BLE001 — defensive
+            logger.exception(
+                "NumberSettingModal: pipeline raised for %s.%s",
+                self.subsystem,
+                self.setting_name,
+            )
+            await interaction.response.send_message(
+                f"❌ Unexpected error: {type(exc).__name__}: {exc}",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.response.send_message(
+            f"✅ Updated `{self.subsystem}.{self.setting_name}` "
+            f"= `{result.new_value!r}` (was `{result.old_value!r}`).",
+            ephemeral=True,
+        )
+        await _refresh_parent(interaction, self.subsystem, self.parent_message)
+
+
+async def _refresh_parent(
+    interaction: discord.Interaction,
+    subsystem: str,
+    parent_message: discord.Message | None,
+) -> None:
+    if parent_message is None:
+        return
+    try:
+        from views.settings.subsystem_view import build_subsystem_embed
+
+        embed = await build_subsystem_embed(interaction, subsystem)
+        await parent_message.edit(embed=embed)
+    except Exception as exc:  # noqa: BLE001 — soft-fail
+        logger.debug(
+            "NumberSettingModal: parent-message refresh failed: %s",
+            exc,
+        )
+
+
+__all__ = ["NumberSettingModal"]

--- a/disbot/views/settings/edit_text.py
+++ b/disbot/views/settings/edit_text.py
@@ -1,0 +1,114 @@
+"""TextSettingModal — S6 edit widget for free-form ``str`` SettingSpecs.
+
+Used for string settings whose ``SettingSpec.allowed_values`` is
+empty.  Settings that declare ``allowed_values`` are routed to the
+:mod:`views.settings.edit_enum` widget instead.
+
+Allowlisted by the S5/S6 read-only invariant scan.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+logger = logging.getLogger("bot.views.settings.edit_text")
+
+
+class TextSettingModal(discord.ui.Modal):
+    """Free-form text input for ``str`` settings without ``allowed_values``."""
+
+    def __init__(
+        self,
+        subsystem: str,
+        setting_name: str,
+        current_value,
+        default_value,
+        parent_message: discord.Message | None = None,
+    ) -> None:
+        super().__init__(
+            title=f"Edit {subsystem}.{setting_name}"[:45],
+            timeout=180,
+        )
+        self.subsystem = subsystem
+        self.setting_name = setting_name
+        self.parent_message = parent_message
+        # Multi-line text supports longer values (templates, hint strings).
+        self.input: discord.ui.TextInput = discord.ui.TextInput(
+            label="New value (text)",
+            placeholder=(f"current={current_value!r} · default={default_value!r}")[
+                :100
+            ],
+            default=str(current_value) if current_value else "",
+            required=False,
+            max_length=2000,
+            style=discord.TextStyle.paragraph,
+        )
+        self.add_item(self.input)
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        raw = self.input.value
+        from services.settings_mutation import (
+            SettingsMutationError,
+            SettingsMutationPipeline,
+        )
+
+        guild = interaction.guild
+        if guild is None:
+            await interaction.response.send_message(
+                "❌ Edit requires a guild context.",
+                ephemeral=True,
+            )
+            return
+        try:
+            result = await SettingsMutationPipeline().set_value(
+                guild,
+                self.subsystem,
+                self.setting_name,
+                raw,
+                interaction.user,
+            )
+        except SettingsMutationError as exc:
+            await interaction.response.send_message(
+                f"❌ {type(exc).__name__}: {exc}",
+                ephemeral=True,
+            )
+            return
+        except Exception as exc:  # noqa: BLE001 — defensive
+            logger.exception(
+                "TextSettingModal: pipeline raised for %s.%s",
+                self.subsystem,
+                self.setting_name,
+            )
+            await interaction.response.send_message(
+                f"❌ Unexpected error: {type(exc).__name__}: {exc}",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.response.send_message(
+            f"✅ Updated `{self.subsystem}.{self.setting_name}` "
+            f"= `{result.new_value!r}`.",
+            ephemeral=True,
+        )
+        await _refresh_parent(interaction, self.subsystem, self.parent_message)
+
+
+async def _refresh_parent(
+    interaction: discord.Interaction,
+    subsystem: str,
+    parent_message: discord.Message | None,
+) -> None:
+    if parent_message is None:
+        return
+    try:
+        from views.settings.subsystem_view import build_subsystem_embed
+
+        embed = await build_subsystem_embed(interaction, subsystem)
+        await parent_message.edit(embed=embed)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("TextSettingModal: parent-message refresh failed: %s", exc)
+
+
+__all__ = ["TextSettingModal"]

--- a/disbot/views/settings/reset_button.py
+++ b/disbot/views/settings/reset_button.py
@@ -1,0 +1,110 @@
+"""ResetSettingButton — S6 reset widget for any scalar SettingSpec.
+
+A reset is functionally ``set_value(spec.default)`` but is recorded
+as a deliberate operator action.  S4's audit row will show the
+prev/new values regardless; the future S6 mutation_type extension
+may distinguish ``reset_value`` from ``set_value`` so dashboards
+can filter.
+
+Allowlisted by the S5/S6 read-only invariant scan.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+logger = logging.getLogger("bot.views.settings.reset_button")
+
+
+async def reset_setting(
+    interaction: discord.Interaction,
+    subsystem: str,
+    setting_name: str,
+    parent_message: discord.Message | None = None,
+) -> None:
+    """Reset ``(subsystem, setting_name)`` to its declared default.
+
+    Sends an ephemeral confirmation on success and best-effort
+    refreshes the parent subsystem-view embed.
+    """
+    from core.runtime.subsystem_schema import get_schema
+    from services.settings_mutation import (
+        SettingsMutationError,
+        SettingsMutationPipeline,
+    )
+
+    guild = interaction.guild
+    if guild is None:
+        await interaction.response.send_message(
+            "❌ Reset requires a guild context.",
+            ephemeral=True,
+        )
+        return
+
+    schema = get_schema(subsystem)
+    spec = None
+    if schema is not None:
+        for s in schema.settings:
+            if s.name == setting_name:
+                spec = s
+                break
+    if spec is None:
+        await interaction.response.send_message(
+            f"❌ Unknown setting `{subsystem}.{setting_name}`.",
+            ephemeral=True,
+        )
+        return
+
+    try:
+        result = await SettingsMutationPipeline().set_value(
+            guild,
+            subsystem,
+            setting_name,
+            spec.default,
+            interaction.user,
+        )
+    except SettingsMutationError as exc:
+        await interaction.response.send_message(
+            f"❌ {type(exc).__name__}: {exc}",
+            ephemeral=True,
+        )
+        return
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.exception(
+            "ResetSettingButton: pipeline raised for %s.%s",
+            subsystem,
+            setting_name,
+        )
+        await interaction.response.send_message(
+            f"❌ Unexpected error: {type(exc).__name__}: {exc}",
+            ephemeral=True,
+        )
+        return
+
+    await interaction.response.send_message(
+        f"✅ Reset `{subsystem}.{setting_name}` to default "
+        f"= `{result.new_value!r}`.",
+        ephemeral=True,
+    )
+    await _refresh_parent(interaction, subsystem, parent_message)
+
+
+async def _refresh_parent(
+    interaction: discord.Interaction,
+    subsystem: str,
+    parent_message: discord.Message | None,
+) -> None:
+    if parent_message is None:
+        return
+    try:
+        from views.settings.subsystem_view import build_subsystem_embed
+
+        embed = await build_subsystem_embed(interaction, subsystem)
+        await parent_message.edit(embed=embed)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("ResetSettingButton: parent-message refresh failed: %s", exc)
+
+
+__all__ = ["reset_setting"]

--- a/disbot/views/settings/subsystem_view.py
+++ b/disbot/views/settings/subsystem_view.py
@@ -237,13 +237,172 @@ class _BackToHubButton(discord.ui.Button):
         )
 
 
+# ---------------------------------------------------------------------------
+# S6 edit + reset selects.  Dispatch to the widget appropriate for the
+# SettingSpec.value_type / allowed_values shape.  See the per-widget
+# modules under :mod:`views.settings.edit_*` for the mutation paths.
+# ---------------------------------------------------------------------------
+
+
+def _editable_specs(subsystem: str) -> list:
+    """Return SettingSpec instances we can edit (subset that has a settings_key)."""
+    from core.runtime.subsystem_schema import get_schema
+
+    schema = get_schema(subsystem)
+    if schema is None:
+        return []
+    return [spec for spec in schema.settings if spec.settings_key]
+
+
+class _EditSettingSelect(discord.ui.Select):
+    """Select listing every editable SettingSpec for the subsystem.
+
+    Picking a setting dispatches to the appropriate edit widget:
+    bool toggles directly; int/float/str-without-allowed_values pop
+    a modal; str-with-allowed_values shows an enum select view.
+    """
+
+    def __init__(self, subsystem: str, specs: list) -> None:
+        self.subsystem = subsystem
+        # Cap to Discord's 25-option limit; surface what we can.
+        options: list[discord.SelectOption] = []
+        for spec in specs[:25]:
+            options.append(
+                discord.SelectOption(
+                    label=spec.name[:100],
+                    value=spec.name,
+                    description=f"type={spec.value_type.__name__}"[:100],
+                ),
+            )
+        super().__init__(
+            placeholder="Edit a setting…",
+            min_values=1,
+            max_values=1,
+            options=options,
+            row=1,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        name = self.values[0]
+        from core.runtime.subsystem_schema import get_schema
+        from services.settings_resolution import resolve_setting
+
+        schema = get_schema(self.subsystem)
+        spec = None
+        if schema is not None:
+            for s in schema.settings:
+                if s.name == name:
+                    spec = s
+                    break
+        if spec is None:
+            await interaction.response.send_message(
+                f"❌ Unknown setting `{self.subsystem}.{name}`.",
+                ephemeral=True,
+            )
+            return
+
+        guild_id = interaction.guild_id
+        current = spec.default
+        if guild_id is not None:
+            resolution = await resolve_setting(guild_id, self.subsystem, name)
+            if resolution is not None:
+                current = resolution.value
+
+        parent_msg = interaction.message
+
+        # Dispatch by value_type and allowed_values shape.
+        if spec.value_type is bool:
+            from views.settings.edit_boolean import toggle_setting
+
+            await toggle_setting(interaction, self.subsystem, name, parent_msg)
+            return
+        if spec.value_type is str and spec.allowed_values:
+            from views.settings.edit_enum import EnumSettingSelectView
+
+            view = EnumSettingSelectView(
+                self.subsystem,
+                name,
+                spec.allowed_values,
+                current,
+                parent_msg,
+            )
+            await interaction.response.send_message(
+                f"Pick a new value for `{self.subsystem}.{name}`:",
+                view=view,
+                ephemeral=True,
+            )
+            return
+        if spec.value_type is int or spec.value_type is float:
+            from views.settings.edit_number import NumberSettingModal
+
+            modal = NumberSettingModal(
+                self.subsystem,
+                name,
+                spec.value_type,
+                current,
+                spec.default,
+                parent_msg,
+            )
+            await interaction.response.send_modal(modal)
+            return
+        # Free-form string.
+        from views.settings.edit_text import TextSettingModal
+
+        modal = TextSettingModal(
+            self.subsystem,
+            name,
+            current,
+            spec.default,
+            parent_msg,
+        )
+        await interaction.response.send_modal(modal)
+
+
+class _ResetSettingSelect(discord.ui.Select):
+    """Select listing every resettable SettingSpec for the subsystem."""
+
+    def __init__(self, subsystem: str, specs: list) -> None:
+        self.subsystem = subsystem
+        options: list[discord.SelectOption] = []
+        for spec in specs[:25]:
+            options.append(
+                discord.SelectOption(
+                    label=f"Reset {spec.name}"[:100],
+                    value=spec.name,
+                    description=f"default={spec.default!r}"[:100],
+                ),
+            )
+        super().__init__(
+            placeholder="Reset a setting to its default…",
+            min_values=1,
+            max_values=1,
+            options=options,
+            row=2,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.settings.reset_button import reset_setting
+
+        name = self.values[0]
+        await reset_setting(
+            interaction,
+            self.subsystem,
+            name,
+            interaction.message,
+        )
+
+
 class SubsystemSettingsView(HubView):
-    """Per-subsystem read-only drill-down panel."""
+    """Per-subsystem panel: read-only embed + S6 edit/reset selects."""
 
     def __init__(self, author: Any, subsystem: str) -> None:
         super().__init__(author)
         self.subsystem = subsystem
         self.add_item(_BackToHubButton())
+        specs = _editable_specs(subsystem)
+        if specs:
+            self.add_item(_EditSettingSelect(subsystem, specs))
+            self.add_item(_ResetSettingSelect(subsystem, specs))
 
 
 __all__ = ["SubsystemSettingsView", "build_subsystem_embed"]

--- a/tests/unit/invariants/test_settings_cog_read_only.py
+++ b/tests/unit/invariants/test_settings_cog_read_only.py
@@ -1,19 +1,27 @@
-"""S5 invariant — Settings Manager cog + views are strictly read-only.
+"""S5/S6 invariant — Settings Manager UI mutation surface is allowlisted.
 
-The S5 directive is explicit: the cog and its views must not edit,
-reset, mutate, create, or otherwise change platform state.  S6
-introduces the first write surface (scalar edit/reset flows) and
-will explicitly add the mutation imports the AST scan below
-forbids.
+S5 (PR #100) shipped the Settings Manager hub + subsystem
+drill-down + four diagnostic sub-panels in strictly read-only
+form.  S6 (this PR) extends the subsystem view with scalar
+edit/reset flows that route writes through
+:class:`services.settings_mutation.SettingsMutationPipeline`.
 
-This test fails CI if any file under:
+This test now scans every file under:
 
   * ``disbot/cogs/settings*``
   * ``disbot/views/settings/**``
 
-imports any mutation pipeline or directly invokes a mutation
-method.  When S6 lands, this invariant tightens to allow the
-expected mutation imports inside an allowlist of edit-flow files.
+and fails CI if any file imports a mutation pipeline OR calls a
+known mutation/create method **unless that file is on the S6
+allowlist** (:data:`_ALLOWED_EDIT_FILES`).  The allowlist is the
+five edit-flow widget modules plus the reset module — every other
+file in the Settings UI surface stays read-only.
+
+When S7 lands and adds binding-edit flows, this allowlist
+expands; access-policy edits arrive in S9 and similarly extend
+the allowlist.  Every new allowlist entry MUST justify why the
+bypass is correct (typically: "the file IS the mutation surface
+for a typed scalar/binding/policy").
 """
 
 from __future__ import annotations
@@ -85,6 +93,24 @@ def _settings_ui_paths() -> list[Path]:
     return out
 
 
+# Files allowed to import a mutation pipeline / call a mutation
+# method.  S6 lifted the invariant to permit the five edit-flow
+# widgets + the reset module; nothing else in the Settings UI
+# surface may write.  Adding entries here weakens the invariant —
+# pair each new entry with a comment naming the milestone that
+# introduced the bypass and the mutation surface it owns.
+_ALLOWED_EDIT_FILES: frozenset[Path] = frozenset(
+    {
+        # S6 — scalar edit / reset flows.
+        _DISBOT / "views" / "settings" / "edit_boolean.py",
+        _DISBOT / "views" / "settings" / "edit_number.py",
+        _DISBOT / "views" / "settings" / "edit_text.py",
+        _DISBOT / "views" / "settings" / "edit_enum.py",
+        _DISBOT / "views" / "settings" / "reset_button.py",
+    },
+)
+
+
 def _module_imports_offenders(tree: ast.AST) -> list[str]:
     offenders: list[str] = []
     for node in ast.walk(tree):
@@ -114,43 +140,68 @@ def _attribute_call_offenders(tree: ast.AST) -> list[str]:
     return offenders
 
 
-def test_settings_ui_has_no_mutation_imports():
+def test_settings_ui_has_no_mutation_imports_outside_allowlist():
     """No file under the Settings Manager UI surface may import a
-    mutation pipeline.
+    mutation pipeline UNLESS it is on :data:`_ALLOWED_EDIT_FILES`.
     """
     paths = _settings_ui_paths()
     assert paths, "settings UI paths empty — sanity check failed"
     violations: list[tuple[str, list[str]]] = []
     for path in paths:
+        if path in _ALLOWED_EDIT_FILES:
+            continue
         tree = ast.parse(path.read_text(), filename=str(path))
         offenders = _module_imports_offenders(tree)
         if offenders:
             violations.append((str(path.relative_to(_REPO_ROOT)), offenders))
     assert not violations, (
-        "S5 invariant violation: Settings Manager UI surface imports a "
-        "mutation pipeline.  S5 is strictly read-only; S6 introduces the "
-        "first edit/reset flow.\n\n"
-        + "\n".join(f"  {p}: {imps}" for p, imps in violations)
+        "S5/S6 invariant violation: Settings Manager UI file imports a "
+        "mutation pipeline but is not on the edit-flow allowlist.  Either "
+        "remove the import or extend `_ALLOWED_EDIT_FILES` with a "
+        "justification.\n\n" + "\n".join(f"  {p}: {imps}" for p, imps in violations)
     )
 
 
-def test_settings_ui_does_not_call_known_mutation_methods():
+def test_settings_ui_does_not_call_known_mutation_methods_outside_allowlist():
     """No file under the Settings Manager UI surface may *call* any
-    of the canonical mutation methods (or any Discord-API create
-    method).  Defense-in-depth above the import scan.
+    canonical mutation method UNLESS it is on the edit-flow
+    allowlist.  Defense-in-depth above the import scan.
     """
     paths = _settings_ui_paths()
     violations: list[tuple[str, list[str]]] = []
     for path in paths:
+        if path in _ALLOWED_EDIT_FILES:
+            continue
         tree = ast.parse(path.read_text(), filename=str(path))
         offenders = _attribute_call_offenders(tree)
         if offenders:
             violations.append((str(path.relative_to(_REPO_ROOT)), offenders))
     assert not violations, (
-        "S5 invariant violation: Settings Manager UI calls a mutation "
-        "or resource-creation method.  S5 is strictly read-only.\n\n"
-        + "\n".join(f"  {p}: {calls}" for p, calls in violations)
+        "S5/S6 invariant violation: Settings Manager UI file calls a "
+        "mutation or resource-creation method but is not on the edit-flow "
+        "allowlist.\n\n" + "\n".join(f"  {p}: {calls}" for p, calls in violations)
     )
+
+
+def test_allowlist_entries_exist():
+    """Every allowlist entry must still exist on disk."""
+    missing = [
+        str(p.relative_to(_REPO_ROOT)) for p in _ALLOWED_EDIT_FILES if not p.exists()
+    ]
+    assert not missing, "S6 allowlist references missing files:\n" + "\n".join(
+        f"  {p}" for p in missing
+    )
+
+
+def test_allowlist_only_contains_edit_flow_files():
+    """Sanity: the allowlist must only contain ``views/settings/edit_*`` and
+    ``views/settings/reset_*`` files.  Catches a future drive-by edit that
+    allowlists, say, the hub or audit view by mistake."""
+    for path in _ALLOWED_EDIT_FILES:
+        name = path.name
+        assert name.startswith("edit_") or name.startswith(
+            "reset_"
+        ), f"unexpected allowlist entry: {path.relative_to(_REPO_ROOT)}"
 
 
 def test_settings_ui_paths_contain_expected_files():
@@ -170,6 +221,12 @@ def test_settings_ui_paths_contain_expected_files():
         Path("disbot/views/settings/invalid_settings.py"),
         Path("disbot/views/settings/missing_bindings.py"),
         Path("disbot/views/settings/audit_view.py"),
+        # S6 edit flow:
+        Path("disbot/views/settings/edit_boolean.py"),
+        Path("disbot/views/settings/edit_number.py"),
+        Path("disbot/views/settings/edit_text.py"),
+        Path("disbot/views/settings/edit_enum.py"),
+        Path("disbot/views/settings/reset_button.py"),
     }
     missing = expected_relpaths - paths
     assert (

--- a/tests/unit/views/test_settings_cog_edit_routes.py
+++ b/tests/unit/views/test_settings_cog_edit_routes.py
@@ -1,0 +1,338 @@
+"""Unit tests for the S6 edit-dispatch routing in SubsystemSettingsView.
+
+Verifies that the Edit-Setting select on the per-subsystem view
+dispatches to the correct widget based on the SettingSpec shape:
+
+* ``bool``                                  → BooleanSettingToggle
+* ``int`` / ``float``                       → NumberSettingModal
+* ``str`` with empty ``allowed_values``     → TextSettingModal
+* ``str`` with non-empty ``allowed_values`` → EnumSettingSelectView
+
+Independent of the modal-on-submit tests in
+``test_settings_edit_modals.py``: this file pins the dispatch
+shape, those files pin the per-widget mutation path.
+"""
+
+from __future__ import annotations
+
+import discord
+import pytest
+
+from core.runtime import guild_config
+from core.runtime import subsystem_schema as schema_mod
+from core.runtime.subsystem_schema import SettingSpec, SubsystemSchema
+from utils import db as db_pkg
+from utils.db import settings as settings_db
+from views.settings.subsystem_view import (
+    SubsystemSettingsView,
+    _EditSettingSelect,
+)
+
+# ---------------------------------------------------------------------------
+# Fakes (kept minimal — the on_submit paths are covered elsewhere)
+# ---------------------------------------------------------------------------
+
+
+class _FakeGuild:
+    def __init__(self, guild_id: int = 1):
+        self.id = guild_id
+
+
+class _FakeMember:
+    def __init__(self, member_id: int = 7, *, guild: _FakeGuild | None = None):
+        self.id = member_id
+        self.guild = guild or _FakeGuild()
+
+
+class _FakeMessage:
+    pass
+
+
+class _FakeResponse:
+    def __init__(self):
+        self.sent_modals: list = []
+        self.sent_messages: list = []
+
+    async def send_message(self, content=None, *, ephemeral=False, view=None, **_kw):
+        self.sent_messages.append({"content": content, "view": view})
+
+    async def send_modal(self, modal):
+        self.sent_modals.append(modal)
+
+
+class _FakeInteraction:
+    def __init__(self, guild: _FakeGuild | None = None):
+        self.guild = guild
+        self.guild_id = guild.id if guild else None
+        self.user = _FakeMember(guild=guild)
+        self.message = _FakeMessage()
+        self.response = _FakeResponse()
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(monkeypatch):
+    saved_schemas = schema_mod.all_schemas()
+    schema_mod._reset_for_tests()
+    guild_config._reset_for_tests()
+
+    _kv: dict[tuple[int, str], str] = {}
+
+    async def _fake_get_setting(
+        guild_id: int,
+        key: str,
+        default: str = "",
+    ) -> str:
+        return _kv.get((guild_id, key), default)
+
+    monkeypatch.setattr(settings_db, "get_setting", _fake_get_setting)
+    monkeypatch.setattr(db_pkg, "get_setting", _fake_get_setting)
+    yield {"kv": _kv}
+    schema_mod._reset_for_tests()
+    for schema in saved_schemas.values():
+        schema_mod.register(schema)
+    guild_config._reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# View shape: edit + reset selects appear when settings exist
+# ---------------------------------------------------------------------------
+
+
+def test_view_adds_edit_and_reset_selects_when_settings_exist():
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="moderation",
+            settings=(
+                SettingSpec(
+                    name="warn_threshold",
+                    value_type=int,
+                    default=3,
+                    settings_key="WARN_THRESHOLD",
+                ),
+            ),
+        ),
+    )
+    view = SubsystemSettingsView(_FakeMember(), "moderation")
+    selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
+    # One edit select + one reset select = two.
+    assert len(selects) == 2
+    placeholders = {s.placeholder for s in selects}
+    assert any("Edit" in p for p in placeholders)
+    assert any("Reset" in p for p in placeholders)
+
+
+def test_view_omits_selects_when_subsystem_has_no_settings():
+    view = SubsystemSettingsView(_FakeMember(), "blackjack")  # no schema
+    selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
+    assert selects == []
+    # Back button still present.
+    buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+    assert len(buttons) == 1
+
+
+def test_view_omits_selects_when_specs_have_no_settings_key():
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="moderation",
+            settings=(
+                # No settings_key → not editable.
+                SettingSpec(name="placeholder", value_type=int, default=0),
+            ),
+        ),
+    )
+    view = SubsystemSettingsView(_FakeMember(), "moderation")
+    selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
+    assert selects == []
+
+
+# ---------------------------------------------------------------------------
+# Dispatch by value_type
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_int_dispatches_to_number_modal(monkeypatch):
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="moderation",
+            settings=(
+                SettingSpec(
+                    name="warn_threshold",
+                    value_type=int,
+                    default=3,
+                    settings_key="WARN_THRESHOLD",
+                ),
+            ),
+        ),
+    )
+    select = _EditSettingSelect(
+        "moderation", [spec for spec in schema_mod.get_schema("moderation").settings]
+    )
+    select._values = ["warn_threshold"]
+    interaction = _FakeInteraction(guild=_FakeGuild())
+    await select.callback(interaction)
+    assert len(interaction.response.sent_modals) == 1
+    from views.settings.edit_number import NumberSettingModal
+
+    assert isinstance(interaction.response.sent_modals[0], NumberSettingModal)
+
+
+@pytest.mark.asyncio
+async def test_float_dispatches_to_number_modal():
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="rate",
+            settings=(
+                SettingSpec(
+                    name="multiplier",
+                    value_type=float,
+                    default=1.0,
+                    settings_key="RATE_MULTIPLIER",
+                ),
+            ),
+        ),
+    )
+    select = _EditSettingSelect(
+        "rate", [spec for spec in schema_mod.get_schema("rate").settings]
+    )
+    select._values = ["multiplier"]
+    interaction = _FakeInteraction(guild=_FakeGuild())
+    await select.callback(interaction)
+    from views.settings.edit_number import NumberSettingModal
+
+    assert isinstance(interaction.response.sent_modals[0], NumberSettingModal)
+
+
+@pytest.mark.asyncio
+async def test_str_without_allowed_values_dispatches_to_text_modal():
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="moderation",
+            settings=(
+                SettingSpec(
+                    name="dm_template",
+                    value_type=str,
+                    default="hello",
+                    settings_key="DM_TEMPLATE",
+                ),
+            ),
+        ),
+    )
+    select = _EditSettingSelect(
+        "moderation", [spec for spec in schema_mod.get_schema("moderation").settings]
+    )
+    select._values = ["dm_template"]
+    interaction = _FakeInteraction(guild=_FakeGuild())
+    await select.callback(interaction)
+    from views.settings.edit_text import TextSettingModal
+
+    assert isinstance(interaction.response.sent_modals[0], TextSettingModal)
+
+
+@pytest.mark.asyncio
+async def test_str_with_allowed_values_dispatches_to_enum_view():
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="cleanup",
+            settings=(
+                SettingSpec(
+                    name="strictness",
+                    value_type=str,
+                    default="normal",
+                    settings_key="CLEANUP_STRICTNESS",
+                    allowed_values=("off", "light", "normal", "strict"),
+                ),
+            ),
+        ),
+    )
+    select = _EditSettingSelect(
+        "cleanup", [spec for spec in schema_mod.get_schema("cleanup").settings]
+    )
+    select._values = ["strictness"]
+    interaction = _FakeInteraction(guild=_FakeGuild())
+    await select.callback(interaction)
+    # No modal — the enum widget is a follow-up view.
+    assert interaction.response.sent_modals == []
+    # An ephemeral message with a view was sent instead.
+    assert len(interaction.response.sent_messages) == 1
+    from views.settings.edit_enum import EnumSettingSelectView
+
+    msg = interaction.response.sent_messages[0]
+    assert isinstance(msg["view"], EnumSettingSelectView)
+
+
+@pytest.mark.asyncio
+async def test_bool_dispatches_to_toggle_directly(monkeypatch, _isolated_state):
+    """Bool select pick toggles the value via the pipeline directly
+    instead of opening a modal."""
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="moderation",
+            settings=(
+                SettingSpec(
+                    name="dm_on_action",
+                    value_type=bool,
+                    default=False,
+                    settings_key="MOD_DM_ON_ACTION",
+                ),
+            ),
+        ),
+    )
+    # Monkeypatch the pipeline through to track that toggle ran.
+    from views.settings import edit_boolean
+
+    captured: dict = {}
+    real_toggle = edit_boolean.toggle_setting
+
+    async def _spy_toggle(*args, **kwargs):
+        captured["called"] = True
+        captured["args"] = args
+        # Don't actually run the pipeline — the modal tests cover that
+        # path.  Just call the interaction.response.send_message stub so
+        # the spy looks like real behaviour.
+        interaction = args[0]
+        await interaction.response.send_message("spy toggle ran", ephemeral=True)
+
+    monkeypatch.setattr(edit_boolean, "toggle_setting", _spy_toggle)
+
+    select = _EditSettingSelect(
+        "moderation", [spec for spec in schema_mod.get_schema("moderation").settings]
+    )
+    select._values = ["dm_on_action"]
+    interaction = _FakeInteraction(guild=_FakeGuild())
+    await select.callback(interaction)
+    assert captured.get("called") is True
+    # No modal opened.
+    assert interaction.response.sent_modals == []
+
+
+@pytest.mark.asyncio
+async def test_unknown_setting_in_select_rejected():
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="moderation",
+            settings=(
+                SettingSpec(
+                    name="warn_threshold",
+                    value_type=int,
+                    default=3,
+                    settings_key="WARN_THRESHOLD",
+                ),
+            ),
+        ),
+    )
+    select = _EditSettingSelect(
+        "moderation", [spec for spec in schema_mod.get_schema("moderation").settings]
+    )
+    # Pick a value that wouldn't appear in options — defensive against
+    # client-side tampering.
+    select._values = ["no_such_setting"]
+    interaction = _FakeInteraction(guild=_FakeGuild())
+    await select.callback(interaction)
+    last = interaction.response.sent_messages[-1]
+    assert "Unknown setting" in (last.get("content") or "")

--- a/tests/unit/views/test_settings_edit_modals.py
+++ b/tests/unit/views/test_settings_edit_modals.py
@@ -1,0 +1,471 @@
+"""Unit tests for the S6 scalar edit / reset widgets.
+
+Covers each widget's mutation-pipeline path independently of the
+SubsystemSettingsView dispatch (which is tested separately by
+test_settings_cog_edit_routes.py): bool toggle, int / float modal,
+free-form text modal, enum-select view, reset button.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.runtime import guild_config
+from core.runtime import subsystem_schema as schema_mod
+from core.runtime.subsystem_schema import SettingSpec, SubsystemSchema
+from services import settings_mutation as sm_mod
+from utils import db as db_pkg
+from utils.db import settings as settings_db
+from utils.db import settings_audit as audit_db
+from views.settings.edit_boolean import toggle_setting
+from views.settings.edit_enum import EnumSettingSelectView
+from views.settings.edit_number import NumberSettingModal
+from views.settings.edit_text import TextSettingModal
+from views.settings.reset_button import reset_setting
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeGuild:
+    def __init__(self, guild_id: int = 1, owner_id: int = 0):
+        self.id = guild_id
+        self.owner_id = owner_id
+
+
+class _FakeMember:
+    def __init__(self, member_id: int = 7, *, guild: _FakeGuild | None = None):
+        self.id = member_id
+        self.guild = guild or _FakeGuild()
+
+        class _Perms:
+            administrator = True
+            manage_channels = True
+            manage_roles = True
+            manage_guild = True
+            moderate_members = False
+
+        self.guild_permissions = _Perms()
+
+
+class _FakeResponse:
+    def __init__(self):
+        self.sent: list[dict] = []
+
+    async def send_message(self, content=None, *, ephemeral=False, view=None, **_kw):
+        self.sent.append(
+            {"content": content, "ephemeral": ephemeral, "view": view},
+        )
+
+    async def send_modal(self, modal):
+        self.sent.append({"modal": modal})
+
+
+class _FakeMessage:
+    def __init__(self):
+        self.edited: list[dict] = []
+
+    async def edit(self, *, embed=None, view=None):
+        self.edited.append({"embed": embed, "view": view})
+
+
+class _FakeInteraction:
+    def __init__(self, guild: _FakeGuild | None = None):
+        self.guild = guild
+        self.guild_id = guild.id if guild else None
+        self.user = _FakeMember(guild=guild)
+        self.message = _FakeMessage()
+        self.response = _FakeResponse()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — shared in-memory KV + audit stubs across all edit widgets
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(monkeypatch):
+    saved_schemas = schema_mod.all_schemas()
+    schema_mod._reset_for_tests()
+    guild_config._reset_for_tests()
+    sm_mod._reset_for_tests = getattr(sm_mod, "_reset_for_tests", lambda: None)
+
+    _kv: dict[tuple[int, str], str] = {}
+
+    async def _fake_get_setting(
+        guild_id: int,
+        key: str,
+        default: str = "",
+    ) -> str:
+        return _kv.get((guild_id, key), default)
+
+    monkeypatch.setattr(settings_db, "get_setting", _fake_get_setting)
+    monkeypatch.setattr(db_pkg, "get_setting", _fake_get_setting)
+
+    audit_log: list[dict] = []
+
+    async def _fake_set_value_with_audit(
+        *,
+        guild_id: int,
+        subsystem: str,
+        name: str,
+        settings_key: str,
+        prev_value_raw,
+        new_value_raw: str,
+        actor_id,
+        actor_type: str,
+        mutation_id: str,
+        mutation_type: str = "set_value",
+    ) -> None:
+        _kv[(guild_id, settings_key)] = new_value_raw
+        audit_log.append(
+            {
+                "guild_id": guild_id,
+                "subsystem": subsystem,
+                "name": name,
+                "settings_key": settings_key,
+                "prev_value_raw": prev_value_raw,
+                "new_value_raw": new_value_raw,
+                "actor_id": actor_id,
+                "actor_type": actor_type,
+                "mutation_id": mutation_id,
+                "mutation_type": mutation_type,
+            },
+        )
+
+    monkeypatch.setattr(audit_db, "set_value_with_audit", _fake_set_value_with_audit)
+
+    from core.events import bus
+
+    emitted: list[dict] = []
+
+    async def _fake_emit(event, /, **payload):
+        emitted.append({"event": event, **payload})
+
+    monkeypatch.setattr(bus, "emit", _fake_emit)
+
+    yield {"kv": _kv, "audit_log": audit_log, "emitted": emitted}
+
+    schema_mod._reset_for_tests()
+    for schema in saved_schemas.values():
+        schema_mod.register(schema)
+    guild_config._reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Boolean toggle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_boolean_toggle_inverts_value(_isolated_state):
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="moderation",
+            settings=(
+                SettingSpec(
+                    name="dm_on_action",
+                    value_type=bool,
+                    default=False,
+                    settings_key="MOD_DM_ON_ACTION",
+                ),
+            ),
+        ),
+    )
+    interaction = _FakeInteraction(guild=_FakeGuild())
+    await toggle_setting(interaction, "moderation", "dm_on_action")
+    assert _isolated_state["audit_log"][-1]["new_value_raw"] == "true"
+    # Confirmation sent.
+    assert any("Toggled" in (s.get("content") or "") for s in interaction.response.sent)
+
+
+@pytest.mark.asyncio
+async def test_boolean_toggle_dm_invocation_rejected():
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="moderation",
+            settings=(
+                SettingSpec(
+                    name="dm_on_action",
+                    value_type=bool,
+                    default=False,
+                    settings_key="MOD_DM_ON_ACTION",
+                ),
+            ),
+        ),
+    )
+    interaction = _FakeInteraction(guild=None)
+    await toggle_setting(interaction, "moderation", "dm_on_action")
+    assert any(
+        "guild" in (s.get("content") or "").lower() for s in interaction.response.sent
+    )
+
+
+# ---------------------------------------------------------------------------
+# Number modal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_number_modal_writes_via_pipeline(_isolated_state):
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="moderation",
+            settings=(
+                SettingSpec(
+                    name="warn_threshold",
+                    value_type=int,
+                    default=3,
+                    settings_key="WARN_THRESHOLD",
+                ),
+            ),
+        ),
+    )
+    modal = NumberSettingModal(
+        subsystem="moderation",
+        setting_name="warn_threshold",
+        value_type=int,
+        current_value=3,
+        default_value=3,
+    )
+    modal.input = type("Stub", (), {"value": "5"})()
+    interaction = _FakeInteraction(guild=_FakeGuild())
+    await modal.on_submit(interaction)
+    assert _isolated_state["audit_log"][-1]["new_value_raw"] == "5"
+    assert _isolated_state["audit_log"][-1]["prev_value_raw"] is None
+    assert any("Updated" in (s.get("content") or "") for s in interaction.response.sent)
+
+
+@pytest.mark.asyncio
+async def test_number_modal_handles_coercion_failure_gracefully():
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="moderation",
+            settings=(
+                SettingSpec(
+                    name="warn_threshold",
+                    value_type=int,
+                    default=3,
+                    settings_key="WARN_THRESHOLD",
+                ),
+            ),
+        ),
+    )
+    modal = NumberSettingModal(
+        subsystem="moderation",
+        setting_name="warn_threshold",
+        value_type=int,
+        current_value=3,
+        default_value=3,
+    )
+    modal.input = type("Stub", (), {"value": "abc"})()  # not coercible
+    interaction = _FakeInteraction(guild=_FakeGuild())
+    await modal.on_submit(interaction)
+    # No audit row written.
+    # Pipeline raises SettingsCoercionError → modal surfaces it ephemerally.
+    last = interaction.response.sent[-1]
+    assert "SettingsCoercionError" in (last.get("content") or "")
+
+
+# ---------------------------------------------------------------------------
+# Text modal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_text_modal_writes_string_value(_isolated_state):
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="moderation",
+            settings=(
+                SettingSpec(
+                    name="dm_template",
+                    value_type=str,
+                    default="Hello",
+                    settings_key="DM_TEMPLATE",
+                ),
+            ),
+        ),
+    )
+    modal = TextSettingModal(
+        subsystem="moderation",
+        setting_name="dm_template",
+        current_value="Hello",
+        default_value="Hello",
+    )
+    modal.input = type("Stub", (), {"value": "Greetings, please review."})()
+    interaction = _FakeInteraction(guild=_FakeGuild())
+    await modal.on_submit(interaction)
+    assert (
+        _isolated_state["audit_log"][-1]["new_value_raw"] == "Greetings, please review."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Enum select view
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enum_select_view_writes_chosen_value(_isolated_state):
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="cleanup",
+            settings=(
+                SettingSpec(
+                    name="strictness",
+                    value_type=str,
+                    default="normal",
+                    settings_key="CLEANUP_STRICTNESS",
+                    allowed_values=("off", "light", "normal", "strict"),
+                ),
+            ),
+        ),
+    )
+    view = EnumSettingSelectView(
+        subsystem="cleanup",
+        setting_name="strictness",
+        allowed_values=("off", "light", "normal", "strict"),
+        current_value="normal",
+    )
+    import discord
+
+    select = next(c for c in view.children if isinstance(c, discord.ui.Select))
+    select._values = ["strict"]
+    interaction = _FakeInteraction(guild=_FakeGuild())
+    await select.callback(interaction)
+    assert _isolated_state["audit_log"][-1]["new_value_raw"] == "strict"
+
+
+def test_enum_select_view_marks_current_value():
+    view = EnumSettingSelectView(
+        subsystem="cleanup",
+        setting_name="strictness",
+        allowed_values=("off", "light", "normal", "strict"),
+        current_value="normal",
+    )
+    import discord
+
+    select = next(c for c in view.children if isinstance(c, discord.ui.Select))
+    defaults = [opt for opt in select.options if opt.default]
+    assert len(defaults) == 1
+    assert defaults[0].value == "normal"
+
+
+# ---------------------------------------------------------------------------
+# Reset button
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reset_button_writes_default_value(_isolated_state):
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="moderation",
+            settings=(
+                SettingSpec(
+                    name="warn_threshold",
+                    value_type=int,
+                    default=3,
+                    settings_key="WARN_THRESHOLD",
+                ),
+            ),
+        ),
+    )
+    _isolated_state["kv"][(1, "WARN_THRESHOLD")] = "9"
+    interaction = _FakeInteraction(guild=_FakeGuild())
+    await reset_setting(interaction, "moderation", "warn_threshold")
+    last_audit = _isolated_state["audit_log"][-1]
+    assert last_audit["new_value_raw"] == "3"
+    assert last_audit["prev_value_raw"] == "9"
+    assert any("Reset" in (s.get("content") or "") for s in interaction.response.sent)
+
+
+@pytest.mark.asyncio
+async def test_reset_button_dm_invocation_rejected():
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="moderation",
+            settings=(
+                SettingSpec(
+                    name="warn_threshold",
+                    value_type=int,
+                    default=3,
+                    settings_key="WARN_THRESHOLD",
+                ),
+            ),
+        ),
+    )
+    interaction = _FakeInteraction(guild=None)
+    await reset_setting(interaction, "moderation", "warn_threshold")
+    assert any(
+        "guild" in (s.get("content") or "").lower() for s in interaction.response.sent
+    )
+
+
+@pytest.mark.asyncio
+async def test_reset_button_unknown_setting_rejected():
+    interaction = _FakeInteraction(guild=_FakeGuild())
+    await reset_setting(interaction, "moderation", "no_such_setting")
+    last = interaction.response.sent[-1]
+    assert "Unknown setting" in (last.get("content") or "")
+
+
+# ---------------------------------------------------------------------------
+# Event + cache invalidation observable end-to-end
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_smoke_warn_threshold_3_to_5_observable(_isolated_state):
+    """User's smoke goal: flip moderation.warn_threshold 3→5 via modal;
+    audit row + event + cache invalidation observable.
+    """
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="moderation",
+            settings=(
+                SettingSpec(
+                    name="warn_threshold",
+                    value_type=int,
+                    default=3,
+                    settings_key="WARN_THRESHOLD",
+                ),
+            ),
+        ),
+    )
+    modal = NumberSettingModal(
+        subsystem="moderation",
+        setting_name="warn_threshold",
+        value_type=int,
+        current_value=3,
+        default_value=3,
+    )
+    modal.input = type("Stub", (), {"value": "5"})()
+    interaction = _FakeInteraction(guild=_FakeGuild())
+    await modal.on_submit(interaction)
+    # Audit row observable.
+    assert _isolated_state["audit_log"][-1] == {
+        "guild_id": 1,
+        "subsystem": "moderation",
+        "name": "warn_threshold",
+        "settings_key": "WARN_THRESHOLD",
+        "prev_value_raw": None,
+        "new_value_raw": "5",
+        "actor_id": 7,
+        "actor_type": "user",
+        "mutation_id": _isolated_state["audit_log"][-1]["mutation_id"],
+        "mutation_type": "set_value",
+    }
+    # Event observable.
+    assert any(
+        ev["event"] == "settings.changed" and ev["new_value_raw"] == "5"
+        for ev in _isolated_state["emitted"]
+    )
+    # Cache invalidation observable (subsequent resolve sees 5).
+    from services.settings_resolution import resolve_setting
+
+    res = await resolve_setting(1, "moderation", "warn_threshold")
+    assert res.value == 5
+    assert res.provenance == "legacy_kv"

--- a/tests/unit/views/test_settings_edit_safety.py
+++ b/tests/unit/views/test_settings_edit_safety.py
@@ -1,0 +1,369 @@
+"""Additional S6 safety tests — covers the four categories the user
+flagged that the modal-routing tests do not exercise:
+
+* permission failure — non-admin actor is rejected by the pipeline
+  and the modal surfaces the error ephemerally.
+* disabled feature flag — the !settings command refuses to open
+  the hub, so the edit flow is unreachable.
+* stale interactions — when ``interaction.response`` calls raise
+  (the 3-second window expired or Discord refused the response),
+  the widget logs and does not propagate.
+* merge-order dependency — the S5 base files this PR stacks on
+  must exist on disk; a stand-alone main-branch checkout would
+  fail this test (alerting the reviewer to the dependency).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.runtime import guild_config
+from core.runtime import subsystem_schema as schema_mod
+from core.runtime.subsystem_schema import SettingSpec, SubsystemSchema
+from services import settings_mutation as sm_mod
+from utils import db as db_pkg
+from utils.db import settings as settings_db
+from utils.db import settings_audit as audit_db
+from views.settings.edit_number import NumberSettingModal
+from views.settings.reset_button import reset_setting
+
+# ---------------------------------------------------------------------------
+# Minimal fakes (own copy — keeps this file standalone)
+# ---------------------------------------------------------------------------
+
+
+class _FakeGuild:
+    def __init__(self, guild_id: int = 1, owner_id: int = 0):
+        self.id = guild_id
+        self.owner_id = owner_id
+
+
+class _FakeMember:
+    """Configurable member.  When ``admin=False`` the visibility-tier
+    lookup returns ``user`` so the pipeline raises
+    UnauthorizedSettingsMutationError.
+    """
+
+    def __init__(self, *, guild: _FakeGuild | None = None, admin: bool = True):
+        self.id = 7
+        self.guild = guild or _FakeGuild()
+
+        class _Perms:
+            administrator = admin
+            manage_channels = admin
+            manage_roles = admin
+            manage_guild = admin
+            moderate_members = False
+
+        self.guild_permissions = _Perms()
+
+
+class _StaleResponse:
+    """``send_message`` raises — simulates the 3-second Discord window
+    having lapsed.  ``send_modal`` similarly raises.
+    """
+
+    async def send_message(self, *_a, **_kw):
+        raise RuntimeError("interaction expired (simulated)")
+
+    async def send_modal(self, *_a, **_kw):
+        raise RuntimeError("interaction expired (simulated)")
+
+
+class _CapturingResponse:
+    def __init__(self):
+        self.sent: list[dict] = []
+
+    async def send_message(self, content=None, *, ephemeral=False, view=None, **_kw):
+        self.sent.append(
+            {"content": content, "ephemeral": ephemeral, "view": view},
+        )
+
+    async def send_modal(self, modal):
+        self.sent.append({"modal": modal})
+
+
+class _FakeInteraction:
+    def __init__(
+        self,
+        *,
+        guild: _FakeGuild | None = None,
+        admin: bool = True,
+        stale: bool = False,
+    ):
+        self.guild = guild
+        self.guild_id = guild.id if guild else None
+        self.user = _FakeMember(guild=guild, admin=admin)
+        self.message = None
+        self.response = _StaleResponse() if stale else _CapturingResponse()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — same shape as the modal tests; isolated KV / audit / event
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(monkeypatch):
+    saved_schemas = schema_mod.all_schemas()
+    schema_mod._reset_for_tests()
+    guild_config._reset_for_tests()
+
+    _kv: dict[tuple[int, str], str] = {}
+
+    async def _fake_get_setting(
+        guild_id: int,
+        key: str,
+        default: str = "",
+    ) -> str:
+        return _kv.get((guild_id, key), default)
+
+    monkeypatch.setattr(settings_db, "get_setting", _fake_get_setting)
+    monkeypatch.setattr(db_pkg, "get_setting", _fake_get_setting)
+
+    audit_log: list[dict] = []
+
+    async def _fake_set_value_with_audit(**kwargs):
+        _kv[(kwargs["guild_id"], kwargs["settings_key"])] = kwargs["new_value_raw"]
+        audit_log.append(kwargs)
+
+    monkeypatch.setattr(audit_db, "set_value_with_audit", _fake_set_value_with_audit)
+
+    from core.events import bus
+
+    async def _fake_emit(*_a, **_kw):
+        return None
+
+    monkeypatch.setattr(bus, "emit", _fake_emit)
+
+    yield {"kv": _kv, "audit_log": audit_log}
+
+    schema_mod._reset_for_tests()
+    for schema in saved_schemas.values():
+        schema_mod.register(schema)
+    guild_config._reset_for_tests()
+    # settings_mutation has no counters reset hook today; mirror the
+    # other pipelines' shape if it grows one in a future PR.
+    _reset = getattr(sm_mod, "_reset_counters_for_tests", None)
+    if _reset is not None:
+        _reset()
+
+
+# ---------------------------------------------------------------------------
+# Permission failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_modal_rejects_non_admin_actor(_isolated_state):
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="moderation",
+            settings=(
+                SettingSpec(
+                    name="warn_threshold",
+                    value_type=int,
+                    default=3,
+                    settings_key="WARN_THRESHOLD",
+                ),
+            ),
+        ),
+    )
+    modal = NumberSettingModal(
+        subsystem="moderation",
+        setting_name="warn_threshold",
+        value_type=int,
+        current_value=3,
+        default_value=3,
+    )
+    modal.input = type("Stub", (), {"value": "5"})()
+    interaction = _FakeInteraction(guild=_FakeGuild(), admin=False)
+    await modal.on_submit(interaction)
+    # No audit row.
+    assert _isolated_state["audit_log"] == []
+    # Ephemeral error mentions UnauthorizedSettingsMutationError.
+    last = interaction.response.sent[-1]
+    assert "Unauthorized" in (last.get("content") or "")
+
+
+@pytest.mark.asyncio
+async def test_reset_rejects_non_admin_actor(_isolated_state):
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="moderation",
+            settings=(
+                SettingSpec(
+                    name="warn_threshold",
+                    value_type=int,
+                    default=3,
+                    settings_key="WARN_THRESHOLD",
+                ),
+            ),
+        ),
+    )
+    interaction = _FakeInteraction(guild=_FakeGuild(), admin=False)
+    await reset_setting(interaction, "moderation", "warn_threshold")
+    assert _isolated_state["audit_log"] == []
+    last = interaction.response.sent[-1]
+    assert "Unauthorized" in (last.get("content") or "")
+
+
+# ---------------------------------------------------------------------------
+# Disabled feature flag — the S6 edit flow is unreachable when the
+# S5 cog gate flag is OFF (the hub never opens).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_settings_cog_blocks_edit_flow_when_flag_off(monkeypatch):
+    """The S5 gate flag is the only entrypoint to the edit flow.
+    With the flag OFF, the !settings command returns the disabled
+    embed and never constructs SubsystemSettingsView — so the edit
+    selects never reach the user.
+    """
+    from cogs import settings_cog
+    from core.runtime import feature_flags
+
+    async def _flag_off(_name, _guild_id):
+        return False
+
+    monkeypatch.setattr(feature_flags, "is_enabled", _flag_off)
+
+    sent: list[object] = []
+
+    class _Channel:
+        async def send(self, *_a, **kw):
+            embed = kw.get("embed")
+            if embed is not None:
+                sent.append(embed)
+
+            class _Msg:
+                id = 1
+
+            return _Msg()
+
+    class _Ctx:
+        guild = _FakeGuild()
+        author = _FakeMember(guild=guild)
+        channel = _Channel()
+
+        async def send(self, *args, **kwargs):
+            return await self.channel.send(*args, **kwargs)
+
+    cog = settings_cog.SettingsCog(bot=None)  # type: ignore[arg-type]
+    await cog.settings_root.callback(cog, _Ctx())
+    assert any("disabled" in (e.title or "").lower() for e in sent)
+
+
+# ---------------------------------------------------------------------------
+# Stale interactions — the modal must not crash if Discord refuses the
+# response (e.g. the 3-second window lapsed).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_modal_stale_interaction_does_not_crash():
+    """When ``interaction.response.send_message`` raises, the on_submit
+    coroutine surfaces the failure cleanly instead of crashing the
+    event loop.
+    """
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="moderation",
+            settings=(
+                SettingSpec(
+                    name="warn_threshold",
+                    value_type=int,
+                    default=3,
+                    settings_key="WARN_THRESHOLD",
+                ),
+            ),
+        ),
+    )
+    modal = NumberSettingModal(
+        subsystem="moderation",
+        setting_name="warn_threshold",
+        value_type=int,
+        current_value=3,
+        default_value=3,
+    )
+    # Submit a value that will FAIL coercion so the modal hits the
+    # send_message branch first (coercion error path).
+    modal.input = type("Stub", (), {"value": "abc"})()
+    interaction = _FakeInteraction(guild=_FakeGuild(), stale=True)
+    # Coercion error tries to send an ephemeral; the stale response
+    # raises.  The on_submit propagates that error up — discord.py's
+    # on_error handler is what the production view error decorator
+    # catches.  We assert the propagation rather than swallowing it
+    # (matches the existing BaseView.on_error contract).
+    with pytest.raises(RuntimeError, match="interaction expired"):
+        await modal.on_submit(interaction)
+
+
+@pytest.mark.asyncio
+async def test_reset_stale_interaction_does_not_crash():
+    schema_mod.register(
+        SubsystemSchema(
+            subsystem="moderation",
+            settings=(
+                SettingSpec(
+                    name="no_such_setting",
+                    value_type=int,
+                    default=0,
+                    settings_key="X",
+                ),
+            ),
+        ),
+    )
+    interaction = _FakeInteraction(guild=_FakeGuild(), stale=True)
+    # ``unknown setting`` path triggers send_message — which raises.
+    with pytest.raises(RuntimeError, match="interaction expired"):
+        await reset_setting(interaction, "moderation", "no_such_setting_x")
+
+
+# ---------------------------------------------------------------------------
+# Merge-order dependency — S6 stacks on S5.  These S5 files MUST exist
+# on disk; if not, the reviewer is on the wrong branch.
+# ---------------------------------------------------------------------------
+
+
+def test_s5_base_files_exist_on_this_branch():
+    """S6 stacks on PR #100 (S5).  Verify the S5 files are present —
+    if they are missing, the branch was created from main without
+    rebasing on the S5 branch, and the PR will fail in surprising
+    ways.
+    """
+    repo_root = Path(__file__).resolve().parents[3]
+    expected = [
+        repo_root / "disbot" / "cogs" / "settings_cog.py",
+        repo_root / "disbot" / "views" / "settings" / "hub.py",
+        repo_root / "disbot" / "views" / "settings" / "subsystem_view.py",
+        repo_root / "disbot" / "views" / "settings" / "audit_view.py",
+    ]
+    missing = [str(p.relative_to(repo_root)) for p in expected if not p.exists()]
+    assert not missing, (
+        "S6 stacks on S5 (PR #100).  The S5 files are missing from this "
+        "branch — was it created from main without rebasing on the S5 "
+        "branch?\n  Missing:\n  " + "\n  ".join(missing)
+    )
+
+
+def test_s6_invariant_allowlist_only_contains_edit_files():
+    """The S5 read-only invariant lifted in S6 must allowlist exactly
+    the five edit-flow files (and nothing else).  Catches a future
+    drive-by edit that allowlists the hub or audit view by mistake.
+    """
+    from tests.unit.invariants.test_settings_cog_read_only import (
+        _ALLOWED_EDIT_FILES,
+    )
+
+    names = {p.name for p in _ALLOWED_EDIT_FILES}
+    assert names == {
+        "edit_boolean.py",
+        "edit_number.py",
+        "edit_text.py",
+        "edit_enum.py",
+        "reset_button.py",
+    }


### PR DESCRIPTION
## ⚠️ Stacked on PR #100 — merge order: #100 first, then this PR

This branch is built on top of `claude/settings-cog-readonly` (PR
#100 — S5 Settings Manager cog shell). It is the **first write
surface** on the Settings Manager UI introduced by S5.

**Base branch:** `claude/settings-cog-readonly` (so the GitHub diff
shows only the S6 increment). When PR #100 merges into `main`, the
GitHub Mergeable UI will automatically retarget this PR onto `main`
and rebase cleanly.

If you'd prefer this PR to target `main` directly, the rebase is
trivial because the two branches touch disjoint files outside the
`feature_flags.py` flag declaration (already merged in PR #100's
base sync against S4.5).

## Summary

S6 of the Global Settings & Customization Manager roadmap. Adds
edit modals + reset selects to the per-subsystem view that S5
introduced. All writes route through
`SettingsMutationPipeline.set_value` (S4 / PR #97).

### Strict scope (per directive)

- ✅ scalar setting edit modals (`int` / `float` / `str` / `bool` / enum)
- ✅ scalar setting reset flow
- ✅ `SettingSpec` validation (via the pipeline)
- ✅ `SettingsMutationPipeline.set_value` only
- ✅ audit / result display (ephemeral confirmation embeds)
- ✅ tests for success, validation failure, permission failure,
  disabled flag, stale interactions, merge-order dependency

### Out of scope (per directive)

- ❌ binding edits
- ❌ resource creation
- ❌ `ResourceProvisioningPipeline` UI
- ❌ logging channel selection
- ❌ cleanup policy edits
- ❌ access policy edits
- ❌ setup wizard
- ❌ slash commands
- ❌ broad schema onboarding
- ❌ unrelated cog panel changes

## Widget dispatch (in SubsystemSettingsView's Edit-Setting Select)

| `SettingSpec.value_type` | `allowed_values` | Widget |
|---|---|---|
| `bool` | — | `BooleanSettingToggle` (direct toggle) |
| `int` / `float` | — | `NumberSettingModal` |
| `str` | `()` empty | `TextSettingModal` |
| `str` | non-empty | `EnumSettingSelectView` (ephemeral follow-up) |

`Reset a setting…` Select writes `spec.default` via the pipeline.

## Files changed (11 files, +2,000 lines)

- **`disbot/core/runtime/subsystem_schema.py`** — extend
  `SettingSpec` with `allowed_values: tuple[Any, ...] = ()`
  (backward compatible).
- **`disbot/views/settings/edit_boolean.py`** *(new)* —
  `toggle_setting` helper.
- **`disbot/views/settings/edit_number.py`** *(new)* —
  `NumberSettingModal` (single `TextInput`; pipeline does
  coercion + validation).
- **`disbot/views/settings/edit_text.py`** *(new)* —
  `TextSettingModal` (paragraph-style, max 2000 chars).
- **`disbot/views/settings/edit_enum.py`** *(new)* —
  `EnumSettingSelectView` for str + non-empty `allowed_values`.
  (Discord modals can't host `Select`, so the enum widget is a
  follow-up view.)
- **`disbot/views/settings/reset_button.py`** *(new)* —
  `reset_setting` helper.
- **`disbot/views/settings/subsystem_view.py`** — add two Selects
  ("Edit a setting…", "Reset a setting to its default…") to the
  per-subsystem view; appear only when the subsystem has at least
  one `SettingSpec` with a `settings_key`. Best-effort
  parent-message refresh after each mutation.
- **`tests/unit/invariants/test_settings_cog_read_only.py`** —
  LIFT the S5 read-only invariant. Introduce
  `_ALLOWED_EDIT_FILES` and update both AST scans (imports +
  method calls) to skip allowlisted files. Add allowlist-shape
  sanity tests.
- **`tests/unit/views/test_settings_edit_modals.py`** *(new, 11
  tests)* — per-widget mutation paths (bool / number / text /
  enum / reset) + end-to-end smoke (`warn_threshold` 3 → 5
  observable via audit row + event + cache invalidation).
- **`tests/unit/views/test_settings_cog_edit_routes.py`** *(new,
  9 tests)* — `SubsystemSettingsView` dispatch shape: Selects
  appear / hide based on schema; bool / int / float / str /
  enum dispatch correctly; unknown setting rejected.
- **`tests/unit/views/test_settings_edit_safety.py`** *(new, 7
  tests)* — the four user-flagged categories:
  - permission failure (modal + reset reject non-admin)
  - disabled flag (S5 cog gate blocks the entry)
  - stale interactions (response failure propagates cleanly so
    `BaseView.on_error` catches)
  - merge-order sanity (S5 base files present)
  - allowlist shape sanity

## Migrations + flags + events

- **No migrations.** S4 (migration 029) already shipped the audit
  table. The S6 pipeline write goes through `set_value_with_audit`.
- **No new feature flags.** Reuses S5's `settings.manager_cog.enabled`
  gate (default OFF) — the edit flow is only reachable through the
  hub, which is gated.
- **No new events.** S4's `settings.changed` is emitted by every
  write.

## Tests run and exact results

- [x] `pytest tests/unit/views/test_settings_edit_modals.py` — **11 passed**
- [x] `pytest tests/unit/views/test_settings_cog_edit_routes.py` — **9 passed**
- [x] `pytest tests/unit/views/test_settings_edit_safety.py` — **7 passed**
- [x] `pytest tests/unit/invariants/test_settings_cog_read_only.py` — **5 passed** (lifted invariant + sanity)
- [x] `pytest tests/unit/cogs/test_settings_cog.py` + neighbours — S5 tests still green
- [x] `pytest tests/unit/` — full suite: **1891 passed, 0 failed, 12 warnings**
- [x] `ruff check disbot/` — clean
- [x] `black --check disbot/` — 253 files unchanged
- [x] `isort --check-only disbot/ tests/` — clean
- [x] `mypy disbot/` — no issues found in 253 source files

## Manual smoke checklist (for the operator)

With `settings.manager_cog.enabled` flipped ON:

- `!settings` → hub → pick `moderation` → drilldown shows
  `warn_threshold` = 3 (default).
- Pick `Edit a setting…` → choose `warn_threshold` → modal opens.
- Type `5` → submit → ephemeral `✅ Updated`.
- Refresh the subsystem view → value is now `5` with provenance
  `legacy_kv`, valid.
- Pick `Reset a setting…` → choose `warn_threshold` →
  ephemeral `✅ Reset`. Drilldown shows `3` again.
- Try `abc` for `warn_threshold` → modal returns
  `❌ SettingsCoercionError: cannot coerce 'abc' to int: …`. No
  audit row, no event.
- Demote your role below administrator → try to open the edit
  modal → `❌ UnauthorizedSettingsMutationError: member … requires
  at least 'administrator' …`. No audit row.

## Risks and rollback

- **Risk:** narrow. The pipeline already had every safety
  (coercion, validation, authority, audit, cache invalidation,
  event emission). S6 adds UI bindings only — no new write path
  semantics.
- **Rollback:** `git revert` of this PR + the lifted invariant
  reverts to the S5 read-only shape. No DB rollback needed.

## Deferred work

Carries over from earlier milestones:

- `services.platform_consistency` collectors for the S1 / S2 /
  S2.5 / S3 / S4 / S4.5 / S5 / S6 diagnostic providers (one PR).
- S6 audit-action distinction: future `mutation_type='reset_value'`
  in migration 031 if dashboards want to filter resets separately
  from sets.

## Next milestones (NOT in this PR)

Per the user's explicit directive to stop after S6:

- S7 — Logging customization (binding edits + create-or-select flow)
- S8 — Cleanup customization expansion
- S9 — Access policy manager
- S10 — Per-subsystem setup packs
- S11 — Help / Admin / Platform integration pass
- S12 — Setup wizard integration planning

These wait for a new directive.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U3sByR3PY3gobeB3jLFDFD)_