### PR TITLE
feat(help): promote Moderation/Safety to a Help category (S8 v1)

### DIFF
--- a/disbot/utils/hub_registry.py
+++ b/disbot/utils/hub_registry.py
@@ -122,6 +122,21 @@ HUBS: tuple[HubEntry, ...] = (
         minimum_tier="user",
     ),
     HubEntry(
+        key="moderation",
+        display_name="Moderation & Safety",
+        emoji="🛡️",
+        purpose="Warnings, timeouts, bans, cleanup, audit logs.",
+        entry_command="!modmenu",
+        # S8 v1: routes to moderation_cog's existing build_help_menu_view
+        # which returns the ModPanelView. Cleanup and Logging are
+        # candidates for parent_hub of "moderation" in a follow-up once
+        # the hub view adds explicit child navigation across the three
+        # subsystems.
+        primary_children=(),
+        cross_link_children=(),
+        minimum_tier="moderator",
+    ),
+    HubEntry(
         key="admin",
         display_name="Admin / Operations",
         emoji="⚙️",

--- a/disbot/utils/hub_registry.py
+++ b/disbot/utils/hub_registry.py
@@ -107,6 +107,21 @@ HUBS: tuple[HubEntry, ...] = (
         minimum_tier="user",
     ),
     HubEntry(
+        key="economy",
+        display_name="Economy",
+        emoji="💰",
+        purpose="Currency, items, work, shop, and standings.",
+        entry_command="!economymenu",
+        # S7 v1 leaves primary_children empty. Inventory and Leaderboard
+        # remain top-level for now; a follow-up promotes them to
+        # parent_hub of "economy" once the hub view adds explicit child
+        # navigation. Mining stays under Games — the cross-link button
+        # ships alongside that promotion.
+        primary_children=(),
+        cross_link_children=(),
+        minimum_tier="user",
+    ),
+    HubEntry(
         key="admin",
         display_name="Admin / Operations",
         emoji="⚙️",

--- a/tests/unit/help/test_help_category_view.py
+++ b/tests/unit/help/test_help_category_view.py
@@ -115,10 +115,12 @@ def test_view_has_one_select_with_visible_hubs_plus_all_commands():
     select = _select(view)
     values = {opt.value for opt in select.options}
     # Committed hubs visible to administrator + ALL_COMMANDS sentinel.
-    # Economy joined in S7; further hubs land in S8-S10.
+    # Economy joined in S7, Moderation in S8; Community/Utility land in
+    # S9-S10.
     assert values == {
         "games",
         "economy",
+        "moderation",
         "admin",
         "settings",
         "diagnostic",
@@ -132,6 +134,8 @@ def test_user_tier_view_omits_admin_hubs():
     values = {opt.value for opt in select.options}
     assert "games" in values
     assert ALL_COMMANDS_KEY in values
+    # Moderation is moderator-tier — must not surface for normal users.
+    assert "moderation" not in values
     assert "admin" not in values
     assert "settings" not in values
     assert "diagnostic" not in values

--- a/tests/unit/help/test_help_category_view.py
+++ b/tests/unit/help/test_help_category_view.py
@@ -114,8 +114,16 @@ def test_view_has_one_select_with_visible_hubs_plus_all_commands():
     view = HelpCategoryView(member_tier="administrator")
     select = _select(view)
     values = {opt.value for opt in select.options}
-    # S3 v1 hubs visible to administrator + ALL_COMMANDS sentinel.
-    assert values == {"games", "admin", "settings", "diagnostic", ALL_COMMANDS_KEY}
+    # Committed hubs visible to administrator + ALL_COMMANDS sentinel.
+    # Economy joined in S7; further hubs land in S8-S10.
+    assert values == {
+        "games",
+        "economy",
+        "admin",
+        "settings",
+        "diagnostic",
+        ALL_COMMANDS_KEY,
+    }
 
 
 def test_user_tier_view_omits_admin_hubs():

--- a/tests/unit/utils/test_hub_registry.py
+++ b/tests/unit/utils/test_hub_registry.py
@@ -49,18 +49,34 @@ def test_committed_hub_set_matches_promoted_hubs():
     """The committed hub set is the union of S3 v1 (Games, Admin,
     Settings, Platform) plus any hubs promoted in later PRs.
 
-    S7 promotes Economy. Moderation/Safety (S8), Community (S9), and
-    Utility (S10) join when their hub views land — adding a hub here
-    without a real panel would re-introduce the "Coming soon"
-    category that the mother-hub map forbids.
+    S7 promotes Economy. S8 promotes Moderation/Safety. Community
+    (S9) and Utility (S10) join when their hub views land — adding a
+    hub here without a real panel would re-introduce the "Coming
+    soon" category that the mother-hub map forbids.
     """
     assert {hub.key for hub in HUBS} == {
         "games",
         "economy",
+        "moderation",
         "admin",
         "settings",
         "diagnostic",
     }
+
+
+def test_moderation_hub_uses_existing_panel():
+    """S8 v1: the Moderation/Safety hub routes to
+    moderation_cog.build_help_menu_view (ModPanelView). Cleanup and
+    Logging stay top-level for now — promotion to parent_hub of
+    "moderation" lands when the hub view gains explicit child nav.
+    """
+    moderation = get_hub("moderation")
+    assert moderation is not None
+    assert moderation.entry_command == "!modmenu"
+    assert moderation.minimum_tier == "moderator"
+    assert moderation.primary_children == ()
+    assert moderation.cross_link_children == ()
+    assert moderation.panel_available is True
 
 
 def test_economy_hub_uses_existing_panel():
@@ -121,11 +137,25 @@ def test_games_hub_primary_children_match_parent_hub_filter():
 
 def test_hubs_for_tier_user_sees_only_user_tier_hubs():
     """Normal users see Games + Economy (user tier) but not
-    Admin/Settings/Platform (administrator tier).
+    Moderation (moderator) or Admin/Settings/Platform (administrator).
     """
     visible = {hub.key for hub in hubs_for_tier("user")}
     assert "games" in visible
     assert "economy" in visible
+    assert "moderation" not in visible
+    assert "admin" not in visible
+    assert "settings" not in visible
+    assert "diagnostic" not in visible
+
+
+def test_hubs_for_tier_moderator_sees_moderation_but_not_admin():
+    """Moderators see user-tier hubs + Moderation, but still can't open
+    administrator-restricted hubs (Admin/Settings/Platform).
+    """
+    visible = {hub.key for hub in hubs_for_tier("moderator")}
+    assert "games" in visible
+    assert "economy" in visible
+    assert "moderation" in visible
     assert "admin" not in visible
     assert "settings" not in visible
     assert "diagnostic" not in visible
@@ -133,12 +163,26 @@ def test_hubs_for_tier_user_sees_only_user_tier_hubs():
 
 def test_hubs_for_tier_administrator_sees_all():
     visible = {hub.key for hub in hubs_for_tier("administrator")}
-    assert visible == {"games", "economy", "admin", "settings", "diagnostic"}
+    assert visible == {
+        "games",
+        "economy",
+        "moderation",
+        "admin",
+        "settings",
+        "diagnostic",
+    }
 
 
 def test_hubs_for_tier_owner_sees_all():
     visible = {hub.key for hub in hubs_for_tier("owner")}
-    assert visible == {"games", "economy", "admin", "settings", "diagnostic"}
+    assert visible == {
+        "games",
+        "economy",
+        "moderation",
+        "admin",
+        "settings",
+        "diagnostic",
+    }
 
 
 def test_hubs_for_tier_filters_panel_unavailable():

--- a/tests/unit/utils/test_hub_registry.py
+++ b/tests/unit/utils/test_hub_registry.py
@@ -45,18 +45,40 @@ def test_all_commands_key_is_not_a_hub():
     assert ALL_COMMANDS_KEY not in {hub.key for hub in HUBS}
 
 
-def test_s3_v1_existing_hubs_only_rollout():
-    """S3 v1 ships exactly four mother-hub categories: Games, Admin,
-    Settings, Platform. Economy/Moderation/Community/Utility wait for
-    S7-S10. Pinning this prevents a future PR from silently adding a
-    "Coming soon" category that the mother-hub map forbids.
+def test_committed_hub_set_matches_promoted_hubs():
+    """The committed hub set is the union of S3 v1 (Games, Admin,
+    Settings, Platform) plus any hubs promoted in later PRs.
+
+    S7 promotes Economy. Moderation/Safety (S8), Community (S9), and
+    Utility (S10) join when their hub views land — adding a hub here
+    without a real panel would re-introduce the "Coming soon"
+    category that the mother-hub map forbids.
     """
     assert {hub.key for hub in HUBS} == {
         "games",
+        "economy",
         "admin",
         "settings",
         "diagnostic",
     }
+
+
+def test_economy_hub_uses_existing_panel():
+    """S7 v1: the Economy hub category routes to the existing
+    economy_cog.build_help_menu_view panel. Inventory/Leaderboard
+    are NOT yet parent_hub="economy" — that promotion happens in a
+    follow-up PR once the hub view gains explicit child navigation.
+    """
+    economy = get_hub("economy")
+    assert economy is not None
+    assert economy.entry_command == "!economymenu"
+    # Empty primary_children / cross_links in v1 — pin so a future
+    # PR doesn't silently rewrite child wiring without updating
+    # subsystem metadata too.
+    assert economy.primary_children == ()
+    assert economy.cross_link_children == ()
+    assert economy.panel_available is True
+    assert economy.minimum_tier == "user"
 
 
 # ---------------------------------------------------------------------------
@@ -98,11 +120,12 @@ def test_games_hub_primary_children_match_parent_hub_filter():
 
 
 def test_hubs_for_tier_user_sees_only_user_tier_hubs():
-    """Normal users see Games (user tier) but not Admin/Settings/Platform
-    (administrator tier).
+    """Normal users see Games + Economy (user tier) but not
+    Admin/Settings/Platform (administrator tier).
     """
     visible = {hub.key for hub in hubs_for_tier("user")}
     assert "games" in visible
+    assert "economy" in visible
     assert "admin" not in visible
     assert "settings" not in visible
     assert "diagnostic" not in visible
@@ -110,12 +133,12 @@ def test_hubs_for_tier_user_sees_only_user_tier_hubs():
 
 def test_hubs_for_tier_administrator_sees_all():
     visible = {hub.key for hub in hubs_for_tier("administrator")}
-    assert visible == {"games", "admin", "settings", "diagnostic"}
+    assert visible == {"games", "economy", "admin", "settings", "diagnostic"}
 
 
 def test_hubs_for_tier_owner_sees_all():
     visible = {hub.key for hub in hubs_for_tier("owner")}
-    assert visible == {"games", "admin", "settings", "diagnostic"}
+    assert visible == {"games", "economy", "admin", "settings", "diagnostic"}
 
 
 def test_hubs_for_tier_filters_panel_unavailable():


### PR DESCRIPTION
## Summary

S8 of the mother-hub PR sequence (see [`mother-hub-map.md`](https://github.com/menno420/superbot/blob/main/docs/building-roadmap/mother-hub-map.md)). Adds the **Moderation / Safety** mother hub to the Help category index. Clicking 🛡️ Moderation & Safety in `!help` now routes to `moderation_cog.build_help_menu_view` — the existing `ModPanelView` — so moderators get a coherent "Moderation" home in Help alongside Games and Economy.

**⚠️ Stacked on #138 (S7 Economy):** both touch `hub_registry.py` and the same tests. When S7 merges, GitHub will rebase this PR cleanly against the new main.

## What changed

- **`disbot/utils/hub_registry.py`** — appends a Moderation/Safety `HubEntry`:
  - `key="moderation"`, `entry_command="!modmenu"`
  - `minimum_tier="moderator"` so it surfaces for moderators and admins, but never for normal users
  - `primary_children=()` in v1 — cleanup/logging stay top-level. Promotion lands when the hub view adds explicit child nav.

## Tier visibility (permission/role matrix)

- **user**: no Moderation category.
- **moderator**: Games + Economy + Moderation; still no Admin/Settings/Platform.
- **administrator** and above: all six committed hubs.

## Tests

- `tests/unit/utils/test_hub_registry.py` — added `test_moderation_hub_uses_existing_panel`, added a moderator-tier visibility test, and updated the committed-hub set + administrator/owner tier tests for the new six-hub state.
- `tests/unit/help/test_help_category_view.py` — dropdown-shape test now expects seven options; user-tier test pins that moderation is hidden.

## Test plan

- [x] `pytest tests/` — **2248 passed**
- [x] `black --check` / `isort --check` / `ruff check` (CI args) / `mypy disbot/` — all clean
- [ ] Manual Discord smoke: log in as a moderator → `!help` → see Moderation & Safety category → select → existing ModPanelView opens

## Rollback

Single `git revert` of the squash commit. No behaviour change beyond the Help dropdown gaining one moderator-tier option.

## Next PR

**S9** — Community hub (new `community_cog`).

https://claude.ai/code/session_01ChWkq1H5kgBLNk8zHn1t6H

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChWkq1H5kgBLNk8zHn1t6H)_