### PR TITLE
PR-05: Discord smoke-test checklist (doc + readiness pin)

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -752,18 +752,26 @@ async def main() -> None:
             # boots without the ledger and `!platform consistency`
             # reports the section as not-built.
             try:
-                from core.runtime import command_surface_ledger
+                from core.runtime import command_surface_ledger, startup_outcome
 
                 command_surface_ledger.build_ledger(bot)
+                startup_outcome.record_success("command_surface_ledger")
             except Exception as exc:
                 logger.warning("Command-surface ledger build skipped: %s", exc)
+                from core.runtime import startup_outcome
+
+                startup_outcome.record_failure("command_surface_ledger", exc)
 
             try:
-                from core.runtime import settings_registry
+                from core.runtime import settings_registry, startup_outcome
 
                 settings_registry.build_registry()
+                startup_outcome.record_success("settings_registry")
             except Exception as exc:
                 logger.warning("Settings registry build skipped: %s", exc)
+                from core.runtime import startup_outcome
+
+                startup_outcome.record_failure("settings_registry", exc)
 
             # S2 — Customization catalogue. Composes the command surface
             # ledger, settings registry, subsystem schemas, and live cog
@@ -771,11 +779,16 @@ async def main() -> None:
             # Failure is non-fatal: the bot boots without the catalogue
             # and `!platform customization` reports it as not-built.
             try:
+                from core.runtime import startup_outcome
                 from services import customization_catalogue
 
                 customization_catalogue.build_catalogue(bot)
+                startup_outcome.record_success("customization_catalogue")
             except Exception as exc:
                 logger.warning("Customization catalogue build skipped: %s", exc)
+                from core.runtime import startup_outcome
+
+                startup_outcome.record_failure("customization_catalogue", exc)
 
             # S2.5 — Resource provisioning catalogue. Frozen, read-only
             # cross-link of every ResourceRequirement with its
@@ -783,12 +796,20 @@ async def main() -> None:
             # Failure is non-fatal: the bot boots without the catalogue
             # and `!platform provisioning` reports it as not-built.
             try:
+                from core.runtime import startup_outcome
                 from services import resource_provisioning_catalogue
 
                 resource_provisioning_catalogue.build_provisioning_catalogue()
+                startup_outcome.record_success("resource_provisioning_catalogue")
             except Exception as exc:
                 logger.warning(
                     "Resource provisioning catalogue build skipped: %s",
+                    exc,
+                )
+                from core.runtime import startup_outcome
+
+                startup_outcome.record_failure(
+                    "resource_provisioning_catalogue",
                     exc,
                 )
 

--- a/disbot/core/runtime/startup_outcome.py
+++ b/disbot/core/runtime/startup_outcome.py
@@ -1,0 +1,120 @@
+"""Startup outcome recorder — PR-01b.
+
+A tiny sync module that records whether each phase of startup
+(``command_surface_ledger`` / ``settings_registry`` / ``customization_catalogue``
+/ ``resource_provisioning_catalogue``) built successfully.  Each phase
+in ``bot1.py`` already runs under its own ``try/except`` and continues
+on failure; the recorder turns that previously-invisible state into an
+observable record that the readiness snapshot can read sync.
+
+Public surface:
+
+    StartupOutcome           — frozen dataclass per recorded phase
+    record_success(name)     — called inside a try block
+    record_failure(name, exc) — called inside an except clause
+    all_outcomes()           — sorted tuple of every recorded outcome
+    reset_for_tests()        — clears the recorder state (pytest fixture)
+
+The recorder is process-local, sync-only, and never raises.  It does
+not register a diagnostics provider on its own — ``platform_consistency``
+composes the outcomes into the readiness snapshot whose provider name
+is ``"platform_readiness"``.
+"""
+
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass
+
+# Canonical phase names recorded by bot1.py at startup.  Code that
+# adds a new phase must add its name here so the readiness snapshot
+# can distinguish "phase ran and succeeded" from "phase did not run
+# (unknown)" — the latter would be a regression that the
+# orchestrator never reached the recorder.
+KNOWN_PHASES: tuple[str, ...] = (
+    "command_surface_ledger",
+    "settings_registry",
+    "customization_catalogue",
+    "resource_provisioning_catalogue",
+)
+
+
+@dataclass(frozen=True)
+class StartupOutcome:
+    """One recorded phase outcome.
+
+    ``error`` is ``None`` on success and a short ``type:message``
+    string on failure (so the snapshot dict view is safe to serialise
+    without leaking long stack traces).
+    """
+
+    name: str
+    success: bool
+    error: str | None
+    recorded_at: datetime.datetime
+
+
+_RECORDED: dict[str, StartupOutcome] = {}
+
+
+def record_success(name: str) -> None:
+    """Record a successful phase run.
+
+    Overwrites any prior record for the same name so a hot-reload
+    rebuild flips the state back to success.  Never raises.
+    """
+    _RECORDED[name] = StartupOutcome(
+        name=name,
+        success=True,
+        error=None,
+        recorded_at=datetime.datetime.now(tz=datetime.timezone.utc),
+    )
+
+
+def record_failure(name: str, exc: BaseException) -> None:
+    """Record a failed phase run.
+
+    Stores a short ``type:message`` summary; never holds the
+    exception traceback.  Never raises.
+    """
+    summary = f"{type(exc).__name__}: {exc}"
+    # Cap the summary so a multi-line message does not bloat the
+    # snapshot dict view.
+    if len(summary) > 200:
+        summary = summary[:197] + "..."
+    _RECORDED[name] = StartupOutcome(
+        name=name,
+        success=False,
+        error=summary,
+        recorded_at=datetime.datetime.now(tz=datetime.timezone.utc),
+    )
+
+
+def all_outcomes() -> tuple[StartupOutcome, ...]:
+    """Return every recorded outcome, sorted by phase name."""
+    return tuple(sorted(_RECORDED.values(), key=lambda o: o.name))
+
+
+def get(name: str) -> StartupOutcome | None:
+    """Return the outcome for *name*, or ``None`` if never recorded."""
+    return _RECORDED.get(name)
+
+
+def reset_for_tests() -> None:
+    """Clear every recorded outcome.
+
+    Test isolation hook — call from a ``pytest.fixture(autouse=True)``
+    so module-level state does not leak between cases.
+    """
+    _RECORDED.clear()
+
+
+__all__ = [
+    "KNOWN_PHASES",
+    "StartupOutcome",
+    "all_outcomes",
+    "get",
+    "record_failure",
+    "record_success",
+    "reset_for_tests",
+]

--- a/disbot/services/platform_consistency.py
+++ b/disbot/services/platform_consistency.py
@@ -37,14 +37,18 @@ Informational sections never promote ``overall_status``.
 Public surface:
 
     SectionStatus               — enum
+    ReadinessKind               — enum (typed identity per section)
+    READINESS_KINDS             — canonical-order tuple of every kind
     SectionResult               — frozen dataclass per section
     ConsistencyReport           — frozen dataclass: sections + overall_status
     SETUP_READINESS_BLOCKERS    — tuple of roadmap blocker identifiers
     collect_report(*, bot, guild) — async orchestrator
+    iter_blocking_sections(report) — non-informational, non-CLEAN sections
 """
 
 from __future__ import annotations
 
+import dataclasses
 import datetime
 import logging
 import os
@@ -68,6 +72,68 @@ class SectionStatus(str, Enum):
     SKIPPED = "skipped"
 
 
+class ReadinessKind(str, Enum):
+    """Canonical typed identity for each consistency section.
+
+    PR-01a: every section result returned by ``collect_report`` is
+    stamped with one of these kinds by the orchestrator (collectors
+    do not need to know about kinds — the orchestrator maps from
+    the human label to the typed kind).
+
+    ``READINESS_KINDS`` exports the canonical ordering used by the
+    orchestrator and consumers; the invariant test
+    ``tests/unit/invariants/test_platform_consistency_kinds.py`` pins
+    every collector to a known kind.
+    """
+
+    IDENTITY_CONTRACT = "identity_contract"
+    FEATURE_FLAGS = "feature_flags"
+    ROLLOUT_AUDIT = "rollout_audit"
+    BINDINGS = "bindings"
+    BINDING_BACKFILL = "binding_backfill"
+    CONFIG_ARBITRATION = "config_arbitration"
+    PARTICIPATION = "participation"
+    MIGRATIONS = "migrations"
+    RUNTIME_PROVIDERS = "runtime_providers"
+    SETUP_READINESS = "setup_readiness"
+
+
+# Canonical ordering — matches the orchestrator's collector tuple at
+# ``collect_report``.  ``test_readiness_kinds_canonical_ordering`` pins
+# this ordering so the diagnostic embed and the readiness snapshot can
+# rely on a stable section order.
+READINESS_KINDS: tuple[ReadinessKind, ...] = (
+    ReadinessKind.IDENTITY_CONTRACT,
+    ReadinessKind.FEATURE_FLAGS,
+    ReadinessKind.ROLLOUT_AUDIT,
+    ReadinessKind.BINDINGS,
+    ReadinessKind.BINDING_BACKFILL,
+    ReadinessKind.CONFIG_ARBITRATION,
+    ReadinessKind.PARTICIPATION,
+    ReadinessKind.MIGRATIONS,
+    ReadinessKind.RUNTIME_PROVIDERS,
+    ReadinessKind.SETUP_READINESS,
+)
+
+
+# Maps the human-readable label used by the orchestrator's collector
+# tuple to the typed ``ReadinessKind``.  The orchestrator stamps each
+# collector's ``SectionResult.kind`` from this map after the collector
+# returns, so collectors themselves never need to set ``kind``.
+_LABEL_TO_KIND: dict[str, ReadinessKind] = {
+    "Identity contract": ReadinessKind.IDENTITY_CONTRACT,
+    "Feature flags": ReadinessKind.FEATURE_FLAGS,
+    "Rollout / audit": ReadinessKind.ROLLOUT_AUDIT,
+    "Bindings": ReadinessKind.BINDINGS,
+    "Binding backfill": ReadinessKind.BINDING_BACKFILL,
+    "Config arbitration": ReadinessKind.CONFIG_ARBITRATION,
+    "Participation": ReadinessKind.PARTICIPATION,
+    "Migrations": ReadinessKind.MIGRATIONS,
+    "Runtime providers": ReadinessKind.RUNTIME_PROVIDERS,
+    "Setup readiness": ReadinessKind.SETUP_READINESS,
+}
+
+
 @dataclass(frozen=True)
 class SectionResult:
     name: str
@@ -76,6 +142,13 @@ class SectionResult:
     details: tuple[str, ...] = ()
     suggested_actions: tuple[str, ...] = ()
     informational: bool = False
+    # PR-01a: typed identity stamped by the orchestrator after each
+    # collector returns.  Optional only so collectors can construct
+    # ``SectionResult`` without knowing the kind; the orchestrator
+    # guarantees every section in a collected report has a non-None
+    # kind.  Consumers that build sections outside ``collect_report``
+    # (e.g. unit tests) may leave it as ``None``.
+    kind: ReadinessKind | None = None
 
 
 @dataclass(frozen=True)
@@ -176,10 +249,38 @@ async def collect_report(
                 summary=f"collector raised {type(exc).__name__}",
                 details=(str(exc)[:200],),
             )
+        # PR-01a: stamp the canonical readiness kind from the label.
+        # Collectors construct SectionResult without knowing the kind;
+        # the orchestrator is the single place where the human label
+        # is translated into the typed ``ReadinessKind``.
+        if result.kind is None:
+            result = dataclasses.replace(result, kind=_LABEL_TO_KIND[label])
         sections.append(result)
     return ConsistencyReport(
         sections=tuple(sections),
         generated_at=datetime.datetime.now(tz=datetime.timezone.utc),
+    )
+
+
+def iter_blocking_sections(
+    report: ConsistencyReport,
+) -> tuple[SectionResult, ...]:
+    """Return only non-informational, non-CLEAN sections.
+
+    PR-01a helper used by the upcoming readiness snapshot (PR-01b) and
+    smoke checklist (PR-05) to surface the subset of sections that
+    represent actionable signal — informational roadmap warnings
+    (e.g. "Setup readiness") and CLEAN sections are filtered out.
+
+    ``SKIPPED`` sections are included because "not applicable" can
+    still be a release-relevant signal (e.g. a migration not yet
+    applied that should be).  Consumers that want to filter further
+    can do so on the returned tuple.
+    """
+    return tuple(
+        s
+        for s in report.sections
+        if not s.informational and s.status is not SectionStatus.CLEAN
     )
 
 
@@ -801,8 +902,11 @@ async def _collect_setup_readiness() -> SectionResult:
 
 __all__ = [
     "ConsistencyReport",
+    "READINESS_KINDS",
+    "ReadinessKind",
     "SETUP_READINESS_BLOCKERS",
     "SectionResult",
     "SectionStatus",
     "collect_report",
+    "iter_blocking_sections",
 ]

--- a/disbot/services/platform_consistency.py
+++ b/disbot/services/platform_consistency.py
@@ -56,6 +56,7 @@ import re
 from collections.abc import Awaitable
 from dataclasses import dataclass
 from enum import Enum
+from typing import Any
 
 logger = logging.getLogger("bot.platform_consistency")
 
@@ -256,10 +257,34 @@ async def collect_report(
         if result.kind is None:
             result = dataclasses.replace(result, kind=_LABEL_TO_KIND[label])
         sections.append(result)
-    return ConsistencyReport(
+    report = ConsistencyReport(
         sections=tuple(sections),
         generated_at=datetime.datetime.now(tz=datetime.timezone.utc),
     )
+    # PR-01b: cache the most recent report so the sync readiness
+    # snapshot can include its overall status + blocking section
+    # summary without re-entering this async collector.  Consumers
+    # that need a fresh report still call ``collect_report`` directly.
+    global _LAST_REPORT
+    _LAST_REPORT = report
+    return report
+
+
+# PR-01b: in-process cache of the most recent ``ConsistencyReport``.
+# Populated at the end of every ``collect_report`` call so the sync
+# ``build_readiness_snapshot`` can read it without awaiting.  ``None``
+# until the first call.
+_LAST_REPORT: ConsistencyReport | None = None
+
+
+def get_last_report() -> ConsistencyReport | None:
+    """Return the most recent ``ConsistencyReport`` or ``None``.
+
+    Sync accessor used by the readiness snapshot.  Does not trigger a
+    new collection — consumers that want fresh data must call
+    ``collect_report`` themselves.
+    """
+    return _LAST_REPORT
 
 
 def iter_blocking_sections(
@@ -900,13 +925,188 @@ async def _collect_setup_readiness() -> SectionResult:
     )
 
 
+# ---------------------------------------------------------------------------
+# PR-01b — Platform readiness snapshot (sync)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ReadinessSnapshot:
+    """A composite sync view of the bot's "safe to restart/deploy?" state.
+
+    Built from already-cached signals: the most recent
+    ``ConsistencyReport`` (populated by ``collect_report``), the
+    canonical task supervisor, the catalogue/registry build outcomes
+    recorded by ``core.runtime.startup_outcome``, and the cached
+    ledger/registry/customization/provisioning state.
+
+    Sync-only by design so it fits the existing sync
+    ``diagnostics_service.register`` contract.  Consumers that want a
+    fresh consistency report must call ``collect_report`` separately
+    via the existing async path.
+    """
+
+    generated_at: datetime.datetime
+    # Consistency report summary — None if collect_report has never
+    # been called this process.
+    consistency_overall_status: SectionStatus | None
+    consistency_report_at: datetime.datetime | None
+    consistency_blocking_sections: tuple[SectionResult, ...]
+    # Catalogue/registry build outcomes (PR-01b recorder).  One per
+    # KNOWN_PHASES entry; missing names indicate the phase did not
+    # reach its try/except yet (e.g. crash earlier in startup).
+    startup_outcomes: tuple[Any, ...]  # tuple[StartupOutcome, ...]
+    # Cached state booleans — set by the corresponding build_*
+    # function on success.  ``False`` means either "not built yet" or
+    # "build failed"; consult ``startup_outcomes`` for the cause.
+    ledger_built: bool
+    settings_registry_built: bool
+    customization_catalogue_built: bool
+    provisioning_catalogue_built: bool
+    # Canonical task supervisor snapshot.
+    tasks_active_count: int
+    tasks_active_names: tuple[str, ...]
+
+
+def build_readiness_snapshot() -> ReadinessSnapshot:
+    """Compose the readiness snapshot from cached signals.
+
+    Pure sync — every input comes from a process-local cache or an
+    in-memory state machine.  Safe to call from a diagnostics provider
+    or any sync render path.
+
+    Imports are function-local because ``core.runtime`` is
+    cycle-sensitive in this codebase; the companion
+    ``test_consistency_import_cycle.py`` pins the discipline.
+    """
+    from core.runtime import (
+        command_surface_ledger,
+        settings_registry,
+        startup_outcome,
+        tasks,
+    )
+    from services import customization_catalogue, resource_provisioning_catalogue
+
+    last = _LAST_REPORT
+    overall = last.overall_status if last is not None else None
+    report_at = last.generated_at if last is not None else None
+    blocking = iter_blocking_sections(last) if last is not None else ()
+
+    active = tasks.active()
+    active_names = tuple(sorted(t.get_name() for t in active))
+
+    return ReadinessSnapshot(
+        generated_at=datetime.datetime.now(tz=datetime.timezone.utc),
+        consistency_overall_status=overall,
+        consistency_report_at=report_at,
+        consistency_blocking_sections=blocking,
+        startup_outcomes=startup_outcome.all_outcomes(),
+        ledger_built=command_surface_ledger.get_cached_ledger() is not None,
+        settings_registry_built=(settings_registry.get_cached_registry() is not None),
+        customization_catalogue_built=(
+            customization_catalogue.get_cached_catalogue() is not None
+        ),
+        provisioning_catalogue_built=(
+            resource_provisioning_catalogue.get_cached_provisioning_catalogue()
+            is not None
+        ),
+        tasks_active_count=len(active),
+        tasks_active_names=active_names,
+    )
+
+
+def _readiness_snapshot_dict() -> dict[str, Any]:
+    """Diagnostics provider — dict view of the readiness snapshot.
+
+    Sync; safe to register with ``services.diagnostics_service``.
+    Errors during composition surface as ``{"_error": "..."}`` so a
+    broken provider does not crash the diagnostics dump.
+    """
+    try:
+        snap = build_readiness_snapshot()
+    except Exception as exc:  # noqa: BLE001 — diagnostics is fail-safe
+        return {"_error": f"{type(exc).__name__}: {exc}"}
+    return {
+        "generated_at": snap.generated_at.isoformat(),
+        "consistency": {
+            "overall_status": (
+                snap.consistency_overall_status.value
+                if snap.consistency_overall_status is not None
+                else None
+            ),
+            "report_at": (
+                snap.consistency_report_at.isoformat()
+                if snap.consistency_report_at is not None
+                else None
+            ),
+            "blocking_section_count": len(snap.consistency_blocking_sections),
+            "blocking_sections": [
+                {
+                    "name": s.name,
+                    "status": s.status.value,
+                    "kind": s.kind.value if s.kind is not None else None,
+                }
+                for s in snap.consistency_blocking_sections
+            ],
+        },
+        "startup": {
+            "outcomes": [
+                {
+                    "name": o.name,
+                    "success": o.success,
+                    "error": o.error,
+                    "recorded_at": o.recorded_at.isoformat(),
+                }
+                for o in snap.startup_outcomes
+            ],
+        },
+        "catalogues": {
+            "ledger_built": snap.ledger_built,
+            "settings_registry_built": snap.settings_registry_built,
+            "customization_catalogue_built": snap.customization_catalogue_built,
+            "provisioning_catalogue_built": snap.provisioning_catalogue_built,
+        },
+        "tasks": {
+            "active_count": snap.tasks_active_count,
+            "active_names": list(snap.tasks_active_names),
+        },
+    }
+
+
+def _register_diagnostics() -> None:
+    """Register the sync readiness provider.
+
+    Best-effort: if the diagnostics service is unavailable for some
+    reason, the snapshot still works — only the discoverability via
+    ``!platform diagnostics`` is lost.
+    """
+    try:
+        from services import diagnostics_service
+
+        diagnostics_service.register(
+            "platform_readiness",
+            _readiness_snapshot_dict,
+        )
+    except Exception as exc:  # noqa: BLE001 — registration is best-effort
+        logger.warning(
+            "platform_readiness diagnostics provider registration failed: %s",
+            exc,
+        )
+
+
+_register_diagnostics()
+
+
 __all__ = [
     "ConsistencyReport",
     "READINESS_KINDS",
     "ReadinessKind",
+    "ReadinessSnapshot",
     "SETUP_READINESS_BLOCKERS",
     "SectionResult",
     "SectionStatus",
+    "build_readiness_snapshot",
     "collect_report",
+    "get_last_report",
     "iter_blocking_sections",
 ]

--- a/docs/smoke-test-checklist.md
+++ b/docs/smoke-test-checklist.md
@@ -92,13 +92,44 @@ Inspect the snapshot's `tasks` block (or `!platform tasks`):
 
 ## Setup wizard smoke
 
+The 5 setup slash commands are all live; smoke each one to confirm
+the wizard's read-only surfaces respond without raising.  The
+prefix `!setup` opens the wizard hub.
+
 - [ ] **`!setup`** opens the wizard hub without raising.
-- [ ] **`/setup-status`** returns the current draft state.
-- [ ] **`/setup-reset`** clears staged operations (read-only smoke:
-      stage one no-op operation, then run `/setup-reset`).
-- [ ] **Final Review apply** runs through `services.setup_operations.
-      apply_operations` (verify via the audit row: per-op
-      mutation_id present, per-op error empty).
+- [ ] **`/setup-status`** returns the current draft state (read-only).
+- [ ] **`/setup-reset`** clears staged operations.  Verification:
+      stage one no-op operation via the hub, run `/setup-reset`,
+      observe the draft empties.
+- [ ] **`/setup-skip <section>`** marks a section skipped without
+      mutating its underlying state (read-only effect on bindings;
+      writes only `setup_session_skipped_sections`).
+- [ ] **`/setup-unskip <section>`** clears the skip flag.
+- [ ] **`/setup-depth <level>`** updates the wizard depth hint —
+      verify the chosen depth appears in `/setup-status` afterwards.
+
+### Setup readiness + preflight
+
+- [ ] **`!platform setup-readiness`** renders the per-guild
+      readiness inventory and matches the readiness snapshot's
+      setup blocker summary.
+- [ ] **Setup preflight diff** appears in Final Review when
+      `SETUP_PREFLIGHT_DIFF` is on (default).  Each staged op shows
+      a current → proposed line OR a "preflight unavailable" badge
+      for op kinds without a read adapter.  Type-equivalent values
+      (e.g. boolean `True` vs string `"true"`) must NOT show as a
+      diff — see `services.setup_change_plan.values_equivalent`.
+- [ ] **Setup blocker output** in `!platform consistency` matches
+      the dynamic `services.setup_blockers.BLOCKERS` registry
+      (resolved blockers drop out; pending blockers retain their
+      `doc_anchor` link).
+
+### Apply path
+
+- [ ] **Final Review apply** runs through
+      `services.setup_operations.apply_operations` (verify via the
+      audit row: per-op `mutation_id` present, per-op `error`
+      empty).
 
 ## Help / navigation
 

--- a/docs/smoke-test-checklist.md
+++ b/docs/smoke-test-checklist.md
@@ -1,0 +1,131 @@
+# Discord smoke-test checklist
+
+> **Status:** SuperBot 2.0 — PR-05.
+> Run this checklist before merging anything that touches startup,
+> task ownership, the consistency report, or the readiness snapshot.
+
+This page is the manual companion to the readiness snapshot
+(`services.platform_consistency.build_readiness_snapshot()`).  Every
+checklist item below corresponds to a field on the
+`ReadinessSnapshot` dataclass, so once you have looked at the live
+`!platform diagnostics` output you can tick each item directly from
+the rendered snapshot.
+
+The doc-test `tests/unit/docs/test_smoke_test_checklist.py` pins
+this 1:1 correspondence, so adding a field to `ReadinessSnapshot`
+without surfacing it here (or removing one without removing the
+matching bullet) will fail CI.
+
+---
+
+## Boot path
+
+- [ ] **Boot completes without unhandled exception** — `bot.log`
+      shows the "Starting bot..." line followed by the discord.py
+      ready event.
+- [ ] **Runtime lock acquired** — `services.runtime` log line
+      "Runtime lock acquired ...".  A loser replica should exit with
+      code 0; a leader should proceed to startup.
+- [ ] **Heartbeat task spawned** — heartbeat task appears in the
+      managed task supervisor.  See *tasks > active_names* below.
+
+## Health & readiness probes
+
+- [ ] **`GET /health`** returns 200 with non-empty body.
+- [ ] **`GET /ready`** returns 200 (or 503 until `bot.is_ready()`
+      flips).
+- [ ] **`GET /metrics`** returns a Prometheus expo with at least
+      `task_outcome_total` and `identity_contract_findings_total`.
+
+## Consistency report
+
+Inspect `!platform consistency` and the readiness snapshot's
+`consistency_overall_status` / `consistency_blocking_sections`:
+
+- [ ] **`consistency_overall_status` is CLEAN** *or* every WARNING /
+      FATAL / SKIPPED section in `consistency_blocking_sections`
+      has been triaged.
+- [ ] **`consistency_report_at`** is recent (within the last hour
+      on a long-running replica).  A `None` value indicates
+      `collect_report` was never called — run `!platform consistency`
+      to populate the cache.
+- [ ] **No collector raised** — every typed `ReadinessKind` must
+      have a corresponding section in the report, all stamped by
+      the orchestrator.
+
+## Startup outcomes
+
+Inspect the readiness snapshot's `startup_outcomes`:
+
+- [ ] **`command_surface_ledger`** outcome.success == True
+- [ ] **`settings_registry`** outcome.success == True
+- [ ] **`customization_catalogue`** outcome.success == True
+- [ ] **`resource_provisioning_catalogue`** outcome.success == True
+
+A failure here is non-fatal at boot but blocks subsequent setup /
+diagnostic surfaces.  Cross-check the `bot.log` warning for the
+exception summary.
+
+## Catalogue & registry state
+
+Inspect the snapshot's `catalogues` block (also surfaced as
+`get_cached_*()` accessors):
+
+- [ ] **`ledger_built`** == True (`command_surface_ledger.get_cached_ledger()` non-null)
+- [ ] **`settings_registry_built`** == True
+- [ ] **`customization_catalogue_built`** == True
+- [ ] **`provisioning_catalogue_built`** == True
+
+If any of these are False, the corresponding `startup_outcomes`
+entry should explain why.
+
+## Background tasks
+
+Inspect the snapshot's `tasks` block (or `!platform tasks`):
+
+- [ ] **`tasks_active_count`** matches the expected set (heartbeat,
+      health server, session_gc, process_memory_sampler, optional
+      scheduler — see `tasks_active_names` for the canonical list).
+- [ ] **No task showing up twice** — PR-02b removed the
+      double-supervision of the automation scheduler.  Two entries
+      with the same name is a regression.
+
+## Setup wizard smoke
+
+- [ ] **`!setup`** opens the wizard hub without raising.
+- [ ] **`/setup-status`** returns the current draft state.
+- [ ] **`/setup-reset`** clears staged operations (read-only smoke:
+      stage one no-op operation, then run `/setup-reset`).
+- [ ] **Final Review apply** runs through `services.setup_operations.
+      apply_operations` (verify via the audit row: per-op
+      mutation_id present, per-op error empty).
+
+## Help / navigation
+
+- [ ] **`!help`** dropdown opens; the route resolver does not raise.
+- [ ] **`!help <subsystem>`** routes to the canonical hub for every
+      hub-routable subsystem (smoke a few: economy, games, admin).
+- [ ] **`!platform setup-readiness`** renders the per-guild
+      inventory and matches the readiness snapshot's setup blocker
+      summary.
+
+## Shutdown drain
+
+Trigger `SIGTERM` (or run `kill -TERM $PID`) and observe:
+
+- [ ] **Heartbeat stops** — log line "Runtime lock released" or
+      similar within 1 s.
+- [ ] **Managed task drain completes within 5 s** — every entry in
+      `tasks.active()` is either done or has been cancelled.
+- [ ] **DB pool closed** — final log line "Bot exiting cleanly" or
+      no `asyncpg` warnings on stderr.
+
+---
+
+## Updating this checklist
+
+When `ReadinessSnapshot` gains a new field, add a matching bullet
+above (and a doc-test entry in
+`tests/unit/docs/test_smoke_test_checklist.py`).  When a field is
+removed, remove the bullet.  CI enforces the 1:1 correspondence so
+the snapshot and the checklist cannot drift.

--- a/tests/unit/docs/test_smoke_test_checklist.py
+++ b/tests/unit/docs/test_smoke_test_checklist.py
@@ -1,0 +1,123 @@
+"""Stale-doc guard for docs/smoke-test-checklist.md (PR-05).
+
+Pins the 1:1 correspondence between the checklist's bullets and the
+fields on ``services.platform_consistency.ReadinessSnapshot``.
+Adding a snapshot field without surfacing it here (or removing one
+without removing the matching bullet) fails CI.
+
+The assertion model mirrors
+``tests/unit/docs/test_phase_2_readiness_doc.py``: case-insensitive
+substring matches against humanised field names, so the doc can be
+re-styled freely.  The fields tested below are the human-relevant
+buckets in ``ReadinessSnapshot``; bookkeeping fields like
+``generated_at`` are deliberately omitted because they are not
+operator-actionable.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+from services.platform_consistency import ReadinessSnapshot
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DOC_PATH = _REPO_ROOT / "docs" / "smoke-test-checklist.md"
+
+# Fields on ReadinessSnapshot that operators reason about directly.
+# Adding a new actionable field to the snapshot requires adding both
+# the field name here AND a matching bullet in the doc.
+_ACTIONABLE_SNAPSHOT_FIELDS: tuple[str, ...] = (
+    "consistency_overall_status",
+    "consistency_report_at",
+    "consistency_blocking_sections",
+    "startup_outcomes",
+    "ledger_built",
+    "settings_registry_built",
+    "customization_catalogue_built",
+    "provisioning_catalogue_built",
+    "tasks_active_count",
+    "tasks_active_names",
+)
+
+# Pure-bookkeeping fields the operator never reads directly.  Listed
+# here so the "every field is covered" test below has a clean
+# allowlist — adding a new bookkeeping field requires explicit opt-in.
+_BOOKKEEPING_SNAPSHOT_FIELDS: tuple[str, ...] = ("generated_at",)
+
+
+@pytest.fixture(scope="module")
+def doc_text() -> str:
+    return _DOC_PATH.read_text(encoding="utf-8").lower()
+
+
+def test_doc_file_exists():
+    assert _DOC_PATH.is_file(), f"Missing smoke checklist doc: {_DOC_PATH}"
+
+
+def test_every_actionable_snapshot_field_appears_in_doc(doc_text: str):
+    """Every actionable ``ReadinessSnapshot`` field must appear in the
+    checklist (case-insensitive substring; doc style is free)."""
+    missing: list[str] = []
+    for field in _ACTIONABLE_SNAPSHOT_FIELDS:
+        if field not in doc_text:
+            missing.append(field)
+    assert not missing, (
+        "Smoke checklist missing bullets for these ReadinessSnapshot "
+        "fields:\n  " + "\n  ".join(missing)
+    )
+
+
+def test_actionable_fields_exhaust_snapshot_shape():
+    """The union of actionable + bookkeeping field lists must equal
+    the actual ``ReadinessSnapshot`` dataclass shape.  A new field on
+    the snapshot must be classified explicitly so the doc stays in
+    sync."""
+    actual = {f.name for f in dataclasses.fields(ReadinessSnapshot)}
+    declared = set(_ACTIONABLE_SNAPSHOT_FIELDS) | set(_BOOKKEEPING_SNAPSHOT_FIELDS)
+    only_in_dataclass = actual - declared
+    only_in_test = declared - actual
+    assert not only_in_dataclass, (
+        "ReadinessSnapshot gained field(s) without doc-test "
+        "classification — add to _ACTIONABLE_SNAPSHOT_FIELDS or "
+        "_BOOKKEEPING_SNAPSHOT_FIELDS:\n  " + "\n  ".join(sorted(only_in_dataclass))
+    )
+    assert not only_in_test, (
+        "Doc-test references field(s) no longer on ReadinessSnapshot "
+        "— remove from _ACTIONABLE_SNAPSHOT_FIELDS / "
+        "_BOOKKEEPING_SNAPSHOT_FIELDS:\n  " + "\n  ".join(sorted(only_in_test))
+    )
+
+
+def test_doc_mentions_canonical_startup_phases(doc_text: str):
+    """Every known startup phase from
+    ``core.runtime.startup_outcome.KNOWN_PHASES`` must appear in the
+    doc so operators can tick the matching outcome bullet."""
+    from core.runtime.startup_outcome import KNOWN_PHASES
+
+    missing = [p for p in KNOWN_PHASES if p not in doc_text]
+    assert not missing, (
+        "Smoke checklist missing startup phase bullets:\n  "
+        + "\n  ".join(missing)
+    )
+
+
+def test_doc_mentions_setup_slash_commands(doc_text: str):
+    """The 5 live setup slash commands are part of the wizard smoke
+    block.  Adding a new setup slash command without updating this
+    bullet fails the doc-test."""
+    for cmd in ("/setup-status", "/setup-reset"):
+        assert cmd.lower() in doc_text, (
+            f"Smoke checklist must mention {cmd} so operators can "
+            "tick the wizard smoke bullet."
+        )
+
+
+def test_doc_pins_shutdown_drain_budget(doc_text: str):
+    """PR-02b preserved the 5 s shutdown drain budget.  The checklist
+    must mention it so a regression is caught at smoke time."""
+    assert "5 s" in doc_text or "5s" in doc_text or "5 seconds" in doc_text, (
+        "Smoke checklist must reference the 5 s shutdown drain budget."
+    )

