### PR TITLE
LP-2: process lifecycle state machine (skeleton; behaviour-neutral)

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -13,6 +13,7 @@ import discord
 from discord.ext import commands
 
 import config
+from core.runtime import lifecycle as _lifecycle
 from services.runtime import BOOT_ID, install_boot_id_logging
 from services.webhook_reporter import WebhookReporter
 from utils import db
@@ -83,13 +84,13 @@ bot = commands.Bot(
 
 ALLOWED_CHANNELS = config.ALLOWED_CHANNELS
 
-# Set by SIGTERM handler — channel guard rejects new commands during drain.
-_shutting_down = False
-
 
 def _begin_shutdown(*_) -> None:
-    global _shutting_down
-    _shutting_down = True
+    """SIGTERM handler: route through the lifecycle service so command
+    admission (``_channel_guard``) and any future observers see one
+    canonical "draining" signal instead of a module-local bool (LP-2).
+    """
+    _lifecycle.request_shutdown(reason="sigterm")
 
 
 # ---------------------------------------------------------------------------
@@ -191,6 +192,10 @@ async def on_ready() -> None:
     live_update_scheduler.setup(bot)
     if reporter:
         await reporter.on_startup(bot)
+    # LP-2: surface "ready to serve" as a lifecycle phase. Only transition
+    # when no shutdown was requested mid-startup; otherwise stay in DRAINING.
+    if _lifecycle.get_phase() is _lifecycle.Phase.STARTING:
+        _lifecycle.set_phase(_lifecycle.Phase.RUNNING, reason="on_ready")
 
 
 @bot.event
@@ -384,7 +389,7 @@ async def on_command_error(ctx: commands.Context, error: commands.CommandError) 
 
 @bot.check
 async def _channel_guard(ctx: commands.Context) -> bool:
-    if _shutting_down:
+    if not _lifecycle.can_accept_commands():
         return False
     return ctx.guild is not None and (
         ctx.channel.id in ALLOWED_CHANNELS
@@ -828,6 +833,14 @@ async def main() -> None:
             logger.info("Starting bot...")
             await bot.start(config.DISCORD_BOT_TOKEN)
     finally:
+        # LP-2: mark the cleanup phase so observers see one canonical
+        # "the bot is winding down" signal. The transition is recorded
+        # in the lifecycle event buffer regardless of which exit path
+        # we arrived through (normal return, SIGTERM, exception).
+        _lifecycle.set_phase(
+            _lifecycle.Phase.SHUTTING_DOWN,
+            reason="main_finally",
+        )
         # Signal the heartbeat loop to stop cleanly before cancelling
         # all app tasks. ``run_heartbeat_loop`` exits its wait early
         # when the event is set, which lets the lock release happen
@@ -869,6 +882,8 @@ async def main() -> None:
         await db.close()
         if reporter:
             await reporter.close()
+        # LP-2: cleanup is done; surface the terminal phase.
+        _lifecycle.set_phase(_lifecycle.Phase.STOPPED, reason="cleanup_complete")
 
 
 if __name__ == "__main__":

--- a/disbot/cogs/bootstrap_access_cog.py
+++ b/disbot/cogs/bootstrap_access_cog.py
@@ -24,6 +24,7 @@ from typing import Any
 from discord.ext import commands
 
 import config
+from core.runtime import lifecycle
 from core.runtime.command_access import (
     can_bypass_channel_guard,
     is_bootstrap_command,
@@ -52,13 +53,6 @@ def _check_is_owned_by_bootstrap_cog(check: Any) -> bool:
     return isinstance(owner, BootstrapAccessCog)
 
 
-def _is_shutting_down_from_legacy_guard(legacy_guard: Any | None) -> bool:
-    """Read ``_shutting_down`` from the original guard's globals, if present."""
-    if legacy_guard is None:
-        return False
-    return bool(getattr(legacy_guard, "__globals__", {}).get("_shutting_down", False))
-
-
 def _command_name(ctx: commands.Context) -> str | None:
     command = getattr(ctx, "command", None)
     if command is None:
@@ -69,9 +63,8 @@ def _command_name(ctx: commands.Context) -> str | None:
 class BootstrapAccessCog(commands.Cog):
     """Installs the fresh-guild-aware global channel guard."""
 
-    def __init__(self, bot: commands.Bot, *, legacy_guard: Any | None = None) -> None:
+    def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
-        self._legacy_guard = legacy_guard
 
     def cog_unload(self) -> None:
         """Remove the global channel guard so a reload doesn't leave a
@@ -93,7 +86,11 @@ class BootstrapAccessCog(commands.Cog):
             )
 
     async def _channel_guard(self, ctx: commands.Context) -> bool:
-        if _is_shutting_down_from_legacy_guard(self._legacy_guard):
+        # LP-2: command admission is owned by the lifecycle service.
+        # Previously this read ``_shutting_down`` from the legacy guard's
+        # ``__globals__`` — that lookup is gone now that bot1.py routes
+        # SIGTERM through ``lifecycle.request_shutdown``.
+        if not lifecycle.can_accept_commands():
             return False
         if ctx.guild is None:
             return False
@@ -157,23 +154,20 @@ async def setup(bot: commands.Bot) -> None:
     silently breaking command access in production guilds.
     """
     existing_checks = _find_channel_guard_checks(bot)
-    legacy_guards = [
-        c for c in existing_checks if not _check_is_owned_by_bootstrap_cog(c)
-    ]
-    bootstrap_remnants = [
-        c for c in existing_checks if _check_is_owned_by_bootstrap_cog(c)
-    ]
-    legacy_guard = legacy_guards[0] if legacy_guards else None
+    legacy_count = sum(
+        1 for c in existing_checks if not _check_is_owned_by_bootstrap_cog(c)
+    )
+    remnant_count = len(existing_checks) - legacy_count
     for guard in existing_checks:
         bot.remove_check(guard)
-    cog = BootstrapAccessCog(bot, legacy_guard=legacy_guard)
+    cog = BootstrapAccessCog(bot)
     bot.add_check(cog._channel_guard)
     await bot.add_cog(cog)
     logger.info(
         "BootstrapAccessCog loaded; replaced %d legacy guard(s) + "
         "cleaned %d bootstrap remnant(s).",
-        len(legacy_guards),
-        len(bootstrap_remnants),
+        legacy_count,
+        remnant_count,
     )
 
 

--- a/disbot/core/runtime/lifecycle.py
+++ b/disbot/core/runtime/lifecycle.py
@@ -1,0 +1,278 @@
+"""Process lifecycle state machine for SuperBot — LP-2.
+
+Owns the canonical state for "is this process accepting commands? draining?
+restarting?" so callers do not pass around module-level booleans. Replaces
+the legacy ``_shutting_down: bool`` in ``bot1.py``.
+
+This module deliberately exposes a minimal API: callers ask for the
+current phase, request a transition, or read recent events. The actual
+exec / exit happens in ``bot1.py``; this module records intent and does
+nothing else.
+
+Phases
+------
+STARTING
+    Initial state before ``on_ready`` fires. Commands admitted (no
+    behaviour change versus the pre-LP-2 ``_shutting_down=False``).
+RUNNING
+    ``on_ready`` fired; commands accepted normally.
+DRAINING
+    Shutdown or restart requested; new commands rejected; in-flight
+    commands still running.
+SHUTTING_DOWN
+    Cleanup in progress (``bot1.main`` finally block).
+RESTARTING
+    Cleanup complete, awaiting exec / respawn. Reserved for LP-3.
+STOPPED
+    Terminal: cleanup done, process about to exit.
+FAILED_STARTUP
+    Terminal: startup raised before ``RUNNING``. Reserved for LP-5 +.
+
+Idempotency
+-----------
+``request_shutdown`` and ``request_restart`` coalesce: a second call
+while a request is already pending is a no-op and returns ``False`` so
+the caller can tell whether its request was the one that took effect.
+A restart request while a plain shutdown is pending also coalesces and
+does *not* upgrade the kind — the first intent wins.
+"""
+
+from __future__ import annotations
+
+import enum
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class Phase(enum.Enum):
+    STARTING = "STARTING"
+    RUNNING = "RUNNING"
+    DRAINING = "DRAINING"
+    SHUTTING_DOWN = "SHUTTING_DOWN"
+    RESTARTING = "RESTARTING"
+    STOPPED = "STOPPED"
+    FAILED_STARTUP = "FAILED_STARTUP"
+
+
+_DRAINING_PHASES: frozenset[Phase] = frozenset(
+    {Phase.DRAINING, Phase.SHUTTING_DOWN, Phase.RESTARTING, Phase.STOPPED},
+)
+_ADMITTING_PHASES: frozenset[Phase] = frozenset(
+    {Phase.STARTING, Phase.RUNNING},
+)
+
+
+@dataclass(frozen=True)
+class LifecycleEvent:
+    """One transition or request recorded in the ring buffer."""
+
+    name: str
+    phase: Phase
+    at: float  # ``time.monotonic()`` seconds
+    actor: str | None = None
+    reason: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class PendingShutdown:
+    """The shutdown / restart request currently in flight, if any."""
+
+    kind: str  # "shutdown" or "restart"
+    reason: str
+    actor: str | None
+    requested_at: float
+    grace_seconds: float | None
+
+
+_EVENT_BUFFER_SIZE = 128
+
+_phase: Phase = Phase.STARTING
+_pending: PendingShutdown | None = None
+_events: deque[LifecycleEvent] = deque(maxlen=_EVENT_BUFFER_SIZE)
+
+
+def get_phase() -> Phase:
+    """Return the current lifecycle phase."""
+    return _phase
+
+
+def set_phase(phase: Phase, *, reason: str | None = None) -> None:
+    """Record a phase transition.
+
+    Intended for the entry point (``bot1.py``) and the lifecycle module
+    itself. Cogs should not call this directly — they use
+    :func:`request_shutdown` / :func:`request_restart`.
+    """
+    global _phase
+    if _phase == phase:
+        return
+    _phase = phase
+    _record_event(f"phase:{phase.value}", reason=reason)
+
+
+def is_shutting_down() -> bool:
+    """True if the bot is draining, shutting down, restarting, or stopped.
+
+    Mirrors the semantics of the legacy ``_shutting_down: bool`` in
+    ``bot1.py``: any phase past ``RUNNING`` counts as "not accepting new
+    work".
+    """
+    return _phase in _DRAINING_PHASES
+
+
+def restart_requested() -> bool:
+    """True if a restart (rather than a plain shutdown) is pending."""
+    return _pending is not None and _pending.kind == "restart"
+
+
+def can_accept_commands() -> bool:
+    """True if new commands may be admitted.
+
+    Returns True only in ``STARTING`` and ``RUNNING``. Every other phase
+    — including the terminal ``FAILED_STARTUP`` — rejects new commands.
+    """
+    return _phase in _ADMITTING_PHASES
+
+
+def request_shutdown(
+    reason: str,
+    *,
+    actor: str | None = None,
+    grace_seconds: float | None = None,
+) -> bool:
+    """Request a graceful shutdown.
+
+    Returns ``True`` if this call established the pending request,
+    ``False`` if a request was already in flight (coalesced).
+    """
+    global _pending
+    if _pending is not None:
+        _record_event(
+            "shutdown_requested_coalesced",
+            reason=reason,
+            actor=actor,
+        )
+        return False
+    _pending = PendingShutdown(
+        kind="shutdown",
+        reason=reason,
+        actor=actor,
+        requested_at=time.monotonic(),
+        grace_seconds=grace_seconds,
+    )
+    _record_event("shutdown_requested", reason=reason, actor=actor)
+    if _phase in (Phase.STARTING, Phase.RUNNING):
+        set_phase(Phase.DRAINING, reason=reason)
+    return True
+
+
+def request_restart(
+    reason: str,
+    *,
+    actor: str | None = None,
+    grace_seconds: float | None = None,
+) -> bool:
+    """Request a graceful restart.
+
+    Returns ``True`` if this call established the pending request,
+    ``False`` if a request was already in flight (coalesced — even if
+    the existing pending intent was a plain ``shutdown``; the first
+    intent wins so callers do not race to upgrade the kind).
+    """
+    global _pending
+    if _pending is not None:
+        _record_event(
+            "restart_requested_coalesced",
+            reason=reason,
+            actor=actor,
+        )
+        return False
+    _pending = PendingShutdown(
+        kind="restart",
+        reason=reason,
+        actor=actor,
+        requested_at=time.monotonic(),
+        grace_seconds=grace_seconds,
+    )
+    _record_event("restart_requested", reason=reason, actor=actor)
+    if _phase in (Phase.STARTING, Phase.RUNNING):
+        set_phase(Phase.DRAINING, reason=reason)
+    return True
+
+
+def get_pending() -> PendingShutdown | None:
+    """Return the current pending request, or ``None`` if none."""
+    return _pending
+
+
+def remaining_shutdown_seconds() -> float | None:
+    """Seconds left in the grace window.
+
+    Returns ``None`` if no shutdown is pending, or if the pending
+    request did not specify a grace window.
+    """
+    if _pending is None or _pending.grace_seconds is None:
+        return None
+    elapsed = time.monotonic() - _pending.requested_at
+    return max(0.0, _pending.grace_seconds - elapsed)
+
+
+def get_recent_events(limit: int = 20) -> list[LifecycleEvent]:
+    """Return the most recent lifecycle events, newest last.
+
+    ``limit <= 0`` returns an empty list.
+    """
+    if limit <= 0:
+        return []
+    return list(_events)[-limit:]
+
+
+def _record_event(
+    name: str,
+    *,
+    reason: str | None = None,
+    actor: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    _events.append(
+        LifecycleEvent(
+            name=name,
+            phase=_phase,
+            at=time.monotonic(),
+            actor=actor,
+            reason=reason,
+            metadata=metadata or {},
+        ),
+    )
+
+
+def reset_for_tests() -> None:
+    """Reset module state back to ``STARTING`` with no pending request.
+
+    Test-only entry point — production code must not call this.
+    """
+    global _phase, _pending
+    _phase = Phase.STARTING
+    _pending = None
+    _events.clear()
+
+
+__all__ = [
+    "LifecycleEvent",
+    "PendingShutdown",
+    "Phase",
+    "can_accept_commands",
+    "get_pending",
+    "get_phase",
+    "get_recent_events",
+    "is_shutting_down",
+    "remaining_shutdown_seconds",
+    "request_restart",
+    "request_shutdown",
+    "reset_for_tests",
+    "restart_requested",
+    "set_phase",
+]

--- a/tests/unit/cogs/test_bootstrap_access_cog.py
+++ b/tests/unit/cogs/test_bootstrap_access_cog.py
@@ -164,7 +164,7 @@ def test_find_channel_guard_checks_matches_by_name():
 
 async def test_channel_guard_allows_inside_allowed_channels(monkeypatch):
     monkeypatch.setattr(config, "ALLOWED_CHANNELS", {12345})
-    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot), legacy_guard=None)
+    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
     ctx = _ctx(channel_id=12345, command_name="daily")
 
     assert await cog._channel_guard(ctx) is True
@@ -172,7 +172,7 @@ async def test_channel_guard_allows_inside_allowed_channels(monkeypatch):
 
 async def test_channel_guard_allows_force_outside_allowed_channels(monkeypatch):
     monkeypatch.setattr(config, "ALLOWED_CHANNELS", set())
-    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot), legacy_guard=None)
+    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
     ctx = _ctx(channel_id=999, command_name="force")
 
     assert await cog._channel_guard(ctx) is True
@@ -180,7 +180,7 @@ async def test_channel_guard_allows_force_outside_allowed_channels(monkeypatch):
 
 async def test_channel_guard_allows_guild_owner_for_bootstrap_command(monkeypatch):
     monkeypatch.setattr(config, "ALLOWED_CHANNELS", set())
-    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot), legacy_guard=None)
+    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
     ctx = _ctx(channel_id=999, command_name="setup", author_id=42, owner_id=42)
 
     assert await cog._channel_guard(ctx) is True
@@ -188,7 +188,7 @@ async def test_channel_guard_allows_guild_owner_for_bootstrap_command(monkeypatc
 
 async def test_channel_guard_denies_normal_command_outside_allowed_channels(monkeypatch):
     monkeypatch.setattr(config, "ALLOWED_CHANNELS", set())
-    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot), legacy_guard=None)
+    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
     ctx = _ctx(channel_id=999, command_name="daily", author_id=42, owner_id=42)
 
     assert await cog._channel_guard(ctx) is False
@@ -196,20 +196,31 @@ async def test_channel_guard_denies_normal_command_outside_allowed_channels(monk
 
 async def test_channel_guard_denies_dm_context(monkeypatch):
     monkeypatch.setattr(config, "ALLOWED_CHANNELS", {12345})
-    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot), legacy_guard=None)
+    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
     ctx = _ctx(channel_id=12345, guild=None, command_name="help")
     ctx.guild = None
 
     assert await cog._channel_guard(ctx) is False
 
 
