### PR TITLE
services+templates: server pulse templates (Track 7 PR 22)

### DIFF
--- a/disbot/services/automation_templates.py
+++ b/disbot/services/automation_templates.py
@@ -208,7 +208,147 @@ _ONBOARDING_TEMPLATES: tuple[AutomationTemplate, ...] = (
 )
 
 
-TEMPLATES: tuple[AutomationTemplate, ...] = _ONBOARDING_TEMPLATES
+# ---------------------------------------------------------------------------
+# Server-pulse templates (Track 7 PR 22)
+# ---------------------------------------------------------------------------
+# Recurring rules the wizard offers under "Server pulse". All default
+# disabled so the operator opts in explicitly.
+
+_SERVER_PULSE_TEMPLATES: tuple[AutomationTemplate, ...] = (
+    AutomationTemplate(
+        slug="daily-readiness-reminder",
+        display_name="Daily readiness reminder",
+        description=(
+            "Post the readiness embed to the configured channel every "
+            "day so configuration drift stays visible."
+        ),
+        trigger_kind="scheduled_time",
+        action_kind="post_readiness_summary",
+        default_trigger_config={"quiet_hours": [22, 6]},
+        default_action_config={"channel_id": 0},
+        required_overrides=("channel_id",),
+        category="server_pulse",
+    ),
+    AutomationTemplate(
+        slug="weekly-server-health-summary",
+        display_name="Weekly server health summary",
+        description="Post the readiness embed weekly to a configured channel.",
+        trigger_kind="interval",
+        action_kind="post_readiness_summary",
+        default_trigger_config={"interval_minutes": 10080},  # 7 days
+        default_action_config={"channel_id": 0},
+        required_overrides=("channel_id",),
+        category="server_pulse",
+    ),
+    AutomationTemplate(
+        slug="weekly-leaderboard",
+        display_name="Weekly leaderboard",
+        description=(
+            "Post the leaderboard for a chosen subsystem to a channel every week."
+        ),
+        trigger_kind="interval",
+        action_kind="post_leaderboard_summary",
+        default_trigger_config={"interval_minutes": 10080},
+        default_action_config={"channel_id": 0, "subsystem": "xp"},
+        required_overrides=("channel_id",),
+        category="server_pulse",
+    ),
+    AutomationTemplate(
+        slug="daily-game-prompt",
+        display_name="Daily game prompt",
+        description=(
+            "Send a message inviting members to play a game in the "
+            "configured channel."
+        ),
+        trigger_kind="scheduled_time",
+        action_kind="send_message",
+        default_action_config={
+            "channel_id": 0,
+            "template": "🎲 Daily game time — drop into the games channel!",
+        },
+        required_overrides=("channel_id",),
+        category="server_pulse",
+    ),
+    AutomationTemplate(
+        slug="inactive-channel-nudge",
+        display_name="Inactive channel nudge",
+        description=(
+            "Post a gentle nudge to a channel that has been quiet for "
+            "more than N days."
+        ),
+        trigger_kind="channel_inactive",
+        action_kind="send_message",
+        default_trigger_config={"channel_id": 0, "days": 30},
+        default_action_config={
+            "channel_id": 0,
+            "template": "🌱 This channel has been quiet — anyone around?",
+        },
+        required_overrides=("channel_id",),
+        category="server_pulse",
+    ),
+    AutomationTemplate(
+        slug="moderation-digest",
+        display_name="Moderation digest",
+        description="Send a weekly moderation summary to the staff channel.",
+        trigger_kind="interval",
+        action_kind="send_message",
+        default_trigger_config={"interval_minutes": 10080},
+        default_action_config={
+            "channel_id": 0,
+            "template": "🛡 Weekly moderation digest.",
+        },
+        required_overrides=("channel_id",),
+        category="server_pulse",
+    ),
+    AutomationTemplate(
+        slug="economy-summary",
+        display_name="Economy summary",
+        description="Post the economy leaderboard / shop summary weekly.",
+        trigger_kind="interval",
+        action_kind="post_leaderboard_summary",
+        default_trigger_config={"interval_minutes": 10080},
+        default_action_config={"channel_id": 0, "subsystem": "economy"},
+        required_overrides=("channel_id",),
+        category="server_pulse",
+    ),
+    AutomationTemplate(
+        slug="tournament-reminder",
+        display_name="Tournament reminder",
+        description=(
+            "Send a configurable reminder about the next tournament to "
+            "a chosen channel."
+        ),
+        trigger_kind="scheduled_time",
+        action_kind="send_message",
+        default_action_config={
+            "channel_id": 0,
+            "template": "🏆 Tournament starting soon — sign up!",
+        },
+        required_overrides=("channel_id",),
+        category="server_pulse",
+    ),
+    AutomationTemplate(
+        slug="bot-update-changelog-post",
+        display_name="Bot update / changelog post",
+        description=(
+            "Post a changelog message to the configured staff channel — "
+            "useful for surfacing bot releases."
+        ),
+        trigger_kind="manual",
+        action_kind="send_message",
+        default_action_config={
+            "channel_id": 0,
+            "template": "🆕 SuperBot update — see #releases.",
+        },
+        required_overrides=("channel_id",),
+        category="server_pulse",
+    ),
+)
+
+
+TEMPLATES: tuple[AutomationTemplate, ...] = (
+    _ONBOARDING_TEMPLATES + _SERVER_PULSE_TEMPLATES
+)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_automation_templates.py
+++ b/tests/unit/services/test_automation_templates.py
@@ -38,7 +38,10 @@ from services.automation_templates import (
 
 
 def test_onboarding_slugs_match_documented_set():
-    assert known_slugs() == {
+    onboarding_slugs = {
+        t.slug for t in list_templates_by_category("onboarding")
+    }
+    assert onboarding_slugs == {
         "welcome-message",
         "rules-channel-binding",
         "new-member-role",
@@ -59,7 +62,14 @@ def test_get_template_returns_none_for_unknown_slug():
 
 def test_list_templates_by_category_filters():
     items = list_templates_by_category("onboarding")
-    assert {t.slug for t in items} == known_slugs()
+    onboarding_slugs = {
+        "welcome-message",
+        "rules-channel-binding",
+        "new-member-role",
+        "delayed-followup-message",
+        "notify-staff-on-join",
+    }
+    assert {t.slug for t in items} == onboarding_slugs
     assert list_templates_by_category("uncategorized") == ()
 
 

--- a/tests/unit/services/test_server_pulse_templates.py
+++ b/tests/unit/services/test_server_pulse_templates.py
@@ -1,0 +1,124 @@
+"""Phase 9h / Track 7 PR 22 — server-pulse templates tests.
+
+Pins:
+
+* All 9 documented server-pulse templates appear in
+  ``list_templates_by_category("server_pulse")``.
+* Each template's resolved (default + overrides) config passes the
+  registry's validation.
+* Templates round-trip through ``AutomationMutationPipeline``
+  (mocked) without raising.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services.automation_mutation import AutomationMutationPipeline
+from services.automation_templates import (
+    AutomationTemplate,
+    get_template,
+    list_templates_by_category,
+)
+
+_SERVER_PULSE_SLUGS = {
+    "daily-readiness-reminder",
+    "weekly-server-health-summary",
+    "weekly-leaderboard",
+    "daily-game-prompt",
+    "inactive-channel-nudge",
+    "moderation-digest",
+    "economy-summary",
+    "tournament-reminder",
+    "bot-update-changelog-post",
+}
+
+
+def test_server_pulse_slug_set_matches_documented():
+    actual = {t.slug for t in list_templates_by_category("server_pulse")}
+    assert actual == _SERVER_PULSE_SLUGS
+
+
+@pytest.mark.parametrize("slug", sorted(_SERVER_PULSE_SLUGS))
+def test_template_category_is_server_pulse(slug):
+    tmpl = get_template(slug)
+    assert isinstance(tmpl, AutomationTemplate)
+    assert tmpl.category == "server_pulse"
+
+
+@pytest.mark.parametrize("slug", sorted(_SERVER_PULSE_SLUGS))
+def test_template_validates_with_meaningful_overrides(slug):
+    tmpl = get_template(slug)
+    assert tmpl is not None
+    overrides = _meaningful_overrides(tmpl)
+    errors = tmpl.validate(action_overrides=overrides)
+    assert errors == [], errors
+
+
+@pytest.mark.parametrize("slug", sorted(_SERVER_PULSE_SLUGS))
+def test_template_requires_channel_override(slug):
+    tmpl = get_template(slug)
+    assert tmpl is not None
+    # No overrides — every server-pulse template ships with
+    # ``channel_id=0`` as the placeholder.
+    errors = tmpl.validate()
+    assert any("channel_id" in e for e in errors)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("slug", sorted(_SERVER_PULSE_SLUGS))
+async def test_template_round_trip_through_pipeline(slug):
+    tmpl = get_template(slug)
+    assert tmpl is not None
+    action_cfg = tmpl.merged_action_config(_meaningful_overrides(tmpl))
+    trigger_cfg = tmpl.merged_trigger_config()
+    with (
+        patch(
+            "services.automation_mutation.db.insert_rule",
+            new_callable=AsyncMock,
+            return_value=1,
+        ),
+        patch(
+            "services.automation_mutation.emit_audit_action",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch("core.events.bus.emit", new_callable=AsyncMock),
+    ):
+        result = await AutomationMutationPipeline().create_rule(
+            guild_id=10,
+            guild_owner_id=99,
+            name=tmpl.slug,
+            trigger_kind=tmpl.trigger_kind,
+            action_kind=tmpl.action_kind,
+            trigger_config=trigger_cfg,
+            action_config=action_cfg,
+            actor_id=99,
+        )
+    assert result.rule_id == 1
+
+
+def test_all_server_pulse_templates_default_to_disabled():
+    """The mutation pipeline always inserts ``enabled=False`` —
+    operators opt in explicitly. The template definitions
+    deliberately don't carry an ``enabled`` field so the default
+    survives."""
+    # Pin via structure: no template has an "enabled" key in its
+    # default config.
+    for tmpl in list_templates_by_category("server_pulse"):
+        assert "enabled" not in tmpl.default_trigger_config
+        assert "enabled" not in tmpl.default_action_config
+
+
+def _meaningful_overrides(tmpl):
+    overrides = {}
+    for key in tmpl.required_overrides:
+        if key.endswith("_id"):
+            overrides[key] = 4242
+        elif key == "template":
+            overrides[key] = "hello"
+        else:
+            overrides[key] = "x"
+    return overrides


### PR DESCRIPTION
## Summary

Restores the server-pulse automation templates that were originally landed via #195. Adds 9 scheduled-rhythm templates (daily readiness, weekly server-health summary, weekly leaderboard, daily game prompt, inactive-channel nudge, moderation digest, economy summary, tournament reminder, changelog post). All default `enabled = False`.

Re-cut directly off `origin/main` after #205/#207 (onboarding + channel templates) merged.

## Scope

### Does

- Extend `disbot/services/automation_templates.py` with 9 server-pulse templates (+142 LOC).
- Extend the registry exports so `TEMPLATES`, `list_templates_by_category("server_pulse")`, and `get_template(slug)` find the new entries.
- Add `tests/unit/services/test_server_pulse_templates.py` (24 cases).
- Minor follow-up in `tests/unit/services/test_automation_templates.py` so the existing category-grouping test sees the new category.

### Does NOT

- No DB writes
- No `automation_rules` insertion (caller must route through `automation_mutation`)
- No scheduler wiring (Track 6 PR 18 / PR 8 in chain)
- No UI / no slash command

## Files changed

| File | Status | LOC |
|---|---|---|
| `disbot/services/automation_templates.py` | modified | +142 |
| `tests/unit/services/test_automation_templates.py` | modified | +14 / -3 |
| `tests/unit/services/test_server_pulse_templates.py` | added | 124 |

## Architecture impact

- Pure additive templates. Each template's `trigger_kind` / `action_kind` is registered in `automation_registry.py`.
- All templates default `enabled = False`; nothing fires until owner activates via the wizard (Track 8) or direct CRUD.
- `to_rule_payload(...)` produces a `automation_mutation.create_rule` payload — no parallel schema.

## Tests run

```
python -m pytest tests/unit/services/test_automation_templates.py \
                 tests/unit/services/test_server_presets.py \
                 tests/unit/services/test_server_pulse_templates.py -q
# 107 passed, 1 skipped

ruff check . --exclude .github,tests,venv,env,build,dist  # clean
black --check . --exclude '(\.github|tests|venv|env|build|dist)'  # clean
isort --check-only . --skip-glob '*/(\.github|tests|venv|env|build|dist)/*'  # clean
mypy disbot/  # 316 source files, no issues (mypy 2.1.0)
```

## Manual smoke

- PENDING — requires Track 6 PR 17/18 executor + scheduler (in progress).

## Rollback

`git revert`. Additive only.

## Out of scope

- Wizard hub UI (PR 10)
- Summary / drift detection (PR 11)
- Cog rewrite (Track 8 PR 23)

## Risk

Low. Templates default disabled; nothing fires automatically.

## Next PR

PR 10 — wizard hub orchestration (re-cut of #196).


---
_Generated by [Claude Code](https://claude.ai/code/session_01YXdDyevoQLQXgmgog7erwY)_