### PR TITLE
feat(logging): Routes subpage + `!logging routes` + per-route Set/Create (Phase 9b)

### DIFF
--- a/disbot/cogs/logging/panel.py
+++ b/disbot/cogs/logging/panel.py
@@ -160,6 +160,32 @@ class LoggingPanelView(HubView):
         await interaction.followup.send(msg, ephemeral=True)
 
     @discord.ui.button(
+        label="🗺️ Routes",
+        style=discord.ButtonStyle.blurple,
+        row=3,
+        custom_id="logging_panel.routes",
+    )
+    async def routes_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        """Open the Phase 9b Routes subpage for severity/audit channels."""
+        # Local import — routes_panel pulls in server_logging's route
+        # tables and the resolver, which we don't need at panel-load
+        # time.
+        from cogs.logging.routes_panel import (
+            LoggingRoutesView,
+            build_routes_embed,
+        )
+
+        if not await safe_defer(interaction):
+            return
+        view = LoggingRoutesView(interaction.user)
+        embed = await build_routes_embed(interaction.guild)
+        await safe_edit(interaction, embed=embed, view=view)
+
+    @discord.ui.button(
         label="↩ Overview",
         style=discord.ButtonStyle.secondary,
         row=4,

--- a/disbot/cogs/logging/provision_view.py
+++ b/disbot/cogs/logging/provision_view.py
@@ -24,14 +24,26 @@ import discord
 logger = logging.getLogger("bot.cogs.logging.provision_view")
 
 
+# Route tables — kept in sync with ``services.server_logging``'s
+# ``_ROUTE_TO_BINDING``. A consistency test pins them together.
 _KIND_TO_BINDING: dict[str, str] = {
     "mod": "mod_channel",
     "cleanup": "cleanup_channel",
+    "debug": "debug_channel",
+    "info": "info_channel",
+    "warning": "warning_channel",
+    "error": "error_channel",
+    "audit": "audit_channel",
 }
 
 _KIND_TO_LABEL: dict[str, str] = {
     "mod": "moderation log",
     "cleanup": "cleanup log",
+    "debug": "debug log",
+    "info": "info log",
+    "warning": "warning log",
+    "error": "error log",
+    "audit": "audit log",
 }
 
 

--- a/disbot/cogs/logging/routes_panel.py
+++ b/disbot/cogs/logging/routes_panel.py
@@ -1,0 +1,306 @@
+"""Phase 9b — LoggingPanelView Routes subpage.
+
+Adds a dense routes view showing all seven logging channel routes
+(``mod`` / ``cleanup`` / ``debug`` / ``info`` / ``warning`` / ``error``
+/ ``audit``), their current binding state, and per-route Set / Create
+controls. Reuses the existing :class:`cogs.logging.select_view.
+LogChannelSelectView` and :class:`cogs.logging.provision_view.
+LogChannelProvisionView` — those views already accept arbitrary ``kind``
+tokens after the Phase 9b table extension.
+
+The view itself contains zero mutation logic. Set routes through
+``BindingMutationPipeline`` via the existing select-view; Create
+routes through ``ResourceProvisioningPipeline`` via the existing
+provision-view. No counter buckets are added in this PR — that waits
+until Phase 9c when actual severity events flow.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import discord
+
+from core.runtime.interaction_helpers import safe_defer, safe_edit
+from utils.ui_constants import ADMIN_COLOR
+from views.base import HubView
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger("bot.cogs.logging.routes_panel")
+
+
+# Display order for the routes embed. Sources first, then severity,
+# then audit — mirrors the operator's typical mental model.
+_ROUTE_DISPLAY_ORDER: tuple[str, ...] = (
+    "mod",
+    "cleanup",
+    "debug",
+    "info",
+    "warning",
+    "error",
+    "audit",
+)
+
+
+async def _resolve_route_state(
+    guild: discord.Guild,
+    kind: str,
+) -> dict[str, object]:
+    """Resolve the current binding state for a route, without raising.
+
+    Returns a dict with:
+
+    * ``kind`` — the route token.
+    * ``binding_name`` — the underlying ``logging.<x>_channel`` name.
+    * ``channel`` — the resolved :class:`discord.TextChannel` or ``None``.
+    * ``source`` — ``"binding"`` if the route's own binding resolved,
+      ``"fallback"`` if it walked the fallback chain to mod, or
+      ``"unset"`` if nothing resolved.
+    """
+    from services.server_logging import (
+        _ROUTE_FALLBACK,
+        _ROUTE_TO_BINDING,
+        resolve_log_channel,
+    )
+
+    binding_name = _ROUTE_TO_BINDING.get(kind, "?")
+
+    # Try the route's own binding directly via the resolver. If it
+    # resolves to a channel, the source depends on whether the fallback
+    # chain kicked in. The cheapest accurate read: try the route, then
+    # try mod (the fallback target); if they match, it's a fallback.
+    try:
+        ch = await resolve_log_channel(guild, kind)
+    except Exception as exc:  # noqa: BLE001 — diagnostics must not raise
+        logger.warning("Routes panel: resolve_log_channel(%r) failed: %s", kind, exc)
+        return {
+            "kind": kind,
+            "binding_name": binding_name,
+            "channel": None,
+            "source": "error",
+        }
+    if ch is None:
+        return {
+            "kind": kind,
+            "binding_name": binding_name,
+            "channel": None,
+            "source": "unset",
+        }
+
+    fallback = _ROUTE_FALLBACK.get(kind)
+    if fallback is None or kind == "mod":
+        # No fallback for ``mod`` — if it resolved, it came from its own
+        # binding (or legacy scalar; we treat both as "binding" for the
+        # operator-facing display).
+        return {
+            "kind": kind,
+            "binding_name": binding_name,
+            "channel": ch,
+            "source": "binding",
+        }
+    try:
+        fallback_ch = await resolve_log_channel(guild, fallback)
+    except Exception:  # noqa: BLE001 — diagnostic only
+        fallback_ch = None
+    source = "fallback" if fallback_ch is ch else "binding"
+    return {
+        "kind": kind,
+        "binding_name": binding_name,
+        "channel": ch,
+        "source": source,
+    }
+
+
+async def build_routes_embed(guild: discord.Guild | None) -> discord.Embed:
+    """Build the read-only Routes overview embed."""
+    embed = discord.Embed(
+        title="🗺️ Logging Routes",
+        description=(
+            "Every logging route, its current binding, and where it "
+            "resolves today. Set / Create through the buttons below — "
+            "writes route through `BindingMutationPipeline` / "
+            "`ResourceProvisioningPipeline` and record an audit row."
+        ),
+        color=ADMIN_COLOR,
+    )
+    if guild is None:
+        embed.add_field(
+            name="No guild context",
+            value="This view requires a guild context to resolve channels.",
+            inline=False,
+        )
+        return embed
+
+    lines: list[str] = []
+    for kind in _ROUTE_DISPLAY_ORDER:
+        state = await _resolve_route_state(guild, kind)
+        ch = state["channel"]
+        source = state["source"]
+        binding = state["binding_name"]
+        mention = getattr(ch, "mention", None) if ch is not None else None
+        if source == "binding" and mention is not None:
+            marker = f"→ {mention}"
+        elif source == "fallback" and mention is not None:
+            marker = f"↪ {mention} *(via mod fallback)*"
+        elif source == "error":
+            marker = "⚠️ *(resolution error — see logs)*"
+        else:
+            marker = "*(unset)*"
+        lines.append(f"**`{kind}`** ・ `logging.{binding}` {marker}")
+    embed.add_field(
+        name="Routes",
+        value="\n".join(lines),
+        inline=False,
+    )
+    embed.set_footer(
+        text=(
+            "Pick a route below, then Set Channel or Create Channel. "
+            "Routes without their own binding fall back to the mod channel."
+        ),
+    )
+    return embed
+
+
+class _RouteSelect(discord.ui.Select):
+    """Single-select listing all seven routes."""
+
+    def __init__(self, selected: str | None) -> None:
+        options: list[discord.SelectOption] = []
+        for kind in _ROUTE_DISPLAY_ORDER:
+            options.append(
+                discord.SelectOption(
+                    label=kind,
+                    value=kind,
+                    default=(kind == selected),
+                ),
+            )
+        super().__init__(
+            placeholder="Choose a route…",
+            min_values=1,
+            max_values=1,
+            options=options,
+            custom_id="logging_routes.select",
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        if not isinstance(view, LoggingRoutesView):
+            return
+        view.selected_kind = self.values[0]
+        # Rebuild the select so ``default=`` tracks current state.
+        view._rebuild_select()
+        if not await safe_defer(interaction):
+            return
+        embed = await build_routes_embed(interaction.guild)
+        await safe_edit(interaction, embed=embed, view=view)
+
+
+class LoggingRoutesView(HubView):
+    """Phase 9b — Routes subpage on top of LoggingPanelView."""
+
+    SUBSYSTEM = "logging"
+
+    def __init__(self, author: discord.Member | discord.User) -> None:
+        super().__init__(author)
+        self.selected_kind: str | None = None
+        self.add_item(_RouteSelect(self.selected_kind))
+
+    def _rebuild_select(self) -> None:
+        """Re-add the select so its ``default=`` tracks current state."""
+        for child in list(self.children):
+            if isinstance(child, discord.ui.Select) and child.custom_id == (
+                "logging_routes.select"
+            ):
+                self.remove_item(child)
+        self.add_item(_RouteSelect(self.selected_kind))
+
+    async def _require_route(
+        self,
+        interaction: discord.Interaction,
+    ) -> str | None:
+        if self.selected_kind is None:
+            await interaction.response.send_message(
+                "Pick a route from the dropdown first.",
+                ephemeral=True,
+            )
+            return None
+        return self.selected_kind
+
+    @discord.ui.button(
+        label="🔗 Set Channel",
+        style=discord.ButtonStyle.blurple,
+        row=1,
+        custom_id="logging_routes.set",
+    )
+    async def btn_set(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        kind = await self._require_route(interaction)
+        if kind is None:
+            return
+        # Local import — keeps the heavy view module out of import time.
+        from cogs.logging.panel import _open_select
+
+        await _open_select(interaction, kind=kind)
+
+    @discord.ui.button(
+        label="🆕 Create Channel",
+        style=discord.ButtonStyle.success,
+        row=1,
+        custom_id="logging_routes.create",
+    )
+    async def btn_create(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        kind = await self._require_route(interaction)
+        if kind is None:
+            return
+        from cogs.logging.panel import _open_provision
+
+        await _open_provision(interaction, kind=kind)
+
+    @discord.ui.button(
+        label="🔄 Refresh",
+        style=discord.ButtonStyle.secondary,
+        row=1,
+        custom_id="logging_routes.refresh",
+    )
+    async def btn_refresh(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        if not await safe_defer(interaction):
+            return
+        embed = await build_routes_embed(interaction.guild)
+        await safe_edit(interaction, embed=embed, view=self)
+
+    @discord.ui.button(
+        label="↩ Back to Logging",
+        style=discord.ButtonStyle.secondary,
+        row=4,
+        custom_id="logging_routes.back",
+    )
+    async def btn_back(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        from cogs.logging.panel import LoggingPanelView, build_panel_embed
+
+        if not await safe_defer(interaction):
+            return
+        view = LoggingPanelView(self._author)
+        embed = await build_panel_embed(interaction.guild)
+        await safe_edit(interaction, embed=embed, view=view)
+
+
+__all__ = ["LoggingRoutesView", "build_routes_embed"]

--- a/disbot/cogs/logging/select_view.py
+++ b/disbot/cogs/logging/select_view.py
@@ -27,14 +27,27 @@ from core.runtime.subsystem_schema import BindingKind
 logger = logging.getLogger("bot.cogs.logging.select_view")
 
 
+# Route tables — kept in sync with ``services.server_logging``'s
+# ``_ROUTE_TO_BINDING``. A consistency test pins them together.
 _KIND_TO_BINDING: dict[str, str] = {
     "mod": "mod_channel",
     "cleanup": "cleanup_channel",
+    # Phase 9a routes — accept the new severity/audit kinds.
+    "debug": "debug_channel",
+    "info": "info_channel",
+    "warning": "warning_channel",
+    "error": "error_channel",
+    "audit": "audit_channel",
 }
 
 _KIND_TO_LABEL: dict[str, str] = {
     "mod": "moderation log",
     "cleanup": "cleanup log",
+    "debug": "debug log",
+    "info": "info log",
+    "warning": "warning log",
+    "error": "error log",
+    "audit": "audit log",
 }
 
 

--- a/disbot/cogs/logging_cog.py
+++ b/disbot/cogs/logging_cog.py
@@ -128,11 +128,18 @@ class LoggingCog(commands.Cog):
         """Open the channel-select view for ``mod`` or ``cleanup`` binding."""
         from cogs.logging.select_view import LogChannelSelectView
 
+        # Phase 9b: accept any of the seven routes (mod / cleanup /
+        # debug / info / warning / error / audit). The set is sourced
+        # from ``services.server_logging._ROUTE_TO_BINDING`` so adding
+        # a new route there propagates automatically.
+        from services.server_logging import _ROUTE_TO_BINDING
+
         kind = kind.strip().lower()
-        if kind not in ("mod", "cleanup"):
+        valid_kinds = sorted(_ROUTE_TO_BINDING.keys())
+        if kind not in valid_kinds:
             await ctx.send(
-                "Usage: `!logging set <mod|cleanup>` — opens the channel "
-                "selector for the requested log binding.",
+                f"Usage: `!logging set <{'|'.join(valid_kinds)}>` — opens "
+                "the channel selector for the requested log binding.",
                 delete_after=20,
             )
             return
@@ -155,17 +162,19 @@ class LoggingCog(commands.Cog):
     @logging_grp.command(name="create")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def logging_create(self, ctx: commands.Context, kind: str = "") -> None:
-        """Preview + create a new log channel for ``mod`` or ``cleanup``."""
+        """Preview + create a new log channel for any registered route."""
         from cogs.logging.provision_view import (
             LogChannelProvisionView,
             build_preview_embed,
         )
+        from services.server_logging import _ROUTE_TO_BINDING
 
         kind = kind.strip().lower()
-        if kind not in ("mod", "cleanup"):
+        valid_kinds = sorted(_ROUTE_TO_BINDING.keys())
+        if kind not in valid_kinds:
             await ctx.send(
-                "Usage: `!logging create <mod|cleanup>` — opens a "
-                "preview + Confirm view for the requested channel.",
+                f"Usage: `!logging create <{'|'.join(valid_kinds)}>` — opens "
+                "a preview + Confirm view for the requested channel.",
                 delete_after=20,
             )
             return
@@ -178,6 +187,26 @@ class LoggingCog(commands.Cog):
         preview_embed, allowed = await build_preview_embed(ctx.guild, kind)
         view = LogChannelProvisionView(ctx.author, kind, confirm_enabled=allowed)
         await ctx.send(embed=preview_embed, view=view)
+
+    @logging_grp.command(name="routes")  # type: ignore[arg-type]
+    @commands.has_permissions(administrator=True)
+    async def logging_routes(self, ctx: commands.Context) -> None:
+        """Open the Phase 9b Routes subpage directly.
+
+        Mirrors the LoggingPanelView Routes button — shows every
+        configured route (mod / cleanup / debug / info / warning /
+        error / audit), its current binding, and Set / Create
+        controls per route.
+        """
+        from cogs.logging.routes_panel import (
+            LoggingRoutesView,
+            build_routes_embed,
+        )
+        from views.base import send_panel
+
+        view = LoggingRoutesView(ctx.author)
+        embed = await build_routes_embed(ctx.guild)
+        await send_panel(ctx, embed=embed, view=view)
 
     @logging_grp.command(name="test")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)

--- a/tests/unit/cogs/test_logging_panel.py
+++ b/tests/unit/cogs/test_logging_panel.py
@@ -55,11 +55,13 @@ def _find_button(view: discord.ui.View, label_substr: str) -> discord.ui.Button:
 # ---------------------------------------------------------------------------
 
 
-def test_panel_view_has_seven_buttons_across_five_rows():
+def test_panel_view_has_eight_buttons_across_five_rows():
+    """Phase 9b added a Routes button alongside Test at row 3."""
     view = LoggingPanelView(_author())
     buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
-    # Refresh, Set Mod, Set Cleanup, Create Mod, Create Cleanup, Test, Overview.
-    assert len(buttons) == 7
+    # Refresh, Set Mod, Set Cleanup, Create Mod, Create Cleanup, Test,
+    # Routes (new in 9b), Overview.
+    assert len(buttons) == 8
     rows = sorted({b.row for b in buttons})
     assert rows == [0, 1, 2, 3, 4]
 

--- a/tests/unit/cogs/test_logging_routes_panel.py
+++ b/tests/unit/cogs/test_logging_routes_panel.py
@@ -1,0 +1,314 @@
+"""Phase 9b tests — LoggingRoutesView + cog wiring + table consistency.
+
+Covers:
+
+* The routes embed renders all seven routes (mod / cleanup / debug /
+  info / warning / error / audit) with their current binding state
+  surfaced (own binding / mod fallback / unset).
+* The view exposes a single route select + Set / Create / Refresh /
+  Back action buttons.
+* Set / Create with no route selected sends an ephemeral and does not
+  open a sub-view.
+* Set / Create after a route is chosen delegates to the existing
+  ``_open_select`` / ``_open_provision`` helpers with the right kind.
+* The route tables in ``server_logging`` and the two view modules
+  stay in sync — a future edit that adds a route to one but not the
+  others fails this consistency test.
+* ``LoggingPanelView`` now exposes a Routes button.
+* The ``!logging routes`` subcommand is registered.
+* ``!logging set`` and ``!logging create`` now accept all seven kinds.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from cogs.logging.routes_panel import (
+    _ROUTE_DISPLAY_ORDER,
+    LoggingRoutesView,
+    build_routes_embed,
+)
+
+
+def _author(id_: int = 7) -> MagicMock:
+    member = MagicMock(spec=discord.Member)
+    member.id = id_
+    member.display_name = "Op"
+    return member
+
+
+def _guild() -> MagicMock:
+    g = MagicMock(spec=discord.Guild)
+    g.id = 42
+    return g
+
+
+def _interaction() -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = _author()
+    interaction.guild = _guild()
+    interaction.guild_id = 42
+    interaction.channel = MagicMock()
+    interaction.client = MagicMock()
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+# ---------------------------------------------------------------------------
+# Route-table consistency — pin that the three tables agree.
+# ---------------------------------------------------------------------------
+
+
+def test_route_tables_are_in_sync_across_modules():
+    """A future edit must update all three tables together or fail this test."""
+    from cogs.logging.provision_view import (
+        _KIND_TO_BINDING as PROVISION_KIND_TO_BINDING,
+    )
+    from cogs.logging.select_view import _KIND_TO_BINDING as SELECT_KIND_TO_BINDING
+    from services.server_logging import _ROUTE_TO_BINDING
+
+    assert set(_ROUTE_TO_BINDING) == set(SELECT_KIND_TO_BINDING)
+    assert set(_ROUTE_TO_BINDING) == set(PROVISION_KIND_TO_BINDING)
+    for k in _ROUTE_TO_BINDING:
+        assert _ROUTE_TO_BINDING[k] == SELECT_KIND_TO_BINDING[k]
+        assert _ROUTE_TO_BINDING[k] == PROVISION_KIND_TO_BINDING[k]
+
+
+def test_route_display_order_covers_every_route():
+    """The Routes embed render-order must include every known route."""
+    from services.server_logging import _ROUTE_TO_BINDING
+
+    assert set(_ROUTE_DISPLAY_ORDER) == set(_ROUTE_TO_BINDING)
+
+
+# ---------------------------------------------------------------------------
+# Routes embed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_routes_embed_lists_every_route():
+    guild = _guild()
+    with patch(
+        "services.server_logging.resolve_log_channel",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        embed = await build_routes_embed(guild)
+    routes_field = next(f for f in embed.fields if f.name == "Routes")
+    for kind in _ROUTE_DISPLAY_ORDER:
+        assert f"`{kind}`" in routes_field.value
+
+
+@pytest.mark.asyncio
+async def test_routes_embed_marks_unset_routes():
+    guild = _guild()
+    with patch(
+        "services.server_logging.resolve_log_channel",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        embed = await build_routes_embed(guild)
+    routes_field = next(f for f in embed.fields if f.name == "Routes")
+    assert "unset" in routes_field.value
+
+
+@pytest.mark.asyncio
+async def test_routes_embed_when_no_guild_context():
+    embed = await build_routes_embed(None)
+    field_names = [f.name for f in embed.fields]
+    assert "No guild context" in field_names
+
+
+# ---------------------------------------------------------------------------
+# View shape
+# ---------------------------------------------------------------------------
+
+
+def test_view_has_one_select_and_four_buttons():
+    view = LoggingRoutesView(_author())
+    selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
+    buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+    assert len(selects) == 1
+    assert len(buttons) == 4
+
+
+def test_view_button_custom_ids():
+    view = LoggingRoutesView(_author())
+    custom_ids = {
+        c.custom_id  # type: ignore[attr-defined]
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+    }
+    assert custom_ids == {
+        "logging_routes.set",
+        "logging_routes.create",
+        "logging_routes.refresh",
+        "logging_routes.back",
+    }
+
+
+def test_view_initial_state_no_route_selected():
+    view = LoggingRoutesView(_author())
+    assert view.selected_kind is None
+
+
+# ---------------------------------------------------------------------------
+# Action buttons — guarded by selected_kind
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_without_route_selected_sends_ephemeral():
+    view = LoggingRoutesView(_author())
+    interaction = _interaction()
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "logging_routes.set"
+    )
+    await btn.callback(interaction)  # type: ignore[union-attr,misc]
+    interaction.response.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_create_without_route_selected_sends_ephemeral():
+    view = LoggingRoutesView(_author())
+    interaction = _interaction()
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "logging_routes.create"
+    )
+    await btn.callback(interaction)  # type: ignore[union-attr,misc]
+    interaction.response.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_set_delegates_to_open_select_with_chosen_kind():
+    view = LoggingRoutesView(_author())
+    view.selected_kind = "error"
+    interaction = _interaction()
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "logging_routes.set"
+    )
+    with patch(
+        "cogs.logging.panel._open_select", new_callable=AsyncMock
+    ) as fake_open:
+        await btn.callback(interaction)  # type: ignore[union-attr,misc]
+    fake_open.assert_awaited_once()
+    _args, kwargs = fake_open.call_args
+    assert kwargs["kind"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_create_delegates_to_open_provision_with_chosen_kind():
+    view = LoggingRoutesView(_author())
+    view.selected_kind = "audit"
+    interaction = _interaction()
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "logging_routes.create"
+    )
+    with patch(
+        "cogs.logging.panel._open_provision", new_callable=AsyncMock
+    ) as fake_open:
+        await btn.callback(interaction)  # type: ignore[union-attr,misc]
+    fake_open.assert_awaited_once()
+    _args, kwargs = fake_open.call_args
+    assert kwargs["kind"] == "audit"
+
+
+@pytest.mark.asyncio
+async def test_back_button_returns_to_logging_panel():
+    view = LoggingRoutesView(_author())
+    interaction = _interaction()
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "logging_routes.back"
+    )
+    with patch(
+        "cogs.logging.panel.build_panel_embed",
+        new_callable=AsyncMock,
+        return_value=discord.Embed(title="Logging"),
+    ):
+        await btn.callback(interaction)  # type: ignore[union-attr,misc]
+    # safe_edit on the interaction was reached.
+    # We don't assert on response.edit_message directly because safe_edit
+    # uses interaction.edit_original_response after defer; the key signal
+    # is no crash and no ephemeral.
+    interaction.response.send_message.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# LoggingPanelView Routes button
+# ---------------------------------------------------------------------------
+
+
+def test_logging_panel_has_routes_button():
+    from cogs.logging.panel import LoggingPanelView
+
+    view = LoggingPanelView(_author())
+    custom_ids = {
+        c.custom_id  # type: ignore[attr-defined]
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+    }
+    assert "logging_panel.routes" in custom_ids
+
+
+# ---------------------------------------------------------------------------
+# Cog wiring — !logging routes / set / create accept all seven kinds
+# ---------------------------------------------------------------------------
+
+
+def test_logging_routes_subcommand_registered():
+    from cogs.logging_cog import LoggingCog
+
+    sub = LoggingCog.logging_grp.get_command("routes")
+    assert sub is not None
+    assert sub.name == "routes"
+
+
+def test_logging_set_and_create_subcommands_still_registered():
+    """Existing subcommands must not regress."""
+    from cogs.logging_cog import LoggingCog
+
+    assert LoggingCog.logging_grp.get_command("set") is not None
+    assert LoggingCog.logging_grp.get_command("create") is not None
+
+
+def test_logging_set_source_references_route_table():
+    """A future addition to the route table should automatically be
+    accepted by ``!logging set`` (no per-route allowlist in the cog).
+    """
+    import inspect
+
+    from cogs.logging_cog import LoggingCog
+
+    src = inspect.getsource(LoggingCog.logging_set.callback)
+    # The set subcommand reads ``_ROUTE_TO_BINDING`` rather than
+    # hard-coding ``("mod", "cleanup")`` — pin the indirection.
+    assert "_ROUTE_TO_BINDING" in src
+
+
+def test_logging_create_source_references_route_table():
+    import inspect
+
+    from cogs.logging_cog import LoggingCog
+
+    src = inspect.getsource(LoggingCog.logging_create.callback)
+    assert "_ROUTE_TO_BINDING" in src


### PR DESCRIPTION
## Objective

**Phase 9b** — Routes UI on top of Phase 9a's schema + resolver foundation. Adds a `LoggingRoutesView` subpage to `LoggingPanelView`, parameterises the existing `LogChannelSelectView` / `LogChannelProvisionView` to accept all seven routes, and ships a `!logging routes` subcommand.

This is the second of three Phase 9 sub-PRs. Phase 9c (publisher callsites + bus subscribers + per-route counter buckets) remains deferred — the audit confirmed `runtime.error_raised`, `runtime.warning_emitted`, and `audit.action_recorded` aren't emitted anywhere today, so adding subscribers without publishers would be dead code.

## Files changed

| File | Change |
|---|---|
| `disbot/cogs/logging/routes_panel.py` *(new, ~280 lines)* | `LoggingRoutesView` + `build_routes_embed` + state resolver. |
| `disbot/cogs/logging/panel.py` | Routes button at row 3 (+24 lines). |
| `disbot/cogs/logging/select_view.py` | `_KIND_TO_BINDING` / `_KIND_TO_LABEL` extended to all 7 routes (+11 lines). |
| `disbot/cogs/logging/provision_view.py` | Same expansion (+11 lines). |
| `disbot/cogs/logging_cog.py` | `!logging routes` subcommand; `!logging set` / `!logging create` now source their kind list from `_ROUTE_TO_BINDING` (~40 lines). |
| `tests/unit/cogs/test_logging_routes_panel.py` *(new)* | 18 new tests. |
| `tests/unit/cogs/test_logging_panel.py` | One existing button-count test updated (7 → 8 buttons). |

## UX

| Action | Effect |
|---|---|
| `!logging` panel → 🗺️ Routes | Opens the Routes subpage in place. |
| `!logging routes` | Opens the same Routes subpage directly. |
| Route select (row 0) | Pick from 7 routes: mod / cleanup / debug / info / warning / error / audit. |
| 🔗 Set Channel | Delegates to existing `LogChannelSelectView` for the selected route. |
| 🆕 Create Channel | Delegates to existing `LogChannelProvisionView` (preview + Confirm) for the selected route. |
| 🔄 Refresh | Re-resolves and re-renders the Routes embed. |
| ↩ Back to Logging | Returns to `LoggingPanelView` overview. |

The Routes embed shows each route with its current state:

```
mod      ・ logging.mod_channel     → #mod-log
cleanup  ・ logging.cleanup_channel ↪ #mod-log (via mod fallback)
debug    ・ logging.debug_channel   (unset)
info     ・ logging.info_channel    (unset)
warning  ・ logging.warning_channel ↪ #mod-log (via mod fallback)
error    ・ logging.error_channel   → #error-log
audit    ・ logging.audit_channel   (unset)
```

`→` = route has its own binding. `↪` = route's binding is unset but the mod fallback resolves. `(unset)` = nothing resolves.

## Hard contracts (pinned by tests)

- The three route tables (`services.server_logging._ROUTE_TO_BINDING`, `cogs.logging.select_view._KIND_TO_BINDING`, `cogs.logging.provision_view._KIND_TO_BINDING`) stay in sync. A future edit that adds a route to one but not the others fails `test_route_tables_are_in_sync_across_modules`.
- `_ROUTE_DISPLAY_ORDER` covers every route in `_ROUTE_TO_BINDING`.
- `!logging set` and `!logging create` source their valid-kind list from `_ROUTE_TO_BINDING` (inspect-pinned) rather than hard-coding `("mod", "cleanup")`.
- All four Routes-view buttons are present with the expected custom_ids.

## What this PR explicitly does NOT do (deferred to Phase 9c)

- Publisher callsites for `runtime.error_raised`, `runtime.warning_emitted`, `audit.action_recorded`.
- Bus subscribers for the above topics.
- Per-route counter buckets — adding them now would create buckets that always read zero, which is noise rather than signal. They land when subscribers exist to populate them.

## Tests run

| Suite | Result |
|---|---|
| `pytest tests/unit/cogs/test_logging_routes_panel.py` | **18 passed** (new file) |
| `pytest tests/unit/cogs/test_logging_panel.py` | **all passed** (1 existing test updated to count 8 buttons) |
| `pytest tests/unit/services/test_server_logging.py tests/unit/cogs/test_logging_schemas.py` | passes — Phase 9a contracts unaffected |
| `pytest` (full suite) | **2182 passed**, 11 warnings, 24.46s |
| `black --check . --exclude '(\.github\|tests\|venv\|env\|build\|dist)'` | clean (270 files) |
| `isort --check-only . --skip-glob …` | clean |
| `ruff check . --exclude .github,tests,venv,env,build,dist` | clean |
| `python3.10 -m mypy disbot/` | **Success: no issues found in 271 source files** |

