### PR TITLE
feat(setup): hub 'Apply all recommended' one-click batch staging

### DIFF
--- a/disbot/services/setup_sections.py
+++ b/disbot/services/setup_sections.py
@@ -74,6 +74,13 @@ class SetupSection:
             Default is all three depths so unmigrated sections remain
             visible everywhere; sections opt into a narrower scope
             (e.g. quick-only or advanced-only) at registration.
+        recommended_ops_builder: Optional async callable that returns
+            the section's recommended :class:`SetupOperation` bundle
+            given the live guild. When set, the hub's "Apply all
+            recommended" button picks it up so operators can stage
+            every section's safe default in one click. ``None`` means
+            the section has no auto-recommended path; operators must
+            customise it manually.
     """
 
     slug: str
@@ -86,6 +93,7 @@ class SetupSection:
     op_kinds: frozenset[str] = frozenset()
     description_if_skipped: str = ""
     depths: frozenset[str] = frozenset({"quick", "standard", "advanced"})
+    recommended_ops_builder: Any = None  # async (Guild) -> list[SetupOperation]
 
     @property
     def session_step(self) -> str:

--- a/disbot/views/setup/hub.py
+++ b/disbot/views/setup/hub.py
@@ -170,9 +170,106 @@ class SetupHubView(BaseView):
         super().__init__(author, public=public, timeout=timeout)
         self.session = session
         depth = session.depth if session is not None else None
-        for section in REGISTRY.for_depth(depth):
+        depth_sections = REGISTRY.for_depth(depth)
+        for section in depth_sections:
             self.add_item(self._build_section_button(section))
+        if any(s.recommended_ops_builder is not None for s in depth_sections):
+            self.add_item(self._build_apply_all_recommended_button())
         self.add_item(self._build_change_depth_button())
+
+    def _build_apply_all_recommended_button(self) -> discord.ui.Button:
+        button: discord.ui.Button = discord.ui.Button(  # type: ignore[var-annotated]
+            label="Apply all recommended",
+            style=discord.ButtonStyle.success,
+            custom_id="setup_hub:apply_all_recommended",
+            row=4,
+        )
+
+        async def _callback(interaction: discord.Interaction) -> None:
+            if not await self._gate_owner(interaction):
+                return
+            if interaction.guild is None or interaction.guild_id is None:
+                await interaction.response.send_message(
+                    "Apply all recommended requires a guild context.",
+                    ephemeral=True,
+                )
+                return
+
+            await self._refresh_session()
+            depth_now = self.session.depth if self.session is not None else None
+            sections = [
+                s
+                for s in REGISTRY.for_depth(depth_now)
+                if s.recommended_ops_builder is not None
+            ]
+            if not sections:
+                await interaction.response.send_message(
+                    "No section in the current depth has a recommended "
+                    "default — pick sections individually instead.",
+                    ephemeral=True,
+                )
+                return
+
+            from core.runtime.interaction_helpers import safe_defer
+
+            if not await safe_defer(interaction, ephemeral=True, thinking=True):
+                return
+            from services import setup_draft
+
+            section_totals: dict[str, int] = {}
+            for section in sections:
+                builder = section.recommended_ops_builder
+                if builder is None:
+                    continue
+                try:
+                    ops = await builder(interaction.guild)
+                except Exception:
+                    logger.exception(
+                        "hub.apply_all_recommended: builder failed (slug=%s)",
+                        section.slug,
+                    )
+                    continue
+                staged = 0
+                for op in ops:
+                    try:
+                        await setup_draft.append(
+                            op,
+                            guild_id=interaction.guild_id,
+                            actor_id=interaction.user.id,
+                            label=f"[apply-all] {section.slug}.{op.kind}",
+                            metadata={"source": "setup_ux:recommended"},
+                        )
+                        staged += 1
+                    except Exception:
+                        logger.exception(
+                            "hub.apply_all_recommended: append failed",
+                        )
+                if staged:
+                    section_totals[section.slug] = staged
+
+            if not section_totals:
+                await interaction.followup.send(
+                    "No recommended operations were generated. Most likely "
+                    "the guild has no high-confidence channel matches or "
+                    "an existing default already covers every section.",
+                    ephemeral=True,
+                )
+                return
+            total = sum(section_totals.values())
+            lines = "\n".join(
+                f"• `{slug}`: **{count}** op(s)"
+                for slug, count in section_totals.items()
+            )
+            word = "operation" if total == 1 else "operations"
+            await interaction.followup.send(
+                f"✅ Staged **{total} {word}** across "
+                f"{len(section_totals)} section(s). Open Final review "
+                f"to apply.\n\n{lines}",
+                ephemeral=True,
+            )
+
+        button.callback = _callback  # type: ignore[method-assign]
+        return button
 
     def _build_change_depth_button(self) -> discord.ui.Button:
         button: discord.ui.Button = discord.ui.Button(  # type: ignore[var-annotated]

--- a/disbot/views/setup/section_card.py
+++ b/disbot/views/setup/section_card.py
@@ -345,7 +345,20 @@ async def show(
     reflects today's progress. The card view captures the supplied
     callbacks so each section can plug in its own detail view and
     recommended-ops builder.
+
+    When ``recommended_ops_builder`` is not passed and
+    ``section.recommended_ops_builder`` is set, the field's value is
+    used as a fallback. This lets sections declare the builder once
+    on their ``SetupSection`` registration and have both the hub's
+    "Apply all recommended" button and the card's "Apply Recommended"
+    button reach the same builder without duplicate wiring.
     """
+    if recommended_ops_builder is None:
+        recommended_ops_builder = getattr(
+            section,
+            "recommended_ops_builder",
+            None,
+        )
     guild = interaction.guild
     member = interaction.user
     if guild is None or interaction.guild_id is None:

--- a/disbot/views/setup/sections/channels.py
+++ b/disbot/views/setup/sections/channels.py
@@ -571,6 +571,7 @@ REGISTRY.register(
             "`!settings`."
         ),
         depths=frozenset({"standard", "advanced"}),
+        recommended_ops_builder=_recommended_channel_ops,
     ),
 )
 

--- a/disbot/views/setup/sections/channels.py
+++ b/disbot/views/setup/sections/channels.py
@@ -546,13 +546,15 @@ async def run(interaction: discord.Interaction, hub: SetupHubView) -> None:
         "guild snapshot. Apply Recommended only stages high-confidence "
         "picks; use Customize to choose manually."
     )
+    # ``recommended_ops_builder`` is read from the registered
+    # ``SetupSection`` field by ``section_card.show`` — no need to
+    # pass it explicitly here.
     await show(
         interaction,
         hub=hub,
         section=REGISTRY.get(SLUG),  # type: ignore[arg-type]
         detected_state=detected,
         on_customize=_customize_run,
-        recommended_ops_builder=_recommended_channel_ops,
     )
 
 

--- a/disbot/views/setup/sections/cleanup.py
+++ b/disbot/views/setup/sections/cleanup.py
@@ -539,13 +539,15 @@ async def run(interaction: discord.Interaction, hub: SetupHubView) -> None:
     from views.setup.section_card import show
 
     detected = "Resolver walks thread → channel → category → guild → default."
+    # ``recommended_ops_builder`` is read from the registered
+    # ``SetupSection`` field by ``section_card.show`` — no need to
+    # pass it explicitly here.
     await show(
         interaction,
         hub=hub,
         section=REGISTRY.get(SLUG),  # type: ignore[arg-type]
         detected_state=detected,
         on_customize=_customize_run,
-        recommended_ops_builder=_recommended_cleanup_ops,
     )
 
 

--- a/disbot/views/setup/sections/cleanup.py
+++ b/disbot/views/setup/sections/cleanup.py
@@ -564,6 +564,7 @@ REGISTRY.register(
             "so. You can revisit cleanup later from `!settings`."
         ),
         depths=frozenset({"standard", "advanced"}),
+        recommended_ops_builder=_recommended_cleanup_ops,
     ),
 )
 

--- a/tests/unit/views/setup/test_wizard_hub.py
+++ b/tests/unit/views/setup/test_wizard_hub.py
@@ -576,3 +576,206 @@ async def test_final_review_apply_partial_success_renders_applied_failed_skipped
     assert "Applied **1**" in desc
     assert "failed **1**" in desc
     assert "skipped **1**" in desc
+
+
+# ---------------------------------------------------------------------------
+# "Apply all recommended" hub button
+# ---------------------------------------------------------------------------
+
+
+def _find_button(view, custom_id: str):
+    for child in view.children:
+        if isinstance(child, discord.ui.Button) and child.custom_id == custom_id:
+            return child
+    return None
+
+
+def test_apply_all_recommended_button_appears_when_section_has_builder():
+    """If any depth-filtered section declares a recommended_ops_builder,
+    the hub renders the "Apply all recommended" button on row 4."""
+    session = SetupSession(
+        guild_id=1,
+        guild_name="x",
+        owner_id=99,
+        setup_status="in_progress",
+        setup_channel_id=None,
+        setup_message_id=None,
+        last_readiness_score=None,
+        current_step=None,
+        delegated_admins=(),
+        depth="standard",  # standard includes cleanup + channels
+    )
+    view = SetupHubView(_owner_member(), session=session)
+    btn = _find_button(view, "setup_hub:apply_all_recommended")
+    assert btn is not None
+    assert btn.label == "Apply all recommended"
+    assert btn.row == 4
+
+
+def test_apply_all_recommended_button_absent_when_no_builders():
+    """If no section in the depth has a recommended_ops_builder (e.g.
+    a depth that only includes read-only sections), the button is
+    omitted from the hub."""
+    from unittest.mock import patch
+
+    from services.setup_sections import REGISTRY
+
+    # Patch the registry's for_depth to return only sections without
+    # builders. We use server_scan (read-only, no builder).
+    server_scan = REGISTRY.get("server_scan")
+    if server_scan is None:
+        pytest.skip("server_scan section not registered")
+
+    session = SetupSession(
+        guild_id=1,
+        guild_name="x",
+        owner_id=99,
+        setup_status="in_progress",
+        setup_channel_id=None,
+        setup_message_id=None,
+        last_readiness_score=None,
+        current_step=None,
+        delegated_admins=(),
+        depth="standard",
+    )
+    with patch.object(REGISTRY, "for_depth", return_value=[server_scan]):
+        view = SetupHubView(_owner_member(), session=session)
+    btn = _find_button(view, "setup_hub:apply_all_recommended")
+    assert btn is None
+
+
+@pytest.mark.asyncio
+async def test_apply_all_recommended_iterates_sections_and_stages_ops():
+    """Clicking the button calls every depth-filtered section's
+    recommended_ops_builder and stages each returned op via
+    setup_draft.append with metadata.source='setup_ux:recommended'."""
+    from services.setup_operations import SetupOperation
+    from services.setup_sections import REGISTRY, SetupSection
+
+    async def _build(_guild):
+        return [
+            SetupOperation(
+                kind="set_cleanup_policy",
+                subsystem="cleanup",
+                target_kind="guild",
+                target_id=1,
+                value="Light",
+            ),
+        ]
+
+    async def _section_run(_interaction, _hub):
+        return None
+
+    fake_section = SetupSection(
+        slug="_fake_apply_all",
+        label="Fake",
+        style=discord.ButtonStyle.secondary,
+        run=_section_run,
+        order=999,
+        depths=frozenset({"standard"}),
+        recommended_ops_builder=_build,
+    )
+
+    session = SetupSession(
+        guild_id=1,
+        guild_name="x",
+        owner_id=99,
+        setup_status="in_progress",
+        setup_channel_id=None,
+        setup_message_id=None,
+        last_readiness_score=None,
+        current_step=None,
+        delegated_admins=(),
+        depth="standard",
+    )
+
+    with patch.object(REGISTRY, "for_depth", return_value=[fake_section]):
+        view = SetupHubView(_owner_member(), session=session)
+        button = _find_button(view, "setup_hub:apply_all_recommended")
+        assert button is not None
+        interaction = _interaction(_owner_member())
+        interaction.guild = MagicMock(id=1)
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+        with (
+            patch.object(
+                view,
+                "_refresh_session",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "services.setup_draft.append",
+                new_callable=AsyncMock,
+                return_value=1,
+            ) as append_mock,
+        ):
+            await button.callback(interaction)
+
+    assert append_mock.await_count == 1
+    metadata = append_mock.await_args.kwargs["metadata"]
+    assert metadata["source"] == "setup_ux:recommended"
+    interaction.followup.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_apply_all_recommended_handles_empty_builder_output():
+    """If every builder returns an empty list, the followup tells the
+    operator nothing was staged."""
+    from services.setup_sections import REGISTRY, SetupSection
+
+    async def _build(_guild):
+        return []
+
+    async def _section_run(_interaction, _hub):
+        return None
+
+    fake_section = SetupSection(
+        slug="_fake_empty",
+        label="Empty",
+        style=discord.ButtonStyle.secondary,
+        run=_section_run,
+        order=999,
+        depths=frozenset({"standard"}),
+        recommended_ops_builder=_build,
+    )
+
+    session = SetupSession(
+        guild_id=1,
+        guild_name="x",
+        owner_id=99,
+        setup_status="in_progress",
+        setup_channel_id=None,
+        setup_message_id=None,
+        last_readiness_score=None,
+        current_step=None,
+        delegated_admins=(),
+        depth="standard",
+    )
+
+    with patch.object(REGISTRY, "for_depth", return_value=[fake_section]):
+        view = SetupHubView(_owner_member(), session=session)
+        button = _find_button(view, "setup_hub:apply_all_recommended")
+        assert button is not None
+        interaction = _interaction(_owner_member())
+        interaction.guild = MagicMock(id=1)
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+        with (
+            patch.object(
+                view,
+                "_refresh_session",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "services.setup_draft.append",
+                new_callable=AsyncMock,
+            ) as append_mock,
+        ):
+            await button.callback(interaction)
+
+    append_mock.assert_not_awaited()
+    interaction.followup.send.assert_awaited_once()
+    msg = interaction.followup.send.await_args.args[0]
+    assert "no" in msg.lower()


### PR DESCRIPTION
## Summary

Single-commit follow-up on top of merged PR #236. Adds a "Apply all
recommended" button to the setup hub so operators in Quick / Standard
depth can stage every section's safe defaults in one click.

### Behavior

- New row-4 success button on `SetupHubView`, rendered **only** when
  at least one section in the operator's selected depth declares a
  `recommended_ops_builder`. Read-only depths or empty catalogues
  hide the button entirely.
- Click flow:
  1. Re-resolves the session (depth may have changed since view
     construction).
  2. `safe_defer`s the interaction (respects INV-L —
     `test_no_raw_interaction_defer_outside_helpers`).
  3. Iterates every depth-filtered section with a builder, `await`s
     `builder(guild)`, stages each returned op via
     `setup_draft.append` with `metadata.source="setup_ux:recommended"`.
  4. Isolates per-builder and per-op failures — one broken section
     doesn't abort the rest of the loop.
  5. Followup message tallies "N operations across M section(s)"
     with per-section breakdown.
- Owner-gated via the existing `_gate_owner`.

### Operator effect

- **Quick** depth (server_scan / preset_select / final_review): no
  sections in this depth have builders today, so the button is
  hidden. Operators still pick a preset via the existing picker.
- **Standard** depth: cleanup + channels both have builders. One
  click stages Light cleanup at guild scope **and** `bind_channel`
  ops for every high-confidence channel recommendation. Operator
  can land at Final Review with everything pre-staged.
- **Advanced** depth: same as Standard plus the manual cleanup
  scope picker / cog_routing profile picker remain available via
  Customize for fine-tuning.

### Plumbing

- `SetupSection` gains `recommended_ops_builder: Any = None` (type-
  erased to avoid pulling `SetupOperation` into the dataclass
  module). Cleanup and channels register their existing builders
  via this new field.

### Constraint preservation

- No new `OperationKind`. Every op routes through the existing
  recommended builders that have been live since the section-card
  PRs.
- No DB writes from the hub view; staging stays in
  `setup_draft.append`.
- Final Review remains the sole apply gate.
- `safe_defer` keeps `test_no_raw_interaction_defer_outside_helpers`
  green.

## Test plan

- [x] `pytest tests/` — **3722 passed**, 3 skipped (3 new tests:
      presence-when-builder-exists, absence-when-empty, iterate-and-
      stage happy path + empty-builder fallback).
- [x] `ruff check .` — clean
- [x] `black --check .` — clean
- [x] `isort --check-only .` — clean
- [x] `mypy disbot/` — clean

Manual smoke (deferred to post-merge): in Standard depth open the
hub, click "Apply all recommended", confirm Final Review now lists
N pre-staged ops with `source=setup_ux:recommended`. Click Final
Review → Apply.

https://claude.ai/code/session_01JMfLzC1f7woiePzWUj55kg

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMfLzC1f7woiePzWUj55kg)_