### PR TITLE
docs+tests: restore server logging audit verification (re-cut of #176)

### DIFF
--- a/docs/server-logging.md
+++ b/docs/server-logging.md
@@ -74,6 +74,81 @@ Counters are exposed via `services.diagnostics_service` under the
 name `"server_logging"` and surface in `!platform consistency`
 (PR-10) under the "Runtime providers" section.
 
+## Audit logging (Phase 9c)
+
+A second channel slot — `logging.audit_channel` — receives the
+canonical `audit.action_recorded` event emitted by every production
+mutation pipeline (Phase 9c.1 / 9c.2). Each accepted mutation lands a
+single embed describing what was changed, by whom, with the
+pre/post values where they are not PII.
+
+### Subscriber
+
+`services.server_logging._on_audit_action` is registered on
+`audit.action_recorded` by `setup(bot)`. The handler reads the bus
+payload, resolves the channel via
+`resolve_log_channel(guild, "audit")`, and renders
+`format_audit_embed(...)`.
+
+### Routing and fallback
+
+Channel resolution uses the Phase 9a route table:
+
+1. If `logging.audit_channel` is set and resolves to a usable channel
+   → that channel.
+2. Otherwise the route table falls back to `logging.mod_channel`.
+3. If both are unset and `logging.auto_create_channels` is OFF, the
+   handler bumps `missing_channel` and returns.
+4. If `logging.auto_create_channels` is ON, `ensure_log_channel`
+   creates `bot-audit-log` (or the source-tier fallback) and binds
+   it on the fly.
+
+The subscriber itself always asks for `kind="audit"` — it never
+walks the fallback chain manually. This keeps the route table the
+single source of truth.
+
+### Payload contract
+
+`audit.action_recorded` carries 11 keyword fields, all required:
+
+| Field | Type | Notes |
+|---|---|---|
+| `mutation_id` | str (UUID) | Links the bus event to the per-pipeline DB audit row. |
+| `subsystem` | str | High-level area (`"logging"`, `"xp"`, `"governance"`, …). |
+| `mutation_type` | str | Pipeline-specific verb token (`"set_value"`, `"upsert_binding"`, `"set_flag_state"`, …). |
+| `target` | str | Human-resolvable identifier (`"setting:xp.xp_min"`, `"flag:bindings.primary"`). |
+| `scope` | str | `"global"`, `"guild"`, or a scope-type token (`"channel"`, `"category"`, …). |
+| `guild_id` | int \| None | Discord guild id, or `None` for global scope. |
+| `prev_value` | str \| None | Pre-mutation value, string-rendered. `None` for first writes / PII-shielded preferences. |
+| `new_value` | str \| None | Post-mutation value, string-rendered. `None` for clears / PII-shielded preferences. |
+| `actor_id` | int \| None | Discord user id, or `None` for system / backfill. |
+| `actor_type` | str | Capability-resolver actor type token. |
+| `occurred_at` | str (ISO-8601) | DB commit timestamp serialised by the shared publisher. |
+
+The shared publisher lives in
+`disbot/services/audit_events.py:emit_audit_action`. Every wired
+pipeline imports it directly so the payload contract stays
+identical across publishers.
+
+### Counters
+
+The `audit_sent` counter increments per delivered audit embed.
+Failure paths share the existing counters in the table above
+(`skipped_disabled`, `missing_channel`, `permission_error`,
+`send_error`, `subscriber_errors`). Operators monitor counts via
+`!platform diagnostics server_logging`.
+
+### Operator workflow (audit channel)
+
+1. Set `logging.enabled` to `true`.
+2. Set `logging.audit_channel` to your preferred audit destination
+   (typically a staff-only channel). If unset, audit embeds fall
+   back to `logging.mod_channel`.
+3. Optionally set `logging.auto_create_channels` to `true` so the
+   service can create `bot-audit-log` on demand.
+4. Verify with `!platform diagnostics server_logging` — every
+   accepted mutation should bump `audit_sent`.
+
 ## Channel provisioning
 
 When auto-create is enabled and the configured channel id is

--- a/tests/unit/services/test_server_logging_audit.py
+++ b/tests/unit/services/test_server_logging_audit.py
@@ -282,6 +282,107 @@ async def test_subscriber_counts_missing_channel():
 
 
 @pytest.mark.asyncio
+async def test_subscriber_falls_back_to_mod_channel_when_audit_unset():
+    """Phase 9a route table: ``audit`` falls back to ``mod`` when
+    ``logging.audit_channel`` is unset. The subscriber must not bypass
+    the route table — it always asks for kind="audit" and trusts
+    ``resolve_log_channel`` to do the fallback chain."""
+    bot = MagicMock()
+    guild = _guild()
+    bot.get_guild.return_value = guild
+    mod_channel = _channel(name="bot-mod-log")
+
+    seen_kinds: list[str] = []
+
+    async def fake_resolve(_guild, kind):
+        # Mimic the real route table: kind="audit" resolves to the
+        # mod channel when audit_channel is unset.
+        seen_kinds.append(kind)
+        return mod_channel
+
+    with (
+        patch.object(server_logging, "_BOT", bot),
+        patch(
+            "services.server_logging.is_enabled",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "services.server_logging.resolve_log_channel",
+            side_effect=fake_resolve,
+        ),
+    ):
+        await _on_audit_action(**_PAYLOAD)
+
+    # The subscriber asks for "audit" exactly once and does not retry
+    # with "mod" on its own — the route table owns the fallback.
+    assert seen_kinds == ["audit"]
+    mod_channel.send.assert_awaited_once()
+    snap = counters_snapshot()
+    assert snap["counters"]["audit_sent"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_subscriber_counts_send_error_on_http_exception():
+    """``discord.HTTPException`` (Discord rate limits, 5xx, etc.) on
+    ``channel.send`` bumps ``send_error`` and is swallowed."""
+    bot = MagicMock()
+    guild = _guild()
+    bot.get_guild.return_value = guild
+    channel = _channel()
+    channel.send = AsyncMock(
+        side_effect=discord.HTTPException(MagicMock(status=503), "service down"),
+    )
+
+    with (
+        patch.object(server_logging, "_BOT", bot),
+        patch(
+            "services.server_logging.is_enabled",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "services.server_logging.resolve_log_channel",
+            AsyncMock(return_value=channel),
+        ),
+    ):
+        # Must not raise.
+        await _on_audit_action(**_PAYLOAD)
+
+    snap = counters_snapshot()
+    assert snap["counters"]["send_error"] >= 1
+    assert snap["counters"]["audit_sent"] == 0
+
+
+@pytest.mark.asyncio
+async def test_subscriber_counts_send_error_on_unexpected_exception():
+    """A non-Discord ``Exception`` on ``channel.send`` (e.g. network
+    timeout from an aiohttp transport bug) is still caught and
+    counted under ``send_error``."""
+    bot = MagicMock()
+    guild = _guild()
+    bot.get_guild.return_value = guild
+    channel = _channel()
+    channel.send = AsyncMock(side_effect=RuntimeError("transport reset"))
+
+    with (
+        patch.object(server_logging, "_BOT", bot),
+        patch(
+            "services.server_logging.is_enabled",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "services.server_logging.resolve_log_channel",
+            AsyncMock(return_value=channel),
+        ),
+    ):
+        # Must not raise — the fail-safe wrapper covers BLE001.
+        await _on_audit_action(**_PAYLOAD)
+
+    snap = counters_snapshot()
+    assert snap["counters"]["send_error"] >= 1
+    assert snap["counters"]["audit_sent"] == 0
+
+
+@pytest.mark.asyncio
 async def test_subscriber_counts_permission_error():
     bot = MagicMock()
     guild = _guild()


### PR DESCRIPTION
## Summary

Re-cut of the previously-closed-without-merge **#176** (Track 1 PR 3). Cherry-picked the original commit verbatim onto fresh `origin/main`. Zero production code change.

## What was restored

- `docs/server-logging.md` — new "Audit logging (Phase 9c)" section documenting the `logging.audit_channel` route, the audit→mod fallback chain, the 11-field payload contract, the `audit_sent` counter, and the operator workflow.
- `tests/unit/services/test_server_logging_audit.py` — 3 new cases covering: route-table fallback verification (`kind="audit"` only), `send_error` on `discord.HTTPException`, `send_error` on a non-Discord `Exception` (BLE001 wrapper).

## Tests run

```
python -m pytest tests/unit/services/test_server_logging_audit.py -q  # 20 passed
python -m pytest -q                                                   # 2786 passed
ruff check . --exclude .github,tests,venv,env,build,dist              # All checks passed
black --check . --exclude '(\.github|tests|venv|env|build|dist)'      # 307 files unchanged
isort --check-only . --skip-glob '*/(\.github|tests|venv|env|build|dist)/*'   # passed
mypy disbot/                                                          # 308 source files, 0 issues
```

## Risk

**Minimal.** Docs + tests only.

## Chain status

This is PR 1 of the chain-restore. PR 2 (`claude/restore-setup-launcher`, #198) is in flight in parallel.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXdDyevoQLQXgmgog7erwY)_