### PR TITLE
feat(logging): audit.action_recorded pilot — publisher + subscriber + audit channel route (Phase 9c.1)

### DIFF
--- a/disbot/core/events_catalogue.py
+++ b/disbot/core/events_catalogue.py
@@ -84,6 +84,15 @@ KNOWN_EVENTS: frozenset[str] = frozenset(
         "feature_flags.changed",
         "rollout.advanced",
         "environment_tier.changed",
+        # ── Audit (Phase 9c.1 — server_logging consumer) ──────────────────
+        # Generic per-mutation audit signal emitted alongside each
+        # pipeline's domain-specific event. Payload contract: see
+        # ``services.server_logging._on_audit_action`` docstring.
+        # Server_logging subscribes and routes to ``logging.audit_channel``
+        # (falls back to ``mod_channel`` via the Phase 9a route table).
+        # Other consumers (future audit dashboards, AI explainers) are
+        # welcome to subscribe; subscriber failure is logged + swallowed.
+        "audit.action_recorded",
         # ── Participation (services/participation_mutation.py, Phase 2c PR-9) ─
         # Advisory.  Cache invalidation is inline (synchronous w.r.t. the
         # mutation result), NOT event-driven — these events are for

--- a/disbot/services/rollout_mutation.py
+++ b/disbot/services/rollout_mutation.py
@@ -65,6 +65,13 @@ EVT_FEATURE_FLAGS_CHANGED = "feature_flags.changed"
 EVT_ROLLOUT_ADVANCED = "rollout.advanced"
 EVT_ENVIRONMENT_TIER_CHANGED = "environment_tier.changed"
 
+# Phase 9c.1 — generic audit signal emitted alongside each
+# pipeline-specific event. The payload contract is documented in
+# ``services.server_logging._on_audit_action`` so audit consumers
+# (server_logging, future audit dashboards) can subscribe via the
+# topic name without coupling to RolloutMutationPipeline internals.
+EVT_AUDIT_ACTION_RECORDED = "audit.action_recorded"
+
 # ---------------------------------------------------------------------------
 # Recognized literal sets (mirror migration 023 / 024 / 025 CHECK constraints)
 # ---------------------------------------------------------------------------
@@ -494,7 +501,13 @@ async def _emit_feature_flag_event(
     actor_type: str,
     committed_at: datetime,
 ) -> bool:
-    """Emit feature_flags.changed.  Returns False on emission failure."""
+    """Emit feature_flags.changed + audit.action_recorded.
+
+    Returns False on feature_flags.changed emission failure. Audit
+    emission failure is logged independently and does not affect the
+    feature-flags return — pipeline-specific consumers receive their
+    event regardless of audit-channel reachability.
+    """
     from core.events import bus
 
     try:
@@ -515,6 +528,77 @@ async def _emit_feature_flag_event(
             "RolloutMutationPipeline: feature_flags.changed emission failed "
             "for mutation_id=%s; DB state is correct, event lost.",
             mutation_id,
+        )
+        return False
+
+    # Phase 9c.1 — companion audit event for the generic audit
+    # consumer (server_logging). Emission failure here is independent
+    # of the feature-flags event success.
+    await _emit_audit_event(
+        mutation_id=mutation_id,
+        subsystem="logging",
+        mutation_type="set_flag_state",
+        target=f"flag:{flag_name}",
+        scope=scope,
+        guild_id=guild_id,
+        prev_value=prev_state,
+        new_value=new_state,
+        actor_id=actor_id,
+        actor_type=actor_type,
+        committed_at=committed_at,
+    )
+    return True
+
+
+async def _emit_audit_event(
+    *,
+    mutation_id: str,
+    subsystem: str,
+    mutation_type: str,
+    target: str,
+    scope: Scope | str,
+    guild_id: int | None,
+    prev_value: str | None,
+    new_value: str | None,
+    actor_id: int | None,
+    actor_type: str,
+    committed_at: datetime,
+) -> bool:
+    """Emit ``audit.action_recorded`` for a single mutation.
+
+    Phase 9c.1 — generic audit-trail event consumed by
+    ``services.server_logging`` and routed to ``logging.audit_channel``
+    (with mod fallback via the Phase 9a route table). Other consumers
+    (future audit dashboards) are welcome to subscribe.
+
+    Failure-safe: emission failure is logged with ``exc_info=True`` and
+    swallowed. DB state is authoritative; a dropped event is non-fatal.
+    """
+    from core.events import bus
+
+    try:
+        await bus.emit(
+            EVT_AUDIT_ACTION_RECORDED,
+            mutation_id=mutation_id,
+            subsystem=subsystem,
+            mutation_type=mutation_type,
+            target=target,
+            scope=scope,
+            guild_id=guild_id,
+            prev_value=prev_value,
+            new_value=new_value,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            occurred_at=committed_at.isoformat(),
+        )
+    except Exception:
+        logger.exception(
+            "audit.action_recorded emission failed for "
+            "mutation_id=%s (subsystem=%s, type=%s); DB state is correct, "
+            "event lost.",
+            mutation_id,
+            subsystem,
+            mutation_type,
         )
         return False
     return True
@@ -550,6 +634,21 @@ async def _emit_rollout_event(
             mutation_id,
         )
         return False
+
+    # Phase 9c.1 — companion audit emit. Rollout percent is global.
+    await _emit_audit_event(
+        mutation_id=mutation_id,
+        subsystem="logging",
+        mutation_type="set_rollout_percent",
+        target=f"flag:{flag_name}",
+        scope="global",
+        guild_id=None,
+        prev_value=str(prev_percent) if prev_percent is not None else None,
+        new_value=str(new_percent),
+        actor_id=actor_id,
+        actor_type=actor_type,
+        committed_at=committed_at,
+    )
     return True
 
 
@@ -583,6 +682,21 @@ async def _emit_environment_tier_event(
             mutation_id,
         )
         return False
+
+    # Phase 9c.1 — companion audit emit. Environment tier is guild-scoped.
+    await _emit_audit_event(
+        mutation_id=mutation_id,
+        subsystem="logging",
+        mutation_type="set_environment_tier",
+        target=f"guild:{guild_id}",
+        scope="guild",
+        guild_id=guild_id,
+        prev_value=prev_tier,
+        new_value=new_tier,
+        actor_id=actor_id,
+        actor_type=actor_type,
+        committed_at=committed_at,
+    )
     return True
 
 
@@ -592,6 +706,7 @@ def _now_utc() -> datetime:
 
 
 __all__ = [
+    "EVT_AUDIT_ACTION_RECORDED",
     "EVT_ENVIRONMENT_TIER_CHANGED",
     "EVT_FEATURE_FLAGS_CHANGED",
     "EVT_ROLLOUT_ADVANCED",

--- a/disbot/services/server_logging.py
+++ b/disbot/services/server_logging.py
@@ -48,6 +48,12 @@ from utils.settings_keys import logging as _log_keys
 logger = logging.getLogger("bot.server_logging")
 
 EVT_MOD_ACTION = "moderation.action_taken"
+# Phase 9c.1 — subscribe to the generic audit-trail event emitted by
+# mutation pipelines. RolloutMutationPipeline is the pilot publisher;
+# other pipelines (SettingsMutationPipeline, BindingMutationPipeline,
+# ResourceProvisioningPipeline, GovernanceMutationPipeline) add their
+# audit emits in Phase 9c.2.
+EVT_AUDIT_ACTION_RECORDED = "audit.action_recorded"
 
 # ---------------------------------------------------------------------------
 # Counters (module-level; reset only via _reset_for_tests)
@@ -63,6 +69,10 @@ _COUNTERS: dict[str, int] = {
     "send_error": 0,
     "auto_create_error": 0,
     "subscriber_errors": 0,
+    # Phase 9c.1 — per-route bucket for the audit subscriber. Other
+    # route buckets (debug_sent / info_sent / warning_sent / error_sent)
+    # land alongside their respective subscribers in Phase 9c.3/9c.4.
+    "audit_sent": 0,
 }
 
 
@@ -74,7 +84,7 @@ def counters_snapshot() -> dict[str, Any]:
     """Stable counter snapshot for diagnostics consumers."""
     return {
         "counters": dict(_COUNTERS),
-        "subscribed_events": [EVT_MOD_ACTION],
+        "subscribed_events": [EVT_MOD_ACTION, EVT_AUDIT_ACTION_RECORDED],
     }
 
 
@@ -470,6 +480,199 @@ async def log_event(
     return True
 
 
+def format_audit_embed(
+    *,
+    mutation_id: str,
+    subsystem: str,
+    mutation_type: str,
+    target: str,
+    scope: str,
+    guild_id: int | None,
+    prev_value: str | None,
+    new_value: str | None,
+    actor_id: int | None,
+    actor_type: str,
+    occurred_at: str,
+) -> discord.Embed:
+    """Render an ``audit.action_recorded`` payload as a Discord embed.
+
+    Phase 9c.1 — generic audit-trail rendering. The payload contract
+    matches what :func:`services.rollout_mutation._emit_audit_event`
+    sends; future publishers (other mutation pipelines) MUST use the
+    same field names.
+    """
+    embed = discord.Embed(
+        title=f"📋 {mutation_type}",
+        description=(
+            f"`{subsystem}` · scope `{scope}`"
+            + (f" · guild `{guild_id}`" if guild_id is not None else "")
+        ),
+        color=discord.Color.dark_teal(),
+    )
+    embed.add_field(name="Target", value=f"`{target}`", inline=True)
+    actor_display = f"<@{actor_id}>" if actor_id else f"`{actor_type}`"
+    embed.add_field(name="Actor", value=actor_display, inline=True)
+    embed.add_field(name="Actor type", value=f"`{actor_type}`", inline=True)
+    embed.add_field(
+        name="Previous",
+        value=f"`{prev_value}`" if prev_value is not None else "*(none)*",
+        inline=True,
+    )
+    embed.add_field(
+        name="New",
+        value=f"`{new_value}`" if new_value is not None else "*(cleared)*",
+        inline=True,
+    )
+    embed.add_field(name="Mutation ID", value=f"`{mutation_id}`", inline=False)
+    embed.set_footer(text=f"Recorded at {occurred_at}")
+    return embed
+
+
+async def log_audit_event(
+    guild: discord.Guild,
+    *,
+    mutation_id: str,
+    subsystem: str,
+    mutation_type: str,
+    target: str,
+    scope: str,
+    guild_id: int | None,
+    prev_value: str | None,
+    new_value: str | None,
+    actor_id: int | None,
+    actor_type: str,
+    occurred_at: str,
+) -> bool:
+    """Send a structured audit embed to the routed audit channel.
+
+    Resolution: ``resolve_log_channel(guild, "audit")`` — which tries
+    ``logging.audit_channel`` first, then falls back to
+    ``logging.mod_channel`` per the Phase 9a route table.
+
+    Returns True if delivered, False on any other outcome. Every
+    failure path is fail-safe and counted.
+    """
+    if not await is_enabled(guild.id):
+        _bump("skipped_disabled")
+        return False
+
+    channel = await resolve_log_channel(guild, "audit")
+    if channel is None and await auto_create_enabled(guild.id):
+        channel = await ensure_log_channel(guild, "audit")
+    if channel is None:
+        _bump("missing_channel")
+        return False
+
+    embed = format_audit_embed(
+        mutation_id=mutation_id,
+        subsystem=subsystem,
+        mutation_type=mutation_type,
+        target=target,
+        scope=scope,
+        guild_id=guild_id,
+        prev_value=prev_value,
+        new_value=new_value,
+        actor_id=actor_id,
+        actor_type=actor_type,
+        occurred_at=occurred_at,
+    )
+    try:
+        await channel.send(embed=embed)
+    except discord.Forbidden:
+        _bump("permission_error")
+        logger.warning(
+            "server_logging audit: missing send permission in #%s (guild %d)",
+            channel.name,
+            guild.id,
+        )
+        return False
+    except discord.HTTPException as exc:
+        _bump("send_error")
+        logger.warning(
+            "server_logging audit: HTTP error sending to #%s (guild %d): %s",
+            channel.name,
+            guild.id,
+            exc,
+        )
+        return False
+    except Exception as exc:  # noqa: BLE001 — fail-safe wrapper
+        _bump("send_error")
+        logger.warning(
+            "server_logging audit: unexpected error sending to #%s (guild %d): %s",
+            channel.name,
+            guild.id,
+            exc,
+            exc_info=True,
+        )
+        return False
+    _bump("audit_sent")
+    return True
+
+
+async def _on_audit_action(
+    *,
+    mutation_id: str,
+    subsystem: str,
+    mutation_type: str,
+    target: str,
+    scope: str,
+    guild_id: int | None,
+    prev_value: str | None,
+    new_value: str | None,
+    actor_id: int | None,
+    actor_type: str,
+    occurred_at: str,
+    **_extras: Any,
+) -> None:
+    """Bus subscriber for ``audit.action_recorded``.
+
+    Resolves the guild via the captured bot reference and delegates to
+    :func:`log_audit_event`. Global-scope mutations (``guild_id=None``)
+    are silently skipped — they have no guild-specific channel to
+    render into.
+
+    Extra payload fields are accepted via ``**_extras`` so the bus
+    contract stays loose: future publishers can add fields without
+    breaking this subscriber.
+
+    The bus already swallows handler exceptions; the try/except below
+    keeps the ``subscriber_errors`` counter honest independently.
+    """
+    try:
+        if guild_id is None:
+            _bump("skipped_no_guild")
+            return
+        bot = _BOT
+        if bot is None:
+            _bump("skipped_no_guild")
+            return
+        guild = bot.get_guild(guild_id)
+        if guild is None:
+            _bump("skipped_no_guild")
+            return
+        await log_audit_event(
+            guild,
+            mutation_id=mutation_id,
+            subsystem=subsystem,
+            mutation_type=mutation_type,
+            target=target,
+            scope=scope,
+            guild_id=guild_id,
+            prev_value=prev_value,
+            new_value=new_value,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            occurred_at=occurred_at,
+        )
+    except Exception as exc:  # noqa: BLE001 — fail-safe subscriber
+        _bump("subscriber_errors")
+        logger.exception(
+            "server_logging audit subscriber raised %s — counted and swallowed.",
+            type(exc).__name__,
+            exc_info=exc,
+        )
+
+
 async def _on_moderation_action(
     *,
     guild_id: int,
@@ -540,10 +743,12 @@ def setup(bot: object | None = None) -> None:
     if _SUBSCRIBED:
         return
     bus.on(EVT_MOD_ACTION, _on_moderation_action)
+    bus.on(EVT_AUDIT_ACTION_RECORDED, _on_audit_action)
     _SUBSCRIBED = True
     logger.info(
-        "server_logging: subscribed to %r (default per-guild policy: OFF)",
+        "server_logging: subscribed to %r + %r (default per-guild policy: OFF)",
         EVT_MOD_ACTION,
+        EVT_AUDIT_ACTION_RECORDED,
     )
 
 
@@ -557,12 +762,15 @@ _register_diagnostics()
 
 
 __all__ = [
+    "EVT_AUDIT_ACTION_RECORDED",
     "EVT_MOD_ACTION",
     "auto_create_enabled",
     "counters_snapshot",
     "ensure_log_channel",
+    "format_audit_embed",
     "format_log_embed",
     "is_enabled",
+    "log_audit_event",
     "log_event",
     "resolve_log_channel",
     "setup",

--- a/tests/unit/feature_flags/test_rollout_mutation_pipeline.py
+++ b/tests/unit/feature_flags/test_rollout_mutation_pipeline.py
@@ -217,10 +217,17 @@ async def test_set_flag_state_global_writes_db_clears_cache_emits_event(pipeline
     assert upsert_call.kwargs["mutation_type"] == "set_state"
     # Cache cleared for that flag
     mock_clear.assert_called_with(flag_name="bindings.primary")
-    # Event emitted with full payload
-    emit_call = mock_emit.await_args
-    assert emit_call.args[0] == EVT_FEATURE_FLAGS_CHANGED
-    payload = emit_call.kwargs
+    # Phase 9c.1: set_flag_state emits BOTH feature_flags.changed AND
+    # audit.action_recorded (in that order). Find the feature_flags
+    # emit by topic so the test stays robust if a future PR adds
+    # more companion emits.
+    feature_flag_emits = [
+        call
+        for call in mock_emit.await_args_list
+        if call.args and call.args[0] == EVT_FEATURE_FLAGS_CHANGED
+    ]
+    assert len(feature_flag_emits) == 1
+    payload = feature_flag_emits[0].kwargs
     assert payload["flag_name"] == "bindings.primary"
     assert payload["scope"] == "global"
     assert payload["guild_id"] is None
@@ -231,6 +238,24 @@ async def test_set_flag_state_global_writes_db_clears_cache_emits_event(pipeline
     assert payload["actor_type"] == "platform_owner"
     assert "occurred_at" in payload
     assert result.event_emitted is True
+
+    # Phase 9c.1: the audit companion event must also fire with the
+    # canonical payload (subsystem / mutation_type / target / scope /
+    # guild_id / prev_value / new_value / actor_*).
+    audit_emits = [
+        call
+        for call in mock_emit.await_args_list
+        if call.args and call.args[0] == "audit.action_recorded"
+    ]
+    assert len(audit_emits) == 1
+    audit_payload = audit_emits[0].kwargs
+    assert audit_payload["subsystem"] == "logging"
+    assert audit_payload["mutation_type"] == "set_flag_state"
+    assert audit_payload["target"] == "flag:bindings.primary"
+    assert audit_payload["scope"] == "global"
+    assert audit_payload["prev_value"] == "off"
+    assert audit_payload["new_value"] == "canary"
+    assert audit_payload["mutation_id"] == result.mutation_id
 
 
 # ---------------------------------------------------------------------------
@@ -368,12 +393,26 @@ async def test_set_rollout_percent_clears_all_guild_caches_for_flag(pipeline):
     assert upsert_call.kwargs["state"] == "production"
     # Cache cleared for the flag (every guild)
     mock_clear.assert_called_with(flag_name="bindings.primary")
-    # Event emitted: rollout.advanced
-    emit_call = mock_emit.await_args
-    assert emit_call.args[0] == EVT_ROLLOUT_ADVANCED
-    assert emit_call.kwargs["prev_percent"] == 10
-    assert emit_call.kwargs["new_percent"] == 50
+    # Phase 9c.1: set_rollout_percent emits rollout.advanced AND a
+    # companion audit.action_recorded. Find by topic.
+    rollout_emits = [
+        call
+        for call in mock_emit.await_args_list
+        if call.args and call.args[0] == EVT_ROLLOUT_ADVANCED
+    ]
+    assert len(rollout_emits) == 1
+    assert rollout_emits[0].kwargs["prev_percent"] == 10
+    assert rollout_emits[0].kwargs["new_percent"] == 50
     assert result.new_rollout_percent == 50
+    # Companion audit event.
+    audit_emits = [
+        call
+        for call in mock_emit.await_args_list
+        if call.args and call.args[0] == "audit.action_recorded"
+    ]
+    assert len(audit_emits) == 1
+    assert audit_emits[0].kwargs["mutation_type"] == "set_rollout_percent"
+    assert audit_emits[0].kwargs["new_value"] == "50"
 
 
 # ---------------------------------------------------------------------------
@@ -407,11 +446,26 @@ async def test_set_environment_tier_clears_full_guild_cache(pipeline):
     assert upsert_call.kwargs["prev_tier"] == "production"
     # The whole guild's cache is dropped (any flag could be affected).
     mock_clear.assert_called_with(guild_id=42)
-    emit_call = mock_emit.await_args
-    assert emit_call.args[0] == EVT_ENVIRONMENT_TIER_CHANGED
-    assert emit_call.kwargs["prev_tier"] == "production"
-    assert emit_call.kwargs["new_tier"] == "canary"
+    # Phase 9c.1: set_environment_tier emits environment_tier.changed
+    # AND a companion audit.action_recorded. Find by topic.
+    tier_emits = [
+        call
+        for call in mock_emit.await_args_list
+        if call.args and call.args[0] == EVT_ENVIRONMENT_TIER_CHANGED
+    ]
+    assert len(tier_emits) == 1
+    assert tier_emits[0].kwargs["prev_tier"] == "production"
+    assert tier_emits[0].kwargs["new_tier"] == "canary"
     assert result.new_tier == "canary"
+    audit_emits = [
+        call
+        for call in mock_emit.await_args_list
+        if call.args and call.args[0] == "audit.action_recorded"
+    ]
+    assert len(audit_emits) == 1
+    assert audit_emits[0].kwargs["mutation_type"] == "set_environment_tier"
+    assert audit_emits[0].kwargs["new_value"] == "canary"
+    assert audit_emits[0].kwargs["guild_id"] == 42
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_server_logging.py
+++ b/tests/unit/services/test_server_logging.py
@@ -933,7 +933,15 @@ def test_counters_snapshot_has_stable_shape():
     assert expected_keys <= set(counters)
     for v in counters.values():
         assert isinstance(v, int)
-    assert snap["subscribed_events"] == ["moderation.action_taken"]
+    # Phase 9c.1 added the audit subscriber alongside the moderation
+    # subscriber. The list is part of the public snapshot shape — pin
+    # both members but keep order-insensitive matching so a future
+    # addition (debug/info/warning/error in 9c.3/9c.4) doesn't break
+    # this guard.
+    assert set(snap["subscribed_events"]) == {
+        "moderation.action_taken",
+        "audit.action_recorded",
+    }
 
 
 def test_diagnostics_service_registers_server_logging_provider():

--- a/tests/unit/services/test_server_logging_audit.py
+++ b/tests/unit/services/test_server_logging_audit.py
@@ -1,0 +1,397 @@
+"""Phase 9c.1 — server_logging audit subscriber tests.
+
+Covers:
+
+* ``audit.action_recorded`` is in ``KNOWN_EVENTS``.
+* ``server_logging.setup(bot)`` registers a subscriber for it.
+* The subscriber respects ``is_enabled`` (skips when logging is OFF).
+* The subscriber skips global-scope mutations (``guild_id=None``).
+* The subscriber resolves the route via
+  ``resolve_log_channel(guild, "audit")`` — falling back to the mod
+  channel through the Phase 9a fallback chain.
+* The subscriber bumps the ``audit_sent`` counter on success.
+* The subscriber catches every exception and bumps
+  ``subscriber_errors`` rather than crashing.
+* ``format_audit_embed`` renders the expected fields.
+* The Phase 9c.1 ``audit_sent`` counter bucket exists in
+  ``counters_snapshot()``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from services import server_logging
+from services.server_logging import (
+    EVT_AUDIT_ACTION_RECORDED,
+    _on_audit_action,
+    counters_snapshot,
+    format_audit_embed,
+    log_audit_event,
+)
+
+
+def _guild(guild_id: int = 42) -> MagicMock:
+    g = MagicMock(spec=discord.Guild)
+    g.id = guild_id
+    return g
+
+
+def _channel(name: str = "bot-audit-log") -> MagicMock:
+    ch = MagicMock(spec=discord.TextChannel)
+    ch.name = name
+    ch.send = AsyncMock()
+    return ch
+
+
+@pytest.fixture(autouse=True)
+def _reset_counters():
+    """Reset counters before each test so per-test bucket asserts work."""
+    server_logging._reset_for_tests()
+    yield
+    server_logging._reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Catalogue + subscription
+# ---------------------------------------------------------------------------
+
+
+def test_audit_topic_is_in_known_events():
+    from core.events_catalogue import KNOWN_EVENTS
+
+    assert "audit.action_recorded" in KNOWN_EVENTS
+
+
+def test_counters_snapshot_includes_audit_sent_bucket():
+    snap = counters_snapshot()
+    assert "audit_sent" in snap["counters"]
+    assert snap["counters"]["audit_sent"] == 0
+    assert "audit.action_recorded" in snap["subscribed_events"]
+
+
+def test_subscriber_signature_accepts_full_payload():
+    """The handler must accept the canonical payload + extra fields
+    (via ``**_extras``) without raising TypeError. A future publisher
+    that adds new keys to the payload should not break this subscriber."""
+    import inspect
+
+    sig = inspect.signature(_on_audit_action)
+    params = sig.parameters
+    for required in (
+        "mutation_id",
+        "subsystem",
+        "mutation_type",
+        "target",
+        "scope",
+        "guild_id",
+        "prev_value",
+        "new_value",
+        "actor_id",
+        "actor_type",
+        "occurred_at",
+    ):
+        assert required in params
+    # **_extras catches arbitrary future additions.
+    assert any(p.kind == p.VAR_KEYWORD for p in params.values())
+
+
+# ---------------------------------------------------------------------------
+# Embed builder
+# ---------------------------------------------------------------------------
+
+
+def test_format_audit_embed_renders_expected_fields():
+    embed = format_audit_embed(
+        mutation_id="abc-123",
+        subsystem="logging",
+        mutation_type="set_flag_state",
+        target="flag:settings.manager_cog.enabled",
+        scope="guild",
+        guild_id=42,
+        prev_value="off",
+        new_value="on",
+        actor_id=99,
+        actor_type="platform_owner",
+        occurred_at="2026-05-19T12:00:00+00:00",
+    )
+    field_names = [f.name for f in embed.fields]
+    for required in (
+        "Target",
+        "Actor",
+        "Actor type",
+        "Previous",
+        "New",
+        "Mutation ID",
+    ):
+        assert required in field_names
+    rendered = "\n".join(f.value for f in embed.fields)
+    assert "abc-123" in rendered
+    assert "off" in rendered
+    assert "on" in rendered
+    assert "<@99>" in rendered  # actor mention
+    assert "set_flag_state" in (embed.title or "")
+
+
+def test_format_audit_embed_handles_cleared_value():
+    embed = format_audit_embed(
+        mutation_id="x",
+        subsystem="logging",
+        mutation_type="set_flag_state",
+        target="flag:x",
+        scope="guild",
+        guild_id=42,
+        prev_value="on",
+        new_value=None,
+        actor_id=99,
+        actor_type="platform_owner",
+        occurred_at="2026-05-19T12:00:00+00:00",
+    )
+    new_field = next(f for f in embed.fields if f.name == "New")
+    assert "cleared" in new_field.value
+
+
+def test_format_audit_embed_handles_system_actor():
+    embed = format_audit_embed(
+        mutation_id="x",
+        subsystem="logging",
+        mutation_type="set_flag_state",
+        target="flag:x",
+        scope="global",
+        guild_id=None,
+        prev_value=None,
+        new_value="canary",
+        actor_id=None,
+        actor_type="system",
+        occurred_at="2026-05-19T12:00:00+00:00",
+    )
+    actor_field = next(f for f in embed.fields if f.name == "Actor")
+    # No actor_id → falls back to actor_type display.
+    assert "system" in actor_field.value
+
+
+# ---------------------------------------------------------------------------
+# Subscriber routing
+# ---------------------------------------------------------------------------
+
+
+_PAYLOAD = {
+    "mutation_id": "abc-123",
+    "subsystem": "logging",
+    "mutation_type": "set_flag_state",
+    "target": "flag:settings.manager_cog.enabled",
+    "scope": "guild",
+    "guild_id": 42,
+    "prev_value": "off",
+    "new_value": "on",
+    "actor_id": 99,
+    "actor_type": "platform_owner",
+    "occurred_at": "2026-05-19T12:00:00+00:00",
+}
+
+
+@pytest.mark.asyncio
+async def test_subscriber_skips_when_logging_disabled():
+    bot = MagicMock()
+    bot.get_guild.return_value = _guild()
+    with patch.object(server_logging, "_BOT", bot), patch(
+        "services.server_logging.is_enabled",
+        AsyncMock(return_value=False),
+    ):
+        await _on_audit_action(**_PAYLOAD)
+    snap = counters_snapshot()
+    assert snap["counters"]["skipped_disabled"] == 1
+    assert snap["counters"]["audit_sent"] == 0
+
+
+@pytest.mark.asyncio
+async def test_subscriber_skips_global_scope_mutations():
+    """Global-scope mutations have no guild to route into."""
+    bot = MagicMock()
+    bot.get_guild.return_value = _guild()
+    payload = dict(_PAYLOAD, guild_id=None, scope="global")
+    with patch.object(server_logging, "_BOT", bot):
+        await _on_audit_action(**payload)
+    snap = counters_snapshot()
+    assert snap["counters"]["skipped_no_guild"] == 1
+    assert snap["counters"]["audit_sent"] == 0
+
+
+@pytest.mark.asyncio
+async def test_subscriber_skips_when_guild_not_resolvable():
+    bot = MagicMock()
+    bot.get_guild.return_value = None  # guild not in bot's cache
+    with patch.object(server_logging, "_BOT", bot):
+        await _on_audit_action(**_PAYLOAD)
+    snap = counters_snapshot()
+    assert snap["counters"]["skipped_no_guild"] == 1
+
+
+@pytest.mark.asyncio
+async def test_subscriber_routes_through_audit_channel():
+    """The subscriber must call ``resolve_log_channel(guild, "audit")``,
+    not "mod" or any other route. This pins the routing contract.
+    """
+    bot = MagicMock()
+    guild = _guild()
+    bot.get_guild.return_value = guild
+    channel = _channel(name="bot-audit-log")
+
+    seen_kinds: list[str] = []
+
+    async def fake_resolve(_guild, kind):
+        seen_kinds.append(kind)
+        return channel
+
+    with patch.object(server_logging, "_BOT", bot), patch(
+        "services.server_logging.is_enabled",
+        AsyncMock(return_value=True),
+    ), patch(
+        "services.server_logging.resolve_log_channel",
+        side_effect=fake_resolve,
+    ):
+        await _on_audit_action(**_PAYLOAD)
+
+    assert seen_kinds == ["audit"]
+    channel.send.assert_awaited_once()
+    snap = counters_snapshot()
+    assert snap["counters"]["audit_sent"] == 1
+
+
+@pytest.mark.asyncio
+async def test_subscriber_counts_missing_channel():
+    bot = MagicMock()
+    bot.get_guild.return_value = _guild()
+    with patch.object(server_logging, "_BOT", bot), patch(
+        "services.server_logging.is_enabled",
+        AsyncMock(return_value=True),
+    ), patch(
+        "services.server_logging.resolve_log_channel",
+        AsyncMock(return_value=None),
+    ), patch(
+        "services.server_logging.auto_create_enabled",
+        AsyncMock(return_value=False),
+    ):
+        await _on_audit_action(**_PAYLOAD)
+    snap = counters_snapshot()
+    assert snap["counters"]["missing_channel"] == 1
+    assert snap["counters"]["audit_sent"] == 0
+
+
+@pytest.mark.asyncio
+async def test_subscriber_counts_permission_error():
+    bot = MagicMock()
+    guild = _guild()
+    bot.get_guild.return_value = guild
+    channel = _channel()
+    channel.send = AsyncMock(side_effect=discord.Forbidden(MagicMock(), "nope"))
+
+    with patch.object(server_logging, "_BOT", bot), patch(
+        "services.server_logging.is_enabled",
+        AsyncMock(return_value=True),
+    ), patch(
+        "services.server_logging.resolve_log_channel",
+        AsyncMock(return_value=channel),
+    ):
+        await _on_audit_action(**_PAYLOAD)
+    snap = counters_snapshot()
+    assert snap["counters"]["permission_error"] == 1
+
+
+@pytest.mark.asyncio
+async def test_subscriber_catches_unexpected_exception():
+    """The handler must not raise into the event bus."""
+
+    async def boom(*_a, **_k):
+        raise RuntimeError("unexpected")
+
+    # The bot lookup itself raising is the cleanest way to force an
+    # exception inside the subscriber body.
+    bad_bot = MagicMock()
+    bad_bot.get_guild = MagicMock(side_effect=RuntimeError("unexpected"))
+    with patch.object(server_logging, "_BOT", bad_bot):
+        # The subscriber must not propagate the exception.
+        await _on_audit_action(**_PAYLOAD)
+    snap = counters_snapshot()
+    assert snap["counters"]["subscriber_errors"] == 1
+
+
+@pytest.mark.asyncio
+async def test_subscriber_accepts_unknown_payload_fields():
+    """A future publisher may add keys. The subscriber must accept
+    them via ``**_extras`` and ignore them."""
+    bot = MagicMock()
+    bot.get_guild.return_value = _guild()
+    channel = _channel()
+    payload_with_extras = dict(
+        _PAYLOAD,
+        future_field_1="ignored",
+        future_field_2=42,
+    )
+    with patch.object(server_logging, "_BOT", bot), patch(
+        "services.server_logging.is_enabled",
+        AsyncMock(return_value=True),
+    ), patch(
+        "services.server_logging.resolve_log_channel",
+        AsyncMock(return_value=channel),
+    ):
+        await _on_audit_action(**payload_with_extras)
+    # No crash, audit was sent normally.
+    snap = counters_snapshot()
+    assert snap["counters"]["audit_sent"] == 1
+
+
+# ---------------------------------------------------------------------------
+# log_audit_event direct entry point (for non-bus consumers)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_log_audit_event_returns_true_on_success():
+    guild = _guild()
+    channel = _channel()
+    with patch(
+        "services.server_logging.is_enabled",
+        AsyncMock(return_value=True),
+    ), patch(
+        "services.server_logging.resolve_log_channel",
+        AsyncMock(return_value=channel),
+    ):
+        result = await log_audit_event(guild, **_PAYLOAD)
+    assert result is True
+    snap = counters_snapshot()
+    assert snap["counters"]["audit_sent"] == 1
+
+
+@pytest.mark.asyncio
+async def test_log_audit_event_returns_false_when_disabled():
+    guild = _guild()
+    with patch(
+        "services.server_logging.is_enabled",
+        AsyncMock(return_value=False),
+    ):
+        result = await log_audit_event(guild, **_PAYLOAD)
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# setup() registers the new subscriber
+# ---------------------------------------------------------------------------
+
+
+def test_setup_registers_audit_subscriber():
+    """``setup(bot)`` must register a handler for
+    ``audit.action_recorded`` (in addition to the existing
+    moderation handler). The bus registration is global so we
+    inspect ``server_logging._SUBSCRIBED`` + the subscribed_events
+    snapshot.
+    """
+    bot = MagicMock()
+    # The setup function is idempotent; calling it multiple times in
+    # tests is safe.
+    server_logging.setup(bot)
+    snap = counters_snapshot()
+    assert EVT_AUDIT_ACTION_RECORDED in snap["subscribed_events"]


### PR DESCRIPTION
## Objective

**Phase 9c.1** — pilot the end-to-end `audit.action_recorded` flow: publisher (RolloutMutationPipeline) → bus → server_logging subscriber → Phase 9a's `resolve_log_channel(guild, "audit")` → audit (or mod-fallback) channel.

This is the smallest possible Phase 9c slice. It establishes the publisher-side and subscriber-side templates that Phase 9c.2+ rolls out to the other mutation pipelines without re-litigating shape.

## Files changed

| File | Change |
|---|---|
| `disbot/core/events_catalogue.py` | +11 lines — registered `audit.action_recorded` in `KNOWN_EVENTS`. |
| `disbot/services/rollout_mutation.py` | +70 / –10 — new `_emit_audit_event(...)`, called from `_emit_feature_flag_event` / `_emit_rollout_event` / `_emit_environment_tier_event`. |
| `disbot/services/server_logging.py` | +180 — `EVT_AUDIT_ACTION_RECORDED` + `format_audit_embed` + `log_audit_event` + `_on_audit_action` subscriber + `audit_sent` counter + `setup(bot)` wiring. |
| `tests/unit/services/test_server_logging_audit.py` *(new, 17 tests)* | Full subscriber + embed + routing coverage. |
| `tests/unit/feature_flags/test_rollout_mutation_pipeline.py` | 3 existing tests updated for companion-emit shape (topic-based lookup, not list-index). |
| `tests/unit/services/test_server_logging.py` | 1 existing test updated — `subscribed_events` now uses set-equality so 9c.3/9c.4 additions don't break it. |

## End-to-end flow

```
RolloutMutationPipeline.set_flag_state(scope="guild", state="on", ...)
        │
        ├──> _emit_feature_flag_event(...)   # existing
        │      └──> bus.emit("feature_flags.changed", ...)
        │
        └──> _emit_audit_event(...)          # Phase 9c.1
               └──> bus.emit("audit.action_recorded",
                       mutation_id, subsystem, mutation_type, target,
                       scope, guild_id, prev_value, new_value,
                       actor_id, actor_type, occurred_at)
                              │
                              v
                server_logging._on_audit_action(**payload)
                              │
                              ├──> is_enabled(guild_id)?      → skipped_disabled
                              ├──> guild_id is None?          → skipped_no_guild
                              ├──> bot.get_guild(guild_id)?   → skipped_no_guild
                              └──> log_audit_event(guild, ...)
                                       ├──> resolve_log_channel(guild, "audit")
                                       │      └──> mod fallback (Phase 9a)
                                       ├──> channel.send(format_audit_embed(...))
                                       └──> audit_sent++ / permission_error / send_error
```

## Payload contract (Phase 9c.2+ publishers must match)

```python
bus.emit(
    "audit.action_recorded",
    mutation_id=str,        # uuid for the mutation
    subsystem=str,          # which subsystem ("logging", "settings", "moderation", …)
    mutation_type=str,      # operation kind ("set_flag_state", "set_binding", …)
    target=str,             # human-readable target (e.g. "flag:foo", "binding:foo")
    scope=str,              # "global" / "guild" / "channel" / etc.
    guild_id=int | None,    # required for routing; None → skipped by subscriber
    prev_value=str | None,
    new_value=str | None,
    actor_id=int | None,
    actor_type=str,         # "platform_owner" / "system" / "backfill" / …
    occurred_at=str,        # ISO 8601 UTC
)
```

The subscriber accepts arbitrary additional payload fields via `**_extras` — a future publisher can grow the payload without breaking it (pinned by `test_subscriber_accepts_unknown_payload_fields`).

## Failure handling (all fail-safe)

| Case | Behaviour |
|---|---|
| Audit emit fails | logged + swallowed; pipeline's primary event return is unaffected; DB state is authoritative |
| Subscriber error | counted (`subscriber_errors`) + logged + swallowed; bus already swallows handler exceptions |
| Logging disabled in guild | `skipped_disabled` counter bumped |
| `guild_id is None` (global mutation) | `skipped_no_guild` counter bumped |
| Channel unbound + auto-create off | `missing_channel` counter bumped |
| Discord 403 | `permission_error` counter bumped |
| Discord HTTP error | `send_error` counter bumped |
| Successful send | `audit_sent` counter bumped |

## Tests run

| Suite | Result |
|---|---|
| `pytest tests/unit/services/test_server_logging_audit.py` | **17 passed** (new file) |
| `pytest tests/unit/feature_flags/test_rollout_mutation_pipeline.py` | passes — 3 existing tests updated for companion-emit shape |
| `pytest tests/unit/services/test_server_logging.py` | passes — 1 existing test updated for set-equality on `subscribed_events` |
| `pytest` (full suite) | **2211 passed**, 11 warnings, 24.63s |
| `black --check . --exclude '(\.github\|tests\|venv\|env\|build\|dist)'` | clean (271 files) |
| `isort --check-only . --skip-glob …` | clean |
| `ruff check . --exclude .github,tests,venv,env,build,dist` | clean |
| `python3.10 -m mypy disbot/` | **Success: no issues found in 272 source files** |

## Manual Discord smoke checklist

- [ ] Bot starts cleanly
- [ ] `!platform identity` reports no fatal findings
- [ ] On a guild with `logging.enabled=true` and `logging.audit_channel` bound: run `!platform flag` → enable a test flag for the guild → an audit embed posts to the audit channel
- [ ] On a guild with `logging.audit_channel` **unbound**: same action → embed posts to `mod_channel` (Phase 9a fallback)
- [ ] On a guild with `logging.enabled=false`: same action → **no** embed posts; `skipped_disabled` counter increments in `!platform health server_logging` (or wherever the snapshot surfaces)
- [ ] Global-scope mutations (admin tooling that calls `set_flag_state(scope="global")`) do NOT emit an audit embed (no guild to route to); `skipped_no_guild` counter increments
- [ ] The `feature_flags.changed` event still fires normally; downstream consumers (feature-flag cache) are unaffected

## Risks

- **Medium.** Adds emit callsites to three already-shipping methods. Each emit is wrapped in try/except and swallowed independently of the pipeline's primary event. The subscriber is registered idempotently and has its own fail-safe wrapper. The `audit_sent` counter is the only new bucket — existing buckets unchanged. The mocked-in-tests `subscribed_events` shape grew from `[mod]` to `{mod, audit}` (set-comparison in the test) so a Phase 9c.3/9c.4 addition won't regress this.

## Rollback plan

1. Revert the commit (six files).
2. `audit.action_recorded` is removed from `KNOWN_EVENTS`.
3. RolloutMutationPipeline returns to emitting only its three pipeline-specific events.
4. `server_logging` returns to subscribing only to `moderation.action_taken`.
5. No data migration; no schema change; the Phase 9a `audit_channel` binding stays declared but goes back to being unused (it's optional, no consumer required it).

## Next recommended phase

After this PR merges:

1. **Phase 9c.2** — add `_emit_audit_event` to the remaining mutation pipelines. Each pipeline is a separate small PR (sub-100 lines). The subscriber doesn't need to change — same payload contract.
2. **Phase 9c.3** — `runtime.error_raised` from centralized error handlers (`Bot.on_command_error`, `Bot.on_error`, `BaseView.on_error`).
3. **Phase 9c.4** — `runtime.warning_emitted` from a curated set of platform warnings.

I will not start Phase 9c.2 without explicit direction.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TeXrWGdRyGEcukWEv1qryT)_