### PR TITLE
services: restore SetupAdvisor Protocol + OpenAI implementation (re-cut of #186)

### DIFF
--- a/disbot/config.py
+++ b/disbot/config.py
@@ -94,3 +94,21 @@ CLEANUP_WHITELIST_CHANNELS: set[int] = _parse_channel_ids(
         1403818013408624642,
     ],
 )
+
+
+# ==========================
+# Setup-wizard advisor (Phase 9f / Track 5)
+# ==========================
+# Provider for the AI-assisted setup advisor. One of:
+#   * ``deterministic`` — name-matching rules only (default).
+#   * ``openai``        — OpenAI gpt-4o-mini behind strict JSON schema.
+#                          Requires ``OPENAI_API_KEY``.
+#   * ``anthropic``     — Claude Sonnet / Haiku. Requires ``ANTHROPIC_API_KEY``.
+#                          Reserved; concrete adapter ships in a follow-up.
+# When the requested provider is unavailable (missing key, missing SDK),
+# the factory falls back to ``deterministic`` so CI / dev envs never make
+# external calls by accident.
+SETUP_ADVISOR_PROVIDER = os.getenv("SETUP_ADVISOR_PROVIDER", "deterministic").lower()
+SETUP_ADVISOR_OPENAI_MODEL = os.getenv("SETUP_ADVISOR_OPENAI_MODEL", "gpt-4o-mini")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
+ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY", "")

--- a/disbot/services/setup_ai_advisor.py
+++ b/disbot/services/setup_ai_advisor.py
@@ -1,0 +1,427 @@
+"""AI-assisted setup advisor — Phase 9f / Track 5 PR 13.
+
+Defines the :class:`SetupAdvisor` Protocol that both deterministic
+and AI advisors implement, an OpenAI implementation, and a
+factory :func:`build_advisor` that picks an implementation based on
+the ``SETUP_ADVISOR_PROVIDER`` environment variable (default:
+``deterministic`` — so CI and dev environments never reach out to
+an external API by accident).
+
+Provider contract
+-----------------
+Any advisor must:
+
+* Take a :class:`GuildSnapshot` as its only input.
+* Return a :class:`SetupPlanDraft` describing recommendations.
+* Never mutate DB state, never call ``guild.create_*``, never
+  invent a subsystem or binding name.
+
+Output validation
+-----------------
+Every advisor's recommendations are re-validated against
+:func:`subsystem_schema.all_schemas` before they ever surface in the
+UI. An AI model that hallucinates a subsystem like ``"vibes"`` or a
+binding kind like ``"emoji"`` simply has its proposal dropped with a
+reason; it cannot extend the bot's mutation surface.
+
+Structured output
+-----------------
+The OpenAI implementation uses strict JSON Schema response format
+(``response_format={"type": "json_schema", "json_schema": {...,
+"strict": true}}``) so the SDK validates shape on the wire. We
+then re-validate the parsed objects against our local schema
+catalogue. Both layers run; CI does not have an OPENAI_API_KEY so
+the path is exercised through mock objects.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+from services.guild_snapshot import GuildSnapshot
+from services.setup_plan import (
+    CONFIDENCES,
+    DeterministicAdvisor,
+    SetupPlanDraft,
+    SetupRecommendation,
+)
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger("bot.services.setup_ai_advisor")
+
+DETERMINISTIC = "deterministic"
+OPENAI = "openai"
+ANTHROPIC = "anthropic"
+
+KNOWN_PROVIDERS: frozenset[str] = frozenset({DETERMINISTIC, OPENAI, ANTHROPIC})
+
+# JSON schema posted alongside ``response_format`` so the SDK guards
+# the shape we then re-validate locally.
+_RECOMMENDATION_JSON_SCHEMA: dict[str, Any] = {
+    "name": "SetupPlanDraft",
+    "schema": {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "recommendations": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "subsystem": {"type": "string"},
+                        "binding_name": {"type": "string"},
+                        "target_kind": {"type": "string"},
+                        "target_id": {"type": "integer"},
+                        "target_name": {"type": "string"},
+                        "confidence": {
+                            "type": "string",
+                            "enum": ["high", "medium", "low"],
+                        },
+                        "reason": {"type": "string"},
+                    },
+                    "required": [
+                        "subsystem",
+                        "binding_name",
+                        "target_kind",
+                        "target_id",
+                        "target_name",
+                        "confidence",
+                        "reason",
+                    ],
+                },
+            },
+        },
+        "required": ["recommendations"],
+    },
+    "strict": True,
+}
+
+
+@runtime_checkable
+class SetupAdvisor(Protocol):
+    """The single interface deterministic + AI advisors implement."""
+
+    async def suggest(self, snapshot: GuildSnapshot) -> SetupPlanDraft: ...
+
+
+# ---------------------------------------------------------------------------
+# OpenAI advisor
+# ---------------------------------------------------------------------------
+
+
+_SYSTEM_PROMPT = (
+    "You are a Discord-server setup assistant. The user will send you a "
+    "metadata snapshot of a guild and ask which channels/categories/roles "
+    "should be bound to which bot subsystems. Reply ONLY with the strict "
+    "JSON schema provided. Never invent a subsystem name, binding name, or "
+    "target kind that does not appear in the snapshot's settings_snapshot "
+    "or bindings_snapshot. If you are unsure, return fewer recommendations "
+    "rather than guessing."
+)
+
+
+class OpenAISetupAdvisor:
+    """OpenAI structured-output adapter.
+
+    Construction is lazy: the SDK + API key are resolved on first
+    use so a session that never invokes the advisor never pulls in
+    the dependency.
+    """
+
+    def __init__(
+        self,
+        *,
+        client: Any = None,
+        model: str | None = None,
+        api_key: str | None = None,
+    ) -> None:
+        self._client = client
+        self._model = model or os.getenv("SETUP_ADVISOR_OPENAI_MODEL", "gpt-4o-mini")
+        self._api_key = api_key
+
+    def _ensure_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        try:
+            from openai import AsyncOpenAI
+        except Exception as exc:  # noqa: BLE001 — import boundary
+            raise RuntimeError(
+                "openai package not installed; install ``openai>=1.40.0`` or "
+                "set SETUP_ADVISOR_PROVIDER=deterministic.",
+            ) from exc
+        api_key = self._api_key or os.getenv("OPENAI_API_KEY", "")
+        if not api_key:
+            raise RuntimeError(
+                "OPENAI_API_KEY is not set; cannot build OpenAISetupAdvisor.",
+            )
+        self._client = AsyncOpenAI(api_key=api_key)
+        return self._client
+
+    async def suggest(self, snapshot: GuildSnapshot) -> SetupPlanDraft:
+        client = self._ensure_client()
+        user_payload = json.dumps(_snapshot_to_prompt(snapshot), default=str)
+        try:
+            response = await client.chat.completions.create(
+                model=self._model,
+                messages=[
+                    {"role": "system", "content": _SYSTEM_PROMPT},
+                    {"role": "user", "content": user_payload},
+                ],
+                response_format={
+                    "type": "json_schema",
+                    "json_schema": _RECOMMENDATION_JSON_SCHEMA,
+                },
+            )
+        except Exception as exc:  # noqa: BLE001 — network boundary
+            logger.exception(
+                "OpenAISetupAdvisor.suggest: chat.completions.create failed; "
+                "falling back to empty draft.",
+            )
+            return SetupPlanDraft(
+                recommendations=(),
+                dropped=(f"openai: {type(exc).__name__}: {exc}",),
+                source=OPENAI,
+            )
+
+        raw = _extract_response_text(response)
+        if raw is None:
+            return SetupPlanDraft(
+                recommendations=(),
+                dropped=("openai: empty response",),
+                source=OPENAI,
+            )
+
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            return SetupPlanDraft(
+                recommendations=(),
+                dropped=(f"openai: invalid JSON ({exc})",),
+                source=OPENAI,
+            )
+
+        return _validate_ai_payload(parsed)
+
+
+def _snapshot_to_prompt(snapshot: GuildSnapshot) -> dict[str, Any]:
+    """Compact serialisation for the LLM prompt.
+
+    Drops the readiness_findings details — the model only needs
+    structure, not the per-finding messages — and renames fields to
+    plain ``snake_case`` (already the case for dataclass fields).
+    """
+    return {
+        "guild_id": snapshot.guild_id,
+        "guild_name": snapshot.guild_name,
+        "channels": [
+            {
+                "id": ch.id,
+                "name": ch.name,
+                "type": ch.type,
+                "topic": ch.topic,
+                "parent_category": ch.parent_category,
+                "bot_can_send": ch.bot_can_send,
+            }
+            for ch in snapshot.channels
+        ],
+        "categories": [{"id": cat.id, "name": cat.name} for cat in snapshot.categories],
+        "roles": [
+            {"id": r.id, "name": r.name, "bot_can_manage": r.bot_can_manage}
+            for r in snapshot.roles
+        ],
+        "settings_snapshot": snapshot.settings_snapshot,
+        "bindings_snapshot": snapshot.bindings_snapshot,
+    }
+
+
+def _extract_response_text(response: Any) -> str | None:
+    """Pull the assistant message text out of an OpenAI ChatCompletion."""
+    choices = getattr(response, "choices", None)
+    if not choices:
+        return None
+    first = choices[0]
+    message = getattr(first, "message", None)
+    if message is None:
+        return None
+    content = getattr(message, "content", None)
+    if not content:
+        return None
+    return content
+
+
+def _validate_ai_payload(parsed: Any) -> SetupPlanDraft:
+    """Re-validate a parsed AI payload against the local schema.
+
+    Steps:
+
+    * The top-level object must carry a ``recommendations`` list.
+    * Each item must carry every required field of
+      :class:`SetupRecommendation`.
+    * ``confidence`` must be one of ``high`` / ``medium`` / ``low``.
+    * The (subsystem, binding_name, target_kind) tuple must match
+      a real :class:`BindingSpec` in
+      ``subsystem_schema.all_schemas()``. Anything else is dropped
+      with a reason.
+    """
+    if not isinstance(parsed, dict):
+        return SetupPlanDraft(
+            recommendations=(),
+            dropped=(f"openai: top-level type {type(parsed).__name__}",),
+            source=OPENAI,
+        )
+
+    recommendations_raw = parsed.get("recommendations")
+    if not isinstance(recommendations_raw, list):
+        return SetupPlanDraft(
+            recommendations=(),
+            dropped=("openai: missing recommendations[]",),
+            source=OPENAI,
+        )
+
+    survivors: list[SetupRecommendation] = []
+    dropped: list[str] = []
+    for index, item in enumerate(recommendations_raw):
+        if not isinstance(item, dict):
+            dropped.append(f"openai: item[{index}] not a dict")
+            continue
+        confidence = item.get("confidence")
+        if confidence not in CONFIDENCES:
+            dropped.append(
+                f"openai: item[{index}] bad confidence {confidence!r}",
+            )
+            continue
+        try:
+            rec = SetupRecommendation(
+                subsystem=item["subsystem"],
+                binding_name=item["binding_name"],
+                target_kind=item["target_kind"],
+                target_id=int(item["target_id"]),
+                target_name=item["target_name"],
+                confidence=confidence,
+                reason=item["reason"],
+                source=OPENAI,
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            dropped.append(f"openai: item[{index}] {type(exc).__name__}: {exc}")
+            continue
+
+        reason = _validate_against_schema(rec)
+        if reason is not None:
+            dropped.append(f"openai: {rec.subsystem}.{rec.binding_name}: {reason}")
+            continue
+        survivors.append(rec)
+
+    return SetupPlanDraft(
+        recommendations=tuple(survivors),
+        dropped=tuple(dropped),
+        source=OPENAI,
+    )
+
+
+def _validate_against_schema(rec: SetupRecommendation) -> str | None:
+    """Mirror of :func:`services.setup_plan._validate_against_schema`."""
+    try:
+        from core.runtime.subsystem_schema import all_schemas
+    except Exception:
+        logger.exception(
+            "setup_ai_advisor: subsystem_schema unavailable; "
+            "dropping every AI recommendation.",
+        )
+        return "subsystem_schema unavailable"
+    schemas = all_schemas() or {}
+    schema = schemas.get(rec.subsystem)
+    if schema is None:
+        return f"subsystem {rec.subsystem!r} not registered"
+    for spec in schema.bindings:
+        if spec.name == rec.binding_name:
+            if spec.kind.value != rec.target_kind:
+                return (
+                    f"binding {rec.subsystem}.{rec.binding_name} has kind "
+                    f"{spec.kind.value}, AI proposed {rec.target_kind}"
+                )
+            return None
+    return f"binding {rec.subsystem}.{rec.binding_name} not declared"
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def build_advisor(
+    provider: str | None = None,
+    *,
+    api_key: str | None = None,
+    model: str | None = None,
+) -> SetupAdvisor:
+    """Pick and instantiate the right advisor.
+
+    Resolution:
+
+    1. Explicit ``provider`` argument (used by tests).
+    2. ``SETUP_ADVISOR_PROVIDER`` environment variable.
+    3. Default: ``deterministic``.
+
+    Whenever the requested provider is unavailable (missing API
+    key, missing SDK), we silently fall back to the deterministic
+    advisor and log a warning. CI never has an ``OPENAI_API_KEY``
+    so the fallback path is the default for the test suite — no
+    external requests are made.
+    """
+    chosen = (provider or os.getenv("SETUP_ADVISOR_PROVIDER", DETERMINISTIC)).lower()
+    if chosen not in KNOWN_PROVIDERS:
+        logger.warning(
+            "setup_ai_advisor: unknown SETUP_ADVISOR_PROVIDER=%r; "
+            "falling back to deterministic.",
+            chosen,
+        )
+        return DeterministicAdvisor()
+
+    if chosen == DETERMINISTIC:
+        return DeterministicAdvisor()
+
+    if chosen == OPENAI:
+        api_key = api_key or os.getenv("OPENAI_API_KEY", "")
+        if not api_key:
+            logger.warning(
+                "setup_ai_advisor: OPENAI_API_KEY not set; "
+                "falling back to deterministic.",
+            )
+            return DeterministicAdvisor()
+        try:
+            return OpenAISetupAdvisor(api_key=api_key, model=model)
+        except Exception:
+            logger.exception(
+                "setup_ai_advisor: OpenAISetupAdvisor construction failed; "
+                "falling back to deterministic.",
+            )
+            return DeterministicAdvisor()
+
+    if chosen == ANTHROPIC:
+        # Reserved — the adapter ships in a follow-up. Until then
+        # we want operators who flip the env var to get a clear
+        # log line, not silent breakage.
+        logger.warning(
+            "setup_ai_advisor: ANTHROPIC adapter is not implemented yet; "
+            "falling back to deterministic.",
+        )
+        return DeterministicAdvisor()
+
+    return DeterministicAdvisor()
+
+
+__all__ = [
+    "ANTHROPIC",
+    "DETERMINISTIC",
+    "KNOWN_PROVIDERS",
+    "OPENAI",
+    "OpenAISetupAdvisor",
+    "SetupAdvisor",
+    "build_advisor",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ asyncpg>=0.29.0
 aiohttp>=3.9.0
 python-json-logger>=2.0.7
 prometheus-client>=0.19.0
+openai>=1.40.0

--- a/tests/unit/services/test_setup_ai_advisor.py
+++ b/tests/unit/services/test_setup_ai_advisor.py
@@ -1,0 +1,438 @@
+"""Phase 9f / Track 5 PR 13 — AI advisor tests.
+
+Pins:
+
+* ``build_advisor`` returns ``DeterministicAdvisor`` by default
+  (the CI/dev safe fallback).
+* Unknown provider strings fall back to deterministic with a
+  warn-level log.
+* ``OpenAISetupAdvisor.suggest`` parses a valid OpenAI response
+  through the JSON schema and emits matching
+  :class:`SetupRecommendation` records.
+* Invalid recommendations are dropped with a reason:
+  * unknown subsystem;
+  * binding name not declared;
+  * kind mismatch;
+  * bad confidence string;
+  * non-JSON content.
+* The advisor never makes a real network call in tests; CI has no
+  ``OPENAI_API_KEY``.
+* AST-level invariants:
+  * ``setup_ai_advisor`` does not import ``utils.db``.
+  * ``setup_ai_advisor`` does not reference ``guild.create_*``.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from core.runtime.subsystem_schema import (
+    BindingKind,
+    BindingSpec,
+    SubsystemSchema,
+)
+from services.guild_snapshot import GuildSnapshot
+from services.setup_ai_advisor import (
+    ANTHROPIC,
+    DETERMINISTIC,
+    OPENAI,
+    OpenAISetupAdvisor,
+    SetupAdvisor,
+    build_advisor,
+)
+from services.setup_plan import (
+    DeterministicAdvisor,
+    SetupPlanDraft,
+    SetupRecommendation,
+)
+
+
+def _snap() -> GuildSnapshot:
+    return GuildSnapshot(
+        guild_id=1,
+        guild_name="Test",
+        owner_id=99,
+    )
+
+
+@pytest.fixture
+def _logging_schema():
+    schemas = {
+        "logging": SubsystemSchema(
+            subsystem="logging",
+            bindings=(
+                BindingSpec(
+                    name="mod_channel",
+                    kind=BindingKind.CHANNEL,
+                    required=True,
+                    hint="",
+                    capability_required="logging.mod_channel.bind",
+                ),
+            ),
+        ),
+    }
+    with patch(
+        "core.runtime.subsystem_schema.all_schemas",
+        return_value=schemas,
+    ):
+        yield schemas
+
+
+@pytest.fixture
+def _no_openai_env(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("SETUP_ADVISOR_PROVIDER", raising=False)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# build_advisor — provider resolution
+# ---------------------------------------------------------------------------
+
+
+def test_build_advisor_defaults_to_deterministic(_no_openai_env):
+    advisor = build_advisor()
+    assert isinstance(advisor, DeterministicAdvisor)
+
+
+def test_build_advisor_explicit_deterministic(_no_openai_env):
+    advisor = build_advisor(provider="deterministic")
+    assert isinstance(advisor, DeterministicAdvisor)
+
+
+def test_build_advisor_unknown_provider_falls_back(_no_openai_env, caplog):
+    with caplog.at_level("WARNING", logger="bot.services.setup_ai_advisor"):
+        advisor = build_advisor(provider="totally_made_up")
+    assert isinstance(advisor, DeterministicAdvisor)
+    assert any(
+        "unknown SETUP_ADVISOR_PROVIDER" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_build_advisor_openai_without_api_key_falls_back(_no_openai_env, caplog):
+    with caplog.at_level("WARNING", logger="bot.services.setup_ai_advisor"):
+        advisor = build_advisor(provider="openai")
+    assert isinstance(advisor, DeterministicAdvisor)
+    assert any(
+        "OPENAI_API_KEY not set" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_build_advisor_anthropic_is_reserved_and_falls_back(_no_openai_env, caplog):
+    with caplog.at_level("WARNING", logger="bot.services.setup_ai_advisor"):
+        advisor = build_advisor(provider="anthropic")
+    assert isinstance(advisor, DeterministicAdvisor)
+    assert any(
+        "ANTHROPIC adapter is not implemented" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_build_advisor_openai_with_key_returns_openai_adapter(_no_openai_env):
+    advisor = build_advisor(provider="openai", api_key="sk-test")
+    assert isinstance(advisor, OpenAISetupAdvisor)
+    assert isinstance(advisor, SetupAdvisor)
+
+
+def test_known_providers_set():
+    from services.setup_ai_advisor import KNOWN_PROVIDERS
+
+    assert KNOWN_PROVIDERS == frozenset({DETERMINISTIC, OPENAI, ANTHROPIC})
+
+
+# ---------------------------------------------------------------------------
+# OpenAISetupAdvisor — happy path
+# ---------------------------------------------------------------------------
+
+
+def _fake_openai_response(payload: dict) -> MagicMock:
+    """Build a chat.completions response that contains ``payload`` as
+    the assistant message JSON string."""
+    message = MagicMock()
+    message.content = json.dumps(payload)
+    choice = MagicMock()
+    choice.message = message
+    response = MagicMock()
+    response.choices = [choice]
+    return response
+
+
+@pytest.mark.asyncio
+async def test_openai_advisor_emits_validated_recommendation(_logging_schema):
+    payload = {
+        "recommendations": [
+            {
+                "subsystem": "logging",
+                "binding_name": "mod_channel",
+                "target_kind": "channel",
+                "target_id": 100,
+                "target_name": "mod-log",
+                "confidence": "high",
+                "reason": "exact name match",
+            },
+        ],
+    }
+    fake_client = MagicMock()
+    fake_client.chat = MagicMock()
+    fake_client.chat.completions = MagicMock()
+    fake_client.chat.completions.create = AsyncMock(
+        return_value=_fake_openai_response(payload),
+    )
+
+    advisor = OpenAISetupAdvisor(client=fake_client, api_key="sk-test")
+    draft = await advisor.suggest(_snap())
+
+    fake_client.chat.completions.create.assert_awaited_once()
+    assert isinstance(draft, SetupPlanDraft)
+    assert len(draft.recommendations) == 1
+    rec = draft.recommendations[0]
+    assert rec.source == "openai"
+    assert rec.subsystem == "logging"
+    assert rec.binding_name == "mod_channel"
+
+
+@pytest.mark.asyncio
+async def test_openai_advisor_drops_unknown_subsystem(_logging_schema):
+    payload = {
+        "recommendations": [
+            {
+                "subsystem": "vibes",
+                "binding_name": "mod_channel",
+                "target_kind": "channel",
+                "target_id": 100,
+                "target_name": "x",
+                "confidence": "high",
+                "reason": "y",
+            },
+        ],
+    }
+    fake_client = MagicMock()
+    fake_client.chat = MagicMock()
+    fake_client.chat.completions = MagicMock()
+    fake_client.chat.completions.create = AsyncMock(
+        return_value=_fake_openai_response(payload),
+    )
+
+    advisor = OpenAISetupAdvisor(client=fake_client, api_key="sk-test")
+    draft = await advisor.suggest(_snap())
+
+    assert draft.recommendations == ()
+    assert any("not registered" in r for r in draft.dropped)
+
+
+@pytest.mark.asyncio
+async def test_openai_advisor_drops_kind_mismatch(_logging_schema):
+    payload = {
+        "recommendations": [
+            {
+                "subsystem": "logging",
+                "binding_name": "mod_channel",
+                "target_kind": "role",  # schema says CHANNEL
+                "target_id": 100,
+                "target_name": "x",
+                "confidence": "high",
+                "reason": "y",
+            },
+        ],
+    }
+    fake_client = MagicMock()
+    fake_client.chat = MagicMock()
+    fake_client.chat.completions = MagicMock()
+    fake_client.chat.completions.create = AsyncMock(
+        return_value=_fake_openai_response(payload),
+    )
+
+    advisor = OpenAISetupAdvisor(client=fake_client, api_key="sk-test")
+    draft = await advisor.suggest(_snap())
+
+    assert draft.recommendations == ()
+    assert any("AI proposed role" in r for r in draft.dropped)
+
+
+@pytest.mark.asyncio
+async def test_openai_advisor_drops_bad_confidence(_logging_schema):
+    payload = {
+        "recommendations": [
+            {
+                "subsystem": "logging",
+                "binding_name": "mod_channel",
+                "target_kind": "channel",
+                "target_id": 100,
+                "target_name": "x",
+                "confidence": "totally_made_up",
+                "reason": "y",
+            },
+        ],
+    }
+    fake_client = MagicMock()
+    fake_client.chat = MagicMock()
+    fake_client.chat.completions = MagicMock()
+    fake_client.chat.completions.create = AsyncMock(
+        return_value=_fake_openai_response(payload),
+    )
+
+    advisor = OpenAISetupAdvisor(client=fake_client, api_key="sk-test")
+    draft = await advisor.suggest(_snap())
+
+    assert draft.recommendations == ()
+    assert any("bad confidence" in r for r in draft.dropped)
+
+
+@pytest.mark.asyncio
+async def test_openai_advisor_drops_missing_field(_logging_schema):
+    payload = {
+        "recommendations": [
+            {
+                # missing target_id
+                "subsystem": "logging",
+                "binding_name": "mod_channel",
+                "target_kind": "channel",
+                "target_name": "x",
+                "confidence": "high",
+                "reason": "y",
+            },
+        ],
+    }
+    fake_client = MagicMock()
+    fake_client.chat = MagicMock()
+    fake_client.chat.completions = MagicMock()
+    fake_client.chat.completions.create = AsyncMock(
+        return_value=_fake_openai_response(payload),
+    )
+
+    advisor = OpenAISetupAdvisor(client=fake_client, api_key="sk-test")
+    draft = await advisor.suggest(_snap())
+
+    assert draft.recommendations == ()
+    assert any("KeyError" in r for r in draft.dropped)
+
+
+@pytest.mark.asyncio
+async def test_openai_advisor_handles_invalid_json():
+    message = MagicMock()
+    message.content = "not json at all {{"
+    choice = MagicMock()
+    choice.message = message
+    response = MagicMock()
+    response.choices = [choice]
+
+    fake_client = MagicMock()
+    fake_client.chat = MagicMock()
+    fake_client.chat.completions = MagicMock()
+    fake_client.chat.completions.create = AsyncMock(return_value=response)
+
+    advisor = OpenAISetupAdvisor(client=fake_client, api_key="sk-test")
+    draft = await advisor.suggest(_snap())
+
+    assert draft.recommendations == ()
+    assert any("invalid JSON" in r for r in draft.dropped)
+
+
+@pytest.mark.asyncio
+async def test_openai_advisor_swallows_network_failure():
+    fake_client = MagicMock()
+    fake_client.chat = MagicMock()
+    fake_client.chat.completions = MagicMock()
+    fake_client.chat.completions.create = AsyncMock(
+        side_effect=RuntimeError("rate limited"),
+    )
+
+    advisor = OpenAISetupAdvisor(client=fake_client, api_key="sk-test")
+    draft = await advisor.suggest(_snap())
+
+    assert draft.recommendations == ()
+    assert any("rate limited" in r for r in draft.dropped)
+
+
+@pytest.mark.asyncio
+async def test_openai_advisor_handles_empty_response():
+    response = MagicMock()
+    response.choices = []
+    fake_client = MagicMock()
+    fake_client.chat = MagicMock()
+    fake_client.chat.completions = MagicMock()
+    fake_client.chat.completions.create = AsyncMock(return_value=response)
+
+    advisor = OpenAISetupAdvisor(client=fake_client, api_key="sk-test")
+    draft = await advisor.suggest(_snap())
+
+    assert draft.recommendations == ()
+    assert any("empty response" in r for r in draft.dropped)
+
+
+# ---------------------------------------------------------------------------
+# Module invariants
+# ---------------------------------------------------------------------------
+
+
+def test_module_has_no_db_imports():
+    import services.setup_ai_advisor as mod
+
+    src = mod.__file__
+    assert src is not None
+    with open(src, encoding="utf-8") as fh:
+        text = fh.read()
+    for forbidden in ("from utils.db import", "import utils.db"):
+        assert forbidden not in text, (
+            f"services.setup_ai_advisor must not import {forbidden}; "
+            "the AI advisor must remain read-only."
+        )
+
+
+def test_module_has_no_discord_create_calls():
+    import services.setup_ai_advisor as mod
+
+    src = mod.__file__
+    assert src is not None
+    with open(src, encoding="utf-8") as fh:
+        text = fh.read()
+    for forbidden in (
+        "guild.create_text_channel",
+        "guild.create_role",
+        "guild.create_category",
+        "create_text_channel(",
+        "create_role(",
+        "create_category(",
+    ):
+        assert forbidden not in text, (
+            f"services.setup_ai_advisor must not call {forbidden}; "
+            "the AI advisor must never create Discord resources."
+        )
+
+
+def test_setup_advisor_protocol_accepts_deterministic_and_openai():
+    """Both implementations satisfy the Protocol."""
+    assert isinstance(DeterministicAdvisor(), SetupAdvisor)
+    assert isinstance(OpenAISetupAdvisor(api_key="sk-test"), SetupAdvisor)
+
+
+def test_protocol_is_runtime_checkable():
+    """``isinstance`` check works for arbitrary objects implementing
+    ``async def suggest(snapshot) -> SetupPlanDraft``."""
+
+    class _Custom:
+        async def suggest(self, snapshot):
+            return SetupPlanDraft()
+
+    assert isinstance(_Custom(), SetupAdvisor)
+
+
+def test_recommendation_source_field_marks_origin():
+    """Sanity: the deterministic baseline marks ``source="deterministic"``,
+    OpenAI marks ``source="openai"``. Tests above already exercise the
+    OpenAI side; this one pins the deterministic default."""
+    rec = SetupRecommendation(
+        subsystem="logging",
+        binding_name="mod_channel",
+        target_kind="channel",
+        target_id=1,
+        target_name="mod-log",
+        confidence="high",
+        reason="x",
+    )
+    assert rec.source == "deterministic"


### PR DESCRIPTION
## Summary

Re-cut of **#186** (Track 5 PR 13). Cherry-pick onto fresh `origin/main`. Adds the typed `SetupAdvisor` Protocol, OpenAI adapter, and `build_advisor` factory.

## Safety

- ✅ **Defaults to deterministic** — `build_advisor()` returns `DeterministicAdvisor` when `SETUP_ADVISOR_PROVIDER` is unset.
- ✅ **No external API calls in CI** — CI has no `OPENAI_API_KEY`; the factory falls back to deterministic with a warn log.
- ✅ **No DB writes / no Discord mutations** — AST tests pin both invariants.
- ✅ **Schema re-validation** — every AI recommendation is re-validated against `subsystem_schema.all_schemas()`; hallucinations get dropped.

## Files restored

- `disbot/services/setup_ai_advisor.py` (~370 LOC).
- `tests/unit/services/test_setup_ai_advisor.py` (~440 LOC, 20 cases).
- `disbot/config.py` — adds `SETUP_ADVISOR_PROVIDER`, `SETUP_ADVISOR_OPENAI_MODEL`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY` env vars.
- `requirements.txt` — `openai>=1.40.0`.

## Tests run

```
python -m pytest tests/unit/services/test_setup_ai_advisor.py -q   # 20 passed
python -m pytest -q                                                # 2830 passed
ruff/black/isort/mypy                                              # all green
```

## Chain status

PRs 1, 2 merged. PR 3 (#200) in flight. This is PR 4.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXdDyevoQLQXgmgog7erwY)_