### PR TITLE
services: setup_readiness v2 — health-aware report (Track 2 PR 5)

### DIFF
--- a/disbot/cogs/diagnostic/_platform_embeds.py
+++ b/disbot/cogs/diagnostic/_platform_embeds.py
@@ -1020,19 +1020,64 @@ def _fmt_snapshot_value(value: object) -> str:
 # ---------------------------------------------------------------------------
 
 
-async def build_setup_readiness_embed(guild_id: int) -> discord.Embed:
+def _render_health_findings(embed, report) -> None:
+    """Add per-subsystem "Health · <sub>" fields for error/warn findings.
+
+    Info-only findings stay in the description blurb; only actionable
+    findings get their own field to keep the embed compact.
+    """
+    actionable = [f for f in report.health_findings if f.severity in ("error", "warn")]
+    if not actionable:
+        return
+    by_sub: dict[str, list[str]] = {}
+    for f in actionable:
+        icon = "🔴" if f.severity == "error" else "🟡"
+        by_sub.setdefault(f.subsystem, []).append(
+            f"{icon} `{f.binding_name}` · {f.status} — {f.message}",
+        )
+    for subsystem in sorted(by_sub):
+        value = "\n".join(by_sub[subsystem])
+        # 1024-char field cap; truncate generously to avoid 400s.
+        if len(value) > 1000:
+            value = value[:997] + "..."
+        embed.add_field(
+            name=f"Health · {subsystem}",
+            value=value,
+            inline=False,
+        )
+
+
+async def build_setup_readiness_embed(
+    guild_id: int,
+    *,
+    guild: discord.Guild | None = None,
+) -> discord.Embed:
     """Render a per-guild setup-readiness inventory.
 
     Calls :func:`services.setup_readiness.collect`, then formats the
     per-subsystem counts + aggregate score into an embed. Subsystems
     with no declared config show as ``—``; populated subsystems show
     ``filled/declared`` for both bindings and settings plus a percent.
+
+    When ``guild`` is provided, the embed also renders Phase 9d
+    resource-health findings grouped by subsystem and a per-severity
+    summary line.
     """
     from services import setup_readiness
 
-    report = await setup_readiness.collect(guild_id)
+    report = await setup_readiness.collect(guild_id, guild=guild)
 
     title_score = "—" if report.aggregate_score is None else f"{report.percentage}%"
+
+    summary = report.health_summary
+    health_blurb = ""
+    if summary:
+        health_blurb = (
+            f" · health "
+            f"`{summary.get('error', 0)} err`"
+            f" `{summary.get('warn', 0)} warn`"
+            f" `{summary.get('info', 0)} info`"
+        )
 
     embed = discord.Embed(
         title=f"🛰 Setup Readiness — {title_score}",
@@ -1040,9 +1085,12 @@ async def build_setup_readiness_embed(guild_id: int) -> discord.Embed:
             f"**{report.bindings_bound}/{report.bindings_declared}** bindings · "
             f"**{report.settings_configured}/{report.settings_declared}** settings · "
             f"**{report.resources_declared}** resource declarations"
+            f"{health_blurb}"
         ),
         color=discord.Color.blurple(),
     )
+
+    _render_health_findings(embed, report)
 
     if not report.per_subsystem:
         embed.add_field(

--- a/disbot/cogs/diagnostic_cog.py
+++ b/disbot/cogs/diagnostic_cog.py
@@ -289,7 +289,7 @@ class DiagnosticCog(commands.Cog):
         """
         from cogs.diagnostic._platform_embeds import build_setup_readiness_embed
 
-        embed = await build_setup_readiness_embed(ctx.guild.id)
+        embed = await build_setup_readiness_embed(ctx.guild.id, guild=ctx.guild)
         await ctx.send(embed=embed)
 
     @platform_grp.command(name="anchors")  # type: ignore[arg-type]

--- a/disbot/services/setup_readiness.py
+++ b/disbot/services/setup_readiness.py
@@ -44,11 +44,22 @@ Public API
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from core.runtime.subsystem_schema import all_schemas
+from services.resource_health import (
+    SEV_ERROR,
+    SEV_INFO,
+    SEV_WARN,
+    ResourceHealthFinding,
+)
+from services.resource_health import inspect as inspect_resource_health
 from utils import db
 from utils.db import bindings as db_bindings
+
+if TYPE_CHECKING:
+    import discord
 
 logger = logging.getLogger("bot.setup_readiness")
 
@@ -78,7 +89,13 @@ class SubsystemReadiness:
 
 @dataclass(frozen=True)
 class ReadinessReport:
-    """Aggregate readiness snapshot for a guild."""
+    """Aggregate readiness snapshot for a guild.
+
+    Phase 9d (Track 2 PR 5): widened with ``health_findings`` and
+    ``health_summary`` — populated only when ``collect`` is called with
+    a live :class:`discord.Guild` so the legacy ``collect(guild_id)``
+    call path keeps working unchanged (empty tuple / empty dict).
+    """
 
     guild_id: int
     per_subsystem: tuple[SubsystemReadiness, ...]
@@ -88,6 +105,8 @@ class ReadinessReport:
     settings_configured: int
     resources_declared: int
     aggregate_score: float | None
+    health_findings: tuple[ResourceHealthFinding, ...] = ()
+    health_summary: dict[str, int] = field(default_factory=dict)
 
     @property
     def percentage(self) -> int:
@@ -144,7 +163,11 @@ def _compute_score(
     return max(0.0, min(1.0, filled / total))
 
 
-async def collect(guild_id: int) -> ReadinessReport:
+async def collect(
+    guild_id: int,
+    *,
+    guild: discord.Guild | None = None,
+) -> ReadinessReport:
     """Build the per-guild readiness report.
 
     Walks :func:`core.runtime.subsystem_schema.all_schemas` and, for each
@@ -156,6 +179,12 @@ async def collect(guild_id: int) -> ReadinessReport:
     Subsystems with no declared bindings or settings appear with
     ``score=None`` so they're surfaced in the report but don't drag the
     aggregate.
+
+    When ``guild`` is provided, the report additionally carries
+    ``health_findings`` from
+    :func:`services.resource_health.inspect`, plus a
+    ``health_summary`` dict counting findings by severity. The legacy
+    ``collect(guild_id)`` call path leaves both empty.
     """
     schemas = all_schemas()
     binding_rows = await db_bindings.list_for_guild(guild_id)
@@ -221,6 +250,20 @@ async def collect(guild_id: int) -> ReadinessReport:
     if scored:
         aggregate = sum(r.score for r in scored) / len(scored)  # type: ignore[misc]
 
+    health_findings: tuple[ResourceHealthFinding, ...] = ()
+    health_summary: dict[str, int] = {}
+    if guild is not None:
+        try:
+            health_findings = await inspect_resource_health(guild)
+        except Exception:
+            logger.exception(
+                "setup_readiness.collect: resource_health.inspect failed "
+                "for guild=%d; report continues with empty health_findings.",
+                guild_id,
+            )
+            health_findings = ()
+        health_summary = _summarise_health(health_findings)
+
     return ReadinessReport(
         guild_id=guild_id,
         per_subsystem=tuple(per_subsystem),
@@ -230,7 +273,20 @@ async def collect(guild_id: int) -> ReadinessReport:
         settings_configured=total_s_configured,
         resources_declared=total_r_declared,
         aggregate_score=aggregate,
+        health_findings=health_findings,
+        health_summary=health_summary,
     )
+
+
+def _summarise_health(
+    findings: tuple[ResourceHealthFinding, ...],
+) -> dict[str, int]:
+    """Count findings per severity (``info`` / ``warn`` / ``error``)."""
+    summary = {SEV_INFO: 0, SEV_WARN: 0, SEV_ERROR: 0}
+    for finding in findings:
+        if finding.severity in summary:
+            summary[finding.severity] += 1
+    return summary
 
 
 __all__ = [

--- a/tests/unit/services/test_setup_readiness.py
+++ b/tests/unit/services/test_setup_readiness.py
@@ -375,3 +375,151 @@ async def test_build_setup_readiness_embed_handles_empty_registry():
     # And the embed explicitly surfaces the "no schemas" message.
     field_values = "\n".join(f.value or "" for f in embed.fields)
     assert "subsystem_schema.register" in field_values
+
+
+# ---------------------------------------------------------------------------
+# Phase 9d / Track 2 PR 5: health_findings + health_summary
+# ---------------------------------------------------------------------------
+
+
+def _stub_finding(
+    subsystem: str = "xp",
+    binding_name: str = "announce",
+    status: str = "stale_binding",
+    severity: str = "error",
+):
+    from core.runtime.subsystem_schema import BindingKind as _BK
+    from services.resource_health import ResourceHealthFinding
+
+    return ResourceHealthFinding(
+        subsystem=subsystem,
+        binding_name=binding_name,
+        kind=_BK.CHANNEL,
+        status=status,
+        severity=severity,
+        message=f"{status} on {subsystem}.{binding_name}",
+    )
+
+
+@pytest.mark.asyncio
+async def test_collect_without_guild_leaves_health_fields_empty():
+    """Backward-compat: ``collect(guild_id)`` (no ``guild=``) returns
+    a report whose ``health_findings`` is empty and ``health_summary``
+    is empty. This is the path every existing caller uses; the legacy
+    embed/test surface must not change shape."""
+    with patch(
+        "services.setup_readiness.db_bindings.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        report = await setup_readiness.collect(guild_id=42)
+    assert report.health_findings == ()
+    assert report.health_summary == {}
+
+
+@pytest.mark.asyncio
+async def test_collect_with_guild_runs_health_inspection_and_summarises():
+    """When ``guild`` is provided, ``collect`` calls
+    ``resource_health.inspect`` and counts findings by severity."""
+    fake_findings = (
+        _stub_finding(severity="error"),
+        _stub_finding(binding_name="vip", severity="error"),
+        _stub_finding(binding_name="hint", severity="warn"),
+        _stub_finding(binding_name="ok_one", severity="info"),
+    )
+    fake_guild = object()  # opaque; resource_health.inspect is patched
+
+    with (
+        patch(
+            "services.setup_readiness.db_bindings.list_for_guild",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "services.setup_readiness.inspect_resource_health",
+            new_callable=AsyncMock,
+            return_value=fake_findings,
+        ) as mock_inspect,
+    ):
+        report = await setup_readiness.collect(guild_id=42, guild=fake_guild)
+    mock_inspect.assert_awaited_once_with(fake_guild)
+    assert report.health_findings == fake_findings
+    assert report.health_summary == {"info": 1, "warn": 1, "error": 2}
+
+
+@pytest.mark.asyncio
+async def test_collect_with_guild_swallows_inspection_failures():
+    """A raising resource_health inspection must not propagate; the
+    report degrades to empty findings + empty summary so the legacy
+    score columns still render."""
+    with (
+        patch(
+            "services.setup_readiness.db_bindings.list_for_guild",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "services.setup_readiness.inspect_resource_health",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("guild cache stale"),
+        ),
+    ):
+        report = await setup_readiness.collect(guild_id=42, guild=object())
+    assert report.health_findings == ()
+    # Summary is the zero-baseline so embed renderers don't have to
+    # branch on its presence.
+    assert report.health_summary == {"info": 0, "warn": 0, "error": 0}
+
+
+@pytest.mark.asyncio
+async def test_build_setup_readiness_embed_renders_health_section():
+    """When ``guild=`` is forwarded into the embed builder, actionable
+    (error/warn) findings render as per-subsystem fields and the
+    description carries a severity-summary blurb. Info-only findings
+    do not get their own field but DO count in the summary."""
+    from cogs.diagnostic._platform_embeds import build_setup_readiness_embed
+
+    findings = (
+        _stub_finding(severity="error"),
+        _stub_finding(binding_name="vip", severity="warn", status="hierarchy_blocked"),
+        _stub_finding(binding_name="ok_one", severity="info", status="ok"),
+    )
+    with (
+        patch(
+            "services.setup_readiness.db_bindings.list_for_guild",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "services.setup_readiness.inspect_resource_health",
+            new_callable=AsyncMock,
+            return_value=findings,
+        ),
+    ):
+        embed = await build_setup_readiness_embed(guild_id=42, guild=object())
+
+    assert "1 err" in (embed.description or "")
+    assert "1 warn" in (embed.description or "")
+    assert "1 info" in (embed.description or "")
+    health_fields = [f for f in embed.fields if (f.name or "").startswith("Health ·")]
+    assert len(health_fields) == 1
+    assert "stale_binding" in (health_fields[0].value or "")
+    assert "hierarchy_blocked" in (health_fields[0].value or "")
+    # info-severity findings stay out of the per-field details.
+    assert "ok_one" not in (health_fields[0].value or "")
+
+
+@pytest.mark.asyncio
+async def test_build_setup_readiness_embed_without_guild_skips_health():
+    """The legacy embed builder call path (``guild_id`` only) renders
+    no Health · fields and no health blurb."""
+    from cogs.diagnostic._platform_embeds import build_setup_readiness_embed
+
+    with patch(
+        "services.setup_readiness.db_bindings.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        embed = await build_setup_readiness_embed(guild_id=42)
+    assert "err" not in (embed.description or "").lower()
+    assert "Health" not in "\n".join(f.name or "" for f in embed.fields)


### PR DESCRIPTION
## Summary

- Widen `services.setup_readiness.ReadinessReport` additively with `health_findings: tuple[ResourceHealthFinding, ...]` (default `()`) and `health_summary: dict[str, int]` (default `{}`).
- `collect(guild_id)` keeps its existing signature; a new optional `guild=` keyword opts the report into running `services.resource_health.inspect` and populating the two new fields.
- `build_setup_readiness_embed(guild_id)` keeps its existing signature; a new optional `guild=` keyword forwards the health context. When supplied, the embed renders a per-severity summary blurb in its description and one `Health · <subsystem>` field per subsystem containing actionable (error/warn) findings.
- `cogs.diagnostic_cog` forwards `ctx.guild` so `!platform setup-readiness` always renders the health section.

> Track 1 (#174, #175, #176) and Track 2 PR 4 (#177) all merged on `main` at branch time; this PR rebases cleanly onto the latest tip.

## Scope table

| Does | Does NOT |
|---|---|
| Add `health_findings` + `health_summary` to `ReadinessReport` with backward-compat defaults | Change the existing `aggregate_score` / per-subsystem score model |
| Add an optional `guild=` keyword to `collect()` and `build_setup_readiness_embed()` | Break any of the 11 existing setup_readiness tests (verified — they pass unmodified) |
| Render actionable findings inline + a severity-summary blurb | Render info-severity findings inline (they stay in the summary counter only) |
| Degrade gracefully if `resource_health.inspect` raises | Add new failure counters / metrics |
| Pin the `inspect_resource_health` alias via tests | Add a `services.readiness_repair` module (Track 2 PR 6) |

## Files changed

- `disbot/services/setup_readiness.py` — additive `ReadinessReport` fields; optional `guild=` keyword on `collect`; `_summarise_health` helper; failure-isolation try/except around the inspector.
- `disbot/cogs/diagnostic/_platform_embeds.py` — extract `_render_health_findings(embed, report)` helper; optional `guild=` keyword on `build_setup_readiness_embed`; description gains a `health \`N err\` \`N warn\` \`N info\`` blurb when the inspection ran.
- `disbot/cogs/diagnostic_cog.py` — forward `ctx.guild` to `build_setup_readiness_embed`.
- `tests/unit/services/test_setup_readiness.py` — 5 new cases pinning the new contract; existing 11 unchanged.

## Architecture impact

**Additive shape change.** The existing `collect(guild_id)` path stays untouched — all 11 existing tests pass without modification. The new behaviour is only activated when a caller forwards a live `Guild`. Subscriber failure in `resource_health.inspect` is caught inside `collect` and logged via `logger.exception`; the report keeps rendering. The embed renderer was refactored to a helper so it runs even when no subsystem schemas are registered (so a guild's bound resources can still surface health issues).

## Tests run

```
python -m pytest tests/unit/services/test_setup_readiness.py -v    # 16 passed (was 11)
python -m pytest -q                                                # 2625 passed (was 2620), 1 warning
ruff check . --exclude .github,tests,venv,env,build,dist           # All checks passed
black --check . --exclude '(\.github|tests|venv|env|build|dist)'   # 295 files unchanged
isort --check-only . --skip-glob '*/(\.github|tests|venv|env|build|dist)/*'   # passed
mypy disbot/                                                       # 296 source files, 0 issues
```

## Manual Discord smoke checklist

- [ ] Run `!platform setup-readiness` in a test guild; verify a `health 0 err 0 warn N info` blurb appears in the description (PENDING — no live runtime).
- [ ] Delete a bound channel; re-run; verify a `Health · <subsystem>` field with the stale_binding finding (PENDING).
- [ ] Strip bot's send permission on a bound channel; re-run; verify a `Health · <subsystem>` field with the permission_blocked finding (PENDING).
- [ ] Confirm the embed stays under Discord's 6000-char total cap with many findings (helper truncates per-field to 1000 chars) (PENDING).

## Rollback plan

`git revert`. The additive fields default to empty so no existing consumer breaks; the embed reverts to its pre-PR layout.

## Out of scope

- `services.readiness_repair` (preview + apply) — Track 2 PR 6.
- Adding a `logging.audit_channel` / `logging.mod_channel` configuration completeness check — could live in this PR but kept separate to keep the diff focused on the additive shape change.
- A separate diagnostics counter for inspection failures — `logger.exception` is the diagnostic path; the report's empty-summary state is observable from the embed.

## Follow-up items

- Track 2 PR 6: `services: readiness repair previews + apply` — convert findings into `RepairPreview` records and route apply through `binding_mutation` / `settings_mutation` / `resource_provisioning`.

## CI status

Pending — subscribing after creation.

## Risk level

**Low.** Additive shape change; all existing call paths unchanged. Failure isolation pinned by tests. The renderer extraction is a refactor, not a behaviour change.

## User-visible behavior change

**Yes (additive).** `!platform setup-readiness` now surfaces resource-health findings (stale bindings, permission gaps, hierarchy blocks, etc.) alongside the existing fill-rate score. No existing field disappears.

## Slash sync or deploy action required

**No.**

## Next PR

`services: readiness repair previews + apply (Track 2 PR 6)` — per the accepted plan at `/root/.claude/plans/superbot-2-0-setup-purring-peach.md` §5 Track 2 PR 6.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXdDyevoQLQXgmgog7erwY)_