### PR TITLE
PR-03: Dynamic setup-readiness blocker registry

### DIFF
--- a/disbot/services/platform_consistency.py
+++ b/disbot/services/platform_consistency.py
@@ -37,14 +37,18 @@ Informational sections never promote ``overall_status``.
 Public surface:
 
     SectionStatus               — enum
+    ReadinessKind               — enum (typed identity per section)
+    READINESS_KINDS             — canonical-order tuple of every kind
     SectionResult               — frozen dataclass per section
     ConsistencyReport           — frozen dataclass: sections + overall_status
     SETUP_READINESS_BLOCKERS    — tuple of roadmap blocker identifiers
     collect_report(*, bot, guild) — async orchestrator
+    iter_blocking_sections(report) — non-informational, non-CLEAN sections
 """
 
 from __future__ import annotations
 
+import dataclasses
 import datetime
 import logging
 import os
@@ -68,6 +72,68 @@ class SectionStatus(str, Enum):
     SKIPPED = "skipped"
 
 
+class ReadinessKind(str, Enum):
+    """Canonical typed identity for each consistency section.
+
+    PR-01a: every section result returned by ``collect_report`` is
+    stamped with one of these kinds by the orchestrator (collectors
+    do not need to know about kinds — the orchestrator maps from
+    the human label to the typed kind).
+
+    ``READINESS_KINDS`` exports the canonical ordering used by the
+    orchestrator and consumers; the invariant test
+    ``tests/unit/invariants/test_platform_consistency_kinds.py`` pins
+    every collector to a known kind.
+    """
+
+    IDENTITY_CONTRACT = "identity_contract"
+    FEATURE_FLAGS = "feature_flags"
+    ROLLOUT_AUDIT = "rollout_audit"
+    BINDINGS = "bindings"
+    BINDING_BACKFILL = "binding_backfill"
+    CONFIG_ARBITRATION = "config_arbitration"
+    PARTICIPATION = "participation"
+    MIGRATIONS = "migrations"
+    RUNTIME_PROVIDERS = "runtime_providers"
+    SETUP_READINESS = "setup_readiness"
+
+
+# Canonical ordering — matches the orchestrator's collector tuple at
+# ``collect_report``.  ``test_readiness_kinds_canonical_ordering`` pins
+# this ordering so the diagnostic embed and the readiness snapshot can
+# rely on a stable section order.
+READINESS_KINDS: tuple[ReadinessKind, ...] = (
+    ReadinessKind.IDENTITY_CONTRACT,
+    ReadinessKind.FEATURE_FLAGS,
+    ReadinessKind.ROLLOUT_AUDIT,
+    ReadinessKind.BINDINGS,
+    ReadinessKind.BINDING_BACKFILL,
+    ReadinessKind.CONFIG_ARBITRATION,
+    ReadinessKind.PARTICIPATION,
+    ReadinessKind.MIGRATIONS,
+    ReadinessKind.RUNTIME_PROVIDERS,
+    ReadinessKind.SETUP_READINESS,
+)
+
+
+# Maps the human-readable label used by the orchestrator's collector
+# tuple to the typed ``ReadinessKind``.  The orchestrator stamps each
+# collector's ``SectionResult.kind`` from this map after the collector
+# returns, so collectors themselves never need to set ``kind``.
+_LABEL_TO_KIND: dict[str, ReadinessKind] = {
+    "Identity contract": ReadinessKind.IDENTITY_CONTRACT,
+    "Feature flags": ReadinessKind.FEATURE_FLAGS,
+    "Rollout / audit": ReadinessKind.ROLLOUT_AUDIT,
+    "Bindings": ReadinessKind.BINDINGS,
+    "Binding backfill": ReadinessKind.BINDING_BACKFILL,
+    "Config arbitration": ReadinessKind.CONFIG_ARBITRATION,
+    "Participation": ReadinessKind.PARTICIPATION,
+    "Migrations": ReadinessKind.MIGRATIONS,
+    "Runtime providers": ReadinessKind.RUNTIME_PROVIDERS,
+    "Setup readiness": ReadinessKind.SETUP_READINESS,
+}
+
+
 @dataclass(frozen=True)
 class SectionResult:
     name: str
@@ -76,6 +142,13 @@ class SectionResult:
     details: tuple[str, ...] = ()
     suggested_actions: tuple[str, ...] = ()
     informational: bool = False
+    # PR-01a: typed identity stamped by the orchestrator after each
+    # collector returns.  Optional only so collectors can construct
+    # ``SectionResult`` without knowing the kind; the orchestrator
+    # guarantees every section in a collected report has a non-None
+    # kind.  Consumers that build sections outside ``collect_report``
+    # (e.g. unit tests) may leave it as ``None``.
+    kind: ReadinessKind | None = None
 
 
 @dataclass(frozen=True)
@@ -176,10 +249,38 @@ async def collect_report(
                 summary=f"collector raised {type(exc).__name__}",
                 details=(str(exc)[:200],),
             )
+        # PR-01a: stamp the canonical readiness kind from the label.
+        # Collectors construct SectionResult without knowing the kind;
+        # the orchestrator is the single place where the human label
+        # is translated into the typed ``ReadinessKind``.
+        if result.kind is None:
+            result = dataclasses.replace(result, kind=_LABEL_TO_KIND[label])
         sections.append(result)
     return ConsistencyReport(
         sections=tuple(sections),
         generated_at=datetime.datetime.now(tz=datetime.timezone.utc),
+    )
+
+
+def iter_blocking_sections(
+    report: ConsistencyReport,
+) -> tuple[SectionResult, ...]:
+    """Return only non-informational, non-CLEAN sections.
+
+    PR-01a helper used by the upcoming readiness snapshot (PR-01b) and
+    smoke checklist (PR-05) to surface the subset of sections that
+    represent actionable signal — informational roadmap warnings
+    (e.g. "Setup readiness") and CLEAN sections are filtered out.
+
+    ``SKIPPED`` sections are included because "not applicable" can
+    still be a release-relevant signal (e.g. a migration not yet
+    applied that should be).  Consumers that want to filter further
+    can do so on the returned tuple.
+    """
+    return tuple(
+        s
+        for s in report.sections
+        if not s.informational and s.status is not SectionStatus.CLEAN
     )
 
 
@@ -801,8 +902,11 @@ async def _collect_setup_readiness() -> SectionResult:
 
 __all__ = [
     "ConsistencyReport",
+    "READINESS_KINDS",
+    "ReadinessKind",
     "SETUP_READINESS_BLOCKERS",
     "SectionResult",
     "SectionStatus",
     "collect_report",
+    "iter_blocking_sections",
 ]

--- a/disbot/services/platform_consistency.py
+++ b/disbot/services/platform_consistency.py
@@ -171,19 +171,23 @@ class ConsistencyReport:
         return SectionStatus.CLEAN
 
 
-SETUP_READINESS_BLOCKERS: tuple[str, ...] = (
-    "command_surface_ledger",
-    "panel_registry",
-    "settings_registry",
-    "settings_mutation_pipeline",
-    "governance_trusted_role_schema",
-    "role_service_extraction",
-    "cleanup_policy_extraction",
-    "logging_settings_integration",
-    "slash_panel_entrypoints",
-    "setup_wizard_readiness_bridge",
-    "setup_wizard",
-)
+# PR-03: derived from the dynamic ``services.setup_blockers.BLOCKERS``
+# registry so the bare-string contract is preserved for backwards-
+# compatible callers (e.g. the doc test) while the actual resolution
+# state is computed dynamically from cached foundation state.  See
+# ``services/setup_blockers.py`` for the registry, status providers,
+# and ownership metadata.
+def _setup_readiness_blocker_ids() -> tuple[str, ...]:
+    # Function-local import keeps this module's import graph
+    # unchanged (setup_blockers itself only imports stdlib at module
+    # scope; each status_provider imports the runtime modules it
+    # needs function-locally).
+    from services import setup_blockers
+
+    return setup_blockers.blocker_ids()
+
+
+SETUP_READINESS_BLOCKERS: tuple[str, ...] = _setup_readiness_blocker_ids()
 
 
 # ---------------------------------------------------------------------------
@@ -871,28 +875,48 @@ async def _collect_runtime_providers() -> SectionResult:
 async def _collect_setup_readiness() -> SectionResult:
     """Section 10: roadmap blockers for the larger UX phase (informational).
 
-    v1 returns a static list from ``SETUP_READINESS_BLOCKERS``.  Dynamic
-    detection of each blocker's resolution state is deferred to a
-    follow-up PR.  The section is marked ``informational=True`` so the
+    PR-03: dynamic — each blocker in
+    ``services.setup_blockers.BLOCKERS`` computes its own status from
+    cached in-process state.  Resolved blockers drop out of the
+    details list; pending / in_progress / blocked / unknown remain
+    visible.  The section is still ``informational=True`` so the
     embed labels it as roadmap-only and ``overall_status`` does not
     promote on it.
+
+    Status providers are sync and fail-safe — a raising provider
+    becomes ``"unknown"`` rather than crashing this collector.
     """
     name = "Setup readiness"
-    if not SETUP_READINESS_BLOCKERS:
+    # Function-local: setup_blockers transitively imports
+    # core.runtime modules in its status providers; module-scope
+    # import would violate the cycle-sensitive contract pinned by
+    # test_consistency_import_cycle.py.
+    from services import setup_blockers
+
+    statuses: list[tuple[str, str]] = [
+        (spec.id, setup_blockers.status_for(spec)) for spec in setup_blockers.BLOCKERS
+    ]
+    resolved = sum(1 for _, st in statuses if st == "resolved")
+    pending = [bid for bid, st in statuses if st != "resolved"]
+    total = len(statuses)
+
+    if not pending:
         return SectionResult(
             name=name,
             status=SectionStatus.CLEAN,
-            summary="No roadmap blockers.",
+            summary=(f"All {total} roadmap blocker(s) resolved."),
             informational=True,
         )
+
+    details = tuple(f"{bid}: {st}" for bid, st in statuses)
     return SectionResult(
         name=name,
         status=SectionStatus.WARNING,
         summary=(
-            f"{len(SETUP_READINESS_BLOCKERS)} roadmap blocker(s) "
-            "tracked (informational; not a runtime health failure)."
+            f"{resolved}/{total} roadmap blocker(s) resolved "
+            "(informational; not a runtime health failure)."
         ),
-        details=tuple(SETUP_READINESS_BLOCKERS),
+        details=details,
         suggested_actions=(
             "See `docs/phase-2-completion-readiness.md` for unlock order.",
         ),

--- a/disbot/services/setup_blockers.py
+++ b/disbot/services/setup_blockers.py
@@ -1,0 +1,336 @@
+"""Dynamic setup-readiness blocker registry — PR-03.
+
+Replaces the static ``SETUP_READINESS_BLOCKERS`` tuple of bare strings
+in ``services.platform_consistency`` with a typed registry whose
+status is computed from cached foundation state.  ``platform_consistency``
+re-exports the constant as a derived tuple of IDs for backward compat
+so existing callers still work.
+
+Design rules (matching the source plan and PR-03's stop conditions):
+
+* Every ``status_provider`` is **sync** and **never performs I/O**.
+  It reads cached in-process state (cached ledger, cached registry,
+  module existence) and returns one of ``"resolved" | "in_progress" |
+  "pending" | "blocked" | "unknown"``.
+* A provider that raises is caught and rendered as ``"unknown"`` —
+  the registry is fail-safe so one bad provider does not blank the
+  whole report.
+* All imports are function-local inside each provider so this module
+  itself does not trigger a cycle with ``core.runtime`` at import
+  time (the consistency report's collectors enforce the same
+  discipline).
+
+Public surface::
+
+    BlockerStatus       — Literal type
+    BlockerSpec         — frozen dataclass per blocker
+    BLOCKERS            — canonical tuple of every blocker spec
+    blocker_ids()       — derived tuple of IDs (re-exported by
+                          platform_consistency.SETUP_READINESS_BLOCKERS)
+    status_for(spec)    — invoke the provider with the unknown fallback
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal
+
+logger = logging.getLogger("bot.setup_blockers")
+
+BlockerStatus = Literal[
+    "resolved",
+    "in_progress",
+    "pending",
+    "blocked",
+    "unknown",
+]
+
+
+@dataclass(frozen=True)
+class BlockerSpec:
+    """A single setup-readiness blocker with metadata + status provider.
+
+    The ``status_provider`` is a zero-arg sync callable that consults
+    cached in-process state.  ``status_for`` wraps it with a
+    fail-safe so a raising provider becomes ``"unknown"`` rather than
+    crashing the consistency report.
+
+    Fields mirror the plan's BlockerSpec shape:
+
+    * ``id`` — stable snake_case ID (matches the original
+      ``SETUP_READINESS_BLOCKERS`` strings for backward compat).
+    * ``owner_project`` — the project area responsible.
+      ``"UNCONFIRMED"`` is allowed for blockers whose owner the
+      reviewer must assign.
+    * ``refactor_layer`` — short tag like ``"registries"``,
+      ``"runtime"``, ``"ui"`` to help readers group them.
+    * ``severity`` — ``"blocks_release"`` | ``"blocks_phase"`` |
+      ``"informational"``.  Today every blocker is
+      ``"informational"`` to preserve the section's
+      ``informational=True`` semantics.
+    * ``unlocks`` / ``blocked_by`` — other blocker IDs by name.
+    * ``doc_anchor`` — anchor in
+      ``docs/phase-2-completion-readiness.md`` (without the leading
+      ``#``) for "where do I read more?"
+    """
+
+    id: str
+    owner_project: str
+    refactor_layer: str
+    status_provider: Callable[[], BlockerStatus]
+    severity: Literal["blocks_release", "blocks_phase", "informational"]
+    unlocks: tuple[str, ...] = ()
+    blocked_by: tuple[str, ...] = ()
+    doc_anchor: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Status providers (all sync; all imports function-local)
+# ---------------------------------------------------------------------------
+
+
+def _command_surface_ledger_status() -> BlockerStatus:
+    from core.runtime import command_surface_ledger
+
+    return "resolved" if command_surface_ledger.get_cached_ledger() else "pending"
+
+
+def _settings_registry_status() -> BlockerStatus:
+    from core.runtime import settings_registry
+
+    return "resolved" if settings_registry.get_cached_registry() else "pending"
+
+
+def _settings_mutation_pipeline_status() -> BlockerStatus:
+    """Resolved if ``services.settings_mutation`` exposes the pipeline.
+
+    The module exists today and exports ``SettingsMutationPipeline``;
+    that is the contract setup_operations depends on.
+    """
+    import importlib
+
+    spec = importlib.util.find_spec("services.settings_mutation")
+    if spec is None:
+        return "pending"
+    module = importlib.import_module("services.settings_mutation")
+    return "resolved" if hasattr(module, "SettingsMutationPipeline") else "in_progress"
+
+
+def _setup_wizard_status() -> BlockerStatus:
+    """Resolved if the setup cog module is importable.
+
+    The cog is loaded at runtime; "importable" is the safest sync
+    signal that the wizard surface exists.  A fully end-user-facing
+    wizard is still in iteration, hence ``in_progress`` if the
+    customization catalogue has not been built yet.
+    """
+    import importlib
+
+    spec = importlib.util.find_spec("cogs.setup_cog")
+    if spec is None:
+        return "pending"
+    # If the customization catalogue is built, the wizard surface has
+    # all of its inputs available.
+    try:
+        from services import customization_catalogue
+
+        if customization_catalogue.get_cached_catalogue() is not None:
+            return "resolved"
+    except Exception:  # noqa: BLE001 — best-effort sync check
+        pass
+    return "in_progress"
+
+
+def _governance_trusted_role_schema_status() -> BlockerStatus:
+    """Resolved if the governance subsystem declares ``trusted_role``.
+
+    Checks the in-process subsystem_schema registry for the binding
+    spec; if the schema module is not built or the binding is
+    missing, marked ``pending``.
+    """
+    try:
+        from core.runtime import subsystem_schema
+
+        schemas = subsystem_schema.all_schemas()
+    except Exception:  # noqa: BLE001 — best-effort sync check
+        return "unknown"
+    gov = schemas.get("governance") if isinstance(schemas, dict) else None
+    if gov is None:
+        return "pending"
+    bindings = getattr(gov, "bindings", ()) or ()
+    for b in bindings:
+        if getattr(b, "name", None) == "trusted_role":
+            return "resolved"
+    return "pending"
+
+
+def _panel_registry_status() -> BlockerStatus:
+    """Panel registry — module exists today as ``panel_manager``.
+
+    ``panel_manager`` provides the version-stamped persistent-view
+    registration.  Treat the module's importability as the resolution
+    signal; absence is ``pending``.
+    """
+    import importlib
+
+    spec = importlib.util.find_spec("core.runtime.panel_manager")
+    if spec is None:
+        return "pending"
+    return "resolved"
+
+
+def _pending_doc_anchor() -> BlockerStatus:
+    """Default provider for blockers with no cached resolution signal.
+
+    Always returns ``pending``; consult the doc anchor for rationale.
+    """
+    return "pending"
+
+
+# ---------------------------------------------------------------------------
+# Canonical registry
+# ---------------------------------------------------------------------------
+
+
+BLOCKERS: tuple[BlockerSpec, ...] = (
+    BlockerSpec(
+        id="command_surface_ledger",
+        owner_project="Core Platform",
+        refactor_layer="registries",
+        status_provider=_command_surface_ledger_status,
+        severity="informational",
+        unlocks=("slash_panel_entrypoints", "setup_wizard"),
+        doc_anchor="command-surface-ledger",
+    ),
+    BlockerSpec(
+        id="panel_registry",
+        owner_project="Core Platform",
+        refactor_layer="registries",
+        status_provider=_panel_registry_status,
+        severity="informational",
+        unlocks=("slash_panel_entrypoints", "setup_wizard"),
+        doc_anchor="panel-registry",
+    ),
+    BlockerSpec(
+        id="settings_registry",
+        owner_project="Core Platform",
+        refactor_layer="registries",
+        status_provider=_settings_registry_status,
+        severity="informational",
+        unlocks=("settings_mutation_pipeline", "setup_wizard"),
+        doc_anchor="settings-registry",
+    ),
+    BlockerSpec(
+        id="settings_mutation_pipeline",
+        owner_project="Core Platform",
+        refactor_layer="services",
+        status_provider=_settings_mutation_pipeline_status,
+        severity="informational",
+        blocked_by=("settings_registry",),
+        unlocks=("setup_wizard",),
+        doc_anchor="settings-mutation-pipeline",
+    ),
+    BlockerSpec(
+        id="governance_trusted_role_schema",
+        owner_project="Core Platform",
+        refactor_layer="config",
+        status_provider=_governance_trusted_role_schema_status,
+        severity="informational",
+        doc_anchor="governance-trusted-role-schema",
+    ),
+    BlockerSpec(
+        id="role_service_extraction",
+        owner_project="Core Platform",
+        refactor_layer="services",
+        status_provider=_pending_doc_anchor,
+        severity="informational",
+        doc_anchor="role-service-extraction",
+    ),
+    BlockerSpec(
+        id="cleanup_policy_extraction",
+        owner_project="Core Platform",
+        refactor_layer="services",
+        status_provider=_pending_doc_anchor,
+        severity="informational",
+        doc_anchor="cleanup-policy-extraction",
+    ),
+    BlockerSpec(
+        id="logging_settings_integration",
+        owner_project="Core Platform",
+        refactor_layer="services",
+        status_provider=_pending_doc_anchor,
+        severity="informational",
+        blocked_by=("settings_registry",),
+        doc_anchor="logging-settings-integration",
+    ),
+    BlockerSpec(
+        id="slash_panel_entrypoints",
+        owner_project="Help & Navigation",
+        refactor_layer="ui",
+        status_provider=_pending_doc_anchor,
+        severity="informational",
+        blocked_by=("panel_registry", "command_surface_ledger"),
+        doc_anchor="slash-panel-entrypoints",
+    ),
+    BlockerSpec(
+        # NOTE: owner UNCONFIRMED per the PR-03 revision plan — reviewer
+        # to assign during PR review.
+        id="setup_wizard_readiness_bridge",
+        owner_project="UNCONFIRMED",
+        refactor_layer="services",
+        status_provider=_pending_doc_anchor,
+        severity="informational",
+        doc_anchor="setup-wizard-readiness-bridge",
+    ),
+    BlockerSpec(
+        id="setup_wizard",
+        owner_project="Setup Wizard",
+        refactor_layer="ui",
+        status_provider=_setup_wizard_status,
+        severity="informational",
+        blocked_by=(
+            "settings_registry",
+            "settings_mutation_pipeline",
+            "panel_registry",
+        ),
+        doc_anchor="setup-wizard",
+    ),
+)
+
+
+def blocker_ids() -> tuple[str, ...]:
+    """Derived tuple of every blocker's ID.
+
+    ``services.platform_consistency.SETUP_READINESS_BLOCKERS`` is
+    re-exported from this view so the bare-string contract is
+    preserved for backwards-compatible callers.
+    """
+    return tuple(b.id for b in BLOCKERS)
+
+
+def status_for(spec: BlockerSpec) -> BlockerStatus:
+    """Invoke ``spec.status_provider`` with a fail-safe wrapper.
+
+    A raising provider becomes ``"unknown"`` so a broken cached-state
+    accessor cannot blank the readiness section.
+    """
+    try:
+        return spec.status_provider()
+    except Exception as exc:  # noqa: BLE001 — registry is fail-safe
+        logger.warning(
+            "setup_blockers: status_provider for %r raised %s",
+            spec.id,
+            exc,
+        )
+        return "unknown"
+
+
+__all__ = [
+    "BLOCKERS",
+    "BlockerSpec",
+    "BlockerStatus",
+    "blocker_ids",
+    "status_for",
+]

--- a/disbot/services/setup_blockers.py
+++ b/disbot/services/setup_blockers.py
@@ -110,6 +110,7 @@ def _settings_mutation_pipeline_status() -> BlockerStatus:
     that is the contract setup_operations depends on.
     """
     import importlib
+    import importlib.util
 
     spec = importlib.util.find_spec("services.settings_mutation")
     if spec is None:
@@ -127,6 +128,7 @@ def _setup_wizard_status() -> BlockerStatus:
     customization catalogue has not been built yet.
     """
     import importlib
+    import importlib.util
 
     spec = importlib.util.find_spec("cogs.setup_cog")
     if spec is None:
@@ -174,6 +176,7 @@ def _panel_registry_status() -> BlockerStatus:
     signal; absence is ``pending``.
     """
     import importlib
+    import importlib.util
 
     spec = importlib.util.find_spec("core.runtime.panel_manager")
     if spec is None:

--- a/tests/unit/docs/test_phase_2_readiness_doc.py
+++ b/tests/unit/docs/test_phase_2_readiness_doc.py
@@ -69,7 +69,12 @@ def test_pr_10_listed_as_current_next_work(doc_text: str):
 
 def test_every_setup_readiness_blocker_appears_in_doc(doc_text: str):
     """Every entry in SETUP_READINESS_BLOCKERS must appear in the doc in
-    humanised form (snake_case → space-separated, case-insensitive)."""
+    humanised form (snake_case → space-separated, case-insensitive).
+
+    PR-03: ``SETUP_READINESS_BLOCKERS`` is now derived from
+    ``services.setup_blockers.blocker_ids()`` but the bare-string
+    contract is preserved, so this assertion still works unchanged.
+    """
     lowered = doc_text.lower()
     missing: list[str] = []
     for blocker in SETUP_READINESS_BLOCKERS:
@@ -79,4 +84,64 @@ def test_every_setup_readiness_blocker_appears_in_doc(doc_text: str):
     assert not missing, (
         "Doc/SETUP_READINESS_BLOCKERS sync gap — add these to the "
         "'Setup-readiness blockers' section:\n  " + "\n  ".join(missing)
+    )
+
+
+# ---------------------------------------------------------------------------
+# PR-03: resolved-marker cross-check
+# ---------------------------------------------------------------------------
+
+
+def test_blocker_ids_match_blocker_specs():
+    """The derived ID list must match the underlying ``BlockerSpec`` IDs.
+
+    Prevents drift between ``services.setup_blockers.BLOCKERS`` and
+    ``platform_consistency.SETUP_READINESS_BLOCKERS`` (which is now a
+    re-export of ``blocker_ids()``)."""
+    from services import setup_blockers
+
+    spec_ids = tuple(b.id for b in setup_blockers.BLOCKERS)
+    assert SETUP_READINESS_BLOCKERS == spec_ids
+
+
+def test_every_blocker_has_resolution_provider_and_doc_anchor():
+    """Each spec must declare a doc_anchor + a callable status_provider.
+
+    Doc anchor is the "where do I read more?" link operators follow
+    when a blocker is pending; status_provider is the sync resolution
+    check the readiness collector consumes."""
+    from services import setup_blockers
+
+    missing_anchor: list[str] = []
+    missing_provider: list[str] = []
+    for spec in setup_blockers.BLOCKERS:
+        if not spec.doc_anchor:
+            missing_anchor.append(spec.id)
+        if not callable(spec.status_provider):
+            missing_provider.append(spec.id)
+    assert not missing_anchor, (
+        "BlockerSpec(s) missing doc_anchor:\n  " + "\n  ".join(missing_anchor)
+    )
+    assert not missing_provider, (
+        "BlockerSpec(s) missing status_provider:\n  " + "\n  ".join(missing_provider)
+    )
+
+
+def test_blocker_status_provider_returns_valid_literal():
+    """Every status_provider must return a member of BlockerStatus.
+
+    Fail-safe ``status_for`` wrapper catches exceptions and returns
+    ``"unknown"``, but this test exercises the providers directly to
+    catch silent shape drift."""
+    from services import setup_blockers
+
+    valid = {"resolved", "in_progress", "pending", "blocked", "unknown"}
+    invalid: list[str] = []
+    for spec in setup_blockers.BLOCKERS:
+        status = setup_blockers.status_for(spec)
+        if status not in valid:
+            invalid.append(f"{spec.id}: returned {status!r}")
+    assert not invalid, (
+        "BlockerSpec.status_provider returned unknown literal:\n  "
+        + "\n  ".join(invalid)
     )

--- a/tests/unit/docs/test_settings_customization_doc.py
+++ b/tests/unit/docs/test_settings_customization_doc.py
@@ -35,6 +35,7 @@ _RPM_OVERVIEW = _DOCS / "resource-provisioning-overview.md"
 _SUBSYSTEM_REGISTRY_SRC = _DISBOT / "utils" / "subsystem_registry.py"
 _CONFIG_SRC = _DISBOT / "config.py"
 _PLATFORM_CONSISTENCY_SRC = _DISBOT / "services" / "platform_consistency.py"
+_SETUP_BLOCKERS_SRC = _DISBOT / "services" / "setup_blockers.py"
 _SETTINGS_KEYS_INIT_SRC = _DISBOT / "utils" / "settings_keys" / "__init__.py"
 
 # 24-field template labels (snake_case form). The doc may format them with
@@ -132,15 +133,53 @@ def _initial_extensions() -> tuple[str, ...]:
 
 
 def _setup_readiness_blockers() -> tuple[str, ...]:
-    """Statically extract SETUP_READINESS_BLOCKERS from platform_consistency.py."""
-    value = _module_assignment(_PLATFORM_CONSISTENCY_SRC, "SETUP_READINESS_BLOCKERS")
+    """Statically extract the canonical blocker IDs.
+
+    PR-03: ``SETUP_READINESS_BLOCKERS`` is now derived from
+    ``services.setup_blockers.BLOCKERS`` (a tuple of ``BlockerSpec``
+    instances with literal ``id="..."`` arguments).  This helper
+    parses the BlockerSpec(...) call expressions and pulls the ``id``
+    keyword argument from each — keeping the doc-test fully static
+    (no code execution).
+    """
+    tree = ast.parse(_SETUP_BLOCKERS_SRC.read_text(encoding="utf-8"))
+    blockers_value: ast.AST | None = None
+    for node in tree.body:
+        if isinstance(node, ast.AnnAssign):
+            tgt = node.target
+            if (
+                isinstance(tgt, ast.Name)
+                and tgt.id == "BLOCKERS"
+                and node.value is not None
+            ):
+                blockers_value = node.value
+                break
+        elif isinstance(node, ast.Assign):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Name) and tgt.id == "BLOCKERS":
+                    blockers_value = node.value
+                    break
+            if blockers_value is not None:
+                break
     assert isinstance(
-        value, (ast.Tuple, ast.List)
-    ), "SETUP_READINESS_BLOCKERS must be a tuple/list literal"
+        blockers_value, (ast.Tuple, ast.List)
+    ), "setup_blockers.BLOCKERS must be a tuple/list literal of BlockerSpec(...) calls"
     out: list[str] = []
-    for elt in value.elts:
-        assert isinstance(elt, ast.Constant) and isinstance(elt.value, str)
-        out.append(elt.value)
+    for elt in blockers_value.elts:
+        assert isinstance(elt, ast.Call), "BLOCKERS entries must be BlockerSpec(...) calls"
+        # id may be passed positionally or as a keyword; canonical form
+        # in setup_blockers.py is keyword.
+        spec_id: str | None = None
+        for kw in elt.keywords:
+            if kw.arg == "id" and isinstance(kw.value, ast.Constant):
+                spec_id = kw.value.value
+                break
+        if spec_id is None and elt.args:
+            first = elt.args[0]
+            if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                spec_id = first.value
+        assert spec_id is not None, f"BlockerSpec call missing id: {ast.dump(elt)}"
+        out.append(spec_id)
     return tuple(out)
 
 

--- a/tests/unit/invariants/test_platform_consistency_kinds.py
+++ b/tests/unit/invariants/test_platform_consistency_kinds.py
@@ -24,7 +24,6 @@ import pytest
 
 from services import platform_consistency as pc
 
-
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _MODULE_PATH = _REPO_ROOT / "disbot" / "services" / "platform_consistency.py"
 

--- a/tests/unit/invariants/test_platform_consistency_kinds.py
+++ b/tests/unit/invariants/test_platform_consistency_kinds.py
@@ -1,0 +1,111 @@
+"""Invariant tests for the platform consistency typed readiness contract.
+
+Pins two structural constraints introduced in PR-01a:
+
+1. ``_LABEL_TO_KIND`` covers every label used by the
+   ``collect_report`` orchestrator.  Adding a new collector requires
+   adding its label/kind pair here at the same time.
+
+2. ``READINESS_KINDS`` is exhaustive over ``ReadinessKind`` and
+   matches the orchestrator's collector tuple order.  A missing kind
+   would silently lose its identity at runtime.
+
+The runtime stamping behaviour (every section in a collected report
+carries a typed kind) is pinned by
+``tests/unit/services/test_platform_consistency.py``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from services import platform_consistency as pc
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MODULE_PATH = _REPO_ROOT / "disbot" / "services" / "platform_consistency.py"
+
+
+def _extract_collector_labels() -> tuple[str, ...]:
+    """Parse the labels used in the ``collect_report`` collector tuple.
+
+    Handles both ``collectors = (...)`` and the annotated form
+    ``collectors: ... = (...)``.  Returns the string label of each
+    entry in declaration order.
+    """
+    tree = ast.parse(_MODULE_PATH.read_text())
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef) or node.name != "collect_report":
+            continue
+        for sub in ast.walk(node):
+            value: ast.AST | None = None
+            if isinstance(sub, ast.Assign):
+                target = sub.targets[0] if sub.targets else None
+                if isinstance(target, ast.Name) and target.id == "collectors":
+                    value = sub.value
+            elif isinstance(sub, ast.AnnAssign):
+                target = sub.target
+                if isinstance(target, ast.Name) and target.id == "collectors":
+                    value = sub.value
+            if value is None or not isinstance(value, ast.Tuple):
+                continue
+            labels: list[str] = []
+            for entry in value.elts:
+                if (
+                    isinstance(entry, ast.Tuple)
+                    and entry.elts
+                    and isinstance(entry.elts[0], ast.Constant)
+                    and isinstance(entry.elts[0].value, str)
+                ):
+                    labels.append(entry.elts[0].value)
+            return tuple(labels)
+    pytest.fail("Could not locate the `collectors` tuple inside collect_report")
+
+
+def test_label_to_kind_covers_every_collector_label():
+    labels = _extract_collector_labels()
+    assert len(labels) == 10, f"Expected 10 collectors; found {len(labels)}"
+    missing = [label for label in labels if label not in pc._LABEL_TO_KIND]
+    assert not missing, (
+        f"_LABEL_TO_KIND missing entries for: {missing}.  "
+        "Adding a new collector requires updating _LABEL_TO_KIND."
+    )
+
+
+def test_label_to_kind_has_no_orphan_entries():
+    labels = set(_extract_collector_labels())
+    orphan = [label for label in pc._LABEL_TO_KIND if label not in labels]
+    assert not orphan, (
+        f"_LABEL_TO_KIND has orphan entries (no matching collector): {orphan}"
+    )
+
+
+def test_readiness_kinds_matches_label_to_kind_values():
+    """Every kind referenced by ``_LABEL_TO_KIND`` is in
+    ``READINESS_KINDS``, and vice versa."""
+    via_labels = set(pc._LABEL_TO_KIND.values())
+    via_tuple = set(pc.READINESS_KINDS)
+    assert via_labels == via_tuple, (
+        f"READINESS_KINDS / _LABEL_TO_KIND drift: "
+        f"only-in-tuple={via_tuple - via_labels}; "
+        f"only-in-labels={via_labels - via_tuple}"
+    )
+
+
+def test_readiness_kinds_exhausts_enum():
+    """Every ``ReadinessKind`` enum member appears in
+    ``READINESS_KINDS``.  Adding a new enum member requires updating
+    the canonical tuple."""
+    assert set(pc.READINESS_KINDS) == set(pc.ReadinessKind)
+
+
+def test_readiness_kinds_order_matches_collector_order():
+    """The order of ``READINESS_KINDS`` matches the order of labels in
+    the orchestrator's collector tuple.  Diagnostic embeds and the
+    readiness snapshot rely on this ordering."""
+    labels = _extract_collector_labels()
+    expected = tuple(pc._LABEL_TO_KIND[label] for label in labels)
+    assert pc.READINESS_KINDS == expected

--- a/tests/unit/services/test_platform_consistency.py
+++ b/tests/unit/services/test_platform_consistency.py
@@ -597,3 +597,125 @@ def test_collect_report_returns_ten_sections_in_order():
     # Last section must be Setup readiness, marked informational.
     assert report.sections[-1].name == "Setup readiness"
     assert report.sections[-1].informational is True
+
+
+# ---------------------------------------------------------------------------
+# PR-01a: typed readiness kind + iter_blocking_sections
+# ---------------------------------------------------------------------------
+
+
+def test_readiness_kinds_canonical_ordering():
+    """``READINESS_KINDS`` pins the canonical section order.
+
+    The diagnostic embed and the upcoming readiness snapshot rely on
+    this ordering being stable; adding a new collector requires
+    appending its kind and updating ``_LABEL_TO_KIND`` together.
+    """
+    assert pc.READINESS_KINDS == (
+        pc.ReadinessKind.IDENTITY_CONTRACT,
+        pc.ReadinessKind.FEATURE_FLAGS,
+        pc.ReadinessKind.ROLLOUT_AUDIT,
+        pc.ReadinessKind.BINDINGS,
+        pc.ReadinessKind.BINDING_BACKFILL,
+        pc.ReadinessKind.CONFIG_ARBITRATION,
+        pc.ReadinessKind.PARTICIPATION,
+        pc.ReadinessKind.MIGRATIONS,
+        pc.ReadinessKind.RUNTIME_PROVIDERS,
+        pc.ReadinessKind.SETUP_READINESS,
+    )
+    # Every declared kind must appear in the canonical tuple.
+    assert set(pc.READINESS_KINDS) == set(pc.ReadinessKind)
+
+
+def test_collect_report_stamps_typed_kind_on_every_section():
+    """Every section in the collected report has a non-None typed kind
+    matching ``READINESS_KINDS``."""
+
+    async def trivial(*args, **kwargs) -> pc.SectionResult:
+        return pc.SectionResult(name="x", status=pc.SectionStatus.SKIPPED, summary="x")
+
+    with patch.multiple(
+        pc,
+        _collect_identity_contract=trivial,
+        _collect_feature_flags=trivial,
+        _collect_rollout_audit=trivial,
+        _collect_bindings=trivial,
+        _collect_binding_backfill=trivial,
+        _collect_config_arbitration=trivial,
+        _collect_participation=trivial,
+        _collect_migrations=trivial,
+        _collect_runtime_providers=trivial,
+        _collect_setup_readiness=trivial,
+    ):
+        report = asyncio.run(pc.collect_report(bot=object(), guild=None))
+
+    kinds = [s.kind for s in report.sections]
+    assert all(k is not None for k in kinds), f"Untyped section in {kinds}"
+    assert tuple(kinds) == pc.READINESS_KINDS
+
+
+def test_collect_report_stamps_kind_even_when_collector_raises():
+    """A collector exception still produces a typed section."""
+
+    async def bad(*args, **kwargs) -> pc.SectionResult:
+        raise RuntimeError("boom")
+
+    async def trivial(*args, **kwargs) -> pc.SectionResult:
+        return pc.SectionResult(name="x", status=pc.SectionStatus.SKIPPED, summary="x")
+
+    with patch.multiple(
+        pc,
+        _collect_identity_contract=bad,
+        _collect_feature_flags=trivial,
+        _collect_rollout_audit=trivial,
+        _collect_bindings=trivial,
+        _collect_binding_backfill=trivial,
+        _collect_config_arbitration=trivial,
+        _collect_participation=trivial,
+        _collect_migrations=trivial,
+        _collect_runtime_providers=trivial,
+        _collect_setup_readiness=trivial,
+    ):
+        report = asyncio.run(pc.collect_report(bot=object(), guild=None))
+
+    # The FATAL fallback section for identity_contract still gets stamped.
+    assert report.sections[0].status == pc.SectionStatus.FATAL
+    assert report.sections[0].kind == pc.ReadinessKind.IDENTITY_CONTRACT
+
+
+def test_iter_blocking_sections_filters_informational_and_clean():
+    """Non-informational FATAL/WARNING/SKIPPED are returned; CLEAN and
+    informational sections are filtered out."""
+    sections = (
+        pc.SectionResult(name="a", status=pc.SectionStatus.CLEAN, summary=""),
+        pc.SectionResult(name="b", status=pc.SectionStatus.WARNING, summary=""),
+        pc.SectionResult(name="c", status=pc.SectionStatus.FATAL, summary=""),
+        pc.SectionResult(name="d", status=pc.SectionStatus.SKIPPED, summary=""),
+        # Informational warning must be excluded (Setup readiness pattern).
+        pc.SectionResult(
+            name="e", status=pc.SectionStatus.WARNING, summary="", informational=True
+        ),
+    )
+    report = pc.ConsistencyReport(
+        sections=sections,
+        generated_at=datetime.datetime.now(tz=datetime.timezone.utc),
+    )
+    blocking = pc.iter_blocking_sections(report)
+    names = [s.name for s in blocking]
+    assert names == ["b", "c", "d"]
+
+
+def test_iter_blocking_sections_returns_empty_for_all_clean():
+    report = _report(pc.SectionStatus.CLEAN, pc.SectionStatus.CLEAN)
+    assert pc.iter_blocking_sections(report) == ()
+
+
+def test_setup_readiness_section_remains_informational():
+    """Regression pin: the Setup readiness collector must report
+    ``informational=True`` so the static blocker list cannot promote
+    ``overall_status``.  PR-03 (dynamic blocker registry) preserves
+    this contract."""
+    result = asyncio.run(pc._collect_setup_readiness())
+    assert result.informational is True
+    # Canonical section name matches the orchestrator's label mapping.
+    assert result.name == "Setup readiness"

--- a/tests/unit/services/test_platform_consistency.py
+++ b/tests/unit/services/test_platform_consistency.py
@@ -549,11 +549,18 @@ def test_participation_skipped_when_tables_absent():
 
 def test_setup_readiness_lists_all_documented_blockers():
     result = asyncio.run(pc._collect_setup_readiness())
-    assert result.status == pc.SectionStatus.WARNING
+    # PR-03: status depends on how many blockers are resolved at the
+    # moment the test runs; WARNING is the expected default since at
+    # least one blocker is still pending in this codebase.
+    assert result.status in (pc.SectionStatus.WARNING, pc.SectionStatus.CLEAN)
     assert result.informational is True
-    # Every constant entry must appear verbatim in the details.
+    # PR-03: details are now "<id>: <status>" pairs.  Every blocker ID
+    # must still appear as a prefix in some detail line.
+    detail_text = " ".join(result.details)
     for blocker in pc.SETUP_READINESS_BLOCKERS:
-        assert blocker in result.details
+        assert blocker in detail_text, (
+            f"{blocker!r} missing from setup readiness section details"
+        )
 
 
 def test_setup_readiness_marked_informational():


### PR DESCRIPTION
## Summary

Replaces the static `SETUP_READINESS_BLOCKERS` tuple with a typed provider-backed registry in a **new** module `services/setup_blockers.py` — per the revision plan's Correction 3, the per-guild `services/setup_readiness.py` is a DB-bound inventory and should not host a global registry.

Part of the SuperBot 2.0 refactor plan (see `/root/.claude/plans/1-recommended-target-agent-zazzy-eclipse.md`).

**Depends on PR-01a (#244)** — extends the typed readiness contract; uses `SectionStatus` and the orchestrator's kind-stamping.

## What changes

### New module `disbot/services/setup_blockers.py`

- `BlockerSpec` frozen dataclass with `id`, `owner_project`, `refactor_layer`, `status_provider`, `severity`, `unlocks`, `blocked_by`, `doc_anchor`.
- `BlockerStatus` Literal: `resolved | in_progress | pending | blocked | unknown`.
- `BLOCKERS` canonical tuple of 11 specs covering every entry from the prior static list.
- **Sync** status providers for resolvable blockers — read cached state (`command_surface_ledger.get_cached_ledger()`, `settings_registry.get_cached_registry()`, etc.) without DB I/O. Pending blockers fall through to a doc-anchor placeholder.
- `status_for(spec)` wraps the provider with a fail-safe — a raising provider becomes `"unknown"` rather than blanking the report.
- `setup_wizard_readiness_bridge` marked `owner="UNCONFIRMED"` per the revision plan's stop condition (reviewer assigns during PR review).

### `platform_consistency.py`

- `SETUP_READINESS_BLOCKERS` is now a derived tuple of IDs via `setup_blockers.blocker_ids()`. **The bare-string contract is preserved** for callers that import the constant.
- `_collect_setup_readiness()` rewritten to call each `spec.status_provider()` and report `<resolved>/<total>` plus per-spec status in details. The section remains `informational=True` so `overall_status` is never promoted by roadmap state.

## Backward compatibility

`from services.platform_consistency import SETUP_READINESS_BLOCKERS` still works and yields the same tuple of string IDs. The doc-test `test_every_setup_readiness_blocker_appears_in_doc` runs unchanged. Historical pins (PR #86 merged, migration 028 on main, PR-10 next work) are **untouched** per the revision plan's stop condition.

## Test plan

- [x] `tests/unit/docs/test_phase_2_readiness_doc.py` — historical pins untouched; adds:
  - `test_blocker_ids_match_blocker_specs` — drift guard
  - `test_every_blocker_has_resolution_provider_and_doc_anchor` — completeness guard
  - `test_blocker_status_provider_returns_valid_literal` — every provider returns a known literal
- [x] `tests/unit/docs/test_settings_customization_doc.py` — updates the AST helper to parse `setup_blockers.BLOCKERS` (the new source of truth) instead of the now-derived `SETUP_READINESS_BLOCKERS`. Keeps the test fully static (no code execution).
- [x] `tests/unit/services/test_platform_consistency.py` — updates the blocker-detail assertion for the new `<id>: <status>` shape; section informational status pinned regression-style.
- [x] 3780 unit tests pass; ruff / isort / black clean.

## Dependencies and unlocks

- **Blocked by**: PR-01a (#244)
- **Unlocks**: PR-04a (preflight can read blocker state); future readiness embed surfaces with per-blocker status


---
_Generated by [Claude Code](https://claude.ai/code/session_01FZb9tZiTdK1z6WfCzXpXmN)_