### PR TITLE
feat(lifecycle): on_lifecycle_close_timeout webhook for force-exit alerts

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -647,6 +647,24 @@ async def _drive_close_on_lifecycle_request() -> None:
             _metrics.lifecycle_close_duration_seconds.labels(
                 kind=kind_label,
             ).observe(LIFECYCLE_CLOSE_TIMEOUT_SECONDS)
+            # Highest-severity lifecycle webhook: bot.close() hung and
+            # the driver is force-exiting.  Tight timeout — the process
+            # is already past its bounded close budget; no point letting
+            # the webhook stall further.
+            if reporter is not None and pending is not None:
+                try:
+                    await asyncio.wait_for(
+                        reporter.on_lifecycle_close_timeout(
+                            pending,
+                            timeout_seconds=LIFECYCLE_CLOSE_TIMEOUT_SECONDS,
+                        ),
+                        timeout=1.0,
+                    )
+                except Exception as report_err:
+                    logger.debug(
+                        "Lifecycle close-timeout webhook skipped: %s",
+                        report_err,
+                    )
             logger.critical(
                 "bot.close() exceeded %.1fs timeout — force-exiting "
                 "so the orchestration platform respawns.",

--- a/disbot/services/webhook_reporter.py
+++ b/disbot/services/webhook_reporter.py
@@ -361,6 +361,56 @@ class WebhookReporter:
             )
         await self._send(embed, username="Bot Lifecycle")
 
+    async def on_lifecycle_close_timeout(
+        self,
+        pending: PendingShutdown,
+        *,
+        timeout_seconds: float,
+    ) -> None:
+        """Posted by the close-driver right before ``os._exit(1)`` when
+        ``bot.close()`` exceeds the bounded timeout.
+
+        This is the rarest and highest-severity lifecycle webhook: the
+        bot has hung during teardown and the close-driver is force-
+        exiting so the orchestrator respawns.  Operators alerting on
+        this embed get a Discord notification of every wedged close —
+        otherwise visible only via the critical log line and the
+        absence of a paired close-complete embed.
+
+        Caller wraps this in ``asyncio.wait_for`` with a tight
+        timeout (1 s) so a stalled webhook cannot meaningfully delay
+        the already-elapsed shutdown.
+        """
+        kind_word = "Restart" if pending.kind == "restart" else "Shutdown"
+        embed = discord.Embed(
+            title=f"🚨 Bot Close Timeout ({kind_word})",
+            description=(
+                f"`bot.close()` exceeded **{timeout_seconds:.1f}s** during "
+                f"a {pending.kind} request.  The close-driver is "
+                f"force-exiting; the orchestration platform will "
+                f"respawn this replica."
+            ),
+            color=discord.Color.dark_red(),
+            timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
+        )
+        embed.add_field(name="Kind", value=pending.kind, inline=True)
+        embed.add_field(
+            name="Reason",
+            value=pending.reason or "<unknown>",
+            inline=True,
+        )
+        embed.add_field(
+            name="Actor",
+            value=pending.actor or "<unknown>",
+            inline=True,
+        )
+        embed.add_field(
+            name="Timeout",
+            value=f"{timeout_seconds:.1f}s",
+            inline=True,
+        )
+        await self._send(embed, username="Bot Lifecycle")
+
     async def on_app_task_died(self, name: str, error: BaseException) -> None:
         """A supervised application task raised after startup.
 

--- a/tests/unit/services/test_webhook_reporter.py
+++ b/tests/unit/services/test_webhook_reporter.py
@@ -268,3 +268,62 @@ async def test_on_lifecycle_close_completed_renders_restart_embed_without_durati
     assert embed.color == discord.Color.gold()
     field_names = {f.name for f in embed.fields}
     assert "Close duration" not in field_names
+
+
+# ---------------------------------------------------------------------------
+# on_lifecycle_close_timeout — highest-severity lifecycle webhook, posted
+# right before os._exit when bot.close() exceeds the bounded timeout.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_lifecycle_close_timeout_renders_shutdown_alert():
+    """Shutdown timeout → dark-red 'Bot Close Timeout (Shutdown)' embed
+    with kind/reason/actor/timeout fields populated."""
+    from core.runtime.lifecycle import PendingShutdown
+
+    reporter = WebhookReporter(url="https://example/wh")
+    reporter._send = AsyncMock()  # type: ignore[method-assign]
+    pending = PendingShutdown(
+        kind="shutdown",
+        reason="sigterm",
+        actor="signal_handler",
+        requested_at=0.0,
+        grace_seconds=None,
+    )
+
+    await reporter.on_lifecycle_close_timeout(pending, timeout_seconds=20.0)
+
+    reporter._send.assert_awaited_once()
+    embed = reporter._send.await_args.args[0]
+    assert "Close Timeout" in embed.title
+    assert "Shutdown" in embed.title
+    assert embed.color == discord.Color.dark_red()
+    assert "20.0" in (embed.description or "")
+    field_names = {f.name for f in embed.fields}
+    assert {"Kind", "Reason", "Actor", "Timeout"} <= field_names
+
+
+@pytest.mark.asyncio
+async def test_on_lifecycle_close_timeout_renders_restart_alert():
+    """Restart timeout → same severity, restart-flavoured title."""
+    from core.runtime.lifecycle import PendingShutdown
+
+    reporter = WebhookReporter(url="https://example/wh")
+    reporter._send = AsyncMock()  # type: ignore[method-assign]
+    pending = PendingShutdown(
+        kind="restart",
+        reason="!restart",
+        actor="op",
+        requested_at=0.0,
+        grace_seconds=None,
+    )
+
+    await reporter.on_lifecycle_close_timeout(pending, timeout_seconds=20.0)
+
+    embed = reporter._send.await_args.args[0]
+    assert "Close Timeout" in embed.title
+    assert "Restart" in embed.title
+    # Severity is dark-red regardless of kind — timeout is always
+    # high-severity (force-exit).
+    assert embed.color == discord.Color.dark_red()

--- a/tests/unit/test_bot1_lifecycle_close_driver.py
+++ b/tests/unit/test_bot1_lifecycle_close_driver.py
@@ -277,6 +277,110 @@ async def test_close_timeout_observes_full_timeout_in_duration_histogram(
 
 
 @pytest.mark.asyncio
+async def test_close_timeout_posts_webhook_before_os_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The highest-severity lifecycle webhook fires from the timeout
+    branch BEFORE os._exit so operators get a Discord alert for every
+    wedged close.  The webhook is wrapped in a tight asyncio.wait_for
+    so a stalled reporter cannot meaningfully delay the already-elapsed
+    shutdown."""
+    timeout_calls: list[dict[str, object]] = []
+
+    class TimeoutReporter:
+        async def on_lifecycle_close_timeout(
+            self,
+            pending: Any,
+            *,
+            timeout_seconds: float,
+        ) -> None:
+            timeout_calls.append(
+                {
+                    "kind": pending.kind,
+                    "reason": pending.reason,
+                    "actor": pending.actor,
+                    "timeout_seconds": timeout_seconds,
+                },
+            )
+
+    class HangingBot:
+        async def close(self) -> None:
+            await asyncio.sleep(60.0)
+
+    monkeypatch.setattr(bot1, "bot", HangingBot())
+    monkeypatch.setattr(bot1, "reporter", TimeoutReporter())
+    monkeypatch.setattr(bot1, "LIFECYCLE_CLOSE_TIMEOUT_SECONDS", 0.05)
+    _install_fast_poll(monkeypatch)
+
+    class _ForceExit(BaseException):
+        pass
+
+    def _fake_exit(_code: int) -> None:
+        raise _ForceExit
+
+    monkeypatch.setattr(bot1.os, "_exit", _fake_exit)
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown(reason="sigterm", actor="signal_handler")
+
+    with pytest.raises(_ForceExit):
+        await asyncio.wait_for(
+            bot1._drive_close_on_lifecycle_request(),
+            timeout=2.0,
+        )
+
+    # The webhook was invoked before the force-exit.
+    assert len(timeout_calls) == 1
+    call = timeout_calls[0]
+    assert call["kind"] == "shutdown"
+    assert call["reason"] == "sigterm"
+    assert call["actor"] == "signal_handler"
+    assert call["timeout_seconds"] == 0.05
+
+
+@pytest.mark.asyncio
+async def test_close_timeout_webhook_error_does_not_block_os_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A reporter exception in the timeout branch must be swallowed —
+    the process is mid-force-exit; a webhook failure cannot be allowed
+    to derail the exit path."""
+
+    class BrokenReporter:
+        async def on_lifecycle_close_timeout(self, _pending: Any, **_kw) -> None:
+            raise RuntimeError("webhook session already torn down")
+
+    class HangingBot:
+        async def close(self) -> None:
+            await asyncio.sleep(60.0)
+
+    monkeypatch.setattr(bot1, "bot", HangingBot())
+    monkeypatch.setattr(bot1, "reporter", BrokenReporter())
+    monkeypatch.setattr(bot1, "LIFECYCLE_CLOSE_TIMEOUT_SECONDS", 0.05)
+    _install_fast_poll(monkeypatch)
+
+    class _ForceExit(BaseException):
+        pass
+
+    monkeypatch.setattr(
+        bot1.os,
+        "_exit",
+        lambda _code: (_ for _ in ()).throw(_ForceExit()),
+    )
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown(reason="sigterm")
+
+    # The reporter exception is swallowed (logged at DEBUG); the
+    # force-exit still happens.
+    with pytest.raises(_ForceExit):
+        await asyncio.wait_for(
+            bot1._drive_close_on_lifecycle_request(),
+            timeout=2.0,
+        )
+
+
+@pytest.mark.asyncio
 async def test_close_driver_metric_uses_restart_kind_for_restart_intent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

The close-driver's force-exit branch (`bot.close()` exceeds `LIFECYCLE_CLOSE_TIMEOUT_SECONDS`, then `os._exit(1)`) is the rarest and highest-severity failure mode of the lifecycle close path. Until now, the only signal was the `CRITICAL` log line — operators had to spot the absence of a paired close-complete embed to realise something went wrong.

This adds `on_lifecycle_close_timeout` posted from the timeout branch right before `os._exit`, so every wedged close raises an alert in the operator channel.

## Stacked on PR #271

Base branch is `claude/lifecycle-close-duration-histogram` (PR #271). Both PRs touch the close-driver's timeout branch; stacking makes the diff clean. When #271 merges, GitHub will re-target this PR's base to `main`.

## Three operator-visible lifecycle webhooks now bracket every close

| Webhook | Trigger | Origin |
|---|---|---|
| `on_lifecycle_close_beginning` | Always | close-driver, before `bot.close()` |
| `on_lifecycle_close_completed` | Happy path | `main()` finalizer (PR #272) |
| `on_lifecycle_close_timeout` | Force-exit | close-driver, before `os._exit(1)` — **this PR** |

A successful close produces `beginning → completed`. A wedged close produces `beginning → timeout`. The pairing alone tells operators which path the bot took, without parsing logs.

## Design choices

- **Tight 1 s wait_for timeout** — the process is already past its bounded close budget; no point letting the webhook stall further.
- **Exception swallowing** matches the close-beginning pattern: a stalled or torn-down reporter session cannot derail `os._exit`.
- **Dark-red severity regardless of kind** — timeout is always high-severity; restart-flavoured timeouts aren't milder than shutdown-flavoured ones.

## What changed

- **`disbot/services/webhook_reporter.py`** — new `on_lifecycle_close_timeout(pending, *, timeout_seconds)` method.
- **`disbot/bot1.py`** — webhook invocation inside the timeout branch, after the metric observation and before the critical log + `os._exit`.
- **`tests/unit/services/test_webhook_reporter.py`** — 2 new tests (shutdown alert, restart alert) asserting title, severity colour, and field set.
- **`tests/unit/test_bot1_lifecycle_close_driver.py`** — 2 new behavioural tests:
  - Happy path: timeout → webhook fires with correct kind/reason/actor/timeout_seconds → then force-exit
  - Failure path: broken reporter raises → exception is swallowed → force-exit still happens

## Test plan

- [x] `pytest tests/unit/test_bot1_lifecycle_close_driver.py tests/unit/services/test_webhook_reporter.py -v` — 21/21 pass
- [x] `pytest tests/unit/` — 4076 passed, 3 skipped
- [x] `black`, `isort`, `ruff`, `mypy` — all clean
- [ ] Sandbox sanity: artificially hang `bot.close()` (e.g. mid-cog teardown sleep) and confirm operator channel receives a 🚨 Bot Close Timeout embed within the bounded window before the process exits.

https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea

---
_Generated by [Claude Code](https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea)_