-async def test_channel_guard_respects_legacy_shutdown_flag(monkeypatch):
-    monkeypatch.setattr(config, "ALLOWED_CHANNELS", {12345})
-    legacy = _legacy_channel_guard_factory(shutting_down=True)
-    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot), legacy_guard=legacy)
-    ctx = _ctx(channel_id=12345, command_name="help")
+async def test_channel_guard_blocks_when_lifecycle_is_shutting_down(monkeypatch):
+    """LP-2: command admission consults
+    :func:`core.runtime.lifecycle.can_accept_commands` (no longer the
+    legacy ``_shutting_down`` attribute on the previous guard).
+    """
+    from core.runtime import lifecycle
 
-    assert await cog._channel_guard(ctx) is False
+    monkeypatch.setattr(config, "ALLOWED_CHANNELS", {12345})
+    lifecycle.reset_for_tests()
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown("test")
+    try:
+        cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
+        ctx = _ctx(channel_id=12345, command_name="help")
+
+        assert await cog._channel_guard(ctx) is False
+    finally:
+        lifecycle.reset_for_tests()
 
 
 # ---------------------------------------------------------------------------
@@ -219,7 +230,7 @@ async def test_channel_guard_respects_legacy_shutdown_flag(monkeypatch):
 
 async def test_on_command_error_replies_for_missing_permissions_on_bootstrap(monkeypatch):
     monkeypatch.setattr(config, "ALLOWED_CHANNELS", set())
-    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot), legacy_guard=None)
+    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
     ctx = _ctx(channel_id=999, command_name="settings")
     error = commands.MissingPermissions(["manage_guild"])
 
@@ -230,7 +241,7 @@ async def test_on_command_error_replies_for_missing_permissions_on_bootstrap(mon
 
 async def test_on_command_error_silent_for_non_bootstrap_command(monkeypatch):
     monkeypatch.setattr(config, "ALLOWED_CHANNELS", set())
-    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot), legacy_guard=None)
+    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
     ctx = _ctx(channel_id=999, command_name="daily")
     error = commands.MissingPermissions(["manage_guild"])
 
@@ -241,7 +252,7 @@ async def test_on_command_error_silent_for_non_bootstrap_command(monkeypatch):
 
 async def test_on_command_error_silent_inside_allowed_channels(monkeypatch):
     monkeypatch.setattr(config, "ALLOWED_CHANNELS", {12345})
-    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot), legacy_guard=None)
+    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
     ctx = _ctx(channel_id=12345, command_name="settings")
     error = commands.MissingPermissions(["manage_guild"])
 
@@ -270,7 +281,7 @@ async def test_on_command_error_handles_each_known_error(
     expected_substring,
 ):
     monkeypatch.setattr(config, "ALLOWED_CHANNELS", set())
-    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot), legacy_guard=None)
+    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
     ctx = _ctx(channel_id=999, command_name="diagnostics")
 
     await cog.on_command_error(ctx, error_factory())

--- a/tests/unit/cogs/test_bootstrap_access_reload.py
+++ b/tests/unit/cogs/test_bootstrap_access_reload.py
@@ -112,9 +112,10 @@ async def test_first_load_installs_exactly_one_check_when_no_legacy_present():
 
 
 @pytest.mark.asyncio
-async def test_first_load_preserves_legacy_guard_reference():
-    """The legacy bot1._channel_guard is captured so the cog can
-    forward ``_shutting_down`` from it.
+async def test_first_load_removes_legacy_guard_from_bot_checks():
+    """LP-2: the legacy ``bot1._channel_guard`` is removed at load time.
+    The cog no longer captures a reference to it; the shutdown signal
+    is owned by ``core.runtime.lifecycle`` instead.
     """
     legacy = _legacy_guard_fn()
     bot = _make_bot(legacy)
@@ -122,7 +123,9 @@ async def test_first_load_preserves_legacy_guard_reference():
 
     cog_arg = bot.add_cog.await_args.args[0]
     assert isinstance(cog_arg, BootstrapAccessCog)
-    assert cog_arg._legacy_guard is legacy
+    # Legacy guard is gone; only the new bootstrap check is registered.
+    assert legacy not in bot._checks
+    assert _find_channel_guard_checks(bot)[0] is not legacy
 
 
 # ---------------------------------------------------------------------------
@@ -154,7 +157,9 @@ async def test_reload_cleans_bootstrap_remnant_before_installing_new_check():
 @pytest.mark.asyncio
 async def test_reload_with_remnant_and_legacy_keeps_only_new_check():
     """Both a bootstrap remnant AND a legacy guard present (worst case);
-    setup cleans both and installs exactly one check.
+    setup cleans both and installs exactly one check (LP-2: no
+    legacy-guard reference is captured any more — lifecycle owns the
+    shutdown signal).
     """
     bot = _make_bot()
     prev_cog = BootstrapAccessCog(bot)
@@ -168,17 +173,14 @@ async def test_reload_with_remnant_and_legacy_keeps_only_new_check():
     assert len(channel_guards) == 1
     assert channel_guards[0] is not prev_cog._channel_guard
     assert channel_guards[0] is not legacy
-    # The new cog still picked up the legacy guard for _shutting_down
-    # forwarding.
-    cog_arg = bot.add_cog.await_args.args[0]
-    assert cog_arg._legacy_guard is legacy
+    assert legacy not in bot._checks
+    assert prev_cog._channel_guard not in bot._checks
 
 
 @pytest.mark.asyncio
-async def test_reload_does_not_preserve_remnant_as_legacy_guard():
-    """A bootstrap remnant must NOT be captured as the legacy guard
-    reference — only a true legacy function (not bound to a
-    BootstrapAccessCog) qualifies.
+async def test_reload_removes_remnant_when_no_legacy_present():
+    """LP-2: with only a bootstrap remnant in place, setup() still
+    removes the remnant and installs exactly one new check.
     """
     bot = _make_bot()
     prev_cog = BootstrapAccessCog(bot)
@@ -186,10 +188,9 @@ async def test_reload_does_not_preserve_remnant_as_legacy_guard():
 
     await setup(bot)
 
-    cog_arg = bot.add_cog.await_args.args[0]
-    # No legacy guard captured because the only existing check was a
-    # bootstrap remnant.
-    assert cog_arg._legacy_guard is None
+    channel_guards = _find_channel_guard_checks(bot)
+    assert len(channel_guards) == 1
+    assert prev_cog._channel_guard not in bot._checks
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/runtime/test_lifecycle.py
+++ b/tests/unit/runtime/test_lifecycle.py
@@ -1,0 +1,202 @@
+"""Tests for ``core.runtime.lifecycle`` — LP-2.
+
+Covers phase transitions, request idempotency (shutdown + restart
+coalesce during DRAINING), command-admission semantics, the event ring
+buffer, and the grace-seconds math.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from core.runtime import lifecycle
+
+
+@pytest.fixture(autouse=True)
+def _reset_lifecycle_state() -> None:
+    lifecycle.reset_for_tests()
+
+
+def test_initial_state_is_starting_and_accepts_commands() -> None:
+    assert lifecycle.get_phase() is lifecycle.Phase.STARTING
+    assert lifecycle.can_accept_commands() is True
+    assert lifecycle.is_shutting_down() is False
+    assert lifecycle.restart_requested() is False
+    assert lifecycle.get_pending() is None
+    assert lifecycle.get_recent_events() == []
+
+
+def test_set_phase_records_transition_and_is_no_op_on_same_phase() -> None:
+    lifecycle.set_phase(lifecycle.Phase.RUNNING, reason="on_ready")
+    lifecycle.set_phase(lifecycle.Phase.RUNNING, reason="on_ready_again")
+
+    events = lifecycle.get_recent_events()
+    assert len(events) == 1
+    assert events[0].name == "phase:RUNNING"
+    assert events[0].reason == "on_ready"
+    assert events[0].phase is lifecycle.Phase.RUNNING
+
+
+def test_running_admits_commands_draining_does_not() -> None:
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    assert lifecycle.can_accept_commands() is True
+
+    lifecycle.request_shutdown("sigterm")
+
+    assert lifecycle.get_phase() is lifecycle.Phase.DRAINING
+    assert lifecycle.can_accept_commands() is False
+    assert lifecycle.is_shutting_down() is True
+
+
+@pytest.mark.parametrize(
+    "phase,admits",
+    [
+        (lifecycle.Phase.STARTING, True),
+        (lifecycle.Phase.RUNNING, True),
+        (lifecycle.Phase.DRAINING, False),
+        (lifecycle.Phase.SHUTTING_DOWN, False),
+        (lifecycle.Phase.RESTARTING, False),
+        (lifecycle.Phase.STOPPED, False),
+        (lifecycle.Phase.FAILED_STARTUP, False),
+    ],
+)
+def test_can_accept_commands_matches_phase(
+    phase: lifecycle.Phase, admits: bool
+) -> None:
+    lifecycle.set_phase(phase)
+    assert lifecycle.can_accept_commands() is admits
+
+
+def test_request_shutdown_returns_true_first_call_false_when_coalesced() -> None:
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    assert lifecycle.request_shutdown("first") is True
+    assert lifecycle.request_shutdown("second") is False
+    assert lifecycle.request_shutdown("third") is False
+
+    pending = lifecycle.get_pending()
+    assert pending is not None
+    assert pending.kind == "shutdown"
+    assert pending.reason == "first"
+
+
+def test_request_restart_returns_true_first_call_false_when_coalesced() -> None:
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    assert lifecycle.request_restart("first") is True
+    assert lifecycle.request_restart("second") is False
+
+    pending = lifecycle.get_pending()
+    assert pending is not None
+    assert pending.kind == "restart"
+    assert pending.reason == "first"
+    assert lifecycle.restart_requested() is True
+
+
+def test_restart_request_does_not_upgrade_existing_shutdown_intent() -> None:
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown("first")
+    # A subsequent restart request must NOT silently upgrade the pending
+    # intent — the first request wins so cogs cannot race each other.
+    assert lifecycle.request_restart("upgrade-attempt") is False
+
+    pending = lifecycle.get_pending()
+    assert pending is not None
+    assert pending.kind == "shutdown"
+    assert lifecycle.restart_requested() is False
+
+
+def test_repeated_sigterm_coalesces_into_single_pending_request() -> None:
+    """Two SIGTERMs in rapid succession must not duplicate the work."""
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+
+    def _sigterm() -> bool:
+        return lifecycle.request_shutdown("sigterm")
+
+    accepted = [_sigterm() for _ in range(5)]
+    assert accepted == [True, False, False, False, False]
+    # Phase reaches DRAINING once and stays there.
+    assert lifecycle.get_phase() is lifecycle.Phase.DRAINING
+
+
+def test_event_buffer_captures_request_then_phase_transition() -> None:
+    lifecycle.set_phase(lifecycle.Phase.RUNNING, reason="on_ready")
+    lifecycle.request_shutdown("sigterm", actor="signal_handler")
+
+    names = [event.name for event in lifecycle.get_recent_events()]
+    assert names == [
+        "phase:RUNNING",
+        "shutdown_requested",
+        "phase:DRAINING",
+    ]
+
+
+def test_event_buffer_records_coalesce_attempts_separately() -> None:
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown("first")
+    lifecycle.request_shutdown("second")
+
+    names = [event.name for event in lifecycle.get_recent_events()]
+    assert "shutdown_requested" in names
+    assert "shutdown_requested_coalesced" in names
+    coalesced = [
+        event for event in lifecycle.get_recent_events()
+        if event.name == "shutdown_requested_coalesced"
+    ]
+    assert coalesced[0].reason == "second"
+
+
+def test_get_recent_events_respects_limit() -> None:
+    for i in range(10):
+        lifecycle._record_event(f"event_{i}")
+    assert len(lifecycle.get_recent_events(limit=3)) == 3
+    assert lifecycle.get_recent_events(limit=0) == []
+    assert lifecycle.get_recent_events(limit=-1) == []
+
+
+def test_remaining_shutdown_seconds_returns_none_when_no_pending() -> None:
+    assert lifecycle.remaining_shutdown_seconds() is None
+
+
+def test_remaining_shutdown_seconds_returns_none_when_no_grace_set() -> None:
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown("sigterm")  # no grace_seconds
+    assert lifecycle.remaining_shutdown_seconds() is None
+
+
+def test_remaining_shutdown_seconds_counts_down_from_grace() -> None:
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown("sigterm", grace_seconds=10.0)
+    remaining = lifecycle.remaining_shutdown_seconds()
+    assert remaining is not None
+    # No real sleep: just assert the value is within the requested
+    # window and non-negative.
+    assert 0.0 <= remaining <= 10.0
+
+
+def test_remaining_shutdown_seconds_clamped_to_zero_after_grace_expires(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_now = [1000.0]
+
+    def _fake_monotonic() -> float:
+        return fake_now[0]
+
+    monkeypatch.setattr(time, "monotonic", _fake_monotonic)
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown("sigterm", grace_seconds=5.0)
+    fake_now[0] += 12.0  # past the grace window
+
+    assert lifecycle.remaining_shutdown_seconds() == 0.0
+
+
+def test_reset_for_tests_clears_phase_pending_and_events() -> None:
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown("sigterm")
+    assert lifecycle.get_pending() is not None
+
+    lifecycle.reset_for_tests()
+
+    assert lifecycle.get_phase() is lifecycle.Phase.STARTING
+    assert lifecycle.get_pending() is None
+    assert lifecycle.get_recent_events() == []

--- a/tests/unit/test_bot_boot.py
+++ b/tests/unit/test_bot_boot.py
@@ -134,6 +134,35 @@ def test_bot1_applies_config_log_level_at_boot() -> None:
     )
 
 
+def test_bot1_sigterm_handler_routes_through_lifecycle() -> None:
+    """LP-2: SIGTERM must enter the lifecycle service rather than
+    flipping a module-local ``_shutting_down: bool``. The legacy global
+    is gone; observers (``_channel_guard``, future PRs) read from
+    ``lifecycle.can_accept_commands()``.
+    """
+    src = _src()
+    assert "_lifecycle.request_shutdown(reason=" in src, (
+        "bot1._begin_shutdown must call lifecycle.request_shutdown(...) "
+        "so SIGTERM is observable through the lifecycle event buffer (LP-2)."
+    )
+    assert "_shutting_down = True" not in src, (
+        "Legacy ``_shutting_down = True`` assignment must be gone — "
+        "the lifecycle service is now the single source of truth (LP-2)."
+    )
+
+
+def test_bot1_channel_guard_admits_via_lifecycle() -> None:
+    """LP-2: ``_channel_guard`` must consult
+    :func:`core.runtime.lifecycle.can_accept_commands` rather than the
+    legacy ``_shutting_down`` bool.
+    """
+    src = _src()
+    assert "_lifecycle.can_accept_commands()" in src, (
+        "bot1._channel_guard must check lifecycle.can_accept_commands() "
+        "so command admission tracks the lifecycle phase (LP-2)."
+    )
+
+
 def test_bot1_shutdown_drain_logs_timeout() -> None:
     """PR-02b (revised): when the 5 s drain budget elapses with tasks
     still pending, a WARNING log must surface so operators see the


### PR DESCRIPTION
## Summary

Introduce `disbot/core/runtime/lifecycle.py` — the canonical owner of
process lifecycle state — and wire it into `bot1.py` and
`bootstrap_access_cog.py`. Replaces the module-local `_shutting_down:
bool` in `bot1.py` with a phase enum (`STARTING`, `RUNNING`,
`DRAINING`, `SHUTTING_DOWN`, `RESTARTING`, `STOPPED`,
`FAILED_STARTUP`) backed by an idempotent request API and a 128-entry
ring buffer of recent events.

This is the foundation PR — **behaviour-neutral**. SIGTERM → drain →
reject commands works exactly as before. The only visible difference
is that the shutdown signal is now observable via the lifecycle event
buffer and a structured phase enum instead of a single bool.

## Why now

The original plan had restart-centralisation (LP-3) ship before the
lifecycle service, with a thin stub in `bot1.py` standing in for the
service. The revised plan swapped the order: lifecycle service first
(LP-2), restart centralisation second (LP-3). LP-3 can now route
`!restart` straight at `lifecycle.request_restart` instead of building
on a stub that would be replaced one PR later. Tighter test boundary,
smaller LP-3 diff.

## Changes

**New: `disbot/core/runtime/lifecycle.py`**

Public API (all module-level functions; no class needed for a
single-process state machine):

- `Phase` enum + `LifecycleEvent` / `PendingShutdown` dataclasses.
- `request_shutdown(reason, actor=None, grace_seconds=None) -> bool` —
  idempotent. Returns `True` if this call established the pending
  request, `False` if a request was already in flight.
- `request_restart(...)` — same idempotency rules. A restart request
  while a shutdown is already pending **does not upgrade the intent**;
  the first caller wins so cogs cannot race to escalate.
- `is_shutting_down()` — True for `DRAINING / SHUTTING_DOWN /
  RESTARTING / STOPPED`. (`FAILED_STARTUP` is not "shutting down" —
  it's a terminal startup-fail state.)
- `can_accept_commands()` — True only for `STARTING / RUNNING`. Every
  other phase rejects new commands, including `FAILED_STARTUP`.
- `get_phase()`, `set_phase()`, `get_pending()`,
  `remaining_shutdown_seconds()`, `get_recent_events(limit=20)`.
- `reset_for_tests()` — test-only.

**`bot1.py`**

- New `from core.runtime import lifecycle as _lifecycle`.
- `_shutting_down: bool` global removed.
- `_begin_shutdown` (SIGTERM handler) calls
  `_lifecycle.request_shutdown(reason="sigterm")`.
- `_channel_guard` checks `_lifecycle.can_accept_commands()`.
- `on_ready` transitions `STARTING → RUNNING` (only if no shutdown
  was requested mid-startup).
- `main()` finally block transitions `→ SHUTTING_DOWN` at entry and
  `→ STOPPED` at completion, so the recent-event buffer captures the
  full shutdown journey regardless of exit path.

**`disbot/cogs/bootstrap_access_cog.py`**

- `_is_shutting_down_from_legacy_guard()` (which inspected the
  previous guard's `__globals__["_shutting_down"]`) removed.
- Cog reads `lifecycle.can_accept_commands()` directly.
- `legacy_guard` parameter removed from `BootstrapAccessCog.__init__`
  and `setup()`. The reload-safety guarantee (find + remove every
  existing `_channel_guard` check, install exactly one new one) is
  preserved; only the legacy-reference capture is gone.

## Test plan

- [x] `python -m pytest tests/unit/runtime/test_lifecycle.py` — 22/22
  pass. Covers initial state, phase-admission for every phase,
  request idempotency (shutdown + restart coalesce; restart does not
  upgrade shutdown intent), repeated SIGTERM coalesces, event-buffer
  ordering + coalesce recording, grace-seconds math.
- [x] `python -m pytest tests/unit/test_bot_boot.py` — 7/7 pass.
  Two new invariants: SIGTERM handler routes through
  `lifecycle.request_shutdown`; `_channel_guard` consults
  `lifecycle.can_accept_commands`.
- [x] `python -m pytest tests/unit/cogs/test_bootstrap_access_cog.py
  tests/unit/cogs/test_bootstrap_access_reload.py` — all pass.
  Updated to drop the `legacy_guard=...` kwarg and to use lifecycle
  in place of the legacy-globals shutdown flag.
- [x] Full suite: `python -m pytest tests/` — 3975 passed, 3 skipped,
  0 failures.
- [x] `black --check`, `isort --check-only`, `ruff check`, `mypy
  disbot/` — all green.

## Scope

This PR intentionally does **not** touch:
- restart centralisation / `os.execv` in `cogs/admin_cog.py` — that
  is LP-3, which builds on this PR.
- the runtime-lock deploy handoff — LP-4.
- any new diagnostics surface — LP-6 will register a lifecycle
  provider in `services/diagnostics_service.py`.

## Behaviour-neutrality check

| Scenario | Before LP-2 | After LP-2 |
|---|---|---|
| Bot starts → on_ready fires | commands admitted | commands admitted (phase = RUNNING) |
| SIGTERM received | `_shutting_down = True` → guard rejects | `lifecycle.request_shutdown("sigterm")` → guard rejects |
| Two SIGTERMs in rapid succession | second is a no-op (already True) | second coalesces (returns False) |
| `!restart` issued | (unchanged — still `os.execv` in cog; LP-3 fixes) | (unchanged — still `os.execv`; LP-3 fixes) |
| Cleanup finally block runs | runs same | runs same; transitions through SHUTTING_DOWN → STOPPED for observability |

https://claude.ai/code/session_01F1dpJ11fmQaQGnWboa78qb

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1dpJ11fmQaQGnWboa78qb)_