### PR TITLE
admin: !syncslash + !slashes for slash-tree deployment diagnostics

### DIFF
--- a/disbot/cogs/admin_cog.py
+++ b/disbot/cogs/admin_cog.py
@@ -150,6 +150,130 @@ class AdminCog(commands.Cog):
         await ctx.send("\n".join(parts) or "✅ Nothing to unload.")
 
     # ------------------------------------------------------------------
+    # Slash-command tree sync + diagnostics (PR E')
+    # ------------------------------------------------------------------
+    @commands.command(name="syncslash", aliases=["syncs"])
+    @commands.is_owner()
+    async def sync_slash_commands(
+        self,
+        ctx: commands.Context,
+        scope: str = "guild",
+    ) -> None:
+        """Sync the app-command tree for slash commands (owner only).
+
+        PR E' — operator tooling for the post-deploy resync workflow.
+        After PR E1 / E2 add or change slash commands, the Discord
+        command tree needs to be told about them. Bot startup already
+        runs a global sync (per ``setup_hook``); this command exists
+        for cases where the operator needs to re-trigger one without
+        a full restart.
+
+        Usage::
+
+            !syncslash             # sync this guild (default — fast)
+            !syncslash guild       # sync this guild (explicit)
+            !syncslash global      # sync globally — rate-limited;
+                                   #   propagation can take up to 1 h
+
+        ``guild`` scope is the right choice in almost every case:
+        Discord rate-limits global sync, and per-guild sync makes
+        new commands appear immediately. ``global`` is only needed
+        if the bot deploys to a guild that hasn't seen the tree yet.
+        """
+        scope = scope.lower()
+        if scope not in ("guild", "global"):
+            await ctx.send("❌ Invalid scope. Use `guild` or `global`.")
+            return
+
+        if scope == "global":
+            try:
+                synced = await self.bot.tree.sync()
+            except discord.HTTPException as exc:
+                await ctx.send(
+                    f"⚠️ Global sync failed: `{type(exc).__name__}`: {exc}",
+                )
+                return
+            await ctx.send(
+                f"✅ Synced **{len(synced)}** slash commands globally. "
+                "Propagation may take up to an hour.",
+            )
+            return
+
+        guild = ctx.guild
+        if guild is None:
+            await ctx.send("❌ `guild` scope requires a guild context.")
+            return
+        try:
+            synced = await self.bot.tree.sync(guild=guild)
+        except discord.HTTPException as exc:
+            await ctx.send(
+                f"⚠️ Guild sync failed: `{type(exc).__name__}`: {exc}",
+            )
+            return
+        await ctx.send(
+            f"✅ Synced **{len(synced)}** slash commands to **{guild.name}**.",
+        )
+
+    @commands.command(name="slashes", aliases=["slashlist"])
+    @commands.has_permissions(administrator=True)
+    async def list_slash_commands(
+        self,
+        ctx: commands.Context,
+        scope: str = "guild",
+    ) -> None:
+        """List currently-registered slash commands (admin only).
+
+        PR E' — read-only deployment diagnostic. Useful for
+        confirming after a sync that the expected commands are
+        present, and for spotting drift between code (what's
+        decorated with ``@app_commands.command``) and what Discord
+        actually has registered.
+
+        Usage::
+
+            !slashes           # this guild (default)
+            !slashes guild     # this guild (explicit)
+            !slashes global    # global tree
+
+        Listing reads from the bot's in-memory tree (what code has
+        registered), not from Discord — so it reflects the current
+        process's state regardless of whether a sync has propagated
+        yet.
+        """
+        scope = scope.lower()
+        if scope not in ("guild", "global"):
+            await ctx.send("❌ Invalid scope. Use `guild` or `global`.")
+            return
+
+        if scope == "global":
+            commands_list = list(self.bot.tree.get_commands())
+            title = "📋 Global Slash Commands"
+        else:
+            guild = ctx.guild
+            if guild is None:
+                await ctx.send("❌ `guild` scope requires a guild context.")
+                return
+            commands_list = list(self.bot.tree.get_commands(guild=guild))
+            title = f"📋 Guild Slash Commands — {guild.name}"
+
+        if not commands_list:
+            await ctx.send(f"_No {scope} slash commands registered._")
+            return
+
+        ordered = sorted(commands_list, key=lambda c: c.name)
+        lines = [
+            f"`/{cmd.name}` — {cmd.description or '_no description_'}"
+            for cmd in ordered
+        ]
+        embed = discord.Embed(
+            title=title,
+            description="\n".join(lines),
+            color=INFO_COLOR,
+        )
+        embed.set_footer(text=f"{len(commands_list)} commands.")
+        await ctx.send(embed=embed)
+
+    # ------------------------------------------------------------------
     # Restart
     # ------------------------------------------------------------------
     @commands.command(name="restart")

--- a/tests/unit/cogs/test_admin_slash_sync.py
+++ b/tests/unit/cogs/test_admin_slash_sync.py
@@ -1,0 +1,270 @@
+"""Unit tests for ``!syncslash`` and ``!slashes`` (PR E').
+
+Operator tooling for the post-deploy slash-tree resync workflow.
+Pins:
+
+* ``!syncslash`` is owner-only.
+* Default scope is ``guild`` — calls ``bot.tree.sync(guild=ctx.guild)``.
+* Explicit ``guild`` scope behaves the same.
+* ``global`` scope calls ``bot.tree.sync()`` without a guild kwarg.
+* Invalid scope is rejected with an operator-readable error.
+* Global sync rate-limit / HTTP failures surface as an ephemeral
+  message rather than uncaught exceptions.
+* ``!slashes`` reads from the in-memory tree (no Discord round-trip).
+* ``!slashes`` is admin-gated (not owner-gated — it's read-only).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+from discord.ext import commands
+
+from cogs.admin_cog import AdminCog
+
+
+def _ctx(*, guild: bool = True) -> MagicMock:
+    ctx = MagicMock(spec=commands.Context)
+    if guild:
+        ctx.guild = MagicMock(spec=discord.Guild)
+        ctx.guild.name = "TestGuild"
+    else:
+        ctx.guild = None
+    ctx.send = AsyncMock()
+    ctx.author = MagicMock(spec=discord.Member)
+    ctx.author.id = 1
+    return ctx
+
+
+def _admin_cog() -> AdminCog:
+    bot = MagicMock()
+    bot.tree = MagicMock()
+    bot.tree.sync = AsyncMock(return_value=[])
+    bot.tree.get_commands = MagicMock(return_value=[])
+    return AdminCog(bot=bot)
+
+
+def _fake_command(name: str, description: str = "") -> MagicMock:
+    cmd = MagicMock()
+    cmd.name = name
+    cmd.description = description
+    return cmd
+
+
+# ---------------------------------------------------------------------------
+# !syncslash registers + permission gating
+# ---------------------------------------------------------------------------
+
+
+def test_syncslash_command_is_registered():
+    cog = _admin_cog()
+    names = {cmd.name for cmd in cog.get_commands()}
+    assert "syncslash" in names
+
+
+def test_syncslash_has_owner_check():
+    cog = _admin_cog()
+    cmd = next(c for c in cog.get_commands() if c.name == "syncslash")
+    # commands.is_owner() registers a check whose qualname contains
+    # ``is_owner``.
+    assert any(
+        "is_owner" in getattr(check, "__qualname__", "") for check in cmd.checks
+    ), "syncslash must be owner-only"
+
+
+# ---------------------------------------------------------------------------
+# !syncslash — guild scope (default + explicit)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_syncslash_default_scope_is_guild():
+    cog = _admin_cog()
+    cog.bot.tree.sync.return_value = [_fake_command("games"), _fake_command("help")]
+    ctx = _ctx()
+
+    await cog.sync_slash_commands.callback(cog, ctx)
+
+    cog.bot.tree.sync.assert_awaited_once_with(guild=ctx.guild)
+    ctx.send.assert_awaited_once()
+    args, kwargs = ctx.send.call_args
+    msg = args[0] if args else kwargs.get("content", "")
+    assert "Synced" in msg
+    assert "**2**" in msg
+    assert "TestGuild" in msg
+
+
+@pytest.mark.asyncio
+async def test_syncslash_explicit_guild_scope():
+    cog = _admin_cog()
+    ctx = _ctx()
+
+    await cog.sync_slash_commands.callback(cog, ctx, "guild")
+
+    cog.bot.tree.sync.assert_awaited_once_with(guild=ctx.guild)
+
+
+# ---------------------------------------------------------------------------
+# !syncslash — global scope
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_syncslash_global_scope_calls_sync_without_guild():
+    cog = _admin_cog()
+    cog.bot.tree.sync.return_value = [_fake_command("help")]
+    ctx = _ctx()
+
+    await cog.sync_slash_commands.callback(cog, ctx, "global")
+
+    cog.bot.tree.sync.assert_awaited_once_with()
+    args, kwargs = ctx.send.call_args
+    msg = args[0] if args else kwargs.get("content", "")
+    assert "globally" in msg
+    assert "Propagation" in msg
+
+
+@pytest.mark.asyncio
+async def test_syncslash_global_handles_http_failure():
+    cog = _admin_cog()
+    cog.bot.tree.sync.side_effect = discord.HTTPException(
+        response=MagicMock(),
+        message="rate limited",
+    )
+    ctx = _ctx()
+
+    await cog.sync_slash_commands.callback(cog, ctx, "global")
+
+    args, kwargs = ctx.send.call_args
+    msg = args[0] if args else kwargs.get("content", "")
+    assert "Global sync failed" in msg
+    assert "HTTPException" in msg
+
+
+# ---------------------------------------------------------------------------
+# !syncslash — invalid scope / no guild
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_syncslash_rejects_unknown_scope():
+    cog = _admin_cog()
+    ctx = _ctx()
+
+    await cog.sync_slash_commands.callback(cog, ctx, "everywhere")
+
+    cog.bot.tree.sync.assert_not_called()
+    args, kwargs = ctx.send.call_args
+    msg = args[0] if args else kwargs.get("content", "")
+    assert "Invalid scope" in msg
+
+
+@pytest.mark.asyncio
+async def test_syncslash_guild_scope_in_dm_context():
+    """Guild-scope sync requires a guild — DM invocation must be
+    rejected rather than calling tree.sync(guild=None) which would
+    sync globally as an unintended side effect.
+    """
+    cog = _admin_cog()
+    ctx = _ctx(guild=False)
+
+    await cog.sync_slash_commands.callback(cog, ctx)
+
+    cog.bot.tree.sync.assert_not_called()
+    args, kwargs = ctx.send.call_args
+    msg = args[0] if args else kwargs.get("content", "")
+    assert "guild context" in msg
+
+
+# ---------------------------------------------------------------------------
+# !slashes — read-only listing
+# ---------------------------------------------------------------------------
+
+
+def test_slashes_command_is_registered():
+    cog = _admin_cog()
+    names = {cmd.name for cmd in cog.get_commands()}
+    assert "slashes" in names
+
+
+@pytest.mark.asyncio
+async def test_slashes_lists_guild_commands_by_default():
+    cog = _admin_cog()
+    cog.bot.tree.get_commands.return_value = [
+        _fake_command("games", "Open the Games hub"),
+        _fake_command("help"),
+    ]
+    ctx = _ctx()
+
+    await cog.list_slash_commands.callback(cog, ctx)
+
+    cog.bot.tree.get_commands.assert_called_once_with(guild=ctx.guild)
+    ctx.send.assert_awaited_once()
+    _args, kwargs = ctx.send.call_args
+    embed = kwargs["embed"]
+    assert "Guild" in (embed.title or "")
+    assert "`/games`" in (embed.description or "")
+    assert "`/help`" in (embed.description or "")
+
+
+@pytest.mark.asyncio
+async def test_slashes_global_scope_lists_without_guild():
+    cog = _admin_cog()
+    cog.bot.tree.get_commands.return_value = [_fake_command("help", "Show help")]
+    ctx = _ctx()
+
+    await cog.list_slash_commands.callback(cog, ctx, "global")
+
+    cog.bot.tree.get_commands.assert_called_once_with()
+    _args, kwargs = ctx.send.call_args
+    embed = kwargs["embed"]
+    assert "Global" in (embed.title or "")
+
+
+@pytest.mark.asyncio
+async def test_slashes_empty_tree_surfaces_message():
+    cog = _admin_cog()
+    cog.bot.tree.get_commands.return_value = []
+    ctx = _ctx()
+
+    await cog.list_slash_commands.callback(cog, ctx)
+
+    args, kwargs = ctx.send.call_args
+    msg = args[0] if args else kwargs.get("content", "")
+    assert "No guild slash commands registered" in msg
+
+
+@pytest.mark.asyncio
+async def test_slashes_lists_commands_sorted_by_name():
+    cog = _admin_cog()
+    cog.bot.tree.get_commands.return_value = [
+        _fake_command("utility"),
+        _fake_command("admin"),
+        _fake_command("games"),
+    ]
+    ctx = _ctx()
+
+    await cog.list_slash_commands.callback(cog, ctx)
+
+    _args, kwargs = ctx.send.call_args
+    description = kwargs["embed"].description or ""
+    # Order in the rendered description must be alphabetical.
+    admin_pos = description.find("/admin")
+    games_pos = description.find("/games")
+    utility_pos = description.find("/utility")
+    assert 0 <= admin_pos < games_pos < utility_pos
+
+
+@pytest.mark.asyncio
+async def test_slashes_in_dm_context_rejects():
+    cog = _admin_cog()
+    ctx = _ctx(guild=False)
+
+    await cog.list_slash_commands.callback(cog, ctx)
+
+    cog.bot.tree.get_commands.assert_not_called()
+    args, kwargs = ctx.send.call_args
+    msg = args[0] if args else kwargs.get("content", "")
+    assert "guild context" in msg


### PR DESCRIPTION
## Summary

PR E' of the post-#152 stabilization plan. Operator tooling for the post-deploy slash-tree resync workflow that PR E1 / E2 motivate — after new slash commands land, Discord needs to be told about them.

## What this PR does

Two new commands on `admin_cog`:

### `!syncslash [guild|global]` (alias: `!syncs`)

Owner-only. Forces a `bot.tree.sync(...)` call.

- **Default / `guild`** — calls `bot.tree.sync(guild=ctx.guild)`. New commands appear immediately in the current guild. Fast, no rate-limit risk.
- **`global`** — calls `bot.tree.sync()` (no guild kwarg). Propagation can take up to an hour; rate-limited by Discord. Useful only when the bot deploys to a guild that hasn't seen the tree yet.
- `discord.HTTPException` (rate-limit, network) surfaces as a typed error message rather than an uncaught exception.
- DM invocation with `guild` scope rejects rather than implicitly globaling.

### `!slashes [guild|global]` (alias: `!slashlist`)

Admin-gated (read-only — no mutation, so doesn't need owner). Reads the in-memory tree via `bot.tree.get_commands(...)` so output reflects the current process's view, regardless of whether a sync has propagated yet.

- Embeds the command name + description in an alphabetically-sorted list.
- Empty tree surfaces a clear message.
- DM invocation rejects.

This is the "did the sync actually take?" diagnostic, paired with `!syncslash` as the action.

## Scope

| File | Change |
|---|---|
| `disbot/cogs/admin_cog.py` | Add `sync_slash_commands` + `list_slash_commands` between cog management and restart sections. |
| `tests/unit/cogs/test_admin_slash_sync.py` | **NEW** — 14 tests. |

`admin_cog.py` grows from 534 → 658 LOC, well under the 800-LOC S4.6 ceiling.

## Test plan

- [x] 14 new tests cover: registration of both commands, owner check on syncslash, default + explicit guild scope, global scope, HTTPException surfacing, invalid scope, DM context handling, !slashes sorted output, !slashes empty tree, !slashes guild vs global routing, !slashes DM rejection.
- [x] Full `tests/` suite — 2468/2468 pass.
- [x] `mypy disbot/`, `ruff check .`, `black --check .`, CI-style isort all clean.
- [ ] Manual Discord smoke (post-deploy, after PR E1/E2 merge):
  - As owner: `!syncslash` reports the count of guild-scoped commands; new `/games`/`/admin`/etc. appear immediately in Discord's slash autocomplete.
  - As owner: `!syncslash global` reports the global count plus the propagation warning.
  - As non-owner admin: `!syncslash` denies.
  - As admin: `!slashes` lists registered commands; output matches what's in source.
  - As normal user: `!slashes` denies.
  - In DM: `!syncslash` and `!slashes` (default scope) reject with the guild-context message.

## Rollback

Additive commands + tests. Revert removes both commands. Slash-tree state in Discord remains as-is (Discord owns it; no local cleanup needed).

## Out of scope for E' — deliberate

- Auto-sync on bot startup — already handled by the bot's `setup_hook` per the existing convention. `!syncslash` is for re-syncing without restart.
- Slash variant `/admin sync` — slash variant of an operator-only sync command would surface it to autocomplete inappropriately. Prefix-only stays.
- Real-time tree-vs-Discord diff (showing commands Discord has but the code doesn't, or vice versa) — would require an async Discord API round-trip; deferred until operators report it as needed.

## Follow-ups

- PR F — `!list` pagination.
- PR G — leaderboard provider registry.
- PR H — Platform/Diagnostics setup readiness inventory.

https://claude.ai/code/session_01VJhdMgBEfU2LmvgiiS5TN4

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJhdMgBEfU2LmvgiiS5TN4)_