### PR TITLE
slash: user-tier front doors (/games, /economy, /community, /utility)

### DIFF
--- a/disbot/cogs/community_cog.py
+++ b/disbot/cogs/community_cog.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import logging
 
 import discord
+from discord import app_commands
 from discord.ext import commands
 
 from core.runtime.interaction_helpers import help_ctx_shim
@@ -50,6 +51,27 @@ class CommunityCog(commands.Cog):
         """Help-menu direct-navigation hook — returns the Community hub panel."""
         ctx_shim = help_ctx_shim(interaction)
         return await build_community_hub_panel(ctx_shim.author, interaction=interaction)
+
+    @app_commands.command(
+        name="community",
+        description="Open the Community hub (XP, Roles, and community games).",
+    )
+    async def community_slash(self, interaction: discord.Interaction) -> None:
+        """Slash front door for the Community hub — ephemeral.
+
+        PR E1 — user-tier slash. Reuses
+        :func:`views.community.hub.build_community_hub_panel` so
+        governance filtering applies identically to the slash entry.
+        """
+        embed, view = await build_community_hub_panel(
+            interaction.user,
+            interaction=interaction,
+        )
+        await interaction.response.send_message(
+            embed=embed,
+            view=view,
+            ephemeral=True,
+        )
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/disbot/cogs/economy_cog.py
+++ b/disbot/cogs/economy_cog.py
@@ -17,6 +17,7 @@ import logging
 import time
 
 import discord
