### PR TITLE
views: restore AI review UI (re-cut of #187)

### DIFF
--- a/disbot/views/setup/ai_review/__init__.py
+++ b/disbot/views/setup/ai_review/__init__.py
@@ -1,0 +1,35 @@
+"""AI review UI — Phase 9f / Track 5 PR 14.
+
+Two panels that surface the :class:`SetupPlanDraft` produced by
+:mod:`services.setup_ai_advisor` (or the deterministic fallback) to
+the server owner.
+
+* :class:`AIReviewPanelView` — aggregate review: shows counts per
+  confidence + subsystem, exposes bulk accept/reject + per-rec drill
+  + rerun-deterministic actions.
+* :class:`PerRecommendationView` — one-by-one walkthrough.
+
+Both panels are pure orchestration: they accept / reject
+recommendations into an in-memory :class:`AcceptedSet`. Nothing
+writes to the DB or calls ``guild.create_*``. The accepted set is
+handed back to the caller (the wizard hub, Track 8 PR 23) which then
+applies recommendations through the existing mutation pipelines.
+"""
+
+from views.setup.ai_review.main_panel import (
+    AcceptedSet,
+    AIReviewPanelView,
+    build_ai_review_embed,
+)
+from views.setup.ai_review.per_recommendation import (
+    PerRecommendationView,
+    build_per_recommendation_embed,
+)
+
+__all__ = [
+    "AIReviewPanelView",
+    "AcceptedSet",
+    "PerRecommendationView",
+    "build_ai_review_embed",
+    "build_per_recommendation_embed",
+]

--- a/disbot/views/setup/ai_review/main_panel.py
+++ b/disbot/views/setup/ai_review/main_panel.py
@@ -1,0 +1,325 @@
+"""Main AI review panel — Phase 9f / Track 5 PR 14.
+
+Aggregate view over a :class:`SetupPlanDraft`:
+
+* Lists counts per confidence tier (high/medium/low).
+* Lists subsystems with at least one recommendation.
+* Offers four buttons:
+  * **Accept all high-confidence** — adds every high-confidence
+    recommendation to :class:`AcceptedSet`.
+  * **Review one-by-one** — transitions to
+    :class:`PerRecommendationView`.
+  * **Reject all AI suggestions** — clears AI recommendations from
+    the draft so only deterministic ones remain.
+  * **Rerun deterministic-only** — re-runs the deterministic
+    advisor and replaces the draft in place.
+
+No DB writes, no Discord resource creation. The panel only mutates
+the in-memory :class:`AcceptedSet` and the in-memory
+:class:`SetupPlanDraft`. The wizard hub (Track 8) consumes the
+final accepted set and routes through pipelines.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import discord
+
+from services.guild_snapshot import GuildSnapshot
+from services.setup_plan import (
+    DeterministicAdvisor,
+    SetupPlanDraft,
+    SetupRecommendation,
+)
+from views.base import BaseView
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger("bot.views.setup.ai_review.main_panel")
+
+_REVIEW_HEADER = "Smart suggestions are recommendations. Review before applying."
+
+
+@dataclass
+class AcceptedSet:
+    """Mutable container of recommendations the operator has accepted.
+
+    Lives on the view; the wizard hub reads :attr:`recommendations`
+    after the operator closes the review panel.
+    """
+
+    recommendations: list[SetupRecommendation] = field(default_factory=list)
+
+    def add(self, rec: SetupRecommendation) -> bool:
+        """Add ``rec`` if not already accepted. Returns True if added."""
+        key = (rec.subsystem, rec.binding_name)
+        if any((r.subsystem, r.binding_name) == key for r in self.recommendations):
+            return False
+        self.recommendations.append(rec)
+        return True
+
+    def add_many(
+        self,
+        recs: tuple[SetupRecommendation, ...] | list[SetupRecommendation],
+    ) -> int:
+        added = 0
+        for rec in recs:
+            if self.add(rec):
+                added += 1
+        return added
+
+    def clear(self) -> None:
+        self.recommendations.clear()
+
+    def remove(self, subsystem: str, binding_name: str) -> bool:
+        for i, rec in enumerate(self.recommendations):
+            if rec.subsystem == subsystem and rec.binding_name == binding_name:
+                del self.recommendations[i]
+                return True
+        return False
+
+    def contains(self, rec: SetupRecommendation) -> bool:
+        return any(
+            (r.subsystem, r.binding_name) == (rec.subsystem, rec.binding_name)
+            for r in self.recommendations
+        )
+
+    @property
+    def count(self) -> int:
+        return len(self.recommendations)
+
+
+def build_ai_review_embed(draft: SetupPlanDraft) -> discord.Embed:
+    """Render the aggregate review embed for a draft."""
+    high = draft.by_confidence("high")
+    medium = draft.by_confidence("medium")
+    low = draft.by_confidence("low")
+
+    description = (
+        f"_{_REVIEW_HEADER}_\n\n"
+        f"**High:** {len(high)} · **Medium:** {len(medium)} · "
+        f"**Low:** {len(low)} · **Source:** `{draft.source}`"
+    )
+    color = (
+        discord.Color.green()
+        if high
+        else discord.Color.gold() if medium else discord.Color.dark_grey()
+    )
+    embed = discord.Embed(
+        title="🤖 Smart suggestions",
+        description=description,
+        color=color,
+    )
+
+    # Group by subsystem for the field section.
+    by_sub: dict[str, list[SetupRecommendation]] = {}
+    for rec in draft.recommendations:
+        by_sub.setdefault(rec.subsystem, []).append(rec)
+    for subsystem in sorted(by_sub):
+        lines = []
+        for rec in by_sub[subsystem]:
+            icon = _CONFIDENCE_ICON[rec.confidence]
+            lines.append(
+                f"{icon} `{rec.binding_name}` → `{rec.target_name}` — {rec.reason}",
+            )
+        value = "\n".join(lines)
+        if len(value) > 1000:
+            value = value[:997] + "..."
+        embed.add_field(
+            name=f"{subsystem}",
+            value=value,
+            inline=False,
+        )
+
+    if draft.dropped:
+        dropped_value = "\n".join(f"• {d}" for d in draft.dropped[:5])
+        if len(draft.dropped) > 5:
+            dropped_value += f"\n_+{len(draft.dropped) - 5} more not shown_"
+        embed.add_field(
+            name="Dropped",
+            value=dropped_value,
+            inline=False,
+        )
+
+    return embed
+
+
+_CONFIDENCE_ICON = {
+    "high": "🟢",
+    "medium": "🟡",
+    "low": "⚪",
+}
+
+
+class AIReviewPanelView(BaseView):
+    """Aggregate AI-review panel.
+
+    Owns the active :class:`SetupPlanDraft` and the
+    :class:`AcceptedSet`. Buttons mutate one or both; the wizard
+    hub reads :attr:`accepted` after the operator closes the
+    panel.
+    """
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        *,
+        draft: SetupPlanDraft,
+        snapshot: GuildSnapshot | None = None,
+        accepted: AcceptedSet | None = None,
+        public: bool = False,
+        timeout: int = 180,
+    ) -> None:
+        super().__init__(author, public=public, timeout=timeout)
+        self.draft = draft
+        self.snapshot = snapshot
+        self.accepted = accepted if accepted is not None else AcceptedSet()
+        self.last_status: str | None = None  # last action label for embed
+
+    def _refresh_embed(self) -> discord.Embed:
+        embed = build_ai_review_embed(self.draft)
+        if self.last_status:
+            embed.set_footer(text=self.last_status)
+        return embed
+
+    async def _refresh(self, interaction: discord.Interaction) -> None:
+        try:
+            await interaction.response.edit_message(
+                embed=self._refresh_embed(),
+                view=self,
+            )
+        except discord.HTTPException:
+            logger.warning(
+                "AIReviewPanelView._refresh: edit_message failed.",
+            )
+
+    @discord.ui.button(
+        label="Accept all high-confidence",
+        style=discord.ButtonStyle.success,
+    )
+    async def _accept_high(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        high = self.draft.by_confidence("high")
+        added = self.accepted.add_many(high)
+        self.last_status = (
+            f"Accepted {added} high-confidence recommendation(s); "
+            f"total accepted: {self.accepted.count}."
+        )
+        await self._refresh(interaction)
+
+    @discord.ui.button(
+        label="Review one-by-one",
+        style=discord.ButtonStyle.primary,
+    )
+    async def _review_each(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        if not self.draft.recommendations:
+            await interaction.response.send_message(
+                "Nothing to review — the draft is empty.",
+                ephemeral=True,
+            )
+            return
+        from views.setup.ai_review.per_recommendation import (
+            PerRecommendationView,
+            build_per_recommendation_embed,
+        )
+
+        per_view = PerRecommendationView(
+            self._author,
+            draft=self.draft,
+            accepted=self.accepted,
+            index=0,
+            parent_view=self,
+            public=self._public,
+            timeout=self.timeout,
+        )
+        await interaction.response.edit_message(
+            embed=build_per_recommendation_embed(self.draft, 0, self.accepted),
+            view=per_view,
+        )
+
+    @discord.ui.button(
+        label="Reject all AI suggestions",
+        style=discord.ButtonStyle.danger,
+    )
+    async def _reject_ai(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        surviving = tuple(r for r in self.draft.recommendations if r.source != "openai")
+        removed = len(self.draft.recommendations) - len(surviving)
+        self.draft = SetupPlanDraft(
+            recommendations=surviving,
+            dropped=self.draft.dropped,
+            source="deterministic" if removed else self.draft.source,
+        )
+        # Also strip rejected AI items from the accepted set.
+        self.accepted.recommendations = [
+            r for r in self.accepted.recommendations if r.source != "openai"
+        ]
+        self.last_status = (
+            f"Rejected {removed} AI suggestion(s); accepted set "
+            f"refreshed to {self.accepted.count}."
+        )
+        await self._refresh(interaction)
+
+    @discord.ui.button(
+        label="Rerun deterministic-only",
+        style=discord.ButtonStyle.secondary,
+    )
+    async def _rerun_deterministic(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        if self.snapshot is None:
+            await interaction.response.send_message(
+                "Cannot rerun deterministic-only: no snapshot stored on this panel.",
+                ephemeral=True,
+            )
+            return
+        deterministic = DeterministicAdvisor()
+        try:
+            self.draft = await deterministic.suggest(self.snapshot)
+        except Exception:
+            logger.exception(
+                "AIReviewPanelView._rerun_deterministic: advisor.suggest failed",
+            )
+            await interaction.response.send_message(
+                "Deterministic rerun failed; the draft is unchanged.",
+                ephemeral=True,
+            )
+            return
+        # Drop any AI-sourced accepted items so the accepted set
+        # stays consistent with the new deterministic-only draft.
+        self.accepted.recommendations = [
+            r for r in self.accepted.recommendations if r.source != "openai"
+        ]
+        self.last_status = (
+            f"Deterministic advisor rerun: "
+            f"{len(self.draft.recommendations)} recommendation(s); "
+            f"accepted set: {self.accepted.count}."
+        )
+        await self._refresh(interaction)
+
+
+__all__ = [
+    "AIReviewPanelView",
+    "AcceptedSet",
+    "build_ai_review_embed",
+]

--- a/disbot/views/setup/ai_review/per_recommendation.py
+++ b/disbot/views/setup/ai_review/per_recommendation.py
@@ -1,0 +1,201 @@
+"""Per-recommendation review view — Phase 9f / Track 5 PR 14.
+
+One-at-a-time walkthrough over a :class:`SetupPlanDraft`. The
+operator advances index-by-index and accepts / rejects each
+recommendation into the shared :class:`AcceptedSet`.
+
+Buttons:
+
+* **Accept** — adds the current recommendation to :class:`AcceptedSet`
+  and advances to the next index.
+* **Reject** — removes any existing acceptance and advances.
+* **Skip** — advances without changing the accepted set.
+* **Back to overview** — returns to :class:`AIReviewPanelView`.
+
+The current index is bounded ``[0, len(recommendations))``. Once
+the operator advances past the last recommendation the view
+auto-returns to the overview panel.
+
+No DB writes, no Discord resource creation — only state mutations on
+the shared :class:`AcceptedSet`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import discord
+
+from services.setup_plan import SetupPlanDraft, SetupRecommendation
+from views.base import BaseView
+
+if TYPE_CHECKING:
+    from views.setup.ai_review.main_panel import AcceptedSet, AIReviewPanelView
+
+logger = logging.getLogger("bot.views.setup.ai_review.per_recommendation")
+
+
+def build_per_recommendation_embed(
+    draft: SetupPlanDraft,
+    index: int,
+    accepted: AcceptedSet,
+) -> discord.Embed:
+    """Render a single recommendation."""
+    total = len(draft.recommendations)
+    if total == 0:
+        return discord.Embed(
+            title="🤖 Smart suggestions",
+            description="No recommendations to review.",
+            color=discord.Color.dark_grey(),
+        )
+    safe_index = max(0, min(index, total - 1))
+    rec = draft.recommendations[safe_index]
+    color = _CONFIDENCE_COLOR[rec.confidence]
+    is_accepted = accepted.contains(rec)
+    state_label = "✅ accepted" if is_accepted else "⬜ pending"
+    embed = discord.Embed(
+        title=(f"🤖 Suggestion {safe_index + 1} / {total} · {state_label}"),
+        description=(
+            f"**Subsystem:** `{rec.subsystem}`\n"
+            f"**Binding:** `{rec.binding_name}` (`{rec.target_kind}`)\n"
+            f"**Target:** `{rec.target_name}` (id `{rec.target_id}`)\n"
+            f"**Confidence:** `{rec.confidence}`\n"
+            f"**Source:** `{rec.source}`\n\n"
+            f"_{rec.reason}_"
+        ),
+        color=color,
+    )
+    embed.set_footer(
+        text=f"Accepted set: {accepted.count} · use Skip to defer, Back to return.",
+    )
+    return embed
+
+
+_CONFIDENCE_COLOR = {
+    "high": discord.Color.green(),
+    "medium": discord.Color.gold(),
+    "low": discord.Color.dark_grey(),
+}
+
+
+class PerRecommendationView(BaseView):
+    """One-at-a-time walkthrough."""
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        *,
+        draft: SetupPlanDraft,
+        accepted: AcceptedSet,
+        index: int = 0,
+        parent_view: AIReviewPanelView | None = None,
+        public: bool = False,
+        timeout: int = 180,
+    ) -> None:
+        super().__init__(author, public=public, timeout=timeout)
+        self.draft = draft
+        self.accepted = accepted
+        self.index = index
+        self.parent_view = parent_view
+
+    @property
+    def current(self) -> SetupRecommendation | None:
+        if 0 <= self.index < len(self.draft.recommendations):
+            return self.draft.recommendations[self.index]
+        return None
+
+    async def _advance_or_return(
+        self,
+        interaction: discord.Interaction,
+    ) -> None:
+        self.index += 1
+        if self.index >= len(self.draft.recommendations):
+            # End of list — return to overview.
+            await self._return_to_overview(interaction)
+            return
+        await interaction.response.edit_message(
+            embed=build_per_recommendation_embed(
+                self.draft,
+                self.index,
+                self.accepted,
+            ),
+            view=self,
+        )
+
+    async def _return_to_overview(
+        self,
+        interaction: discord.Interaction,
+    ) -> None:
+        if self.parent_view is None:
+            await interaction.response.send_message(
+                "Review complete. The accepted set is ready to apply.",
+                ephemeral=True,
+            )
+            return
+        from views.setup.ai_review.main_panel import build_ai_review_embed
+
+        self.parent_view.last_status = (
+            f"Per-recommendation review finished; "
+            f"accepted set: {self.accepted.count}."
+        )
+        self.parent_view.draft = self.draft
+        await interaction.response.edit_message(
+            embed=build_ai_review_embed(self.parent_view.draft),
+            view=self.parent_view,
+        )
+
+    @discord.ui.button(label="Accept", style=discord.ButtonStyle.success)
+    async def _accept(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        rec = self.current
+        if rec is None:
+            await self._return_to_overview(interaction)
+            return
+        self.accepted.add(rec)
+        await self._advance_or_return(interaction)
+
+    @discord.ui.button(label="Reject", style=discord.ButtonStyle.danger)
+    async def _reject(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        rec = self.current
+        if rec is None:
+            await self._return_to_overview(interaction)
+            return
+        self.accepted.remove(rec.subsystem, rec.binding_name)
+        await self._advance_or_return(interaction)
+
+    @discord.ui.button(label="Skip", style=discord.ButtonStyle.secondary)
+    async def _skip(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        await self._advance_or_return(interaction)
+
+    @discord.ui.button(
+        label="Back to overview",
+        style=discord.ButtonStyle.secondary,
+    )
+    async def _back(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        await self._return_to_overview(interaction)
+
+
+__all__ = [
+    "PerRecommendationView",
+    "build_per_recommendation_embed",
+]

--- a/tests/unit/views/setup/ai_review/test_ai_review_panels.py
+++ b/tests/unit/views/setup/ai_review/test_ai_review_panels.py
@@ -1,0 +1,473 @@
+"""Phase 9f / Track 5 PR 14 — AI review panel tests.
+
+Pins:
+
+* The aggregate panel renders counts per confidence and groups
+  recommendations by subsystem.
+* The "Accept all high-confidence" button adds every high
+  recommendation to the accepted set; subsequent click is a no-op
+  (deduplication by (subsystem, binding_name)).
+* "Reject all AI suggestions" strips ``source="openai"``
+  recommendations from both the draft and the accepted set.
+* "Rerun deterministic-only" calls ``DeterministicAdvisor.suggest``
+  with the stored snapshot, replaces the draft, and strips AI items
+  from the accepted set.
+* The per-recommendation view advances through the draft and
+  transitions back to the parent overview when it runs out of items.
+* AST invariants: panels don't import ``utils.db`` and don't call
+  ``guild.create_*``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.guild_snapshot import GuildSnapshot
+from services.setup_plan import SetupPlanDraft, SetupRecommendation
+from views.setup.ai_review.main_panel import (
+    AcceptedSet,
+    AIReviewPanelView,
+    build_ai_review_embed,
+)
+from views.setup.ai_review.per_recommendation import (
+    PerRecommendationView,
+    build_per_recommendation_embed,
+)
+
+
+def _rec(
+    *,
+    subsystem="logging",
+    binding="mod_channel",
+    confidence="high",
+    source="deterministic",
+    target_id=100,
+):
+    return SetupRecommendation(
+        subsystem=subsystem,
+        binding_name=binding,
+        target_kind="channel",
+        target_id=target_id,
+        target_name=f"{binding}-{target_id}",
+        confidence=confidence,
+        reason="x",
+        source=source,
+    )
+
+
+def _author():
+    member = MagicMock()
+    member.id = 99
+    return member
+
+
+def _interaction(*, guild_id=1):
+    interaction = MagicMock()
+    interaction.guild_id = guild_id
+    interaction.guild = MagicMock(id=guild_id)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    return interaction
+
+
+# ---------------------------------------------------------------------------
+# AcceptedSet
+# ---------------------------------------------------------------------------
+
+
+def test_accepted_set_dedupes_by_subsystem_and_binding():
+    accepted = AcceptedSet()
+    rec_a = _rec(target_id=100)
+    rec_b = _rec(target_id=101)  # same (subsystem, binding)
+    assert accepted.add(rec_a) is True
+    assert accepted.add(rec_b) is False
+    assert accepted.count == 1
+
+
+def test_accepted_set_remove():
+    accepted = AcceptedSet()
+    rec = _rec()
+    accepted.add(rec)
+    assert accepted.remove("logging", "mod_channel") is True
+    assert accepted.count == 0
+    assert accepted.remove("logging", "mod_channel") is False
+
+
+def test_accepted_set_contains():
+    accepted = AcceptedSet()
+    rec = _rec()
+    assert accepted.contains(rec) is False
+    accepted.add(rec)
+    assert accepted.contains(rec) is True
+
+
+# ---------------------------------------------------------------------------
+# Aggregate embed
+# ---------------------------------------------------------------------------
+
+
+def test_build_ai_review_embed_renders_header_and_counts():
+    draft = SetupPlanDraft(
+        recommendations=(
+            _rec(confidence="high"),
+            _rec(binding="audit_channel", target_id=101, confidence="medium"),
+        ),
+    )
+    embed = build_ai_review_embed(draft)
+    desc = embed.description or ""
+    assert "recommendations" in desc.lower()
+    assert "High:** 1" in desc
+    assert "Medium:** 1" in desc
+
+
+def test_build_ai_review_embed_groups_by_subsystem():
+    draft = SetupPlanDraft(
+        recommendations=(
+            _rec(subsystem="logging", binding="mod_channel"),
+            _rec(subsystem="counting", binding="channel", target_id=200),
+        ),
+    )
+    embed = build_ai_review_embed(draft)
+    field_names = [f.name for f in embed.fields]
+    assert "counting" in field_names
+    assert "logging" in field_names
+
+
+def test_build_ai_review_embed_shows_dropped_diagnostics():
+    draft = SetupPlanDraft(
+        recommendations=(),
+        dropped=("openai: invalid",) * 7,
+    )
+    embed = build_ai_review_embed(draft)
+    dropped = next(f for f in embed.fields if f.name == "Dropped")
+    assert "openai" in (dropped.value or "")
+    assert "2 more" in (dropped.value or "")
+
+
+# ---------------------------------------------------------------------------
+# AIReviewPanelView buttons
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_accept_high_button_adds_high_confidence_recs():
+    draft = SetupPlanDraft(
+        recommendations=(
+            _rec(confidence="high"),
+            _rec(binding="audit_channel", target_id=101, confidence="high"),
+            _rec(binding="cleanup_channel", target_id=102, confidence="medium"),
+        ),
+    )
+    view = AIReviewPanelView(_author(), draft=draft)
+    interaction = _interaction()
+
+    await view._accept_high.callback(interaction)
+
+    assert view.accepted.count == 2
+    interaction.response.edit_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_accept_high_button_is_idempotent():
+    """A second click should NOT re-add the same recommendations."""
+    draft = SetupPlanDraft(
+        recommendations=(
+            _rec(confidence="high"),
+            _rec(binding="audit_channel", target_id=101, confidence="high"),
+        ),
+    )
+    view = AIReviewPanelView(_author(), draft=draft)
+    interaction = _interaction()
+
+    await view._accept_high.callback(interaction)
+    await view._accept_high.callback(interaction)
+
+    assert view.accepted.count == 2
+
+
+@pytest.mark.asyncio
+async def test_review_each_transitions_to_per_recommendation_view():
+    draft = SetupPlanDraft(recommendations=(_rec(confidence="high"),))
+    view = AIReviewPanelView(_author(), draft=draft)
+    interaction = _interaction()
+
+    await view._review_each.callback(interaction)
+
+    interaction.response.edit_message.assert_awaited_once()
+    new_view = interaction.response.edit_message.await_args.kwargs["view"]
+    assert isinstance(new_view, PerRecommendationView)
+
+
+@pytest.mark.asyncio
+async def test_review_each_with_empty_draft_sends_ephemeral_message():
+    view = AIReviewPanelView(_author(), draft=SetupPlanDraft())
+    interaction = _interaction()
+
+    await view._review_each.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    assert "empty" in interaction.response.send_message.await_args.args[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_reject_ai_strips_openai_recommendations_only():
+    draft = SetupPlanDraft(
+        recommendations=(
+            _rec(confidence="high", source="openai"),
+            _rec(
+                binding="audit_channel",
+                target_id=101,
+                confidence="high",
+                source="deterministic",
+            ),
+        ),
+        source="openai",
+    )
+    accepted = AcceptedSet()
+    accepted.add_many(draft.recommendations)
+    view = AIReviewPanelView(_author(), draft=draft, accepted=accepted)
+    interaction = _interaction()
+
+    await view._reject_ai.callback(interaction)
+
+    assert len(view.draft.recommendations) == 1
+    assert view.draft.recommendations[0].source == "deterministic"
+    # Accepted set drops the AI item too.
+    assert view.accepted.count == 1
+    assert view.accepted.recommendations[0].source == "deterministic"
+
+
+@pytest.mark.asyncio
+async def test_rerun_deterministic_replaces_draft():
+    snapshot = GuildSnapshot(guild_id=1, guild_name="x", owner_id=99)
+    deterministic_draft = SetupPlanDraft(
+        recommendations=(
+            _rec(confidence="medium", source="deterministic"),
+        ),
+        source="deterministic",
+    )
+
+    fake_advisor = MagicMock()
+    fake_advisor.suggest = AsyncMock(return_value=deterministic_draft)
+
+    view = AIReviewPanelView(
+        _author(),
+        draft=SetupPlanDraft(
+            recommendations=(_rec(source="openai", confidence="high"),),
+            source="openai",
+        ),
+        snapshot=snapshot,
+    )
+    interaction = _interaction()
+
+    with patch(
+        "views.setup.ai_review.main_panel.DeterministicAdvisor",
+        return_value=fake_advisor,
+    ):
+        await view._rerun_deterministic.callback(interaction)
+
+    fake_advisor.suggest.assert_awaited_once_with(snapshot)
+    assert view.draft is deterministic_draft
+
+
+@pytest.mark.asyncio
+async def test_rerun_deterministic_refuses_without_snapshot():
+    view = AIReviewPanelView(
+        _author(),
+        draft=SetupPlanDraft(recommendations=(_rec(),)),
+        snapshot=None,
+    )
+    interaction = _interaction()
+
+    await view._rerun_deterministic.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    assert (
+        "no snapshot"
+        in interaction.response.send_message.await_args.args[0].lower()
+    )
+
+
+# ---------------------------------------------------------------------------
+# PerRecommendationView
+# ---------------------------------------------------------------------------
+
+
+def test_per_recommendation_embed_renders_current_item():
+    draft = SetupPlanDraft(
+        recommendations=(
+            _rec(confidence="high"),
+            _rec(binding="audit_channel", target_id=101, confidence="medium"),
+        ),
+    )
+    accepted = AcceptedSet()
+    embed = build_per_recommendation_embed(draft, 1, accepted)
+    assert "2 / 2" in (embed.title or "")
+    assert "audit_channel" in (embed.description or "")
+
+
+@pytest.mark.asyncio
+async def test_per_recommendation_accept_advances():
+    draft = SetupPlanDraft(
+        recommendations=(
+            _rec(),
+            _rec(binding="audit_channel", target_id=101),
+        ),
+    )
+    accepted = AcceptedSet()
+    view = PerRecommendationView(
+        _author(),
+        draft=draft,
+        accepted=accepted,
+        index=0,
+    )
+    interaction = _interaction()
+
+    await view._accept.callback(interaction)
+
+    assert view.index == 1
+    assert accepted.count == 1
+
+
+@pytest.mark.asyncio
+async def test_per_recommendation_reject_removes_and_advances():
+    draft = SetupPlanDraft(recommendations=(_rec(),))
+    accepted = AcceptedSet()
+    accepted.add(draft.recommendations[0])
+    parent = AIReviewPanelView(_author(), draft=draft, accepted=accepted)
+    view = PerRecommendationView(
+        _author(),
+        draft=draft,
+        accepted=accepted,
+        index=0,
+        parent_view=parent,
+    )
+    interaction = _interaction()
+
+    await view._reject.callback(interaction)
+
+    assert accepted.count == 0
+    # End of list → returns to overview (parent's embed gets edited in).
+    interaction.response.edit_message.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_per_recommendation_skip_does_not_modify_accepted():
+    draft = SetupPlanDraft(
+        recommendations=(_rec(), _rec(binding="audit_channel", target_id=101)),
+    )
+    accepted = AcceptedSet()
+    view = PerRecommendationView(
+        _author(),
+        draft=draft,
+        accepted=accepted,
+        index=0,
+    )
+    interaction = _interaction()
+
+    await view._skip.callback(interaction)
+
+    assert view.index == 1
+    assert accepted.count == 0
+
+
+@pytest.mark.asyncio
+async def test_per_recommendation_end_of_list_returns_to_overview():
+    draft = SetupPlanDraft(recommendations=(_rec(),))
+    accepted = AcceptedSet()
+    parent = AIReviewPanelView(_author(), draft=draft, accepted=accepted)
+    view = PerRecommendationView(
+        _author(),
+        draft=draft,
+        accepted=accepted,
+        index=0,
+        parent_view=parent,
+    )
+    interaction = _interaction()
+
+    await view._skip.callback(interaction)
+
+    # The interaction got the parent view back.
+    new_view = interaction.response.edit_message.await_args.kwargs["view"]
+    assert new_view is parent
+
+
+@pytest.mark.asyncio
+async def test_per_recommendation_back_button_returns_immediately():
+    draft = SetupPlanDraft(
+        recommendations=(_rec(), _rec(binding="audit_channel", target_id=101)),
+    )
+    parent = AIReviewPanelView(_author(), draft=draft)
+    view = PerRecommendationView(
+        _author(),
+        draft=draft,
+        accepted=parent.accepted,
+        index=0,
+        parent_view=parent,
+    )
+    interaction = _interaction()
+
+    await view._back.callback(interaction)
+
+    # Returns immediately even at index 0.
+    new_view = interaction.response.edit_message.await_args.kwargs["view"]
+    assert new_view is parent
+
+
+# ---------------------------------------------------------------------------
+# Module invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "views.setup.ai_review.main_panel",
+        "views.setup.ai_review.per_recommendation",
+    ],
+)
+def test_module_has_no_db_imports(module_name):
+    import importlib
+
+    mod = importlib.import_module(module_name)
+    src = mod.__file__
+    assert src is not None
+    with open(src, encoding="utf-8") as fh:
+        text = fh.read()
+    for forbidden in ("from utils.db import", "import utils.db"):
+        assert forbidden not in text, (
+            f"{module_name} must not import {forbidden}; views never "
+            "write directly to the DB."
+        )
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "views.setup.ai_review.main_panel",
+        "views.setup.ai_review.per_recommendation",
+    ],
+)
+def test_module_has_no_direct_discord_create_calls(module_name):
+    import importlib
+
+    mod = importlib.import_module(module_name)
+    src = mod.__file__
+    assert src is not None
+    with open(src, encoding="utf-8") as fh:
+        text = fh.read()
+    for forbidden in (
+        "guild.create_text_channel",
+        "guild.create_role",
+        "guild.create_category",
+        "create_text_channel(",
+        "create_role(",
+        "create_category(",
+    ):
+        assert forbidden not in text, (
+            f"{module_name} must not call {forbidden}; route through "
+            "services.resource_provisioning when needed."
+        )


### PR DESCRIPTION
## Summary

Re-cut of **#187** (Track 5 PR 14). `AIReviewPanelView` + `PerRecommendationView` over a shared in-memory `AcceptedSet`. No apply behaviour, no DB writes, no Discord resource creation — invariants pinned by AST tests.

## Files restored

- `disbot/views/setup/ai_review/__init__.py` / `main_panel.py` / `per_recommendation.py` (~525 LOC).
- `tests/unit/views/setup/ai_review/__init__.py` + `test_ai_review_panels.py` (~470 LOC, 23 cases).

## Tests

```
python -m pytest tests/unit/views/setup/ai_review/ -q   # 23 passed
python -m pytest -q                                     # 2844 passed
ruff / black / isort / mypy                              # all green
```

## Risk

**Low.** Pure orchestration views.

## Chain status

PRs 1, 2, 3 merged. PRs 4 (#201) + this one in flight.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXdDyevoQLQXgmgog7erwY)_