### PR TITLE
settings: numeric presets + channel/role selectors

### DIFF
--- a/disbot/cogs/economy/schemas.py
+++ b/disbot/cogs/economy/schemas.py
@@ -68,6 +68,10 @@ ECONOMY_SETTINGS: tuple[SettingSpec, ...] = (
             "settings_mutation_audit trail."
         ),
         validator=_validate_channel_id_or_empty,
+        # PR #7 — opt in to the native channel select.  Operators
+        # pick the channel from Discord's UI instead of pasting a
+        # numeric ID into a text modal.
+        input_hint="channel",
     ),
 )
 

--- a/disbot/cogs/xp/schemas.py
+++ b/disbot/cogs/xp/schemas.py
@@ -108,6 +108,12 @@ XP_SETTINGS: tuple[SettingSpec, ...] = (
             "cooldown (not recommended in active guilds)."
         ),
         validator=_validate_cooldown,
+        # PR #7 — Settings edit dispatcher picks the preset row when
+        # the hint is "numeric_presets" and ``presets`` is non-empty.
+        # Operators still get the free-form modal via the "Override…"
+        # button so values outside the preset set remain reachable.
+        input_hint="numeric_presets",
+        presets=(0, 15, 30, 60, 120, 300),
     ),
     SettingSpec(
         name="xp_announce_channel",
@@ -121,6 +127,12 @@ XP_SETTINGS: tuple[SettingSpec, ...] = (
             "happened."
         ),
         validator=_validate_channel_id_or_empty,
+        # PR #7 — opt in to the native channel select.  The Settings
+        # edit dispatcher renders a discord.ui.ChannelSelect; the
+        # legacy text-modal fallback is still reachable when the spec
+        # is mutated programmatically (the SettingSpec.value_type is
+        # still str so the pipeline accepts either shape).
+        input_hint="channel",
     ),
 )
 

--- a/disbot/core/runtime/subsystem_schema.py
+++ b/disbot/core/runtime/subsystem_schema.py
@@ -142,6 +142,29 @@ class SettingSpec:
         strictness ``"off"``/``"light"``/``"normal"``/``"strict"``).
         Empty tuple (default) preserves backward compatibility — the
         widget is a free-form modal text input.
+    input_hint:
+        Optional dispatch hint that overrides ``value_type`` /
+        ``allowed_values`` routing in the S6/S7 edit dispatcher.
+        Recognised values (PR #7):
+
+        * ``""`` (default) — use the ``value_type`` / ``allowed_values``
+          rules: bool→toggle, str+allowed_values→enum select,
+          int/float→free-form modal, str→free-form modal.
+        * ``"channel"`` — render a Discord channel select (numeric
+          channel ID writes through the pipeline as a string).
+        * ``"role"`` — render a Discord role select (numeric role ID
+          writes through the pipeline as a string).
+        * ``"numeric_presets"`` — render a preset button row backed by
+          :attr:`presets`, with an override modal for custom values.
+
+        Unrecognised hints fall through to the default routing so
+        new hints can be added without coordinating every dispatcher
+        update.
+    presets:
+        Suggested values for the ``"numeric_presets"`` input mode.
+        Each entry becomes a button labelled with its value.  Empty
+        tuple (default) means "no presets — use the free-form modal
+        only", which is the previous int/float behaviour.
     """
 
     name: str
@@ -152,6 +175,8 @@ class SettingSpec:
     hint: str = ""
     validator: Callable[[Any], None] | None = None
     allowed_values: tuple[Any, ...] = ()
+    input_hint: str = ""
+    presets: tuple[Any, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/disbot/views/settings/edit_channel.py
+++ b/disbot/views/settings/edit_channel.py
@@ -1,0 +1,185 @@
+"""ChannelSettingSelectView — S7 edit widget for channel-typed settings.
+
+Dispatched when a ``SettingSpec`` declares ``input_hint="channel"``.
+The setting's value_type is ``str`` and the underlying value is the
+numeric Discord channel ID (or ``""`` to clear).  The widget renders
+a native :class:`discord.ui.ChannelSelect` so the operator picks a
+channel by name instead of typing an ID.
+
+Mutation path mirrors :class:`views.settings.edit_enum.EnumSettingSelectView`:
+
+  1. Operator picks a setting in the SubsystemSettingsView's edit
+     dropdown.
+  2. The dispatcher sees ``SettingSpec.input_hint == "channel"`` and
+     replies with an ephemeral message that hosts a
+     :class:`ChannelSettingSelectView`.
+  3. Operator picks the channel from the native channel select OR
+     clicks the "Clear" button to remove the binding.
+  4. The callback writes through
+     :class:`services.settings_mutation.SettingsMutationPipeline` and
+     confirms ephemerally.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+logger = logging.getLogger("bot.views.settings.edit_channel")
+
+
+async def _write_channel_value(
+    interaction: discord.Interaction,
+    subsystem: str,
+    setting_name: str,
+    new_value: str,
+    parent_message: discord.Message | None,
+) -> None:
+    """Shared write path for select + clear callbacks."""
+    from services.settings_mutation import (
+        SettingsMutationError,
+        SettingsMutationPipeline,
+    )
+
+    guild = interaction.guild
+    if guild is None:
+        await interaction.response.send_message(
+            "❌ Edit requires a guild context.",
+            ephemeral=True,
+        )
+        return
+    try:
+        result = await SettingsMutationPipeline().set_value(
+            guild,
+            subsystem,
+            setting_name,
+            new_value,
+            interaction.user,
+        )
+    except SettingsMutationError as exc:
+        await interaction.response.send_message(
+            f"❌ {type(exc).__name__}: {exc}",
+            ephemeral=True,
+        )
+        return
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.exception(
+            "ChannelSettingSelect: pipeline raised for %s.%s",
+            subsystem,
+            setting_name,
+        )
+        await interaction.response.send_message(
+            f"❌ Unexpected error: {type(exc).__name__}: {exc}",
+            ephemeral=True,
+        )
+        return
+
+    if new_value:
+        await interaction.response.send_message(
+            f"✅ Updated `{subsystem}.{setting_name}` = <#{new_value}> "
+            f"(was `{result.old_value!r}`).",
+            ephemeral=True,
+        )
+    else:
+        await interaction.response.send_message(
+            f"✅ Cleared `{subsystem}.{setting_name}` "
+            f"(was `{result.old_value!r}`).",
+            ephemeral=True,
+        )
+    await _refresh_parent(interaction, subsystem, parent_message)
+
+
+class _ChannelPickSelect(discord.ui.ChannelSelect):
+    """Native channel select restricted to text-channel kinds."""
+
+    def __init__(
+        self,
+        subsystem: str,
+        setting_name: str,
+        parent_message: discord.Message | None,
+    ) -> None:
+        super().__init__(
+            placeholder="Pick a channel…",
+            channel_types=[discord.ChannelType.text],
+            min_values=1,
+            max_values=1,
+            row=0,
+        )
+        self.subsystem = subsystem
+        self.setting_name = setting_name
+        self.parent_message = parent_message
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        picked = self.values[0]
+        await _write_channel_value(
+            interaction,
+            self.subsystem,
+            self.setting_name,
+            str(picked.id),
+            self.parent_message,
+        )
+
+
+class _ClearChannelButton(discord.ui.Button):
+    """Clear the channel binding by writing the empty string."""
+
+    def __init__(
+        self,
+        subsystem: str,
+        setting_name: str,
+        parent_message: discord.Message | None,
+    ) -> None:
+        super().__init__(
+            label="Clear",
+            style=discord.ButtonStyle.secondary,
+            row=1,
+        )
+        self.subsystem = subsystem
+        self.setting_name = setting_name
+        self.parent_message = parent_message
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await _write_channel_value(
+            interaction,
+            self.subsystem,
+            self.setting_name,
+            "",
+            self.parent_message,
+        )
+
+
+class ChannelSettingSelectView(discord.ui.View):
+    """Ephemeral follow-up view hosting the channel select + clear button."""
+
+    def __init__(
+        self,
+        subsystem: str,
+        setting_name: str,
+        parent_message: discord.Message | None = None,
+    ) -> None:
+        super().__init__(timeout=180)
+        self.add_item(_ChannelPickSelect(subsystem, setting_name, parent_message))
+        self.add_item(_ClearChannelButton(subsystem, setting_name, parent_message))
+
+
+async def _refresh_parent(
+    interaction: discord.Interaction,
+    subsystem: str,
+    parent_message: discord.Message | None,
+) -> None:
+    if parent_message is None:
+        return
+    try:
+        from views.settings.subsystem_view import build_subsystem_embed
+
+        embed = await build_subsystem_embed(interaction, subsystem)
+        await parent_message.edit(embed=embed)
+    except Exception as exc:  # noqa: BLE001 — soft-fail
+        logger.debug(
+            "ChannelSettingSelect: parent-message refresh failed: %s",
+            exc,
+        )
+
+
+__all__ = ["ChannelSettingSelectView"]

--- a/disbot/views/settings/edit_number_presets.py
+++ b/disbot/views/settings/edit_number_presets.py
@@ -1,0 +1,238 @@
+"""NumericPresetsView — S7 edit widget for int/float settings with presets.
+
+Dispatched when a ``SettingSpec`` declares
+``input_hint="numeric_presets"``.  The spec's ``presets`` tuple lists
+suggested values; the widget renders one button per preset plus an
+"Override…" button that opens the existing free-form modal so the
+operator can still type a custom value.
+
+Mirrors the channel/role widgets' write path — each preset button
+calls :class:`services.settings_mutation.SettingsMutationPipeline`
+with the preset value, then reports success/failure ephemerally.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+logger = logging.getLogger("bot.views.settings.edit_number_presets")
+
+
+async def _write_preset_value(
+    interaction: discord.Interaction,
+    subsystem: str,
+    setting_name: str,
+    value: object,
+    parent_message: discord.Message | None,
+) -> None:
+    """Shared write path for every preset button."""
+    from services.settings_mutation import (
+        SettingsMutationError,
+        SettingsMutationPipeline,
+    )
+
+    guild = interaction.guild
+    if guild is None:
+        await interaction.response.send_message(
+            "❌ Edit requires a guild context.",
+            ephemeral=True,
+        )
+        return
+    try:
+        result = await SettingsMutationPipeline().set_value(
+            guild,
+            subsystem,
+            setting_name,
+            value,
+            interaction.user,
+        )
+    except SettingsMutationError as exc:
+        await interaction.response.send_message(
+            f"❌ {type(exc).__name__}: {exc}",
+            ephemeral=True,
+        )
+        return
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.exception(
+            "NumericPresets: pipeline raised for %s.%s",
+            subsystem,
+            setting_name,
+        )
+        await interaction.response.send_message(
+            f"❌ Unexpected error: {type(exc).__name__}: {exc}",
+            ephemeral=True,
+        )
+        return
+
+    await interaction.response.send_message(
+        f"✅ Updated `{subsystem}.{setting_name}` = `{result.new_value!r}` "
+        f"(was `{result.old_value!r}`).",
+        ephemeral=True,
+    )
+    await _refresh_parent(interaction, subsystem, parent_message)
+
+
+class _PresetButton(discord.ui.Button):
+    """One button per preset value."""
+
+    def __init__(
+        self,
+        subsystem: str,
+        setting_name: str,
+        value: object,
+        parent_message: discord.Message | None,
+        is_current: bool,
+        row: int,
+    ) -> None:
+        # Discord button labels are bounded; coerce + truncate.
+        label = str(value)[:80] or "(unset)"
+        super().__init__(
+            label=label,
+            # Highlight the current value in primary; rest stay secondary.
+            style=(
+                discord.ButtonStyle.primary
+                if is_current
+                else discord.ButtonStyle.secondary
+            ),
+            row=row,
+        )
+        self.subsystem = subsystem
+        self.setting_name = setting_name
+        self.value = value
+        self.parent_message = parent_message
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await _write_preset_value(
+            interaction,
+            self.subsystem,
+            self.setting_name,
+            self.value,
+            self.parent_message,
+        )
+
+
+class _OverrideButton(discord.ui.Button):
+    """Opens the free-form ``NumberSettingModal`` for a custom value."""
+
+    def __init__(
+        self,
+        subsystem: str,
+        setting_name: str,
+        value_type: type,
+        current_value: object,
+        default_value: object,
+        parent_message: discord.Message | None,
+        row: int,
+    ) -> None:
+        super().__init__(
+            label="Override…",
+            style=discord.ButtonStyle.grey,
+            row=row,
+        )
+        self.subsystem = subsystem
+        self.setting_name = setting_name
+        self.value_type = value_type
+        self.current_value = current_value
+        self.default_value = default_value
+        self.parent_message = parent_message
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        # Reuse the existing free-form numeric modal.
+        from views.settings.edit_number import NumberSettingModal
+
+        modal = NumberSettingModal(
+            self.subsystem,
+            self.setting_name,
+            self.value_type,
+            self.current_value,
+            self.default_value,
+            self.parent_message,
+        )
+        await interaction.response.send_modal(modal)
+
+
+class NumericPresetsView(discord.ui.View):
+    """Ephemeral follow-up view: preset buttons + override.
+
+    Presets render two-per-row up to four rows (Discord's component
+    limit is 5 rows of 5 buttons, and the override button takes one
+    slot).  When the spec declares more presets than fit, the surplus
+    is dropped with a WARNING — the override button is always
+    available so no value is unreachable.
+    """
+
+    _MAX_PRESET_BUTTONS = 19  # 4 rows × 5 = 20 buttons; reserve one for override
+    _BUTTONS_PER_ROW = 5
+
+    def __init__(
+        self,
+        subsystem: str,
+        setting_name: str,
+        value_type: type,
+        current_value: object,
+        default_value: object,
+        presets: tuple,
+        parent_message: discord.Message | None = None,
+    ) -> None:
+        super().__init__(timeout=180)
+        bounded = list(presets)
+        if len(bounded) > self._MAX_PRESET_BUTTONS:
+            logger.warning(
+                "NumericPresets: %s.%s declares %d presets — only the "
+                "first %d render; remaining values reachable via Override.",
+                subsystem,
+                setting_name,
+                len(bounded),
+                self._MAX_PRESET_BUTTONS,
+            )
+            bounded = bounded[: self._MAX_PRESET_BUTTONS]
+        for idx, preset in enumerate(bounded):
+            self.add_item(
+                _PresetButton(
+                    subsystem=subsystem,
+                    setting_name=setting_name,
+                    value=preset,
+                    parent_message=parent_message,
+                    is_current=preset == current_value,
+                    row=idx // self._BUTTONS_PER_ROW,
+                ),
+            )
+        # Override sits below the preset rows.
+        override_row = (len(bounded) - 1) // self._BUTTONS_PER_ROW + 1 if bounded else 0
+        # Cap at row 4 — Discord's last row.
+        override_row = min(override_row, 4)
+        self.add_item(
+            _OverrideButton(
+                subsystem=subsystem,
+                setting_name=setting_name,
+                value_type=value_type,
+                current_value=current_value,
+                default_value=default_value,
+                parent_message=parent_message,
+                row=override_row,
+            ),
+        )
+
+
+async def _refresh_parent(
+    interaction: discord.Interaction,
+    subsystem: str,
+    parent_message: discord.Message | None,
+) -> None:
+    if parent_message is None:
+        return
+    try:
+        from views.settings.subsystem_view import build_subsystem_embed
+
+        embed = await build_subsystem_embed(interaction, subsystem)
+        await parent_message.edit(embed=embed)
+    except Exception as exc:  # noqa: BLE001 — soft-fail
+        logger.debug(
+            "NumericPresets: parent-message refresh failed: %s",
+            exc,
+        )
+
+
+__all__ = ["NumericPresetsView"]

--- a/disbot/views/settings/edit_role.py
+++ b/disbot/views/settings/edit_role.py
@@ -1,0 +1,183 @@
+"""RoleSettingSelectView — S7 edit widget for role-typed settings.
+
+Dispatched when a ``SettingSpec`` declares ``input_hint="role"``.
+The setting's value_type is ``str`` and the underlying value is the
+numeric Discord role ID (or ``""`` to clear).  The widget renders a
+native :class:`discord.ui.RoleSelect` so the operator picks a role
+by name instead of typing an ID.
+
+Mirrors the channel-select widget's flow:
+
+  1. Operator picks a setting in the SubsystemSettingsView's edit
+     dropdown.
+  2. The dispatcher sees ``SettingSpec.input_hint == "role"`` and
+     replies with an ephemeral message hosting a
+     :class:`RoleSettingSelectView`.
+  3. Operator picks the role from the native role select OR clicks
+     "Clear" to remove the binding.
+  4. The callback writes through
+     :class:`services.settings_mutation.SettingsMutationPipeline`.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+logger = logging.getLogger("bot.views.settings.edit_role")
+
+
+async def _write_role_value(
+    interaction: discord.Interaction,
+    subsystem: str,
+    setting_name: str,
+    new_value: str,
+    parent_message: discord.Message | None,
+) -> None:
+    """Shared write path for select + clear callbacks."""
+    from services.settings_mutation import (
+        SettingsMutationError,
+        SettingsMutationPipeline,
+    )
+
+    guild = interaction.guild
+    if guild is None:
+        await interaction.response.send_message(
+            "❌ Edit requires a guild context.",
+            ephemeral=True,
+        )
+        return
+    try:
+        result = await SettingsMutationPipeline().set_value(
+            guild,
+            subsystem,
+            setting_name,
+            new_value,
+            interaction.user,
+        )
+    except SettingsMutationError as exc:
+        await interaction.response.send_message(
+            f"❌ {type(exc).__name__}: {exc}",
+            ephemeral=True,
+        )
+        return
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.exception(
+            "RoleSettingSelect: pipeline raised for %s.%s",
+            subsystem,
+            setting_name,
+        )
+        await interaction.response.send_message(
+            f"❌ Unexpected error: {type(exc).__name__}: {exc}",
+            ephemeral=True,
+        )
+        return
+
+    if new_value:
+        await interaction.response.send_message(
+            f"✅ Updated `{subsystem}.{setting_name}` = <@&{new_value}> "
+            f"(was `{result.old_value!r}`).",
+            ephemeral=True,
+        )
+    else:
+        await interaction.response.send_message(
+            f"✅ Cleared `{subsystem}.{setting_name}` "
+            f"(was `{result.old_value!r}`).",
+            ephemeral=True,
+        )
+    await _refresh_parent(interaction, subsystem, parent_message)
+
+
+class _RolePickSelect(discord.ui.RoleSelect):
+    """Native role select."""
+
+    def __init__(
+        self,
+        subsystem: str,
+        setting_name: str,
+        parent_message: discord.Message | None,
+    ) -> None:
+        super().__init__(
+            placeholder="Pick a role…",
+            min_values=1,
+            max_values=1,
+            row=0,
+        )
+        self.subsystem = subsystem
+        self.setting_name = setting_name
+        self.parent_message = parent_message
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        picked = self.values[0]
+        await _write_role_value(
+            interaction,
+            self.subsystem,
+            self.setting_name,
+            str(picked.id),
+            self.parent_message,
+        )
+
+
+class _ClearRoleButton(discord.ui.Button):
+    """Clear the role binding by writing the empty string."""
+
+    def __init__(
+        self,
+        subsystem: str,
+        setting_name: str,
+        parent_message: discord.Message | None,
+    ) -> None:
+        super().__init__(
+            label="Clear",
+            style=discord.ButtonStyle.secondary,
+            row=1,
+        )
+        self.subsystem = subsystem
+        self.setting_name = setting_name
+        self.parent_message = parent_message
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await _write_role_value(
+            interaction,
+            self.subsystem,
+            self.setting_name,
+            "",
+            self.parent_message,
+        )
+
+
+class RoleSettingSelectView(discord.ui.View):
+    """Ephemeral follow-up view hosting the role select + clear button."""
+
+    def __init__(
+        self,
+        subsystem: str,
+        setting_name: str,
+        parent_message: discord.Message | None = None,
+    ) -> None:
+        super().__init__(timeout=180)
+        self.add_item(_RolePickSelect(subsystem, setting_name, parent_message))
+        self.add_item(_ClearRoleButton(subsystem, setting_name, parent_message))
+
+
+async def _refresh_parent(
+    interaction: discord.Interaction,
+    subsystem: str,
+    parent_message: discord.Message | None,
+) -> None:
+    if parent_message is None:
+        return
+    try:
+        from views.settings.subsystem_view import build_subsystem_embed
+
+        embed = await build_subsystem_embed(interaction, subsystem)
+        await parent_message.edit(embed=embed)
+    except Exception as exc:  # noqa: BLE001 — soft-fail
+        logger.debug(
+            "RoleSettingSelect: parent-message refresh failed: %s",
+            exc,
+        )
+
+
+__all__ = ["RoleSettingSelectView"]

--- a/disbot/views/settings/subsystem_view.py
+++ b/disbot/views/settings/subsystem_view.py
@@ -445,7 +445,53 @@ class _EditSettingSelect(discord.ui.Select):
 
         parent_msg = interaction.message
 
-        # Dispatch by value_type and allowed_values shape.
+        # Dispatch by explicit input_hint first (PR #7); fall through
+        # to the value_type / allowed_values rules so settings that
+        # don't opt into the new modes keep their existing widget.
+        hint = (spec.input_hint or "").strip().lower()
+        if hint == "channel":
+            from views.settings.edit_channel import ChannelSettingSelectView
+
+            view = ChannelSettingSelectView(self.subsystem, name, parent_msg)
+            await interaction.response.send_message(
+                f"Pick a channel for `{self.subsystem}.{name}` "
+                f"(current=`{current!r}`):",
+                view=view,
+                ephemeral=True,
+            )
+            return
+        if hint == "role":
+            from views.settings.edit_role import RoleSettingSelectView
+
+            view = RoleSettingSelectView(self.subsystem, name, parent_msg)
+            await interaction.response.send_message(
+                f"Pick a role for `{self.subsystem}.{name}` "
+                f"(current=`{current!r}`):",
+                view=view,
+                ephemeral=True,
+            )
+            return
+        if hint == "numeric_presets" and spec.presets:
+            from views.settings.edit_number_presets import NumericPresetsView
+
+            view = NumericPresetsView(
+                subsystem=self.subsystem,
+                setting_name=name,
+                value_type=spec.value_type,
+                current_value=current,
+                default_value=spec.default,
+                presets=spec.presets,
+                parent_message=parent_msg,
+            )
+            await interaction.response.send_message(
+                f"Pick a value for `{self.subsystem}.{name}` "
+                f"(current=`{current!r}`, default=`{spec.default!r}`):",
+                view=view,
+                ephemeral=True,
+            )
+            return
+
+        # Default routing — unchanged from S6.
         if spec.value_type is bool:
             from views.settings.edit_boolean import toggle_setting
 

--- a/tests/unit/invariants/test_settings_cog_read_only.py
+++ b/tests/unit/invariants/test_settings_cog_read_only.py
@@ -107,6 +107,13 @@ _ALLOWED_EDIT_FILES: frozenset[Path] = frozenset(
         _DISBOT / "views" / "settings" / "edit_text.py",
         _DISBOT / "views" / "settings" / "edit_enum.py",
         _DISBOT / "views" / "settings" / "reset_button.py",
+        # PR #7 — channel / role native selects + numeric presets.
+        # Each calls SettingsMutationPipeline like the S6 widgets;
+        # routing decision lives in subsystem_view.py via the new
+        # SettingSpec.input_hint field.
+        _DISBOT / "views" / "settings" / "edit_channel.py",
+        _DISBOT / "views" / "settings" / "edit_role.py",
+        _DISBOT / "views" / "settings" / "edit_number_presets.py",
     },
 )
 
@@ -227,6 +234,10 @@ def test_settings_ui_paths_contain_expected_files():
         Path("disbot/views/settings/edit_text.py"),
         Path("disbot/views/settings/edit_enum.py"),
         Path("disbot/views/settings/reset_button.py"),
+        # PR #7 — channel/role native selects + numeric presets:
+        Path("disbot/views/settings/edit_channel.py"),
+        Path("disbot/views/settings/edit_role.py"),
+        Path("disbot/views/settings/edit_number_presets.py"),
     }
     missing = expected_relpaths - paths
     assert (

--- a/tests/unit/views/test_settings_edit_safety.py
+++ b/tests/unit/views/test_settings_edit_safety.py
@@ -351,8 +351,8 @@ def test_s5_base_files_exist_on_this_branch():
 
 
 def test_s6_invariant_allowlist_only_contains_edit_files():
-    """The S5 read-only invariant lifted in S6 must allowlist exactly
-    the five edit-flow files (and nothing else).  Catches a future
+    """The S5 read-only invariant lifted in S6 (and extended in PR #7)
+    must allowlist exactly the edit-flow files.  Catches a future
     drive-by edit that allowlists the hub or audit view by mistake.
     """
     from tests.unit.invariants.test_settings_cog_read_only import (
@@ -361,9 +361,14 @@ def test_s6_invariant_allowlist_only_contains_edit_files():
 
     names = {p.name for p in _ALLOWED_EDIT_FILES}
     assert names == {
+        # S6 — scalar edit / reset flows.
         "edit_boolean.py",
         "edit_number.py",
         "edit_text.py",
         "edit_enum.py",
         "reset_button.py",
+        # PR #7 — native selects + numeric presets.
+        "edit_channel.py",
+        "edit_role.py",
+        "edit_number_presets.py",
     }

--- a/tests/unit/views/test_settings_input_hint_dispatch.py
+++ b/tests/unit/views/test_settings_input_hint_dispatch.py
@@ -1,0 +1,289 @@
+"""PR #7 — tests for input_hint-based dispatch and the three new widgets.
+
+The dispatcher in ``views.settings.subsystem_view._EditSettingSelect``
+gained three new branches keyed off ``SettingSpec.input_hint``:
+
+* ``"channel"`` → ``ChannelSettingSelectView``
+* ``"role"`` → ``RoleSettingSelectView``
+* ``"numeric_presets"`` (with non-empty ``presets``) →
+  ``NumericPresetsView``
+
+Settings without ``input_hint`` keep their S6 widget. Tests below pin
+each branch + the SettingSpec field shapes.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from core.runtime.subsystem_schema import SettingSpec
+from views.settings.edit_channel import ChannelSettingSelectView
+from views.settings.edit_number_presets import NumericPresetsView
+from views.settings.edit_role import RoleSettingSelectView
+from views.settings.subsystem_view import _EditSettingSelect
+
+# ---------------------------------------------------------------------------
+# SettingSpec carries the new fields with safe defaults
+# ---------------------------------------------------------------------------
+
+
+def test_setting_spec_defaults_are_backward_compatible():
+    spec = SettingSpec(name="dummy", value_type=int, default=0)
+    assert spec.input_hint == ""
+    assert spec.presets == ()
+
+
+def test_setting_spec_accepts_input_hint_and_presets():
+    spec = SettingSpec(
+        name="dummy",
+        value_type=int,
+        default=60,
+        input_hint="numeric_presets",
+        presets=(0, 30, 60, 120),
+    )
+    assert spec.input_hint == "numeric_presets"
+    assert spec.presets == (0, 30, 60, 120)
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher routing
+# ---------------------------------------------------------------------------
+
+
+def _make_select(spec: SettingSpec) -> _EditSettingSelect:
+    select = _EditSettingSelect("xp", [spec])
+    select._values = [spec.name]  # type: ignore[attr-defined]
+    return select
+
+
+def _patch_schema(spec: SettingSpec):
+    schema = MagicMock()
+    schema.settings = (spec,)
+    return patch(
+        "core.runtime.subsystem_schema.get_schema",
+        return_value=schema,
+    )
+
+
+def _patch_resolution(value: object | None):
+    if value is None:
+        return patch(
+            "services.settings_resolution.resolve_setting",
+            new=AsyncMock(return_value=None),
+        )
+    resolution = MagicMock()
+    resolution.value = value
+    return patch(
+        "services.settings_resolution.resolve_setting",
+        new=AsyncMock(return_value=resolution),
+    )
+
+
+def _mock_interaction() -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.guild_id = 7
+    interaction.message = MagicMock()
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.send_modal = AsyncMock()
+    return interaction
+
+
+@pytest.mark.asyncio
+async def test_dispatch_channel_hint_opens_channel_select():
+    spec = SettingSpec(
+        name="ch",
+        value_type=str,
+        default="",
+        input_hint="channel",
+    )
+    select = _make_select(spec)
+    interaction = _mock_interaction()
+    with _patch_schema(spec), _patch_resolution("123"):
+        await select.callback(interaction)
+    interaction.response.send_message.assert_awaited_once()
+    kwargs = interaction.response.send_message.await_args.kwargs
+    assert isinstance(kwargs["view"], ChannelSettingSelectView)
+    assert kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_dispatch_role_hint_opens_role_select():
+    spec = SettingSpec(
+        name="r",
+        value_type=str,
+        default="",
+        input_hint="role",
+    )
+    select = _make_select(spec)
+    interaction = _mock_interaction()
+    with _patch_schema(spec), _patch_resolution(""):
+        await select.callback(interaction)
+    interaction.response.send_message.assert_awaited_once()
+    kwargs = interaction.response.send_message.await_args.kwargs
+    assert isinstance(kwargs["view"], RoleSettingSelectView)
+    assert kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_dispatch_numeric_presets_opens_presets_view():
+    spec = SettingSpec(
+        name="cd",
+        value_type=int,
+        default=60,
+        input_hint="numeric_presets",
+        presets=(0, 15, 30, 60),
+    )
+    select = _make_select(spec)
+    interaction = _mock_interaction()
+    with _patch_schema(spec), _patch_resolution(30):
+        await select.callback(interaction)
+    interaction.response.send_message.assert_awaited_once()
+    kwargs = interaction.response.send_message.await_args.kwargs
+    assert isinstance(kwargs["view"], NumericPresetsView)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_numeric_presets_with_empty_presets_falls_back_to_modal():
+    """A hint of ``"numeric_presets"`` without any ``presets`` declared
+    should NOT raise — it falls through to the S6 modal so the value
+    is still reachable.
+    """
+    spec = SettingSpec(
+        name="cd",
+        value_type=int,
+        default=60,
+        input_hint="numeric_presets",
+        presets=(),
+    )
+    select = _make_select(spec)
+    interaction = _mock_interaction()
+    with _patch_schema(spec), _patch_resolution(30):
+        await select.callback(interaction)
+    interaction.response.send_modal.assert_awaited_once()
+    interaction.response.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unknown_input_hint_falls_through_to_default_routing():
+    """An unrecognised hint must not error; the default
+    value_type-based routing takes over.
+    """
+    spec = SettingSpec(
+        name="cd",
+        value_type=int,
+        default=60,
+        input_hint="not-a-known-mode",
+    )
+    select = _make_select(spec)
+    interaction = _mock_interaction()
+    with _patch_schema(spec), _patch_resolution(30):
+        await select.callback(interaction)
+    interaction.response.send_modal.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Widget shapes — minimal smoke (full pipeline calls are exercised in
+# the existing modal / select test files)
+# ---------------------------------------------------------------------------
+
+
+def test_channel_view_has_select_and_clear_button():
+    view = ChannelSettingSelectView("xp", "xp_announce_channel", None)
+    types = {type(c).__name__ for c in view.children}
+    assert "_ChannelPickSelect" in types
+    assert "_ClearChannelButton" in types
+
+
+def test_role_view_has_select_and_clear_button():
+    view = RoleSettingSelectView("role", "moderator_role", None)
+    types = {type(c).__name__ for c in view.children}
+    assert "_RolePickSelect" in types
+    assert "_ClearRoleButton" in types
+
+
+def test_presets_view_renders_one_button_per_preset_plus_override():
+    view = NumericPresetsView(
+        subsystem="xp",
+        setting_name="xp_cooldown",
+        value_type=int,
+        current_value=60,
+        default_value=60,
+        presets=(0, 15, 30, 60, 300),
+        parent_message=None,
+    )
+    buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+    # 5 preset buttons + 1 override button
+    assert len(buttons) == 6
+    override_buttons = [b for b in buttons if b.label == "Override…"]
+    assert len(override_buttons) == 1
+
+
+def test_presets_view_highlights_current_preset_in_primary_style():
+    view = NumericPresetsView(
+        subsystem="xp",
+        setting_name="xp_cooldown",
+        value_type=int,
+        current_value=30,
+        default_value=60,
+        presets=(0, 15, 30, 60),
+        parent_message=None,
+    )
+    primary = [
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+        and c.style is discord.ButtonStyle.primary
+    ]
+    # Exactly one button should be highlighted — the one matching current.
+    assert len(primary) == 1
+    assert primary[0].label == "30"
+
+
+def test_presets_view_truncates_when_too_many_presets():
+    """More presets than the 19-button cap drop with a WARNING; override
+    button stays available.
+    """
+    presets = tuple(range(30))
+    view = NumericPresetsView(
+        subsystem="xp",
+        setting_name="xp_cooldown",
+        value_type=int,
+        current_value=0,
+        default_value=60,
+        presets=presets,
+        parent_message=None,
+    )
+    buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+    # 19 capped presets + override.
+    assert len(buttons) == 20
+
+
+# ---------------------------------------------------------------------------
+# Existing channel SettingSpecs opted in (PR #7 wiring sanity)
+# ---------------------------------------------------------------------------
+
+
+def test_xp_announce_channel_uses_channel_hint():
+    from cogs.xp.schemas import XP_SETTINGS
+
+    by_name = {spec.name: spec for spec in XP_SETTINGS}
+    assert by_name["xp_announce_channel"].input_hint == "channel"
+
+
+def test_xp_cooldown_uses_numeric_presets_hint():
+    from cogs.xp.schemas import XP_SETTINGS
+
+    by_name = {spec.name: spec for spec in XP_SETTINGS}
+    assert by_name["xp_cooldown"].input_hint == "numeric_presets"
+    assert len(by_name["xp_cooldown"].presets) > 0
+
+
+def test_economy_log_channel_uses_channel_hint():
+    from cogs.economy.schemas import ECONOMY_SETTINGS
+
+    by_name = {spec.name: spec for spec in ECONOMY_SETTINGS}
+    assert by_name["economy_log_channel"].input_hint == "channel"


### PR DESCRIPTION
## Summary

Closes three of the four missing input modes from the config-input standard: native channel select, native role select, and numeric presets (preset buttons + override modal). Adds two optional `SettingSpec` fields (`input_hint`, `presets`) for the dispatcher, three new widget modules, and opts in the existing channel SettingSpecs (`xp_announce_channel`, `economy_log_channel`) plus `xp_cooldown` to demonstrate each mode. Plan PR #7.

## Files changed

| File | Role |
|---|---|
| `disbot/core/runtime/subsystem_schema.py` | Add `SettingSpec.input_hint` + `SettingSpec.presets`; both default to backward-compatible empty values |
| `disbot/views/settings/subsystem_view.py` | `_EditSettingSelect.callback` checks `input_hint` first; falls through to S6 routing on unknown / empty hint |
| `disbot/views/settings/edit_channel.py` | New — `ChannelSettingSelectView` (text-channel select + Clear button) |
| `disbot/views/settings/edit_role.py` | New — `RoleSettingSelectView` (role select + Clear button) |
| `disbot/views/settings/edit_number_presets.py` | New — `NumericPresetsView` (preset row, current highlighted, override button) |
| `disbot/cogs/xp/schemas.py` | Opt `xp_announce_channel` into `"channel"`; opt `xp_cooldown` into `"numeric_presets"` with 6 presets |
| `disbot/cogs/economy/schemas.py` | Opt `economy_log_channel` into `"channel"` |
| `tests/unit/invariants/test_settings_cog_read_only.py` | Add the 3 new widget files to `_ALLOWED_EDIT_FILES` + the expected-paths set |
| `tests/unit/views/test_settings_edit_safety.py` | Extend the explicit allowlist-name assertion to the 8 edit files |
| `tests/unit/views/test_settings_input_hint_dispatch.py` | New — 15 tests covering schema defaults, dispatcher routing, widget shapes, and opt-in sanity |

## Architecture impact

- **SettingSpec extensibility**: two new optional fields, both with empty defaults. Every existing SettingSpec keeps its current S6 widget. Unrecognised `input_hint` values fall through to the existing routing so the dispatcher can grow without breaking older specs.
- **Pipeline contract preserved**: every new widget calls `SettingsMutationPipeline().set_value(...)` — same audit trail, same cache invalidation, same event emission. The S6 invariant tests are extended (allowlist) but the architectural contract is unchanged.
- **Visible UX change**: editing `xp_announce_channel`, `economy_log_channel`, or `xp_cooldown` from `!settings` now opens the new widget instead of a free-form modal. The numeric modal is still reachable for `xp_cooldown` via the "Override…" button so operators can type arbitrary values.

## Test plan

- Full suite: **2394 passed** (was 2379 pre-PR; +15 new PR #7 tests).
- CI gates run locally (Python 3.10): `pytest`, `black --check`, `isort --check-only`, `ruff check`, `mypy disbot/` — all clean.
- New tests cover: schema field defaults + accepted shapes; dispatcher routing for `"channel"` / `"role"` / `"numeric_presets"` / `""` / unknown / empty-presets; widget child shapes; preset highlight + truncation; opt-in sanity for the three migrated SettingSpecs.

## Manual Discord smoke plan

(All require `settings.manager_cog.enabled` flipped on for the test guild — flag default is still OFF; PR #8 flips it.)

- [ ] `!settings` → pick `xp` → Edit → `xp_announce_channel` → native channel select pops as an ephemeral. Pick a channel → `settings_mutation_audit` row + the Settings panel refreshes with the new value. Click Clear → audit row with `""` + the cleared value renders.
- [ ] Same flow for `economy_log_channel`.
- [ ] `!settings` → pick `xp` → Edit → `xp_cooldown` → 6 preset buttons (0 / 15 / 30 / 60 / 120 / 300) + Override. Current value highlighted in blue. Pick a preset → audit row + refresh.
- [ ] Same flow → Override → free-form modal opens with the current value pre-filled. Submit a custom value → audit row + refresh.
- [ ] Edit a setting WITHOUT an `input_hint` (e.g. `xp_min`) → free-form modal opens (regression check for the unchanged S6 path).
- [ ] On mobile Discord, verify the preset row fits cleanly and the channel/role selects render their native pickers.

## CI status

Pending on push; monitored via the PR activity subscription.

## Rollback notes

Single commit. A revert restores:
- The two SettingSpec fields are removed (defaults make existing specs unaffected, so a revert is safe even mid-flight).
- The three widget modules are deleted.
- The dispatcher branch table reverts to the S6 four-way dispatch.
- The opt-in `input_hint` / `presets` declarations on the three SettingSpecs vanish.
- The allowlist + expected-paths additions back out.

No data, schema migration, or pipeline changes.

## Follow-up items

Plan PR #8 (Settings default-on with kill switch) is next, then PR #9 (`/help` slash proof).

Out of scope (candidate follow-ups):
- `member_select` mode (the fourth missing standard mode); the existing `views/selectors/_resource_helpers` infrastructure makes this a straightforward extension whenever a SettingSpec needs it.
- Migrate the logging-cog channel BindingSpecs (`mod_channel`, `cleanup_channel`, etc.) so they're editable via `!settings logging` — requires either adding mirror SettingSpecs for each (the PR #5 / PR #6 pattern) or extending `BindingMutationPipeline` to plumb through the new selectors. The widgets themselves are reusable as-is.
- Replace the existing `views/selectors/channel.py` + `views/selectors/role.py` legacy selectors with adapters that build a `ChannelSettingSelectView` / `RoleSettingSelectView`. They're decoupled today; consolidating is a cleanup follow-up.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KTjPVwXmAhK4c3RaG9Qod5)_