### PR TITLE
services+views: setup complete + drift detection (Track 8 PR 24)

### DIFF
--- a/disbot/services/setup_session.py
+++ b/disbot/services/setup_session.py
@@ -126,8 +126,105 @@ async def record_readiness_score(guild_id: int, score: int | None) -> None:
     await db.set_readiness_score(guild_id, score)
 
 
+# ---------------------------------------------------------------------------
+# Drift detection (Phase 9i / Track 8 PR 24)
+# ---------------------------------------------------------------------------
+
+
+from dataclasses import dataclass  # noqa: E402 — local symbol
+
+
+@dataclass(frozen=True)
+class DriftReport:
+    """Diff between the last accepted state and a fresh readiness scan."""
+
+    has_drift: bool
+    score_delta: int | None
+    prev_score: int | None
+    current_score: int | None
+    new_error_findings: tuple[str, ...] = ()
+    new_warn_findings: tuple[str, ...] = ()
+    summary: str = ""
+
+
+_DRIFT_SCORE_THRESHOLD = 5
+
+
+def detect_drift(
+    *,
+    previous_score: int | None,
+    current_score: int | None,
+    current_health_summary: dict[str, int] | None = None,
+    new_findings: tuple[object, ...] = (),
+) -> DriftReport:
+    """Compute the drift between a previous readiness snapshot and a
+    fresh ``ReadinessReport``.
+
+    ``has_drift`` is True when:
+
+    * The readiness score moved by more than
+      ``_DRIFT_SCORE_THRESHOLD`` (5 points).
+    * The fresh health summary surfaces at least one ``error``
+      severity finding (a regression).
+    * One or more ``new_findings`` are passed in (the caller
+      already filtered).
+
+    The summary string is a one-liner the wizard renders in the
+    launcher / summary view.
+    """
+    score_delta: int | None = None
+    if previous_score is not None and current_score is not None:
+        score_delta = current_score - previous_score
+
+    new_errors = tuple(
+        f"{getattr(f, 'subsystem', '?')}.{getattr(f, 'binding_name', '?')}"
+        for f in new_findings
+        if getattr(f, "severity", None) == "error"
+    )
+    new_warns = tuple(
+        f"{getattr(f, 'subsystem', '?')}.{getattr(f, 'binding_name', '?')}"
+        for f in new_findings
+        if getattr(f, "severity", None) == "warn"
+    )
+    summary_health_errors = (current_health_summary or {}).get("error", 0)
+
+    score_moved = score_delta is not None and abs(score_delta) >= _DRIFT_SCORE_THRESHOLD
+    has_drift = bool(
+        score_moved or new_errors or new_warns or summary_health_errors > 0,
+    )
+
+    if not has_drift:
+        summary = "No drift detected. Configuration matches the accepted plan."
+    else:
+        bits = []
+        if score_moved and score_delta is not None:
+            direction = "improved" if score_delta > 0 else "regressed"
+            bits.append(f"readiness {direction} by {abs(score_delta)}%")
+        if new_errors:
+            bits.append(f"{len(new_errors)} new error finding(s)")
+        if new_warns:
+            bits.append(f"{len(new_warns)} new warning finding(s)")
+        if summary_health_errors and "error finding" not in " ".join(bits):
+            bits.append(
+                f"{summary_health_errors} health error(s) outstanding",
+            )
+        summary = "Drift detected: " + "; ".join(bits) + "."
+
+    return DriftReport(
+        has_drift=has_drift,
+        score_delta=score_delta,
+        prev_score=previous_score,
+        current_score=current_score,
+        new_error_findings=new_errors,
+        new_warn_findings=new_warns,
+        summary=summary,
+    )
+
+
 __all__ = [
+    "DriftReport",
     "SetupSession",
+    "detect_drift",
     "dismiss",
     "mark_complete",
     "mark_in_progress",

--- a/disbot/views/setup/summary.py
+++ b/disbot/views/setup/summary.py
@@ -1,0 +1,222 @@
+"""Setup-summary view — Phase 9i / Track 8 PR 24.
+
+The launcher swaps to **Re-run Setup** + **View summary** once
+``setup_status='complete'``. The View summary button opens this
+panel: a digest of what the wizard applied (subsystems + binding
+names + audit IDs when available) and a drift line that flags any
+deviation from the accepted plan based on the current readiness
+scan.
+
+No DB writes from this view. The drift detection runs against a
+fresh :func:`services.setup_readiness.collect` and the cached
+``last_readiness_score`` already on the
+:class:`SetupSession`.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import discord
+
+from services.setup_session import DriftReport, detect_drift
+from views.base import BaseView
+
+if TYPE_CHECKING:
+    from services.setup_session import SetupSession
+
+logger = logging.getLogger("bot.views.setup.summary")
+
+
+@dataclass(frozen=True)
+class AppliedRecord:
+    """One line item the wizard applied during Final review."""
+
+    subsystem: str
+    binding_name: str
+    target_name: str
+    mutation_id: str | None = None
+    audit_id: int | None = None
+
+
+@dataclass(frozen=True)
+class SummarySnapshot:
+    """Aggregate of every applied operation + drift verdict."""
+
+    applied: tuple[AppliedRecord, ...] = ()
+    drift: DriftReport | None = None
+    extra_notes: tuple[str, ...] = field(default_factory=tuple)
+
+
+def build_summary_embed(snapshot: SummarySnapshot) -> discord.Embed:
+    """Render the summary embed.
+
+    Three states:
+
+    * No applied operations — operator finished setup with no
+      changes (e.g. accepted nothing). The embed surfaces drift
+      only.
+    * Applied + clean — green embed listing every applied
+      ``subsystem.binding`` → target name + audit id.
+    * Applied + drift — yellow embed; drift line callouts on top
+      of the applied list.
+    """
+    drift = snapshot.drift
+    has_drift = drift is not None and drift.has_drift
+
+    if not snapshot.applied:
+        color = discord.Color.gold() if has_drift else discord.Color.dark_grey()
+        embed = discord.Embed(
+            title="🛰 Setup summary",
+            description=(
+                "Setup finished without recording any applied changes. "
+                "Run **Smart suggestions** → **Final review** to apply "
+                "recommendations."
+            ),
+            color=color,
+        )
+        if drift is not None:
+            embed.add_field(
+                name="Drift",
+                value=drift.summary,
+                inline=False,
+            )
+        return embed
+
+    color = discord.Color.gold() if has_drift else discord.Color.green()
+    embed = discord.Embed(
+        title="🛰 Setup summary",
+        description=(
+            f"**{len(snapshot.applied)}** recommendation(s) applied during "
+            "the wizard run."
+        ),
+        color=color,
+    )
+    lines = []
+    for rec in snapshot.applied:
+        parts = [
+            f"• `{rec.subsystem}.{rec.binding_name}` → `{rec.target_name}`",
+        ]
+        if rec.mutation_id:
+            parts.append(f"_(mutation `{rec.mutation_id[:8]}`)_")
+        if rec.audit_id is not None:
+            parts.append(f"_(audit `{rec.audit_id}`)_")
+        lines.append(" ".join(parts))
+    value = "\n".join(lines)
+    if len(value) > 1000:
+        value = value[:997] + "..."
+    embed.add_field(name="Applied", value=value, inline=False)
+
+    if drift is not None:
+        embed.add_field(
+            name="Drift",
+            value=drift.summary,
+            inline=False,
+        )
+
+    if snapshot.extra_notes:
+        embed.add_field(
+            name="Notes",
+            value="\n".join(f"• {n}" for n in snapshot.extra_notes),
+            inline=False,
+        )
+    return embed
+
+
+class SummaryView(BaseView):
+    """Owner-facing summary panel.
+
+    The constructor accepts a pre-built :class:`SummarySnapshot` so
+    the launcher / wizard can build it from whatever state they
+    have (the wizard hub passes through the last ``FinalReview``
+    result; the launcher passes through the cached
+    ``last_readiness_score`` plus a fresh drift detection).
+    """
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        *,
+        snapshot: SummarySnapshot,
+        public: bool = False,
+        timeout: int = 180,
+    ) -> None:
+        super().__init__(author, public=public, timeout=timeout)
+        self.snapshot = snapshot
+
+    @discord.ui.button(label="Close", style=discord.ButtonStyle.secondary)
+    async def _close(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        for child in self.children:
+            child.disabled = True  # type: ignore[attr-defined]
+        await interaction.response.edit_message(view=self)
+        self.stop()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def build_summary_snapshot(
+    *,
+    session: SetupSession,
+    applied: tuple[AppliedRecord, ...] = (),
+    guild: object | None = None,
+) -> SummarySnapshot:
+    """Convenience helper: combine the persisted applied records
+    with a fresh drift scan.
+
+    The fresh scan calls ``services.setup_readiness.collect`` if a
+    ``guild`` is passed in; otherwise the drift report uses the
+    persisted ``last_readiness_score`` against ``None`` for the
+    current score (which the drift detector then surfaces as "no
+    score").
+    """
+    current_score: int | None = None
+    current_summary: dict[str, int] = {}
+    new_findings: tuple[object, ...] = ()
+    if guild is not None:
+        try:
+            from services import setup_readiness
+
+            report = await setup_readiness.collect(
+                session.guild_id,
+                guild=guild,
+            )
+        except Exception:
+            logger.exception(
+                "summary: setup_readiness.collect failed for guild=%d",
+                session.guild_id,
+            )
+            report = None
+        if report is not None:
+            current_score = report.percentage
+            current_summary = dict(report.health_summary)
+            new_findings = tuple(
+                f for f in report.health_findings if f.severity in ("error", "warn")
+            )
+
+    drift = detect_drift(
+        previous_score=session.last_readiness_score,
+        current_score=current_score,
+        current_health_summary=current_summary,
+        new_findings=new_findings,
+    )
+
+    return SummarySnapshot(applied=applied, drift=drift)
+
+
+__all__ = [
+    "AppliedRecord",
+    "SummarySnapshot",
+    "SummaryView",
+    "build_summary_embed",
+    "build_summary_snapshot",
+]

--- a/tests/unit/services/test_drift_detection.py
+++ b/tests/unit/services/test_drift_detection.py
@@ -1,0 +1,110 @@
+"""Phase 9i / Track 8 PR 24 — drift detection tests.
+
+Pins:
+
+* ``detect_drift`` returns ``has_drift=False`` when the score is
+  unchanged and there are no new findings.
+* Score deltas at or above the threshold (5%) mark drift.
+* New error / warn findings mark drift even when the score didn't
+  move.
+* Outstanding health-error counts (from ``current_health_summary``)
+  mark drift.
+* The summary string is human-readable and surfaces the drift
+  cause.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from services.setup_session import DriftReport, detect_drift
+
+
+def _finding(*, severity: str, subsystem: str = "logging", name: str = "mod_channel"):
+    return SimpleNamespace(
+        severity=severity,
+        subsystem=subsystem,
+        binding_name=name,
+    )
+
+
+def test_no_score_no_drift_no_findings():
+    report = detect_drift(previous_score=None, current_score=None)
+    assert isinstance(report, DriftReport)
+    assert report.has_drift is False
+    assert "No drift" in report.summary
+
+
+def test_identical_scores_no_drift():
+    report = detect_drift(previous_score=85, current_score=85)
+    assert report.has_drift is False
+    assert report.score_delta == 0
+
+
+def test_small_score_change_below_threshold_does_not_drift():
+    report = detect_drift(previous_score=85, current_score=88)  # +3
+    assert report.has_drift is False
+
+
+def test_score_regression_at_threshold_marks_drift():
+    report = detect_drift(previous_score=90, current_score=85)  # -5
+    assert report.has_drift is True
+    assert "regressed" in report.summary
+    assert "5" in report.summary
+
+
+def test_score_improvement_at_threshold_marks_drift():
+    report = detect_drift(previous_score=80, current_score=90)  # +10
+    assert report.has_drift is True
+    assert "improved" in report.summary
+    assert "10" in report.summary
+
+
+def test_new_error_findings_mark_drift_even_when_score_unchanged():
+    report = detect_drift(
+        previous_score=85,
+        current_score=85,
+        new_findings=(_finding(severity="error"),),
+    )
+    assert report.has_drift is True
+    assert "1 new error finding" in report.summary
+    assert report.new_error_findings == ("logging.mod_channel",)
+
+
+def test_new_warn_findings_mark_drift_even_when_score_unchanged():
+    report = detect_drift(
+        previous_score=85,
+        current_score=85,
+        new_findings=(_finding(severity="warn", name="audit_channel"),),
+    )
+    assert report.has_drift is True
+    assert "1 new warning finding" in report.summary
+
+
+def test_outstanding_health_errors_mark_drift():
+    report = detect_drift(
+        previous_score=85,
+        current_score=85,
+        current_health_summary={"error": 2, "warn": 0, "info": 0},
+    )
+    assert report.has_drift is True
+
+
+def test_report_carries_score_delta():
+    report = detect_drift(previous_score=80, current_score=90)
+    assert report.score_delta == 10
+    assert report.prev_score == 80
+    assert report.current_score == 90
+
+
+@pytest.mark.parametrize(
+    ("prev", "curr"),
+    [(None, 90), (None, None), (50, None)],
+)
+def test_partial_score_inputs_dont_break_detector(prev, curr):
+    report = detect_drift(previous_score=prev, current_score=curr)
+    # Should never raise — drift defaults to False when there's no
+    # numeric comparison available.
+    assert isinstance(report, DriftReport)

--- a/tests/unit/views/setup/test_summary_view.py
+++ b/tests/unit/views/setup/test_summary_view.py
@@ -1,0 +1,192 @@
+"""Phase 9i / Track 8 PR 24 — setup summary view tests.
+
+Pins:
+
+* ``build_summary_embed`` handles 3 documented states (no applied
+  + clean, applied + clean, applied + drift).
+* The Close button disables both buttons and edits the message.
+* ``build_summary_snapshot`` swallows a failing
+  ``setup_readiness.collect`` and still returns a SummarySnapshot.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.setup_session import DriftReport, SetupSession
+from views.setup.summary import (
+    AppliedRecord,
+    SummarySnapshot,
+    SummaryView,
+    build_summary_embed,
+    build_summary_snapshot,
+)
+
+
+def _author():
+    import discord
+
+    m = MagicMock(spec=discord.Member)
+    m.id = 99
+    return m
+
+
+def _interaction():
+    interaction = MagicMock()
+    interaction.user = _author()
+    interaction.response = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    return interaction
+
+
+def _session(*, score=85):
+    return SetupSession(
+        guild_id=1,
+        guild_name="x",
+        owner_id=99,
+        setup_status="complete",
+        setup_channel_id=None,
+        setup_message_id=None,
+        last_readiness_score=score,
+        current_step=None,
+        delegated_admins=(),
+    )
+
+
+def _drift(has_drift: bool = False):
+    return DriftReport(
+        has_drift=has_drift,
+        score_delta=0,
+        prev_score=85,
+        current_score=85,
+        summary="No drift" if not has_drift else "Drift detected: x.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_summary_embed states
+# ---------------------------------------------------------------------------
+
+
+def test_summary_embed_no_applied_no_drift_renders_dark_grey():
+    embed = build_summary_embed(SummarySnapshot())
+    assert "without recording" in (embed.description or "").lower()
+
+
+def test_summary_embed_no_applied_with_drift_renders_yellow():
+    snap = SummarySnapshot(drift=_drift(has_drift=True))
+    embed = build_summary_embed(snap)
+    drift_field = next((f for f in embed.fields if f.name == "Drift"), None)
+    assert drift_field is not None
+    assert "Drift detected" in (drift_field.value or "")
+
+
+def test_summary_embed_applied_and_clean_renders_applied_section():
+    snap = SummarySnapshot(
+        applied=(
+            AppliedRecord(
+                subsystem="logging",
+                binding_name="mod_channel",
+                target_name="mod-log",
+                mutation_id="abc123def",
+                audit_id=42,
+            ),
+        ),
+        drift=_drift(has_drift=False),
+    )
+    embed = build_summary_embed(snap)
+    applied_field = next(
+        (f for f in embed.fields if f.name == "Applied"), None,
+    )
+    assert applied_field is not None
+    rendered = applied_field.value or ""
+    assert "mod_channel" in rendered
+    assert "abc123de" in rendered  # mutation id prefix
+    assert "42" in rendered  # audit id
+
+
+def test_summary_embed_applied_and_drift_keeps_both_sections():
+    snap = SummarySnapshot(
+        applied=(
+            AppliedRecord(
+                subsystem="logging",
+                binding_name="mod_channel",
+                target_name="mod-log",
+            ),
+        ),
+        drift=_drift(has_drift=True),
+        extra_notes=("operator overrode default name",),
+    )
+    embed = build_summary_embed(snap)
+    names = {f.name for f in embed.fields}
+    assert "Applied" in names
+    assert "Drift" in names
+    assert "Notes" in names
+
+
+# ---------------------------------------------------------------------------
+# SummaryView
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_summary_view_close_button_disables_and_edits():
+    view = SummaryView(_author(), snapshot=SummarySnapshot())
+    interaction = _interaction()
+    await view._close.callback(interaction)
+    interaction.response.edit_message.assert_awaited_once()
+    for child in view.children:
+        assert getattr(child, "disabled", False) is True
+
+
+# ---------------------------------------------------------------------------
+# build_summary_snapshot
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_snapshot_swallows_readiness_failure():
+    session = _session(score=85)
+    guild = MagicMock()
+    with patch(
+        "services.setup_readiness.collect",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("db down"),
+    ):
+        snap = await build_summary_snapshot(session=session, guild=guild)
+    assert isinstance(snap, SummarySnapshot)
+    assert snap.drift is not None
+    # Drift should default to "no drift" since current_score is None.
+    assert snap.drift.has_drift is False
+
+
+@pytest.mark.asyncio
+async def test_build_snapshot_without_guild_skips_collect():
+    session = _session(score=85)
+    snap = await build_summary_snapshot(session=session, guild=None)
+    assert snap.drift is not None
+    assert snap.drift.current_score is None
+
+
+@pytest.mark.asyncio
+async def test_build_snapshot_with_guild_uses_collected_score():
+    session = _session(score=85)
+    guild = MagicMock()
+    fake_report = SimpleNamespace(
+        percentage=90,
+        health_summary={"error": 0, "warn": 0, "info": 0},
+        health_findings=(),
+    )
+    with patch(
+        "services.setup_readiness.collect",
+        new_callable=AsyncMock,
+        return_value=fake_report,
+    ):
+        snap = await build_summary_snapshot(session=session, guild=guild)
+    assert snap.drift is not None
+    assert snap.drift.current_score == 90
+    assert snap.drift.score_delta == 5
+    assert snap.drift.has_drift is True


### PR DESCRIPTION
## Summary

- 🎉 **Final PR of the 24-PR SuperBot 2.0 buildout.**
- Add drift detection to `services.setup_session` and the `SummaryView` for the post-completion launcher.
- The wizard now has a real "Done" state: applied recommendations are listed alongside any drift the operator's resource cache reveals.

> Stacked on top of PR #196 (`views: guided wizard orchestration`). Auto-rebases to `main` when the chain lands.

## Scope table

| Does | Does NOT |
|---|---|
| Add `DriftReport` + `detect_drift` pure function in `services.setup_session` | Run drift detection on a schedule (the wizard hub / summary view triggers it on demand) |
| Add `AppliedRecord` / `SummarySnapshot` / `SummaryView` / `build_summary_embed` / `build_summary_snapshot` | Persist applied records (operator opens the summary fresh each time; the wizard hub passes them in) |
| Trigger drift on score delta ≥5 points, new error/warn findings, or outstanding health errors | Modify launcher button labels (Track 4 PR 10 already covers per-status relabels) |
| Swallow readiness failures in `build_summary_snapshot` | Touch any pipeline |

## Files changed

- `disbot/services/setup_session.py` — `+~95 LOC`: `DriftReport` dataclass + `detect_drift` function.
- `disbot/views/setup/summary.py` — **new** (~210 LOC).
- `tests/unit/services/test_drift_detection.py` — **new** (~120 LOC, 12 cases).
- `tests/unit/views/setup/test_summary_view.py` — **new** (~160 LOC, 8 cases).

## Tests run

```
python -m pytest tests/unit/services/test_drift_detection.py tests/unit/views/setup/test_summary_view.py -v   # 20 passed
python -m pytest -q                                                # 2985 passed, 1 skipped, 1 warning
ruff check . --exclude .github,tests,venv,env,build,dist           # All checks passed
black --check . --exclude '(\.github|tests|venv|env|build|dist)'   # 315 files unchanged
isort --check-only . --skip-glob '*/(\.github|tests|venv|env|build|dist)/*'   # passed
mypy disbot/                                                       # 316 source files, 0 issues
```

## Rollback plan

`git revert`. Drift detection becomes orphaned; the summary view goes away. The wizard hub from PR 23 keeps working.

## CI status

Pending — subscribing after creation.

## Risk level

**Low.** Pure read service + a small view. No pipelines touched.

## Plan complete

All 24 PRs from `/root/.claude/plans/superbot-2-0-setup-purring-peach.md` §5 are now either merged on `main` or open in the stacked PR chain. The remaining open PRs will auto-rebase their bases as the chain lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXdDyevoQLQXgmgog7erwY)_