### PR TITLE
feat(games): router-only Blackjack + RPS panels (Phase 7 Option A)

### DIFF
--- a/disbot/cogs/blackjack_cog.py
+++ b/disbot/cogs/blackjack_cog.py
@@ -65,13 +65,12 @@ from cogs.blackjack._state import (  # noqa: F401 — re-exported
     _TournPlayerState,
 )
 from core.runtime import resources, tasks
-from core.runtime.component_registry import stats_block
 from services import economy_service, game_state_service
 from services.blackjack_engine import is_blackjack as _is_blackjack
 from utils import db
 from utils.channels import cleanup_category, create_private_channel
 from utils.settings_keys import ACTIVE_TOURNAMENT
-from utils.ui_constants import ECONOMY_COLOR, GAME_COLOR, SUCCESS_COLOR
+from utils.ui_constants import ECONOMY_COLOR, SUCCESS_COLOR
 from views.blackjack import (  # noqa: F401 — re-exported
     BlackjackView,
     _ChallengeView,
@@ -97,28 +96,19 @@ class BlackjackCog(commands.Cog):
         self,
         interaction: discord.Interaction,
     ) -> tuple[discord.Embed, discord.ui.View]:
-        """Help-menu direct-navigation hook (returns a blackjack overview).
+        """Help-menu direct-navigation hook — returns the Blackjack hub panel.
 
-        The blackjack subsystem has no hub panel — the entry command starts
-        a game with an optional bet/opponent — so we return an informational
-        embed with no buttons. The help-cog appends the "↩ Back to Help"
-        control automatically.
+        Phase 7 Option A: router-only panel that lists Classic and Rules.
+        Game-engine code paths are untouched; Practice/Replay are deferred
+        to Phase 7b once the engine-side design is settled.
         """
-        embed = stats_block(
-            "🃏 Blackjack",
-            [
-                ("Solo vs bot", "`!blackjack <bet>` or `!bj <bet>`", False),
-                ("PvP challenge", "`!blackjack @user <bet>`", False),
-                ("Tournament", "`!bjtournament` — open registration", False),
-            ],
-            GAME_COLOR,
-            description=(
-                "Classic 21 — play solo against the bot or challenge another "
-                "player. Tournament mode runs scheduled brackets."
-            ),
-            footer="Bets are in 🪙 coins. Bet 0 for a free game.",
+        from views.games.blackjack_panel import (
+            BlackjackPanelView,
+            build_blackjack_overview_embed,
         )
-        return embed, discord.ui.View(timeout=300)
+
+        view = BlackjackPanelView(interaction.user)
+        return build_blackjack_overview_embed(), view
 
     # ------------------------------------------------------------------
     # Lifecycle + recovery

--- a/disbot/cogs/rps_tournament_cog.py
+++ b/disbot/cogs/rps_tournament_cog.py
@@ -64,14 +64,13 @@ from cogs.rps_tournament.rules import (
     normalize_move,
 )
 from core.runtime import tasks
-from core.runtime.component_registry import stats_block
 from services import (  # noqa: F401 — game_state_service kept for back-compat patch sites
     economy_service,
     game_state_service,
 )
 from utils import db as global_db
 from utils.settings_keys import ACTIVE_TOURNAMENT
-from utils.ui_constants import GAME_COLOR, INFO_COLOR
+from utils.ui_constants import INFO_COLOR
 from views.rps import _RpsRegistrationView
 
 logger = logging.getLogger("bot")
@@ -120,39 +119,16 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # 
         self,
         interaction: discord.Interaction,
     ) -> tuple[discord.Embed, discord.ui.View]:
-        """Help-menu direct-navigation hook (returns an RPS overview).
+        """Help-menu direct-navigation hook — returns the RPS hub panel.
 
-        RPS has no hub panel — the entry commands either start a quick
-        match (``!rps``) or open tournament registration (``!rpsregister``).
-        The returned overview embed describes both flows; the help-cog
-        appends the "↩ Back to Help" control automatically.
+        Phase 7 Option A: router-only panel listing Single Round / Tournament
+        / Rules. Tournament state stays in this cog; the panel routes to
+        the existing typed commands and never duplicates match orchestration.
         """
-        embed = stats_block(
-            "✂️ Rock-Paper-Scissors",
-            [
-                (
-                    "Quick match",
-                    "`!rps` solo vs bot · `!rps @user` PvP · `!rps @user <bet>`",
-                    False,
-                ),
-                (
-                    "Tournament",
-                    (
-                        "`!rpsregister` — open registration\n"
-                        "`!rpsstart` — begin bracket\n"
-                        "`!rpshelp` — full tournament help"
-                    ),
-                    False,
-                ),
-            ],
-            GAME_COLOR,
-            description=(
-                "Quick matches vs the bot or another player, plus scheduled "
-                "tournaments with optional entry fees."
-            ),
-            footer="Default mode: classic · best of 3.",
-        )
-        return embed, discord.ui.View(timeout=300)
+        from views.games.rps_panel import RPSPanelView, build_rps_overview_embed
+
+        view = RPSPanelView(interaction.user)
+        return build_rps_overview_embed(), view
 
     # ------------------------------------------------------------------
     # Lifecycle + recovery (delegators preserve test invariants)

--- a/disbot/views/games/blackjack_panel.py
+++ b/disbot/views/games/blackjack_panel.py
@@ -1,0 +1,171 @@
+"""Blackjack hub panel — Phase 7 Option A (router only).
+
+A discovery surface that lists Classic and Rules under the Games hub.
+Game logic, modes, replay, and economy paths are **untouched** — every
+button either swaps the embed in place or routes back to a parent hub
+via the standard ``attach_back_to_*`` factories.
+
+Phase 7 Option A explicitly defers Practice / Replay / Best-of variants
+to a follow-up (Phase 7b) once the engine-side design call is made
+(``bet=0`` vs separate no-economy path, post-game callback shape,
+double-charge prevention).
+"""
+
+from __future__ import annotations
+
+import discord
+
+from utils.ui_constants import GAME_COLOR
+from views.base import HubView
+
+
+def build_blackjack_overview_embed() -> discord.Embed:
+    embed = discord.Embed(
+        title="🃏 Blackjack",
+        description=(
+            "Classic 21 — solo against the bot, PvP against another "
+            "player, or scheduled tournaments. The buttons below explain "
+            "how to start each mode; typed shortcuts still work."
+        ),
+        color=GAME_COLOR,
+    )
+    embed.add_field(
+        name="Modes",
+        value=(
+            "▶ **Classic** — start a standard game\n"
+            "📖 **Rules** — how the deal/hit/stand flow works"
+        ),
+        inline=False,
+    )
+    embed.set_footer(text="Typed shortcuts: !blackjack, !bj, !bjtournament.")
+    return embed
+
+
+def build_blackjack_classic_embed() -> discord.Embed:
+    embed = discord.Embed(
+        title="🃏 Blackjack — Classic",
+        description=(
+            "Start a Classic game with a typed command. Bets are in "
+            "🪙 coins; use `0` for a free game."
+        ),
+        color=GAME_COLOR,
+    )
+    embed.add_field(
+        name="Solo vs bot",
+        value="`!blackjack <bet>` or `!bj <bet>`",
+        inline=False,
+    )
+    embed.add_field(
+        name="PvP challenge",
+        value="`!blackjack @user <bet>`",
+        inline=False,
+    )
+    embed.add_field(
+        name="Tournament",
+        value="`!bjtournament` — open registration",
+        inline=False,
+    )
+    embed.set_footer(text="Click ◀ Overview to return to the Blackjack hub.")
+    return embed
+
+
+def build_blackjack_rules_embed() -> discord.Embed:
+    embed = discord.Embed(
+        title="🃏 Blackjack — Rules",
+        description=(
+            "Each player is dealt two cards; the goal is to reach a "
+            "hand value as close to 21 as possible without going over."
+        ),
+        color=GAME_COLOR,
+    )
+    embed.add_field(
+        name="Card values",
+        value=(
+            "• Number cards = face value (2–10)\n"
+            "• Face cards (J/Q/K) = 10\n"
+            "• Ace = 1 or 11, whichever is best for the hand"
+        ),
+        inline=False,
+    )
+    embed.add_field(
+        name="Actions",
+        value=(
+            "• **Hit** — draw another card\n"
+            "• **Stand** — keep the current hand\n"
+            "• Bust at >21 — the other side wins automatically"
+        ),
+        inline=False,
+    )
+    embed.add_field(
+        name="Outcomes",
+        value=(
+            "• Player blackjack (A + 10-value, two cards) usually pays "
+            "extra\n"
+            "• Tie returns the bet"
+        ),
+        inline=False,
+    )
+    embed.set_footer(text="Click ◀ Overview to return to the Blackjack hub.")
+    return embed
+
+
+class BlackjackPanelView(HubView):
+    """Router-only Blackjack hub surfaced via Help → Blackjack and the Games hub.
+
+    No game logic. No economy hooks. No new betting modes. The view's
+    sole job is to keep Blackjack discoverable from a single panel and
+    route to the existing typed commands for the actual start path.
+    """
+
+    SUBSYSTEM = "blackjack"
+
+    def __init__(self, author: discord.Member | discord.User) -> None:
+        super().__init__(author)
+
+    @discord.ui.button(
+        label="▶ Classic",
+        style=discord.ButtonStyle.success,
+        custom_id="blackjack_panel:classic",
+        row=0,
+    )
+    async def btn_classic(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        await interaction.response.edit_message(
+            embed=build_blackjack_classic_embed(),
+            view=self,
+        )
+
+    @discord.ui.button(
+        label="📖 Rules",
+        style=discord.ButtonStyle.secondary,
+        custom_id="blackjack_panel:rules",
+        row=0,
+    )
+    async def btn_rules(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        await interaction.response.edit_message(
+            embed=build_blackjack_rules_embed(),
+            view=self,
+        )
+
+    @discord.ui.button(
+        label="◀ Overview",
+        style=discord.ButtonStyle.secondary,
+        custom_id="blackjack_panel:overview",
+        row=0,
+    )
+    async def btn_overview(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        await interaction.response.edit_message(
+            embed=build_blackjack_overview_embed(),
+            view=self,
+        )

--- a/disbot/views/games/rps_panel.py
+++ b/disbot/views/games/rps_panel.py
@@ -1,0 +1,209 @@
+"""RPS hub panel — Phase 7 Option A (router only).
+
+Routes from the Games hub into the existing typed RPS flow. The view
+contains zero engine logic; every button swaps the embed in place,
+listing the typed commands users invoke to actually play.
+
+Phase 7 Option A defers Best-of/Replay variants to a later PR. The
+Tournament button routes to the existing tournament-registration flow
+(``!rpsregister``) — tournament state lives in ``RPSTournamentCog`` and
+is **not** duplicated here.
+"""
+
+from __future__ import annotations
+
+import discord
+
+from utils.ui_constants import GAME_COLOR
+from views.base import HubView
+
+
+def build_rps_overview_embed() -> discord.Embed:
+    embed = discord.Embed(
+        title="✂️ Rock-Paper-Scissors",
+        description=(
+            "Quick matches vs the bot or another player, plus scheduled "
+            "tournaments with optional entry fees. Pick a mode to see "
+            "how to start it."
+        ),
+        color=GAME_COLOR,
+    )
+    embed.add_field(
+        name="Modes",
+        value=(
+            "▶ **Single Round** — quick match (solo or PvP)\n"
+            "🏆 **Tournament** — registration + bracket\n"
+            "📖 **Rules** — how the matches work"
+        ),
+        inline=False,
+    )
+    embed.set_footer(
+        text="Typed shortcuts: !rps, !rpsregister, !rpsstart, !rpshelp.",
+    )
+    return embed
+
+
+def build_rps_single_round_embed() -> discord.Embed:
+    embed = discord.Embed(
+        title="✂️ RPS — Single Round",
+        description=(
+            "Each round is a single classic Rock-Paper-Scissors throw "
+            "(the underlying tournament cog defaults to best-of-3 for "
+            "tournament brackets — single-round behaviour is unchanged "
+            "by this panel)."
+        ),
+        color=GAME_COLOR,
+    )
+    embed.add_field(
+        name="Solo vs bot",
+        value="`!rps`",
+        inline=False,
+    )
+    embed.add_field(
+        name="Challenge a user",
+        value="`!rps @user`",
+        inline=False,
+    )
+    embed.add_field(
+        name="Stakes match",
+        value="`!rps @user <bet>` — both sides cover the bet from 🪙 coins",
+        inline=False,
+    )
+    embed.set_footer(text="Click ◀ Overview to return to the RPS hub.")
+    return embed
+
+
+def build_rps_tournament_embed() -> discord.Embed:
+    embed = discord.Embed(
+        title="✂️ RPS — Tournament",
+        description=(
+            "Open a registration window, accept entries via reaction, "
+            "then run the bracket. Tournament state and pot accounting "
+            "live in `RPSTournamentCog` — this panel does not duplicate "
+            "either."
+        ),
+        color=GAME_COLOR,
+    )
+    embed.add_field(
+        name="Open registration",
+        value="`!rpsregister` — optionally with a role mention + entry fee",
+        inline=False,
+    )
+    embed.add_field(
+        name="Begin bracket",
+        value="`!rpsstart` — runs every match in order",
+        inline=False,
+    )
+    embed.add_field(
+        name="Help / settings",
+        value="`!rpshelp` · `!rpssettings`",
+        inline=False,
+    )
+    embed.set_footer(text="Click ◀ Overview to return to the RPS hub.")
+    return embed
+
+
+def build_rps_rules_embed() -> discord.Embed:
+    embed = discord.Embed(
+        title="✂️ RPS — Rules",
+        description=(
+            "Rock crushes Scissors, Scissors cut Paper, Paper covers "
+            "Rock. Identical throws are a draw and (in single-round) "
+            "stay scoreless; tournaments replay drawn rounds."
+        ),
+        color=GAME_COLOR,
+    )
+    embed.add_field(
+        name="Best-of",
+        value=(
+            "Tournament matches default to best-of-3 with a configurable "
+            "round count via `!rpssettings`."
+        ),
+        inline=False,
+    )
+    embed.add_field(
+        name="Stakes",
+        value=(
+            "Stakes matches (`!rps @user <bet>`) debit both sides at "
+            "match start; the winner takes the combined pot."
+        ),
+        inline=False,
+    )
+    embed.set_footer(text="Click ◀ Overview to return to the RPS hub.")
+    return embed
+
+
+class RPSPanelView(HubView):
+    """Router-only RPS hub.
+
+    No tournament state, no match orchestration, no replay logic.
+    """
+
+    SUBSYSTEM = "rps_tournament"
+
+    def __init__(self, author: discord.Member | discord.User) -> None:
+        super().__init__(author)
+
+    @discord.ui.button(
+        label="▶ Single Round",
+        style=discord.ButtonStyle.success,
+        custom_id="rps_panel:single",
+        row=0,
+    )
+    async def btn_single(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        await interaction.response.edit_message(
+            embed=build_rps_single_round_embed(),
+            view=self,
+        )
+
+    @discord.ui.button(
+        label="🏆 Tournament",
+        style=discord.ButtonStyle.primary,
+        custom_id="rps_panel:tournament",
+        row=0,
+    )
+    async def btn_tournament(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        await interaction.response.edit_message(
+            embed=build_rps_tournament_embed(),
+            view=self,
+        )
+
+    @discord.ui.button(
+        label="📖 Rules",
+        style=discord.ButtonStyle.secondary,
+        custom_id="rps_panel:rules",
+        row=0,
+    )
+    async def btn_rules(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        await interaction.response.edit_message(
+            embed=build_rps_rules_embed(),
+            view=self,
+        )
+
+    @discord.ui.button(
+        label="◀ Overview",
+        style=discord.ButtonStyle.secondary,
+        custom_id="rps_panel:overview",
+        row=1,
+    )
+    async def btn_overview(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        await interaction.response.edit_message(
+            embed=build_rps_overview_embed(),
+            view=self,
+        )

--- a/tests/unit/views/test_game_panels.py
+++ b/tests/unit/views/test_game_panels.py
@@ -1,0 +1,297 @@
+"""Phase 7 Option A — router-only Blackjack/RPS panel tests.
+
+Pins:
+
+* The panels contain only navigation/embed-swap logic — no game-engine
+  imports.
+* Each cog's ``build_help_menu_view`` now returns the new panel
+  (not an empty View as it did pre-Phase 7).
+* Practice / Replay / Best-of variants are not yet present — their
+  buttons should NOT exist; a re-introduction must be deliberate.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from views.games import blackjack_panel, rps_panel
+
+
+def _author(id_: int = 1) -> MagicMock:
+    member = MagicMock(spec=discord.Member)
+    member.id = id_
+    member.display_name = "Test"
+    return member
+
+
+def _interaction() -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = _author()
+    interaction.response = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    return interaction
+
+
+# ---------------------------------------------------------------------------
+# Module-level invariants — no game logic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "module_path",
+    [
+        Path(blackjack_panel.__file__),
+        Path(rps_panel.__file__),
+    ],
+    ids=["blackjack_panel", "rps_panel"],
+)
+def test_panel_modules_do_not_import_game_engines(module_path: Path):
+    """The panels are pure navigation. Importing the blackjack engine,
+    economy service, persistence, or tournament state from a panel
+    would mean game logic crept in.
+    """
+    src = module_path.read_text()
+    head = src.split("\ndef ", 1)[0]  # module-import section
+    forbidden = [
+        "blackjack_engine",
+        "economy_service",
+        "game_state_service",
+        "from cogs.blackjack._persistence",
+        "from cogs.blackjack._state",
+        "from cogs.rps_tournament._persistence",
+    ]
+    for token in forbidden:
+        assert token not in head, (
+            f"{module_path.name} imports game-engine token {token!r} at module "
+            f"load — Phase 7 Option A keeps panels router-only."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Blackjack panel — view shape
+# ---------------------------------------------------------------------------
+
+
+def test_blackjack_overview_embed_lists_modes_and_typed_shortcuts():
+    embed = blackjack_panel.build_blackjack_overview_embed()
+    title = (embed.title or "")
+    assert "Blackjack" in title
+    description = (embed.description or "") + "\n".join(
+        f.value for f in embed.fields
+    ) + (embed.footer.text or "")
+    assert "Classic" in description
+    assert "Rules" in description
+    assert "!blackjack" in description or "!bj" in description
+
+
+def test_blackjack_panel_buttons_are_classic_rules_overview_only():
+    view = blackjack_panel.BlackjackPanelView(_author())
+    custom_ids = {
+        c.custom_id
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+    }
+    assert custom_ids == {
+        "blackjack_panel:classic",
+        "blackjack_panel:rules",
+        "blackjack_panel:overview",
+    }
+
+
+def test_blackjack_panel_has_no_practice_or_replay_button_yet():
+    """Phase 7b is the place for Practice / Replay. Phase 7a panels
+    must not pre-leak those button labels.
+    """
+    view = blackjack_panel.BlackjackPanelView(_author())
+    labels = [
+        (c.label or "")
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+    ]
+    for token in ("Practice", "Replay", "Change Mode"):
+        assert not any(token in lbl for lbl in labels), (
+            f"BlackjackPanelView already exposes {token!r} — Phase 7b "
+            "should re-introduce these together with engine support."
+        )
+
+
+@pytest.mark.asyncio
+async def test_blackjack_classic_button_renders_classic_embed():
+    view = blackjack_panel.BlackjackPanelView(_author())
+    interaction = _interaction()
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+        and c.custom_id == "blackjack_panel:classic"
+    )
+    await btn.callback(interaction)  # type: ignore[union-attr,misc]
+    interaction.response.edit_message.assert_awaited_once()
+    _args, kwargs = interaction.response.edit_message.call_args
+    embed: discord.Embed = kwargs["embed"]
+    assert "Classic" in (embed.title or "")
+    rendered = "\n".join(f.value for f in embed.fields)
+    assert "!blackjack" in rendered or "!bj" in rendered
+
+
+@pytest.mark.asyncio
+async def test_blackjack_rules_button_renders_rules_embed():
+    view = blackjack_panel.BlackjackPanelView(_author())
+    interaction = _interaction()
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+        and c.custom_id == "blackjack_panel:rules"
+    )
+    await btn.callback(interaction)  # type: ignore[union-attr,misc]
+    interaction.response.edit_message.assert_awaited_once()
+    _args, kwargs = interaction.response.edit_message.call_args
+    embed: discord.Embed = kwargs["embed"]
+    assert "Rules" in (embed.title or "")
+    rendered = "\n".join(f.value for f in embed.fields)
+    assert "Hit" in rendered or "Stand" in rendered
+
+
+@pytest.mark.asyncio
+async def test_blackjack_overview_button_returns_to_overview():
+    view = blackjack_panel.BlackjackPanelView(_author())
+    interaction = _interaction()
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+        and c.custom_id == "blackjack_panel:overview"
+    )
+    await btn.callback(interaction)  # type: ignore[union-attr,misc]
+    _args, kwargs = interaction.response.edit_message.call_args
+    embed: discord.Embed = kwargs["embed"]
+    # Overview embed names "Modes" as a field; the detail embeds don't.
+    field_names = [f.name for f in embed.fields]
+    assert "Modes" in field_names
+
+
+# ---------------------------------------------------------------------------
+# RPS panel
+# ---------------------------------------------------------------------------
+
+
+def test_rps_overview_embed_lists_single_tournament_rules():
+    embed = rps_panel.build_rps_overview_embed()
+    rendered = (embed.description or "") + "\n".join(
+        f.value for f in embed.fields
+    ) + (embed.footer.text or "")
+    assert "Single Round" in rendered
+    assert "Tournament" in rendered
+    assert "Rules" in rendered
+    assert "!rps" in rendered
+
+
+def test_rps_panel_buttons_are_single_tournament_rules_overview():
+    view = rps_panel.RPSPanelView(_author())
+    custom_ids = {
+        c.custom_id
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+    }
+    assert custom_ids == {
+        "rps_panel:single",
+        "rps_panel:tournament",
+        "rps_panel:rules",
+        "rps_panel:overview",
+    }
+
+
+def test_rps_panel_has_no_replay_or_best_of_button_yet():
+    view = rps_panel.RPSPanelView(_author())
+    labels = [
+        (c.label or "")
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+    ]
+    for token in ("Replay", "Best of"):
+        assert not any(token in lbl for lbl in labels)
+
+
+@pytest.mark.asyncio
+async def test_rps_single_button_renders_single_embed():
+    view = rps_panel.RPSPanelView(_author())
+    interaction = _interaction()
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "rps_panel:single"
+    )
+    await btn.callback(interaction)  # type: ignore[union-attr,misc]
+    _args, kwargs = interaction.response.edit_message.call_args
+    embed: discord.Embed = kwargs["embed"]
+    assert "Single Round" in (embed.title or "")
+
+
+@pytest.mark.asyncio
+async def test_rps_tournament_button_renders_tournament_embed():
+    view = rps_panel.RPSPanelView(_author())
+    interaction = _interaction()
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+        and c.custom_id == "rps_panel:tournament"
+    )
+    await btn.callback(interaction)  # type: ignore[union-attr,misc]
+    _args, kwargs = interaction.response.edit_message.call_args
+    embed: discord.Embed = kwargs["embed"]
+    assert "Tournament" in (embed.title or "")
+    rendered = "\n".join(f.value for f in embed.fields)
+    assert "!rpsregister" in rendered or "!rpsstart" in rendered
+
+
+@pytest.mark.asyncio
+async def test_rps_rules_button_renders_rules_embed():
+    view = rps_panel.RPSPanelView(_author())
+    interaction = _interaction()
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "rps_panel:rules"
+    )
+    await btn.callback(interaction)  # type: ignore[union-attr,misc]
+    _args, kwargs = interaction.response.edit_message.call_args
+    embed: discord.Embed = kwargs["embed"]
+    assert "Rules" in (embed.title or "")
+
+
+# ---------------------------------------------------------------------------
+# Cog wiring — build_help_menu_view now returns the panel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_blackjack_cog_build_help_menu_view_returns_panel():
+    from cogs.blackjack_cog import BlackjackCog
+
+    cog = BlackjackCog(bot=MagicMock())
+    interaction = MagicMock()
+    interaction.user = _author()
+    embed, view = await cog.build_help_menu_view(interaction)
+    assert isinstance(view, blackjack_panel.BlackjackPanelView)
+    assert "Blackjack" in (embed.title or "")
+
+
+@pytest.mark.asyncio
+async def test_rps_cog_build_help_menu_view_returns_panel():
+    from cogs.rps_tournament_cog import RPSTournamentCog
+
+    cog = RPSTournamentCog(bot=MagicMock())
+    interaction = MagicMock()
+    interaction.user = _author()
+    embed, view = await cog.build_help_menu_view(interaction)
+    assert isinstance(view, rps_panel.RPSPanelView)
+    assert (
+        "Rock-Paper-Scissors" in (embed.title or "")
+        or "RPS" in (embed.title or "")
+    )


### PR DESCRIPTION
## Objective

Phase 7 **Option A** (per the user's explicit choice): router-only Blackjack and RPS hub panels. Makes the Games hub feel complete without touching game engines, economy hooks, or tournament state.

Practice / Replay / Best-of variants are explicitly deferred to **Phase 7b**, which needs a product + engine design call on:
- whether Practice uses `bet=0` or a separate no-economy path,
- whether Practice affects stats / leaderboards / tournaments,
- how `BlackjackView` exposes a post-game callback,
- how Replay avoids accidental double-charges.

Independent of #121 (Phase 5) and #123 (Phase 6.5a); starts from current `main`.

## Files changed

**New panels:**
- `disbot/views/games/blackjack_panel.py` *(new)* — `BlackjackPanelView` + overview/classic/rules embed builders.
- `disbot/views/games/rps_panel.py` *(new)* — `RPSPanelView` + overview/single/tournament/rules embed builders.

**Cog wiring:**
- `disbot/cogs/blackjack_cog.py` — `build_help_menu_view` returns `BlackjackPanelView`. Removed `stats_block` + `GAME_COLOR` imports (now dead).
- `disbot/cogs/rps_tournament_cog.py` — `build_help_menu_view` returns `RPSPanelView`. Same dead-import cleanup.

**Tests:**
- `tests/unit/views/test_game_panels.py` *(new, 16 tests)*.

## Panel surface

### BlackjackPanelView
| Button | Effect |
|---|---|
| ▶ Classic | Swap embed → typed-command instructions for `!blackjack <bet>` / `!bj <bet>` / `!blackjack @user <bet>` / `!bjtournament` |
| 📖 Rules | Swap embed → card values, hit/stand, blackjack/tie outcomes |
| ◀ Overview | Swap embed → back to the overview |

### RPSPanelView
| Button | Effect |
|---|---|
| ▶ Single Round | Swap embed → typed-command instructions for `!rps`, `!rps @user`, `!rps @user <bet>` |
| 🏆 Tournament | Swap embed → typed-command instructions for `!rpsregister`, `!rpsstart`, `!rpshelp`, `!rpssettings` |
| 📖 Rules | Swap embed → rule recap (rock/paper/scissors, best-of, stakes) |
| ◀ Overview | Swap embed → back to the overview |

Neither panel carries a built-in Back-to-Games or Back-to-Help button — that's added by the wrapping context (Games hub's `attach_back_to_games_button` or help_cog's `_attach_back_to_help_button`). Same convention as Counting hub, Mining hub, Games hub, etc.

## What this PR explicitly does NOT do (pinned by tests)

- **No game-engine imports in either panel.** A parametrised test scans both module sources for `blackjack_engine`, `economy_service`, `game_state_service`, `cogs.blackjack._persistence`, `cogs.blackjack._state`, `cogs.rps_tournament._persistence`. Any future import that crosses this line fails CI.
- **No Practice button.** A button-label scan asserts no label contains `Practice`, `Replay`, or `Change Mode` on BlackjackPanelView, and no `Replay` / `Best of` on RPSPanelView. Re-introducing those buttons is intentional — they'll be added together with the engine support in Phase 7b.
- No tournament-state duplication. The Tournament button shows typed commands; orchestration stays in `RPSTournamentCog`.
- No new commands. The entry points (`!blackjack`, `!bj`, `!bjtournament`, `!rps`, `!rpsregister`, `!rpsstart`, `!rpshelp`, `!rpssettings`) are unchanged.
- No economy effect — the panels never call `economy_service`.

## Tests run

| Suite | Result |
|---|---|
| `pytest tests/unit/views/test_game_panels.py` | **16 passed** |
| `pytest` (full suite) | **2107 passed**, 11 warnings, 24.17s |
| `black --check . --exclude '(\.github\|tests\|venv\|env\|build\|dist)'` | clean (266 files) |
| `isort --check-only . --skip-glob …` | clean |
| `ruff check . --exclude .github,tests,venv,env,build,dist` | clean |
| `python3.10 -m mypy disbot/` | **Success: no issues found in 267 source files** |

## Manual Discord smoke checklist

- [ ] Bot starts cleanly
- [ ] `!help` → Games → Blackjack opens the new panel
- [ ] Classic button shows typed-command embed
- [ ] Rules button shows the rules embed
- [ ] Overview returns to the panel overview embed
- [ ] Help-cog's "↩ Back to Help" appears at row 4 (added externally)
- [ ] Games hub's "↩ Back to Games" appears at row 4 (added externally) when opened via Games hub
- [ ] `!help` → Games → RPS opens the RPS panel
- [ ] Single Round / Tournament / Rules buttons each swap the embed
- [ ] `!blackjack`, `!bj`, `!bjtournament` still work as typed shortcuts (unchanged)
- [ ] `!rps`, `!rpsregister`, `!rpsstart`, `!rpshelp` still work as typed shortcuts (unchanged)
- [ ] No regression in tournament state, stake matches, or economy
- [ ] `!platform identity` reports no fatal findings

## Risks

- **Low.** The panels are pure presentation — they have no path that mutates state. The riskiest change is the `build_help_menu_view` swap: it now returns a view with three buttons instead of an empty View. Tests pin the new contract and both cogs still expose their original commands unchanged.

## Rollback plan

1. Revert this commit (five files).
2. `build_help_menu_view` returns to the prior `stats_block(...)` + empty View.
3. New panel modules are deleted by the revert.
4. No data migration; no schema change; no engine touch.

## Next recommended phase

**Phase 8 (a–e)** — Role, Economy, Proof, Inventory/Leaderboard, Channel panels. Each is a one-PR sub-phase that follows the same pattern (`<cog>PanelView`, `KNOWN_PANEL_COMMANDS` entry, `build_help_menu_view` exposure). Risk per sub-phase: low-medium. **Or** the deferred *Phase 7b* (Practice/Replay engine work) when product/engine decisions are ready.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TeXrWGdRyGEcukWEv1qryT)_