### PR TITLE
hubs: filter Games + Community child buttons by governance visibility

### DIFF
--- a/disbot/cogs/community_cog.py
+++ b/disbot/cogs/community_cog.py
@@ -26,7 +26,7 @@ from discord.ext import commands
 
 from core.runtime.interaction_helpers import help_ctx_shim
 from views.base import send_panel
-from views.community.hub import CommunityHubView, build_community_hub_embed
+from views.community.hub import build_community_hub_panel
 
 logger = logging.getLogger("bot.cogs.community")
 
@@ -40,8 +40,8 @@ class CommunityCog(commands.Cog):
     @commands.command(name="community")
     async def community_menu(self, ctx: commands.Context) -> None:
         """Open the Community hub — XP, Roles, and community activities."""
-        view = CommunityHubView(ctx.author)
-        await send_panel(ctx, embed=build_community_hub_embed(), view=view)
+        embed, view = await build_community_hub_panel(ctx.author, ctx=ctx)
+        await send_panel(ctx, embed=embed, view=view)
 
     async def build_help_menu_view(
         self,
@@ -49,8 +49,7 @@ class CommunityCog(commands.Cog):
     ) -> tuple[discord.Embed, discord.ui.View]:
         """Help-menu direct-navigation hook — returns the Community hub panel."""
         ctx_shim = help_ctx_shim(interaction)
-        view = CommunityHubView(ctx_shim.author)
-        return build_community_hub_embed(), view
+        return await build_community_hub_panel(ctx_shim.author, interaction=interaction)
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/disbot/cogs/games_cog.py
+++ b/disbot/cogs/games_cog.py
@@ -22,7 +22,7 @@ from discord.ext import commands
 
 from core.runtime.interaction_helpers import help_ctx_shim
 from views.base import send_panel
-from views.games.hub import GamesHubView, build_games_hub_embed
+from views.games.hub import build_games_hub_panel
 
 logger = logging.getLogger("bot.cogs.games")
 
@@ -36,8 +36,8 @@ class GamesCog(commands.Cog):
     @commands.command(name="games")
     async def games_menu(self, ctx: commands.Context) -> None:
         """Open the Games hub — competitive games and channel activities."""
-        view = GamesHubView(ctx.author)
-        await send_panel(ctx, embed=build_games_hub_embed(), view=view)
+        embed, view = await build_games_hub_panel(ctx.author, ctx=ctx)
+        await send_panel(ctx, embed=embed, view=view)
 
     async def build_help_menu_view(
         self,
@@ -45,8 +45,7 @@ class GamesCog(commands.Cog):
     ) -> tuple[discord.Embed, discord.ui.View]:
         """Help-menu direct-navigation hook — returns the Games hub panel."""
         ctx_shim = help_ctx_shim(interaction)
-        view = GamesHubView(ctx_shim.author)
-        return build_games_hub_embed(), view
+        return await build_games_hub_panel(ctx_shim.author, interaction=interaction)
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/disbot/views/community/hub.py
+++ b/disbot/views/community/hub.py
@@ -30,11 +30,15 @@ from __future__ import annotations
 import logging
 
 import discord
+from discord.ext import commands
 
+from services import governance_service
+from services.governance_service import GovernanceContext
 from utils.hub_registry import get_hub
 from utils.subsystem_registry import SUBSYSTEMS
 from utils.ui_constants import GENERAL_COLOR
 from views.base import HubView
+from views.navigation import attach_back_button
 
 logger = logging.getLogger("bot.views.community")
 
@@ -88,15 +92,25 @@ def _format_child_label(subsystem: str, meta: dict) -> str:
     return f"{emoji} {display}"
 
 
-def build_community_hub_embed() -> discord.Embed:
+def build_community_hub_embed(
+    primary: list[tuple[str, dict]] | None = None,
+    cross_link: list[tuple[str, dict]] | None = None,
+) -> discord.Embed:
     """Build the embed shown by :class:`CommunityHubView`.
 
     Description is generated from the discovered children so it stays
     in sync with the registry. The "Progression" / "Community games &
     standings" group headings are hardcoded — they are presentational
     framing, not metadata.
+
+    PR D: when ``primary`` and ``cross_link`` are supplied (typically
+    pre-filtered by :func:`build_community_hub_panel`), the embed only
+    describes those subsystems. When either is ``None``, falls back to
+    unfiltered discovery — used by callers that construct the view
+    directly (tests, persistent re-registration).
     """
-    primary, cross_link = discover_community_children()
+    if primary is None or cross_link is None:
+        primary, cross_link = discover_community_children()
     parts = ["Pick a community feature below."]
 
     if primary:
@@ -124,6 +138,82 @@ def build_community_hub_embed() -> discord.Embed:
     return embed
 
 
+async def build_community_hub_panel(
+    author: discord.Member | discord.User,
+    *,
+    interaction: discord.Interaction | None = None,
+    ctx: commands.Context | None = None,
+    visible: set[str] | None = None,
+) -> tuple[discord.Embed, CommunityHubView]:
+    """Resolve governance, filter children, and build the hub panel.
+
+    Single source of truth for opening the Community hub. Callers:
+
+    * ``!community`` prefix command → pass ``ctx``.
+    * ``CommunityCog.build_help_menu_view`` (help hook) → pass ``interaction``.
+    * Back-to-Community closure rebuilds → pass ``interaction``.
+
+    When ``visible`` is supplied the caller has already resolved
+    visibility and we skip the re-resolution. Otherwise the factory
+    builds a :class:`GovernanceContext` from whichever of
+    ``interaction`` / ``ctx`` was provided and calls
+    ``governance_service.resolve_visibility``.
+
+    Both primary and cross-link children are filtered through the
+    visible set. Cross-links that point at a hidden subsystem are
+    dropped silently — operators see them again as soon as the
+    subsystem becomes visible.
+    """
+    if visible is None:
+        if interaction is not None:
+            gctx = GovernanceContext.from_interaction(interaction)
+        elif ctx is not None:
+            gctx = GovernanceContext.from_ctx(ctx)
+        else:
+            raise ValueError(
+                "build_community_hub_panel requires interaction or ctx "
+                "when visible is not pre-resolved",
+            )
+        result = await governance_service.resolve_visibility(gctx)
+        visible = result.visible_subsystems
+
+    primary, cross_link = discover_community_children()
+    primary = [(name, meta) for name, meta in primary if name in visible]
+    cross_link = [(name, meta) for name, meta in cross_link if name in visible]
+
+    embed = build_community_hub_embed(primary, cross_link)
+    view = CommunityHubView(author, primary=primary, cross_link=cross_link)
+    return embed, view
+
+
+def attach_back_to_community_button(
+    view: discord.ui.View,
+    author: discord.Member | discord.User,
+) -> bool:
+    """Append a "↩ Back to Community" control to a child view.
+
+    Mirrors :func:`disbot.views.games.hub.attach_back_to_games_button`.
+    The parent-builder closure routes through
+    :func:`build_community_hub_panel` so the rebuilt hub is filtered
+    through governance at click time.
+    """
+
+    async def _build_community_parent(
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        return await build_community_hub_panel(author, interaction=interaction)
+
+    return attach_back_button(
+        view,
+        label="↩ Back to Community",
+        custom_id="community:back",
+        parent_builder=_build_community_parent,
+        row=4,
+        style=discord.ButtonStyle.secondary,
+        error_message="Could not reload the Community hub. Please try again.",
+    )
+
+
 class _CommunityChildButton(discord.ui.Button):
     """A button on the Community hub that opens a child cog's
     ``build_help_menu_view`` in place.
@@ -146,6 +236,21 @@ class _CommunityChildButton(discord.ui.Button):
         self._subsystem = subsystem
 
     async def callback(self, interaction: discord.Interaction) -> None:
+        # PR D: click-time governance recheck. If the targeted
+        # subsystem has become invisible since this button was
+        # rendered, fail closed with an ephemeral and do NOT call into
+        # the cog. ``resolve_visibility`` is cached by ``(guild_id,
+        # channel_id, tier, role_ids)`` so the re-check is essentially
+        # free in steady state.
+        gctx = GovernanceContext.from_interaction(interaction)
+        vis_result = await governance_service.resolve_visibility(gctx)
+        if self._subsystem not in vis_result.visible_subsystems:
+            await interaction.response.send_message(
+                "That feature is no longer available in this channel.",
+                ephemeral=True,
+            )
+            return
+
         # Local import keeps the help cog out of module-import time.
         from cogs.help_cog import _cog_for_subsystem
 
@@ -195,9 +300,23 @@ class CommunityHubView(HubView):
 
     SUBSYSTEM = "community"
 
-    def __init__(self, author: discord.Member | discord.User) -> None:
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        *,
+        primary: list[tuple[str, dict]] | None = None,
+        cross_link: list[tuple[str, dict]] | None = None,
+    ) -> None:
         super().__init__(author)
-        primary, cross_link = discover_community_children()
+        # PR D: ``primary`` and ``cross_link`` are normally pre-filtered
+        # by :func:`build_community_hub_panel` so only
+        # governance-visible subsystems render. Either being ``None``
+        # falls back to unfiltered discovery — used by tests and any
+        # caller that constructs the view directly. Click-time recheck
+        # in :class:`_CommunityChildButton.callback` still gates
+        # correctly even on the unfiltered path.
+        if primary is None or cross_link is None:
+            primary, cross_link = discover_community_children()
         for subsystem, meta in primary:
             self.add_item(
                 _CommunityChildButton(
@@ -220,6 +339,8 @@ class CommunityHubView(HubView):
 
 __all__ = [
     "CommunityHubView",
+    "attach_back_to_community_button",
     "build_community_hub_embed",
+    "build_community_hub_panel",
     "discover_community_children",
 ]

--- a/disbot/views/games/hub.py
+++ b/disbot/views/games/hub.py
@@ -29,7 +29,10 @@ from __future__ import annotations
 import logging
 
 import discord
+from discord.ext import commands
 
+from services import governance_service
+from services.governance_service import GovernanceContext
 from utils.subsystem_registry import SUBSYSTEMS
 from utils.ui_constants import GAME_COLOR
 from views.base import HubView
@@ -68,8 +71,17 @@ def discover_game_children() -> list[tuple[str, dict]]:
     return children
 
 
-def build_games_hub_embed() -> discord.Embed:
-    """Build the embed shown by :class:`GamesHubView`."""
+def build_games_hub_embed(
+    children: list[tuple[str, dict]] | None = None,
+) -> discord.Embed:
+    """Build the embed shown by :class:`GamesHubView`.
+
+    When ``children`` is supplied (typically pre-filtered by
+    :func:`build_games_hub_panel`), the embed only describes those
+    subsystems. When ``None``, falls back to the unfiltered list — used
+    by callers that construct the view directly (tests, persistent
+    re-registration).
+    """
     embed = discord.Embed(
         title="🎮 Games Hub",
         description=(
@@ -79,8 +91,11 @@ def build_games_hub_embed() -> discord.Embed:
         color=GAME_COLOR,
     )
 
+    if children is None:
+        children = discover_game_children()
+
     by_group: dict[str, list[tuple[str, dict]]] = {}
-    for name, meta in discover_game_children():
+    for name, meta in children:
         group = meta.get("hub_group") or "other"
         by_group.setdefault(group, []).append((name, meta))
 
@@ -110,6 +125,52 @@ def build_games_hub_embed() -> discord.Embed:
     return embed
 
 
+async def build_games_hub_panel(
+    author: discord.Member | discord.User,
+    *,
+    interaction: discord.Interaction | None = None,
+    ctx: commands.Context | None = None,
+    visible: set[str] | None = None,
+) -> tuple[discord.Embed, GamesHubView]:
+    """Resolve governance, filter children, and build the hub panel.
+
+    Single source of truth for opening the Games hub. Callers are:
+
+    * ``!games`` prefix command → pass ``ctx``.
+    * ``GamesCog.build_help_menu_view`` (help hook) → pass ``interaction``.
+    * Back-to-Games closure rebuilds → pass ``interaction``.
+
+    When ``visible`` is supplied the caller has already resolved
+    visibility (e.g. inside an outer closure) and we skip the
+    re-resolution. Otherwise the factory builds a
+    :class:`GovernanceContext` from whichever of ``interaction`` /
+    ``ctx`` was provided and calls
+    ``governance_service.resolve_visibility``.
+
+    Filtered children are passed to both the embed builder and the
+    view constructor so the surface stays in sync.
+    """
+    if visible is None:
+        if interaction is not None:
+            gctx = GovernanceContext.from_interaction(interaction)
+        elif ctx is not None:
+            gctx = GovernanceContext.from_ctx(ctx)
+        else:
+            raise ValueError(
+                "build_games_hub_panel requires interaction or ctx "
+                "when visible is not pre-resolved",
+            )
+        result = await governance_service.resolve_visibility(gctx)
+        visible = result.visible_subsystems
+
+    children = [
+        (name, meta) for name, meta in discover_game_children() if name in visible
+    ]
+    embed = build_games_hub_embed(children)
+    view = GamesHubView(author, children=children)
+    return embed, view
+
+
 def attach_back_to_games_button(
     view: discord.ui.View,
     author: discord.Member | discord.User,
@@ -119,8 +180,11 @@ def attach_back_to_games_button(
     Thin wrapper around :func:`views.navigation.attach_back_button` (S2).
     The parent-builder closure captures ``author`` so the rebuilt
     :class:`GamesHubView` remains invoker-restricted; the child list is
-    re-discovered from ``SUBSYSTEMS`` at click time so the hub reflects
-    the live registry, not the snapshot from when the panel was opened.
+    re-discovered (and re-filtered through governance) at click time so
+    the hub reflects the live state — not the snapshot from when the
+    panel was opened. PR D: rebuild now routes through
+    :func:`build_games_hub_panel` to apply governance filtering on the
+    rebuilt hub.
 
     Returns ``False`` (no-op) if the view is already at Discord's
     25-component cap — ``attach_back_button`` logs a WARNING in that
@@ -128,9 +192,9 @@ def attach_back_to_games_button(
     """
 
     async def _build_games_parent(
-        _interaction: discord.Interaction,
+        interaction: discord.Interaction,
     ) -> tuple[discord.Embed, discord.ui.View]:
-        return build_games_hub_embed(), GamesHubView(author)
+        return await build_games_hub_panel(author, interaction=interaction)
 
     return attach_back_button(
         view,
@@ -229,7 +293,11 @@ class GamesHubView(HubView):
 
     SUBSYSTEM = "games"
 
-    def __init__(self, author: discord.Member | discord.User) -> None:
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        children: list[tuple[str, dict]] | None = None,
+    ) -> None:
         super().__init__(author)
         # NOTE: discord.py's ``discord.ui.View`` uses ``self._children``
         # for its internal items list (see ``discord/ui/view.py``
@@ -237,7 +305,16 @@ class GamesHubView(HubView):
         # ``self._children`` overwrites the items list and lets tuples
         # leak into the view's components — which fails serialization
         # when the view is sent to Discord. Use a distinct name.
-        self._game_children = discover_game_children()
+        #
+        # PR D: ``children`` is normally pre-filtered by
+        # :func:`build_games_hub_panel` so only governance-visible
+        # subsystems render. ``None`` falls back to the unfiltered
+        # discovery — used by tests and any caller that constructs
+        # the view directly. Click-time recheck in :meth:`handle_select`
+        # still gates correctly even on the unfiltered path.
+        if children is None:
+            children = discover_game_children()
+        self._game_children = children
         self.add_item(_GamesHubSelect(self._game_children))
 
     async def handle_select(
@@ -257,6 +334,21 @@ class GamesHubView(HubView):
         if meta is None or meta.get("parent_hub") != "games":
             await interaction.response.send_message(
                 "That game is no longer routed to the Games hub.",
+                ephemeral=True,
+            )
+            return
+
+        # PR D: click-time governance recheck. If the subsystem has
+        # become invisible between render and click (visibility change,
+        # role removal, channel scope override), fail closed with an
+        # ephemeral. ``resolve_visibility`` is cached by
+        # ``(guild_id, channel_id, tier, role_ids)`` so the re-check is
+        # essentially free in steady state.
+        gctx = GovernanceContext.from_interaction(interaction)
+        vis_result = await governance_service.resolve_visibility(gctx)
+        if sub_name not in vis_result.visible_subsystems:
+            await interaction.response.send_message(
+                "That feature is no longer available in this channel.",
                 ephemeral=True,
             )
             return

--- a/tests/unit/cogs/test_games_cog.py
+++ b/tests/unit/cogs/test_games_cog.py
@@ -11,13 +11,16 @@ These tests assert the contract surfaces:
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
 from discord.ext import commands
 
 from cogs.games_cog import GamesCog
+from governance.models import VisibilityResult
+from utils.subsystem_registry import SUBSYSTEMS
 from views.games.hub import GamesHubView
 
 
@@ -30,6 +33,28 @@ def _author(id_: int = 1) -> MagicMock:
 def _cog() -> GamesCog:
     bot = MagicMock(spec=commands.Bot)
     return GamesCog(bot)
+
+
+@contextmanager
+def _all_visible():
+    """Patch resolve_visibility to return every subsystem visible.
+
+    PR D: `build_games_hub_panel` resolves governance internally before
+    constructing the view. Tests that don't exercise the governance
+    surface still need this so the factory doesn't try to hit the DB.
+    """
+    vis_result = VisibilityResult(
+        visible_subsystems=set(SUBSYSTEMS),
+        member_tier="moderator",
+        resolved_from={},
+        traces={},
+    )
+    with patch(
+        "services.governance_service.resolve_visibility",
+        new_callable=AsyncMock,
+        return_value=vis_result,
+    ):
+        yield
 
 
 def test_cog_registers_games_command():
@@ -69,10 +94,12 @@ async def test_build_help_menu_view_returns_embed_and_view():
     interaction = MagicMock(spec=discord.Interaction)
     interaction.user = _author()
     interaction.guild = MagicMock()
+    interaction.guild_id = 42
     interaction.channel = MagicMock()
     interaction.client = MagicMock()
 
-    embed, view = await cog.build_help_menu_view(interaction)
+    with _all_visible():
+        embed, view = await cog.build_help_menu_view(interaction)
 
     assert isinstance(embed, discord.Embed)
     assert isinstance(view, GamesHubView)
@@ -83,10 +110,15 @@ async def test_games_command_sends_panel():
     cog = _cog()
     ctx = MagicMock(spec=commands.Context)
     ctx.author = _author()
+    ctx.guild = MagicMock()
+    ctx.channel = MagicMock()
+    ctx.message = MagicMock()
+    ctx.message.author = ctx.author
     ctx.send = AsyncMock(return_value=MagicMock(spec=discord.Message))
 
     # Invoke the underlying callback directly so we don't need a real bot.
-    await cog.games_menu.callback(cog, ctx)
+    with _all_visible():
+        await cog.games_menu.callback(cog, ctx)
 
     ctx.send.assert_awaited_once()
     _args, kwargs = ctx.send.call_args

--- a/tests/unit/views/test_community_hub_view.py
+++ b/tests/unit/views/test_community_hub_view.py
@@ -21,11 +21,13 @@ resolution.
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
 
+from governance.models import VisibilityResult
 from utils.hub_registry import get_hub
 from utils.subsystem_registry import SUBSYSTEMS
 from views.community.hub import (
@@ -49,6 +51,30 @@ def _interaction() -> MagicMock:
     interaction.response.send_message = AsyncMock()
     interaction.response.edit_message = AsyncMock()
     return interaction
+
+
+@contextmanager
+def _all_visible():
+    """Patch resolve_visibility to return every subsystem visible.
+
+    PR D added a click-time recheck inside
+    ``_CommunityChildButton.callback`` that hits
+    ``governance_service.resolve_visibility`` before delegating to the
+    target cog. Existing button-callback tests assume the recheck
+    passes; without this stub the recheck tries to hit the DB.
+    """
+    vis_result = VisibilityResult(
+        visible_subsystems=set(SUBSYSTEMS),
+        member_tier="moderator",
+        resolved_from={},
+        traces={},
+    )
+    with patch(
+        "services.governance_service.resolve_visibility",
+        new_callable=AsyncMock,
+        return_value=vis_result,
+    ):
+        yield
 
 
 # ---------------------------------------------------------------------------
@@ -241,7 +267,9 @@ async def test_button_opens_host_cog_panel_in_place():
     fake_cog.build_help_menu_view = AsyncMock(return_value=(fake_embed, fake_view))
 
     interaction = _interaction()
-    with patch("cogs.help_cog._cog_for_subsystem", return_value=fake_cog):
+    with _all_visible(), patch(
+        "cogs.help_cog._cog_for_subsystem", return_value=fake_cog
+    ):
         await button.callback(interaction)
 
     fake_cog.build_help_menu_view.assert_awaited_once_with(interaction)
@@ -260,7 +288,9 @@ async def test_button_missing_cog_sends_ephemeral():
         row=0,
     )
     interaction = _interaction()
-    with patch("cogs.help_cog._cog_for_subsystem", return_value=None):
+    with _all_visible(), patch(
+        "cogs.help_cog._cog_for_subsystem", return_value=None
+    ):
         await button.callback(interaction)
     interaction.response.send_message.assert_awaited_once()
     interaction.response.edit_message.assert_not_called()
@@ -276,7 +306,9 @@ async def test_button_cog_without_hook_sends_ephemeral():
     )
     fake_cog = MagicMock(spec=[])  # no build_help_menu_view attr
     interaction = _interaction()
-    with patch("cogs.help_cog._cog_for_subsystem", return_value=fake_cog):
+    with _all_visible(), patch(
+        "cogs.help_cog._cog_for_subsystem", return_value=fake_cog
+    ):
         await button.callback(interaction)
     interaction.response.send_message.assert_awaited_once()
     interaction.response.edit_message.assert_not_called()
@@ -293,7 +325,9 @@ async def test_button_hook_exception_sends_ephemeral():
     fake_cog = MagicMock()
     fake_cog.build_help_menu_view = AsyncMock(side_effect=RuntimeError("boom"))
     interaction = _interaction()
-    with patch("cogs.help_cog._cog_for_subsystem", return_value=fake_cog):
+    with _all_visible(), patch(
+        "cogs.help_cog._cog_for_subsystem", return_value=fake_cog
+    ):
         await button.callback(interaction)
     interaction.response.send_message.assert_awaited_once()
     interaction.response.edit_message.assert_not_called()
@@ -311,3 +345,147 @@ def test_view_contains_no_select_components():
     view = CommunityHubView(_author())
     selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
     assert selects == []
+
+
+# ---------------------------------------------------------------------------
+# PR D — Governance filtering and click-time recheck
+# ---------------------------------------------------------------------------
+
+
+def test_view_falls_back_to_unfiltered_when_lists_omitted():
+    """Backward-compat: ``CommunityHubView(author)`` still works for
+    tests and persistent re-registration paths that can't await the
+    factory. Click-time recheck remains the safety net.
+    """
+    view = CommunityHubView(_author())
+    buttons = {
+        c._subsystem  # type: ignore[attr-defined]
+        for c in view.children
+        if isinstance(c, _CommunityChildButton)
+    }
+    # Same as before PR D — five children rendered when nothing is filtered.
+    assert buttons == {"xp", "role", "counting", "chain", "leaderboard"}
+
+
+def test_view_uses_pre_filtered_lists_when_supplied():
+    """The factory passes ``primary`` and ``cross_link`` so only
+    visible subsystems render. Pin the constructor honors the filter.
+    """
+    primary = [("xp", dict(SUBSYSTEMS["xp"]))]
+    cross_link = [("leaderboard", dict(SUBSYSTEMS["leaderboard"]))]
+    view = CommunityHubView(
+        _author(),
+        primary=primary,
+        cross_link=cross_link,
+    )
+    buttons = {
+        c._subsystem  # type: ignore[attr-defined]
+        for c in view.children
+        if isinstance(c, _CommunityChildButton)
+    }
+    assert buttons == {"xp", "leaderboard"}
+
+
+@pytest.mark.asyncio
+async def test_build_community_hub_panel_filters_via_visible_set():
+    from views.community.hub import build_community_hub_panel
+
+    _embed, view = await build_community_hub_panel(
+        _author(),
+        visible={"xp", "leaderboard"},
+    )
+    buttons = {
+        c._subsystem  # type: ignore[attr-defined]
+        for c in view.children
+        if isinstance(c, _CommunityChildButton)
+    }
+    assert buttons == {"xp", "leaderboard"}
+
+
+@pytest.mark.asyncio
+async def test_build_community_hub_panel_resolves_when_visible_none():
+    """The factory must call governance once when ``visible`` is None."""
+    from views.community.hub import build_community_hub_panel
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = _author()
+    interaction.guild_id = 7
+    interaction.channel = MagicMock()
+
+    vis_result = VisibilityResult(
+        visible_subsystems={"xp"},
+        member_tier="moderator",
+        resolved_from={},
+        traces={},
+    )
+    with patch(
+        "services.governance_service.resolve_visibility",
+        new_callable=AsyncMock,
+        return_value=vis_result,
+    ) as mock_resolve:
+        _embed, view = await build_community_hub_panel(
+            _author(),
+            interaction=interaction,
+        )
+
+    mock_resolve.assert_awaited_once()
+    buttons = {
+        c._subsystem  # type: ignore[attr-defined]
+        for c in view.children
+        if isinstance(c, _CommunityChildButton)
+    }
+    assert buttons == {"xp"}
+
+
+@pytest.mark.asyncio
+async def test_button_fails_closed_when_subsystem_invisible():
+    """Click-time recheck: if a subsystem drops out of visibility
+    between render and click, the button must surface an ephemeral
+    and NOT call into the cog.
+    """
+    button = _CommunityChildButton(
+        subsystem="xp",
+        label="🏆 XP",
+        style=discord.ButtonStyle.primary,
+        row=0,
+    )
+    interaction = _interaction()
+    interaction.user = _author()
+    interaction.guild_id = 7
+    interaction.channel = MagicMock()
+
+    vis_result = VisibilityResult(
+        visible_subsystems=set(),  # xp not visible anymore
+        member_tier="member",
+        resolved_from={},
+        traces={},
+    )
+    cog_lookup = MagicMock()
+    with patch(
+        "services.governance_service.resolve_visibility",
+        new_callable=AsyncMock,
+        return_value=vis_result,
+    ), patch("cogs.help_cog._cog_for_subsystem", cog_lookup):
+        await button.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    args, kwargs = interaction.response.send_message.call_args
+    message = args[0] if args else kwargs.get("content", "")
+    assert "no longer available" in message
+    assert kwargs.get("ephemeral") is True
+    cog_lookup.assert_not_called()
+    interaction.response.edit_message.assert_not_called()
+
+
+def test_attach_back_to_community_button_adds_back_button():
+    """Symmetry pin: a back-to-community helper must exist for child
+    panels opened from the hub, mirroring back-to-games.
+    """
+    from views.community.hub import attach_back_to_community_button
+
+    view = discord.ui.View()
+    added = attach_back_to_community_button(view, _author())
+    assert added is True
+    btn = next(c for c in view.children if isinstance(c, discord.ui.Button))
+    assert btn.label == "↩ Back to Community"
+    assert btn.custom_id == "community:back"

--- a/tests/unit/views/test_games_hub_view.py
+++ b/tests/unit/views/test_games_hub_view.py
@@ -16,11 +16,13 @@ tests assert on routing surfaces only.
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
 
+from governance.models import VisibilityResult
 from utils.subsystem_registry import SUBSYSTEMS
 from views.games.hub import (
     _GROUP_ORDER,
@@ -36,6 +38,30 @@ def _author(id_: int = 1) -> MagicMock:
     author = MagicMock(spec=discord.Member)
     author.id = id_
     return author
+
+
+@contextmanager
+def _all_visible():
+    """Stub resolve_visibility to return every subsystem visible.
+
+    PR D added a click-time recheck inside ``handle_select`` and the
+    rebuilt-hub path inside ``attach_back_to_games_button`` now goes
+    through ``build_games_hub_panel`` which resolves governance. Tests
+    that aren't designed to exercise the gating need a stub so the
+    factory doesn't hit the real DB.
+    """
+    vis_result = VisibilityResult(
+        visible_subsystems=set(SUBSYSTEMS),
+        member_tier="moderator",
+        resolved_from={},
+        traces={},
+    )
+    with patch(
+        "services.governance_service.resolve_visibility",
+        new_callable=AsyncMock,
+        return_value=vis_result,
+    ):
+        yield
 
 
 # ---------------------------------------------------------------------------
@@ -268,7 +294,7 @@ async def test_handle_select_missing_cog_renders_fallback():
     interaction.response.send_message = AsyncMock()
     interaction.response.edit_message = AsyncMock()
 
-    with patch("views.games.hub.SUBSYSTEMS") as fake_subs:
+    with _all_visible(), patch("views.games.hub.SUBSYSTEMS") as fake_subs:
         # Pick any real games child but make _cog_for_subsystem return None.
         sub_name = "blackjack"
         fake_subs.get.return_value = dict(SUBSYSTEMS[sub_name])
@@ -294,7 +320,9 @@ async def test_handle_select_hook_failure_renders_fallback():
     fake_cog = MagicMock()
     fake_cog.build_help_menu_view = AsyncMock(side_effect=RuntimeError("boom"))
 
-    with patch("cogs.help_cog._cog_for_subsystem", return_value=fake_cog):
+    with _all_visible(), patch(
+        "cogs.help_cog._cog_for_subsystem", return_value=fake_cog
+    ):
         await view.handle_select(interaction, "blackjack")
 
     interaction.response.edit_message.assert_awaited_once()
@@ -314,7 +342,9 @@ async def test_handle_select_success_attaches_back_button():
     fake_cog = MagicMock()
     fake_cog.build_help_menu_view = AsyncMock(return_value=(child_embed, child_view))
 
-    with patch("cogs.help_cog._cog_for_subsystem", return_value=fake_cog):
+    with _all_visible(), patch(
+        "cogs.help_cog._cog_for_subsystem", return_value=fake_cog
+    ):
         await view.handle_select(interaction, "blackjack")
 
     interaction.response.edit_message.assert_awaited_once()
@@ -378,7 +408,8 @@ async def test_back_button_callback_rebuilds_games_hub_with_original_author():
     interaction.edit_original_response = AsyncMock()
 
     btn = next(c for c in view.children if isinstance(c, discord.ui.Button))
-    await btn.callback(interaction)  # type: ignore[union-attr,misc]
+    with _all_visible():
+        await btn.callback(interaction)  # type: ignore[union-attr,misc]
 
     interaction.response.edit_message.assert_awaited_once()
     _args, kwargs = interaction.response.edit_message.call_args
@@ -406,3 +437,138 @@ def test_attach_back_to_games_button_delegates_to_shared_helper():
     # The shared helper must be reachable via an actual import — either at
     # module level or function-local. Pin both shapes.
     assert "from views.navigation" in module_src or "views.navigation" in fn_src
+
+
+# ---------------------------------------------------------------------------
+# PR D — Governance filtering and click-time recheck
+# ---------------------------------------------------------------------------
+
+
+def test_view_falls_back_to_unfiltered_when_children_omitted():
+    """Backward-compat: callers that construct ``GamesHubView(author)``
+    directly (tests, persistent re-registration) still get the
+    unfiltered discovery so the view renders. Click-time recheck is
+    the safety net for that path.
+    """
+    view = GamesHubView(_author())
+    options = [c for c in view.children if isinstance(c, discord.ui.Select)][0].options
+    option_values = {o.value for o in options}
+    expected = {name for name, _ in discover_game_children()}
+    assert option_values == expected
+
+
+def test_view_uses_pre_filtered_children_when_supplied():
+    """The factory passes ``children`` so only visible subsystems
+    appear in the select. Pin the constructor honors the filter.
+    """
+    only = [(name, dict(SUBSYSTEMS[name])) for name in ("blackjack",)]
+    view = GamesHubView(_author(), children=only)
+    select = next(c for c in view.children if isinstance(c, discord.ui.Select))
+    option_values = {o.value for o in select.options}
+    assert option_values == {"blackjack"}
+
+
+@pytest.mark.asyncio
+async def test_build_games_hub_panel_filters_via_visible_set():
+    """When ``visible`` is supplied the factory does not call
+    ``resolve_visibility`` — pure filter path. The resulting view
+    contains only the filtered children.
+    """
+    from views.games.hub import build_games_hub_panel
+
+    _embed, view = await build_games_hub_panel(
+        _author(),
+        visible={"blackjack"},
+    )
+    select = next(c for c in view.children if isinstance(c, discord.ui.Select))
+    option_values = {o.value for o in select.options}
+    assert option_values == {"blackjack"}
+
+
+@pytest.mark.asyncio
+async def test_build_games_hub_panel_resolves_when_visible_none():
+    """When ``visible`` is omitted the factory must call
+    ``governance_service.resolve_visibility`` exactly once.
+    """
+    from views.games.hub import build_games_hub_panel
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = _author()
+    interaction.guild_id = 7
+    interaction.channel = MagicMock()
+
+    vis_result = VisibilityResult(
+        visible_subsystems={"blackjack"},
+        member_tier="moderator",
+        resolved_from={},
+        traces={},
+    )
+    with patch(
+        "services.governance_service.resolve_visibility",
+        new_callable=AsyncMock,
+        return_value=vis_result,
+    ) as mock_resolve:
+        _embed, view = await build_games_hub_panel(
+            _author(),
+            interaction=interaction,
+        )
+
+    mock_resolve.assert_awaited_once()
+    select = next(c for c in view.children if isinstance(c, discord.ui.Select))
+    option_values = {o.value for o in select.options}
+    # Only the subsystem the stub returned as visible appears.
+    assert option_values == {"blackjack"}
+
+
+@pytest.mark.asyncio
+async def test_build_games_hub_panel_raises_without_context():
+    """When ``visible`` is None and neither ``interaction`` nor ``ctx``
+    is given, the factory must raise — programming-error fail-fast.
+    """
+    from views.games.hub import build_games_hub_panel
+
+    with pytest.raises(ValueError, match="interaction or ctx"):
+        await build_games_hub_panel(_author())
+
+
+@pytest.mark.asyncio
+async def test_handle_select_fails_closed_when_subsystem_invisible():
+    """Click-time recheck: if a subsystem drops out of visibility
+    between render and click, the select must surface an ephemeral
+    and NOT call into the cog. This is the failure-closed safety net
+    for stale persistent views.
+    """
+    view = GamesHubView(_author())
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = MagicMock()
+    interaction.user = _author()
+    interaction.guild_id = 7
+    interaction.channel = MagicMock()
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+
+    # Blackjack is no longer in visible_subsystems — stale click path.
+    vis_result = VisibilityResult(
+        visible_subsystems=set(),
+        member_tier="member",
+        resolved_from={},
+        traces={},
+    )
+    cog_lookup = MagicMock()
+    with patch(
+        "services.governance_service.resolve_visibility",
+        new_callable=AsyncMock,
+        return_value=vis_result,
+    ), patch("cogs.help_cog._cog_for_subsystem", cog_lookup):
+        await view.handle_select(interaction, "blackjack")
+
+    interaction.response.send_message.assert_awaited_once()
+    args, kwargs = interaction.response.send_message.call_args
+    message = args[0] if args else kwargs.get("content", "")
+    assert "no longer available" in message
+    assert kwargs.get("ephemeral") is True
+    # Crucial: the cog lookup must NOT have been called — gating
+    # happens BEFORE any side-effect.
+    cog_lookup.assert_not_called()
+    interaction.response.edit_message.assert_not_called()

--- a/tests/unit/views/test_mining_back_to_games.py
+++ b/tests/unit/views/test_mining_back_to_games.py
@@ -18,11 +18,13 @@ rendering) and the live debugging steps in plan §5a Bug #5 take over.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
 
+from governance.models import VisibilityResult
+from utils.subsystem_registry import SUBSYSTEMS
 from views.games.hub import GamesHubView, attach_back_to_games_button
 from views.mining.main_panel import MiningHubView
 
@@ -77,7 +79,21 @@ async def test_games_hub_select_attaches_back_to_games_on_child(monkeypatch):
     interaction.client = MagicMock()
     interaction.response.edit_message = AsyncMock()
 
-    await hub.handle_select(interaction, "mining")
+    # PR D: GamesHubView.handle_select now re-resolves governance at
+    # click time. Stub it to return every subsystem visible so the test
+    # exercises the routing path, not the gating.
+    vis_result = VisibilityResult(
+        visible_subsystems=set(SUBSYSTEMS),
+        member_tier="moderator",
+        resolved_from={},
+        traces={},
+    )
+    with patch(
+        "services.governance_service.resolve_visibility",
+        new_callable=AsyncMock,
+        return_value=vis_result,
+    ):
+        await hub.handle_select(interaction, "mining")
 
     interaction.response.edit_message.assert_awaited_once()
     kwargs = interaction.response.edit_message.await_args.kwargs


### PR DESCRIPTION
## Summary

PR D of the post-#152 stabilization plan. Closes issues #7 and #8 from the audit — the Games and Community hubs render child buttons unconditionally from `SUBSYSTEMS`/`hub_registry` metadata, with no governance filter. A normal user on a Community panel might see an admin-only Roles button; a stale click on a since-disabled subsystem would still open it.

## What this PR does

### Render-time filtering — factory pattern (no new modules)

Adds `async def build_games_hub_panel(author, *, interaction=None, ctx=None, visible=None)` and `async def build_community_hub_panel(...)` next to the existing embed builders. When `visible is None`, the factory builds `GovernanceContext` from whichever of `interaction`/`ctx` was provided and calls `services.governance_service.resolve_visibility`. Then it filters the discovered children and passes them to both the embed builder and the view constructor.

`GamesHubView.__init__` and `CommunityHubView.__init__` both gain an optional pre-filtered children kwarg. Backward-compat: constructing the view directly (no children) falls back to unfiltered discovery — used by tests and any persistent-view re-registration path.

`games_cog.py` and `community_cog.py` route both the prefix command and the `build_help_menu_view` hook through the factory. `attach_back_to_games_button._build_games_parent` now calls the factory so back-to-Games re-applies governance on rebuild. New `attach_back_to_community_button` mirrors the games helper for child views opened from community.

### Click-time fail-closed

`GamesHubView.handle_select` and `_CommunityChildButton.callback` both re-resolve visibility at the top of their click handlers. If the targeted subsystem has dropped out of visibility (toggled mid-session, role removed, channel scope override), they send an ephemeral and do NOT call into the target cog. `resolve_visibility` is cached by `(guild_id, channel_id, tier, role_ids)` per `disbot/governance/resolver.py:294` so the re-check is essentially free in steady state.

### Persistent-view fail-safe

Persistent views re-register on bot restart with `children=None` (factory not called because there's no interaction yet). The unfiltered fallback ensures the panel still renders; the click-time recheck is the correctness safety net. Documented in both hub module docstrings.

### Scope

| File | Change |
|---|---|
| `disbot/views/games/hub.py` | Add `build_games_hub_panel` factory + governance import; widen `GamesHubView.__init__` to accept `children=None`; add click-time recheck in `handle_select`; route back-to-games closure through factory. |
| `disbot/views/community/hub.py` | Symmetric `build_community_hub_panel` factory; widen `CommunityHubView.__init__` to accept `primary`/`cross_link`; click-time recheck in `_CommunityChildButton.callback`; new `attach_back_to_community_button` helper. |
| `disbot/cogs/games_cog.py` | Route prefix command and help hook through factory. |
| `disbot/cogs/community_cog.py` | Same. |
| `tests/unit/views/test_games_hub_view.py` | 6 new tests + stub `resolve_visibility` for 4 existing tests. |
| `tests/unit/views/test_community_hub_view.py` | 6 new tests + stub `resolve_visibility` for 4 existing tests. |
| `tests/unit/cogs/test_games_cog.py` | Stub `resolve_visibility` for 2 tests. |
| `tests/unit/views/test_mining_back_to_games.py` | Stub `resolve_visibility` for 1 test. |

### Test plan

- [x] 12 new tests covering factory filtering, factory resolving when `visible=None`, factory error when no context, render-time pre-filter, render-time fallback, click-time fail-closed (no cog lookup), and back-to-community helper presence.
- [x] 11 existing tests updated to stub `resolve_visibility` so they exercise the routing path, not the gating.
- [x] Full `tests/` suite — 2429/2429 pass.
- [x] `mypy disbot/`, `ruff check .`, `black --check .`, `isort --check-only disbot/` all clean.
- [ ] Manual Discord smoke (post-merge / post-deploy):
  - Normal user: `!community` and `/help` → Community shows only user-tier children (no Roles if Roles is admin-tier).
  - Admin: `!community` and `/help` → Community shows all five children.
  - Normal user: `!games` → only games visible at user-tier.
  - Toggle a subsystem via `!platform flag` mid-session → reopen hub → button gone; click stale cached button → ephemeral fail-closed.
  - Restart bot → click an old persistent hub message → click-time recheck still gates correctly.

### Rollback

Additive factory + optional kwargs; revert restores the unfiltered render path. No schema or migration changes. `resolve_visibility` cache is untouched.

### Out of scope for D — deliberate

- `back_target` kwarg on the factory: planned in the AB2 design but BackTarget integration is a separate, smaller follow-up after this lands.
- Other hubs (Economy, Moderation, Utility) — Games and Community are the two with the audited governance-leak issue. The pattern set here applies cleanly when other hubs need it.
- `_cog_for_subsystem` and `build_help_menu_view` hooks themselves — unchanged, they continue to be the routing primitive.

### Follow-ups

- PR B': tournament direct-write classification + migration (issue #10).
- PR C: interactive cog manager with critical-cog protection (issue #6).
- PR E1: user-tier slash front doors (depends on this PR being merged first).

https://claude.ai/code/session_01VJhdMgBEfU2LmvgiiS5TN4

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJhdMgBEfU2LmvgiiS5TN4)_