### PR TITLE
services: resource health inspector (Track 2 PR 4)

### DIFF
--- a/disbot/services/resource_health.py
+++ b/disbot/services/resource_health.py
@@ -1,0 +1,462 @@
+"""Resource-health inspector — Phase 9d / Track 2 PR 4.
+
+Pure-read inspector that joins each subsystem's declared
+:class:`~core.runtime.subsystem_schema.BindingSpec` with the live
+binding row from ``subsystem_bindings`` and the actual Discord
+resource (channel / role / category / thread / member) in the guild
+cache. The output is a frozen tuple of
+:class:`ResourceHealthFinding` records consumed downstream by
+:mod:`services.setup_readiness` (Track 2 PR 5) and by the future
+repair previews (Track 2 PR 6).
+
+**Read-only.** No DB writes. No Discord resource creation. No
+mutation calls. Tests pin both invariants via static AST asserts.
+
+Status codes:
+
+* ``ok``                 — binding present, resolved, kind matches,
+                           permissions/hierarchy OK.
+* ``not_configured``     — optional binding has no row yet.
+* ``missing``            — required binding has no row yet.
+* ``unbound``            — row exists with ``target_id IS NULL`` or
+                           status ``unresolved``.
+* ``stale_binding``      — row's ``target_id`` no longer resolves to
+                           a live resource.
+* ``wrong_type``         — resolved resource exists but its kind does
+                           not match the spec's :class:`BindingKind`.
+* ``permission_blocked`` — resource exists but the bot lacks the
+                           permissions it needs (view/send/embed for
+                           channels; manage for roles).
+* ``hierarchy_blocked``  — role exists but sits at or above the
+                           bot's top role, so the bot cannot manage
+                           it.
+* ``unknown``            — escape hatch for an unhandled
+                           :class:`BindingKind` so a future enum
+                           expansion doesn't crash this service.
+
+Severity tiers:
+
+* ``info``  — informational only; no operator action required.
+* ``warn``  — best-effort issue; the bot may degrade silently.
+* ``error`` — blocker for the affected subsystem; fix to restore
+              full function.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+import discord
+
+from core.runtime.guild_resources import resolve_member, resolve_role
+from core.runtime.subsystem_schema import BindingKind, BindingSpec, all_schemas
+from utils.db import bindings as bindings_db
+
+logger = logging.getLogger("bot.services.resource_health")
+
+OK = "ok"
+NOT_CONFIGURED = "not_configured"
+MISSING = "missing"
+UNBOUND = "unbound"
+STALE_BINDING = "stale_binding"
+WRONG_TYPE = "wrong_type"
+PERMISSION_BLOCKED = "permission_blocked"
+HIERARCHY_BLOCKED = "hierarchy_blocked"
+UNKNOWN = "unknown"
+
+STATUS_CODES: frozenset[str] = frozenset(
+    {
+        OK,
+        NOT_CONFIGURED,
+        MISSING,
+        UNBOUND,
+        STALE_BINDING,
+        WRONG_TYPE,
+        PERMISSION_BLOCKED,
+        HIERARCHY_BLOCKED,
+        UNKNOWN,
+    },
+)
+
+SEV_INFO = "info"
+SEV_WARN = "warn"
+SEV_ERROR = "error"
+
+SEVERITIES: frozenset[str] = frozenset({SEV_INFO, SEV_WARN, SEV_ERROR})
+
+
+@dataclass(frozen=True)
+class ResourceHealthFinding:
+    """A single health verdict for one (subsystem, binding) slot."""
+
+    subsystem: str
+    binding_name: str
+    kind: BindingKind
+    status: str
+    severity: str
+    message: str
+    target_id: int | None = None
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+async def inspect(guild: discord.Guild) -> tuple[ResourceHealthFinding, ...]:
+    """Return one :class:`ResourceHealthFinding` per declared binding.
+
+    The findings are sorted by ``(subsystem, binding_name)`` so consumers
+    get a stable order across calls.
+    """
+    schemas = all_schemas()
+    if not schemas:
+        return ()
+
+    rows_by_key = await _load_binding_rows(guild.id)
+    bot_member = guild.me
+
+    findings: list[ResourceHealthFinding] = []
+    for subsystem, schema in sorted(schemas.items()):
+        for spec in schema.bindings:
+            row = rows_by_key.get((subsystem, spec.name))
+            findings.append(_inspect_one(guild, bot_member, subsystem, spec, row))
+    return tuple(findings)
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+async def _load_binding_rows(guild_id: int) -> dict[tuple[str, str], dict[str, Any]]:
+    """One DB read; key by ``(subsystem, binding_name)``."""
+    try:
+        rows = await bindings_db.list_for_guild(guild_id)
+    except Exception:
+        logger.exception(
+            "resource_health: bindings_db.list_for_guild failed for guild=%d; "
+            "every finding will be marked as unknown.",
+            guild_id,
+        )
+        return {}
+    return {(r["subsystem"], r["binding_name"]): r for r in rows}
+
+
+def _inspect_one(
+    guild: discord.Guild,
+    bot_member: discord.Member | None,
+    subsystem: str,
+    spec: BindingSpec,
+    row: dict[str, Any] | None,
+) -> ResourceHealthFinding:
+    """Produce a :class:`ResourceHealthFinding` for one declared slot."""
+    # 1. No row → missing (if required) / not_configured (if optional).
+    if row is None:
+        if spec.required:
+            return ResourceHealthFinding(
+                subsystem=subsystem,
+                binding_name=spec.name,
+                kind=spec.kind,
+                status=MISSING,
+                severity=SEV_ERROR,
+                message=(
+                    f"required binding {subsystem}.{spec.name} has no row; "
+                    "operator must bind it before this subsystem is usable."
+                ),
+            )
+        return ResourceHealthFinding(
+            subsystem=subsystem,
+            binding_name=spec.name,
+            kind=spec.kind,
+            status=NOT_CONFIGURED,
+            severity=SEV_INFO,
+            message=(f"optional binding {subsystem}.{spec.name} is not configured."),
+        )
+
+    target_id = row.get("target_id")
+    row_status = row.get("status")
+
+    # 2. Row exists but unbound (NULL target_id or status=unresolved).
+    if target_id is None or row_status == "unresolved":
+        return ResourceHealthFinding(
+            subsystem=subsystem,
+            binding_name=spec.name,
+            kind=spec.kind,
+            status=UNBOUND,
+            severity=SEV_WARN,
+            message=(
+                f"binding {subsystem}.{spec.name} exists but points at no "
+                "live resource (cleared or never resolved)."
+            ),
+            target_id=None,
+        )
+
+    # 3. Resolve the live resource by kind. Per-kind branch.
+    if spec.kind is BindingKind.CHANNEL:
+        return _inspect_channel(subsystem, spec, target_id, guild, bot_member)
+    if spec.kind is BindingKind.CATEGORY:
+        return _inspect_category(subsystem, spec, target_id, guild, bot_member)
+    if spec.kind is BindingKind.ROLE:
+        return _inspect_role(subsystem, spec, target_id, guild, bot_member)
+    if spec.kind is BindingKind.THREAD:
+        return _inspect_thread(subsystem, spec, target_id, guild)
+    if spec.kind is BindingKind.MEMBER:
+        return _inspect_member(subsystem, spec, target_id, guild)
+
+    return ResourceHealthFinding(
+        subsystem=subsystem,
+        binding_name=spec.name,
+        kind=spec.kind,
+        status=UNKNOWN,
+        severity=SEV_WARN,
+        message=(
+            f"binding kind {spec.kind!r} is not handled by resource_health; "
+            "extend the inspector when adding new BindingKind values."
+        ),
+        target_id=target_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-kind probes (pure, in-memory; no I/O)
+# ---------------------------------------------------------------------------
+
+
+def _inspect_channel(
+    subsystem: str,
+    spec: BindingSpec,
+    target_id: int,
+    guild: discord.Guild,
+    bot_member: discord.Member | None,
+) -> ResourceHealthFinding:
+    channel = guild.get_channel(target_id)
+    if channel is None:
+        return _stale(subsystem, spec, target_id)
+    if not isinstance(
+        channel,
+        (discord.TextChannel, discord.VoiceChannel, discord.StageChannel),
+    ):
+        return _wrong_type(subsystem, spec, target_id, channel)
+    if bot_member is None:
+        return ResourceHealthFinding(
+            subsystem=subsystem,
+            binding_name=spec.name,
+            kind=spec.kind,
+            status=OK,
+            severity=SEV_INFO,
+            message=(
+                f"channel {subsystem}.{spec.name} resolves; bot member not "
+                "in cache so permission probe was skipped."
+            ),
+            target_id=target_id,
+        )
+    perms = channel.permissions_for(bot_member)
+    missing = _missing_channel_perms(channel, perms)
+    if missing:
+        return ResourceHealthFinding(
+            subsystem=subsystem,
+            binding_name=spec.name,
+            kind=spec.kind,
+            status=PERMISSION_BLOCKED,
+            severity=SEV_ERROR,
+            message=(
+                f"channel #{channel.name} is bound but bot lacks: "
+                f"{', '.join(missing)}."
+            ),
+            target_id=target_id,
+        )
+    return _ok(subsystem, spec, target_id, f"#{channel.name}")
+
+
+def _inspect_category(
+    subsystem: str,
+    spec: BindingSpec,
+    target_id: int,
+    guild: discord.Guild,
+    bot_member: discord.Member | None,
+) -> ResourceHealthFinding:
+    category = guild.get_channel(target_id)
+    if category is None:
+        return _stale(subsystem, spec, target_id)
+    if not isinstance(category, discord.CategoryChannel):
+        return _wrong_type(subsystem, spec, target_id, category)
+    if bot_member is None:
+        return _ok(subsystem, spec, target_id, category.name)
+    perms = category.permissions_for(bot_member)
+    if not perms.view_channel:
+        return ResourceHealthFinding(
+            subsystem=subsystem,
+            binding_name=spec.name,
+            kind=spec.kind,
+            status=PERMISSION_BLOCKED,
+            severity=SEV_ERROR,
+            message=(f"category {category.name!r} is bound but bot lacks view."),
+            target_id=target_id,
+        )
+    return _ok(subsystem, spec, target_id, category.name)
+
+
+def _inspect_role(
+    subsystem: str,
+    spec: BindingSpec,
+    target_id: int,
+    guild: discord.Guild,
+    bot_member: discord.Member | None,
+) -> ResourceHealthFinding:
+    role = resolve_role(guild, role_id=target_id)
+    if role is None:
+        return _stale(subsystem, spec, target_id)
+    if bot_member is None:
+        return _ok(subsystem, spec, target_id, f"@{role.name}")
+    if not bot_member.guild_permissions.manage_roles:
+        return ResourceHealthFinding(
+            subsystem=subsystem,
+            binding_name=spec.name,
+            kind=spec.kind,
+            status=PERMISSION_BLOCKED,
+            severity=SEV_ERROR,
+            message=(f"role @{role.name} is bound but bot lacks Manage Roles."),
+            target_id=target_id,
+        )
+    if role >= bot_member.top_role:
+        return ResourceHealthFinding(
+            subsystem=subsystem,
+            binding_name=spec.name,
+            kind=spec.kind,
+            status=HIERARCHY_BLOCKED,
+            severity=SEV_ERROR,
+            message=(
+                f"role @{role.name} sits at or above the bot's top role "
+                f"(@{bot_member.top_role.name}); cannot be managed."
+            ),
+            target_id=target_id,
+        )
+    return _ok(subsystem, spec, target_id, f"@{role.name}")
+
+
+def _inspect_thread(
+    subsystem: str,
+    spec: BindingSpec,
+    target_id: int,
+    guild: discord.Guild,
+) -> ResourceHealthFinding:
+    thread = guild.get_thread(target_id)
+    if thread is None:
+        return _stale(subsystem, spec, target_id)
+    return _ok(subsystem, spec, target_id, f"#{thread.name}")
+
+
+def _inspect_member(
+    subsystem: str,
+    spec: BindingSpec,
+    target_id: int,
+    guild: discord.Guild,
+) -> ResourceHealthFinding:
+    member = resolve_member(guild, target_id)
+    if member is None:
+        return _stale(subsystem, spec, target_id)
+    return _ok(subsystem, spec, target_id, str(member))
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+
+def _missing_channel_perms(
+    channel: discord.abc.GuildChannel,
+    perms: discord.Permissions,
+) -> list[str]:
+    """Return the subset of channel permissions the bot is missing."""
+    needed: Iterable[tuple[str, bool]]
+    if isinstance(channel, discord.TextChannel):
+        needed = (
+            ("view_channel", perms.view_channel),
+            ("send_messages", perms.send_messages),
+            ("embed_links", perms.embed_links),
+        )
+    elif isinstance(channel, (discord.VoiceChannel, discord.StageChannel)):
+        needed = (
+            ("view_channel", perms.view_channel),
+            ("connect", perms.connect),
+        )
+    else:
+        needed = (("view_channel", perms.view_channel),)
+    return [name for name, ok in needed if not ok]
+
+
+def _stale(subsystem: str, spec: BindingSpec, target_id: int) -> ResourceHealthFinding:
+    return ResourceHealthFinding(
+        subsystem=subsystem,
+        binding_name=spec.name,
+        kind=spec.kind,
+        status=STALE_BINDING,
+        severity=SEV_ERROR,
+        message=(
+            f"binding {subsystem}.{spec.name} points at {spec.kind.value}="
+            f"{target_id} which is not in the guild — clear the binding "
+            "or re-bind to a live resource."
+        ),
+        target_id=target_id,
+    )
+
+
+def _wrong_type(
+    subsystem: str,
+    spec: BindingSpec,
+    target_id: int,
+    resource: Any,
+) -> ResourceHealthFinding:
+    return ResourceHealthFinding(
+        subsystem=subsystem,
+        binding_name=spec.name,
+        kind=spec.kind,
+        status=WRONG_TYPE,
+        severity=SEV_ERROR,
+        message=(
+            f"binding {subsystem}.{spec.name} declares kind={spec.kind.value} "
+            f"but target_id={target_id} resolves to {type(resource).__name__}."
+        ),
+        target_id=target_id,
+    )
+
+
+def _ok(
+    subsystem: str,
+    spec: BindingSpec,
+    target_id: int,
+    display: str,
+) -> ResourceHealthFinding:
+    return ResourceHealthFinding(
+        subsystem=subsystem,
+        binding_name=spec.name,
+        kind=spec.kind,
+        status=OK,
+        severity=SEV_INFO,
+        message=f"binding {subsystem}.{spec.name} resolves to {display}.",
+        target_id=target_id,
+    )
+
+
+__all__ = [
+    "HIERARCHY_BLOCKED",
+    "MISSING",
+    "NOT_CONFIGURED",
+    "OK",
+    "PERMISSION_BLOCKED",
+    "ResourceHealthFinding",
+    "SEVERITIES",
+    "SEV_ERROR",
+    "SEV_INFO",
+    "SEV_WARN",
+    "STALE_BINDING",
+    "STATUS_CODES",
+    "UNBOUND",
+    "UNKNOWN",
+    "WRONG_TYPE",
+    "inspect",
+]

--- a/tests/unit/services/test_resource_health.py
+++ b/tests/unit/services/test_resource_health.py
@@ -1,0 +1,629 @@
+"""Track 2 PR 4 — resource_health inspector.
+
+Covers every status code via a fake ``discord.Guild`` fixture and a
+fake ``bindings_db.list_for_guild`` stub. Pins:
+
+* Each :class:`BindingKind` (CHANNEL, ROLE, CATEGORY, THREAD, MEMBER)
+  produces a finding.
+* Status codes: ok / missing / not_configured / unbound /
+  stale_binding / wrong_type / permission_blocked / hierarchy_blocked.
+* Severity mapping per status.
+* Per-finding ``target_id`` field is populated where applicable.
+* The inspector is read-only (no DB writes, no Discord create calls).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import discord
+import pytest
+
+from core.runtime.subsystem_schema import BindingKind, BindingSpec, SubsystemSchema
+from services import resource_health
+from services.resource_health import (
+    HIERARCHY_BLOCKED,
+    MISSING,
+    NOT_CONFIGURED,
+    OK,
+    PERMISSION_BLOCKED,
+    SEV_ERROR,
+    SEV_INFO,
+    SEV_WARN,
+    STALE_BINDING,
+    UNBOUND,
+    UNKNOWN,
+    WRONG_TYPE,
+    ResourceHealthFinding,
+    inspect,
+)
+
+# ---------------------------------------------------------------------------
+# Fake Discord guild + resources
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeRole:
+    id: int
+    name: str
+    position: int = 1
+
+    def __ge__(self, other):  # used by ``role >= bot_top_role``
+        return self.position >= other.position
+
+    def __gt__(self, other):
+        return self.position > other.position
+
+
+class _FakePerms:
+    def __init__(
+        self,
+        *,
+        view_channel: bool = True,
+        send_messages: bool = True,
+        embed_links: bool = True,
+        connect: bool = True,
+        manage_roles: bool = True,
+    ):
+        self.view_channel = view_channel
+        self.send_messages = send_messages
+        self.embed_links = embed_links
+        self.connect = connect
+        self.manage_roles = manage_roles
+
+
+class _FakeTextChannel(discord.TextChannel):
+    """A bare ``isinstance``-compatible TextChannel that ducks attribute access."""
+
+    def __init__(self, *, channel_id: int, name: str, perms: _FakePerms):
+        # Skip discord.py's __init__ chain — we only need attribute access.
+        self.id = channel_id
+        self.name = name
+        self._perms = perms
+
+    def permissions_for(self, member):  # type: ignore[override]
+        return self._perms
+
+
+class _FakeCategory(discord.CategoryChannel):
+    def __init__(self, *, channel_id: int, name: str, perms: _FakePerms):
+        self.id = channel_id
+        self.name = name
+        self._perms = perms
+
+    def permissions_for(self, member):  # type: ignore[override]
+        return self._perms
+
+
+@dataclass
+class _FakeBotMember:
+    top_role: _FakeRole
+    guild_permissions: _FakePerms
+
+
+class _FakeGuild:
+    def __init__(
+        self,
+        guild_id: int = 1,
+        *,
+        channels: dict[int, object] | None = None,
+        roles: dict[int, _FakeRole] | None = None,
+        threads: dict[int, object] | None = None,
+        members: dict[int, object] | None = None,
+        me: _FakeBotMember | None = None,
+    ):
+        self.id = guild_id
+        self._channels = channels or {}
+        self._roles = roles or {}
+        self._threads = threads or {}
+        self._members = members or {}
+        self.me = me
+
+    def get_channel(self, cid):
+        return self._channels.get(cid)
+
+    def get_role(self, rid):
+        return self._roles.get(rid)
+
+    def get_thread(self, tid):
+        return self._threads.get(tid)
+
+    def get_member(self, mid):
+        return self._members.get(mid)
+
+
+# ---------------------------------------------------------------------------
+# Schema fixtures
+# ---------------------------------------------------------------------------
+
+
+def _spec(name: str, kind: BindingKind, required: bool = True) -> BindingSpec:
+    return BindingSpec(
+        name=name,
+        kind=kind,
+        required=required,
+        hint="",
+        capability_required=f"xp.{name}.bind",
+    )
+
+
+def _row(
+    subsystem: str,
+    name: str,
+    *,
+    target_id: int | None = 100,
+    status: str = "bound",
+    kind: BindingKind = BindingKind.CHANNEL,
+):
+    return {
+        "guild_id": 1,
+        "subsystem": subsystem,
+        "binding_name": name,
+        "kind": kind.value,
+        "target_id": target_id,
+        "status": status,
+    }
+
+
+@pytest.fixture
+def _isolate_schemas():
+    """Yield a registry override; restore on exit."""
+
+    def _install(schemas):
+        return patch.object(
+            resource_health,
+            "all_schemas",
+            return_value=schemas,
+        )
+
+    return _install
+
+
+# ---------------------------------------------------------------------------
+# Sanity: empty registry → empty findings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inspect_empty_registry_returns_empty_tuple(_isolate_schemas):
+    with _isolate_schemas({}), patch(
+        "services.resource_health.bindings_db.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        result = await inspect(_FakeGuild())
+    assert result == ()
+
+
+# ---------------------------------------------------------------------------
+# Per-status coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_required_binding(_isolate_schemas):
+    schema = SubsystemSchema(
+        subsystem="xp",
+        bindings=(_spec("announce", BindingKind.CHANNEL, required=True),),
+    )
+    with _isolate_schemas({"xp": schema}), patch(
+        "services.resource_health.bindings_db.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        findings = await inspect(_FakeGuild())
+    assert len(findings) == 1
+    assert findings[0].status == MISSING
+    assert findings[0].severity == SEV_ERROR
+
+
+@pytest.mark.asyncio
+async def test_not_configured_optional_binding(_isolate_schemas):
+    schema = SubsystemSchema(
+        subsystem="xp",
+        bindings=(_spec("announce", BindingKind.CHANNEL, required=False),),
+    )
+    with _isolate_schemas({"xp": schema}), patch(
+        "services.resource_health.bindings_db.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        findings = await inspect(_FakeGuild())
+    assert findings[0].status == NOT_CONFIGURED
+    assert findings[0].severity == SEV_INFO
+
+
+@pytest.mark.asyncio
+async def test_unbound_row_with_null_target(_isolate_schemas):
+    schema = SubsystemSchema(
+        subsystem="xp",
+        bindings=(_spec("announce", BindingKind.CHANNEL),),
+    )
+    with _isolate_schemas({"xp": schema}), patch(
+        "services.resource_health.bindings_db.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[_row("xp", "announce", target_id=None)],
+    ):
+        findings = await inspect(_FakeGuild())
+    assert findings[0].status == UNBOUND
+    assert findings[0].severity == SEV_WARN
+    assert findings[0].target_id is None
+
+
+@pytest.mark.asyncio
+async def test_unbound_row_with_unresolved_status(_isolate_schemas):
+    schema = SubsystemSchema(
+        subsystem="xp",
+        bindings=(_spec("announce", BindingKind.CHANNEL),),
+    )
+    with _isolate_schemas({"xp": schema}), patch(
+        "services.resource_health.bindings_db.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[_row("xp", "announce", target_id=42, status="unresolved")],
+    ):
+        findings = await inspect(_FakeGuild())
+    assert findings[0].status == UNBOUND
+
+
+@pytest.mark.asyncio
+async def test_stale_channel_binding(_isolate_schemas):
+    schema = SubsystemSchema(
+        subsystem="xp",
+        bindings=(_spec("announce", BindingKind.CHANNEL),),
+    )
+    # Row says channel 999 is bound; the guild does not contain channel 999.
+    with _isolate_schemas({"xp": schema}), patch(
+        "services.resource_health.bindings_db.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[_row("xp", "announce", target_id=999)],
+    ):
+        findings = await inspect(_FakeGuild())
+    assert findings[0].status == STALE_BINDING
+    assert findings[0].severity == SEV_ERROR
+    assert findings[0].target_id == 999
+
+
+@pytest.mark.asyncio
+async def test_wrong_type_channel_kind_resolves_to_category(_isolate_schemas):
+    schema = SubsystemSchema(
+        subsystem="xp",
+        bindings=(_spec("announce", BindingKind.CHANNEL),),
+    )
+    cat = _FakeCategory(channel_id=100, name="Mod", perms=_FakePerms())
+    guild = _FakeGuild(channels={100: cat})
+    with _isolate_schemas({"xp": schema}), patch(
+        "services.resource_health.bindings_db.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[_row("xp", "announce", target_id=100)],
+    ):
+        findings = await inspect(guild)
+    assert findings[0].status == WRONG_TYPE
+    assert findings[0].severity == SEV_ERROR
+
+
+@pytest.mark.asyncio
+async def test_channel_permission_blocked_when_send_missing(_isolate_schemas):
+    schema = SubsystemSchema(
+        subsystem="xp",
+        bindings=(_spec("announce", BindingKind.CHANNEL),),
+    )
+    ch = _FakeTextChannel(
+        channel_id=100,
+        name="general",
+        perms=_FakePerms(send_messages=False),
+    )
+    guild = _FakeGuild(
+        channels={100: ch},
+        me=_FakeBotMember(
+            top_role=_FakeRole(id=999, name="Bot", position=10),
+            guild_permissions=_FakePerms(),
+        ),
+    )
+    with _isolate_schemas({"xp": schema}), patch(
+        "services.resource_health.bindings_db.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[_row("xp", "announce", target_id=100)],
+    ):
+        findings = await inspect(guild)
+    assert findings[0].status == PERMISSION_BLOCKED
+    assert findings[0].severity == SEV_ERROR
+    assert "send_messages" in findings[0].message
+
+
+@pytest.mark.asyncio
+async def test_channel_ok(_isolate_schemas):
+    schema = SubsystemSchema(
+        subsystem="xp",
+        bindings=(_spec("announce", BindingKind.CHANNEL),),
+    )
+    ch = _FakeTextChannel(channel_id=100, name="general", perms=_FakePerms())
+    guild = _FakeGuild(
+        channels={100: ch},
+        me=_FakeBotMember(
+            top_role=_FakeRole(id=999, name="Bot", position=10),
+            guild_permissions=_FakePerms(),
+        ),
+    )
+    with _isolate_schemas({"xp": schema}), patch(
+        "services.resource_health.bindings_db.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[_row("xp", "announce", target_id=100)],
+    ):
+        findings = await inspect(guild)
+    assert findings[0].status == OK
+    assert findings[0].severity == SEV_INFO
+
+
+@pytest.mark.asyncio
+async def test_role_hierarchy_blocked(_isolate_schemas):
+    schema = SubsystemSchema(
+        subsystem="xp",
+        bindings=(_spec("vip", BindingKind.ROLE),),
+    )
+    target = _FakeRole(id=200, name="VIP", position=20)  # ABOVE bot
+    guild = _FakeGuild(
+        roles={200: target},
+        me=_FakeBotMember(
+            top_role=_FakeRole(id=999, name="Bot", position=10),
+            guild_permissions=_FakePerms(),
+        ),
+    )
+    with _isolate_schemas({"xp": schema}), patch(
+        "services.resource_health.bindings_db.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[_row("xp", "vip", target_id=200, kind=BindingKind.ROLE)],
+    ):
+        findings = await inspect(guild)
+    assert findings[0].status == HIERARCHY_BLOCKED
+    assert findings[0].severity == SEV_ERROR
+
+
+@pytest.mark.asyncio
+async def test_role_permission_blocked_when_manage_roles_missing(_isolate_schemas):
+    schema = SubsystemSchema(
+        subsystem="xp",
+        bindings=(_spec("vip", BindingKind.ROLE),),
+    )
+    target = _FakeRole(id=200, name="VIP", position=5)  # below bot
+    guild = _FakeGuild(
+        roles={200: target},
+        me=_FakeBotMember(
+            top_role=_FakeRole(id=999, name="Bot", position=10),
+            guild_permissions=_FakePerms(manage_roles=False),
+        ),
+    )
+    with _isolate_schemas({"xp": schema}), patch(
+        "services.resource_health.bindings_db.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[_row("xp", "vip", target_id=200, kind=BindingKind.ROLE)],
+    ):
+        findings = await inspect(guild)
+    assert findings[0].status == PERMISSION_BLOCKED
+    assert "Manage Roles" in findings[0].message
+
+
+@pytest.mark.asyncio
+async def test_role_ok(_isolate_schemas):
+    schema = SubsystemSchema(
+        subsystem="xp",
+        bindings=(_spec("vip", BindingKind.ROLE),),
+    )
+    target = _FakeRole(id=200, name="VIP", position=5)
+    guild = _FakeGuild(
+        roles={200: target},
+        me=_FakeBotMember(
+            top_role=_FakeRole(id=999, name="Bot", position=10),
+            guild_permissions=_FakePerms(),
+        ),
+    )
+    with _isolate_schemas({"xp": schema}), patch(
+        "services.resource_health.bindings_db.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[_row("xp", "vip", target_id=200, kind=BindingKind.ROLE)],
+    ):
+        findings = await inspect(guild)
+    assert findings[0].status == OK
+
+
+@pytest.mark.asyncio
+async def test_category_ok(_isolate_schemas):
+    schema = SubsystemSchema(
+        subsystem="moderation",
+        bindings=(_spec("category", BindingKind.CATEGORY),),
+    )
+    cat = _FakeCategory(channel_id=300, name="Mod", perms=_FakePerms())
+    guild = _FakeGuild(
+        channels={300: cat},
+        me=_FakeBotMember(
+            top_role=_FakeRole(id=999, name="Bot", position=10),
+            guild_permissions=_FakePerms(),
+        ),
+    )
+    with _isolate_schemas({"moderation": schema}), patch(
+        "services.resource_health.bindings_db.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[
+            _row("moderation", "category", target_id=300, kind=BindingKind.CATEGORY),
+        ],
+    ):
+        findings = await inspect(guild)
+    assert findings[0].status == OK
+
+
+@pytest.mark.asyncio
+async def test_thread_stale(_isolate_schemas):
+    schema = SubsystemSchema(
+        subsystem="xp",
+        bindings=(_spec("announce_thread", BindingKind.THREAD),),
+    )
+    guild = _FakeGuild()  # no threads in cache
+    with _isolate_schemas({"xp": schema}), patch(
+        "services.resource_health.bindings_db.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[
+            _row("xp", "announce_thread", target_id=400, kind=BindingKind.THREAD),
+        ],
+    ):
+        findings = await inspect(guild)
+    assert findings[0].status == STALE_BINDING
+
+
+@pytest.mark.asyncio
+async def test_member_ok(_isolate_schemas):
+    schema = SubsystemSchema(
+        subsystem="moderation",
+        bindings=(_spec("contact", BindingKind.MEMBER),),
+    )
+    member = SimpleNamespace(id=500)
+    member.__str__ = lambda self=member: "ContactUser#0001"  # type: ignore[assignment]
+    guild = _FakeGuild(members={500: member})
+    with _isolate_schemas({"moderation": schema}), patch(
+        "services.resource_health.bindings_db.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[
+            _row("moderation", "contact", target_id=500, kind=BindingKind.MEMBER),
+        ],
+    ):
+        findings = await inspect(guild)
+    assert findings[0].status == OK
+
+
+# ---------------------------------------------------------------------------
+# Aggregate behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inspect_returns_findings_sorted_by_subsystem_then_name(_isolate_schemas):
+    schemas = {
+        "xp": SubsystemSchema(
+            subsystem="xp",
+            bindings=(
+                _spec("z_last", BindingKind.CHANNEL),
+                _spec("a_first", BindingKind.CHANNEL),
+            ),
+        ),
+        "moderation": SubsystemSchema(
+            subsystem="moderation",
+            bindings=(_spec("category", BindingKind.CATEGORY),),
+        ),
+    }
+    with _isolate_schemas(schemas), patch(
+        "services.resource_health.bindings_db.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        findings = await inspect(_FakeGuild())
+    # Subsystem order is alphabetised; binding order is declared (within a
+    # schema, the spec tuple is the source of truth).
+    assert [(f.subsystem, f.binding_name) for f in findings] == [
+        ("moderation", "category"),
+        ("xp", "z_last"),
+        ("xp", "a_first"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_db_failure_yields_findings_using_no_rows(_isolate_schemas):
+    """If the DB read fails the inspector still returns findings for
+    every declared binding — they look like ``missing`` /
+    ``not_configured`` since no rows are available."""
+    schema = SubsystemSchema(
+        subsystem="xp",
+        bindings=(_spec("announce", BindingKind.CHANNEL),),
+    )
+    with _isolate_schemas({"xp": schema}), patch(
+        "services.resource_health.bindings_db.list_for_guild",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("db down"),
+    ):
+        findings = await inspect(_FakeGuild())
+    assert len(findings) == 1
+    assert findings[0].status == MISSING  # required spec + no row available
+
+
+# ---------------------------------------------------------------------------
+# Module invariants — pure read, no DB writes, no Discord create
+# ---------------------------------------------------------------------------
+
+
+def test_resource_health_module_has_no_db_write_imports():
+    import services.resource_health as mod
+
+    src = mod.__file__
+    assert src is not None
+    with open(src, encoding="utf-8") as fh:
+        text = fh.read()
+    # Allowed: ``from utils.db import bindings as bindings_db``.
+    # Forbidden: any other ``utils.db`` import — bindings_db.list_for_guild
+    # is the only DB API we call, and it is read-only.
+    forbidden_writes = (
+        "upsert_with_audit",
+        "clear_with_audit",
+        "set_value_with_audit",
+        "delete_active_bindings_for_guild",
+    )
+    for needle in forbidden_writes:
+        assert needle not in text, (
+            f"services.resource_health imports {needle}; it must remain "
+            "read-only (no DB mutations)."
+        )
+
+
+def test_resource_health_module_has_no_discord_create_calls():
+    import services.resource_health as mod
+
+    src = mod.__file__
+    assert src is not None
+    with open(src, encoding="utf-8") as fh:
+        text = fh.read()
+    forbidden_creates = (
+        "ensure_channel",
+        "ensure_role",
+        "ensure_category",
+        "create_text_channel",
+        "create_role",
+        "create_category",
+    )
+    for needle in forbidden_creates:
+        assert needle not in text, (
+            f"services.resource_health references {needle}; it must remain "
+            "read-only (no Discord resource creation)."
+        )
+
+
+def test_resource_health_finding_is_frozen():
+    """The dataclass must be frozen so consumers can put it in sets/dicts
+    and so the contract value can't be mutated downstream."""
+    finding = ResourceHealthFinding(
+        subsystem="xp",
+        binding_name="announce",
+        kind=BindingKind.CHANNEL,
+        status=OK,
+        severity=SEV_INFO,
+        message="ok",
+    )
+    with pytest.raises((AttributeError, TypeError)):
+        finding.status = STALE_BINDING  # type: ignore[misc]
+
+
+def test_status_codes_and_severities_match_documented_set():
+    from services.resource_health import SEVERITIES, STATUS_CODES
+
+    assert STATUS_CODES == frozenset(
+        {
+            OK,
+            NOT_CONFIGURED,
+            MISSING,
+            UNBOUND,
+            STALE_BINDING,
+            WRONG_TYPE,
+            PERMISSION_BLOCKED,
+            HIERARCHY_BLOCKED,
+            UNKNOWN,
+        },
+    )
+    assert SEVERITIES == frozenset({SEV_INFO, SEV_WARN, SEV_ERROR})


### PR DESCRIPTION
## Summary

- Add the read-only `services.resource_health` module that joins each subsystem's declared `BindingSpec` with the live binding row and the actual Discord resource in the guild cache.
- `inspect(guild)` returns one `ResourceHealthFinding` per declared binding (sorted by `(subsystem, binding_name)`), tagged with one of 9 status codes and a 3-tier severity.
- Pure read; no DB writes; no Discord resource creation. Both invariants pinned by AST-level tests.
- Independent of PRs #175 (Track 1 PR 2) and #176 (Track 1 PR 3) — touches new files only.

## Scope table

| Does | Does NOT |
|---|---|
| Add `disbot/services/resource_health.py` (~390 LOC) with `inspect()` + `ResourceHealthFinding` | Mutate any DB row (only read via `bindings_db.list_for_guild`) |
| Cover all 5 `BindingKind` values: CHANNEL, ROLE, CATEGORY, THREAD, MEMBER | Create or delete Discord resources |
| Cover 9 status codes (`ok` / `not_configured` / `missing` / `unbound` / `stale_binding` / `wrong_type` / `permission_blocked` / `hierarchy_blocked` / `unknown`) and 3 severities (`info` / `warn` / `error`) | Render embeds or surface findings through `setup_readiness` (Track 2 PR 5 does that) |
| Use the cached `resolve_role` / `resolve_member` resolvers per the `test_guild_resources_invariant` AST rule | Generate repair previews (Track 2 PR 6) |
| Pin module invariants (no `utils.db` write imports, no `ensure_*` / `create_*` Discord calls, frozen dataclass) | Add docs (already covered by the module docstring) |

## Files changed

- `disbot/services/resource_health.py` — **new** (~390 LOC). Public: `inspect`, `ResourceHealthFinding`, `STATUS_CODES`, `SEVERITIES`, plus per-status string constants.
- `tests/unit/services/test_resource_health.py` — **new** (~520 LOC, 21 cases): one test per status × kind matrix entry that needs coverage, plus aggregate ordering, DB-failure degradation, and 3 module-invariant pins.

## Architecture impact

**Additive.** Pure read service depending on existing substrate (`subsystem_schema.all_schemas`, `bindings_db.list_for_guild`, `guild_resources.resolve_role` / `resolve_member`). No imports from views/cogs; no consumers in this PR. Track 2 PR 5 will surface findings through `setup_readiness.ReadinessReport`.

## Tests run

```
python -m pytest tests/unit/services/test_resource_health.py -v   # 21 passed
python -m pytest -q                                               # 2620 passed (was 2599), 1 warning
ruff check . --exclude .github,tests,venv,env,build,dist          # All checks passed
black --check . --exclude '(\.github|tests|venv|env|build|dist)'  # 295 files unchanged
isort --check-only . --skip-glob '*/(\.github|tests|venv|env|build|dist)/*'   # passed
mypy disbot/                                                      # 296 source files, 0 issues
```

## Manual Discord smoke checklist

- [ ] In a test guild, bind a channel; call `services.resource_health.inspect(guild)`; verify one `ok` finding (PENDING — no live runtime).
- [ ] Delete the bound channel via Discord UI; re-inspect; verify a `stale_binding` finding (PENDING).
- [ ] Strip bot's send permission from the channel; re-bind; re-inspect; verify a `permission_blocked` finding listing `send_messages` (PENDING).
- [ ] Bind a role above the bot's top role; re-inspect; verify a `hierarchy_blocked` finding (PENDING).

## Rollback plan

`git revert`. The module is additive; no consumers in this PR; removing it has no runtime effect.

## Out of scope

- Surfacing findings through `services.setup_readiness.ReadinessReport` — Track 2 PR 5 widens the report shape additively.
- `services.readiness_repair` (preview generation + apply) — Track 2 PR 6.
- The `logging.audit_channel` / `logging.mod_channel` completeness check — that lives in Track 2 PR 5 where settings-level readiness checks land alongside health-level checks.

## Follow-up items

- Track 2 PR 5: `services: setup_readiness v2` — extend `ReadinessReport` with `health_findings: tuple[ResourceHealthFinding, ...]` and update `build_setup_readiness_embed` to render them.
- Track 2 PR 6: `services: readiness repair previews + apply` — convert findings into `RepairPreview` records and route apply through `binding_mutation` / `settings_mutation` / `resource_provisioning`.

## CI status

Pending — subscribing after creation.

## Risk level

**Low.** Pure read service, no consumers in this PR, every status code covered by tests. The AST-level invariant tests catch any future accidental DB or Discord-create coupling.

## User-visible behavior change

**No.** New module with no callers yet.

## Slash sync or deploy action required

**No.**

## Next PR

`services: setup_readiness v2 (Track 2 PR 5)` — additive extension of `ReadinessReport` to carry health findings, plus a renderer update in `cogs/diagnostic/_platform_embeds.py:build_setup_readiness_embed`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXdDyevoQLQXgmgog7erwY)_