### PR TITLE
feat(cleanup): !cleanup hub panel routing to wordmenu + logging + settings (Phase 5)

### DIFF
--- a/disbot/cogs/cleanup/panel.py
+++ b/disbot/cogs/cleanup/panel.py
@@ -1,0 +1,222 @@
+"""Cleanup hub panel — Phase 5 of the interface-completion roadmap.
+
+A read-mostly router that surfaces existing cleanup functionality
+through a single ``!cleanup`` entry. The panel itself owns no
+mutation paths; every button hands off to a subsystem that already
+exists:
+
+* **Prohibited Words** → reuses ``_WordMenuView`` from ``cleanup_cog``
+  (the current ``!wordmenu`` UX). The view is rendered in place via
+  ``interaction.response.edit_message``.
+* **Logging Status** → routes to :class:`cogs.logging.panel.LoggingPanelView`.
+  Cleanup events flow through the logging subsystem, so this is the
+  natural diagnostic next step from a cleanup operator's perspective.
+* **Settings** → opens :class:`views.settings.subsystem_view.SubsystemSettingsView`
+  for the ``cleanup`` subsystem. There are no scalar settings registered
+  for cleanup today, so the page currently has no edit/reset selects;
+  this hook gives the wiring a stable place to live once the
+  channel-policy storage in the open question for Phase 5 lands.
+* **Refresh** rebuilds the read-only overview.
+
+The view contains no mutation, no auto-create, and no new settings —
+mirroring the roadmap's "first iteration mostly read-only" constraint.
+All cog imports are function-local to keep this module import-safe
+(it can be loaded before ``cogs.cleanup_cog`` finishes initialising
+without triggering a circular import).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import discord
+
+from core.runtime.interaction_helpers import help_ctx_shim
+from utils.ui_constants import ADMIN_COLOR
+from views.base import HubView
+
+if TYPE_CHECKING:
+    from cogs.cleanup_cog import Cleanup
+
+
+logger = logging.getLogger("bot.cogs.cleanup.panel")
+
+
+def build_cleanup_overview_embed(
+    cog: Cleanup,
+    guild_id: int | None,
+) -> discord.Embed:
+    """Read-only summary of cleanup state for the current guild.
+
+    Cleanup currently has no DB-persisted scalar knobs — its
+    user-visible state is the prohibited-words list (per-guild) and a
+    static whitelist of channels read from configuration at startup
+    (``config.CLEANUP_WHITELIST_CHANNELS``). The overview surfaces
+    both without touching any state.
+    """
+    word_count = len(cog._word_cache.get(guild_id, [])) if guild_id is not None else 0
+    whitelist_channels = list(cog.whitelisted_channels or ())
+
+    embed = discord.Embed(
+        title="🧹 Cleanup Hub",
+        description=(
+            "Auto-moderation policies for command-style messages and "
+            "prohibited content. Channels you explicitly whitelist below "
+            "are exempt from the command-pattern check."
+        ),
+        color=ADMIN_COLOR,
+    )
+    embed.add_field(
+        name="Prohibited Words",
+        value=f"{word_count} configured" if word_count else "_None configured_",
+        inline=True,
+    )
+    embed.add_field(
+        name="Whitelisted Channels",
+        value=(
+            "\n".join(f"<#{cid}>" for cid in whitelist_channels)
+            if whitelist_channels
+            else "_None_"
+        ),
+        inline=True,
+    )
+    embed.add_field(
+        name="Auto-Delete",
+        value=(
+            "Command-style messages outside whitelisted channels are "
+            "removed. Prohibited-word matches are removed with a brief "
+            "warning."
+        ),
+        inline=False,
+    )
+    embed.set_footer(
+        text="Read-only summary. Use the buttons below to manage policies.",
+    )
+    return embed
+
+
+class CleanupPanelView(HubView):
+    """Top-level Cleanup hub view — routes to existing subsystem panels."""
+
+    SUBSYSTEM = "cleanup"
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        cog: Cleanup,
+        guild_id: int | None,
+    ) -> None:
+        super().__init__(author)
+        self.cog = cog
+        self.guild_id = guild_id
+
+    def build_embed(self) -> discord.Embed:
+        return build_cleanup_overview_embed(self.cog, self.guild_id)
+
+    @discord.ui.button(
+        label="🔤 Prohibited Words",
+        style=discord.ButtonStyle.blurple,
+        custom_id="cleanup:words",
+        row=0,
+    )
+    async def btn_words(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        from cogs.cleanup_cog import _WordMenuView
+
+        # ``_WordMenuView`` reads the live word cache; ensure the guild
+        # has been loaded before rendering. ``_load_guild`` is idempotent.
+        if self.guild_id is not None and self.guild_id not in self.cog._word_cache:
+            await self.cog._load_guild(self.guild_id)
+        view = _WordMenuView(help_ctx_shim(interaction), self.cog)
+        await interaction.response.edit_message(
+            embed=view.build_embed(),
+            view=view,
+        )
+
+    @discord.ui.button(
+        label="📝 Logging Status",
+        style=discord.ButtonStyle.secondary,
+        custom_id="cleanup:logging",
+        row=0,
+    )
+    async def btn_logging(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        # Local import keeps this module import-safe — the logging panel
+        # ultimately pulls in ``core.runtime`` symbols we don't want at
+        # cleanup-panel module load time.
+        from cogs.logging.panel import LoggingPanelView
+
+        logging_cog = interaction.client.get_cog("LoggingCog")  # type: ignore[attr-defined]
+        if logging_cog is None:
+            await interaction.response.send_message(
+                "The logging cog is not loaded.",
+                ephemeral=True,
+            )
+            return
+        build_hook = getattr(logging_cog, "build_help_menu_view", None)
+        if callable(build_hook):
+            try:
+                embed, view = await build_hook(interaction)
+            except Exception as exc:  # noqa: BLE001 — navigation must not crash
+                logger.warning(
+                    "Cleanup panel → logging: build_help_menu_view failed: %s",
+                    exc,
+                    exc_info=True,
+                )
+                await interaction.response.send_message(
+                    "Couldn't open the logging panel.",
+                    ephemeral=True,
+                )
+                return
+            await interaction.response.edit_message(embed=embed, view=view)
+            return
+        # Fallback — construct the panel directly. Mirrors the contract
+        # the cog itself uses, so any future signature changes propagate.
+        view = LoggingPanelView(interaction.user)  # type: ignore[arg-type]
+        embed = await view.build_embed(interaction)  # type: ignore[attr-defined]
+        await interaction.response.edit_message(embed=embed, view=view)
+
+    @discord.ui.button(
+        label="⚙️ Settings",
+        style=discord.ButtonStyle.secondary,
+        custom_id="cleanup:settings",
+        row=0,
+    )
+    async def btn_settings(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        from views.settings.subsystem_view import (
+            SubsystemSettingsView,
+            build_subsystem_embed,
+        )
+
+        view = SubsystemSettingsView(interaction.user, "cleanup")
+        embed = await build_subsystem_embed(interaction, "cleanup")
+        await interaction.response.edit_message(embed=embed, view=view)
+
+    @discord.ui.button(
+        label="🔄 Refresh",
+        style=discord.ButtonStyle.secondary,
+        custom_id="cleanup:refresh",
+        row=1,
+    )
+    async def btn_refresh(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        if self.guild_id is not None:
+            await self.cog._load_guild(self.guild_id)
+        await interaction.response.edit_message(
+            embed=self.build_embed(),
+            view=self,
+        )

--- a/disbot/cogs/cleanup_cog.py
+++ b/disbot/cogs/cleanup_cog.py
@@ -310,14 +310,34 @@ class Cleanup(commands.Cog):
         view = _WordMenuView(ctx, self)
         await send_panel(ctx, embed=view.build_embed(), view=view)
 
+    @commands.command(name="cleanup")
+    @commands.has_permissions(administrator=True)
+    async def cleanup_menu(self, ctx):
+        """Open the Cleanup hub panel — overview + routing to subviews."""
+        from cogs.cleanup.panel import CleanupPanelView
+
+        if ctx.guild.id not in self._word_cache:
+            await self._load_guild(ctx.guild.id)
+        view = CleanupPanelView(ctx.author, self, ctx.guild.id)
+        await send_panel(ctx, embed=view.build_embed(), view=view)
+
     async def build_help_menu_view(
         self,
         interaction: discord.Interaction,
     ) -> tuple[discord.Embed, discord.ui.View]:
-        """Help-menu direct-navigation hook (returns the word-list panel)."""
+        """Help-menu direct-navigation hook — returns the Cleanup hub panel.
+
+        Phase 5 replaces the previous direct-to-wordmenu hop. The
+        Prohibited Words manager is now reachable as the first button
+        of :class:`CleanupPanelView`, alongside Logging Status and
+        Settings.
+        """
+        from cogs.cleanup.panel import CleanupPanelView
+
         if interaction.guild_id not in self._word_cache:
             await self._load_guild(interaction.guild_id)
-        view = _WordMenuView(help_ctx_shim(interaction), self)
+        ctx_shim = help_ctx_shim(interaction)
+        view = CleanupPanelView(ctx_shim.author, self, interaction.guild_id)
         return view.build_embed(), view
 
 

--- a/disbot/services/customization_catalogue.py
+++ b/disbot/services/customization_catalogue.py
@@ -75,6 +75,7 @@ KNOWN_PANEL_COMMANDS: tuple[tuple[str, str], ...] = (
     ("admin", "adminmenu"),
     ("chain", "chainmenu"),
     ("channel", "channelmenu"),
+    ("cleanup", "cleanup"),
     ("cleanup", "wordmenu"),
     ("counting", "countingmenu"),
     ("economy", "economymenu"),

--- a/disbot/utils/subsystem_registry.py
+++ b/disbot/utils/subsystem_registry.py
@@ -259,7 +259,7 @@ SUBSYSTEMS: dict[str, dict] = {
         "visibility_mode": "normal",
         "category": "moderation",
         "tags": ["cleanup", "words", "moderation", "hygiene"],
-        "entry_points": ["wordmenu", "cleanuphistory"],
+        "entry_points": ["cleanup", "wordmenu", "cleanuphistory"],
         "default_channels": ["staff"],
         "related_subsystems": ["moderation"],
         "dependencies": [],

--- a/tests/unit/cogs/test_cleanup_panel.py
+++ b/tests/unit/cogs/test_cleanup_panel.py
@@ -1,0 +1,274 @@
+"""Unit tests for :class:`CleanupPanelView` (Phase 5).
+
+Covers:
+
+* The overview embed renders the prohibited-word count and
+  whitelist-channel summary read-only.
+* The view exposes Prohibited Words / Logging Status / Settings /
+  Refresh buttons in the expected layout.
+* The Prohibited Words button opens the existing ``_WordMenuView``
+  in-place (no new view class is invented).
+* The Logging Status button delegates to the logging cog's
+  ``build_help_menu_view`` hook when available, and falls back to a
+  defensive ephemeral when the cog is missing.
+* The Settings button routes to ``SubsystemSettingsView("cleanup")``.
+* The Refresh button rebuilds the embed without mutation.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from cogs.cleanup.panel import (
+    CleanupPanelView,
+    build_cleanup_overview_embed,
+)
+
+
+def _author(id_: int = 1) -> MagicMock:
+    author = MagicMock(spec=discord.Member)
+    author.id = id_
+    return author
+
+
+def _cog(words: list[str] | None = None, channels: list[int] | None = None) -> MagicMock:
+    cog = MagicMock()
+    cog._word_cache = {42: list(words or [])}
+    cog._load_guild = AsyncMock()
+    cog.whitelisted_channels = list(channels or [])
+    return cog
+
+
+# ---------------------------------------------------------------------------
+# Overview embed
+# ---------------------------------------------------------------------------
+
+
+def test_overview_embed_shows_word_count():
+    cog = _cog(words=["badword", "another"])
+    embed = build_cleanup_overview_embed(cog, guild_id=42)
+    word_field = next(f for f in embed.fields if "Words" in f.name)
+    assert "2" in word_field.value
+
+
+def test_overview_embed_shows_empty_word_list_gracefully():
+    cog = _cog(words=[])
+    embed = build_cleanup_overview_embed(cog, guild_id=42)
+    word_field = next(f for f in embed.fields if "Words" in f.name)
+    assert "None" in word_field.value
+
+
+def test_overview_embed_lists_whitelist_channels():
+    cog = _cog(words=[], channels=[111, 222])
+    embed = build_cleanup_overview_embed(cog, guild_id=42)
+    whitelist_field = next(f for f in embed.fields if "Whitelist" in f.name)
+    assert "<#111>" in whitelist_field.value
+    assert "<#222>" in whitelist_field.value
+
+
+def test_overview_embed_when_guild_unloaded():
+    cog = _cog(words=[])
+    # guild_id=None mimics a DM context or a fresh guild not yet warmed.
+    embed = build_cleanup_overview_embed(cog, guild_id=None)
+    word_field = next(f for f in embed.fields if "Words" in f.name)
+    assert "None" in word_field.value
+
+
+# ---------------------------------------------------------------------------
+# View shape
+# ---------------------------------------------------------------------------
+
+
+def test_view_has_four_buttons_with_expected_custom_ids():
+    view = CleanupPanelView(_author(), _cog(), guild_id=42)
+    custom_ids = {
+        c.custom_id  # type: ignore[attr-defined]
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+    }
+    assert custom_ids == {
+        "cleanup:words",
+        "cleanup:logging",
+        "cleanup:settings",
+        "cleanup:refresh",
+    }
+
+
+def test_view_buttons_use_two_rows():
+    view = CleanupPanelView(_author(), _cog(), guild_id=42)
+    rows = {
+        c.row  # type: ignore[attr-defined]
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+    }
+    # Three top-row routing buttons + the refresh button on a second row.
+    assert rows == {0, 1}
+
+
+# ---------------------------------------------------------------------------
+# Routing buttons
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_words_button_renders_word_menu_view_in_place():
+    cog = _cog(words=["badword"])
+    view = CleanupPanelView(_author(), cog, guild_id=42)
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = MagicMock()
+    interaction.user = view._author
+    interaction.guild = MagicMock()
+    interaction.channel = MagicMock()
+    interaction.response = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "cleanup:words"
+    )
+    await btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    interaction.response.edit_message.assert_awaited_once()
+    _args, kwargs = interaction.response.edit_message.call_args
+    # The new view must be the existing _WordMenuView, not a fresh
+    # cleanup-specific re-implementation.
+    from cogs.cleanup_cog import _WordMenuView
+
+    assert isinstance(kwargs["view"], _WordMenuView)
+
+
+@pytest.mark.asyncio
+async def test_words_button_loads_guild_when_missing():
+    cog = _cog(words=[])
+    cog._word_cache = {}  # guild 42 not loaded
+    view = CleanupPanelView(_author(), cog, guild_id=42)
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = view._author
+    interaction.guild = MagicMock()
+    interaction.channel = MagicMock()
+    interaction.client = MagicMock()
+    interaction.response = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "cleanup:words"
+    )
+    await btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    cog._load_guild.assert_awaited_once_with(42)
+
+
+@pytest.mark.asyncio
+async def test_logging_button_routes_via_cog_build_hook():
+    cog = _cog()
+    view = CleanupPanelView(_author(), cog, guild_id=42)
+
+    logging_cog = MagicMock()
+    expected_embed = discord.Embed(title="Logging")
+    expected_view = discord.ui.View()
+    logging_cog.build_help_menu_view = AsyncMock(
+        return_value=(expected_embed, expected_view),
+    )
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = MagicMock()
+    interaction.client.get_cog = MagicMock(return_value=logging_cog)
+    interaction.response = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "cleanup:logging"
+    )
+    await btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    interaction.client.get_cog.assert_called_with("LoggingCog")
+    logging_cog.build_help_menu_view.assert_awaited_once_with(interaction)
+    interaction.response.edit_message.assert_awaited_once()
+    _args, kwargs = interaction.response.edit_message.call_args
+    assert kwargs["embed"] is expected_embed
+    assert kwargs["view"] is expected_view
+
+
+@pytest.mark.asyncio
+async def test_logging_button_handles_missing_logging_cog():
+    view = CleanupPanelView(_author(), _cog(), guild_id=42)
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = MagicMock()
+    interaction.client.get_cog = MagicMock(return_value=None)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "cleanup:logging"
+    )
+    await btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    interaction.response.send_message.assert_awaited_once()
+    interaction.response.edit_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_settings_button_routes_to_subsystem_settings_view():
+    view = CleanupPanelView(_author(), _cog(), guild_id=42)
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = view._author
+    interaction.client = MagicMock()
+    interaction.guild = MagicMock()
+    interaction.channel = MagicMock()
+    interaction.response = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+
+    fake_embed = discord.Embed(title="Cleanup settings")
+    with patch(
+        "views.settings.subsystem_view.build_subsystem_embed",
+        AsyncMock(return_value=fake_embed),
+    ):
+        btn = next(
+            c
+            for c in view.children
+            if isinstance(c, discord.ui.Button) and c.custom_id == "cleanup:settings"
+        )
+        await btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    from views.settings.subsystem_view import SubsystemSettingsView
+
+    interaction.response.edit_message.assert_awaited_once()
+    _args, kwargs = interaction.response.edit_message.call_args
+    assert kwargs["embed"] is fake_embed
+    assert isinstance(kwargs["view"], SubsystemSettingsView)
+    assert kwargs["view"].subsystem == "cleanup"
+
+
+@pytest.mark.asyncio
+async def test_refresh_button_rebuilds_embed_without_mutation():
+    cog = _cog(words=["alpha"])
+    view = CleanupPanelView(_author(), cog, guild_id=42)
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = view._author
+    interaction.response = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "cleanup:refresh"
+    )
+    await btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    cog._load_guild.assert_awaited_once_with(42)
+    interaction.response.edit_message.assert_awaited_once()
+    _args, kwargs = interaction.response.edit_message.call_args
+    assert kwargs["view"] is view
+    assert isinstance(kwargs["embed"], discord.Embed)


### PR DESCRIPTION
## Objective

Phase 5: add a `!cleanup` hub panel that surfaces existing cleanup functionality through a single, read-mostly router. The prohibited-words manager (`!wordmenu`) becomes a subpage; the panel also routes to the logging panel and the Settings Manager. **No mutation paths owned by the panel.** No new settings. No channel-specific cleanup policy writes (storage doesn't exist yet — that's an open question for Phase 5).

This PR is independent of #120 (Phase 4) and starts from current `main`.

## Files changed

**Registry / catalogue:**
- `disbot/utils/subsystem_registry.py` — cleanup's `entry_points` adds `"cleanup"`.
- `disbot/services/customization_catalogue.py` — `("cleanup", "cleanup")` added alongside existing `("cleanup", "wordmenu")`. The catalogue already groups multiple panel commands per subsystem in a `dict[str, set[str]]`.

**Cog:**
- `disbot/cogs/cleanup_cog.py` — adds the `!cleanup` command (admin-gated, mirrors `!wordmenu`) and updates `build_help_menu_view` to return the new hub. `!wordmenu` remains as a typed shortcut.
- `disbot/cogs/cleanup/__init__.py` *(new)* — package marker.
- `disbot/cogs/cleanup/panel.py` *(new)* — `CleanupPanelView` + `build_cleanup_overview_embed`.

**Tests:**
- `tests/unit/cogs/test_cleanup_panel.py` *(new, 12 tests)*.

## Panel surface

| Button | Action |
|---|---|
| 🔤 Prohibited Words | Renders the existing `_WordMenuView` in place (function-local import to avoid module-load cycle). Loads the guild's word cache if missing. |
| 📝 Logging Status | Routes to `LoggingCog.build_help_menu_view` if loaded; ephemeral fallback otherwise. |
| ⚙️ Settings | Opens `SubsystemSettingsView("cleanup")` + the standard subsystem embed. Renders cleanly even though cleanup has no registered settings schema today. |
| 🔄 Refresh | Reloads the guild's word cache (idempotent) and rebuilds the read-only overview embed. No mutation. |

## Schema audit (Step 5c of the roadmap)

The roadmap step says: *"Add `SubsystemSchema` to `disbot/cogs/cleanup/` declaring whichever scalar settings already exist."* On audit, cleanup has **no** DB-persisted scalar settings today:

- Prohibited words live in their own DB table (per-guild list), not as scalar settings.
- The channel whitelist comes from `config.CLEANUP_WHITELIST_CHANNELS` (env/startup), not from per-guild storage.
- The warning text and timing are hardcoded, not configurable.

Registering an empty `SubsystemSchema` would only add noise to the customization catalogue. **This PR therefore skips Step 5c entirely.** Future work that introduces real scalar knobs (e.g. when channel-specific cleanup policy storage lands per the open question for Phase 5) can declare them then.

## Confirmation of no runtime behavior change

Grep confirms `disbot/cogs/cleanup/panel.py` imports no service or pipeline mutation symbol:

```
$ grep -E 'pipeline|MutationPipeline|service' disbot/cogs/cleanup/panel.py
# (no matches — pure presentation + routing)
```

The cleanup auto-mod path (`remove_unwanted_message`, `CleanupStage.process`) and the prohibited-words DB operations are untouched. `!wordmenu` continues to work as before.

## Tests run

| Suite | Result |
|---|---|
| `pytest tests/unit/cogs/test_cleanup_panel.py` | **12 passed** |
| `pytest` (full suite) | **2077 passed**, 12 warnings, 22.63s |
| `black --check . --exclude '(\.github\|tests\|venv\|env\|build\|dist)'` | clean (264 files) |
| `isort --check-only . --skip-glob …` | clean |
| `ruff check . --exclude .github,tests,venv,env,build,dist` | clean |
| `mypy disbot/` | **Success: no issues found in 265 source files** |

## Manual Discord smoke checklist

- [ ] Bot starts cleanly
- [ ] `!cleanup` opens the new panel
- [ ] `!wordmenu` still opens directly (typed shortcut preserved)
- [ ] Cleanup panel's "Prohibited Words" button renders the same UI as `!wordmenu`
- [ ] Cleanup panel's "Logging Status" button jumps to the Logging panel
- [ ] Cleanup panel's "Settings" button opens the cleanup subsystem settings page
- [ ] Refresh rebuilds the overview without side effects
- [ ] Auto-mod behavior unchanged (commands deleted in non-whitelisted channels; prohibited words removed)
- [ ] `!platform identity` reports no fatal findings
- [ ] `!platform customization` shows both `("cleanup", "cleanup")` and `("cleanup", "wordmenu")` panels

## Risks

- **Medium.** Cleanup touches the message pipeline and moderation flow; this PR deliberately stays read-only/routing-only. The only state-touching call from the panel is `_load_guild`, which is idempotent and already invoked by `!wordmenu` and `build_help_menu_view` on the same paths.
- The `build_help_menu_view` target change (was `_WordMenuView`, now `CleanupPanelView`) is a UX shift: users coming from `!help` → Cleanup will see the new hub instead of the word manager directly. They reach the same word manager with one extra click. This matches the roadmap's intent ("wordmenu becomes a subpage").

## Rollback plan

1. Revert this commit (six files).
2. The `("cleanup", "cleanup")` catalogue entry and the `"cleanup"` entry_point go away; `!wordmenu`/`build_help_menu_view` returns to its prior behavior.
3. No data migration required — the panel holds no per-guild state and the prohibited-words DB table is unchanged.

## Next recommended phase

**Phase 6** — read-only Access policy explorer through `!settings access`. Surfaces effective governance/access policy via `governance_service.explain_access` (add the helper if missing). Read-only first — the write surface is later work. Tier filtering is security-sensitive; the tests there must pin who can see what. I'll cut that branch next.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TeXrWGdRyGEcukWEv1qryT)_