### PR TITLE
LP-0: honor LOG_LEVEL env var at boot

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -36,7 +36,10 @@ except ImportError:  # python-json-logger not installed — use stdlib formatter
         "%(asctime)s | %(levelname)s | %(name)s | boot=%(boot_id)s | %(message)s",
     )
 _root = logging.getLogger()
-_root.setLevel(logging.INFO)
+_log_level = getattr(logging, config.LOG_LEVEL, logging.INFO)
+if not isinstance(_log_level, int):
+    _log_level = logging.INFO
+_root.setLevel(_log_level)
 
 _handlers: list[logging.Handler] = [
     logging.handlers.RotatingFileHandler(

--- a/tests/unit/test_bot_boot.py
+++ b/tests/unit/test_bot_boot.py
@@ -116,6 +116,24 @@ def test_bot1_shutdown_drains_via_core_runtime_tasks() -> None:
     )
 
 
+def test_bot1_applies_config_log_level_at_boot() -> None:
+    """LP-0: bot1.py applies ``config.LOG_LEVEL`` to the root logger at
+    boot so the env var matches the runtime behaviour of the
+    ``!loglevel`` operator command at ``cogs/admin_cog.py:329-334``.
+    Invalid values fall back to ``logging.INFO`` so a typo in the env
+    var never blocks startup.
+    """
+    src = _src()
+    assert re.search(r"getattr\(\s*logging\s*,\s*config\.LOG_LEVEL\s*,", src), (
+        "bot1.py must resolve config.LOG_LEVEL via getattr(logging, ...) "
+        "so the LOG_LEVEL env var takes effect at boot (LP-0)."
+    )
+    assert not re.search(r"_root\.setLevel\(\s*logging\.INFO\s*\)", src), (
+        "bot1.py must not hardcode root setLevel to logging.INFO — "
+        "the LOG_LEVEL env var must be honoured (LP-0)."
+    )
+
+
 def test_bot1_shutdown_drain_logs_timeout() -> None:
     """PR-02b (revised): when the 5 s drain budget elapses with tasks
     still pending, a WARNING log must surface so operators see the


### PR DESCRIPTION
## Summary

Resolve `config.LOG_LEVEL` via `getattr(logging, ...)` when configuring
the root logger in `bot1.py`, so operators who set `LOG_LEVEL=DEBUG` see
DEBUG output from the first log record.

Before this change, the env var was read into `config.LOG_LEVEL` but
never applied — the root logger was hardcoded to `INFO`. The
`!loglevel` operator command at `cogs/admin_cog.py:329-334` works fine
at runtime; only the boot-time path was dead.

The resolution matches `!loglevel` exactly: `getattr(logging, name, None)`
+ `isinstance(..., int)` fallback to `logging.INFO`. A typo in the env
var falls back silently instead of blocking startup.

## Why now

This is **LP-0** of the Runtime Lifecycle Plan (see plan at
`.claude/plans/superbot-2-0-agile-duckling.md` if reviewing locally).
It's the one-line warm-up; subsequent LPs build on a working log-level
path so DEBUG output is available when diagnosing them.

## Test plan

- [x] `python -m pytest tests/unit/test_bot_boot.py -v` — 5/5 pass
  (4 existing + the new `test_bot1_applies_config_log_level_at_boot`).
- [x] Full test suite: `python -m pytest tests/ -v` — 3952 passed, 3
  skipped, 0 failures.
- [x] `black --check`, `isort --check-only`, `ruff check`, `mypy` —
  all green on `disbot/bot1.py`.
- [ ] Manual: deploy with `LOG_LEVEL=DEBUG` set and observe DEBUG
  records in `bot.log` and stdout from the first boot line. (Cannot be
  exercised in CI without spinning up the bot.)

## Scope

This PR intentionally does **not** touch:
- the lifecycle state machine (LP-2)
- restart centralisation / `os.execv` removal (LP-3)
- webhook redaction (LP-1)

Each LP ships as a separate small PR per the plan.

https://claude.ai/code/session_01F1dpJ11fmQaQGnWboa78qb

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1dpJ11fmQaQGnWboa78qb)_