### PR TITLE
feat(metrics): lifecycle_phase gauge for current-phase observability

### DIFF
--- a/disbot/core/runtime/lifecycle.py
+++ b/disbot/core/runtime/lifecycle.py
@@ -99,6 +99,24 @@ def get_phase() -> Phase:
     return _phase
 
 
+def _publish_phase_gauge(phase: Phase) -> None:
+    """Update ``lifecycle_phase`` so exactly one ``phase`` label is 1.0.
+
+    Wrapped in try/except so a missing or partially-initialized metrics
+    module never blocks a phase transition — metrics are observability,
+    not control plane.
+    """
+    try:
+        from services import metrics as _metrics
+
+        for p in Phase:
+            _metrics.lifecycle_phase.labels(phase=p.value).set(
+                1.0 if p is phase else 0.0,
+            )
+    except Exception:  # noqa: BLE001 — metrics are observability only
+        pass
+
+
 def set_phase(phase: Phase, *, reason: str | None = None) -> None:
     """Record a phase transition.
 
@@ -111,6 +129,7 @@ def set_phase(phase: Phase, *, reason: str | None = None) -> None:
         return
     _phase = phase
     _record_event(f"phase:{phase.value}", reason=reason)
+    _publish_phase_gauge(phase)
 
 
 def is_shutting_down() -> bool:
@@ -279,6 +298,7 @@ def reset_for_tests() -> None:
     _phase = Phase.STARTING
     _pending = None
     _events.clear()
+    _publish_phase_gauge(_phase)
 
 
 def diagnostics_snapshot() -> dict[str, Any]:
@@ -331,6 +351,12 @@ try:
     _diagnostics_service.register("lifecycle", diagnostics_snapshot)
 except Exception:  # noqa: BLE001 — diagnostics is observability only
     pass
+
+# Initialise the lifecycle_phase gauge so STARTING reads as the current
+# phase from process start, before any explicit set_phase() call.
+# Without this, Grafana would show "no data" for the gauge until the
+# first phase transition (typically the STARTING → RUNNING on_ready).
+_publish_phase_gauge(_phase)
 
 
 __all__ = [

--- a/disbot/services/metrics.py
+++ b/disbot/services/metrics.py
@@ -140,6 +140,20 @@ runtime_lock_heartbeat_total = Counter(
     ["outcome"],  # ok | error | lost
 )
 
+# Current lifecycle phase, encoded as a multi-series gauge: exactly one
+# ``phase`` label has value 1.0 at any moment; the rest are 0.0.  This
+# is the canonical Prometheus state-machine encoding (cf.
+# ``node_systemd_unit_state``).  In Grafana, ``max by (phase)
+# (lifecycle_phase)`` renders the current phase as a single-stat panel;
+# ``max_over_time(lifecycle_phase[5m])`` surfaces any phase the bot
+# passed through in the last 5 minutes.
+lifecycle_phase = Gauge(
+    "lifecycle_phase",
+    "Current lifecycle phase as a multi-series gauge (1=current, 0=other).",
+    ["phase"],  # STARTING | RUNNING | DRAINING | SHUTTING_DOWN |
+    #             RESTARTING | STOPPED | FAILED_STARTUP
+)
+
 governance_fail_open_total = Counter(
     "governance_fail_open_total",
     "Interaction-router governance gate fell open due to resolver error. "

--- a/tests/unit/runtime/test_lifecycle.py
+++ b/tests/unit/runtime/test_lifecycle.py
@@ -254,3 +254,59 @@ def test_close_executing_event_appears_in_diagnostics_snapshot() -> None:
     snapshot = lifecycle.diagnostics_snapshot()
     event_names = [event["name"] for event in snapshot["recent_events"]]
     assert "close_executing" in event_names
+
+
+def _read_phase_gauge() -> dict[str, float]:
+    """Return ``{phase_value: gauge_value}`` for ``lifecycle_phase``."""
+    from services import metrics as _metrics
+
+    samples = next(iter(_metrics.lifecycle_phase.collect())).samples
+    return {
+        sample.labels["phase"]: sample.value
+        for sample in samples
+        if sample.name == "lifecycle_phase"
+    }
+
+
+def test_lifecycle_phase_gauge_reflects_current_phase_after_reset() -> None:
+    """The autouse reset_for_tests fixture must re-publish the gauge so
+    every test sees STARTING=1 and the other phases=0; without this the
+    gauge would leak stale values across tests."""
+    values = _read_phase_gauge()
+    assert values.get("STARTING") == 1.0
+    for other in ("RUNNING", "DRAINING", "SHUTTING_DOWN", "RESTARTING", "STOPPED"):
+        assert values.get(other) == 0.0
+
+
+def test_lifecycle_phase_gauge_updates_on_each_transition() -> None:
+    """After set_phase, exactly one series is 1.0 (the new phase) and
+    the previously-current series resets to 0.0.  This is the canonical
+    Prometheus state-machine encoding so Grafana panels using
+    ``max by (phase) (lifecycle_phase)`` always render a single point."""
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    values = _read_phase_gauge()
+    assert values["RUNNING"] == 1.0
+    assert values["STARTING"] == 0.0
+
+    lifecycle.request_shutdown("sigterm")
+    values = _read_phase_gauge()
+    assert values["DRAINING"] == 1.0
+    assert values["RUNNING"] == 0.0
+    assert values["STARTING"] == 0.0
+
+
+def test_lifecycle_phase_gauge_terminal_state_reflects_stopped() -> None:
+    """Terminal phases (STOPPED, RESTARTING) must also surface — the
+    bot may stop emitting metrics shortly after but the last scrape
+    before exit should show the terminal state."""
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown("sigterm")
+    lifecycle.set_phase(lifecycle.Phase.SHUTTING_DOWN)
+    lifecycle.set_phase(lifecycle.Phase.STOPPED)
+
+    values = _read_phase_gauge()
+    assert values["STOPPED"] == 1.0
+    # Only the terminal phase is 1; all others, including the prior
+    # SHUTTING_DOWN, must be 0.
+    nonzero = {phase for phase, value in values.items() if value > 0}
+    assert nonzero == {"STOPPED"}


### PR DESCRIPTION
## Summary

Operators can see the current phase via `!platform lifecycle` in Discord, but Prometheus/Grafana had no per-phase signal — only event counters and duration histograms from the close-driver metrics (#271). This adds the canonical state-machine encoding so a Grafana single-stat panel can render the current phase.

```
lifecycle_phase{phase="STARTING"}      0.0
lifecycle_phase{phase="RUNNING"}       1.0   ← current
lifecycle_phase{phase="DRAINING"}      0.0
lifecycle_phase{phase="SHUTTING_DOWN"} 0.0
lifecycle_phase{phase="RESTARTING"}    0.0
lifecycle_phase{phase="STOPPED"}       0.0
lifecycle_phase{phase="FAILED_STARTUP"} 0.0
```

Mirrors `node_exporter`'s `node_systemd_unit_state` pattern — exactly one series is `1.0` at any moment. Use `max by (phase) (lifecycle_phase)` for a single-stat panel; `max_over_time(lifecycle_phase[5m])` to surface phases the bot passed through in the last 5 minutes (catches fast restarts that would otherwise be invisible between scrape intervals).

## Why multi-series instead of an ordinal Gauge

A `lifecycle_phase_ordinal = 1` would be simpler but loses the human-readable phase name in dashboards and forces an integer-to-name mapping in every consumer. The multi-series encoding is the documented Prometheus convention for state machines and works natively in Grafana single-stat panels via `max by (phase)`.

## Initialisation matters

Without module-load initialisation, the gauge starts with no series exposed — Grafana shows "no data" until the first `set_phase()` call (typically `STARTING → RUNNING` on `on_ready`). For a healthy bot that's seconds, but during a slow boot it's exactly the window operators want visibility into. The `_publish_phase_gauge(_phase)` call at module bottom fixes this.

## What changed

- **`disbot/services/metrics.py`** — `lifecycle_phase` Gauge definition with rationale comment.
- **`disbot/core/runtime/lifecycle.py`** — `_publish_phase_gauge()` helper (try/except so metrics never block a phase transition); called from `set_phase()`, `reset_for_tests()`, and at module load.
- **`tests/unit/runtime/test_lifecycle.py`** — 3 new tests:
  - `reset_for_tests` publishes STARTING=1, others=0 (test-isolation hygiene)
  - Each transition updates exactly one series to 1, others to 0
  - Terminal `STOPPED` state is the canonical final reading

## Test plan

- [x] `pytest tests/unit/runtime/test_lifecycle.py -v` — 28/28 pass
- [x] `pytest tests/unit/` — 4071 passed, 3 skipped
- [x] `black`, `isort`, `ruff`, `mypy` on the two changed source files — all clean
- [ ] Sandbox sanity: `curl /metrics | grep ^lifecycle_phase` shows all 7 series with the current phase at 1.0. After SIGTERM, the DRAINING series rises to 1.0 and RUNNING drops to 0.0 within one scrape interval.

https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea

---
_Generated by [Claude Code](https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea)_