### PR TITLE
setup_cog: add View Summary button (PR-E)

### DIFF
--- a/disbot/cogs/setup_cog.py
+++ b/disbot/cogs/setup_cog.py
@@ -310,9 +310,67 @@ class SetupLauncherView(discord.ui.View):
         )
 
     @discord.ui.button(
+        label="View Summary",
+        style=discord.ButtonStyle.secondary,
+        custom_id="setup:summary",
+        row=1,
+    )
+    async def _view_summary(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        if not await self._gate_admin(interaction):
+            return
+        guild = interaction.guild
+        if guild is None or interaction.guild_id is None:
+            await self._deny(
+                interaction,
+                "View Summary requires a guild context.",
+            )
+            return
+        session = await self._resolve_session(interaction)
+        if session is None or session.setup_status != "complete":
+            await self._deny(
+                interaction,
+                "Setup is not complete yet. Run **Start Setup** to finish "
+                "the wizard before viewing the summary.",
+            )
+            return
+
+        from views.setup.summary import (
+            SummaryView,
+            build_summary_embed,
+            build_summary_snapshot,
+        )
+
+        try:
+            snapshot = await build_summary_snapshot(
+                session=session,
+                guild=guild,
+            )
+        except Exception:
+            logger.exception("setup_cog._view_summary: snapshot build failed")
+            await self._deny(
+                interaction,
+                "Could not build the summary. Try **Run Readiness Scan** "
+                "for a deterministic baseline.",
+            )
+            return
+
+        view = SummaryView(interaction.user, snapshot=snapshot)
+        await interaction.response.send_message(
+            embed=build_summary_embed(snapshot),
+            view=view,
+            ephemeral=True,
+        )
+
+    @discord.ui.button(
         label="Dismiss",
         style=discord.ButtonStyle.danger,
         custom_id="setup:dismiss",
+        row=1,
     )
     async def _dismiss(
         self,

--- a/tests/unit/cogs/test_setup_cog.py
+++ b/tests/unit/cogs/test_setup_cog.py
@@ -498,6 +498,113 @@ async def test_preset_button_opens_template_picker_for_owner():
 
 
 @pytest.mark.asyncio
+async def test_view_summary_denies_when_status_not_complete():
+    """View Summary refuses cleanly when the wizard has not finished."""
+    view = SetupLauncherView()
+    interaction = _mock_interaction(_owner_member())
+    pending_session = SetupSession(
+        guild_id=1,
+        guild_name="x",
+        owner_id=99,
+        setup_status="pending",
+        setup_channel_id=None,
+        setup_message_id=None,
+        last_readiness_score=None,
+        current_step=None,
+        delegated_admins=(),
+    )
+
+    with patch(
+        "cogs.setup_cog.setup_session.resume_session",
+        new_callable=AsyncMock,
+        return_value=pending_session,
+    ):
+        await view._view_summary.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "not complete" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_view_summary_opens_summary_view_when_complete():
+    """View Summary builds a snapshot + opens SummaryView."""
+    from services.setup_session import DriftReport
+    from views.setup.summary import SummarySnapshot, SummaryView
+
+    view = SetupLauncherView()
+    interaction = _mock_interaction(_owner_member())
+    complete_session = SetupSession(
+        guild_id=1,
+        guild_name="x",
+        owner_id=99,
+        setup_status="complete",
+        setup_channel_id=None,
+        setup_message_id=None,
+        last_readiness_score=80,
+        current_step=None,
+        delegated_admins=(),
+    )
+
+    fake_drift = DriftReport(
+        has_drift=False,
+        score_delta=None,
+        prev_score=80,
+        current_score=80,
+        summary="No drift detected.",
+    )
+    fake_snapshot = SummarySnapshot(applied=(), drift=fake_drift)
+
+    with (
+        patch(
+            "cogs.setup_cog.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=complete_session,
+        ),
+        patch(
+            "views.setup.summary.build_summary_snapshot",
+            new_callable=AsyncMock,
+            return_value=fake_snapshot,
+        ) as snapshot_mock,
+    ):
+        await view._view_summary.callback(interaction)
+
+    snapshot_mock.assert_awaited_once()
+    interaction.response.send_message.assert_awaited_once()
+    sent_view = interaction.response.send_message.await_args.kwargs.get("view")
+    assert isinstance(sent_view, SummaryView)
+    assert interaction.response.send_message.await_args.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_view_summary_button_random_denied():
+    """Random non-admin members must be denied."""
+    view = SetupLauncherView()
+    random = _random_member()
+    interaction = _mock_interaction(random)
+    session = SetupSession(
+        guild_id=1,
+        guild_name="x",
+        owner_id=99,
+        setup_status="complete",
+        setup_channel_id=None,
+        setup_message_id=None,
+        last_readiness_score=None,
+        current_step=None,
+        delegated_admins=(),
+    )
+    with patch(
+        "cogs.setup_cog.setup_session.resume_session",
+        new_callable=AsyncMock,
+        return_value=session,
+    ):
+        await view._view_summary.callback(interaction)
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "setup admin" in msg.lower()
+
+
+@pytest.mark.asyncio
 async def test_readiness_button_admin_allowed():
     view = SetupLauncherView()
     interaction = _mock_interaction(_admin_member())


### PR DESCRIPTION
## Summary

Adds a sixth `custom_id="setup:summary"` button to `SetupLauncherView`
(row 1, alongside Dismiss) so an admin can re-open the wizard's final
summary after `setup_status='complete'`.

The summary view (`SummaryView`) and the helper
(`build_summary_snapshot`) landed in PR #210 (Track 8 PR 24) — the
launcher had no entry point. This wires them up.

Behavior:
- Admin gate (matches the readiness scan — owner, admin, or delegated
  admin). Summaries are useful to staff debugging drift and contain
  no mutation paths.
- When `session.setup_status != 'complete'`: deny ephemerally with
  "Setup is not complete yet — run Start Setup to finish."
- When complete: `views.setup.summary.build_summary_snapshot(...)`
  runs `services.setup_readiness.collect` and feeds the result into
  `services.setup_session.detect_drift(...)`. Then opens `SummaryView`
  with `build_summary_embed` ephemerally.
- Snapshot exceptions are caught + logged + surfaced.

The existing `setup:dismiss` is moved to row 1 too so the launcher
shows a clean 4 + 2 button layout (primary on row 0, secondary on
row 1).

## Activation policy

Active by default. Admin-gated; preview-only (no mutations).

## Test plan

- [x] `pytest tests/unit/cogs/test_setup_cog.py` (36 tests; 3 new)
- [x] `pytest tests/` (3073 passed, 1 skipped, 0 failed)
- [x] `ruff check`, `ruff format --check`
- [ ] §9 step 22, 23 — complete setup, View Summary opens; drift detection
  flags a diverged binding

## Rollback

Revert the button addition; existing summary infra is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJ9uQ6akxAXeMd7VTuvKi7)_