### PR TITLE
feat(s7a): logging subsystem schema — settings/bindings/resources

### DIFF
--- a/disbot/cogs/admin_cog.py
+++ b/disbot/cogs/admin_cog.py
@@ -56,6 +56,18 @@ class AdminCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
+    async def cog_load(self) -> None:
+        """Register schemas for subsystems owned by this cog.
+
+        Admin currently hosts the ``!logging`` group, so the
+        S7a logging schema (settings / bindings / resources) is
+        registered here.  S7d may extract a dedicated ``LoggingCog``
+        and move this call there.
+        """
+        from cogs.logging.schemas import register_schemas
+
+        register_schemas()
+
     # ------------------------------------------------------------------
     # Admin menu
     # ------------------------------------------------------------------

--- a/disbot/cogs/logging/__init__.py
+++ b/disbot/cogs/logging/__init__.py
@@ -1,0 +1,16 @@
+"""Logging subsystem package — S7 of the Settings Manager roadmap.
+
+This package owns the ``logging`` subsystem's customization surface.
+Today it carries only the schema declarations (S7a); S7b/S7c will
+add the existing-channel-select and create-channel flows that route
+through :mod:`services.binding_mutation` and
+:mod:`services.resource_provisioning`.
+
+The runtime logging behavior (event subscription, embed posting,
+counters) continues to live in :mod:`services.server_logging`.  This
+package is intentionally separate so future S7d work can extract a
+dedicated ``LoggingCog`` with its own ``build_help_menu_view`` hook
+without touching the service.
+"""
+
+from __future__ import annotations

--- a/disbot/cogs/logging/schemas.py
+++ b/disbot/cogs/logging/schemas.py
@@ -1,0 +1,184 @@
+"""Logging subsystem schema — S7a.
+
+Declares the ``logging`` :class:`SubsystemSchema` so the Settings
+Manager hub renders a read-only logging page and so the binding /
+provisioning catalogues (S7b / S7c) can discover the channel slots.
+
+What this schema declares
+-------------------------
+
+* **Scalar settings** (today): ``enabled`` and ``auto_create_channels``.
+  Both point at the existing legacy keys in
+  :mod:`utils.settings_keys.logging` via ``settings_key=``, so the
+  S6 edit/reset flows can mutate them through
+  :class:`SettingsMutationPipeline` without any service changes.
+
+* **Bindings** (declared, not yet wired into the runtime read path):
+  ``mod_channel`` and ``cleanup_channel`` — both ``BindingKind.CHANNEL``,
+  not required.  S7b introduces the
+  :class:`BindingMutationPipeline` write path; today
+  :func:`services.server_logging.resolve_log_channel` still reads the
+  legacy ``LOGGING_MOD_CHANNEL`` / ``LOGGING_CLEANUP_CHANNEL`` scalar
+  keys.  Declaring the bindings now lets the catalogues surface them
+  and gives S7b a stable contract to migrate against.
+
+* **Resource requirements**: ``mod_log`` and ``cleanup_log`` channels.
+  ``RECOMMENDED`` priority because logging is opt-in by default
+  (``logging.enabled`` defaults to False) — auto-provisioning waits
+  for S7c.
+
+No behavior change is introduced by S7a.  Registering this schema
+adds entries to the customization / settings registry / provisioning
+catalogues; the runtime logging service is unchanged.
+"""
+
+from __future__ import annotations
+
+from core.runtime.resource_specs import (
+    ProvisioningHint,
+    ProvisioningPriority,
+    ResourceKind,
+    ResourceRequirement,
+)
+from core.runtime.subsystem_schema import (
+    BindingKind,
+    BindingSpec,
+    SettingSpec,
+    SubsystemSchema,
+)
+from utils.settings_keys import logging as _log_keys
+
+
+def _validate_bool(value: object) -> None:
+    if not isinstance(value, bool):
+        raise ValueError(f"expected bool, got {type(value).__name__}: {value!r}")
+
+
+# ---------------------------------------------------------------------------
+# Scalar settings
+# ---------------------------------------------------------------------------
+
+LOGGING_SETTINGS: tuple[SettingSpec, ...] = (
+    SettingSpec(
+        name="enabled",
+        value_type=bool,
+        default=False,
+        settings_key=_log_keys.LOGGING_ENABLED,
+        capability_required="logging.settings.configure",
+        hint=(
+            "Master switch for server-logging.  When off, "
+            "moderation/cleanup events are not posted to the configured "
+            "log channel."
+        ),
+        validator=_validate_bool,
+    ),
+    SettingSpec(
+        name="auto_create_channels",
+        value_type=bool,
+        default=False,
+        settings_key=_log_keys.LOGGING_AUTO_CREATE_CHANNELS,
+        capability_required="logging.settings.configure",
+        hint=(
+            "When enabled and a configured log channel is missing or "
+            "invalid, the service creates a fallback channel "
+            "(`bot-mod-log` / `bot-cleanup-log`) on next use.  Off by "
+            "default so a fresh install never surprises an admin with "
+            "spontaneous channels."
+        ),
+        validator=_validate_bool,
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Bindings (S7b will wire the mutation path; S7a only declares)
+# ---------------------------------------------------------------------------
+
+LOGGING_BINDINGS: tuple[BindingSpec, ...] = (
+    BindingSpec(
+        name="mod_channel",
+        kind=BindingKind.CHANNEL,
+        required=False,
+        hint=(
+            "Channel where non-cleanup moderation events (warn, timeout, "
+            "kick, ban) are posted.  Falls back to silent when unbound."
+        ),
+        capability_required="logging.settings.configure",
+    ),
+    BindingSpec(
+        name="cleanup_channel",
+        kind=BindingKind.CHANNEL,
+        required=False,
+        hint=(
+            "Channel where cleanup auto-delete events are posted.  "
+            "Falls back to `mod_channel` when unbound."
+        ),
+        capability_required="logging.settings.configure",
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Resource requirements (consumed by S7c create-channel flow)
+# ---------------------------------------------------------------------------
+
+LOGGING_RESOURCE_REQUIREMENTS: tuple[ResourceRequirement, ...] = (
+    ResourceRequirement(
+        kind=ResourceKind.CHANNEL,
+        intent="mod_log",
+        provisioning=ProvisioningHint(
+            priority=ProvisioningPriority.RECOMMENDED,
+            suggested_name="bot-mod-log",
+            suggested_category="Staff",
+        ),
+        binding_name="mod_channel",
+        description=(
+            "Operator-facing audit channel for moderation actions.  "
+            "Recommended for every guild that runs moderation."
+        ),
+    ),
+    ResourceRequirement(
+        kind=ResourceKind.CHANNEL,
+        intent="cleanup_log",
+        provisioning=ProvisioningHint(
+            priority=ProvisioningPriority.RECOMMENDED,
+            suggested_name="bot-cleanup-log",
+            suggested_category="Staff",
+        ),
+        binding_name="cleanup_channel",
+        description=(
+            "Operator-facing channel for cleanup auto-delete events.  "
+            "Falls back to the mod-log channel when unbound."
+        ),
+    ),
+)
+
+
+LOGGING_CONFIG_SCHEMA = SubsystemSchema(
+    subsystem="logging",
+    settings=LOGGING_SETTINGS,
+    bindings=LOGGING_BINDINGS,
+    resource_requirements=LOGGING_RESOURCE_REQUIREMENTS,
+    version=1,
+)
+
+
+def register_schemas() -> None:
+    """Register S7a schemas for the logging subsystem.
+
+    Called from :meth:`AdminCog.cog_load` because the ``!logging``
+    command group currently lives in :mod:`cogs.admin_cog`.  S7d may
+    extract a dedicated ``LoggingCog`` and move this call there.
+    """
+    from core.runtime import subsystem_schema
+
+    subsystem_schema.register(LOGGING_CONFIG_SCHEMA)
+
+
+__all__ = [
+    "LOGGING_CONFIG_SCHEMA",
+    "LOGGING_BINDINGS",
+    "LOGGING_RESOURCE_REQUIREMENTS",
+    "LOGGING_SETTINGS",
+    "register_schemas",
+]

--- a/disbot/services/customization_catalogue.py
+++ b/disbot/services/customization_catalogue.py
@@ -79,6 +79,7 @@ KNOWN_PANEL_COMMANDS: tuple[tuple[str, str], ...] = (
     ("counting", "countingmenu"),
     ("economy", "economymenu"),
     ("general", "generalmenu"),
+    ("logging", "logging"),
     ("mining", "minemenu"),
     ("moderation", "modmenu"),
     ("proof_channel", "prizemenu"),

--- a/disbot/utils/subsystem_registry.py
+++ b/disbot/utils/subsystem_registry.py
@@ -521,6 +521,32 @@ SUBSYSTEMS: dict[str, dict] = {
             "settings.manager.view",
         ],
     },
+    "logging": {
+        "display_name": "Server Logging",
+        "description": (
+            "Per-guild moderation/cleanup event logging — channel "
+            "selection, auto-create, and audit (S7)"
+        ),
+        "emoji": "📝",
+        "color": ADMIN_COLOR.value,
+        "visibility_tier": "administrator",
+        "visibility_mode": "normal",
+        "category": "admin",
+        "tags": ["logging", "audit", "moderation", "cleanup"],
+        "entry_points": ["logging"],
+        "default_channels": ["staff", "bot-mod-log", "bot-cleanup-log"],
+        "related_subsystems": ["moderation", "cleanup", "admin"],
+        "dependencies": [],
+        "soft_dependencies": [],
+        "supports_dm": False,
+        "has_cleanup_rules": False,
+        "ui_priority": 85,
+        "capabilities": [
+            "logging.settings.configure",
+            "logging.channel.bind",
+            "logging.channel.create",
+        ],
+    },
 }
 
 # ---------------------------------------------------------------------------

--- a/docs/settings-customization-command-map.md
+++ b/docs/settings-customization-command-map.md
@@ -927,6 +927,84 @@ Subsystems (21): `admin`, `moderation`, `economy`, `inventory`, `mining`,
     (per-subsystem write surfaces).
 
 
+### logging
+
+1. **cog_module**: `disbot/cogs/logging/schemas.py` (S7a) — schema-only;
+   the `!logging` group still lives in `disbot/cogs/admin_cog.py:211`
+   until S7d extracts a dedicated `LoggingCog`.
+2. **subsystem**: `logging`
+3. **current_commands**: `!logging status`, `!logging test` (admin tier).
+4. **current_command_groups**: `!logging` (group at `admin_cog.py:211`).
+5. **current_command_panel_or_menu**: none yet — S7d adds the panel.
+   Discoverability passes today via `KNOWN_PANEL_COMMANDS`
+   (`("logging", "logging")`).
+6. **help_menu_discoverable**: Yes via SUBSYSTEMS — registered at
+   administrator tier with `entry_points=["logging"]`.  Help-menu
+   direct-nav routes through `AdminCog.build_help_menu_view` until
+   S7d ships the logging-specific panel.
+7. **dedicated_panel_command**: deferred to S7d.
+8. **help_menu_direct_navigation_hook**: indirect (`AdminCog` owns
+   `!logging`).  S7d adds a logging-specific
+   `build_help_menu_view`.
+9. **existing_SettingSpec_declarations**: `enabled` (bool, default
+   False), `auto_create_channels` (bool, default False).  Both point
+   at the existing legacy keys via `settings_key=` so the S6
+   edit/reset flows mutate them through `SettingsMutationPipeline`
+   today.
+10. **existing_settings_keys**: `LOGGING_ENABLED`,
+    `LOGGING_AUTO_CREATE_CHANNELS` from `utils.settings_keys.logging`.
+    The two channel-id keys (`LOGGING_MOD_CHANNEL`,
+    `LOGGING_CLEANUP_CHANNEL`) are legacy and are migrating to
+    bindings in S7b.
+11. **existing_BindingSpec_entries**: `mod_channel`, `cleanup_channel`
+    — both `BindingKind.CHANNEL`, optional.  Declared in S7a; S7b
+    wires the mutation path through `BindingMutationPipeline`.
+12. **existing_ResourceRequirement_entries**: `mod_log` channel
+    (`bot-mod-log`, RECOMMENDED), `cleanup_log` channel
+    (`bot-cleanup-log`, RECOMMENDED).  Both link to the declared
+    bindings via `binding_name=`.
+13. **current_access_policy_behavior**: `visibility_tier=administrator`;
+    capabilities `logging.settings.configure`, `logging.channel.bind`,
+    `logging.channel.create`.  Master switch `logging.enabled`
+    defaults to OFF; the service in `services/server_logging.py`
+    stays inert until an operator opts in.
+14. **hardcoded_or_env_only_behavior**: `DEFAULT_MOD_CHANNEL_NAME` /
+    `DEFAULT_CLEANUP_CHANNEL_NAME` are module-level constants in
+    `utils.settings_keys.logging`; the create-channel flow (S7c)
+    uses the schema's `suggested_name` instead, so these constants
+    become a legacy fallback once S7c lands.
+15. **missing_customization_commands**: existing-channel selection
+    (S7b), create-new-channel flow (S7c), per-event-class routing
+    (deferred — not in S7 scope).
+16. **missing_settings_pages**: bind-existing-channel flow (S7b),
+    create-channel preview/confirm flow (S7c), logging admin panel
+    (S7d).
+17. **missing_menu_buttons_selects_modals**: `LogChannelSelectView`
+    (S7b), `LogChannelProvisionView` + confirmation modal (S7c),
+    logging admin panel buttons (S7d).
+18. **setting_class_per_value**: scalar (`enabled`,
+    `auto_create_channels`); binding (`mod_channel`,
+    `cleanup_channel`); provisionable resource (`mod_log`,
+    `cleanup_log`).
+19. **target_Settings_Manager_page**: `!settings → logging` — the
+    page renders from the registered `LOGGING_CONFIG_SCHEMA` already.
+20. **target_mutation_path**: scalar edits via
+    `SettingsMutationPipeline` (S6 — works today); channel binding
+    via `BindingMutationPipeline` (S7b); channel creation via
+    `ResourceProvisioningPipeline` (S7c).
+21. **target_help_or_menu_route**: Help direct-nav routes via
+    `KNOWN_PANEL_COMMANDS` today; dedicated logging panel via
+    `build_help_menu_view` in S7d.
+22. **provisionable_resources**: `mod_log` channel,
+    `cleanup_log` channel — both RECOMMENDED priority, both consumed
+    by S7c.
+23. **priority**: `P1` — first real binding/provisioning consumer in
+    the Settings Manager.
+24. **recommended_PR_phase**: S7a (schema, this PR) + S7b
+    (binding-select) + S7c (provisioning preview/confirm) + S7d
+    (panel + Help / Admin integration).
+
+
 ## Setting class summary
 
 Cross-cut by class, this is the work distribution implied by the per-cog

--- a/tests/unit/cogs/test_logging_schemas.py
+++ b/tests/unit/cogs/test_logging_schemas.py
@@ -1,0 +1,210 @@
+"""Unit tests for the logging subsystem schema (S7a).
+
+Verifies the schema declarations register correctly and conform to
+the contracts the Settings Manager / customization catalogue /
+provisioning catalogue depend on:
+
+- two scalar settings (``enabled``, ``auto_create_channels``) with
+  ``settings_key`` pointing at the existing legacy keys so the S6
+  edit/reset flows work today;
+- two channel bindings (``mod_channel``, ``cleanup_channel``) — both
+  optional — that S7b will wire through
+  :class:`BindingMutationPipeline`;
+- two resource requirements with ``RECOMMENDED`` priority for S7c's
+  create-channel flow.
+
+The schema is registered via
+:func:`cogs.logging.schemas.register_schemas` so the test can call
+it directly without needing a live cog/bot.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.runtime import subsystem_schema as schema_mod
+from core.runtime.resource_specs import ProvisioningPriority, ResourceKind
+from core.runtime.subsystem_schema import BindingKind
+from utils.settings_keys import logging as _log_keys
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state():
+    saved_schemas = schema_mod.all_schemas()
+    schema_mod._reset_for_tests()
+    yield
+    schema_mod._reset_for_tests()
+    for schema in saved_schemas.values():
+        schema_mod.register(schema)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_register_schemas_adds_logging_to_registry():
+    from cogs.logging.schemas import register_schemas
+
+    register_schemas()
+    assert "logging" in schema_mod.registered_subsystems()
+    schema = schema_mod.get_schema("logging")
+    assert schema is not None
+    assert schema.subsystem == "logging"
+
+
+def test_register_schemas_is_idempotent_after_reset():
+    from cogs.logging.schemas import register_schemas
+
+    register_schemas()
+    schema_mod._reset_for_tests()
+    register_schemas()
+    assert schema_mod.get_schema("logging") is not None
+
+
+# ---------------------------------------------------------------------------
+# Settings
+# ---------------------------------------------------------------------------
+
+
+def test_logging_settings_include_enabled_and_auto_create():
+    from cogs.logging.schemas import LOGGING_CONFIG_SCHEMA
+
+    setting_names = {s.name for s in LOGGING_CONFIG_SCHEMA.settings}
+    assert setting_names == {"enabled", "auto_create_channels"}
+
+
+def test_logging_enabled_setting_points_at_legacy_key():
+    from cogs.logging.schemas import LOGGING_CONFIG_SCHEMA
+
+    enabled = next(s for s in LOGGING_CONFIG_SCHEMA.settings if s.name == "enabled")
+    assert enabled.value_type is bool
+    assert enabled.default is False
+    assert enabled.settings_key == _log_keys.LOGGING_ENABLED
+    assert enabled.capability_required == "logging.settings.configure"
+
+
+def test_logging_auto_create_setting_points_at_legacy_key():
+    from cogs.logging.schemas import LOGGING_CONFIG_SCHEMA
+
+    auto = next(
+        s for s in LOGGING_CONFIG_SCHEMA.settings if s.name == "auto_create_channels"
+    )
+    assert auto.value_type is bool
+    assert auto.default is False
+    assert auto.settings_key == _log_keys.LOGGING_AUTO_CREATE_CHANNELS
+    assert auto.capability_required == "logging.settings.configure"
+
+
+def test_logging_settings_have_validators_that_reject_non_bool():
+    from cogs.logging.schemas import LOGGING_CONFIG_SCHEMA
+
+    for spec in LOGGING_CONFIG_SCHEMA.settings:
+        assert spec.validator is not None
+        # accepts bool
+        spec.validator(True)
+        spec.validator(False)
+        # rejects non-bool — int subclasses (e.g. 1) are not accepted.
+        with pytest.raises(ValueError):
+            spec.validator(1)
+        with pytest.raises(ValueError):
+            spec.validator("true")
+
+
+# ---------------------------------------------------------------------------
+# Bindings
+# ---------------------------------------------------------------------------
+
+
+def test_logging_bindings_declare_mod_and_cleanup_channels():
+    from cogs.logging.schemas import LOGGING_CONFIG_SCHEMA
+
+    binding_names = {b.name for b in LOGGING_CONFIG_SCHEMA.bindings}
+    assert binding_names == {"mod_channel", "cleanup_channel"}
+
+
+def test_logging_bindings_are_channel_kind_and_optional():
+    from cogs.logging.schemas import LOGGING_CONFIG_SCHEMA
+
+    for binding in LOGGING_CONFIG_SCHEMA.bindings:
+        assert binding.kind == BindingKind.CHANNEL
+        assert binding.required is False
+        assert binding.capability_required == "logging.settings.configure"
+
+
+# ---------------------------------------------------------------------------
+# Resource requirements
+# ---------------------------------------------------------------------------
+
+
+def test_logging_resource_requirements_cover_both_channels():
+    from cogs.logging.schemas import LOGGING_CONFIG_SCHEMA
+
+    intents = {r.intent for r in LOGGING_CONFIG_SCHEMA.resource_requirements}
+    assert intents == {"mod_log", "cleanup_log"}
+
+
+def test_logging_resource_requirements_link_to_bindings():
+    """Each ResourceRequirement.binding_name must match a declared BindingSpec."""
+    from cogs.logging.schemas import LOGGING_CONFIG_SCHEMA
+
+    binding_names = {b.name for b in LOGGING_CONFIG_SCHEMA.bindings}
+    for req in LOGGING_CONFIG_SCHEMA.resource_requirements:
+        assert req.binding_name in binding_names, (
+            f"ResourceRequirement intent={req.intent!r} "
+            f"references unknown binding {req.binding_name!r}"
+        )
+
+
+def test_logging_resource_requirements_are_recommended_not_required():
+    """Logging is opt-in by default; channels are RECOMMENDED, not REQUIRED."""
+    from cogs.logging.schemas import LOGGING_CONFIG_SCHEMA
+
+    for req in LOGGING_CONFIG_SCHEMA.resource_requirements:
+        assert req.provisioning.priority == ProvisioningPriority.RECOMMENDED
+
+
+def test_logging_resource_requirements_have_suggested_channel_names():
+    """Match the existing DEFAULT_*_CHANNEL_NAME constants so S7c's
+    create-channel flow does not have to invent new names."""
+    from cogs.logging.schemas import LOGGING_CONFIG_SCHEMA
+
+    by_intent = {r.intent: r for r in LOGGING_CONFIG_SCHEMA.resource_requirements}
+    assert by_intent["mod_log"].provisioning.suggested_name == "bot-mod-log"
+    assert by_intent["cleanup_log"].provisioning.suggested_name == "bot-cleanup-log"
+    for req in LOGGING_CONFIG_SCHEMA.resource_requirements:
+        assert req.kind == ResourceKind.CHANNEL
+
+
+# ---------------------------------------------------------------------------
+# Registry-level checks (logging shows up in SUBSYSTEMS)
+# ---------------------------------------------------------------------------
+
+
+def test_subsystems_registry_includes_logging():
+    from utils.subsystem_registry import SUBSYSTEMS
+
+    assert "logging" in SUBSYSTEMS
+    meta = SUBSYSTEMS["logging"]
+    assert meta["visibility_mode"] == "normal"
+    assert meta["visibility_tier"] == "administrator"
+    assert "logging" in meta["entry_points"]
+
+
+def test_logging_subsystem_has_three_declared_capabilities():
+    from utils.subsystem_registry import SUBSYSTEMS
+
+    caps = set(SUBSYSTEMS["logging"]["capabilities"])
+    assert caps == {
+        "logging.settings.configure",
+        "logging.channel.bind",
+        "logging.channel.create",
+    }
+
+
+def test_logging_in_known_panel_commands():
+    """Discoverability invariant relies on KNOWN_PANEL_COMMANDS for
+    cogs that don't have a build_help_menu_view hook of their own."""
+    from services.customization_catalogue import KNOWN_PANEL_COMMANDS
+
+    assert ("logging", "logging") in KNOWN_PANEL_COMMANDS


### PR DESCRIPTION
## Objective

First slice of S7 — Logging customization. Declare the `logging` `SubsystemSchema` (settings + bindings + resources) so the Settings Manager hub shows a read-only logging page and so S7b / S7c have stable catalogue contracts to migrate against.

**No runtime behavior change** to `services/server_logging.py` or the `!logging status` / `!logging test` commands. The schema is metadata-only in this PR.

## Schema (new — `disbot/cogs/logging/schemas.py`)

| Element | Name | Type / Kind | Notes |
|---|---|---|---|
| SettingSpec | `enabled` | bool, default `False` | `settings_key = LOGGING_ENABLED` — S6 edit/reset works today via `SettingsMutationPipeline` |
| SettingSpec | `auto_create_channels` | bool, default `False` | `settings_key = LOGGING_AUTO_CREATE_CHANNELS` |
| BindingSpec | `mod_channel` | `BindingKind.CHANNEL`, optional | S7b wires `BindingMutationPipeline` |
| BindingSpec | `cleanup_channel` | `BindingKind.CHANNEL`, optional | falls back to `mod_channel` at runtime |
| ResourceRequirement | `mod_log` | CHANNEL, RECOMMENDED, `bot-mod-log` | binding_name=`mod_channel`; S7c create-channel target |
| ResourceRequirement | `cleanup_log` | CHANNEL, RECOMMENDED, `bot-cleanup-log` | binding_name=`cleanup_channel` |

## Registry alignment

- `SUBSYSTEMS["logging"]` added — administrator tier, normal visibility, `entry_points=["logging"]`, capabilities `logging.settings.configure`, `logging.channel.bind`, `logging.channel.create`.
- `KNOWN_PANEL_COMMANDS` gains `("logging", "logging")` so the discoverability invariant (#109) classifies logging via `panel_command`.
- `AdminCog.cog_load` registers the schema — admin currently hosts the `!logging` group; S7d may extract a `LoggingCog` and move this call.

## Files

```
 disbot/cogs/admin_cog.py                   |  +12
 disbot/cogs/logging/__init__.py            |  +14 (new)
 disbot/cogs/logging/schemas.py             | +175 (new)
 disbot/services/customization_catalogue.py |   +1
 disbot/utils/subsystem_registry.py         |  +26
 docs/settings-customization-command-map.md |  +78
 tests/unit/cogs/test_logging_schemas.py    | +221 (new)
```

7 files, +527.

## Migrations

**None.** S6 audit table already covers the legacy scalar keys; S7b will add the binding-backfill helper.

## Validation

| Gate | Result |
|---|---|
| `ruff check disbot/` | All checks passed |
| `black --check disbot/` | 256 files unchanged |
| `isort --check-only disbot/ tests/` | clean |
| `mypy disbot/` | no issues found in 256 source files |
| `pytest tests/unit/` | **1959 passed** (was 1943 on main + 15 new schema tests + 1 from the discoverability invariant picking up the new logging entry) |
| Manual sanity | `SettingsHubView._candidate_subsystems()` surfaces "Server Logging" — verified locally |

**15 new tests** in `tests/unit/cogs/test_logging_schemas.py`:

- Registration: `register_schemas` adds logging; idempotent after `_reset_for_tests`.
- Settings: 2 SettingSpecs named correctly, pointing at the right legacy keys, with bool validators that reject ints/strings.
- Bindings: 2 BindingSpecs (`mod_channel`, `cleanup_channel`), both CHANNEL kind, optional, gated by `logging.settings.configure`.
- Resource requirements: cover both intents, link to declared bindings via `binding_name`, RECOMMENDED priority, correct suggested channel names.
- Registry: SUBSYSTEMS includes logging at admin tier; 3 capabilities declared; KNOWN_PANEL_COMMANDS entry present.

## Manual Discord smoke checklist (operator)

- `!settings` → "Server Logging" appears in the subsystem dropdown.
- Pick Server Logging → page renders:
  - Scalar settings: `enabled = False (default)`, `auto_create_channels = False (default)`.
  - Bindings: `mod_channel` (channel, optional), `cleanup_channel` (channel, optional).
  - Provisionable resources: `mod_log → bot-mod-log` (RECOMMENDED), `cleanup_log → bot-cleanup-log` (RECOMMENDED).
- S6 edit modal for `enabled` → toggling to True writes via `SettingsMutationPipeline` (audit row visible via `!settings → Audit`).
- `!logging status` / `!logging test` → unchanged behavior.
- `!platform settings-registry` → logging entries appear.
- `!platform schemas` → logging schema appears with 2 settings, 2 bindings, 2 resources.
- `!platform customization` → logging shows up with `help_hook=no, panel=panel_command`.
- `!platform provisioning` → both logging resource requirements appear at RECOMMENDED priority.

## Risk

**Low.** Schema-only PR. No mutation paths added. No new feature flags. No migrations. No changes to the runtime logging service. The S6 edit/reset flows now work on the two scalar settings because the schema declares them; this is the intended behavior.

## Rollback

`git revert` of this PR removes the schema declaration, the SUBSYSTEMS entry, and the doc section. No DB rollback needed.

## Deferred to subsequent S7 PRs

- **S7b** — Existing-channel selection through `BindingMutationPipeline`. Backfill from legacy `LOGGING_MOD_CHANNEL` / `LOGGING_CLEANUP_CHANNEL` scalars to the new bindings; `services/server_logging.resolve_log_channel` updated to prefer the binding.
- **S7c** — Create-channel flow through `ResourceProvisioningPipeline` with preview + explicit confirmation. On success, auto-bind via `BindingMutationPipeline`.
- **S7d** — Dedicated logging panel; replace the inline Logging button in `!adminmenu` with one that opens the full panel; add `build_help_menu_view` hook so `!help → Logging` opens the same panel.

## Depends on

Nothing open. Branches from `origin/main` directly (post navigation-coherence merge of #105–#109).

---

_S7a of 4 in the Logging customization sequence. Next: S7b — existing-channel binding._

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmoR3bvr1BHg1T1zqYLi1G)_