### PR TITLE
LP-4: runtime-lock boot-wait loop for rolling-deploy handoff

### DIFF
--- a/disbot/services/metrics.py
+++ b/disbot/services/metrics.py
@@ -112,6 +112,22 @@ task_outcome_total = Counter(
     ["name", "outcome"],  # outcome: ok | error | cancelled
 )
 
+# LP-4: rolling-deploy handoff for the runtime lock. ``acquired_immediate``
+# is the happy path (no peer held the lock); ``acquired_after_wait`` means
+# the old replica drained and we took over; ``timeout`` means the boot
+# wait budget elapsed and this replica exited idle.
+runtime_lock_boot_handoff_total = Counter(
+    "runtime_lock_boot_handoff_total",
+    "Outcome of the boot-time runtime-lock acquisition loop.",
+    ["outcome"],  # acquired_immediate | acquired_after_wait | timeout
+)
+
+runtime_lock_boot_wait_seconds = Histogram(
+    "runtime_lock_boot_wait_seconds",
+    "Time spent waiting for the runtime lock during boot (acquired or timed out).",
+    buckets=(0.1, 0.5, 1.0, 5.0, 15.0, 30.0, 60.0, 120.0, 300.0),
+)
+
 governance_fail_open_total = Counter(
     "governance_fail_open_total",
     "Interaction-router governance gate fell open due to resolver error. "

--- a/disbot/services/runtime.py
+++ b/disbot/services/runtime.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import time
 import uuid
 
 from utils.db import runtime_lock
@@ -32,6 +33,43 @@ BOOT_ID: uuid.UUID = uuid.uuid4()
 
 DEFAULT_HEARTBEAT_SECONDS: int = 30
 _HEARTBEAT_FAILURE_LIMIT: int = 3
+
+# LP-4: rolling-deploy handoff. When another fresh replica still holds
+# the runtime lock at boot, poll for up to ``DEFAULT_BOOT_WAIT_SECONDS``
+# rather than exit-zeroing immediately. 150 s comfortably covers a
+# graceful old-replica drain (heartbeat 30 s + drain budget 5 s + DB
+# close) plus margin for slow networks. Operators override per
+# environment via the env knobs below; Railway's default healthcheck
+# window must be at least the wait budget or new replicas will be
+# rotated out as unhealthy before they can claim the lock.
+DEFAULT_BOOT_WAIT_SECONDS: float = 150.0
+DEFAULT_BOOT_POLL_SECONDS: float = 5.0
+
+
+def _env_float(name: str, default: float) -> float:
+    """Read a positive float from an env var, falling back on parse error."""
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid %s=%r; using default %.1fs.",
+            name,
+            raw,
+            default,
+        )
+        return default
+    if value < 0:
+        logger.warning(
+            "%s=%.1f is negative; using default %.1fs.",
+            name,
+            value,
+            default,
+        )
+        return default
+    return value
 
 
 class BootIdFilter(logging.Filter):
@@ -74,51 +112,131 @@ async def acquire_lock_or_exit(
     boot_id: uuid.UUID = BOOT_ID,
     lock_name: str = runtime_lock.DEFAULT_LOCK_NAME,
     stale_after_seconds: int = runtime_lock.DEFAULT_STALE_AFTER_SECONDS,
+    boot_wait_seconds: float | None = None,
+    boot_poll_seconds: float | None = None,
 ) -> None:
     """Claim the runtime lock or exit the process cleanly.
 
-    Exit code 0 (not 1) when the lock is held by a fresh peer — this is
-    a normal multi-replica scenario, not a crash, so Railway should not
-    restart the loser.
+    LP-4: when another fresh replica holds the lock at boot, poll up
+    to ``boot_wait_seconds`` (env ``RUNTIME_LOCK_BOOT_WAIT_SECONDS``,
+    default 150 s) for it to release, rather than exit-zeroing on the
+    first attempt. This smooths rolling-deploy handoffs where the new
+    replica boots before the old one has finished draining. On
+    timeout we still exit 0 so the orchestration platform leaves this
+    replica idle.
 
-    Exit code 1 when the underlying DB call fails — we want Railway to
-    restart and retry. The DB failure is logged before exit.
+    Exit code 0 when the lock is held by a fresh peer after the wait
+    budget elapses — normal multi-replica handoff, not a crash.
+
+    Exit code 1 when the underlying DB call fails — we want the
+    orchestration platform to restart and retry. The DB failure is
+    logged before exit.
+    """
+    if boot_wait_seconds is None:
+        boot_wait_seconds = _env_float(
+            "RUNTIME_LOCK_BOOT_WAIT_SECONDS",
+            DEFAULT_BOOT_WAIT_SECONDS,
+        )
+    if boot_poll_seconds is None:
+        boot_poll_seconds = _env_float(
+            "RUNTIME_LOCK_BOOT_POLL_SECONDS",
+            DEFAULT_BOOT_POLL_SECONDS,
+        )
+    # Sanity: poll must be > 0 and strictly less than wait so the loop
+    # makes progress. If misconfigured, fall back to safe values.
+    if boot_wait_seconds > 0 and (
+        boot_poll_seconds <= 0 or boot_poll_seconds >= boot_wait_seconds
+    ):
+        logger.warning(
+            "RUNTIME_LOCK_BOOT_POLL_SECONDS=%.1f vs "
+            "RUNTIME_LOCK_BOOT_WAIT_SECONDS=%.1f — using min(1s, wait) "
+            "for poll.",
+            boot_poll_seconds,
+            boot_wait_seconds,
+        )
+        boot_poll_seconds = min(1.0, boot_wait_seconds)
+
+    started_at = time.monotonic()
+    deadline = started_at + boot_wait_seconds
+    attempts = 0
+    while True:
+        attempts += 1
+        try:
+            result = await runtime_lock.try_acquire(
+                boot_id,
+                lock_name=lock_name,
+                stale_after_seconds=stale_after_seconds,
+            )
+        except Exception as exc:
+            logger.critical(
+                "runtime_lock.try_acquire failed: %s — exiting so the "
+                "orchestration platform restarts this replica.",
+                exc,
+                exc_info=True,
+            )
+            raise SystemExit(1) from exc
+
+        elapsed = time.monotonic() - started_at
+        if result.acquired:
+            logger.info(
+                "Runtime lock acquired (lock_name=%s boot_id=%s "
+                "attempts=%d wait=%.1fs).",
+                lock_name,
+                boot_id,
+                attempts,
+                elapsed,
+            )
+            _record_handoff_outcome(
+                "acquired_after_wait" if attempts > 1 else "acquired_immediate",
+                elapsed,
+            )
+            return
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            logger.warning(
+                "Runtime lock held by another live replica after "
+                "%.1fs of waiting (lock_name=%s holder_boot_id=%s "
+                "last_heartbeat=%s reason=%s attempts=%d). Exiting "
+                "cleanly so the orchestration platform leaves this "
+                "replica idle.",
+                elapsed,
+                lock_name,
+                result.holder_boot_id,
+                result.holder_heartbeat_at,
+                result.reason,
+                attempts,
+            )
+            _record_handoff_outcome("timeout", elapsed)
+            raise SystemExit(0)
+
+        sleep_for = min(boot_poll_seconds, remaining)
+        logger.info(
+            "Runtime lock held by peer (holder=%s heartbeat=%s "
+            "reason=%s attempt=%d); retrying in %.1fs "
+            "(remaining=%.1fs of %.1fs budget).",
+            result.holder_boot_id,
+            result.holder_heartbeat_at,
+            result.reason,
+            attempts,
+            sleep_for,
+            remaining,
+            boot_wait_seconds,
+        )
+        await asyncio.sleep(sleep_for)
+
+
+def _record_handoff_outcome(outcome: str, elapsed_seconds: float) -> None:
+    """Update boot-handoff metrics, swallowing import errors so the
+    runtime path never depends on prometheus_client being installed.
     """
     try:
-        result = await runtime_lock.try_acquire(
-            boot_id,
-            lock_name=lock_name,
-            stale_after_seconds=stale_after_seconds,
-        )
-    except Exception as exc:
-        logger.critical(
-            "runtime_lock.try_acquire failed: %s — exiting so Railway "
-            "restarts this replica.",
-            exc,
-            exc_info=True,
-        )
-        raise SystemExit(1) from exc
+        from services import metrics as _metrics
 
-    if result.acquired:
-        logger.info(
-            "Runtime lock acquired (lock_name=%s boot_id=%s).",
-            lock_name,
-            boot_id,
-        )
-        return
-
-    holder = result.holder_boot_id
-    heartbeat = result.holder_heartbeat_at
-    logger.warning(
-        "Runtime lock held by another live replica "
-        "(lock_name=%s holder_boot_id=%s last_heartbeat=%s reason=%s). "
-        "Exiting cleanly so Railway leaves this replica idle.",
-        lock_name,
-        holder,
-        heartbeat,
-        result.reason,
-    )
-    raise SystemExit(0)
+        _metrics.runtime_lock_boot_handoff_total.labels(outcome=outcome).inc()
+        _metrics.runtime_lock_boot_wait_seconds.observe(elapsed_seconds)
+    except Exception:
+        logger.debug("Boot-handoff metric not recorded (metrics unavailable).")
 
 
 async def run_heartbeat_loop(

--- a/tests/unit/services/test_runtime.py
+++ b/tests/unit/services/test_runtime.py
@@ -63,6 +63,8 @@ async def test_acquire_lock_or_exit_returns_when_acquired():
 
 @pytest.mark.asyncio
 async def test_acquire_lock_or_exit_exits_zero_when_held_by_peer():
+    """LP-4: with ``boot_wait_seconds=0`` the loop short-circuits to
+    the pre-LP-4 single-shot semantics — peer held → SystemExit(0)."""
     fake_result = rl_db.AcquireResult(
         acquired=False,
         holder_boot_id=uuid.uuid4(),
@@ -71,7 +73,7 @@ async def test_acquire_lock_or_exit_exits_zero_when_held_by_peer():
     )
     with patch.object(rl_db, "try_acquire", AsyncMock(return_value=fake_result)):
         with pytest.raises(SystemExit) as exc_info:
-            await runtime.acquire_lock_or_exit()
+            await runtime.acquire_lock_or_exit(boot_wait_seconds=0)
         assert exc_info.value.code == 0
 
 
@@ -83,8 +85,123 @@ async def test_acquire_lock_or_exit_exits_one_when_db_fails():
         AsyncMock(side_effect=RuntimeError("db down")),
     ):
         with pytest.raises(SystemExit) as exc_info:
-            await runtime.acquire_lock_or_exit()
+            await runtime.acquire_lock_or_exit(boot_wait_seconds=0)
         assert exc_info.value.code == 1
+
+
+@pytest.mark.asyncio
+async def test_acquire_lock_or_exit_polls_until_peer_releases():
+    """LP-4: when a fresh peer holds the lock, the loop should retry
+    on each tick until the peer releases (acquired=True). The total
+    wait is bounded by ``boot_wait_seconds`` but the loop exits as
+    soon as acquisition succeeds."""
+    held = rl_db.AcquireResult(
+        acquired=False,
+        holder_boot_id=uuid.uuid4(),
+        holder_heartbeat_at=None,
+        reason="row_fresh",
+    )
+    acquired = rl_db.AcquireResult(
+        acquired=True,
+        holder_boot_id=runtime.BOOT_ID,
+        holder_heartbeat_at=None,
+        reason="acquired",
+    )
+    # First two attempts: peer holds. Third: peer released, we acquire.
+    try_acquire = AsyncMock(side_effect=[held, held, acquired])
+    sleep_mock = AsyncMock()
+
+    with (
+        patch.object(rl_db, "try_acquire", try_acquire),
+        patch("services.runtime.asyncio.sleep", sleep_mock),
+    ):
+        await runtime.acquire_lock_or_exit(
+            boot_wait_seconds=60.0,
+            boot_poll_seconds=0.01,
+        )
+
+    assert try_acquire.await_count == 3
+    # Two retries → two sleeps.
+    assert sleep_mock.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_acquire_lock_or_exit_exits_zero_after_wait_timeout():
+    """LP-4: a peer that never releases causes the loop to give up
+    after ``boot_wait_seconds`` and exit with code 0 (idle, not crash)."""
+    fake_result = rl_db.AcquireResult(
+        acquired=False,
+        holder_boot_id=uuid.uuid4(),
+        holder_heartbeat_at=None,
+        reason="row_fresh",
+    )
+    try_acquire = AsyncMock(return_value=fake_result)
+    sleep_mock = AsyncMock()
+
+    with (
+        patch.object(rl_db, "try_acquire", try_acquire),
+        patch("services.runtime.asyncio.sleep", sleep_mock),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            # Use a tiny budget so the test finishes quickly without
+            # mocking ``time.monotonic``.
+            await runtime.acquire_lock_or_exit(
+                boot_wait_seconds=0.05,
+                boot_poll_seconds=0.01,
+            )
+        assert exc_info.value.code == 0
+    # At least two attempts: one immediate + one after a sleep before
+    # the deadline elapses.
+    assert try_acquire.await_count >= 2
+
+
+@pytest.mark.asyncio
+async def test_acquire_lock_or_exit_reads_env_knobs_when_args_omitted(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Env vars supply the defaults when the caller doesn't pass
+    explicit ``boot_wait_seconds`` / ``boot_poll_seconds``."""
+    fake_result = rl_db.AcquireResult(
+        acquired=False,
+        holder_boot_id=uuid.uuid4(),
+        holder_heartbeat_at=None,
+        reason="row_fresh",
+    )
+    monkeypatch.setenv("RUNTIME_LOCK_BOOT_WAIT_SECONDS", "0")
+    monkeypatch.setenv("RUNTIME_LOCK_BOOT_POLL_SECONDS", "0")
+
+    with patch.object(rl_db, "try_acquire", AsyncMock(return_value=fake_result)):
+        with pytest.raises(SystemExit) as exc_info:
+            await runtime.acquire_lock_or_exit()
+        assert exc_info.value.code == 0
+
+
+@pytest.mark.asyncio
+async def test_acquire_lock_or_exit_falls_back_to_safe_defaults_on_bad_poll(
+    caplog: pytest.LogCaptureFixture,
+):
+    """If poll >= wait, fall back to a safe poll value and warn so the
+    operator sees the misconfiguration in logs."""
+    fake_result = rl_db.AcquireResult(
+        acquired=False,
+        holder_boot_id=uuid.uuid4(),
+        holder_heartbeat_at=None,
+        reason="row_fresh",
+    )
+    sleep_mock = AsyncMock()
+    with (
+        patch.object(rl_db, "try_acquire", AsyncMock(return_value=fake_result)),
+        patch("services.runtime.asyncio.sleep", sleep_mock),
+        caplog.at_level(logging.WARNING, logger="bot.services.runtime"),
+    ):
+        with pytest.raises(SystemExit):
+            await runtime.acquire_lock_or_exit(
+                boot_wait_seconds=0.05,
+                boot_poll_seconds=10.0,  # poll > wait
+            )
+    assert any(
+        "BOOT_POLL_SECONDS" in record.message for record in caplog.records
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`services.runtime.acquire_lock_or_exit` now polls up to a bounded
budget when another fresh replica holds the runtime lock at boot,
rather than `SystemExit(0)`-ing on the first attempt. This smooths
rolling-deploy handoffs: under the old single-shot semantics the new
replica saw a fresh peer and exited immediately, forcing Railway to
rotate it out and reschedule. After this PR the new replica waits up
to 150 s (default) for the old replica to finish draining, then
acquires the lock and continues boot.

Independent of LP-2 / LP-3 — no lifecycle wiring; just the loop +
metrics. Base is `main`.

## Decision-gate note

The plan's gate 2 asks: **"Railway healthcheck timeout must be ≥ the
boot wait budget (default 150 s) or new replicas will be rotated out
as unhealthy before they can claim the lock."** Please verify Railway's
healthcheck window covers 150 s before merging, or set
`RUNTIME_LOCK_BOOT_WAIT_SECONDS` lower in the environment to match.

## Changes

**`disbot/services/runtime.py`**

- New env helpers: `RUNTIME_LOCK_BOOT_WAIT_SECONDS` (default 150.0),
  `RUNTIME_LOCK_BOOT_POLL_SECONDS` (default 5.0). Read at function
  entry; explicit callable args override.
- `acquire_lock_or_exit` gains `boot_wait_seconds` and
  `boot_poll_seconds` keyword-only parameters.
- Loop body:
  1. `try_acquire`; on exception → `SystemExit(1)` (unchanged).
  2. `acquired=True` → log + metric (`acquired_immediate` /
     `acquired_after_wait`) + return.
  3. `acquired=False` with budget remaining → log + sleep
     `min(poll, remaining)` + try again.
  4. `acquired=False` with budget exhausted → log + metric
     (`timeout`) + `SystemExit(0)`.
- Misconfiguration guard: if `poll >= wait`, fall back to
  `min(1s, wait)` and log a warning so the operator sees it.
- All metric calls wrapped in try/except so a missing
  `prometheus_client` never breaks the boot path.

**`disbot/services/metrics.py`** — two new Prometheus surfaces:

- `runtime_lock_boot_handoff_total{outcome}` counter — labelled by
  `acquired_immediate` / `acquired_after_wait` / `timeout`.
- `runtime_lock_boot_wait_seconds` histogram — total wait time
  (acquired or timed out). Buckets: 0.1, 0.5, 1, 5, 15, 30, 60, 120,
  300 s.

## Behaviour comparison

| Scenario | Before LP-4 | After LP-4 |
|---|---|---|
| No peer at boot | acquire → log → return | acquire → log + `acquired_immediate` metric → return |
| Peer holds + drains within 5 s | `SystemExit(0)` immediately → Railway loses the new worker → reschedule | wait 5 s → peer gone → acquire + `acquired_after_wait` metric |
| Peer holds forever | `SystemExit(0)` immediately | wait 150 s → log + `timeout` metric + `SystemExit(0)` |
| DB error | `SystemExit(1)` | `SystemExit(1)` (unchanged) |

## Test plan

- [x] `python -m pytest tests/unit/services/test_runtime.py` — 15/15
  pass. Two existing tests updated to pass `boot_wait_seconds=0`
  (preserves single-shot semantics for the unchanged scenarios).
  Four new tests:
  - `polls_until_peer_releases` — 3 attempts (`held → held →
    acquired`), 2 sleeps.
  - `exits_zero_after_wait_timeout` — bounded 50 ms budget; assert
    `SystemExit(0)` + ≥2 attempts.
  - `reads_env_knobs_when_args_omitted` — env vars supply defaults
    when caller omits them.
  - `falls_back_to_safe_defaults_on_bad_poll` — `poll > wait`
    triggers fallback + WARNING log.
- [x] Full suite: `python -m pytest tests/` — 3955 passed, 3 skipped,
  0 failures.
- [x] `black`, `isort`, `ruff`, `mypy disbot/` — all green.

## Scope

This PR intentionally does **not** touch:
- the lifecycle service (LP-2) — boot-wait outcomes are observable
  via the new metrics. Wiring into `lifecycle.get_recent_events()` is
  a future follow-up if a unified event stream is desired.
- shutdown / restart paths (LP-3, LP-5).
- diagnostics surfaces (LP-6).

The `RUNTIME_LOCK_BOOT_WAIT_SECONDS` / `BOOT_POLL_SECONDS` env vars
should be documented in the operator runbook in LP-12.

https://claude.ai/code/session_01F1dpJ11fmQaQGnWboa78qb

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1dpJ11fmQaQGnWboa78qb)_