### PR TITLE
settings: default-enable with kill switch

### DIFF
--- a/disbot/cogs/settings_cog.py
+++ b/disbot/cogs/settings_cog.py
@@ -16,11 +16,12 @@ Hard limits for S5:
   :data:`utils.subsystem_registry.SUBSYSTEMS` so help / admin /
   menu discoverability stays stable.
 * The :data:`core.runtime.feature_flags.SETTINGS_MANAGER_COG_ENABLED`
-  flag (default OFF) gates the runtime *behaviour* of ``!settings``
-  and the ``build_help_menu_view`` hook.  When OFF, invocations
-  return a clearly-worded disabled embed describing how to enable
-  it.  This avoids the "command exists but mysteriously hidden"
-  discoverability bug.
+  flag (default ON since PR #8) gates the runtime *behaviour* of
+  ``!settings`` and the ``build_help_menu_view`` hook.  When OFF
+  (kill-switched), invocations return a clearly-worded disabled
+  embed describing how to re-enable it.  The cog still loads either
+  way so help/admin/menu discoverability stays stable — this avoids
+  the "command exists but mysteriously hidden" discoverability bug.
 
 Pinned by ``tests/unit/invariants/test_settings_cog_read_only.py``:
 no imports of mutation pipelines in ``disbot/cogs/settings*`` or
@@ -53,20 +54,24 @@ def _disabled_embed() -> discord.Embed:
         title="⚙️ Settings Manager — disabled",
         description=(
             "The Settings Manager cog is registered for discoverability, "
-            "but its runtime behaviour is gated behind the "
-            f"`{_FLAG_NAME}` feature flag, which defaults to **OFF**.\n\n"
-            "When this flag is ON the `!settings` command opens the "
-            "Settings hub (read-only browsing of every subsystem's "
-            "scalar settings, bindings, resource requirements, and "
-            "recent audit history).\n\n"
-            "Flip the flag via the feature-flag mutation pipeline "
-            "(future `!platform flags set …` command) or the "
+            "but its runtime behaviour has been kill-switched via the "
+            f"`{_FLAG_NAME}` feature flag.\n\n"
+            "Since PR #8 this flag defaults to **ON** — this guild has "
+            "explicitly turned it OFF (or the flag evaluator is "
+            "unavailable, in which case the gate fails closed for "
+            "safety).\n\n"
+            "When ON the `!settings` command opens the Settings hub "
+            "(browsing + scalar edit/reset of every subsystem's "
+            "settings, bindings, resource requirements, and recent "
+            "audit history).\n\n"
+            "Re-enable via the feature-flag mutation pipeline (future "
+            "`!platform flags set …` command) or the "
             "`SUPERBOT_FF_SETTINGS__MANAGER_COG__ENABLED=on` env "
             "override."
         ),
         color=discord.Color.greyple(),
     )
-    embed.set_footer(text="S5 — read-only Settings Manager shell (default OFF).")
+    embed.set_footer(text="Settings Manager (default ON since PR #8).")
     return embed
 
 

--- a/disbot/core/runtime/feature_flags.py
+++ b/disbot/core/runtime/feature_flags.py
@@ -286,19 +286,29 @@ RESOURCE_PROVISIONING_PRIMARY = FeatureFlag(
 # The cog ALWAYS loads and registers in SUBSYSTEMS so help/admin/menu
 # discoverability stays stable; the flag gates the runtime *behaviour*
 # of the !settings command and the build_help_menu_view hook so
-# operators can disable the cog without breaking the registry.  When
-# the flag is OFF (default), invocations return an explanatory
-# embed describing how to enable it.
+# operators can disable the cog without breaking the registry.
+#
+# PR #8 flipped the default to ON now that PR #5/#6 routed XP and
+# Economy log-channel writes through SettingsMutationPipeline (closing
+# the audit gap) and PR #7 added channel/role/numeric-presets input
+# modes (closing the input-coverage gap).  The kill-switch path is
+# unchanged: operators flip OFF either via the
+# ``SUPERBOT_FF_SETTINGS__MANAGER_COG__ENABLED=off`` env override or
+# the future ``!platform flags set …`` command.  When OFF, the cog
+# still loads (registry stability) but ``!settings`` returns the
+# disabled embed.
 SETTINGS_MANAGER_COG_ENABLED = FeatureFlag(
     name="settings.manager_cog.enabled",
     description=(
         "Gates the runtime behaviour of the user-facing Settings Manager "
-        "cog (!settings) introduced in S5.  Default OFF — the cog still "
-        "loads and registers so help discoverability stays stable, but "
-        "invocations return a clearly-worded 'disabled' embed until the "
-        "flag is flipped."
+        "cog (!settings) introduced in S5.  Default ON since PR #8 — the "
+        "cog opens the Settings hub for administrators by default.  "
+        "Operators can kill-switch it OFF via the "
+        "SUPERBOT_FF_SETTINGS__MANAGER_COG__ENABLED=off env override or the "
+        "(future) !platform flags command; when OFF the cog returns a "
+        "clearly-worded 'disabled' embed instead."
     ),
-    default_value=False,
+    default_value=True,
     owner="platform",
     removal_target="S11 stable",
 )

--- a/docs/building-roadmap/admin-powers-config-coverage.md
+++ b/docs/building-roadmap/admin-powers-config-coverage.md
@@ -50,6 +50,25 @@ away from is the view callback that writes to the DB itself, calls
 
 ---
 
+## Default-on canonical surface
+
+The Settings Manager cog (``!settings``) is the canonical landing
+surface for scalar config changes that go through
+``SettingsMutationPipeline``. Since stabilization-plan PR #8 it
+defaults ON — administrators see the hub the first time they
+invoke ``!settings`` without any opt-in. The feature flag remains
+in place as a kill-switch (``SUPERBOT_FF_SETTINGS__MANAGER_COG__ENABLED=off``
+env override or the future ``!platform flags`` command) so a guild
+experiencing trouble can disable the runtime behaviour without
+touching deploy artefacts.
+
+The flag flip is independent of the architectural ownership rules
+below — those describe which pipeline owns each category of change
+regardless of whether the front-end happens to ride the Settings
+Manager cog or some other surface.
+
+---
+
 ## Ownership rules
 
 Eight categories of change, eight ownership rules.

--- a/docs/settings-customization-roadmap.md
+++ b/docs/settings-customization-roadmap.md
@@ -82,6 +82,17 @@ via the Settings Manager cog and services — never directly.
 | S11   | Help / Admin / Platform integration pass | `claude/settings-discoverability-integration` |
 | S12   | Setup wizard integration planning | `claude/setup-wizard-planning` |
 
+**Feature-flag state.** The Settings Manager cog ships with the
+``settings.manager_cog.enabled`` flag.  S5/S6/S7 landed with the flag
+default OFF — operators opted in per guild.  PR #8 (after the
+stabilization plan's S5-S7 close-out: XP/Economy pipeline migrations
++ channel/role/numeric-presets input modes) **flipped the default to
+ON** so the hub is available by default once the cog loads.  The
+kill-switch remains: operators flip it OFF either via the
+``SUPERBOT_FF_SETTINGS__MANAGER_COG__ENABLED=off`` env override or
+the (future) ``!platform flags`` command, and the cog returns the
+disabled embed in that state.
+
 
 ## Execution workflow
 

--- a/tests/unit/cogs/test_settings_cog.py
+++ b/tests/unit/cogs/test_settings_cog.py
@@ -76,11 +76,29 @@ def test_settings_subsystem_emoji_and_display_name():
 # ---------------------------------------------------------------------------
 
 
-def test_feature_flag_declared_default_off():
+def test_feature_flag_declared_default_on():
+    """PR #8 flipped the default to ON after PR #5/#6 closed the audit
+    gap and PR #7 finished the input-mode coverage. Pin the new default
+    + the unchanged ``owner`` so a drive-by edit can't silently revert
+    either field.
+    """
     flag = feature_flags.get("settings.manager_cog.enabled")
     assert flag is not None
-    assert flag.default_value is False
+    assert flag.default_value is True
     assert flag.owner == "platform"
+
+
+def test_feature_flag_description_documents_kill_switch():
+    """Operators need a discoverable kill-switch path. Pin both the
+    env-var override and the future ``!platform flags`` command in the
+    flag's own description so ``!platform flags get`` (when it lands)
+    surfaces a clear remediation hint.
+    """
+    flag = feature_flags.get("settings.manager_cog.enabled")
+    assert flag is not None
+    description = flag.description.lower()
+    assert "kill" in description or "off" in description
+    assert "superbot_ff_settings__manager_cog__enabled" in description
 
 
 # ---------------------------------------------------------------------------
@@ -175,6 +193,23 @@ def test_disabled_embed_mentions_flag_name():
     embed = settings_cog._disabled_embed()
     description = embed.description or ""
     assert "settings.manager_cog.enabled" in description
+
+
+def test_disabled_embed_documents_kill_switch_remediation():
+    """The embed shown when the flag is OFF must surface both
+    remediation paths so an operator can re-enable without spelunking
+    the codebase. PR #8 pins both the env-variable override and the
+    future ``!platform flags`` command.
+    """
+    embed = settings_cog._disabled_embed()
+    description = embed.description or ""
+    # Env override path — exact env-var name.
+    assert "SUPERBOT_FF_SETTINGS__MANAGER_COG__ENABLED" in description
+    # Command path (future) — `!platform flags` framing.
+    assert "platform flags" in description.lower()
+    # Reflects the PR #8 flip — the embed should say "default ON" so
+    # operators reading it know they explicitly turned it OFF.
+    assert "default" in description.lower() and "on" in description.lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Flips `settings.manager_cog.enabled` from default OFF to default ON now that PRs #5/#6/#7 closed the audit-gap and input-coverage gates that justified keeping it gated. Kill-switch path is unchanged: env override and the future `!platform flags` command continue to work. Plan PR #8.

## Files changed

| File | Role |
|---|---|
| `disbot/core/runtime/feature_flags.py` | `SETTINGS_MANAGER_COG_ENABLED.default_value` flipped to `True`; description rewritten to enumerate the kill-switch paths |
| `disbot/cogs/settings_cog.py` | Module docstring + `_disabled_embed` reframed for the new default-ON state |
| `tests/unit/cogs/test_settings_cog.py` | Rename `test_feature_flag_declared_default_off` → `test_feature_flag_declared_default_on`; add `test_feature_flag_description_documents_kill_switch` + `test_disabled_embed_documents_kill_switch_remediation` |
| `docs/settings-customization-roadmap.md` | New "Feature-flag state" paragraph documenting the PR #8 flip + kill-switch paths |
| `docs/building-roadmap/admin-powers-config-coverage.md` | New "Default-on canonical surface" section noting the cog is now the canonical landing surface for scalar config changes |

## Architecture impact

- **Kill-switch unchanged**: the cog still reads `is_enabled` at runtime. Setting the flag to OFF (via env override or the DB) returns the disabled embed exactly like before. The bootstrap-fallback path (DB unavailable → declared default) is the only place the user-visible behaviour differs, and that's the intent of the flip.
- **No data / schema / pipeline changes**: this is a flag flip + doc and test updates. Single `git revert` restores the previous default cleanly.
- **Backward compat on env overrides**: any operator who set `SUPERBOT_FF_SETTINGS__MANAGER_COG__ENABLED=on` to opt in now has a no-op override — still ON, just explicitly. No action required.
- **Audit + input coverage prerequisites met**: PR #5 (XP modals → pipeline), PR #6 (Economy log-channel → pipeline), PR #7 (channel/role/numeric-presets input modes) collectively closed the gaps that justified leaving the cog OFF.

## Test plan

- Full suite: **2396 passed** (was 2394 pre-PR; +2 net new PR #8 tests).
- New tests pin: the flipped default value, the flag description's kill-switch documentation, the disabled embed's kill-switch remediation text. The existing `_flag_on` / `_flag_off` / `_flag_raises` tests stay green — they monkey-patch `is_enabled` directly so they don't depend on the default.
- CI gates run locally (Python 3.10): pytest, black --check, isort --check-only, ruff check, mypy disbot/ — all clean.

## Manual Discord smoke plan

- [ ] `!settings` in a fresh guild (no env override, no DB row) → hub opens immediately. No "disabled" embed.
- [ ] `!settings` → pick a subsystem → Edit → confirm the existing widgets (PR #5/#7 contracts) still work end-to-end.
- [ ] Set `SUPERBOT_FF_SETTINGS__MANAGER_COG__ENABLED=off` in the bot's environment and restart → `!settings` returns the disabled embed.
- [ ] The disabled embed mentions: the canonical env-var name, the future `!platform flags` command, and the "default ON since PR #8" framing so a reader knows OFF is now an explicit override.
- [ ] Clear the env override and restart → `!settings` returns to opening the hub.
- [ ] Help dropdown → Settings Manager → opens the hub (default-ON path through `build_help_menu_view`).

## CI status

Pending on push; monitored via the PR activity subscription.

## Rollback notes

Single commit. A revert restores:
- `default_value=False` in `feature_flags.py`.
- The pre-PR-#8 docstring + disabled embed wording.
- The pre-PR-#8 tests (default-off assertion + the existing flag-gate tests).
- The pre-PR-#8 doc state.

No data, schema migration, or pipeline changes. Operators who'd already deployed `SUPERBOT_FF_SETTINGS__MANAGER_COG__ENABLED=on` keep an explicit override even after the revert.

## Follow-up items

Plan PR #9 (`/help` slash front door reusing `HelpRoute`) is the last PR in the approved sequence.

Out of scope (candidate follow-ups):
- Implement `!platform flags set …` so the kill-switch can be flipped without a redeploy. The flag-mutation pipeline (`RolloutMutationPipeline`) is already in place; only the command surface is missing. Track separately.
- Per-guild rollout (gradual flip) — `RolloutMutationPipeline` supports it; not needed for this binary flag but the precedent exists for future feature flags.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KTjPVwXmAhK4c3RaG9Qod5)_