### PR TITLE
views: migrate Blackjack + Deathmatch back-buttons to shared helper

### DIFF
--- a/disbot/views/games/blackjack_panel.py
+++ b/disbot/views/games/blackjack_panel.py
@@ -37,6 +37,7 @@ from cogs.blackjack.actions import (
 from utils.ui_constants import GAME_COLOR
 from views.base import HubView
 from views.blackjack.embeds import _tourn_embed
+from views.games.common import BackToPanelButton
 
 logger = logging.getLogger("bot.views.games.blackjack_panel")
 
@@ -176,7 +177,7 @@ class _BlackjackBetPresetView(HubView):
         for preset in _BET_PRESETS:
             self.add_item(_BlackjackBetPresetButton(preset))
         self.add_item(_BlackjackBetCustomButton())
-        self.add_item(_BlackjackBackToPanelButton())
+        self.add_item(_make_blackjack_back_button())
 
 
 class _BlackjackBetPresetButton(discord.ui.Button):
@@ -281,7 +282,7 @@ class _BlackjackChallengeSelectView(HubView):
     def __init__(self, author: discord.Member | discord.User) -> None:
         super().__init__(author)
         self.add_item(_BlackjackOpponentSelect())
-        self.add_item(_BlackjackBackToPanelButton())
+        self.add_item(_make_blackjack_back_button())
 
 
 class _BlackjackOpponentSelect(discord.ui.UserSelect):
@@ -337,7 +338,7 @@ class _BlackjackTournamentSubView(HubView):
         super().__init__(author)
         if is_admin and not has_active:
             self.add_item(_BlackjackTournamentOpenButton())
-        self.add_item(_BlackjackBackToPanelButton())
+        self.add_item(_make_blackjack_back_button())
 
 
 class _BlackjackTournamentOpenButton(discord.ui.Button):
@@ -392,22 +393,17 @@ class _BlackjackTournamentOpenButton(discord.ui.Button):
             result.tournament.reg_message = interaction.message
 
 
-class _BlackjackBackToPanelButton(discord.ui.Button):
-    def __init__(self) -> None:
-        super().__init__(
-            label="◀ Back to Blackjack",
-            style=discord.ButtonStyle.secondary,
-            custom_id="blackjack_panel:back",
-            row=4,
-        )
-
-    async def callback(self, interaction: discord.Interaction) -> None:
-        parent_view = self.view
-        author = getattr(parent_view, "_author", interaction.user)
-        await interaction.response.edit_message(
-            embed=build_blackjack_overview_embed(),
-            view=BlackjackPanelView(author),
-        )
+def _make_blackjack_back_button() -> BackToPanelButton:
+    """Return a fresh "◀ Back to Blackjack" button for any Blackjack
+    sub-view. Follow-up to PR 7 — Blackjack now uses the shared
+    helper from ``views.games.common`` alongside RPS.
+    """
+    return BackToPanelButton(
+        label="◀ Back to Blackjack",
+        custom_id="blackjack_panel:back",
+        panel_builder=BlackjackPanelView,
+        overview_builder=build_blackjack_overview_embed,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/disbot/views/games/deathmatch_panel.py
+++ b/disbot/views/games/deathmatch_panel.py
@@ -30,6 +30,7 @@ from cogs.deathmatch.actions import (
 from cogs.deathmatch_cog import Deathmatch, _ChallengeView, _Duel
 from utils.ui_constants import GAME_COLOR
 from views.base import HubView
+from views.games.common import BackToPanelButton
 
 logger = logging.getLogger("bot.views.games.deathmatch_panel")
 
@@ -286,7 +287,7 @@ class _DeathmatchChallengeSelectView(HubView):
     def __init__(self, author: discord.Member | discord.User) -> None:
         super().__init__(author)
         self.add_item(_DeathmatchOpponentSelect())
-        self.add_item(_DeathmatchBackToPanelButton())
+        self.add_item(_make_deathmatch_back_button())
 
 
 class _DeathmatchOpponentSelect(discord.ui.UserSelect):
@@ -365,22 +366,17 @@ def _resolve_deathmatch_cog(
     return None
 
 
-class _DeathmatchBackToPanelButton(discord.ui.Button):
-    def __init__(self) -> None:
-        super().__init__(
-            label="◀ Back to Deathmatch",
-            style=discord.ButtonStyle.secondary,
-            custom_id="deathmatch_panel:back",
-            row=4,
-        )
-
-    async def callback(self, interaction: discord.Interaction) -> None:
-        parent_view = self.view
-        author = getattr(parent_view, "_author", interaction.user)
-        await interaction.response.edit_message(
-            embed=build_deathmatch_overview_embed(),
-            view=DeathmatchPanelView(author),
-        )
+def _make_deathmatch_back_button() -> BackToPanelButton:
+    """Return a fresh "◀ Back to Deathmatch" button for any Deathmatch
+    sub-view. Follow-up to PR 7 — Deathmatch now uses the shared
+    helper from ``views.games.common`` alongside RPS and Blackjack.
+    """
+    return BackToPanelButton(
+        label="◀ Back to Deathmatch",
+        custom_id="deathmatch_panel:back",
+        panel_builder=DeathmatchPanelView,
+        overview_builder=build_deathmatch_overview_embed,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/views/test_games_common.py
+++ b/tests/unit/views/test_games_common.py
@@ -138,3 +138,87 @@ async def test_rps_tournament_subview_includes_back_to_panel_button():
     )
     backs = [c for c in sub.children if isinstance(c, BackToPanelButton)]
     assert len(backs) == 1
+
+
+# ---------------------------------------------------------------------------
+# Blackjack + Deathmatch migrations (follow-up to PR 7)
+# ---------------------------------------------------------------------------
+
+
+def test_blackjack_bet_preset_view_includes_shared_back_button():
+    """Follow-up to PR 7: Blackjack now uses the shared
+    ``BackToPanelButton`` helper instead of its local
+    ``_BlackjackBackToPanelButton`` class.
+    """
+    from views.games.blackjack_panel import _BlackjackBetPresetView
+
+    view = _BlackjackBetPresetView(_author())  # type: ignore[arg-type]
+    backs = [c for c in view.children if isinstance(c, BackToPanelButton)]
+    assert len(backs) == 1
+    assert backs[0].custom_id == "blackjack_panel:back"
+
+
+def test_blackjack_challenge_select_view_includes_shared_back_button():
+    from views.games.blackjack_panel import _BlackjackChallengeSelectView
+
+    view = _BlackjackChallengeSelectView(_author())  # type: ignore[arg-type]
+    backs = [c for c in view.children if isinstance(c, BackToPanelButton)]
+    assert len(backs) == 1
+
+
+def test_blackjack_tournament_subview_includes_shared_back_button():
+    from views.games.blackjack_panel import _BlackjackTournamentSubView
+
+    sub = _BlackjackTournamentSubView(
+        _author(),  # type: ignore[arg-type]
+        is_admin=False,
+        has_active=False,
+    )
+    backs = [c for c in sub.children if isinstance(c, BackToPanelButton)]
+    assert len(backs) == 1
+
+
+def test_deathmatch_challenge_select_view_includes_shared_back_button():
+    from views.games.deathmatch_panel import _DeathmatchChallengeSelectView
+
+    view = _DeathmatchChallengeSelectView(_author())  # type: ignore[arg-type]
+    backs = [c for c in view.children if isinstance(c, BackToPanelButton)]
+    assert len(backs) == 1
+    assert backs[0].custom_id == "deathmatch_panel:back"
+
+
+@pytest.mark.asyncio
+async def test_blackjack_back_button_returns_blackjack_panel():
+    """The Blackjack back button must rebuild ``BlackjackPanelView``
+    on click — pin the helper wiring across the migration.
+    """
+    from views.games.blackjack_panel import (
+        BlackjackPanelView,
+        _BlackjackBetPresetView,
+    )
+
+    author = _author(42)
+    parent = _BlackjackBetPresetView(author)  # type: ignore[arg-type]
+    btn = next(c for c in parent.children if isinstance(c, BackToPanelButton))
+    interaction = _stub_interaction(author)
+    await btn.callback(interaction)
+    interaction.response.edit_message.assert_awaited_once()
+    _args, kwargs = interaction.response.edit_message.call_args
+    assert isinstance(kwargs["view"], BlackjackPanelView)
+
+
+@pytest.mark.asyncio
+async def test_deathmatch_back_button_returns_deathmatch_panel():
+    from views.games.deathmatch_panel import (
+        DeathmatchPanelView,
+        _DeathmatchChallengeSelectView,
+    )
+
+    author = _author(42)
+    parent = _DeathmatchChallengeSelectView(author)  # type: ignore[arg-type]
+    btn = next(c for c in parent.children if isinstance(c, BackToPanelButton))
+    interaction = _stub_interaction(author)
+    await btn.callback(interaction)
+    interaction.response.edit_message.assert_awaited_once()
+    _args, kwargs = interaction.response.edit_message.call_args
+    assert isinstance(kwargs["view"], DeathmatchPanelView)


### PR DESCRIPTION
## Summary

- Migrate `_BlackjackBackToPanelButton` and `_DeathmatchBackToPanelButton` to the shared `BackToPanelButton` helper introduced in PR #170 (PR 7 of the actionability sweep).
- Documented follow-up from PR #172's roadmap doc — now actionable because PRs #168 (Blackjack), #169 (Deathmatch), and #170 (BackToPanelButton helper) are all merged.

## Scope table

| Does | Does NOT |
|---|---|
| Replace 2 local back-button classes with shared helper | Add new behaviour |
| Add tests pinning the migration for both games | Touch RPS panel (already uses helper) |
| Reuse the existing `BackToPanelButton` from `views.games.common` | Add `BetPresetView` / `OpponentSelectView` (not enough callers per plan §2.9.1) |
| Verify the rebuilt panel type on back click | Change custom_ids or labels (preserved verbatim) |

## Files changed

- `disbot/views/games/blackjack_panel.py` — replace `_BlackjackBackToPanelButton` with `_make_blackjack_back_button()` factory.
- `disbot/views/games/deathmatch_panel.py` — replace `_DeathmatchBackToPanelButton` with `_make_deathmatch_back_button()` factory.
- `tests/unit/views/test_games_common.py` — 6 new tests pinning the migration for both games.

## Architecture impact

**Pure refactor.** Three callers of `BackToPanelButton` now (RPS, Blackjack, Deathmatch); confirms the PR 7 extraction's evidence-driven decision. Total LOC reduction: ~36 lines (3 class defs → 2 factory funcs).

## Tests run

```
python -m pytest -q                                        # 2591 passed
python -m pytest tests/unit/views/test_games_common.py -v  # 12 passed
ruff check . --exclude .github,tests,venv,env,build,dist   # All checks passed
black --check . --exclude '...'                            # 293 files unchanged
isort --check-only .                                       # passed
fresh-venv mypy disbot/                                    # 294 source files, 0 issues
```

## Manual Discord smoke checklist

- [ ] Help → Games → Blackjack → Solo Bet → Back to Blackjack → main Blackjack panel (PENDING — no live runtime).
- [ ] Help → Games → Blackjack → Challenge Player → Back to Blackjack → main panel (PENDING).
- [ ] Help → Games → Blackjack → Tournament → Back to Blackjack → main panel (PENDING).
- [ ] Help → Games → Deathmatch → Challenge Player → Back to Deathmatch → main Deathmatch panel (PENDING).

## Rollback plan

`git revert <merge-commit>`. The two factory functions revert to local classes; the shared helper is unaffected (RPS still uses it).

## Out of scope

- `BetPresetView` extraction (still only RPS + Blackjack use it; KISS extraction threshold per plan §2.9.1 is "second caller exists with identical shape", but the modal/preset logic differs slightly — defer).
- `OpponentSelectView` extraction (each game has different post-select validation; one-size-fits-all factory would lose clarity).
- Additional game settings — each blocked on runtime read wiring per plan §2.12.

## Follow-up items

- None tracked. The other "deferred — next session candidates" items in PR #172's roadmap doc (inventory redesign, RPS canonical-key migration, RPS package move, bot-duel difficulty, Game Leaderboards button, full setup wizard) all require larger scoping work and are appropriate for the next session.

## CI status

Pending — subscribing after creation.

## Risk level

**Low.** Pure refactor with identical behavior; back buttons preserve their labels and custom_ids verbatim.

## User-visible behavior change

**No.**

## Slash sync or deploy action required

**No.**

https://claude.ai/code/session_011QAYCgaMJ6GkhWtJZeRGVq

---
_Generated by [Claude Code](https://claude.ai/code/session_011QAYCgaMJ6GkhWtJZeRGVq)_