### PR TITLE
fix(runtime): generalize lifecycle close-driver for SIGTERM + restart

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -551,59 +551,93 @@ async def _sample_process_memory() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Restart close-driver — LP-3
+# Lifecycle close-driver
 # ---------------------------------------------------------------------------
 
-RESTART_CLOSE_TIMEOUT_SECONDS: float = 20.0
-_RESTART_CLOSE_POLL_INTERVAL: float = 0.5
+LIFECYCLE_CLOSE_TIMEOUT_SECONDS: float = 20.0
+_LIFECYCLE_CLOSE_POLL_INTERVAL: float = 0.5
+_LIFECYCLE_CLOSE_WEBHOOK_TIMEOUT_SECONDS: float = 2.0
 
 
-async def _drive_close_on_restart_request() -> None:
-    """Turn a lifecycle restart request into ``bot.close()``.
+def _should_drive_lifecycle_close() -> bool:
+    """Single eligibility predicate for the close-driver.
 
-    LP-3: cog commands (``!restart``) record intent via
-    :func:`core.runtime.lifecycle.request_restart` but never touch
-    process control directly.  This watchdog polls the lifecycle
-    pending state and, when a restart is pending, closes the bot with
-    a bounded timeout.  ``main()`` then unwinds through the finally
-    block (heartbeat stop → task drain → lock release → DB close) and
-    the process exits cleanly, so the orchestration platform respawns
-    the container.
+    True iff a lifecycle request is pending AND the lifecycle module
+    has already moved the phase into DRAINING.  Both
+    ``request_shutdown`` and ``request_restart`` perform that
+    STARTING/RUNNING → DRAINING transition themselves, so polling on
+    this predicate covers shutdown and restart with one code path.
+    """
+    pending = _lifecycle.get_pending()
+    phase = _lifecycle.get_phase()
+    return pending is not None and phase is _lifecycle.Phase.DRAINING
 
-    On timeout the close is force-completed via ``os._exit(1)`` rather
-    than left hanging — Railway will respawn after a non-zero exit and
-    that is preferable to a wedged process holding the runtime lock
-    until the 90 s TTL.
 
-    Shutdown intent (``request_shutdown`` without restart) is owned by
-    LP-5; this task only acts on restart-flavoured intent.
+async def _drive_close_on_lifecycle_request() -> None:
+    """Turn any pending lifecycle request into ``bot.close()``.
+
+    SIGTERM (``request_shutdown``) and ``!restart``
+    (``request_restart``) both record intent via
+    :mod:`core.runtime.lifecycle`; neither touches process control
+    directly.  This watchdog is the single executor for both: it polls
+    the lifecycle state, and when a request is pending and the phase
+    has reached DRAINING, fires a best-effort close-beginning webhook
+    and then awaits ``bot.close()`` with a bounded timeout.  ``main()``
+    then unwinds through its existing finally block (heartbeat stop →
+    task drain → runtime-lock release → DB close → reporter close →
+    terminal phase) and the process exits cleanly.
+
+    The driver does **not** distinguish shutdown vs restart — the
+    finalizer makes that distinction via
+    :func:`core.runtime.lifecycle.restart_requested` when choosing the
+    terminal phase.  It also does not own any cleanup itself; that
+    separation is what lets shutdown and restart share one code path
+    without duplicating cleanup responsibility.
+
+    On close-timeout the process is force-exited via ``os._exit(1)``
+    so the orchestration platform respawns rather than leaving the
+    runtime lock wedged until its 90 s TTL.
     """
     while True:
         try:
-            await asyncio.sleep(_RESTART_CLOSE_POLL_INTERVAL)
+            await asyncio.sleep(_LIFECYCLE_CLOSE_POLL_INTERVAL)
         except asyncio.CancelledError:
             return
-        if not _lifecycle.restart_requested():
+        if not _should_drive_lifecycle_close():
             continue
         pending = _lifecycle.get_pending()
+        kind = pending.kind if pending else "<unknown>"
         actor = pending.actor if pending and pending.actor else "<unknown>"
         reason = pending.reason if pending else "<unknown>"
         logger.info(
-            "Restart requested by %s (reason=%r); closing bot (timeout %.1fs).",
+            "Lifecycle %s requested by %s (reason=%r); closing bot "
+            "(timeout %.1fs).",
+            kind,
             actor,
             reason,
-            RESTART_CLOSE_TIMEOUT_SECONDS,
+            LIFECYCLE_CLOSE_TIMEOUT_SECONDS,
         )
+        if reporter is not None and pending is not None:
+            try:
+                await asyncio.wait_for(
+                    reporter.on_lifecycle_close_beginning(pending),
+                    timeout=_LIFECYCLE_CLOSE_WEBHOOK_TIMEOUT_SECONDS,
+                )
+            except Exception as report_err:
+                logger.debug(
+                    "Lifecycle close-beginning webhook skipped: %s",
+                    report_err,
+                )
         try:
             await asyncio.wait_for(
                 bot.close(),
-                timeout=RESTART_CLOSE_TIMEOUT_SECONDS,
+                timeout=LIFECYCLE_CLOSE_TIMEOUT_SECONDS,
             )
         except asyncio.TimeoutError:
             logger.critical(
                 "bot.close() exceeded %.1fs timeout — force-exiting "
                 "so the orchestration platform respawns.",
-                RESTART_CLOSE_TIMEOUT_SECONDS,
+                LIFECYCLE_CLOSE_TIMEOUT_SECONDS,
             )
             os._exit(1)
         return
@@ -724,13 +758,15 @@ async def main() -> None:
                 on_error=_on_app_task_died_webhook,
             )
 
-            # LP-3: turn lifecycle.request_restart into bot.close(). The
-            # cog only records intent; this watchdog is the single
-            # executor. Bounded timeout falls back to os._exit so a
-            # wedged close cannot hold the runtime lock past its TTL.
+            # Turn any pending lifecycle request (SIGTERM shutdown or
+            # !restart) into bot.close(). Cogs and signal handlers only
+            # record intent; this watchdog is the single executor for
+            # both shutdown and restart.  Bounded timeout falls back to
+            # os._exit so a wedged close cannot hold the runtime lock
+            # past its TTL.
             _runtime_tasks.spawn(
-                "restart_close_driver",
-                _drive_close_on_restart_request(),
+                "lifecycle_close_driver",
+                _drive_close_on_lifecycle_request(),
                 on_error=_on_app_task_died_webhook,
             )
 

--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -610,8 +610,7 @@ async def _drive_close_on_lifecycle_request() -> None:
         actor = pending.actor if pending and pending.actor else "<unknown>"
         reason = pending.reason if pending else "<unknown>"
         logger.info(
-            "Lifecycle %s requested by %s (reason=%r); closing bot "
-            "(timeout %.1fs).",
+            "Lifecycle %s requested by %s (reason=%r); closing bot (timeout %.1fs).",
             kind,
             actor,
             reason,

--- a/disbot/services/webhook_reporter.py
+++ b/disbot/services/webhook_reporter.py
@@ -14,11 +14,15 @@ from __future__ import annotations
 import datetime
 import logging
 import traceback
+from typing import TYPE_CHECKING
 
 import aiohttp
 import discord
 
 from core.runtime.ai.redaction import redact_text
+
+if TYPE_CHECKING:
+    from core.runtime.lifecycle import PendingShutdown
 
 logger = logging.getLogger("bot.webhook")
 
@@ -274,6 +278,42 @@ class WebhookReporter:
             timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
         )
         await self._send(embed, username="Bot Health")
+
+    async def on_lifecycle_close_beginning(
+        self,
+        pending: "PendingShutdown",
+    ) -> None:
+        """Posted by the close-driver immediately before ``bot.close()``.
+
+        Operators see one canonical "the bot is about to close" signal
+        for both SIGTERM shutdown and ``!restart``.  The caller wraps
+        this in best-effort try/except + ``asyncio.wait_for`` so a
+        stalled webhook cannot delay ``bot.close()`` and the finalizer.
+        """
+        is_restart = pending.kind == "restart"
+        title = (
+            "♻️ Bot Restart Beginning"
+            if is_restart
+            else "🛑 Bot Shutdown Beginning"
+        )
+        color = discord.Color.gold() if is_restart else discord.Color.red()
+        embed = discord.Embed(
+            title=title,
+            color=color,
+            timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
+        )
+        embed.add_field(name="Kind", value=pending.kind, inline=True)
+        embed.add_field(
+            name="Reason",
+            value=pending.reason or "<unknown>",
+            inline=True,
+        )
+        embed.add_field(
+            name="Actor",
+            value=pending.actor or "<unknown>",
+            inline=True,
+        )
+        await self._send(embed, username="Bot Lifecycle")
 
     async def on_app_task_died(self, name: str, error: BaseException) -> None:
         """A supervised application task raised after startup.

--- a/disbot/services/webhook_reporter.py
+++ b/disbot/services/webhook_reporter.py
@@ -281,7 +281,7 @@ class WebhookReporter:
 
     async def on_lifecycle_close_beginning(
         self,
-        pending: "PendingShutdown",
+        pending: PendingShutdown,
     ) -> None:
         """Posted by the close-driver immediately before ``bot.close()``.
 
@@ -292,9 +292,7 @@ class WebhookReporter:
         """
         is_restart = pending.kind == "restart"
         title = (
-            "♻️ Bot Restart Beginning"
-            if is_restart
-            else "🛑 Bot Shutdown Beginning"
+            "♻️ Bot Restart Beginning" if is_restart else "🛑 Bot Shutdown Beginning"
         )
         color = discord.Color.gold() if is_restart else discord.Color.red()
         embed = discord.Embed(

--- a/tests/unit/test_bot1_lifecycle_close_driver.py
+++ b/tests/unit/test_bot1_lifecycle_close_driver.py
@@ -1,0 +1,247 @@
+"""Behavioural tests for ``bot1._drive_close_on_lifecycle_request``.
+
+The close-driver is the single executor for both SIGTERM-driven
+shutdown and ``!restart``-driven restart: cogs and signal handlers
+only record intent via ``core.runtime.lifecycle``; this watchdog turns
+that intent into ``bot.close()`` so ``main()``'s finally block can run
+cleanup.
+
+These tests verify the close-driver contract without booting the real
+bot, by monkeypatching the module-level ``bot`` and ``reporter`` that
+the driver reads from globals at call time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+import bot1
+from core.runtime import lifecycle
+
+
+@pytest.fixture(autouse=True)
+def _reset_lifecycle_state() -> None:
+    """Match the lifecycle test suite — autouse so module-level state
+    cannot leak between cases (the lifecycle module holds a process-wide
+    phase, pending request, and event buffer)."""
+    lifecycle.reset_for_tests()
+    yield
+    lifecycle.reset_for_tests()
+
+
+class _FakeBot:
+    """Minimal stand-in for ``commands.Bot`` exposing only ``close``."""
+
+    def __init__(self) -> None:
+        self.close_calls = 0
+
+    async def close(self) -> None:
+        self.close_calls += 1
+
+
+class _FakeReporter:
+    def __init__(self) -> None:
+        self.calls: list[Any] = []
+
+    async def on_lifecycle_close_beginning(self, pending: Any) -> None:
+        self.calls.append(("close_beginning", pending))
+
+
+def _install_fast_poll(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the driver loop iterate fast enough to fit a test."""
+    monkeypatch.setattr(bot1, "_LIFECYCLE_CLOSE_POLL_INTERVAL", 0.01)
+
+
+@pytest.mark.asyncio
+async def test_shutdown_pending_drives_bot_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SIGTERM intent (``request_shutdown``) must reach ``bot.close()``.
+
+    This is the regression this PR exists to fix: previously the driver
+    only acted on restart intent, so a plain shutdown left the bot in
+    DRAINING with ``bot.start(...)`` never unwinding.
+    """
+    fake_bot = _FakeBot()
+    monkeypatch.setattr(bot1, "bot", fake_bot)
+    monkeypatch.setattr(bot1, "reporter", None)
+    _install_fast_poll(monkeypatch)
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown(reason="sigterm")
+    assert lifecycle.get_phase() is lifecycle.Phase.DRAINING
+
+    await asyncio.wait_for(bot1._drive_close_on_lifecycle_request(), timeout=2.0)
+
+    assert fake_bot.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_restart_pending_drives_bot_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``!restart`` intent (``request_restart``) must still reach
+    ``bot.close()`` — the generalised driver must not regress the
+    behaviour the old restart-only driver provided."""
+    fake_bot = _FakeBot()
+    monkeypatch.setattr(bot1, "bot", fake_bot)
+    monkeypatch.setattr(bot1, "reporter", None)
+    _install_fast_poll(monkeypatch)
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_restart(reason="!restart", actor="op")
+    assert lifecycle.get_phase() is lifecycle.Phase.DRAINING
+
+    await asyncio.wait_for(bot1._drive_close_on_lifecycle_request(), timeout=2.0)
+
+    assert fake_bot.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_no_close_when_phase_past_draining(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pending request alone is not enough — the driver must wait
+    until the phase reaches DRAINING.  Once cleanup has already started
+    (SHUTTING_DOWN), firing close again would re-enter the teardown
+    path."""
+    fake_bot = _FakeBot()
+    monkeypatch.setattr(bot1, "bot", fake_bot)
+    monkeypatch.setattr(bot1, "reporter", None)
+    _install_fast_poll(monkeypatch)
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown(reason="sigterm")
+    lifecycle.set_phase(
+        lifecycle.Phase.SHUTTING_DOWN,
+        reason="finalizer_started",
+    )
+    assert lifecycle.get_pending() is not None
+    assert lifecycle.get_phase() is lifecycle.Phase.SHUTTING_DOWN
+
+    task = asyncio.create_task(bot1._drive_close_on_lifecycle_request())
+    await asyncio.sleep(0.05)
+    task.cancel()
+    result = await task
+
+    assert result is None
+    assert fake_bot.close_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_webhook_fires_before_bot_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Operators must see the close-beginning embed before the bot
+    starts tearing down — verifies call ordering and that the
+    reporter receives the actual ``PendingShutdown`` object."""
+    order: list[str] = []
+
+    class OrderedBot:
+        async def close(self) -> None:
+            order.append("close")
+
+    class OrderedReporter:
+        async def on_lifecycle_close_beginning(self, pending: Any) -> None:
+            order.append("webhook")
+            assert pending.kind == "shutdown"
+            assert pending.reason == "sigterm"
+
+    monkeypatch.setattr(bot1, "bot", OrderedBot())
+    monkeypatch.setattr(bot1, "reporter", OrderedReporter())
+    _install_fast_poll(monkeypatch)
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown(reason="sigterm")
+
+    await asyncio.wait_for(bot1._drive_close_on_lifecycle_request(), timeout=2.0)
+
+    assert order == ["webhook", "close"]
+
+
+@pytest.mark.asyncio
+async def test_idle_cancellation_exits_cleanly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no pending lifecycle request the driver polls indefinitely;
+    cancellation while idle must exit cleanly (no exception escapes).
+
+    The supervisor's ``cancel_all()`` calls ``task.cancel()`` on every
+    supervised task at shutdown and then awaits them in a 5 s drain
+    window.  Catching ``CancelledError`` and returning ``None`` keeps
+    the supervisor's drain summary clean (no spurious failures in the
+    on-error hook)."""
+    fake_bot = _FakeBot()
+    monkeypatch.setattr(bot1, "bot", fake_bot)
+    monkeypatch.setattr(bot1, "reporter", None)
+    _install_fast_poll(monkeypatch)
+
+    assert lifecycle.get_pending() is None
+
+    task = asyncio.create_task(bot1._drive_close_on_lifecycle_request())
+    await asyncio.sleep(0.05)
+    task.cancel()
+    result = await task
+
+    assert result is None
+    assert fake_bot.close_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_close_timeout_force_exits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``bot.close()`` hangs past the timeout the driver must
+    invoke ``os._exit(1)`` so the orchestrator respawns rather than
+    leaving the runtime lock wedged until its 90 s TTL."""
+
+    class HangingBot:
+        async def close(self) -> None:
+            await asyncio.sleep(60.0)
+
+    monkeypatch.setattr(bot1, "bot", HangingBot())
+    monkeypatch.setattr(bot1, "reporter", None)
+    monkeypatch.setattr(bot1, "LIFECYCLE_CLOSE_TIMEOUT_SECONDS", 0.05)
+    _install_fast_poll(monkeypatch)
+
+    exit_calls: list[int] = []
+
+    class _ForceExit(BaseException):
+        """Sentinel so the test process itself does not exit."""
+
+    def _fake_exit(code: int) -> None:
+        exit_calls.append(code)
+        raise _ForceExit
+
+    monkeypatch.setattr(bot1.os, "_exit", _fake_exit)
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown(reason="sigterm")
+
+    with pytest.raises(_ForceExit):
+        await asyncio.wait_for(
+            bot1._drive_close_on_lifecycle_request(),
+            timeout=2.0,
+        )
+
+    assert exit_calls == [1]
+
+
+def test_should_drive_lifecycle_close_predicate() -> None:
+    """Predicate-level coverage so the eligibility logic is exercised
+    independently of the polling loop.  Used by tests and source
+    invariants to keep the driver logic in one place."""
+    assert bot1._should_drive_lifecycle_close() is False
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    assert bot1._should_drive_lifecycle_close() is False
+
+    lifecycle.request_shutdown(reason="sigterm")
+    assert lifecycle.get_phase() is lifecycle.Phase.DRAINING
+    assert bot1._should_drive_lifecycle_close() is True
+
+    lifecycle.set_phase(lifecycle.Phase.SHUTTING_DOWN)
+    assert bot1._should_drive_lifecycle_close() is False

--- a/tests/unit/test_bot_boot.py
+++ b/tests/unit/test_bot_boot.py
@@ -185,36 +185,124 @@ def test_bot1_posts_startup_summary_webhook_before_bot_start() -> None:
     )
 
 
-def test_bot1_spawns_restart_close_driver() -> None:
-    """LP-3: the restart watchdog must be supervised at boot so a
-    ``lifecycle.request_restart`` call turns into ``bot.close()``."""
+def test_bot1_spawns_lifecycle_close_driver() -> None:
+    """The lifecycle close-driver must be supervised at boot so any
+    pending lifecycle request (SIGTERM shutdown or ``!restart``) turns
+    into ``bot.close()``."""
     src = _src()
-    assert "restart_close_driver" in src, (
+    assert "lifecycle_close_driver" in src, (
         "bot1.py must spawn a supervised task named "
-        "'restart_close_driver' to drive bot.close() on restart (LP-3)."
+        "'lifecycle_close_driver' to drive bot.close() on any pending "
+        "lifecycle request."
     )
-    assert "_drive_close_on_restart_request" in src, (
-        "bot1.py must define and spawn _drive_close_on_restart_request "
-        "(LP-3)."
+    assert "_drive_close_on_lifecycle_request" in src, (
+        "bot1.py must define and spawn _drive_close_on_lifecycle_request."
     )
 
 
-def test_bot1_restart_watchdog_uses_bounded_close_timeout() -> None:
-    """LP-3: the watchdog must wrap ``bot.close()`` in
+def test_bot1_close_driver_uses_bounded_timeout() -> None:
+    """The close-driver must wrap ``bot.close()`` in
     ``asyncio.wait_for`` with a timeout so a wedged close cannot hold
     the runtime lock past its TTL."""
     src = _src()
-    assert "RESTART_CLOSE_TIMEOUT_SECONDS" in src, (
-        "bot1.py must declare RESTART_CLOSE_TIMEOUT_SECONDS as the "
-        "named bound for the restart close (LP-3)."
+    assert "LIFECYCLE_CLOSE_TIMEOUT_SECONDS" in src, (
+        "bot1.py must declare LIFECYCLE_CLOSE_TIMEOUT_SECONDS as the "
+        "named bound for the close."
     )
     assert re.search(
         r"asyncio\.wait_for\(\s*bot\.close\(\)\s*,",
         src,
     ), (
         "bot1.py must wrap bot.close() in asyncio.wait_for with a "
-        "bounded timeout (LP-3)."
+        "bounded timeout."
     )
+
+
+def test_bot1_close_driver_gates_on_pending_and_draining() -> None:
+    """The close-driver eligibility must consult both the lifecycle
+    pending request and the DRAINING phase — that pair is what makes
+    one watchdog cover both shutdown and restart."""
+    src = _src()
+    assert "_lifecycle.get_pending()" in src, (
+        "bot1.py close-driver must consult _lifecycle.get_pending() — "
+        "not restart_requested() — so shutdown intent is also closed."
+    )
+    assert "_lifecycle.Phase.DRAINING" in src, (
+        "bot1.py close-driver must gate on _lifecycle.Phase.DRAINING."
+    )
+
+
+def test_bot1_close_driver_does_not_own_cleanup() -> None:
+    """Architectural boundary: cleanup belongs to ``main()``'s finally
+    block, not the close-driver.  The driver function body must not
+    call runtime-lock release, db.close, reporter.close, os.execv, or
+    sys.exit.  ``os._exit`` is permitted (close-timeout fail-safe).
+
+    AST-scoped to the driver function so that legitimate uses of those
+    same calls elsewhere in bot1.py (the actual finalizer) are not
+    flagged.
+    """
+    tree = ast.parse(_src())
+    driver_fn: ast.AsyncFunctionDef | None = None
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "_drive_close_on_lifecycle_request"
+        ):
+            driver_fn = node
+            break
+    assert driver_fn is not None, (
+        "bot1.py must define async def _drive_close_on_lifecycle_request."
+    )
+
+    forbidden_attr_calls = {
+        "release_lock_best_effort",
+        "execv",
+    }
+    forbidden_attr_chains = {
+        ("db", "close"),
+        ("reporter", "close"),
+        ("sys", "exit"),
+    }
+    for node in ast.walk(driver_fn):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Attribute):
+            if func.attr in forbidden_attr_calls:
+                raise AssertionError(
+                    f"close-driver must not call {func.attr!r}; "
+                    f"cleanup is owned by main()'s finally block.",
+                )
+            if isinstance(func.value, ast.Name):
+                pair = (func.value.id, func.attr)
+                if pair in forbidden_attr_chains:
+                    raise AssertionError(
+                        f"close-driver must not call "
+                        f"{pair[0]}.{pair[1]}; cleanup is owned by "
+                        f"main()'s finally block.",
+                    )
+
+
+def test_bot1_no_legacy_restart_close_driver_names() -> None:
+    """Guard against regressing the restart-only close-driver split.
+
+    The previous design coupled close execution to restart intent;
+    SIGTERM shutdowns therefore never reached bot.close().  Re-adding
+    any of these names would reintroduce that split.
+    """
+    src = _src()
+    for legacy in (
+        "_drive_close_on_restart_request",
+        "restart_close_driver",
+        "RESTART_CLOSE_TIMEOUT_SECONDS",
+        "_RESTART_CLOSE_POLL_INTERVAL",
+    ):
+        assert legacy not in src, (
+            f"Legacy restart-only close-driver name {legacy!r} "
+            f"reintroduced — see plan; the close-driver must remain "
+            f"keyed on lifecycle pending + DRAINING phase."
+        )
 
 
 def test_bot1_finally_block_transitions_to_restarting_when_restart_pending() -> (


### PR DESCRIPTION
## Summary

The bot1 close-driver was restart-only: it polled `lifecycle.restart_requested()` and ignored shutdown intent. Combined with SIGTERM now routing through `lifecycle.request_shutdown()`, this split meant a plain shutdown could move the bot into `DRAINING` with nothing ever calling `bot.close()` — `bot.start()` never unwound, the `main()` finalizer never ran, and the runtime lock stayed held until its 90 s TTL expired.

This PR generalizes the driver to act on any pending lifecycle request once phase reaches `DRAINING`, while keeping cleanup ownership inside the existing `main()` finalizer.

## What changed

- **`disbot/bot1.py`** — replaced restart-only `_drive_close_on_restart_request` with `_drive_close_on_lifecycle_request` keyed on `pending + DRAINING`. Added `_should_drive_lifecycle_close()` predicate so eligibility logic lives in one place. Renamed constants (`RESTART_*` → `LIFECYCLE_*`) and task name (`restart_close_driver` → `lifecycle_close_driver`).
- **`disbot/services/webhook_reporter.py`** — added `on_lifecycle_close_beginning(pending)` posting a shutdown-vs-restart embed via the standard `_send()` redaction path. Caller wraps it in `asyncio.wait_for(timeout=2.0)` so a stalled webhook cannot delay `bot.close()`.
- **`tests/unit/test_bot_boot.py`** — replaced two restart-only source invariants with name + DRAINING-gate invariants, plus an AST-scoped finalizer-ownership guard and a legacy-name guard that fails the build if any of the old restart-only names reappear.
- **`tests/unit/test_bot1_lifecycle_close_driver.py`** (new) — 7 behavioural tests covering shutdown, restart, past-DRAINING gate, webhook ordering, idle cancellation, close-timeout `os._exit` (sentinel-mocked), and the predicate.

## Architectural boundary preserved

```
Close-driver owns:   pending + DRAINING → webhook → bot.close() (bounded)
                                                         ↓
                                                 os._exit(1) only on timeout

main() finalizer owns:   heartbeat stop → task drain → runtime-lock release
                       → DB close → reporter close → terminal phase
```

The AST-scoped invariant fails the build if the driver body ever calls `release_lock_best_effort`, `db.close`, `reporter.close`, `execv`, or `sys.exit`.

## Test plan

- [x] `pytest tests/unit/test_bot1_lifecycle_close_driver.py tests/unit/test_bot_boot.py -v` — 21/21 pass
- [x] `pytest tests/unit/runtime/test_lifecycle.py tests/unit/cogs/test_admin_restart.py -v` — 26/26 pass (no behavioural drift)
- [x] `pytest tests/unit/services/test_webhook_reporter*.py -v` — 9/9 pass
- [x] Full `pytest tests/unit/` — 4054 passed, 3 skipped
- [x] `grep -rn "restart_close_driver\|_drive_close_on_restart_request\|RESTART_CLOSE_TIMEOUT_SECONDS"` returns only the legacy-guard test itself
- [ ] Behavioural sanity in a sandbox bot: SIGTERM → DRAINING → close-driver fires → finalizer runs → STOPPED; then `!restart` → RESTARTING

## Follow-up

Lifecycle-aware `/ready` in `healthserver.py` (return 503 during DRAINING/SHUTTING_DOWN/RESTARTING/STOPPED with phase + admission state in the payload) — split out to keep this PR focused on the close-path repair.

https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea

---
_Generated by [Claude Code](https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea)_