### PR TITLE
feat(help): mother-hub category index for Help (S3)

### DIFF
--- a/disbot/cogs/help_cog.py
+++ b/disbot/cogs/help_cog.py
@@ -546,8 +546,7 @@ class HelpCategoryView(PersistentView):
             visible_list = [
                 name
                 for name, meta in all_subsystems_sorted()
-                if name in vis_result.visible_subsystems
-                and not meta.get("parent_hub")
+                if name in vis_result.visible_subsystems and not meta.get("parent_hub")
             ]
             new_view = HelpPanelView(visible_list, page=0)
             embed = _build_page_embed(

--- a/disbot/cogs/help_cog.py
+++ b/disbot/cogs/help_cog.py
@@ -9,6 +9,7 @@ from discord.ext import commands
 from core.runtime.persistent_views import PersistentView, register
 from services import governance_service
 from services.governance_service import GovernanceContext
+from utils.hub_registry import ALL_COMMANDS_KEY, get_hub, hubs_for_tier
 from utils.subsystem_registry import SUBSYSTEMS, all_subsystems_sorted
 from utils.ui_constants import ADMIN_COLOR, GENERAL_COLOR, MOD_COLOR, UTILITY_COLOR
 
@@ -144,12 +145,8 @@ def _build_help_page_view(visible_list: list[str], page: int) -> HelpPanelView:
     return HelpPanelView(visible_list, page)
 
 
-def _attach_back_to_help_button(
-    view: discord.ui.View,
-    visible_list: list[str],
-    page: int,
-) -> None:
-    """Add a "↩ Back to Help" control to a subsystem panel surfaced from help.
+def _attach_back_to_help_button(view: discord.ui.View) -> None:
+    """Add a "↩ Back to Help" control to a panel surfaced from Help.
 
     Does not mutate the cog's panel class — adds the button to the live view
     instance only. No-op if the view already has 25 components (Discord cap;
@@ -159,9 +156,10 @@ def _attach_back_to_help_button(
     to reflects current visibility (not the stale snapshot from when the
     panel was opened).
 
-    Phase 3.5: implementation moved to ``views.navigation.attach_back_button``;
-    the help-specific parent-builder (governance resolve + pagination clamp +
-    fresh HelpPanelView) is kept here as a closure.
+    S3: rebuilds :class:`HelpCategoryView` — the new top-level of Help
+    after the category-index refactor. The pre-S3 implementation rebuilt
+    a paginated :class:`HelpPanelView`; that view is still reachable as
+    the "All Commands / Advanced" category but is no longer the top.
     """
     # Local import — navigation is at the views layer; help_cog is at
     # the cogs layer. Function-local import keeps the import graph
@@ -174,19 +172,8 @@ def _attach_back_to_help_button(
     ) -> tuple[discord.Embed, discord.ui.View]:
         gctx = GovernanceContext.from_interaction(interaction)
         vis_result = await governance_service.resolve_visibility(gctx)
-        fresh_visible = [
-            name
-            for name, meta in all_subsystems_sorted()
-            if name in vis_result.visible_subsystems and not meta.get("parent_hub")
-        ]
-        new_page = min(page, max(0, math.ceil(len(fresh_visible) / _PAGE_SIZE) - 1))
-        new_view = HelpPanelView(fresh_visible, new_page)
-        embed = _build_page_embed(
-            interaction.client,  # type: ignore[arg-type]
-            fresh_visible,
-            new_page,
-            vis_result.member_tier,
-        )
+        new_view = HelpCategoryView(vis_result.member_tier)
+        embed = build_categories_overview_embed(vis_result.member_tier)
         return embed, new_view
 
     attach_back_button(
@@ -244,16 +231,76 @@ def _build_page_embed(
     return embed
 
 
+def build_categories_overview_embed(member_tier: str) -> discord.Embed:
+    """Build the top-level Help embed showing mother-hub categories (S3).
+
+    Iterates :data:`utils.hub_registry.HUBS`, filters to hubs visible at
+    ``member_tier`` via :func:`hubs_for_tier`, and always appends the
+    permanent "All Commands / Advanced" fallback row. Each hub line
+    states purpose, includes-list (primary + cross-link children with
+    display names from ``SUBSYSTEMS``), and typed entry command — the
+    user-centered orientation rule from the mother-hub map.
+    """
+    embed = discord.Embed(
+        title="📚 Help Menu",
+        description="Pick a category from the dropdown below.",
+        color=UTILITY_COLOR,
+    )
+
+    visible_hubs = hubs_for_tier(member_tier)
+    for hub in visible_hubs:
+        included: list[str] = []
+        for child_key in hub.primary_children:
+            child_meta = SUBSYSTEMS.get(child_key)
+            if child_meta is not None:
+                included.append(child_meta.get("display_name", child_key))
+        for child_key in hub.cross_link_children:
+            child_meta = SUBSYSTEMS.get(child_key)
+            if child_meta is not None:
+                included.append(
+                    f"{child_meta.get('display_name', child_key)} (cross-link)",
+                )
+
+        lines = [hub.purpose]
+        if included:
+            lines.append(f"Includes: {', '.join(included)}.")
+        lines.append(f"→ `{hub.entry_command}`")
+        embed.add_field(
+            name=f"{hub.emoji} {hub.display_name}",
+            value="\n".join(lines),
+            inline=False,
+        )
+
+    # All Commands / Advanced is permanent — guarantees discoverability
+    # for every visible subsystem even when no mother hub owns it.
+    embed.add_field(
+        name="📋 All Commands / Advanced",
+        value=(
+            "Browse every visible command directly, grouped by tier.\n"
+            "Power-user fallback: use this when you know the command name."
+        ),
+        inline=False,
+    )
+
+    if not embed.fields:
+        embed.description = "No commands are available in this channel."
+    return embed
+
+
 async def resolve_help_panel_state(
     interaction: discord.Interaction,
-) -> tuple[discord.Embed, HelpPanelView]:
-    """Resolve governance + build the Help-panel ``(embed, view)`` pair.
+) -> tuple[discord.Embed, HelpCategoryView]:
+    """Resolve governance + build the Help top-level ``(embed, view)`` pair.
 
     Used by navigation buttons in other cogs / views (e.g.
     ``cogs.admin_cog._AdminPanelView.help_btn`` and
     ``views.mining.mine_view._MineResultsView.help_btn``) so they
-    don't re-implement governance resolution + page-embed
-    construction.
+    don't re-implement governance resolution + embed construction.
+
+    S3: the returned view is :class:`HelpCategoryView` — the new
+    mother-hub category index. The legacy :class:`HelpPanelView` is
+    reached by selecting "All Commands / Advanced" inside the
+    category view.
 
     Raises whatever ``governance_service.resolve_visibility`` raises;
     callers are responsible for catching to fall back to an in-place
@@ -261,18 +308,8 @@ async def resolve_help_panel_state(
     """
     gctx = GovernanceContext.from_interaction(interaction)
     vis_result = await governance_service.resolve_visibility(gctx)
-    visible_list = [
-        name
-        for name, meta in all_subsystems_sorted()
-        if name in vis_result.visible_subsystems and not meta.get("parent_hub")
-    ]
-    view = HelpPanelView(visible_list, page=0)
-    embed = _build_page_embed(
-        interaction.client,  # type: ignore[arg-type]
-        visible_list,
-        0,
-        vis_result.member_tier,
-    )
+    view = HelpCategoryView(vis_result.member_tier)
+    embed = build_categories_overview_embed(vis_result.member_tier)
     return embed, view
 
 
@@ -386,7 +423,7 @@ class HelpPanelView(PersistentView):
         if callable(build_panel):
             try:
                 embed, sub_view = await build_panel(interaction)
-                _attach_back_to_help_button(sub_view, self._visible, self._page)
+                _attach_back_to_help_button(sub_view)
                 await interaction.response.edit_message(embed=embed, view=sub_view)
                 return
             except Exception as exc:
@@ -429,6 +466,141 @@ class HelpPanelView(PersistentView):
             member_tier,
         )
         await interaction.response.edit_message(embed=embed, view=new_view)
+
+
+@register
+class HelpCategoryView(PersistentView):
+    """Top-level Help — mother-hub category index (S3).
+
+    Replaces the pre-S3 paginated subsystem-list view as the surface
+    ``!help`` opens. The dropdown shows one option per visible mother
+    hub plus a permanent "All Commands / Advanced" fallback that swaps
+    the view in place to :class:`HelpPanelView` (the legacy paginated
+    list, now reachable only via that option).
+
+    SUBSYSTEM is ``"help"`` — overwrites :class:`HelpPanelView`'s
+    registration in the persistent-view registry. That's intentional:
+    help anchors are skipped at restart (see
+    ``message_anchor_manager.restore_anchors``), so the registration
+    is effectively unused for restore but is kept for symmetry with
+    the rest of the codebase.
+
+    Stateless aside from ``_member_tier`` cached at construction time
+    so the dropdown options match the user's governance tier. The
+    select callback re-resolves visibility before opening a hub so a
+    user who lost a tier between Help renders gets the current state,
+    not the stale snapshot.
+    """
+
+    SUBSYSTEM = "help"
+
+    def __init__(self, member_tier: str | None = None) -> None:
+        super().__init__()
+        self._member_tier = member_tier or "user"
+        self._rebuild_items()
+
+    def _rebuild_items(self) -> None:
+        self.clear_items()
+        visible_hubs = hubs_for_tier(self._member_tier)
+        options: list[discord.SelectOption] = []
+        for hub in visible_hubs:
+            options.append(
+                discord.SelectOption(
+                    label=hub.display_name[:100],
+                    value=hub.key,
+                    description=hub.purpose[:100],
+                    emoji=hub.emoji or None,
+                ),
+            )
+        # All Commands / Advanced is permanent — guarantees discoverability
+        # for every visible subsystem even when no mother hub owns it.
+        options.append(
+            discord.SelectOption(
+                label="All Commands / Advanced",
+                value=ALL_COMMANDS_KEY,
+                description="Browse every visible command directly.",
+                emoji="📋",
+            ),
+        )
+        select = discord.ui.Select(  # type: ignore[var-annotated]
+            custom_id="help_categories:select",
+            placeholder="Pick a category…",
+            min_values=1,
+            max_values=1,
+            options=options,
+            row=0,
+        )
+        select.callback = self._on_select  # type: ignore[method-assign]
+        self.add_item(select)
+
+    async def _on_select(self, interaction: discord.Interaction) -> None:
+        value = interaction.data["values"][0]  # type: ignore[typeddict-item]
+
+        # Re-resolve governance at click time so the user's current
+        # visibility/tier drives the next view, not the snapshot from
+        # when the category panel was first rendered.
+        gctx = GovernanceContext.from_interaction(interaction)
+        vis_result = await governance_service.resolve_visibility(gctx)
+
+        if value == ALL_COMMANDS_KEY:
+            visible_list = [
+                name
+                for name, meta in all_subsystems_sorted()
+                if name in vis_result.visible_subsystems
+                and not meta.get("parent_hub")
+            ]
+            new_view = HelpPanelView(visible_list, page=0)
+            embed = _build_page_embed(
+                interaction.client,  # type: ignore[arg-type]
+                visible_list,
+                0,
+                vis_result.member_tier,
+            )
+            await interaction.response.edit_message(embed=embed, view=new_view)
+            return
+
+        # Hub category — route to the host cog's build_help_menu_view.
+        hub = get_hub(value)
+        if hub is None:
+            await interaction.response.send_message(
+                "That category is no longer available.",
+                ephemeral=True,
+            )
+            return
+
+        cog = _cog_for_subsystem(interaction.client, hub.key)  # type: ignore[arg-type]
+        if cog is None:
+            await interaction.response.send_message(
+                f"The {hub.display_name} hub is not loaded right now.",
+                ephemeral=True,
+            )
+            return
+
+        build_panel = getattr(cog, "build_help_menu_view", None)
+        if not callable(build_panel):
+            await interaction.response.send_message(
+                f"The {hub.display_name} hub doesn't expose a panel yet.",
+                ephemeral=True,
+            )
+            return
+
+        try:
+            embed, sub_view = await build_panel(interaction)
+        except Exception as exc:  # noqa: BLE001 — Help must never crash on hook
+            logger.warning(
+                "HelpCategoryView: build_help_menu_view failed for hub=%r: %s",
+                hub.key,
+                exc,
+                exc_info=True,
+            )
+            await interaction.response.send_message(
+                f"Could not open the {hub.display_name} hub — see bot logs.",
+                ephemeral=True,
+            )
+            return
+
+        _attach_back_to_help_button(sub_view)
+        await interaction.response.edit_message(embed=embed, view=sub_view)
 
 
 class HelpCog(commands.Cog):
@@ -502,8 +674,14 @@ class HelpCog(commands.Cog):
             )
             return
 
