### PR TITLE
setup_cog: wire Smart Suggestions to AIReviewPanelView (PR-C)

### DIFF
--- a/disbot/cogs/setup_cog.py
+++ b/disbot/cogs/setup_cog.py
@@ -225,7 +225,47 @@ class SetupLauncherView(discord.ui.View):
         del button
         if not await self._gate_owner(interaction):
             return
-        await interaction.response.send_message(_COMING_SOON, ephemeral=True)
+        guild = interaction.guild
+        if guild is None or interaction.guild_id is None:
+            await self._deny(
+                interaction,
+                "Smart Suggestions requires a guild context.",
+            )
+            return
+
+        from services.guild_snapshot import collect as collect_snapshot
+        from services.setup_ai_advisor import build_advisor
+        from views.setup.ai_review.main_panel import (
+            AIReviewPanelView,
+            build_ai_review_embed,
+        )
+
+        try:
+            snapshot = await collect_snapshot(guild)
+            advisor = build_advisor()
+            draft = await advisor.suggest(snapshot)
+        except Exception:
+            logger.exception("setup_cog._suggestions: advisor flow failed")
+            await self._deny(
+                interaction,
+                "Smart Suggestions failed. Run **Run Readiness Scan** for "
+                "a deterministic baseline.",
+            )
+            return
+
+        panel = AIReviewPanelView(interaction.user, draft=draft, snapshot=snapshot)
+        await interaction.response.send_message(
+            embed=build_ai_review_embed(draft),
+            view=panel,
+            ephemeral=True,
+        )
+        try:
+            await setup_session.mark_in_progress(
+                interaction.guild_id,
+                step="suggestions",
+            )
+        except Exception:
+            logger.exception("setup_cog._suggestions: mark_in_progress failed")
 
     @discord.ui.button(
         label="Choose Preset",
@@ -515,8 +555,7 @@ class SetupCog(commands.Cog):
             await message.edit(embed=embed, view=view)
         except discord.HTTPException as exc:
             logger.warning(
-                "setup_cog.on_ready: edit_message failed for launcher in "
-                "guild=%d: %s",
+                "setup_cog.on_ready: edit_message failed for launcher in guild=%d: %s",
                 guild.id,
                 exc,
             )

--- a/tests/unit/cogs/test_setup_cog.py
+++ b/tests/unit/cogs/test_setup_cog.py
@@ -363,6 +363,84 @@ async def test_smart_suggestions_button_owner_only():
 
 
 @pytest.mark.asyncio
+async def test_smart_suggestions_opens_ai_review_for_owner():
+    """Owner click runs deterministic advisor + opens AIReviewPanelView."""
+    from services.guild_snapshot import GuildSnapshot
+    from services.setup_plan import (
+        SetupPlanDraft,
+        SetupRecommendation,
+    )
+    from views.setup.ai_review.main_panel import AIReviewPanelView
+
+    view = SetupLauncherView()
+    interaction = _mock_interaction(_owner_member())
+
+    fake_snapshot = MagicMock(spec=GuildSnapshot)
+    fake_recommendation = SetupRecommendation(
+        subsystem="moderation",
+        binding_name="mod_log",
+        target_kind="channel",
+        target_id=42,
+        target_name="mod-logs",
+        confidence="high",
+        reason="name-match",
+    )
+    fake_draft = SetupPlanDraft(
+        recommendations=(fake_recommendation,),
+        source="deterministic",
+    )
+    fake_advisor = MagicMock()
+    fake_advisor.suggest = AsyncMock(return_value=fake_draft)
+
+    with (
+        patch(
+            "services.guild_snapshot.collect",
+            new_callable=AsyncMock,
+            return_value=fake_snapshot,
+        ),
+        patch(
+            "services.setup_ai_advisor.build_advisor",
+            return_value=fake_advisor,
+        ),
+        patch(
+            "services.setup_session.mark_in_progress",
+            new_callable=AsyncMock,
+        ) as mark_mock,
+    ):
+        await view._suggestions.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    sent_view = interaction.response.send_message.await_args.kwargs.get("view")
+    assert isinstance(sent_view, AIReviewPanelView)
+    assert (
+        interaction.response.send_message.await_args.kwargs.get("ephemeral")
+        is True
+    )
+    mark_mock.assert_awaited_once()
+    assert mark_mock.await_args.kwargs.get("step") == "suggestions"
+
+
+@pytest.mark.asyncio
+async def test_smart_suggestions_falls_back_when_advisor_raises():
+    """If snapshot/advisor blows up, owner sees an apology — no crash."""
+    view = SetupLauncherView()
+    interaction = _mock_interaction(_owner_member())
+
+    with (
+        patch(
+            "services.guild_snapshot.collect",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("snapshot down"),
+        ),
+    ):
+        await view._suggestions.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "smart suggestions" in msg.lower()
+
+
+@pytest.mark.asyncio
 async def test_preset_button_owner_only():
     view = SetupLauncherView()
     interaction = _mock_interaction(_admin_member())


### PR DESCRIPTION
## Summary

Replaces the `_COMING_SOON` stub in `SetupLauncherView._suggestions`
with the AI review flow. The deterministic advisor (#185), OpenAI
advisor (#201) and review UI (#202) all landed but were unreachable:
the launcher's Smart Suggestions button was the only entry point and
stubbed.

Behavior:
- Owner gate + guild-context guard.
- `services.guild_snapshot.collect(guild)` builds the snapshot.
- `services.setup_ai_advisor.build_advisor()` honours
  `SETUP_ADVISOR_PROVIDER` env. Default is `deterministic`; factory
  falls back to deterministic when `OPENAI_API_KEY` is missing or
  the SDK fails. CI / dev envs never make external calls.
- Renders `AIReviewPanelView` ephemerally so accept / reject is
  interactive in-place.
- Marks the session step as `suggestions`.
- Snapshot/advisor exceptions are caught and the operator gets a
  user-facing apology rather than an interaction crash.

## Activation policy

Active by default. Provider env defaults to `deterministic` per
`disbot/config.py:111`; OpenAI only activates when `OPENAI_API_KEY`
is set AND `SETUP_ADVISOR_PROVIDER=openai`.

## Test plan

- [x] `pytest tests/unit/cogs/test_setup_cog.py` (35 tests)
- [x] `pytest tests/` (3072 passed, 1 skipped, 0 failed)
- [x] `ruff check`, `ruff format --check`, `mypy disbot/cogs/setup_cog.py`
- [ ] §9 step 13, 14, 15, 16 — deterministic happy path, OpenAI happy path,
  invalid target dropped, accept records to AcceptedSet without applying

## Rollback

Revert the single function edit; the deterministic advisor and AI
panel are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJ9uQ6akxAXeMd7VTuvKi7)_