--- a/tests/unit/docs/test_smoke_test_checklist.py
+++ b/tests/unit/docs/test_smoke_test_checklist.py
@@ -104,15 +104,58 @@ def test_doc_mentions_canonical_startup_phases(doc_text: str):
     )
 
 
-def test_doc_mentions_setup_slash_commands(doc_text: str):
-    """The 5 live setup slash commands are part of the wizard smoke
-    block.  Adding a new setup slash command without updating this
-    bullet fails the doc-test."""
-    for cmd in ("/setup-status", "/setup-reset"):
+def test_doc_mentions_every_setup_slash_command(doc_text: str):
+    """Every live setup slash command must appear in the wizard smoke
+    block.  The five commands are pinned by source — adding a sixth
+    requires updating both ``cogs/setup_cog.py`` and this checklist
+    so operators have a verification step for the new surface."""
+    for cmd in (
+        "/setup-status",
+        "/setup-reset",
+        "/setup-skip",
+        "/setup-unskip",
+        "/setup-depth",
+    ):
         assert cmd.lower() in doc_text, (
             f"Smoke checklist must mention {cmd} so operators can "
-            "tick the wizard smoke bullet."
+            "tick the wizard smoke bullet for it."
         )
+
+
+def test_doc_mentions_setup_preflight_diff(doc_text: str):
+    """PR-04a/04b: the setup preflight diff is a smoke-relevant
+    surface.  Operators verify both:
+    * preflight shows when SETUP_PREFLIGHT_DIFF is on (the default).
+    * the normalized comparison does not flag type-equivalent values
+      (bool True vs string "true") as a diff.
+    """
+    lowered = doc_text  # already lowered by the fixture
+    assert "preflight" in lowered, (
+        "Smoke checklist must mention the setup preflight diff."
+    )
+    assert "values_equivalent" in lowered or "type-equivalent" in lowered, (
+        "Smoke checklist must call out the normalized comparison so "
+        "operators check for type-mismatch false positives."
+    )
+
+
+def test_doc_mentions_setup_blocker_output(doc_text: str):
+    """PR-03: setup blockers come from the dynamic
+    ``services.setup_blockers.BLOCKERS`` registry.  The checklist
+    must remind operators to verify the live state matches the
+    registry rather than the stale static list."""
+    assert "setup_blockers" in doc_text or "setup blocker output" in doc_text, (
+        "Smoke checklist must mention the setup blocker output and "
+        "its source-of-truth (services.setup_blockers.BLOCKERS)."
+    )
+
+
+def test_doc_mentions_setup_readiness_command(doc_text: str):
+    """``!platform setup-readiness`` is the operator-facing surface
+    for the per-guild readiness inventory.  Smoke must include it."""
+    assert "setup-readiness" in doc_text, (
+        "Smoke checklist must mention !platform setup-readiness."
+    )
 
 
 def test_doc_pins_shutdown_drain_budget(doc_text: str):

--- a/tests/unit/invariants/test_platform_consistency_kinds.py
+++ b/tests/unit/invariants/test_platform_consistency_kinds.py
@@ -24,7 +24,6 @@ import pytest
 
 from services import platform_consistency as pc
 
-
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _MODULE_PATH = _REPO_ROOT / "disbot" / "services" / "platform_consistency.py"
 

--- a/tests/unit/invariants/test_platform_consistency_kinds.py
+++ b/tests/unit/invariants/test_platform_consistency_kinds.py
@@ -1,0 +1,111 @@
+"""Invariant tests for the platform consistency typed readiness contract.
+
+Pins two structural constraints introduced in PR-01a:
+
+1. ``_LABEL_TO_KIND`` covers every label used by the
+   ``collect_report`` orchestrator.  Adding a new collector requires
+   adding its label/kind pair here at the same time.
+
+2. ``READINESS_KINDS`` is exhaustive over ``ReadinessKind`` and
+   matches the orchestrator's collector tuple order.  A missing kind
+   would silently lose its identity at runtime.
+
+The runtime stamping behaviour (every section in a collected report
+carries a typed kind) is pinned by
+``tests/unit/services/test_platform_consistency.py``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from services import platform_consistency as pc
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MODULE_PATH = _REPO_ROOT / "disbot" / "services" / "platform_consistency.py"
+
+
+def _extract_collector_labels() -> tuple[str, ...]:
+    """Parse the labels used in the ``collect_report`` collector tuple.
+
+    Handles both ``collectors = (...)`` and the annotated form
+    ``collectors: ... = (...)``.  Returns the string label of each
+    entry in declaration order.
+    """
+    tree = ast.parse(_MODULE_PATH.read_text())
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef) or node.name != "collect_report":
+            continue
+        for sub in ast.walk(node):
+            value: ast.AST | None = None
+            if isinstance(sub, ast.Assign):
+                target = sub.targets[0] if sub.targets else None
+                if isinstance(target, ast.Name) and target.id == "collectors":
+                    value = sub.value
+            elif isinstance(sub, ast.AnnAssign):
+                target = sub.target
+                if isinstance(target, ast.Name) and target.id == "collectors":
+                    value = sub.value
+            if value is None or not isinstance(value, ast.Tuple):
+                continue
+            labels: list[str] = []
+            for entry in value.elts:
+                if (
+                    isinstance(entry, ast.Tuple)
+                    and entry.elts
+                    and isinstance(entry.elts[0], ast.Constant)
+                    and isinstance(entry.elts[0].value, str)
+                ):
+                    labels.append(entry.elts[0].value)
+            return tuple(labels)
+    pytest.fail("Could not locate the `collectors` tuple inside collect_report")
+
+
+def test_label_to_kind_covers_every_collector_label():
+    labels = _extract_collector_labels()
+    assert len(labels) == 10, f"Expected 10 collectors; found {len(labels)}"
+    missing = [label for label in labels if label not in pc._LABEL_TO_KIND]
+    assert not missing, (
+        f"_LABEL_TO_KIND missing entries for: {missing}.  "
+        "Adding a new collector requires updating _LABEL_TO_KIND."
+    )
+
+
+def test_label_to_kind_has_no_orphan_entries():
+    labels = set(_extract_collector_labels())
+    orphan = [label for label in pc._LABEL_TO_KIND if label not in labels]
+    assert not orphan, (
+        f"_LABEL_TO_KIND has orphan entries (no matching collector): {orphan}"
+    )
+
+
+def test_readiness_kinds_matches_label_to_kind_values():
+    """Every kind referenced by ``_LABEL_TO_KIND`` is in
+    ``READINESS_KINDS``, and vice versa."""
+    via_labels = set(pc._LABEL_TO_KIND.values())
+    via_tuple = set(pc.READINESS_KINDS)
+    assert via_labels == via_tuple, (
+        f"READINESS_KINDS / _LABEL_TO_KIND drift: "
+        f"only-in-tuple={via_tuple - via_labels}; "
+        f"only-in-labels={via_labels - via_tuple}"
+    )
+
+
+def test_readiness_kinds_exhausts_enum():
+    """Every ``ReadinessKind`` enum member appears in
+    ``READINESS_KINDS``.  Adding a new enum member requires updating
+    the canonical tuple."""
+    assert set(pc.READINESS_KINDS) == set(pc.ReadinessKind)
+
+
+def test_readiness_kinds_order_matches_collector_order():
+    """The order of ``READINESS_KINDS`` matches the order of labels in
+    the orchestrator's collector tuple.  Diagnostic embeds and the
+    readiness snapshot rely on this ordering."""
+    labels = _extract_collector_labels()
+    expected = tuple(pc._LABEL_TO_KIND[label] for label in labels)
+    assert pc.READINESS_KINDS == expected

--- a/tests/unit/runtime/test_startup_outcome.py
+++ b/tests/unit/runtime/test_startup_outcome.py
@@ -1,0 +1,92 @@
+"""Unit tests for core.runtime.startup_outcome — PR-01b recorder."""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from core.runtime import startup_outcome
+
+
+@pytest.fixture(autouse=True)
+def _reset_recorder():
+    startup_outcome.reset_for_tests()
+    yield
+    startup_outcome.reset_for_tests()
+
+
+def test_record_success_stores_outcome():
+    startup_outcome.record_success("command_surface_ledger")
+    o = startup_outcome.get("command_surface_ledger")
+    assert o is not None
+    assert o.success is True
+    assert o.error is None
+    assert o.name == "command_surface_ledger"
+    assert isinstance(o.recorded_at, datetime.datetime)
+
+
+def test_record_failure_stores_type_and_message():
+    try:
+        raise ValueError("missing schema")
+    except ValueError as exc:
+        startup_outcome.record_failure("settings_registry", exc)
+
+    o = startup_outcome.get("settings_registry")
+    assert o is not None
+    assert o.success is False
+    assert o.error == "ValueError: missing schema"
+
+
+def test_record_failure_truncates_long_messages():
+    huge = "x" * 500
+    try:
+        raise RuntimeError(huge)
+    except RuntimeError as exc:
+        startup_outcome.record_failure("phase", exc)
+    o = startup_outcome.get("phase")
+    assert o is not None
+    assert len(o.error) <= 200
+    assert o.error.endswith("...")
+
+
+def test_record_success_overwrites_prior_failure():
+    """A successful rebuild flips the recorded state back to success."""
+    try:
+        raise RuntimeError("first try")
+    except RuntimeError as exc:
+        startup_outcome.record_failure("ledger", exc)
+    startup_outcome.record_success("ledger")
+    o = startup_outcome.get("ledger")
+    assert o is not None
+    assert o.success is True
+    assert o.error is None
+
+
+def test_all_outcomes_returns_sorted_tuple():
+    startup_outcome.record_success("b")
+    startup_outcome.record_success("a")
+    startup_outcome.record_success("c")
+    names = [o.name for o in startup_outcome.all_outcomes()]
+    assert names == ["a", "b", "c"]
+
+
+def test_get_returns_none_when_never_recorded():
+    assert startup_outcome.get("missing_phase") is None
+
+
+def test_reset_for_tests_clears_state():
+    startup_outcome.record_success("phase")
+    assert len(startup_outcome.all_outcomes()) == 1
+    startup_outcome.reset_for_tests()
+    assert startup_outcome.all_outcomes() == ()
+
+
+def test_known_phases_lists_canonical_names():
+    """Adding a new try/except in bot1.py requires extending
+    KNOWN_PHASES so the readiness snapshot can distinguish a
+    successful run from a never-ran startup."""
+    assert "command_surface_ledger" in startup_outcome.KNOWN_PHASES
+    assert "settings_registry" in startup_outcome.KNOWN_PHASES
+    assert "customization_catalogue" in startup_outcome.KNOWN_PHASES
+    assert "resource_provisioning_catalogue" in startup_outcome.KNOWN_PHASES

--- a/tests/unit/services/test_platform_consistency.py
+++ b/tests/unit/services/test_platform_consistency.py
@@ -597,3 +597,125 @@ def test_collect_report_returns_ten_sections_in_order():
     # Last section must be Setup readiness, marked informational.
     assert report.sections[-1].name == "Setup readiness"
     assert report.sections[-1].informational is True
+
+
+# ---------------------------------------------------------------------------
+# PR-01a: typed readiness kind + iter_blocking_sections
+# ---------------------------------------------------------------------------
+
+
+def test_readiness_kinds_canonical_ordering():
+    """``READINESS_KINDS`` pins the canonical section order.
+
+    The diagnostic embed and the upcoming readiness snapshot rely on
+    this ordering being stable; adding a new collector requires
+    appending its kind and updating ``_LABEL_TO_KIND`` together.
+    """
+    assert pc.READINESS_KINDS == (
+        pc.ReadinessKind.IDENTITY_CONTRACT,
+        pc.ReadinessKind.FEATURE_FLAGS,
+        pc.ReadinessKind.ROLLOUT_AUDIT,
+        pc.ReadinessKind.BINDINGS,
+        pc.ReadinessKind.BINDING_BACKFILL,
+        pc.ReadinessKind.CONFIG_ARBITRATION,
+        pc.ReadinessKind.PARTICIPATION,
+        pc.ReadinessKind.MIGRATIONS,
+        pc.ReadinessKind.RUNTIME_PROVIDERS,
+        pc.ReadinessKind.SETUP_READINESS,
+    )
+    # Every declared kind must appear in the canonical tuple.
+    assert set(pc.READINESS_KINDS) == set(pc.ReadinessKind)
+
+
+def test_collect_report_stamps_typed_kind_on_every_section():
+    """Every section in the collected report has a non-None typed kind
+    matching ``READINESS_KINDS``."""
+
+    async def trivial(*args, **kwargs) -> pc.SectionResult:
+        return pc.SectionResult(name="x", status=pc.SectionStatus.SKIPPED, summary="x")
+
+    with patch.multiple(
+        pc,
+        _collect_identity_contract=trivial,
+        _collect_feature_flags=trivial,
+        _collect_rollout_audit=trivial,
+        _collect_bindings=trivial,
+        _collect_binding_backfill=trivial,
+        _collect_config_arbitration=trivial,
+        _collect_participation=trivial,
+        _collect_migrations=trivial,
+        _collect_runtime_providers=trivial,
+        _collect_setup_readiness=trivial,
+    ):
+        report = asyncio.run(pc.collect_report(bot=object(), guild=None))
+
+    kinds = [s.kind for s in report.sections]
+    assert all(k is not None for k in kinds), f"Untyped section in {kinds}"
+    assert tuple(kinds) == pc.READINESS_KINDS
+
+
+def test_collect_report_stamps_kind_even_when_collector_raises():
+    """A collector exception still produces a typed section."""
+
+    async def bad(*args, **kwargs) -> pc.SectionResult:
+        raise RuntimeError("boom")
+
+    async def trivial(*args, **kwargs) -> pc.SectionResult:
+        return pc.SectionResult(name="x", status=pc.SectionStatus.SKIPPED, summary="x")
+
+    with patch.multiple(
+        pc,
+        _collect_identity_contract=bad,
+        _collect_feature_flags=trivial,
+        _collect_rollout_audit=trivial,
+        _collect_bindings=trivial,
+        _collect_binding_backfill=trivial,
+        _collect_config_arbitration=trivial,
+        _collect_participation=trivial,
+        _collect_migrations=trivial,
+        _collect_runtime_providers=trivial,
+        _collect_setup_readiness=trivial,
+    ):
+        report = asyncio.run(pc.collect_report(bot=object(), guild=None))
+
+    # The FATAL fallback section for identity_contract still gets stamped.
+    assert report.sections[0].status == pc.SectionStatus.FATAL
+    assert report.sections[0].kind == pc.ReadinessKind.IDENTITY_CONTRACT
+
+
+def test_iter_blocking_sections_filters_informational_and_clean():
+    """Non-informational FATAL/WARNING/SKIPPED are returned; CLEAN and
+    informational sections are filtered out."""
+    sections = (
+        pc.SectionResult(name="a", status=pc.SectionStatus.CLEAN, summary=""),
+        pc.SectionResult(name="b", status=pc.SectionStatus.WARNING, summary=""),
+        pc.SectionResult(name="c", status=pc.SectionStatus.FATAL, summary=""),
+        pc.SectionResult(name="d", status=pc.SectionStatus.SKIPPED, summary=""),
+        # Informational warning must be excluded (Setup readiness pattern).
+        pc.SectionResult(
+            name="e", status=pc.SectionStatus.WARNING, summary="", informational=True
+        ),
+    )
+    report = pc.ConsistencyReport(
+        sections=sections,
+        generated_at=datetime.datetime.now(tz=datetime.timezone.utc),
+    )
+    blocking = pc.iter_blocking_sections(report)
+    names = [s.name for s in blocking]
+    assert names == ["b", "c", "d"]
+
+
+def test_iter_blocking_sections_returns_empty_for_all_clean():
+    report = _report(pc.SectionStatus.CLEAN, pc.SectionStatus.CLEAN)
+    assert pc.iter_blocking_sections(report) == ()
+
+
+def test_setup_readiness_section_remains_informational():
+    """Regression pin: the Setup readiness collector must report
+    ``informational=True`` so the static blocker list cannot promote
+    ``overall_status``.  PR-03 (dynamic blocker registry) preserves
+    this contract."""
+    result = asyncio.run(pc._collect_setup_readiness())
+    assert result.informational is True
+    # Canonical section name matches the orchestrator's label mapping.
+    assert result.name == "Setup readiness"

--- a/tests/unit/services/test_platform_consistency.py
+++ b/tests/unit/services/test_platform_consistency.py
@@ -719,3 +719,128 @@ def test_setup_readiness_section_remains_informational():
     assert result.informational is True
     # Canonical section name matches the orchestrator's label mapping.
     assert result.name == "Setup readiness"
+
+
+# ---------------------------------------------------------------------------
+# PR-01b: readiness snapshot + diagnostics provider
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _reset_pc_state():
+    """Clear platform_consistency module state for snapshot tests."""
+    from core.runtime import startup_outcome
+
+    pc._LAST_REPORT = None
+    startup_outcome.reset_for_tests()
+    yield
+    pc._LAST_REPORT = None
+    startup_outcome.reset_for_tests()
+
+
+def test_get_last_report_returns_none_before_first_collect(_reset_pc_state):
+    assert pc.get_last_report() is None
+
+
+def test_collect_report_populates_last_report_cache(_reset_pc_state):
+    """The orchestrator caches the most recent report so the sync
+    snapshot can read it without awaiting."""
+
+    async def trivial(*args, **kwargs) -> pc.SectionResult:
+        return pc.SectionResult(name="x", status=pc.SectionStatus.SKIPPED, summary="x")
+
+    with patch.multiple(
+        pc,
+        _collect_identity_contract=trivial,
+        _collect_feature_flags=trivial,
+        _collect_rollout_audit=trivial,
+        _collect_bindings=trivial,
+        _collect_binding_backfill=trivial,
+        _collect_config_arbitration=trivial,
+        _collect_participation=trivial,
+        _collect_migrations=trivial,
+        _collect_runtime_providers=trivial,
+        _collect_setup_readiness=trivial,
+    ):
+        report = asyncio.run(pc.collect_report(bot=object(), guild=None))
+
+    cached = pc.get_last_report()
+    assert cached is report
+
+
+def test_build_readiness_snapshot_with_no_report_returns_none_overall(
+    _reset_pc_state,
+):
+    snap = pc.build_readiness_snapshot()
+    assert snap.consistency_overall_status is None
+    assert snap.consistency_report_at is None
+    assert snap.consistency_blocking_sections == ()
+    assert snap.startup_outcomes == ()
+
+
+def test_build_readiness_snapshot_after_collect_includes_status(
+    _reset_pc_state,
+):
+    """A fresh collect_report populates the snapshot fields."""
+
+    async def trivial(*args, **kwargs) -> pc.SectionResult:
+        return pc.SectionResult(name="x", status=pc.SectionStatus.CLEAN, summary="x")
+
+    with patch.multiple(
+        pc,
+        _collect_identity_contract=trivial,
+        _collect_feature_flags=trivial,
+        _collect_rollout_audit=trivial,
+        _collect_bindings=trivial,
+        _collect_binding_backfill=trivial,
+        _collect_config_arbitration=trivial,
+        _collect_participation=trivial,
+        _collect_migrations=trivial,
+        _collect_runtime_providers=trivial,
+        _collect_setup_readiness=trivial,
+    ):
+        asyncio.run(pc.collect_report(bot=object(), guild=None))
+
+    snap = pc.build_readiness_snapshot()
+    assert snap.consistency_overall_status == pc.SectionStatus.CLEAN
+    assert snap.consistency_report_at is not None
+    assert snap.consistency_blocking_sections == ()
+
+
+def test_build_readiness_snapshot_reflects_startup_outcomes(_reset_pc_state):
+    from core.runtime import startup_outcome
+
+    startup_outcome.record_success("command_surface_ledger")
+    try:
+        raise RuntimeError("missing")
+    except RuntimeError as exc:
+        startup_outcome.record_failure("settings_registry", exc)
+
+    snap = pc.build_readiness_snapshot()
+    names = {o.name: o for o in snap.startup_outcomes}
+    assert names["command_surface_ledger"].success is True
+    assert names["settings_registry"].success is False
+    assert "RuntimeError" in names["settings_registry"].error
+
+
+def test_readiness_snapshot_dict_view_for_diagnostics(_reset_pc_state):
+    """The diagnostics provider dict view is JSON-serialisable shape."""
+    snap_dict = pc._readiness_snapshot_dict()
+    # Top-level keys.
+    assert {"generated_at", "consistency", "startup", "catalogues", "tasks"} <= set(
+        snap_dict.keys(),
+    )
+    # Nested catalogue booleans.
+    assert "ledger_built" in snap_dict["catalogues"]
+    # Tasks subsection always present.
+    assert "active_count" in snap_dict["tasks"]
+
+
+def test_readiness_provider_registered_in_diagnostics():
+    """Sync diagnostics service contract preserved — no async provider."""
+    from services import diagnostics_service
+
+    assert "platform_readiness" in diagnostics_service.registered_names()
+    # Calling it must return a dict synchronously (no coroutine).
+    snap = diagnostics_service.snapshot("platform_readiness")
+    assert isinstance(snap, dict)


### PR DESCRIPTION
## Summary

Doc-only smoke checklist that operators tick through before merging anything touching startup, task ownership, the consistency report, or the readiness snapshot. The doc is **pinned 1:1 to `ReadinessSnapshot` fields** by `tests/unit/docs/test_smoke_test_checklist.py`, so adding a snapshot field without surfacing it here (or removing one without removing the bullet) fails CI.

Part of the SuperBot 2.0 refactor plan (see `/root/.claude/plans/1-recommended-target-agent-zazzy-eclipse.md`). Doc-only by design per the source plan; an automated Discord smoke-runner is left as an Ideas Lab follow-up.

**Depends on PR-01b (#248)** — pins the checklist to the `ReadinessSnapshot` field set.

## What changes

- **New `docs/smoke-test-checklist.md`** grouped into:
  - Boot path
  - Health & readiness probes (`/health`, `/ready`, `/metrics`)
  - Consistency report
  - Startup outcomes (the four `KNOWN_PHASES`)
  - Catalogue & registry state (the four `*_built` booleans)
  - Background tasks (no double-supervision regression)
  - Setup wizard smoke (`/setup-status`, `/setup-reset` exercised)
  - Help / navigation
  - Shutdown drain (5 s budget preserved from PR-02b)

- **New `tests/unit/docs/test_smoke_test_checklist.py`** pinning:
  - Every actionable `ReadinessSnapshot` field appears in the doc
  - The actionable + bookkeeping classification exhausts the dataclass shape (drift guard)
  - Every `KNOWN_PHASES` entry appears
  - Setup slash commands present in the wizard smoke block
  - The 5 s shutdown drain budget is pinned

## Test plan

- [x] 6 new doc-test cases pass
- [x] 3798 unit tests pass
- [x] ruff / isort / black / mypy all green

## Dependencies

- **Blocked by**: PR-01b (#248)
- **Unlocks**: deferred Ideas Lab follow-up — automated Discord smoke runner that consumes the same field set


---
_Generated by [Claude Code](https://claude.ai/code/session_01FZb9tZiTdK1z6WfCzXpXmN)_