### PR TITLE
PR-04a: Setup operation preflight (additive, behind SETUP_PREFLIGHT_DIFF flag)

### DIFF
--- a/disbot/services/platform_consistency.py
+++ b/disbot/services/platform_consistency.py
@@ -37,14 +37,18 @@ Informational sections never promote ``overall_status``.
 Public surface:
 
     SectionStatus               — enum
+    ReadinessKind               — enum (typed identity per section)
+    READINESS_KINDS             — canonical-order tuple of every kind
     SectionResult               — frozen dataclass per section
     ConsistencyReport           — frozen dataclass: sections + overall_status
     SETUP_READINESS_BLOCKERS    — tuple of roadmap blocker identifiers
     collect_report(*, bot, guild) — async orchestrator
+    iter_blocking_sections(report) — non-informational, non-CLEAN sections
 """
 
 from __future__ import annotations
 
+import dataclasses
 import datetime
 import logging
 import os
@@ -68,6 +72,68 @@ class SectionStatus(str, Enum):
     SKIPPED = "skipped"
 
 
+class ReadinessKind(str, Enum):
+    """Canonical typed identity for each consistency section.
+
+    PR-01a: every section result returned by ``collect_report`` is
+    stamped with one of these kinds by the orchestrator (collectors
+    do not need to know about kinds — the orchestrator maps from
+    the human label to the typed kind).
+
+    ``READINESS_KINDS`` exports the canonical ordering used by the
+    orchestrator and consumers; the invariant test
+    ``tests/unit/invariants/test_platform_consistency_kinds.py`` pins
+    every collector to a known kind.
+    """
+
+    IDENTITY_CONTRACT = "identity_contract"
+    FEATURE_FLAGS = "feature_flags"
+    ROLLOUT_AUDIT = "rollout_audit"
+    BINDINGS = "bindings"
+    BINDING_BACKFILL = "binding_backfill"
+    CONFIG_ARBITRATION = "config_arbitration"
+    PARTICIPATION = "participation"
+    MIGRATIONS = "migrations"
+    RUNTIME_PROVIDERS = "runtime_providers"
+    SETUP_READINESS = "setup_readiness"
+
+
+# Canonical ordering — matches the orchestrator's collector tuple at
+# ``collect_report``.  ``test_readiness_kinds_canonical_ordering`` pins
+# this ordering so the diagnostic embed and the readiness snapshot can
+# rely on a stable section order.
+READINESS_KINDS: tuple[ReadinessKind, ...] = (
+    ReadinessKind.IDENTITY_CONTRACT,
+    ReadinessKind.FEATURE_FLAGS,
+    ReadinessKind.ROLLOUT_AUDIT,
+    ReadinessKind.BINDINGS,
+    ReadinessKind.BINDING_BACKFILL,
+    ReadinessKind.CONFIG_ARBITRATION,
+    ReadinessKind.PARTICIPATION,
+    ReadinessKind.MIGRATIONS,
+    ReadinessKind.RUNTIME_PROVIDERS,
+    ReadinessKind.SETUP_READINESS,
+)
+
+
+# Maps the human-readable label used by the orchestrator's collector
+# tuple to the typed ``ReadinessKind``.  The orchestrator stamps each
+# collector's ``SectionResult.kind`` from this map after the collector
+# returns, so collectors themselves never need to set ``kind``.
+_LABEL_TO_KIND: dict[str, ReadinessKind] = {
+    "Identity contract": ReadinessKind.IDENTITY_CONTRACT,
+    "Feature flags": ReadinessKind.FEATURE_FLAGS,
+    "Rollout / audit": ReadinessKind.ROLLOUT_AUDIT,
+    "Bindings": ReadinessKind.BINDINGS,
+    "Binding backfill": ReadinessKind.BINDING_BACKFILL,
+    "Config arbitration": ReadinessKind.CONFIG_ARBITRATION,
+    "Participation": ReadinessKind.PARTICIPATION,
+    "Migrations": ReadinessKind.MIGRATIONS,
+    "Runtime providers": ReadinessKind.RUNTIME_PROVIDERS,
+    "Setup readiness": ReadinessKind.SETUP_READINESS,
+}
+
+
 @dataclass(frozen=True)
 class SectionResult:
     name: str
@@ -76,6 +142,13 @@ class SectionResult:
     details: tuple[str, ...] = ()
     suggested_actions: tuple[str, ...] = ()
     informational: bool = False
+    # PR-01a: typed identity stamped by the orchestrator after each
+    # collector returns.  Optional only so collectors can construct
+    # ``SectionResult`` without knowing the kind; the orchestrator
+    # guarantees every section in a collected report has a non-None
+    # kind.  Consumers that build sections outside ``collect_report``
+    # (e.g. unit tests) may leave it as ``None``.
+    kind: ReadinessKind | None = None
 
 
 @dataclass(frozen=True)
@@ -176,10 +249,38 @@ async def collect_report(
                 summary=f"collector raised {type(exc).__name__}",
                 details=(str(exc)[:200],),
             )
+        # PR-01a: stamp the canonical readiness kind from the label.
+        # Collectors construct SectionResult without knowing the kind;
+        # the orchestrator is the single place where the human label
+        # is translated into the typed ``ReadinessKind``.
+        if result.kind is None:
+            result = dataclasses.replace(result, kind=_LABEL_TO_KIND[label])
         sections.append(result)
     return ConsistencyReport(
         sections=tuple(sections),
         generated_at=datetime.datetime.now(tz=datetime.timezone.utc),
+    )
+
+
+def iter_blocking_sections(
+    report: ConsistencyReport,
+) -> tuple[SectionResult, ...]:
+    """Return only non-informational, non-CLEAN sections.
+
+    PR-01a helper used by the upcoming readiness snapshot (PR-01b) and
+    smoke checklist (PR-05) to surface the subset of sections that
+    represent actionable signal — informational roadmap warnings
+    (e.g. "Setup readiness") and CLEAN sections are filtered out.
+
+    ``SKIPPED`` sections are included because "not applicable" can
+    still be a release-relevant signal (e.g. a migration not yet
+    applied that should be).  Consumers that want to filter further
+    can do so on the returned tuple.
+    """
+    return tuple(
+        s
+        for s in report.sections
+        if not s.informational and s.status is not SectionStatus.CLEAN
     )
 
 
@@ -801,8 +902,11 @@ async def _collect_setup_readiness() -> SectionResult:
 
 __all__ = [
     "ConsistencyReport",
+    "READINESS_KINDS",
+    "ReadinessKind",
     "SETUP_READINESS_BLOCKERS",
     "SectionResult",
     "SectionStatus",
     "collect_report",
+    "iter_blocking_sections",
 ]

--- a/disbot/services/platform_consistency.py
+++ b/disbot/services/platform_consistency.py
@@ -171,19 +171,23 @@ class ConsistencyReport:
         return SectionStatus.CLEAN
 
 
-SETUP_READINESS_BLOCKERS: tuple[str, ...] = (
-    "command_surface_ledger",
-    "panel_registry",
-    "settings_registry",
-    "settings_mutation_pipeline",
-    "governance_trusted_role_schema",
-    "role_service_extraction",
-    "cleanup_policy_extraction",
-    "logging_settings_integration",
-    "slash_panel_entrypoints",
-    "setup_wizard_readiness_bridge",
-    "setup_wizard",
-)
+# PR-03: derived from the dynamic ``services.setup_blockers.BLOCKERS``
+# registry so the bare-string contract is preserved for backwards-
+# compatible callers (e.g. the doc test) while the actual resolution
+# state is computed dynamically from cached foundation state.  See
+# ``services/setup_blockers.py`` for the registry, status providers,
+# and ownership metadata.
+def _setup_readiness_blocker_ids() -> tuple[str, ...]:
+    # Function-local import keeps this module's import graph
+    # unchanged (setup_blockers itself only imports stdlib at module
+    # scope; each status_provider imports the runtime modules it
+    # needs function-locally).
+    from services import setup_blockers
+
+    return setup_blockers.blocker_ids()
+
+
+SETUP_READINESS_BLOCKERS: tuple[str, ...] = _setup_readiness_blocker_ids()
 
 
 # ---------------------------------------------------------------------------
@@ -871,28 +875,48 @@ async def _collect_runtime_providers() -> SectionResult:
 async def _collect_setup_readiness() -> SectionResult:
     """Section 10: roadmap blockers for the larger UX phase (informational).
 
-    v1 returns a static list from ``SETUP_READINESS_BLOCKERS``.  Dynamic
-    detection of each blocker's resolution state is deferred to a
-    follow-up PR.  The section is marked ``informational=True`` so the
+    PR-03: dynamic — each blocker in
+    ``services.setup_blockers.BLOCKERS`` computes its own status from
+    cached in-process state.  Resolved blockers drop out of the
+    details list; pending / in_progress / blocked / unknown remain
+    visible.  The section is still ``informational=True`` so the
     embed labels it as roadmap-only and ``overall_status`` does not
     promote on it.
+
+    Status providers are sync and fail-safe — a raising provider
+    becomes ``"unknown"`` rather than crashing this collector.
     """
     name = "Setup readiness"
-    if not SETUP_READINESS_BLOCKERS:
+    # Function-local: setup_blockers transitively imports
+    # core.runtime modules in its status providers; module-scope
+    # import would violate the cycle-sensitive contract pinned by
+    # test_consistency_import_cycle.py.
+    from services import setup_blockers
+
+    statuses: list[tuple[str, str]] = [
+        (spec.id, setup_blockers.status_for(spec)) for spec in setup_blockers.BLOCKERS
+    ]
+    resolved = sum(1 for _, st in statuses if st == "resolved")
+    pending = [bid for bid, st in statuses if st != "resolved"]
+    total = len(statuses)
+
+    if not pending:
         return SectionResult(
             name=name,
             status=SectionStatus.CLEAN,
-            summary="No roadmap blockers.",
+            summary=(f"All {total} roadmap blocker(s) resolved."),
             informational=True,
         )
+
+    details = tuple(f"{bid}: {st}" for bid, st in statuses)
     return SectionResult(
         name=name,
         status=SectionStatus.WARNING,
         summary=(
-            f"{len(SETUP_READINESS_BLOCKERS)} roadmap blocker(s) "
-            "tracked (informational; not a runtime health failure)."
+            f"{resolved}/{total} roadmap blocker(s) resolved "
+            "(informational; not a runtime health failure)."
         ),
-        details=tuple(SETUP_READINESS_BLOCKERS),
+        details=details,
         suggested_actions=(
             "See `docs/phase-2-completion-readiness.md` for unlock order.",
         ),

--- a/disbot/services/setup_blockers.py
+++ b/disbot/services/setup_blockers.py
@@ -1,0 +1,336 @@
+"""Dynamic setup-readiness blocker registry — PR-03.
+
+Replaces the static ``SETUP_READINESS_BLOCKERS`` tuple of bare strings
+in ``services.platform_consistency`` with a typed registry whose
+status is computed from cached foundation state.  ``platform_consistency``
+re-exports the constant as a derived tuple of IDs for backward compat
+so existing callers still work.
+
+Design rules (matching the source plan and PR-03's stop conditions):
+
+* Every ``status_provider`` is **sync** and **never performs I/O**.
+  It reads cached in-process state (cached ledger, cached registry,
+  module existence) and returns one of ``"resolved" | "in_progress" |
+  "pending" | "blocked" | "unknown"``.
+* A provider that raises is caught and rendered as ``"unknown"`` —
+  the registry is fail-safe so one bad provider does not blank the
+  whole report.
+* All imports are function-local inside each provider so this module
+  itself does not trigger a cycle with ``core.runtime`` at import
+  time (the consistency report's collectors enforce the same
+  discipline).
+
+Public surface::
+
+    BlockerStatus       — Literal type
+    BlockerSpec         — frozen dataclass per blocker
+    BLOCKERS            — canonical tuple of every blocker spec
+    blocker_ids()       — derived tuple of IDs (re-exported by
+                          platform_consistency.SETUP_READINESS_BLOCKERS)
+    status_for(spec)    — invoke the provider with the unknown fallback
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal
+
+logger = logging.getLogger("bot.setup_blockers")
+
+BlockerStatus = Literal[
+    "resolved",
+    "in_progress",
+    "pending",
+    "blocked",
+    "unknown",
+]
+
+
+@dataclass(frozen=True)
+class BlockerSpec:
+    """A single setup-readiness blocker with metadata + status provider.
+
+    The ``status_provider`` is a zero-arg sync callable that consults
+    cached in-process state.  ``status_for`` wraps it with a
+    fail-safe so a raising provider becomes ``"unknown"`` rather than
+    crashing the consistency report.
+
+    Fields mirror the plan's BlockerSpec shape:
+
+    * ``id`` — stable snake_case ID (matches the original
+      ``SETUP_READINESS_BLOCKERS`` strings for backward compat).
+    * ``owner_project`` — the project area responsible.
+      ``"UNCONFIRMED"`` is allowed for blockers whose owner the
+      reviewer must assign.
+    * ``refactor_layer`` — short tag like ``"registries"``,
+      ``"runtime"``, ``"ui"`` to help readers group them.
+    * ``severity`` — ``"blocks_release"`` | ``"blocks_phase"`` |
+      ``"informational"``.  Today every blocker is
+      ``"informational"`` to preserve the section's
+      ``informational=True`` semantics.
+    * ``unlocks`` / ``blocked_by`` — other blocker IDs by name.
+    * ``doc_anchor`` — anchor in
+      ``docs/phase-2-completion-readiness.md`` (without the leading
+      ``#``) for "where do I read more?"
+    """
+
+    id: str
+    owner_project: str
+    refactor_layer: str
+    status_provider: Callable[[], BlockerStatus]
+    severity: Literal["blocks_release", "blocks_phase", "informational"]
+    unlocks: tuple[str, ...] = ()
+    blocked_by: tuple[str, ...] = ()
+    doc_anchor: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Status providers (all sync; all imports function-local)
+# ---------------------------------------------------------------------------
+
+
+def _command_surface_ledger_status() -> BlockerStatus:
+    from core.runtime import command_surface_ledger
+
+    return "resolved" if command_surface_ledger.get_cached_ledger() else "pending"
+
+
+def _settings_registry_status() -> BlockerStatus:
+    from core.runtime import settings_registry
+
+    return "resolved" if settings_registry.get_cached_registry() else "pending"
+
+
+def _settings_mutation_pipeline_status() -> BlockerStatus:
+    """Resolved if ``services.settings_mutation`` exposes the pipeline.
+
+    The module exists today and exports ``SettingsMutationPipeline``;
+    that is the contract setup_operations depends on.
+    """
+    import importlib
+
+    spec = importlib.util.find_spec("services.settings_mutation")
+    if spec is None:
+        return "pending"
+    module = importlib.import_module("services.settings_mutation")
+    return "resolved" if hasattr(module, "SettingsMutationPipeline") else "in_progress"
+
+
+def _setup_wizard_status() -> BlockerStatus:
+    """Resolved if the setup cog module is importable.
+
+    The cog is loaded at runtime; "importable" is the safest sync
+    signal that the wizard surface exists.  A fully end-user-facing
+    wizard is still in iteration, hence ``in_progress`` if the
+    customization catalogue has not been built yet.
+    """
+    import importlib
+
+    spec = importlib.util.find_spec("cogs.setup_cog")
+    if spec is None:
+        return "pending"
+    # If the customization catalogue is built, the wizard surface has
+    # all of its inputs available.
+    try:
+        from services import customization_catalogue
+
+        if customization_catalogue.get_cached_catalogue() is not None:
+            return "resolved"
+    except Exception:  # noqa: BLE001 — best-effort sync check
+        pass
+    return "in_progress"
+
+
+def _governance_trusted_role_schema_status() -> BlockerStatus:
+    """Resolved if the governance subsystem declares ``trusted_role``.
+
+    Checks the in-process subsystem_schema registry for the binding
+    spec; if the schema module is not built or the binding is
+    missing, marked ``pending``.
+    """
+    try:
+        from core.runtime import subsystem_schema
+
+        schemas = subsystem_schema.all_schemas()
+    except Exception:  # noqa: BLE001 — best-effort sync check
+        return "unknown"
+    gov = schemas.get("governance") if isinstance(schemas, dict) else None
+    if gov is None:
+        return "pending"
+    bindings = getattr(gov, "bindings", ()) or ()
+    for b in bindings:
+        if getattr(b, "name", None) == "trusted_role":
+            return "resolved"
+    return "pending"
+
+
+def _panel_registry_status() -> BlockerStatus:
+    """Panel registry — module exists today as ``panel_manager``.
+
+    ``panel_manager`` provides the version-stamped persistent-view
+    registration.  Treat the module's importability as the resolution
+    signal; absence is ``pending``.
+    """
+    import importlib
+
+    spec = importlib.util.find_spec("core.runtime.panel_manager")
+    if spec is None:
+        return "pending"
+    return "resolved"
+
+
+def _pending_doc_anchor() -> BlockerStatus:
+    """Default provider for blockers with no cached resolution signal.
+
+    Always returns ``pending``; consult the doc anchor for rationale.
+    """
+    return "pending"
+
+
+# ---------------------------------------------------------------------------
+# Canonical registry
+# ---------------------------------------------------------------------------
+
+
+BLOCKERS: tuple[BlockerSpec, ...] = (
+    BlockerSpec(
+        id="command_surface_ledger",
+        owner_project="Core Platform",
+        refactor_layer="registries",
+        status_provider=_command_surface_ledger_status,
+        severity="informational",
+        unlocks=("slash_panel_entrypoints", "setup_wizard"),
+        doc_anchor="command-surface-ledger",
+    ),
+    BlockerSpec(
+        id="panel_registry",
+        owner_project="Core Platform",
+        refactor_layer="registries",
+        status_provider=_panel_registry_status,
+        severity="informational",
+        unlocks=("slash_panel_entrypoints", "setup_wizard"),
+        doc_anchor="panel-registry",
+    ),
+    BlockerSpec(
+        id="settings_registry",
+        owner_project="Core Platform",
+        refactor_layer="registries",
+        status_provider=_settings_registry_status,
+        severity="informational",
+        unlocks=("settings_mutation_pipeline", "setup_wizard"),
+        doc_anchor="settings-registry",
+    ),
+    BlockerSpec(
+        id="settings_mutation_pipeline",
+        owner_project="Core Platform",
+        refactor_layer="services",
+        status_provider=_settings_mutation_pipeline_status,
+        severity="informational",
+        blocked_by=("settings_registry",),
+        unlocks=("setup_wizard",),
+        doc_anchor="settings-mutation-pipeline",
+    ),
+    BlockerSpec(
+        id="governance_trusted_role_schema",
+        owner_project="Core Platform",
+        refactor_layer="config",
+        status_provider=_governance_trusted_role_schema_status,
+        severity="informational",
+        doc_anchor="governance-trusted-role-schema",
+    ),
+    BlockerSpec(
+        id="role_service_extraction",
+        owner_project="Core Platform",
+        refactor_layer="services",
+        status_provider=_pending_doc_anchor,
+        severity="informational",
+        doc_anchor="role-service-extraction",
+    ),
+    BlockerSpec(
+        id="cleanup_policy_extraction",
+        owner_project="Core Platform",
+        refactor_layer="services",
+        status_provider=_pending_doc_anchor,
+        severity="informational",
+        doc_anchor="cleanup-policy-extraction",
+    ),
+    BlockerSpec(
+        id="logging_settings_integration",
+        owner_project="Core Platform",
+        refactor_layer="services",
+        status_provider=_pending_doc_anchor,
+        severity="informational",
+        blocked_by=("settings_registry",),
+        doc_anchor="logging-settings-integration",
+    ),
+    BlockerSpec(
+        id="slash_panel_entrypoints",
+        owner_project="Help & Navigation",
+        refactor_layer="ui",
+        status_provider=_pending_doc_anchor,
+        severity="informational",
+        blocked_by=("panel_registry", "command_surface_ledger"),
+        doc_anchor="slash-panel-entrypoints",
+    ),
+    BlockerSpec(
+        # NOTE: owner UNCONFIRMED per the PR-03 revision plan — reviewer
+        # to assign during PR review.
+        id="setup_wizard_readiness_bridge",
+        owner_project="UNCONFIRMED",
+        refactor_layer="services",
+        status_provider=_pending_doc_anchor,
+        severity="informational",
+        doc_anchor="setup-wizard-readiness-bridge",
+    ),
+    BlockerSpec(
+        id="setup_wizard",
+        owner_project="Setup Wizard",
+        refactor_layer="ui",
+        status_provider=_setup_wizard_status,
+        severity="informational",
+        blocked_by=(
+            "settings_registry",
+            "settings_mutation_pipeline",
+            "panel_registry",
+        ),
+        doc_anchor="setup-wizard",
+    ),
+)
+
+
+def blocker_ids() -> tuple[str, ...]:
+    """Derived tuple of every blocker's ID.
+
+    ``services.platform_consistency.SETUP_READINESS_BLOCKERS`` is
+    re-exported from this view so the bare-string contract is
+    preserved for backwards-compatible callers.
+    """
+    return tuple(b.id for b in BLOCKERS)
+
+
+def status_for(spec: BlockerSpec) -> BlockerStatus:
+    """Invoke ``spec.status_provider`` with a fail-safe wrapper.
+
+    A raising provider becomes ``"unknown"`` so a broken cached-state
+    accessor cannot blank the readiness section.
+    """
+    try:
+        return spec.status_provider()
+    except Exception as exc:  # noqa: BLE001 — registry is fail-safe
+        logger.warning(
+            "setup_blockers: status_provider for %r raised %s",
+            spec.id,
+            exc,
+        )
+        return "unknown"
+
+
+__all__ = [
+    "BLOCKERS",
+    "BlockerSpec",
+    "BlockerStatus",
+    "blocker_ids",
+    "status_for",
+]

--- a/disbot/services/setup_blockers.py
+++ b/disbot/services/setup_blockers.py
@@ -110,6 +110,7 @@ def _settings_mutation_pipeline_status() -> BlockerStatus:
     that is the contract setup_operations depends on.
     """
     import importlib
+    import importlib.util
 
     spec = importlib.util.find_spec("services.settings_mutation")
     if spec is None:
@@ -127,6 +128,7 @@ def _setup_wizard_status() -> BlockerStatus:
     customization catalogue has not been built yet.
     """
     import importlib
+    import importlib.util
 
     spec = importlib.util.find_spec("cogs.setup_cog")
     if spec is None:
@@ -174,6 +176,7 @@ def _panel_registry_status() -> BlockerStatus:
     signal; absence is ``pending``.
     """
     import importlib
+    import importlib.util
 
     spec = importlib.util.find_spec("core.runtime.panel_manager")
     if spec is None:

--- a/disbot/services/setup_change_plan.py
+++ b/disbot/services/setup_change_plan.py
@@ -1,0 +1,119 @@
+"""Setup operation change plan — PR-04a.
+
+The :func:`services.setup_operations.preflight_operations` function
+returns a list of :class:`ChangePlanEntry` records describing what a
+batch of :class:`SetupOperation` items would change.  The Final
+Review embed renders this diff before apply (behind feature flag
+``SETUP_PREFLIGHT_DIFF``); the apply path is unchanged.
+
+**Read-only contract.**  Every read adapter that contributes to a
+``ChangePlanEntry`` is forbidden from writing to the DB or calling a
+mutation pipeline.  The invariant test
+``tests/unit/invariants/test_setup_preflight_readonly.py`` enforces
+this with AST checks.  A heavy read (>10 ms) should populate
+``read_error`` with the ``"preflight: skipped (heavy)"`` sentinel
+rather than blocking the preflight.
+
+Sentinels are spelled out as module-level constants so the
+ChangePlanEntry instances can be serialised to a diagnostics dict
+view without serialising raw Python objects.
+
+Public surface::
+
+    RiskLevel        — Literal: low | medium | high | unknown
+    ChangeValueKind  — Literal: value | absent | unknown
+    ChangeValue      — frozen dataclass wrapping a value + kind
+    ChangePlanEntry  — frozen dataclass per operation
+    ABSENT           — convenience sentinel ChangeValue(kind="absent")
+    UNKNOWN          — convenience sentinel ChangeValue(kind="unknown")
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+RiskLevel = Literal["low", "medium", "high", "unknown"]
+ChangeValueKind = Literal["value", "absent", "unknown"]
+
+
+@dataclass(frozen=True)
+class ChangeValue:
+    """A sum type over (concrete value, absent, unknown).
+
+    Using a small wrapper instead of bare ``Any`` keeps the rendered
+    diff legible — "absent" and "unknown" are common signals for
+    create_* and unsupported preflight kinds.
+    """
+
+    kind: ChangeValueKind = "value"
+    value: Any = None
+
+    def __repr__(self) -> str:  # noqa: D401 — short form for embeds
+        if self.kind == "value":
+            return repr(self.value)
+        return self.kind.upper()
+
+
+ABSENT: ChangeValue = ChangeValue(kind="absent")
+UNKNOWN: ChangeValue = ChangeValue(kind="unknown")
+
+
+@dataclass(frozen=True)
+class ChangePlanEntry:
+    """Per-operation preflight result.
+
+    Fields:
+
+    * ``op`` — the :class:`services.setup_operations.SetupOperation`
+      this entry describes (the dispatcher does not consume this
+      back; it is here so a Final Review embed can render the op
+      summary alongside the diff).
+    * ``current`` — the current value read from the DB / canonical
+      service.  ``ABSENT`` when no current value exists (e.g. a
+      ``create_*`` op or an unbound slot); ``UNKNOWN`` when the read
+      adapter could not determine the current state (and likely set
+      ``read_error``).
+    * ``proposed`` — the value the op would produce.  Always set;
+      ``ABSENT`` only for ``clear_binding`` (the op explicitly
+      removes the slot).
+    * ``would_change`` — ``True`` if applying the op would change
+      observable state, ``False`` if the proposed value matches
+      ``current``.  Conservative: when the current value is
+      ``UNKNOWN``, ``would_change`` is set to ``True``.
+    * ``risk`` — best-effort severity from
+      ``op.metadata["risk"]`` if present, else ``"unknown"``.
+    * ``rollback_note`` — human-readable rollback hint from
+      ``op.metadata["rollback_note"]`` if present, else the empty
+      string.
+    * ``affected`` — string identifiers of additional state that
+      would be touched (e.g. cleanup policy scope).  Populated by
+      adapters; defaults to empty.
+    * ``read_error`` — short ``type:message`` string when the read
+      adapter raised or skipped.  ``None`` means the read succeeded
+      (or never ran, for op kinds without a v1 adapter).
+    * ``preflight_skipped_reason`` — ``None`` by default; set to
+      ``"heavy"`` / ``"no_adapter"`` / etc. when this op kind has no
+      read adapter or the read was deliberately skipped.
+    """
+
+    op: Any  # SetupOperation (typed via forward ref in setup_operations)
+    label: str
+    current: ChangeValue
+    proposed: ChangeValue
+    would_change: bool
+    risk: RiskLevel = "unknown"
+    rollback_note: str = ""
+    affected: tuple[str, ...] = field(default_factory=tuple)
+    read_error: str | None = None
+    preflight_skipped_reason: str | None = None
+
+
+__all__ = [
+    "ABSENT",
+    "UNKNOWN",
+    "ChangePlanEntry",
+    "ChangeValue",
+    "ChangeValueKind",
+    "RiskLevel",
+]

--- a/disbot/services/setup_change_plan.py
+++ b/disbot/services/setup_change_plan.py
@@ -59,6 +59,92 @@ ABSENT: ChangeValue = ChangeValue(kind="absent")
 UNKNOWN: ChangeValue = ChangeValue(kind="unknown")
 
 
+# ---------------------------------------------------------------------------
+# PR-04a — Normalized preflight comparison
+# ---------------------------------------------------------------------------
+
+
+# Strings that ``utils.db.get_setting`` may return for a "no value
+# stored" cell, in addition to ``None``.  Treated as equivalent to
+# ``None`` so a freshly-set value to "" or an unset row to "" is not
+# rendered as a misleading diff.  Aligns with the convention used by
+# the settings mutation pipeline (see ``services.settings_resolution``
+# canonical accessors).
+_NORMALIZED_EMPTY: frozenset[str] = frozenset({"", "None", "null"})
+
+# Strings that normalize to ``True`` / ``False`` for boolean settings.
+# Settings stored as canonical strings ("true"/"false", "1"/"0",
+# "yes"/"no") should compare equal to the boolean form an operator
+# stages from the wizard.
+_TRUTHY_TOKENS: frozenset[str] = frozenset({"true", "1", "yes", "on"})
+_FALSY_TOKENS: frozenset[str] = frozenset({"false", "0", "no", "off"})
+
+
+def _normalize_for_compare(value: Any) -> Any:
+    """Return a canonical form of ``value`` for the preflight diff.
+
+    The settings layer stores everything as TEXT, so naive string
+    comparison would either hide real type mismatches (``int 1`` vs
+    string ``"1"``) or surface false positives (``bool True`` vs
+    string ``"true"``).  The normalizer collapses common equivalent
+    forms so the preflight diff only flags **observable** changes.
+
+    Rules (deliberately small — bigger normalization is the settings
+    layer's job):
+
+    * ``None`` → ``None``.
+    * Strings ``""`` / ``"None"`` / ``"null"`` → ``None`` (DB layer
+      sometimes stores the empty form for "unset").
+    * Booleans → ``True`` / ``False`` directly.
+    * Strings matching ``_TRUTHY_TOKENS`` → ``True``.
+    * Strings matching ``_FALSY_TOKENS`` → ``False``.
+    * Numeric strings → ``int`` if exactly parseable, else stripped
+      string.
+    * Other strings → stripped + lowercased so trailing whitespace
+      / case drift does not show as a diff.
+    * Everything else: returned unchanged.
+
+    The normalizer is deterministic and side-effect-free.  Adding a
+    new equivalence here costs one entry; the comparison itself
+    remains a single ``==``.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, str):
+        s = value.strip()
+        if s in _NORMALIZED_EMPTY:
+            return None
+        lowered = s.lower()
+        if lowered in _TRUTHY_TOKENS:
+            return True
+        if lowered in _FALSY_TOKENS:
+            return False
+        # Numeric coercion — only exact int parse so we don't
+        # accidentally collapse "1.0" with "1" for non-numeric keys.
+        try:
+            return int(s)
+        except ValueError:
+            pass
+        return lowered
+    return value
+
+
+def values_equivalent(current: Any, proposed: Any) -> bool:
+    """Return ``True`` when the preflight should treat the two values
+    as the same observable state.
+
+    Use this in every preflight adapter that needs to decide
+    ``would_change``.  Centralising the rule here means a new
+    equivalence (e.g. canonical channel-ID string vs int) is one edit
+    rather than a sweep of adapters.
+    """
+    return _normalize_for_compare(current) == _normalize_for_compare(proposed)
+
+
 @dataclass(frozen=True)
 class ChangePlanEntry:
     """Per-operation preflight result.
@@ -116,4 +202,5 @@ __all__ = [
     "ChangeValue",
     "ChangeValueKind",
     "RiskLevel",
+    "values_equivalent",
 ]

--- a/disbot/services/setup_operations.py
+++ b/disbot/services/setup_operations.py
@@ -415,8 +415,17 @@ async def _preflight_set_setting(
     op: SetupOperation,
     guild_id: int | None,
 ) -> tuple[ChangeValue, ChangeValue, bool, str | None]:
-    """Read the current setting value to diff against ``op.value``."""
-    from services.setup_change_plan import UNKNOWN, ChangeValue
+    """Read the current setting value to diff against ``op.value``.
+
+    Uses :func:`services.setup_change_plan.values_equivalent` for the
+    diff so settings stored as TEXT in the DB compare correctly to the
+    typed values the wizard stages (e.g. ``"true"`` vs ``True``,
+    ``"100"`` vs ``int 100``, ``""`` vs ``None``).  Naive string
+    comparison would either hide real mismatches or render false
+    positives — see ``test_setup_change_plan.TestValuesEquivalent`` for
+    the full equivalence table.
+    """
+    from services.setup_change_plan import UNKNOWN, ChangeValue, values_equivalent
 
     if guild_id is None or not op.subsystem or not op.setting_name:
         return (
@@ -441,7 +450,7 @@ async def _preflight_set_setting(
         )
     current = ChangeValue(kind="value", value=current_raw)
     proposed = ChangeValue(kind="value", value=op.value)
-    would_change = str(current_raw) != str(op.value)
+    would_change = not values_equivalent(current_raw, op.value)
     return current, proposed, would_change, None
 
 

--- a/disbot/services/setup_operations.py
+++ b/disbot/services/setup_operations.py
@@ -33,7 +33,10 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from services.setup_change_plan import ChangePlanEntry, ChangeValue
 
 logger = logging.getLogger("bot.services.setup_operations")
 
@@ -203,6 +206,9 @@ def preview_operations(ops: list[SetupOperation]) -> list[SetupOperationResult]:
     Validates each operation's kind only.  Operations with known kinds are
     optimistically reported as ``"applied"``; unknown kinds are
     ``"not_yet_implemented"``.  No DB reads are performed.
+
+    Kept as the sync fast path; consumers wanting a real current /
+    proposed diff call :func:`preflight_operations` (PR-04a).
     """
     results: list[SetupOperationResult] = []
     for op in ops:
@@ -218,6 +224,264 @@ def preview_operations(ops: list[SetupOperation]) -> list[SetupOperationResult]:
             ),
         )
     return results
+
+
+# ---------------------------------------------------------------------------
+# PR-04a — Preflight (read-only ChangePlan diff)
+# ---------------------------------------------------------------------------
+
+
+import os  # noqa: E402
+
+_PREFLIGHT_FLAG_ENV = "SETUP_PREFLIGHT_DIFF"
+
+
+def is_preflight_enabled() -> bool:
+    """Return ``True`` when the preflight diff feature is enabled.
+
+    Reads the ``SETUP_PREFLIGHT_DIFF`` env var.  Default: off in
+    PR-04a; PR-04b flips the default after a clean canary.  Final
+    Review consults this helper to decide whether to invoke
+    :func:`preflight_operations` or fall back to the validation-only
+    :func:`preview_operations` path.
+    """
+    val = os.getenv(_PREFLIGHT_FLAG_ENV, "").strip().lower()
+    return val in ("1", "true", "yes", "on")
+
+
+async def preflight_operations(
+    ops: list[SetupOperation],
+    *,
+    guild: Any,
+) -> list[ChangePlanEntry]:
+    """Return one :class:`ChangePlanEntry` per operation.
+
+    PR-04a: real current/proposed diff for the most common operation
+    kinds (``bind_*`` / ``clear_binding``, ``set_setting``,
+    ``set_cog_routing``).  Other kinds emit a ChangePlanEntry with
+    ``preflight_skipped_reason="no_adapter"`` so the Final Review
+    embed can label them ``"preflight unavailable"`` rather than
+    silently dropping the op.
+
+    **Read-only** by contract: adapters here must not write to the
+    DB or call a mutation pipeline.  The
+    ``tests/unit/invariants/test_setup_preflight_readonly.py``
+    invariant enforces this at AST level.
+
+    Failures in a single adapter are isolated — the entry gets a
+    ``read_error`` string and the rest of the batch continues.  An
+    unknown ``op.kind`` produces a no-adapter entry rather than
+    raising.
+    """
+    from services.setup_change_plan import (
+        ABSENT,
+        UNKNOWN,
+        ChangePlanEntry,
+        ChangeValue,
+    )
+
+    entries: list[ChangePlanEntry] = []
+    guild_id = getattr(guild, "id", None)
+    for op in ops:
+        meta = op.metadata or {}
+        risk = meta.get("risk", "unknown") if isinstance(meta, dict) else "unknown"
+        rollback = meta.get("rollback_note", "") if isinstance(meta, dict) else ""
+        if risk not in ("low", "medium", "high", "unknown"):
+            risk = "unknown"
+
+        # Defaults — overwritten by per-kind adapters below.
+        current: ChangeValue = UNKNOWN
+        proposed: ChangeValue = UNKNOWN
+        would_change = True
+        read_error: str | None = None
+        skipped_reason: str | None = None
+
+        kind = op.kind
+        if kind not in _KNOWN_KINDS:
+            # Validation-time failure: render as no-adapter.
+            skipped_reason = "unknown_op_kind"
+            proposed = ChangeValue(kind="value", value=op.target_id or op.value)
+        elif kind in _BINDING_KINDS:
+            current, proposed, would_change, read_error = await _preflight_bind(
+                op,
+                guild_id,
+            )
+        elif kind == "clear_binding":
+            current, proposed, would_change, read_error = (
+                await _preflight_clear_binding(
+                    op,
+                    guild_id,
+                )
+            )
+        elif kind == "set_setting":
+            current, proposed, would_change, read_error = await _preflight_set_setting(
+                op,
+                guild_id,
+            )
+        elif kind == "set_cog_routing":
+            current, proposed, would_change, read_error = (
+                await _preflight_set_cog_routing(
+                    op,
+                    guild_id,
+                )
+            )
+        else:
+            # Known kind without a v1 read adapter (create_*, automation,
+            # cleanup_policy).  Render proposed value where available;
+            # signal that the diff is not computed.
+            skipped_reason = "no_adapter"
+            current = ABSENT if kind.startswith("create_") else UNKNOWN
+            proposed_val = (
+                op.value if op.value is not None else op.target_id or op.target_name
+            )
+            proposed = ChangeValue(kind="value", value=proposed_val)
+
+        entries.append(
+            ChangePlanEntry(
+                op=op,
+                label=_label(op),
+                current=current,
+                proposed=proposed,
+                would_change=would_change,
+                risk=risk,
+                rollback_note=rollback,
+                read_error=read_error,
+                preflight_skipped_reason=skipped_reason,
+            ),
+        )
+    return entries
+
+
+async def _preflight_bind(
+    op: SetupOperation,
+    guild_id: int | None,
+) -> tuple[ChangeValue, ChangeValue, bool, str | None]:
+    """Read the current binding row to diff against ``op``."""
+    from services.setup_change_plan import ABSENT, UNKNOWN, ChangeValue
+
+    if guild_id is None or not op.subsystem or not op.binding_name:
+        return (
+            UNKNOWN,
+            ChangeValue(kind="value", value=op.target_id),
+            True,
+            "missing guild/subsystem/binding_name on op",
+        )
+    try:
+        from utils.db import bindings as bindings_db
+
+        row = await bindings_db.get_one(guild_id, op.subsystem, op.binding_name)
+    except Exception as exc:  # noqa: BLE001 — preflight is fail-safe
+        return (
+            UNKNOWN,
+            ChangeValue(kind="value", value=op.target_id),
+            True,
+            f"{type(exc).__name__}: {exc}",
+        )
+    current: ChangeValue
+    if row is None:
+        current = ABSENT
+    else:
+        current = ChangeValue(kind="value", value=row.get("target_id"))
+    proposed = ChangeValue(kind="value", value=op.target_id)
+    if current.kind != "value" or proposed.kind != "value":
+        would_change = True
+    else:
+        would_change = current.value != proposed.value
+    return current, proposed, would_change, None
+
+
+async def _preflight_clear_binding(
+    op: SetupOperation,
+    guild_id: int | None,
+) -> tuple[ChangeValue, ChangeValue, bool, str | None]:
+    """Read the current binding row to determine whether clear is a no-op."""
+    from services.setup_change_plan import ABSENT, UNKNOWN, ChangeValue
+
+    if guild_id is None or not op.subsystem or not op.binding_name:
+        return (UNKNOWN, ABSENT, True, "missing guild/subsystem/binding_name on op")
+    try:
+        from utils.db import bindings as bindings_db
+
+        row = await bindings_db.get_one(guild_id, op.subsystem, op.binding_name)
+    except Exception as exc:  # noqa: BLE001 — preflight is fail-safe
+        return (UNKNOWN, ABSENT, True, f"{type(exc).__name__}: {exc}")
+    if row is None:
+        return (ABSENT, ABSENT, False, None)
+    current = ChangeValue(kind="value", value=row.get("target_id"))
+    return (current, ABSENT, True, None)
+
+
+async def _preflight_set_setting(
+    op: SetupOperation,
+    guild_id: int | None,
+) -> tuple[ChangeValue, ChangeValue, bool, str | None]:
+    """Read the current setting value to diff against ``op.value``."""
+    from services.setup_change_plan import UNKNOWN, ChangeValue
+
+    if guild_id is None or not op.subsystem or not op.setting_name:
+        return (
+            UNKNOWN,
+            ChangeValue(kind="value", value=op.value),
+            True,
+            "missing guild/subsystem/setting_name on op",
+        )
+    try:
+        from utils import db
+
+        current_raw = await db.get_setting(
+            guild_id,
+            f"{op.subsystem}.{op.setting_name}",
+        )
+    except Exception as exc:  # noqa: BLE001 — preflight is fail-safe
+        return (
+            UNKNOWN,
+            ChangeValue(kind="value", value=op.value),
+            True,
+            f"{type(exc).__name__}: {exc}",
+        )
+    current = ChangeValue(kind="value", value=current_raw)
+    proposed = ChangeValue(kind="value", value=op.value)
+    would_change = str(current_raw) != str(op.value)
+    return current, proposed, would_change, None
+
+
+async def _preflight_set_cog_routing(
+    op: SetupOperation,
+    guild_id: int | None,
+) -> tuple[ChangeValue, ChangeValue, bool, str | None]:
+    """Read the current cog-routing policy for a given scope."""
+    from services.setup_change_plan import UNKNOWN, ChangeValue
+
+    if guild_id is None or not op.subsystem:
+        return (
+            UNKNOWN,
+            ChangeValue(kind="value", value=op.value),
+            True,
+            "missing guild/subsystem on op",
+        )
+    proposed_val = bool(op.value) if op.value is not None else False
+    proposed = ChangeValue(kind="value", value=proposed_val)
+    try:
+        from services import command_routing
+
+        # The cog-routing scope is per-channel; the op carries the
+        # scope target_id when present.  Without a target_id we read
+        # the guild-level policy.
+        current_val = await command_routing.is_cog_enabled(
+            guild_id,
+            op.subsystem,
+            channel_id=op.target_id,
+        )
+    except Exception as exc:  # noqa: BLE001 — preflight is fail-safe
+        return (
+            UNKNOWN,
+            proposed,
+            True,
+            f"{type(exc).__name__}: {exc}",
+        )
+    current = ChangeValue(kind="value", value=bool(current_val))
+    would_change = bool(current_val) != proposed_val
+    return current, proposed, would_change, None
 
 
 async def apply_operations(

--- a/tests/unit/docs/test_phase_2_readiness_doc.py
+++ b/tests/unit/docs/test_phase_2_readiness_doc.py
@@ -69,7 +69,12 @@ def test_pr_10_listed_as_current_next_work(doc_text: str):
 
 def test_every_setup_readiness_blocker_appears_in_doc(doc_text: str):
     """Every entry in SETUP_READINESS_BLOCKERS must appear in the doc in
-    humanised form (snake_case → space-separated, case-insensitive)."""
+    humanised form (snake_case → space-separated, case-insensitive).
+
+    PR-03: ``SETUP_READINESS_BLOCKERS`` is now derived from
+    ``services.setup_blockers.blocker_ids()`` but the bare-string
+    contract is preserved, so this assertion still works unchanged.
+    """
     lowered = doc_text.lower()
     missing: list[str] = []
     for blocker in SETUP_READINESS_BLOCKERS:
@@ -79,4 +84,64 @@ def test_every_setup_readiness_blocker_appears_in_doc(doc_text: str):
     assert not missing, (
         "Doc/SETUP_READINESS_BLOCKERS sync gap — add these to the "
         "'Setup-readiness blockers' section:\n  " + "\n  ".join(missing)
+    )
+
+
+# ---------------------------------------------------------------------------
+# PR-03: resolved-marker cross-check
+# ---------------------------------------------------------------------------
+
+
+def test_blocker_ids_match_blocker_specs():
+    """The derived ID list must match the underlying ``BlockerSpec`` IDs.
+
+    Prevents drift between ``services.setup_blockers.BLOCKERS`` and
+    ``platform_consistency.SETUP_READINESS_BLOCKERS`` (which is now a
+    re-export of ``blocker_ids()``)."""
+    from services import setup_blockers
+
+    spec_ids = tuple(b.id for b in setup_blockers.BLOCKERS)
+    assert SETUP_READINESS_BLOCKERS == spec_ids
+
+
+def test_every_blocker_has_resolution_provider_and_doc_anchor():
+    """Each spec must declare a doc_anchor + a callable status_provider.
+
+    Doc anchor is the "where do I read more?" link operators follow
+    when a blocker is pending; status_provider is the sync resolution
+    check the readiness collector consumes."""
+    from services import setup_blockers
+
+    missing_anchor: list[str] = []
+    missing_provider: list[str] = []
+    for spec in setup_blockers.BLOCKERS:
+        if not spec.doc_anchor:
+            missing_anchor.append(spec.id)
+        if not callable(spec.status_provider):
+            missing_provider.append(spec.id)
+    assert not missing_anchor, (
+        "BlockerSpec(s) missing doc_anchor:\n  " + "\n  ".join(missing_anchor)
+    )
+    assert not missing_provider, (
+        "BlockerSpec(s) missing status_provider:\n  " + "\n  ".join(missing_provider)
+    )
+
+
+def test_blocker_status_provider_returns_valid_literal():
+    """Every status_provider must return a member of BlockerStatus.
+
+    Fail-safe ``status_for`` wrapper catches exceptions and returns
+    ``"unknown"``, but this test exercises the providers directly to
+    catch silent shape drift."""
+    from services import setup_blockers
+
+    valid = {"resolved", "in_progress", "pending", "blocked", "unknown"}
+    invalid: list[str] = []
+    for spec in setup_blockers.BLOCKERS:
+        status = setup_blockers.status_for(spec)
+        if status not in valid:
+            invalid.append(f"{spec.id}: returned {status!r}")
+    assert not invalid, (
+        "BlockerSpec.status_provider returned unknown literal:\n  "
+        + "\n  ".join(invalid)
     )

--- a/tests/unit/docs/test_settings_customization_doc.py
+++ b/tests/unit/docs/test_settings_customization_doc.py
@@ -35,6 +35,7 @@ _RPM_OVERVIEW = _DOCS / "resource-provisioning-overview.md"
 _SUBSYSTEM_REGISTRY_SRC = _DISBOT / "utils" / "subsystem_registry.py"
 _CONFIG_SRC = _DISBOT / "config.py"
 _PLATFORM_CONSISTENCY_SRC = _DISBOT / "services" / "platform_consistency.py"
+_SETUP_BLOCKERS_SRC = _DISBOT / "services" / "setup_blockers.py"
 _SETTINGS_KEYS_INIT_SRC = _DISBOT / "utils" / "settings_keys" / "__init__.py"
 
 # 24-field template labels (snake_case form). The doc may format them with
@@ -132,15 +133,53 @@ def _initial_extensions() -> tuple[str, ...]:
 
 
 def _setup_readiness_blockers() -> tuple[str, ...]:
-    """Statically extract SETUP_READINESS_BLOCKERS from platform_consistency.py."""
-    value = _module_assignment(_PLATFORM_CONSISTENCY_SRC, "SETUP_READINESS_BLOCKERS")
+    """Statically extract the canonical blocker IDs.
+
+    PR-03: ``SETUP_READINESS_BLOCKERS`` is now derived from
+    ``services.setup_blockers.BLOCKERS`` (a tuple of ``BlockerSpec``
+    instances with literal ``id="..."`` arguments).  This helper
+    parses the BlockerSpec(...) call expressions and pulls the ``id``
+    keyword argument from each — keeping the doc-test fully static
+    (no code execution).
+    """
+    tree = ast.parse(_SETUP_BLOCKERS_SRC.read_text(encoding="utf-8"))
+    blockers_value: ast.AST | None = None
+    for node in tree.body:
+        if isinstance(node, ast.AnnAssign):
+            tgt = node.target
+            if (
+                isinstance(tgt, ast.Name)
+                and tgt.id == "BLOCKERS"
+                and node.value is not None
+            ):
+                blockers_value = node.value
+                break
+        elif isinstance(node, ast.Assign):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Name) and tgt.id == "BLOCKERS":
+                    blockers_value = node.value
+                    break
+            if blockers_value is not None:
+                break
     assert isinstance(
-        value, (ast.Tuple, ast.List)
-    ), "SETUP_READINESS_BLOCKERS must be a tuple/list literal"
+        blockers_value, (ast.Tuple, ast.List)
+    ), "setup_blockers.BLOCKERS must be a tuple/list literal of BlockerSpec(...) calls"
     out: list[str] = []
-    for elt in value.elts:
-        assert isinstance(elt, ast.Constant) and isinstance(elt.value, str)
-        out.append(elt.value)
+    for elt in blockers_value.elts:
+        assert isinstance(elt, ast.Call), "BLOCKERS entries must be BlockerSpec(...) calls"
+        # id may be passed positionally or as a keyword; canonical form
+        # in setup_blockers.py is keyword.
+        spec_id: str | None = None
+        for kw in elt.keywords:
+            if kw.arg == "id" and isinstance(kw.value, ast.Constant):
+                spec_id = kw.value.value
+                break
+        if spec_id is None and elt.args:
+            first = elt.args[0]
+            if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                spec_id = first.value
+        assert spec_id is not None, f"BlockerSpec call missing id: {ast.dump(elt)}"
+        out.append(spec_id)
     return tuple(out)
 
 

--- a/tests/unit/invariants/test_platform_consistency_kinds.py
+++ b/tests/unit/invariants/test_platform_consistency_kinds.py
@@ -24,7 +24,6 @@ import pytest
 
 from services import platform_consistency as pc
 
-
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _MODULE_PATH = _REPO_ROOT / "disbot" / "services" / "platform_consistency.py"
 

--- a/tests/unit/invariants/test_platform_consistency_kinds.py
+++ b/tests/unit/invariants/test_platform_consistency_kinds.py
@@ -1,0 +1,111 @@
+"""Invariant tests for the platform consistency typed readiness contract.
+
+Pins two structural constraints introduced in PR-01a:
+
+1. ``_LABEL_TO_KIND`` covers every label used by the
+   ``collect_report`` orchestrator.  Adding a new collector requires
+   adding its label/kind pair here at the same time.
+
+2. ``READINESS_KINDS`` is exhaustive over ``ReadinessKind`` and
+   matches the orchestrator's collector tuple order.  A missing kind
+   would silently lose its identity at runtime.
+
+The runtime stamping behaviour (every section in a collected report
+carries a typed kind) is pinned by
+``tests/unit/services/test_platform_consistency.py``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from services import platform_consistency as pc
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MODULE_PATH = _REPO_ROOT / "disbot" / "services" / "platform_consistency.py"
+
+
+def _extract_collector_labels() -> tuple[str, ...]:
+    """Parse the labels used in the ``collect_report`` collector tuple.
+
+    Handles both ``collectors = (...)`` and the annotated form
+    ``collectors: ... = (...)``.  Returns the string label of each
+    entry in declaration order.
+    """
+    tree = ast.parse(_MODULE_PATH.read_text())
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef) or node.name != "collect_report":
+            continue
+        for sub in ast.walk(node):
+            value: ast.AST | None = None
+            if isinstance(sub, ast.Assign):
+                target = sub.targets[0] if sub.targets else None
+                if isinstance(target, ast.Name) and target.id == "collectors":
+                    value = sub.value
+            elif isinstance(sub, ast.AnnAssign):
+                target = sub.target
+                if isinstance(target, ast.Name) and target.id == "collectors":
+                    value = sub.value
+            if value is None or not isinstance(value, ast.Tuple):
+                continue
+            labels: list[str] = []
+            for entry in value.elts:
+                if (
+                    isinstance(entry, ast.Tuple)
+                    and entry.elts
+                    and isinstance(entry.elts[0], ast.Constant)
+                    and isinstance(entry.elts[0].value, str)
+                ):
+                    labels.append(entry.elts[0].value)
+            return tuple(labels)
+    pytest.fail("Could not locate the `collectors` tuple inside collect_report")
+
+
+def test_label_to_kind_covers_every_collector_label():
+    labels = _extract_collector_labels()
+    assert len(labels) == 10, f"Expected 10 collectors; found {len(labels)}"
+    missing = [label for label in labels if label not in pc._LABEL_TO_KIND]
+    assert not missing, (
+        f"_LABEL_TO_KIND missing entries for: {missing}.  "
+        "Adding a new collector requires updating _LABEL_TO_KIND."
+    )
+
+
+def test_label_to_kind_has_no_orphan_entries():
+    labels = set(_extract_collector_labels())
+    orphan = [label for label in pc._LABEL_TO_KIND if label not in labels]
+    assert not orphan, (
+        f"_LABEL_TO_KIND has orphan entries (no matching collector): {orphan}"
+    )
+
+
+def test_readiness_kinds_matches_label_to_kind_values():
+    """Every kind referenced by ``_LABEL_TO_KIND`` is in
+    ``READINESS_KINDS``, and vice versa."""
+    via_labels = set(pc._LABEL_TO_KIND.values())
+    via_tuple = set(pc.READINESS_KINDS)
+    assert via_labels == via_tuple, (
+        f"READINESS_KINDS / _LABEL_TO_KIND drift: "
+        f"only-in-tuple={via_tuple - via_labels}; "
+        f"only-in-labels={via_labels - via_tuple}"
+    )
+
+
+def test_readiness_kinds_exhausts_enum():
+    """Every ``ReadinessKind`` enum member appears in
+    ``READINESS_KINDS``.  Adding a new enum member requires updating
+    the canonical tuple."""
+    assert set(pc.READINESS_KINDS) == set(pc.ReadinessKind)
+
+
+def test_readiness_kinds_order_matches_collector_order():
+    """The order of ``READINESS_KINDS`` matches the order of labels in
+    the orchestrator's collector tuple.  Diagnostic embeds and the
+    readiness snapshot rely on this ordering."""
+    labels = _extract_collector_labels()
+    expected = tuple(pc._LABEL_TO_KIND[label] for label in labels)
+    assert pc.READINESS_KINDS == expected

--- a/tests/unit/invariants/test_setup_preflight_readonly.py
+++ b/tests/unit/invariants/test_setup_preflight_readonly.py
@@ -1,0 +1,140 @@
+"""PR-04a invariant: setup preflight is strictly read-only.
+
+The :func:`services.setup_operations.preflight_operations` adapters
+must never write to the DB or invoke a mutation pipeline.  This test
+walks the AST of ``setup_operations.py`` and asserts no preflight
+adapter contains a mutation-pipeline call or a DB write helper.
+
+If a future adapter needs to read from a heavy source, the contract
+is to populate ``ChangePlanEntry.read_error`` (e.g.
+``"preflight: skipped (heavy)"``) rather than fall back to a write.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SETUP_OPS = _REPO_ROOT / "disbot" / "services" / "setup_operations.py"
+
+# Functions whose AST body must not contain any mutation calls.
+_PREFLIGHT_FUNCS: frozenset[str] = frozenset(
+    {
+        "preflight_operations",
+        "_preflight_bind",
+        "_preflight_clear_binding",
+        "_preflight_set_setting",
+        "_preflight_set_cog_routing",
+    },
+)
+
+# Forbidden attribute calls.  The preflight adapters can read these
+# modules but must never invoke their mutation methods.
+_FORBIDDEN_ATTR_NAMES: frozenset[str] = frozenset(
+    {
+        "set_binding",
+        "clear_binding",
+        "set_value",
+        "set_setting",
+        "set_policy",
+        "create_rule",
+        "set_enabled",
+        "provision",
+        "upsert_with_audit",
+        "clear_with_audit",
+        "set_cleanup_policy_for_scope",
+        "create_channel",
+        "create_role",
+        "create_category",
+        "set_one",  # utils.db.command_routing mutation
+    },
+)
+
+
+def _find_preflight_function_bodies() -> dict[str, ast.AST]:
+    """Return {func_name: AST body} for every preflight function."""
+    tree = ast.parse(_SETUP_OPS.read_text(encoding="utf-8"))
+    found: dict[str, ast.AST] = {}
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name in _PREFLIGHT_FUNCS
+        ):
+            found[node.name] = node
+    return found
+
+
+def test_every_preflight_function_present():
+    found = _find_preflight_function_bodies()
+    missing = _PREFLIGHT_FUNCS - found.keys()
+    assert not missing, f"Expected preflight function(s) missing: {missing}"
+
+
+def test_preflight_functions_call_no_mutation_method():
+    """No preflight function may contain an attribute call whose name
+    matches a known mutation method.  Adapters read from
+    ``utils.db.bindings.get_one`` / ``db.get_setting`` /
+    ``command_routing.is_cog_enabled`` — every other call is suspect."""
+    violations: list[str] = []
+    for name, node in _find_preflight_function_bodies().items():
+        for sub in ast.walk(node):
+            if not isinstance(sub, ast.Call):
+                continue
+            func = sub.func
+            if isinstance(func, ast.Attribute) and func.attr in _FORBIDDEN_ATTR_NAMES:
+                violations.append(f"{name}: calls .{func.attr}(...)")
+    assert not violations, (
+        "Preflight adapter(s) contain forbidden mutation call(s):\n  "
+        + "\n  ".join(violations)
+    )
+
+
+def test_preflight_functions_do_not_open_db_transactions():
+    """A preflight adapter using an explicit transaction would imply
+    a write.  We forbid ``async with pool.acquire() as conn: async
+    with conn.transaction():`` style usage by scanning for
+    ``.transaction()`` calls inside preflight bodies."""
+    violations: list[str] = []
+    for name, node in _find_preflight_function_bodies().items():
+        for sub in ast.walk(node):
+            if not isinstance(sub, ast.Call):
+                continue
+            func = sub.func
+            if isinstance(func, ast.Attribute) and func.attr == "transaction":
+                violations.append(f"{name}: opens a transaction()")
+    assert not violations, (
+        "Preflight adapter(s) open a transaction — preflight is "
+        "read-only:\n  " + "\n  ".join(violations)
+    )
+
+
+def test_preflight_module_does_not_import_mutation_pipelines_at_module_scope():
+    """``setup_operations`` already forbids module-scope imports of
+    pipeline modules (other invariant pins that).  PR-04a adapters
+    must continue that discipline: any pipeline import stays
+    function-local so the preflight read path cannot accidentally
+    drag a mutation surface into scope."""
+    tree = ast.parse(_SETUP_OPS.read_text(encoding="utf-8"))
+    forbidden_modules = {
+        "services.binding_mutation",
+        "services.settings_mutation",
+        "services.resource_provisioning",
+        "services.automation_mutation",
+    }
+    violations: list[str] = []
+    for node in tree.body:  # module-scope only
+        if isinstance(node, ast.ImportFrom):
+            if node.module in forbidden_modules:
+                violations.append(f"module-scope from {node.module} import ...")
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name in forbidden_modules:
+                    violations.append(f"module-scope import {alias.name}")
+    if violations:
+        pytest.fail(
+            "setup_operations imports mutation pipeline at module scope:\n  "
+            + "\n  ".join(violations),
+        )

--- a/tests/unit/services/test_platform_consistency.py
+++ b/tests/unit/services/test_platform_consistency.py
@@ -597,3 +597,125 @@ def test_collect_report_returns_ten_sections_in_order():
     # Last section must be Setup readiness, marked informational.
     assert report.sections[-1].name == "Setup readiness"
     assert report.sections[-1].informational is True
+
+
+# ---------------------------------------------------------------------------
+# PR-01a: typed readiness kind + iter_blocking_sections
+# ---------------------------------------------------------------------------
+
+
+def test_readiness_kinds_canonical_ordering():
+    """``READINESS_KINDS`` pins the canonical section order.
+
+    The diagnostic embed and the upcoming readiness snapshot rely on
+    this ordering being stable; adding a new collector requires
+    appending its kind and updating ``_LABEL_TO_KIND`` together.
+    """
+    assert pc.READINESS_KINDS == (
+        pc.ReadinessKind.IDENTITY_CONTRACT,
+        pc.ReadinessKind.FEATURE_FLAGS,
+        pc.ReadinessKind.ROLLOUT_AUDIT,
+        pc.ReadinessKind.BINDINGS,
+        pc.ReadinessKind.BINDING_BACKFILL,
+        pc.ReadinessKind.CONFIG_ARBITRATION,
+        pc.ReadinessKind.PARTICIPATION,
+        pc.ReadinessKind.MIGRATIONS,
+        pc.ReadinessKind.RUNTIME_PROVIDERS,
+        pc.ReadinessKind.SETUP_READINESS,
+    )
+    # Every declared kind must appear in the canonical tuple.
+    assert set(pc.READINESS_KINDS) == set(pc.ReadinessKind)
+
+
+def test_collect_report_stamps_typed_kind_on_every_section():
+    """Every section in the collected report has a non-None typed kind
+    matching ``READINESS_KINDS``."""
+
+    async def trivial(*args, **kwargs) -> pc.SectionResult:
+        return pc.SectionResult(name="x", status=pc.SectionStatus.SKIPPED, summary="x")
+
+    with patch.multiple(
+        pc,
+        _collect_identity_contract=trivial,
+        _collect_feature_flags=trivial,
+        _collect_rollout_audit=trivial,
+        _collect_bindings=trivial,
+        _collect_binding_backfill=trivial,
+        _collect_config_arbitration=trivial,
+        _collect_participation=trivial,
+        _collect_migrations=trivial,
+        _collect_runtime_providers=trivial,
+        _collect_setup_readiness=trivial,
+    ):
+        report = asyncio.run(pc.collect_report(bot=object(), guild=None))
+
+    kinds = [s.kind for s in report.sections]
+    assert all(k is not None for k in kinds), f"Untyped section in {kinds}"
+    assert tuple(kinds) == pc.READINESS_KINDS
+
+
+def test_collect_report_stamps_kind_even_when_collector_raises():
+    """A collector exception still produces a typed section."""
+
+    async def bad(*args, **kwargs) -> pc.SectionResult:
+        raise RuntimeError("boom")
+
+    async def trivial(*args, **kwargs) -> pc.SectionResult:
+        return pc.SectionResult(name="x", status=pc.SectionStatus.SKIPPED, summary="x")
+
+    with patch.multiple(
+        pc,
+        _collect_identity_contract=bad,
+        _collect_feature_flags=trivial,
+        _collect_rollout_audit=trivial,
+        _collect_bindings=trivial,
+        _collect_binding_backfill=trivial,
+        _collect_config_arbitration=trivial,
+        _collect_participation=trivial,
+        _collect_migrations=trivial,
+        _collect_runtime_providers=trivial,
+        _collect_setup_readiness=trivial,
+    ):
+        report = asyncio.run(pc.collect_report(bot=object(), guild=None))
+
+    # The FATAL fallback section for identity_contract still gets stamped.
+    assert report.sections[0].status == pc.SectionStatus.FATAL
+    assert report.sections[0].kind == pc.ReadinessKind.IDENTITY_CONTRACT
+
+
+def test_iter_blocking_sections_filters_informational_and_clean():
+    """Non-informational FATAL/WARNING/SKIPPED are returned; CLEAN and
+    informational sections are filtered out."""
+    sections = (
+        pc.SectionResult(name="a", status=pc.SectionStatus.CLEAN, summary=""),
+        pc.SectionResult(name="b", status=pc.SectionStatus.WARNING, summary=""),
+        pc.SectionResult(name="c", status=pc.SectionStatus.FATAL, summary=""),
+        pc.SectionResult(name="d", status=pc.SectionStatus.SKIPPED, summary=""),
+        # Informational warning must be excluded (Setup readiness pattern).
+        pc.SectionResult(
+            name="e", status=pc.SectionStatus.WARNING, summary="", informational=True
+        ),
+    )
+    report = pc.ConsistencyReport(
+        sections=sections,
+        generated_at=datetime.datetime.now(tz=datetime.timezone.utc),
+    )
+    blocking = pc.iter_blocking_sections(report)
+    names = [s.name for s in blocking]
+    assert names == ["b", "c", "d"]
+
+
+def test_iter_blocking_sections_returns_empty_for_all_clean():
+    report = _report(pc.SectionStatus.CLEAN, pc.SectionStatus.CLEAN)
+    assert pc.iter_blocking_sections(report) == ()
+
+
+def test_setup_readiness_section_remains_informational():
+    """Regression pin: the Setup readiness collector must report
+    ``informational=True`` so the static blocker list cannot promote
+    ``overall_status``.  PR-03 (dynamic blocker registry) preserves
+    this contract."""
+    result = asyncio.run(pc._collect_setup_readiness())
+    assert result.informational is True
+    # Canonical section name matches the orchestrator's label mapping.
+    assert result.name == "Setup readiness"

--- a/tests/unit/services/test_platform_consistency.py
+++ b/tests/unit/services/test_platform_consistency.py
@@ -549,11 +549,18 @@ def test_participation_skipped_when_tables_absent():
 
 def test_setup_readiness_lists_all_documented_blockers():
     result = asyncio.run(pc._collect_setup_readiness())
-    assert result.status == pc.SectionStatus.WARNING
+    # PR-03: status depends on how many blockers are resolved at the
+    # moment the test runs; WARNING is the expected default since at
+    # least one blocker is still pending in this codebase.
+    assert result.status in (pc.SectionStatus.WARNING, pc.SectionStatus.CLEAN)
     assert result.informational is True
-    # Every constant entry must appear verbatim in the details.
+    # PR-03: details are now "<id>: <status>" pairs.  Every blocker ID
+    # must still appear as a prefix in some detail line.
+    detail_text = " ".join(result.details)
     for blocker in pc.SETUP_READINESS_BLOCKERS:
-        assert blocker in result.details
+        assert blocker in detail_text, (
+            f"{blocker!r} missing from setup readiness section details"
+        )
 
 
 def test_setup_readiness_marked_informational():

--- a/tests/unit/services/test_setup_change_plan.py
+++ b/tests/unit/services/test_setup_change_plan.py
@@ -305,3 +305,204 @@ async def test_preflight_entry_carries_op_back():
         entries = await preflight_operations([op], guild=_guild())
     assert entries[0].op is op
     assert entries[0].label  # non-empty
+
+
+# ---------------------------------------------------------------------------
+# PR-04a (review fix) — normalized comparison via values_equivalent
+# ---------------------------------------------------------------------------
+
+
+from services.setup_change_plan import values_equivalent  # noqa: E402
+
+
+class TestValuesEquivalent:
+    """Pin the normalization table used by _preflight_set_setting.
+
+    The DB stores settings as TEXT but operators stage them via the
+    wizard as Python-typed values (bool, int, etc.).  Naive ``str()``
+    comparison would either hide real type mismatches or surface false
+    diffs; ``values_equivalent`` collapses common equivalent forms.
+    """
+
+    # ---- Equivalence cases (must be True) -------------------------------
+
+    @pytest.mark.parametrize(
+        ("current", "proposed"),
+        [
+            (None, None),
+            ("", None),
+            ("None", None),
+            ("null", None),
+            ("  ", None),
+            (True, "true"),
+            (True, "True"),
+            (True, "1"),
+            (True, "yes"),
+            (True, "ON"),
+            (False, "false"),
+            (False, "0"),
+            (False, "no"),
+            (False, "off"),
+            (1, "1"),
+            (100, "100"),
+            (0, "0"),
+            ("abc", "ABC"),
+            ("abc", " abc "),
+        ],
+    )
+    def test_equivalent_pairs(self, current, proposed):
+        assert values_equivalent(current, proposed) is True, (
+            f"{current!r} should compare equal to {proposed!r}"
+        )
+        # Must be symmetric.
+        assert values_equivalent(proposed, current) is True, (
+            f"Equality must be symmetric: {proposed!r} vs {current!r}"
+        )
+
+    # ---- Type-sensitive mismatches (must be False) ----------------------
+
+    @pytest.mark.parametrize(
+        ("current", "proposed"),
+        [
+            # Note: "" → None is *intentionally equivalent* (the DB
+            # layer stores unset values as the empty string for some
+            # keys).  See test_equivalent_pairs above.
+            (None, "abc"),
+            (True, False),
+            (True, "garbage"),
+            (1, 2),
+            (1, "2"),
+            ("abc", "def"),
+            (None, 0),  # None != 0 — different observable state
+            (None, False),  # None != False — distinct unset vs unchecked
+        ],
+    )
+    def test_type_sensitive_mismatches(self, current, proposed):
+        assert values_equivalent(current, proposed) is False, (
+            f"{current!r} must NOT compare equal to {proposed!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# PR-04a (review fix) — preflight set_setting normalized comparison
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightSetSettingNormalized:
+    """Integration: _preflight_set_setting consumes values_equivalent."""
+
+    @pytest.mark.asyncio
+    async def test_bool_true_vs_string_true_is_noop(self):
+        op = SetupOperation(
+            kind="set_setting",
+            subsystem="logging",
+            setting_name="enabled",
+            value=True,
+        )
+        with patch("utils.db.get_setting", new=AsyncMock(return_value="true")):
+            entries = await preflight_operations([op], guild=_guild())
+        assert entries[0].would_change is False
+
+    @pytest.mark.asyncio
+    async def test_int_vs_string_int_is_noop(self):
+        op = SetupOperation(
+            kind="set_setting",
+            subsystem="xp",
+            setting_name="threshold",
+            value=100,
+        )
+        with patch("utils.db.get_setting", new=AsyncMock(return_value="100")):
+            entries = await preflight_operations([op], guild=_guild())
+        assert entries[0].would_change is False
+
+    @pytest.mark.asyncio
+    async def test_empty_string_vs_none_is_noop(self):
+        op = SetupOperation(
+            kind="set_setting",
+            subsystem="logging",
+            setting_name="channel",
+            value=None,
+        )
+        with patch("utils.db.get_setting", new=AsyncMock(return_value="")):
+            entries = await preflight_operations([op], guild=_guild())
+        assert entries[0].would_change is False
+
+    @pytest.mark.asyncio
+    async def test_real_type_change_still_detected(self):
+        """``True`` → ``False`` (or string-equivalents) MUST surface."""
+        op = SetupOperation(
+            kind="set_setting",
+            subsystem="logging",
+            setting_name="enabled",
+            value=False,
+        )
+        with patch("utils.db.get_setting", new=AsyncMock(return_value="true")):
+            entries = await preflight_operations([op], guild=_guild())
+        assert entries[0].would_change is True
+
+    @pytest.mark.asyncio
+    async def test_int_to_different_int_still_detected(self):
+        op = SetupOperation(
+            kind="set_setting",
+            subsystem="xp",
+            setting_name="threshold",
+            value=200,
+        )
+        with patch("utils.db.get_setting", new=AsyncMock(return_value="100")):
+            entries = await preflight_operations([op], guild=_guild())
+        assert entries[0].would_change is True
+
+    @pytest.mark.asyncio
+    async def test_string_change_detected(self):
+        op = SetupOperation(
+            kind="set_setting",
+            subsystem="logging",
+            setting_name="prefix",
+            value="warn",
+        )
+        with patch("utils.db.get_setting", new=AsyncMock(return_value="info")):
+            entries = await preflight_operations([op], guild=_guild())
+        assert entries[0].would_change is True
+
+    @pytest.mark.asyncio
+    async def test_missing_current_value_marks_change(self):
+        """None current vs concrete proposed = change."""
+        op = SetupOperation(
+            kind="set_setting",
+            subsystem="logging",
+            setting_name="channel",
+            value="123456",
+        )
+        with patch("utils.db.get_setting", new=AsyncMock(return_value=None)):
+            entries = await preflight_operations([op], guild=_guild())
+        assert entries[0].would_change is True
+
+    @pytest.mark.asyncio
+    async def test_multi_op_batch_evaluates_each_independently(self):
+        """A no-op and a real change in the same batch render
+        differently; the normalizer is per-entry."""
+        noop = SetupOperation(
+            kind="set_setting",
+            subsystem="xp",
+            setting_name="threshold",
+            value=100,
+        )
+        change = SetupOperation(
+            kind="set_setting",
+            subsystem="logging",
+            setting_name="enabled",
+            value=False,
+        )
+
+        # Distinct return values for distinct settings; the side_effect
+        # is invoked once per get_setting call.
+        async def fake_get_setting(_gid, key):
+            return {
+                "xp.threshold": "100",
+                "logging.enabled": "true",
+            }[key]
+
+        with patch("utils.db.get_setting", side_effect=fake_get_setting):
+            entries = await preflight_operations([noop, change], guild=_guild())
+        assert entries[0].would_change is False
+        assert entries[1].would_change is True

--- a/tests/unit/services/test_setup_change_plan.py
+++ b/tests/unit/services/test_setup_change_plan.py
@@ -1,0 +1,307 @@
+"""Unit tests for services.setup_change_plan + preflight_operations — PR-04a."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.setup_change_plan import (
+    ABSENT,
+    UNKNOWN,
+    ChangePlanEntry,
+    ChangeValue,
+)
+from services.setup_operations import (
+    SetupOperation,
+    is_preflight_enabled,
+    preflight_operations,
+)
+
+# ---------------------------------------------------------------------------
+# ChangeValue / sentinels
+# ---------------------------------------------------------------------------
+
+
+class TestChangeValue:
+    def test_value_kind_default(self):
+        cv = ChangeValue(kind="value", value=42)
+        assert cv.kind == "value"
+        assert cv.value == 42
+        assert repr(cv) == "42"
+
+    def test_absent_singleton_repr(self):
+        assert ABSENT.kind == "absent"
+        assert "ABSENT" in repr(ABSENT)
+
+    def test_unknown_singleton_repr(self):
+        assert UNKNOWN.kind == "unknown"
+        assert "UNKNOWN" in repr(UNKNOWN)
+
+    def test_default_kind_is_value(self):
+        cv = ChangeValue()
+        assert cv.kind == "value"
+        assert cv.value is None
+
+
+# ---------------------------------------------------------------------------
+# Feature flag toggle
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightFlag:
+    def test_disabled_by_default(self):
+        with patch.dict("os.environ", {}, clear=False):
+            # Ensure the env var is not set in this test.
+            import os
+
+            os.environ.pop("SETUP_PREFLIGHT_DIFF", None)
+            assert is_preflight_enabled() is False
+
+    @pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on"])
+    def test_truthy_values_enable(self, val: str):
+        with patch.dict("os.environ", {"SETUP_PREFLIGHT_DIFF": val}):
+            assert is_preflight_enabled() is True
+
+    @pytest.mark.parametrize("val", ["", "0", "no", "off", "garbage"])
+    def test_other_values_keep_disabled(self, val: str):
+        with patch.dict("os.environ", {"SETUP_PREFLIGHT_DIFF": val}):
+            assert is_preflight_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# preflight_operations — per-op-kind diff coverage
+# ---------------------------------------------------------------------------
+
+
+def _guild(gid: int = 100) -> SimpleNamespace:
+    return SimpleNamespace(id=gid)
+
+
+@pytest.mark.asyncio
+async def test_preflight_bind_channel_existing_match_no_change():
+    op = SetupOperation(
+        kind="bind_channel",
+        subsystem="logging",
+        binding_name="mod_channel",
+        target_id=42,
+        target_kind="channel",
+    )
+    fake_row = {"target_id": 42, "status": "bound", "kind": "channel"}
+    with patch(
+        "utils.db.bindings.get_one",
+        new=AsyncMock(return_value=fake_row),
+    ):
+        entries = await preflight_operations([op], guild=_guild())
+    assert len(entries) == 1
+    e = entries[0]
+    assert e.current.kind == "value"
+    assert e.current.value == 42
+    assert e.proposed.value == 42
+    assert e.would_change is False
+    assert e.read_error is None
+
+
+@pytest.mark.asyncio
+async def test_preflight_bind_channel_existing_different_target_changes():
+    op = SetupOperation(
+        kind="bind_channel",
+        subsystem="logging",
+        binding_name="mod_channel",
+        target_id=99,
+        target_kind="channel",
+    )
+    fake_row = {"target_id": 42, "status": "bound", "kind": "channel"}
+    with patch(
+        "utils.db.bindings.get_one",
+        new=AsyncMock(return_value=fake_row),
+    ):
+        entries = await preflight_operations([op], guild=_guild())
+    assert entries[0].would_change is True
+    assert entries[0].current.value == 42
+    assert entries[0].proposed.value == 99
+
+
+@pytest.mark.asyncio
+async def test_preflight_bind_channel_absent_current_marks_change():
+    op = SetupOperation(
+        kind="bind_channel",
+        subsystem="logging",
+        binding_name="mod_channel",
+        target_id=99,
+    )
+    with patch(
+        "utils.db.bindings.get_one",
+        new=AsyncMock(return_value=None),
+    ):
+        entries = await preflight_operations([op], guild=_guild())
+    assert entries[0].current.kind == "absent"
+    assert entries[0].would_change is True
+
+
+@pytest.mark.asyncio
+async def test_preflight_bind_read_error_isolated_to_entry():
+    """A raising adapter populates read_error; the batch continues."""
+    op_bad = SetupOperation(
+        kind="bind_channel",
+        subsystem="logging",
+        binding_name="mod_channel",
+        target_id=1,
+    )
+    op_good = SetupOperation(
+        kind="bind_role",
+        subsystem="logging",
+        binding_name="mod_role",
+        target_id=2,
+    )
+    call_count = {"n": 0}
+
+    async def flaky(*args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError("db down")
+        return None
+
+    with patch("utils.db.bindings.get_one", side_effect=flaky):
+        entries = await preflight_operations([op_bad, op_good], guild=_guild())
+    assert len(entries) == 2
+    assert entries[0].read_error is not None
+    assert "RuntimeError" in entries[0].read_error
+    assert entries[1].read_error is None
+
+
+@pytest.mark.asyncio
+async def test_preflight_clear_binding_existing_row_changes():
+    op = SetupOperation(
+        kind="clear_binding",
+        subsystem="logging",
+        binding_name="mod_channel",
+    )
+    fake_row = {"target_id": 42, "status": "bound", "kind": "channel"}
+    with patch(
+        "utils.db.bindings.get_one",
+        new=AsyncMock(return_value=fake_row),
+    ):
+        entries = await preflight_operations([op], guild=_guild())
+    e = entries[0]
+    assert e.current.value == 42
+    assert e.proposed.kind == "absent"
+    assert e.would_change is True
+
+
+@pytest.mark.asyncio
+async def test_preflight_clear_binding_absent_row_is_noop():
+    op = SetupOperation(
+        kind="clear_binding",
+        subsystem="logging",
+        binding_name="mod_channel",
+    )
+    with patch(
+        "utils.db.bindings.get_one",
+        new=AsyncMock(return_value=None),
+    ):
+        entries = await preflight_operations([op], guild=_guild())
+    assert entries[0].current.kind == "absent"
+    assert entries[0].proposed.kind == "absent"
+    assert entries[0].would_change is False
+
+
+@pytest.mark.asyncio
+async def test_preflight_set_setting_equal_value_is_noop():
+    op = SetupOperation(
+        kind="set_setting",
+        subsystem="xp",
+        setting_name="threshold",
+        value="100",
+    )
+    with patch(
+        "utils.db.get_setting",
+        new=AsyncMock(return_value="100"),
+    ):
+        entries = await preflight_operations([op], guild=_guild())
+    assert entries[0].current.value == "100"
+    assert entries[0].would_change is False
+
+
+@pytest.mark.asyncio
+async def test_preflight_set_setting_different_value_changes():
+    op = SetupOperation(
+        kind="set_setting",
+        subsystem="xp",
+        setting_name="threshold",
+        value="200",
+    )
+    with patch(
+        "utils.db.get_setting",
+        new=AsyncMock(return_value="100"),
+    ):
+        entries = await preflight_operations([op], guild=_guild())
+    assert entries[0].would_change is True
+
+
+@pytest.mark.asyncio
+async def test_preflight_set_cog_routing_equal_is_noop():
+    op = SetupOperation(
+        kind="set_cog_routing",
+        subsystem="economy",
+        target_id=12345,
+        value=True,
+    )
+    with patch(
+        "services.command_routing.is_cog_enabled",
+        new=AsyncMock(return_value=True),
+    ):
+        entries = await preflight_operations([op], guild=_guild())
+    assert entries[0].would_change is False
+
+
+@pytest.mark.asyncio
+async def test_preflight_unknown_kind_marks_no_adapter():
+    op = SetupOperation(kind="bogus_kind", subsystem="logging")
+    entries = await preflight_operations([op], guild=_guild())
+    assert entries[0].preflight_skipped_reason == "unknown_op_kind"
+
+
+@pytest.mark.asyncio
+async def test_preflight_create_channel_marks_no_adapter():
+    op = SetupOperation(
+        kind="create_channel",
+        subsystem="logging",
+        resource_name="mod-log",
+    )
+    entries = await preflight_operations([op], guild=_guild())
+    assert entries[0].preflight_skipped_reason == "no_adapter"
+    assert entries[0].current.kind == "absent"
+
+
+@pytest.mark.asyncio
+async def test_preflight_propagates_risk_and_rollback_metadata():
+    op = SetupOperation(
+        kind="set_setting",
+        subsystem="xp",
+        setting_name="threshold",
+        value="100",
+        metadata={
+            "risk": "high",
+            "rollback_note": "revert to legacy default",
+        },
+    )
+    with patch("utils.db.get_setting", new=AsyncMock(return_value="100")):
+        entries = await preflight_operations([op], guild=_guild())
+    assert entries[0].risk == "high"
+    assert entries[0].rollback_note == "revert to legacy default"
+
+
+@pytest.mark.asyncio
+async def test_preflight_entry_carries_op_back():
+    op = SetupOperation(
+        kind="bind_channel",
+        subsystem="logging",
+        binding_name="mod_channel",
+        target_id=1,
+    )
+    with patch("utils.db.bindings.get_one", new=AsyncMock(return_value=None)):
+        entries = await preflight_operations([op], guild=_guild())
+    assert entries[0].op is op
+    assert entries[0].label  # non-empty


### PR DESCRIPTION
## Summary

Additive read-only preflight that produces a current/proposed diff per `SetupOperation` without touching the apply path. Gated behind the `SETUP_PREFLIGHT_DIFF` env flag (default off in PR-04a; PR-04b flips the default after a clean canary).

Part of the SuperBot 2.0 refactor plan (see `/root/.claude/plans/1-recommended-target-agent-zazzy-eclipse.md`).

**Depends on PR-03 (#249)** — extends the same dispatcher and lives under the same invariant umbrella.

## What changes

### New module `disbot/services/setup_change_plan.py`

- `RiskLevel` + `ChangeValueKind` Literal types
- `ChangeValue` wrapper over (value, absent, unknown) sentinels — used in both `current` and `proposed` fields so the renderer can distinguish "no current value" from "value None"
- `ChangePlanEntry` frozen dataclass: `op`, `label`, `current`, `proposed`, `would_change`, `risk`, `rollback_note`, `affected`, `read_error`, `preflight_skipped_reason`
- `ABSENT` / `UNKNOWN` module-level sentinel singletons

### `services/setup_operations.py`

- `is_preflight_enabled()` — reads `SETUP_PREFLIGHT_DIFF` env var. Default off; consumers fall through to validation-only `preview_operations`.
- `async preflight_operations(ops, *, guild)` returning `list[ChangePlanEntry]`. **Real DB reads** for the most common op kinds:
  - `bind_*` / `clear_binding` → `utils.db.bindings.get_one`
  - `set_setting` → `utils.db.get_setting`
  - `set_cog_routing` → `services.command_routing.is_cog_enabled`
  - `create_*` / automation / cleanup → `preflight_skipped_reason="no_adapter"` with a sensible `current` (ABSENT for create) so the renderer can label them
- **Per-adapter exception isolation**: a read failure populates `read_error` with a `type:message` string; the rest of the batch continues.
- `preview_operations` stays as the sync fast path. **Apply behaviour is unchanged.**

## Read-only invariant

`tests/unit/invariants/test_setup_preflight_readonly.py` walks every preflight function AST and asserts:
- No call to a mutation method (`set_binding`, `set_value`, `set_policy`, `create_*`, `upsert_with_audit`, etc.)
- No `transaction()` opening
- Module-scope mutation-pipeline imports remain forbidden

A future "heavy adapter" should set `preflight_skipped_reason="heavy"` rather than write to the DB.

## Test plan

- [x] `tests/unit/services/test_setup_change_plan.py` — 16 cases:
  - ChangeValue construction + sentinel repr
  - `SETUP_PREFLIGHT_DIFF` flag toggle (off by default; truthy values enable)
  - bind_channel/role match-no-change, different-target, absent-current
  - read_error isolation across the batch
  - clear_binding existing-row-changes, absent-row-noop
  - set_setting equal-value-noop, different-value-changes
  - set_cog_routing equal-noop
  - unknown kind → `unknown_op_kind`
  - create_channel → `no_adapter`
  - risk + rollback_note metadata propagation
- [x] `tests/unit/invariants/test_setup_preflight_readonly.py` — 4 AST invariants
- [x] 3812 unit tests pass; ruff / isort / black / mypy all green

## Out of scope (deferred to PR-04b)

- Final Review embed render integration (flag is off; the current sync preview path is preserved)
- Heavy-adapter handling
- Flipping `SETUP_PREFLIGHT_DIFF` default to on

## Dependencies and unlocks

- **Blocked by**: PR-01a (#244), PR-03 (#249)
- **Unlocks**: PR-04b (default-on + Final Review render); future Setup Repair Mode


---
_Generated by [Claude Code](https://claude.ai/code/session_01FZb9tZiTdK1z6WfCzXpXmN)_