+from discord import app_commands
 from discord.ext import commands
 
 from cogs.economy._helpers import (
@@ -32,6 +33,7 @@ from cogs.economy._helpers import (
     _shop_embed,
 )
 from core.runtime import panel_manager, resources
+from core.runtime.interaction_helpers import safe_defer, safe_followup
 from services import economy_service
 from utils import db
 from utils.cooldowns import check_cooldown, format_remaining
@@ -75,6 +77,23 @@ class EconomyCog(commands.Cog):
         view = EconomyPanelView()
         embed = await _build_economy_embed(interaction.user, interaction.guild_id)
         return embed, view
+
+    @app_commands.command(
+        name="economy",
+        description="Open the Economy hub (daily, work, shop, balance).",
+    )
+    async def economy_slash(self, interaction: discord.Interaction) -> None:
+        """Slash front door for the Economy hub — ephemeral.
+
+        PR E1 — user-tier slash. Reuses
+        :meth:`build_help_menu_view` so the slash entry uses the same
+        panel + embed builder as the help-routed entry. Response is
+        ephemeral (per the ``/help`` convention).
+        """
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        embed, view = await self.build_help_menu_view(interaction)
+        await safe_followup(interaction, embed=embed, view=view, ephemeral=True)
 
     # ------------------------------------------------------------------ events
 

--- a/disbot/cogs/games_cog.py
+++ b/disbot/cogs/games_cog.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import logging
 
 import discord
+from discord import app_commands
 from discord.ext import commands
 
 from core.runtime.interaction_helpers import help_ctx_shim
@@ -46,6 +47,29 @@ class GamesCog(commands.Cog):
         """Help-menu direct-navigation hook — returns the Games hub panel."""
         ctx_shim = help_ctx_shim(interaction)
         return await build_games_hub_panel(ctx_shim.author, interaction=interaction)
+
+    @app_commands.command(
+        name="games",
+        description="Open the Games hub (competitive + activities).",
+    )
+    async def games_slash(self, interaction: discord.Interaction) -> None:
+        """Slash front door for the Games hub — ephemeral, governance-filtered.
+
+        PR E1 — user-tier slash front door. Reuses
+        :func:`views.games.hub.build_games_hub_panel` so visibility
+        filtering and the click-time recheck from PR D apply
+        identically to the slash entry. The response is ephemeral —
+        slash hubs are personal panels per the ``/help`` convention.
+        """
+        embed, view = await build_games_hub_panel(
+            interaction.user,
+            interaction=interaction,
+        )
+        await interaction.response.send_message(
+            embed=embed,
+            view=view,
+            ephemeral=True,
+        )
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/disbot/cogs/utility_cog.py
+++ b/disbot/cogs/utility_cog.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 
 import discord
+from discord import app_commands
 from discord.ext import commands
 
 from core.runtime import tasks
@@ -51,6 +52,24 @@ class UtilityCog(commands.Cog):
         """Help-menu direct-navigation hook (returns the utility panel)."""
         view = _UtilityPanelView(help_ctx_shim(interaction))
         return view.build_embed(), view
+
+    @app_commands.command(
+        name="utility",
+        description="Open the Utility hub (server info, polls, reminders).",
+    )
+    async def utility_slash(self, interaction: discord.Interaction) -> None:
+        """Slash front door for the Utility hub — ephemeral.
+
+        PR E1 — user-tier slash. Reuses
+        :meth:`build_help_menu_view` so the slash entry mirrors the
+        help-routed and prefix entries.
+        """
+        embed, view = await self.build_help_menu_view(interaction)
+        await interaction.response.send_message(
+            embed=embed,
+            view=view,
+            ephemeral=True,
+        )
 
     @commands.command(name="clear", aliases=["purge"])
     @commands.has_permissions(manage_messages=True)

--- a/tests/unit/cogs/test_slash_user_tier.py
+++ b/tests/unit/cogs/test_slash_user_tier.py
@@ -1,0 +1,256 @@
+"""Unit tests for the user-tier slash front doors (PR E1).
+
+Pins the contract for ``/games``, ``/economy``, ``/community``, and
+``/utility``:
+
+* Each slash command is registered on its owning cog.
+* Each callback returns ephemerally — slash hubs are personal
+  panels per the ``/help`` convention.
+* ``/games`` and ``/community`` route through the PR D factory so
+  governance filtering applies identically to the slash entry.
+* ``/economy`` and ``/utility`` route through ``build_help_menu_view``
+  so the slash entry uses the same builder as the help-routed entry.
+* No business-logic duplication — each callback delegates and
+  surfaces the existing panel.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+from discord.ext import commands
+
+from cogs.community_cog import CommunityCog
+from cogs.economy_cog import EconomyCog
+from cogs.games_cog import GamesCog
+from cogs.utility_cog import UtilityCog
+from governance.models import VisibilityResult
+from utils.subsystem_registry import SUBSYSTEMS
+
+
+def _interaction(user_id: int = 1) -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    user = MagicMock(spec=discord.Member)
+    user.id = user_id
+    interaction.user = user
+    interaction.guild = MagicMock()
+    interaction.guild_id = 42
+    interaction.channel = MagicMock()
+    interaction.client = MagicMock()
+    interaction.response = MagicMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    interaction.original_response = AsyncMock(return_value=MagicMock())
+    return interaction
+
+
+@contextmanager
+def _all_visible():
+    vis_result = VisibilityResult(
+        visible_subsystems=set(SUBSYSTEMS),
+        member_tier="moderator",
+        resolved_from={},
+        traces={},
+    )
+    with patch(
+        "services.governance_service.resolve_visibility",
+        new_callable=AsyncMock,
+        return_value=vis_result,
+    ):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Slash commands exist on their owning cogs
+# ---------------------------------------------------------------------------
+
+
+def test_games_cog_has_slash_command():
+    cog = GamesCog(MagicMock(spec=commands.Bot))
+    app_command_names = {cmd.name for cmd in cog.walk_app_commands()}
+    assert "games" in app_command_names
+
+
+def test_economy_cog_has_slash_command():
+    cog = EconomyCog(MagicMock(spec=commands.Bot))
+    app_command_names = {cmd.name for cmd in cog.walk_app_commands()}
+    assert "economy" in app_command_names
+
+
+def test_community_cog_has_slash_command():
+    cog = CommunityCog(MagicMock(spec=commands.Bot))
+    app_command_names = {cmd.name for cmd in cog.walk_app_commands()}
+    assert "community" in app_command_names
+
+
+def test_utility_cog_has_slash_command():
+    cog = UtilityCog(MagicMock(spec=commands.Bot))
+    app_command_names = {cmd.name for cmd in cog.walk_app_commands()}
+    assert "utility" in app_command_names
+
+
+# ---------------------------------------------------------------------------
+# /games — routes through the PR D factory, ephemeral
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_games_slash_responds_ephemerally_through_factory():
+    cog = GamesCog(MagicMock(spec=commands.Bot))
+    interaction = _interaction()
+    with _all_visible():
+        await cog.games_slash.callback(cog, interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    _args, kwargs = interaction.response.send_message.call_args
+    assert kwargs.get("ephemeral") is True
+    assert isinstance(kwargs.get("embed"), discord.Embed)
+    # The view returned by build_games_hub_panel is a GamesHubView; verify
+    # the slash callback didn't replace it with a different surface.
+    from views.games.hub import GamesHubView
+
+    assert isinstance(kwargs.get("view"), GamesHubView)
+
+
+# ---------------------------------------------------------------------------
+# /community — routes through the PR D factory, ephemeral
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_community_slash_responds_ephemerally_through_factory():
+    cog = CommunityCog(MagicMock(spec=commands.Bot))
+    interaction = _interaction()
+    with _all_visible():
+        await cog.community_slash.callback(cog, interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    _args, kwargs = interaction.response.send_message.call_args
+    assert kwargs.get("ephemeral") is True
+    assert isinstance(kwargs.get("embed"), discord.Embed)
+    from views.community.hub import CommunityHubView
+
+    assert isinstance(kwargs.get("view"), CommunityHubView)
+
+
+# ---------------------------------------------------------------------------
+# /economy — routes through build_help_menu_view, ephemeral
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_economy_slash_defers_then_followups_ephemerally():
+    cog = EconomyCog(MagicMock(spec=commands.Bot))
+    interaction = _interaction()
+
+    fake_embed = discord.Embed(title="Economy")
+    fake_view = discord.ui.View()
+
+    with patch.object(
+        cog,
+        "build_help_menu_view",
+        AsyncMock(return_value=(fake_embed, fake_view)),
+    ), patch(
+        "cogs.economy_cog.safe_defer",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as mock_defer, patch(
+        "cogs.economy_cog.safe_followup",
+        new_callable=AsyncMock,
+    ) as mock_followup:
+        await cog.economy_slash.callback(cog, interaction)
+
+    mock_defer.assert_awaited_once_with(interaction, ephemeral=True)
+    mock_followup.assert_awaited_once()
+    _args, kwargs = mock_followup.call_args
+    assert kwargs.get("embed") is fake_embed
+    assert kwargs.get("view") is fake_view
+    assert kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_economy_slash_bails_when_defer_fails():
+    """If ``safe_defer`` reports False (token expired or HTTP failure),
+    the slash callback must abort without calling ``followup`` or
+    ``build_help_menu_view``.
+    """
+    cog = EconomyCog(MagicMock(spec=commands.Bot))
+    interaction = _interaction()
+
+    with patch.object(
+        cog,
+        "build_help_menu_view",
+        new_callable=AsyncMock,
+    ) as mock_hook, patch(
+        "cogs.economy_cog.safe_defer",
+        new_callable=AsyncMock,
+        return_value=False,
+    ), patch(
+        "cogs.economy_cog.safe_followup",
+        new_callable=AsyncMock,
+    ) as mock_followup:
+        await cog.economy_slash.callback(cog, interaction)
+
+    mock_hook.assert_not_awaited()
+    mock_followup.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# /utility — routes through build_help_menu_view, ephemeral
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_utility_slash_responds_ephemerally_via_hook():
+    cog = UtilityCog(MagicMock(spec=commands.Bot))
+    interaction = _interaction()
+
+    fake_embed = discord.Embed(title="Utility")
+    fake_view = discord.ui.View()
+
+    with patch.object(
+        cog,
+        "build_help_menu_view",
+        AsyncMock(return_value=(fake_embed, fake_view)),
+    ):
+        await cog.utility_slash.callback(cog, interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    _args, kwargs = interaction.response.send_message.call_args
+    assert kwargs.get("embed") is fake_embed
+    assert kwargs.get("view") is fake_view
+    assert kwargs.get("ephemeral") is True
+
+
+# ---------------------------------------------------------------------------
+# Each slash callback exists and reuses the existing panel-builder
+# ---------------------------------------------------------------------------
+
+
+def test_slash_callbacks_have_descriptions():
+    """The /slash UI surfaces command descriptions in Discord's
+    autocomplete. Pin that every user-tier front door has a non-empty
+    description so operators see what each command does.
+    """
+    cogs = [
+        GamesCog(MagicMock(spec=commands.Bot)),
+        EconomyCog(MagicMock(spec=commands.Bot)),
+        CommunityCog(MagicMock(spec=commands.Bot)),
+        UtilityCog(MagicMock(spec=commands.Bot)),
+    ]
+    seen: set[str] = set()
+    for cog in cogs:
+        for cmd in cog.walk_app_commands():
+            if cmd.name in {"games", "economy", "community", "utility"}:
+                seen.add(cmd.name)
+                assert cmd.description, (
+                    f"/{cmd.name} has empty description — Discord requires "
+                    f"a non-empty description on slash commands."
+                )
+    assert seen == {"games", "economy", "community", "utility"}


### PR DESCRIPTION
## Summary

PR E1 of the post-#152 stabilization plan. Adds the four user-tier ephemeral slash front doors that mirror the existing prefix hubs. Closes the user-tier portion of issue P1 (`/help` was the only slash command until now). Privileged front doors (`/admin`, `/settings`, `/moderation`, `/platform`) ship separately as PR E2 to scope reviewer attention to the permission-gate edge cases.

## Routing

Each slash command reuses the existing panel builders — **no business-logic duplication**:

- **`/games`** and **`/community`** route through `views.{games,community}.hub.build_*_hub_panel(interaction.user, interaction=interaction)`. The factories from PR D resolve governance and filter children, so the slash entry inherits the same visibility gating and click-time recheck as the prefix entry. Response is `interaction.response.send_message(ephemeral=True)` — no defer needed (the factory's `resolve_visibility` call is cached and fast).
- **`/economy`** calls `safe_defer(interaction, ephemeral=True)` first (its `build_help_menu_view` does DB reads that could exceed the 3-second interaction token window), then `build_help_menu_view`, then `safe_followup`. The helpers swallow recoverable token-expiry / HTTP errors per the INV-L invariant.
- **`/utility`** calls `build_help_menu_view` directly (no DB reads in the panel build) and responds via `interaction.response.send_message(ephemeral=True)`.

## Scope

| File | Change |
|---|---|
| `disbot/cogs/games_cog.py` | Add `app_commands` import + `games_slash` callback. |
| `disbot/cogs/community_cog.py` | Add `app_commands` import + `community_slash` callback. |
| `disbot/cogs/economy_cog.py` | Add `app_commands` import + `safe_defer`/`safe_followup` import + `economy_slash` callback. |
| `disbot/cogs/utility_cog.py` | Add `app_commands` import + `utility_slash` callback. |
| `tests/unit/cogs/test_slash_user_tier.py` | **NEW** — 10 tests. |

## Test plan

- [x] 10 new tests cover: each cog registers its slash command, each callback responds ephemerally, `/games` + `/community` return the hub view types built by their factories, `/economy` uses `safe_defer` + `safe_followup` and bails cleanly when defer reports failure (token expired path), `/utility` delegates to its hook and responds ephemerally, and every front door has a non-empty Discord description.
- [x] Full `tests/` suite — 2464/2464 pass.
- [x] `mypy disbot/`, `ruff check .`, `black --check .`, CI-style `isort --check-only . --skip-glob '...'` all clean.
- [x] INV-L (no raw `interaction.response.defer(`) passes — `/economy` uses `safe_defer`.
- [ ] Manual Discord smoke (post-deploy):
  - As normal user: `/games`, `/economy`, `/community`, `/utility` each open an ephemeral panel; compare to prefix output.
  - Hub views from `/games` and `/community` show only governance-visible children (matches PR D's filter).
  - `/economy` followup arrives ephemerally even on a slow guild (DB reads complete after defer).
  - Compare slash autocomplete descriptions vs the ones in the cog source.
  - After deploy, run `!admin sync` (lands in PR E') if commands don't appear.

## Rollback

Additive callbacks + tests. Revert removes the slash registrations on next bot restart. No state changes; the existing prefix entry points are unchanged.

## Out of scope for E1 — deliberate

- Permission-gated privileged commands (`/admin`, `/settings`, `/moderation`, `/platform`) — split into PR E2 per the plan, since those carry permission-gate edge cases worth a focused review.
- `/help` already exists from PR #151 — untouched here.
- App-command tree resync command — PR E' adds `!admin sync` for the post-deploy resync workflow.

## Follow-ups

- PR E2 — privileged slash front doors.
- PR E' — `!admin sync` for app-command tree resync diagnostics.
- PR F — `!list` pagination.
- PR G — leaderboard provider registry.
- PR H — Platform/Diagnostics setup readiness inventory.

https://claude.ai/code/session_01VJhdMgBEfU2LmvgiiS5TN4

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJhdMgBEfU2LmvgiiS5TN4)_