### PR TITLE
views: AI review UI (Track 5 PR 14)

### DIFF
--- a/disbot/config.py
+++ b/disbot/config.py
@@ -93,3 +93,21 @@ CLEANUP_WHITELIST_CHANNELS: set[int] = _parse_channel_ids(
         1403818013408624642,
     ],
 )
+
+
+# ==========================
+# Setup-wizard advisor (Phase 9f / Track 5)
+# ==========================
+# Provider for the AI-assisted setup advisor. One of:
+#   * ``deterministic`` — name-matching rules only (default).
+#   * ``openai``        — OpenAI gpt-4o-mini behind strict JSON schema.
+#                          Requires ``OPENAI_API_KEY``.
+#   * ``anthropic``     — Claude Sonnet / Haiku. Requires ``ANTHROPIC_API_KEY``.
+#                          Reserved; concrete adapter ships in a follow-up.
+# When the requested provider is unavailable (missing key, missing SDK),
+# the factory falls back to ``deterministic`` so CI / dev envs never make
+# external calls by accident.
+SETUP_ADVISOR_PROVIDER = os.getenv("SETUP_ADVISOR_PROVIDER", "deterministic").lower()
+SETUP_ADVISOR_OPENAI_MODEL = os.getenv("SETUP_ADVISOR_OPENAI_MODEL", "gpt-4o-mini")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
+ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY", "")

--- a/disbot/services/setup_ai_advisor.py
+++ b/disbot/services/setup_ai_advisor.py
@@ -1,0 +1,427 @@
+"""AI-assisted setup advisor — Phase 9f / Track 5 PR 13.
+
+Defines the :class:`SetupAdvisor` Protocol that both deterministic
+and AI advisors implement, an OpenAI implementation, and a
+factory :func:`build_advisor` that picks an implementation based on
+the ``SETUP_ADVISOR_PROVIDER`` environment variable (default:
+``deterministic`` — so CI and dev environments never reach out to
+an external API by accident).
+
+Provider contract
+-----------------
+Any advisor must:
+
+* Take a :class:`GuildSnapshot` as its only input.
+* Return a :class:`SetupPlanDraft` describing recommendations.
+* Never mutate DB state, never call ``guild.create_*``, never
+  invent a subsystem or binding name.
+
+Output validation
+-----------------
+Every advisor's recommendations are re-validated against
+:func:`subsystem_schema.all_schemas` before they ever surface in the
+UI. An AI model that hallucinates a subsystem like ``"vibes"`` or a
+binding kind like ``"emoji"`` simply has its proposal dropped with a
+reason; it cannot extend the bot's mutation surface.
+
+Structured output
+-----------------
+The OpenAI implementation uses strict JSON Schema response format
+(``response_format={"type": "json_schema", "json_schema": {...,
+"strict": true}}``) so the SDK validates shape on the wire. We
+then re-validate the parsed objects against our local schema
+catalogue. Both layers run; CI does not have an OPENAI_API_KEY so
+the path is exercised through mock objects.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+from services.guild_snapshot import GuildSnapshot
+from services.setup_plan import (
+    CONFIDENCES,
+    DeterministicAdvisor,
+    SetupPlanDraft,
+    SetupRecommendation,
+)
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger("bot.services.setup_ai_advisor")
+
+DETERMINISTIC = "deterministic"
+OPENAI = "openai"
+ANTHROPIC = "anthropic"
+
+KNOWN_PROVIDERS: frozenset[str] = frozenset({DETERMINISTIC, OPENAI, ANTHROPIC})
+
+# JSON schema posted alongside ``response_format`` so the SDK guards
+# the shape we then re-validate locally.
+_RECOMMENDATION_JSON_SCHEMA: dict[str, Any] = {
+    "name": "SetupPlanDraft",
+    "schema": {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "recommendations": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "subsystem": {"type": "string"},
+                        "binding_name": {"type": "string"},
+                        "target_kind": {"type": "string"},
+                        "target_id": {"type": "integer"},
+                        "target_name": {"type": "string"},
+                        "confidence": {
+                            "type": "string",
+                            "enum": ["high", "medium", "low"],
+                        },
+                        "reason": {"type": "string"},
+                    },
+                    "required": [
+                        "subsystem",
+                        "binding_name",
+                        "target_kind",
+                        "target_id",
+                        "target_name",
+                        "confidence",
+                        "reason",
+                    ],
+                },
+            },
+        },
+        "required": ["recommendations"],
+    },
+    "strict": True,
+}
+
+
+@runtime_checkable
+class SetupAdvisor(Protocol):
+    """The single interface deterministic + AI advisors implement."""
+
+    async def suggest(self, snapshot: GuildSnapshot) -> SetupPlanDraft: ...
+
+
+# ---------------------------------------------------------------------------
+# OpenAI advisor
+# ---------------------------------------------------------------------------
+
+
+_SYSTEM_PROMPT = (
+    "You are a Discord-server setup assistant. The user will send you a "
+    "metadata snapshot of a guild and ask which channels/categories/roles "
+    "should be bound to which bot subsystems. Reply ONLY with the strict "
+    "JSON schema provided. Never invent a subsystem name, binding name, or "
+    "target kind that does not appear in the snapshot's settings_snapshot "
+    "or bindings_snapshot. If you are unsure, return fewer recommendations "
+    "rather than guessing."
+)
+
+
+class OpenAISetupAdvisor:
+    """OpenAI structured-output adapter.
+
+    Construction is lazy: the SDK + API key are resolved on first
+    use so a session that never invokes the advisor never pulls in
+    the dependency.
+    """
+
+    def __init__(
+        self,
+        *,
+        client: Any = None,
+        model: str | None = None,
+        api_key: str | None = None,
+    ) -> None:
+        self._client = client
+        self._model = model or os.getenv("SETUP_ADVISOR_OPENAI_MODEL", "gpt-4o-mini")
+        self._api_key = api_key
+
+    def _ensure_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        try:
+            from openai import AsyncOpenAI
+        except Exception as exc:  # noqa: BLE001 — import boundary
+            raise RuntimeError(
+                "openai package not installed; install ``openai>=1.40.0`` or "
+                "set SETUP_ADVISOR_PROVIDER=deterministic.",
+            ) from exc
+        api_key = self._api_key or os.getenv("OPENAI_API_KEY", "")
+        if not api_key:
+            raise RuntimeError(
+                "OPENAI_API_KEY is not set; cannot build OpenAISetupAdvisor.",
+            )
+        self._client = AsyncOpenAI(api_key=api_key)
+        return self._client
+
+    async def suggest(self, snapshot: GuildSnapshot) -> SetupPlanDraft:
+        client = self._ensure_client()
+        user_payload = json.dumps(_snapshot_to_prompt(snapshot), default=str)
+        try:
+            response = await client.chat.completions.create(
+                model=self._model,
+                messages=[
+                    {"role": "system", "content": _SYSTEM_PROMPT},
+                    {"role": "user", "content": user_payload},
+                ],
+                response_format={
+                    "type": "json_schema",
+                    "json_schema": _RECOMMENDATION_JSON_SCHEMA,
+                },
+            )
+        except Exception as exc:  # noqa: BLE001 — network boundary
+            logger.exception(
+                "OpenAISetupAdvisor.suggest: chat.completions.create failed; "
+                "falling back to empty draft.",
+            )
+            return SetupPlanDraft(
+                recommendations=(),
+                dropped=(f"openai: {type(exc).__name__}: {exc}",),
+                source=OPENAI,
+            )
+
+        raw = _extract_response_text(response)
+        if raw is None:
+            return SetupPlanDraft(
+                recommendations=(),
+                dropped=("openai: empty response",),
+                source=OPENAI,
+            )
+
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            return SetupPlanDraft(
+                recommendations=(),
+                dropped=(f"openai: invalid JSON ({exc})",),
+                source=OPENAI,
+            )
+
+        return _validate_ai_payload(parsed)
+
+
+def _snapshot_to_prompt(snapshot: GuildSnapshot) -> dict[str, Any]:
+    """Compact serialisation for the LLM prompt.
+
+    Drops the readiness_findings details — the model only needs
+    structure, not the per-finding messages — and renames fields to
+    plain ``snake_case`` (already the case for dataclass fields).
+    """
+    return {
+        "guild_id": snapshot.guild_id,
+        "guild_name": snapshot.guild_name,
+        "channels": [
+            {
+                "id": ch.id,
+                "name": ch.name,
+                "type": ch.type,
+                "topic": ch.topic,
+                "parent_category": ch.parent_category,
+                "bot_can_send": ch.bot_can_send,
+            }
+            for ch in snapshot.channels
+        ],
+        "categories": [{"id": cat.id, "name": cat.name} for cat in snapshot.categories],
+        "roles": [
+            {"id": r.id, "name": r.name, "bot_can_manage": r.bot_can_manage}
+            for r in snapshot.roles
+        ],
+        "settings_snapshot": snapshot.settings_snapshot,
+        "bindings_snapshot": snapshot.bindings_snapshot,
+    }
+
+
+def _extract_response_text(response: Any) -> str | None:
+    """Pull the assistant message text out of an OpenAI ChatCompletion."""
+    choices = getattr(response, "choices", None)
+    if not choices:
+        return None
+    first = choices[0]
+    message = getattr(first, "message", None)
+    if message is None:
+        return None
+    content = getattr(message, "content", None)
+    if not content:
+        return None
+    return content
+
+
+def _validate_ai_payload(parsed: Any) -> SetupPlanDraft:
+    """Re-validate a parsed AI payload against the local schema.
+
+    Steps:
+
+    * The top-level object must carry a ``recommendations`` list.
+    * Each item must carry every required field of
+      :class:`SetupRecommendation`.
+    * ``confidence`` must be one of ``high`` / ``medium`` / ``low``.
+    * The (subsystem, binding_name, target_kind) tuple must match
+      a real :class:`BindingSpec` in
+      ``subsystem_schema.all_schemas()``. Anything else is dropped
+      with a reason.
+    """
+    if not isinstance(parsed, dict):
+        return SetupPlanDraft(
+            recommendations=(),
+            dropped=(f"openai: top-level type {type(parsed).__name__}",),
+            source=OPENAI,
+        )
+
+    recommendations_raw = parsed.get("recommendations")
+    if not isinstance(recommendations_raw, list):
+        return SetupPlanDraft(
+            recommendations=(),
+            dropped=("openai: missing recommendations[]",),
+            source=OPENAI,
+        )
+
+    survivors: list[SetupRecommendation] = []
+    dropped: list[str] = []
+    for index, item in enumerate(recommendations_raw):
+        if not isinstance(item, dict):
+            dropped.append(f"openai: item[{index}] not a dict")
+            continue
+        confidence = item.get("confidence")
+        if confidence not in CONFIDENCES:
+            dropped.append(
+                f"openai: item[{index}] bad confidence {confidence!r}",
+            )
+            continue
+        try:
+            rec = SetupRecommendation(
+                subsystem=item["subsystem"],
+                binding_name=item["binding_name"],
+                target_kind=item["target_kind"],
+                target_id=int(item["target_id"]),
+                target_name=item["target_name"],
+                confidence=confidence,
+                reason=item["reason"],
+                source=OPENAI,
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            dropped.append(f"openai: item[{index}] {type(exc).__name__}: {exc}")
+            continue
+
+        reason = _validate_against_schema(rec)
+        if reason is not None:
+            dropped.append(f"openai: {rec.subsystem}.{rec.binding_name}: {reason}")
+            continue
+        survivors.append(rec)
+
+    return SetupPlanDraft(
+        recommendations=tuple(survivors),
+        dropped=tuple(dropped),
+        source=OPENAI,
+    )
+
+
+def _validate_against_schema(rec: SetupRecommendation) -> str | None:
+    """Mirror of :func:`services.setup_plan._validate_against_schema`."""
+    try:
+        from core.runtime.subsystem_schema import all_schemas
+    except Exception:
+        logger.exception(
+            "setup_ai_advisor: subsystem_schema unavailable; "
+            "dropping every AI recommendation.",
+        )
+        return "subsystem_schema unavailable"
+    schemas = all_schemas() or {}
+    schema = schemas.get(rec.subsystem)
+    if schema is None:
+        return f"subsystem {rec.subsystem!r} not registered"
+    for spec in schema.bindings:
+        if spec.name == rec.binding_name:
+            if spec.kind.value != rec.target_kind:
+                return (
+                    f"binding {rec.subsystem}.{rec.binding_name} has kind "
+                    f"{spec.kind.value}, AI proposed {rec.target_kind}"
+                )
+            return None
+    return f"binding {rec.subsystem}.{rec.binding_name} not declared"
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def build_advisor(
+    provider: str | None = None,
+    *,
+    api_key: str | None = None,
+    model: str | None = None,
+) -> SetupAdvisor:
+    """Pick and instantiate the right advisor.
+
+    Resolution:
+
+    1. Explicit ``provider`` argument (used by tests).
+    2. ``SETUP_ADVISOR_PROVIDER`` environment variable.
+    3. Default: ``deterministic``.
+
+    Whenever the requested provider is unavailable (missing API
+    key, missing SDK), we silently fall back to the deterministic
+    advisor and log a warning. CI never has an ``OPENAI_API_KEY``
+    so the fallback path is the default for the test suite — no
+    external requests are made.
+    """
+    chosen = (provider or os.getenv("SETUP_ADVISOR_PROVIDER", DETERMINISTIC)).lower()
+    if chosen not in KNOWN_PROVIDERS:
+        logger.warning(
+            "setup_ai_advisor: unknown SETUP_ADVISOR_PROVIDER=%r; "
+            "falling back to deterministic.",
+            chosen,
+        )
+        return DeterministicAdvisor()
+
+    if chosen == DETERMINISTIC:
+        return DeterministicAdvisor()
+
+    if chosen == OPENAI:
+        api_key = api_key or os.getenv("OPENAI_API_KEY", "")
+        if not api_key:
+            logger.warning(
+                "setup_ai_advisor: OPENAI_API_KEY not set; "
+                "falling back to deterministic.",
+            )
+            return DeterministicAdvisor()
+        try:
+            return OpenAISetupAdvisor(api_key=api_key, model=model)
+        except Exception:
+            logger.exception(
+                "setup_ai_advisor: OpenAISetupAdvisor construction failed; "
+                "falling back to deterministic.",
+            )
+            return DeterministicAdvisor()
+
+    if chosen == ANTHROPIC:
+        # Reserved — the adapter ships in a follow-up. Until then
+        # we want operators who flip the env var to get a clear
+        # log line, not silent breakage.
+        logger.warning(
+            "setup_ai_advisor: ANTHROPIC adapter is not implemented yet; "
+            "falling back to deterministic.",
+        )
+        return DeterministicAdvisor()
+
+    return DeterministicAdvisor()
+
+
+__all__ = [
+    "ANTHROPIC",
+    "DETERMINISTIC",
+    "KNOWN_PROVIDERS",
+    "OPENAI",
+    "OpenAISetupAdvisor",
+    "SetupAdvisor",
+    "build_advisor",
+]

--- a/disbot/views/setup/ai_review/__init__.py
+++ b/disbot/views/setup/ai_review/__init__.py
@@ -1,0 +1,35 @@
+"""AI review UI — Phase 9f / Track 5 PR 14.
+
+Two panels that surface the :class:`SetupPlanDraft` produced by
+:mod:`services.setup_ai_advisor` (or the deterministic fallback) to
+the server owner.
+
+* :class:`AIReviewPanelView` — aggregate review: shows counts per
+  confidence + subsystem, exposes bulk accept/reject + per-rec drill
+  + rerun-deterministic actions.
+* :class:`PerRecommendationView` — one-by-one walkthrough.
+
+Both panels are pure orchestration: they accept / reject
+recommendations into an in-memory :class:`AcceptedSet`. Nothing
+writes to the DB or calls ``guild.create_*``. The accepted set is
+handed back to the caller (the wizard hub, Track 8 PR 23) which then
+applies recommendations through the existing mutation pipelines.
+"""
+
+from views.setup.ai_review.main_panel import (
+    AcceptedSet,
+    AIReviewPanelView,
+    build_ai_review_embed,
+)
+from views.setup.ai_review.per_recommendation import (
+    PerRecommendationView,
+    build_per_recommendation_embed,
+)
+
+__all__ = [
+    "AIReviewPanelView",
+    "AcceptedSet",
+    "PerRecommendationView",
+    "build_ai_review_embed",
+    "build_per_recommendation_embed",
+]

--- a/disbot/views/setup/ai_review/main_panel.py
+++ b/disbot/views/setup/ai_review/main_panel.py
@@ -1,0 +1,325 @@
+"""Main AI review panel — Phase 9f / Track 5 PR 14.
+
+Aggregate view over a :class:`SetupPlanDraft`:
+
+* Lists counts per confidence tier (high/medium/low).
+* Lists subsystems with at least one recommendation.
+* Offers four buttons:
+  * **Accept all high-confidence** — adds every high-confidence
+    recommendation to :class:`AcceptedSet`.
+  * **Review one-by-one** — transitions to
+    :class:`PerRecommendationView`.
+  * **Reject all AI suggestions** — clears AI recommendations from
+    the draft so only deterministic ones remain.
+  * **Rerun deterministic-only** — re-runs the deterministic
+    advisor and replaces the draft in place.
+
+No DB writes, no Discord resource creation. The panel only mutates
+the in-memory :class:`AcceptedSet` and the in-memory
+:class:`SetupPlanDraft`. The wizard hub (Track 8) consumes the
+final accepted set and routes through pipelines.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import discord
+
+from services.guild_snapshot import GuildSnapshot
+from services.setup_plan import (
+    DeterministicAdvisor,
+    SetupPlanDraft,
+    SetupRecommendation,
+)
+from views.base import BaseView
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger("bot.views.setup.ai_review.main_panel")
+
+_REVIEW_HEADER = "Smart suggestions are recommendations. Review before applying."
+
+
+@dataclass
+class AcceptedSet:
+    """Mutable container of recommendations the operator has accepted.
+
+    Lives on the view; the wizard hub reads :attr:`recommendations`
+    after the operator closes the review panel.
+    """
+
+    recommendations: list[SetupRecommendation] = field(default_factory=list)
+
+    def add(self, rec: SetupRecommendation) -> bool:
+        """Add ``rec`` if not already accepted. Returns True if added."""
+        key = (rec.subsystem, rec.binding_name)
+        if any((r.subsystem, r.binding_name) == key for r in self.recommendations):
+            return False
+        self.recommendations.append(rec)
+        return True
+
+    def add_many(
+        self,
+        recs: tuple[SetupRecommendation, ...] | list[SetupRecommendation],
+    ) -> int:
+        added = 0
+        for rec in recs:
+            if self.add(rec):
+                added += 1
+        return added
+
+    def clear(self) -> None:
+        self.recommendations.clear()
+
+    def remove(self, subsystem: str, binding_name: str) -> bool:
+        for i, rec in enumerate(self.recommendations):
+            if rec.subsystem == subsystem and rec.binding_name == binding_name:
+                del self.recommendations[i]
+                return True
+        return False
+
+    def contains(self, rec: SetupRecommendation) -> bool:
+        return any(
+            (r.subsystem, r.binding_name) == (rec.subsystem, rec.binding_name)
+            for r in self.recommendations
+        )
+
+    @property
+    def count(self) -> int:
+        return len(self.recommendations)
+
+
+def build_ai_review_embed(draft: SetupPlanDraft) -> discord.Embed:
+    """Render the aggregate review embed for a draft."""
+    high = draft.by_confidence("high")
+    medium = draft.by_confidence("medium")
+    low = draft.by_confidence("low")
+
+    description = (
+        f"_{_REVIEW_HEADER}_\n\n"
+        f"**High:** {len(high)} · **Medium:** {len(medium)} · "
+        f"**Low:** {len(low)} · **Source:** `{draft.source}`"
+    )
+    color = (
+        discord.Color.green()
+        if high
+        else discord.Color.gold() if medium else discord.Color.dark_grey()
+    )
+    embed = discord.Embed(
+        title="🤖 Smart suggestions",
+        description=description,
+        color=color,
+    )
+
+    # Group by subsystem for the field section.
+    by_sub: dict[str, list[SetupRecommendation]] = {}
+    for rec in draft.recommendations:
+        by_sub.setdefault(rec.subsystem, []).append(rec)
+    for subsystem in sorted(by_sub):
+        lines = []
+        for rec in by_sub[subsystem]:
+            icon = _CONFIDENCE_ICON[rec.confidence]
+            lines.append(
+                f"{icon} `{rec.binding_name}` → `{rec.target_name}` — {rec.reason}",
+            )
+        value = "\n".join(lines)
+        if len(value) > 1000:
+            value = value[:997] + "..."
+        embed.add_field(
+            name=f"{subsystem}",
+            value=value,
+            inline=False,
+        )
+
+    if draft.dropped:
+        dropped_value = "\n".join(f"• {d}" for d in draft.dropped[:5])
+        if len(draft.dropped) > 5:
+            dropped_value += f"\n_+{len(draft.dropped) - 5} more not shown_"
+        embed.add_field(
+            name="Dropped",
+            value=dropped_value,
+            inline=False,
+        )
+
+    return embed
+
+
+_CONFIDENCE_ICON = {
+    "high": "🟢",
+    "medium": "🟡",
+    "low": "⚪",
+}
+
+
+class AIReviewPanelView(BaseView):
+    """Aggregate AI-review panel.
+
+    Owns the active :class:`SetupPlanDraft` and the
+    :class:`AcceptedSet`. Buttons mutate one or both; the wizard
+    hub reads :attr:`accepted` after the operator closes the
+    panel.
+    """
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        *,
+        draft: SetupPlanDraft,
+        snapshot: GuildSnapshot | None = None,
+        accepted: AcceptedSet | None = None,
+        public: bool = False,
+        timeout: int = 180,
+    ) -> None:
+        super().__init__(author, public=public, timeout=timeout)
+        self.draft = draft
+        self.snapshot = snapshot
+        self.accepted = accepted if accepted is not None else AcceptedSet()
+        self.last_status: str | None = None  # last action label for embed
+
+    def _refresh_embed(self) -> discord.Embed:
+        embed = build_ai_review_embed(self.draft)
+        if self.last_status:
+            embed.set_footer(text=self.last_status)
+        return embed
+
+    async def _refresh(self, interaction: discord.Interaction) -> None:
+        try:
+            await interaction.response.edit_message(
+                embed=self._refresh_embed(),
+                view=self,
+            )
+        except discord.HTTPException:
+            logger.warning(
+                "AIReviewPanelView._refresh: edit_message failed.",
+            )
+
+    @discord.ui.button(
+        label="Accept all high-confidence",
+        style=discord.ButtonStyle.success,
+    )
+    async def _accept_high(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        high = self.draft.by_confidence("high")
+        added = self.accepted.add_many(high)
+        self.last_status = (
+            f"Accepted {added} high-confidence recommendation(s); "
+            f"total accepted: {self.accepted.count}."
+        )
+        await self._refresh(interaction)
+
+    @discord.ui.button(
+        label="Review one-by-one",
+        style=discord.ButtonStyle.primary,
+    )
+    async def _review_each(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        if not self.draft.recommendations:
+            await interaction.response.send_message(
+                "Nothing to review — the draft is empty.",
+                ephemeral=True,
+            )
+            return
+        from views.setup.ai_review.per_recommendation import (
+            PerRecommendationView,
+            build_per_recommendation_embed,
+        )
+
+        per_view = PerRecommendationView(
+            self._author,
+            draft=self.draft,
+            accepted=self.accepted,
+            index=0,
+            parent_view=self,
+            public=self._public,
+            timeout=self.timeout,
+        )
+        await interaction.response.edit_message(
+            embed=build_per_recommendation_embed(self.draft, 0, self.accepted),
+            view=per_view,
+        )
+
+    @discord.ui.button(
+        label="Reject all AI suggestions",
+        style=discord.ButtonStyle.danger,
+    )
+    async def _reject_ai(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        surviving = tuple(r for r in self.draft.recommendations if r.source != "openai")
+        removed = len(self.draft.recommendations) - len(surviving)
+        self.draft = SetupPlanDraft(
+            recommendations=surviving,
+            dropped=self.draft.dropped,
+            source="deterministic" if removed else self.draft.source,
+        )
+        # Also strip rejected AI items from the accepted set.
+        self.accepted.recommendations = [
+            r for r in self.accepted.recommendations if r.source != "openai"
+        ]
+        self.last_status = (
+            f"Rejected {removed} AI suggestion(s); accepted set "
+            f"refreshed to {self.accepted.count}."
+        )
+        await self._refresh(interaction)
+
+    @discord.ui.button(
+        label="Rerun deterministic-only",
+        style=discord.ButtonStyle.secondary,
+    )
+    async def _rerun_deterministic(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        if self.snapshot is None:
+            await interaction.response.send_message(
+                "Cannot rerun deterministic-only: no snapshot stored on this panel.",
+                ephemeral=True,
+            )
+            return
+        deterministic = DeterministicAdvisor()
+        try:
+            self.draft = await deterministic.suggest(self.snapshot)
+        except Exception:
+            logger.exception(
+                "AIReviewPanelView._rerun_deterministic: advisor.suggest failed",
+            )
+            await interaction.response.send_message(
+                "Deterministic rerun failed; the draft is unchanged.",
+                ephemeral=True,
+            )
+            return
+        # Drop any AI-sourced accepted items so the accepted set
+        # stays consistent with the new deterministic-only draft.
+        self.accepted.recommendations = [
+            r for r in self.accepted.recommendations if r.source != "openai"
+        ]
+        self.last_status = (
+            f"Deterministic advisor rerun: "
+            f"{len(self.draft.recommendations)} recommendation(s); "
+            f"accepted set: {self.accepted.count}."
+        )
+        await self._refresh(interaction)
+
+
+__all__ = [
+    "AIReviewPanelView",
+    "AcceptedSet",
+    "build_ai_review_embed",
+]

--- a/disbot/views/setup/ai_review/per_recommendation.py
+++ b/disbot/views/setup/ai_review/per_recommendation.py
@@ -1,0 +1,201 @@
+"""Per-recommendation review view — Phase 9f / Track 5 PR 14.
+
+One-at-a-time walkthrough over a :class:`SetupPlanDraft`. The
+operator advances index-by-index and accepts / rejects each
+recommendation into the shared :class:`AcceptedSet`.
+
+Buttons:
+
+* **Accept** — adds the current recommendation to :class:`AcceptedSet`
+  and advances to the next index.
+* **Reject** — removes any existing acceptance and advances.
+* **Skip** — advances without changing the accepted set.
+* **Back to overview** — returns to :class:`AIReviewPanelView`.
+
+The current index is bounded ``[0, len(recommendations))``. Once
+the operator advances past the last recommendation the view
+auto-returns to the overview panel.
+
+No DB writes, no Discord resource creation — only state mutations on
+the shared :class:`AcceptedSet`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import discord
+
+from services.setup_plan import SetupPlanDraft, SetupRecommendation
+from views.base import BaseView
+
+if TYPE_CHECKING:
+    from views.setup.ai_review.main_panel import AcceptedSet, AIReviewPanelView
+
+logger = logging.getLogger("bot.views.setup.ai_review.per_recommendation")
+
+
+def build_per_recommendation_embed(
+    draft: SetupPlanDraft,
+    index: int,
+    accepted: AcceptedSet,
+) -> discord.Embed:
+    """Render a single recommendation."""
+    total = len(draft.recommendations)
+    if total == 0:
+        return discord.Embed(
+            title="🤖 Smart suggestions",
+            description="No recommendations to review.",
+            color=discord.Color.dark_grey(),
+        )
+    safe_index = max(0, min(index, total - 1))
+    rec = draft.recommendations[safe_index]
+    color = _CONFIDENCE_COLOR[rec.confidence]
+    is_accepted = accepted.contains(rec)
+    state_label = "✅ accepted" if is_accepted else "⬜ pending"
+    embed = discord.Embed(
+        title=(f"🤖 Suggestion {safe_index + 1} / {total} · {state_label}"),
+        description=(
+            f"**Subsystem:** `{rec.subsystem}`\n"
+            f"**Binding:** `{rec.binding_name}` (`{rec.target_kind}`)\n"
+            f"**Target:** `{rec.target_name}` (id `{rec.target_id}`)\n"
+            f"**Confidence:** `{rec.confidence}`\n"
+            f"**Source:** `{rec.source}`\n\n"
+            f"_{rec.reason}_"
+        ),
+        color=color,
+    )
+    embed.set_footer(
+        text=f"Accepted set: {accepted.count} · use Skip to defer, Back to return.",
+    )
+    return embed
+
+
+_CONFIDENCE_COLOR = {
+    "high": discord.Color.green(),
+    "medium": discord.Color.gold(),
+    "low": discord.Color.dark_grey(),
+}
+
+
+class PerRecommendationView(BaseView):
+    """One-at-a-time walkthrough."""
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        *,
+        draft: SetupPlanDraft,
+        accepted: AcceptedSet,
+        index: int = 0,
+        parent_view: AIReviewPanelView | None = None,
+        public: bool = False,
+        timeout: int = 180,
+    ) -> None:
+        super().__init__(author, public=public, timeout=timeout)
+        self.draft = draft
+        self.accepted = accepted
+        self.index = index
+        self.parent_view = parent_view
+
+    @property
+    def current(self) -> SetupRecommendation | None:
+        if 0 <= self.index < len(self.draft.recommendations):
+            return self.draft.recommendations[self.index]
+        return None
+
+    async def _advance_or_return(
+        self,
+        interaction: discord.Interaction,
+    ) -> None:
+        self.index += 1
+        if self.index >= len(self.draft.recommendations):
+            # End of list — return to overview.
+            await self._return_to_overview(interaction)
+            return
+        await interaction.response.edit_message(
+            embed=build_per_recommendation_embed(
+                self.draft,
+                self.index,
+                self.accepted,
+            ),
+            view=self,
+        )
+
+    async def _return_to_overview(
+        self,
+        interaction: discord.Interaction,
+    ) -> None:
+        if self.parent_view is None:
+            await interaction.response.send_message(
+                "Review complete. The accepted set is ready to apply.",
+                ephemeral=True,
+            )
+            return
+        from views.setup.ai_review.main_panel import build_ai_review_embed
+
+        self.parent_view.last_status = (
+            f"Per-recommendation review finished; "
+            f"accepted set: {self.accepted.count}."
+        )
+        self.parent_view.draft = self.draft
+        await interaction.response.edit_message(
+            embed=build_ai_review_embed(self.parent_view.draft),
+            view=self.parent_view,
+        )
+
+    @discord.ui.button(label="Accept", style=discord.ButtonStyle.success)
+    async def _accept(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        rec = self.current
+        if rec is None:
+            await self._return_to_overview(interaction)
+            return
+        self.accepted.add(rec)
+        await self._advance_or_return(interaction)
+
+    @discord.ui.button(label="Reject", style=discord.ButtonStyle.danger)
+    async def _reject(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        rec = self.current
+        if rec is None:
+            await self._return_to_overview(interaction)
+            return
+        self.accepted.remove(rec.subsystem, rec.binding_name)
+        await self._advance_or_return(interaction)
+
+    @discord.ui.button(label="Skip", style=discord.ButtonStyle.secondary)
+    async def _skip(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        await self._advance_or_return(interaction)
+
+    @discord.ui.button(
+        label="Back to overview",
+        style=discord.ButtonStyle.secondary,
+    )
+    async def _back(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        await self._return_to_overview(interaction)
+
+
+__all__ = [
+    "PerRecommendationView",
+    "build_per_recommendation_embed",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ asyncpg>=0.29.0
 aiohttp>=3.9.0
 python-json-logger>=2.0.7
 prometheus-client>=0.19.0
+openai>=1.40.0

--- a/tests/unit/services/test_setup_ai_advisor.py
+++ b/tests/unit/services/test_setup_ai_advisor.py
@@ -1,0 +1,438 @@
+"""Phase 9f / Track 5 PR 13 — AI advisor tests.
+
+Pins:
+
+* ``build_advisor`` returns ``DeterministicAdvisor`` by default
+  (the CI/dev safe fallback).
+* Unknown provider strings fall back to deterministic with a
+  warn-level log.
+* ``OpenAISetupAdvisor.suggest`` parses a valid OpenAI response
+  through the JSON schema and emits matching
+  :class:`SetupRecommendation` records.
+* Invalid recommendations are dropped with a reason:
+  * unknown subsystem;
+  * binding name not declared;
+  * kind mismatch;
+  * bad confidence string;
+  * non-JSON content.
+* The advisor never makes a real network call in tests; CI has no
+  ``OPENAI_API_KEY``.
+* AST-level invariants:
+  * ``setup_ai_advisor`` does not import ``utils.db``.
+  * ``setup_ai_advisor`` does not reference ``guild.create_*``.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from core.runtime.subsystem_schema import (
+    BindingKind,
+    BindingSpec,
+    SubsystemSchema,
+)
+from services.guild_snapshot import GuildSnapshot
+from services.setup_ai_advisor import (
+    ANTHROPIC,
+    DETERMINISTIC,
+    OPENAI,
+    OpenAISetupAdvisor,
+    SetupAdvisor,
+    build_advisor,
+)
+from services.setup_plan import (
+    DeterministicAdvisor,
+    SetupPlanDraft,
+    SetupRecommendation,
+)
+
+
+def _snap() -> GuildSnapshot:
+    return GuildSnapshot(
+        guild_id=1,
+        guild_name="Test",
+        owner_id=99,
+    )
+
+
+@pytest.fixture
+def _logging_schema():
+    schemas = {
+        "logging": SubsystemSchema(
+            subsystem="logging",
+            bindings=(
+                BindingSpec(
+                    name="mod_channel",
+                    kind=BindingKind.CHANNEL,
+                    required=True,
+                    hint="",
+                    capability_required="logging.mod_channel.bind",
+                ),
+            ),
+        ),
+    }
+    with patch(
+        "core.runtime.subsystem_schema.all_schemas",
+        return_value=schemas,
+    ):
+        yield schemas
+
+
+@pytest.fixture
+def _no_openai_env(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("SETUP_ADVISOR_PROVIDER", raising=False)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# build_advisor — provider resolution
+# ---------------------------------------------------------------------------
+
+
+def test_build_advisor_defaults_to_deterministic(_no_openai_env):
+    advisor = build_advisor()
+    assert isinstance(advisor, DeterministicAdvisor)
+
+
+def test_build_advisor_explicit_deterministic(_no_openai_env):
+    advisor = build_advisor(provider="deterministic")
+    assert isinstance(advisor, DeterministicAdvisor)
+
+
+def test_build_advisor_unknown_provider_falls_back(_no_openai_env, caplog):
+    with caplog.at_level("WARNING", logger="bot.services.setup_ai_advisor"):
+        advisor = build_advisor(provider="totally_made_up")
+    assert isinstance(advisor, DeterministicAdvisor)
+    assert any(
+        "unknown SETUP_ADVISOR_PROVIDER" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_build_advisor_openai_without_api_key_falls_back(_no_openai_env, caplog):
+    with caplog.at_level("WARNING", logger="bot.services.setup_ai_advisor"):
+        advisor = build_advisor(provider="openai")
+    assert isinstance(advisor, DeterministicAdvisor)
+    assert any(
+        "OPENAI_API_KEY not set" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_build_advisor_anthropic_is_reserved_and_falls_back(_no_openai_env, caplog):
+    with caplog.at_level("WARNING", logger="bot.services.setup_ai_advisor"):
+        advisor = build_advisor(provider="anthropic")
+    assert isinstance(advisor, DeterministicAdvisor)
+    assert any(
+        "ANTHROPIC adapter is not implemented" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_build_advisor_openai_with_key_returns_openai_adapter(_no_openai_env):
+    advisor = build_advisor(provider="openai", api_key="sk-test")
+    assert isinstance(advisor, OpenAISetupAdvisor)
+    assert isinstance(advisor, SetupAdvisor)
+
+
+def test_known_providers_set():
+    from services.setup_ai_advisor import KNOWN_PROVIDERS
+
+    assert KNOWN_PROVIDERS == frozenset({DETERMINISTIC, OPENAI, ANTHROPIC})
+
+
+# ---------------------------------------------------------------------------
+# OpenAISetupAdvisor — happy path
+# ---------------------------------------------------------------------------
+
+
+def _fake_openai_response(payload: dict) -> MagicMock:
+    """Build a chat.completions response that contains ``payload`` as
+    the assistant message JSON string."""
+    message = MagicMock()
+    message.content = json.dumps(payload)
+    choice = MagicMock()
+    choice.message = message
+    response = MagicMock()
+    response.choices = [choice]
+    return response
+
+
+@pytest.mark.asyncio
+async def test_openai_advisor_emits_validated_recommendation(_logging_schema):
+    payload = {
+        "recommendations": [
+            {
+                "subsystem": "logging",
+                "binding_name": "mod_channel",
+                "target_kind": "channel",
+                "target_id": 100,
+                "target_name": "mod-log",
+                "confidence": "high",
+                "reason": "exact name match",
+            },
+        ],
+    }
+    fake_client = MagicMock()
+    fake_client.chat = MagicMock()
+    fake_client.chat.completions = MagicMock()
+    fake_client.chat.completions.create = AsyncMock(
+        return_value=_fake_openai_response(payload),
+    )
+
+    advisor = OpenAISetupAdvisor(client=fake_client, api_key="sk-test")
+    draft = await advisor.suggest(_snap())
+
+    fake_client.chat.completions.create.assert_awaited_once()
+    assert isinstance(draft, SetupPlanDraft)
+    assert len(draft.recommendations) == 1
+    rec = draft.recommendations[0]
+    assert rec.source == "openai"
+    assert rec.subsystem == "logging"
+    assert rec.binding_name == "mod_channel"
+
+
+@pytest.mark.asyncio
+async def test_openai_advisor_drops_unknown_subsystem(_logging_schema):
+    payload = {
+        "recommendations": [
+            {
+                "subsystem": "vibes",
+                "binding_name": "mod_channel",
+                "target_kind": "channel",
+                "target_id": 100,
+                "target_name": "x",
+                "confidence": "high",
+                "reason": "y",
+            },
+        ],
+    }
+    fake_client = MagicMock()
+    fake_client.chat = MagicMock()
+    fake_client.chat.completions = MagicMock()
+    fake_client.chat.completions.create = AsyncMock(
+        return_value=_fake_openai_response(payload),
+    )
+
+    advisor = OpenAISetupAdvisor(client=fake_client, api_key="sk-test")
+    draft = await advisor.suggest(_snap())
+
+    assert draft.recommendations == ()
+    assert any("not registered" in r for r in draft.dropped)
+
+
+@pytest.mark.asyncio
+async def test_openai_advisor_drops_kind_mismatch(_logging_schema):
+    payload = {
+        "recommendations": [
+            {
+                "subsystem": "logging",
+                "binding_name": "mod_channel",
+                "target_kind": "role",  # schema says CHANNEL
+                "target_id": 100,
+                "target_name": "x",
+                "confidence": "high",
+                "reason": "y",
+            },
+        ],
+    }
+    fake_client = MagicMock()
+    fake_client.chat = MagicMock()
+    fake_client.chat.completions = MagicMock()
+    fake_client.chat.completions.create = AsyncMock(
+        return_value=_fake_openai_response(payload),
+    )
+
+    advisor = OpenAISetupAdvisor(client=fake_client, api_key="sk-test")
+    draft = await advisor.suggest(_snap())
+
+    assert draft.recommendations == ()
+    assert any("AI proposed role" in r for r in draft.dropped)
+
+
+@pytest.mark.asyncio
+async def test_openai_advisor_drops_bad_confidence(_logging_schema):
+    payload = {
+        "recommendations": [
+            {
+                "subsystem": "logging",
+                "binding_name": "mod_channel",
+                "target_kind": "channel",
+                "target_id": 100,
+                "target_name": "x",
+                "confidence": "totally_made_up",
+                "reason": "y",
+            },
+        ],
+    }
+    fake_client = MagicMock()
+    fake_client.chat = MagicMock()
+    fake_client.chat.completions = MagicMock()
+    fake_client.chat.completions.create = AsyncMock(
+        return_value=_fake_openai_response(payload),
+    )
+
+    advisor = OpenAISetupAdvisor(client=fake_client, api_key="sk-test")
+    draft = await advisor.suggest(_snap())
+
+    assert draft.recommendations == ()
+    assert any("bad confidence" in r for r in draft.dropped)
+
+
+@pytest.mark.asyncio
+async def test_openai_advisor_drops_missing_field(_logging_schema):
+    payload = {
+        "recommendations": [
+            {
+                # missing target_id
+                "subsystem": "logging",
+                "binding_name": "mod_channel",
+                "target_kind": "channel",
+                "target_name": "x",
+                "confidence": "high",
+                "reason": "y",
+            },
+        ],
+    }
+    fake_client = MagicMock()
+    fake_client.chat = MagicMock()
+    fake_client.chat.completions = MagicMock()
+    fake_client.chat.completions.create = AsyncMock(
+        return_value=_fake_openai_response(payload),
+    )
+
+    advisor = OpenAISetupAdvisor(client=fake_client, api_key="sk-test")
+    draft = await advisor.suggest(_snap())
+
+    assert draft.recommendations == ()
+    assert any("KeyError" in r for r in draft.dropped)
+
+
+@pytest.mark.asyncio
+async def test_openai_advisor_handles_invalid_json():
+    message = MagicMock()
+    message.content = "not json at all {{"
+    choice = MagicMock()
+    choice.message = message
+    response = MagicMock()
+    response.choices = [choice]
+
+    fake_client = MagicMock()
+    fake_client.chat = MagicMock()
+    fake_client.chat.completions = MagicMock()
+    fake_client.chat.completions.create = AsyncMock(return_value=response)
+
+    advisor = OpenAISetupAdvisor(client=fake_client, api_key="sk-test")
+    draft = await advisor.suggest(_snap())
+
+    assert draft.recommendations == ()
+    assert any("invalid JSON" in r for r in draft.dropped)
+
+
+@pytest.mark.asyncio
+async def test_openai_advisor_swallows_network_failure():
+    fake_client = MagicMock()
+    fake_client.chat = MagicMock()
+    fake_client.chat.completions = MagicMock()
+    fake_client.chat.completions.create = AsyncMock(
+        side_effect=RuntimeError("rate limited"),
+    )
+
+    advisor = OpenAISetupAdvisor(client=fake_client, api_key="sk-test")
+    draft = await advisor.suggest(_snap())
+
+    assert draft.recommendations == ()
+    assert any("rate limited" in r for r in draft.dropped)
+
+
+@pytest.mark.asyncio
+async def test_openai_advisor_handles_empty_response():
+    response = MagicMock()
+    response.choices = []
+    fake_client = MagicMock()
+    fake_client.chat = MagicMock()
+    fake_client.chat.completions = MagicMock()
+    fake_client.chat.completions.create = AsyncMock(return_value=response)
+
+    advisor = OpenAISetupAdvisor(client=fake_client, api_key="sk-test")
+    draft = await advisor.suggest(_snap())
+
+    assert draft.recommendations == ()
+    assert any("empty response" in r for r in draft.dropped)
+
+
+# ---------------------------------------------------------------------------
+# Module invariants
+# ---------------------------------------------------------------------------
+
+
+def test_module_has_no_db_imports():
+    import services.setup_ai_advisor as mod
+
+    src = mod.__file__
+    assert src is not None
+    with open(src, encoding="utf-8") as fh:
+        text = fh.read()
+    for forbidden in ("from utils.db import", "import utils.db"):
+        assert forbidden not in text, (
+            f"services.setup_ai_advisor must not import {forbidden}; "
+            "the AI advisor must remain read-only."
+        )
+
+
+def test_module_has_no_discord_create_calls():
+    import services.setup_ai_advisor as mod
+
+    src = mod.__file__
+    assert src is not None
+    with open(src, encoding="utf-8") as fh:
+        text = fh.read()
+    for forbidden in (
+        "guild.create_text_channel",
+        "guild.create_role",
+        "guild.create_category",
+        "create_text_channel(",
+        "create_role(",
+        "create_category(",
+    ):
+        assert forbidden not in text, (
+            f"services.setup_ai_advisor must not call {forbidden}; "
+            "the AI advisor must never create Discord resources."
+        )
+
+
+def test_setup_advisor_protocol_accepts_deterministic_and_openai():
+    """Both implementations satisfy the Protocol."""
+    assert isinstance(DeterministicAdvisor(), SetupAdvisor)
+    assert isinstance(OpenAISetupAdvisor(api_key="sk-test"), SetupAdvisor)
+
+
+def test_protocol_is_runtime_checkable():
+    """``isinstance`` check works for arbitrary objects implementing
+    ``async def suggest(snapshot) -> SetupPlanDraft``."""
+
+    class _Custom:
+        async def suggest(self, snapshot):
+            return SetupPlanDraft()
+
+    assert isinstance(_Custom(), SetupAdvisor)
+
+
+def test_recommendation_source_field_marks_origin():
+    """Sanity: the deterministic baseline marks ``source="deterministic"``,
+    OpenAI marks ``source="openai"``. Tests above already exercise the
+    OpenAI side; this one pins the deterministic default."""
+    rec = SetupRecommendation(
+        subsystem="logging",
+        binding_name="mod_channel",
+        target_kind="channel",
+        target_id=1,
+        target_name="mod-log",
+        confidence="high",
+        reason="x",
+    )
+    assert rec.source == "deterministic"

--- a/tests/unit/views/setup/ai_review/test_ai_review_panels.py
+++ b/tests/unit/views/setup/ai_review/test_ai_review_panels.py
@@ -1,0 +1,473 @@
+"""Phase 9f / Track 5 PR 14 — AI review panel tests.
+
+Pins:
+
+* The aggregate panel renders counts per confidence and groups
+  recommendations by subsystem.
+* The "Accept all high-confidence" button adds every high
+  recommendation to the accepted set; subsequent click is a no-op
+  (deduplication by (subsystem, binding_name)).
+* "Reject all AI suggestions" strips ``source="openai"``
+  recommendations from both the draft and the accepted set.
+* "Rerun deterministic-only" calls ``DeterministicAdvisor.suggest``
+  with the stored snapshot, replaces the draft, and strips AI items
+  from the accepted set.
+* The per-recommendation view advances through the draft and
+  transitions back to the parent overview when it runs out of items.
+* AST invariants: panels don't import ``utils.db`` and don't call
+  ``guild.create_*``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.guild_snapshot import GuildSnapshot
+from services.setup_plan import SetupPlanDraft, SetupRecommendation
+from views.setup.ai_review.main_panel import (
+    AcceptedSet,
+    AIReviewPanelView,
+    build_ai_review_embed,
+)
+from views.setup.ai_review.per_recommendation import (
+    PerRecommendationView,
+    build_per_recommendation_embed,
+)
+
+
+def _rec(
+    *,
+    subsystem="logging",
+    binding="mod_channel",
+    confidence="high",
+    source="deterministic",
+    target_id=100,
+):
+    return SetupRecommendation(
+        subsystem=subsystem,
+        binding_name=binding,
+        target_kind="channel",
+        target_id=target_id,
+        target_name=f"{binding}-{target_id}",
+        confidence=confidence,
+        reason="x",
+        source=source,
+    )
+
+
+def _author():
+    member = MagicMock()
+    member.id = 99
+    return member
+
+
+def _interaction(*, guild_id=1):
+    interaction = MagicMock()
+    interaction.guild_id = guild_id
+    interaction.guild = MagicMock(id=guild_id)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    return interaction
+
+
+# ---------------------------------------------------------------------------
+# AcceptedSet
+# ---------------------------------------------------------------------------
+
+
+def test_accepted_set_dedupes_by_subsystem_and_binding():
+    accepted = AcceptedSet()
+    rec_a = _rec(target_id=100)
+    rec_b = _rec(target_id=101)  # same (subsystem, binding)
+    assert accepted.add(rec_a) is True
+    assert accepted.add(rec_b) is False
+    assert accepted.count == 1
+
+
+def test_accepted_set_remove():
+    accepted = AcceptedSet()
+    rec = _rec()
+    accepted.add(rec)
+    assert accepted.remove("logging", "mod_channel") is True
+    assert accepted.count == 0
+    assert accepted.remove("logging", "mod_channel") is False
+
+
+def test_accepted_set_contains():
+    accepted = AcceptedSet()
+    rec = _rec()
+    assert accepted.contains(rec) is False
+    accepted.add(rec)
+    assert accepted.contains(rec) is True
+
+
+# ---------------------------------------------------------------------------
+# Aggregate embed
+# ---------------------------------------------------------------------------
+
+
+def test_build_ai_review_embed_renders_header_and_counts():
+    draft = SetupPlanDraft(
+        recommendations=(
+            _rec(confidence="high"),
+            _rec(binding="audit_channel", target_id=101, confidence="medium"),
+        ),
+    )
+    embed = build_ai_review_embed(draft)
+    desc = embed.description or ""
+    assert "recommendations" in desc.lower()
+    assert "High:** 1" in desc
+    assert "Medium:** 1" in desc
+
+
+def test_build_ai_review_embed_groups_by_subsystem():
+    draft = SetupPlanDraft(
+        recommendations=(
+            _rec(subsystem="logging", binding="mod_channel"),
+            _rec(subsystem="counting", binding="channel", target_id=200),
+        ),
+    )
+    embed = build_ai_review_embed(draft)
+    field_names = [f.name for f in embed.fields]
+    assert "counting" in field_names
+    assert "logging" in field_names
+
+
+def test_build_ai_review_embed_shows_dropped_diagnostics():
+    draft = SetupPlanDraft(
+        recommendations=(),
+        dropped=("openai: invalid",) * 7,
+    )
+    embed = build_ai_review_embed(draft)
+    dropped = next(f for f in embed.fields if f.name == "Dropped")
+    assert "openai" in (dropped.value or "")
+    assert "2 more" in (dropped.value or "")
+
+
+# ---------------------------------------------------------------------------
+# AIReviewPanelView buttons
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_accept_high_button_adds_high_confidence_recs():
+    draft = SetupPlanDraft(
+        recommendations=(
+            _rec(confidence="high"),
+            _rec(binding="audit_channel", target_id=101, confidence="high"),
+            _rec(binding="cleanup_channel", target_id=102, confidence="medium"),
+        ),
+    )
+    view = AIReviewPanelView(_author(), draft=draft)
+    interaction = _interaction()
+
+    await view._accept_high.callback(interaction)
+
+    assert view.accepted.count == 2
+    interaction.response.edit_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_accept_high_button_is_idempotent():
+    """A second click should NOT re-add the same recommendations."""
+    draft = SetupPlanDraft(
+        recommendations=(
+            _rec(confidence="high"),
+            _rec(binding="audit_channel", target_id=101, confidence="high"),
+        ),
+    )
+    view = AIReviewPanelView(_author(), draft=draft)
+    interaction = _interaction()
+
+    await view._accept_high.callback(interaction)
+    await view._accept_high.callback(interaction)
+
+    assert view.accepted.count == 2
+
+
+@pytest.mark.asyncio
+async def test_review_each_transitions_to_per_recommendation_view():
+    draft = SetupPlanDraft(recommendations=(_rec(confidence="high"),))
+    view = AIReviewPanelView(_author(), draft=draft)
+    interaction = _interaction()
+
+    await view._review_each.callback(interaction)
+
+    interaction.response.edit_message.assert_awaited_once()
+    new_view = interaction.response.edit_message.await_args.kwargs["view"]
+    assert isinstance(new_view, PerRecommendationView)
+
+
+@pytest.mark.asyncio
+async def test_review_each_with_empty_draft_sends_ephemeral_message():
+    view = AIReviewPanelView(_author(), draft=SetupPlanDraft())
+    interaction = _interaction()
+
+    await view._review_each.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    assert "empty" in interaction.response.send_message.await_args.args[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_reject_ai_strips_openai_recommendations_only():
+    draft = SetupPlanDraft(
+        recommendations=(
+            _rec(confidence="high", source="openai"),
+            _rec(
+                binding="audit_channel",
+                target_id=101,
+                confidence="high",
+                source="deterministic",
+            ),
+        ),
+        source="openai",
+    )
+    accepted = AcceptedSet()
+    accepted.add_many(draft.recommendations)
+    view = AIReviewPanelView(_author(), draft=draft, accepted=accepted)
+    interaction = _interaction()
+
+    await view._reject_ai.callback(interaction)
+
+    assert len(view.draft.recommendations) == 1
+    assert view.draft.recommendations[0].source == "deterministic"
+    # Accepted set drops the AI item too.
+    assert view.accepted.count == 1
+    assert view.accepted.recommendations[0].source == "deterministic"
+
+
+@pytest.mark.asyncio
+async def test_rerun_deterministic_replaces_draft():
+    snapshot = GuildSnapshot(guild_id=1, guild_name="x", owner_id=99)
+    deterministic_draft = SetupPlanDraft(
+        recommendations=(
+            _rec(confidence="medium", source="deterministic"),
+        ),
+        source="deterministic",
+    )
+
+    fake_advisor = MagicMock()
+    fake_advisor.suggest = AsyncMock(return_value=deterministic_draft)
+
+    view = AIReviewPanelView(
+        _author(),
+        draft=SetupPlanDraft(
+            recommendations=(_rec(source="openai", confidence="high"),),
+            source="openai",
+        ),
+        snapshot=snapshot,
+    )
+    interaction = _interaction()
+
+    with patch(
+        "views.setup.ai_review.main_panel.DeterministicAdvisor",
+        return_value=fake_advisor,
+    ):
+        await view._rerun_deterministic.callback(interaction)
+
+    fake_advisor.suggest.assert_awaited_once_with(snapshot)
+    assert view.draft is deterministic_draft
+
+
+@pytest.mark.asyncio
+async def test_rerun_deterministic_refuses_without_snapshot():
+    view = AIReviewPanelView(
+        _author(),
+        draft=SetupPlanDraft(recommendations=(_rec(),)),
+        snapshot=None,
+    )
+    interaction = _interaction()
+
+    await view._rerun_deterministic.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    assert (
+        "no snapshot"
+        in interaction.response.send_message.await_args.args[0].lower()
+    )
+
+
+# ---------------------------------------------------------------------------
+# PerRecommendationView
+# ---------------------------------------------------------------------------
+
+
+def test_per_recommendation_embed_renders_current_item():
+    draft = SetupPlanDraft(
+        recommendations=(
+            _rec(confidence="high"),
+            _rec(binding="audit_channel", target_id=101, confidence="medium"),
+        ),
+    )
+    accepted = AcceptedSet()
+    embed = build_per_recommendation_embed(draft, 1, accepted)
+    assert "2 / 2" in (embed.title or "")
+    assert "audit_channel" in (embed.description or "")
+
+
+@pytest.mark.asyncio
+async def test_per_recommendation_accept_advances():
+    draft = SetupPlanDraft(
+        recommendations=(
+            _rec(),
+            _rec(binding="audit_channel", target_id=101),
+        ),
+    )
+    accepted = AcceptedSet()
+    view = PerRecommendationView(
+        _author(),
+        draft=draft,
+        accepted=accepted,
+        index=0,
+    )
+    interaction = _interaction()
+
+    await view._accept.callback(interaction)
+
+    assert view.index == 1
+    assert accepted.count == 1
+
+
+@pytest.mark.asyncio
+async def test_per_recommendation_reject_removes_and_advances():
+    draft = SetupPlanDraft(recommendations=(_rec(),))
+    accepted = AcceptedSet()
+    accepted.add(draft.recommendations[0])
+    parent = AIReviewPanelView(_author(), draft=draft, accepted=accepted)
+    view = PerRecommendationView(
+        _author(),
+        draft=draft,
+        accepted=accepted,
+        index=0,
+        parent_view=parent,
+    )
+    interaction = _interaction()
+
+    await view._reject.callback(interaction)
+
+    assert accepted.count == 0
+    # End of list → returns to overview (parent's embed gets edited in).
+    interaction.response.edit_message.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_per_recommendation_skip_does_not_modify_accepted():
+    draft = SetupPlanDraft(
+        recommendations=(_rec(), _rec(binding="audit_channel", target_id=101)),
+    )
+    accepted = AcceptedSet()
+    view = PerRecommendationView(
+        _author(),
+        draft=draft,
+        accepted=accepted,
+        index=0,
+    )
+    interaction = _interaction()
+
+    await view._skip.callback(interaction)
+
+    assert view.index == 1
+    assert accepted.count == 0
+
+
+@pytest.mark.asyncio
+async def test_per_recommendation_end_of_list_returns_to_overview():
+    draft = SetupPlanDraft(recommendations=(_rec(),))
+    accepted = AcceptedSet()
+    parent = AIReviewPanelView(_author(), draft=draft, accepted=accepted)
+    view = PerRecommendationView(
+        _author(),
+        draft=draft,
+        accepted=accepted,
+        index=0,
+        parent_view=parent,
+    )
+    interaction = _interaction()
+
+    await view._skip.callback(interaction)
+
+    # The interaction got the parent view back.
+    new_view = interaction.response.edit_message.await_args.kwargs["view"]
+    assert new_view is parent
+
+
+@pytest.mark.asyncio
+async def test_per_recommendation_back_button_returns_immediately():
+    draft = SetupPlanDraft(
+        recommendations=(_rec(), _rec(binding="audit_channel", target_id=101)),
+    )
+    parent = AIReviewPanelView(_author(), draft=draft)
+    view = PerRecommendationView(
+        _author(),
+        draft=draft,
+        accepted=parent.accepted,
+        index=0,
+        parent_view=parent,
+    )
+    interaction = _interaction()
+
+    await view._back.callback(interaction)
+
+    # Returns immediately even at index 0.
+    new_view = interaction.response.edit_message.await_args.kwargs["view"]
+    assert new_view is parent
+
+
+# ---------------------------------------------------------------------------
+# Module invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "views.setup.ai_review.main_panel",
+        "views.setup.ai_review.per_recommendation",
+    ],
+)
+def test_module_has_no_db_imports(module_name):
+    import importlib
+
+    mod = importlib.import_module(module_name)
+    src = mod.__file__
+    assert src is not None
+    with open(src, encoding="utf-8") as fh:
+        text = fh.read()
+    for forbidden in ("from utils.db import", "import utils.db"):
+        assert forbidden not in text, (
+            f"{module_name} must not import {forbidden}; views never "
+            "write directly to the DB."
+        )
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "views.setup.ai_review.main_panel",
+        "views.setup.ai_review.per_recommendation",
+    ],
+)
+def test_module_has_no_direct_discord_create_calls(module_name):
+    import importlib
+
+    mod = importlib.import_module(module_name)
+    src = mod.__file__
+    assert src is not None
+    with open(src, encoding="utf-8") as fh:
+        text = fh.read()
+    for forbidden in (
+        "guild.create_text_channel",
+        "guild.create_role",
+        "guild.create_category",
+        "create_text_channel(",
+        "create_role(",
+        "create_category(",
+    ):
+        assert forbidden not in text, (
+            f"{module_name} must not call {forbidden}; route through "
+            "services.resource_provisioning when needed."
+        )


### PR DESCRIPTION
## Summary

- Closes Track 5 with the AI review panels: `AIReviewPanelView` (aggregate) + `PerRecommendationView` (one-at-a-time walkthrough).
- Header text matches the accepted plan §5 PR 14 verbatim: _"Smart suggestions are recommendations. Review before applying."_
- 4 aggregate buttons + 4 per-rec buttons; no DB writes, no Discord resource creation, dedupe by `(subsystem, binding_name)`.

> Stacked on top of PR #186 (`services: SetupAdvisor Protocol + OpenAI implementation`). Auto-rebases to `main` when #186 lands.

## Scope table

| Does | Does NOT |
|---|---|
| Add `AIReviewPanelView` + `PerRecommendationView` + `AcceptedSet` + standalone embed builders | Apply any recommendation to the DB / Discord (Track 8 PR 23) |
| Wire the 4 aggregate buttons (Accept high / Review each / Reject AI / Rerun deterministic) | Persist drafts |
| Wire the 4 per-rec buttons (Accept / Reject / Skip / Back) | Render UI for the wizard hub (Track 8 PR 23) |
| Dedupe accepted recommendations by `(subsystem, binding_name)` | Add a per-rec preview of applied state |
| Pin no-DB-import + no-Discord-create invariants on both modules | Add a back-out / undo path beyond Reject (the wizard's final-review screen owns that) |

## Files changed

- `disbot/views/setup/ai_review/__init__.py` — **new**. Re-exports.
- `disbot/views/setup/ai_review/main_panel.py` — **new** (~325 LOC).
- `disbot/views/setup/ai_review/per_recommendation.py` — **new** (~200 LOC).
- `tests/unit/views/setup/ai_review/__init__.py` — empty marker.
- `tests/unit/views/setup/ai_review/test_ai_review_panels.py` — **new** (~470 LOC, 23 cases).

## Architecture impact

**Additive.** Two new views consuming `SetupPlanDraft` (T5P12) + `SetupAdvisor` (T5P13). Acceptance state lives in an in-memory `AcceptedSet` that gets handed to the wizard hub (Track 8) when the operator is done; the wizard hub then routes each entry through `services.binding_mutation` / `services.settings_mutation` / `services.resource_provisioning`.

The two panels coordinate via a shared `AcceptedSet` reference. `PerRecommendationView` holds a back-pointer to the parent `AIReviewPanelView` so the "Back to overview" button can swap the message back to the aggregate panel in place. When the operator advances past the final recommendation in per-rec mode the view auto-returns to the overview.

## Tests run

```
python -m pytest tests/unit/views/setup/ai_review/ -v   # 23 passed
python -m pytest -q                                     # 2783 passed, 1 warning
ruff check . --exclude .github,tests,venv,env,build,dist            # All checks passed
black --check . --exclude '(\.github|tests|venv|env|build|dist)'    # 309 files unchanged
isort --check-only . --skip-glob '*/(\.github|tests|venv|env|build|dist)/*'   # passed
mypy disbot/                                            # 310 source files, 0 issues
```

## Manual Discord smoke checklist

- [ ] Build a `SetupPlanDraft` with mixed high/medium/low/AI/deterministic recommendations and send `AIReviewPanelView` to a test guild (PENDING — no live runtime).
- [ ] Click "Accept all high-confidence"; verify the footer shows count + accepted set size (PENDING).
- [ ] Click "Reject all AI suggestions"; verify only deterministic recs remain in the embed (PENDING).
- [ ] Click "Review one-by-one"; verify the per-rec view shows index `1/N` and Accept / Reject / Skip cycle through (PENDING).
- [ ] Click "Back to overview" mid-walkthrough; verify the aggregate panel returns with the accepted-set status footer (PENDING).

## Rollback plan

`git revert`. New views, no consumers yet; removing them has no runtime effect.

## Out of scope

- Final wizard hub view that consumes the `AcceptedSet` — Track 8 PR 23.
- Applying recommendations through pipelines — Track 8 PR 23.
- Saving the draft for later — drafts live in memory until accepted.
- Showing per-rec ground-truth from `resource_health.inspect` (e.g. "this channel is already bound elsewhere") — Track 8 PR 23 polish.

## Follow-up items

- Track 6 PR 15: `db+services: automation schema + registry` — opens Track 6 (automation substrate).

## CI status

Pending — subscribing after creation.

## Risk level

**Low.** Pure orchestration views, no DB / Discord resource calls. Failure isolation via the deduping `AcceptedSet`; the `Reject all AI` and `Rerun deterministic-only` paths reset the AI-sourced acceptances so the accepted set stays consistent with the new draft.

## User-visible behavior change

**No.** New views with no callers yet.

## Slash sync or deploy action required

**No.**

## Next PR

`db+services: automation schema + registry (Track 6 PR 15)` — per the accepted plan at `/root/.claude/plans/superbot-2-0-setup-purring-peach.md` §5 Track 6 PR 15.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXdDyevoQLQXgmgog7erwY)_