### PR TITLE
feat(healthserver): lifecycle-aware /ready endpoint

### DIFF
--- a/disbot/healthserver.py
+++ b/disbot/healthserver.py
@@ -3,8 +3,12 @@
 Exposes two endpoints on 0.0.0.0:8080 (configurable via HEALTH_PORT env var):
 
   GET /health  — liveness probe; returns 200 while the event loop is running
-  GET /ready   — readiness probe; returns 200 once the bot is logged in to Discord,
-                 503 while still connecting
+  GET /ready   — readiness probe; returns 200 only when the bot is logged in
+                 to Discord AND the lifecycle service is admitting commands.
+                 Returns 503 during STARTING (gateway not connected yet) or
+                 any draining/terminal phase (DRAINING, SHUTTING_DOWN,
+                 RESTARTING, STOPPED) so the orchestrator routes traffic
+                 away during graceful shutdown / restart.
 
 The server runs as a background asyncio task alongside the bot, sharing the
 same event loop. It adds no threads and has negligible overhead.
@@ -34,6 +38,8 @@ import os
 
 from aiohttp import web
 from discord.ext import commands
+
+from core.runtime import lifecycle
 
 try:
     from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
@@ -72,13 +78,50 @@ async def _health_handler(request: web.Request) -> web.Response:
 
 
 async def _ready_handler(request: web.Request) -> web.Response:
-    """Readiness probe — 503 until Discord gateway connection is established."""
+    """Readiness probe — 200 only when the bot is fully serving traffic.
+
+    Returns 200 when both:
+      - ``bot.is_ready()`` — Discord gateway handshake is complete
+      - ``lifecycle.can_accept_commands()`` — the lifecycle service is
+        in ``STARTING`` or ``RUNNING`` (i.e., not draining)
+
+    Returns 503 in every other case.  The payload always includes the
+    lifecycle ``phase`` and ``accepting_commands`` so the orchestrator
+    can distinguish "still connecting" from "draining for shutdown"
+    when alerting or routing traffic.
+
+    The lifecycle gate matters during graceful shutdown: SIGTERM moves
+    the bot into ``DRAINING`` before ``bot.close()`` is awaited, and
+    ``bot.is_ready()`` stays True for some of that window.  Without
+    the lifecycle check, the orchestrator would keep routing traffic
+    to a draining replica.
+    """
     bot: commands.Bot = request.app["bot"]
-    if bot.is_ready():
-        body = json.dumps({"status": "ready", "user": str(bot.user)})
+    phase = lifecycle.get_phase()
+    accepting = lifecycle.can_accept_commands()
+    is_ready = bot.is_ready()
+
+    if is_ready and accepting:
+        body = json.dumps(
+            {
+                "status": "ready",
+                "phase": phase.value,
+                "accepting_commands": True,
+                "user": str(bot.user),
+            },
+        )
         return web.Response(text=body, content_type="application/json")
+
+    reason = "gateway_not_ready" if not is_ready else f"lifecycle_{phase.value}"
     return web.Response(
-        text=json.dumps({"status": "not_ready"}),
+        text=json.dumps(
+            {
+                "status": "not_ready",
+                "phase": phase.value,
+                "accepting_commands": accepting,
+                "reason": reason,
+            },
+        ),
         status=503,
         content_type="application/json",
     )

--- a/tests/unit/runtime/test_healthserver.py
+++ b/tests/unit/runtime/test_healthserver.py
@@ -174,3 +174,136 @@ async def test_on_health_startup_failed_posts_embed():
     embed = reporter._send.await_args.args[0]
     assert "Aborting" in embed.description
     assert "port in use" in embed.description
+
+
+# ---------------------------------------------------------------------------
+# /ready lifecycle-awareness
+#
+# /ready must consult lifecycle.can_accept_commands() in addition to
+# bot.is_ready() so the orchestrator stops routing traffic to a replica
+# that is draining for SIGTERM / restart.  Without this, bot.is_ready()
+# stays True for the early part of the DRAINING window and the load
+# balancer keeps sending requests at a replica that has stopped
+# admitting commands.
+# ---------------------------------------------------------------------------
+
+
+def _ready_request_for(bot) -> MagicMock:
+    """Build a minimal aiohttp Request mock for ``_ready_handler``."""
+    request = MagicMock()
+    request.app = {"bot": bot}
+    return request
+
+
+@pytest.fixture(autouse=False)
+def _reset_lifecycle():
+    """Reset lifecycle state around lifecycle-aware /ready tests so they
+    cannot leak phase or pending state into one another."""
+    from core.runtime import lifecycle
+
+    lifecycle.reset_for_tests()
+    yield
+    lifecycle.reset_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_ready_returns_200_when_ready_and_lifecycle_accepts_commands(
+    _reset_lifecycle,
+):
+    """Happy path: gateway up + lifecycle RUNNING → 200 with phase
+    and ``accepting_commands: True`` in the payload."""
+    import json as _json
+
+    from core.runtime import lifecycle
+    from healthserver import _ready_handler
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    bot = _make_bot()  # is_ready=True
+
+    response = await _ready_handler(_ready_request_for(bot))
+
+    assert response.status == 200
+    body = _json.loads(response.text)
+    assert body["status"] == "ready"
+    assert body["phase"] == "RUNNING"
+    assert body["accepting_commands"] is True
+
+
+@pytest.mark.asyncio
+async def test_ready_returns_503_when_gateway_not_ready(_reset_lifecycle):
+    """Existing behavior preserved: bot.is_ready() False → 503 with
+    ``gateway_not_ready`` reason regardless of lifecycle state."""
+    import json as _json
+
+    from core.runtime import lifecycle
+    from healthserver import _ready_handler
+
+    lifecycle.set_phase(lifecycle.Phase.STARTING)
+    bot = _make_bot()
+    bot.is_ready = MagicMock(return_value=False)
+
+    response = await _ready_handler(_ready_request_for(bot))
+
+    assert response.status == 503
+    body = _json.loads(response.text)
+    assert body["status"] == "not_ready"
+    assert body["reason"] == "gateway_not_ready"
+    assert body["phase"] == "STARTING"
+    assert body["accepting_commands"] is True  # STARTING still admits
+
+
+@pytest.mark.asyncio
+async def test_ready_returns_503_when_lifecycle_draining(_reset_lifecycle):
+    """The regression this PR is preventing: SIGTERM moves lifecycle into
+    DRAINING but bot.is_ready() can still be True for part of the window.
+    /ready must return 503 in that window so the load balancer stops
+    routing traffic."""
+    import json as _json
+
+    from core.runtime import lifecycle
+    from healthserver import _ready_handler
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown(reason="sigterm")
+    assert lifecycle.get_phase() is lifecycle.Phase.DRAINING
+
+    bot = _make_bot()  # is_ready still True
+    response = await _ready_handler(_ready_request_for(bot))
+
+    assert response.status == 503
+    body = _json.loads(response.text)
+    assert body["status"] == "not_ready"
+    assert body["phase"] == "DRAINING"
+    assert body["accepting_commands"] is False
+    assert body["reason"] == "lifecycle_DRAINING"
+
+
+@pytest.mark.parametrize(
+    "phase",
+    [
+        "SHUTTING_DOWN",
+        "RESTARTING",
+        "STOPPED",
+    ],
+)
+@pytest.mark.asyncio
+async def test_ready_returns_503_in_every_terminal_phase(
+    _reset_lifecycle, phase: str
+):
+    """All non-admitting phases past DRAINING must also produce 503.
+    Belt-and-suspenders parametrization so a future lifecycle-state
+    addition does not silently re-enable 200 in a draining phase."""
+    import json as _json
+
+    from core.runtime import lifecycle
+    from healthserver import _ready_handler
+
+    lifecycle.set_phase(getattr(lifecycle.Phase, phase))
+    bot = _make_bot()
+    response = await _ready_handler(_ready_request_for(bot))
+
+    assert response.status == 503
+    body = _json.loads(response.text)
+    assert body["accepting_commands"] is False
+    assert body["phase"] == phase
+    assert body["reason"] == f"lifecycle_{phase}"


### PR DESCRIPTION
## Summary

`/ready` previously returned 200 as soon as `bot.is_ready()` was true. During graceful shutdown the lifecycle service moves into `DRAINING` (command admission off) before the Discord gateway is actually closed — so for that window `/ready` was 200 while the bot had stopped accepting work, and orchestrators kept routing traffic to a draining replica.

`/ready` now returns 200 only when **both** gates pass:
- `bot.is_ready()` — Discord handshake complete
- `lifecycle.can_accept_commands()` — phase is `STARTING` or `RUNNING`

Otherwise: 503. Payload always includes lifecycle `phase`, `accepting_commands`, and a `reason` (`gateway_not_ready` or `lifecycle_<PHASE>`) so operators can distinguish "still connecting" from "draining for shutdown" at a glance.

## Follow-up from PR #266

This is the optional Phase 6 deferred from the lifecycle close-driver repair (PR #266). That PR fixed close *execution*; this one closes the corresponding *traffic-routing* gap that the analysis flagged. The two changes are independent and can land in either order.

## What changed

- **`disbot/healthserver.py`** — `_ready_handler` now consults `lifecycle.get_phase()` + `lifecycle.can_accept_commands()`; richer JSON payload; module-level lifecycle import.
- **`tests/unit/runtime/test_healthserver.py`** — 6 new tests:
  - 200 when ready + RUNNING
  - 503 when gateway not ready (existing behaviour preserved)
  - 503 when DRAINING (the regression this PR prevents)
  - 503 parametrized across `SHUTTING_DOWN`, `RESTARTING`, `STOPPED` so a future lifecycle-state addition cannot silently re-enable 200 in a draining phase

## Test plan

- [x] `pytest tests/unit/runtime/test_healthserver.py -v` — 13/13 pass (7 existing + 6 new)
- [x] `pytest tests/unit/` — 4050 passed, 3 skipped
- [x] `black --check`, `isort --check-only`, `ruff check`, `mypy disbot/healthserver.py` — all clean
- [ ] Behavioural sanity in a sandbox: `curl /ready` during normal operation → 200 with `phase: RUNNING`; send SIGTERM → immediate 503 with `reason: lifecycle_DRAINING` before the bot finishes closing

## Compatibility

The 200/503 status codes are unchanged for the existing two states (ready and not-ready-yet). New payload fields (`phase`, `accepting_commands`, `reason`) are additive — existing probes that only inspect the HTTP status code or the `status` string are unaffected.

https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea

---
_Generated by [Claude Code](https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea)_