### PR TITLE
tests: Help/Games actionability contract (PR 1 of 9)

### DIFF
--- a/tests/unit/help/test_help_actionability_contract.py
+++ b/tests/unit/help/test_help_actionability_contract.py
@@ -1,0 +1,563 @@
+"""PR 1 — Help/Games Actionability Contract.
+
+Replaces the discoverability-only floor with an actionability invariant:
+every visible game subsystem's Help/Games panel must contain at least
+one button that starts a real action (modal, select, playable view).
+
+Router-only panels (which only swap an embed in place with "type
+``!command``" instructions) and empty ``discord.ui.View()`` returns are
+no longer acceptable.
+
+Classification categories (one per terminal button):
+
+* ``action_modal``     — opens a :class:`discord.ui.Modal`
+* ``action_new_view``  — spawns a new playable view (e.g. ``_RpsView``,
+  ``BlackjackView``, ``DeathmatchPanelView``) via
+  ``interaction.response.edit_message(view=<other>)``
+* ``action_external``  — sends a new message, opens a select, or
+  delegates to a follow-up flow
+* ``navigation``       — Back/Overview/Cancel — moves inside the hub
+  graph (allowed, skipped from the action-count requirement)
+* ``read_only``        — Rules/Stats/Status/Leaderboard — informational
+  surface (allowed alongside an action button)
+* ``instruction_only`` — only swaps to a ``"type !command"`` embed
+  (FAILS the contract)
+* ``empty_view``       — ``build_help_menu_view`` returned a View with
+  no buttons (FAILS)
+* ``unknown``          — could not classify under the current stub
+
+Strict targets: ``blackjack``, ``rps_tournament`` (display "Rock
+Paper Scissors"), ``deathmatch``, ``mining``, ``counting``, ``chain``.
+
+xfail markers identify the known regressions PRs 4–6 will fix:
+
+* ``rps_tournament`` → PR 4 (``RPSPanelView`` becomes actionable)
+* ``blackjack``      → PR 5 (``BlackjackPanelView`` becomes actionable)
+* ``deathmatch``     → PR 6 (``DeathmatchPanelView`` replaces empty View)
+
+The strict=True xfails turn into hard failures (xpass) once the
+underlying panels become actionable, prompting the implementer to
+remove the marker and let the test pass cleanly.
+
+Owner/admin dangerous operations that must remain prefix-only should
+be added to ``COMMAND_REFERENCE_ALLOWLIST`` with a one-line
+justification.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+_DISBOT = Path(__file__).parents[3] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+
+# ---------------------------------------------------------------------------
+# Classification constants
+# ---------------------------------------------------------------------------
+
+ACTION_MODAL = "action_modal"
+ACTION_NEW_VIEW = "action_new_view"
+ACTION_EXTERNAL = "action_external"
+NAVIGATION = "navigation"
+READ_ONLY = "read_only"
+INSTRUCTION_ONLY = "instruction_only"
+EMPTY_VIEW = "empty_view"
+UNKNOWN = "unknown"
+
+ACTION_CLASSES = frozenset({ACTION_MODAL, ACTION_NEW_VIEW, ACTION_EXTERNAL})
+
+# Labels signalling pure navigation inside the hub graph.
+NAVIGATION_LABEL_TOKENS = (
+    "back",
+    "overview",
+    "cancel",
+    "close",
+    "↩",
+    "◀",
+)
+
+# Labels signalling a read-only diagnostic surface.
+READ_ONLY_LABEL_TOKENS = (
+    "rules",
+    "help",
+    "stats",
+    "status",
+    "leaderboard",
+    "info",
+)
+
+# Owner/admin dangerous operations that may stay prefix-only — entries
+# here intentionally bypass the actionability contract. Add a one-line
+# justification per entry. Empty today; populated only when a real case
+# arises.
+COMMAND_REFERENCE_ALLOWLIST: dict[str, str] = {}
+
+
+# ---------------------------------------------------------------------------
+# Stub interaction
+# ---------------------------------------------------------------------------
+
+
+def _stub_interaction(user_id: int = 111, guild_id: int = 222) -> MagicMock:
+    """A best-effort stand-in for :class:`discord.Interaction`.
+
+    Mocks ``response.send_modal``/``edit_message``/``send_message`` and
+    ``followup.send`` as :class:`AsyncMock` so the classifier can read
+    ``await_count`` and ``call_args`` after the callback returns.
+    """
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = SimpleNamespace(
+        id=user_id,
+        display_name="tester",
+        display_avatar=SimpleNamespace(url="http://x"),
+        guild_permissions=SimpleNamespace(administrator=True),
+        mention="<@111>",
+        bot=False,
+    )
+    interaction.guild = MagicMock()
+    interaction.guild.id = guild_id
+    interaction.guild_id = guild_id
+    interaction.channel = MagicMock()
+    interaction.channel.id = 333
+    interaction.channel.mention = "#test"
+    interaction.client = MagicMock()
+    interaction.message = MagicMock(id=444)
+    interaction.response = MagicMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.response.send_modal = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+# ---------------------------------------------------------------------------
+# Classification helpers
+# ---------------------------------------------------------------------------
+
+
+def _label_matches(label: str, tokens: tuple[str, ...]) -> bool:
+    lower = (label or "").lower()
+    return any(token in lower for token in tokens)
+
+
+def _embed_is_instruction_only(embed: discord.Embed | None) -> bool:
+    """An embed is instruction-only when its visible text is dominated
+    by typed-command examples (``!`` or ``/`` prefixed tokens) with no
+    playable affordance signals.
+    """
+    if embed is None:
+        return False
+    parts: list[str] = []
+    if embed.description:
+        parts.append(embed.description)
+    for f in embed.fields:
+        parts.append(f.name or "")
+        parts.append(f.value or "")
+    if embed.footer and embed.footer.text:
+        parts.append(embed.footer.text)
+    text = "\n".join(parts)
+    if "!" not in text and "/" not in text:
+        return False
+    affordance_signals = (
+        "press ",
+        "click ",
+        "tap ",
+        "pick ",
+        "use the buttons",
+        "use the menu",
+        "your move",
+        "your turn",
+        "your hand",
+        "your hp",
+        "rock",
+        "paper",
+        "scissors",
+        "accept",
+        "decline",
+    )
+    lower = text.lower()
+    if any(sig in lower for sig in affordance_signals):
+        return False
+    return True
+
+
+async def _classify_button(
+    button: discord.ui.Button, panel: discord.ui.View
+) -> str:
+    """Classify a single button by running its callback against a stub
+    interaction and inspecting the recorded calls.
+    """
+    label = button.label or ""
+    custom_id = button.custom_id or ""
+    if custom_id in COMMAND_REFERENCE_ALLOWLIST:
+        return READ_ONLY
+    if _label_matches(label, NAVIGATION_LABEL_TOKENS):
+        return NAVIGATION
+
+    interaction = _stub_interaction()
+    try:
+        await button.callback(interaction)  # type: ignore[misc]
+    except Exception:
+        # Callback raised — likely needs richer guild/db state. Fall
+        # through to inspect whether any response method was *attempted*
+        # before the failure.
+        pass
+
+    if interaction.response.send_modal.await_count > 0:
+        return ACTION_MODAL
+    if interaction.response.send_message.await_count > 0:
+        return ACTION_EXTERNAL
+    if interaction.followup.send.await_count > 0:
+        return ACTION_EXTERNAL
+
+    if interaction.response.edit_message.await_count > 0:
+        args, kwargs = interaction.response.edit_message.call_args
+        new_view = kwargs.get("view")
+        new_embed = kwargs.get("embed")
+        if new_view is not None and new_view is not panel:
+            return ACTION_NEW_VIEW
+        if _label_matches(label, READ_ONLY_LABEL_TOKENS):
+            return READ_ONLY
+        if _embed_is_instruction_only(new_embed):
+            return INSTRUCTION_ONLY
+        return UNKNOWN
+
+    return UNKNOWN
+
+
+async def classify_panel(panel: discord.ui.View) -> dict[str, str]:
+    """Classify every :class:`discord.ui.Button` child of ``panel``."""
+    result: dict[str, str] = {}
+    for child in panel.children:
+        if not isinstance(child, discord.ui.Button):
+            continue
+        key = child.custom_id or child.label or f"<unnamed:{id(child)}>"
+        result[key] = await _classify_button(child, panel)
+    return result
+
+
+def _panel_has_action(classification: dict[str, str]) -> bool:
+    return any(c in ACTION_CLASSES for c in classification.values())
+
+
+def _punchlist(
+    subsystem: str,
+    embed: discord.Embed,
+    view: discord.ui.View,
+    cls: dict[str, str],
+) -> str:
+    button_count = sum(
+        1 for c in view.children if isinstance(c, discord.ui.Button)
+    )
+    return (
+        f"Subsystem {subsystem!r} panel is not actionable.\n"
+        f"  view type:       {type(view).__name__}\n"
+        f"  buttons total:   {button_count}\n"
+        f"  classifications: {cls}\n"
+        f"  embed title:     {embed.title!r}\n"
+        f"  fail reason:     no button classifies as action_*\n"
+        f"  expected:        at least one button opens a modal, spawns "
+        f"a new playable view, or sends a real action message."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cog construction
+# ---------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def _panel_construction_patches(subsystem: str):
+    """Context manager patching DB / external calls that some panels
+    invoke during ``build_help_menu_view`` / ``build_embed``.
+
+    The actionability contract is about button shape, not DB state, so
+    we stub out reads with empty/default results so the panel can be
+    constructed without a live pool.
+    """
+    patches: list = []
+    if subsystem == "chain":
+        patches.append(
+            patch(
+                "cogs.chain_cog.db.get_all_chain_channels",
+                new=AsyncMock(return_value=[]),
+            )
+        )
+    with contextlib.ExitStack() as stack:
+        for p in patches:
+            stack.enter_context(p)
+        yield
+
+
+async def _build_panel_for(
+    subsystem: str,
+) -> tuple[discord.Embed, discord.ui.View]:
+    """Instantiate the canonical cog for ``subsystem`` and call its
+    ``build_help_menu_view``.
+    """
+    interaction = _stub_interaction()
+    if subsystem == "blackjack":
+        from cogs.blackjack_cog import BlackjackCog
+
+        cog = BlackjackCog(MagicMock())
+    elif subsystem in ("rps_tournament", "rps"):
+        from cogs.rps_tournament_cog import RPSTournamentCog
+
+        cog = RPSTournamentCog(MagicMock())
+    elif subsystem in ("deathmatch", "dm"):
+        from cogs.deathmatch_cog import Deathmatch
+
+        cog = Deathmatch(MagicMock())
+    elif subsystem == "mining":
+        from cogs.mining_cog import MiningCog
+
+        cog = MiningCog(MagicMock())
+    elif subsystem == "counting":
+        from cogs.counting_cog import CountingCog
+
+        cog = CountingCog(MagicMock())
+    elif subsystem == "chain":
+        from cogs.chain_cog import ChainCog
+
+        cog = ChainCog(MagicMock())
+    else:
+        raise NotImplementedError(
+            f"No cog mapping for actionability target {subsystem!r}. "
+            "Update _build_panel_for when adding a new Games child."
+        )
+
+    with _panel_construction_patches(subsystem):
+        embed, view = await cog.build_help_menu_view(interaction)
+    return embed, view
+
+
+# ---------------------------------------------------------------------------
+# Per-subsystem actionability tests
+# ---------------------------------------------------------------------------
+
+
+_RPS_XFAIL = pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Resolved in PR 4 — RPSPanelView becomes actionable "
+        "(Quick Play / Bet Match / Challenge Player / Bot Match / "
+        "Tournament). Remove this xfail when PR 4 lands."
+    ),
+)
+_BLACKJACK_XFAIL = pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Resolved in PR 5 — BlackjackPanelView becomes actionable "
+        "(Solo Free / Solo Bet / Challenge Player / Tournament / "
+        "Status). Remove this xfail when PR 5 lands."
+    ),
+)
+_DEATHMATCH_XFAIL = pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Resolved in PR 6 — DeathmatchPanelView replaces the empty "
+        "discord.ui.View() and adds Fight Bot / Challenge Player. "
+        "Remove this xfail when PR 6 lands."
+    ),
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "subsystem",
+    [
+        pytest.param("rps_tournament", marks=_RPS_XFAIL),
+        pytest.param("blackjack", marks=_BLACKJACK_XFAIL),
+        pytest.param("deathmatch", marks=_DEATHMATCH_XFAIL),
+        pytest.param("mining"),
+        pytest.param("counting"),
+        pytest.param("chain"),
+    ],
+)
+async def test_games_subsystem_panel_is_actionable(subsystem: str) -> None:
+    embed, view = await _build_panel_for(subsystem)
+    button_count = sum(
+        1 for c in view.children if isinstance(c, discord.ui.Button)
+    )
+    assert button_count > 0, (
+        f"Subsystem {subsystem!r} returned a panel with zero Button "
+        f"children — Help → Games → {subsystem} cannot reach any "
+        "action."
+    )
+    cls = await classify_panel(view)
+    assert _panel_has_action(cls), _punchlist(subsystem, embed, view, cls)
+
+
+# ---------------------------------------------------------------------------
+# Regression catches — specific known failures
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Resolved in PR 5 — BlackjackPanelView.btn_classic no longer "
+        "renders a 'type !blackjack <bet>' instruction-only embed. "
+        "Remove this xfail when PR 5 lands."
+    ),
+)
+async def test_blackjack_classic_button_is_actionable_not_instruction_only() -> None:
+    from views.games import blackjack_panel
+
+    panel = blackjack_panel.BlackjackPanelView(
+        SimpleNamespace(id=111, display_name="tester")
+    )
+    btn = next(
+        c
+        for c in panel.children
+        if isinstance(c, discord.ui.Button)
+        and (c.custom_id or "").endswith(":classic")
+    )
+    klass = await _classify_button(btn, panel)
+    assert klass in ACTION_CLASSES, (
+        f"BlackjackPanelView 'Classic' button classifies as {klass!r}; "
+        "must be action_* (PR 5 wires Solo Free / Solo Bet to "
+        "BlackjackView directly)."
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Resolved in PR 4 — RPSPanelView.btn_single no longer renders a "
+        "'type !rps' instruction-only embed. Remove this xfail when PR "
+        "4 lands."
+    ),
+)
+async def test_rps_single_button_is_actionable_not_instruction_only() -> None:
+    from views.games import rps_panel
+
+    panel = rps_panel.RPSPanelView(
+        SimpleNamespace(id=111, display_name="tester")
+    )
+    btn = next(
+        c
+        for c in panel.children
+        if isinstance(c, discord.ui.Button)
+        and (c.custom_id or "").endswith(":single")
+    )
+    klass = await _classify_button(btn, panel)
+    assert klass in ACTION_CLASSES, (
+        f"RPSPanelView 'Single Round' button classifies as {klass!r}; "
+        "must be action_* (PR 4 wires Quick Play to _RpsView directly)."
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Resolved in PR 4 — RPSPanelView.btn_tournament no longer "
+        "renders a 'type !rpsregister' instruction-only embed. Remove "
+        "this xfail when PR 4 lands."
+    ),
+)
+async def test_rps_tournament_button_is_actionable_not_instruction_only() -> None:
+    from views.games import rps_panel
+
+    panel = rps_panel.RPSPanelView(
+        SimpleNamespace(id=111, display_name="tester")
+    )
+    btn = next(
+        c
+        for c in panel.children
+        if isinstance(c, discord.ui.Button)
+        and (c.custom_id or "").endswith(":tournament")
+    )
+    klass = await _classify_button(btn, panel)
+    assert klass in ACTION_CLASSES, (
+        f"RPSPanelView 'Tournament' button classifies as {klass!r}; "
+        "must be action_* (PR 4 wires Tournament to admin setup modal / "
+        "Join/Status flow)."
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Resolved in PR 6 — Deathmatch.build_help_menu_view no longer "
+        "returns an empty discord.ui.View(). Remove this xfail when PR "
+        "6 lands with DeathmatchPanelView."
+    ),
+)
+async def test_deathmatch_panel_is_not_empty_view() -> None:
+    from cogs.deathmatch_cog import Deathmatch
+
+    cog = Deathmatch(MagicMock())
+    _embed, view = await cog.build_help_menu_view(_stub_interaction())
+    has_buttons = any(isinstance(c, discord.ui.Button) for c in view.children)
+    assert has_buttons, (
+        "Deathmatch.build_help_menu_view returns an empty View "
+        f"(type={type(view).__name__}); PR 6 adds DeathmatchPanelView "
+        "with Fight Bot / Challenge Player / Rules / Leaderboard "
+        "buttons."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Coverage gate — the strict target list must mirror SUBSYSTEMS
+# ---------------------------------------------------------------------------
+
+
+def _games_subsystems_from_registry() -> set[str]:
+    """All visible subsystems with ``parent_hub == "games"``."""
+    from utils.subsystem_registry import SUBSYSTEMS
+
+    return {
+        name
+        for name, meta in SUBSYSTEMS.items()
+        if meta.get("parent_hub") == "games"
+        and meta.get("visibility_mode") != "internal"
+    }
+
+
+def test_actionability_targets_match_registry_games_children() -> None:
+    """The strict actionability target list must equal the set of
+    visible Games-hub children in SUBSYSTEMS.
+
+    If a new game is added without updating the parametrize list, the
+    contract would silently skip it. This test is the alarm: it forces
+    the new game into the test_games_subsystem_panel_is_actionable
+    parameter list.
+    """
+    registry_games = _games_subsystems_from_registry()
+    expected = {
+        "blackjack",
+        "rps_tournament",
+        "deathmatch",
+        "mining",
+        "counting",
+        "chain",
+    }
+    new_in_registry = registry_games - expected
+    removed_from_registry = expected - registry_games
+    assert not new_in_registry, (
+        "New Games subsystems found that are not covered by the "
+        f"actionability contract: {sorted(new_in_registry)}. Add them "
+        "to test_games_subsystem_panel_is_actionable's parameter list."
+    )
+    assert not removed_from_registry, (
+        "Games subsystems referenced by the actionability contract no "
+        f"longer exist in SUBSYSTEMS: {sorted(removed_from_registry)}. "
+        "Remove them from test_games_subsystem_panel_is_actionable."
+    )

--- a/tests/unit/views/test_game_panels.py
+++ b/tests/unit/views/test_game_panels.py
@@ -1,19 +1,34 @@
-"""Phase 7 Option A — router-only Blackjack/RPS panel tests.
+"""Game-panel structural invariants — narrowed by PR 1.
 
-Pins:
+The Phase 7 Option A "panels are pure routers" doctrine is being
+superseded by PRs 4–6, which make ``RPSPanelView``,
+``BlackjackPanelView``, and the new ``DeathmatchPanelView`` actionable
+launchers. The strict tests that pinned the exact custom_id set and
+the instruction-only embed bodies were moved out so PRs 4–6 are not
+blocked.
 
-* The panels contain only navigation/embed-swap logic — no game-engine
-  imports.
-* Each cog's ``build_help_menu_view`` now returns the new panel
-  (not an empty View as it did pre-Phase 7).
-* Practice / Replay / Best-of variants are not yet present — their
-  buttons should NOT exist; a re-introduction must be deliberate.
+What remains here:
+
+* Engine-internal imports stay forbidden in the panel modules — panels
+  call helpers/views, never engine internals (``blackjack_engine``,
+  persistence layers, etc.) directly.
+* The "no Practice/Replay/Best-of button yet" invariants stay as
+  regression alarms — those labels aren't planned in PRs 4–6 either
+  and a future addition should be deliberate.
+* The Rules button must still exist as a read-only diagnostic surface
+  (looked up by label, not custom_id, to stay forward-compatible with
+  PR 4/5 button-naming changes).
+* ``build_help_menu_view`` must still return the panel class as the
+  view component.
+
+The new actionability invariant lives in
+``tests/unit/help/test_help_actionability_contract.py``.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import discord
 import pytest
@@ -28,16 +43,17 @@ def _author(id_: int = 1) -> MagicMock:
     return member
 
 
-def _interaction() -> MagicMock:
-    interaction = MagicMock(spec=discord.Interaction)
-    interaction.user = _author()
-    interaction.response = MagicMock()
-    interaction.response.edit_message = AsyncMock()
-    return interaction
+def _find_rules_button(view: discord.ui.View) -> discord.ui.Button | None:
+    for child in view.children:
+        if not isinstance(child, discord.ui.Button):
+            continue
+        if "rules" in (child.label or "").lower():
+            return child
+    return None
 
 
 # ---------------------------------------------------------------------------
-# Module-level invariants — no game logic
+# Module-level invariants — engine internals stay out of panels
 # ---------------------------------------------------------------------------
 
 
@@ -50,9 +66,9 @@ def _interaction() -> MagicMock:
     ids=["blackjack_panel", "rps_panel"],
 )
 def test_panel_modules_do_not_import_game_engines(module_path: Path):
-    """The panels are pure navigation. Importing the blackjack engine,
-    economy service, persistence, or tournament state from a panel
-    would mean game logic crept in.
+    """Panels may import view classes (``_RpsView``, ``BlackjackView``,
+    ``_Duel``) and orchestration helpers, but must not reach into the
+    engine internals (persistence, raw db, engine math) directly.
     """
     src = module_path.read_text()
     head = src.split("\ndef ", 1)[0]  # module-import section
