### PR TITLE
feat(platform): editable per-guild flag manager via `!platform flag` (Phase 6.5a)

### DIFF
--- a/disbot/cogs/diagnostic_cog.py
+++ b/disbot/cogs/diagnostic_cog.py
@@ -353,6 +353,29 @@ class DiagnosticCog(commands.Cog):
         """Feature flags: declarations + Phase 2d evaluator state per flag."""
         await ctx.send(embed=await build_flags_embed(ctx.guild))
 
+    @platform_grp.command(name="flag")  # type: ignore[arg-type]
+    @commands.has_permissions(administrator=True)
+    async def platform_flag_manager(self, ctx):
+        """Open the editable per-guild flag manager (Phase 6.5a).
+
+        Every mutation routes through
+        :class:`services.rollout_mutation.RolloutMutationPipeline`
+        (validates, writes audit, invalidates cache, emits event).
+        """
+        from views.base import send_panel
+        from views.diagnostic.flag_manager import (
+            FlagManagerView,
+            build_flag_manager_overview_embed,
+        )
+
+        guild_id = ctx.guild.id if ctx.guild else None
+        view = FlagManagerView(ctx.author, guild_id=guild_id)
+        await send_panel(
+            ctx,
+            embed=build_flag_manager_overview_embed(),
+            view=view,
+        )
+
     @platform_grp.command(name="migrations")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def platform_migrations(self, ctx):

--- a/disbot/views/diagnostic/flag_manager.py
+++ b/disbot/views/diagnostic/flag_manager.py
@@ -1,0 +1,380 @@
+"""Platform flag manager view — Phase 6.5a.
+
+Editable companion to ``!platform flags`` (which stays read-only).
+Every mutation routes through :class:`services.rollout_mutation.
+RolloutMutationPipeline`, the canonical write path that validates
+flags/states/scopes, writes to ``feature_flag_state`` plus an audit
+row, invalidates the feature-flag cache, and emits an event.
+
+**No direct DB writes.** Tests pin this contract via a grep over
+this module.
+
+Scope of this PR:
+
+* Per-guild enable/disable through ``set_flag_state(scope="guild")``.
+* Read-only render of every declared flag's default, effective
+  value, source, and owner (mirrors ``build_flags_embed``).
+
+Explicit non-goals (per the roadmap):
+
+* No reset/delete of guild overrides — the pipeline does not expose
+  a delete path today, and inventing a direct DB delete here would
+  bypass audit/cache invalidation. The button is omitted entirely
+  (better than a confusingly disabled control).
+* No rollout-percent slider.
+* No global-scope mutation.
+* No environment-tier editing.
+* No slash command.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import discord
+
+from utils.ui_constants import ADMIN_COLOR
+from views.base import HubView
+
+logger = logging.getLogger("bot.views.diagnostic.flag_manager")
+
+
+# Max flags renderable in one Discord select.
+_MAX_FLAGS_PER_SELECT = 25
+
+
+def _sorted_flag_names() -> list[str]:
+    """All declared feature flags, sorted for deterministic UI ordering."""
+    from core.runtime import feature_flags
+
+    return sorted(feature_flags.declared_names())
+
+
+async def _resolve_flag_details(
+    flag_name: str,
+    guild_id: int | None,
+) -> dict[str, Any]:
+    """Read-only snapshot of a flag's declaration + effective resolution.
+
+    Returns a dict with keys ``name``, ``default``, ``effective``,
+    ``source``, ``owner``, ``description``, ``removal_target``,
+    ``has_guild_override``. Resolution errors are caught and surfaced
+    as ``source="error:<exc>"`` so the embed never crashes.
+    """
+    from core.runtime import feature_flags
+    from utils.db import feature_flag_state as ff_db
+
+    flag = feature_flags.get(flag_name)
+    if flag is None:
+        return {
+            "name": flag_name,
+            "default": "?",
+            "effective": "?",
+            "source": "unregistered",
+            "owner": "?",
+            "description": "Flag is no longer declared.",
+            "removal_target": "",
+            "has_guild_override": False,
+        }
+    try:
+        decision = await feature_flags.resolve_with_provenance(flag_name, guild_id)
+        effective = "on" if decision.value else "off"
+        source = decision.source
+    except Exception as exc:  # noqa: BLE001 — diagnostics must not raise
+        effective = "?"
+        source = f"error:{type(exc).__name__}"
+
+    has_guild_override = False
+    if guild_id is not None:
+        try:
+            row = await ff_db.get_guild_override(flag_name, guild_id)
+            has_guild_override = row is not None
+        except Exception as exc:  # noqa: BLE001 — non-fatal
+            logger.debug(
+                "Could not read guild override for %r/%d: %s",
+                flag_name,
+                guild_id,
+                exc,
+            )
+
+    return {
+        "name": flag_name,
+        "default": "on" if flag.default_value else "off",
+        "effective": effective,
+        "source": source,
+        "owner": flag.owner,
+        "description": flag.description,
+        "removal_target": flag.removal_target,
+        "has_guild_override": has_guild_override,
+    }
+
+
+def build_flag_manager_overview_embed() -> discord.Embed:
+    """Pre-selection overview embed."""
+    embed = discord.Embed(
+        title="🚩 Flag Manager",
+        description=(
+            "Pick a flag from the dropdown to view its current state and "
+            "enable/disable it for this guild. Every mutation routes "
+            "through the rollout pipeline (validated + audited + cache "
+            "invalidated)."
+        ),
+        color=ADMIN_COLOR,
+    )
+    embed.set_footer(
+        text=(
+            "Read-only by default. Enable/Disable only mutate the per-guild "
+            "override — global flag state and rollout percent are unchanged."
+        ),
+    )
+    return embed
+
+
+def build_flag_detail_embed(details: dict[str, Any]) -> discord.Embed:
+    """Render a flag's read-only details as the manager embed."""
+    color = ADMIN_COLOR
+    title = f"🚩 {details['name']}"
+    description = details.get("description") or "_No description._"
+    embed = discord.Embed(title=title, description=description, color=color)
+    embed.add_field(name="Default", value=f"`{details['default']}`", inline=True)
+    embed.add_field(name="Effective", value=f"`{details['effective']}`", inline=True)
+    embed.add_field(name="Source", value=f"`{details['source']}`", inline=True)
+    embed.add_field(name="Owner", value=f"`{details['owner']}`", inline=True)
+    embed.add_field(
+        name="Guild override",
+        value="`yes`" if details["has_guild_override"] else "`none`",
+        inline=True,
+    )
+    removal = details.get("removal_target")
+    if removal:
+        embed.add_field(name="Removal target", value=removal, inline=True)
+    embed.set_footer(
+        text=(
+            "Enable/Disable writes a per-guild override through "
+            "RolloutMutationPipeline.set_flag_state."
+        ),
+    )
+    return embed
+
+
+class _FlagSelect(discord.ui.Select):
+    def __init__(self, flag_names: list[str], selected: str | None) -> None:
+        options: list[discord.SelectOption] = []
+        for name in flag_names[:_MAX_FLAGS_PER_SELECT]:
+            options.append(
+                discord.SelectOption(
+                    label=name[:100],
+                    value=name,
+                    default=(name == selected),
+                ),
+            )
+        if not options:
+            options.append(
+                discord.SelectOption(
+                    label="No flags declared",
+                    value="__none__",
+                    description="The feature-flag registry is empty.",
+                ),
+            )
+        super().__init__(
+            placeholder="Choose a flag…",
+            min_values=1,
+            max_values=1,
+            options=options,
+            custom_id="flag_manager:select",
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        if not isinstance(view, FlagManagerView):
+            return
+        await view.handle_select(interaction, self.values[0])
+
+
+class FlagManagerView(HubView):
+    """Per-guild feature-flag editor.
+
+    Construction is sync (no DB calls); render goes through
+    :meth:`refresh` after mutation or selection.
+    """
+
+    SUBSYSTEM = "diagnostic"
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        *,
+        guild_id: int | None,
+    ) -> None:
+        super().__init__(author)
+        self.guild_id = guild_id
+        self.selected_flag: str | None = None
+        self._flag_names = _sorted_flag_names()
+        self.add_item(_FlagSelect(self._flag_names, self.selected_flag))
+
+    def _replace_select(self) -> None:
+        """Rebuild the flag select so the ``default=`` marker tracks state."""
+        to_remove = [
+            child
+            for child in self.children
+            if isinstance(child, discord.ui.Select)
+            and child.custom_id == "flag_manager:select"
+        ]
+        for item in to_remove:
+            self.remove_item(item)
+        self.add_item(_FlagSelect(self._flag_names, self.selected_flag))
+
+    async def handle_select(
+        self,
+        interaction: discord.Interaction,
+        flag_name: str,
+    ) -> None:
+        if flag_name == "__none__":
+            await interaction.response.send_message(
+                "No flags are declared in this build.",
+                ephemeral=True,
+            )
+            return
+        self.selected_flag = flag_name
+        self._replace_select()
+        details = await _resolve_flag_details(flag_name, self.guild_id)
+        await interaction.response.edit_message(
+            embed=build_flag_detail_embed(details),
+            view=self,
+        )
+
+    async def _apply_state(
+        self,
+        interaction: discord.Interaction,
+        new_state: str,
+    ) -> None:
+        if not self.selected_flag or self.selected_flag == "__none__":
+            await interaction.response.send_message(
+                "Pick a flag from the dropdown before changing its state.",
+                ephemeral=True,
+            )
+            return
+        if self.guild_id is None:
+            await interaction.response.send_message(
+                "Guild context is required to set a per-guild override.",
+                ephemeral=True,
+            )
+            return
+
+        # Local imports — keep the heavy pipeline + DB modules out of
+        # this view's import time.
+        from services.rollout_mutation import (
+            RolloutMutationError,
+            RolloutMutationPipeline,
+        )
+
+        pipeline = RolloutMutationPipeline()
+        try:
+            await pipeline.set_flag_state(
+                flag_name=self.selected_flag,
+                scope="guild",
+                state=new_state,
+                actor_id=interaction.user.id,
+                actor_type="platform_owner",
+                guild_id=self.guild_id,
+            )
+        except RolloutMutationError as exc:
+            await interaction.response.send_message(
+                f"Mutation rejected by pipeline: `{type(exc).__name__}: {exc}`",
+                ephemeral=True,
+            )
+            return
+        except Exception as exc:  # noqa: BLE001 — UI must not crash
+            logger.exception(
+                "FlagManagerView: pipeline call failed unexpectedly "
+                "(flag=%r, state=%r): %s",
+                self.selected_flag,
+                new_state,
+                exc,
+            )
+            await interaction.response.send_message(
+                f"Mutation failed: `{type(exc).__name__}`. See bot logs.",
+                ephemeral=True,
+            )
+            return
+
+        # Refresh the detail embed so the operator sees the new state /
+        # source / override marker in place.
+        details = await _resolve_flag_details(self.selected_flag, self.guild_id)
+        await interaction.response.edit_message(
+            embed=build_flag_detail_embed(details),
+            view=self,
+        )
+
+    @discord.ui.button(
+        label="✅ Enable for this guild",
+        style=discord.ButtonStyle.success,
+        custom_id="flag_manager:enable",
+        row=1,
+    )
+    async def btn_enable(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        await self._apply_state(interaction, "on")
+
+    @discord.ui.button(
+        label="🛑 Disable for this guild",
+        style=discord.ButtonStyle.danger,
+        custom_id="flag_manager:disable",
+        row=1,
+    )
+    async def btn_disable(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        await self._apply_state(interaction, "off")
+
+    @discord.ui.button(
+        label="🔄 Refresh",
+        style=discord.ButtonStyle.secondary,
+        custom_id="flag_manager:refresh",
+        row=1,
+    )
+    async def btn_refresh(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        if not self.selected_flag or self.selected_flag == "__none__":
+            await interaction.response.edit_message(
+                embed=build_flag_manager_overview_embed(),
+                view=self,
+            )
+            return
+        details = await _resolve_flag_details(self.selected_flag, self.guild_id)
+        await interaction.response.edit_message(
+            embed=build_flag_detail_embed(details),
+            view=self,
+        )
+
+    @discord.ui.button(
+        label="↩ Back to Platform",
+        style=discord.ButtonStyle.secondary,
+        custom_id="flag_manager:back",
+        row=4,
+    )
+    async def btn_back(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        from views.diagnostic.platform_panel import (
+            _PlatformHubView,
+            build_platform_hub_embed,
+        )
+
+        new_view = _PlatformHubView(self._author)
+        await interaction.response.edit_message(
+            embed=build_platform_hub_embed(),
+            view=new_view,
+        )

--- a/tests/unit/views/test_flag_manager.py
+++ b/tests/unit/views/test_flag_manager.py
@@ -1,0 +1,480 @@
+"""Unit tests for :class:`FlagManagerView` (Phase 6.5a).
+
+Pins the canonical-pipeline contract:
+
+* Enable/Disable buttons route through
+  :func:`RolloutMutationPipeline.set_flag_state` — they never touch
+  ``utils.db.feature_flag_state`` directly.
+* The view module contains no direct DB-mutation call sites (the
+  test scans the source as a regression guard).
+* Mutation errors and unknown-flag rejections surface as ephemerals.
+* The flag select lists every declared flag, sorted.
+* After a successful mutation, the embed refreshes with the new
+  resolution.
+
+A grep-based source assertion holds the no-direct-DB-write rule in
+place across future edits.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from views.diagnostic import flag_manager as fm
+
+_FAKE_FLAG_NAMES = [
+    "settings.manager_cog.enabled",
+    "platform.bindings.primary",
+    "platform.participation.enabled",
+]
+
+
+def _author(id_: int = 99) -> MagicMock:
+    member = MagicMock(spec=discord.Member)
+    member.id = id_
+    member.display_name = "Op"
+    return member
+
+
+def _interaction(*, user_id: int = 99, guild_id: int | None = 42) -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = MagicMock()
+    interaction.user.id = user_id
+    interaction.guild_id = guild_id
+    interaction.guild = MagicMock()
+    interaction.guild.id = guild_id
+    interaction.channel = MagicMock()
+    interaction.client = MagicMock()
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    return interaction
+
+
+# ---------------------------------------------------------------------------
+# Module-level invariants
+# ---------------------------------------------------------------------------
+
+
+def test_flag_manager_module_does_not_import_db_layer_at_top_level():
+    """The view must not pull the DB module at import time.
+
+    A direct import line would make this view module depend on the DB
+    package eagerly; the existing convention is function-local imports
+    only.
+    """
+    src = Path(fm.__file__).read_text()
+    # Find module-import section: everything before the first ``def``.
+    head = src.split("\ndef ", 1)[0]
+    assert "from utils.db" not in head
+    assert "import utils.db" not in head
+    assert "from utils.db.feature_flag_state" not in head
+
+
+def test_flag_manager_does_not_call_db_mutations_directly():
+    """The view must never invoke ``ff_db`` mutation functions.
+
+    The pipeline is the only sanctioned write path; this assertion
+    guards against a future edit that "just adds a quick delete".
+    """
+    src = Path(fm.__file__).read_text()
+    for forbidden in (
+        "upsert_global_with_audit",
+        "upsert_guild_with_audit",
+        "delete_guild_override",
+        "delete_global_override",
+    ):
+        assert forbidden not in src, (
+            f"flag_manager.py contains forbidden DB mutation call {forbidden!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Overview + detail embeds
+# ---------------------------------------------------------------------------
+
+
+def test_overview_embed_describes_read_only_default():
+    embed = fm.build_flag_manager_overview_embed()
+    desc = (embed.description or "") + (embed.footer.text or "")
+    assert "pipeline" in desc.lower() or "audit" in desc.lower()
+    assert "guild" in desc.lower()
+
+
+def test_detail_embed_renders_required_fields():
+    details = {
+        "name": "platform.example.flag",
+        "default": "off",
+        "effective": "on",
+        "source": "guild_override",
+        "owner": "platform",
+        "description": "Example",
+        "removal_target": "Phase 99 stable",
+        "has_guild_override": True,
+    }
+    embed = fm.build_flag_detail_embed(details)
+    field_names = [f.name for f in embed.fields]
+    assert "Default" in field_names
+    assert "Effective" in field_names
+    assert "Source" in field_names
+    assert "Owner" in field_names
+    assert "Guild override" in field_names
+    assert "Removal target" in field_names
+
+
+def test_detail_embed_omits_removal_when_empty():
+    details = {
+        "name": "x.y",
+        "default": "off",
+        "effective": "off",
+        "source": "default",
+        "owner": "platform",
+        "description": "",
+        "removal_target": "",
+        "has_guild_override": False,
+    }
+    embed = fm.build_flag_detail_embed(details)
+    assert "Removal target" not in [f.name for f in embed.fields]
+
+
+# ---------------------------------------------------------------------------
+# View shape
+# ---------------------------------------------------------------------------
+
+
+def test_view_lists_every_declared_flag_in_select():
+    with patch.object(fm, "_sorted_flag_names", return_value=list(_FAKE_FLAG_NAMES)):
+        view = fm.FlagManagerView(_author(), guild_id=42)
+        select = next(c for c in view.children if isinstance(c, discord.ui.Select))
+        assert [o.value for o in select.options] == list(_FAKE_FLAG_NAMES)
+
+
+def test_view_exposes_expected_button_set():
+    view = fm.FlagManagerView(_author(), guild_id=42)
+    custom_ids = {
+        c.custom_id
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+    }
+    assert custom_ids == {
+        "flag_manager:enable",
+        "flag_manager:disable",
+        "flag_manager:refresh",
+        "flag_manager:back",
+    }
+
+
+def test_view_omits_reset_button_until_pipeline_supports_it():
+    """The pipeline does not expose a guild-override delete path today,
+    so the manager intentionally does not show a Reset button. Confirm
+    the omission so a future re-introduction is deliberate.
+    """
+    view = fm.FlagManagerView(_author(), guild_id=42)
+    button_labels = {
+        c.label
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+    }
+    assert not any("reset" in (label or "").lower() for label in button_labels)
+
+
+# ---------------------------------------------------------------------------
+# Select handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_select_none_sentinel_sends_ephemeral():
+    with patch.object(fm, "_sorted_flag_names", return_value=[]):
+        view = fm.FlagManagerView(_author(), guild_id=42)
+        interaction = _interaction()
+        await view.handle_select(interaction, "__none__")
+    interaction.response.send_message.assert_awaited_once()
+    interaction.response.edit_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_select_routes_through_resolve_details():
+    with patch.object(fm, "_sorted_flag_names", return_value=list(_FAKE_FLAG_NAMES)):
+        view = fm.FlagManagerView(_author(), guild_id=42)
+    interaction = _interaction()
+    fake_details = {
+        "name": "platform.bindings.primary",
+        "default": "off",
+        "effective": "on",
+        "source": "guild_override",
+        "owner": "platform",
+        "description": "Bindings primary",
+        "removal_target": "",
+        "has_guild_override": True,
+    }
+    with patch.object(
+        fm,
+        "_resolve_flag_details",
+        AsyncMock(return_value=fake_details),
+    ) as fake_resolve:
+        await view.handle_select(interaction, "platform.bindings.primary")
+    fake_resolve.assert_awaited_once_with("platform.bindings.primary", 42)
+    interaction.response.edit_message.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Enable / Disable — pipeline routing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enable_calls_pipeline_set_flag_state_with_guild_scope():
+    with patch.object(fm, "_sorted_flag_names", return_value=list(_FAKE_FLAG_NAMES)):
+        view = fm.FlagManagerView(_author(), guild_id=42)
+        view.selected_flag = "platform.bindings.primary"
+    interaction = _interaction()
+
+    fake_pipeline = MagicMock()
+    fake_pipeline.set_flag_state = AsyncMock()
+    fake_details = {
+        "name": "platform.bindings.primary",
+        "default": "off",
+        "effective": "on",
+        "source": "guild_override",
+        "owner": "platform",
+        "description": "",
+        "removal_target": "",
+        "has_guild_override": True,
+    }
+    with patch(
+        "services.rollout_mutation.RolloutMutationPipeline",
+        return_value=fake_pipeline,
+    ), patch.object(
+        fm,
+        "_resolve_flag_details",
+        AsyncMock(return_value=fake_details),
+    ):
+        btn = next(
+            c
+            for c in view.children
+            if isinstance(c, discord.ui.Button) and c.custom_id == "flag_manager:enable"
+        )
+        await btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    fake_pipeline.set_flag_state.assert_awaited_once()
+    kwargs = fake_pipeline.set_flag_state.call_args.kwargs
+    assert kwargs["flag_name"] == "platform.bindings.primary"
+    assert kwargs["scope"] == "guild"
+    assert kwargs["state"] == "on"
+    assert kwargs["guild_id"] == 42
+    assert kwargs["actor_id"] == 99
+    assert kwargs["actor_type"] == "platform_owner"
+    interaction.response.edit_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_disable_calls_pipeline_with_state_off():
+    with patch.object(fm, "_sorted_flag_names", return_value=list(_FAKE_FLAG_NAMES)):
+        view = fm.FlagManagerView(_author(), guild_id=42)
+        view.selected_flag = "platform.bindings.primary"
+    interaction = _interaction()
+
+    fake_pipeline = MagicMock()
+    fake_pipeline.set_flag_state = AsyncMock()
+    fake_details = {
+        "name": "platform.bindings.primary",
+        "default": "off",
+        "effective": "off",
+        "source": "guild_override",
+        "owner": "platform",
+        "description": "",
+        "removal_target": "",
+        "has_guild_override": True,
+    }
+    with patch(
+        "services.rollout_mutation.RolloutMutationPipeline",
+        return_value=fake_pipeline,
+    ), patch.object(
+        fm,
+        "_resolve_flag_details",
+        AsyncMock(return_value=fake_details),
+    ):
+        btn = next(
+            c
+            for c in view.children
+            if isinstance(c, discord.ui.Button) and c.custom_id == "flag_manager:disable"
+        )
+        await btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    fake_pipeline.set_flag_state.assert_awaited_once()
+    kwargs = fake_pipeline.set_flag_state.call_args.kwargs
+    assert kwargs["state"] == "off"
+    assert kwargs["scope"] == "guild"
+
+
+@pytest.mark.asyncio
+async def test_enable_without_selection_sends_ephemeral():
+    view = fm.FlagManagerView(_author(), guild_id=42)
+    interaction = _interaction()
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "flag_manager:enable"
+    )
+    await btn.callback(interaction)  # type: ignore[union-attr,misc]
+    interaction.response.send_message.assert_awaited_once()
+    interaction.response.edit_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_enable_without_guild_id_sends_ephemeral():
+    view = fm.FlagManagerView(_author(), guild_id=None)
+    view.selected_flag = "platform.bindings.primary"
+    interaction = _interaction(guild_id=None)
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "flag_manager:enable"
+    )
+    await btn.callback(interaction)  # type: ignore[union-attr,misc]
+    interaction.response.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_enable_pipeline_error_surfaces_ephemeral():
+    with patch.object(fm, "_sorted_flag_names", return_value=list(_FAKE_FLAG_NAMES)):
+        view = fm.FlagManagerView(_author(), guild_id=42)
+        view.selected_flag = "platform.bindings.primary"
+    interaction = _interaction()
+
+    from services.rollout_mutation import UnknownFeatureFlagError
+
+    fake_pipeline = MagicMock()
+    fake_pipeline.set_flag_state = AsyncMock(
+        side_effect=UnknownFeatureFlagError("unknown"),
+    )
+    with patch(
+        "services.rollout_mutation.RolloutMutationPipeline",
+        return_value=fake_pipeline,
+    ):
+        btn = next(
+            c
+            for c in view.children
+            if isinstance(c, discord.ui.Button) and c.custom_id == "flag_manager:enable"
+        )
+        await btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    interaction.response.send_message.assert_awaited_once()
+    interaction.response.edit_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unexpected_exception_does_not_crash_view():
+    with patch.object(fm, "_sorted_flag_names", return_value=list(_FAKE_FLAG_NAMES)):
+        view = fm.FlagManagerView(_author(), guild_id=42)
+        view.selected_flag = "platform.bindings.primary"
+    interaction = _interaction()
+
+    fake_pipeline = MagicMock()
+    fake_pipeline.set_flag_state = AsyncMock(side_effect=RuntimeError("boom"))
+    with patch(
+        "services.rollout_mutation.RolloutMutationPipeline",
+        return_value=fake_pipeline,
+    ):
+        btn = next(
+            c
+            for c in view.children
+            if isinstance(c, discord.ui.Button) and c.custom_id == "flag_manager:enable"
+        )
+        await btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    interaction.response.send_message.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Refresh + Back
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_without_selection_rebuilds_overview():
+    view = fm.FlagManagerView(_author(), guild_id=42)
+    interaction = _interaction()
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "flag_manager:refresh"
+    )
+    await btn.callback(interaction)  # type: ignore[union-attr,misc]
+    interaction.response.edit_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_refresh_after_selection_resolves_again():
+    with patch.object(fm, "_sorted_flag_names", return_value=list(_FAKE_FLAG_NAMES)):
+        view = fm.FlagManagerView(_author(), guild_id=42)
+        view.selected_flag = "platform.bindings.primary"
+    interaction = _interaction()
+
+    fake_details = {
+        "name": "platform.bindings.primary",
+        "default": "off",
+        "effective": "off",
+        "source": "default",
+        "owner": "platform",
+        "description": "",
+        "removal_target": "",
+        "has_guild_override": False,
+    }
+    with patch.object(
+        fm,
+        "_resolve_flag_details",
+        AsyncMock(return_value=fake_details),
+    ) as fake_resolve:
+        btn = next(
+            c
+            for c in view.children
+            if isinstance(c, discord.ui.Button) and c.custom_id == "flag_manager:refresh"
+        )
+        await btn.callback(interaction)  # type: ignore[union-attr,misc]
+    fake_resolve.assert_awaited_once_with("platform.bindings.primary", 42)
+
+
+@pytest.mark.asyncio
+async def test_back_button_returns_to_platform_hub():
+    view = fm.FlagManagerView(_author(), guild_id=42)
+    interaction = _interaction()
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "flag_manager:back"
+    )
+    await btn.callback(interaction)  # type: ignore[union-attr,misc]
+    interaction.response.edit_message.assert_awaited_once()
+    from views.diagnostic.platform_panel import _PlatformHubView
+
+    _args, kwargs = interaction.response.edit_message.call_args
+    assert isinstance(kwargs["view"], _PlatformHubView)
+
+
+# ---------------------------------------------------------------------------
+# Cog wiring — !platform flag
+# ---------------------------------------------------------------------------
+
+
+def test_platform_flag_subcommand_exists():
+    from cogs.diagnostic_cog import DiagnosticCog
+
+    sub = DiagnosticCog.platform_grp.get_command("flag")
+    assert sub is not None
+    assert sub.name == "flag"
+
+
+def test_platform_flags_read_only_command_still_exists():
+    """`!platform flags` (plural) must remain — the new manager is a sibling,
+    not a replacement.
+    """
+    from cogs.diagnostic_cog import DiagnosticCog
+
+    sub = DiagnosticCog.platform_grp.get_command("flags")
+    assert sub is not None


### PR DESCRIPTION
## Objective

Phase 6.5a: add an editable companion to `!platform flags`. A new `!platform flag` (singular) subcommand opens `FlagManagerView` — an admin-only per-guild feature-flag editor that routes every mutation through `services.rollout_mutation.RolloutMutationPipeline.set_flag_state`, the canonical write path that validates + audits + invalidates cache + emits an event.

Independent of #121 (Phase 5, still open); starts from current `main` (which now includes Phase 6).

## Files changed

- `disbot/views/diagnostic/flag_manager.py` *(new, ~330 lines)* — `FlagManagerView`, embed builders, `_FlagSelect`, helpers.
- `disbot/cogs/diagnostic_cog.py` — adds `!platform flag` subcommand (~20 lines).
- `tests/unit/views/test_flag_manager.py` *(new, 21 tests)*.

## UX

| Action | Effect |
|---|---|
| `!platform flags` (plural) | Unchanged read-only overview. |
| `!platform flag` (singular) | Opens `FlagManagerView`. |
| Flag select (row 0) | Lists every declared flag, sorted. |
| ✅ Enable for this guild | `pipeline.set_flag_state(scope="guild", state="on")`, refresh embed |
| 🛑 Disable for this guild | `pipeline.set_flag_state(scope="guild", state="off")`, refresh embed |
| 🔄 Refresh | Re-resolves the selected flag with provenance |
| ↩ Back to Platform | Returns to the platform hub |

The detail embed shows: default, effective value, source, owner, whether a guild override exists, and `removal_target` if set.

## What this PR explicitly does NOT do

- **No reset of guild overrides.** `RolloutMutationPipeline` does not expose a guild-override delete method today. Inventing a direct DB delete in the UI would bypass audit/cache invalidation. The button is **omitted entirely** rather than shown-but-disabled. A pinned test asserts the Reset button stays absent until the pipeline grows a sanctioned reset path — so its absence is deliberate, not forgotten.
- No global-scope mutation, no rollout-percent slider, no environment-tier editing.
- No slash command.
- **No direct DB-mutation call sites in the view module.** Two grep-based tests pin this contract:
  - `test_flag_manager_module_does_not_import_db_layer_at_top_level` — no `from utils.db` or `import utils.db` in the module-level import section.
  - `test_flag_manager_does_not_call_db_mutations_directly` — substring-scans the source for `upsert_global_with_audit`, `upsert_guild_with_audit`, `delete_guild_override`, `delete_global_override`. Each match would fail the test.

## Tests run

| Suite | Result |
|---|---|
| `pytest tests/unit/views/test_flag_manager.py` | **21 passed** |
| `pytest` (full suite) | **2112 passed**, 11 warnings, 26.25s |
| `black --check . --exclude '(\.github\|tests\|venv\|env\|build\|dist)'` | clean (265 files) |
| `isort --check-only . --skip-glob …` | clean |
| `ruff check . --exclude .github,tests,venv,env,build,dist` | clean |
| `python3.10 -m mypy disbot/` | **Success: no issues found in 266 source files** |

## Manual Discord smoke checklist

- [ ] Bot starts cleanly
- [ ] `!platform flag` opens the manager
- [ ] `!platform flags` still shows the read-only overview unchanged
- [ ] Pick a safe test flag (e.g. `settings.manager_cog.enabled`)
- [ ] **Enable for this guild** → effective becomes `on`, source becomes `guild_override`, guild-override marker flips to `yes`
- [ ] **Disable for this guild** → effective becomes `off`, source stays `guild_override`, override marker stays `yes`
- [ ] Run `!settings` after toggling `settings.manager_cog.enabled` and confirm behaviour matches the override
- [ ] Run `!platform flags` (plural) again — confirm provenance matches the manager
- [ ] **Back to Platform** returns to the hub overview
- [ ] `!platform identity` reports no fatal findings
- [ ] Audit log table receives a row per mutation (mutation_id matches the pipeline's return value)

## Risks

- **Medium.** Touching feature-flag state in production. The mitigation is the pipeline itself — it's the same code path that all other rollout mutations use, with the same validation/audit/cache-invalidation guarantees. No direct DB writes anywhere in this PR (two pinned tests prevent that from regressing). Error paths fall through to ephemeral messages so a failed mutation never crashes the view.

## Rollback plan

1. Revert this commit (three files).
2. The `!platform flag` subcommand goes away; `!platform flags` plural is unaffected.
3. No data migration — the pipeline's writes go to the same `feature_flag_state` rows the rollout flow already uses, so existing overrides stay valid regardless of whether this PR is in.

## Next recommended phase

**Phase 7 Option A** — router-only Blackjack/RPS panels. Per the user's directive: Classic + Rules + Back to Games + Back to Help. No Practice. No Replay. No engine touches. Practice/Replay becomes Phase 7b after a short product/engine design pass. I'll cut that branch next.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TeXrWGdRyGEcukWEv1qryT)_