### PR TITLE
refactor(games): migrate Back to Games to shared navigation helper (S2)

### DIFF
--- a/disbot/views/games/hub.py
+++ b/disbot/views/games/hub.py
@@ -11,11 +11,9 @@ Mining, Counting, Chain). This view is a navigation surface only:
 * The select dropdown forwards to the child cog's
   :meth:`build_help_menu_view` hook, identical to how ``!help`` routes
   into a subsystem.
-* A "↩ Back to Games" button is attached to the child view so users can
-  return to the hub. The Phase 2 roadmap step (a shared back-nav helper)
-  is deferred to Phase 3.5; until then, the inline factory below mirrors
-  the existing patterns in ``help_cog.py``, ``admin_cog.py``, and
-  ``views/settings/subsystem_view.py``.
+* A "↩ Back to Games" button is attached to the child view via
+  :func:`views.navigation.attach_back_button` (S2). The closure captures
+  the original author so the rebuilt hub remains invoker-restricted.
 
 Direct ``!games`` invocation: the hub opens with the select only.
 ``!help`` is the way back to the help menu in that flow, mirroring
@@ -35,6 +33,7 @@ import discord
 from utils.subsystem_registry import SUBSYSTEMS
 from utils.ui_constants import GAME_COLOR
 from views.base import HubView
+from views.navigation import attach_back_button
 
 logger = logging.getLogger("bot.views.games")
 
@@ -117,37 +116,31 @@ def attach_back_to_games_button(
 ) -> bool:
     """Append a "↩ Back to Games" control to a child view opened from the hub.
 
-    No-op (returns ``False``) if the view already has Discord's 25-child
-    limit. The callback rebuilds a fresh :class:`GamesHubView` so the
-    child list reflects the current registry on click.
+    Thin wrapper around :func:`views.navigation.attach_back_button` (S2).
+    The parent-builder closure captures ``author`` so the rebuilt
+    :class:`GamesHubView` remains invoker-restricted; the child list is
+    re-discovered from ``SUBSYSTEMS`` at click time so the hub reflects
+    the live registry, not the snapshot from when the panel was opened.
 
-    Inline factory mirroring ``cogs.help_cog._attach_back_to_help_button``
-    and friends. Will be migrated into a shared helper in Phase 3.5.
+    Returns ``False`` (no-op) if the view is already at Discord's
+    25-component cap — ``attach_back_button`` logs a WARNING in that
+    case so operators can see why a panel lost its back nav.
     """
-    if len(view.children) >= 25:
-        logger.warning(
-            "Back-to-games button skipped — %s already has 25 children.",
-            type(view).__name__,
-        )
-        return False
 
-    back_btn = discord.ui.Button(  # type: ignore[var-annotated]
+    async def _build_games_parent(
+        _interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        return build_games_hub_embed(), GamesHubView(author)
+
+    return attach_back_button(
+        view,
         label="↩ Back to Games",
         custom_id="games:back",
-        style=discord.ButtonStyle.secondary,
+        parent_builder=_build_games_parent,
         row=4,
+        style=discord.ButtonStyle.secondary,
+        error_message="Could not reload the Games hub. Please try again.",
     )
-
-    async def _back_callback(interaction: discord.Interaction) -> None:
-        new_view = GamesHubView(author)
-        await interaction.response.edit_message(
-            embed=build_games_hub_embed(),
-            view=new_view,
-        )
-
-    back_btn.callback = _back_callback  # type: ignore[method-assign]
-    view.add_item(back_btn)
-    return True
 
 
 def _build_no_panel_embed(name: str, meta: dict) -> discord.Embed:

--- a/tests/unit/views/test_games_hub_view.py
+++ b/tests/unit/views/test_games_hub_view.py
@@ -353,3 +353,56 @@ def test_build_no_panel_embed_handles_empty_entry_points():
     embed = _build_no_panel_embed("empty", fake_meta)
     assert embed.fields  # always shows a Commands field
     assert "No commands declared" in embed.fields[0].value
+
+
+# ---------------------------------------------------------------------------
+# Back-to-Games click-time behaviour (S2 migration)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_back_button_callback_rebuilds_games_hub_with_original_author():
+    """Clicking ↩ Back to Games must rebuild ``GamesHubView`` with the
+    same author the panel was opened by — pins the closure's author
+    capture across the navigation.attach_back_button migration.
+    """
+    author = _author(id_=42)
+    view = discord.ui.View()
+    attach_back_to_games_button(view, author)
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.response = MagicMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.response.edit_message = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.edit_original_response = AsyncMock()
+
+    btn = next(c for c in view.children if isinstance(c, discord.ui.Button))
+    await btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    interaction.response.edit_message.assert_awaited_once()
+    _args, kwargs = interaction.response.edit_message.call_args
+    rebuilt = kwargs["view"]
+    assert isinstance(rebuilt, GamesHubView)
+    # The rebuilt hub must keep the original author so invoker-restriction
+    # still applies after the user navigates back.
+    assert rebuilt._author is author
+
+
+def test_attach_back_to_games_button_delegates_to_shared_helper():
+    """Migration pin (S2): ``attach_back_to_games_button`` must call into
+    ``views.navigation.attach_back_button``. Prevents an accidental
+    in-line revert that would re-duplicate the back-nav logic.
+    """
+    import inspect
+
+    from views.games import hub as games_hub
+
+    fn_src = inspect.getsource(games_hub.attach_back_to_games_button)
+    module_src = inspect.getsource(games_hub)
+    # The wrapper must call the shared helper, not re-implement the
+    # 25-component cap / edit-message dance inline.
+    assert "attach_back_button" in fn_src
+    # The shared helper must be reachable via an actual import — either at
+    # module level or function-local. Pin both shapes.
+    assert "from views.navigation" in module_src or "views.navigation" in fn_src


### PR DESCRIPTION
## Summary

S2 of the S1–S13 mother-hub PR sequence (see [`mother-hub-map.md`](https://github.com/menno420/superbot/pull/133) — S1).

Removes the inline back-button factory in `disbot/views/games/hub.py` and delegates to `views/navigation.py:attach_back_button` — the canonical helper landed by PR #130. The Games hub is the canonical mother-hub pattern that future hubs (Economy, Moderation/Safety, Community, Utility) copy in S7–S10; migrating its back-nav now strengthens the template before those PRs land.

## What changed

**`disbot/views/games/hub.py`**

- `attach_back_to_games_button` is now a thin wrapper around `views/navigation.attach_back_button` with a parent-builder closure that captures the original `author`.
- The rebuilt `GamesHubView` still re-discovers children from `SUBSYSTEMS` at click time, and remains invoker-restricted via the captured author.
- Custom ID preserved (`games:back`) so any persistent-view registrations continue to resolve.
- Cap behaviour, ephemeral fallback on builder failure, and `edit_original_response` fallback for deferred interactions all come from the shared helper for free.

**`tests/unit/views/test_games_hub_view.py`** (2 new tests)

- `test_back_button_callback_rebuilds_games_hub_with_original_author` — pins the closure's author capture across the migration; clicking ↩ Back to Games must rebuild `GamesHubView` with the same author the panel was opened by.
- `test_attach_back_to_games_button_delegates_to_shared_helper` — migration pin mirroring `help_cog` and `logging/routes_panel` pins. An in-line revert would fail CI.

## Test plan

- [x] `PYTHONPATH=disbot python -m pytest tests/unit/views/ tests/unit/help/ tests/unit/cogs/test_games_cog.py` — **263 passed**
- [x] `ruff check disbot/views/games/hub.py` — All checks passed
- [x] Custom ID preserved (`games:back`)
- [x] No persistent-view registry changes needed
- [ ] Manual Discord smoke: `!help` → Games → child → Back to Games → Back to Help

## Rollback

Single `git revert` of the squash commit. No data, schema, or API changes.

## Next PR

**S3** — Help category index v1 (existing hubs only: Games + Admin + Settings + Platform + All Commands); introduces `disbot/utils/hub_registry.py`.

https://claude.ai/code/session_01ChWkq1H5kgBLNk8zHn1t6H

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChWkq1H5kgBLNk8zHn1t6H)_