### PR TITLE
feat(setup): direct entry (!setup, /setup) + per-section progress tracking

### DIFF
--- a/disbot/cogs/setup_cog.py
+++ b/disbot/cogs/setup_cog.py
@@ -57,10 +57,13 @@ async def _resolve_hub_entry(
 ):
     """Resolve the hub-entry response for ``member`` in ``guild``.
 
-    Returns one of three shapes:
+    Returns one of four shapes:
 
-    * ``(hub_embed, hub_view, "hub")`` — member can apply setup; full
-      hub is rendered. Caller marks the session in progress.
+    * ``(depth_embed, depth_view, "depth_picker")`` — first-time entry
+      for an apply-capable member with no depth chosen yet.
+    * ``(hub_embed, hub_view, "hub")`` — member can apply setup and
+      has a persisted depth; full hub renders, filtered by depth.
+      Caller marks the session in progress.
     * ``(readiness_embed, None, "readiness")`` — member is a setup
       admin without apply authority; render the deterministic
       readiness embed instead.
@@ -84,6 +87,15 @@ async def _resolve_hub_entry(
                     "setup_cog._resolve_hub_entry: start_session failed",
                 )
                 session = None
+
+        if session is not None and session.depth is None:
+            from views.setup.depth_panel import (
+                DepthPanelView,
+                build_depth_embed,
+            )
+
+            view = DepthPanelView(member, session=session)
+            return build_depth_embed(), view, "depth_picker"
 
         from services import setup_draft
         from views.setup.hub import SetupHubView, build_hub_embed
@@ -169,10 +181,11 @@ class SetupCog(commands.Cog):
             await ctx.send("Could not build the setup hub. See logs.")
             return
         await ctx.send(embed=embed, view=view)
-        try:
-            await setup_session.mark_in_progress(guild.id, step="hub")
-        except Exception:
-            logger.exception("setup_cog.setup_cmd: mark_in_progress failed")
+        if mode == "hub":
+            try:
+                await setup_session.mark_in_progress(guild.id, step="hub")
+            except Exception:
+                logger.exception("setup_cog.setup_cmd: mark_in_progress failed")
 
     @app_commands.command(
         name="setup",
@@ -224,10 +237,11 @@ class SetupCog(commands.Cog):
             view=view,
             ephemeral=True,
         )
-        try:
-            await setup_session.mark_in_progress(guild.id, step="hub")
-        except Exception:
-            logger.exception("setup_cog.setup_slash: mark_in_progress failed")
+        if mode == "hub":
+            try:
+                await setup_session.mark_in_progress(guild.id, step="hub")
+            except Exception:
+                logger.exception("setup_cog.setup_slash: mark_in_progress failed")
 
     @commands.Cog.listener()
     async def on_guild_join(self, guild: discord.Guild) -> None:

--- a/disbot/cogs/setup_cog.py
+++ b/disbot/cogs/setup_cog.py
@@ -238,11 +238,22 @@ class SetupCog(commands.Cog):
         await self._resume_launchers()
 
     async def _handle_join(self, guild: discord.Guild) -> None:
-        """Internal entry point — split out for direct testing."""
+        """Internal entry point — split out for direct testing.
+
+        Tries to auto-create a private ``#superbot-setup`` channel and
+        post the launcher there with an owner ping. If the bot lacks
+        Manage Channels (or the create fails), falls back to
+        :func:`post_launcher` which picks the safest existing channel
+        or DMs the owner.
+        """
         try:
-            channel, message = await post_launcher(guild)
-            channel_id = channel.id if channel is not None else None
-            message_id = message.id if message is not None else None
+            channel_id, message_id = await self._post_launcher_in_setup_channel(
+                guild,
+            )
+            if channel_id is None:
+                channel, message = await post_launcher(guild)
+                channel_id = channel.id if channel is not None else None
+                message_id = message.id if message is not None else None
             await setup_session.start_session(
                 guild_id=guild.id,
                 guild_name=guild.name,
@@ -255,6 +266,78 @@ class SetupCog(commands.Cog):
                 "setup_cog.on_guild_join: handler failed for guild=%d",
                 guild.id,
             )
+
+    async def _post_launcher_in_setup_channel(
+        self,
+        guild: discord.Guild,
+    ) -> tuple[int | None, int | None]:
+        """Try the private-setup-channel path; return ``(channel_id,
+        message_id)`` on success or ``(None, None)`` to signal the
+        caller should fall back to :func:`post_launcher`.
+
+        Resuming on bot restart hits the same path and is idempotent
+        (``ensure_setup_channel`` returns the existing channel without
+        recreating, and the cog keeps the prior message id when the
+        existing launcher message is still posted).
+        """
+        from services.setup_channel import ensure_setup_channel
+
+        existing_session = await setup_session.resume_session(guild.id)
+        existing_channel_id = (
+            existing_session.setup_channel_id if existing_session else None
+        )
+        try:
+            channel, was_created = await ensure_setup_channel(
+                guild,
+                existing_channel_id=existing_channel_id,
+            )
+        except Exception:
+            logger.exception(
+                "setup_cog._post_launcher_in_setup_channel: ensure failed "
+                "(guild=%d)",
+                guild.id,
+            )
+            return None, None
+        if channel is None:
+            return None, None
+
+        # On a restart where the channel already existed and we already
+        # posted a launcher, do not double-post — the existing message
+        # gets edited in place by ``_resume_launchers`` on ``on_ready``.
+        if (
+            not was_created
+            and existing_session is not None
+            and existing_session.setup_channel_id == channel.id
+            and existing_session.setup_message_id is not None
+        ):
+            return channel.id, existing_session.setup_message_id
+
+        embed = _build_launcher_embed(None)
+        view = SetupLauncherView()
+        owner_mention = guild.owner.mention if guild.owner is not None else ""
+        content = (
+            f"{owner_mention} SuperBot just joined! I'll use this private "
+            f"channel as the setup workspace. Click **Start Setup** below "
+            f"(or run `!setup` / `/setup`) to begin."
+            if was_created
+            else None
+        )
+        try:
+            message = await channel.send(
+                content=content,
+                embed=embed,
+                view=view,
+                allowed_mentions=discord.AllowedMentions(users=True, everyone=False),
+            )
+        except discord.HTTPException as exc:
+            logger.warning(
+                "setup_cog._post_launcher_in_setup_channel: send failed "
+                "in guild=%d: %s",
+                guild.id,
+                exc,
+            )
+            return None, None
+        return channel.id, message.id
 
     async def _resume_launchers(self) -> None:
         """Refresh every guild's launcher message in place; isolate failures."""

--- a/disbot/cogs/setup_cog.py
+++ b/disbot/cogs/setup_cog.py
@@ -1,30 +1,24 @@
 """Setup-wizard launcher cog.
 
-Posts a persistent owner-gated launcher when the bot joins a guild and
-on every subsequent ``on_ready`` for guilds whose launcher is still
-``pending`` / ``in_progress``.
+Discord-facing surface only. The persistent launcher view, embed
+builder, and channel-selection helpers live in
+:mod:`views.setup.launcher`; this file holds:
+
+* the cog class with lifecycle listeners and slash/prefix entry
+  commands (``!setup`` / ``/setup``);
+* a shared ``_resolve_hub_entry`` helper that branches between the
+  guided hub (owner / delegated admin) and the deterministic
+  readiness embed (plain administrator).
+
+Re-exports the launcher view + post helpers so callers that imported
+``cogs.setup_cog.SetupLauncherView`` / ``post_launcher`` /
+``pick_launcher_channel`` keep working.
 
 Wires:
 * :mod:`services.setup_session` for the lifecycle row.
 * :mod:`services.setup_access` for owner / admin / non-admin gating.
 * :func:`services.setup_readiness.collect` for readiness scans.
 * :class:`views.setup.hub.SetupHubView` for the guided setup hub.
-* :mod:`services.setup_ai_advisor` and
-  :class:`views.setup.ai_review.main_panel.AIReviewPanelView` for Smart
-  Suggestions.
-* :class:`views.setup.template_picker.TemplatePickerView` for preset
-  selection.
-* :mod:`views.setup.summary` for completed-setup summaries and drift review.
-
-Interactive launcher actions:
-* **Start Setup** opens the guided setup hub and marks the session in progress.
-* **Run Readiness Scan** renders the deterministic setup-readiness snapshot.
-* **Smart Suggestions** collects a guild snapshot and opens the AI/deterministic
-  recommendation review panel.
-* **Choose Preset** opens the automation-template picker.
-* **View Summary** opens the completed setup summary when setup is complete.
-* **Dismiss** flips ``setup_status`` to ``dismissed``; never deletes Discord
-  resources or DB rows.
 """
 
 from __future__ import annotations
@@ -36,530 +30,16 @@ from discord import app_commands
 from discord.ext import commands
 
 from services import setup_access, setup_session
-from services.setup_session import SetupSession
-
-logger = logging.getLogger("bot.cogs.setup")
-
-_LAUNCHER_TITLE = "🛰 SuperBot setup"
-_LAUNCHER_DESC = (
-    "Welcome! I'll help you wire SuperBot up to this server.\n\n"
-    "Use **Start Setup** for the guided walkthrough, **Run Readiness Scan** "
-    "to see what's already configured, or **Dismiss** to defer."
+from views.setup.launcher import (
+    SetupLauncherView,
+)
+from views.setup.launcher import _build_launcher_embed as _build_launcher_embed
+from views.setup.launcher import (
+    pick_launcher_channel,
+    post_launcher,
 )
 
-
-def _build_launcher_embed(session: SetupSession | None) -> discord.Embed:
-    color = discord.Color.blurple()
-    if session is not None and session.setup_status == "complete":
-        color = discord.Color.green()
-    elif session is not None and session.setup_status == "dismissed":
-        color = discord.Color.dark_grey()
-
-    description = _LAUNCHER_DESC
-    if session is not None:
-        description = f"{_LAUNCHER_DESC}\n\n**Status:** `{session.setup_status}`"
-        if session.last_readiness_score is not None:
-            description += f" · readiness `{session.last_readiness_score}%`"
-        if session.current_step:
-            description += f" · step `{session.current_step}`"
-
-    embed = discord.Embed(
-        title=_LAUNCHER_TITLE,
-        description=description,
-        color=color,
-    )
-    embed.set_footer(
-        text="Owner-gated for write actions. Admins can run the readiness scan.",
-    )
-    return embed
-
-
-_START_LABELS_BY_STATUS = {
-    "pending": "Start Setup",
-    "in_progress": "Resume Setup",
-    "complete": "Re-run Setup",
-    "dismissed": "Start Setup",
-}
-
-
-class SetupLauncherView(discord.ui.View):
-    """Persistent owner-gated launcher view.
-
-    ``timeout=None`` + static ``custom_id`` per button = the message
-    survives bot restarts; :meth:`SetupCog._resume_launchers` rebinds
-    in-flight launcher messages with a status-aware label set on
-    ``on_ready``.
-
-    Labels:
-
-    * ``status="pending"`` / ``None`` / ``"dismissed"`` — default
-      "Start Setup".
-    * ``status="in_progress"`` — "Resume Setup".
-    * ``status="complete"`` — "Re-run Setup".
-
-    Custom IDs never change; discord.py routes interactions by id,
-    not by label, so the rebound message keeps working against the
-    cog-load-registered view.
-    """
-
-    def __init__(self, *, status: str | None = None) -> None:
-        super().__init__(timeout=None)
-        self.status = status
-        if status is not None:
-            self._apply_status_labels(status)
-
-    def _apply_status_labels(self, status: str) -> None:
-        start_label = _START_LABELS_BY_STATUS.get(status, "Start Setup")
-        for child in self.children:
-            if (
-                isinstance(child, discord.ui.Button)
-                and getattr(child, "custom_id", None) == "setup:start"
-            ):
-                child.label = start_label
-
-    async def _resolve_session(
-        self,
-        interaction: discord.Interaction,
-    ) -> SetupSession | None:
-        if interaction.guild_id is None:
-            return None
-        return await setup_session.resume_session(interaction.guild_id)
-
-    async def _deny(
-        self,
-        interaction: discord.Interaction,
-        message: str,
-    ) -> None:
-        await interaction.response.send_message(message, ephemeral=True)
-
-    async def _gate_owner(
-        self,
-        interaction: discord.Interaction,
-    ) -> bool:
-        member = interaction.user
-        if not isinstance(member, discord.Member):
-            await self._deny(
-                interaction,
-                "This button must be used inside the server.",
-            )
-            return False
-        if not setup_access.is_server_owner(member):
-            await self._deny(
-                interaction,
-                "Only the server owner can start setup or change presets.",
-            )
-            return False
-        return True
-
-    async def _gate_admin(
-        self,
-        interaction: discord.Interaction,
-    ) -> bool:
-        member = interaction.user
-        if not isinstance(member, discord.Member):
-            await self._deny(
-                interaction,
-                "This button must be used inside the server.",
-            )
-            return False
-        session = await self._resolve_session(interaction)
-        if not setup_access.is_setup_admin(member, session):
-            await self._deny(
-                interaction,
-                "Only the server owner, an administrator, or a delegated "
-                "setup admin can use this button.",
-            )
-            return False
-        return True
-
-    @discord.ui.button(
-        label="Start Setup",
-        style=discord.ButtonStyle.success,
-        custom_id="setup:start",
-    )
-    async def _start(
-        self,
-        interaction: discord.Interaction,
-        button: discord.ui.Button,
-    ) -> None:
-        del button
-        if not await self._gate_owner(interaction):
-            return
-        if interaction.guild_id is None:
-            await self._deny(
-                interaction,
-                "Setup requires a guild context.",
-            )
-            return
-
-        from services import setup_draft
-        from views.setup.hub import SetupHubView, build_hub_embed
-
-        session = await self._resolve_session(interaction)
-        try:
-            draft_ops = await setup_draft.list_ops(interaction.guild_id)
-        except Exception:
-            logger.exception("setup_cog._start: setup_draft.list_ops failed")
-            draft_ops = []
-        pending_ops = len(draft_ops)
-        hub = SetupHubView(interaction.user, session=session)
-        await interaction.response.send_message(
-            embed=build_hub_embed(
-                session,
-                pending_ops=pending_ops,
-                draft_ops=draft_ops,
-            ),
-            view=hub,
-            ephemeral=True,
-        )
-        try:
-            await setup_session.mark_in_progress(interaction.guild_id, step="hub")
-        except Exception:
-            logger.exception("setup_cog._start: mark_in_progress failed")
-
-    @discord.ui.button(
-        label="Run Readiness Scan",
-        style=discord.ButtonStyle.primary,
-        custom_id="setup:readiness",
-    )
-    async def _readiness(
-        self,
-        interaction: discord.Interaction,
-        button: discord.ui.Button,
-    ) -> None:
-        del button
-        if not await self._gate_admin(interaction):
-            return
-        guild = interaction.guild
-        if guild is None:
-            await self._deny(
-                interaction,
-                "Readiness scan requires a guild context.",
-            )
-            return
-        from cogs.diagnostic._platform_embeds import build_setup_readiness_embed
-
-        embed = await build_setup_readiness_embed(guild.id, guild=guild)
-        await interaction.response.send_message(embed=embed, ephemeral=True)
-
-    @discord.ui.button(
-        label="Smart Suggestions",
-        style=discord.ButtonStyle.secondary,
-        custom_id="setup:smart_suggestions",
-    )
-    async def _suggestions(
-        self,
-        interaction: discord.Interaction,
-        button: discord.ui.Button,
-    ) -> None:
-        del button
-        if not await self._gate_owner(interaction):
-            return
-        guild = interaction.guild
-        if guild is None or interaction.guild_id is None:
-            await self._deny(
-                interaction,
-                "Smart Suggestions requires a guild context.",
-            )
-            return
-
-        from services.guild_snapshot import collect as collect_snapshot
-        from services.setup_ai_advisor import build_advisor
-        from views.setup.ai_review.main_panel import (
-            AIReviewPanelView,
-            build_ai_review_embed,
-        )
-
-        try:
-            snapshot = await collect_snapshot(guild)
-            advisor = build_advisor()
-            draft = await advisor.suggest(snapshot)
-        except Exception:
-            logger.exception("setup_cog._suggestions: advisor flow failed")
-            await self._deny(
-                interaction,
-                "Smart Suggestions failed. Run **Run Readiness Scan** for "
-                "a deterministic baseline.",
-            )
-            return
-
-        panel = AIReviewPanelView(interaction.user, draft=draft, snapshot=snapshot)
-        await interaction.response.send_message(
-            embed=build_ai_review_embed(draft),
-            view=panel,
-            ephemeral=True,
-        )
-        try:
-            await setup_session.mark_in_progress(
-                interaction.guild_id,
-                step="suggestions",
-            )
-        except Exception:
-            logger.exception("setup_cog._suggestions: mark_in_progress failed")
-
-    @discord.ui.button(
-        label="Choose Preset",
-        style=discord.ButtonStyle.secondary,
-        custom_id="setup:preset",
-    )
-    async def _preset(
-        self,
-        interaction: discord.Interaction,
-        button: discord.ui.Button,
-    ) -> None:
-        del button
-        if not await self._gate_owner(interaction):
-            return
-
-        from views.setup.template_picker import TemplatePickerView, build_picker_embed
-
-        picker = TemplatePickerView(interaction.user)
-        await interaction.response.send_message(
-            embed=build_picker_embed(),
-            view=picker,
-            ephemeral=True,
-        )
-
-    @discord.ui.button(
-        label="View Summary",
-        style=discord.ButtonStyle.secondary,
-        custom_id="setup:summary",
-        row=1,
-    )
-    async def _view_summary(
-        self,
-        interaction: discord.Interaction,
-        button: discord.ui.Button,
-    ) -> None:
-        del button
-        if not await self._gate_admin(interaction):
-            return
-        guild = interaction.guild
-        if guild is None or interaction.guild_id is None:
-            await self._deny(
-                interaction,
-                "View Summary requires a guild context.",
-            )
-            return
-        session = await self._resolve_session(interaction)
-        if session is None or session.setup_status != "complete":
-            await self._deny(
-                interaction,
-                "Setup is not complete yet. Run **Start Setup** to finish "
-                "the wizard before viewing the summary.",
-            )
-            return
-
-        from views.setup.summary import (
-            SummaryView,
-            build_summary_embed,
-            build_summary_snapshot,
-        )
-
-        try:
-            snapshot = await build_summary_snapshot(
-                session=session,
-                guild=guild,
-            )
-        except Exception:
-            logger.exception("setup_cog._view_summary: snapshot build failed")
-            await self._deny(
-                interaction,
-                "Could not build the summary. Try **Run Readiness Scan** "
-                "for a deterministic baseline.",
-            )
-            return
-
-        view = SummaryView(interaction.user, snapshot=snapshot)
-        await interaction.response.send_message(
-            embed=build_summary_embed(snapshot),
-            view=view,
-            ephemeral=True,
-        )
-
-    @discord.ui.button(
-        label="Repost launcher",
-        style=discord.ButtonStyle.secondary,
-        custom_id="setup:repost_launcher",
-        row=1,
-    )
-    async def _repost_launcher(
-        self,
-        interaction: discord.Interaction,
-        button: discord.ui.Button,
-    ) -> None:
-        del button
-        if not await self._gate_admin(interaction):
-            return
-        guild = interaction.guild
-        if guild is None:
-            await self._deny(
-                interaction,
-                "Repost launcher requires a guild context.",
-            )
-            return
-
-        channel, message = await post_launcher(guild)
-        if message is None:
-            await self._deny(
-                interaction,
-                "Could not post the launcher anywhere — bot has no sendable "
-                "channel and the owner has DMs closed.",
-            )
-            return
-
-        try:
-            await setup_session.start_session(
-                guild_id=guild.id,
-                guild_name=guild.name,
-                owner_id=guild.owner_id or 0,
-                setup_channel_id=channel.id if channel is not None else None,
-                setup_message_id=message.id,
-            )
-        except Exception:
-            logger.exception(
-                "setup_cog._repost_launcher: start_session refresh failed",
-            )
-
-        where = f"<#{channel.id}>" if channel is not None else "your DMs"
-        await interaction.response.send_message(
-            f"Launcher reposted in {where}.",
-            ephemeral=True,
-        )
-
-    @discord.ui.button(
-        label="Dismiss",
-        style=discord.ButtonStyle.danger,
-        custom_id="setup:dismiss",
-        row=1,
-    )
-    async def _dismiss(
-        self,
-        interaction: discord.Interaction,
-        button: discord.ui.Button,
-    ) -> None:
-        del button
-        if not await self._gate_owner(interaction):
-            return
-        if interaction.guild_id is None:
-            await self._deny(
-                interaction,
-                "Dismiss requires a guild context.",
-            )
-            return
-        await setup_session.dismiss(interaction.guild_id)
-        await interaction.response.send_message(
-            "Setup dismissed. Use the setup launcher later to resume.",
-            ephemeral=True,
-        )
-
-
-# ---------------------------------------------------------------------------
-# Channel selection — pick the safest place to post the launcher.
-# ---------------------------------------------------------------------------
-
-
-def _bot_can_send_in(channel: discord.TextChannel, me: discord.Member) -> bool:
-    perms = channel.permissions_for(me)
-    return bool(perms.view_channel and perms.send_messages and perms.embed_links)
-
-
-def pick_launcher_channel(guild: discord.Guild) -> discord.TextChannel | None:
-    """Return the safest text channel to post the launcher in.
-
-    Order:
-      1. ``guild.system_channel`` if the bot can send + embed there.
-      2. First channel whose name contains ``admin`` / ``mod`` /
-         ``staff`` that the bot can send in.
-      3. First channel whose name contains ``bot`` that the bot can
-         send in.
-      4. First text channel in the guild the bot can send in.
-      5. ``None`` — caller should DM the owner instead.
-    """
-    me = guild.me
-    if me is None:
-        return None
-
-    system = guild.system_channel
-    if isinstance(system, discord.TextChannel) and _bot_can_send_in(system, me):
-        return system
-
-    keyword_groups: tuple[tuple[str, ...], ...] = (
-        ("admin", "mod", "staff"),
-        ("bot",),
-    )
-    for needles in keyword_groups:
-        for channel in guild.text_channels:
-            name = (channel.name or "").lower()
-            if any(needle in name for needle in needles) and _bot_can_send_in(
-                channel,
-                me,
-            ):
-                return channel
-
-    for channel in guild.text_channels:
-        if _bot_can_send_in(channel, me):
-            return channel
-    return None
-
-
-async def post_launcher(
-    guild: discord.Guild,
-) -> tuple[discord.TextChannel | None, discord.Message | None]:
-    """Pick a channel + post the launcher message.
-
-    Returns ``(channel, message)`` on success, ``(None, None)`` when
-    no channel is sendable and the owner-DM fallback also failed.
-    The caller is responsible for updating ``setup_session`` with the
-    resulting ids.
-    """
-    embed = _build_launcher_embed(None)
-    view = SetupLauncherView()
-
-    channel = pick_launcher_channel(guild)
-    if channel is not None:
-        try:
-            message = await channel.send(embed=embed, view=view)
-            return channel, message
-        except discord.Forbidden:
-            logger.warning(
-                "setup_cog: forbidden when posting launcher in #%s (guild=%d)",
-                channel.name,
-                guild.id,
-            )
-        except discord.HTTPException as exc:
-            logger.warning(
-                "setup_cog: HTTP error posting launcher in #%s (guild=%d): %s",
-                channel.name,
-                guild.id,
-                exc,
-            )
-
-    # Channel fallback: DM the owner.
-    owner = guild.owner
-    if owner is not None:
-        try:
-            message = await owner.send(embed=embed, view=view)
-            logger.info(
-                "setup_cog: DMed launcher to owner %d (guild=%d)",
-                owner.id,
-                guild.id,
-            )
-            return None, message
-        except discord.Forbidden:
-            logger.warning(
-                "setup_cog: cannot DM owner %d for guild=%d (DMs closed)",
-                owner.id,
-                guild.id,
-            )
-        except discord.HTTPException as exc:
-            logger.warning(
-                "setup_cog: HTTP error DMing owner for guild=%d: %s",
-                guild.id,
-                exc,
-            )
-
-    return None, None
+logger = logging.getLogger("bot.cogs.setup")
 
 
 # ---------------------------------------------------------------------------
@@ -641,14 +121,9 @@ class SetupCog(commands.Cog):
     """Setup-wizard launcher.
 
     Listens for ``on_guild_join`` and ``on_ready`` and keeps the
-    launcher message in sync with the ``setup_session`` row:
-
-    * ``on_guild_join`` — fresh launcher posted, session row upserted
-      in ``pending``.
-    * ``on_ready`` — for every guild with a recorded launcher
-      message, the message is edited in place with a status-aware
-      embed + view (e.g. ``Start Setup`` becomes ``Resume Setup``
-      when the row is mid-flow).
+    launcher message in sync with the ``setup_session`` row.
+    Exposes ``!setup`` and ``/setup`` as direct entry / recovery
+    commands; both route through ``_resolve_hub_entry``.
 
     The base ``SetupLauncherView`` is registered at ``cog_load`` so
     discord.py can dispatch interactions even before the resume
@@ -659,10 +134,6 @@ class SetupCog(commands.Cog):
         self.bot = bot
 
     async def cog_load(self) -> None:
-        # Register the persistent view so discord.py can match
-        # interactions to it after restart. The base instance has
-        # the default labels; ``_resume_launchers`` later edits
-        # individual messages with status-aware label sets.
         self.bot.add_view(SetupLauncherView())
 
     @commands.command(name="setup")
@@ -672,8 +143,7 @@ class SetupCog(commands.Cog):
 
         Owners and delegated setup admins get the hub; administrators
         without delegation get a read-only readiness embed; everyone
-        else is denied. Recovery path when the launcher message has
-        been deleted.
+        else is denied.
         """
         guild = ctx.guild
         member = ctx.author
@@ -712,12 +182,9 @@ class SetupCog(commands.Cog):
     @app_commands.checks.has_permissions(administrator=True)
     @app_commands.guild_only()
     async def setup_slash(self, interaction: discord.Interaction) -> None:
-        """Slash front door for the setup wizard — ephemeral.
+        """Ephemeral slash front door for the setup wizard.
 
-        Mirrors the access ladder of the prefix command: owner /
-        delegated admin → hub; administrator → readiness; otherwise
-        denied (the ``has_permissions`` decorator will already have
-        short-circuited the deny case for non-admins).
+        Mirrors the access ladder of the prefix command.
         """
         guild = interaction.guild
         member = interaction.user
@@ -790,17 +257,7 @@ class SetupCog(commands.Cog):
             )
 
     async def _resume_launchers(self) -> None:
-        """Walk ``self.bot.guilds`` and refresh each launcher message.
-
-        For every guild whose ``setup_session`` row carries both a
-        ``setup_channel_id`` and a ``setup_message_id``, the message
-        is edited in place with the right status-aware label set.
-        Stale channel / message ids are detected via ``Forbidden`` /
-        ``NotFound`` / ``HTTPException`` and the corresponding row
-        fields are NOT cleared here (Track 4 PR 9 keeps the cog
-        non-destructive; an explicit teardown is the only path that
-        removes session state).
-        """
+        """Refresh every guild's launcher message in place; isolate failures."""
         for guild in list(self.bot.guilds):
             try:
                 await self._resume_one_launcher(guild)
@@ -824,13 +281,9 @@ class SetupCog(commands.Cog):
             return False
 
         channel = guild.get_channel(session.setup_channel_id)
-        if not isinstance(
-            channel,
-            (discord.TextChannel, discord.Thread),
-        ):
+        if not isinstance(channel, (discord.TextChannel, discord.Thread)):
             logger.debug(
-                "setup_cog.on_ready: channel %s not in guild %d cache; "
-                "skipping resume.",
+                "setup_cog.on_ready: channel %s not in guild %d cache.",
                 session.setup_channel_id,
                 guild.id,
             )
@@ -840,16 +293,14 @@ class SetupCog(commands.Cog):
             message = await channel.fetch_message(session.setup_message_id)
         except discord.NotFound:
             logger.info(
-                "setup_cog.on_ready: launcher message %s in guild %d is "
-                "gone; skipping resume (next on_guild_join will re-post).",
+                "setup_cog.on_ready: launcher message %s in guild %d is gone.",
                 session.setup_message_id,
                 guild.id,
             )
             return False
         except discord.Forbidden:
             logger.warning(
-                "setup_cog.on_ready: cannot fetch launcher message in "
-                "#%s (guild=%d) — missing read_message_history.",
+                "setup_cog.on_ready: cannot fetch launcher in #%s (guild=%d).",
                 channel.name,
                 guild.id,
             )

--- a/disbot/cogs/setup_cog.py
+++ b/disbot/cogs/setup_cog.py
@@ -197,13 +197,18 @@ class SetupLauncherView(discord.ui.View):
 
         session = await self._resolve_session(interaction)
         try:
-            pending_ops = await setup_draft.count(interaction.guild_id)
+            draft_ops = await setup_draft.list_ops(interaction.guild_id)
         except Exception:
-            logger.exception("setup_cog._start: setup_draft.count failed")
-            pending_ops = None
+            logger.exception("setup_cog._start: setup_draft.list_ops failed")
+            draft_ops = []
+        pending_ops = len(draft_ops)
         hub = SetupHubView(interaction.user, session=session)
         await interaction.response.send_message(
-            embed=build_hub_embed(session, pending_ops=pending_ops),
+            embed=build_hub_embed(
+                session,
+                pending_ops=pending_ops,
+                draft_ops=draft_ops,
+            ),
             view=hub,
             ephemeral=True,
         )
@@ -604,14 +609,18 @@ async def _resolve_hub_entry(
         from views.setup.hub import SetupHubView, build_hub_embed
 
         try:
-            pending_ops = await setup_draft.count(guild.id)
+            draft_ops = await setup_draft.list_ops(guild.id)
         except Exception:
             logger.exception(
-                "setup_cog._resolve_hub_entry: setup_draft.count failed",
+                "setup_cog._resolve_hub_entry: setup_draft.list_ops failed",
             )
-            pending_ops = None
+            draft_ops = []
         hub = SetupHubView(member, session=session)
-        embed = build_hub_embed(session, pending_ops=pending_ops)
+        embed = build_hub_embed(
+            session,
+            pending_ops=len(draft_ops),
+            draft_ops=draft_ops,
+        )
         return embed, hub, "hub"
 
     if setup_access.is_setup_admin(member, session):

--- a/disbot/cogs/setup_cog.py
+++ b/disbot/cogs/setup_cog.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import logging
 
 import discord
+from discord import app_commands
 from discord.ext import commands
 
 from services import setup_access, setup_session
@@ -372,6 +373,56 @@ class SetupLauncherView(discord.ui.View):
         )
 
     @discord.ui.button(
+        label="Repost launcher",
+        style=discord.ButtonStyle.secondary,
+        custom_id="setup:repost_launcher",
+        row=1,
+    )
+    async def _repost_launcher(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        if not await self._gate_admin(interaction):
+            return
+        guild = interaction.guild
+        if guild is None:
+            await self._deny(
+                interaction,
+                "Repost launcher requires a guild context.",
+            )
+            return
+
+        channel, message = await post_launcher(guild)
+        if message is None:
+            await self._deny(
+                interaction,
+                "Could not post the launcher anywhere — bot has no sendable "
+                "channel and the owner has DMs closed.",
+            )
+            return
+
+        try:
+            await setup_session.start_session(
+                guild_id=guild.id,
+                guild_name=guild.name,
+                owner_id=guild.owner_id or 0,
+                setup_channel_id=channel.id if channel is not None else None,
+                setup_message_id=message.id,
+            )
+        except Exception:
+            logger.exception(
+                "setup_cog._repost_launcher: start_session refresh failed",
+            )
+
+        where = f"<#{channel.id}>" if channel is not None else "your DMs"
+        await interaction.response.send_message(
+            f"Launcher reposted in {where}.",
+            ephemeral=True,
+        )
+
+    @discord.ui.button(
         label="Dismiss",
         style=discord.ButtonStyle.danger,
         custom_id="setup:dismiss",
@@ -507,6 +558,72 @@ async def post_launcher(
 
 
 # ---------------------------------------------------------------------------
+# Shared hub-entry helper for direct commands (!setup / /setup).
+# ---------------------------------------------------------------------------
+
+
+async def _resolve_hub_entry(
+    member: discord.Member,
+    guild: discord.Guild,
+) -> (
+    tuple[discord.Embed, discord.ui.View, str]
+    | tuple[discord.Embed, None, str]
+    | tuple[None, None, str]
+):
+    """Resolve the hub-entry response for ``member`` in ``guild``.
+
+    Returns one of three shapes:
+
+    * ``(hub_embed, hub_view, "hub")`` — member can apply setup; full
+      hub is rendered. Caller marks the session in progress.
+    * ``(readiness_embed, None, "readiness")`` — member is a setup
+      admin without apply authority; render the deterministic
+      readiness embed instead.
+    * ``(None, None, "denied")`` — member is not a setup admin.
+
+    The helper performs no Discord send; the calling command decides
+    whether to reply ephemerally (slash) or to ``ctx.send`` (prefix).
+    """
+    session = await setup_session.resume_session(guild.id)
+
+    if setup_access.can_apply_setup(member, session):
+        if session is None:
+            try:
+                session = await setup_session.start_session(
+                    guild_id=guild.id,
+                    guild_name=guild.name,
+                    owner_id=guild.owner_id or 0,
+                )
+            except Exception:
+                logger.exception(
+                    "setup_cog._resolve_hub_entry: start_session failed",
+                )
+                session = None
+
+        from services import setup_draft
+        from views.setup.hub import SetupHubView, build_hub_embed
+
+        try:
+            pending_ops = await setup_draft.count(guild.id)
+        except Exception:
+            logger.exception(
+                "setup_cog._resolve_hub_entry: setup_draft.count failed",
+            )
+            pending_ops = None
+        hub = SetupHubView(member, session=session)
+        embed = build_hub_embed(session, pending_ops=pending_ops)
+        return embed, hub, "hub"
+
+    if setup_access.is_setup_admin(member, session):
+        from cogs.diagnostic._platform_embeds import build_setup_readiness_embed
+
+        embed = await build_setup_readiness_embed(guild.id, guild=guild)
+        return embed, None, "readiness"
+
+    return None, None, "denied"
+
+
+# ---------------------------------------------------------------------------
 # Cog
 # ---------------------------------------------------------------------------
 
@@ -538,6 +655,103 @@ class SetupCog(commands.Cog):
         # the default labels; ``_resume_launchers`` later edits
         # individual messages with status-aware label sets.
         self.bot.add_view(SetupLauncherView())
+
+    @commands.command(name="setup")
+    @commands.guild_only()
+    async def setup_cmd(self, ctx: commands.Context) -> None:
+        """Open or resume the setup wizard from any channel.
+
+        Owners and delegated setup admins get the hub; administrators
+        without delegation get a read-only readiness embed; everyone
+        else is denied. Recovery path when the launcher message has
+        been deleted.
+        """
+        guild = ctx.guild
+        member = ctx.author
+        if guild is None or not isinstance(member, discord.Member):
+            await ctx.send("Run `!setup` from inside the server.")
+            return
+
+        embed, view, mode = await _resolve_hub_entry(member, guild)
+        if mode == "denied":
+            await ctx.send(
+                "Only the server owner, an administrator, or a delegated "
+                "setup admin can open the setup wizard.",
+            )
+            return
+        if mode == "readiness":
+            if embed is None:
+                await ctx.send("Could not build the readiness scan.")
+                return
+            await ctx.send(embed=embed)
+            return
+
+        if embed is None or view is None:
+            await ctx.send("Could not build the setup hub. See logs.")
+            return
+        await ctx.send(embed=embed, view=view)
+        try:
+            await setup_session.mark_in_progress(guild.id, step="hub")
+        except Exception:
+            logger.exception("setup_cog.setup_cmd: mark_in_progress failed")
+
+    @app_commands.command(
+        name="setup",
+        description="Open the setup wizard (owner, delegated admin, or admin).",
+    )
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.guild_only()
+    async def setup_slash(self, interaction: discord.Interaction) -> None:
+        """Slash front door for the setup wizard — ephemeral.
+
+        Mirrors the access ladder of the prefix command: owner /
+        delegated admin → hub; administrator → readiness; otherwise
+        denied (the ``has_permissions`` decorator will already have
+        short-circuited the deny case for non-admins).
+        """
+        guild = interaction.guild
+        member = interaction.user
+        if guild is None or not isinstance(member, discord.Member):
+            await interaction.response.send_message(
+                "Use `/setup` from inside the server.",
+                ephemeral=True,
+            )
+            return
+
+        embed, view, mode = await _resolve_hub_entry(member, guild)
+        if mode == "denied":
+            await interaction.response.send_message(
+                "Only the server owner, an administrator, or a delegated "
+                "setup admin can open the setup wizard.",
+                ephemeral=True,
+            )
+            return
+        if mode == "readiness":
+            if embed is None:
+                await interaction.response.send_message(
+                    "Could not build the readiness scan.",
+                    ephemeral=True,
+                )
+                return
+            await interaction.response.send_message(embed=embed, ephemeral=True)
+            return
+
+        if embed is None or view is None:
+            await interaction.response.send_message(
+                "Could not build the setup hub. See logs.",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.send_message(
+            embed=embed,
+            view=view,
+            ephemeral=True,
+        )
+        try:
+            await setup_session.mark_in_progress(guild.id, step="hub")
+        except Exception:
+            logger.exception("setup_cog.setup_slash: mark_in_progress failed")
 
     @commands.Cog.listener()
     async def on_guild_join(self, guild: discord.Guild) -> None:

--- a/disbot/migrations/037_setup_session_skipped_sections.sql
+++ b/disbot/migrations/037_setup_session_skipped_sections.sql
@@ -1,0 +1,22 @@
+-- Migration 037: setup_session.skipped_sections column.
+--
+-- Adds a TEXT[] column to setup_session so the wizard can remember
+-- which sections the operator explicitly skipped during a run.
+-- Skipped sections render with a distinct status badge on the hub
+-- and tell readiness/summary to omit "needs attention" hints for
+-- those slugs.
+--
+-- Stored as an unordered set semantically (no PG SET type, so TEXT[]
+-- with COALESCE on read); empty array means no sections skipped yet.
+-- Section slugs are stable per setup_sections.REGISTRY validation
+-- (lowercase letters / digits / underscores, max 64 chars).
+--
+-- Rollback
+-- --------
+-- ``ALTER TABLE setup_session DROP COLUMN skipped_sections``
+-- removes the column. No downstream FK depends on the contents.
+--
+-- Forward-only and idempotent.
+
+ALTER TABLE setup_session
+    ADD COLUMN IF NOT EXISTS skipped_sections TEXT[] NOT NULL DEFAULT '{}';

--- a/disbot/migrations/038_setup_session_depth.sql
+++ b/disbot/migrations/038_setup_session_depth.sql
@@ -1,0 +1,26 @@
+-- Migration 038: setup_session.depth column.
+--
+-- Adds a nullable ``depth`` column to ``setup_session`` that records
+-- the operator's choice of wizard depth (quick / standard /
+-- advanced). The hub uses the value to filter which registered
+-- :class:`SetupSection`s appear; ``NULL`` means "operator has not
+-- yet chosen", which signals the hub to show the depth picker
+-- before rendering section buttons.
+--
+-- Existing rows keep ``depth IS NULL`` so a re-run of the wizard
+-- will surface the picker once and persist the choice. New guilds
+-- get the same treatment on first launcher open.
+--
+-- Rollback
+-- --------
+-- ``ALTER TABLE setup_session DROP COLUMN depth`` removes the
+-- column. The hub falls back to "all sections" when the column is
+-- absent (the SELECT in utils/db/setup_session.py SELECTs the
+-- column explicitly, so removing it requires reverting that change
+-- as well).
+--
+-- Forward-only and idempotent.
+
+ALTER TABLE setup_session
+    ADD COLUMN IF NOT EXISTS depth TEXT
+        CHECK (depth IS NULL OR depth IN ('quick', 'standard', 'advanced'));

--- a/disbot/services/automation_templates.py
+++ b/disbot/services/automation_templates.py
@@ -627,6 +627,43 @@ _SERVER_PRESETS: tuple[ServerPreset, ...] = (
         ),
     ),
     ServerPreset(
+        slug="existing-safe",
+        display_name="Existing-server safe",
+        description=(
+            "Binds likely-existing channels for rules + moderation log. "
+            "Never creates channels, roles, or automation rules — safe to "
+            "apply to a server that already has its own structure."
+        ),
+        suggested_log_channels=("bot-mod-log",),
+        suggested_command_channels=("bot-commands",),
+        operations=(
+            PresetOperation(
+                kind="bind_channel",
+                description="Bind an existing rules channel.",
+                payload={
+                    "subsystem": "logging",
+                    "binding_name": "rules_channel",
+                },
+            ),
+            PresetOperation(
+                kind="bind_channel",
+                description="Bind an existing moderation log channel.",
+                payload={
+                    "subsystem": "logging",
+                    "binding_name": "mod_channel",
+                },
+            ),
+            PresetOperation(
+                kind="bind_channel",
+                description="Bind an existing bot-commands channel.",
+                payload={
+                    "subsystem": "moderation",
+                    "binding_name": "bot_command_channel",
+                },
+            ),
+        ),
+    ),
+    ServerPreset(
         slug="custom",
         display_name="Custom",
         description=(

--- a/disbot/services/setup_channel.py
+++ b/disbot/services/setup_channel.py
@@ -1,0 +1,154 @@
+"""Auto-managed private setup channel.
+
+When SuperBot joins a guild and has Manage Channels permission, it
+creates a private ``#superbot-setup`` channel visible only to the bot
+itself and the guild owner. The launcher cog posts the setup launcher
+in that channel and @mentions the owner so they discover the wizard
+immediately.
+
+This module owns the idempotent "ensure" operation. The actual Discord
+channel creation routes through
+:func:`core.runtime.guild_resources.ensure_channel` — the canonical
+infrastructure primitive on the S4.5 no-silent-auto-create allowlist.
+
+Constraints preserved:
+
+* No ``guild.create_text_channel`` call here — that lives in
+  ``guild_resources.ensure_channel``.
+* No DB writes here. The caller updates ``setup_session`` with the
+  new channel id via the standard ``start_session`` upsert.
+* No required permissions raise; missing perms / HTTP failures
+  surface as ``(None, False)`` and the caller falls back to
+  ``post_launcher`` (which already DMs the owner if no channel is
+  sendable).
+
+The channel name is namespaced so it does not collide with
+operator-named "setup" channels.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+from core.runtime.guild_resources import ensure_channel
+
+logger = logging.getLogger("bot.services.setup_channel")
+
+#: Channel name for the bot-managed setup workspace. Namespaced so
+#: operator-created "setup" channels are not accidentally adopted.
+SETUP_CHANNEL_NAME = "superbot-setup"
+
+
+def _private_overwrites(
+    guild: discord.Guild,
+) -> dict[discord.Member | discord.Role, discord.PermissionOverwrite]:
+    """Build the permission overwrite set for the private setup channel.
+
+    Visible to the bot and the guild owner; hidden from @everyone.
+    Administrator-tier members keep their global view permission via
+    Discord's own permission resolver — we only restrict ``@everyone``.
+    """
+    overwrites: dict[discord.Member | discord.Role, discord.PermissionOverwrite] = {
+        guild.default_role: discord.PermissionOverwrite(view_channel=False),
+    }
+    if guild.me is not None:
+        overwrites[guild.me] = discord.PermissionOverwrite(
+            view_channel=True,
+            send_messages=True,
+            embed_links=True,
+            read_message_history=True,
+            manage_messages=True,
+        )
+    if guild.owner is not None:
+        overwrites[guild.owner] = discord.PermissionOverwrite(
+            view_channel=True,
+            send_messages=True,
+            read_message_history=True,
+        )
+    return overwrites
+
+
+def _bot_can_manage_channels(guild: discord.Guild) -> bool:
+    """True iff the bot member holds Manage Channels in this guild."""
+    me = guild.me
+    if me is None:
+        return False
+    return bool(getattr(me.guild_permissions, "manage_channels", False))
+
+
+async def ensure_setup_channel(
+    guild: discord.Guild,
+    *,
+    existing_channel_id: int | None = None,
+) -> tuple[discord.TextChannel | None, bool]:
+    """Return the private setup channel for ``guild``, creating if absent.
+
+    Idempotent. The function tries the following, in order:
+
+    1. If ``existing_channel_id`` is given and the channel is still in
+       the guild cache, return it unchanged.
+    2. Look up by canonical name (``superbot-setup``) — covers the
+       restart case where the cog lost track of the channel id.
+    3. Create the channel with private overwrites via
+       :func:`core.runtime.guild_resources.ensure_channel`. Requires
+       the bot to hold Manage Channels.
+
+    Returns:
+        ``(channel, was_just_created)`` where ``channel`` is ``None``
+        when the bot lacks permission or Discord refused the create.
+        Callers should fall back to the existing ``post_launcher``
+        path in that case so setup still gets a launcher somewhere.
+    """
+    if existing_channel_id is not None:
+        existing = guild.get_channel(existing_channel_id)
+        if isinstance(existing, discord.TextChannel):
+            return existing, False
+
+    if not _bot_can_manage_channels(guild):
+        logger.info(
+            "setup_channel: bot lacks Manage Channels in guild %d; falling back",
+            guild.id,
+        )
+        return None, False
+
+    try:
+        channel = await ensure_channel(
+            guild,
+            SETUP_CHANNEL_NAME,
+            kind="text",
+            category=None,
+            overwrites=_private_overwrites(guild),
+        )
+    except discord.Forbidden as exc:
+        logger.warning(
+            "setup_channel: forbidden creating #%s in guild %d: %s",
+            SETUP_CHANNEL_NAME,
+            guild.id,
+            exc,
+        )
+        return None, False
+    except discord.HTTPException as exc:
+        logger.warning(
+            "setup_channel: HTTP error creating #%s in guild %d: %s",
+            SETUP_CHANNEL_NAME,
+            guild.id,
+            exc,
+        )
+        return None, False
+
+    if not isinstance(channel, discord.TextChannel):
+        logger.warning(
+            "setup_channel: guild_resources returned non-text channel for guild %d",
+            guild.id,
+        )
+        return None, False
+
+    return channel, True
+
+
+__all__ = [
+    "SETUP_CHANNEL_NAME",
+    "ensure_setup_channel",
+]

--- a/disbot/services/setup_progress.py
+++ b/disbot/services/setup_progress.py
@@ -1,0 +1,195 @@
+"""Setup wizard progress + per-section status computation.
+
+Pure, read-only helpers that decide which status badge each section in
+the registry should render on the hub.  No DB writes and no Discord
+I/O — callers pass in the resolved :class:`SetupSession` snapshot and
+the list of staged :class:`SetupOperation` rows from
+:mod:`services.setup_draft`.
+
+Status vocabulary
+-----------------
+
+``NOT_STARTED``
+    No staged draft ops match the section's :attr:`SetupSection.op_kinds`
+    AND the section is not in :attr:`SetupSession.skipped_sections` AND
+    the session is not yet ``complete``.
+
+``CUSTOMIZED``
+    At least one draft op matches the section's :attr:`SetupSection.op_kinds`
+    AND those ops did not come from ``setup_ux:recommended`` staging.
+    (PR 3 introduces the recommended source; until then any matched op
+    is treated as customised.)
+
+``RECOMMENDED``
+    Every matching draft op was staged with metadata
+    ``source == "setup_ux:recommended"``.  Distinguishes the "I clicked
+    Apply Recommended" path from the "I customised this" path.
+
+``SKIPPED``
+    The slug appears in :attr:`SetupSession.skipped_sections`, regardless
+    of whether ops are also staged.  Skipping is an explicit operator
+    declaration; the badge wins over staging state.
+
+``APPLIED``
+    The session is ``complete`` and either ops have already been applied
+    OR the section is read-only.  Final Review clears the draft, so
+    "complete + no matching draft" is the post-apply state.
+
+``NEEDS_ATTENTION``
+    Reserved for future use (PR 4+ when readiness findings can flag a
+    section as warranting re-visit).  Currently never returned by
+    :func:`compute_section_status`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from services.setup_operations import SetupOperation
+    from services.setup_sections import SetupSection
+    from services.setup_session import SetupSession
+
+
+class SectionStatus(str, Enum):
+    """One-of status for a setup section relative to the current session.
+
+    String-valued so it can be JSON-serialised, compared with literals,
+    and used directly in embed text via :attr:`SectionStatus.value`.
+    """
+
+    NOT_STARTED = "not_started"
+    RECOMMENDED = "recommended"
+    CUSTOMIZED = "customized"
+    SKIPPED = "skipped"
+    NEEDS_ATTENTION = "needs_attention"
+    APPLIED = "applied"
+
+
+@dataclass(frozen=True)
+class SectionProgress:
+    """Per-section progress snapshot rendered by the hub."""
+
+    slug: str
+    status: SectionStatus
+    pending_ops: int
+
+
+_BADGE_BY_STATUS: dict[SectionStatus, str] = {
+    SectionStatus.NOT_STARTED: "⬜",
+    SectionStatus.RECOMMENDED: "✅",
+    SectionStatus.CUSTOMIZED: "🟡",
+    SectionStatus.SKIPPED: "⚠️",
+    SectionStatus.NEEDS_ATTENTION: "❗",
+    SectionStatus.APPLIED: "✅",
+}
+
+
+def badge_for(status: SectionStatus) -> str:
+    """Return the emoji glyph shown next to a section label on the hub."""
+    return _BADGE_BY_STATUS.get(status, "⬜")
+
+
+_RECOMMENDED_SOURCE = "setup_ux:recommended"
+
+
+def _matches_section(op: SetupOperation, section: SetupSection) -> bool:
+    """True iff ``op`` belongs to ``section`` per its declared op_kinds.
+
+    Read-only sections (empty ``op_kinds``) never match a draft op, so
+    they fall through to NOT_STARTED / APPLIED purely based on session
+    state.
+    """
+    if not section.op_kinds:
+        return False
+    return op.kind in section.op_kinds
+
+
+def compute_section_status(
+    section: SetupSection,
+    *,
+    session: SetupSession | None,
+    draft_ops: Iterable[SetupOperation],
+) -> SectionProgress:
+    """Compute the status badge for ``section`` in the current session.
+
+    The function is deterministic and side-effect-free; ``draft_ops``
+    is iterated once.
+
+    Decision order (first match wins):
+
+    1. ``SKIPPED`` if the section slug is in
+       :attr:`SetupSession.skipped_sections`.
+    2. ``APPLIED`` if the session is ``complete``.
+    3. ``RECOMMENDED`` if every matching draft op has
+       ``metadata.source == "setup_ux:recommended"``.
+    4. ``CUSTOMIZED`` if any matching draft op exists.
+    5. ``NOT_STARTED`` otherwise.
+    """
+    if session is not None and section.slug in session.skipped_sections:
+        return SectionProgress(
+            slug=section.slug,
+            status=SectionStatus.SKIPPED,
+            pending_ops=0,
+        )
+
+    matching = [op for op in draft_ops if _matches_section(op, section)]
+    pending = len(matching)
+
+    if session is not None and session.setup_status == "complete":
+        return SectionProgress(
+            slug=section.slug,
+            status=SectionStatus.APPLIED,
+            pending_ops=pending,
+        )
+
+    if not matching:
+        return SectionProgress(
+            slug=section.slug,
+            status=SectionStatus.NOT_STARTED,
+            pending_ops=0,
+        )
+
+    sources = {
+        (op.metadata or {}).get("source", "") if op.metadata else "" for op in matching
+    }
+    if sources == {_RECOMMENDED_SOURCE}:
+        return SectionProgress(
+            slug=section.slug,
+            status=SectionStatus.RECOMMENDED,
+            pending_ops=pending,
+        )
+    return SectionProgress(
+        slug=section.slug,
+        status=SectionStatus.CUSTOMIZED,
+        pending_ops=pending,
+    )
+
+
+def compute_all(
+    sections: Iterable[SetupSection],
+    *,
+    session: SetupSession | None,
+    draft_ops: Iterable[SetupOperation],
+) -> list[SectionProgress]:
+    """Compute :class:`SectionProgress` for every section in ``sections``.
+
+    The draft op iterable is materialised once and reused, so passing a
+    generator is safe.
+    """
+    op_list = list(draft_ops)
+    return [
+        compute_section_status(s, session=session, draft_ops=op_list) for s in sections
+    ]
+
+
+__all__ = [
+    "SectionProgress",
+    "SectionStatus",
+    "badge_for",
+    "compute_all",
+    "compute_section_status",
+]

--- a/disbot/services/setup_sections.py
+++ b/disbot/services/setup_sections.py
@@ -69,6 +69,11 @@ class SetupSection:
             what happens if this section is skipped.  Rendered on the
             section card (PR 3) and surfaced by the hub embed.  Empty
             string means "no special skip impact documented yet".
+        depths: Wizard depths in which this section appears.  The hub
+            filters its button layout by the session's depth choice.
+            Default is all three depths so unmigrated sections remain
+            visible everywhere; sections opt into a narrower scope
+            (e.g. quick-only or advanced-only) at registration.
     """
 
     slug: str
@@ -80,6 +85,7 @@ class SetupSection:
     step: str | None = None
     op_kinds: frozenset[str] = frozenset()
     description_if_skipped: str = ""
+    depths: frozenset[str] = frozenset({"quick", "standard", "advanced"})
 
     @property
     def session_step(self) -> str:
@@ -122,6 +128,18 @@ class SetupSectionRegistry:
             self._sections.values(),
             key=lambda s: (s.order, s.slug),
         )
+
+    def for_depth(self, depth: str | None) -> list[SetupSection]:
+        """Return registered sections that participate in ``depth``.
+
+        ``depth`` ∈ ``{"quick", "standard", "advanced"}``.  Passing
+        ``None`` (no choice persisted yet) returns every section so
+        the hub still works in legacy / pre-picker code paths.
+        Sorted by ``(order, slug)`` to match :meth:`all`.
+        """
+        if depth is None:
+            return self.all()
+        return [s for s in self.all() if depth in s.depths]
 
     def __contains__(self, slug: object) -> bool:
         return isinstance(slug, str) and slug in self._sections

--- a/disbot/services/setup_sections.py
+++ b/disbot/services/setup_sections.py
@@ -59,6 +59,16 @@ class SetupSection:
         step: Optional override for the `setup_session.current_step`
             marker written when the section is invoked.  Defaults to
             `slug`.
+        op_kinds: SetupOperation kind strings this section can stage
+            (e.g. ``frozenset({"bind_channel"})`` for `channels`).
+            Used by `services.setup_progress.compute_section_status`
+            to decide which draft rows belong to this section.  Empty
+            for read-only sections (`server_scan`, `readiness`,
+            `final_review`).
+        description_if_skipped: Operator-facing one-liner that explains
+            what happens if this section is skipped.  Rendered on the
+            section card (PR 3) and surfaced by the hub embed.  Empty
+            string means "no special skip impact documented yet".
     """
 
     slug: str
@@ -68,6 +78,8 @@ class SetupSection:
     emoji: str | None = None
     order: int = 100
     step: str | None = None
+    op_kinds: frozenset[str] = frozenset()
+    description_if_skipped: str = ""
 
     @property
     def session_step(self) -> str:

--- a/disbot/services/setup_session.py
+++ b/disbot/services/setup_session.py
@@ -41,6 +41,7 @@ class SetupSession:
     last_readiness_score: int | None
     current_step: str | None
     delegated_admins: tuple[int, ...]
+    skipped_sections: frozenset[str] = frozenset()
 
     @classmethod
     def from_row(cls, row: dict[str, Any]) -> SetupSession:
@@ -54,6 +55,7 @@ class SetupSession:
             last_readiness_score=row.get("last_readiness_score"),
             current_step=row.get("current_step"),
             delegated_admins=tuple(row.get("delegated_admins") or ()),
+            skipped_sections=frozenset(row.get("skipped_sections") or ()),
         )
 
 
@@ -105,8 +107,8 @@ async def mark_in_progress(guild_id: int, *, step: str | None = None) -> None:
 
 
 async def mark_complete(guild_id: int) -> None:
-    """Move the row to ``complete``; clears any in-flight step token
-    and drops any pending draft operations.
+    """Move the row to ``complete``; clears any in-flight step token,
+    drops pending draft operations, and clears the skipped-section set.
 
     Final Review calls this after a successful apply, so the draft
     is empty by that point.  Clearing here is defence-in-depth — if
@@ -115,12 +117,13 @@ async def mark_complete(guild_id: int) -> None:
     """
     await db.set_status(guild_id, "complete")
     await db.set_step(guild_id, None)
+    await db.clear_skipped_sections(guild_id)
     await _clear_draft(guild_id)
 
 
 async def dismiss(guild_id: int) -> None:
-    """Move the row to ``dismissed``; clears any in-flight step token
-    and drops any pending draft operations.
+    """Move the row to ``dismissed``; clears any in-flight step token,
+    drops pending draft operations, and clears the skipped-section set.
 
     Note: this only flips the launcher state and discards staged
     drafts.  It does **not** delete the guild's already-applied
@@ -129,6 +132,7 @@ async def dismiss(guild_id: int) -> None:
     """
     await db.set_status(guild_id, "dismissed")
     await db.set_step(guild_id, None)
+    await db.clear_skipped_sections(guild_id)
     await _clear_draft(guild_id)
 
 
@@ -152,6 +156,20 @@ async def _clear_draft(guild_id: int) -> None:
 async def record_readiness_score(guild_id: int, score: int | None) -> None:
     """Cache the latest readiness % so drift can be detected on re-runs."""
     await db.set_readiness_score(guild_id, score)
+
+
+async def mark_section_skipped(guild_id: int, slug: str) -> None:
+    """Record that ``slug`` was explicitly skipped during the current run.
+
+    Idempotent — the underlying primitive uses set semantics, so calling
+    twice with the same slug leaves the set unchanged.
+    """
+    await db.add_skipped_section(guild_id, slug)
+
+
+async def unmark_section_skipped(guild_id: int, slug: str) -> None:
+    """Drop ``slug`` from the skipped-sections set."""
+    await db.remove_skipped_section(guild_id, slug)
 
 
 # ---------------------------------------------------------------------------
@@ -256,7 +274,9 @@ __all__ = [
     "dismiss",
     "mark_complete",
     "mark_in_progress",
+    "mark_section_skipped",
     "record_readiness_score",
     "resume_session",
     "start_session",
+    "unmark_section_skipped",
 ]

--- a/disbot/services/setup_session.py
+++ b/disbot/services/setup_session.py
@@ -42,6 +42,7 @@ class SetupSession:
     current_step: str | None
     delegated_admins: tuple[int, ...]
     skipped_sections: frozenset[str] = frozenset()
+    depth: str | None = None
 
     @classmethod
     def from_row(cls, row: dict[str, Any]) -> SetupSession:
@@ -56,6 +57,7 @@ class SetupSession:
             current_step=row.get("current_step"),
             delegated_admins=tuple(row.get("delegated_admins") or ()),
             skipped_sections=frozenset(row.get("skipped_sections") or ()),
+            depth=row.get("depth"),
         )
 
 
@@ -172,6 +174,15 @@ async def unmark_section_skipped(guild_id: int, slug: str) -> None:
     await db.remove_skipped_section(guild_id, slug)
 
 
+async def set_depth(guild_id: int, depth: str | None) -> None:
+    """Persist the operator's depth choice (quick / standard / advanced).
+
+    Passing ``None`` clears the choice, which makes the hub re-prompt
+    on the next open.
+    """
+    await db.set_depth(guild_id, depth)
+
+
 # ---------------------------------------------------------------------------
 # Drift detection (Phase 9i / Track 8 PR 24)
 # ---------------------------------------------------------------------------
@@ -277,6 +288,7 @@ __all__ = [
     "mark_section_skipped",
     "record_readiness_score",
     "resume_session",
+    "set_depth",
     "start_session",
     "unmark_section_skipped",
 ]

--- a/disbot/utils/db/setup_session.py
+++ b/disbot/utils/db/setup_session.py
@@ -34,7 +34,7 @@ async def get(guild_id: int) -> dict[str, Any] | None:
         """
         SELECT guild_id, guild_name, owner_id, joined_at, setup_status,
                setup_channel_id, setup_message_id, last_readiness_score,
-               current_step, delegated_admins, skipped_sections,
+               current_step, delegated_admins, skipped_sections, depth,
                created_at, updated_at
         FROM setup_session
         WHERE guild_id = $1
@@ -222,7 +222,34 @@ async def clear_skipped_sections(guild_id: int) -> None:
     )
 
 
+KNOWN_DEPTHS: frozenset[str] = frozenset({"quick", "standard", "advanced"})
+
+
+async def set_depth(guild_id: int, depth: str | None) -> None:
+    """Persist the operator's depth choice (or ``None`` to unset).
+
+    Accepts ``"quick"``, ``"standard"``, ``"advanced"``, or ``None``;
+    other values raise ``ValueError``. The CHECK constraint in
+    migration 038 enforces the same set at the DB layer.
+    """
+    if depth is not None and depth not in KNOWN_DEPTHS:
+        raise ValueError(
+            f"depth must be one of {sorted(KNOWN_DEPTHS)} or None, got {depth!r}",
+        )
+    await pool.get().execute(
+        """
+        UPDATE setup_session
+           SET depth = $2,
+               updated_at = NOW()
+         WHERE guild_id = $1
+        """,
+        guild_id,
+        depth,
+    )
+
+
 __all__ = [
+    "KNOWN_DEPTHS",
     "KNOWN_STATUSES",
     "add_delegated_admin",
     "add_skipped_section",
@@ -231,6 +258,7 @@ __all__ = [
     "get",
     "remove_delegated_admin",
     "remove_skipped_section",
+    "set_depth",
     "set_readiness_score",
     "set_status",
     "set_step",

--- a/disbot/utils/db/setup_session.py
+++ b/disbot/utils/db/setup_session.py
@@ -34,7 +34,8 @@ async def get(guild_id: int) -> dict[str, Any] | None:
         """
         SELECT guild_id, guild_name, owner_id, joined_at, setup_status,
                setup_channel_id, setup_message_id, last_readiness_score,
-               current_step, delegated_admins, created_at, updated_at
+               current_step, delegated_admins, skipped_sections,
+               created_at, updated_at
         FROM setup_session
         WHERE guild_id = $1
         """,
@@ -177,12 +178,59 @@ async def clear(guild_id: int) -> None:
     )
 
 
+async def add_skipped_section(guild_id: int, slug: str) -> None:
+    """Append ``slug`` to ``skipped_sections`` (idempotent set semantics)."""
+    await pool.get().execute(
+        """
+        UPDATE setup_session
+           SET skipped_sections = (
+                   SELECT ARRAY(SELECT DISTINCT UNNEST(skipped_sections || $2::TEXT))
+                   FROM setup_session WHERE guild_id = $1
+               ),
+               updated_at = NOW()
+         WHERE guild_id = $1
+        """,
+        guild_id,
+        slug,
+    )
+
+
+async def remove_skipped_section(guild_id: int, slug: str) -> None:
+    """Drop ``slug`` from ``skipped_sections``."""
+    await pool.get().execute(
+        """
+        UPDATE setup_session
+           SET skipped_sections = ARRAY_REMOVE(skipped_sections, $2::TEXT),
+               updated_at = NOW()
+         WHERE guild_id = $1
+        """,
+        guild_id,
+        slug,
+    )
+
+
+async def clear_skipped_sections(guild_id: int) -> None:
+    """Empty the skipped-section set for ``guild_id``."""
+    await pool.get().execute(
+        """
+        UPDATE setup_session
+           SET skipped_sections = '{}',
+               updated_at = NOW()
+         WHERE guild_id = $1
+        """,
+        guild_id,
+    )
+
+
 __all__ = [
     "KNOWN_STATUSES",
     "add_delegated_admin",
+    "add_skipped_section",
     "clear",
+    "clear_skipped_sections",
     "get",
     "remove_delegated_admin",
+    "remove_skipped_section",
     "set_readiness_score",
     "set_status",
     "set_step",

--- a/disbot/views/setup/depth_panel.py
+++ b/disbot/views/setup/depth_panel.py
@@ -1,0 +1,174 @@
+"""Setup-wizard depth picker — first menu the operator sees.
+
+When the operator opens the wizard for the first time the bot does
+not yet know how much help they want. The depth picker offers three
+buckets:
+
+* **Quick** — only the essentials (server scan → preset → final review).
+* **Standard** — quick + channels & log routing + cleanup.
+* **Advanced** — every registered section (smart suggestions, cog
+  routing, identity, etc.).
+
+The chosen depth is persisted on
+:attr:`services.setup_session.SetupSession.depth` via
+:func:`services.setup_session.set_depth` and used by the hub
+(:class:`views.setup.hub.SetupHubView`) to filter which sections
+render as buttons. The picker can be re-entered later from the hub's
+**Change depth** button to widen or narrow the scope mid-run.
+
+Constraint preservation:
+
+* No DB writes from the buttons except through ``set_depth``.
+* No SetupOperations staged here.
+* The picker swaps the panel in place via ``edit_message`` — the
+  wizard's single anchored message stays the operator's working
+  surface.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import discord
+
+from services import setup_session
+from services.setup_session import SetupSession
+from views.base import BaseView
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger("bot.views.setup.depth_panel")
+
+
+_DEPTH_DESCRIPTIONS: dict[str, tuple[str, str]] = {
+    "quick": (
+        "⚡ Quick",
+        "3 steps — server scan, choose a preset, apply. Best for small "
+        "servers that just want safe defaults.",
+    ),
+    "standard": (
+        "🛠 Standard",
+        "5–6 steps — scan, channels & logging, cleanup, optional preset, "
+        "review. Best for most communities.",
+    ),
+    "advanced": (
+        "🔬 Advanced",
+        "Every section — identity, smart suggestions, cog routing, "
+        "cleanup, channels, presets. Best for owners who want control.",
+    ),
+}
+
+
+def build_depth_embed() -> discord.Embed:
+    embed = discord.Embed(
+        title="🛰 Choose your setup depth",
+        description=(
+            "How detailed do you want the wizard to be? You can change "
+            "this later from the hub. Your selection only filters which "
+            "sections appear — nothing applies until **Final review**."
+        ),
+        color=discord.Color.blurple(),
+    )
+    for label, description in _DEPTH_DESCRIPTIONS.values():
+        embed.add_field(name=label, value=description, inline=False)
+    embed.set_footer(text="Recommended: Standard.")
+    return embed
+
+
+class DepthPanelView(BaseView):
+    """Three-button depth picker. Each button persists the selection
+    and swaps the panel to the setup hub in place.
+
+    Constructor takes the live session so we can show the operator
+    which depth (if any) is currently chosen — the corresponding
+    button is styled in success colour as a visual cue.
+    """
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        *,
+        session: SetupSession | None = None,
+        timeout: int = 180,
+    ) -> None:
+        super().__init__(author, timeout=timeout)
+        current = session.depth if session is not None else None
+        for slug in ("quick", "standard", "advanced"):
+            label, _ = _DEPTH_DESCRIPTIONS[slug]
+            style = (
+                discord.ButtonStyle.success
+                if slug == current
+                else discord.ButtonStyle.secondary
+            )
+            button: discord.ui.Button = discord.ui.Button(  # type: ignore[var-annotated]
+                label=label,
+                style=style,
+                custom_id=f"setup_depth:{slug}",
+            )
+
+            async def _callback(
+                interaction: discord.Interaction,
+                *,
+                chosen: str = slug,
+            ) -> None:
+                await self._select(interaction, chosen)
+
+            button.callback = _callback  # type: ignore[method-assign]
+            self.add_item(button)
+
+    async def _select(
+        self,
+        interaction: discord.Interaction,
+        depth: str,
+    ) -> None:
+        guild = interaction.guild
+        if guild is None or interaction.guild_id is None:
+            await interaction.response.send_message(
+                "Depth picker requires a guild context.",
+                ephemeral=True,
+            )
+            return
+        try:
+            await setup_session.set_depth(interaction.guild_id, depth)
+        except Exception:
+            logger.exception(
+                "depth_panel._select: set_depth failed (depth=%s)",
+                depth,
+            )
+            await interaction.response.send_message(
+                "Could not save your depth choice. See logs.",
+                ephemeral=True,
+            )
+            return
+
+        # Open the hub at the selected depth.
+        from services import setup_draft
+        from views.setup.hub import SetupHubView, build_hub_embed
+
+        try:
+            session = await setup_session.resume_session(interaction.guild_id)
+        except Exception:
+            logger.exception("depth_panel._select: resume_session failed")
+            session = None
+        try:
+            draft_ops = await setup_draft.list_ops(interaction.guild_id)
+        except Exception:
+            logger.exception("depth_panel._select: list_ops failed")
+            draft_ops = []
+
+        hub = SetupHubView(interaction.user, session=session)
+        embed = build_hub_embed(
+            session,
+            pending_ops=len(draft_ops),
+            draft_ops=draft_ops,
+        )
+        await interaction.response.edit_message(embed=embed, view=hub)
+        self.stop()
+
+
+__all__ = [
+    "DepthPanelView",
+    "build_depth_embed",
+]

--- a/disbot/views/setup/hub.py
+++ b/disbot/views/setup/hub.py
@@ -151,7 +151,13 @@ def build_hub_embed(
 
 
 class SetupHubView(BaseView):
-    """Top-level wizard view: renders one button per registered section."""
+    """Top-level wizard view: renders one button per registered section.
+
+    Section layout is filtered by the session's persisted depth
+    (``quick`` / ``standard`` / ``advanced``). When ``session.depth``
+    is ``None`` (the legacy / pre-picker path) every registered
+    section renders so the hub is never empty.
+    """
 
     def __init__(
         self,
@@ -163,8 +169,36 @@ class SetupHubView(BaseView):
     ) -> None:
         super().__init__(author, public=public, timeout=timeout)
         self.session = session
-        for section in REGISTRY.all():
+        depth = session.depth if session is not None else None
+        for section in REGISTRY.for_depth(depth):
             self.add_item(self._build_section_button(section))
+        self.add_item(self._build_change_depth_button())
+
+    def _build_change_depth_button(self) -> discord.ui.Button:
+        button: discord.ui.Button = discord.ui.Button(  # type: ignore[var-annotated]
+            label="Change depth",
+            style=discord.ButtonStyle.secondary,
+            custom_id="setup_hub:change_depth",
+            row=4,
+        )
+
+        async def _callback(interaction: discord.Interaction) -> None:
+            if not await self._gate_owner(interaction):
+                return
+            from views.setup.depth_panel import (
+                DepthPanelView,
+                build_depth_embed,
+            )
+
+            await self._refresh_session()
+            view = DepthPanelView(interaction.user, session=self.session)
+            await interaction.response.edit_message(
+                embed=build_depth_embed(),
+                view=view,
+            )
+
+        button.callback = _callback  # type: ignore[method-assign]
+        return button
 
     async def _refresh_session(self) -> None:
         if self.session is None:

--- a/disbot/views/setup/hub.py
+++ b/disbot/views/setup/hub.py
@@ -25,12 +25,15 @@ No DB writes from this view directly; every state change goes through
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 
 import discord
 
 # Triggers section module imports → registry registration.
 import views.setup.sections  # noqa: F401
-from services import setup_access, setup_session
+from services import setup_access, setup_progress, setup_session
+from services.setup_operations import SetupOperation
+from services.setup_progress import SectionProgress, badge_for
 from services.setup_sections import REGISTRY, SetupSection
 from services.setup_session import SetupSession
 from views.base import BaseView
@@ -46,19 +49,43 @@ _HUB_DESCRIPTION = (
 )
 
 
-def _hub_sections_value() -> str:
-    sections = REGISTRY.all()
+def _hub_sections_value(
+    sections: list[SetupSection],
+    progress_by_slug: dict[str, SectionProgress] | None,
+) -> str:
+    """Render the "Sections" field of the hub embed.
+
+    When ``progress_by_slug`` is ``None`` (legacy callers that haven't
+    computed progress yet) the field falls back to the plain numbered
+    label list.  Otherwise each row is prefixed with a status glyph
+    and (for sections with staged ops) a trailing "(N pending)" hint.
+    """
     if not sections:
         return "_No sections registered._"
-    return "\n".join(
-        f"{idx}. {section.label}" for idx, section in enumerate(sections, start=1)
-    )
+    if progress_by_slug is None:
+        return "\n".join(
+            f"{idx}. {section.label}" for idx, section in enumerate(sections, start=1)
+        )
+    lines: list[str] = []
+    for idx, section in enumerate(sections, start=1):
+        progress = progress_by_slug.get(section.slug)
+        if progress is None:
+            lines.append(f"{idx}. {section.label}")
+            continue
+        glyph = badge_for(progress.status)
+        line = f"{glyph} {idx}. {section.label}"
+        if progress.pending_ops:
+            suffix = "op" if progress.pending_ops == 1 else "ops"
+            line += f" · {progress.pending_ops} pending {suffix}"
+        lines.append(line)
+    return "\n".join(lines)
 
 
 def build_hub_embed(
     session: SetupSession | None,
     *,
     pending_ops: int | None = None,
+    draft_ops: Iterable[SetupOperation] | None = None,
 ) -> discord.Embed:
     """Build the wizard hub embed.
 
@@ -68,6 +95,12 @@ def build_hub_embed(
     ``None`` the field is omitted — callers that haven't checked the
     draft store yet (or for whom it is irrelevant) keep the legacy
     layout.
+
+    ``draft_ops`` is the iterable of staged operations for the guild.
+    When supplied it drives the per-section status badges in the
+    "Sections" field.  When ``None`` the field renders without
+    badges, preserving the legacy layout for callers that haven't
+    been migrated yet.
     """
     color = discord.Color.blurple()
     if session is not None and session.setup_status == "complete":
@@ -89,6 +122,18 @@ def build_hub_embed(
         )
         description = f"{prefix}**Pending operations:** `{pending_ops}`"
 
+    sections = REGISTRY.all()
+    progress_by_slug: dict[str, SectionProgress] | None
+    if draft_ops is None:
+        progress_by_slug = None
+    else:
+        progress_list = setup_progress.compute_all(
+            sections,
+            session=session,
+            draft_ops=draft_ops,
+        )
+        progress_by_slug = {p.slug: p for p in progress_list}
+
     embed = discord.Embed(
         title=_HUB_TITLE,
         description=description,
@@ -96,7 +141,7 @@ def build_hub_embed(
     )
     embed.add_field(
         name="Sections",
-        value=_hub_sections_value(),
+        value=_hub_sections_value(sections, progress_by_slug),
         inline=False,
     )
     embed.set_footer(

--- a/disbot/views/setup/launcher.py
+++ b/disbot/views/setup/launcher.py
@@ -1,0 +1,550 @@
+"""Setup-wizard launcher view + channel-selection helpers.
+
+Hosts the persistent ``SetupLauncherView`` that the launcher cog posts
+on ``on_guild_join`` and edits in place on ``on_ready``, plus the
+deterministic channel-selection helpers used by ``post_launcher``.
+
+Extracted from :mod:`cogs.setup_cog` to keep the cog file under the
+S4.6 800-LOC ceiling and to let the launcher view evolve in views/
+alongside the rest of the setup wizard panels.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+from services import setup_access, setup_session
+from services.setup_session import SetupSession
+
+logger = logging.getLogger("bot.views.setup.launcher")
+
+_LAUNCHER_TITLE = "🛰 SuperBot setup"
+_LAUNCHER_DESC = (
+    "Welcome! I'll help you wire SuperBot up to this server.\n\n"
+    "Use **Start Setup** for the guided walkthrough, **Run Readiness Scan** "
+    "to see what's already configured, or **Dismiss** to defer. You can also "
+    "run `!setup` or `/setup` from any channel."
+)
+
+
+def _build_launcher_embed(session: SetupSession | None) -> discord.Embed:
+    color = discord.Color.blurple()
+    if session is not None and session.setup_status == "complete":
+        color = discord.Color.green()
+    elif session is not None and session.setup_status == "dismissed":
+        color = discord.Color.dark_grey()
+
+    description = _LAUNCHER_DESC
+    if session is not None:
+        description = f"{_LAUNCHER_DESC}\n\n**Status:** `{session.setup_status}`"
+        if session.last_readiness_score is not None:
+            description += f" · readiness `{session.last_readiness_score}%`"
+        if session.current_step:
+            description += f" · step `{session.current_step}`"
+
+    embed = discord.Embed(
+        title=_LAUNCHER_TITLE,
+        description=description,
+        color=color,
+    )
+    embed.set_footer(
+        text="Owner-gated for write actions. Admins can run the readiness scan.",
+    )
+    return embed
+
+
+_START_LABELS_BY_STATUS = {
+    "pending": "Start Setup",
+    "in_progress": "Resume Setup",
+    "complete": "Re-run Setup",
+    "dismissed": "Start Setup",
+}
+
+
+class SetupLauncherView(discord.ui.View):
+    """Persistent owner-gated launcher view.
+
+    ``timeout=None`` + static ``custom_id`` per button = the message
+    survives bot restarts; :meth:`SetupCog._resume_launchers` rebinds
+    in-flight launcher messages with a status-aware label set on
+    ``on_ready``.
+
+    Labels:
+
+    * ``status="pending"`` / ``None`` / ``"dismissed"`` — default
+      "Start Setup".
+    * ``status="in_progress"`` — "Resume Setup".
+    * ``status="complete"`` — "Re-run Setup".
+
+    Custom IDs never change; discord.py routes interactions by id,
+    not by label, so the rebound message keeps working against the
+    cog-load-registered view.
+    """
+
+    def __init__(self, *, status: str | None = None) -> None:
+        super().__init__(timeout=None)
+        self.status = status
+        if status is not None:
+            self._apply_status_labels(status)
+
+    def _apply_status_labels(self, status: str) -> None:
+        start_label = _START_LABELS_BY_STATUS.get(status, "Start Setup")
+        for child in self.children:
+            if (
+                isinstance(child, discord.ui.Button)
+                and getattr(child, "custom_id", None) == "setup:start"
+            ):
+                child.label = start_label
+
+    async def _resolve_session(
+        self,
+        interaction: discord.Interaction,
+    ) -> SetupSession | None:
+        if interaction.guild_id is None:
+            return None
+        return await setup_session.resume_session(interaction.guild_id)
+
+    async def _deny(
+        self,
+        interaction: discord.Interaction,
+        message: str,
+    ) -> None:
+        await interaction.response.send_message(message, ephemeral=True)
+
+    async def _gate_owner(
+        self,
+        interaction: discord.Interaction,
+    ) -> bool:
+        member = interaction.user
+        if not isinstance(member, discord.Member):
+            await self._deny(
+                interaction,
+                "This button must be used inside the server.",
+            )
+            return False
+        if not setup_access.is_server_owner(member):
+            await self._deny(
+                interaction,
+                "Only the server owner can start setup or change presets.",
+            )
+            return False
+        return True
+
+    async def _gate_admin(
+        self,
+        interaction: discord.Interaction,
+    ) -> bool:
+        member = interaction.user
+        if not isinstance(member, discord.Member):
+            await self._deny(
+                interaction,
+                "This button must be used inside the server.",
+            )
+            return False
+        session = await self._resolve_session(interaction)
+        if not setup_access.is_setup_admin(member, session):
+            await self._deny(
+                interaction,
+                "Only the server owner, an administrator, or a delegated "
+                "setup admin can use this button.",
+            )
+            return False
+        return True
+
+    @discord.ui.button(
+        label="Start Setup",
+        style=discord.ButtonStyle.success,
+        custom_id="setup:start",
+    )
+    async def _start(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        if not await self._gate_owner(interaction):
+            return
+        if interaction.guild_id is None:
+            await self._deny(
+                interaction,
+                "Setup requires a guild context.",
+            )
+            return
+
+        from services import setup_draft
+        from views.setup.hub import SetupHubView, build_hub_embed
+
+        session = await self._resolve_session(interaction)
+        try:
+            draft_ops = await setup_draft.list_ops(interaction.guild_id)
+        except Exception:
+            logger.exception("setup launcher: setup_draft.list_ops failed")
+            draft_ops = []
+        pending_ops = len(draft_ops)
+        hub = SetupHubView(interaction.user, session=session)
+        await interaction.response.send_message(
+            embed=build_hub_embed(
+                session,
+                pending_ops=pending_ops,
+                draft_ops=draft_ops,
+            ),
+            view=hub,
+            ephemeral=True,
+        )
+        try:
+            await setup_session.mark_in_progress(interaction.guild_id, step="hub")
+        except Exception:
+            logger.exception("setup launcher: mark_in_progress failed")
+
+    @discord.ui.button(
+        label="Run Readiness Scan",
+        style=discord.ButtonStyle.primary,
+        custom_id="setup:readiness",
+    )
+    async def _readiness(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        if not await self._gate_admin(interaction):
+            return
+        guild = interaction.guild
+        if guild is None:
+            await self._deny(
+                interaction,
+                "Readiness scan requires a guild context.",
+            )
+            return
+        from cogs.diagnostic._platform_embeds import build_setup_readiness_embed
+
+        embed = await build_setup_readiness_embed(guild.id, guild=guild)
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+
+    @discord.ui.button(
+        label="Smart Suggestions",
+        style=discord.ButtonStyle.secondary,
+        custom_id="setup:smart_suggestions",
+    )
+    async def _suggestions(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        if not await self._gate_owner(interaction):
+            return
+        guild = interaction.guild
+        if guild is None or interaction.guild_id is None:
+            await self._deny(
+                interaction,
+                "Smart Suggestions requires a guild context.",
+            )
+            return
+
+        from services.guild_snapshot import collect as collect_snapshot
+        from services.setup_ai_advisor import build_advisor
+        from views.setup.ai_review.main_panel import (
+            AIReviewPanelView,
+            build_ai_review_embed,
+        )
+
+        try:
+            snapshot = await collect_snapshot(guild)
+            advisor = build_advisor()
+            draft = await advisor.suggest(snapshot)
+        except Exception:
+            logger.exception("setup launcher: advisor flow failed")
+            await self._deny(
+                interaction,
+                "Smart Suggestions failed. Run **Run Readiness Scan** for "
+                "a deterministic baseline.",
+            )
+            return
+
+        panel = AIReviewPanelView(interaction.user, draft=draft, snapshot=snapshot)
+        await interaction.response.send_message(
+            embed=build_ai_review_embed(draft),
+            view=panel,
+            ephemeral=True,
+        )
+        try:
+            await setup_session.mark_in_progress(
+                interaction.guild_id,
+                step="suggestions",
+            )
+        except Exception:
+            logger.exception("setup launcher: mark_in_progress failed")
+
+    @discord.ui.button(
+        label="Choose Preset",
+        style=discord.ButtonStyle.secondary,
+        custom_id="setup:preset",
+    )
+    async def _preset(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        if not await self._gate_owner(interaction):
+            return
+
+        from views.setup.template_picker import TemplatePickerView, build_picker_embed
+
+        picker = TemplatePickerView(interaction.user)
+        await interaction.response.send_message(
+            embed=build_picker_embed(),
+            view=picker,
+            ephemeral=True,
+        )
+
+    @discord.ui.button(
+        label="View Summary",
+        style=discord.ButtonStyle.secondary,
+        custom_id="setup:summary",
+        row=1,
+    )
+    async def _view_summary(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        if not await self._gate_admin(interaction):
+            return
+        guild = interaction.guild
+        if guild is None or interaction.guild_id is None:
+            await self._deny(
+                interaction,
+                "View Summary requires a guild context.",
+            )
+            return
+        session = await self._resolve_session(interaction)
+        if session is None or session.setup_status != "complete":
+            await self._deny(
+                interaction,
+                "Setup is not complete yet. Run **Start Setup** to finish "
+                "the wizard before viewing the summary.",
+            )
+            return
+
+        from views.setup.summary import (
+            SummaryView,
+            build_summary_embed,
+            build_summary_snapshot,
+        )
+
+        try:
+            snapshot = await build_summary_snapshot(
+                session=session,
+                guild=guild,
+            )
+        except Exception:
+            logger.exception("setup launcher: summary snapshot build failed")
+            await self._deny(
+                interaction,
+                "Could not build the summary. Try **Run Readiness Scan** "
+                "for a deterministic baseline.",
+            )
+            return
+
+        view = SummaryView(interaction.user, snapshot=snapshot)
+        await interaction.response.send_message(
+            embed=build_summary_embed(snapshot),
+            view=view,
+            ephemeral=True,
+        )
+
+    @discord.ui.button(
+        label="Repost launcher",
+        style=discord.ButtonStyle.secondary,
+        custom_id="setup:repost_launcher",
+        row=1,
+    )
+    async def _repost_launcher(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        if not await self._gate_admin(interaction):
+            return
+        guild = interaction.guild
+        if guild is None:
+            await self._deny(
+                interaction,
+                "Repost launcher requires a guild context.",
+            )
+            return
+
+        channel, message = await post_launcher(guild)
+        if message is None:
+            await self._deny(
+                interaction,
+                "Could not post the launcher anywhere — bot has no sendable "
+                "channel and the owner has DMs closed.",
+            )
+            return
+
+        try:
+            await setup_session.start_session(
+                guild_id=guild.id,
+                guild_name=guild.name,
+                owner_id=guild.owner_id or 0,
+                setup_channel_id=channel.id if channel is not None else None,
+                setup_message_id=message.id,
+            )
+        except Exception:
+            logger.exception(
+                "setup launcher: start_session refresh failed",
+            )
+
+        where = f"<#{channel.id}>" if channel is not None else "your DMs"
+        await interaction.response.send_message(
+            f"Launcher reposted in {where}.",
+            ephemeral=True,
+        )
+
+    @discord.ui.button(
+        label="Dismiss",
+        style=discord.ButtonStyle.danger,
+        custom_id="setup:dismiss",
+        row=1,
+    )
+    async def _dismiss(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        if not await self._gate_owner(interaction):
+            return
+        if interaction.guild_id is None:
+            await self._deny(
+                interaction,
+                "Dismiss requires a guild context.",
+            )
+            return
+        await setup_session.dismiss(interaction.guild_id)
+        await interaction.response.send_message(
+            "Setup dismissed. Use the setup launcher later to resume.",
+            ephemeral=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Channel selection — pick the safest place to post the launcher.
+# ---------------------------------------------------------------------------
+
+
+def _bot_can_send_in(channel: discord.TextChannel, me: discord.Member) -> bool:
+    perms = channel.permissions_for(me)
+    return bool(perms.view_channel and perms.send_messages and perms.embed_links)
+
+
+def pick_launcher_channel(guild: discord.Guild) -> discord.TextChannel | None:
+    """Return the safest text channel to post the launcher in.
+
+    Order:
+      1. ``guild.system_channel`` if the bot can send + embed there.
+      2. First channel whose name contains ``admin`` / ``mod`` /
+         ``staff`` that the bot can send in.
+      3. First channel whose name contains ``bot`` that the bot can
+         send in.
+      4. First text channel in the guild the bot can send in.
+      5. ``None`` — caller should DM the owner instead.
+    """
+    me = guild.me
+    if me is None:
+        return None
+
+    system = guild.system_channel
+    if isinstance(system, discord.TextChannel) and _bot_can_send_in(system, me):
+        return system
+
+    keyword_groups: tuple[tuple[str, ...], ...] = (
+        ("admin", "mod", "staff"),
+        ("bot",),
+    )
+    for needles in keyword_groups:
+        for channel in guild.text_channels:
+            name = (channel.name or "").lower()
+            if any(needle in name for needle in needles) and _bot_can_send_in(
+                channel,
+                me,
+            ):
+                return channel
+
+    for channel in guild.text_channels:
+        if _bot_can_send_in(channel, me):
+            return channel
+    return None
+
+
+async def post_launcher(
+    guild: discord.Guild,
+) -> tuple[discord.TextChannel | None, discord.Message | None]:
+    """Pick a channel + post the launcher message.
+
+    Returns ``(channel, message)`` on success, ``(None, None)`` when
+    no channel is sendable and the owner-DM fallback also failed.
+    The caller is responsible for updating ``setup_session`` with the
+    resulting ids.
+    """
+    embed = _build_launcher_embed(None)
+    view = SetupLauncherView()
+
+    channel = pick_launcher_channel(guild)
+    if channel is not None:
+        try:
+            message = await channel.send(embed=embed, view=view)
+            return channel, message
+        except discord.Forbidden:
+            logger.warning(
+                "setup launcher: forbidden when posting in #%s (guild=%d)",
+                channel.name,
+                guild.id,
+            )
+        except discord.HTTPException as exc:
+            logger.warning(
+                "setup launcher: HTTP error posting in #%s (guild=%d): %s",
+                channel.name,
+                guild.id,
+                exc,
+            )
+
+    # Channel fallback: DM the owner.
+    owner = guild.owner
+    if owner is not None:
+        try:
+            message = await owner.send(embed=embed, view=view)
+            logger.info(
+                "setup launcher: DMed launcher to owner %d (guild=%d)",
+                owner.id,
+                guild.id,
+            )
+            return None, message
+        except discord.Forbidden:
+            logger.warning(
+                "setup launcher: cannot DM owner %d for guild=%d (DMs closed)",
+                owner.id,
+                guild.id,
+            )
+        except discord.HTTPException as exc:
+            logger.warning(
+                "setup launcher: HTTP error DMing owner for guild=%d: %s",
+                guild.id,
+                exc,
+            )
+
+    return None, None
+
+
+__all__ = [
+    "SetupLauncherView",
+    "pick_launcher_channel",
+    "post_launcher",
+]

--- a/disbot/views/setup/section_card.py
+++ b/disbot/views/setup/section_card.py
@@ -1,0 +1,408 @@
+"""Setup wizard section card — shared entry panel for setup sections.
+
+Every section that supports the new staged-navigation pattern uses this
+module's :func:`show` helper as its registered ``run`` callback. The
+card surfaces, in one place:
+
+* step number + total
+* section purpose (the registered label)
+* detected current state (section-specific text)
+* "if you skip this" description (from ``SetupSection.description_if_skipped``)
+* pending op count + status badge (from ``services.setup_progress``)
+* a button row: **Apply Recommended** · **Customize** · **Skip** · **Hub**
+
+Buttons:
+
+* **Apply Recommended** — calls the section's ``recommended_ops_builder``
+  (passed in by the section module) and stages each returned
+  :class:`SetupOperation` via :func:`services.setup_draft.append` with
+  metadata ``source="setup_ux:recommended"``. Disabled when no
+  builder was supplied.
+* **Customize** — calls the section-supplied ``on_customize`` callback,
+  which typically opens the section's existing detail view. Disabled
+  when no callback was supplied.
+* **Skip** — calls :func:`services.setup_session.mark_section_skipped`
+  and closes the card.
+* **Hub** — closes the card; the hub message remains the operator's
+  anchor.
+
+Constraints preserved:
+
+* No DB writes from the view — only via the canonical
+  ``setup_draft.append`` and ``setup_session.mark_section_skipped``.
+* No SetupOperation kinds invented here — recommended builders return
+  the same kinds the section already supports.
+* Final Review remains the only apply gate. Apply Recommended **stages**;
+  nothing executes until Final Review confirms.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
+
+import discord
+
+from services import setup_draft, setup_progress, setup_session
+from services.setup_operations import SetupOperation
+from services.setup_progress import SectionProgress, badge_for
+from services.setup_sections import REGISTRY, SetupSection
+from views.base import BaseView
+
+if TYPE_CHECKING:
+    from views.setup.hub import SetupHubView
+
+logger = logging.getLogger("bot.views.setup.section_card")
+
+
+CustomizeCallback = Callable[
+    [discord.Interaction, "SetupHubView | None"],
+    Awaitable[None],
+]
+
+RecommendedOpsBuilder = Callable[[discord.Guild], list[SetupOperation]]
+
+
+_STATUS_LABELS = {
+    "not_started": "Not started",
+    "recommended": "Recommended selected",
+    "customized": "Customized",
+    "skipped": "Skipped",
+    "needs_attention": "Needs attention",
+    "applied": "Applied",
+}
+
+
+def _step_index(section: SetupSection, sections: list[SetupSection]) -> int:
+    """Return the 1-based position of ``section`` in ``sections``."""
+    for idx, s in enumerate(sections, start=1):
+        if s.slug == section.slug:
+            return idx
+    return 0
+
+
+def build_section_card(
+    *,
+    section: SetupSection,
+    progress: SectionProgress,
+    detected_state: str,
+    has_recommended: bool,
+    has_customize: bool,
+) -> discord.Embed:
+    """Build the section card embed.
+
+    The card is the single source of section-level UX: every field an
+    operator might want when standing on a stage panel is rendered
+    here. Section modules supply ``detected_state`` (what's currently
+    configured) and the booleans flag whether the corresponding action
+    will be enabled in the button row.
+    """
+    sections = REGISTRY.all()
+    total = len(sections)
+    step = _step_index(section, sections)
+    glyph = badge_for(progress.status)
+    status_label = _STATUS_LABELS.get(progress.status.value, progress.status.value)
+
+    title_emoji = section.emoji or "🛰"
+    title = f"{title_emoji} {section.label}"
+
+    color = discord.Color.blurple()
+    if progress.status.value in ("recommended", "applied"):
+        color = discord.Color.green()
+    elif progress.status.value == "skipped":
+        color = discord.Color.dark_grey()
+    elif progress.status.value == "needs_attention":
+        color = discord.Color.gold()
+
+    embed = discord.Embed(
+        title=title,
+        description=(
+            f"**Step {step} of {total}** · {glyph} *{status_label}*"
+            if step
+            else f"{glyph} *{status_label}*"
+        ),
+        color=color,
+    )
+    embed.add_field(
+        name="Detected",
+        value=detected_state or "_(no state detected)_",
+        inline=False,
+    )
+    recommended_value = (
+        "Click **Apply Recommended** to stage the section's safe defaults."
+        if has_recommended
+        else "_(this section has no recommended defaults — use Customize.)_"
+    )
+    embed.add_field(name="Recommended action", value=recommended_value, inline=False)
+    if section.description_if_skipped:
+        embed.add_field(
+            name="If you skip this",
+            value=section.description_if_skipped,
+            inline=False,
+        )
+    if progress.pending_ops:
+        suffix = "operation" if progress.pending_ops == 1 else "operations"
+        embed.add_field(
+            name="Pending",
+            value=f"{progress.pending_ops} {suffix} staged for Final review.",
+            inline=False,
+        )
+    footer_bits = []
+    if has_customize:
+        footer_bits.append("Customize to open the detailed picker")
+    footer_bits.append("Final Review applies all staged ops")
+    embed.set_footer(text=" · ".join(footer_bits))
+    return embed
+
+
+class SectionCardView(BaseView):
+    """Card view that owns the four-button section panel."""
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        *,
+        section: SetupSection,
+        hub: SetupHubView | None,
+        on_customize: CustomizeCallback | None,
+        recommended_ops_builder: RecommendedOpsBuilder | None,
+    ) -> None:
+        super().__init__(author, timeout=180)
+        self._section = section
+        self._hub = hub
+        self._on_customize = on_customize
+        self._recommended_ops_builder = recommended_ops_builder
+
+        self._apply_button: discord.ui.Button = discord.ui.Button(  # type: ignore[var-annotated]
+            label="Apply Recommended",
+            style=discord.ButtonStyle.success,
+            custom_id=f"setup_card:{section.slug}:apply_recommended",
+            disabled=recommended_ops_builder is None,
+        )
+        self._apply_button.callback = self._apply_recommended  # type: ignore[method-assign]
+        self.add_item(self._apply_button)
+
+        self._customize_button: discord.ui.Button = discord.ui.Button(  # type: ignore[var-annotated]
+            label="Customize",
+            style=discord.ButtonStyle.primary,
+            custom_id=f"setup_card:{section.slug}:customize",
+            disabled=on_customize is None,
+        )
+        self._customize_button.callback = self._customize  # type: ignore[method-assign]
+        self.add_item(self._customize_button)
+
+        self._skip_button: discord.ui.Button = discord.ui.Button(  # type: ignore[var-annotated]
+            label="Skip",
+            style=discord.ButtonStyle.secondary,
+            custom_id=f"setup_card:{section.slug}:skip",
+        )
+        self._skip_button.callback = self._skip  # type: ignore[method-assign]
+        self.add_item(self._skip_button)
+
+        self._hub_button: discord.ui.Button = discord.ui.Button(  # type: ignore[var-annotated]
+            label="↩ Hub",
+            style=discord.ButtonStyle.secondary,
+            custom_id=f"setup_card:{section.slug}:hub",
+        )
+        self._hub_button.callback = self._return_to_hub  # type: ignore[method-assign]
+        self.add_item(self._hub_button)
+
+    async def _apply_recommended(self, interaction: discord.Interaction) -> None:
+        if self._recommended_ops_builder is None:
+            await interaction.response.send_message(
+                "This section has no recommended defaults.",
+                ephemeral=True,
+            )
+            return
+        guild = interaction.guild
+        if guild is None or interaction.guild_id is None:
+            await interaction.response.send_message(
+                "Apply Recommended requires a guild context.",
+                ephemeral=True,
+            )
+            return
+        try:
+            ops = self._recommended_ops_builder(guild)
+        except Exception:
+            logger.exception(
+                "section_card._apply_recommended: builder failed (section=%s)",
+                self._section.slug,
+            )
+            await interaction.response.send_message(
+                "Could not build the recommended defaults. See logs.",
+                ephemeral=True,
+            )
+            return
+        if not ops:
+            await interaction.response.send_message(
+                "No recommended operations were generated for this section.",
+                ephemeral=True,
+            )
+            return
+
+        for op in ops:
+            try:
+                await setup_draft.append(
+                    op,
+                    guild_id=interaction.guild_id,
+                    actor_id=interaction.user.id,
+                    label=f"[Recommended] {op.kind}",
+                    metadata={"source": "setup_ux:recommended"},
+                )
+            except Exception:
+                logger.exception(
+                    "section_card._apply_recommended: append failed",
+                )
+
+        try:
+            await setup_session.unmark_section_skipped(
+                interaction.guild_id,
+                self._section.slug,
+            )
+        except Exception:
+            logger.exception("section_card: unmark skip failed")
+
+        word = "operation" if len(ops) == 1 else "operations"
+        await interaction.response.send_message(
+            f"Staged **{len(ops)} recommended {word}** for {self._section.label}. "
+            "Open Final review to apply.",
+            ephemeral=True,
+        )
+
+    async def _customize(self, interaction: discord.Interaction) -> None:
+        if self._on_customize is None:
+            await interaction.response.send_message(
+                "This section has no detail view yet.",
+                ephemeral=True,
+            )
+            return
+        try:
+            await self._on_customize(interaction, self._hub)
+        except Exception:
+            logger.exception(
+                "section_card._customize: handler failed (section=%s)",
+                self._section.slug,
+            )
+            if not interaction.response.is_done():
+                await interaction.response.send_message(
+                    "Could not open the detail view. See logs.",
+                    ephemeral=True,
+                )
+
+    async def _skip(self, interaction: discord.Interaction) -> None:
+        if interaction.guild_id is None:
+            await interaction.response.send_message(
+                "Skip requires a guild context.",
+                ephemeral=True,
+            )
+            return
+        try:
+            await setup_session.mark_section_skipped(
+                interaction.guild_id,
+                self._section.slug,
+            )
+        except Exception:
+            logger.exception(
+                "section_card._skip: mark_section_skipped failed (section=%s)",
+                self._section.slug,
+            )
+            await interaction.response.send_message(
+                "Could not record the skip. See logs.",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.send_message(
+            f"Marked **{self._section.label}** as skipped. "
+            f"Reopen the section any time to change your mind.",
+            ephemeral=True,
+        )
+
+    async def _return_to_hub(self, interaction: discord.Interaction) -> None:
+        # Closing the ephemeral card returns the operator to the hub
+        # message that was already open above it.
+        await interaction.response.send_message(
+            "Returning to the setup hub above.",
+            ephemeral=True,
+        )
+
+
+async def show(
+    interaction: discord.Interaction,
+    *,
+    hub: SetupHubView | None,
+    section: SetupSection,
+    detected_state: str = "",
+    on_customize: CustomizeCallback | None = None,
+    recommended_ops_builder: RecommendedOpsBuilder | None = None,
+) -> None:
+    """Render the section card for ``section`` and post it ephemerally.
+
+    Builds the embed from live session + draft state so the card
+    reflects today's progress. The card view captures the supplied
+    callbacks so each section can plug in its own detail view and
+    recommended-ops builder.
+    """
+    guild = interaction.guild
+    member = interaction.user
+    if guild is None or interaction.guild_id is None:
+        await interaction.response.send_message(
+            "Setup sections must be opened inside the server.",
+            ephemeral=True,
+        )
+        return
+
+    try:
+        session = await setup_session.resume_session(interaction.guild_id)
+    except Exception:
+        logger.exception("section_card.show: resume_session failed")
+        session = None
+
+    try:
+        draft_ops = await setup_draft.list_ops(interaction.guild_id)
+    except Exception:
+        logger.exception("section_card.show: list_ops failed")
+        draft_ops = []
+
+    progress = setup_progress.compute_section_status(
+        section,
+        session=session,
+        draft_ops=draft_ops,
+    )
+
+    embed = build_section_card(
+        section=section,
+        progress=progress,
+        detected_state=detected_state,
+        has_recommended=recommended_ops_builder is not None,
+        has_customize=on_customize is not None,
+    )
+    view = SectionCardView(
+        member,
+        section=section,
+        hub=hub,
+        on_customize=on_customize,
+        recommended_ops_builder=recommended_ops_builder,
+    )
+    await interaction.response.send_message(
+        embed=embed,
+        view=view,
+        ephemeral=True,
+    )
+
+    try:
+        await setup_session.mark_in_progress(
+            interaction.guild_id,
+            step=section.session_step,
+        )
+    except Exception:
+        logger.exception("section_card.show: mark_in_progress failed")
+
+
+__all__ = [
+    "CustomizeCallback",
+    "RecommendedOpsBuilder",
+    "SectionCardView",
+    "build_section_card",
+    "show",
+]

--- a/disbot/views/setup/sections/channels.py
+++ b/disbot/views/setup/sections/channels.py
@@ -436,6 +436,7 @@ REGISTRY.register(
             "have a dedicated log channel. Configure these later in "
             "`!settings`."
         ),
+        depths=frozenset({"standard", "advanced"}),
     ),
 )
 

--- a/disbot/views/setup/sections/channels.py
+++ b/disbot/views/setup/sections/channels.py
@@ -431,6 +431,11 @@ REGISTRY.register(
         emoji="📡",
         order=40,
         op_kinds=frozenset({"bind_channel", "clear_binding"}),
+        description_if_skipped=(
+            "SuperBot keeps the current command-channel rules and may not "
+            "have a dedicated log channel. Configure these later in "
+            "`!settings`."
+        ),
     ),
 )
 

--- a/disbot/views/setup/sections/channels.py
+++ b/disbot/views/setup/sections/channels.py
@@ -430,6 +430,7 @@ REGISTRY.register(
         run=run,
         emoji="📡",
         order=40,
+        op_kinds=frozenset({"bind_channel", "clear_binding"}),
     ),
 )
 

--- a/disbot/views/setup/sections/cleanup.py
+++ b/disbot/views/setup/sections/cleanup.py
@@ -440,6 +440,7 @@ REGISTRY.register(
             "be aggressively deleted unless existing policies already say "
             "so. You can revisit cleanup later from `!settings`."
         ),
+        depths=frozenset({"standard", "advanced"}),
     ),
 )
 

--- a/disbot/views/setup/sections/cleanup.py
+++ b/disbot/views/setup/sections/cleanup.py
@@ -368,7 +368,11 @@ async def _stage_cleanup_policy(
 # ---------------------------------------------------------------------------
 
 
-async def run(interaction: discord.Interaction, hub: SetupHubView) -> None:
+async def _customize_run(
+    interaction: discord.Interaction,
+    hub: SetupHubView | None,
+) -> None:
+    """Open the detailed cleanup picker (the card's Customize target)."""
     del hub
     guild = interaction.guild
     if guild is None:
@@ -387,6 +391,41 @@ async def run(interaction: discord.Interaction, hub: SetupHubView) -> None:
     )
 
 
+def _recommended_cleanup_ops(guild: discord.Guild) -> list[SetupOperation]:
+    """Default cleanup recommendation: Light cleanup at guild scope.
+
+    Light deletes invalid commands after 10s and leaves failed-command
+    messages alone — a safe baseline for most servers.
+    """
+    return [
+        SetupOperation(
+            kind="set_cleanup_policy",
+            subsystem="cleanup",
+            binding_name=None,
+            setting_name=None,
+            target_id=guild.id,
+            target_name=guild.name,
+            target_kind="guild",
+            value="Light",
+        ),
+    ]
+
+
+async def run(interaction: discord.Interaction, hub: SetupHubView) -> None:
+    """Cleanup section entry — shows the section card."""
+    from views.setup.section_card import show
+
+    detected = "Resolver walks thread → channel → category → guild → default."
+    await show(
+        interaction,
+        hub=hub,
+        section=REGISTRY.get(SLUG),  # type: ignore[arg-type]
+        detected_state=detected,
+        on_customize=_customize_run,
+        recommended_ops_builder=_recommended_cleanup_ops,
+    )
+
+
 REGISTRY.register(
     SetupSection(
         slug=SLUG,
@@ -396,6 +435,11 @@ REGISTRY.register(
         emoji="🧹",
         order=60,
         op_kinds=frozenset({"set_cleanup_policy"}),
+        description_if_skipped=(
+            "Cleanup stays at the current server default. Commands will not "
+            "be aggressively deleted unless existing policies already say "
+            "so. You can revisit cleanup later from `!settings`."
+        ),
     ),
 )
 

--- a/disbot/views/setup/sections/cleanup.py
+++ b/disbot/views/setup/sections/cleanup.py
@@ -395,6 +395,7 @@ REGISTRY.register(
         run=run,
         emoji="🧹",
         order=60,
+        op_kinds=frozenset({"set_cleanup_policy"}),
     ),
 )
 

--- a/disbot/views/setup/sections/cog_routing.py
+++ b/disbot/views/setup/sections/cog_routing.py
@@ -441,6 +441,7 @@ REGISTRY.register(
         run=run,
         emoji="🧭",
         order=70,
+        op_kinds=frozenset({"set_cog_routing"}),
     ),
 )
 

--- a/disbot/views/setup/sections/cog_routing.py
+++ b/disbot/views/setup/sections/cog_routing.py
@@ -442,6 +442,11 @@ REGISTRY.register(
         emoji="🧭",
         order=70,
         op_kinds=frozenset({"set_cog_routing"}),
+        description_if_skipped=(
+            "All loaded cogs stay enabled in every channel per the current "
+            "default policy. You can tighten per-channel/category routing "
+            "later in `!settings`."
+        ),
     ),
 )
 

--- a/disbot/views/setup/sections/cog_routing.py
+++ b/disbot/views/setup/sections/cog_routing.py
@@ -447,6 +447,7 @@ REGISTRY.register(
             "default policy. You can tighten per-channel/category routing "
             "later in `!settings`."
         ),
+        depths=frozenset({"advanced"}),
     ),
 )
 

--- a/disbot/views/setup/sections/identity.py
+++ b/disbot/views/setup/sections/identity.py
@@ -265,6 +265,11 @@ REGISTRY.register(
         order=30,
     ),
 )
+# Identity stages `set_setting` ops but `set_setting` is shared with
+# many other surfaces (settings cog, automation, etc.). Leaving
+# op_kinds empty here keeps the channels/cleanup/cog_routing badges
+# from polluting the identity row; tighter scoping comes in PR 3 once
+# section cards declare a per-section subsystem filter.
 
 
 __all__ = [

--- a/disbot/views/setup/sections/identity.py
+++ b/disbot/views/setup/sections/identity.py
@@ -263,12 +263,16 @@ REGISTRY.register(
         run=run,
         emoji="🪪",
         order=30,
+        description_if_skipped=(
+            "Identity defaults stay at the existing values. You can change "
+            "them later in `!settings` without re-running the wizard."
+        ),
     ),
 )
 # Identity stages `set_setting` ops but `set_setting` is shared with
 # many other surfaces (settings cog, automation, etc.). Leaving
 # op_kinds empty here keeps the channels/cleanup/cog_routing badges
-# from polluting the identity row; tighter scoping comes in PR 3 once
+# from polluting the identity row; tighter scoping comes once
 # section cards declare a per-section subsystem filter.
 
 

--- a/disbot/views/setup/sections/identity.py
+++ b/disbot/views/setup/sections/identity.py
@@ -267,6 +267,7 @@ REGISTRY.register(
             "Identity defaults stay at the existing values. You can change "
             "them later in `!settings` without re-running the wizard."
         ),
+        depths=frozenset({"advanced"}),
     ),
 )
 # Identity stages `set_setting` ops but `set_setting` is shared with

--- a/disbot/views/setup/sections/preset_select.py
+++ b/disbot/views/setup/sections/preset_select.py
@@ -330,6 +330,10 @@ REGISTRY.register(
         run=run,
         emoji="🎛",
         order=25,
+        description_if_skipped=(
+            "No bundled preset is staged. Configure channels, cleanup, and "
+            "routing one section at a time, or load a preset later."
+        ),
     ),
 )
 

--- a/disbot/views/setup/sections/suggestions.py
+++ b/disbot/views/setup/sections/suggestions.py
@@ -96,6 +96,7 @@ REGISTRY.register(
         style=discord.ButtonStyle.success,
         run=run,
         order=20,
+        depths=frozenset({"advanced"}),
     ),
 )
 

--- a/disbot/views/setup/summary.py
+++ b/disbot/views/setup/summary.py
@@ -182,7 +182,7 @@ class SummaryView(BaseView):
                 "summary._open_settings: SettingsHubView build failed",
             )
             await interaction.response.send_message(
-                "Could not open the Settings Manager. Run `!settings` " "instead.",
+                "Could not open the Settings Manager. Run `!settings` instead.",
                 ephemeral=True,
             )
             return

--- a/disbot/views/setup/summary.py
+++ b/disbot/views/setup/summary.py
@@ -146,6 +146,50 @@ class SummaryView(BaseView):
         super().__init__(author, public=public, timeout=timeout)
         self.snapshot = snapshot
 
+    @discord.ui.button(
+        label="Open Settings Manager",
+        style=discord.ButtonStyle.success,
+    )
+    async def _open_settings(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        """Swap the current summary message to the Settings Manager hub.
+
+        Uses ``edit_message`` to keep the wizard's single anchored
+        message — the operator does not get yet another ephemeral.
+        """
+        del button
+        try:
+            from views.settings.hub import SettingsHubView
+        except Exception:
+            logger.exception(
+                "summary._open_settings: SettingsHubView import failed",
+            )
+            await interaction.response.send_message(
+                "Settings Manager is unavailable right now. Run `!settings` "
+                "to open it directly.",
+                ephemeral=True,
+            )
+            return
+
+        try:
+            embed = SettingsHubView.build_embed()
+            view = SettingsHubView(interaction.user)
+        except Exception:
+            logger.exception(
+                "summary._open_settings: SettingsHubView build failed",
+            )
+            await interaction.response.send_message(
+                "Could not open the Settings Manager. Run `!settings` " "instead.",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.response.edit_message(embed=embed, view=view)
+        self.stop()
+
     @discord.ui.button(label="Close", style=discord.ButtonStyle.secondary)
     async def _close(
         self,

--- a/tests/unit/cogs/test_setup_cog.py
+++ b/tests/unit/cogs/test_setup_cog.py
@@ -1049,7 +1049,18 @@ def _mock_ctx(author, guild=None, guild_id: int = 1):
     return ctx
 
 
-def _delegated_session(*, owner_id: int = 99, delegated=(42,)) -> SetupSession:
+def _delegated_session(
+    *,
+    owner_id: int = 99,
+    delegated=(42,),
+    depth: str | None = "standard",
+) -> SetupSession:
+    """Test fixture session.
+
+    Defaults ``depth="standard"`` so callers exercising the hub path
+    don't accidentally hit the depth picker. Pass ``depth=None`` to
+    test the picker flow.
+    """
     return SetupSession(
         guild_id=1,
         guild_name="Test",
@@ -1060,6 +1071,7 @@ def _delegated_session(*, owner_id: int = 99, delegated=(42,)) -> SetupSession:
         last_readiness_score=None,
         current_step=None,
         delegated_admins=tuple(delegated),
+        depth=depth,
     )
 
 
@@ -1128,6 +1140,37 @@ async def test_setup_cmd_starts_session_when_missing():
 
     start_mock.assert_awaited_once()
     ctx.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_setup_cmd_shows_depth_picker_when_depth_unset():
+    """First-time entry (session.depth=None) routes the operator
+    through the depth picker before opening the hub."""
+    from cogs.setup_cog import SetupCog
+    from views.setup.depth_panel import DepthPanelView
+
+    cog = SetupCog(MagicMock())
+    ctx = _mock_ctx(_owner_member())
+
+    with (
+        patch(
+            "cogs.setup_cog.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_delegated_session(depth=None),
+        ),
+        patch(
+            "cogs.setup_cog.setup_session.mark_in_progress",
+            new_callable=AsyncMock,
+        ) as mark_mock,
+    ):
+        await cog.setup_cmd.callback(cog, ctx)
+
+    ctx.send.assert_awaited_once()
+    sent_view = ctx.send.await_args.kwargs.get("view")
+    assert isinstance(sent_view, DepthPanelView)
+    # mark_in_progress should NOT fire — the operator hasn't reached
+    # the hub yet.
+    mark_mock.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cogs/test_setup_cog.py
+++ b/tests/unit/cogs/test_setup_cog.py
@@ -200,7 +200,59 @@ async def test_post_launcher_falls_back_to_dm_on_forbidden_in_channel():
 
 
 @pytest.mark.asyncio
-async def test_on_guild_join_calls_start_session_with_channel_ids():
+async def test_on_guild_join_uses_setup_channel_when_creatable():
+    """The bot now tries to auto-create a private setup channel first
+    and posts the launcher there with an owner ping."""
+    from cogs.setup_cog import SetupCog
+
+    bot = MagicMock()
+    cog = SetupCog(bot)
+
+    setup_ch = MagicMock()
+    setup_ch.id = 7000
+    setup_ch.send = AsyncMock(return_value=MagicMock(id=8000))
+    g = _guild(
+        system=None,
+        text_channels=[],
+        me=MagicMock(),
+        owner_id=99,
+        guild_id=42,
+        name="My Server",
+    )
+    g.owner = MagicMock()
+    g.owner.mention = "<@99>"
+
+    with (
+        patch(
+            "services.setup_channel.ensure_setup_channel",
+            new_callable=AsyncMock,
+            return_value=(setup_ch, True),
+        ),
+        patch(
+            "cogs.setup_cog.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "cogs.setup_cog.setup_session.start_session",
+            new_callable=AsyncMock,
+        ) as start_mock,
+    ):
+        await cog._handle_join(g)
+
+    setup_ch.send.assert_awaited_once()
+    # Owner mention surfaces in the posted content.
+    sent_content = setup_ch.send.await_args.kwargs.get("content")
+    assert sent_content is not None and "<@99>" in sent_content
+    kwargs = start_mock.await_args.kwargs
+    assert kwargs["setup_channel_id"] == 7000
+    assert kwargs["setup_message_id"] == 8000
+
+
+@pytest.mark.asyncio
+async def test_on_guild_join_falls_back_to_post_launcher_when_no_setup_channel():
+    """When the bot lacks Manage Channels (or create fails) the join
+    handler falls back to the legacy post_launcher path."""
     from cogs.setup_cog import SetupCog
 
     bot = MagicMock()
@@ -219,17 +271,27 @@ async def test_on_guild_join_calls_start_session_with_channel_ids():
         name="My Server",
     )
 
-    with patch(
-        "cogs.setup_cog.setup_session.start_session",
-        new_callable=AsyncMock,
-    ) as start_mock:
+    with (
+        patch(
+            "services.setup_channel.ensure_setup_channel",
+            new_callable=AsyncMock,
+            return_value=(None, False),
+        ),
+        patch(
+            "cogs.setup_cog.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "cogs.setup_cog.setup_session.start_session",
+            new_callable=AsyncMock,
+        ) as start_mock,
+    ):
         await cog._handle_join(g)
 
     start_mock.assert_awaited_once()
     kwargs = start_mock.await_args.kwargs
     assert kwargs["guild_id"] == 42
-    assert kwargs["guild_name"] == "My Server"
-    assert kwargs["owner_id"] == 99
     assert kwargs["setup_channel_id"] == 5555
     assert kwargs["setup_message_id"] == 8888
 
@@ -245,16 +307,78 @@ async def test_on_guild_join_records_none_ids_when_dm_succeeds():
     g.owner = MagicMock()
     g.owner.send = AsyncMock(return_value=MagicMock(id=99001))
 
-    with patch(
-        "cogs.setup_cog.setup_session.start_session",
-        new_callable=AsyncMock,
-    ) as start_mock:
+    with (
+        patch(
+            "services.setup_channel.ensure_setup_channel",
+            new_callable=AsyncMock,
+            return_value=(None, False),
+        ),
+        patch(
+            "cogs.setup_cog.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "cogs.setup_cog.setup_session.start_session",
+            new_callable=AsyncMock,
+        ) as start_mock,
+    ):
         await cog._handle_join(g)
 
     kwargs = start_mock.await_args.kwargs
     assert kwargs["setup_channel_id"] is None
     # DM message id still captured.
     assert kwargs["setup_message_id"] == 99001
+
+
+@pytest.mark.asyncio
+async def test_on_guild_join_skips_double_post_on_restart():
+    """If a setup channel already exists with a stored message id, the
+    handler reuses the prior message rather than posting a second one."""
+    from cogs.setup_cog import SetupCog
+
+    bot = MagicMock()
+    cog = SetupCog(bot)
+
+    existing_ch = MagicMock()
+    existing_ch.id = 7000
+    existing_ch.send = AsyncMock()
+    g = _guild(text_channels=[], me=MagicMock(), guild_id=42, name="Test")
+
+    prior_session = SetupSession(
+        guild_id=42,
+        guild_name="Test",
+        owner_id=99,
+        setup_status="in_progress",
+        setup_channel_id=7000,
+        setup_message_id=8000,
+        last_readiness_score=None,
+        current_step=None,
+        delegated_admins=(),
+    )
+
+    with (
+        patch(
+            "cogs.setup_cog.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=prior_session,
+        ),
+        patch(
+            "services.setup_channel.ensure_setup_channel",
+            new_callable=AsyncMock,
+            return_value=(existing_ch, False),  # not just created
+        ),
+        patch(
+            "cogs.setup_cog.setup_session.start_session",
+            new_callable=AsyncMock,
+        ) as start_mock,
+    ):
+        await cog._handle_join(g)
+
+    existing_ch.send.assert_not_awaited()
+    kwargs = start_mock.await_args.kwargs
+    assert kwargs["setup_channel_id"] == 7000
+    assert kwargs["setup_message_id"] == 8000
 
 
 @pytest.mark.asyncio
@@ -268,10 +392,22 @@ async def test_on_guild_join_swallows_handler_failure():
     g.id = 1
     g.name = "x"
 
-    with patch(
-        "cogs.setup_cog.post_launcher",
-        new_callable=AsyncMock,
-        side_effect=RuntimeError("boom"),
+    with (
+        patch(
+            "services.setup_channel.ensure_setup_channel",
+            new_callable=AsyncMock,
+            return_value=(None, False),
+        ),
+        patch(
+            "cogs.setup_cog.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "cogs.setup_cog.post_launcher",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("boom"),
+        ),
     ):
         # Must not raise.
         await cog._handle_join(g)

--- a/tests/unit/cogs/test_setup_cog.py
+++ b/tests/unit/cogs/test_setup_cog.py
@@ -331,8 +331,7 @@ async def test_start_button_refuses_non_owner():
 
     interaction.response.send_message.assert_awaited_once()
     assert (
-        "server owner"
-        in interaction.response.send_message.await_args.args[0].lower()
+        "server owner" in interaction.response.send_message.await_args.args[0].lower()
     )
 
 
@@ -388,8 +387,7 @@ async def test_smart_suggestions_button_owner_only():
 
     interaction.response.send_message.assert_awaited_once()
     assert (
-        "server owner"
-        in interaction.response.send_message.await_args.args[0].lower()
+        "server owner" in interaction.response.send_message.await_args.args[0].lower()
     )
 
 
@@ -443,10 +441,7 @@ async def test_smart_suggestions_opens_ai_review_for_owner():
     interaction.response.send_message.assert_awaited_once()
     sent_view = interaction.response.send_message.await_args.kwargs.get("view")
     assert isinstance(sent_view, AIReviewPanelView)
-    assert (
-        interaction.response.send_message.await_args.kwargs.get("ephemeral")
-        is True
-    )
+    assert interaction.response.send_message.await_args.kwargs.get("ephemeral") is True
     mark_mock.assert_awaited_once()
     assert mark_mock.await_args.kwargs.get("step") == "suggestions"
 
@@ -897,3 +892,370 @@ async def test_resume_launchers_iterates_every_guild_and_isolates_failures():
     # All three guilds processed, the failure on guild 2 did not
     # short-circuit the sweep.
     assert seen_ids == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# Direct entry: !setup prefix command + /setup slash command
+# ---------------------------------------------------------------------------
+
+
+def _mock_ctx(author, guild=None, guild_id: int = 1):
+    """Construct a minimal commands.Context double for prefix-command tests."""
+    if guild is None:
+        guild = MagicMock()
+        guild.id = guild_id
+        guild.name = "Test"
+        guild.owner_id = 99
+    ctx = MagicMock()
+    ctx.author = author
+    ctx.guild = guild
+    ctx.send = AsyncMock()
+    return ctx
+
+
+def _delegated_session(*, owner_id: int = 99, delegated=(42,)) -> SetupSession:
+    return SetupSession(
+        guild_id=1,
+        guild_name="Test",
+        owner_id=owner_id,
+        setup_status="pending",
+        setup_channel_id=None,
+        setup_message_id=None,
+        last_readiness_score=None,
+        current_step=None,
+        delegated_admins=tuple(delegated),
+    )
+
+
+@pytest.mark.asyncio
+async def test_setup_cmd_opens_hub_for_owner():
+    from cogs.setup_cog import SetupCog
+    from views.setup.hub import SetupHubView
+
+    cog = SetupCog(MagicMock())
+    ctx = _mock_ctx(_owner_member())
+
+    with (
+        patch(
+            "cogs.setup_cog.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_delegated_session(),
+        ),
+        patch(
+            "services.setup_draft.count",
+            new_callable=AsyncMock,
+            return_value=0,
+        ),
+        patch(
+            "cogs.setup_cog.setup_session.mark_in_progress",
+            new_callable=AsyncMock,
+        ) as mark_mock,
+    ):
+        await cog.setup_cmd.callback(cog, ctx)
+
+    ctx.send.assert_awaited_once()
+    sent_view = ctx.send.await_args.kwargs.get("view")
+    assert isinstance(sent_view, SetupHubView)
+    mark_mock.assert_awaited_once()
+    assert mark_mock.await_args.kwargs.get("step") == "hub"
+
+
+@pytest.mark.asyncio
+async def test_setup_cmd_starts_session_when_missing():
+    from cogs.setup_cog import SetupCog
+
+    cog = SetupCog(MagicMock())
+    ctx = _mock_ctx(_owner_member())
+
+    with (
+        patch(
+            "cogs.setup_cog.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "cogs.setup_cog.setup_session.start_session",
+            new_callable=AsyncMock,
+            return_value=_delegated_session(),
+        ) as start_mock,
+        patch(
+            "services.setup_draft.count",
+            new_callable=AsyncMock,
+            return_value=0,
+        ),
+        patch(
+            "cogs.setup_cog.setup_session.mark_in_progress",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await cog.setup_cmd.callback(cog, ctx)
+
+    start_mock.assert_awaited_once()
+    ctx.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_setup_cmd_returns_readiness_for_plain_admin():
+    """A Discord administrator with no delegation gets the readiness embed,
+    not the hub — they may scan but not apply."""
+    from cogs.setup_cog import SetupCog
+
+    cog = SetupCog(MagicMock())
+    ctx = _mock_ctx(_admin_member())
+
+    fake_embed = MagicMock()
+    with (
+        patch(
+            "cogs.setup_cog.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_delegated_session(delegated=()),
+        ),
+        patch(
+            "cogs.diagnostic._platform_embeds.build_setup_readiness_embed",
+            new_callable=AsyncMock,
+            return_value=fake_embed,
+        ),
+    ):
+        await cog.setup_cmd.callback(cog, ctx)
+
+    ctx.send.assert_awaited_once()
+    # Readiness path sends an embed but no hub view.
+    assert ctx.send.await_args.kwargs.get("embed") is fake_embed
+    assert ctx.send.await_args.kwargs.get("view") is None
+
+
+@pytest.mark.asyncio
+async def test_setup_cmd_opens_hub_for_delegated_admin():
+    from cogs.setup_cog import SetupCog
+    from views.setup.hub import SetupHubView
+
+    cog = SetupCog(MagicMock())
+    # Delegated admin: not the owner, not a Discord administrator, but
+    # listed in session.delegated_admins.
+    member = _random_member(user_id=42)
+    ctx = _mock_ctx(member)
+
+    with (
+        patch(
+            "cogs.setup_cog.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_delegated_session(delegated=(42,)),
+        ),
+        patch(
+            "services.setup_draft.count",
+            new_callable=AsyncMock,
+            return_value=0,
+        ),
+        patch(
+            "cogs.setup_cog.setup_session.mark_in_progress",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await cog.setup_cmd.callback(cog, ctx)
+
+    sent_view = ctx.send.await_args.kwargs.get("view")
+    assert isinstance(sent_view, SetupHubView)
+
+
+@pytest.mark.asyncio
+async def test_setup_cmd_denies_random_member():
+    from cogs.setup_cog import SetupCog
+
+    cog = SetupCog(MagicMock())
+    ctx = _mock_ctx(_random_member())
+
+    with patch(
+        "cogs.setup_cog.setup_session.resume_session",
+        new_callable=AsyncMock,
+        return_value=_delegated_session(delegated=()),
+    ):
+        await cog.setup_cmd.callback(cog, ctx)
+
+    ctx.send.assert_awaited_once()
+    msg = ctx.send.await_args.args[0]
+    assert "owner" in msg.lower() or "admin" in msg.lower()
+    # Denial path sends a string with no embed/view.
+    assert ctx.send.await_args.kwargs == {}
+
+
+@pytest.mark.asyncio
+async def test_setup_cmd_requires_guild_context():
+    from cogs.setup_cog import SetupCog
+
+    cog = SetupCog(MagicMock())
+    ctx = _mock_ctx(_owner_member(), guild=None)
+    # Author isn't a discord.Member outside a guild — make it a User.
+    ctx.author = MagicMock()  # not isinstance discord.Member
+
+    await cog.setup_cmd.callback(cog, ctx)
+
+    ctx.send.assert_awaited_once()
+    assert "server" in ctx.send.await_args.args[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_setup_slash_opens_hub_for_owner():
+    from cogs.setup_cog import SetupCog
+    from views.setup.hub import SetupHubView
+
+    cog = SetupCog(MagicMock())
+    interaction = _mock_interaction(_owner_member())
+
+    with (
+        patch(
+            "cogs.setup_cog.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_delegated_session(),
+        ),
+        patch(
+            "services.setup_draft.count",
+            new_callable=AsyncMock,
+            return_value=0,
+        ),
+        patch(
+            "cogs.setup_cog.setup_session.mark_in_progress",
+            new_callable=AsyncMock,
+        ) as mark_mock,
+    ):
+        await cog.setup_slash.callback(cog, interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    kwargs = interaction.response.send_message.await_args.kwargs
+    assert kwargs.get("ephemeral") is True
+    assert isinstance(kwargs.get("view"), SetupHubView)
+    mark_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_setup_slash_returns_readiness_for_plain_admin():
+    from cogs.setup_cog import SetupCog
+
+    cog = SetupCog(MagicMock())
+    interaction = _mock_interaction(_admin_member())
+
+    fake_embed = MagicMock()
+    with (
+        patch(
+            "cogs.setup_cog.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_delegated_session(delegated=()),
+        ),
+        patch(
+            "cogs.diagnostic._platform_embeds.build_setup_readiness_embed",
+            new_callable=AsyncMock,
+            return_value=fake_embed,
+        ),
+    ):
+        await cog.setup_slash.callback(cog, interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    kwargs = interaction.response.send_message.await_args.kwargs
+    assert kwargs.get("ephemeral") is True
+    assert kwargs.get("embed") is fake_embed
+    assert "view" not in kwargs or kwargs.get("view") is None
+
+
+# ---------------------------------------------------------------------------
+# Repost launcher button
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_repost_launcher_admin_can_repost():
+    """Admin click reposts launcher in current guild and refreshes session ids."""
+    view = SetupLauncherView()
+    interaction = _mock_interaction(_admin_member())
+    interaction.guild = MagicMock()
+    interaction.guild.id = 1
+    interaction.guild.name = "Test"
+    interaction.guild.owner_id = 99
+
+    fake_channel = MagicMock()
+    fake_channel.id = 7777
+    fake_message = MagicMock()
+    fake_message.id = 9999
+
+    with (
+        patch(
+            "cogs.setup_cog.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_delegated_session(delegated=()),
+        ),
+        patch(
+            "cogs.setup_cog.post_launcher",
+            new_callable=AsyncMock,
+            return_value=(fake_channel, fake_message),
+        ),
+        patch(
+            "cogs.setup_cog.setup_session.start_session",
+            new_callable=AsyncMock,
+        ) as start_mock,
+    ):
+        await view._repost_launcher.callback(interaction)
+
+    start_mock.assert_awaited_once()
+    kwargs = start_mock.await_args.kwargs
+    assert kwargs["setup_channel_id"] == 7777
+    assert kwargs["setup_message_id"] == 9999
+    interaction.response.send_message.assert_awaited_once()
+    assert "7777" in interaction.response.send_message.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_repost_launcher_denies_random_member():
+    view = SetupLauncherView()
+    interaction = _mock_interaction(_random_member())
+
+    with (
+        patch(
+            "cogs.setup_cog.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_delegated_session(delegated=()),
+        ),
+        patch(
+            "cogs.setup_cog.post_launcher",
+            new_callable=AsyncMock,
+        ) as post_mock,
+    ):
+        await view._repost_launcher.callback(interaction)
+
+    post_mock.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_repost_launcher_handles_no_target():
+    """When no channel is sendable AND owner DM is closed, surface a deny."""
+    view = SetupLauncherView()
+    interaction = _mock_interaction(_admin_member())
+    interaction.guild = MagicMock(id=1, name="Test", owner_id=99)
+
+    with (
+        patch(
+            "cogs.setup_cog.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_delegated_session(delegated=()),
+        ),
+        patch(
+            "cogs.setup_cog.post_launcher",
+            new_callable=AsyncMock,
+            return_value=(None, None),
+        ),
+        patch(
+            "cogs.setup_cog.setup_session.start_session",
+            new_callable=AsyncMock,
+        ) as start_mock,
+    ):
+        await view._repost_launcher.callback(interaction)
+
+    start_mock.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "could not" in msg.lower() or "sendable" in msg.lower()
+
+
+def test_launcher_view_has_repost_launcher_button():
+    view = SetupLauncherView()
+    btn = _find_button(view, "setup:repost_launcher")
+    assert btn.label == "Repost launcher"
+    assert btn.row == 1

--- a/tests/unit/cogs/test_setup_cog.py
+++ b/tests/unit/cogs/test_setup_cog.py
@@ -1177,17 +1177,17 @@ async def test_repost_launcher_admin_can_repost():
 
     with (
         patch(
-            "cogs.setup_cog.setup_session.resume_session",
+            "views.setup.launcher.setup_session.resume_session",
             new_callable=AsyncMock,
             return_value=_delegated_session(delegated=()),
         ),
         patch(
-            "cogs.setup_cog.post_launcher",
+            "views.setup.launcher.post_launcher",
             new_callable=AsyncMock,
             return_value=(fake_channel, fake_message),
         ),
         patch(
-            "cogs.setup_cog.setup_session.start_session",
+            "views.setup.launcher.setup_session.start_session",
             new_callable=AsyncMock,
         ) as start_mock,
     ):
@@ -1208,12 +1208,12 @@ async def test_repost_launcher_denies_random_member():
 
     with (
         patch(
-            "cogs.setup_cog.setup_session.resume_session",
+            "views.setup.launcher.setup_session.resume_session",
             new_callable=AsyncMock,
             return_value=_delegated_session(delegated=()),
         ),
         patch(
-            "cogs.setup_cog.post_launcher",
+            "views.setup.launcher.post_launcher",
             new_callable=AsyncMock,
         ) as post_mock,
     ):
@@ -1232,17 +1232,17 @@ async def test_repost_launcher_handles_no_target():
 
     with (
         patch(
-            "cogs.setup_cog.setup_session.resume_session",
+            "views.setup.launcher.setup_session.resume_session",
             new_callable=AsyncMock,
             return_value=_delegated_session(delegated=()),
         ),
         patch(
-            "cogs.setup_cog.post_launcher",
+            "views.setup.launcher.post_launcher",
             new_callable=AsyncMock,
             return_value=(None, None),
         ),
         patch(
-            "cogs.setup_cog.setup_session.start_session",
+            "views.setup.launcher.setup_session.start_session",
             new_callable=AsyncMock,
         ) as start_mock,
     ):

--- a/tests/unit/services/test_server_presets.py
+++ b/tests/unit/services/test_server_presets.py
@@ -34,6 +34,7 @@ from services.automation_templates import (
 def test_documented_preset_slugs():
     assert known_preset_slugs() == {
         "minimal",
+        "existing-safe",
         "community",
         "gaming",
         "moderation-heavy",
@@ -134,6 +135,21 @@ def test_preview_warns_on_unknown_template_slug():
     )
     preview = preview_preset(preset)
     assert any("unknown template slug" in w for w in preview.warnings)
+
+
+def test_existing_safe_preset_binds_only_never_creates():
+    """``existing-safe`` is for servers that already have their own
+    structure: every operation must be ``bind_channel`` — no
+    creates, no role additions, no automation rules."""
+    preset = get_preset("existing-safe")
+    assert preset is not None
+    kinds = {op.kind for op in preset.operations}
+    assert kinds == {"bind_channel"}
+    # Specifically, the rules, mod log, and bot-commands bindings.
+    binding_names = {op.payload.get("binding_name") for op in preset.operations}
+    assert "rules_channel" in binding_names
+    assert "mod_channel" in binding_names
+    assert "bot_command_channel" in binding_names
 
 
 def test_minimal_preset_binds_rules_and_mod_log_only():

--- a/tests/unit/services/test_setup_channel.py
+++ b/tests/unit/services/test_setup_channel.py
@@ -1,0 +1,191 @@
+"""Tests for ``services.setup_channel`` — auto-created private setup channel."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from services.setup_channel import (
+    SETUP_CHANNEL_NAME,
+    ensure_setup_channel,
+)
+
+
+def _make_guild(
+    *,
+    guild_id: int = 1,
+    can_manage_channels: bool = True,
+    me_present: bool = True,
+    owner_present: bool = True,
+    cached_channel: discord.TextChannel | None = None,
+):
+    g = MagicMock(spec=discord.Guild)
+    g.id = guild_id
+    g.name = "Test"
+
+    if me_present:
+        me = MagicMock()
+        me.guild_permissions = SimpleNamespace(manage_channels=can_manage_channels)
+        g.me = me
+    else:
+        g.me = None
+
+    if owner_present:
+        g.owner = MagicMock()
+        g.owner.mention = "<@99>"
+    else:
+        g.owner = None
+
+    g.default_role = MagicMock()
+    g.get_channel = MagicMock(
+        return_value=cached_channel if cached_channel is not None else None,
+    )
+    return g
+
+
+def _make_text_channel(channel_id: int = 7000):
+    ch = MagicMock(spec=discord.TextChannel)
+    ch.id = channel_id
+    ch.name = SETUP_CHANNEL_NAME
+    return ch
+
+
+@pytest.mark.asyncio
+async def test_ensure_setup_channel_creates_when_missing():
+    guild = _make_guild()
+    created = _make_text_channel(7000)
+
+    with patch(
+        "services.setup_channel.ensure_channel",
+        new_callable=AsyncMock,
+        return_value=created,
+    ) as ensure_mock:
+        channel, was_created = await ensure_setup_channel(guild)
+
+    assert channel is created
+    assert was_created is True
+    ensure_mock.assert_awaited_once()
+    kwargs = ensure_mock.await_args.kwargs
+    assert kwargs["kind"] == "text"
+
+
+@pytest.mark.asyncio
+async def test_ensure_setup_channel_reuses_cached_id():
+    """When the caller supplies the prior ``existing_channel_id`` and the
+    guild still has that channel, no creation attempt is made."""
+    cached = _make_text_channel(7000)
+    guild = _make_guild(cached_channel=cached)
+
+    with patch(
+        "services.setup_channel.ensure_channel",
+        new_callable=AsyncMock,
+    ) as ensure_mock:
+        channel, was_created = await ensure_setup_channel(
+            guild,
+            existing_channel_id=7000,
+        )
+
+    assert channel is cached
+    assert was_created is False
+    ensure_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ensure_setup_channel_returns_none_when_no_manage_channels():
+    """Without Manage Channels the bot cannot create; falls back to caller."""
+    guild = _make_guild(can_manage_channels=False)
+
+    with patch(
+        "services.setup_channel.ensure_channel",
+        new_callable=AsyncMock,
+    ) as ensure_mock:
+        channel, was_created = await ensure_setup_channel(guild)
+
+    assert channel is None
+    assert was_created is False
+    ensure_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ensure_setup_channel_returns_none_when_me_missing():
+    """``guild.me`` may be ``None`` for guilds not yet fully resolved."""
+    guild = _make_guild(me_present=False)
+
+    channel, was_created = await ensure_setup_channel(guild)
+
+    assert channel is None
+    assert was_created is False
+
+
+@pytest.mark.asyncio
+async def test_ensure_setup_channel_handles_forbidden_gracefully():
+    guild = _make_guild()
+
+    with patch(
+        "services.setup_channel.ensure_channel",
+        new_callable=AsyncMock,
+        side_effect=discord.Forbidden(MagicMock(), "manage_channels missing"),
+    ):
+        channel, was_created = await ensure_setup_channel(guild)
+
+    assert channel is None
+    assert was_created is False
+
+
+@pytest.mark.asyncio
+async def test_ensure_setup_channel_handles_http_error_gracefully():
+    guild = _make_guild()
+
+    with patch(
+        "services.setup_channel.ensure_channel",
+        new_callable=AsyncMock,
+        side_effect=discord.HTTPException(MagicMock(), "boom"),
+    ):
+        channel, was_created = await ensure_setup_channel(guild)
+
+    assert channel is None
+    assert was_created is False
+
+
+@pytest.mark.asyncio
+async def test_ensure_setup_channel_returns_none_when_helper_yields_non_text():
+    """If ``ensure_channel`` somehow returns a voice/category we refuse."""
+    guild = _make_guild()
+    bad = MagicMock(spec=discord.VoiceChannel)
+
+    with patch(
+        "services.setup_channel.ensure_channel",
+        new_callable=AsyncMock,
+        return_value=bad,
+    ):
+        channel, was_created = await ensure_setup_channel(guild)
+
+    assert channel is None
+    assert was_created is False
+
+
+@pytest.mark.asyncio
+async def test_ensure_setup_channel_passes_private_overwrites():
+    """The ``overwrites`` dict denies @everyone view and grants the bot."""
+    guild = _make_guild()
+    created = _make_text_channel(7000)
+
+    with patch(
+        "services.setup_channel.ensure_channel",
+        new_callable=AsyncMock,
+        return_value=created,
+    ) as ensure_mock:
+        await ensure_setup_channel(guild)
+
+    overwrites = ensure_mock.await_args.kwargs["overwrites"]
+    # @everyone (default_role) must be present with view denied
+    assert guild.default_role in overwrites
+    default_overwrite = overwrites[guild.default_role]
+    assert default_overwrite.view_channel is False
+    # Bot must be granted access
+    assert guild.me in overwrites
+    # Owner must be granted access when present
+    assert guild.owner in overwrites

--- a/tests/unit/services/test_setup_progress.py
+++ b/tests/unit/services/test_setup_progress.py
@@ -1,0 +1,225 @@
+"""Tests for ``services.setup_progress`` — section status computation."""
+
+from __future__ import annotations
+
+import pytest
+
+from services.setup_operations import SetupOperation
+from services.setup_progress import (
+    SectionStatus,
+    badge_for,
+    compute_all,
+    compute_section_status,
+)
+from services.setup_sections import SetupSection
+from services.setup_session import SetupSession
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _noop(_interaction, _hub):  # pragma: no cover — never invoked here
+    return None
+
+
+def _section(slug, op_kinds=()):
+    return SetupSection(
+        slug=slug,
+        label=slug.replace("_", " ").title(),
+        style=None,
+        run=_noop,
+        op_kinds=frozenset(op_kinds),
+    )
+
+
+def _session(
+    *,
+    status="pending",
+    skipped=(),
+    guild_id=1,
+):
+    return SetupSession(
+        guild_id=guild_id,
+        guild_name="Test",
+        owner_id=99,
+        setup_status=status,
+        setup_channel_id=None,
+        setup_message_id=None,
+        last_readiness_score=None,
+        current_step=None,
+        delegated_admins=(),
+        skipped_sections=frozenset(skipped),
+    )
+
+
+def _op(kind, subsystem="mod", *, source=None):
+    metadata = None
+    if source is not None:
+        metadata = {"source": source}
+    return SetupOperation(
+        kind=kind,
+        subsystem=subsystem,
+        binding_name="log",
+        target_id=42,
+        target_name="logs",
+        target_kind="channel",
+        metadata=metadata,
+    )
+
+
+# ---------------------------------------------------------------------------
+# compute_section_status
+# ---------------------------------------------------------------------------
+
+
+def test_not_started_when_no_session_and_no_ops():
+    section = _section("channels", op_kinds={"bind_channel"})
+    progress = compute_section_status(section, session=None, draft_ops=[])
+    assert progress.status is SectionStatus.NOT_STARTED
+    assert progress.pending_ops == 0
+
+
+def test_not_started_when_no_matching_op():
+    section = _section("channels", op_kinds={"bind_channel"})
+    progress = compute_section_status(
+        section,
+        session=_session(),
+        draft_ops=[_op("set_cleanup_policy")],
+    )
+    assert progress.status is SectionStatus.NOT_STARTED
+
+
+def test_customized_when_matching_op_with_non_recommended_source():
+    section = _section("channels", op_kinds={"bind_channel"})
+    progress = compute_section_status(
+        section,
+        session=_session(),
+        draft_ops=[_op("bind_channel", source="manual")],
+    )
+    assert progress.status is SectionStatus.CUSTOMIZED
+    assert progress.pending_ops == 1
+
+
+def test_recommended_when_every_matching_op_is_recommended():
+    section = _section("cleanup", op_kinds={"set_cleanup_policy"})
+    progress = compute_section_status(
+        section,
+        session=_session(),
+        draft_ops=[
+            _op("set_cleanup_policy", source="setup_ux:recommended"),
+            _op("set_cleanup_policy", source="setup_ux:recommended"),
+        ],
+    )
+    assert progress.status is SectionStatus.RECOMMENDED
+    assert progress.pending_ops == 2
+
+
+def test_mixed_sources_falls_back_to_customized():
+    section = _section("cleanup", op_kinds={"set_cleanup_policy"})
+    progress = compute_section_status(
+        section,
+        session=_session(),
+        draft_ops=[
+            _op("set_cleanup_policy", source="setup_ux:recommended"),
+            _op("set_cleanup_policy", source="manual"),
+        ],
+    )
+    assert progress.status is SectionStatus.CUSTOMIZED
+
+
+def test_skipped_wins_over_staged_ops():
+    section = _section("cleanup", op_kinds={"set_cleanup_policy"})
+    progress = compute_section_status(
+        section,
+        session=_session(skipped=["cleanup"]),
+        draft_ops=[_op("set_cleanup_policy")],
+    )
+    assert progress.status is SectionStatus.SKIPPED
+
+
+def test_applied_when_session_complete():
+    section = _section("channels", op_kinds={"bind_channel"})
+    # Draft is empty post-apply; complete session should render as APPLIED.
+    progress = compute_section_status(
+        section,
+        session=_session(status="complete"),
+        draft_ops=[],
+    )
+    assert progress.status is SectionStatus.APPLIED
+
+
+def test_applied_session_with_skipped_slug_still_skipped():
+    """Skipped is the explicit operator declaration; APPLIED is the implicit
+    'session done' state. Skipped should win even after completion."""
+    section = _section("cleanup", op_kinds={"set_cleanup_policy"})
+    progress = compute_section_status(
+        section,
+        session=_session(status="complete", skipped=["cleanup"]),
+        draft_ops=[],
+    )
+    assert progress.status is SectionStatus.SKIPPED
+
+
+def test_read_only_section_falls_to_not_started():
+    """Sections with empty op_kinds never match a draft op; they default
+    to NOT_STARTED unless skipped or applied."""
+    section = _section("server_scan", op_kinds=())
+    progress = compute_section_status(
+        section,
+        session=_session(),
+        draft_ops=[_op("bind_channel")],
+    )
+    assert progress.status is SectionStatus.NOT_STARTED
+
+
+# ---------------------------------------------------------------------------
+# compute_all + badge_for
+# ---------------------------------------------------------------------------
+
+
+def test_compute_all_returns_one_progress_per_section():
+    sections = [
+        _section("channels", op_kinds={"bind_channel"}),
+        _section("cleanup", op_kinds={"set_cleanup_policy"}),
+    ]
+    progresses = compute_all(
+        sections,
+        session=_session(),
+        draft_ops=[_op("set_cleanup_policy", source="setup_ux:recommended")],
+    )
+    by_slug = {p.slug: p.status for p in progresses}
+    assert by_slug == {
+        "channels": SectionStatus.NOT_STARTED,
+        "cleanup": SectionStatus.RECOMMENDED,
+    }
+
+
+def test_compute_all_materialises_generator_once():
+    """A single-pass generator must be consumable across all sections."""
+
+    def gen():
+        yield _op("bind_channel")
+
+    sections = [
+        _section("channels", op_kinds={"bind_channel"}),
+        _section("cleanup", op_kinds={"set_cleanup_policy"}),
+    ]
+    progresses = compute_all(sections, session=_session(), draft_ops=gen())
+    assert progresses[0].status is SectionStatus.CUSTOMIZED
+    assert progresses[1].status is SectionStatus.NOT_STARTED
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        (SectionStatus.NOT_STARTED, "⬜"),
+        (SectionStatus.RECOMMENDED, "✅"),
+        (SectionStatus.CUSTOMIZED, "🟡"),
+        (SectionStatus.SKIPPED, "⚠️"),
+        (SectionStatus.APPLIED, "✅"),
+        (SectionStatus.NEEDS_ATTENTION, "❗"),
+    ],
+)
+def test_badge_for_returns_expected_glyph(status, expected):
+    assert badge_for(status) == expected

--- a/tests/unit/services/test_setup_sections.py
+++ b/tests/unit/services/test_setup_sections.py
@@ -180,3 +180,92 @@ def test_session_step_uses_explicit_step_override():
 
 def test_module_registry_is_a_setup_section_registry():
     assert isinstance(REGISTRY, SetupSectionRegistry)
+
+
+# ---------------------------------------------------------------------------
+# for_depth filtering
+# ---------------------------------------------------------------------------
+
+
+def test_for_depth_returns_only_matching_sections():
+    registry = SetupSectionRegistry()
+    quick_only = _section("quick_only", order=10)
+    quick_only_with_depth = SetupSection(
+        slug=quick_only.slug,
+        label=quick_only.label,
+        style=quick_only.style,
+        run=quick_only.run,
+        order=quick_only.order,
+        depths=frozenset({"quick"}),
+    )
+    standard_only = SetupSection(
+        slug="standard_only",
+        label="Standard Only",
+        style=discord.ButtonStyle.secondary,
+        run=_noop,
+        order=20,
+        depths=frozenset({"standard"}),
+    )
+    universal = SetupSection(
+        slug="universal",
+        label="Universal",
+        style=discord.ButtonStyle.secondary,
+        run=_noop,
+        order=30,
+        depths=frozenset({"quick", "standard", "advanced"}),
+    )
+    registry.register(quick_only_with_depth)
+    registry.register(standard_only)
+    registry.register(universal)
+
+    quick = {s.slug for s in registry.for_depth("quick")}
+    standard = {s.slug for s in registry.for_depth("standard")}
+    advanced = {s.slug for s in registry.for_depth("advanced")}
+
+    assert quick == {"quick_only", "universal"}
+    assert standard == {"standard_only", "universal"}
+    assert advanced == {"universal"}
+
+
+def test_for_depth_none_returns_every_section():
+    """``None`` is the legacy / pre-picker fallback — show everything."""
+    registry = SetupSectionRegistry()
+    registry.register(
+        SetupSection(
+            slug="advanced_only",
+            label="Advanced Only",
+            style=discord.ButtonStyle.secondary,
+            run=_noop,
+            order=10,
+            depths=frozenset({"advanced"}),
+        ),
+    )
+    sections = registry.for_depth(None)
+    assert len(sections) == 1
+
+
+def test_for_depth_is_sorted_consistently_with_all():
+    registry = SetupSectionRegistry()
+    registry.register(
+        SetupSection(
+            slug="z_section",
+            label="Z",
+            style=discord.ButtonStyle.secondary,
+            run=_noop,
+            order=10,
+            depths=frozenset({"standard"}),
+        ),
+    )
+    registry.register(
+        SetupSection(
+            slug="a_section",
+            label="A",
+            style=discord.ButtonStyle.secondary,
+            run=_noop,
+            order=10,
+            depths=frozenset({"standard"}),
+        ),
+    )
+    sections = registry.for_depth("standard")
+    # Order-then-slug means a_section first.
+    assert [s.slug for s in sections] == ["a_section", "z_section"]

--- a/tests/unit/services/test_setup_session.py
+++ b/tests/unit/services/test_setup_session.py
@@ -28,6 +28,7 @@ def _row(**overrides):
         "last_readiness_score": None,
         "current_step": None,
         "delegated_admins": [],
+        "skipped_sections": [],
         "created_at": None,
         "updated_at": None,
     }
@@ -39,7 +40,9 @@ def _row(**overrides):
 def _mock_db():
     with (
         patch("services.setup_session.db.get", new_callable=AsyncMock) as get_mock,
-        patch("services.setup_session.db.upsert", new_callable=AsyncMock) as upsert_mock,
+        patch(
+            "services.setup_session.db.upsert", new_callable=AsyncMock
+        ) as upsert_mock,
         patch(
             "services.setup_session.db.set_status",
             new_callable=AsyncMock,
@@ -52,6 +55,18 @@ def _mock_db():
             "services.setup_session.db.set_readiness_score",
             new_callable=AsyncMock,
         ) as set_score_mock,
+        patch(
+            "services.setup_session.db.add_skipped_section",
+            new_callable=AsyncMock,
+        ) as add_skipped_mock,
+        patch(
+            "services.setup_session.db.remove_skipped_section",
+            new_callable=AsyncMock,
+        ) as remove_skipped_mock,
+        patch(
+            "services.setup_session.db.clear_skipped_sections",
+            new_callable=AsyncMock,
+        ) as clear_skipped_mock,
     ):
         yield {
             "get": get_mock,
@@ -59,6 +74,9 @@ def _mock_db():
             "set_status": set_status_mock,
             "set_step": set_step_mock,
             "set_readiness_score": set_score_mock,
+            "add_skipped_section": add_skipped_mock,
+            "remove_skipped_section": remove_skipped_mock,
+            "clear_skipped_sections": clear_skipped_mock,
         }
 
 
@@ -182,3 +200,45 @@ async def test_mark_complete_tolerates_draft_clear_failure(_mock_db):
 async def test_record_readiness_score_delegates(_mock_db):
     await svc.record_readiness_score(1, 75)
     _mock_db["set_readiness_score"].assert_awaited_once_with(1, 75)
+
+
+# ---------------------------------------------------------------------------
+# Skipped-section tracking
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mark_section_skipped_delegates(_mock_db):
+    await svc.mark_section_skipped(1, "cleanup")
+    _mock_db["add_skipped_section"].assert_awaited_once_with(1, "cleanup")
+
+
+@pytest.mark.asyncio
+async def test_unmark_section_skipped_delegates(_mock_db):
+    await svc.unmark_section_skipped(1, "cleanup")
+    _mock_db["remove_skipped_section"].assert_awaited_once_with(1, "cleanup")
+
+
+@pytest.mark.asyncio
+async def test_mark_complete_clears_skipped_sections(_mock_db):
+    with patch("services.setup_session._clear_draft", new_callable=AsyncMock):
+        await svc.mark_complete(1)
+    _mock_db["clear_skipped_sections"].assert_awaited_once_with(1)
+
+
+@pytest.mark.asyncio
+async def test_dismiss_clears_skipped_sections(_mock_db):
+    with patch("services.setup_session._clear_draft", new_callable=AsyncMock):
+        await svc.dismiss(1)
+    _mock_db["clear_skipped_sections"].assert_awaited_once_with(1)
+
+
+@pytest.mark.asyncio
+async def test_resume_session_hydrates_skipped_sections(_mock_db):
+    _mock_db["get"].return_value = _row(
+        setup_status="in_progress",
+        skipped_sections=["cleanup", "cog_routing"],
+    )
+    session = await svc.resume_session(1)
+    assert session is not None
+    assert session.skipped_sections == frozenset({"cleanup", "cog_routing"})

--- a/tests/unit/views/setup/sections/test_cleanup_section.py
+++ b/tests/unit/views/setup/sections/test_cleanup_section.py
@@ -368,6 +368,8 @@ async def test_stage_does_not_call_apply_operations():
 
 @pytest.mark.asyncio
 async def test_run_rejects_dm_context():
+    """PR 3 routes ``run`` through the section card, which rejects DMs
+    with a 'server'/'guild' phrasing inside its ``show`` helper."""
     interaction = MagicMock()
     interaction.user = SimpleNamespace(id=99)
     interaction.guild = None
@@ -376,15 +378,37 @@ async def test_run_rejects_dm_context():
     await cleanup.run(interaction, MagicMock())
     interaction.response.send_message.assert_awaited_once()
     args = interaction.response.send_message.await_args.args
-    assert "guild" in args[0].lower()
+    assert "server" in args[0].lower() or "guild" in args[0].lower()
 
 
 @pytest.mark.asyncio
-async def test_run_sends_cleanup_panel_in_guild():
+async def test_run_opens_section_card_in_guild():
+    """``run`` now shows the shared section card; the detailed cleanup
+    picker is reachable via the card's Customize button."""
+    from views.setup.section_card import SectionCardView
+
     interaction = _interaction()
-    await cleanup.run(interaction, MagicMock())
+
+    with (
+        patch(
+            "views.setup.section_card.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "views.setup.section_card.setup_draft.list_ops",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "views.setup.section_card.setup_session.mark_in_progress",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await cleanup.run(interaction, MagicMock())
+
     interaction.response.send_message.assert_awaited_once()
     kwargs = interaction.response.send_message.await_args.kwargs
     assert kwargs.get("ephemeral") is True
-    assert isinstance(kwargs["view"], cleanup.CleanupSectionView)
-    assert "Cleanup" in kwargs["embed"].title
+    assert isinstance(kwargs["view"], SectionCardView)
+    assert "Cleanup" in (kwargs["embed"].title or "")

--- a/tests/unit/views/setup/test_depth_panel.py
+++ b/tests/unit/views/setup/test_depth_panel.py
@@ -1,0 +1,137 @@
+"""Tests for ``views.setup.depth_panel`` — wizard depth picker."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from services.setup_session import SetupSession
+from views.setup.depth_panel import DepthPanelView, build_depth_embed
+
+
+def _owner_member(user_id: int = 99):
+    m = MagicMock(spec=discord.Member)
+    m.id = user_id
+    m.guild = SimpleNamespace(owner_id=user_id)
+    m.guild_permissions = SimpleNamespace(administrator=False)
+    return m
+
+
+def _interaction(*, guild_id: int = 1):
+    interaction = MagicMock()
+    interaction.user = _owner_member()
+    interaction.guild_id = guild_id
+    interaction.guild = MagicMock(id=guild_id, name="Test", owner_id=99)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    return interaction
+
+
+def _session(*, depth: str | None = None) -> SetupSession:
+    return SetupSession(
+        guild_id=1,
+        guild_name="Test",
+        owner_id=99,
+        setup_status="pending",
+        setup_channel_id=None,
+        setup_message_id=None,
+        last_readiness_score=None,
+        current_step=None,
+        delegated_admins=(),
+        depth=depth,
+    )
+
+
+def test_depth_embed_lists_three_modes():
+    embed = build_depth_embed()
+    field_names = {(f.name or "").lower() for f in embed.fields}
+    assert any("quick" in n for n in field_names)
+    assert any("standard" in n for n in field_names)
+    assert any("advanced" in n for n in field_names)
+
+
+def test_depth_panel_has_three_buttons():
+    view = DepthPanelView(_owner_member())
+    custom_ids = {
+        c.custom_id for c in view.children if isinstance(c, discord.ui.Button)
+    }
+    assert custom_ids == {"setup_depth:quick", "setup_depth:standard", "setup_depth:advanced"}
+
+
+def test_depth_panel_highlights_current_choice():
+    """When session.depth is set, the matching button is styled in
+    success colour to surface the existing pick."""
+    view = DepthPanelView(_owner_member(), session=_session(depth="standard"))
+    by_id = {
+        c.custom_id: c for c in view.children if isinstance(c, discord.ui.Button)
+    }
+    assert by_id["setup_depth:standard"].style is discord.ButtonStyle.success
+    assert by_id["setup_depth:quick"].style is discord.ButtonStyle.secondary
+    assert by_id["setup_depth:advanced"].style is discord.ButtonStyle.secondary
+
+
+@pytest.mark.asyncio
+async def test_depth_panel_select_persists_and_opens_hub():
+    """Clicking a depth button persists it and edits the message to
+    the hub view in place."""
+    from views.setup.hub import SetupHubView
+
+    view = DepthPanelView(_owner_member(), session=_session())
+    interaction = _interaction()
+
+    with (
+        patch(
+            "views.setup.depth_panel.setup_session.set_depth",
+            new_callable=AsyncMock,
+        ) as set_depth_mock,
+        patch(
+            "views.setup.depth_panel.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_session(depth="standard"),
+        ),
+        patch(
+            "services.setup_draft.list_ops",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+    ):
+        await view._select(interaction, "standard")
+
+    set_depth_mock.assert_awaited_once_with(1, "standard")
+    interaction.response.edit_message.assert_awaited_once()
+    kwargs = interaction.response.edit_message.await_args.kwargs
+    assert isinstance(kwargs.get("view"), SetupHubView)
+
+
+@pytest.mark.asyncio
+async def test_depth_panel_select_handles_set_depth_failure():
+    view = DepthPanelView(_owner_member(), session=_session())
+    interaction = _interaction()
+
+    with patch(
+        "views.setup.depth_panel.setup_session.set_depth",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("db down"),
+    ):
+        await view._select(interaction, "quick")
+
+    interaction.response.send_message.assert_awaited_once()
+    interaction.response.edit_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_depth_panel_select_requires_guild_context():
+    view = DepthPanelView(_owner_member(), session=_session())
+    interaction = _interaction()
+    interaction.guild = None
+    interaction.guild_id = None
+
+    await view._select(interaction, "quick")
+
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "guild" in msg.lower()

--- a/tests/unit/views/setup/test_section_card.py
+++ b/tests/unit/views/setup/test_section_card.py
@@ -1,0 +1,362 @@
+"""Tests for ``views.setup.section_card`` — shared section panel."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+import views.setup.sections  # noqa: F401 — populate REGISTRY for tests
+from services.setup_operations import SetupOperation
+from services.setup_progress import SectionProgress, SectionStatus
+from services.setup_sections import REGISTRY, SetupSection
+from views.setup.section_card import SectionCardView, build_section_card, show
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _noop_run(_interaction, _hub):  # pragma: no cover — not exercised here
+    return None
+
+
+def _section(slug="cleanup", *, description_if_skipped="", emoji="🧹"):
+    return SetupSection(
+        slug=slug,
+        label=slug.replace("_", " ").title(),
+        style=discord.ButtonStyle.secondary,
+        run=_noop_run,
+        emoji=emoji,
+        order=60,
+        op_kinds=frozenset({"set_cleanup_policy"}),
+        description_if_skipped=description_if_skipped,
+    )
+
+
+def _progress(*, status=SectionStatus.NOT_STARTED, pending_ops=0, slug="cleanup"):
+    return SectionProgress(slug=slug, status=status, pending_ops=pending_ops)
+
+
+def _owner_member(user_id: int = 99):
+    m = MagicMock(spec=discord.Member)
+    m.id = user_id
+    m.guild = SimpleNamespace(owner_id=user_id)
+    m.guild_permissions = SimpleNamespace(administrator=False)
+    return m
+
+
+def _interaction_with_guild(user, *, guild_id: int = 1):
+    interaction = MagicMock()
+    interaction.user = user
+    interaction.guild_id = guild_id
+    interaction.guild = MagicMock(id=guild_id, name="Test", owner_id=99)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+    return interaction
+
+
+# ---------------------------------------------------------------------------
+# build_section_card embed
+# ---------------------------------------------------------------------------
+
+
+def test_card_embed_includes_step_and_status():
+    """Section registered in REGISTRY (production sections always are) gets
+    a 'Step N of M' header derived from registry order."""
+    # The production cleanup section is registered; use its real registered
+    # SetupSection so the step index resolves.
+    section = REGISTRY.get("cleanup")
+    assert section is not None
+    progress = _progress()
+    embed = build_section_card(
+        section=section,
+        progress=progress,
+        detected_state="Resolver walks thread → channel → category → guild.",
+        has_recommended=True,
+        has_customize=True,
+    )
+    title = embed.title or ""
+    assert "Cleanup" in title
+    description = embed.description or ""
+    assert "Step" in description
+    assert "Not started" in description
+
+
+def test_card_embed_unregistered_section_omits_step():
+    """Sections constructed in tests (not in REGISTRY) just show the badge."""
+    section = _section(slug="not_registered")
+    progress = _progress(slug="not_registered")
+    embed = build_section_card(
+        section=section,
+        progress=progress,
+        detected_state="",
+        has_recommended=True,
+        has_customize=True,
+    )
+    description = embed.description or ""
+    assert "Step" not in description
+    assert "Not started" in description
+
+
+def test_card_embed_renders_skip_impact_when_present():
+    section = _section(description_if_skipped="Cleanup stays at the current default.")
+    embed = build_section_card(
+        section=section,
+        progress=_progress(),
+        detected_state="",
+        has_recommended=True,
+        has_customize=True,
+    )
+    fields = {(f.name or "").lower(): (f.value or "") for f in embed.fields}
+    assert "if you skip this" in fields
+    assert "current default" in fields["if you skip this"].lower()
+
+
+def test_card_embed_omits_skip_impact_when_empty():
+    section = _section(description_if_skipped="")
+    embed = build_section_card(
+        section=section,
+        progress=_progress(),
+        detected_state="",
+        has_recommended=True,
+        has_customize=True,
+    )
+    fields = {(f.name or "").lower() for f in embed.fields}
+    assert "if you skip this" not in fields
+
+
+def test_card_embed_surfaces_pending_op_count():
+    embed = build_section_card(
+        section=_section(),
+        progress=_progress(status=SectionStatus.CUSTOMIZED, pending_ops=3),
+        detected_state="",
+        has_recommended=True,
+        has_customize=True,
+    )
+    fields = {(f.name or "").lower(): (f.value or "") for f in embed.fields}
+    assert "pending" in fields
+    assert "3 operations" in fields["pending"]
+
+
+def test_card_embed_explains_when_no_recommended_action():
+    embed = build_section_card(
+        section=_section(),
+        progress=_progress(),
+        detected_state="",
+        has_recommended=False,
+        has_customize=True,
+    )
+    fields = {(f.name or "").lower(): (f.value or "") for f in embed.fields}
+    assert "recommended action" in fields
+    assert "no recommended" in fields["recommended action"].lower()
+
+
+# ---------------------------------------------------------------------------
+# SectionCardView buttons
+# ---------------------------------------------------------------------------
+
+
+def test_view_disables_apply_recommended_when_no_builder():
+    section = _section()
+    view = SectionCardView(
+        _owner_member(),
+        section=section,
+        hub=None,
+        on_customize=_noop_run,
+        recommended_ops_builder=None,
+    )
+    apply_btn = next(c for c in view.children if c.label == "Apply Recommended")
+    assert apply_btn.disabled is True
+
+
+def test_view_disables_customize_when_no_callback():
+    section = _section()
+    view = SectionCardView(
+        _owner_member(),
+        section=section,
+        hub=None,
+        on_customize=None,
+        recommended_ops_builder=lambda g: [],
+    )
+    customize_btn = next(c for c in view.children if c.label == "Customize")
+    assert customize_btn.disabled is True
+
+
+def test_view_has_skip_and_hub_buttons():
+    view = SectionCardView(
+        _owner_member(),
+        section=_section(),
+        hub=None,
+        on_customize=_noop_run,
+        recommended_ops_builder=lambda g: [],
+    )
+    labels = {c.label for c in view.children}
+    assert "Skip" in labels
+    assert "↩ Hub" in labels
+
+
+@pytest.mark.asyncio
+async def test_apply_recommended_stages_ops_with_recommended_source():
+    section = _section()
+    ops = [
+        SetupOperation(
+            kind="set_cleanup_policy",
+            subsystem="cleanup",
+            target_kind="guild",
+            target_id=1,
+            value="Light",
+        ),
+    ]
+    view = SectionCardView(
+        _owner_member(),
+        section=section,
+        hub=None,
+        on_customize=_noop_run,
+        recommended_ops_builder=lambda g: ops,
+    )
+    interaction = _interaction_with_guild(_owner_member())
+
+    with (
+        patch(
+            "views.setup.section_card.setup_draft.append",
+            new_callable=AsyncMock,
+        ) as append_mock,
+        patch(
+            "views.setup.section_card.setup_session.unmark_section_skipped",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await view._apply_recommended(interaction)
+
+    append_mock.assert_awaited_once()
+    metadata = append_mock.await_args.kwargs["metadata"]
+    assert metadata["source"] == "setup_ux:recommended"
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "1 recommended operation" in msg
+
+
+@pytest.mark.asyncio
+async def test_apply_recommended_handles_empty_builder_output():
+    view = SectionCardView(
+        _owner_member(),
+        section=_section(),
+        hub=None,
+        on_customize=_noop_run,
+        recommended_ops_builder=lambda g: [],
+    )
+    interaction = _interaction_with_guild(_owner_member())
+
+    with patch(
+        "views.setup.section_card.setup_draft.append",
+        new_callable=AsyncMock,
+    ) as append_mock:
+        await view._apply_recommended(interaction)
+
+    append_mock.assert_not_awaited()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "no recommended" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_skip_marks_section_skipped():
+    view = SectionCardView(
+        _owner_member(),
+        section=_section(),
+        hub=None,
+        on_customize=_noop_run,
+        recommended_ops_builder=lambda g: [],
+    )
+    interaction = _interaction_with_guild(_owner_member())
+
+    with patch(
+        "views.setup.section_card.setup_session.mark_section_skipped",
+        new_callable=AsyncMock,
+    ) as skip_mock:
+        await view._skip(interaction)
+
+    skip_mock.assert_awaited_once_with(1, "cleanup")
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "skipped" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_customize_calls_supplied_callback():
+    seen = []
+
+    async def fake_customize(interaction, hub):
+        seen.append((interaction, hub))
+
+    view = SectionCardView(
+        _owner_member(),
+        section=_section(),
+        hub=None,
+        on_customize=fake_customize,
+        recommended_ops_builder=lambda g: [],
+    )
+    interaction = _interaction_with_guild(_owner_member())
+
+    await view._customize(interaction)
+
+    assert len(seen) == 1
+    assert seen[0][0] is interaction
+
+
+# ---------------------------------------------------------------------------
+# show() entry point
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_show_posts_ephemeral_card_and_marks_step():
+    section = _section()
+    interaction = _interaction_with_guild(_owner_member())
+
+    with (
+        patch(
+            "views.setup.section_card.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "views.setup.section_card.setup_draft.list_ops",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "views.setup.section_card.setup_session.mark_in_progress",
+            new_callable=AsyncMock,
+        ) as mark_mock,
+    ):
+        await show(
+            interaction,
+            hub=None,
+            section=section,
+            detected_state="Test",
+            on_customize=_noop_run,
+            recommended_ops_builder=lambda g: [],
+        )
+
+    interaction.response.send_message.assert_awaited_once()
+    kwargs = interaction.response.send_message.await_args.kwargs
+    assert kwargs.get("ephemeral") is True
+    assert isinstance(kwargs.get("view"), SectionCardView)
+    mark_mock.assert_awaited_once()
+    assert mark_mock.await_args.kwargs.get("step") == "cleanup"
+
+
+# ---------------------------------------------------------------------------
+# Cleanup section integration — it is now wired through the card
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_section_registers_description_if_skipped():
+    """The cleanup registration must carry a non-empty skip-impact string
+    so PR 3's section card can surface it without code changes."""
+    section = REGISTRY.get("cleanup")
+    assert section is not None
+    assert "cleanup" in section.description_if_skipped.lower()

--- a/tests/unit/views/setup/test_summary_view.py
+++ b/tests/unit/views/setup/test_summary_view.py
@@ -142,6 +142,48 @@ async def test_summary_view_close_button_disables_and_edits():
         assert getattr(child, "disabled", False) is True
 
 
+@pytest.mark.asyncio
+async def test_summary_view_open_settings_swaps_to_settings_hub():
+    """The new handoff button replaces the summary embed/view with the
+    Settings Manager hub in place — operators stay anchored to one
+    message across the cog transition."""
+    from views.settings.hub import SettingsHubView
+
+    view = SummaryView(_author(), snapshot=SummarySnapshot())
+    interaction = _interaction()
+    await view._open_settings.callback(interaction)
+    interaction.response.edit_message.assert_awaited_once()
+    kwargs = interaction.response.edit_message.await_args.kwargs
+    assert isinstance(kwargs.get("view"), SettingsHubView)
+    assert kwargs.get("embed") is not None
+
+
+@pytest.mark.asyncio
+async def test_summary_view_open_settings_falls_back_when_hub_unavailable():
+    """If SettingsHubView construction blows up the user sees an
+    ephemeral fallback pointing at ``!settings`` instead of a crash."""
+    view = SummaryView(_author(), snapshot=SummarySnapshot())
+    interaction = _interaction()
+    interaction.response.send_message = AsyncMock()
+
+    with patch(
+        "views.settings.hub.SettingsHubView",
+        side_effect=RuntimeError("hub down"),
+    ):
+        await view._open_settings.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "!settings" in msg.lower()
+
+
+def test_summary_view_has_open_settings_button():
+    view = SummaryView(_author(), snapshot=SummarySnapshot())
+    labels = {getattr(c, "label", None) for c in view.children}
+    assert "Open Settings Manager" in labels
+    assert "Close" in labels
+
+
 # ---------------------------------------------------------------------------
 # build_summary_snapshot
 # ---------------------------------------------------------------------------

--- a/tests/unit/views/setup/test_wizard_hub.py
+++ b/tests/unit/views/setup/test_wizard_hub.py
@@ -134,6 +134,67 @@ def test_build_hub_embed_shows_zero_pending_when_drafts_empty():
     assert "0" in description
 
 
+def test_build_hub_embed_renders_section_status_badges_when_draft_ops_provided():
+    """When ``draft_ops`` is passed, every Sections-field row gets a status
+    glyph; sections with matching staged ops show their op count."""
+    from services.setup_operations import SetupOperation
+
+    ops = [
+        SetupOperation(
+            kind="set_cleanup_policy",
+            subsystem="cleanup",
+            metadata={"source": "setup_ux:recommended"},
+        ),
+    ]
+    embed = build_hub_embed(None, pending_ops=1, draft_ops=ops)
+    sections_field = next(
+        f for f in embed.fields if (f.name or "").lower() == "sections"
+    )
+    value = sections_field.value or ""
+    # Cleanup row shows the recommended badge and a pending-op hint.
+    assert "Cleanup" in value
+    assert "✅" in value
+    assert "pending" in value
+
+
+def test_build_hub_embed_without_draft_ops_falls_back_to_legacy_layout():
+    """Existing callers that don't pass ``draft_ops`` see the original
+    numbered-label list with no badges."""
+    embed = build_hub_embed(None, pending_ops=0)
+    sections_field = next(
+        f for f in embed.fields if (f.name or "").lower() == "sections"
+    )
+    value = sections_field.value or ""
+    # No badge glyphs from the new layout — Cleanup still appears, but
+    # without ⬜/✅/🟡 prefixes.
+    assert "Cleanup" in value
+    assert "⬜" not in value
+    assert "✅" not in value
+
+
+def test_build_hub_embed_marks_skipped_sections_with_warning_badge():
+    """A section slug in ``session.skipped_sections`` renders as SKIPPED
+    even when no draft ops match its op_kinds."""
+    session = SetupSession(
+        guild_id=1,
+        guild_name="x",
+        owner_id=99,
+        setup_status="in_progress",
+        setup_channel_id=None,
+        setup_message_id=None,
+        last_readiness_score=None,
+        current_step=None,
+        delegated_admins=(),
+        skipped_sections=frozenset({"cleanup"}),
+    )
+    embed = build_hub_embed(session, pending_ops=0, draft_ops=[])
+    sections_field = next(
+        f for f in embed.fields if (f.name or "").lower() == "sections"
+    )
+    value = sections_field.value or ""
+    assert "⚠️" in value
+
+
 @pytest.mark.asyncio
 async def test_hub_readiness_button_owner_only():
     view = SetupHubView(_other_member())
@@ -230,9 +291,9 @@ def test_hub_renders_one_button_per_registered_section():
         if isinstance(item, discord.ui.Button)
         and (item.custom_id or "").startswith("setup_section:")
     }
-    assert registered <= rendered, (
-        f"hub missing registered sections: {registered - rendered}"
-    )
+    assert (
+        registered <= rendered
+    ), f"hub missing registered sections: {registered - rendered}"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

First two steps of the Setup Wizard UX overhaul outlined in
`/root/.claude/plans/use-this-prompt-for-expressive-steele.md`. Stacks
cleanly on PR #233 (draft-first foundation) and #234 (cleanup/routing
dispatch). Two atomic commits — each independently tested.

### Commit 1 — Direct entry + launcher recovery (`a5cd276`)

Setup was previously only reachable through the persistent launcher
message. Deleting that message stranded setup until the next
`on_guild_join`, and testing required re-inviting the bot.

- `!setup` prefix command and `/setup` slash command on `SetupCog`,
  routing through the existing `services.setup_access` access ladder
  (owner / delegated admin → hub; plain administrator → readiness
  embed; everyone else denied).
- New admin-gated "Repost launcher" button on `SetupLauncherView`
  reuses `post_launcher` + the idempotent `start_session` upsert to
  refresh the session's `setup_channel_id` / `setup_message_id`.
- New module-level helper `_resolve_hub_entry(member, guild)` keeps
  the access logic and hub/readiness branching in one place; both
  commands and the existing `_start` button now share it indirectly.

### Commit 2 — Per-section status badges + skipped tracking (`473e7ee`)

Operators previously saw a plain numbered list of section labels and
had no idea which were touched, skipped, or applied. This commit lays
the foundation for staged navigation:

- New `services.setup_progress` module computes a per-section
  `SectionStatus` (NOT_STARTED / RECOMMENDED / CUSTOMIZED / SKIPPED /
  APPLIED / NEEDS_ATTENTION) from the resolved session + the staged
  draft ops. Pure, deterministic, no Discord I/O.
- `SetupSection` gains `op_kinds: frozenset[str]` and
  `description_if_skipped: str` (the latter is populated in the
  follow-up section-card PR). `channels`, `cleanup`, and `cog_routing`
  declare their `op_kinds` today; read-only or shared-kind sections
  keep the default empty.
- New `setup_session.skipped_sections TEXT[]` column (migration 037)
  with idempotent `add_skipped_section` / `remove_skipped_section` /
  `clear_skipped_sections` primitives. Wrapped at the service layer
  by `mark_section_skipped` / `unmark_section_skipped`. `mark_complete`
  and `dismiss` clear the set so a re-run starts fresh.
- `build_hub_embed` accepts an optional `draft_ops` iterable; when
  provided it renders status glyphs and pending-op counts per section.
  Legacy callers (no `draft_ops`) keep the original layout. The
  `_start` button, the new `!setup`/`/setup` commands, and the
  hub-entry helper all pass `draft_ops` so the badges surface
  immediately.

### Constraint preservation

- No new SetupOperation kinds, no new dispatcher arms.
- Final Review remains the only apply gate.
- Sections still stage drafts; no DB writes from views or commands.
- Discord resource creation continues to flow through
  `ResourceProvisioningPipeline` (the Repost button reuses
  `post_launcher`, which is the existing canonical path).

## Test plan

- [x] `pytest tests/unit/cogs/ tests/unit/services/ tests/unit/views/setup/ tests/unit/db/test_setup_session.py` — 1637 passed
- [x] `ruff check disbot/...` — clean
- [x] `black --check disbot/...` — clean
- [x] `isort --check-only disbot/...` — clean
- [x] `mypy disbot/...` — clean on changed files
- [ ] Manual smoke (deferred to post-merge): `!setup` from a non-bot channel; `/setup` from any channel; delete launcher message → click Repost launcher; stage a `bind_channel` op → confirm yellow badge on hub; mark section skipped → confirm warning badge.

## Follow-ups on this branch

The next push will start the section-card sweep (PR 3 in the plan):
each section's `run` callback converted from "post a new ephemeral"
to "edit the hub message in place" via
`views.navigation.transition_to`, with an `[Apply Recommended] /
[Customize] / [Skip]` button row and the `description_if_skipped`
text per section.

https://claude.ai/code/session_01JMfLzC1f7woiePzWUj55kg

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMfLzC1f7woiePzWUj55kg)_