### PR TITLE
feat(ux): empty-state next-step hints for leaderboard + mining (S4)

### DIFF
--- a/disbot/cogs/leaderboard_cog.py
+++ b/disbot/cogs/leaderboard_cog.py
@@ -42,6 +42,29 @@ async def _build_embed(
     title, _ = CATEGORIES.get(category, ("Leaderboard", ""))
     embed = discord.Embed(title=title, color=ECONOMY_COLOR)
 
+    # Empty-state hints per category — explain what the feature does and
+    # what the next step is (S4 / user-centered UX rule #5).
+    _EMPTY_HINTS = {
+        "xp": "No XP earned yet. Chat in this server to start ranking up.",
+        "coins": (
+            "No coin totals yet. Use `!daily` once per day or `!work` to start "
+            "earning."
+        ),
+        "mining": "No mining records yet. Use `!mine` to start collecting items.",
+        "deathmatch": (
+            "No deathmatch results yet. Start a match with `!deathmatch` to "
+            "appear here."
+        ),
+        "rps": (
+            "No RPS games played yet. Challenge someone with `!rps` to appear "
+            "here."
+        ),
+        "counting": (
+            "No counting activity yet. Count in the counting channel to appear "
+            "here."
+        ),
+    }
+
     if category == "xp":
         rows = await db.fetchall(
             "SELECT user_id, xp, level FROM xp WHERE guild_id=$1 ORDER BY xp DESC LIMIT 10",
@@ -52,7 +75,7 @@ async def _build_embed(
             name = resources.member_display(guild, row["user_id"])
             icon = MEDALS[i] if i < 3 else f"`#{i+1}`"
             lines.append(f"{icon} **{name}** — Level {row['level']} ({row['xp']} XP)")
-        embed.description = "\n".join(lines) or "No data yet!"
+        embed.description = "\n".join(lines) or _EMPTY_HINTS["xp"]
 
     elif category == "coins":
         rows = await db.fetchall(
@@ -64,7 +87,7 @@ async def _build_embed(
             name = resources.member_display(guild, row["user_id"])
             icon = MEDALS[i] if i < 3 else f"`#{i+1}`"
             lines.append(f"{icon} **{name}** — {row['coins']} 🪙")
-        embed.description = "\n".join(lines) or "No data yet!"
+        embed.description = "\n".join(lines) or _EMPTY_HINTS["coins"]
 
     elif category == "mining":
         rows = await db.get_all_mining_totals(guild.id)
@@ -73,7 +96,7 @@ async def _build_embed(
             name = resources.member_display(guild, user_id)
             icon = MEDALS[i] if i < 3 else f"`#{i+1}`"
             lines.append(f"{icon} **{name}** — {total} items")
-        embed.description = "\n".join(lines) or "No data yet!"
+        embed.description = "\n".join(lines) or _EMPTY_HINTS["mining"]
 
     elif category == "deathmatch":
         rows = await db.get_deathmatch_leaderboard()
@@ -82,7 +105,7 @@ async def _build_embed(
             name = resources.member_display(guild, row["user_id"])
             icon = MEDALS[i] if i < 3 else f"`#{i+1}`"
             lines.append(f"{icon} **{name}** — {row['wins']}W / {row['losses']}L")
-        embed.description = "\n".join(lines) or "No data yet!"
+        embed.description = "\n".join(lines) or _EMPTY_HINTS["deathmatch"]
 
     elif category == "rps":
         rows = await db.rps_get_leaderboard(guild.id)
@@ -92,7 +115,7 @@ async def _build_embed(
             lines.append(
                 f"{icon} **{row['name']}** — {row['wins']}W / {row['losses']}L / {row['ties']}T",
             )
-        embed.description = "\n".join(lines) or "No data yet!"
+        embed.description = "\n".join(lines) or _EMPTY_HINTS["rps"]
 
     elif category == "counting":
         # Aggregate counting totals across all channels for this guild
@@ -107,7 +130,7 @@ async def _build_embed(
             name = resources.member_display(guild, uid)
             icon = MEDALS[i] if i < 3 else f"`#{i+1}`"
             lines.append(f"{icon} **{name}** — {cnt} counts")
-        embed.description = "\n".join(lines) or "No counting data yet!"
+        embed.description = "\n".join(lines) or _EMPTY_HINTS["counting"]
 
     return embed
 

--- a/disbot/cogs/leaderboard_cog.py
+++ b/disbot/cogs/leaderboard_cog.py
@@ -46,23 +46,11 @@ async def _build_embed(
     # what the next step is (S4 / user-centered UX rule #5).
     _EMPTY_HINTS = {
         "xp": "No XP earned yet. Chat in this server to start ranking up.",
-        "coins": (
-            "No coin totals yet. Use `!daily` once per day or `!work` to start "
-            "earning."
-        ),
+        "coins": "No coin totals yet. Use `!daily` once per day or `!work` to start earning.",  # noqa: E501
         "mining": "No mining records yet. Use `!mine` to start collecting items.",
-        "deathmatch": (
-            "No deathmatch results yet. Start a match with `!deathmatch` to "
-            "appear here."
-        ),
-        "rps": (
-            "No RPS games played yet. Challenge someone with `!rps` to appear "
-            "here."
-        ),
-        "counting": (
-            "No counting activity yet. Count in the counting channel to appear "
-            "here."
-        ),
+        "deathmatch": "No deathmatch results yet. Start a match with `!deathmatch` to appear here.",  # noqa: E501
+        "rps": "No RPS games played yet. Challenge someone with `!rps` to appear here.",
+        "counting": "No counting activity yet. Count in the counting channel to appear here.",  # noqa: E501
     }
 
     if category == "xp":

--- a/disbot/views/mining/main_panel.py
+++ b/disbot/views/mining/main_panel.py
@@ -151,7 +151,12 @@ class MiningHubView(PersistentView):
         user_id = str(interaction.user.id)
         inventory = await db.get_mining_inventory(user_id, interaction.guild_id)
         if not inventory:
-            description = "Your mining inventory is empty."
+            # Empty-state UX rule (mother-hub-map.md): explain what the
+            # feature does and what the next step is.
+            description = (
+                "Your mining inventory is empty. Use `!mine` in the mining "
+                "channel to start collecting items."
+            )
         else:
             description = "\n".join(
                 f"**{item.title()}**: {qty}" for item, qty in sorted(inventory.items())

--- a/tests/unit/cogs/test_leaderboard_empty_states.py
+++ b/tests/unit/cogs/test_leaderboard_empty_states.py
@@ -1,0 +1,119 @@
+"""Empty-state behaviour for the leaderboard panel (S4).
+
+Per the user-centered UX rules in the mother-hub map (rule #5: Empty
+states), an empty panel must explain what the feature does and what
+the next step is — not just say "No data yet!".
+
+These tests stub the DB layer to return no rows for each category and
+verify the embed description contains a concrete next-step hint (e.g.
+``!mine``, ``!daily``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from cogs import leaderboard_cog
+
+
+def _guild() -> MagicMock:
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 999
+    return guild
+
+
+def _channel() -> MagicMock:
+    return MagicMock(spec=discord.abc.GuildChannel)
+
+
+# ---------------------------------------------------------------------------
+# Per-category empty-state next-step hint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_xp_leaderboard_empty_hints_chat_to_earn_xp():
+    with patch.object(
+        leaderboard_cog.db,
+        "fetchall",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        embed = await leaderboard_cog._build_embed("xp", _guild(), _channel())
+    assert "Chat" in (embed.description or "")
+    assert "rank" in (embed.description or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_coins_leaderboard_empty_hints_daily_and_work():
+    with patch.object(
+        leaderboard_cog.db,
+        "fetchall",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        embed = await leaderboard_cog._build_embed("coins", _guild(), _channel())
+    assert "!daily" in (embed.description or "")
+    assert "!work" in (embed.description or "")
+
+
+@pytest.mark.asyncio
+async def test_mining_leaderboard_empty_hints_mine_command():
+    with patch.object(
+        leaderboard_cog.db,
+        "get_all_mining_totals",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        embed = await leaderboard_cog._build_embed("mining", _guild(), _channel())
+    assert "!mine" in (embed.description or "")
+
+
+@pytest.mark.asyncio
+async def test_deathmatch_leaderboard_empty_hints_start_a_match():
+    with patch.object(
+        leaderboard_cog.db,
+        "get_deathmatch_leaderboard",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        embed = await leaderboard_cog._build_embed(
+            "deathmatch",
+            _guild(),
+            _channel(),
+        )
+    assert "!deathmatch" in (embed.description or "")
+
+
+@pytest.mark.asyncio
+async def test_rps_leaderboard_empty_hints_challenge_someone():
+    with patch.object(
+        leaderboard_cog.db,
+        "rps_get_leaderboard",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        embed = await leaderboard_cog._build_embed("rps", _guild(), _channel())
+    assert "!rps" in (embed.description or "")
+
+
+@pytest.mark.asyncio
+async def test_counting_leaderboard_empty_hints_count_in_channel():
+    with patch.object(
+        leaderboard_cog.db,
+        "get_counting_state",
+        new_callable=AsyncMock,
+        return_value={"channels": {}},
+    ):
+        embed = await leaderboard_cog._build_embed(
+            "counting",
+            _guild(),
+            _channel(),
+        )
+    # No "No data yet!" — must point at the counting channel.
+    desc = embed.description or ""
+    assert "No data yet!" not in desc
+    assert "count" in desc.lower()


### PR DESCRIPTION
## Summary

S4 of the mother-hub PR sequence (see [`mother-hub-map.md`](https://github.com/menno420/superbot/pull/133)). Replaces generic `"No data yet!"` empty states with concrete next-step hints per the user-centered UX rule #5 ("Empty states explain what the feature does and the next step") from the mother-hub map.

## What changed

**`disbot/cogs/leaderboard_cog.py`** — each leaderboard category now shows a category-specific hint when empty:

| Category | Empty-state hint |
|---|---|
| XP | "Chat in this server to start ranking up." |
| Coins | "Use `!daily` once per day or `!work` to start earning." |
| Mining | "Use `!mine` to start collecting items." |
| Deathmatch | "Start a match with `!deathmatch` to appear here." |
| RPS | "Challenge someone with `!rps` to appear here." |
| Counting | "Count in the counting channel to appear here." |

**`disbot/views/mining/main_panel.py`** — the mining-inventory empty state now points the user at `!mine`.

**NEW `tests/unit/cogs/test_leaderboard_empty_states.py`** (6 tests) — pins each category's next-step hint.

## What S4 did NOT touch (intentionally)

- **`disbot/views/channels/visibility_panel.py`** "category and guild-scope coming soon" copy — per the mother-hub map (placeholder doctrine), this depends on settings ownership (Settings hub vs Channels hub) so it waits for **S5**.
- **`disbot/views/games/hub.py`** "Panel view not implemented yet" fallback — unreachable today (every games child has `build_help_menu_view`); the existing invariant test `test_every_visible_subsystem_cog_has_build_help_menu_view` (`tests/unit/help/test_help_direct_navigation.py`) prevents regression.

## Test plan

- [x] `pytest tests/` — **2219 passed**
- [x] `ruff check disbot/cogs/leaderboard_cog.py disbot/views/mining/main_panel.py` — All checks passed
- [ ] Manual Discord smoke: open the leaderboard panel on a fresh guild → verify each category shows the next-step hint

## Rollback

Single `git revert` of the squash commit. No data, schema, or API changes.

## Next PR

**S5** — settings/config completion: register the dormant `moderation` and `xp` schemas; declare missing schemas (`role`, `channel`, `proof_channel`, `blackjack`); resolve the channel-visibility scope placeholder.

https://claude.ai/code/session_01ChWkq1H5kgBLNk8zHn1t6H

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChWkq1H5kgBLNk8zHn1t6H)_