### PR TITLE
cleanup: restore dead-end exits via back-to-Cleanup buttons

### DIFF
--- a/disbot/cogs/cleanup/panel.py
+++ b/disbot/cogs/cleanup/panel.py
@@ -35,6 +35,7 @@ import discord
 from core.runtime.interaction_helpers import help_ctx_shim
 from utils.ui_constants import ADMIN_COLOR
 from views.base import HubView
+from views.navigation import attach_back_button
 
 if TYPE_CHECKING:
     from cogs.cleanup_cog import Cleanup
@@ -96,6 +97,39 @@ def build_cleanup_overview_embed(
     return embed
 
 
+def _attach_back_to_cleanup_button(
+    child_view: discord.ui.View,
+    cleanup_panel: CleanupPanelView,
+) -> bool:
+    """Attach a "↩ Back to Cleanup" button on ``child_view``.
+
+    The parent-builder closure returns the *live* ``cleanup_panel``
+    instance — not a fresh ``CleanupPanelView()``. Re-using the same
+    instance preserves any back button attached to it by the opener
+    (back-to-Help when entered via ``!help cleanup`` / ``/help cleanup``,
+    back-to-Admin when entered via ``!adminmenu`` → Cleanup, none for
+    direct ``!cleanup``). A rebuild would lose that opener back button.
+
+    If ``cleanup_panel`` has timed out by click time, the rebuilt view
+    is inert; this is acceptable for AB1's scope. PR AB2's
+    ``BackTarget`` / ``chain_back`` flow rebuilds with origin
+    re-attached and avoids the inert-instance risk for deeper chains.
+    """
+
+    async def _return_to_cleanup(
+        _interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        return cleanup_panel.build_embed(), cleanup_panel
+
+    return attach_back_button(
+        child_view,
+        label="↩ Back to Cleanup",
+        custom_id="cleanup:back",
+        parent_builder=_return_to_cleanup,
+        error_message="Couldn't reopen the Cleanup hub. Try `!cleanup` again.",
+    )
+
+
 class CleanupPanelView(HubView):
     """Top-level Cleanup hub view — routes to existing subsystem panels."""
 
@@ -132,6 +166,7 @@ class CleanupPanelView(HubView):
         if self.guild_id is not None and self.guild_id not in self.cog._word_cache:
             await self.cog._load_guild(self.guild_id)
         view = _WordMenuView(help_ctx_shim(interaction), self.cog)
+        _attach_back_to_cleanup_button(view, self)
         await interaction.response.edit_message(
             embed=view.build_embed(),
             view=view,
@@ -171,16 +206,18 @@ class CleanupPanelView(HubView):
                     exc_info=True,
                 )
                 await interaction.response.send_message(
-                    "Couldn't open the logging panel.",
+                    f"Couldn't open the logging panel ({exc.__class__.__name__}).",
                     ephemeral=True,
                 )
                 return
+            _attach_back_to_cleanup_button(view, self)
             await interaction.response.edit_message(embed=embed, view=view)
             return
         # Fallback — construct the panel directly. Mirrors the contract
         # the cog itself uses, so any future signature changes propagate.
         view = LoggingPanelView(interaction.user)  # type: ignore[arg-type]
         embed = await view.build_embed(interaction)  # type: ignore[attr-defined]
+        _attach_back_to_cleanup_button(view, self)
         await interaction.response.edit_message(embed=embed, view=view)
 
     @discord.ui.button(
@@ -201,6 +238,7 @@ class CleanupPanelView(HubView):
 
         view = SubsystemSettingsView(interaction.user, "cleanup")
         embed = await build_subsystem_embed(interaction, "cleanup")
+        _attach_back_to_cleanup_button(view, self)
         await interaction.response.edit_message(embed=embed, view=view)
 
     @discord.ui.button(

--- a/tests/unit/cogs/test_cleanup_panel.py
+++ b/tests/unit/cogs/test_cleanup_panel.py
@@ -272,3 +272,205 @@ async def test_refresh_button_rebuilds_embed_without_mutation():
     _args, kwargs = interaction.response.edit_message.call_args
     assert kwargs["view"] is view
     assert isinstance(kwargs["embed"], discord.Embed)
+
+
+# ---------------------------------------------------------------------------
+# Back-to-Cleanup attachment on every routed sub-view (PR AB1)
+# ---------------------------------------------------------------------------
+
+
+def _back_button(view: discord.ui.View) -> discord.ui.Button | None:
+    for child in view.children:
+        if (
+            isinstance(child, discord.ui.Button)
+            and child.custom_id == "cleanup:back"
+        ):
+            return child
+    return None
+
+
+@pytest.mark.asyncio
+async def test_words_button_attaches_back_to_cleanup_on_child():
+    """Prohibited Words view must carry a Back-to-Cleanup button so the
+    user is not trapped — issue #1 of the post-#152 stabilization sweep.
+    """
+    cog = _cog(words=["badword"])
+    view = CleanupPanelView(_author(), cog, guild_id=42)
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = MagicMock()
+    interaction.user = view._author
+    interaction.guild = MagicMock()
+    interaction.channel = MagicMock()
+    interaction.response = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "cleanup:words"
+    )
+    await btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    _args, kwargs = interaction.response.edit_message.call_args
+    child_view = kwargs["view"]
+    back = _back_button(child_view)
+    assert back is not None, "Words view must have a cleanup:back button"
+    assert back.label == "↩ Back to Cleanup"
+
+
+@pytest.mark.asyncio
+async def test_logging_button_attaches_back_to_cleanup_on_child():
+    cog = _cog()
+    view = CleanupPanelView(_author(), cog, guild_id=42)
+
+    logging_cog = MagicMock()
+    returned_view = discord.ui.View()
+    logging_cog.build_help_menu_view = AsyncMock(
+        return_value=(discord.Embed(title="Logging"), returned_view),
+    )
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = MagicMock()
+    interaction.client.get_cog = MagicMock(return_value=logging_cog)
+    interaction.response = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "cleanup:logging"
+    )
+    await btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    back = _back_button(returned_view)
+    assert back is not None, "Logging view must have a cleanup:back button"
+    assert back.label == "↩ Back to Cleanup"
+
+
+@pytest.mark.asyncio
+async def test_logging_button_failure_path_includes_exception_class_name():
+    """If the logging cog's build hook raises, the ephemeral should name
+    the exception class so operators can triage from the user's report.
+    """
+    cog = _cog()
+    view = CleanupPanelView(_author(), cog, guild_id=42)
+
+    logging_cog = MagicMock()
+    logging_cog.build_help_menu_view = AsyncMock(
+        side_effect=RuntimeError("boom"),
+    )
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = MagicMock()
+    interaction.client.get_cog = MagicMock(return_value=logging_cog)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "cleanup:logging"
+    )
+    await btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    interaction.response.send_message.assert_awaited_once()
+    args, kwargs = interaction.response.send_message.call_args
+    message = args[0] if args else kwargs.get("content", "")
+    assert "RuntimeError" in message
+    assert kwargs.get("ephemeral") is True
+    interaction.response.edit_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_settings_button_attaches_back_to_cleanup_on_child():
+    view = CleanupPanelView(_author(), _cog(), guild_id=42)
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = view._author
+    interaction.client = MagicMock()
+    interaction.guild = MagicMock()
+    interaction.channel = MagicMock()
+    interaction.response = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+
+    with patch(
+        "views.settings.subsystem_view.build_subsystem_embed",
+        AsyncMock(return_value=discord.Embed(title="Cleanup settings")),
+    ):
+        btn = next(
+            c
+            for c in view.children
+            if isinstance(c, discord.ui.Button) and c.custom_id == "cleanup:settings"
+        )
+        await btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    _args, kwargs = interaction.response.edit_message.call_args
+    child_view = kwargs["view"]
+    back = _back_button(child_view)
+    assert back is not None, "Settings view must have a cleanup:back button"
+    assert back.label == "↩ Back to Cleanup"
+
+
+@pytest.mark.asyncio
+async def test_back_button_returns_to_same_cleanup_panel_instance():
+    """The back button's parent_builder must return the SAME live
+    CleanupPanelView instance (identity), not a fresh rebuild. This is
+    how AB1 preserves any back-to-Help / back-to-Admin attached by the
+    opener — a rebuild would lose those.
+    """
+    cog = _cog(words=["badword"])
+    view = CleanupPanelView(_author(), cog, guild_id=42)
+
+    # Mimic an opener attaching its own back button (e.g. back-to-Help)
+    # on the live CleanupPanelView before any subroute is opened.
+    synthetic_origin_btn = discord.ui.Button(
+        label="↩ Back to Help",
+        custom_id="help:back",
+        style=discord.ButtonStyle.secondary,
+        row=4,
+    )
+    view.add_item(synthetic_origin_btn)
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = MagicMock()
+    interaction.user = view._author
+    interaction.guild = MagicMock()
+    interaction.channel = MagicMock()
+    interaction.response = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "cleanup:words"
+    )
+    await btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    _args, kwargs = interaction.response.edit_message.call_args
+    child_view = kwargs["view"]
+    back = _back_button(child_view)
+    assert back is not None
+
+    # Invoke the back button's callback directly and verify it edits
+    # the message with the original CleanupPanelView instance — the one
+    # that still carries the synthetic back-to-Help button.
+    next_interaction = MagicMock(spec=discord.Interaction)
+    next_interaction.client = MagicMock()
+    next_interaction.response = MagicMock()
+    next_interaction.response.is_done = MagicMock(return_value=False)
+    next_interaction.response.edit_message = AsyncMock()
+    next_interaction.response.send_message = AsyncMock()
+    next_interaction.edit_original_response = AsyncMock()
+
+    await back.callback(next_interaction)  # type: ignore[union-attr,misc]
+
+    next_interaction.response.edit_message.assert_awaited_once()
+    _args, edit_kwargs = next_interaction.response.edit_message.call_args
+    assert edit_kwargs["view"] is view, (
+        "Back button must return the live CleanupPanelView instance"
+    )
+    # The synthetic origin button (e.g. back-to-Help) must still be on
+    # the returned view — that's the whole point of preserving identity.
+    assert synthetic_origin_btn in view.children


### PR DESCRIPTION
## Summary

PR AB1 of the post-#152 stabilization plan. Closes three S0 dead ends in the Cleanup hub that trap users with no exit:

1. Prohibited Words manager (issue #1) — `_WordMenuView` had zero exit buttons.
2. Cleanup → Logging Status (issue #2) — the logging panel opened with no back-to-Cleanup.
3. Cleanup → Settings (issue #3) — `SubsystemSettingsView` opened with no back-to-Cleanup.

### Approach

Each subview opener attaches a "↩ Back to Cleanup" button via a shared `_attach_back_to_cleanup_button` helper that wraps the existing `views.navigation.attach_back_button`.

The parent_builder closure returns the **live `CleanupPanelView` instance** rather than rebuilding a fresh one. Re-using the same instance preserves whatever back button the opener attached on it (back-to-Help when entered via `/help cleanup` / `!help cleanup`, back-to-Admin when entered via `!adminmenu` → Cleanup, none for direct `!cleanup`). A rebuild would lose the opener's back button.

Also widens the logging build-hook failure-path ephemeral to include the exception class name so operators can triage from a user report (was: "Couldn't open the logging panel."; now: "Couldn't open the logging panel (RuntimeError).").

### Scope

- `disbot/cogs/cleanup/panel.py` — adds the shared helper, wires it into `btn_words`, `btn_logging`, and `btn_settings`. Two-line tweak to the logging failure ephemeral.
- `tests/unit/cogs/test_cleanup_panel.py` — five new tests covering back-button presence on each subview, the widened error message, and an identity test that verifies the back button returns the same `CleanupPanelView` instance with the opener's synthetic back-to-Help still intact.

### Test plan

- [x] Unit: `tests/unit/cogs/test_cleanup_panel.py` — 17/17 pass (12 existing + 5 new).
- [x] Regression: full `tests/` suite — 2407/2407 pass.
- [x] Static: `mypy disbot/`, `ruff check .`, `black --check .` all clean.
- [ ] Manual Discord smoke (post-merge, since the bot may need a Railway redeploy to come back online):
  - `!cleanup` → Prohibited Words → ↩ Back to Cleanup → overview.
  - `!cleanup` → Logging Status → ↩ Back to Cleanup.
  - `!cleanup` → Settings → ↩ Back to Cleanup.
  - `!adminmenu` → Cleanup → Words/Logging/Settings → ↩ Back to Cleanup → confirm back-to-Admin still present on Cleanup.
  - `!help cleanup` and `/help cleanup` → Words/Logging/Settings → ↩ Back to Cleanup → confirm back-to-Help still present on Cleanup → ↩ Back to Help works.

### Rollback

Additive button attachments only. Revert restores the dead-end behavior; no schema or migration changes.

### Follow-ups (not in this PR)

- PR AB2 will retrofit these closures to use the typed `BackTarget` / `chain_back` helper and extend origin preservation to the Economy → Inventory / Shop chain (issues #4, #5).
- PR D will add governance filtering on the Games and Community hub child buttons (issues #7, #8).

https://claude.ai/code/session_01VJhdMgBEfU2LmvgiiS5TN4

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJhdMgBEfU2LmvgiiS5TN4)_