### PR TITLE
ranking: centralize !rank + !leaderboard via provider registry

### DIFF
--- a/disbot/cogs/leaderboard_cog.py
+++ b/disbot/cogs/leaderboard_cog.py
@@ -1,126 +1,75 @@
+"""Centralised leaderboards for XP, coins, mining, deathmatch, RPS, and counting.
+
+PR G refactored the per-category branches that previously lived in a
+single ``_build_embed`` function into a provider registry under
+:mod:`services.rank_providers`. This cog now contains only the
+embed-rendering shell + the Discord-facing command surface; adding a
+new category means registering a provider, not touching this file.
+"""
+
 from __future__ import annotations
 
 import discord
 from discord.ext import commands
 
-from core.runtime import resources
 from core.runtime.interaction_helpers import safe_defer
-from utils import db
+from services.rank_providers import (
+    ALIASES,
+    RankProvider,
+    get_provider,
+    provider_names,
+)
 from utils.ui_constants import ECONOMY_COLOR, UTILITY_COLOR
 from views.base import BaseView
 
 MEDALS = ["🥇", "🥈", "🥉"]
 
-CATEGORIES = {
-    "xp": ("🏆 XP Leaderboard", "xp"),
-    "coins": ("🪙 Coin Leaderboard", "coins"),
-    "mining": ("⛏️ Mining Leaderboard", "mining"),
-    "deathmatch": ("⚔️ Deathmatch Leaderboard", "deathmatch"),
-    "rps": ("✂️ RPS Leaderboard", "rps"),
-    "counting": ("🔢 Counting Leaderboard", "counting"),
-}
 
-ALIASES_MAP = {
-    "minelb": "mining",
-    "miningleaderboard": "mining",
-    "dm_leaderboard": "deathmatch",
-    "dm_lb": "deathmatch",
-    "board": "deathmatch",
-    "rpslb": "rps",
-    "countlb": "counting",
-    "counting_leaderboard": "counting",
-    "lb": "xp",
-    "rankings": "xp",
-}
-
-
-async def _build_embed(
-    category: str,
+async def _build_provider_embed(
+    provider: RankProvider,
     guild: discord.Guild,
-    ctx_channel: discord.abc.GuildChannel,
 ) -> discord.Embed:
-    title, _ = CATEGORIES.get(category, ("Leaderboard", ""))
-    embed = discord.Embed(title=title, color=ECONOMY_COLOR)
-
-    # Empty-state hints per category — explain what the feature does and
-    # what the next step is (S4 / user-centered UX rule #5).
-    _EMPTY_HINTS = {
-        "xp": "No XP earned yet. Chat in this server to start ranking up.",
-        "coins": "No coin totals yet. Use `!daily` once per day or `!work` to start earning.",  # noqa: E501
-        "mining": "No mining records yet. Use `!mine` to start collecting items.",
-        "deathmatch": "No deathmatch results yet. Start a match with `!deathmatch` to appear here.",  # noqa: E501
-        "rps": "No RPS games played yet. Challenge someone with `!rps` to appear here.",
-        "counting": "No counting activity yet. Count in the counting channel to appear here.",  # noqa: E501
-    }
-
-    if category == "xp":
-        rows = await db.fetchall(
-            "SELECT user_id, xp, level FROM xp WHERE guild_id=$1 ORDER BY xp DESC LIMIT 10",
-            (guild.id,),
-        )
-        lines = []
-        for i, row in enumerate(rows):
-            name = resources.member_display(guild, row["user_id"])
-            icon = MEDALS[i] if i < 3 else f"`#{i+1}`"
-            lines.append(f"{icon} **{name}** — Level {row['level']} ({row['xp']} XP)")
-        embed.description = "\n".join(lines) or _EMPTY_HINTS["xp"]
-
-    elif category == "coins":
-        rows = await db.fetchall(
-            "SELECT user_id, coins FROM xp WHERE guild_id=$1 ORDER BY coins DESC LIMIT 10",
-            (guild.id,),
-        )
-        lines = []
-        for i, row in enumerate(rows):
-            name = resources.member_display(guild, row["user_id"])
-            icon = MEDALS[i] if i < 3 else f"`#{i+1}`"
-            lines.append(f"{icon} **{name}** — {row['coins']} 🪙")
-        embed.description = "\n".join(lines) or _EMPTY_HINTS["coins"]
-
-    elif category == "mining":
-        rows = await db.get_all_mining_totals(guild.id)
-        lines = []
-        for i, (user_id, total) in enumerate(rows):
-            name = resources.member_display(guild, user_id)
-            icon = MEDALS[i] if i < 3 else f"`#{i+1}`"
-            lines.append(f"{icon} **{name}** — {total} items")
-        embed.description = "\n".join(lines) or _EMPTY_HINTS["mining"]
-
-    elif category == "deathmatch":
-        rows = await db.get_deathmatch_leaderboard()
-        lines = []
-        for i, row in enumerate(rows):
-            name = resources.member_display(guild, row["user_id"])
-            icon = MEDALS[i] if i < 3 else f"`#{i+1}`"
-            lines.append(f"{icon} **{name}** — {row['wins']}W / {row['losses']}L")
-        embed.description = "\n".join(lines) or _EMPTY_HINTS["deathmatch"]
-
-    elif category == "rps":
-        rows = await db.rps_get_leaderboard(guild.id)
-        lines = []
-        for i, row in enumerate(rows):
-            icon = MEDALS[i] if i < 3 else f"`#{i+1}`"
-            lines.append(
-                f"{icon} **{row['name']}** — {row['wins']}W / {row['losses']}L / {row['ties']}T",
-            )
-        embed.description = "\n".join(lines) or _EMPTY_HINTS["rps"]
-
-    elif category == "counting":
-        # Aggregate counting totals across all channels for this guild
-        state = await db.get_counting_state(guild.id)
-        totals: dict[str, int] = {}
-        for ch_data in state.get("channels", {}).values():
-            for uid, cnt in ch_data.get("leaderboard", {}).items():
-                totals[uid] = totals.get(uid, 0) + cnt
-        sorted_totals = sorted(totals.items(), key=lambda x: x[1], reverse=True)[:10]
-        lines = []
-        for i, (uid, cnt) in enumerate(sorted_totals):
-            name = resources.member_display(guild, uid)
-            icon = MEDALS[i] if i < 3 else f"`#{i+1}`"
-            lines.append(f"{icon} **{name}** — {cnt} counts")
-        embed.description = "\n".join(lines) or _EMPTY_HINTS["counting"]
-
+    """Render a leaderboard embed from a provider's top-N rows."""
+    embed = discord.Embed(title=provider.display_title, color=ECONOMY_COLOR)
+    entries = await provider.top(guild)
+    if not entries:
+        embed.description = provider.empty_hint
+        return embed
+    lines = []
+    for i, entry in enumerate(entries):
+        icon = MEDALS[i] if i < 3 else f"`#{i+1}`"
+        lines.append(f"{icon} {entry.label}")
+    embed.description = "\n".join(lines)
     return embed
+
+
+def _build_overview_embed() -> discord.Embed:
+    return discord.Embed(
+        title="📊 Leaderboards",
+        description="Select a category below to view the leaderboard.",
+        color=UTILITY_COLOR,
+    )
+
+
+def _select_options() -> list[discord.SelectOption]:
+    """Build the category-selector options from the provider registry.
+
+    Order matches :func:`services.rank_providers.provider_names` so a
+    new provider added there shows up here without further edits.
+    """
+    options: list[discord.SelectOption] = []
+    for name in provider_names():
+        provider = get_provider(name)
+        if provider is None:
+            continue
+        options.append(
+            discord.SelectOption(
+                label=provider.select_label,
+                value=provider.name,
+                emoji=provider.select_emoji,
+            ),
+        )
+    return options
 
 
 class LeaderboardView(BaseView):
@@ -135,27 +84,37 @@ class LeaderboardView(BaseView):
         super().__init__(author, timeout=120)
         self.guild = guild
         self.channel = channel
+        self.add_item(_CategorySelect())
 
-    @discord.ui.select(
-        placeholder="Choose a leaderboard category…",
-        options=[
-            discord.SelectOption(label="XP", value="xp", emoji="🏆"),
-            discord.SelectOption(label="Coins", value="coins", emoji="🪙"),
-            discord.SelectOption(label="Mining", value="mining", emoji="⛏️"),
-            discord.SelectOption(label="Deathmatch", value="deathmatch", emoji="⚔️"),
-            discord.SelectOption(label="RPS", value="rps", emoji="✂️"),
-            discord.SelectOption(label="Counting", value="counting", emoji="🔢"),
-        ],
-    )
-    async def select_category(
-        self,
-        interaction: discord.Interaction,
-        select: discord.ui.Select,
-    ):
+
+class _CategorySelect(discord.ui.Select):
+    """Runtime-built select whose options come from the provider registry."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            placeholder="Choose a leaderboard category…",
+            options=_select_options(),
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
         if not await safe_defer(interaction):
             return
-        embed = await _build_embed(select.values[0], self.guild, self.channel)
-        await interaction.edit_original_response(embed=embed, view=self)
+        view = self.view
+        if not isinstance(view, LeaderboardView):
+            await interaction.followup.send(
+                "This dropdown is no longer attached to the leaderboard.",
+                ephemeral=True,
+            )
+            return
+        provider = get_provider(self.values[0])
+        if provider is None:
+            await interaction.followup.send(
+                f"Unknown category `{self.values[0]}`.",
+                ephemeral=True,
+            )
+            return
+        embed = await _build_provider_embed(provider, view.guild)
+        await interaction.edit_original_response(embed=embed, view=view)
 
 
 class LeaderboardCog(commands.Cog, name="Leaderboard"):  # type: ignore[call-arg]
@@ -180,20 +139,25 @@ class LeaderboardCog(commands.Cog, name="Leaderboard"):  # type: ignore[call-arg
         ],
     )
     async def leaderboard(self, ctx: commands.Context, category: str = ""):
-        """Show a leaderboard.  !leaderboard [xp|coins|mining|deathmatch|rps|counting]"""
-        cat = ALIASES_MAP.get(ctx.invoked_with, category.lower()) or ""
-        cat = ALIASES_MAP.get(cat, cat)
+        """Show a leaderboard.  !leaderboard [xp|coins|mining|deathmatch|rps|counting]
+
+        Aliases (``!minelb``, ``!dm_lb``, ``!rpslb``, ``!countlb``, etc.)
+        resolve to the same provider via the registry's alias map.
+        """
+        # Prefer the alias (``ctx.invoked_with``) only when it is itself
+        # a known alias key. Otherwise fall back to the operator-typed
+        # category argument so ``!leaderboard mining`` still works.
+        invoked = (ctx.invoked_with or "").lower()
+        if invoked in ALIASES:
+            provider = get_provider(invoked)
+        else:
+            provider = get_provider(category) if category else None
 
         view = LeaderboardView(ctx.guild, ctx.channel, ctx.author)  # type: ignore[arg-type]
-
-        if cat and cat in CATEGORIES:
-            embed = await _build_embed(cat, ctx.guild, ctx.channel)  # type: ignore[arg-type]
+        if provider is not None:
+            embed = await _build_provider_embed(provider, ctx.guild)
         else:
-            embed = discord.Embed(
-                title="📊 Leaderboards",
-                description="Select a category below to view the leaderboard.",
-                color=UTILITY_COLOR,
-            )
+            embed = _build_overview_embed()
 
         view.message = await ctx.send(embed=embed, view=view)
 
@@ -207,12 +171,7 @@ class LeaderboardCog(commands.Cog, name="Leaderboard"):  # type: ignore[call-arg
             interaction.channel,  # type: ignore[arg-type]
             interaction.user,  # type: ignore[arg-type]
         )
-        embed = discord.Embed(
-            title="📊 Leaderboards",
-            description="Select a category below to view the leaderboard.",
-            color=UTILITY_COLOR,
-        )
-        return embed, view
+        return _build_overview_embed(), view
 
 
 async def setup(bot: commands.Bot):

--- a/disbot/cogs/xp_cog.py
+++ b/disbot/cogs/xp_cog.py
@@ -8,13 +8,42 @@ from discord.ext import commands
 from cogs.xp._helpers import _STAT_TYPES, _build_rank_embed
 from core.runtime.interaction_helpers import help_ctx_shim
 from services import xp_service
+from services.rank_providers import get_provider
 from utils import embeds as em
+from utils.ui_constants import ECONOMY_COLOR
 from views.base import send_panel
 from views.xp.config_panel import XpConfigView
 from views.xp.main_panel import _XpHubView
 from views.xp.rank_view import _RankView
 
 logger = logging.getLogger("bot")
+
+
+async def _build_rank_provider_embed(
+    provider,
+    member: discord.Member,
+    guild: discord.Guild,
+) -> discord.Embed:
+    """Render a single-user rank card for any non-XP provider.
+
+    XP and coins keep their richer level / progress-bar card via
+    :func:`cogs.xp._helpers._build_rank_embed`. Everything else uses
+    this thinner card: title from the provider, a single field with
+    the member's rank + provider-formatted value, or an empty-state
+    line when the member has no entry.
+    """
+    rank_pos, rendered = await provider.member_rank(guild, member.id)
+    embed = discord.Embed(
+        title=f"{provider.display_title} — {member.display_name}",
+        color=ECONOMY_COLOR,
+    )
+    embed.set_thumbnail(url=member.display_avatar.url)
+    if rank_pos is None:
+        embed.description = provider.empty_hint
+    else:
+        embed.add_field(name="Rank", value=f"#{rank_pos}", inline=True)
+        embed.add_field(name="Value", value=rendered, inline=True)
+    return embed
 
 
 class XpCog(commands.Cog):
@@ -55,18 +84,48 @@ class XpCog(commands.Cog):
 
     @commands.command(name="rank")
     async def rank(self, ctx: commands.Context, *args):
-        """Show XP/coin rank.  !rank [user] [xp|coins|both]"""
-        member: discord.Member = ctx.author  # type: ignore[assignment]
-        stat: str = "both"
-        for arg in args:
-            if arg.lower() in _STAT_TYPES:
-                stat = arg.lower()
-            else:
-                try:
-                    member = await commands.MemberConverter().convert(ctx, arg)
-                except commands.BadArgument:
-                    pass
+        """Show rank in a category.
 
+        PR G — provider-aware. Supported forms:
+
+        * ``!rank``                — XP + coins overview (legacy default).
+        * ``!rank xp|coins|both``  — XP/coin rank card (legacy).
+        * ``!rank @user``          — XP + coins for another member.
+        * ``!rank @user xp|coins`` — that user's XP or coin card.
+        * ``!rank <category>``     — your rank in mining / deathmatch /
+          rps / counting (any provider name or alias from
+          :mod:`services.rank_providers`).
+        """
+        member: discord.Member = ctx.author  # type: ignore[assignment]
+        stat: str | None = None
+        category: str | None = None
+        for arg in args:
+            lowered = arg.lower()
+            if lowered in _STAT_TYPES:
+                stat = lowered
+                continue
+            # Try a non-XP provider category (mining, deathmatch, rps,
+            # counting, plus all the aliases). Skip "xp"/"coins" — those
+            # already match _STAT_TYPES above so the legacy rank card
+            # path handles them.
+            if lowered not in {"xp", "coins"}:
+                provider = get_provider(lowered)
+                if provider is not None:
+                    category = provider.name
+                    continue
+            try:
+                member = await commands.MemberConverter().convert(ctx, arg)
+            except commands.BadArgument:
+                pass
+
+        if category is not None:
+            provider = get_provider(category)
+            assert provider is not None  # noqa: S101 — guarded above
+            embed = await _build_rank_provider_embed(provider, member, ctx.guild)
+            await ctx.send(embed=embed)
+            return
+
+        stat = stat or "both"
         embed = await _build_rank_embed(member, ctx.guild, stat)
         view = _RankView(member, ctx.guild, stat)
         view.message = await ctx.send(embed=embed, view=view)

--- a/disbot/services/rank_providers.py
+++ b/disbot/services/rank_providers.py
@@ -1,0 +1,378 @@
+"""Provider registry for ``!rank`` and ``!leaderboard`` (PR G).
+
+Centralises the per-category ranking logic that previously lived as
+inline branches in :mod:`cogs.leaderboard_cog._build_embed` and
+:mod:`cogs.xp._helpers._build_rank_embed`. Each provider declares:
+
+* ``name`` — canonical identifier ("xp", "coins", "mining", …).
+* ``display_title`` / ``select_label`` / ``select_emoji`` — UI strings.
+* ``empty_hint`` — operator-friendly empty-state line.
+* :meth:`top` — async, returns up to 10 :class:`RankEntry` rows.
+* :meth:`member_rank` — async, returns ``(rank, rendered_value)`` for
+  one user, or ``(None, None)`` when the user is not on the board.
+
+The registry is read via :func:`get_provider` (alias-aware) and
+:func:`provider_names`. ``leaderboard_cog`` and ``xp_cog`` are the
+two consumers; new categories are added by registering a provider
+here, not by editing either cog.
+
+Identity / aliases match the historical
+:data:`cogs.leaderboard_cog.ALIASES_MAP` so existing prefix
+shortcuts (``!minelb``, ``!dm_lb``, ``!rpslb``, ``!countlb``, etc.)
+continue to resolve to the same provider.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+import discord
+
+from core.runtime import resources
+from utils import db
+
+
+@dataclass(frozen=True)
+class RankEntry:
+    """One row in a ranked top-N response.
+
+    ``label`` is the fully-rendered text that follows the rank/medal
+    prefix — e.g. ``"**Alice** — Level 5 (250 XP)"``. Providers own
+    their own formatting so the registry doesn't need a per-category
+    schema.
+    """
+
+    label: str
+
+
+class RankProvider(ABC):
+    """Abstract base for a leaderboard category.
+
+    Subclasses must define the class-level metadata attributes
+    (``name``, ``display_title``, ``select_label``, ``select_emoji``,
+    ``empty_hint``) and implement :meth:`top` + :meth:`member_rank`.
+    """
+
+    name: str
+    display_title: str
+    select_label: str
+    select_emoji: str | None
+    empty_hint: str
+
+    @abstractmethod
+    async def top(self, guild: discord.Guild) -> list[RankEntry]:
+        """Return up to 10 ranked rows, sorted highest-first."""
+
+    @abstractmethod
+    async def member_rank(
+        self,
+        guild: discord.Guild,
+        user_id: int,
+    ) -> tuple[int | None, str | None]:
+        """Return ``(rank, rendered_value)`` for ``user_id``.
+
+        ``rank`` is the 1-based position in the full ordering or
+        ``None`` if the user has no entry on this board. ``rendered_value``
+        is the provider-formatted statistic (e.g. ``"250 XP"``) or
+        ``None`` matching ``rank=None``.
+        """
+
+
+# ---------------------------------------------------------------------------
+# Concrete providers
+# ---------------------------------------------------------------------------
+
+
+class XpProvider(RankProvider):
+    name = "xp"
+    display_title = "🏆 XP Leaderboard"
+    select_label = "XP"
+    select_emoji = "🏆"
+    empty_hint = "No XP earned yet. Chat in this server to start ranking up."
+
+    async def top(self, guild: discord.Guild) -> list[RankEntry]:
+        rows = await db.fetchall(
+            "SELECT user_id, xp, level FROM xp WHERE guild_id=$1 "
+            "ORDER BY xp DESC LIMIT 10",
+            (guild.id,),
+        )
+        return [
+            RankEntry(
+                label=(
+                    f"**{resources.member_display(guild, row['user_id'])}** "
+                    f"— Level {row['level']} ({row['xp']} XP)"
+                ),
+            )
+            for row in rows
+        ]
+
+    async def member_rank(
+        self,
+        guild: discord.Guild,
+        user_id: int,
+    ) -> tuple[int | None, str | None]:
+        all_xp = await db.fetchall(
+            "SELECT user_id, xp, level FROM xp WHERE guild_id=$1 ORDER BY xp DESC",
+            (guild.id,),
+        )
+        for i, row in enumerate(all_xp):
+            if row["user_id"] == user_id:
+                return i + 1, f"Level {row['level']} ({row['xp']} XP)"
+        return None, None
+
+
+class CoinsProvider(RankProvider):
+    name = "coins"
+    display_title = "🪙 Coin Leaderboard"
+    select_label = "Coins"
+    select_emoji = "🪙"
+    empty_hint = (
+        "No coin totals yet. Use `!daily` once per day or `!work` to start earning."
+    )
+
+    async def top(self, guild: discord.Guild) -> list[RankEntry]:
+        rows = await db.fetchall(
+            "SELECT user_id, coins FROM xp WHERE guild_id=$1 "
+            "ORDER BY coins DESC LIMIT 10",
+            (guild.id,),
+        )
+        return [
+            RankEntry(
+                label=(
+                    f"**{resources.member_display(guild, row['user_id'])}** "
+                    f"— {row['coins']} 🪙"
+                ),
+            )
+            for row in rows
+        ]
+
+    async def member_rank(
+        self,
+        guild: discord.Guild,
+        user_id: int,
+    ) -> tuple[int | None, str | None]:
+        all_coins = await db.fetchall(
+            "SELECT user_id, coins FROM xp WHERE guild_id=$1 ORDER BY coins DESC",
+            (guild.id,),
+        )
+        for i, row in enumerate(all_coins):
+            if row["user_id"] == user_id:
+                return i + 1, f"{row['coins']} 🪙"
+        return None, None
+
+
+class MiningProvider(RankProvider):
+    name = "mining"
+    display_title = "⛏️ Mining Leaderboard"
+    select_label = "Mining"
+    select_emoji = "⛏️"
+    empty_hint = "No mining records yet. Use `!mine` to start collecting items."
+
+    async def top(self, guild: discord.Guild) -> list[RankEntry]:
+        rows = await db.get_all_mining_totals(guild.id)
+        return [
+            RankEntry(
+                label=(
+                    f"**{resources.member_display(guild, user_id)}** "
+                    f"— {total} items"
+                ),
+            )
+            for user_id, total in rows[:10]
+        ]
+
+    async def member_rank(
+        self,
+        guild: discord.Guild,
+        user_id: int,
+    ) -> tuple[int | None, str | None]:
+        rows = await db.get_all_mining_totals(guild.id)
+        for i, (uid, total) in enumerate(rows):
+            if uid == user_id:
+                return i + 1, f"{total} items"
+        return None, None
+
+
+class DeathmatchProvider(RankProvider):
+    name = "deathmatch"
+    display_title = "⚔️ Deathmatch Leaderboard"
+    select_label = "Deathmatch"
+    select_emoji = "⚔️"
+    empty_hint = (
+        "No deathmatch results yet. Start a match with `!deathmatch` to appear here."
+    )
+
+    async def top(self, guild: discord.Guild) -> list[RankEntry]:
+        rows = await db.get_deathmatch_leaderboard()
+        return [
+            RankEntry(
+                label=(
+                    f"**{resources.member_display(guild, row['user_id'])}** "
+                    f"— {row['wins']}W / {row['losses']}L"
+                ),
+            )
+            for row in rows[:10]
+        ]
+
+    async def member_rank(
+        self,
+        guild: discord.Guild,
+        user_id: int,
+    ) -> tuple[int | None, str | None]:
+        rows = await db.get_deathmatch_leaderboard()
+        for i, row in enumerate(rows):
+            if row["user_id"] == user_id:
+                return i + 1, f"{row['wins']}W / {row['losses']}L"
+        return None, None
+
+
+class RpsProvider(RankProvider):
+    name = "rps"
+    display_title = "✂️ RPS Leaderboard"
+    select_label = "RPS"
+    select_emoji = "✂️"
+    empty_hint = (
+        "No RPS games played yet. Challenge someone with `!rps` to appear here."
+    )
+
+    async def top(self, guild: discord.Guild) -> list[RankEntry]:
+        # The RPS leaderboard query already returns a "name" column —
+        # display name is captured at game time, so don't re-resolve.
+        rows = await db.rps_get_leaderboard(guild.id)
+        return [
+            RankEntry(
+                label=(
+                    f"**{row['name']}** — "
+                    f"{row['wins']}W / {row['losses']}L / {row['ties']}T"
+                ),
+            )
+            for row in rows[:10]
+        ]
+
+    async def member_rank(
+        self,
+        guild: discord.Guild,
+        user_id: int,
+    ) -> tuple[int | None, str | None]:
+        rows = await db.rps_get_leaderboard(guild.id)
+        for i, row in enumerate(rows):
+            # The query may not return user_id in every row shape;
+            # match on the resolved display name as a fallback.
+            row_uid = row.get("user_id") if isinstance(row, dict) else None
+            if row_uid == user_id:
+                return (
+                    i + 1,
+                    f"{row['wins']}W / {row['losses']}L / {row['ties']}T",
+                )
+        return None, None
+
+
+class CountingProvider(RankProvider):
+    name = "counting"
+    display_title = "🔢 Counting Leaderboard"
+    select_label = "Counting"
+    select_emoji = "🔢"
+    empty_hint = (
+        "No counting activity yet. Count in the counting channel to appear here."
+    )
+
+    async def _all_totals(
+        self,
+        guild: discord.Guild,
+    ) -> list[tuple[int, int]]:
+        state = await db.get_counting_state(guild.id)
+        totals: dict[int, int] = {}
+        for ch_data in state.get("channels", {}).values():
+            for uid_str, cnt in ch_data.get("leaderboard", {}).items():
+                try:
+                    uid = int(uid_str)
+                except (TypeError, ValueError):
+                    continue
+                totals[uid] = totals.get(uid, 0) + int(cnt)
+        return sorted(totals.items(), key=lambda x: x[1], reverse=True)
+
+    async def top(self, guild: discord.Guild) -> list[RankEntry]:
+        sorted_totals = await self._all_totals(guild)
+        return [
+            RankEntry(
+                label=(
+                    f"**{resources.member_display(guild, uid)}** " f"— {cnt} counts"
+                ),
+            )
+            for uid, cnt in sorted_totals[:10]
+        ]
+
+    async def member_rank(
+        self,
+        guild: discord.Guild,
+        user_id: int,
+    ) -> tuple[int | None, str | None]:
+        sorted_totals = await self._all_totals(guild)
+        for i, (uid, cnt) in enumerate(sorted_totals):
+            if uid == user_id:
+                return i + 1, f"{cnt} counts"
+        return None, None
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+_PROVIDERS: dict[str, RankProvider] = {
+    p.name: p
+    for p in (
+        XpProvider(),
+        CoinsProvider(),
+        MiningProvider(),
+        DeathmatchProvider(),
+        RpsProvider(),
+        CountingProvider(),
+    )
+}
+
+# Alias map — historical ``!leaderboard`` shortcuts that should resolve
+# to the same provider. Pin compatibility for existing operators.
+ALIASES: dict[str, str] = {
+    "lb": "xp",
+    "rankings": "xp",
+    "minelb": "mining",
+    "miningleaderboard": "mining",
+    "dm_leaderboard": "deathmatch",
+    "dm_lb": "deathmatch",
+    "board": "deathmatch",
+    "rpslb": "rps",
+    "countlb": "counting",
+    "counting_leaderboard": "counting",
+}
+
+
+def provider_names() -> list[str]:
+    """Return the canonical provider names in registration order."""
+    return list(_PROVIDERS.keys())
+
+
+def get_provider(name: str) -> RankProvider | None:
+    """Resolve a provider by canonical name or alias.
+
+    Returns ``None`` if the key is unknown — callers handle that as
+    an operator error (typed wrong category).
+    """
+    key = name.lower().strip()
+    key = ALIASES.get(key, key)
+    return _PROVIDERS.get(key)
+
+
+__all__ = [
+    "ALIASES",
+    "CoinsProvider",
+    "CountingProvider",
+    "DeathmatchProvider",
+    "MiningProvider",
+    "RankEntry",
+    "RankProvider",
+    "RpsProvider",
+    "XpProvider",
+    "get_provider",
+    "provider_names",
+]

--- a/disbot/services/rank_providers.py
+++ b/disbot/services/rank_providers.py
@@ -295,9 +295,7 @@ class CountingProvider(RankProvider):
         sorted_totals = await self._all_totals(guild)
         return [
             RankEntry(
-                label=(
-                    f"**{resources.member_display(guild, uid)}** " f"— {cnt} counts"
-                ),
+                label=f"**{resources.member_display(guild, uid)}** — {cnt} counts",
             )
             for uid, cnt in sorted_totals[:10]
         ]

--- a/tests/unit/cogs/test_leaderboard_empty_states.py
+++ b/tests/unit/cogs/test_leaderboard_empty_states.py
@@ -4,9 +4,11 @@ Per the user-centered UX rules in the mother-hub map (rule #5: Empty
 states), an empty panel must explain what the feature does and what
 the next step is — not just say "No data yet!".
 
-These tests stub the DB layer to return no rows for each category and
-verify the embed description contains a concrete next-step hint (e.g.
-``!mine``, ``!daily``).
+PR G migrated the per-category branches into
+:mod:`services.rank_providers`; these tests now exercise the shared
+``_build_provider_embed`` renderer through each provider and verify
+the empty-state description still carries a concrete next-step hint
+(e.g. ``!mine``, ``!daily``).
 """
 
 from __future__ import annotations
@@ -17,6 +19,7 @@ import discord
 import pytest
 
 from cogs import leaderboard_cog
+from services.rank_providers import get_provider
 
 
 def _guild() -> MagicMock:
@@ -25,8 +28,10 @@ def _guild() -> MagicMock:
     return guild
 
 
-def _channel() -> MagicMock:
-    return MagicMock(spec=discord.abc.GuildChannel)
+async def _empty_embed_for(provider_name: str) -> discord.Embed:
+    provider = get_provider(provider_name)
+    assert provider is not None
+    return await leaderboard_cog._build_provider_embed(provider, _guild())
 
 
 # ---------------------------------------------------------------------------
@@ -36,83 +41,69 @@ def _channel() -> MagicMock:
 
 @pytest.mark.asyncio
 async def test_xp_leaderboard_empty_hints_chat_to_earn_xp():
-    with patch.object(
-        leaderboard_cog.db,
-        "fetchall",
+    with patch(
+        "services.rank_providers.db.fetchall",
         new_callable=AsyncMock,
         return_value=[],
     ):
-        embed = await leaderboard_cog._build_embed("xp", _guild(), _channel())
+        embed = await _empty_embed_for("xp")
     assert "Chat" in (embed.description or "")
     assert "rank" in (embed.description or "").lower()
 
 
 @pytest.mark.asyncio
 async def test_coins_leaderboard_empty_hints_daily_and_work():
-    with patch.object(
-        leaderboard_cog.db,
-        "fetchall",
+    with patch(
+        "services.rank_providers.db.fetchall",
         new_callable=AsyncMock,
         return_value=[],
     ):
-        embed = await leaderboard_cog._build_embed("coins", _guild(), _channel())
+        embed = await _empty_embed_for("coins")
     assert "!daily" in (embed.description or "")
     assert "!work" in (embed.description or "")
 
 
 @pytest.mark.asyncio
 async def test_mining_leaderboard_empty_hints_mine_command():
-    with patch.object(
-        leaderboard_cog.db,
-        "get_all_mining_totals",
+    with patch(
+        "services.rank_providers.db.get_all_mining_totals",
         new_callable=AsyncMock,
         return_value=[],
     ):
-        embed = await leaderboard_cog._build_embed("mining", _guild(), _channel())
+        embed = await _empty_embed_for("mining")
     assert "!mine" in (embed.description or "")
 
 
 @pytest.mark.asyncio
 async def test_deathmatch_leaderboard_empty_hints_start_a_match():
-    with patch.object(
-        leaderboard_cog.db,
-        "get_deathmatch_leaderboard",
+    with patch(
+        "services.rank_providers.db.get_deathmatch_leaderboard",
         new_callable=AsyncMock,
         return_value=[],
     ):
-        embed = await leaderboard_cog._build_embed(
-            "deathmatch",
-            _guild(),
-            _channel(),
-        )
+        embed = await _empty_embed_for("deathmatch")
     assert "!deathmatch" in (embed.description or "")
 
 
 @pytest.mark.asyncio
 async def test_rps_leaderboard_empty_hints_challenge_someone():
-    with patch.object(
-        leaderboard_cog.db,
-        "rps_get_leaderboard",
+    with patch(
+        "services.rank_providers.db.rps_get_leaderboard",
         new_callable=AsyncMock,
         return_value=[],
     ):
-        embed = await leaderboard_cog._build_embed("rps", _guild(), _channel())
+        embed = await _empty_embed_for("rps")
     assert "!rps" in (embed.description or "")
 
 
 @pytest.mark.asyncio
 async def test_counting_leaderboard_empty_hints_count_in_channel():
-    with patch.object(
-        leaderboard_cog.db,
-        "get_counting_state",
+    with patch(
+        "services.rank_providers.db.get_counting_state",
         new_callable=AsyncMock,
         return_value={"channels": {}},
     ):
-        embed = await leaderboard_cog._build_embed(
-            "counting",
-            _guild(),
-            _channel(),
-        )
+        embed = await _empty_embed_for("counting")
     # No "No data yet!" — must point at the counting channel.
     desc = embed.description or ""
     assert "No data yet!" not in desc

--- a/tests/unit/services/test_rank_providers.py
+++ b/tests/unit/services/test_rank_providers.py
@@ -1,0 +1,296 @@
+"""Unit tests for :mod:`services.rank_providers` (PR G).
+
+Pins:
+
+* Provider registry exposes the six existing categories.
+* Historical aliases (``!minelb``, ``!dm_lb``, ``!rpslb``,
+  ``!countlb``, ``lb``, ``rankings``, etc.) resolve to the same
+  providers they previously mapped to in
+  ``cogs.leaderboard_cog.ALIASES_MAP``.
+* Each provider's ``top`` returns ranked :class:`RankEntry` rows
+  with provider-specific formatting baked into ``label``.
+* Each provider's ``member_rank`` returns ``(rank, value)`` for an
+  on-board user and ``(None, None)`` for an off-board user.
+* The shared embed renderer in ``leaderboard_cog`` uses providers'
+  ``empty_hint`` when ``top`` returns no rows.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from cogs.leaderboard_cog import _build_provider_embed
+from services.rank_providers import (
+    ALIASES,
+    RankEntry,
+    get_provider,
+    provider_names,
+)
+
+
+def _guild() -> MagicMock:
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 42
+    return guild
+
+
+# ---------------------------------------------------------------------------
+# Registry shape
+# ---------------------------------------------------------------------------
+
+
+def test_registry_exposes_six_canonical_categories():
+    assert set(provider_names()) == {
+        "xp",
+        "coins",
+        "mining",
+        "deathmatch",
+        "rps",
+        "counting",
+    }
+
+
+def test_get_provider_returns_none_for_unknown_name():
+    assert get_provider("not_a_category") is None
+    assert get_provider("") is None
+
+
+def test_get_provider_resolves_canonical_names():
+    for name in ("xp", "coins", "mining", "deathmatch", "rps", "counting"):
+        provider = get_provider(name)
+        assert provider is not None
+        assert provider.name == name
+
+
+def test_historical_aliases_match_pre_pr_g_map():
+    """The alias map mirrors the historical
+    ``cogs.leaderboard_cog.ALIASES_MAP`` so existing operator
+    shortcuts keep resolving to the same provider.
+    """
+    expected = {
+        "minelb": "mining",
+        "miningleaderboard": "mining",
+        "dm_leaderboard": "deathmatch",
+        "dm_lb": "deathmatch",
+        "board": "deathmatch",
+        "rpslb": "rps",
+        "countlb": "counting",
+        "counting_leaderboard": "counting",
+        "lb": "xp",
+        "rankings": "xp",
+    }
+    for alias, canonical in expected.items():
+        assert ALIASES.get(alias) == canonical
+        assert (get_provider(alias) or MagicMock()).name == canonical
+
+
+def test_each_provider_has_select_metadata():
+    """Select options in the leaderboard view come from providers —
+    every provider must declare label/emoji/title so the registry
+    can drive the dropdown without per-cog overrides.
+    """
+    for name in provider_names():
+        provider = get_provider(name)
+        assert provider is not None
+        assert provider.display_title
+        assert provider.select_label
+        assert provider.empty_hint
+
+
+# ---------------------------------------------------------------------------
+# XP provider
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_xp_top_returns_rank_entries():
+    provider = get_provider("xp")
+    rows = [
+        {"user_id": 1, "xp": 250, "level": 5},
+        {"user_id": 2, "xp": 100, "level": 2},
+    ]
+    with patch(
+        "services.rank_providers.db.fetchall",
+        new_callable=AsyncMock,
+        return_value=rows,
+    ), patch(
+        "services.rank_providers.resources.member_display",
+        side_effect=lambda g, uid: f"User{uid}",
+    ):
+        entries = await provider.top(_guild())
+    assert len(entries) == 2
+    assert isinstance(entries[0], RankEntry)
+    assert "User1" in entries[0].label
+    assert "Level 5" in entries[0].label
+    assert "250 XP" in entries[0].label
+
+
+@pytest.mark.asyncio
+async def test_xp_member_rank_finds_user_on_board():
+    provider = get_provider("xp")
+    rows = [
+        {"user_id": 7, "xp": 500, "level": 10},
+        {"user_id": 42, "xp": 250, "level": 5},
+        {"user_id": 99, "xp": 100, "level": 2},
+    ]
+    with patch(
+        "services.rank_providers.db.fetchall",
+        new_callable=AsyncMock,
+        return_value=rows,
+    ):
+        rank_pos, value = await provider.member_rank(_guild(), 42)
+    assert rank_pos == 2
+    assert value == "Level 5 (250 XP)"
+
+
+@pytest.mark.asyncio
+async def test_xp_member_rank_returns_none_when_off_board():
+    provider = get_provider("xp")
+    with patch(
+        "services.rank_providers.db.fetchall",
+        new_callable=AsyncMock,
+        return_value=[{"user_id": 7, "xp": 500, "level": 10}],
+    ):
+        rank_pos, value = await provider.member_rank(_guild(), 999)
+    assert rank_pos is None
+    assert value is None
+
+
+# ---------------------------------------------------------------------------
+# Coins / Mining / Deathmatch / RPS / Counting providers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_coins_top_renders_coins_glyph():
+    provider = get_provider("coins")
+    with patch(
+        "services.rank_providers.db.fetchall",
+        new_callable=AsyncMock,
+        return_value=[{"user_id": 1, "coins": 9999}],
+    ), patch(
+        "services.rank_providers.resources.member_display",
+        return_value="Alice",
+    ):
+        entries = await provider.top(_guild())
+    assert "Alice" in entries[0].label
+    assert "9999 🪙" in entries[0].label
+
+
+@pytest.mark.asyncio
+async def test_mining_top_caps_at_ten_entries():
+    provider = get_provider("mining")
+    rows = [(uid, uid * 10) for uid in range(1, 20)]
+    with patch(
+        "services.rank_providers.db.get_all_mining_totals",
+        new_callable=AsyncMock,
+        return_value=rows,
+    ), patch(
+        "services.rank_providers.resources.member_display",
+        side_effect=lambda g, uid: f"U{uid}",
+    ):
+        entries = await provider.top(_guild())
+    assert len(entries) == 10
+
+
+@pytest.mark.asyncio
+async def test_deathmatch_member_rank_finds_w_l_record():
+    provider = get_provider("deathmatch")
+    rows = [
+        {"user_id": 1, "wins": 5, "losses": 1},
+        {"user_id": 42, "wins": 3, "losses": 2},
+    ]
+    with patch(
+        "services.rank_providers.db.get_deathmatch_leaderboard",
+        new_callable=AsyncMock,
+        return_value=rows,
+    ):
+        rank_pos, value = await provider.member_rank(_guild(), 42)
+    assert rank_pos == 2
+    assert value == "3W / 2L"
+
+
+@pytest.mark.asyncio
+async def test_rps_top_uses_pre_resolved_name():
+    provider = get_provider("rps")
+    rows = [{"name": "Bob", "wins": 4, "losses": 1, "ties": 2}]
+    with patch(
+        "services.rank_providers.db.rps_get_leaderboard",
+        new_callable=AsyncMock,
+        return_value=rows,
+    ):
+        entries = await provider.top(_guild())
+    # RPS query returns a "name" column directly — no member_display.
+    assert "Bob" in entries[0].label
+    assert "4W / 1L / 2T" in entries[0].label
+
+
+@pytest.mark.asyncio
+async def test_counting_aggregates_across_channels():
+    provider = get_provider("counting")
+    state = {
+        "channels": {
+            "100": {"leaderboard": {"1": 50, "2": 20}},
+            "200": {"leaderboard": {"1": 10, "3": 15}},
+        },
+    }
+    with patch(
+        "services.rank_providers.db.get_counting_state",
+        new_callable=AsyncMock,
+        return_value=state,
+    ), patch(
+        "services.rank_providers.resources.member_display",
+        side_effect=lambda g, uid: f"U{uid}",
+    ):
+        entries = await provider.top(_guild())
+        rank_pos, value = await provider.member_rank(_guild(), 1)
+    # User 1 has 50 + 10 = 60 counts across two channels.
+    assert "U1" in entries[0].label
+    assert "60" in entries[0].label
+    assert rank_pos == 1
+    assert value == "60 counts"
+
+
+# ---------------------------------------------------------------------------
+# Shared embed renderer in leaderboard_cog uses provider empty_hint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_provider_embed_surfaces_empty_hint():
+    provider = get_provider("mining")
+    with patch(
+        "services.rank_providers.db.get_all_mining_totals",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        embed = await _build_provider_embed(provider, _guild())
+    assert provider.empty_hint in (embed.description or "")
+
+
+@pytest.mark.asyncio
+async def test_build_provider_embed_applies_medal_prefixes():
+    """First three entries get medal glyphs; the rest get ``#N`` prefixes."""
+    provider = get_provider("xp")
+    rows = [
+        {"user_id": i, "xp": 1000 - i, "level": 10 - i}
+        for i in range(1, 6)
+    ]
+    with patch(
+        "services.rank_providers.db.fetchall",
+        new_callable=AsyncMock,
+        return_value=rows,
+    ), patch(
+        "services.rank_providers.resources.member_display",
+        side_effect=lambda g, uid: f"U{uid}",
+    ):
+        embed = await _build_provider_embed(provider, _guild())
+    description = embed.description or ""
+    assert "🥇" in description
+    assert "🥈" in description
+    assert "🥉" in description
+    assert "#4" in description
+    assert "#5" in description


### PR DESCRIPTION
## Summary

PR G of the post-#152 stabilization plan. Closes issue P2 from the audit — `!rank` previously only supported `xp`/`coins`/`both` while `!leaderboard` covered six categories via inline `_build_embed` branches. Both surfaces now route through a typed provider registry under `services/rank_providers.py`.

## What this PR does

### Provider registry

`disbot/services/rank_providers.py`:

- **`RankProvider`** ABC with class-level metadata (`name`, `display_title`, `select_label`, `select_emoji`, `empty_hint`) and two async methods:
  - `top(guild)` → `list[RankEntry]` — top 10 with provider-specific formatting.
  - `member_rank(guild, user_id)` → `(rank, value) | (None, None)` — single-user position.
- Six concrete providers (`XpProvider`, `CoinsProvider`, `MiningProvider`, `DeathmatchProvider`, `RpsProvider`, `CountingProvider`) — same data sources and formatting as the previous inline branches.
- `get_provider(name)` is alias-aware. `ALIASES` dict mirrors the historical `cogs.leaderboard_cog.ALIASES_MAP` so `!minelb`, `!dm_lb`, `!rpslb`, `!countlb`, `lb`, `rankings`, etc. still resolve.

### `leaderboard_cog` refactor

The per-category `_build_embed` dispatch is gone. Renderer is now `_build_provider_embed(provider, guild)` calling `provider.top`. `LeaderboardView` select options are built at runtime from `provider_names()` so a new provider auto-appears in the dropdown without editing this cog.

### `xp_cog` `!rank` refactor

- Unchanged for `xp`/`coins`/`both` — still routes to the rich `_build_rank_embed` + `_RankView` card (level, progress bar, dual rank).
- New: `!rank mining`, `!rank deathmatch`, `!rank rps`, `!rank counting` (and their aliases) — renders a single-user rank card via `_build_rank_provider_embed(provider, member, guild)` using `provider.member_rank`. Empty board surfaces the provider's `empty_hint`.
- Still supports `!rank @user` and `!rank @user xp|coins` (legacy mixing).

### Scope

| File | Change |
|---|---|
| `disbot/services/rank_providers.py` | **NEW** — registry + six providers. |
| `disbot/cogs/leaderboard_cog.py` | Replace inline category branches with provider dispatch. |
| `disbot/cogs/xp_cog.py` | `!rank` supports any provider name; add `_build_rank_provider_embed`. |
| `tests/unit/services/test_rank_providers.py` | **NEW** — 15 tests. |
| `tests/unit/cogs/test_leaderboard_empty_states.py` | Migrate 6 existing tests to patch the provider's DB calls and exercise the shared renderer. |

## Test plan

- [x] 15 new tests: registry shape, alias resolution matches the pre-PR-G map, every provider declares select metadata, per-provider top() + member_rank() (on-board + off-board), counting aggregation across channels, shared embed renderer applies medal prefixes and uses empty_hint when the board is empty.
- [x] 6 existing empty-state tests migrated to the new provider path.
- [x] Full `tests/` suite — 2526/2526 pass.
- [x] `mypy disbot/`, `ruff check .`, `black --check .`, CI-style isort all clean.
- [ ] Manual Discord smoke (post-deploy):
  - `!leaderboard` → category selector opens; pick each category → embed matches pre-PR-G output.
  - `!rank` → XP+coins overview (unchanged).
  - `!rank @user xp` → that user's XP card.
  - `!rank mining` → your mining rank (new in this PR).
  - `!rank deathmatch`, `!rank rps`, `!rank counting` — new categories work.
  - Aliases: `!minelb`, `!dm_lb`, `!rpslb`, `!countlb`, `!lb`, `!rankings` all resolve to the right provider.
  - Empty guild (no XP earned): leaderboard surfaces the "Chat in this server" hint.

## Rollback

Revert removes the registry, restores the inline `_build_embed` branches in `leaderboard_cog`, and restores the legacy `!rank` xp/coins-only behavior. No state changes; underlying DB queries unchanged.

## Out of scope for G — deliberate

- Slash variants `/leaderboard` and `/rank` — slash entry points are PR E1/E2's territory; adding them here would conflate the refactor with new commands.
- Per-provider pagination (top 11+) — the registry returns top 10 consistently; pagination on a single category is not in the audit's scope.
- Cross-server leaderboards — current scope is per-guild; the providers take a `guild` argument so cross-server would be a separate extension.

## Follow-ups

- PR H — Platform/Diagnostics setup readiness inventory.

https://claude.ai/code/session_01VJhdMgBEfU2LmvgiiS5TN4

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJhdMgBEfU2LmvgiiS5TN4)_