### PR TITLE
feat(metrics): lifecycle_close_duration_seconds histogram (+ re-add missing counter)

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -627,23 +627,35 @@ async def _drive_close_on_lifecycle_request() -> None:
                     "Lifecycle close-beginning webhook skipped: %s",
                     report_err,
                 )
+        from services import metrics as _metrics
+
         if pending is not None:
             _lifecycle.record_close_executing(pending)
-            from services import metrics as _metrics
-
             _metrics.lifecycle_close_driver_total.labels(kind=pending.kind).inc()
+        kind_label = pending.kind if pending is not None else "unknown"
+        close_started_at = time.monotonic()
         try:
             await asyncio.wait_for(
                 bot.close(),
                 timeout=LIFECYCLE_CLOSE_TIMEOUT_SECONDS,
             )
         except asyncio.TimeoutError:
+            # Observe the timeout value so a single observation in the
+            # topmost bucket is the canonical "force-exit" signature in
+            # Prometheus.  Done before os._exit so the next scrape (if
+            # it lands in the millisecond window before exit) sees it.
+            _metrics.lifecycle_close_duration_seconds.labels(
+                kind=kind_label,
+            ).observe(LIFECYCLE_CLOSE_TIMEOUT_SECONDS)
             logger.critical(
                 "bot.close() exceeded %.1fs timeout — force-exiting "
                 "so the orchestration platform respawns.",
                 LIFECYCLE_CLOSE_TIMEOUT_SECONDS,
             )
             os._exit(1)
+        _metrics.lifecycle_close_duration_seconds.labels(
+            kind=kind_label,
+        ).observe(time.monotonic() - close_started_at)
         return
 
 

--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -629,6 +629,9 @@ async def _drive_close_on_lifecycle_request() -> None:
                 )
         if pending is not None:
             _lifecycle.record_close_executing(pending)
+            from services import metrics as _metrics
+
+            _metrics.lifecycle_close_driver_total.labels(kind=pending.kind).inc()
         try:
             await asyncio.wait_for(
                 bot.close(),

--- a/disbot/services/metrics.py
+++ b/disbot/services/metrics.py
@@ -165,6 +165,20 @@ lifecycle_close_driver_total = Counter(
     ["kind"],  # shutdown | restart
 )
 
+# Duration of bot.close() invoked by the close-driver above.  The 20 s
+# bucket aligns with LIFECYCLE_CLOSE_TIMEOUT_SECONDS so a single observation
+# in the topmost bucket is the canonical "close hit the timeout and the
+# driver force-exited" signature.  Sub-second buckets capture the
+# normal-path close.  Sustained drift towards higher buckets is the
+# leading indicator of an unhealthy close path before it actually hits
+# the timeout.
+lifecycle_close_duration_seconds = Histogram(
+    "lifecycle_close_duration_seconds",
+    "Duration of bot.close() invoked by the lifecycle close-driver.",
+    ["kind"],  # shutdown | restart
+    buckets=(0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 15.0, 20.0),
+)
+
 governance_fail_open_total = Counter(
     "governance_fail_open_total",
     "Interaction-router governance gate fell open due to resolver error. "

--- a/disbot/services/metrics.py
+++ b/disbot/services/metrics.py
@@ -154,6 +154,17 @@ lifecycle_phase = Gauge(
     #             RESTARTING | STOPPED | FAILED_STARTUP
 )
 
+# Lifecycle close-driver invocations: increments once each time the watchdog
+# in bot1 drives bot.close() from a pending lifecycle request.  ``shutdown``
+# is SIGTERM-driven; ``restart`` is !restart-driven.  Use this to alert on
+# unexpected close rates (e.g. a sustained non-zero ``restart`` rate without
+# operator action indicates a restart loop).
+lifecycle_close_driver_total = Counter(
+    "lifecycle_close_driver_total",
+    "Lifecycle close-driver invocations by pending request kind.",
+    ["kind"],  # shutdown | restart
+)
+
 governance_fail_open_total = Counter(
     "governance_fail_open_total",
     "Interaction-router governance gate fell open due to resolver error. "

--- a/tests/unit/test_bot1_lifecycle_close_driver.py
+++ b/tests/unit/test_bot1_lifecycle_close_driver.py
@@ -187,6 +187,95 @@ async def test_close_driver_increments_close_metric_with_kind_label(
     assert after == before + 1
 
 
+def _histogram_count_and_sum(histogram_child) -> tuple[float, float]:
+    """Read (count, sum) from a Prometheus Histogram label child.
+
+    Histogram does not expose a public ``_count`` attribute — the count
+    is the +Inf bucket value.  Using ``collect()`` here so the assertion
+    is decoupled from prometheus_client's internal layout.
+    """
+    samples = next(iter(histogram_child.collect())).samples
+    count = next(s.value for s in samples if s.name.endswith("_count"))
+    total = next(s.value for s in samples if s.name.endswith("_sum"))
+    return count, total
+
+
+@pytest.mark.asyncio
+async def test_close_driver_observes_close_duration_histogram(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each successful bot.close() observation lands in
+    ``lifecycle_close_duration_seconds{kind=...}`` so operators can
+    alert on a sustained drift towards higher buckets before close
+    actually hits the bounded timeout."""
+    from services import metrics as _metrics
+
+    fake_bot = _FakeBot()
+    monkeypatch.setattr(bot1, "bot", fake_bot)
+    monkeypatch.setattr(bot1, "reporter", None)
+    _install_fast_poll(monkeypatch)
+
+    histogram = _metrics.lifecycle_close_duration_seconds.labels(kind="shutdown")
+    before_count, before_sum = _histogram_count_and_sum(histogram)
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown(reason="sigterm")
+
+    await asyncio.wait_for(bot1._drive_close_on_lifecycle_request(), timeout=2.0)
+
+    after_count, after_sum = _histogram_count_and_sum(histogram)
+    assert after_count == before_count + 1
+    # Healthy close completes in well under 1s; bound under the timeout
+    # to avoid CI scheduler jitter false positives.
+    assert (after_sum - before_sum) < bot1.LIFECYCLE_CLOSE_TIMEOUT_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_close_timeout_observes_full_timeout_in_duration_histogram(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The force-exit timeout path must observe the full timeout value
+    before calling ``os._exit`` so a Prometheus scrape arriving in the
+    millisecond window before exit can distinguish "close hung" from
+    "close took 0s and the process died for unrelated reasons"."""
+    from services import metrics as _metrics
+
+    class HangingBot:
+        async def close(self) -> None:
+            await asyncio.sleep(60.0)
+
+    monkeypatch.setattr(bot1, "bot", HangingBot())
+    monkeypatch.setattr(bot1, "reporter", None)
+    monkeypatch.setattr(bot1, "LIFECYCLE_CLOSE_TIMEOUT_SECONDS", 0.05)
+    _install_fast_poll(monkeypatch)
+
+    class _ForceExit(BaseException):
+        pass
+
+    def _fake_exit(_code: int) -> None:
+        raise _ForceExit
+
+    monkeypatch.setattr(bot1.os, "_exit", _fake_exit)
+
+    histogram = _metrics.lifecycle_close_duration_seconds.labels(kind="shutdown")
+    before_count, before_sum = _histogram_count_and_sum(histogram)
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown(reason="sigterm")
+
+    with pytest.raises(_ForceExit):
+        await asyncio.wait_for(
+            bot1._drive_close_on_lifecycle_request(),
+            timeout=2.0,
+        )
+
+    after_count, after_sum = _histogram_count_and_sum(histogram)
+    assert after_count == before_count + 1
+    # Observation is the timeout constant (0.05s in this test) — that
+    # exact value is what marks "force-exit" in dashboards.
+    assert (after_sum - before_sum) == pytest.approx(0.05, abs=0.001)
+
+
 @pytest.mark.asyncio
 async def test_close_driver_metric_uses_restart_kind_for_restart_intent(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_bot1_lifecycle_close_driver.py
+++ b/tests/unit/test_bot1_lifecycle_close_driver.py
@@ -163,6 +163,55 @@ async def test_webhook_fires_before_bot_close(
 
 
 @pytest.mark.asyncio
+async def test_close_driver_increments_close_metric_with_kind_label(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each close-driver invocation increments
+    ``lifecycle_close_driver_total{kind=...}`` so operators can alert
+    on unexpected close/restart rates from Prometheus."""
+    from services import metrics as _metrics
+
+    fake_bot = _FakeBot()
+    monkeypatch.setattr(bot1, "bot", fake_bot)
+    monkeypatch.setattr(bot1, "reporter", None)
+    _install_fast_poll(monkeypatch)
+
+    before = _metrics.lifecycle_close_driver_total.labels(kind="shutdown")._value.get()
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown(reason="sigterm")
+
+    await asyncio.wait_for(bot1._drive_close_on_lifecycle_request(), timeout=2.0)
+
+    after = _metrics.lifecycle_close_driver_total.labels(kind="shutdown")._value.get()
+    assert after == before + 1
+
+
+@pytest.mark.asyncio
+async def test_close_driver_metric_uses_restart_kind_for_restart_intent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Restart and shutdown invocations land on distinct label series so
+    operators can graph them separately."""
+    from services import metrics as _metrics
+
+    fake_bot = _FakeBot()
+    monkeypatch.setattr(bot1, "bot", fake_bot)
+    monkeypatch.setattr(bot1, "reporter", None)
+    _install_fast_poll(monkeypatch)
+
+    before = _metrics.lifecycle_close_driver_total.labels(kind="restart")._value.get()
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_restart(reason="!restart", actor="op")
+
+    await asyncio.wait_for(bot1._drive_close_on_lifecycle_request(), timeout=2.0)
+
+    after = _metrics.lifecycle_close_driver_total.labels(kind="restart")._value.get()
+    assert after == before + 1
+
+
+@pytest.mark.asyncio
 async def test_close_driver_records_close_executing_lifecycle_event(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Adds a `lifecycle_close_duration_seconds` histogram so operators can alert on `bot.close()` slowness **before** the bounded timeout fires.

```
lifecycle_close_duration_seconds{kind="shutdown"}
lifecycle_close_duration_seconds{kind="restart"}
```

Buckets `(0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 15.0, 20.0)`. The 20 s bucket aligns with `LIFECYCLE_CLOSE_TIMEOUT_SECONDS` so a single observation in the topmost bucket is the canonical "close hit the timeout and the driver force-exited" signature. The timeout branch observes the full timeout value **before** `os._exit` so a Prometheus scrape arriving in the millisecond window before exit can distinguish "close hung" from "close took 0s and the process died for unrelated reasons".

## Also re-adds `lifecycle_close_driver_total` counter

PR #269 was approved and merged, but its base branch was the stacked `claude/lifecycle-close-event` which itself merged into main via PR #268's merge commit — and that merge only carried #268's commit, not #269's. So the `lifecycle_close_driver_total` counter from #269 never reached `main`. This PR includes that commit again (cleanly applied) alongside the new histogram, so both close-driver metrics land together.

The two commits:
```
1ca990e  feat(metrics): lifecycle_close_driver_total counter   (from PR #269, re-applied)
5a1df1b  feat(metrics): lifecycle_close_duration_seconds histogram
```

## Bonus cleanup

The close-driver section in `bot1.py` was acquiring `services.metrics` three times via lazy imports (once for the counter inc, once in the timeout branch for the histogram observe, once after the try/except for the success observe). Consolidated into a single lazy import at the top of the close section.

## What changed

- **`disbot/services/metrics.py`** — both metric definitions with rationale comments.
- **`disbot/bot1.py`** — one consolidated `from services import metrics as _metrics` import, counter inc before close, duration observe on both the success and timeout branches.
- **`tests/unit/test_bot1_lifecycle_close_driver.py`** — 4 new tests (2 from re-applied #269 counter + 2 new for the histogram), plus a `_histogram_count_and_sum` helper that uses `collect()` so the assertions stay decoupled from `prometheus_client`'s internal `_sum` / `_buckets` layout.

## Test plan

- [x] `pytest tests/unit/test_bot1_lifecycle_close_driver.py -v` — 12/12 pass
- [x] `pytest tests/unit/` — 4062 passed, 3 skipped
- [x] `black --check`, `isort --check-only`, `ruff check`, `mypy disbot/bot1.py disbot/services/metrics.py` — all clean
- [ ] Sandbox sanity: `curl /metrics | grep lifecycle_close_duration_seconds` after a SIGTERM shows one observation in the sub-second bucket; same after `!restart`. After an artificial hang, the topmost bucket shows the timeout observation right before the process exits.

https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea

---
_Generated by [Claude Code](https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea)_