### PR TITLE
platform: setup-readiness inventory + !platform setup-readiness

### DIFF
--- a/disbot/cogs/diagnostic/_platform_embeds.py
+++ b/disbot/cogs/diagnostic/_platform_embeds.py
@@ -1015,6 +1015,82 @@ def _fmt_snapshot_value(value: object) -> str:
     return _impl(value)
 
 
+# ---------------------------------------------------------------------------
+# Setup readiness (PR H)
+# ---------------------------------------------------------------------------
+
+
+async def build_setup_readiness_embed(guild_id: int) -> discord.Embed:
+    """Render a per-guild setup-readiness inventory.
+
+    Calls :func:`services.setup_readiness.collect`, then formats the
+    per-subsystem counts + aggregate score into an embed. Subsystems
+    with no declared config show as ``—``; populated subsystems show
+    ``filled/declared`` for both bindings and settings plus a percent.
+    """
+    from services import setup_readiness
+
+    report = await setup_readiness.collect(guild_id)
+
+    title_score = "—" if report.aggregate_score is None else f"{report.percentage}%"
+
+    embed = discord.Embed(
+        title=f"🛰 Setup Readiness — {title_score}",
+        description=(
+            f"**{report.bindings_bound}/{report.bindings_declared}** bindings · "
+            f"**{report.settings_configured}/{report.settings_declared}** settings · "
+            f"**{report.resources_declared}** resource declarations"
+        ),
+        color=discord.Color.blurple(),
+    )
+
+    if not report.per_subsystem:
+        embed.add_field(
+            name="No subsystem schemas registered",
+            value="`cog_load` did not call `subsystem_schema.register`.",
+            inline=False,
+        )
+        return embed
+
+    # Render each subsystem as one line; group up to ~15 per field so
+    # we stay under the 1024-char per-field cap with operator-readable
+    # wrapping.
+    lines: list[str] = []
+    for entry in report.per_subsystem:
+        # entry.has_config is False iff bindings_declared == 0 AND
+        # settings_declared == 0 — same case where score ends up None.
+        # Treat both as "nothing to score" and surface the em-dash.
+        if not entry.has_config or entry.score is None:
+            score = "—"
+        else:
+            score = f"{round(entry.score * 100)}%"
+        lines.append(
+            f"`{entry.subsystem:<14}` "
+            f"bindings {entry.bindings_bound}/{entry.bindings_declared} · "
+            f"settings {entry.settings_configured}/{entry.settings_declared} · "
+            f"resources {entry.resources_declared} · {score}",
+        )
+
+    # Chunk lines into ≤15 per field to stay comfortably under 1024.
+    chunk_size = 15
+    for i in range(0, len(lines), chunk_size):
+        chunk = lines[i : i + chunk_size]
+        name = (
+            f"Subsystems ({i + 1}–{i + len(chunk)})"
+            if len(lines) > chunk_size
+            else "Subsystems"
+        )
+        embed.add_field(name=name, value="\n".join(chunk), inline=False)
+
+    embed.set_footer(
+        text=(
+            "Read-only. Empty settings_keys (legacy KV) count as unconfigured. "
+            "Subsystems with no declared config show — in the score column."
+        ),
+    )
+    return embed
+
+
 __all__ = [
     "build_anchors_embed",
     "build_bindings_embed",
@@ -1033,6 +1109,7 @@ __all__ = [
     "build_schemas_embed",
     "build_sessions_embed",
     "build_settings_registry_embed",
+    "build_setup_readiness_embed",
     "build_slow_embed",
     "build_status_embed",
     "build_tasks_embed",

--- a/disbot/cogs/diagnostic_cog.py
+++ b/disbot/cogs/diagnostic_cog.py
@@ -273,6 +273,25 @@ class DiagnosticCog(commands.Cog):
         """High-level platform status: uptime, cogs, governance, scheduler."""
         await ctx.send(embed=build_status_embed(self.bot))
 
+    @platform_grp.command(name="setup-readiness", aliases=["readiness", "ready"])  # type: ignore[arg-type]
+    @commands.has_permissions(administrator=True)
+    async def platform_setup_readiness(self, ctx):
+        """Per-guild setup-readiness inventory (PR H).
+
+        Walks ``core.runtime.subsystem_schema.all_schemas`` and joins
+        each subsystem's declared bindings + settings against this
+        guild's stored values to compute how much of the configurable
+        surface has been populated.
+
+        Read-only — does not mutate anything. The output is the
+        substrate for a future setup wizard; for now operators use it
+        to spot subsystems that need attention.
+        """
+        from cogs.diagnostic._platform_embeds import build_setup_readiness_embed
+
+        embed = await build_setup_readiness_embed(ctx.guild.id)
+        await ctx.send(embed=embed)
+
     @platform_grp.command(name="anchors")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def platform_anchors(self, ctx):

--- a/disbot/services/setup_readiness.py
+++ b/disbot/services/setup_readiness.py
@@ -1,0 +1,240 @@
+"""Per-guild setup-readiness inventory (PR H).
+
+Aggregates the bot's declared configuration surface — :class:`SettingSpec`,
+:class:`BindingSpec`, :class:`ResourceRequirement` from
+:mod:`core.runtime.subsystem_schema` — and reports how much of it the
+operator has actually populated for a given guild.
+
+The output is read-only: this service does NOT mutate anything. It
+exists as the substrate for a future setup wizard and, immediately, as
+the data backing ``!platform setup-readiness`` (PR H).
+
+Score model
+-----------
+Per subsystem we count three buckets:
+
+* **Bindings** — declared in the schema's ``bindings`` list; bound when
+  there is a row in ``subsystem_bindings`` for ``(guild_id, subsystem,
+  binding_name)`` with non-empty status (any non-error status).
+* **Settings** — declared in the schema's ``settings`` list; configured
+  when ``db.get_setting(guild_id, settings_key, "")`` is non-empty AND
+  differs from the spec's default. Settings with an empty
+  ``settings_key`` (not yet migrated off the legacy KV) count as
+  declared but never as configured — surfaces them as known gaps.
+* **Resource requirements** — declared in the schema's
+  ``resource_requirements``. These are descriptive — they tell the
+  wizard what platform resources the subsystem consumes — and don't
+  carry their own "configured" signal independent of bindings, so
+  they show as declared counts only.
+
+Per-subsystem score = (bound + configured) / (declared bindings +
+declared settings) — clamped to [0, 1.0]; subsystems with no declared
+config evaluate to ``None`` so they don't drag down the average.
+
+Aggregate score = unweighted mean of per-subsystem scores that are
+not ``None``.
+
+Public API
+----------
+* :func:`collect` — build a :class:`ReadinessReport` for a guild.
+* :class:`ReadinessReport` — frozen dataclass returned by :func:`collect`.
+* :class:`SubsystemReadiness` — per-subsystem entry.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from core.runtime.subsystem_schema import all_schemas
+from utils import db
+from utils.db import bindings as db_bindings
+
+logger = logging.getLogger("bot.setup_readiness")
+
+
+@dataclass(frozen=True)
+class SubsystemReadiness:
+    """Per-subsystem readiness counts.
+
+    ``score`` is ``None`` when the subsystem declares no bindings or
+    settings — there's nothing to be ready about, so it should not be
+    averaged into the aggregate.
+    """
+
+    subsystem: str
+    bindings_declared: int
+    bindings_bound: int
+    settings_declared: int
+    settings_configured: int
+    resources_declared: int
+    score: float | None
+
+    @property
+    def has_config(self) -> bool:
+        """True when the subsystem has anything operator-configurable."""
+        return self.bindings_declared > 0 or self.settings_declared > 0
+
+
+@dataclass(frozen=True)
+class ReadinessReport:
+    """Aggregate readiness snapshot for a guild."""
+
+    guild_id: int
+    per_subsystem: tuple[SubsystemReadiness, ...]
+    bindings_declared: int
+    bindings_bound: int
+    settings_declared: int
+    settings_configured: int
+    resources_declared: int
+    aggregate_score: float | None
+
+    @property
+    def percentage(self) -> int:
+        """Aggregate score as an integer 0–100 (``0`` when no config)."""
+        if self.aggregate_score is None:
+            return 0
+        return round(self.aggregate_score * 100)
+
+
+async def _is_setting_configured(
+    guild_id: int,
+    settings_key: str,
+    default_repr: str,
+) -> bool:
+    """Return True if the stored value differs from the spec's default.
+
+    Settings without a ``settings_key`` (not migrated off the legacy
+    KV) cannot be looked up here; they count as un-configured.
+    """
+    if not settings_key:
+        return False
+    try:
+        stored = await db.get_setting(guild_id, settings_key, "")
+    except Exception as exc:  # noqa: BLE001 — diagnostic surface, fail closed
+        logger.warning(
+            "setup_readiness: get_setting failed for %s/%s: %s",
+            guild_id,
+            settings_key,
+            exc,
+        )
+        return False
+    if not stored:
+        return False
+    # ``default_repr`` is ``repr(spec.default)``; the stored value is
+    # always a string. Compare by repr to handle int/bool defaults
+    # (``"42"`` should not match ``repr(42)`` of ``'42'``, but stored
+    # "True" matches repr(True) = "True"). A configured non-default
+    # value satisfies the readiness check.
+    return repr(stored) != default_repr and stored != default_repr
+
+
+def _compute_score(
+    *,
+    bindings_declared: int,
+    bindings_bound: int,
+    settings_declared: int,
+    settings_configured: int,
+) -> float | None:
+    """Per-subsystem score in [0, 1] — or ``None`` when nothing to score."""
+    total = bindings_declared + settings_declared
+    if total == 0:
+        return None
+    filled = bindings_bound + settings_configured
+    return max(0.0, min(1.0, filled / total))
+
+
+async def collect(guild_id: int) -> ReadinessReport:
+    """Build the per-guild readiness report.
+
+    Walks :func:`core.runtime.subsystem_schema.all_schemas` and, for each
+    declared subsystem, joins the schema against:
+
+    * :func:`utils.db.bindings.list_for_guild` for binding fill state.
+    * :func:`utils.db.get_setting` for setting fill state.
+
+    Subsystems with no declared bindings or settings appear with
+    ``score=None`` so they're surfaced in the report but don't drag the
+    aggregate.
+    """
+    schemas = all_schemas()
+    binding_rows = await db_bindings.list_for_guild(guild_id)
+    # Group bound bindings by (subsystem, binding_name) for O(1) lookup.
+    bound_keys: set[tuple[str, str]] = set()
+    for row in binding_rows:
+        status = (row.get("status") or "").lower()
+        # Skip rows in failed/cleared states — they exist as audit
+        # rows but don't represent a satisfied binding slot.
+        if status in {"cleared", "error", ""}:
+            continue
+        bound_keys.add((row["subsystem"], row["binding_name"]))
+
+    per_subsystem: list[SubsystemReadiness] = []
+    total_b_declared = 0
+    total_b_bound = 0
+    total_s_declared = 0
+    total_s_configured = 0
+    total_r_declared = 0
+
+    for subsystem in sorted(schemas):
+        schema = schemas[subsystem]
+        b_decl = len(schema.bindings)
+        b_bound = sum(
+            1 for spec in schema.bindings if (subsystem, spec.name) in bound_keys
+        )
+        s_decl = len(schema.settings)
+        s_configured = 0
+        for spec in schema.settings:
+            if await _is_setting_configured(
+                guild_id,
+                spec.settings_key,
+                repr(spec.default),
+            ):
+                s_configured += 1
+        r_decl = len(schema.resource_requirements)
+
+        score = _compute_score(
+            bindings_declared=b_decl,
+            bindings_bound=b_bound,
+            settings_declared=s_decl,
+            settings_configured=s_configured,
+        )
+        per_subsystem.append(
+            SubsystemReadiness(
+                subsystem=subsystem,
+                bindings_declared=b_decl,
+                bindings_bound=b_bound,
+                settings_declared=s_decl,
+                settings_configured=s_configured,
+                resources_declared=r_decl,
+                score=score,
+            ),
+        )
+        total_b_declared += b_decl
+        total_b_bound += b_bound
+        total_s_declared += s_decl
+        total_s_configured += s_configured
+        total_r_declared += r_decl
+
+    scored = [r for r in per_subsystem if r.score is not None]
+    aggregate: float | None = None
+    if scored:
+        aggregate = sum(r.score for r in scored) / len(scored)  # type: ignore[misc]
+
+    return ReadinessReport(
+        guild_id=guild_id,
+        per_subsystem=tuple(per_subsystem),
+        bindings_declared=total_b_declared,
+        bindings_bound=total_b_bound,
+        settings_declared=total_s_declared,
+        settings_configured=total_s_configured,
+        resources_declared=total_r_declared,
+        aggregate_score=aggregate,
+    )
+
+
+__all__ = [
+    "ReadinessReport",
+    "SubsystemReadiness",
+    "collect",
+]

--- a/tests/unit/services/test_setup_readiness.py
+++ b/tests/unit/services/test_setup_readiness.py
@@ -1,0 +1,377 @@
+"""Unit tests for :mod:`services.setup_readiness` (PR H).
+
+Pins:
+
+* ``collect`` walks every registered subsystem schema; subsystems
+  with no bindings/settings get ``score=None`` so they don't drag
+  the aggregate.
+* Each subsystem's score is ``(bound + configured) / (declared
+  bindings + declared settings)``.
+* Aggregate score is the unweighted mean of per-subsystem scores
+  that are not ``None``.
+* A setting counts as configured only when:
+  - the stored value is non-empty, AND
+  - the stored value differs from the spec's default, AND
+  - the spec has a non-empty ``settings_key`` (legacy KV migration).
+* A binding counts as bound when ``subsystem_bindings`` has a row
+  whose status is anything other than the sentinel "cleared"/"error"
+  states.
+* The shared embed renderer produces an operator-readable summary
+  including the aggregate percentage and per-subsystem lines.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from core.runtime.subsystem_schema import (
+    BindingKind,
+    BindingSpec,
+    SettingSpec,
+    SubsystemSchema,
+    _reset_for_tests,
+    register,
+)
+from services import setup_readiness
+
+
+@pytest.fixture(autouse=True)
+def _isolated_schema_registry():
+    """Each test owns the schema registry. Reset before + after.
+
+    The real registry is populated by ``cog_load`` hooks across the
+    bot; isolated tests need a clean slate so they assert only on
+    what they declare.
+    """
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+def _register_subsystem(
+    name: str,
+    *,
+    bindings: list[tuple[str, BindingKind]] | None = None,
+    settings: list[tuple[str, str, str | int | bool]] | None = None,
+) -> None:
+    """Register a minimal :class:`SubsystemSchema` for the test.
+
+    ``bindings`` is a list of ``(binding_name, kind)`` tuples;
+    ``settings`` is ``(name, settings_key, default)`` tuples.
+    """
+    binding_specs = tuple(
+        BindingSpec(
+            name=bn,
+            kind=kind,
+            required=False,
+            hint="",
+            capability_required=f"{name}.test.bind",
+        )
+        for bn, kind in (bindings or [])
+    )
+    setting_specs = tuple(
+        SettingSpec(
+            name=sn,
+            value_type=type(default),
+            default=default,
+            settings_key=key,
+            capability_required=f"{name}.test.set",
+            hint="",
+        )
+        for sn, key, default in (settings or [])
+    )
+    register(
+        SubsystemSchema(
+            subsystem=name,
+            bindings=binding_specs,
+            settings=setting_specs,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# collect — registry walk + per-subsystem scoring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_collect_empty_registry_returns_none_score():
+    """No registered schemas — no scores. Should not divide-by-zero."""
+    with patch(
+        "services.setup_readiness.db_bindings.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        report = await setup_readiness.collect(guild_id=42)
+    assert report.aggregate_score is None
+    assert report.per_subsystem == ()
+    assert report.percentage == 0
+
+
+@pytest.mark.asyncio
+async def test_subsystem_with_no_config_has_none_score():
+    """Subsystems declaring no bindings/settings get ``score=None``."""
+    _register_subsystem("empty_sub")
+    with patch(
+        "services.setup_readiness.db_bindings.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        report = await setup_readiness.collect(guild_id=42)
+    assert len(report.per_subsystem) == 1
+    entry = report.per_subsystem[0]
+    assert entry.subsystem == "empty_sub"
+    assert entry.score is None
+    assert entry.has_config is False
+    # Empty-config subsystem does NOT drag the aggregate down.
+    assert report.aggregate_score is None
+
+
+@pytest.mark.asyncio
+async def test_all_bound_all_configured_scores_full():
+    """A subsystem with every binding bound and every setting
+    configured scores 1.0 (100%).
+    """
+    _register_subsystem(
+        "fully_ready",
+        bindings=[("announce_channel", BindingKind.CHANNEL)],
+        settings=[("threshold", "fully_ready.threshold", 3)],
+    )
+
+    binding_rows = [
+        {
+            "subsystem": "fully_ready",
+            "binding_name": "announce_channel",
+            "status": "active",
+        },
+    ]
+    with patch(
+        "services.setup_readiness.db_bindings.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=binding_rows,
+    ), patch(
+        "services.setup_readiness.db.get_setting",
+        new_callable=AsyncMock,
+        # Non-default value — stored "10" differs from default 3.
+        return_value="10",
+    ):
+        report = await setup_readiness.collect(guild_id=42)
+
+    entry = report.per_subsystem[0]
+    assert entry.bindings_bound == 1
+    assert entry.settings_configured == 1
+    assert entry.score == 1.0
+    assert report.percentage == 100
+
+
+@pytest.mark.asyncio
+async def test_partial_fill_scores_half():
+    """Two declared, one filled → 0.5."""
+    _register_subsystem(
+        "half_ready",
+        bindings=[("log_channel", BindingKind.CHANNEL)],
+        settings=[("interval", "half_ready.interval", 5)],
+    )
+    # Binding is bound but the setting is unset (stored "" — default).
+    with patch(
+        "services.setup_readiness.db_bindings.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[
+            {
+                "subsystem": "half_ready",
+                "binding_name": "log_channel",
+                "status": "active",
+            },
+        ],
+    ), patch(
+        "services.setup_readiness.db.get_setting",
+        new_callable=AsyncMock,
+        return_value="",
+    ):
+        report = await setup_readiness.collect(guild_id=42)
+    entry = report.per_subsystem[0]
+    assert entry.bindings_bound == 1
+    assert entry.settings_configured == 0
+    assert entry.score == 0.5
+
+
+@pytest.mark.asyncio
+async def test_setting_equal_to_default_does_not_count_as_configured():
+    """A stored value that matches the spec's default is treated as
+    'not yet customized' so the score reflects operator intent.
+    """
+    _register_subsystem(
+        "default_setting",
+        settings=[("ttl", "default_setting.ttl", 60)],
+    )
+    with patch(
+        "services.setup_readiness.db_bindings.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[],
+    ), patch(
+        "services.setup_readiness.db.get_setting",
+        new_callable=AsyncMock,
+        # Stored value matches the default repr.
+        return_value="60",
+    ):
+        report = await setup_readiness.collect(guild_id=42)
+    assert report.per_subsystem[0].settings_configured == 0
+
+
+@pytest.mark.asyncio
+async def test_setting_with_empty_key_never_counts_as_configured():
+    """SettingSpec with empty ``settings_key`` cannot be looked up via
+    the legacy KV — treat it as un-configured and surface as a known
+    migration gap.
+    """
+    _register_subsystem(
+        "unmigrated",
+        settings=[("legacy_thing", "", "default")],
+    )
+    with patch(
+        "services.setup_readiness.db_bindings.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[],
+    ), patch(
+        "services.setup_readiness.db.get_setting",
+        new_callable=AsyncMock,
+        return_value="something",
+    ):
+        report = await setup_readiness.collect(guild_id=42)
+    assert report.per_subsystem[0].settings_configured == 0
+
+
+@pytest.mark.asyncio
+async def test_cleared_binding_status_does_not_count_as_bound():
+    """Bindings with cleared/error status are audit residue, not
+    satisfied slots. They should NOT count toward the score.
+    """
+    _register_subsystem(
+        "with_cleared_binding",
+        bindings=[("ch", BindingKind.CHANNEL)],
+    )
+    with patch(
+        "services.setup_readiness.db_bindings.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[
+            {
+                "subsystem": "with_cleared_binding",
+                "binding_name": "ch",
+                "status": "cleared",
+            },
+        ],
+    ), patch(
+        "services.setup_readiness.db.get_setting",
+        new_callable=AsyncMock,
+        return_value="",
+    ):
+        report = await setup_readiness.collect(guild_id=42)
+    assert report.per_subsystem[0].bindings_bound == 0
+
+
+@pytest.mark.asyncio
+async def test_aggregate_score_excludes_subsystems_without_config():
+    """The aggregate averages only subsystems with declared
+    bindings/settings — empty-config subsystems don't drag it down.
+    """
+    _register_subsystem("empty_sub")
+    _register_subsystem(
+        "scored_sub",
+        bindings=[("ch", BindingKind.CHANNEL)],
+        settings=[("x", "scored_sub.x", 1)],
+    )
+    with patch(
+        "services.setup_readiness.db_bindings.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[
+            {"subsystem": "scored_sub", "binding_name": "ch", "status": "active"},
+        ],
+    ), patch(
+        "services.setup_readiness.db.get_setting",
+        new_callable=AsyncMock,
+        return_value="42",  # non-default
+    ):
+        report = await setup_readiness.collect(guild_id=42)
+    # scored_sub: 1.0 (1/1 + 1/1). empty_sub: None.
+    # Aggregate = mean([1.0]) = 1.0 — empty_sub excluded.
+    assert report.aggregate_score == 1.0
+
+
+@pytest.mark.asyncio
+async def test_report_totals_aggregate_across_subsystems():
+    """``ReadinessReport`` totals are sums across all subsystems."""
+    _register_subsystem(
+        "a",
+        bindings=[("ch1", BindingKind.CHANNEL), ("ch2", BindingKind.CHANNEL)],
+    )
+    _register_subsystem(
+        "b",
+        settings=[
+            ("s1", "b.s1", 10),
+            ("s2", "b.s2", 20),
+            ("s3", "b.s3", 30),
+        ],
+    )
+    with patch(
+        "services.setup_readiness.db_bindings.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[
+            {"subsystem": "a", "binding_name": "ch1", "status": "active"},
+        ],
+    ), patch(
+        "services.setup_readiness.db.get_setting",
+        new_callable=AsyncMock,
+        return_value="",
+    ):
+        report = await setup_readiness.collect(guild_id=42)
+    assert report.bindings_declared == 2
+    assert report.bindings_bound == 1
+    assert report.settings_declared == 3
+    assert report.settings_configured == 0
+
+
+# ---------------------------------------------------------------------------
+# Embed renderer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_setup_readiness_embed_includes_percentage_in_title():
+    from cogs.diagnostic._platform_embeds import build_setup_readiness_embed
+
+    _register_subsystem(
+        "scored",
+        bindings=[("ch", BindingKind.CHANNEL)],
+    )
+    with patch(
+        "services.setup_readiness.db_bindings.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[
+            {"subsystem": "scored", "binding_name": "ch", "status": "active"},
+        ],
+    ), patch(
+        "services.setup_readiness.db.get_setting",
+        new_callable=AsyncMock,
+        return_value="",
+    ):
+        embed = await build_setup_readiness_embed(guild_id=42)
+    assert "100%" in (embed.title or "")
+
+
+@pytest.mark.asyncio
+async def test_build_setup_readiness_embed_handles_empty_registry():
+    from cogs.diagnostic._platform_embeds import build_setup_readiness_embed
+
+    with patch(
+        "services.setup_readiness.db_bindings.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        embed = await build_setup_readiness_embed(guild_id=42)
+    # No score — title shows the em-dash.
+    assert "—" in (embed.title or "")
+    # And the embed explicitly surfaces the "no schemas" message.
+    field_values = "\n".join(f.value or "" for f in embed.fields)
+    assert "subsystem_schema.register" in field_values


### PR DESCRIPTION
## Summary

PR H of the post-#152 stabilization plan — the final PR in the planned sequence. Closes audit issue P3: declared `SettingSpec` / `BindingSpec` / `ResourceRequirement` existed across `cogs/*/schemas.py` but no operator-facing surface reported how much of that configuration surface had been populated for a given guild.

## What this PR does

### `services/setup_readiness.py`

Walks `core.runtime.subsystem_schema.all_schemas()`, joins each subsystem's declared bindings/settings against the guild's stored values, and returns a typed `ReadinessReport`.

**Per subsystem:** `bindings_declared`, `bindings_bound`, `settings_declared`, `settings_configured`, `resources_declared`, and a `score` in `[0, 1]` (or `None` when the subsystem declares no config).

**Aggregate:** unweighted mean of per-subsystem scores that are not `None` — empty-config subsystems do not drag it down.

**Scoring rules:**

- A **binding** counts as bound when its `subsystem_bindings` row has a status other than `cleared`/`error`/empty.
- A **setting** counts as configured when its stored value is non-empty AND differs from the spec's default AND the spec has a non-empty `settings_key`. Settings with an empty `settings_key` (not yet migrated off the legacy KV) count as declared but never as configured — surfaces them as known migration gaps.

### `!platform setup-readiness` (aliases `readiness`, `ready`)

New `!platform` subcommand gated by the existing `administrator=True` check. Renders the report as an embed:

- **Title** shows the aggregate percentage (`—` when no config is declared anywhere).
- **Description** shows the totals across all subsystems: `X/Y bindings · X/Y settings · N resource declarations`.
- **Subsystem fields** list each subsystem one per line with `bindings bound/declared · settings configured/declared · resources N · score%`. Chunked at 15 lines per field to stay under Discord's per-field 1024-char cap.
- **Footer** explains that empty `settings_key`s count as unconfigured and that subsystems with no declared config show `—` in the score column.

### Reserved `!setup` namespace

The `!setup` command remains unused so a future actual setup-wizard PR can claim it without renaming this diagnostic. Operators discover readiness via `!platform setup-readiness` (or the `readiness`/`ready` aliases).

## Scope

| File | Change |
|---|---|
| `disbot/services/setup_readiness.py` | **NEW** — `collect()` + `ReadinessReport` + `SubsystemReadiness`. |
| `disbot/cogs/diagnostic_cog.py` | Add `platform_setup_readiness` subcommand. |
| `disbot/cogs/diagnostic/_platform_embeds.py` | Add `build_setup_readiness_embed`; export from `__all__`. |
| `tests/unit/services/test_setup_readiness.py` | **NEW** — 11 tests. |

## Test plan

- [x] 11 new tests cover: empty-registry case, empty-config-subsystem case, fully-populated subsystem (score = 1.0), half-filled (score = 0.5), setting equal to default does NOT count as configured, setting with empty `settings_key` never counts as configured, cleared binding status does NOT count as bound, aggregate score excludes empty-config subsystems, report totals aggregate across subsystems, embed renderer includes the percentage in the title, embed renderer surfaces the "no schemas" hint on an empty registry.
- [x] Full `tests/` suite — 2537/2537 pass.
- [x] `mypy disbot/`, `ruff check .`, `black --check .`, CI-style isort all clean.
- [ ] Manual Discord smoke (post-deploy):
  - As admin: `!platform setup-readiness` on a partially-configured guild — embed shows the aggregate percentage; per-subsystem counts match what the operator expects.
  - On a guild with no bindings or non-default settings: title shows `—`; aggregate description shows `0/X · 0/Y`.
  - On a guild with every binding bound and every setting customized: title shows `100%`.
  - Verify `readiness` and `ready` aliases work.

## Rollback

Revert removes the service, the subcommand, and the embed builder. No state changes; underlying schema registry, settings, and bindings tables are unchanged.

## Out of scope for H — deliberate

- An actual setup **wizard** that walks the operator through configuring missing bindings/settings — the plan reserved this PR for the readiness diagnostic only, since the wizard requires per-subsystem UX decisions beyond this PR's scope. The data substrate (`ReadinessReport`) is in place for that future PR.
- Per-subsystem completion **deeplinks** that open the relevant config panel from the readiness embed — same reason; the readiness surface is the inventory and the wizard is the action.
- `/platform setup-readiness` slash variant — `/platform` (the hub) already exists from PR E2; the per-subcommand slash tree is intentionally out of scope (see PR E2's "Out of scope" notes).
- `ResourceRequirement` fill-state (resources are descriptive, not independently configured) — counts shown as declared only.

## Sequence complete

This is the last PR in the post-#152 stabilization plan (P0 → AB1 → AB2 → D → B' → C → E1 → E2 → E' → F → G → H). All audited issues have been addressed:

- Issues #1, #2, #3 (cleanup dead ends) — PR AB1.
- Issues #4, #5 (Help → Economy chain loss) — PR AB2.
- Issues #6 (admin cog manager) — PR C with critical-cog protection.
- Issues #7, #8 (hub governance leakage) — PR D.
- Issue #9 (`!list` embed-cap risk) — PR F.
- Issue #10 (tournament direct writes) — PR B'.
- P1 (slash front doors) — PR E1 user-tier, PR E2 privileged, PR E' resync diagnostics.
- P2 (`!rank` vs `!leaderboard` divergence) — PR G provider registry.
- P3 (setup wizard schemas not aggregated) — **this PR**.

https://claude.ai/code/session_01VJhdMgBEfU2LmvgiiS5TN4

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJhdMgBEfU2LmvgiiS5TN4)_