### PR TITLE
tournaments: typed tournament_state_service for ACTIVE_TOURNAMENT flag

### DIFF
--- a/disbot/cogs/blackjack_cog.py
+++ b/disbot/cogs/blackjack_cog.py
@@ -65,11 +65,10 @@ from cogs.blackjack._state import (  # noqa: F401 — re-exported
     _TournPlayerState,
 )
 from core.runtime import resources, tasks
-from services import economy_service, game_state_service
+from services import economy_service, game_state_service, tournament_state_service
 from services.blackjack_engine import is_blackjack as _is_blackjack
 from utils import db
 from utils.channels import cleanup_category, create_private_channel
-from utils.settings_keys import ACTIVE_TOURNAMENT
 from utils.ui_constants import ECONOMY_COLOR, SUCCESS_COLOR
 from views.blackjack import (  # noqa: F401 — re-exported
     BlackjackView,
@@ -354,9 +353,9 @@ class BlackjackCog(commands.Cog):
         """On startup, find leftover BJ Tournament categories and notify players."""
         await self.bot.wait_until_ready()
         for guild in self.bot.guilds:
-            flag = await db.get_setting(guild.id, ACTIVE_TOURNAMENT, "")
+            flag = await tournament_state_service.get_active(guild.id)
             if flag == "blackjack":
-                await db.set_setting(guild.id, ACTIVE_TOURNAMENT, "")
+                await tournament_state_service.clear_active(guild.id)
             cat = resources.resolve_channel(
                 guild,
                 name="BJ Tournament",
@@ -501,7 +500,7 @@ class BlackjackCog(commands.Cog):
         if _tournaments.get(ctx.guild.id):
             await ctx.send("A tournament is already running.", delete_after=8)
             return
-        existing = await db.get_setting(ctx.guild.id, ACTIVE_TOURNAMENT, "")
+        existing = await tournament_state_service.get_active(ctx.guild.id)
         if existing:
             await ctx.send(
                 f"A **{existing}** tournament is already active in this server.",
@@ -521,7 +520,7 @@ class BlackjackCog(commands.Cog):
             duration_mins,
         )
         _tournaments[ctx.guild.id] = tourn
-        await db.set_setting(ctx.guild.id, ACTIVE_TOURNAMENT, "blackjack")
+        await tournament_state_service.set_active(ctx.guild.id, "blackjack")
 
         view = _TournRegistrationView(tourn)
         msg = await ctx.send(embed=_tourn_embed(tourn), view=view)
@@ -574,7 +573,7 @@ async def _launch_tournament(
         if announce:
             await announce.send("❌ Tournament cancelled — no players registered.")  # type: ignore[union-attr]
         _tournaments.pop(tourn.guild_id, None)
-        await db.set_setting(tourn.guild_id, ACTIVE_TOURNAMENT, "")
+        await tournament_state_service.clear_active(tourn.guild_id)
         return
 
     # Deduct entry fees (uses shared TournamentRegistration helper)
@@ -587,7 +586,7 @@ async def _launch_tournament(
                 "❌ Tournament cancelled — no players could afford the entry fee.",
             )
         _tournaments.pop(tourn.guild_id, None)
-        await db.set_setting(tourn.guild_id, ACTIVE_TOURNAMENT, "")
+        await tournament_state_service.clear_active(tourn.guild_id)
         return
 
     if announce:
@@ -637,7 +636,7 @@ async def _launch_tournament(
             if announce:
                 await announce.send("❌ I don't have permission to create channels.")  # type: ignore[union-attr]
             _tournaments.pop(tourn.guild_id, None)
-            await db.set_setting(tourn.guild_id, ACTIVE_TOURNAMENT, "")
+            await tournament_state_service.clear_active(tourn.guild_id)
             return
         except Exception as e:
             logger.error("Failed to create tournament channel: %s", e)

--- a/disbot/cogs/rps_tournament/_helpers.py
+++ b/disbot/cogs/rps_tournament/_helpers.py
@@ -25,9 +25,9 @@ import discord
 from discord.ext import commands
 
 from core.runtime import resources, tasks
+from services import tournament_state_service
 from utils import db as global_db
 from utils.channels import cleanup_category, create_private_channel
-from utils.settings_keys import ACTIVE_TOURNAMENT
 
 logger = logging.getLogger("bot")
 
@@ -160,9 +160,9 @@ async def clear_stale_tournament_flag(bot: commands.Bot) -> None:
     """
     await bot.wait_until_ready()
     for guild in bot.guilds:
-        flag = await global_db.get_setting(guild.id, ACTIVE_TOURNAMENT, "")
+        flag = await tournament_state_service.get_active(guild.id)
         if flag == "rps":
-            await global_db.set_setting(guild.id, ACTIVE_TOURNAMENT, "")
+            await tournament_state_service.clear_active(guild.id)
 
 
 async def cleanup_orphaned_channels(bot: commands.Bot) -> None:

--- a/disbot/cogs/rps_tournament_cog.py
+++ b/disbot/cogs/rps_tournament_cog.py
@@ -67,9 +67,8 @@ from core.runtime import tasks
 from services import (  # noqa: F401 — game_state_service kept for back-compat patch sites
     economy_service,
     game_state_service,
+    tournament_state_service,
 )
-from utils import db as global_db
-from utils.settings_keys import ACTIVE_TOURNAMENT
 from utils.ui_constants import INFO_COLOR
 from views.rps import _RpsRegistrationView
 
@@ -189,14 +188,14 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # 
             await ctx.send("Registration is already active.")
             return
 
-        existing = await global_db.get_setting(ctx.guild.id, ACTIVE_TOURNAMENT, "")
+        existing = await tournament_state_service.get_active(ctx.guild.id)
         if existing:
             await ctx.send(
                 f"A **{existing}** tournament is already active in this server.",
             )
             return
 
-        await global_db.set_setting(ctx.guild.id, ACTIVE_TOURNAMENT, "rps")
+        await tournament_state_service.set_active(ctx.guild.id, "rps")
 
         self.registration_active = True
         self.registration_role = role
@@ -293,7 +292,7 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # 
             await ctx.send("An error occurred while ending registration.")
 
         if len(self.players) < 2:
-            await global_db.set_setting(ctx.guild.id, ACTIVE_TOURNAMENT, "")
+            await tournament_state_service.clear_active(ctx.guild.id)
 
     async def try_register_player(self, user, guild_id: int) -> bool:
         """Check entry fee, deduct if needed, register player. Returns success.
@@ -656,7 +655,7 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # 
             announce = guild.system_channel or last_channel
             await announce.send("\n".join(msg_lines))
             self.tournament_active = False
-            await global_db.set_setting(guild.id, ACTIVE_TOURNAMENT, "")
+            await tournament_state_service.clear_active(guild.id)
             self.players.clear()
             self.scores.clear()
             self.matches.clear()

--- a/disbot/services/tournament_state_service.py
+++ b/disbot/services/tournament_state_service.py
@@ -1,0 +1,95 @@
+"""Typed access for the per-guild active-tournament flag.
+
+PR B' classification: the ``ACTIVE_TOURNAMENT`` key is **runtime
+tournament state**, not guild configuration:
+
+* Written by tournament lifecycle code (start / cancel / end /
+  startup-sweep) — never by operator-facing UI.
+* Read at start time to prevent two tournaments overlapping in the
+  same guild, and at startup to recover stale flags after a crash.
+* Operators do not configure whether a tournament is "active" — it is
+  a side effect of running a tournament command.
+
+Per the post-#152 stabilization audit, this means the value must NOT
+go through :class:`services.settings_mutation.SettingsMutationPipeline`
+— that would pollute the settings audit log with per-match state and
+emit cache-invalidation events for a flag that operator-facing settings
+panels never expose. Instead, callers route through this thin service.
+
+Storage today is the same ``settings`` table the previous direct
+writes used (via :func:`utils.db.set_setting`); the service is the
+canonical access boundary. A future PR may move the data to a
+dedicated table without changing this API.
+
+Public API
+----------
+* :func:`get_active` — return the current kind ("rps", "blackjack",
+  or "" when no tournament is active).
+* :func:`set_active` — mark a tournament of ``kind`` active; raises
+  :class:`ValueError` for unknown kinds.
+* :func:`clear_active` — clear the flag (called on completion or
+  cancellation).
+
+Invariant
+---------
+``tests/unit/services/test_tournament_state_service.py`` pins that
+direct writes to :data:`utils.settings_keys.ACTIVE_TOURNAMENT` happen
+ONLY inside this module. CI fails if a future caller adds a new
+``db.set_setting(..., ACTIVE_TOURNAMENT, …)`` outside the service.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from utils import db
+from utils.settings_keys import ACTIVE_TOURNAMENT
+
+logger = logging.getLogger("bot.tournament_state")
+
+# Known tournament kinds. New kinds must be added here; ``set_active``
+# rejects anything outside this allowlist so a typo can't silently
+# wedge the "is a tournament active?" check.
+_VALID_KINDS: frozenset[str] = frozenset({"rps", "blackjack"})
+
+
+async def get_active(guild_id: int) -> str:
+    """Return the current active-tournament kind for ``guild_id``.
+
+    Returns the kind string (one of ``_VALID_KINDS``) or ``""`` when
+    no tournament is active. Callers should compare against the kind
+    they intend to start (e.g. ``if existing == "rps": ...``) so a
+    foreign kind doesn't get clobbered by accident.
+    """
+    return await db.get_setting(guild_id, ACTIVE_TOURNAMENT, "")
+
+
+async def set_active(guild_id: int, kind: str) -> None:
+    """Mark ``kind`` as the active tournament for ``guild_id``.
+
+    Raises :class:`ValueError` if ``kind`` is not in the known
+    allowlist — that surfaces typos at the call site rather than as a
+    silent miscategorization in the readers.
+    """
+    if kind not in _VALID_KINDS:
+        raise ValueError(
+            f"Unknown tournament kind {kind!r}. "
+            f"Expected one of {sorted(_VALID_KINDS)!r}.",
+        )
+    await db.set_setting(guild_id, ACTIVE_TOURNAMENT, kind)
+
+
+async def clear_active(guild_id: int) -> None:
+    """Clear the active-tournament flag for ``guild_id``.
+
+    Called on tournament completion, cancellation, or startup sweep
+    to recover from a crash that left the flag set.
+    """
+    await db.set_setting(guild_id, ACTIVE_TOURNAMENT, "")
+
+
+__all__ = [
+    "clear_active",
+    "get_active",
+    "set_active",
+]

--- a/disbot/views/blackjack/tournament_views.py
+++ b/disbot/views/blackjack/tournament_views.py
@@ -28,12 +28,10 @@ from cogs.blackjack._state import (
     _TournPlayerState,
 )
 from core.runtime import resources
-from services import economy_service, game_state_service
+from services import economy_service, game_state_service, tournament_state_service
 from services.blackjack_engine import hand_value as _hand_value
 from services.blackjack_engine import is_blackjack as _is_blackjack
-from utils import db
 from utils.channels import cleanup_category
-from utils.settings_keys import ACTIVE_TOURNAMENT
 from utils.ui_constants import ECONOMY_COLOR, ERROR_COLOR, GAME_COLOR, SUCCESS_COLOR
 from views.base import handle_view_error as _on_view_error
 from views.blackjack.embeds import _game_embed, _update_tourn_embed
@@ -306,4 +304,4 @@ async def _check_tourn_done(tourn: _BjTournament, bot: commands.Bot):
         )
 
     _tournaments.pop(tourn.guild_id, None)
-    await db.set_setting(tourn.guild_id, ACTIVE_TOURNAMENT, "")
+    await tournament_state_service.clear_active(tourn.guild_id)

--- a/tests/unit/invariants/test_no_direct_settings_keys_writes.py
+++ b/tests/unit/invariants/test_no_direct_settings_keys_writes.py
@@ -53,17 +53,22 @@ _ALLOWED_PATHS = {
     _DISBOT / "utils" / "db" / "settings.py",
     # Re-export module (re-exports ``set_setting`` from ``utils.db.settings``).
     _DISBOT / "utils" / "db" / "__init__.py",
+    # PR B' — runtime tournament-state flag has its own typed service.
+    # ``ACTIVE_TOURNAMENT`` is per-match runtime state (start/cancel/end
+    # lifecycle), not operator-tunable guild configuration; the audit
+    # surface SettingsMutationPipeline provides is wrong for it.
+    # The tournament_state_service is the canonical access boundary;
+    # the four pre-PR-B' callers (blackjack_cog, rps_tournament_cog,
+    # rps_tournament/_helpers, views/blackjack/tournament_views) were
+    # removed from this allowlist when they migrated to the service.
+    _DISBOT / "services" / "tournament_state_service.py",
     # Pre-existing callers — migrate to SettingsMutationPipeline in S10.
     # Each entry below corresponds to a per-subsystem S10 sub-PR
     # ("settings/<subsystem>") that will route the call through the
     # pipeline and remove the entry.
-    _DISBOT / "cogs" / "blackjack_cog.py",        # ACTIVE_TOURNAMENT writes
     # ``cogs/economy_cog.py`` migrated to SettingsMutationPipeline in PR #6
     # — removed from the allowlist (the AST scan now enforces it).
-    _DISBOT / "cogs" / "rps_tournament_cog.py",   # ACTIVE_TOURNAMENT writes
-    _DISBOT / "cogs" / "rps_tournament" / "_helpers.py",  # ACTIVE_TOURNAMENT
     _DISBOT / "governance" / "writes.py",         # internal governance writes
-    _DISBOT / "views" / "blackjack" / "tournament_views.py",
     # ``views/xp/modals.py`` migrated to SettingsMutationPipeline in PR #5
     # — removed from the allowlist (the AST scan now enforces it).
     # Documentation reference (string literal in a module docstring,

--- a/tests/unit/services/test_tournament_state_service.py
+++ b/tests/unit/services/test_tournament_state_service.py
@@ -1,0 +1,158 @@
+"""Unit tests for :mod:`services.tournament_state_service` (PR B').
+
+The service wraps the per-guild ``ACTIVE_TOURNAMENT`` flag so callers
+cannot bypass typed validation. These tests pin:
+
+* ``get_active`` reads via ``db.get_setting`` with the canonical key.
+* ``set_active`` rejects unknown kinds.
+* ``set_active`` and ``clear_active`` route through ``db.set_setting``
+  with the canonical key.
+* A regex-based invariant scan that the four pre-PR-B' caller modules
+  (blackjack_cog, rps_tournament_cog, rps_tournament/_helpers,
+  views/blackjack/tournament_views) no longer reference the
+  ``ACTIVE_TOURNAMENT`` key — the migration is the whole point.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services import tournament_state_service
+
+
+@pytest.mark.asyncio
+async def test_get_active_reads_canonical_key():
+    with patch(
+        "services.tournament_state_service.db.get_setting",
+        new_callable=AsyncMock,
+        return_value="rps",
+    ) as mock_get:
+        kind = await tournament_state_service.get_active(42)
+
+    assert kind == "rps"
+    mock_get.assert_awaited_once_with(42, "active_tournament", "")
+
+
+@pytest.mark.asyncio
+async def test_get_active_returns_empty_for_inactive_guild():
+    with patch(
+        "services.tournament_state_service.db.get_setting",
+        new_callable=AsyncMock,
+        return_value="",
+    ):
+        assert await tournament_state_service.get_active(42) == ""
+
+
+@pytest.mark.asyncio
+async def test_set_active_rejects_unknown_kind():
+    with patch(
+        "services.tournament_state_service.db.set_setting",
+        new_callable=AsyncMock,
+    ) as mock_set:
+        with pytest.raises(ValueError, match="Unknown tournament kind"):
+            await tournament_state_service.set_active(42, "tetris")
+    # Defense-in-depth: the DB must NOT have been touched on a rejected
+    # kind. If the validation ever moves below the write, this fails.
+    mock_set.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_set_active_writes_rps():
+    with patch(
+        "services.tournament_state_service.db.set_setting",
+        new_callable=AsyncMock,
+    ) as mock_set:
+        await tournament_state_service.set_active(42, "rps")
+    mock_set.assert_awaited_once_with(42, "active_tournament", "rps")
+
+
+@pytest.mark.asyncio
+async def test_set_active_writes_blackjack():
+    with patch(
+        "services.tournament_state_service.db.set_setting",
+        new_callable=AsyncMock,
+    ) as mock_set:
+        await tournament_state_service.set_active(42, "blackjack")
+    mock_set.assert_awaited_once_with(42, "active_tournament", "blackjack")
+
+
+@pytest.mark.asyncio
+async def test_clear_active_writes_empty_string():
+    with patch(
+        "services.tournament_state_service.db.set_setting",
+        new_callable=AsyncMock,
+    ) as mock_set:
+        await tournament_state_service.clear_active(42)
+    mock_set.assert_awaited_once_with(42, "active_tournament", "")
+
+
+# ---------------------------------------------------------------------------
+# Migration invariant — pre-PR-B' callers must not reference the key directly
+# ---------------------------------------------------------------------------
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DISBOT = _REPO_ROOT / "disbot"
+
+# These four modules previously contained the 9-plus direct
+# ``set_setting(..., ACTIVE_TOURNAMENT, ...)`` writes that PR B'
+# migrated to ``tournament_state_service``. They must no longer touch
+# the key directly — any new direct caller would defeat the typed
+# service boundary.
+_MIGRATED_FILES = [
+    _DISBOT / "cogs" / "blackjack_cog.py",
+    _DISBOT / "cogs" / "rps_tournament_cog.py",
+    _DISBOT / "cogs" / "rps_tournament" / "_helpers.py",
+    _DISBOT / "views" / "blackjack" / "tournament_views.py",
+]
+
+
+def test_migrated_callers_no_longer_reference_active_tournament_key():
+    """The four migrated files must not import or use
+    ``ACTIVE_TOURNAMENT`` after PR B'.
+
+    A future refactor that re-imports the key in any of these files
+    should also re-introduce the direct ``set_setting`` write, which
+    the existing S4 invariant
+    (``test_no_direct_settings_keys_writes.py``) would catch. This
+    test catches the import alone, before the write lands.
+    """
+    pattern = re.compile(r"\bACTIVE_TOURNAMENT\b")
+    violations: list[tuple[str, int, str]] = []
+    for path in _MIGRATED_FILES:
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            # Allow docstring / comment mentions — the failure mode we
+            # care about is an actual code reference. A simple test:
+            # ignore lines whose stripped form starts with ``#`` or
+            # which are inside a triple-quoted docstring. Detecting
+            # docstrings precisely needs AST; an approximation here is
+            # to skip lines whose only ACTIVE_TOURNAMENT use is inside
+            # double-quoted strings beginning with `"""` or `'''`.
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            if pattern.search(line):
+                # Allow narrative docstring lines (``""" ... ACTIVE_TOURNAMENT ...``).
+                if stripped.startswith('"""') or stripped.startswith("'''"):
+                    continue
+                # The phrasing "on-startup ACTIVE_TOURNAMENT sweep" appears
+                # inside a docstring; if the line contains 'sweep' AND
+                # 'ACTIVE_TOURNAMENT' the regex would still match — guard
+                # by requiring a likely-code form (assignment / call /
+                # import). For belt-and-braces, also exclude lines that
+                # are pure prose (no =, no (, no .).
+                if not any(ch in line for ch in "=(."):
+                    continue
+                violations.append(
+                    (str(path.relative_to(_REPO_ROOT)), lineno, line.rstrip()),
+                )
+    assert not violations, (
+        "PR B' invariant violation: a migrated tournament file still "
+        "references ACTIVE_TOURNAMENT directly. Route through "
+        "services.tournament_state_service instead.\n\n"
+        + "\n".join(f"  {p}:{ln}: {src}" for p, ln, src in violations)
+    )


### PR DESCRIPTION
## Summary

PR B' of the post-#152 stabilization plan. Closes issue #10 from the audit — direct `db.set_setting(..., ACTIVE_TOURNAMENT, ...)` writes that bypass any typed boundary. Service-layer only; no UI changes.

## Classification (the gate before migration)

Per the planning constraint, runtime tournament state must NOT be blindly routed through `SettingsMutationPipeline`. I read every write site and classified `ACTIVE_TOURNAMENT` as **runtime tournament-state**, not guild configuration:

- Written by tournament lifecycle code only (start / cancel / end / startup-sweep).
- Read at start time to prevent overlap, and at startup to recover stale flags after a crash.
- Never exposed to operators as a knob; the value is a side effect of running a tournament.

Routing this through `SettingsMutationPipeline` would pollute the settings audit log with per-match state and emit cache-invalidation events for a flag no operator-facing UI exposes — exactly the misclassification the plan warned against.

## Migration target

Created `disbot/services/tournament_state_service.py` — a thin, typed service with three accessors:

- `async def get_active(guild_id) -> str` — returns "rps", "blackjack", or "".
- `async def set_active(guild_id, kind)` — kind must be in `{"rps", "blackjack"}`; raises `ValueError` otherwise.
- `async def clear_active(guild_id)` — equivalent to setting to "".

Storage today is still the `settings` table (no schema migration); the service is the canonical access boundary. A future PR can move to a dedicated table without changing this API.

## Audit found one extra site

The original audit listed 9 direct writes. I found a 10th in `disbot/views/blackjack/tournament_views.py:309` (natural-completion clear). All 10 writes + 4 reads now go through the service.

## Call sites migrated

| File | Operation | Before | After |
|---|---|---|---|
| `cogs/rps_tournament_cog.py:192` | read existing | `db.get_setting(...)` | `tournament_state_service.get_active(...)` |
| `cogs/rps_tournament_cog.py:199` | start RPS | `db.set_setting(..., "rps")` | `set_active(..., "rps")` |
| `cogs/rps_tournament_cog.py:296` | end-reg clear | `db.set_setting(..., "")` | `clear_active(...)` |
| `cogs/rps_tournament_cog.py:659` | tournament done | `db.set_setting(..., "")` | `clear_active(...)` |
| `cogs/blackjack_cog.py:357` | startup orphan read | `db.get_setting(...)` | `get_active(...)` |
| `cogs/blackjack_cog.py:359` | startup orphan clear | `db.set_setting(..., "")` | `clear_active(...)` |
| `cogs/blackjack_cog.py:504` | read existing | `db.get_setting(...)` | `get_active(...)` |
| `cogs/blackjack_cog.py:524` | start BJ | `db.set_setting(..., "blackjack")` | `set_active(..., "blackjack")` |
| `cogs/blackjack_cog.py:577` | cancel no-players | `db.set_setting(..., "")` | `clear_active(...)` |
| `cogs/blackjack_cog.py:590` | cancel no-fee | `db.set_setting(..., "")` | `clear_active(...)` |
| `cogs/blackjack_cog.py:640` | channel-forbidden abort | `db.set_setting(..., "")` | `clear_active(...)` |
| `cogs/rps_tournament/_helpers.py:163` | startup sweep read | `global_db.get_setting(...)` | `get_active(...)` |
| `cogs/rps_tournament/_helpers.py:165` | startup sweep clear | `global_db.set_setting(..., "")` | `clear_active(...)` |
| `views/blackjack/tournament_views.py:309` | natural completion | `db.set_setting(..., "")` | `clear_active(...)` |

## Invariants

- `tests/unit/invariants/test_no_direct_settings_keys_writes.py` — allowlist now includes `services/tournament_state_service.py` and **removes** the four migrated caller files. A future direct `db.set_setting` from any of them fails CI.
- `tests/unit/services/test_tournament_state_service.py` — 7 tests covering: canonical-key read, empty-for-inactive read, kind rejection (with defense-in-depth assertion that the DB is not touched on rejection), set_active for both kinds, clear_active, and a regex scan that pins no migrated file references `ACTIVE_TOURNAMENT` in code.

## Scope

| File | Change |
|---|---|
| `disbot/services/tournament_state_service.py` | **NEW** — typed accessors + allowlist. |
| `disbot/cogs/rps_tournament_cog.py` | 4 sites migrated; remove obsolete `global_db` + `ACTIVE_TOURNAMENT` imports. |
| `disbot/cogs/rps_tournament/_helpers.py` | 2 sites (read + clear) migrated. |
| `disbot/cogs/blackjack_cog.py` | 6 sites migrated; remove obsolete `ACTIVE_TOURNAMENT` import. |
| `disbot/views/blackjack/tournament_views.py` | 1 site migrated; remove obsolete `db` + `ACTIVE_TOURNAMENT` imports. |
| `tests/unit/invariants/test_no_direct_settings_keys_writes.py` | Allowlist updated. |
| `tests/unit/services/test_tournament_state_service.py` | **NEW** — 7 tests. |

## Test plan

- [x] 7 new service tests pass.
- [x] Allowlist invariant still passes.
- [x] Full `tests/` suite — 2436/2436 pass.
- [x] `mypy disbot/`, `ruff check .`, `black --check .`, `isort --check-only disbot/` all clean.
- [ ] Manual smoke (post-deploy):
  - `!rpstournament` → join → end-reg → verify state persists across a process restart.
  - `!bjtournament` → join → play one round → end cleanly.
  - Force a crash mid-tournament; restart; confirm the startup sweep clears the stale flag (logs show the clear path was taken).
  - Try `set_active(guild_id, "tetris")` from a debug REPL → expect `ValueError`.

## Rollback

Revert restores direct writes; `_VALID_KINDS` allowlist disappears with the file. Storage stays untouched (same `settings` table), so existing flag values remain valid post-revert. Audit rows already written by `SettingsMutationPipeline` (none, in this case — direct writes bypassed it before this PR) are unaffected.

## Out of scope for B' — deliberate

- Moving `ACTIVE_TOURNAMENT` to a dedicated table. The service makes that a one-PR change later without touching any caller.
- Migrating `db.get_setting(..., ACTIVE_TOURNAMENT, ...)` from callers that read for purposes unrelated to the lifecycle (none found, but the service's `get_active` is the right place if any appear).
- Adding capability-based permission checks. The current writes are gated by command permission decorators upstream; the service is a typed boundary, not an authorization boundary.

## Follow-ups

- PR C — interactive cog manager with critical-cog protection (issue #6).
- PR E1/E2 — slash front doors (depend on D, which is now in main).
- PR F — `!list` pagination.
- PR G — leaderboard provider registry.
- PR H — Platform/Diagnostics setup readiness inventory.

https://claude.ai/code/session_01VJhdMgBEfU2LmvgiiS5TN4

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJhdMgBEfU2LmvgiiS5TN4)_