### PR TITLE
cogs+views: setup launcher resumption + status (Track 4 PR 10)

### DIFF
--- a/disbot/cogs/setup_cog.py
+++ b/disbot/cogs/setup_cog.py
@@ -74,15 +74,48 @@ def _build_launcher_embed(session: SetupSession | None) -> discord.Embed:
     return embed
 
 
+_START_LABELS_BY_STATUS = {
+    "pending": "Start Setup",
+    "in_progress": "Resume Setup",
+    "complete": "Re-run Setup",
+    "dismissed": "Start Setup",
+}
+
+
 class SetupLauncherView(discord.ui.View):
     """Persistent owner-gated launcher view.
 
     ``timeout=None`` + static ``custom_id`` per button = the message
-    survives bot restarts (Track 4 PR 10 re-binds it on ``on_ready``).
+    survives bot restarts; :meth:`SetupCog._resume_launchers` rebinds
+    in-flight launcher messages with a status-aware label set on
+    ``on_ready``.
+
+    Labels:
+
+    * ``status="pending"`` / ``None`` / ``"dismissed"`` — default
+      "Start Setup".
+    * ``status="in_progress"`` — "Resume Setup".
+    * ``status="complete"`` — "Re-run Setup".
+
+    Custom IDs never change; discord.py routes interactions by id,
+    not by label, so the rebound message keeps working against the
+    cog-load-registered view.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, status: str | None = None) -> None:
         super().__init__(timeout=None)
+        self.status = status
+        if status is not None:
+            self._apply_status_labels(status)
+
+    def _apply_status_labels(self, status: str) -> None:
+        start_label = _START_LABELS_BY_STATUS.get(status, "Start Setup")
+        for child in self.children:
+            if (
+                isinstance(child, discord.ui.Button)
+                and getattr(child, "custom_id", None) == "setup:start"
+            ):
+                child.label = start_label
 
     async def _resolve_session(
         self,
@@ -351,10 +384,19 @@ async def post_launcher(
 class SetupCog(commands.Cog):
     """Setup-wizard launcher.
 
-    Listens for ``on_guild_join`` and posts the owner-gated launcher
-    view. Adds a single persistent ``SetupLauncherView`` instance to
-    the bot at ``cog_load`` so existing launcher messages survive
-    restarts.
+    Listens for ``on_guild_join`` and ``on_ready`` and keeps the
+    launcher message in sync with the ``setup_session`` row:
+
+    * ``on_guild_join`` — fresh launcher posted, session row upserted
+      in ``pending``.
+    * ``on_ready`` — for every guild with a recorded launcher
+      message, the message is edited in place with a status-aware
+      embed + view (e.g. ``Start Setup`` becomes ``Resume Setup``
+      when the row is mid-flow).
+
+    The base ``SetupLauncherView`` is registered at ``cog_load`` so
+    discord.py can dispatch interactions even before the resume
+    sweep finishes (the rebound message has the same custom_ids).
     """
 
     def __init__(self, bot: commands.Bot) -> None:
@@ -362,14 +404,18 @@ class SetupCog(commands.Cog):
 
     async def cog_load(self) -> None:
         # Register the persistent view so discord.py can match
-        # interactions to it after restart. Track 4 PR 10 will
-        # rebind every active launcher message to fresh anchor
-        # entries.
+        # interactions to it after restart. The base instance has
+        # the default labels; ``_resume_launchers`` later edits
+        # individual messages with status-aware label sets.
         self.bot.add_view(SetupLauncherView())
 
     @commands.Cog.listener()
     async def on_guild_join(self, guild: discord.Guild) -> None:
         await self._handle_join(guild)
+
+    @commands.Cog.listener()
+    async def on_ready(self) -> None:
+        await self._resume_launchers()
 
     async def _handle_join(self, guild: discord.Guild) -> None:
         """Internal entry point — split out for direct testing."""
@@ -389,6 +435,93 @@ class SetupCog(commands.Cog):
                 "setup_cog.on_guild_join: handler failed for guild=%d",
                 guild.id,
             )
+
+    async def _resume_launchers(self) -> None:
+        """Walk ``self.bot.guilds`` and refresh each launcher message.
+
+        For every guild whose ``setup_session`` row carries both a
+        ``setup_channel_id`` and a ``setup_message_id``, the message
+        is edited in place with the right status-aware label set.
+        Stale channel / message ids are detected via ``Forbidden`` /
+        ``NotFound`` / ``HTTPException`` and the corresponding row
+        fields are NOT cleared here (Track 4 PR 9 keeps the cog
+        non-destructive; an explicit teardown is the only path that
+        removes session state).
+        """
+        for guild in list(self.bot.guilds):
+            try:
+                await self._resume_one_launcher(guild)
+            except Exception:
+                logger.exception(
+                    "setup_cog.on_ready: resume failed for guild=%d",
+                    guild.id,
+                )
+
+    async def _resume_one_launcher(self, guild: discord.Guild) -> bool:
+        """Refresh one guild's launcher message.
+
+        Returns ``True`` when the message was edited, ``False`` when
+        no row exists, the row has no channel/message ids, or the
+        original message could not be fetched.
+        """
+        session = await setup_session.resume_session(guild.id)
+        if session is None:
+            return False
+        if session.setup_channel_id is None or session.setup_message_id is None:
+            return False
+
+        channel = guild.get_channel(session.setup_channel_id)
+        if not isinstance(
+            channel,
+            (discord.TextChannel, discord.Thread),
+        ):
+            logger.debug(
+                "setup_cog.on_ready: channel %s not in guild %d cache; "
+                "skipping resume.",
+                session.setup_channel_id,
+                guild.id,
+            )
+            return False
+
+        try:
+            message = await channel.fetch_message(session.setup_message_id)
+        except discord.NotFound:
+            logger.info(
+                "setup_cog.on_ready: launcher message %s in guild %d is "
+                "gone; skipping resume (next on_guild_join will re-post).",
+                session.setup_message_id,
+                guild.id,
+            )
+            return False
+        except discord.Forbidden:
+            logger.warning(
+                "setup_cog.on_ready: cannot fetch launcher message in "
+                "#%s (guild=%d) — missing read_message_history.",
+                channel.name,
+                guild.id,
+            )
+            return False
+        except discord.HTTPException as exc:
+            logger.warning(
+                "setup_cog.on_ready: HTTP error fetching launcher in " "guild=%d: %s",
+                guild.id,
+                exc,
+            )
+            return False
+
+        view = SetupLauncherView(status=session.setup_status)
+        embed = _build_launcher_embed(session)
+        try:
+            await message.edit(embed=embed, view=view)
+        except discord.HTTPException as exc:
+            logger.warning(
+                "setup_cog.on_ready: edit_message failed for launcher in "
+                "guild=%d: %s",
+                guild.id,
+                exc,
+            )
+            return False
+        return True
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/tests/unit/cogs/test_setup_cog.py
+++ b/tests/unit/cogs/test_setup_cog.py
@@ -454,3 +454,214 @@ async def test_dismiss_button_refuses_non_owner():
 
     dismiss_mock.assert_not_awaited()
     interaction.response.send_message.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Track 4 PR 10: status-aware labels + on_ready resumption
+# ---------------------------------------------------------------------------
+
+
+def _find_button(view, custom_id: str):
+    import discord
+
+    return next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == custom_id
+    )
+
+
+def test_launcher_view_default_label_is_start_setup():
+    view = SetupLauncherView()
+    assert _find_button(view, "setup:start").label == "Start Setup"
+
+
+def test_launcher_view_in_progress_relabels_to_resume_setup():
+    view = SetupLauncherView(status="in_progress")
+    assert _find_button(view, "setup:start").label == "Resume Setup"
+
+
+def test_launcher_view_complete_relabels_to_re_run_setup():
+    view = SetupLauncherView(status="complete")
+    assert _find_button(view, "setup:start").label == "Re-run Setup"
+
+
+def test_launcher_view_pending_keeps_default_label():
+    view = SetupLauncherView(status="pending")
+    assert _find_button(view, "setup:start").label == "Start Setup"
+
+
+def test_launcher_view_dismissed_keeps_default_label():
+    view = SetupLauncherView(status="dismissed")
+    assert _find_button(view, "setup:start").label == "Start Setup"
+
+
+def _session_with_message(
+    *,
+    status: str = "in_progress",
+    channel_id: int = 5555,
+    message_id: int = 8888,
+):
+    return SetupSession(
+        guild_id=1,
+        guild_name="Test",
+        owner_id=99,
+        setup_status=status,
+        setup_channel_id=channel_id,
+        setup_message_id=message_id,
+        last_readiness_score=None,
+        current_step=None,
+        delegated_admins=(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_resume_one_launcher_edits_message_with_status_aware_view():
+    import discord
+
+    from cogs.setup_cog import SetupCog
+
+    bot = MagicMock()
+    cog = SetupCog(bot)
+
+    message = MagicMock()
+    message.edit = AsyncMock()
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.fetch_message = AsyncMock(return_value=message)
+    guild = MagicMock(id=1)
+    guild.get_channel = MagicMock(return_value=channel)
+
+    with patch(
+        "cogs.setup_cog.setup_session.resume_session",
+        new_callable=AsyncMock,
+        return_value=_session_with_message(status="in_progress"),
+    ):
+        result = await cog._resume_one_launcher(guild)
+
+    assert result is True
+    channel.fetch_message.assert_awaited_once_with(8888)
+    message.edit.assert_awaited_once()
+    edited_view = message.edit.await_args.kwargs["view"]
+    assert isinstance(edited_view, SetupLauncherView)
+    assert _find_button(edited_view, "setup:start").label == "Resume Setup"
+
+
+@pytest.mark.asyncio
+async def test_resume_one_launcher_skips_when_no_session_row():
+    from cogs.setup_cog import SetupCog
+
+    bot = MagicMock()
+    cog = SetupCog(bot)
+    guild = MagicMock(id=1)
+
+    with patch(
+        "cogs.setup_cog.setup_session.resume_session",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        result = await cog._resume_one_launcher(guild)
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_resume_one_launcher_skips_when_channel_or_message_id_missing():
+    from cogs.setup_cog import SetupCog
+
+    bot = MagicMock()
+    cog = SetupCog(bot)
+    guild = MagicMock(id=1)
+
+    with patch(
+        "cogs.setup_cog.setup_session.resume_session",
+        new_callable=AsyncMock,
+        return_value=_session_with_message(channel_id=None, message_id=None),
+    ):
+        result = await cog._resume_one_launcher(guild)
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_resume_one_launcher_handles_deleted_message_silently():
+    import discord
+
+    from cogs.setup_cog import SetupCog
+
+    bot = MagicMock()
+    cog = SetupCog(bot)
+
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.fetch_message = AsyncMock(
+        side_effect=discord.NotFound(MagicMock(), "gone"),
+    )
+    guild = MagicMock(id=1)
+    guild.get_channel = MagicMock(return_value=channel)
+
+    with patch(
+        "cogs.setup_cog.setup_session.resume_session",
+        new_callable=AsyncMock,
+        return_value=_session_with_message(),
+    ):
+        # Must not raise.
+        result = await cog._resume_one_launcher(guild)
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_resume_one_launcher_handles_forbidden_silently():
+    import discord
+
+    from cogs.setup_cog import SetupCog
+
+    bot = MagicMock()
+    cog = SetupCog(bot)
+
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.name = "general"
+    channel.fetch_message = AsyncMock(
+        side_effect=discord.Forbidden(MagicMock(), "no perm"),
+    )
+    guild = MagicMock(id=1)
+    guild.get_channel = MagicMock(return_value=channel)
+
+    with patch(
+        "cogs.setup_cog.setup_session.resume_session",
+        new_callable=AsyncMock,
+        return_value=_session_with_message(),
+    ):
+        result = await cog._resume_one_launcher(guild)
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_resume_launchers_iterates_every_guild_and_isolates_failures():
+    from cogs.setup_cog import SetupCog
+
+    bot = MagicMock()
+    g1 = MagicMock(id=1)
+    g2 = MagicMock(id=2)
+    g3 = MagicMock(id=3)
+    bot.guilds = [g1, g2, g3]
+    cog = SetupCog(bot)
+
+    seen_ids: list[int] = []
+
+    async def fake_resume_one(guild):
+        seen_ids.append(guild.id)
+        if guild.id == 2:
+            raise RuntimeError("boom on guild 2")
+        return True
+
+    with patch.object(
+        cog,
+        "_resume_one_launcher",
+        side_effect=fake_resume_one,
+    ):
+        await cog._resume_launchers()
+
+    # All three guilds processed, the failure on guild 2 did not
+    # short-circuit the sweep.
+    assert seen_ids == [1, 2, 3]


### PR DESCRIPTION
## Summary

- Adds status-aware labels on the launcher's Start button: `pending` → "Start Setup", `in_progress` → "Resume Setup", `complete` → "Re-run Setup".
- Adds an `on_ready` resumption sweep that walks `bot.guilds` and edits each recorded launcher message in place with the right label set and a fresh status-aware embed.
- Closes Track 4.

> Stacked on top of PR #182 (`cogs: setup launcher + on_guild_join`). GitHub will auto-rebase to `main` when PRs #181 → #182 land in order.

## Scope table

| Does | Does NOT |
|---|---|
| Add `SetupLauncherView(status=...)` constructor and relabel the Start button per status | Change any button's `custom_id` (interaction routing untouched) |
| Add `SetupCog._resume_launchers` + `_resume_one_launcher` for on_ready re-binding | Implement the wizard flow itself (Track 8) |
| Isolate per-guild resume failures so one bad guild doesn't abort the sweep | Clear stale channel/message ids in the row — leave that to an explicit teardown (Track 8 PR 24 may add a soft-clear path) |
| Pin the label map + the 4 resume-failure modes via tests | Add drift detection (Track 8 PR 24) |

## Files changed

- `disbot/cogs/setup_cog.py` — adds `_START_LABELS_BY_STATUS`, `SetupLauncherView` constructor + `_apply_status_labels`, `SetupCog.on_ready`, `SetupCog._resume_launchers`, `SetupCog._resume_one_launcher`.
- `tests/unit/cogs/test_setup_cog.py` — 11 new cases.

## Architecture impact

**Additive polish on T4P9.** No new modules. The base `SetupLauncherView()` is still what `cog_load` registers with `bot.add_view`; discord.py uses it to dispatch any incoming interaction (it matches by `custom_id`, not by label). The status-aware instance is only used as the message's visible view — labels are rendered for the user but never affect callback routing.

Failure-isolation is layered:
- Inside `_resume_one_launcher`: each Discord call wrapped to swallow `NotFound` / `Forbidden` / `HTTPException` with a warn/debug log.
- Inside `_resume_launchers`: each guild wrapped in try/except so one bad guild does not abort the sweep.

## Tests run

```
python -m pytest tests/unit/cogs/test_setup_cog.py -v   # 33 passed (was 22 in T4P9)
python -m pytest -q                                     # 2751 passed (was 2740), 1 warning
ruff check . --exclude .github,tests,venv,env,build,dist            # All checks passed
black --check . --exclude '(\.github|tests|venv|env|build|dist)'    # 304 files unchanged
isort --check-only . --skip-glob '*/(\.github|tests|venv|env|build|dist)/*'   # passed
mypy disbot/                                            # 305 source files, 0 issues
```

## Manual Discord smoke checklist

- [ ] In a test guild whose `setup_session.setup_status='in_progress'`, restart the bot; verify the launcher message updates with "Resume Setup" instead of "Start Setup" (PENDING — no live runtime).
- [ ] Set `setup_status='complete'`, restart; verify "Re-run Setup" appears (PENDING).
- [ ] Delete the launcher message manually, restart; verify the cog logs a `NotFound` and does not crash (PENDING).
- [ ] Strip the bot's `Read Message History` permission on the launcher channel; restart; verify `Forbidden` is swallowed and a warning logs (PENDING).

## Rollback plan

`git revert`. The launcher reverts to T4P9 behaviour (fixed labels, no on_ready resume). No DB schema change.

## Out of scope

- Drift detection (highlight changes from the accepted plan when readiness re-runs after `complete`) — Track 8 PR 24.
- Clearing stale channel/message ids from the row when the launcher is gone — kept non-destructive in this PR.
- Wizard flow itself — Track 8.

## Follow-up items

- Track 5 PR 11: `services: guild snapshot` — opens Track 5 (AI advisor). The metadata-only snapshot type used by deterministic + AI advisors.

## CI status

Pending — subscribing after creation.

## Risk level

**Low.** Label-only diff + idempotent edit_message sweep. Custom IDs unchanged. Every failure path on the resume sweep is logged + swallowed.

## User-visible behavior change

**Yes (additive).** Launcher message now reflects the current status across restarts. Existing buttons keep working with the same callback semantics.

## Slash sync or deploy action required

**No.**

## Next PR

`services: guild snapshot (Track 5 PR 11)` — per the accepted plan at `/root/.claude/plans/superbot-2-0-setup-purring-peach.md` §5 Track 5 PR 11. Opens Track 5 (AI advisor) with the privacy-vetted `GuildSnapshot` frozen dataclass that both the deterministic and AI advisors consume.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXdDyevoQLQXgmgog7erwY)_