### PR TITLE
feat(lifecycle): record close_executing event when driver invokes bot.close()

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -627,6 +627,8 @@ async def _drive_close_on_lifecycle_request() -> None:
                     "Lifecycle close-beginning webhook skipped: %s",
                     report_err,
                 )
+        if pending is not None:
+            _lifecycle.record_close_executing(pending)
         try:
             await asyncio.wait_for(
                 bot.close(),

--- a/disbot/core/runtime/lifecycle.py
+++ b/disbot/core/runtime/lifecycle.py
@@ -203,6 +203,27 @@ def request_restart(
     return True
 
 
+def record_close_executing(pending: PendingShutdown) -> None:
+    """Record that the close-driver has reached ``bot.close()``.
+
+    Surfaces in :func:`get_recent_events` / :func:`diagnostics_snapshot`
+    so operators can distinguish "the lifecycle request was recorded but
+    nothing executed it" from "the close-driver actually ran".  The
+    pre-existing ``shutdown_requested`` / ``restart_requested`` events
+    capture intent; this captures execution.
+
+    ``pending.kind`` is stored under ``metadata`` because
+    :class:`LifecycleEvent` does not expose a top-level ``kind`` field —
+    metadata is the documented extension point for per-event payload.
+    """
+    _record_event(
+        "close_executing",
+        reason=pending.reason,
+        actor=pending.actor,
+        metadata={"kind": pending.kind},
+    )
+
+
 def get_pending() -> PendingShutdown | None:
     """Return the current pending request, or ``None`` if none."""
     return _pending
@@ -322,6 +343,7 @@ __all__ = [
     "get_phase",
     "get_recent_events",
     "is_shutting_down",
+    "record_close_executing",
     "remaining_shutdown_seconds",
     "request_restart",
     "request_shutdown",

--- a/tests/unit/runtime/test_lifecycle.py
+++ b/tests/unit/runtime/test_lifecycle.py
@@ -200,3 +200,57 @@ def test_reset_for_tests_clears_phase_pending_and_events() -> None:
     assert lifecycle.get_phase() is lifecycle.Phase.STARTING
     assert lifecycle.get_pending() is None
     assert lifecycle.get_recent_events() == []
+
+
+def test_record_close_executing_appends_event_with_kind_metadata() -> None:
+    """The close-driver records this event right before bot.close() so
+    operators can distinguish "intent recorded" from "executor ran".
+
+    Kind goes into metadata because LifecycleEvent does not surface a
+    top-level ``kind`` field — metadata is the documented payload slot.
+    """
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown("sigterm", actor="signal_handler")
+    pending = lifecycle.get_pending()
+    assert pending is not None
+
+    lifecycle.record_close_executing(pending)
+
+    names = [event.name for event in lifecycle.get_recent_events()]
+    assert names[-1] == "close_executing"
+
+    event = lifecycle.get_recent_events()[-1]
+    assert event.phase is lifecycle.Phase.DRAINING
+    assert event.actor == "signal_handler"
+    assert event.reason == "sigterm"
+    assert event.metadata == {"kind": "shutdown"}
+
+
+def test_record_close_executing_carries_restart_kind_for_restart_intent() -> None:
+    """Restart intent surfaces with ``kind="restart"`` so the event
+    distinguishes restart-driven close from shutdown-driven close."""
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_restart("!restart", actor="operator#0001")
+    pending = lifecycle.get_pending()
+    assert pending is not None
+
+    lifecycle.record_close_executing(pending)
+
+    event = lifecycle.get_recent_events()[-1]
+    assert event.name == "close_executing"
+    assert event.metadata == {"kind": "restart"}
+
+
+def test_close_executing_event_appears_in_diagnostics_snapshot() -> None:
+    """The diagnostics snapshot exposes recent events to !platform
+    runtime; close_executing must be visible there without any extra
+    plumbing."""
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown("sigterm")
+    pending = lifecycle.get_pending()
+    assert pending is not None
+    lifecycle.record_close_executing(pending)
+
+    snapshot = lifecycle.diagnostics_snapshot()
+    event_names = [event["name"] for event in snapshot["recent_events"]]
+    assert "close_executing" in event_names

--- a/tests/unit/test_bot1_lifecycle_close_driver.py
+++ b/tests/unit/test_bot1_lifecycle_close_driver.py
@@ -163,6 +163,38 @@ async def test_webhook_fires_before_bot_close(
 
 
 @pytest.mark.asyncio
+async def test_close_driver_records_close_executing_lifecycle_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The close-driver records a ``close_executing`` lifecycle event
+    right before ``bot.close()`` so ``!platform runtime`` distinguishes
+    "intent recorded but executor never ran" from "executor ran".
+
+    Asserts both that the event exists and that it carries the kind in
+    metadata, so the event is informative without requiring a custom
+    embed.
+    """
+    fake_bot = _FakeBot()
+    monkeypatch.setattr(bot1, "bot", fake_bot)
+    monkeypatch.setattr(bot1, "reporter", None)
+    _install_fast_poll(monkeypatch)
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown(reason="sigterm", actor="signal_handler")
+
+    await asyncio.wait_for(bot1._drive_close_on_lifecycle_request(), timeout=2.0)
+
+    event_names = [e.name for e in lifecycle.get_recent_events()]
+    assert "close_executing" in event_names
+    close_event = next(
+        e for e in lifecycle.get_recent_events() if e.name == "close_executing"
+    )
+    assert close_event.metadata == {"kind": "shutdown"}
+    assert close_event.actor == "signal_handler"
+    assert close_event.reason == "sigterm"
+
+
+@pytest.mark.asyncio
 async def test_idle_cancellation_exits_cleanly(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

The lifecycle event ring buffer already captures **intent** — the moment a shutdown or restart is requested — via `shutdown_requested` / `restart_requested` events. It did not capture **execution**: nothing in diagnostics distinguished "intent recorded but the close-driver never ran" from "the close-driver ran and `bot.close()` returned (or timed out)".

This PR adds a public `lifecycle.record_close_executing(pending)` helper and wires it into the close-driver in `bot1.py` so the event is recorded immediately before `await bot.close()`. It surfaces automatically in the existing `diagnostics_snapshot()` and therefore in `!platform runtime` / `platform_consistency` reports without any new commands or embeds.

## Stacked on #266

Base branch is `claude/stoic-lovelace-gJyPW` (PR #266). This PR depends on the close-driver from that PR. When #266 merges, GitHub will re-target this PR's base to `main` automatically — no rebase needed unless conflicts arise.

## What changed

- **`disbot/core/runtime/lifecycle.py`** — public `record_close_executing(pending)` helper appending a `close_executing` event with `kind` in `metadata`. Added to `__all__`.
- **`disbot/bot1.py`** — one-line call from the close-driver, right after the best-effort webhook and right before `await bot.close()`.
- **`tests/unit/runtime/test_lifecycle.py`** — 3 new tests covering shutdown metadata, restart metadata, and visibility through `diagnostics_snapshot()`.
- **`tests/unit/test_bot1_lifecycle_close_driver.py`** — 1 new test asserting the driver actually records the event under a real shutdown intent (with `actor` and `reason` preserved).

## Why metadata, not a top-level field

`LifecycleEvent` exposes `name`, `phase`, `at`, `actor`, `reason`, `metadata`. `kind` ("shutdown" vs "restart") is per-event payload, not a stable field on every event — `metadata` is the documented slot.

## Test plan

- [x] `pytest tests/unit/runtime/test_lifecycle.py tests/unit/test_bot1_lifecycle_close_driver.py tests/unit/test_bot_boot.py -v` — 47/47 pass
- [x] `pytest tests/unit/` — 4058 passed, 3 skipped
- [x] `black --check`, `isort --check-only`, `ruff check`, `mypy` on the two changed source files — all clean
- [ ] Sandbox sanity: send SIGTERM → confirm `!platform runtime` recent-events panel shows `shutdown_requested` followed by `close_executing` (both during DRAINING)

https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea

---
_Generated by [Claude Code](https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea)_