### PR TITLE
admin: interactive cog manager with critical-cog protection

### DIFF
--- a/disbot/cogs/admin/__init__.py
+++ b/disbot/cogs/admin/__init__.py
@@ -1,0 +1,12 @@
+"""Admin cog helpers — extracted per the F-3 decomposition convention.
+
+This subpackage holds support modules for ``cogs/admin_cog.py``:
+
+* :mod:`cogs.admin.cog_manager` — discovery helpers, load/unload/reload
+  primitives, the ``_PROTECTED_COGS`` constant, and the interactive
+  :class:`_CogManagerView`. Kept out of ``admin_cog.py`` to stay under
+  the S4.6 cog-size invariant.
+
+``admin_cog.py`` remains the Discord-facing surface (the cog
+registers commands and panel views from here); helpers live here.
+"""

--- a/disbot/cogs/admin/cog_manager.py
+++ b/disbot/cogs/admin/cog_manager.py
@@ -1,0 +1,395 @@
+"""Cog discovery, load/unload/reload primitives, and the interactive
+:class:`_CogManagerView` (PR C).
+
+Extracted from ``cogs/admin_cog.py`` to keep that file under the S4.6
+800-LOC ceiling. The module owns:
+
+* :data:`COGS_DIR` — absolute path to the cogs directory.
+* Discovery helpers (:func:`_normalize`, :func:`_find_module`,
+  :func:`_all_cog_modules`, :func:`_syntax_ok`).
+* :data:`_PROTECTED_COGS` — core cogs that may not be unloaded from
+  the panel UI (prefix ``!cog unload`` retains no protection).
+* :func:`_do_load`, :func:`_do_unload`, :func:`_do_reload` — shared
+  body for the ``!cog`` prefix command and the panel buttons.
+* :class:`_CogManagerSelect`, :class:`_CogManagerView` — interactive
+  panel surface.
+
+``admin_cog.py`` imports the helpers and view from here.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import re
+from typing import TYPE_CHECKING
+
+import discord
+from discord.ext import commands
+
+from utils.ui_constants import INFO_COLOR
+from views.base import HubView
+
+if TYPE_CHECKING:
+    from cogs.admin_cog import AdminCog
+
+# Absolute path to ``cogs/`` — the parent directory of ``cogs/admin/``.
+COGS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _normalize(name: str) -> str:
+    """Strip underscores/spaces, lowercase, remove trailing 'cog'."""
+    return re.sub(r"[\s_]+", "", name.lower()).removesuffix("cog")
+
+
+def _find_module(name: str) -> str | None:
+    """Return the full module path (e.g. 'cogs.admin_cog') for a fuzzy cog name."""
+    target = _normalize(name)
+    for fname in sorted(os.listdir(COGS_DIR)):
+        if fname.endswith("_cog.py") and not fname.startswith("__"):
+            if _normalize(fname[:-3]) == target:
+                return f"cogs.{fname[:-3]}"
+    return None
+
+
+def _all_cog_modules() -> list[str]:
+    """Return module paths for every *_cog.py file."""
+    return [
+        f"cogs.{f[:-3]}"
+        for f in sorted(os.listdir(COGS_DIR))
+        if f.endswith("_cog.py") and not f.startswith("__")
+    ]
+
+
+def _syntax_ok(fname: str) -> bool:
+    """Return True if the file parses without syntax errors."""
+    try:
+        with open(os.path.join(COGS_DIR, fname), encoding="utf-8") as fh:
+            ast.parse(fh.read(), fname)
+        return True
+    except SyntaxError:
+        return False
+
+
+# Core cogs that must NOT be unloaded from the panel UI without a
+# deliberate operator action. Unloading any of these can wedge the
+# bot's safety / runtime surface (admin_cog itself is the obvious
+# self-foot-gun; settings, help, logging, and cleanup are the
+# bot's operator-facing minimum).
+#
+# Critical cogs may still be RELOADED from the panel (reversible) and
+# the prefix ``!cog unload <name>`` command retains no protection — it
+# is the operator's escape hatch when the panel won't open. Document
+# the asymmetry in any operator-facing copy that grows around this.
+_PROTECTED_COGS: frozenset[str] = frozenset(
+    {
+        "cogs.admin_cog",
+        "cogs.cleanup_cog",
+        "cogs.help_cog",
+        "cogs.logging_cog",
+        "cogs.settings_cog",
+    },
+)
+
+
+async def _do_load(bot: commands.Bot, module: str) -> str:
+    """Load ``module``; return an operator-readable status string."""
+    try:
+        await bot.load_extension(module)
+        return f"✅ `{module}` loaded."
+    except Exception as exc:  # noqa: BLE001 — operator-facing surface
+        return f"⚠️ Error loading `{module}`: {exc}"
+
+
+async def _do_unload(bot: commands.Bot, module: str) -> str:
+    """Unload ``module``; return an operator-readable status string."""
+    try:
+        await bot.unload_extension(module)
+        return f"🔴 `{module}` unloaded."
+    except Exception as exc:  # noqa: BLE001 — operator-facing surface
+        return f"⚠️ Error unloading `{module}`: {exc}"
+
+
+async def _do_reload(bot: commands.Bot, module: str) -> str:
+    """Reload ``module``; return an operator-readable status string."""
+    try:
+        await bot.reload_extension(module)
+        return f"🔄 `{module}` reloaded."
+    except Exception as exc:  # noqa: BLE001 — operator-facing surface
+        return f"⚠️ Error reloading `{module}`: {exc}"
+
+
+# ---------------------------------------------------------------------------
+# Interactive Cog Manager (PR C)
+# ---------------------------------------------------------------------------
+
+
+class _CogManagerSelect(discord.ui.Select):
+    """Dropdown listing every ``*_cog.py`` discovered under ``COGS_DIR``.
+
+    Selecting an option stashes the choice on the parent view; the
+    Load / Unload / Reload buttons act on that selection. Status icons
+    in the option label show the current state at panel-render time —
+    refresh after each mutation to keep them current.
+    """
+
+    def __init__(self, loaded: set[str]) -> None:
+        options: list[discord.SelectOption] = []
+        for fname in sorted(os.listdir(COGS_DIR)):
+            if not fname.endswith("_cog.py") or fname.startswith("__"):
+                continue
+            short = fname[:-3]
+            module = f"cogs.{short}"
+            load_glyph = "✅" if module in loaded else "❌"
+            syntax_glyph = "🟢" if _syntax_ok(fname) else "🔴"
+            protected_glyph = "🛡" if module in _PROTECTED_COGS else ""
+            label = f"{load_glyph}{syntax_glyph}{protected_glyph} {short}"[:100]
+            options.append(
+                discord.SelectOption(
+                    label=label,
+                    value=module,
+                    description=(
+                        "Protected core cog — panel unload denied"
+                        if module in _PROTECTED_COGS
+                        else None
+                    ),
+                ),
+            )
+        if not options:
+            options.append(
+                discord.SelectOption(label="No cogs found", value="__none__"),
+            )
+        super().__init__(
+            placeholder="Choose a cog…",
+            min_values=1,
+            max_values=1,
+            options=options[:25],  # Discord cap
+            custom_id="admin:cogmgr:select",
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        if not isinstance(view, _CogManagerView):
+            await interaction.response.send_message(
+                "This dropdown is no longer attached to the cog manager.",
+                ephemeral=True,
+            )
+            return
+        value = self.values[0]
+        if value == "__none__":
+            await interaction.response.send_message(
+                "No cogs available.",
+                ephemeral=True,
+            )
+            return
+        view.selected_module = value
+        await interaction.response.edit_message(
+            embed=view.build_embed(),
+            view=view,
+        )
+
+
+class _CogManagerView(HubView):
+    """Owner-driven Load / Unload / Reload panel.
+
+    PR C replaces the previous read-only embed under "Cog List" with
+    an interactive surface. Mutations are owner-gated:
+
+    * Non-owners see the same status surface but the action buttons
+      ephemerally deny.
+    * Owners can load any cog, reload any cog (including protected
+      core cogs — reload is reversible), and unload any non-protected
+      cog.
+    * Unloading a protected core cog from the panel is refused; the
+      ephemeral surfaces the prefix-command escape hatch.
+
+    Load / Unload / Reload paths share their bodies with the
+    ``!cog`` prefix command via the module-level :func:`_do_load` /
+    :func:`_do_unload` / :func:`_do_reload` helpers.
+    """
+
+    def __init__(
+        self,
+        cog: AdminCog,
+        author: discord.Member | discord.User,
+    ) -> None:
+        super().__init__(author)
+        self.cog = cog
+        self.selected_module: str | None = None
+        self.last_status: str | None = None
+        self._add_components()
+
+    def _add_components(self) -> None:
+        loaded = set(self.cog.bot.extensions.keys())
+        self.add_item(_CogManagerSelect(loaded))
+
+        load = discord.ui.Button(  # type: ignore[var-annotated]
+            label="Load",
+            style=discord.ButtonStyle.green,
+            row=1,
+            custom_id="admin:cogmgr:load",
+        )
+        load.callback = self._on_load  # type: ignore[method-assign]
+        self.add_item(load)
+
+        unload = discord.ui.Button(  # type: ignore[var-annotated]
+            label="Unload",
+            style=discord.ButtonStyle.danger,
+            row=1,
+            custom_id="admin:cogmgr:unload",
+        )
+        unload.callback = self._on_unload  # type: ignore[method-assign]
+        self.add_item(unload)
+
+        reload_btn = discord.ui.Button(  # type: ignore[var-annotated]
+            label="Reload",
+            style=discord.ButtonStyle.blurple,
+            row=1,
+            custom_id="admin:cogmgr:reload",
+        )
+        reload_btn.callback = self._on_reload  # type: ignore[method-assign]
+        self.add_item(reload_btn)
+
+        refresh = discord.ui.Button(  # type: ignore[var-annotated]
+            label="🔄 Refresh",
+            style=discord.ButtonStyle.secondary,
+            row=2,
+            custom_id="admin:cogmgr:refresh",
+        )
+        refresh.callback = self._on_refresh  # type: ignore[method-assign]
+        self.add_item(refresh)
+
+    def build_embed(self) -> discord.Embed:
+        loaded = set(self.cog.bot.extensions.keys())
+        lines = []
+        for fname in sorted(os.listdir(COGS_DIR)):
+            if not fname.endswith("_cog.py") or fname.startswith("__"):
+                continue
+            module = f"cogs.{fname[:-3]}"
+            load_icon = "✅" if module in loaded else "❌"
+            syntax_icon = "🟢" if _syntax_ok(fname) else "🔴"
+            protected_icon = " 🛡" if module in _PROTECTED_COGS else ""
+            marker = "  ← selected" if module == self.selected_module else ""
+            lines.append(
+                f"{load_icon} {syntax_icon}  `{fname[:-3]}`{protected_icon}{marker}",
+            )
+
+        description_parts = [
+            "**Pick a cog from the dropdown, then Load / Unload / Reload.**",
+            "",
+            "\n".join(lines) or "_No cogs found._",
+            "",
+            (
+                "✅ Loaded  ❌ Unloaded  🟢 OK  🔴 Syntax error  🛡 "
+                "Protected (panel unload denied — use `!cog unload <name>`)"
+            ),
+        ]
+        if self.last_status:
+            description_parts.append("")
+            description_parts.append(self.last_status)
+        embed = discord.Embed(
+            title="📋 Cog Manager",
+            description="\n".join(description_parts),
+            color=INFO_COLOR,
+        )
+        if self.selected_module:
+            embed.set_footer(text=f"Selected: {self.selected_module}")
+        else:
+            embed.set_footer(text="No cog selected.")
+        return embed
+
+    async def _require_owner_or_deny(
+        self,
+        interaction: discord.Interaction,
+    ) -> bool:
+        if not await interaction.client.is_owner(interaction.user):  # type: ignore[attr-defined]
+            await interaction.response.send_message(
+                "Owner only.",
+                ephemeral=True,
+            )
+            return False
+        return True
+
+    async def _require_selection_or_deny(
+        self,
+        interaction: discord.Interaction,
+    ) -> bool:
+        if self.selected_module is None:
+            await interaction.response.send_message(
+                "Pick a cog from the dropdown first.",
+                ephemeral=True,
+            )
+            return False
+        return True
+
+    async def _on_load(self, interaction: discord.Interaction) -> None:
+        if not await self._require_owner_or_deny(interaction):
+            return
+        if not await self._require_selection_or_deny(interaction):
+            return
+        assert self.selected_module is not None  # noqa: S101 — guarded above
+        self.last_status = await _do_load(self.cog.bot, self.selected_module)
+        await interaction.response.edit_message(
+            embed=self.build_embed(),
+            view=self,
+        )
+
+    async def _on_unload(self, interaction: discord.Interaction) -> None:
+        if not await self._require_owner_or_deny(interaction):
+            return
+        if not await self._require_selection_or_deny(interaction):
+            return
+        assert self.selected_module is not None  # noqa: S101 — guarded above
+        if self.selected_module in _PROTECTED_COGS:
+            short = self.selected_module.split(".")[-1]
+            await interaction.response.send_message(
+                f"`{self.selected_module}` is a protected core cog. "
+                f"Use `!cog unload {short}` from a terminal if you really "
+                "need to (risk of bot lockup).",
+                ephemeral=True,
+            )
+            return
+        self.last_status = await _do_unload(self.cog.bot, self.selected_module)
+        await interaction.response.edit_message(
+            embed=self.build_embed(),
+            view=self,
+        )
+
+    async def _on_reload(self, interaction: discord.Interaction) -> None:
+        if not await self._require_owner_or_deny(interaction):
+            return
+        if not await self._require_selection_or_deny(interaction):
+            return
+        assert self.selected_module is not None  # noqa: S101 — guarded above
+        # Reload is allowed even for protected core cogs — it is
+        # reversible and is the operator's hot-path for picking up a
+        # code change without restarting the process.
+        self.last_status = await _do_reload(self.cog.bot, self.selected_module)
+        await interaction.response.edit_message(
+            embed=self.build_embed(),
+            view=self,
+        )
+
+    async def _on_refresh(self, interaction: discord.Interaction) -> None:
+        # Refresh is open to any admin who reached the panel — it
+        # only re-reads load state, no mutation.
+        self.last_status = None
+        await interaction.response.edit_message(
+            embed=self.build_embed(),
+            view=self,
+        )
+
+
+__all__ = [
+    "COGS_DIR",
+    "_CogManagerView",
+    "_PROTECTED_COGS",
+    "_all_cog_modules",
+    "_do_load",
+    "_do_reload",
+    "_do_unload",
+    "_find_module",
+    "_normalize",
+    "_syntax_ok",
+]

--- a/disbot/cogs/admin_cog.py
+++ b/disbot/cogs/admin_cog.py
@@ -1,55 +1,27 @@
 from __future__ import annotations
 
-import ast
 import logging
 import os
-import re
 import sys
 
 import discord
 from discord.ext import commands
 
+from cogs.admin.cog_manager import (  # noqa: F401 — re-exported for back-compat (callers may import here)
+    COGS_DIR,
+    _all_cog_modules,
+    _CogManagerView,
+    _do_load,
+    _do_reload,
+    _do_unload,
+    _find_module,
+)
 from core.runtime import resources
 from core.runtime.interaction_helpers import help_ctx_shim, safe_defer, safe_edit
-from utils.ui_constants import ADMIN_COLOR, INFO_COLOR, SUCCESS_COLOR
+from utils.ui_constants import ADMIN_COLOR, INFO_COLOR, SUCCESS_COLOR  # noqa: F401
 from views.base import HubView, send_panel
 
-COGS_DIR = os.path.dirname(os.path.abspath(__file__))
 PID_FILE = os.path.join(os.path.dirname(COGS_DIR), "bot.pid")
-
-
-def _normalize(name: str) -> str:
-    """Strip underscores/spaces, lowercase, remove trailing 'cog'."""
-    return re.sub(r"[\s_]+", "", name.lower()).removesuffix("cog")
-
-
-def _find_module(name: str) -> str | None:
-    """Return the full module path (e.g. 'cogs.admin_cog') for a fuzzy cog name."""
-    target = _normalize(name)
-    for fname in sorted(os.listdir(COGS_DIR)):
-        if fname.endswith("_cog.py") and not fname.startswith("__"):
-            if _normalize(fname[:-3]) == target:
-                return f"cogs.{fname[:-3]}"
-    return None
-
-
-def _all_cog_modules() -> list[str]:
-    """Return module paths for every *_cog.py file."""
-    return [
-        f"cogs.{f[:-3]}"
-        for f in sorted(os.listdir(COGS_DIR))
-        if f.endswith("_cog.py") and not f.startswith("__")
-    ]
-
-
-def _syntax_ok(fname: str) -> bool:
-    """Return True if the file parses without syntax errors."""
-    try:
-        with open(os.path.join(COGS_DIR, fname), encoding="utf-8") as fh:
-            ast.parse(fh.read(), fname)
-        return True
-    except SyntaxError:
-        return False
 
 
 class AdminCog(commands.Cog):
@@ -104,7 +76,13 @@ class AdminCog(commands.Cog):
     @commands.command(name="cog")
     @commands.is_owner()
     async def manage_cog(self, ctx, action: str, cog_name: str):
-        """Load, unload, or reload a cog by name (underscores and _cog suffix optional)."""
+        """Load, unload, or reload a cog by name (underscores and _cog suffix optional).
+
+        The prefix command intentionally retains no critical-cog
+        protection — it is the operator's escape hatch when the panel
+        won't open or a protected cog needs to be unloaded. The panel
+        Unload button refuses protected cogs (see ``_PROTECTED_COGS``).
+        """
         action = action.lower()
         if action not in ("load", "unload", "reload"):
             await ctx.send(
@@ -115,16 +93,12 @@ class AdminCog(commands.Cog):
         if not module:
             await ctx.send(f"❌ No cog found matching `{cog_name}`.")
             return
-        try:
-            if action == "load":
-                await self.bot.load_extension(module)
-            elif action == "unload":
-                await self.bot.unload_extension(module)
-            elif action == "reload":
-                await self.bot.reload_extension(module)
-            await ctx.send(f"✅ `{module}` {action}ed.")
-        except Exception as e:
-            await ctx.send(f"⚠️ Error {action}ing `{module}`: {e}")
+        if action == "load":
+            await ctx.send(await _do_load(self.bot, module))
+        elif action == "unload":
+            await ctx.send(await _do_unload(self.bot, module))
+        else:  # action == "reload"
+            await ctx.send(await _do_reload(self.bot, module))
 
     @commands.command(name="loadall")
     @commands.is_owner()
@@ -327,24 +301,21 @@ class _AdminPanelView(HubView):
 
     @discord.ui.button(label="📋 Cog List", style=discord.ButtonStyle.blurple, row=0)
     async def coglist_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
-        loaded = set(self.cog.bot.extensions.keys())
-        lines = []
-        for fname in sorted(os.listdir(COGS_DIR)):
-            if not fname.endswith("_cog.py") or fname.startswith("__"):
-                continue
-            module = f"cogs.{fname[:-3]}"
-            load_icon = "✅" if module in loaded else "❌"
-            syntax_icon = "🟢" if _syntax_ok(fname) else "🔴"
-            lines.append(f"{load_icon} {syntax_icon}  `{fname[:-3]}`")
-        embed = discord.Embed(
-            title="📋 Cog List",
-            description="\n".join(lines) or "No cogs found.",
-            color=INFO_COLOR,
+        """Open the interactive cog manager (PR C).
+
+        Replaces the previous read-only embed. Owners can load /
+        unload / reload from the panel; non-owners see the same
+        status surface but mutation buttons deny. Protected core
+        cogs (``_PROTECTED_COGS``) refuse unload from the panel —
+        prefix ``!cog unload`` retains no protection as the
+        operator's escape hatch.
+        """
+        view = _CogManagerView(self.cog, self._author)
+        attach_back_to_admin_button(view, self._author)
+        await interaction.response.edit_message(
+            embed=view.build_embed(),
+            view=view,
         )
-        embed.set_footer(
-            text="✅ Loaded  ❌ Unloaded  🟢 OK  🔴 Syntax Error  •  ↩ Overview to return",
-        )
-        await interaction.response.edit_message(embed=embed, view=self)
 
     @discord.ui.button(label="🔄 Reload All", style=discord.ButtonStyle.grey, row=0)
     async def reload_btn(self, interaction: discord.Interaction, _: discord.ui.Button):

--- a/tests/unit/cogs/test_admin_cog_manager.py
+++ b/tests/unit/cogs/test_admin_cog_manager.py
@@ -1,0 +1,416 @@
+"""Unit tests for the interactive cog manager (PR C).
+
+Pins:
+
+* The "📋 Cog List" button opens a :class:`_CogManagerView` instead of
+  the previous read-only embed.
+* The view exposes Select + Load / Unload / Reload / Refresh +
+  back-to-admin (the back button is added by ``coglist_btn`` via
+  ``attach_back_to_admin_button``).
+* Owner check: non-owners trigger an ephemeral "Owner only." denial
+  on mutation buttons and ``bot.{load,unload,reload}_extension`` is
+  NOT called.
+* Critical-cog protection: panel Unload on a member of
+  ``_PROTECTED_COGS`` refuses with an ephemeral citing the prefix
+  escape hatch; ``bot.unload_extension`` is NOT called. Reload of a
+  protected cog IS allowed.
+* The prefix ``!cog`` command remains unprotected (it is the
+  escape hatch).
+* Load / Unload / Reload paths share their bodies with the prefix
+  command via :func:`_do_load` / :func:`_do_unload` / :func:`_do_reload`.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from cogs.admin.cog_manager import (
+    _CogManagerView,
+    _PROTECTED_COGS,
+    _do_load,
+    _do_reload,
+    _do_unload,
+)
+from cogs.admin_cog import AdminCog, _AdminPanelView
+
+
+def _author(id_: int = 1) -> MagicMock:
+    author = MagicMock(spec=discord.Member)
+    author.id = id_
+    return author
+
+
+def _admin_cog(extensions: dict[str, object] | None = None) -> AdminCog:
+    bot = MagicMock()
+    bot.extensions = extensions or {"cogs.admin_cog": object()}
+    bot.load_extension = AsyncMock()
+    bot.unload_extension = AsyncMock()
+    bot.reload_extension = AsyncMock()
+    return AdminCog(bot=bot)
+
+
+# ---------------------------------------------------------------------------
+# _AdminPanelView.coglist_btn opens the interactive manager
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_coglist_button_opens_cog_manager_view():
+    cog = _admin_cog()
+    ctx = MagicMock()
+    ctx.author = _author()
+    panel = _AdminPanelView(ctx, cog)
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = panel._author
+    interaction.client = MagicMock()
+    interaction.response = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+
+    btn = next(
+        c
+        for c in panel.children
+        if isinstance(c, discord.ui.Button)
+        and "Cog List" in (c.label or "")
+    )
+    await btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    interaction.response.edit_message.assert_awaited_once()
+    _args, kwargs = interaction.response.edit_message.call_args
+    assert isinstance(kwargs["view"], _CogManagerView)
+
+
+# ---------------------------------------------------------------------------
+# View shape — Select + 4 action buttons
+# ---------------------------------------------------------------------------
+
+
+def test_cog_manager_view_has_select_and_four_buttons():
+    view = _CogManagerView(_admin_cog(), _author())
+    selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
+    buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+    assert len(selects) == 1
+    assert {b.label for b in buttons} == {"Load", "Unload", "Reload", "🔄 Refresh"}
+
+
+def test_cog_manager_view_select_options_label_loaded_state():
+    cog = _admin_cog(extensions={"cogs.admin_cog": object()})
+    view = _CogManagerView(cog, _author())
+    select = next(c for c in view.children if isinstance(c, discord.ui.Select))
+    # Every option's label encodes the load state (✅ or ❌).
+    for opt in select.options:
+        assert "✅" in opt.label or "❌" in opt.label
+
+
+def test_cog_manager_view_protected_options_carry_shield_glyph():
+    view = _CogManagerView(_admin_cog(), _author())
+    select = next(c for c in view.children if isinstance(c, discord.ui.Select))
+    for opt in select.options:
+        if opt.value in _PROTECTED_COGS:
+            assert "🛡" in opt.label
+            assert opt.description and "Protected" in opt.description
+
+
+# ---------------------------------------------------------------------------
+# Owner gate — non-owner mutation buttons deny
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_owner_load_button_denies_and_does_not_load():
+    cog = _admin_cog()
+    view = _CogManagerView(cog, _author())
+    view.selected_module = "cogs.general_cog"
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = MagicMock()
+    interaction.client.is_owner = AsyncMock(return_value=False)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+
+    load_btn = next(
+        c for c in view.children if isinstance(c, discord.ui.Button) and c.label == "Load"
+    )
+    await load_btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    interaction.response.send_message.assert_awaited_once()
+    args, kwargs = interaction.response.send_message.call_args
+    assert "Owner only" in (args[0] if args else kwargs.get("content", ""))
+    assert kwargs.get("ephemeral") is True
+    cog.bot.load_extension.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_non_owner_unload_button_denies_and_does_not_unload():
+    cog = _admin_cog()
+    view = _CogManagerView(cog, _author())
+    view.selected_module = "cogs.general_cog"
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = MagicMock()
+    interaction.client.is_owner = AsyncMock(return_value=False)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+
+    unload_btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.label == "Unload"
+    )
+    await unload_btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    interaction.response.send_message.assert_awaited_once()
+    cog.bot.unload_extension.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_non_owner_reload_button_denies_and_does_not_reload():
+    cog = _admin_cog()
+    view = _CogManagerView(cog, _author())
+    view.selected_module = "cogs.general_cog"
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = MagicMock()
+    interaction.client.is_owner = AsyncMock(return_value=False)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+
+    reload_btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.label == "Reload"
+    )
+    await reload_btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    interaction.response.send_message.assert_awaited_once()
+    cog.bot.reload_extension.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Owner mutation paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_owner_load_button_calls_bot_load_extension():
+    cog = _admin_cog()
+    view = _CogManagerView(cog, _author())
+    view.selected_module = "cogs.general_cog"
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = MagicMock()
+    interaction.client.is_owner = AsyncMock(return_value=True)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+
+    load_btn = next(
+        c for c in view.children if isinstance(c, discord.ui.Button) and c.label == "Load"
+    )
+    await load_btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    cog.bot.load_extension.assert_awaited_once_with("cogs.general_cog")
+    interaction.response.edit_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_owner_unload_button_calls_bot_unload_extension():
+    cog = _admin_cog(extensions={"cogs.general_cog": object()})
+    view = _CogManagerView(cog, _author())
+    view.selected_module = "cogs.general_cog"
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = MagicMock()
+    interaction.client.is_owner = AsyncMock(return_value=True)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+
+    unload_btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.label == "Unload"
+    )
+    await unload_btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    cog.bot.unload_extension.assert_awaited_once_with("cogs.general_cog")
+
+
+@pytest.mark.asyncio
+async def test_owner_reload_button_calls_bot_reload_extension():
+    cog = _admin_cog(extensions={"cogs.general_cog": object()})
+    view = _CogManagerView(cog, _author())
+    view.selected_module = "cogs.general_cog"
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = MagicMock()
+    interaction.client.is_owner = AsyncMock(return_value=True)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+
+    reload_btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.label == "Reload"
+    )
+    await reload_btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    cog.bot.reload_extension.assert_awaited_once_with("cogs.general_cog")
+
+
+@pytest.mark.asyncio
+async def test_owner_load_button_with_no_selection_asks_to_pick_first():
+    cog = _admin_cog()
+    view = _CogManagerView(cog, _author())
+    # No selected_module set.
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = MagicMock()
+    interaction.client.is_owner = AsyncMock(return_value=True)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+
+    load_btn = next(
+        c for c in view.children if isinstance(c, discord.ui.Button) and c.label == "Load"
+    )
+    await load_btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    interaction.response.send_message.assert_awaited_once()
+    args, kwargs = interaction.response.send_message.call_args
+    assert "Pick a cog" in (args[0] if args else kwargs.get("content", ""))
+    cog.bot.load_extension.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Critical-cog protection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_owner_panel_unload_of_protected_cog_is_refused():
+    cog = _admin_cog(extensions={"cogs.admin_cog": object()})
+    view = _CogManagerView(cog, _author())
+    # admin_cog is in _PROTECTED_COGS by design.
+    view.selected_module = "cogs.admin_cog"
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = MagicMock()
+    interaction.client.is_owner = AsyncMock(return_value=True)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+
+    unload_btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.label == "Unload"
+    )
+    await unload_btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    interaction.response.send_message.assert_awaited_once()
+    args, kwargs = interaction.response.send_message.call_args
+    msg = args[0] if args else kwargs.get("content", "")
+    assert "protected core cog" in msg
+    assert "!cog unload" in msg  # escape-hatch reference
+    assert kwargs.get("ephemeral") is True
+    # The protected cog must NOT have been touched.
+    cog.bot.unload_extension.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_owner_panel_reload_of_protected_cog_is_allowed():
+    """Reload is reversible — protected cogs may still be reloaded
+    from the panel, since reload doesn't risk losing the cog.
+    """
+    cog = _admin_cog(extensions={"cogs.admin_cog": object()})
+    view = _CogManagerView(cog, _author())
+    view.selected_module = "cogs.admin_cog"
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = MagicMock()
+    interaction.client.is_owner = AsyncMock(return_value=True)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+
+    reload_btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.label == "Reload"
+    )
+    await reload_btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    cog.bot.reload_extension.assert_awaited_once_with("cogs.admin_cog")
+
+
+# ---------------------------------------------------------------------------
+# Prefix `!cog` retains no protection (escape hatch)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prefix_cog_unload_of_protected_cog_is_not_blocked():
+    """``!cog unload admin`` is the operator's escape hatch when the
+    panel won't open. The prefix command intentionally has no
+    protected-cog check — only the panel does. Pin that.
+    """
+    cog = _admin_cog(extensions={"cogs.admin_cog": object()})
+    ctx = MagicMock()
+    ctx.send = AsyncMock()
+
+    await cog.manage_cog.callback(cog, ctx, "unload", "admin")
+
+    # The prefix command DID call the underlying unload (regardless
+    # of whether ``cogs.admin_cog`` is protected).
+    cog.bot.unload_extension.assert_awaited_once_with("cogs.admin_cog")
+
+
+# ---------------------------------------------------------------------------
+# Helper bodies are shared between prefix command and panel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_do_load_calls_bot_load_extension():
+    bot = MagicMock()
+    bot.load_extension = AsyncMock()
+    status = await _do_load(bot, "cogs.general_cog")
+    bot.load_extension.assert_awaited_once_with("cogs.general_cog")
+    assert "loaded" in status
+
+
+@pytest.mark.asyncio
+async def test_do_load_returns_error_on_exception():
+    bot = MagicMock()
+    bot.load_extension = AsyncMock(side_effect=RuntimeError("boom"))
+    status = await _do_load(bot, "cogs.general_cog")
+    assert "Error loading" in status
+    assert "boom" in status
+
+
+@pytest.mark.asyncio
+async def test_do_unload_calls_bot_unload_extension():
+    bot = MagicMock()
+    bot.unload_extension = AsyncMock()
+    status = await _do_unload(bot, "cogs.general_cog")
+    bot.unload_extension.assert_awaited_once_with("cogs.general_cog")
+    assert "unloaded" in status
+
+
+@pytest.mark.asyncio
+async def test_do_reload_calls_bot_reload_extension():
+    bot = MagicMock()
+    bot.reload_extension = AsyncMock()
+    status = await _do_reload(bot, "cogs.general_cog")
+    bot.reload_extension.assert_awaited_once_with("cogs.general_cog")
+    assert "reloaded" in status

--- a/tests/unit/cogs/test_admin_cog_manager.py
+++ b/tests/unit/cogs/test_admin_cog_manager.py
@@ -28,8 +28,8 @@ import discord
 import pytest
 
 from cogs.admin.cog_manager import (
-    _CogManagerView,
     _PROTECTED_COGS,
+    _CogManagerView,
     _do_load,
     _do_reload,
     _do_unload,


### PR DESCRIPTION
## Summary

PR C of the post-#152 stabilization plan. Closes issue #6 — Admin → Cog List was a read-only embed; operators had to use the prefix `!cog` command for load/unload/reload. Now the panel is interactive, with critical-cog protection layered on top.

## What this PR does

### Interactive Cog Manager panel

The "📋 Cog List" button on `_AdminPanelView` now opens `_CogManagerView`:

- **Select** lists every `*_cog.py` with status icons (✅/❌ loaded, 🟢/🔴 syntax, 🛡 protected).
- **Load** / **Unload** / **Reload** buttons act on the current selection.
- **🔄 Refresh** re-reads load state without mutation.
- **↩ Back to Admin** attached via `attach_back_to_admin_button`.

### Critical-cog protection

`_PROTECTED_COGS` frozenset: `admin_cog`, `cleanup_cog`, `help_cog`, `logging_cog`, `settings_cog`.

- Panel **Unload** of a protected cog → refused with an ephemeral citing the prefix-command escape hatch.
- Panel **Reload** of a protected cog → allowed (reload is reversible).
- Panel **Load** → unrestricted.
- Prefix `!cog unload <name>` → **intentionally** retains no protection. It is the operator's escape hatch when the panel won't open.

### Owner gate

Mutation buttons check `interaction.client.is_owner(interaction.user)` before doing anything. Non-owners see "Owner only." and `bot.{load,unload,reload}_extension` is NOT called. Select + Refresh remain open so admins can still inspect state.

### S4.6 cog-size compliance

Adding ~270 LOC of view + helper code to `admin_cog.py` would push it from ~620 to ~890 — over the 800-LOC hard ceiling enforced by `tests/unit/invariants/test_cog_size.py`. So this PR follows the F-3 decomposition convention:

- **New** `disbot/cogs/admin/__init__.py` and `disbot/cogs/admin/cog_manager.py` hold the discovery helpers (`_normalize`, `_find_module`, `_all_cog_modules`, `_syntax_ok`), shared load/unload/reload primitives (`_do_load`, `_do_unload`, `_do_reload`), `_PROTECTED_COGS`, and the new `_CogManagerView` + `_CogManagerSelect`.
- `admin_cog.py` imports from there; shrinks from ~620 LOC to **534 LOC**.

### Scope

| File | Change |
|---|---|
| `disbot/cogs/admin/__init__.py` | **NEW** — subpackage marker. |
| `disbot/cogs/admin/cog_manager.py` | **NEW** — helpers + view + protected set. |
| `disbot/cogs/admin_cog.py` | Slimmed to import from `cog_manager`; `coglist_btn` now opens the manager view; `manage_cog` prefix uses shared `_do_load/unload/reload`. |
| `tests/unit/cogs/test_admin_cog_manager.py` | **NEW** — 18 tests. |

### Test plan

- [x] 18 new tests cover: Cog List routes to the manager, view shape (1 Select + 4 buttons), label glyphs, owner gate on Load/Unload/Reload (deny + no extension call), owner mutation paths (each button calls the corresponding `bot.X_extension` once), selection-required guard, protected-cog unload refusal with escape-hatch reference, protected-cog reload still allowed, prefix `!cog unload` of a protected cog not blocked, and helper behavior including error formatting.
- [x] Full `tests/` suite — 2447/2447 pass.
- [x] `mypy disbot/`, `ruff check .`, `black --check .`, `isort --check-only disbot/` all clean.
- [x] `admin_cog.py` at 534 LOC — under the 800-LOC S4.6 ceiling.
- [ ] Manual Discord smoke (post-deploy):
  - As owner: `!adminmenu` → Cog List → select a non-protected cog → Unload → ❌; → Load → ✅; → Reload → ✅.
  - As owner: select a protected cog (e.g. `cleanup_cog`) → Unload → ephemeral denial; → Reload → ✅.
  - Force a syntax error in one cog; confirm 🔴 marker; reload surfaces the error.
  - As admin (non-owner): Cog List opens; Load/Unload/Reload deny ephemerally.
  - Back to Admin returns to the admin panel.

### Rollback

Additive subpackage + replaced one button body. Revert restores the read-only embed. No state changes; the extension registry is unaffected.

### Out of scope for C — deliberate

- Slash variant of `/cog` — operators run this from a terminal/admin panel; slash add comes only if the panel proves insufficient.
- Live syntax-check refresh on file change — current `_syntax_ok` reads at panel open; the Refresh button re-reads. A file-watcher would be heavier and adds little.
- Per-cog dependency awareness — unloading `economy_cog` doesn't currently warn about dependents. Out of scope.

### Follow-ups

- PR E1 — user-tier slash front doors (depends on D, which is now in main; this PR is independent).
- PR E2 — privileged slash front doors.
- PR E' — `!admin sync` for app-command tree resync.
- PR F — `!list` pagination.
- PR G — leaderboard provider registry.
- PR H — Platform/Diagnostics setup readiness inventory.

https://claude.ai/code/session_01VJhdMgBEfU2LmvgiiS5TN4

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJhdMgBEfU2LmvgiiS5TN4)_