### PR TITLE
slash: /help front door reusing HelpRoute

### DIFF
--- a/disbot/cogs/help_cog.py
+++ b/disbot/cogs/help_cog.py
@@ -4,6 +4,7 @@ import logging
 import math
 
 import discord
+from discord import app_commands
 from discord.ext import commands
 
 from cogs.help.route import HUB_PANEL_BUILDERS as _HUB_PANEL_BUILDERS
@@ -661,6 +662,82 @@ class HelpCog(commands.Cog):
             ctx.channel.id,
             "help",
             msg.id,
+        )
+
+    @app_commands.command(
+        name="help",
+        description="Show available commands (optionally narrow to one category).",
+    )
+    @app_commands.describe(name="Optional category, hub, or command name")
+    async def help_slash(
+        self,
+        interaction: discord.Interaction,
+        name: str | None = None,
+    ) -> None:
+        """Slash front door for Help — resolves identically to ``!help``.
+
+        Same governance resolution + ``HelpRoute`` resolver + opener
+        as the prefix command; differences are purely entry-point:
+
+        * Responses are ephemeral (slash help is personal — each user
+          gets their own panel without polluting the channel).
+        * No message-anchor bookkeeping (Discord owns the ephemeral
+          lifecycle; there is no anchor to clean up).
+        * For hub/subsystem/advanced routes, the Back-to-Help button is
+          attached so the user can return to the category index without
+          rerunning ``/help``.
+
+        PR #9 — first slash command in the bot. Proves the
+        ``HelpRoute`` reuse pattern; follow-ups can land
+        ``/games``, ``/economy``, etc.
+        """
+        gctx = GovernanceContext.from_interaction(interaction)
+        vis_result = await governance_service.resolve_visibility(gctx)
+        visible_set = vis_result.visible_subsystems
+        member_tier = vis_result.member_tier
+
+        if name:
+            opener = HelpOpener.from_interaction(interaction)
+            route = _resolve_route(name, bot=self.bot)
+
+            if route.kind == "unknown":
+                await interaction.response.send_message(
+                    f"No command or category named `{name}` found.",
+                    ephemeral=True,
+                )
+                return
+
+            embed, sub_view = await _open_route(
+                route,
+                opener,
+                visible_subsystems=visible_set,
+                member_tier=member_tier,
+                prefix="!",
+            )
+
+            if sub_view is None:
+                await interaction.response.send_message(embed=embed, ephemeral=True)
+                return
+
+            # Mirror the prefix path: any hub/subsystem/advanced surface
+            # gets a Back-to-Help button so the user can return to the
+            # category index in place.
+            _attach_back_to_help_button(sub_view)
+            await interaction.response.send_message(
+                embed=embed,
+                view=sub_view,
+                ephemeral=True,
+            )
+            return
+
+        # Default: top-level category index. Reuse
+        # ``resolve_help_panel_state`` so the slash path and every
+        # navigation Back-to-Help button land on the same builder.
+        embed, view = await resolve_help_panel_state(interaction)
+        await interaction.response.send_message(
+            embed=embed,
+            view=view,
+            ephemeral=True,
         )
 
 

--- a/tests/unit/help/test_slash_help_command.py
+++ b/tests/unit/help/test_slash_help_command.py
@@ -1,0 +1,281 @@
+"""PR #9 — tests for the ``/help`` slash front door.
+
+The slash command resolves identically to ``!help`` because both
+share the ``HelpRoute`` resolver in ``cogs.help.route``. These
+tests pin the parity contract:
+
+* ``/help`` (no argument) opens the same Help Home view as the
+  prefix path, via ``resolve_help_panel_state``.
+* ``/help <name>`` resolves through ``_resolve_route`` + ``_open_route``
+  identically to ``!help <name>``.
+* The Back-to-Help button is attached to hub/subsystem routes so
+  the user can return to the category index.
+* Unknown names produce an ephemeral "not found" reply.
+* Every slash response is ephemeral (slash help is personal).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from cogs import help_cog
+
+
+def _mock_interaction(*, user_id: int = 1, guild_id: int = 42) -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = MagicMock(spec=discord.Member)
+    interaction.user.id = user_id
+    interaction.user.roles = []
+    interaction.guild = MagicMock()
+    interaction.guild.id = guild_id
+    interaction.guild_id = guild_id
+    interaction.channel = MagicMock()
+    interaction.channel.id = 999
+    interaction.client = MagicMock()
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    return interaction
+
+
+def _patch_governance(member_tier: str = "user", visible: set | None = None):
+    vis_result = MagicMock()
+    vis_result.visible_subsystems = visible or {"games", "economy"}
+    vis_result.member_tier = member_tier
+    return patch.object(
+        help_cog.governance_service,
+        "resolve_visibility",
+        new=AsyncMock(return_value=vis_result),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Slash command registration
+# ---------------------------------------------------------------------------
+
+
+def test_help_cog_registers_slash_command():
+    """``HelpCog.help_slash`` must be decorated as an
+    ``app_commands.command`` so the bot's tree picks it up on cog load.
+    """
+    cog = help_cog.HelpCog(bot=MagicMock())
+    cmd = cog.help_slash
+    # discord.py wraps the bound method in a ``Command`` descriptor when
+    # the cog is added to the bot; the underlying ``__discord_app_commands__``
+    # marker remains accessible on the function attribute.
+    assert hasattr(cog.__class__.help_slash, "_callback") or hasattr(
+        cog.__class__.help_slash,
+        "callback",
+    ), (
+        "HelpCog.help_slash must be an app_commands.command descriptor "
+        "so the bot tree registers it on load."
+    )
+    # The command name must be exactly ``help`` so users invoke ``/help``.
+    name = getattr(cog.__class__.help_slash, "name", None)
+    assert name == "help"
+
+
+# ---------------------------------------------------------------------------
+# Default (no argument) — opens Help Home ephemerally
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_slash_help_no_args_opens_help_home_ephemerally():
+    cog = help_cog.HelpCog(bot=MagicMock())
+    interaction = _mock_interaction()
+
+    fake_embed = discord.Embed(title="Help Menu")
+    fake_view = MagicMock(spec=discord.ui.View)
+
+    with _patch_governance(), patch.object(
+        help_cog,
+        "resolve_help_panel_state",
+        new=AsyncMock(return_value=(fake_embed, fake_view)),
+    ):
+        await cog.help_slash.callback(cog, interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    kwargs = interaction.response.send_message.await_args.kwargs
+    assert kwargs["embed"] is fake_embed
+    assert kwargs["view"] is fake_view
+    assert kwargs.get("ephemeral") is True
+
+
+# ---------------------------------------------------------------------------
+# Named-route parity: /help <name> resolves like !help <name>
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_slash_help_named_route_resolves_via_shared_resolver():
+    """``/help games`` must call ``_resolve_route`` + ``_open_route`` the
+    same way ``!help games`` does. Pins the parity contract.
+    """
+    cog = help_cog.HelpCog(bot=MagicMock())
+    interaction = _mock_interaction()
+
+    fake_route = help_cog.HelpRoute(key="games", kind="hub", target="games")
+    fake_embed = discord.Embed(title="Games Hub")
+    fake_view = discord.ui.View()
+
+    with _patch_governance(), patch.object(
+        help_cog,
+        "_resolve_route",
+        return_value=fake_route,
+    ) as resolve_mock, patch.object(
+        help_cog,
+        "_open_route",
+        new=AsyncMock(return_value=(fake_embed, fake_view)),
+    ) as open_mock, patch.object(
+        help_cog,
+        "_attach_back_to_help_button",
+    ) as back_mock:
+        await cog.help_slash.callback(cog, interaction, name="games")
+
+    # Resolver receives the user-supplied name + the bot client.
+    resolve_mock.assert_called_once_with("games", bot=cog.bot)
+    # Opener receives the resolved route + governance result.
+    open_mock.assert_awaited_once()
+    open_kwargs = open_mock.await_args.kwargs
+    assert open_kwargs["visible_subsystems"] == {"games", "economy"}
+    assert open_kwargs["member_tier"] == "user"
+    # Back-to-Help is attached to the sub-view before send.
+    back_mock.assert_called_once_with(fake_view)
+    # Response is ephemeral + carries the route's embed/view.
+    interaction.response.send_message.assert_awaited_once()
+    kwargs = interaction.response.send_message.await_args.kwargs
+    assert kwargs["embed"] is fake_embed
+    assert kwargs["view"] is fake_view
+    assert kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_slash_help_unknown_name_returns_ephemeral_not_found():
+    cog = help_cog.HelpCog(bot=MagicMock())
+    interaction = _mock_interaction()
+    unknown_route = help_cog.HelpRoute(key="bogus", kind="unknown", target=None)
+
+    with _patch_governance(), patch.object(
+        help_cog,
+        "_resolve_route",
+        return_value=unknown_route,
+    ), patch.object(
+        help_cog,
+        "_open_route",
+        new=AsyncMock(),
+    ) as open_mock:
+        await cog.help_slash.callback(cog, interaction, name="bogus")
+
+    open_mock.assert_not_called()
+    interaction.response.send_message.assert_awaited_once()
+    sent = interaction.response.send_message.await_args
+    assert sent.kwargs.get("ephemeral") is True
+    # The user-visible text mentions the offending input.
+    content = sent.args[0] if sent.args else sent.kwargs.get("content", "")
+    assert "bogus" in content
+
+
+# ---------------------------------------------------------------------------
+# Embed-only route (single command, advanced fallback) — no view → no back
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_slash_help_embed_only_route_skips_back_attachment():
+    """When ``_open_route`` returns ``view=None`` (e.g. single-command
+    detail) the slash path sends just the embed and does NOT call
+    ``_attach_back_to_help_button``.
+    """
+    cog = help_cog.HelpCog(bot=MagicMock())
+    interaction = _mock_interaction()
+
+    cmd_route = help_cog.HelpRoute(key="bal", kind="command", target="bal")
+    fake_embed = discord.Embed(title="!bal")
+
+    with _patch_governance(), patch.object(
+        help_cog,
+        "_resolve_route",
+        return_value=cmd_route,
+    ), patch.object(
+        help_cog,
+        "_open_route",
+        new=AsyncMock(return_value=(fake_embed, None)),
+    ), patch.object(
+        help_cog,
+        "_attach_back_to_help_button",
+    ) as back_mock:
+        await cog.help_slash.callback(cog, interaction, name="bal")
+
+    back_mock.assert_not_called()
+    interaction.response.send_message.assert_awaited_once()
+    kwargs = interaction.response.send_message.await_args.kwargs
+    assert kwargs["embed"] is fake_embed
+    assert "view" not in kwargs
+    assert kwargs.get("ephemeral") is True
+
+
+# ---------------------------------------------------------------------------
+# Parity sanity: shared resolver call signature matches !help
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_slash_and_prefix_call_resolve_route_with_same_args():
+    """``/help games`` and ``!help games`` must both call
+    ``_resolve_route("games", bot=...)`` so a future divergence (e.g.
+    one path adding flags the other doesn't) breaks the test.
+    """
+    cog = help_cog.HelpCog(bot=MagicMock())
+
+    # Slash side.
+    slash_interaction = _mock_interaction()
+    fake_route = help_cog.HelpRoute(key="games", kind="hub", target="games")
+    with _patch_governance(), patch.object(
+        help_cog,
+        "_resolve_route",
+        return_value=fake_route,
+    ) as slash_resolve, patch.object(
+        help_cog,
+        "_open_route",
+        new=AsyncMock(return_value=(discord.Embed(), discord.ui.View())),
+    ), patch.object(
+        help_cog,
+        "_attach_back_to_help_button",
+    ):
+        await cog.help_slash.callback(cog, slash_interaction, name="games")
+
+    # Prefix side.
+    prefix_ctx = MagicMock()
+    prefix_ctx.author = MagicMock(spec=discord.Member)
+    prefix_ctx.author.id = 1
+    prefix_ctx.author.roles = []
+    prefix_ctx.guild = MagicMock()
+    prefix_ctx.guild.id = 42
+    prefix_ctx.channel = MagicMock()
+    prefix_ctx.channel.id = 999
+    prefix_ctx.bot = MagicMock()
+    prefix_ctx.send = AsyncMock()
+    prefix_ctx.prefix = "!"
+
+    with _patch_governance(), patch.object(
+        help_cog,
+        "_resolve_route",
+        return_value=fake_route,
+    ) as prefix_resolve, patch.object(
+        help_cog,
+        "_open_route",
+        new=AsyncMock(return_value=(discord.Embed(), discord.ui.View())),
+    ), patch.object(
+        help_cog,
+        "_attach_back_to_help_button",
+    ):
+        await cog.help_command.callback(cog, prefix_ctx, category="games")
+
+    # Both paths called the resolver with positional name + bot kwarg.
+    assert slash_resolve.call_args.args == ("games",)
+    assert prefix_resolve.call_args.args == ("games",)
+    assert "bot" in slash_resolve.call_args.kwargs
+    assert "bot" in prefix_resolve.call_args.kwargs


### PR DESCRIPTION
## Summary

First slash command in the bot. `/help` and `!help` share the same `HelpRoute` resolver + opener so a name typed into either entry point lands on the same destination. Plan PR #9 — the final PR in the approved stabilization sequence.

## Files changed

| File | Role |
|---|---|
| `disbot/cogs/help_cog.py` | Add `HelpCog.help_slash` decorated with `@app_commands.command(name="help", ...)`; reuses `_resolve_route` + `_open_route` + `_attach_back_to_help_button` + `resolve_help_panel_state`. Imports `discord.app_commands`. |
| `tests/unit/help/test_slash_help_command.py` | New — 6 tests: decorator presence, Help Home default branch, named-route parity with the prefix path, unknown-name fallback, embed-only routes skip Back attachment, and a parity-sanity test asserting both paths call `_resolve_route` with the same args. |

## Architecture impact

- **HelpRoute reuse pattern proven**: the new command is a 30-line addition because every load-bearing piece (resolver, opener, governance, back-attachment) already exists. Follow-up slash front doors (`/games`, `/economy`, etc.) will use this recipe directly.
- **Tree state**: the bot tree gains exactly one global command (`/help`). The bot's existing `setup_hook`-based tree sync publishes it on next start. No new infrastructure required.
- **Differences from `!help`**: responses are ephemeral (slash help is personal — each user gets their own panel without polluting the channel) and there's no `message_anchor_manager` bookkeeping (Discord owns the ephemeral lifecycle).
- **No new routes / resolver branches**: the contract of `cogs.help.route` is unchanged. The slash path threads through the same `HelpRoute` + `HelpOpener.from_interaction` + `_open_route` + `_attach_back_to_help_button` pieces.

## Test plan

- Full suite: **2402 passed** (was 2396 pre-PR; +6 new PR #9 tests).
- New tests cover: decorator presence + correct command name; default-branch Help Home build; named-route resolver call + opener call + Back attachment; unknown-name ephemeral fallback (no opener call); embed-only route (`view=None`) skips Back attachment; cross-path parity asserting both `/help games` and `!help games` invoke `_resolve_route` with identical positional + `bot` kwarg.
- CI gates run locally (Python 3.10): pytest, black --check, isort --check-only, ruff check, mypy disbot/ — all clean.

## Manual Discord smoke plan

(Requires the bot's tree sync to publish the new command — typically a few minutes after the first restart on this branch, or instant if guild-scoped.)

- [ ] `/help` (no argument) → ephemeral Help Home opens (same view as `!help`).
- [ ] `/help games` → ephemeral Games hub with `↩ Back to Help` button → click Back → returns to Help Home in place (same `interaction.response.edit_message` semantics).
- [ ] `/help mining` → ephemeral Mining panel with Back-to-Help → Back navigates correctly.
- [ ] `/help diagnostics` → opens the Diagnostics subsystem (subsystem-alias branch — same routing as `!help diagnostics`).
- [ ] `/help platform` → opens the Platform Hub via the `HUB_PANEL_BUILDERS["diagnostic"]` override (same as `!help platform`).
- [ ] `/help bogus_name` → ephemeral "No command or category named `bogus_name` found." (no panel).
- [ ] `/help bal` (single command) → ephemeral embed only, no Back button (the route is `command`, not `hub`/`subsystem`).
- [ ] Channel sanity: only the invoker sees the slash response; the channel stays clean. (`!help` continues to post public embeds — unchanged.)

## CI status

Pending on push; monitored via the PR activity subscription.

## Rollback notes

Single-file production change (`help_cog.py`) + one new test file. A revert removes the slash command from the cog; the bot's next tree sync unregisters the global `/help`. The prefix path is untouched throughout — `!help` continues to work as a fallback.

## Follow-up items

The approved stabilization plan is complete with this PR. The plan explicitly listed only `/help` for PR #9 — broader slash rollout (`/games`, `/economy`, `/community`, `/utility`, `/moderation`, `/admin`, `/settings`, `/platform`) is **out of scope** and tracked as follow-up.

Out of scope candidates:
- `/games`, `/economy`, `/community`, `/utility`, `/moderation`, `/admin`, `/platform` slash front doors — each is a ~30-line addition mirroring the recipe in this PR. Permission-tier checks should use `governance.permission_tiers.tier_at_or_above` so moderator/admin commands are restricted.
- `/settings` slash front door — depends on the `settings.manager_cog.enabled` flag (default ON since PR #8) so it can ship in the same round as the others.
- Tree-sync admin command (`!sync` or similar) — currently the bot's `setup_hook` handles sync; adding an explicit admin command would let operators force a refresh without a restart. Existing infrastructure suggests this is straightforward; tracked separately.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KTjPVwXmAhK4c3RaG9Qod5)_