### PR TITLE
LP-3: route !restart through lifecycle service (remove os.execv from cog)

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -550,6 +550,65 @@ async def _sample_process_memory() -> None:
         await asyncio.sleep(PROCESS_MEMORY_SAMPLE_INTERVAL)
 
 
+# ---------------------------------------------------------------------------
+# Restart close-driver — LP-3
+# ---------------------------------------------------------------------------
+
+RESTART_CLOSE_TIMEOUT_SECONDS: float = 20.0
+_RESTART_CLOSE_POLL_INTERVAL: float = 0.5
+
+
+async def _drive_close_on_restart_request() -> None:
+    """Turn a lifecycle restart request into ``bot.close()``.
+
+    LP-3: cog commands (``!restart``) record intent via
+    :func:`core.runtime.lifecycle.request_restart` but never touch
+    process control directly.  This watchdog polls the lifecycle
+    pending state and, when a restart is pending, closes the bot with
+    a bounded timeout.  ``main()`` then unwinds through the finally
+    block (heartbeat stop → task drain → lock release → DB close) and
+    the process exits cleanly, so the orchestration platform respawns
+    the container.
+
+    On timeout the close is force-completed via ``os._exit(1)`` rather
+    than left hanging — Railway will respawn after a non-zero exit and
+    that is preferable to a wedged process holding the runtime lock
+    until the 90 s TTL.
+
+    Shutdown intent (``request_shutdown`` without restart) is owned by
+    LP-5; this task only acts on restart-flavoured intent.
+    """
+    while True:
+        try:
+            await asyncio.sleep(_RESTART_CLOSE_POLL_INTERVAL)
+        except asyncio.CancelledError:
+            return
+        if not _lifecycle.restart_requested():
+            continue
+        pending = _lifecycle.get_pending()
+        actor = pending.actor if pending and pending.actor else "<unknown>"
+        reason = pending.reason if pending else "<unknown>"
+        logger.info(
+            "Restart requested by %s (reason=%r); closing bot (timeout %.1fs).",
+            actor,
+            reason,
+            RESTART_CLOSE_TIMEOUT_SECONDS,
+        )
+        try:
+            await asyncio.wait_for(
+                bot.close(),
+                timeout=RESTART_CLOSE_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            logger.critical(
+                "bot.close() exceeded %.1fs timeout — force-exiting "
+                "so the orchestration platform respawns.",
+                RESTART_CLOSE_TIMEOUT_SECONDS,
+            )
+            os._exit(1)
+        return
+
+
 async def main() -> None:
     from services.governance_exceptions import GovernanceError
     from utils.subsystem_registry import validate_registry
@@ -662,6 +721,16 @@ async def main() -> None:
             _runtime_tasks.spawn(
                 "process_memory_sampler",
                 _sample_process_memory(),
+                on_error=_on_app_task_died_webhook,
+            )
+
+            # LP-3: turn lifecycle.request_restart into bot.close(). The
+            # cog only records intent; this watchdog is the single
+            # executor. Bounded timeout falls back to os._exit so a
+            # wedged close cannot hold the runtime lock past its TTL.
+            _runtime_tasks.spawn(
+                "restart_close_driver",
+                _drive_close_on_restart_request(),
                 on_error=_on_app_task_died_webhook,
             )
 
@@ -882,8 +951,20 @@ async def main() -> None:
         await db.close()
         if reporter:
             await reporter.close()
-        # LP-2: cleanup is done; surface the terminal phase.
-        _lifecycle.set_phase(_lifecycle.Phase.STOPPED, reason="cleanup_complete")
+        # LP-2 + LP-3: surface the terminal phase. A pending restart
+        # request promotes the transition to RESTARTING so observers
+        # (and the recent-event buffer) see that the process is exiting
+        # specifically for a restart rather than a plain shutdown.
+        if _lifecycle.restart_requested():
+            _lifecycle.set_phase(
+                _lifecycle.Phase.RESTARTING,
+                reason="cleanup_complete_restart_pending",
+            )
+        else:
+            _lifecycle.set_phase(
+                _lifecycle.Phase.STOPPED,
+                reason="cleanup_complete",
+            )
 
 
 if __name__ == "__main__":

--- a/disbot/cogs/admin_cog.py
+++ b/disbot/cogs/admin_cog.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
-import sys
 
 import discord
 from discord import app_commands
@@ -17,12 +15,10 @@ from cogs.admin.cog_manager import (  # noqa: F401 — re-exported for back-comp
     _do_unload,
     _find_module,
 )
-from core.runtime import resources
+from core.runtime import lifecycle, resources
 from core.runtime.interaction_helpers import help_ctx_shim, safe_defer, safe_edit
 from utils.ui_constants import ADMIN_COLOR, INFO_COLOR, SUCCESS_COLOR  # noqa: F401
 from views.base import HubView, send_panel
-
-PID_FILE = os.path.join(os.path.dirname(COGS_DIR), "bot.pid")
 
 
 class AdminCog(commands.Cog):
@@ -309,13 +305,27 @@ class AdminCog(commands.Cog):
     @commands.command(name="restart")
     @commands.is_owner()
     async def reload_main_script(self, ctx):
-        """Restart the bot process."""
-        await ctx.send("♻️ Restarting bot...")
-        logging.info("Restarting bot...")
-        if os.path.exists(PID_FILE):
-            os.remove(PID_FILE)
-        await self.bot.close()
-        os.execv(sys.executable, [sys.executable] + sys.argv)
+        """Request a graceful restart through the lifecycle service.
+
+        LP-3: the cog no longer owns process control. It records intent
+        via :func:`core.runtime.lifecycle.request_restart`; a watchdog in
+        ``bot1.py`` turns the request into ``bot.close()`` with a bounded
+        timeout, the ``main()`` finally block runs cleanup, and the
+        process exits cleanly so the orchestration platform respawns it.
+        Repeated ``!restart`` calls during drain coalesce — only the
+        first caller wins.
+        """
+        accepted = lifecycle.request_restart(
+            reason="!restart",
+            actor=str(ctx.author),
+        )
+        if accepted:
+            await ctx.send("♻️ Restart requested. Bot is closing for restart.")
+            logging.info("Restart requested by %s", ctx.author)
+        else:
+            await ctx.send(
+                "⚠️ A shutdown or restart is already in progress — request coalesced.",
+            )
 
     # ------------------------------------------------------------------
     # Webhook log level

--- a/tests/unit/cogs/test_admin_restart.py
+++ b/tests/unit/cogs/test_admin_restart.py
@@ -1,0 +1,140 @@
+"""Tests for ``cogs.admin_cog`` restart command — LP-3.
+
+Pins the contract that ``!restart`` records intent through
+:mod:`core.runtime.lifecycle` and never touches process control
+(``os.execv`` / ``os._exit``) directly. The watchdog in ``bot1.py``
+turns the intent into ``bot.close()`` with a bounded timeout.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from cogs.admin_cog import AdminCog
+from core.runtime import lifecycle
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_ADMIN_COG = _REPO_ROOT / "disbot" / "cogs" / "admin_cog.py"
+
+
+@pytest.fixture(autouse=True)
+def _reset_lifecycle_state() -> None:
+    lifecycle.reset_for_tests()
+    yield
+    lifecycle.reset_for_tests()
+
+
+def _src() -> str:
+    return _ADMIN_COG.read_text()
+
+
+def test_admin_cog_source_does_not_touch_process_control() -> None:
+    """LP-3: cog must not call ``os.execv`` / ``os._exit`` / ``sys.exit``
+    / ``bot.close()``. Process control belongs to ``bot1.py``."""
+    src = _src()
+    assert "os.execv" not in src, (
+        "admin_cog must not call os.execv — restart is routed through "
+        "lifecycle.request_restart, executed by the bot1 watchdog (LP-3)."
+    )
+    assert "os._exit" not in src, "admin_cog must not call os._exit (LP-3)."
+    assert "sys.exit" not in src, "admin_cog must not call sys.exit (LP-3)."
+    assert ".bot.close(" not in src and "self.bot.close(" not in src, (
+        "admin_cog must not call bot.close() directly — the close is "
+        "driven by the bot1 restart watchdog so the timeout fallback "
+        "applies uniformly (LP-3)."
+    )
+
+
+def test_admin_cog_restart_command_calls_lifecycle_request_restart() -> None:
+    """AST-level: restart command body contains a
+    ``lifecycle.request_restart`` call."""
+    src = _src()
+    tree = ast.parse(src)
+    restart_fn: ast.AsyncFunctionDef | None = None
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "reload_main_script"
+        ):
+            restart_fn = node
+            break
+    assert restart_fn is not None, (
+        "admin_cog must define an async reload_main_script handler"
+    )
+    body_src = ast.unparse(restart_fn)
+    assert re.search(
+        r"lifecycle\.request_restart\(",
+        body_src,
+    ), "restart command must call lifecycle.request_restart (LP-3)"
+
+
+@pytest.mark.asyncio
+async def test_restart_command_records_intent_and_replies_to_user() -> None:
+    """Behavioural: invoking the command records the intent in
+    lifecycle and sends an acknowledgement to the user. The cog never
+    closes the bot itself."""
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+
+    bot = MagicMock()
+    bot.close = AsyncMock()
+    cog = AdminCog(bot)
+
+    author = SimpleNamespace()
+    author.__str__ = lambda self: "alice#0001"  # type: ignore[method-assign]
+    ctx = MagicMock()
+    ctx.send = AsyncMock()
+    ctx.author = "alice#0001"  # str() on this is the literal
+
+    await cog.reload_main_script.callback(cog, ctx)
+
+    pending = lifecycle.get_pending()
+    assert pending is not None
+    assert pending.kind == "restart"
+    assert pending.reason == "!restart"
+    assert pending.actor == "alice#0001"
+    ctx.send.assert_awaited_once()
+    sent = ctx.send.await_args.args[0]
+    assert "restart" in sent.lower()
+    bot.close.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_repeated_restart_command_coalesces_with_user_message() -> None:
+    """A second ``!restart`` while one is already pending must coalesce
+    and give the user explicit feedback rather than silently double-firing."""
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+
+    bot = MagicMock()
+    bot.close = AsyncMock()
+    cog = AdminCog(bot)
+
+    ctx1 = MagicMock()
+    ctx1.send = AsyncMock()
+    ctx1.author = "alice#0001"
+
+    ctx2 = MagicMock()
+    ctx2.send = AsyncMock()
+    ctx2.author = "bob#0002"
+
+    await cog.reload_main_script.callback(cog, ctx1)
+    await cog.reload_main_script.callback(cog, ctx2)
+
+    # Only the first request is recorded; the second coalesces.
+    pending = lifecycle.get_pending()
+    assert pending is not None
+    assert pending.actor == "alice#0001"
+
+    # Both users get feedback; the second message must clearly say
+    # "already in progress" / "coalesced".
+    first_msg = ctx1.send.await_args.args[0]
+    second_msg = ctx2.send.await_args.args[0]
+    assert "restart" in first_msg.lower()
+    second_lower = second_msg.lower()
+    assert "progress" in second_lower or "coalesced" in second_lower
+    bot.close.assert_not_called()

--- a/tests/unit/test_bot_boot.py
+++ b/tests/unit/test_bot_boot.py
@@ -163,6 +163,57 @@ def test_bot1_channel_guard_admits_via_lifecycle() -> None:
     )
 
 
+def test_bot1_spawns_restart_close_driver() -> None:
+    """LP-3: the restart watchdog must be supervised at boot so a
+    ``lifecycle.request_restart`` call turns into ``bot.close()``."""
+    src = _src()
+    assert "restart_close_driver" in src, (
+        "bot1.py must spawn a supervised task named "
+        "'restart_close_driver' to drive bot.close() on restart (LP-3)."
+    )
+    assert "_drive_close_on_restart_request" in src, (
+        "bot1.py must define and spawn _drive_close_on_restart_request "
+        "(LP-3)."
+    )
+
+
+def test_bot1_restart_watchdog_uses_bounded_close_timeout() -> None:
+    """LP-3: the watchdog must wrap ``bot.close()`` in
+    ``asyncio.wait_for`` with a timeout so a wedged close cannot hold
+    the runtime lock past its TTL."""
+    src = _src()
+    assert "RESTART_CLOSE_TIMEOUT_SECONDS" in src, (
+        "bot1.py must declare RESTART_CLOSE_TIMEOUT_SECONDS as the "
+        "named bound for the restart close (LP-3)."
+    )
+    assert re.search(
+        r"asyncio\.wait_for\(\s*bot\.close\(\)\s*,",
+        src,
+    ), (
+        "bot1.py must wrap bot.close() in asyncio.wait_for with a "
+        "bounded timeout (LP-3)."
+    )
+
+
+def test_bot1_finally_block_transitions_to_restarting_when_restart_pending() -> (
+    None
+):
+    """LP-3: the finally block surfaces RESTARTING as the terminal
+    phase when a restart was requested, so the recent-event buffer
+    distinguishes restart-exit from shutdown-exit."""
+    src = _src()
+    finally_block = src.split("finally:", 1)[-1]
+    assert "Phase.RESTARTING" in finally_block, (
+        "bot1.py finally block must promote the terminal phase to "
+        "RESTARTING when lifecycle.restart_requested() is true (LP-3)."
+    )
+    assert "restart_requested()" in finally_block, (
+        "bot1.py finally block must consult "
+        "lifecycle.restart_requested() to choose between STOPPED and "
+        "RESTARTING (LP-3)."
+    )
+
+
 def test_bot1_shutdown_drain_logs_timeout() -> None:
     """PR-02b (revised): when the 5 s drain budget elapses with tasks
     still pending, a WARNING log must surface so operators see the


### PR DESCRIPTION
## Summary

**Stacked on #259 (LP-2).** Merge #259 first; GitHub will then retarget
this PR's base to `main` automatically.

Closes the highest-severity architectural violation flagged in the
original Runtime Lifecycle audit: `cogs/admin_cog.py:309-318` calls
`os.execv` directly. After this PR, the cog only records intent
through `lifecycle.request_restart(reason, actor)`; a watchdog in
`bot1.py` turns the intent into `bot.close()` with a bounded timeout,
the `main()` finally block runs cleanup, and the process exits cleanly
so Railway respawns the container.

Decision gate 1 from the plan revision: chose **clean exit + Railway
respawn** over in-process `os.execv` from `bot1.py`. Simpler;
eliminates the exec race; the lock release races nothing because the
new replica boots only after the old process is gone.

## Changes

**`disbot/cogs/admin_cog.py`**

- Remove `import os`, `import sys` (used only by the deleted `os.execv`
  + `PID_FILE` plumbing).
- Remove the vestigial `PID_FILE` constant — nothing in the codebase
  creates that file; it was bookkeeping for an older deployment model.
- `reload_main_script` (`!restart`) now calls
  `lifecycle.request_restart(reason="!restart", actor=str(ctx.author))`:
  - Accepted → user sees `♻️ Restart requested. Bot is closing for restart.`
  - Coalesced → user sees `⚠️ A shutdown or restart is already in
    progress — request coalesced.`
- The cog never calls `bot.close()`, `os.execv`, `os._exit`, or
  `sys.exit` directly.

**`disbot/bot1.py`**

- New `_drive_close_on_restart_request` watchdog: polls
  `lifecycle.restart_requested()` every 0.5 s, then calls
  `asyncio.wait_for(bot.close(), timeout=RESTART_CLOSE_TIMEOUT_SECONDS)`.
- On timeout: `logger.critical` + `os._exit(1)`. Railway respawns on
  the non-zero exit; the runtime lock cannot be held past its 90 s
  TTL by a wedged process.
- `RESTART_CLOSE_TIMEOUT_SECONDS = 20.0` is the named bound.
- Watchdog spawned as supervised task `"restart_close_driver"` via the
  canonical `_runtime_tasks.spawn`, next to the other supervised app
  tasks (heartbeat, health, session_gc, memory sampler, scheduler).
- `main()` finally block now promotes the terminal phase to
  `RESTARTING` (instead of `STOPPED`) when
  `lifecycle.restart_requested()` is true, so the recent-event buffer
  distinguishes restart-exit from shutdown-exit.

## Flow

```
!restart command
  → lifecycle.request_restart(reason="!restart", actor=...)
    → phase: RUNNING → DRAINING
    → channel guard begins rejecting new commands
  → cog acks "♻️ Restart requested..."
  → (separately, in background)
    restart_close_driver watchdog wakes:
      lifecycle.restart_requested() → True
      → asyncio.wait_for(bot.close(), timeout=20.0)
        → on success: bot.start() in main() returns
          → finally block runs:
              phase → SHUTTING_DOWN
              heartbeat stop, task drain (5s), lock release, db close
              phase → RESTARTING (restart_requested was True)
          → main() returns
          → process exits with code 0
          → Railway respawns
        → on timeout: os._exit(1) → Railway respawns
```

## Test plan

- [x] `python -m pytest tests/unit/cogs/test_admin_restart.py` — 4/4
  pass. Source contains no `os.execv`/`os._exit`/`sys.exit`/`bot.close()`;
  AST shows `lifecycle.request_restart` in the command body; invoking
  the command records the intent and ACKs the user without closing
  the bot; concurrent invocations coalesce with explicit user
  feedback.
- [x] `python -m pytest tests/unit/test_bot_boot.py` — 10/10 pass.
  Three new LP-3 invariants: `restart_close_driver` is spawned; the
  watchdog uses `asyncio.wait_for(bot.close(), ...)` with the
  `RESTART_CLOSE_TIMEOUT_SECONDS` bound; finally block consults
  `lifecycle.restart_requested()` and promotes to `RESTARTING`.
- [x] Full suite: `python -m pytest tests/` — 3982 passed, 3 skipped,
  0 failures.
- [x] `black`, `isort`, `ruff`, `mypy disbot/` — all green.

## Scope

This PR intentionally does **not** touch:
- the runtime-lock deploy handoff (LP-4 — the boot-wait retry loop
  for rolling deploys).
- SIGTERM-driven shutdown still relies on the orchestration platform
  to send SIGKILL after the grace period. LP-5 fixes SIGTERM to
  enter the lifecycle close path through this same watchdog (or
  through an explicit shutdown-driver task).

## Behaviour comparison

| Scenario | Before LP-3 (`os.execv` in cog) | After LP-3 (clean exit + respawn) |
|---|---|---|
| `!restart` happy path | cog calls `bot.close()`, then `os.execv` overlays the address space. If `bot.close()` is fast, finally block completes before exec. | cog records intent; watchdog closes bot with timeout; finally block runs; process exits cleanly; Railway respawns. |
| `bot.close()` hangs | `os.execv` fires anyway; finally block half-runs; new process boots into contention with the stalled old PID's lock (still owned for up to 90 s TTL). | watchdog times out at 20 s; `os._exit(1)`; Railway respawns; new process can claim the lock only after the orphan TTL — but that scenario is now bounded and observable. |
| Two `!restart`s in 1s | first `bot.close()` is awaited; second goes through guard rejection (which is racy depending on order). | second call coalesces in lifecycle; user gets explicit "already in progress" message; only one close runs. |

https://claude.ai/code/session_01F1dpJ11fmQaQGnWboa78qb

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1dpJ11fmQaQGnWboa78qb)_