### PR TITLE
feat(metrics): runtime_lock_heartbeat_total counter

### DIFF
--- a/disbot/services/metrics.py
+++ b/disbot/services/metrics.py
@@ -128,6 +128,18 @@ runtime_lock_boot_wait_seconds = Histogram(
     buckets=(0.1, 0.5, 1.0, 5.0, 15.0, 30.0, 60.0, 120.0, 300.0),
 )
 
+# Runtime-lock heartbeat refresh attempts.  ``ok`` = lock still owned by
+# this boot; ``error`` = transient DB exception (retried up to
+# _HEARTBEAT_FAILURE_LIMIT before force-exit); ``lost`` = a peer reclaimed
+# the lock (single observation followed immediately by os._exit).
+# A sustained non-zero ``error`` rate indicates DB connectivity issues;
+# any ``lost`` observation indicates a split-brain that was just resolved.
+runtime_lock_heartbeat_total = Counter(
+    "runtime_lock_heartbeat_total",
+    "Runtime-lock heartbeat refresh attempts by outcome.",
+    ["outcome"],  # ok | error | lost
+)
+
 governance_fail_open_total = Counter(
     "governance_fail_open_total",
     "Interaction-router governance gate fell open due to resolver error. "

--- a/disbot/services/runtime.py
+++ b/disbot/services/runtime.py
@@ -259,6 +259,8 @@ async def run_heartbeat_loop(
       ``boot_id``): treat as fatal; another replica won. Exit
       immediately so we don't double-respond.
     """
+    from services import metrics as _metrics
+
     consecutive_failures = 0
     while not stop_event.is_set():
         try:
@@ -268,6 +270,7 @@ async def run_heartbeat_loop(
             )
         except Exception as exc:
             consecutive_failures += 1
+            _metrics.runtime_lock_heartbeat_total.labels(outcome="error").inc()
             logger.warning(
                 "runtime_lock.heartbeat failed (%d/%d): %s",
                 consecutive_failures,
@@ -283,6 +286,7 @@ async def run_heartbeat_loop(
                 os._exit(1)
         else:
             if not owned:
+                _metrics.runtime_lock_heartbeat_total.labels(outcome="lost").inc()
                 logger.critical(
                     "Runtime lock no longer owned by this boot "
                     "(lock_name=%s boot_id=%s). Another replica has "
@@ -291,6 +295,7 @@ async def run_heartbeat_loop(
                     boot_id,
                 )
                 os._exit(1)
+            _metrics.runtime_lock_heartbeat_total.labels(outcome="ok").inc()
             consecutive_failures = 0
         try:
             await asyncio.wait_for(stop_event.wait(), timeout=interval_seconds)

--- a/tests/unit/services/test_runtime.py
+++ b/tests/unit/services/test_runtime.py
@@ -273,3 +273,78 @@ async def test_release_lock_best_effort_swallows_exceptions():
     ):
         # Must not raise.
         await runtime.release_lock_best_effort()
+
+
+# ---------------------------------------------------------------------------
+# runtime_lock_heartbeat_total metric — increments on every loop iteration
+# with one of three outcomes: ok / error / lost.  Operators alert on a
+# sustained non-zero ``error`` rate (DB issues) or any ``lost`` observation
+# (split-brain).
+# ---------------------------------------------------------------------------
+
+
+def _heartbeat_counter_value(outcome: str) -> float:
+    from services import metrics as _metrics
+
+    return _metrics.runtime_lock_heartbeat_total.labels(outcome=outcome)._value.get()
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_metric_increments_ok_on_successful_refresh():
+    stop = asyncio.Event()
+    before = _heartbeat_counter_value("ok")
+
+    async def _hb(*_a, **_kw):
+        stop.set()
+        return True
+
+    with patch.object(rl_db, "heartbeat", side_effect=_hb):
+        await runtime.run_heartbeat_loop(stop, interval_seconds=0)
+
+    assert _heartbeat_counter_value("ok") == before + 1
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_metric_increments_error_on_exception():
+    """Transient DB exception must surface as outcome=error so operators
+    can graph DB connectivity issues separately from healthy refreshes."""
+    stop = asyncio.Event()
+    before_error = _heartbeat_counter_value("error")
+    before_ok = _heartbeat_counter_value("ok")
+    side_effects = [RuntimeError("blip"), True]
+
+    async def _hb(*_a, **_kw):
+        v = side_effects.pop(0)
+        if isinstance(v, Exception):
+            raise v
+        # Stop the loop on the successful recovery so the test's
+        # observation count is precise (no extra iterations).
+        stop.set()
+        return v
+
+    with patch.object(rl_db, "heartbeat", side_effect=_hb), patch(
+        "services.runtime.os._exit",
+    ):
+        await runtime.run_heartbeat_loop(stop, interval_seconds=0)
+
+    assert _heartbeat_counter_value("error") == before_error + 1
+    # The retry succeeded, so ok also incremented exactly once.
+    assert _heartbeat_counter_value("ok") == before_ok + 1
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_metric_increments_lost_when_peer_reclaims():
+    """``UPDATE 0`` (peer reclaimed the lock) must surface as outcome=lost
+    immediately before os._exit so the metric captures the split-brain
+    moment even if the next Prometheus scrape happens after exit."""
+    stop = asyncio.Event()
+    before = _heartbeat_counter_value("lost")
+
+    with patch.object(rl_db, "heartbeat", AsyncMock(return_value=False)), patch(
+        "services.runtime.os._exit",
+    ) as exit_mock:
+        exit_mock.side_effect = lambda code: stop.set()
+        await runtime.run_heartbeat_loop(stop, interval_seconds=0)
+
+    assert _heartbeat_counter_value("lost") == before + 1
+    exit_mock.assert_called_with(1)


### PR DESCRIPTION
## Summary

The runtime-lock heartbeat is the keep-alive that prevents stale-lock takeover after 90 s. Before this PR, the only signal for heartbeat health was log lines — there was no Prometheus metric, so operators couldn't alert on DB connectivity issues hitting the heartbeat path, and any split-brain (peer reclaim) was visible only as the `Runtime lock no longer owned` CRITICAL log immediately followed by process exit.

```
runtime_lock_heartbeat_total{outcome="ok"}     ← healthy refresh
runtime_lock_heartbeat_total{outcome="error"}  ← transient DB exception
runtime_lock_heartbeat_total{outcome="lost"}   ← peer reclaim (then exit)
```

## Most useful alerts this enables

- `rate(runtime_lock_heartbeat_total{outcome="error"}[5m]) > 0` — DB connectivity degrading the heartbeat path. Catches the lead-in before the `_HEARTBEAT_FAILURE_LIMIT=3` force-exit fires.
- `increase(runtime_lock_heartbeat_total{outcome="lost"}[1d]) > 0` — split-brain resolved by peer reclaim. Definitionally singular; any non-zero rate is an incident.

## Pre-exit scrape race

The `lost` increment lands **immediately before** `os._exit(1)` so a Prometheus scrape arriving in the millisecond window before exit can distinguish "process was killed for unrelated reasons" from "lock was stolen". Same pattern used for `lifecycle_close_duration_seconds` on timeout (PR #271).

## Design choices

- **Single `outcome` label, 3 values** — matches the `runtime_lock_boot_handoff_total{outcome}` pattern in `services/metrics.py:119`.
- **No duration histogram** — heartbeat is a single `UPDATE` query; latency is uninteresting unless DB is unhealthy, which the `error` outcome already captures.
- **Lazy import** of `services.metrics` at the top of `run_heartbeat_loop` matches the existing pattern at line 234 in `acquire_lock_or_exit` and avoids any import-order pitfalls.

## What changed

- **`disbot/services/metrics.py`** — counter definition with rationale and alerting guidance.
- **`disbot/services/runtime.py`** — three `inc()` calls inside `run_heartbeat_loop`, one per outcome branch.
- **`tests/unit/services/test_runtime.py`** — 3 new tests, one per outcome (ok / error / lost), asserting exact counter increments. The error-path test stops the loop on recovery so the observation count is precise.

## Test plan

- [x] `pytest tests/unit/services/test_runtime.py -v -k heartbeat` — 7/7 pass (4 existing + 3 new)
- [x] `pytest tests/unit/` — 4071 passed, 3 skipped
- [x] `black`, `isort`, `ruff`, `mypy` on the two changed source files — all clean
- [ ] Sandbox sanity: `curl /metrics | grep runtime_lock_heartbeat_total` shows the `ok` series climbing every 30 s during normal operation. Simulate a DB outage and confirm the `error` series climbs accordingly.

https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea

---
_Generated by [Claude Code](https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea)_