### PR TITLE
services: role automation decision module (Track 7 PR 20)

### DIFF
--- a/disbot/services/role_automation.py
+++ b/disbot/services/role_automation.py
@@ -1,0 +1,460 @@
+"""Role-automation decision logic — Phase 9h / Track 7 PR 20.
+
+Pure-read decision module extracted from :mod:`disbot.cogs.role_cog`.
+Owns the time-based / threshold-based role progression logic:
+
+* :func:`compute_assignments` — pure: given the guild's threshold
+  table + the live member roster, return the planned add / remove
+  operations.
+* :func:`explain_assignment_for` — single-member reasoning for the
+  ``!roles explain`` operator surface and the wizard's
+  drill-down view.
+* :func:`check_preflight` — owner-facing safety check: confirms the
+  bot has ``manage_roles`` and that the configured progression
+  roles are below the bot's top role.
+* :func:`apply` — perform the actual ``add_roles`` /
+  ``remove_roles`` calls. Wrapped per-member in try/except so one
+  hierarchy-blocked role does not abort the whole batch. Emits
+  ``audit.action_recorded`` via the Track 1 shared helper for
+  every successful change.
+
+Tests pin:
+
+* Dry-run produces no mutations.
+* ``explain_assignment_for`` returns deterministic reasoning.
+* Hierarchy preflight catches a progression role above the bot's
+  top role.
+* Permission preflight catches a missing ``manage_roles``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+from services.audit_events import emit_audit_action
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger("bot.services.role_automation")
+
+
+# ---------------------------------------------------------------------------
+# Data shapes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RoleThreshold:
+    """One progression row: ``role_name`` requires ``days_required``."""
+
+    role_name: str
+    days_required: int
+
+
+@dataclass(frozen=True)
+class Assignment:
+    """One planned (member, add/remove) operation."""
+
+    member_id: int
+    member_display: str
+    add_role_id: int | None
+    add_role_name: str | None
+    remove_role_ids: tuple[int, ...]
+    remove_role_names: tuple[str, ...]
+    reason: str  # human-readable explanation
+    days_in_guild: int
+
+
+@dataclass(frozen=True)
+class PreflightResult:
+    """Outcome of :func:`check_preflight`."""
+
+    bot_has_manage_roles: bool
+    hierarchy_blockers: tuple[str, ...] = ()
+    missing_roles: tuple[str, ...] = ()
+
+    @property
+    def ok(self) -> bool:
+        return (
+            self.bot_has_manage_roles
+            and not self.hierarchy_blockers
+            and not self.missing_roles
+        )
+
+
+@dataclass(frozen=True)
+class ApplyResult:
+    """Outcome of :func:`apply`."""
+
+    attempted: int = 0
+    succeeded: int = 0
+    failed: int = 0
+    skipped: int = 0
+    errors: tuple[str, ...] = ()
+
+
+# ---------------------------------------------------------------------------
+# Pure decision logic
+# ---------------------------------------------------------------------------
+
+
+def _normalize(name: str | None) -> str:
+    return (name or "").strip().lower()
+
+
+def _resolve_role(guild: Any, name: str) -> Any | None:
+    """Cache-only normalised role lookup."""
+    norm = _normalize(name)
+    for role in getattr(guild, "roles", ()) or ():
+        if _normalize(role.name) == norm:
+            return role
+    return None
+
+
+def compute_assignments(
+    guild: Any,
+    thresholds: list[RoleThreshold] | tuple[RoleThreshold, ...],
+    *,
+    skip_role_names: tuple[str, ...] = (),
+    now: datetime | None = None,
+) -> tuple[Assignment, ...]:
+    """Walk ``guild.members`` and produce planned operations.
+
+    Pure: no Discord API mutation, no DB writes. The result is what
+    :func:`apply` would do if invoked with ``dry_run=False``.
+    """
+    if now is None:
+        now = datetime.now(tz=timezone.utc)
+    if not thresholds:
+        return ()
+
+    role_map = {t.role_name: t.days_required for t in thresholds}
+    progression = sorted(role_map, key=lambda r: role_map[r])
+
+    skip_roles = tuple(
+        r for n in skip_role_names if (r := _resolve_role(guild, n)) is not None
+    )
+
+    out: list[Assignment] = []
+    for member in getattr(guild, "members", ()) or ():
+        if getattr(member, "bot", False):
+            continue
+        if any(role in getattr(member, "roles", ()) for role in skip_roles):
+            continue
+        joined_at = getattr(member, "joined_at", None)
+        if joined_at is None:
+            continue
+
+        days = (now - joined_at).days
+
+        target_name: str | None = None
+        for name in progression:
+            if days >= role_map[name]:
+                target_name = name
+
+        target_role = _resolve_role(guild, target_name) if target_name else None
+        member_roles = list(getattr(member, "roles", ()) or ())
+
+        # Walk through member's existing roles, find any that belong
+        # to the progression — to figure out the operator's "current
+        # tier" and avoid demotions.
+        current_highest: str | None = None
+        for role in member_roles:
+            matched = next(
+                (n for n in role_map if _normalize(n) == _normalize(role.name)),
+                None,
+            )
+            if matched is not None:
+                if current_highest is None or progression.index(
+                    matched,
+                ) > progression.index(current_highest):
+                    current_highest = matched
+
+        if (
+            current_highest
+            and target_name
+            and progression.index(current_highest) > progression.index(target_name)
+        ):
+            continue  # never demote
+
+        to_remove = [
+            r
+            for r in member_roles
+            if any(_normalize(r.name) == _normalize(n) for n in role_map)
+            and r != target_role
+        ]
+
+        add_role_id = target_role.id if target_role else None
+        add_role_name = target_role.name if target_role else None
+        already_assigned = target_role in member_roles if target_role else False
+
+        if not to_remove and already_assigned:
+            continue  # no-op
+
+        if target_role and not already_assigned and not to_remove:
+            reason = (
+                f"{member.display_name} has {days} day(s) in guild; "
+                f"earns role '{target_role.name}'."
+            )
+        elif to_remove and target_role and not already_assigned:
+            reason = (
+                f"{member.display_name} has {days} day(s); promote to "
+                f"'{target_role.name}', remove "
+                f"{[r.name for r in to_remove]}."
+            )
+        elif to_remove and not target_role:
+            reason = (
+                f"{member.display_name} no longer earns any progression "
+                f"role at {days} day(s); remove "
+                f"{[r.name for r in to_remove]}."
+            )
+        else:
+            reason = "no-op"
+
+        out.append(
+            Assignment(
+                member_id=member.id,
+                member_display=getattr(
+                    member,
+                    "display_name",
+                    str(member.id),
+                ),
+                add_role_id=add_role_id if not already_assigned else None,
+                add_role_name=add_role_name if not already_assigned else None,
+                remove_role_ids=tuple(r.id for r in to_remove),
+                remove_role_names=tuple(r.name for r in to_remove),
+                reason=reason,
+                days_in_guild=days,
+            ),
+        )
+
+    return tuple(out)
+
+
+def explain_assignment_for(
+    guild: Any,
+    member: Any,
+    thresholds: list[RoleThreshold] | tuple[RoleThreshold, ...],
+    *,
+    skip_role_names: tuple[str, ...] = (),
+    now: datetime | None = None,
+) -> Assignment | None:
+    """Return the planned operation for one member, or ``None`` if
+    no change is needed.
+    """
+    fake_guild = _SingleMemberGuild(guild, member)
+    plans = compute_assignments(
+        fake_guild,
+        thresholds,
+        skip_role_names=skip_role_names,
+        now=now,
+    )
+    return plans[0] if plans else None
+
+
+class _SingleMemberGuild:
+    """Tiny adapter that exposes one member as ``guild.members``."""
+
+    def __init__(self, guild: Any, member: Any) -> None:
+        self._guild = guild
+        self._member = member
+
+    @property
+    def roles(self):
+        return getattr(self._guild, "roles", ()) or ()
+
+    @property
+    def members(self):
+        return (self._member,)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._guild, name)
+
+
+# ---------------------------------------------------------------------------
+# Preflight checks
+# ---------------------------------------------------------------------------
+
+
+def check_preflight(
+    guild: Any,
+    thresholds: list[RoleThreshold] | tuple[RoleThreshold, ...],
+) -> PreflightResult:
+    """Permission + hierarchy + missing-role check.
+
+    Returns a :class:`PreflightResult` whose ``ok`` is True iff:
+
+    * The bot has ``manage_roles``.
+    * Every progression role exists in the guild.
+    * Every progression role's position is below the bot's top role.
+    """
+    me = getattr(guild, "me", None)
+    if me is None:
+        return PreflightResult(
+            bot_has_manage_roles=False,
+            missing_roles=tuple(t.role_name for t in thresholds),
+        )
+    bot_has_manage = bool(
+        getattr(
+            getattr(me, "guild_permissions", None),
+            "manage_roles",
+            False,
+        ),
+    )
+    bot_top_position = getattr(
+        getattr(me, "top_role", None),
+        "position",
+        0,
+    )
+
+    missing: list[str] = []
+    blockers: list[str] = []
+    for t in thresholds:
+        role = _resolve_role(guild, t.role_name)
+        if role is None:
+            missing.append(t.role_name)
+            continue
+        if getattr(role, "position", 0) >= bot_top_position:
+            blockers.append(t.role_name)
+
+    return PreflightResult(
+        bot_has_manage_roles=bot_has_manage,
+        hierarchy_blockers=tuple(blockers),
+        missing_roles=tuple(missing),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Apply
+# ---------------------------------------------------------------------------
+
+
+async def apply(
+    guild: Any,
+    assignments: tuple[Assignment, ...] | list[Assignment],
+    *,
+    dry_run: bool = False,
+    actor_id: int | None = None,
+    actor_type: str = "system",
+) -> ApplyResult:
+    """Apply ``assignments`` to the live guild.
+
+    Each member is handled in isolation: an exception on one
+    ``add_roles`` / ``remove_roles`` call increments the failure
+    counter but does NOT abort subsequent members. Every successful
+    change emits a ``audit.action_recorded`` event via the Track 1
+    shared helper.
+    """
+    if dry_run:
+        return ApplyResult(
+            attempted=len(assignments),
+            skipped=len(assignments),
+        )
+
+    attempted = 0
+    succeeded = 0
+    failed = 0
+    errors: list[str] = []
+
+    members_by_id = {m.id: m for m in (getattr(guild, "members", ()) or ())}
+
+    for plan in assignments:
+        attempted += 1
+        member = members_by_id.get(plan.member_id)
+        if member is None:
+            failed += 1
+            errors.append(f"member {plan.member_id} not in cache")
+            continue
+        try:
+            await _apply_single(guild, member, plan, actor_id, actor_type)
+            succeeded += 1
+        except Exception as exc:  # noqa: BLE001 — per-member boundary
+            logger.exception(
+                "role_automation.apply: failed for member=%d",
+                plan.member_id,
+            )
+            failed += 1
+            errors.append(
+                f"member {plan.member_id}: {type(exc).__name__}: {exc}",
+            )
+
+    return ApplyResult(
+        attempted=attempted,
+        succeeded=succeeded,
+        failed=failed,
+        errors=tuple(errors),
+    )
+
+
+async def _apply_single(
+    guild: Any,
+    member: Any,
+    plan: Assignment,
+    actor_id: int | None,
+    actor_type: str,
+) -> None:
+    """Per-member work. Wrapped in try/except by :func:`apply`."""
+    occurred_at = datetime.now(tz=timezone.utc)
+
+    if plan.remove_role_ids:
+        roles_to_remove = [
+            r for r in getattr(guild, "roles", ()) or () if r.id in plan.remove_role_ids
+        ]
+        if roles_to_remove:
+            await member.remove_roles(
+                *roles_to_remove,
+                reason="role_automation:demote",
+            )
+            await emit_audit_action(
+                mutation_id=f"role_automation:{member.id}:{occurred_at.timestamp()}",
+                subsystem="role_automation",
+                mutation_type="remove_role",
+                target=f"member:{member.id}",
+                scope="guild",
+                guild_id=guild.id,
+                prev_value=",".join(plan.remove_role_names),
+                new_value=None,
+                actor_id=actor_id,
+                actor_type=actor_type,
+                occurred_at=occurred_at,
+            )
+
+    if plan.add_role_id is not None:
+        target = next(
+            (r for r in getattr(guild, "roles", ()) or () if r.id == plan.add_role_id),
+            None,
+        )
+        if target is not None:
+            await member.add_roles(
+                target,
+                reason="role_automation:promote",
+            )
+            await emit_audit_action(
+                mutation_id=f"role_automation:{member.id}:{occurred_at.timestamp()}",
+                subsystem="role_automation",
+                mutation_type="assign_role",
+                target=f"member:{member.id}",
+                scope="guild",
+                guild_id=guild.id,
+                prev_value=None,
+                new_value=plan.add_role_name,
+                actor_id=actor_id,
+                actor_type=actor_type,
+                occurred_at=occurred_at,
+            )
+
+
+__all__ = [
+    "ApplyResult",
+    "Assignment",
+    "PreflightResult",
+    "RoleThreshold",
+    "apply",
+    "check_preflight",
+    "compute_assignments",
+    "explain_assignment_for",
+]

--- a/tests/unit/services/test_role_automation.py
+++ b/tests/unit/services/test_role_automation.py
@@ -1,0 +1,346 @@
+"""Phase 9h / Track 7 PR 20 — role_automation service tests.
+
+Pins:
+
+* ``compute_assignments`` produces no mutations (pure read).
+* The decision logic respects the documented invariants:
+  - Skip bots / skip members in skip-role list / skip joined_at=None.
+  - Never demote: a member at a higher tier stays put.
+  - Promote when days_in_guild crosses the next threshold.
+* ``explain_assignment_for`` returns deterministic per-member
+  reasoning.
+* ``check_preflight`` flags missing manage_roles, missing roles,
+  and hierarchy blockers (roles >= bot's top role position).
+* ``apply`` calls ``member.add_roles`` / ``member.remove_roles``
+  per assignment when not dry-run; emits one
+  ``audit.action_recorded`` event per change.
+* ``apply(dry_run=True)`` performs no Discord side effects and no
+  audit emit.
+* A raising ``add_roles`` is isolated — the rest of the batch
+  continues, failure counter increments.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.role_automation import (
+    ApplyResult,
+    Assignment,
+    PreflightResult,
+    RoleThreshold,
+    apply,
+    check_preflight,
+    compute_assignments,
+    explain_assignment_for,
+)
+
+
+def _role(rid: int, name: str, position: int = 1):
+    return SimpleNamespace(id=rid, name=name, position=position)
+
+
+def _member(
+    *,
+    mid: int,
+    display: str,
+    roles=(),
+    joined_days_ago: int | None = None,
+    is_bot: bool = False,
+):
+    joined_at = (
+        datetime.now(tz=timezone.utc) - timedelta(days=joined_days_ago)
+        if joined_days_ago is not None
+        else None
+    )
+    return SimpleNamespace(
+        id=mid,
+        display_name=display,
+        roles=list(roles),
+        joined_at=joined_at,
+        bot=is_bot,
+        add_roles=AsyncMock(),
+        remove_roles=AsyncMock(),
+    )
+
+
+def _guild(
+    *,
+    roles=(),
+    members=(),
+    me=None,
+    guild_id: int = 1,
+):
+    return SimpleNamespace(
+        id=guild_id,
+        roles=list(roles),
+        members=list(members),
+        me=me,
+    )
+
+
+def _me_member(*, manage_roles: bool = True, top_position: int = 10):
+    return SimpleNamespace(
+        guild_permissions=SimpleNamespace(manage_roles=manage_roles),
+        top_role=SimpleNamespace(position=top_position),
+    )
+
+
+# ---------------------------------------------------------------------------
+# compute_assignments
+# ---------------------------------------------------------------------------
+
+
+def test_compute_assignments_empty_thresholds_returns_empty():
+    g = _guild(members=[_member(mid=1, display="a", joined_days_ago=100)])
+    assert compute_assignments(g, []) == ()
+
+
+def test_compute_assignments_skips_bots_and_missing_joined_at():
+    threshold_role = _role(100, "Veteran")
+    g = _guild(
+        roles=[threshold_role],
+        members=[
+            _member(mid=1, display="bot", joined_days_ago=100, is_bot=True),
+            _member(mid=2, display="ghost"),  # no joined_at
+        ],
+    )
+    plans = compute_assignments(
+        g,
+        [RoleThreshold("Veteran", 30)],
+    )
+    assert plans == ()
+
+
+def test_compute_assignments_skips_members_in_skip_roles():
+    admin = _role(99, "Admin")
+    threshold_role = _role(100, "Veteran")
+    member = _member(
+        mid=1,
+        display="adminuser",
+        roles=[admin],
+        joined_days_ago=100,
+    )
+    g = _guild(roles=[admin, threshold_role], members=[member])
+    plans = compute_assignments(
+        g,
+        [RoleThreshold("Veteran", 30)],
+        skip_role_names=("Admin",),
+    )
+    assert plans == ()
+
+
+def test_compute_assignments_promotes_member_who_crosses_threshold():
+    veteran = _role(100, "Veteran")
+    g = _guild(
+        roles=[veteran],
+        members=[_member(mid=1, display="u1", joined_days_ago=45)],
+    )
+    plans = compute_assignments(
+        g,
+        [RoleThreshold("Veteran", 30)],
+    )
+    assert len(plans) == 1
+    assert plans[0].add_role_id == 100
+    assert plans[0].add_role_name == "Veteran"
+    assert plans[0].remove_role_ids == ()
+
+
+def test_compute_assignments_never_demotes():
+    veteran = _role(100, "Veteran", position=2)
+    legendary = _role(101, "Legendary", position=3)
+    member = _member(
+        mid=1,
+        display="u1",
+        roles=[legendary],
+        joined_days_ago=45,
+    )
+    g = _guild(roles=[veteran, legendary], members=[member])
+    plans = compute_assignments(
+        g,
+        [
+            RoleThreshold("Veteran", 30),
+            RoleThreshold("Legendary", 90),
+        ],
+    )
+    # 45 days isn't enough for Legendary, but member already has it
+    # — never demote.
+    assert plans == ()
+
+
+def test_compute_assignments_emits_remove_when_promoting():
+    veteran = _role(100, "Veteran", position=2)
+    legendary = _role(101, "Legendary", position=3)
+    member = _member(
+        mid=1,
+        display="u1",
+        roles=[veteran],
+        joined_days_ago=120,
+    )
+    g = _guild(roles=[veteran, legendary], members=[member])
+    plans = compute_assignments(
+        g,
+        [
+            RoleThreshold("Veteran", 30),
+            RoleThreshold("Legendary", 90),
+        ],
+    )
+    assert len(plans) == 1
+    assert plans[0].add_role_name == "Legendary"
+    assert plans[0].remove_role_names == ("Veteran",)
+
+
+def test_explain_assignment_for_returns_per_member_plan():
+    veteran = _role(100, "Veteran")
+    target = _member(mid=42, display="u42", joined_days_ago=60)
+    g = _guild(
+        roles=[veteran],
+        members=[
+            _member(mid=1, display="x", joined_days_ago=10),
+            target,
+        ],
+    )
+    plan = explain_assignment_for(g, target, [RoleThreshold("Veteran", 30)])
+    assert plan is not None
+    assert plan.member_id == 42
+    assert "Veteran" in plan.reason
+
+
+def test_explain_assignment_for_returns_none_when_no_change_needed():
+    veteran = _role(100, "Veteran")
+    target = _member(
+        mid=42,
+        display="u42",
+        roles=[veteran],
+        joined_days_ago=60,
+    )
+    g = _guild(roles=[veteran], members=[target])
+    plan = explain_assignment_for(g, target, [RoleThreshold("Veteran", 30)])
+    assert plan is None
+
+
+# ---------------------------------------------------------------------------
+# check_preflight
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_flags_missing_manage_roles():
+    veteran = _role(100, "Veteran", position=5)
+    g = _guild(
+        roles=[veteran],
+        me=_me_member(manage_roles=False, top_position=10),
+    )
+    result = check_preflight(g, [RoleThreshold("Veteran", 30)])
+    assert result.bot_has_manage_roles is False
+    assert result.ok is False
+
+
+def test_preflight_flags_missing_role():
+    g = _guild(
+        roles=[],  # progression role absent
+        me=_me_member(),
+    )
+    result = check_preflight(g, [RoleThreshold("Veteran", 30)])
+    assert "Veteran" in result.missing_roles
+    assert result.ok is False
+
+
+def test_preflight_flags_hierarchy_blocker():
+    above_bot = _role(100, "Veteran", position=20)  # above bot's 10
+    g = _guild(roles=[above_bot], me=_me_member(top_position=10))
+    result = check_preflight(g, [RoleThreshold("Veteran", 30)])
+    assert "Veteran" in result.hierarchy_blockers
+    assert result.ok is False
+
+
+def test_preflight_ok_when_all_clear():
+    veteran = _role(100, "Veteran", position=5)
+    g = _guild(roles=[veteran], me=_me_member(top_position=10))
+    result = check_preflight(g, [RoleThreshold("Veteran", 30)])
+    assert result.ok is True
+
+
+# ---------------------------------------------------------------------------
+# apply
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_dry_run_does_not_touch_members():
+    veteran = _role(100, "Veteran")
+    member = _member(mid=1, display="u1", joined_days_ago=60)
+    g = _guild(roles=[veteran], members=[member])
+    plans = compute_assignments(g, [RoleThreshold("Veteran", 30)])
+    result = await apply(g, plans, dry_run=True)
+    assert isinstance(result, ApplyResult)
+    assert result.skipped == len(plans)
+    member.add_roles.assert_not_awaited()
+    member.remove_roles.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_apply_calls_add_roles_for_promotions():
+    veteran = _role(100, "Veteran")
+    member = _member(mid=1, display="u1", joined_days_ago=60)
+    g = _guild(roles=[veteran], members=[member])
+    plans = compute_assignments(g, [RoleThreshold("Veteran", 30)])
+    with patch(
+        "services.role_automation.emit_audit_action",
+        new_callable=AsyncMock,
+    ) as emit_mock:
+        result = await apply(g, plans)
+    member.add_roles.assert_awaited_once()
+    assert result.succeeded == 1
+    emit_mock.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_apply_isolates_per_member_failures():
+    veteran = _role(100, "Veteran")
+    ok = _member(mid=1, display="ok", joined_days_ago=60)
+    bad = _member(mid=2, display="bad", joined_days_ago=60)
+    bad.add_roles = AsyncMock(side_effect=RuntimeError("hierarchy"))
+    g = _guild(roles=[veteran], members=[ok, bad])
+    plans = compute_assignments(g, [RoleThreshold("Veteran", 30)])
+    with patch(
+        "services.role_automation.emit_audit_action",
+        new_callable=AsyncMock,
+    ):
+        result = await apply(g, plans)
+    ok.add_roles.assert_awaited_once()
+    assert result.succeeded == 1
+    assert result.failed == 1
+    assert any("hierarchy" in e for e in result.errors)
+
+
+@pytest.mark.asyncio
+async def test_apply_emits_one_audit_event_per_change():
+    veteran = _role(100, "Veteran", position=2)
+    legendary = _role(101, "Legendary", position=3)
+    member = _member(
+        mid=1,
+        display="u1",
+        roles=[veteran],
+        joined_days_ago=120,
+    )
+    g = _guild(roles=[veteran, legendary], members=[member])
+    plans = compute_assignments(
+        g,
+        [
+            RoleThreshold("Veteran", 30),
+            RoleThreshold("Legendary", 90),
+        ],
+    )
+    assert len(plans) == 1
+    with patch(
+        "services.role_automation.emit_audit_action",
+        new_callable=AsyncMock,
+    ) as emit_mock:
+        await apply(g, plans)
+    # Promote = 1 remove + 1 add = 2 audit events
+    assert emit_mock.await_count == 2


### PR DESCRIPTION
## Summary

- Extract the time-based role progression decision logic into `services.role_automation` as a pure-read module + a typed apply function.
- 16 tests pin the invariants (skip bots, never demote, hierarchy preflight, dry-run = zero side effects, per-member failure isolation, audit events per change).
- Defers the actual `role_cog._assign_roles` rewrite to a Track 8 follow-up so behaviour stays unchanged in this PR.

> Stacked on top of PR #192 (`services+templates: onboarding automation templates`). Auto-rebases to `main` when #192 lands.

## Scope table

| Does | Does NOT |
|---|---|
| Add `RoleThreshold` / `Assignment` / `PreflightResult` / `ApplyResult` shapes | Modify `role_cog.py` (deferred to Track 8) |
| Add `compute_assignments` (pure read) | Touch reaction-role / createrole / setrole code paths |
| Add `explain_assignment_for` for per-member reasoning | Persist plans to DB |
| Add `check_preflight` for permission + hierarchy + missing-role checks | Wire diagnostics |
| Add `apply` with dry-run, per-member failure isolation, and audit emission | Add a UI panel for the operator |

## Files changed

- `disbot/services/role_automation.py` — **new** (~370 LOC).
- `tests/unit/services/test_role_automation.py` — **new** (~380 LOC, 16 cases).

## Tests run

```
python -m pytest tests/unit/services/test_role_automation.py -v   # 16 passed
python -m pytest -q                                                # 2865 passed, 1 skipped, 1 warning
ruff check . --exclude .github,tests,venv,env,build,dist           # All checks passed
black --check . --exclude '(\.github|tests|venv|env|build|dist)'   # 312 files unchanged
isort --check-only . --skip-glob '*/(\.github|tests|venv|env|build|dist)/*'   # passed
mypy disbot/                                                       # 313 source files, 0 issues
```

## Rollback plan

`git revert`. The module is additive; `role_cog._assign_roles` continues to drive the existing behaviour.

## Out of scope

- Cog rewrite to call `apply(...)` — deferred to Track 8 PR 23 so the wizard ships before the cog rewrite.
- Reaction-role mutations + `createrole` + `setrole` — those are separate paths the wizard will own.

## CI status

Pending — subscribing after creation.

## Risk level

**Low.** Pure-read decision module + an `apply` with explicit dry-run and failure isolation. No callers yet.

## Next PR

`services+templates: channel templates (Track 7 PR 21)` — per the accepted plan §5.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXdDyevoQLQXgmgog7erwY)_