### PR TITLE
Fix guild slash sync; add successful-command cleanup and actual history cleanup

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -13,6 +13,7 @@ import discord
 from discord.ext import commands
 
 import config
+from services import governance_service
 from services.runtime import BOOT_ID, install_boot_id_logging
 from services.webhook_reporter import WebhookReporter
 from utils import db
@@ -263,6 +264,28 @@ async def on_command_completion(ctx: commands.Context) -> None:
     )
     if reporter:
         await reporter.on_command_success(ctx)
+    await _maybe_cleanup_successful_command(ctx)
+
+
+async def _maybe_cleanup_successful_command(ctx: commands.Context) -> None:
+    if ctx.guild is None or ctx.author.bot or not getattr(ctx, "message", None):
+        return
+    try:
+        gctx = governance_service.GovernanceContext.from_ctx(ctx)
+        policy = await governance_service.resolve_cleanup_policy(gctx)
+        if not policy.delete_message:
+            return
+        await ctx.message.delete(delay=policy.delete_after_seconds)
+    except discord.NotFound:
+        return
+    except discord.Forbidden:
+        logger.warning(
+            "Cleanup failed for successful command in guild=%s channel=%s: missing Manage Messages",
+            ctx.guild.id if ctx.guild else None,
+            ctx.channel.id if ctx.channel else None,
+        )
+    except discord.HTTPException as exc:
+        logger.warning("Cleanup failed for successful command: %s", exc)
 
 
 @bot.event

--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -13,7 +13,6 @@ import discord
 from discord.ext import commands
 
 import config
-from services import governance_service
 from services.runtime import BOOT_ID, install_boot_id_logging
 from services.webhook_reporter import WebhookReporter
 from utils import db
@@ -270,6 +269,8 @@ async def on_command_completion(ctx: commands.Context) -> None:
 async def _maybe_cleanup_successful_command(ctx: commands.Context) -> None:
     if ctx.guild is None or ctx.author.bot or not getattr(ctx, "message", None):
         return
+    from services import governance_service
+
     try:
         gctx = governance_service.GovernanceContext.from_ctx(ctx)
         policy = await governance_service.resolve_cleanup_policy(gctx)

--- a/disbot/cogs/admin_cog.py
+++ b/disbot/cogs/admin_cog.py
@@ -185,10 +185,8 @@ class AdminCog(commands.Cog):
 
         PR E' — operator tooling for the post-deploy resync workflow.
         After PR E1 / E2 add or change slash commands, the Discord
-        command tree needs to be told about them. Bot startup already
-        runs a global sync (per ``setup_hook``); this command exists
-        for cases where the operator needs to re-trigger one without
-        a full restart.
+        command tree needs to be told about them. This command lets
+        operators trigger that sync workflow on demand.
 
         Usage::
 
@@ -226,6 +224,7 @@ class AdminCog(commands.Cog):
             await ctx.send("❌ `guild` scope requires a guild context.")
             return
         try:
+            self.bot.tree.copy_global_to(guild=guild)
             synced = await self.bot.tree.sync(guild=guild)
         except discord.HTTPException as exc:
             await ctx.send(
@@ -233,7 +232,8 @@ class AdminCog(commands.Cog):
             )
             return
         await ctx.send(
-            f"✅ Synced **{len(synced)}** slash commands to **{guild.name}**.",
+            f"✅ Copied global slash commands and synced **{len(synced)}** commands "
+            f"to **{guild.name}**.",
         )
 
     @commands.command(name="slashes", aliases=["slashlist"])
@@ -279,7 +279,15 @@ class AdminCog(commands.Cog):
             title = f"📋 Guild Slash Commands — {guild.name}"
 
         if not commands_list:
-            await ctx.send(f"_No {scope} slash commands registered._")
+            if scope == "guild":
+                await ctx.send(
+                    "_No guild-local slash commands registered._ "
+                    "Most slash commands may be in the global tree. "
+                    "Use `!syncslash guild` to copy global commands into this guild "
+                    "and sync them immediately.",
+                )
+            else:
+                await ctx.send("_No global slash commands registered._")
             return
 
         ordered = sorted(commands_list, key=lambda c: c.name)

--- a/disbot/cogs/cleanup_cog.py
+++ b/disbot/cogs/cleanup_cog.py
@@ -22,6 +22,9 @@ from views.base import HubView, send_panel
 
 CLEANUP_STAGE_NAME = "cleanup"
 CLEANUP_STAGE_ORDER = 10  # moderation tier per plan §3.2
+MAX_CLEANUP_HISTORY_LIMIT = 1000
+SPAM_DUPLICATE_WINDOW_SECONDS = 15
+HELPER_DELETE_DELAY_SECONDS = 3
 
 
 def _extract_command_name(content: str, prefixes: list[str]) -> str | None:
@@ -191,36 +194,39 @@ class Cleanup(commands.Cog):
             )
             return
 
+        if limit > MAX_CLEANUP_HISTORY_LIMIT:
+            await ctx.send(
+                f"⚠️ Limit capped at {MAX_CLEANUP_HISTORY_LIMIT}; scanning that many messages.",
+                delete_after=7,
+            )
+            limit = MAX_CLEANUP_HISTORY_LIMIT
+
         raw_filter = (keyword or "").strip()
         parts = raw_filter.split(maxsplit=1) if raw_filter else []
         mode = "prohibited"
         query: str | None = None
-        if parts and parts[0].lower() in {"keyword", "commands", "prohibited"}:
+        if parts and parts[0].lower() in {"keyword", "commands", "prohibited", "spam"}:
             mode = parts[0].lower()
             query = parts[1] if len(parts) > 1 else None
         elif raw_filter:
             mode = "keyword"
             query = raw_filter
 
-        if not raw_filter:
-            await ctx.send(
-                "Usage: `!cleanuphistory <limit> <mode>` where mode is "
-                "`keyword <text>`, `commands`, or `prohibited`. "
-                "Backward compatible: `!cleanuphistory <limit> <word>` is keyword mode.",
-                delete_after=8,
-            )
-            return
-
         if mode == "keyword" and not query:
-            await ctx.send("Please provide text for keyword cleanup.", delete_after=5)
+            await ctx.send(
+                "Usage: `!cleanuphistory <limit> keyword <text>` "
+                f"(limit max: {MAX_CLEANUP_HISTORY_LIMIT}).",
+                delete_after=7,
+            )
             return
 
         perms = getattr(ctx.channel, "permissions_for", lambda _a: None)(ctx.guild.me)
         if perms is not None and not perms.manage_messages:
-            await ctx.send(
-                "⚠️ I am missing **Manage Messages** in this channel, so cleanup may fail.",
-                delete_after=8,
+            warning_msg = await ctx.send(
+                "❌ I need **Manage Messages** in this channel to run cleanuphistory.",
             )
+            await self._delete_helper_messages_later(ctx, warning_msg)
+            return
 
         prohibited_words = await db.get_prohibited_words(ctx.guild.id)
         plan = await build_history_cleanup_plan(
@@ -230,12 +236,16 @@ class Cleanup(commands.Cog):
             keyword=query,
             command_prefixes=self.command_prefixes,
             prohibited_words=prohibited_words,
+            exclude_message_ids={ctx.message.id},
+            spam_duplicate_window_seconds=SPAM_DUPLICATE_WINDOW_SECONDS,
         )
+        final_msg = None
+        confirmation_msg = None
         if not plan.matched:
-            await ctx.send(
+            final_msg = await ctx.send(
                 f"Scanned {plan.scanned} messages. Matched 0 messages for `{mode}`.",
-                delete_after=7,
             )
+            await self._delete_helper_messages_later(ctx, final_msg)
             return
 
         confirmation_msg = await ctx.send(
@@ -274,9 +284,8 @@ class Cleanup(commands.Cog):
                         )
                     except discord.HTTPException:
                         failed += 1
-                await ctx.send(
+                final_msg = await ctx.send(
                     f"Cleanup completed. Deleted {deleted} message(s), failed {failed}.",
-                    delete_after=7,
                 )
                 self.logger.info(
                     "Cleanup history completed in %s: scanned=%s matched=%s deleted=%s failed=%s mode=%s",
@@ -288,17 +297,25 @@ class Cleanup(commands.Cog):
                     mode,
                 )
             else:
-                await ctx.send("Cleanup canceled.", delete_after=5)
+                final_msg = await ctx.send("Cleanup canceled.")
         except asyncio.TimeoutError:
-            await ctx.send("Cleanup confirmation timed out.", delete_after=5)
+            final_msg = await ctx.send("Cleanup confirmation timed out.")
         finally:
-            for msg in (getattr(ctx, "message", None), confirmation_msg):
-                if msg is None:
-                    continue
-                try:
-                    await msg.delete()
-                except discord.DiscordException:
-                    pass
+            await self._delete_helper_messages_later(ctx, confirmation_msg, final_msg)
+
+    async def _delete_helper_messages_later(self, ctx, *messages) -> None:
+        await asyncio.sleep(HELPER_DELETE_DELAY_SECONDS)
+        for msg in [*messages, getattr(ctx, "message", None)]:
+            if msg is None:
+                continue
+            try:
+                await msg.delete()
+            except discord.NotFound:
+                continue
+            except discord.Forbidden:
+                self.logger.warning("cleanuphistory could not delete helper message (Forbidden).")
+            except discord.HTTPException as exc:
+                self.logger.warning("cleanuphistory helper delete failed: %s", exc)
 
     @commands.group(name="word", invoke_without_command=True)
     @commands.has_permissions(administrator=True)

--- a/disbot/cogs/cleanup_cog.py
+++ b/disbot/cogs/cleanup_cog.py
@@ -323,7 +323,9 @@ class Cleanup(commands.Cog):
             except discord.NotFound:
                 continue
             except discord.Forbidden:
-                self.logger.warning("cleanuphistory could not delete helper message (Forbidden).")
+                self.logger.warning(
+                    "cleanuphistory could not delete helper message (Forbidden).",
+                )
             except discord.HTTPException as exc:
                 self.logger.warning("cleanuphistory helper delete failed: %s", exc)
 

--- a/disbot/cogs/cleanup_cog.py
+++ b/disbot/cogs/cleanup_cog.py
@@ -194,12 +194,14 @@ class Cleanup(commands.Cog):
             )
             return
 
-        if limit > MAX_CLEANUP_HISTORY_LIMIT:
+        requested_limit = limit
+        effective_limit = min(requested_limit, MAX_CLEANUP_HISTORY_LIMIT)
+        if requested_limit > MAX_CLEANUP_HISTORY_LIMIT:
             await ctx.send(
-                f"⚠️ Limit capped at {MAX_CLEANUP_HISTORY_LIMIT}; scanning that many messages.",
+                f"⚠️ Requested {requested_limit} messages. Maximum is "
+                f"{MAX_CLEANUP_HISTORY_LIMIT}, so I will scan {effective_limit}.",
                 delete_after=7,
             )
-            limit = MAX_CLEANUP_HISTORY_LIMIT
 
         raw_filter = (keyword or "").strip()
         parts = raw_filter.split(maxsplit=1) if raw_filter else []
@@ -231,7 +233,7 @@ class Cleanup(commands.Cog):
         prohibited_words = await db.get_prohibited_words(ctx.guild.id)
         plan = await build_history_cleanup_plan(
             ctx.channel,
-            limit=limit,
+            limit=effective_limit,
             mode=mode,
             keyword=query,
             command_prefixes=self.command_prefixes,
@@ -243,14 +245,21 @@ class Cleanup(commands.Cog):
         confirmation_msg = None
         if not plan.matched:
             final_msg = await ctx.send(
-                f"Scanned {plan.scanned} messages. Matched 0 messages for `{mode}`.",
+                f"Scanned {plan.scanned} message(s) (requested {requested_limit}, "
+                f"effective {effective_limit}). Matched 0 messages for `{mode}`.",
             )
             await self._delete_helper_messages_later(ctx, final_msg)
             return
 
         confirmation_msg = await ctx.send(
-            f"Scanned {plan.scanned} messages and matched {len(plan.matched)} "
-            f"for `{mode}`. Delete matched messages? React ✅ to confirm or ❌ to cancel.",
+            f"Ready to scan up to {effective_limit} message(s)"
+            + (
+                f" (requested {requested_limit})"
+                if requested_limit != effective_limit
+                else ""
+            )
+            + f". Found {len(plan.matched)} candidate message(s) in `{mode}` mode. "
+            "Delete matched messages? React ✅ to confirm or ❌ to cancel.",
         )
         await confirmation_msg.add_reaction("✅")
         await confirmation_msg.add_reaction("❌")
@@ -285,7 +294,9 @@ class Cleanup(commands.Cog):
                     except discord.HTTPException:
                         failed += 1
                 final_msg = await ctx.send(
-                    f"Cleanup completed. Deleted {deleted} message(s), failed {failed}.",
+                    f"Cleanup completed. Scanned {plan.scanned} message(s) "
+                    f"(requested {requested_limit}, effective {effective_limit}). "
+                    f"Deleted {deleted} message(s), failed {failed}.",
                 )
                 self.logger.info(
                     "Cleanup history completed in %s: scanned=%s matched=%s deleted=%s failed=%s mode=%s",
@@ -304,12 +315,11 @@ class Cleanup(commands.Cog):
             await self._delete_helper_messages_later(ctx, confirmation_msg, final_msg)
 
     async def _delete_helper_messages_later(self, ctx, *messages) -> None:
-        await asyncio.sleep(HELPER_DELETE_DELAY_SECONDS)
         for msg in [*messages, getattr(ctx, "message", None)]:
             if msg is None:
                 continue
             try:
-                await msg.delete()
+                await msg.delete(delay=HELPER_DELETE_DELAY_SECONDS)
             except discord.NotFound:
                 continue
             except discord.Forbidden:

--- a/disbot/cogs/cleanup_cog.py
+++ b/disbot/cogs/cleanup_cog.py
@@ -202,9 +202,25 @@ class Cleanup(commands.Cog):
             mode = "keyword"
             query = raw_filter
 
+        if not raw_filter:
+            await ctx.send(
+                "Usage: `!cleanuphistory <limit> <mode>` where mode is "
+                "`keyword <text>`, `commands`, or `prohibited`. "
+                "Backward compatible: `!cleanuphistory <limit> <word>` is keyword mode.",
+                delete_after=8,
+            )
+            return
+
         if mode == "keyword" and not query:
             await ctx.send("Please provide text for keyword cleanup.", delete_after=5)
             return
+
+        perms = getattr(ctx.channel, "permissions_for", lambda _a: None)(ctx.guild.me)
+        if perms is not None and not perms.manage_messages:
+            await ctx.send(
+                "⚠️ I am missing **Manage Messages** in this channel, so cleanup may fail.",
+                delete_after=8,
+            )
 
         prohibited_words = await db.get_prohibited_words(ctx.guild.id)
         plan = await build_history_cleanup_plan(
@@ -276,8 +292,13 @@ class Cleanup(commands.Cog):
         except asyncio.TimeoutError:
             await ctx.send("Cleanup confirmation timed out.", delete_after=5)
         finally:
-            await ctx.message.delete()
-            await confirmation_msg.delete()
+            for msg in (getattr(ctx, "message", None), confirmation_msg):
+                if msg is None:
+                    continue
+                try:
+                    await msg.delete()
+                except discord.DiscordException:
+                    pass
 
     @commands.group(name="word", invoke_without_command=True)
     @commands.has_permissions(administrator=True)

--- a/disbot/cogs/cleanup_cog.py
+++ b/disbot/cogs/cleanup_cog.py
@@ -15,6 +15,7 @@ from core.runtime.message_pipeline import (
 )
 from services import governance_service, moderation_service
 from services.governance_service import GovernanceContext
+from services.history_cleanup import build_history_cleanup_plan
 from utils import db
 from utils.ui_constants import ADMIN_COLOR
 from views.base import HubView, send_panel
@@ -182,7 +183,7 @@ class Cleanup(commands.Cog):
     @commands.has_permissions(manage_messages=True)
     @commands.cooldown(1, 10, commands.BucketType.channel)
     async def cleanup_history(self, ctx, limit: int = 100, *, keyword: str = None):
-        """Cleans up messages containing prohibited content or disallowed commands from the channel history."""
+        """Clean matching channel history by keyword, commands, or prohibited words."""
         if limit <= 0:
             await ctx.send(
                 "Please provide a positive number of messages to scan.",
@@ -190,10 +191,40 @@ class Cleanup(commands.Cog):
             )
             return
 
+        raw_filter = (keyword or "").strip()
+        parts = raw_filter.split(maxsplit=1) if raw_filter else []
+        mode = "prohibited"
+        query: str | None = None
+        if parts and parts[0].lower() in {"keyword", "commands", "prohibited"}:
+            mode = parts[0].lower()
+            query = parts[1] if len(parts) > 1 else None
+        elif raw_filter:
+            mode = "keyword"
+            query = raw_filter
+
+        if mode == "keyword" and not query:
+            await ctx.send("Please provide text for keyword cleanup.", delete_after=5)
+            return
+
+        prohibited_words = await db.get_prohibited_words(ctx.guild.id)
+        plan = await build_history_cleanup_plan(
+            ctx.channel,
+            limit=limit,
+            mode=mode,
+            keyword=query,
+            command_prefixes=self.command_prefixes,
+            prohibited_words=prohibited_words,
+        )
+        if not plan.matched:
+            await ctx.send(
+                f"Scanned {plan.scanned} messages. Matched 0 messages for `{mode}`.",
+                delete_after=7,
+            )
+            return
+
         confirmation_msg = await ctx.send(
-            f"Are you sure you want to clean up the last {limit} messages"
-            + (f" filtering by `{keyword}`" if keyword else "")
-            + "? React with ✅ to confirm or ❌ to cancel.",
+            f"Scanned {plan.scanned} messages and matched {len(plan.matched)} "
+            f"for `{mode}`. Delete matched messages? React ✅ to confirm or ❌ to cancel.",
         )
         await confirmation_msg.add_reaction("✅")
         await confirmation_msg.add_reaction("❌")
@@ -212,20 +243,33 @@ class Cleanup(commands.Cog):
                 check=check,
             )
             if str(reaction.emoji) == "✅":
+                deleted = 0
+                failed = 0
+                for message in plan.matched:
+                    try:
+                        await message.delete()
+                        deleted += 1
+                    except discord.Forbidden:
+                        failed += 1
+                        self.logger.warning(
+                            "cleanuphistory missing Manage Messages in #%s (%s)",
+                            getattr(ctx.channel, "name", "unknown"),
+                            getattr(ctx.channel, "id", "unknown"),
+                        )
+                    except discord.HTTPException:
+                        failed += 1
                 await ctx.send(
-                    f"Starting cleanup for the last {limit} messages"
-                    + (f" filtering by `{keyword}`" if keyword else ""),
-                    delete_after=5,
+                    f"Cleanup completed. Deleted {deleted} message(s), failed {failed}.",
+                    delete_after=7,
                 )
-                async for message in ctx.channel.history(limit=limit):
-                    if message.author.bot:
-                        continue
-                    if keyword and keyword.lower() not in message.content.lower():
-                        continue
-                    await self.remove_unwanted_message(message)
-                await ctx.send("Cleanup completed.", delete_after=5)
                 self.logger.info(
-                    f"Cleanup completed for the last {limit} messages in {ctx.channel.name}",
+                    "Cleanup history completed in %s: scanned=%s matched=%s deleted=%s failed=%s mode=%s",
+                    ctx.channel.name,
+                    plan.scanned,
+                    len(plan.matched),
+                    deleted,
+                    failed,
+                    mode,
                 )
             else:
                 await ctx.send("Cleanup canceled.", delete_after=5)

--- a/disbot/services/history_cleanup.py
+++ b/disbot/services/history_cleanup.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 import datetime as dt
 import re
+from dataclasses import dataclass
 from typing import Literal
 
 import discord
 
+
 def _extract_command_name(content: str, prefixes: list[str]) -> str | None:
     for prefix in prefixes:
         if content.startswith(prefix):
-            rest = content[len(prefix) :].split()[0] if content[len(prefix) :].strip() else ""
+            rest = (
+                content[len(prefix) :].split()[0]
+                if content[len(prefix) :].strip()
+                else ""
+            )
             return rest.lower() if rest else None
     return None
 
@@ -41,7 +46,8 @@ async def build_history_cleanup_plan(
     exclude_message_ids = exclude_message_ids or set()
     command_prefixes = command_prefixes or []
     prohibited_patterns = [
-        re.compile(rf"\b{re.escape(w)}\b", re.IGNORECASE) for w in (prohibited_words or [])
+        re.compile(rf"\b{re.escape(w)}\b", re.IGNORECASE)
+        for w in (prohibited_words or [])
     ]
     keyword_norm = keyword.lower() if keyword else None
     spam_last_seen: dict[str, dt.datetime] = {}
@@ -59,11 +65,15 @@ async def build_history_cleanup_plan(
             include = bool(keyword_norm and keyword_norm in content)
         elif mode == "commands":
             include = (
-                _extract_command_name((message.content or "").lstrip(), command_prefixes)
+                _extract_command_name(
+                    (message.content or "").lstrip(), command_prefixes,
+                )
                 is not None
             )
         elif mode == "prohibited":
-            include = any(pattern.search(message.content or "") for pattern in prohibited_patterns)
+            include = any(
+                pattern.search(message.content or "") for pattern in prohibited_patterns
+            )
         elif mode == "spam":
             # processed in a second pass oldest→newest (history API is newest→oldest)
             continue

--- a/disbot/services/history_cleanup.py
+++ b/disbot/services/history_cleanup.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import re
+from typing import Literal
+
+import discord
 
 def _extract_command_name(content: str, prefixes: list[str]) -> str | None:
     for prefix in prefixes:
@@ -13,22 +17,27 @@ def _extract_command_name(content: str, prefixes: list[str]) -> str | None:
 @dataclass
 class HistoryCleanupPlan:
     scanned: int
-    matched: list
+    matched: list[discord.Message]
 
 
 async def build_history_cleanup_plan(
     channel,
     *,
     limit: int,
-    mode: str,
+    mode: Literal["keyword", "commands", "prohibited"],
     keyword: str | None = None,
     command_prefixes: list[str] | None = None,
     prohibited_words: list[str] | None = None,
 ) -> HistoryCleanupPlan:
+    if mode not in {"keyword", "commands", "prohibited"}:
+        raise ValueError(f"Unsupported cleanuphistory mode: {mode}")
+
     scanned = 0
-    matched: list = []
+    matched: list[discord.Message] = []
     command_prefixes = command_prefixes or []
-    prohibited_words = [w.lower() for w in (prohibited_words or [])]
+    prohibited_patterns = [
+        re.compile(rf"\b{re.escape(w)}\b", re.IGNORECASE) for w in (prohibited_words or [])
+    ]
     keyword_norm = keyword.lower() if keyword else None
 
     async for message in channel.history(limit=limit):
@@ -40,9 +49,12 @@ async def build_history_cleanup_plan(
         if mode == "keyword":
             include = bool(keyword_norm and keyword_norm in content)
         elif mode == "commands":
-            include = _extract_command_name(message.content.strip(), command_prefixes) is not None
+            include = (
+                _extract_command_name((message.content or "").lstrip(), command_prefixes)
+                is not None
+            )
         elif mode == "prohibited":
-            include = any(word in content for word in prohibited_words)
+            include = any(pattern.search(message.content or "") for pattern in prohibited_patterns)
         if include:
             matched.append(message)
     return HistoryCleanupPlan(scanned=scanned, matched=matched)

--- a/disbot/services/history_cleanup.py
+++ b/disbot/services/history_cleanup.py
@@ -37,6 +37,7 @@ async def build_history_cleanup_plan(
 
     scanned = 0
     matched: list[discord.Message] = []
+    scanned_messages: list[discord.Message] = []
     exclude_message_ids = exclude_message_ids or set()
     command_prefixes = command_prefixes or []
     prohibited_patterns = [
@@ -47,6 +48,7 @@ async def build_history_cleanup_plan(
 
     async for message in channel.history(limit=limit):
         scanned += 1
+        scanned_messages.append(message)
         if message.id in exclude_message_ids:
             continue
         if message.author.bot:
@@ -63,18 +65,25 @@ async def build_history_cleanup_plan(
         elif mode == "prohibited":
             include = any(pattern.search(message.content or "") for pattern in prohibited_patterns)
         elif mode == "spam":
-            normalized = " ".join((message.content or "").lower().split())
-            if normalized:
-                created_at = message.created_at
-                previous = spam_last_seen.get(normalized)
-                if previous is None:
-                    spam_last_seen[normalized] = created_at
-                else:
-                    delta = (previous - created_at).total_seconds()
-                    if delta <= spam_duplicate_window_seconds:
-                        include = True
-                    else:
-                        spam_last_seen[normalized] = created_at
+            # processed in a second pass oldest→newest (history API is newest→oldest)
+            continue
         if include:
             matched.append(message)
+    if mode == "spam":
+        for message in reversed(scanned_messages):
+            if message.id in exclude_message_ids or message.author.bot:
+                continue
+            normalized = " ".join((message.content or "").lower().split())
+            if not normalized:
+                continue
+            created_at = message.created_at
+            previous = spam_last_seen.get(normalized)
+            if previous is None:
+                spam_last_seen[normalized] = created_at
+                continue
+            delta = (created_at - previous).total_seconds()
+            if delta <= spam_duplicate_window_seconds:
+                matched.append(message)
+            else:
+                spam_last_seen[normalized] = created_at
     return HistoryCleanupPlan(scanned=scanned, matched=matched)

--- a/disbot/services/history_cleanup.py
+++ b/disbot/services/history_cleanup.py
@@ -66,7 +66,8 @@ async def build_history_cleanup_plan(
         elif mode == "commands":
             include = (
                 _extract_command_name(
-                    (message.content or "").lstrip(), command_prefixes,
+                    (message.content or "").lstrip(),
+                    command_prefixes,
                 )
                 is not None
             )

--- a/disbot/services/history_cleanup.py
+++ b/disbot/services/history_cleanup.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+def _extract_command_name(content: str, prefixes: list[str]) -> str | None:
+    for prefix in prefixes:
+        if content.startswith(prefix):
+            rest = content[len(prefix) :].split()[0] if content[len(prefix) :].strip() else ""
+            return rest.lower() if rest else None
+    return None
+
+
+@dataclass
+class HistoryCleanupPlan:
+    scanned: int
+    matched: list
+
+
+async def build_history_cleanup_plan(
+    channel,
+    *,
+    limit: int,
+    mode: str,
+    keyword: str | None = None,
+    command_prefixes: list[str] | None = None,
+    prohibited_words: list[str] | None = None,
+) -> HistoryCleanupPlan:
+    scanned = 0
+    matched: list = []
+    command_prefixes = command_prefixes or []
+    prohibited_words = [w.lower() for w in (prohibited_words or [])]
+    keyword_norm = keyword.lower() if keyword else None
+
+    async for message in channel.history(limit=limit):
+        scanned += 1
+        if message.author.bot:
+            continue
+        content = (message.content or "").lower()
+        include = False
+        if mode == "keyword":
+            include = bool(keyword_norm and keyword_norm in content)
+        elif mode == "commands":
+            include = _extract_command_name(message.content.strip(), command_prefixes) is not None
+        elif mode == "prohibited":
+            include = any(word in content for word in prohibited_words)
+        if include:
+            matched.append(message)
+    return HistoryCleanupPlan(scanned=scanned, matched=matched)

--- a/disbot/services/history_cleanup.py
+++ b/disbot/services/history_cleanup.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import datetime as dt
 import re
 from typing import Literal
 
@@ -24,24 +25,30 @@ async def build_history_cleanup_plan(
     channel,
     *,
     limit: int,
-    mode: Literal["keyword", "commands", "prohibited"],
+    mode: Literal["keyword", "commands", "prohibited", "spam"],
     keyword: str | None = None,
     command_prefixes: list[str] | None = None,
     prohibited_words: list[str] | None = None,
+    exclude_message_ids: set[int] | None = None,
+    spam_duplicate_window_seconds: int = 15,
 ) -> HistoryCleanupPlan:
-    if mode not in {"keyword", "commands", "prohibited"}:
+    if mode not in {"keyword", "commands", "prohibited", "spam"}:
         raise ValueError(f"Unsupported cleanuphistory mode: {mode}")
 
     scanned = 0
     matched: list[discord.Message] = []
+    exclude_message_ids = exclude_message_ids or set()
     command_prefixes = command_prefixes or []
     prohibited_patterns = [
         re.compile(rf"\b{re.escape(w)}\b", re.IGNORECASE) for w in (prohibited_words or [])
     ]
     keyword_norm = keyword.lower() if keyword else None
+    spam_last_seen: dict[str, dt.datetime] = {}
 
     async for message in channel.history(limit=limit):
         scanned += 1
+        if message.id in exclude_message_ids:
+            continue
         if message.author.bot:
             continue
         content = (message.content or "").lower()
@@ -55,6 +62,19 @@ async def build_history_cleanup_plan(
             )
         elif mode == "prohibited":
             include = any(pattern.search(message.content or "") for pattern in prohibited_patterns)
+        elif mode == "spam":
+            normalized = " ".join((message.content or "").lower().split())
+            if normalized:
+                created_at = message.created_at
+                previous = spam_last_seen.get(normalized)
+                if previous is None:
+                    spam_last_seen[normalized] = created_at
+                else:
+                    delta = (previous - created_at).total_seconds()
+                    if delta <= spam_duplicate_window_seconds:
+                        include = True
+                    else:
+                        spam_last_seen[normalized] = created_at
         if include:
             matched.append(message)
     return HistoryCleanupPlan(scanned=scanned, matched=matched)

--- a/tests/unit/cogs/test_admin_slash_sync.py
+++ b/tests/unit/cogs/test_admin_slash_sync.py
@@ -95,7 +95,7 @@ async def test_syncslash_default_scope_is_guild():
     ctx.send.assert_awaited_once()
     args, kwargs = ctx.send.call_args
     msg = args[0] if args else kwargs.get("content", "")
-    assert "Synced" in msg
+    assert "synced" in msg.lower()
     assert "**2**" in msg
     assert "TestGuild" in msg
 

--- a/tests/unit/cogs/test_admin_slash_sync.py
+++ b/tests/unit/cogs/test_admin_slash_sync.py
@@ -42,6 +42,7 @@ def _admin_cog() -> AdminCog:
     bot = MagicMock()
     bot.tree = MagicMock()
     bot.tree.sync = AsyncMock(return_value=[])
+    bot.tree.copy_global_to = MagicMock()
     bot.tree.get_commands = MagicMock(return_value=[])
     return AdminCog(bot=bot)
 
@@ -87,6 +88,7 @@ async def test_syncslash_default_scope_is_guild():
 
     await cog.sync_slash_commands.callback(cog, ctx)
 
+    cog.bot.tree.copy_global_to.assert_called_once_with(guild=ctx.guild)
     cog.bot.tree.sync.assert_awaited_once_with(guild=ctx.guild)
     ctx.send.assert_awaited_once()
     args, kwargs = ctx.send.call_args
@@ -103,6 +105,7 @@ async def test_syncslash_explicit_guild_scope():
 
     await cog.sync_slash_commands.callback(cog, ctx, "guild")
 
+    cog.bot.tree.copy_global_to.assert_called_once_with(guild=ctx.guild)
     cog.bot.tree.sync.assert_awaited_once_with(guild=ctx.guild)
 
 
@@ -120,6 +123,7 @@ async def test_syncslash_global_scope_calls_sync_without_guild():
     await cog.sync_slash_commands.callback(cog, ctx, "global")
 
     cog.bot.tree.sync.assert_awaited_once_with()
+    cog.bot.tree.copy_global_to.assert_not_called()
     args, kwargs = ctx.send.call_args
     msg = args[0] if args else kwargs.get("content", "")
     assert "globally" in msg
@@ -233,7 +237,8 @@ async def test_slashes_empty_tree_surfaces_message():
 
     args, kwargs = ctx.send.call_args
     msg = args[0] if args else kwargs.get("content", "")
-    assert "No guild slash commands registered" in msg
+    assert "No guild-local slash commands registered" in msg
+    assert "!syncslash guild" in msg
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cogs/test_admin_slash_sync.py
+++ b/tests/unit/cogs/test_admin_slash_sync.py
@@ -14,6 +14,8 @@ Pins:
 * ``!slashes`` is admin-gated (not owner-gated — it's read-only).
 """
 
+# ruff: noqa: S101
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock

--- a/tests/unit/cogs/test_cleanup_history.py
+++ b/tests/unit/cogs/test_cleanup_history.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+from datetime import timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
 
-from cogs.cleanup_cog import Cleanup
+from cogs.cleanup_cog import Cleanup, MAX_CLEANUP_HISTORY_LIMIT
 
 
 def _msg(content: str):
@@ -35,6 +36,7 @@ def _ctx(messages):
     ctx.channel.id = 9
     ctx.author = SimpleNamespace(id=42)
     ctx.message = MagicMock()
+    ctx.message.id = 999
     ctx.message.delete = AsyncMock()
     ctx.send = AsyncMock()
     return ctx
@@ -61,6 +63,7 @@ async def test_cleanuphistory_keyword_mode_deletes_only_matching_message():
         await cog.cleanup_history.callback(cog, ctx, 10, keyword="keyword bad")
     match.delete.assert_awaited_once()
     other.delete.assert_not_called()
+    ctx.message.delete.assert_awaited()
 
 
 @pytest.mark.asyncio
@@ -85,7 +88,9 @@ async def test_cleanuphistory_commands_mode_deletes_prefixed_messages():
     cog = Cleanup(MagicMock())
     cmd = _msg("   !help me")
     normal = _msg("hello world")
-    ctx = _ctx([cmd, normal])
+    invocation = _msg("!cleanuphistory 10 commands")
+    invocation.id = 999
+    ctx = _ctx([invocation, cmd, normal])
     confirm = MagicMock(id=100)
     confirm.add_reaction = AsyncMock()
     confirm.delete = AsyncMock()
@@ -97,6 +102,7 @@ async def test_cleanuphistory_commands_mode_deletes_prefixed_messages():
         await cog.cleanup_history.callback(cog, ctx, 10, keyword="commands")
     cmd.delete.assert_awaited_once()
     normal.delete.assert_not_called()
+    invocation.delete.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -126,6 +132,23 @@ async def test_cleanuphistory_zero_match_skips_confirmation():
         await cog.cleanup_history.callback(cog, ctx, 10, keyword="keyword missing")
     first_msg = ctx.send.await_args_list[0].args[0]
     assert "Matched 0" in first_msg
+
+
+@pytest.mark.asyncio
+async def test_cleanuphistory_no_filter_defaults_to_prohibited():
+    cog = Cleanup(MagicMock())
+    exact = _msg("contains badword")
+    ctx = _ctx([exact])
+    confirm = MagicMock(id=100)
+    confirm.add_reaction = AsyncMock()
+    confirm.delete = AsyncMock()
+    ctx.send.side_effect = [confirm, MagicMock()]
+    with (
+        patch("cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=["badword"])),
+        patch.object(cog.bot, "wait_for", new=AsyncMock(return_value=(_confirmed_reaction(), ctx.author))),
+    ):
+        await cog.cleanup_history.callback(cog, ctx, 100, keyword=None)
+    exact.delete.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -166,3 +189,55 @@ async def test_cleanuphistory_delete_failure_is_counted():
         await cog.cleanup_history.callback(cog, ctx, 10, keyword="keyword keyword")
     completion = ctx.send.await_args_list[-1].args[0]
     assert "failed 1" in completion
+
+
+@pytest.mark.asyncio
+async def test_cleanuphistory_limit_above_max_is_clamped():
+    cog = Cleanup(MagicMock())
+    ctx = _ctx([_msg("badword")])
+    confirm = MagicMock(id=100)
+    confirm.add_reaction = AsyncMock()
+    confirm.delete = AsyncMock()
+    ctx.send.side_effect = [MagicMock(), confirm, MagicMock()]
+    with (
+        patch("cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=["badword"])),
+        patch("cogs.cleanup_cog.build_history_cleanup_plan", new=AsyncMock(return_value=SimpleNamespace(scanned=1, matched=[_msg("badword")]))) as planner,
+        patch.object(cog.bot, "wait_for", new=AsyncMock(return_value=(_confirmed_reaction(), ctx.author))),
+    ):
+        await cog.cleanup_history.callback(cog, ctx, MAX_CLEANUP_HISTORY_LIMIT + 1, keyword="prohibited")
+    assert planner.await_args.kwargs["limit"] == MAX_CLEANUP_HISTORY_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_cleanuphistory_missing_manage_messages_stops_early():
+    cog = Cleanup(MagicMock())
+    ctx = _ctx([_msg("badword")])
+    ctx.channel.permissions_for.return_value = SimpleNamespace(manage_messages=False)
+    with patch("cogs.cleanup_cog.build_history_cleanup_plan", new=AsyncMock()) as planner:
+        await cog.cleanup_history.callback(cog, ctx, 100, keyword="prohibited")
+    planner.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cleanuphistory_spam_mode_duplicate_window():
+    now = discord.utils.utcnow()
+    first = _msg("Hello   there")
+    first.created_at = now
+    second = _msg("hello there")
+    second.created_at = now - timedelta(seconds=5)
+    third = _msg("hello there")
+    third.created_at = now - timedelta(seconds=30)
+    cog = Cleanup(MagicMock())
+    ctx = _ctx([first, second, third])
+    confirm = MagicMock(id=100)
+    confirm.add_reaction = AsyncMock()
+    confirm.delete = AsyncMock()
+    ctx.send.side_effect = [confirm, MagicMock()]
+    with (
+        patch("cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=[])),
+        patch.object(cog.bot, "wait_for", new=AsyncMock(return_value=(_confirmed_reaction(), ctx.author))),
+    ):
+        await cog.cleanup_history.callback(cog, ctx, 100, keyword="spam")
+    first.delete.assert_not_called()
+    second.delete.assert_awaited_once()
+    third.delete.assert_not_called()

--- a/tests/unit/cogs/test_cleanup_history.py
+++ b/tests/unit/cogs/test_cleanup_history.py
@@ -206,6 +206,10 @@ async def test_cleanuphistory_limit_above_max_is_clamped():
     ):
         await cog.cleanup_history.callback(cog, ctx, MAX_CLEANUP_HISTORY_LIMIT + 1, keyword="prohibited")
     assert planner.await_args.kwargs["limit"] == MAX_CLEANUP_HISTORY_LIMIT
+    warning = ctx.send.await_args_list[0].args[0]
+    final = ctx.send.await_args_list[-1].args[0]
+    assert "Requested" in warning and "Maximum" in warning
+    assert "effective" in final and "Scanned" in final
 
 
 @pytest.mark.asyncio
@@ -221,14 +225,15 @@ async def test_cleanuphistory_missing_manage_messages_stops_early():
 @pytest.mark.asyncio
 async def test_cleanuphistory_spam_mode_duplicate_window():
     now = discord.utils.utcnow()
-    first = _msg("Hello   there")
-    first.created_at = now
-    second = _msg("hello there")
-    second.created_at = now - timedelta(seconds=5)
-    third = _msg("hello there")
-    third.created_at = now - timedelta(seconds=30)
+    newest = _msg("hello there")
+    newest.created_at = now
+    middle = _msg("Hello   there")
+    middle.created_at = now - timedelta(seconds=5)
+    oldest = _msg("hello there")
+    oldest.created_at = now - timedelta(seconds=30)
     cog = Cleanup(MagicMock())
-    ctx = _ctx([first, second, third])
+    # history() is newest-first; spam logic must still preserve oldest in a burst.
+    ctx = _ctx([newest, middle, oldest])
     confirm = MagicMock(id=100)
     confirm.add_reaction = AsyncMock()
     confirm.delete = AsyncMock()
@@ -238,6 +243,6 @@ async def test_cleanuphistory_spam_mode_duplicate_window():
         patch.object(cog.bot, "wait_for", new=AsyncMock(return_value=(_confirmed_reaction(), ctx.author))),
     ):
         await cog.cleanup_history.callback(cog, ctx, 100, keyword="spam")
-    first.delete.assert_not_called()
-    second.delete.assert_awaited_once()
-    third.delete.assert_not_called()
+    oldest.delete.assert_not_called()
+    middle.delete.assert_not_called()
+    newest.delete.assert_awaited_once()

--- a/tests/unit/cogs/test_cleanup_history.py
+++ b/tests/unit/cogs/test_cleanup_history.py
@@ -44,6 +44,12 @@ def _ctx(messages):
     return ctx
 
 
+def _reply():
+    m = MagicMock()
+    m.delete = AsyncMock()
+    return m
+
+
 def _confirmed_reaction():
     return SimpleNamespace(emoji="✅", message=SimpleNamespace(id=100))
 
@@ -57,7 +63,7 @@ async def test_cleanuphistory_keyword_mode_deletes_only_matching_message():
     confirm = MagicMock(id=100)
     confirm.add_reaction = AsyncMock()
     confirm.delete = AsyncMock()
-    ctx.send.side_effect = [confirm, MagicMock()]
+    ctx.send.side_effect = [confirm, _reply()]
     with (
         patch(
             "cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=[]),
@@ -82,7 +88,7 @@ async def test_cleanuphistory_backward_compat_keyword():
     confirm = MagicMock(id=100)
     confirm.add_reaction = AsyncMock()
     confirm.delete = AsyncMock()
-    ctx.send.side_effect = [confirm, MagicMock()]
+    ctx.send.side_effect = [confirm, _reply()]
     with (
         patch(
             "cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=[]),
@@ -108,7 +114,7 @@ async def test_cleanuphistory_commands_mode_deletes_prefixed_messages():
     confirm = MagicMock(id=100)
     confirm.add_reaction = AsyncMock()
     confirm.delete = AsyncMock()
-    ctx.send.side_effect = [confirm, MagicMock()]
+    ctx.send.side_effect = [confirm, _reply()]
     with (
         patch(
             "cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=[]),
@@ -134,7 +140,7 @@ async def test_cleanuphistory_prohibited_mode_uses_word_boundary():
     confirm = MagicMock(id=100)
     confirm.add_reaction = AsyncMock()
     confirm.delete = AsyncMock()
-    ctx.send.side_effect = [confirm, MagicMock()]
+    ctx.send.side_effect = [confirm, _reply()]
     with (
         patch(
             "cogs.cleanup_cog.db.get_prohibited_words",
@@ -171,7 +177,7 @@ async def test_cleanuphistory_no_filter_defaults_to_prohibited():
     confirm = MagicMock(id=100)
     confirm.add_reaction = AsyncMock()
     confirm.delete = AsyncMock()
-    ctx.send.side_effect = [confirm, MagicMock()]
+    ctx.send.side_effect = [confirm, _reply()]
     with (
         patch(
             "cogs.cleanup_cog.db.get_prohibited_words",
@@ -195,7 +201,7 @@ async def test_cleanuphistory_cancel_confirmation_deletes_nothing():
     confirm = MagicMock(id=100)
     confirm.add_reaction = AsyncMock()
     confirm.delete = AsyncMock()
-    ctx.send.side_effect = [confirm, MagicMock()]
+    ctx.send.side_effect = [confirm, _reply()]
     reaction = SimpleNamespace(emoji="❌", message=SimpleNamespace(id=100))
     with (
         patch(
@@ -220,7 +226,7 @@ async def test_cleanuphistory_delete_failure_is_counted():
     confirm = MagicMock(id=100)
     confirm.add_reaction = AsyncMock()
     confirm.delete = AsyncMock()
-    status_msg = MagicMock()
+    status_msg = _reply()
     ctx.send.side_effect = [confirm, status_msg]
     with (
         patch(
@@ -244,7 +250,7 @@ async def test_cleanuphistory_limit_above_max_is_clamped():
     confirm = MagicMock(id=100)
     confirm.add_reaction = AsyncMock()
     confirm.delete = AsyncMock()
-    ctx.send.side_effect = [MagicMock(), confirm, MagicMock()]
+    ctx.send.side_effect = [_reply(), confirm, _reply()]
     with (
         patch(
             "cogs.cleanup_cog.db.get_prohibited_words",
@@ -301,7 +307,7 @@ async def test_cleanuphistory_spam_mode_duplicate_window():
     confirm = MagicMock(id=100)
     confirm.add_reaction = AsyncMock()
     confirm.delete = AsyncMock()
-    ctx.send.side_effect = [confirm, MagicMock()]
+    ctx.send.side_effect = [confirm, _reply()]
     with (
         patch(
             "cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=[]),

--- a/tests/unit/cogs/test_cleanup_history.py
+++ b/tests/unit/cogs/test_cleanup_history.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from cogs.cleanup_cog import Cleanup
+
+
+def _msg(content: str):
+    m = MagicMock()
+    m.content = content
+    m.author = SimpleNamespace(bot=False)
+    m.delete = AsyncMock()
+    return m
+
+
+def _ctx(messages):
+    ctx = MagicMock()
+    ctx.guild = SimpleNamespace(id=1)
+    ctx.channel = MagicMock()
+
+    async def _history(limit=100):
+        for m in messages[:limit]:
+            yield m
+
+    ctx.channel.history = _history
+    ctx.channel.name = "general"
+    ctx.channel.id = 9
+    ctx.author = SimpleNamespace(id=42)
+    ctx.message = MagicMock()
+    ctx.message.delete = AsyncMock()
+    ctx.send = AsyncMock()
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_cleanuphistory_keyword_mode_deletes_matches():
+    cog = Cleanup(MagicMock())
+    ctx = _ctx([_msg("hello bad"), _msg("clean")])
+    confirm = MagicMock(id=100)
+    confirm.add_reaction = AsyncMock()
+    confirm.delete = AsyncMock()
+    ctx.send.side_effect = [confirm, MagicMock()]
+    reaction = SimpleNamespace(emoji="✅", message=SimpleNamespace(id=100))
+    with (
+        patch("cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=[])),
+        patch.object(cog.bot, "wait_for", new=AsyncMock(return_value=(reaction, ctx.author))),
+    ):
+        await cog.cleanup_history.callback(cog, ctx, 10, keyword="keyword bad")
+    assert ctx.channel.history is not None
+    assert ctx.send.await_count >= 2
+
+
+@pytest.mark.asyncio
+async def test_cleanuphistory_backward_compat_keyword():
+    cog = Cleanup(MagicMock())
+    match = _msg("contains legacyword")
+    ctx = _ctx([match])
+    confirm = MagicMock(id=100)
+    confirm.add_reaction = AsyncMock()
+    confirm.delete = AsyncMock()
+    ctx.send.side_effect = [confirm, MagicMock()]
+    reaction = SimpleNamespace(emoji="✅", message=SimpleNamespace(id=100))
+    with (
+        patch("cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=[])),
+        patch.object(cog.bot, "wait_for", new=AsyncMock(return_value=(reaction, ctx.author))),
+    ):
+        await cog.cleanup_history.callback(cog, ctx, 10, keyword="legacyword")
+    match.delete.assert_awaited_once()
+

--- a/tests/unit/cogs/test_cleanup_history.py
+++ b/tests/unit/cogs/test_cleanup_history.py
@@ -7,7 +7,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import discord
 import pytest
 
-from cogs.cleanup_cog import Cleanup, MAX_CLEANUP_HISTORY_LIMIT
+from cogs.cleanup_cog import MAX_CLEANUP_HISTORY_LIMIT, Cleanup
+
+# ruff: noqa: S101
 
 
 def _msg(content: str):
@@ -30,7 +32,7 @@ def _ctx(messages):
 
     ctx.channel.history = _history
     ctx.channel.permissions_for = MagicMock(
-        return_value=SimpleNamespace(manage_messages=True)
+        return_value=SimpleNamespace(manage_messages=True),
     )
     ctx.channel.name = "general"
     ctx.channel.id = 9
@@ -57,8 +59,14 @@ async def test_cleanuphistory_keyword_mode_deletes_only_matching_message():
     confirm.delete = AsyncMock()
     ctx.send.side_effect = [confirm, MagicMock()]
     with (
-        patch("cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=[])),
-        patch.object(cog.bot, "wait_for", new=AsyncMock(return_value=(_confirmed_reaction(), ctx.author))),
+        patch(
+            "cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            cog.bot,
+            "wait_for",
+            new=AsyncMock(return_value=(_confirmed_reaction(), ctx.author)),
+        ),
     ):
         await cog.cleanup_history.callback(cog, ctx, 10, keyword="keyword bad")
     match.delete.assert_awaited_once()
@@ -76,8 +84,14 @@ async def test_cleanuphistory_backward_compat_keyword():
     confirm.delete = AsyncMock()
     ctx.send.side_effect = [confirm, MagicMock()]
     with (
-        patch("cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=[])),
-        patch.object(cog.bot, "wait_for", new=AsyncMock(return_value=(_confirmed_reaction(), ctx.author))),
+        patch(
+            "cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            cog.bot,
+            "wait_for",
+            new=AsyncMock(return_value=(_confirmed_reaction(), ctx.author)),
+        ),
     ):
         await cog.cleanup_history.callback(cog, ctx, 10, keyword="legacyword")
     match.delete.assert_awaited_once()
@@ -96,8 +110,14 @@ async def test_cleanuphistory_commands_mode_deletes_prefixed_messages():
     confirm.delete = AsyncMock()
     ctx.send.side_effect = [confirm, MagicMock()]
     with (
-        patch("cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=[])),
-        patch.object(cog.bot, "wait_for", new=AsyncMock(return_value=(_confirmed_reaction(), ctx.author))),
+        patch(
+            "cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            cog.bot,
+            "wait_for",
+            new=AsyncMock(return_value=(_confirmed_reaction(), ctx.author)),
+        ),
     ):
         await cog.cleanup_history.callback(cog, ctx, 10, keyword="commands")
     cmd.delete.assert_awaited_once()
@@ -116,8 +136,15 @@ async def test_cleanuphistory_prohibited_mode_uses_word_boundary():
     confirm.delete = AsyncMock()
     ctx.send.side_effect = [confirm, MagicMock()]
     with (
-        patch("cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=["badword"])),
-        patch.object(cog.bot, "wait_for", new=AsyncMock(return_value=(_confirmed_reaction(), ctx.author))),
+        patch(
+            "cogs.cleanup_cog.db.get_prohibited_words",
+            new=AsyncMock(return_value=["badword"]),
+        ),
+        patch.object(
+            cog.bot,
+            "wait_for",
+            new=AsyncMock(return_value=(_confirmed_reaction(), ctx.author)),
+        ),
     ):
         await cog.cleanup_history.callback(cog, ctx, 10, keyword="prohibited")
     exact.delete.assert_awaited_once()
@@ -128,7 +155,9 @@ async def test_cleanuphistory_prohibited_mode_uses_word_boundary():
 async def test_cleanuphistory_zero_match_skips_confirmation():
     cog = Cleanup(MagicMock())
     ctx = _ctx([_msg("hello world")])
-    with patch("cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=[])):
+    with patch(
+        "cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=[]),
+    ):
         await cog.cleanup_history.callback(cog, ctx, 10, keyword="keyword missing")
     first_msg = ctx.send.await_args_list[0].args[0]
     assert "Matched 0" in first_msg
@@ -144,8 +173,15 @@ async def test_cleanuphistory_no_filter_defaults_to_prohibited():
     confirm.delete = AsyncMock()
     ctx.send.side_effect = [confirm, MagicMock()]
     with (
-        patch("cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=["badword"])),
-        patch.object(cog.bot, "wait_for", new=AsyncMock(return_value=(_confirmed_reaction(), ctx.author))),
+        patch(
+            "cogs.cleanup_cog.db.get_prohibited_words",
+            new=AsyncMock(return_value=["badword"]),
+        ),
+        patch.object(
+            cog.bot,
+            "wait_for",
+            new=AsyncMock(return_value=(_confirmed_reaction(), ctx.author)),
+        ),
     ):
         await cog.cleanup_history.callback(cog, ctx, 100, keyword=None)
     exact.delete.assert_awaited_once()
@@ -162,8 +198,12 @@ async def test_cleanuphistory_cancel_confirmation_deletes_nothing():
     ctx.send.side_effect = [confirm, MagicMock()]
     reaction = SimpleNamespace(emoji="❌", message=SimpleNamespace(id=100))
     with (
-        patch("cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=[])),
-        patch.object(cog.bot, "wait_for", new=AsyncMock(return_value=(reaction, ctx.author))),
+        patch(
+            "cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            cog.bot, "wait_for", new=AsyncMock(return_value=(reaction, ctx.author)),
+        ),
     ):
         await cog.cleanup_history.callback(cog, ctx, 10, keyword="keyword keyword")
     match.delete.assert_not_called()
@@ -183,8 +223,14 @@ async def test_cleanuphistory_delete_failure_is_counted():
     status_msg = MagicMock()
     ctx.send.side_effect = [confirm, status_msg]
     with (
-        patch("cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=[])),
-        patch.object(cog.bot, "wait_for", new=AsyncMock(return_value=(_confirmed_reaction(), ctx.author))),
+        patch(
+            "cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            cog.bot,
+            "wait_for",
+            new=AsyncMock(return_value=(_confirmed_reaction(), ctx.author)),
+        ),
     ):
         await cog.cleanup_history.callback(cog, ctx, 10, keyword="keyword keyword")
     completion = ctx.send.await_args_list[-1].args[0]
@@ -200,16 +246,32 @@ async def test_cleanuphistory_limit_above_max_is_clamped():
     confirm.delete = AsyncMock()
     ctx.send.side_effect = [MagicMock(), confirm, MagicMock()]
     with (
-        patch("cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=["badword"])),
-        patch("cogs.cleanup_cog.build_history_cleanup_plan", new=AsyncMock(return_value=SimpleNamespace(scanned=1, matched=[_msg("badword")]))) as planner,
-        patch.object(cog.bot, "wait_for", new=AsyncMock(return_value=(_confirmed_reaction(), ctx.author))),
+        patch(
+            "cogs.cleanup_cog.db.get_prohibited_words",
+            new=AsyncMock(return_value=["badword"]),
+        ),
+        patch(
+            "cogs.cleanup_cog.build_history_cleanup_plan",
+            new=AsyncMock(
+                return_value=SimpleNamespace(scanned=1, matched=[_msg("badword")]),
+            ),
+        ) as planner,
+        patch.object(
+            cog.bot,
+            "wait_for",
+            new=AsyncMock(return_value=(_confirmed_reaction(), ctx.author)),
+        ),
     ):
-        await cog.cleanup_history.callback(cog, ctx, MAX_CLEANUP_HISTORY_LIMIT + 1, keyword="prohibited")
+        await cog.cleanup_history.callback(
+            cog, ctx, MAX_CLEANUP_HISTORY_LIMIT + 1, keyword="prohibited",
+        )
     assert planner.await_args.kwargs["limit"] == MAX_CLEANUP_HISTORY_LIMIT
     warning = ctx.send.await_args_list[0].args[0]
     final = ctx.send.await_args_list[-1].args[0]
-    assert "Requested" in warning and "Maximum" in warning
-    assert "effective" in final and "Scanned" in final
+    assert "Requested" in warning
+    assert "Maximum" in warning
+    assert "effective" in final
+    assert "Scanned" in final
 
 
 @pytest.mark.asyncio
@@ -217,7 +279,9 @@ async def test_cleanuphistory_missing_manage_messages_stops_early():
     cog = Cleanup(MagicMock())
     ctx = _ctx([_msg("badword")])
     ctx.channel.permissions_for.return_value = SimpleNamespace(manage_messages=False)
-    with patch("cogs.cleanup_cog.build_history_cleanup_plan", new=AsyncMock()) as planner:
+    with patch(
+        "cogs.cleanup_cog.build_history_cleanup_plan", new=AsyncMock(),
+    ) as planner:
         await cog.cleanup_history.callback(cog, ctx, 100, keyword="prohibited")
     planner.assert_not_awaited()
 
@@ -239,8 +303,14 @@ async def test_cleanuphistory_spam_mode_duplicate_window():
     confirm.delete = AsyncMock()
     ctx.send.side_effect = [confirm, MagicMock()]
     with (
-        patch("cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=[])),
-        patch.object(cog.bot, "wait_for", new=AsyncMock(return_value=(_confirmed_reaction(), ctx.author))),
+        patch(
+            "cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            cog.bot,
+            "wait_for",
+            new=AsyncMock(return_value=(_confirmed_reaction(), ctx.author)),
+        ),
     ):
         await cog.cleanup_history.callback(cog, ctx, 100, keyword="spam")
     oldest.delete.assert_not_called()

--- a/tests/unit/cogs/test_cleanup_history.py
+++ b/tests/unit/cogs/test_cleanup_history.py
@@ -19,7 +19,8 @@ def _msg(content: str):
 
 def _ctx(messages):
     ctx = MagicMock()
-    ctx.guild = SimpleNamespace(id=1)
+    me = SimpleNamespace()
+    ctx.guild = SimpleNamespace(id=1, me=me)
     ctx.channel = MagicMock()
 
     async def _history(limit=100):
@@ -27,6 +28,9 @@ def _ctx(messages):
             yield m
 
     ctx.channel.history = _history
+    ctx.channel.permissions_for = MagicMock(
+        return_value=SimpleNamespace(manage_messages=True)
+    )
     ctx.channel.name = "general"
     ctx.channel.id = 9
     ctx.author = SimpleNamespace(id=42)
@@ -36,22 +40,27 @@ def _ctx(messages):
     return ctx
 
 
+def _confirmed_reaction():
+    return SimpleNamespace(emoji="✅", message=SimpleNamespace(id=100))
+
+
 @pytest.mark.asyncio
-async def test_cleanuphistory_keyword_mode_deletes_matches():
+async def test_cleanuphistory_keyword_mode_deletes_only_matching_message():
     cog = Cleanup(MagicMock())
-    ctx = _ctx([_msg("hello bad"), _msg("clean")])
+    match = _msg("hello bad")
+    other = _msg("clean")
+    ctx = _ctx([match, other])
     confirm = MagicMock(id=100)
     confirm.add_reaction = AsyncMock()
     confirm.delete = AsyncMock()
     ctx.send.side_effect = [confirm, MagicMock()]
-    reaction = SimpleNamespace(emoji="✅", message=SimpleNamespace(id=100))
     with (
         patch("cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=[])),
-        patch.object(cog.bot, "wait_for", new=AsyncMock(return_value=(reaction, ctx.author))),
+        patch.object(cog.bot, "wait_for", new=AsyncMock(return_value=(_confirmed_reaction(), ctx.author))),
     ):
         await cog.cleanup_history.callback(cog, ctx, 10, keyword="keyword bad")
-    assert ctx.channel.history is not None
-    assert ctx.send.await_count >= 2
+    match.delete.assert_awaited_once()
+    other.delete.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -63,11 +72,97 @@ async def test_cleanuphistory_backward_compat_keyword():
     confirm.add_reaction = AsyncMock()
     confirm.delete = AsyncMock()
     ctx.send.side_effect = [confirm, MagicMock()]
-    reaction = SimpleNamespace(emoji="✅", message=SimpleNamespace(id=100))
     with (
         patch("cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=[])),
-        patch.object(cog.bot, "wait_for", new=AsyncMock(return_value=(reaction, ctx.author))),
+        patch.object(cog.bot, "wait_for", new=AsyncMock(return_value=(_confirmed_reaction(), ctx.author))),
     ):
         await cog.cleanup_history.callback(cog, ctx, 10, keyword="legacyword")
     match.delete.assert_awaited_once()
 
+
+@pytest.mark.asyncio
+async def test_cleanuphistory_commands_mode_deletes_prefixed_messages():
+    cog = Cleanup(MagicMock())
+    cmd = _msg("   !help me")
+    normal = _msg("hello world")
+    ctx = _ctx([cmd, normal])
+    confirm = MagicMock(id=100)
+    confirm.add_reaction = AsyncMock()
+    confirm.delete = AsyncMock()
+    ctx.send.side_effect = [confirm, MagicMock()]
+    with (
+        patch("cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=[])),
+        patch.object(cog.bot, "wait_for", new=AsyncMock(return_value=(_confirmed_reaction(), ctx.author))),
+    ):
+        await cog.cleanup_history.callback(cog, ctx, 10, keyword="commands")
+    cmd.delete.assert_awaited_once()
+    normal.delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cleanuphistory_prohibited_mode_uses_word_boundary():
+    cog = Cleanup(MagicMock())
+    exact = _msg("this has badword here")
+    partial = _msg("this has badwording")
+    ctx = _ctx([exact, partial])
+    confirm = MagicMock(id=100)
+    confirm.add_reaction = AsyncMock()
+    confirm.delete = AsyncMock()
+    ctx.send.side_effect = [confirm, MagicMock()]
+    with (
+        patch("cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=["badword"])),
+        patch.object(cog.bot, "wait_for", new=AsyncMock(return_value=(_confirmed_reaction(), ctx.author))),
+    ):
+        await cog.cleanup_history.callback(cog, ctx, 10, keyword="prohibited")
+    exact.delete.assert_awaited_once()
+    partial.delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cleanuphistory_zero_match_skips_confirmation():
+    cog = Cleanup(MagicMock())
+    ctx = _ctx([_msg("hello world")])
+    with patch("cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=[])):
+        await cog.cleanup_history.callback(cog, ctx, 10, keyword="keyword missing")
+    first_msg = ctx.send.await_args_list[0].args[0]
+    assert "Matched 0" in first_msg
+
+
+@pytest.mark.asyncio
+async def test_cleanuphistory_cancel_confirmation_deletes_nothing():
+    cog = Cleanup(MagicMock())
+    match = _msg("keyword hit")
+    ctx = _ctx([match])
+    confirm = MagicMock(id=100)
+    confirm.add_reaction = AsyncMock()
+    confirm.delete = AsyncMock()
+    ctx.send.side_effect = [confirm, MagicMock()]
+    reaction = SimpleNamespace(emoji="❌", message=SimpleNamespace(id=100))
+    with (
+        patch("cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=[])),
+        patch.object(cog.bot, "wait_for", new=AsyncMock(return_value=(reaction, ctx.author))),
+    ):
+        await cog.cleanup_history.callback(cog, ctx, 10, keyword="keyword keyword")
+    match.delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cleanuphistory_delete_failure_is_counted():
+    cog = Cleanup(MagicMock())
+    match = _msg("keyword hit")
+    resp = MagicMock(status=500)
+    resp.reason = "oops"
+    match.delete.side_effect = discord.HTTPException(resp, "boom")
+    ctx = _ctx([match])
+    confirm = MagicMock(id=100)
+    confirm.add_reaction = AsyncMock()
+    confirm.delete = AsyncMock()
+    status_msg = MagicMock()
+    ctx.send.side_effect = [confirm, status_msg]
+    with (
+        patch("cogs.cleanup_cog.db.get_prohibited_words", new=AsyncMock(return_value=[])),
+        patch.object(cog.bot, "wait_for", new=AsyncMock(return_value=(_confirmed_reaction(), ctx.author))),
+    ):
+        await cog.cleanup_history.callback(cog, ctx, 10, keyword="keyword keyword")
+    completion = ctx.send.await_args_list[-1].args[0]
+    assert "failed 1" in completion

--- a/tests/unit/runtime/test_successful_command_cleanup.py
+++ b/tests/unit/runtime/test_successful_command_cleanup.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+import bot1
+
+
+def _ctx(*, guild=True, bot_author=False, with_message=True):
+    ctx = MagicMock()
+    ctx.guild = MagicMock() if guild else None
+    ctx.author = MagicMock()
+    ctx.author.bot = bot_author
+    ctx.channel = MagicMock()
+    ctx.channel.id = 123
+    if with_message:
+        ctx.message = MagicMock()
+        ctx.message.delete = AsyncMock()
+    else:
+        ctx.message = None
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_successful_command_is_deleted_when_policy_says_delete():
+    ctx = _ctx()
+    policy = SimpleNamespace(delete_message=True, delete_after_seconds=7)
+    with (
+        patch("bot1.governance_service.GovernanceContext.from_ctx", return_value=MagicMock()),
+        patch("bot1.governance_service.resolve_cleanup_policy", new=AsyncMock(return_value=policy)),
+    ):
+        await bot1._maybe_cleanup_successful_command(ctx)
+    ctx.message.delete.assert_awaited_once_with(delay=7)
+
+
+@pytest.mark.asyncio
+async def test_successful_command_preserved_when_policy_says_no_delete():
+    ctx = _ctx()
+    policy = SimpleNamespace(delete_message=False, delete_after_seconds=0)
+    with (
+        patch("bot1.governance_service.GovernanceContext.from_ctx", return_value=MagicMock()),
+        patch("bot1.governance_service.resolve_cleanup_policy", new=AsyncMock(return_value=policy)),
+    ):
+        await bot1._maybe_cleanup_successful_command(ctx)
+    ctx.message.delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dm_context_is_ignored():
+    ctx = _ctx(guild=False)
+    await bot1._maybe_cleanup_successful_command(ctx)
+    ctx.message.delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_missing_message_is_ignored():
+    ctx = _ctx(with_message=False)
+    await bot1._maybe_cleanup_successful_command(ctx)
+
+
+@pytest.mark.asyncio
+async def test_forbidden_does_not_raise():
+    ctx = _ctx()
+    response = MagicMock(status=403)
+    response.reason = "Forbidden"
+    policy = SimpleNamespace(delete_message=True, delete_after_seconds=0)
+    ctx.message.delete.side_effect = discord.Forbidden(response, "Forbidden")
+    with (
+        patch("bot1.governance_service.GovernanceContext.from_ctx", return_value=MagicMock()),
+        patch("bot1.governance_service.resolve_cleanup_policy", new=AsyncMock(return_value=policy)),
+    ):
+        await bot1._maybe_cleanup_successful_command(ctx)

--- a/tests/unit/runtime/test_successful_command_cleanup.py
+++ b/tests/unit/runtime/test_successful_command_cleanup.py
@@ -29,8 +29,14 @@ async def test_successful_command_is_deleted_when_policy_says_delete():
     ctx = _ctx()
     policy = SimpleNamespace(delete_message=True, delete_after_seconds=7)
     with (
-        patch("services.governance_service.GovernanceContext.from_ctx", return_value=MagicMock()),
-        patch("services.governance_service.resolve_cleanup_policy", new=AsyncMock(return_value=policy)),
+        patch(
+            "services.governance_service.GovernanceContext.from_ctx",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "services.governance_service.resolve_cleanup_policy",
+            new=AsyncMock(return_value=policy),
+        ),
     ):
         await bot1._maybe_cleanup_successful_command(ctx)
     ctx.message.delete.assert_awaited_once_with(delay=7)
@@ -41,8 +47,14 @@ async def test_successful_command_preserved_when_policy_says_no_delete():
     ctx = _ctx()
     policy = SimpleNamespace(delete_message=False, delete_after_seconds=0)
     with (
-        patch("services.governance_service.GovernanceContext.from_ctx", return_value=MagicMock()),
-        patch("services.governance_service.resolve_cleanup_policy", new=AsyncMock(return_value=policy)),
+        patch(
+            "services.governance_service.GovernanceContext.from_ctx",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "services.governance_service.resolve_cleanup_policy",
+            new=AsyncMock(return_value=policy),
+        ),
     ):
         await bot1._maybe_cleanup_successful_command(ctx)
     ctx.message.delete.assert_not_called()
@@ -69,7 +81,13 @@ async def test_forbidden_does_not_raise():
     policy = SimpleNamespace(delete_message=True, delete_after_seconds=0)
     ctx.message.delete.side_effect = discord.Forbidden(response, "Forbidden")
     with (
-        patch("services.governance_service.GovernanceContext.from_ctx", return_value=MagicMock()),
-        patch("services.governance_service.resolve_cleanup_policy", new=AsyncMock(return_value=policy)),
+        patch(
+            "services.governance_service.GovernanceContext.from_ctx",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "services.governance_service.resolve_cleanup_policy",
+            new=AsyncMock(return_value=policy),
+        ),
     ):
         await bot1._maybe_cleanup_successful_command(ctx)

--- a/tests/unit/runtime/test_successful_command_cleanup.py
+++ b/tests/unit/runtime/test_successful_command_cleanup.py
@@ -29,8 +29,8 @@ async def test_successful_command_is_deleted_when_policy_says_delete():
     ctx = _ctx()
     policy = SimpleNamespace(delete_message=True, delete_after_seconds=7)
     with (
-        patch("bot1.governance_service.GovernanceContext.from_ctx", return_value=MagicMock()),
-        patch("bot1.governance_service.resolve_cleanup_policy", new=AsyncMock(return_value=policy)),
+        patch("services.governance_service.GovernanceContext.from_ctx", return_value=MagicMock()),
+        patch("services.governance_service.resolve_cleanup_policy", new=AsyncMock(return_value=policy)),
     ):
         await bot1._maybe_cleanup_successful_command(ctx)
     ctx.message.delete.assert_awaited_once_with(delay=7)
@@ -41,8 +41,8 @@ async def test_successful_command_preserved_when_policy_says_no_delete():
     ctx = _ctx()
     policy = SimpleNamespace(delete_message=False, delete_after_seconds=0)
     with (
-        patch("bot1.governance_service.GovernanceContext.from_ctx", return_value=MagicMock()),
-        patch("bot1.governance_service.resolve_cleanup_policy", new=AsyncMock(return_value=policy)),
+        patch("services.governance_service.GovernanceContext.from_ctx", return_value=MagicMock()),
+        patch("services.governance_service.resolve_cleanup_policy", new=AsyncMock(return_value=policy)),
     ):
         await bot1._maybe_cleanup_successful_command(ctx)
     ctx.message.delete.assert_not_called()
@@ -69,7 +69,7 @@ async def test_forbidden_does_not_raise():
     policy = SimpleNamespace(delete_message=True, delete_after_seconds=0)
     ctx.message.delete.side_effect = discord.Forbidden(response, "Forbidden")
     with (
-        patch("bot1.governance_service.GovernanceContext.from_ctx", return_value=MagicMock()),
-        patch("bot1.governance_service.resolve_cleanup_policy", new=AsyncMock(return_value=policy)),
+        patch("services.governance_service.GovernanceContext.from_ctx", return_value=MagicMock()),
+        patch("services.governance_service.resolve_cleanup_policy", new=AsyncMock(return_value=policy)),
     ):
         await bot1._maybe_cleanup_successful_command(ctx)


### PR DESCRIPTION
### Motivation
- Fix `!syncslash guild` so guild-local syncs actually copy global app commands into the guild before syncing. 
- Ensure strict cleanup removes successful prefix-command invocation messages when governance policy requires it. 
- Make `!cleanuphistory` reliably scan, present, and delete matched messages rather than reusing the live classifier and missing matches.

### Description
- Update `AdminCog.sync_slash_commands` to call `self.bot.tree.copy_global_to(guild=guild)` before `self.bot.tree.sync(guild=guild)` and improve user-facing guild success/guidance text and stale doc wording in `disbot/cogs/admin_cog.py`.
- Add a centralized helper `_maybe_cleanup_successful_command(ctx)` and call it from `on_command_completion` in `disbot/bot1.py` to resolve the effective cleanup policy via the existing governance resolver and delete successful user command messages when policy requires it, while handling `NotFound`, `Forbidden`, and `HTTPException` safely.
- Rework `cleanup_history` in `disbot/cogs/cleanup_cog.py` to build an explicit scan/match plan and delete only the matched messages after confirmation, supporting `keyword`, `commands`, and `prohibited` modes and preserving backward-compatible `!cleanuphistory <limit> <word>` behavior.
- Add a small helper service `disbot/services/history_cleanup.py` implementing `build_history_cleanup_plan` to keep history scanning logic out of the cog.
- Preserve existing governance cleanup resolution and blocked-command cleanup behavior; do not change setup wizard, counting/parsing logic, or message-pipeline architecture.
- Add unit tests covering guild sync behavior and guidance, successful-command cleanup helper behavior, and history-cleanup flows (new tests in `tests/unit/cogs/test_cleanup_history.py` and `tests/unit/runtime/test_successful_command_cleanup.py`, with updates to `tests/unit/cogs/test_admin_slash_sync.py`).

### Testing
- Ran targeted unit tests: `tests/unit/cogs/test_admin_slash_sync.py`, `tests/unit/cogs/test_cleanup_stage.py`, `tests/unit/cogs/test_cleanup_history.py`, and `tests/unit/runtime/test_successful_command_cleanup.py` in this environment.
- The async-marked tests could not complete in the current test environment because the `@pytest.mark.asyncio` plugin/marker is not configured here, causing most async tests to error; non-async assertions and static checks remained unaffected.
- New and updated unit tests are present and exercise the changed behaviors; they are expected to pass in CI environments with the async test plugin (`pytest-asyncio`) available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a100ddbeb848322835446733c189fe6)