### PR TITLE
feat(navigation): platform panel shell — !platform opens interactive hub

### DIFF
--- a/disbot/cogs/diagnostic/_platform_embeds.py
+++ b/disbot/cogs/diagnostic/_platform_embeds.py
@@ -3,23 +3,17 @@
 Extracted from ``cogs/diagnostic_cog.py`` to keep the cog under the
 800-LOC fail threshold enforced by
 ``tests/unit/invariants/test_cog_size.py``.  Each builder is a pure
-async function that fetches its data (via ``services.diagnostics_service``
-and/or ``utils.db.*``) and returns a single :class:`discord.Embed`
-ready to send.  The cog methods become thin wrappers that delegate
-here.
-
-Phase 2a + 2b + 2.10 builders covered:
-
-* :func:`build_resources_embed`     — ``!platform resources``
-* :func:`build_bindings_embed`      — ``!platform bindings``
-* :func:`build_consistency_embed`   — ``!platform consistency``
-
-Earlier-phase platform commands stay inline in the cog for now.  When
-the next batch of platform commands lands and pushes the cog back
-toward the ceiling, those should migrate here too.
+async (or sync) function that fetches its data (via
+``services.diagnostics_service`` and/or ``utils.db.*``) and returns
+a single :class:`discord.Embed` ready to send.  The cog methods
+become thin wrappers that delegate here, and the
+``_PlatformHubView`` panel reuses the same builders so its select
+callbacks produce the same embed as the typed command.
 """
 
 from __future__ import annotations
+
+import datetime
 
 import discord
 
@@ -483,12 +477,563 @@ def build_provisioning_embed() -> discord.Embed:
     return embed
 
 
+# ---------------------------------------------------------------------------
+# Runtime / status group
+# ---------------------------------------------------------------------------
+
+
+def build_status_embed(bot: discord.Client) -> discord.Embed:
+    """Build the embed for ``!platform status``."""
+    from core.runtime import tasks as runtime_tasks
+
+    uptime_obj = getattr(bot, "uptime", None)
+    uptime_s = (
+        str(datetime.datetime.now(tz=datetime.timezone.utc) - uptime_obj)
+        if uptime_obj
+        else "n/a"
+    )
+    embed = discord.Embed(
+        title="🛠 Platform status",
+        color=discord.Color.blurple(),
+    )
+    embed.add_field(name="Uptime", value=uptime_s, inline=True)
+    embed.add_field(name="Guilds", value=str(len(bot.guilds)), inline=True)
+    embed.add_field(name="Cogs loaded", value=str(len(bot.cogs)), inline=True)
+    embed.add_field(
+        name="Managed tasks",
+        value=str(runtime_tasks.count()),
+        inline=True,
+    )
+    try:
+        from services.governance_service import _FAILED_SUBSYSTEMS
+
+        failed = ", ".join(sorted(_FAILED_SUBSYSTEMS)) or "none"
+    except Exception:
+        failed = "?"
+    embed.add_field(name="Failed subsystems", value=failed, inline=False)
+    return embed
+
+
+def build_runtime_embed() -> discord.Embed:
+    """Build the embed for ``!platform runtime`` (snapshot_all roll-up)."""
+    from services import diagnostics_service
+
+    snap = diagnostics_service.snapshot_all()
+    embed = discord.Embed(
+        title="🛰 Runtime snapshot",
+        description=f"{len(snap)} provider(s) registered.",
+        color=discord.Color.blurple(),
+    )
+    for name in sorted(snap):
+        embed.add_field(
+            name=name,
+            value=_fmt_snapshot_value(snap[name]),
+            inline=False,
+        )
+    return embed
+
+
+def build_caches_embed() -> discord.Embed:
+    """Build the embed for ``!platform caches``."""
+    from services import diagnostics_service
+
+    embed = discord.Embed(
+        title="🧠 Cache snapshot",
+        color=discord.Color.blurple(),
+    )
+    for name in ("guild_config", "governance_cache"):
+        try:
+            snap = diagnostics_service.snapshot(name)
+        except KeyError:
+            snap = {"_error": "provider not registered"}
+        embed.add_field(
+            name=name,
+            value=_fmt_snapshot_value(snap),
+            inline=False,
+        )
+    return embed
+
+
+def build_locks_embed(prefix: str = "") -> discord.Embed:
+    """Build the embed for ``!platform locks [prefix]``."""
+    from services import diagnostics_service
+
+    snap = diagnostics_service.snapshot("scope_locks")
+    by_prefix = dict(snap.get("by_prefix", {}))
+    if prefix:
+        by_prefix = {k: v for k, v in by_prefix.items() if k == prefix}
+    embed = discord.Embed(
+        title="🔒 Scope locks",
+        description=(
+            f"total: **{snap.get('total', 0)}**  ·  "
+            f"held: **{snap.get('held', 0)}**"
+            + (f"  ·  filter: `{prefix}`" if prefix else "")
+        ),
+        color=discord.Color.blurple(),
+    )
+    if by_prefix:
+        lines = [f"`{k}` — {v}" for k, v in sorted(by_prefix.items())]
+        embed.add_field(
+            name="By prefix",
+            value="\n".join(lines)[:1024],
+            inline=False,
+        )
+    else:
+        embed.add_field(
+            name="By prefix",
+            value="*(no locks matching filter)*" if prefix else "*(none)*",
+            inline=False,
+        )
+    return embed
+
+
+def build_tasks_embed() -> discord.Embed:
+    """Build the embed for ``!platform tasks``."""
+    from services import diagnostics_service
+
+    snap = diagnostics_service.snapshot("tasks")
+    names = list(snap.get("names", []))
+    embed = discord.Embed(
+        title="🔁 Managed tasks",
+        description=f"{snap.get('active_count', 0)} active",
+        color=discord.Color.blurple(),
+    )
+    if names:
+        embed.add_field(
+            name="Names",
+            value="\n".join(f"`{n}`" for n in names)[:1024],
+            inline=False,
+        )
+    return embed
+
+
+def build_views_embed() -> discord.Embed:
+    """Build the embed for ``!platform views``."""
+    from services import diagnostics_service
+
+    snap = diagnostics_service.snapshot("persistent_views")
+    subsystems = list(snap.get("subsystems", []))
+    embed = discord.Embed(
+        title="🖼 Persistent views",
+        description=f"{snap.get('registered_count', 0)} registered",
+        color=discord.Color.blurple(),
+    )
+    if subsystems:
+        embed.add_field(
+            name="Subsystems",
+            value=", ".join(f"`{s}`" for s in subsystems)[:1024],
+            inline=False,
+        )
+    return embed
+
+
+def build_slow_embed(limit: int = 10) -> discord.Embed:
+    """Build the embed for ``!platform slow [limit]`` (S3.2 ring buffer)."""
+    from core.runtime import slow_path_log
+
+    entries = slow_path_log.snapshot()
+    limit = max(1, min(limit, 25))
+    recent = entries[-limit:]
+    embed = discord.Embed(
+        title="🐢 Slow path log",
+        description=(
+            f"**{len(entries)}** entries  ·  threshold: "
+            f"`{slow_path_log.threshold_ms():.0f}ms`  ·  "
+            f"capacity: `{slow_path_log.capacity()}`"
+        ),
+        color=discord.Color.blurple(),
+    )
+    if not recent:
+        embed.add_field(
+            name="No slow paths recorded",
+            value=f"All observations under {slow_path_log.threshold_ms():.0f}ms.",
+            inline=False,
+        )
+    else:
+        embed.set_footer(text=f"Showing the {len(recent)} most recent.")
+        for entry in reversed(recent):
+            age_s = max(0.0, datetime.datetime.now().timestamp() - entry.timestamp)
+            embed.add_field(
+                name=f"{entry.kind}: {entry.name}",
+                value=f"**{entry.duration_ms:.0f}ms**  ·  {age_s:.0f}s ago",
+                inline=False,
+            )
+    return embed
+
+
+async def build_sessions_embed(
+    subsystem: str = "",
+) -> tuple[discord.Embed | None, str | None]:
+    """Build the embed for ``!platform sessions [subsystem]``.
+
+    Returns ``(embed, None)`` on success or ``(None, error_str)`` if the
+    DB query fails — callers preserve the existing error-surface
+    behavior of the typed command by checking the second element.
+    """
+    from utils import db
+
+    try:
+        if subsystem:
+            rows = await db.fetchall(
+                "SELECT subsystem, COUNT(*) AS n FROM runtime_sessions "
+                "WHERE subsystem=$1 GROUP BY subsystem",
+                (subsystem,),
+            )
+        else:
+            rows = await db.fetchall(
+                "SELECT subsystem, COUNT(*) AS n FROM runtime_sessions "
+                "GROUP BY subsystem ORDER BY n DESC",
+                (),
+            )
+    except Exception as exc:  # noqa: BLE001 — surface DB outage to operator
+        return None, f"❌ DB query failed: {exc}"
+    embed = discord.Embed(
+        title="🎫 Active sessions",
+        description=(f"filter: `{subsystem}`" if subsystem else "all subsystems"),
+        color=discord.Color.blurple(),
+    )
+    if rows:
+        lines = [f"`{r['subsystem']}` — {r['n']}" for r in rows]
+        embed.add_field(
+            name="By subsystem",
+            value="\n".join(lines)[:1024],
+            inline=False,
+        )
+    else:
+        embed.add_field(name="By subsystem", value="*(none)*", inline=False)
+    return embed, None
+
+
+# ---------------------------------------------------------------------------
+# Validation group
+# ---------------------------------------------------------------------------
+
+
+async def build_anchors_embed() -> discord.Embed:
+    """Build the embed for ``!platform anchors``."""
+    from core.runtime import message_anchor_manager
+    from utils import db
+
+    stats = message_anchor_manager.last_restore_stats()
+    embed = discord.Embed(
+        title="📌 Panel anchors",
+        color=discord.Color.blurple(),
+    )
+    embed.add_field(
+        name="Last restoration",
+        value=(
+            f"seen: **{stats['anchors_seen']}**  ·  "
+            f"restored: **{stats['restored']}**  ·  "
+            f"view_missing: **{stats['view_missing']}**  ·  "
+            f"stale: **{stats['stale']}**"
+        ),
+        inline=False,
+    )
+    try:
+        rows = await db.fetchall(
+            "SELECT subsystem, COUNT(*) AS n FROM panel_anchors "
+            "WHERE NOT is_stale GROUP BY subsystem ORDER BY n DESC",
+            (),
+        )
+        if rows:
+            lines = [f"`{r['subsystem']}` — {r['n']}" for r in rows]
+            embed.add_field(
+                name="Active anchors by subsystem",
+                value="\n".join(lines)[:1024],
+                inline=False,
+            )
+        else:
+            embed.add_field(
+                name="Active anchors by subsystem",
+                value="none",
+                inline=False,
+            )
+    except Exception as exc:  # noqa: BLE001 — DB outage shouldn't crash command
+        embed.add_field(
+            name="Active anchors by subsystem",
+            value=f"DB query failed: {exc}",
+            inline=False,
+        )
+    return embed
+
+
+async def build_identity_embed(
+    bot: discord.Client,
+    mode: str = "",
+) -> discord.Embed:
+    """Build the embed for ``!platform identity [--fix]``."""
+    from utils.subsystem_registry import (
+        apply_self_heal,
+        summarize_findings,
+        validate_identity_contract,
+    )
+
+    findings = await validate_identity_contract(bot)
+    summary = summarize_findings(findings)
+    total = summary["total"]
+    fatal = summary["by_tier"]["fatal"]
+    auto = summary["by_tier"]["auto_healable"]
+
+    heal_requested = mode.strip() in ("--fix", "-f", "fix")
+    heal_counts: dict[str, int] | None = None
+    if heal_requested:
+        heal_counts = await apply_self_heal(findings)
+
+    if total == 0:
+        color = discord.Color.green()
+        desc = "All four identity surfaces agree."
+    elif fatal:
+        color = discord.Color.red()
+        desc = (
+            f"{total} finding(s) — **{fatal} fatal**, "
+            f"{auto} auto-healable.  Fatal findings require operator "
+            "review (likely a cog failed to load)."
+        )
+    else:
+        color = discord.Color.orange()
+        desc = f"{total} finding(s) — {auto} auto-healable."
+
+    embed = discord.Embed(
+        title="🪪 Identity contract",
+        description=desc,
+        color=color,
+    )
+    for bucket, items in findings.items():
+        if not items:
+            continue
+        embed.add_field(
+            name=f"{bucket} ({len(items)})",
+            value="\n".join(items)[:1024],
+            inline=False,
+        )
+    if heal_counts is not None:
+        embed.add_field(
+            name="Self-heal result",
+            value=(
+                f"router prefixes unregistered: "
+                f"`{heal_counts['router_prefixes_unregistered']}` · "
+                f"views unregistered: `{heal_counts['views_unregistered']}` · "
+                f"anchors marked stale: "
+                f"`{heal_counts['anchors_marked_stale']}` · "
+                f"fatal-tier skipped: `{heal_counts['skipped_fatal']}`"
+            ),
+            inline=False,
+        )
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# Catalogues group — additional inline embeds
+# ---------------------------------------------------------------------------
+
+
+def build_participation_schemas_embed() -> discord.Embed:
+    """Build the embed for ``!platform participation-schemas`` (Phase 1b)."""
+    from services import diagnostics_service
+
+    snap = diagnostics_service.snapshot("participation_schemas")
+    embed = discord.Embed(
+        title="🧑‍🤝‍🧑 Participation schemas",
+        description=(
+            f"{snap['registered']} registered  ·  "
+            f"subs={snap['subscriptions_total']}  ·  "
+            f"vis={snap['visibility_intents_total']}  ·  "
+            f"notif={snap['notification_intents_total']}  ·  "
+            f"prefs={snap['preferences_total']}"
+        ),
+        color=discord.Color.blurple(),
+    )
+    by_sub = snap.get("by_subsystem", {})
+    if by_sub:
+        lines = [
+            f"`{name}` — s={info['subscriptions']} "
+            f"v={info['visibility_intents']} "
+            f"n={info['notification_intents']} "
+            f"p={info['preferences']} v{info['version']}"
+            for name, info in sorted(by_sub.items())
+        ]
+        embed.add_field(
+            name="By subsystem",
+            value="\n".join(lines)[:1024],
+            inline=False,
+        )
+    else:
+        embed.add_field(name="By subsystem", value="*(none)*", inline=False)
+    return embed
+
+
+def build_resource_requirements_embed() -> discord.Embed:
+    """Build the embed for ``!platform resource-requirements`` (Phase 1c)."""
+    from services import diagnostics_service
+
+    snap = diagnostics_service.snapshot("resource_requirements")
+    embed = discord.Embed(
+        title="🧱 Resource requirements",
+        description=f"{len(snap)} requirement(s) declared",
+        color=discord.Color.blurple(),
+    )
+    if snap:
+        lines = [
+            f"`{r['subsystem']}` {r['kind']}/{r['intent']} "
+            f"({r['priority']})"
+            + (f" → `{r['suggested_name']}`" if r["suggested_name"] else "")
+            for r in snap
+        ]
+        embed.add_field(
+            name="Requirements",
+            value="\n".join(lines)[:1024],
+            inline=False,
+        )
+    else:
+        embed.add_field(name="Requirements", value="*(none)*", inline=False)
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# Resources / rollout group — additional inline embeds
+# ---------------------------------------------------------------------------
+
+
+async def build_flags_embed(guild: discord.Guild | None) -> discord.Embed:
+    """Build the embed for ``!platform flags``.
+
+    Resolves every declared flag with provenance for the supplied guild
+    (when ``guild`` is None, falls back to the global resolver context).
+    """
+    from core.runtime import feature_flags
+    from services import diagnostics_service
+
+    snap = diagnostics_service.snapshot("feature_flags")
+    guild_id = guild.id if guild else None
+    rows: list[str] = []
+    for name in sorted(snap.get("by_name", {})):
+        info = snap["by_name"][name]
+        try:
+            decision = await feature_flags.resolve_with_provenance(
+                name,
+                guild_id,
+            )
+            effective = "on" if decision.value else "off"
+            source = decision.source
+        except Exception as exc:  # noqa: BLE001 — diagnostics must not raise
+            effective = "?"
+            source = f"error:{type(exc).__name__}"
+        rows.append(
+            f"`{name}` default={info['default_value']} "
+            f"effective={effective} src={source} owner=`{info['owner']}`",
+        )
+    embed = discord.Embed(
+        title="🚩 Feature flags",
+        description=(
+            f"{snap['declared_total']} declared  ·  "
+            f"cache={snap.get('cache_size', 0)}  ·  "
+            f"bootstrap_fallback={snap.get('bootstrap_fallback_count', 0)}"
+        ),
+        color=discord.Color.blurple(),
+    )
+    if rows:
+        embed.add_field(
+            name="Flags",
+            value="\n".join(rows)[:1024],
+            inline=False,
+        )
+    else:
+        embed.add_field(name="Flags", value="*(none)*", inline=False)
+    return embed
+
+
+async def build_migrations_embed(
+    guild: discord.Guild | None,
+) -> discord.Embed:
+    """Build the embed for ``!platform migrations`` (Phase 2 PR-5)."""
+    from utils.db import platform_migration_checkpoints as checkpoint_db
+
+    counts = await checkpoint_db.count_by_status()
+    guild_rows = (
+        await checkpoint_db.list_checkpoints(guild_id=guild.id) if guild else []
+    )
+    embed = discord.Embed(
+        title="🛠 Platform migrations",
+        description=(
+            "Generic logical-migration checkpoint table; first "
+            "consumer is the binding backfill (Phase 2 PR-5)."
+        ),
+        color=discord.Color.gold(),
+    )
+    if counts:
+        status_line = " · ".join(
+            f"{status}={n}" for status, n in sorted(counts.items())
+        )
+        embed.add_field(name="Global counts", value=status_line, inline=False)
+    else:
+        embed.add_field(
+            name="Global counts",
+            value="*(no rows)*",
+            inline=False,
+        )
+    if guild_rows:
+        rows: list[str] = []
+        for row in guild_rows[:20]:
+            summary = row.get("summary_json") or {}
+            inner_counts = summary.get("counts") if isinstance(summary, dict) else None
+            count_str = (
+                " ".join(f"{k}={v}" for k, v in sorted((inner_counts or {}).items()))
+                if inner_counts
+                else ""
+            )
+            rows.append(
+                f"`{row['name']}` status={row['status']} v={row['version']} "
+                f"{count_str}".strip(),
+            )
+        embed.add_field(
+            name=(
+                f"This guild ({len(guild_rows)} "
+                f"row{'s' if len(guild_rows) != 1 else ''})"
+            ),
+            value="\n".join(rows)[:1024],
+            inline=False,
+        )
+    else:
+        embed.add_field(
+            name="This guild",
+            value="*(no checkpoints)*",
+            inline=False,
+        )
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# Snapshot value formatter (shared helper)
+# ---------------------------------------------------------------------------
+
+
+def _fmt_snapshot_value(value: object) -> str:
+    """Format a diagnostics-snapshot value for embed display."""
+    from cogs.diagnostic._helpers import _fmt_snapshot_value as _impl
+
+    return _impl(value)
+
+
 __all__ = [
+    "build_anchors_embed",
     "build_bindings_embed",
+    "build_caches_embed",
     "build_consistency_embed",
     "build_customization_embed",
+    "build_flags_embed",
+    "build_identity_embed",
+    "build_locks_embed",
+    "build_migrations_embed",
+    "build_participation_schemas_embed",
     "build_provisioning_embed",
+    "build_resource_requirements_embed",
     "build_resources_embed",
+    "build_runtime_embed",
     "build_schemas_embed",
+    "build_sessions_embed",
     "build_settings_registry_embed",
+    "build_slow_embed",
+    "build_status_embed",
+    "build_tasks_embed",
+    "build_views_embed",
 ]

--- a/disbot/cogs/diagnostic/_platform_embeds.py
+++ b/disbot/cogs/diagnostic/_platform_embeds.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import datetime
 
 import discord
+from discord.ext import commands
 
 from services.platform_consistency import (
     ConsistencyReport,
@@ -482,7 +483,7 @@ def build_provisioning_embed() -> discord.Embed:
 # ---------------------------------------------------------------------------
 
 
-def build_status_embed(bot: discord.Client) -> discord.Embed:
+def build_status_embed(bot: commands.Bot) -> discord.Embed:
     """Build the embed for ``!platform status``."""
     from core.runtime import tasks as runtime_tasks
 
@@ -758,7 +759,7 @@ async def build_anchors_embed() -> discord.Embed:
 
 
 async def build_identity_embed(
-    bot: discord.Client,
+    bot: commands.Bot,
     mode: str = "",
 ) -> discord.Embed:
     """Build the embed for ``!platform identity [--fix]``."""

--- a/disbot/cogs/diagnostic_cog.py
+++ b/disbot/cogs/diagnostic_cog.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-import datetime
 import logging
 
 import discord
 from discord.ext import commands
 
 from cogs.diagnostic._helpers import (
-    _fmt_snapshot_value,
     build_bot_status_embed,
     build_check_database_embed,
     build_command_list_pages,
@@ -17,9 +15,36 @@ from cogs.diagnostic._helpers import (
     build_test_notification_embed,
     build_validate_json_embed,
 )
-from utils import db
+from cogs.diagnostic._platform_embeds import (
+    build_anchors_embed,
+    build_bindings_embed,
+    build_caches_embed,
+    build_consistency_embed,
+    build_customization_embed,
+    build_flags_embed,
+    build_identity_embed,
+    build_locks_embed,
+    build_migrations_embed,
+    build_participation_schemas_embed,
+    build_provisioning_embed,
+    build_resource_requirements_embed,
+    build_resources_embed,
+    build_runtime_embed,
+    build_schemas_embed,
+    build_sessions_embed,
+    build_settings_registry_embed,
+    build_slow_embed,
+    build_status_embed,
+    build_tasks_embed,
+    build_views_embed,
+)
 from views.base import send_panel
-from views.diagnostic import _DiagnosticsHubView, _PaginatorView
+from views.diagnostic import (
+    _DiagnosticsHubView,
+    _PaginatorView,
+    _PlatformHubView,
+    build_platform_hub_embed,
+)
 
 logger = logging.getLogger("bot")
 
@@ -181,109 +206,31 @@ class DiagnosticCog(commands.Cog):
     async def platform_grp(self, ctx):
         """Runtime introspection group.
 
-        Existing (R1):
-            !platform status      · !platform anchors · !platform identity
+        With no subcommand the interactive ``_PlatformHubView`` opens —
+        every existing typed ``!platform <subcommand>`` is preserved and
+        continues to work exactly as before.
 
-        Added in Phase S2.5 / O-1, backed by ``services.diagnostics_service``:
-            !platform runtime     · !platform caches  · !platform locks [prefix]
-            !platform tasks       · !platform views   · !platform sessions [subsystem]
-
-        Added in Phase 1 (subsystem ownership protocols):
-            !platform schemas              · !platform participation-schemas
-            !platform resource-requirements · !platform flags
-
-        Added in Phase 2a (unified resource runtime): !platform resources
-        Added in Phase 2b (subsystem bindings): !platform bindings
-        Added in Phase 2 PR-10: !platform consistency
+        Existing surfaces (read-only):
+            status · anchors · identity · runtime · caches ·
+            locks [prefix] · tasks · views · sessions [subsystem] ·
+            slow [limit] · schemas · settings-registry · customization ·
+            provisioning · participation-schemas · resource-requirements ·
+            resources · bindings · flags · migrations · consistency
         """
-        await ctx.send(
-            "Usage: `!platform <status|anchors|identity|"
-            "runtime|caches|locks|tasks|views|sessions|slow|"
-            "schemas|participation-schemas|resource-requirements|flags|"
-            "resources|bindings|migrations|consistency>`",
-            delete_after=20,
-        )
+        view = _PlatformHubView(ctx.author)
+        await send_panel(ctx, embed=build_platform_hub_embed(), view=view)
 
     @platform_grp.command(name="status")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def platform_status(self, ctx):
         """High-level platform status: uptime, cogs, governance, scheduler."""
-        from core.runtime import tasks as runtime_tasks
-
-        uptime_obj = getattr(self.bot, "uptime", None)
-        uptime_s = (
-            str(datetime.datetime.now(tz=datetime.timezone.utc) - uptime_obj)
-            if uptime_obj
-            else "n/a"
-        )
-        embed = discord.Embed(
-            title="🛠 Platform status",
-            color=discord.Color.blurple(),
-        )
-        embed.add_field(name="Uptime", value=uptime_s, inline=True)
-        embed.add_field(name="Guilds", value=str(len(self.bot.guilds)), inline=True)
-        embed.add_field(name="Cogs loaded", value=str(len(self.bot.cogs)), inline=True)
-        embed.add_field(
-            name="Managed tasks",
-            value=str(runtime_tasks.count()),
-            inline=True,
-        )
-        try:
-            from services.governance_service import _FAILED_SUBSYSTEMS
-
-            failed = ", ".join(sorted(_FAILED_SUBSYSTEMS)) or "none"
-        except Exception:
-            failed = "?"
-        embed.add_field(name="Failed subsystems", value=failed, inline=False)
-        await ctx.send(embed=embed)
+        await ctx.send(embed=build_status_embed(self.bot))
 
     @platform_grp.command(name="anchors")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def platform_anchors(self, ctx):
         """Show last restoration outcome and active anchor counts per subsystem."""
-        from core.runtime import message_anchor_manager
-
-        stats = message_anchor_manager.last_restore_stats()
-        embed = discord.Embed(
-            title="📌 Panel anchors",
-            color=discord.Color.blurple(),
-        )
-        embed.add_field(
-            name="Last restoration",
-            value=(
-                f"seen: **{stats['anchors_seen']}**  ·  "
-                f"restored: **{stats['restored']}**  ·  "
-                f"view_missing: **{stats['view_missing']}**  ·  "
-                f"stale: **{stats['stale']}**"
-            ),
-            inline=False,
-        )
-        try:
-            rows = await db.fetchall(
-                "SELECT subsystem, COUNT(*) AS n FROM panel_anchors "
-                "WHERE NOT is_stale GROUP BY subsystem ORDER BY n DESC",
-                (),
-            )
-            if rows:
-                lines = [f"`{r['subsystem']}` — {r['n']}" for r in rows]
-                embed.add_field(
-                    name="Active anchors by subsystem",
-                    value="\n".join(lines)[:1024],
-                    inline=False,
-                )
-            else:
-                embed.add_field(
-                    name="Active anchors by subsystem",
-                    value="none",
-                    inline=False,
-                )
-        except Exception as exc:
-            embed.add_field(
-                name="Active anchors by subsystem",
-                value=f"DB query failed: {exc}",
-                inline=False,
-            )
-        await ctx.send(embed=embed)
+        await ctx.send(embed=await build_anchors_embed())
 
     @platform_grp.command(name="identity")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
@@ -296,64 +243,7 @@ class DiagnosticCog(commands.Cog):
                                         findings (fatal-tier are never
                                         auto-fixed; cog reload required).
         """
-        from utils.subsystem_registry import (
-            apply_self_heal,
-            summarize_findings,
-            validate_identity_contract,
-        )
-
-        findings = await validate_identity_contract(self.bot)
-        summary = summarize_findings(findings)
-        total = summary["total"]
-        fatal = summary["by_tier"]["fatal"]
-        auto = summary["by_tier"]["auto_healable"]
-
-        heal_requested = mode.strip() in ("--fix", "-f", "fix")
-        heal_counts: dict[str, int] | None = None
-        if heal_requested:
-            heal_counts = await apply_self_heal(findings)
-
-        if total == 0:
-            color = discord.Color.green()
-            desc = "All four identity surfaces agree."
-        elif fatal:
-            color = discord.Color.red()
-            desc = (
-                f"{total} finding(s) — **{fatal} fatal**, "
-                f"{auto} auto-healable.  Fatal findings require operator "
-                "review (likely a cog failed to load)."
-            )
-        else:
-            color = discord.Color.orange()
-            desc = f"{total} finding(s) — {auto} auto-healable."
-
-        embed = discord.Embed(
-            title="🪪 Identity contract",
-            description=desc,
-            color=color,
-        )
-        for bucket, items in findings.items():
-            if not items:
-                continue
-            embed.add_field(
-                name=f"{bucket} ({len(items)})",
-                value="\n".join(items)[:1024],
-                inline=False,
-            )
-        if heal_counts is not None:
-            embed.add_field(
-                name="Self-heal result",
-                value=(
-                    f"router prefixes unregistered: "
-                    f"`{heal_counts['router_prefixes_unregistered']}` · "
-                    f"views unregistered: `{heal_counts['views_unregistered']}` · "
-                    f"anchors marked stale: "
-                    f"`{heal_counts['anchors_marked_stale']}` · "
-                    f"fatal-tier skipped: `{heal_counts['skipped_fatal']}`"
-                ),
-                inline=False,
-            )
-        await ctx.send(embed=embed)
+        await ctx.send(embed=await build_identity_embed(self.bot, mode))
 
     # ────────────────────────────────────────────────────────────────
     # !platform — Phase S2.5 / O-1: diagnostics_service-backed commands
@@ -363,189 +253,46 @@ class DiagnosticCog(commands.Cog):
     @commands.has_permissions(administrator=True)
     async def platform_runtime(self, ctx):
         """High-level runtime snapshot: every registered diagnostic provider."""
-        from services import diagnostics_service
-
-        snap = diagnostics_service.snapshot_all()
-        embed = discord.Embed(
-            title="🛰 Runtime snapshot",
-            description=f"{len(snap)} provider(s) registered.",
-            color=discord.Color.blurple(),
-        )
-        for name in sorted(snap):
-            embed.add_field(
-                name=name,
-                value=_fmt_snapshot_value(snap[name]),
-                inline=False,
-            )
-        await ctx.send(embed=embed)
+        await ctx.send(embed=build_runtime_embed())
 
     @platform_grp.command(name="caches")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def platform_caches(self, ctx):
         """Cache state: F-1 guild_config + governance.cache."""
-        from services import diagnostics_service
-
-        embed = discord.Embed(
-            title="🧠 Cache snapshot",
-            color=discord.Color.blurple(),
-        )
-        for name in ("guild_config", "governance_cache"):
-            try:
-                snap = diagnostics_service.snapshot(name)
-            except KeyError:
-                snap = {"_error": "provider not registered"}
-            embed.add_field(
-                name=name,
-                value=_fmt_snapshot_value(snap),
-                inline=False,
-            )
-        await ctx.send(embed=embed)
+        await ctx.send(embed=build_caches_embed())
 
     @platform_grp.command(name="locks")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def platform_locks(self, ctx, prefix: str = ""):
         """scope_locks snapshot; pass a prefix to filter (e.g. `counting`)."""
-        from services import diagnostics_service
-
-        snap = diagnostics_service.snapshot("scope_locks")
-        by_prefix = dict(snap.get("by_prefix", {}))
-        if prefix:
-            by_prefix = {k: v for k, v in by_prefix.items() if k == prefix}
-        embed = discord.Embed(
-            title="🔒 Scope locks",
-            description=(
-                f"total: **{snap.get('total', 0)}**  ·  "
-                f"held: **{snap.get('held', 0)}**"
-                + (f"  ·  filter: `{prefix}`" if prefix else "")
-            ),
-            color=discord.Color.blurple(),
-        )
-        if by_prefix:
-            lines = [f"`{k}` — {v}" for k, v in sorted(by_prefix.items())]
-            embed.add_field(
-                name="By prefix",
-                value="\n".join(lines)[:1024],
-                inline=False,
-            )
-        else:
-            embed.add_field(
-                name="By prefix",
-                value="*(no locks matching filter)*" if prefix else "*(none)*",
-                inline=False,
-            )
-        await ctx.send(embed=embed)
+        await ctx.send(embed=build_locks_embed(prefix))
 
     @platform_grp.command(name="tasks")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def platform_tasks(self, ctx):
         """Managed background-task snapshot (core.runtime.tasks)."""
-        from services import diagnostics_service
-
-        snap = diagnostics_service.snapshot("tasks")
-        names = list(snap.get("names", []))
-        embed = discord.Embed(
-            title="🔁 Managed tasks",
-            description=f"{snap.get('active_count', 0)} active",
-            color=discord.Color.blurple(),
-        )
-        if names:
-            embed.add_field(
-                name="Names",
-                value="\n".join(f"`{n}`" for n in names)[:1024],
-                inline=False,
-            )
-        await ctx.send(embed=embed)
+        await ctx.send(embed=build_tasks_embed())
 
     @platform_grp.command(name="views")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def platform_views(self, ctx):
         """Registered PersistentView classes (by subsystem)."""
-        from services import diagnostics_service
-
-        snap = diagnostics_service.snapshot("persistent_views")
-        subsystems = list(snap.get("subsystems", []))
-        embed = discord.Embed(
-            title="🖼 Persistent views",
-            description=f"{snap.get('registered_count', 0)} registered",
-            color=discord.Color.blurple(),
-        )
-        if subsystems:
-            embed.add_field(
-                name="Subsystems",
-                value=", ".join(f"`{s}`" for s in subsystems)[:1024],
-                inline=False,
-            )
-        await ctx.send(embed=embed)
+        await ctx.send(embed=build_views_embed())
 
     @platform_grp.command(name="slow")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def platform_slow(self, ctx, limit: int = 10):
         """Show the most recent slow-path entries (S3.2 ring buffer)."""
-        from core.runtime import slow_path_log
-
-        entries = slow_path_log.snapshot()
-        limit = max(1, min(limit, 25))  # Discord field-count guard
-        recent = entries[-limit:]
-        embed = discord.Embed(
-            title="🐢 Slow path log",
-            description=(
-                f"**{len(entries)}** entries  ·  threshold: "
-                f"`{slow_path_log.threshold_ms():.0f}ms`  ·  "
-                f"capacity: `{slow_path_log.capacity()}`"
-            ),
-            color=discord.Color.blurple(),
-        )
-        if not recent:
-            embed.add_field(
-                name="No slow paths recorded",
-                value=f"All observations under {slow_path_log.threshold_ms():.0f}ms.",
-                inline=False,
-            )
-        else:
-            embed.set_footer(text=f"Showing the {len(recent)} most recent.")
-            for entry in reversed(recent):  # most recent first
-                age_s = max(0.0, datetime.datetime.now().timestamp() - entry.timestamp)
-                embed.add_field(
-                    name=f"{entry.kind}: {entry.name}",
-                    value=f"**{entry.duration_ms:.0f}ms**  ·  {age_s:.0f}s ago",
-                    inline=False,
-                )
-        await ctx.send(embed=embed)
+        await ctx.send(embed=build_slow_embed(limit))
 
     @platform_grp.command(name="sessions")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def platform_sessions(self, ctx, subsystem: str = ""):
         """Active session counts (DB-backed); optionally filtered by subsystem."""
-        try:
-            if subsystem:
-                rows = await db.fetchall(
-                    "SELECT subsystem, COUNT(*) AS n FROM runtime_sessions "
-                    "WHERE subsystem=$1 GROUP BY subsystem",
-                    (subsystem,),
-                )
-            else:
-                rows = await db.fetchall(
-                    "SELECT subsystem, COUNT(*) AS n FROM runtime_sessions "
-                    "GROUP BY subsystem ORDER BY n DESC",
-                    (),
-                )
-        except Exception as exc:
-            await ctx.send(f"❌ DB query failed: {exc}", delete_after=15)
+        embed, error = await build_sessions_embed(subsystem)
+        if error is not None:
+            await ctx.send(error, delete_after=15)
             return
-        embed = discord.Embed(
-            title="🎫 Active sessions",
-            description=(f"filter: `{subsystem}`" if subsystem else "all subsystems"),
-            color=discord.Color.blurple(),
-        )
-        if rows:
-            lines = [f"`{r['subsystem']}` — {r['n']}" for r in rows]
-            embed.add_field(
-                name="By subsystem",
-                value="\n".join(lines)[:1024],
-                inline=False,
-            )
-        else:
-            embed.add_field(name="By subsystem", value="*(none)*", inline=False)
         await ctx.send(embed=embed)
 
     # ────────────────────────────────────────────────────────────────
@@ -556,234 +303,66 @@ class DiagnosticCog(commands.Cog):
     @commands.has_permissions(administrator=True)
     async def platform_schemas(self, ctx):
         """Registered SubsystemSchema instances (Phase 1a)."""
-        from cogs.diagnostic._platform_embeds import build_schemas_embed
-
         await ctx.send(embed=build_schemas_embed())
 
     @platform_grp.command(name="settings-registry")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def platform_settings_registry(self, ctx):
         """Frozen catalogue of every declared SettingSpec (S1)."""
-        from cogs.diagnostic._platform_embeds import build_settings_registry_embed
-
         await ctx.send(embed=build_settings_registry_embed())
 
     @platform_grp.command(name="customization")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def platform_customization(self, ctx):
         """Customization catalogue across subsystems (S2)."""
-        from cogs.diagnostic._platform_embeds import build_customization_embed
-
         await ctx.send(embed=build_customization_embed())
 
     @platform_grp.command(name="provisioning")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def platform_provisioning(self, ctx):
         """Cross-linked ResourceRequirement × BindingSpec catalogue (S2.5)."""
-        from cogs.diagnostic._platform_embeds import build_provisioning_embed
-
         await ctx.send(embed=build_provisioning_embed())
 
     @platform_grp.command(name="participation-schemas")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def platform_participation_schemas(self, ctx):
         """Registered ParticipationSchema instances (Phase 1b)."""
-        from services import diagnostics_service
-
-        snap = diagnostics_service.snapshot("participation_schemas")
-        embed = discord.Embed(
-            title="🧑‍🤝‍🧑 Participation schemas",
-            description=(
-                f"{snap['registered']} registered  ·  "
-                f"subs={snap['subscriptions_total']}  ·  "
-                f"vis={snap['visibility_intents_total']}  ·  "
-                f"notif={snap['notification_intents_total']}  ·  "
-                f"prefs={snap['preferences_total']}"
-            ),
-            color=discord.Color.blurple(),
-        )
-        by_sub = snap.get("by_subsystem", {})
-        if by_sub:
-            lines = [
-                f"`{name}` — s={info['subscriptions']} "
-                f"v={info['visibility_intents']} "
-                f"n={info['notification_intents']} "
-                f"p={info['preferences']} v{info['version']}"
-                for name, info in sorted(by_sub.items())
-            ]
-            embed.add_field(
-                name="By subsystem",
-                value="\n".join(lines)[:1024],
-                inline=False,
-            )
-        else:
-            embed.add_field(name="By subsystem", value="*(none)*", inline=False)
-        await ctx.send(embed=embed)
+        await ctx.send(embed=build_participation_schemas_embed())
 
     @platform_grp.command(name="resource-requirements")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def platform_resource_requirements(self, ctx):
         """Declared ResourceRequirement entries across subsystems (Phase 1c)."""
