### PR TITLE
cogs: restore setup launcher + on_guild_join (re-cut of #182)

### DIFF
--- a/disbot/cogs/setup_cog.py
+++ b/disbot/cogs/setup_cog.py
@@ -1,0 +1,404 @@
+"""Setup-wizard launcher cog — Phase 9e / Track 4 PR 9.
+
+Posts a persistent owner-gated launcher when the bot joins a guild and
+on every subsequent ``on_ready`` for guilds whose launcher is still
+``pending`` / ``in_progress``.
+
+Wires:
+* :mod:`services.setup_session` for the lifecycle row.
+* :mod:`services.setup_access` for owner / admin / non-admin gating.
+* :func:`services.setup_readiness.collect` for the readiness scan.
+
+This PR ships the launcher entry point only:
+* **Start Setup** and **Smart Suggestions** stub to "Coming soon"
+  (Tracks 5 + 8 fill them).
+* **Choose Preset** stub to "Coming soon" (Track 7 fills it).
+* **Run Readiness Scan** runs ``setup_readiness.collect`` and renders
+  the existing
+  :func:`cogs.diagnostic._platform_embeds.build_setup_readiness_embed`.
+* **Dismiss** flips ``setup_status`` to ``dismissed``; never deletes
+  Discord resources or DB rows.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import discord
+from discord.ext import commands
+
+from services import setup_access, setup_session
+from services.setup_session import SetupSession
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger("bot.cogs.setup")
+
+_LAUNCHER_TITLE = "🛰 SuperBot setup"
+_LAUNCHER_DESC = (
+    "Welcome! I'll help you wire SuperBot up to this server.\n\n"
+    "Use **Start Setup** for the guided walkthrough, **Run Readiness Scan** "
+    "to see what's already configured, or **Dismiss** to defer."
+)
+_COMING_SOON = (
+    "This step is not wired up yet — it lands in an upcoming PR. "
+    "Run **Run Readiness Scan** to see the current configuration."
+)
+
+
+def _build_launcher_embed(session: SetupSession | None) -> discord.Embed:
+    color = discord.Color.blurple()
+    if session is not None and session.setup_status == "complete":
+        color = discord.Color.green()
+    elif session is not None and session.setup_status == "dismissed":
+        color = discord.Color.dark_grey()
+
+    description = _LAUNCHER_DESC
+    if session is not None:
+        description = f"{_LAUNCHER_DESC}\n\n**Status:** `{session.setup_status}`"
+        if session.last_readiness_score is not None:
+            description += f" · readiness `{session.last_readiness_score}%`"
+        if session.current_step:
+            description += f" · step `{session.current_step}`"
+
+    embed = discord.Embed(
+        title=_LAUNCHER_TITLE,
+        description=description,
+        color=color,
+    )
+    embed.set_footer(
+        text="Owner-gated for write actions. Admins can run the readiness scan.",
+    )
+    return embed
+
+
+class SetupLauncherView(discord.ui.View):
+    """Persistent owner-gated launcher view.
+
+    ``timeout=None`` + static ``custom_id`` per button = the message
+    survives bot restarts (Track 4 PR 10 re-binds it on ``on_ready``).
+    """
+
+    def __init__(self) -> None:
+        super().__init__(timeout=None)
+
+    async def _resolve_session(
+        self,
+        interaction: discord.Interaction,
+    ) -> SetupSession | None:
+        if interaction.guild_id is None:
+            return None
+        return await setup_session.resume_session(interaction.guild_id)
+
+    async def _deny(
+        self,
+        interaction: discord.Interaction,
+        message: str,
+    ) -> None:
+        await interaction.response.send_message(message, ephemeral=True)
+
+    async def _gate_owner(
+        self,
+        interaction: discord.Interaction,
+    ) -> bool:
+        member = interaction.user
+        if not isinstance(member, discord.Member):
+            await self._deny(
+                interaction,
+                "This button must be used inside the server.",
+            )
+            return False
+        if not setup_access.is_server_owner(member):
+            await self._deny(
+                interaction,
+                "Only the server owner can start setup or change presets.",
+            )
+            return False
+        return True
+
+    async def _gate_admin(
+        self,
+        interaction: discord.Interaction,
+    ) -> bool:
+        member = interaction.user
+        if not isinstance(member, discord.Member):
+            await self._deny(
+                interaction,
+                "This button must be used inside the server.",
+            )
+            return False
+        session = await self._resolve_session(interaction)
+        if not setup_access.is_setup_admin(member, session):
+            await self._deny(
+                interaction,
+                "Only the server owner, an administrator, or a delegated "
+                "setup admin can use this button.",
+            )
+            return False
+        return True
+
+    @discord.ui.button(
+        label="Start Setup",
+        style=discord.ButtonStyle.success,
+        custom_id="setup:start",
+    )
+    async def _start(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        if not await self._gate_owner(interaction):
+            return
+        await interaction.response.send_message(_COMING_SOON, ephemeral=True)
+
+    @discord.ui.button(
+        label="Run Readiness Scan",
+        style=discord.ButtonStyle.primary,
+        custom_id="setup:readiness",
+    )
+    async def _readiness(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        if not await self._gate_admin(interaction):
+            return
+        guild = interaction.guild
+        if guild is None:
+            await self._deny(
+                interaction,
+                "Readiness scan requires a guild context.",
+            )
+            return
+        from cogs.diagnostic._platform_embeds import build_setup_readiness_embed
+
+        embed = await build_setup_readiness_embed(guild.id, guild=guild)
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+
+    @discord.ui.button(
+        label="Smart Suggestions",
+        style=discord.ButtonStyle.secondary,
+        custom_id="setup:smart_suggestions",
+    )
+    async def _suggestions(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        if not await self._gate_owner(interaction):
+            return
+        await interaction.response.send_message(_COMING_SOON, ephemeral=True)
+
+    @discord.ui.button(
+        label="Choose Preset",
+        style=discord.ButtonStyle.secondary,
+        custom_id="setup:preset",
+    )
+    async def _preset(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        if not await self._gate_owner(interaction):
+            return
+        await interaction.response.send_message(_COMING_SOON, ephemeral=True)
+
+    @discord.ui.button(
+        label="Dismiss",
+        style=discord.ButtonStyle.danger,
+        custom_id="setup:dismiss",
+    )
+    async def _dismiss(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        if not await self._gate_owner(interaction):
+            return
+        if interaction.guild_id is None:
+            await self._deny(
+                interaction,
+                "Dismiss requires a guild context.",
+            )
+            return
+        await setup_session.dismiss(interaction.guild_id)
+        await interaction.response.send_message(
+            "Setup dismissed. Run `/setup` later to resume.",
+            ephemeral=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Channel selection — pick the safest place to post the launcher.
+# ---------------------------------------------------------------------------
+
+
+def _bot_can_send_in(channel: discord.TextChannel, me: discord.Member) -> bool:
+    perms = channel.permissions_for(me)
+    return bool(perms.view_channel and perms.send_messages and perms.embed_links)
+
+
+def pick_launcher_channel(guild: discord.Guild) -> discord.TextChannel | None:
+    """Return the safest text channel to post the launcher in.
+
+    Order:
+      1. ``guild.system_channel`` if the bot can send + embed there.
+      2. First channel whose name contains ``admin`` / ``mod`` /
+         ``staff`` that the bot can send in.
+      3. First channel whose name contains ``bot`` that the bot can
+         send in.
+      4. First text channel in the guild the bot can send in.
+      5. ``None`` — caller should DM the owner instead.
+    """
+    me = guild.me
+    if me is None:
+        return None
+
+    system = guild.system_channel
+    if isinstance(system, discord.TextChannel) and _bot_can_send_in(system, me):
+        return system
+
+    keyword_groups: tuple[tuple[str, ...], ...] = (
+        ("admin", "mod", "staff"),
+        ("bot",),
+    )
+    for needles in keyword_groups:
+        for channel in guild.text_channels:
+            name = (channel.name or "").lower()
+            if any(needle in name for needle in needles) and _bot_can_send_in(
+                channel,
+                me,
+            ):
+                return channel
+
+    for channel in guild.text_channels:
+        if _bot_can_send_in(channel, me):
+            return channel
+    return None
+
+
+async def post_launcher(
+    guild: discord.Guild,
+) -> tuple[discord.TextChannel | None, discord.Message | None]:
+    """Pick a channel + post the launcher message.
+
+    Returns ``(channel, message)`` on success, ``(None, None)`` when
+    no channel is sendable and the owner-DM fallback also failed.
+    The caller is responsible for updating ``setup_session`` with the
+    resulting ids.
+    """
+    embed = _build_launcher_embed(None)
+    view = SetupLauncherView()
+
+    channel = pick_launcher_channel(guild)
+    if channel is not None:
+        try:
+            message = await channel.send(embed=embed, view=view)
+            return channel, message
+        except discord.Forbidden:
+            logger.warning(
+                "setup_cog: forbidden when posting launcher in #%s (guild=%d)",
+                channel.name,
+                guild.id,
+            )
+        except discord.HTTPException as exc:
+            logger.warning(
+                "setup_cog: HTTP error posting launcher in #%s (guild=%d): %s",
+                channel.name,
+                guild.id,
+                exc,
+            )
+
+    # Channel fallback: DM the owner.
+    owner = guild.owner
+    if owner is not None:
+        try:
+            message = await owner.send(embed=embed, view=view)
+            logger.info(
+                "setup_cog: DMed launcher to owner %d (guild=%d)",
+                owner.id,
+                guild.id,
+            )
+            return None, message
+        except discord.Forbidden:
+            logger.warning(
+                "setup_cog: cannot DM owner %d for guild=%d (DMs closed)",
+                owner.id,
+                guild.id,
+            )
+        except discord.HTTPException as exc:
+            logger.warning(
+                "setup_cog: HTTP error DMing owner for guild=%d: %s",
+                guild.id,
+                exc,
+            )
+
+    return None, None
+
+
+# ---------------------------------------------------------------------------
+# Cog
+# ---------------------------------------------------------------------------
+
+
+class SetupCog(commands.Cog):
+    """Setup-wizard launcher.
+
+    Listens for ``on_guild_join`` and posts the owner-gated launcher
+    view. Adds a single persistent ``SetupLauncherView`` instance to
+    the bot at ``cog_load`` so existing launcher messages survive
+    restarts.
+    """
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    async def cog_load(self) -> None:
+        # Register the persistent view so discord.py can match
+        # interactions to it after restart. Track 4 PR 10 will
+        # rebind every active launcher message to fresh anchor
+        # entries.
+        self.bot.add_view(SetupLauncherView())
+
+    @commands.Cog.listener()
+    async def on_guild_join(self, guild: discord.Guild) -> None:
+        await self._handle_join(guild)
+
+    async def _handle_join(self, guild: discord.Guild) -> None:
+        """Internal entry point — split out for direct testing."""
+        try:
+            channel, message = await post_launcher(guild)
+            channel_id = channel.id if channel is not None else None
+            message_id = message.id if message is not None else None
+            await setup_session.start_session(
+                guild_id=guild.id,
+                guild_name=guild.name,
+                owner_id=guild.owner_id or 0,
+                setup_channel_id=channel_id,
+                setup_message_id=message_id,
+            )
+        except Exception:
+            logger.exception(
+                "setup_cog.on_guild_join: handler failed for guild=%d",
+                guild.id,
+            )
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(SetupCog(bot))
+
+
+__all__ = [
+    "SetupCog",
+    "SetupLauncherView",
+    "pick_launcher_channel",
+    "post_launcher",
+    "setup",
+]

--- a/disbot/config.py
+++ b/disbot/config.py
@@ -55,6 +55,7 @@ INITIAL_EXTENSIONS = [
     "cogs.logging_cog",
     "cogs.games_cog",
     "cogs.community_cog",
+    "cogs.setup_cog",
 ]
 
 # ==========================

--- a/docs/settings-customization-command-map.md
+++ b/docs/settings-customization-command-map.md
@@ -95,7 +95,8 @@ Cogs (22): `admin_cog`, `blackjack_cog`, `chain_cog`, `channel_cog`,
 `cleanup_cog`, `counting_cog`, `deathmatch_cog`, `diagnostic_cog`,
 `economy_cog`, `general_cog`, `help_cog`, `inventory_cog`, `leaderboard_cog`,
 `logging_cog`, `mining_cog`, `moderation_cog`, `proof_channel_cog`,
-`role_cog`, `rps_tournament_cog`, `settings_cog`, `utility_cog`, `xp_cog`.
+`role_cog`, `rps_tournament_cog`, `settings_cog`, `setup_cog`,
+`utility_cog`, `xp_cog`.
 
 Subsystems (22): `admin`, `moderation`, `economy`, `inventory`, `mining`,
 `xp`, `role`, `channel`, `cleanup`, `blackjack`, `deathmatch`,

--- a/tests/unit/cogs/test_setup_cog.py
+++ b/tests/unit/cogs/test_setup_cog.py
@@ -1,0 +1,456 @@
+"""Phase 9e / Track 4 PR 9 — ``cogs.setup_cog`` tests.
+
+Pins:
+
+* ``pick_launcher_channel`` walks the documented preference order:
+  system → admin/mod/staff → bot → first sendable → None.
+* ``post_launcher`` falls back to DMing the owner when no channel
+  is sendable.
+* ``on_guild_join`` upserts the session row via
+  :mod:`services.setup_session` regardless of where the launcher
+  ended up.
+* Button gating refuses non-owner / non-admin members appropriately.
+* The Dismiss button calls ``setup_session.dismiss`` and posts an
+  ephemeral confirmation.
+* Coming-soon buttons send an ephemeral message and do not touch
+  any pipeline.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cogs.setup_cog import (
+    SetupLauncherView,
+    pick_launcher_channel,
+    post_launcher,
+)
+from services.setup_session import SetupSession
+
+# ---------------------------------------------------------------------------
+# Channel selection
+# ---------------------------------------------------------------------------
+
+
+def _perms(*, view=True, send=True, embed=True):
+    return SimpleNamespace(
+        view_channel=view,
+        send_messages=send,
+        embed_links=embed,
+    )
+
+
+def _channel(name: str, perms, type_=None):
+    import discord
+
+    if type_ is None:
+        type_ = discord.TextChannel
+    ch = MagicMock(spec=type_)
+    ch.name = name
+    ch.id = hash(name) & 0xFFFFFF
+    ch.permissions_for = MagicMock(return_value=perms)
+    return ch
+
+
+def _guild(
+    *,
+    system: object | None = None,
+    text_channels=(),
+    me=None,
+    owner=None,
+    guild_id: int = 1,
+    name: str = "Test",
+    owner_id: int = 99,
+):
+    import discord
+
+    g = MagicMock(spec=discord.Guild)
+    g.id = guild_id
+    g.name = name
+    g.owner_id = owner_id
+    g.system_channel = system
+    g.text_channels = list(text_channels)
+    g.me = me
+    g.owner = owner
+    return g
+
+
+def test_pick_launcher_returns_system_channel_when_sendable():
+    me = MagicMock()
+    system = _channel("general", _perms())
+    other = _channel("random", _perms())
+    g = _guild(system=system, text_channels=[system, other], me=me)
+    assert pick_launcher_channel(g) is system
+
+
+def test_pick_launcher_skips_system_when_not_sendable():
+    me = MagicMock()
+    system = _channel("general", _perms(send=False))
+    admin = _channel("admin-chat", _perms())
+    g = _guild(system=system, text_channels=[system, admin], me=me)
+    assert pick_launcher_channel(g) is admin
+
+
+def test_pick_launcher_prefers_admin_over_bot_keyword():
+    me = MagicMock()
+    bot_ch = _channel("bot-spam", _perms())
+    mod_ch = _channel("mod-log", _perms())
+    g = _guild(text_channels=[bot_ch, mod_ch], me=me)
+    assert pick_launcher_channel(g) is mod_ch
+
+
+def test_pick_launcher_falls_back_to_bot_keyword_then_first_sendable():
+    me = MagicMock()
+    bot_ch = _channel("bot-spam", _perms())
+    random_ch = _channel("random", _perms())
+    g = _guild(text_channels=[random_ch, bot_ch], me=me)
+    assert pick_launcher_channel(g) is bot_ch
+
+
+def test_pick_launcher_returns_first_sendable_when_no_keyword_match():
+    me = MagicMock()
+    random1 = _channel("random", _perms())
+    random2 = _channel("chatter", _perms())
+    g = _guild(text_channels=[random1, random2], me=me)
+    assert pick_launcher_channel(g) is random1
+
+
+def test_pick_launcher_returns_none_when_no_sendable_channels():
+    me = MagicMock()
+    silent = _channel("locked", _perms(send=False))
+    g = _guild(text_channels=[silent], me=me)
+    assert pick_launcher_channel(g) is None
+
+
+def test_pick_launcher_returns_none_when_bot_member_missing():
+    g = _guild(me=None, text_channels=[_channel("general", _perms())])
+    assert pick_launcher_channel(g) is None
+
+
+# ---------------------------------------------------------------------------
+# post_launcher
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_launcher_sends_to_picked_channel():
+    me = MagicMock()
+    sendable = _channel("general", _perms())
+    sendable.send = AsyncMock(return_value=MagicMock(id=12345))
+    g = _guild(system=sendable, text_channels=[sendable], me=me)
+
+    channel, message = await post_launcher(g)
+    assert channel is sendable
+    assert message.id == 12345
+    sendable.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_post_launcher_falls_back_to_owner_dm_when_no_channel():
+    g = _guild(text_channels=[], me=MagicMock())
+    g.owner = MagicMock()
+    g.owner.id = 99
+    g.owner.send = AsyncMock(return_value=MagicMock(id=99001))
+
+    channel, message = await post_launcher(g)
+    assert channel is None
+    assert message.id == 99001
+    g.owner.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_post_launcher_returns_none_pair_when_dm_also_fails():
+    import discord
+
+    g = _guild(text_channels=[], me=MagicMock())
+    g.owner = MagicMock()
+    g.owner.id = 99
+    g.owner.send = AsyncMock(
+        side_effect=discord.Forbidden(MagicMock(), "dms closed"),
+    )
+
+    channel, message = await post_launcher(g)
+    assert channel is None
+    assert message is None
+
+
+@pytest.mark.asyncio
+async def test_post_launcher_falls_back_to_dm_on_forbidden_in_channel():
+    import discord
+
+    me = MagicMock()
+    ch = _channel("general", _perms())
+    ch.send = AsyncMock(side_effect=discord.Forbidden(MagicMock(), "no perm"))
+    g = _guild(system=ch, text_channels=[ch], me=me)
+    g.owner = MagicMock()
+    g.owner.id = 99
+    g.owner.send = AsyncMock(return_value=MagicMock(id=42))
+
+    channel, message = await post_launcher(g)
+    assert channel is None
+    assert message.id == 42
+
+
+# ---------------------------------------------------------------------------
+# on_guild_join → setup_session.start_session
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_guild_join_calls_start_session_with_channel_ids():
+    from cogs.setup_cog import SetupCog
+
+    bot = MagicMock()
+    cog = SetupCog(bot)
+
+    me = MagicMock()
+    ch = _channel("general", _perms())
+    ch.id = 5555
+    ch.send = AsyncMock(return_value=MagicMock(id=8888))
+    g = _guild(
+        system=ch,
+        text_channels=[ch],
+        me=me,
+        owner_id=99,
+        guild_id=42,
+        name="My Server",
+    )
+
+    with patch(
+        "cogs.setup_cog.setup_session.start_session",
+        new_callable=AsyncMock,
+    ) as start_mock:
+        await cog._handle_join(g)
+
+    start_mock.assert_awaited_once()
+    kwargs = start_mock.await_args.kwargs
+    assert kwargs["guild_id"] == 42
+    assert kwargs["guild_name"] == "My Server"
+    assert kwargs["owner_id"] == 99
+    assert kwargs["setup_channel_id"] == 5555
+    assert kwargs["setup_message_id"] == 8888
+
+
+@pytest.mark.asyncio
+async def test_on_guild_join_records_none_ids_when_dm_succeeds():
+    from cogs.setup_cog import SetupCog
+
+    bot = MagicMock()
+    cog = SetupCog(bot)
+
+    g = _guild(text_channels=[], me=MagicMock())
+    g.owner = MagicMock()
+    g.owner.send = AsyncMock(return_value=MagicMock(id=99001))
+
+    with patch(
+        "cogs.setup_cog.setup_session.start_session",
+        new_callable=AsyncMock,
+    ) as start_mock:
+        await cog._handle_join(g)
+
+    kwargs = start_mock.await_args.kwargs
+    assert kwargs["setup_channel_id"] is None
+    # DM message id still captured.
+    assert kwargs["setup_message_id"] == 99001
+
+
+@pytest.mark.asyncio
+async def test_on_guild_join_swallows_handler_failure():
+    from cogs.setup_cog import SetupCog
+
+    bot = MagicMock()
+    cog = SetupCog(bot)
+
+    g = MagicMock()
+    g.id = 1
+    g.name = "x"
+
+    with patch(
+        "cogs.setup_cog.post_launcher",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("boom"),
+    ):
+        # Must not raise.
+        await cog._handle_join(g)
+
+
+# ---------------------------------------------------------------------------
+# Button gating
+# ---------------------------------------------------------------------------
+
+
+def _owner_member(guild_owner_id: int = 99):
+    import discord
+
+    m = MagicMock(spec=discord.Member)
+    m.id = guild_owner_id
+    m.guild = SimpleNamespace(owner_id=guild_owner_id)
+    m.guild_permissions = SimpleNamespace(administrator=False)
+    return m
+
+
+def _admin_member(guild_owner_id: int = 99, user_id: int = 42):
+    import discord
+
+    m = MagicMock(spec=discord.Member)
+    m.id = user_id
+    m.guild = SimpleNamespace(owner_id=guild_owner_id)
+    m.guild_permissions = SimpleNamespace(administrator=True)
+    return m
+
+
+def _random_member(guild_owner_id: int = 99, user_id: int = 42):
+    import discord
+
+    m = MagicMock(spec=discord.Member)
+    m.id = user_id
+    m.guild = SimpleNamespace(owner_id=guild_owner_id)
+    m.guild_permissions = SimpleNamespace(administrator=False)
+    return m
+
+
+def _mock_interaction(user, guild_id: int = 1):
+    interaction = MagicMock()
+    interaction.user = user
+    interaction.guild_id = guild_id
+    interaction.guild = MagicMock(id=guild_id)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    return interaction
+
+
+@pytest.mark.asyncio
+async def test_start_button_refuses_non_owner():
+    view = SetupLauncherView()
+    interaction = _mock_interaction(_admin_member())
+
+    await view._start.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    assert (
+        "server owner"
+        in interaction.response.send_message.await_args.args[0].lower()
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_button_shows_coming_soon_for_owner():
+    view = SetupLauncherView()
+    interaction = _mock_interaction(_owner_member())
+
+    await view._start.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "not wired up" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_smart_suggestions_button_owner_only():
+    view = SetupLauncherView()
+    interaction = _mock_interaction(_admin_member())
+
+    await view._suggestions.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    assert (
+        "server owner"
+        in interaction.response.send_message.await_args.args[0].lower()
+    )
+
+
+@pytest.mark.asyncio
+async def test_preset_button_owner_only():
+    view = SetupLauncherView()
+    interaction = _mock_interaction(_admin_member())
+
+    await view._preset.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_readiness_button_admin_allowed():
+    view = SetupLauncherView()
+    interaction = _mock_interaction(_admin_member())
+
+    fake_embed = MagicMock()
+    with (
+        patch(
+            "cogs.setup_cog.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "cogs.diagnostic._platform_embeds.build_setup_readiness_embed",
+            new_callable=AsyncMock,
+            return_value=fake_embed,
+        ) as build_mock,
+    ):
+        await view._readiness.callback(interaction)
+
+    build_mock.assert_awaited_once()
+    interaction.response.send_message.assert_awaited_once()
+    assert interaction.response.send_message.await_args.kwargs["embed"] is fake_embed
+
+
+@pytest.mark.asyncio
+async def test_readiness_button_random_denied():
+    view = SetupLauncherView()
+    random = _random_member()
+    interaction = _mock_interaction(random)
+    session = SetupSession(
+        guild_id=1,
+        guild_name="x",
+        owner_id=99,
+        setup_status="pending",
+        setup_channel_id=None,
+        setup_message_id=None,
+        last_readiness_score=None,
+        current_step=None,
+        delegated_admins=(),
+    )
+
+    with patch(
+        "cogs.setup_cog.setup_session.resume_session",
+        new_callable=AsyncMock,
+        return_value=session,
+    ):
+        await view._readiness.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "admin" in msg.lower() or "owner" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_dismiss_button_owner_calls_dismiss():
+    view = SetupLauncherView()
+    interaction = _mock_interaction(_owner_member())
+
+    with patch(
+        "cogs.setup_cog.setup_session.dismiss",
+        new_callable=AsyncMock,
+    ) as dismiss_mock:
+        await view._dismiss.callback(interaction)
+
+    dismiss_mock.assert_awaited_once_with(interaction.guild_id)
+    interaction.response.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_dismiss_button_refuses_non_owner():
+    view = SetupLauncherView()
+    interaction = _mock_interaction(_admin_member())
+
+    with patch(
+        "cogs.setup_cog.setup_session.dismiss",
+        new_callable=AsyncMock,
+    ) as dismiss_mock:
+        await view._dismiss.callback(interaction)
+
+    dismiss_mock.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once()


### PR DESCRIPTION
## Summary

Re-cut of the previously-closed-without-merge **#182** (Track 4 PR 9). Restores the missing setup-wizard entry point. Without this cog, the `setup_session` substrate already on `main` (from PR #181) has no producer — `on_guild_join` never records anything and operators never see a launcher.

Cherry-picked the original commit verbatim onto fresh `origin/main`. **Additionally** wires `cogs.setup_cog` into `INITIAL_EXTENSIONS` (the original PR forgot this; the cog code existed but never loaded), and adds the cog reference to the command-map doc so the existing `test_every_loaded_cog_referenced` invariant passes.

## What was restored

- `disbot/cogs/setup_cog.py` — `SetupCog` + `SetupLauncherView` + `pick_launcher_channel` + `post_launcher`.
- `tests/unit/cogs/test_setup_cog.py` — 22 cases covering channel selection, DM fallback, `on_guild_join`, and every button gate.
- `disbot/config.py` — adds `"cogs.setup_cog"` to `INITIAL_EXTENSIONS`.
- `docs/settings-customization-command-map.md` — adds `setup_cog` to the cog list.

## Safety checklist (from the brief)

- ✅ **Owner-gated** `Start Setup`, `Smart Suggestions`, `Choose Preset`, `Dismiss` — `_gate_owner` via `services.setup_access.is_server_owner`.
- ✅ **Admin-allowed** `Run Readiness Scan` — `_gate_admin` via `is_setup_admin` (owner OR administrator OR delegated admin).
- ✅ **Non-admin denied** with an ephemeral message.
- ✅ **No auto-create** anywhere — `pick_launcher_channel` only resolves existing channels; DM-owner fallback is read-only.
- ✅ **No setup apply on guild join** — `_handle_join` only posts the launcher and upserts the session row in `pending`.
- ✅ **Dismiss is non-destructive** — only flips `setup_status='dismissed'`, never deletes a Discord resource.
- ✅ **Persistent view** — `bot.add_view(SetupLauncherView())` at `cog_load` with static `custom_id` per button.

## Tests run

```
python -m pytest tests/unit/cogs/test_setup_cog.py -q              # 22 passed
python -m pytest -q                                                # 2807 passed, 15 warnings
ruff check . --exclude .github,tests,venv,env,build,dist           # All checks passed
black --check . --exclude '(\.github|tests|venv|env|build|dist)'   # 308 files unchanged
isort --check-only . --skip-glob '*/(\.github|tests|venv|env|build|dist)/*'   # passed
mypy disbot/                                                       # 309 source files, 0 issues
```

## Why this is safe to merge directly to main

- Pure-additive cog. No existing cog touched, no DB schema change (migration 031 already on main from #181).
- The persistent view's `custom_id` set is fresh (`setup:start`, `setup:readiness`, etc.) — no risk of colliding with any existing handler.
- `on_guild_join` only writes the `setup_session` row; the row was schema-ready since #181.

## Rollback plan

`git revert` removes the cog + the wiring. The `setup_session` row from any existing guild stays; `guild_lifecycle.teardown` layer 18 (already on main) cleans it on bot removal.

## Status of the broader chain

| Missing on main | Plan |
|---|---|
| **#182** (this PR) | Re-cutting now |
| #176, #183 | Next PRs in this session |
| #186, #187, #189–#191 | After |
| #192–#195 | After |
| #196, #197 | Last |

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXdDyevoQLQXgmgog7erwY)_