### PR TITLE
feat(setup): /setup-skip and /setup-unskip slash commands

### DIFF
--- a/disbot/cogs/setup_cog.py
+++ b/disbot/cogs/setup_cog.py
@@ -323,6 +323,108 @@ class SetupCog(commands.Cog):
                 logger.exception("setup_cog.setup_slash: mark_in_progress failed")
 
     @app_commands.command(
+        name="setup-skip",
+        description="Mark a setup section as skipped (owner/delegated admin only).",
+    )
+    @app_commands.describe(
+        section="Section slug (e.g. cleanup, channels, cog_routing).",
+    )
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.guild_only()
+    async def setup_skip_slash(
+        self,
+        interaction: discord.Interaction,
+        section: str,
+    ) -> None:
+        """Add ``section`` to the session's skipped_sections set.
+
+        The hub renders the section with a ⚠️ Skipped badge and the
+        ``Apply all recommended`` button skips it. Use
+        ``/setup-unskip`` to revert.
+        """
+        await self._toggle_skip(interaction, section, skipped=True)
+
+    @app_commands.command(
+        name="setup-unskip",
+        description="Remove a section from the skipped set (owner/delegated admin only).",
+    )
+    @app_commands.describe(
+        section="Section slug (e.g. cleanup, channels, cog_routing).",
+    )
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.guild_only()
+    async def setup_unskip_slash(
+        self,
+        interaction: discord.Interaction,
+        section: str,
+    ) -> None:
+        """Drop ``section`` from the session's skipped_sections set."""
+        await self._toggle_skip(interaction, section, skipped=False)
+
+    async def _toggle_skip(
+        self,
+        interaction: discord.Interaction,
+        slug: str,
+        *,
+        skipped: bool,
+    ) -> None:
+        guild = interaction.guild
+        member = interaction.user
+        if guild is None or not isinstance(member, discord.Member):
+            cmd = "skip" if skipped else "unskip"
+            await interaction.response.send_message(
+                f"Use `/setup-{cmd}` from inside the server.",
+                ephemeral=True,
+            )
+            return
+
+        try:
+            session = await setup_session.resume_session(guild.id)
+        except Exception:
+            logger.exception("setup_cog._toggle_skip: resume failed")
+            session = None
+
+        if not setup_access.can_apply_setup(member, session):
+            await interaction.response.send_message(
+                "Only the server owner or a delegated setup admin can "
+                "change a section's skipped state.",
+                ephemeral=True,
+            )
+            return
+
+        from services.setup_sections import REGISTRY
+
+        if REGISTRY.get(slug) is None:
+            available = ", ".join(f"`{s.slug}`" for s in REGISTRY.all())
+            await interaction.response.send_message(
+                f"Unknown section `{slug}`. Available: {available}",
+                ephemeral=True,
+            )
+            return
+
+        try:
+            if skipped:
+                await setup_session.mark_section_skipped(guild.id, slug)
+            else:
+                await setup_session.unmark_section_skipped(guild.id, slug)
+        except Exception:
+            verb = "mark" if skipped else "unmark"
+            logger.exception("setup_cog._toggle_skip: %s failed", verb)
+            await interaction.response.send_message(
+                "Could not update the skip state — see logs.",
+                ephemeral=True,
+            )
+            return
+
+        verb = "skipped" if skipped else "un-skipped"
+        await interaction.response.send_message(
+            f"✅ Section `{slug}` {verb}.",
+            ephemeral=True,
+        )
+
+    @app_commands.command(
         name="setup-reset",
         description="Clear all staged setup operations (owner/delegated admin only).",
     )

--- a/disbot/views/setup/hub.py
+++ b/disbot/views/setup/hub.py
@@ -197,7 +197,11 @@ def build_hub_embed(
     if hint:
         embed.add_field(name="Next step", value=hint, inline=False)
     embed.set_footer(
-        text="Owner-gated. No mutation runs until you confirm in Final review.",
+        text=(
+            "Owner-gated. No mutation runs until Final review confirms. "
+            "Tip: /setup-status for a read-only peek · /setup-reset to "
+            "clear staged ops."
+        ),
     )
     return embed
 

--- a/tests/unit/cogs/test_setup_cog.py
+++ b/tests/unit/cogs/test_setup_cog.py
@@ -1689,3 +1689,116 @@ def test_launcher_embed_mentions_slash_commands():
     assert "!setup" in description or "/setup" in description
     assert "/setup-status" in description
     assert "/setup-reset" in description
+
+
+# ---------------------------------------------------------------------------
+# /setup-skip and /setup-unskip slash commands
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_setup_skip_slash_marks_section_skipped():
+    from cogs.setup_cog import SetupCog
+
+    cog = SetupCog(MagicMock())
+    interaction = _mock_interaction(_owner_member())
+
+    with (
+        patch(
+            "cogs.setup_cog.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_delegated_session(),
+        ),
+        patch(
+            "cogs.setup_cog.setup_session.mark_section_skipped",
+            new_callable=AsyncMock,
+        ) as skip_mock,
+    ):
+        await cog.setup_skip_slash.callback(cog, interaction, section="cleanup")
+
+    skip_mock.assert_awaited_once_with(1, "cleanup")
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "cleanup" in msg.lower()
+    assert "skipped" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_setup_unskip_slash_unmarks_section():
+    from cogs.setup_cog import SetupCog
+
+    cog = SetupCog(MagicMock())
+    interaction = _mock_interaction(_owner_member())
+
+    with (
+        patch(
+            "cogs.setup_cog.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_delegated_session(),
+        ),
+        patch(
+            "cogs.setup_cog.setup_session.unmark_section_skipped",
+            new_callable=AsyncMock,
+        ) as unskip_mock,
+    ):
+        await cog.setup_unskip_slash.callback(
+            cog, interaction, section="cleanup",
+        )
+
+    unskip_mock.assert_awaited_once_with(1, "cleanup")
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "un-skipped" in msg.lower() or "unskipped" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_setup_skip_slash_rejects_unknown_section():
+    """Unknown slugs surface a list of valid options."""
+    from cogs.setup_cog import SetupCog
+
+    cog = SetupCog(MagicMock())
+    interaction = _mock_interaction(_owner_member())
+
+    with (
+        patch(
+            "cogs.setup_cog.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_delegated_session(),
+        ),
+        patch(
+            "cogs.setup_cog.setup_session.mark_section_skipped",
+            new_callable=AsyncMock,
+        ) as skip_mock,
+    ):
+        await cog.setup_skip_slash.callback(
+            cog, interaction, section="bogus-section",
+        )
+
+    skip_mock.assert_not_awaited()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "unknown" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_setup_skip_slash_denies_random_member():
+    from cogs.setup_cog import SetupCog
+
+    cog = SetupCog(MagicMock())
+    interaction = _mock_interaction(_random_member())
+
+    with (
+        patch(
+            "cogs.setup_cog.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_delegated_session(delegated=()),
+        ),
+        patch(
+            "cogs.setup_cog.setup_session.mark_section_skipped",
+            new_callable=AsyncMock,
+        ) as skip_mock,
+    ):
+        await cog.setup_skip_slash.callback(
+            cog, interaction, section="cleanup",
+        )
+
+    skip_mock.assert_not_awaited()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "owner" in msg.lower()


### PR DESCRIPTION
## Summary

Single-commit follow-up on top of merged PR #240. Adds two slash
commands so operators can toggle a section's skipped state from
any channel without opening the interactive hub.

### Commands

- `/setup-skip section:<slug>` — adds the slug to
  `SetupSession.skipped_sections`. The hub renders the section
  with the ⚠️ Skipped badge and the "Apply all recommended"
  button passes over it.
- `/setup-unskip section:<slug>` — reverses the skip.

### Implementation

- Both share `_toggle_skip(interaction, slug, *, skipped)` to
  deduplicate gate + validate + persist.
- Unknown slugs surface a friendly error listing every
  available slug from `REGISTRY.all()`.
- `can_apply_setup` gating: owner / delegated admin only; plain
  admins get the standard denial.
- Persistence reuses the existing `setup_session.mark_section_skipped`
  / `unmark_section_skipped` service helpers that the section
  card's Skip button already calls — no new DB primitive.

`setup_cog.py` is at 738 LOC, in the warn-tier but under the
800-LOC fail threshold.

## Test plan

- [x] `pytest tests/` — **3747 passed**, 3 skipped (4 new tests:
      skip happy path, unskip happy path, unknown-slug error,
      random-user deny).
- [x] `ruff check .` — clean
- [x] `black --check .` — clean
- [x] `mypy disbot/` — clean

Manual smoke (deferred to post-merge): `/setup-skip
section:cleanup` → hub shows cleanup with ⚠️ badge →
`/setup-unskip section:cleanup` → badge reverts.

https://claude.ai/code/session_01JMfLzC1f7woiePzWUj55kg

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMfLzC1f7woiePzWUj55kg)_