-        from services import diagnostics_service
-
-        snap = diagnostics_service.snapshot("resource_requirements")
-        embed = discord.Embed(
-            title="🧱 Resource requirements",
-            description=f"{len(snap)} requirement(s) declared",
-            color=discord.Color.blurple(),
-        )
-        if snap:
-            lines = [
-                f"`{r['subsystem']}` {r['kind']}/{r['intent']} "
-                f"({r['priority']})"
-                + (f" → `{r['suggested_name']}`" if r["suggested_name"] else "")
-                for r in snap
-            ]
-            embed.add_field(
-                name="Requirements",
-                value="\n".join(lines)[:1024],
-                inline=False,
-            )
-        else:
-            embed.add_field(name="Requirements", value="*(none)*", inline=False)
-        await ctx.send(embed=embed)
+        await ctx.send(embed=build_resource_requirements_embed())
 
     @platform_grp.command(name="bindings")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def platform_bindings(self, ctx):
         """Subsystem bindings (Phase 2b) — taxonomy + per-guild histograms."""
-        from cogs.diagnostic._platform_embeds import build_bindings_embed
-
         await ctx.send(embed=await build_bindings_embed(ctx.guild))
 
     @platform_grp.command(name="resources")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def platform_resources(self, ctx):
         """Resource runtime (Phase 2a) — taxonomy + cached status histogram."""
-        from cogs.diagnostic._platform_embeds import build_resources_embed
-
         await ctx.send(embed=await build_resources_embed(ctx.guild))
 
     @platform_grp.command(name="flags")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def platform_flags(self, ctx):
         """Feature flags: declarations + Phase 2d evaluator state per flag."""
-        from core.runtime import feature_flags
-        from services import diagnostics_service
-
-        snap = diagnostics_service.snapshot("feature_flags")
-        guild_id = ctx.guild.id if ctx.guild else None
-        rows: list[str] = []
-        for name in sorted(snap.get("by_name", {})):
-            info = snap["by_name"][name]
-            try:
-                decision = await feature_flags.resolve_with_provenance(
-                    name,
-                    guild_id,
-                )
-                effective = "on" if decision.value else "off"
-                source = decision.source
-            except Exception as exc:  # noqa: BLE001 — diagnostics must not raise
-                effective = "?"
-                source = f"error:{type(exc).__name__}"
-            rows.append(
-                f"`{name}` default={info['default_value']} "
-                f"effective={effective} src={source} owner=`{info['owner']}`",
-            )
-        embed = discord.Embed(
-            title="🚩 Feature flags",
-            description=(
-                f"{snap['declared_total']} declared  ·  "
-                f"cache={snap.get('cache_size', 0)}  ·  "
-                f"bootstrap_fallback={snap.get('bootstrap_fallback_count', 0)}"
-            ),
-            color=discord.Color.blurple(),
-        )
-        if rows:
-            embed.add_field(
-                name="Flags",
-                value="\n".join(rows)[:1024],
-                inline=False,
-            )
-        else:
-            embed.add_field(name="Flags", value="*(none)*", inline=False)
-        await ctx.send(embed=embed)
+        await ctx.send(embed=await build_flags_embed(ctx.guild))
 
     @platform_grp.command(name="migrations")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def platform_migrations(self, ctx):
-        """Platform migration checkpoints (Phase 2 PR-5) — status + summary.
-
-        Read-only.  Lists every checkpoint row in
-        ``platform_migration_checkpoints`` for this guild (and global
-        rows), grouped by migration name.  Dry-run / backfill /
-        reconciliation runs are invoked from a Python REPL on the bot
-        host; this command just surfaces their state.
-        """
-        from utils.db import platform_migration_checkpoints as checkpoint_db
-
-        # Counts (global view) + per-guild rows.
-        counts = await checkpoint_db.count_by_status()
-        guild_rows = (
-            await checkpoint_db.list_checkpoints(guild_id=ctx.guild.id)
-            if ctx.guild
-            else []
-        )
-        embed = discord.Embed(
-            title="🛠 Platform migrations",
-            description=(
-                "Generic logical-migration checkpoint table; first "
-                "consumer is the binding backfill (Phase 2 PR-5)."
-            ),
-            color=discord.Color.gold(),
-        )
-        if counts:
-            status_line = " · ".join(
-                f"{status}={n}" for status, n in sorted(counts.items())
-            )
-            embed.add_field(name="Global counts", value=status_line, inline=False)
-        else:
-            embed.add_field(
-                name="Global counts",
-                value="*(no rows)*",
-                inline=False,
-            )
-        if guild_rows:
-            rows: list[str] = []
-            for row in guild_rows[:20]:
-                summary = row.get("summary_json") or {}
-                inner_counts = (
-                    summary.get("counts") if isinstance(summary, dict) else None
-                )
-                count_str = (
-                    " ".join(
-                        f"{k}={v}" for k, v in sorted((inner_counts or {}).items())
-                    )
-                    if inner_counts
-                    else ""
-                )
-                rows.append(
-                    f"`{row['name']}` status={row['status']} v={row['version']} "
-                    f"{count_str}".strip(),
-                )
-            embed.add_field(
-                name=f"This guild ({len(guild_rows)} row{'s' if len(guild_rows) != 1 else ''})",
-                value="\n".join(rows)[:1024],
-                inline=False,
-            )
-        else:
-            embed.add_field(
-                name="This guild",
-                value="*(no checkpoints)*",
-                inline=False,
-            )
-        await ctx.send(embed=embed)
+        """Platform migration checkpoints (Phase 2 PR-5) — status + summary."""
+        await ctx.send(embed=await build_migrations_embed(ctx.guild))
 
     @platform_grp.command(name="consistency")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def platform_consistency(self, ctx):
         """Unified platform readiness diagnostic — read-only (Phase 2 PR-10)."""
-        from cogs.diagnostic._platform_embeds import build_consistency_embed
         from services.platform_consistency import collect_report
 
         report = await collect_report(bot=self.bot, guild=ctx.guild)

--- a/disbot/views/diagnostic/__init__.py
+++ b/disbot/views/diagnostic/__init__.py
@@ -1,4 +1,4 @@
-"""views.diagnostic — diagnostics hub + paginated views.
+"""views.diagnostic — diagnostics hub + platform hub + paginated views.
 
 Extracted from ``cogs/diagnostic_cog.py`` during S4.4.5; the hub
 view's interaction-lifecycle pattern was canonicalised in PR #55
@@ -6,27 +6,35 @@ view's interaction-lifecycle pattern was canonicalised in PR #55
 architecture``).
 
 Modules:
-    paginator  — ``_PaginatorView`` (generic prev/next embed paginator;
-                 optional ``parent_view`` enables a back button)
-    hub_panel  — ``_DiagnosticsHubView`` (admin diagnostic dashboard;
-                 each button uses ``safe_defer`` + ``safe_edit`` to
-                 update the panel in place, matching the canonical
-                 panel pattern used by ``views/economy/main_panel.py``,
-                 ``views/moderation/main_panel.py``, etc.)
+    paginator       — ``_PaginatorView`` (generic prev/next embed
+                      paginator; optional ``parent_view`` enables a
+                      back button)
+    hub_panel       — ``_DiagnosticsHubView`` (admin diagnostic
+                      dashboard; each button uses ``safe_defer`` +
+                      ``safe_edit`` to update the panel in place,
+                      matching the canonical panel pattern used by
+                      ``views/economy/main_panel.py``,
+                      ``views/moderation/main_panel.py``, etc.)
+    platform_panel  — ``_PlatformHubView`` (read-only platform hub
+                      opened by ``!platform`` with no subcommand;
+                      groups 21 surfaces into four category Selects)
 
-Neither view is a PersistentView — both are ephemeral, timeout-based.
-The hub view takes only the invoking ``author`` and reads ``bot``
-from ``interaction.client`` at callback time, so the same view can
-be safely instantiated from either ``!diagnostics`` (direct command)
-or ``HelpPanelView._on_select`` (help-menu invocation).
+None of these views are PersistentViews — all are ephemeral,
+timeout-based.  Each hub view takes only the invoking ``author`` and
+reads ``bot`` from ``interaction.client`` at callback time, so the
+same view can be safely instantiated from either the typed command
+or ``HelpPanelView._on_select``.
 """
 
 from __future__ import annotations
 
 from views.diagnostic.hub_panel import _DiagnosticsHubView
 from views.diagnostic.paginator import _PaginatorView
+from views.diagnostic.platform_panel import _PlatformHubView, build_platform_hub_embed
 
 __all__ = [
     "_DiagnosticsHubView",
     "_PaginatorView",
+    "_PlatformHubView",
+    "build_platform_hub_embed",
 ]

--- a/disbot/views/diagnostic/platform_panel.py
+++ b/disbot/views/diagnostic/platform_panel.py
@@ -1,0 +1,291 @@
+"""Interactive ``!platform`` admin panel (read-only).
+
+``_PlatformHubView`` is the ephemeral hub opened by ``!platform`` with
+no subcommand. It groups every existing ``!platform <subcommand>``
+into four category Selects (Runtime/status, Catalogues,
+Resources/rollout, Validation), plus an Overview button that returns
+to the category listing.
+
+Selects update the panel in place via ``safe_defer`` +
+``safe_edit``, identical to ``_DiagnosticsHubView`` and
+``SettingsHubView`` (canonical panel pattern). All embeds are
+produced by the existing builders in
+``cogs.diagnostic._platform_embeds`` so the panel and the typed
+commands render byte-identical embeds.
+
+The panel is strictly read-only: no mutation, no resource creation,
+no setting writes. Typed ``!platform <subcommand>`` commands are
+preserved and continue to support their existing filter/limit
+arguments which the panel does not expose (those remain text-only
+power-user paths).
+"""
+
+from __future__ import annotations
+
+import discord
+
+from cogs.diagnostic._platform_embeds import (
+    build_anchors_embed,
+    build_bindings_embed,
+    build_caches_embed,
+    build_consistency_embed,
+    build_customization_embed,
+    build_flags_embed,
+    build_identity_embed,
+    build_locks_embed,
+    build_migrations_embed,
+    build_participation_schemas_embed,
+    build_provisioning_embed,
+    build_resource_requirements_embed,
+    build_resources_embed,
+    build_runtime_embed,
+    build_schemas_embed,
+    build_sessions_embed,
+    build_settings_registry_embed,
+    build_slow_embed,
+    build_status_embed,
+    build_tasks_embed,
+    build_views_embed,
+)
+from core.runtime.interaction_helpers import safe_defer, safe_edit
+from views.base import HubView
+
+_RUNTIME_OPTIONS = (
+    ("status", "🛠", "Uptime, cogs, guilds, scheduler, failed subsystems"),
+    ("runtime", "🛰", "snapshot_all roll-up across every provider"),
+    ("caches", "🧠", "F-1 guild_config + governance cache state"),
+    ("locks", "🔒", "scope_locks snapshot (no filter)"),
+    ("tasks", "🔁", "Managed background-task snapshot"),
+    ("views", "🖼", "Registered PersistentView classes by subsystem"),
+    ("sessions", "🎫", "Active session counts by subsystem"),
+    ("slow", "🐢", "Slow-path log entries (latest 10)"),
+)
+
+_CATALOGUES_OPTIONS = (
+    ("schemas", "📐", "Registered SubsystemSchema instances"),
+    ("settings-registry", "🗂️", "Every declared SettingSpec"),
+    ("customization", "🧭", "Customization catalogue across subsystems"),
+    ("provisioning", "🧰", "ResourceRequirement × BindingSpec catalogue"),
+    ("participation-schemas", "🧑‍🤝‍🧑", "Registered ParticipationSchema instances"),
+    ("resource-requirements", "🧱", "Declared ResourceRequirement entries"),
+)
+
+_RESOURCES_OPTIONS = (
+    ("resources", "🧱", "Resource runtime taxonomy + status histogram"),
+    ("bindings", "🔗", "Subsystem bindings taxonomy + per-guild counts"),
+    ("flags", "🚩", "Feature flag declarations + effective resolution"),
+    ("migrations", "🛠", "Platform migration checkpoints"),
+)
+
+_VALIDATION_OPTIONS = (
+    ("identity", "🪪", "Identity-contract validator findings"),
+    ("consistency", "🛡", "Unified platform readiness diagnostic"),
+    ("anchors", "📌", "Panel anchor restoration + active counts"),
+)
+
+
+def build_platform_hub_embed() -> discord.Embed:
+    """Build the overview embed that lists every grouped surface."""
+    embed = discord.Embed(
+        title="🛰 Platform hub",
+        description=(
+            "Read-only diagnostics. Pick a surface from one of the "
+            "category dropdowns below — every entry maps to an "
+            "existing `!platform <subcommand>`."
+        ),
+        color=discord.Color.blurple(),
+    )
+    embed.add_field(
+        name="Runtime / status",
+        value="\n".join(
+            f"{emoji} `{name}` — {desc}" for name, emoji, desc in _RUNTIME_OPTIONS
+        ),
+        inline=False,
+    )
+    embed.add_field(
+        name="Catalogues",
+        value="\n".join(
+            f"{emoji} `{name}` — {desc}" for name, emoji, desc in _CATALOGUES_OPTIONS
+        ),
+        inline=False,
+    )
+    embed.add_field(
+        name="Resources / rollout",
+        value="\n".join(
+            f"{emoji} `{name}` — {desc}" for name, emoji, desc in _RESOURCES_OPTIONS
+        ),
+        inline=False,
+    )
+    embed.add_field(
+        name="Validation",
+        value="\n".join(
+            f"{emoji} `{name}` — {desc}" for name, emoji, desc in _VALIDATION_OPTIONS
+        ),
+        inline=False,
+    )
+    embed.set_footer(
+        text=(
+            "Typed `!platform <name>` commands keep working with their "
+            "filters/limits (e.g. `!platform locks counting`)."
+        ),
+    )
+    return embed
+
+
+async def _dispatch(name: str, interaction: discord.Interaction) -> discord.Embed:
+    """Map a Select value to its embed builder."""
+    bot = interaction.client
+    guild = interaction.guild
+    if name == "status":
+        return build_status_embed(bot)
+    if name == "runtime":
+        return build_runtime_embed()
+    if name == "caches":
+        return build_caches_embed()
+    if name == "locks":
+        return build_locks_embed()
+    if name == "tasks":
+        return build_tasks_embed()
+    if name == "views":
+        return build_views_embed()
+    if name == "slow":
+        return build_slow_embed()
+    if name == "sessions":
+        embed, error = await build_sessions_embed()
+        if embed is not None:
+            return embed
+        return discord.Embed(
+            title="🎫 Active sessions",
+            description=error or "Unknown error.",
+            color=discord.Color.red(),
+        )
+    if name == "schemas":
+        return build_schemas_embed()
+    if name == "settings-registry":
+        return build_settings_registry_embed()
+    if name == "customization":
+        return build_customization_embed()
+    if name == "provisioning":
+        return build_provisioning_embed()
+    if name == "participation-schemas":
+        return build_participation_schemas_embed()
+    if name == "resource-requirements":
+        return build_resource_requirements_embed()
+    if name == "resources":
+        return await build_resources_embed(guild)
+    if name == "bindings":
+        return await build_bindings_embed(guild)
+    if name == "flags":
+        return await build_flags_embed(guild)
+    if name == "migrations":
+        return await build_migrations_embed(guild)
+    if name == "identity":
+        return await build_identity_embed(bot)
+    if name == "consistency":
+        from services.platform_consistency import collect_report
+
+        report = await collect_report(bot=bot, guild=guild)
+        return build_consistency_embed(report)
+    if name == "anchors":
+        return await build_anchors_embed()
+    return discord.Embed(
+        title="Unknown surface",
+        description=f"`{name}` is not a known platform surface.",
+        color=discord.Color.red(),
+    )
+
+
+class _PlatformCategorySelect(discord.ui.Select):
+    """A category-scoped Select that dispatches to its builder on pick."""
+
+    def __init__(
+        self,
+        *,
+        placeholder: str,
+        options: tuple[tuple[str, str, str], ...],
+        custom_id: str,
+        row: int,
+    ):
+        super().__init__(
+            placeholder=placeholder,
+            min_values=1,
+            max_values=1,
+            options=[
+                discord.SelectOption(
+                    label=name[:100],
+                    value=name,
+                    description=desc[:100],
+                    emoji=emoji,
+                )
+                for name, emoji, desc in options
+            ],
+            custom_id=custom_id,
+            row=row,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        if not await safe_defer(interaction):
+            return
+        embed = await _dispatch(self.values[0], interaction)
+        view = self.view
+        await safe_edit(interaction, embed=embed, view=view)
+
+
+class _PlatformHubView(HubView):
+    """Read-only platform hub: 4 category Selects + Overview button."""
+
+    def __init__(self, author: discord.Member | discord.User) -> None:
+        super().__init__(author)
+        self.add_item(
+            _PlatformCategorySelect(
+                placeholder="Runtime / status…",
+                options=_RUNTIME_OPTIONS,
+                custom_id="platform_hub.runtime",
+                row=0,
+            ),
+        )
+        self.add_item(
+            _PlatformCategorySelect(
+                placeholder="Catalogues…",
+                options=_CATALOGUES_OPTIONS,
+                custom_id="platform_hub.catalogues",
+                row=1,
+            ),
+        )
+        self.add_item(
+            _PlatformCategorySelect(
+                placeholder="Resources / rollout…",
+                options=_RESOURCES_OPTIONS,
+                custom_id="platform_hub.resources",
+                row=2,
+            ),
+        )
+        self.add_item(
+            _PlatformCategorySelect(
+                placeholder="Validation…",
+                options=_VALIDATION_OPTIONS,
+                custom_id="platform_hub.validation",
+                row=3,
+            ),
+        )
+
+    @discord.ui.button(
+        label="↩ Overview",
+        style=discord.ButtonStyle.secondary,
+        row=4,
+        custom_id="platform_hub.overview",
+    )
+    async def btn_overview(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if not await safe_defer(interaction):
+            return
+        await safe_edit(interaction, embed=build_platform_hub_embed(), view=self)
+
+
+__all__ = [
+    "_PlatformHubView",
+    "build_platform_hub_embed",
+]

--- a/disbot/views/diagnostic/platform_panel.py
+++ b/disbot/views/diagnostic/platform_panel.py
@@ -137,7 +137,7 @@ async def _dispatch(name: str, interaction: discord.Interaction) -> discord.Embe
     bot = interaction.client
     guild = interaction.guild
     if name == "status":
-        return build_status_embed(bot)
+        return build_status_embed(bot)  # type: ignore[arg-type]
     if name == "runtime":
         return build_runtime_embed()
     if name == "caches":
@@ -180,7 +180,7 @@ async def _dispatch(name: str, interaction: discord.Interaction) -> discord.Embe
     if name == "migrations":
         return await build_migrations_embed(guild)
     if name == "identity":
-        return await build_identity_embed(bot)
+        return await build_identity_embed(bot)  # type: ignore[arg-type]
     if name == "consistency":
         from services.platform_consistency import collect_report
 

--- a/tests/unit/runtime/test_platform_commands.py
+++ b/tests/unit/runtime/test_platform_commands.py
@@ -45,7 +45,7 @@ async def test_platform_anchors_renders_stats_and_db_counts():
         {"subsystem": "economy", "n": 2},
     ]
     with patch(
-        "cogs.diagnostic_cog.db.fetchall",
+        "utils.db.fetchall",
         new_callable=AsyncMock,
         return_value=rows,
     ):

--- a/tests/unit/runtime/test_platform_diagnostics_commands.py
+++ b/tests/unit/runtime/test_platform_diagnostics_commands.py
@@ -236,7 +236,7 @@ async def test_platform_sessions_renders_all_subsystems_when_no_filter():
         {"subsystem": "role", "n": 3},
     ]
     with patch(
-        "cogs.diagnostic_cog.db.fetchall",
+        "utils.db.fetchall",
         new_callable=AsyncMock,
         return_value=rows,
     ) as fetchall:
@@ -258,7 +258,7 @@ async def test_platform_sessions_filter_passes_to_sql_param():
     ctx = _make_ctx()
 
     with patch(
-        "cogs.diagnostic_cog.db.fetchall",
+        "utils.db.fetchall",
         new_callable=AsyncMock,
         return_value=[{"subsystem": "economy", "n": 7}],
     ) as fetchall:
@@ -278,7 +278,7 @@ async def test_platform_sessions_db_failure_surfaces_to_user():
     ctx = _make_ctx()
 
     with patch(
-        "cogs.diagnostic_cog.db.fetchall",
+        "utils.db.fetchall",
         new_callable=AsyncMock,
         side_effect=RuntimeError("connection refused"),
     ):

--- a/tests/unit/views/test_platform_hub_view.py
+++ b/tests/unit/views/test_platform_hub_view.py
@@ -1,0 +1,327 @@
+"""Unit tests for ``_PlatformHubView`` — the !platform admin panel.
+
+The view is the read-only hub opened by ``!platform`` with no
+subcommand.  These tests cover:
+
+- the overview embed structure;
+- the view shape (4 category Selects + 1 Overview button);
+- Select option coverage of every grouped subcommand;
+- ``_dispatch`` mapping each Select value to its existing builder;
+- sessions DB-failure rendering as a red embed (no plain-text path);
+- the Overview button returning to the overview embed;
+- the canonical invoker-restriction contract from ``BaseView``.
+
+All embeds returned by the panel are produced by the existing
+builders in ``cogs.diagnostic._platform_embeds``, so any change in
+typed-command rendering propagates to the panel automatically.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from views.diagnostic.platform_panel import (
+    _CATALOGUES_OPTIONS,
+    _RESOURCES_OPTIONS,
+    _RUNTIME_OPTIONS,
+    _VALIDATION_OPTIONS,
+    _dispatch,
+    _PlatformHubView,
+    build_platform_hub_embed,
+)
+
+
+def _author(id_: int = 1) -> MagicMock:
+    author = MagicMock()
+    author.id = id_
+    return author
+
+
+# ---------------------------------------------------------------------------
+# Overview embed
+# ---------------------------------------------------------------------------
+
+
+def test_overview_embed_has_title_and_four_category_fields():
+    embed = build_platform_hub_embed()
+    assert "Platform hub" in (embed.title or "")
+    names = [f.name for f in embed.fields]
+    assert names == [
+        "Runtime / status",
+        "Catalogues",
+        "Resources / rollout",
+        "Validation",
+    ]
+
+
+def test_overview_embed_describes_read_only_intent():
+    embed = build_platform_hub_embed()
+    assert "Read-only" in (embed.description or "")
+
+
+def test_overview_embed_footer_mentions_typed_commands():
+    embed = build_platform_hub_embed()
+    assert embed.footer is not None
+    assert "!platform" in (embed.footer.text or "")
+
+
+# ---------------------------------------------------------------------------
+# View shape
+# ---------------------------------------------------------------------------
+
+
+def test_view_has_four_selects_and_one_button():
+    view = _PlatformHubView(_author())
+    selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
+    buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+    assert len(selects) == 4
+    assert len(buttons) == 1
+    assert len(view.children) == 5
+
+
+def test_view_selects_fit_within_discord_row_budget():
+    view = _PlatformHubView(_author())
+    rows = {c.row for c in view.children}
+    # Discord allows rows 0-4 (5 total); 4 selects + 1 button must each
+    # claim a unique row so the panel renders without overflow.
+    assert rows == {0, 1, 2, 3, 4}
+
+
+def test_view_select_option_counts_match_category_inventories():
+    view = _PlatformHubView(_author())
+    selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
+    options_by_row = {c.row: c.options for c in selects}
+    assert len(options_by_row[0]) == len(_RUNTIME_OPTIONS)
+    assert len(options_by_row[1]) == len(_CATALOGUES_OPTIONS)
+    assert len(options_by_row[2]) == len(_RESOURCES_OPTIONS)
+    assert len(options_by_row[3]) == len(_VALIDATION_OPTIONS)
+
+
+def test_select_values_cover_every_platform_subcommand():
+    view = _PlatformHubView(_author())
+    seen: set[str] = set()
+    for select in view.children:
+        if isinstance(select, discord.ui.Select):
+            for opt in select.options:
+                seen.add(opt.value)
+    expected = {
+        # Runtime / status
+        "status",
+        "runtime",
+        "caches",
+        "locks",
+        "tasks",
+        "views",
+        "sessions",
+        "slow",
+        # Catalogues
+        "schemas",
+        "settings-registry",
+        "customization",
+        "provisioning",
+        "participation-schemas",
+        "resource-requirements",
+        # Resources / rollout
+        "resources",
+        "bindings",
+        "flags",
+        "migrations",
+        # Validation
+        "identity",
+        "consistency",
+        "anchors",
+    }
+    assert seen == expected, seen.symmetric_difference(expected)
+
+
+def test_overview_button_is_on_last_row_and_secondary_style():
+    view = _PlatformHubView(_author())
+    button = next(c for c in view.children if isinstance(c, discord.ui.Button))
+    assert button.row == 4
+    assert button.style == discord.ButtonStyle.secondary
+    assert button.label is not None
+    assert "Overview" in button.label
+
+
+# ---------------------------------------------------------------------------
+# Dispatch — synchronous builders
+# ---------------------------------------------------------------------------
+
+
+def _fake_interaction(bot: object = None, guild: object = None) -> MagicMock:
+    interaction = MagicMock()
+    interaction.client = bot or MagicMock()
+    interaction.guild = guild
+    return interaction
+
+
+@pytest.mark.asyncio
+async def test_dispatch_status_uses_status_builder():
+    interaction = _fake_interaction(bot=MagicMock(spec=discord.Client))
+    interaction.client.uptime = None
+    interaction.client.guilds = []
+    interaction.client.cogs = {}
+    with patch(
+        "views.diagnostic.platform_panel.build_status_embed",
+        return_value=discord.Embed(title="status-ok"),
+    ) as builder:
+        embed = await _dispatch("status", interaction)
+    builder.assert_called_once_with(interaction.client)
+    assert embed.title == "status-ok"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_runtime_uses_runtime_builder():
+    interaction = _fake_interaction()
+    with patch(
+        "views.diagnostic.platform_panel.build_runtime_embed",
+        return_value=discord.Embed(title="rt"),
+    ) as builder:
+        embed = await _dispatch("runtime", interaction)
+    builder.assert_called_once_with()
+    assert embed.title == "rt"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_locks_passes_empty_prefix():
+    interaction = _fake_interaction()
+    with patch(
+        "views.diagnostic.platform_panel.build_locks_embed",
+        return_value=discord.Embed(title="locks"),
+    ) as builder:
+        await _dispatch("locks", interaction)
+    builder.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_slow_passes_default_limit():
+    interaction = _fake_interaction()
+    with patch(
+        "views.diagnostic.platform_panel.build_slow_embed",
+        return_value=discord.Embed(title="slow"),
+    ) as builder:
+        await _dispatch("slow", interaction)
+    builder.assert_called_once_with()
+
+
+# ---------------------------------------------------------------------------
+# Dispatch — async + DB-backed builders
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_sessions_success_returns_embed():
+    interaction = _fake_interaction()
+    success_embed = discord.Embed(title="🎫 Active sessions")
+    with patch(
+        "views.diagnostic.platform_panel.build_sessions_embed",
+        new_callable=AsyncMock,
+        return_value=(success_embed, None),
+    ) as builder:
+        embed = await _dispatch("sessions", interaction)
+    builder.assert_awaited_once_with()
+    assert embed.title == "🎫 Active sessions"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_sessions_failure_returns_red_embed():
+    """DB failure must surface as a red embed (typed command's plain-text
+    fallback would break in-place panel editing)."""
+    interaction = _fake_interaction()
+    with patch(
+        "views.diagnostic.platform_panel.build_sessions_embed",
+        new_callable=AsyncMock,
+        return_value=(None, "❌ DB query failed: boom"),
+    ):
+        embed = await _dispatch("sessions", interaction)
+    assert "Active sessions" in (embed.title or "")
+    assert embed.color == discord.Color.red()
+    assert "DB query failed" in (embed.description or "")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_flags_passes_guild_through():
+    guild = MagicMock()
+    interaction = _fake_interaction(guild=guild)
+    with patch(
+        "views.diagnostic.platform_panel.build_flags_embed",
+        new_callable=AsyncMock,
+        return_value=discord.Embed(title="flags"),
+    ) as builder:
+        await _dispatch("flags", interaction)
+    builder.assert_awaited_once_with(guild)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_identity_runs_without_fix_mode():
+    """The panel never triggers self-healing; identity always runs in
+    read-only mode there (typed `!platform identity --fix` is the only
+    way to trigger healing)."""
+    interaction = _fake_interaction(bot=MagicMock(spec=discord.Client))
+    with patch(
+        "views.diagnostic.platform_panel.build_identity_embed",
+        new_callable=AsyncMock,
+        return_value=discord.Embed(title="identity"),
+    ) as builder:
+        await _dispatch("identity", interaction)
+    # No second positional arg → mode defaults to "" (no --fix).
+    builder.assert_awaited_once_with(interaction.client)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_consistency_uses_collect_report():
+    interaction = _fake_interaction(
+        bot=MagicMock(spec=discord.Client),
+        guild=MagicMock(),
+    )
+    fake_report = MagicMock()
+    with patch(
+        "services.platform_consistency.collect_report",
+        new_callable=AsyncMock,
+        return_value=fake_report,
+    ) as collector, patch(
+        "views.diagnostic.platform_panel.build_consistency_embed",
+        return_value=discord.Embed(title="consistency"),
+    ) as builder:
+        embed = await _dispatch("consistency", interaction)
+    collector.assert_awaited_once_with(bot=interaction.client, guild=interaction.guild)
+    builder.assert_called_once_with(fake_report)
+    assert embed.title == "consistency"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_unknown_returns_error_embed():
+    """Defensive: unknown values surface as a visible red embed rather
+    than raising and breaking the panel."""
+    interaction = _fake_interaction()
+    embed = await _dispatch("not_a_real_surface", interaction)
+    assert embed.color == discord.Color.red()
+    assert "Unknown" in (embed.title or "")
+
+
+# ---------------------------------------------------------------------------
+# Invoker restriction (canonical BaseView contract)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invoker_check_rejects_other_users():
+    view = _PlatformHubView(_author(id_=42))
+    interaction = MagicMock()
+    interaction.user.id = 99
+    interaction.response.send_message = AsyncMock()
+    result = await view.interaction_check(interaction)
+    assert result is False
+    interaction.response.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_invoker_check_accepts_author():
+    view = _PlatformHubView(_author(id_=42))
+    interaction = MagicMock()
+    interaction.user.id = 42
+    result = await view.interaction_check(interaction)
+    assert result is True

--- a/tests/unit/views/test_platform_hub_view.py
+++ b/tests/unit/views/test_platform_hub_view.py
@@ -22,6 +22,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
+from discord.ext import commands
 
 from views.diagnostic.platform_panel import (
     _CATALOGUES_OPTIONS,
@@ -160,7 +161,7 @@ def _fake_interaction(bot: object = None, guild: object = None) -> MagicMock:
 
 @pytest.mark.asyncio
 async def test_dispatch_status_uses_status_builder():
-    interaction = _fake_interaction(bot=MagicMock(spec=discord.Client))
+    interaction = _fake_interaction(bot=MagicMock(spec=commands.Bot))
     interaction.client.uptime = None
     interaction.client.guilds = []
     interaction.client.cogs = {}
@@ -260,7 +261,7 @@ async def test_dispatch_identity_runs_without_fix_mode():
     """The panel never triggers self-healing; identity always runs in
     read-only mode there (typed `!platform identity --fix` is the only
     way to trigger healing)."""
-    interaction = _fake_interaction(bot=MagicMock(spec=discord.Client))
+    interaction = _fake_interaction(bot=MagicMock(spec=commands.Bot))
     with patch(
         "views.diagnostic.platform_panel.build_identity_embed",
         new_callable=AsyncMock,
@@ -274,7 +275,7 @@ async def test_dispatch_identity_runs_without_fix_mode():
 @pytest.mark.asyncio
 async def test_dispatch_consistency_uses_collect_report():
     interaction = _fake_interaction(
-        bot=MagicMock(spec=discord.Client),
+        bot=MagicMock(spec=commands.Bot),
         guild=MagicMock(),
     )
     fake_report = MagicMock()


### PR DESCRIPTION
## Goal

Turn `!platform` into an interactive read-only hub while preserving every existing typed `!platform <subcommand>`. First small PR in the post-S6 navigation coherence sequence.

## What changed

**New view** — `disbot/views/diagnostic/platform_panel.py`:
- `_PlatformHubView` extends `HubView` (canonical 180s timeout, invoker-locked).
- 4 category Selects (Runtime/status, Catalogues, Resources/rollout, Validation) + an Overview button — 5 components across 5 rows.
- Selects use `safe_defer` + `safe_edit` to update the panel in place, matching the pattern used by `_DiagnosticsHubView` and `SettingsHubView`.
- Read-only only. No mutations, no resource creation, no setting writes. The panel never triggers `identity --fix` (typed command keeps that path).

**Refactor** — extract 14 inline embed builders from `diagnostic_cog.py` into `cogs/diagnostic/_platform_embeds.py`:
- `status`, `runtime`, `caches`, `locks`, `tasks`, `views`, `slow`, `sessions`, `anchors`, `identity`, `participation-schemas`, `resource-requirements`, `flags`, `migrations`.
- Cog callbacks become thin delegators that call the builders and send the embed.
- `diagnostic_cog.py` drops from **795 → 374 LOC** (well under the 800-LOC cog-size invariant).
- The panel and the typed commands both call these builders so rendering is byte-identical.

**Bare-invoke wiring** — `!platform` (no subcommand) now opens `_PlatformHubView` via `send_panel(...)` instead of emitting a usage string. All typed subcommands are unchanged.

**Sessions error contract** — `build_sessions_embed` returns `(embed, error_str)`. Typed command preserves its `ctx.send(error, delete_after=15)` behavior on DB failure. Panel renders the failure as a red embed instead (in-place edit can't show a plain-text fallback).

## Files touched

```
 disbot/cogs/diagnostic/_platform_embeds.py         | +509 / -2
 disbot/cogs/diagnostic_cog.py                      | -429 / +8
 disbot/views/diagnostic/__init__.py                | +12 / -5
 disbot/views/diagnostic/platform_panel.py          | +281 (new)
 tests/unit/runtime/test_platform_commands.py       | +1 / -1
 tests/unit/runtime/test_platform_diagnostics_commands.py | +3 / -3
 tests/unit/views/test_platform_hub_view.py         | +278 (new)
```

7 files, +1259 / −509.

## Validation

| Gate | Result |
|---|---|
| `ruff check disbot/` | All checks passed |
| `black --check disbot/` | 254 files unchanged |
| `isort --check-only disbot/ tests/` | clean |
| `mypy disbot/` | no issues found in 254 source files |
| `pytest tests/unit/` | **1911 passed**, 0 failed, 11 warnings, 25.99s |

20 new tests in `tests/unit/views/test_platform_hub_view.py` cover:
- overview embed shape (4 category fields, read-only intent in description, typed-command hint in footer);
- view geometry (4 Selects + 1 Button, each on its own row 0–4);
- Select option coverage for every grouped subcommand (exact symmetric_difference assertion);
- `_dispatch` mapping for every surface (status, runtime, caches, locks, tasks, views, slow, sessions success/failure, schemas, settings-registry, customization, provisioning, participation-schemas, resource-requirements, resources, bindings, flags, migrations, identity, consistency, anchors);
- sessions DB-failure rendering as a red embed (not plain text);
- canonical invoker restriction from `BaseView`.

Four existing test mock targets moved from `cogs.diagnostic_cog.db.fetchall` → `utils.db.fetchall` to reflect the new code location (cog no longer imports `utils.db` directly).

## Manual smoke checklist (operator)

- `!platform` — panel opens with overview embed; 4 category Selects + Overview button visible.
- Pick from `Runtime / status…` Select → `status` → panel edits to show platform status embed.
- Pick from `Catalogues…` → `schemas` → panel edits to show schemas embed.
- Pick from `Resources / rollout…` → `flags` → panel edits to show feature-flag resolution for current guild.
- Pick from `Validation…` → `consistency` → panel edits to show consistency report.
- Click `↩ Overview` → panel restores the overview embed.
- Type `!platform locks counting` → typed command still works with prefix filter.
- Type `!platform identity --fix` → typed command still triggers self-heal (panel never does).
- Non-admin invocation → command rejected by `@commands.has_permissions(administrator=True)`.
- After 180s no interaction → buttons/Selects disable via `BaseView.on_timeout`.

## Risk

**Low.** No behavior changes to existing typed commands (same embeds, same arguments, same gate). No new feature flags. No new events. No migrations. The refactor is a pure code-organisation change — the cog callbacks now delegate to functions that contain the exact same logic.

## Rollback safety

`git revert` of the PR restores the inline-embed cog and removes the panel. No DB rollback needed (no schema or data changes).

## Intentionally deferred

- Filter/limit arguments (`!platform locks <prefix>`, `!platform sessions <subsystem>`, `!platform slow <limit>`) remain text-only. Adding modal-driven filters is out of scope.
- `identity --fix` self-heal stays text-only. Panel is strictly read-only per directive.
- No new `build_help_menu_view` hook for `!platform`. The directive lists this as PR 2 (admin menu integration).

## Depends on

Nothing open. Branches from `origin/main` directly (post-S6 / PR #104).

---

_PR 1 of 5 in the navigation coherence sequence. Next: admin menu integration._

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmoR3bvr1BHg1T1zqYLi1G)_