### PR TITLE
test(invariant): add discoverability audit for every subsystem

### DIFF
--- a/tests/unit/invariants/test_discoverability.py
+++ b/tests/unit/invariants/test_discoverability.py
@@ -1,0 +1,276 @@
+"""Discoverability audit invariant (PR 5).
+
+Every entry in :data:`utils.subsystem_registry.SUBSYSTEMS` must have
+at least one discoverability path: a Help route (cog implements
+``build_help_menu_view``), a panel command (listed in
+``KNOWN_PANEL_COMMANDS`` or matches the ``.+menu$`` regex), or an
+explicit internal classification (``visibility_mode == "internal"``).
+
+This is a static audit — it does not load the Discord bot or
+instantiate cogs.  It uses:
+
+* :data:`utils.subsystem_registry.SUBSYSTEMS` for declared metadata;
+* :data:`services.customization_catalogue.KNOWN_PANEL_COMMANDS` for
+  the curated panel-command floor (the same source the customization
+  catalogue uses);
+* :mod:`ast` to scan each cog file for a ``build_help_menu_view``
+  method definition.
+
+When a subsystem has no discoverability path the invariant fails
+with a punch list of offenders so the operator can decide between
+(a) adding a help hook, (b) marking it internal, or (c) adding it
+to ``KNOWN_PANEL_COMMANDS``.
+
+The test also produces a categorized report (``HUB_REPORT``) that
+counts each discovery mechanism — useful as documentation, not a
+gate.
+
+Sibling read-only invariants:
+
+- ``test_identity_contract_strict.py`` — entry_points alignment.
+- ``test_settings_cog_read_only.py`` — settings UI mutation discipline.
+- ``test_cog_size.py`` — per-cog LOC ceiling.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+from services.customization_catalogue import KNOWN_PANEL_COMMANDS
+from utils.subsystem_registry import SUBSYSTEMS
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_COG_DIR = _REPO_ROOT / "disbot" / "cogs"
+_MENU_REGEX = re.compile(r".+menu$")
+
+
+def _cog_has_help_hook(subsystem: str) -> bool:
+    """Return True if ``{subsystem}_cog.py`` declares ``build_help_menu_view``.
+
+    Static check via :mod:`ast` — does not load the cog.  Returns
+    False when the cog file doesn't exist (subsystems that don't
+    correspond to a single cog file fall through to other
+    discoverability paths).
+    """
+    cog_path = _COG_DIR / f"{subsystem}_cog.py"
+    if not cog_path.exists():
+        return False
+    try:
+        tree = ast.parse(cog_path.read_text())
+    except SyntaxError:
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef):
+            if node.name == "build_help_menu_view":
+                return True
+    return False
+
+
+def _discoverability(subsystem: str) -> tuple[bool, str]:
+    """Return ``(is_discoverable, mechanism)`` for the named subsystem.
+
+    Mechanism keys:
+        ``internal``       — visibility_mode == "internal"
+        ``help_root``      — subsystem == "help" with "help" entry_point
+                             (the help system is its own discovery path)
+        ``panel_command``  — entry_point listed in KNOWN_PANEL_COMMANDS
+        ``menu_regex``     — entry_point matches ``.+menu$``
+        ``help_hook``      — cog file declares build_help_menu_view
+        ``none``           — no discoverability path
+    """
+    meta = SUBSYSTEMS.get(subsystem) or {}
+    if meta.get("visibility_mode") == "internal":
+        return True, "internal"
+
+    entry_points = set(meta.get("entry_points") or ())
+
+    # The help system is the root discovery surface — by definition it
+    # cannot be reached *through* itself, so the canonical mechanisms
+    # below don't apply.  Recognised explicitly so the invariant
+    # doesn't flag a tautological orphan.
+    if subsystem == "help" and "help" in entry_points:
+        return True, "help_root"
+
+    panel_cmds = {cmd for sub, cmd in KNOWN_PANEL_COMMANDS if sub == subsystem}
+    if panel_cmds & entry_points:
+        return True, "panel_command"
+
+    if any(_MENU_REGEX.match(ep) for ep in entry_points):
+        return True, "menu_regex"
+
+    if _cog_has_help_hook(subsystem):
+        return True, "help_hook"
+
+    return False, "none"
+
+
+# ---------------------------------------------------------------------------
+# Invariant
+# ---------------------------------------------------------------------------
+
+
+def test_every_subsystem_has_a_discoverability_path():
+    """No subsystem may exist without at least one discovery route.
+
+    Failure mode: emits a punch list of subsystems missing every
+    mechanism.  Each offender can be fixed by adding (a) a
+    ``build_help_menu_view`` method to its cog, (b) a panel command
+    entry in :data:`KNOWN_PANEL_COMMANDS`, (c) an entry_point ending
+    in ``menu``, or (d) ``visibility_mode = "internal"`` in
+    :data:`SUBSYSTEMS`.
+    """
+    offenders: list[str] = []
+    for subsystem in SUBSYSTEMS:
+        ok, _mechanism = _discoverability(subsystem)
+        if not ok:
+            offenders.append(subsystem)
+
+    assert not offenders, (
+        "These subsystems have no discoverability path "
+        "(help hook / panel command / internal classification): "
+        f"{sorted(offenders)}.  Add one of: build_help_menu_view, "
+        "KNOWN_PANEL_COMMANDS entry, .+menu entry_point, or set "
+        "visibility_mode='internal'."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Report — counts each mechanism + per-mechanism subsystem list
+# ---------------------------------------------------------------------------
+
+
+def build_discoverability_report() -> dict[str, list[str]]:
+    """Return a ``{mechanism: [subsystem, ...]}`` map for tooling.
+
+    Public helper — useful from REPL or future docs generators.
+    """
+    report: dict[str, list[str]] = {
+        "internal": [],
+        "help_root": [],
+        "panel_command": [],
+        "menu_regex": [],
+        "help_hook": [],
+        "none": [],
+    }
+    for subsystem in sorted(SUBSYSTEMS):
+        _ok, mechanism = _discoverability(subsystem)
+        report[mechanism].append(subsystem)
+    return report
+
+
+def test_report_covers_every_subsystem_exactly_once():
+    """Sanity: every subsystem appears in exactly one report bucket."""
+    report = build_discoverability_report()
+    seen: list[str] = []
+    for entries in report.values():
+        seen.extend(entries)
+    assert sorted(seen) == sorted(SUBSYSTEMS.keys())
+
+
+def test_report_has_no_orphans_in_none_bucket():
+    """The ``none`` bucket must be empty — mirror of the main invariant.
+
+    Kept as a separate test so the per-mechanism counts surface in
+    pytest output alongside the punch list.
+    """
+    report = build_discoverability_report()
+    assert report["none"] == [], (
+        f"Discoverability orphans: {report['none']}. "
+        "See test_every_subsystem_has_a_discoverability_path for the fix."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Help-hook coverage — informational
+# ---------------------------------------------------------------------------
+
+
+def test_majority_of_visible_subsystems_have_a_help_hook():
+    """Soft check: most visibility_mode='normal' subsystems should
+    expose a ``build_help_menu_view`` hook, because the help menu's
+    direct-navigation path consumes that hook.
+
+    Not a hard failure — subsystems may legitimately rely on panel
+    commands without a hook (e.g. game cogs whose menu is the panel
+    itself).  The threshold is intentionally loose (≥60%) so this
+    test serves as a regression alarm rather than a forced pattern.
+    """
+    visible = [
+        s for s, m in SUBSYSTEMS.items() if m.get("visibility_mode") != "internal"
+    ]
+    with_hook = [s for s in visible if _cog_has_help_hook(s)]
+    if not visible:
+        pytest.skip("No visible subsystems registered.")
+    ratio = len(with_hook) / len(visible)
+    assert ratio >= 0.6, (
+        f"Only {len(with_hook)}/{len(visible)} visible subsystems "
+        f"({ratio:.0%}) have build_help_menu_view hooks.  Help-menu "
+        "direct-navigation requires the hook; subsystems below this "
+        "threshold may be unreachable from !help."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test for the discoverability helpers themselves
+# ---------------------------------------------------------------------------
+
+
+def test_cog_has_help_hook_detects_known_cog():
+    """Sanity check: admin_cog declares build_help_menu_view."""
+    assert _cog_has_help_hook("admin") is True
+
+
+def test_cog_has_help_hook_returns_false_for_nonexistent_file():
+    assert _cog_has_help_hook("not_a_real_subsystem") is False
+
+
+def test_discoverability_recognises_internal_classification():
+    """If a subsystem is marked internal, it's discoverable regardless
+    of panel/hook presence."""
+    saved = SUBSYSTEMS.copy()
+    try:
+        SUBSYSTEMS["__test_internal__"] = {
+            "display_name": "Test Internal",
+            "description": "fixture",
+            "emoji": "🔒",
+            "color": 0,
+            "visibility_tier": "owner",
+            "visibility_mode": "internal",
+            "category": "test",
+            "tags": [],
+            "entry_points": [],
+            "default_channels": [],
+            "related_subsystems": [],
+            "dependencies": [],
+            "soft_dependencies": [],
+            "supports_dm": False,
+            "has_cleanup_rules": False,
+            "ui_priority": 0,
+            "capabilities": [],
+        }
+        ok, mechanism = _discoverability("__test_internal__")
+        assert ok is True
+        assert mechanism == "internal"
+    finally:
+        SUBSYSTEMS.clear()
+        SUBSYSTEMS.update(saved)
+
+
+def test_discoverability_recognises_panel_command():
+    """A subsystem with an entry_point in KNOWN_PANEL_COMMANDS is
+    discoverable via panel_command (admin has 'adminmenu')."""
+    ok, mechanism = _discoverability("admin")
+    assert ok is True
+    # admin maps to panel_command (KNOWN_PANEL_COMMANDS includes admin/adminmenu).
+    assert mechanism in ("panel_command", "menu_regex", "help_hook")
+
+
+def test_discoverability_returns_none_for_missing_subsystem():
+    """Unknown subsystem with no metadata falls to 'none'."""
+    ok, mechanism = _discoverability("not_a_subsystem")
+    assert ok is False
+    assert mechanism == "none"


### PR DESCRIPTION
## Goal

Prove statically that every entry in `SUBSYSTEMS` has at least one discoverability path so future work cannot accidentally introduce an undiscoverable user-facing subsystem.

## What this adds

A new read-only invariant test: **`tests/unit/invariants/test_discoverability.py`**.

The invariant accepts five discovery mechanisms for any subsystem:

| Mechanism | Check |
|---|---|
| `internal` | `visibility_mode == "internal"` (explicit classification) |
| `help_root` | the `help` subsystem itself — the discovery root |
| `panel_command` | an entry_point listed in `KNOWN_PANEL_COMMANDS` (from `services.customization_catalogue`) |
| `menu_regex` | an entry_point ending in `menu` |
| `help_hook` | the cog file declares `build_help_menu_view` (AST-checked, no bot loading) |

When a subsystem has none of these, the invariant fails with a punch list:

```
Subsystems with no discoverability path: ['foo']. Add one of:
build_help_menu_view, KNOWN_PANEL_COMMANDS entry, .+menu
entry_point, or set visibility_mode='internal'.
```

## Current report (main, after audit)

```
internal:      0    (no internal-classified subsystems)
help_root:     1    help
panel_command: 13   admin, chain, channel, cleanup, counting, economy,
                    general, mining, moderation, proof_channel, role,
                    utility, xp
menu_regex:    0    (all menu-shaped entry_points are also in
                    KNOWN_PANEL_COMMANDS, so they classify earlier)
help_hook:     7    blackjack, deathmatch, diagnostic, inventory,
                    leaderboard, rps_tournament, settings
none:          0    ← gate
```

Every one of the 21 registered subsystems has a discovery path. ✓

## Architecture

- **No runtime behavior change.** Only the test file is added. `SUBSYSTEMS`, `customization_catalogue`, and the cogs themselves are untouched.
- **Static analysis only.** Uses `ast` to scan cog files for `build_help_menu_view` definitions — no bot loading, no fixtures.
- **Reuses existing classification sources.** Pulls `KNOWN_PANEL_COMMANDS` from `services.customization_catalogue` (same source the live catalogue uses) and `SUBSYSTEMS` from `utils.subsystem_registry`. No parallel registry.
- **Public report helper.** `build_discoverability_report()` returns a `{mechanism: [subsystems...]}` map for tooling or future docs generators.

## Files touched

```
 tests/unit/invariants/test_discoverability.py | +276 (new)
```

1 file, +276. No production code modified.

## Validation

| Gate | Result |
|---|---|
| `ruff check disbot/` | All checks passed |
| `black --check disbot/` | 253 files unchanged |
| `isort --check-only disbot/ tests/` | clean |
| `mypy disbot/` | no issues found in 253 source files |
| `pytest tests/unit/` | **1900 passed**, 0 failed, 12 warnings, 24.59s |

**9 new tests:**
- `test_every_subsystem_has_a_discoverability_path` — main invariant.
- `test_report_covers_every_subsystem_exactly_once` — sanity.
- `test_report_has_no_orphans_in_none_bucket` — mirror of main.
- `test_majority_of_visible_subsystems_have_a_help_hook` — soft alarm (60%) for help-hook adoption drops.
- `test_cog_has_help_hook_detects_known_cog` — helper sanity (admin cog has the hook).
- `test_cog_has_help_hook_returns_false_for_nonexistent_file` — negative.
- `test_discoverability_recognises_internal_classification` — rule unit.
- `test_discoverability_recognises_panel_command` — rule unit.
- `test_discoverability_returns_none_for_missing_subsystem` — negative.

## Manual smoke checklist

- `!help` still opens normally — no runtime change affects this.
- Re-running pytest shows the 9 new tests pass under all conditions.

## Risk

**Zero runtime risk.** Test-only PR. If the invariant ever fails on a future PR, the punch list points the developer to the four acceptable fixes (add help hook / add panel command / mark internal / add menu-suffix entry_point).

## Rollback safety

`git revert` removes the test file. No DB / runtime / config impact.

## Intentionally deferred

- No metadata corrections needed — every subsystem already has a discovery path.
- No new `panel_command` decoration of existing commands (could be a follow-up that uses the `@panel_command` decorator declared in `customization_catalogue.py`, removing dependency on `KNOWN_PANEL_COMMANDS`).
- The 60% help-hook threshold is intentionally conservative; tightening it is a separate hardening pass.

## Depends on

Nothing open. Branches from `origin/main` directly.

---

_PR 5 of 5 in the navigation coherence sequence._

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmoR3bvr1BHg1T1zqYLi1G)_