### PR TITLE
setup_cog: wire Start Setup to SetupHubView (PR-B)

### DIFF
--- a/disbot/cogs/setup_cog.py
+++ b/disbot/cogs/setup_cog.py
@@ -185,7 +185,26 @@ class SetupLauncherView(discord.ui.View):
         del button
         if not await self._gate_owner(interaction):
             return
-        await interaction.response.send_message(_COMING_SOON, ephemeral=True)
+        if interaction.guild_id is None:
+            await self._deny(
+                interaction,
+                "Setup requires a guild context.",
+            )
+            return
+
+        from views.setup.hub import SetupHubView, build_hub_embed
+
+        session = await self._resolve_session(interaction)
+        hub = SetupHubView(interaction.user, session=session)
+        await interaction.response.send_message(
+            embed=build_hub_embed(session),
+            view=hub,
+            ephemeral=True,
+        )
+        try:
+            await setup_session.mark_in_progress(interaction.guild_id, step="hub")
+        except Exception:
+            logger.exception("setup_cog._start: mark_in_progress failed")
 
     @discord.ui.button(
         label="Run Readiness Scan",
@@ -515,8 +534,7 @@ class SetupCog(commands.Cog):
             await message.edit(embed=embed, view=view)
         except discord.HTTPException as exc:
             logger.warning(
-                "setup_cog.on_ready: edit_message failed for launcher in "
-                "guild=%d: %s",
+                "setup_cog.on_ready: edit_message failed for launcher in guild=%d: %s",
                 guild.id,
                 exc,
             )

--- a/tests/unit/cogs/test_setup_cog.py
+++ b/tests/unit/cogs/test_setup_cog.py
@@ -337,15 +337,46 @@ async def test_start_button_refuses_non_owner():
 
 
 @pytest.mark.asyncio
-async def test_start_button_shows_coming_soon_for_owner():
+async def test_start_button_opens_setup_hub_for_owner():
+    """Start Setup must open ``SetupHubView`` — no longer a stub."""
     view = SetupLauncherView()
     interaction = _mock_interaction(_owner_member())
+
+    with patch("services.setup_session.resume_session", AsyncMock(return_value=None)):
+        with patch(
+            "services.setup_session.mark_in_progress",
+            AsyncMock(),
+        ) as mark_mock:
+            await view._start.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    kwargs = interaction.response.send_message.await_args.kwargs
+    # Hub is rendered with an embed + view, sent ephemerally.
+    assert kwargs.get("ephemeral") is True
+    assert kwargs.get("embed") is not None
+    sent_view = kwargs.get("view")
+    assert sent_view is not None
+    # The view dispatched must be the wizard hub, not the launcher.
+    from views.setup.hub import SetupHubView
+
+    assert isinstance(sent_view, SetupHubView)
+    # Session step is persisted so the launcher relabels after restart.
+    mark_mock.assert_awaited_once()
+    assert mark_mock.await_args.kwargs.get("step") == "hub"
+
+
+@pytest.mark.asyncio
+async def test_start_button_requires_guild_context():
+    """No guild_id → deny rather than crash inside SetupHubView."""
+    view = SetupLauncherView()
+    interaction = _mock_interaction(_owner_member())
+    interaction.guild_id = None
 
     await view._start.callback(interaction)
 
     interaction.response.send_message.assert_awaited_once()
     msg = interaction.response.send_message.await_args.args[0]
-    assert "not wired up" in msg.lower()
+    assert "guild" in msg.lower()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Replaces the `_COMING_SOON` stub in `SetupLauncherView._start` with the
wizard hub. The hub (`views/setup/hub.py::SetupHubView`) landed in
PR #209 but was unreachable — the launcher's Start Setup button was
the only entry point and stubbed.

Behavior:
- Same owner gate as before.
- Resolves the current `setup_session` row so the hub renders with the
  right status header.
- Opens `SetupHubView` ephemerally with `build_hub_embed(session)`.
- Marks the session step as `hub` so the launcher relabels to
  "Resume Setup" after restart.

## Activation policy

Active by default. Hub is owner-gated; safe to expose.

## Test plan

- [x] `pytest tests/unit/cogs/test_setup_cog.py` (35 tests)
- [x] `pytest tests/` (3072 passed, 1 skipped, 0 failed)
- [x] `ruff check`, `ruff format --check`, `mypy disbot/cogs/setup_cog.py`
- [ ] §9 step 8, 17, 18 — owner clicks Start Setup, hub opens, Final Review preview-only

## Rollback

Revert the single function edit in `disbot/cogs/setup_cog.py::_start`.
No DB state becomes invalid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJ9uQ6akxAXeMd7VTuvKi7)_