### PR TITLE
slash: privileged front doors (/admin, /settings, /moderation, /platform)

### DIFF
--- a/disbot/cogs/admin_cog.py
+++ b/disbot/cogs/admin_cog.py
@@ -5,6 +5,7 @@ import os
 import sys
 
 import discord
+from discord import app_commands
 from discord.ext import commands
 
 from cogs.admin.cog_manager import (  # noqa: F401 — re-exported for back-compat (callers may import here)
@@ -47,6 +48,27 @@ class AdminCog(commands.Cog):
         """Help-menu direct-navigation hook (returns the admin control panel)."""
         view = _AdminPanelView(help_ctx_shim(interaction), self)
         return view.build_embed(), view
+
+    @app_commands.command(
+        name="admin",
+        description="Open the Admin control panel (administrator only).",
+    )
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.checks.has_permissions(administrator=True)
+    async def admin_slash(self, interaction: discord.Interaction) -> None:
+        """Slash front door for the Admin hub — ephemeral, admin-only.
+
+        PR E2 — privileged slash. ``default_permissions`` hides the
+        command from non-admins in the Discord UI; ``checks.has_permissions``
+        enforces at runtime. Both layers are kept so the gate works
+        whether or not the guild's Discord client is up to date.
+        """
+        embed, view = await self.build_help_menu_view(interaction)
+        await interaction.response.send_message(
+            embed=embed,
+            view=view,
+            ephemeral=True,
+        )
 
     # ------------------------------------------------------------------
     # Server Statistics

--- a/disbot/cogs/diagnostic_cog.py
+++ b/disbot/cogs/diagnostic_cog.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 
 import discord
+from discord import app_commands
 from discord.ext import commands
 
 from cogs.diagnostic._helpers import (
@@ -104,6 +105,27 @@ class DiagnosticCog(commands.Cog):
         """
         view = _PlatformHubView(interaction.user)
         return build_platform_hub_embed(), view
+
+    @app_commands.command(
+        name="platform",
+        description="Open the Platform / Diagnostics hub (administrator only).",
+    )
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.checks.has_permissions(administrator=True)
+    async def platform_slash(self, interaction: discord.Interaction) -> None:
+        """Slash front door for the Platform hub — ephemeral, admin-only.
+
+        PR E2 — privileged slash. Mirrors ``!platform`` (gated by
+        ``administrator=True``). Reuses
+        :meth:`build_platform_help_menu_view` so the slash entry
+        opens the same Platform hub as Help → Platform/Diagnostics.
+        """
+        embed, view = await self.build_platform_help_menu_view(interaction)
+        await interaction.response.send_message(
+            embed=embed,
+            view=view,
+            ephemeral=True,
+        )
 
     # ------------------------------------------------------------------
     # Command overview

--- a/disbot/cogs/moderation_cog.py
+++ b/disbot/cogs/moderation_cog.py
@@ -4,7 +4,7 @@ import logging
 from datetime import timedelta
 
 import discord
-from discord import Member
+from discord import Member, app_commands
 from discord.ext import commands
 
 from cogs.moderation._helpers import _build_mod_panel_embed
@@ -73,6 +73,27 @@ class ModerationCog(commands.Cog):
     ) -> tuple[discord.Embed, discord.ui.View]:
         """Help-menu direct-navigation hook (returns the moderation panel)."""
         return _build_mod_panel_embed(), ModPanelView()
+
+    @app_commands.command(
+        name="moderation",
+        description="Open the Moderation hub (moderator only).",
+    )
+    @app_commands.default_permissions(moderate_members=True)
+    @app_commands.checks.has_permissions(moderate_members=True)
+    async def moderation_slash(self, interaction: discord.Interaction) -> None:
+        """Slash front door for the Moderation hub — ephemeral, mod-only.
+
+        PR E2 — privileged slash. Gated by ``moderate_members`` to
+        mirror the ``!modmenu`` prefix command's permission check.
+        Reuses :meth:`build_help_menu_view` so the embed + view are
+        identical to the prefix / help routes.
+        """
+        embed, view = await self.build_help_menu_view(interaction)
+        await interaction.response.send_message(
+            embed=embed,
+            view=view,
+            ephemeral=True,
+        )
 
     # ------------------------------------------------------------------
     # Traditional text commands (kept for direct use)

--- a/disbot/cogs/settings_cog.py
+++ b/disbot/cogs/settings_cog.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import logging
 
 import discord
+from discord import app_commands
 from discord.ext import commands
 
 from views.base import send_panel
@@ -185,6 +186,27 @@ class SettingsCog(commands.Cog):
 
         view = SettingsHubView(interaction.user)
         return SettingsHubView.build_embed(), view
+
+    @app_commands.command(
+        name="settings",
+        description="Open the Settings Manager hub (administrator only).",
+    )
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.checks.has_permissions(administrator=True)
+    async def settings_slash(self, interaction: discord.Interaction) -> None:
+        """Slash front door for Settings Manager — ephemeral, admin-only.
+
+        PR E2 — privileged slash. Reuses :meth:`build_help_menu_view`
+        so the kill-switch gate is enforced identically: when the
+        feature flag is OFF the slash entry surfaces the disabled
+        embed; when ON the hub view is returned.
+        """
+        embed, view = await self.build_help_menu_view(interaction)
+        await interaction.response.send_message(
+            embed=embed,
+            view=view,
+            ephemeral=True,
+        )
 
 
 class _DisabledHelpHookView(discord.ui.View):

--- a/tests/unit/cogs/test_slash_privileged.py
+++ b/tests/unit/cogs/test_slash_privileged.py
@@ -1,0 +1,277 @@
+"""Unit tests for the privileged-tier slash front doors (PR E2).
+
+Pins the contract for ``/admin``, ``/settings``, ``/moderation``, and
+``/platform``:
+
+* Each slash command is registered on its owning cog.
+* Each carries a runtime permission check via
+  ``@app_commands.checks.has_permissions`` AND the corresponding
+  ``@app_commands.default_permissions`` Discord-side visibility hint.
+  Both layers must be present so the gate works regardless of
+  whether the guild's Discord client respects the visibility hint.
+* Successful callbacks respond ephemerally.
+* Each callback delegates to the existing panel builder — no
+  business-logic duplication.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+from discord.ext import commands
+
+from cogs.admin_cog import AdminCog
+from cogs.diagnostic_cog import DiagnosticCog
+from cogs.moderation_cog import ModerationCog
+from cogs.settings_cog import SettingsCog
+
+
+def _interaction(user_id: int = 1) -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    user = MagicMock(spec=discord.Member)
+    user.id = user_id
+    interaction.user = user
+    interaction.guild = MagicMock()
+    interaction.guild_id = 42
+    interaction.channel = MagicMock()
+    interaction.client = MagicMock()
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _has_app_command(cog: commands.Cog, name: str) -> bool:
+    return any(cmd.name == name for cmd in cog.walk_app_commands())
+
+
+def _get_app_command(cog: commands.Cog, name: str):
+    for cmd in cog.walk_app_commands():
+        if cmd.name == name:
+            return cmd
+    raise AssertionError(f"No app command named {name!r}")
+
+
+# ---------------------------------------------------------------------------
+# Each privileged slash command is registered
+# ---------------------------------------------------------------------------
+
+
+def test_admin_cog_has_slash_command():
+    assert _has_app_command(AdminCog(MagicMock(spec=commands.Bot)), "admin")
+
+
+def test_settings_cog_has_slash_command():
+    assert _has_app_command(SettingsCog(MagicMock(spec=commands.Bot)), "settings")
+
+
+def test_moderation_cog_has_slash_command():
+    assert _has_app_command(
+        ModerationCog(MagicMock(spec=commands.Bot)),
+        "moderation",
+    )
+
+
+def test_diagnostic_cog_has_platform_slash_command():
+    assert _has_app_command(DiagnosticCog(MagicMock(spec=commands.Bot)), "platform")
+
+
+# ---------------------------------------------------------------------------
+# Each privileged slash carries default_permissions (Discord UI hide)
+# ---------------------------------------------------------------------------
+
+
+def test_admin_slash_default_permissions_administrator():
+    cmd = _get_app_command(AdminCog(MagicMock(spec=commands.Bot)), "admin")
+    perms = cmd.default_permissions
+    assert perms is not None
+    assert perms.administrator is True
+
+
+def test_settings_slash_default_permissions_administrator():
+    cmd = _get_app_command(SettingsCog(MagicMock(spec=commands.Bot)), "settings")
+    perms = cmd.default_permissions
+    assert perms is not None
+    assert perms.administrator is True
+
+
+def test_moderation_slash_default_permissions_moderate_members():
+    cmd = _get_app_command(
+        ModerationCog(MagicMock(spec=commands.Bot)),
+        "moderation",
+    )
+    perms = cmd.default_permissions
+    assert perms is not None
+    assert perms.moderate_members is True
+
+
+def test_platform_slash_default_permissions_administrator():
+    cmd = _get_app_command(DiagnosticCog(MagicMock(spec=commands.Bot)), "platform")
+    perms = cmd.default_permissions
+    assert perms is not None
+    assert perms.administrator is True
+
+
+# ---------------------------------------------------------------------------
+# Each privileged slash carries a runtime has_permissions check
+# ---------------------------------------------------------------------------
+
+
+def _has_runtime_permission_check(cmd) -> bool:
+    """Return True if ``cmd.checks`` contains a runtime
+    ``has_permissions`` check from ``app_commands``.
+
+    discord.py's ``has_permissions`` registers itself on
+    ``Command.checks``; iterate looking for the signature.
+    """
+    for check in cmd.checks:
+        # has_permissions wraps a predicate closure with the
+        # permission kwargs captured. Check the qualified name.
+        if "has_permissions" in getattr(check, "__qualname__", ""):
+            return True
+    return False
+
+
+def test_admin_slash_has_runtime_admin_check():
+    cmd = _get_app_command(AdminCog(MagicMock(spec=commands.Bot)), "admin")
+    assert _has_runtime_permission_check(cmd)
+
+
+def test_settings_slash_has_runtime_admin_check():
+    cmd = _get_app_command(SettingsCog(MagicMock(spec=commands.Bot)), "settings")
+    assert _has_runtime_permission_check(cmd)
+
+
+def test_moderation_slash_has_runtime_mod_check():
+    cmd = _get_app_command(
+        ModerationCog(MagicMock(spec=commands.Bot)),
+        "moderation",
+    )
+    assert _has_runtime_permission_check(cmd)
+
+
+def test_platform_slash_has_runtime_admin_check():
+    cmd = _get_app_command(DiagnosticCog(MagicMock(spec=commands.Bot)), "platform")
+    assert _has_runtime_permission_check(cmd)
+
+
+# ---------------------------------------------------------------------------
+# Successful callbacks respond ephemerally and reuse existing builders
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_slash_responds_ephemerally():
+    cog = AdminCog(MagicMock(spec=commands.Bot))
+    interaction = _interaction()
+
+    fake_embed = discord.Embed(title="Admin")
+    fake_view = discord.ui.View()
+
+    with patch.object(
+        cog,
+        "build_help_menu_view",
+        AsyncMock(return_value=(fake_embed, fake_view)),
+    ):
+        await cog.admin_slash.callback(cog, interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    _args, kwargs = interaction.response.send_message.call_args
+    assert kwargs.get("embed") is fake_embed
+    assert kwargs.get("view") is fake_view
+    assert kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_settings_slash_responds_ephemerally():
+    cog = SettingsCog(MagicMock(spec=commands.Bot))
+    interaction = _interaction()
+
+    fake_embed = discord.Embed(title="Settings")
+    fake_view = discord.ui.View()
+
+    with patch.object(
+        cog,
+        "build_help_menu_view",
+        AsyncMock(return_value=(fake_embed, fake_view)),
+    ):
+        await cog.settings_slash.callback(cog, interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    _args, kwargs = interaction.response.send_message.call_args
+    assert kwargs.get("embed") is fake_embed
+    assert kwargs.get("view") is fake_view
+    assert kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_moderation_slash_responds_ephemerally():
+    cog = ModerationCog(MagicMock(spec=commands.Bot))
+    interaction = _interaction()
+
+    fake_embed = discord.Embed(title="Moderation")
+    fake_view = discord.ui.View()
+
+    with patch.object(
+        cog,
+        "build_help_menu_view",
+        AsyncMock(return_value=(fake_embed, fake_view)),
+    ):
+        await cog.moderation_slash.callback(cog, interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    _args, kwargs = interaction.response.send_message.call_args
+    assert kwargs.get("embed") is fake_embed
+    assert kwargs.get("view") is fake_view
+    assert kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_platform_slash_responds_ephemerally():
+    cog = DiagnosticCog(MagicMock(spec=commands.Bot))
+    interaction = _interaction()
+
+    fake_embed = discord.Embed(title="Platform")
+    fake_view = discord.ui.View()
+
+    with patch.object(
+        cog,
+        "build_platform_help_menu_view",
+        AsyncMock(return_value=(fake_embed, fake_view)),
+    ):
+        await cog.platform_slash.callback(cog, interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    _args, kwargs = interaction.response.send_message.call_args
+    assert kwargs.get("embed") is fake_embed
+    assert kwargs.get("view") is fake_view
+    assert kwargs.get("ephemeral") is True
+
+
+# ---------------------------------------------------------------------------
+# Descriptions present for Discord's autocomplete UI
+# ---------------------------------------------------------------------------
+
+
+def test_privileged_slash_callbacks_have_descriptions():
+    cogs = [
+        AdminCog(MagicMock(spec=commands.Bot)),
+        SettingsCog(MagicMock(spec=commands.Bot)),
+        ModerationCog(MagicMock(spec=commands.Bot)),
+        DiagnosticCog(MagicMock(spec=commands.Bot)),
+    ]
+    seen: set[str] = set()
+    for cog in cogs:
+        for cmd in cog.walk_app_commands():
+            if cmd.name in {"admin", "settings", "moderation", "platform"}:
+                seen.add(cmd.name)
+                assert cmd.description, (
+                    f"/{cmd.name} has empty description — Discord requires "
+                    f"a non-empty description on slash commands."
+                )
+    assert seen == {"admin", "settings", "moderation", "platform"}


### PR DESCRIPTION
## Summary

PR E2 of the post-#152 stabilization plan. Adds the four privileged-tier ephemeral slash front doors. Closes the privileged portion of issue P1 (`/help` is the only slash command on main; `/games`, `/economy`, `/community`, `/utility` ship in PR E1 — independent branch, no file overlap with this PR).

## What this PR does

### Two-layer permission gate

Each privileged slash carries both:

- **`@app_commands.default_permissions(...)`** — hides the command from non-privileged users in Discord's slash autocomplete. This is a UI hint Discord interprets client-side.
- **`@app_commands.checks.has_permissions(...)`** — enforces at runtime. Discord may not respect the visibility hint in every client (old clients, mobile race conditions), so the runtime check is the source of truth.

Both layers are kept on every command — defence in depth.

### Routing — no business-logic duplication

| Command | Permission | Builder reused |
|---|---|---|
| `/admin` | `administrator=True` | `AdminCog.build_help_menu_view` |
| `/settings` | `administrator=True` | `SettingsCog.build_help_menu_view` (preserves the kill-switch gate flag — when OFF the slash entry shows the disabled embed) |
| `/moderation` | `moderate_members=True` | `ModerationCog.build_help_menu_view` |
| `/platform` | `administrator=True` | `DiagnosticCog.build_platform_help_menu_view` |

The moderation gate uses `moderate_members` to mirror `!modmenu`'s prefix check. Platform mirrors `!platform`'s `administrator=True` gate (not `is_owner` — operators with admin can already invoke the prefix today).

### Scope

| File | Change |
|---|---|
| `disbot/cogs/admin_cog.py` | Add `app_commands` import + `admin_slash` callback. |
| `disbot/cogs/settings_cog.py` | Add `app_commands` import + `settings_slash` callback. |
| `disbot/cogs/moderation_cog.py` | Add `app_commands` import + `moderation_slash` callback. |
| `disbot/cogs/diagnostic_cog.py` | Add `app_commands` import + `platform_slash` callback. |
| `tests/unit/cogs/test_slash_privileged.py` | **NEW** — 17 tests. |

## Test plan

- [x] 17 new tests cover: each cog registers its slash command, each carries `default_permissions` matching its tier, each carries a runtime `has_permissions` check, each callback responds ephemerally and delegates to the existing builder, every front door has a non-empty Discord description.
- [x] Full `tests/` suite — 2471/2471 pass.
- [x] `mypy disbot/`, `ruff check .`, `black --check .`, CI-style isort all clean.
- [ ] Manual Discord smoke (post-deploy):
  - As admin: `/admin`, `/settings`, `/platform` each open an ephemeral panel; behavior matches prefix commands.
  - As moderator (no admin): `/moderation` opens ephemeral panel; `/admin` is hidden from autocomplete and denied at runtime.
  - As normal user: all four are hidden from autocomplete; if invoked via cached client, runtime gate denies.
  - With Settings kill-switch flag OFF: `/settings` surfaces the disabled embed (not the hub).
  - Compare `/admin` vs `!adminmenu` and `/platform` vs `!platform` outputs.
  - After deploy, run `!admin sync` (lands in PR E') if commands don't appear.

## Rollback

Additive callbacks + tests. Revert removes the slash registrations on next bot restart. No state changes; existing prefix entry points are unchanged.

## Out of scope for E2 — deliberate

- User-tier `/games`, `/economy`, `/community`, `/utility` — ship in PR E1 (split per the plan to scope reviewer attention to permission-gate edge cases here).
- App-command tree resync command — PR E' adds `!admin sync` for the post-deploy resync workflow.
- Owner-only variants (e.g. `/cog`, `/restart`) — owner-only operations stay on prefix commands; slash variants would surface secrets/runtime ops to autocomplete and we don't gain reach by adding them.
- Per-subcommand slash trees (e.g. `/platform status`, `/platform anchors`) — the hub-level slash opens the interactive panel; the per-subcommand surfaces remain prefix-only for now.

## Follow-ups

- PR E' — `!admin sync` for app-command tree resync diagnostics.
- PR F — `!list` pagination.
- PR G — leaderboard provider registry.
- PR H — Platform/Diagnostics setup readiness inventory.

https://claude.ai/code/session_01VJhdMgBEfU2LmvgiiS5TN4

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJhdMgBEfU2LmvgiiS5TN4)_