### PR TITLE
services: guild snapshot (Track 5 PR 11)

### DIFF
--- a/disbot/services/guild_snapshot.py
+++ b/disbot/services/guild_snapshot.py
@@ -1,0 +1,335 @@
+"""Guild metadata snapshot — Phase 9f / Track 5 PR 11.
+
+Collects an opt-in, privacy-vetted view of a guild's structure that
+both the deterministic and AI advisors consume. The snapshot is a
+frozen dataclass with explicit fields — no ``**extra``, no
+``__dict__`` shoveling — so a future schema change is a code change,
+not an accidental data exposure.
+
+Privacy contract
+----------------
+**Included by default** (anything operator-visible in the Discord UI):
+
+* Guild id + name + owner id.
+* Channel + category + role metadata: id, name, type, position,
+  topic (channels only), parent category, manageable flag.
+* Per-channel bot-permission summary (a compact view-only string —
+  no member-by-member ACL matrix).
+* The bot's existing settings + bindings snapshots (already in
+  service catalogues).
+* The output of :func:`services.resource_health.inspect` so the
+  advisor can ground recommendations against actual health.
+
+**Excluded by default** (operator can later opt in per
+``setup.snapshot_scope = "extended"``, but Track 5 ships OFF):
+
+* Message content.
+* Member list / member count per channel.
+* Invites.
+* Per-channel permission-overwrite matrix (the raw bitmask grid).
+
+Tests pin both lists via the documented field-name conventions: a
+test enumerates ``dataclasses.asdict(snapshot)`` and rejects any
+key that smells like a member, invite, message, or overwrite
+field.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field, fields
+from typing import TYPE_CHECKING, Any
+
+from services.resource_health import (
+    ResourceHealthFinding,
+)
+from services.resource_health import inspect as inspect_resource_health
+
+if TYPE_CHECKING:
+    import discord
+
+logger = logging.getLogger("bot.services.guild_snapshot")
+
+
+@dataclass(frozen=True)
+class ChannelMeta:
+    """View-only channel metadata."""
+
+    id: int
+    name: str
+    type: str
+    topic: str | None
+    parent_category: str | None
+    position: int
+    bot_can_view: bool
+    bot_can_send: bool
+    bot_can_embed: bool
+
+
+@dataclass(frozen=True)
+class CategoryMeta:
+    """View-only category metadata."""
+
+    id: int
+    name: str
+    position: int
+    bot_can_manage: bool
+
+
+@dataclass(frozen=True)
+class RoleMeta:
+    """View-only role metadata."""
+
+    id: int
+    name: str
+    position: int
+    bot_can_manage: bool
+
+
+@dataclass(frozen=True)
+class GuildSnapshot:
+    """Metadata-only snapshot of a guild's structure.
+
+    All fields are documented; the field set is closed (no dynamic
+    attributes) so a future privacy widening is a deliberate edit,
+    not an accident.
+    """
+
+    guild_id: int
+    guild_name: str
+    owner_id: int
+    channels: tuple[ChannelMeta, ...] = ()
+    categories: tuple[CategoryMeta, ...] = ()
+    roles: tuple[RoleMeta, ...] = ()
+    settings_snapshot: dict[str, Any] = field(default_factory=dict)
+    bindings_snapshot: dict[str, Any] = field(default_factory=dict)
+    readiness_findings: tuple[ResourceHealthFinding, ...] = ()
+
+
+# Documented "should never appear in a snapshot" field-name tokens.
+# Tests assert these against the keys of ``dataclasses.asdict(snapshot)``.
+EXCLUDED_FIELD_TOKENS: frozenset[str] = frozenset(
+    {
+        "message_content",
+        "messages",
+        "members",
+        "member_count",
+        "member_list",
+        "invites",
+        "permission_overwrites",
+        "overwrites_matrix",
+        "raw_permissions",
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# Collect
+# ---------------------------------------------------------------------------
+
+
+async def collect(guild: discord.Guild) -> GuildSnapshot:
+    """Build the snapshot for ``guild``.
+
+    Pure read; no DB writes, no Discord create calls. The
+    readiness inspection may raise (DB down, etc.); failure is
+    swallowed and ``readiness_findings`` is left empty so the
+    advisor still has something to work with.
+    """
+    me = guild.me
+
+    channels = _collect_channels(guild, me)
+    categories = _collect_categories(guild, me)
+    roles = _collect_roles(guild, me)
+    settings_snapshot = _collect_settings_snapshot()
+    bindings_snapshot = _collect_bindings_snapshot()
+
+    findings: tuple[ResourceHealthFinding, ...] = ()
+    try:
+        findings = await inspect_resource_health(guild)
+    except Exception:
+        logger.exception(
+            "guild_snapshot.collect: resource_health.inspect failed for "
+            "guild=%d; snapshot continues with empty readiness_findings.",
+            guild.id,
+        )
+
+    return GuildSnapshot(
+        guild_id=guild.id,
+        guild_name=guild.name,
+        owner_id=guild.owner_id or 0,
+        channels=channels,
+        categories=categories,
+        roles=roles,
+        settings_snapshot=settings_snapshot,
+        bindings_snapshot=bindings_snapshot,
+        readiness_findings=findings,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-collection helpers
+# ---------------------------------------------------------------------------
+
+
+def _collect_channels(guild: Any, me: Any) -> tuple[ChannelMeta, ...]:
+    import discord  # local — keep the module importable without discord
+
+    out: list[ChannelMeta] = []
+    text_channels = list(getattr(guild, "text_channels", ()) or ())
+    voice_channels = list(getattr(guild, "voice_channels", ()) or ())
+    stage_channels = list(getattr(guild, "stage_channels", ()) or ())
+
+    def _add_text_like(channels, kind_label):
+        for ch in channels:
+            perms = ch.permissions_for(me) if me is not None else None
+            parent = getattr(ch, "category", None)
+            out.append(
+                ChannelMeta(
+                    id=ch.id,
+                    name=ch.name,
+                    type=kind_label,
+                    topic=getattr(ch, "topic", None),
+                    parent_category=parent.name if parent is not None else None,
+                    position=getattr(ch, "position", 0),
+                    bot_can_view=(
+                        bool(getattr(perms, "view_channel", False))
+                        if perms is not None
+                        else False
+                    ),
+                    bot_can_send=(
+                        bool(getattr(perms, "send_messages", False))
+                        if perms is not None
+                        else False
+                    ),
+                    bot_can_embed=(
+                        bool(getattr(perms, "embed_links", False))
+                        if perms is not None
+                        else False
+                    ),
+                ),
+            )
+
+    _add_text_like(text_channels, "text")
+    _add_text_like(voice_channels, "voice")
+    _add_text_like(stage_channels, "stage")
+
+    del discord  # keep mypy happy without an unused-import warning
+    return tuple(out)
+
+
+def _collect_categories(guild: Any, me: Any) -> tuple[CategoryMeta, ...]:
+    out: list[CategoryMeta] = []
+    for cat in getattr(guild, "categories", ()) or ():
+        perms = cat.permissions_for(me) if me is not None else None
+        out.append(
+            CategoryMeta(
+                id=cat.id,
+                name=cat.name,
+                position=getattr(cat, "position", 0),
+                bot_can_manage=(
+                    bool(getattr(perms, "manage_channels", False))
+                    if perms is not None
+                    else False
+                ),
+            ),
+        )
+    return tuple(out)
+
+
+def _collect_roles(guild: Any, me: Any) -> tuple[RoleMeta, ...]:
+    out: list[RoleMeta] = []
+    bot_top_position = (
+        getattr(getattr(me, "top_role", None), "position", 0) if me is not None else 0
+    )
+    bot_can_manage_roles = (
+        bool(getattr(getattr(me, "guild_permissions", None), "manage_roles", False))
+        if me is not None
+        else False
+    )
+    for role in getattr(guild, "roles", ()) or ():
+        position = getattr(role, "position", 0)
+        manageable = bool(
+            bot_can_manage_roles and position < bot_top_position,
+        )
+        out.append(
+            RoleMeta(
+                id=role.id,
+                name=role.name,
+                position=position,
+                bot_can_manage=manageable,
+            ),
+        )
+    return tuple(out)
+
+
+def _collect_settings_snapshot() -> dict[str, Any]:
+    """Return a flat ``{subsystem.name: default_value}`` snapshot.
+
+    Uses :func:`core.runtime.subsystem_schema.all_schemas` so the
+    advisor knows what settings exist without us shipping a
+    parallel catalogue. Defaults only — per-guild values are not
+    surfaced through the snapshot to keep it metadata-only.
+    """
+    try:
+        from core.runtime.subsystem_schema import all_schemas
+    except Exception:
+        logger.exception(
+            "guild_snapshot: subsystem_schema unavailable; settings_snapshot empty.",
+        )
+        return {}
+    out: dict[str, Any] = {}
+    for subsystem, schema in (all_schemas() or {}).items():
+        for spec in schema.settings:
+            out[f"{subsystem}.{spec.name}"] = spec.default
+    return out
+
+
+def _collect_bindings_snapshot() -> dict[str, Any]:
+    """Return a flat ``{subsystem.name: {kind, required, hint}}`` snapshot.
+
+    Names + kinds only — binding TARGETS (channel/role ids) are out
+    of scope for the snapshot; the per-guild target state lives in
+    the readiness findings.
+    """
+    try:
+        from core.runtime.subsystem_schema import all_schemas
+    except Exception:
+        logger.exception(
+            "guild_snapshot: subsystem_schema unavailable; bindings_snapshot empty.",
+        )
+        return {}
+    out: dict[str, Any] = {}
+    for subsystem, schema in (all_schemas() or {}).items():
+        for binding in schema.bindings:
+            out[f"{subsystem}.{binding.name}"] = {
+                "kind": binding.kind.value,
+                "required": binding.required,
+                "hint": binding.hint,
+            }
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Static introspection helper used by tests
+# ---------------------------------------------------------------------------
+
+
+def documented_field_names() -> tuple[str, ...]:
+    """Return every field name declared on :class:`GuildSnapshot`.
+
+    Tests pin the set so adding a new field requires updating the
+    privacy test list at the same time.
+    """
+    return tuple(f.name for f in fields(GuildSnapshot))
+
+
+__all__ = [
+    "EXCLUDED_FIELD_TOKENS",
+    "CategoryMeta",
+    "ChannelMeta",
+    "GuildSnapshot",
+    "RoleMeta",
+    "collect",
+    "documented_field_names",
+]

--- a/tests/unit/services/test_guild_snapshot.py
+++ b/tests/unit/services/test_guild_snapshot.py
@@ -1,0 +1,397 @@
+"""Phase 9f / Track 5 PR 11 — guild_snapshot tests.
+
+Pins:
+
+* ``collect`` populates the documented fields from a fake guild.
+* The frozen dataclass has exactly the field set we documented;
+  any new field is a deliberate edit (caught by the field-name
+  pin in :func:`test_documented_fields_match_expected`).
+* No excluded field-name token (message_content, members,
+  invites, permission_overwrites, etc.) appears anywhere in the
+  serialized snapshot.
+* Per-channel bot-permission booleans reflect what ``permissions_for``
+  returns; the snapshot does **not** expose the raw permission
+  matrix.
+* Role ``bot_can_manage`` requires both Manage Roles AND the
+  role sitting below the bot's top role.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.guild_snapshot import (
+    EXCLUDED_FIELD_TOKENS,
+    CategoryMeta,
+    ChannelMeta,
+    GuildSnapshot,
+    RoleMeta,
+    collect,
+    documented_field_names,
+)
+from services.resource_health import ResourceHealthFinding
+
+# ---------------------------------------------------------------------------
+# Fake guild factory
+# ---------------------------------------------------------------------------
+
+
+def _perms(**overrides):
+    base = dict(
+        view_channel=True,
+        send_messages=True,
+        embed_links=True,
+        manage_channels=True,
+        manage_roles=True,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _channel(*, id, name, topic=None, parent=None, position=0, perms=None):
+    perms = perms if perms is not None else _perms()
+    ch = MagicMock()
+    ch.id = id
+    ch.name = name
+    ch.topic = topic
+    ch.category = parent
+    ch.position = position
+    ch.permissions_for = MagicMock(return_value=perms)
+    return ch
+
+
+def _category(*, id, name, position=0, perms=None):
+    perms = perms if perms is not None else _perms()
+    cat = MagicMock()
+    cat.id = id
+    cat.name = name
+    cat.position = position
+    cat.permissions_for = MagicMock(return_value=perms)
+    return cat
+
+
+def _role(*, id, name, position):
+    role = MagicMock()
+    role.id = id
+    role.name = name
+    role.position = position
+    return role
+
+
+def _me(*, top_role_position=10, manage_roles=True):
+    top = SimpleNamespace(position=top_role_position)
+    return SimpleNamespace(
+        top_role=top,
+        guild_permissions=_perms(manage_roles=manage_roles),
+    )
+
+
+def _guild(
+    *,
+    id=1,
+    name="Test Guild",
+    owner_id=99,
+    text_channels=(),
+    voice_channels=(),
+    stage_channels=(),
+    categories=(),
+    roles=(),
+    me=None,
+):
+    g = MagicMock()
+    g.id = id
+    g.name = name
+    g.owner_id = owner_id
+    g.text_channels = list(text_channels)
+    g.voice_channels = list(voice_channels)
+    g.stage_channels = list(stage_channels)
+    g.categories = list(categories)
+    g.roles = list(roles)
+    g.me = me if me is not None else _me()
+    return g
+
+
+# ---------------------------------------------------------------------------
+# Schema / readiness mocks (shared)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _mock_schemas():
+    """Stub :func:`core.runtime.subsystem_schema.all_schemas`."""
+    from core.runtime.subsystem_schema import (
+        BindingKind,
+        BindingSpec,
+        SettingSpec,
+        SubsystemSchema,
+    )
+
+    schemas = {
+        "logging": SubsystemSchema(
+            subsystem="logging",
+            bindings=(
+                BindingSpec(
+                    name="mod_channel",
+                    kind=BindingKind.CHANNEL,
+                    required=True,
+                    hint="moderation log channel",
+                    capability_required="logging.mod_channel.bind",
+                ),
+            ),
+            settings=(
+                SettingSpec(
+                    name="enabled",
+                    value_type=bool,
+                    default=False,
+                    settings_key="LOGGING_ENABLED",
+                ),
+            ),
+        ),
+    }
+    with patch(
+        "services.guild_snapshot.all_schemas",
+        return_value=schemas,
+        create=True,  # all_schemas is imported lazily
+    ):
+        # Lazy import lives inside helpers; patching at the
+        # call-site module so the helper imports our stub.
+        with (
+            patch(
+                "core.runtime.subsystem_schema.all_schemas",
+                return_value=schemas,
+            ),
+        ):
+            yield schemas
+
+
+@pytest.fixture
+def _mock_resource_health_empty():
+    with patch(
+        "services.guild_snapshot.inspect_resource_health",
+        new_callable=AsyncMock,
+        return_value=(),
+    ) as mock:
+        yield mock
+
+
+# ---------------------------------------------------------------------------
+# Static field set + EXCLUDED_FIELD_TOKENS
+# ---------------------------------------------------------------------------
+
+
+def test_documented_fields_match_expected():
+    """Pin the closed field set so an accidental addition is caught."""
+    assert set(documented_field_names()) == {
+        "guild_id",
+        "guild_name",
+        "owner_id",
+        "channels",
+        "categories",
+        "roles",
+        "settings_snapshot",
+        "bindings_snapshot",
+        "readiness_findings",
+    }
+
+
+def test_excluded_tokens_cover_documented_privacy_categories():
+    """The privacy-test token set must include each documented
+    category from the module docstring."""
+    must_include = {
+        "message_content",
+        "members",
+        "member_count",
+        "invites",
+        "permission_overwrites",
+    }
+    assert must_include.issubset(EXCLUDED_FIELD_TOKENS)
+
+
+# ---------------------------------------------------------------------------
+# collect: happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_collect_returns_documented_fields(
+    _mock_schemas, _mock_resource_health_empty
+):
+    g = _guild(
+        text_channels=[
+            _channel(id=100, name="general", topic="welcome", position=1),
+        ],
+        categories=[_category(id=200, name="Mod", position=1)],
+        roles=[_role(id=300, name="@everyone", position=0)],
+    )
+    snap = await collect(g)
+    assert isinstance(snap, GuildSnapshot)
+    assert snap.guild_id == g.id
+    assert snap.guild_name == g.name
+    assert snap.owner_id == g.owner_id
+    assert any(isinstance(c, ChannelMeta) for c in snap.channels)
+    assert any(isinstance(cat, CategoryMeta) for cat in snap.categories)
+    assert any(isinstance(r, RoleMeta) for r in snap.roles)
+    # Settings/bindings snapshots include the stubbed schema entries.
+    assert "logging.enabled" in snap.settings_snapshot
+    assert "logging.mod_channel" in snap.bindings_snapshot
+    # readiness empty because the mock returned ()
+    assert snap.readiness_findings == ()
+
+
+@pytest.mark.asyncio
+async def test_collect_classifies_channel_types(
+    _mock_schemas, _mock_resource_health_empty
+):
+    g = _guild(
+        text_channels=[_channel(id=100, name="text-1")],
+        voice_channels=[_channel(id=101, name="voice-1")],
+        stage_channels=[_channel(id=102, name="stage-1")],
+    )
+    snap = await collect(g)
+    by_id = {c.id: c.type for c in snap.channels}
+    assert by_id[100] == "text"
+    assert by_id[101] == "voice"
+    assert by_id[102] == "stage"
+
+
+@pytest.mark.asyncio
+async def test_collect_renders_parent_category_name(
+    _mock_schemas, _mock_resource_health_empty
+):
+    cat = _category(id=200, name="Mod")
+    ch = _channel(id=100, name="mod-log", parent=cat)
+    g = _guild(text_channels=[ch], categories=[cat])
+    snap = await collect(g)
+    text_ch = next(c for c in snap.channels if c.id == 100)
+    assert text_ch.parent_category == "Mod"
+
+
+@pytest.mark.asyncio
+async def test_collect_per_channel_permissions_reflect_permissions_for(
+    _mock_schemas, _mock_resource_health_empty
+):
+    locked = _channel(
+        id=100,
+        name="locked",
+        perms=_perms(send_messages=False, embed_links=False),
+    )
+    sendable = _channel(id=101, name="ok")
+    g = _guild(text_channels=[locked, sendable])
+    snap = await collect(g)
+    by_id = {c.id: c for c in snap.channels}
+    assert by_id[100].bot_can_view is True
+    assert by_id[100].bot_can_send is False
+    assert by_id[100].bot_can_embed is False
+    assert by_id[101].bot_can_send is True
+
+
+@pytest.mark.asyncio
+async def test_collect_role_can_manage_requires_position_below_bot(
+    _mock_schemas, _mock_resource_health_empty
+):
+    above_bot = _role(id=300, name="High", position=20)
+    below_bot = _role(id=301, name="Low", position=5)
+    g = _guild(roles=[above_bot, below_bot], me=_me(top_role_position=10))
+    snap = await collect(g)
+    by_id = {r.id: r for r in snap.roles}
+    assert by_id[300].bot_can_manage is False
+    assert by_id[301].bot_can_manage is True
+
+
+@pytest.mark.asyncio
+async def test_collect_role_can_manage_false_when_bot_lacks_manage_roles(
+    _mock_schemas, _mock_resource_health_empty
+):
+    role = _role(id=300, name="VIP", position=5)
+    g = _guild(
+        roles=[role],
+        me=_me(top_role_position=10, manage_roles=False),
+    )
+    snap = await collect(g)
+    assert snap.roles[0].bot_can_manage is False
+
+
+@pytest.mark.asyncio
+async def test_collect_swallows_resource_health_failure(_mock_schemas):
+    g = _guild()
+    with patch(
+        "services.guild_snapshot.inspect_resource_health",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("db down"),
+    ):
+        snap = await collect(g)
+    assert snap.readiness_findings == ()
+
+
+@pytest.mark.asyncio
+async def test_collect_includes_readiness_findings_when_inspection_succeeds(
+    _mock_schemas,
+):
+    from core.runtime.subsystem_schema import BindingKind
+
+    finding = ResourceHealthFinding(
+        subsystem="logging",
+        binding_name="mod_channel",
+        kind=BindingKind.CHANNEL,
+        status="ok",
+        severity="info",
+        message="ok",
+    )
+    g = _guild()
+    with patch(
+        "services.guild_snapshot.inspect_resource_health",
+        new_callable=AsyncMock,
+        return_value=(finding,),
+    ):
+        snap = await collect(g)
+    assert snap.readiness_findings == (finding,)
+
+
+# ---------------------------------------------------------------------------
+# Privacy contract
+# ---------------------------------------------------------------------------
+
+
+def _all_keys(value):
+    """Recursively yield every dict key inside a nested asdict output."""
+    if isinstance(value, dict):
+        for k, v in value.items():
+            yield k
+            yield from _all_keys(v)
+    elif isinstance(value, (list, tuple)):
+        for v in value:
+            yield from _all_keys(v)
+
+
+@pytest.mark.asyncio
+async def test_serialised_snapshot_contains_no_excluded_field_tokens(
+    _mock_schemas, _mock_resource_health_empty
+):
+    """Privacy invariant: the asdict() output of a populated
+    snapshot must not contain any key whose name matches an
+    excluded-field token."""
+    g = _guild(
+        text_channels=[
+            _channel(
+                id=100,
+                name="mod-log",
+                topic="moderation log",
+                parent=_category(id=200, name="Mod"),
+            ),
+        ],
+        categories=[_category(id=200, name="Mod")],
+        roles=[_role(id=300, name="VIP", position=5)],
+    )
+    snap = await collect(g)
+    serialised = dataclasses.asdict(snap)
+
+    every_key = list(_all_keys(serialised))
+    for token in EXCLUDED_FIELD_TOKENS:
+        assert not any(token in key for key in every_key), (
+            f"Excluded token {token!r} appeared in serialised snapshot keys: "
+            f"{[k for k in every_key if token in k]}"
+        )


### PR DESCRIPTION
## Summary

- Add `services.guild_snapshot` — opens Track 5 (AI advisor) with the metadata-only `GuildSnapshot` frozen dataclass that both deterministic and AI advisors will consume.
- Closed field set, no `**extra` shoveling. Excluded fields (`message_content`, `members`, `invites`, `permission_overwrites_matrix`, …) are pinned by a recursive `asdict()` walk in tests.
- Tracks 1–4 now fully on `main` (PRs #174, #175, #176, #177, #178, #179, #180, #181, #182, #183 all merged).

## Scope table

| Does | Does NOT |
|---|---|
| Add `GuildSnapshot` + `ChannelMeta` / `CategoryMeta` / `RoleMeta` frozen dataclasses | Surface member lists / counts |
| Add `collect(guild)` async builder, pure read | Surface message content |
| Wire `services.resource_health.inspect` for the `readiness_findings` field | Surface invites |
| Wire `core.runtime.subsystem_schema.all_schemas` for the `settings_snapshot` + `bindings_snapshot` fields | Expose the raw permission-overwrite bitmask matrix |
| Pin the closed field set via `documented_field_names()` + a privacy-contract test that walks `dataclasses.asdict(snapshot)` keys against `EXCLUDED_FIELD_TOKENS` | Add the deterministic advisor (Track 5 PR 12) or AI advisor (Track 5 PR 13) |
| Swallow `resource_health.inspect` failures so the snapshot still returns useful data | Persist the snapshot |

## Files changed

- `disbot/services/guild_snapshot.py` — **new** (~310 LOC).
- `tests/unit/services/test_guild_snapshot.py` — **new** (~390 LOC, 11 cases).

## Architecture impact

**Additive.** New pure read service. No callers in this PR; Track 5 PR 12 (deterministic advisor) and PR 13 (AI advisor) consume `GuildSnapshot`. The privacy contract is enforced at the dataclass-shape level (closed fields, frozen) AND at the test level (asdict walk against `EXCLUDED_FIELD_TOKENS`). Both safeguards are needed: the dataclass prevents accidental dynamic attribute shoveling, the asdict walk prevents accidental field additions whose names look benign but contain restricted information.

## Tests run

```
python -m pytest tests/unit/services/test_guild_snapshot.py -v          # 11 passed
python -m pytest -q                                                     # 2684 passed, 1 warning
ruff check . --exclude .github,tests,venv,env,build,dist                # All checks passed
black --check . --exclude '(\.github|tests|venv|env|build|dist)'        # 301 files unchanged
isort --check-only . --skip-glob '*/(\.github|tests|venv|env|build|dist)/*'   # passed
mypy disbot/                                                            # 302 source files, 0 issues
```

## Manual Discord smoke checklist

- [ ] In a test guild, call `await services.guild_snapshot.collect(guild)`; verify the channel list, category list, and role list match what `!platform setup-readiness` shows (PENDING — no live runtime).
- [ ] Strip bot send permission on one channel; re-collect; verify `bot_can_send=False` for that channel (PENDING).
- [ ] Promote a role above the bot's top role; re-collect; verify `bot_can_manage=False` for that role (PENDING).

## Rollback plan

`git revert`. The module is additive with no callers; removing it has no runtime effect.

## Out of scope

- Deterministic advisor that maps the snapshot to `SetupRecommendation` records — Track 5 PR 12.
- AI advisor (OpenAI / Anthropic protocol) — Track 5 PR 13.
- Extended-scope snapshot opt-in (`setup.snapshot_scope = "extended"`) — deferred decision per the accepted plan §11.

## Follow-up items

- Track 5 PR 12: `services: deterministic advisor` — adds `SetupRecommendation` + `SetupPlanDraft` + `DeterministicAdvisor.suggest(snapshot) -> SetupPlanDraft`.

## CI status

Pending — subscribing after creation.

## Risk level

**Low.** Pure read service, closed dataclass + privacy invariant pinned by a recursive asdict walk. No callers, no schema changes.

## User-visible behavior change

**No.** New module with no callers yet.

## Slash sync or deploy action required

**No.**

## Next PR

`services: deterministic advisor (Track 5 PR 12)` — per the accepted plan at `/root/.claude/plans/superbot-2-0-setup-purring-peach.md` §5 Track 5 PR 12.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXdDyevoQLQXgmgog7erwY)_