### PR TITLE
PR-01a: Platform consistency typed readiness contract

### DIFF
--- a/disbot/services/platform_consistency.py
+++ b/disbot/services/platform_consistency.py
@@ -37,14 +37,18 @@ Informational sections never promote ``overall_status``.
 Public surface:
 
     SectionStatus               — enum
+    ReadinessKind               — enum (typed identity per section)
+    READINESS_KINDS             — canonical-order tuple of every kind
     SectionResult               — frozen dataclass per section
     ConsistencyReport           — frozen dataclass: sections + overall_status
     SETUP_READINESS_BLOCKERS    — tuple of roadmap blocker identifiers
     collect_report(*, bot, guild) — async orchestrator
+    iter_blocking_sections(report) — non-informational, non-CLEAN sections
 """
 
 from __future__ import annotations
 
+import dataclasses
 import datetime
 import logging
 import os
@@ -68,6 +72,68 @@ class SectionStatus(str, Enum):
     SKIPPED = "skipped"
 
 
+class ReadinessKind(str, Enum):
+    """Canonical typed identity for each consistency section.
+
+    PR-01a: every section result returned by ``collect_report`` is
+    stamped with one of these kinds by the orchestrator (collectors
+    do not need to know about kinds — the orchestrator maps from
+    the human label to the typed kind).
+
+    ``READINESS_KINDS`` exports the canonical ordering used by the
+    orchestrator and consumers; the invariant test
+    ``tests/unit/invariants/test_platform_consistency_kinds.py`` pins
+    every collector to a known kind.
+    """
+
+    IDENTITY_CONTRACT = "identity_contract"
+    FEATURE_FLAGS = "feature_flags"
+    ROLLOUT_AUDIT = "rollout_audit"
+    BINDINGS = "bindings"
+    BINDING_BACKFILL = "binding_backfill"
+    CONFIG_ARBITRATION = "config_arbitration"
+    PARTICIPATION = "participation"
+    MIGRATIONS = "migrations"
+    RUNTIME_PROVIDERS = "runtime_providers"
+    SETUP_READINESS = "setup_readiness"
+
+
+# Canonical ordering — matches the orchestrator's collector tuple at
+# ``collect_report``.  ``test_readiness_kinds_canonical_ordering`` pins
+# this ordering so the diagnostic embed and the readiness snapshot can
+# rely on a stable section order.
+READINESS_KINDS: tuple[ReadinessKind, ...] = (
+    ReadinessKind.IDENTITY_CONTRACT,
+    ReadinessKind.FEATURE_FLAGS,
+    ReadinessKind.ROLLOUT_AUDIT,
+    ReadinessKind.BINDINGS,
+    ReadinessKind.BINDING_BACKFILL,
+    ReadinessKind.CONFIG_ARBITRATION,
+    ReadinessKind.PARTICIPATION,
+    ReadinessKind.MIGRATIONS,
+    ReadinessKind.RUNTIME_PROVIDERS,
+    ReadinessKind.SETUP_READINESS,
+)
+
+
+# Maps the human-readable label used by the orchestrator's collector
+# tuple to the typed ``ReadinessKind``.  The orchestrator stamps each
+# collector's ``SectionResult.kind`` from this map after the collector
+# returns, so collectors themselves never need to set ``kind``.
+_LABEL_TO_KIND: dict[str, ReadinessKind] = {
+    "Identity contract": ReadinessKind.IDENTITY_CONTRACT,
+    "Feature flags": ReadinessKind.FEATURE_FLAGS,
+    "Rollout / audit": ReadinessKind.ROLLOUT_AUDIT,
+    "Bindings": ReadinessKind.BINDINGS,
+    "Binding backfill": ReadinessKind.BINDING_BACKFILL,
+    "Config arbitration": ReadinessKind.CONFIG_ARBITRATION,
+    "Participation": ReadinessKind.PARTICIPATION,
+    "Migrations": ReadinessKind.MIGRATIONS,
+    "Runtime providers": ReadinessKind.RUNTIME_PROVIDERS,
+    "Setup readiness": ReadinessKind.SETUP_READINESS,
+}
+
+
 @dataclass(frozen=True)
 class SectionResult:
     name: str
@@ -76,6 +142,13 @@ class SectionResult:
     details: tuple[str, ...] = ()
     suggested_actions: tuple[str, ...] = ()
     informational: bool = False
+    # PR-01a: typed identity stamped by the orchestrator after each
+    # collector returns.  Optional only so collectors can construct
+    # ``SectionResult`` without knowing the kind; the orchestrator
+    # guarantees every section in a collected report has a non-None
+    # kind.  Consumers that build sections outside ``collect_report``
+    # (e.g. unit tests) may leave it as ``None``.
+    kind: ReadinessKind | None = None
 
 
 @dataclass(frozen=True)
@@ -176,10 +249,38 @@ async def collect_report(
                 summary=f"collector raised {type(exc).__name__}",
                 details=(str(exc)[:200],),
             )
+        # PR-01a: stamp the canonical readiness kind from the label.
+        # Collectors construct SectionResult without knowing the kind;
+        # the orchestrator is the single place where the human label
+        # is translated into the typed ``ReadinessKind``.
+        if result.kind is None:
+            result = dataclasses.replace(result, kind=_LABEL_TO_KIND[label])
         sections.append(result)
     return ConsistencyReport(
         sections=tuple(sections),
         generated_at=datetime.datetime.now(tz=datetime.timezone.utc),
+    )
+
+
+def iter_blocking_sections(
+    report: ConsistencyReport,
+) -> tuple[SectionResult, ...]:
+    """Return only non-informational, non-CLEAN sections.
+
+    PR-01a helper used by the upcoming readiness snapshot (PR-01b) and
+    smoke checklist (PR-05) to surface the subset of sections that
+    represent actionable signal — informational roadmap warnings
+    (e.g. "Setup readiness") and CLEAN sections are filtered out.
+
+    ``SKIPPED`` sections are included because "not applicable" can
+    still be a release-relevant signal (e.g. a migration not yet
+    applied that should be).  Consumers that want to filter further
+    can do so on the returned tuple.
+    """
+    return tuple(
+        s
+        for s in report.sections
+        if not s.informational and s.status is not SectionStatus.CLEAN
     )
 
 
@@ -801,8 +902,11 @@ async def _collect_setup_readiness() -> SectionResult:
 
 __all__ = [
     "ConsistencyReport",
+    "READINESS_KINDS",
+    "ReadinessKind",
     "SETUP_READINESS_BLOCKERS",
     "SectionResult",
     "SectionStatus",
     "collect_report",
+    "iter_blocking_sections",
 ]

--- a/tests/unit/invariants/test_platform_consistency_kinds.py
+++ b/tests/unit/invariants/test_platform_consistency_kinds.py
@@ -24,7 +24,6 @@ import pytest
 
 from services import platform_consistency as pc
 
-
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _MODULE_PATH = _REPO_ROOT / "disbot" / "services" / "platform_consistency.py"
 

--- a/tests/unit/invariants/test_platform_consistency_kinds.py
+++ b/tests/unit/invariants/test_platform_consistency_kinds.py
@@ -1,0 +1,111 @@
+"""Invariant tests for the platform consistency typed readiness contract.
+
+Pins two structural constraints introduced in PR-01a:
+
+1. ``_LABEL_TO_KIND`` covers every label used by the
+   ``collect_report`` orchestrator.  Adding a new collector requires
+   adding its label/kind pair here at the same time.
+
+2. ``READINESS_KINDS`` is exhaustive over ``ReadinessKind`` and
+   matches the orchestrator's collector tuple order.  A missing kind
+   would silently lose its identity at runtime.
+
+The runtime stamping behaviour (every section in a collected report
+carries a typed kind) is pinned by
+``tests/unit/services/test_platform_consistency.py``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from services import platform_consistency as pc
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MODULE_PATH = _REPO_ROOT / "disbot" / "services" / "platform_consistency.py"
+
+
+def _extract_collector_labels() -> tuple[str, ...]:
+    """Parse the labels used in the ``collect_report`` collector tuple.
+
+    Handles both ``collectors = (...)`` and the annotated form
+    ``collectors: ... = (...)``.  Returns the string label of each
+    entry in declaration order.
+    """
+    tree = ast.parse(_MODULE_PATH.read_text())
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef) or node.name != "collect_report":
+            continue
+        for sub in ast.walk(node):
+            value: ast.AST | None = None
+            if isinstance(sub, ast.Assign):
+                target = sub.targets[0] if sub.targets else None
+                if isinstance(target, ast.Name) and target.id == "collectors":
+                    value = sub.value
+            elif isinstance(sub, ast.AnnAssign):
+                target = sub.target
+                if isinstance(target, ast.Name) and target.id == "collectors":
+                    value = sub.value
+            if value is None or not isinstance(value, ast.Tuple):
+                continue
+            labels: list[str] = []
+            for entry in value.elts:
+                if (
+                    isinstance(entry, ast.Tuple)
+                    and entry.elts
+                    and isinstance(entry.elts[0], ast.Constant)
+                    and isinstance(entry.elts[0].value, str)
+                ):
+                    labels.append(entry.elts[0].value)
+            return tuple(labels)
+    pytest.fail("Could not locate the `collectors` tuple inside collect_report")
+
+
+def test_label_to_kind_covers_every_collector_label():
+    labels = _extract_collector_labels()
+    assert len(labels) == 10, f"Expected 10 collectors; found {len(labels)}"
+    missing = [label for label in labels if label not in pc._LABEL_TO_KIND]
+    assert not missing, (
+        f"_LABEL_TO_KIND missing entries for: {missing}.  "
+        "Adding a new collector requires updating _LABEL_TO_KIND."
+    )
+
+
+def test_label_to_kind_has_no_orphan_entries():
+    labels = set(_extract_collector_labels())
+    orphan = [label for label in pc._LABEL_TO_KIND if label not in labels]
+    assert not orphan, (
+        f"_LABEL_TO_KIND has orphan entries (no matching collector): {orphan}"
+    )
+
+
+def test_readiness_kinds_matches_label_to_kind_values():
+    """Every kind referenced by ``_LABEL_TO_KIND`` is in
+    ``READINESS_KINDS``, and vice versa."""
+    via_labels = set(pc._LABEL_TO_KIND.values())
+    via_tuple = set(pc.READINESS_KINDS)
+    assert via_labels == via_tuple, (
+        f"READINESS_KINDS / _LABEL_TO_KIND drift: "
+        f"only-in-tuple={via_tuple - via_labels}; "
+        f"only-in-labels={via_labels - via_tuple}"
+    )
+
+
+def test_readiness_kinds_exhausts_enum():
+    """Every ``ReadinessKind`` enum member appears in
+    ``READINESS_KINDS``.  Adding a new enum member requires updating
+    the canonical tuple."""
+    assert set(pc.READINESS_KINDS) == set(pc.ReadinessKind)
+
+
+def test_readiness_kinds_order_matches_collector_order():
+    """The order of ``READINESS_KINDS`` matches the order of labels in
+    the orchestrator's collector tuple.  Diagnostic embeds and the
+    readiness snapshot rely on this ordering."""
+    labels = _extract_collector_labels()
+    expected = tuple(pc._LABEL_TO_KIND[label] for label in labels)
+    assert pc.READINESS_KINDS == expected

--- a/tests/unit/services/test_platform_consistency.py
+++ b/tests/unit/services/test_platform_consistency.py
@@ -597,3 +597,125 @@ def test_collect_report_returns_ten_sections_in_order():
     # Last section must be Setup readiness, marked informational.
     assert report.sections[-1].name == "Setup readiness"
     assert report.sections[-1].informational is True
+
+
+# ---------------------------------------------------------------------------
+# PR-01a: typed readiness kind + iter_blocking_sections
+# ---------------------------------------------------------------------------
+
+
+def test_readiness_kinds_canonical_ordering():
+    """``READINESS_KINDS`` pins the canonical section order.
+
+    The diagnostic embed and the upcoming readiness snapshot rely on
+    this ordering being stable; adding a new collector requires
+    appending its kind and updating ``_LABEL_TO_KIND`` together.
+    """
+    assert pc.READINESS_KINDS == (
+        pc.ReadinessKind.IDENTITY_CONTRACT,
+        pc.ReadinessKind.FEATURE_FLAGS,
+        pc.ReadinessKind.ROLLOUT_AUDIT,
+        pc.ReadinessKind.BINDINGS,
+        pc.ReadinessKind.BINDING_BACKFILL,
+        pc.ReadinessKind.CONFIG_ARBITRATION,
+        pc.ReadinessKind.PARTICIPATION,
+        pc.ReadinessKind.MIGRATIONS,
+        pc.ReadinessKind.RUNTIME_PROVIDERS,
+        pc.ReadinessKind.SETUP_READINESS,
+    )
+    # Every declared kind must appear in the canonical tuple.
+    assert set(pc.READINESS_KINDS) == set(pc.ReadinessKind)
+
+
+def test_collect_report_stamps_typed_kind_on_every_section():
+    """Every section in the collected report has a non-None typed kind
+    matching ``READINESS_KINDS``."""
+
+    async def trivial(*args, **kwargs) -> pc.SectionResult:
+        return pc.SectionResult(name="x", status=pc.SectionStatus.SKIPPED, summary="x")
+
+    with patch.multiple(
+        pc,
+        _collect_identity_contract=trivial,
+        _collect_feature_flags=trivial,
+        _collect_rollout_audit=trivial,
+        _collect_bindings=trivial,
+        _collect_binding_backfill=trivial,
+        _collect_config_arbitration=trivial,
+        _collect_participation=trivial,
+        _collect_migrations=trivial,
+        _collect_runtime_providers=trivial,
+        _collect_setup_readiness=trivial,
+    ):
+        report = asyncio.run(pc.collect_report(bot=object(), guild=None))
+
+    kinds = [s.kind for s in report.sections]
+    assert all(k is not None for k in kinds), f"Untyped section in {kinds}"
+    assert tuple(kinds) == pc.READINESS_KINDS
+
+
+def test_collect_report_stamps_kind_even_when_collector_raises():
+    """A collector exception still produces a typed section."""
+
+    async def bad(*args, **kwargs) -> pc.SectionResult:
+        raise RuntimeError("boom")
+
+    async def trivial(*args, **kwargs) -> pc.SectionResult:
+        return pc.SectionResult(name="x", status=pc.SectionStatus.SKIPPED, summary="x")
+
+    with patch.multiple(
+        pc,
+        _collect_identity_contract=bad,
+        _collect_feature_flags=trivial,
+        _collect_rollout_audit=trivial,
+        _collect_bindings=trivial,
+        _collect_binding_backfill=trivial,
+        _collect_config_arbitration=trivial,
+        _collect_participation=trivial,
+        _collect_migrations=trivial,
+        _collect_runtime_providers=trivial,
+        _collect_setup_readiness=trivial,
+    ):
+        report = asyncio.run(pc.collect_report(bot=object(), guild=None))
+
+    # The FATAL fallback section for identity_contract still gets stamped.
+    assert report.sections[0].status == pc.SectionStatus.FATAL
+    assert report.sections[0].kind == pc.ReadinessKind.IDENTITY_CONTRACT
+
+
+def test_iter_blocking_sections_filters_informational_and_clean():
+    """Non-informational FATAL/WARNING/SKIPPED are returned; CLEAN and
+    informational sections are filtered out."""
+    sections = (
+        pc.SectionResult(name="a", status=pc.SectionStatus.CLEAN, summary=""),
+        pc.SectionResult(name="b", status=pc.SectionStatus.WARNING, summary=""),
+        pc.SectionResult(name="c", status=pc.SectionStatus.FATAL, summary=""),
+        pc.SectionResult(name="d", status=pc.SectionStatus.SKIPPED, summary=""),
+        # Informational warning must be excluded (Setup readiness pattern).
+        pc.SectionResult(
+            name="e", status=pc.SectionStatus.WARNING, summary="", informational=True
+        ),
+    )
+    report = pc.ConsistencyReport(
+        sections=sections,
+        generated_at=datetime.datetime.now(tz=datetime.timezone.utc),
+    )
+    blocking = pc.iter_blocking_sections(report)
+    names = [s.name for s in blocking]
+    assert names == ["b", "c", "d"]
+
+
+def test_iter_blocking_sections_returns_empty_for_all_clean():
+    report = _report(pc.SectionStatus.CLEAN, pc.SectionStatus.CLEAN)
+    assert pc.iter_blocking_sections(report) == ()
+
+
+def test_setup_readiness_section_remains_informational():
+    """Regression pin: the Setup readiness collector must report
+    ``informational=True`` so the static blocker list cannot promote
+    ``overall_status``.  PR-03 (dynamic blocker registry) preserves
+    this contract."""
+    result = asyncio.run(pc._collect_setup_readiness())
+    assert result.informational is True
+    # Canonical section name matches the orchestrator's label mapping.
+    assert result.name == "Setup readiness"


### PR DESCRIPTION
## Summary

Adds the typed readiness layer that the upcoming readiness snapshot (PR-01b), dynamic blocker registry (PR-03), and smoke checklist (PR-05) will consume. **No behaviour change** — collectors continue to construct `SectionResult` without knowing about kinds; the orchestrator stamps the typed kind from the existing human label after each collector returns.

Part of the SuperBot 2.0 refactor plan (see `/root/.claude/plans/1-recommended-target-agent-zazzy-eclipse.md` for the full PR queue).

## Public surface additions

- `ReadinessKind` enum with one member per existing collector (10 kinds)
- `READINESS_KINDS` canonical-order tuple
- `SectionResult.kind` optional field (stamped by orchestrator)
- `iter_blocking_sections(report)` helper — returns non-informational, non-CLEAN sections

## Why a sync optional field instead of mandatory?

Collectors construct `SectionResult` in many places (each has 3-5 return paths). Making `kind` required would force a `kind=...` argument at every callsite (~30+). Instead, the orchestrator stamps `kind = _LABEL_TO_KIND[label]` via `dataclasses.replace` after each collector returns. The invariant test asserts every section in a collected report carries a non-None kind, so the typed identity is guaranteed at the consumer boundary.

## Test plan

- [x] Extends `tests/unit/services/test_platform_consistency.py` with kind-stamping coverage (clean + exception paths), `iter_blocking_sections` cases, and a regression pin that the Setup readiness section stays `informational=True`.
- [x] New invariant test `tests/unit/invariants/test_platform_consistency_kinds.py` parses the orchestrator's collector tuple via AST and asserts:
  - `_LABEL_TO_KIND` covers every collector label
  - No orphan entries in `_LABEL_TO_KIND`
  - `READINESS_KINDS` matches `_LABEL_TO_KIND.values()`
  - `READINESS_KINDS` exhausts the `ReadinessKind` enum
  - The canonical tuple order matches the collector declaration order
- [x] All 1510 existing unit tests still pass
- [x] `ruff check` and `black --check` clean

## Unlocks

- PR-01b: startup outcome + sync readiness snapshot composing `iter_blocking_sections` + cached state
- PR-03: dynamic blocker registry consumes `ReadinessKind` for typed routing
- PR-04a: setup preflight can re-use the section/risk typing
- PR-05: smoke-test checklist pins items to `READINESS_KINDS` fields


---
_Generated by [Claude Code](https://claude.ai/code/session_01FZb9tZiTdK1z6WfCzXpXmN)_