### PR TITLE
LP-1: scrub webhook embeds through redaction before send (security)

### DIFF
--- a/disbot/services/webhook_reporter.py
+++ b/disbot/services/webhook_reporter.py
@@ -2,6 +2,11 @@
 
 Extracted from bot1.py so bot startup logic stays lean and this service can
 be tested, replaced, or disabled without touching the entry point.
+
+Every embed is run through :func:`_redact_embed` immediately before
+``wh.send`` so secret-looking substrings (Discord tokens, API keys,
+``postgres://`` URLs, bearer tokens, emails, secret-bearing URL query
+params) are scrubbed before they reach the operator channel.
 """
 
 from __future__ import annotations
@@ -13,7 +18,49 @@ import traceback
 import aiohttp
 import discord
 
+from core.runtime.ai.redaction import redact_text
+
 logger = logging.getLogger("bot.webhook")
+
+
+def _redact_embed(embed: discord.Embed) -> dict[str, int]:
+    """Scrub sensitive substrings from text fields of ``embed`` in place.
+
+    Operates on title, description, every field name + value, footer
+    text, and author name. Returns aggregate replacement counts so
+    callers can observe redactions without re-walking the embed.
+    """
+    counts: dict[str, int] = {}
+
+    def _scrub(text: str) -> str:
+        result = redact_text(text)
+        for key, n in result.replacements.items():
+            counts[key] = counts.get(key, 0) + n
+        return result.value
+
+    if embed.title:
+        embed.title = _scrub(embed.title)
+    if embed.description:
+        embed.description = _scrub(embed.description)
+    for index, field in enumerate(embed.fields):
+        embed.set_field_at(
+            index,
+            name=_scrub(field.name) if field.name else field.name,
+            value=_scrub(field.value) if field.value else field.value,
+            inline=field.inline,
+        )
+    if embed.footer and embed.footer.text:
+        embed.set_footer(
+            text=_scrub(embed.footer.text),
+            icon_url=embed.footer.icon_url,
+        )
+    if embed.author and embed.author.name:
+        embed.set_author(
+            name=_scrub(embed.author.name),
+            url=embed.author.url,
+            icon_url=embed.author.icon_url,
+        )
+    return counts
 
 
 class WebhookReporter:
@@ -34,6 +81,9 @@ class WebhookReporter:
     async def _send(self, embed: discord.Embed, username: str = "Bot Logger") -> None:
         if not self.url or not self._session:
             return
+        counts = _redact_embed(embed)
+        if counts:
+            logger.debug("Webhook embed redacted: %s", counts)
         try:
             wh = discord.Webhook.from_url(self.url, session=self._session)
             await wh.send(embed=embed, username=username)

--- a/tests/unit/runtime/ai/test_redaction.py
+++ b/tests/unit/runtime/ai/test_redaction.py
@@ -1,0 +1,120 @@
+"""Tests for ``core.runtime.ai.redaction`` — every regex exercised with
+positive and negative samples, plus idempotency and nested-payload
+coverage (LP-1).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.runtime.ai.redaction import redact_payload, redact_text
+
+# Built at runtime so the .py source never contains a 3-part base64-shaped
+# literal — GitHub's secret scanner would flag any such string as a possible
+# Discord bot token even when every part is a single repeated character.
+_DISCORD_TOKEN_FIXTURE = ".".join(("a" * 24, "b" * 8, "c" * 21))
+
+# (input, expected_label, marker_must_appear_in_output)
+_POSITIVE_CASES = [
+    # discord_token_like — three base64-ish parts (23+ . 6+ . 20+)
+    (
+        _DISCORD_TOKEN_FIXTURE,
+        "discord_token_like",
+        "[discord_token_like:redacted]",
+    ),
+    # api_key_like — sk_/pk_/rk_/xoxb_/ghp_ + 12+ chars
+    ("sk_live_abc123def456ghi", "api_key_like", "[api_key_like:redacted]"),
+    ("ghp_1234567890abcdefghij", "api_key_like", "[api_key_like:redacted]"),
+    ("xoxb_long_enough_token_value", "api_key_like", "[api_key_like:redacted]"),
+    # database_url
+    ("postgres://user:pass@host:5432/db", "database_url", "[database_url:redacted]"),
+    ("postgresql://u:p@example.com:5432/x", "database_url", "[database_url:redacted]"),
+    # bearer_token (case-insensitive)
+    ("Authorization: Bearer abc.def-123", "bearer_token", "[bearer_token:redacted]"),
+    ("bearer abc.def-123", "bearer_token", "[bearer_token:redacted]"),
+    # email
+    ("Contact alice@example.com please", "email", "[email:redacted]"),
+    # url_secret_query — token/key/secret/password/signature
+    (
+        "https://api.example.com/x?token=foo&other=baz",
+        "url_secret_query",
+        "?token=[redacted]",
+    ),
+    (
+        "https://api.example.com/x?other=baz&password=hunter2",
+        "url_secret_query",
+        "&password=[redacted]",
+    ),
+]
+
+
+@pytest.mark.parametrize("text,label,marker", _POSITIVE_CASES)
+def test_redact_text_matches_known_secret_shapes(
+    text: str, label: str, marker: str
+) -> None:
+    result = redact_text(text)
+    assert result.replacements.get(label) == 1, (
+        f"expected one match for {label!r} in {text!r}; got {result.replacements}"
+    )
+    assert marker in result.value, (
+        f"marker {marker!r} missing from redacted output {result.value!r}"
+    )
+
+
+_NEGATIVE_CASES = [
+    "a.b.c",  # discord_token_like — too short
+    "sk_short",  # api_key_like — under 12 chars after the prefix
+    "https://example.com/page",  # database_url — wrong scheme
+    "Carrier abc-def-1234",  # bearer_token — wrong keyword
+    "@example.com",  # email — missing local part
+    "?other=foo",  # url_secret_query — non-secret key name
+    "Hello world.",
+    "1234567890",
+    "",
+]
+
+
+@pytest.mark.parametrize("text", _NEGATIVE_CASES)
+def test_redact_text_leaves_non_secret_strings_alone(text: str) -> None:
+    result = redact_text(text)
+    assert result.value == text
+    assert not result.replacements
+
+
+def test_redact_text_redacts_multiple_secrets_in_one_string() -> None:
+    text = "key sk_live_abcdef123456 and postgres://x:y@h/d"
+    result = redact_text(text)
+    assert result.replacements.get("api_key_like") == 1
+    assert result.replacements.get("database_url") == 1
+    assert "[api_key_like:redacted]" in result.value
+    assert "[database_url:redacted]" in result.value
+
+
+def test_redact_text_is_idempotent_on_already_redacted_output() -> None:
+    once = redact_text("sk_live_abcdef123456").value
+    twice = redact_text(once)
+    assert twice.value == once
+    assert not twice.replacements
+
+
+def test_redact_payload_walks_dicts_lists_tuples() -> None:
+    payload = {
+        "outer": "no secrets",
+        "nested": ["sk_live_abcdef123456", {"deep": "postgres://u:p@h/d"}],
+        "tup": ("Bearer abc-def-1234",),
+    }
+    result = redact_payload(payload)
+    assert result.replacements.get("api_key_like") == 1
+    assert result.replacements.get("database_url") == 1
+    assert result.replacements.get("bearer_token") == 1
+    assert result.value["outer"] == "no secrets"
+    assert "[api_key_like:redacted]" in result.value["nested"][0]
+    assert "[database_url:redacted]" in result.value["nested"][1]["deep"]
+    assert "[bearer_token:redacted]" in result.value["tup"][0]
+
+
+def test_redact_payload_preserves_non_string_leaves() -> None:
+    payload = {"count": 42, "flag": True, "none": None, "nested": [1, 2, 3]}
+    result = redact_payload(payload)
+    assert result.value == payload
+    assert not result.replacements

--- a/tests/unit/services/test_webhook_reporter.py
+++ b/tests/unit/services/test_webhook_reporter.py
@@ -1,0 +1,143 @@
+"""Tests for ``services.webhook_reporter`` — embed redaction wiring (LP-1).
+
+Covers the `_redact_embed` helper directly and an end-to-end path
+through ``WebhookReporter._send`` and ``on_command_error`` to prove
+secret-looking substrings never reach ``discord.Webhook.send``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from services.webhook_reporter import WebhookReporter, _redact_embed
+
+
+class _Stringy:
+    """Tiny stand-in for objects whose ``__str__`` is interpolated into
+    embed fields (``ctx.author``, ``ctx.guild`` etc.)."""
+
+    def __init__(self, s: str, id_: int | None = None) -> None:
+        self._s = s
+        if id_ is not None:
+            self.id = id_
+
+    def __str__(self) -> str:
+        return self._s
+
+
+def test_redact_embed_scrubs_every_textual_surface() -> None:
+    embed = discord.Embed(
+        title="ok",  # benign title
+        description="connection string: postgres://u:secret@host/db failed",
+    )
+    embed.add_field(name="key", value="sk_live_abcdef123456", inline=False)
+    embed.set_footer(text="contact alice@example.com")
+    embed.set_author(name="Bearer abc.def-123")
+
+    counts = _redact_embed(embed)
+
+    assert "[database_url:redacted]" in (embed.description or "")
+    assert "[api_key_like:redacted]" in embed.fields[0].value
+    assert "[email:redacted]" in (embed.footer.text or "")
+    assert "[bearer_token:redacted]" in (embed.author.name or "")
+    assert counts.get("database_url") == 1
+    assert counts.get("api_key_like") == 1
+    assert counts.get("email") == 1
+    assert counts.get("bearer_token") == 1
+
+
+def test_redact_embed_no_secrets_means_no_changes() -> None:
+    embed = discord.Embed(title="ok", description="all good")
+    embed.add_field(name="x", value="123", inline=True)
+
+    counts = _redact_embed(embed)
+
+    assert embed.title == "ok"
+    assert embed.description == "all good"
+    assert embed.fields[0].value == "123"
+    assert not counts
+
+
+@pytest.mark.asyncio
+async def test_send_scrubs_embed_before_dispatch_to_webhook() -> None:
+    reporter = WebhookReporter("https://discord.com/api/webhooks/123/abc")
+    reporter._session = MagicMock()  # truthy so _send proceeds past the early-return guard
+
+    embed = discord.Embed(
+        title="Crash",
+        description="Traceback ... postgres://u:p@h/db ... raise",
+    )
+
+    wh_mock = MagicMock()
+    wh_mock.send = AsyncMock()
+
+    with patch(
+        "services.webhook_reporter.discord.Webhook.from_url",
+        return_value=wh_mock,
+    ):
+        await reporter._send(embed)
+
+    wh_mock.send.assert_awaited_once()
+    sent_embed = wh_mock.send.call_args.kwargs["embed"]
+    assert "[database_url:redacted]" in (sent_embed.description or "")
+    assert "postgres://" not in (sent_embed.description or "")
+
+
+@pytest.mark.asyncio
+async def test_send_no_session_returns_early_without_redaction_or_dispatch() -> None:
+    reporter = WebhookReporter("https://discord.com/api/webhooks/123/abc")
+    # _session left as None — _send should bail before redacting or sending.
+
+    embed = discord.Embed(description="postgres://u:p@h/db")
+
+    with patch(
+        "services.webhook_reporter.discord.Webhook.from_url",
+    ) as from_url:
+        await reporter._send(embed)
+
+    from_url.assert_not_called()
+    # Embed not mutated because we never reached the redaction step.
+    assert embed.description == "postgres://u:p@h/db"
+
+
+@pytest.mark.asyncio
+async def test_on_command_error_redacts_traceback_secret_end_to_end() -> None:
+    """Construct a real exception whose message contains a Postgres URL,
+    route through ``on_command_error``, and verify the embed that reached
+    ``discord.Webhook.send`` no longer carries the raw URL.
+    """
+    reporter = WebhookReporter("https://example.com/webhook")
+    reporter._session = MagicMock()
+
+    ctx = MagicMock()
+    ctx.message.content = "!leak"
+    ctx.author = _Stringy("alice#0001", id_=12345)
+    ctx.guild = _Stringy("Test Guild")
+    ctx.channel = _Stringy("general")
+    ctx.command = _Stringy("leak")
+    ctx.cog = None
+
+    try:
+        raise RuntimeError("connection failed for postgres://u:p@host:5432/db")
+    except RuntimeError as exc:
+        err = exc
+
+    wh_mock = MagicMock()
+    wh_mock.send = AsyncMock()
+
+    with patch(
+        "services.webhook_reporter.discord.Webhook.from_url",
+        return_value=wh_mock,
+    ):
+        await reporter.on_command_error(ctx, err)
+
+    wh_mock.send.assert_awaited_once()
+    sent_embed = wh_mock.send.call_args.kwargs["embed"]
+    body = (sent_embed.description or "") + "".join(
+        (f.value or "") for f in sent_embed.fields
+    )
+    assert "postgres://u:p@host" not in body
+    assert "[database_url:redacted]" in body


### PR DESCRIPTION
## Summary

Wire `core.runtime.ai.redaction` (until now an unused scaffold with no
importers in the codebase) into `services.webhook_reporter` so every
embed dispatched to the operator webhook is scrubbed by `redact_text` on
its title, description, every field name + value, footer text, and
author name immediately before `discord.Webhook.send`.

Secret-looking substrings — Discord tokens, `sk_/pk_/rk_/xoxb_/ghp_`
API keys, `postgres://` URLs, `Bearer` tokens, emails, and
secret-bearing URL query params (`?token=`, `&password=`, etc.) — are
replaced with `[<label>:redacted]` markers. Per-label counts are
logged at DEBUG for observability without re-walking the embed.

## Why now

`services/webhook_reporter.py` logs `ctx.message.content[:200]` for
every command and the formatted traceback (last 1500 chars) for every
unhandled error. Today this happens with **zero redaction** — a user
typing `!setapikey sk_live_...` or an exception whose message contains
a Postgres connection string leaks the raw value straight to the
operator channel.

The `core/runtime/ai/redaction.py` regex set already covered the
shapes we need; it just had no consumers. This PR connects them.

LP-1 of the Runtime Lifecycle Plan — gating PR for any subsequent
work that constructs AI prompts from operator-facing payloads (LP-9),
since the same leak would otherwise reach the AI prompt.

## Test plan

- [x] `python -m pytest tests/unit/runtime/ai/test_redaction.py` —
  24/24 pass. Each regex exercised with positive samples + negative
  look-alikes; idempotency on already-redacted output; recursive walk
  of dict/list/tuple payloads; non-string leaves preserved.
- [x] `python -m pytest tests/unit/services/test_webhook_reporter.py`
  — 5/5 pass. `_redact_embed` scrubs every textual surface; `_send`
  redacts then dispatches; no-session short-circuit bypasses redaction
  *and* dispatch; end-to-end through `on_command_error` proves a real
  exception's traceback containing `postgres://u:p@host:5432/db` is
  scrubbed before reaching `wh.send`.
- [x] Full test suite: `python -m pytest tests/` — 3980 passed, 3
  skipped, 0 failures.
- [x] `black --check`, `isort --check-only`, `ruff check`, `mypy
  disbot/` — all green.

## Scope

This PR intentionally does **not** touch:
- the lifecycle state machine (LP-2)
- restart centralisation (LP-3)
- AI startup summary (LP-9)

LP-9 is gated on this PR being live.

## Note on the Discord-token test fixture

GitHub's secret scanner flagged the original 3-part base64 literal in
the test fixture (correctly — the regex matches that shape, which is
the whole point of the test). The fixture is now assembled at runtime
via `".".join(("a" * 24, "b" * 8, "c" * 21))` so the source contains
no literal that looks like a Discord bot token, while the runtime
value still triggers the regex.

https://claude.ai/code/session_01F1dpJ11fmQaQGnWboa78qb

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1dpJ11fmQaQGnWboa78qb)_