### PR TITLE
views: Blackjack playable panel (PR 5 of 9)

### DIFF
--- a/disbot/cogs/blackjack/actions.py
+++ b/disbot/cogs/blackjack/actions.py
@@ -1,0 +1,282 @@
+"""Blackjack action helpers (PR 5).
+
+Shared helpers used by the playable Help/Games → Blackjack panel
+(``views.games.blackjack_panel``). The cog's typed-command bodies
+(``!blackjack``, ``!bjtournament``) remain authoritative; these
+helpers wrap the same engine state (``_Game``, ``_active``,
+``_pvp``, ``_tournaments``) so the panel buttons run identical
+gameplay logic without duplicating it.
+
+Three entry points:
+
+* :func:`start_solo_blackjack` — solo vs dealer (used by Solo Free
+  Play / Solo Bet buttons).
+* :func:`build_blackjack_challenge_view` — PvP challenge spawner
+  (used by Challenge Player button).
+* :func:`open_blackjack_tournament` — admin tournament setup (used
+  by Tournament → Open Registration button).
+
+Each helper returns the (embed, view, message_text) tuple the panel
+edit_message call needs. The auto-payout "natural blackjack" path
+returns ``view=None`` so the panel knows not to attach the playable
+view.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+import discord
+from discord.ext import commands
+
+from cogs.blackjack._persistence import _save_game_state
+from cogs.blackjack._state import (
+    FREE_WIN_COINS,
+    _active,
+    _BjTournament,
+    _Game,
+    _pvp,
+    _tournaments,
+)
+from core.runtime import tasks
+from services import economy_service, tournament_state_service
+from services.blackjack_engine import is_blackjack as _is_blackjack
+from utils import db
+from utils.ui_constants import ECONOMY_COLOR, SUCCESS_COLOR
+from views.blackjack.embeds import _game_embed, _tourn_embed
+from views.blackjack.pvp_view import _ChallengeView
+from views.blackjack.solo_view import BlackjackView
+from views.blackjack.tournament_views import _TournRegistrationView
+
+
+@dataclass
+class SoloStartResult:
+    """Return tuple for :func:`start_solo_blackjack`.
+
+    ``view`` is ``None`` when the start short-circuited (already
+    playing, insufficient balance, natural blackjack auto-payout). In
+    that case ``ephemeral_message`` carries the user-facing reason for
+    short-circuits and ``embed`` is set for the auto-payout path.
+    ``game`` is set only when a playable hand was dealt — the caller
+    is responsible for assigning ``view.message`` and calling
+    :func:`_save_game_state` after the message edit succeeds.
+    """
+
+    embed: discord.Embed | None
+    view: BlackjackView | None
+    game: _Game | None
+    ephemeral_message: str | None = None
+
+
+async def start_solo_blackjack(
+    user: discord.Member | discord.User,
+    guild: discord.Guild,
+    channel: discord.abc.MessageableChannel,
+    bet: int,
+) -> SoloStartResult:
+    """Deal a fresh solo Blackjack hand, mirroring the ``!blackjack``
+    body (cogs/blackjack_cog.py:405-488). No new state machinery; the
+    same ``_Game``, ``_active`` dict, and persistence path.
+    """
+    if bet < 0:
+        return SoloStartResult(
+            None,
+            None,
+            None,
+            ephemeral_message="Bet must be 0 or positive.",
+        )
+    key = (user.id, guild.id)
+    if key in _active:
+        return SoloStartResult(
+            None,
+            None,
+            None,
+            ephemeral_message="You already have a game running!",
+        )
+    if bet > 0:
+        bal = await db.get_coins(user.id, guild.id)
+        if bet > bal:
+            return SoloStartResult(
+                None,
+                None,
+                None,
+                ephemeral_message=f"❌ You only have **{bal}** 🪙.",
+            )
+
+    game = _Game(user.id, guild.id, bet, channel_id=channel.id)
+    _active[key] = game
+
+    if _is_blackjack(game.player):
+        payout = int(bet * 1.5) if bet else FREE_WIN_COINS
+        new_bal = await economy_service.credit(
+            guild.id,
+            user.id,
+            payout,
+            reason="blackjack:natural_blackjack",
+            actor_id=user.id,
+        )
+        embed = _game_embed(game, reveal=True)
+        embed.color = ECONOMY_COLOR
+        embed.add_field(
+            name="🎉 Blackjack!",
+            value=f"+{payout} 🪙  |  Balance: **{new_bal}** 🪙",
+            inline=False,
+        )
+        _active.pop(key)
+        return SoloStartResult(embed, None, None)
+
+    return SoloStartResult(_game_embed(game), BlackjackView(game), game)
+
+
+async def commit_solo_blackjack(view: BlackjackView, message: discord.Message) -> None:
+    """Attach the message to the live view and persist the initial
+    snapshot. Mirrors the cog command's post-send bookkeeping.
+    """
+    view.message = message
+    await _save_game_state(view.game)
+
+
+def build_blackjack_challenge_view(
+    challenger: discord.Member,
+    opponent: discord.Member,
+    guild_id: int,
+    bet: int,
+) -> tuple[discord.Embed, _ChallengeView | None, str | None]:
+    """Build the PvP challenge embed + view.
+
+    Returns ``(embed, view, error_message)``. When ``error_message``
+    is set, ``view`` is ``None`` and the caller should surface the
+    message ephemerally (challenge target is invalid).
+    """
+    if opponent.id == challenger.id:
+        return _empty_embed(), None, "You can't challenge yourself."
+    if opponent.bot:
+        return (
+            _empty_embed(),
+            None,
+            "You can't challenge a bot to PvP.",
+        )
+    key = frozenset({challenger.id, opponent.id})
+    if key in _pvp:
+        return (
+            _empty_embed(),
+            None,
+            "There's already a PvP game between these players.",
+        )
+    bet_str = f"**{bet}** 🪙" if bet else "free play"
+    embed = discord.Embed(
+        title="🃏 Blackjack Challenge!",
+        description=(
+            f"{challenger.mention} challenges {opponent.mention} to "
+            f"Blackjack ({bet_str}).\n{opponent.mention}, do you accept?"
+        ),
+        color=SUCCESS_COLOR,
+    )
+    view = _ChallengeView(challenger, opponent, guild_id, bet)
+    return embed, view, None
+
+
+def _empty_embed() -> discord.Embed:
+    """A placeholder embed for the error branch — never displayed,
+    but lets the return tuple stay homogeneous.
+    """
+    return discord.Embed(title=" ", description=" ")
+
+
+@dataclass
+class TournamentStartResult:
+    """Return tuple for :func:`open_blackjack_tournament`."""
+
+    embed: discord.Embed | None
+    view: _TournRegistrationView | None
+    tournament: _BjTournament | None
+    ephemeral_message: str | None = None
+
+
+async def open_blackjack_tournament(
+    host: discord.Member | discord.User,
+    guild: discord.Guild,
+    channel: discord.abc.MessageableChannel,
+    bot: commands.Bot,
+    *,
+    entry_fee: int = 0,
+    rounds: int = 5,
+    duration_mins: int = 5,
+) -> TournamentStartResult:
+    """Spawn a Blackjack tournament registration window — same engine
+    state as ``!bjtournament`` (cogs/blackjack_cog.py:490-538). The
+    caller is responsible for adding the ✅ reaction and capturing the
+    sent message on ``tourn.reg_message``.
+    """
+    from cogs.blackjack_cog import _launch_tournament  # local — avoid cycle
+
+    if _tournaments.get(guild.id):
+        return TournamentStartResult(
+            None,
+            None,
+            None,
+            ephemeral_message="A tournament is already running.",
+        )
+    existing = await tournament_state_service.get_active(guild.id)
+    if existing:
+        return TournamentStartResult(
+            None,
+            None,
+            None,
+            ephemeral_message=(
+                f"A **{existing}** tournament is already active in this server."
+            ),
+        )
+    if entry_fee < 0 or rounds < 1 or duration_mins < 1:
+        return TournamentStartResult(
+            None,
+            None,
+            None,
+            ephemeral_message="Invalid parameters.",
+        )
+
+    tourn = _BjTournament(
+        host.id,
+        guild.id,
+        channel.id,
+        entry_fee,
+        rounds,
+        duration_mins,
+    )
+    _tournaments[guild.id] = tourn
+    await tournament_state_service.set_active(guild.id, "blackjack")
+
+    async def _auto_start():
+        await asyncio.sleep(duration_mins * 60)
+        if not tourn.started and tourn.guild_id in _tournaments:
+            await _launch_tournament(tourn, guild, bot)
+
+    tourn.timer_task = tasks.spawn(
+        f"blackjack:autostart:{tourn.guild_id}",
+        _auto_start(),
+    )
+
+    return TournamentStartResult(
+        _tourn_embed(tourn),
+        _TournRegistrationView(tourn),
+        tourn,
+    )
+
+
+def get_active_tournament(guild_id: int) -> _BjTournament | None:
+    """Return the currently registered Blackjack tournament for the
+    guild, or ``None`` if no tournament is open.
+    """
+    return _tournaments.get(guild_id)
+
+
+__all__ = [
+    "SoloStartResult",
+    "TournamentStartResult",
+    "build_blackjack_challenge_view",
+    "commit_solo_blackjack",
+    "get_active_tournament",
+    "open_blackjack_tournament",
+    "start_solo_blackjack",
+]

--- a/disbot/views/games/blackjack_panel.py
+++ b/disbot/views/games/blackjack_panel.py
@@ -1,80 +1,134 @@
-"""Blackjack hub panel — Phase 7 Option A (router only).
+"""Blackjack hub panel — PR 5 (playable launcher).
 
-A discovery surface that lists Classic and Rules under the Games hub.
-Game logic, modes, replay, and economy paths are **untouched** — every
-button either swaps the embed in place or routes back to a parent hub
-via the standard ``attach_back_to_*`` factories.
+PR 5 converted the panel from router-only embeds into an actionable
+launcher that spawns real Blackjack games. The buttons reuse the
+existing ``BlackjackView``, ``_ChallengeView``, and
+``_TournRegistrationView`` via the action helpers in
+:mod:`cogs.blackjack.actions` — no duplicate game state lives here.
 
-Phase 7 Option A explicitly defers Practice / Replay / Best-of variants
-to a follow-up (Phase 7b) once the engine-side design call is made
-(``bet=0`` vs separate no-economy path, post-game callback shape,
-double-charge prevention).
+Layout:
+
+* Row 0: ▶ Solo Free Play | 💰 Solo Bet | 👤 Challenge Player
+* Row 1: 🏆 Tournament | 📊 Status | 📖 Rules
+
+Tournament behaviour:
+
+* Admin (``guild_permissions.administrator``) sees an "Open
+  Registration" button that spawns a tournament with default
+  parameters (entry_fee=0, rounds=5, 5-minute window) and emits the
+  ✅ react.
+* Non-admin sees an existing-tournament status if one is open,
+  otherwise a "no tournament" embed.
 """
 
 from __future__ import annotations
 
+import logging
+
 import discord
 
+from cogs.blackjack.actions import (
+    build_blackjack_challenge_view,
+    commit_solo_blackjack,
+    get_active_tournament,
+    open_blackjack_tournament,
+    start_solo_blackjack,
+)
 from utils.ui_constants import GAME_COLOR
 from views.base import HubView
+from views.blackjack.embeds import _tourn_embed
+
+logger = logging.getLogger("bot.views.games.blackjack_panel")
+
+# Bet presets shown in the Solo Bet sub-view. Mirrors the RPS panel
+# layout (PR 4) so the cross-game UX is consistent.
+_BET_PRESETS: tuple[int, ...] = (10, 25, 50, 100)
+
+
+# ---------------------------------------------------------------------------
+# Embed builders
+# ---------------------------------------------------------------------------
 
 
 def build_blackjack_overview_embed() -> discord.Embed:
     embed = discord.Embed(
         title="🃏 Blackjack",
         description=(
-            "Classic 21 — solo against the bot, PvP against another "
-            "player, or scheduled tournaments. The buttons below explain "
-            "how to start each mode; typed shortcuts still work."
+            "Classic 21 — Solo Free Play is no-stakes vs the dealer; "
+            "Solo Bet stakes 🪙 coins; Challenge Player opens a PvP "
+            "match; Tournament runs the multi-round bracket."
         ),
         color=GAME_COLOR,
     )
-    embed.add_field(
-        name="Modes",
-        value=(
-            "▶ **Classic** — start a standard game\n"
-            "📖 **Rules** — how the deal/hit/stand flow works"
-        ),
-        inline=False,
-    )
-    embed.set_footer(text="Typed shortcuts: !blackjack, !bj, !bjtournament.")
+    embed.set_footer(text="Only you can interact with this panel.")
     return embed
 
 
-def build_blackjack_classic_embed() -> discord.Embed:
-    embed = discord.Embed(
-        title="🃏 Blackjack — Classic",
+def build_blackjack_bet_preset_embed() -> discord.Embed:
+    return discord.Embed(
+        title="🃏 Blackjack — Solo Bet",
         description=(
-            "Start a Classic game with a typed command. Bets are in "
-            "🪙 coins; use `0` for a free game."
+            "Choose a bet amount, then play vs the dealer. Win pays "
+            "the bet (or 1.5× on natural blackjack); lose debits the "
+            "bet."
         ),
         color=GAME_COLOR,
     )
-    embed.add_field(
-        name="Solo vs bot",
-        value="`!blackjack <bet>` or `!bj <bet>`",
-        inline=False,
+
+
+def build_blackjack_challenge_picker_embed() -> discord.Embed:
+    return discord.Embed(
+        title="🃏 Blackjack — Challenge Player",
+        description=(
+            "Pick the player you want to challenge. They'll see an "
+            "Accept / Decline prompt."
+        ),
+        color=GAME_COLOR,
     )
-    embed.add_field(
-        name="PvP challenge",
-        value="`!blackjack @user <bet>`",
-        inline=False,
+
+
+def build_blackjack_tournament_overview_embed(
+    *,
+    is_admin: bool,
+    has_active: bool,
+) -> discord.Embed:
+    if has_active:
+        return discord.Embed(
+            title="🏆 Blackjack Tournament — Active",
+            description=(
+                "A tournament is already registered in this server. "
+                "Use **Status** to see registered players and round "
+                "progress."
+            ),
+            color=GAME_COLOR,
+        )
+    if is_admin:
+        return discord.Embed(
+            title="🏆 Blackjack Tournament — Setup",
+            description=(
+                "Click **Open Registration** to start a new tournament "
+                "with default settings (no entry fee, 5 rounds, "
+                "5-minute registration window). Use `!bjtournament "
+                "<entry_fee> <rounds> <mins>` for custom parameters."
+            ),
+            color=GAME_COLOR,
+        )
+    return discord.Embed(
+        title="🏆 Blackjack Tournament — Idle",
+        description=(
+            "No tournament is currently registered. An admin can "
+            "start one with `!bjtournament`."
+        ),
+        color=GAME_COLOR,
     )
-    embed.add_field(
-        name="Tournament",
-        value="`!bjtournament` — open registration",
-        inline=False,
-    )
-    embed.set_footer(text="Click ◀ Overview to return to the Blackjack hub.")
-    return embed
 
 
 def build_blackjack_rules_embed() -> discord.Embed:
     embed = discord.Embed(
         title="🃏 Blackjack — Rules",
         description=(
-            "Each player is dealt two cards; the goal is to reach a "
-            "hand value as close to 21 as possible without going over."
+            "Each player is dealt two cards; reach 21 (or as close as "
+            "possible without busting) to beat the dealer."
         ),
         color=GAME_COLOR,
     )
@@ -92,6 +146,7 @@ def build_blackjack_rules_embed() -> discord.Embed:
         value=(
             "• **Hit** — draw another card\n"
             "• **Stand** — keep the current hand\n"
+            "• **Double** — double your bet and take exactly one card\n"
             "• Bust at >21 — the other side wins automatically"
         ),
         inline=False,
@@ -99,22 +154,274 @@ def build_blackjack_rules_embed() -> discord.Embed:
     embed.add_field(
         name="Outcomes",
         value=(
-            "• Player blackjack (A + 10-value, two cards) usually pays "
-            "extra\n"
+            "• Natural blackjack (A + 10-value, two cards) pays 1.5× "
+            "the bet\n"
             "• Tie returns the bet"
         ),
         inline=False,
     )
-    embed.set_footer(text="Click ◀ Overview to return to the Blackjack hub.")
     return embed
 
 
-class BlackjackPanelView(HubView):
-    """Router-only Blackjack hub surfaced via Help → Blackjack and the Games hub.
+# ---------------------------------------------------------------------------
+# Sub-views
+# ---------------------------------------------------------------------------
 
-    No game logic. No economy hooks. No new betting modes. The view's
-    sole job is to keep Blackjack discoverable from a single panel and
-    route to the existing typed commands for the actual start path.
+
+class _BlackjackBetPresetView(HubView):
+    """Bet-preset picker: 10/25/50/100/Custom + Back."""
+
+    def __init__(self, author: discord.Member | discord.User) -> None:
+        super().__init__(author)
+        for preset in _BET_PRESETS:
+            self.add_item(_BlackjackBetPresetButton(preset))
+        self.add_item(_BlackjackBetCustomButton())
+        self.add_item(_BlackjackBackToPanelButton())
+
+
+class _BlackjackBetPresetButton(discord.ui.Button):
+    def __init__(self, bet: int) -> None:
+        super().__init__(
+            label=f"{bet} 🪙",
+            style=discord.ButtonStyle.primary,
+            custom_id=f"blackjack_panel:bet:{bet}",
+            row=0,
+        )
+        self._bet = bet
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await _spawn_solo(interaction, self._bet)
+
+
+class _BlackjackBetCustomButton(discord.ui.Button):
+    def __init__(self) -> None:
+        super().__init__(
+            label="Custom",
+            style=discord.ButtonStyle.secondary,
+            custom_id="blackjack_panel:bet:custom",
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await interaction.response.send_modal(_BlackjackCustomBetModal())
+
+
+class _BlackjackCustomBetModal(discord.ui.Modal, title="Custom Bet"):
+    bet_input: discord.ui.TextInput = discord.ui.TextInput(  # type: ignore[var-annotated]
+        label="Bet (🪙 coins)",
+        placeholder="Enter a positive integer (or 0 for free play)",
+        required=True,
+        max_length=10,
+    )
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        raw = (self.bet_input.value or "").strip()
+        try:
+            bet = int(raw)
+        except ValueError:
+            await interaction.response.send_message(
+                "Bet must be an integer.",
+                ephemeral=True,
+            )
+            return
+        if bet < 0:
+            await interaction.response.send_message(
+                "Bet must be 0 or positive.",
+                ephemeral=True,
+            )
+            return
+        await _spawn_solo(interaction, bet)
+
+
+async def _spawn_solo(interaction: discord.Interaction, bet: int) -> None:
+    """Shared Solo Free / Solo Bet / Custom spawn path."""
+    if interaction.guild is None or interaction.channel is None:
+        await interaction.response.send_message(
+            "Blackjack can only be started in a server channel.",
+            ephemeral=True,
+        )
+        return
+    result = await start_solo_blackjack(
+        interaction.user,  # type: ignore[arg-type]
+        interaction.guild,
+        interaction.channel,  # type: ignore[arg-type]
+        bet,
+    )
+    if result.ephemeral_message:
+        await interaction.response.send_message(
+            result.ephemeral_message,
+            ephemeral=True,
+        )
+        return
+    if result.embed is None:
+        # Defensive: helper guaranteed (ephemeral_message OR embed),
+        # but the type annotations leave embed Optional. Surface a
+        # generic ephemeral rather than crashing.
+        await interaction.response.send_message(
+            "Could not start the game — please retry.",
+            ephemeral=True,
+        )
+        return
+    if result.view is None:
+        # Natural-blackjack auto-payout: no playable view to attach.
+        await interaction.response.edit_message(
+            embed=result.embed,
+            view=None,
+        )
+        return
+    await interaction.response.edit_message(
+        embed=result.embed,
+        view=result.view,
+    )
+    if interaction.message is not None and result.game is not None:
+        await commit_solo_blackjack(result.view, interaction.message)
+
+
+class _BlackjackChallengeSelectView(HubView):
+    def __init__(self, author: discord.Member | discord.User) -> None:
+        super().__init__(author)
+        self.add_item(_BlackjackOpponentSelect())
+        self.add_item(_BlackjackBackToPanelButton())
+
+
+class _BlackjackOpponentSelect(discord.ui.UserSelect):
+    def __init__(self) -> None:
+        super().__init__(
+            placeholder="Choose an opponent…",
+            min_values=1,
+            max_values=1,
+            custom_id="blackjack_panel:opponent_select",
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        opponent = self.values[0]
+        if not isinstance(opponent, discord.Member):
+            await interaction.response.send_message(
+                "Opponent must be a server member.",
+                ephemeral=True,
+            )
+            return
+        challenger = interaction.user
+        if not isinstance(challenger, discord.Member):
+            await interaction.response.send_message(
+                "Challenger must be a server member.",
+                ephemeral=True,
+            )
+            return
+        bet = 0  # PvP bet picker deferred to a future PR
+        embed, view, error = build_blackjack_challenge_view(
+            challenger,
+            opponent,
+            interaction.guild_id or 0,
+            bet,
+        )
+        if error or view is None:
+            await interaction.response.send_message(
+                error or "Could not start challenge.",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.edit_message(embed=embed, view=view)
+        view.message = interaction.message
+
+
+class _BlackjackTournamentSubView(HubView):
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        *,
+        is_admin: bool,
+        has_active: bool,
+    ) -> None:
+        super().__init__(author)
+        if is_admin and not has_active:
+            self.add_item(_BlackjackTournamentOpenButton())
+        self.add_item(_BlackjackBackToPanelButton())
+
+
+class _BlackjackTournamentOpenButton(discord.ui.Button):
+    def __init__(self) -> None:
+        super().__init__(
+            label="🏆 Open Registration",
+            style=discord.ButtonStyle.primary,
+            custom_id="blackjack_panel:tournament:open",
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        if interaction.guild is None or interaction.channel is None:
+            await interaction.response.send_message(
+                "Tournament can only be started in a server channel.",
+                ephemeral=True,
+            )
+            return
+        result = await open_blackjack_tournament(
+            interaction.user,  # type: ignore[arg-type]
+            interaction.guild,
+            interaction.channel,  # type: ignore[arg-type]
+            interaction.client,  # type: ignore[arg-type]
+        )
+        if result.ephemeral_message:
+            await interaction.response.send_message(
+                result.ephemeral_message,
+                ephemeral=True,
+            )
+            return
+        if result.embed is None or result.view is None or result.tournament is None:
+            # Defensive: helper guarantees (ephemeral OR full tuple) but
+            # mypy can't see that. Fall back to ephemeral so the panel
+            # never crashes.
+            await interaction.response.send_message(
+                "Could not open registration — please retry.",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.edit_message(
+            embed=result.embed,
+            view=result.view,
+        )
+        if interaction.message is not None:
+            try:
+                await interaction.message.add_reaction("✅")
+            except Exception as exc:  # noqa: BLE001 — reaction is optional
+                logger.debug(
+                    "blackjack panel: add_reaction failed: %s",
+                    exc,
+                )
+            result.tournament.reg_message = interaction.message
+
+
+class _BlackjackBackToPanelButton(discord.ui.Button):
+    def __init__(self) -> None:
+        super().__init__(
+            label="◀ Back to Blackjack",
+            style=discord.ButtonStyle.secondary,
+            custom_id="blackjack_panel:back",
+            row=4,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        parent_view = self.view
+        author = getattr(parent_view, "_author", interaction.user)
+        await interaction.response.edit_message(
+            embed=build_blackjack_overview_embed(),
+            view=BlackjackPanelView(author),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Main panel
+# ---------------------------------------------------------------------------
+
+
+class BlackjackPanelView(HubView):
+    """Actionable Blackjack hub (PR 5).
+
+    Six direct buttons: Solo Free Play, Solo Bet, Challenge Player,
+    Tournament, Status, Rules. Engine logic lives in
+    :mod:`cogs.blackjack.actions` and :mod:`views.blackjack`; this
+    view is a launcher only.
     """
 
     SUBSYSTEM = "blackjack"
@@ -123,18 +430,98 @@ class BlackjackPanelView(HubView):
         super().__init__(author)
 
     @discord.ui.button(
-        label="▶ Classic",
+        label="▶ Solo Free Play",
         style=discord.ButtonStyle.success,
-        custom_id="blackjack_panel:classic",
+        custom_id="blackjack_panel:solo_free",
         row=0,
     )
-    async def btn_classic(
+    async def btn_solo_free(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        await _spawn_solo(interaction, 0)
+
+    @discord.ui.button(
+        label="💰 Solo Bet",
+        style=discord.ButtonStyle.primary,
+        custom_id="blackjack_panel:solo_bet",
+        row=0,
+    )
+    async def btn_solo_bet(
         self,
         interaction: discord.Interaction,
         _button: discord.ui.Button,
     ) -> None:
         await interaction.response.edit_message(
-            embed=build_blackjack_classic_embed(),
+            embed=build_blackjack_bet_preset_embed(),
+            view=_BlackjackBetPresetView(interaction.user),
+        )
+
+    @discord.ui.button(
+        label="👤 Challenge Player",
+        style=discord.ButtonStyle.primary,
+        custom_id="blackjack_panel:challenge",
+        row=0,
+    )
+    async def btn_challenge(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        await interaction.response.edit_message(
+            embed=build_blackjack_challenge_picker_embed(),
+            view=_BlackjackChallengeSelectView(interaction.user),
+        )
+
+    @discord.ui.button(
+        label="🏆 Tournament",
+        style=discord.ButtonStyle.primary,
+        custom_id="blackjack_panel:tournament",
+        row=1,
+    )
+    async def btn_tournament(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        guild_perms = getattr(interaction.user, "guild_permissions", None)
+        is_admin = bool(guild_perms and guild_perms.administrator)
+        guild_id = interaction.guild_id or 0
+        has_active = get_active_tournament(guild_id) is not None
+        await interaction.response.edit_message(
+            embed=build_blackjack_tournament_overview_embed(
+                is_admin=is_admin,
+                has_active=has_active,
+            ),
+            view=_BlackjackTournamentSubView(
+                interaction.user,
+                is_admin=is_admin,
+                has_active=has_active,
+            ),
+        )
+
+    @discord.ui.button(
+        label="📊 Status",
+        style=discord.ButtonStyle.secondary,
+        custom_id="blackjack_panel:status",
+        row=1,
+    )
+    async def btn_status(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        guild_id = interaction.guild_id or 0
+        tourn = get_active_tournament(guild_id)
+        if tourn is None:
+            await interaction.response.send_message(
+                "No active Blackjack tournament in this server.",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.edit_message(
+            embed=_tourn_embed(tourn),
             view=self,
         )
 
@@ -142,7 +529,7 @@ class BlackjackPanelView(HubView):
         label="📖 Rules",
         style=discord.ButtonStyle.secondary,
         custom_id="blackjack_panel:rules",
-        row=0,
+        row=1,
     )
     async def btn_rules(
         self,
@@ -154,18 +541,9 @@ class BlackjackPanelView(HubView):
             view=self,
         )
 
-    @discord.ui.button(
-        label="◀ Overview",
-        style=discord.ButtonStyle.secondary,
-        custom_id="blackjack_panel:overview",
-        row=0,
-    )
-    async def btn_overview(
-        self,
-        interaction: discord.Interaction,
-        _button: discord.ui.Button,
-    ) -> None:
-        await interaction.response.edit_message(
-            embed=build_blackjack_overview_embed(),
-            view=self,
-        )
+
+__all__ = [
+    "BlackjackPanelView",
+    "build_blackjack_overview_embed",
+    "build_blackjack_rules_embed",
+]

--- a/tests/unit/help/test_help_actionability_contract.py
+++ b/tests/unit/help/test_help_actionability_contract.py
@@ -348,14 +348,6 @@ async def _build_panel_for(
 # ---------------------------------------------------------------------------
 
 
-_BLACKJACK_XFAIL = pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Resolved in PR 5 — BlackjackPanelView becomes actionable "
-        "(Solo Free / Solo Bet / Challenge Player / Tournament / "
-        "Status). Remove this xfail when PR 5 lands."
-    ),
-)
 _DEATHMATCH_XFAIL = pytest.mark.xfail(
     strict=True,
     reason=(
@@ -371,7 +363,7 @@ _DEATHMATCH_XFAIL = pytest.mark.xfail(
     "subsystem",
     [
         pytest.param("rps_tournament"),
-        pytest.param("blackjack", marks=_BLACKJACK_XFAIL),
+        pytest.param("blackjack"),
         pytest.param("deathmatch", marks=_DEATHMATCH_XFAIL),
         pytest.param("mining"),
         pytest.param("counting"),
@@ -398,15 +390,11 @@ async def test_games_subsystem_panel_is_actionable(subsystem: str) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Resolved in PR 5 — BlackjackPanelView.btn_classic no longer "
-        "renders a 'type !blackjack <bet>' instruction-only embed. "
-        "Remove this xfail when PR 5 lands."
-    ),
-)
-async def test_blackjack_classic_button_is_actionable_not_instruction_only() -> None:
+async def test_blackjack_panel_solo_free_spawns_new_view() -> None:
+    """PR 5 regression pin: Solo Free Play must spawn ``BlackjackView``
+    (a new playable view) rather than swap an instruction embed in
+    place.
+    """
     from views.games import blackjack_panel
 
     panel = blackjack_panel.BlackjackPanelView(
@@ -416,13 +404,34 @@ async def test_blackjack_classic_button_is_actionable_not_instruction_only() -> 
         c
         for c in panel.children
         if isinstance(c, discord.ui.Button)
-        and (c.custom_id or "").endswith(":classic")
+        and (c.custom_id or "").endswith(":solo_free")
     )
     klass = await _classify_button(btn, panel)
     assert klass in ACTION_CLASSES, (
-        f"BlackjackPanelView 'Classic' button classifies as {klass!r}; "
-        "must be action_* (PR 5 wires Solo Free / Solo Bet to "
-        "BlackjackView directly)."
+        f"BlackjackPanelView 'Solo Free Play' button classifies as "
+        f"{klass!r}; must be action_* — should spawn BlackjackView "
+        "directly."
+    )
+
+
+@pytest.mark.asyncio
+async def test_blackjack_panel_solo_bet_opens_preset_view() -> None:
+    """PR 5 regression pin: Solo Bet must open the preset sub-view."""
+    from views.games import blackjack_panel
+
+    panel = blackjack_panel.BlackjackPanelView(
+        SimpleNamespace(id=111, display_name="tester")
+    )
+    btn = next(
+        c
+        for c in panel.children
+        if isinstance(c, discord.ui.Button)
+        and (c.custom_id or "").endswith(":solo_bet")
+    )
+    klass = await _classify_button(btn, panel)
+    assert klass in ACTION_CLASSES, (
+        f"BlackjackPanelView 'Solo Bet' button classifies as {klass!r}; "
+        "must be action_* — should open the bet preset sub-view."
     )
 
 


### PR DESCRIPTION
## Summary

- Replace router-only `BlackjackPanelView` with an actionable launcher: Solo Free Play, Solo Bet, Challenge Player, Tournament, Status, Rules.
- Add `disbot/cogs/blackjack/actions.py` — shared helpers (`start_solo_blackjack`, `build_blackjack_challenge_view`, `open_blackjack_tournament`, `get_active_tournament`) that wrap the same engine state the cog command bodies use.
- Remove Blackjack xfails from PR 1's actionability contract.

## Scope table

| Does | Does NOT |
|---|---|
| Make Blackjack playable from Help/Games via buttons | Touch RPS or Deathmatch |
| Reuse `BlackjackView`, `_ChallengeView`, `_TournRegistrationView`, `_Game`, `_BjTournament`, `_active`, `_pvp`, `_tournaments` | Change rules / hand evaluation |
| Mirror the cog command bodies in helpers (including natural-blackjack auto-payout) | Add new commands |
| Tournament admin button uses the same engine path as `!bjtournament` (timer task, registration message) | Change `BlackjackCog.blackjack` / `BlackjackCog.bjtournament` bodies |
| Drop Blackjack xfails from PR 1's contract | Touch RPS / Deathmatch panels |

## Files changed

- `disbot/cogs/blackjack/actions.py` — **new** (286 LOC) with `SoloStartResult`, `TournamentStartResult`, four helpers, `get_active_tournament`.
- `disbot/views/games/blackjack_panel.py` — full rewrite (461 LOC). New classes: `_BlackjackBetPresetView`, `_BlackjackBetPresetButton`, `_BlackjackBetCustomButton`, `_BlackjackCustomBetModal`, `_BlackjackChallengeSelectView`, `_BlackjackOpponentSelect`, `_BlackjackTournamentSubView`, `_BlackjackTournamentOpenButton`, `_BlackjackBackToPanelButton`.
- `tests/unit/help/test_help_actionability_contract.py` — remove `_BLACKJACK_XFAIL`; replace `:classic` regression xfail with positive assertions for `:solo_free` and `:solo_bet`.

## Architecture impact

**Additive.** Public surface (`BlackjackPanelView` class) preserved. New actions module is a thin wrapper over existing engine state. No DB writes from view code; all writes go through `economy_service`, `tournament_state_service`, and the existing persistence layer.

## Tests run

```
python -m pytest -q                                # 2556 passed, 5 xfailed
python -m pytest tests/unit/help/ tests/unit/views/ -q   # all green
ruff check . --exclude .github,tests,venv,env,build,dist   # All checks passed
black --check . --exclude '...'                            # 286 files unchanged
isort --check-only .                                       # passed
fresh-venv mypy disbot/                                    # 287 source files, 0 issues
```

## Manual Discord smoke checklist

- [ ] Help → Games → Blackjack → Solo Free Play → BlackjackView Hit/Stand/Double (PENDING — no live runtime).
- [ ] Solo Bet preset (10/25/50/100) starts game with bet (PENDING).
- [ ] Solo Bet → Custom opens modal, validates integer (PENDING).
- [ ] Already-playing check returns ephemeral (PENDING).
- [ ] Challenge Player → UserSelect → opens `_ChallengeView` (PENDING).
- [ ] Tournament → admin sees "Open Registration", click spawns `_TournRegistrationView` + ✅ reaction (PENDING).
- [ ] Non-admin Tournament shows status-only embed (PENDING).
- [ ] Status button shows existing tournament if any (PENDING).
- [ ] `!blackjack`, `!bj`, `!bjtournament`, `!bjstart`, `!bjstatus` all still work unchanged (PENDING).
- [ ] Back chain: panel → sub-view → Back to Blackjack → Games → Help (PENDING).

## Rollback plan

`git revert <merge-commit>`. Panel reverts to router-only; new actions module is harmless if left in place (no callers in cog code).

## Out of scope

- PvP bet picker (deferred — challenges currently start with bet=0).
- Tournament parameter customization on the panel (entry_fee / rounds / mins) — admin can still use `!bjtournament <args>`.
- Game Leaderboards / Game Settings (deferred to PR 8 / PR 9).

## Follow-up items

- PR 6: Deathmatch playable panel + bot duels.

## CI status

Pending — subscribing after creation.

## Risk level

**Medium-high.** New helpers wrap engine state used by both cog commands and panel buttons. Mitigated by reusing the exact same `_Game` / `_BjTournament` / `_active` / `_pvp` / `_tournaments` paths the cog command bodies use; no parallel state.

## User-visible behavior change

**Yes.** Help → Games → Blackjack now opens a playable launcher. Existing `!blackjack` / `!bj` / `!bjtournament` / `!bjstart` / `!bjstatus` commands unchanged.

## Slash sync or deploy action required

**No.**

https://claude.ai/code/session_011QAYCgaMJ6GkhWtJZeRGVq

---
_Generated by [Claude Code](https://claude.ai/code/session_011QAYCgaMJ6GkhWtJZeRGVq)_