### PR TITLE
Add CodeGraph usage guide and update CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5,32 +5,40 @@ This project has a CodeGraph MCP server (`mcp__codegraph__*` tools) configured. 
 
 Install: `npm install -g @optave/codegraph` — Build/rebuild index: `codegraph build .` from the project root.
 
-### When to prefer codegraph over native search
+### Use CodeGraph first for structural exploration
 
-Use codegraph for **structural** questions — what calls what, what would break, where is X defined, what is X's signature. Use native grep/read only for **literal text** queries (string contents, comments, log messages) or after you already have a specific file open.
+Use CodeGraph for **structural** questions — what calls what, what would break, where is X defined, what is X's signature. Use native grep/Read only for **literal text** queries (string contents, comments, log messages) or after you already have a specific file open.
 
 | Question | Tool |
 |---|---|
 | "Where is X defined?" / "Find symbol named X" | `mcp__codegraph__where` |
-| "What calls function Y?" | `mcp__codegraph__query` (mode: callers) |
-| "What does Y call?" | `mcp__codegraph__execution_flow` |
+| "Full source + callers + callees for Y" | `mcp__codegraph__context` |
+| "What calls function Y?" (direct callers) | `mcp__codegraph__fn_impact` Level 1 |
+| "What does Y call?" (callees) | `mcp__codegraph__execution_flow` |
 | "What would break if I changed Z?" | `mcp__codegraph__fn_impact` |
-| "Show me Y's signature / source / docstring" | `mcp__codegraph__context` |
-| "Give me focused context for a task/area" | `mcp__codegraph__context` |
-| "Survey an unfamiliar module/topic" | `mcp__codegraph__structure` or `mcp__codegraph__module_map` |
+| "Survey an unfamiliar module/topic" | `mcp__codegraph__structure` |
 | "What files/functions exist under path/" | `mcp__codegraph__list_functions` |
 | "What does this file import/export?" | `mcp__codegraph__file_deps` |
 | "Is the index healthy? / graph stats" | `mcp__codegraph__audit` |
 
 ### Rules of thumb
 
-- **Trust codegraph results.** They come from a full AST parse. Do NOT re-verify them with grep — that's slower, less accurate, and wastes context.
+- **Use CodeGraph first** for structural exploration; then verify with source files before editing.
 - **Don't grep first** when looking up a symbol by name. `mcp__codegraph__where` is faster and returns kind + location + signature in one call.
-- **Don't chain `where` + `context`** when you just want full context — `context` alone is one call.
-- **`structure` / `module_map` are the heavy hitters** for unfamiliar areas — return full structural info but are token-heavy. If your harness supports parallel subagents, spawn one for explore-class questions to keep main session context clean.
+- **`context` is the workhorse** — it returns source, direct callers, callees, and signature in one call. Prefer it over chaining `where` + `fn_impact`.
 - **Index lag**: after editing a file run `codegraph build .` to rebuild; don't re-query immediately after editing in the same turn without rebuilding.
+
+### Known limitations — do not trust these uncritically
+
+- **`mcp__codegraph__module_map` is broken for this codebase.** It returns 0 in/out edges for every file despite 22 000+ edges existing in the index. Do not use it for connectivity analysis.
+- **`mcp__codegraph__brief` overcounts callers.** It reports call-site counts (not distinct calling functions) and inflates the numbers further. Do not use its caller count as authoritative; use `mcp__codegraph__fn_impact` or `mcp__codegraph__context` instead.
+- **Python lazy/function-body imports are not resolved.** When a function is imported inside a function body (`from services.X import Y` inside a method), CodeGraph cannot trace the call edge. Affected symbols are labelled `dead-unresolved` with 0 callers even when they are widely used. Always grep-verify when a symbol is marked `dead-unresolved`.
+
+### Source files win
+
+If CodeGraph output conflicts with what the source file says, **source files are authoritative**. Before editing any shared runtime, setup, settings, help/menu, database, or mutation pipeline code, read the exact target source files with the `Read` tool to confirm what's there.
 
 ### If `.codegraph/` doesn't exist
 
-Run `codegraph build .` from the project root to build the index. If `codegraph` is not installed, run `npm install -g @optave/codegraph` first.
+Run `codegraph build .` from the project root. If `codegraph` is not installed, run `npm install -g @optave/codegraph` first.
 <!-- CODEGRAPH_END -->

--- a/docs/codegraph-usage.md
+++ b/docs/codegraph-usage.md
@@ -1,0 +1,99 @@
+# CodeGraph Usage Guide
+
+CodeGraph provides a tree-sitter-parsed knowledge graph of every symbol, edge,
+and file in the codebase. It is exposed to Claude Code via an MCP server.
+
+---
+
+## Activation checklist
+
+1. Install the CLI: `npm install -g @optave/codegraph`
+2. Build the index from the project root: `codegraph build .`
+3. Confirm the index: `codegraph info` — look for `Active engine: native`
+4. The `.claude.json` already configures the MCP server (`codegraph mcp`).
+5. Restart Claude Code after installing to load the MCP server.
+
+---
+
+## Known-good MCP tools
+
+These tools are confirmed exposed by the server (verified via `tools/list`) and
+produce accurate results:
+
+| MCP tool name | CLI equivalent | Purpose |
+|---|---|---|
+| `mcp__codegraph__where` | `codegraph where <name>` | Find a symbol by name — returns kind, file, line, signature |
+| `mcp__codegraph__context` | `codegraph context <name>` | Full source + direct callers + callees + signature |
+| `mcp__codegraph__fn_impact` | `codegraph fn-impact <name>` | Blast-radius analysis — what breaks if this changes |
+| `mcp__codegraph__execution_flow` | `codegraph flow <name>` | Forward execution trace (callees) |
+| `mcp__codegraph__query` | `codegraph query <name>` | Dependency chain / shortest path between symbols |
+| `mcp__codegraph__file_deps` | `codegraph deps <file>` | What a file imports and what imports it |
+| `mcp__codegraph__structure` | `codegraph structure <path>` | Full structural overview of a module |
+| `mcp__codegraph__list_functions` | `codegraph brief <path>` | Symbols in a file or directory |
+| `mcp__codegraph__semantic_search` | `codegraph search <query>` | Semantic / keyword symbol search |
+| `mcp__codegraph__audit` | `codegraph audit <target>` | Per-function health metrics + impact |
+| `mcp__codegraph__complexity` | `codegraph complexity <name>` | Cognitive / cyclomatic complexity |
+| `mcp__codegraph__file_deps` | `codegraph deps <file>` | Import/export graph for a file |
+| `mcp__codegraph__impact_analysis` | `codegraph impact <file>` | Transitive file-level impact |
+| `mcp__codegraph__diff_impact` | `codegraph diff-impact` | Impact of current git changes |
+
+The full tool list has 34 entries. The ones above cover the most common tasks.
+
+---
+
+## Known-bad / unreliable tool names
+
+Do not use these:
+
+| Name | Problem |
+|---|---|
+| `mcp__codegraph__module_map` | Returns 0 in/out edges for every file in this codebase despite 22 000+ edges existing in the graph. Do not use for connectivity analysis. |
+| `mcp__codegraph__brief` (caller counts) | Overcounts callers. Reports call-site counts rather than distinct calling functions, and inflates further. Use `fn_impact` or `context` for accurate caller counts. |
+| `mcp__codegraph__codegraph_status` | Does not exist. No tool in this server uses the `codegraph_` name prefix. |
+| `mcp__codegraph__codegraph_search` | Does not exist. Use `mcp__codegraph__where` or `mcp__codegraph__semantic_search`. |
+| `mcp__codegraph__codegraph_callers` | Does not exist. Use `mcp__codegraph__fn_impact` (Level 1) or `mcp__codegraph__context`. |
+| `mcp__codegraph__codegraph_callees` | Does not exist. Use `mcp__codegraph__execution_flow`. |
+| `mcp__codegraph__codegraph_impact` | Does not exist. Use `mcp__codegraph__fn_impact` or `mcp__codegraph__impact_analysis`. |
+| `mcp__codegraph__codegraph_node` | Does not exist. Use `mcp__codegraph__where` + `mcp__codegraph__context`. |
+
+---
+
+## Rule: CodeGraph for exploration, source files for final truth
+
+Use CodeGraph to orient yourself — find symbols, trace edges, understand blast
+radius. Before making any edit, confirm the exact content with `Read` on the
+target source file. If CodeGraph output conflicts with the source file, the
+source file is authoritative.
+
+### Python lazy-import limitation
+
+CodeGraph cannot resolve call edges where the import happens inside a function
+body:
+
+```python
+async def _apply(...):
+    from services.setup_operations import apply_operations  # ← inside function
+    batch = await apply_operations(ops, guild=guild, actor=actor)
+```
+
+Any function imported only via function-body imports will appear as
+`dead-unresolved` with 0 callers even if it is widely used. When you see
+`dead-unresolved`, grep for the symbol name to find its actual callers.
+
+**Verified example**: `apply_operations` (setup_operations.py:215) is called
+from `views/setup/final_review.py:235` and `views/setup/sections/identity.py:160`
+but CodeGraph reports 0 callers because both call sites use function-body imports.
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `codegraph: command not found` | `npm install -g @optave/codegraph` |
+| "index not initialized" or empty results | `codegraph build .` from the project root |
+| Stale index after editing files | `codegraph build .` to rebuild, or run `codegraph watch` for incremental updates |
+| MCP tools unavailable in Claude Code | Restart Claude Code so it reloads the MCP server from `.claude.json` |
+| `Active engine: wasm` in `codegraph info` | Performance is degraded. Rebuild the native binding: ensure `node-gyp` prerequisites are installed, then `npm rebuild better-sqlite3` inside the codegraph package. |
+| `module_map` returns all zeros | Known bug for this codebase. Use `mcp__codegraph__structure` or `mcp__codegraph__list_functions` instead. |
+| Caller count seems too high from `brief` | Use `mcp__codegraph__fn_impact` or `mcp__codegraph__context` for accurate distinct-caller counts. |


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for CodeGraph usage and updates the project's Claude Code guidelines to reflect real-world experience with the MCP server, including known limitations and best practices.

## Changes

- **New file: `docs/codegraph-usage.md`** — Complete usage guide covering:
  - Activation checklist (install, build, verify)
  - Table of 14 known-good MCP tools with CLI equivalents and purposes
  - Known-bad/unreliable tool names with explanations (e.g., `module_map` returns all zeros, `brief` overcounts callers)
  - Python lazy-import limitation and workaround (grep-verify for `dead-unresolved` symbols)
  - Troubleshooting table for common issues

- **Updated `.claude/CLAUDE.md`** — Refined guidance based on practical experience:
  - Clarified that CodeGraph is for structural exploration; source files are authoritative for final truth
  - Removed `module_map` from recommended tools (known broken for this codebase)
  - Added explicit section on known limitations with actionable workarounds
  - Simplified tool recommendation table (removed redundant entries, added `context` as the workhorse)
  - Emphasized the "explore with CodeGraph, verify with source files" workflow
  - Added troubleshooting guidance for native engine fallback and index staleness

## Notable Details

- The guide documents a real bug in `module_map` (returns 0 edges despite 22,000+ existing) and provides alternatives
- Includes a verified example of Python lazy-import limitation (`apply_operations` in setup_operations.py)
- Provides clear distinction between tools: `fn_impact` for blast radius, `context` for full source + callers/callees, `execution_flow` for forward traces
- Emphasizes that source files win in case of conflicts with CodeGraph output

https://claude.ai/code/session_01LXrkjLqjkCt1Rqi7QGkXp5