### PR TITLE
rps: display rename Rock Paper Scissors with legacy aliases (PR 3 of 9)

### DIFF
--- a/disbot/cogs/games_cog.py
+++ b/disbot/cogs/games_cog.py
@@ -1,7 +1,7 @@
 """Games hub cog — thin router that opens :class:`GamesHubView`.
 
 This cog contains **zero** game logic. Individual game logic stays in
-Blackjack, RPS Tournament, Deathmatch, Mining, Counting, and Chain.
+Blackjack, Rock Paper Scissors, Deathmatch, Mining, Counting, and Chain.
 The hub here only owns:
 
 * The ``!games`` command that opens the hub directly.

--- a/disbot/cogs/help/route.py
+++ b/disbot/cogs/help/route.py
@@ -48,9 +48,17 @@ HUB_ALIAS_OVERRIDES: dict[str, str] = {
 # ``build_help_menu_view`` which returns ``_DiagnosticsHubView``);
 # routing them through the hub key ``diagnostic`` would instead open
 # Platform Hub via ``build_platform_help_menu_view``.
+#
+# PR 3 (RPS rename) also registers ``rps`` and ``rock paper scissors``
+# here so they open the Rock Paper Scissors subsystem panel rather
+# than the ``!rps`` command's single-command help embed (which
+# ``bot.get_command("rps")`` would otherwise resolve to via the
+# fallthrough command branch).
 SUBSYSTEM_ALIAS_OVERRIDES: dict[str, str] = {
     "diagnostics": "diagnostic",
     "diag": "diagnostic",
+    "rps": "rps_tournament",
+    "rock paper scissors": "rps_tournament",
 }
 
 # Hubs whose dedicated Help builder is NOT ``build_help_menu_view``.

--- a/disbot/cogs/rps_tournament/_quickplay.py
+++ b/disbot/cogs/rps_tournament/_quickplay.py
@@ -47,7 +47,7 @@ async def run_quickrps_command(
         embed = discord.Embed(
             title="✂️ RPS Challenge!",
             description=(
-                f"{ctx.author.mention} challenges {target.mention} to Rock-Paper-Scissors "
+                f"{ctx.author.mention} challenges {target.mention} to Rock Paper Scissors "
                 f"({bet_str}).\n{target.mention}, do you accept?"
             ),
             color=GAME_COLOR,

--- a/disbot/cogs/rps_tournament_cog.py
+++ b/disbot/cogs/rps_tournament_cog.py
@@ -75,8 +75,22 @@ from views.rps import _RpsRegistrationView
 logger = logging.getLogger("bot")
 
 
-class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # type: ignore[call-arg]
-    """Cog for managing Rock-Paper-Scissors tournaments with multiple game modes."""
+class RockPaperScissorsCog(commands.Cog, name="Rock Paper Scissors"):  # type: ignore[call-arg]
+    """Rock Paper Scissors cog: quick play, PvP, bot matches, and tournaments.
+
+    PR 3 (display rename) renamed this from ``RPSTournamentCog`` to
+    ``RockPaperScissorsCog`` and changed the discord.py cog ``name=``
+    attribute from "Rock-Paper-Scissors Tournament" to "Rock Paper
+    Scissors". The canonical SUBSYSTEMS key remains ``rps_tournament``
+    for back-compat with saved state, providers, tournament ``kind``
+    values, and rank-provider aliases — see the operating-contract
+    plan §13 acceptance checklist for the deferred canonical-key
+    migration.
+
+    The ``RPSTournamentCog`` import alias below preserves any
+    out-of-tree or test imports that still reference the old class
+    name.
+    """
 
     def __init__(self, bot) -> None:
         self.bot = bot
@@ -203,7 +217,7 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # 
         # Send the registration message
         fee_str = f"**{self.entry_fee}** 🪙" if self.entry_fee else "Free"
         embed = discord.Embed(
-            title="🎮 Rock-Paper-Scissors Tournament Registration 🎮",
+            title="🎮 Rock Paper Scissors Tournament Registration 🎮",
             description=(
                 "React ✅ or click **Join** to sign up!\n"
                 f"Registration ends in {self.registration_timer // 60} minutes."
@@ -713,7 +727,7 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # 
     async def rps_help(self, ctx):
         """Displays help information for RPS tournament commands."""
         help_text = (
-            "**Rock-Paper-Scissors Tournament Commands:**\n"
+            "**Rock Paper Scissors Tournament Commands:**\n"
             "`!rps_register [@role]` - Starts registration. Optionally mention a role to notify.\n"
             "`!rps_start [mode] [best_of]` - Start the tournament (Admin only). Modes: classic, lizard_spock, chess, elemental.\n"
             "`!rps_bot [mode] [best_of] [@members/@roles]` - Play against the bot.\n"
@@ -768,5 +782,13 @@ class RPSTournamentCog(commands.Cog, name="Rock-Paper-Scissors Tournament"):  # 
         await run_quickrps_command(ctx, target, bet)
 
 
+# Back-compat alias — PR 3 renamed ``RPSTournamentCog`` to
+# ``RockPaperScissorsCog`` but the old name stays importable so any
+# out-of-tree imports, test references, or pickled state that
+# reference ``cogs.rps_tournament_cog.RPSTournamentCog`` continue to
+# resolve to the same class object.
+RPSTournamentCog = RockPaperScissorsCog
+
+
 async def setup(bot):
-    await bot.add_cog(RPSTournamentCog(bot))
+    await bot.add_cog(RockPaperScissorsCog(bot))

--- a/disbot/utils/subsystem_registry.py
+++ b/disbot/utils/subsystem_registry.py
@@ -375,8 +375,8 @@ SUBSYSTEMS: dict[str, dict] = {
         ],
     },
     "rps_tournament": {
-        "display_name": "RPS Tournament",
-        "description": "Rock-Paper-Scissors tournament system",
+        "display_name": "Rock Paper Scissors",
+        "description": "Rock Paper Scissors: quick play, PvP, bot matches, tournaments",
         "emoji": "✂️",
         "color": GAME_COLOR.value,
         "visibility_tier": "user",

--- a/disbot/views/games/rps_panel.py
+++ b/disbot/views/games/rps_panel.py
@@ -20,7 +20,7 @@ from views.base import HubView
 
 def build_rps_overview_embed() -> discord.Embed:
     embed = discord.Embed(
-        title="✂️ Rock-Paper-Scissors",
+        title="✂️ Rock Paper Scissors",
         description=(
             "Quick matches vs the bot or another player, plus scheduled "
             "tournaments with optional entry fees. Pick a mode to see "
@@ -47,7 +47,7 @@ def build_rps_single_round_embed() -> discord.Embed:
     embed = discord.Embed(
         title="✂️ RPS — Single Round",
         description=(
-            "Each round is a single classic Rock-Paper-Scissors throw "
+            "Each round is a single classic Rock Paper Scissors throw "
             "(the underlying tournament cog defaults to best-of-3 for "
             "tournament brackets — single-round behaviour is unchanged "
             "by this panel)."

--- a/tests/unit/cogs/test_rps_naming.py
+++ b/tests/unit/cogs/test_rps_naming.py
@@ -1,0 +1,203 @@
+"""PR 3 — Rock Paper Scissors display rename + alias pins.
+
+The canonical subsystem key remains ``rps_tournament`` (no second
+active SUBSYSTEMS entry is added — see §13 acceptance checklist of
+the operating-contract plan). What changes:
+
+* Display name: ``"RPS Tournament"`` → ``"Rock Paper Scissors"``.
+* Help aliases: ``rps``, ``rock paper scissors``, and ``rps_tournament``
+  all resolve to the same subsystem panel.
+* Class rename: ``RPSTournamentCog`` → ``RockPaperScissorsCog`` with a
+  back-compat alias keeping the old name importable.
+* User-facing labels in the panel embed + tournament UI use the new
+  spelling.
+
+What does **not** change:
+
+* The ``"rps_tournament"`` key in :data:`SUBSYSTEMS`.
+* Tournament state ``kind="rps"`` in
+  :mod:`services.tournament_state_service`.
+* The leaderboard / rank-provider name ``"rps"``.
+* Existing prefix commands (``!rps``, ``!rpsregister``, ``!rpsstart``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from discord.ext import commands
+
+from cogs.help.route import resolve_route
+from utils.subsystem_registry import SUBSYSTEMS
+from views.games.hub import discover_game_children
+
+
+def _bot_without_rps_command() -> MagicMock:
+    """A bot mock whose ``get_command`` returns ``None`` so a
+    fallthrough into the command branch would short-circuit on an
+    explicit None and not mask the override / SUBSYSTEMS-loop match.
+    """
+    bot = MagicMock(spec=commands.Bot)
+    bot.get_command = MagicMock(return_value=None)
+    return bot
+
+
+# ---------------------------------------------------------------------------
+# Registry — display name + no duplicate active entry
+# ---------------------------------------------------------------------------
+
+
+def test_rps_subsystem_display_name_is_rock_paper_scissors():
+    assert SUBSYSTEMS["rps_tournament"]["display_name"] == "Rock Paper Scissors"
+
+
+def test_no_second_active_rps_subsystem_entry():
+    """The canonical key stays ``rps_tournament``. A second active entry
+    keyed ``rps`` would duplicate Games-hub children, readiness rows,
+    settings schema entries, and rank-provider registrations — see the
+    operating-contract plan §13 acceptance checklist.
+    """
+    assert "rps" not in SUBSYSTEMS, (
+        "A second active SUBSYSTEMS entry keyed 'rps' would create "
+        "duplicate Games-hub children / readiness rows. Canonical key "
+        "for this sweep is 'rps_tournament' — see plan §13."
+    )
+
+
+def test_rps_appears_exactly_once_in_games_hub():
+    children = discover_game_children()
+    rps_entries = [
+        (name, meta)
+        for name, meta in children
+        if "rps" in name.lower()
+        or "rock paper" in (meta.get("display_name") or "").lower()
+    ]
+    assert len(rps_entries) == 1, (
+        f"Games hub must show exactly one RPS entry; found "
+        f"{[name for name, _ in rps_entries]}. Plan §13 forbids "
+        "duplicate visible RPS surfaces."
+    )
+    name, meta = rps_entries[0]
+    assert name == "rps_tournament"
+    assert meta["display_name"] == "Rock Paper Scissors"
+
+
+# ---------------------------------------------------------------------------
+# Help route resolution — three aliases, one target
+# ---------------------------------------------------------------------------
+
+
+def test_help_resolves_rps_to_rps_tournament_subsystem():
+    """``!help rps`` must open the Rock Paper Scissors panel rather
+    than the single-command help for ``!rps``. The
+    SUBSYSTEM_ALIAS_OVERRIDES branch handles this; without the
+    override the resolver would fall through to ``bot.get_command
+    ("rps")`` which returns the ``!rps`` command.
+    """
+    bot = _bot_without_rps_command()
+    route = resolve_route("rps", bot=bot)
+    assert route.kind == "subsystem"
+    assert route.target == "rps_tournament"
+
+
+def test_help_resolves_rock_paper_scissors_to_rps_tournament_subsystem():
+    bot = _bot_without_rps_command()
+    route = resolve_route("rock paper scissors", bot=bot)
+    assert route.kind == "subsystem"
+    assert route.target == "rps_tournament"
+
+
+def test_help_resolves_rps_tournament_to_rps_tournament_subsystem():
+    """Legacy name keeps working — back-compat for operators who type
+    the old display name.
+    """
+    bot = _bot_without_rps_command()
+    route = resolve_route("rps_tournament", bot=bot)
+    assert route.kind == "subsystem"
+    assert route.target == "rps_tournament"
+
+
+def test_help_resolution_is_case_insensitive():
+    bot = _bot_without_rps_command()
+    for variant in ("RPS", "Rps", "Rock Paper Scissors", "ROCK PAPER SCISSORS"):
+        route = resolve_route(variant, bot=bot)
+        assert route.kind == "subsystem", f"variant {variant!r}: {route!r}"
+        assert route.target == "rps_tournament", (
+            f"variant {variant!r}: {route!r}"
+        )
+
+
+def test_all_three_rps_aliases_resolve_to_same_target():
+    """Symmetry pin: every alias must produce the same routed target so
+    the user-visible panel is identical regardless of how they typed
+    it.
+    """
+    bot = _bot_without_rps_command()
+    targets = {
+        resolve_route(name, bot=bot).target
+        for name in ("rps", "rock paper scissors", "rps_tournament")
+    }
+    assert targets == {"rps_tournament"}
+
+
+# ---------------------------------------------------------------------------
+# Class rename + back-compat alias
+# ---------------------------------------------------------------------------
+
+
+def test_rock_paper_scissors_cog_class_exists():
+    from cogs.rps_tournament_cog import RockPaperScissorsCog
+
+    assert RockPaperScissorsCog is not None
+
+
+def test_legacy_rps_tournament_cog_alias_still_importable():
+    """Back-compat: old imports continue to resolve to the renamed
+    class without code changes anywhere else.
+    """
+    from cogs.rps_tournament_cog import RPSTournamentCog, RockPaperScissorsCog
+
+    assert RPSTournamentCog is RockPaperScissorsCog
+
+
+def test_cog_name_attribute_uses_rock_paper_scissors_display():
+    """discord.py's ``commands.Cog`` ``name=`` attribute drives the cog
+    registry key (``bot.cogs[...]``) and the help-page section header.
+    PR 3 updates it from "Rock-Paper-Scissors Tournament" to "Rock
+    Paper Scissors".
+    """
+    from cogs.rps_tournament_cog import RockPaperScissorsCog
+
+    # ``commands.Cog`` stores the name attribute on the class via the
+    # ``name=`` kwarg in its metaclass; check via the underscored attr
+    # discord.py uses internally.
+    name_attr = getattr(RockPaperScissorsCog, "__cog_name__", None)
+    assert name_attr == "Rock Paper Scissors", (
+        f"Cog name attribute is {name_attr!r}; expected 'Rock Paper "
+        "Scissors'."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Out-of-scope state stays untouched
+# ---------------------------------------------------------------------------
+
+
+def test_tournament_state_kind_value_rps_still_valid():
+    """The tournament-state service uses ``kind="rps"`` (short form,
+    not ``"rps_tournament"``). PR 3 must not change this; the
+    canonical-key migration is deferred per plan §12.
+    """
+    from services.tournament_state_service import _VALID_KINDS
+
+    assert "rps" in _VALID_KINDS
+
+
+def test_rank_provider_rps_name_unchanged():
+    """The leaderboard / rank provider uses ``name = "rps"``. PR 3 must
+    not change it; rank-provider aliases are deferred state.
+    """
+    from services.rank_providers import RpsProvider
+
+    assert RpsProvider.name == "rps"

--- a/tests/unit/cogs/test_rps_naming.py
+++ b/tests/unit/cogs/test_rps_naming.py
@@ -156,7 +156,7 @@ def test_legacy_rps_tournament_cog_alias_still_importable():
     """Back-compat: old imports continue to resolve to the renamed
     class without code changes anywhere else.
     """
-    from cogs.rps_tournament_cog import RPSTournamentCog, RockPaperScissorsCog
+    from cogs.rps_tournament_cog import RockPaperScissorsCog, RPSTournamentCog
 
     assert RPSTournamentCog is RockPaperScissorsCog
 

--- a/tests/unit/help/test_help_direct_navigation.py
+++ b/tests/unit/help/test_help_direct_navigation.py
@@ -253,7 +253,7 @@ async def test_rps_build_help_menu_view_returns_embed_and_view():
     embed, view = await cog.build_help_menu_view(_stub_interaction())
     assert isinstance(embed, discord.Embed)
     assert isinstance(view, discord.ui.View)
-    assert embed.title == "✂️ Rock-Paper-Scissors"
+    assert embed.title == "✂️ Rock Paper Scissors"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Display rename: "RPS Tournament" / "Rock-Paper-Scissors" → **"Rock Paper Scissors"** across registry, panel, tournament UI, and class name.
- Help aliases: `rps`, `rock paper scissors`, `rps_tournament` all resolve to the same subsystem panel.
- Class rename: `RPSTournamentCog` → `RockPaperScissorsCog` with `RPSTournamentCog = RockPaperScissorsCog` back-compat alias.
- **Canonical SUBSYSTEMS key remains `rps_tournament`** — a second active entry is forbidden (plan §13).

## Scope table

| Does | Does NOT |
|---|---|
| Change display_name + description in SUBSYSTEMS["rps_tournament"] | Add a second SUBSYSTEMS entry keyed `rps` |
| Add Help aliases via `SUBSYSTEM_ALIAS_OVERRIDES` | Rename any prefix commands |
| Rename class + add back-compat alias | Change tournament state `kind="rps"` |
| Update user-facing strings (panel, registration title, command help header, PvP challenge embed) | Change rank-provider `RpsProvider.name="rps"` |
| | Move `cogs/rps_tournament/` package (deferred past PR 9) |
| | Change Discord category name "RPS Tournaments" (cleanup scanner pins this literal) |

## Files changed

- `disbot/utils/subsystem_registry.py` — display_name + description.
- `disbot/cogs/help/route.py` — `SUBSYSTEM_ALIAS_OVERRIDES["rps"]` and `["rock paper scissors"]`.
- `disbot/cogs/rps_tournament_cog.py` — class rename + back-compat alias + 2 user-facing string updates.
- `disbot/cogs/rps_tournament/_quickplay.py` — PvP challenge embed text.
- `disbot/cogs/games_cog.py` — module docstring.
- `disbot/views/games/rps_panel.py` — embed titles.
- `tests/unit/help/test_help_direct_navigation.py` — updated for new title.
- `tests/unit/cogs/test_rps_naming.py` **(new, 13 tests)** — alias resolution + uniqueness + back-compat pins.

## Architecture impact

**Additive.** Public surface (`RPSTournamentCog`, `rps_tournament` subsystem key, `kind="rps"`, `RpsProvider.name="rps"`, all commands) preserved by alias.

## Tests run

```
pytest -q                                     # 2546 passed, 7 xfailed
pytest tests/unit/cogs/test_rps_naming.py -v  # 13 passed
pytest tests/unit/help/ -q                    # all green

ruff check . --exclude .github,tests,venv,env,build,dist   # All checks passed
black --check . --exclude '(\.github|tests|venv|env|build|dist)'  # 285 files unchanged
mypy disbot/                                                       # 286 source files, 0 issues
```

## Manual Discord smoke checklist

- [ ] `!help rps` shows panel labeled "Rock Paper Scissors" (PENDING — no live runtime).
- [ ] `!help rock paper scissors` same panel (PENDING).
- [ ] `!help rps_tournament` same panel (PENDING).
- [ ] Games hub shows exactly one RPS entry labeled "Rock Paper Scissors" (PENDING).
- [ ] `!rps`, `!rpsregister`, `!rpsstart` still work (PENDING).
- [ ] `!leaderboard rps` still works (PENDING).
- [ ] `!platform setup-readiness` shows no duplicate RPS row (PENDING).

## Rollback plan

`git revert <merge-commit>`. Class alias makes rollback safe — any code importing `RPSTournamentCog` post-revert still resolves to the same class. Saved DB state (tournament_state.kind="rps", rank provider keys) was never touched.

## Out of scope

- Canonical SUBSYSTEMS key migration `rps_tournament` → `rps` (deferred to a dedicated future PR; see plan §12).
- Package move `cogs/rps_tournament/` → `cogs/rps/` (deferred past PR 9).
- RPS leaderboard display strings ("✂️ RPS Leaderboard") — leaderboard UI; out of subsystem-display scope.
- Tournament Discord category rename ("RPS Tournaments") — cleanup scanner pins the literal; separate migration concern.

## Follow-up items

- PR 4: RPS playable panel that turns the `rps_tournament` xfail in the actionability contract into xpass.

## CI status

Pending — subscribing after creation.

## Risk level

**Low-medium.** Display + alias only; canonical key untouched. Saved state, providers, tournament `kind`, and commands all preserved.

## User-visible behavior change

**Yes.** Cog display name, panel embed titles, help menu label, and tournament registration UI all read "Rock Paper Scissors". Typing `!help rps` now opens the panel instead of the single-command help for `!rps`.

## Slash sync or deploy action required

**No.** No slash command surface changed.

https://claude.ai/code/session_011QAYCgaMJ6GkhWtJZeRGVq

---
_Generated by [Claude Code](https://claude.ai/code/session_011QAYCgaMJ6GkhWtJZeRGVq)_