### PR TITLE
community: metadata-driven hub children

### DIFF
--- a/disbot/utils/hub_registry.py
+++ b/disbot/utils/hub_registry.py
@@ -146,16 +146,19 @@ HUBS: tuple[HubEntry, ...] = (
         emoji="🌱",
         purpose="Progression, roles, and community activities.",
         entry_command="!community",
-        # PR #3 promotes XP and Role to parent_hub of "community"
-        # (their primary placement). Counting, Chain (Games children)
-        # and Leaderboard (Economy child) remain cross-links via the
-        # Community hub view's hardcoded ``_HUB_CHILDREN`` tuple; PR #4
-        # migrates the view to discover them from this declaration.
+        # XP and Role are the primary children (parent_hub="community"
+        # since PR #3). Counting, Chain (whose primary is Games) and
+        # Leaderboard (whose primary is Economy) appear as cross-links —
+        # CommunityHubView discovers both groups from registry (PR #4).
         primary_children=(
             "xp",
             "role",
         ),
-        cross_link_children=(),
+        cross_link_children=(
+            "counting",
+            "chain",
+            "leaderboard",
+        ),
         minimum_tier="user",
     ),
     HubEntry(

--- a/disbot/views/community/hub.py
+++ b/disbot/views/community/hub.py
@@ -5,19 +5,24 @@ of its own. Per the mother-hub map, it groups progression and
 community-activity subsystems whose primary owners are spread across
 the codebase:
 
-* **XP** and **Roles** are the primary children (no existing domain
-  cog owned them as a group, hence the new ``community_cog``).
+* **XP** and **Roles** are the primary children. Discovered from
+  ``SUBSYSTEMS`` where ``parent_hub == "community"``.
 * **Counting**, **Chain**, and **Leaderboard** appear as **cross-links**
   — their primary homes stay under Games (counting/chain) and Economy
-  (leaderboard) per the cross-link policy. The buttons here route to
-  the same ``build_help_menu_view`` hook those cogs already expose;
-  no metadata change.
+  (leaderboard). Discovered from
+  ``utils.hub_registry.get_hub("community").cross_link_children``.
+
+Mirrors the Games hub pattern (``views.games.hub:discover_game_children``)
+so the source of truth is the registry, not a hardcoded view-local
+tuple. PR #4 migrated the view here from the previous ``_HUB_CHILDREN``
+literal.
 
 Five children fit comfortably under the hub-ui-standard button
-threshold (≤8 buttons preferred over a dropdown). Back-nav is
-attached by ``HelpCategoryView`` when the hub is surfaced from
-``!help``; the direct ``!community`` entry shows the hub without a
-back button, matching the ``!games`` pattern.
+threshold (≤8 buttons preferred over a dropdown). Layout: primary
+children on row 0 with primary style, cross-links on row 1 with
+secondary style. Back-nav is attached by ``HelpCategoryView`` when
+the hub is surfaced from ``!help``; the direct ``!community`` entry
+shows the hub without a back button, matching the ``!games`` pattern.
 """
 
 from __future__ import annotations
@@ -26,37 +31,93 @@ import logging
 
 import discord
 
+from utils.hub_registry import get_hub
+from utils.subsystem_registry import SUBSYSTEMS
 from utils.ui_constants import GENERAL_COLOR
 from views.base import HubView
 
 logger = logging.getLogger("bot.views.community")
 
 
-# Each tuple is (subsystem_key, button_label, button_style, row).
-# Rows match the layout: progression on row 0, community games on row 1.
-_HUB_CHILDREN: tuple[tuple[str, str, discord.ButtonStyle, int], ...] = (
-    ("xp", "🏆 XP & Levels", discord.ButtonStyle.primary, 0),
-    ("role", "🎭 Roles", discord.ButtonStyle.primary, 0),
-    ("counting", "🔢 Counting", discord.ButtonStyle.secondary, 1),
-    ("chain", "⛓️ Chain", discord.ButtonStyle.secondary, 1),
-    ("leaderboard", "📊 Leaderboard", discord.ButtonStyle.secondary, 1),
-)
+def discover_community_children() -> (
+    tuple[list[tuple[str, dict]], list[tuple[str, dict]]]
+):
+    """Return ``(primary, cross_link)`` lists of (subsystem, meta) pairs.
+
+    Primary children come from ``SUBSYSTEMS`` filtered by
+    ``parent_hub == "community"``, sorted by ``ui_priority`` then key
+    for determinism (matches the Games hub ordering rule).
+
+    Cross-link children come from
+    ``hub_registry.get_hub("community").cross_link_children`` in
+    declared order. Unknown / missing subsystem keys are dropped with
+    a WARNING — the hub stays functional even if a cross-link points
+    at a subsystem that was unloaded.
+    """
+    primary = [
+        (name, dict(meta))
+        for name, meta in SUBSYSTEMS.items()
+        if meta.get("parent_hub") == "community"
+    ]
+    primary.sort(key=lambda item: (item[1].get("ui_priority", 99), item[0]))
+
+    cross_link: list[tuple[str, dict]] = []
+    hub = get_hub("community")
+    if hub is not None:
+        for key in hub.cross_link_children:
+            meta = SUBSYSTEMS.get(key)
+            if meta is None:
+                logger.warning(
+                    "community hub cross_link_children %r is not in SUBSYSTEMS",
+                    key,
+                )
+                continue
+            cross_link.append((key, dict(meta)))
+
+    return primary, cross_link
+
+
+def _format_child_label(subsystem: str, meta: dict) -> str:
+    """Build a button label from registry metadata.
+
+    Mirrors the Games hub which uses
+    ``meta.get("display_name") or name`` plus the subsystem emoji.
+    """
+    emoji = meta.get("emoji") or "•"
+    display = meta.get("display_name") or subsystem
+    return f"{emoji} {display}"
 
 
 def build_community_hub_embed() -> discord.Embed:
-    """Build the embed shown by :class:`CommunityHubView`."""
+    """Build the embed shown by :class:`CommunityHubView`.
+
+    Description is generated from the discovered children so it stays
+    in sync with the registry. The "Progression" / "Community games &
+    standings" group headings are hardcoded — they are presentational
+    framing, not metadata.
+    """
+    primary, cross_link = discover_community_children()
+    parts = ["Pick a community feature below."]
+
+    if primary:
+        parts.append("\n**Progression**")
+        for name, meta in primary:
+            emoji = meta.get("emoji") or "•"
+            display = meta.get("display_name") or name
+            desc = meta.get("description") or ""
+            parts.append(f"• {emoji} **{display}** — {desc}".rstrip(" —"))
+
+    if cross_link:
+        parts.append("\n**Community games & standings**")
+        for name, meta in cross_link:
+            emoji = meta.get("emoji") or "•"
+            display = meta.get("display_name") or name
+            desc = meta.get("description") or ""
+            parts.append(f"• {emoji} **{display}** — {desc}".rstrip(" —"))
+
     embed = discord.Embed(
         title="🌱 Community Hub",
-        description=(
-            "Pick a community feature below.\n\n"
-            "**Progression**\n"
-            "• 🏆 **XP & Levels** — earn XP by chatting; view your rank.\n"
-            "• 🎭 **Roles** — manage self-assignable / XP / time-based roles.\n\n"
-            "**Community games & standings**\n"
-            "• 🔢 **Counting** — collaborative counting channel.\n"
-            "• ⛓️ **Chain** — collaborative chain channel.\n"
-            "• 📊 **Leaderboard** — cross-feature standings."
-        ),
+        description="\n".join(parts),
         color=GENERAL_COLOR,
     )
     embed.set_footer(text="Only you can interact with this panel.")
@@ -125,22 +186,40 @@ class _CommunityChildButton(discord.ui.Button):
 class CommunityHubView(HubView):
     """Router-only hub for the Community subsystem.
 
-    Surfaces XP + Roles (primary children) and cross-links to
-    Counting, Chain, and Leaderboard. The hub view itself contains
-    zero business logic — every button forwards to the target cog's
-    existing ``build_help_menu_view`` hook.
+    Discovers primary children from ``SUBSYSTEMS`` (``parent_hub ==
+    "community"``) and cross-links from ``hub_registry.get_hub
+    ("community").cross_link_children``. Every button forwards to the
+    target cog's existing ``build_help_menu_view`` hook — no business
+    logic lives in this view.
     """
 
     SUBSYSTEM = "community"
 
     def __init__(self, author: discord.Member | discord.User) -> None:
         super().__init__(author)
-        for subsystem, label, style, row in _HUB_CHILDREN:
+        primary, cross_link = discover_community_children()
+        for subsystem, meta in primary:
             self.add_item(
                 _CommunityChildButton(
                     subsystem=subsystem,
-                    label=label,
-                    style=style,
-                    row=row,
+                    label=_format_child_label(subsystem, meta),
+                    style=discord.ButtonStyle.primary,
+                    row=0,
                 ),
             )
+        for subsystem, meta in cross_link:
+            self.add_item(
+                _CommunityChildButton(
+                    subsystem=subsystem,
+                    label=_format_child_label(subsystem, meta),
+                    style=discord.ButtonStyle.secondary,
+                    row=1,
+                ),
+            )
+
+
+__all__ = [
+    "CommunityHubView",
+    "build_community_hub_embed",
+    "discover_community_children",
+]

--- a/tests/unit/utils/test_hub_registry.py
+++ b/tests/unit/utils/test_hub_registry.py
@@ -81,19 +81,19 @@ def test_utility_hub_uses_existing_panel():
 
 
 def test_community_hub_uses_new_cog():
-    """Post-PR-#3: the Community hub's ``community_cog`` is nav-only.
-    ``xp`` and ``role`` are now primary children via ``parent_hub=
+    """Post-PR-#4: the Community hub's ``community_cog`` is nav-only.
+    ``xp`` and ``role`` are primary children via ``parent_hub=
     "community"``. Counting, Chain (Games children) and Leaderboard
-    (Economy child) remain cross-links via the Community hub view's
-    hardcoded ``_HUB_CHILDREN`` tuple until PR #4 migrates the view
-    to discover them from registry.
+    (Economy child) are now declared as ``cross_link_children`` so the
+    ``CommunityHubView`` can discover them from registry rather than
+    a hardcoded view-local tuple.
     """
     community = get_hub("community")
     assert community is not None
     assert community.entry_command == "!community"
     assert community.minimum_tier == "user"
     assert community.primary_children == ("xp", "role")
-    assert community.cross_link_children == ()
+    assert community.cross_link_children == ("counting", "chain", "leaderboard")
     assert community.panel_available is True
 
 

--- a/tests/unit/views/test_community_hub_view.py
+++ b/tests/unit/views/test_community_hub_view.py
@@ -1,12 +1,17 @@
-"""Unit tests for the Community hub view (S9).
+"""Unit tests for the Community hub view (S9 + PR #4).
 
-Pins the v1 behaviour:
+Pins the metadata-driven v2 behaviour:
 
-- Five cross-link buttons routing to xp / role / counting / chain /
-  leaderboard via each cog's existing ``build_help_menu_view`` hook.
-- Buttons follow the hub-ui-standard layout: progression on row 0,
-  community activities on row 1.
+- Primary children discovered from ``SUBSYSTEMS`` where
+  ``parent_hub == "community"`` (xp + role today).
+- Cross-link children discovered from
+  ``hub_registry.get_hub("community").cross_link_children``
+  (counting + chain + leaderboard today).
+- Buttons follow the hub-ui-standard layout: primary on row 0 with
+  primary style, cross-links on row 1 with secondary style.
 - Stable custom_ids in ``community:open:<subsystem>`` form.
+- Labels come from registry metadata (emoji + display_name) — not
+  view-local hardcoded strings.
 - Failure paths surface as ephemerals; the message is never left
   half-edited.
 
@@ -21,10 +26,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import discord
 import pytest
 
+from utils.hub_registry import get_hub
+from utils.subsystem_registry import SUBSYSTEMS
 from views.community.hub import (
     CommunityHubView,
     _CommunityChildButton,
     build_community_hub_embed,
+    discover_community_children,
 )
 
 
@@ -44,6 +52,48 @@ def _interaction() -> MagicMock:
 
 
 # ---------------------------------------------------------------------------
+# discover_community_children — metadata-driven discovery
+# ---------------------------------------------------------------------------
+
+
+def test_discover_primary_comes_from_parent_hub_metadata():
+    """Primary children must equal the set of SUBSYSTEMS entries with
+    ``parent_hub == "community"`` — never a hardcoded view-local list.
+    """
+    primary, _cross = discover_community_children()
+    primary_keys = {name for name, _meta in primary}
+    expected = {
+        name
+        for name, meta in SUBSYSTEMS.items()
+        if meta.get("parent_hub") == "community"
+    }
+    assert primary_keys == expected
+
+
+def test_discover_cross_link_comes_from_hub_registry():
+    """Cross-links must equal the HubEntry.cross_link_children tuple —
+    never a hardcoded view-local list.
+    """
+    _primary, cross = discover_community_children()
+    cross_keys = [name for name, _meta in cross]
+    hub = get_hub("community")
+    assert hub is not None
+    assert tuple(cross_keys) == hub.cross_link_children
+
+
+def test_discover_primary_sorted_by_ui_priority_then_key():
+    """Ordering must be deterministic — ui_priority ascending, then key
+    ascending — so the button layout doesn't drift across imports.
+    """
+    primary, _cross = discover_community_children()
+    keys = [
+        (meta.get("ui_priority", 99), name)
+        for name, meta in primary
+    ]
+    assert keys == sorted(keys)
+
+
+# ---------------------------------------------------------------------------
 # Embed
 # ---------------------------------------------------------------------------
 
@@ -51,14 +101,30 @@ def _interaction() -> MagicMock:
 def test_embed_lists_all_five_children():
     embed = build_community_hub_embed()
     description = embed.description or ""
-    for token in ("XP", "Roles", "Counting", "Chain", "Leaderboard"):
-        assert token in description, token
+    # Match by display_name as registered today; this catches metadata
+    # drift but not styling tweaks to the description.
+    for key in ("xp", "role", "counting", "chain", "leaderboard"):
+        display = SUBSYSTEMS[key]["display_name"]
+        assert display in description, (
+            f"{key!r} display_name {display!r} missing from embed description"
+        )
 
 
 def test_embed_title_and_color():
     embed = build_community_hub_embed()
     assert "Community" in (embed.title or "")
     assert embed.color is not None
+
+
+def test_embed_section_headings_present():
+    """The Progression / Community games & standings headings are
+    hardcoded framing and must remain so a registry-only edit doesn't
+    silently collapse the layout.
+    """
+    embed = build_community_hub_embed()
+    description = embed.description or ""
+    assert "**Progression**" in description
+    assert "**Community games & standings**" in description
 
 
 # ---------------------------------------------------------------------------
@@ -74,7 +140,11 @@ def test_view_has_five_child_buttons():
 
 def test_buttons_cover_each_target_subsystem():
     view = CommunityHubView(_author())
-    subsystems = {btn._subsystem for btn in view.children if isinstance(btn, _CommunityChildButton)}  # type: ignore[attr-defined]
+    subsystems = {
+        btn._subsystem  # type: ignore[attr-defined]
+        for btn in view.children
+        if isinstance(btn, _CommunityChildButton)
+    }
     assert subsystems == {"xp", "role", "counting", "chain", "leaderboard"}
 
 
@@ -95,9 +165,9 @@ def test_button_custom_ids_are_stable_and_namespaced():
 
 
 def test_buttons_split_across_two_rows():
-    """Progression (XP/Roles) sit on row 0; community activities
-    (Counting/Chain/Leaderboard) sit on row 1 — pinning the layout
-    keeps the hub-ui-standard preset stable across edits.
+    """Primary children (XP/Roles, parent_hub="community") on row 0;
+    cross-links (Counting/Chain/Leaderboard, declared in
+    hub_registry.cross_link_children) on row 1.
     """
     view = CommunityHubView(_author())
     row0 = {
@@ -112,6 +182,44 @@ def test_buttons_split_across_two_rows():
     }
     assert row0 == {"xp", "role"}
     assert row1 == {"counting", "chain", "leaderboard"}
+
+
+def test_row_0_uses_primary_style_row_1_uses_secondary():
+    """Layout convention: primaries are visually highlighted (primary
+    style); cross-links recede (secondary style).
+    """
+    view = CommunityHubView(_author())
+    for btn in view.children:
+        if not isinstance(btn, _CommunityChildButton):
+            continue
+        if btn.row == 0:
+            assert btn.style is discord.ButtonStyle.primary, (
+                f"row-0 button {btn._subsystem!r} has non-primary style "  # type: ignore[attr-defined]
+                f"{btn.style!r}"
+            )
+        elif btn.row == 1:
+            assert btn.style is discord.ButtonStyle.secondary, (
+                f"row-1 button {btn._subsystem!r} has non-secondary style "  # type: ignore[attr-defined]
+                f"{btn.style!r}"
+            )
+
+
+def test_button_labels_come_from_registry_metadata():
+    """Labels must use the subsystem's registered emoji + display_name,
+    not a hardcoded view-local string. PR #4 removed the literal label
+    table; this test pins the new contract.
+    """
+    view = CommunityHubView(_author())
+    for btn in view.children:
+        if not isinstance(btn, _CommunityChildButton):
+            continue
+        key = btn._subsystem  # type: ignore[attr-defined]
+        meta = SUBSYSTEMS[key]
+        expected = f"{meta['emoji']} {meta['display_name']}"
+        assert btn.label == expected, (
+            f"button {key!r} label {btn.label!r} does not match registry "
+            f"metadata {expected!r}"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Replaces `views/community/hub.py`'s hardcoded `_HUB_CHILDREN` tuple with registry discovery. Primary children come from `SUBSYSTEMS` filtered by `parent_hub == "community"` (xp + role, per PR #3). Cross-links come from `hub_registry.get_hub("community").cross_link_children` — populated in this PR with `("counting", "chain", "leaderboard")` (the deferred step PR #3 explicitly framed as PR #4's job). Mirrors the Games hub pattern. Plan PR #4 from `/root/.claude/plans/superbot-planning-jolly-wadler.md` §8.

## Files changed

| File | Role |
|---|---|
| `disbot/utils/hub_registry.py` | Populate `community.cross_link_children=("counting", "chain", "leaderboard")`; update comment |
| `disbot/views/community/hub.py` | New `discover_community_children()`; `CommunityHubView` + embed builder consume it; labels built from registry metadata |
| `tests/unit/utils/test_hub_registry.py` | `test_community_hub_uses_new_cog` asserts the populated cross_link tuple |
| `tests/unit/views/test_community_hub_view.py` | +6 metadata-discovery contract tests (primary source, cross-link source, ordering, row styles, label format, section headings); all previous shape assertions retained |

## Architecture impact

- **Single source of truth**: `views/community/hub.py` no longer carries a duplicate of the hub-children list. The registry (`SUBSYSTEMS` + `hub_registry`) is now the only declaration; future hub-child additions/removals flow through PR #3-style metadata edits without touching the view.
- **Mirrors Games**: `discover_community_children()` parallels `discover_game_children()` in shape. Both filter SUBSYSTEMS by `parent_hub`, both sort deterministically by `(ui_priority, key)`. Difference: Games has no cross-links (its hub is single-group); Community has both groups.
- **Visible label change**: button labels now come from registry metadata (`emoji` + `display_name`). Three labels drift:
  - `xp`: `🏆 XP & Levels` → `⭐ XP & Levels`
  - `chain`: `⛓️ Chain` → `🔗 Word Chain`
  - `leaderboard`: `📊 Leaderboard` → `🏆 Leaderboard`
  - (`role` and `counting` unchanged.)

  This is intentional: the registry is the single source of truth for display metadata. If specific emoji choices are preferred, fix the registry in a follow-up rather than re-introducing view-local overrides. The plan explicitly accepted metadata-driven labels ("verify the same 5 buttons render ... and the source is metadata").
- **No back-compat shims**: the old `_HUB_CHILDREN` symbol is gone. No internal callers existed.

## Test plan

- Full suite: **2362 passed** (was 2356 pre-PR; +6 new PR #4 tests).
- New tests pin: primary discovery from SUBSYSTEMS, cross-link discovery from hub_registry, deterministic ordering, primary-style row 0 / secondary-style row 1, label format `{emoji} {display_name}`, section headings preserved.
- All previous tests retained (button count, custom_ids, subsystem coverage, callback routing, failure paths, no-select doctrine).
- Lint: `ruff check`, `black --check`, `isort --check` on modified files → clean.

## Manual Discord smoke plan

- [ ] `!community` — verify all 5 buttons render: XP & Levels, Roles, Word Chain, Counting, Leaderboard. **Note the label drift on xp / chain / leaderboard.**
- [ ] Row 0: XP, Roles (primary style, blurple).
- [ ] Row 1: Counting, Chain, Leaderboard (secondary style, grey).
- [ ] Click each button — opens the target subsystem's panel via `build_help_menu_view`. No detached messages.
- [ ] `!help` → dropdown → Community → same 5 buttons, with the Back-to-Help button attached by `HelpCategoryView`.
- [ ] Mobile Discord — button layout fits in 2 rows under the 25-component cap.

## CI status

Pending on push; monitored via the PR activity subscription.

## Rollback notes

Single commit. A revert restores:
- `community.cross_link_children` back to `()`.
- Hardcoded `_HUB_CHILDREN` tuple in `views/community/hub.py`.
- Pre-PR labels (the three drifted emojis come back).
- Pre-PR test assertions.

No data, schema, or pipeline changes.

## Follow-up items

Plan PRs #5–#9 continue: XP modal pipeline migration → Economy log-channel pipeline → Settings selectors → Settings default-on → `/help` slash proof.

Out of scope, candidate follow-ups:
- If a reviewer prefers the pre-PR emojis (`🏆` for XP, `⛓️` for Chain, `📊` for Leaderboard), update the registry's emoji fields in a small dedicated PR. The registry is the right place; do NOT re-introduce view-local overrides.
- Economy and Moderation hub views (`views/economy/main_panel.py`, `views/moderation/main_panel.py`) still ship hardcoded button layouts. They're not pure routers like Games and Community — they include action buttons (Daily, Work, Warn, etc.) — so a metadata-discovery migration is a larger UX decision. Not part of this PR sequence.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KTjPVwXmAhK4c3RaG9Qod5)_