### PR TITLE
docs: status refresh after stabilization plan PRs #143-#151

### DIFF
--- a/docs/building-roadmap/interface-completion-roadmap.md
+++ b/docs/building-roadmap/interface-completion-roadmap.md
@@ -1,6 +1,6 @@
 # SuperBot Interface Completion Roadmap
 
-Status: Open roadmap — Phases 1, 3, 4, 5, 6, 6.5a, 7 (Option A) landed; Phase 8 audit-complete
+Status: Open roadmap — Phases 1, 3, 4, 5, 6, 6.5a, 7 (Option A) landed; Phase 8 audit-complete; stabilization plan PRs #143-#151 landed (navigation lifecycle + parent_hub metadata + Community metadata-driven + XP/Economy pipelines + Settings selectors/presets + Settings default-on + `/help` slash)
 Runtime impact: None for this doc
 
 This document captures the next major arc of SuperBot work: pulling the existing scattered cog surface into a coherent, discoverable, Discord-native application. The platform foundation (settings/customization map, registry, pipelines, `!platform` hub, Settings Manager shell, Logging subsystem) was complete before this roadmap started; the interface skeleton is now also landed (see status snapshot below).
@@ -36,6 +36,7 @@ This is the current actual state of the roadmap, reconciled against `main`. Per-
 | 9a — Logging schema + resolver | #128 | Five new severity/audit channel bindings + RECOMMENDED resource requirements. `LOGGING_CONFIG_SCHEMA.version` 1 → 2. Table-driven 7-route `resolve_log_channel` with mod fallback. |
 | 9b — Logging Routes UI | #129 | `LoggingRoutesView` subpage + 🗺️ Routes button on `LoggingPanelView` + `!logging routes` subcommand + parameterised `LogChannelSelectView` / `LogChannelProvisionView` for all 7 kinds. |
 | 3.5 *(partial)* — Shared nav helper | *(this refresh)* | `disbot/views/navigation.py` — `attach_back_button` + `transition_to`. Migrated help-cog back-button injection and `LoggingRoutesView.btn_back`. Admin / settings / games inline factories remain as-is and migrate on demand. |
+| Stabilization plan PRs #143-#151 | #143-#151 | Nine-PR sequence touching navigation lifecycle, registry metadata, and Settings UI. **#143** fixed Economy → Inventory detached panel, Economy → Work dead-end result, Mining root no-op Overview; added five-helper symmetry via `attach_back_to_economy_button`. **#144** refreshed `help-command-surface-map.md` post-PR-#142. **#145** declared `parent_hub` metadata on the eight S7-S10 children (inventory, leaderboard, xp, role, cleanup, logging, proof_channel, general). **#146** migrated `CommunityHubView` to metadata-driven discovery mirroring Games. **#147** routed three XP config modals through `SettingsMutationPipeline` and added the `xp_announce_channel` SettingSpec. **#148** routed `ECONOMY_LOG_CHANNEL` writes through the pipeline and added the `economy_log_channel` SettingSpec. **#149** added `SettingSpec.input_hint` + `presets` plus three new widget modules (`edit_channel.py`, `edit_role.py`, `edit_number_presets.py`); opted in xp/economy channel specs and `xp_cooldown` presets. **#150** flipped `settings.manager_cog.enabled` default to ON (kill-switch retained). **#151** added the `/help` slash front door reusing `HelpRoute` — first slash command in the bot. |
 
 ### Audit-complete (no implementation needed)
 
@@ -58,7 +59,7 @@ This is the current actual state of the roadmap, reconciled against `main`. Per-
 | Phase | Notes |
 |---|---|
 | 9c — Logging publishers + subscribers | Next major implementation candidate. Adds publish callsites + bus subscribers + per-route counter buckets. Needs the publisher-strategy decision documented in the Phase 9 section. |
-| 10 — Slash front doors | Thin `/help`, `/games`, `/cleanup`, `/platform`, `/settings` hybrid-command wrappers. Small but lower-impact than Phase 9c. |
+| 10 — Slash front doors | **Partial** — `/help` landed via PR #151 (proves the `HelpRoute` reuse pattern). Remaining `/games`, `/economy`, `/community`, `/utility`, `/moderation`, `/admin`, `/platform`, `/settings` follow-ups still ahead; each is a ~30-line addition mirroring the `/help` recipe. |
 | 11 — Setup wizard | Deferred until the prerequisites (cleanup panel ✅, access explorer ✅, `SetupPackCatalogue` prototype ⏳) stabilize. |
 
 ---
@@ -666,7 +667,7 @@ Wizard flow per pack:
 | 8 | Phase 8 (a–e) | ✅ audit-complete | Every panel already implemented; no PRs. Future Phase-8-adjacent work is UX standardization per `hub-ui-standard.md`, not panel re-creation. |
 | Cleanup Settings Foundation | follow-up | ⏳ deferred | Waits for runtime to consume new cleanup scalar settings. |
 | 9 | Phase 9 | ⏳ next major candidate | Logging advanced route table. **Not started by this roadmap-refresh PR.** Requires the prerequisites called out in Phase 9's open questions. |
-| 10 | Phase 10 | ⏳ later | Slash front doors. Thin hybrid-command wrappers. |
+| 10 | Phase 10 | ⏳ partial | Slash front doors. `/help` landed via PR #151 — proves the `HelpRoute` reuse pattern. Remaining `/games`, `/economy`, `/community`, `/utility`, `/moderation`, `/admin`, `/platform`, `/settings` follow-ups still ahead. |
 | 11 | Phase 11 | ⏳ deferred | Setup wizard. Prereqs partially met. |
 
 **Roadmap is open. Revise after each phase.**

--- a/docs/help-command-surface-map.md
+++ b/docs/help-command-surface-map.md
@@ -166,31 +166,57 @@ routing issues. See `tests/unit/views/test_economy_inventory_edit.py`,
 ## 5. Future routing surfaces
 
 Tracked as the stabilization-plan PR sequence
-(`/root/.claude/plans/superbot-planning-jolly-wadler.md` §8). Listed
-here so a future reader can map this doc to the in-flight plan.
+(`/root/.claude/plans/superbot-planning-jolly-wadler.md` §8). All
+nine PRs have landed; this section is now a historical map between
+the plan numbers and the merge PR numbers, plus the work that remains
+beyond the plan.
 
 - **`parent_hub` metadata for S7–S10 children** (plan PR #3) —
-  **done.** `parent_hub` declared on `inventory → economy`,
+  **done** via PR #145. `parent_hub` declared on `inventory → economy`,
   `leaderboard → economy`, `xp → community`, `role → community`,
   `cleanup → moderation`, `logging → moderation`,
   `proof_channel → moderation`, `general → utility`. The eight rows
   above now read "hub child (...) — declared". Mining is additionally
   declared as a `cross_link_children` on the Economy hub.
-- **Community metadata-driven hub** (plan PR #4) — replace
-  `CommunityHubView._HUB_CHILDREN` hardcoded tuple with SUBSYSTEMS
-  discovery, mirroring `views/games/hub.py:discover_game_children`.
-  After PR #3 the metadata exists; the migration is a view-only
-  change.
-- **XP config modal pipeline migration** (plan PR #5) — three modals
-  in `disbot/views/xp/modals.py` write directly via `db.set_setting`;
-  migrate to `SettingsMutationPipeline`.
-- **Economy log-channel pipeline migration** (plan PR #6) — preferred
-  via `BindingMutationPipeline`.
-- **Settings numeric presets + channel/role selectors** (plan PR #7).
-- **Settings default-on with kill switch** (plan PR #8).
-- **Slash front door** `/help` (plan PR #9) — reuses `resolve_route` +
-  `open_route` + `HelpOpener.from_interaction`. Broader slash rollout
-  (`/games`, `/economy`, etc.) follows in subsequent PRs.
+- **Community metadata-driven hub** (plan PR #4) — **done** via
+  PR #146. `CommunityHubView` discovers primary children from
+  `SUBSYSTEMS` (`parent_hub == "community"`) and cross-links from
+  `hub_registry.get_hub("community").cross_link_children`, mirroring
+  the Games hub pattern. Button labels now come from registry
+  metadata (`emoji` + `display_name`).
+- **XP config modal pipeline migration** (plan PR #5) — **done** via
+  PR #147. The three XP config modals (`_XpRangeModal`,
+  `_XpCooldownModal`, `_XpChannelModal`) now route through
+  `SettingsMutationPipeline().set_value(...)`; a new
+  `xp_announce_channel` SettingSpec carries the channel-id-as-str
+  shape. Each write lands a `settings_mutation_audit` row.
+- **Economy log-channel pipeline migration** (plan PR #6) — **done**
+  via PR #148. Used `SettingsMutationPipeline` (not
+  `BindingMutationPipeline`) because two of the three call sites are
+  listener-triggered with no actor; the binding pipeline currently
+  requires an administrator-tier actor. The existing `log_channel`
+  BindingSpec stays as the typed-resource declaration; the new
+  `economy_log_channel` SettingSpec drives the write path. Same
+  duality the PR #5 commit documented for `xp_announce_channel`.
+- **Settings numeric presets + channel/role selectors** (plan PR #7)
+  — **done** via PR #149. Added `SettingSpec.input_hint` +
+  `SettingSpec.presets` fields and three new widget modules
+  (`edit_channel.py`, `edit_role.py`, `edit_number_presets.py`).
+  Opted in `xp_announce_channel`, `economy_log_channel`
+  (`input_hint="channel"`), and `xp_cooldown`
+  (`input_hint="numeric_presets"`, six presets).
+- **Settings default-on with kill switch** (plan PR #8) — **done**
+  via PR #150. `SETTINGS_MANAGER_COG_ENABLED.default_value` flipped
+  to `True`; kill-switch path
+  (`SUPERBOT_FF_SETTINGS__MANAGER_COG__ENABLED=off` env override or
+  the future `!platform flags` command) unchanged.
+- **Slash front door** `/help` (plan PR #9) — **done** via PR #151.
+  `HelpCog.help_slash` reuses `resolve_route` + `open_route` +
+  `HelpOpener.from_interaction` + `_attach_back_to_help_button`.
+  Responses are ephemeral. Broader slash rollout (`/games`,
+  `/economy`, `/community`, `/utility`, `/moderation`, `/admin`,
+  `/platform`, `/settings`) follows in subsequent PRs and uses the
+  same 30-line recipe.
 - **Setup wizard** (`!setup`) — deferred until the S7 logging-route
   pipeline, S8 cleanup-policy pipeline, S10 preset packs, and the P5
   platform UI framework all land. See `docs/roadmap_setup_platform.md`.

--- a/docs/loose-ends-audit-roadmap.md
+++ b/docs/loose-ends-audit-roadmap.md
@@ -6,6 +6,45 @@ Baseline inspected: `main` at Phase 9b merge (`baacf461`)
 Purpose: define the safest completion pass before feature expansion, with a button-first command surface, complete Help discovery, consistent panel navigation, and a clear slash-front-door strategy.
 
 > **Status note (S1):** The PR sequence L1–L6 below is **superseded** by [`building-roadmap/mother-hub-map.md`](./building-roadmap/mother-hub-map.md) S1–S13. PR L1 (shared navigation helper) partially landed via PR #130 — S2 in the new sequence completes the migration. The findings, navigation duplication evidence, placeholder inventory, and panel/subsystem inventory in this document remain valid as the source audit; only the PR sequence is replaced.
+>
+> **Stabilization plan update (PRs #143-#151, 2026-05):** A nine-PR
+> stabilization sequence landed on top of the post-PR-#142 baseline:
+>
+> - **Navigation duplication.** Five sibling Back-to-X helpers now
+>   exist (Help / Admin / Settings / Games / Economy) — PR #143 added
+>   `attach_back_to_economy_button` to round out the family for the
+>   live mother hubs. The duplication finding in Finding 1 below is
+>   still accurate as audit context, but the migration is now
+>   feature-complete for the affected surface.
+> - **Phase 4 parent_hub filter.** PR #145 declared `parent_hub`
+>   metadata on the eight S7-S10 children (`inventory`, `leaderboard`,
+>   `xp`, `role`, `cleanup`, `logging`, `proof_channel`, `general`),
+>   so the filter consistently hides them from the top-level Help
+>   overview.
+> - **Community hub.** PR #146 migrated `CommunityHubView` to
+>   metadata-driven discovery (primary children from `SUBSYSTEMS`,
+>   cross-links from `hub_registry`), mirroring the Games hub
+>   pattern.
+> - **Direct-write remediation.** PR #147 and PR #148 routed the
+>   last XP and Economy direct-write sites through
+>   `SettingsMutationPipeline` (closing the audit gap that Finding 5
+>   flagged).
+> - **Settings input modes.** PR #149 added the `channel_select`,
+>   `role_select`, and `numeric_presets` widgets and wired the
+>   dispatcher via the new `SettingSpec.input_hint` field.
+> - **Settings default-on.** PR #150 flipped
+>   `settings.manager_cog.enabled` to default ON with the
+>   `SUPERBOT_FF_SETTINGS__MANAGER_COG__ENABLED=off` env-var kill-switch
+>   retained.
+> - **Slash front door.** PR #151 added `/help` reusing `HelpRoute` —
+>   the first slash command in the bot. The remaining slash front
+>   doors (`/games`, `/economy`, `/community`, `/utility`,
+>   `/moderation`, `/admin`, `/platform`, `/settings`) are
+>   straightforward follow-ups using the same recipe.
+>
+> The placeholder inventory below remains the canonical audit; the
+> Mining root "↩ Overview" no-op button was removed in PR #143 and
+> the Games-fallback finding still applies.
 
 ---
 


### PR DESCRIPTION
## Summary

Doc-only follow-up after the nine-PR stabilization sequence merged. Reconciles three read-only roadmap / status docs with the merged state of `main`. No code, no test, no runtime changes.

## Files changed

| File | What changed |
|---|---|
| `docs/help-command-surface-map.md` | §5 plan-PR table — flip PRs #4-#9 from "ahead" to "**done** via PR #N"; preamble notes "all nine PRs have landed" |
| `docs/building-roadmap/interface-completion-roadmap.md` | Top-of-file status line, "Landed" table (new combined row for PRs #143-#151), "Still ahead" Phase 10 row (now `⏳ partial — /help landed`), and the line-669 status-snapshot table |
| `docs/loose-ends-audit-roadmap.md` | Header status note gains a "Stabilization plan update (PRs #143-#151, 2026-05)" paragraph with seven concrete pieces of audit progress + the Mining root Overview removal callout |

## Why this PR exists

The three docs are status / roadmap trackers consumed by future agents and operators. Each had stale entries that lagged the merged state:

- `help-command-surface-map.md` §5 only marked plan PR #3 as done; PRs #4-#9 were merged but still read as "preferred via" / "future".
- `interface-completion-roadmap.md` listed Phase 10 (slash front doors) under "Still ahead" with no mention that `/help` is now live.
- `loose-ends-audit-roadmap.md` header note correctly framed the L1-L6 sequence as superseded but didn't reflect the seven concrete pieces of stabilization progress that landed since.

## What I deliberately did NOT change

Docs that were already updated mid-plan or are intentionally forward-looking:

- `docs/settings-customization-roadmap.md` (PR #150 added the "Feature-flag state" paragraph).
- `docs/settings-customization-command-map.md` (PR #147 + PR #148 added the SettingSpec entries).
- `docs/building-roadmap/admin-powers-config-coverage.md` (PR #150 added the "Default-on canonical surface" section).
- `docs/operator-settings-presets.md` (forward-looking preset library; "future" wording is intentional, not status drift).
- `docs/phase-2-completion-readiness.md` (tracks Phase 2 pipeline work specifically; the stabilization plan didn't touch Phase 2 surface).
- `docs/architecture.md`, `docs/runtime_contracts.md`, `docs/ownership.md`, `docs/decisions/*` (architecture / immutable decisions, unaffected).
- `docs/platform-consistency-ledger.md`, `docs/roadmap_setup_platform.md` (no stabilization-related drift).

## Test plan

- Full suite: 2402 passed (unchanged from PR #151 head — these are doc-only edits).
- Doc-shape tests under `tests/unit/docs/`: 29 passed. The surface-map doc still lists every committed hub key and every subsystem key in backticks; the `## 3. Known inconsistencies` heading stays in place.

## CI status

Pending on push; monitored via subscription.

## Rollback notes

Single commit, three modified files. A revert restores the pre-refresh wording on each doc cleanly. No code or schema impact.

## Follow-up items

None within this PR's scope. The actual implementation follow-ups (Phase 9c logging publishers, the remaining slash front doors, the setup wizard) are tracked by the now-current "Still ahead" tables.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KTjPVwXmAhK4c3RaG9Qod5)_