-        view = HelpPanelView(visible_list, page=0)
-        embed = _build_page_embed(self.bot, visible_list, 0, member_tier)
+        # S3: the top of Help is now the mother-hub category index.
+        # The legacy paginated subsystem list is reached only via the
+        # "All Commands / Advanced" entry inside HelpCategoryView; the
+        # hub-child filter lives in that branch (see
+        # HelpCategoryView._on_select), not here.
+        del visible_list
+        view = HelpCategoryView(member_tier)
+        embed = build_categories_overview_embed(member_tier)
 
         # The help panel is invoke-and-see, not a stable hub: each !help should
         # appear at the bottom of the channel where the user just typed.

--- a/disbot/utils/hub_registry.py
+++ b/disbot/utils/hub_registry.py
@@ -1,0 +1,188 @@
+"""Central hub presentation registry (S3).
+
+Hub display metadata MUST NOT be scattered inside ``help_cog.py`` —
+that would couple Help rendering to subsystem-specific knowledge and
+make new hubs (S7–S10) painful to land. Instead, every visible mother
+hub registers a single :class:`HubEntry` here. Help and (later) slash
+front doors both read from this single source.
+
+Presentation only. The registry describes Help/category display.
+It is NOT a second router and must not own business logic:
+
+* No DB writes.
+* No governance resolution. ``minimum_tier`` is metadata — Help
+  is responsible for applying it via ``governance_service``.
+* No command dispatch. ``entry_command`` is metadata; the actual
+  ``!`` command lives in the host cog.
+
+Cross-references:
+
+* :mod:`utils.subsystem_registry` — canonical SUBSYSTEMS metadata
+  (with ``parent_hub`` / ``hub_group`` for child discovery).
+* :mod:`docs.building-roadmap.mother-hub-map` — the design
+  doctrine this registry implements (§ "Central hub presentation
+  registry").
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Sentinel hub key for the permanent tier-grouped subsystem browser.
+# Selecting this category in the Help dropdown opens the paginated
+# all-commands view (the pre-S3 Help layout, now demoted to a
+# secondary navigation path).
+ALL_COMMANDS_KEY = "all_commands"
+
+
+@dataclass(frozen=True)
+class HubEntry:
+    """One mother-hub entry in the Help category index.
+
+    Fields:
+        key: stable internal id (e.g. ``"games"``). Doubles as the
+            registry key. For hubs with a ``parent_hub``-backed child
+            list, this must equal the ``parent_hub`` value used in
+            ``SUBSYSTEMS``.
+        display_name: user-facing name (e.g. ``"Games"``).
+        emoji: single emoji for the dropdown / embed.
+        purpose: 1-line description shown under the category heading.
+        entry_command: typed ``!`` command (e.g. ``"!games"``). The
+            doctrine forbids panel-only hubs.
+        slash_command: future ``/`` command, ``None`` until S11.
+        primary_children: subsystem keys whose ``parent_hub`` equals
+            ``key``. Empty for hubs that don't use child discovery
+            (Admin, Settings, Platform).
+        cross_link_children: subsystem keys cross-listed via UI
+            buttons (no metadata change). Empty for the v1 hubs.
+        minimum_tier: lowest governance tier that may see this hub.
+            ``"user"`` shows to everyone; ``"administrator"`` hides
+            from non-admins. Help applies the filter.
+        settings_path: settings hub subsystem key (or ``None``).
+        panel_available: ``True`` when the hub has a real panel that
+            ``build_help_menu_view`` can return. ``False`` hides the
+            hub from Help — the visibility rule.
+    """
+
+    key: str
+    display_name: str
+    emoji: str
+    purpose: str
+    entry_command: str
+    slash_command: str | None = None
+    primary_children: tuple[str, ...] = ()
+    cross_link_children: tuple[str, ...] = ()
+    minimum_tier: str = "user"
+    settings_path: str | None = None
+    panel_available: bool = True
+
+
+# ---------------------------------------------------------------------------
+# Canonical hub list (S3 v1 — existing-hub-only rollout)
+# ---------------------------------------------------------------------------
+#
+# Only hubs whose panels exist today appear here. Economy, Moderation/
+# Safety, Community, and Utility hubs are added by S7–S10 PRs once their
+# panels land. Until then, their child subsystems remain reachable via
+# the All Commands / Advanced fallback.
+#
+# Order in this tuple drives display order in Help. The All Commands
+# fallback always sorts last (Help appends it after the iteration).
+
+HUBS: tuple[HubEntry, ...] = (
+    HubEntry(
+        key="games",
+        display_name="Games",
+        emoji="🎮",
+        purpose="Game flows and tournaments.",
+        entry_command="!games",
+        primary_children=(
+            "blackjack",
+            "deathmatch",
+            "rps_tournament",
+            "mining",
+            "counting",
+            "chain",
+        ),
+        minimum_tier="user",
+    ),
+    HubEntry(
+        key="admin",
+        display_name="Admin / Operations",
+        emoji="⚙️",
+        purpose="Cog management, role/channel admin, runtime ops.",
+        entry_command="!adminmenu",
+        minimum_tier="administrator",
+    ),
+    HubEntry(
+        key="settings",
+        display_name="Settings / Configuration",
+        emoji="🔧",
+        purpose="Configure all subsystems via mutation pipelines.",
+        entry_command="!settings",
+        minimum_tier="administrator",
+    ),
+    HubEntry(
+        key="diagnostic",
+        display_name="Platform / Diagnostics",
+        emoji="🩺",
+        purpose="Platform identity, feature flags, runtime health.",
+        entry_command="!platform",
+        minimum_tier="administrator",
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Lookups
+# ---------------------------------------------------------------------------
+
+
+def get_hub(key: str) -> HubEntry | None:
+    """Return the :class:`HubEntry` for ``key``, or ``None``."""
+    for hub in HUBS:
+        if hub.key == key:
+            return hub
+    return None
+
+
+def hubs_for_tier(member_tier: str) -> list[HubEntry]:
+    """Return hubs visible to ``member_tier`` in registry order.
+
+    Uses :func:`governance.permission_tiers.tier_at_or_above` so the
+    tier comparison stays consistent with the rest of the bot.
+
+    Hubs with ``panel_available=False`` are filtered out — the
+    visibility rule from the mother-hub map.
+
+    Unknown or legacy tier strings (e.g. an old ``"everyone"`` left in
+    a fixture) are treated as the lowest tier ``"user"`` so Help never
+    crashes on stale data. The decision is logged at WARNING via the
+    governance module for visibility.
+    """
+    # Local import: governance lives outside utils to keep the
+    # import graph layered. Function-local keeps this module
+    # cheap to import at startup.
+    from governance.permission_tiers import tier_at_or_above
+
+    visible: list[HubEntry] = []
+    for hub in HUBS:
+        if not hub.panel_available:
+            continue
+        try:
+            allowed = tier_at_or_above(member_tier, hub.minimum_tier)
+        except ValueError:
+            # Defensive: unknown tier string → only user-tier hubs.
+            allowed = tier_at_or_above("user", hub.minimum_tier)
+        if allowed:
+            visible.append(hub)
+    return visible
+
+
+__all__ = [
+    "ALL_COMMANDS_KEY",
+    "HUBS",
+    "HubEntry",
+    "get_hub",
+    "hubs_for_tier",
+]

--- a/tests/unit/cogs/test_admin_menu_integration.py
+++ b/tests/unit/cogs/test_admin_menu_integration.py
@@ -320,7 +320,10 @@ async def test_open_via_help_hook_handles_hook_exception():
 
 
 @pytest.mark.asyncio
-async def test_help_button_opens_help_panel_view():
+async def test_help_button_opens_help_category_view():
+    """S3: the admin Help button returns the user to the top of Help,
+    which is now :class:`HelpCategoryView` (mother-hub categories).
+    """
     view = _admin_view()
     btn = _find_button(view, "Help")
     interaction = MagicMock()
@@ -328,8 +331,8 @@ async def test_help_button_opens_help_panel_view():
 
     vis_result = MagicMock()
     vis_result.visible_subsystems = {"economy", "moderation"}
-    vis_result.member_tier = "everyone"
-    fake_panel_view = discord.ui.View()
+    vis_result.member_tier = "administrator"
+    fake_view = discord.ui.View()
     fake_embed = discord.Embed(title="Help")
 
     with patch(
@@ -344,30 +347,20 @@ async def test_help_button_opens_help_panel_view():
         "services.governance_service.GovernanceContext.from_interaction",
         return_value=MagicMock(),
     ), patch(
-        "cogs.help_cog.all_subsystems_sorted",
-        return_value=[
-            ("economy", {}),
-            ("moderation", {}),
-            ("invisible_sub", {}),
-        ],
-    ), patch(
-        "cogs.help_cog.HelpPanelView",
-        return_value=fake_panel_view,
-    ) as panel_cls, patch(
-        "cogs.help_cog._build_page_embed",
+        "cogs.help_cog.HelpCategoryView",
+        return_value=fake_view,
+    ) as view_cls, patch(
+        "cogs.help_cog.build_categories_overview_embed",
         return_value=fake_embed,
-    ) as page_builder, patch(
+    ), patch(
         "cogs.admin_cog.safe_edit",
         new_callable=AsyncMock,
         return_value=True,
     ) as edit:
         await btn.callback(interaction)
-    panel_cls.assert_called_once()
-    visible_list_arg = panel_cls.call_args.args[0]
-    assert visible_list_arg == ["economy", "moderation"]
-    page_builder.assert_called_once()
+    view_cls.assert_called_once_with("administrator")
     edit.assert_awaited_once()
-    assert edit.await_args.kwargs["view"] is fake_panel_view
+    assert edit.await_args.kwargs["view"] is fake_view
 
 
 @pytest.mark.asyncio

--- a/tests/unit/help/test_help_category_view.py
+++ b/tests/unit/help/test_help_category_view.py
@@ -1,0 +1,363 @@
+"""Unit tests for HelpCategoryView (S3 — Help category index).
+
+Pins the S3 behaviour:
+
+- ``!help`` opens a category-grouped view, not the legacy paginated
+  subsystem list.
+- The dropdown shows one option per visible mother hub + the permanent
+  ALL_COMMANDS fallback. Hub children never appear at this level.
+- Selecting a hub category opens the hub's ``build_help_menu_view``
+  and attaches Back-to-Help (which rebuilds the category view).
+- Selecting ALL_COMMANDS swaps the view to :class:`HelpPanelView`
+  populated with a parent_hub-filtered visible list.
+- Permission/role matrix: admin-restricted hubs hide from non-admin
+  users; the ALL_COMMANDS option is always visible.
+- Failure paths surface as ephemerals; the message is never left
+  half-edited.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from cogs import help_cog
+from cogs.help_cog import (
+    ALL_COMMANDS_KEY,
+    HelpCategoryView,
+    HelpPanelView,
+    build_categories_overview_embed,
+)
+
+
+def _interaction() -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = MagicMock()
+    interaction.user = MagicMock()
+    interaction.user.id = 7
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    return interaction
+
+
+def _select(view: HelpCategoryView) -> discord.ui.Select:
+    return next(c for c in view.children if isinstance(c, discord.ui.Select))
+
+
+# ---------------------------------------------------------------------------
+# Embed shape — orientation rule from the mother-hub map
+# ---------------------------------------------------------------------------
+
+
+def test_categories_embed_lists_each_visible_hub_with_purpose_and_entry_cmd():
+    """Per the orientation rule: every category states what it is for,
+    who/what it includes, and its typed entry command.
+    """
+    embed = build_categories_overview_embed(member_tier="administrator")
+    field_names = [f.name for f in embed.fields]
+    field_values = [f.value for f in embed.fields]
+
+    # The four S3-v1 hubs must each appear as a top-level field.
+    assert any("Games" in n for n in field_names)
+    assert any("Admin" in n for n in field_names)
+    assert any("Settings" in n for n in field_names)
+    assert any("Platform" in n for n in field_names)
+
+    # Each field value contains the typed entry command.
+    joined = "\n".join(field_values)
+    assert "!games" in joined
+    assert "!adminmenu" in joined
+    assert "!settings" in joined
+    assert "!platform" in joined
+
+
+def test_categories_embed_always_includes_all_commands_fallback():
+    embed = build_categories_overview_embed(member_tier="user")
+    field_names = [f.name for f in embed.fields]
+    assert any("All Commands" in n for n in field_names)
+
+
+def test_categories_embed_hides_admin_only_hubs_from_normal_users():
+    embed = build_categories_overview_embed(member_tier="user")
+    field_names = [f.name for f in embed.fields]
+    # Normal-tier users must not see administrator-restricted hubs as
+    # top-level categories.
+    assert not any("Admin" in n for n in field_names)
+    assert not any("Settings" in n for n in field_names)
+    assert not any("Platform" in n for n in field_names)
+    # But Games (user tier) and the fallback are still visible.
+    assert any("Games" in n for n in field_names)
+    assert any("All Commands" in n for n in field_names)
+
+
+def test_categories_embed_includes_line_lists_games_children():
+    """The Games category must show its children in the 'Includes:'
+    line so users know what's behind the dropdown.
+    """
+    embed = build_categories_overview_embed(member_tier="user")
+    games_field = next(f for f in embed.fields if "Games" in f.name)
+    # Pin a sampling of the known children rather than the full set —
+    # changes to game roster shouldn't break this test.
+    assert "Blackjack" in games_field.value
+    assert "Mining" in games_field.value
+
+
+# ---------------------------------------------------------------------------
+# View shape
+# ---------------------------------------------------------------------------
+
+
+def test_view_has_one_select_with_visible_hubs_plus_all_commands():
+    view = HelpCategoryView(member_tier="administrator")
+    select = _select(view)
+    values = {opt.value for opt in select.options}
+    # S3 v1 hubs visible to administrator + ALL_COMMANDS sentinel.
+    assert values == {"games", "admin", "settings", "diagnostic", ALL_COMMANDS_KEY}
+
+
+def test_user_tier_view_omits_admin_hubs():
+    view = HelpCategoryView(member_tier="user")
+    select = _select(view)
+    values = {opt.value for opt in select.options}
+    assert "games" in values
+    assert ALL_COMMANDS_KEY in values
+    assert "admin" not in values
+    assert "settings" not in values
+    assert "diagnostic" not in values
+
+
+def test_view_has_no_individual_hub_child_options():
+    """Hub children (Blackjack, RPS, Mining, etc.) must never appear at
+    the top level — they're reachable only through their parent hub.
+    """
+    view = HelpCategoryView(member_tier="owner")
+    select = _select(view)
+    values = {opt.value for opt in select.options}
+    for hub_child in (
+        "blackjack",
+        "rps_tournament",
+        "deathmatch",
+        "mining",
+        "counting",
+        "chain",
+    ):
+        assert hub_child not in values, (
+            f"hub child {hub_child!r} leaked into HelpCategoryView top-level"
+        )
+
+
+def test_view_default_member_tier_is_user_when_unspecified():
+    view = HelpCategoryView()
+    # Default tier is "user" — admin hubs must not surface.
+    assert view._member_tier == "user"  # type: ignore[attr-defined]
+    select = _select(view)
+    values = {opt.value for opt in select.options}
+    assert "admin" not in values
+
+
+# ---------------------------------------------------------------------------
+# Routing — All Commands branch swaps to HelpPanelView
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_selecting_all_commands_swaps_to_help_panel_view(monkeypatch):
+    """Selecting "All Commands / Advanced" opens the legacy paginated
+    view in place. Custom IDs from the new dropdown go away because
+    Discord matches the next click against the new view's custom_ids.
+    """
+    interaction = _interaction()
+    interaction.data = {"values": [ALL_COMMANDS_KEY]}
+
+    vis_result = MagicMock()
+    vis_result.visible_subsystems = set(["economy", "mining", "games"])
+    vis_result.member_tier = "owner"
+
+    monkeypatch.setattr(
+        help_cog.governance_service,
+        "resolve_visibility",
+        AsyncMock(return_value=vis_result),
+    )
+    monkeypatch.setattr(
+        help_cog.GovernanceContext,
+        "from_interaction",
+        lambda i: MagicMock(),
+    )
+
+    view = HelpCategoryView(member_tier="owner")
+    await view._on_select(interaction)
+
+    interaction.response.edit_message.assert_awaited_once()
+    _args, kwargs = interaction.response.edit_message.call_args
+    assert isinstance(kwargs["view"], HelpPanelView)
+
+
+# ---------------------------------------------------------------------------
+# Routing — Hub category opens host cog's build_help_menu_view
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_selecting_hub_category_opens_host_cog_panel(monkeypatch):
+    interaction = _interaction()
+    interaction.data = {"values": ["games"]}
+
+    vis_result = MagicMock()
+    vis_result.visible_subsystems = set()
+    vis_result.member_tier = "owner"
+
+    monkeypatch.setattr(
+        help_cog.governance_service,
+        "resolve_visibility",
+        AsyncMock(return_value=vis_result),
+    )
+    monkeypatch.setattr(
+        help_cog.GovernanceContext,
+        "from_interaction",
+        lambda i: MagicMock(),
+    )
+
+    fake_panel_view = discord.ui.View()
+    fake_panel_embed = discord.Embed(title="Games Hub")
+    fake_cog = MagicMock()
+    fake_cog.build_help_menu_view = AsyncMock(
+        return_value=(fake_panel_embed, fake_panel_view),
+    )
+
+    with patch("cogs.help_cog._cog_for_subsystem", return_value=fake_cog):
+        view = HelpCategoryView(member_tier="owner")
+        await view._on_select(interaction)
+
+    fake_cog.build_help_menu_view.assert_awaited_once()
+    interaction.response.edit_message.assert_awaited_once()
+    _args, kwargs = interaction.response.edit_message.call_args
+    assert kwargs["embed"] is fake_panel_embed
+    assert kwargs["view"] is fake_panel_view
+
+    # Back-to-Help must be attached to the hub panel so the user can
+    # return to the category index.
+    back_buttons = [
+        c
+        for c in fake_panel_view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "help:back"
+    ]
+    assert len(back_buttons) == 1
+
+
+@pytest.mark.asyncio
+async def test_selecting_unknown_hub_sends_ephemeral(monkeypatch):
+    interaction = _interaction()
+    interaction.data = {"values": ["not_a_real_hub"]}
+
+    vis_result = MagicMock()
+    vis_result.visible_subsystems = set()
+    vis_result.member_tier = "owner"
+
+    monkeypatch.setattr(
+        help_cog.governance_service,
+        "resolve_visibility",
+        AsyncMock(return_value=vis_result),
+    )
+    monkeypatch.setattr(
+        help_cog.GovernanceContext,
+        "from_interaction",
+        lambda i: MagicMock(),
+    )
+
+    view = HelpCategoryView(member_tier="owner")
+    await view._on_select(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    interaction.response.edit_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_hub_cog_missing_send_ephemeral(monkeypatch):
+    interaction = _interaction()
+    interaction.data = {"values": ["games"]}
+
+    vis_result = MagicMock()
+    vis_result.visible_subsystems = set()
+    vis_result.member_tier = "owner"
+
+    monkeypatch.setattr(
+        help_cog.governance_service,
+        "resolve_visibility",
+        AsyncMock(return_value=vis_result),
+    )
+    monkeypatch.setattr(
+        help_cog.GovernanceContext,
+        "from_interaction",
+        lambda i: MagicMock(),
+    )
+
+    with patch("cogs.help_cog._cog_for_subsystem", return_value=None):
+        view = HelpCategoryView(member_tier="owner")
+        await view._on_select(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    interaction.response.edit_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_hub_build_help_menu_view_exception_sends_ephemeral(monkeypatch):
+    interaction = _interaction()
+    interaction.data = {"values": ["games"]}
+
+    vis_result = MagicMock()
+    vis_result.visible_subsystems = set()
+    vis_result.member_tier = "owner"
+
+    monkeypatch.setattr(
+        help_cog.governance_service,
+        "resolve_visibility",
+        AsyncMock(return_value=vis_result),
+    )
+    monkeypatch.setattr(
+        help_cog.GovernanceContext,
+        "from_interaction",
+        lambda i: MagicMock(),
+    )
+
+    fake_cog = MagicMock()
+    fake_cog.build_help_menu_view = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with patch("cogs.help_cog._cog_for_subsystem", return_value=fake_cog):
+        view = HelpCategoryView(member_tier="owner")
+        await view._on_select(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    interaction.response.edit_message.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Persistent-view registration
+# ---------------------------------------------------------------------------
+
+
+def test_help_category_view_registered_as_help_subsystem():
+    """``HelpCategoryView`` is the canonical Help view after S3, so it
+    must claim the ``"help"`` subsystem key in the persistent-view
+    registry.
+    """
+    from core.runtime.persistent_views import get_view_class
+
+    assert get_view_class("help") is HelpCategoryView
+
+
+# ---------------------------------------------------------------------------
+# Custom IDs are stable and follow <subsystem>:<action>
+# ---------------------------------------------------------------------------
+
+
+def test_category_select_custom_id_is_stable():
+    """Custom ID must remain ``help_categories:select`` so that any
+    future persistent-view registrations or click handlers continue
+    to resolve.
+    """
+    view = HelpCategoryView(member_tier="owner")
+    select = _select(view)
+    assert select.custom_id == "help_categories:select"

--- a/tests/unit/help/test_help_parent_hub_filter.py
+++ b/tests/unit/help/test_help_parent_hub_filter.py
@@ -112,13 +112,16 @@ def test_build_page_embed_excludes_parent_hub_children():
 
 
 @pytest.mark.asyncio
-async def test_resolve_help_panel_state_visible_list_excludes_hub_children(
-    monkeypatch,
-):
-    """``resolve_help_panel_state`` must filter hub children out of the
-    visible_list it passes to HelpPanelView, otherwise pagination and
-    the select would still include them.
+async def test_resolve_help_panel_state_returns_category_view(monkeypatch):
+    """S3: ``resolve_help_panel_state`` returns the new
+    :class:`HelpCategoryView` (mother-hub category index), not the
+    legacy paginated subsystem list. The category view's dropdown lists
+    mother hubs + the permanent "All Commands / Advanced" fallback —
+    individual hub children (Blackjack, RPS, etc.) only appear after
+    the user selects the relevant hub.
     """
+    import discord as _discord
+
     interaction = MagicMock()
     interaction.client = MagicMock()
 
@@ -139,11 +142,64 @@ async def test_resolve_help_panel_state_visible_list_excludes_hub_children(
     )
 
     embed, view = await help_cog.resolve_help_panel_state(interaction)
-    visible_list = view._visible  # type: ignore[attr-defined]
+    assert isinstance(view, help_cog.HelpCategoryView)
 
+    # The top-level dropdown must never expose individual hub children
+    # (e.g. Blackjack, RPS, Mining) — those are reached via the parent
+    # hub category, not from Help directly.
+    option_values: set[str] = set()
+    for child in view.children:
+        if isinstance(child, _discord.ui.Select):
+            option_values.update(opt.value for opt in child.options)
+    for child in _hub_children():
+        assert child not in option_values, (
+            f"hub child {child!r} leaked into HelpCategoryView dropdown"
+        )
+    # The Games hub itself IS in the dropdown.
+    assert "games" in option_values
+
+
+@pytest.mark.asyncio
+async def test_help_category_view_all_commands_branch_filters_hub_children(
+    monkeypatch,
+):
+    """Selecting "All Commands / Advanced" inside :class:`HelpCategoryView`
+    swaps the view to :class:`HelpPanelView` populated with a
+    parent_hub-filtered list — so the paginated fallback never leaks
+    hub children into the top-level command list.
+    """
+    interaction = MagicMock()
+    interaction.client = MagicMock()
+    interaction.response = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    interaction.data = {"values": [help_cog.ALL_COMMANDS_KEY]}
+
+    vis_result = MagicMock()
+    vis_result.visible_subsystems = _all_visible_set()
+    vis_result.member_tier = "owner"
+
+    monkeypatch.setattr(
+        help_cog.governance_service,
+        "resolve_visibility",
+        AsyncMock(return_value=vis_result),
+    )
+    monkeypatch.setattr(
+        help_cog.GovernanceContext,
+        "from_interaction",
+        lambda i: MagicMock(),
+    )
+
+    view = help_cog.HelpCategoryView(member_tier="owner")
+    await view._on_select(interaction)
+
+    interaction.response.edit_message.assert_awaited_once()
+    _args, kwargs = interaction.response.edit_message.call_args
+    new_view = kwargs["view"]
+    assert isinstance(new_view, help_cog.HelpPanelView)
+    visible_list = new_view._visible  # type: ignore[attr-defined]
     for child in _hub_children():
         assert child not in visible_list, (
-            f"hub child {child!r} leaked into resolve_help_panel_state visible_list"
+            f"hub child {child!r} leaked into the All Commands view"
         )
     assert "games" in visible_list
 

--- a/tests/unit/help/test_resolve_help_panel_state.py
+++ b/tests/unit/help/test_resolve_help_panel_state.py
@@ -1,18 +1,20 @@
 """Unit tests for cogs.help_cog.resolve_help_panel_state.
 
-The helper consolidates the governance-resolve + HelpPanelView-open
-flow used by navigation buttons in other cogs / views
-(admin_cog.help_btn, mine_view._MineResultsView.help_btn).  These
-tests pin the helper's contract:
+S3: the helper now returns a :class:`HelpCategoryView` — the new
+mother-hub category index — instead of the legacy paginated
+:class:`HelpPanelView`. Callers (``admin_cog.help_btn``,
+``mine_view._MineResultsView.help_btn``) edit the message with the
+returned ``(embed, view)`` pair; they don't care which class the
+view is, only that it represents the top of Help.
 
-- it resolves the visibility set via governance and filters
-  all_subsystems_sorted() to that set;
-- it instantiates HelpPanelView with the filtered list at page=0;
-- it builds the page embed via _build_page_embed with the resolved
-  member tier;
-- it returns (embed, view) — never raises on the happy path;
-- exceptions from governance_service propagate so callers can render
-  their own fallback (no swallowing inside the helper).
+Pinned contract:
+
+- governance is resolved at every call;
+- the returned view is :class:`HelpCategoryView`;
+- the embed is built by :func:`build_categories_overview_embed` with
+  the member tier from governance;
+- exceptions from ``governance_service`` propagate so callers can
+  render their own fallback (no swallowing inside the helper).
 """
 
 from __future__ import annotations
@@ -22,7 +24,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import discord
 import pytest
 
-from cogs.help_cog import HelpPanelView, resolve_help_panel_state
+from cogs.help_cog import HelpCategoryView, resolve_help_panel_state
 
 
 def _interaction() -> MagicMock:
@@ -39,13 +41,17 @@ def _interaction() -> MagicMock:
 
 
 @pytest.mark.asyncio
-async def test_resolves_visible_subsystems_and_returns_panel_state():
+async def test_resolves_visibility_and_returns_category_view():
+    """S3: the helper resolves governance, builds a category-index
+    embed for the resolved tier, and returns the new
+    :class:`HelpCategoryView` (not the legacy paginated view).
+    """
     interaction = _interaction()
     vis_result = MagicMock()
     vis_result.visible_subsystems = {"economy", "mining"}
     vis_result.member_tier = "user"
 
-    fake_panel_view = HelpPanelView(visible_list=[], page=0)
+    fake_view = HelpCategoryView(member_tier="user")
     fake_embed = discord.Embed(title="Help")
 
     with patch(
@@ -56,44 +62,30 @@ async def test_resolves_visible_subsystems_and_returns_panel_state():
         new_callable=AsyncMock,
         return_value=vis_result,
     ), patch(
-        "cogs.help_cog.all_subsystems_sorted",
-        return_value=[("economy", {}), ("mining", {}), ("admin", {})],
-    ), patch(
-        "cogs.help_cog.HelpPanelView",
-        return_value=fake_panel_view,
-    ) as panel_cls, patch(
-        "cogs.help_cog._build_page_embed",
+        "cogs.help_cog.HelpCategoryView",
+        return_value=fake_view,
+    ) as view_cls, patch(
+        "cogs.help_cog.build_categories_overview_embed",
         return_value=fake_embed,
-    ) as page_builder:
+    ) as embed_builder:
         embed, view = await resolve_help_panel_state(interaction)
 
-    # admin must be filtered out (not in visible_subsystems).
-    panel_cls.assert_called_once()
-    visible_list_arg = panel_cls.call_args.args[0]
-    assert visible_list_arg == ["economy", "mining"]
-    assert panel_cls.call_args.kwargs.get("page") == 0
-
-    page_builder.assert_called_once()
-    # _build_page_embed(bot, visible_list, page=0, member_tier).
-    pb_args = page_builder.call_args.args
-    assert pb_args[0] is interaction.client
-    assert pb_args[1] == ["economy", "mining"]
-    assert pb_args[2] == 0
-    assert pb_args[3] == "user"
-
+    view_cls.assert_called_once_with("user")
+    embed_builder.assert_called_once_with("user")
     assert embed is fake_embed
-    assert view is fake_panel_view
+    assert view is fake_view
 
 
 @pytest.mark.asyncio
-async def test_empty_visible_subsystems_yields_empty_visible_list():
+async def test_admin_tier_yields_category_view_with_admin_options():
+    """An administrator-tier user sees admin-restricted hubs in the
+    category dropdown — verifies the tier flows through governance
+    into the view constructor.
+    """
     interaction = _interaction()
     vis_result = MagicMock()
     vis_result.visible_subsystems = set()
-    vis_result.member_tier = "user"
-
-    fake_panel_view = HelpPanelView(visible_list=[], page=0)
-    fake_embed = discord.Embed(title="Help")
+    vis_result.member_tier = "administrator"
 
     with patch(
         "services.governance_service.GovernanceContext.from_interaction",
@@ -102,20 +94,11 @@ async def test_empty_visible_subsystems_yields_empty_visible_list():
         "services.governance_service.resolve_visibility",
         new_callable=AsyncMock,
         return_value=vis_result,
-    ), patch(
-        "cogs.help_cog.all_subsystems_sorted",
-        return_value=[("economy", {}), ("mining", {})],
-    ), patch(
-        "cogs.help_cog.HelpPanelView",
-        return_value=fake_panel_view,
-    ) as panel_cls, patch(
-        "cogs.help_cog._build_page_embed",
-        return_value=fake_embed,
     ):
         embed, view = await resolve_help_panel_state(interaction)
-    assert panel_cls.call_args.args[0] == []
-    assert embed is fake_embed
-    assert view is fake_panel_view
+
+    assert isinstance(view, HelpCategoryView)
+    assert view._member_tier == "administrator"  # type: ignore[attr-defined]
 
 
 # ---------------------------------------------------------------------------
@@ -125,7 +108,7 @@ async def test_empty_visible_subsystems_yields_empty_visible_list():
 
 @pytest.mark.asyncio
 async def test_governance_exception_propagates_to_caller():
-    """The helper does NOT swallow governance failures.  Each caller
+    """The helper does NOT swallow governance failures. Each caller
     (admin_cog, mine_view) wraps the call in its own try/except to
     render a contextual orange embed."""
     interaction = _interaction()
@@ -139,40 +122,3 @@ async def test_governance_exception_propagates_to_caller():
     ):
         with pytest.raises(RuntimeError, match="gov down"):
             await resolve_help_panel_state(interaction)
-
-
-# ---------------------------------------------------------------------------
-# Visibility filtering preserves all_subsystems_sorted ordering
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_visible_list_preserves_registry_ordering():
-    """The filtered list must keep the order produced by
-    all_subsystems_sorted, not the iteration order of the visibility
-    set (which is unordered)."""
-    interaction = _interaction()
-    vis_result = MagicMock()
-    vis_result.visible_subsystems = {"c", "a", "b"}
-    vis_result.member_tier = "user"
-
-    fake_panel_view = HelpPanelView(visible_list=[], page=0)
-    with patch(
-        "services.governance_service.GovernanceContext.from_interaction",
-        return_value=MagicMock(),
-    ), patch(
-        "services.governance_service.resolve_visibility",
-        new_callable=AsyncMock,
-        return_value=vis_result,
-    ), patch(
-        "cogs.help_cog.all_subsystems_sorted",
-        return_value=[("a", {}), ("b", {}), ("c", {})],
-    ), patch(
-        "cogs.help_cog.HelpPanelView",
-        return_value=fake_panel_view,
-    ) as panel_cls, patch(
-        "cogs.help_cog._build_page_embed",
-        return_value=discord.Embed(),
-    ):
-        await resolve_help_panel_state(interaction)
-    assert panel_cls.call_args.args[0] == ["a", "b", "c"]

--- a/tests/unit/utils/test_hub_registry.py
+++ b/tests/unit/utils/test_hub_registry.py
@@ -1,0 +1,162 @@
+"""Unit tests for the central hub presentation registry (S3).
+
+Pins the canonical structure shipped with S3 v1 (existing-hub-only
+rollout): only mother hubs whose panels exist today appear here.
+Economy, Moderation/Safety, Community, and Utility hubs are added by
+S7-S10 PRs and will land with their own entries — the tests should
+fail loudly if a hub is added without a corresponding panel.
+"""
+
+from __future__ import annotations
+
+from utils.hub_registry import (
+    ALL_COMMANDS_KEY,
+    HUBS,
+    HubEntry,
+    get_hub,
+    hubs_for_tier,
+)
+from utils.subsystem_registry import SUBSYSTEMS
+
+
+# ---------------------------------------------------------------------------
+# Registry shape
+# ---------------------------------------------------------------------------
+
+
+def test_hubs_are_immutable_tuple_of_hubentry():
+    """HUBS is intentionally a tuple — readers may iterate but not mutate.
+    Each entry must be a frozen HubEntry so a stale reference can't be
+    edited at runtime.
+    """
+    assert isinstance(HUBS, tuple)
+    for hub in HUBS:
+        assert isinstance(hub, HubEntry)
+
+
+def test_hub_keys_are_unique():
+    keys = [hub.key for hub in HUBS]
+    assert len(keys) == len(set(keys)), f"duplicate hub keys: {keys}"
+
+
+def test_all_commands_key_is_not_a_hub():
+    """ALL_COMMANDS_KEY is a sentinel for the permanent fallback option,
+    not a mother hub. It must not appear in HUBS.
+    """
+    assert ALL_COMMANDS_KEY not in {hub.key for hub in HUBS}
+
+
+def test_s3_v1_existing_hubs_only_rollout():
+    """S3 v1 ships exactly four mother-hub categories: Games, Admin,
+    Settings, Platform. Economy/Moderation/Community/Utility wait for
+    S7-S10. Pinning this prevents a future PR from silently adding a
+    "Coming soon" category that the mother-hub map forbids.
+    """
+    assert {hub.key for hub in HUBS} == {
+        "games",
+        "admin",
+        "settings",
+        "diagnostic",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Cross-references with SUBSYSTEMS
+# ---------------------------------------------------------------------------
+
+
+def test_hub_keys_resolve_to_real_subsystems():
+    """Every hub key must correspond to a real ``SUBSYSTEMS`` entry so
+    ``_cog_for_subsystem(hub.key)`` can find the host cog.
+    """
+    for hub in HUBS:
+        assert hub.key in SUBSYSTEMS, (
+            f"hub key {hub.key!r} has no matching SUBSYSTEMS entry"
+        )
+
+
+def test_games_hub_primary_children_match_parent_hub_filter():
+    """The Games hub's ``primary_children`` must equal the set of
+    SUBSYSTEMS entries whose ``parent_hub == "games"`` — otherwise the
+    Help "Includes:" line and the GamesHubView dropdown disagree.
+    """
+    games = get_hub("games")
+    assert games is not None
+    declared = set(games.primary_children)
+    actual = {
+        name
+        for name, meta in SUBSYSTEMS.items()
+        if meta.get("parent_hub") == "games"
+    }
+    assert declared == actual, (
+        f"Games primary_children {declared} != parent_hub filter {actual}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tier visibility
+# ---------------------------------------------------------------------------
+
+
+def test_hubs_for_tier_user_sees_only_user_tier_hubs():
+    """Normal users see Games (user tier) but not Admin/Settings/Platform
+    (administrator tier).
+    """
+    visible = {hub.key for hub in hubs_for_tier("user")}
+    assert "games" in visible
+    assert "admin" not in visible
+    assert "settings" not in visible
+    assert "diagnostic" not in visible
+
+
+def test_hubs_for_tier_administrator_sees_all():
+    visible = {hub.key for hub in hubs_for_tier("administrator")}
+    assert visible == {"games", "admin", "settings", "diagnostic"}
+
+
+def test_hubs_for_tier_owner_sees_all():
+    visible = {hub.key for hub in hubs_for_tier("owner")}
+    assert visible == {"games", "admin", "settings", "diagnostic"}
+
+
+def test_hubs_for_tier_filters_panel_unavailable():
+    """If a hub were to be defined with panel_available=False, it must
+    not appear regardless of tier. Pinned via a runtime-constructed
+    fake registry so the contract holds even when no hub uses it.
+    """
+    from dataclasses import replace
+
+    # Mutate a copy of an existing hub to flip the flag.
+    fake_hub = replace(HUBS[0], panel_available=False)
+    # Use the same hubs_for_tier code but with a monkeypatch on HUBS.
+    import utils.hub_registry as registry
+
+    original = registry.HUBS
+    try:
+        registry.HUBS = (fake_hub,)
+        visible = registry.hubs_for_tier("owner")
+        assert visible == []
+    finally:
+        registry.HUBS = original
+
+
+# ---------------------------------------------------------------------------
+# Doctrine: registry is presentation, not a router
+# ---------------------------------------------------------------------------
+
+
+def test_no_runtime_callable_fields_on_hubentry():
+    """HubEntry is a frozen dataclass with literal/string fields only —
+    no callbacks, no factory closures. Pins the "presentation only"
+    doctrine; if a future field types a callable, this catches it.
+    """
+    import dataclasses
+
+    for field in dataclasses.fields(HubEntry):
+        annotation = field.type
+        # Allow str, str|None, int, bool, tuple[str, ...], etc. Reject
+        # anything that looks like a callable type.
+        assert "Callable" not in str(annotation), (
+            f"HubEntry.{field.name} appears to type a callable — registry "
+            "must stay presentation-only"
+        )

--- a/tests/unit/utils/test_hub_registry.py
+++ b/tests/unit/utils/test_hub_registry.py
@@ -18,7 +18,6 @@ from utils.hub_registry import (
 )
 from utils.subsystem_registry import SUBSYSTEMS
 
-
 # ---------------------------------------------------------------------------
 # Registry shape
 # ---------------------------------------------------------------------------

--- a/tests/unit/views/test_mining_navigation.py
+++ b/tests/unit/views/test_mining_navigation.py
@@ -178,7 +178,12 @@ async def test_mining_menu_button_swaps_to_mining_hub_view():
 
 
 @pytest.mark.asyncio
-async def test_help_button_opens_help_panel_with_visible_subsystems():
+async def test_help_button_opens_help_category_view():
+    """S3: the mining Help button returns the user to the top of Help,
+    which is now :class:`HelpCategoryView` (the mother-hub category
+    index). The legacy paginated subsystem list is reached only via
+    the "All Commands / Advanced" entry inside that category view.
+    """
     results = _MineResultsView(user_id=1, guild_id=2)
     btn = _find_button(results, "Help")
     interaction = MagicMock()
@@ -186,8 +191,8 @@ async def test_help_button_opens_help_panel_with_visible_subsystems():
 
     vis_result = MagicMock()
     vis_result.visible_subsystems = {"mining", "economy"}
-    vis_result.member_tier = "everyone"
-    fake_panel_view = discord.ui.View()
+    vis_result.member_tier = "user"
+    fake_view = discord.ui.View()
     fake_embed = discord.Embed(title="Help")
 
     with patch(
@@ -202,17 +207,10 @@ async def test_help_button_opens_help_panel_with_visible_subsystems():
         "services.governance_service.GovernanceContext.from_interaction",
         return_value=MagicMock(),
     ), patch(
-        "cogs.help_cog.all_subsystems_sorted",
-        return_value=[
-            ("mining", {}),
-            ("economy", {}),
-            ("admin", {}),
-        ],
-    ), patch(
-        "cogs.help_cog.HelpPanelView",
-        return_value=fake_panel_view,
-    ) as panel_cls, patch(
-        "cogs.help_cog._build_page_embed",
+        "cogs.help_cog.HelpCategoryView",
+        return_value=fake_view,
+    ) as view_cls, patch(
+        "cogs.help_cog.build_categories_overview_embed",
         return_value=fake_embed,
     ), patch(
         "views.mining.mine_view.safe_edit",
@@ -221,12 +219,9 @@ async def test_help_button_opens_help_panel_with_visible_subsystems():
     ) as edit:
         await btn.callback(interaction)
 
-    panel_cls.assert_called_once()
-    visible_list_arg = panel_cls.call_args.args[0]
-    # admin is filtered out because it's not in visible_subsystems.
-    assert visible_list_arg == ["mining", "economy"]
+    view_cls.assert_called_once_with("user")
     edit.assert_awaited_once()
-    assert edit.await_args.kwargs["view"] is fake_panel_view
+    assert edit.await_args.kwargs["view"] is fake_view
 
 
 @pytest.mark.asyncio

--- a/tests/unit/views/test_navigation.py
+++ b/tests/unit/views/test_navigation.py
@@ -320,19 +320,21 @@ def test_help_cog_back_button_uses_shared_navigation_helper():
     assert "views.navigation" in src or "from views.navigation" in src
 
 
-def test_help_cog_back_button_still_clamps_pagination_in_builder():
-    """The help-specific builder kept inside ``help_cog`` must still
-    re-resolve governance and clamp pagination — that logic is help's
-    concern, not the shared helper's.
+def test_help_cog_back_button_rebuilds_category_view_via_governance():
+    """S3: the help-specific builder kept inside ``help_cog`` must still
+    re-resolve governance at click time (so visibility/tier are fresh)
+    and must rebuild :class:`HelpCategoryView` — the new top of Help.
     """
     import inspect
 
     from cogs import help_cog
 
     src = inspect.getsource(help_cog._attach_back_to_help_button)
+    # Governance is still resolved at click time.
     assert "resolve_visibility" in src
-    assert "math.ceil" in src or "_PAGE_SIZE" in src
-    assert "parent_hub" in src  # the Phase 4 filter pin
+    # The new top-of-Help is the category index, not the paginated list.
+    assert "HelpCategoryView" in src
+    assert "build_categories_overview_embed" in src
 
 
 def test_logging_routes_back_uses_shared_navigation_helper():

--- a/tests/unit/views/test_view_error_handling.py
+++ b/tests/unit/views/test_view_error_handling.py
@@ -188,7 +188,7 @@ class TestBackCallbackErrorHandling:
             sub_view = MagicMock()
             sub_view.children = []
             sub_view.add_item = MagicMock(side_effect=lambda btn: None)
-            help_cog._attach_back_to_help_button(sub_view, ["general"], 0)
+            help_cog._attach_back_to_help_button(sub_view)
 
             # The back button was passed to add_item; retrieve it.
             assert sub_view.add_item.called
@@ -215,7 +215,7 @@ class TestBackCallbackErrorHandling:
             sub_view = MagicMock()
             sub_view.children = []
             sub_view.add_item = MagicMock()
-            help_cog._attach_back_to_help_button(sub_view, ["general"], 0)
+            help_cog._attach_back_to_help_button(sub_view)
             back_btn = sub_view.add_item.call_args[0][0]
             # Must not raise even if interaction is already done.
             await back_btn.callback(interaction)


### PR DESCRIPTION
## Summary

S3 of the mother-hub PR sequence (see [`mother-hub-map.md`](https://github.com/menno420/superbot/pull/133)). `!help` now opens a category-grouped view (`HelpCategoryView`) that lists the four mother hubs whose panels exist today — **Games**, **Admin / Operations**, **Settings / Configuration**, **Platform / Diagnostics** — plus a permanent **"All Commands / Advanced"** fallback that swaps in place to the legacy paginated subsystem list.

**Existing-hub-only rollout:** Economy, Moderation/Safety, Community, Utility wait for S7–S10 and each promotes to its own category when its panel lands. The mother-hub map forbids advertising hubs that don't exist.

## What changed

**NEW `disbot/utils/hub_registry.py`** — central hub presentation registry. `HubEntry` is a frozen dataclass with literal/string fields only; no callables, no DB writes, no governance resolution, no command dispatch. Help, hub views, and (later) slash front doors all read from this single source.

**`disbot/cogs/help_cog.py`**
- `HelpCategoryView` (new): top-level category dropdown registered as `SUBSYSTEM="help"`. Overrides `HelpPanelView`'s persistent-view registration — restart recovery for help anchors is already skipped (`message_anchor_manager.py:142`), so the swap is safe.
- `build_categories_overview_embed`: per-hub purpose + "Includes:" line + typed entry command. Satisfies the orientation rule from the mother-hub map.
- `resolve_help_panel_state` now returns `HelpCategoryView` so `admin_cog.help_btn` and `mine_view.help_btn` return the user to the new top of Help.
- `_attach_back_to_help_button` simplified — no more `visible_list`/`page` args; rebuilds `HelpCategoryView` with fresh governance state at click time.
- `HelpCog.help_command` opens `HelpCategoryView` by default. Typed `!help <category>` lookup is unchanged.
- `HelpPanelView` is structurally unchanged but is now only reached via the "All Commands / Advanced" entry inside the category view.

## Tier visibility (permission/role matrix)

- **user tier**: Games + All Commands. Admin/Settings/Platform hidden.
- **moderator**: same as user (no moderator-tier hub in S3 v1).
- **administrator / owner**: all four hubs + All Commands.
- Unknown/legacy tier strings (e.g. `"everyone"`) downgrade to user tier — Help must never crash on stale fixtures.

## Custom IDs

- **New**: `help_categories:select` (HelpCategoryView dropdown)
- **Unchanged**: `help:select`, `help:prev`, `help:next`, `help:back`, `help:page_lbl`

## Test plan

- [x] `pytest tests/` — **2237 passed**
- [x] `ruff check disbot/utils/hub_registry.py disbot/cogs/help_cog.py` — All checks passed
- [x] **NEW** `tests/unit/utils/test_hub_registry.py` (11 tests) — pins S3 v1 hub set, tier visibility, registry immutability, presentation-only doctrine
- [x] **NEW** `tests/unit/help/test_help_category_view.py` (15 tests) — embed shape, dropdown shape, All Commands routing, hub routing, failure paths, persistent-view registration
- [ ] Manual Discord smoke: `!help` → category list → Games → Blackjack → Back to Games → Back to Help → All Commands → subsystem → Back to Help

## Rollback

Single `git revert` of the squash commit. The legacy `HelpPanelView` is unchanged and still works on its own custom_ids; help anchors are skipped at restart so no persisted state depends on this PR.

## Next PR

**S4** — visible placeholder/dead-end cleanup (except channel visibility scope which waits for S5).

https://claude.ai/code/session_01ChWkq1H5kgBLNk8zHn1t6H

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChWkq1H5kgBLNk8zHn1t6H)_