### PR TITLE
feat(lifecycle): on_lifecycle_close_completed webhook posted from finalizer

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -1006,6 +1006,40 @@ async def main() -> None:
             pass
         await db.close()
         if reporter:
+            # Post the close-complete webhook BEFORE tearing down the
+            # reporter's HTTP session.  Operators see a paired
+            # "beginning" / "complete" lifecycle signal in the operator
+            # channel; the gap between the two embeds is the close +
+            # cleanup duration as observed end-to-end.  Wrapped in
+            # wait_for so a stalled webhook cannot delay process exit.
+            pending_for_webhook = _lifecycle.get_pending()
+            if pending_for_webhook is not None:
+                close_event = next(
+                    (
+                        event
+                        for event in _lifecycle.get_recent_events()
+                        if event.name == "close_executing"
+                    ),
+                    None,
+                )
+                duration_s = (
+                    time.monotonic() - close_event.at
+                    if close_event is not None
+                    else None
+                )
+                try:
+                    await asyncio.wait_for(
+                        reporter.on_lifecycle_close_completed(
+                            pending_for_webhook,
+                            duration_seconds=duration_s,
+                        ),
+                        timeout=2.0,
+                    )
+                except Exception as report_err:
+                    logger.debug(
+                        "Lifecycle close-completed webhook skipped: %s",
+                        report_err,
+                    )
             await reporter.close()
         # LP-2 + LP-3: surface the terminal phase. A pending restart
         # request promotes the transition to RESTARTING so observers

--- a/disbot/services/webhook_reporter.py
+++ b/disbot/services/webhook_reporter.py
@@ -313,6 +313,49 @@ class WebhookReporter:
         )
         await self._send(embed, username="Bot Lifecycle")
 
+    async def on_lifecycle_close_completed(
+        self,
+        pending: PendingShutdown,
+        *,
+        duration_seconds: float | None = None,
+    ) -> None:
+        """Posted by ``main()``'s finalizer after cleanup completes but
+        before ``reporter.close()`` tears down the HTTP session.
+
+        Companion to :meth:`on_lifecycle_close_beginning`: operators see
+        a paired "starting" / "complete" signal so the gap between them
+        — close + finalizer cleanup duration — is visible end-to-end in
+        the operator channel without parsing Prometheus.  Caller wraps
+        this in ``asyncio.wait_for`` with a small timeout so a stalled
+        webhook cannot delay process exit.
+        """
+        is_restart = pending.kind == "restart"
+        title = "♻️ Bot Restart Complete" if is_restart else "🛑 Bot Shutdown Complete"
+        color = discord.Color.gold() if is_restart else discord.Color.dark_red()
+        embed = discord.Embed(
+            title=title,
+            color=color,
+            timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
+        )
+        embed.add_field(name="Kind", value=pending.kind, inline=True)
+        embed.add_field(
+            name="Reason",
+            value=pending.reason or "<unknown>",
+            inline=True,
+        )
+        embed.add_field(
+            name="Actor",
+            value=pending.actor or "<unknown>",
+            inline=True,
+        )
+        if duration_seconds is not None:
+            embed.add_field(
+                name="Close duration",
+                value=f"{duration_seconds:.2f}s",
+                inline=True,
+            )
+        await self._send(embed, username="Bot Lifecycle")
+
     async def on_app_task_died(self, name: str, error: BaseException) -> None:
         """A supervised application task raised after startup.
 

--- a/tests/unit/services/test_webhook_reporter.py
+++ b/tests/unit/services/test_webhook_reporter.py
@@ -141,3 +141,63 @@ async def test_on_command_error_redacts_traceback_secret_end_to_end() -> None:
     )
     assert "postgres://u:p@host" not in body
     assert "[database_url:redacted]" in body
+
+
+# ---------------------------------------------------------------------------
+# on_lifecycle_close_completed — companion to on_lifecycle_close_beginning,
+# posted from main()'s finalizer right before reporter.close().
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_lifecycle_close_completed_renders_shutdown_embed():
+    """Shutdown intent → red embed titled 'Shutdown Complete' with
+    kind/reason/actor fields populated from the pending request."""
+    from core.runtime.lifecycle import PendingShutdown
+
+    reporter = WebhookReporter(url="https://example/wh")
+    reporter._send = AsyncMock()  # type: ignore[method-assign]
+    pending = PendingShutdown(
+        kind="shutdown",
+        reason="sigterm",
+        actor="signal_handler",
+        requested_at=0.0,
+        grace_seconds=None,
+    )
+
+    await reporter.on_lifecycle_close_completed(pending, duration_seconds=1.42)
+
+    reporter._send.assert_awaited_once()
+    embed = reporter._send.await_args.args[0]
+    assert "Shutdown Complete" in embed.title
+    assert embed.color == discord.Color.dark_red()
+    field_names = {f.name for f in embed.fields}
+    assert {"Kind", "Reason", "Actor", "Close duration"} <= field_names
+    duration_field = next(f for f in embed.fields if f.name == "Close duration")
+    assert duration_field.value == "1.42s"
+
+
+@pytest.mark.asyncio
+async def test_on_lifecycle_close_completed_renders_restart_embed_without_duration():
+    """Restart intent → gold embed titled 'Restart Complete'.  When the
+    caller cannot compute duration (e.g. no close_executing event found),
+    the Close duration field is omitted rather than rendered as 'None'."""
+    from core.runtime.lifecycle import PendingShutdown
+
+    reporter = WebhookReporter(url="https://example/wh")
+    reporter._send = AsyncMock()  # type: ignore[method-assign]
+    pending = PendingShutdown(
+        kind="restart",
+        reason="!restart",
+        actor="operator#0001",
+        requested_at=0.0,
+        grace_seconds=None,
+    )
+
+    await reporter.on_lifecycle_close_completed(pending, duration_seconds=None)
+
+    embed = reporter._send.await_args.args[0]
+    assert "Restart Complete" in embed.title
+    assert embed.color == discord.Color.gold()
+    field_names = {f.name for f in embed.fields}
+    assert "Close duration" not in field_names

--- a/tests/unit/test_bot_boot.py
+++ b/tests/unit/test_bot_boot.py
@@ -324,6 +324,33 @@ def test_bot1_finally_block_transitions_to_restarting_when_restart_pending() -> 
     )
 
 
+def test_bot1_finally_block_posts_close_completed_webhook_before_reporter_close() -> (
+    None
+):
+    """Companion to the close-beginning webhook posted by the close-driver:
+    the finalizer must post on_lifecycle_close_completed BEFORE
+    reporter.close() tears down the HTTP session, otherwise the embed
+    cannot reach the operator channel.  The two operator-visible signals
+    bracket the shutdown / restart window so the gap between them is the
+    close + cleanup duration."""
+    src = _src()
+    finally_block = src.split("finally:", 1)[-1]
+    assert "on_lifecycle_close_completed" in finally_block, (
+        "bot1.py finally block must invoke "
+        "reporter.on_lifecycle_close_completed so the close-complete "
+        "embed reaches the operator channel before reporter teardown."
+    )
+    # Ordering: the close-completed call must appear before
+    # ``reporter.close()`` so the HTTP session is still alive.
+    webhook_idx = finally_block.index("on_lifecycle_close_completed")
+    reporter_close_idx = finally_block.index("reporter.close()")
+    assert webhook_idx < reporter_close_idx, (
+        "on_lifecycle_close_completed must be posted BEFORE "
+        "reporter.close() — otherwise the webhook is dispatched on a "
+        "torn-down aiohttp session and silently dropped."
+    )
+
+
 def test_bot1_shutdown_drain_logs_timeout() -> None:
     """PR-02b (revised): when the 5 s drain budget elapses with tasks
     still pending, a WARNING log must surface so operators see the


### PR DESCRIPTION
## Summary

The close-driver posts `on_lifecycle_close_beginning` right before `bot.close()`, but there was no companion "close complete" signal — operators saw the bot start closing and then had to infer from process logs (or their absence) that cleanup actually finished.

This PR adds `on_lifecycle_close_completed` posted from `main()`'s finalizer right before `reporter.close()` tears down the HTTP session. Operators see a paired **Beginning / Complete** signal in the operator channel; the gap between the two embeds is the close + cleanup duration end-to-end.

## Design choices

- **Duration computed from the `close_executing` event timestamp** (added in PR #268). No extra state plumbing between the close-driver and the finalizer — the lifecycle ring buffer is already the source of truth.
- **Wrapped in `asyncio.wait_for(timeout=2.0)`** so a stalled webhook cannot delay process exit. Best-effort: any exception is caught and logged at DEBUG, matching the close-beginning pattern.
- **Posted before `reporter.close()`** (asserted by source invariant) so the HTTP session is still alive — otherwise the embed silently drops.
- **Duration field omitted** rather than rendered as `None` when the close_executing event isn't found (e.g., a code path that reaches the finalizer without going through the close-driver).

## What changed

- **`disbot/services/webhook_reporter.py`** — new `on_lifecycle_close_completed(pending, *, duration_seconds)` method following the close-beginning pattern.
- **`disbot/bot1.py`** — finalizer reads the close_executing event, computes duration, and posts the webhook before `reporter.close()`.
- **`tests/unit/services/test_webhook_reporter.py`** — 2 new tests covering shutdown-with-duration (dark-red, "Shutdown Complete") and restart-without-duration (gold, "Restart Complete", no Close duration field).
- **`tests/unit/test_bot_boot.py`** — source invariant asserting the webhook call sits **before** `reporter.close()` so it cannot regress to a torn-down session.

## Test plan

- [x] `pytest tests/unit/services/test_webhook_reporter.py tests/unit/test_bot_boot.py -v` — 22/22 pass
- [x] `pytest tests/unit/` — 4071 passed, 3 skipped
- [x] `black`, `isort`, `ruff`, `mypy` — all clean
- [ ] Sandbox sanity: trigger SIGTERM and confirm operator channel receives `🛑 Bot Shutdown Beginning` followed by `🛑 Bot Shutdown Complete` with a sub-second Close duration field. Same for `!restart` with gold-coloured embeds.

https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea

---
_Generated by [Claude Code](https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea)_