### PR TITLE
PR-06a: Command classification contract (additive types only)

### DIFF
--- a/disbot/core/runtime/command_surface_ledger.py
+++ b/disbot/core/runtime/command_surface_ledger.py
@@ -23,6 +23,8 @@ re-walking ``bot.commands``.
 Public surface:
 
     CommandSurfaceEntry      — frozen dataclass per command
+    Classification           — Literal of canonical classification values
+    CLASSIFICATIONS          — tuple of all canonical classification values
     RouterPrefixEntry        — frozen dataclass per registered router prefix
     LedgerFindings           — frozen dataclass with orphan/duplicate buckets
     CommandSurfaceLedger     — frozen aggregate snapshot
@@ -39,7 +41,7 @@ import datetime
 import logging
 import re
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal, get_args
 
 logger = logging.getLogger("bot.runtime.command_surface_ledger")
 
@@ -47,6 +49,43 @@ logger = logging.getLogger("bot.runtime.command_surface_ledger")
 # ---------------------------------------------------------------------------
 # Public types
 # ---------------------------------------------------------------------------
+
+
+# PR-06a — Classification contract.
+#
+# Each command entrypoint is classified so help/navigation surfaces and
+# the readiness embed can decide whether to render, dim, hide, or warn
+# about a command without consulting the help cog directly.  PR-06a
+# ships only the type + the default; PR-06b wires slash-command
+# ingestion; PR-06c sweeps the cogs to annotate.
+#
+# Values:
+#
+# * ``primary_entrypoint`` — the canonical command operators use.
+#   Default for unannotated commands so PR-06a is purely additive.
+# * ``power_user_shortcut`` — alternative spelling kept for fluency;
+#   help may dim it after PR-06c.
+# * ``panel_action`` — invoked from a panel button rather than typed;
+#   help can omit from the prefix-typed listing.
+# * ``legacy_duplicate`` — an alias kept around for backwards-compat;
+#   PR-06c may filter from help suggestions.
+# * ``internal_admin`` — surfaced only to staff/operators.
+# * ``hidden`` — never surfaced in help (still callable).
+# * ``deprecated`` — surfaced with a deprecation warning.
+Classification = Literal[
+    "primary_entrypoint",
+    "power_user_shortcut",
+    "panel_action",
+    "legacy_duplicate",
+    "internal_admin",
+    "hidden",
+    "deprecated",
+]
+
+# Canonical tuple of every classification value.  Used by the
+# invariant test to assert nothing has drifted between the Literal and
+# any classification registry added by PR-06c.
+CLASSIFICATIONS: tuple[Classification, ...] = get_args(Classification)
 
 
 @dataclass(frozen=True)
@@ -61,6 +100,11 @@ class CommandSurfaceEntry:
     parent_group: str | None = None
     is_declared: bool = False
     kind: str = "prefix"  # reserved values: "prefix" | "slash"
+    # PR-06a: classification defaults to ``primary_entrypoint`` so
+    # adding the field is purely additive.  PR-06c populates this from
+    # per-cog declarations (decorator or metadata map) and surfaces
+    # the unclassified set as a finding.
+    classification: Classification = "primary_entrypoint"
 
 
 @dataclass(frozen=True)
@@ -80,6 +124,12 @@ class LedgerFindings:
     duplicate_alias_names: tuple[str, ...] = ()
     undeclared_entry_points: tuple[str, ...] = ()
     router_prefix_unknown: tuple[str, ...] = ()
+    # PR-06a: populated by PR-06c once per-cog classification metadata
+    # exists.  Empty in PR-06a because the default classification
+    # (``primary_entrypoint``) means every command is considered
+    # classified out of the box.  Reserved here so the dataclass shape
+    # is stable across the PR-06a → PR-06c sequence.
+    unclassified_entry_points: tuple[str, ...] = ()
 
     @property
     def total(self) -> int:
@@ -89,6 +139,7 @@ class LedgerFindings:
             + len(self.duplicate_alias_names)
             + len(self.undeclared_entry_points)
             + len(self.router_prefix_unknown)
+            + len(self.unclassified_entry_points)
         )
 
 
@@ -392,6 +443,9 @@ def _snapshot() -> dict[str, Any]:
             "duplicate_alias_names": len(ledger.findings.duplicate_alias_names),
             "undeclared_entry_points": len(ledger.findings.undeclared_entry_points),
             "router_prefix_unknown": len(ledger.findings.router_prefix_unknown),
+            "unclassified_entry_points": len(
+                ledger.findings.unclassified_entry_points,
+            ),
         },
     }
 
@@ -406,6 +460,8 @@ _register_diagnostics()
 
 
 __all__ = [
+    "CLASSIFICATIONS",
+    "Classification",
     "CommandSurfaceEntry",
     "CommandSurfaceLedger",
     "LedgerFindings",

--- a/tests/unit/runtime/test_command_surface_ledger.py
+++ b/tests/unit/runtime/test_command_surface_ledger.py
@@ -9,6 +9,7 @@ import pytest
 
 from core.runtime import command_surface_ledger as ledger_mod
 from core.runtime.command_surface_ledger import (
+    CLASSIFICATIONS,
     CommandSurfaceEntry,
     CommandSurfaceLedger,
     LedgerFindings,
@@ -470,3 +471,80 @@ def test_does_not_call_validate_identity_contract():
                         "Ledger imports validate_identity_contract — "
                         "complementary, not consumer",
                     )
+
+
+# ---------------------------------------------------------------------------
+# PR-06a — Classification contract (additive)
+# ---------------------------------------------------------------------------
+
+
+class TestClassification:
+    def test_classifications_tuple_matches_literal_args(self):
+        """Canonical tuple must list every value declared in the
+        Classification Literal — drift would let cog annotations use a
+        value the type checker accepts but no consumer knows about."""
+        from typing import get_args
+
+        from core.runtime.command_surface_ledger import Classification
+
+        assert set(CLASSIFICATIONS) == set(get_args(Classification))
+
+    def test_classifications_includes_seven_canonical_values(self):
+        assert set(CLASSIFICATIONS) == {
+            "primary_entrypoint",
+            "power_user_shortcut",
+            "panel_action",
+            "legacy_duplicate",
+            "internal_admin",
+            "hidden",
+            "deprecated",
+        }
+
+    def test_command_surface_entry_default_classification(self):
+        entry = CommandSurfaceEntry(
+            name="daily",
+            cog_name="EconomyCog",
+            subsystem="economy",
+            visibility_tier="user",
+        )
+        assert entry.classification == "primary_entrypoint"
+
+    def test_command_surface_entry_classification_explicitly_set(self):
+        entry = CommandSurfaceEntry(
+            name="legacy_daily",
+            cog_name="EconomyCog",
+            subsystem="economy",
+            visibility_tier="user",
+            classification="legacy_duplicate",
+        )
+        assert entry.classification == "legacy_duplicate"
+
+    def test_findings_unclassified_entry_points_default_empty(self):
+        findings = LedgerFindings()
+        assert findings.unclassified_entry_points == ()
+        assert findings.total == 0
+
+    def test_findings_total_includes_unclassified_count(self):
+        findings = LedgerFindings(
+            unclassified_entry_points=("economy.daily", "rps.duel"),
+        )
+        assert findings.total == 2
+
+    def test_diagnostics_snapshot_includes_unclassified_count(self):
+        """The diagnostics provider exposes the new bucket so the
+        readiness embed and !platform diagnostics show it without
+        cog-side knowledge of the field name."""
+        from core.runtime.command_surface_ledger import _snapshot
+
+        bot = MagicMock()
+        bot.walk_commands = lambda: []
+        with patch(
+            "core.runtime.command_surface_ledger._walk_router_prefixes",
+            return_value=[],
+        ):
+            build_ledger(bot)
+        snap = _snapshot()
+        assert "unclassified_entry_points" in snap["findings"]
+        assert snap["findings"]["unclassified_entry_points"] == 0
+
+


### PR DESCRIPTION
## Summary

Additive types-only contract for command classification — the foundation that PR-06b (slash ledger ingestion) and PR-06c (annotation sweep + help filtering) will build on. **No annotations, no help filtering, no behaviour change.**

Part of the SuperBot 2.0 refactor plan (see `/root/.claude/plans/1-recommended-target-agent-zazzy-eclipse.md`).

## What changes

- **`Classification` Literal** with the 7 canonical values: `primary_entrypoint`, `power_user_shortcut`, `panel_action`, `legacy_duplicate`, `internal_admin`, `hidden`, `deprecated`.
- **`CLASSIFICATIONS` tuple** via `typing.get_args` — pinned against the Literal by an invariant test so the tuple and the type can't drift.
- **`CommandSurfaceEntry.classification`** field defaulting to `primary_entrypoint` so existing entries keep their identity. Pure additive — no callsite needs to know about the field yet.
- **`LedgerFindings.unclassified_entry_points`** bucket (empty in PR-06a). Reserved here so the dataclass shape is stable across PR-06a → PR-06c; PR-06c populates it.
- **Diagnostics snapshot** exposes the new bucket count via `findings.unclassified_entry_points`.

## Why default = `primary_entrypoint`?

A default of `primary_entrypoint` makes PR-06a strictly additive: every existing command's effective classification is unchanged at runtime. PR-06c can change individual cogs to declare other classifications without coordinating with this PR. An alternative (`unclassified` default + per-cog opt-in) would have classified every command in the codebase as unclassified at boot, defeating the purpose of staged annotation.

## Test plan

- [x] `tests/unit/runtime/test_command_surface_ledger.py` — 7 new test cases:
  - `CLASSIFICATIONS` tuple matches `Literal` args (drift guard)
  - All 7 canonical values present
  - `CommandSurfaceEntry` default classification is `primary_entrypoint`
  - Explicit override accepted
  - `LedgerFindings.unclassified_entry_points` defaults to empty tuple
  - `findings.total` arithmetic includes the new bucket
  - Diagnostics snapshot exposes `findings.unclassified_entry_points` count
- [x] All 1475 unit tests still pass
- [x] ruff / isort / black checks clean

## Dependencies and unlocks

- **Blocked by**: none (parallel-safe with PR-01a, PR-02a)
- **Unlocks**: PR-06b (slash command ledger ingestion) and PR-06c (annotation sweep + help filtering)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FZb9tZiTdK1z6WfCzXpXmN)_