### PR TITLE
feat(help): unify typed Help and dropdown routing; split Platform/Diagnostics

### DIFF
--- a/disbot/cogs/diagnostic_cog.py
+++ b/disbot/cogs/diagnostic_cog.py
@@ -76,9 +76,34 @@ class DiagnosticCog(commands.Cog):
         The view reads ``bot`` from ``interaction.client`` inside each
         button callback, so no ctx-shim is required.  This matches the
         canonical pattern used by every other subsystem hub.
+
+        This hook stays pointed at the Diagnostics Hub so Admin →
+        Diagnostics and ``!help diagnostics`` / ``!help diag`` continue
+        to open the diagnostics surface. The Help "Platform /
+        Diagnostics" entry uses :meth:`build_platform_help_menu_view`
+        instead — see the ``_HUB_PANEL_BUILDERS`` override in
+        ``help_cog``.
         """
         view = _DiagnosticsHubView(interaction.user)
         return view.build_embed(), view
+
+    async def build_platform_help_menu_view(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        """Help-menu direct-navigation hook for the Platform hub.
+
+        Routed to by Help's ``_HUB_PANEL_BUILDERS`` override for the
+        ``diagnostic`` hub key (display name "Platform / Diagnostics").
+        ``DiagnosticCog`` owns both surfaces; this sibling hook keeps
+        :meth:`build_help_menu_view` free for the Diagnostics callers
+        that already depend on it.
+
+        Reads only ``interaction.user`` — the ``HelpOpener`` adapter is
+        a safe drop-in here.
+        """
+        view = _PlatformHubView(interaction.user)
+        return build_platform_hub_embed(), view
 
     # ------------------------------------------------------------------
     # Command overview

--- a/disbot/cogs/help/route.py
+++ b/disbot/cogs/help/route.py
@@ -1,0 +1,296 @@
+"""Help route model + resolver (shared by typed Help and the dropdown).
+
+Both the ``!help <name>`` command and the Help dropdown call
+:func:`resolve_route` so the same name produces the same destination
+regardless of entry point. The opener is :func:`open_route` in this
+module; the cog wires it into the two entry points.
+
+Routes have five kinds:
+
+- ``hub``       — open a mother-hub panel via the host cog's
+                  ``build_help_menu_view`` (or the override named in
+                  :data:`HUB_PANEL_BUILDERS`).
+- ``subsystem`` — open a subsystem panel via ``build_help_menu_view``
+                  with a command-list embed fallback when the hook is
+                  missing or raises.
+- ``advanced``  — open the legacy paginated ``HelpPanelView``.
+- ``command``   — render a single-command help embed.
+- ``unknown``   — render the "not found" fallback embed.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Literal
+
+import discord
+from discord.ext import commands
+
+from utils.hub_registry import HUBS, get_hub
+from utils.subsystem_registry import SUBSYSTEMS, all_subsystems_sorted
+from utils.ui_constants import UTILITY_COLOR
+
+logger = logging.getLogger("bot")
+
+# Aliases that route to the legacy paginated subsystem browser.
+ADVANCED_ALIASES = frozenset({"advanced", "all", "commands", "all commands"})
+
+# Hub aliases beyond the registered key / display_name / entry_command.
+# Keep this small — it's a typed-name shorthand, not a second registry.
+HUB_ALIAS_OVERRIDES: dict[str, str] = {
+    "mod": "moderation",
+    "platform": "diagnostic",
+}
+
+# Subsystem aliases that must NOT collide with a hub. ``diagnostics`` /
+# ``diag`` open the Diagnostics Hub via the subsystem route (it uses
+# ``build_help_menu_view`` which returns ``_DiagnosticsHubView``);
+# routing them through the hub key ``diagnostic`` would instead open
+# Platform Hub via ``build_platform_help_menu_view``.
+SUBSYSTEM_ALIAS_OVERRIDES: dict[str, str] = {
+    "diagnostics": "diagnostic",
+    "diag": "diagnostic",
+}
+
+# Hubs whose dedicated Help builder is NOT ``build_help_menu_view``.
+# Keep this minimal — additions require a source-grounded justification.
+# The Platform / Diagnostics hub is the canonical example: its host cog
+# ``DiagnosticCog`` exposes ``build_help_menu_view`` (Diagnostics Hub)
+# for Admin → Diagnostics and ``build_platform_help_menu_view`` (Platform
+# Hub) for the Help "Platform / Diagnostics" entry.
+HUB_PANEL_BUILDERS: dict[str, str] = {
+    "diagnostic": "build_platform_help_menu_view",
+}
+
+
+@dataclass(frozen=True)
+class HelpRoute:
+    """Resolved Help destination. ``target`` meaning depends on ``kind``.
+
+    - ``hub``       → hub key from :data:`utils.hub_registry.HUBS`.
+    - ``subsystem`` → subsystem key from :data:`SUBSYSTEMS`.
+    - ``command``   → canonical command name (after alias resolution).
+    - ``advanced`` / ``unknown`` → ``None``.
+    """
+
+    key: str
+    kind: Literal["hub", "subsystem", "advanced", "command", "unknown"]
+    target: str | None = None
+
+
+@dataclass(frozen=True)
+class HelpOpener:
+    """Metadata-only adapter passed to ``build_help_menu_view`` hooks.
+
+    Source-verified that every cog's hook reads only ``.user``, ``.guild``,
+    ``.guild_id``, ``.client``, ``.channel`` (some via ``help_ctx_shim``,
+    which exposes the same fields). Hooks that need ``.response``,
+    ``.followup``, ``.data``, or the interaction lifecycle would raise on
+    this adapter — :func:`open_route` catches those errors and falls
+    back to the command-list embed so Help never crashes.
+
+    ``HelpInteractionContext`` is an equally acceptable name; this stayed
+    as ``HelpOpener`` only because it was shorter for callers.
+    """
+
+    user: discord.Member | discord.User
+    guild: discord.Guild | None
+    guild_id: int | None
+    client: commands.Bot
+    channel: discord.abc.Messageable | None
+
+    @classmethod
+    def from_interaction(cls, interaction: discord.Interaction) -> HelpOpener:
+        return cls(
+            user=interaction.user,
+            guild=interaction.guild,
+            guild_id=interaction.guild_id,
+            client=interaction.client,  # type: ignore[arg-type]
+            channel=interaction.channel,
+        )
+
+    @classmethod
+    def from_ctx(cls, ctx: commands.Context) -> HelpOpener:
+        return cls(
+            user=ctx.author,
+            guild=ctx.guild,
+            guild_id=ctx.guild.id if ctx.guild else None,
+            client=ctx.bot,
+            channel=ctx.channel,
+        )
+
+
+def build_single_command_embed(
+    cmd: commands.Command,
+    prefix: str,
+) -> discord.Embed:
+    """Render the single-command help embed used by ``!help <command>``."""
+    embed = discord.Embed(
+        title=f"`{prefix}{cmd.name}`",
+        description=cmd.help or "No description.",
+        color=UTILITY_COLOR,
+    )
+    if cmd.aliases:
+        embed.add_field(
+            name="Aliases",
+            value=", ".join(f"`{a}`" for a in cmd.aliases),
+        )
+    sig = f" {cmd.signature}" if cmd.signature else ""
+    embed.add_field(
+        name="Usage",
+        value=f"`{prefix}{cmd.name}{sig}`",
+        inline=False,
+    )
+    return embed
+
+
+def build_not_found_embed(name: str) -> discord.Embed:
+    """Render the not-found fallback embed used when no route matches."""
+    return discord.Embed(
+        title="📚 Help",
+        description=f"No command or category named `{name}` found.",
+        color=UTILITY_COLOR,
+    )
+
+
+def resolve_route(name: str, *, bot: commands.Bot) -> HelpRoute:
+    """Resolve a typed/selected name to a :class:`HelpRoute`.
+
+    The resolver is the only place Help routing logic lives. Both the
+    typed ``!help <name>`` command and the Help dropdown call this so the
+    same name produces the same destination regardless of entry point.
+
+    Priority:
+      1. Advanced aliases (``advanced``, ``all``, ``commands``, ...).
+      2. Subsystem alias overrides (``diagnostics`` / ``diag``) — these
+         must run before the hub match so they aren't captured by the
+         Platform / Diagnostics hub.
+      3. Hub aliases (key / display_name / entry_command + a small
+         shorthand table for ``mod`` and ``platform``).
+      4. Subsystem key / display_name.
+      5. Command name (after alias resolution).
+      6. Unknown — caller renders the not-found fallback.
+    """
+    n = name.strip().lower()
+
+    if n in ADVANCED_ALIASES:
+        return HelpRoute(key=name, kind="advanced")
+
+    if n in SUBSYSTEM_ALIAS_OVERRIDES:
+        return HelpRoute(
+            key=name,
+            kind="subsystem",
+            target=SUBSYSTEM_ALIAS_OVERRIDES[n],
+        )
+
+    if n in HUB_ALIAS_OVERRIDES:
+        return HelpRoute(key=name, kind="hub", target=HUB_ALIAS_OVERRIDES[n])
+
+    for hub in HUBS:
+        entry = hub.entry_command.lstrip("!").lower()
+        if n == hub.key.lower() or n == hub.display_name.lower() or n == entry:
+            return HelpRoute(key=name, kind="hub", target=hub.key)
+
+    for sname, meta in SUBSYSTEMS.items():
+        if n == sname.lower() or n == meta.get("display_name", "").lower():
+            return HelpRoute(key=name, kind="subsystem", target=sname)
+
+    cmd = bot.get_command(name)
+    if cmd is not None:
+        return HelpRoute(key=name, kind="command", target=cmd.name)
+
+    return HelpRoute(key=name, kind="unknown")
+
+
+async def open_route(
+    route: HelpRoute,
+    opener: HelpOpener,
+    *,
+    visible_subsystems: set[str],
+    member_tier: str,
+    prefix: str = "!",
+) -> tuple[discord.Embed, discord.ui.View | None]:
+    """Build the ``(embed, view)`` pair for a resolved :class:`HelpRoute`.
+
+    Returns ``view=None`` when the destination is an embed-only surface
+    (single-command help, not-found fallback, command-list fallback for
+    subsystems whose hook raised). The caller decides whether to send a
+    new message or edit in place.
+
+    Imports of ``HelpPanelView``, ``_build_page_embed``, ``build_cog_embed``,
+    and ``_cog_for_subsystem`` are function-local to avoid an import
+    cycle with ``cogs.help_cog`` (where the cog and views live).
+    """
+    from cogs.help_cog import (
+        HelpPanelView,
+        _build_page_embed,
+        _cog_for_subsystem,
+        build_cog_embed,
+    )
+
+    if route.kind == "advanced":
+        visible_list = [
+            name
+            for name, meta in all_subsystems_sorted()
+            if name in visible_subsystems and not meta.get("parent_hub")
+        ]
+        view = HelpPanelView(visible_list, page=0)
+        embed = _build_page_embed(opener.client, visible_list, 0, member_tier)
+        return embed, view
+
+    if route.kind == "hub":
+        if route.target is None:
+            return build_not_found_embed(route.key), None
+        hub = get_hub(route.target)
+        if hub is None:
+            return build_not_found_embed(route.key), None
+        cog = _cog_for_subsystem(opener.client, hub.key)
+        if cog is None:
+            return build_not_found_embed(hub.display_name), None
+        builder_name = HUB_PANEL_BUILDERS.get(hub.key, "build_help_menu_view")
+        builder = getattr(cog, builder_name, None)
+        if not callable(builder):
+            return build_not_found_embed(hub.display_name), None
+        try:
+            embed, sub_view = await builder(opener)
+        except Exception as exc:  # noqa: BLE001 — Help must never crash on hook
+            logger.warning(
+                "Help hub builder failed | hub=%r builder=%r: %s",
+                hub.key,
+                builder_name,
+                exc,
+                exc_info=True,
+            )
+            return build_not_found_embed(hub.display_name), None
+        return embed, sub_view
+
+    if route.kind == "subsystem":
+        if route.target is None:
+            return build_not_found_embed(route.key), None
+        cog = _cog_for_subsystem(opener.client, route.target)
+        if cog is None:
+            return build_not_found_embed(route.key), None
+        builder = getattr(cog, "build_help_menu_view", None)
+        if callable(builder):
+            try:
+                embed, sub_view = await builder(opener)
+                return embed, sub_view
+            except Exception as exc:  # noqa: BLE001 — fall back to command list
+                logger.warning(
+                    "Help subsystem builder failed | subsystem=%r: %s",
+                    route.target,
+                    exc,
+                    exc_info=True,
+                )
+        return build_cog_embed(cog, prefix, route.target), None
+
+    if route.kind == "command":
+        if route.target is None:
+            return build_not_found_embed(route.key), None
+        cmd = opener.client.get_command(route.target)
+        if cmd is None:
+            return build_not_found_embed(route.key), None
+        return build_single_command_embed(cmd, prefix), None
+
+    return build_not_found_embed(route.key), None

--- a/disbot/cogs/help/route.py
+++ b/disbot/cogs/help/route.py
@@ -107,7 +107,7 @@ class HelpOpener:
             guild=interaction.guild,
             guild_id=interaction.guild_id,
             client=interaction.client,  # type: ignore[arg-type]
-            channel=interaction.channel,
+            channel=interaction.channel,  # type: ignore[arg-type]
         )
 
     @classmethod

--- a/disbot/cogs/help_cog.py
+++ b/disbot/cogs/help_cog.py
@@ -6,13 +6,13 @@ import math
 import discord
 from discord.ext import commands
 
+from cogs.help.route import HUB_PANEL_BUILDERS as _HUB_PANEL_BUILDERS
 from cogs.help.route import (
-    HUB_PANEL_BUILDERS as _HUB_PANEL_BUILDERS,
     HelpOpener,
     HelpRoute,
-    open_route as _open_route,
-    resolve_route as _resolve_route,
 )
+from cogs.help.route import open_route as _open_route
+from cogs.help.route import resolve_route as _resolve_route
 from core.runtime.persistent_views import PersistentView, register
 from services import governance_service
 from services.governance_service import GovernanceContext

--- a/disbot/cogs/help_cog.py
+++ b/disbot/cogs/help_cog.py
@@ -6,14 +6,33 @@ import math
 import discord
 from discord.ext import commands
 
+from cogs.help.route import (
+    HUB_PANEL_BUILDERS as _HUB_PANEL_BUILDERS,
+    HelpOpener,
+    HelpRoute,
+    open_route as _open_route,
+    resolve_route as _resolve_route,
+)
 from core.runtime.persistent_views import PersistentView, register
 from services import governance_service
 from services.governance_service import GovernanceContext
-from utils.hub_registry import ALL_COMMANDS_KEY, get_hub, hubs_for_tier
+from utils.hub_registry import ALL_COMMANDS_KEY, hubs_for_tier
 from utils.subsystem_registry import SUBSYSTEMS, all_subsystems_sorted
 from utils.ui_constants import ADMIN_COLOR, GENERAL_COLOR, MOD_COLOR, UTILITY_COLOR
 
 logger = logging.getLogger("bot")
+
+# Re-exports kept for test compatibility — the canonical definitions
+# live in ``cogs.help.route``. The Help route model is shared by the
+# typed ``!help <name>`` command and the Help dropdown so the same
+# name produces the same destination regardless of entry point.
+__all__ = [
+    "HelpOpener",
+    "HelpRoute",
+    "_HUB_PANEL_BUILDERS",
+    "_open_route",
+    "_resolve_route",
+]
 
 _PAGE_SIZE = 12  # subsystems per help page — well under Discord's 25-option limit
 
@@ -232,14 +251,13 @@ def _build_page_embed(
 
 
 def build_categories_overview_embed(member_tier: str) -> discord.Embed:
-    """Build the top-level Help embed showing mother-hub categories (S3).
+    """Build the top-level Help embed showing mother-hub categories.
 
     Iterates :data:`utils.hub_registry.HUBS`, filters to hubs visible at
     ``member_tier`` via :func:`hubs_for_tier`, and always appends the
-    permanent "All Commands / Advanced" fallback row. Each hub line
-    states purpose, includes-list (primary + cross-link children with
-    display names from ``SUBSYSTEMS``), and typed entry command — the
-    user-centered orientation rule from the mother-hub map.
+    permanent "Advanced / All Commands" fallback row. Each hub row is a
+    uniform two-line shape — purpose + typed entry command — with no
+    ``Includes:`` line. Child rosters live inside each hub panel.
     """
     embed = discord.Embed(
         title="📚 Help Menu",
@@ -247,38 +265,18 @@ def build_categories_overview_embed(member_tier: str) -> discord.Embed:
         color=UTILITY_COLOR,
     )
 
-    visible_hubs = hubs_for_tier(member_tier)
-    for hub in visible_hubs:
-        included: list[str] = []
-        for child_key in hub.primary_children:
-            child_meta = SUBSYSTEMS.get(child_key)
-            if child_meta is not None:
-                included.append(child_meta.get("display_name", child_key))
-        for child_key in hub.cross_link_children:
-            child_meta = SUBSYSTEMS.get(child_key)
-            if child_meta is not None:
-                included.append(
-                    f"{child_meta.get('display_name', child_key)} (cross-link)",
-                )
-
-        lines = [hub.purpose]
-        if included:
-            lines.append(f"Includes: {', '.join(included)}.")
-        lines.append(f"→ `{hub.entry_command}`")
+    for hub in hubs_for_tier(member_tier):
         embed.add_field(
             name=f"{hub.emoji} {hub.display_name}",
-            value="\n".join(lines),
+            value=f"{hub.purpose}\n→ `{hub.entry_command}`",
             inline=False,
         )
 
-    # All Commands / Advanced is permanent — guarantees discoverability
+    # Advanced / All Commands is permanent — guarantees discoverability
     # for every visible subsystem even when no mother hub owns it.
     embed.add_field(
-        name="📋 All Commands / Advanced",
-        value=(
-            "Browse every visible command directly, grouped by tier.\n"
-            "Power-user fallback: use this when you know the command name."
-        ),
+        name="📋 Advanced / All Commands",
+        value="Browse every available command directly.",
         inline=False,
     )
 
@@ -542,62 +540,40 @@ class HelpCategoryView(PersistentView):
         gctx = GovernanceContext.from_interaction(interaction)
         vis_result = await governance_service.resolve_visibility(gctx)
 
-        if value == ALL_COMMANDS_KEY:
-            visible_list = [
-                name
-                for name, meta in all_subsystems_sorted()
-                if name in vis_result.visible_subsystems and not meta.get("parent_hub")
-            ]
-            new_view = HelpPanelView(visible_list, page=0)
-            embed = _build_page_embed(
-                interaction.client,  # type: ignore[arg-type]
-                visible_list,
-                0,
-                vis_result.member_tier,
-            )
-            await interaction.response.edit_message(embed=embed, view=new_view)
-            return
+        # The sentinel "All Commands / Advanced" routes through the same
+        # resolver as everything else — keyed by the canonical "advanced"
+        # alias so typed Help and the dropdown share one branch.
+        name = "advanced" if value == ALL_COMMANDS_KEY else value
+        opener = HelpOpener.from_interaction(interaction)
+        route = _resolve_route(name, bot=opener.client)
 
-        # Hub category — route to the host cog's build_help_menu_view.
-        hub = get_hub(value)
-        if hub is None:
+        if route.kind == "unknown":
             await interaction.response.send_message(
                 "That category is no longer available.",
                 ephemeral=True,
             )
             return
 
-        cog = _cog_for_subsystem(interaction.client, hub.key)  # type: ignore[arg-type]
-        if cog is None:
+        embed, sub_view = await _open_route(
+            route,
+            opener,
+            visible_subsystems=vis_result.visible_subsystems,
+            member_tier=vis_result.member_tier,
+        )
+
+        if sub_view is None:
+            # Embed-only fallback (e.g. hub builder failed) — surface as
+            # an ephemeral so the category panel stays intact.
             await interaction.response.send_message(
-                f"The {hub.display_name} hub is not loaded right now.",
+                embed=embed,
                 ephemeral=True,
             )
             return
 
-        build_panel = getattr(cog, "build_help_menu_view", None)
-        if not callable(build_panel):
-            await interaction.response.send_message(
-                f"The {hub.display_name} hub doesn't expose a panel yet.",
-                ephemeral=True,
-            )
-            return
-
-        try:
-            embed, sub_view = await build_panel(interaction)
-        except Exception as exc:  # noqa: BLE001 — Help must never crash on hook
-            logger.warning(
-                "HelpCategoryView: build_help_menu_view failed for hub=%r: %s",
-                hub.key,
-                exc,
-                exc_info=True,
-            )
-            await interaction.response.send_message(
-                f"Could not open the {hub.display_name} hub — see bot logs.",
-                ephemeral=True,
-            )
-            return
-
+        # Attach Back-to-Help on every interactive surface opened from
+        # the category index. ``HelpPanelView`` (the Advanced branch)
+        # already provides its own pagination; the back button still
+        # gives the user a one-click return to the category index.
         _attach_back_to_help_button(sub_view)
         await interaction.response.edit_message(embed=embed, view=sub_view)
 
@@ -614,71 +590,41 @@ class HelpCog(commands.Cog):
         vis_result = await governance_service.resolve_visibility(gctx)
         visible_set = vis_result.visible_subsystems
         member_tier = vis_result.member_tier
-        # parent_hub children are reachable via their hub and via typed
-        # commands; they're hidden from the overview/select. The typed
-        # category-lookup branch below iterates SUBSYSTEMS directly and
-        # is therefore unaffected by this filter.
-        visible_list = [
-            name
-            for name, meta in all_subsystems_sorted()
-            if name in visible_set and not meta.get("parent_hub")
-        ]
+        prefix = ctx.prefix or "!"
 
         if category:
-            for name, meta in SUBSYSTEMS.items():
-                if name not in visible_set:
-                    continue
-                if category.lower() in (
-                    name.lower(),
-                    meta.get("display_name", "").lower(),
-                ):
-                    cog = _cog_for_subsystem(self.bot, name)
-                    if cog:
-                        await ctx.send(
-                            embed=build_cog_embed(cog, ctx.prefix or "!", name),
-                            delete_after=60,
-                        )
-                        return
+            opener = HelpOpener.from_ctx(ctx)
+            route = _resolve_route(category, bot=self.bot)
 
-            cog = self.bot.get_cog(category) or self.bot.get_cog(category + "Cog")
-            cmd = self.bot.get_command(category)
-            if cog:
+            if route.kind == "unknown":
                 await ctx.send(
-                    embed=build_cog_embed(cog, ctx.prefix or "!"),
-                    delete_after=60,
+                    f"No command or category named `{category}` found.",
+                    delete_after=10,
                 )
                 return
-            if cmd:
-                prefix = ctx.prefix or "!"
-                embed = discord.Embed(
-                    title=f"`{prefix}{cmd.name}`",
-                    description=cmd.help or "No description.",
-                    color=UTILITY_COLOR,
-                )
-                if cmd.aliases:
-                    embed.add_field(
-                        name="Aliases",
-                        value=", ".join(f"`{a}`" for a in cmd.aliases),
-                    )
-                embed.add_field(
-                    name="Usage",
-                    value=f"`{prefix}{cmd.name}{(' ' + cmd.signature) if cmd.signature else ''}`",
-                    inline=False,
-                )
+
+            embed, sub_view = await _open_route(
+                route,
+                opener,
+                visible_subsystems=visible_set,
+                member_tier=member_tier,
+                prefix=prefix,
+            )
+
+            if sub_view is None:
                 await ctx.send(embed=embed, delete_after=60)
                 return
-            await ctx.send(
-                f"No command or category named `{category}` found.",
-                delete_after=10,
-            )
+
+            # For typed Help with a hub/subsystem/advanced surface, send
+            # the panel as a fresh message and attach Back-to-Help so the
+            # user can return to the category index.
+            _attach_back_to_help_button(sub_view)
+            await ctx.send(embed=embed, view=sub_view)
             return
 
-        # S3: the top of Help is now the mother-hub category index.
-        # The legacy paginated subsystem list is reached only via the
-        # "All Commands / Advanced" entry inside HelpCategoryView; the
-        # hub-child filter lives in that branch (see
-        # HelpCategoryView._on_select), not here.
-        del visible_list
+        # S3: the top of Help is the mother-hub category index. The
+        # legacy paginated subsystem list is reached only via the
+        # "Advanced / All Commands" entry inside HelpCategoryView.
         view = HelpCategoryView(member_tier)
         embed = build_categories_overview_embed(member_tier)
 

--- a/docs/building-roadmap/admin-powers-config-coverage.md
+++ b/docs/building-roadmap/admin-powers-config-coverage.md
@@ -1,0 +1,299 @@
+# Admin Powers — Config Coverage Map
+
+Status: Reference only
+Runtime impact: None
+Scope: Pipeline-ownership map for every category of admin/operator config — answers "who owns the write path for this kind of change?"
+
+This document captures the ownership rule for every category of admin
+or operator change. It is **a reference, not a refactor plan** —
+existing surfaces are not in scope. New admin/settings work should
+align with the rules here so we stop accumulating ad-hoc write paths.
+
+Related references:
+
+- `command-integration-standard.md` — non-negotiable rules every command/panel must obey
+- `hub-ui-standard.md` — hub/panel shape standard
+- `config-input-standard.md` — input-collection standard (the front end that calls these pipelines)
+- `../settings-customization-roadmap.md`
+- `../platform-consistency-ledger.md`
+
+---
+
+## Why this doc exists
+
+Several subsystems still write directly from view callbacks or admin
+commands into ``guild_config`` (or the relevant table) without going
+through a pipeline. The result is the same operation having a different
+side-effect surface depending on which entry point the operator used:
+
+- Some surfaces emit an audit row; others don't.
+- Some invalidate the relevant cache; others rely on next-fetch
+  staleness.
+- Some emit a domain event so listeners react; others mutate silently.
+
+This doc is the canonical answer to "for this kind of change, which
+pipeline must the write path go through?" — so any new admin surface
+or any future migration of an old surface can pick the right back end
+without re-deriving the rules.
+
+---
+
+## Statement
+
+> **Feature Action Panels are valid. Direct mutation from view callbacks
+> is the anti-pattern.**
+
+A view callback that opens a confirm step, gathers input, and then calls
+a mutation pipeline is the canonical shape. The thing we are migrating
+away from is the view callback that writes to the DB itself, calls
+``guild_config.set`` directly, or otherwise side-steps the pipeline.
+
+---
+
+## Ownership rules
+
+Eight categories of change, eight ownership rules.
+
+### 1. Scalar settings → `SettingsMutationPipeline`
+
+**Examples:** XP cooldown, daily reward amount, raid threshold,
+welcome message, level-up message template, feature toggles whose
+shape is `setting_key=value`.
+
+**Pipeline:** `services/settings_mutation.py:SettingsMutationPipeline`.
+
+**Contract:**
+- Validates against the `SettingSpec` (type, bounds, regex).
+- Writes the new value to `guild_settings`.
+- Writes an audit row to `audit_log` with operator id, before/after.
+- Invalidates the `guild_config` cache for this guild.
+- Emits a `setting_changed` domain event.
+
+**Front-end strategies:** `boolean_buttons`, `enum_select`,
+`numeric_presets`, `text_modal`, `advanced_custom`.
+
+### 2. Bindings → `BindingMutationPipeline`
+
+**Examples:** mod role, admin role, audit log channel, mod log channel,
+welcome channel, level-up channel, prize drop channel, custom XP role
+thresholds.
+
+**Pipeline:** `services/binding_mutation.py:BindingMutationPipeline`.
+
+**Contract:**
+- Validates the target exists in the guild (role/channel still present).
+- Validates the binding spec (e.g. role tier doesn't exceed operator's
+  own).
+- Writes the binding row.
+- Writes an audit row.
+- Invalidates the binding cache (and any downstream caches the
+  `BindingSpec` declares).
+- Emits a `binding_changed` event for listeners (e.g. logging service
+  re-resolves routes).
+
+**Front-end strategies:** `role_select`, `channel_select`,
+sometimes `member_select` for member-typed bindings.
+
+### 3. Resources → `ResourceProvisioningPipeline`
+
+**Examples:** creating the moderation log channel from scratch,
+ensuring the mute role exists with the right permissions, allocating a
+new economy currency category.
+
+**Pipeline:** `services/resource_provisioning.py:ResourceProvisioningPipeline`.
+
+**Contract:**
+- Checks whether the resource already exists (idempotent by design).
+- Creates the resource if needed via the Discord API.
+- Persists the resulting id into the relevant binding via
+  `BindingMutationPipeline`.
+- Writes an audit row.
+- Emits a `resource_provisioned` event.
+
+**Front-end strategies:** `Provision` button on the relevant config
+panel; typically used during the setup wizard's first-run flow.
+
+### 4. Access / visibility → governance writes
+
+**Examples:** raising a member to operator tier, granting a one-off
+override (allow this user to use this command despite the default
+visibility rule), pausing a subsystem for one guild.
+
+**Pipeline:** `services/governance_service.py` write APIs (the
+mutation surface is split across `governance_service` and the rules
+modules under `governance/`).
+
+**Contract:**
+- Validates the operator's own tier covers the grant.
+- Writes the access record (or override row).
+- Writes an audit row.
+- Invalidates the per-member visibility cache.
+- Emits a `governance_changed` event for the visibility cache.
+
+**Front-end strategies:** `role_select` or `member_select` plus a
+required confirm (any grant is a power-elevation surface).
+
+### 5. Cleanup policies / word lists → cleanup service / cleanup storage
+
+**Examples:** adding a word to the blocked list, removing a word,
+adjusting the cleanup retention window, enabling regex mode.
+
+**Pipeline:** `cogs/cleanup/` services (the cleanup subsystem owns its
+own store — there is no `CleanupMutationPipeline` because the wordlist
+is stored as a structured column, not as guild_settings scalars).
+
+**Contract:**
+- Validates regex compiles (when regex mode).
+- Writes the new list to the cleanup store.
+- Writes an audit row.
+- Invalidates the cleanup compiled-pattern cache.
+- Emits a `cleanup_policy_changed` event so any in-flight cleanup task
+  re-reads the policy on its next iteration.
+
+**Front-end strategies:** `text_modal` for word add/remove,
+`boolean_buttons` for mode toggles, `numeric_presets` for retention.
+
+### 6. Logging routes → logging service / route pipeline
+
+**Examples:** routing audit-log events to a specific channel, splitting
+mod-log routing from member-event routing, attaching a webhook for one
+event type.
+
+**Pipeline:** logging service write paths in `cogs/logging/` and
+`services/server_logging.py`.
+
+**Contract:**
+- Validates the destination is reachable (channel or webhook).
+- Writes the route to the logging-route store.
+- Writes an audit row.
+- Invalidates the logging-route cache.
+- Emits a `logging_route_changed` event for the dispatcher to re-read.
+
+**Front-end strategies:** `channel_select` per route, plus
+`enum_select` for event-type when the route is event-scoped.
+
+### 7. Feature flags → `RolloutMutationPipeline`
+
+**Examples:** enabling a feature for one guild, setting a rollout
+percentage, scheduling a flag flip, pausing a flag.
+
+**Pipeline:** `services/rollout_mutation.py:RolloutMutationPipeline`.
+
+**Contract:**
+- Validates the flag is declared in the feature-flag registry.
+- Validates the new state matches the flag's declared shape (boolean,
+  percentage, scheduled).
+- Writes the new state to the flag store.
+- Writes an audit row.
+- Invalidates the flag evaluator cache.
+- Emits a `flag_changed` event so the evaluator re-reads on next check.
+
+**Front-end strategies:** `boolean_buttons` for simple toggles,
+`numeric_presets` for percentage rollouts, `text_modal` for scheduled
+flips.
+
+### 8. Game / economy runtime state → domain services
+
+**Examples:** crediting/debiting a wallet, awarding XP, opening a
+blackjack round, transferring inventory items.
+
+**Pipeline:** domain services under `services/` — `economy_service`,
+`xp_service`, `blackjack_engine`, `moderation_service`,
+`game_state_service`, etc. Each owns its own transactional API.
+
+**Contract:**
+- Validates the runtime action against domain rules (sufficient
+  balance, role still present, game still active).
+- Performs the runtime mutation transactionally.
+- Writes an audit/event row for surfaces that require one (economy
+  always; XP optionally; games on settlement only).
+- Invalidates any per-user cache the service maintains.
+- Emits a domain event when consumers exist (`economy.credit`,
+  `xp.awarded`, `game.settled`).
+
+**Front-end strategies:** typed commands or hub action panels.
+**Runtime state is never a config field** — it does not belong on the
+settings hub.
+
+### 9. Participation state → `ParticipationMutationPipeline`
+
+**Examples:** opting a member in/out of a tournament, registering for
+a participation pool, releasing a participation hold.
+
+**Pipeline:** `services/participation_mutation.py:ParticipationMutationPipeline`.
+
+**Contract:**
+- Validates the participation schema for the subsystem.
+- Writes the participation record.
+- Writes an audit row.
+- Invalidates the per-subsystem participation cache.
+- Emits a `participation_changed` event.
+
+**Front-end strategies:** `member_select`, `boolean_buttons` for
+self-opt-in flows, sometimes `enum_select` for tier-based pools.
+
+---
+
+## How to pick the right pipeline (decision flow)
+
+1. **Is the value a single key-value scalar that lives in
+   `guild_settings`?** → `SettingsMutationPipeline`.
+2. **Does the value reference a Discord entity (role, channel,
+   member)?** → `BindingMutationPipeline` (or `member_select` grant via
+   subsystem service).
+3. **Does the change create a new Discord resource (channel, role,
+   webhook)?** → `ResourceProvisioningPipeline`.
+4. **Does the change raise/lower a member's permissions or override
+   visibility?** → governance writes (`governance_service`).
+5. **Is the change a subsystem-specific policy with its own table
+   (wordlist, logging route, participation roster)?** → that
+   subsystem's pipeline / service.
+6. **Is the change a feature-flag flip or rollout adjustment?** →
+   `RolloutMutationPipeline`.
+7. **Is the change runtime/domain state (wallet, XP, game)?** → that
+   domain service. **Not config; do not surface on Settings.**
+
+If none of the above match, the change is either truly novel (file an
+issue) or it is multi-pipeline (a preset that flips several fields at
+once — orchestrate the pipeline calls behind a confirm).
+
+---
+
+## Anti-patterns (don't ship these)
+
+1. **View callback writes directly to `guild_config`.** Route through
+   `SettingsMutationPipeline.set_scalar`.
+2. **View callback writes to a binding table.** Route through
+   `BindingMutationPipeline`.
+3. **View callback grants a role or assigns a permission directly.**
+   Route through the governance write API and confirm.
+4. **Admin command that bypasses audit.** Every operator-visible
+   mutation writes an audit row. Background reconciliation tasks may
+   skip audit but must log at INFO and emit a domain event instead.
+5. **Cache invalidation living in the view.** Pipelines own their
+   caches. Duplicated invalidation in the view races the pipeline's
+   own invalidation and risks stale reads.
+6. **Two pipelines writing the same column.** Each ownership rule
+   above is exclusive. If two pipelines need to touch the same field,
+   factor a service the field's owner exposes and call the service —
+   don't write the column twice.
+7. **Mixing config and runtime on the same surface.** A "give a member
+   100 XP" button on the XP settings page conflates config with runtime
+   state. Runtime actions belong on action panels; config belongs on
+   settings panels.
+
+---
+
+## Open questions (deferred)
+
+- **Cross-subsystem presets.** The current presets framework wires each
+  field through its own pipeline. A "server-type" preset that touches
+  10+ subsystems is on the roadmap but needs a pre-flight that surfaces
+  every individual confirm in one place.
+- **Soft-locks.** Some bindings (mod role, admin role) shouldn't be
+  changed during a live incident. A future "config freeze" toggle could
+  pause every pipeline except governance writes — not designed yet.
+- **Schema-driven pipeline dispatch.** Once every field has a
+  `SettingSpec` (or equivalent) that declares its pipeline by name, the
+  config UI generator can dispatch automatically. This doc is the
+  contract that dispatcher would target.

--- a/docs/building-roadmap/config-input-standard.md
+++ b/docs/building-roadmap/config-input-standard.md
@@ -1,0 +1,233 @@
+# Config Input Standard
+
+Status: Reference only
+Runtime impact: None
+Scope: Future config-mutation UIs — how every admin/settings input should be shaped so the same patterns work across subsystems
+
+This document captures the input-collection standard for SuperBot's
+config and settings UIs. It is **a reference, not a refactor plan** —
+existing views are not in scope. New config surfaces and any future
+view-layer regrouping should align with the principles here.
+
+Related references:
+
+- `command-integration-standard.md` — non-negotiable rules every command/panel must obey
+- `hub-ui-standard.md` — hub/panel shape standard (where this input shape lives)
+- `admin-powers-config-coverage.md` — pipeline ownership map (the back end that input forms call)
+- `../settings-customization-roadmap.md`
+- `../settings-customization-command-map.md`
+
+---
+
+## Why this doc exists
+
+Today every settings/admin surface invents its own input shape:
+
+- Some panels open a text modal and ask the operator to type a channel
+  mention.
+- Some panels use a 25-option dropdown of preset values.
+- Some panels are buttons-only and don't expose the underlying value at
+  all.
+- Several panels write directly from the view callback to the DB or to
+  ``guild_config`` — bypassing audit, validation, and cache
+  invalidation.
+
+The inconsistency is not a bug — each subsystem evolved independently —
+but new config surfaces (the setup wizard, the per-guild flag manager
+v2, Economy v2 settings, Moderation v2 thresholds) need a shared
+shape. This doc captures that shape so the next round lands consistent
+by construction.
+
+---
+
+## Core principles
+
+1. **Guided input first; raw text only when nothing else fits.** Use
+   visible buttons, selects, or paginated picks whenever the value space
+   is small, enumerated, or referential. Raw text modals are a fallback,
+   not a default.
+2. **Views collect; pipelines mutate.** The view's job is to gather
+   input, render a preview, and call the right pipeline. Validation,
+   mutation, audit logging, event emission, and cache invalidation belong
+   in the pipeline — never in the view callback. See
+   `admin-powers-config-coverage.md` for the pipeline-ownership map.
+3. **Show the current value before asking for the next one.** Every
+   config surface displays the field's current value (or "not set") so
+   the operator knows what they're changing from.
+4. **Dangerous changes preview and confirm.** Destructive or
+   wide-blast-radius changes — disabling a subsystem, replacing a binding,
+   clearing a word list — render a confirm step that restates the change
+   in plain language before the pipeline runs.
+5. **Failures explain, they don't crash.** Pipeline rejections surface
+   as an ephemeral with the reason. The original panel stays open so the
+   operator can correct and retry.
+6. **One input strategy per field.** Don't ask the same field through
+   both a dropdown and a modal in the same panel — pick one. The
+   strategy table below names the canonical option for each field shape.
+7. **Audit is non-optional.** Every successful mutation writes an audit
+   row through the pipeline. Views must not call mutation primitives
+   that skip the audit path.
+8. **Feature Action Panels are valid.** Operator/admin panels that mix
+   read, navigate, and mutate are an accepted pattern when the mutation
+   routes through a pipeline. The anti-pattern is the view callback
+   itself writing to the database or to ``guild_config``.
+
+---
+
+## Input strategies
+
+Eight recognised input shapes. Picking the right strategy for a field
+is the first design decision.
+
+### 1. `boolean_buttons`
+
+For an on/off field with no third state.
+
+- **Surface:** two buttons (`Enable` / `Disable`), the active one
+  disabled and styled `success`/`danger`.
+- **Current value:** rendered above the buttons as
+  `Current: Enabled` / `Current: Disabled`.
+- **Preview/confirm:** not required — single-click flips the bit.
+- **Pipeline:** `SettingsMutationPipeline.set_scalar`.
+
+### 2. `enum_select`
+
+For a field with 2–25 named values (mode toggles, severity tiers).
+
+- **Surface:** a single dropdown listing every option with its emoji
+  and one-line description.
+- **Current value:** the active option is marked `(current)` in its
+  description; never disabled (operator can re-select to confirm).
+- **Preview/confirm:** required if the enum drives wide visibility or
+  routing changes (e.g. mod-tier escalation).
+- **Pipeline:** `SettingsMutationPipeline.set_scalar`.
+
+### 3. `numeric_presets`
+
+For numeric fields with a small set of operator-meaningful values
+(seconds, minutes, percentages, common counts).
+
+- **Surface:** 3–6 preset buttons (e.g. `5m`, `30m`, `1h`, `4h`,
+  `24h`) plus a `Custom…` button that opens a single-field text modal
+  for off-preset values.
+- **Current value:** rendered above the buttons; the matching preset
+  is disabled when applicable.
+- **Preview/confirm:** not required for tunables; required for limits
+  (XP cooldown, raid thresholds).
+- **Pipeline:** `SettingsMutationPipeline.set_scalar`.
+
+### 4. `role_select`
+
+For fields that reference one or more roles.
+
+- **Surface:** Discord-native `RoleSelect` component. Single- or
+  multi-select per field semantics.
+- **Current value:** mentions rendered above the select.
+- **Preview/confirm:** required for tier-escalating bindings
+  (`mod_role`, `admin_role`).
+- **Pipeline:** `BindingMutationPipeline.set_role_binding` (or
+  `replace_role_binding` for multi-role fields).
+
+### 5. `channel_select`
+
+For fields that reference one or more channels.
+
+- **Surface:** Discord-native `ChannelSelect` filtered by channel type
+  (text vs voice vs category) appropriate to the field.
+- **Current value:** mention(s) rendered above the select.
+- **Preview/confirm:** required when the channel becomes a routing
+  target (mod logs, audit channel, prize drop channel).
+- **Pipeline:** `BindingMutationPipeline.set_channel_binding`.
+
+### 6. `member_select`
+
+For per-user grants (designated VIPs, exempt members).
+
+- **Surface:** Discord-native `UserSelect`. Multi-select where the
+  field is a list.
+- **Current value:** mentions rendered above the select; truncate with
+  `+N more` when the list exceeds 5.
+- **Preview/confirm:** always required — grants are a power-elevation
+  surface.
+- **Pipeline:** subsystem-specific grant API or
+  `BindingMutationPipeline` if the field is a binding.
+
+### 7. `text_modal`
+
+For free-form text — names, messages, regex patterns, custom URLs.
+
+- **Surface:** a `Modal` with one or two `TextInput` fields, label
+  + placeholder + max-length.
+- **Current value:** rendered above the launch button.
+- **Preview/confirm:** required for changes that go to many users
+  (welcome message, level-up message, broadcast template).
+- **Pipeline:** `SettingsMutationPipeline.set_scalar` or a
+  subsystem-specific service for fields that need parse/normalize
+  (e.g. cleanup word lists → `cleanup` service).
+
+### 8. `preset_pack_select`
+
+For coordinated multi-field changes — "set up Moderation for a small
+server", "switch Economy to the high-payout preset".
+
+- **Surface:** dropdown of named packs with a short description.
+- **Current value:** the active pack (if any) marked `(applied)`;
+  custom (no-pack) states render as `Custom`.
+- **Preview/confirm:** **always required** — the preview lists every
+  field the pack will overwrite and the current vs new value.
+- **Pipeline:** delegates to the relevant mutation pipelines for each
+  field; the preset orchestrator never bypasses them.
+
+### 9. `advanced_custom` (fallback)
+
+For fields that don't fit any of the above (free-form JSON blobs,
+operator-only overrides, schema fragments).
+
+- **Surface:** an `Advanced…` button that opens a multi-field modal or
+  a paginated text editor.
+- **Current value:** rendered as a code block above the launch button.
+- **Preview/confirm:** always required; the preview must render the
+  parsed-and-normalized form, not the raw input.
+- **Pipeline:** subsystem-specific. The view still does **not** write
+  directly.
+
+---
+
+## Anti-patterns (don't ship these)
+
+1. **Raw text modal for an enumerated value.** If the value space is
+   known and bounded, use `enum_select` or `boolean_buttons`.
+2. **Direct ``guild_config.set(...)`` from a view callback.** Always
+   call the right mutation pipeline.
+3. **Side-channel cache invalidation.** Pipelines own cache
+   invalidation. A view that mutates and then manually calls
+   ``cache.invalidate(...)`` is duplicating work that the pipeline
+   already does and risks divergence.
+4. **Silent failure.** A pipeline rejection that gets swallowed by the
+   view (no ephemeral, no log, no retry path) hides config drift from
+   the operator.
+5. **Skipping the current-value line.** Every config surface shows
+   what's there now. Operators should not have to leave a panel to
+   discover the current state.
+6. **No-confirm destructive change.** Disabling a subsystem, replacing
+   a binding to a high-tier role, or clearing a word list always
+   confirms.
+7. **Bypassing the audit row.** Mutation primitives that don't write
+   audit are operator-side only (used in tests/migrations). Live UI
+   must go through the pipeline.
+
+---
+
+## Open questions (deferred)
+
+- **Per-field rollback UI.** Pipelines emit audit rows but there's no
+  user-facing "revert last change" yet. The audit table has the data;
+  the UI does not. Future work.
+- **Bulk-edit pages.** Several subsystems benefit from editing 10–30
+  fields at once (the operator-presets flow). The current `apply
+  preset` action covers most cases; a generic bulk editor is future
+  work.
+- **Schema-driven generation.** Once every settable field has a
+  `SettingSpec` and a strategy hint, the input surface can be
+  generated from the schema. This is the long-term direction; the
+  strategy table above is the contract that generator would target.

--- a/docs/help-command-surface-map.md
+++ b/docs/help-command-surface-map.md
@@ -1,0 +1,121 @@
+# Help / Command Surface Map
+
+Source-of-truth inventory for every loaded cog/subsystem and how each is
+reachable today through Help, hubs, and typed commands. Captured at HEAD
+`7f85d9a` and updated alongside the Help routing PR.
+
+The columns that matter most are **owner**, **panel**, **Help route**,
+**hub route**, and **recommended placement**. Command lists are
+representative, not exhaustive — large alias/legacy families are
+summarized with a count.
+
+## 1. Mother hubs
+
+8 hubs in `disbot/utils/hub_registry.py`. Every hub key matches a
+`SUBSYSTEMS` key so Help can resolve a hub entry to its host cog.
+
+| key | display | entry | host cog | panel | min tier |
+| --- | --- | --- | --- | --- | --- |
+| `games` | 🎮 Games | `!games` | `games_cog` | `GamesHubView` (`views/games/hub.py`) | user |
+| `economy` | 💰 Economy | `!economymenu` | `economy_cog` | `EconomyPanelView` | user |
+| `moderation` | 🛡️ Moderation & Safety | `!modmenu` | `moderation_cog` | `ModPanelView` | moderator |
+| `community` | 🌱 Community | `!community` | `community_cog` | `CommunityHubView` | user |
+| `utility` | 🧰 Utility | `!utilitymenu` | `utility_cog` | `UtilityPanelView` | user |
+| `admin` | ⚙️ Admin / Operations | `!adminmenu` | `admin_cog` | `_AdminPanelView` | administrator |
+| `settings` | 🔧 Settings / Configuration | `!settings` | `settings_cog` | `SettingsHubView` | administrator |
+| `diagnostic` | 🩺 Platform / Diagnostics | `!platform` | `diagnostic_cog` | `_PlatformHubView` | administrator |
+
+## 2. Subsystem inventory
+
+24 cogs in `disbot/config.py:33-58`. 23 of 24 expose
+`build_help_menu_view`; only `help_cog` itself does not. The Help route
+resolver therefore opens a real panel for every subsystem except `help`,
+and only falls back to the command-list embed when the hook is missing
+or raises.
+
+| subsystem | owner | public commands (sample) | hidden / legacy | panel hook | Help route today | Hub route today | Recommendation |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `admin` | `admin_cog.py` | `adminmenu`, `serverstats`, `cog`, `loadall`, `unloadall`, `restart`, `loglevel` | — | `_AdminPanelView` | `!help admin` → command-list | dropdown Admin → panel | hub child (top-level Admin) |
+| `blackjack` | `blackjack_cog.py:95` | `blackjack`, `bj`, `bjtournament`, `bjstart`, `bjstatus` | — | `BlackjackPanelView` | `!help blackjack` → command-list | reached via Games | hub child (Games) |
+| `chain` | `chain_cog.py` | `chain`, `chainmenu` | — | `ChainPanelView` | `!help chain` → command-list | reached via Games / Community | hub child |
+| `channel` | `channel_cog.py:144` | `lock`, `unlock` | several `*_channel`-family commands | `ChannelPanelView` | `!help channel` → command-list | reached via Admin | hub child (Admin) |
+| `cleanup` | `cleanup_cog.py:324` | `cleanuphistory`, `word`, `wordmenu`, `cleanup` | — | `CleanupHubView` | `!help cleanup` → command-list | reached via Moderation | hub child (Moderation) |
+| `community` | `community_cog.py` | `community` | — | `CommunityHubView` | `!help community` → command-list | dropdown Community → panel | hub top-level |
+| `counting` | `counting_cog.py` | `countingmenu`, `start_match`, `end_match`, `reset_count` | — | `CountingPanelView` | `!help counting` → command-list | reached via Games / Community | hub child |
+| `deathmatch` | `deathmatch_cog.py` | `dm_challenge`, `deathmatch`, `dm`, `dm_help` | — | `DeathmatchPanelView` | `!help deathmatch` → command-list | reached via Games | hub child (Games) |
+| `diagnostic` | `diagnostic_cog.py:70` | `diagnostics`, `diag`, `latency`, `platform` (group, 20+ subcommands) | — | `_DiagnosticsHubView` (generic hook); `_PlatformHubView` (new platform hook) | `!help diagnostic` → command-list (wrong: should open Platform Hub); `!help diagnostics`/`diag` → not currently routed to panel | Hub key `diagnostic` is "Platform / Diagnostics" → calls `build_help_menu_view` → **wrong view (Diagnostics, not Platform)** | hub top-level (Platform); `diagnostics`/`diag` open Diagnostics Hub |
+| `economy` | `economy_cog.py` | `economymenu`, `daily`, `work`, `shop`, `balance`/`bal`/`wallet` | several admin/legacy commands | `EconomyPanelView` | `!help economy` → command-list (wrong: should open Economy hub) | dropdown Economy → panel | hub top-level |
+| `games` | `games_cog.py` | `games` | — | `GamesHubView` | `!help games` → command-list (wrong: should open Games hub) | dropdown Games → panel | hub top-level (cleanest model) |
+| `general` | `general_cog.py` | `fact`, `joke`, `quote`, `motivate`, `greet` | — | (small panel) | `!help general` → command-list | none today | hub child (Utility, future) |
+| `help` | `help_cog.py` | `help` (alias `hilfe`) | — | **no panel hook (Help itself is the panel)** | n/a | dropdown root | Help Home |
+| `inventory` | `inventory_cog.py:376` | `inventory`, `inv` | — | `InventoryPanelView` | `!help inventory` → command-list | top-level today | hub child (Economy, future) |
+| `leaderboard` | `leaderboard_cog.py:200` | (none public-flagged; entry inferred from registry) | — | `LeaderboardPanelView` | `!help leaderboard` → command-list | top-level today | hub child (Economy / Community) |
+| `logging` | `logging_cog.py:88` | `logging` | — | `LoggingPanelView` | `!help logging` → command-list | reached via Moderation / Admin | hub child |
+| `mining` | `mining_cog.py:65` | `mineinv`/`mineinventory`, `minestats` | mining game flow commands (start/dig/etc.) | `MiningHubView` | `!help mining` → command-list | reached via Games / Economy cross-link | hub child (Games) |
+| `moderation` | `moderation_cog.py` | `modmenu`, `warn`, `timeout`, `kick`, `ban`, `unban`, `clearwarnings`, `modlogs` | — | `ModPanelView` | `!help moderation` → command-list (wrong: should open Moderation hub) | dropdown Moderation → panel | hub top-level |
+| `proof_channel` | `proof_channel_cog.py:113` | `prizestatus`, `prizemenu`, `timedprize` | — | `ProofPanelView` | `!help proof` → command-list | reached via Moderation | hub child (Moderation) |
+| `role` | `role_cog.py:334` | `roles`, `rolesettings`, `rolemenu` (legacy alias) | 8+ legacy commands: `rolecreator`, `createrole`, `deleterole`, `setrole`, `unsetrole`, `assignroles`, `debugroles`, `refreshmembers`, plus react-role family | `RolePanelView` | `!help roles` → command-list | reached via Community | hub child (Community); legacy commands remain as hidden compatibility |
+| `rps_tournament` | `rps_tournament_cog.py:118` | `rpsregister`/`rpsreg`, `rpsstart`/`rpsbegin`, `rpsbot`, `rpsmatchup`, `rpshelp`, `rpssettings` | — | `RpsPanelView` | `!help rps` → command-list | reached via Games | hub child (Games) |
+| `settings` | `settings_cog.py` | (entry via `!settings`) | — | `SettingsHubView` | `!help settings` → command-list (wrong: should open Settings hub) | dropdown Settings → panel | hub top-level |
+| `utility` | `utility_cog.py` | `utilitymenu`, `clear`/`purge`, `info`, `serverinfo`, `userinfo`, `avatar`, `remind` | — | `UtilityPanelView` | `!help utility` → command-list (wrong: should open Utility hub) | dropdown Utility → panel | hub top-level |
+| `xp` | `xp_cog.py` | `xpmenu`, `rank`, `givexp`, `resetxp`, `xpconfig` | — | `XpPanelView` | `!help xp` → command-list | reached via Community | hub child (Community); admin controls live in panel |
+
+## 3. Known inconsistencies (resolved by this PR)
+
+1. **Typed Help and dropdown Help diverge.** `!help <category>` in
+   `help_cog.py:609-674` iterates `SUBSYSTEMS` and renders
+   `build_cog_embed` — it never consults `hub_registry`, never calls
+   `build_help_menu_view`, and never attaches Back-to-Help. The dropdown
+   (`HelpCategoryView._on_select`, lines 536-602) does all three. Same
+   word, two different surfaces.
+2. **Platform Help route mismatch.** The hub `diagnostic` is registered
+   as "Platform / Diagnostics" with entry `!platform`
+   (`hub_registry.py:184-191`), but `DiagnosticCog.build_help_menu_view`
+   returns `_DiagnosticsHubView` (`diagnostic_cog.py:70-81`). The Help
+   dropdown therefore opens the wrong hub when the user picks "Platform
+   / Diagnostics". The fix is a sibling builder
+   `build_platform_help_menu_view` returning `_PlatformHubView`, plus a
+   per-hub override table in `help_cog.py`. The generic hook stays on
+   Diagnostics so Admin → Diagnostics still works.
+3. **Help Home rows are uneven.** `build_categories_overview_embed`
+   shows an `Includes: ...` line for Games (populated
+   `primary_children`) and nothing for Economy / Moderation / Community
+   / Utility (empty `primary_children` per S7–S10 v1). The new copy
+   removes `Includes:` entirely and uses uniform two-line rows.
+
+## 4. Architectural notes
+
+- **Games is the cleanest current model.** Hub view is registry-driven
+  via `parent_hub`, has all six game children explicitly listed, and
+  the hub UI is built from a single source.
+- **S7–S10 Help promotions (Economy / Moderation / Community / Utility)
+  are first-pass.** Their hubs route to existing panels via
+  `build_help_menu_view`. Their `primary_children` are empty until
+  follow-ups flip `parent_hub` metadata on the relevant subsystems.
+- **Role public entry is `!roles`.** Legacy `rolemenu` and the
+  rolemenu-style command family remain registered as hidden
+  compatibility — they will not surface in Help.
+- **Utility / Proof / Channel exposure gaps.** Several admin tools
+  (channel lock/unlock, proof prize controls, cleanup history) are
+  reachable only through hub panels — `!help <name>` resolves but the
+  command-list embed undersells them. Hub panels are the canonical
+  exposure point.
+- **XP mixes user rank display with admin controls.** The XP panel
+  surfaces both. Admin-only routing belongs in the panel, not in the
+  command list. Marked for a future split if/when XP gets its own hub.
+- **Advanced remains necessary but secondary.** Power-users who know a
+  command name should not have to navigate hubs to find it.
+
+## 5. Future routing surfaces (not in scope here)
+
+The following are intentionally out of scope for the Help routing PR
+and are listed only to make the eventual landing surface clearer:
+
+- **Slash front door** (`/help`, `/games`, etc.) — needs `HelpRoute`
+  shared with the slash registrar.
+- **Setup wizard** (`!setup`) — first-run onboarding that walks an
+  admin through binding the required channels/roles.
+- **Hub v2 redesigns** — explicit `parent_hub` metadata on Inventory,
+  Leaderboard, XP, Role, Cleanup, Logging, Proof, Channel, General.
+- **Direct-write remediation** — view callbacks that mutate state
+  directly today should route through mutation pipelines.

--- a/tests/unit/docs/test_help_surface_map_doc.py
+++ b/tests/unit/docs/test_help_surface_map_doc.py
@@ -1,0 +1,56 @@
+"""Sanity check for ``docs/help-command-surface-map.md``.
+
+Verifies the inventory doc exists, has the expected section headings,
+and lists every committed subsystem and every committed hub.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from utils.hub_registry import HUBS
+from utils.subsystem_registry import SUBSYSTEMS
+
+DOC_PATH = Path(__file__).resolve().parents[3] / "docs" / "help-command-surface-map.md"
+
+
+@pytest.fixture(scope="module")
+def doc_text() -> str:
+    assert DOC_PATH.exists(), f"missing inventory doc at {DOC_PATH}"
+    return DOC_PATH.read_text(encoding="utf-8")
+
+
+def test_doc_has_required_section_headings(doc_text):
+    """Section headings keep the doc navigable. Hub table, subsystem
+    inventory, and the inconsistencies callout are the load-bearing
+    sections — pin these three explicitly.
+    """
+    for heading in (
+        "## 1. Mother hubs",
+        "## 2. Subsystem inventory",
+        "## 3. Known inconsistencies",
+    ):
+        assert heading in doc_text, f"missing required heading: {heading}"
+
+
+def test_doc_lists_every_committed_hub(doc_text):
+    """Every hub registered in :data:`HUBS` must appear in the doc so
+    the inventory tracks reality. We match by hub key wrapped in
+    backticks (the doc's table convention).
+    """
+    for hub in HUBS:
+        assert f"`{hub.key}`" in doc_text, (
+            f"hub {hub.key!r} missing from inventory doc"
+        )
+
+
+def test_doc_lists_every_subsystem_key(doc_text):
+    """Every subsystem key in :data:`SUBSYSTEMS` must appear in the
+    inventory table. Match by key wrapped in backticks.
+    """
+    for key in SUBSYSTEMS:
+        assert f"`{key}`" in doc_text, (
+            f"subsystem {key!r} missing from inventory doc"
+        )

--- a/tests/unit/help/test_help_category_view.py
+++ b/tests/unit/help/test_help_category_view.py
@@ -93,16 +93,21 @@ def test_categories_embed_hides_admin_only_hubs_from_normal_users():
     assert any("All Commands" in n for n in field_names)
 
 
-def test_categories_embed_includes_line_lists_games_children():
-    """The Games category must show its children in the 'Includes:'
-    line so users know what's behind the dropdown.
+def test_categories_embed_uses_uniform_row_shape_with_no_includes_line():
+    """Each hub row must be the uniform two-line shape — purpose +
+    typed entry command — with no ``Includes:`` line. Child rosters
+    live inside each hub panel, not on Help Home.
     """
     embed = build_categories_overview_embed(member_tier="user")
+    for field in embed.fields:
+        assert "Includes:" not in field.value, (
+            f"Help Home row {field.name!r} still has an Includes: line: "
+            f"{field.value!r}"
+        )
     games_field = next(f for f in embed.fields if "Games" in f.name)
-    # Pin a sampling of the known children rather than the full set —
-    # changes to game roster shouldn't break this test.
-    assert "Blackjack" in games_field.value
-    assert "Mining" in games_field.value
+    # Purpose + entry command, both present and on their own lines.
+    assert "Game" in games_field.value or "game" in games_field.value
+    assert "!games" in games_field.value
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/help/test_help_home_copy.py
+++ b/tests/unit/help/test_help_home_copy.py
@@ -1,0 +1,63 @@
+"""Help Home embed copy tests.
+
+After the routing-consistency PR, every hub row uses the same two-line
+shape — purpose + typed entry command — with no ``Includes:`` line and
+no internal metadata terms.
+"""
+
+from __future__ import annotations
+
+from cogs.help_cog import build_categories_overview_embed
+
+
+def test_no_includes_line_in_any_row():
+    embed = build_categories_overview_embed(member_tier="owner")
+    for field in embed.fields:
+        assert "Includes:" not in field.value, (
+            f"row {field.name!r} contains an Includes: line"
+        )
+
+
+def test_no_internal_metadata_terms():
+    embed = build_categories_overview_embed(member_tier="owner")
+    body = "\n".join(f.value for f in embed.fields)
+    for term in ("primary_children", "cross_link_children", "parent_hub"):
+        assert term not in body, f"internal term {term!r} leaked into Help Home"
+
+
+def test_each_hub_row_has_uniform_two_line_shape():
+    r"""Each hub row contains a one-line purpose followed by a
+    ``→ \`!command\``` line. Pin the shape, not the exact wording.
+    """
+    embed = build_categories_overview_embed(member_tier="owner")
+    for field in embed.fields:
+        if "Advanced" in field.name:
+            continue
+        assert "→" in field.value, f"row {field.name!r} missing → entry line"
+        lines = field.value.split("\n")
+        assert len(lines) >= 2, f"row {field.name!r} has fewer than 2 lines"
+
+
+def test_advanced_row_is_present_for_every_tier():
+    for tier in ("user", "moderator", "administrator", "owner"):
+        embed = build_categories_overview_embed(member_tier=tier)
+        names = [f.name for f in embed.fields]
+        assert any("Advanced" in n for n in names), (
+            f"Advanced row missing at tier={tier}"
+        )
+
+
+def test_admin_tier_sees_all_hubs():
+    embed = build_categories_overview_embed(member_tier="administrator")
+    names = [f.name for f in embed.fields]
+    for label in ("Games", "Admin", "Settings", "Platform"):
+        assert any(label in n for n in names), f"hub {label} missing for admin"
+
+
+def test_user_tier_hides_admin_only_hubs():
+    embed = build_categories_overview_embed(member_tier="user")
+    names = [f.name for f in embed.fields]
+    for label in ("Admin", "Settings", "Platform"):
+        assert not any(label in n for n in names), (
+            f"admin-only hub {label} leaked into user-tier Help Home"
+        )

--- a/tests/unit/help/test_help_parent_hub_filter.py
+++ b/tests/unit/help/test_help_parent_hub_filter.py
@@ -269,35 +269,23 @@ def test_help_panel_view_select_omits_hub_children_when_visible_list_excludes_th
 # ---------------------------------------------------------------------------
 
 
-def test_typed_help_category_lookup_unchanged_for_hub_children():
-    """``!help blackjack`` resolves by iterating SUBSYSTEMS directly —
-    the visible_set check still passes (governance allows blackjack),
-    and there is no parent_hub filter on the category lookup branch.
-
-    This test is a code-survey assertion rather than a runtime call: it
-    inspects ``help_cog.HelpCog.help_command`` source to confirm the
-    category branch doesn't filter on ``parent_hub``.
+def test_typed_help_route_for_hub_child_resolves_to_subsystem():
+    """``!help blackjack`` must resolve to the Blackjack subsystem so the
+    panel opens — never to a parent-hub filter that would silently drop
+    hub children. This is a runtime assertion against the resolver
+    rather than a source-text grep; the previous implementation lived
+    inside ``help_command`` and is now centralized in ``_resolve_route``.
     """
-    import inspect
+    from unittest.mock import MagicMock
 
-    # ``help_command`` is wrapped by ``@commands.command`` into a Command
-    # object — read the underlying callback source.
-    src = inspect.getsource(help_cog.HelpCog.help_command.callback)
-    # The overview branch builds visible_list with the parent_hub filter
-    # (this is the line whose comment we want to find).
-    assert "parent_hub" in src, (
-        "help_command source no longer mentions parent_hub — filter likely removed"
-    )
-    # The category branch iterates ``SUBSYSTEMS.items()`` and skips
-    # invisible names. It must NOT skip on parent_hub.
-    # Match the actual ``if category:`` statement, not occurrences
-    # inside docstrings or comments — code indentation is 8 spaces.
-    category_branch_start = src.find("\n        if category:")
-    assert category_branch_start != -1
-    category_branch = src[category_branch_start:]
-    # ``parent_hub`` must not appear inside the category branch.
-    # (If a future refactor adds such a filter, this test will tell us.)
-    assert "parent_hub" not in category_branch, (
-        "category lookup branch now filters by parent_hub — that would "
-        "break typed ``!help blackjack`` access"
-    )
+    bot = MagicMock()
+    bot.get_command = MagicMock(return_value=None)
+
+    route = help_cog._resolve_route("blackjack", bot=bot)
+    assert route.kind == "subsystem"
+    assert route.target == "blackjack"
+
+    # Mining is another canonical hub child — same expectation.
+    route = help_cog._resolve_route("mining", bot=bot)
+    assert route.kind == "subsystem"
+    assert route.target == "mining"

--- a/tests/unit/help/test_help_route_resolution.py
+++ b/tests/unit/help/test_help_route_resolution.py
@@ -1,0 +1,163 @@
+"""Unit tests for :func:`cogs.help_cog._resolve_route` — the single
+resolver shared by typed ``!help <name>`` and the Help dropdown.
+
+The resolver normalizes the input name and returns one of five route
+kinds: ``hub``, ``subsystem``, ``advanced``, ``command``, ``unknown``.
+Typed Help and the dropdown both call this so the same name produces
+the same destination regardless of entry point.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from cogs import help_cog
+
+
+def _bot(command_names: tuple[str, ...] = ()) -> MagicMock:
+    bot = MagicMock()
+
+    def _get_command(name: str):
+        if name in command_names:
+            cmd = MagicMock()
+            cmd.name = name
+            return cmd
+        return None
+
+    bot.get_command = _get_command
+    return bot
+
+
+# ---------------------------------------------------------------------------
+# Advanced aliases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["advanced", "all", "commands", "all commands", "Advanced", "ALL"],
+)
+def test_advanced_aliases_resolve_to_advanced(name):
+    route = help_cog._resolve_route(name, bot=_bot())
+    assert route.kind == "advanced"
+
+
+# ---------------------------------------------------------------------------
+# Hub aliases — every committed hub
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("name", "expected_hub"),
+    [
+        ("games", "games"),
+        ("economy", "economy"),
+        ("moderation", "moderation"),
+        ("mod", "moderation"),
+        ("community", "community"),
+        ("utility", "utility"),
+        ("admin", "admin"),
+        ("settings", "settings"),
+        ("platform", "diagnostic"),
+        ("diagnostic", "diagnostic"),
+        # Case-insensitive
+        ("Games", "games"),
+        ("PLATFORM", "diagnostic"),
+        # Entry-command match (without leading !)
+        ("adminmenu", "admin"),
+        ("modmenu", "moderation"),
+        ("utilitymenu", "utility"),
+        ("economymenu", "economy"),
+    ],
+)
+def test_hub_aliases_resolve_to_hub(name, expected_hub):
+    route = help_cog._resolve_route(name, bot=_bot())
+    assert route.kind == "hub", f"{name!r} did not resolve as hub"
+    assert route.target == expected_hub
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics subsystem aliases — must NOT route to Platform hub
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ["diagnostics", "diag", "Diagnostics", "DIAG"])
+def test_diagnostics_aliases_resolve_to_diagnostic_subsystem(name):
+    """The subsystem alias overrides run before the hub match so plural
+    "diagnostics" and short "diag" stay on the Diagnostics Hub via the
+    generic ``build_help_menu_view`` hook (the singular "diagnostic" and
+    "platform" continue to open the Platform Hub).
+    """
+    route = help_cog._resolve_route(name, bot=_bot())
+    assert route.kind == "subsystem"
+    assert route.target == "diagnostic"
+
+
+# ---------------------------------------------------------------------------
+# Subsystem keys with build_help_menu_view → subsystem route
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "blackjack",
+        "mining",
+        "inventory",
+        "leaderboard",
+        "cleanup",
+        "logging",
+        "channel",
+        "proof_channel",
+        "xp",
+        "rps_tournament",
+        "deathmatch",
+        "counting",
+        "chain",
+    ],
+)
+def test_subsystem_keys_resolve_to_subsystem(name):
+    route = help_cog._resolve_route(name, bot=_bot())
+    assert route.kind == "subsystem"
+    assert route.target == name
+
+
+def test_role_subsystem_resolves_to_role():
+    route = help_cog._resolve_route("role", bot=_bot())
+    assert route.kind == "subsystem"
+    assert route.target == "role"
+
+
+# ---------------------------------------------------------------------------
+# Command name route
+# ---------------------------------------------------------------------------
+
+
+def test_command_name_resolves_to_command():
+    """When no hub/subsystem matches but the name is a real command,
+    resolve to the command route (single-command help embed).
+    """
+    bot = _bot(command_names=("daily",))
+    route = help_cog._resolve_route("daily", bot=bot)
+    # ``daily`` is not a hub key or subsystem key today — it's a command
+    # owned by the economy cog. The resolver should fall through to the
+    # command branch.
+    assert route.kind == "command"
+    assert route.target == "daily"
+
+
+# ---------------------------------------------------------------------------
+# Unknown fallback
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_name_resolves_to_unknown():
+    route = help_cog._resolve_route("not-a-real-thing", bot=_bot())
+    assert route.kind == "unknown"
+
+
+def test_empty_name_resolves_to_unknown():
+    route = help_cog._resolve_route("", bot=_bot())
+    assert route.kind == "unknown"

--- a/tests/unit/help/test_help_typed_category_routes.py
+++ b/tests/unit/help/test_help_typed_category_routes.py
@@ -1,0 +1,290 @@
+"""Integration tests for typed ``!help <name>`` parity with the dropdown.
+
+After the routing-consistency PR, typed Help and the Help dropdown both
+go through :func:`cogs.help_cog._resolve_route` and
+:func:`cogs.help_cog._open_route`. These tests verify the resolver
++ opener pipeline lands on the same surface as the dropdown would.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from cogs import help_cog
+
+
+def _opener() -> help_cog.HelpOpener:
+    user = MagicMock()
+    user.id = 1
+    bot = MagicMock()
+    return help_cog.HelpOpener(
+        user=user,
+        guild=None,
+        guild_id=None,
+        client=bot,
+        channel=MagicMock(),
+    )
+
+
+def _opener_with_fake_cog(cog_subsystem: str, fake_cog) -> help_cog.HelpOpener:
+    opener = _opener()
+    # Patch ``_cog_for_subsystem`` to return our fake cog for the
+    # subsystem the route resolves to.
+    return opener, fake_cog
+
+
+# ---------------------------------------------------------------------------
+# Hub routes — open the host cog's panel via build_help_menu_view
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_help_games_opens_games_hub_panel(monkeypatch):
+    """``!help games`` must resolve to the games hub and call its
+    ``build_help_menu_view`` (matching the dropdown).
+    """
+    opener = _opener()
+    route = help_cog._resolve_route("games", bot=opener.client)
+    assert route.kind == "hub"
+    assert route.target == "games"
+
+    fake_view = discord.ui.View()
+    fake_embed = discord.Embed(title="Games Hub")
+    fake_cog = MagicMock()
+    fake_cog.build_help_menu_view = AsyncMock(return_value=(fake_embed, fake_view))
+
+    monkeypatch.setattr(help_cog, "_cog_for_subsystem", lambda _bot, _key: fake_cog)
+    embed, view = await help_cog._open_route(
+        route,
+        opener,
+        visible_subsystems={"games"},
+        member_tier="user",
+    )
+    fake_cog.build_help_menu_view.assert_awaited_once()
+    assert embed is fake_embed
+    assert view is fake_view
+
+
+@pytest.mark.asyncio
+async def test_help_platform_opens_platform_hub_via_dedicated_builder(monkeypatch):
+    """``!help platform`` must call ``build_platform_help_menu_view`` —
+    the Platform hub's dedicated builder — not the generic hook.
+    """
+    opener = _opener()
+    route = help_cog._resolve_route("platform", bot=opener.client)
+    assert route.kind == "hub"
+    assert route.target == "diagnostic"
+
+    fake_view = discord.ui.View()
+    fake_embed = discord.Embed(title="Platform hub")
+    fake_cog = MagicMock()
+    fake_cog.build_platform_help_menu_view = AsyncMock(
+        return_value=(fake_embed, fake_view),
+    )
+    fake_cog.build_help_menu_view = AsyncMock(
+        return_value=(discord.Embed(title="WRONG"), discord.ui.View()),
+    )
+
+    monkeypatch.setattr(help_cog, "_cog_for_subsystem", lambda _bot, _key: fake_cog)
+    embed, view = await help_cog._open_route(
+        route,
+        opener,
+        visible_subsystems={"diagnostic"},
+        member_tier="administrator",
+    )
+    fake_cog.build_platform_help_menu_view.assert_awaited_once()
+    fake_cog.build_help_menu_view.assert_not_called()
+    assert embed.title == "Platform hub"
+    assert view is fake_view
+
+
+@pytest.mark.asyncio
+async def test_help_diagnostic_singular_opens_platform_hub(monkeypatch):
+    """The singular hub key ``diagnostic`` is the Platform / Diagnostics
+    hub. ``!help diagnostic`` routes the same as ``!help platform``.
+    """
+    opener = _opener()
+    route = help_cog._resolve_route("diagnostic", bot=opener.client)
+    assert route.kind == "hub"
+    assert route.target == "diagnostic"
+
+    fake_view = discord.ui.View()
+    fake_embed = discord.Embed(title="Platform hub")
+    fake_cog = MagicMock()
+    fake_cog.build_platform_help_menu_view = AsyncMock(
+        return_value=(fake_embed, fake_view),
+    )
+
+    monkeypatch.setattr(help_cog, "_cog_for_subsystem", lambda _bot, _key: fake_cog)
+    embed, view = await help_cog._open_route(
+        route,
+        opener,
+        visible_subsystems={"diagnostic"},
+        member_tier="administrator",
+    )
+    fake_cog.build_platform_help_menu_view.assert_awaited_once()
+    assert embed.title == "Platform hub"
+
+
+@pytest.mark.asyncio
+async def test_help_diagnostics_plural_opens_diagnostics_hub(monkeypatch):
+    """``!help diagnostics`` / ``!help diag`` open the Diagnostics Hub
+    via the generic ``build_help_menu_view`` hook — not the Platform Hub
+    builder. This is the canary against any future change that merges
+    the two hooks.
+    """
+    opener = _opener()
+    route = help_cog._resolve_route("diagnostics", bot=opener.client)
+    assert route.kind == "subsystem"
+    assert route.target == "diagnostic"
+
+    fake_view = discord.ui.View()
+    fake_embed = discord.Embed(title="Diagnostics Hub")
+    fake_cog = MagicMock()
+    fake_cog.build_help_menu_view = AsyncMock(return_value=(fake_embed, fake_view))
+    fake_cog.build_platform_help_menu_view = AsyncMock(
+        return_value=(discord.Embed(title="WRONG"), discord.ui.View()),
+    )
+
+    monkeypatch.setattr(help_cog, "_cog_for_subsystem", lambda _bot, _key: fake_cog)
+    embed, view = await help_cog._open_route(
+        route,
+        opener,
+        visible_subsystems={"diagnostic"},
+        member_tier="administrator",
+    )
+    fake_cog.build_help_menu_view.assert_awaited_once()
+    fake_cog.build_platform_help_menu_view.assert_not_called()
+    assert embed.title == "Diagnostics Hub"
+
+
+# ---------------------------------------------------------------------------
+# Subsystem routes — open panel hooks, not command-list fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_help_blackjack_opens_blackjack_panel(monkeypatch):
+    """``!help blackjack`` must open the Blackjack panel via the cog's
+    ``build_help_menu_view`` hook, not the command-list fallback.
+    """
+    opener = _opener()
+    route = help_cog._resolve_route("blackjack", bot=opener.client)
+    assert route.kind == "subsystem"
+    assert route.target == "blackjack"
+
+    fake_view = discord.ui.View()
+    fake_embed = discord.Embed(title="Blackjack")
+    fake_cog = MagicMock()
+    fake_cog.build_help_menu_view = AsyncMock(return_value=(fake_embed, fake_view))
+
+    monkeypatch.setattr(help_cog, "_cog_for_subsystem", lambda _bot, _key: fake_cog)
+    embed, view = await help_cog._open_route(
+        route,
+        opener,
+        visible_subsystems={"blackjack"},
+        member_tier="user",
+    )
+    fake_cog.build_help_menu_view.assert_awaited_once()
+    assert embed is fake_embed
+    assert view is fake_view
+
+
+@pytest.mark.asyncio
+async def test_subsystem_route_falls_back_to_command_list_on_hook_failure(monkeypatch):
+    """If a cog's ``build_help_menu_view`` raises, the resolver must
+    fall back to the command-list embed rather than crashing.
+    """
+    opener = _opener()
+    route = help_cog._resolve_route("blackjack", bot=opener.client)
+
+    fake_cog = MagicMock()
+    fake_cog.build_help_menu_view = AsyncMock(side_effect=RuntimeError("boom"))
+    fake_cog.qualified_name = "BlackjackCog"
+    fake_cog.get_commands = MagicMock(return_value=[])
+
+    monkeypatch.setattr(help_cog, "_cog_for_subsystem", lambda _bot, _key: fake_cog)
+    embed, view = await help_cog._open_route(
+        route,
+        opener,
+        visible_subsystems={"blackjack"},
+        member_tier="user",
+    )
+    assert view is None  # command-list fallback is embed-only
+    assert isinstance(embed, discord.Embed)
+
+
+# ---------------------------------------------------------------------------
+# Advanced route — opens HelpPanelView
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_help_advanced_opens_help_panel_view():
+    """``!help advanced`` opens the paginated HelpPanelView."""
+    opener = _opener()
+    route = help_cog._resolve_route("advanced", bot=opener.client)
+    assert route.kind == "advanced"
+
+    embed, view = await help_cog._open_route(
+        route,
+        opener,
+        visible_subsystems={"games", "economy"},
+        member_tier="user",
+    )
+    assert isinstance(view, help_cog.HelpPanelView)
+    assert isinstance(embed, discord.Embed)
+
+
+# ---------------------------------------------------------------------------
+# Command route — single-command embed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_help_command_name_returns_single_command_embed():
+    """``!help <command>`` returns the single-command help embed."""
+    opener = _opener()
+    fake_cmd = MagicMock()
+    fake_cmd.name = "daily"
+    fake_cmd.aliases = []
+    fake_cmd.signature = ""
+    fake_cmd.help = "Claim your daily reward."
+    opener.client.get_command = MagicMock(return_value=fake_cmd)
+
+    route = help_cog._resolve_route("daily", bot=opener.client)
+    assert route.kind == "command"
+
+    embed, view = await help_cog._open_route(
+        route,
+        opener,
+        visible_subsystems=set(),
+        member_tier="user",
+    )
+    assert view is None
+    assert "daily" in (embed.title or "")
+
+
+# ---------------------------------------------------------------------------
+# Unknown route — not-found fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_name_returns_not_found_embed():
+    opener = _opener()
+    opener.client.get_command = MagicMock(return_value=None)
+    route = help_cog._resolve_route("not-a-real-thing", bot=opener.client)
+    assert route.kind == "unknown"
+
+    embed, view = await help_cog._open_route(
+        route,
+        opener,
+        visible_subsystems=set(),
+        member_tier="user",
+    )
+    assert view is None
+    assert "not-a-real-thing" in (embed.description or "")

--- a/tests/unit/help/test_platform_diagnostics_split.py
+++ b/tests/unit/help/test_platform_diagnostics_split.py
@@ -1,0 +1,97 @@
+"""Regression canary for the Platform/Diagnostics hook split.
+
+Pins all four invariants in one file so any future change that tries
+to collapse the two hooks back into one trips a single, named test:
+
+1. ``DiagnosticCog.build_help_menu_view(opener)`` returns
+   ``_DiagnosticsHubView``.
+2. ``DiagnosticCog.build_platform_help_menu_view(opener)`` returns
+   ``_PlatformHubView``.
+3. Help route ``platform`` opens ``_PlatformHubView``.
+4. Help route ``diagnostics`` opens ``_DiagnosticsHubView``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from cogs import help_cog
+from cogs.diagnostic_cog import DiagnosticCog
+from views.diagnostic import _DiagnosticsHubView, _PlatformHubView
+
+
+def _interaction() -> MagicMock:
+    interaction = MagicMock()
+    user = MagicMock()
+    user.id = 1
+    interaction.user = user
+    interaction.guild = None
+    interaction.guild_id = None
+    interaction.client = MagicMock()
+    interaction.channel = MagicMock()
+    return interaction
+
+
+def _opener() -> help_cog.HelpOpener:
+    user = MagicMock()
+    user.id = 1
+    return help_cog.HelpOpener(
+        user=user,
+        guild=None,
+        guild_id=None,
+        client=MagicMock(),
+        channel=MagicMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_help_menu_view_returns_diagnostics_hub():
+    """Invariant #1: the generic hook stays pointed at Diagnostics so
+    Admin → Diagnostics keeps working.
+    """
+    cog = DiagnosticCog(bot=MagicMock())
+    interaction = _interaction()
+    _embed, view = await cog.build_help_menu_view(interaction)
+    assert isinstance(view, _DiagnosticsHubView)
+
+
+@pytest.mark.asyncio
+async def test_build_platform_help_menu_view_returns_platform_hub():
+    """Invariant #2: the new sibling hook returns the Platform Hub."""
+    cog = DiagnosticCog(bot=MagicMock())
+    interaction = _interaction()
+    _embed, view = await cog.build_platform_help_menu_view(interaction)
+    assert isinstance(view, _PlatformHubView)
+
+
+def test_help_routes_platform_to_diagnostic_hub_key():
+    """Invariant #3 (resolver half): the ``platform`` alias must
+    resolve to the ``diagnostic`` hub key. ``_open_route`` then uses
+    the ``_HUB_PANEL_BUILDERS`` override to call the platform builder.
+    """
+    route = help_cog._resolve_route("platform", bot=MagicMock())
+    assert route.kind == "hub"
+    assert route.target == "diagnostic"
+    # Override table must point at the Platform builder, not the
+    # generic ``build_help_menu_view`` hook.
+    assert help_cog._HUB_PANEL_BUILDERS["diagnostic"] == "build_platform_help_menu_view"
+
+
+def test_help_routes_diagnostics_to_diagnostic_subsystem():
+    """Invariant #4 (resolver half): the ``diagnostics`` alias must
+    resolve to the ``diagnostic`` subsystem so it opens via
+    ``build_help_menu_view`` (Diagnostics Hub), not the Platform Hub
+    builder.
+    """
+    route = help_cog._resolve_route("diagnostics", bot=MagicMock())
+    assert route.kind == "subsystem"
+    assert route.target == "diagnostic"
+
+
+def test_help_routes_diag_short_alias_to_diagnostic_subsystem():
+    """The short ``diag`` alias mirrors the ``diagnostics`` route."""
+    route = help_cog._resolve_route("diag", bot=MagicMock())
+    assert route.kind == "subsystem"
+    assert route.target == "diagnostic"


### PR DESCRIPTION
## Summary

- Single resolver/opener (`cogs/help/route.py`) now shared by typed `!help <name>` and the Help dropdown — the same name produces the same surface from either entry point.
- New `DiagnosticCog.build_platform_help_menu_view` returns Platform Hub. The generic `build_help_menu_view` stays pointed at Diagnostics, so Admin → Diagnostics and `!help diagnostics` / `!help diag` keep working. A `_HUB_PANEL_BUILDERS` override table in `help_cog.py` is the only place that knows the Platform/Diagnostics split.
- Help Home embed simplified: every hub row is a uniform two-line shape (purpose + typed entry command), no `Includes:` line, no internal metadata terms.
- New `docs/help-command-surface-map.md` inventories every cog/subsystem with ownership, panel, current Help/hub route, and recommended placement.
- Plan's optional Step 8 docs included: `config-input-standard.md` (nine input strategies) and `admin-powers-config-coverage.md` (pipeline-ownership map).

### Critical invariant pinned

```
DiagnosticCog.build_help_menu_view()           -> _DiagnosticsHubView   (UNCHANGED)
DiagnosticCog.build_platform_help_menu_view()  -> _PlatformHubView      (NEW)
```

A dedicated regression test (`tests/unit/help/test_platform_diagnostics_split.py`) pins all four invariants in one canary file: generic hook returns Diagnostics, platform hook returns Platform, `!help platform` opens Platform, `!help diagnostics` opens Diagnostics.

### Out of scope (explicitly not in this PR)

- Slash commands / setup wizard / hub-v2 redesigns / direct-write remediation.
- `disbot/cogs/admin_cog.py` is untouched — source verification confirmed both Admin → Platform and Admin → Diagnostics buttons remain correct.
- `disbot/utils/hub_registry.py` and `disbot/utils/subsystem_registry.py` are untouched.

## Test plan

- [x] `pytest tests/ -q` — 2332 passed
- [x] `pytest tests/unit/help/ tests/unit/views/test_platform_hub_view.py tests/unit/docs/ -q` — 301 passed (43 new in `test_help_route_resolution.py` alone)
- [x] `ruff check disbot/` — all checks passed
- [x] `mypy disbot/cogs/help_cog.py disbot/cogs/help/route.py disbot/cogs/diagnostic_cog.py` — no issues
- [x] Cog size invariant: `help_cog.py` is 669 LOC (under the 800 hard ceiling)

### Manual smoke (for reviewer)

```
!help
dropdown → Games
dropdown → Platform / Diagnostics
!help games
!help economy
!help moderation
!help community
!help utility
!help admin
!help settings
!help platform           → Platform Hub
!help diagnostic         → Platform Hub
!help diagnostics        → Diagnostics Hub
!help diag               → Diagnostics Hub
!help blackjack          → Blackjack panel
!help mining             → Mining hub
!help inventory          → Inventory panel
!help advanced
!platform                → unchanged
!diagnostics             → unchanged
```

Expected:
- Help Home is uniform and concise; no `Includes:` lines.
- Typed Help and dropdown Help routes match for every hub.
- Platform and Diagnostics are separate but related.
- Subsystems with `build_help_menu_view` open panels rather than command-list embeds.
- Admin → Platform and Admin → Diagnostics buttons still work.

## Rollback

`git revert <merge_sha>`. No DB migration, no schema change, no persistent data change. Behavioral changes are: typed Help route resolution, Help Home copy, and the new Platform-specific Help hook. `DiagnosticCog.build_help_menu_view` remains Diagnostics.

https://claude.ai/code/session_019he5bvbd95NuYmpbUkVfJh

---
_Generated by [Claude Code](https://claude.ai/code/session_019he5bvbd95NuYmpbUkVfJh)_