### PR TITLE
Add AI readiness scaffold and connector planning

### DIFF
--- a/disbot/core/runtime/ai/README.md
+++ b/disbot/core/runtime/ai/README.md
@@ -1,0 +1,38 @@
+# AI Runtime Scaffold
+
+This package is intentionally inert in the AI readiness scaffold PR.
+
+Nothing in production runtime imports this package yet.  The files here define future connector points so later PRs can wire AI support without inventing duplicate abstractions.
+
+## Files
+
+- `contracts.py` defines provider-neutral request, response, suggestion, scope, and diagnostics dataclasses.
+- `redaction.py` defines deterministic redaction helpers for future provider payload preparation.
+- `suggestion_templates.py` maps AI tasks to advisory suggestion categories and deterministic operation owners.
+
+## Intended future flow
+
+```text
+Cog or view
+  -> AI service
+    -> AI gateway
+      -> provider adapter
+    -> typed AIResponse / AISuggestion
+  -> existing deterministic pipeline after explicit confirmation
+```
+
+## Ownership boundaries
+
+AI runtime contracts should not import cogs, views, Discord clients, database modules, or provider SDKs.
+
+Provider SDKs belong behind the future AI gateway.
+
+State changes belong in existing deterministic services.
+
+## Safe next PRs
+
+1. Add AI feature flags and metrics declarations.
+2. Add a read-only `!platform ai` diagnostics surface.
+3. Extract setup advisor provider calls behind an AI gateway.
+4. Add a read-only bot-monitor explainer.
+5. Add a log-triage service after a bounded log-event source exists.

--- a/disbot/core/runtime/ai/__init__.py
+++ b/disbot/core/runtime/ai/__init__.py
@@ -1,0 +1,10 @@
+"""AI runtime contract scaffold for future SuperBot AI features.
+
+This package is intentionally inert in the scaffold PR.  Nothing imports it
+from production runtime yet.  Future PRs can wire these contracts into an
+AI gateway, diagnostics provider, and optional AI cog.
+"""
+
+from __future__ import annotations
+
+__all__ = []

--- a/disbot/core/runtime/ai/contracts.py
+++ b/disbot/core/runtime/ai/contracts.py
@@ -1,0 +1,159 @@
+"""Provider-neutral AI contracts for future SuperBot AI services.
+
+Inert scaffold: these types are not imported by existing runtime code yet.
+They define the shared language future services should use so setup,
+diagnostics, log triage, settings help, and command help do not invent
+parallel request/response shapes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Literal
+
+
+class AITask(str, Enum):
+    """Stable task identifiers for metrics, policy, and diagnostics."""
+
+    SETUP_SUGGEST = "setup.suggest"
+    SETUP_EXPLAIN = "setup.explain"
+    PLATFORM_EXPLAIN_STATUS = "platform.explain_status"
+    PLATFORM_EXPLAIN_CONSISTENCY = "platform.explain_consistency"
+    LOGS_TRIAGE = "logs.triage"
+    SETTINGS_EXPLAIN = "settings.explain"
+    SETTINGS_PROPOSE = "settings.propose"
+    HELP_ANSWER = "help.answer"
+    CODE_CONTEXT_EXPLAIN = "code_context.explain"
+    MODERATION_ASSIST = "moderation.assist"
+
+
+class AIScope(str, Enum):
+    """Where an AI request is allowed to operate."""
+
+    USER = "user"
+    MODERATOR = "moderator"
+    ADMIN = "admin"
+    SERVER_OWNER = "server_owner"
+    PLATFORM_OWNER = "platform_owner"
+    SYSTEM = "system"
+
+
+class AIResponseMode(str, Enum):
+    """Expected response shape."""
+
+    TEXT = "text"
+    JSON = "json"
+    SUGGESTIONS = "suggestions"
+
+
+class AISuggestionKind(str, Enum):
+    """Kinds of advisory suggestions AI services may produce."""
+
+    EXPLANATION = "explanation"
+    SETTING_CHANGE = "setting_change"
+    BINDING_CHANGE = "binding_change"
+    RESOURCE_PROVISION = "resource_provision"
+    DIAGNOSTIC_NEXT_STEP = "diagnostic_next_step"
+    HELP_NAVIGATION = "help_navigation"
+    MODERATION_REVIEW = "moderation_review"
+
+
+Confidence = Literal["high", "medium", "low"]
+Severity = Literal["info", "warning", "error", "critical"]
+
+
+@dataclass(frozen=True)
+class AIRequestContext:
+    """Low-risk metadata attached to an AI request.
+
+    Do not store sensitive values here.  Provider keys, raw tokens, and
+    private environment values belong outside the request payload.
+    """
+
+    task: AITask
+    scope: AIScope
+    guild_id: int | None = None
+    actor_id: int | None = None
+    channel_id: int | None = None
+    correlation_id: str | None = None
+    source: str = "unknown"
+
+
+@dataclass(frozen=True)
+class AIRequest:
+    """Provider-neutral request passed to a future AI gateway."""
+
+    context: AIRequestContext
+    system_prompt: str
+    payload: dict[str, Any]
+    mode: AIResponseMode = AIResponseMode.TEXT
+    response_schema: dict[str, Any] | None = None
+    max_output_tokens: int = 800
+    timeout_seconds: float = 20.0
+
+
+@dataclass(frozen=True)
+class AISuggestion:
+    """Advisory suggestion returned by an AI service.
+
+    Suggestions must remain advisory until converted into typed operations
+    and validated by the existing deterministic service layer.
+    """
+
+    kind: AISuggestionKind
+    title: str
+    summary: str
+    confidence: Confidence = "medium"
+    severity: Severity = "info"
+    subsystem: str | None = None
+    target: str | None = None
+    proposed_value: Any | None = None
+    next_command: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class AIResponse:
+    """Provider-neutral response returned by a future AI gateway."""
+
+    task: AITask
+    provider: str
+    model: str
+    text: str | None = None
+    data: dict[str, Any] | None = None
+    suggestions: tuple[AISuggestion, ...] = ()
+    latency_ms: float | None = None
+    degraded: bool = False
+    fallback_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class AIDiagnosticsSnapshot:
+    """Read-only snapshot for a future `!platform ai` surface."""
+
+    provider_requested: str
+    provider_active: str
+    model: str
+    enabled: bool
+    redaction_enabled: bool
+    degraded: bool = False
+    last_error_type: str | None = None
+    last_fallback_reason: str | None = None
+    requests_observed: int = 0
+    failures_observed: int = 0
+
+
+__all__ = [
+    "AIDiagnosticsSnapshot",
+    "AIRequest",
+    "AIRequestContext",
+    "AIResponse",
+    "AIResponseMode",
+    "AIScope",
+    "AISuggestion",
+    "AISuggestionKind",
+    "AITask",
+    "Confidence",
+    "Severity",
+]

--- a/disbot/core/runtime/ai/redaction.py
+++ b/disbot/core/runtime/ai/redaction.py
@@ -34,7 +34,8 @@ _TOKEN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
 
 _EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b")
 _URL_QUERY_RE = re.compile(
-    r"([?&](?:token|key|secret|password|signature)=)[^&\s]+", re.IGNORECASE
+    r"([?&](?:token|key|secret|password|signature)=)[^&\s]+",
+    re.IGNORECASE,
 )
 
 
@@ -52,7 +53,6 @@ def _count(replacements: dict[str, int], key: str) -> None:
 
 def redact_text(text: str) -> RedactionResult:
     """Redact sensitive-looking substrings from plain text."""
-
     replacements: dict[str, int] = {}
     value = text
 
@@ -80,7 +80,6 @@ def redact_text(text: str) -> RedactionResult:
 
 def redact_payload(payload: Any) -> RedactionResult:
     """Recursively redact strings in common JSON-like payloads."""
-
     replacements: dict[str, int] = {}
 
     def merge(child: RedactionResult) -> Any:

--- a/disbot/core/runtime/ai/redaction.py
+++ b/disbot/core/runtime/ai/redaction.py
@@ -1,0 +1,91 @@
+"""Redaction helpers for future AI request preparation.
+
+Inert scaffold: not imported by production runtime yet.
+
+The future AI gateway should run payloads through these helpers before
+provider calls.  Keep the helpers deterministic and conservative: they
+should reduce risk without requiring network access or external state.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+
+_TOKEN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("discord_token_like", re.compile(r"[A-Za-z0-9_-]{23,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{20,}")),
+    ("api_key_like", re.compile(r"\b(?:sk|pk|rk|xoxb|ghp)_[A-Za-z0-9_\-]{12,}\b")),
+    ("database_url", re.compile(r"\b(?:postgres|postgresql)://[^\s]+", re.IGNORECASE)),
+    ("bearer_token", re.compile(r"\bBearer\s+[A-Za-z0-9._\-]+", re.IGNORECASE)),
+)
+
+_EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b")
+_URL_QUERY_RE = re.compile(r"([?&](?:token|key|secret|password|signature)=)[^&\s]+", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class RedactionResult:
+    """Result of redacting one value."""
+
+    value: Any
+    replacements: dict[str, int]
+
+
+def _count(replacements: dict[str, int], key: str) -> None:
+    replacements[key] = replacements.get(key, 0) + 1
+
+
+def redact_text(text: str) -> RedactionResult:
+    """Redact sensitive-looking substrings from plain text."""
+
+    replacements: dict[str, int] = {}
+    value = text
+
+    for label, pattern in _TOKEN_PATTERNS:
+        def _replace_token(_: re.Match[str], *, redaction_label: str = label) -> str:
+            _count(replacements, redaction_label)
+            return f"[{redaction_label}:redacted]"
+
+        value = pattern.sub(_replace_token, value)
+
+    def _replace_email(_: re.Match[str]) -> str:
+        _count(replacements, "email")
+        return "[email:redacted]"
+
+    value = _EMAIL_RE.sub(_replace_email, value)
+
+    def _replace_query(match: re.Match[str]) -> str:
+        _count(replacements, "url_secret_query")
+        return f"{match.group(1)}[redacted]"
+
+    value = _URL_QUERY_RE.sub(_replace_query, value)
+    return RedactionResult(value=value, replacements=replacements)
+
+
+def redact_payload(payload: Any) -> RedactionResult:
+    """Recursively redact strings in common JSON-like payloads."""
+
+    replacements: dict[str, int] = {}
+
+    def merge(child: RedactionResult) -> Any:
+        for key, count in child.replacements.items():
+            replacements[key] = replacements.get(key, 0) + count
+        return child.value
+
+    def walk(value: Any) -> Any:
+        if isinstance(value, str):
+            return merge(redact_text(value))
+        if isinstance(value, dict):
+            return {str(k): walk(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [walk(v) for v in value]
+        if isinstance(value, tuple):
+            return tuple(walk(v) for v in value)
+        return value
+
+    return RedactionResult(value=walk(payload), replacements=replacements)
+
+
+__all__ = ["RedactionResult", "redact_payload", "redact_text"]

--- a/disbot/core/runtime/ai/redaction.py
+++ b/disbot/core/runtime/ai/redaction.py
@@ -13,13 +13,10 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
-
 _TOKEN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "discord_token_like",
-        re.compile(
-            r"[A-Za-z0-9_-]{23,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{20,}"
-        ),
+        re.compile(r"[A-Za-z0-9_-]{23,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{20,}"),
     ),
     (
         "api_key_like",

--- a/disbot/core/runtime/ai/redaction.py
+++ b/disbot/core/runtime/ai/redaction.py
@@ -15,14 +15,30 @@ from typing import Any
 
 
 _TOKEN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
-    ("discord_token_like", re.compile(r"[A-Za-z0-9_-]{23,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{20,}")),
-    ("api_key_like", re.compile(r"\b(?:sk|pk|rk|xoxb|ghp)_[A-Za-z0-9_\-]{12,}\b")),
-    ("database_url", re.compile(r"\b(?:postgres|postgresql)://[^\s]+", re.IGNORECASE)),
-    ("bearer_token", re.compile(r"\bBearer\s+[A-Za-z0-9._\-]+", re.IGNORECASE)),
+    (
+        "discord_token_like",
+        re.compile(
+            r"[A-Za-z0-9_-]{23,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{20,}"
+        ),
+    ),
+    (
+        "api_key_like",
+        re.compile(r"\b(?:sk|pk|rk|xoxb|ghp)_[A-Za-z0-9_\-]{12,}\b"),
+    ),
+    (
+        "database_url",
+        re.compile(r"\b(?:postgres|postgresql)://[^\s]+", re.IGNORECASE),
+    ),
+    (
+        "bearer_token",
+        re.compile(r"\bBearer\s+[A-Za-z0-9._\-]+", re.IGNORECASE),
+    ),
 )
 
 _EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b")
-_URL_QUERY_RE = re.compile(r"([?&](?:token|key|secret|password|signature)=)[^&\s]+", re.IGNORECASE)
+_URL_QUERY_RE = re.compile(
+    r"([?&](?:token|key|secret|password|signature)=)[^&\s]+", re.IGNORECASE
+)
 
 
 @dataclass(frozen=True)
@@ -44,6 +60,7 @@ def redact_text(text: str) -> RedactionResult:
     value = text
 
     for label, pattern in _TOKEN_PATTERNS:
+
         def _replace_token(_: re.Match[str], *, redaction_label: str = label) -> str:
             _count(replacements, redaction_label)
             return f"[{redaction_label}:redacted]"

--- a/disbot/core/runtime/ai/suggestion_templates.py
+++ b/disbot/core/runtime/ai/suggestion_templates.py
@@ -96,7 +96,6 @@ TEMPLATES: tuple[SuggestionTemplate, ...] = (
 
 def templates_for_task(task: AITask) -> tuple[SuggestionTemplate, ...]:
     """Return templates matching `task`."""
-
     return tuple(template for template in TEMPLATES if template.task == task)
 
 

--- a/disbot/core/runtime/ai/suggestion_templates.py
+++ b/disbot/core/runtime/ai/suggestion_templates.py
@@ -1,0 +1,103 @@
+"""Suggestion templates for future AI-assisted SuperBot services.
+
+Inert scaffold: not imported by production runtime yet.
+
+Templates describe what each AI task may suggest and which deterministic
+service should own any eventual state change.  They are intentionally
+small so future UI panels can render consistent previews.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from core.runtime.ai.contracts import AISuggestionKind, AITask
+
+OperationOwner = Literal[
+    "read_only",
+    "settings_mutation",
+    "binding_mutation",
+    "resource_provisioning",
+    "setup_operations",
+    "moderation_review",
+]
+
+
+@dataclass(frozen=True)
+class SuggestionTemplate:
+    """Declarative template for one AI suggestion family."""
+
+    task: AITask
+    kind: AISuggestionKind
+    owner: OperationOwner
+    title: str
+    description: str
+    confirmation_required: bool = True
+    default_enabled: bool = False
+
+
+TEMPLATES: tuple[SuggestionTemplate, ...] = (
+    SuggestionTemplate(
+        task=AITask.SETUP_SUGGEST,
+        kind=AISuggestionKind.BINDING_CHANGE,
+        owner="setup_operations",
+        title="Setup binding recommendation",
+        description="Suggests a channel or role binding for a registered subsystem.",
+    ),
+    SuggestionTemplate(
+        task=AITask.SETUP_SUGGEST,
+        kind=AISuggestionKind.RESOURCE_PROVISION,
+        owner="setup_operations",
+        title="Setup resource recommendation",
+        description="Suggests a missing channel, role, or category for setup review.",
+    ),
+    SuggestionTemplate(
+        task=AITask.PLATFORM_EXPLAIN_STATUS,
+        kind=AISuggestionKind.DIAGNOSTIC_NEXT_STEP,
+        owner="read_only",
+        title="Platform status explanation",
+        description="Explains diagnostics output and suggests the next command to inspect.",
+        confirmation_required=False,
+    ),
+    SuggestionTemplate(
+        task=AITask.LOGS_TRIAGE,
+        kind=AISuggestionKind.DIAGNOSTIC_NEXT_STEP,
+        owner="read_only",
+        title="Log triage finding",
+        description="Groups recent runtime signals into an operator-facing incident summary.",
+        confirmation_required=False,
+    ),
+    SuggestionTemplate(
+        task=AITask.SETTINGS_PROPOSE,
+        kind=AISuggestionKind.SETTING_CHANGE,
+        owner="settings_mutation",
+        title="Settings change proposal",
+        description="Suggests a scalar setting change that must pass SettingsMutationPipeline.",
+    ),
+    SuggestionTemplate(
+        task=AITask.HELP_ANSWER,
+        kind=AISuggestionKind.HELP_NAVIGATION,
+        owner="read_only",
+        title="Help navigation answer",
+        description="Suggests the most relevant command panel or help surface.",
+        confirmation_required=False,
+        default_enabled=True,
+    ),
+    SuggestionTemplate(
+        task=AITask.MODERATION_ASSIST,
+        kind=AISuggestionKind.MODERATION_REVIEW,
+        owner="moderation_review",
+        title="Moderation review suggestion",
+        description="Classifies a moderation situation for human review only.",
+    ),
+)
+
+
+def templates_for_task(task: AITask) -> tuple[SuggestionTemplate, ...]:
+    """Return templates matching `task`."""
+
+    return tuple(template for template in TEMPLATES if template.task == task)
+
+
+__all__ = ["OperationOwner", "SuggestionTemplate", "TEMPLATES", "templates_for_task"]

--- a/docs/ai-readiness-plan.md
+++ b/docs/ai-readiness-plan.md
@@ -1,0 +1,130 @@
+# SuperBot AI Readiness Plan
+
+Status: planning and inert scaffold only. This document does not change runtime behavior.
+
+## Purpose
+
+SuperBot already has a narrow AI surface in the setup wizard. The next step should be a reusable AI platform layer rather than direct provider calls inside individual cogs.
+
+The goal is to prepare for setup guidance, diagnostics explanations, log triage, settings help, command help, and future code-context assistance while preserving the existing architecture.
+
+## Architectural rule
+
+AI may recommend, summarize, classify, and explain.
+
+Deterministic SuperBot services must continue to own all state changes.
+
+Any future AI-produced recommendation must be converted into a typed operation and validated by the existing service layer before anything is applied.
+
+## Existing foundations to reuse
+
+- setup advisor boundary for Smart Suggestions
+- diagnostics snapshot registry
+- platform diagnostics panel
+- feature flag runtime
+- Prometheus metrics service
+- centralized message pipeline
+- settings and binding mutation pipelines
+- resource provisioning pipeline
+- event catalogue
+
+AI readiness should extend those surfaces instead of creating parallel systems.
+
+## Proposed layers
+
+### AI gateway
+
+Future target: `disbot/services/ai_gateway.py`.
+
+The gateway should become the only provider boundary. It should resolve provider and model, apply redaction, enforce timeouts, emit metrics, and return typed responses. It must not write database state or Discord state directly.
+
+### AI contracts
+
+Future target: `disbot/core/runtime/ai/`.
+
+Contracts should describe request scopes, task names, response payloads, suggestion records, and diagnostic snapshots. They should stay provider-neutral.
+
+### AI diagnostics
+
+Future target: `!platform ai`.
+
+The platform surface should show provider status, active model, feature flag status, fallback state, recent failures, latency, and whether redaction is enabled. It should never expose sensitive values.
+
+### AI feature flags
+
+Future flags should include:
+
+- `ai.primary`
+- `ai.setup_advisor.enabled`
+- `ai.general_cog.enabled`
+- `ai.log_triage.enabled`
+- `ai.bot_monitor.enabled`
+- `ai.code_context.enabled`
+- `ai.moderation_assist.enabled`
+
+Broad AI behavior should default off until the gateway and diagnostics are proven.
+
+## Candidate services
+
+### Setup advisor v2
+
+Improves Smart Suggestions with better explanations, confidence, and operation previews.
+
+### Bot monitor explainer
+
+Summarizes diagnostics, consistency checks, runtime status, slow paths, and failed tasks into operator-facing guidance.
+
+### Log triage
+
+Groups recent warning/error events into incidents and suggests the next deterministic diagnostic command to run.
+
+### Settings assistant
+
+Explains configurable settings and proposes changes that are later validated through the settings mutation pipeline.
+
+### Help assistant
+
+Answers questions about commands, panels, and subsystem behavior using command/help metadata.
+
+### Code context assistant
+
+Uses a generated context pack to explain cogs, commands, schemas, settings, events, and database ownership without runtime source-code scanning.
+
+## Rollout order
+
+### Phase A: inert readiness scaffold
+
+Add docs, contracts, and templates only. No runtime imports. No behavior change.
+
+### Phase B: diagnostics visibility
+
+Add flags, metrics declarations, diagnostics provider, and a `!platform ai` read-only panel.
+
+### Phase C: gateway extraction
+
+Move provider calls behind the gateway while preserving existing setup advisor behavior.
+
+### Phase D: read-only AI monitor
+
+Add a bot-monitor summary service using diagnostics and consistency reports.
+
+### Phase E: log triage MVP
+
+Add bounded log-event ingestion and admin-only triage summaries.
+
+### Phase F: general AI hub
+
+Add an AI cog and UI hub that delegates to services instead of calling providers directly.
+
+## Review checklist
+
+Future AI PRs should answer:
+
+1. Which service owns deterministic state changes?
+2. Which feature flag gates the behavior?
+3. Which diagnostics surface reports status?
+4. Which metrics report latency and failures?
+5. Which redaction rules run before provider calls?
+6. Which permission tier can invoke it?
+7. What happens if the provider is unavailable?
+8. Does the bot still work without external AI?

--- a/docs/ai-readiness-pr-notes.md
+++ b/docs/ai-readiness-pr-notes.md
@@ -1,0 +1,56 @@
+# AI Readiness Scaffold PR Notes
+
+## Intent
+
+This PR prepares connector points for broader AI support without changing runtime behavior.
+
+It is designed to avoid conflicts with active implementation work by adding only new files.
+
+## What this PR adds
+
+- AI readiness architecture plan.
+- Service integration map for future AI use cases.
+- Inert runtime AI package scaffold.
+- Provider-neutral AI contracts.
+- Deterministic redaction helper scaffold.
+- Suggestion templates that map AI output to existing deterministic service owners.
+
+## What this PR does not do
+
+- Does not import the new package from existing runtime files.
+- Does not add a new cog.
+- Does not call any external AI provider.
+- Does not alter setup advisor behavior.
+- Does not add or change environment variables.
+- Does not add feature flags yet.
+- Does not mutate existing docs or source files.
+
+## Why this helps later development
+
+Future PRs can now reference stable task names, request/response contracts, suggestion types, redaction expectations, and service ownership rules.
+
+This should speed up later work on:
+
+- `!platform ai`
+- AI gateway extraction
+- setup advisor v2
+- AI bot monitor
+- AI log triage
+- AI settings assistant
+- AI help assistant
+- generated code context pack
+
+## Suggested review focus
+
+- Are the task names broad enough?
+- Are the ownership boundaries strict enough?
+- Are the suggested connector points aligned with the current platform architecture?
+- Are there any future AI services missing from the integration map?
+
+## Suggested follow-up PRs
+
+1. Add AI feature flags and AI metrics declarations.
+2. Add read-only AI diagnostics provider and `!platform ai` surface.
+3. Extract provider calls from setup advisor into a central AI gateway.
+4. Add a fake-provider test harness for gateway behavior.
+5. Add read-only AI bot monitor using diagnostics snapshots.

--- a/docs/ai-service-integration-map.md
+++ b/docs/ai-service-integration-map.md
@@ -1,0 +1,204 @@
+# AI Service Integration Map
+
+Status: planning artifact. No runtime behavior is changed by this file.
+
+## Purpose
+
+This map shows where future AI-assisted behavior should connect to existing SuperBot services. It is meant to reduce future implementation time and prevent duplicate architecture.
+
+## Connector rules
+
+1. Cogs own Discord commands and UI entry points.
+2. Services own orchestration and deterministic state changes.
+3. Runtime modules own registries, feature flags, event flow, and typed platform utilities.
+4. AI provider calls must go through one gateway.
+5. AI output must be advisory unless converted into validated operations.
+
+## Recommended connector points
+
+### Setup wizard
+
+Existing surfaces:
+
+- `services.setup_ai_advisor`
+- `services.guild_snapshot`
+- `services.setup_plan`
+- `services.setup_operations`
+- `views.setup.ai_review`
+- `views.setup.hub`
+
+AI opportunity:
+
+- richer setup suggestions
+- operation previews
+- explanation of why each binding or setting is recommended
+- setup readiness summary
+
+Safe path:
+
+`Setup UI -> SetupAdvisor -> AIGateway -> typed SetupPlanDraft -> SetupOperation preview -> existing apply dispatcher`
+
+### Diagnostics and platform hub
+
+Existing surfaces:
+
+- `services.diagnostics_service`
+- `services.platform_consistency`
+- `cogs.diagnostic._platform_embeds`
+- `views.diagnostic.platform_panel`
+
+AI opportunity:
+
+- explain platform consistency output
+- summarize runtime health
+- identify likely next diagnostic command
+- translate technical findings into operator actions
+
+Safe path:
+
+`Platform panel -> AI monitor service -> diagnostics snapshots -> AIGateway -> read-only summary embed`
+
+### Metrics and health
+
+Existing surfaces:
+
+- `services.metrics`
+- `healthserver.py`
+
+AI opportunity:
+
+- summarize slow commands
+- identify unusual latency or fallback patterns
+- produce deployment health summaries
+
+Safe path:
+
+`metrics snapshot/derived summary -> AI monitor service -> read-only output`
+
+### Settings manager
+
+Existing surfaces:
+
+- `services.settings_mutation`
+- `services.settings_resolution`
+- `core.runtime.subsystem_schema`
+- settings UI views
+
+AI opportunity:
+
+- explain settings
+- propose configuration changes
+- generate safe operation previews
+
+Safe path:
+
+`AI settings assistant -> proposed SettingChange -> SettingsMutationPipeline after explicit user confirmation`
+
+### Binding and resource provisioning
+
+Existing surfaces:
+
+- `services.binding_mutation`
+- `services.resource_provisioning`
+- subsystem schemas
+- resource requirements
+
+AI opportunity:
+
+- recommend channel and role bindings
+- explain missing resources
+- propose setup packs for server types
+
+Safe path:
+
+`AI recommendation -> schema validation -> resource/binding preview -> existing provisioning/binding pipeline`
+
+### Message pipeline
+
+Existing surfaces:
+
+- `core.runtime.message_pipeline`
+- moderation services
+- cleanup/counting/chain stages
+
+AI opportunity:
+
+- optional classification or moderation assistance
+- summarize repeated message-stage failures
+- identify noisy stages
+
+Safe path:
+
+AI stages should be disabled by default, rate-limited, and advisory in early versions. Deterministic moderation rules remain authoritative.
+
+### Help and command navigation
+
+Existing surfaces:
+
+- help cog
+- command registry
+- command panels
+- subsystem registry
+
+AI opportunity:
+
+- answer how-to questions
+- recommend the correct command panel
+- explain admin commands based on permissions
+
+Safe path:
+
+`Help question -> command/help metadata -> AIGateway -> response filtered by caller permission`
+
+### Event catalogue and audit
+
+Existing surfaces:
+
+- `core.events_catalogue`
+- audit events
+- domain-specific events
+
+AI opportunity:
+
+- explain recent platform events
+- summarize mutation history
+- identify related actions across services
+
+Safe path:
+
+`bounded event summary -> AI explainer -> read-only output`
+
+## Suggested AI task identifiers
+
+Use stable task names for metrics and policy:
+
+- `setup.suggest`
+- `setup.explain`
+- `platform.explain_status`
+- `platform.explain_consistency`
+- `logs.triage`
+- `settings.explain`
+- `settings.propose`
+- `help.answer`
+- `code_context.explain`
+- `moderation.assist`
+
+## Suggested permission tiers
+
+- Normal users: help assistant only.
+- Moderators: moderation explanations and basic server help.
+- Admins: settings, setup, diagnostics summaries.
+- Server owner: setup apply previews and deployment-sensitive diagnostics.
+- Platform owner: code context, provider status, rollout diagnostics.
+
+## Suggested failure behavior
+
+When AI is unavailable:
+
+- setup falls back to deterministic suggestions
+- diagnostics still show raw platform embeds
+- log triage returns a deterministic recent-error list
+- help assistant falls back to command metadata
+- settings assistant returns the relevant settings panel
+
+The bot should never require AI to remain operational.


### PR DESCRIPTION
## Summary

Adds a low-conflict AI readiness scaffold without changing existing runtime behavior.

This PR intentionally adds only new files so it can coexist with active Claude implementation work.

## Added

- `docs/ai-readiness-plan.md`
- `docs/ai-service-integration-map.md`
- `docs/ai-readiness-pr-notes.md`
- `disbot/core/runtime/ai/__init__.py`
- `disbot/core/runtime/ai/README.md`
- `disbot/core/runtime/ai/contracts.py`
- `disbot/core/runtime/ai/redaction.py`
- `disbot/core/runtime/ai/suggestion_templates.py`

## Intent

The scaffold prepares future connector points for:

- AI gateway extraction
- `!platform ai` diagnostics
- setup advisor v2
- log triage
- bot monitor summaries
- settings assistant
- help assistant
- generated code context pack

## Safety / conflict profile

- No existing files edited.
- No runtime imports added.
- No provider calls added.
- No environment/config changes.
- No feature flags changed.
- No Discord command behavior changed.

## Architectural boundary

AI may recommend, summarize, classify, and explain.

Existing deterministic services should continue to own state-changing mutations.