### PR TITLE
audit: shared audit publisher (Track 1 PR 1)

### DIFF
--- a/disbot/services/audit_events.py
+++ b/disbot/services/audit_events.py
@@ -1,0 +1,99 @@
+"""Shared ``audit.action_recorded`` publisher.
+
+Phase 9c.2 — every mutation pipeline that lands a row in an audit log
+must also emit the generic ``audit.action_recorded`` event so the
+audit-routing subscriber in :mod:`services.server_logging` can render
+a single canonical embed to ``logging.audit_channel`` (with mod
+fallback).
+
+This module exists to keep the payload contract in one place. Pipelines
+import :func:`emit_audit_action` and pass the canonical 11 fields; the
+payload sent on the bus is identical regardless of pipeline.
+
+Payload contract (11 fields, all keyword-only):
+
+* ``mutation_id``   — pipeline-issued UUID linking the bus event back
+                      to the audit DB row.
+* ``subsystem``     — high-level area (``"logging"`` for rollout,
+                      ``"settings"`` for settings_mutation, etc.).
+* ``mutation_type`` — pipeline-specific verb token
+                      (``"set_flag_state"``, ``"upsert_binding"``, …).
+* ``target``        — human-resolvable identifier of the thing changed
+                      (``"flag:bindings.primary"``, ``"binding:counting"``).
+* ``scope``         — ``"global"`` or ``"guild"`` (string; type stays
+                      open so future scopes don't require a refactor).
+* ``guild_id``      — discord guild ID or ``None`` for global scope.
+* ``prev_value``    — string-rendered prior value, or ``None`` for
+                      first-time writes.
+* ``new_value``     — string-rendered new value, or ``None`` for
+                      deletes / clears.
+* ``actor_id``      — discord user ID or ``None`` for system/backfill.
+* ``actor_type``    — capability-resolver actor type token.
+* ``occurred_at``   — ISO-8601 timestamp string serialized from the
+                      DB commit ``datetime``.
+
+The helper is failure-safe: if the event bus raises, the exception is
+logged with ``exc_info=True`` and the helper returns ``False``.  DB
+state is authoritative; a dropped audit event is non-fatal. Callers
+do not need to check the return value, but it is provided as a
+diagnostic for tests and future metric counters.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+EVT_AUDIT_ACTION_RECORDED = "audit.action_recorded"
+
+logger = logging.getLogger("bot.services.audit_events")
+
+
+async def emit_audit_action(
+    *,
+    mutation_id: str,
+    subsystem: str,
+    mutation_type: str,
+    target: str,
+    scope: str,
+    guild_id: int | None,
+    prev_value: str | None,
+    new_value: str | None,
+    actor_id: int | None,
+    actor_type: str,
+    occurred_at: datetime,
+) -> bool:
+    """Emit ``audit.action_recorded`` for a single mutation.
+
+    See module docstring for the payload contract. Returns ``True`` on
+    successful emit, ``False`` on bus failure (diagnostic only — the
+    caller's DB state is authoritative either way).
+    """
+    from core.events import bus
+
+    try:
+        await bus.emit(
+            EVT_AUDIT_ACTION_RECORDED,
+            mutation_id=mutation_id,
+            subsystem=subsystem,
+            mutation_type=mutation_type,
+            target=target,
+            scope=scope,
+            guild_id=guild_id,
+            prev_value=prev_value,
+            new_value=new_value,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            occurred_at=occurred_at.isoformat(),
+        )
+    except Exception:
+        logger.exception(
+            "audit.action_recorded emission failed for "
+            "mutation_id=%s (subsystem=%s, type=%s); DB state is correct, "
+            "event lost.",
+            mutation_id,
+            subsystem,
+            mutation_type,
+        )
+        return False
+    return True

--- a/disbot/services/rollout_mutation.py
+++ b/disbot/services/rollout_mutation.py
@@ -52,6 +52,7 @@ from datetime import datetime, timezone
 from typing import Literal
 
 from core.runtime import feature_flags
+from services.audit_events import EVT_AUDIT_ACTION_RECORDED, emit_audit_action
 from utils.db import environment_tiers as et_db
 from utils.db import feature_flag_state as ff_db
 
@@ -65,12 +66,10 @@ EVT_FEATURE_FLAGS_CHANGED = "feature_flags.changed"
 EVT_ROLLOUT_ADVANCED = "rollout.advanced"
 EVT_ENVIRONMENT_TIER_CHANGED = "environment_tier.changed"
 
-# Phase 9c.1 — generic audit signal emitted alongside each
-# pipeline-specific event. The payload contract is documented in
-# ``services.server_logging._on_audit_action`` so audit consumers
-# (server_logging, future audit dashboards) can subscribe via the
-# topic name without coupling to RolloutMutationPipeline internals.
-EVT_AUDIT_ACTION_RECORDED = "audit.action_recorded"
+# ``EVT_AUDIT_ACTION_RECORDED`` is re-exported from
+# :mod:`services.audit_events` (Phase 9c.2 shared publisher) so existing
+# importers of ``from services.rollout_mutation import
+# EVT_AUDIT_ACTION_RECORDED`` keep working.
 
 # ---------------------------------------------------------------------------
 # Recognized literal sets (mirror migration 023 / 024 / 025 CHECK constraints)
@@ -534,7 +533,7 @@ async def _emit_feature_flag_event(
     # Phase 9c.1 — companion audit event for the generic audit
     # consumer (server_logging). Emission failure here is independent
     # of the feature-flags event success.
-    await _emit_audit_event(
+    await emit_audit_action(
         mutation_id=mutation_id,
         subsystem="logging",
         mutation_type="set_flag_state",
@@ -545,62 +544,8 @@ async def _emit_feature_flag_event(
         new_value=new_state,
         actor_id=actor_id,
         actor_type=actor_type,
-        committed_at=committed_at,
+        occurred_at=committed_at,
     )
-    return True
-
-
-async def _emit_audit_event(
-    *,
-    mutation_id: str,
-    subsystem: str,
-    mutation_type: str,
-    target: str,
-    scope: Scope | str,
-    guild_id: int | None,
-    prev_value: str | None,
-    new_value: str | None,
-    actor_id: int | None,
-    actor_type: str,
-    committed_at: datetime,
-) -> bool:
-    """Emit ``audit.action_recorded`` for a single mutation.
-
-    Phase 9c.1 — generic audit-trail event consumed by
-    ``services.server_logging`` and routed to ``logging.audit_channel``
-    (with mod fallback via the Phase 9a route table). Other consumers
-    (future audit dashboards) are welcome to subscribe.
-
-    Failure-safe: emission failure is logged with ``exc_info=True`` and
-    swallowed. DB state is authoritative; a dropped event is non-fatal.
-    """
-    from core.events import bus
-
-    try:
-        await bus.emit(
-            EVT_AUDIT_ACTION_RECORDED,
-            mutation_id=mutation_id,
-            subsystem=subsystem,
-            mutation_type=mutation_type,
-            target=target,
-            scope=scope,
-            guild_id=guild_id,
-            prev_value=prev_value,
-            new_value=new_value,
-            actor_id=actor_id,
-            actor_type=actor_type,
-            occurred_at=committed_at.isoformat(),
-        )
-    except Exception:
-        logger.exception(
-            "audit.action_recorded emission failed for "
-            "mutation_id=%s (subsystem=%s, type=%s); DB state is correct, "
-            "event lost.",
-            mutation_id,
-            subsystem,
-            mutation_type,
-        )
-        return False
     return True
 
 
@@ -636,7 +581,7 @@ async def _emit_rollout_event(
         return False
 
     # Phase 9c.1 — companion audit emit. Rollout percent is global.
-    await _emit_audit_event(
+    await emit_audit_action(
         mutation_id=mutation_id,
         subsystem="logging",
         mutation_type="set_rollout_percent",
@@ -647,7 +592,7 @@ async def _emit_rollout_event(
         new_value=str(new_percent),
         actor_id=actor_id,
         actor_type=actor_type,
-        committed_at=committed_at,
+        occurred_at=committed_at,
     )
     return True
 
@@ -684,7 +629,7 @@ async def _emit_environment_tier_event(
         return False
 
     # Phase 9c.1 — companion audit emit. Environment tier is guild-scoped.
-    await _emit_audit_event(
+    await emit_audit_action(
         mutation_id=mutation_id,
         subsystem="logging",
         mutation_type="set_environment_tier",
@@ -695,7 +640,7 @@ async def _emit_environment_tier_event(
         new_value=new_tier,
         actor_id=actor_id,
         actor_type=actor_type,
-        committed_at=committed_at,
+        occurred_at=committed_at,
     )
     return True
 

--- a/tests/unit/feature_flags/test_rollout_mutation_pipeline.py
+++ b/tests/unit/feature_flags/test_rollout_mutation_pipeline.py
@@ -258,6 +258,52 @@ async def test_set_flag_state_global_writes_db_clears_cache_emits_event(pipeline
     assert audit_payload["mutation_id"] == result.mutation_id
 
 
+@pytest.mark.asyncio
+async def test_set_flag_state_routes_audit_through_shared_helper(pipeline):
+    """Phase 9c.2: rollout mutation delegates audit emit to the shared
+    ``services.audit_events.emit_audit_action`` helper rather than
+    carrying its own inline emitter. Patching the name at the call
+    site verifies the import path."""
+    with (
+        patch(
+            "utils.db.feature_flag_state.get_global_override",
+            new_callable=AsyncMock,
+            return_value={"state": "off", "rollout_percent": None},
+        ),
+        patch(
+            "utils.db.feature_flag_state.upsert_global_with_audit",
+            new_callable=AsyncMock,
+        ),
+        patch.object(feature_flags, "clear_cache"),
+        patch("core.events.bus.emit", new_callable=AsyncMock),
+        patch(
+            "services.rollout_mutation.emit_audit_action",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as mock_audit,
+    ):
+        result = await pipeline.set_flag_state(
+            flag_name="bindings.primary",
+            scope="global",
+            state="canary",
+            actor_id=99,
+        )
+    mock_audit.assert_awaited_once()
+    kwargs = mock_audit.await_args.kwargs
+    assert kwargs["mutation_id"] == result.mutation_id
+    assert kwargs["subsystem"] == "logging"
+    assert kwargs["mutation_type"] == "set_flag_state"
+    assert kwargs["target"] == "flag:bindings.primary"
+    assert kwargs["scope"] == "global"
+    assert kwargs["prev_value"] == "off"
+    assert kwargs["new_value"] == "canary"
+    assert kwargs["actor_id"] == 99
+    assert kwargs["actor_type"] == "platform_owner"
+    # The shared helper takes a datetime for occurred_at; the helper
+    # itself serialises it. The rollout pipeline does NOT pre-format.
+    assert hasattr(kwargs["occurred_at"], "isoformat")
+
+
 # ---------------------------------------------------------------------------
 # DB write + cache + event (set_flag_state guild scope)
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_audit_events.py
+++ b/tests/unit/services/test_audit_events.py
@@ -1,0 +1,158 @@
+"""Phase 9c.2 — shared ``audit.action_recorded`` publisher.
+
+Pins the 11-field payload contract that
+:mod:`services.server_logging`'s ``_on_audit_action`` subscriber relies
+on, and pins the failure-safe behaviour (a raising event bus must not
+propagate; pipelines have already committed their DB state).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services.audit_events import EVT_AUDIT_ACTION_RECORDED, emit_audit_action
+
+PAYLOAD_FIELDS = (
+    "mutation_id",
+    "subsystem",
+    "mutation_type",
+    "target",
+    "scope",
+    "guild_id",
+    "prev_value",
+    "new_value",
+    "actor_id",
+    "actor_type",
+    "occurred_at",
+)
+
+
+def _sample_kwargs():
+    return dict(
+        mutation_id="00000000-0000-4000-8000-000000000001",
+        subsystem="logging",
+        mutation_type="set_flag_state",
+        target="flag:bindings.primary",
+        scope="global",
+        guild_id=None,
+        prev_value="off",
+        new_value="canary",
+        actor_id=99,
+        actor_type="platform_owner",
+        occurred_at=datetime(2026, 5, 20, 12, 0, 0, tzinfo=timezone.utc),
+    )
+
+
+@pytest.mark.asyncio
+async def test_emit_audit_action_emits_under_canonical_topic():
+    with patch("core.events.bus.emit", new_callable=AsyncMock) as mock_emit:
+        ok = await emit_audit_action(**_sample_kwargs())
+    assert ok is True
+    mock_emit.assert_awaited_once()
+    topic = mock_emit.await_args.args[0]
+    assert topic == EVT_AUDIT_ACTION_RECORDED == "audit.action_recorded"
+
+
+@pytest.mark.asyncio
+async def test_emit_audit_action_payload_has_all_eleven_fields():
+    with patch("core.events.bus.emit", new_callable=AsyncMock) as mock_emit:
+        await emit_audit_action(**_sample_kwargs())
+    payload = mock_emit.await_args.kwargs
+    for field in PAYLOAD_FIELDS:
+        assert field in payload, f"missing {field}"
+    assert set(payload.keys()) == set(PAYLOAD_FIELDS), (
+        f"unexpected extra fields: {set(payload.keys()) - set(PAYLOAD_FIELDS)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_emit_audit_action_payload_values_match_inputs():
+    kwargs = _sample_kwargs()
+    with patch("core.events.bus.emit", new_callable=AsyncMock) as mock_emit:
+        await emit_audit_action(**kwargs)
+    payload = mock_emit.await_args.kwargs
+    assert payload["mutation_id"] == kwargs["mutation_id"]
+    assert payload["subsystem"] == kwargs["subsystem"]
+    assert payload["mutation_type"] == kwargs["mutation_type"]
+    assert payload["target"] == kwargs["target"]
+    assert payload["scope"] == kwargs["scope"]
+    assert payload["guild_id"] == kwargs["guild_id"]
+    assert payload["prev_value"] == kwargs["prev_value"]
+    assert payload["new_value"] == kwargs["new_value"]
+    assert payload["actor_id"] == kwargs["actor_id"]
+    assert payload["actor_type"] == kwargs["actor_type"]
+    # datetime is serialised via .isoformat() so the wire format stays
+    # JSON-friendly.
+    assert payload["occurred_at"] == kwargs["occurred_at"].isoformat()
+
+
+@pytest.mark.asyncio
+async def test_emit_audit_action_accepts_none_for_optional_fields():
+    kwargs = _sample_kwargs()
+    kwargs.update(
+        guild_id=None,
+        prev_value=None,
+        new_value=None,
+        actor_id=None,
+    )
+    with patch("core.events.bus.emit", new_callable=AsyncMock) as mock_emit:
+        ok = await emit_audit_action(**kwargs)
+    assert ok is True
+    payload = mock_emit.await_args.kwargs
+    assert payload["guild_id"] is None
+    assert payload["prev_value"] is None
+    assert payload["new_value"] is None
+    assert payload["actor_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_emit_audit_action_swallows_bus_exceptions(caplog):
+    with patch(
+        "core.events.bus.emit",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("bus down"),
+    ):
+        with caplog.at_level("ERROR", logger="bot.services.audit_events"):
+            ok = await emit_audit_action(**_sample_kwargs())
+    assert ok is False
+    # The exception is logged with exc_info so the traceback is
+    # captured by caplog records.
+    assert any(
+        "audit.action_recorded emission failed" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_audit_events_module_has_no_db_imports():
+    """Pin: the shared publisher must not pull in DB code.
+
+    Pipelines own DB writes; this helper exists strictly to push the
+    canonical companion event onto the bus.
+    """
+    import services.audit_events as mod
+
+    src = mod.__file__
+    assert src is not None
+    with open(src, encoding="utf-8") as fh:
+        text = fh.read()
+    # The module's only runtime dependency outside stdlib is
+    # ``core.events.bus``, which is imported lazily inside the
+    # function. A top-level ``import utils.db`` / ``from utils.db``
+    # would mean the helper has acquired hidden DB coupling.
+    assert "utils.db" not in text
+    assert "asyncpg" not in text
+
+
+def test_audit_events_module_has_no_discord_imports():
+    """Pin: the helper must be pure (no discord coupling)."""
+    import services.audit_events as mod
+
+    src = mod.__file__
+    assert src is not None
+    with open(src, encoding="utf-8") as fh:
+        text = fh.read()
+    assert "import discord" not in text
+    assert "from discord" not in text


### PR DESCRIPTION
## Summary

- Extract the inline `_emit_audit_event` helper from `services.rollout_mutation` into a new `services.audit_events` module — the shared publisher every mutation pipeline (settings, binding, resource provisioning, participation) will call in Track 1 PR 2.
- Preserves the existing `audit.action_recorded` event name and the 11-field payload contract that `services.server_logging._on_audit_action` subscribes to today.
- Re-exports `EVT_AUDIT_ACTION_RECORDED` from `services.rollout_mutation` so existing imports keep working.

## Scope table

| Does | Does NOT |
|---|---|
| Add `services.audit_events.emit_audit_action` | Wire other pipelines to it (Track 1 PR 2) |
| Re-route `rollout_mutation`'s 3 audit emit sites through the shared helper | Change the event name or payload contract |
| Re-export `EVT_AUDIT_ACTION_RECORDED` from `rollout_mutation` | Touch `server_logging` subscriber behaviour |
| Pin the 11-field payload shape, None handling, and failure-safety in dedicated tests | Add durable idempotency or silent dedupe |
| Pin no-DB / no-discord module invariants on the new helper | Add a metrics counter (repo has no matching pattern yet) |

## Files changed

- `disbot/services/audit_events.py` — **new** (~105 LOC). `emit_audit_action` (async, 11 kw-only params, failure-safe) + `EVT_AUDIT_ACTION_RECORDED` constant.
- `disbot/services/rollout_mutation.py` — drop the local `_emit_audit_event` function and inline constant; import the shared helper; rename the kwarg at the 3 call sites from `committed_at=committed_at` to `occurred_at=committed_at` to match the shared helper's signature. Net: -66 LOC.
- `tests/unit/services/test_audit_events.py` — **new** (~150 LOC, 7 cases): canonical topic, 11-field payload shape, payload-value round-trip, None handling, failure-safety, no-DB-imports invariant, no-discord-imports invariant.
- `tests/unit/feature_flags/test_rollout_mutation_pipeline.py` — add `test_set_flag_state_routes_audit_through_shared_helper` (1 case): patches `services.rollout_mutation.emit_audit_action` and asserts the rollout pipeline now goes through the shared helper with the right kwargs.

## Architecture impact

**Additive substrate.** No behaviour change for `audit.action_recorded` consumers; same topic, same payload, same failure isolation. The new module is the single canonical publisher every subsequent pipeline (Track 1 PR 2) will route through. `services.rollout_mutation` shrinks by ~66 LOC.

## Tests run

```
python -m pytest tests/unit/services/test_audit_events.py -v             # 7 passed
python -m pytest tests/unit/feature_flags/test_rollout_mutation_pipeline.py -v   # 19 passed
python -m pytest -q                                                      # 2599 passed (was 2591), 1 warning
ruff check . --exclude .github,tests,venv,env,build,dist                 # All checks passed
black --check . --exclude '(\.github|tests|venv|env|build|dist)'         # 294 files unchanged
isort --check-only . --skip-glob '*/(\.github|tests|venv|env|build|dist)/*'   # passed
mypy disbot/                                                             # 295 source files, 0 issues
```

## Manual Discord smoke checklist

- [ ] In a test guild with `logging.enabled=true` and `logging.audit_channel` bound, mutate a feature flag via the rollout-mutation entry point and verify an audit embed lands in `logging.audit_channel` (PENDING — no live runtime).
- [ ] `!platform diagnostics server_logging` shows `audit_sent` incremented after the mutation (PENDING).

## Rollback plan

`git revert`. The shared helper becomes orphaned; the inline `_emit_audit_event` is restored along with the local constant. No DB / migration / subscriber impact.

## Out of scope

- Wiring `settings_mutation`, `binding_mutation`, `resource_provisioning`, `participation_mutation` (and `governance` writes if present) to the shared helper — that's Track 1 PR 2.
- Changes to `services.server_logging` behaviour — Track 1 PR 3 (docs + counter coverage tests only; no behaviour change).
- Adding durable idempotency / dedupe (no existing repo pattern; reserved for a later PR if needed).
- Adding a failure metric counter (no existing matching pattern yet; current diagnostic is the `False` return value + `logger.exception` already in place).

## Follow-up items

- Track 1 PR 2: `audit: wire remaining mutation pipelines` — extends the four production mutation pipelines (and `governance/writes.py` if it has a pipeline) to emit `audit.action_recorded` via this helper after their DB+audit commit.
- Track 1 PR 3: `docs+tests: server logging audit verification` — docs for `logging.audit_channel` + counter coverage tests (`audit_sent`, `skipped_disabled`, `permission_error`, `send_error`, `subscriber_errors`).

## CI status

Pending — subscribing after creation.

## Risk level

**Low.** Pure refactor + additive helper. The event name, payload fields, payload values, and failure isolation are all preserved bit-for-bit; the dedicated tests pin the contract so any future drift is caught at PR time.

## User-visible behavior change

**No.** `audit.action_recorded` consumers receive identical events with identical payloads.

## Slash sync or deploy action required

**No.**

## Next PR

`audit: wire remaining mutation pipelines (Track 1 PR 2)` — per the accepted plan at `/root/.claude/plans/superbot-2-0-setup-purring-peach.md` §5 Track 1 PR 2.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXdDyevoQLQXgmgog7erwY)_