### PR TITLE
setup_cog+views: wire Choose Preset to template picker (PR-D)

### DIFF
--- a/disbot/cogs/setup_cog.py
+++ b/disbot/cogs/setup_cog.py
@@ -240,7 +240,15 @@ class SetupLauncherView(discord.ui.View):
         del button
         if not await self._gate_owner(interaction):
             return
-        await interaction.response.send_message(_COMING_SOON, ephemeral=True)
+
+        from views.setup.template_picker import TemplatePickerView, build_picker_embed
+
+        picker = TemplatePickerView(interaction.user)
+        await interaction.response.send_message(
+            embed=build_picker_embed(),
+            view=picker,
+            ephemeral=True,
+        )
 
     @discord.ui.button(
         label="Dismiss",
@@ -515,8 +523,7 @@ class SetupCog(commands.Cog):
             await message.edit(embed=embed, view=view)
         except discord.HTTPException as exc:
             logger.warning(
-                "setup_cog.on_ready: edit_message failed for launcher in "
-                "guild=%d: %s",
+                "setup_cog.on_ready: edit_message failed for launcher in guild=%d: %s",
                 guild.id,
                 exc,
             )

--- a/disbot/views/setup/template_picker.py
+++ b/disbot/views/setup/template_picker.py
@@ -1,0 +1,425 @@
+"""Setup-wizard template picker (PR-D).
+
+The wizard launcher's **Choose Preset** button opens
+:class:`TemplatePickerView`, which lists every operator-facing
+:class:`AutomationTemplate` grouped by category. Picking one opens
+:class:`TemplateConfigView`, which prompts for the template's required
+overrides (channel id, role id) and routes the apply through
+:class:`services.automation_mutation.AutomationMutationPipeline.create_rule`.
+
+Rules are created **disabled** (``enabled=False`` per migration 032
+line 74); the operator must flip them on via ``!automation enable``
+once the scheduler is also activated by
+``AUTOMATION_SCHEDULER_ENABLED=true``. That two-key activation
+matches the safety policy in the reconciliation plan §7.
+
+No DB writes from this module — every mutation routes through the
+audited pipeline so the audit publisher records it.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import discord
+
+from services.automation_templates import (
+    TEMPLATES,
+    AutomationTemplate,
+    get_template,
+)
+from views.base import BaseView
+
+logger = logging.getLogger("bot.views.setup.template_picker")
+
+
+_CATEGORY_LABELS: dict[str, str] = {
+    "onboarding": "Onboarding",
+    "server_pulse": "Server pulse",
+    "channels": "Channels",
+    "uncategorized": "Other",
+}
+
+
+@dataclass(frozen=True)
+class ApplyOutcome:
+    """Outcome of :func:`apply_template_to_guild`."""
+
+    ok: bool
+    rule_id: int | None
+    template_slug: str
+    detail: str
+
+
+def _category_label(category: str) -> str:
+    return _CATEGORY_LABELS.get(category, category.replace("_", " ").title())
+
+
+def build_picker_embed() -> discord.Embed:
+    """Embed listing categories and a hint about the activation policy."""
+    embed = discord.Embed(
+        title="📦 Choose a preset",
+        description=(
+            "Pick an automation template to install in this guild.\n\n"
+            "Every template is created **disabled** — once configured, "
+            "flip it on via `!automation enable <name>` (the automation "
+            "scheduler must also be activated server-side via "
+            "`AUTOMATION_SCHEDULER_ENABLED=true`)."
+        ),
+        color=discord.Color.blurple(),
+    )
+    counts: dict[str, int] = {}
+    for tmpl in TEMPLATES:
+        counts[tmpl.category] = counts.get(tmpl.category, 0) + 1
+    lines = [
+        f"• **{_category_label(cat)}** — {n} template(s)"
+        for cat, n in sorted(counts.items())
+    ]
+    if lines:
+        embed.add_field(
+            name="Available categories",
+            value="\n".join(lines),
+            inline=False,
+        )
+    embed.set_footer(text="Owner-gated. No rule runs until you enable it.")
+    return embed
+
+
+def _select_options() -> list[discord.SelectOption]:
+    options: list[discord.SelectOption] = []
+    # Discord caps Select options at 25; we currently have 14 onboarding
+    # + server_pulse templates so we fit, but the slice is defensive.
+    for tmpl in list(TEMPLATES)[:25]:
+        label = f"[{_category_label(tmpl.category)}] {tmpl.display_name}"[:100]
+        description = tmpl.description[:100]
+        options.append(
+            discord.SelectOption(
+                label=label,
+                description=description,
+                value=tmpl.slug,
+            ),
+        )
+    return options
+
+
+class _TemplatePickerSelect(discord.ui.Select):
+    """Single Select listing every known template across categories."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            placeholder="Pick a template…",
+            options=_select_options(),
+            min_values=1,
+            max_values=1,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        slug = self.values[0]
+        template = get_template(slug)
+        if template is None:
+            await interaction.response.send_message(
+                f"Template `{slug}` not found.",
+                ephemeral=True,
+            )
+            return
+        config = TemplateConfigView(interaction.user, template=template)
+        await interaction.response.send_message(
+            embed=build_template_config_embed(template),
+            view=config,
+            ephemeral=True,
+        )
+
+
+class TemplatePickerView(BaseView):
+    """Owner-gated picker — lists every template via a single Select."""
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        *,
+        public: bool = False,
+        timeout: int = 180,
+    ) -> None:
+        super().__init__(author, public=public, timeout=timeout)
+        self.add_item(_TemplatePickerSelect())
+
+
+# ---------------------------------------------------------------------------
+# Per-template configuration view
+# ---------------------------------------------------------------------------
+
+
+def build_template_config_embed(
+    template: AutomationTemplate,
+    *,
+    outcome: ApplyOutcome | None = None,
+) -> discord.Embed:
+    """Render the per-template embed.
+
+    Three states: pre-apply (lists details + required overrides),
+    post-apply success (green, names the rule id), post-apply
+    failure (red, names the error).
+    """
+    if outcome is not None and outcome.ok:
+        return discord.Embed(
+            title=f"✅ Installed: {template.display_name}",
+            description=(
+                f"`automation_rules.id = {outcome.rule_id}` created "
+                f"**disabled**. Flip on via "
+                f"`!automation enable {template.slug}`."
+            ),
+            color=discord.Color.green(),
+        )
+    if outcome is not None and not outcome.ok:
+        return discord.Embed(
+            title=f"❌ Could not install: {template.display_name}",
+            description=outcome.detail,
+            color=discord.Color.red(),
+        )
+
+    embed = discord.Embed(
+        title=f"📦 {template.display_name}",
+        description=template.description,
+        color=discord.Color.blurple(),
+    )
+    embed.add_field(
+        name="Category",
+        value=_category_label(template.category),
+        inline=True,
+    )
+    embed.add_field(name="Trigger", value=template.trigger_kind, inline=True)
+    embed.add_field(name="Action", value=template.action_kind, inline=True)
+    if template.required_overrides:
+        embed.add_field(
+            name="Required overrides",
+            value=", ".join(f"`{k}`" for k in template.required_overrides),
+            inline=False,
+        )
+    else:
+        embed.add_field(
+            name="Required overrides",
+            value="_None — applies with defaults._",
+            inline=False,
+        )
+    embed.set_footer(
+        text="Rules are created disabled. You enable them after review.",
+    )
+    return embed
+
+
+class _ChannelPick(discord.ui.ChannelSelect):
+    def __init__(self) -> None:
+        super().__init__(
+            placeholder="Pick a channel…",
+            channel_types=[discord.ChannelType.text],
+            min_values=1,
+            max_values=1,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from core.runtime.interaction_helpers import safe_defer
+
+        view = self.view
+        if isinstance(view, TemplateConfigView):
+            view.selected_channel_id = self.values[0].id
+        await safe_defer(interaction)
+
+
+class _RolePick(discord.ui.RoleSelect):
+    def __init__(self) -> None:
+        super().__init__(
+            placeholder="Pick a role…",
+            min_values=1,
+            max_values=1,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from core.runtime.interaction_helpers import safe_defer
+
+        view = self.view
+        if isinstance(view, TemplateConfigView):
+            view.selected_role_id = self.values[0].id
+        await safe_defer(interaction)
+
+
+class TemplateConfigView(BaseView):
+    """Single-template config + apply panel.
+
+    Attributes:
+        template: the :class:`AutomationTemplate` being configured.
+        selected_channel_id: filled in by :class:`_ChannelPick`.
+        selected_role_id: filled in by :class:`_RolePick`.
+    """
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        *,
+        template: AutomationTemplate,
+        public: bool = False,
+        timeout: int = 180,
+    ) -> None:
+        super().__init__(author, public=public, timeout=timeout)
+        self.template = template
+        self.selected_channel_id: int | None = None
+        self.selected_role_id: int | None = None
+        if "channel_id" in template.required_overrides:
+            self.add_item(_ChannelPick())
+        if "role_id" in template.required_overrides:
+            self.add_item(_RolePick())
+
+    @discord.ui.button(label="Apply", style=discord.ButtonStyle.success, row=2)
+    async def _apply(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        guild = interaction.guild
+        if guild is None:
+            await interaction.response.send_message(
+                "Apply requires a guild context.",
+                ephemeral=True,
+            )
+            return
+        # Validate required overrides are filled.
+        missing: list[str] = []
+        if "channel_id" in self.template.required_overrides:
+            if self.selected_channel_id is None:
+                missing.append("channel_id")
+        if "role_id" in self.template.required_overrides:
+            if self.selected_role_id is None:
+                missing.append("role_id")
+        if missing:
+            await interaction.response.send_message(
+                "Pick a value for the required override(s) first: "
+                + ", ".join(f"`{m}`" for m in missing),
+                ephemeral=True,
+            )
+            return
+
+        outcome = await apply_template_to_guild(
+            template=self.template,
+            guild_id=guild.id,
+            guild_owner_id=guild.owner_id or 0,
+            channel_id=self.selected_channel_id,
+            role_id=self.selected_role_id,
+            actor_id=interaction.user.id,
+        )
+        await interaction.response.send_message(
+            embed=build_template_config_embed(self.template, outcome=outcome),
+            ephemeral=True,
+        )
+
+    @discord.ui.button(label="Cancel", style=discord.ButtonStyle.secondary, row=2)
+    async def _cancel(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        await interaction.response.send_message(
+            f"Cancelled — `{self.template.slug}` was NOT installed.",
+            ephemeral=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Apply helper (routes through the audited mutation pipeline)
+# ---------------------------------------------------------------------------
+
+
+async def apply_template_to_guild(
+    *,
+    template: AutomationTemplate,
+    guild_id: int,
+    guild_owner_id: int,
+    channel_id: int | None,
+    role_id: int | None,
+    actor_id: int,
+) -> ApplyOutcome:
+    """Create one ``automation_rules`` row from a template (disabled).
+
+    Routes through :class:`AutomationMutationPipeline.create_rule` so
+    audit + event emission happen consistently. The pipeline already
+    creates rules with ``enabled=False`` by default (migration 032
+    line 74); we never override.
+    """
+    from services.automation_mutation import (
+        AutomationMutationPipeline,
+        InvalidAutomationConfigError,
+    )
+
+    trigger_overrides: dict[str, Any] = {}
+    action_overrides: dict[str, Any] = {}
+    if channel_id is not None:
+        # Channel-id can appear in either side depending on the
+        # action kind; the registry validator will reject any that
+        # don't apply.
+        if "channel_id" in template.default_action_config:
+            action_overrides["channel_id"] = channel_id
+        if "channel_id" in template.default_trigger_config:
+            trigger_overrides["channel_id"] = channel_id
+    if role_id is not None:
+        if "role_id" in template.default_action_config:
+            action_overrides["role_id"] = role_id
+        if "role_id" in template.default_trigger_config:
+            trigger_overrides["role_id"] = role_id
+
+    pipeline = AutomationMutationPipeline()
+    try:
+        result = await pipeline.create_rule(
+            guild_id=guild_id,
+            guild_owner_id=guild_owner_id,
+            name=template.slug,
+            trigger_kind=template.trigger_kind,
+            action_kind=template.action_kind,
+            trigger_config=template.merged_trigger_config(trigger_overrides),
+            action_config=template.merged_action_config(action_overrides),
+            actor_id=actor_id,
+            actor_type="platform_owner",
+        )
+    except InvalidAutomationConfigError as exc:
+        logger.warning(
+            "template apply rejected for slug=%s guild=%d: %s",
+            template.slug,
+            guild_id,
+            exc,
+        )
+        return ApplyOutcome(
+            ok=False,
+            rule_id=None,
+            template_slug=template.slug,
+            detail=f"Validation failed: {exc}",
+        )
+    except Exception as exc:
+        logger.exception(
+            "template apply crashed for slug=%s guild=%d",
+            template.slug,
+            guild_id,
+        )
+        return ApplyOutcome(
+            ok=False,
+            rule_id=None,
+            template_slug=template.slug,
+            detail=f"{type(exc).__name__}: {exc}",
+        )
+
+    return ApplyOutcome(
+        ok=True,
+        rule_id=result.rule_id,
+        template_slug=template.slug,
+        detail="created disabled",
+    )
+
+
+__all__ = [
+    "ApplyOutcome",
+    "TemplateConfigView",
+    "TemplatePickerView",
+    "apply_template_to_guild",
+    "build_picker_embed",
+    "build_template_config_embed",
+]

--- a/tests/unit/cogs/test_setup_cog.py
+++ b/tests/unit/cogs/test_setup_cog.py
@@ -373,6 +373,22 @@ async def test_preset_button_owner_only():
 
 
 @pytest.mark.asyncio
+async def test_preset_button_opens_template_picker_for_owner():
+    """Owner click opens the template picker view, not a stub."""
+    from views.setup.template_picker import TemplatePickerView
+
+    view = SetupLauncherView()
+    interaction = _mock_interaction(_owner_member())
+
+    await view._preset.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    kwargs = interaction.response.send_message.await_args.kwargs
+    assert isinstance(kwargs.get("view"), TemplatePickerView)
+    assert kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
 async def test_readiness_button_admin_allowed():
     view = SetupLauncherView()
     interaction = _mock_interaction(_admin_member())

--- a/tests/unit/views/setup/test_template_picker.py
+++ b/tests/unit/views/setup/test_template_picker.py
@@ -1,0 +1,259 @@
+"""PR-D — ``views.setup.template_picker`` tests.
+
+Covers:
+
+* Picker embed lists known categories.
+* The select populates options from :data:`TEMPLATES`.
+* :func:`apply_template_to_guild` routes through
+  :class:`AutomationMutationPipeline.create_rule` with the right
+  template defaults + override injection, and never sets
+  ``enabled=True``.
+* Apply with a missing required override is short-circuited with a
+  validation message; the pipeline is not called.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.automation_mutation import AutomationMutationResult
+from services.automation_templates import (
+    TEMPLATES,
+    AutomationTemplate,
+    get_template,
+)
+from views.setup.template_picker import (
+    ApplyOutcome,
+    TemplateConfigView,
+    TemplatePickerView,
+    apply_template_to_guild,
+    build_picker_embed,
+    build_template_config_embed,
+)
+
+
+def _author():
+    member = MagicMock()
+    member.id = 99
+    return member
+
+
+def test_build_picker_embed_lists_categories_with_counts():
+    embed = build_picker_embed()
+    assert "Choose a preset" in embed.title
+    fields = embed.fields
+    cat_field = next((f for f in fields if "categories" in f.name.lower()), None)
+    assert cat_field is not None
+    # At least one of the documented categories appears.
+    assert (
+        "Onboarding" in cat_field.value
+        or "Server pulse" in cat_field.value
+    )
+
+
+def test_picker_view_seeds_one_select_with_template_options():
+    view = TemplatePickerView(_author())
+    selects = [c for c in view.children if hasattr(c, "options")]
+    assert len(selects) == 1
+    select = selects[0]
+    assert len(select.options) >= 1
+    # First option should map to a known slug.
+    first_slug = select.options[0].value
+    assert get_template(first_slug) is not None
+
+
+def test_template_config_embed_pre_apply_lists_required_overrides():
+    template = next(t for t in TEMPLATES if t.required_overrides)
+    embed = build_template_config_embed(template)
+    field = next(f for f in embed.fields if "Required" in f.name)
+    assert any(
+        f"`{key}`" in field.value for key in template.required_overrides
+    )
+
+
+def test_template_config_embed_post_apply_success_is_green():
+    template = next(iter(TEMPLATES))
+    outcome = ApplyOutcome(
+        ok=True,
+        rule_id=42,
+        template_slug=template.slug,
+        detail="ok",
+    )
+    embed = build_template_config_embed(template, outcome=outcome)
+    assert embed.color is not None
+    assert "Installed" in embed.title
+    assert "42" in embed.description
+
+
+def test_template_config_embed_post_apply_failure_is_red():
+    template = next(iter(TEMPLATES))
+    outcome = ApplyOutcome(
+        ok=False,
+        rule_id=None,
+        template_slug=template.slug,
+        detail="something blew up",
+    )
+    embed = build_template_config_embed(template, outcome=outcome)
+    assert "Could not install" in embed.title
+    assert "something blew up" in embed.description
+
+
+@pytest.mark.asyncio
+async def test_apply_routes_through_mutation_pipeline_with_disabled_default():
+    """Apply must call the pipeline and never pass ``enabled=True``."""
+    template = next(
+        t for t in TEMPLATES if "channel_id" in t.required_overrides
+    )
+
+    fake_result = AutomationMutationResult(
+        mutation_id="m1",
+        rule_id=101,
+        guild_id=1,
+        mutation_type="create",
+        name=template.slug,
+        trigger_kind=template.trigger_kind,
+        action_kind=template.action_kind,
+        prev_enabled=None,
+        new_enabled=False,
+        committed_at=None,  # type: ignore[arg-type]
+        event_emitted=True,
+    )
+
+    pipeline_class = MagicMock()
+    pipeline_instance = MagicMock()
+    pipeline_instance.create_rule = AsyncMock(return_value=fake_result)
+    pipeline_class.return_value = pipeline_instance
+
+    with patch(
+        "services.automation_mutation.AutomationMutationPipeline",
+        pipeline_class,
+    ):
+        outcome = await apply_template_to_guild(
+            template=template,
+            guild_id=1,
+            guild_owner_id=99,
+            channel_id=12345,
+            role_id=None,
+            actor_id=99,
+        )
+
+    assert outcome.ok is True
+    assert outcome.rule_id == 101
+    pipeline_instance.create_rule.assert_awaited_once()
+    kwargs = pipeline_instance.create_rule.await_args.kwargs
+    assert kwargs["guild_id"] == 1
+    assert kwargs["actor_type"] == "platform_owner"
+    assert kwargs["trigger_kind"] == template.trigger_kind
+    assert kwargs["action_kind"] == template.action_kind
+    # No `enabled` kwarg passed at all — pipeline defaults to false.
+    assert "enabled" not in kwargs
+    # The selected channel id must appear in either action or trigger config.
+    action_config = kwargs.get("action_config", {})
+    trigger_config = kwargs.get("trigger_config", {})
+    assert (
+        action_config.get("channel_id") == 12345
+        or trigger_config.get("channel_id") == 12345
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_returns_validation_error_when_pipeline_rejects():
+    template = next(
+        t for t in TEMPLATES if "channel_id" in t.required_overrides
+    )
+
+    from services.automation_mutation import InvalidAutomationConfigError
+
+    pipeline_class = MagicMock()
+    pipeline_instance = MagicMock()
+    pipeline_instance.create_rule = AsyncMock(
+        side_effect=InvalidAutomationConfigError("channel_id is required"),
+    )
+    pipeline_class.return_value = pipeline_instance
+
+    with patch(
+        "services.automation_mutation.AutomationMutationPipeline",
+        pipeline_class,
+    ):
+        outcome = await apply_template_to_guild(
+            template=template,
+            guild_id=1,
+            guild_owner_id=99,
+            channel_id=0,  # invalid sentinel
+            role_id=None,
+            actor_id=99,
+        )
+
+    assert outcome.ok is False
+    assert "channel_id is required" in outcome.detail
+
+
+@pytest.mark.asyncio
+async def test_apply_button_short_circuits_when_required_override_missing():
+    """Apply with required ``channel_id`` unset must not call the pipeline."""
+    template = next(
+        t for t in TEMPLATES if "channel_id" in t.required_overrides
+    )
+    view = TemplateConfigView(_author(), template=template)
+    # channel_id was never selected.
+    assert view.selected_channel_id is None
+
+    interaction = MagicMock()
+    interaction.guild = MagicMock(id=1, owner_id=99)
+    interaction.user = MagicMock(id=99)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+
+    with patch(
+        "views.setup.template_picker.apply_template_to_guild",
+        new_callable=AsyncMock,
+    ) as apply_mock:
+        await view._apply.callback(interaction)
+
+    apply_mock.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "channel_id" in msg
+
+
+@pytest.mark.asyncio
+async def test_apply_button_calls_pipeline_when_overrides_filled():
+    template = next(
+        t for t in TEMPLATES if "channel_id" in t.required_overrides
+    )
+    view = TemplateConfigView(_author(), template=template)
+    view.selected_channel_id = 12345
+
+    interaction = MagicMock()
+    interaction.guild = MagicMock(id=1, owner_id=99)
+    interaction.user = MagicMock(id=99)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+
+    outcome = ApplyOutcome(
+        ok=True,
+        rule_id=42,
+        template_slug=template.slug,
+        detail="ok",
+    )
+    with patch(
+        "views.setup.template_picker.apply_template_to_guild",
+        new_callable=AsyncMock,
+        return_value=outcome,
+    ) as apply_mock:
+        await view._apply.callback(interaction)
+
+    apply_mock.assert_awaited_once()
+    interaction.response.send_message.assert_awaited_once()
+    kwargs = apply_mock.await_args.kwargs
+    assert kwargs["template"].slug == template.slug
+    assert kwargs["guild_id"] == 1
+    assert kwargs["channel_id"] == 12345
+
+
+def test_picker_select_options_never_exceed_25():
+    view = TemplatePickerView(_author())
+    selects = [c for c in view.children if hasattr(c, "options")]
+    assert len(selects[0].options) <= 25


### PR DESCRIPTION
## Summary

Replaces the `_COMING_SOON` stub in `SetupLauncherView._preset` with
`TemplatePickerView`. New `disbot/views/setup/template_picker.py`
ships:

- **`TemplatePickerView`** — owner-gated picker, single Select listing
  every `AutomationTemplate` across categories (`onboarding`,
  `server_pulse`). Discord caps Selects at 25 options; defensively
  sliced.
- **`TemplateConfigView`** — per-template config panel. Inspects
  `template.required_overrides` and adds `ChannelSelect` /
  `RoleSelect` as needed. Apply collects the picks and routes through
  the helper.
- **`apply_template_to_guild(...)`** — wraps
  `AutomationMutationPipeline.create_rule(...)`. **Never** passes
  `enabled=True`; rules land disabled per migration 032 line 74. The
  operator flips them on later via `!automation enable <slug>` AND
  must enable the scheduler via `AUTOMATION_SCHEDULER_ENABLED=true`.

`InvalidAutomationConfigError` surfaces as a red embed on the confirm
panel; other exceptions are caught + logged + surfaced.

Channel/Role select callbacks use
`core.runtime.interaction_helpers.safe_defer` to satisfy INV-L
(no raw `interaction.response.defer`).

## Activation policy

Active by default. Rules are created `enabled=false` per migration
032; cannot fire until the scheduler is enabled AND the operator
flips the rule on.

## Test plan

- [x] `pytest tests/unit/views/setup/test_template_picker.py tests/unit/cogs/test_setup_cog.py` (44 tests; 10 new)
- [x] `pytest tests/` (3081 passed, 1 skipped, 0 failed)
- [x] `ruff check`, `ruff format --check`, `mypy`
- [ ] §9 step 19, 20 — template picker lists onboarding + server-pulse,
  confirm creates row with `enabled=false`, rule does not fire with
  scheduler off

## Rollback

Revert the cog dispatch + remove the new view file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJ9uQ6akxAXeMd7VTuvKi7)_