@@ -66,46 +82,20 @@ def test_panel_modules_do_not_import_game_engines(module_path: Path):
     ]
     for token in forbidden:
         assert token not in head, (
-            f"{module_path.name} imports game-engine token {token!r} at module "
-            f"load — Phase 7 Option A keeps panels router-only."
+            f"{module_path.name} imports engine-internal token "
+            f"{token!r} at module load — panels must call helpers, "
+            "not reach into engine internals."
         )
 
 
 # ---------------------------------------------------------------------------
-# Blackjack panel — view shape
+# No-Practice/Replay/Best-of regression alarms
 # ---------------------------------------------------------------------------
 
 
-def test_blackjack_overview_embed_lists_modes_and_typed_shortcuts():
-    embed = blackjack_panel.build_blackjack_overview_embed()
-    title = (embed.title or "")
-    assert "Blackjack" in title
-    description = (embed.description or "") + "\n".join(
-        f.value for f in embed.fields
-    ) + (embed.footer.text or "")
-    assert "Classic" in description
-    assert "Rules" in description
-    assert "!blackjack" in description or "!bj" in description
-
-
-def test_blackjack_panel_buttons_are_classic_rules_overview_only():
-    view = blackjack_panel.BlackjackPanelView(_author())
-    custom_ids = {
-        c.custom_id
-        for c in view.children
-        if isinstance(c, discord.ui.Button)
-    }
-    assert custom_ids == {
-        "blackjack_panel:classic",
-        "blackjack_panel:rules",
-        "blackjack_panel:overview",
-    }
-
-
-def test_blackjack_panel_has_no_practice_or_replay_button_yet():
-    """Phase 7b is the place for Practice / Replay. Phase 7a panels
-    must not pre-leak those button labels.
-    """
+def test_blackjack_panel_has_no_practice_or_replay_button():
+    """Practice / Replay / Change-Mode are not planned in PR 5. Any
+    reintroduction should be deliberate with engine support."""
     view = blackjack_panel.BlackjackPanelView(_author())
     labels = [
         (c.label or "")
@@ -114,99 +104,14 @@ def test_blackjack_panel_has_no_practice_or_replay_button_yet():
     ]
     for token in ("Practice", "Replay", "Change Mode"):
         assert not any(token in lbl for lbl in labels), (
-            f"BlackjackPanelView already exposes {token!r} — Phase 7b "
-            "should re-introduce these together with engine support."
+            f"BlackjackPanelView already exposes {token!r} — "
+            "reintroduction should be deliberate with engine support."
         )
 
 
-@pytest.mark.asyncio
-async def test_blackjack_classic_button_renders_classic_embed():
-    view = blackjack_panel.BlackjackPanelView(_author())
-    interaction = _interaction()
-    btn = next(
-        c
-        for c in view.children
-        if isinstance(c, discord.ui.Button)
-        and c.custom_id == "blackjack_panel:classic"
-    )
-    await btn.callback(interaction)  # type: ignore[union-attr,misc]
-    interaction.response.edit_message.assert_awaited_once()
-    _args, kwargs = interaction.response.edit_message.call_args
-    embed: discord.Embed = kwargs["embed"]
-    assert "Classic" in (embed.title or "")
-    rendered = "\n".join(f.value for f in embed.fields)
-    assert "!blackjack" in rendered or "!bj" in rendered
-
-
-@pytest.mark.asyncio
-async def test_blackjack_rules_button_renders_rules_embed():
-    view = blackjack_panel.BlackjackPanelView(_author())
-    interaction = _interaction()
-    btn = next(
-        c
-        for c in view.children
-        if isinstance(c, discord.ui.Button)
-        and c.custom_id == "blackjack_panel:rules"
-    )
-    await btn.callback(interaction)  # type: ignore[union-attr,misc]
-    interaction.response.edit_message.assert_awaited_once()
-    _args, kwargs = interaction.response.edit_message.call_args
-    embed: discord.Embed = kwargs["embed"]
-    assert "Rules" in (embed.title or "")
-    rendered = "\n".join(f.value for f in embed.fields)
-    assert "Hit" in rendered or "Stand" in rendered
-
-
-@pytest.mark.asyncio
-async def test_blackjack_overview_button_returns_to_overview():
-    view = blackjack_panel.BlackjackPanelView(_author())
-    interaction = _interaction()
-    btn = next(
-        c
-        for c in view.children
-        if isinstance(c, discord.ui.Button)
-        and c.custom_id == "blackjack_panel:overview"
-    )
-    await btn.callback(interaction)  # type: ignore[union-attr,misc]
-    _args, kwargs = interaction.response.edit_message.call_args
-    embed: discord.Embed = kwargs["embed"]
-    # Overview embed names "Modes" as a field; the detail embeds don't.
-    field_names = [f.name for f in embed.fields]
-    assert "Modes" in field_names
-
-
-# ---------------------------------------------------------------------------
-# RPS panel
-# ---------------------------------------------------------------------------
-
-
-def test_rps_overview_embed_lists_single_tournament_rules():
-    embed = rps_panel.build_rps_overview_embed()
-    rendered = (embed.description or "") + "\n".join(
-        f.value for f in embed.fields
-    ) + (embed.footer.text or "")
-    assert "Single Round" in rendered
-    assert "Tournament" in rendered
-    assert "Rules" in rendered
-    assert "!rps" in rendered
-
-
-def test_rps_panel_buttons_are_single_tournament_rules_overview():
-    view = rps_panel.RPSPanelView(_author())
-    custom_ids = {
-        c.custom_id
-        for c in view.children
-        if isinstance(c, discord.ui.Button)
-    }
-    assert custom_ids == {
-        "rps_panel:single",
-        "rps_panel:tournament",
-        "rps_panel:rules",
-        "rps_panel:overview",
-    }
-
-
-def test_rps_panel_has_no_replay_or_best_of_button_yet():
+def test_rps_panel_has_no_replay_or_best_of_button():
+    """Replay / Best-of selectors are not planned in PR 4. Any
+    reintroduction should be deliberate."""
     view = rps_panel.RPSPanelView(_author())
     labels = [
         (c.label or "")
@@ -214,59 +119,35 @@ def test_rps_panel_has_no_replay_or_best_of_button_yet():
         if isinstance(c, discord.ui.Button)
     ]
     for token in ("Replay", "Best of"):
-        assert not any(token in lbl for lbl in labels)
-
-
-@pytest.mark.asyncio
-async def test_rps_single_button_renders_single_embed():
-    view = rps_panel.RPSPanelView(_author())
-    interaction = _interaction()
-    btn = next(
-        c
-        for c in view.children
-        if isinstance(c, discord.ui.Button) and c.custom_id == "rps_panel:single"
-    )
-    await btn.callback(interaction)  # type: ignore[union-attr,misc]
-    _args, kwargs = interaction.response.edit_message.call_args
-    embed: discord.Embed = kwargs["embed"]
-    assert "Single Round" in (embed.title or "")
-
-
-@pytest.mark.asyncio
-async def test_rps_tournament_button_renders_tournament_embed():
-    view = rps_panel.RPSPanelView(_author())
-    interaction = _interaction()
-    btn = next(
-        c
-        for c in view.children
-        if isinstance(c, discord.ui.Button)
-        and c.custom_id == "rps_panel:tournament"
-    )
-    await btn.callback(interaction)  # type: ignore[union-attr,misc]
-    _args, kwargs = interaction.response.edit_message.call_args
-    embed: discord.Embed = kwargs["embed"]
-    assert "Tournament" in (embed.title or "")
-    rendered = "\n".join(f.value for f in embed.fields)
-    assert "!rpsregister" in rendered or "!rpsstart" in rendered
-
-
-@pytest.mark.asyncio
-async def test_rps_rules_button_renders_rules_embed():
-    view = rps_panel.RPSPanelView(_author())
-    interaction = _interaction()
-    btn = next(
-        c
-        for c in view.children
-        if isinstance(c, discord.ui.Button) and c.custom_id == "rps_panel:rules"
-    )
-    await btn.callback(interaction)  # type: ignore[union-attr,misc]
-    _args, kwargs = interaction.response.edit_message.call_args
-    embed: discord.Embed = kwargs["embed"]
-    assert "Rules" in (embed.title or "")
+        assert not any(token in lbl for lbl in labels), (
+            f"RPSPanelView already exposes {token!r} — reintroduction "
+            "should be deliberate."
+        )
 
 
 # ---------------------------------------------------------------------------
-# Cog wiring — build_help_menu_view now returns the panel
+# Rules button — still required as a read-only diagnostic
+# ---------------------------------------------------------------------------
+
+
+def test_blackjack_panel_exposes_rules_button():
+    view = blackjack_panel.BlackjackPanelView(_author())
+    assert _find_rules_button(view) is not None, (
+        "BlackjackPanelView must keep a Rules button as the read-only "
+        "diagnostic surface."
+    )
+
+
+def test_rps_panel_exposes_rules_button():
+    view = rps_panel.RPSPanelView(_author())
+    assert _find_rules_button(view) is not None, (
+        "RPSPanelView must keep a Rules button as the read-only "
+        "diagnostic surface."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cog wiring — build_help_menu_view returns the panel
 # ---------------------------------------------------------------------------
 
 
@@ -291,7 +172,9 @@ async def test_rps_cog_build_help_menu_view_returns_panel():
     interaction.user = _author()
     embed, view = await cog.build_help_menu_view(interaction)
     assert isinstance(view, rps_panel.RPSPanelView)
+    title = embed.title or ""
     assert (
-        "Rock-Paper-Scissors" in (embed.title or "")
-        or "RPS" in (embed.title or "")
+        "Rock-Paper-Scissors" in title
+        or "Rock Paper Scissors" in title
+        or "RPS" in title
     )


### PR DESCRIPTION
## Summary

- Add `tests/unit/help/test_help_actionability_contract.py` — classifies every terminal Help/Games panel button (action_*, navigation, read_only, instruction_only, empty_view) and asserts every visible Games subsystem reaches at least one action.
- Mark RPS / Blackjack / Deathmatch as `xfail(strict=True)` with PR references so each fix turns xfail → xpass and forces marker removal.
- Refactor `tests/unit/views/test_game_panels.py` to drop the router-only pins that would block PRs 4–6, while keeping engine-import bans, no-Practice/Replay regression alarms, Rules-button presence, and `build_help_menu_view` return-type checks.

## Scope table

| Does | Does NOT |
|---|---|
| Add the actionability contract test file | Touch any panel, hub, or cog code |
| `xfail(strict=True)` the three known regressions | Make any UI change |
| Loosen `test_game_panels.py` pins that conflict with PR 4–6 | Rename anything |
| Document the classification taxonomy in the test docstring | Add new buttons or behavior |

## Files changed

- `tests/unit/help/test_help_actionability_contract.py` (new, 633 lines)
- `tests/unit/views/test_game_panels.py` (refactored, -187 / +70)

## Architecture impact

None. Test-only PR. No runtime code touched.

## Tests run

```
python -m pytest -q
# 2533 passed, 7 xfailed, 13 warnings in 27.94s

python -m pytest tests/unit/help/ tests/unit/views/ tests/unit/invariants/ -q
# 573 passed, 7 xfailed, 9 warnings in 6.35s

python -m pytest tests/unit/help/test_help_actionability_contract.py tests/unit/views/test_game_panels.py -v
# 12 passed, 7 xfailed (the three intended RPS/Blackjack/Deathmatch markers x 2-3 tests each)

ruff check . --exclude .github,tests,venv,env,build,dist        # All checks passed
black --check . --exclude '(\.github|tests|venv|env|build|dist)' # 285 files unchanged
isort --check-only . --skip-glob '*/tests/*' ...                 # passed
mypy disbot/                                                     # Success: 286 source files
```

## Manual Discord smoke checklist

- [ ] N/A — test-only PR; no runtime/UI behavior changed.

## Rollback plan

`git revert <merge-commit>` — restores the discoverability-only floor. No data migration. No live behavior reverts.

## Out of scope

- All actual panel / hub / cog changes (PRs 2–9).
- Removing the xfail markers (PRs 4–6 do that as they fix the underlying panels).
- Mining/Counting/Chain panel hardening (their current actionability already passes the contract).

## Follow-up items

- PR 2: Games Hub v2 + Community back-button fix.
- PR 3: RPS display rename.
- PR 4–6: panel implementations that remove the xfail markers added here.

## CI status

Pending — will subscribe to PR activity after creation.

## Risk level

**Low.** Test-only; no runtime code changed. Worst case is a flaky regression alarm, easily reverted.

## User-visible behavior change

**No.** No production code or UI touched.

## Slash sync or deploy action required

**No.**

https://claude.ai/code/session_011QAYCgaMJ6GkhWtJZeRGVq

---
_Generated by [Claude Code](https://claude.ai/code/session_011QAYCgaMJ6GkhWtJZeRGVq)_