### PR TITLE
xp: migrate config modals to SettingsMutationPipeline

### DIFF
--- a/disbot/cogs/xp/schemas.py
+++ b/disbot/cogs/xp/schemas.py
@@ -34,6 +34,7 @@ from core.runtime.subsystem_schema import (
     SubsystemSchema,
 )
 from utils.settings_keys import (
+    XP_ANNOUNCE_CHANNEL,
     XP_COOLDOWN,
     XP_MAX,
     XP_MIN,
@@ -48,6 +49,16 @@ def _validate_positive_int(value: object) -> None:
 def _validate_cooldown(value: object) -> None:
     if not isinstance(value, int) or value < 0:
         raise ValueError(f"expected non-negative int cooldown, got {value!r}")
+
+
+def _validate_channel_id_or_empty(value: object) -> None:
+    """Empty string clears the announce channel; otherwise a numeric ID."""
+    if not isinstance(value, str):
+        raise ValueError(f"expected str, got {type(value).__name__}")
+    if value and not value.isdigit():
+        raise ValueError(
+            "must be empty (to clear) or a numeric Discord channel ID",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -97,6 +108,19 @@ XP_SETTINGS: tuple[SettingSpec, ...] = (
             "cooldown (not recommended in active guilds)."
         ),
         validator=_validate_cooldown,
+    ),
+    SettingSpec(
+        name="xp_announce_channel",
+        value_type=str,
+        default="",
+        settings_key=XP_ANNOUNCE_CHANNEL,
+        capability_required="xp.settings.configure",
+        hint=(
+            "Numeric Discord channel ID for level-up announcements.  "
+            "Leave empty to announce in the channel where the level-up "
+            "happened."
+        ),
+        validator=_validate_channel_id_or_empty,
     ),
 )
 

--- a/disbot/views/xp/modals.py
+++ b/disbot/views/xp/modals.py
@@ -1,4 +1,4 @@
-"""XP modals (S4.2-followup extraction).
+"""XP modals (S4.2-followup extraction, PR #5 pipeline migration).
 
 Five modals extracted from ``cogs/xp_cog.py``:
 
@@ -8,28 +8,111 @@ Five modals extracted from ``cogs/xp_cog.py``:
   _XpCooldownModal   — XP gain cooldown seconds (XpConfigView)
   _XpChannelModal    — level-up announcement channel id (XpConfigView)
 
-The three config modals call back into their owning ``XpConfigView``
-to refresh the panel after a successful write.  They each invoke
-``invalidate_xp_config`` so the F-1 cache picks up the new value on
-the next ``on_message`` hot-path read.
+The three config modals (range / cooldown / channel) write through
+:class:`services.settings_mutation.SettingsMutationPipeline` since
+PR #5.  The pipeline handles audit, the per-key SettingSpec-lane
+cache invalidation, and event emission — each scalar value lands
+with a row in ``settings_mutation_audit``.
+
+After every successful pipeline write, the helper also calls
+:func:`utils.guild_config_accessors.invalidate_xp_config` to drop the
+legacy composite ``XpConfig`` cache that the XP ``on_message`` hot
+path consumes.  The pipeline's own invalidation covers the per-key
+SettingSpec lane only; the composite cache is owned by
+``guild_config_accessors`` and must be poked separately until the
+hot path migrates to SettingSpec reads.
+
+The ``_GiveXpModal`` and ``_ResetXpModal`` flows are unchanged: they
+use ``xp_service.award`` / ``xp_service.reset`` which are domain
+services, not legacy-KV writes, so the pipeline is not involved.
 """
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 import discord
 
 from core.runtime.interaction_helpers import safe_defer
 from services import xp_service
-from utils import db
 from utils.guild_config_accessors import invalidate_xp_config
 from utils.helpers import _parse_member
-from utils.settings_keys import XP_ANNOUNCE_CHANNEL, XP_COOLDOWN, XP_MAX, XP_MIN
 
 if TYPE_CHECKING:
     from views.xp.config_panel import XpConfigView
     from views.xp.main_panel import _XpHubView
+
+logger = logging.getLogger("bot.views.xp.modals")
+
+
+# ---------------------------------------------------------------------------
+# Shared pipeline helper
+# ---------------------------------------------------------------------------
+
+
+async def _set_xp_setting_via_pipeline(
+    interaction: discord.Interaction,
+    name: str,
+    value: object,
+) -> bool:
+    """Write a single ``(xp, name)`` value through SettingsMutationPipeline.
+
+    Returns True on success.  On failure sends an ephemeral message
+    describing the error and returns False so the caller can short-
+    circuit before refreshing the parent view.
+    """
+    from services.settings_mutation import (
+        SettingsCoercionError,
+        SettingsMutationError,
+        SettingsMutationPipeline,
+        SettingsValidationError,
+    )
+
+    guild = interaction.guild
+    if guild is None:
+        await interaction.response.send_message(
+            "❌ XP config requires a guild context.",
+            ephemeral=True,
+        )
+        return False
+    try:
+        await SettingsMutationPipeline().set_value(
+            guild,
+            "xp",
+            name,
+            value,
+            interaction.user,
+        )
+    except (SettingsCoercionError, SettingsValidationError) as exc:
+        await interaction.response.send_message(
+            f"❌ {exc}",
+            ephemeral=True,
+        )
+        return False
+    except SettingsMutationError as exc:
+        await interaction.response.send_message(
+            f"❌ {type(exc).__name__}: {exc}",
+            ephemeral=True,
+        )
+        return False
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.exception(
+            "XP modal pipeline write failed for xp.%s",
+            name,
+        )
+        await interaction.response.send_message(
+            f"❌ Unexpected error: {type(exc).__name__}: {exc}",
+            ephemeral=True,
+        )
+        return False
+    # The pipeline invalidates the per-key SettingSpec lane via
+    # ``invalidate_setting_value``.  The legacy composite
+    # ``XpConfig`` accessor used by the XP on_message hot path is a
+    # separate cache; drop it explicitly so the next message read
+    # sees the new value without waiting for the TTL.
+    invalidate_xp_config(guild.id)
+    return True
 
 
 class _GiveXpModal(discord.ui.Modal, title="Give XP"):  # type: ignore[call-arg]
@@ -132,18 +215,25 @@ class _XpRangeModal(discord.ui.Modal, title="Set XP Range"):  # type: ignore[cal
     async def on_submit(self, interaction: discord.Interaction):
         try:
             mn, mx = int(self.xp_min.value), int(self.xp_max.value)
-            if mn <= 0 or mx < mn:
-                raise ValueError
         except ValueError:
             await interaction.response.send_message(
-                "Invalid values — min and max must be positive integers with min ≤ max.",
+                "❌ Both values must be integers.",
                 ephemeral=True,
             )
             return
-        gid = self.view.ctx.guild.id
-        await db.set_setting(gid, XP_MIN, str(mn))
-        await db.set_setting(gid, XP_MAX, str(mx))
-        invalidate_xp_config(gid)
+        if mx < mn:
+            await interaction.response.send_message(
+                "❌ Max must be ≥ min.",
+                ephemeral=True,
+            )
+            return
+        # The xp_min / xp_max SettingSpecs each enforce
+        # _validate_positive_int via the pipeline; per-field errors
+        # surface as ephemerals from _set_xp_setting_via_pipeline.
+        if not await _set_xp_setting_via_pipeline(interaction, "xp_min", mn):
+            return
+        if not await _set_xp_setting_via_pipeline(interaction, "xp_max", mx):
+            return
         if not await safe_defer(interaction):
             return
         await self.view._refresh(interaction)
@@ -163,17 +253,14 @@ class _XpCooldownModal(discord.ui.Modal, title="Set XP Cooldown"):  # type: igno
     async def on_submit(self, interaction: discord.Interaction):
         try:
             val = int(self.seconds.value)
-            if val < 0:
-                raise ValueError
         except ValueError:
             await interaction.response.send_message(
-                "Must be a non-negative integer.",
+                "❌ Cooldown must be an integer.",
                 ephemeral=True,
             )
             return
-        gid = self.view.ctx.guild.id
-        await db.set_setting(gid, XP_COOLDOWN, str(val))
-        invalidate_xp_config(gid)
+        if not await _set_xp_setting_via_pipeline(interaction, "xp_cooldown", val):
+            return
         if not await safe_defer(interaction):
             return
         await self.view._refresh(interaction)
@@ -191,16 +278,16 @@ class _XpChannelModal(discord.ui.Modal, title="Level-up Announcement Channel"): 
         self.view = view
 
     async def on_submit(self, interaction: discord.Interaction):
+        # The xp_announce_channel SettingSpec's validator enforces
+        # "empty or numeric"; surface any failure as an ephemeral and
+        # bail before touching the parent view.
         val = self.channel_id.value.strip()
-        if val and not val.isdigit():
-            await interaction.response.send_message(
-                "Enter a valid numeric channel ID, or leave blank.",
-                ephemeral=True,
-            )
+        if not await _set_xp_setting_via_pipeline(
+            interaction,
+            "xp_announce_channel",
+            val,
+        ):
             return
-        gid = self.view.ctx.guild.id
-        await db.set_setting(gid, XP_ANNOUNCE_CHANNEL, val)
-        invalidate_xp_config(gid)
         if not await safe_defer(interaction):
             return
         await self.view._refresh(interaction)

--- a/docs/settings-customization-command-map.md
+++ b/docs/settings-customization-command-map.md
@@ -318,8 +318,12 @@ Subsystems (22): `admin`, `moderation`, `economy`, `inventory`, `mining`,
 6. **help_menu_discoverable**: Yes.
 7. **dedicated_panel_command**: `none`.
 8. **help_menu_direct_navigation_hook**: `none`.
-9. **existing_SettingSpec_declarations**: `xp_min`, `xp_max`, `xp_cooldown`
-    (`disbot/cogs/xp/schemas.py`).
+9. **existing_SettingSpec_declarations**: `xp_min`, `xp_max`, `xp_cooldown`,
+    `xp_announce_channel` (`disbot/cogs/xp/schemas.py`). PR #5 promoted
+    the announce-channel scalar to a SettingSpec so all four XP config
+    modals write through `SettingsMutationPipeline`; the existing
+    `announce_channel` BindingSpec (item 11) remains the canonical
+    typed-resource declaration and is read by the arbitration ladder.
 10. **existing_settings_keys**: `XP_MIN`, `XP_MAX`, `XP_COOLDOWN`,
     `XP_ANNOUNCE_CHANNEL` (`disbot/utils/settings_keys/xp.py`).
 11. **existing_BindingSpec_entries**: `announce_channel`

--- a/tests/unit/invariants/test_no_direct_settings_keys_writes.py
+++ b/tests/unit/invariants/test_no_direct_settings_keys_writes.py
@@ -63,7 +63,8 @@ _ALLOWED_PATHS = {
     _DISBOT / "cogs" / "rps_tournament" / "_helpers.py",  # ACTIVE_TOURNAMENT
     _DISBOT / "governance" / "writes.py",         # internal governance writes
     _DISBOT / "views" / "blackjack" / "tournament_views.py",
-    _DISBOT / "views" / "xp" / "modals.py",       # XP_MIN/MAX/COOLDOWN/ANNOUNCE
+    # ``views/xp/modals.py`` migrated to SettingsMutationPipeline in PR #5
+    # — removed from the allowlist (the AST scan now enforces it).
     # Documentation reference (string literal in a module docstring,
     # not a call) — kept on the allowlist so the docstring is not
     # forced to rephrase.

--- a/tests/unit/views/test_xp_config_modals_use_pipeline.py
+++ b/tests/unit/views/test_xp_config_modals_use_pipeline.py
@@ -31,7 +31,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-
 _MODALS_PATH = (
     Path(__file__).resolve().parents[3] / "disbot" / "views" / "xp" / "modals.py"
 )

--- a/tests/unit/views/test_xp_config_modals_use_pipeline.py
+++ b/tests/unit/views/test_xp_config_modals_use_pipeline.py
@@ -1,0 +1,353 @@
+"""Regression tests for PR #5 — XP config modals use SettingsMutationPipeline.
+
+Pre-PR-#5 the three XP config modals (range / cooldown / channel)
+called ``db.set_setting`` directly and then manually invoked
+``invalidate_xp_config``. PR #5 routes each write through
+``services.settings_mutation.SettingsMutationPipeline`` so the
+mutation lands with audit + per-key cache invalidation + event
+emission; the modal still pokes ``invalidate_xp_config`` afterward
+because the legacy composite ``XpConfig`` accessor is a separate
+cache that the pipeline doesn't know about.
+
+These tests pin the new contract by:
+
+* Asserting the modals do not import ``db.set_setting``.
+* Patching ``SettingsMutationPipeline.set_value`` and verifying each
+  modal's ``on_submit`` calls it with the expected ``(subsystem,
+  name, value)`` triple for valid inputs.
+* Verifying ``invalidate_xp_config(guild.id)`` is called after a
+  successful pipeline write so the legacy hot-path cache stays
+  fresh.
+* Verifying validation failures stay ephemeral (no pipeline call,
+  no cache poke) for non-numeric / non-positive inputs.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+_MODALS_PATH = (
+    Path(__file__).resolve().parents[3] / "disbot" / "views" / "xp" / "modals.py"
+)
+
+
+# ---------------------------------------------------------------------------
+# AST-level: no db.set_setting references survive in the modals module
+# ---------------------------------------------------------------------------
+
+
+def test_modals_module_does_not_reference_db_set_setting():
+    """``views/xp/modals.py`` has been removed from the no-direct-writes
+    invariant allowlist; it must not call ``db.set_setting`` directly.
+    """
+    source = _MODALS_PATH.read_text()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and node.attr == "set_setting":
+            raise AssertionError(
+                f"views/xp/modals.py still references set_setting at line "
+                f"{node.lineno}",
+            )
+
+
+def test_modals_module_imports_pipeline_helper():
+    """The module-level helper that wraps the pipeline must be present
+    (function name is the stable contract every modal calls).
+    """
+    modals = importlib.import_module("views.xp.modals")
+    assert hasattr(modals, "_set_xp_setting_via_pipeline")
+
+
+# ---------------------------------------------------------------------------
+# Helper-level: _set_xp_setting_via_pipeline calls the pipeline + invalidator
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_helper_calls_pipeline_and_invalidates_legacy_cache():
+    from views.xp import modals as xp_modals
+
+    interaction = MagicMock()
+    interaction.guild = MagicMock()
+    interaction.guild.id = 99
+    interaction.user = MagicMock()
+    interaction.response.send_message = AsyncMock()
+
+    pipeline_instance = MagicMock()
+    pipeline_instance.set_value = AsyncMock(return_value=MagicMock())
+
+    with patch(
+        "services.settings_mutation.SettingsMutationPipeline",
+        return_value=pipeline_instance,
+    ), patch.object(
+        xp_modals,
+        "invalidate_xp_config",
+    ) as invalidator:
+        ok = await xp_modals._set_xp_setting_via_pipeline(interaction, "xp_min", 17)
+
+    assert ok is True
+    pipeline_instance.set_value.assert_awaited_once_with(
+        interaction.guild,
+        "xp",
+        "xp_min",
+        17,
+        interaction.user,
+    )
+    invalidator.assert_called_once_with(99)
+
+
+@pytest.mark.asyncio
+async def test_helper_returns_false_without_invalidating_on_dm():
+    """No guild context → ephemeral error, no pipeline call, no
+    cache invalidation.
+    """
+    from views.xp import modals as xp_modals
+
+    interaction = MagicMock()
+    interaction.guild = None
+    interaction.response.send_message = AsyncMock()
+
+    with patch(
+        "services.settings_mutation.SettingsMutationPipeline",
+    ) as pipeline_cls, patch.object(
+        xp_modals,
+        "invalidate_xp_config",
+    ) as invalidator:
+        ok = await xp_modals._set_xp_setting_via_pipeline(interaction, "xp_min", 17)
+
+    assert ok is False
+    pipeline_cls.assert_not_called()
+    invalidator.assert_not_called()
+    interaction.response.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_helper_surfaces_validation_error_as_ephemeral():
+    from services.settings_mutation import SettingsValidationError
+    from views.xp import modals as xp_modals
+
+    interaction = MagicMock()
+    interaction.guild = MagicMock()
+    interaction.guild.id = 99
+    interaction.user = MagicMock()
+    interaction.response.send_message = AsyncMock()
+
+    pipeline_instance = MagicMock()
+    pipeline_instance.set_value = AsyncMock(
+        side_effect=SettingsValidationError("expected positive int, got -3"),
+    )
+
+    with patch(
+        "services.settings_mutation.SettingsMutationPipeline",
+        return_value=pipeline_instance,
+    ), patch.object(
+        xp_modals,
+        "invalidate_xp_config",
+    ) as invalidator:
+        ok = await xp_modals._set_xp_setting_via_pipeline(interaction, "xp_min", -3)
+
+    assert ok is False
+    interaction.response.send_message.assert_awaited_once()
+    sent = interaction.response.send_message.await_args
+    assert sent.kwargs.get("ephemeral") is True
+    invalidator.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Modal-level: each on_submit drives the helper with the right (name, value)
+# ---------------------------------------------------------------------------
+
+
+def _modal_interaction() -> MagicMock:
+    interaction = MagicMock()
+    interaction.guild = MagicMock()
+    interaction.guild.id = 99
+    interaction.user = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    return interaction
+
+
+@pytest.mark.asyncio
+async def test_xp_range_modal_writes_min_and_max():
+    from views.xp import modals as xp_modals
+
+    fake_view = MagicMock()
+    fake_view._refresh = AsyncMock()
+
+    modal = xp_modals._XpRangeModal(fake_view)
+    modal.xp_min = MagicMock()
+    modal.xp_min.value = "12"
+    modal.xp_max = MagicMock()
+    modal.xp_max.value = "28"
+
+    interaction = _modal_interaction()
+
+    with patch.object(
+        xp_modals,
+        "_set_xp_setting_via_pipeline",
+        new=AsyncMock(return_value=True),
+    ) as helper, patch.object(
+        xp_modals,
+        "safe_defer",
+        new=AsyncMock(return_value=True),
+    ):
+        await modal.on_submit(interaction)
+
+    calls = [call.args[1:] for call in helper.await_args_list]
+    assert calls == [
+        ("xp_min", 12),
+        ("xp_max", 28),
+    ]
+    fake_view._refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_xp_range_modal_rejects_max_less_than_min():
+    """Range coherence check stays in the modal; it short-circuits
+    before the first pipeline call.
+    """
+    from views.xp import modals as xp_modals
+
+    modal = xp_modals._XpRangeModal(MagicMock())
+    modal.xp_min = MagicMock()
+    modal.xp_min.value = "30"
+    modal.xp_max = MagicMock()
+    modal.xp_max.value = "10"
+
+    interaction = _modal_interaction()
+
+    with patch.object(
+        xp_modals,
+        "_set_xp_setting_via_pipeline",
+        new=AsyncMock(return_value=True),
+    ) as helper:
+        await modal.on_submit(interaction)
+
+    helper.assert_not_called()
+    interaction.response.send_message.assert_awaited_once()
+    sent = interaction.response.send_message.await_args
+    assert sent.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_xp_cooldown_modal_writes_cooldown():
+    from views.xp import modals as xp_modals
+
+    fake_view = MagicMock()
+    fake_view._refresh = AsyncMock()
+    modal = xp_modals._XpCooldownModal(fake_view)
+    modal.seconds = MagicMock()
+    modal.seconds.value = "45"
+
+    interaction = _modal_interaction()
+
+    with patch.object(
+        xp_modals,
+        "_set_xp_setting_via_pipeline",
+        new=AsyncMock(return_value=True),
+    ) as helper, patch.object(
+        xp_modals,
+        "safe_defer",
+        new=AsyncMock(return_value=True),
+    ):
+        await modal.on_submit(interaction)
+
+    helper.assert_awaited_once()
+    assert helper.await_args.args[1:] == ("xp_cooldown", 45)
+    fake_view._refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_xp_channel_modal_writes_channel_string():
+    from views.xp import modals as xp_modals
+
+    fake_view = MagicMock()
+    fake_view._refresh = AsyncMock()
+    modal = xp_modals._XpChannelModal(fake_view)
+    modal.channel_id = MagicMock()
+    modal.channel_id.value = "1234567890"
+
+    interaction = _modal_interaction()
+
+    with patch.object(
+        xp_modals,
+        "_set_xp_setting_via_pipeline",
+        new=AsyncMock(return_value=True),
+    ) as helper, patch.object(
+        xp_modals,
+        "safe_defer",
+        new=AsyncMock(return_value=True),
+    ):
+        await modal.on_submit(interaction)
+
+    helper.assert_awaited_once()
+    assert helper.await_args.args[1:] == ("xp_announce_channel", "1234567890")
+    fake_view._refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_xp_channel_modal_writes_empty_string_to_clear():
+    """Empty input clears the channel — passed through to the pipeline
+    as ``""`` (the SettingSpec validator accepts empty).
+    """
+    from views.xp import modals as xp_modals
+
+    fake_view = MagicMock()
+    fake_view._refresh = AsyncMock()
+    modal = xp_modals._XpChannelModal(fake_view)
+    modal.channel_id = MagicMock()
+    modal.channel_id.value = "  "
+
+    interaction = _modal_interaction()
+
+    with patch.object(
+        xp_modals,
+        "_set_xp_setting_via_pipeline",
+        new=AsyncMock(return_value=True),
+    ) as helper, patch.object(
+        xp_modals,
+        "safe_defer",
+        new=AsyncMock(return_value=True),
+    ):
+        await modal.on_submit(interaction)
+
+    helper.assert_awaited_once()
+    assert helper.await_args.args[1:] == ("xp_announce_channel", "")
+
+
+# ---------------------------------------------------------------------------
+# SettingSpec presence (PR #5 schema addition)
+# ---------------------------------------------------------------------------
+
+
+def test_xp_announce_channel_settingspec_declared():
+    """PR #5 added ``xp_announce_channel`` to ``XP_SETTINGS`` so the
+    pipeline accepts writes for it. Pin the declaration and the
+    validator's empty-or-numeric contract via the schema, not the
+    modal.
+    """
+    from cogs.xp.schemas import XP_SETTINGS
+
+    by_name = {spec.name: spec for spec in XP_SETTINGS}
+    assert "xp_announce_channel" in by_name, (
+        "xp_announce_channel must be declared as a SettingSpec — "
+        "PR #5 promoted it from a direct-write to a pipeline-managed "
+        "scalar."
+    )
+    spec = by_name["xp_announce_channel"]
+    assert spec.value_type is str
+    assert spec.default == ""
+    assert spec.validator is not None
+    # Empty is allowed.
+    spec.validator("")
+    # Numeric IDs are allowed.
+    spec.validator("1234567890")
+    # Non-numeric non-empty is rejected.
+    with pytest.raises(ValueError):
+        spec.validator("not-a-channel")


### PR DESCRIPTION
## Summary

Closes the largest remaining hole in the S4 mutation contract by routing the four XP config writes (xp_min, xp_max, xp_cooldown, xp_announce_channel) through `SettingsMutationPipeline` instead of bare `db.set_setting`. Adds the fourth SettingSpec (`xp_announce_channel`), removes `views/xp/modals.py` from the no-direct-writes allowlist, and adds 11 regression tests. Plan PR #5 from `/root/.claude/plans/superbot-planning-jolly-wadler.md` §8.

## Files changed

| File | Role |
|---|---|
| `disbot/cogs/xp/schemas.py` | New `xp_announce_channel` SettingSpec (str, default "") with `_validate_channel_id_or_empty` validator |
| `disbot/views/xp/modals.py` | New `_set_xp_setting_via_pipeline` helper; three config modals rewritten to call it; legacy `db.set_setting` calls removed |
| `tests/unit/invariants/test_no_direct_settings_keys_writes.py` | Remove `views/xp/modals.py` from the allowlist; the AST scan now enforces it |
| `tests/unit/views/test_xp_config_modals_use_pipeline.py` | New — 11 tests pinning AST, helper, modal-per-modal, and SettingSpec-presence contracts |
| `docs/settings-customization-command-map.md` | Add `xp_announce_channel` to the XP SettingSpec list with the PR #5 note |

## Architecture impact

- **Audit + event coverage**: every XP config change now lands a `settings_mutation_audit` row and emits a `settings.changed` event. Previously the writes were invisible to the audit dashboard.
- **Validator pushed to schema**: the "positive int" check for min/max, the "non-negative int" check for cooldown, and the new "empty or numeric" check for the channel all live on the SettingSpec and are dispatched by the pipeline. Modals only handle composite checks (`mx >= mn`) that span fields and the typed int-parse step before handing off.
- **Composite cache invalidation preserved**: the modal helper still calls `invalidate_xp_config(guild.id)` after a successful pipeline write because the legacy `_xp_config_accessor` (consumed by the XP `on_message` hot path) is a separate cache from the pipeline's per-key SettingSpec-lane cache. This is documented in the module docstring and pinned by `test_helper_calls_pipeline_and_invalidates_legacy_cache`. A follow-up could migrate the hot path to SettingSpec reads and drop the composite cache.
- **SettingSpec + BindingSpec duality for `xp_announce_channel`**: a transition state. Writes flow through the SettingSpec scalar lane; reads use `get_xp_announce_channel` which arbitrates between the bindings table (where `binding_backfill` is migrating values) and the legacy KV. A future PR can collapse either side. Documented in the commit body and the doc note.

## Test plan

- Full suite: **2373 passed** (was 2362 pre-PR; +11 new PR #5 tests).
- 11 new tests cover: AST cleanliness, helper contract (pipeline call + legacy invalidation), helper failure paths (DM, validation error), per-modal pipeline dispatch (range × 2 writes, cooldown × 1, channel × 1 numeric + 1 empty), and SettingSpec presence + validator behaviour.
- Lint: `ruff check`, `black --check`, `isort --check` on modified files → clean.

## Manual Discord smoke plan

- [ ] `!xpmenu` → Configure → XP Range → submit valid min/max → "✅" or new values reflected in the panel embed → check `settings_mutation_audit` for two new rows (one per setting).
- [ ] Same flow with min=10, max=5 → ephemeral "Max must be ≥ min" (modal-local), no pipeline calls, no audit row.
- [ ] Cooldown → submit 30 → audit row appears with old/new values.
- [ ] Cooldown → submit -5 → ephemeral error from validator ("expected non-negative int cooldown"); no audit row.
- [ ] Level-up Channel → submit a numeric channel ID → audit row with `name=xp_announce_channel`.
- [ ] Level-up Channel → submit blank → audit row with new value `""`.
- [ ] Level-up Channel → submit `not-a-channel` → ephemeral error from validator; no audit row.
- [ ] After any successful change, send a chat message that earns XP → verify the new values take effect immediately (legacy composite cache was invalidated).

## CI status

Pending on push; monitored via the PR activity subscription.

## Rollback notes

Single commit. A revert restores:
- The four direct `db.set_setting` calls in `views/xp/modals.py`.
- The manual `invalidate_xp_config` calls.
- The `xp_announce_channel` SettingSpec is removed.
- The allowlist entry returns.
- All 11 new tests are dropped.

No data migration, no schema migration (SettingSpec lives in code only), no pipeline changes.

## Follow-up items

Plan PR #6 (Economy log-channel pipeline) is next. PRs #7–#9 continue: Settings selectors → Settings default-on → `/help` slash proof.

Out of scope (candidate follow-ups):
- Migrate the XP `on_message` hot path to `services.settings_resolution.resolve_setting` so the composite `_xp_config_accessor` cache + manual `invalidate_xp_config` calls can both go away.
- Resolve the SettingSpec/BindingSpec duality for `xp_announce_channel` by picking one canonical write path. The plan §5b flagged the same shape for `ECONOMY_LOG_CHANNEL`, which PR #6 will address — that decision should set the precedent.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KTjPVwXmAhK4c3RaG9Qod5)_