### PR TITLE
Wire set_cleanup_policy + set_cog_routing dispatcher arms

### DIFF
--- a/disbot/services/cleanup_levels.py
+++ b/disbot/services/cleanup_levels.py
@@ -1,0 +1,62 @@
+"""Setup-wizard cleanup level vocabulary.
+
+Maps the operator-facing level names that the wizard's Cleanup section
+exposes (``Off`` / ``Light`` / ``Standard`` / ``Strict``) to the
+``cleanup_policies`` column values that :mod:`governance.writes`
+persists.
+
+Single source of truth: both
+:mod:`views.setup.sections.cleanup` (the operator picker) and
+:mod:`services.setup_operations` (the Final Review dispatcher) read
+this table.  Adding a new level here automatically appears in both
+places.
+
+Custom-tuned policies remain a separate path — operators who need
+non-standard ``delete_after_seconds`` should configure via
+``!platform`` or a future ``!settings cleanup`` flow rather than
+extending this table.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["LEVELS", "columns_for_level", "known_level_names"]
+
+
+LEVELS: dict[str, dict[str, Any]] = {
+    "Off": {
+        "delete_invalid_commands": False,
+        "delete_failed_commands": False,
+        "delete_after_seconds": 0,
+    },
+    "Light": {
+        "delete_invalid_commands": True,
+        "delete_failed_commands": False,
+        "delete_after_seconds": 10,
+    },
+    "Standard": {
+        "delete_invalid_commands": True,
+        "delete_failed_commands": True,
+        "delete_after_seconds": 5,
+    },
+    "Strict": {
+        "delete_invalid_commands": True,
+        "delete_failed_commands": True,
+        "delete_after_seconds": 2,
+    },
+}
+
+
+def columns_for_level(name: str) -> dict[str, Any]:
+    """Return the cleanup_policies column values for ``name``.
+
+    Raises ``KeyError`` if the level is unknown — the caller is
+    responsible for surfacing the error in a way the operator sees.
+    """
+    return LEVELS[name]
+
+
+def known_level_names() -> frozenset[str]:
+    """Return the set of operator-facing level names."""
+    return frozenset(LEVELS)

--- a/disbot/services/setup_operations.py
+++ b/disbot/services/setup_operations.py
@@ -76,11 +76,10 @@ _KNOWN_KINDS: frozenset[str] = frozenset(
         "add_automation_rule",
         "enable_automation_rule",
         "disable_automation_rule",
-        # PR 8 + PR 9 op kinds.  The dispatcher returns
-        # ``not_yet_implemented`` for these until PR 11 adds routing
-        # arms (Final Review apply).  Listed here so the staging
-        # layer accepts them and the embed displays the right kind
-        # label.
+        # Per-feature op kinds.  ``set_cleanup_policy`` routes through
+        # governance.writes.set_cleanup_policy_for_scope; ``set_cog_routing``
+        # routes through services.command_routing.set_policy.  See the
+        # dispatch arms in this module.
         "set_cleanup_policy",
         "set_cog_routing",
     },
@@ -517,6 +516,22 @@ async def _dispatch_one(
                 label=label,
             )
 
+        if op.kind == "set_cleanup_policy":
+            return await _apply_set_cleanup_policy(
+                op,
+                guild=guild,
+                actor=actor,
+                label=label,
+            )
+
+        if op.kind == "set_cog_routing":
+            return await _apply_set_cog_routing(
+                op,
+                guild=guild,
+                actor=actor,
+                label=label,
+            )
+
         # Unreachable given validate_operation above, but explicit.
         return SetupOperationResult(
             status="not_yet_implemented",
@@ -733,6 +748,204 @@ async def _apply_automation_set_enabled(
 
 
 # ---------------------------------------------------------------------------
+# Cleanup policy + cog routing dispatchers
+# ---------------------------------------------------------------------------
+#
+# Both arms route through the existing canonical writers:
+#
+# * ``set_cleanup_policy`` → ``governance.writes.set_cleanup_policy_for_scope``
+#   (atomic upsert + governance audit row + ``audit.action_recorded``
+#   event, all in one transaction).
+# * ``set_cog_routing`` → ``services.command_routing.set_policy``
+#   (existing per-scope upsert primitive).  Routing rows do not yet
+#   ship through a mutation pipeline; we emit ``audit.action_recorded``
+#   here so the apply still surfaces in the audit channel.
+#
+# No direct DB writes from these helpers — every persistence call is
+# delegated.
+
+_CLEANUP_SCOPE_TYPES: frozenset[str] = frozenset({"guild", "category", "channel"})
+_ROUTING_SCOPE_TYPES: frozenset[str] = frozenset({"guild", "category", "channel"})
+
+
+def _coerce_routing_enabled(op: SetupOperation) -> bool:
+    """Return the operator-chosen enabled flag for a ``set_cog_routing`` op.
+
+    The wizard's cog-routing section stages the boolean as a string in
+    ``op.metadata["enabled"]`` ("true" / "false") so the JSONB column
+    in ``setup_draft_operations`` doesn't need a bespoke schema.  This
+    helper handles the round-trip cleanly.
+    """
+    raw = (op.metadata or {}).get("enabled")
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, str):
+        return raw.strip().lower() == "true"
+    # Default to True so a drafting bug doesn't silently disable a cog.
+    return True
+
+
+async def _apply_set_cleanup_policy(
+    op: SetupOperation,
+    *,
+    guild: Any,
+    actor: Any,
+    label: str,
+) -> SetupOperationResult:
+    """Persist a cleanup-policy draft via :mod:`governance.writes`.
+
+    Translates the operator-facing level (``Off`` / ``Light`` /
+    ``Standard`` / ``Strict``) to ``cleanup_policies`` columns via
+    :mod:`services.cleanup_levels` and calls
+    :func:`governance.writes.set_cleanup_policy_for_scope`, which
+    handles the DB write, governance audit row, cache invalidation,
+    and ``audit.action_recorded`` event in one transaction.
+    """
+    from governance.models import GovernanceContext
+    from governance.writes import set_cleanup_policy_for_scope
+    from services.cleanup_levels import columns_for_level, known_level_names
+
+    scope_kind = (op.target_kind or "").strip().lower()
+    if scope_kind not in _CLEANUP_SCOPE_TYPES:
+        return SetupOperationResult(
+            status="failed",
+            operation=op,
+            label=label,
+            error=(
+                f"set_cleanup_policy: target_kind {scope_kind!r} is not one "
+                f"of {sorted(_CLEANUP_SCOPE_TYPES)}"
+            ),
+        )
+
+    level = op.value if isinstance(op.value, str) else None
+    if level is None or level not in known_level_names():
+        return SetupOperationResult(
+            status="failed",
+            operation=op,
+            label=label,
+            error=(
+                f"set_cleanup_policy: level {op.value!r} is not one of "
+                f"{sorted(known_level_names())}"
+            ),
+        )
+
+    # Guild-scope writes use scope_id=0 (the column is NOT NULL on the
+    # governance table) — see governance/writes.py.  Category/channel
+    # writes carry the snowflake.
+    scope_id = op.target_id if scope_kind != "guild" else 0
+    if scope_kind != "guild" and scope_id is None:
+        return SetupOperationResult(
+            status="failed",
+            operation=op,
+            label=label,
+            error=f"set_cleanup_policy: {scope_kind} scope requires target_id",
+        )
+
+    columns = columns_for_level(level)
+    ctx = GovernanceContext(guild_id=guild.id, member=actor)
+    await set_cleanup_policy_for_scope(
+        ctx,
+        scope_kind,
+        scope_id or 0,
+        delete_invalid_commands=columns["delete_invalid_commands"],
+        delete_failed_commands=columns["delete_failed_commands"],
+        delete_after_seconds=columns["delete_after_seconds"],
+    )
+    return SetupOperationResult(
+        status="applied",
+        operation=op,
+        label=label,
+    )
+
+
+async def _apply_set_cog_routing(
+    op: SetupOperation,
+    *,
+    guild: Any,
+    actor: Any,
+    label: str,
+) -> SetupOperationResult:
+    """Persist a cog-routing draft via :mod:`services.command_routing`.
+
+    Reads the enabled flag from ``op.metadata["enabled"]`` (the wizard
+    section stages it as a "true"/"false" string), and routes through
+    the existing :func:`services.command_routing.set_policy`
+    primitive.  Emits ``audit.action_recorded`` so the apply is visible
+    in the audit channel.
+    """
+    import uuid
+    from datetime import datetime, timezone
+
+    from services import command_routing
+    from services.audit_events import emit_audit_action
+
+    scope_kind = (op.target_kind or "").strip().lower()
+    if scope_kind not in _ROUTING_SCOPE_TYPES:
+        return SetupOperationResult(
+            status="failed",
+            operation=op,
+            label=label,
+            error=(
+                f"set_cog_routing: target_kind {scope_kind!r} is not one "
+                f"of {sorted(_ROUTING_SCOPE_TYPES)}"
+            ),
+        )
+
+    cog_name = op.value if isinstance(op.value, str) else None
+    if not cog_name:
+        return SetupOperationResult(
+            status="failed",
+            operation=op,
+            label=label,
+            error="set_cog_routing: value must be the cog name (non-empty string)",
+        )
+
+    if scope_kind != "guild" and op.target_id is None:
+        return SetupOperationResult(
+            status="failed",
+            operation=op,
+            label=label,
+            error=f"set_cog_routing: {scope_kind} scope requires target_id",
+        )
+
+    enabled = _coerce_routing_enabled(op)
+    scope_id = op.target_id if scope_kind != "guild" else None
+    actor_id = getattr(actor, "id", None)
+
+    mutation_id = str(uuid.uuid4())
+    await command_routing.set_policy(
+        guild_id=guild.id,
+        scope_type=scope_kind,
+        scope_id=scope_id,
+        cog_name=cog_name,
+        enabled=enabled,
+        actor_id=actor_id,
+    )
+    # Routing rows don't ship through a full mutation pipeline yet —
+    # surface the apply via the canonical audit event so dashboards
+    # and the audit channel still see it.
+    await emit_audit_action(
+        mutation_id=mutation_id,
+        subsystem="cog_routing",
+        mutation_type="set_cog_routing",
+        target=f"{scope_kind}:{scope_id if scope_id is not None else 'guild'}:{cog_name}",
+        scope=scope_kind,
+        guild_id=guild.id,
+        prev_value=None,
+        new_value="enabled" if enabled else "disabled",
+        actor_id=actor_id,
+        actor_type="user",
+        occurred_at=datetime.now(tz=timezone.utc),
+    )
+    return SetupOperationResult(
+        status="applied",
+        operation=op,
+        label=label,
+        mutation_id=mutation_id,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -760,6 +973,20 @@ def _label(op: SetupOperation) -> str:
             str(op.automation_rule_id) if op.automation_rule_id is not None else "?"
         )
         return f"{op.kind}: {name}"
+    if op.kind == "set_cleanup_policy":
+        scope = op.target_kind or "?"
+        scope_label = op.target_name or (
+            str(op.target_id) if op.target_id is not None else "guild"
+        )
+        return f"cleanup.{scope}({scope_label}) = {op.value!r}"
+    if op.kind == "set_cog_routing":
+        scope = op.target_kind or "?"
+        scope_label = op.target_name or (
+            str(op.target_id) if op.target_id is not None else "guild"
+        )
+        enabled = _coerce_routing_enabled(op)
+        flag = "enabled" if enabled else "disabled"
+        return f"cog_routing.{scope}({scope_label}).{op.value!r} = {flag}"
     return f"{op.kind}: {op.subsystem}"
 
 

--- a/disbot/utils/db/setup_draft.py
+++ b/disbot/utils/db/setup_draft.py
@@ -51,10 +51,9 @@ _KNOWN_OP_KINDS: frozenset[str] = frozenset(
         "add_automation_rule",
         "enable_automation_rule",
         "disable_automation_rule",
-        # Per-feature op kinds staged by Setup Wizard sections.  Their
-        # dispatcher routing arms land alongside Final Review apply
-        # ordering (PR 11); until then the dispatcher surfaces them
-        # as ``not_yet_implemented``.
+        # Per-feature op kinds staged by Setup Wizard sections.
+        # Routed by services.setup_operations._apply_set_cleanup_policy
+        # and _apply_set_cog_routing respectively.
         "set_cleanup_policy",
         "set_cog_routing",
     },

--- a/disbot/views/setup/sections/cleanup.py
+++ b/disbot/views/setup/sections/cleanup.py
@@ -6,26 +6,24 @@ The existing :mod:`governance.cleanup` resolver continues to be
 authoritative at read time (``thread > channel > category > guild >
 fallback``); the wizard only stages writes.
 
-Levels map to ``cleanup_policies`` columns:
-
-* **Off**       — ``delete_invalid_commands=False, delete_failed_commands=False, delete_after_seconds=0``
-* **Light**     — ``delete_invalid_commands=True, delete_failed_commands=False, delete_after_seconds=10``
-* **Standard**  — ``delete_invalid_commands=True, delete_failed_commands=True, delete_after_seconds=5``
-* **Strict**    — ``delete_invalid_commands=True, delete_failed_commands=True, delete_after_seconds=2``
-
-PR 11 adds the ``set_cleanup_policy`` dispatcher routing arm; until
-then Final Review surfaces these as ``not_yet_implemented`` rather
-than silently dropping them.
+Levels map to ``cleanup_policies`` columns via
+:mod:`services.cleanup_levels`; Final Review's dispatcher routes the
+staged ``set_cleanup_policy`` op through
+:func:`governance.writes.set_cleanup_policy_for_scope`, which writes
+the policy row + governance audit row + emits
+``audit.action_recorded`` in one transaction.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import discord
 
 from services import setup_draft, setup_session
+from services.cleanup_levels import LEVELS
+from services.cleanup_levels import columns_for_level as level_metadata
 from services.setup_operations import SetupOperation
 from services.setup_sections import REGISTRY, SetupSection
 from views.base import BaseView
@@ -36,37 +34,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger("bot.views.setup.sections.cleanup")
 
 SLUG = "cleanup"
-
-
-# Operator-facing level names → cleanup_policies column values.
-# Exposed as a constant so tests can pin the mapping.
-LEVELS: dict[str, dict[str, Any]] = {
-    "Off": {
-        "delete_invalid_commands": False,
-        "delete_failed_commands": False,
-        "delete_after_seconds": 0,
-    },
-    "Light": {
-        "delete_invalid_commands": True,
-        "delete_failed_commands": False,
-        "delete_after_seconds": 10,
-    },
-    "Standard": {
-        "delete_invalid_commands": True,
-        "delete_failed_commands": True,
-        "delete_after_seconds": 5,
-    },
-    "Strict": {
-        "delete_invalid_commands": True,
-        "delete_failed_commands": True,
-        "delete_after_seconds": 2,
-    },
-}
-
-
-def level_metadata(level: str) -> dict[str, Any]:
-    """Return the cleanup_policies column values for a level name."""
-    return LEVELS[level]
 
 
 SCOPE_OPTIONS: list[discord.SelectOption] = [

--- a/disbot/views/setup/sections/cog_routing.py
+++ b/disbot/views/setup/sections/cog_routing.py
@@ -8,9 +8,9 @@ walks ``channel → category → guild → default-true`` so a fresh guild
 UX mirrors the cleanup section: operator picks a scope (guild
 default / category override / channel override), picks a cog from the
 SUBSYSTEMS registry, picks Enable or Disable, and the pick stages a
-``set_cog_routing`` op.  Final Review applies; until PR 11 adds the
-dispatcher routing arm Final Review surfaces these as
-``not_yet_implemented``.
+``set_cog_routing`` op.  Final Review's dispatcher routes the staged
+op through :func:`services.command_routing.set_policy` and emits
+``audit.action_recorded`` for visibility in the audit channel.
 """
 
 from __future__ import annotations

--- a/tests/unit/services/test_setup_operations_cleanup_and_routing.py
+++ b/tests/unit/services/test_setup_operations_cleanup_and_routing.py
@@ -1,0 +1,565 @@
+"""Dispatcher tests for ``set_cleanup_policy`` and ``set_cog_routing``.
+
+These two op kinds were registered in PR #233 but routed to
+``not_yet_implemented``.  This module pins the apply path that Final
+Review uses:
+
+* ``set_cleanup_policy`` goes through
+  :func:`governance.writes.set_cleanup_policy_for_scope`, which
+  handles the atomic DB write + governance audit row +
+  ``audit.action_recorded`` event.
+* ``set_cog_routing`` goes through
+  :func:`services.command_routing.set_policy`, with an
+  ``audit.action_recorded`` event emitted alongside so the apply is
+  visible in the audit channel.
+
+The tests stay asyncpg-free by patching the canonical writers.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services.setup_operations import (
+    _KNOWN_KINDS,
+    SetupOperation,
+    apply_operations,
+    preview_operations,
+    validate_operation,
+)
+
+
+def _guild(guild_id: int = 1, owner_id: int = 99):
+    return SimpleNamespace(id=guild_id, owner_id=owner_id)
+
+
+def _actor(actor_id: int = 99):
+    return SimpleNamespace(id=actor_id)
+
+
+# ---------------------------------------------------------------------------
+# Registration / preview state
+# ---------------------------------------------------------------------------
+
+
+def test_set_cleanup_policy_is_a_known_kind():
+    assert "set_cleanup_policy" in _KNOWN_KINDS
+
+
+def test_set_cog_routing_is_a_known_kind():
+    assert "set_cog_routing" in _KNOWN_KINDS
+
+
+def test_validate_operation_accepts_set_cleanup_policy():
+    op = SetupOperation(
+        kind="set_cleanup_policy",
+        subsystem="cleanup",
+        target_kind="guild",
+        value="Standard",
+    )
+    assert validate_operation(op) is None
+
+
+def test_validate_operation_accepts_set_cog_routing():
+    op = SetupOperation(
+        kind="set_cog_routing",
+        subsystem="cog_routing",
+        target_kind="guild",
+        value="games",
+    )
+    assert validate_operation(op) is None
+
+
+def test_preview_operations_reports_applied_for_both_kinds():
+    """Preview only inspects ``kind``; the dispatcher's routing arm is
+    what proves the apply path.  Confirm both kinds round-trip as
+    applied (not ``not_yet_implemented``).
+    """
+    ops = [
+        SetupOperation(
+            kind="set_cleanup_policy", subsystem="cleanup",
+            target_kind="guild", value="Standard",
+        ),
+        SetupOperation(
+            kind="set_cog_routing", subsystem="cog_routing",
+            target_kind="guild", value="games",
+        ),
+    ]
+    results = preview_operations(ops)
+    assert [r.status for r in results] == ["applied", "applied"]
+
+
+# ---------------------------------------------------------------------------
+# set_cleanup_policy — dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_cleanup_policy_routes_through_governance_writer():
+    op = SetupOperation(
+        kind="set_cleanup_policy",
+        subsystem="cleanup",
+        target_kind="guild",
+        target_id=None,
+        target_name="guild",
+        value="Standard",
+    )
+    with patch(
+        "governance.writes.set_cleanup_policy_for_scope",
+        new_callable=AsyncMock,
+    ) as writer:
+        batch = await apply_operations([op], guild=_guild(), actor=_actor())
+
+    writer.assert_awaited_once()
+    kwargs = writer.await_args.kwargs
+    # Standard level → invalid+failed delete, 5s.
+    assert kwargs["delete_invalid_commands"] is True
+    assert kwargs["delete_failed_commands"] is True
+    assert kwargs["delete_after_seconds"] == 5
+    # Positional args: ctx, scope_type, scope_id.
+    ctx_arg, scope_type, scope_id = writer.await_args.args
+    assert scope_type == "guild"
+    assert scope_id == 0  # guild scope uses 0 (column is NOT NULL)
+    assert ctx_arg.guild_id == 1
+    assert ctx_arg.member is not None  # actor passed through
+
+    assert len(batch.applied) == 1
+    assert batch.applied[0].status == "applied"
+    assert batch.failed == []
+    assert batch.not_yet_implemented == []
+
+
+@pytest.mark.asyncio
+async def test_set_cleanup_policy_passes_through_each_level():
+    """Every operator-facing level maps to the right column values."""
+    from services.cleanup_levels import LEVELS
+
+    for level_name, expected in LEVELS.items():
+        op = SetupOperation(
+            kind="set_cleanup_policy",
+            subsystem="cleanup",
+            target_kind="guild",
+            value=level_name,
+        )
+        with patch(
+            "governance.writes.set_cleanup_policy_for_scope",
+            new_callable=AsyncMock,
+        ) as writer:
+            batch = await apply_operations([op], guild=_guild(), actor=_actor())
+        kwargs = writer.await_args.kwargs
+        assert kwargs["delete_invalid_commands"] == expected["delete_invalid_commands"]
+        assert kwargs["delete_failed_commands"] == expected["delete_failed_commands"]
+        assert kwargs["delete_after_seconds"] == expected["delete_after_seconds"]
+        assert len(batch.applied) == 1, f"{level_name}: not applied"
+
+
+@pytest.mark.asyncio
+async def test_set_cleanup_policy_passes_category_scope_id():
+    op = SetupOperation(
+        kind="set_cleanup_policy",
+        subsystem="cleanup",
+        target_kind="category",
+        target_id=42,
+        target_name="Staff",
+        value="Strict",
+    )
+    with patch(
+        "governance.writes.set_cleanup_policy_for_scope",
+        new_callable=AsyncMock,
+    ) as writer:
+        await apply_operations([op], guild=_guild(), actor=_actor())
+    _, scope_type, scope_id = writer.await_args.args
+    assert scope_type == "category"
+    assert scope_id == 42
+
+
+@pytest.mark.asyncio
+async def test_set_cleanup_policy_rejects_unknown_scope_type():
+    op = SetupOperation(
+        kind="set_cleanup_policy",
+        subsystem="cleanup",
+        target_kind="role",  # cleanup_policies doesn't support role scope
+        target_id=1,
+        value="Strict",
+    )
+    with patch(
+        "governance.writes.set_cleanup_policy_for_scope",
+        new_callable=AsyncMock,
+    ) as writer:
+        batch = await apply_operations([op], guild=_guild(), actor=_actor())
+    writer.assert_not_awaited()
+    assert len(batch.failed) == 1
+    assert "target_kind" in batch.failed[0].error
+
+
+@pytest.mark.asyncio
+async def test_set_cleanup_policy_rejects_unknown_level():
+    op = SetupOperation(
+        kind="set_cleanup_policy",
+        subsystem="cleanup",
+        target_kind="guild",
+        value="Nuclear",  # not a known level
+    )
+    with patch(
+        "governance.writes.set_cleanup_policy_for_scope",
+        new_callable=AsyncMock,
+    ) as writer:
+        batch = await apply_operations([op], guild=_guild(), actor=_actor())
+    writer.assert_not_awaited()
+    assert len(batch.failed) == 1
+    assert "level" in batch.failed[0].error
+
+
+@pytest.mark.asyncio
+async def test_set_cleanup_policy_rejects_category_without_target_id():
+    op = SetupOperation(
+        kind="set_cleanup_policy",
+        subsystem="cleanup",
+        target_kind="category",
+        target_id=None,  # category scope must carry an id
+        value="Strict",
+    )
+    with patch(
+        "governance.writes.set_cleanup_policy_for_scope",
+        new_callable=AsyncMock,
+    ) as writer:
+        batch = await apply_operations([op], guild=_guild(), actor=_actor())
+    writer.assert_not_awaited()
+    assert len(batch.failed) == 1
+    assert "target_id" in batch.failed[0].error
+
+
+@pytest.mark.asyncio
+async def test_set_cleanup_policy_surfaces_writer_failure_per_op():
+    """A writer raise should turn into a per-op `failed` result —
+    other ops in the same batch keep running.
+    """
+    failing = SetupOperation(
+        kind="set_cleanup_policy", subsystem="cleanup",
+        target_kind="guild", value="Standard",
+    )
+    succeeding = SetupOperation(
+        kind="set_cleanup_policy", subsystem="cleanup",
+        target_kind="channel", target_id=999, value="Off",
+    )
+    calls = {"n": 0}
+
+    async def writer(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("simulated DB down")
+        return None
+
+    with patch("governance.writes.set_cleanup_policy_for_scope", new=writer):
+        batch = await apply_operations(
+            [failing, succeeding], guild=_guild(), actor=_actor(),
+        )
+    assert len(batch.failed) == 1
+    assert "simulated DB down" in batch.failed[0].error
+    assert len(batch.applied) == 1
+
+
+# ---------------------------------------------------------------------------
+# set_cog_routing — dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_cog_routing_routes_through_command_routing_service():
+    op = SetupOperation(
+        kind="set_cog_routing",
+        subsystem="cog_routing",
+        target_kind="guild",
+        target_id=None,
+        target_name="guild",
+        value="games",
+        metadata={"enabled": "false"},
+    )
+    with (
+        patch(
+            "services.command_routing.set_policy",
+            new_callable=AsyncMock,
+        ) as set_policy,
+        patch(
+            "services.audit_events.emit_audit_action",
+            new_callable=AsyncMock,
+        ),
+    ):
+        batch = await apply_operations([op], guild=_guild(), actor=_actor())
+
+    set_policy.assert_awaited_once()
+    kwargs = set_policy.await_args.kwargs
+    assert kwargs["guild_id"] == 1
+    assert kwargs["scope_type"] == "guild"
+    assert kwargs["scope_id"] is None  # guild scope is NULL
+    assert kwargs["cog_name"] == "games"
+    assert kwargs["enabled"] is False
+    assert kwargs["actor_id"] == 99
+    assert len(batch.applied) == 1
+    assert batch.applied[0].status == "applied"
+    # The dispatcher generates a mutation_id even though routing rows
+    # don't ship through a full mutation pipeline.
+    assert batch.applied[0].mutation_id
+
+
+@pytest.mark.asyncio
+async def test_set_cog_routing_default_enabled_true_when_metadata_missing():
+    """A drafting bug that omits ``metadata.enabled`` defaults to
+    enabled — never silently disable a cog.
+    """
+    op = SetupOperation(
+        kind="set_cog_routing", subsystem="cog_routing",
+        target_kind="guild", value="games",
+    )
+    with (
+        patch(
+            "services.command_routing.set_policy",
+            new_callable=AsyncMock,
+        ) as set_policy,
+        patch(
+            "services.audit_events.emit_audit_action",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await apply_operations([op], guild=_guild(), actor=_actor())
+    assert set_policy.await_args.kwargs["enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_set_cog_routing_handles_bool_enabled_metadata():
+    """Accept ``metadata.enabled`` as a real bool too, not just "true"/"false"."""
+    op = SetupOperation(
+        kind="set_cog_routing", subsystem="cog_routing",
+        target_kind="guild", value="games",
+        metadata={"enabled": False},
+    )
+    with (
+        patch(
+            "services.command_routing.set_policy",
+            new_callable=AsyncMock,
+        ) as set_policy,
+        patch(
+            "services.audit_events.emit_audit_action",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await apply_operations([op], guild=_guild(), actor=_actor())
+    assert set_policy.await_args.kwargs["enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_set_cog_routing_passes_scope_id_for_non_guild_scopes():
+    op = SetupOperation(
+        kind="set_cog_routing", subsystem="cog_routing",
+        target_kind="channel", target_id=555, target_name="general",
+        value="economy", metadata={"enabled": "true"},
+    )
+    with (
+        patch(
+            "services.command_routing.set_policy",
+            new_callable=AsyncMock,
+        ) as set_policy,
+        patch(
+            "services.audit_events.emit_audit_action",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await apply_operations([op], guild=_guild(), actor=_actor())
+    kwargs = set_policy.await_args.kwargs
+    assert kwargs["scope_type"] == "channel"
+    assert kwargs["scope_id"] == 555
+
+
+@pytest.mark.asyncio
+async def test_set_cog_routing_emits_audit_action_event():
+    """Routing apply must surface in the canonical audit stream so the
+    audit channel and audit-row dashboards see it.
+    """
+    op = SetupOperation(
+        kind="set_cog_routing", subsystem="cog_routing",
+        target_kind="channel", target_id=999, value="games",
+        metadata={"enabled": "false"},
+    )
+    with (
+        patch(
+            "services.command_routing.set_policy",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "services.audit_events.emit_audit_action",
+            new_callable=AsyncMock,
+        ) as emit,
+    ):
+        await apply_operations([op], guild=_guild(), actor=_actor())
+    emit.assert_awaited_once()
+    kwargs = emit.await_args.kwargs
+    assert kwargs["subsystem"] == "cog_routing"
+    assert kwargs["mutation_type"] == "set_cog_routing"
+    assert kwargs["scope"] == "channel"
+    assert kwargs["guild_id"] == 1
+    assert kwargs["actor_id"] == 99
+    assert kwargs["new_value"] == "disabled"
+
+
+@pytest.mark.asyncio
+async def test_set_cog_routing_rejects_unknown_scope_type():
+    op = SetupOperation(
+        kind="set_cog_routing", subsystem="cog_routing",
+        target_kind="thread",  # routing supports guild/category/channel only
+        target_id=1, value="games",
+    )
+    with patch(
+        "services.command_routing.set_policy",
+        new_callable=AsyncMock,
+    ) as set_policy:
+        batch = await apply_operations([op], guild=_guild(), actor=_actor())
+    set_policy.assert_not_awaited()
+    assert len(batch.failed) == 1
+    assert "target_kind" in batch.failed[0].error
+
+
+@pytest.mark.asyncio
+async def test_set_cog_routing_rejects_empty_cog_name():
+    op = SetupOperation(
+        kind="set_cog_routing", subsystem="cog_routing",
+        target_kind="guild", value="",
+    )
+    with patch(
+        "services.command_routing.set_policy",
+        new_callable=AsyncMock,
+    ) as set_policy:
+        batch = await apply_operations([op], guild=_guild(), actor=_actor())
+    set_policy.assert_not_awaited()
+    assert len(batch.failed) == 1
+    assert "cog name" in batch.failed[0].error
+
+
+@pytest.mark.asyncio
+async def test_set_cog_routing_rejects_non_guild_scope_without_target_id():
+    op = SetupOperation(
+        kind="set_cog_routing", subsystem="cog_routing",
+        target_kind="category", target_id=None, value="games",
+    )
+    with patch(
+        "services.command_routing.set_policy",
+        new_callable=AsyncMock,
+    ) as set_policy:
+        batch = await apply_operations([op], guild=_guild(), actor=_actor())
+    set_policy.assert_not_awaited()
+    assert len(batch.failed) == 1
+    assert "target_id" in batch.failed[0].error
+
+
+# ---------------------------------------------------------------------------
+# No `not_yet_implemented` leftovers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_neither_kind_returns_not_yet_implemented_after_wiring():
+    """Smoke-check the regression these PRs aim to close: neither of
+    the two newly-wired kinds may surface as ``not_yet_implemented``
+    when patched canonical writers succeed.
+    """
+    ops = [
+        SetupOperation(
+            kind="set_cleanup_policy", subsystem="cleanup",
+            target_kind="guild", value="Off",
+        ),
+        SetupOperation(
+            kind="set_cog_routing", subsystem="cog_routing",
+            target_kind="guild", value="games",
+            metadata={"enabled": "true"},
+        ),
+    ]
+    with (
+        patch(
+            "governance.writes.set_cleanup_policy_for_scope",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "services.command_routing.set_policy",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "services.audit_events.emit_audit_action",
+            new_callable=AsyncMock,
+        ),
+    ):
+        batch = await apply_operations(ops, guild=_guild(), actor=_actor())
+    assert batch.not_yet_implemented == []
+    assert len(batch.applied) == 2
+
+
+# ---------------------------------------------------------------------------
+# Final Review phase ordering — cleanup before cog_routing before automation
+# ---------------------------------------------------------------------------
+
+
+def test_phase_order_keeps_cleanup_before_cog_routing():
+    """The wizard's Final Review applies cleanup before routing so a
+    routing-table miss for a still-being-cleaned channel doesn't
+    surprise anyone.  Pin the order here so a future _PHASE_ORDER
+    edit can't silently reorder them.
+    """
+    from views.setup.final_review import _PHASE_ORDER
+
+    cleanup_idx = next(
+        i for i, (name, _) in enumerate(_PHASE_ORDER) if name == "cleanup_policy"
+    )
+    routing_idx = next(
+        i for i, (name, _) in enumerate(_PHASE_ORDER) if name == "cog_routing"
+    )
+    automation_idx = next(
+        i for i, (name, _) in enumerate(_PHASE_ORDER) if name == "automation_add"
+    )
+    assert cleanup_idx < routing_idx < automation_idx
+
+
+@pytest.mark.asyncio
+async def test_final_review_apply_ops_in_order_applies_both_kinds():
+    """End-to-end: a mixed batch (cleanup + routing) applied via
+    Final Review's _apply_ops_in_order routes through both writers
+    in phase order.
+    """
+    from views.setup.final_review import _apply_ops_in_order
+
+    ops = [
+        SetupOperation(
+            kind="set_cog_routing", subsystem="cog_routing",
+            target_kind="guild", value="games",
+            metadata={"enabled": "true"},
+        ),
+        SetupOperation(
+            kind="set_cleanup_policy", subsystem="cleanup",
+            target_kind="guild", value="Standard",
+        ),
+    ]
+    with (
+        patch(
+            "governance.writes.set_cleanup_policy_for_scope",
+            new_callable=AsyncMock,
+        ) as cleanup_writer,
+        patch(
+            "services.command_routing.set_policy",
+            new_callable=AsyncMock,
+        ) as routing_writer,
+        patch(
+            "services.audit_events.emit_audit_action",
+            new_callable=AsyncMock,
+        ),
+    ):
+        summary = await _apply_ops_in_order(
+            ops, guild=_guild(), actor=_actor(),
+        )
+
+    cleanup_writer.assert_awaited_once()
+    routing_writer.assert_awaited_once()
+    assert len(summary.applied) == 2
+    assert summary.failed == []
+    # Phase order: cleanup_policy (4) before cog_routing (5).
+    assert "cleanup" in summary.applied[0].lower()
+    assert "cog_routing" in summary.applied[1].lower()


### PR DESCRIPTION
## Summary

Closes the two deferred routing arms from PR #233 so Final Review can actually apply ``set_cleanup_policy`` and ``set_cog_routing`` drafts. Both kinds previously landed in the draft store but routed to ``not_yet_implemented`` at apply time.

## Architecture

| Op kind | Routes to | Audit / event |
|---|---|---|
| `set_cleanup_policy` | `governance.writes.set_cleanup_policy_for_scope` | Already emits `audit.action_recorded` + writes `governance_audit_log` row in the same transaction |
| `set_cog_routing` | `services.command_routing.set_policy` | New: dispatcher emits `audit.action_recorded` from the apply path so the audit channel sees it |

- No bypass of canonical pipelines; no direct DB writes from the dispatcher.
- Per-op isolation preserved: a writer failure for one op surfaces as a per-op `failed` result without aborting the rest of the Final Review batch.
- Phase ordering unchanged: cleanup → cog routing → automation.

## Files changed

| File | Purpose |
|---|---|
| `disbot/services/setup_operations.py` | New `_apply_set_cleanup_policy` + `_apply_set_cog_routing` dispatch arms wired into `_dispatch_one`. Extended `_label` for nice rendering. `_coerce_routing_enabled` handles the "true"/"false"/bool metadata round-trip. |
| `disbot/services/cleanup_levels.py` *(new)* | Shared `LEVELS` table + `columns_for_level` / `known_level_names`. Single source of truth for both the wizard section and the dispatcher. |
| `disbot/views/setup/sections/cleanup.py` | Imports `LEVELS` from the new shared module. Docstring refreshed to reflect the live dispatcher path. |
| `disbot/views/setup/sections/cog_routing.py` | Docstring refreshed (was claiming the apply path didn't exist yet). |
| `disbot/utils/db/setup_draft.py` | Dropped stale "PR 11" comment in the op-kind allowlist. |
| `tests/unit/services/test_setup_operations_cleanup_and_routing.py` *(new)* | 23 new tests covering registration / preview / dispatch / failure / phase order / end-to-end. |

## Tests added

23 new tests in `test_setup_operations_cleanup_and_routing.py`:

- Both kinds remain in `_KNOWN_KINDS` and pass `validate_operation`.
- `preview_operations` reports `applied` (not `not_yet_implemented`) for both.
- **set_cleanup_policy:**
  - Routes through the governance writer with correct columns derived from each level (Off / Light / Standard / Strict).
  - Passes category/channel `scope_id` when provided.
  - Rejects unknown `scope_type`, unknown level, and category/channel scope missing `target_id` — all surface as per-op failed.
  - Writer failure surfaces per-op without aborting the batch.
- **set_cog_routing:**
  - Routes through `command_routing.set_policy` with the right guild_id / scope_type / scope_id / cog_name / enabled / actor_id.
  - Defaults `metadata.enabled` missing to True (never silently disables a cog).
  - Accepts both string and bool enabled.
  - Emits `audit.action_recorded` with the canonical payload shape.
  - Rejects unknown scope_type, empty cog name, and non-guild scope missing target_id.
- **Regression:** neither kind returns `not_yet_implemented` after wiring.
- **Phase ordering** preserved: `cleanup_policy` still before `cog_routing` before `automation` in Final Review's `_PHASE_ORDER`.
- **End-to-end:** mixed batch applied via `_apply_ops_in_order` routes both writers in phase order.

All 3529 existing tests + 4 linters (black, isort, ruff, mypy 2.1.0) pass.

## Manual smoke

In a dev guild:

1. **Cleanup override apply:**
   - `!setup` → Start Setup → **Cleanup inheritance**.
   - Pick **Channel override** → pick a test channel → pick **Strict**.
   - Hub embed shows `Pending operations: 1`.
   - **Final review** → Apply.
   - Confirm in the audit channel: one `audit.action_recorded` event with `mutation_type=set_cleanup_policy`, `scope=channel`.
   - Confirm in DB: `SELECT * FROM cleanup_policies WHERE scope_type='channel' AND scope_id=<picked id>;` shows `delete_after_seconds=2, delete_invalid_commands=true, delete_failed_commands=true`.
   - Confirm runtime: invoke an invalid command in the picked channel → message deleted after ~2 seconds.

2. **Cog routing override apply:**
   - `!setup` → **Cog routing**.
   - Pick **Channel override** → pick a test channel → pick a cog (e.g. `economy`) → **Disable**.
   - **Final review** → Apply.
   - Confirm audit channel: `audit.action_recorded` with `mutation_type=set_cog_routing`, `new_value=disabled`.
   - Confirm DB: `SELECT * FROM command_routing_policy WHERE scope_type='channel' AND scope_id=<picked id>;` shows `enabled=false`.

3. **Final Review failure behaviour:**
   - Stage one valid op and one bad op (e.g. drop the bot's `manage_channels` perm temporarily to make a cleanup write fail at the audit-row layer).
   - Apply. Confirm summary lists the good op in **Applied (1)** and the bad op in **Failed (1)** with the error inline — neither aborts the other.

## Remaining risks / follow-ups

- **Routing audit visibility is dispatcher-level**, not pipeline-level. If a `!platform routing` admin command lands later that mutates `command_routing_policy` directly, it should mirror this audit-emit pattern. A proper `CommandRoutingMutationPipeline` (matching `BindingMutationPipeline`'s shape) is the cleaner long-term fix; not in this PR's scope.
- **GovernanceContext authority check.** `governance.writes._validate_authority` requires the actor to be at least `moderator` tier. Final Review is already owner-gated by the hub view, so this only blocks an apply if the owner has somehow been demoted between staging and apply — surfaces as a per-op `failed` with the governance error.
- The remaining plan gaps after this PR: setup summary persistence + completeness scoring (PR 11 follow-up), Settings Manager binding/resource UI parallel track, manual Discord smoke verification.

https://claude.ai/code/session_012v3dRcykVxa62aEjZAfEqx

---
_Generated by [Claude Code](https://claude.ai/code/session_012v3dRcykVxa62aEjZAfEqx)_