### PR TITLE
PR-02a: Task compat wrapper — on_error hook + bot1 delegation

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -94,48 +94,58 @@ def _begin_shutdown(*_) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Supervised app-task helper — Phase S2.4 / C-2
+# Supervised app-task helper — Phase S2.4 / C-2 (PR-02a compat wrapper)
 # Every entry-point-layer asyncio.create_task call should go through this
 # helper so unhandled exceptions are loud (critical log + webhook alert)
 # instead of escaping the event loop silently.
+#
+# PR-02a: _supervised_task now delegates to core.runtime.tasks.spawn,
+# passing the existing webhook-alert behaviour as an ``on_error`` hook.
+# The canonical task supervisor handles strong refs, metrics, the
+# cancellation/clean-exit filter, and ERROR-level logging; this module's
+# hook layers the CRITICAL log + webhook follow-up on top.  _APP_TASKS
+# stays as the entry-point-level mirror used by shutdown drain (the
+# drain migration to ``tasks.cancel_all`` is PR-02b).
 # ---------------------------------------------------------------------------
+
+from core.runtime import tasks as _runtime_tasks  # noqa: E402
 
 
 def _supervised_task(coro, *, name: str) -> asyncio.Task:
     """Spawn an app-owned background task with a death-detecting callback."""
-    task = asyncio.create_task(coro, name=name)
-    task.add_done_callback(_on_app_task_done)
-    return task
+    return _runtime_tasks.spawn(name, coro, on_error=_on_app_task_died_webhook)
 
 
-def _on_app_task_done(task: asyncio.Task) -> None:
-    """Done-callback: surface unhandled task exceptions instead of swallowing.
+def _on_app_task_died_webhook(
+    task: asyncio.Task,
+    exc: BaseException,
+) -> None:
+    """``tasks.spawn`` on_error hook: CRITICAL log + webhook follow-up.
 
-    Cancellations are normal during shutdown and ignored.  Real
-    exceptions get a critical log + a webhook alert via the supervisor
-    channel.  The webhook is scheduled in a new task because
-    done_callback runs in the loop but cannot be ``await``-ed in.
+    Invoked by ``core.runtime.tasks._on_done`` only for tasks that
+    raised a non-cancellation exception (cancellations and clean exits
+    are filtered there).  The webhook follow-up is itself scheduled
+    through ``tasks.spawn`` so it inherits managed-task lifecycle —
+    no bare ``asyncio.create_task`` callsites in this module other
+    than the one-shot health-bind coordination at the
+    ``asyncio.wait`` callsite below.
     """
-    if task.cancelled():
-        return
-    exc = task.exception()
-    if exc is None:
-        return
     logger.critical(
         "App task %r died: %s",
         task.get_name(),
         exc,
         exc_info=exc,
     )
-    if reporter is not None:
-        try:
-            asyncio.create_task(
-                reporter.on_app_task_died(task.get_name(), exc),
-                name=f"_on_app_task_died:{task.get_name()}",
-            )
-        except RuntimeError:
-            # No running loop (e.g., during shutdown) — log only.
-            logger.debug("Could not schedule app-task webhook (no loop).")
+    if reporter is None:
+        return
+    try:
+        _runtime_tasks.spawn(
+            f"on_app_task_died:{task.get_name()}",
+            reporter.on_app_task_died(task.get_name(), exc),
+        )
+    except RuntimeError:
+        # No running loop (e.g., during shutdown) — log only.
+        logger.debug("Could not schedule app-task webhook (no loop).")
 
 
 def _identity_contract_strict() -> bool:

--- a/disbot/core/runtime/tasks.py
+++ b/disbot/core/runtime/tasks.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Coroutine
+from collections.abc import Callable, Coroutine
 from typing import Any
 
 from services import metrics
@@ -43,8 +43,21 @@ logger = logging.getLogger("bot.runtime.tasks")
 # may discard the return value of spawn() without risking GC.
 _TASKS: set[asyncio.Task[Any]] = set()
 
+# Per-task on_error hooks (PR-02a).  Populated by ``spawn`` when an
+# ``on_error`` argument is supplied and consumed (popped) by
+# ``_on_done`` once the task completes.  Keyed by task identity rather
+# than by name because two short-lived tasks may transiently share a
+# name across the metric label.
+OnErrorHook = Callable[[asyncio.Task[Any], BaseException], None]
+_ON_ERROR_HOOKS: dict[asyncio.Task[Any], OnErrorHook] = {}
 
-def spawn(name: str, coro: Coroutine[Any, Any, Any]) -> asyncio.Task[Any]:
+
+def spawn(
+    name: str,
+    coro: Coroutine[Any, Any, Any],
+    *,
+    on_error: OnErrorHook | None = None,
+) -> asyncio.Task[Any]:
     """Spawn a managed background task and return the ``asyncio.Task``.
 
     The task is held in a module-level set until it completes; callers do
@@ -54,6 +67,13 @@ def spawn(name: str, coro: Coroutine[Any, Any, Any]) -> asyncio.Task[Any]:
         name: Identifier used for logging and the ``task_outcome_total``
             metric label.  Convention: ``<subsystem>:<short-purpose>``.
         coro: The coroutine to run.
+        on_error: Optional sync callback invoked from the done-callback
+            when the task raises a non-``CancelledError`` exception.
+            Receives ``(task, exception)``.  Used by ``bot1.py``'s
+            supervised-task wrapper (PR-02a) to surface CRITICAL logs
+            plus webhook alerts without bot1 maintaining its own
+            done-callback.  The hook must not raise; any exception it
+            raises is logged and swallowed.
 
     Returns:
         The created ``asyncio.Task``.  Callers may await or cancel it,
@@ -61,6 +81,8 @@ def spawn(name: str, coro: Coroutine[Any, Any, Any]) -> asyncio.Task[Any]:
     """
     task = asyncio.create_task(coro, name=name)
     _TASKS.add(task)
+    if on_error is not None:
+        _ON_ERROR_HOOKS[task] = on_error
     task.add_done_callback(_on_done)
     return task
 
@@ -68,6 +90,7 @@ def spawn(name: str, coro: Coroutine[Any, Any, Any]) -> asyncio.Task[Any]:
 def _on_done(task: asyncio.Task[Any]) -> None:
     """Done-callback: drop strong ref, log exceptions, increment metric."""
     _TASKS.discard(task)
+    on_error = _ON_ERROR_HOOKS.pop(task, None)
     name = task.get_name()
     if task.cancelled():
         metrics.task_outcome_total.labels(name=name, outcome="cancelled").inc()
@@ -76,6 +99,14 @@ def _on_done(task: asyncio.Task[Any]) -> None:
     if exc is not None:
         metrics.task_outcome_total.labels(name=name, outcome="error").inc()
         logger.error("Managed task %r failed", name, exc_info=exc)
+        if on_error is not None:
+            try:
+                on_error(task, exc)
+            except Exception:  # noqa: BLE001 — hook isolation
+                logger.exception(
+                    "on_error hook for managed task %r raised",
+                    name,
+                )
         return
     metrics.task_outcome_total.labels(name=name, outcome="ok").inc()
 

--- a/tests/unit/invariants/test_no_unmanaged_create_task.py
+++ b/tests/unit/invariants/test_no_unmanaged_create_task.py
@@ -1,0 +1,122 @@
+"""PR-02a invariant: no unmanaged ``asyncio.create_task`` outside an allowlist.
+
+Every entry-point/cog/service background task must go through
+``core.runtime.tasks.spawn`` so the canonical supervisor can hold a
+strong reference, log exceptions, increment the
+``task_outcome_total{name,outcome}`` Prometheus counter, and (for
+app-level callers) invoke an ``on_error`` hook.
+
+Bare ``asyncio.create_task`` is allowed only at two locations:
+
+1. ``disbot/core/runtime/tasks.py`` — the legitimate definition site
+   inside ``spawn()`` itself.
+2. ``disbot/bot1.py`` — the one-shot coordination primitive used
+   inside ``asyncio.wait({...}, timeout=5.0)`` to race the
+   health-server bind-ready event against a supervised task.  This is
+   not a long-lived background task; it's a transient join helper.
+
+``disbot/core/runtime/session_gc.py`` is allowlisted transitionally —
+PR-02b migrates ``session_gc.start()`` to ``tasks.spawn``.
+
+Any new occurrence of ``asyncio.create_task`` outside the allowlist
+fails CI; add the callsite to the allowlist (with rationale) or
+migrate it to ``tasks.spawn``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DISBOT = _REPO_ROOT / "disbot"
+
+# Allowlist: (relative_path, expected_callsite_count).  Each entry must
+# include the count so accidentally adding a SECOND bare create_task to
+# an allowlisted file still fails the invariant.
+_ALLOWED_CREATE_TASK_SITES: dict[str, int] = {
+    # Legitimate definition inside spawn().
+    "core/runtime/tasks.py": 1,
+    # One-shot coordination primitive racing health-bind vs supervised
+    # task inside asyncio.wait.  Not a background root.
+    "bot1.py": 1,
+    # Transitional: PR-02b migrates session_gc.start() to tasks.spawn.
+    "core/runtime/session_gc.py": 1,
+}
+
+
+def _iter_disbot_py_files() -> list[Path]:
+    return [
+        p
+        for p in _DISBOT.rglob("*.py")
+        if "__pycache__" not in p.parts and "tests" not in p.parts
+    ]
+
+
+def _count_create_task_calls(path: Path) -> int:
+    """Return the number of ``asyncio.create_task(...)`` callsites."""
+    try:
+        tree = ast.parse(path.read_text())
+    except SyntaxError:
+        pytest.fail(f"Could not parse {path}: SyntaxError")
+    count = 0
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        # asyncio.create_task(...)
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "create_task"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "asyncio"
+        ):
+            count += 1
+    return count
+
+
+def test_no_unmanaged_create_task_outside_allowlist():
+    """Every bare ``asyncio.create_task`` callsite is allowlisted."""
+    violations: list[str] = []
+    for path in _iter_disbot_py_files():
+        rel = str(path.relative_to(_DISBOT))
+        count = _count_create_task_calls(path)
+        if count == 0:
+            continue
+        expected = _ALLOWED_CREATE_TASK_SITES.get(rel)
+        if expected is None:
+            violations.append(
+                f"{rel}: {count} bare asyncio.create_task call(s); "
+                f"migrate to core.runtime.tasks.spawn",
+            )
+            continue
+        if count != expected:
+            violations.append(
+                f"{rel}: {count} bare asyncio.create_task call(s); "
+                f"allowlist expects {expected}.  Add new callsite to "
+                f"_ALLOWED_CREATE_TASK_SITES with rationale or migrate "
+                f"to core.runtime.tasks.spawn.",
+            )
+    assert not violations, (
+        "Unmanaged asyncio.create_task callsite(s):\n  " + "\n  ".join(violations)
+    )
+
+
+def test_allowlist_entries_still_exist():
+    """An allowlist entry whose path was deleted (or whose count went
+    to zero) indicates the underlying callsite was migrated; remove
+    the allowlist entry rather than leaving dead config."""
+    stale: list[str] = []
+    for rel, _expected in _ALLOWED_CREATE_TASK_SITES.items():
+        path = _DISBOT / rel
+        if not path.is_file():
+            stale.append(f"{rel}: file no longer exists")
+            continue
+        if _count_create_task_calls(path) == 0:
+            stale.append(f"{rel}: file has zero create_task callsites")
+    assert not stale, (
+        "Allowlist has stale entries (remove from "
+        "_ALLOWED_CREATE_TASK_SITES):\n  " + "\n  ".join(stale)
+    )

--- a/tests/unit/runtime/test_tasks.py
+++ b/tests/unit/runtime/test_tasks.py
@@ -190,3 +190,95 @@ class TestCancelByPrefix:
         finally:
             t.cancel()
             await asyncio.gather(t, return_exceptions=True)
+
+
+# ---------------------------------------------------------------------------
+# PR-02a — on_error hook
+# ---------------------------------------------------------------------------
+
+
+class TestOnErrorHook:
+    @pytest.mark.asyncio
+    async def test_on_error_invoked_on_exception(self):
+        async def boom():
+            raise RuntimeError("kaboom")
+
+        captured: list[tuple[str, str]] = []
+
+        def hook(task: asyncio.Task, exc: BaseException) -> None:
+            captured.append((task.get_name(), type(exc).__name__))
+
+        t = tasks.spawn("test:on_error", boom(), on_error=hook)
+        with pytest.raises(RuntimeError):
+            await t
+        await asyncio.sleep(0)  # let done callback run
+        assert captured == [("test:on_error", "RuntimeError")]
+
+    @pytest.mark.asyncio
+    async def test_on_error_not_invoked_on_clean_exit(self):
+        captured: list[object] = []
+
+        def hook(task: asyncio.Task, exc: BaseException) -> None:
+            captured.append(exc)
+
+        async def ok():
+            return None
+
+        t = tasks.spawn("test:clean", ok(), on_error=hook)
+        await t
+        await asyncio.sleep(0)
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_on_error_not_invoked_on_cancellation(self):
+        captured: list[object] = []
+
+        def hook(task: asyncio.Task, exc: BaseException) -> None:
+            captured.append(exc)
+
+        async def waiter():
+            await asyncio.sleep(60)
+
+        t = tasks.spawn("test:cancel", waiter(), on_error=hook)
+        t.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await t
+        await asyncio.sleep(0)
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_on_error_exception_is_isolated(self, caplog):
+        """A raising on_error hook must not propagate or mask the metric."""
+
+        async def boom():
+            raise RuntimeError("original")
+
+        def bad_hook(task: asyncio.Task, exc: BaseException) -> None:
+            raise ValueError("hook raised")
+
+        with (
+            patch("core.runtime.tasks.metrics.task_outcome_total") as m,
+            caplog.at_level(logging.ERROR, logger="bot.runtime.tasks"),
+        ):
+            t = tasks.spawn("test:bad_hook", boom(), on_error=bad_hook)
+            with pytest.raises(RuntimeError):
+                await t
+            await asyncio.sleep(0)
+
+        m.labels.assert_called_with(name="test:bad_hook", outcome="error")
+        # The hook's exception is logged but does not crash the loop.
+        assert any("hook" in r.message.lower() for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_on_error_hook_dict_cleared_after_done(self):
+        async def boom():
+            raise RuntimeError("kaboom")
+
+        def hook(task: asyncio.Task, exc: BaseException) -> None:
+            pass
+
+        t = tasks.spawn("test:cleanup", boom(), on_error=hook)
+        with pytest.raises(RuntimeError):
+            await t
+        await asyncio.sleep(0)
+        assert t not in tasks._ON_ERROR_HOOKS


### PR DESCRIPTION
## Summary

Additive compatibility wrapper that makes `core.runtime.tasks` the single supervisor for app-owned background tasks. **No behaviour change** — `_APP_TASKS` is still populated by callers and drained on shutdown unchanged. The shutdown-drain migration is PR-02b; `_APP_TASKS` removal is PR-02c.

Part of the SuperBot 2.0 refactor plan (see `/root/.claude/plans/1-recommended-target-agent-zazzy-eclipse.md`).

## What changes

- **`core.runtime.tasks.spawn`** gains an optional `on_error` kw-arg that receives `(task, exception)` for non-cancellation exceptions. Hook exceptions are caught and logged — they do not propagate or mask the `task_outcome_total{outcome="error"}` metric.
- **`bot1._supervised_task`** now delegates to `tasks.spawn`, passing the existing webhook-alert behaviour as the `on_error` hook. The hook itself uses `tasks.spawn` to schedule the webhook follow-up, so the only bare `asyncio.create_task` left in `bot1.py` is the one-shot health-bind coordination at the `asyncio.wait` callsite — already a transient join helper, not a background root.
- **New invariant test** `tests/unit/invariants/test_no_unmanaged_create_task.py` walks every `disbot/**/*.py` and rejects bare `asyncio.create_task` callsites outside an explicit allowlist. `session_gc.py` is transitionally allowlisted; PR-02b migrates it to `tasks.spawn`.

## Webhook-alert parity

The CRITICAL log + `reporter.on_app_task_died` call now fires from the `on_error` hook instead of `bot1`'s own done-callback. Behaviour is identical: only non-cancellation exceptions trigger the hook, and the webhook follow-up is a fire-and-forget managed task.

## Test plan

- [x] `tests/unit/runtime/test_tasks.py` — adds 5 new test cases:
  - `on_error` invoked on real exception
  - NOT invoked on clean exit
  - NOT invoked on cancellation
  - Hook exception isolated (does not propagate or mask metric)
  - Hook dict cleared after done
- [x] New invariant test enforces the allowlist (3 entries: `tasks.py:62` legitimate definition, `bot1.py:613` health-bind one-shot, `session_gc.py:143` transitional)
- [x] 1475 unit tests pass; ruff/isort/black/black checks clean

## Dependencies and unlocks

- **Blocked by**: none (parallel-safe with PR-01a)
- **Unlocks**: PR-02b (shutdown drain migration through `tasks.cancel_all`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FZb9tZiTdK1z6WfCzXpXmN)_