### PR TITLE
feat(diagnostics): !platform lifecycle dedicated embed

### DIFF
--- a/disbot/cogs/diagnostic/_platform_embeds.py
+++ b/disbot/cogs/diagnostic/_platform_embeds.py
@@ -534,6 +534,97 @@ def build_runtime_embed() -> discord.Embed:
     return embed
 
 
+_LIFECYCLE_PHASE_COLORS: dict[str, discord.Color] = {
+    "STARTING": discord.Color.gold(),
+    "RUNNING": discord.Color.green(),
+    "DRAINING": discord.Color.gold(),
+    "SHUTTING_DOWN": discord.Color.dark_red(),
+    "RESTARTING": discord.Color.dark_red(),
+    "STOPPED": discord.Color.dark_red(),
+    "FAILED_STARTUP": discord.Color.dark_red(),
+}
+
+
+def build_lifecycle_embed() -> discord.Embed:
+    """Build the embed for ``!platform lifecycle``.
+
+    Renders the lifecycle service state machine — current phase, the
+    pending shutdown/restart request if any (with grace remaining),
+    and the most recent events from the ring buffer, newest first.
+    The events include ``shutdown_requested`` / ``restart_requested``
+    (intent), ``close_executing`` (close-driver invocation), and the
+    ``phase:<NAME>`` transitions, so operators get a one-screen view
+    of what the lifecycle has done lately.
+
+    Falls back to a degraded embed if the ``lifecycle`` provider is
+    not registered, matching the ``build_caches_embed`` pattern.
+    """
+    from services import diagnostics_service
+
+    try:
+        snap = diagnostics_service.snapshot("lifecycle")
+    except KeyError:
+        return discord.Embed(
+            title="🔄 Lifecycle",
+            description="Provider not registered.",
+            color=discord.Color.greyple(),
+        )
+
+    phase = str(snap.get("phase", "unknown"))
+    can_accept = bool(snap.get("can_accept_commands", False))
+    embed = discord.Embed(
+        title="🔄 Lifecycle",
+        description=(f"Phase: **{phase}** · Accepting commands: **{can_accept}**"),
+        color=_LIFECYCLE_PHASE_COLORS.get(phase, discord.Color.greyple()),
+    )
+
+    pending = snap.get("pending")
+    if pending:
+        remaining = snap.get("remaining_shutdown_seconds")
+        remaining_part = (
+            f" · grace remaining: **{remaining:.1f}s**"
+            if isinstance(remaining, (int, float)) and remaining > 0
+            else ""
+        )
+        embed.add_field(
+            name="Pending request",
+            value=(
+                f"kind: `{pending.get('kind', '<unknown>')}`{remaining_part}\n"
+                f"reason: `{pending.get('reason', '<unknown>')}`\n"
+                f"actor: `{pending.get('actor', '<unknown>')}`"
+            ),
+            inline=False,
+        )
+    else:
+        embed.add_field(name="Pending request", value="_none_", inline=False)
+
+    events = list(snap.get("recent_events", []))
+    if events:
+        # Snapshot is oldest-first; render newest-first and cap at 10 so
+        # the field fits Discord's 1024-char limit comfortably.
+        lines: list[str] = []
+        for event in reversed(events[-10:]):
+            actor_part = f" by `{event['actor']}`" if event.get("actor") else ""
+            reason_part = f" — {event['reason']}" if event.get("reason") else ""
+            lines.append(
+                f"• `{event.get('name', '?')}` @ "
+                f"{event.get('phase', '?')}{actor_part}{reason_part}",
+            )
+        embed.add_field(
+            name=f"Recent events ({len(events)})",
+            value="\n".join(lines)[:1024],
+            inline=False,
+        )
+    else:
+        embed.add_field(
+            name="Recent events",
+            value="_none recorded_",
+            inline=False,
+        )
+
+    return embed
+
+
 def build_caches_embed() -> discord.Embed:
     """Build the embed for ``!platform caches``."""
     from services import diagnostics_service
@@ -1147,6 +1238,7 @@ __all__ = [
     "build_customization_embed",
     "build_flags_embed",
     "build_identity_embed",
+    "build_lifecycle_embed",
     "build_locks_embed",
     "build_migrations_embed",
     "build_participation_schemas_embed",

--- a/disbot/cogs/diagnostic_cog.py
+++ b/disbot/cogs/diagnostic_cog.py
@@ -24,6 +24,7 @@ from cogs.diagnostic._platform_embeds import (
     build_customization_embed,
     build_flags_embed,
     build_identity_embed,
+    build_lifecycle_embed,
     build_locks_embed,
     build_migrations_embed,
     build_participation_schemas_embed,
@@ -320,6 +321,12 @@ class DiagnosticCog(commands.Cog):
     async def platform_runtime(self, ctx):
         """High-level runtime snapshot: every registered diagnostic provider."""
         await ctx.send(embed=build_runtime_embed())
+
+    @platform_grp.command(name="lifecycle")  # type: ignore[arg-type]
+    @commands.has_permissions(administrator=True)
+    async def platform_lifecycle(self, ctx):
+        """Lifecycle state: phase, pending request, recent events."""
+        await ctx.send(embed=build_lifecycle_embed())
 
     @platform_grp.command(name="caches")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)

--- a/tests/unit/runtime/test_platform_diagnostics_commands.py
+++ b/tests/unit/runtime/test_platform_diagnostics_commands.py
@@ -343,3 +343,141 @@ async def test_platform_slow_limit_argument_caps_field_count():
 
     embed = ctx.send.call_args.kwargs["embed"]
     assert len(embed.fields) == 3  # capped at limit=3
+
+
+# ---------------------------------------------------------------------------
+# !platform lifecycle — dedicated lifecycle embed
+#
+# The lifecycle provider is already rolled into !platform runtime, but
+# operators looking for shutdown/restart context shouldn't have to scan
+# the multi-provider dump.  This command formats phase, pending request,
+# and the recent_events ring buffer (including close_executing entries
+# from the close-driver) into a focused single-purpose embed.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_platform_lifecycle_renders_running_phase_with_no_pending():
+    """Healthy path: RUNNING phase, no pending request, no events recorded."""
+    cog = _make_cog()
+    ctx = _make_ctx()
+
+    snap = {
+        "phase": "RUNNING",
+        "can_accept_commands": True,
+        "pending": None,
+        "remaining_shutdown_seconds": None,
+        "recent_events": [],
+    }
+    with patch("services.diagnostics_service.snapshot", return_value=snap):
+        await cog.platform_lifecycle.callback(cog, ctx)
+
+    embed = ctx.send.call_args.kwargs["embed"]
+    assert "RUNNING" in (embed.description or "")
+    field_names = {f.name for f in embed.fields}
+    assert field_names == {"Pending request", "Recent events"}
+    pending_field = next(f for f in embed.fields if f.name == "Pending request")
+    assert pending_field.value.strip().startswith("_none_") or "none" in pending_field.value
+
+
+@pytest.mark.asyncio
+async def test_platform_lifecycle_renders_pending_shutdown_with_grace():
+    """DRAINING phase with grace-remaining displays the grace value so
+    operators can see how much time the request has left before the
+    close-driver will fire."""
+    cog = _make_cog()
+    ctx = _make_ctx()
+
+    snap = {
+        "phase": "DRAINING",
+        "can_accept_commands": False,
+        "pending": {
+            "kind": "shutdown",
+            "reason": "sigterm",
+            "actor": "signal_handler",
+            "grace_seconds": 30.0,
+        },
+        "remaining_shutdown_seconds": 12.5,
+        "recent_events": [],
+    }
+    with patch("services.diagnostics_service.snapshot", return_value=snap):
+        await cog.platform_lifecycle.callback(cog, ctx)
+
+    embed = ctx.send.call_args.kwargs["embed"]
+    pending_field = next(f for f in embed.fields if f.name == "Pending request")
+    assert "shutdown" in pending_field.value
+    assert "sigterm" in pending_field.value
+    assert "signal_handler" in pending_field.value
+    assert "12.5" in pending_field.value  # grace remaining
+
+
+@pytest.mark.asyncio
+async def test_platform_lifecycle_renders_close_executing_event_newest_first():
+    """The close-driver records ``close_executing`` events; they must
+    surface in this embed so an operator can confirm the executor ran
+    after intent was recorded.  Recent events are oldest-last in the
+    snapshot but should be displayed newest-first."""
+    cog = _make_cog()
+    ctx = _make_ctx()
+
+    snap = {
+        "phase": "DRAINING",
+        "can_accept_commands": False,
+        "pending": {
+            "kind": "shutdown",
+            "reason": "sigterm",
+            "actor": "signal_handler",
+        },
+        "remaining_shutdown_seconds": None,
+        "recent_events": [
+            {
+                "name": "shutdown_requested",
+                "phase": "RUNNING",
+                "actor": "signal_handler",
+                "reason": "sigterm",
+            },
+            {
+                "name": "phase:DRAINING",
+                "phase": "DRAINING",
+                "actor": None,
+                "reason": "sigterm",
+            },
+            {
+                "name": "close_executing",
+                "phase": "DRAINING",
+                "actor": "signal_handler",
+                "reason": "sigterm",
+            },
+        ],
+    }
+    with patch("services.diagnostics_service.snapshot", return_value=snap):
+        await cog.platform_lifecycle.callback(cog, ctx)
+
+    embed = ctx.send.call_args.kwargs["embed"]
+    events_field = next(f for f in embed.fields if f.name.startswith("Recent events"))
+    body = events_field.value
+    # All three event names should be present.
+    assert "close_executing" in body
+    assert "shutdown_requested" in body
+    assert "phase:DRAINING" in body
+    # Newest-first ordering: close_executing must appear before
+    # shutdown_requested in the rendered text.
+    assert body.index("close_executing") < body.index("shutdown_requested")
+
+
+@pytest.mark.asyncio
+async def test_platform_lifecycle_degrades_gracefully_when_provider_unregistered():
+    """Mirror build_caches_embed's KeyError fallback — render an
+    informative embed instead of letting the exception escape into
+    ctx.send."""
+    cog = _make_cog()
+    ctx = _make_ctx()
+
+    with patch(
+        "services.diagnostics_service.snapshot",
+        side_effect=KeyError("lifecycle"),
+    ):
+        await cog.platform_lifecycle.callback(cog, ctx)
+
+    embed = ctx.send.call_args.kwargs["embed"]
+    assert "not registered" in (embed.description or "")


### PR DESCRIPTION
## Summary

The lifecycle provider is already rolled into `!platform runtime` as one field among many, rendered via the generic `_fmt_snapshot_value` dict-dump. Operators looking for shutdown/restart context have to scan the multi-provider output and parse the raw dict.

This PR adds `!platform lifecycle` as a focused single-purpose embed:

- **Header**: current phase + `accepting_commands` flag, color-coded
  (green `RUNNING`, gold `STARTING`/`DRAINING`, dark-red terminal phases)
- **Pending request**: kind, reason, actor, and grace remaining if any
- **Recent events**: up to 10 newest-first, each showing `name @ phase` with actor and reason

## Independent from PR #268 / #269

The embed reads from the existing lifecycle `diagnostics_snapshot()`. Once #268 (which adds `close_executing` events) merges, those entries will appear in the Recent events panel automatically — but this PR works correctly on `main` today and does not depend on #268 / #269 being merged first. Base is `main`.

## Graceful degradation

If the `lifecycle` provider is not registered (e.g., a test fixture or partial bootstrap), the embed renders "Provider not registered." instead of letting `KeyError` escape into `ctx.send`. Matches the pattern in `build_caches_embed`.

## What changed

- **`disbot/cogs/diagnostic/_platform_embeds.py`** — `build_lifecycle_embed()` + `_LIFECYCLE_PHASE_COLORS` mapping; added to `__all__`.
- **`disbot/cogs/diagnostic_cog.py`** — import + `@platform_grp.command(name="lifecycle")` registration, sitting between `platform_runtime` and `platform_caches`.
- **`tests/unit/runtime/test_platform_diagnostics_commands.py`** — 4 new tests:
  - RUNNING phase with no pending request → "none" panel
  - DRAINING with grace_seconds → grace remaining surfaced
  - `close_executing` event in `recent_events` renders newest-first (asserts ordering)
  - `KeyError` on provider lookup → degraded embed, no exception escape

## Test plan

- [x] `pytest tests/unit/runtime/test_platform_diagnostics_commands.py -v` — 18/18 pass
- [x] `pytest tests/unit/` — 4058 passed, 3 skipped
- [x] `black`, `isort`, `ruff`, `mypy` — all clean
- [ ] Sandbox sanity: run `!platform lifecycle` in normal operation (RUNNING/no pending), then again right after a SIGTERM is in flight; confirm the embed reflects the expected phase, pending request, and event list.

https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea

---
_Generated by [Claude Code](https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea)_