### PR TITLE
registry: add parent_hub metadata for S7-S10 children

### DIFF
--- a/disbot/utils/hub_registry.py
+++ b/disbot/utils/hub_registry.py
@@ -112,13 +112,15 @@ HUBS: tuple[HubEntry, ...] = (
         emoji="💰",
         purpose="Currency, items, work, shop, and standings.",
         entry_command="!economymenu",
-        # S7 v1 leaves primary_children empty. Inventory and Leaderboard
-        # remain top-level for now; a follow-up promotes them to
-        # parent_hub of "economy" once the hub view adds explicit child
-        # navigation. Mining stays under Games — the cross-link button
-        # ships alongside that promotion.
-        primary_children=(),
-        cross_link_children=(),
+        # PR #3 promotes Inventory and Leaderboard to parent_hub of
+        # "economy" (their primary placement). Mining stays under
+        # Games — Economy declares it as a cross-link so the Economy
+        # hub view can surface it without changing Mining's metadata.
+        primary_children=(
+            "inventory",
+            "leaderboard",
+        ),
+        cross_link_children=("mining",),
         minimum_tier="user",
     ),
     HubEntry(
@@ -127,12 +129,14 @@ HUBS: tuple[HubEntry, ...] = (
         emoji="🛡️",
         purpose="Warnings, timeouts, bans, cleanup, audit logs.",
         entry_command="!modmenu",
-        # S8 v1: routes to moderation_cog's existing build_help_menu_view
-        # which returns the ModPanelView. Cleanup and Logging are
-        # candidates for parent_hub of "moderation" in a follow-up once
-        # the hub view adds explicit child navigation across the three
-        # subsystems.
-        primary_children=(),
+        # PR #3 promotes Cleanup, Logging, and Proof Channel to
+        # parent_hub of "moderation" so they hide from the Help Home
+        # top-level overview and surface under this hub instead.
+        primary_children=(
+            "cleanup",
+            "logging",
+            "proof_channel",
+        ),
         cross_link_children=(),
         minimum_tier="moderator",
     ),
@@ -142,12 +146,15 @@ HUBS: tuple[HubEntry, ...] = (
         emoji="🌱",
         purpose="Progression, roles, and community activities.",
         entry_command="!community",
-        # S9: XP and Role are primary children but stay top-level for
-        # now (parent_hub metadata not flipped yet). The Community hub
-        # view in views/community/hub.py has explicit cross-link
-        # buttons to xp/role/counting/chain/leaderboard — no Help
-        # auto-discovery, no metadata changes to those subsystems.
-        primary_children=(),
+        # PR #3 promotes XP and Role to parent_hub of "community"
+        # (their primary placement). Counting, Chain (Games children)
+        # and Leaderboard (Economy child) remain cross-links via the
+        # Community hub view's hardcoded ``_HUB_CHILDREN`` tuple; PR #4
+        # migrates the view to discover them from this declaration.
+        primary_children=(
+            "xp",
+            "role",
+        ),
         cross_link_children=(),
         minimum_tier="user",
     ),
@@ -157,11 +164,10 @@ HUBS: tuple[HubEntry, ...] = (
         emoji="🧰",
         purpose="Info, tools, and discovery commands.",
         entry_command="!utilitymenu",
-        # S10 v1: routes to the existing utility hub panel. General
-        # and Help remain top-level for now; a follow-up promotes
-        # general to parent_hub of "utility" once the hub view adds
-        # explicit child navigation.
-        primary_children=(),
+        # PR #3 promotes General to parent_hub of "utility". Help
+        # itself stays top-level — it IS the Help surface so it never
+        # surfaces under any hub.
+        primary_children=("general",),
         cross_link_children=(),
         minimum_tier="user",
     ),

--- a/disbot/utils/subsystem_registry.py
+++ b/disbot/utils/subsystem_registry.py
@@ -149,6 +149,7 @@ SUBSYSTEMS: dict[str, dict] = {
         "supports_dm": False,
         "has_cleanup_rules": False,
         "ui_priority": 15,
+        "parent_hub": "economy",
         "capabilities": [
             "inventory.item.view",
             "inventory.item.use",
@@ -196,6 +197,7 @@ SUBSYSTEMS: dict[str, dict] = {
         "supports_dm": False,
         "has_cleanup_rules": False,
         "ui_priority": 25,
+        "parent_hub": "community",
         "capabilities": [
             "xp.rank.view",
             "xp.leaderboard.view",
@@ -219,6 +221,7 @@ SUBSYSTEMS: dict[str, dict] = {
         "supports_dm": False,
         "has_cleanup_rules": True,
         "ui_priority": 70,
+        "parent_hub": "community",
         "capabilities": [
             "role.threshold.configure",
             "role.assignment.manage",
@@ -267,6 +270,7 @@ SUBSYSTEMS: dict[str, dict] = {
         "supports_dm": False,
         "has_cleanup_rules": False,
         "ui_priority": 72,
+        "parent_hub": "moderation",
         "capabilities": [
             "cleanup.word.add",
             "cleanup.word.remove",
@@ -459,6 +463,7 @@ SUBSYSTEMS: dict[str, dict] = {
         "supports_dm": False,
         "has_cleanup_rules": False,
         "ui_priority": 40,
+        "parent_hub": "economy",
         "capabilities": [
             "leaderboard.xp.view",
             "leaderboard.economy.view",
@@ -481,6 +486,7 @@ SUBSYSTEMS: dict[str, dict] = {
         "supports_dm": False,
         "has_cleanup_rules": False,
         "ui_priority": 65,
+        "parent_hub": "moderation",
         "capabilities": [
             "proof_channel.access.grant",
             "proof_channel.access.revoke",
@@ -527,6 +533,7 @@ SUBSYSTEMS: dict[str, dict] = {
         "supports_dm": False,
         "has_cleanup_rules": False,
         "ui_priority": 3,
+        "parent_hub": "utility",
         "capabilities": [
             "general.info.view",
             "general.community.interact",
@@ -619,6 +626,7 @@ SUBSYSTEMS: dict[str, dict] = {
         "supports_dm": False,
         "has_cleanup_rules": False,
         "ui_priority": 85,
+        "parent_hub": "moderation",
         "capabilities": [
             "logging.settings.configure",
             "logging.channel.bind",

--- a/docs/help-command-surface-map.md
+++ b/docs/help-command-surface-map.md
@@ -55,26 +55,26 @@ or raises.
 | `blackjack` | `blackjack_cog.py:95` | `blackjack`, `bj`, `bjtournament`, `bjstart`, `bjstatus` | — | `BlackjackPanelView` | `!help blackjack` → opens Blackjack panel (shared resolver) | reached via Games | hub child (Games) |
 | `chain` | `chain_cog.py` | `chain`, `chainmenu` | — | `ChainPanelView` | `!help chain` → opens Chain panel (shared resolver) | reached via Games / Community | hub child |
 | `channel` | `channel_cog.py:144` | `lock`, `unlock` | several `*_channel`-family commands | `ChannelPanelView` | `!help channel` → opens Channel panel (shared resolver) | reached via Admin | hub child (Admin) |
-| `cleanup` | `cleanup_cog.py:324` | `cleanuphistory`, `word`, `wordmenu`, `cleanup` | — | `CleanupHubView` | `!help cleanup` → opens Cleanup panel (shared resolver) | reached via Moderation | hub child (Moderation) |
+| `cleanup` | `cleanup_cog.py:324` | `cleanuphistory`, `word`, `wordmenu`, `cleanup` | — | `CleanupHubView` | `!help cleanup` → opens Cleanup panel (shared resolver) | reached via Moderation; `parent_hub="moderation"` since PR #3 | hub child (Moderation) — declared |
 | `community` | `community_cog.py` | `community` | — | `CommunityHubView` | `!help community` → opens Community panel (shared resolver) | dropdown Community → panel | hub top-level |
 | `counting` | `counting_cog.py` | `countingmenu`, `start_match`, `end_match`, `reset_count` | — | `CountingPanelView` | `!help counting` → opens Counting panel (shared resolver) | reached via Games / Community | hub child |
 | `deathmatch` | `deathmatch_cog.py` | `dm_challenge`, `deathmatch`, `dm`, `dm_help` | — | `DeathmatchPanelView` | `!help deathmatch` → opens Deathmatch panel (shared resolver) | reached via Games | hub child (Games) |
 | `diagnostic` | `diagnostic_cog.py:70` | `diagnostics`, `diag`, `latency`, `platform` (group, 20+ subcommands) | — | `_DiagnosticsHubView` (generic hook); `_PlatformHubView` (platform builder) | `!help platform` / `!help diagnostic` → opens Platform Hub via the `HUB_PANEL_BUILDERS["diagnostic"]` override; `!help diagnostics` / `!help diag` → opens Diagnostics subsystem via the subsystem-alias branch (not the Platform hub) | hub top-level "Platform / Diagnostics" via the override; sibling subsystem aliases reach Diagnostics | hub top-level (Platform); `diagnostics`/`diag` open Diagnostics Hub |
 | `economy` | `economy_cog.py` | `economymenu`, `daily`, `work`, `shop`, `balance`/`bal`/`wallet` | several admin/legacy commands | `EconomyPanelView` | `!help economy` → opens Economy panel (shared resolver) | dropdown Economy → panel | hub top-level |
 | `games` | `games_cog.py` | `games` | — | `GamesHubView` | `!help games` → opens Games hub (shared resolver) | dropdown Games → panel | hub top-level (cleanest model) |
-| `general` | `general_cog.py` | `fact`, `joke`, `quote`, `motivate`, `greet` | — | `_GeneralPanelView` | `!help general` → opens General panel (shared resolver) | reached via Utility (future, once `parent_hub` is set) | hub child (Utility, future) |
+| `general` | `general_cog.py` | `fact`, `joke`, `quote`, `motivate`, `greet` | — | `_GeneralPanelView` | `!help general` → opens General panel (shared resolver) | reached via Utility (`parent_hub="utility"` since PR #3) | hub child (Utility) — declared |
 | `help` | `help_cog.py` | `help` (alias `hilfe`) | — | **no panel hook (Help itself is the panel)** | n/a (Help Home embeds + `HelpCategoryView` dropdown) | dropdown root | Help Home |
-| `inventory` | `inventory_cog.py:376` | `inventory`, `inv` | — | `UnifiedInventoryView` | `!help inventory` → opens Inventory panel (shared resolver) | reached via Economy (Inventory btn → in-place edit + Back-to-Economy; PR #143) | hub child (Economy, future) |
-| `leaderboard` | `leaderboard_cog.py:200` | (none public-flagged; entry inferred from registry) | — | `LeaderboardView` | `!help leaderboard` → opens Leaderboard panel (shared resolver) | top-level today; cross-linked from Economy / Community (future) | hub child (Economy / Community) |
-| `logging` | `logging_cog.py:88` | `logging` | — | `LoggingPanelView` | `!help logging` → opens Logging panel (shared resolver) | reached via Moderation / Admin | hub child |
-| `mining` | `mining_cog.py:65` | `mineinv`/`mineinventory`, `minestats` | mining game flow commands (start/dig/etc.) | `MiningHubView` | `!help mining` → opens Mining panel (shared resolver) | reached via Games (primary) / Economy cross-link | hub child (Games) |
+| `inventory` | `inventory_cog.py:376` | `inventory`, `inv` | — | `UnifiedInventoryView` | `!help inventory` → opens Inventory panel (shared resolver) | reached via Economy (Inventory btn → in-place edit + Back-to-Economy; PR #143). `parent_hub="economy"` since PR #3. | hub child (Economy) — declared |
+| `leaderboard` | `leaderboard_cog.py:200` | (none public-flagged; entry inferred from registry) | — | `LeaderboardView` | `!help leaderboard` → opens Leaderboard panel (shared resolver) | `parent_hub="economy"` since PR #3; Community cross-link migrates in PR #4 | hub child (Economy) — declared; Community cross-link in PR #4 |
+| `logging` | `logging_cog.py:88` | `logging` | — | `LoggingPanelView` | `!help logging` → opens Logging panel (shared resolver) | reached via Moderation / Admin; `parent_hub="moderation"` since PR #3 | hub child (Moderation) — declared |
+| `mining` | `mining_cog.py:65` | `mineinv`/`mineinventory`, `minestats` | mining game flow commands (start/dig/etc.) | `MiningHubView` | `!help mining` → opens Mining panel (shared resolver) | reached via Games (primary, `parent_hub="games"`); Economy hub declares Mining as a `cross_link_children` since PR #3 | hub child (Games); Economy cross-link |
 | `moderation` | `moderation_cog.py` | `modmenu`, `warn`, `timeout`, `kick`, `ban`, `unban`, `clearwarnings`, `modlogs` | — | `ModPanelView` | `!help moderation` → opens Moderation panel (shared resolver) | dropdown Moderation → panel | hub top-level |
-| `proof_channel` | `proof_channel_cog.py:113` | `prizestatus`, `prizemenu`, `timedprize` | — | `_PrizeManagerView` | `!help proof` → opens Proof Channel panel (shared resolver) | reached via Moderation | hub child (Moderation) |
-| `role` | `role_cog.py:334` | `roles`, `rolesettings`, `rolemenu` (legacy alias) | 8+ legacy commands: `rolecreator`, `createrole`, `deleterole`, `setrole`, `unsetrole`, `assignroles`, `debugroles`, `refreshmembers`, plus react-role family | `RoleHubPanelView` | `!help roles` → opens Role panel (shared resolver) | reached via Community | hub child (Community); legacy commands remain as hidden compatibility |
+| `proof_channel` | `proof_channel_cog.py:113` | `prizestatus`, `prizemenu`, `timedprize` | — | `_PrizeManagerView` | `!help proof` → opens Proof Channel panel (shared resolver) | reached via Moderation; `parent_hub="moderation"` since PR #3 | hub child (Moderation) — declared |
+| `role` | `role_cog.py:334` | `roles`, `rolesettings`, `rolemenu` (legacy alias) | 8+ legacy commands: `rolecreator`, `createrole`, `deleterole`, `setrole`, `unsetrole`, `assignroles`, `debugroles`, `refreshmembers`, plus react-role family | `RoleHubPanelView` | `!help roles` → opens Role panel (shared resolver) | reached via Community; `parent_hub="community"` since PR #3 | hub child (Community) — declared; legacy commands remain as hidden compatibility |
 | `rps_tournament` | `rps_tournament_cog.py:118` | `rpsregister`/`rpsreg`, `rpsstart`/`rpsbegin`, `rpsbot`, `rpsmatchup`, `rpshelp`, `rpssettings` | — | `RPSPanelView` | `!help rps` → opens RPS panel (shared resolver) | reached via Games | hub child (Games) |
 | `settings` | `settings_cog.py` | (entry via `!settings`) | — | `SettingsHubView` | `!help settings` → opens Settings panel (shared resolver) | dropdown Settings → panel | hub top-level |
 | `utility` | `utility_cog.py` | `utilitymenu`, `clear`/`purge`, `info`, `serverinfo`, `userinfo`, `avatar`, `remind` | — | `_UtilityPanelView` | `!help utility` → opens Utility panel (shared resolver) | dropdown Utility → panel | hub top-level |
-| `xp` | `xp_cog.py` | `xpmenu`, `rank`, `givexp`, `resetxp`, `xpconfig` | — | `_XpHubView` | `!help xp` → opens XP panel (shared resolver) | reached via Community | hub child (Community); admin controls live in panel |
+| `xp` | `xp_cog.py` | `xpmenu`, `rank`, `givexp`, `resetxp`, `xpconfig` | — | `_XpHubView` | `!help xp` → opens XP panel (shared resolver) | reached via Community; `parent_hub="community"` since PR #3 | hub child (Community) — declared; admin controls live in panel |
 
 ## 3. Known inconsistencies (resolved by PR #142 / PR #143)
 
@@ -129,11 +129,15 @@ routing issues. See `tests/unit/views/test_economy_inventory_edit.py`,
   via `parent_hub`, has all six game children explicitly listed, and
   the hub UI is built from a single source.
 - **S7–S10 Help promotions (Economy / Moderation / Community / Utility)
-  are first-pass.** Their hubs route to existing panels via
-  `build_help_menu_view`. Their `primary_children` are empty until a
-  follow-up PR flips `parent_hub` metadata on `inventory`, `leaderboard`,
-  `xp`, `role`, `cleanup`, `logging`, `proof_channel`, and `general` —
-  tracked as plan PR #3.
+  have declared parent_hub metadata for their children since PR #3.**
+  `inventory` and `leaderboard` point at Economy; `xp` and `role` point
+  at Community; `cleanup`, `logging`, and `proof_channel` point at
+  Moderation; `general` points at Utility. Each parent hub's
+  `primary_children` tuple in `hub_registry.py` mirrors that set. The
+  hub views still render children via their own discovery — Games uses
+  `discover_game_children()` from SUBSYSTEMS; Community uses a
+  hardcoded `_HUB_CHILDREN` tuple that PR #4 will migrate to
+  registry-driven discovery.
 - **Role public entry is `!roles`.** Legacy `rolemenu` and the
   rolemenu-style command family remain registered as hidden
   compatibility — they will not surface in Help.
@@ -166,15 +170,17 @@ Tracked as the stabilization-plan PR sequence
 here so a future reader can map this doc to the in-flight plan.
 
 - **`parent_hub` metadata for S7–S10 children** (plan PR #3) —
-  declare `parent_hub` on `inventory → economy`, `leaderboard →
-  economy`, `xp → community`, `role → community`, `cleanup →
-  moderation`, `logging → moderation`, `proof_channel → moderation`,
-  `general → utility`. After it lands, the *Recommendation* column
-  below the corresponding rows changes from "hub child (... future)"
-  to "hub child (...) — declared".
+  **done.** `parent_hub` declared on `inventory → economy`,
+  `leaderboard → economy`, `xp → community`, `role → community`,
+  `cleanup → moderation`, `logging → moderation`,
+  `proof_channel → moderation`, `general → utility`. The eight rows
+  above now read "hub child (...) — declared". Mining is additionally
+  declared as a `cross_link_children` on the Economy hub.
 - **Community metadata-driven hub** (plan PR #4) — replace
   `CommunityHubView._HUB_CHILDREN` hardcoded tuple with SUBSYSTEMS
   discovery, mirroring `views/games/hub.py:discover_game_children`.
+  After PR #3 the metadata exists; the migration is a view-only
+  change.
 - **XP config modal pipeline migration** (plan PR #5) — three modals
   in `disbot/views/xp/modals.py` write directly via `db.set_setting`;
   migrate to `SettingsMutationPipeline`.

--- a/tests/unit/help/test_help_parent_hub_filter.py
+++ b/tests/unit/help/test_help_parent_hub_filter.py
@@ -31,10 +31,18 @@ from utils.subsystem_registry import SUBSYSTEMS
 
 
 def _hub_children() -> list[str]:
+    """Subsystems with any ``parent_hub`` set.
+
+    Pre-PR-#3 this was only games children (6 entries). PR #3 added
+    parent_hub on inventory, leaderboard, xp, role, cleanup, logging,
+    proof_channel, and general — so this filter now expands to cover
+    every subsystem expected to be hidden from the top-level overview.
+    The existing per-test loops naturally extend to the larger set.
+    """
     return [
         name
         for name, meta in SUBSYSTEMS.items()
-        if meta.get("parent_hub") == "games"
+        if meta.get("parent_hub")
     ]
 
 
@@ -60,9 +68,14 @@ async def test_build_overview_embed_excludes_parent_hub_children():
     )
 
     rendered = "\n".join(field.value for field in embed.fields)
+    # build_overview_embed renders each entry as
+    # ``{emoji} **{display_name}** — {desc}`` (help_cog.py:118). Match
+    # the bolded form so substring collisions in descriptions (e.g.
+    # "General" appearing inside "General utility commands") don't
+    # false-positive against a hub child's display_name.
     for child in _hub_children():
         display = SUBSYSTEMS[child]["display_name"]
-        assert display not in rendered, (
+        assert f"**{display}**" not in rendered, (
             f"hub child {child!r} ({display!r}) leaked into overview embed"
         )
 
@@ -99,9 +112,11 @@ def test_build_page_embed_excludes_parent_hub_children():
         member_tier="owner",
     )
     rendered = "\n".join(field.value for field in embed.fields)
+    # Match the bolded display form so descriptions can't collide with
+    # a hub child's display_name (see overview test above).
     for child in _hub_children():
         display = SUBSYSTEMS[child]["display_name"]
-        assert display not in rendered, (
+        assert f"**{display}**" not in rendered, (
             f"hub child {child!r} leaked into page-embed render"
         )
 
@@ -289,3 +304,90 @@ def test_typed_help_route_for_hub_child_resolves_to_subsystem():
     route = help_cog._resolve_route("mining", bot=bot)
     assert route.kind == "subsystem"
     assert route.target == "mining"
+
+
+# ---------------------------------------------------------------------------
+# PR #3 — new parent_hub assignments for S7-S10 children
+# ---------------------------------------------------------------------------
+
+
+def test_pr3_metadata_assignments_present():
+    """Pin the exact 8 parent_hub assignments PR #3 declares so future
+    metadata edits cannot silently break the Help filter or the hub
+    panel discovery contracts.
+    """
+    expected = {
+        "inventory": "economy",
+        "leaderboard": "economy",
+        "xp": "community",
+        "role": "community",
+        "cleanup": "moderation",
+        "logging": "moderation",
+        "proof_channel": "moderation",
+        "general": "utility",
+    }
+    for child, parent in expected.items():
+        actual = SUBSYSTEMS[child].get("parent_hub")
+        assert actual == parent, (
+            f"SUBSYSTEMS[{child!r}].parent_hub: expected {parent!r}, got {actual!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_pr3_new_children_hidden_from_overview():
+    """Every subsystem promoted in PR #3 must not appear in the
+    top-level Help overview (the Phase 4 filter is parent_hub-driven).
+    """
+    bot = MagicMock()
+    ctx = MagicMock()
+    embed = await help_cog.build_overview_embed(
+        bot,
+        ctx,
+        visible=_all_visible_set(),
+        member_tier="owner",
+    )
+    rendered = "\n".join(field.value for field in embed.fields)
+
+    pr3_children = {
+        "inventory",
+        "leaderboard",
+        "xp",
+        "role",
+        "cleanup",
+        "logging",
+        "proof_channel",
+        "general",
+    }
+    # Match the bolded display form to avoid substring collisions
+    # (e.g. "General" appearing in Utility's description).
+    for child in pr3_children:
+        display = SUBSYSTEMS[child]["display_name"]
+        assert f"**{display}**" not in rendered, (
+            f"PR #3 child {child!r} ({display!r}) leaked into overview embed — "
+            f"parent_hub filter is broken"
+        )
+
+
+def test_pr3_typed_routes_still_resolve_to_subsystem():
+    """Typed ``!help <child>`` for each PR #3 child must still resolve
+    to its subsystem so the panel opens. The filter hides them from the
+    OVERVIEW, not from direct lookup.
+    """
+    from unittest.mock import MagicMock
+
+    bot = MagicMock()
+    bot.get_command = MagicMock(return_value=None)
+
+    for name in (
+        "inventory",
+        "leaderboard",
+        "xp",
+        "role",
+        "cleanup",
+        "logging",
+        "proof_channel",
+        "general",
+    ):
+        route = help_cog._resolve_route(name, bot=bot)
+        assert route.kind == "subsystem", f"{name!r} resolved as {route.kind!r}"
+        assert route.target == name, f"{name!r} resolved to target {route.target!r}"

--- a/tests/unit/utils/test_hub_registry.py
+++ b/tests/unit/utils/test_hub_registry.py
@@ -66,64 +66,64 @@ def test_committed_hub_set_matches_promoted_hubs():
 
 
 def test_utility_hub_uses_existing_panel():
-    """S10 v1: the Utility hub routes to the existing utility_cog
-    build_help_menu_view (UtilityHubView). General and Help remain
-    top-level for now; promotion to parent_hub="utility" lands when
-    the hub view gains explicit child navigation.
+    """Post-PR-#3: the Utility hub routes to the existing utility_cog
+    ``build_help_menu_view`` (UtilityHubView). ``general`` is now its
+    primary child via ``parent_hub="utility"``; ``help`` itself stays
+    top-level — it IS the Help surface.
     """
     utility = get_hub("utility")
     assert utility is not None
     assert utility.entry_command == "!utilitymenu"
     assert utility.minimum_tier == "user"
-    assert utility.primary_children == ()
+    assert utility.primary_children == ("general",)
     assert utility.cross_link_children == ()
     assert utility.panel_available is True
 
 
 def test_community_hub_uses_new_cog():
-    """S9: the Community hub gets a brand-new ``community_cog`` because
-    no existing domain cog naturally owns the union of XP + Roles +
-    Counting + Chain + Leaderboard. The cog is nav-only; cross-link
-    buttons forward to the host cogs' existing build_help_menu_view.
+    """Post-PR-#3: the Community hub's ``community_cog`` is nav-only.
+    ``xp`` and ``role`` are now primary children via ``parent_hub=
+    "community"``. Counting, Chain (Games children) and Leaderboard
+    (Economy child) remain cross-links via the Community hub view's
+    hardcoded ``_HUB_CHILDREN`` tuple until PR #4 migrates the view
+    to discover them from registry.
     """
     community = get_hub("community")
     assert community is not None
     assert community.entry_command == "!community"
     assert community.minimum_tier == "user"
-    assert community.primary_children == ()
+    assert community.primary_children == ("xp", "role")
     assert community.cross_link_children == ()
     assert community.panel_available is True
 
 
 def test_moderation_hub_uses_existing_panel():
-    """S8 v1: the Moderation/Safety hub routes to
-    moderation_cog.build_help_menu_view (ModPanelView). Cleanup and
-    Logging stay top-level for now — promotion to parent_hub of
-    "moderation" lands when the hub view gains explicit child nav.
+    """Post-PR-#3: the Moderation/Safety hub routes to
+    ``moderation_cog.build_help_menu_view`` (ModPanelView). Cleanup,
+    Logging, and Proof Channel are now primary children via
+    ``parent_hub="moderation"``.
     """
     moderation = get_hub("moderation")
     assert moderation is not None
     assert moderation.entry_command == "!modmenu"
     assert moderation.minimum_tier == "moderator"
-    assert moderation.primary_children == ()
+    assert moderation.primary_children == ("cleanup", "logging", "proof_channel")
     assert moderation.cross_link_children == ()
     assert moderation.panel_available is True
 
 
 def test_economy_hub_uses_existing_panel():
-    """S7 v1: the Economy hub category routes to the existing
-    economy_cog.build_help_menu_view panel. Inventory/Leaderboard
-    are NOT yet parent_hub="economy" — that promotion happens in a
-    follow-up PR once the hub view gains explicit child navigation.
+    """Post-PR-#3: the Economy hub category routes to the existing
+    ``economy_cog.build_help_menu_view`` panel. Inventory and
+    Leaderboard are now primary children via ``parent_hub="economy"``.
+    Mining stays under Games (its primary) and appears here only as a
+    cross-link.
     """
     economy = get_hub("economy")
     assert economy is not None
     assert economy.entry_command == "!economymenu"
-    # Empty primary_children / cross_links in v1 — pin so a future
-    # PR doesn't silently rewrite child wiring without updating
-    # subsystem metadata too.
-    assert economy.primary_children == ()
-    assert economy.cross_link_children == ()
+    assert economy.primary_children == ("inventory", "leaderboard")
+    assert economy.cross_link_children == ("mining",)
     assert economy.panel_available is True
     assert economy.minimum_tier == "user"
 
@@ -159,6 +159,47 @@ def test_games_hub_primary_children_match_parent_hub_filter():
     assert declared == actual, (
         f"Games primary_children {declared} != parent_hub filter {actual}"
     )
+
+
+def test_every_hub_primary_children_match_parent_hub_filter():
+    """For every hub whose key is referenced by at least one
+    subsystem's ``parent_hub``, the hub's ``primary_children`` must
+    equal the set of subsystems pointing at it. Generalises the
+    games-only check above so future PRs cannot silently drift
+    metadata away from the hub declaration.
+    """
+    # Collect parent_hub references per hub key.
+    parents: dict[str, set[str]] = {}
+    for name, meta in SUBSYSTEMS.items():
+        parent = meta.get("parent_hub")
+        if parent is None:
+            continue
+        parents.setdefault(parent, set()).add(name)
+
+    for hub_key, expected_children in parents.items():
+        hub = get_hub(hub_key)
+        assert hub is not None, (
+            f"subsystem(s) {expected_children} point at hub {hub_key!r} but "
+            f"no such hub exists in HUBS"
+        )
+        declared = set(hub.primary_children)
+        assert declared == expected_children, (
+            f"hub {hub_key!r}: primary_children {declared} != parent_hub "
+            f"filter {expected_children}"
+        )
+
+
+def test_cross_link_children_reference_real_subsystems():
+    """Every entry in any hub's ``cross_link_children`` must be a real
+    subsystem key. Pins the contract for the Mining → Economy
+    cross-link added in PR #3 and for any future cross-links.
+    """
+    for hub in HUBS:
+        for child in hub.cross_link_children:
+            assert child in SUBSYSTEMS, (
+                f"hub {hub.key!r} declares cross_link_children {child!r} "
+                f"which is not a valid SUBSYSTEMS key"
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Completes the Phase 4 Help filter introduced by PR #142 by declaring `parent_hub` on the eight S7–S10 hub children that were still implicit (`inventory`, `leaderboard`, `xp`, `role`, `cleanup`, `logging`, `proof_channel`, `general`). Populates the matching `primary_children` tuples on the four affected hubs in `hub_registry.py` and declares Mining as a `cross_link_children` on Economy. Doc and tests follow. This is plan PR #3 from `/root/.claude/plans/superbot-planning-jolly-wadler.md` §8.

## Files changed

| File | Role |
|---|---|
| `disbot/utils/subsystem_registry.py` | Eight new `parent_hub` keys |
| `disbot/utils/hub_registry.py` | Economy/Moderation/Community/Utility `primary_children` populated; Economy `cross_link_children=("mining",)`; comments updated |
| `tests/unit/utils/test_hub_registry.py` | Update 4 existing pinned-empty assertions; add `test_every_hub_primary_children_match_parent_hub_filter`; add `test_cross_link_children_reference_real_subsystems` |
| `tests/unit/help/test_help_parent_hub_filter.py` | Expand `_hub_children()` to cover all parent_hub'd subsystems; add 3 PR #3 tests; tighten the existing overview-leak assertions to match the bolded `**{display}**` form (fixes a substring false-positive that "General" would trigger via Utility's "General utility commands" description) |
| `docs/help-command-surface-map.md` | Flip 8 rows from "(... future)" to "— declared"; update §4 architectural note; update §5 plan-PR map |

## Architecture impact

- **Filter activation**: PR #142 added the Phase 4 filter that reads `SUBSYSTEMS[name].get("parent_hub")` to hide hub children from the top-level Help overview. The filter has been live since #142; this PR populates the data so it actually hides those eight subsystems.
- **Runtime view discovery**: Games' `discover_game_children()` reads from `SUBSYSTEMS`, not from `hub_registry.HubEntry.primary_children` — so populating the latter has no effect on today's GamesHubView. It becomes load-bearing in PR #4 when CommunityHubView migrates off its hardcoded `_HUB_CHILDREN` tuple. No view code changes here.
- **Mining cross-link**: Declared at the hub-registry level only. Mining's `parent_hub` stays `"games"` — no metadata change on Mining itself. The Economy hub view does not yet consume `cross_link_children`; that wiring lands when the Economy hub gains explicit child navigation.
- **Backward compatibility**: existing typed lookups for the eight children (`!help inventory`, `!help xp`, etc.) keep resolving to subsystem panels because `_resolve_route` matches by name first; the filter only affects the overview list.

## Test plan

- Full suite: **2356 passed** (was 2351 pre-PR; +5 new PR #3 tests).
- `tests/unit/registry/` — 280 passed (registry validator accepts the new metadata; two-hop check + entry-points routability check both pass for the four target parent hubs).
- `tests/unit/help/test_help_parent_hub_filter.py` — extended; the bolded-form assertion fixes a pre-existing substring false-positive that would have leaked if "General" became a hub child.
- `tests/unit/utils/test_hub_registry.py` — flipped + generalised; the new `test_every_hub_primary_children_match_parent_hub_filter` mechanically catches any future drift between hub_registry and subsystem_registry.
- Lint: `ruff check .`, `black --check disbot/`, `isort --check disbot/` — all clean.

## Manual Discord smoke plan

This is a metadata-only PR; no view or interaction code changes. Smoke is brief:

- [ ] `!help` — verify Inventory, Leaderboard, XP, Role, Cleanup, Logging, Proof Channel, and General no longer appear at the top-level overview (they should be hidden by the Phase 4 filter).
- [ ] `!help inventory`, `!help xp`, `!help cleanup`, `!help general`, etc. — verify each still opens its subsystem panel via the shared resolver.
- [ ] `!help` → dropdown → All Commands / Advanced — verify the eight children also hidden from the paginated list (they're under their parent hubs, not floating at the top).
- [ ] `!games` — Mining still appears (parent_hub="games" unchanged).
- [ ] `!economymenu`, `!community`, `!modmenu`, `!utilitymenu` — verify each hub still opens (no view code touched here; behaviour identical to pre-PR).

## CI status

Pending on push; monitored via the PR activity subscription.

## Rollback notes

Single commit. A revert restores the pre-PR state cleanly:
- Eight `parent_hub` keys removed from `subsystem_registry.py`.
- Four `primary_children` tuples and one `cross_link_children` revert to empty.
- Tests revert to pre-PR assertions.
- Doc reverts to "(... future)" wording.

No data migration, no view code, no pipeline changes.

## Follow-up items

Plan PR #4 (community: metadata-driven hub children) is now unblocked — the metadata it needs to discover from is in place. Subsequent plan PRs continue: XP modal pipeline migration → Economy log-channel pipeline → Settings selectors → Settings default-on → `/help` slash proof.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KTjPVwXmAhK4c3RaG9Qod5)_