### PR TITLE
feat(metrics): lifecycle_close_driver_total counter for close-driver invocations

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -629,6 +629,9 @@ async def _drive_close_on_lifecycle_request() -> None:
                 )
         if pending is not None:
             _lifecycle.record_close_executing(pending)
+            from services import metrics as _metrics
+
+            _metrics.lifecycle_close_driver_total.labels(kind=pending.kind).inc()
         try:
             await asyncio.wait_for(
                 bot.close(),

--- a/disbot/services/metrics.py
+++ b/disbot/services/metrics.py
@@ -128,6 +128,17 @@ runtime_lock_boot_wait_seconds = Histogram(
     buckets=(0.1, 0.5, 1.0, 5.0, 15.0, 30.0, 60.0, 120.0, 300.0),
 )
 
+# Lifecycle close-driver invocations: increments once each time the watchdog
+# in bot1 drives bot.close() from a pending lifecycle request.  ``shutdown``
+# is SIGTERM-driven; ``restart`` is !restart-driven.  Use this to alert on
+# unexpected close rates (e.g. a sustained non-zero ``restart`` rate without
+# operator action indicates a restart loop).
+lifecycle_close_driver_total = Counter(
+    "lifecycle_close_driver_total",
+    "Lifecycle close-driver invocations by pending request kind.",
+    ["kind"],  # shutdown | restart
+)
+
 governance_fail_open_total = Counter(
     "governance_fail_open_total",
     "Interaction-router governance gate fell open due to resolver error. "

--- a/tests/unit/test_bot1_lifecycle_close_driver.py
+++ b/tests/unit/test_bot1_lifecycle_close_driver.py
@@ -163,6 +163,55 @@ async def test_webhook_fires_before_bot_close(
 
 
 @pytest.mark.asyncio
+async def test_close_driver_increments_close_metric_with_kind_label(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each close-driver invocation increments
+    ``lifecycle_close_driver_total{kind=...}`` so operators can alert
+    on unexpected close/restart rates from Prometheus."""
+    from services import metrics as _metrics
+
+    fake_bot = _FakeBot()
+    monkeypatch.setattr(bot1, "bot", fake_bot)
+    monkeypatch.setattr(bot1, "reporter", None)
+    _install_fast_poll(monkeypatch)
+
+    before = _metrics.lifecycle_close_driver_total.labels(kind="shutdown")._value.get()
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown(reason="sigterm")
+
+    await asyncio.wait_for(bot1._drive_close_on_lifecycle_request(), timeout=2.0)
+
+    after = _metrics.lifecycle_close_driver_total.labels(kind="shutdown")._value.get()
+    assert after == before + 1
+
+
+@pytest.mark.asyncio
+async def test_close_driver_metric_uses_restart_kind_for_restart_intent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Restart and shutdown invocations land on distinct label series so
+    operators can graph them separately."""
+    from services import metrics as _metrics
+
+    fake_bot = _FakeBot()
+    monkeypatch.setattr(bot1, "bot", fake_bot)
+    monkeypatch.setattr(bot1, "reporter", None)
+    _install_fast_poll(monkeypatch)
+
+    before = _metrics.lifecycle_close_driver_total.labels(kind="restart")._value.get()
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_restart(reason="!restart", actor="op")
+
+    await asyncio.wait_for(bot1._drive_close_on_lifecycle_request(), timeout=2.0)
+
+    after = _metrics.lifecycle_close_driver_total.labels(kind="restart")._value.get()
+    assert after == before + 1
+
+
+@pytest.mark.asyncio
 async def test_close_driver_records_close_executing_lifecycle_event(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Operators previously had only log lines to observe close-driver activity. This PR exposes the same signal in Prometheus so close/restart rates can be graphed and alerted on alongside the other lifecycle and runtime-lock metrics.

```
lifecycle_close_driver_total{kind="shutdown"}
lifecycle_close_driver_total{kind="restart"}
```

Increments inside the close-driver right before `bot.close()` is awaited, alongside the existing `lifecycle.record_close_executing` event call from PR #268.

## Stacked on #268

Base branch is `claude/lifecycle-close-event` (PR #268). Both PRs touch the same close-driver section; stacking makes the diff clean. When #268 merges, GitHub will re-target this PR's base to `main`.

## Design choices

- **Single label `kind`** — keeps cardinality at 2, matches the `runtime_lock_boot_handoff_total{outcome}` pattern in `services/metrics.py:119`.
- **No `reason` label** — reasons are freeform strings ("sigterm", "!restart", future operator messages); high-cardinality labels are anti-pattern.
- **No timeout outcome label** — `os._exit(1)` happens immediately after the timeout branch, so a `outcome="timed_out"` value would race the next Prometheus scrape. The webhook + log line are more reliable signals for timeouts; the counter measures invocations only.

## Most useful alert this enables

A sustained non-zero `restart` rate without corresponding operator activity is the canonical "restart loop" signature — distinct from healthy SIGTERM-driven shutdowns which appear under `kind="shutdown"`.

## What changed

- **`disbot/services/metrics.py`** — counter definition with docstring and label rationale.
- **`disbot/bot1.py`** — one-line label-and-inc inside the close-driver, with a lazy import matching the existing `from services import metrics as _metrics` pattern used by `on_command_completion`.
- **`tests/unit/test_bot1_lifecycle_close_driver.py`** — 2 new tests asserting the counter increments by 1 per invocation, once for each kind label.

## Test plan

- [x] `pytest tests/unit/test_bot1_lifecycle_close_driver.py -v` — 10/10 pass (8 existing + 2 new)
- [x] `pytest tests/unit/` — 4060 passed, 3 skipped
- [x] `black --check`, `isort --check-only`, `ruff check`, `mypy` on the two changed source files — all clean
- [ ] Sandbox sanity: `curl /metrics | grep lifecycle_close_driver_total` returns the two series at the expected counts after a SIGTERM and after a `!restart`

https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea

---
_Generated by [Claude Code](https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea)_