### PR TITLE
feat(help): promote Economy to a Help category (S7 v1)

### DIFF
--- a/disbot/utils/hub_registry.py
+++ b/disbot/utils/hub_registry.py
@@ -107,6 +107,21 @@ HUBS: tuple[HubEntry, ...] = (
         minimum_tier="user",
     ),
     HubEntry(
+        key="economy",
+        display_name="Economy",
+        emoji="💰",
+        purpose="Currency, items, work, shop, and standings.",
+        entry_command="!economymenu",
+        # S7 v1 leaves primary_children empty. Inventory and Leaderboard
+        # remain top-level for now; a follow-up promotes them to
+        # parent_hub of "economy" once the hub view adds explicit child
+        # navigation. Mining stays under Games — the cross-link button
+        # ships alongside that promotion.
+        primary_children=(),
+        cross_link_children=(),
+        minimum_tier="user",
+    ),
+    HubEntry(
         key="admin",
         display_name="Admin / Operations",
         emoji="⚙️",

--- a/tests/unit/help/test_help_category_view.py
+++ b/tests/unit/help/test_help_category_view.py
@@ -114,8 +114,16 @@ def test_view_has_one_select_with_visible_hubs_plus_all_commands():
     view = HelpCategoryView(member_tier="administrator")
     select = _select(view)
     values = {opt.value for opt in select.options}
-    # S3 v1 hubs visible to administrator + ALL_COMMANDS sentinel.
-    assert values == {"games", "admin", "settings", "diagnostic", ALL_COMMANDS_KEY}
+    # Committed hubs visible to administrator + ALL_COMMANDS sentinel.
+    # Economy joined in S7; further hubs land in S8-S10.
+    assert values == {
+        "games",
+        "economy",
+        "admin",
+        "settings",
+        "diagnostic",
+        ALL_COMMANDS_KEY,
+    }
 
 
 def test_user_tier_view_omits_admin_hubs():

--- a/tests/unit/utils/test_hub_registry.py
+++ b/tests/unit/utils/test_hub_registry.py
@@ -45,18 +45,40 @@ def test_all_commands_key_is_not_a_hub():
     assert ALL_COMMANDS_KEY not in {hub.key for hub in HUBS}
 
 
-def test_s3_v1_existing_hubs_only_rollout():
-    """S3 v1 ships exactly four mother-hub categories: Games, Admin,
-    Settings, Platform. Economy/Moderation/Community/Utility wait for
-    S7-S10. Pinning this prevents a future PR from silently adding a
-    "Coming soon" category that the mother-hub map forbids.
+def test_committed_hub_set_matches_promoted_hubs():
+    """The committed hub set is the union of S3 v1 (Games, Admin,
+    Settings, Platform) plus any hubs promoted in later PRs.
+
+    S7 promotes Economy. Moderation/Safety (S8), Community (S9), and
+    Utility (S10) join when their hub views land — adding a hub here
+    without a real panel would re-introduce the "Coming soon"
+    category that the mother-hub map forbids.
     """
     assert {hub.key for hub in HUBS} == {
         "games",
+        "economy",
         "admin",
         "settings",
         "diagnostic",
     }
+
+
+def test_economy_hub_uses_existing_panel():
+    """S7 v1: the Economy hub category routes to the existing
+    economy_cog.build_help_menu_view panel. Inventory/Leaderboard
+    are NOT yet parent_hub="economy" — that promotion happens in a
+    follow-up PR once the hub view gains explicit child navigation.
+    """
+    economy = get_hub("economy")
+    assert economy is not None
+    assert economy.entry_command == "!economymenu"
+    # Empty primary_children / cross_links in v1 — pin so a future
+    # PR doesn't silently rewrite child wiring without updating
+    # subsystem metadata too.
+    assert economy.primary_children == ()
+    assert economy.cross_link_children == ()
+    assert economy.panel_available is True
+    assert economy.minimum_tier == "user"
 
 
 # ---------------------------------------------------------------------------
@@ -98,11 +120,12 @@ def test_games_hub_primary_children_match_parent_hub_filter():
 
 
 def test_hubs_for_tier_user_sees_only_user_tier_hubs():
-    """Normal users see Games (user tier) but not Admin/Settings/Platform
-    (administrator tier).
+    """Normal users see Games + Economy (user tier) but not
+    Admin/Settings/Platform (administrator tier).
     """
     visible = {hub.key for hub in hubs_for_tier("user")}
     assert "games" in visible
+    assert "economy" in visible
     assert "admin" not in visible
     assert "settings" not in visible
     assert "diagnostic" not in visible
@@ -110,12 +133,12 @@ def test_hubs_for_tier_user_sees_only_user_tier_hubs():
 
 def test_hubs_for_tier_administrator_sees_all():
     visible = {hub.key for hub in hubs_for_tier("administrator")}
-    assert visible == {"games", "admin", "settings", "diagnostic"}
+    assert visible == {"games", "economy", "admin", "settings", "diagnostic"}
 
 
 def test_hubs_for_tier_owner_sees_all():
     visible = {hub.key for hub in hubs_for_tier("owner")}
-    assert visible == {"games", "admin", "settings", "diagnostic"}
+    assert visible == {"games", "economy", "admin", "settings", "diagnostic"}
 
 
 def test_hubs_for_tier_filters_panel_unavailable():


### PR DESCRIPTION
## Summary

S7 of the mother-hub PR sequence (see [`mother-hub-map.md`](https://github.com/menno420/superbot/blob/main/docs/building-roadmap/mother-hub-map.md)). Adds the **Economy** mother hub to the Help category index. Clicking 💰 Economy in `!help` now routes to `economy_cog.build_help_menu_view` — the existing `EconomyPanelView` — so users get a coherent "Economy" home in Help without restructuring the underlying panel.

## What changed

- **`disbot/utils/hub_registry.py`** — appends an `Economy` `HubEntry` to `HUBS` with the existing economy panel as the host (entry_command `!economymenu`, minimum_tier `user`).
- Existing `HelpCategoryView` automatically picks up the new entry — no `help_cog` code change needed. The Economy category appears in the dropdown for every user-tier+ member alongside Games.

## What S7 v1 does NOT do (deferred to S7b)

- `parent_hub` metadata on `inventory` / `leaderboard` — they remain top-level for now so they're still reachable via "All Commands / Advanced". The promotion lands when the Economy hub view gains explicit child-navigation buttons.
- Cross-link button for `mining` — ships with the same follow-up.
- A dedicated `EconomyHubView` class — the existing `EconomyPanelView` is good enough for v1.

## Tests

- `tests/unit/utils/test_hub_registry.py`
  - Renamed the existing-hub-only-rollout test to "committed hub set" (it now includes economy) and added a focused `test_economy_hub_uses_existing_panel` that pins the entry shape.
  - Updated tier-visibility tests to expect economy at user tier.
- `tests/unit/help/test_help_category_view.py` — the dropdown-shape test now expects six options (`games`, `economy`, `admin`, `settings`, `diagnostic`, `ALL_COMMANDS`).

## Test plan

- [x] `pytest tests/` — **2246 passed**
- [x] `black --check` / `isort --check` / `ruff check` (CI args) / `mypy disbot/` — all clean
- [ ] Manual Discord smoke: `!help` → see Economy in the dropdown → select → existing economy panel opens with Back-to-Help

## Rollback

Single `git revert` of the squash commit. No behaviour change beyond the Help dropdown gaining one option; no metadata, schema, or DB changes.

## Next PR

**S8** — Moderation/Safety hub (uses existing `moderation_cog`).

https://claude.ai/code/session_01ChWkq1H5kgBLNk8zHn1t6H

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChWkq1H5kgBLNk8zHn1t6H)_