### PR TITLE
feat(navigation): admin menu integration — re-target #106 to main

### DIFF
--- a/disbot/cogs/admin_cog.py
+++ b/disbot/cogs/admin_cog.py
@@ -10,7 +10,7 @@ import discord
 from discord.ext import commands
 
 from core.runtime import resources
-from core.runtime.interaction_helpers import help_ctx_shim, safe_defer
+from core.runtime.interaction_helpers import help_ctx_shim, safe_defer, safe_edit
 from utils.ui_constants import ADMIN_COLOR, INFO_COLOR, SUCCESS_COLOR
 from views.base import HubView, send_panel
 
@@ -224,56 +224,7 @@ class AdminCog(commands.Cog):
     @commands.has_permissions(administrator=True)
     async def logging_status(self, ctx):
         """Show this guild's server-logging configuration + counters."""
-        from services import server_logging
-
-        enabled = await server_logging.is_enabled(ctx.guild.id) if ctx.guild else False
-        auto_create = (
-            await server_logging.auto_create_enabled(ctx.guild.id)
-            if ctx.guild
-            else False
-        )
-        mod_channel = cleanup_channel = None
-        if ctx.guild:
-            mod_channel = await server_logging.resolve_log_channel(ctx.guild, "mod")
-            cleanup_channel = await server_logging.resolve_log_channel(
-                ctx.guild,
-                "cleanup",
-            )
-        counters = server_logging.counters_snapshot()["counters"]
-
-        embed = discord.Embed(
-            title="📝 Server logging — status",
-            color=SUCCESS_COLOR if enabled else INFO_COLOR,
-        )
-        embed.add_field(
-            name="Enabled",
-            value="✅ on" if enabled else "⚪ off",
-            inline=True,
-        )
-        embed.add_field(
-            name="Auto-create channels",
-            value="✅ on" if auto_create else "⚪ off",
-            inline=True,
-        )
-        embed.add_field(
-            name="Mod channel",
-            value=mod_channel.mention if mod_channel else "*(unset)*",
-            inline=False,
-        )
-        cleanup_value = (
-            cleanup_channel.mention if cleanup_channel else "*(falls back to mod)*"
-        )
-        embed.add_field(
-            name="Cleanup channel",
-            value=cleanup_value,
-            inline=False,
-        )
-        embed.add_field(
-            name="Counters (process-local)",
-            value="\n".join(f"`{k}` = {v}" for k, v in sorted(counters.items())),
-            inline=False,
-        )
-        await ctx.send(embed=embed)
+        await ctx.send(embed=await build_logging_status_embed(ctx.guild))
 
     @logging_grp.command(name="test")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
@@ -316,6 +267,110 @@ class AdminCog(commands.Cog):
 
 
 # ---------------------------------------------------------------------------
+# Shared admin helpers
+# ---------------------------------------------------------------------------
+
+
+async def build_logging_status_embed(guild: discord.Guild | None) -> discord.Embed:
+    """Build the server-logging status embed.
+
+    Extracted from ``logging_status`` so the admin panel and the typed
+    ``!logging status`` command both render the same embed without
+    duplicating the field-building logic.
+    """
+    from services import server_logging
+
+    enabled = await server_logging.is_enabled(guild.id) if guild else False
+    auto_create = await server_logging.auto_create_enabled(guild.id) if guild else False
+    mod_channel = cleanup_channel = None
+    if guild:
+        mod_channel = await server_logging.resolve_log_channel(guild, "mod")
+        cleanup_channel = await server_logging.resolve_log_channel(guild, "cleanup")
+    counters = server_logging.counters_snapshot()["counters"]
+
+    embed = discord.Embed(
+        title="📝 Server logging — status",
+        color=SUCCESS_COLOR if enabled else INFO_COLOR,
+    )
+    embed.add_field(
+        name="Enabled",
+        value="✅ on" if enabled else "⚪ off",
+        inline=True,
+    )
+    embed.add_field(
+        name="Auto-create channels",
+        value="✅ on" if auto_create else "⚪ off",
+        inline=True,
+    )
+    embed.add_field(
+        name="Mod channel",
+        value=mod_channel.mention if mod_channel else "*(unset)*",
+        inline=False,
+    )
+    cleanup_value = (
+        cleanup_channel.mention if cleanup_channel else "*(falls back to mod)*"
+    )
+    embed.add_field(
+        name="Cleanup channel",
+        value=cleanup_value,
+        inline=False,
+    )
+    embed.add_field(
+        name="Counters (process-local)",
+        value="\n".join(f"`{k}` = {v}" for k, v in sorted(counters.items())),
+        inline=False,
+    )
+    return embed
+
+
+def attach_back_to_admin_button(
+    view: discord.ui.View,
+    author: discord.Member | discord.User,
+) -> None:
+    """Append a "↩ Back to Admin" control to a sub-view opened from the panel.
+
+    Mirrors :func:`cogs.help_cog._attach_back_to_help_button`: the
+    cog's panel class is not mutated — only the live view instance
+    receives the extra button.  No-op if the view already has 25
+    components (Discord cap).  When the back button is clicked a
+    fresh ``_AdminPanelView`` is constructed so the embed reflects
+    current cog load state.
+    """
+    if len(view.children) >= 25:
+        logging.getLogger("bot.cogs.admin").warning(
+            "Back-to-admin button skipped — %s already has 25 children.",
+            type(view).__name__,
+        )
+        return
+
+    back_btn = discord.ui.Button(  # type: ignore[var-annotated]
+        label="↩ Back to Admin",
+        custom_id="admin:back",
+        style=discord.ButtonStyle.secondary,
+        row=4,
+    )
+
+    async def _back_callback(interaction: discord.Interaction) -> None:
+        cog = interaction.client.get_cog("AdminCog")  # type: ignore[attr-defined]
+        if cog is None:
+            await interaction.response.send_message(
+                "Admin cog unavailable.",
+                ephemeral=True,
+            )
+            return
+        ctx_shim = help_ctx_shim(interaction)
+        new_view = _AdminPanelView(ctx_shim, cog)  # type: ignore[arg-type]
+        new_view._author = author  # preserve invoker identity
+        await interaction.response.edit_message(
+            embed=new_view.build_embed(),
+            view=new_view,
+        )
+
+    back_btn.callback = _back_callback  # type: ignore[method-assign]
+    view.add_item(back_btn)
+
+
+# ---------------------------------------------------------------------------
 # Admin Panel View
 # ---------------------------------------------------------------------------
 
@@ -334,10 +389,11 @@ class _AdminPanelView(HubView):
             title="🛠️ Admin Control Panel",
             description=(
                 f"Loaded cogs: **{loaded_count}**\n\n"
-                "**📊 Server Stats** — member & channel statistics\n"
-                "**📋 Cog List** — all cogs with load status\n"
-                "**🔄 Reload All** — reload all loaded cogs (owner)\n"
-                "**📝 Log Level** — change the bot log level"
+                "**Tools**\n"
+                "📊 Server Stats · 📋 Cog List · 🔄 Reload All · 📝 Log Level\n\n"
+                "**Navigate**\n"
+                "🛠 Settings · 🛰 Platform · 🩺 Diagnostics · 📝 Logging · "
+                "🧹 Cleanup · 📚 Help"
             ),
             color=ADMIN_COLOR,
         )
@@ -422,13 +478,171 @@ class _AdminPanelView(HubView):
     ):
         await interaction.response.send_modal(_LogLevelModal(self))
 
-    @discord.ui.button(label="↩ Overview", style=discord.ButtonStyle.secondary, row=1)
+    # ------------------------------------------------------------------
+    # Row 1 — navigation to subsystem hubs (no logic duplicated; each
+    # button delegates to the existing cog's panel/hook).
+    # ------------------------------------------------------------------
+
+    @discord.ui.button(label="🛠 Settings", style=discord.ButtonStyle.blurple, row=1)
+    async def settings_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ):
+        await self._open_via_help_hook(interaction, cog_name="SettingsCog")
+
+    @discord.ui.button(label="🛰 Platform", style=discord.ButtonStyle.blurple, row=1)
+    async def platform_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ):
+        if not await safe_defer(interaction):
+            return
+        from views.diagnostic import _PlatformHubView, build_platform_hub_embed
+
+        sub_view = _PlatformHubView(interaction.user)
+        attach_back_to_admin_button(sub_view, interaction.user)
+        await safe_edit(
+            interaction,
+            embed=build_platform_hub_embed(),
+            view=sub_view,
+        )
+
+    @discord.ui.button(label="🩺 Diagnostics", style=discord.ButtonStyle.blurple, row=1)
+    async def diagnostics_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ):
+        await self._open_via_help_hook(interaction, cog_name="DiagnosticCog")
+
+    @discord.ui.button(label="📝 Logging", style=discord.ButtonStyle.blurple, row=1)
+    async def logging_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ):
+        if not await safe_defer(interaction):
+            return
+        embed = await build_logging_status_embed(interaction.guild)
+        await safe_edit(interaction, embed=embed, view=self)
+
+    # ------------------------------------------------------------------
+    # Row 2 — cleanup + help shortcuts
+    # ------------------------------------------------------------------
+
+    @discord.ui.button(label="🧹 Cleanup", style=discord.ButtonStyle.blurple, row=2)
+    async def cleanup_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ):
+        await self._open_via_help_hook(interaction, cog_name="Cleanup")
+
+    @discord.ui.button(label="📚 Help", style=discord.ButtonStyle.blurple, row=2)
+    async def help_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ):
+        if not await safe_defer(interaction):
+            return
+        try:
+            from cogs.help_cog import HelpPanelView, _build_page_embed
+            from services import governance_service
+            from services.governance_service import GovernanceContext
+            from utils.subsystem_registry import all_subsystems_sorted
+
+            gctx = GovernanceContext.from_interaction(interaction)
+            vis_result = await governance_service.resolve_visibility(gctx)
+            visible_list = [
+                name
+                for name, _meta in all_subsystems_sorted()
+                if name in vis_result.visible_subsystems
+            ]
+            new_view = HelpPanelView(visible_list, page=0)
+            embed = _build_page_embed(
+                interaction.client,  # type: ignore[arg-type]
+                visible_list,
+                0,
+                vis_result.member_tier,
+            )
+            await safe_edit(interaction, embed=embed, view=new_view)
+        except Exception as exc:  # noqa: BLE001 — navigation must not crash panel
+            logging.getLogger("bot.cogs.admin").warning(
+                "Admin → Help navigation failed: %s",
+                exc,
+                exc_info=True,
+            )
+            embed = discord.Embed(
+                title="Help unavailable",
+                description=f"Could not open Help: `{type(exc).__name__}`.",
+                color=discord.Color.orange(),
+            )
+            await safe_edit(interaction, embed=embed, view=self)
+
+    # ------------------------------------------------------------------
+    # Row 3 — overview anchor (rebuilds this panel in place)
+    # ------------------------------------------------------------------
+
+    @discord.ui.button(label="↩ Overview", style=discord.ButtonStyle.secondary, row=3)
     async def overview_btn(
         self,
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ):
         await interaction.response.edit_message(embed=self.build_embed(), view=self)
+
+    # ------------------------------------------------------------------
+    # Shared helper for the three "open another cog's panel" buttons.
+    # ------------------------------------------------------------------
+
+    async def _open_via_help_hook(
+        self,
+        interaction: discord.Interaction,
+        *,
+        cog_name: str,
+    ) -> None:
+        """Open ``cog.build_help_menu_view(interaction)`` and edit in place.
+
+        Mirrors the help cog's direct-navigation pattern: the target
+        cog owns the panel; this panel just routes to it.  Adds a
+        "↩ Back to Admin" button so the user can return.
+        """
+        if not await safe_defer(interaction):
+            return
+        cog = interaction.client.get_cog(cog_name)  # type: ignore[attr-defined]
+        build_panel = getattr(cog, "build_help_menu_view", None) if cog else None
+        if not callable(build_panel):
+            embed = discord.Embed(
+                title=f"{cog_name} unavailable",
+                description=(
+                    f"`{cog_name}` is not loaded or does not expose "
+                    "`build_help_menu_view`."
+                ),
+                color=discord.Color.orange(),
+            )
+            await safe_edit(interaction, embed=embed, view=self)
+            return
+        try:
+            sub_embed, sub_view = await build_panel(interaction)
+        except Exception as exc:  # noqa: BLE001 — navigation must not crash panel
+            logging.getLogger("bot.cogs.admin").warning(
+                "Admin → %s navigation failed: %s",
+                cog_name,
+                exc,
+                exc_info=True,
+            )
+            embed = discord.Embed(
+                title=f"{cog_name} unavailable",
+                description=f"Could not open `{cog_name}`: `{type(exc).__name__}`.",
+                color=discord.Color.orange(),
+            )
+            await safe_edit(interaction, embed=embed, view=self)
+            return
+        attach_back_to_admin_button(sub_view, interaction.user)
+        await safe_edit(interaction, embed=sub_embed, view=sub_view)
 
 
 class _LogLevelModal(discord.ui.Modal, title="Set Log Level"):  # type: ignore[call-arg]

--- a/tests/unit/cogs/test_admin_menu_integration.py
+++ b/tests/unit/cogs/test_admin_menu_integration.py
@@ -1,0 +1,466 @@
+"""Unit tests for the admin menu integration buttons (PR 2).
+
+The admin menu (``!adminmenu`` / ``_AdminPanelView``) gains six
+navigation buttons that route into existing cog hubs / panels:
+
+- 🛠 Settings    → SettingsCog.build_help_menu_view
+- 🛰 Platform    → views.diagnostic._PlatformHubView (PR 1)
+- 🩺 Diagnostics → DiagnosticCog.build_help_menu_view
+- 📝 Logging     → build_logging_status_embed (in-place)
+- 🧹 Cleanup     → Cleanup.build_help_menu_view
+- 📚 Help        → cogs.help_cog.HelpPanelView
+
+These tests cover the view shape and the dispatch wiring.  The
+``build_help_menu_view`` hooks are mocked so we exercise the admin
+panel's routing logic without instantiating each downstream cog.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from cogs.admin_cog import (
+    AdminCog,
+    _AdminPanelView,
+    attach_back_to_admin_button,
+    build_logging_status_embed,
+)
+
+
+def _ctx_shim(user_id: int = 1) -> MagicMock:
+    ctx = MagicMock()
+    ctx.author = MagicMock()
+    ctx.author.id = user_id
+    return ctx
+
+
+def _admin_view(user_id: int = 1) -> _AdminPanelView:
+    bot = MagicMock()
+    bot.extensions = {"cogs.admin_cog": object()}
+    cog = AdminCog(bot=bot)
+    return _AdminPanelView(_ctx_shim(user_id), cog)
+
+
+def _find_button(view: discord.ui.View, label_substr: str) -> discord.ui.Button:
+    for child in view.children:
+        if isinstance(child, discord.ui.Button) and label_substr in (child.label or ""):
+            return child
+    raise AssertionError(f"No button with label containing {label_substr!r}")
+
+
+# ---------------------------------------------------------------------------
+# View shape
+# ---------------------------------------------------------------------------
+
+
+def test_admin_view_has_eleven_components_across_four_rows():
+    view = _admin_view()
+    # 4 existing tool buttons + 6 navigation buttons + 1 overview = 11.
+    assert len(view.children) == 11
+    rows = sorted({c.row for c in view.children})
+    assert rows == [0, 1, 2, 3]
+
+
+def test_admin_view_row_zero_contains_four_existing_tool_buttons():
+    view = _admin_view()
+    row0 = [c for c in view.children if c.row == 0]
+    labels = [b.label for b in row0]
+    assert len(row0) == 4
+    assert any("Server Stats" in (lbl or "") for lbl in labels)
+    assert any("Cog List" in (lbl or "") for lbl in labels)
+    assert any("Reload All" in (lbl or "") for lbl in labels)
+    assert any("Log Level" in (lbl or "") for lbl in labels)
+
+
+def test_admin_view_navigation_buttons_cover_all_six_destinations():
+    view = _admin_view()
+    nav_labels = [
+        c.label
+        for c in view.children
+        if c.row in (1, 2) and isinstance(c, discord.ui.Button)
+    ]
+    assert len(nav_labels) == 6
+    # Order-independent — verify each destination is reachable from
+    # the panel.
+    joined = " | ".join(lbl or "" for lbl in nav_labels)
+    assert "Settings" in joined
+    assert "Platform" in joined
+    assert "Diagnostics" in joined
+    assert "Logging" in joined
+    assert "Cleanup" in joined
+    assert "Help" in joined
+
+
+def test_admin_view_overview_is_last_row():
+    view = _admin_view()
+    overview = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and "Overview" in (c.label or "")
+    )
+    assert overview.row == 3
+    assert overview.style == discord.ButtonStyle.secondary
+
+
+def test_admin_overview_description_mentions_both_tools_and_navigation():
+    view = _admin_view()
+    embed = view.build_embed()
+    description = embed.description or ""
+    assert "Tools" in description
+    assert "Navigate" in description
+
+
+# ---------------------------------------------------------------------------
+# Logging button — direct dispatch to the extracted builder
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_logging_button_calls_logging_status_builder():
+    view = _admin_view()
+    btn = _find_button(view, "Logging")
+    interaction = MagicMock()
+    interaction.user = view._author
+    interaction.guild = MagicMock()
+    with patch(
+        "cogs.admin_cog.safe_defer",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "cogs.admin_cog.build_logging_status_embed",
+        new_callable=AsyncMock,
+        return_value=discord.Embed(title="📝 Server logging — status"),
+    ) as builder, patch(
+        "cogs.admin_cog.safe_edit",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as edit:
+        await btn.callback(interaction)
+    builder.assert_awaited_once_with(interaction.guild)
+    edit.assert_awaited_once()
+    assert edit.await_args.kwargs["view"] is view
+
+
+@pytest.mark.asyncio
+async def test_logging_button_bails_when_defer_fails():
+    view = _admin_view()
+    btn = _find_button(view, "Logging")
+    interaction = MagicMock()
+    interaction.user = view._author
+    with patch(
+        "cogs.admin_cog.safe_defer",
+        new_callable=AsyncMock,
+        return_value=False,
+    ), patch(
+        "cogs.admin_cog.build_logging_status_embed",
+        new_callable=AsyncMock,
+    ) as builder:
+        await btn.callback(interaction)
+    builder.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Platform button — opens _PlatformHubView from PR 1
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_platform_button_opens_platform_hub_view():
+    view = _admin_view()
+    btn = _find_button(view, "Platform")
+    interaction = MagicMock()
+    interaction.user = view._author
+    with patch(
+        "cogs.admin_cog.safe_defer",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "cogs.admin_cog.safe_edit",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as edit:
+        await btn.callback(interaction)
+    # _PlatformHubView is the swap target — verify by class name to
+    # avoid coupling to the import path.
+    edit.assert_awaited_once()
+    swapped_view = edit.await_args.kwargs["view"]
+    assert type(swapped_view).__name__ == "_PlatformHubView"
+
+
+@pytest.mark.asyncio
+async def test_platform_button_attaches_back_to_admin_button():
+    view = _admin_view()
+    btn = _find_button(view, "Platform")
+    interaction = MagicMock()
+    interaction.user = view._author
+    captured: dict[str, discord.ui.View] = {}
+
+    async def _capture_edit(interaction, **kwargs):
+        captured["view"] = kwargs["view"]
+        return True
+
+    with patch(
+        "cogs.admin_cog.safe_defer",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch("cogs.admin_cog.safe_edit", new=_capture_edit):
+        await btn.callback(interaction)
+    sub_view = captured["view"]
+    back_btns = [
+        c
+        for c in sub_view.children
+        if isinstance(c, discord.ui.Button) and "Back to Admin" in (c.label or "")
+    ]
+    assert len(back_btns) == 1
+
+
+# ---------------------------------------------------------------------------
+# _open_via_help_hook — Settings / Diagnostics / Cleanup buttons share this
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_open_via_help_hook_invokes_target_cog_hook():
+    view = _admin_view()
+    interaction = MagicMock()
+    interaction.user = view._author
+
+    fake_cog = MagicMock()
+    fake_embed = discord.Embed(title="Subsystem")
+    fake_view: discord.ui.View = discord.ui.View()
+    fake_cog.build_help_menu_view = AsyncMock(return_value=(fake_embed, fake_view))
+    interaction.client.get_cog.return_value = fake_cog
+
+    with patch(
+        "cogs.admin_cog.safe_defer",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "cogs.admin_cog.safe_edit",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as edit:
+        await view._open_via_help_hook(interaction, cog_name="SettingsCog")
+    interaction.client.get_cog.assert_called_with("SettingsCog")
+    fake_cog.build_help_menu_view.assert_awaited_once_with(interaction)
+    edit.assert_awaited_once()
+    assert edit.await_args.kwargs["embed"] is fake_embed
+    # Back-to-admin button must be attached to the routed sub-view.
+    back_btns = [
+        c
+        for c in fake_view.children
+        if isinstance(c, discord.ui.Button) and "Back to Admin" in (c.label or "")
+    ]
+    assert len(back_btns) == 1
+
+
+@pytest.mark.asyncio
+async def test_open_via_help_hook_handles_missing_cog():
+    view = _admin_view()
+    interaction = MagicMock()
+    interaction.user = view._author
+    interaction.client.get_cog.return_value = None
+    with patch(
+        "cogs.admin_cog.safe_defer",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "cogs.admin_cog.safe_edit",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as edit:
+        await view._open_via_help_hook(interaction, cog_name="GhostCog")
+    edit.assert_awaited_once()
+    embed = edit.await_args.kwargs["embed"]
+    assert "GhostCog unavailable" in (embed.title or "")
+    # Stay on the admin view; do not swap.
+    assert edit.await_args.kwargs["view"] is view
+
+
+@pytest.mark.asyncio
+async def test_open_via_help_hook_handles_hook_exception():
+    view = _admin_view()
+    interaction = MagicMock()
+    interaction.user = view._author
+    fake_cog = MagicMock()
+    fake_cog.build_help_menu_view = AsyncMock(side_effect=RuntimeError("boom"))
+    interaction.client.get_cog.return_value = fake_cog
+    with patch(
+        "cogs.admin_cog.safe_defer",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "cogs.admin_cog.safe_edit",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as edit:
+        await view._open_via_help_hook(interaction, cog_name="SettingsCog")
+    embed = edit.await_args.kwargs["embed"]
+    assert "SettingsCog unavailable" in (embed.title or "")
+    assert "RuntimeError" in (embed.description or "")
+
+
+# ---------------------------------------------------------------------------
+# Help button — resolves governance and opens HelpPanelView
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_help_button_opens_help_panel_view():
+    view = _admin_view()
+    btn = _find_button(view, "Help")
+    interaction = MagicMock()
+    interaction.user = view._author
+
+    vis_result = MagicMock()
+    vis_result.visible_subsystems = {"economy", "moderation"}
+    vis_result.member_tier = "everyone"
+    fake_panel_view = discord.ui.View()
+    fake_embed = discord.Embed(title="Help")
+
+    with patch(
+        "cogs.admin_cog.safe_defer",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "services.governance_service.resolve_visibility",
+        new_callable=AsyncMock,
+        return_value=vis_result,
+    ), patch(
+        "services.governance_service.GovernanceContext.from_interaction",
+        return_value=MagicMock(),
+    ), patch(
+        "utils.subsystem_registry.all_subsystems_sorted",
+        return_value=[
+            ("economy", {}),
+            ("moderation", {}),
+            ("invisible_sub", {}),
+        ],
+    ), patch(
+        "cogs.help_cog.HelpPanelView",
+        return_value=fake_panel_view,
+    ) as panel_cls, patch(
+        "cogs.help_cog._build_page_embed",
+        return_value=fake_embed,
+    ) as page_builder, patch(
+        "cogs.admin_cog.safe_edit",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as edit:
+        await btn.callback(interaction)
+    panel_cls.assert_called_once()
+    visible_list_arg = panel_cls.call_args.args[0]
+    assert visible_list_arg == ["economy", "moderation"]
+    page_builder.assert_called_once()
+    edit.assert_awaited_once()
+    assert edit.await_args.kwargs["view"] is fake_panel_view
+
+
+@pytest.mark.asyncio
+async def test_help_button_falls_back_to_orange_embed_on_governance_failure():
+    view = _admin_view()
+    btn = _find_button(view, "Help")
+    interaction = MagicMock()
+    interaction.user = view._author
+    with patch(
+        "cogs.admin_cog.safe_defer",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "services.governance_service.resolve_visibility",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("gov down"),
+    ), patch(
+        "services.governance_service.GovernanceContext.from_interaction",
+        return_value=MagicMock(),
+    ), patch(
+        "cogs.admin_cog.safe_edit",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as edit:
+        await btn.callback(interaction)
+    embed = edit.await_args.kwargs["embed"]
+    assert "Help unavailable" in (embed.title or "")
+    assert edit.await_args.kwargs["view"] is view
+
+
+# ---------------------------------------------------------------------------
+# attach_back_to_admin_button helper
+# ---------------------------------------------------------------------------
+
+
+def test_attach_back_to_admin_button_adds_a_button():
+    sub_view: discord.ui.View = discord.ui.View()
+    author = MagicMock()
+    author.id = 7
+    attach_back_to_admin_button(sub_view, author)
+    btns = [c for c in sub_view.children if isinstance(c, discord.ui.Button)]
+    assert len(btns) == 1
+    assert "Back to Admin" in (btns[0].label or "")
+    assert btns[0].custom_id == "admin:back"
+    assert btns[0].row == 4
+
+
+def test_attach_back_to_admin_button_noop_when_view_full():
+    sub_view: discord.ui.View = discord.ui.View()
+    # Fill to 25 components.
+    for i in range(25):
+        sub_view.add_item(
+            discord.ui.Button(label=f"x{i}", custom_id=f"x{i}", row=i // 5),
+        )
+    author = MagicMock()
+    attach_back_to_admin_button(sub_view, author)
+    # Still 25 — no overflow.
+    assert len(sub_view.children) == 25
+
+
+# ---------------------------------------------------------------------------
+# build_logging_status_embed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_logging_status_embed_with_disabled_logging():
+    guild = MagicMock()
+    guild.id = 1234
+    with patch(
+        "services.server_logging.is_enabled",
+        new_callable=AsyncMock,
+        return_value=False,
+    ), patch(
+        "services.server_logging.auto_create_enabled",
+        new_callable=AsyncMock,
+        return_value=False,
+    ), patch(
+        "services.server_logging.resolve_log_channel",
+        new_callable=AsyncMock,
+        return_value=None,
+    ), patch(
+        "services.server_logging.counters_snapshot",
+        return_value={"counters": {"sent": 0, "failed": 0}},
+    ):
+        embed = await build_logging_status_embed(guild)
+    field_names = [f.name for f in embed.fields]
+    assert field_names == [
+        "Enabled",
+        "Auto-create channels",
+        "Mod channel",
+        "Cleanup channel",
+        "Counters (process-local)",
+    ]
+    enabled_field = next(f for f in embed.fields if f.name == "Enabled")
+    assert "off" in enabled_field.value
+
+
+@pytest.mark.asyncio
+async def test_build_logging_status_embed_with_no_guild():
+    """DM invocation: build with guild=None must not crash."""
+    with patch(
+        "services.server_logging.counters_snapshot",
+        return_value={"counters": {}},
+    ):
+        embed = await build_logging_status_embed(None)
+    assert "Server logging" in (embed.title or "")


### PR DESCRIPTION
## Why this PR exists

PR #106 (admin menu integration) is **not on `main`**, even though GitHub reports it as merged. Same housekeeping pattern as PR #104 (re-target of the original PR #102):

- PR #106's actual merge commit is `159d83e`, with parents `0999a84` (old PR #105 head) and `15853d3` (PR #106 head).
- That merge commit only lives on `origin/claude/platform-panel-shell` — the now-merged feature branch of PR #105.
- When PR #105 merged to `main` it used a different merge commit (`09b8700` with parents `88fa04c` + `0999a84`). PR #106's content never reached `main`.

Verified on `origin/main`:
- `git show origin/main:disbot/cogs/admin_cog.py | grep -c "build_logging_status_embed"` → **0** (helper missing)
- `git show origin/main:disbot/cogs/admin_cog.py | grep -c "attach_back_to_admin_button"` → **0** (helper missing)
- `git merge-base --is-ancestor 15853d3 origin/main` → **NO**

Without this re-target, the navigation smoke checklist for `!adminmenu → Settings/Platform/Diagnostics/Logging/Cleanup/Help` cannot pass, and S7b/S7d are blocked because they reference `build_logging_status_embed`.

## What this PR does

Cherry-picks `15853d33e577c148a13a4dac70bdb8020c30c410` (the original PR #106 commit) onto a fresh branch from latest `origin/main`. **No scope change.** Strictly housekeeping.

`git cherry-pick -x` annotates the new commit message with `(cherry picked from commit 15853d3…)` for traceability.

## Verification (all gates clean)

- `ruff check disbot/` — All checks passed
- `black --check disbot/` — 254 files unchanged
- `isort --check-only disbot/ tests/` — clean
- `mypy disbot/` — no issues found in 254 source files
- `pytest tests/unit/cogs/test_admin_menu_integration.py` — **18 passed**
- `pytest tests/unit/` — **1961 passed** (was 1943 on main; 18 admin-menu tests now contribute since the file is back)

## Risk

**Low.**

- Cherry-pick applied cleanly with no conflicts. Drift check between PR #106's base (`40bdf5c`) and current `origin/main` on `disbot/cogs/admin_cog.py`: **zero** byte-level changes — the file's lineage from base goes straight to current main; PR #106's diff applies as-if linear.
- Pure UI/navigation. No mutation paths added. No new feature flags. No migrations.
- The `build_logging_status_embed` extraction it contains is byte-equivalent to the inline embed in the existing `!logging status` command.

## Rollback

`git revert` of this PR returns `main` to its current state. No DB rollback.

## Manual smoke (operator-side, after merge)

- `!adminmenu` — overview shows Tools (row 0) + Navigate (rows 1–2) + ↩ Overview (row 3).
- Settings / Platform / Diagnostics / Cleanup / Help buttons → each routes to the target hub with a "↩ Back to Admin" button. Back returns to admin overview.
- Logging button → in-place server-logging status embed.
- Non-admin invocation → blocked by `@commands.has_permissions(administrator=True)`.
- 180s no interaction → all buttons disable.

## Depends on

Nothing open. Branches from `origin/main` directly.

## Follow-ups blocked until this lands

- S7a (PR #110 — logging schema) is fine on its own but its full benefit (admin-menu Logging → status embed using `build_logging_status_embed`) only materialises once this PR lands.
- S7b (existing-channel binding select) — paused; will be resumed after this PR merges.

---

_Re-target PR. Source: cherry-picked from `15853d33e577c148a13a4dac70bdb8020c30c410` (PR #106). Original orphan merge: `159d83e` on `claude/platform-panel-shell`._

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmoR3bvr1BHg1T1zqYLi1G)_