### PR TITLE
services: setup operation dispatcher + Final Review migration (PR 1)

### DIFF
--- a/disbot/services/setup_operations.py
+++ b/disbot/services/setup_operations.py
@@ -1,0 +1,602 @@
+"""Setup operation dispatcher — PR 1 of the setup-operations refactor.
+
+:mod:`services.setup_operations` is the canonical setup/preset/repair
+operation dispatcher.  All setup views, preset flows, and readiness-repair
+actions must produce :class:`SetupOperation` batches and route them through
+:func:`apply_operations` rather than calling individual mutation pipelines
+directly.
+
+Routing contract:
+
+* Binding operations (``bind_*`` / ``clear_binding``) →
+  :class:`services.binding_mutation.BindingMutationPipeline`.
+* Setting operations (``set_setting``) →
+  :class:`services.settings_mutation.SettingsMutationPipeline`.
+* Resource creation (``create_channel`` / ``create_role`` /
+  ``create_category``) →
+  :class:`services.resource_provisioning.ResourceProvisioningPipeline`.
+* Automation rule operations (``add_automation_rule`` /
+  ``enable_automation_rule`` / ``disable_automation_rule``) →
+  :class:`services.automation_mutation.AutomationMutationPipeline`.
+
+No direct DB writes or Discord resource creation in this module —
+every side effect routes through the canonical pipeline above it.
+
+Final Review uses this dispatcher, not concrete mutation pipelines
+directly; the view is orchestration-only.
+
+Future preset and readiness-repair migration should produce
+:class:`SetupOperation` batches and call :func:`apply_operations`.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+logger = logging.getLogger("bot.services.setup_operations")
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+OperationKind = Literal[
+    "bind_channel",
+    "bind_role",
+    "bind_category",
+    "bind_thread",
+    "bind_member",
+    "clear_binding",
+    "set_setting",
+    "create_channel",
+    "create_role",
+    "create_category",
+    "add_automation_rule",
+    "enable_automation_rule",
+    "disable_automation_rule",
+]
+
+OperationStatus = Literal["applied", "failed", "skipped", "not_yet_implemented"]
+
+_KNOWN_KINDS: frozenset[str] = frozenset(
+    {
+        "bind_channel",
+        "bind_role",
+        "bind_category",
+        "bind_thread",
+        "bind_member",
+        "clear_binding",
+        "set_setting",
+        "create_channel",
+        "create_role",
+        "create_category",
+        "add_automation_rule",
+        "enable_automation_rule",
+        "disable_automation_rule",
+    },
+)
+
+# bind_* kinds that route through BindingMutationPipeline.set_binding.
+_BINDING_KINDS: frozenset[str] = frozenset(
+    {"bind_channel", "bind_role", "bind_category", "bind_thread", "bind_member"},
+)
+
+# Adapter: SetupRecommendation.target_kind → OperationKind.
+_TARGET_KIND_TO_OP_KIND: dict[str, str] = {
+    "channel": "bind_channel",
+    "role": "bind_role",
+    "category": "bind_category",
+    "thread": "bind_thread",
+    "member": "bind_member",
+}
+
+
+@dataclass
+class SetupOperation:
+    """One typed setup action to be dispatched through the canonical pipelines.
+
+    Only the fields relevant to ``kind`` need to be provided; all optional
+    fields default to ``None``.  The dispatcher inspects ``kind`` first and
+    reads only the fields required for that routing path.
+    """
+
+    kind: str  # OperationKind — validated at dispatch time
+    subsystem: str
+    binding_name: str | None = None
+    setting_name: str | None = None
+    target_id: int | None = None
+    target_name: str | None = None
+    target_kind: str | None = None
+    value: Any = None
+    resource_name: str | None = None
+    resource_mode: str | None = None
+    existing_id: int | None = None
+    automation_rule_id: int | None = None
+    automation_rule_name: str | None = None
+    trigger_kind: str | None = None
+    action_kind: str | None = None
+    trigger_config: dict[str, Any] | None = None
+    action_config: dict[str, Any] | None = None
+    schedule: str | None = None
+    timezone: str | None = None
+    metadata: dict[str, Any] | None = None
+
+
+@dataclass
+class SetupOperationResult:
+    """Outcome of one :class:`SetupOperation` dispatch attempt.
+
+    ``status`` is the canonical partition key for callers rendering results.
+    ``mutation_id`` is set when the underlying pipeline returned one.
+    ``error`` is set when ``status`` is ``"failed"`` or ``"not_yet_implemented"``.
+    """
+
+    status: str  # OperationStatus
+    operation: SetupOperation
+    label: str
+    mutation_id: str | None = None
+    error: str | None = None
+
+
+@dataclass
+class SetupOperationBatchResult:
+    """Aggregated outcome of :func:`apply_operations`.
+
+    ``results`` is the ordered list of per-operation outcomes.
+    The four properties provide pre-partitioned views for embed rendering.
+    """
+
+    results: list[SetupOperationResult] = field(default_factory=list)
+
+    @property
+    def applied(self) -> list[SetupOperationResult]:
+        return [r for r in self.results if r.status == "applied"]
+
+    @property
+    def failed(self) -> list[SetupOperationResult]:
+        return [r for r in self.results if r.status == "failed"]
+
+    @property
+    def skipped(self) -> list[SetupOperationResult]:
+        return [r for r in self.results if r.status == "skipped"]
+
+    @property
+    def not_yet_implemented(self) -> list[SetupOperationResult]:
+        return [r for r in self.results if r.status == "not_yet_implemented"]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def validate_operation(op: SetupOperation) -> SetupOperationResult | None:
+    """Return a ``not_yet_implemented`` result if ``op.kind`` is unknown.
+
+    Returns ``None`` when the operation is dispatchable, allowing::
+
+        if err := validate_operation(op):
+            return err
+    """
+    if op.kind not in _KNOWN_KINDS:
+        return SetupOperationResult(
+            status="not_yet_implemented",
+            operation=op,
+            label=_label(op),
+            error=f"operation kind {op.kind!r} is not a known OperationKind",
+        )
+    return None
+
+
+def preview_operations(ops: list[SetupOperation]) -> list[SetupOperationResult]:
+    """Return validation results for each operation without side effects.
+
+    Validates each operation's kind only.  Operations with known kinds are
+    optimistically reported as ``"applied"``; unknown kinds are
+    ``"not_yet_implemented"``.  No DB reads are performed.
+    """
+    results: list[SetupOperationResult] = []
+    for op in ops:
+        err = validate_operation(op)
+        if err is not None:
+            results.append(err)
+            continue
+        results.append(
+            SetupOperationResult(
+                status="applied",
+                operation=op,
+                label=_label(op),
+            ),
+        )
+    return results
+
+
+async def apply_operations(
+    ops: list[SetupOperation],
+    *,
+    guild: Any,
+    actor: Any,
+    actor_type: str = "user",
+) -> SetupOperationBatchResult:
+    """Dispatch each operation through the appropriate mutation pipeline.
+
+    Failures are isolated per operation — one failure does not abort later
+    operations.  Each :class:`SetupOperationResult` carries ``status``,
+    ``label``, ``mutation_id`` (when the pipeline returned one), and
+    ``error`` (when the pipeline raised or the kind is unsupported).
+
+    Returns :class:`SetupOperationBatchResult` whose ``.applied``,
+    ``.failed``, ``.skipped``, and ``.not_yet_implemented`` properties
+    provide pre-partitioned views for embed rendering.
+    """
+    batch = SetupOperationBatchResult()
+    for op in ops:
+        result = await _dispatch_one(
+            op,
+            guild=guild,
+            actor=actor,
+            actor_type=actor_type,
+        )
+        batch.results.append(result)
+    return batch
+
+
+def operations_from_recommendations(
+    recs: list[Any],  # list[services.setup_plan.SetupRecommendation]
+) -> list[SetupOperation]:
+    """Adapt :class:`services.setup_plan.SetupRecommendation` objects to
+    :class:`SetupOperation` binding operations.
+
+    The current recommendation model only produces binding proposals, so every
+    ``SetupRecommendation`` maps to a ``bind_*`` operation.  Unknown
+    ``target_kind`` values produce operations whose kind is not in
+    ``_KNOWN_KINDS`` — the dispatcher will surface them as
+    ``"not_yet_implemented"`` rather than silently dropping them.
+
+    Future recommendation shapes (``set_setting``, ``create_resource``, etc.)
+    will extend this adapter in follow-up PRs.
+    """
+    result: list[SetupOperation] = []
+    for rec in recs:
+        raw_kind = (rec.target_kind or "").lower()
+        kind = _TARGET_KIND_TO_OP_KIND.get(
+            raw_kind,
+            # Unknown target_kind → synthetic kind that the dispatcher
+            # will surface as not_yet_implemented, not silently dropped.
+            f"bind_{raw_kind}" if raw_kind else "bind_unknown",
+        )
+        result.append(
+            SetupOperation(
+                kind=kind,
+                subsystem=rec.subsystem,
+                binding_name=rec.binding_name,
+                target_id=rec.target_id,
+                target_name=rec.target_name,
+                target_kind=rec.target_kind,
+                metadata={
+                    "source": getattr(rec, "source", "unknown"),
+                    "confidence": getattr(rec, "confidence", None),
+                },
+            ),
+        )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Internal dispatch
+# ---------------------------------------------------------------------------
+
+
+async def _dispatch_one(
+    op: SetupOperation,
+    *,
+    guild: Any,
+    actor: Any,
+    actor_type: str,
+) -> SetupOperationResult:
+    """Route one operation to the correct pipeline.  Never raises."""
+    label = _label(op)
+
+    err = validate_operation(op)
+    if err is not None:
+        return err
+
+    try:
+        if op.kind in _BINDING_KINDS:
+            return await _apply_binding(op, guild=guild, actor=actor, label=label)
+
+        if op.kind == "clear_binding":
+            return await _apply_clear_binding(op, guild=guild, actor=actor, label=label)
+
+        if op.kind == "set_setting":
+            return await _apply_set_setting(
+                op,
+                guild=guild,
+                actor=actor,
+                actor_type=actor_type,
+                label=label,
+            )
+
+        if op.kind in ("create_channel", "create_role", "create_category"):
+            return await _apply_resource_create(
+                op,
+                guild=guild,
+                actor=actor,
+                actor_type=actor_type,
+                label=label,
+            )
+
+        if op.kind == "add_automation_rule":
+            return await _apply_automation_create(
+                op,
+                guild=guild,
+                actor=actor,
+                label=label,
+            )
+
+        if op.kind in ("enable_automation_rule", "disable_automation_rule"):
+            return await _apply_automation_set_enabled(
+                op,
+                guild=guild,
+                actor=actor,
+                label=label,
+            )
+
+        # Unreachable given validate_operation above, but explicit.
+        return SetupOperationResult(
+            status="not_yet_implemented",
+            operation=op,
+            label=label,
+            error=f"operation kind {op.kind!r} has no dispatch path",
+        )
+
+    except Exception as exc:  # noqa: BLE001 — per-operation isolation boundary
+        logger.exception(
+            "setup_operations: failed to apply kind=%r label=%r",
+            op.kind,
+            label,
+        )
+        return SetupOperationResult(
+            status="failed",
+            operation=op,
+            label=label,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+
+
+async def _apply_binding(
+    op: SetupOperation,
+    *,
+    guild: Any,
+    actor: Any,
+    label: str,
+) -> SetupOperationResult:
+    from core.runtime.subsystem_schema import BindingKind
+    from services.binding_mutation import BindingMutationPipeline
+
+    raw = (op.target_kind or "").lower()
+    try:
+        kind = BindingKind(raw)
+    except ValueError:
+        return SetupOperationResult(
+            status="not_yet_implemented",
+            operation=op,
+            label=label,
+            error=f"target_kind {raw!r} is not a known BindingKind",
+        )
+
+    result = await BindingMutationPipeline().set_binding(
+        guild,
+        op.subsystem,
+        op.binding_name,  # type: ignore[arg-type]
+        kind,
+        op.target_id,  # type: ignore[arg-type]
+        actor,
+    )
+    return SetupOperationResult(
+        status="applied",
+        operation=op,
+        label=label,
+        mutation_id=result.mutation_id,
+    )
+
+
+async def _apply_clear_binding(
+    op: SetupOperation,
+    *,
+    guild: Any,
+    actor: Any,
+    label: str,
+) -> SetupOperationResult:
+    from core.runtime.subsystem_schema import BindingKind
+    from services.binding_mutation import BindingMutationPipeline
+
+    raw = (op.target_kind or "").lower()
+    try:
+        kind = BindingKind(raw)
+    except ValueError:
+        return SetupOperationResult(
+            status="not_yet_implemented",
+            operation=op,
+            label=label,
+            error=f"target_kind {raw!r} is not a known BindingKind for clear",
+        )
+
+    result = await BindingMutationPipeline().clear_binding(
+        guild,
+        op.subsystem,
+        op.binding_name,  # type: ignore[arg-type]
+        kind,
+        actor,
+    )
+    return SetupOperationResult(
+        status="applied",
+        operation=op,
+        label=label,
+        mutation_id=result.mutation_id,
+    )
+
+
+async def _apply_set_setting(
+    op: SetupOperation,
+    *,
+    guild: Any,
+    actor: Any,
+    actor_type: str,
+    label: str,
+) -> SetupOperationResult:
+    from services.settings_mutation import SettingsMutationPipeline
+
+    result = await SettingsMutationPipeline().set_value(
+        guild,
+        op.subsystem,
+        op.setting_name,  # type: ignore[arg-type]
+        op.value,
+        actor,
+        actor_type=actor_type,
+    )
+    return SetupOperationResult(
+        status="applied",
+        operation=op,
+        label=label,
+        mutation_id=result.mutation_id,
+    )
+
+
+async def _apply_resource_create(
+    op: SetupOperation,
+    *,
+    guild: Any,
+    actor: Any,
+    actor_type: str,
+    label: str,
+) -> SetupOperationResult:
+    from services.resource_provisioning import (
+        ProvisioningRequest,
+        ResourceProvisioningPipeline,
+    )
+
+    mode = op.resource_mode or (
+        "use_existing" if op.existing_id is not None else "create"
+    )
+    request = ProvisioningRequest(
+        subsystem=op.subsystem,
+        binding_name=op.binding_name or "",
+        mode=mode,
+        existing_id=op.existing_id,
+        custom_name=op.resource_name,
+    )
+    result = await ResourceProvisioningPipeline().provision(
+        guild,
+        request,
+        actor,
+        confirmed=True,
+        actor_type=actor_type,
+    )
+    return SetupOperationResult(
+        status="applied",
+        operation=op,
+        label=label,
+        mutation_id=result.mutation_id,
+    )
+
+
+async def _apply_automation_create(
+    op: SetupOperation,
+    *,
+    guild: Any,
+    actor: Any,
+    label: str,
+) -> SetupOperationResult:
+    from services.automation_mutation import AutomationMutationPipeline
+
+    result = await AutomationMutationPipeline().create_rule(
+        guild_id=guild.id,
+        guild_owner_id=guild.owner_id,
+        name=op.automation_rule_name or "",
+        trigger_kind=op.trigger_kind or "",
+        action_kind=op.action_kind or "",
+        trigger_config=op.trigger_config or {},
+        action_config=op.action_config or {},
+        schedule=op.schedule,
+        timezone_str=op.timezone or "UTC",
+        actor_id=getattr(actor, "id", None),
+        actor_type="system",
+    )
+    return SetupOperationResult(
+        status="applied",
+        operation=op,
+        label=label,
+        mutation_id=result.mutation_id,
+    )
+
+
+async def _apply_automation_set_enabled(
+    op: SetupOperation,
+    *,
+    guild: Any,
+    actor: Any,
+    label: str,
+) -> SetupOperationResult:
+    from services.automation_mutation import AutomationMutationPipeline
+
+    enabled = op.kind == "enable_automation_rule"
+    result = await AutomationMutationPipeline().set_enabled(
+        guild_id=guild.id,
+        guild_owner_id=guild.owner_id,
+        rule_id=op.automation_rule_id or 0,
+        enabled=enabled,
+        actor_id=getattr(actor, "id", None),
+        actor_type="system",
+    )
+    return SetupOperationResult(
+        status="applied",
+        operation=op,
+        label=label,
+        mutation_id=result.mutation_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _label(op: SetupOperation) -> str:
+    """Short human-readable description for logs and embed fields."""
+    if op.kind in _BINDING_KINDS or op.kind == "clear_binding":
+        target = op.target_name or (
+            str(op.target_id) if op.target_id is not None else "?"
+        )
+        return f"{op.subsystem}.{op.binding_name} → {target}"
+    if op.kind == "set_setting":
+        return f"{op.subsystem}.{op.setting_name} = {op.value!r}"
+    if op.kind in ("create_channel", "create_role", "create_category"):
+        return (
+            f"{op.kind}: {op.resource_name or '?'} "
+            f"({op.subsystem}.{op.binding_name})"
+        )
+    if op.kind in (
+        "add_automation_rule",
+        "enable_automation_rule",
+        "disable_automation_rule",
+    ):
+        name = op.automation_rule_name or (
+            str(op.automation_rule_id) if op.automation_rule_id is not None else "?"
+        )
+        return f"{op.kind}: {name}"
+    return f"{op.kind}: {op.subsystem}"
+
+
+__all__ = [
+    "OperationKind",
+    "OperationStatus",
+    "SetupOperation",
+    "SetupOperationBatchResult",
+    "SetupOperationResult",
+    "apply_operations",
+    "operations_from_recommendations",
+    "preview_operations",
+    "validate_operation",
+]

--- a/disbot/views/setup/final_review.py
+++ b/disbot/views/setup/final_review.py
@@ -2,17 +2,19 @@
 
 The last step of the wizard. The operator sees every accepted
 :class:`SetupRecommendation` in one place; clicking **Apply**
-routes each through the existing mutation pipelines.
+routes each through :mod:`services.setup_operations` (the canonical
+setup/preset/repair operation dispatcher) rather than calling mutation
+pipelines directly.
 
 Routing:
 
-* All recommendations go through
-  :class:`services.binding_mutation.BindingMutationPipeline.set_binding`
-  for binding kinds the operator picked from the AI / deterministic
-  advisor. Other target kinds (set_setting, create_role, etc.) are
-  routed in follow-up polish.
+* Accepted recommendations are converted to :class:`SetupOperation`
+  objects via :func:`services.setup_operations.operations_from_recommendations`
+  and applied via :func:`services.setup_operations.apply_operations`.
 * Failures are isolated per recommendation: one bad binding does
   not abort the rest.
+* Unsupported operation kinds are surfaced as skipped/not_yet_implemented,
+  not raised as exceptions.
 * Pipeline emission of ``audit.action_recorded`` (Track 1 PR 1)
   keeps the audit trail intact without any extra plumbing here.
 """
@@ -214,50 +216,41 @@ async def _apply_accepted(
     guild: Any,
     actor: Any,
 ) -> ApplySummary:
-    """Route each recommendation through the right pipeline.
+    """Route each recommendation through :mod:`services.setup_operations`.
 
-    All of v1 uses ``BindingMutationPipeline.set_binding`` because
-    the deterministic + AI advisors only produce binding
-    recommendations. Settings / role-create flows will route
-    through ``SettingsMutationPipeline`` / ``role_automation`` in
-    follow-up polish.
+    Converts recommendations to :class:`~services.setup_operations.SetupOperation`
+    objects, delegates to :func:`~services.setup_operations.apply_operations`,
+    then maps the :class:`~services.setup_operations.SetupOperationBatchResult`
+    back to :class:`ApplySummary` for rendering.
+
+    Failures are isolated per recommendation.  Unsupported or unrecognised
+    operation kinds appear in ``skipped`` rather than raising.
     """
-    from core.runtime.subsystem_schema import BindingKind
-    from services.binding_mutation import BindingMutationPipeline
+    from services.setup_operations import (
+        apply_operations,
+        operations_from_recommendations,
+    )
+
+    ops = operations_from_recommendations(recs)
+    batch = await apply_operations(ops, guild=guild, actor=actor)
 
     summary = ApplySummary()
-    pipeline = BindingMutationPipeline()
-    for rec in recs:
-        try:
-            kind_value = (rec.target_kind or "").lower()
-            try:
-                kind = BindingKind(kind_value)
-            except ValueError:
-                summary.skipped.append(
-                    f"{rec.subsystem}.{rec.binding_name}: unsupported "
-                    f"target_kind {kind_value!r}",
-                )
-                continue
-            await pipeline.set_binding(
-                guild,
-                rec.subsystem,
-                rec.binding_name,
-                kind,
-                rec.target_id,
-                actor,
-            )
-            summary.applied.append(
-                f"{rec.subsystem}.{rec.binding_name} → {rec.target_name}",
-            )
-        except Exception as exc:  # noqa: BLE001 — per-rec boundary
-            logger.exception(
-                "final_review: failed to apply %s.%s",
-                rec.subsystem,
-                rec.binding_name,
-            )
-            summary.failed.append(
-                f"{rec.subsystem}.{rec.binding_name}: {type(exc).__name__}: {exc}",
-            )
+    for result in batch.applied:
+        summary.applied.append(result.label)
+    for result in batch.failed:
+        summary.failed.append(
+            f"{result.label}: {result.error}" if result.error else result.label,
+        )
+    for result in batch.skipped:
+        summary.skipped.append(result.label)
+    for result in batch.not_yet_implemented:
+        summary.skipped.append(
+            (
+                f"{result.label} (not yet implemented)"
+                if not result.error
+                else f"{result.label}: {result.error}"
+            ),
+        )
     return summary
 
 

--- a/tests/unit/invariants/test_setup_operations_invariants.py
+++ b/tests/unit/invariants/test_setup_operations_invariants.py
@@ -1,0 +1,200 @@
+"""Invariant tests for the setup operation dispatcher — PR 1.
+
+Pins three structural constraints:
+
+1. Setup views that act as recommendation-apply orchestrators must not
+   import concrete mutation pipelines directly for their apply path.
+   After the dispatcher migration, ``final_review.py`` routes all
+   mutations through ``services.setup_operations``.
+
+   Purpose-built pipeline UI panels (provisioning preview/confirm) are
+   explicitly allowlisted: they are thin wrappers around one specific
+   pipeline and are NOT generic orchestrators.  They migrate to the
+   dispatcher in a dedicated future PR.
+
+2. ``services.setup_operations`` must not import low-level
+   ``utils.db.*`` mutation helpers at the top level.  All DB writes
+   flow through the canonical pipeline APIs.
+
+3. ``services.setup_operations`` must not call ``guild.create_*``
+   methods directly.  That constraint is already enforced globally by
+   ``test_no_silent_auto_create.py``; the third test here is a targeted
+   pin that remains meaningful if the global allowlist is later widened.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DISBOT = _REPO_ROOT / "disbot"
+_SETUP_VIEWS_DIR = _DISBOT / "views" / "setup"
+_SETUP_OPS_PATH = _DISBOT / "services" / "setup_operations.py"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _iter_setup_view_files() -> list[Path]:
+    return [
+        p
+        for p in _SETUP_VIEWS_DIR.rglob("*.py")
+        if "__pycache__" not in p.parts and p.name != "__init__.py"
+    ]
+
+
+def _top_level_import_names(path: Path) -> set[str]:
+    """Return the set of top-level module names imported by ``path``.
+
+    Covers both ``import X`` and ``from X import Y`` where X is
+    module-level (not inside a function or class).
+    """
+    tree = ast.parse(path.read_text())
+    names: set[str] = set()
+    for node in ast.iter_child_nodes(tree):  # only top-level nodes
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name.split(".")[0])
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                names.add(node.module.split(".")[0])
+                names.add(node.module)
+    return names
+
+
+def _has_attr_call(tree: ast.AST, attr_name: str) -> bool:
+    """True if the AST contains any ``<expr>.<attr_name>(...)`` call."""
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == attr_name
+        ):
+            return True
+    return False
+
+
+_FORBIDDEN_PIPELINE_MODULES = {
+    "services.binding_mutation",
+    "services.settings_mutation",
+    "services.resource_provisioning",
+    "services.automation_mutation",
+}
+
+# Purpose-built pipeline UI panels are thin wrappers around one specific
+# pipeline operation (preview / confirm a provisioning request).  They are
+# NOT generic recommendation-apply orchestrators and are allowlisted here
+# pending a future dedicated migration PR.
+_PIPELINE_IMPORT_ALLOWLIST: set[Path] = {
+    _SETUP_VIEWS_DIR / "provisioning" / "preview_panel.py",
+    _SETUP_VIEWS_DIR / "provisioning" / "confirm_panel.py",
+}
+
+_FORBIDDEN_DB_PREFIXES = {
+    "utils.db",
+}
+
+_FORBIDDEN_CREATE_METHODS = {
+    "create_text_channel",
+    "create_voice_channel",
+    "create_category",
+    "create_category_channel",
+    "create_role",
+    "create_thread",
+}
+
+
+# ---------------------------------------------------------------------------
+# 1. Setup views must not import concrete mutation pipelines at top level
+# ---------------------------------------------------------------------------
+
+
+def test_setup_views_do_not_import_mutation_pipelines_at_top_level():
+    """Setup view files outside the purpose-built-pipeline-UI allowlist must
+    not import concrete mutation pipelines at module (top) level.
+
+    After PR 1 the recommendation-apply path routes through
+    services.setup_operations.  Pipelines may still appear inside function
+    bodies (lazy imports) in any file; the constraint is top-level only.
+
+    Files in ``_PIPELINE_IMPORT_ALLOWLIST`` are purpose-built pipeline UI
+    panels (e.g. provisioning preview/confirm) and are exempted until a
+    future migration PR migrates them to the dispatcher.
+    """
+    violations: list[str] = []
+    for path in _iter_setup_view_files():
+        if path in _PIPELINE_IMPORT_ALLOWLIST:
+            continue
+        imports = _top_level_import_names(path)
+        bad = _FORBIDDEN_PIPELINE_MODULES & imports
+        if bad:
+            violations.append(
+                f"{path.relative_to(_REPO_ROOT)}: imports {sorted(bad)}"
+            )
+    assert not violations, (
+        "Setup view files must not import concrete mutation pipelines at the top "
+        "level — route mutations through services.setup_operations instead.\n"
+        "If this file is a purpose-built pipeline UI panel, add it to "
+        "_PIPELINE_IMPORT_ALLOWLIST with a migration note.\n\n"
+        + "\n".join(f"  {v}" for v in sorted(violations))
+    )
+
+
+def test_setup_views_invariant_path_exists():
+    """The setup views directory must exist — catches a rename that would
+    silently make this invariant vacuously true."""
+    assert _SETUP_VIEWS_DIR.is_dir(), (
+        f"disbot/views/setup/ not found at {_SETUP_VIEWS_DIR}; "
+        "update the invariant path if the directory was renamed"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. setup_operations.py must not import utils.db.* at top level
+# ---------------------------------------------------------------------------
+
+
+def test_setup_operations_does_not_import_db_utils_at_top_level():
+    """services/setup_operations.py must not import utils.db.* helpers at
+    module level.  All DB writes route through the canonical pipeline APIs.
+    """
+    assert _SETUP_OPS_PATH.exists(), (
+        f"services/setup_operations.py not found at {_SETUP_OPS_PATH}"
+    )
+    imports = _top_level_import_names(_SETUP_OPS_PATH)
+    bad = {m for m in imports if any(m.startswith(p) for p in _FORBIDDEN_DB_PREFIXES)}
+    assert not bad, (
+        "services/setup_operations.py must not import utils.db.* at the top level — "
+        "all DB writes must flow through the canonical pipeline APIs (e.g. "
+        "BindingMutationPipeline).  Offending imports:\n  "
+        + "\n  ".join(sorted(bad))
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. setup_operations.py must not call guild.create_* directly
+# ---------------------------------------------------------------------------
+
+
+def test_setup_operations_does_not_call_guild_create_directly():
+    """services/setup_operations.py must not call any guild.create_*
+    method.  Resource creation must route through
+    ResourceProvisioningPipeline which in turn calls guild_resources.ensure_*.
+    """
+    assert _SETUP_OPS_PATH.exists()
+    tree = ast.parse(_SETUP_OPS_PATH.read_text())
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr in _FORBIDDEN_CREATE_METHODS:
+            offenders.append(node.func.attr)
+    assert not offenders, (
+        "services/setup_operations.py must not call guild.create_* directly — "
+        "route resource creation through ResourceProvisioningPipeline.provision(). "
+        "Offending calls:\n  " + "\n  ".join(offenders)
+    )

--- a/tests/unit/services/test_setup_operations.py
+++ b/tests/unit/services/test_setup_operations.py
@@ -1,0 +1,517 @@
+"""Setup operation dispatcher tests — PR 1.
+
+Pins:
+
+* ``validate_operation`` accepts every known OperationKind and rejects
+  unknown kinds as ``not_yet_implemented``.
+* ``operations_from_recommendations`` maps each ``target_kind`` to the
+  correct ``bind_*`` kind and surfaces unknown target kinds as
+  not-yet-implemented operations rather than silently dropping them.
+* ``apply_operations`` routes each kind to the correct pipeline mock.
+* Batch apply isolates failure: one failed operation does not abort later
+  ones.
+* Result objects carry stable fields: ``status``, ``label``, ``mutation_id``
+  (when available), and ``error`` (when failed/not_yet_implemented).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.setup_operations import (
+    SetupOperation,
+    SetupOperationBatchResult,
+    SetupOperationResult,
+    apply_operations,
+    operations_from_recommendations,
+    preview_operations,
+    validate_operation,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _guild(guild_id: int = 1, owner_id: int = 99):
+    g = MagicMock()
+    g.id = guild_id
+    g.owner_id = owner_id
+    return g
+
+
+def _actor(actor_id: int = 99):
+    m = MagicMock()
+    m.id = actor_id
+    m.guild = SimpleNamespace(owner_id=actor_id)
+    return m
+
+
+def _bind_op(
+    kind: str = "bind_channel",
+    subsystem: str = "logging",
+    binding_name: str = "mod_channel",
+    target_id: int = 100,
+    target_name: str = "mod-log",
+    target_kind: str = "channel",
+) -> SetupOperation:
+    return SetupOperation(
+        kind=kind,
+        subsystem=subsystem,
+        binding_name=binding_name,
+        target_id=target_id,
+        target_name=target_name,
+        target_kind=target_kind,
+    )
+
+
+def _rec(
+    subsystem: str = "logging",
+    binding_name: str = "mod_channel",
+    target_kind: str = "channel",
+    target_id: int = 100,
+    target_name: str = "mod-log",
+    confidence: str = "high",
+):
+    # Use SimpleNamespace to avoid the deep asyncpg import chain that
+    # services.setup_plan → services.guild_snapshot → utils.db.pool triggers.
+    # operations_from_recommendations uses duck-typing, so this is fine.
+    return SimpleNamespace(
+        subsystem=subsystem,
+        binding_name=binding_name,
+        target_kind=target_kind,
+        target_id=target_id,
+        target_name=target_name,
+        confidence=confidence,
+        source="deterministic",
+        reason="test",
+    )
+
+
+# ---------------------------------------------------------------------------
+# validate_operation
+# ---------------------------------------------------------------------------
+
+
+def test_validate_operation_known_kind_returns_none():
+    from services.setup_operations import _KNOWN_KINDS
+
+    for kind in _KNOWN_KINDS:
+        op = SetupOperation(kind=kind, subsystem="logging")
+        assert validate_operation(op) is None, f"expected None for known kind {kind!r}"
+
+
+def test_validate_operation_unknown_kind_returns_not_yet_implemented():
+    op = SetupOperation(kind="totally_made_up_kind", subsystem="logging")
+    result = validate_operation(op)
+    assert result is not None
+    assert result.status == "not_yet_implemented"
+    assert "totally_made_up_kind" in (result.error or "")
+
+
+def test_validate_operation_result_carries_operation_reference():
+    op = SetupOperation(kind="unknown_xyz", subsystem="logging")
+    result = validate_operation(op)
+    assert result is not None
+    assert result.operation is op
+
+
+# ---------------------------------------------------------------------------
+# operations_from_recommendations
+# ---------------------------------------------------------------------------
+
+
+def test_operations_from_recommendations_maps_channel():
+    ops = operations_from_recommendations([_rec(target_kind="channel")])
+    assert len(ops) == 1
+    assert ops[0].kind == "bind_channel"
+
+
+def test_operations_from_recommendations_maps_role():
+    ops = operations_from_recommendations([_rec(target_kind="role")])
+    assert ops[0].kind == "bind_role"
+
+
+def test_operations_from_recommendations_maps_category():
+    ops = operations_from_recommendations([_rec(target_kind="category")])
+    assert ops[0].kind == "bind_category"
+
+
+def test_operations_from_recommendations_maps_thread():
+    ops = operations_from_recommendations([_rec(target_kind="thread")])
+    assert ops[0].kind == "bind_thread"
+
+
+def test_operations_from_recommendations_maps_member():
+    ops = operations_from_recommendations([_rec(target_kind="member")])
+    assert ops[0].kind == "bind_member"
+
+
+def test_operations_from_recommendations_preserves_fields():
+    rec = _rec(
+        subsystem="logging",
+        binding_name="mod_channel",
+        target_id=42,
+        target_name="mod-log",
+        target_kind="channel",
+    )
+    ops = operations_from_recommendations([rec])
+    op = ops[0]
+    assert op.subsystem == "logging"
+    assert op.binding_name == "mod_channel"
+    assert op.target_id == 42
+    assert op.target_name == "mod-log"
+    assert op.target_kind == "channel"
+
+
+def test_operations_from_recommendations_unknown_target_kind_not_silently_dropped():
+    """Unknown target_kind produces an operation that the dispatcher surfaces as
+    not_yet_implemented rather than silently omitting it from the batch."""
+    ops = operations_from_recommendations([_rec(target_kind="webhook")])
+    assert len(ops) == 1
+    # The kind won't be in _KNOWN_KINDS, so validate_operation will flag it.
+    result = validate_operation(ops[0])
+    assert result is not None
+    assert result.status == "not_yet_implemented"
+
+
+def test_operations_from_recommendations_metadata_carries_confidence():
+    rec = _rec(confidence="medium")
+    ops = operations_from_recommendations([rec])
+    meta = ops[0].metadata or {}
+    assert meta.get("confidence") == "medium"
+
+
+def test_operations_from_recommendations_empty_list_returns_empty():
+    assert operations_from_recommendations([]) == []
+
+
+# ---------------------------------------------------------------------------
+# preview_operations
+# ---------------------------------------------------------------------------
+
+
+def test_preview_operations_known_kinds_all_applied():
+    ops = [_bind_op("bind_channel"), _bind_op("bind_role", target_kind="role")]
+    results = preview_operations(ops)
+    assert all(r.status == "applied" for r in results)
+
+
+def test_preview_operations_unknown_kind_returns_not_yet_implemented():
+    ops = [SetupOperation(kind="bind_webhook", subsystem="x")]
+    results = preview_operations(ops)
+    assert results[0].status == "not_yet_implemented"
+
+
+# ---------------------------------------------------------------------------
+# apply_operations — binding path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_binding_operation_routes_through_binding_pipeline():
+    mock_result = MagicMock(mutation_id="m-001")
+    mock_pipeline = MagicMock()
+    mock_pipeline.set_binding = AsyncMock(return_value=mock_result)
+
+    op = _bind_op(kind="bind_channel", target_kind="channel")
+    # Pipelines are lazily imported inside dispatch functions, so patch the source.
+    with patch(
+        "services.binding_mutation.BindingMutationPipeline",
+        return_value=mock_pipeline,
+    ):
+        batch = await apply_operations([op], guild=_guild(), actor=_actor())
+
+    mock_pipeline.set_binding.assert_awaited_once()
+    assert len(batch.applied) == 1
+    assert batch.applied[0].mutation_id == "m-001"
+    assert batch.applied[0].status == "applied"
+
+
+@pytest.mark.asyncio
+async def test_apply_clear_binding_routes_through_binding_pipeline():
+    mock_result = MagicMock(mutation_id="m-clr")
+    mock_pipeline = MagicMock()
+    mock_pipeline.clear_binding = AsyncMock(return_value=mock_result)
+
+    op = SetupOperation(
+        kind="clear_binding",
+        subsystem="logging",
+        binding_name="mod_channel",
+        target_kind="channel",
+    )
+    with patch(
+        "services.binding_mutation.BindingMutationPipeline",
+        return_value=mock_pipeline,
+    ):
+        batch = await apply_operations([op], guild=_guild(), actor=_actor())
+
+    mock_pipeline.clear_binding.assert_awaited_once()
+    assert len(batch.applied) == 1
+    assert batch.applied[0].mutation_id == "m-clr"
+
+
+# ---------------------------------------------------------------------------
+# apply_operations — settings path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_setting_operation_routes_through_settings_pipeline():
+    mock_result = MagicMock(mutation_id="m-set")
+    mock_pipeline = MagicMock()
+    mock_pipeline.set_value = AsyncMock(return_value=mock_result)
+
+    op = SetupOperation(
+        kind="set_setting",
+        subsystem="economy",
+        setting_name="daily_coins",
+        value=100,
+    )
+    with patch(
+        "services.settings_mutation.SettingsMutationPipeline",
+        return_value=mock_pipeline,
+    ):
+        batch = await apply_operations([op], guild=_guild(), actor=_actor())
+
+    mock_pipeline.set_value.assert_awaited_once()
+    assert len(batch.applied) == 1
+    assert batch.applied[0].mutation_id == "m-set"
+
+
+# ---------------------------------------------------------------------------
+# apply_operations — automation path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_automation_create_routes_through_automation_pipeline():
+    mock_result = MagicMock(mutation_id="m-auto")
+    mock_pipeline = MagicMock()
+    mock_pipeline.create_rule = AsyncMock(return_value=mock_result)
+
+    op = SetupOperation(
+        kind="add_automation_rule",
+        subsystem="automation",
+        automation_rule_name="daily-summary",
+        trigger_kind="schedule",
+        action_kind="post_readiness_summary",
+    )
+    with patch(
+        "services.automation_mutation.AutomationMutationPipeline",
+        return_value=mock_pipeline,
+    ):
+        batch = await apply_operations([op], guild=_guild(), actor=_actor())
+
+    mock_pipeline.create_rule.assert_awaited_once()
+    assert len(batch.applied) == 1
+    assert batch.applied[0].mutation_id == "m-auto"
+
+
+@pytest.mark.asyncio
+async def test_apply_automation_enable_routes_through_automation_pipeline():
+    mock_result = MagicMock(mutation_id="m-en")
+    mock_pipeline = MagicMock()
+    mock_pipeline.set_enabled = AsyncMock(return_value=mock_result)
+
+    op = SetupOperation(
+        kind="enable_automation_rule",
+        subsystem="automation",
+        automation_rule_id=7,
+    )
+    with patch(
+        "services.automation_mutation.AutomationMutationPipeline",
+        return_value=mock_pipeline,
+    ):
+        batch = await apply_operations([op], guild=_guild(), actor=_actor())
+
+    mock_pipeline.set_enabled.assert_awaited_once()
+    call_kwargs = mock_pipeline.set_enabled.await_args.kwargs
+    assert call_kwargs["enabled"] is True
+    assert call_kwargs["rule_id"] == 7
+
+
+@pytest.mark.asyncio
+async def test_apply_automation_disable_passes_enabled_false():
+    mock_result = MagicMock(mutation_id="m-dis")
+    mock_pipeline = MagicMock()
+    mock_pipeline.set_enabled = AsyncMock(return_value=mock_result)
+
+    op = SetupOperation(
+        kind="disable_automation_rule",
+        subsystem="automation",
+        automation_rule_id=3,
+    )
+    with patch(
+        "services.automation_mutation.AutomationMutationPipeline",
+        return_value=mock_pipeline,
+    ):
+        batch = await apply_operations([op], guild=_guild(), actor=_actor())
+
+    call_kwargs = mock_pipeline.set_enabled.await_args.kwargs
+    assert call_kwargs["enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# apply_operations — resource provisioning path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_create_channel_routes_through_provisioning_pipeline():
+    mock_result = MagicMock(mutation_id="m-prov")
+    mock_pipeline = MagicMock()
+    mock_pipeline.provision = AsyncMock(return_value=mock_result)
+
+    op = SetupOperation(
+        kind="create_channel",
+        subsystem="logging",
+        binding_name="mod_channel",
+        resource_name="mod-log",
+    )
+    with patch(
+        "services.resource_provisioning.ResourceProvisioningPipeline",
+        return_value=mock_pipeline,
+    ):
+        batch = await apply_operations([op], guild=_guild(), actor=_actor())
+
+    mock_pipeline.provision.assert_awaited_once()
+    assert len(batch.applied) == 1
+    assert batch.applied[0].mutation_id == "m-prov"
+
+
+# ---------------------------------------------------------------------------
+# Batch isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_batch_isolates_failure_one_failed_does_not_abort_others():
+    mock_pipeline = MagicMock()
+    mock_pipeline.set_binding = AsyncMock(
+        side_effect=[
+            MagicMock(mutation_id="m-ok"),
+            RuntimeError("boom"),
+            MagicMock(mutation_id="m-ok2"),
+        ]
+    )
+
+    ops = [
+        _bind_op(target_id=1),
+        _bind_op(target_id=2),
+        _bind_op(target_id=3),
+    ]
+    with patch(
+        "services.binding_mutation.BindingMutationPipeline",
+        return_value=mock_pipeline,
+    ):
+        batch = await apply_operations(ops, guild=_guild(), actor=_actor())
+
+    assert len(batch.applied) == 2
+    assert len(batch.failed) == 1
+    assert "boom" in (batch.failed[0].error or "")
+    # total results == total ops
+    assert len(batch.results) == 3
+
+
+@pytest.mark.asyncio
+async def test_not_yet_implemented_kind_does_not_abort_batch():
+    """An unrecognised kind in a batch is surfaced as not_yet_implemented
+    and subsequent operations still execute."""
+    mock_pipeline = MagicMock()
+    mock_pipeline.set_binding = AsyncMock(return_value=MagicMock(mutation_id="m-ok"))
+
+    ops = [
+        SetupOperation(kind="bind_webhook", subsystem="x"),  # unknown
+        _bind_op(),  # known
+    ]
+    with patch(
+        "services.binding_mutation.BindingMutationPipeline",
+        return_value=mock_pipeline,
+    ):
+        batch = await apply_operations(ops, guild=_guild(), actor=_actor())
+
+    assert len(batch.not_yet_implemented) == 1
+    assert len(batch.applied) == 1
+    assert len(batch.results) == 2
+
+
+# ---------------------------------------------------------------------------
+# Result shape invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_result_applied_has_mutation_id_and_no_error():
+    mock_result = MagicMock(mutation_id="m-shape")
+    mock_pipeline = MagicMock()
+    mock_pipeline.set_binding = AsyncMock(return_value=mock_result)
+
+    with patch(
+        "services.binding_mutation.BindingMutationPipeline",
+        return_value=mock_pipeline,
+    ):
+        batch = await apply_operations([_bind_op()], guild=_guild(), actor=_actor())
+
+    r = batch.applied[0]
+    assert r.status == "applied"
+    assert r.mutation_id == "m-shape"
+    assert r.error is None
+    assert r.label != ""
+
+
+@pytest.mark.asyncio
+async def test_result_failed_has_error_text_and_no_mutation_id():
+    mock_pipeline = MagicMock()
+    mock_pipeline.set_binding = AsyncMock(side_effect=ValueError("bad value"))
+
+    with patch(
+        "services.binding_mutation.BindingMutationPipeline",
+        return_value=mock_pipeline,
+    ):
+        batch = await apply_operations([_bind_op()], guild=_guild(), actor=_actor())
+
+    r = batch.failed[0]
+    assert r.status == "failed"
+    assert "bad value" in (r.error or "")
+    assert r.mutation_id is None
+    assert r.label != ""
+
+
+def test_result_not_yet_implemented_carries_kind_in_error():
+    op = SetupOperation(kind="bind_smoke_signal", subsystem="y")
+    result = validate_operation(op)
+    assert result is not None
+    assert result.status == "not_yet_implemented"
+    assert "bind_smoke_signal" in (result.error or "")
+    assert result.label != ""
+
+
+# ---------------------------------------------------------------------------
+# SetupOperationBatchResult partition helpers
+# ---------------------------------------------------------------------------
+
+
+def test_batch_result_partitions_are_consistent():
+    ops_result = [
+        SetupOperationResult(status="applied", operation=_bind_op(), label="a"),
+        SetupOperationResult(
+            status="failed", operation=_bind_op(), label="b", error="e"
+        ),
+        SetupOperationResult(status="skipped", operation=_bind_op(), label="c"),
+        SetupOperationResult(
+            status="not_yet_implemented", operation=_bind_op(), label="d", error="nyi"
+        ),
+    ]
+    batch = SetupOperationBatchResult(results=ops_result)
+    assert len(batch.applied) == 1
+    assert len(batch.failed) == 1
+    assert len(batch.skipped) == 1
+    assert len(batch.not_yet_implemented) == 1
+    assert batch.applied[0].label == "a"
+    assert batch.failed[0].label == "b"
+    assert batch.skipped[0].label == "c"
+    assert batch.not_yet_implemented[0].label == "d"

--- a/tests/unit/views/setup/test_wizard_hub.py
+++ b/tests/unit/views/setup/test_wizard_hub.py
@@ -9,8 +9,8 @@ Pins:
 * The Final Review button opens the ``FinalReviewView`` with the
   current accepted set (empty in this view's lifecycle).
 * ``FinalReviewView`` routes each accepted recommendation through
-  ``BindingMutationPipeline.set_binding`` and isolates per-rec
-  failures into the ``failed`` list.
+  :func:`services.setup_operations.apply_operations` (not directly
+  through ``BindingMutationPipeline``) and isolates per-rec failures.
 * ``FinalReviewView`` disables Apply when ``accepted`` is empty.
 """
 

--- a/tests/unit/views/setup/test_wizard_hub.py
+++ b/tests/unit/views/setup/test_wizard_hub.py
@@ -229,35 +229,99 @@ def test_final_review_view_disables_apply_when_empty():
 
 
 @pytest.mark.asyncio
-async def test_final_review_apply_routes_through_binding_pipeline():
-    pipeline_mock = MagicMock()
-    pipeline_mock.set_binding = AsyncMock(
-        return_value=MagicMock(mutation_id="m1"),
+async def test_final_review_apply_calls_setup_operations_dispatcher():
+    """FinalReviewView.Apply routes through setup_operations.apply_operations,
+    not directly through BindingMutationPipeline."""
+    from services.setup_operations import (
+        SetupOperationBatchResult,
+        SetupOperationResult,
     )
+
+    fake_op = MagicMock()
+    fake_result = SetupOperationResult(
+        status="applied",
+        operation=fake_op,
+        label="logging.mod_channel → mod-log",
+        mutation_id="m1",
+    )
+    fake_batch = SetupOperationBatchResult(results=[fake_result])
+
     view = FinalReviewView(_owner_member(), accepted=[_rec()])
     interaction = _interaction(_owner_member())
     with (
         patch(
-            "services.binding_mutation.BindingMutationPipeline",
-            return_value=pipeline_mock,
-        ),
+            "services.setup_operations.apply_operations",
+            new_callable=AsyncMock,
+            return_value=fake_batch,
+        ) as apply_mock,
         patch(
             "services.setup_session.mark_complete",
             new_callable=AsyncMock,
         ),
     ):
         await view._apply.callback(interaction)
-    pipeline_mock.set_binding.assert_awaited_once()
+    apply_mock.assert_awaited_once()
     assert view.summary is not None
     assert len(view.summary.applied) == 1
     assert view.summary.failed == []
 
 
 @pytest.mark.asyncio
+async def test_final_review_apply_does_not_call_binding_pipeline_directly():
+    """After the dispatcher migration, BindingMutationPipeline must NOT be
+    instantiated directly by FinalReviewView._apply."""
+    from services.setup_operations import (
+        SetupOperationBatchResult,
+        SetupOperationResult,
+    )
+
+    fake_batch = SetupOperationBatchResult(
+        results=[
+            SetupOperationResult(
+                status="applied",
+                operation=MagicMock(),
+                label="x",
+                mutation_id="m1",
+            )
+        ]
+    )
+
+    view = FinalReviewView(_owner_member(), accepted=[_rec()])
+    interaction = _interaction(_owner_member())
+    binding_ctor = MagicMock()
+    with (
+        patch(
+            "services.setup_operations.apply_operations",
+            new_callable=AsyncMock,
+            return_value=fake_batch,
+        ),
+        patch("services.binding_mutation.BindingMutationPipeline", binding_ctor),
+        patch("services.setup_session.mark_complete", new_callable=AsyncMock),
+    ):
+        await view._apply.callback(interaction)
+    # The view must not have constructed BindingMutationPipeline itself.
+    binding_ctor.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_final_review_apply_isolates_per_rec_failures():
-    pipeline_mock = MagicMock()
-    pipeline_mock.set_binding = AsyncMock(
-        side_effect=[MagicMock(mutation_id="m1"), RuntimeError("boom")],
+    """One failed operation in the batch does not abort later ones; the
+    summary receives correct applied/failed counts."""
+    from services.setup_operations import (
+        SetupOperationBatchResult,
+        SetupOperationResult,
+    )
+
+    op = MagicMock()
+    fake_batch = SetupOperationBatchResult(
+        results=[
+            SetupOperationResult(
+                status="applied", operation=op, label="a", mutation_id="m1"
+            ),
+            SetupOperationResult(
+                status="failed", operation=op, label="b", error="boom"
+            ),
+        ]
     )
     view = FinalReviewView(
         _owner_member(),
@@ -266,13 +330,11 @@ async def test_final_review_apply_isolates_per_rec_failures():
     interaction = _interaction(_owner_member())
     with (
         patch(
-            "services.binding_mutation.BindingMutationPipeline",
-            return_value=pipeline_mock,
-        ),
-        patch(
-            "services.setup_session.mark_complete",
+            "services.setup_operations.apply_operations",
             new_callable=AsyncMock,
+            return_value=fake_batch,
         ),
+        patch("services.setup_session.mark_complete", new_callable=AsyncMock),
     ):
         await view._apply.callback(interaction)
     assert view.summary is not None
@@ -283,24 +345,80 @@ async def test_final_review_apply_isolates_per_rec_failures():
 
 @pytest.mark.asyncio
 async def test_final_review_apply_skips_unsupported_target_kind():
+    """Unsupported/not_yet_implemented operations land in summary.skipped,
+    not in failed, and do not crash the apply."""
+    from services.setup_operations import (
+        SetupOperationBatchResult,
+        SetupOperationResult,
+    )
+
+    op = MagicMock()
+    fake_batch = SetupOperationBatchResult(
+        results=[
+            SetupOperationResult(
+                status="not_yet_implemented",
+                operation=op,
+                label="logging.mod_channel → ?",
+                error="operation kind 'bind_totally_made_up_kind' is not a known OperationKind",
+            )
+        ]
+    )
     view = FinalReviewView(
         _owner_member(),
         accepted=[_rec(target_kind="totally_made_up_kind")],
     )
-    pipeline_mock = MagicMock()
-    pipeline_mock.set_binding = AsyncMock()
     interaction = _interaction(_owner_member())
     with (
         patch(
-            "services.binding_mutation.BindingMutationPipeline",
-            return_value=pipeline_mock,
-        ),
-        patch(
-            "services.setup_session.mark_complete",
+            "services.setup_operations.apply_operations",
             new_callable=AsyncMock,
+            return_value=fake_batch,
         ),
+        patch("services.setup_session.mark_complete", new_callable=AsyncMock),
     ):
         await view._apply.callback(interaction)
-    pipeline_mock.set_binding.assert_not_awaited()
     assert view.summary is not None
     assert len(view.summary.skipped) == 1
+    assert view.summary.applied == []
+    assert view.summary.failed == []
+
+
+@pytest.mark.asyncio
+async def test_final_review_apply_partial_success_renders_applied_failed_skipped():
+    """build_final_review_embed renders correct counts from a mixed-status batch."""
+    from services.setup_operations import (
+        SetupOperationBatchResult,
+        SetupOperationResult,
+    )
+
+    op = MagicMock()
+    fake_batch = SetupOperationBatchResult(
+        results=[
+            SetupOperationResult(
+                status="applied", operation=op, label="a", mutation_id="x"
+            ),
+            SetupOperationResult(status="failed", operation=op, label="b", error="err"),
+            SetupOperationResult(
+                status="not_yet_implemented", operation=op, label="c", error="nyi"
+            ),
+        ]
+    )
+    view = FinalReviewView(
+        _owner_member(),
+        accepted=[_rec(), _rec(target_id=2), _rec(target_id=3)],
+    )
+    interaction = _interaction(_owner_member())
+    with (
+        patch(
+            "services.setup_operations.apply_operations",
+            new_callable=AsyncMock,
+            return_value=fake_batch,
+        ),
+        patch("services.setup_session.mark_complete", new_callable=AsyncMock),
+    ):
+        await view._apply.callback(interaction)
+    embed = build_final_review_embed(view.accepted, summary=view.summary)
+    desc = embed.description or ""
+    assert "Applied **1**" in desc
+    assert "failed **1**" in desc
+    assert "skipped **1**" in desc


### PR DESCRIPTION
## Summary

- Introduces `services/setup_operations.py` as the canonical dispatcher for all setup wizard, preset, and readiness-repair mutations — no view may call a mutation pipeline directly for apply behaviour after this PR
- Migrates `FinalReviewView._apply` from direct `BindingMutationPipeline` calls to `apply_operations`; user-facing behaviour is unchanged
- Adds 3 structural invariant tests that enforce the new boundary going forward

## What's in this PR

### New: `disbot/services/setup_operations.py`

Typed public surface:
- `SetupOperation` — operation shape (19 fields, all optional except `kind`/`subsystem`)
- `SetupOperationResult` / `SetupOperationBatchResult` — per-op and batch outcomes with `.applied`, `.failed`, `.skipped`, `.not_yet_implemented` partition properties
- `validate_operation` — side-effect-free kind check
- `preview_operations` — dry-run batch validation (no DB reads)
- `apply_operations` — dispatches through canonical pipelines with per-op failure isolation
- `operations_from_recommendations` — adapts `SetupRecommendation` to `bind_*` ops; unknown `target_kind` surfaces as `not_yet_implemented`, never silently dropped

Routing:
| kind | pipeline |
|---|---|
| `bind_channel/role/category/thread/member`, `clear_binding` | `BindingMutationPipeline` |
| `set_setting` | `SettingsMutationPipeline` |
| `create_channel/role/category` | `ResourceProvisioningPipeline` |
| `add/enable/disable_automation_rule` | `AutomationMutationPipeline` |

No direct DB writes or `guild.create_*` calls — every side effect routes through the canonical pipeline above it.

### Modified: `disbot/views/setup/final_review.py`

`_apply_accepted` is now 15 lines using `operations_from_recommendations` + `apply_operations`. Direct `BindingMutationPipeline` import removed. `not_yet_implemented` results fold into `summary.skipped` for UI backward compatibility.

### Tests

- `tests/unit/services/test_setup_operations.py` — 27 new tests covering all routing paths, batch isolation, result shape invariants, and recommendation adapter
- `tests/unit/views/setup/test_wizard_hub.py` — 3 old binding-pipeline tests replaced; 5 new dispatcher-aware tests added (including a test that asserts `BindingMutationPipeline` is NOT constructed by the view)
- `tests/unit/invariants/test_setup_operations_invariants.py` — 3 invariant tests: setup views may not top-level-import mutation pipelines (allowlist for purpose-built provisioning panels), `setup_operations.py` may not top-level-import `utils.db.*`, `setup_operations.py` may not call `guild.create_*`

## Test results

```
tests/unit/services/test_setup_operations.py   27 passed
tests/unit/views/setup/                        69 passed
tests/unit/invariants/                        153 passed
tests/unit/ (full suite)                     3151 passed, 1 skipped
ruff / black / isort                          clean
```

## Follow-up PR map

| PR | Scope |
|---|---|
| PR 2 | Persist setup drafts and applied operation records |
| PR 3 | Split setup wizard into section modules; add setup section registry |
| PR 4 | Schema-driven settings panel generated from `SettingSpec` |
| PR 5 | Preset preview/apply via `SetupOperation` batches (migrate `template_picker.py`) |
| PR 6 | Automation management and diagnostics panel |
| PR 7 | Global panel actionability contract across all subsystem panels |
| PR 8 | Consolidate channel, cleanup, and role command panels |

https://claude.ai/code/session_01LQKw1jTPTgZiiof3T6Egqq

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQKw1jTPTgZiiof3T6Egqq)_