### PR TITLE
feat(s7b): logging existing-channel binding through BindingMutationPipeline

### DIFF
--- a/disbot/cogs/admin_cog.py
+++ b/disbot/cogs/admin_cog.py
@@ -225,10 +225,10 @@ class AdminCog(commands.Cog):
     async def logging_grp(self, ctx):
         """Server-logging admin commands.
 
-        Usage: `!logging status` · `!logging test`
+        Usage: `!logging status` · `!logging test` · `!logging set <mod|cleanup>`
         """
         await ctx.send(
-            "Usage: `!logging <status|test>` — see `docs/server-logging.md`.",
+            "Usage: `!logging <status|test|set>` — see `docs/server-logging.md`.",
             delete_after=20,
         )
 
@@ -237,6 +237,45 @@ class AdminCog(commands.Cog):
     async def logging_status(self, ctx):
         """Show this guild's server-logging configuration + counters."""
         await ctx.send(embed=await build_logging_status_embed(ctx.guild))
+
+    @logging_grp.command(name="set")  # type: ignore[arg-type]
+    @commands.has_permissions(administrator=True)
+    async def logging_set(self, ctx, kind: str = ""):
+        """Open the channel-select view for ``mod`` or ``cleanup`` log binding.
+
+        Usage:
+            !logging set mod      open the mod-log channel selector
+            !logging set cleanup  open the cleanup-log channel selector
+
+        Writes through :class:`BindingMutationPipeline`; no scalar
+        settings are touched.  Available channels are filtered to
+        ``TextChannel`` only.
+        """
+        from cogs.logging.select_view import LogChannelSelectView
+
+        kind = kind.strip().lower()
+        if kind not in ("mod", "cleanup"):
+            await ctx.send(
+                "Usage: `!logging set <mod|cleanup>` — opens the channel "
+                "selector for the requested log binding.",
+                delete_after=20,
+            )
+            return
+        if ctx.guild is None:
+            await ctx.send(
+                "`!logging set` requires a guild context.",
+                delete_after=15,
+            )
+            return
+        view = LogChannelSelectView(ctx.author, kind)
+        await ctx.send(
+            (
+                f"Pick a channel to bind as the **{kind} log** for this guild.  "
+                "All writes route through `BindingMutationPipeline` and "
+                "produce an audit row."
+            ),
+            view=view,
+        )
 
     @logging_grp.command(name="test")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)

--- a/disbot/cogs/logging/select_view.py
+++ b/disbot/cogs/logging/select_view.py
@@ -1,0 +1,254 @@
+"""LogChannelSelectView — S7b existing-channel selection for logging bindings.
+
+Ephemeral view that lets an operator pick an existing TextChannel to
+bind as ``logging.mod_channel`` or ``logging.cleanup_channel``.  All
+writes route through :class:`BindingMutationPipeline` — no direct
+binding writes.
+
+The view is launched from the ``!logging set <mod|cleanup>`` typed
+command (S7b) and will also be embedded in the logging admin panel
+introduced in S7d.
+
+Strict scope (S7b):
+- existing-channel selection only; channel creation is S7c.
+- bindings only; no scalar settings writes here.
+- ephemeral confirmation messages so the operator gets immediate
+  feedback without anchoring a panel.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+from core.runtime.subsystem_schema import BindingKind
+
+logger = logging.getLogger("bot.cogs.logging.select_view")
+
+
+_KIND_TO_BINDING: dict[str, str] = {
+    "mod": "mod_channel",
+    "cleanup": "cleanup_channel",
+}
+
+_KIND_TO_LABEL: dict[str, str] = {
+    "mod": "moderation log",
+    "cleanup": "cleanup log",
+}
+
+
+def _binding_name_for(kind: str) -> str:
+    binding_name = _KIND_TO_BINDING.get(kind)
+    if binding_name is None:
+        raise ValueError(f"unknown logging channel kind: {kind!r}")
+    return binding_name
+
+
+class _LogChannelSelect(discord.ui.ChannelSelect):  # type: ignore[type-arg]
+    """Channel picker constrained to TextChannels in the current guild."""
+
+    def __init__(self, kind: str) -> None:
+        # Validate up front so a bad caller sees ValueError rather
+        # than a confusing KeyError from the label lookup below.
+        _binding_name_for(kind)
+        self.kind = kind
+        super().__init__(
+            placeholder=f"Pick the {_KIND_TO_LABEL[kind]} channel…",
+            min_values=1,
+            max_values=1,
+            channel_types=[discord.ChannelType.text],
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await _commit_selection(
+            interaction,
+            kind=self.kind,
+            target=self.values[0],
+        )
+
+
+class _ClearBindingButton(discord.ui.Button):
+    """Clear the current binding (sets target to NULL)."""
+
+    def __init__(self, kind: str) -> None:
+        self.kind = kind
+        super().__init__(
+            label="Clear binding",
+            style=discord.ButtonStyle.secondary,
+            row=1,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await _commit_clear(interaction, kind=self.kind)
+
+
+class LogChannelSelectView(discord.ui.View):
+    """Invoker-locked view with one ChannelSelect + a Clear button.
+
+    The view does not edit a parent message; selection callbacks send
+    ephemeral confirmation messages.  The view itself self-stops after
+    a successful interaction.
+    """
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        kind: str,
+    ) -> None:
+        super().__init__(timeout=120)
+        self._author = author
+        self.kind = kind
+        self.add_item(_LogChannelSelect(kind))
+        self.add_item(_ClearBindingButton(kind))
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self._author.id:
+            await interaction.response.send_message(
+                "This selector isn't yours.",
+                ephemeral=True,
+            )
+            return False
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Commit helpers — both go through BindingMutationPipeline
+# ---------------------------------------------------------------------------
+
+
+async def _commit_selection(
+    interaction: discord.Interaction,
+    *,
+    kind: str,
+    target: discord.abc.GuildChannel,
+) -> None:
+    """Write the binding via :class:`BindingMutationPipeline`.
+
+    Always responds ephemerally with success/failure.  Caller-facing
+    errors carry the exception class name; the full traceback is
+    logged.
+    """
+    guild = interaction.guild
+    if guild is None:
+        await interaction.response.send_message(
+            "Binding logging channels requires a guild context.",
+            ephemeral=True,
+        )
+        return
+
+    binding_name = _binding_name_for(kind)
+    actor = interaction.user
+    if not isinstance(actor, discord.Member):
+        await interaction.response.send_message(
+            "Could not resolve your guild membership for the audit row.",
+            ephemeral=True,
+        )
+        return
+
+    from services.binding_mutation import (
+        BindingMutationError,
+        BindingMutationPipeline,
+    )
+
+    try:
+        result = await BindingMutationPipeline().set_binding(
+            guild=guild,
+            subsystem="logging",
+            binding_name=binding_name,
+            kind=BindingKind.CHANNEL,
+            target_id=target.id,
+            actor=actor,
+        )
+    except BindingMutationError as exc:
+        logger.warning(
+            "logging.%s bind failed (guild=%d, target=%d, actor=%d): %s",
+            binding_name,
+            guild.id,
+            target.id,
+            actor.id,
+            exc,
+        )
+        await interaction.response.send_message(
+            f"❌ Could not bind {_KIND_TO_LABEL[kind]} channel: "
+            f"`{type(exc).__name__}`: {exc!s:.200}",
+            ephemeral=True,
+        )
+        return
+
+    embed = discord.Embed(
+        title=f"✅ {_KIND_TO_LABEL[kind].title()} channel bound",
+        description=(
+            f"Bound `logging.{binding_name}` → {target.mention}.\n"
+            f"Status: `{result.new_status.value}`."
+        ),
+        color=discord.Color.green(),
+    )
+    await interaction.response.send_message(embed=embed, ephemeral=True)
+
+
+async def _commit_clear(
+    interaction: discord.Interaction,
+    *,
+    kind: str,
+) -> None:
+    """Clear the binding via :class:`BindingMutationPipeline`."""
+    guild = interaction.guild
+    if guild is None:
+        await interaction.response.send_message(
+            "Clearing logging bindings requires a guild context.",
+            ephemeral=True,
+        )
+        return
+
+    binding_name = _binding_name_for(kind)
+    actor = interaction.user
+    if not isinstance(actor, discord.Member):
+        await interaction.response.send_message(
+            "Could not resolve your guild membership for the audit row.",
+            ephemeral=True,
+        )
+        return
+
+    from services.binding_mutation import (
+        BindingMutationError,
+        BindingMutationPipeline,
+    )
+
+    try:
+        await BindingMutationPipeline().clear_binding(
+            guild=guild,
+            subsystem="logging",
+            binding_name=binding_name,
+            kind=BindingKind.CHANNEL,
+            actor=actor,
+        )
+    except BindingMutationError as exc:
+        logger.warning(
+            "logging.%s clear failed (guild=%d, actor=%d): %s",
+            binding_name,
+            guild.id,
+            actor.id,
+            exc,
+        )
+        await interaction.response.send_message(
+            f"❌ Could not clear {_KIND_TO_LABEL[kind]} channel: "
+            f"`{type(exc).__name__}`: {exc!s:.200}",
+            ephemeral=True,
+        )
+        return
+
+    embed = discord.Embed(
+        title=f"✅ {_KIND_TO_LABEL[kind].title()} channel cleared",
+        description=(
+            f"Cleared `logging.{binding_name}`.  Falls back to "
+            "the legacy scalar key (or, for cleanup, to the mod "
+            "channel binding)."
+        ),
+        color=discord.Color.green(),
+    )
+    await interaction.response.send_message(embed=embed, ephemeral=True)
+
+
+__all__ = ["LogChannelSelectView"]

--- a/disbot/services/server_logging.py
+++ b/disbot/services/server_logging.py
@@ -131,23 +131,84 @@ async def resolve_log_channel(
 ) -> discord.TextChannel | None:
     """Resolve the configured log channel for *kind* (``"mod"`` / ``"cleanup"``).
 
-    Returns ``None`` if the setting is unset or points at a channel
-    not currently in the guild cache.  Cleanup falls back to the mod
-    channel id when its own slot is unset.
+    Resolution order (S7b):
+
+    1. ``logging.<kind>_channel`` binding — the canonical store going
+       forward.  Set/cleared by :class:`BindingMutationPipeline` via
+       :class:`cogs.logging.select_view.LogChannelSelectView`.
+    2. ``logging_<kind>_channel`` legacy scalar — transitional
+       fallback for guilds that configured logging before S7b.  Will
+       be removed once the binding-backfill helper lands.
+    3. For ``kind == "cleanup"`` only: fall back to the mod channel
+       (via the same two-step lookup against the mod binding then
+       the mod legacy scalar).
+
+    Returns ``None`` if no source resolves to a current TextChannel.
     """
     # core.runtime imports stay function-local to avoid re-entering
     # partially-loaded core.runtime during startup.
+    from core.runtime.bindings import get_binding
     from core.runtime.guild_resources import resolve_settings_channel
+    from core.runtime.subsystem_schema import BindingKind
 
-    keys: tuple[str, ...]
+    primary_binding = "mod_channel" if kind == "mod" else "cleanup_channel"
+    primary_legacy = (
+        _log_keys.LOGGING_MOD_CHANNEL
+        if kind == "mod"
+        else _log_keys.LOGGING_CLEANUP_CHANNEL
+    )
+
+    # 1. Try the primary binding.
+    try:
+        binding = await get_binding(
+            guild.id,
+            "logging",
+            primary_binding,
+            expected_kind=BindingKind.CHANNEL,
+        )
+    except Exception as exc:  # noqa: BLE001 — read must never crash logging
+        logger.warning(
+            "resolve_log_channel: get_binding(%r) failed: %s",
+            primary_binding,
+            exc,
+        )
+        binding = None  # fall through to legacy
+    if binding is not None and binding.target_id is not None:
+        ch = guild.get_channel(binding.target_id)
+        if isinstance(ch, discord.TextChannel):
+            return ch
+
+    # 2. Try the primary legacy scalar (transitional fallback).
+    legacy = await resolve_settings_channel(guild, primary_legacy)
+    if isinstance(legacy, discord.TextChannel):
+        return legacy
+
+    # 3. Cleanup falls back to the mod channel (both binding + legacy).
     if kind == "cleanup":
-        keys = (_log_keys.LOGGING_CLEANUP_CHANNEL, _log_keys.LOGGING_MOD_CHANNEL)
-    else:
-        keys = (_log_keys.LOGGING_MOD_CHANNEL,)
-    for key in keys:
-        channel = await resolve_settings_channel(guild, key)
-        if isinstance(channel, discord.TextChannel):
-            return channel
+        try:
+            mod_binding = await get_binding(
+                guild.id,
+                "logging",
+                "mod_channel",
+                expected_kind=BindingKind.CHANNEL,
+            )
+        except Exception as exc:  # noqa: BLE001 — read must never crash
+            logger.warning(
+                "resolve_log_channel: get_binding(mod_channel fallback) failed: %s",
+                exc,
+            )
+            mod_binding = None
+        if mod_binding is not None and mod_binding.target_id is not None:
+            ch = guild.get_channel(mod_binding.target_id)
+            if isinstance(ch, discord.TextChannel):
+                return ch
+        mod_legacy = await resolve_settings_channel(
+            guild,
+            _log_keys.LOGGING_MOD_CHANNEL,
+        )
+        if isinstance(mod_legacy, discord.TextChannel):
+            return mod_legacy
+
     return None
 
 

--- a/tests/unit/cogs/test_logging_binding_select.py
+++ b/tests/unit/cogs/test_logging_binding_select.py
@@ -1,0 +1,379 @@
+"""Unit tests for the S7b logging binding-select flow.
+
+Covers:
+
+- :class:`LogChannelSelectView` shape (ChannelSelect + Clear button,
+  invoker-locked).
+- The select callback routes through
+  :class:`BindingMutationPipeline.set_binding` with the correct
+  ``subsystem`` / ``binding_name`` / ``kind`` / ``target_id`` /
+  ``actor``.
+- The clear button routes through
+  :class:`BindingMutationPipeline.clear_binding`.
+- Pipeline failure surfaces as an ephemeral error embed.
+- DM invocation (no guild) is rejected with a clear message.
+
+The S7b update to :func:`services.server_logging.resolve_log_channel`
+is covered by additional tests in
+``tests/unit/services/test_server_logging.py``; here we exercise the
+binding-first resolution explicitly so the new code path has direct
+coverage.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from cogs.logging.select_view import LogChannelSelectView
+from core.runtime.subsystem_schema import BindingKind
+
+
+def _author(id_: int = 1) -> MagicMock:
+    member = MagicMock(spec=discord.Member)
+    member.id = id_
+    return member
+
+
+def _text_channel(id_: int = 100) -> MagicMock:
+    ch = MagicMock(spec=discord.TextChannel)
+    ch.id = id_
+    ch.mention = f"<#{id_}>"
+    return ch
+
+
+def _interaction(*, author: MagicMock, guild: object) -> MagicMock:
+    interaction = MagicMock()
+    interaction.user = author
+    interaction.guild = guild
+    interaction.response.send_message = AsyncMock()
+    return interaction
+
+
+# ---------------------------------------------------------------------------
+# View shape
+# ---------------------------------------------------------------------------
+
+
+def test_view_has_channel_select_and_clear_button():
+    view = LogChannelSelectView(_author(), "mod")
+    selects = [c for c in view.children if isinstance(c, discord.ui.ChannelSelect)]
+    buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+    assert len(selects) == 1
+    assert len(buttons) == 1
+    assert "Clear" in (buttons[0].label or "")
+
+
+def test_view_channel_select_restricted_to_text_channels():
+    view = LogChannelSelectView(_author(), "cleanup")
+    sel = next(c for c in view.children if isinstance(c, discord.ui.ChannelSelect))
+    assert discord.ChannelType.text in sel.channel_types
+
+
+def test_view_kind_unknown_raises():
+    """A typo in kind must fail fast at construction time."""
+    with pytest.raises(ValueError):
+        LogChannelSelectView(_author(), "garbage")
+
+
+@pytest.mark.asyncio
+async def test_view_invoker_check_rejects_other_user():
+    view = LogChannelSelectView(_author(id_=42), "mod")
+    interaction = MagicMock()
+    interaction.user.id = 99
+    interaction.response.send_message = AsyncMock()
+    result = await view.interaction_check(interaction)
+    assert result is False
+    interaction.response.send_message.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Select callback — routes through BindingMutationPipeline.set_binding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_select_callback_writes_via_binding_pipeline_for_mod():
+    actor = _author()
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 7
+    target = _text_channel(id_=500)
+    interaction = _interaction(author=actor, guild=guild)
+
+    fake_result = MagicMock()
+    fake_result.new_status.value = "ok"
+    fake_pipeline = MagicMock()
+    fake_pipeline.set_binding = AsyncMock(return_value=fake_result)
+
+    with patch(
+        "services.binding_mutation.BindingMutationPipeline",
+        return_value=fake_pipeline,
+    ):
+        from cogs.logging.select_view import _commit_selection
+
+        await _commit_selection(interaction, kind="mod", target=target)
+
+    fake_pipeline.set_binding.assert_awaited_once_with(
+        guild=guild,
+        subsystem="logging",
+        binding_name="mod_channel",
+        kind=BindingKind.CHANNEL,
+        target_id=500,
+        actor=actor,
+    )
+
+
+@pytest.mark.asyncio
+async def test_select_callback_writes_via_binding_pipeline_for_cleanup():
+    actor = _author()
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 7
+    target = _text_channel(id_=600)
+    interaction = _interaction(author=actor, guild=guild)
+
+    fake_result = MagicMock()
+    fake_result.new_status.value = "ok"
+    fake_pipeline = MagicMock()
+    fake_pipeline.set_binding = AsyncMock(return_value=fake_result)
+
+    with patch(
+        "services.binding_mutation.BindingMutationPipeline",
+        return_value=fake_pipeline,
+    ):
+        from cogs.logging.select_view import _commit_selection
+
+        await _commit_selection(interaction, kind="cleanup", target=target)
+
+    fake_pipeline.set_binding.assert_awaited_once_with(
+        guild=guild,
+        subsystem="logging",
+        binding_name="cleanup_channel",
+        kind=BindingKind.CHANNEL,
+        target_id=600,
+        actor=actor,
+    )
+
+
+@pytest.mark.asyncio
+async def test_select_callback_rejects_dm_invocation():
+    interaction = _interaction(author=_author(), guild=None)
+
+    from cogs.logging.select_view import _commit_selection
+
+    await _commit_selection(interaction, kind="mod", target=_text_channel())
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "guild context" in msg
+
+
+@pytest.mark.asyncio
+async def test_select_callback_surfaces_pipeline_error_ephemerally():
+    """A BindingMutationError must produce an ephemeral message; the
+    view must not crash and must not silently swallow the failure."""
+    from services.binding_mutation import BindingMutationError
+
+    actor = _author()
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 7
+    interaction = _interaction(author=actor, guild=guild)
+
+    fake_pipeline = MagicMock()
+    fake_pipeline.set_binding = AsyncMock(
+        side_effect=BindingMutationError("kind mismatch"),
+    )
+
+    with patch(
+        "services.binding_mutation.BindingMutationPipeline",
+        return_value=fake_pipeline,
+    ):
+        from cogs.logging.select_view import _commit_selection
+
+        await _commit_selection(interaction, kind="mod", target=_text_channel())
+
+    interaction.response.send_message.assert_awaited_once()
+    sent = interaction.response.send_message.await_args
+    assert sent.kwargs.get("ephemeral") is True
+    msg = sent.args[0]
+    assert "BindingMutationError" in msg
+
+
+# ---------------------------------------------------------------------------
+# Clear callback — routes through clear_binding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clear_callback_routes_through_clear_binding():
+    actor = _author()
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 7
+    interaction = _interaction(author=actor, guild=guild)
+
+    fake_pipeline = MagicMock()
+    fake_pipeline.clear_binding = AsyncMock(return_value=MagicMock())
+
+    with patch(
+        "services.binding_mutation.BindingMutationPipeline",
+        return_value=fake_pipeline,
+    ):
+        from cogs.logging.select_view import _commit_clear
+
+        await _commit_clear(interaction, kind="cleanup")
+
+    fake_pipeline.clear_binding.assert_awaited_once_with(
+        guild=guild,
+        subsystem="logging",
+        binding_name="cleanup_channel",
+        kind=BindingKind.CHANNEL,
+        actor=actor,
+    )
+
+
+@pytest.mark.asyncio
+async def test_clear_callback_rejects_dm_invocation():
+    interaction = _interaction(author=_author(), guild=None)
+
+    from cogs.logging.select_view import _commit_clear
+
+    await _commit_clear(interaction, kind="mod")
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "guild context" in msg
+
+
+# ---------------------------------------------------------------------------
+# resolve_log_channel — binding-first resolution (the S7b service change)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_log_channel_prefers_binding_over_legacy():
+    """When the binding is set, it wins over the legacy scalar key."""
+    from services.server_logging import resolve_log_channel
+
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 7
+    bound_channel = MagicMock(spec=discord.TextChannel)
+    guild.get_channel = MagicMock(return_value=bound_channel)
+
+    bound_binding = MagicMock()
+    bound_binding.target_id = 42
+
+    with patch(
+        "core.runtime.bindings.get_binding",
+        new_callable=AsyncMock,
+        return_value=bound_binding,
+    ), patch(
+        "core.runtime.guild_resources.resolve_settings_channel",
+        new_callable=AsyncMock,
+        return_value=MagicMock(spec=discord.TextChannel),  # legacy also set
+    ):
+        result = await resolve_log_channel(guild, "mod")
+    assert result is bound_channel
+    guild.get_channel.assert_called_with(42)
+
+
+@pytest.mark.asyncio
+async def test_resolve_log_channel_falls_back_to_legacy_when_binding_unset():
+    from services.server_logging import resolve_log_channel
+
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 7
+    legacy_channel = MagicMock(spec=discord.TextChannel)
+
+    unbound = MagicMock()
+    unbound.target_id = None
+
+    with patch(
+        "core.runtime.bindings.get_binding",
+        new_callable=AsyncMock,
+        return_value=unbound,
+    ), patch(
+        "core.runtime.guild_resources.resolve_settings_channel",
+        new_callable=AsyncMock,
+        return_value=legacy_channel,
+    ):
+        result = await resolve_log_channel(guild, "mod")
+    assert result is legacy_channel
+
+
+@pytest.mark.asyncio
+async def test_resolve_log_channel_falls_back_to_legacy_when_binding_target_missing():
+    """If the binding's target_id no longer exists in the guild, fall through."""
+    from services.server_logging import resolve_log_channel
+
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 7
+    guild.get_channel = MagicMock(return_value=None)  # binding target missing
+    legacy_channel = MagicMock(spec=discord.TextChannel)
+
+    bound_to_missing = MagicMock()
+    bound_to_missing.target_id = 999
+
+    with patch(
+        "core.runtime.bindings.get_binding",
+        new_callable=AsyncMock,
+        return_value=bound_to_missing,
+    ), patch(
+        "core.runtime.guild_resources.resolve_settings_channel",
+        new_callable=AsyncMock,
+        return_value=legacy_channel,
+    ):
+        result = await resolve_log_channel(guild, "mod")
+    assert result is legacy_channel
+
+
+@pytest.mark.asyncio
+async def test_resolve_log_channel_cleanup_falls_back_to_mod_binding():
+    """When cleanup binding + legacy are both unset, fall back to the mod binding."""
+    from services.server_logging import resolve_log_channel
+
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 7
+    mod_channel = MagicMock(spec=discord.TextChannel)
+    guild.get_channel = MagicMock(
+        side_effect=lambda cid: mod_channel if cid == 42 else None,
+    )
+
+    def fake_get_binding(_gid, _sub, binding_name, *, expected_kind=None):
+        out = MagicMock()
+        if binding_name == "cleanup_channel":
+            out.target_id = None
+        else:  # mod_channel
+            out.target_id = 42
+        return out
+
+    with patch(
+        "core.runtime.bindings.get_binding",
+        new=AsyncMock(side_effect=fake_get_binding),
+    ), patch(
+        "core.runtime.guild_resources.resolve_settings_channel",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        result = await resolve_log_channel(guild, "cleanup")
+    assert result is mod_channel
+
+
+@pytest.mark.asyncio
+async def test_resolve_log_channel_swallows_binding_lookup_exception():
+    """A get_binding exception must NOT crash logging — fall through to legacy."""
+    from services.server_logging import resolve_log_channel
+
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 7
+    legacy_channel = MagicMock(spec=discord.TextChannel)
+
+    with patch(
+        "core.runtime.bindings.get_binding",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("registry busted"),
+    ), patch(
+        "core.runtime.guild_resources.resolve_settings_channel",
+        new_callable=AsyncMock,
+        return_value=legacy_channel,
+    ):
+        result = await resolve_log_channel(guild, "mod")
+    assert result is legacy_channel

--- a/tests/unit/services/test_server_logging.py
+++ b/tests/unit/services/test_server_logging.py
@@ -247,11 +247,22 @@ def test_format_log_embed_extra_value_truncated_at_cap():
 # ---------------------------------------------------------------------------
 
 
+def _unbound_binding() -> MagicMock:
+    """Helper: a get_binding return value with no target set."""
+    b = MagicMock()
+    b.target_id = None
+    return b
+
+
 @pytest.mark.asyncio
 async def test_resolve_log_channel_mod_returns_text_channel():
     guild = _make_guild()
     channel = _make_text_channel(name="mod-log")
     with patch(
+        "core.runtime.bindings.get_binding",
+        new_callable=AsyncMock,
+        return_value=_unbound_binding(),
+    ), patch(
         "core.runtime.guild_resources.resolve_settings_channel",
         new_callable=AsyncMock,
         return_value=channel,
@@ -275,12 +286,17 @@ async def test_resolve_log_channel_cleanup_falls_back_to_mod():
         return None
 
     with patch(
+        "core.runtime.bindings.get_binding",
+        new_callable=AsyncMock,
+        return_value=_unbound_binding(),
+    ), patch(
         "core.runtime.guild_resources.resolve_settings_channel",
         side_effect=fake_resolve,
     ):
         result = await resolve_log_channel(guild, "cleanup")
     assert result is mod_channel
-    # Looked at cleanup first, then mod.
+    # Looked at cleanup first, then mod (both legacy fallbacks since
+    # the binding mock returns unbound for both).
     assert calls == ["logging_cleanup_channel", "logging_mod_channel"]
 
 
@@ -288,6 +304,10 @@ async def test_resolve_log_channel_cleanup_falls_back_to_mod():
 async def test_resolve_log_channel_returns_none_when_setting_unset():
     guild = _make_guild()
     with patch(
+        "core.runtime.bindings.get_binding",
+        new_callable=AsyncMock,
+        return_value=_unbound_binding(),
+    ), patch(
         "core.runtime.guild_resources.resolve_settings_channel",
         new_callable=AsyncMock,
         return_value=None,
@@ -300,6 +320,10 @@ async def test_resolve_log_channel_skips_non_text_channel():
     guild = _make_guild()
     voice = MagicMock(spec=discord.VoiceChannel)
     with patch(
+        "core.runtime.bindings.get_binding",
+        new_callable=AsyncMock,
+        return_value=_unbound_binding(),
+    ), patch(
         "core.runtime.guild_resources.resolve_settings_channel",
         new_callable=AsyncMock,
         return_value=voice,


### PR DESCRIPTION
## ⚠️ Stacked on PR #110 (S7a) — merge order: #110 first, then this PR

The BindingSpec declarations this PR depends on (`logging.mod_channel`, `logging.cleanup_channel`) live on `claude/s7a-logging-schema` (PR #110). When #110 merges into `main`, GitHub auto-retargets this PR onto `main`. The two PRs touch disjoint files outside the schema declarations.

## Objective

S7b — first write surface in the logging customization sequence. Operators can bind existing TextChannels to `logging.mod_channel` / `logging.cleanup_channel` via a `ChannelSelect` view; every write routes through `BindingMutationPipeline` — no direct binding writes, no scalar writes from this path.

## What this adds

### 1. New view — `cogs/logging/select_view.py`

| Element | Purpose |
|---|---|
| `LogChannelSelectView(author, kind)` | Invoker-locked ephemeral, 120s timeout, `ChannelSelect` restricted to `ChannelType.text` + `Clear binding` button |
| `_commit_selection(...)` | Routes through `BindingMutationPipeline.set_binding`; surfaces `BindingMutationError` ephemerally |
| `_commit_clear(...)` | Routes through `BindingMutationPipeline.clear_binding` |

Validates `kind` up front so a typo produces `ValueError`, not a confusing `KeyError`.

### 2. New typed subcommand — `!logging set <mod|cleanup>`

Lives under the existing `!logging` group in `admin_cog.py`. Opens `LogChannelSelectView` for the requested slot. DM context rejected with a clear message; missing/invalid `kind` arg prints usage. `@commands.has_permissions(administrator=True)` gating preserved.

### 3. Service rewrite — `services/server_logging.resolve_log_channel`

New resolution order:

1. `logging.<kind>_channel` binding via `core.runtime.bindings.get_binding` (canonical going forward).
2. `logging_<kind>_channel` legacy scalar (transitional fallback — preserves existing per-guild configuration).
3. For `kind == "cleanup"`: fall back to `mod_channel` binding, then legacy mod scalar.

`get_binding` exceptions are caught + logged at WARNING; a binding-table outage never crashes the logging path.

## Files

```
 disbot/cogs/admin_cog.py                          | +43
 disbot/cogs/logging/select_view.py                | +231 (new)
 disbot/services/server_logging.py                 | +73 / -11
 tests/unit/cogs/test_logging_binding_select.py    | +331 (new)
 tests/unit/services/test_server_logging.py        | +21 / -3
```

5 files, +699 / −14.

## Migrations

**None.** S6 audit table (migration 029) already covers binding writes via `BindingMutationPipeline`. No backfill in this PR — the first `!logging set` invocation populates the binding, after which subsequent reads prefer it.

## Validation

| Gate | Result |
|---|---|
| `ruff check disbot/` | All checks passed |
| `black --check disbot/` | 257 files unchanged |
| `isort --check-only disbot/ tests/` | clean |
| `mypy disbot/` | no issues found in 257 source files |
| `pytest tests/unit/` | **1992 passed**, 0 failed (S7a baseline 1977 + 15 new binding-select tests) |

**15 new tests** cover: view shape (ChannelSelect + Clear, invoker-locked); channel select restricted to text channels; unknown kind raises `ValueError`; `interaction_check` rejects non-author; select callback writes via `set_binding` with correct args for both mod and cleanup; DM invocation rejected (both select and clear paths); `BindingMutationError` surfaces ephemerally with class name; clear callback routes through `clear_binding`; `resolve_log_channel` prefers binding over legacy when set; falls back to legacy when binding unset; falls back to legacy when binding's `target_id` is no longer in the guild; cleanup falls back to mod binding when its own binding+legacy are unset; `get_binding` exception is swallowed and legacy fallback runs.

4 existing `resolve_log_channel` tests updated to also mock `get_binding` returning unbound so they still flow through the legacy path they were asserting on.

## Manual Discord smoke checklist (operator)

- `!logging set mod` → ChannelSelect view opens; pick `#mod-logs` → ephemeral "✅ Moderation Log channel bound" with `status=ok`.
- `!logging set cleanup` → same flow for `cleanup_channel`.
- Click "Clear binding" → ephemeral "✅ Moderation Log channel cleared" with fallback note.
- `!logging set garbage` → usage hint.
- `!logging set mod` in DM → rejected with clear message.
- `!logging status` → shows the newly bound channels in the embed (resolve_log_channel prefers bindings).
- `!platform bindings` → guild's `logging.mod_channel` / `cleanup_channel` appear in the per-guild bindings histogram.
- Non-admin tries `!logging set` → blocked by `@commands.has_permissions(administrator=True)`.

## Risk

**Low.**

- Single new write path, fully audited by `BindingMutationPipeline` (set + clear both audit).
- Resolve change is backwards-compatible: any guild with the legacy scalar set continues to work unchanged until they call `!logging set`.
- No mutations to scalar settings from this path. No resource creation. No new feature flags. No migrations.

## Rollback

`git revert` of this PR restores the previous `resolve_log_channel` behavior and removes `LogChannelSelectView` + the `!logging set` subcommand. Any bindings already written remain in `subsystem_bindings` but become inactive (the reverted resolver only reads legacy scalars).

## Deferred to subsequent S7 PRs

- **S7c** — Create-channel flow through `ResourceProvisioningPipeline` with preview + explicit confirmation. On success, auto-bind via `BindingMutationPipeline`.
- **S7d** — Dedicated logging admin panel; replace the inline `!adminmenu` Logging button with one that opens the full panel; add `build_help_menu_view` hook so `!help → Logging` opens it.

## Depends on

PR #110 (S7a — logging schema) — the `BindingSpec`s for `mod_channel` / `cleanup_channel` are declared there.

---

_S7b of 4 in the Logging customization sequence. Next: S7c — create-channel flow._

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmoR3bvr1BHg1T1zqYLi1G)_