### PR TITLE
role_cog: route threshold paths through role_automation (PR-G)

### DIFF
--- a/disbot/cogs/role_cog.py
+++ b/disbot/cogs/role_cog.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
 
 import discord
 from discord.ext import commands, tasks
@@ -9,6 +8,7 @@ from discord.ext import commands, tasks
 from core.runtime import panel_manager, resources
 from core.runtime.component_registry import stats_block
 from core.runtime.persistent_views import PersistentView, register
+from services import role_automation
 from utils import db
 from utils.guild_config_accessors import invalidate_xp_threshold_roles
 from utils.helpers import normalize_name
@@ -234,100 +234,53 @@ class RoleCog(commands.Cog):
         guild: discord.Guild,
         ctx: commands.Context = None,
     ) -> int:
-        """Assign time-based roles to all members. Returns count of assignments made."""
+        """Assign time-based roles to all members.
+
+        Returns the count of successful assignments. Delegates the
+        decision + mutation to
+        :mod:`services.role_automation` so that audit events
+        (``audit.action_recorded``) are emitted for every change and
+        the guild-wide batch shares logic with
+        :meth:`on_member_join`.
+        """
         await _ensure_defaults(guild.id)
         thresholds = await db.get_role_thresholds(guild.id)
         if not thresholds:
+            if ctx:
+                await ctx.send("✅ Role check complete — 0 assignment(s) made.")
             return 0
 
-        role_map = {row["role_name"]: row["days_required"] for row in thresholds}
-        progression = sorted(role_map, key=lambda r: role_map[r])
-
-        skip_role_names = [
+        skip_role_names = tuple(
             n.strip()
             for n in (await db.get_setting(guild.id, "skip_roles", "Admin")).split(",")
             if n.strip()
-        ]
-        admin_role = next(
-            (
-                r
-                for name in skip_role_names
-                for r in [_find_role_normalized(guild, name)]
-                if r
-            ),
-            None,
         )
-        assigned = 0
 
-        for member in guild.members:
-            if member.bot:
-                continue
-            if admin_role and admin_role in member.roles:
-                continue
-            if not member.joined_at:
-                continue
-
-            days = (datetime.now(tz=timezone.utc) - member.joined_at).days
-
-            target_name = None
-            for name in progression:
-                if days >= role_map[name]:
-                    target_name = name
-
-            target_role = (
-                _find_role_normalized(guild, target_name) if target_name else None
+        threshold_objs = tuple(
+            role_automation.RoleThreshold(
+                role_name=row["role_name"],
+                days_required=row["days_required"],
             )
+            for row in thresholds
+        )
 
-            current_highest: str | None = None
-            for role in member.roles:
-                matched = next(
-                    (
-                        n
-                        for n in role_map
-                        if normalize_name(n) == normalize_name(role.name)
-                    ),
-                    None,
-                )
-                if matched:
-                    if current_highest is None or progression.index(
-                        matched,
-                    ) > progression.index(current_highest):
-                        current_highest = matched
-
-            if (
-                current_highest
-                and target_name
-                and progression.index(current_highest) > progression.index(target_name)
-            ):
-                continue
-
-            to_remove = [
-                r
-                for r in member.roles
-                if any(normalize_name(r.name) == normalize_name(n) for n in role_map)
-                and r != target_role
-            ]
-            if to_remove:
-                try:
-                    await member.remove_roles(*to_remove)
-                except (discord.Forbidden, discord.HTTPException):
-                    pass
-
-            if target_role and target_role not in member.roles:
-                try:
-                    await member.add_roles(target_role)
-                    assigned += 1
-                    logger.info(
-                        "Assigned %s to %s",
-                        target_role.name,
-                        member.display_name,
-                    )
-                except (discord.Forbidden, discord.HTTPException):
-                    pass
+        assignments = role_automation.compute_assignments(
+            guild,
+            threshold_objs,
+            skip_role_names=skip_role_names,
+        )
+        result = await role_automation.apply(
+            guild,
+            assignments,
+            actor_id=None,
+            actor_type="system",
+        )
 
         if ctx:
-            await ctx.send(f"✅ Role check complete — {assigned} assignment(s) made.")
-        return assigned
+            await ctx.send(
+                f"✅ Role check complete — {result.succeeded} assignment(s) made.",
+            )
+        return result.succeeded
 
     # ------------------------------------------------------------------ primary commands
 
@@ -596,23 +549,29 @@ class RoleCog(commands.Cog):
             return
         await _ensure_defaults(member.guild.id)
         thresholds = await db.get_role_thresholds(member.guild.id)
-        zero_day = next(
-            (r["role_name"] for r in thresholds if r["days_required"] == 0),
-            None,
-        )
-        if not zero_day:
+        if not thresholds:
             return
-        role = _find_role_normalized(member.guild, zero_day)
-        if role:
-            try:
-                await member.add_roles(role)
-                logger.info(
-                    "Assigned '%s' to %s on join.",
-                    zero_day,
-                    member.display_name,
-                )
-            except (discord.Forbidden, discord.HTTPException):
-                pass
+
+        threshold_objs = tuple(
+            role_automation.RoleThreshold(
+                role_name=row["role_name"],
+                days_required=row["days_required"],
+            )
+            for row in thresholds
+        )
+        plan = role_automation.explain_assignment_for(
+            member.guild,
+            member,
+            threshold_objs,
+        )
+        if plan is None:
+            return
+        await role_automation.apply(
+            member.guild,
+            (plan,),
+            actor_id=None,
+            actor_type="system",
+        )
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/tests/unit/cogs/test_role_cog_routing.py
+++ b/tests/unit/cogs/test_role_cog_routing.py
@@ -1,0 +1,247 @@
+"""PR-G — ``role_cog`` threshold paths must route through ``role_automation``.
+
+Verifies that the cog no longer calls ``member.add_roles`` /
+``member.remove_roles`` directly inside the threshold flow. The cog
+delegates the decision to ``role_automation.compute_assignments`` /
+``explain_assignment_for`` and the mutation to ``role_automation.apply``,
+which is what emits ``audit.action_recorded``.
+
+The reaction-role and create/delete-role paths are intentionally NOT
+routed through this service (different domain) and are exempt from
+the routing check below.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cogs.role_cog import RoleCog
+from services import role_automation
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_ROLE_COG = _REPO_ROOT / "disbot" / "cogs" / "role_cog.py"
+
+
+@pytest.mark.asyncio
+async def test_assign_roles_delegates_to_role_automation():
+    """_assign_roles must call compute_assignments + apply, not Discord directly."""
+    bot = MagicMock()
+    cog = RoleCog(bot)
+
+    guild = MagicMock()
+    guild.id = 1
+    guild.members = []
+
+    fake_apply_result = role_automation.ApplyResult(
+        attempted=2, succeeded=2, failed=0,
+    )
+
+    with (
+        patch(
+            "cogs.role_cog._ensure_defaults",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "cogs.role_cog.db.get_role_thresholds",
+            new_callable=AsyncMock,
+            return_value=[
+                {"role_name": "Newbie", "days_required": 0},
+                {"role_name": "Veteran", "days_required": 30},
+            ],
+        ),
+        patch(
+            "cogs.role_cog.db.get_setting",
+            new_callable=AsyncMock,
+            return_value="Admin",
+        ),
+        patch(
+            "cogs.role_cog.role_automation.compute_assignments",
+            return_value=(),
+        ) as compute_mock,
+        patch(
+            "cogs.role_cog.role_automation.apply",
+            new_callable=AsyncMock,
+            return_value=fake_apply_result,
+        ) as apply_mock,
+    ):
+        count = await cog._assign_roles(guild)
+
+    compute_mock.assert_called_once()
+    apply_mock.assert_awaited_once()
+    assert count == 2
+    # The cog must pass a tuple of RoleThreshold objects, not raw rows.
+    threshold_arg = compute_mock.call_args.args[1]
+    assert all(isinstance(t, role_automation.RoleThreshold) for t in threshold_arg)
+
+
+@pytest.mark.asyncio
+async def test_assign_roles_returns_zero_when_no_thresholds():
+    """Empty threshold list short-circuits without calling the service."""
+    bot = MagicMock()
+    cog = RoleCog(bot)
+    guild = MagicMock(id=1)
+
+    with (
+        patch(
+            "cogs.role_cog._ensure_defaults",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "cogs.role_cog.db.get_role_thresholds",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "cogs.role_cog.role_automation.compute_assignments",
+        ) as compute_mock,
+        patch(
+            "cogs.role_cog.role_automation.apply",
+            new_callable=AsyncMock,
+        ) as apply_mock,
+    ):
+        count = await cog._assign_roles(guild)
+
+    assert count == 0
+    compute_mock.assert_not_called()
+    apply_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_member_join_delegates_to_role_automation():
+    """on_member_join must route through explain_assignment_for + apply."""
+    bot = MagicMock()
+    cog = RoleCog(bot)
+
+    member = MagicMock()
+    member.bot = False
+    member.guild = MagicMock(id=1)
+
+    fake_plan = role_automation.Assignment(
+        member_id=42,
+        member_display="bob",
+        add_role_id=7,
+        add_role_name="Newbie",
+        remove_role_ids=(),
+        remove_role_names=(),
+        reason="…",
+        days_in_guild=0,
+    )
+
+    with (
+        patch(
+            "cogs.role_cog._ensure_defaults",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "cogs.role_cog.db.get_role_thresholds",
+            new_callable=AsyncMock,
+            return_value=[
+                {"role_name": "Newbie", "days_required": 0},
+            ],
+        ),
+        patch(
+            "cogs.role_cog.role_automation.explain_assignment_for",
+            return_value=fake_plan,
+        ) as explain_mock,
+        patch(
+            "cogs.role_cog.role_automation.apply",
+            new_callable=AsyncMock,
+            return_value=role_automation.ApplyResult(),
+        ) as apply_mock,
+    ):
+        await cog.on_member_join(member)
+
+    explain_mock.assert_called_once()
+    apply_mock.assert_awaited_once()
+    # apply is called with a one-tuple containing the planned assignment.
+    plan_arg = apply_mock.await_args.args[1]
+    assert plan_arg == (fake_plan,)
+
+
+@pytest.mark.asyncio
+async def test_on_member_join_skips_when_no_plan():
+    """If explain_assignment_for returns None, apply is not invoked."""
+    bot = MagicMock()
+    cog = RoleCog(bot)
+    member = MagicMock()
+    member.bot = False
+    member.guild = MagicMock(id=1)
+
+    with (
+        patch(
+            "cogs.role_cog._ensure_defaults",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "cogs.role_cog.db.get_role_thresholds",
+            new_callable=AsyncMock,
+            return_value=[{"role_name": "Newbie", "days_required": 0}],
+        ),
+        patch(
+            "cogs.role_cog.role_automation.explain_assignment_for",
+            return_value=None,
+        ),
+        patch(
+            "cogs.role_cog.role_automation.apply",
+            new_callable=AsyncMock,
+        ) as apply_mock,
+    ):
+        await cog.on_member_join(member)
+
+    apply_mock.assert_not_awaited()
+
+
+def test_role_cog_threshold_paths_do_not_call_member_role_apis_directly():
+    """Static check: the threshold path must not call Discord member.add_roles
+    / member.remove_roles directly. Reaction-role and admin role create/delete
+    paths intentionally still call Discord directly (out of role_automation
+    scope) and are exempt.
+    """
+    src = _ROLE_COG.read_text()
+
+    # The two threshold methods are ``_assign_roles`` and ``on_member_join``.
+    # Both must be free of direct member.add_roles / member.remove_roles.
+    threshold_methods = [
+        _extract_method(src, "_assign_roles"),
+        _extract_method(src, "on_member_join"),
+    ]
+    for body in threshold_methods:
+        assert body is not None, (
+            "Expected to find the threshold method in role_cog.py"
+        )
+        assert (
+            "member.add_roles" not in body
+        ), (
+            "Threshold path must not call member.add_roles directly — "
+            "route through services.role_automation.apply (PR-G)."
+        )
+        assert (
+            "member.remove_roles" not in body
+        ), (
+            "Threshold path must not call member.remove_roles directly — "
+            "route through services.role_automation.apply (PR-G)."
+        )
+
+
+def _extract_method(src: str, name: str) -> str | None:
+    """Return the source of method ``name`` (until the next method/class)."""
+    pattern = re.compile(
+        r"^[ \t]*(async\s+)?def\s+" + re.escape(name) + r"\s*\(",
+        re.MULTILINE,
+    )
+    match = pattern.search(src)
+    if not match:
+        return None
+    start = match.start()
+    # Find the start of the next method/class at same or shallower indent.
+    next_def = re.compile(
+        r"^[ \t]*(async\s+)?def\s+\w+\s*\(|^class\s+\w+",
+        re.MULTILINE,
+    )
+    next_match = next_def.search(src, pos=match.end())
+    end = next_match.start() if next_match else len(src)
+    return src[start:end]


### PR DESCRIPTION
## Summary

Refactors `_assign_roles` (daily progression batch + `!checkroles`
command) and `on_member_join` (new-member zero-day path) so they
delegate to `services.role_automation`:

- **`_assign_roles`**: builds `RoleThreshold` objects from DB rows,
  calls `compute_assignments(guild, thresholds, skip_role_names=...)`
  for the pure decision step, then `await apply(guild, assignments,
  actor_type="system")` for the audited mutation. Returns
  `ApplyResult.succeeded`.
- **`on_member_join`**: calls
  `explain_assignment_for(guild, member, thresholds)` and applies the
  single-member plan via `apply(...)`.

The mutation now emits `audit.action_recorded` for every assign /
remove via the Track 1 shared helper, where previously the direct
`member.add_roles` / `member.remove_roles` calls vanished without
trail. Per-member failure isolation comes from `apply` so one
hierarchy-blocked role no longer aborts the batch.

`services.role_automation` (#206) landed in main but was never
integrated.

## Out of scope

The following paths intentionally remain on direct Discord calls —
they're different domains, not threshold-based:
- `!createrole` / `!deleterole` admin commands (lines 395, 411).
- Reaction-role add/remove listeners (lines 496, 520) — event-driven,
  single-member, single-role.

The reconciliation plan §6 also explicitly says: "Do not rewrite
`role_cog.py` and templates in the same PR unless unavoidable."

Removed now-unused `datetime`/`timezone` imports from `role_cog.py`.

## Activation policy

Active by default.

## Test plan

- [x] `pytest tests/unit/cogs/test_role_cog_routing.py` (5 new tests)
- [x] `pytest tests/unit/services/test_role_automation.py` (16 tests, all pass)
- [x] `pytest tests/` (3075 passed, 1 skipped, 0 failed)
- [x] Static check: threshold-path methods no longer call
  `member.add_roles` / `member.remove_roles` directly (reaction-role
  paths exempt)
- [ ] §9 — re-run role-cog commands in smoke guild; behavior identical;
  audit publisher records each event

## Rollback

Revert the file. No state migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJ9uQ6akxAXeMd7VTuvKi7)_