### PR TITLE
fix(mining): replace MineView dead-end with results navigation view

### DIFF
--- a/disbot/views/mining/main_panel.py
+++ b/disbot/views/mining/main_panel.py
@@ -21,7 +21,7 @@ from core.runtime.interaction_helpers import safe_defer, safe_edit, safe_followu
 from core.runtime.persistent_views import PersistentView, register
 from utils import db
 from utils.ui_constants import ERROR_COLOR, MINING_COLOR, SUCCESS_COLOR
-from views.mining.mine_view import MineView
+from views.mining.mine_view import MineView, _build_mine_prompt_embed
 
 
 @register
@@ -61,15 +61,10 @@ class MiningHubView(PersistentView):
             )
             return
         view = MineView(interaction.user.id, interaction.guild_id)
-        embed = discord.Embed(
-            title="Mining",
-            description=(
-                "Choose a direction to mine.\n"
-                "If you own a pickaxe, you'll get extra loot!"
-            ),
-            color=MINING_COLOR,
+        await interaction.response.edit_message(
+            embed=_build_mine_prompt_embed(),
+            view=view,
         )
-        await interaction.response.edit_message(embed=embed, view=view)
         view.message = interaction.message
 
     @discord.ui.button(

--- a/disbot/views/mining/mine_view.py
+++ b/disbot/views/mining/mine_view.py
@@ -9,15 +9,38 @@ called ``self.cog.update_inventory(...)`` which routed to
 ``db.update_mining_item``.  The extracted view skips the cog round-
 trip and calls the DB primitive directly so it has no cog dependency
 and can be unit-tested without a Discord mock.
+
+After a direction is picked, the message swaps to a
+:class:`_MineResultsView` (Mine Again / Back to Mining Menu / Back
+to Help) so the user never lands on a dead-end message — fixes the
+pre-PR-4 behavior where the view was set to ``None`` after a single
+mine action.
 """
 
 from __future__ import annotations
 
+import logging
+
 import discord
 
 from cogs.mining.rewards import roll_mine_loot
-from core.runtime.interaction_helpers import safe_defer
+from core.runtime.interaction_helpers import safe_defer, safe_edit
 from utils import db
+from utils.ui_constants import MINING_COLOR
+
+logger = logging.getLogger("bot.views.mining.mine_view")
+
+
+def _build_mine_prompt_embed() -> discord.Embed:
+    """The same embed shown when ``MiningHubView``'s Mine button opens."""
+    return discord.Embed(
+        title="Mining",
+        description=(
+            "Choose a direction to mine.\n"
+            "If you own a pickaxe, you'll get extra loot!"
+        ),
+        color=MINING_COLOR,
+    )
 
 
 class MineView(discord.ui.View):
@@ -80,14 +103,140 @@ class MineView(discord.ui.View):
 
         await db.update_mining_item(user_id, self.guild_id, found, amount)
 
-        new_content = (
-            f"{interaction.user.mention} mined {amount}x **{found}** "
-            f"by going {direction}!"
+        result_embed = discord.Embed(
+            title="⛏️ Mined!",
+            description=(
+                f"{interaction.user.mention} mined **{amount}x {found}** "
+                f"by going {direction}!"
+            ),
+            color=MINING_COLOR,
         )
+        result_embed.set_footer(
+            text=(
+                "Click ⛏️ Mine Again to try another direction, "
+                "or use the buttons below to navigate."
+            ),
+        )
+        results_view = _MineResultsView(self.user_id, self.guild_id)
         await interaction.followup.edit_message(
             message_id=interaction.message.id,
-            content=new_content,
-            embed=None,
-            view=None,
+            content=None,
+            embed=result_embed,
+            view=results_view,
+        )
+        results_view.message = interaction.message
+        self.stop()
+
+
+class _MineResultsView(discord.ui.View):
+    """Post-mine results view: Mine Again / Back to Mining Menu / Back to Help.
+
+    Fixes the pre-PR-4 dead-end where the MineView was replaced with
+    ``view=None`` after a single direction click, leaving the user
+    with no on-message way to continue.
+    """
+
+    def __init__(self, user_id: int, guild_id: int) -> None:
+        super().__init__(timeout=60)
+        self.user_id = user_id
+        self.guild_id = guild_id
+        self.message: discord.Message | None = None
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        return interaction.user.id == self.user_id
+
+    async def on_timeout(self) -> None:
+        for item in self.children:
+            item.disabled = True  # type: ignore[attr-defined]
+        if self.message is not None:
+            try:
+                await self.message.edit(view=self)
+            except discord.HTTPException:
+                pass
+
+    @discord.ui.button(
+        label="⛏️ Mine Again",
+        style=discord.ButtonStyle.primary,
+        row=0,
+    )
+    async def mine_again_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        view = MineView(self.user_id, self.guild_id)
+        await interaction.response.edit_message(
+            embed=_build_mine_prompt_embed(),
+            view=view,
+        )
+        view.message = interaction.message
+        self.stop()
+
+    @discord.ui.button(
+        label="↩ Mining Menu",
+        style=discord.ButtonStyle.secondary,
+        row=0,
+    )
+    async def mining_menu_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        # Late import to keep the module-load graph acyclic
+        # (main_panel imports this module).
+        from views.mining.main_panel import MiningHubView
+
+        view = MiningHubView()
+        await interaction.response.edit_message(
+            embed=view.build_embed(),
+            view=view,
         )
         self.stop()
+
+    @discord.ui.button(
+        label="📚 Back to Help",
+        style=discord.ButtonStyle.secondary,
+        row=0,
+    )
+    async def help_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if not await safe_defer(interaction):
+            return
+        try:
+            from cogs.help_cog import HelpPanelView, _build_page_embed
+            from services import governance_service
+            from services.governance_service import GovernanceContext
+            from utils.subsystem_registry import all_subsystems_sorted
+
+            gctx = GovernanceContext.from_interaction(interaction)
+            vis_result = await governance_service.resolve_visibility(gctx)
+            visible_list = [
+                name
+                for name, _meta in all_subsystems_sorted()
+                if name in vis_result.visible_subsystems
+            ]
+            new_view = HelpPanelView(visible_list, page=0)
+            embed = _build_page_embed(
+                interaction.client,  # type: ignore[arg-type]
+                visible_list,
+                0,
+                vis_result.member_tier,
+            )
+            await safe_edit(interaction, embed=embed, view=new_view)
+        except Exception as exc:  # noqa: BLE001 — navigation must not crash panel
+            logger.warning(
+                "Mining results → Help navigation failed: %s",
+                exc,
+                exc_info=True,
+            )
+            embed = discord.Embed(
+                title="Help unavailable",
+                description=f"Could not open Help: `{type(exc).__name__}`.",
+                color=discord.Color.orange(),
+            )
+            await safe_edit(interaction, embed=embed, view=self)
+        else:
+            self.stop()

--- a/tests/unit/views/test_mining_navigation.py
+++ b/tests/unit/views/test_mining_navigation.py
@@ -1,0 +1,279 @@
+"""Unit tests for the mining navigation fix (PR 4).
+
+Before PR 4, picking a direction on ``MineView`` swapped the message
+view to ``None`` — a dead end.  PR 4 introduces ``_MineResultsView``
+(Mine Again / ↩ Mining Menu / 📚 Back to Help) so the user always
+has an on-message way to continue.
+
+These tests cover:
+
+- the new prompt embed helper;
+- ``_MineResultsView`` shape (3 buttons on row 0);
+- the result of ``MineView._handle_mine`` swaps to
+  ``_MineResultsView`` (not ``view=None``);
+- Mine Again returns to a fresh ``MineView`` with the prompt embed;
+- Mining Menu swaps to ``MiningHubView``;
+- Help button resolves governance + opens ``HelpPanelView``;
+- Help button falls back to an orange embed on governance failure.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from views.mining.mine_view import (
+    MineView,
+    _build_mine_prompt_embed,
+    _MineResultsView,
+)
+
+
+def _find_button(view: discord.ui.View, label_substr: str) -> discord.ui.Button:
+    for child in view.children:
+        if isinstance(child, discord.ui.Button) and label_substr in (child.label or ""):
+            return child
+    raise AssertionError(f"No button with label containing {label_substr!r}")
+
+
+# ---------------------------------------------------------------------------
+# Prompt embed helper
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_embed_describes_direction_choice():
+    embed = _build_mine_prompt_embed()
+    assert embed.title == "Mining"
+    assert "direction" in (embed.description or "")
+
+
+# ---------------------------------------------------------------------------
+# _MineResultsView shape
+# ---------------------------------------------------------------------------
+
+
+def test_results_view_has_three_navigation_buttons_on_row_zero():
+    view = _MineResultsView(user_id=1, guild_id=2)
+    buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+    assert len(buttons) == 3
+    rows = {b.row for b in buttons}
+    assert rows == {0}
+    labels = " | ".join(b.label or "" for b in buttons)
+    assert "Mine Again" in labels
+    assert "Mining Menu" in labels
+    assert "Help" in labels
+
+
+def test_results_view_locks_to_invoking_user():
+    view = _MineResultsView(user_id=42, guild_id=2)
+    assert view.user_id == 42
+
+
+@pytest.mark.asyncio
+async def test_results_view_interaction_check_rejects_other_user():
+    view = _MineResultsView(user_id=42, guild_id=2)
+    interaction = MagicMock()
+    interaction.user.id = 99
+    assert await view.interaction_check(interaction) is False
+
+
+# ---------------------------------------------------------------------------
+# MineView._handle_mine swaps to _MineResultsView (no dead-end)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_mine_swaps_to_results_view_not_none():
+    view = MineView(user_id=1, guild_id=2)
+    interaction = MagicMock()
+    interaction.user.mention = "@user"
+    interaction.message = MagicMock()
+    interaction.message.id = 12345
+    interaction.followup.edit_message = AsyncMock()
+
+    with patch(
+        "views.mining.mine_view.safe_defer",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "views.mining.mine_view.db.get_mining_inventory",
+        new_callable=AsyncMock,
+        return_value={"pickaxe": 1},
+    ), patch(
+        "views.mining.mine_view.db.update_mining_item",
+        new_callable=AsyncMock,
+    ), patch(
+        "views.mining.mine_view.roll_mine_loot",
+        return_value=("stone", 5),
+    ):
+        await view._handle_mine(interaction, "left")
+
+    interaction.followup.edit_message.assert_awaited_once()
+    kwargs = interaction.followup.edit_message.await_args.kwargs
+    # Crucial: view is not None.  This is the dead-end fix.
+    swapped_view = kwargs["view"]
+    assert swapped_view is not None
+    assert isinstance(swapped_view, _MineResultsView)
+    embed = kwargs["embed"]
+    assert "stone" in (embed.description or "")
+    assert "5" in (embed.description or "")
+    assert kwargs["content"] is None
+
+
+# ---------------------------------------------------------------------------
+# Mine Again button
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mine_again_button_swaps_to_fresh_mine_view():
+    results = _MineResultsView(user_id=1, guild_id=2)
+    btn = _find_button(results, "Mine Again")
+    interaction = MagicMock()
+    interaction.user.id = 1
+    interaction.response.edit_message = AsyncMock()
+    interaction.message = MagicMock()
+
+    await btn.callback(interaction)
+
+    interaction.response.edit_message.assert_awaited_once()
+    kwargs = interaction.response.edit_message.await_args.kwargs
+    new_view = kwargs["view"]
+    assert isinstance(new_view, MineView)
+    assert new_view.user_id == 1
+    assert new_view.guild_id == 2
+    assert kwargs["embed"].title == "Mining"
+
+
+# ---------------------------------------------------------------------------
+# Mining Menu button
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mining_menu_button_swaps_to_mining_hub_view():
+    results = _MineResultsView(user_id=1, guild_id=2)
+    btn = _find_button(results, "Mining Menu")
+    interaction = MagicMock()
+    interaction.user.id = 1
+    interaction.response.edit_message = AsyncMock()
+
+    await btn.callback(interaction)
+
+    interaction.response.edit_message.assert_awaited_once()
+    kwargs = interaction.response.edit_message.await_args.kwargs
+    swapped_view = kwargs["view"]
+    # MiningHubView is a PersistentView — assert by class name to
+    # avoid coupling to the import path.
+    assert type(swapped_view).__name__ == "MiningHubView"
+    embed = kwargs["embed"]
+    assert "Mining Hub" in (embed.title or "")
+
+
+# ---------------------------------------------------------------------------
+# Help button — governance + HelpPanelView dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_help_button_opens_help_panel_with_visible_subsystems():
+    results = _MineResultsView(user_id=1, guild_id=2)
+    btn = _find_button(results, "Help")
+    interaction = MagicMock()
+    interaction.user.id = 1
+
+    vis_result = MagicMock()
+    vis_result.visible_subsystems = {"mining", "economy"}
+    vis_result.member_tier = "everyone"
+    fake_panel_view = discord.ui.View()
+    fake_embed = discord.Embed(title="Help")
+
+    with patch(
+        "views.mining.mine_view.safe_defer",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "services.governance_service.resolve_visibility",
+        new_callable=AsyncMock,
+        return_value=vis_result,
+    ), patch(
+        "services.governance_service.GovernanceContext.from_interaction",
+        return_value=MagicMock(),
+    ), patch(
+        "utils.subsystem_registry.all_subsystems_sorted",
+        return_value=[
+            ("mining", {}),
+            ("economy", {}),
+            ("admin", {}),
+        ],
+    ), patch(
+        "cogs.help_cog.HelpPanelView",
+        return_value=fake_panel_view,
+    ) as panel_cls, patch(
+        "cogs.help_cog._build_page_embed",
+        return_value=fake_embed,
+    ), patch(
+        "views.mining.mine_view.safe_edit",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as edit:
+        await btn.callback(interaction)
+
+    panel_cls.assert_called_once()
+    visible_list_arg = panel_cls.call_args.args[0]
+    # admin is filtered out because it's not in visible_subsystems.
+    assert visible_list_arg == ["mining", "economy"]
+    edit.assert_awaited_once()
+    assert edit.await_args.kwargs["view"] is fake_panel_view
+
+
+@pytest.mark.asyncio
+async def test_help_button_falls_back_on_governance_failure():
+    results = _MineResultsView(user_id=1, guild_id=2)
+    btn = _find_button(results, "Help")
+    interaction = MagicMock()
+    interaction.user.id = 1
+
+    with patch(
+        "views.mining.mine_view.safe_defer",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "services.governance_service.resolve_visibility",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("gov down"),
+    ), patch(
+        "services.governance_service.GovernanceContext.from_interaction",
+        return_value=MagicMock(),
+    ), patch(
+        "views.mining.mine_view.safe_edit",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as edit:
+        await btn.callback(interaction)
+
+    edit.assert_awaited_once()
+    embed = edit.await_args.kwargs["embed"]
+    assert "Help unavailable" in (embed.title or "")
+    # Stay on the results view.
+    assert edit.await_args.kwargs["view"] is results
+
+
+@pytest.mark.asyncio
+async def test_help_button_bails_when_defer_fails():
+    results = _MineResultsView(user_id=1, guild_id=2)
+    btn = _find_button(results, "Help")
+    interaction = MagicMock()
+    interaction.user.id = 1
+    with patch(
+        "views.mining.mine_view.safe_defer",
+        new_callable=AsyncMock,
+        return_value=False,
+    ), patch(
+        "services.governance_service.resolve_visibility",
+        new_callable=AsyncMock,
+    ) as resolver:
+        await btn.callback(interaction)
+    resolver.assert_not_called()


### PR DESCRIPTION
## Goal

Fix the `MineView` dead-end where picking Mine Left/Right/Down replaced the message view with `None`, stranding the user on a content-only message with no on-message way to continue.

## What changed

After `_handle_mine`, the message now swaps to a new **`_MineResultsView`** with three buttons on row 0:

| Button | Behavior |
|---|---|
| ⛏️ **Mine Again** | Reopens a fresh `MineView` with the same prompt embed — no retyping needed. |
| ↩ **Mining Menu** | Swaps the message to `MiningHubView`. |
| 📚 **Back to Help** | Resolves `GovernanceContext` + opens `HelpPanelView` (same pattern as `HelpCog.help_command`). |

The results view has a 60s timeout (vs `MineView`'s 30s) and is invoker-locked. Buttons gracefully self-disable on timeout via the standard `message.edit` pattern.

## Architecture

- **`_build_mine_prompt_embed`** extracts the "Choose a direction" embed shared by `MiningHubView.mine_btn` and the new Mine Again button so both render byte-identical content (no duplication).
- **Late import** of `MiningHubView` inside the Mining Menu callback keeps the `views.mining` module graph acyclic — `main_panel.py` imports `mine_view`, so `mine_view` can't import `main_panel` at module load.
- The **Help callback** mirrors `cogs.admin_cog`'s Help button (PR 2). On governance outage it surfaces an orange embed in place rather than crashing the panel.
- **Reward logic is untouched.** `roll_mine_loot` + `db.update_mining_item` are called identically to before — only the post-mine UI state changes.

## Files touched

```
 disbot/views/mining/mine_view.py             | +183 / -10
 disbot/views/mining/main_panel.py            | +5 / -6
 tests/unit/views/test_mining_navigation.py   | +267 (new)
```

3 files, +439 / −16.

## Validation

| Gate | Result |
|---|---|
| `ruff check disbot/` | All checks passed |
| `black --check disbot/` | 253 files unchanged |
| `isort --check-only disbot/ tests/` | clean |
| `mypy disbot/` | no issues found in 253 source files |
| `pytest tests/unit/` | **1901 passed**, 0 failed, 12 warnings, 25.20s |

**10 new tests** cover: prompt embed shape, results-view geometry (3 buttons on row 0, single row), invoker-locked `interaction_check`, the critical "view is not None" assertion on `_handle_mine` (the dead-end fix), Mine Again returning to a fresh `MineView` with the prompt embed, Mining Menu swapping to `MiningHubView`, Help governance resolution + `visible_list` filtering, Help governance-failure fallback, and Help defer-failure short-circuit.

## Manual smoke checklist (operator)

- `!help` → Mining → click ⛏️ Mine button.
- Pick a direction (Mine Left / Right / Down). The message swaps to the results view with **Mine Again** / **Mining Menu** / **Help** buttons. **Previously this was a dead-end.**
- Click ⛏️ Mine Again → message swaps to the direction prompt + Mine L/R/D buttons. No need to re-invoke `!minemenu`.
- Mine again, then click ↩ Mining Menu → swaps to `MiningHubView` (the persistent hub).
- From a fresh mine, pick a direction, then click 📚 Back to Help → swaps to `HelpPanelView` filtered by current member's visibility.
- 60s no interaction on results view → all 3 buttons disable.
- Non-invoking user clicks any button → blocked by `interaction_check`.

## Risk

**Low.** No mutation paths changed. No new feature flags. No migrations. Reward logic and DB writes are identical to before — only the post-mine view differs.

## Rollback safety

`git revert` of this PR restores the previous behavior (view replaced with `None` after mine). No DB rollback needed.

## Intentionally deferred (per directive)

- No mining or economy redesign.
- No replay-mode preservation (Mine Again doesn't remember the last direction).
- No "Mine again at same coords" or similar gameplay tweaks.
- No XP / Settings / Inventory shortcuts on the results view — adding more buttons is part of the larger "Mining panel improvements" backlog item, not this dead-end fix.
- The MiningHubView's "↩ Overview" button already returns to the hub overview, so no additional back navigation is added there.

## Depends on

Nothing open. Branches from `origin/main` directly.

---

_PR 4 of 5 in the navigation coherence sequence. Next: discoverability audit._

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmoR3bvr1BHg1T1zqYLi1G)_