### PR TITLE
nav: typed BackTarget + chain_back for composable back navigation

### DIFF
--- a/disbot/cogs/help_cog.py
+++ b/disbot/cogs/help_cog.py
@@ -180,12 +180,16 @@ def _attach_back_to_help_button(view: discord.ui.View) -> None:
     after the category-index refactor. The pre-S3 implementation rebuilt
     a paginated :class:`HelpPanelView`; that view is still reachable as
     the "All Commands / Advanced" category but is no longer the top.
+
+    AB2: also stashes a :class:`BackTarget` on ``view._back_target`` so
+    that openers further down the chain can use :func:`chain_back` to
+    preserve back-to-Help when they rebuild this panel.
     """
     # Local import — navigation is at the views layer; help_cog is at
     # the cogs layer. Function-local import keeps the import graph
     # acyclic in case the navigation module ever grows imports of its
     # own.
-    from views.navigation import attach_back_button
+    from views.navigation import BackTarget, attach_back_button
 
     async def _build_help_parent(
         interaction: discord.Interaction,
@@ -204,6 +208,16 @@ def _attach_back_to_help_button(view: discord.ui.View) -> None:
         row=4,
         style=discord.ButtonStyle.secondary,
         error_message="Could not load help menu. Please try again.",
+    )
+    # AB2: child openers further down can compose back-to-Help via
+    # ``chain_back(_build_me, grandparent=self._back_target)``. The
+    # attribute is set unconditionally; persistent-view re-registration
+    # constructs without ever calling this helper, so ``_back_target``
+    # remains unset on restored views (the fail-safe contract).
+    view._back_target = BackTarget(  # type: ignore[attr-defined]
+        builder=_build_help_parent,
+        label="↩ Back to Help",
+        custom_id="help:back",
     )
 
 

--- a/disbot/views/economy/main_panel.py
+++ b/disbot/views/economy/main_panel.py
@@ -36,7 +36,7 @@ from utils import db
 from utils.cooldowns import check_cooldown, format_remaining
 from utils.helpers import post_log_embed
 from utils.ui_constants import ECONOMY_COLOR, INFO_COLOR
-from views.navigation import attach_back_button
+from views.navigation import BackTarget, attach_back_button, chain_back
 
 
 @register
@@ -176,6 +176,10 @@ class EconomyPanelView(PersistentView):
 
         uid, gid = interaction.user.id, interaction.guild_id
         shop_view = _ShopSubView(uid, gid)
+        # AB2: propagate this panel's back target (e.g. back-to-Help)
+        # so the shop's Back button rebuilds Economy with the chain
+        # re-attached.
+        shop_view._back_target = getattr(self, "_back_target", None)
         await interaction.response.edit_message(embed=_shop_embed(), view=shop_view)
 
     @discord.ui.button(
@@ -219,7 +223,14 @@ class EconomyPanelView(PersistentView):
         uid, gid = interaction.user.id, interaction.guild_id
         grouped = await _build_combined_inventory(uid, gid)
         view = UnifiedInventoryView(interaction.user, interaction.user, grouped)
-        attach_back_to_economy_button(view, interaction.user)
+        # AB2: forward this panel's own back target (back-to-Help if
+        # opened via /help economy) so back-to-Economy from Inventory
+        # rebuilds Economy WITH back-to-Help re-attached.
+        attach_back_to_economy_button(
+            view,
+            interaction.user,
+            grandparent=getattr(self, "_back_target", None),
+        )
         await safe_edit(interaction, embed=view.build_hub_embed(), view=view)
         view.message = interaction.message
 
@@ -291,12 +302,23 @@ class EconomyPanelView(PersistentView):
 def attach_back_to_economy_button(
     view: discord.ui.View,
     author: discord.Member | discord.User,
+    *,
+    grandparent: BackTarget | None = None,
 ) -> bool:
     """Append a "↩ Back to Economy" control to a child view opened from the hub.
 
     Thin wrapper around :func:`views.navigation.attach_back_button`. The
     parent-builder closure rebuilds a fresh :class:`EconomyPanelView` on
     click so the persistent hub reflects current state, not a snapshot.
+
+    AB2: when ``grandparent`` is supplied (typically Help's own
+    :class:`BackTarget`), :func:`views.navigation.chain_back` wraps the
+    builder so the rebuilt Economy panel also gets the grandparent
+    re-attached. This is how Help → Economy → Inventory → Back
+    preserves back-to-Help on the rebuilt Economy.
+
+    Also stashes ``view._back_target`` for further-down openers (e.g.
+    a Category view inside Inventory) to chain back through Economy.
 
     Returns ``False`` (no-op) if the view is already at Discord's 25-component
     cap — ``attach_back_button`` logs a WARNING in that case so operators can
@@ -309,15 +331,22 @@ def attach_back_to_economy_button(
         embed = await _build_economy_embed(author, interaction.guild_id)
         return embed, EconomyPanelView()
 
-    return attach_back_button(
+    composed_builder = chain_back(_build_economy_parent, grandparent)
+    added = attach_back_button(
         view,
         label="↩ Back to Economy",
         custom_id="economy:back",
-        parent_builder=_build_economy_parent,
+        parent_builder=composed_builder,
         row=4,
         style=discord.ButtonStyle.secondary,
         error_message="Could not reload the Economy hub. Please try again.",
     )
+    view._back_target = BackTarget(  # type: ignore[attr-defined]
+        builder=composed_builder,
+        label="↩ Back to Economy",
+        custom_id="economy:back",
+    )
+    return added
 
 
 __all__ = ["EconomyPanelView", "attach_back_to_economy_button"]

--- a/disbot/views/economy/shop_panel.py
+++ b/disbot/views/economy/shop_panel.py
@@ -142,9 +142,17 @@ class _ShopSubView(discord.ui.View):
     @discord.ui.button(label="↩ Back", style=discord.ButtonStyle.grey, row=1)
     async def back_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
         from views.economy.main_panel import EconomyPanelView
+        from views.navigation import attach_back_target
 
         embed = await _build_economy_embed(interaction.user, interaction.guild_id)
-        await interaction.response.edit_message(embed=embed, view=EconomyPanelView())
+        view = EconomyPanelView()
+        # AB2: if a grandparent was propagated from the opener
+        # (typically Help's back target), re-attach it so the rebuilt
+        # Economy panel keeps the back-to-Help chain.
+        origin = getattr(self, "_back_target", None)
+        if origin is not None:
+            attach_back_target(view, origin)
+        await interaction.response.edit_message(embed=embed, view=view)
         self.stop()
 
     async def on_timeout(self):

--- a/disbot/views/navigation.py
+++ b/disbot/views/navigation.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from typing import TypeAlias
 
 import discord
@@ -55,6 +56,33 @@ ParentBuilder: TypeAlias = Callable[
     [discord.Interaction],
     Awaitable[tuple[discord.Embed, discord.ui.View]],
 ]
+
+
+@dataclass(frozen=True)
+class BackTarget:
+    """A captured "what comes above me" for back-chain composition (AB2).
+
+    Each opener in a Help → X → Y chain can stash a ``BackTarget`` on
+    the child it opens (typically as ``child_view._back_target``). The
+    child's own opener, when it builds back-to-Y, uses
+    :func:`chain_back` to compose: pressing back rebuilds Y AND
+    re-attaches the captured ``BackTarget`` on the rebuilt Y. This
+    lets a deep navigation unwind all the way back to Help with each
+    intermediate parent's back button still attached, without inventing
+    a router or a stack.
+
+    Persistent-view fail-safe: ``BackTarget`` MUST NOT be persisted
+    across bot restarts (the ``builder`` closure cannot be
+    serialized). Persistent-view re-registration must construct views
+    without a ``_back_target``; in that case the panel still works
+    as the top-of-stack and click-time governance recheck (PR D) is
+    the correctness safety net.
+    """
+
+    builder: ParentBuilder
+    label: str
+    custom_id: str
+
 
 # Discord's per-view component cap. Pulled out as a constant so tests
 # don't hard-code the magic number.
@@ -209,9 +237,71 @@ async def transition_to(
     await safe_edit(interaction, embed=embed, view=view)
 
 
+def attach_back_target(view: discord.ui.View, target: BackTarget) -> bool:
+    """Convenience: :func:`attach_back_button` driven by a :class:`BackTarget`.
+
+    Equivalent to::
+
+        attach_back_button(
+            view,
+            label=target.label,
+            custom_id=target.custom_id,
+            parent_builder=target.builder,
+        )
+
+    Returns the same value as :func:`attach_back_button` — ``True`` if
+    the button was added, ``False`` if the view was at the 25-component
+    cap.
+    """
+    return attach_back_button(
+        view,
+        label=target.label,
+        custom_id=target.custom_id,
+        parent_builder=target.builder,
+    )
+
+
+def chain_back(
+    builder: ParentBuilder,
+    grandparent: BackTarget | None,
+) -> ParentBuilder:
+    """Return a wrapped builder that re-attaches ``grandparent`` after rebuild.
+
+    Composition rule: the wrapped builder calls ``builder`` to obtain
+    ``(embed, view)``, then — if ``grandparent`` is not ``None`` —
+    invokes :func:`attach_back_target` on the rebuilt view. The
+    grandparent itself may be a :class:`BackTarget` whose builder was
+    also produced by :func:`chain_back`, so arbitrary depth composes
+    naturally through the closure tree.
+
+    If ``grandparent`` is ``None`` this is the identity transform —
+    the builder is returned unchanged. That keeps top-of-stack openers
+    (direct ``!cleanup``, ``!economymenu``) from gaining an unwanted
+    spurious back button.
+
+    Persistent-view fail-safe: the wrapped builder is in-memory only.
+    Persistent views must re-register without a chain; click-time
+    checks remain the correctness safety net.
+    """
+    if grandparent is None:
+        return builder
+
+    async def _chained_builder(
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        embed, view = await builder(interaction)
+        attach_back_target(view, grandparent)
+        return embed, view
+
+    return _chained_builder
+
+
 __all__ = [
     "MAX_COMPONENTS",
+    "BackTarget",
     "ParentBuilder",
     "attach_back_button",
+    "attach_back_target",
+    "chain_back",
     "transition_to",
 ]

--- a/tests/unit/views/test_navigation.py
+++ b/tests/unit/views/test_navigation.py
@@ -36,7 +36,10 @@ import pytest
 
 from views.navigation import (
     MAX_COMPONENTS,
+    BackTarget,
     attach_back_button,
+    attach_back_target,
+    chain_back,
     transition_to,
 )
 
@@ -352,3 +355,333 @@ def test_logging_routes_back_uses_shared_navigation_helper():
     src = inspect.getsource(LoggingRoutesView.btn_back)
     assert "transition_to" in src
     assert "views.navigation" in src or "from views.navigation" in src
+
+
+# ---------------------------------------------------------------------------
+# BackTarget / attach_back_target / chain_back (AB2)
+# ---------------------------------------------------------------------------
+
+
+async def _stub_builder(_interaction):
+    return discord.Embed(title="stub"), discord.ui.View()
+
+
+def test_back_target_is_frozen_and_hashable():
+    """``BackTarget`` is a frozen dataclass — values are immutable and
+    the instance is hashable so it can be safely stashed on views
+    without surprising aliasing.
+    """
+    target = BackTarget(
+        builder=_stub_builder,
+        label="↩ Back to X",
+        custom_id="x:back",
+    )
+    # Hashable.
+    {target}
+    # Frozen.
+    with pytest.raises(Exception):
+        target.label = "mutated"  # type: ignore[misc]
+
+
+def test_attach_back_target_delegates_to_attach_back_button():
+    """``attach_back_target(view, target)`` is equivalent to
+    ``attach_back_button(view, label=…, custom_id=…, parent_builder=…)``
+    — verify the button properties match.
+    """
+    view = discord.ui.View()
+    target = BackTarget(
+        builder=_stub_builder,
+        label="↩ Back to X",
+        custom_id="x:back",
+    )
+
+    added = attach_back_target(view, target)
+
+    assert added is True
+    assert len(view.children) == 1
+    btn = view.children[0]
+    assert isinstance(btn, discord.ui.Button)
+    assert btn.label == target.label
+    assert btn.custom_id == target.custom_id
+
+
+def test_chain_back_identity_when_no_grandparent():
+    """With ``grandparent=None``, ``chain_back`` returns the builder
+    unchanged — direct-entry openers must not pick up a spurious
+    back button on rebuild.
+    """
+    wrapped = chain_back(_stub_builder, None)
+    assert wrapped is _stub_builder
+
+
+@pytest.mark.asyncio
+async def test_chain_back_re_attaches_grandparent_on_rebuild():
+    """When ``grandparent`` is provided, the wrapped builder rebuilds
+    the parent AND attaches the grandparent's back button on it.
+    """
+    parent_embed = discord.Embed(title="parent")
+    parent_view = discord.ui.View()
+
+    async def builder(_interaction):
+        return parent_embed, parent_view
+
+    grandparent = BackTarget(
+        builder=_stub_builder,
+        label="↩ Back to Grandparent",
+        custom_id="gp:back",
+    )
+
+    wrapped = chain_back(builder, grandparent)
+    # Not the identity transform when grandparent is provided.
+    assert wrapped is not builder
+
+    embed, view = await wrapped(_interaction())
+    assert embed is parent_embed
+    assert view is parent_view
+    # The rebuilt view now carries the grandparent's button.
+    custom_ids = {
+        c.custom_id  # type: ignore[attr-defined]
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+    }
+    assert "gp:back" in custom_ids
+
+
+@pytest.mark.asyncio
+async def test_chain_back_composes_arbitrarily_deep():
+    """Composition is associative: a chain of three builders unwinds
+    via two ``chain_back`` calls and the rebuilt top-most view ends
+    up carrying both intermediate back buttons.
+    """
+    top_view = discord.ui.View()
+
+    async def build_top(_interaction):
+        return discord.Embed(title="top"), top_view
+
+    mid_target = BackTarget(
+        builder=build_top,
+        label="↩ Back to Top",
+        custom_id="top:back",
+    )
+
+    async def build_middle(_interaction):
+        return discord.Embed(title="middle"), discord.ui.View()
+
+    composed_mid = chain_back(build_middle, mid_target)
+    leaf_target = BackTarget(
+        builder=composed_mid,
+        label="↩ Back to Middle",
+        custom_id="middle:back",
+    )
+
+    leaf_view = discord.ui.View()
+    attach_back_target(leaf_view, leaf_target)
+    # Leaf has back-to-middle.
+    leaf_custom_ids = {
+        c.custom_id  # type: ignore[attr-defined]
+        for c in leaf_view.children
+        if isinstance(c, discord.ui.Button)
+    }
+    assert "middle:back" in leaf_custom_ids
+
+    # Pressing back-to-middle invokes the composed builder; the
+    # rebuilt middle view must carry back-to-top.
+    middle_btn = next(
+        c
+        for c in leaf_view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "middle:back"
+    )
+    interaction = _interaction()
+    await middle_btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    interaction.response.edit_message.assert_awaited_once()
+    _args, kwargs = interaction.response.edit_message.call_args
+    rebuilt_middle = kwargs["view"]
+    mid_custom_ids = {
+        c.custom_id  # type: ignore[attr-defined]
+        for c in rebuilt_middle.children
+        if isinstance(c, discord.ui.Button)
+    }
+    assert "top:back" in mid_custom_ids
+
+
+# ---------------------------------------------------------------------------
+# Help cog stashes BackTarget for downstream chain composition (AB2)
+# ---------------------------------------------------------------------------
+
+
+def test_help_cog_back_button_stashes_back_target():
+    """``_attach_back_to_help_button`` must stash a ``BackTarget`` on
+    the view so downstream openers can use ``chain_back`` to keep
+    back-to-Help attached when they rebuild their own parent panels.
+    """
+    from cogs import help_cog
+
+    view = discord.ui.View()
+    help_cog._attach_back_to_help_button(view)
+    target = getattr(view, "_back_target", None)
+    assert target is not None
+    assert isinstance(target, BackTarget)
+    assert target.label == "↩ Back to Help"
+    assert target.custom_id == "help:back"
+
+
+# ---------------------------------------------------------------------------
+# Economy back chain (AB2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_attach_back_to_economy_button_re_attaches_grandparent():
+    """If ``attach_back_to_economy_button`` is called with a grandparent,
+    the rebuilt Economy panel produced by clicking back-to-Economy
+    must also have the grandparent's button re-attached. This is the
+    Help → Economy → Inventory → back path.
+    """
+    from views.economy.main_panel import attach_back_to_economy_button
+
+    grandparent = BackTarget(
+        builder=_stub_builder,
+        label="↩ Back to Help",
+        custom_id="help:back",
+    )
+
+    view = discord.ui.View()
+    author = MagicMock()
+
+    # Patch the binding at the point of use — main_panel imports the
+    # helper at module load, so patching the source module would not
+    # affect the rebound reference.
+    with patch(
+        "views.economy.main_panel._build_economy_embed",
+        AsyncMock(return_value=discord.Embed(title="Economy")),
+    ):
+        attach_back_to_economy_button(view, author, grandparent=grandparent)
+
+        # The Inventory view now has back-to-Economy.
+        economy_btn = next(
+            c
+            for c in view.children
+            if isinstance(c, discord.ui.Button) and c.custom_id == "economy:back"
+        )
+
+        # Clicking back-to-Economy rebuilds Economy. The rebuilt view
+        # must carry back-to-Help (grandparent).
+        interaction = _interaction()
+        await economy_btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    interaction.response.edit_message.assert_awaited_once()
+    _args, kwargs = interaction.response.edit_message.call_args
+    rebuilt_economy = kwargs["view"]
+    rebuilt_custom_ids = {
+        c.custom_id  # type: ignore[attr-defined]
+        for c in rebuilt_economy.children
+        if isinstance(c, discord.ui.Button)
+    }
+    assert "help:back" in rebuilt_custom_ids
+
+
+def test_attach_back_to_economy_button_stashes_back_target_on_child():
+    """The Inventory view must receive ``_back_target`` so its own
+    children (e.g. a Category view) can chain back through Economy
+    if they want to rebuild.
+    """
+    from views.economy.main_panel import attach_back_to_economy_button
+
+    view = discord.ui.View()
+    attach_back_to_economy_button(view, MagicMock(), grandparent=None)
+    target = getattr(view, "_back_target", None)
+    assert target is not None
+    assert isinstance(target, BackTarget)
+    assert target.label == "↩ Back to Economy"
+    assert target.custom_id == "economy:back"
+
+
+def _shop_view_back_button(shop_view) -> discord.ui.Button:
+    """Look up the ``↩ Back`` button from a ``_ShopSubView`` instance.
+
+    The decorator-defined button is added to ``children`` on view
+    construction; iterate to find it rather than calling the raw
+    function descriptor on the class.
+    """
+    for child in shop_view.children:
+        if (
+            isinstance(child, discord.ui.Button)
+            and child.label is not None
+            and "Back" in child.label
+        ):
+            return child
+    raise AssertionError("Shop subview has no Back button")
+
+
+@pytest.mark.asyncio
+async def test_shop_subview_back_btn_re_attaches_origin_on_rebuild():
+    """When ``_ShopSubView`` was opened from an EconomyPanelView that
+    has a propagated origin (e.g. back-to-Help), the shop's Back
+    button must re-attach that origin on the rebuilt Economy.
+    """
+    from views.economy.shop_panel import _ShopSubView
+
+    shop_view = _ShopSubView(user_id=1, guild_id=42)
+    # Mimic the propagation that EconomyPanelView.shop_btn does.
+    shop_view._back_target = BackTarget(  # type: ignore[attr-defined]
+        builder=_stub_builder,
+        label="↩ Back to Help",
+        custom_id="help:back",
+    )
+
+    interaction = _interaction()
+    interaction.guild_id = 42
+
+    with patch(
+        "views.economy.shop_panel._build_economy_embed",
+        AsyncMock(return_value=discord.Embed(title="Economy")),
+    ):
+        await _shop_view_back_button(shop_view).callback(  # type: ignore[union-attr,misc]
+            interaction,
+        )
+
+    interaction.response.edit_message.assert_awaited_once()
+    _args, kwargs = interaction.response.edit_message.call_args
+    rebuilt_economy = kwargs["view"]
+    rebuilt_custom_ids = {
+        c.custom_id  # type: ignore[attr-defined]
+        for c in rebuilt_economy.children
+        if isinstance(c, discord.ui.Button)
+    }
+    assert "help:back" in rebuilt_custom_ids
+
+
+@pytest.mark.asyncio
+async def test_shop_subview_back_btn_with_no_origin_omits_chain():
+    """When ``_ShopSubView`` was opened directly (e.g. !shop / direct
+    !economymenu → shop), there is no origin to chain — the rebuilt
+    Economy must NOT have a spurious back button.
+    """
+    from views.economy.shop_panel import _ShopSubView
+
+    shop_view = _ShopSubView(user_id=1, guild_id=42)
+    # No _back_target propagated.
+
+    interaction = _interaction()
+    interaction.guild_id = 42
+
+    with patch(
+        "views.economy.shop_panel._build_economy_embed",
+        AsyncMock(return_value=discord.Embed(title="Economy")),
+    ):
+        await _shop_view_back_button(shop_view).callback(  # type: ignore[union-attr,misc]
+            interaction,
+        )
+
+    interaction.response.edit_message.assert_awaited_once()
+    _args, kwargs = interaction.response.edit_message.call_args
+    rebuilt_economy = kwargs["view"]
+    rebuilt_custom_ids = {
+        c.custom_id  # type: ignore[attr-defined]
+        for c in rebuilt_economy.children
+        if isinstance(c, discord.ui.Button)
+    }
+    # No spurious back buttons.
+    assert "help:back" not in rebuilt_custom_ids
+    assert "economy:back" not in rebuilt_custom_ids


### PR DESCRIPTION
## Summary

PR AB2 of the post-#152 stabilization plan. Closes the back-chain loss across Economy → Inventory / Shop (issues #4, #5) by introducing a typed, composable back-target helper next to the existing `attach_back_button` / `transition_to`.

### Why

Before AB2, `attach_back_to_economy_button` rebuilt a fresh `EconomyPanelView()` on click. When the user entered via `/help economy` → Inventory → Back, the rebuilt Economy panel was missing the back-to-Help button that Help had attached on the original instance. Same bug on Shop.

### The helper

Three additions to `disbot/views/navigation.py`:

- `BackTarget` — frozen dataclass `(builder, label, custom_id)`. Captures "what comes above me."
- `attach_back_target(view, target)` — convenience wrapper for `attach_back_button(view, label=…, custom_id=…, parent_builder=…)`.
- `chain_back(builder, grandparent)` — returns a wrapped builder that, after calling `builder`, attaches `grandparent` via `attach_back_target` on the rebuilt view. Identity transform when `grandparent is None` so direct-entry openers don't pick up a spurious back button.

The chain is purely closure-based. No router, no view base class change, no decorator. Persistent-view fail-safe: `BackTarget` closures are in-memory only; restored views start without a chain and rely on click-time governance recheck (PR D) for correctness.

### Wiring

- `help_cog._attach_back_to_help_button` now stashes `view._back_target` so downstream openers can compose through Help.
- `views.economy.main_panel.attach_back_to_economy_button` accepts `grandparent: BackTarget | None`, uses `chain_back`, and stashes its own `_back_target` on the child.
- `EconomyPanelView.inventory_btn` forwards `self._back_target` as the grandparent.
- `EconomyPanelView.shop_btn` propagates `self._back_target` onto the `_ShopSubView`.
- `shop_panel._ShopSubView.back_btn` re-attaches its propagated origin on the rebuilt `EconomyPanelView` when present.

### Why I did NOT touch `inventory_cog._CategoryView`

`_CategoryView._back_to_hub` returns to the **live** `UnifiedInventoryView` instance (`self._hub`), which already carries the chained back-to-Economy attached by `attach_back_to_economy_button`. So Category → Back → Inventory (live) → Back to Economy (rebuilt via `chain_back` with Help re-attached) → Back to Help all work without modifying Category. The plan called for an optional rebuild via `chain_back` to handle the hub-instance-timeout case; that's a minor UX risk only (180s timeout vs typical sub-second navigation) and would have widened the PR. Can be added in a follow-up if telemetry shows the staleness is hit in practice.

### Scope

| File | Change |
|---|---|
| `disbot/views/navigation.py` | Add `BackTarget`, `attach_back_target`, `chain_back`. |
| `disbot/cogs/help_cog.py` | Stash `_back_target` after attaching back-to-Help. |
| `disbot/views/economy/main_panel.py` | `attach_back_to_economy_button` accepts grandparent + uses chain_back + stashes its own `_back_target`. Inventory and Shop buttons propagate the chain. |
| `disbot/views/economy/shop_panel.py` | `_ShopSubView.back_btn` re-attaches origin when present. |
| `tests/unit/views/test_navigation.py` | 10 new tests for the helper + integration. |

### Test plan

- [x] `tests/unit/views/test_navigation.py` — 22/22 (12 existing + 10 new).
- [x] Full `tests/` suite — 2417/2417.
- [x] `mypy disbot/`, `ruff check .`, `black --check .`, `isort --check-only disbot/` all clean.
- [ ] Manual Discord smoke (post-merge / post-deploy):
  - `/help economy` → Inventory → category → ↩ back → Inventory (back-to-Economy still present) → ↩ back → Economy (back-to-Help present) → ↩ back → Help.
  - `/help economy` → Shop → buy → ↩ back → Economy (back-to-Help present) → ↩ back → Help.
  - `!economymenu` → Inventory → category → ↩ back → Inventory → no back-to-Help (top of stack, correct).
  - `!economymenu` → Shop → buy → ↩ back → Economy → no back-to-Help.
  - Restart bot. Click a stale persistent Economy panel → it works as top-of-stack (no chain), no errors.

### Rollback

Additive helper + opt-in attribute + opt-in kwarg. Revert restores the per-call hand-attached back behavior; no schema or migration changes.

### Follow-ups

- PR D: governance filter on Games / Community hub child buttons (issues #7, #8).
- PR C: interactive cog manager with critical-cog protection (issue #6).
- PR B': tournament direct-write classification + migration (issue #10).
- Optional: `_CategoryView._back_to_hub` rebuild via `chain_back` for hub-instance-timeout robustness.

https://claude.ai/code/session_01VJhdMgBEfU2LmvgiiS5TN4

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJhdMgBEfU2LmvgiiS5TN4)_