### PR TITLE
feat(registry): add optional parent_hub/hub_group metadata (Phase 1)

### DIFF
--- a/disbot/utils/subsystem_registry.py
+++ b/disbot/utils/subsystem_registry.py
@@ -7,6 +7,19 @@ Overrides (visibility, cleanup rules) belong in governance DB, never here.
 Capability namespace rule: {subsystem}.{resource}.{action} — three parts, enforced.
 Reserved prefixes: _internal.*, system.*, governance.*
 
+Optional metadata (Phase 1, schema v2):
+    parent_hub: str | None — the key of a routable hub subsystem this entry
+        belongs to (e.g. ``"games"``). When set, downstream UI code (Help
+        filter, hubs) may treat the entry as a hub member. Two-hop chains
+        (a parent_hub pointing at a subsystem that itself has parent_hub
+        set) are rejected at validation time.
+    hub_group: str | None — free-form visual grouping label (≤ 32 chars).
+        Hubs use this to render sub-sections (e.g. ``"competitive"`` vs
+        ``"activities"``); the rendering layer validates allowed values.
+
+Phase 1 only introduces the *capability* — no existing entries set either
+field. Assignments happen in Phase 3.
+
 See services/governance_service.py for runtime policy resolution.
 """
 
@@ -31,7 +44,11 @@ from utils.ui_constants import (
 REGISTRY_VERSION = 1
 
 # Incremented when the subsystem dict schema/shape itself changes.
-REGISTRY_SCHEMA_VERSION = 1
+# v2 (Phase 1): added optional ``parent_hub`` and ``hub_group`` fields.
+REGISTRY_SCHEMA_VERSION = 2
+
+# Maximum length of the optional ``hub_group`` label.
+_HUB_GROUP_MAX_LEN = 32
 
 # ---------------------------------------------------------------------------
 # Subsystem manifest
@@ -723,7 +740,56 @@ def validate_registry() -> None:
                     f"subsystem '{name}': unknown related_subsystem '{rel}'",
                 )
 
+        # parent_hub / hub_group — optional Phase 1 metadata (schema v2)
+        parent_hub = meta.get("parent_hub")
+        if parent_hub is not None:
+            if not isinstance(parent_hub, str) or not parent_hub:
+                raise RegistryValidationError(
+                    f"subsystem '{name}': parent_hub must be a non-empty string",
+                )
+            if parent_hub == name:
+                raise RegistryValidationError(
+                    f"subsystem '{name}': parent_hub cannot reference self",
+                )
+            if parent_hub not in all_names:
+                raise RegistryValidationError(
+                    f"subsystem '{name}': parent_hub '{parent_hub}' is not a "
+                    f"registered subsystem",
+                )
+
+        hub_group = meta.get("hub_group")
+        if hub_group is not None:
+            if not isinstance(hub_group, str) or not hub_group:
+                raise RegistryValidationError(
+                    f"subsystem '{name}': hub_group must be a non-empty string",
+                )
+            if len(hub_group) > _HUB_GROUP_MAX_LEN:
+                raise RegistryValidationError(
+                    f"subsystem '{name}': hub_group length must be ≤ "
+                    f"{_HUB_GROUP_MAX_LEN} (got {len(hub_group)})",
+                )
+
         dep_graph[name] = list(meta.get("dependencies", []))
+
+    # parent_hub cross-entry checks: no two-hop hubs, hub must be routable.
+    # A second pass is needed because each entry's parent_hub references
+    # another entry and the referenced entry's own parent_hub must be
+    # known to validate the no-two-hop rule.
+    for name, meta in SUBSYSTEMS.items():
+        parent_hub = meta.get("parent_hub")
+        if parent_hub is None:
+            continue
+        parent_meta = SUBSYSTEMS[parent_hub]
+        if parent_meta.get("parent_hub") is not None:
+            raise RegistryValidationError(
+                f"subsystem '{name}': parent_hub '{parent_hub}' itself has a "
+                f"parent_hub — two-hop hubs are not allowed",
+            )
+        if not parent_meta.get("entry_points"):
+            raise RegistryValidationError(
+                f"subsystem '{name}': parent_hub '{parent_hub}' has no "
+                f"entry_points and is not routable",
+            )
 
     # DFS cycle detection
     visited: set[str] = set()

--- a/tests/unit/utils/test_subsystem_registry.py
+++ b/tests/unit/utils/test_subsystem_registry.py
@@ -28,7 +28,6 @@ import pytest
 import utils.subsystem_registry as reg
 from services.governance_exceptions import RegistryValidationError
 
-
 # ---------------------------------------------------------------------------
 # Synthetic-registry helpers (mirror the governance startup-validation file)
 # ---------------------------------------------------------------------------

--- a/tests/unit/utils/test_subsystem_registry.py
+++ b/tests/unit/utils/test_subsystem_registry.py
@@ -1,0 +1,268 @@
+"""Phase 1 tests for ``utils.subsystem_registry``.
+
+Covers the schema-v2 additions:
+
+* ``REGISTRY_SCHEMA_VERSION`` has been bumped to 2.
+* The real registry continues to validate cleanly with the new
+  validator in place (smoke test).
+* ``parent_hub`` and ``hub_group`` are accepted when valid.
+* ``parent_hub`` and ``hub_group`` are rejected when malformed,
+  unknown, self-referential, two-hop, or pointing at a non-routable
+  parent.
+* Deep-freeze still applies after validation when the new fields are
+  present.
+
+The negative cases follow the same monkeypatch pattern used by
+``tests/unit/governance/test_startup_validation.py``: build a minimal
+synthetic registry, mutate it, run the validator, assert the expected
+``RegistryValidationError``.
+"""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Callable
+
+import pytest
+
+import utils.subsystem_registry as reg
+from services.governance_exceptions import RegistryValidationError
+
+
+# ---------------------------------------------------------------------------
+# Synthetic-registry helpers (mirror the governance startup-validation file)
+# ---------------------------------------------------------------------------
+
+
+def _minimal_registry_with_hub() -> dict:
+    """Two subsystems: ``hub`` (routable) and ``child`` (no parent yet)."""
+    return {
+        "hub": {
+            "display_name": "Hub",
+            "description": "A routable hub",
+            "emoji": "🎮",
+            "color": 0x123456,
+            "visibility_tier": "user",
+            "visibility_mode": "normal",
+            "category": "test",
+            "tags": [],
+            "entry_points": ["hub"],
+            "default_channels": [],
+            "related_subsystems": [],
+            "dependencies": [],
+            "soft_dependencies": [],
+            "supports_dm": False,
+            "has_cleanup_rules": False,
+            "ui_priority": 50,
+            "capabilities": ["hub.view.show"],
+        },
+        "child": {
+            "display_name": "Child",
+            "description": "A potential hub member",
+            "emoji": "🅰️",
+            "color": 0xABCDEF,
+            "visibility_tier": "user",
+            "visibility_mode": "normal",
+            "category": "test",
+            "tags": [],
+            "entry_points": ["child"],
+            "default_channels": [],
+            "related_subsystems": [],
+            "dependencies": [],
+            "soft_dependencies": [],
+            "supports_dm": False,
+            "has_cleanup_rules": False,
+            "ui_priority": 51,
+            "capabilities": ["child.resource.read"],
+        },
+    }
+
+
+def _run_validation_with(monkeypatch, subsystems: dict) -> None:
+    monkeypatch.setattr(reg, "SUBSYSTEMS", subsystems)
+    monkeypatch.setattr(reg, "COMMAND_TO_SUBSYSTEM", {})
+    monkeypatch.setattr(reg, "CAPABILITY_TO_SUBSYSTEM", {})
+    monkeypatch.setattr(reg, "_COMPILED_DEPENDENTS", {})
+    monkeypatch.setattr(reg, "_COMPILED_TIERS", {})
+    monkeypatch.setattr(reg, "_COMPILED_CAPABILITIES", {})
+    monkeypatch.setattr(reg, "_COMPILED_ENTRYPOINTS", {})
+    monkeypatch.setattr(reg, "_COMPILED_DEPENDENCY_ORDER", [])
+    reg.validate_registry()
+
+
+Mutator = Callable[[dict], None]
+
+
+# ---------------------------------------------------------------------------
+# Schema version + real-registry smoke tests
+# ---------------------------------------------------------------------------
+
+
+def test_registry_schema_version_is_v2():
+    """Phase 1 bumps the schema version to 2."""
+    assert reg.REGISTRY_SCHEMA_VERSION == 2
+
+
+def test_real_registry_validates_under_schema_v2():
+    """The conftest already validated the real registry — this asserts the
+    deep-frozen result still contains every existing entry and that the
+    new optional fields read as ``None`` for all of them (Phase 1 sets
+    none of them).
+    """
+    assert len(reg.SUBSYSTEMS) >= 22
+    for name, meta in reg.SUBSYSTEMS.items():
+        assert meta.get("parent_hub") is None, (
+            f"subsystem {name!r} unexpectedly has parent_hub set in Phase 1"
+        )
+        assert meta.get("hub_group") is None, (
+            f"subsystem {name!r} unexpectedly has hub_group set in Phase 1"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Positive cases
+# ---------------------------------------------------------------------------
+
+
+def test_valid_parent_hub_passes(monkeypatch):
+    good = _minimal_registry_with_hub()
+    good["child"]["parent_hub"] = "hub"
+    _run_validation_with(monkeypatch, good)
+    # Validator deep-froze the registry; assert the field round-trips.
+    assert reg.SUBSYSTEMS["child"]["parent_hub"] == "hub"
+
+
+def test_valid_hub_group_passes(monkeypatch):
+    good = _minimal_registry_with_hub()
+    good["child"]["parent_hub"] = "hub"
+    good["child"]["hub_group"] = "competitive"
+    _run_validation_with(monkeypatch, good)
+    assert reg.SUBSYSTEMS["child"]["hub_group"] == "competitive"
+
+
+def test_hub_group_allowed_without_parent_hub(monkeypatch):
+    """``hub_group`` does not require ``parent_hub`` to be set; the
+    rendering layer owns semantic validation of the label.
+    """
+    good = _minimal_registry_with_hub()
+    good["child"]["hub_group"] = "ungrouped"
+    _run_validation_with(monkeypatch, good)
+    assert reg.SUBSYSTEMS["child"]["hub_group"] == "ungrouped"
+
+
+def test_deep_freeze_holds_after_validation_with_new_fields(monkeypatch):
+    """The new optional fields must not break the deep-freeze invariant."""
+    good = _minimal_registry_with_hub()
+    good["child"]["parent_hub"] = "hub"
+    good["child"]["hub_group"] = "competitive"
+    _run_validation_with(monkeypatch, good)
+    # SUBSYSTEMS itself is a MappingProxyType after validate_registry.
+    assert isinstance(reg.SUBSYSTEMS, MappingProxyType)
+    # And every entry is too.
+    for meta in reg.SUBSYSTEMS.values():
+        assert isinstance(meta, MappingProxyType)
+    # Mutation attempt raises.
+    with pytest.raises(TypeError):
+        reg.SUBSYSTEMS["child"]["parent_hub"] = "other"  # type: ignore[index]
+
+
+# ---------------------------------------------------------------------------
+# Negative cases — parent_hub
+# ---------------------------------------------------------------------------
+
+
+def _set_parent_hub(value: object) -> Mutator:
+    def mutate(r: dict) -> None:
+        r["child"]["parent_hub"] = value
+    return mutate
+
+
+def _set_hub_group(value: object) -> Mutator:
+    def mutate(r: dict) -> None:
+        r["child"]["hub_group"] = value
+    return mutate
+
+
+@pytest.mark.parametrize(
+    "mutator, expected_fragment",
+    [
+        (_set_parent_hub(""), "non-empty string"),
+        (_set_parent_hub(123), "non-empty string"),
+        (_set_parent_hub("child"), "reference self"),
+        (_set_parent_hub("missing_subsystem"), "not a registered subsystem"),
+    ],
+    ids=[
+        "parent_hub_empty_string",
+        "parent_hub_wrong_type",
+        "parent_hub_self_reference",
+        "parent_hub_unknown_subsystem",
+    ],
+)
+def test_parent_hub_invalid_cases(monkeypatch, mutator: Mutator, expected_fragment: str):
+    bad = _minimal_registry_with_hub()
+    mutator(bad)
+    with pytest.raises(RegistryValidationError) as excinfo:
+        _run_validation_with(monkeypatch, bad)
+    assert expected_fragment in str(excinfo.value)
+
+
+def test_parent_hub_two_hop_rejected(monkeypatch):
+    """A parent_hub pointing at a subsystem that itself has parent_hub set
+    must be rejected: hubs are flat.
+    """
+    bad = _minimal_registry_with_hub()
+    # Add a third subsystem so we can construct a 3-link chain.
+    bad["grandchild"] = {
+        **bad["child"],
+        "entry_points": ["grandchild"],
+        "capabilities": ["grandchild.resource.read"],
+    }
+    bad["child"]["parent_hub"] = "hub"
+    bad["grandchild"]["parent_hub"] = "child"  # child itself has a parent_hub
+    with pytest.raises(RegistryValidationError) as excinfo:
+        _run_validation_with(monkeypatch, bad)
+    assert "two-hop" in str(excinfo.value)
+
+
+def test_parent_hub_non_routable_parent_rejected(monkeypatch):
+    """The referenced parent_hub must have entry_points (be reachable)."""
+    bad = _minimal_registry_with_hub()
+    bad["hub"]["entry_points"] = []  # hub is no longer routable
+    bad["child"]["parent_hub"] = "hub"
+    with pytest.raises(RegistryValidationError) as excinfo:
+        _run_validation_with(monkeypatch, bad)
+    assert "not routable" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Negative cases — hub_group
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mutator, expected_fragment",
+    [
+        (_set_hub_group(""), "non-empty string"),
+        (_set_hub_group(123), "non-empty string"),
+        (_set_hub_group("x" * 33), "≤ 32"),
+    ],
+    ids=[
+        "hub_group_empty_string",
+        "hub_group_wrong_type",
+        "hub_group_too_long",
+    ],
+)
+def test_hub_group_invalid_cases(monkeypatch, mutator: Mutator, expected_fragment: str):
+    bad = _minimal_registry_with_hub()
+    mutator(bad)
+    with pytest.raises(RegistryValidationError) as excinfo:
+        _run_validation_with(monkeypatch, bad)
+    assert expected_fragment in str(excinfo.value)
+
+
+def test_hub_group_max_length_exactly_32_accepted(monkeypatch):
+    """The ≤ 32 bound is inclusive."""
+    good = _minimal_registry_with_hub()
+    good["child"]["hub_group"] = "x" * 32
+    _run_validation_with(monkeypatch, good)
+    assert reg.SUBSYSTEMS["child"]["hub_group"] == "x" * 32


### PR DESCRIPTION
## Objective

Phase 1 of the interface-completion roadmap: add optional `parent_hub` and `hub_group` metadata to the `SUBSYSTEMS` schema, with full startup validation, and bump `REGISTRY_SCHEMA_VERSION` 1 → 2.

This PR only adds the *capability*. No existing entries set either field; assignments land in Phase 3 alongside the Games hub.

## Files changed

- `disbot/utils/subsystem_registry.py` — added two optional fields with module-level docstring, per-entry validation block, cross-entry second-pass check, schema-version bump, and a `_HUB_GROUP_MAX_LEN` constant.
- `tests/unit/utils/__init__.py` *(new)* — package marker, matching sibling test packages.
- `tests/unit/utils/test_subsystem_registry.py` *(new, 16 tests)* — schema-version assertion, smoke check that the real registry validates under v2 and that every existing entry has `parent_hub=None` / `hub_group=None`, positive cases for valid `parent_hub` / `hub_group`, negative cases for malformed / unknown / self-referential / two-hop / non-routable parents and malformed / oversized `hub_group`, and a deep-freeze invariant assertion.

## Validation rules added

| Rule | Behavior |
|---|---|
| `parent_hub` set | must be a non-empty string |
| `parent_hub` set | must not reference self |
| `parent_hub` set | must reference a registered subsystem |
| `parent_hub` set | referenced parent must not itself have `parent_hub` set (no two-hop) |
| `parent_hub` set | referenced parent must have `entry_points` (be routable) |
| `hub_group` set | must be a non-empty string |
| `hub_group` set | length must be ≤ 32 chars |
| `hub_group` set without `parent_hub` | allowed — rendering layer owns semantic validation |

## Confirmation of no runtime behavior change

- Zero existing `SUBSYSTEMS` entries are modified. Every entry's `parent_hub` and `hub_group` remain `None` (implicit, since the keys aren't declared).
- The only consumer of `REGISTRY_SCHEMA_VERSION` is `disbot/governance/snapshot.py:54`, which just propagates the value into a `GovernanceSnapshot` — no code compares it against a fixed expected value.
- Deep-freeze invariant preserved: `SUBSYSTEMS` is still a `MappingProxyType` and every entry is too.

## Tests run

| Suite | Result |
|---|---|
| `pytest tests/unit/utils/test_subsystem_registry.py` | **16 passed** |
| `pytest tests/unit/governance/test_startup_validation.py tests/unit/registry/ tests/unit/services/test_customization_catalogue.py tests/unit/services/test_platform_consistency.py tests/unit/runtime/test_platform_commands.py tests/unit/schema/test_subsystem_schema_registry.py` | **386 passed** |
| `pytest` (full suite) | **2039 passed**, 12 warnings, 22.84s |
| `ruff check disbot/` | **clean** |
| `mypy disbot/utils/subsystem_registry.py` | **Success: no issues found in 1 source file** |

## Manual Discord smoke checklist

- [ ] Bot starts cleanly
- [ ] `!platform identity` reports no fatal findings
- [ ] `!platform schemas` lists all existing subsystems unchanged
- [ ] `!help` behavior unchanged (no new entries, no filtering)
- [ ] No regression in `!platform customization` reporting

(Automated tests cover the registry-validation paths these checks would exercise, but the manual run on a live bot is the integration verification.)

## Risks

- **Low.** Pure schema addition. Validation runs at startup and is deterministic. Every existing entry implicitly resolves `parent_hub` / `hub_group` to `None`, so behavior is unchanged. The `REGISTRY_SCHEMA_VERSION` bump propagates only into `GovernanceSnapshot.registry_schema_version`, which is treated as opaque metadata.

## Rollback plan

Revert the field-default additions, validator rules, and schema-version bump together, unless a later merged PR already depends on version 2. Since no entries in this PR set the new fields, no further data migration is required to roll back.

## Next recommended phase

**Phase 2 decision gate** — inspect whether `disbot/views/navigation_helpers.py` can be created import-safe (stdlib + `discord` only at module load, no cog imports, no `core.runtime.*` imports, parent-view reconstruction via callable). If yes, ship Phase 2; if any check fails, skip directly to Phase 3 (Games hub) and revisit helper extraction as Phase 3.5.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TeXrWGdRyGEcukWEv1qryT)_