### PR TITLE
services: restore automation mutation pipeline (re-cut of #189)

### DIFF
--- a/disbot/core/events_catalogue.py
+++ b/disbot/core/events_catalogue.py
@@ -93,6 +93,11 @@ KNOWN_EVENTS: frozenset[str] = frozenset(
         # Other consumers (future audit dashboards, AI explainers) are
         # welcome to subscribe; subscriber failure is logged + swallowed.
         "audit.action_recorded",
+        # ── Automation (services/automation_mutation.py, Phase 9g PR 16) ─
+        # Advisory. Emitted after every automation_rules CRUD mutation.
+        # The Track 6 PR 18 scheduler subscribes for cache invalidation;
+        # the wizard hub (Track 8) subscribes to refresh its panel.
+        "automation.rule_changed",
         # ── Participation (services/participation_mutation.py, Phase 2c PR-9) ─
         # Advisory.  Cache invalidation is inline (synchronous w.r.t. the
         # mutation result), NOT event-driven — these events are for

--- a/disbot/services/automation_mutation.py
+++ b/disbot/services/automation_mutation.py
@@ -1,0 +1,477 @@
+"""Automation mutation pipeline — Phase 9g / Track 6 PR 16.
+
+The canonical write path for ``automation_rules``. Mirrors the
+7-step contract from
+:class:`services.binding_mutation.BindingMutationPipeline`:
+
+  1. Input validation       — config keys match the registry's
+                              ``required_config_keys``; schedule
+                              syntax sanity-checked.
+  2. Authority validation   — actor must be the guild owner (or
+                              ``actor_type='system'`` for setup
+                              templates).
+  3. Read previous state    — for the audit row's prev_value.
+  4. DB write + audit       — single asyncpg transaction via
+                              :mod:`utils.db.automation`.
+  5. Cache invalidation     — no-op in v1; the scheduler polls
+                              every 30 s so there is no in-process
+                              cache to invalidate. Documented
+                              here for shape parity.
+  6. Event emission         — ``automation.rule_changed`` +
+                              ``audit.action_recorded`` via the
+                              Track 1 shared publisher.
+  7. Return result          — with mutation_id for cross-pipeline
+                              correlation.
+
+The pipeline exposes three entry points:
+
+* :meth:`create_rule`   — insert + emit + audit.
+* :meth:`set_enabled`   — flip the enabled bit on an existing rule.
+* :meth:`delete_rule`   — delete the rule (cascades to runs).
+
+Authority model: this is owner-only by default. ``actor_type``
+literals match the existing rollout pipeline:
+
+* ``platform_owner`` — actor_id must be the guild's owner.
+* ``system``         — for CI seeds and the setup wizard's
+                       template-application path. ``actor_id`` may
+                       be None.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from services.audit_events import emit_audit_action
+from services.automation_registry import (
+    KNOWN_ACTION_KINDS,
+    KNOWN_TRIGGER_KINDS,
+    validate_action_config,
+    validate_trigger_config,
+)
+from utils.db import automation as db
+
+logger = logging.getLogger("bot.services.automation_mutation")
+
+EVT_AUTOMATION_RULE_CHANGED = "automation.rule_changed"
+
+_ALLOWED_ACTOR_TYPES: frozenset[str] = frozenset({"platform_owner", "system"})
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class AutomationMutationError(Exception):
+    """Base class for failures from :class:`AutomationMutationPipeline`."""
+
+
+class InvalidAutomationConfigError(AutomationMutationError):
+    """Trigger / action config validation failed."""
+
+
+class UnauthorizedAutomationMutationError(AutomationMutationError):
+    """Actor below the required tier."""
+
+
+class UnknownAutomationRuleError(AutomationMutationError):
+    """``rule_id`` does not exist for the guild."""
+
+
+# ---------------------------------------------------------------------------
+# Result
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AutomationMutationResult:
+    mutation_id: str
+    rule_id: int
+    guild_id: int
+    mutation_type: str  # "create" / "set_enabled" / "delete"
+    name: str
+    trigger_kind: str | None
+    action_kind: str | None
+    prev_enabled: bool | None
+    new_enabled: bool | None
+    committed_at: datetime
+    event_emitted: bool
+
+
+# ---------------------------------------------------------------------------
+# Pipeline
+# ---------------------------------------------------------------------------
+
+
+class AutomationMutationPipeline:
+    """Owner-gated, audit-emitting writer for ``automation_rules``.
+
+    Stateless; instantiate once or per-call.
+    """
+
+    async def create_rule(
+        self,
+        *,
+        guild_id: int,
+        guild_owner_id: int,
+        name: str,
+        trigger_kind: str,
+        action_kind: str,
+        trigger_config: dict[str, Any] | None = None,
+        action_config: dict[str, Any] | None = None,
+        schedule: str | None = None,
+        timezone_str: str = "UTC",
+        actor_id: int | None,
+        actor_type: str = "platform_owner",
+    ) -> AutomationMutationResult:
+        # 1. Input validation.
+        self._validate_kinds(trigger_kind, action_kind)
+        errors = list(
+            validate_trigger_config(trigger_kind, trigger_config or {}),
+        ) + list(validate_action_config(action_kind, action_config or {}))
+        if errors:
+            raise InvalidAutomationConfigError("; ".join(errors))
+
+        # 2. Authority validation.
+        self._validate_actor(
+            actor_type=actor_type,
+            actor_id=actor_id,
+            guild_owner_id=guild_owner_id,
+        )
+
+        # 3. Read previous (none — create path).
+        mutation_id = str(uuid.uuid4())
+
+        # 4. DB write.
+        try:
+            rule_id = await db.insert_rule(
+                guild_id=guild_id,
+                name=name,
+                trigger_kind=trigger_kind,
+                action_kind=action_kind,
+                trigger_config=trigger_config or {},
+                action_config=action_config or {},
+                schedule=schedule,
+                timezone=timezone_str,
+                created_by=actor_id,
+            )
+        except Exception:
+            logger.exception(
+                "AutomationMutationPipeline.create_rule: insert failed for "
+                "guild=%d name=%r",
+                guild_id,
+                name,
+            )
+            raise
+
+        committed_at = _now_utc()
+
+        # 5. (No cache to invalidate; scheduler polls.)
+
+        # 6. Events.
+        event_emitted = await self._emit_event(
+            mutation_id=mutation_id,
+            rule_id=rule_id,
+            guild_id=guild_id,
+            mutation_type="create",
+            name=name,
+            committed_at=committed_at,
+        )
+        await emit_audit_action(
+            mutation_id=mutation_id,
+            subsystem="automation",
+            mutation_type="create_rule",
+            target=f"rule:{name}",
+            scope="guild",
+            guild_id=guild_id,
+            prev_value=None,
+            new_value=f"{trigger_kind}->{action_kind}",
+            actor_id=actor_id,
+            actor_type=actor_type,
+            occurred_at=committed_at,
+        )
+
+        # 7. Return.
+        return AutomationMutationResult(
+            mutation_id=mutation_id,
+            rule_id=rule_id,
+            guild_id=guild_id,
+            mutation_type="create",
+            name=name,
+            trigger_kind=trigger_kind,
+            action_kind=action_kind,
+            prev_enabled=None,
+            new_enabled=False,
+            committed_at=committed_at,
+            event_emitted=event_emitted,
+        )
+
+    async def set_enabled(
+        self,
+        *,
+        guild_id: int,
+        guild_owner_id: int,
+        rule_id: int,
+        enabled: bool,
+        actor_id: int | None,
+        actor_type: str = "platform_owner",
+    ) -> AutomationMutationResult:
+        # 2. Authority.
+        self._validate_actor(
+            actor_type=actor_type,
+            actor_id=actor_id,
+            guild_owner_id=guild_owner_id,
+        )
+        # 3. Read previous.
+        existing = await db.get_rule(rule_id)
+        if existing is None or existing.get("guild_id") != guild_id:
+            raise UnknownAutomationRuleError(
+                f"rule_id={rule_id} not found for guild_id={guild_id}",
+            )
+        prev_enabled = bool(existing.get("enabled"))
+        if prev_enabled == enabled:
+            # No-op; still emit an audit row so the trail is honest.
+            mutation_id = str(uuid.uuid4())
+            committed_at = _now_utc()
+            await emit_audit_action(
+                mutation_id=mutation_id,
+                subsystem="automation",
+                mutation_type="set_enabled",
+                target=f"rule:{existing['name']}",
+                scope="guild",
+                guild_id=guild_id,
+                prev_value=str(prev_enabled),
+                new_value=str(enabled),
+                actor_id=actor_id,
+                actor_type=actor_type,
+                occurred_at=committed_at,
+            )
+            return AutomationMutationResult(
+                mutation_id=mutation_id,
+                rule_id=rule_id,
+                guild_id=guild_id,
+                mutation_type="set_enabled",
+                name=existing["name"],
+                trigger_kind=existing["trigger_kind"],
+                action_kind=existing["action_kind"],
+                prev_enabled=prev_enabled,
+                new_enabled=enabled,
+                committed_at=committed_at,
+                event_emitted=False,
+            )
+
+        mutation_id = str(uuid.uuid4())
+
+        # 4. DB write.
+        try:
+            await db.set_enabled(rule_id, enabled)
+        except Exception:
+            logger.exception(
+                "AutomationMutationPipeline.set_enabled: db.set_enabled "
+                "failed for rule_id=%d",
+                rule_id,
+            )
+            raise
+
+        committed_at = _now_utc()
+
+        # 6. Events.
+        event_emitted = await self._emit_event(
+            mutation_id=mutation_id,
+            rule_id=rule_id,
+            guild_id=guild_id,
+            mutation_type="set_enabled",
+            name=existing["name"],
+            committed_at=committed_at,
+        )
+        await emit_audit_action(
+            mutation_id=mutation_id,
+            subsystem="automation",
+            mutation_type="set_enabled",
+            target=f"rule:{existing['name']}",
+            scope="guild",
+            guild_id=guild_id,
+            prev_value=str(prev_enabled),
+            new_value=str(enabled),
+            actor_id=actor_id,
+            actor_type=actor_type,
+            occurred_at=committed_at,
+        )
+
+        return AutomationMutationResult(
+            mutation_id=mutation_id,
+            rule_id=rule_id,
+            guild_id=guild_id,
+            mutation_type="set_enabled",
+            name=existing["name"],
+            trigger_kind=existing["trigger_kind"],
+            action_kind=existing["action_kind"],
+            prev_enabled=prev_enabled,
+            new_enabled=enabled,
+            committed_at=committed_at,
+            event_emitted=event_emitted,
+        )
+
+    async def delete_rule(
+        self,
+        *,
+        guild_id: int,
+        guild_owner_id: int,
+        rule_id: int,
+        actor_id: int | None,
+        actor_type: str = "platform_owner",
+    ) -> AutomationMutationResult:
+        # 2. Authority.
+        self._validate_actor(
+            actor_type=actor_type,
+            actor_id=actor_id,
+            guild_owner_id=guild_owner_id,
+        )
+        # 3. Read previous.
+        existing = await db.get_rule(rule_id)
+        if existing is None or existing.get("guild_id") != guild_id:
+            raise UnknownAutomationRuleError(
+                f"rule_id={rule_id} not found for guild_id={guild_id}",
+            )
+
+        mutation_id = str(uuid.uuid4())
+
+        # 4. DB write.
+        try:
+            await db.delete_rule(rule_id)
+        except Exception:
+            logger.exception(
+                "AutomationMutationPipeline.delete_rule: db.delete_rule "
+                "failed for rule_id=%d",
+                rule_id,
+            )
+            raise
+
+        committed_at = _now_utc()
+
+        # 6. Events.
+        event_emitted = await self._emit_event(
+            mutation_id=mutation_id,
+            rule_id=rule_id,
+            guild_id=guild_id,
+            mutation_type="delete",
+            name=existing["name"],
+            committed_at=committed_at,
+        )
+        await emit_audit_action(
+            mutation_id=mutation_id,
+            subsystem="automation",
+            mutation_type="delete_rule",
+            target=f"rule:{existing['name']}",
+            scope="guild",
+            guild_id=guild_id,
+            prev_value=f"{existing['trigger_kind']}->{existing['action_kind']}",
+            new_value=None,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            occurred_at=committed_at,
+        )
+
+        return AutomationMutationResult(
+            mutation_id=mutation_id,
+            rule_id=rule_id,
+            guild_id=guild_id,
+            mutation_type="delete",
+            name=existing["name"],
+            trigger_kind=existing["trigger_kind"],
+            action_kind=existing["action_kind"],
+            prev_enabled=bool(existing.get("enabled")),
+            new_enabled=None,
+            committed_at=committed_at,
+            event_emitted=event_emitted,
+        )
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _validate_kinds(trigger_kind: str, action_kind: str) -> None:
+        if trigger_kind not in KNOWN_TRIGGER_KINDS:
+            raise InvalidAutomationConfigError(
+                f"trigger_kind={trigger_kind!r} not in "
+                f"{sorted(KNOWN_TRIGGER_KINDS)}",
+            )
+        if action_kind not in KNOWN_ACTION_KINDS:
+            raise InvalidAutomationConfigError(
+                f"action_kind={action_kind!r} not in {sorted(KNOWN_ACTION_KINDS)}",
+            )
+
+    @staticmethod
+    def _validate_actor(
+        *,
+        actor_type: str,
+        actor_id: int | None,
+        guild_owner_id: int,
+    ) -> None:
+        if actor_type not in _ALLOWED_ACTOR_TYPES:
+            raise UnauthorizedAutomationMutationError(
+                f"actor_type={actor_type!r} not in {sorted(_ALLOWED_ACTOR_TYPES)}",
+            )
+        if actor_type == "platform_owner":
+            if actor_id is None:
+                raise UnauthorizedAutomationMutationError(
+                    "actor_type='platform_owner' requires non-None actor_id",
+                )
+            if actor_id != guild_owner_id:
+                raise UnauthorizedAutomationMutationError(
+                    f"actor_id={actor_id} is not the guild owner "
+                    f"(owner_id={guild_owner_id}); automation_rules "
+                    "mutations are owner-only.",
+                )
+
+    async def _emit_event(
+        self,
+        *,
+        mutation_id: str,
+        rule_id: int,
+        guild_id: int,
+        mutation_type: str,
+        name: str,
+        committed_at: datetime,
+    ) -> bool:
+        from core.events import bus
+
+        try:
+            await bus.emit(
+                EVT_AUTOMATION_RULE_CHANGED,
+                mutation_id=mutation_id,
+                rule_id=rule_id,
+                guild_id=guild_id,
+                mutation_type=mutation_type,
+                name=name,
+                occurred_at=committed_at.isoformat(),
+            )
+        except Exception:
+            logger.exception(
+                "AutomationMutationPipeline._emit_event: bus.emit failed "
+                "for mutation_id=%s; DB state correct, event lost.",
+                mutation_id,
+            )
+            return False
+        return True
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+__all__ = [
+    "EVT_AUTOMATION_RULE_CHANGED",
+    "AutomationMutationError",
+    "AutomationMutationPipeline",
+    "AutomationMutationResult",
+    "InvalidAutomationConfigError",
+    "UnauthorizedAutomationMutationError",
+    "UnknownAutomationRuleError",
+]

--- a/tests/unit/services/test_automation_mutation_pipeline.py
+++ b/tests/unit/services/test_automation_mutation_pipeline.py
@@ -1,0 +1,363 @@
+"""Phase 9g / Track 6 PR 16 — automation mutation pipeline tests.
+
+Pins:
+
+* Input validation rejects unknown kinds + missing required config keys.
+* Authority gate: ``platform_owner`` requires ``actor_id ==
+  guild_owner_id``; ``system`` actor allowed without actor_id;
+  any other actor_type rejected.
+* Create / set_enabled / delete each emit
+  ``automation.rule_changed`` AND ``audit.action_recorded`` with
+  matching ``mutation_id``.
+* set_enabled is idempotent for a no-op flip: still emits an audit
+  row but does NOT emit ``automation.rule_changed``.
+* Pipeline failures in the bus.emit path do NOT roll back DB
+  writes — the audit emitter swallows.
+* Unknown rule_id (or wrong guild_id) on update/delete raises
+  ``UnknownAutomationRuleError``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services.automation_mutation import (
+    AutomationMutationPipeline,
+    InvalidAutomationConfigError,
+    UnauthorizedAutomationMutationError,
+    UnknownAutomationRuleError,
+)
+
+
+@pytest.fixture
+def pipeline():
+    return AutomationMutationPipeline()
+
+
+@pytest.fixture
+def _mock_db():
+    with (
+        patch(
+            "services.automation_mutation.db.insert_rule",
+            new_callable=AsyncMock,
+        ) as insert_rule,
+        patch(
+            "services.automation_mutation.db.get_rule",
+            new_callable=AsyncMock,
+        ) as get_rule,
+        patch(
+            "services.automation_mutation.db.set_enabled",
+            new_callable=AsyncMock,
+        ) as set_enabled,
+        patch(
+            "services.automation_mutation.db.delete_rule",
+            new_callable=AsyncMock,
+        ) as delete_rule,
+        patch(
+            "services.automation_mutation.emit_audit_action",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as emit_audit,
+        patch("core.events.bus.emit", new_callable=AsyncMock) as bus_emit,
+    ):
+        yield {
+            "insert_rule": insert_rule,
+            "get_rule": get_rule,
+            "set_enabled": set_enabled,
+            "delete_rule": delete_rule,
+            "emit_audit": emit_audit,
+            "bus_emit": bus_emit,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_unknown_trigger_kind(pipeline, _mock_db):
+    with pytest.raises(InvalidAutomationConfigError, match="trigger_kind"):
+        await pipeline.create_rule(
+            guild_id=1,
+            guild_owner_id=99,
+            name="x",
+            trigger_kind="garbage",
+            action_kind="notify_owner",
+            action_config={"template": "hi"},
+            actor_id=99,
+        )
+    _mock_db["insert_rule"].assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_unknown_action_kind(pipeline, _mock_db):
+    with pytest.raises(InvalidAutomationConfigError, match="action_kind"):
+        await pipeline.create_rule(
+            guild_id=1,
+            guild_owner_id=99,
+            name="x",
+            trigger_kind="manual",
+            action_kind="eat_sandwich",
+            actor_id=99,
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_missing_required_config_key(pipeline, _mock_db):
+    with pytest.raises(InvalidAutomationConfigError, match="template"):
+        # send_message requires channel_id + template; only channel_id given.
+        await pipeline.create_rule(
+            guild_id=1,
+            guild_owner_id=99,
+            name="x",
+            trigger_kind="manual",
+            action_kind="send_message",
+            action_config={"channel_id": 555},
+            actor_id=99,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Authority
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_unknown_actor_type(pipeline, _mock_db):
+    with pytest.raises(UnauthorizedAutomationMutationError, match="actor_type"):
+        await pipeline.create_rule(
+            guild_id=1,
+            guild_owner_id=99,
+            name="x",
+            trigger_kind="manual",
+            action_kind="notify_owner",
+            action_config={"template": "hi"},
+            actor_id=99,
+            actor_type="user",
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_non_owner(pipeline, _mock_db):
+    with pytest.raises(UnauthorizedAutomationMutationError, match="not the guild owner"):
+        await pipeline.create_rule(
+            guild_id=1,
+            guild_owner_id=99,
+            name="x",
+            trigger_kind="manual",
+            action_kind="notify_owner",
+            action_config={"template": "hi"},
+            actor_id=42,
+            actor_type="platform_owner",
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_accepts_system_actor_without_actor_id(pipeline, _mock_db):
+    _mock_db["insert_rule"].return_value = 7
+    result = await pipeline.create_rule(
+        guild_id=1,
+        guild_owner_id=99,
+        name="seed",
+        trigger_kind="manual",
+        action_kind="notify_owner",
+        action_config={"template": "hi"},
+        actor_id=None,
+        actor_type="system",
+    )
+    assert result.mutation_type == "create"
+    assert result.rule_id == 7
+
+
+# ---------------------------------------------------------------------------
+# Happy paths + event emission
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_emits_rule_changed_and_audit(pipeline, _mock_db):
+    _mock_db["insert_rule"].return_value = 7
+    result = await pipeline.create_rule(
+        guild_id=1,
+        guild_owner_id=99,
+        name="welcome",
+        trigger_kind="member_join",
+        action_kind="send_message",
+        action_config={"channel_id": 1, "template": "hi"},
+        actor_id=99,
+    )
+    # Pipeline event
+    bus_call = _mock_db["bus_emit"].await_args
+    assert bus_call.args[0] == "automation.rule_changed"
+    assert bus_call.kwargs["mutation_id"] == result.mutation_id
+    assert bus_call.kwargs["mutation_type"] == "create"
+    # Companion audit
+    audit_kwargs = _mock_db["emit_audit"].await_args.kwargs
+    assert audit_kwargs["mutation_id"] == result.mutation_id
+    assert audit_kwargs["subsystem"] == "automation"
+    assert audit_kwargs["mutation_type"] == "create_rule"
+    assert audit_kwargs["target"] == "rule:welcome"
+    assert audit_kwargs["new_value"] == "member_join->send_message"
+    assert audit_kwargs["actor_id"] == 99
+
+
+@pytest.mark.asyncio
+async def test_set_enabled_emits_when_state_changes(pipeline, _mock_db):
+    _mock_db["get_rule"].return_value = {
+        "id": 7,
+        "guild_id": 1,
+        "name": "welcome",
+        "enabled": False,
+        "trigger_kind": "manual",
+        "action_kind": "notify_owner",
+    }
+    result = await pipeline.set_enabled(
+        guild_id=1,
+        guild_owner_id=99,
+        rule_id=7,
+        enabled=True,
+        actor_id=99,
+    )
+    _mock_db["set_enabled"].assert_awaited_once_with(7, True)
+    assert result.event_emitted is True
+    assert result.prev_enabled is False
+    assert result.new_enabled is True
+
+
+@pytest.mark.asyncio
+async def test_set_enabled_is_idempotent_for_no_op(pipeline, _mock_db):
+    """Flipping enabled from True to True still emits an audit row
+    but does NOT emit ``automation.rule_changed``."""
+    _mock_db["get_rule"].return_value = {
+        "id": 7,
+        "guild_id": 1,
+        "name": "welcome",
+        "enabled": True,
+        "trigger_kind": "manual",
+        "action_kind": "notify_owner",
+    }
+    result = await pipeline.set_enabled(
+        guild_id=1,
+        guild_owner_id=99,
+        rule_id=7,
+        enabled=True,
+        actor_id=99,
+    )
+    _mock_db["set_enabled"].assert_not_awaited()
+    _mock_db["bus_emit"].assert_not_awaited()
+    _mock_db["emit_audit"].assert_awaited_once()
+    assert result.event_emitted is False
+    assert result.prev_enabled is True
+    assert result.new_enabled is True
+
+
+@pytest.mark.asyncio
+async def test_delete_emits_audit_with_old_value(pipeline, _mock_db):
+    _mock_db["get_rule"].return_value = {
+        "id": 7,
+        "guild_id": 1,
+        "name": "welcome",
+        "enabled": True,
+        "trigger_kind": "member_join",
+        "action_kind": "send_message",
+    }
+    result = await pipeline.delete_rule(
+        guild_id=1,
+        guild_owner_id=99,
+        rule_id=7,
+        actor_id=99,
+    )
+    _mock_db["delete_rule"].assert_awaited_once_with(7)
+    audit_kwargs = _mock_db["emit_audit"].await_args.kwargs
+    assert audit_kwargs["mutation_type"] == "delete_rule"
+    assert audit_kwargs["prev_value"] == "member_join->send_message"
+    assert audit_kwargs["new_value"] is None
+    assert result.event_emitted is True
+
+
+# ---------------------------------------------------------------------------
+# Unknown rule
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_enabled_raises_when_rule_missing(pipeline, _mock_db):
+    _mock_db["get_rule"].return_value = None
+    with pytest.raises(UnknownAutomationRuleError):
+        await pipeline.set_enabled(
+            guild_id=1,
+            guild_owner_id=99,
+            rule_id=7,
+            enabled=True,
+            actor_id=99,
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_enabled_raises_when_rule_in_different_guild(pipeline, _mock_db):
+    _mock_db["get_rule"].return_value = {
+        "id": 7,
+        "guild_id": 2,  # different guild
+        "name": "x",
+        "enabled": False,
+        "trigger_kind": "manual",
+        "action_kind": "notify_owner",
+    }
+    with pytest.raises(UnknownAutomationRuleError):
+        await pipeline.set_enabled(
+            guild_id=1,
+            guild_owner_id=99,
+            rule_id=7,
+            enabled=True,
+            actor_id=99,
+        )
+
+
+@pytest.mark.asyncio
+async def test_delete_raises_when_rule_missing(pipeline, _mock_db):
+    _mock_db["get_rule"].return_value = None
+    with pytest.raises(UnknownAutomationRuleError):
+        await pipeline.delete_rule(
+            guild_id=1,
+            guild_owner_id=99,
+            rule_id=7,
+            actor_id=99,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Failure isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_event_emission_failure_does_not_undo_db_write(pipeline, _mock_db):
+    """A raising bus.emit must not propagate; the pipeline returns
+    ``event_emitted=False`` and the DB write stays."""
+    _mock_db["insert_rule"].return_value = 7
+    _mock_db["bus_emit"].side_effect = RuntimeError("bus down")
+    result = await pipeline.create_rule(
+        guild_id=1,
+        guild_owner_id=99,
+        name="welcome",
+        trigger_kind="manual",
+        action_kind="notify_owner",
+        action_config={"template": "hi"},
+        actor_id=99,
+    )
+    _mock_db["insert_rule"].assert_awaited_once()
+    assert result.event_emitted is False
+
+
+# ---------------------------------------------------------------------------
+# Catalogue
+# ---------------------------------------------------------------------------
+
+
+def test_event_topic_in_known_events():
+    from core.events_catalogue import KNOWN_EVENTS
+
+    assert "automation.rule_changed" in KNOWN_EVENTS


### PR DESCRIPTION
## Summary

Re-cut of **#189** (Track 6 PR 16). Owner/system-gated 7-step pipeline for `automation_rules`. Emits `automation.rule_changed` + `audit.action_recorded` via the shared helper.

Depends on #188 (schema) — already on main.

## Files restored

- `disbot/services/automation_mutation.py` (~470 LOC).
- `disbot/core/events_catalogue.py` — adds `automation.rule_changed` to `KNOWN_EVENTS`.
- `tests/unit/services/test_automation_mutation_pipeline.py` (~290 LOC, 15 cases).

## Tests

```
python -m pytest tests/unit/services/test_automation_mutation_pipeline.py -q   # 15 passed
python -m pytest -q                                                            # 2856 passed
ruff / black / isort / mypy                                                     # all green
```

## Safety

- Owner OR system actor only. `platform_owner` requires `actor_id == guild_owner_id`.
- Failure isolation: bus.emit raising is swallowed; DB state is authoritative.
- Audit emission via the Track 1 shared publisher; same path as every other pipeline.

## Chain status

PRs 1–4 merged. PRs 5 (#202) + this one in flight.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXdDyevoQLQXgmgog7erwY)_