### PR TITLE
services+templates: channel templates / server presets (Track 7 PR 21)

### DIFF
--- a/disbot/services/automation_templates.py
+++ b/disbot/services/automation_templates.py
@@ -212,6 +212,370 @@ TEMPLATES: tuple[AutomationTemplate, ...] = _ONBOARDING_TEMPLATES
 
 
 # ---------------------------------------------------------------------------
+# Server presets (Track 7 PR 21)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PresetOperation:
+    """One step of a :class:`ServerPreset`.
+
+    Operations stay in this leaf-level shape rather than reaching
+    into pipeline APIs directly so the wizard can preview the full
+    plan without touching Discord. ``kind`` literals:
+
+    * ``"bind_channel"``  — operator selects an existing channel.
+    * ``"create_channel"`` — provisioning pipeline creates it.
+    * ``"create_role"``   — wizard creates the role (Track 8).
+    * ``"add_rule"``      — apply an :class:`AutomationTemplate` by
+                            slug with operator-supplied overrides.
+    * ``"set_setting"``   — settings_mutation pipeline.
+    * ``"set_binding_target"`` — binding_mutation pipeline against
+                            an already-bound channel/role.
+    """
+
+    kind: str
+    description: str
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ServerPreset:
+    """One named bundle of operations the wizard can apply at once."""
+
+    slug: str
+    display_name: str
+    description: str
+    operations: tuple[PresetOperation, ...] = ()
+    suggested_role_names: tuple[str, ...] = ()
+    suggested_categories: tuple[str, ...] = ()
+    suggested_log_channels: tuple[str, ...] = ()
+    suggested_command_channels: tuple[str, ...] = ()
+
+    def operations_of_kind(self, kind: str) -> tuple[PresetOperation, ...]:
+        return tuple(op for op in self.operations if op.kind == kind)
+
+
+@dataclass(frozen=True)
+class ReuseCandidate:
+    """One operator-visible suggestion: 'reuse this existing channel
+    instead of creating a new one'.
+    """
+
+    operation_index: int
+    suggested_name: str
+    existing_channel_id: int | None = None
+    existing_role_id: int | None = None
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class PresetPreview:
+    """What :func:`apply_preset` would do.
+
+    Pure read; tests pin that constructing this never touches the
+    Discord API or the DB.
+    """
+
+    preset_slug: str
+    operations: tuple[PresetOperation, ...] = ()
+    reuse_candidates: tuple[ReuseCandidate, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+    @property
+    def operation_count(self) -> int:
+        return len(self.operations)
+
+
+_SERVER_PRESETS: tuple[ServerPreset, ...] = (
+    ServerPreset(
+        slug="minimal",
+        display_name="Minimal",
+        description=(
+            "Bare-bones setup: a rules channel binding + a mod log channel "
+            "binding. Nothing else."
+        ),
+        suggested_log_channels=("bot-mod-log",),
+        operations=(
+            PresetOperation(
+                kind="bind_channel",
+                description="Bind the rules channel.",
+                payload={
+                    "subsystem": "logging",
+                    "binding_name": "rules_channel",
+                },
+            ),
+            PresetOperation(
+                kind="bind_channel",
+                description="Bind the moderation log channel.",
+                payload={
+                    "subsystem": "logging",
+                    "binding_name": "mod_channel",
+                },
+            ),
+        ),
+    ),
+    ServerPreset(
+        slug="community",
+        display_name="Community",
+        description=(
+            "Welcome flow + general / off-topic channel bindings + "
+            "moderation log + new-member role."
+        ),
+        suggested_categories=("Community",),
+        suggested_log_channels=("bot-mod-log",),
+        suggested_command_channels=("bot-commands",),
+        suggested_role_names=("New Member",),
+        operations=(
+            PresetOperation(
+                kind="bind_channel",
+                description="Bind the welcome channel.",
+                payload={
+                    "subsystem": "onboarding",
+                    "binding_name": "welcome_channel",
+                },
+            ),
+            PresetOperation(
+                kind="bind_channel",
+                description="Bind the rules channel.",
+                payload={
+                    "subsystem": "logging",
+                    "binding_name": "rules_channel",
+                },
+            ),
+            PresetOperation(
+                kind="bind_channel",
+                description="Bind the moderation log channel.",
+                payload={
+                    "subsystem": "logging",
+                    "binding_name": "mod_channel",
+                },
+            ),
+            PresetOperation(
+                kind="add_rule",
+                description="Welcome message on member join.",
+                payload={"template_slug": "welcome-message"},
+            ),
+            PresetOperation(
+                kind="add_rule",
+                description="Auto-assign New Member role on join.",
+                payload={"template_slug": "new-member-role"},
+            ),
+        ),
+    ),
+    ServerPreset(
+        slug="gaming",
+        display_name="Gaming",
+        description=(
+            "Community preset plus a games / leaderboard hub channel binding."
+        ),
+        suggested_categories=("Games",),
+        suggested_log_channels=("bot-mod-log",),
+        suggested_command_channels=("bot-commands",),
+        operations=(
+            PresetOperation(
+                kind="bind_channel",
+                description="Bind the rules channel.",
+                payload={
+                    "subsystem": "logging",
+                    "binding_name": "rules_channel",
+                },
+            ),
+            PresetOperation(
+                kind="bind_channel",
+                description="Bind the moderation log channel.",
+                payload={
+                    "subsystem": "logging",
+                    "binding_name": "mod_channel",
+                },
+            ),
+            PresetOperation(
+                kind="bind_channel",
+                description="Bind the leaderboard / counting channel.",
+                payload={
+                    "subsystem": "counting",
+                    "binding_name": "channel",
+                },
+            ),
+            PresetOperation(
+                kind="add_rule",
+                description="Notify staff when a new member joins.",
+                payload={"template_slug": "notify-staff-on-join"},
+            ),
+        ),
+    ),
+    ServerPreset(
+        slug="moderation-heavy",
+        display_name="Moderation heavy",
+        description=(
+            "Strict log routing: mod / cleanup / audit channels each "
+            "bound to dedicated channels."
+        ),
+        suggested_categories=("Moderation",),
+        suggested_log_channels=("bot-mod-log", "bot-cleanup-log", "bot-audit-log"),
+        operations=(
+            PresetOperation(
+                kind="bind_channel",
+                description="Bind the rules channel.",
+                payload={
+                    "subsystem": "logging",
+                    "binding_name": "rules_channel",
+                },
+            ),
+            PresetOperation(
+                kind="bind_channel",
+                description="Bind the moderation log channel.",
+                payload={
+                    "subsystem": "logging",
+                    "binding_name": "mod_channel",
+                },
+            ),
+            PresetOperation(
+                kind="bind_channel",
+                description="Bind the cleanup log channel.",
+                payload={
+                    "subsystem": "logging",
+                    "binding_name": "cleanup_channel",
+                },
+            ),
+            PresetOperation(
+                kind="bind_channel",
+                description="Bind the audit log channel.",
+                payload={
+                    "subsystem": "logging",
+                    "binding_name": "audit_channel",
+                },
+            ),
+            PresetOperation(
+                kind="set_setting",
+                description="Turn logging on.",
+                payload={
+                    "subsystem": "logging",
+                    "name": "enabled",
+                    "value": True,
+                },
+            ),
+        ),
+    ),
+    ServerPreset(
+        slug="economy",
+        display_name="Economy",
+        description=("Bind economy + shop channels and seed the welcome message."),
+        suggested_categories=("Economy",),
+        operations=(
+            PresetOperation(
+                kind="bind_channel",
+                description="Bind the economy announce channel.",
+                payload={
+                    "subsystem": "economy",
+                    "binding_name": "announce_channel",
+                },
+            ),
+            PresetOperation(
+                kind="bind_channel",
+                description="Bind the moderation log channel.",
+                payload={
+                    "subsystem": "logging",
+                    "binding_name": "mod_channel",
+                },
+            ),
+            PresetOperation(
+                kind="add_rule",
+                description="Welcome message on member join.",
+                payload={"template_slug": "welcome-message"},
+            ),
+        ),
+    ),
+    ServerPreset(
+        slug="custom",
+        display_name="Custom",
+        description=(
+            "Empty preset — the wizard builds the operations list as the "
+            "operator picks each binding."
+        ),
+        operations=(),
+    ),
+)
+
+
+SERVER_PRESETS: tuple[ServerPreset, ...] = _SERVER_PRESETS
+
+
+def known_preset_slugs() -> frozenset[str]:
+    return frozenset(p.slug for p in SERVER_PRESETS)
+
+
+def get_preset(slug: str) -> ServerPreset | None:
+    for preset in SERVER_PRESETS:
+        if preset.slug == slug:
+            return preset
+    return None
+
+
+def preview_preset(
+    preset: ServerPreset,
+    *,
+    existing_channels: dict[str, int] | None = None,
+    existing_roles: dict[str, int] | None = None,
+) -> PresetPreview:
+    """Render the preset against the operator's current resources.
+
+    Pure read — no Discord API, no DB. Returns the planned
+    operations alongside reuse candidates: when ``existing_channels``
+    or ``existing_roles`` contain a name that matches a suggested
+    resource, surface it so the wizard can offer "reuse" instead of
+    "create".
+    """
+    existing_channels = existing_channels or {}
+    existing_roles = existing_roles or {}
+    reuse: list[ReuseCandidate] = []
+    warnings: list[str] = []
+
+    for index, op in enumerate(preset.operations):
+        if op.kind == "create_channel":
+            name = str(op.payload.get("name") or "")
+            channel_id = existing_channels.get(name.lower())
+            if channel_id is not None:
+                reuse.append(
+                    ReuseCandidate(
+                        operation_index=index,
+                        suggested_name=name,
+                        existing_channel_id=channel_id,
+                        reason=f"channel #{name} already exists; reuse it.",
+                    ),
+                )
+        elif op.kind == "create_role":
+            name = str(op.payload.get("name") or "")
+            role_id = existing_roles.get(name.lower())
+            if role_id is not None:
+                reuse.append(
+                    ReuseCandidate(
+                        operation_index=index,
+                        suggested_name=name,
+                        existing_role_id=role_id,
+                        reason=f"role @{name} already exists; reuse it.",
+                    ),
+                )
+
+    # Sanity warnings: every "add_rule" must reference a known
+    # template slug.
+    for index, op in enumerate(preset.operations):
+        if op.kind == "add_rule":
+            slug = str(op.payload.get("template_slug") or "")
+            if get_template(slug) is None:
+                warnings.append(
+                    f"operation[{index}]: unknown template slug {slug!r}",
+                )
+
+    return PresetPreview(
+        preset_slug=preset.slug,
+        operations=preset.operations,
+        reuse_candidates=tuple(reuse),
+        warnings=tuple(warnings),
+    )
+
+
+# ---------------------------------------------------------------------------
 # Lookup helpers
 # ---------------------------------------------------------------------------
 
@@ -232,9 +596,17 @@ def known_slugs() -> frozenset[str]:
 
 
 __all__ = [
+    "SERVER_PRESETS",
     "TEMPLATES",
     "AutomationTemplate",
+    "PresetOperation",
+    "PresetPreview",
+    "ReuseCandidate",
+    "ServerPreset",
+    "get_preset",
     "get_template",
+    "known_preset_slugs",
     "known_slugs",
     "list_templates_by_category",
+    "preview_preset",
 ]

--- a/tests/unit/services/test_server_presets.py
+++ b/tests/unit/services/test_server_presets.py
@@ -1,0 +1,173 @@
+"""Phase 9h / Track 7 PR 21 — server preset templates tests.
+
+Pins:
+
+* 6 documented presets (Minimal / Community / Gaming /
+  Moderation heavy / Economy / Custom) appear in
+  ``SERVER_PRESETS``.
+* ``get_preset`` returns the matching preset or ``None``.
+* ``preview_preset`` is pure — never calls Discord or DB; tests
+  rely on a stub-channels-only fixture and assert the planned
+  operations stay unchanged.
+* Reuse-candidate detection: ``preview_preset`` flags
+  ``create_channel`` operations whose suggested name already
+  exists in the operator's current resources.
+* Sanity check: ``add_rule`` operations referencing an unknown
+  template slug surface as warnings.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from services.automation_templates import (
+    SERVER_PRESETS,
+    PresetOperation,
+    ReuseCandidate,
+    ServerPreset,
+    get_preset,
+    known_preset_slugs,
+    preview_preset,
+)
+
+
+def test_documented_preset_slugs():
+    assert known_preset_slugs() == {
+        "minimal",
+        "community",
+        "gaming",
+        "moderation-heavy",
+        "economy",
+        "custom",
+    }
+
+
+@pytest.mark.parametrize("slug", sorted(known_preset_slugs()))
+def test_get_preset_returns_match(slug):
+    preset = get_preset(slug)
+    assert isinstance(preset, ServerPreset)
+    assert preset.slug == slug
+
+
+def test_get_preset_returns_none_for_unknown_slug():
+    assert get_preset("does-not-exist") is None
+
+
+@pytest.mark.parametrize("slug", sorted(known_preset_slugs()))
+def test_preview_preserves_operations(slug):
+    preset = get_preset(slug)
+    assert preset is not None
+    preview = preview_preset(preset)
+    assert preview.operations == preset.operations
+    assert preview.preset_slug == slug
+
+
+def test_preview_is_a_pure_read():
+    """No Discord or DB call should happen during preview;
+    if the test fixture's "existing_channels" dict shows up as
+    keys, we know no resolution leaked through."""
+    preset = get_preset("community")
+    assert preset is not None
+    preview = preview_preset(preset)
+    assert preview.reuse_candidates == ()
+    assert preview.warnings == ()
+
+
+def test_preview_emits_reuse_candidate_when_create_channel_already_exists():
+    preset = ServerPreset(
+        slug="probe",
+        display_name="Probe",
+        description="",
+        operations=(
+            PresetOperation(
+                kind="create_channel",
+                description="Create bot-mod-log.",
+                payload={"name": "bot-mod-log"},
+            ),
+        ),
+    )
+    preview = preview_preset(
+        preset,
+        existing_channels={"bot-mod-log": 12345},
+    )
+    assert len(preview.reuse_candidates) == 1
+    candidate = preview.reuse_candidates[0]
+    assert isinstance(candidate, ReuseCandidate)
+    assert candidate.suggested_name == "bot-mod-log"
+    assert candidate.existing_channel_id == 12345
+
+
+def test_preview_emits_reuse_candidate_when_create_role_already_exists():
+    preset = ServerPreset(
+        slug="probe",
+        display_name="Probe",
+        description="",
+        operations=(
+            PresetOperation(
+                kind="create_role",
+                description="Create New Member role.",
+                payload={"name": "New Member"},
+            ),
+        ),
+    )
+    preview = preview_preset(
+        preset,
+        existing_roles={"new member": 9999},
+    )
+    assert len(preview.reuse_candidates) == 1
+    candidate = preview.reuse_candidates[0]
+    assert candidate.existing_role_id == 9999
+
+
+def test_preview_warns_on_unknown_template_slug():
+    preset = ServerPreset(
+        slug="probe",
+        display_name="Probe",
+        description="",
+        operations=(
+            PresetOperation(
+                kind="add_rule",
+                description="Apply a non-existent rule.",
+                payload={"template_slug": "does-not-exist"},
+            ),
+        ),
+    )
+    preview = preview_preset(preset)
+    assert any("unknown template slug" in w for w in preview.warnings)
+
+
+def test_minimal_preset_binds_rules_and_mod_log_only():
+    preset = get_preset("minimal")
+    assert preset is not None
+    binding_targets = {
+        op.payload["binding_name"]
+        for op in preset.operations_of_kind("bind_channel")
+    }
+    assert binding_targets == {"rules_channel", "mod_channel"}
+
+
+def test_community_preset_includes_welcome_and_role_rules():
+    preset = get_preset("community")
+    assert preset is not None
+    add_rule_slugs = {
+        op.payload["template_slug"]
+        for op in preset.operations_of_kind("add_rule")
+    }
+    assert "welcome-message" in add_rule_slugs
+    assert "new-member-role" in add_rule_slugs
+
+
+def test_moderation_heavy_includes_audit_and_cleanup_channels():
+    preset = get_preset("moderation-heavy")
+    assert preset is not None
+    binding_targets = {
+        op.payload["binding_name"]
+        for op in preset.operations_of_kind("bind_channel")
+    }
+    assert binding_targets >= {"audit_channel", "cleanup_channel", "mod_channel"}
+
+
+def test_custom_preset_has_no_operations():
+    preset = get_preset("custom")
+    assert preset is not None
+    assert preset.operations == ()


### PR DESCRIPTION
## Summary

Restores the channel-template / server-preset module that was originally landed via #194. Extends `automation_templates.py` with the six documented server presets: Minimal / Community / Gaming / Moderation heavy / Economy / Custom. Each preset is a typed bundle of `PresetOperation` records — pure read previews; apply is the wizard hub's responsibility (Track 8 PR 23).

Re-cut directly off `origin/main` after #205 (onboarding templates) merged.

## Scope

### Does

- Extend `disbot/services/automation_templates.py` (+372 LOC)
- Public surface added:
  - `ServerPreset` — frozen dataclass (`slug`, `display_name`, `description`, `operations`, suggested-resource hints)
  - `PresetOperation` — frozen tagged-union row, `kind` literal: `bind_channel` | `create_channel` | `create_role` | `add_rule` | `set_setting` | `set_binding_target`
  - `PresetPreview` + `ReuseCandidate` — preview shapes for the wizard
  - `SERVER_PRESETS` — tuple of the six presets
  - `get_preset(slug)` / `known_preset_slugs()` — lookup
  - `preview_preset(preset, *, existing_channels, existing_roles)` — pure read, flags reuse candidates
- Add `tests/unit/services/test_server_presets.py` (22 cases)

### Does NOT

- **No apply path** — wizard hub (Track 8 PR 23) owns routing through existing pipelines
- No auto-delete (presets only add or bind)
- No DB schema change
- No new resource catalogue entries

## Files changed

| File | Status | LOC |
|---|---|---|
| `disbot/services/automation_templates.py` | modified | +372 |
| `tests/unit/services/test_server_presets.py` | added | 173 |

## Architecture impact

- Apply path (deferred to Track 8 PR 23) routes each operation through existing pipelines:
  - `bind_channel` / `set_binding_target` → `BindingMutationPipeline`
  - `create_channel` / `create_role` → `ResourceProvisioningPipeline`
  - `add_rule` → `AutomationMutationPipeline.create_rule`
  - `set_setting` → `SettingsMutationPipeline`
- No direct Discord resource creation; preview only flags reuse candidates.

## Tests run

```
python -m pytest tests/unit/services/test_automation_templates.py tests/unit/services/test_server_presets.py -q
# 42 passed, 1 skipped

ruff check . --exclude .github,tests,venv,env,build,dist  # clean
black --check . --exclude '(\.github|tests|venv|env|build|dist)'  # clean
isort --check-only . --skip-glob '*/(\.github|tests|venv|env|build|dist)/*'  # clean
mypy disbot/  # 315 source files, no issues
```

## Manual smoke

- PENDING — wizard hub apply path arrives in Track 8 PR 23.

## Rollback

`git revert`. Module is additive read-only; nothing consumes the presets yet.

## Out of scope

- Apply wiring (Track 8 PR 23)
- Server-pulse templates (separate PR 9d)
- Wizard hub UI (PR 10)

## Risk

Low. Read-only preview; no production code path mutates state.

## Next PR

PR 9d — server-pulse templates (re-cut of #195).


---
_Generated by [Claude Code](https://claude.ai/code/session_01YXdDyevoQLQXgmgog7erwY)_