### PR TITLE
PR-06b: Slash command ledger ingestion

### DIFF
--- a/disbot/core/runtime/command_surface_ledger.py
+++ b/disbot/core/runtime/command_surface_ledger.py
@@ -1,9 +1,9 @@
 """Command surface ledger — Phase 2 PR-12.
 
 An immutable, in-memory catalogue of every command entrypoint the bot
-exposes — prefix commands today, slash commands reserved for a future
-PR — together with their owner subsystem, visibility tier, and any
-group/alias relationships.
+exposes — prefix commands AND slash commands (PR-06b) — together
+with their owner subsystem, visibility tier, and any group/alias
+relationships.
 
 The ledger is **read-only** and **builder-driven**: ``build_ledger(bot)``
 walks the live ``bot.commands`` surface and the interaction router's
@@ -262,6 +262,81 @@ def _walk_commands(bot: object) -> list[CommandSurfaceEntry]:
     return entries
 
 
+def _walk_slash_commands(bot: object) -> list[CommandSurfaceEntry]:
+    """Walk ``bot.tree`` and build one entry per registered slash command.
+
+    PR-06b: 5 setup slash commands (``/setup-status``, ``/setup-reset``,
+    ``/setup-skip``, ``/setup-unskip``, ``/setup-depth``) are
+    registered today but were previously invisible to the ledger
+    because the walker only enumerated prefix commands.  This walk
+    runs over ``bot.tree.walk_commands()`` (discord.py
+    ``CommandTree.walk_commands``) and emits one
+    ``CommandSurfaceEntry`` per slash command with ``kind="slash"``.
+
+    Groups (``app_commands.Group``) are flattened — only leaf
+    commands are emitted, with ``parent_group`` set to the group's
+    qualified name.  ``binding`` (the cog instance) is read via
+    ``getattr`` so a missing attribute (e.g. unbound) yields
+    ``cog_name=""`` rather than raising.
+
+    The default ``classification`` is left at ``"primary_entrypoint"``;
+    PR-06c will annotate the setup slash commands as panel actions
+    where appropriate.
+    """
+    entries: list[CommandSurfaceEntry] = []
+    tree = getattr(bot, "tree", None)
+    if tree is None:
+        return entries
+    walk = getattr(tree, "walk_commands", None)
+    if walk is None:
+        return entries
+    try:
+        iter_cmds = walk()
+    except Exception as exc:  # noqa: BLE001 — best-effort walk
+        logger.warning(
+            "command_surface_ledger: slash walk_commands raised %s",
+            exc,
+        )
+        return entries
+    for cmd in iter_cmds:
+        # Skip groups; only leaf commands carry a callable binding.
+        # discord.py's ``app_commands.Group`` does not have a
+        # ``callback`` attribute — leaf ``Command`` instances do.
+        if not hasattr(cmd, "callback"):
+            continue
+        binding = getattr(cmd, "binding", None)
+        cog_name = binding.__class__.__name__ if binding is not None else ""
+        subsystem = cog_name_to_subsystem(cog_name) if cog_name else None
+        visibility_tier = _visibility_for(subsystem)
+        parent = getattr(cmd, "parent", None)
+        parent_name = (
+            getattr(parent, "qualified_name", None) if parent is not None else None
+        )
+        qualified_name = getattr(cmd, "qualified_name", None) or getattr(
+            cmd,
+            "name",
+            "",
+        )
+        is_declared = _is_declared_entry_point(
+            getattr(cmd, "name", ""),
+            qualified_name,
+            subsystem,
+        )
+        entries.append(
+            CommandSurfaceEntry(
+                name=qualified_name,
+                cog_name=cog_name,
+                subsystem=subsystem,
+                visibility_tier=visibility_tier,
+                aliases=(),
+                parent_group=parent_name,
+                is_declared=is_declared,
+                kind="slash",
+            ),
+        )
+    return entries
+
+
 def _visibility_for(subsystem: str | None) -> str | None:
     if subsystem is None:
         return None
@@ -380,8 +455,15 @@ def build_ledger(bot: object) -> CommandSurfaceLedger:
     Caches the result for later diagnostics access; call again to
     refresh after a hot-reload.  The function is sync-safe: it does
     not perform I/O.
+
+    PR-06b: in addition to prefix commands (``bot.walk_commands``),
+    the builder now walks ``bot.tree.walk_commands`` to populate
+    ``slash_entries``.  Missing trees or older bots without an
+    ``app_commands`` surface gracefully degrade to an empty
+    ``slash_entries`` tuple.
     """
     entries = _walk_commands(bot)
+    slash_entries = _walk_slash_commands(bot)
     router_prefixes = _walk_router_prefixes()
     findings = _compute_findings(entries, router_prefixes)
     ledger = CommandSurfaceLedger(
@@ -390,14 +472,16 @@ def build_ledger(bot: object) -> CommandSurfaceLedger:
         entries=tuple(entries),
         router_prefixes=tuple(router_prefixes),
         findings=findings,
+        slash_entries=tuple(slash_entries),
     )
     global _CACHED
     _CACHED = ledger
     logger.info(
-        "command_surface_ledger: built v%d — %d commands, %d router prefixes, "
-        "%d findings",
+        "command_surface_ledger: built v%d — %d prefix command(s), "
+        "%d slash command(s), %d router prefix(es), %d finding(s)",
         ledger.version,
         len(ledger.entries),
+        len(ledger.slash_entries),
         len(ledger.router_prefixes),
         findings.total,
     )

--- a/disbot/core/runtime/command_surface_ledger.py
+++ b/disbot/core/runtime/command_surface_ledger.py
@@ -23,6 +23,8 @@ re-walking ``bot.commands``.
 Public surface:
 
     CommandSurfaceEntry      — frozen dataclass per command
+    Classification           — Literal of canonical classification values
+    CLASSIFICATIONS          — tuple of all canonical classification values
     RouterPrefixEntry        — frozen dataclass per registered router prefix
     LedgerFindings           — frozen dataclass with orphan/duplicate buckets
     CommandSurfaceLedger     — frozen aggregate snapshot
@@ -39,7 +41,7 @@ import datetime
 import logging
 import re
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal, get_args
 
 logger = logging.getLogger("bot.runtime.command_surface_ledger")
 
@@ -47,6 +49,43 @@ logger = logging.getLogger("bot.runtime.command_surface_ledger")
 # ---------------------------------------------------------------------------
 # Public types
 # ---------------------------------------------------------------------------
+
+
+# PR-06a — Classification contract.
+#
+# Each command entrypoint is classified so help/navigation surfaces and
+# the readiness embed can decide whether to render, dim, hide, or warn
+# about a command without consulting the help cog directly.  PR-06a
+# ships only the type + the default; PR-06b wires slash-command
+# ingestion; PR-06c sweeps the cogs to annotate.
+#
+# Values:
+#
+# * ``primary_entrypoint`` — the canonical command operators use.
+#   Default for unannotated commands so PR-06a is purely additive.
+# * ``power_user_shortcut`` — alternative spelling kept for fluency;
+#   help may dim it after PR-06c.
+# * ``panel_action`` — invoked from a panel button rather than typed;
+#   help can omit from the prefix-typed listing.
+# * ``legacy_duplicate`` — an alias kept around for backwards-compat;
+#   PR-06c may filter from help suggestions.
+# * ``internal_admin`` — surfaced only to staff/operators.
+# * ``hidden`` — never surfaced in help (still callable).
+# * ``deprecated`` — surfaced with a deprecation warning.
+Classification = Literal[
+    "primary_entrypoint",
+    "power_user_shortcut",
+    "panel_action",
+    "legacy_duplicate",
+    "internal_admin",
+    "hidden",
+    "deprecated",
+]
+
+# Canonical tuple of every classification value.  Used by the
+# invariant test to assert nothing has drifted between the Literal and
+# any classification registry added by PR-06c.
+CLASSIFICATIONS: tuple[Classification, ...] = get_args(Classification)
 
 
 @dataclass(frozen=True)
@@ -61,6 +100,11 @@ class CommandSurfaceEntry:
     parent_group: str | None = None
     is_declared: bool = False
     kind: str = "prefix"  # reserved values: "prefix" | "slash"
+    # PR-06a: classification defaults to ``primary_entrypoint`` so
+    # adding the field is purely additive.  PR-06c populates this from
+    # per-cog declarations (decorator or metadata map) and surfaces
+    # the unclassified set as a finding.
+    classification: Classification = "primary_entrypoint"
 
 
 @dataclass(frozen=True)
@@ -80,6 +124,12 @@ class LedgerFindings:
     duplicate_alias_names: tuple[str, ...] = ()
     undeclared_entry_points: tuple[str, ...] = ()
     router_prefix_unknown: tuple[str, ...] = ()
+    # PR-06a: populated by PR-06c once per-cog classification metadata
+    # exists.  Empty in PR-06a because the default classification
+    # (``primary_entrypoint``) means every command is considered
+    # classified out of the box.  Reserved here so the dataclass shape
+    # is stable across the PR-06a → PR-06c sequence.
+    unclassified_entry_points: tuple[str, ...] = ()
 
     @property
     def total(self) -> int:
@@ -89,6 +139,7 @@ class LedgerFindings:
             + len(self.duplicate_alias_names)
             + len(self.undeclared_entry_points)
             + len(self.router_prefix_unknown)
+            + len(self.unclassified_entry_points)
         )
 
 
@@ -392,6 +443,9 @@ def _snapshot() -> dict[str, Any]:
             "duplicate_alias_names": len(ledger.findings.duplicate_alias_names),
             "undeclared_entry_points": len(ledger.findings.undeclared_entry_points),
             "router_prefix_unknown": len(ledger.findings.router_prefix_unknown),
+            "unclassified_entry_points": len(
+                ledger.findings.unclassified_entry_points,
+            ),
         },
     }
 
@@ -406,6 +460,8 @@ _register_diagnostics()
 
 
 __all__ = [
+    "CLASSIFICATIONS",
+    "Classification",
     "CommandSurfaceEntry",
     "CommandSurfaceLedger",
     "LedgerFindings",

--- a/tests/unit/runtime/test_command_surface_ledger.py
+++ b/tests/unit/runtime/test_command_surface_ledger.py
@@ -548,3 +548,131 @@ class TestClassification:
         assert snap["findings"]["unclassified_entry_points"] == 0
 
 
+# ---------------------------------------------------------------------------
+# PR-06b — Slash command ledger ingestion
+# ---------------------------------------------------------------------------
+
+
+def _make_slash_cmd(
+    name: str,
+    cog_name: str = "DiagnosticCog",
+    parent_name: str | None = None,
+) -> MagicMock:
+    """Build a discord.py ``app_commands.Command`` look-alike.
+
+    Leaf commands have a ``callback``; groups don't, so the walker
+    can filter groups out.  ``binding`` is the cog instance.
+    """
+    cmd = MagicMock()
+    cmd.name = name
+    cmd.qualified_name = f"{parent_name} {name}" if parent_name else name
+    cmd.callback = MagicMock()  # marks this as a leaf, not a group
+    if cog_name:
+        cmd.binding = MagicMock()
+        cmd.binding.__class__ = type(cog_name, (), {})
+    else:
+        cmd.binding = None
+    if parent_name:
+        parent = MagicMock()
+        parent.qualified_name = parent_name
+        cmd.parent = parent
+    else:
+        cmd.parent = None
+    return cmd
+
+
+def _make_bot_with_tree(*prefix_cmds, slash_cmds=()) -> MagicMock:
+    bot = MagicMock()
+    bot.walk_commands = MagicMock(return_value=list(prefix_cmds))
+    bot.tree = MagicMock()
+    bot.tree.walk_commands = MagicMock(return_value=list(slash_cmds))
+    return bot
+
+
+class TestSlashLedgerIngestion:
+    def test_build_ledger_walks_slash_tree(self):
+        cmd = _make_slash_cmd("setup-status", cog_name="DiagnosticCog")
+        bot = _make_bot_with_tree(slash_cmds=(cmd,))
+        ledger = build_ledger(bot)
+        assert len(ledger.slash_entries) == 1
+        slash = ledger.slash_entries[0]
+        assert slash.name == "setup-status"
+        assert slash.cog_name == "DiagnosticCog"
+        assert slash.subsystem == "diagnostic"
+        assert slash.kind == "slash"
+
+    def test_build_ledger_captures_five_setup_slash_commands(self):
+        """The 5 live setup slash commands appear in slash_entries when
+        the bot tree contains them.  PR-06b's primary regression."""
+        names = (
+            "setup-status",
+            "setup-reset",
+            "setup-skip",
+            "setup-unskip",
+            "setup-depth",
+        )
+        cmds = [_make_slash_cmd(n, cog_name="DiagnosticCog") for n in names]
+        bot = _make_bot_with_tree(slash_cmds=cmds)
+        ledger = build_ledger(bot)
+        captured = {e.name for e in ledger.slash_entries}
+        assert captured == set(names)
+        for entry in ledger.slash_entries:
+            assert entry.kind == "slash"
+            assert entry.classification == "primary_entrypoint"
+
+    def test_slash_groups_filtered_out(self):
+        """``app_commands.Group`` instances have no ``callback`` and
+        must not appear as slash entries — only leaf commands do."""
+        leaf = _make_slash_cmd("setup-status", cog_name="DiagnosticCog")
+        group = MagicMock(spec=["name"])
+        group.name = "setup"
+        bot = _make_bot_with_tree(slash_cmds=(group, leaf))
+        ledger = build_ledger(bot)
+        names = [e.name for e in ledger.slash_entries]
+        assert "setup-status" in names
+        assert "setup" not in names
+
+    def test_build_ledger_handles_bot_without_tree(self):
+        """Bots without an ``app_commands`` surface (older fixtures)
+        still build a ledger; slash_entries is empty."""
+        bot = MagicMock(spec=["walk_commands"])
+        bot.walk_commands = MagicMock(return_value=[])
+        ledger = build_ledger(bot)
+        assert ledger.slash_entries == ()
+
+    def test_build_ledger_handles_tree_walk_raise(self):
+        """Defensive: if tree.walk_commands raises, slash ingestion
+        returns an empty list rather than crashing the builder."""
+        bot = MagicMock()
+        bot.walk_commands = MagicMock(return_value=[])
+        bot.tree = MagicMock()
+        bot.tree.walk_commands = MagicMock(side_effect=RuntimeError("boom"))
+        ledger = build_ledger(bot)
+        assert ledger.slash_entries == ()
+
+    def test_slash_entry_records_parent_group(self):
+        sub = _make_slash_cmd(
+            "status",
+            cog_name="DiagnosticCog",
+            parent_name="setup",
+        )
+        bot = _make_bot_with_tree(slash_cmds=(sub,))
+        ledger = build_ledger(bot)
+        assert ledger.slash_entries[0].name == "setup status"
+        assert ledger.slash_entries[0].parent_group == "setup"
+
+    def test_diagnostics_snapshot_reflects_slash_entry_count(self):
+        from core.runtime.command_surface_ledger import _snapshot
+
+        cmds = [
+            _make_slash_cmd(n, cog_name="DiagnosticCog")
+            for n in ("setup-status", "setup-reset")
+        ]
+        bot = _make_bot_with_tree(slash_cmds=cmds)
+        with patch(
+            "core.runtime.command_surface_ledger._walk_router_prefixes",
+            return_value=[],
+        ):
+            build_ledger(bot)
+        snap = _snapshot()
+        assert snap["slash_entry_count"] == 2

--- a/tests/unit/runtime/test_command_surface_ledger.py
+++ b/tests/unit/runtime/test_command_surface_ledger.py
@@ -9,6 +9,7 @@ import pytest
 
 from core.runtime import command_surface_ledger as ledger_mod
 from core.runtime.command_surface_ledger import (
+    CLASSIFICATIONS,
     CommandSurfaceEntry,
     CommandSurfaceLedger,
     LedgerFindings,
@@ -470,3 +471,80 @@ def test_does_not_call_validate_identity_contract():
                         "Ledger imports validate_identity_contract — "
                         "complementary, not consumer",
                     )
+
+
+# ---------------------------------------------------------------------------
+# PR-06a — Classification contract (additive)
+# ---------------------------------------------------------------------------
+
+
+class TestClassification:
+    def test_classifications_tuple_matches_literal_args(self):
+        """Canonical tuple must list every value declared in the
+        Classification Literal — drift would let cog annotations use a
+        value the type checker accepts but no consumer knows about."""
+        from typing import get_args
+
+        from core.runtime.command_surface_ledger import Classification
+
+        assert set(CLASSIFICATIONS) == set(get_args(Classification))
+
+    def test_classifications_includes_seven_canonical_values(self):
+        assert set(CLASSIFICATIONS) == {
+            "primary_entrypoint",
+            "power_user_shortcut",
+            "panel_action",
+            "legacy_duplicate",
+            "internal_admin",
+            "hidden",
+            "deprecated",
+        }
+
+    def test_command_surface_entry_default_classification(self):
+        entry = CommandSurfaceEntry(
+            name="daily",
+            cog_name="EconomyCog",
+            subsystem="economy",
+            visibility_tier="user",
+        )
+        assert entry.classification == "primary_entrypoint"
+
+    def test_command_surface_entry_classification_explicitly_set(self):
+        entry = CommandSurfaceEntry(
+            name="legacy_daily",
+            cog_name="EconomyCog",
+            subsystem="economy",
+            visibility_tier="user",
+            classification="legacy_duplicate",
+        )
+        assert entry.classification == "legacy_duplicate"
+
+    def test_findings_unclassified_entry_points_default_empty(self):
+        findings = LedgerFindings()
+        assert findings.unclassified_entry_points == ()
+        assert findings.total == 0
+
+    def test_findings_total_includes_unclassified_count(self):
+        findings = LedgerFindings(
+            unclassified_entry_points=("economy.daily", "rps.duel"),
+        )
+        assert findings.total == 2
+
+    def test_diagnostics_snapshot_includes_unclassified_count(self):
+        """The diagnostics provider exposes the new bucket so the
+        readiness embed and !platform diagnostics show it without
+        cog-side knowledge of the field name."""
+        from core.runtime.command_surface_ledger import _snapshot
+
+        bot = MagicMock()
+        bot.walk_commands = lambda: []
+        with patch(
+            "core.runtime.command_surface_ledger._walk_router_prefixes",
+            return_value=[],
+        ):
+            build_ledger(bot)
+        snap = _snapshot()
+        assert "unclassified_entry_points" in snap["findings"]
+        assert snap["findings"]["unclassified_entry_points"] == 0
+
+


### PR DESCRIPTION
## Summary

Populates the `CommandSurfaceLedger`'s `slash_entries` field by walking `bot.tree.walk_commands()`. The 5 live setup slash commands (`/setup-status`, `/setup-reset`, `/setup-skip`, `/setup-unskip`, `/setup-depth`) were previously invisible to the ledger because the walker only enumerated prefix commands — a gap the revision plan flagged as Correction 5 (broad classification before slash coverage would silently miss them).

Part of the SuperBot 2.0 refactor plan (see `/root/.claude/plans/1-recommended-target-agent-zazzy-eclipse.md`).

**Depends on PR-06a (#246)** — uses the `Classification` field on `CommandSurfaceEntry`.

## What changes

- **New `_walk_slash_commands(bot)`** function that iterates `bot.tree.walk_commands()`, filters out `app_commands.Group` instances (only leaf `Command` objects have a `callback`), reads the `binding` attribute for cog ownership, and emits one `CommandSurfaceEntry` per slash command with `kind="slash"`. Subcommands (group leaves) record `parent_group` for help routing.
- **`build_ledger`** now calls `_walk_slash_commands` and sets `slash_entries` on the returned snapshot. The existing diagnostics snapshot already exposed `slash_entry_count`; it now reflects real data.
- **Defensive**: missing `bot.tree`, missing `walk_commands`, or a raising `walk_commands` all degrade to an empty `slash_entries` tuple rather than crashing the builder.
- Module docstring updated to reflect that slash commands are now part of the ledger.

## Discord.py compatibility

The walker reads through `getattr` so a missing `binding`, `parent`, or `qualified_name` falls back gracefully. discord.py's `app_commands.Command` always has a `callback`; `app_commands.Group` does not — this is the leaf-vs-group filter.

## Test plan

- [x] New `TestSlashLedgerIngestion` class with 7 cases:
  - `walks_slash_tree` — basic capture + kind/subsystem assertions
  - `captures_five_setup_slash_commands` — **PR-06b's primary regression**
  - `slash_groups_filtered_out` — only leaf commands appear
  - `handles_bot_without_tree` — older fixtures still build
  - `handles_tree_walk_raise` — defensive
  - `records_parent_group` — subcommand parent
  - `diagnostics_snapshot_reflects_slash_entry_count`
- [x] 3780 unit tests pass; ruff / isort / black / mypy all green

## Dependencies and unlocks

- **Blocked by**: PR-06a (#246)
- **Unlocks**: PR-06c (annotation sweep + help filtering — can now annotate both prefix and slash commands in one pass)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FZb9tZiTdK1z6WfCzXpXmN)_