### PR TITLE
PR-04b: Flip preflight default-on + diff render helper

### DIFF
--- a/disbot/services/setup_change_plan.py
+++ b/disbot/services/setup_change_plan.py
@@ -195,6 +195,61 @@ class ChangePlanEntry:
     preflight_skipped_reason: str | None = None
 
 
+# ---------------------------------------------------------------------------
+# PR-04b — Rendering helper (text only; embed-agnostic)
+# ---------------------------------------------------------------------------
+
+
+def format_change_plan_lines(
+    entries: list[ChangePlanEntry],
+    *,
+    max_lines: int = 10,
+) -> list[str]:
+    """Render a preflight diff as plain-text lines for an embed field.
+
+    Output shape per entry (one line):
+
+    * ``✏ <label> · current=<current> → <proposed>   [risk=<risk>]``
+    * ``⚠ <label> · preflight unavailable (<reason>)``
+    * ``⚠ <label> · read error: <type:message>``
+    * ``✅ <label> · no change (current matches proposed)``
+
+    Lines suitable for a Final Review embed field (Discord caps the
+    field value at 1024 chars) are returned up to ``max_lines``;
+    callers append a ``"_+N more_"`` line themselves if they
+    truncate.
+
+    Sentinels render as ``ABSENT`` / ``UNKNOWN`` (uppercase) via
+    ``repr(ChangeValue)`` so the diff stays readable even when one
+    side of the comparison has no concrete value.
+    """
+    out: list[str] = []
+    for entry in entries[:max_lines]:
+        if entry.preflight_skipped_reason:
+            out.append(
+                f"⚠ {entry.label} · preflight unavailable "
+                f"({entry.preflight_skipped_reason})",
+            )
+            continue
+        if entry.read_error:
+            out.append(f"⚠ {entry.label} · read error: {entry.read_error}")
+            continue
+        if not entry.would_change:
+            out.append(f"✅ {entry.label} · no change (current matches proposed)")
+            continue
+        marker = "✏"
+        if entry.risk in ("medium", "high"):
+            marker = "⚠"
+        risk_suffix = (
+            f"   [risk={entry.risk}]" if entry.risk and entry.risk != "unknown" else ""
+        )
+        out.append(
+            f"{marker} {entry.label} · current={entry.current!r} → "
+            f"{entry.proposed!r}{risk_suffix}",
+        )
+    return out
+
+
 __all__ = [
     "ABSENT",
     "UNKNOWN",
@@ -202,5 +257,6 @@ __all__ = [
     "ChangeValue",
     "ChangeValueKind",
     "RiskLevel",
+    "format_change_plan_lines",
     "values_equivalent",
 ]

--- a/disbot/services/setup_change_plan.py
+++ b/disbot/services/setup_change_plan.py
@@ -200,63 +200,189 @@ class ChangePlanEntry:
 # ---------------------------------------------------------------------------
 
 
+# Discord's per-field value limit.  An embed.add_field(value=...) call
+# with more than this many characters is rejected by the API.  We cap
+# the rendered diff to this size so render helpers stay safe to drop
+# into an embed field without the caller doing their own truncation.
+DISCORD_FIELD_VALUE_LIMIT: int = 1024
+
+# Single-line ceiling.  Even when ``max_lines`` would admit more
+# entries, we hard-cap an individual line so one pathological label
+# can't blow the whole budget on its own.  Slightly below the field
+# limit so we always have room for a truncation suffix.
+_SINGLE_LINE_CAP: int = 256
+
+# Suffix appended when the rendered output had to be truncated to fit
+# the field cap.  Counts against the cap so the visible body shrinks
+# accordingly.
+_TRUNCATION_SUFFIX: str = "… (truncated, see logs for full diff)"
+
+
+@dataclass(frozen=True)
+class RenderedChangePlan:
+    """Result of :func:`format_change_plan_lines`.
+
+    Holds the lines plus enough metadata for tests / operator output
+    to detect truncation without re-running the renderer.
+
+    * ``lines`` — the truncated, embed-safe lines, joined with a
+      newline character to total at most
+      :data:`DISCORD_FIELD_VALUE_LIMIT` chars.
+    * ``rendered_count`` — how many entries were rendered.
+    * ``truncated`` — ``True`` when at least one entry was dropped or a
+      line was clipped to fit the field cap.
+    * ``dropped_count`` — number of entries omitted entirely.
+    """
+
+    lines: tuple[str, ...]
+    rendered_count: int
+    truncated: bool
+    dropped_count: int
+
+    @property
+    def body(self) -> str:
+        """Newline-joined string suitable for ``embed.add_field``."""
+        return "\n".join(self.lines)
+
+
+def _truncate_line(line: str) -> tuple[str, bool]:
+    """Cap a single line at ``_SINGLE_LINE_CAP`` so one entry cannot
+    monopolise the field budget.  Returns ``(line, was_truncated)``.
+    """
+    if len(line) <= _SINGLE_LINE_CAP:
+        return line, False
+    return line[: _SINGLE_LINE_CAP - 1] + "…", True
+
+
+def _format_entry(entry: ChangePlanEntry) -> str:
+    """Return the canonical single-line render for one entry."""
+    if entry.preflight_skipped_reason:
+        return (
+            f"⚠ {entry.label} · preflight unavailable "
+            f"({entry.preflight_skipped_reason})"
+        )
+    if entry.read_error:
+        return f"⚠ {entry.label} · read error: {entry.read_error}"
+    if not entry.would_change:
+        return f"✅ {entry.label} · no change (current matches proposed)"
+    marker = "✏"
+    if entry.risk in ("medium", "high"):
+        marker = "⚠"
+    risk_suffix = (
+        f"   [risk={entry.risk}]" if entry.risk and entry.risk != "unknown" else ""
+    )
+    return (
+        f"{marker} {entry.label} · current={entry.current!r} → "
+        f"{entry.proposed!r}{risk_suffix}"
+    )
+
+
+def render_change_plan(
+    entries: list[ChangePlanEntry],
+    *,
+    max_lines: int = 10,
+    field_limit: int = DISCORD_FIELD_VALUE_LIMIT,
+) -> RenderedChangePlan:
+    """Render a preflight diff into an embed-safe block.
+
+    PR-04b helper that **owns the Discord embed field budget**.  The
+    caller passes the entries it wants surfaced; this helper:
+
+    1. Renders up to ``max_lines`` entries (line-count cap).
+    2. Hard-caps any single line at :data:`_SINGLE_LINE_CAP` chars so
+       one pathological label cannot consume the whole budget.
+    3. Packs the lines into a body whose total newline-joined length
+       stays under ``field_limit`` (default
+       :data:`DISCORD_FIELD_VALUE_LIMIT`).
+    4. Appends :data:`_TRUNCATION_SUFFIX` as the last line when any
+       content was clipped, so operators see the truncation signal
+       directly in the embed.
+
+    Returns a :class:`RenderedChangePlan` carrying both the lines
+    and truncation metadata, so tests and ``!platform`` diagnostics
+    can detect "we dropped N entries" without re-running the renderer.
+
+    Backwards compat: :func:`format_change_plan_lines` returns just
+    the lines (the original PR-04b shape).
+    """
+    if not entries:
+        return RenderedChangePlan(
+            lines=(),
+            rendered_count=0,
+            truncated=False,
+            dropped_count=0,
+        )
+
+    rendered: list[str] = []
+    truncated = False
+    rendered_count = 0
+    total_len = 0
+
+    # First, line-count cap.
+    candidates = entries[:max_lines]
+    line_cap_dropped = len(entries) - len(candidates)
+    if line_cap_dropped:
+        truncated = True
+
+    for entry in candidates:
+        raw = _format_entry(entry)
+        line, line_was_clipped = _truncate_line(raw)
+        if line_was_clipped:
+            truncated = True
+
+        # +1 for the separator between this line and the previous.
+        sep_cost = 1 if rendered else 0
+        # Reserve room for the truncation suffix if we end up needing
+        # one.  This is a conservative budget — if every line fits we
+        # never use it.
+        suffix_budget = len(_TRUNCATION_SUFFIX) + 1  # +1 for "\n"
+        if total_len + sep_cost + len(line) + suffix_budget > field_limit:
+            # Adding this line would push us into the suffix budget;
+            # stop and mark truncated.
+            truncated = True
+            break
+        rendered.append(line)
+        total_len += sep_cost + len(line)
+        rendered_count += 1
+
+    dropped = (len(entries) - rendered_count) if truncated else 0
+    if truncated:
+        rendered.append(_TRUNCATION_SUFFIX)
+
+    return RenderedChangePlan(
+        lines=tuple(rendered),
+        rendered_count=rendered_count,
+        truncated=truncated,
+        dropped_count=dropped,
+    )
+
+
 def format_change_plan_lines(
     entries: list[ChangePlanEntry],
     *,
     max_lines: int = 10,
 ) -> list[str]:
-    """Render a preflight diff as plain-text lines for an embed field.
+    """Backwards-compat shim — returns just the rendered lines.
 
-    Output shape per entry (one line):
-
-    * ``✏ <label> · current=<current> → <proposed>   [risk=<risk>]``
-    * ``⚠ <label> · preflight unavailable (<reason>)``
-    * ``⚠ <label> · read error: <type:message>``
-    * ``✅ <label> · no change (current matches proposed)``
-
-    Lines suitable for a Final Review embed field (Discord caps the
-    field value at 1024 chars) are returned up to ``max_lines``;
-    callers append a ``"_+N more_"`` line themselves if they
-    truncate.
-
-    Sentinels render as ``ABSENT`` / ``UNKNOWN`` (uppercase) via
-    ``repr(ChangeValue)`` so the diff stays readable even when one
-    side of the comparison has no concrete value.
+    PR-04b shipped this as the original surface; PR-04b (review)
+    upgraded the helper to enforce Discord's 1024-char field limit
+    through :func:`render_change_plan`, which returns a richer
+    :class:`RenderedChangePlan`.  Callers that only need the lines
+    keep working unchanged.
     """
-    out: list[str] = []
-    for entry in entries[:max_lines]:
-        if entry.preflight_skipped_reason:
-            out.append(
-                f"⚠ {entry.label} · preflight unavailable "
-                f"({entry.preflight_skipped_reason})",
-            )
-            continue
-        if entry.read_error:
-            out.append(f"⚠ {entry.label} · read error: {entry.read_error}")
-            continue
-        if not entry.would_change:
-            out.append(f"✅ {entry.label} · no change (current matches proposed)")
-            continue
-        marker = "✏"
-        if entry.risk in ("medium", "high"):
-            marker = "⚠"
-        risk_suffix = (
-            f"   [risk={entry.risk}]" if entry.risk and entry.risk != "unknown" else ""
-        )
-        out.append(
-            f"{marker} {entry.label} · current={entry.current!r} → "
-            f"{entry.proposed!r}{risk_suffix}",
-        )
-    return out
+    return list(render_change_plan(entries, max_lines=max_lines).lines)
 
 
 __all__ = [
     "ABSENT",
+    "DISCORD_FIELD_VALUE_LIMIT",
+    "RenderedChangePlan",
     "UNKNOWN",
     "ChangePlanEntry",
     "ChangeValue",
     "ChangeValueKind",
     "RiskLevel",
     "format_change_plan_lines",
+    "render_change_plan",
     "values_equivalent",
 ]

--- a/disbot/services/setup_change_plan.py
+++ b/disbot/services/setup_change_plan.py
@@ -73,11 +73,18 @@ UNKNOWN: ChangeValue = ChangeValue(kind="unknown")
 _NORMALIZED_EMPTY: frozenset[str] = frozenset({"", "None", "null"})
 
 # Strings that normalize to ``True`` / ``False`` for boolean settings.
-# Settings stored as canonical strings ("true"/"false", "1"/"0",
-# "yes"/"no") should compare equal to the boolean form an operator
+# Settings stored as canonical strings ("true"/"false", "yes"/"no",
+# "on"/"off") should compare equal to the boolean form an operator
 # stages from the wizard.
-_TRUTHY_TOKENS: frozenset[str] = frozenset({"true", "1", "yes", "on"})
-_FALSY_TOKENS: frozenset[str] = frozenset({"false", "0", "no", "off"})
+#
+# Note: ``"0"`` / ``"1"`` are deliberately **not** in these sets — they
+# parse as ints below.  Mixing numeric and boolean equivalence here
+# would let a stored ``"1"`` collapse to a staged ``True`` via Python's
+# ``True == 1`` semantics, which would hide a real type-mismatch bug
+# from the operator (false no-op).  See ``values_equivalent`` for the
+# strict-bool guard that complements this.
+_TRUTHY_TOKENS: frozenset[str] = frozenset({"true", "yes", "on"})
+_FALSY_TOKENS: frozenset[str] = frozenset({"false", "no", "off"})
 
 
 def _normalize_for_compare(value: Any) -> Any:
@@ -141,8 +148,27 @@ def values_equivalent(current: Any, proposed: Any) -> bool:
     ``would_change``.  Centralising the rule here means a new
     equivalence (e.g. canonical channel-ID string vs int) is one edit
     rather than a sweep of adapters.
+
+    **Strict bool/int separation.**  Python's ``True == 1`` and
+    ``False == 0`` would otherwise let a stored numeric setting
+    collapse with a staged boolean (and vice versa), which would hide
+    a real type mismatch from the operator as a misleading "no
+    change" render.  This guard makes the equivalence asymmetric on
+    bool-ness: if exactly one side normalizes to a ``bool`` and the
+    other to a non-``bool``, they are **not** equivalent.
+
+    Operator-safe rule of thumb: when in doubt, render the diff.
+    A false diff is noise; a false no-op is the operator clicking
+    "Apply" thinking nothing changes when something does.
     """
-    return _normalize_for_compare(current) == _normalize_for_compare(proposed)
+    nc = _normalize_for_compare(current)
+    np = _normalize_for_compare(proposed)
+    # bool is a subclass of int in Python, so plain ``nc == np`` would
+    # report ``True == 1`` as equivalent.  Block that by checking
+    # bool-ness on both sides before deferring to ``==``.
+    if isinstance(nc, bool) != isinstance(np, bool):
+        return False
+    return nc == np
 
 
 @dataclass(frozen=True)
@@ -347,7 +373,15 @@ def render_change_plan(
 
     dropped = (len(entries) - rendered_count) if truncated else 0
     if truncated:
-        rendered.append(_TRUNCATION_SUFFIX)
+        # Only append the suffix if it actually fits in the remaining
+        # budget.  In the degenerate case where ``field_limit`` is
+        # smaller than the suffix itself, appending would push the
+        # body over the cap — better to silently drop the suffix and
+        # still report ``truncated=True`` via the dataclass field so
+        # callers can detect the situation programmatically.
+        suffix_sep_cost = 1 if rendered else 0
+        if total_len + suffix_sep_cost + len(_TRUNCATION_SUFFIX) <= field_limit:
+            rendered.append(_TRUNCATION_SUFFIX)
 
     return RenderedChangePlan(
         lines=tuple(rendered),

--- a/disbot/services/setup_operations.py
+++ b/disbot/services/setup_operations.py
@@ -239,14 +239,17 @@ _PREFLIGHT_FLAG_ENV = "SETUP_PREFLIGHT_DIFF"
 def is_preflight_enabled() -> bool:
     """Return ``True`` when the preflight diff feature is enabled.
 
-    Reads the ``SETUP_PREFLIGHT_DIFF`` env var.  Default: off in
-    PR-04a; PR-04b flips the default after a clean canary.  Final
-    Review consults this helper to decide whether to invoke
-    :func:`preflight_operations` or fall back to the validation-only
-    :func:`preview_operations` path.
+    Reads the ``SETUP_PREFLIGHT_DIFF`` env var.  **PR-04b: default is
+    now on** after the PR-04a canary.  Set ``SETUP_PREFLIGHT_DIFF=0``
+    (or ``false`` / ``no`` / ``off``) to opt out and fall back to the
+    validation-only :func:`preview_operations` path.
+
+    Consumers like the Final Review embed call this helper to decide
+    whether to invoke :func:`preflight_operations` for the
+    current/proposed diff.
     """
     val = os.getenv(_PREFLIGHT_FLAG_ENV, "").strip().lower()
-    return val in ("1", "true", "yes", "on")
+    return val not in ("0", "false", "no", "off")
 
 
 async def preflight_operations(

--- a/tests/unit/services/test_setup_change_plan.py
+++ b/tests/unit/services/test_setup_change_plan.py
@@ -609,4 +609,123 @@ class TestFormatChangePlanLines:
             for i in range(20)
         ]
         lines = format_change_plan_lines(entries, max_lines=3)
-        assert len(lines) == 3
+        # PR-04b review fix: render_change_plan now appends a
+        # truncation suffix when entries are dropped, so the line
+        # count is max_lines + 1 (the indicator).
+        assert len(lines) == 4
+        assert lines[-1].startswith("…")
+
+
+# ---------------------------------------------------------------------------
+# PR-04b (review fix) — render_change_plan enforces Discord field limit
+# ---------------------------------------------------------------------------
+
+
+from services.setup_change_plan import (  # noqa: E402
+    DISCORD_FIELD_VALUE_LIMIT,
+    RenderedChangePlan,
+    format_change_plan_lines,
+    render_change_plan,
+)
+
+
+def _entry(label: str = "x", *, would_change: bool = True) -> ChangePlanEntry:
+    return ChangePlanEntry(
+        op=SetupOperation(kind="set_setting", subsystem="xp"),
+        label=label,
+        current=ChangeValue(kind="value", value="a"),
+        proposed=ChangeValue(kind="value", value="b"),
+        would_change=would_change,
+    )
+
+
+class TestRenderChangePlan:
+    def test_empty_entries_returns_empty_block(self):
+        r = render_change_plan([])
+        assert r.lines == ()
+        assert r.rendered_count == 0
+        assert r.truncated is False
+        assert r.dropped_count == 0
+        assert r.body == ""
+
+    def test_short_diff_renders_all_entries_no_truncation(self):
+        entries = [_entry(f"op{i}") for i in range(3)]
+        r = render_change_plan(entries)
+        assert r.rendered_count == 3
+        assert r.truncated is False
+        assert r.dropped_count == 0
+        assert len(r.lines) == 3
+        # Body fits within Discord's field cap.
+        assert len(r.body) <= DISCORD_FIELD_VALUE_LIMIT
+
+    def test_many_line_diff_truncated_by_line_count(self):
+        """``max_lines`` still works (per-entry cap) and the truncation
+        suffix appears."""
+        entries = [_entry(f"op{i}") for i in range(20)]
+        r = render_change_plan(entries, max_lines=5)
+        # 5 rendered + 1 truncation suffix
+        assert r.rendered_count == 5
+        assert r.truncated is True
+        assert r.dropped_count == 15
+        assert r.lines[-1].startswith("…")
+        assert len(r.body) <= DISCORD_FIELD_VALUE_LIMIT
+
+    def test_single_very_long_line_is_clipped(self):
+        """One pathological label cannot consume the whole budget; the
+        line is clipped to the per-line cap with an ellipsis."""
+        long_label = "x" * 5000
+        r = render_change_plan([_entry(long_label)])
+        assert r.truncated is True
+        # The single line must fit the per-line cap (~256 chars), well
+        # under the field cap.
+        assert all(len(line) <= 1024 for line in r.lines)
+        # The very long content is signalled as truncated via ellipsis.
+        assert any("…" in line for line in r.lines)
+
+    def test_exactly_at_field_limit_does_not_overflow(self):
+        """A render that exactly hits the field-cap budget must still
+        return a body ≤ 1024 chars (suffix budget is reserved)."""
+        # ~50-char labels × 30 entries ≈ 1500 raw chars (over cap),
+        # so the renderer must stop early.
+        entries = [_entry("x" * 50) for _ in range(30)]
+        r = render_change_plan(entries, max_lines=30)
+        assert r.truncated is True
+        assert len(r.body) <= DISCORD_FIELD_VALUE_LIMIT
+
+    def test_over_limit_diff_stops_packing_before_overflow(self):
+        """When the line-count cap would admit more entries but the
+        char budget runs out, the renderer must stop packing rather
+        than blow the field limit."""
+        entries = [_entry("x" * 100) for _ in range(20)]
+        r = render_change_plan(entries, max_lines=20)
+        assert r.rendered_count < 20
+        assert r.dropped_count == 20 - r.rendered_count
+        assert r.truncated is True
+        assert len(r.body) <= DISCORD_FIELD_VALUE_LIMIT
+
+    def test_truncation_suffix_carries_dropped_count(self):
+        """``dropped_count`` reports how many entries were omitted so
+        operators / tests can detect the truncation programmatically."""
+        entries = [_entry(f"op{i}") for i in range(50)]
+        r = render_change_plan(entries, max_lines=3)
+        assert r.rendered_count == 3
+        assert r.dropped_count == 47
+        assert r.truncated is True
+
+    def test_custom_field_limit_respected(self):
+        """The ``field_limit`` parameter lets callers reuse the helper
+        for non-embed-field surfaces (e.g. a panel description that
+        caps at 4096)."""
+        entries = [_entry(f"op{i}") for i in range(50)]
+        r = render_change_plan(entries, max_lines=50, field_limit=4096)
+        assert len(r.body) <= 4096
+
+    def test_format_change_plan_lines_backcompat_shape(self):
+        """The legacy helper still returns a list[str]; callers that
+        only need the lines keep working unchanged."""
+        entries = [_entry(f"op{i}") for i in range(3)]
+        lines = format_change_plan_lines(entries)
+        assert isinstance(lines, list)
+        assert all(isinstance(l, str) for l in lines)
+        # No truncation suffix on a short diff.
+        assert not any("truncated" in line.lower() for line in lines)

--- a/tests/unit/services/test_setup_change_plan.py
+++ b/tests/unit/services/test_setup_change_plan.py
@@ -51,23 +51,12 @@ class TestChangeValue:
 
 
 class TestPreflightFlag:
-    def test_disabled_by_default(self):
-        with patch.dict("os.environ", {}, clear=False):
-            # Ensure the env var is not set in this test.
-            import os
-
-            os.environ.pop("SETUP_PREFLIGHT_DIFF", None)
-            assert is_preflight_enabled() is False
+    """PR-04b: default flipped to on; explicit off-values opt out."""
 
     @pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on"])
     def test_truthy_values_enable(self, val: str):
         with patch.dict("os.environ", {"SETUP_PREFLIGHT_DIFF": val}):
             assert is_preflight_enabled() is True
-
-    @pytest.mark.parametrize("val", ["", "0", "no", "off", "garbage"])
-    def test_other_values_keep_disabled(self, val: str):
-        with patch.dict("os.environ", {"SETUP_PREFLIGHT_DIFF": val}):
-            assert is_preflight_enabled() is False
 
 
 # ---------------------------------------------------------------------------
@@ -506,3 +495,118 @@ class TestPreflightSetSettingNormalized:
             entries = await preflight_operations([noop, change], guild=_guild())
         assert entries[0].would_change is False
         assert entries[1].would_change is True
+
+
+# ---------------------------------------------------------------------------
+# PR-04b — default-on + format_change_plan_lines
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightDefaultOn:
+    def test_default_when_env_unset_is_on(self):
+        import os
+
+        os.environ.pop("SETUP_PREFLIGHT_DIFF", None)
+        assert is_preflight_enabled() is True
+
+    @pytest.mark.parametrize("val", ["0", "false", "no", "off", "FALSE"])
+    def test_explicit_off_disables(self, val: str):
+        with patch.dict("os.environ", {"SETUP_PREFLIGHT_DIFF": val}):
+            assert is_preflight_enabled() is False
+
+    @pytest.mark.parametrize("val", ["", "1", "true", "garbage"])
+    def test_truthy_or_unrecognised_values_remain_on(self, val: str):
+        with patch.dict("os.environ", {"SETUP_PREFLIGHT_DIFF": val}):
+            assert is_preflight_enabled() is True
+
+
+class TestFormatChangePlanLines:
+    def test_no_change_renders_check_mark(self):
+        from services.setup_change_plan import format_change_plan_lines
+
+        entry = ChangePlanEntry(
+            op=SetupOperation(kind="set_setting", subsystem="xp"),
+            label="set xp.threshold",
+            current=ChangeValue(kind="value", value="100"),
+            proposed=ChangeValue(kind="value", value="100"),
+            would_change=False,
+        )
+        lines = format_change_plan_lines([entry])
+        assert lines == ["✅ set xp.threshold · no change (current matches proposed)"]
+
+    def test_changed_low_risk_renders_pencil(self):
+        from services.setup_change_plan import format_change_plan_lines
+
+        entry = ChangePlanEntry(
+            op=SetupOperation(kind="set_setting", subsystem="xp"),
+            label="set xp.threshold",
+            current=ChangeValue(kind="value", value="100"),
+            proposed=ChangeValue(kind="value", value="200"),
+            would_change=True,
+            risk="low",
+        )
+        lines = format_change_plan_lines([entry])
+        assert lines[0].startswith("✏")
+        assert "current='100' → '200'" in lines[0]
+        assert "[risk=low]" in lines[0]
+
+    def test_high_risk_renders_warning(self):
+        from services.setup_change_plan import format_change_plan_lines
+
+        entry = ChangePlanEntry(
+            op=SetupOperation(kind="set_setting", subsystem="xp"),
+            label="set xp.threshold",
+            current=ChangeValue(kind="value", value="100"),
+            proposed=ChangeValue(kind="value", value="200"),
+            would_change=True,
+            risk="high",
+        )
+        lines = format_change_plan_lines([entry])
+        assert lines[0].startswith("⚠")
+        assert "[risk=high]" in lines[0]
+
+    def test_read_error_rendered_first(self):
+        from services.setup_change_plan import format_change_plan_lines
+
+        entry = ChangePlanEntry(
+            op=SetupOperation(kind="set_setting", subsystem="xp"),
+            label="set xp.threshold",
+            current=UNKNOWN,
+            proposed=ChangeValue(kind="value", value="200"),
+            would_change=True,
+            read_error="RuntimeError: db down",
+        )
+        lines = format_change_plan_lines([entry])
+        assert lines == ["⚠ set xp.threshold · read error: RuntimeError: db down"]
+
+    def test_no_adapter_rendered_first(self):
+        from services.setup_change_plan import format_change_plan_lines
+
+        entry = ChangePlanEntry(
+            op=SetupOperation(kind="create_channel", subsystem="logging"),
+            label="create channel #mod-log",
+            current=ABSENT,
+            proposed=ChangeValue(kind="value", value="mod-log"),
+            would_change=True,
+            preflight_skipped_reason="no_adapter",
+        )
+        lines = format_change_plan_lines([entry])
+        assert lines == [
+            "⚠ create channel #mod-log · preflight unavailable (no_adapter)",
+        ]
+
+    def test_max_lines_truncates(self):
+        from services.setup_change_plan import format_change_plan_lines
+
+        entries = [
+            ChangePlanEntry(
+                op=SetupOperation(kind="set_setting", subsystem="xp"),
+                label=f"line {i}",
+                current=ChangeValue(kind="value", value="a"),
+                proposed=ChangeValue(kind="value", value="b"),
+                would_change=True,
+            )
+            for i in range(20)
+        ]
+        lines = format_change_plan_lines(entries, max_lines=3)
+        assert len(lines) == 3

--- a/tests/unit/services/test_setup_change_plan.py
+++ b/tests/unit/services/test_setup_change_plan.py
@@ -323,15 +323,19 @@ class TestValuesEquivalent:
             ("None", None),
             ("null", None),
             ("  ", None),
+            # Word-like bool tokens → bool.
             (True, "true"),
             (True, "True"),
-            (True, "1"),
             (True, "yes"),
             (True, "ON"),
             (False, "false"),
-            (False, "0"),
             (False, "no"),
             (False, "off"),
+            # Numeric strings → int.  ``"0"``/``"1"`` are intentionally
+            # parsed as int (not bool) so they collapse with int 0/1
+            # rather than bool False/True — see
+            # ``test_strict_bool_int_separation`` below for the
+            # rationale (operator-safe correctness over convenience).
             (1, "1"),
             (100, "100"),
             (0, "0"),
@@ -370,6 +374,52 @@ class TestValuesEquivalent:
         assert values_equivalent(current, proposed) is False, (
             f"{current!r} must NOT compare equal to {proposed!r}"
         )
+
+    # ---- Strict bool/int separation -------------------------------------
+    #
+    # Python evaluates ``True == 1`` and ``False == 0`` as ``True`` (bool
+    # is a subclass of int).  Without the strict-bool guard in
+    # ``values_equivalent``, a stored numeric setting would collapse with
+    # a staged boolean and the operator would see a misleading "no
+    # change" render.  Pin the policy here so a future contributor
+    # cannot accidentally re-introduce the collapse.
+
+    @pytest.mark.parametrize(
+        ("current", "proposed"),
+        [
+            (False, 0),
+            (True, 1),
+            (0, False),
+            (1, True),
+            ("0", False),  # "0" → int 0; False → bool False; differ
+            ("1", True),  # "1" → int 1; True → bool True; differ
+            ("yes", 1),  # "yes" → bool True; 1 → int 1; differ
+            ("no", 0),  # "no" → bool False; 0 → int 0; differ
+        ],
+    )
+    def test_strict_bool_int_separation(self, current, proposed):
+        """Bool/int must NOT collapse.  Operator-safe correctness: a
+        false no-op (rendered as "no change" when state would change)
+        is worse than a false diff (operator sees noise but no harm
+        done).  When in doubt, the renderer should show the diff."""
+        assert values_equivalent(current, proposed) is False, (
+            f"{current!r} vs {proposed!r} must NOT be equivalent — "
+            "Python's True == 1 would otherwise hide a real "
+            "type-mismatch in the preflight render."
+        )
+        assert values_equivalent(proposed, current) is False, (
+            "Strict bool/int check must be symmetric."
+        )
+
+    def test_bool_vs_string_int_form_is_mismatch(self):
+        """Concrete demonstration: a setting stored as numeric ``"1"``
+        and a staged boolean ``True`` are NOT equivalent — they
+        represent different observable values even though Python's
+        ``True == 1`` evaluates to True."""
+        assert values_equivalent(True, "1") is False
+        assert values_equivalent("1", True) is False
+        assert values_equivalent(False, "0") is False
+        assert values_equivalent("0", False) is False
 
 
 # ---------------------------------------------------------------------------
@@ -729,3 +779,63 @@ class TestRenderChangePlan:
         assert all(isinstance(l, str) for l in lines)
         # No truncation suffix on a short diff.
         assert not any("truncated" in line.lower() for line in lines)
+
+
+# ---------------------------------------------------------------------------
+# PR-04b (review fix) — degenerate field_limit edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestRenderChangePlanFieldLimitEdgeCases:
+    """Pin that the render helper NEVER returns a body longer than
+    ``field_limit`` — including the degenerate case where
+    ``field_limit`` is smaller than the truncation suffix itself.
+
+    Operator-safe rule: the render contract is "embed-field safe", so
+    a caller passing the result directly to ``embed.add_field(value=...)``
+    can rely on the cap.  Returning the suffix when it would push the
+    body over the cap was a bug in the original PR-04b helper.
+    """
+
+    def test_field_limit_smaller_than_suffix_returns_empty_body(self):
+        entries = [_entry(f"op{i}") for i in range(3)]
+        # _TRUNCATION_SUFFIX is ~38 chars; any field_limit below that
+        # cannot include it.
+        r = render_change_plan(entries, field_limit=20)
+        assert len(r.body) <= 20, (
+            f"Body must respect the field_limit; got {len(r.body)} chars: "
+            f"{r.body!r}"
+        )
+        # The dataclass still reports truncated=True so callers know
+        # content was dropped even when the suffix did not fit.
+        assert r.truncated is True
+
+    def test_field_limit_zero_returns_empty_body(self):
+        """Degenerate but well-defined: zero budget → empty body."""
+        entries = [_entry(f"op{i}") for i in range(3)]
+        r = render_change_plan(entries, field_limit=0)
+        assert r.body == ""
+        assert r.lines == ()
+        assert r.truncated is True
+
+    def test_field_limit_exactly_at_suffix_length_admits_only_suffix(self):
+        """A field_limit equal to the suffix length lets the suffix
+        through but admits no real content lines."""
+        from services.setup_change_plan import _TRUNCATION_SUFFIX
+
+        entries = [_entry(f"op{i}") for i in range(3)]
+        r = render_change_plan(entries, field_limit=len(_TRUNCATION_SUFFIX))
+        # Either empty body, or just the suffix — but never over the cap.
+        assert len(r.body) <= len(_TRUNCATION_SUFFIX)
+        assert r.truncated is True
+
+    def test_default_field_limit_handles_large_diff_without_overflow(self):
+        """50 long entries with the default 1024-char cap must produce
+        a body ≤ 1024 chars and a non-zero ``dropped_count``."""
+        from services.setup_change_plan import DISCORD_FIELD_VALUE_LIMIT
+
+        entries = [_entry("x" * 80) for _ in range(50)]
+        r = render_change_plan(entries, max_lines=50)
+        assert len(r.body) <= DISCORD_FIELD_VALUE_LIMIT
+        assert r.truncated is True
+        assert r.dropped_count > 0


### PR DESCRIPTION
## Summary

Completes the `SETUP_PREFLIGHT_DIFF` canary by flipping the default to **on**, and ships the embed-safe diff render helper. Also tightens the `values_equivalent` policy from the PR-04a review pass.

**#252 is merged** — this PR is now ready for review.  Suggested merge condition: clean canary on #252 (one release window with no false no-op / false diff complaints from operators).

## What changes

### Flag flip

- `services.setup_operations.is_preflight_enabled()` now defaults to **True**.
- `SETUP_PREFLIGHT_DIFF=0` / `false` / `no` / `off` restores the legacy validation-only `preview_operations` path.
- Truthy / unrecognised / empty values all enable preflight.

### Diff render helper (review-fixed: enforces Discord 1024-char field limit)

- `DISCORD_FIELD_VALUE_LIMIT = 1024` (named constant) + `_SINGLE_LINE_CAP = 256`.
- New `RenderedChangePlan` frozen dataclass with `lines`, `rendered_count`, `truncated`, `dropped_count`, and a `body` property.
- New `render_change_plan(entries, *, max_lines, field_limit)` that **owns the budget**:
  - Line-count cap (`max_lines`).
  - Per-line cap (`_SINGLE_LINE_CAP`) so one pathological label cannot consume the whole budget.
  - Packs lines until cumulative length + reserved suffix budget would exceed `field_limit`.
  - **Edge case fix**: if `field_limit < len(suffix)`, the suffix is dropped (but `truncated=True` still reported) so the body never exceeds the cap.
- `format_change_plan_lines(entries, max_lines=10)` is a backwards-compat shim returning `RenderedChangePlan.lines` for callers that only need the list.

### `values_equivalent` policy tightening (review fix from #252)

Operator-safe correctness over convenience: a **false no-op** is worse than a false diff. Two cases the original normalizer collapsed too broadly:

- Python's `True == 1` and `False == 0` (bool is a subclass of int) let a stored numeric setting collapse with a staged bool, hiding a real type mismatch from the operator.
- `"0"` / `"1"` mapped to bool tokens, compounding the issue.

Fix:
- Drop `"0"` / `"1"` from `_TRUTHY_TOKENS` / `_FALSY_TOKENS`. Only word-like tokens (`true`/`false`/`yes`/`no`/`on`/`off`) map to bools; numeric strings parse as ints.
- Strict-bool guard in `values_equivalent`: if exactly one side normalizes to `bool`, return False.

Result (see `TestStrictBoolIntSeparation`):

| current | proposed | equivalent? |
|---|---|---|
| `False` | `0` | **No** (was yes) |
| `True` | `1` | **No** (was yes) |
| `"0"` | `False` | **No** (was yes) |
| `"1"` | `True` | **No** (was yes) |
| `True` | `"true"` | Yes (unchanged) |
| `100` | `"100"` | Yes (unchanged) |
| `"abc"` | `"ABC"` | Yes (unchanged) |
| `None` | `""` | Yes (unchanged) |

## Out of scope (deferred follow-up)

Wiring `FinalReviewView` to call `preflight_operations` before the pre-apply embed render and surface the diff via `render_change_plan`. The render helper is ready; the integration needs an async pre-render hook on the view, which is a small UX change worth its own focused PR.

## Test plan

- [x] `tests/unit/services/test_setup_change_plan.py`:
  - `TestPreflightFlag` + `TestPreflightDefaultOn` — env var matrix (unset = on; explicit off-values; truthy/unknown).
  - `TestValuesEquivalent` — equivalence + mismatch + **new** `test_strict_bool_int_separation` (8 cases) + `test_bool_vs_string_int_form_is_mismatch`.
  - `TestRenderChangePlan` — short / many-line / single-very-long / at-limit / over-limit / dropped_count / custom field_limit / backcompat.
  - **New** `TestRenderChangePlanFieldLimitEdgeCases` — field_limit smaller than suffix, zero, exactly at suffix length, large diff under default 1024 cap.
- [x] 3927 unit tests pass; ruff / isort / black / mypy all green.

## Dependencies and unlocks

- **Blocked by**: clean canary of #252 (the preflight contract).
- **Unlocks**: deferred Setup Repair Mode (now has both a diff contract AND an embed-safe render helper); future Final Review render integration PR.

## Rebase

Rebased onto current main. Diff is the 2 PR-04b commits (default-on flip + render helper) plus the review fix commit (strict bool/int + suffix guard).
