### PR TITLE
docs+tests: server logging audit verification (Track 1 PR 3)

### DIFF
--- a/docs/server-logging.md
+++ b/docs/server-logging.md
@@ -74,6 +74,81 @@ Counters are exposed via `services.diagnostics_service` under the
 name `"server_logging"` and surface in `!platform consistency`
 (PR-10) under the "Runtime providers" section.
 
+## Audit logging (Phase 9c)
+
+A second channel slot — `logging.audit_channel` — receives the
+canonical `audit.action_recorded` event emitted by every production
+mutation pipeline (Phase 9c.1 / 9c.2). Each accepted mutation lands a
+single embed describing what was changed, by whom, with the
+pre/post values where they are not PII.
+
+### Subscriber
+
+`services.server_logging._on_audit_action` is registered on
+`audit.action_recorded` by `setup(bot)`. The handler reads the bus
+payload, resolves the channel via
+`resolve_log_channel(guild, "audit")`, and renders
+`format_audit_embed(...)`.
+
+### Routing and fallback
+
+Channel resolution uses the Phase 9a route table:
+
+1. If `logging.audit_channel` is set and resolves to a usable channel
+   → that channel.
+2. Otherwise the route table falls back to `logging.mod_channel`.
+3. If both are unset and `logging.auto_create_channels` is OFF, the
+   handler bumps `missing_channel` and returns.
+4. If `logging.auto_create_channels` is ON, `ensure_log_channel`
+   creates `bot-audit-log` (or the source-tier fallback) and binds
+   it on the fly.
+
+The subscriber itself always asks for `kind="audit"` — it never
+walks the fallback chain manually. This keeps the route table the
+single source of truth.
+
+### Payload contract
+
+`audit.action_recorded` carries 11 keyword fields, all required:
+
+| Field | Type | Notes |
+|---|---|---|
+| `mutation_id` | str (UUID) | Links the bus event to the per-pipeline DB audit row. |
+| `subsystem` | str | High-level area (`"logging"`, `"xp"`, `"governance"`, …). |
+| `mutation_type` | str | Pipeline-specific verb token (`"set_value"`, `"upsert_binding"`, `"set_flag_state"`, …). |
+| `target` | str | Human-resolvable identifier (`"setting:xp.xp_min"`, `"flag:bindings.primary"`). |
+| `scope` | str | `"global"`, `"guild"`, or a scope-type token (`"channel"`, `"category"`, …). |
+| `guild_id` | int \| None | Discord guild id, or `None` for global scope. |
+| `prev_value` | str \| None | Pre-mutation value, string-rendered. `None` for first writes / PII-shielded preferences. |
+| `new_value` | str \| None | Post-mutation value, string-rendered. `None` for clears / PII-shielded preferences. |
+| `actor_id` | int \| None | Discord user id, or `None` for system / backfill. |
+| `actor_type` | str | Capability-resolver actor type token. |
+| `occurred_at` | str (ISO-8601) | DB commit timestamp serialised by the shared publisher. |
+
+The shared publisher lives in
+`disbot/services/audit_events.py:emit_audit_action`. Every wired
+pipeline imports it directly so the payload contract stays
+identical across publishers.
+
+### Counters
+
+The `audit_sent` counter increments per delivered audit embed.
+Failure paths share the existing counters in the table above
+(`skipped_disabled`, `missing_channel`, `permission_error`,
+`send_error`, `subscriber_errors`). Operators monitor counts via
+`!platform diagnostics server_logging`.
+
+### Operator workflow (audit channel)
+
+1. Set `logging.enabled` to `true`.
+2. Set `logging.audit_channel` to your preferred audit destination
+   (typically a staff-only channel). If unset, audit embeds fall
+   back to `logging.mod_channel`.
+3. Optionally set `logging.auto_create_channels` to `true` so the
+   service can create `bot-audit-log` on demand.
+4. Verify with `!platform diagnostics server_logging` — every
+   accepted mutation should bump `audit_sent`.
+
 ## Channel provisioning
 
 When auto-create is enabled and the configured channel id is

--- a/tests/unit/services/test_server_logging_audit.py
+++ b/tests/unit/services/test_server_logging_audit.py
@@ -282,6 +282,107 @@ async def test_subscriber_counts_missing_channel():
 
 
 @pytest.mark.asyncio
+async def test_subscriber_falls_back_to_mod_channel_when_audit_unset():
+    """Phase 9a route table: ``audit`` falls back to ``mod`` when
+    ``logging.audit_channel`` is unset. The subscriber must not bypass
+    the route table — it always asks for kind="audit" and trusts
+    ``resolve_log_channel`` to do the fallback chain."""
+    bot = MagicMock()
+    guild = _guild()
+    bot.get_guild.return_value = guild
+    mod_channel = _channel(name="bot-mod-log")
+
+    seen_kinds: list[str] = []
+
+    async def fake_resolve(_guild, kind):
+        # Mimic the real route table: kind="audit" resolves to the
+        # mod channel when audit_channel is unset.
+        seen_kinds.append(kind)
+        return mod_channel
+
+    with (
+        patch.object(server_logging, "_BOT", bot),
+        patch(
+            "services.server_logging.is_enabled",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "services.server_logging.resolve_log_channel",
+            side_effect=fake_resolve,
+        ),
+    ):
+        await _on_audit_action(**_PAYLOAD)
+
+    # The subscriber asks for "audit" exactly once and does not retry
+    # with "mod" on its own — the route table owns the fallback.
+    assert seen_kinds == ["audit"]
+    mod_channel.send.assert_awaited_once()
+    snap = counters_snapshot()
+    assert snap["counters"]["audit_sent"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_subscriber_counts_send_error_on_http_exception():
+    """``discord.HTTPException`` (Discord rate limits, 5xx, etc.) on
+    ``channel.send`` bumps ``send_error`` and is swallowed."""
+    bot = MagicMock()
+    guild = _guild()
+    bot.get_guild.return_value = guild
+    channel = _channel()
+    channel.send = AsyncMock(
+        side_effect=discord.HTTPException(MagicMock(status=503), "service down"),
+    )
+
+    with (
+        patch.object(server_logging, "_BOT", bot),
+        patch(
+            "services.server_logging.is_enabled",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "services.server_logging.resolve_log_channel",
+            AsyncMock(return_value=channel),
+        ),
+    ):
+        # Must not raise.
+        await _on_audit_action(**_PAYLOAD)
+
+    snap = counters_snapshot()
+    assert snap["counters"]["send_error"] >= 1
+    assert snap["counters"]["audit_sent"] == 0
+
+
+@pytest.mark.asyncio
+async def test_subscriber_counts_send_error_on_unexpected_exception():
+    """A non-Discord ``Exception`` on ``channel.send`` (e.g. network
+    timeout from an aiohttp transport bug) is still caught and
+    counted under ``send_error``."""
+    bot = MagicMock()
+    guild = _guild()
+    bot.get_guild.return_value = guild
+    channel = _channel()
+    channel.send = AsyncMock(side_effect=RuntimeError("transport reset"))
+
+    with (
+        patch.object(server_logging, "_BOT", bot),
+        patch(
+            "services.server_logging.is_enabled",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "services.server_logging.resolve_log_channel",
+            AsyncMock(return_value=channel),
+        ),
+    ):
+        # Must not raise — the fail-safe wrapper covers BLE001.
+        await _on_audit_action(**_PAYLOAD)
+
+    snap = counters_snapshot()
+    assert snap["counters"]["send_error"] >= 1
+    assert snap["counters"]["audit_sent"] == 0
+
+
+@pytest.mark.asyncio
 async def test_subscriber_counts_permission_error():
     bot = MagicMock()
     guild = _guild()


### PR DESCRIPTION
## Summary

- Document the `logging.audit_channel` route and the Phase 9a audit→mod fallback chain in `docs/server-logging.md`.
- Pin the three remaining counter-coverage gaps for the audit subscriber: the routing-fallback contract, `send_error` on `discord.HTTPException`, and `send_error` on a non-Discord `Exception` (BLE001 fail-safe wrapper).
- No `services.server_logging` behaviour change — docs and tests only.

> Stacked on top of PR #175 (`audit: wire remaining mutation pipelines`). When that lands, GitHub will auto-rebase this PR's base to `main`.

## Scope table

| Does | Does NOT |
|---|---|
| Add an "Audit logging (Phase 9c)" section to `docs/server-logging.md` (subscriber, route table, payload contract, counters, operator workflow) | Change `services.server_logging` runtime behaviour |
| Add 3 audit-subscriber counter tests: route-table fallback, `send_error` on `HTTPException`, `send_error` on a non-Discord `Exception` | Add a metric counter beyond the existing 5 |
| Pin that the subscriber always asks for `kind="audit"` and never walks the fallback chain manually | Touch `resolve_log_channel` / route table |

## Files changed

- `docs/server-logging.md` — **+76 LOC**. New "Audit logging (Phase 9c)" section between the existing "Fail-safe guarantees" and "Channel provisioning" sections.
- `tests/unit/services/test_server_logging_audit.py` — **+100 LOC**. Three new test functions added before `test_subscriber_counts_permission_error`. Existing tests untouched.

## Architecture impact

**Documentation + test coverage only.** No production code changes. The new tests close the per-counter coverage matrix called out in the accepted plan §5 Track 1 PR 3.

## Tests run

```
python -m pytest tests/unit/services/test_server_logging_audit.py -v   # 23 passed (was 20)
python -m pytest -q                                                    # 2612 passed (was 2609), 1 warning
ruff check . --exclude .github,tests,venv,env,build,dist               # All checks passed
black --check . --exclude '(\.github|tests|venv|env|build|dist)'       # 294 files unchanged
isort --check-only . --skip-glob '*/(\.github|tests|venv|env|build|dist)/*'   # passed
mypy disbot/                                                           # 295 source files, 0 issues
```

## Manual Discord smoke checklist

- [ ] In a test guild with `logging.enabled=true` and `logging.audit_channel` bound to a staff-only channel, mutate any setting; verify the audit embed lands in `logging.audit_channel` (PENDING — no live runtime).
- [ ] Unset `logging.audit_channel` and repeat; verify the audit embed falls back to `logging.mod_channel` (PENDING).
- [ ] With `logging.enabled=false`, mutate; verify `!platform diagnostics server_logging` shows `skipped_disabled` increment and no `audit_sent` (PENDING).
- [ ] Force `discord.Forbidden` on the audit channel (e.g. by removing bot send permission); verify `permission_error` increment (PENDING).

## Rollback plan

`git revert`. Docs and tests revert cleanly; no runtime effect.

## Out of scope

- New counter buckets — the 5 existing counters already cover the failure matrix.
- Behavioural changes to `_on_audit_action` or `log_audit_event`.
- Reconciliation with `docs/roadmap_setup_platform.md` Phase 0–8 numbering — separate docs PR.

## CI status

Pending — subscribing after creation.

## Risk level

**Minimal.** Documentation + test-only PR. No source files under `disbot/` modified.

## User-visible behavior change

**No.**

## Slash sync or deploy action required

**No.**

## Next PR

`services: resource health inspector (Track 2 PR 4)` — per the accepted plan at `/root/.claude/plans/superbot-2-0-setup-purring-peach.md` §5 Track 2 PR 4. Adds the new pure-read `services.resource_health` module that produces the health-finding shape consumed by Track 2 PR 5's readiness extension.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXdDyevoQLQXgmgog7erwY)_