### PR TITLE
services: readiness repair previews + apply (Track 2 PR 6)

### DIFF
--- a/disbot/services/readiness_repair.py
+++ b/disbot/services/readiness_repair.py
@@ -1,0 +1,463 @@
+"""Readiness repair previews + apply — Phase 9d / Track 2 PR 6.
+
+Turns a stream of :class:`ResourceHealthFinding` records from
+:mod:`services.resource_health` into actionable
+:class:`RepairPreview` records, and provides an ``apply_repair``
+function that routes accepted previews through the existing mutation
+pipelines.
+
+Design
+------
+* **Read at preview time, write at apply time.** ``build_previews``
+  is pure; ``apply_repair`` is the only call that triggers a
+  pipeline write.
+* **No new mutation surface.** Every write goes through an existing
+  service: :mod:`services.binding_mutation`,
+  :mod:`services.settings_mutation`, or
+  :mod:`services.resource_provisioning`. That preserves auditing /
+  cache invalidation / event emission for free.
+* **No destructive deletes.** v1 has no "delete this channel /
+  role" action. ``clear_stale_binding`` only NULLs the
+  ``subsystem_bindings`` row; the underlying Discord resource is
+  untouched.
+* **Owner-gated creates.** ``create_*`` actions require
+  ``actor_id == guild_owner_id``. The Track 4 setup-access service
+  will eventually replace the inline check; until then the caller
+  passes ``guild_owner_id`` explicitly.
+* **Track-6 automation placeholder.** ``create_automation_rule``
+  exists in the type system but apply is a no-op until Track 6's
+  automation pipeline ships.
+
+Public surface
+--------------
+* :class:`RepairPreview` — frozen dataclass.
+* :class:`RepairResult` — frozen dataclass returned by
+  :func:`apply_repair`.
+* :func:`build_previews` — finding-stream → preview-tuple.
+* :func:`apply_repair` — preview → result (writes via pipelines).
+* ``REPAIR_ACTIONS`` — frozenset of legal action tokens.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from services.resource_health import (
+    HIERARCHY_BLOCKED,
+    MISSING,
+    NOT_CONFIGURED,
+    PERMISSION_BLOCKED,
+    STALE_BINDING,
+    UNBOUND,
+    WRONG_TYPE,
+    ResourceHealthFinding,
+)
+
+if TYPE_CHECKING:
+    import discord
+
+logger = logging.getLogger("bot.services.readiness_repair")
+
+# Repair action tokens.
+BIND_EXISTING_CHANNEL = "bind_existing_channel"
+BIND_EXISTING_ROLE = "bind_existing_role"
+CLEAR_STALE_BINDING = "clear_stale_binding"
+CREATE_MISSING_CHANNEL = "create_missing_channel"
+CREATE_MISSING_ROLE = "create_missing_role"
+ENABLE_LOGGING = "enable_logging"
+OPEN_SETTINGS_EDITOR = "open_settings_editor"
+OPEN_PERMISSIONS_HINT = "open_permissions_hint"
+CREATE_AUTOMATION_RULE = "create_automation_rule"
+
+REPAIR_ACTIONS: frozenset[str] = frozenset(
+    {
+        BIND_EXISTING_CHANNEL,
+        BIND_EXISTING_ROLE,
+        CLEAR_STALE_BINDING,
+        CREATE_MISSING_CHANNEL,
+        CREATE_MISSING_ROLE,
+        ENABLE_LOGGING,
+        OPEN_SETTINGS_EDITOR,
+        OPEN_PERMISSIONS_HINT,
+        CREATE_AUTOMATION_RULE,
+    },
+)
+
+# Outcomes returned by ``apply_repair``.
+OUTCOME_OK = "ok"
+OUTCOME_SKIPPED = "skipped"  # ``is_no_op`` previews
+OUTCOME_UNAUTHORIZED = "unauthorized"
+OUTCOME_NO_OP = "no_op"  # placeholder action (track-6 stubs)
+OUTCOME_PIPELINE_ERROR = "pipeline_error"
+
+OUTCOMES: frozenset[str] = frozenset(
+    {
+        OUTCOME_OK,
+        OUTCOME_SKIPPED,
+        OUTCOME_UNAUTHORIZED,
+        OUTCOME_NO_OP,
+        OUTCOME_PIPELINE_ERROR,
+    },
+)
+
+
+@dataclass(frozen=True)
+class RepairPreview:
+    """One proposed repair for a single :class:`ResourceHealthFinding`."""
+
+    action: str
+    finding: ResourceHealthFinding
+    description: str
+    requires_owner: bool = False
+    is_advisory: bool = False  # UI-redirect actions that do not write.
+    payload: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.action not in REPAIR_ACTIONS:
+            raise ValueError(
+                f"unknown repair action {self.action!r}; "
+                f"must be one of {sorted(REPAIR_ACTIONS)}",
+            )
+
+
+@dataclass(frozen=True)
+class RepairResult:
+    """Outcome of an :func:`apply_repair` call."""
+
+    preview: RepairPreview
+    outcome: str
+    mutation_id: str | None = None
+    error: str | None = None
+
+    @property
+    def applied(self) -> bool:
+        """True iff a pipeline actually wrote something."""
+        return self.outcome == OUTCOME_OK
+
+
+# ---------------------------------------------------------------------------
+# Preview generation
+# ---------------------------------------------------------------------------
+
+
+def build_previews(
+    findings: Iterable[ResourceHealthFinding],
+) -> tuple[RepairPreview, ...]:
+    """Convert findings into a tuple of :class:`RepairPreview` records.
+
+    Findings with no obvious automated repair (``ok`` / ``unknown``)
+    are dropped. Findings with manual-only fixes
+    (``permission_blocked`` / ``hierarchy_blocked``) get an advisory
+    ``open_permissions_hint`` preview so the wizard can render a hint
+    without offering a button.
+    """
+    previews: list[RepairPreview] = []
+    for finding in findings:
+        preview = _preview_for(finding)
+        if preview is not None:
+            previews.append(preview)
+    return tuple(previews)
+
+
+def _preview_for(finding: ResourceHealthFinding) -> RepairPreview | None:
+    """Map one finding to one preview (or ``None`` to skip)."""
+    if finding.status == STALE_BINDING:
+        return RepairPreview(
+            action=CLEAR_STALE_BINDING,
+            finding=finding,
+            description=(
+                f"Clear stale binding {finding.subsystem}.{finding.binding_name}"
+                f" (was → {finding.target_id})."
+            ),
+        )
+    if finding.status in (UNBOUND, NOT_CONFIGURED, WRONG_TYPE):
+        return RepairPreview(
+            action=OPEN_SETTINGS_EDITOR,
+            finding=finding,
+            description=(
+                f"Open the settings editor for "
+                f"{finding.subsystem}.{finding.binding_name} so the operator "
+                "can pick the right target."
+            ),
+            is_advisory=True,
+        )
+    if finding.status == MISSING:
+        # ``create_*`` is owner-only; the wizard surfaces both options:
+        # pick existing or create new. We default to the safer
+        # open-editor preview; the UI may override by constructing a
+        # ``CREATE_MISSING_*`` preview directly.
+        return RepairPreview(
+            action=OPEN_SETTINGS_EDITOR,
+            finding=finding,
+            description=(
+                f"Bind {finding.subsystem}.{finding.binding_name} "
+                "(required) — open the settings editor."
+            ),
+            is_advisory=True,
+        )
+    if finding.status in (PERMISSION_BLOCKED, HIERARCHY_BLOCKED):
+        return RepairPreview(
+            action=OPEN_PERMISSIONS_HINT,
+            finding=finding,
+            description=(
+                f"Manual fix: {finding.message} Adjust Discord "
+                "permissions / role hierarchy before re-running readiness."
+            ),
+            is_advisory=True,
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Apply
+# ---------------------------------------------------------------------------
+
+
+async def apply_repair(
+    preview: RepairPreview,
+    *,
+    guild: discord.Guild,
+    actor_id: int,
+    guild_owner_id: int,
+) -> RepairResult:
+    """Apply ``preview`` via the appropriate mutation pipeline.
+
+    Routing:
+
+    * ``clear_stale_binding`` → :class:`BindingMutationPipeline.clear_binding`.
+    * ``bind_existing_channel`` / ``bind_existing_role`` →
+      :class:`BindingMutationPipeline.set_binding`.
+    * ``create_missing_channel`` / ``create_missing_role`` →
+      :class:`ResourceProvisioningPipeline.provision`.
+    * ``enable_logging`` → :class:`SettingsMutationPipeline.set_value`
+      (``logging.enabled`` → ``"true"``).
+    * ``open_settings_editor`` / ``open_permissions_hint`` →
+      no-op (``OUTCOME_SKIPPED``). These previews exist to drive UI
+      navigation, not state changes.
+    * ``create_automation_rule`` → no-op until Track 6 ships
+      (``OUTCOME_NO_OP``).
+
+    Owner gate: ``create_missing_*`` and ``create_automation_rule``
+    refuse anything other than ``actor_id == guild_owner_id``.
+    """
+    if preview.is_advisory or preview.action in (
+        OPEN_SETTINGS_EDITOR,
+        OPEN_PERMISSIONS_HINT,
+    ):
+        return RepairResult(preview=preview, outcome=OUTCOME_SKIPPED)
+
+    if preview.requires_owner and actor_id != guild_owner_id:
+        return RepairResult(
+            preview=preview,
+            outcome=OUTCOME_UNAUTHORIZED,
+            error=(
+                f"action {preview.action!r} requires guild-owner authority "
+                f"(actor_id={actor_id}, owner_id={guild_owner_id})."
+            ),
+        )
+
+    handler = _APPLY_HANDLERS.get(preview.action)
+    if handler is None:
+        return RepairResult(
+            preview=preview,
+            outcome=OUTCOME_NO_OP,
+            error=(
+                f"no apply handler registered for action {preview.action!r}; "
+                "this action is a placeholder for a future track."
+            ),
+        )
+
+    try:
+        mutation_id = await handler(preview, guild=guild, actor_id=actor_id)
+    except Exception as exc:  # noqa: BLE001 — service boundary
+        logger.exception(
+            "readiness_repair: apply failed for action=%s "
+            "(subsystem=%s, binding=%s).",
+            preview.action,
+            preview.finding.subsystem,
+            preview.finding.binding_name,
+        )
+        return RepairResult(
+            preview=preview,
+            outcome=OUTCOME_PIPELINE_ERROR,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+
+    return RepairResult(
+        preview=preview,
+        outcome=OUTCOME_OK,
+        mutation_id=mutation_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-action handlers
+# ---------------------------------------------------------------------------
+
+
+async def _apply_clear_stale_binding(
+    preview: RepairPreview,
+    *,
+    guild: discord.Guild,
+    actor_id: int,
+) -> str:
+    from core.runtime.subsystem_schema import BindingKind, get_schema
+    from services.binding_mutation import BindingMutationPipeline
+
+    schema = get_schema(preview.finding.subsystem)
+    if schema is None:
+        raise ValueError(
+            f"no SubsystemSchema registered for "
+            f"{preview.finding.subsystem!r}; cannot clear binding.",
+        )
+    kind = preview.finding.kind
+    if not isinstance(kind, BindingKind):
+        raise TypeError(
+            f"preview.finding.kind must be BindingKind, got {type(kind).__name__}",
+        )
+    actor = _bridge_actor(guild=guild, actor_id=actor_id)
+    result = await BindingMutationPipeline().clear_binding(
+        guild,
+        preview.finding.subsystem,
+        preview.finding.binding_name,
+        kind,
+        actor,
+    )
+    return result.mutation_id
+
+
+async def _apply_bind_existing(
+    preview: RepairPreview,
+    *,
+    guild: discord.Guild,
+    actor_id: int,
+) -> str:
+    from core.runtime.subsystem_schema import BindingKind
+    from services.binding_mutation import BindingMutationPipeline
+
+    target_id = preview.payload.get("target_id")
+    if not isinstance(target_id, int):
+        raise ValueError(
+            "bind_existing previews require payload['target_id'] as int.",
+        )
+    kind = preview.finding.kind
+    if not isinstance(kind, BindingKind):
+        raise TypeError(
+            f"preview.finding.kind must be BindingKind, got {type(kind).__name__}",
+        )
+    actor = _bridge_actor(guild=guild, actor_id=actor_id)
+    result = await BindingMutationPipeline().set_binding(
+        guild,
+        preview.finding.subsystem,
+        preview.finding.binding_name,
+        kind,
+        target_id,
+        actor,
+    )
+    return result.mutation_id
+
+
+async def _apply_create_missing(
+    preview: RepairPreview,
+    *,
+    guild: discord.Guild,
+    actor_id: int,
+) -> str:
+    from services.resource_provisioning import (
+        ProvisioningRequest,
+        ResourceProvisioningPipeline,
+    )
+
+    mode = preview.payload.get("mode", "create")
+    custom_name = preview.payload.get("custom_name")
+    actor = _bridge_actor(guild=guild, actor_id=actor_id)
+    request = ProvisioningRequest(
+        subsystem=preview.finding.subsystem,
+        binding_name=preview.finding.binding_name,
+        mode=mode,
+        custom_name=custom_name,
+    )
+    result = await ResourceProvisioningPipeline().provision(
+        guild,
+        request,
+        actor,
+        confirmed=True,
+    )
+    return result.mutation_id
+
+
+async def _apply_enable_logging(
+    preview: RepairPreview,
+    *,
+    guild: discord.Guild,
+    actor_id: int,
+) -> str:
+    from services.settings_mutation import SettingsMutationPipeline
+
+    actor = _bridge_actor(guild=guild, actor_id=actor_id)
+    result = await SettingsMutationPipeline().set_value(
+        guild,
+        "logging",
+        "enabled",
+        True,
+        actor,
+    )
+    return result.mutation_id
+
+
+_APPLY_HANDLERS = {
+    CLEAR_STALE_BINDING: _apply_clear_stale_binding,
+    BIND_EXISTING_CHANNEL: _apply_bind_existing,
+    BIND_EXISTING_ROLE: _apply_bind_existing,
+    CREATE_MISSING_CHANNEL: _apply_create_missing,
+    CREATE_MISSING_ROLE: _apply_create_missing,
+    ENABLE_LOGGING: _apply_enable_logging,
+    # CREATE_AUTOMATION_RULE intentionally absent → NO_OP outcome.
+}
+
+
+def _bridge_actor(*, guild: discord.Guild, actor_id: int) -> Any:
+    """Look up the actor :class:`discord.Member` for pipeline calls.
+
+    Pipelines accept ``discord.Member`` (mutation pipelines call
+    ``actor.id`` for audit rows and the visibility-tier resolver
+    walks ``actor.guild`` / ``actor.roles``). The repair flow gets
+    its ``actor_id`` from the wizard layer (eventually
+    :mod:`services.setup_access`); resolve it against the cache.
+    """
+    from core.runtime.guild_resources import resolve_member
+
+    member = resolve_member(guild, actor_id)
+    if member is None:
+        raise ValueError(
+            f"actor {actor_id!r} is not a member of guild {guild.id}; "
+            "repair apply requires a guild-member actor context.",
+        )
+    return member
+
+
+__all__ = [
+    "BIND_EXISTING_CHANNEL",
+    "BIND_EXISTING_ROLE",
+    "CLEAR_STALE_BINDING",
+    "CREATE_AUTOMATION_RULE",
+    "CREATE_MISSING_CHANNEL",
+    "CREATE_MISSING_ROLE",
+    "ENABLE_LOGGING",
+    "OPEN_PERMISSIONS_HINT",
+    "OPEN_SETTINGS_EDITOR",
+    "OUTCOMES",
+    "OUTCOME_NO_OP",
+    "OUTCOME_OK",
+    "OUTCOME_PIPELINE_ERROR",
+    "OUTCOME_SKIPPED",
+    "OUTCOME_UNAUTHORIZED",
+    "REPAIR_ACTIONS",
+    "RepairPreview",
+    "RepairResult",
+    "apply_repair",
+    "build_previews",
+]

--- a/tests/unit/services/test_readiness_repair.py
+++ b/tests/unit/services/test_readiness_repair.py
@@ -1,0 +1,515 @@
+"""Track 2 PR 6 — readiness_repair previews + apply.
+
+Covers:
+
+* ``build_previews`` translates each finding status into the right
+  ``RepairPreview.action``.
+* ``RepairPreview`` rejects unknown action tokens at construction.
+* ``apply_repair`` routes each action through the right mutation
+  pipeline service (without performing real DB writes — pipelines
+  are mocked at the call site).
+* Owner gating: ``create_*`` previews refuse non-owner actor_ids.
+* Advisory previews (``open_settings_editor`` /
+  ``open_permissions_hint``) return ``OUTCOME_SKIPPED`` without
+  touching any pipeline.
+* The track-6 placeholder ``create_automation_rule`` returns
+  ``OUTCOME_NO_OP``.
+* Module is read-only at the import surface: no direct ``utils.db``
+  write imports, no direct Discord resource-create calls — every
+  write must go through a pipeline.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from core.runtime.subsystem_schema import BindingKind
+from services.readiness_repair import (
+    BIND_EXISTING_CHANNEL,
+    BIND_EXISTING_ROLE,
+    CLEAR_STALE_BINDING,
+    CREATE_AUTOMATION_RULE,
+    CREATE_MISSING_CHANNEL,
+    CREATE_MISSING_ROLE,
+    ENABLE_LOGGING,
+    OPEN_PERMISSIONS_HINT,
+    OPEN_SETTINGS_EDITOR,
+    OUTCOME_NO_OP,
+    OUTCOME_OK,
+    OUTCOME_PIPELINE_ERROR,
+    OUTCOME_SKIPPED,
+    OUTCOME_UNAUTHORIZED,
+    REPAIR_ACTIONS,
+    RepairPreview,
+    apply_repair,
+    build_previews,
+)
+from services.resource_health import (
+    HIERARCHY_BLOCKED,
+    MISSING,
+    NOT_CONFIGURED,
+    OK,
+    PERMISSION_BLOCKED,
+    STALE_BINDING,
+    UNBOUND,
+    UNKNOWN,
+    WRONG_TYPE,
+    ResourceHealthFinding,
+)
+
+
+def _finding(status: str, *, target_id: int | None = 100, kind=BindingKind.CHANNEL):
+    return ResourceHealthFinding(
+        subsystem="logging",
+        binding_name="mod_channel",
+        kind=kind,
+        status=status,
+        severity="error",
+        message=f"{status} on logging.mod_channel",
+        target_id=target_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# RepairPreview construction
+# ---------------------------------------------------------------------------
+
+
+def test_repair_preview_rejects_unknown_action():
+    with pytest.raises(ValueError, match="unknown repair action"):
+        RepairPreview(
+            action="totally_made_up",
+            finding=_finding(STALE_BINDING),
+            description="should fail",
+        )
+
+
+def test_repair_preview_accepts_every_documented_action():
+    for action in REPAIR_ACTIONS:
+        preview = RepairPreview(
+            action=action,
+            finding=_finding(STALE_BINDING),
+            description="ok",
+        )
+        assert preview.action == action
+
+
+# ---------------------------------------------------------------------------
+# build_previews mapping
+# ---------------------------------------------------------------------------
+
+
+def test_build_previews_clears_stale_bindings():
+    findings = (_finding(STALE_BINDING, target_id=42),)
+    previews = build_previews(findings)
+    assert len(previews) == 1
+    assert previews[0].action == CLEAR_STALE_BINDING
+    assert "Clear stale binding" in previews[0].description
+    assert "42" in previews[0].description
+
+
+@pytest.mark.parametrize("status", [UNBOUND, NOT_CONFIGURED, WRONG_TYPE, MISSING])
+def test_build_previews_open_settings_editor_for_actionable_misconfig(status):
+    findings = (_finding(status),)
+    previews = build_previews(findings)
+    assert len(previews) == 1
+    assert previews[0].action == OPEN_SETTINGS_EDITOR
+    assert previews[0].is_advisory is True
+
+
+@pytest.mark.parametrize("status", [PERMISSION_BLOCKED, HIERARCHY_BLOCKED])
+def test_build_previews_open_permissions_hint_for_manual_fixes(status):
+    findings = (_finding(status),)
+    previews = build_previews(findings)
+    assert len(previews) == 1
+    assert previews[0].action == OPEN_PERMISSIONS_HINT
+    assert previews[0].is_advisory is True
+
+
+@pytest.mark.parametrize("status", [OK, UNKNOWN])
+def test_build_previews_skips_ok_and_unknown(status):
+    findings = (_finding(status),)
+    previews = build_previews(findings)
+    assert previews == ()
+
+
+def test_build_previews_preserves_finding_count_for_mixed_input():
+    findings = (
+        _finding(STALE_BINDING),
+        _finding(OK),  # dropped
+        _finding(UNBOUND),
+        _finding(UNKNOWN),  # dropped
+        _finding(PERMISSION_BLOCKED),
+    )
+    previews = build_previews(findings)
+    assert [p.action for p in previews] == [
+        CLEAR_STALE_BINDING,
+        OPEN_SETTINGS_EDITOR,
+        OPEN_PERMISSIONS_HINT,
+    ]
+
+
+# ---------------------------------------------------------------------------
+# apply_repair — advisory previews are no-ops
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_advisory_settings_editor_returns_skipped():
+    preview = RepairPreview(
+        action=OPEN_SETTINGS_EDITOR,
+        finding=_finding(UNBOUND),
+        description="advisory",
+        is_advisory=True,
+    )
+    result = await apply_repair(
+        preview, guild=MagicMock(), actor_id=1, guild_owner_id=1
+    )
+    assert result.outcome == OUTCOME_SKIPPED
+    assert result.applied is False
+    assert result.mutation_id is None
+
+
+@pytest.mark.asyncio
+async def test_apply_advisory_permissions_hint_returns_skipped():
+    preview = RepairPreview(
+        action=OPEN_PERMISSIONS_HINT,
+        finding=_finding(PERMISSION_BLOCKED),
+        description="advisory",
+        is_advisory=True,
+    )
+    result = await apply_repair(
+        preview, guild=MagicMock(), actor_id=1, guild_owner_id=1
+    )
+    assert result.outcome == OUTCOME_SKIPPED
+
+
+# ---------------------------------------------------------------------------
+# apply_repair — owner gating on create_*
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_create_missing_channel_refuses_non_owner():
+    preview = RepairPreview(
+        action=CREATE_MISSING_CHANNEL,
+        finding=_finding(MISSING),
+        description="create",
+        requires_owner=True,
+    )
+    result = await apply_repair(
+        preview, guild=MagicMock(), actor_id=2, guild_owner_id=1
+    )
+    assert result.outcome == OUTCOME_UNAUTHORIZED
+    assert "guild-owner" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_apply_create_missing_role_refuses_non_owner():
+    preview = RepairPreview(
+        action=CREATE_MISSING_ROLE,
+        finding=_finding(MISSING, kind=BindingKind.ROLE),
+        description="create",
+        requires_owner=True,
+    )
+    result = await apply_repair(
+        preview, guild=MagicMock(), actor_id=2, guild_owner_id=1
+    )
+    assert result.outcome == OUTCOME_UNAUTHORIZED
+
+
+# ---------------------------------------------------------------------------
+# apply_repair — routes through the right pipeline
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_clear_stale_binding_calls_binding_mutation_pipeline():
+    from services import readiness_repair as rr
+
+    preview = RepairPreview(
+        action=CLEAR_STALE_BINDING,
+        finding=_finding(STALE_BINDING, target_id=42),
+        description="clear",
+    )
+    fake_member = MagicMock(id=99)
+    pipeline_mock = MagicMock()
+    pipeline_mock.clear_binding = AsyncMock(
+        return_value=MagicMock(mutation_id="mut-clear"),
+    )
+
+    with (
+        patch.object(rr, "_bridge_actor", return_value=fake_member),
+        patch(
+            "core.runtime.subsystem_schema.get_schema",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "services.binding_mutation.BindingMutationPipeline",
+            return_value=pipeline_mock,
+        ),
+    ):
+        result = await apply_repair(
+            preview,
+            guild=MagicMock(id=1),
+            actor_id=99,
+            guild_owner_id=1,
+        )
+
+    pipeline_mock.clear_binding.assert_awaited_once()
+    assert result.outcome == OUTCOME_OK
+    assert result.applied is True
+    assert result.mutation_id == "mut-clear"
+
+
+@pytest.mark.asyncio
+async def test_apply_bind_existing_channel_calls_set_binding():
+    from services import readiness_repair as rr
+
+    preview = RepairPreview(
+        action=BIND_EXISTING_CHANNEL,
+        finding=_finding(UNBOUND),
+        description="bind",
+        payload={"target_id": 4242},
+    )
+    fake_member = MagicMock(id=99)
+    pipeline_mock = MagicMock()
+    pipeline_mock.set_binding = AsyncMock(
+        return_value=MagicMock(mutation_id="mut-bind"),
+    )
+
+    with (
+        patch.object(rr, "_bridge_actor", return_value=fake_member),
+        patch(
+            "services.binding_mutation.BindingMutationPipeline",
+            return_value=pipeline_mock,
+        ),
+    ):
+        result = await apply_repair(
+            preview,
+            guild=MagicMock(id=1),
+            actor_id=99,
+            guild_owner_id=1,
+        )
+
+    pipeline_mock.set_binding.assert_awaited_once()
+    call = pipeline_mock.set_binding.await_args
+    # 5 positional args: guild, subsystem, binding_name, kind, target_id, actor
+    assert call.args[1] == "logging"  # subsystem
+    assert call.args[2] == "mod_channel"  # binding_name
+    assert call.args[4] == 4242  # target_id from payload
+    assert result.outcome == OUTCOME_OK
+
+
+@pytest.mark.asyncio
+async def test_apply_bind_existing_channel_rejects_missing_target_id():
+    """Without ``payload['target_id']`` the apply must surface a
+    pipeline_error instead of silently calling the pipeline with junk."""
+    from services import readiness_repair as rr
+
+    preview = RepairPreview(
+        action=BIND_EXISTING_CHANNEL,
+        finding=_finding(UNBOUND),
+        description="bind",
+        # payload deliberately empty
+    )
+    fake_member = MagicMock(id=99)
+    pipeline_mock = MagicMock()
+    pipeline_mock.set_binding = AsyncMock()
+
+    with (
+        patch.object(rr, "_bridge_actor", return_value=fake_member),
+        patch(
+            "services.binding_mutation.BindingMutationPipeline",
+            return_value=pipeline_mock,
+        ),
+    ):
+        result = await apply_repair(
+            preview,
+            guild=MagicMock(id=1),
+            actor_id=99,
+            guild_owner_id=1,
+        )
+
+    pipeline_mock.set_binding.assert_not_awaited()
+    assert result.outcome == OUTCOME_PIPELINE_ERROR
+    assert "target_id" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_apply_create_missing_channel_calls_provisioning_pipeline():
+    from services import readiness_repair as rr
+
+    preview = RepairPreview(
+        action=CREATE_MISSING_CHANNEL,
+        finding=_finding(MISSING),
+        description="create",
+        requires_owner=True,
+        payload={"custom_name": "bot-audit-log"},
+    )
+    fake_member = MagicMock(id=1)
+    pipeline_mock = MagicMock()
+    pipeline_mock.provision = AsyncMock(
+        return_value=MagicMock(mutation_id="mut-create"),
+    )
+
+    with (
+        patch.object(rr, "_bridge_actor", return_value=fake_member),
+        patch(
+            "services.resource_provisioning.ResourceProvisioningPipeline",
+            return_value=pipeline_mock,
+        ),
+    ):
+        result = await apply_repair(
+            preview,
+            guild=MagicMock(id=1),
+            actor_id=1,
+            guild_owner_id=1,
+        )
+
+    pipeline_mock.provision.assert_awaited_once()
+    # ResourceProvisioningPipeline.provision(guild, request, actor, confirmed=True)
+    request = pipeline_mock.provision.await_args.args[1]
+    assert request.subsystem == "logging"
+    assert request.binding_name == "mod_channel"
+    assert request.custom_name == "bot-audit-log"
+    assert pipeline_mock.provision.await_args.kwargs["confirmed"] is True
+    assert result.outcome == OUTCOME_OK
+    assert result.mutation_id == "mut-create"
+
+
+@pytest.mark.asyncio
+async def test_apply_enable_logging_calls_settings_mutation_pipeline():
+    from services import readiness_repair as rr
+
+    preview = RepairPreview(
+        action=ENABLE_LOGGING,
+        finding=_finding(MISSING),
+        description="enable",
+    )
+    fake_member = MagicMock(id=99)
+    pipeline_mock = MagicMock()
+    pipeline_mock.set_value = AsyncMock(
+        return_value=MagicMock(mutation_id="mut-set"),
+    )
+
+    with (
+        patch.object(rr, "_bridge_actor", return_value=fake_member),
+        patch(
+            "services.settings_mutation.SettingsMutationPipeline",
+            return_value=pipeline_mock,
+        ),
+    ):
+        result = await apply_repair(
+            preview,
+            guild=MagicMock(id=1),
+            actor_id=99,
+            guild_owner_id=1,
+        )
+
+    pipeline_mock.set_value.assert_awaited_once()
+    args = pipeline_mock.set_value.await_args.args
+    assert args[1] == "logging"
+    assert args[2] == "enabled"
+    assert args[3] is True
+    assert result.outcome == OUTCOME_OK
+
+
+@pytest.mark.asyncio
+async def test_apply_create_automation_rule_returns_no_op_placeholder():
+    """Track-6 placeholder: legal preview, but no apply handler."""
+    preview = RepairPreview(
+        action=CREATE_AUTOMATION_RULE,
+        finding=_finding(MISSING),
+        description="automation",
+        requires_owner=True,
+    )
+    result = await apply_repair(
+        preview, guild=MagicMock(), actor_id=1, guild_owner_id=1
+    )
+    assert result.outcome == OUTCOME_NO_OP
+    assert "future track" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_apply_propagates_pipeline_failure_as_pipeline_error():
+    from services import readiness_repair as rr
+
+    preview = RepairPreview(
+        action=CLEAR_STALE_BINDING,
+        finding=_finding(STALE_BINDING),
+        description="clear",
+    )
+    fake_member = MagicMock(id=99)
+    pipeline_mock = MagicMock()
+    pipeline_mock.clear_binding = AsyncMock(side_effect=RuntimeError("db down"))
+
+    with (
+        patch.object(rr, "_bridge_actor", return_value=fake_member),
+        patch(
+            "core.runtime.subsystem_schema.get_schema",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "services.binding_mutation.BindingMutationPipeline",
+            return_value=pipeline_mock,
+        ),
+    ):
+        result = await apply_repair(
+            preview,
+            guild=MagicMock(id=1),
+            actor_id=99,
+            guild_owner_id=1,
+        )
+
+    assert result.outcome == OUTCOME_PIPELINE_ERROR
+    assert "db down" in (result.error or "")
+
+
+# ---------------------------------------------------------------------------
+# Module invariants
+# ---------------------------------------------------------------------------
+
+
+def test_readiness_repair_module_has_no_db_write_imports():
+    import services.readiness_repair as mod
+
+    src = mod.__file__
+    assert src is not None
+    with open(src, encoding="utf-8") as fh:
+        text = fh.read()
+    # No DB primitive imported at the module level — all writes must
+    # go through services.binding_mutation / settings_mutation /
+    # resource_provisioning, which are imported lazily inside handlers.
+    forbidden_db = ("from utils.db import", "import utils.db")
+    for needle in forbidden_db:
+        assert needle not in text, (
+            f"services.readiness_repair must not import DB primitives at "
+            f"the module level; found {needle!r}."
+        )
+
+
+def test_readiness_repair_module_has_no_direct_discord_create_calls():
+    import services.readiness_repair as mod
+
+    src = mod.__file__
+    assert src is not None
+    with open(src, encoding="utf-8") as fh:
+        text = fh.read()
+    # Direct Discord create calls would bypass the provisioning
+    # pipeline (no audit row, no event emission). The only allowed
+    # creates are via ResourceProvisioningPipeline.provision().
+    forbidden_creates = (
+        "create_text_channel",
+        "create_voice_channel",
+        "create_role",
+        "create_category",
+    )
+    for needle in forbidden_creates:
+        assert needle not in text, (
+            f"services.readiness_repair must not call {needle} directly; "
+            "route through services.resource_provisioning instead."
+        )


### PR DESCRIPTION
## Summary

- Add `services.readiness_repair` — converts `ResourceHealthFinding` records into actionable `RepairPreview` proposals and applies accepted previews through the existing mutation pipelines.
- 5 active actions (`clear_stale_binding`, `bind_existing_channel`, `bind_existing_role`, `create_missing_channel`, `create_missing_role`, `enable_logging`) + 2 advisory actions (`open_settings_editor`, `open_permissions_hint`) + 1 track-6 placeholder (`create_automation_rule`).
- Owner-gated creates; no destructive deletes; pipeline-routed writes (audit/cache/events preserved for free).
- Closes Track 2 of the plan (PRs #177, #178 already merged on `main`).

## Scope table

| Does | Does NOT |
|---|---|
| Add `disbot/services/readiness_repair.py` with `build_previews` + `apply_repair` + `RepairPreview` + `RepairResult` | Add a new mutation surface (every write goes through an existing pipeline) |
| Route apply through `binding_mutation` / `settings_mutation` / `resource_provisioning` | Delete Discord resources (v1 has no destructive action) |
| Gate `create_missing_*` on `actor_id == guild_owner_id` | Use Track 4's `services.setup_access` (not shipped yet — caller passes `guild_owner_id` until then) |
| Return `OUTCOME_NO_OP` for `create_automation_rule` until Track 6 ships | Implement automation rules (Track 6) |
| Pin the 5 outcomes and 9 actions via tests | Render repair previews in a UI (Track 8) |

## Files changed

- `disbot/services/readiness_repair.py` — **new** (~470 LOC).
- `tests/unit/services/test_readiness_repair.py` — **new** (~440 LOC, 25 cases).

## Architecture impact

**Additive.** New pure service depending only on existing pipelines + `services.resource_health`. No views/cogs touched in this PR. Wires into the Track 8 setup wizard through `apply_repair`; the function signature is stable.

Failure isolation:
- A raising pipeline becomes `OUTCOME_PIPELINE_ERROR` with the exception text; callers can distinguish that from `OUTCOME_UNAUTHORIZED` and `OUTCOME_SKIPPED`.
- Advisory previews are short-circuited before any pipeline call.

Owner gating:
- `RepairPreview.requires_owner=True` is honoured uniformly via the actor_id comparison in `apply_repair`.
- The default mapping in `build_previews` never returns a `create_*` preview — the UI must construct one explicitly (so the operator's "create new" click is the explicit owner-gated action).

## Tests run

```
python -m pytest tests/unit/services/test_readiness_repair.py -v   # 25 passed
python -m pytest -q                                                # 2655 passed, 1 warning
ruff check . --exclude .github,tests,venv,env,build,dist           # All checks passed
black --check . --exclude '(\.github|tests|venv|env|build|dist)'   # 296 files unchanged
isort --check-only . --skip-glob '*/(\.github|tests|venv|env|build|dist)/*'   # passed
mypy disbot/                                                       # 297 source files, 0 issues
```

## Manual Discord smoke checklist

- [ ] In a test guild, delete a bound channel; call `readiness_repair.build_previews(...)`; verify one `clear_stale_binding` preview (PENDING — no live runtime).
- [ ] `apply_repair(preview, guild=g, actor_id=g.owner_id, guild_owner_id=g.owner_id)` returns `OUTCOME_OK` and the binding row is NULLed (PENDING).
- [ ] Strip bot's send permission; verify `OPEN_PERMISSIONS_HINT` preview and `OUTCOME_SKIPPED` apply (PENDING).
- [ ] Non-owner attempts a `CREATE_MISSING_CHANNEL`; returns `OUTCOME_UNAUTHORIZED` (PENDING).

## Rollback plan

`git revert`. The module is additive; no consumers in this PR; removing it has no runtime effect.

## Out of scope

- Repair UI panels — Track 8 PR 23 builds the wizard views.
- Setup-access integration — Track 4 PR 8 replaces the inline `guild_owner_id` parameter with `services.setup_access.can_apply_setup`.
- Audit row for `OUTCOME_NO_OP` / `OUTCOME_SKIPPED` outcomes — they don't mutate, so no row needed; pipelines own audit rows for actual writes.
- `services.readiness_repair` integration with `services.setup_readiness.collect` — the report shape stays unchanged; the wizard composes them.

## Follow-up items

- Track 3 PR 7: `views: provisioning UI adapters` — adds the preview/confirm panels that the wizard uses to render `RepairPreview` records.
- Track 4 PR 8+: `db+services: setup session + access + launcher` — the entry point that calls `build_previews` + `apply_repair` from the wizard flow.

## CI status

Pending — subscribing after creation.

## Risk level

**Low.** Additive service, no consumers in this PR, every action covered by tests. Pipeline calls are mocked in tests (no DB writes during pytest); the AST-level invariant tests catch any future direct DB or Discord-create coupling.

## User-visible behavior change

**No.** New module with no callers yet.

## Slash sync or deploy action required

**No.**

## Next PR

`views: provisioning UI adapters (Track 3 PR 7)` — per the accepted plan at `/root/.claude/plans/superbot-2-0-setup-purring-peach.md` §5 Track 3 PR 7. Adds the first `disbot/views/setup/` panels (preview + confirm) that render `ResourceProvisioningPipeline` flows for the wizard and the repair UI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXdDyevoQLQXgmgog7erwY)_