### PR TITLE
services: automation scheduler (Track 6 PR 18)

### DIFF
--- a/disbot/guild_lifecycle.py
+++ b/disbot/guild_lifecycle.py
@@ -53,6 +53,9 @@ async def teardown(guild_id: int) -> None:
       18. Setup session         — delete the setup_session row (Phase 9e PR 8).
                                    The launcher cog re-creates it on the next
                                    on_guild_join.
+      19. Automation rules      — delete every automation_rules row for the
+                                   guild (Phase 9g PR 18). ``automation_runs``
+                                   rows are removed via ON DELETE CASCADE.
     """
     logger.info("guild_lifecycle.teardown: beginning cleanup for guild=%d", guild_id)
 
@@ -112,6 +115,10 @@ async def teardown(guild_id: int) -> None:
     #     it via ``services.setup_session.start_session`` on the next
     #     ``on_guild_join``.
     await _teardown_setup_session(guild_id)
+
+    # 19. Automation rules (Phase 9g PR 18). ``automation_runs`` rows
+    #     get cleaned up by the ON DELETE CASCADE on rule_id.
+    await _teardown_automation_rules(guild_id)
 
     logger.info("guild_lifecycle.teardown: complete for guild=%d", guild_id)
 
@@ -477,6 +484,30 @@ async def _teardown_setup_session(guild_id: int) -> None:
     except Exception as exc:
         logger.warning(
             "guild_lifecycle: setup_session teardown failed for guild=%d: %s",
+            guild_id,
+            exc,
+        )
+
+
+async def _teardown_automation_rules(guild_id: int) -> None:
+    """Delete every automation_rules row for the departed guild.
+
+    Phase 9g PR 18. ``automation_runs`` history rows cascade away
+    via the FK; nothing else references the rules.
+    """
+    try:
+        from utils.db import automation as db
+
+        count = await db.delete_rules_for_guild(guild_id)
+        if count:
+            logger.debug(
+                "guild_lifecycle: deleted %d automation rule(s) for guild=%d",
+                count,
+                guild_id,
+            )
+    except Exception as exc:
+        logger.warning(
+            "guild_lifecycle: automation_rules teardown failed for guild=%d: %s",
             guild_id,
             exc,
         )

--- a/disbot/services/automation_scheduler.py
+++ b/disbot/services/automation_scheduler.py
@@ -1,0 +1,397 @@
+"""Automation scheduler — Phase 9g / Track 6 PR 18.
+
+Long-running supervised task that polls ``automation_rules`` for
+due rules and routes them through
+:func:`services.automation_executor.execute_rule`. Closes Track 6.
+
+Responsibilities:
+
+* Poll every ``poll_interval_seconds`` (default 30 s) for rules
+  where ``enabled=true`` and ``next_run_at <= NOW()``.
+* Claim each due rule via ``utils.db.automation.claim_run`` with a
+  derived ``idempotency_key`` so two concurrent schedulers cannot
+  double-run the same rule.
+* Respect per-rule quiet hours stored in
+  ``trigger_config['quiet_hours']`` (a ``[start_hour, end_hour]``
+  pair in the rule's timezone).
+* Auto-disable rules whose ``failure_count`` exceeds
+  ``failure_threshold`` (default 5) after this run records a
+  failure.
+* Compute ``next_run_at`` based on ``trigger_kind`` /
+  ``trigger_config``. ``manual`` rules are NEVER re-armed.
+* Surface live counters + the last poll timestamp via
+  ``services.diagnostics_service`` under the name
+  ``automation_scheduler``.
+
+The scheduler is supervised: failures inside the loop are caught
++ logged, then the loop continues. A truly fatal error (cancelled
+task, asyncio shutdown) propagates so the supervisor can restart.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from services.automation_executor import execute_rule
+from utils.db import automation as db
+
+logger = logging.getLogger("bot.services.automation_scheduler")
+
+_DEFAULT_POLL_SECONDS = 30
+_DEFAULT_FAILURE_THRESHOLD = 5
+
+
+@dataclass
+class SchedulerCounters:
+    """Snapshot of scheduler observability counters."""
+
+    polls: int = 0
+    rules_seen: int = 0
+    rules_claimed: int = 0
+    rules_skipped_quiet_hours: int = 0
+    rules_skipped_collision: int = 0
+    rules_succeeded: int = 0
+    rules_failed: int = 0
+    rules_auto_disabled: int = 0
+    last_poll_at: datetime | None = None
+    last_error: str | None = None
+
+    def snapshot(self) -> dict[str, Any]:
+        return {
+            "polls": self.polls,
+            "rules_seen": self.rules_seen,
+            "rules_claimed": self.rules_claimed,
+            "rules_skipped_quiet_hours": self.rules_skipped_quiet_hours,
+            "rules_skipped_collision": self.rules_skipped_collision,
+            "rules_succeeded": self.rules_succeeded,
+            "rules_failed": self.rules_failed,
+            "rules_auto_disabled": self.rules_auto_disabled,
+            "last_poll_at": (
+                self.last_poll_at.isoformat() if self.last_poll_at else None
+            ),
+            "last_error": self.last_error,
+        }
+
+
+@dataclass
+class AutomationScheduler:
+    """Supervised task that drives the executor.
+
+    Construction is side-effect-free; call :meth:`run_forever` from
+    a supervised task wrapper (see :func:`spawn_scheduler`).
+    """
+
+    bot: Any = None
+    poll_interval_seconds: int = _DEFAULT_POLL_SECONDS
+    failure_threshold: int = _DEFAULT_FAILURE_THRESHOLD
+    counters: SchedulerCounters = field(default_factory=SchedulerCounters)
+    _stop: asyncio.Event | None = None
+
+    def stop(self) -> None:
+        if self._stop is not None:
+            self._stop.set()
+
+    async def run_forever(self) -> None:
+        """The supervised loop."""
+        self._stop = asyncio.Event()
+        logger.info(
+            "automation_scheduler: starting (poll_interval=%ds, "
+            "failure_threshold=%d)",
+            self.poll_interval_seconds,
+            self.failure_threshold,
+        )
+        try:
+            while not self._stop.is_set():
+                try:
+                    await self.tick()
+                except Exception as exc:  # noqa: BLE001 — loop boundary
+                    self.counters.last_error = f"{type(exc).__name__}: {exc}"
+                    logger.exception("automation_scheduler.tick: failed")
+                try:
+                    await asyncio.wait_for(
+                        self._stop.wait(),
+                        timeout=self.poll_interval_seconds,
+                    )
+                except asyncio.TimeoutError:
+                    pass
+        finally:
+            logger.info("automation_scheduler: stopped")
+
+    async def tick(self) -> None:
+        """One poll cycle. Exposed for direct testing."""
+        self.counters.polls += 1
+        self.counters.last_poll_at = _now_utc()
+
+        due = await self._fetch_due_rules()
+        self.counters.rules_seen += len(due)
+        for rule in due:
+            await self._dispatch_one(rule)
+
+    async def _fetch_due_rules(self) -> list[dict[str, Any]]:
+        """Return enabled rules whose ``next_run_at`` is in the past.
+
+        Tests can monkeypatch this to inject synthetic schedules.
+        Production uses a direct query against the pool; we keep
+        the logic here so it stays mockable.
+        """
+        from utils.db import pool
+
+        try:
+            rows = await pool.get().fetch(
+                """
+                SELECT id, guild_id, name, enabled, trigger_kind,
+                       trigger_config, action_kind, action_config,
+                       schedule, timezone, last_run_at, next_run_at,
+                       failure_count, last_error, created_by,
+                       created_at, updated_at
+                FROM automation_rules
+                WHERE enabled
+                  AND (next_run_at IS NULL OR next_run_at <= NOW())
+                ORDER BY next_run_at NULLS FIRST
+                LIMIT 50
+                """,
+            )
+        except Exception:
+            logger.exception(
+                "automation_scheduler._fetch_due_rules: query failed",
+            )
+            return []
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            rec = dict(row)
+            rec["trigger_config"] = db._decode(rec.get("trigger_config")) or {}
+            rec["action_config"] = db._decode(rec.get("action_config")) or {}
+            out.append(rec)
+        return out
+
+    async def _dispatch_one(self, rule: dict[str, Any]) -> None:
+        rule_id = int(rule["id"])
+        guild_id = int(rule["guild_id"])
+
+        if _in_quiet_hours(rule):
+            self.counters.rules_skipped_quiet_hours += 1
+            logger.debug(
+                "automation_scheduler: rule_id=%d in quiet hours; skipping",
+                rule_id,
+            )
+            await db.update_schedule_state(
+                rule_id,
+                next_run_at=_compute_next_run_at(rule),
+                last_run_at=_now_utc(),
+            )
+            return
+
+        idempotency_key = _idempotency_key(rule)
+        run_id = await db.claim_run(
+            rule_id=rule_id,
+            guild_id=guild_id,
+            idempotency_key=idempotency_key,
+            dry_run=False,
+        )
+        if run_id is None:
+            self.counters.rules_skipped_collision += 1
+            return
+        self.counters.rules_claimed += 1
+
+        await db.mark_running(run_id)
+
+        guild = self.bot.get_guild(guild_id) if self.bot is not None else None
+        result = await execute_rule(
+            rule,
+            dry_run=False,
+            bot=self.bot,
+            guild=guild,
+            actor_id=rule.get("created_by"),
+        )
+        await db.finish_run(
+            run_id=run_id,
+            status=result.status,
+            result_summary=result.result_summary,
+            error=result.error,
+        )
+
+        if result.status == "success":
+            self.counters.rules_succeeded += 1
+            await db.reset_failure_count(rule_id)
+        else:
+            self.counters.rules_failed += 1
+            failure_count = await db.record_failure(
+                rule_id,
+                result.error or "unknown",
+            )
+            if failure_count >= self.failure_threshold:
+                await db.set_enabled(rule_id, False)
+                self.counters.rules_auto_disabled += 1
+                logger.warning(
+                    "automation_scheduler: rule_id=%d disabled after "
+                    "%d consecutive failures",
+                    rule_id,
+                    failure_count,
+                )
+
+        # Re-arm or leave dormant. Manual rules never auto-fire so
+        # they are not re-armed; everything else gets a fresh
+        # ``next_run_at`` computed from its trigger config.
+        if rule.get("trigger_kind") != "manual":
+            await db.update_schedule_state(
+                rule_id,
+                next_run_at=_compute_next_run_at(rule),
+                last_run_at=_now_utc(),
+            )
+        else:
+            await db.update_schedule_state(
+                rule_id,
+                next_run_at=None,
+                last_run_at=_now_utc(),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _idempotency_key(rule: dict[str, Any]) -> str:
+    """Per-tick claim key.
+
+    Includes the rule id + the rule's currently-scheduled
+    ``next_run_at`` epoch, plus a UUID4 component. The
+    (rule_id, next_run_at) bound guarantees the same claim string
+    is never reused for a different tick — even if the UUID is the
+    same in some pathological mock.
+    """
+    rule_id = rule["id"]
+    next_run_at = rule.get("next_run_at")
+    epoch = int(next_run_at.timestamp()) if isinstance(next_run_at, datetime) else 0
+    return f"rule:{rule_id}:tick:{epoch}:{uuid.uuid4()}"
+
+
+def _in_quiet_hours(rule: dict[str, Any]) -> bool:
+    """Return True when the current UTC hour falls inside
+    ``trigger_config['quiet_hours']``.
+
+    ``quiet_hours`` is a ``[start_hour, end_hour]`` pair. The range
+    is inclusive at the start, exclusive at the end. Wrap-around
+    (e.g. ``[22, 6]``) is supported.
+    """
+    qh = rule.get("trigger_config", {}).get("quiet_hours")
+    if not qh:
+        return False
+    try:
+        start = int(qh[0])
+        end = int(qh[1])
+    except (TypeError, ValueError, IndexError):
+        return False
+    hour = _now_utc().hour
+    if start <= end:
+        return start <= hour < end
+    return hour >= start or hour < end
+
+
+def _compute_next_run_at(rule: dict[str, Any]) -> datetime | None:
+    """Compute the rule's next scheduled fire time.
+
+    v1 supports two kinds:
+
+    * ``interval`` — fire every ``interval_minutes`` minutes.
+    * ``scheduled_time`` — placeholder; returns ``+1 day``
+      until a real cron parser ships.
+
+    Other kinds return ``None`` (rules drop off the schedule
+    queue until something else flips ``next_run_at``).
+    """
+    trigger_kind = rule.get("trigger_kind")
+    cfg = rule.get("trigger_config") or {}
+    now = _now_utc()
+    if trigger_kind == "interval":
+        try:
+            minutes = int(cfg.get("interval_minutes", 0))
+        except (TypeError, ValueError):
+            minutes = 0
+        if minutes <= 0:
+            return None
+        return now + timedelta(minutes=minutes)
+    if trigger_kind == "scheduled_time":
+        # TODO Track 7 PR 22 — replace with cron parser.
+        return now + timedelta(days=1)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics registration
+# ---------------------------------------------------------------------------
+
+
+_INSTANCE: AutomationScheduler | None = None
+
+
+def get_or_create(bot: Any | None = None) -> AutomationScheduler:
+    """Return the singleton scheduler, instantiating if needed."""
+    global _INSTANCE
+    if _INSTANCE is None:
+        _INSTANCE = AutomationScheduler(bot=bot)
+    elif bot is not None and _INSTANCE.bot is None:
+        _INSTANCE.bot = bot
+    return _INSTANCE
+
+
+def _diagnostics_snapshot() -> dict[str, Any]:
+    if _INSTANCE is None:
+        return {"running": False}
+    snap = _INSTANCE.counters.snapshot()
+    snap["running"] = _INSTANCE._stop is not None and not _INSTANCE._stop.is_set()
+    snap["poll_interval_seconds"] = _INSTANCE.poll_interval_seconds
+    snap["failure_threshold"] = _INSTANCE.failure_threshold
+    return snap
+
+
+def register_diagnostics() -> None:
+    """Register the snapshot under ``automation_scheduler``.
+
+    Idempotent: a re-registration just overwrites the provider so
+    the diagnostics surface always points at the active instance.
+    """
+    from services import diagnostics_service
+
+    diagnostics_service.register(
+        "automation_scheduler",
+        _diagnostics_snapshot,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Spawn helper
+# ---------------------------------------------------------------------------
+
+
+def spawn_scheduler(bot: Any | None = None) -> Any:
+    """Spawn the scheduler as a supervised task.
+
+    Returns the asyncio.Task so the cog can hold a reference.
+    """
+    from core.runtime import tasks
+
+    scheduler = get_or_create(bot)
+    register_diagnostics()
+    return tasks.spawn(
+        "automation_scheduler",
+        scheduler.run_forever(),
+    )
+
+
+__all__ = [
+    "AutomationScheduler",
+    "SchedulerCounters",
+    "get_or_create",
+    "register_diagnostics",
+    "spawn_scheduler",
+]

--- a/tests/unit/services/test_automation_scheduler.py
+++ b/tests/unit/services/test_automation_scheduler.py
@@ -1,0 +1,319 @@
+"""Phase 9g / Track 6 PR 18 — automation scheduler tests.
+
+Pins:
+
+* ``tick`` polls for due rules, claims via ``claim_run``, runs the
+  executor, finishes the run with the result, and arms the next
+  fire time.
+* Quiet hours: a rule inside its ``quiet_hours`` window is
+  skipped + re-armed, never executed.
+* Idempotency collisions: ``claim_run`` returning None bumps the
+  collision counter; the executor is not invoked.
+* Auto-disable: a rule whose ``failure_count`` reaches the
+  threshold gets ``set_enabled(False)``.
+* Manual rules are not auto-rearmed.
+* Diagnostics snapshot exposes counters + running state.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.automation_scheduler import (
+    AutomationScheduler,
+    SchedulerCounters,
+    _compute_next_run_at,
+    _idempotency_key,
+    _in_quiet_hours,
+    register_diagnostics,
+)
+
+
+def _rule(
+    *,
+    rule_id=7,
+    guild_id=1,
+    trigger_kind="interval",
+    trigger_config=None,
+    action_kind="notify_owner",
+    action_config=None,
+    next_run_at=None,
+    enabled=True,
+    failure_count=0,
+):
+    if trigger_config is None:
+        trigger_config = {"interval_minutes": 5}
+    if action_config is None:
+        action_config = {"template": "hi"}
+    return {
+        "id": rule_id,
+        "guild_id": guild_id,
+        "name": "x",
+        "enabled": enabled,
+        "trigger_kind": trigger_kind,
+        "trigger_config": trigger_config,
+        "action_kind": action_kind,
+        "action_config": action_config,
+        "schedule": None,
+        "timezone": "UTC",
+        "last_run_at": None,
+        "next_run_at": next_run_at,
+        "failure_count": failure_count,
+        "last_error": None,
+        "created_by": 99,
+        "created_at": None,
+        "updated_at": None,
+    }
+
+
+@pytest.fixture
+def _mock_db():
+    with (
+        patch(
+            "services.automation_scheduler.db.claim_run",
+            new_callable=AsyncMock,
+        ) as claim_run,
+        patch(
+            "services.automation_scheduler.db.mark_running",
+            new_callable=AsyncMock,
+        ) as mark_running,
+        patch(
+            "services.automation_scheduler.db.finish_run",
+            new_callable=AsyncMock,
+        ) as finish_run,
+        patch(
+            "services.automation_scheduler.db.set_enabled",
+            new_callable=AsyncMock,
+        ) as set_enabled,
+        patch(
+            "services.automation_scheduler.db.record_failure",
+            new_callable=AsyncMock,
+        ) as record_failure,
+        patch(
+            "services.automation_scheduler.db.reset_failure_count",
+            new_callable=AsyncMock,
+        ) as reset_failure,
+        patch(
+            "services.automation_scheduler.db.update_schedule_state",
+            new_callable=AsyncMock,
+        ) as update_state,
+        patch(
+            "services.automation_scheduler.execute_rule",
+            new_callable=AsyncMock,
+        ) as execute,
+    ):
+        yield {
+            "claim_run": claim_run,
+            "mark_running": mark_running,
+            "finish_run": finish_run,
+            "set_enabled": set_enabled,
+            "record_failure": record_failure,
+            "reset_failure_count": reset_failure,
+            "update_schedule_state": update_state,
+            "execute_rule": execute,
+        }
+
+
+def _success_result():
+    return MagicMock(
+        status="success",
+        result_summary={"sent": 1},
+        error=None,
+    )
+
+
+def _failure_result(error="boom"):
+    return MagicMock(
+        status="failure",
+        result_summary={},
+        error=error,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def test_quiet_hours_simple_window():
+    rule = _rule(trigger_config={"quiet_hours": [0, 23]})
+    # Currently-UTC hour is in [0, 23) for almost the entire day.
+    # Use a fixed hour via patching.
+    with patch(
+        "services.automation_scheduler._now_utc",
+        return_value=datetime(2026, 5, 20, 10, 0, tzinfo=timezone.utc),
+    ):
+        assert _in_quiet_hours(rule) is True
+
+
+def test_quiet_hours_wraparound_overnight():
+    rule = _rule(trigger_config={"quiet_hours": [22, 6]})
+    with patch(
+        "services.automation_scheduler._now_utc",
+        return_value=datetime(2026, 5, 20, 23, 0, tzinfo=timezone.utc),
+    ):
+        assert _in_quiet_hours(rule) is True
+    with patch(
+        "services.automation_scheduler._now_utc",
+        return_value=datetime(2026, 5, 20, 3, 0, tzinfo=timezone.utc),
+    ):
+        assert _in_quiet_hours(rule) is True
+    with patch(
+        "services.automation_scheduler._now_utc",
+        return_value=datetime(2026, 5, 20, 12, 0, tzinfo=timezone.utc),
+    ):
+        assert _in_quiet_hours(rule) is False
+
+
+def test_quiet_hours_absent_returns_false():
+    assert _in_quiet_hours(_rule()) is False
+
+
+def test_idempotency_key_includes_rule_and_next_run_epoch():
+    when = datetime(2026, 5, 20, 12, 0, tzinfo=timezone.utc)
+    rule = _rule(next_run_at=when)
+    key = _idempotency_key(rule)
+    assert key.startswith(f"rule:7:tick:{int(when.timestamp())}:")
+
+
+def test_compute_next_run_at_for_interval():
+    rule = _rule(trigger_kind="interval", trigger_config={"interval_minutes": 30})
+    when = _compute_next_run_at(rule)
+    assert when is not None
+    delta = when - datetime.now(timezone.utc)
+    assert timedelta(minutes=29) < delta < timedelta(minutes=31)
+
+
+def test_compute_next_run_at_for_manual_returns_none():
+    rule = _rule(trigger_kind="manual")
+    assert _compute_next_run_at(rule) is None
+
+
+# ---------------------------------------------------------------------------
+# tick — happy paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tick_dispatches_due_rule_success(_mock_db):
+    scheduler = AutomationScheduler()
+    rule = _rule()
+    with patch.object(scheduler, "_fetch_due_rules", new=AsyncMock(return_value=[rule])):
+        _mock_db["claim_run"].return_value = 42
+        _mock_db["execute_rule"].return_value = _success_result()
+        await scheduler.tick()
+
+    _mock_db["claim_run"].assert_awaited_once()
+    _mock_db["mark_running"].assert_awaited_once_with(42)
+    _mock_db["execute_rule"].assert_awaited_once()
+    _mock_db["finish_run"].assert_awaited_once()
+    _mock_db["reset_failure_count"].assert_awaited_once_with(7)
+    # Re-armed via update_schedule_state.
+    _mock_db["update_schedule_state"].assert_awaited()
+    assert scheduler.counters.rules_claimed == 1
+    assert scheduler.counters.rules_succeeded == 1
+
+
+@pytest.mark.asyncio
+async def test_tick_records_failure_and_increments_counter(_mock_db):
+    scheduler = AutomationScheduler()
+    rule = _rule()
+    with patch.object(scheduler, "_fetch_due_rules", new=AsyncMock(return_value=[rule])):
+        _mock_db["claim_run"].return_value = 42
+        _mock_db["execute_rule"].return_value = _failure_result()
+        _mock_db["record_failure"].return_value = 1
+        await scheduler.tick()
+
+    _mock_db["record_failure"].assert_awaited_once_with(7, "boom")
+    _mock_db["set_enabled"].assert_not_awaited()
+    assert scheduler.counters.rules_failed == 1
+
+
+@pytest.mark.asyncio
+async def test_tick_auto_disables_after_threshold(_mock_db):
+    scheduler = AutomationScheduler(failure_threshold=3)
+    rule = _rule(failure_count=2)
+    with patch.object(scheduler, "_fetch_due_rules", new=AsyncMock(return_value=[rule])):
+        _mock_db["claim_run"].return_value = 42
+        _mock_db["execute_rule"].return_value = _failure_result()
+        _mock_db["record_failure"].return_value = 3  # crosses threshold
+        await scheduler.tick()
+
+    _mock_db["set_enabled"].assert_awaited_once_with(7, False)
+    assert scheduler.counters.rules_auto_disabled == 1
+
+
+@pytest.mark.asyncio
+async def test_tick_skips_quiet_hours_without_running_executor(_mock_db):
+    scheduler = AutomationScheduler()
+    rule = _rule(trigger_config={"interval_minutes": 5, "quiet_hours": [0, 23]})
+    with (
+        patch.object(scheduler, "_fetch_due_rules", new=AsyncMock(return_value=[rule])),
+        patch(
+            "services.automation_scheduler._now_utc",
+            return_value=datetime(2026, 5, 20, 10, 0, tzinfo=timezone.utc),
+        ),
+    ):
+        await scheduler.tick()
+
+    _mock_db["execute_rule"].assert_not_awaited()
+    _mock_db["claim_run"].assert_not_awaited()
+    _mock_db["update_schedule_state"].assert_awaited()
+    assert scheduler.counters.rules_skipped_quiet_hours == 1
+
+
+@pytest.mark.asyncio
+async def test_tick_skips_idempotency_collision_without_executing(_mock_db):
+    scheduler = AutomationScheduler()
+    rule = _rule()
+    with patch.object(scheduler, "_fetch_due_rules", new=AsyncMock(return_value=[rule])):
+        _mock_db["claim_run"].return_value = None  # another scheduler beat us
+        await scheduler.tick()
+
+    _mock_db["execute_rule"].assert_not_awaited()
+    _mock_db["mark_running"].assert_not_awaited()
+    assert scheduler.counters.rules_skipped_collision == 1
+
+
+@pytest.mark.asyncio
+async def test_tick_manual_rule_does_not_rearm_next_run_at(_mock_db):
+    scheduler = AutomationScheduler()
+    rule = _rule(trigger_kind="manual", trigger_config={})
+    with patch.object(scheduler, "_fetch_due_rules", new=AsyncMock(return_value=[rule])):
+        _mock_db["claim_run"].return_value = 42
+        _mock_db["execute_rule"].return_value = _success_result()
+        await scheduler.tick()
+
+    call = _mock_db["update_schedule_state"].await_args
+    assert call.kwargs["next_run_at"] is None
+
+
+# ---------------------------------------------------------------------------
+# Counters + diagnostics
+# ---------------------------------------------------------------------------
+
+
+def test_counters_snapshot_serialises_datetimes():
+    counters = SchedulerCounters(
+        polls=3,
+        last_poll_at=datetime(2026, 5, 20, 10, 0, tzinfo=timezone.utc),
+    )
+    snap = counters.snapshot()
+    assert snap["polls"] == 3
+    assert isinstance(snap["last_poll_at"], str)
+
+
+def test_register_diagnostics_calls_diagnostics_service():
+    from services import automation_scheduler as mod
+
+    mod._INSTANCE = AutomationScheduler()  # fresh
+    with patch(
+        "services.diagnostics_service.register",
+    ) as reg_mock:
+        register_diagnostics()
+    reg_mock.assert_called_once()
+    args = reg_mock.call_args.args
+    assert args[0] == "automation_scheduler"


### PR DESCRIPTION
## Summary

- Closes Track 6 with the supervised poll loop driving the executor.
- 30-second polling, quiet-hours support, idempotency-key claim, configurable auto-disable threshold, full diagnostics surface.
- Adds layer 19 (`_teardown_automation_rules`) to `guild_lifecycle.teardown`.

> Stacked on top of PR #190 (`services: automation executor`). Auto-rebases to `main` when #190 lands.

## Scope table

| Does | Does NOT |
|---|---|
| Add `AutomationScheduler.run_forever` + `tick` | Spawn the scheduler at cog_load (Track 8 PR 23) |
| Wire diagnostics under `automation_scheduler` | Add a cog-level UI panel (Track 7 PR 22) |
| Add `_teardown_automation_rules` to `guild_lifecycle.teardown` (layer 19) | Implement the cron parser for `scheduled_time` (placeholder until Track 7 PR 22) |
| Handle idempotency collisions silently (collision counter) | Persist counters across restarts (in-memory only) |

## Files changed

- `disbot/services/automation_scheduler.py` — **new** (~360 LOC).
- `disbot/guild_lifecycle.py` — `+~22 LOC`: layer 19 + `_teardown_automation_rules` helper.
- `tests/unit/services/test_automation_scheduler.py` — **new** (~300 LOC, 14 cases).

## Architecture impact

**Additive substrate task.** Supervised via `core.runtime.tasks.spawn`. Failure isolation is layered — tick errors are logged and the loop keeps polling; handler errors are isolated by the executor (Track 6 PR 17); pipeline errors are isolated by the mutation pipeline (Track 6 PR 16).

`guild_lifecycle.teardown` gains a 19th layer; `automation_runs` rows cascade away via the FK so we only need to delete from `automation_rules`.

## Tests run

```
python -m pytest tests/unit/services/test_automation_scheduler.py -v   # 14 passed
python -m pytest -q                                                    # 2829 passed, 1 warning
ruff check . --exclude .github,tests,venv,env,build,dist               # All checks passed
black --check . --exclude '(\.github|tests|venv|env|build|dist)'       # 310 files unchanged
isort --check-only . --skip-glob '*/(\.github|tests|venv|env|build|dist)/*'   # passed
mypy disbot/                                                           # 311 source files, 0 issues
```

## Rollback plan

`git revert`. The scheduler stops getting spawned (no cog change in this PR, so nothing currently spawns it — Track 8 wires that). DB schema + executor + mutation pipeline remain available for direct DB driving.

## Out of scope

- Cog spawn — Track 8 PR 23.
- Cron parser for `scheduled_time` — Track 7 PR 22.
- Concrete leaderboard builder — Track 7 PR 22.

## CI status

Pending — subscribing after creation.

## Risk level

**Low.** Supervised task, no callers yet, failure isolation pinned. Counters are observable via `!platform diagnostics automation_scheduler`. Auto-disable threshold prevents runaway rules.

## Next PR

`services+templates: onboarding automation templates (Track 7 PR 19)` — per the accepted plan at `/root/.claude/plans/superbot-2-0-setup-purring-peach.md` §5 Track 7 PR 19.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXdDyevoQLQXgmgog7erwY)_