### PR TITLE
feat(navigation): settings → cog panel button on subsystem pages

### DIFF
--- a/disbot/views/settings/subsystem_view.py
+++ b/disbot/views/settings/subsystem_view.py
@@ -237,6 +237,141 @@ class _BackToHubButton(discord.ui.Button):
         )
 
 
+def attach_back_to_settings_button(
+    view: discord.ui.View,
+    author: discord.Member | discord.User,
+    subsystem: str,
+) -> None:
+    """Append a "↩ Back to Settings" control to a sub-view opened from this panel.
+
+    Mirrors :func:`cogs.help_cog._attach_back_to_help_button` and
+    :func:`cogs.admin_cog.attach_back_to_admin_button`.  The button
+    rebuilds a fresh :class:`SubsystemSettingsView` on click so the
+    embed reflects current setting / binding state.  No-op if the
+    sub-view already has 25 components (Discord cap).
+    """
+    if len(view.children) >= 25:
+        logger.warning(
+            "Back-to-settings button skipped — %s already has 25 children.",
+            type(view).__name__,
+        )
+        return
+
+    btn = discord.ui.Button(  # type: ignore[var-annotated]
+        label="↩ Back to Settings",
+        custom_id="settings:back",
+        style=discord.ButtonStyle.secondary,
+        row=4,
+    )
+
+    async def _back_callback(interaction: discord.Interaction) -> None:
+        new_view = SubsystemSettingsView(author, subsystem)
+        embed = await build_subsystem_embed(interaction, subsystem)
+        await interaction.response.edit_message(embed=embed, view=new_view)
+
+    btn.callback = _back_callback  # type: ignore[method-assign]
+    view.add_item(btn)
+
+
+class _OpenRelatedPanelButton(discord.ui.Button):
+    """Route from a subsystem settings page to the related cog panel.
+
+    At click time, look up the cog that owns the subsystem and call
+    its :func:`build_help_menu_view` hook (the same hook the help
+    menu uses).  When the cog or hook is missing, render a fallback
+    embed listing the subsystem's entry_points so the operator can
+    still discover the typed commands.
+    """
+
+    def __init__(self, subsystem: str) -> None:
+        self.subsystem = subsystem
+        super().__init__(
+            label="Open Panel",
+            emoji="🪟",
+            style=discord.ButtonStyle.blurple,
+            custom_id="settings_subsystem.open_panel",
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from core.runtime.interaction_helpers import safe_defer, safe_edit
+
+        if not await safe_defer(interaction):
+            return
+        bot = interaction.client
+        cog = _resolve_cog_for_subsystem(bot, self.subsystem)
+        hook = getattr(cog, "build_help_menu_view", None) if cog else None
+        if not callable(hook):
+            fallback = _build_no_panel_embed(self.subsystem)
+            await safe_edit(interaction, embed=fallback, view=self.view)
+            return
+        try:
+            sub_embed, sub_view = await hook(interaction)
+        except Exception as exc:  # noqa: BLE001 — navigation must not crash panel
+            logger.warning(
+                "Settings → cog panel open failed (subsystem=%r): %s",
+                self.subsystem,
+                exc,
+                exc_info=True,
+            )
+            msg = str(exc)[:200]
+            embed = discord.Embed(
+                title="Could not open cog panel",
+                description=f"`{self.subsystem}` → `{type(exc).__name__}`: {msg}",
+                color=discord.Color.orange(),
+            )
+            await safe_edit(interaction, embed=embed, view=self.view)
+            return
+        attach_back_to_settings_button(sub_view, interaction.user, self.subsystem)
+        await safe_edit(interaction, embed=sub_embed, view=sub_view)
+
+
+def _resolve_cog_for_subsystem(bot: Any, subsystem: str) -> Any:
+    """Find the cog matching ``subsystem`` by entry-point intersection.
+
+    Delegates to :func:`cogs.help_cog._cog_for_subsystem` so the
+    settings-to-cog navigation uses the exact same resolution logic
+    the help menu uses — no parallel router.
+    """
+    try:
+        from cogs.help_cog import _cog_for_subsystem
+    except Exception:  # noqa: BLE001 — help cog must be loaded for this path
+        return None
+    try:
+        return _cog_for_subsystem(bot, subsystem)
+    except Exception:  # noqa: BLE001 — never crash navigation
+        return None
+
+
+def _build_no_panel_embed(subsystem: str) -> discord.Embed:
+    """Fallback embed shown when no cog hook exists for the subsystem."""
+    meta = SUBSYSTEMS.get(subsystem) or {}
+    display = meta.get("display_name", subsystem)
+    entry_points = list(meta.get("entry_points") or ())
+    embed = discord.Embed(
+        title=f"No interactive panel for {display}",
+        description=(
+            "This subsystem does not expose a panel hook.  Use the "
+            "typed commands below to interact with it."
+        ),
+        color=discord.Color.orange(),
+    )
+    if entry_points:
+        embed.add_field(
+            name="Typed commands",
+            value=", ".join(f"`!{ep}`" for ep in entry_points),
+            inline=False,
+        )
+    else:
+        embed.add_field(
+            name="Typed commands",
+            value="*(no entry_points declared)*",
+            inline=False,
+        )
+    embed.set_footer(text="Click ↩ Back to Hub to return to Settings.")
+    return embed
+
+
 # ---------------------------------------------------------------------------
 # S6 edit + reset selects.  Dispatch to the widget appropriate for the
 # SettingSpec.value_type / allowed_values shape.  See the per-widget
@@ -393,16 +528,21 @@ class _ResetSettingSelect(discord.ui.Select):
 
 
 class SubsystemSettingsView(HubView):
-    """Per-subsystem panel: read-only embed + S6 edit/reset selects."""
+    """Per-subsystem panel: read-only embed + S6 edit/reset selects + cog link."""
 
     def __init__(self, author: Any, subsystem: str) -> None:
         super().__init__(author)
         self.subsystem = subsystem
         self.add_item(_BackToHubButton())
+        self.add_item(_OpenRelatedPanelButton(subsystem))
         specs = _editable_specs(subsystem)
         if specs:
             self.add_item(_EditSettingSelect(subsystem, specs))
             self.add_item(_ResetSettingSelect(subsystem, specs))
 
 
-__all__ = ["SubsystemSettingsView", "build_subsystem_embed"]
+__all__ = [
+    "SubsystemSettingsView",
+    "attach_back_to_settings_button",
+    "build_subsystem_embed",
+]

--- a/tests/unit/views/test_settings_cog_edit_routes.py
+++ b/tests/unit/views/test_settings_cog_edit_routes.py
@@ -130,9 +130,12 @@ def test_view_omits_selects_when_subsystem_has_no_settings():
     view = SubsystemSettingsView(_FakeMember(), "blackjack")  # no schema
     selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
     assert selects == []
-    # Back button still present.
+    # Two buttons: "Back to Hub" + "Open Panel" (PR 3 navigation).
     buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
-    assert len(buttons) == 1
+    assert len(buttons) == 2
+    labels = [b.label or "" for b in buttons]
+    assert any("Back" in lbl for lbl in labels)
+    assert any("Open Panel" in lbl for lbl in labels)
 
 
 def test_view_omits_selects_when_specs_have_no_settings_key():

--- a/tests/unit/views/test_settings_cog_navigation.py
+++ b/tests/unit/views/test_settings_cog_navigation.py
@@ -1,0 +1,313 @@
+"""Unit tests for settings → cog panel navigation (PR 3).
+
+The per-subsystem settings page (``SubsystemSettingsView``) gains an
+``_OpenRelatedPanelButton`` that routes into the related cog's
+``build_help_menu_view`` hook when one exists, or shows a fallback
+embed listing entry_points when no hook is available.  Sub-views
+opened from this path get a "↩ Back to Settings" button so the
+operator can return to the subsystem page.
+
+These tests:
+
+- verify the button is present on the view;
+- exercise the dispatch path through a mocked cog hook;
+- exercise the fallback path when no hook is registered;
+- exercise the exception path when the hook raises;
+- verify ``attach_back_to_settings_button`` builds a working back
+  button and handles the 25-component cap.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from views.settings.subsystem_view import (
+    SubsystemSettingsView,
+    _build_no_panel_embed,
+    _OpenRelatedPanelButton,
+    _resolve_cog_for_subsystem,
+    attach_back_to_settings_button,
+)
+
+
+def _author(id_: int = 1) -> MagicMock:
+    author = MagicMock()
+    author.id = id_
+    return author
+
+
+def _find_button(view: discord.ui.View, label_substr: str) -> discord.ui.Button:
+    for child in view.children:
+        if isinstance(child, discord.ui.Button) and label_substr in (child.label or ""):
+            return child
+    raise AssertionError(f"No button with label containing {label_substr!r}")
+
+
+# ---------------------------------------------------------------------------
+# View shape
+# ---------------------------------------------------------------------------
+
+
+def test_view_includes_open_panel_button():
+    view = SubsystemSettingsView(_author(), "moderation")
+    open_btn = _find_button(view, "Open Panel")
+    assert isinstance(open_btn, _OpenRelatedPanelButton)
+    assert open_btn.subsystem == "moderation"
+    assert open_btn.row == 0
+
+
+def test_view_open_panel_button_is_distinct_from_back_button():
+    view = SubsystemSettingsView(_author(), "economy")
+    open_btn = _find_button(view, "Open Panel")
+    back_btn = _find_button(view, "Back to Hub")
+    assert open_btn is not back_btn
+
+
+# ---------------------------------------------------------------------------
+# Dispatch — hook found
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_open_panel_button_calls_cog_hook_and_attaches_back():
+    btn = _OpenRelatedPanelButton("moderation")
+    # Manually attach a parent view so callbacks can edit it back.
+    parent = SubsystemSettingsView(_author(), "moderation")
+    btn._view = parent  # type: ignore[attr-defined]
+
+    interaction = MagicMock()
+    interaction.user = _author()
+    interaction.client = MagicMock()
+
+    fake_cog = MagicMock()
+    fake_embed = discord.Embed(title="Moderation panel")
+    fake_view = discord.ui.View()
+    fake_cog.build_help_menu_view = AsyncMock(return_value=(fake_embed, fake_view))
+
+    with patch(
+        "views.settings.subsystem_view._resolve_cog_for_subsystem",
+        return_value=fake_cog,
+    ), patch(
+        "core.runtime.interaction_helpers.safe_defer",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "core.runtime.interaction_helpers.safe_edit",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as edit:
+        await btn.callback(interaction)
+
+    fake_cog.build_help_menu_view.assert_awaited_once_with(interaction)
+    edit.assert_awaited_once()
+    swapped_view = edit.await_args.kwargs["view"]
+    # The fake_view should have gained a "↩ Back to Settings" button.
+    back_btns = [
+        c
+        for c in swapped_view.children
+        if isinstance(c, discord.ui.Button) and "Back to Settings" in (c.label or "")
+    ]
+    assert len(back_btns) == 1
+
+
+# ---------------------------------------------------------------------------
+# Dispatch — no hook
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_open_panel_button_shows_fallback_when_no_cog():
+    btn = _OpenRelatedPanelButton("moderation")
+    parent = SubsystemSettingsView(_author(), "moderation")
+    btn._view = parent  # type: ignore[attr-defined]
+
+    interaction = MagicMock()
+    interaction.user = _author()
+    interaction.client = MagicMock()
+
+    with patch(
+        "views.settings.subsystem_view._resolve_cog_for_subsystem",
+        return_value=None,
+    ), patch(
+        "core.runtime.interaction_helpers.safe_defer",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "core.runtime.interaction_helpers.safe_edit",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as edit:
+        await btn.callback(interaction)
+
+    embed = edit.await_args.kwargs["embed"]
+    assert "No interactive panel" in (embed.title or "")
+    # Stay on the parent view rather than swapping.
+    assert edit.await_args.kwargs["view"] is parent
+
+
+@pytest.mark.asyncio
+async def test_open_panel_button_shows_fallback_when_cog_has_no_hook():
+    btn = _OpenRelatedPanelButton("moderation")
+    parent = SubsystemSettingsView(_author(), "moderation")
+    btn._view = parent  # type: ignore[attr-defined]
+
+    interaction = MagicMock()
+    interaction.user = _author()
+    interaction.client = MagicMock()
+
+    fake_cog = MagicMock(spec=[])  # no build_help_menu_view attribute
+
+    with patch(
+        "views.settings.subsystem_view._resolve_cog_for_subsystem",
+        return_value=fake_cog,
+    ), patch(
+        "core.runtime.interaction_helpers.safe_defer",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "core.runtime.interaction_helpers.safe_edit",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as edit:
+        await btn.callback(interaction)
+
+    embed = edit.await_args.kwargs["embed"]
+    assert "No interactive panel" in (embed.title or "")
+
+
+# ---------------------------------------------------------------------------
+# Dispatch — hook raises
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_open_panel_button_handles_hook_exception():
+    btn = _OpenRelatedPanelButton("moderation")
+    parent = SubsystemSettingsView(_author(), "moderation")
+    btn._view = parent  # type: ignore[attr-defined]
+
+    interaction = MagicMock()
+    interaction.user = _author()
+    interaction.client = MagicMock()
+
+    fake_cog = MagicMock()
+    fake_cog.build_help_menu_view = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with patch(
+        "views.settings.subsystem_view._resolve_cog_for_subsystem",
+        return_value=fake_cog,
+    ), patch(
+        "core.runtime.interaction_helpers.safe_defer",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "core.runtime.interaction_helpers.safe_edit",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as edit:
+        await btn.callback(interaction)
+
+    embed = edit.await_args.kwargs["embed"]
+    assert "Could not open" in (embed.title or "")
+    assert "RuntimeError" in (embed.description or "")
+    # Stay on the parent view.
+    assert edit.await_args.kwargs["view"] is parent
+
+
+@pytest.mark.asyncio
+async def test_open_panel_button_bails_when_defer_fails():
+    btn = _OpenRelatedPanelButton("moderation")
+    parent = SubsystemSettingsView(_author(), "moderation")
+    btn._view = parent  # type: ignore[attr-defined]
+
+    interaction = MagicMock()
+    interaction.user = _author()
+
+    with patch(
+        "core.runtime.interaction_helpers.safe_defer",
+        new_callable=AsyncMock,
+        return_value=False,
+    ), patch(
+        "views.settings.subsystem_view._resolve_cog_for_subsystem",
+    ) as resolver:
+        await btn.callback(interaction)
+    resolver.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _build_no_panel_embed
+# ---------------------------------------------------------------------------
+
+
+def test_build_no_panel_embed_lists_entry_points_when_available():
+    embed = _build_no_panel_embed("moderation")
+    assert "No interactive panel" in (embed.title or "")
+    field = next(f for f in embed.fields if f.name == "Typed commands")
+    # SUBSYSTEMS["moderation"]["entry_points"] includes modmenu.
+    assert "modmenu" in field.value
+
+
+def test_build_no_panel_embed_handles_unknown_subsystem():
+    embed = _build_no_panel_embed("not_a_real_subsystem")
+    assert "No interactive panel" in (embed.title or "")
+    field = next(f for f in embed.fields if f.name == "Typed commands")
+    assert "no entry_points declared" in field.value
+
+
+# ---------------------------------------------------------------------------
+# _resolve_cog_for_subsystem
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_cog_delegates_to_help_cog():
+    """The settings → cog router reuses help_cog._cog_for_subsystem."""
+    bot = MagicMock()
+    fake_cog = MagicMock()
+    with patch(
+        "cogs.help_cog._cog_for_subsystem",
+        return_value=fake_cog,
+    ) as delegate:
+        result = _resolve_cog_for_subsystem(bot, "moderation")
+    delegate.assert_called_once_with(bot, "moderation")
+    assert result is fake_cog
+
+
+def test_resolve_cog_returns_none_on_resolver_exception():
+    bot = MagicMock()
+    with patch(
+        "cogs.help_cog._cog_for_subsystem",
+        side_effect=RuntimeError("registry busted"),
+    ):
+        result = _resolve_cog_for_subsystem(bot, "moderation")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# attach_back_to_settings_button helper
+# ---------------------------------------------------------------------------
+
+
+def test_attach_back_to_settings_button_adds_a_button():
+    sub_view: discord.ui.View = discord.ui.View()
+    author = MagicMock()
+    author.id = 7
+    attach_back_to_settings_button(sub_view, author, "moderation")
+    btns = [c for c in sub_view.children if isinstance(c, discord.ui.Button)]
+    assert len(btns) == 1
+    assert "Back to Settings" in (btns[0].label or "")
+    assert btns[0].custom_id == "settings:back"
+    assert btns[0].row == 4
+
+
+def test_attach_back_to_settings_button_noop_when_view_full():
+    sub_view: discord.ui.View = discord.ui.View()
+    for i in range(25):
+        sub_view.add_item(
+            discord.ui.Button(label=f"x{i}", custom_id=f"x{i}", row=i // 5),
+        )
+    author = MagicMock()
+    attach_back_to_settings_button(sub_view, author, "moderation")
+    assert len(sub_view.children) == 25

--- a/tests/unit/views/test_subsystem_settings_view.py
+++ b/tests/unit/views/test_subsystem_settings_view.py
@@ -235,8 +235,11 @@ def test_subsystem_view_has_back_button():
     import discord
 
     buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
-    assert len(buttons) == 1
-    assert "Back" in (buttons[0].label or "")
+    # PR 3 added an "Open Panel" navigation button next to "Back to Hub".
+    assert len(buttons) == 2
+    labels = [b.label or "" for b in buttons]
+    assert any("Back" in lbl for lbl in labels)
+    assert any("Open Panel" in lbl for lbl in labels)
 
 
 def test_subsystem_view_carries_subsystem_key():


### PR DESCRIPTION
## Goal

Let the operator jump from a Settings subsystem page directly into the related cog panel. Adds an "🪟 Open Panel" button to `SubsystemSettingsView` (used by `!settings → <subsystem>`).

## Architecture

- The button reuses **`cogs.help_cog._cog_for_subsystem`** (via a thin `_resolve_cog_for_subsystem` wrapper) — no parallel router is introduced. Settings-to-cog navigation uses the exact same resolution logic the help menu uses.
- At click time, the button looks up the cog and calls its existing **`build_help_menu_view(interaction)`** hook. Every major cog already owns this hook (admin, settings, diagnostic, cleanup, moderation, counting, mining, economy, role, xp, etc.) — no new cog API.
- When the cog or hook is missing, the button shows a fallback embed listing the subsystem's `entry_points` so the operator can still discover the typed commands. No silent failures.
- When the hook raises, the button surfaces an orange embed with the exception class + truncated message instead of crashing the panel.

Sub-views routed from here get a **"↩ Back to Settings"** button appended via the new `attach_back_to_settings_button` helper, which mirrors `cogs.help_cog._attach_back_to_help_button` and `cogs.admin_cog.attach_back_to_admin_button`. On click the back button rebuilds a fresh `SubsystemSettingsView` for the same subsystem so the embed reflects current setting state.

## Strict scope (read-only)

- No mutation paths added. The read-only AST invariant (`tests/unit/invariants/test_settings_cog_read_only.py`) still passes.
- The `build_help_menu_view` hook is the existing one — no new cog API surface.
- Cleanup, Diagnostics, Admin, Help, Platform, Settings, etc. are all reachable via this button by virtue of already exposing the hook.

## Files touched

```
 disbot/views/settings/subsystem_view.py           | +138 / -2
 tests/unit/views/test_settings_cog_edit_routes.py | +5 / -1
 tests/unit/views/test_subsystem_settings_view.py  | +5 / -2
 tests/unit/views/test_settings_cog_navigation.py  | +316 (new)
```

4 files, +465 / −6.

## Validation

| Gate | Result |
|---|---|
| `ruff check disbot/` | All checks passed |
| `black --check disbot/` | 253 files unchanged |
| `isort --check-only disbot/ tests/` | clean |
| `mypy disbot/` | no issues found in 253 source files |
| `pytest tests/unit/` | **1904 passed**, 0 failed, 12 warnings, 24.99s |

**13 new tests** cover: button presence on the view, dispatch through a mocked cog hook with back-to-settings attached to the routed sub-view, fallback when the cog is `None`, fallback when the cog lacks the hook attribute, exception handling when the hook raises, defer-failure short-circuit, `_build_no_panel_embed` with both known and unknown subsystems, `_resolve_cog_for_subsystem` delegating to `help_cog` with graceful exception handling, and `attach_back_to_settings_button` add + no-op-when-full behavior.

2 existing tests adjusted to expect 2 buttons (`Back to Hub` + `Open Panel`) instead of 1.

## Manual smoke checklist (operator)

- `!settings` → pick `moderation` → subsystem page renders with two row-0 buttons: ↩ Back to Hub + 🪟 Open Panel.
- Click 🪟 Open Panel → panel swaps to `_AdminPanelView` (moderation's owning cog), with a "↩ Back to Settings" button at row 4.
- Click ↩ Back to Settings → returns to the moderation subsystem page.
- ↩ Back to Hub still returns to `SettingsHubView`.
- Pick a subsystem with no `build_help_menu_view` hook (none in current codebase, but synthetic test path covers it): 🪟 Open Panel shows an orange "No interactive panel" embed listing entry_points.
- If the hook raises (e.g. cog half-loaded): 🪟 Open Panel shows an orange "Could not open cog panel" embed and stays on the settings page.
- 180s no interaction → all controls disable via `BaseView.on_timeout`.

## Risk

**Low.** No new mutation paths. No new feature flags. No migrations. No breaking changes to existing tests (2 minor count-assertions updated for the new button).

## Rollback safety

`git revert` of this PR removes the button and helper from `SubsystemSettingsView`. No DB rollback needed.

## Intentionally deferred

- Routing the Settings hub itself to per-subsystem-panel from the Help menu remains via the existing `build_help_menu_view` hook on SettingsCog — unchanged.
- Mining-specific dead-end fix is PR 4 (next).
- Discoverability audit / invariant test is PR 5.

## Depends on

Nothing open. Branches from `origin/main` directly.

---

_PR 3 of 5 in the navigation coherence sequence. Next: mining navigation fix._

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmoR3bvr1BHg1T1zqYLi1G)_