### PR TITLE
bot1: spawn the automation scheduler at boot (PR-F)

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -627,6 +627,18 @@ async def main() -> None:
                 ),
             )
 
+            # Automation scheduler (Track 6 PR 18 / #211): gated behind
+            # ``AUTOMATION_SCHEDULER_ENABLED=true``. ``spawn_scheduler``
+            # returns ``None`` when the flag is off (default), so the
+            # bot boots inert by default. The returned task is already
+            # supervised by ``core.runtime.tasks.spawn``; we still
+            # append it to ``_APP_TASKS`` so shutdown cancels it.
+            from services.automation_scheduler import spawn_scheduler
+
+            scheduler_task = spawn_scheduler(bot)
+            if scheduler_task is not None:
+                _APP_TASKS.append(scheduler_task)
+
             await _load_cogs()
 
             # Cross-check subsystem identity surfaces (C1 / INV-B):

--- a/tests/unit/test_bot_boot.py
+++ b/tests/unit/test_bot_boot.py
@@ -1,0 +1,58 @@
+"""Static invariants on ``disbot/bot1.py`` startup wiring.
+
+Verifies that the entry-point module wires every supervised task we
+expect at boot. These are intentionally grep-style assertions: the
+runtime path runs inside ``async def main()`` and touching it from
+unit tests would require building the full bot lifecycle.
+
+Each invariant has a short rationale tied to the reconciliation plan.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_BOT1 = _REPO_ROOT / "disbot" / "bot1.py"
+
+
+def _src() -> str:
+    return _BOT1.read_text()
+
+
+def test_bot1_imports_and_calls_spawn_scheduler() -> None:
+    """PR-F: the automation scheduler must actually be spawned at boot.
+
+    ``spawn_scheduler`` is defined in
+    ``services/automation_scheduler.py`` but for production it must be
+    invoked from the entry-point module. The reconciliation plan §6
+    PR-F documents this as the call site.
+    """
+    src = _src()
+    assert "from services.automation_scheduler import spawn_scheduler" in src, (
+        "bot1.py must import spawn_scheduler so the automation scheduler "
+        "can be spawned at boot (PR-F)."
+    )
+    # Must call it with ``bot`` so the cog can reach the running loop.
+    assert re.search(r"spawn_scheduler\s*\(\s*bot\s*\)", src), (
+        "bot1.py must call spawn_scheduler(bot) at startup (PR-F)."
+    )
+
+
+def test_bot1_appends_scheduler_task_to_app_tasks() -> None:
+    """The spawned task must be cancelled on shutdown via _APP_TASKS."""
+    src = _src()
+    # Look for the conditional append — the scheduler returns None
+    # when the env flag is off, so the append is guarded.
+    assert "scheduler_task = spawn_scheduler(bot)" in src
+    assert (
+        re.search(
+            r"if\s+scheduler_task\s+is\s+not\s+None\s*:\s*\n\s*_APP_TASKS\.append\(\s*scheduler_task\s*\)",
+            src,
+        )
+        is not None
+    ), (
+        "bot1.py must append the spawn_scheduler() task to _APP_TASKS "
+        "when it is not None so shutdown can cancel it cleanly."
+    )


### PR DESCRIPTION
## Summary

Calls `services.automation_scheduler.spawn_scheduler(bot)` inside
`main()`'s `async with bot:` block, between supervised app-task setup
and `_load_cogs()`. The scheduler service was already wired and tested
(#211) — it just had no call site. With this PR the scheduler reaches
the loop when an operator opts in.

The scheduler module already gates on `AUTOMATION_SCHEDULER_ENABLED=true`
and returns `None` when the flag is off — so the default is inert and
matches the activation policy in the reconciliation plan §7.

When the flag is enabled, the returned task is appended to `_APP_TASKS`
so the shutdown path cancels it cleanly along with the other supervised
tasks (health server, session_gc, memory sampler).

## Activation policy

**Feature-flagged.** Default `AUTOMATION_SCHEDULER_ENABLED=false`
stays — no scheduler runs until the operator opts in.

## ⚠️ Prerequisite

**Merge PR-A (runtime instance lock) first** — without it, two
Railway replicas can both run the scheduler and double-fire every
automation rule.

## Test plan

- [x] `pytest tests/unit/test_bot_boot.py` (2 grep-style invariants pinning
  the import + call + `_APP_TASKS.append` pattern)
- [x] `pytest tests/` (3072 passed, 1 skipped, 0 failed)
- [x] `ruff check`, `ruff format --check`
- [ ] §9 step 20, 21 — rule with scheduler-off does NOT fire; with
  scheduler-on AND rule enabled fires once at next poll; second poll
  does not double-fire

## Rollback

Remove the `spawn_scheduler(bot)` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJ9uQ6akxAXeMd7VTuvKi7)_