### PR TITLE
economy: migrate ECONOMY_LOG_CHANNEL writes to SettingsMutationPipeline

### DIFF
--- a/disbot/cogs/economy/schemas.py
+++ b/disbot/cogs/economy/schemas.py
@@ -19,8 +19,21 @@ from core.runtime.resource_specs import (
 from core.runtime.subsystem_schema import (
     BindingKind,
     BindingSpec,
+    SettingSpec,
     SubsystemSchema,
 )
+from utils.settings_keys import ECONOMY_LOG_CHANNEL
+
+
+def _validate_channel_id_or_empty(value: object) -> None:
+    """Empty string clears the log channel; otherwise a numeric ID."""
+    if not isinstance(value, str):
+        raise ValueError(f"expected str, got {type(value).__name__}")
+    if value and not value.isdigit():
+        raise ValueError(
+            "must be empty (to clear) or a numeric Discord channel ID",
+        )
+
 
 # ---------------------------------------------------------------------------
 # Phase 1a — Guild config schema
@@ -36,6 +49,25 @@ ECONOMY_BINDINGS: tuple[BindingSpec, ...] = (
             "are logged.  Leave unbound to suppress logging."
         ),
         capability_required="economy.settings.configure",
+    ),
+)
+
+ECONOMY_SETTINGS: tuple[SettingSpec, ...] = (
+    SettingSpec(
+        name="economy_log_channel",
+        value_type=str,
+        default="",
+        settings_key=ECONOMY_LOG_CHANNEL,
+        capability_required="economy.settings.configure",
+        hint=(
+            "Numeric Discord channel ID for the economy mutations log.  "
+            "Leave empty to suppress logging.  Mirrors the "
+            "``log_channel`` BindingSpec — reads go through the "
+            "binding/legacy arbitration ladder; PR #6 routes writes "
+            "through SettingsMutationPipeline so they land in the "
+            "settings_mutation_audit trail."
+        ),
+        validator=_validate_channel_id_or_empty,
     ),
 )
 
@@ -59,6 +91,7 @@ ECONOMY_RESOURCE_REQUIREMENTS: tuple[ResourceRequirement, ...] = (
 ECONOMY_CONFIG_SCHEMA = SubsystemSchema(
     subsystem="economy",
     bindings=ECONOMY_BINDINGS,
+    settings=ECONOMY_SETTINGS,
     resource_requirements=ECONOMY_RESOURCE_REQUIREMENTS,
     version=1,
 )

--- a/disbot/cogs/economy_cog.py
+++ b/disbot/cogs/economy_cog.py
@@ -89,6 +89,34 @@ class EconomyCog(commands.Cog):
         """Auto-create an economy-log channel when the bot joins a new guild."""
         await self._ensure_log_channel(guild)
 
+    async def _record_log_channel(
+        self,
+        guild: discord.Guild,
+        channel_id: str,
+        *,
+        actor: discord.Member | None,
+        actor_type: str = "user",
+    ) -> None:
+        """Persist the economy log channel via :class:`SettingsMutationPipeline`.
+
+        Used by both the system-triggered ``_ensure_log_channel`` path
+        (``on_ready`` / ``on_guild_join``, ``actor_type='system'``,
+        ``actor=None``) and the admin ``!setlogchannel`` command
+        (``actor_type='user'``, ``actor`` is the invoking member).
+        Either way the pipeline records the change in
+        ``settings_mutation_audit`` and invalidates the per-key cache.
+        """
+        from services.settings_mutation import SettingsMutationPipeline
+
+        await SettingsMutationPipeline().set_value(
+            guild,
+            "economy",
+            "economy_log_channel",
+            channel_id,
+            actor,
+            actor_type=actor_type,
+        )
+
     async def _ensure_log_channel(self, guild: discord.Guild) -> None:
         """Create #economy-log for *guild* if it doesn't already exist."""
         if await resources.resolve_settings_channel(guild, ECONOMY_LOG_CHANNEL):
@@ -96,7 +124,12 @@ class EconomyCog(commands.Cog):
 
         existing = resources.resolve_channel(guild, name="economy-log")
         if existing:
-            await db.set_setting(guild.id, ECONOMY_LOG_CHANNEL, str(existing.id))
+            await self._record_log_channel(
+                guild,
+                str(existing.id),
+                actor=None,
+                actor_type="system",
+            )
             return
 
         try:
@@ -121,7 +154,12 @@ class EconomyCog(commands.Cog):
                 category=cat,
                 topic="Live feed of XP level-ups, daily rewards, work earnings, and shop purchases.",
             )
-            await db.set_setting(guild.id, ECONOMY_LOG_CHANNEL, str(ch.id))
+            await self._record_log_channel(
+                guild,
+                str(ch.id),
+                actor=None,
+                actor_type="system",
+            )
             embed = discord.Embed(
                 title="📊 Economy Log",
                 description=(
@@ -279,7 +317,11 @@ class EconomyCog(commands.Cog):
     @commands.has_permissions(administrator=True)
     async def setlogchannel(self, ctx: commands.Context, channel: discord.TextChannel):
         """Set the economy log channel. Usage: !setlogchannel #channel"""
-        await db.set_setting(ctx.guild.id, ECONOMY_LOG_CHANNEL, str(channel.id))
+        await self._record_log_channel(
+            ctx.guild,
+            str(channel.id),
+            actor=ctx.author,
+        )
         await ctx.send(f"✅ Economy log channel set to {channel.mention}.")
 
     # ------------------------------------------------------------------ !joblist

--- a/disbot/cogs/economy_cog.py
+++ b/disbot/cogs/economy_cog.py
@@ -94,7 +94,7 @@ class EconomyCog(commands.Cog):
         guild: discord.Guild,
         channel_id: str,
         *,
-        actor: discord.Member | None,
+        actor: discord.Member | discord.User | None,
         actor_type: str = "user",
     ) -> None:
         """Persist the economy log channel via :class:`SettingsMutationPipeline`.

--- a/docs/settings-customization-command-map.md
+++ b/docs/settings-customization-command-map.md
@@ -203,8 +203,15 @@ Subsystems (22): `admin`, `moderation`, `economy`, `inventory`, `mining`,
 6. **help_menu_discoverable**: Yes.
 7. **dedicated_panel_command**: `none`.
 8. **help_menu_direct_navigation_hook**: `none`.
-9. **existing_SettingSpec_declarations**: none yet (daily/work cooldowns
-   pending promotion).
+9. **existing_SettingSpec_declarations**: `economy_log_channel`
+   (`disbot/cogs/economy/schemas.py`).  PR #6 promoted the log channel
+   to a SettingSpec so the cog's three direct ``db.set_setting`` writes
+   (``on_ready``, ``on_guild_join``, ``!setlogchannel``) route through
+   ``SettingsMutationPipeline`` and land in
+   ``settings_mutation_audit``.  The existing ``log_channel`` BindingSpec
+   (item 11) remains the canonical typed-resource declaration and is
+   read via the arbitration ladder.  Daily/work cooldowns pending
+   promotion.
 10. **existing_settings_keys**: `ECONOMY_LOG_CHANNEL`
     (`disbot/utils/settings_keys/economy.py`).
 11. **existing_BindingSpec_entries**: `log_channel`

--- a/tests/unit/cogs/test_economy_log_channel_pipeline.py
+++ b/tests/unit/cogs/test_economy_log_channel_pipeline.py
@@ -1,0 +1,206 @@
+"""Regression tests for PR #6 — economy_cog log-channel writes use the pipeline.
+
+Pre-PR-#6 ``cogs/economy_cog.py`` wrote ``ECONOMY_LOG_CHANNEL`` via
+``db.set_setting`` from three sites:
+
+* ``on_ready`` listener (``_ensure_log_channel`` → existing channel found)
+* ``on_guild_join`` listener (``_ensure_log_channel`` → newly created)
+* ``!setlogchannel`` admin command
+
+PR #6 routes all three through ``services.settings_mutation.
+SettingsMutationPipeline`` via the new ``_record_log_channel`` helper.
+System-triggered paths pass ``actor=None`` + ``actor_type='system'``;
+the admin command passes the invoking member.
+
+These tests pin the new contract by:
+
+* Asserting the cog module no longer references ``db.set_setting``.
+* Patching the pipeline class and verifying each call site invokes
+  it with the expected ``(subsystem, name, value, actor_type)`` shape.
+* Asserting the ``economy_log_channel`` SettingSpec is declared with
+  the empty-or-numeric validator.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+_COG_PATH = (
+    Path(__file__).resolve().parents[3] / "disbot" / "cogs" / "economy_cog.py"
+)
+
+
+# ---------------------------------------------------------------------------
+# AST-level: no db.set_setting references survive in the cog
+# ---------------------------------------------------------------------------
+
+
+def test_economy_cog_does_not_reference_db_set_setting():
+    """``cogs/economy_cog.py`` is removed from the no-direct-writes
+    allowlist in PR #6; the AST scan now enforces it.
+    """
+    source = _COG_PATH.read_text()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and node.attr == "set_setting":
+            raise AssertionError(
+                f"cogs/economy_cog.py still references set_setting at line "
+                f"{node.lineno}",
+            )
+
+
+def test_economy_cog_exports_record_helper():
+    cog_module = importlib.import_module("cogs.economy_cog")
+    klass = cog_module.EconomyCog
+    assert hasattr(klass, "_record_log_channel")
+
+
+# ---------------------------------------------------------------------------
+# Helper-level: _record_log_channel hits the pipeline with the right shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_record_log_channel_uses_pipeline_for_admin_writes():
+    from cogs.economy_cog import EconomyCog
+
+    cog = EconomyCog(MagicMock())
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 99
+    actor = MagicMock(spec=discord.Member)
+    actor.id = 7
+
+    pipeline_instance = MagicMock()
+    pipeline_instance.set_value = AsyncMock(return_value=MagicMock())
+
+    with patch(
+        "services.settings_mutation.SettingsMutationPipeline",
+        return_value=pipeline_instance,
+    ):
+        await cog._record_log_channel(guild, "1234567890", actor=actor)
+
+    pipeline_instance.set_value.assert_awaited_once_with(
+        guild,
+        "economy",
+        "economy_log_channel",
+        "1234567890",
+        actor,
+        actor_type="user",
+    )
+
+
+@pytest.mark.asyncio
+async def test_record_log_channel_uses_system_actor_type_for_listeners():
+    """The two listener-triggered paths (on_ready / on_guild_join via
+    ``_ensure_log_channel``) call ``_record_log_channel`` with
+    ``actor=None`` + ``actor_type='system'`` so the pipeline's
+    administrator-tier check is bypassed via the system bucket.
+    """
+    from cogs.economy_cog import EconomyCog
+
+    cog = EconomyCog(MagicMock())
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 99
+
+    pipeline_instance = MagicMock()
+    pipeline_instance.set_value = AsyncMock(return_value=MagicMock())
+
+    with patch(
+        "services.settings_mutation.SettingsMutationPipeline",
+        return_value=pipeline_instance,
+    ):
+        await cog._record_log_channel(
+            guild,
+            "555",
+            actor=None,
+            actor_type="system",
+        )
+
+    pipeline_instance.set_value.assert_awaited_once_with(
+        guild,
+        "economy",
+        "economy_log_channel",
+        "555",
+        None,
+        actor_type="system",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Listener path: _ensure_log_channel routes existing-channel pickup through
+# the pipeline
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ensure_log_channel_existing_routes_through_pipeline():
+    """When ``resources.resolve_channel`` finds an existing
+    #economy-log, ``_ensure_log_channel`` records its id via the
+    pipeline (not ``db.set_setting``).
+    """
+    from cogs import economy_cog
+
+    cog = economy_cog.EconomyCog(MagicMock())
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 42
+
+    existing = MagicMock()
+    existing.id = 12345
+
+    pipeline_instance = MagicMock()
+    pipeline_instance.set_value = AsyncMock(return_value=MagicMock())
+
+    with patch.object(
+        economy_cog.resources,
+        "resolve_settings_channel",
+        new=AsyncMock(return_value=None),
+    ), patch.object(
+        economy_cog.resources,
+        "resolve_channel",
+        return_value=existing,
+    ), patch(
+        "services.settings_mutation.SettingsMutationPipeline",
+        return_value=pipeline_instance,
+    ):
+        await cog._ensure_log_channel(guild)
+
+    pipeline_instance.set_value.assert_awaited_once()
+    call = pipeline_instance.set_value.await_args
+    assert call.args[1:4] == ("economy", "economy_log_channel", "12345")
+    assert call.kwargs.get("actor_type") == "system"
+
+
+# ---------------------------------------------------------------------------
+# SettingSpec presence (PR #6 schema addition)
+# ---------------------------------------------------------------------------
+
+
+def test_economy_log_channel_settingspec_declared():
+    """PR #6 added ``economy_log_channel`` to ``ECONOMY_SETTINGS`` so the
+    pipeline accepts writes for it.  Pin the spec shape and validator.
+    """
+    from cogs.economy.schemas import ECONOMY_SETTINGS
+
+    by_name = {spec.name: spec for spec in ECONOMY_SETTINGS}
+    assert "economy_log_channel" in by_name, (
+        "economy_log_channel must be declared as a SettingSpec — "
+        "PR #6 promoted it from a direct-write to a pipeline-managed "
+        "scalar."
+    )
+    spec = by_name["economy_log_channel"]
+    assert spec.value_type is str
+    assert spec.default == ""
+    assert spec.validator is not None
+    # Empty is allowed (clears the channel).
+    spec.validator("")
+    # Numeric IDs are allowed.
+    spec.validator("1234567890")
+    # Non-numeric non-empty is rejected.
+    with pytest.raises(ValueError):
+        spec.validator("not-a-channel")

--- a/tests/unit/invariants/test_no_direct_settings_keys_writes.py
+++ b/tests/unit/invariants/test_no_direct_settings_keys_writes.py
@@ -58,7 +58,8 @@ _ALLOWED_PATHS = {
     # ("settings/<subsystem>") that will route the call through the
     # pipeline and remove the entry.
     _DISBOT / "cogs" / "blackjack_cog.py",        # ACTIVE_TOURNAMENT writes
-    _DISBOT / "cogs" / "economy_cog.py",          # ECONOMY_LOG_CHANNEL writes
+    # ``cogs/economy_cog.py`` migrated to SettingsMutationPipeline in PR #6
+    # — removed from the allowlist (the AST scan now enforces it).
     _DISBOT / "cogs" / "rps_tournament_cog.py",   # ACTIVE_TOURNAMENT writes
     _DISBOT / "cogs" / "rps_tournament" / "_helpers.py",  # ACTIVE_TOURNAMENT
     _DISBOT / "governance" / "writes.py",         # internal governance writes


### PR DESCRIPTION
## Summary

Routes the three `ECONOMY_LOG_CHANNEL` writes (two listener-triggered, one admin command) through `SettingsMutationPipeline` so each lands an audit row + cache invalidation + event. Plan PR #6.

## Files changed

| File | Role |
|---|---|
| `disbot/cogs/economy/schemas.py` | New `ECONOMY_SETTINGS` tuple with one `SettingSpec` for `economy_log_channel`; same empty-or-numeric validator shape as PR #5's `xp_announce_channel` |
| `disbot/cogs/economy_cog.py` | New `EconomyCog._record_log_channel` helper; `_ensure_log_channel` (×2 sites) and `setlogchannel` (×1) call it; legacy `db.set_setting` calls removed |
| `tests/unit/invariants/test_no_direct_settings_keys_writes.py` | Remove `cogs/economy_cog.py` from the allowlist; AST scan now enforces it |
| `tests/unit/cogs/test_economy_log_channel_pipeline.py` | New — 6 tests pin AST cleanliness, helper contract (user + system actor_types), the existing-channel listener path, and SettingSpec presence + validator |
| `docs/settings-customization-command-map.md` | Update economy `existing_SettingSpec_declarations` from "none yet" to the new declaration with the PR #6 note |

## Architecture choice — SettingsMutationPipeline over BindingMutationPipeline

The plan called this out as a binding-vs-setting decision. Chose `SettingsMutationPipeline` because two of the three call sites (`on_ready` and `on_guild_join` via `_ensure_log_channel`) run from event listeners with no invoking member. The settings pipeline supports `actor_type='system'`; `BindingMutationPipeline._validate_authority` requires an administrator-tier actor with no system-actor escape hatch.

Reads already arbitrate via `get_economy_log_channel` between the bindings table (where `binding_backfill` migrates legacy values) and the legacy KV — so the writes-to-KV / reads-from-arbitration model remains coherent. The `log_channel` BindingSpec stays as the typed-resource declaration; the new SettingSpec drives the write path. Same shape PR #5 documented for `xp_announce_channel`, with the same fold-or-collapse follow-up note.

## Test plan

- Full suite: **2379 passed** (was 2373 pre-PR; +6 new PR #6 tests).
- New tests cover: AST cleanliness, helper invocation shape for both `user` and `system` actor types, the existing-channel listener path explicitly, and SettingSpec/validator behaviour.
- CI gates locally: `black --check`, `isort --check-only`, `ruff check`, `mypy disbot/`, `pytest tests/` — all clean.

## Manual Discord smoke plan

- [ ] `!setlogchannel #some-channel` as admin → ✅ confirmation; check `settings_mutation_audit` for a new row with subsystem=economy, name=economy_log_channel, actor_type=user, actor_id=<admin>.
- [ ] Send any economy action (e.g. `!daily`) → log embed posts to the new channel (the existing `post_log_embed` read path uses `get_economy_log_channel` which arbitrates correctly).
- [ ] Restart bot in a guild that doesn't have #economy-log → `on_ready` triggers `_ensure_log_channel` → channel created → audit row with actor_type=system, actor_id=NULL.
- [ ] Add bot to a new test guild → `on_guild_join` triggers `_ensure_log_channel` → audit row with actor_type=system.
- [ ] `!setlogchannel` without admin permission → ephemeral / silent denial (the `@has_permissions(administrator=True)` check fires before the pipeline call).

## CI status

Pending on push; monitored via the PR activity subscription.

## Rollback notes

Single commit. A revert restores:
- The three direct `db.set_setting` calls.
- The `ECONOMY_SETTINGS` tuple in `schemas.py` is removed.
- The allowlist entry returns.
- The 6 new tests are dropped.

No data migration, no schema migration (SettingSpec lives in code only).

## Follow-up items

Plan PR #7 (settings: numeric presets + channel/role selectors) is next, followed by #8 (settings default-on) and #9 (`/help` slash proof).

Out of scope (candidate follow-ups):
- Fold both `_ensure_log_channel` writes plus `!setlogchannel` through `ResourceProvisioningPipeline` (S4.5) which composes `set_binding` with the resource lookup. Would make this SettingSpec redundant. Same decision needed for `xp_announce_channel`.
- Extend `BindingMutationPipeline` to accept `actor_type='system'` so listener-triggered binding writes have a canonical path. Currently every listener-triggered binding write must use SettingsMutationPipeline.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KTjPVwXmAhK4c3RaG9Qod5)_