### PR TITLE
feat(games): Games hub router + `parent_hub` wiring (Phase 3)

### DIFF
--- a/disbot/cogs/games_cog.py
+++ b/disbot/cogs/games_cog.py
@@ -1,0 +1,53 @@
+"""Games hub cog — thin router that opens :class:`GamesHubView`.
+
+This cog contains **zero** game logic. Individual game logic stays in
+Blackjack, RPS Tournament, Deathmatch, Mining, Counting, and Chain.
+The hub here only owns:
+
+* The ``!games`` command that opens the hub directly.
+* The :meth:`build_help_menu_view` hook that surfaces the hub from
+  ``!help`` → "Games".
+
+The view itself (in :mod:`views.games.hub`) discovers its children from
+``SUBSYSTEMS`` by filtering on ``parent_hub == "games"`` — there is no
+hard-coded child list here.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+from discord.ext import commands
+
+from core.runtime.interaction_helpers import help_ctx_shim
+from views.base import send_panel
+from views.games.hub import GamesHubView, build_games_hub_embed
+
+logger = logging.getLogger("bot.cogs.games")
+
+
+class GamesCog(commands.Cog):
+    """Router-only Games hub. No game logic lives here."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @commands.command(name="games")
+    async def games_menu(self, ctx: commands.Context) -> None:
+        """Open the Games hub — competitive games and channel activities."""
+        view = GamesHubView(ctx.author)
+        await send_panel(ctx, embed=build_games_hub_embed(), view=view)
+
+    async def build_help_menu_view(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        """Help-menu direct-navigation hook — returns the Games hub panel."""
+        ctx_shim = help_ctx_shim(interaction)
+        view = GamesHubView(ctx_shim.author)
+        return build_games_hub_embed(), view
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(GamesCog(bot))

--- a/disbot/config.py
+++ b/disbot/config.py
@@ -53,6 +53,7 @@ INITIAL_EXTENSIONS = [
     "cogs.leaderboard_cog",
     "cogs.settings_cog",
     "cogs.logging_cog",
+    "cogs.games_cog",
 ]
 
 # ==========================

--- a/disbot/services/customization_catalogue.py
+++ b/disbot/services/customization_catalogue.py
@@ -78,6 +78,7 @@ KNOWN_PANEL_COMMANDS: tuple[tuple[str, str], ...] = (
     ("cleanup", "wordmenu"),
     ("counting", "countingmenu"),
     ("economy", "economymenu"),
+    ("games", "games"),
     ("general", "generalmenu"),
     ("logging", "logging"),
     ("mining", "minemenu"),

--- a/disbot/utils/subsystem_registry.py
+++ b/disbot/utils/subsystem_registry.py
@@ -172,6 +172,8 @@ SUBSYSTEMS: dict[str, dict] = {
         "supports_dm": False,
         "has_cleanup_rules": False,
         "ui_priority": 20,
+        "parent_hub": "games",
+        "hub_group": "activities",
         "capabilities": [
             "mining.resource.mine",
             "mining.resource.view",
@@ -272,6 +274,34 @@ SUBSYSTEMS: dict[str, dict] = {
             "cleanup.policy.configure",
         ],
     },
+    "games": {
+        "display_name": "Games",
+        "description": "Competitive games and channel activities",
+        "emoji": "🎮",
+        "color": GAME_COLOR.value,
+        "visibility_tier": "user",
+        "visibility_mode": "normal",
+        "category": "games",
+        "tags": ["games", "hub", "activities"],
+        "entry_points": ["games"],
+        "default_channels": ["games", "bot-commands"],
+        "related_subsystems": [
+            "blackjack",
+            "rps_tournament",
+            "deathmatch",
+            "mining",
+            "counting",
+            "chain",
+        ],
+        "dependencies": [],
+        "soft_dependencies": [],
+        "supports_dm": False,
+        "has_cleanup_rules": False,
+        "ui_priority": 28,
+        "capabilities": [
+            "games.hub.view",
+        ],
+    },
     "blackjack": {
         "display_name": "Blackjack",
         "description": "Blackjack card game",
@@ -289,6 +319,8 @@ SUBSYSTEMS: dict[str, dict] = {
         "supports_dm": False,
         "has_cleanup_rules": False,
         "ui_priority": 30,
+        "parent_hub": "games",
+        "hub_group": "competitive",
         "capabilities": [
             "blackjack.game.play",
         ],
@@ -310,6 +342,8 @@ SUBSYSTEMS: dict[str, dict] = {
         "supports_dm": False,
         "has_cleanup_rules": False,
         "ui_priority": 32,
+        "parent_hub": "games",
+        "hub_group": "competitive",
         "capabilities": [
             "deathmatch.game.challenge",
             "deathmatch.stat.view",
@@ -332,6 +366,8 @@ SUBSYSTEMS: dict[str, dict] = {
         "supports_dm": False,
         "has_cleanup_rules": False,
         "ui_priority": 34,
+        "parent_hub": "games",
+        "hub_group": "competitive",
         "capabilities": [
             "rps_tournament.game.join",
             "rps_tournament.tournament.manage",
@@ -354,6 +390,8 @@ SUBSYSTEMS: dict[str, dict] = {
         "supports_dm": False,
         "has_cleanup_rules": False,
         "ui_priority": 36,
+        "parent_hub": "games",
+        "hub_group": "activities",
         "capabilities": [
             "counting.game.play",
             "counting.game.configure",
@@ -376,6 +414,8 @@ SUBSYSTEMS: dict[str, dict] = {
         "supports_dm": False,
         "has_cleanup_rules": False,
         "ui_priority": 38,
+        "parent_hub": "games",
+        "hub_group": "activities",
         "capabilities": [
             "chain.game.play",
             "chain.game.configure",

--- a/disbot/views/games/hub.py
+++ b/disbot/views/games/hub.py
@@ -1,0 +1,298 @@
+"""Games hub view — routes to per-game help/hub panels.
+
+The Games subsystem is a router-only hub. It discovers its children
+dynamically from :data:`utils.subsystem_registry.SUBSYSTEMS` by filtering
+for entries whose ``parent_hub`` equals ``"games"``, then groups them by
+``hub_group`` (currently ``"competitive"`` and ``"activities"``).
+
+Game logic stays in each individual cog (Blackjack, RPS, Deathmatch,
+Mining, Counting, Chain). This view is a navigation surface only:
+
+* The select dropdown forwards to the child cog's
+  :meth:`build_help_menu_view` hook, identical to how ``!help`` routes
+  into a subsystem.
+* A "↩ Back to Games" button is attached to the child view so users can
+  return to the hub. The Phase 2 roadmap step (a shared back-nav helper)
+  is deferred to Phase 3.5; until then, the inline factory below mirrors
+  the existing patterns in ``help_cog.py``, ``admin_cog.py``, and
+  ``views/settings/subsystem_view.py``.
+
+Direct ``!games`` invocation: the hub opens with the select only.
+``!help`` is the way back to the help menu in that flow, mirroring
+``!countingmenu`` / ``!minemenu`` / ``!adminmenu`` conventions.
+
+When the hub is surfaced via ``!help`` → "Games", :func:`HelpPanelView`
+appends the "↩ Back to Help" button itself — so this view never adds
+that button, avoiding duplicates.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+from utils.subsystem_registry import SUBSYSTEMS
+from utils.ui_constants import GAME_COLOR
+from views.base import HubView
+
+logger = logging.getLogger("bot.views.games")
+
+# Hub group rendering order. Groups not listed sort last (alphabetically).
+_GROUP_ORDER: dict[str, int] = {"competitive": 0, "activities": 1}
+
+_GROUP_HEADINGS: dict[str, str] = {
+    "competitive": "🏆 Competitive",
+    "activities": "🎲 Activities",
+}
+
+
+def discover_game_children() -> list[tuple[str, dict]]:
+    """Return SUBSYSTEMS entries that route to the Games hub.
+
+    Sorted by ``hub_group`` (competitive before activities), then by
+    ``ui_priority``, then by subsystem key — fully deterministic so the
+    UI ordering is stable.
+    """
+    children = [
+        (name, dict(meta))
+        for name, meta in SUBSYSTEMS.items()
+        if meta.get("parent_hub") == "games"
+    ]
+    children.sort(
+        key=lambda item: (
+            _GROUP_ORDER.get(item[1].get("hub_group") or "", 99),
+            item[1].get("ui_priority", 99),
+            item[0],
+        ),
+    )
+    return children
+
+
+def build_games_hub_embed() -> discord.Embed:
+    """Build the embed shown by :class:`GamesHubView`."""
+    embed = discord.Embed(
+        title="🎮 Games Hub",
+        description=(
+            "Pick a game from the dropdown to see its commands and modes. "
+            "Typed shortcuts (e.g. `!blackjack`, `!mine`) still work."
+        ),
+        color=GAME_COLOR,
+    )
+
+    by_group: dict[str, list[tuple[str, dict]]] = {}
+    for name, meta in discover_game_children():
+        group = meta.get("hub_group") or "other"
+        by_group.setdefault(group, []).append((name, meta))
+
+    if not by_group:
+        embed.add_field(
+            name="No games configured",
+            value="No subsystems route to the Games hub yet.",
+            inline=False,
+        )
+        return embed
+
+    seen_groups = sorted(
+        by_group,
+        key=lambda g: (_GROUP_ORDER.get(g, 99), g),
+    )
+    for group in seen_groups:
+        members = by_group[group]
+        heading = _GROUP_HEADINGS.get(group, group.title())
+        lines = [
+            f"{meta.get('emoji', '')} **{meta['display_name']}** — "
+            f"{meta['description']}".strip()
+            for _, meta in members
+        ]
+        embed.add_field(name=heading, value="\n".join(lines), inline=False)
+
+    embed.set_footer(text="Only you can interact with this panel.")
+    return embed
+
+
+def attach_back_to_games_button(
+    view: discord.ui.View,
+    author: discord.Member | discord.User,
+) -> bool:
+    """Append a "↩ Back to Games" control to a child view opened from the hub.
+
+    No-op (returns ``False``) if the view already has Discord's 25-child
+    limit. The callback rebuilds a fresh :class:`GamesHubView` so the
+    child list reflects the current registry on click.
+
+    Inline factory mirroring ``cogs.help_cog._attach_back_to_help_button``
+    and friends. Will be migrated into a shared helper in Phase 3.5.
+    """
+    if len(view.children) >= 25:
+        logger.warning(
+            "Back-to-games button skipped — %s already has 25 children.",
+            type(view).__name__,
+        )
+        return False
+
+    back_btn = discord.ui.Button(  # type: ignore[var-annotated]
+        label="↩ Back to Games",
+        custom_id="games:back",
+        style=discord.ButtonStyle.secondary,
+        row=4,
+    )
+
+    async def _back_callback(interaction: discord.Interaction) -> None:
+        new_view = GamesHubView(author)
+        await interaction.response.edit_message(
+            embed=build_games_hub_embed(),
+            view=new_view,
+        )
+
+    back_btn.callback = _back_callback  # type: ignore[method-assign]
+    view.add_item(back_btn)
+    return True
+
+
+def _build_no_panel_embed(name: str, meta: dict) -> discord.Embed:
+    """Fallback embed for a child whose cog lacks ``build_help_menu_view``."""
+    embed = discord.Embed(
+        title=f"{meta.get('emoji', '')} {meta['display_name']}".strip(),
+        description=meta.get("description", ""),
+        color=meta.get("color", GAME_COLOR.value),
+    )
+    entries = meta.get("entry_points", ())
+    if entries:
+        embed.add_field(
+            name="Commands",
+            value="\n".join(f"`!{ep}`" for ep in entries),
+            inline=False,
+        )
+    else:
+        embed.add_field(
+            name="Commands",
+            value="_No commands declared for this subsystem._",
+            inline=False,
+        )
+    embed.set_footer(text="Panel view not implemented yet.")
+    return embed
+
+
+class _GamesHubSelect(discord.ui.Select):
+    """Dropdown listing every ``parent_hub == "games"`` child."""
+
+    def __init__(self, children: list[tuple[str, dict]]) -> None:
+        options: list[discord.SelectOption] = []
+        for name, meta in children[:25]:  # Discord cap
+            label = (meta.get("display_name") or name)[:100]
+            description = (meta.get("description") or "")[:100] or None
+            emoji = meta.get("emoji") or None
+            options.append(
+                discord.SelectOption(
+                    label=label,
+                    value=name,
+                    description=description,
+                    emoji=emoji,
+                ),
+            )
+        if not options:
+            # Discord rejects a Select with zero options; provide a sentinel.
+            options.append(
+                discord.SelectOption(
+                    label="No games available",
+                    value="__none__",
+                    description="No subsystems route to the Games hub yet.",
+                ),
+            )
+        super().__init__(
+            placeholder="Choose a game…",
+            min_values=1,
+            max_values=1,
+            options=options,
+            custom_id="games:select",
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        # ``self.view`` is the GamesHubView this select was added to.
+        view = self.view
+        if not isinstance(view, GamesHubView):
+            await interaction.response.send_message(
+                "This dropdown is no longer attached to the Games hub.",
+                ephemeral=True,
+            )
+            return
+        await view.handle_select(interaction, self.values[0])
+
+
+class GamesHubView(HubView):
+    """Router-only hub for the Games subsystem.
+
+    Discovers ``parent_hub == "games"`` children from
+    :data:`utils.subsystem_registry.SUBSYSTEMS` and surfaces them in a
+    single select. Selecting a child calls that child cog's
+    ``build_help_menu_view`` hook; if the hook is missing the hub falls
+    back to a typed-command embed so the operator can still discover
+    commands.
+
+    The view itself contains zero game logic — pure routing.
+    """
+
+    SUBSYSTEM = "games"
+
+    def __init__(self, author: discord.Member | discord.User) -> None:
+        super().__init__(author)
+        self._children = discover_game_children()
+        self.add_item(_GamesHubSelect(self._children))
+
+    async def handle_select(
+        self,
+        interaction: discord.Interaction,
+        sub_name: str,
+    ) -> None:
+        """Open the selected child's help panel in place."""
+        if sub_name == "__none__":
+            await interaction.response.send_message(
+                "No games are routed to the Games hub yet.",
+                ephemeral=True,
+            )
+            return
+
+        meta = SUBSYSTEMS.get(sub_name)
+        if meta is None or meta.get("parent_hub") != "games":
+            await interaction.response.send_message(
+                "That game is no longer routed to the Games hub.",
+                ephemeral=True,
+            )
+            return
+
+        # Local import keeps the helper out of module-import time and
+        # avoids dragging the help cog into every consumer of this view.
+        from cogs.help_cog import _cog_for_subsystem
+
+        cog = _cog_for_subsystem(interaction.client, sub_name)  # type: ignore[arg-type]
+        if cog is None:
+            embed = _build_no_panel_embed(sub_name, dict(meta))
+            attach_back_to_games_button(self, self._author)
+            await interaction.response.edit_message(embed=embed, view=self)
+            return
+
+        build_panel = getattr(cog, "build_help_menu_view", None)
+        if not callable(build_panel):
+            embed = _build_no_panel_embed(sub_name, dict(meta))
+            attach_back_to_games_button(self, self._author)
+            await interaction.response.edit_message(embed=embed, view=self)
+            return
+
+        try:
+            embed, sub_view = await build_panel(interaction)
+        except Exception as exc:  # noqa: BLE001 — navigation must not crash
+            logger.warning(
+                "Games hub: build_help_menu_view failed for subsystem=%r: %s",
+                sub_name,
+                exc,
+                exc_info=True,
+            )
+            fallback = _build_no_panel_embed(sub_name, dict(meta))
+            attach_back_to_games_button(self, self._author)
+            await interaction.response.edit_message(embed=fallback, view=self)
+            return
+
+        attach_back_to_games_button(sub_view, self._author)
+        await interaction.response.edit_message(embed=embed, view=sub_view)

--- a/docs/settings-customization-command-map.md
+++ b/docs/settings-customization-command-map.md
@@ -479,6 +479,42 @@ Subsystems (22): `admin`, `moderation`, `economy`, `inventory`, `mining`,
 24. **recommended_PR_phase**: S8.
 
 
+### games
+
+1. **cog_module**: `disbot/cogs/games_cog.py`.
+2. **subsystem**: `games`
+3. **current_commands**: `!games`.
+4. **current_command_groups**: none.
+5. **current_command_panel_or_menu**: `games` entry — opens `GamesHubView`
+   in `disbot/views/games/hub.py`.
+6. **help_menu_discoverable**: Yes (via the standard `SUBSYSTEMS`
+   iteration in `help_cog.py`).
+7. **dedicated_panel_command**: `!games`.
+8. **help_menu_direct_navigation_hook**: `GamesCog.build_help_menu_view`.
+9. **existing_SettingSpec_declarations**: none.
+10. **existing_settings_keys**: none.
+11. **existing_BindingSpec_entries**: none.
+12. **existing_ResourceRequirement_entries**: none.
+13. **current_access_policy_behavior**: `visibility_tier=user`; capabilities
+    `games.hub.view`.
+14. **hardcoded_or_env_only_behavior**: hub children discovered dynamically
+    from `SUBSYSTEMS` entries whose `parent_hub == "games"`.
+15. **missing_customization_commands**: none — Games is a router, not a
+    configurable subsystem.
+16. **missing_settings_pages**: none planned; the hub itself has no
+    persisted state.
+17. **missing_menu_buttons_selects_modals**: per-child mode/replay panels
+    are layered later (Phase 7 of the interface-completion roadmap).
+18. **setting_class_per_value**: n/a (router only).
+19. **target_Settings_Manager_page**: none — children expose their own.
+20. **target_mutation_path**: n/a; no state.
+21. **target_help_or_menu_route**: Help direct-nav into `GamesHubView`,
+    Games hub's select into each child's `build_help_menu_view`.
+22. **provisionable_resources**: none.
+23. **priority**: `P1` — interface skeleton, low risk.
+24. **recommended_PR_phase**: interface-completion Phase 3.
+
+
 ### blackjack
 
 1. **cog_module**: `disbot/cogs/blackjack_cog.py` (+ `disbot/cogs/blackjack/`

--- a/tests/unit/cogs/test_games_cog.py
+++ b/tests/unit/cogs/test_games_cog.py
@@ -1,0 +1,94 @@
+"""Unit tests for :class:`cogs.games_cog.GamesCog` (Phase 3).
+
+The cog is a router-only thin wrapper that opens :class:`GamesHubView`.
+These tests assert the contract surfaces:
+
+* ``!games`` is registered as a prefix command.
+* ``build_help_menu_view`` returns the expected (embed, view) shape.
+* The cog contains no command alias claiming any game's command name —
+  game logic stays in the original cogs.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+from discord.ext import commands
+
+from cogs.games_cog import GamesCog
+from views.games.hub import GamesHubView
+
+
+def _author(id_: int = 1) -> MagicMock:
+    author = MagicMock(spec=discord.Member)
+    author.id = id_
+    return author
+
+
+def _cog() -> GamesCog:
+    bot = MagicMock(spec=commands.Bot)
+    return GamesCog(bot)
+
+
+def test_cog_registers_games_command():
+    cog = _cog()
+    command_names = {cmd.name for cmd in cog.get_commands()}
+    assert "games" in command_names
+
+
+def test_cog_owns_no_game_subcommands():
+    """The hub must not steal a game-specific command name."""
+    cog = _cog()
+    reserved = {
+        "blackjack",
+        "bj",
+        "deathmatch",
+        "dm",
+        "rps",
+        "mine",
+        "minemenu",
+        "countingmenu",
+        "chainmenu",
+        "chain",
+    }
+    command_names: set[str] = set()
+    for cmd in cog.get_commands():
+        command_names.add(cmd.name)
+        command_names.update(cmd.aliases)
+    assert command_names.isdisjoint(reserved), (
+        f"GamesCog registered reserved game commands: "
+        f"{command_names & reserved}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_help_menu_view_returns_embed_and_view():
+    cog = _cog()
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = _author()
+    interaction.guild = MagicMock()
+    interaction.channel = MagicMock()
+    interaction.client = MagicMock()
+
+    embed, view = await cog.build_help_menu_view(interaction)
+
+    assert isinstance(embed, discord.Embed)
+    assert isinstance(view, GamesHubView)
+
+
+@pytest.mark.asyncio
+async def test_games_command_sends_panel():
+    cog = _cog()
+    ctx = MagicMock(spec=commands.Context)
+    ctx.author = _author()
+    ctx.send = AsyncMock(return_value=MagicMock(spec=discord.Message))
+
+    # Invoke the underlying callback directly so we don't need a real bot.
+    await cog.games_menu.callback(cog, ctx)
+
+    ctx.send.assert_awaited_once()
+    _args, kwargs = ctx.send.call_args
+    assert isinstance(kwargs["view"], GamesHubView)
+    assert isinstance(kwargs["embed"], discord.Embed)

--- a/tests/unit/utils/test_subsystem_registry.py
+++ b/tests/unit/utils/test_subsystem_registry.py
@@ -104,18 +104,27 @@ def test_registry_schema_version_is_v2():
 
 def test_real_registry_validates_under_schema_v2():
     """The conftest already validated the real registry — this asserts the
-    deep-frozen result still contains every existing entry and that the
-    new optional fields read as ``None`` for all of them (Phase 1 sets
-    none of them).
+    deep-frozen result still contains every existing entry and that every
+    ``parent_hub`` reference points at a real, routable subsystem.
+
+    Phase 1 added the fields. Phase 3 set them on the Games-hub children
+    (Blackjack, RPS Tournament, Deathmatch, Mining, Counting, Chain).
     """
     assert len(reg.SUBSYSTEMS) >= 22
     for name, meta in reg.SUBSYSTEMS.items():
-        assert meta.get("parent_hub") is None, (
-            f"subsystem {name!r} unexpectedly has parent_hub set in Phase 1"
-        )
-        assert meta.get("hub_group") is None, (
-            f"subsystem {name!r} unexpectedly has hub_group set in Phase 1"
-        )
+        parent = meta.get("parent_hub")
+        if parent is not None:
+            assert parent in reg.SUBSYSTEMS, (
+                f"subsystem {name!r} parent_hub={parent!r} is not registered"
+            )
+            parent_meta = reg.SUBSYSTEMS[parent]
+            assert parent_meta.get("parent_hub") is None, (
+                f"subsystem {name!r} has a two-hop parent_hub chain through "
+                f"{parent!r}"
+            )
+            assert parent_meta.get("entry_points"), (
+                f"subsystem {name!r} parent_hub={parent!r} has no entry_points"
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/views/test_games_hub_view.py
+++ b/tests/unit/views/test_games_hub_view.py
@@ -1,0 +1,310 @@
+"""Unit tests for the Games hub view (Phase 3).
+
+Covers:
+
+* ``discover_game_children`` filters and orders correctly.
+* ``build_games_hub_embed`` produces the expected sections.
+* ``GamesHubView`` has exactly one select with the right options.
+* ``attach_back_to_games_button`` adds a button and no-ops at the
+  25-child cap.
+* The select callback gracefully handles missing cog,
+  missing ``build_help_menu_view`` hook, and exceptions from the hook.
+
+The Games hub is a router — it never contains game logic — so the
+tests assert on routing surfaces only.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from utils.subsystem_registry import SUBSYSTEMS
+from views.games.hub import (
+    _GROUP_ORDER,
+    GamesHubView,
+    _build_no_panel_embed,
+    attach_back_to_games_button,
+    build_games_hub_embed,
+    discover_game_children,
+)
+
+
+def _author(id_: int = 1) -> MagicMock:
+    author = MagicMock(spec=discord.Member)
+    author.id = id_
+    return author
+
+
+# ---------------------------------------------------------------------------
+# discover_game_children
+# ---------------------------------------------------------------------------
+
+
+def test_discover_returns_only_parent_hub_games():
+    names = [name for name, _ in discover_game_children()]
+    # Every returned child must declare parent_hub == "games" in the registry.
+    for name in names:
+        assert SUBSYSTEMS[name].get("parent_hub") == "games", (
+            f"discover_game_children returned {name!r} which is not a games child"
+        )
+    # And no games-tagged subsystem with parent_hub == "games" is missing.
+    expected = {
+        n for n, m in SUBSYSTEMS.items() if m.get("parent_hub") == "games"
+    }
+    assert set(names) == expected
+
+
+def test_discover_groups_competitive_before_activities():
+    children = discover_game_children()
+    groups = [meta.get("hub_group") for _, meta in children]
+    competitive_indices = [i for i, g in enumerate(groups) if g == "competitive"]
+    activities_indices = [i for i, g in enumerate(groups) if g == "activities"]
+    # Every competitive index must come before every activities index.
+    if competitive_indices and activities_indices:
+        assert max(competitive_indices) < min(activities_indices), (
+            f"groups out of order: {groups}"
+        )
+
+
+def test_discover_is_deterministic():
+    """Order must be ``(group_rank, ui_priority, key)`` — fully deterministic."""
+    children = discover_game_children()
+    keys = [
+        (
+            _GROUP_ORDER.get(meta.get("hub_group") or "", 99),
+            meta.get("ui_priority", 99),
+            name,
+        )
+        for name, meta in children
+    ]
+    assert keys == sorted(keys), f"discover_game_children is not deterministic: {keys}"
+
+
+# ---------------------------------------------------------------------------
+# build_games_hub_embed
+# ---------------------------------------------------------------------------
+
+
+def test_embed_has_competitive_and_activities_sections():
+    embed = build_games_hub_embed()
+    field_names = [f.name for f in embed.fields]
+    assert any("Competitive" in n for n in field_names), field_names
+    assert any("Activities" in n for n in field_names), field_names
+
+
+def test_embed_title_and_color():
+    embed = build_games_hub_embed()
+    assert embed.title is not None
+    assert "Games" in embed.title
+    assert embed.color is not None
+
+
+def test_embed_mentions_typed_shortcuts_in_description():
+    """Operators must still know typed commands work after the hub lands."""
+    embed = build_games_hub_embed()
+    description = embed.description or ""
+    # Either a literal typed shortcut OR an explicit "Typed shortcut" mention.
+    assert (
+        "!blackjack" in description
+        or "!mine" in description
+        or "Typed" in description
+    ), description
+
+
+# ---------------------------------------------------------------------------
+# GamesHubView shape
+# ---------------------------------------------------------------------------
+
+
+def test_view_has_exactly_one_select():
+    view = GamesHubView(_author())
+    selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
+    assert len(selects) == 1
+
+
+def test_view_has_no_built_in_back_button():
+    """Back-to-Help is added by help_cog when surfaced from the help menu;
+    direct ``!games`` invocation has no back nav (mirrors !countingmenu).
+    """
+    view = GamesHubView(_author())
+    buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+    assert buttons == []
+
+
+def test_select_options_cover_every_child():
+    view = GamesHubView(_author())
+    select = next(c for c in view.children if isinstance(c, discord.ui.Select))
+    option_values = {o.value for o in select.options}
+    expected_values = {name for name, _ in discover_game_children()}
+    assert option_values == expected_values
+
+
+def test_select_options_carry_emoji_and_description():
+    view = GamesHubView(_author())
+    select = next(c for c in view.children if isinstance(c, discord.ui.Select))
+    for option in select.options:
+        meta = SUBSYSTEMS[option.value]
+        if meta.get("emoji"):
+            # PartialEmoji.name preserves the unicode glyph
+            actual = (
+                option.emoji.name
+                if option.emoji is not None
+                else None
+            )
+            assert actual == meta["emoji"], (
+                f"emoji for {option.value!r}: expected {meta['emoji']!r}, "
+                f"got {actual!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# attach_back_to_games_button
+# ---------------------------------------------------------------------------
+
+
+def test_attach_back_button_adds_one_button():
+    view = discord.ui.View()
+    added = attach_back_to_games_button(view, _author())
+    assert added is True
+    assert len(view.children) == 1
+    button = view.children[0]
+    assert isinstance(button, discord.ui.Button)
+    assert button.label == "↩ Back to Games"
+    assert button.custom_id == "games:back"
+    assert button.row == 4
+
+
+def test_attach_back_button_noops_at_25_children():
+    view = discord.ui.View()
+    # Fill view to exactly 25 children — Discord's hard cap.
+    for i in range(25):
+        view.add_item(
+            discord.ui.Button(
+                label=f"b{i}",
+                custom_id=f"filler:{i}",
+                style=discord.ButtonStyle.secondary,
+                row=i // 5,
+            ),
+        )
+    added = attach_back_to_games_button(view, _author())
+    assert added is False
+    assert len(view.children) == 25
+
+
+# ---------------------------------------------------------------------------
+# Select-callback routing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_select_unknown_subsystem_sends_ephemeral():
+    view = GamesHubView(_author())
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = MagicMock()
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+
+    await view.handle_select(interaction, "not_a_real_subsystem")
+
+    interaction.response.send_message.assert_awaited_once()
+    interaction.response.edit_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_select_missing_cog_renders_fallback():
+    view = GamesHubView(_author())
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = MagicMock()
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+
+    with patch("views.games.hub.SUBSYSTEMS") as fake_subs:
+        # Pick any real games child but make _cog_for_subsystem return None.
+        sub_name = "blackjack"
+        fake_subs.get.return_value = dict(SUBSYSTEMS[sub_name])
+        with patch("cogs.help_cog._cog_for_subsystem", return_value=None):
+            await view.handle_select(interaction, sub_name)
+
+    interaction.response.edit_message.assert_awaited_once()
+    args, kwargs = interaction.response.edit_message.call_args
+    assert kwargs["view"] is view  # falls back to the hub itself + back btn
+    embed: discord.Embed = kwargs["embed"]
+    assert "Blackjack" in (embed.title or "")
+
+
+@pytest.mark.asyncio
+async def test_handle_select_hook_failure_renders_fallback():
+    view = GamesHubView(_author())
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = MagicMock()
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+
+    fake_cog = MagicMock()
+    fake_cog.build_help_menu_view = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with patch("cogs.help_cog._cog_for_subsystem", return_value=fake_cog):
+        await view.handle_select(interaction, "blackjack")
+
+    interaction.response.edit_message.assert_awaited_once()
+    fake_cog.build_help_menu_view.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_select_success_attaches_back_button():
+    view = GamesHubView(_author())
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = MagicMock()
+    interaction.response = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+
+    child_view = discord.ui.View()
+    child_embed = discord.Embed(title="Blackjack")
+    fake_cog = MagicMock()
+    fake_cog.build_help_menu_view = AsyncMock(return_value=(child_embed, child_view))
+
+    with patch("cogs.help_cog._cog_for_subsystem", return_value=fake_cog):
+        await view.handle_select(interaction, "blackjack")
+
+    interaction.response.edit_message.assert_awaited_once()
+    args, kwargs = interaction.response.edit_message.call_args
+    assert kwargs["embed"] is child_embed
+    assert kwargs["view"] is child_view
+    # The back-to-games button must have been attached to the child view.
+    back_buttons = [
+        c
+        for c in child_view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "games:back"
+    ]
+    assert len(back_buttons) == 1
+
+
+# ---------------------------------------------------------------------------
+# Fallback embed
+# ---------------------------------------------------------------------------
+
+
+def test_build_no_panel_embed_lists_entry_points():
+    embed = _build_no_panel_embed("blackjack", dict(SUBSYSTEMS["blackjack"]))
+    field_values = [f.value for f in embed.fields]
+    text = "\n".join(field_values)
+    for ep in SUBSYSTEMS["blackjack"]["entry_points"]:
+        assert f"!{ep}" in text
+
+
+def test_build_no_panel_embed_handles_empty_entry_points():
+    fake_meta = {
+        "display_name": "Empty",
+        "description": "",
+        "entry_points": (),
+        "emoji": "🧪",
+    }
+    embed = _build_no_panel_embed("empty", fake_meta)
+    assert embed.fields  # always shows a Commands field
+    assert "No commands declared" in embed.fields[0].value


### PR DESCRIPTION
## Objective

Phase 3 of the interface-completion roadmap: add the **Games hub** as a router-only subsystem that presents the six existing game cogs as members, visually subgrouped into **Competitive** (Blackjack, RPS Tournament, Deathmatch) and **Activities** (Mining, Counting, Chain). The hub contains **zero** game logic.

This PR depends on **#118** (now merged) for the `parent_hub` / `hub_group` schema fields.

## Files changed

**Registry:**
- `disbot/utils/subsystem_registry.py` — adds the `games` subsystem entry; sets `parent_hub="games"` on six existing entries (`blackjack`, `rps_tournament`, `deathmatch` → `hub_group="competitive"`; `mining`, `counting`, `chain` → `hub_group="activities"`). Mining keeps `category="economy"`; routing and category intentionally disagree.

**Cog + view:**
- `disbot/cogs/games_cog.py` *(new)* — `GamesCog` with the `!games` command and `build_help_menu_view` hook. Pure router; no game logic.
- `disbot/views/games/__init__.py` *(new)* — package marker.
- `disbot/views/games/hub.py` *(new)* — `GamesHubView` (`HubView` subclass) plus `discover_game_children`, `build_games_hub_embed`, `attach_back_to_games_button`, `_build_no_panel_embed`.

**Registration:**
- `disbot/services/customization_catalogue.py` — `("games", "games")` added to `KNOWN_PANEL_COMMANDS`.
- `disbot/config.py` — `"cogs.games_cog"` added to `INITIAL_EXTENSIONS`.

**Docs / tests:**
- `docs/settings-customization-command-map.md` — adds a `### games` section (the doc invariant test requires one per subsystem).
- `tests/unit/utils/test_subsystem_registry.py` — `test_real_registry_validates_under_schema_v2` now asserts the cross-entry `parent_hub` invariant (PR-0 listed it as a Phase 1 placeholder).
- `tests/unit/cogs/test_games_cog.py` *(new, 4 tests)*.
- `tests/unit/views/test_games_hub_view.py` *(new, 18 tests)*.

## Confirmation of no game-logic movement

Grep confirms `games_cog.py` imports zero game-engine modules:

```
$ grep -E 'blackjack|rps|deathmatch|mining|counting|chain' disbot/cogs/games_cog.py
# (no matches — the cog only imports discord, the GamesHubView, and help_ctx_shim)
```

The hub's select routes to each child via `_cog_for_subsystem(...).build_help_menu_view(interaction)` — the exact same routing primitive `!help` uses.

## Deviations from the roadmap

| Item | Roadmap | Actual | Reason |
|---|---|---|---|
| `ui_priority` of games entry | 25 | **28** | Avoids collision with `xp.ui_priority=25` (Python sort is stable but ties become insertion-order-dependent — non-deterministic across refactors). 28 keeps Games adjacent to Blackjack (30) at the top of the games cluster. |
| `GamesHubView` has built-in "Back to Help" | yes | **no** | help_cog already adds a "Back to Help" via `_attach_back_to_help_button` whenever a subsystem is surfaced from Help. A built-in button on the hub would produce duplicate "Back to Help" controls in that flow. Matches the existing pattern in `_CountingHubView`, `_MiningHubView`, `_AdminPanelView` — none of which carry built-in back-nav. Direct `!games` users navigate away via typed `!help`, identical to `!countingmenu` / `!minemenu`. |

Both deviations are minimal, conservative, and documented in the code.

## Tests run

| Suite | Result |
|---|---|
| `pytest tests/unit/views/test_games_hub_view.py tests/unit/cogs/test_games_cog.py` | **22 passed** |
| `pytest tests/unit/utils tests/unit/docs tests/unit/governance tests/unit/registry tests/unit/services tests/unit/runtime tests/unit/schema` | passes |
| `pytest` (full suite) | **2064 passed**, 12 warnings, 22.48s |
| `black --check . --exclude '(\.github\|tests\|venv\|env\|build\|dist)'` | clean (262 files) |
| `isort --check-only . --skip-glob …` | clean |
| `ruff check . --exclude .github,tests,venv,env,build,dist` | clean |
| `mypy disbot/` | **Success: no issues found in 263 source files** |

## Manual Discord smoke checklist

- [ ] Bot starts cleanly with `cogs.games_cog` loaded
- [ ] `!games` opens the hub
- [ ] Competitive section shows Blackjack, RPS Tournament, Deathmatch
- [ ] Activities section shows Mining, Counting, Chain
- [ ] Selecting any child opens its existing `build_help_menu_view` (the same view `!help` → that subsystem would open)
- [ ] Selected child view shows a "↩ Back to Games" button at row 4
- [ ] Back to Games returns to a fresh hub
- [ ] `!blackjack`, `!mine`, `!countingmenu`, `!chainmenu`, `!dm`, `!rps` still work as typed shortcuts
- [ ] `!help` shows Games as a new entry alongside the individual game cogs (Phase 4 will hide the children)
- [ ] `!help` → Games opens the hub (auto-adds "Back to Help" via help_cog)
- [ ] `!platform identity` reports no fatal findings
- [ ] `!platform customization` reports `("games", "games")` under the games subsystem

## Risks

- **Medium.** The hub becomes a new top-level help entry alongside the existing six game entries — for one phase, the menu shows both the hub and the children. Phase 4 hides the children. Until Phase 4 lands users see both; that is the explicit roadmap sequence.
- The fallback path (child cog lacks `build_help_menu_view`) is exercised by tests but should not trigger in production today — every existing child cog has the hook.
- The select-callback path locally imports `cogs.help_cog._cog_for_subsystem` to avoid an import cycle. If `help_cog` is ever unloaded mid-session the import will still succeed (the module stays in `sys.modules`), but `_cog_for_subsystem` requires the bot reference passed in.

## Rollback plan

1. Revert this commit.
2. The Phase 1 schema fields (`parent_hub`, `hub_group`) stay — they simply go back to being unused.
3. Remove `"cogs.games_cog"` from `INITIAL_EXTENSIONS` (covered by the revert).
4. The `("games", "games")` entry in `KNOWN_PANEL_COMMANDS` is removed (covered by the revert).

No data migration required — the hub holds no per-guild state.

## Next recommended phase

**Phase 4** — single-file change to `disbot/cogs/help_cog.py` adding `if meta.get("parent_hub"): continue` to the overview-embed iteration and the `HelpPanelView` select builder. Hides the six children from the top-level Help menu; they remain typed-accessible and reachable through the Games hub. Risk: low-medium. I'll cut that branch after this PR merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TeXrWGdRyGEcukWEv1qryT)_