### PR TITLE
test(registry): pin schema-registration invariant (S5)

### DIFF
--- a/tests/unit/registry/test_schema_registration.py
+++ b/tests/unit/registry/test_schema_registration.py
@@ -1,0 +1,116 @@
+"""Invariant: every subsystem that declares a schema must register it (S5).
+
+A subsystem with ``cogs/<name>/schemas.py:register_schemas`` is declared
+but only becomes reachable from the Settings hub when its cog calls
+``register_schemas()`` from :meth:`cog_load`. A previous audit
+incorrectly claimed moderation/xp schemas were declared but not
+registered — this test pins the actual state so a future PR can't
+silently regress it.
+
+The test is AST-based so it works without loading the cog (which
+would require database / token setup).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_DISBOT = Path(__file__).parents[3] / "disbot"
+_COGS_DIR = _DISBOT / "cogs"
+
+
+def _cogs_declaring_schemas() -> dict[str, Path]:
+    """Return ``{subsystem -> schemas.py path}`` for every subdirectory
+    cog package whose ``schemas.py`` defines ``register_schemas``.
+    """
+    declarers: dict[str, Path] = {}
+    for schemas_py in _COGS_DIR.glob("*/schemas.py"):
+        try:
+            tree = ast.parse(schemas_py.read_text(), filename=str(schemas_py))
+        except SyntaxError:
+            continue
+        has_register = any(
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == "register_schemas"
+            for node in ast.walk(tree)
+        )
+        if has_register:
+            declarers[schemas_py.parent.name] = schemas_py
+    return declarers
+
+
+def _cog_file_for_subsystem(subsystem: str) -> Path | None:
+    """Find the ``cogs/<subsystem>_cog.py`` file that owns the subsystem."""
+    candidate = _COGS_DIR / f"{subsystem}_cog.py"
+    if candidate.exists():
+        return candidate
+    return None
+
+
+def _cog_load_calls_register_schemas(cog_path: Path) -> bool:
+    """Return True if any ``cog_load`` method in the cog file calls
+    ``register_schemas()``.
+    """
+    tree = ast.parse(cog_path.read_text(), filename=str(cog_path))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef):
+            continue
+        if node.name != "cog_load":
+            continue
+        for child in ast.walk(node):
+            if not isinstance(child, ast.Call):
+                continue
+            func = child.func
+            # Match both `register_schemas()` and `module.register_schemas()`.
+            if isinstance(func, ast.Name) and func.id == "register_schemas":
+                return True
+            if isinstance(func, ast.Attribute) and func.attr == "register_schemas":
+                return True
+    return False
+
+
+def test_every_schema_declaring_cog_registers_in_cog_load():
+    """Invariant: declaring ``cogs/<name>/schemas.py:register_schemas``
+    without calling it from ``<name>_cog.py:cog_load`` leaves the
+    schema orphaned — settings hub can't discover it, audit pipelines
+    can't enforce capability requirements.
+
+    Pinning this prevents a regression where a developer adds a new
+    schema file but forgets the cog_load wiring.
+    """
+    declarers = _cogs_declaring_schemas()
+    assert declarers, "expected at least one cog to declare schemas"
+
+    orphaned: list[str] = []
+    missing_cog_file: list[str] = []
+    for subsystem in declarers:
+        cog_path = _cog_file_for_subsystem(subsystem)
+        if cog_path is None:
+            missing_cog_file.append(subsystem)
+            continue
+        if not _cog_load_calls_register_schemas(cog_path):
+            orphaned.append(f"{subsystem} → {cog_path.name}")
+
+    assert not missing_cog_file, (
+        "schemas.py declares register_schemas() but the owning "
+        "cogs/<name>_cog.py is missing:\n  " + "\n  ".join(missing_cog_file)
+    )
+    assert not orphaned, (
+        "schemas.py declares register_schemas() but cog_load() never "
+        "calls it — settings hub won't discover these schemas:\n  "
+        + "\n  ".join(orphaned)
+    )
+
+
+def test_known_subsystems_with_schemas_are_present():
+    """Pin the set of subsystems that have schemas today, so a future
+    PR that accidentally removes one fails CI loudly.
+    """
+    declarers = set(_cogs_declaring_schemas())
+    expected = {"economy", "logging", "moderation", "xp"}
+    missing = expected - declarers
+    assert not missing, (
+        f"expected schemas for {expected}; missing: {missing}. "
+        "If a schema was deliberately removed, update this test."
+    )


### PR DESCRIPTION
## Summary

S5 of the mother-hub PR sequence (see [`mother-hub-map.md`](https://github.com/menno420/superbot/pull/133)).

A previous audit (the planning doc for this arc) claimed moderation/xp schemas were "declared but never registered". Source verification shows they ARE registered: `cogs/moderation_cog.py:cog_load` and `cogs/xp_cog.py:cog_load` both call `register_schemas()` the same way economy/logging do. So the visible drift the plan worried about doesn't exist — but the invariant the plan called for is still valuable.

## What changed

**NEW `tests/unit/registry/test_schema_registration.py`** — AST-scans every `cogs/<name>/schemas.py` that defines `register_schemas()` and asserts the matching `<name>_cog.py:cog_load` actually calls it. Catches the regression where a future PR adds a new schema file but forgets the cog_load wiring. Also pins the known schema set (economy, logging, moderation, xp) so an accidental removal fails CI loudly.

## S5 work explicitly deferred

- **Channel visibility scope placeholder** — waits for ownership decision per the placeholder doctrine in `mother-hub-map.md`.
- **Missing schemas for role / channel / proof_channel / blackjack** — those subsystems currently use direct DB writes from views (flagged for PR S6 remediation). Adding minimal schemas would expose settings paths but those settings would still bypass the mutation pipeline until S6 lands.

## Test plan

- [x] `pytest tests/` — **2215 passed**
- [x] `ruff check . --exclude .github,tests,venv,env,build,dist` — All checks passed
- [x] `mypy disbot/` — Success: no issues found in 272 source files
- [x] New invariant test verifies all four currently-declared schemas (economy, logging, moderation, xp) are wired through cog_load

## Rollback

Single `git revert` of the squash commit. Test-only addition; no behaviour change.

## Next PR

**S6** — direct-DB-writes-from-views remediation; scoped, incremental, one cog per PR.

https://claude.ai/code/session_01ChWkq1H5kgBLNk8zHn1t6H

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChWkq1H5kgBLNk8zHn1t6H)_