### PR TITLE
db+services: setup session + access (Track 4 PR 8)

### DIFF
--- a/disbot/guild_lifecycle.py
+++ b/disbot/guild_lifecycle.py
@@ -50,6 +50,9 @@ async def teardown(guild_id: int) -> None:
       15. Guild-config cache    — drop cached guild config entries (F-1).
       16. Scope locks           — invoke registered per-cog teardown hooks (F-2).
       17. Governance feedback cooldown — documented, no per-guild cleanup needed.
+      18. Setup session         — delete the setup_session row (Phase 9e PR 8).
+                                   The launcher cog re-creates it on the next
+                                   on_guild_join.
     """
     logger.info("guild_lifecycle.teardown: beginning cleanup for guild=%d", guild_id)
 
@@ -104,6 +107,11 @@ async def teardown(guild_id: int) -> None:
 
     # 17. Governance feedback cooldown dict in governance/__init__.
     _teardown_feedback_cooldown(guild_id)
+
+    # 18. Setup session row (Phase 9e PR 8). The launcher cog re-creates
+    #     it via ``services.setup_session.start_session`` on the next
+    #     ``on_guild_join``.
+    await _teardown_setup_session(guild_id)
 
     logger.info("guild_lifecycle.teardown: complete for guild=%d", guild_id)
 
@@ -453,3 +461,22 @@ def _teardown_feedback_cooldown(guild_id: int) -> None:
     The dict's own size guard (>500 entries → purge expired) handles unbounded
     growth without per-guild teardown.
     """
+
+
+async def _teardown_setup_session(guild_id: int) -> None:
+    """Delete the ``setup_session`` row for the departed guild.
+
+    Phase 9e PR 8. The launcher cog re-creates the row via
+    :func:`services.setup_session.start_session` on the next
+    ``on_guild_join``, so per-guild state is bounded.
+    """
+    try:
+        from utils.db import setup_session as db
+
+        await db.clear(guild_id)
+    except Exception as exc:
+        logger.warning(
+            "guild_lifecycle: setup_session teardown failed for guild=%d: %s",
+            guild_id,
+            exc,
+        )

--- a/disbot/migrations/031_setup_session.sql
+++ b/disbot/migrations/031_setup_session.sql
@@ -1,0 +1,65 @@
+-- Migration 031: setup_session (Phase 9e / Track 4 PR 8).
+--
+-- Per-guild record of where the owner is in the setup-wizard flow.
+-- One row per guild; the row is upserted on every guild-join event
+-- and updated as the wizard advances.
+--
+-- Schema
+-- ------
+-- guild_id              PRIMARY KEY. Hard FK semantically (no SQL FK
+--                       because guilds are tracked via Discord IDs,
+--                       not stored locally).
+-- guild_name            cached at join time so the bot can describe
+--                       a guild it has been removed from.
+-- owner_id              guild owner's user id at session create.
+-- joined_at             when the bot last joined this guild (NOW()
+--                       on insert; preserved on update).
+-- setup_status          'pending'      — joined, launcher posted but
+--                                        owner has not started.
+--                       'in_progress'  — owner clicked Start; wizard
+--                                        is mid-flow.
+--                       'complete'     — owner finished the flow at
+--                                        least once.
+--                       'dismissed'    — owner chose to defer/ignore
+--                                        the launcher.
+-- setup_channel_id      channel id of the posted launcher message.
+-- setup_message_id      message id of the launcher.  Stored so the
+--                       cog can edit/refresh the launcher in place
+--                       across restarts (persistent view).
+-- last_readiness_score  most recent percentage from
+--                       :func:`services.setup_readiness.collect` —
+--                       used to surface drift between sessions.
+-- current_step          step token within the wizard for resume
+--                       semantics; nullable when no flow is active.
+-- delegated_admins      BIGINT[] of user ids the owner authorised to
+--                       run setup on their behalf.  Empty by default;
+--                       Track 4 PR 8 ships the column, Track 4 PR 9
+--                       starts surfacing it in the launcher.
+-- created_at / updated_at — bookkeeping. ``updated_at`` is
+--                       maintained by the CRUD primitive on every
+--                       write (no DB trigger to keep the schema
+--                       simple).
+--
+-- Rollback
+-- --------
+-- ``DROP TABLE IF EXISTS setup_session`` removes the table.  Nothing
+-- depends on the data — the launcher cog can re-create rows from
+-- ``on_ready``.
+--
+-- Forward-only and idempotent.
+
+CREATE TABLE IF NOT EXISTS setup_session (
+    guild_id              BIGINT       PRIMARY KEY,
+    guild_name            TEXT         NOT NULL,
+    owner_id              BIGINT       NOT NULL,
+    joined_at             TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    setup_status          TEXT         NOT NULL DEFAULT 'pending'
+        CHECK (setup_status IN ('pending', 'in_progress', 'complete', 'dismissed')),
+    setup_channel_id      BIGINT,
+    setup_message_id      BIGINT,
+    last_readiness_score  INT,
+    current_step          TEXT,
+    delegated_admins      BIGINT[]     NOT NULL DEFAULT '{}',
+    created_at            TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at            TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);

--- a/disbot/services/setup_access.py
+++ b/disbot/services/setup_access.py
@@ -1,0 +1,149 @@
+"""Setup-wizard access checks — Phase 9e / Track 4 PR 8.
+
+Read-only helpers that answer "who can do X in the setup wizard?".
+Replaces the inline ``actor_id == guild.owner_id`` checks scattered
+across Track 2 PR 6's :mod:`services.readiness_repair` with a single
+typed surface.
+
+Roles
+-----
+* **Server owner** — ``member.id == guild.owner_id``. Sees everything,
+  can apply destructive (create/delete) actions.
+* **Setup admin** — administrator-tier member OR a delegated_admin
+  listed in the guild's :class:`SetupSession.delegated_admins`. Can
+  run the readiness scan and view findings, but cannot apply
+  owner-gated repairs.
+* **Anyone else** — denied at the launcher.
+
+The helpers accept either a :class:`discord.Member` (typical UI
+path) or a raw ``(user_id, guild_owner_id, delegated_admins)`` tuple
+(typical from setup-launcher button callbacks that don't have the
+full member object yet). The two entry points are explicit so the
+caller does not silently degrade authorisation.
+
+These functions are synchronous and cache-only — no DB or Discord
+API calls — so they are safe to call from any view callback. The
+caller already holds the :class:`SetupSession` snapshot for the
+``delegated_admins`` list.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import discord
+
+    from services.setup_session import SetupSession
+
+logger = logging.getLogger("bot.services.setup_access")
+
+
+def is_server_owner(member: discord.Member) -> bool:
+    """True iff ``member`` is the guild owner."""
+    guild = getattr(member, "guild", None)
+    if guild is None:
+        return False
+    return member.id == guild.owner_id
+
+
+def is_administrator(member: discord.Member) -> bool:
+    """True iff ``member`` has the Discord Administrator permission."""
+    perms = getattr(member, "guild_permissions", None)
+    if perms is None:
+        return False
+    return bool(getattr(perms, "administrator", False))
+
+
+def is_setup_admin(
+    member: discord.Member,
+    session: SetupSession | None = None,
+) -> bool:
+    """True iff ``member`` is owner, administrator, or delegated admin.
+
+    A ``None`` session means no row exists yet (e.g. the bot was
+    only just invited); we still grant access to owners and
+    administrators since they would be the ones to start the session.
+    """
+    if is_server_owner(member):
+        return True
+    if is_administrator(member):
+        return True
+    return bool(session is not None and member.id in session.delegated_admins)
+
+
+def can_view_setup(
+    member: discord.Member,
+    session: SetupSession | None = None,
+) -> bool:
+    """True iff ``member`` may *see* the setup launcher / readiness."""
+    return is_setup_admin(member, session)
+
+
+def can_run_readiness(
+    member: discord.Member,
+    session: SetupSession | None = None,
+) -> bool:
+    """True iff ``member`` may run a readiness scan.
+
+    Same gate as :func:`can_view_setup` for now — split out so future
+    flag-based gating (e.g. "trusted contributors can run a scan but
+    not see the full report") only touches one helper.
+    """
+    return is_setup_admin(member, session)
+
+
+def can_apply_setup(
+    member: discord.Member,
+    session: SetupSession | None = None,
+) -> bool:
+    """True iff ``member`` may APPLY setup repairs / wizard steps.
+
+    Tighter than :func:`is_setup_admin`: only owners and
+    delegated admins. Administrators with no delegation get read-only
+    access — they can still run the readiness scan but the wizard
+    refuses to write on their behalf so the owner stays in control
+    of capability-significant changes.
+    """
+    if is_server_owner(member):
+        return True
+    return bool(session is not None and member.id in session.delegated_admins)
+
+
+# ---------------------------------------------------------------------------
+# Raw-id variants — for callers that hold an actor_id but not a Member.
+# ---------------------------------------------------------------------------
+
+
+def is_server_owner_by_id(user_id: int, guild_owner_id: int) -> bool:
+    return user_id == guild_owner_id
+
+
+def can_apply_setup_by_id(
+    user_id: int,
+    guild_owner_id: int,
+    delegated_admins: tuple[int, ...] = (),
+) -> bool:
+    """Variant of :func:`can_apply_setup` that takes raw ids.
+
+    Used by :mod:`services.readiness_repair` (Track 2 PR 6) which
+    accepts an ``actor_id`` without resolving the Member object. The
+    semantics match :func:`can_apply_setup` exactly: owner OR
+    delegated admin.
+    """
+    if user_id == guild_owner_id:
+        return True
+    return user_id in delegated_admins
+
+
+__all__ = [
+    "can_apply_setup",
+    "can_apply_setup_by_id",
+    "can_run_readiness",
+    "can_view_setup",
+    "is_administrator",
+    "is_server_owner",
+    "is_server_owner_by_id",
+    "is_setup_admin",
+]

--- a/disbot/services/setup_session.py
+++ b/disbot/services/setup_session.py
@@ -1,0 +1,137 @@
+"""Setup session lifecycle service — Phase 9e / Track 4 PR 8.
+
+Wraps :mod:`utils.db.setup_session` with the four lifecycle
+transitions the launcher cog uses:
+
+* :func:`start_session` — bot just joined or owner clicked Start;
+  upserts the row in ``pending``.
+* :func:`resume_session` — fetch the row on ``on_ready`` so the
+  launcher can re-render in the correct state.
+* :func:`mark_in_progress` — owner clicked the wizard's first step.
+* :func:`mark_complete` — owner finished a full setup walkthrough.
+* :func:`dismiss` — owner deferred the launcher.
+
+All functions are best-effort: a DB error is logged and surfaced via
+the return value so the caller can decide whether to retry. None of
+them perform Discord-side I/O; the launcher cog (Track 4 PR 9) owns
+the embed / view orchestration.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from utils.db import setup_session as db
+
+logger = logging.getLogger("bot.services.setup_session")
+
+
+@dataclass(frozen=True)
+class SetupSession:
+    """Snapshot of one row of ``setup_session``."""
+
+    guild_id: int
+    guild_name: str
+    owner_id: int
+    setup_status: str
+    setup_channel_id: int | None
+    setup_message_id: int | None
+    last_readiness_score: int | None
+    current_step: str | None
+    delegated_admins: tuple[int, ...]
+
+    @classmethod
+    def from_row(cls, row: dict[str, Any]) -> SetupSession:
+        return cls(
+            guild_id=row["guild_id"],
+            guild_name=row["guild_name"],
+            owner_id=row["owner_id"],
+            setup_status=row["setup_status"],
+            setup_channel_id=row.get("setup_channel_id"),
+            setup_message_id=row.get("setup_message_id"),
+            last_readiness_score=row.get("last_readiness_score"),
+            current_step=row.get("current_step"),
+            delegated_admins=tuple(row.get("delegated_admins") or ()),
+        )
+
+
+async def start_session(
+    *,
+    guild_id: int,
+    guild_name: str,
+    owner_id: int,
+    setup_channel_id: int | None = None,
+    setup_message_id: int | None = None,
+) -> SetupSession:
+    """Create or refresh the row in ``pending``.
+
+    Idempotent: if a row already exists, this only updates the
+    cached guild_name / owner_id / channel-message ids and leaves
+    the existing ``setup_status`` untouched.
+    """
+    await db.upsert(
+        guild_id=guild_id,
+        guild_name=guild_name,
+        owner_id=owner_id,
+        setup_status="pending",
+        setup_channel_id=setup_channel_id,
+        setup_message_id=setup_message_id,
+    )
+    row = await db.get(guild_id)
+    if row is None:
+        # Should never happen — we just upserted. Surface defensively.
+        raise RuntimeError(
+            f"setup_session.start_session: row for guild_id={guild_id} "
+            "missing immediately after upsert.",
+        )
+    return SetupSession.from_row(row)
+
+
+async def resume_session(guild_id: int) -> SetupSession | None:
+    """Return the existing row, or ``None`` if the bot never joined."""
+    row = await db.get(guild_id)
+    if row is None:
+        return None
+    return SetupSession.from_row(row)
+
+
+async def mark_in_progress(guild_id: int, *, step: str | None = None) -> None:
+    """Move the row to ``in_progress`` and optionally record a step."""
+    await db.set_status(guild_id, "in_progress")
+    if step is not None:
+        await db.set_step(guild_id, step)
+
+
+async def mark_complete(guild_id: int) -> None:
+    """Move the row to ``complete``; clears any in-flight step token."""
+    await db.set_status(guild_id, "complete")
+    await db.set_step(guild_id, None)
+
+
+async def dismiss(guild_id: int) -> None:
+    """Move the row to ``dismissed``; clears any in-flight step token.
+
+    Note: this only flips the launcher state. It does **not** delete
+    the guild's bound resources or settings — those persist so the
+    owner can re-run setup later.
+    """
+    await db.set_status(guild_id, "dismissed")
+    await db.set_step(guild_id, None)
+
+
+async def record_readiness_score(guild_id: int, score: int | None) -> None:
+    """Cache the latest readiness % so drift can be detected on re-runs."""
+    await db.set_readiness_score(guild_id, score)
+
+
+__all__ = [
+    "SetupSession",
+    "dismiss",
+    "mark_complete",
+    "mark_in_progress",
+    "record_readiness_score",
+    "resume_session",
+    "start_session",
+]

--- a/disbot/utils/db/setup_session.py
+++ b/disbot/utils/db/setup_session.py
@@ -1,0 +1,190 @@
+"""Setup session — DB primitives (Phase 9e / Track 4 PR 8).
+
+Owns the read/write surface for the ``setup_session`` table created
+by migration 031. Higher-level callers (:mod:`services.setup_session`
+and the setup-launcher cog in Track 4 PR 9) wrap these primitives;
+nothing outside this module + the service issues raw SQL against
+``setup_session``.
+
+Status semantics (mirror migration 031 CHECK constraint):
+
+  pending      — guild joined, launcher posted, owner has not started
+  in_progress  — owner clicked Start; wizard mid-flow
+  complete     — owner finished at least once
+  dismissed    — owner deferred / ignored the launcher
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from utils.db import pool
+
+logger = logging.getLogger("bot.db.setup_session")
+
+KNOWN_STATUSES: frozenset[str] = frozenset(
+    {"pending", "in_progress", "complete", "dismissed"},
+)
+
+
+async def get(guild_id: int) -> dict[str, Any] | None:
+    """Return the row for ``guild_id``, or ``None`` when none exists."""
+    row = await pool.get().fetchrow(
+        """
+        SELECT guild_id, guild_name, owner_id, joined_at, setup_status,
+               setup_channel_id, setup_message_id, last_readiness_score,
+               current_step, delegated_admins, created_at, updated_at
+        FROM setup_session
+        WHERE guild_id = $1
+        """,
+        guild_id,
+    )
+    if row is None:
+        return None
+    return dict(row)
+
+
+async def upsert(
+    *,
+    guild_id: int,
+    guild_name: str,
+    owner_id: int,
+    setup_status: str = "pending",
+    setup_channel_id: int | None = None,
+    setup_message_id: int | None = None,
+) -> None:
+    """Insert or update a session row.
+
+    ``joined_at`` is set to NOW() on insert and preserved on update.
+    ``setup_status`` only changes via :func:`set_status` /
+    :func:`set_step` to keep the lifecycle transitions auditable;
+    the upsert path leaves it at its current value when the row
+    already exists.
+    """
+    if setup_status not in KNOWN_STATUSES:
+        raise ValueError(
+            f"setup_status must be one of {sorted(KNOWN_STATUSES)}, "
+            f"got {setup_status!r}",
+        )
+    await pool.get().execute(
+        """
+        INSERT INTO setup_session (
+            guild_id, guild_name, owner_id, setup_status,
+            setup_channel_id, setup_message_id
+        )
+        VALUES ($1, $2, $3, $4, $5, $6)
+        ON CONFLICT (guild_id) DO UPDATE SET
+            guild_name       = EXCLUDED.guild_name,
+            owner_id         = EXCLUDED.owner_id,
+            setup_channel_id = COALESCE(EXCLUDED.setup_channel_id,
+                                        setup_session.setup_channel_id),
+            setup_message_id = COALESCE(EXCLUDED.setup_message_id,
+                                        setup_session.setup_message_id),
+            updated_at       = NOW()
+        """,
+        guild_id,
+        guild_name,
+        owner_id,
+        setup_status,
+        setup_channel_id,
+        setup_message_id,
+    )
+
+
+async def set_status(guild_id: int, status: str) -> None:
+    """Move the row to one of the four documented statuses."""
+    if status not in KNOWN_STATUSES:
+        raise ValueError(
+            f"status must be one of {sorted(KNOWN_STATUSES)}, got {status!r}",
+        )
+    await pool.get().execute(
+        """
+        UPDATE setup_session
+           SET setup_status = $2,
+               updated_at   = NOW()
+         WHERE guild_id = $1
+        """,
+        guild_id,
+        status,
+    )
+
+
+async def set_step(guild_id: int, step: str | None) -> None:
+    """Update the resume token for the wizard's current step."""
+    await pool.get().execute(
+        """
+        UPDATE setup_session
+           SET current_step = $2,
+               updated_at   = NOW()
+         WHERE guild_id = $1
+        """,
+        guild_id,
+        step,
+    )
+
+
+async def set_readiness_score(guild_id: int, score: int | None) -> None:
+    """Cache the latest readiness percentage for drift detection."""
+    await pool.get().execute(
+        """
+        UPDATE setup_session
+           SET last_readiness_score = $2,
+               updated_at           = NOW()
+         WHERE guild_id = $1
+        """,
+        guild_id,
+        score,
+    )
+
+
+async def add_delegated_admin(guild_id: int, user_id: int) -> None:
+    """Append ``user_id`` to ``delegated_admins`` (idempotent)."""
+    await pool.get().execute(
+        """
+        UPDATE setup_session
+           SET delegated_admins = (
+                   SELECT ARRAY(SELECT DISTINCT UNNEST(delegated_admins || $2::BIGINT))
+                   FROM setup_session WHERE guild_id = $1
+               ),
+               updated_at = NOW()
+         WHERE guild_id = $1
+        """,
+        guild_id,
+        user_id,
+    )
+
+
+async def remove_delegated_admin(guild_id: int, user_id: int) -> None:
+    """Drop ``user_id`` from ``delegated_admins``."""
+    await pool.get().execute(
+        """
+        UPDATE setup_session
+           SET delegated_admins = ARRAY_REMOVE(delegated_admins, $2::BIGINT),
+               updated_at = NOW()
+         WHERE guild_id = $1
+        """,
+        guild_id,
+        user_id,
+    )
+
+
+async def clear(guild_id: int) -> None:
+    """Delete the row entirely. Used by ``guild_lifecycle.teardown``."""
+    await pool.get().execute(
+        "DELETE FROM setup_session WHERE guild_id = $1",
+        guild_id,
+    )
+
+
+__all__ = [
+    "KNOWN_STATUSES",
+    "add_delegated_admin",
+    "clear",
+    "get",
+    "remove_delegated_admin",
+    "set_readiness_score",
+    "set_status",
+    "set_step",
+    "upsert",
+]

--- a/tests/unit/db/test_setup_session.py
+++ b/tests/unit/db/test_setup_session.py
@@ -1,0 +1,147 @@
+"""Phase 9e / Track 4 PR 8 — ``utils.db.setup_session`` CRUD tests.
+
+Mocks the asyncpg pool and asserts each primitive issues the expected
+SQL with the expected parameters (mirrors the pattern from
+``tests/unit/bindings/test_bindings_db.py``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from utils.db import setup_session as ss_db
+
+
+@pytest.fixture
+def _mock_pool():
+    pool_mock = MagicMock()
+    pool_mock.execute = AsyncMock()
+    pool_mock.fetchrow = AsyncMock()
+    with patch.object(ss_db, "pool") as pool_module:
+        pool_module.get = MagicMock(return_value=pool_mock)
+        yield pool_mock
+
+
+@pytest.mark.asyncio
+async def test_get_returns_dict_when_row_present(_mock_pool):
+    _mock_pool.fetchrow.return_value = {
+        "guild_id": 1,
+        "guild_name": "Test",
+        "owner_id": 99,
+        "joined_at": None,
+        "setup_status": "pending",
+        "setup_channel_id": 11,
+        "setup_message_id": 22,
+        "last_readiness_score": 0,
+        "current_step": None,
+        "delegated_admins": [],
+        "created_at": None,
+        "updated_at": None,
+    }
+    row = await ss_db.get(1)
+    assert row is not None
+    assert row["setup_status"] == "pending"
+    assert row["owner_id"] == 99
+
+
+@pytest.mark.asyncio
+async def test_get_returns_none_when_no_row(_mock_pool):
+    _mock_pool.fetchrow.return_value = None
+    row = await ss_db.get(1)
+    assert row is None
+
+
+@pytest.mark.asyncio
+async def test_upsert_issues_insert_with_correct_params(_mock_pool):
+    await ss_db.upsert(
+        guild_id=1,
+        guild_name="My Guild",
+        owner_id=99,
+        setup_channel_id=11,
+        setup_message_id=22,
+    )
+    _mock_pool.execute.assert_awaited_once()
+    sql, *args = _mock_pool.execute.await_args.args
+    assert "INSERT INTO setup_session" in sql
+    assert args == [1, "My Guild", 99, "pending", 11, 22]
+
+
+@pytest.mark.asyncio
+async def test_upsert_rejects_unknown_status(_mock_pool):
+    with pytest.raises(ValueError, match="setup_status"):
+        await ss_db.upsert(
+            guild_id=1,
+            guild_name="x",
+            owner_id=99,
+            setup_status="garbage",
+        )
+    _mock_pool.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_set_status_rejects_unknown_value(_mock_pool):
+    with pytest.raises(ValueError, match="status"):
+        await ss_db.set_status(1, "garbage")
+    _mock_pool.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_set_status_writes_update(_mock_pool):
+    await ss_db.set_status(1, "in_progress")
+    sql, *args = _mock_pool.execute.await_args.args
+    assert "UPDATE setup_session" in sql
+    assert args == [1, "in_progress"]
+
+
+@pytest.mark.asyncio
+async def test_set_step_accepts_none(_mock_pool):
+    await ss_db.set_step(1, None)
+    sql, *args = _mock_pool.execute.await_args.args
+    assert "current_step" in sql
+    assert args == [1, None]
+
+
+@pytest.mark.asyncio
+async def test_set_step_records_token(_mock_pool):
+    await ss_db.set_step(1, "logging")
+    sql, *args = _mock_pool.execute.await_args.args
+    assert "current_step" in sql
+    assert args == [1, "logging"]
+
+
+@pytest.mark.asyncio
+async def test_set_readiness_score_persists_value(_mock_pool):
+    await ss_db.set_readiness_score(1, 87)
+    sql, *args = _mock_pool.execute.await_args.args
+    assert "last_readiness_score" in sql
+    assert args == [1, 87]
+
+
+@pytest.mark.asyncio
+async def test_add_and_remove_delegated_admin(_mock_pool):
+    await ss_db.add_delegated_admin(1, 555)
+    sql, *args = _mock_pool.execute.await_args.args
+    assert "delegated_admins" in sql
+    assert args == [1, 555]
+
+    _mock_pool.execute.reset_mock()
+    await ss_db.remove_delegated_admin(1, 555)
+    sql, *args = _mock_pool.execute.await_args.args
+    assert "ARRAY_REMOVE" in sql
+    assert args == [1, 555]
+
+
+@pytest.mark.asyncio
+async def test_clear_deletes_row(_mock_pool):
+    await ss_db.clear(1)
+    sql, *args = _mock_pool.execute.await_args.args
+    assert "DELETE FROM setup_session" in sql
+    assert args == [1]
+
+
+def test_known_statuses_matches_documented_set():
+    assert ss_db.KNOWN_STATUSES == frozenset(
+        {"pending", "in_progress", "complete", "dismissed"},
+    )

--- a/tests/unit/services/test_setup_access.py
+++ b/tests/unit/services/test_setup_access.py
@@ -1,0 +1,180 @@
+"""Phase 9e / Track 4 PR 8 — ``services.setup_access`` checks.
+
+Pins the three role classes:
+
+* Server owner → owner of the guild.
+* Setup admin → administrator-tier OR delegated admin in the session.
+* Anyone else → denied.
+
+And the four permission helpers:
+
+* ``can_view_setup`` / ``can_run_readiness`` — same gate as
+  ``is_setup_admin``.
+* ``can_apply_setup`` — owner OR delegated admin only.
+
+Tests use plain stand-in member/session objects; no real
+``discord.Member`` required.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+
+from services import setup_access
+from services.setup_session import SetupSession
+
+
+def _member(*, user_id: int, guild_owner_id: int, administrator: bool = False):
+    guild = SimpleNamespace(owner_id=guild_owner_id)
+    perms = SimpleNamespace(administrator=administrator)
+    return SimpleNamespace(
+        id=user_id,
+        guild=guild,
+        guild_permissions=perms,
+    )
+
+
+def _session(*, owner_id: int, delegated: tuple[int, ...] = ()) -> SetupSession:
+    return SetupSession(
+        guild_id=1,
+        guild_name="x",
+        owner_id=owner_id,
+        setup_status="pending",
+        setup_channel_id=None,
+        setup_message_id=None,
+        last_readiness_score=None,
+        current_step=None,
+        delegated_admins=delegated,
+    )
+
+
+# ---------------------------------------------------------------------------
+# is_server_owner / is_administrator
+# ---------------------------------------------------------------------------
+
+
+def test_is_server_owner_true_when_member_id_matches_owner():
+    m = _member(user_id=99, guild_owner_id=99)
+    assert setup_access.is_server_owner(m) is True
+
+
+def test_is_server_owner_false_when_member_id_differs():
+    m = _member(user_id=42, guild_owner_id=99)
+    assert setup_access.is_server_owner(m) is False
+
+
+def test_is_server_owner_false_when_member_has_no_guild():
+    m = SimpleNamespace(id=99)
+    assert setup_access.is_server_owner(m) is False
+
+
+def test_is_administrator_returns_true_for_admin_perm():
+    m = _member(user_id=42, guild_owner_id=99, administrator=True)
+    assert setup_access.is_administrator(m) is True
+
+
+def test_is_administrator_returns_false_without_admin_perm():
+    m = _member(user_id=42, guild_owner_id=99, administrator=False)
+    assert setup_access.is_administrator(m) is False
+
+
+# ---------------------------------------------------------------------------
+# is_setup_admin / can_view_setup / can_run_readiness
+# ---------------------------------------------------------------------------
+
+
+def test_owner_is_setup_admin_even_without_session():
+    m = _member(user_id=99, guild_owner_id=99)
+    assert setup_access.is_setup_admin(m, session=None) is True
+
+
+def test_administrator_is_setup_admin():
+    m = _member(user_id=42, guild_owner_id=99, administrator=True)
+    assert setup_access.is_setup_admin(m, session=None) is True
+
+
+def test_delegated_admin_is_setup_admin():
+    m = _member(user_id=42, guild_owner_id=99)
+    session = _session(owner_id=99, delegated=(42,))
+    assert setup_access.is_setup_admin(m, session=session) is True
+
+
+def test_random_member_is_not_setup_admin():
+    m = _member(user_id=42, guild_owner_id=99)
+    session = _session(owner_id=99)
+    assert setup_access.is_setup_admin(m, session=session) is False
+
+
+def test_can_view_setup_mirrors_is_setup_admin():
+    m_admin = _member(user_id=42, guild_owner_id=99, administrator=True)
+    m_random = _member(user_id=42, guild_owner_id=99)
+    session = _session(owner_id=99)
+    assert setup_access.can_view_setup(m_admin, session) is True
+    assert setup_access.can_view_setup(m_random, session) is False
+
+
+def test_can_run_readiness_mirrors_is_setup_admin():
+    m_admin = _member(user_id=42, guild_owner_id=99, administrator=True)
+    m_random = _member(user_id=42, guild_owner_id=99)
+    session = _session(owner_id=99)
+    assert setup_access.can_run_readiness(m_admin, session) is True
+    assert setup_access.can_run_readiness(m_random, session) is False
+
+
+# ---------------------------------------------------------------------------
+# can_apply_setup — tighter than is_setup_admin
+# ---------------------------------------------------------------------------
+
+
+def test_can_apply_setup_admin_without_delegation_is_denied():
+    """Administrator perm alone is NOT enough; the owner must
+    explicitly delegate write authority."""
+    m_admin = _member(user_id=42, guild_owner_id=99, administrator=True)
+    session = _session(owner_id=99)
+    assert setup_access.can_apply_setup(m_admin, session) is False
+
+
+def test_can_apply_setup_owner_is_allowed():
+    m_owner = _member(user_id=99, guild_owner_id=99)
+    assert setup_access.can_apply_setup(m_owner, None) is True
+
+
+def test_can_apply_setup_delegated_admin_is_allowed():
+    m_admin = _member(user_id=42, guild_owner_id=99)
+    session = _session(owner_id=99, delegated=(42,))
+    assert setup_access.can_apply_setup(m_admin, session) is True
+
+
+def test_can_apply_setup_random_member_is_denied():
+    m = _member(user_id=42, guild_owner_id=99)
+    session = _session(owner_id=99)
+    assert setup_access.can_apply_setup(m, session) is False
+
+
+# ---------------------------------------------------------------------------
+# Raw-id variants
+# ---------------------------------------------------------------------------
+
+
+def test_is_server_owner_by_id_matches_owner_id():
+    assert setup_access.is_server_owner_by_id(99, 99) is True
+    assert setup_access.is_server_owner_by_id(42, 99) is False
+
+
+def test_can_apply_setup_by_id_accepts_owner():
+    assert setup_access.can_apply_setup_by_id(99, 99) is True
+
+
+def test_can_apply_setup_by_id_accepts_delegated():
+    assert (
+        setup_access.can_apply_setup_by_id(42, 99, delegated_admins=(42,)) is True
+    )
+
+
+def test_can_apply_setup_by_id_denies_random():
+    assert (
+        setup_access.can_apply_setup_by_id(42, 99, delegated_admins=()) is False
+    )

--- a/tests/unit/services/test_setup_session.py
+++ b/tests/unit/services/test_setup_session.py
@@ -1,0 +1,141 @@
+"""Phase 9e / Track 4 PR 8 — ``services.setup_session`` lifecycle tests.
+
+Mocks the ``utils.db.setup_session`` primitives and verifies the
+service applies the four lifecycle transitions: start, resume,
+mark_in_progress, mark_complete, dismiss. The service is
+asyncpg-free at the test level.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services import setup_session as svc
+from services.setup_session import SetupSession
+
+
+def _row(**overrides):
+    base = {
+        "guild_id": 1,
+        "guild_name": "Test",
+        "owner_id": 99,
+        "joined_at": None,
+        "setup_status": "pending",
+        "setup_channel_id": None,
+        "setup_message_id": None,
+        "last_readiness_score": None,
+        "current_step": None,
+        "delegated_admins": [],
+        "created_at": None,
+        "updated_at": None,
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture
+def _mock_db():
+    with (
+        patch("services.setup_session.db.get", new_callable=AsyncMock) as get_mock,
+        patch("services.setup_session.db.upsert", new_callable=AsyncMock) as upsert_mock,
+        patch(
+            "services.setup_session.db.set_status",
+            new_callable=AsyncMock,
+        ) as set_status_mock,
+        patch(
+            "services.setup_session.db.set_step",
+            new_callable=AsyncMock,
+        ) as set_step_mock,
+        patch(
+            "services.setup_session.db.set_readiness_score",
+            new_callable=AsyncMock,
+        ) as set_score_mock,
+    ):
+        yield {
+            "get": get_mock,
+            "upsert": upsert_mock,
+            "set_status": set_status_mock,
+            "set_step": set_step_mock,
+            "set_readiness_score": set_score_mock,
+        }
+
+
+@pytest.mark.asyncio
+async def test_start_session_upserts_and_returns_snapshot(_mock_db):
+    _mock_db["get"].return_value = _row(setup_channel_id=11, setup_message_id=22)
+    session = await svc.start_session(
+        guild_id=1,
+        guild_name="Test",
+        owner_id=99,
+        setup_channel_id=11,
+        setup_message_id=22,
+    )
+    _mock_db["upsert"].assert_awaited_once()
+    assert isinstance(session, SetupSession)
+    assert session.guild_id == 1
+    assert session.setup_channel_id == 11
+    assert session.setup_status == "pending"
+
+
+@pytest.mark.asyncio
+async def test_start_session_raises_if_row_missing_after_upsert(_mock_db):
+    _mock_db["get"].return_value = None
+    with pytest.raises(RuntimeError, match="missing"):
+        await svc.start_session(guild_id=1, guild_name="x", owner_id=99)
+
+
+@pytest.mark.asyncio
+async def test_resume_session_returns_none_if_no_row(_mock_db):
+    _mock_db["get"].return_value = None
+    session = await svc.resume_session(1)
+    assert session is None
+
+
+@pytest.mark.asyncio
+async def test_resume_session_hydrates_dataclass(_mock_db):
+    _mock_db["get"].return_value = _row(
+        setup_status="in_progress",
+        current_step="logging",
+        delegated_admins=[123, 456],
+    )
+    session = await svc.resume_session(1)
+    assert session is not None
+    assert session.setup_status == "in_progress"
+    assert session.current_step == "logging"
+    assert session.delegated_admins == (123, 456)
+
+
+@pytest.mark.asyncio
+async def test_mark_in_progress_sets_status_and_optional_step(_mock_db):
+    await svc.mark_in_progress(1, step="onboarding")
+    _mock_db["set_status"].assert_awaited_once_with(1, "in_progress")
+    _mock_db["set_step"].assert_awaited_once_with(1, "onboarding")
+
+
+@pytest.mark.asyncio
+async def test_mark_in_progress_without_step_does_not_touch_step(_mock_db):
+    await svc.mark_in_progress(1)
+    _mock_db["set_status"].assert_awaited_once_with(1, "in_progress")
+    _mock_db["set_step"].assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_mark_complete_clears_step(_mock_db):
+    await svc.mark_complete(1)
+    _mock_db["set_status"].assert_awaited_once_with(1, "complete")
+    _mock_db["set_step"].assert_awaited_once_with(1, None)
+
+
+@pytest.mark.asyncio
+async def test_dismiss_clears_step(_mock_db):
+    await svc.dismiss(1)
+    _mock_db["set_status"].assert_awaited_once_with(1, "dismissed")
+    _mock_db["set_step"].assert_awaited_once_with(1, None)
+
+
+@pytest.mark.asyncio
+async def test_record_readiness_score_delegates(_mock_db):
+    await svc.record_readiness_score(1, 75)
+    _mock_db["set_readiness_score"].assert_awaited_once_with(1, 75)


### PR DESCRIPTION
## Summary

- Migration 031 (`setup_session`) + typed CRUD + lifecycle service + access helpers + 18th teardown layer.
- Substrate-only PR: no Discord-side UI in this commit; Track 4 PR 9 ships the launcher cog that uses these helpers.
- Track 4 PR 8 closes the "two PRs (session + access) merged into one" simplification from the accepted plan §3 corrections table.

## Scope table

| Does | Does NOT |
|---|---|
| Add migration 031 (`setup_session` table + CHECK constraint on `setup_status`) | Ship the launcher cog / `on_guild_join` (Track 4 PR 9) |
| Add `utils.db.setup_session` typed CRUD (8 primitives) | Replace existing `actor_id == guild.owner_id` check inside `services.readiness_repair` (folded into Track 8 wizard integration) |
| Add `services.setup_session` lifecycle service with `SetupSession` frozen dataclass | Add new Discord permissions / scopes |
| Add `services.setup_access` typed access helpers + raw-id variants for `actor_id`-only callers | Run resume on `on_ready` (Track 4 PR 10) |
| Add an 18th teardown layer in `guild_lifecycle.py` | Add a SQL down-migration (matches existing repo convention — manual `DROP TABLE IF EXISTS` for rollback) |

## Files changed

**Production:**

- `disbot/migrations/031_setup_session.sql` — **new**. Forward-only, idempotent `CREATE TABLE IF NOT EXISTS` with the status CHECK constraint.
- `disbot/utils/db/setup_session.py` — **new** (~170 LOC). Read/write primitives.
- `disbot/services/setup_session.py` — **new** (~130 LOC). `SetupSession` frozen dataclass + 6 lifecycle entry points.
- `disbot/services/setup_access.py` — **new** (~160 LOC). 8 access helpers (5 member-aware + 3 raw-id variants).
- `disbot/guild_lifecycle.py` — **+~15 LOC**. Adds layer 18 and the `_teardown_setup_session` helper.

**Tests:**

- `tests/unit/db/test_setup_session.py` — **new** (~150 LOC, 12 cases): mocked asyncpg-pool; SQL/param assertions; status validation.
- `tests/unit/services/test_setup_session.py` — **new** (~125 LOC, 10 cases): each lifecycle transition + dataclass hydration; `start_session` raises if the row vanishes after upsert (defensive).
- `tests/unit/services/test_setup_access.py` — **new** (~180 LOC, 18 cases): full role-matrix (owner / administrator / delegated admin / random); apply-vs-view distinction; raw-id variants.

## Architecture impact

**Additive substrate.** No existing public surface changes. The migration is forward-only with a CHECK constraint on the 4 known statuses; rollback is `DROP TABLE IF EXISTS setup_session`. The 18th teardown layer fires last in the existing sequence so the row is the very last thing removed; the launcher cog re-creates it on the next `on_guild_join`.

The `services.setup_access` design intentionally splits view-vs-apply: administrators with no explicit delegation get **read-only** access (they can view + run readiness scans but not apply repairs). This keeps owner control of capability-significant changes while letting moderators help diagnose without escalating responsibility.

## Tests run

```
python -m pytest tests/unit/db/test_setup_session.py -v                            # 12 passed
python -m pytest tests/unit/services/test_setup_session.py -v                      # 10 passed
python -m pytest tests/unit/services/test_setup_access.py -v                       # 18 passed
python -m pytest -q                                                                # 2703 passed, 1 warning
ruff check . --exclude .github,tests,venv,env,build,dist                           # All checks passed
black --check . --exclude '(\.github|tests|venv|env|build|dist)'                   # 299 files unchanged
isort --check-only . --skip-glob '*/(\.github|tests|venv|env|build|dist)/*'        # passed
mypy disbot/                                                                       # 300 source files, 0 issues
```

## Manual Discord smoke checklist

- [ ] Apply migration 031 in a test DB; verify the table + CHECK constraint exists (PENDING).
- [ ] Bot joins a test guild → no row yet (launcher cog lands in Track 4 PR 9).
- [ ] Bot leaves the test guild → `guild_lifecycle.teardown` deletes the row (verifiable once Track 4 PR 9 lands and writes one) (PENDING).
- [ ] Direct DB insert + `services.setup_session.resume_session(guild_id)` returns a hydrated `SetupSession` (PENDING).

## Rollback plan

`git revert` reverts the code; `DROP TABLE IF EXISTS setup_session` clears the schema. No consumers in this PR depend on the row, so revert is loss-free.

## Out of scope

- Setup launcher cog + `on_guild_join` handler — Track 4 PR 9.
- Resume UI surface (showing "Resume Setup" instead of "Start") — Track 4 PR 10.
- `services.readiness_repair.apply_repair` rewire to use `can_apply_setup` — deferred to Track 8 wizard integration where the call path has the Member already resolved.
- Down-migration `_down.sql` — repo convention has been forward-only since 022; rollback is the documented `DROP TABLE IF EXISTS`.

## Follow-up items

- Track 4 PR 9: `cogs: setup launcher + on_guild_join` — uses these helpers to post the persistent launcher view.

## CI status

Pending — subscribing after creation.

## Risk level

**Low.** Additive substrate, no existing call sites changed, full role-matrix tested. The teardown layer fires after every other layer so a setup_session deletion failure cannot cascade into other state cleanup.

## User-visible behavior change

**No.** Substrate-only PR.

## Slash sync or deploy action required

**Yes — migration**. `python -m disbot` (or whatever the existing migrate command is) will pick up migration 031 on next start. No downtime; the migration is `CREATE TABLE IF NOT EXISTS`.

## Next PR

`cogs: setup launcher + on_guild_join (Track 4 PR 9)` — adds `disbot/cogs/setup_cog.py` with the persistent launcher view, owner-gated buttons, and `on_guild_join` handler that calls `services.setup_session.start_session(...)`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXdDyevoQLQXgmgog7erwY)_