### PR TITLE
feat(s7c): logging create-channel flow through ResourceProvisioningPipeline

### DIFF
--- a/disbot/cogs/admin_cog.py
+++ b/disbot/cogs/admin_cog.py
@@ -225,10 +225,15 @@ class AdminCog(commands.Cog):
     async def logging_grp(self, ctx):
         """Server-logging admin commands.
 
-        Usage: `!logging status` · `!logging test` · `!logging set <mod|cleanup>`
+        Usage:
+            !logging status
+            !logging test
+            !logging set <mod|cleanup>     pick an existing channel
+            !logging create <mod|cleanup>  create + bind a new channel
         """
         await ctx.send(
-            "Usage: `!logging <status|test|set>` — see `docs/server-logging.md`.",
+            "Usage: `!logging <status|test|set|create>` — see "
+            "`docs/server-logging.md`.",
             delete_after=20,
         )
 
@@ -276,6 +281,43 @@ class AdminCog(commands.Cog):
             ),
             view=view,
         )
+
+    @logging_grp.command(name="create")  # type: ignore[arg-type]
+    @commands.has_permissions(administrator=True)
+    async def logging_create(self, ctx, kind: str = ""):
+        """Open the preview + confirm view for creating a new log channel.
+
+        Usage:
+            !logging create mod      preview creation of the mod-log channel
+            !logging create cleanup  preview creation of the cleanup-log channel
+
+        Routes through :class:`ResourceProvisioningPipeline.provision`
+        which composes :class:`BindingMutationPipeline.set_binding`
+        atomically.  An audit row is recorded.  No channel is
+        created until the operator clicks Confirm Create.
+        """
+        from cogs.logging.provision_view import (
+            LogChannelProvisionView,
+            build_preview_embed,
+        )
+
+        kind = kind.strip().lower()
+        if kind not in ("mod", "cleanup"):
+            await ctx.send(
+                "Usage: `!logging create <mod|cleanup>` — opens a "
+                "preview + Confirm view for the requested channel.",
+                delete_after=20,
+            )
+            return
+        if ctx.guild is None:
+            await ctx.send(
+                "`!logging create` requires a guild context.",
+                delete_after=15,
+            )
+            return
+        preview_embed, allowed = await build_preview_embed(ctx.guild, kind)
+        view = LogChannelProvisionView(ctx.author, kind, confirm_enabled=allowed)
+        await ctx.send(embed=preview_embed, view=view)
 
     @logging_grp.command(name="test")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)

--- a/disbot/cogs/logging/provision_view.py
+++ b/disbot/cogs/logging/provision_view.py
@@ -1,0 +1,268 @@
+"""LogChannelProvisionView — S7c create-channel flow for logging bindings.
+
+Ephemeral view that shows the operator a preview of the channel
+about to be created, then requires an explicit Confirm click before
+calling :class:`ResourceProvisioningPipeline`.  The pipeline's
+11-step contract handles the create + bind + audit atomically (the
+binding write composes through :class:`BindingMutationPipeline` as
+part of step 8).
+
+Strict scope (S7c):
+- channel creation only; existing-channel selection is S7b.
+- no preview side effects (the pipeline's preview is side-effect-free).
+- explicit confirmation required — no silent provisioning.
+- the pipeline emits both the resource_provisioning_audit row and
+  the canonical advisory ``resource.provisioned`` event.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+logger = logging.getLogger("bot.cogs.logging.provision_view")
+
+
+_KIND_TO_BINDING: dict[str, str] = {
+    "mod": "mod_channel",
+    "cleanup": "cleanup_channel",
+}
+
+_KIND_TO_LABEL: dict[str, str] = {
+    "mod": "moderation log",
+    "cleanup": "cleanup log",
+}
+
+
+def _binding_name_for(kind: str) -> str:
+    binding_name = _KIND_TO_BINDING.get(kind)
+    if binding_name is None:
+        raise ValueError(f"unknown logging channel kind: {kind!r}")
+    return binding_name
+
+
+async def build_preview_embed(
+    guild: discord.Guild,
+    kind: str,
+) -> tuple[discord.Embed, bool]:
+    """Return ``(embed, allowed)`` for the preview shown before Confirm.
+
+    Calls :meth:`ResourceProvisioningPipeline.preview` — no side
+    effects.  When ``allowed=False`` the embed surfaces the warnings
+    so the operator sees the cause (permission missing, slot already
+    bound, name collision, etc.) without having to click Confirm and
+    fail.
+    """
+    binding_name = _binding_name_for(kind)
+    from services.resource_provisioning import (
+        ProvisioningRequest,
+        ResourceProvisioningPipeline,
+    )
+
+    request = ProvisioningRequest(
+        subsystem="logging",
+        binding_name=binding_name,
+        mode="create",
+    )
+    preview = await ResourceProvisioningPipeline().preview(guild, request)
+
+    color = discord.Color.green() if preview.allowed else discord.Color.orange()
+    label = _KIND_TO_LABEL[kind]
+    embed = discord.Embed(
+        title=f"🆕 Provision {label} channel — preview",
+        description=(
+            "This will create a new Discord channel and bind it to "
+            f"`logging.{binding_name}`.  All writes route through "
+            "`ResourceProvisioningPipeline` + `BindingMutationPipeline`, "
+            "and an audit row is recorded."
+        ),
+        color=color,
+    )
+    embed.add_field(
+        name="Action",
+        value=f"`{preview.action}`",
+        inline=True,
+    )
+    embed.add_field(
+        name="Target name",
+        value=f"`{preview.target_name}`" if preview.target_name else "*(unset)*",
+        inline=True,
+    )
+    embed.add_field(
+        name="Allowed",
+        value="✅ yes" if preview.allowed else "⚪ no",
+        inline=True,
+    )
+    if preview.warnings:
+        embed.add_field(
+            name="Warnings",
+            value="\n".join(f"• {w}" for w in preview.warnings)[:1024],
+            inline=False,
+        )
+    embed.set_footer(
+        text=(
+            "Click Confirm Create to provision.  Cancel to abort."
+            if preview.allowed
+            else "Address the warnings above before retrying."
+        ),
+    )
+    return embed, preview.allowed
+
+
+class _ConfirmCreateButton(discord.ui.Button):
+    """Confirm + run the audited create + bind transaction."""
+
+    def __init__(self, kind: str) -> None:
+        self.kind = kind
+        super().__init__(
+            label="Confirm Create",
+            style=discord.ButtonStyle.success,
+            row=0,
+            emoji="🆕",
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await _commit_provision(interaction, kind=self.kind)
+
+
+class _CancelButton(discord.ui.Button):
+    def __init__(self) -> None:
+        super().__init__(
+            label="Cancel",
+            style=discord.ButtonStyle.secondary,
+            row=0,
+            emoji="✖",
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        embed = discord.Embed(
+            title="Cancelled",
+            description="No channel created.  No audit row recorded.",
+            color=discord.Color.greyple(),
+        )
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+        view = self.view
+        if view is not None:
+            view.stop()
+
+
+class LogChannelProvisionView(discord.ui.View):
+    """Invoker-locked preview-then-confirm view.
+
+    The preview embed is built by the caller and shown when the
+    view opens.  The Confirm button calls
+    :meth:`ResourceProvisioningPipeline.provision(confirmed=True)`,
+    which runs the 11-step contract: option resolution, permission
+    check, name validation, optional collision handling, Discord
+    create, binding write via :class:`BindingMutationPipeline`,
+    audit row, event emission.
+    """
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        kind: str,
+        *,
+        confirm_enabled: bool,
+    ) -> None:
+        # Validate kind up front so a bad caller sees ValueError.
+        _binding_name_for(kind)
+        super().__init__(timeout=120)
+        self._author = author
+        self.kind = kind
+        confirm = _ConfirmCreateButton(kind)
+        if not confirm_enabled:
+            confirm.disabled = True
+        self.add_item(confirm)
+        self.add_item(_CancelButton())
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self._author.id:
+            await interaction.response.send_message(
+                "This selector isn't yours.",
+                ephemeral=True,
+            )
+            return False
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Commit — routes through ResourceProvisioningPipeline.provision(confirmed=True)
+# ---------------------------------------------------------------------------
+
+
+async def _commit_provision(
+    interaction: discord.Interaction,
+    *,
+    kind: str,
+) -> None:
+    """Run the audited create + bind transaction."""
+    guild = interaction.guild
+    if guild is None:
+        await interaction.response.send_message(
+            "Provisioning logging channels requires a guild context.",
+            ephemeral=True,
+        )
+        return
+
+    binding_name = _binding_name_for(kind)
+    actor = interaction.user
+    if not isinstance(actor, discord.Member):
+        await interaction.response.send_message(
+            "Could not resolve your guild membership for the audit row.",
+            ephemeral=True,
+        )
+        return
+
+    from services.resource_provisioning import (
+        ProvisioningRequest,
+        ResourceProvisioningError,
+        ResourceProvisioningPipeline,
+    )
+
+    request = ProvisioningRequest(
+        subsystem="logging",
+        binding_name=binding_name,
+        mode="create",
+    )
+
+    try:
+        result = await ResourceProvisioningPipeline().provision(
+            guild,
+            request,
+            actor,
+            confirmed=True,
+        )
+    except ResourceProvisioningError as exc:
+        logger.warning(
+            "logging.%s provision failed (guild=%d, actor=%d): %s",
+            binding_name,
+            guild.id,
+            actor.id,
+            exc,
+        )
+        await interaction.response.send_message(
+            f"❌ Provision failed: `{type(exc).__name__}`: {exc!s:.200}",
+            ephemeral=True,
+        )
+        return
+
+    channel_mention = (
+        f"<#{result.resource_id}>" if result.resource_id is not None else "*(unknown)*"
+    )
+    embed = discord.Embed(
+        title=f"✅ {_KIND_TO_LABEL[kind].title()} channel provisioned",
+        description=(
+            f"Created {channel_mention} and bound it to "
+            f"`logging.{binding_name}`.\n"
+            f"Outcome: `{result.outcome}` · "
+            f"binding_written: `{result.binding_written}` · "
+            f"audit_id: `{result.audit_id}`."
+        ),
+        color=discord.Color.green(),
+    )
+    await interaction.response.send_message(embed=embed, ephemeral=True)
+
+
+__all__ = ["LogChannelProvisionView", "build_preview_embed"]

--- a/tests/unit/cogs/test_logging_provision_channel.py
+++ b/tests/unit/cogs/test_logging_provision_channel.py
@@ -1,0 +1,286 @@
+"""Unit tests for the S7c logging create-channel flow.
+
+Covers:
+
+- :func:`build_preview_embed` calls
+  :meth:`ResourceProvisioningPipeline.preview` and renders the
+  result (allowed → green; blocked → orange + warnings field).
+- :class:`LogChannelProvisionView` shape (Confirm + Cancel,
+  invoker-locked).  Confirm button is disabled when the preview
+  is not allowed.
+- Confirm callback calls
+  :meth:`ResourceProvisioningPipeline.provision(confirmed=True)`
+  with the correct request shape (mode="create").
+- Provisioning failure surfaces as an ephemeral error embed.
+- Cancel produces an ephemeral cancellation embed and stops the view.
+- DM invocation rejected.
+
+The pipeline's auto-bind via :class:`BindingMutationPipeline` is
+internal to ``ResourceProvisioningPipeline.provision`` (step 8) and
+is exercised by the existing pipeline tests; here we verify the UI
+calls the right pipeline method with the right args.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from cogs.logging.provision_view import (
+    LogChannelProvisionView,
+    _commit_provision,
+    build_preview_embed,
+)
+
+
+def _author(id_: int = 1) -> MagicMock:
+    member = MagicMock(spec=discord.Member)
+    member.id = id_
+    return member
+
+
+def _interaction(*, author: MagicMock, guild: object) -> MagicMock:
+    interaction = MagicMock()
+    interaction.user = author
+    interaction.guild = guild
+    interaction.response.send_message = AsyncMock()
+    return interaction
+
+
+# ---------------------------------------------------------------------------
+# build_preview_embed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_allowed_returns_green_embed_and_allowed_true():
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 7
+
+    fake_preview = MagicMock()
+    fake_preview.allowed = True
+    fake_preview.action = "create_new"
+    fake_preview.target_name = "bot-mod-log"
+    fake_preview.warnings = ()
+
+    fake_pipeline = MagicMock()
+    fake_pipeline.preview = AsyncMock(return_value=fake_preview)
+
+    with patch(
+        "services.resource_provisioning.ResourceProvisioningPipeline",
+        return_value=fake_pipeline,
+    ):
+        embed, allowed = await build_preview_embed(guild, "mod")
+    assert allowed is True
+    assert embed.color == discord.Color.green()
+    fake_pipeline.preview.assert_awaited_once()
+    field_names = [f.name for f in embed.fields]
+    assert "Action" in field_names
+    assert "Target name" in field_names
+    assert "Allowed" in field_names
+    # No "Warnings" field when warnings is empty.
+    assert "Warnings" not in field_names
+
+
+@pytest.mark.asyncio
+async def test_preview_blocked_shows_warnings_and_orange_color():
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 7
+
+    fake_preview = MagicMock()
+    fake_preview.allowed = False
+    fake_preview.action = "blocked"
+    fake_preview.target_name = ""
+    fake_preview.warnings = (
+        "missing manage_channels permission",
+        "slot already bound",
+    )
+
+    fake_pipeline = MagicMock()
+    fake_pipeline.preview = AsyncMock(return_value=fake_preview)
+
+    with patch(
+        "services.resource_provisioning.ResourceProvisioningPipeline",
+        return_value=fake_pipeline,
+    ):
+        embed, allowed = await build_preview_embed(guild, "cleanup")
+    assert allowed is False
+    assert embed.color == discord.Color.orange()
+    warnings_field = next(f for f in embed.fields if f.name == "Warnings")
+    assert "manage_channels permission" in warnings_field.value
+    assert "slot already bound" in warnings_field.value
+
+
+@pytest.mark.asyncio
+async def test_preview_invalid_kind_raises():
+    guild = MagicMock(spec=discord.Guild)
+    with pytest.raises(ValueError):
+        await build_preview_embed(guild, "garbage")
+
+
+# ---------------------------------------------------------------------------
+# View shape
+# ---------------------------------------------------------------------------
+
+
+def test_view_has_confirm_and_cancel_button():
+    view = LogChannelProvisionView(_author(), "mod", confirm_enabled=True)
+    buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+    labels = [b.label or "" for b in buttons]
+    assert any("Confirm" in lbl for lbl in labels)
+    assert any("Cancel" in lbl for lbl in labels)
+
+
+def test_view_confirm_button_disabled_when_not_allowed():
+    view = LogChannelProvisionView(_author(), "cleanup", confirm_enabled=False)
+    confirm = next(
+        b
+        for b in view.children
+        if isinstance(b, discord.ui.Button) and "Confirm" in (b.label or "")
+    )
+    assert confirm.disabled is True
+
+
+def test_view_kind_unknown_raises():
+    with pytest.raises(ValueError):
+        LogChannelProvisionView(_author(), "garbage", confirm_enabled=True)
+
+
+@pytest.mark.asyncio
+async def test_view_invoker_check_rejects_other_user():
+    view = LogChannelProvisionView(_author(id_=42), "mod", confirm_enabled=True)
+    interaction = MagicMock()
+    interaction.user.id = 99
+    interaction.response.send_message = AsyncMock()
+    result = await view.interaction_check(interaction)
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Confirm callback — routes through ResourceProvisioningPipeline.provision
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_commit_provision_calls_pipeline_with_confirmed_true_for_mod():
+    actor = _author()
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 7
+    interaction = _interaction(author=actor, guild=guild)
+
+    fake_result = MagicMock()
+    fake_result.resource_id = 500
+    fake_result.outcome = "created"
+    fake_result.binding_written = True
+    fake_result.audit_id = 1
+    fake_pipeline = MagicMock()
+    fake_pipeline.provision = AsyncMock(return_value=fake_result)
+
+    with patch(
+        "services.resource_provisioning.ResourceProvisioningPipeline",
+        return_value=fake_pipeline,
+    ):
+        await _commit_provision(interaction, kind="mod")
+
+    fake_pipeline.provision.assert_awaited_once()
+    args = fake_pipeline.provision.await_args
+    # Pipeline.provision(guild, request, actor, confirmed=True)
+    assert args.args[0] is guild
+    assert args.args[1].subsystem == "logging"
+    assert args.args[1].binding_name == "mod_channel"
+    assert args.args[1].mode == "create"
+    assert args.args[2] is actor
+    assert args.kwargs.get("confirmed") is True
+
+
+@pytest.mark.asyncio
+async def test_commit_provision_routes_cleanup_to_cleanup_channel():
+    actor = _author()
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 7
+    interaction = _interaction(author=actor, guild=guild)
+
+    fake_result = MagicMock()
+    fake_result.resource_id = 600
+    fake_result.outcome = "created"
+    fake_result.binding_written = True
+    fake_result.audit_id = 2
+    fake_pipeline = MagicMock()
+    fake_pipeline.provision = AsyncMock(return_value=fake_result)
+
+    with patch(
+        "services.resource_provisioning.ResourceProvisioningPipeline",
+        return_value=fake_pipeline,
+    ):
+        await _commit_provision(interaction, kind="cleanup")
+
+    assert fake_pipeline.provision.await_args.args[1].binding_name == "cleanup_channel"
+
+
+@pytest.mark.asyncio
+async def test_commit_provision_rejects_dm_invocation():
+    interaction = _interaction(author=_author(), guild=None)
+
+    await _commit_provision(interaction, kind="mod")
+
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "guild context" in msg
+
+
+@pytest.mark.asyncio
+async def test_commit_provision_surfaces_pipeline_error_ephemerally():
+    from services.resource_provisioning import ResourceProvisioningError
+
+    actor = _author()
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 7
+    interaction = _interaction(author=actor, guild=guild)
+
+    fake_pipeline = MagicMock()
+    fake_pipeline.provision = AsyncMock(
+        side_effect=ResourceProvisioningError("missing manage_channels"),
+    )
+
+    with patch(
+        "services.resource_provisioning.ResourceProvisioningPipeline",
+        return_value=fake_pipeline,
+    ):
+        await _commit_provision(interaction, kind="mod")
+
+    interaction.response.send_message.assert_awaited_once()
+    sent = interaction.response.send_message.await_args
+    assert sent.kwargs.get("ephemeral") is True
+    msg = sent.args[0]
+    assert "ResourceProvisioningError" in msg
+    assert "manage_channels" in msg
+
+
+# ---------------------------------------------------------------------------
+# Cancel callback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_button_sends_cancellation_and_stops_view():
+    view = LogChannelProvisionView(_author(), "mod", confirm_enabled=True)
+    cancel = next(
+        b
+        for b in view.children
+        if isinstance(b, discord.ui.Button) and "Cancel" in (b.label or "")
+    )
+    interaction = MagicMock()
+    interaction.user = view._author
+    interaction.response.send_message = AsyncMock()
+
+    await cancel.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    sent = interaction.response.send_message.await_args
+    assert sent.kwargs.get("ephemeral") is True
+    embed = sent.kwargs.get("embed")
+    assert embed is not None
+    assert "Cancel" in (embed.title or "")
+    assert view.is_finished()


### PR DESCRIPTION
## ⚠️ Stacked on PR #112 (S7b) — merge order: #110 → #112 → this PR

Builds on the schema (#110) and the existing-channel binding flow (#112). When those land, GitHub auto-retargets this PR onto main.

## Objective

S7c — second write surface in the logging customization sequence. Operators can create new log channels via an explicit **preview + Confirm** flow. Routes through `ResourceProvisioningPipeline.provision(confirmed=True)`, which auto-binds via `BindingMutationPipeline.set_binding` as step 8 of its 11-step contract.

## What this adds

### 1. New view — `cogs/logging/provision_view.py`

| Element | Purpose |
|---|---|
| `build_preview_embed(guild, kind)` | Calls `ResourceProvisioningPipeline.preview` (side-effect-free). Renders action, target_name, allowed-state, warnings. Green when allowed; orange when blocked. |
| `LogChannelProvisionView` | Invoker-locked, 120s timeout. Confirm + Cancel buttons. Confirm auto-disabled when `preview.allowed=False` so the operator can't trigger a known-blocked request. |
| `_commit_provision` | Confirm callback. Calls `pipeline.provision(confirmed=True)`. `ResourceProvisioningError` surfaces ephemerally with class name; success shows new channel mention + outcome + `binding_written` + `audit_id`. |

### 2. New typed subcommand — `!logging create <mod|cleanup>`

Builds the preview embed via `build_preview_embed`, opens `LogChannelProvisionView` with `confirm_enabled` mirroring the preview's `allowed` flag. DM rejected; missing/invalid `kind` prints usage. Group usage hint updated to list `set + create` alongside `status + test`.

## Architecture notes

- `ResourceProvisioningPipeline`'s 11-step contract already composes `BindingMutationPipeline.set_binding` at step 8 — no separate bind call needed.
- Confirm-disabled-on-blocked-preview is an explicit UX guardrail, not a security boundary — the pipeline still raises on `confirmed=True` against an unauthorised request.
- The view does not emit its own events. The pipeline emits the canonical `resource.provisioned` advisory event after commit.

## Files

```
 disbot/cogs/admin_cog.py                          | +38
 disbot/cogs/logging/provision_view.py             | +250 (new)
 tests/unit/cogs/test_logging_provision_channel.py | +310 (new)
```

3 files, +598 / −2.

## Migrations

**None.** S4.5 audit table (migration 030) already covers provisioning audit rows. S7b's binding audit (migration 029) covers the auto-bind step.

## Validation

| Gate | Result |
|---|---|
| `ruff check disbot/` | All checks passed |
| `black --check disbot/` | 258 files unchanged |
| `isort --check-only disbot/ tests/` | clean |
| `mypy disbot/` | no issues found in 258 source files |
| `pytest tests/unit/` | **2004 passed**, 0 failed (S7b baseline 1992 + 12 new provision tests) |

**12 new tests** cover: `build_preview_embed` allowed → green embed (no Warnings field); blocked → orange embed with Warnings; invalid kind → `ValueError`. View: Confirm + Cancel present; Confirm disabled when `confirm_enabled=False`; invalid kind raises; `interaction_check` rejects non-author. `_commit_provision`: calls `pipeline.provision(confirmed=True)` with correct `subsystem` / `binding_name` / `mode` for both mod and cleanup; DM rejected; `ResourceProvisioningError` surfaces ephemerally with class name. Cancel: sends cancellation embed + stops view.

## Manual Discord smoke checklist (operator)

- `!logging create mod` → preview embed (action=`create_new`, target=`bot-mod-log`, allowed=`yes` when bot has `manage_channels`). Confirm Create button enabled.
- Click Confirm Create → ephemeral "✅ Moderation Log channel provisioned" with new channel mention + outcome + `audit_id`.
- `!platform bindings` → newly-created channel appears as `logging.mod_channel` binding.
- `!platform consistency` → `resource_provisioning_audit` shows a new row with `outcome=created`.
- `!logging create mod` when bot lacks `manage_channels` → preview shows `allowed=no` with warnings; Confirm Create button disabled.
- `!logging create cleanup` → same flow for `cleanup_channel`.
- Click Cancel → ephemeral "Cancelled" embed; no channel created.
- `!logging create garbage` → usage hint.
- `!logging create mod` in DM → rejected with clear message.

## Risk

**Low-to-medium** (this is a creation path):

- Single new write path, fully audited via the existing pipeline.
- Pipeline's safety net: permission check, name validation, optional collision handling, audit row before raise (where applicable).
- UX guardrail: Confirm button disabled when preview is blocked — the operator can't even click through.
- Auto-bind is atomic with creation; if the bind fails the audit row is `binding_failed` so the operator can reconcile.
- The `test_no_silent_auto_create.py` invariant still passes because all creation flows through the pipeline.

## Rollback

`git revert` of this PR removes `LogChannelProvisionView` + the `!logging create` subcommand. Any channels already created remain in the guild and any bindings written via this PR persist — they are visible via `!platform bindings`.

## Deferred to S7d

- **S7d** — Dedicated logging admin panel; replace the inline `!adminmenu` Logging button with one that opens the full panel (status + set + create entry points); add `build_help_menu_view` hook so `!help → Logging` opens it.

## Depends on

- PR #112 (S7b) — binding-select flow. Stacked.
- PR #110 (S7a) — schema declarations. Indirectly stacked through #112.

---

_S7c of 4 in the Logging customization sequence. Next: S7d — panel integration polish._

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmoR3bvr1BHg1T1zqYLi1G)_