### PR TITLE
core: bootstrap command access for fresh guilds

### DIFF
--- a/disbot/cogs/bootstrap_access_cog.py
+++ b/disbot/cogs/bootstrap_access_cog.py
@@ -1,0 +1,130 @@
+"""Fresh-guild bootstrap access wiring.
+
+This cog is intentionally loaded first.  It replaces the legacy entry-point
+channel guard with the centralized helper from
+``core.runtime.command_access`` so setup/help/platform/admin/settings commands
+remain reachable for guild operators before a new server has configured bot
+channels.
+
+The replacement stays narrow:
+
+* normal commands still require ``BOT_ALLOWED_CHANNELS``;
+* ``!force`` remains the explicit admin escape hatch;
+* bootstrap bypass only applies to guild owners, administrators,
+  ``manage_guild`` members, and bot owners;
+* command-level permission decorators still run after this guard.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from typing import Any
+
+from discord.ext import commands
+
+import config
+from core.runtime.command_access import (
+    can_bypass_channel_guard,
+    is_bootstrap_command,
+)
+
+logger = logging.getLogger("bot.cogs.bootstrap_access")
+
+
+def _find_channel_guard_checks(bot: commands.Bot) -> list[Any]:
+    """Return installed global checks that look like the legacy guard."""
+    checks: Iterable[Any] = getattr(bot, "_checks", ())
+    return [check for check in checks if getattr(check, "__name__", "") == "_channel_guard"]
+
+
+def _is_shutting_down_from_legacy_guard(legacy_guard: Any | None) -> bool:
+    """Read ``_shutting_down`` from the original guard's globals, if present."""
+    if legacy_guard is None:
+        return False
+    return bool(getattr(legacy_guard, "__globals__", {}).get("_shutting_down", False))
+
+
+def _command_name(ctx: commands.Context) -> str | None:
+    command = getattr(ctx, "command", None)
+    if command is None:
+        return getattr(ctx, "invoked_with", None)
+    return getattr(command, "qualified_name", None) or getattr(command, "name", None)
+
+
+class BootstrapAccessCog(commands.Cog):
+    """Installs the fresh-guild-aware global channel guard."""
+
+    def __init__(self, bot: commands.Bot, *, legacy_guard: Any | None = None) -> None:
+        self.bot = bot
+        self._legacy_guard = legacy_guard
+
+    async def _channel_guard(self, ctx: commands.Context) -> bool:
+        if _is_shutting_down_from_legacy_guard(self._legacy_guard):
+            return False
+        if ctx.guild is None:
+            return False
+        if ctx.channel.id in config.ALLOWED_CHANNELS:
+            return True
+        if ctx.command is not None and ctx.command.name == "force":
+            return True
+        return await can_bypass_channel_guard(ctx)
+
+    @commands.Cog.listener()
+    async def on_command_error(
+        self,
+        ctx: commands.Context,
+        error: commands.CommandError,
+    ) -> None:
+        """Surface bootstrap permission/usage errors outside allowed channels.
+
+        The entry-point ``bot1.on_command_error`` intentionally suppresses
+        user-facing replies outside ``BOT_ALLOWED_CHANNELS``.  Once bootstrap
+        commands can bypass that channel guard, operators still need feedback
+        for ordinary decorator failures such as ``MissingPermissions`` or a
+        bad argument.  Only bootstrap commands outside allowed channels are
+        handled here, so normal command channels keep the existing behavior.
+        """
+        if ctx.guild is None or ctx.channel.id in config.ALLOWED_CHANNELS:
+            return
+        if not is_bootstrap_command(_command_name(ctx)):
+            return
+
+        if isinstance(error, commands.MissingPermissions):
+            await ctx.send(
+                "❌ You do not have permission to use this bootstrap command.",
+                delete_after=10,
+            )
+        elif isinstance(error, commands.BotMissingPermissions):
+            await ctx.send(
+                f"❌ I'm missing permissions to do that: `{error.missing_permissions}`",
+                delete_after=10,
+            )
+        elif isinstance(error, commands.MissingRequiredArgument):
+            await ctx.send(
+                f"⚠️ Missing argument: `{error.param.name}`. Use `!help {ctx.command}` for usage.",
+                delete_after=10,
+            )
+        elif isinstance(error, commands.BadArgument):
+            await ctx.send(f"⚠️ Bad argument: {error}", delete_after=10)
+        elif isinstance(error, commands.CommandOnCooldown):
+            await ctx.send(
+                f"⏰ This command is on cooldown. Try again in **{error.retry_after:.1f}s**.",
+                delete_after=8,
+            )
+
+
+async def setup(bot: commands.Bot) -> None:
+    legacy_guards = _find_channel_guard_checks(bot)
+    legacy_guard = legacy_guards[0] if legacy_guards else None
+    for guard in legacy_guards:
+        bot.remove_check(guard)
+    bot.add_check(BootstrapAccessCog(bot, legacy_guard=legacy_guard)._channel_guard)
+    await bot.add_cog(BootstrapAccessCog(bot, legacy_guard=legacy_guard))
+    logger.info(
+        "BootstrapAccessCog loaded; replaced %d legacy channel guard(s).",
+        len(legacy_guards),
+    )
+
+
+__all__ = ["BootstrapAccessCog", "setup"]

--- a/disbot/core/runtime/command_access.py
+++ b/disbot/core/runtime/command_access.py
@@ -1,0 +1,150 @@
+"""Command-access helpers for fresh-guild bootstrap flows.
+
+The global channel guard in ``bot1.py`` restricts most prefix commands to
+``BOT_ALLOWED_CHANNELS``.  That is appropriate for day-to-day command
+traffic, but it can strand a newly invited guild: the operator needs a
+small, safe set of setup / diagnostics entry points before the guild has
+configured channel bindings or command-policy state.
+
+This module owns that exception in one place.  It does not execute command
+logic and it does not bypass command-level permission decorators; it only
+answers whether the entry-point channel guard may let a bootstrap command
+reach the normal discord.py checks.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from discord.ext import commands
+
+# Keep this intentionally small: these are operator/bootstrap surfaces, not
+# normal gameplay or economy commands.  Group roots cover subcommands through
+# ``Command.qualified_name`` (for example, ``platform identity`` → ``platform``).
+BOOTSTRAP_COMMANDS: frozenset[str] = frozenset(
+    {
+        "admin",
+        "adminmenu",
+        "check_database",
+        "checkdb",
+        "diag",
+        "diag_status",
+        "diagnostic_bot_status",
+        "diagnostics",
+        "find_command",
+        "findcmd",
+        "help",
+        "latency",
+        "list_commands_detailed",
+        "listcmds",
+        "ping",
+        "platform",
+        "settings",
+        "setup",
+        "slashes",
+        "slashlist",
+        "syncs",
+        "syncslash",
+        "system_info",
+        "sysinfo",
+    },
+)
+
+
+def is_bootstrap_command(command_name: str | None) -> bool:
+    """Return ``True`` if ``command_name`` is a bootstrap command.
+
+    Accepts both bare names (``"help"``) and qualified group names
+    (``"platform identity"``).  The root of a qualified name is checked so
+    existing platform/settings/admin subcommands inherit their parent gate.
+    """
+    if not command_name:
+        return False
+    normalized = command_name.strip().lower()
+    if not normalized:
+        return False
+    root = normalized.split(maxsplit=1)[0]
+    return normalized in BOOTSTRAP_COMMANDS or root in BOOTSTRAP_COMMANDS
+
+
+def _candidate_command_names(ctx: commands.Context) -> Iterable[str]:
+    """Yield every command spelling worth checking for bootstrap access."""
+    command = getattr(ctx, "command", None)
+    if command is not None:
+        name = getattr(command, "name", None)
+        if name:
+            yield str(name)
+        qualified_name = getattr(command, "qualified_name", None)
+        if qualified_name:
+            yield str(qualified_name)
+        for alias in getattr(command, "aliases", ()) or ():
+            if alias:
+                yield str(alias)
+    invoked_with = getattr(ctx, "invoked_with", None)
+    if invoked_with:
+        yield str(invoked_with)
+
+
+def _is_guild_operator(author: Any, guild: Any) -> bool:
+    """Return whether ``author`` can bootstrap configuration for ``guild``."""
+    author_id = getattr(author, "id", None)
+    if author_id is not None and author_id == getattr(guild, "owner_id", None):
+        return True
+
+    permissions = getattr(author, "guild_permissions", None)
+    if permissions is None:
+        return False
+    return bool(
+        getattr(permissions, "administrator", False)
+        or getattr(permissions, "manage_guild", False)
+    )
+
+
+async def _is_bot_owner(ctx: commands.Context) -> bool:
+    """Best-effort bot-owner check used as an operator escape hatch."""
+    bot = getattr(ctx, "bot", None)
+    is_owner = getattr(bot, "is_owner", None)
+    if not callable(is_owner):
+        return False
+    try:
+        return bool(await is_owner(getattr(ctx, "author", None)))
+    except Exception:
+        return False
+
+
+async def can_bypass_channel_guard(ctx: commands.Context) -> bool:
+    """Return whether ``ctx`` may bypass the global channel allowlist.
+
+    This is deliberately narrower than command authorization:
+
+    * DMs never bypass; setup is guild-scoped.
+    * Non-bootstrap commands never bypass.
+    * The guild owner, administrators, members with ``manage_guild``, and
+      bot owners may bypass for bootstrap commands only.
+
+    Command-specific decorators such as ``@commands.has_permissions`` still
+    run after this check, so this helper does not grant access to the command
+    itself.  It only prevents fresh-guild operators from being blocked before
+    setup can run.
+    """
+    guild = getattr(ctx, "guild", None)
+    if guild is None:
+        return False
+
+    if not any(is_bootstrap_command(name) for name in _candidate_command_names(ctx)):
+        return False
+
+    author = getattr(ctx, "author", None)
+    if _is_guild_operator(author, guild):
+        return True
+
+    return await _is_bot_owner(ctx)
+
+
+__all__ = [
+    "BOOTSTRAP_COMMANDS",
+    "can_bypass_channel_guard",
+    "is_bootstrap_command",
+]

--- a/tests/unit/core/runtime/test_command_access.py
+++ b/tests/unit/core/runtime/test_command_access.py
@@ -1,0 +1,118 @@
+"""Tests for fresh-guild bootstrap command access helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from core.runtime.command_access import (
+    can_bypass_channel_guard,
+    is_bootstrap_command,
+)
+
+
+def _ctx(
+    *,
+    command_name: str = "help",
+    qualified_name: str | None = None,
+    aliases: tuple[str, ...] = (),
+    invoked_with: str | None = None,
+    author_id: int = 10,
+    owner_id: int = 10,
+    administrator: bool = False,
+    manage_guild: bool = False,
+    is_bot_owner: bool = False,
+    guild: object | None = None,
+):
+    if guild is None:
+        guild = SimpleNamespace(owner_id=owner_id)
+    author = SimpleNamespace(
+        id=author_id,
+        guild_permissions=SimpleNamespace(
+            administrator=administrator,
+            manage_guild=manage_guild,
+        ),
+    )
+    command = SimpleNamespace(
+        name=command_name,
+        qualified_name=qualified_name or command_name,
+        aliases=aliases,
+    )
+    bot = SimpleNamespace(is_owner=AsyncMock(return_value=is_bot_owner))
+    return SimpleNamespace(
+        guild=guild,
+        author=author,
+        command=command,
+        invoked_with=invoked_with or command_name,
+        bot=bot,
+    )
+
+
+def test_is_bootstrap_command_accepts_bare_and_qualified_names():
+    assert is_bootstrap_command("help") is True
+    assert is_bootstrap_command("platform identity") is True
+    assert is_bootstrap_command("settings access") is True
+
+
+def test_is_bootstrap_command_rejects_normal_gameplay_commands():
+    assert is_bootstrap_command("daily") is False
+    assert is_bootstrap_command("blackjack") is False
+    assert is_bootstrap_command(None) is False
+
+
+@pytest.mark.asyncio
+async def test_guild_owner_can_bypass_for_bootstrap_command():
+    ctx = _ctx(command_name="help", author_id=42, owner_id=42)
+
+    assert await can_bypass_channel_guard(ctx) is True
+
+
+@pytest.mark.asyncio
+async def test_administrator_can_bypass_for_bootstrap_command():
+    ctx = _ctx(command_name="platform", author_id=7, owner_id=42, administrator=True)
+
+    assert await can_bypass_channel_guard(ctx) is True
+
+
+@pytest.mark.asyncio
+async def test_manage_guild_member_can_bypass_for_bootstrap_command():
+    ctx = _ctx(command_name="settings", author_id=7, owner_id=42, manage_guild=True)
+
+    assert await can_bypass_channel_guard(ctx) is True
+
+
+@pytest.mark.asyncio
+async def test_bot_owner_can_bypass_for_bootstrap_command():
+    ctx = _ctx(command_name="syncslash", author_id=7, owner_id=42, is_bot_owner=True)
+
+    assert await can_bypass_channel_guard(ctx) is True
+
+
+@pytest.mark.asyncio
+async def test_non_operator_cannot_bypass_for_bootstrap_command():
+    ctx = _ctx(command_name="help", author_id=7, owner_id=42)
+
+    assert await can_bypass_channel_guard(ctx) is False
+
+
+@pytest.mark.asyncio
+async def test_operator_cannot_bypass_for_normal_command():
+    ctx = _ctx(command_name="daily", author_id=42, owner_id=42)
+
+    assert await can_bypass_channel_guard(ctx) is False
+
+
+@pytest.mark.asyncio
+async def test_dm_context_cannot_bypass():
+    ctx = _ctx(command_name="help", guild=None)
+
+    assert await can_bypass_channel_guard(ctx) is False
+
+
+@pytest.mark.asyncio
+async def test_alias_can_mark_command_as_bootstrap():
+    ctx = _ctx(command_name="diagnostics", aliases=("diag",), invoked_with="diag", author_id=1, owner_id=1)
+
+    assert await can_bypass_channel_guard(ctx) is True


### PR DESCRIPTION
## Summary

Starts Phase 1 / PR 1 of the multi-server readiness plan: fresh-guild bootstrap command access.

This draft adds:

- `core.runtime.command_access` as the centralized bootstrap command-access helper
- `cogs.bootstrap_access_cog` as the runtime wiring intended to replace the legacy global channel guard with a fresh-guild-aware guard
- unit coverage for the helper behavior

## Important status

This PR is **draft / not merge-ready yet**. The helper and cog are added, but the extension still needs to be wired into startup before it is functional. The intended next edit is to load `cogs.bootstrap_access_cog` before `cogs.admin_cog` in `config.INITIAL_EXTENSIONS`, or alternatively fold the install step into the already-first-loaded admin cog setup.

## Intended behavior once wired

- Normal commands still require `BOT_ALLOWED_CHANNELS`.
- `!force` remains unchanged.
- Bootstrap commands such as `help`, `platform`, `diagnostics`, `adminmenu`, `settings`, `syncslash`, and `slashes` can be run by guild owners/admins/manage-guild members/bot owners outside the old allowed channels.
- Command-level permission decorators still run after the channel guard.

## Next steps before merge

1. Wire `cogs.bootstrap_access_cog` as the first loaded extension.
2. Add/adjust tests confirming startup wiring.
3. Run `pytest tests/unit/core/runtime/test_command_access.py`.
4. Run full CI.
5. Smoke test in a fresh guild outside `BOT_ALLOWED_CHANNELS`.

## Rollback

Revert this PR; it is additive until startup wiring is completed.