## Manual Discord smoke checklist

- [ ] Bot starts cleanly
- [ ] `!logging` opens the panel
- [ ] 🗺️ Routes button opens the Routes subpage
- [ ] Routes embed lists all 7 routes (mod / cleanup / debug / info / warning / error / audit)
- [ ] Each route shows correct state — own binding `→`, fallback `↪`, or `(unset)`
- [ ] Pick a route → "Set Channel" opens the channel-select ephemeral
- [ ] Pick a route → "Create Channel" opens the provision preview
- [ ] Pre-existing `!logging set mod` still works
- [ ] New `!logging set error` opens the error-channel select
- [ ] New `!logging create audit` opens the `bot-audit-log` preview
- [ ] `!logging routes` opens the Routes subpage directly
- [ ] "Back to Logging" returns to the panel overview
- [ ] `!platform identity` reports no fatal findings

## Risks

- **Medium-low.** No mutation logic is added by this PR — every action delegates to the existing audited pipelines (`BindingMutationPipeline` / `ResourceProvisioningPipeline`) that have shipped since S7b. The only "behaviour change" is that `!logging set <kind>` and `!logging create <kind>` now accept five additional kinds; the previous two-kind allowlist would have rejected them with a usage message, so any guild that wasn't using them is unaffected.

## Rollback plan

1. Revert the commit (seven files).
2. The Routes button and `!logging routes` subcommand go away.
3. `!logging set` / `!logging create` return to accepting `mod` / `cleanup` only.
4. The Phase 9a schema + resolver are unaffected.
5. No data migration; no DB writes touched.

## Next recommended phase

After this PR merges, the next safe step is **Phase 9c**:

1. Decide where `runtime.error_raised`, `runtime.warning_emitted`, `audit.action_recorded` should be published from (likely the existing error handlers + audit-table writers).
2. Add the publish callsites + register them in `events_catalogue.py`'s `KNOWN_EVENTS`.
3. Subscribe `server_logging` to the new topics; route to the appropriate channel via `resolve_log_channel(guild, severity)`.
4. Add per-route counter buckets.

Phase 9c needs the publish-strategy decision before implementation. I will not start Phase 9c without explicit direction.

Alternative low-friction follow-ups after 9b merges:
- **Phase 3.5** — Extract the shared `attach_back_to_*` helper now that four call sites exist.
- **Phase 10** — Slash front doors (thin `/help` / `/games` / `/cleanup` / `/platform` / `/settings` / `/logging` wrappers).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TeXrWGdRyGEcukWEv1qryT)_