### PR TITLE
feat(metrics): lifecycle_startup_seconds histogram for time-to-ready

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -627,23 +627,35 @@ async def _drive_close_on_lifecycle_request() -> None:
                     "Lifecycle close-beginning webhook skipped: %s",
                     report_err,
                 )
+        from services import metrics as _metrics
+
         if pending is not None:
             _lifecycle.record_close_executing(pending)
-            from services import metrics as _metrics
-
             _metrics.lifecycle_close_driver_total.labels(kind=pending.kind).inc()
+        kind_label = pending.kind if pending is not None else "unknown"
+        close_started_at = time.monotonic()
         try:
             await asyncio.wait_for(
                 bot.close(),
                 timeout=LIFECYCLE_CLOSE_TIMEOUT_SECONDS,
             )
         except asyncio.TimeoutError:
+            # Observe the timeout value so a single observation in the
+            # topmost bucket is the canonical "force-exit" signature in
+            # Prometheus.  Done before os._exit so the next scrape (if
+            # it lands in the millisecond window before exit) sees it.
+            _metrics.lifecycle_close_duration_seconds.labels(
+                kind=kind_label,
+            ).observe(LIFECYCLE_CLOSE_TIMEOUT_SECONDS)
             logger.critical(
                 "bot.close() exceeded %.1fs timeout — force-exiting "
                 "so the orchestration platform respawns.",
                 LIFECYCLE_CLOSE_TIMEOUT_SECONDS,
             )
             os._exit(1)
+        _metrics.lifecycle_close_duration_seconds.labels(
+            kind=kind_label,
+        ).observe(time.monotonic() - close_started_at)
         return
 
 

--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -629,6 +629,9 @@ async def _drive_close_on_lifecycle_request() -> None:
                 )
         if pending is not None:
             _lifecycle.record_close_executing(pending)
+            from services import metrics as _metrics
+
+            _metrics.lifecycle_close_driver_total.labels(kind=pending.kind).inc()
         try:
             await asyncio.wait_for(
                 bot.close(),

--- a/disbot/core/runtime/lifecycle.py
+++ b/disbot/core/runtime/lifecycle.py
@@ -93,6 +93,14 @@ _phase: Phase = Phase.STARTING
 _pending: PendingShutdown | None = None
 _events: deque[LifecycleEvent] = deque(maxlen=_EVENT_BUFFER_SIZE)
 
+# Captured at module-load time as the "process start" reference for the
+# ``lifecycle_startup_seconds`` histogram.  This module is imported very
+# early in bot1's import chain, so it is a tight approximation of
+# os.getpid() creation time.  Only used for the one-shot observation on
+# STARTING → RUNNING; reset by ``reset_for_tests`` so each test sees a
+# fresh reference.
+_MODULE_LOAD_AT: float = time.monotonic()
+
 
 def get_phase() -> Phase:
     """Return the current lifecycle phase."""
@@ -117,6 +125,36 @@ def _publish_phase_gauge(phase: Phase) -> None:
         pass
 
 
+_startup_duration_observed: bool = False
+
+
+def _observe_startup_duration_once() -> None:
+    """Observe ``lifecycle_startup_seconds`` exactly once per process.
+
+    Fires on the first transition into ``RUNNING``.  Guarded so an
+    erratic RUNNING ↔ DRAINING ↔ RUNNING sequence (theoretical, since
+    the lifecycle doesn't re-enter RUNNING today) cannot double-count.
+
+    Skips negative observations as a defensive guard: tests sometimes
+    monkeypatch :func:`time.monotonic` to a fixed value, which would
+    make ``elapsed`` negative.  In production ``time.monotonic`` is
+    guaranteed non-decreasing so this branch is unreachable.
+    """
+    global _startup_duration_observed
+    if _startup_duration_observed:
+        return
+    try:
+        from services import metrics as _metrics
+
+        elapsed = time.monotonic() - _MODULE_LOAD_AT
+        if elapsed < 0:
+            return
+        _metrics.lifecycle_startup_seconds.observe(elapsed)
+        _startup_duration_observed = True
+    except Exception:  # noqa: BLE001 — metrics are observability only
+        pass
+
+
 def set_phase(phase: Phase, *, reason: str | None = None) -> None:
     """Record a phase transition.
 
@@ -130,6 +168,8 @@ def set_phase(phase: Phase, *, reason: str | None = None) -> None:
     _phase = phase
     _record_event(f"phase:{phase.value}", reason=reason)
     _publish_phase_gauge(phase)
+    if phase is Phase.RUNNING:
+        _observe_startup_duration_once()
 
 
 def is_shutting_down() -> bool:
@@ -294,11 +334,15 @@ def reset_for_tests() -> None:
 
     Test-only entry point — production code must not call this.
     """
-    global _phase, _pending
+    global _phase, _pending, _startup_duration_observed, _MODULE_LOAD_AT
     _phase = Phase.STARTING
     _pending = None
     _events.clear()
     _publish_phase_gauge(_phase)
+    # Reset the once-flag and the reference moment so each test sees a
+    # clean startup-duration observation if it transitions into RUNNING.
+    _startup_duration_observed = False
+    _MODULE_LOAD_AT = time.monotonic()
 
 
 def diagnostics_snapshot() -> dict[str, Any]:

--- a/disbot/services/metrics.py
+++ b/disbot/services/metrics.py
@@ -165,6 +165,20 @@ lifecycle_close_driver_total = Counter(
     ["kind"],  # shutdown | restart
 )
 
+# Duration of bot.close() invoked by the close-driver above.  The 20 s
+# bucket aligns with LIFECYCLE_CLOSE_TIMEOUT_SECONDS so a single observation
+# in the topmost bucket is the canonical "close hit the timeout and the
+# driver force-exited" signature.  Sub-second buckets capture the
+# normal-path close.  Sustained drift towards higher buckets is the
+# leading indicator of an unhealthy close path before it actually hits
+# the timeout.
+lifecycle_close_duration_seconds = Histogram(
+    "lifecycle_close_duration_seconds",
+    "Duration of bot.close() invoked by the lifecycle close-driver.",
+    ["kind"],  # shutdown | restart
+    buckets=(0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 15.0, 20.0),
+)
+
 governance_fail_open_total = Counter(
     "governance_fail_open_total",
     "Interaction-router governance gate fell open due to resolver error. "

--- a/disbot/services/metrics.py
+++ b/disbot/services/metrics.py
@@ -154,6 +154,17 @@ lifecycle_phase = Gauge(
     #             RESTARTING | STOPPED | FAILED_STARTUP
 )
 
+# Lifecycle close-driver invocations: increments once each time the watchdog
+# in bot1 drives bot.close() from a pending lifecycle request.  ``shutdown``
+# is SIGTERM-driven; ``restart`` is !restart-driven.  Use this to alert on
+# unexpected close rates (e.g. a sustained non-zero ``restart`` rate without
+# operator action indicates a restart loop).
+lifecycle_close_driver_total = Counter(
+    "lifecycle_close_driver_total",
+    "Lifecycle close-driver invocations by pending request kind.",
+    ["kind"],  # shutdown | restart
+)
+
 governance_fail_open_total = Counter(
     "governance_fail_open_total",
     "Interaction-router governance gate fell open due to resolver error. "

--- a/disbot/services/metrics.py
+++ b/disbot/services/metrics.py
@@ -179,6 +179,20 @@ lifecycle_close_duration_seconds = Histogram(
     buckets=(0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 15.0, 20.0),
 )
 
+# Time from process start to the STARTING → RUNNING transition (i.e.
+# Discord's on_ready event firing).  Observed exactly once per boot,
+# at the moment lifecycle.set_phase(RUNNING) is called for the first
+# time.  Sustained drift towards higher buckets indicates a degrading
+# boot path (slow migrations, slow extension load, slow Discord
+# handshake, slow identity-contract validation, etc).  Buckets span
+# 0.5 s — 5 min so both fast healthy boots and pathological cold-starts
+# land somewhere informative.
+lifecycle_startup_seconds = Histogram(
+    "lifecycle_startup_seconds",
+    "Time from process start to lifecycle phase RUNNING (on_ready fired).",
+    buckets=(0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0, 300.0),
+)
+
 governance_fail_open_total = Counter(
     "governance_fail_open_total",
     "Interaction-router governance gate fell open due to resolver error. "

--- a/tests/unit/runtime/test_lifecycle.py
+++ b/tests/unit/runtime/test_lifecycle.py
@@ -310,3 +310,55 @@ def test_lifecycle_phase_gauge_terminal_state_reflects_stopped() -> None:
     # SHUTTING_DOWN, must be 0.
     nonzero = {phase for phase, value in values.items() if value > 0}
     assert nonzero == {"STOPPED"}
+
+
+def _read_startup_histogram() -> tuple[float, float]:
+    """Return (count, sum) for ``lifecycle_startup_seconds``."""
+    from services import metrics as _metrics
+
+    samples = next(iter(_metrics.lifecycle_startup_seconds.collect())).samples
+    count = next(s.value for s in samples if s.name.endswith("_count"))
+    total = next(s.value for s in samples if s.name.endswith("_sum"))
+    return count, total
+
+
+def test_lifecycle_startup_seconds_observed_on_first_running_transition() -> None:
+    """The STARTING → RUNNING transition observes startup duration
+    exactly once.  ``reset_for_tests`` re-arms the once-flag so each
+    test can verify the observation independently."""
+    before_count, _ = _read_startup_histogram()
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    after_count, after_sum = _read_startup_histogram()
+    assert after_count == before_count + 1
+    # ``_MODULE_LOAD_AT`` is reset in reset_for_tests, so the elapsed
+    # value should be very small but strictly non-negative.
+    assert after_sum >= 0
+
+
+def test_lifecycle_startup_seconds_not_observed_for_non_running_transitions() -> None:
+    """Transitions to DRAINING, SHUTTING_DOWN, STOPPED, etc. must not
+    fire the startup observation — only the canonical "boot complete"
+    moment (first RUNNING) counts."""
+    before_count, _ = _read_startup_histogram()
+    lifecycle.set_phase(lifecycle.Phase.DRAINING)
+    lifecycle.set_phase(lifecycle.Phase.SHUTTING_DOWN)
+    lifecycle.set_phase(lifecycle.Phase.STOPPED)
+    after_count, _ = _read_startup_histogram()
+    assert after_count == before_count
+
+
+def test_lifecycle_startup_seconds_does_not_double_count_on_repeated_running() -> (
+    None
+):
+    """If RUNNING is somehow re-entered (DRAINING → RUNNING is not a
+    legal transition today but the guard exists in case the state
+    machine grows), the observation must NOT fire twice — startup is
+    a one-shot per-process measurement."""
+    before_count, _ = _read_startup_histogram()
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    # Force the phase back, then re-enter RUNNING.  The once-flag must
+    # still suppress the second observation.
+    lifecycle.set_phase(lifecycle.Phase.DRAINING)
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    after_count, _ = _read_startup_histogram()
+    assert after_count == before_count + 1

--- a/tests/unit/test_bot1_lifecycle_close_driver.py
+++ b/tests/unit/test_bot1_lifecycle_close_driver.py
@@ -187,6 +187,95 @@ async def test_close_driver_increments_close_metric_with_kind_label(
     assert after == before + 1
 
 
+def _histogram_count_and_sum(histogram_child) -> tuple[float, float]:
+    """Read (count, sum) from a Prometheus Histogram label child.
+
+    Histogram does not expose a public ``_count`` attribute — the count
+    is the +Inf bucket value.  Using ``collect()`` here so the assertion
+    is decoupled from prometheus_client's internal layout.
+    """
+    samples = next(iter(histogram_child.collect())).samples
+    count = next(s.value for s in samples if s.name.endswith("_count"))
+    total = next(s.value for s in samples if s.name.endswith("_sum"))
+    return count, total
+
+
+@pytest.mark.asyncio
+async def test_close_driver_observes_close_duration_histogram(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each successful bot.close() observation lands in
+    ``lifecycle_close_duration_seconds{kind=...}`` so operators can
+    alert on a sustained drift towards higher buckets before close
+    actually hits the bounded timeout."""
+    from services import metrics as _metrics
+
+    fake_bot = _FakeBot()
+    monkeypatch.setattr(bot1, "bot", fake_bot)
+    monkeypatch.setattr(bot1, "reporter", None)
+    _install_fast_poll(monkeypatch)
+
+    histogram = _metrics.lifecycle_close_duration_seconds.labels(kind="shutdown")
+    before_count, before_sum = _histogram_count_and_sum(histogram)
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown(reason="sigterm")
+
+    await asyncio.wait_for(bot1._drive_close_on_lifecycle_request(), timeout=2.0)
+
+    after_count, after_sum = _histogram_count_and_sum(histogram)
+    assert after_count == before_count + 1
+    # Healthy close completes in well under 1s; bound under the timeout
+    # to avoid CI scheduler jitter false positives.
+    assert (after_sum - before_sum) < bot1.LIFECYCLE_CLOSE_TIMEOUT_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_close_timeout_observes_full_timeout_in_duration_histogram(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The force-exit timeout path must observe the full timeout value
+    before calling ``os._exit`` so a Prometheus scrape arriving in the
+    millisecond window before exit can distinguish "close hung" from
+    "close took 0s and the process died for unrelated reasons"."""
+    from services import metrics as _metrics
+
+    class HangingBot:
+        async def close(self) -> None:
+            await asyncio.sleep(60.0)
+
+    monkeypatch.setattr(bot1, "bot", HangingBot())
+    monkeypatch.setattr(bot1, "reporter", None)
+    monkeypatch.setattr(bot1, "LIFECYCLE_CLOSE_TIMEOUT_SECONDS", 0.05)
+    _install_fast_poll(monkeypatch)
+
+    class _ForceExit(BaseException):
+        pass
+
+    def _fake_exit(_code: int) -> None:
+        raise _ForceExit
+
+    monkeypatch.setattr(bot1.os, "_exit", _fake_exit)
+
+    histogram = _metrics.lifecycle_close_duration_seconds.labels(kind="shutdown")
+    before_count, before_sum = _histogram_count_and_sum(histogram)
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown(reason="sigterm")
+
+    with pytest.raises(_ForceExit):
+        await asyncio.wait_for(
+            bot1._drive_close_on_lifecycle_request(),
+            timeout=2.0,
+        )
+
+    after_count, after_sum = _histogram_count_and_sum(histogram)
+    assert after_count == before_count + 1
+    # Observation is the timeout constant (0.05s in this test) — that
+    # exact value is what marks "force-exit" in dashboards.
+    assert (after_sum - before_sum) == pytest.approx(0.05, abs=0.001)
+
+
 @pytest.mark.asyncio
 async def test_close_driver_metric_uses_restart_kind_for_restart_intent(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_bot1_lifecycle_close_driver.py
+++ b/tests/unit/test_bot1_lifecycle_close_driver.py
@@ -163,6 +163,55 @@ async def test_webhook_fires_before_bot_close(
 
 
 @pytest.mark.asyncio
+async def test_close_driver_increments_close_metric_with_kind_label(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each close-driver invocation increments
+    ``lifecycle_close_driver_total{kind=...}`` so operators can alert
+    on unexpected close/restart rates from Prometheus."""
+    from services import metrics as _metrics
+
+    fake_bot = _FakeBot()
+    monkeypatch.setattr(bot1, "bot", fake_bot)
+    monkeypatch.setattr(bot1, "reporter", None)
+    _install_fast_poll(monkeypatch)
+
+    before = _metrics.lifecycle_close_driver_total.labels(kind="shutdown")._value.get()
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown(reason="sigterm")
+
+    await asyncio.wait_for(bot1._drive_close_on_lifecycle_request(), timeout=2.0)
+
+    after = _metrics.lifecycle_close_driver_total.labels(kind="shutdown")._value.get()
+    assert after == before + 1
+
+
+@pytest.mark.asyncio
+async def test_close_driver_metric_uses_restart_kind_for_restart_intent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Restart and shutdown invocations land on distinct label series so
+    operators can graph them separately."""
+    from services import metrics as _metrics
+
+    fake_bot = _FakeBot()
+    monkeypatch.setattr(bot1, "bot", fake_bot)
+    monkeypatch.setattr(bot1, "reporter", None)
+    _install_fast_poll(monkeypatch)
+
+    before = _metrics.lifecycle_close_driver_total.labels(kind="restart")._value.get()
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_restart(reason="!restart", actor="op")
+
+    await asyncio.wait_for(bot1._drive_close_on_lifecycle_request(), timeout=2.0)
+
+    after = _metrics.lifecycle_close_driver_total.labels(kind="restart")._value.get()
+    assert after == before + 1
+
+
+@pytest.mark.asyncio
 async def test_close_driver_records_close_executing_lifecycle_event(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Operators have close-side timing via `lifecycle_close_duration_seconds` (PR #271) and the current phase via `lifecycle_phase` (PR #273), but no metric for the inverse: time from process start to `RUNNING`. This is the canonical "boot complete" measurement — the leading indicator for deploy health.

```
lifecycle_startup_seconds   histogram, observed once per process
```

Buckets `(0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0, 300.0)` span fast healthy boots (typically 2-10 s) to pathological cold-starts where migrations, identity-contract validation, or Discord handshake degrade.

## Stacked on PR #273

Base is `claude/lifecycle-phase-gauge` (PR #273). Both PRs touch `set_phase` to fire metrics, so stacking keeps the diffs minimal. When #273 merges, GitHub re-targets this PR's base to `main`.

## Design choices

- **Module-load reference instead of process start syscall** — `time.monotonic()` captured at lifecycle module load is a tight approximation of process start because lifecycle is imported very early in bot1's import chain. Avoids a `psutil.Process().create_time()` dependency.
- **Once-flag** — guards against re-entry into `RUNNING` (theoretical today; defensive for future state-machine extensions).
- **Negative-elapsed guard** — `time.monotonic()` is non-decreasing in production, but the existing `test_remaining_shutdown_seconds_clamped_to_zero_after_grace_expires` monkeypatches it to a fixed value, which would otherwise produce a negative observation. The guard returns silently so test isolation cannot pollute the histogram.
- **`reset_for_tests` re-arms both the once-flag and `_MODULE_LOAD_AT`** so each test sees a fresh observation window.

## What changed

- **`disbot/services/metrics.py`** — histogram definition with rationale.
- **`disbot/core/runtime/lifecycle.py`** — `_MODULE_LOAD_AT`, `_observe_startup_duration_once()`, call from `set_phase`, reset wiring.
- **`tests/unit/runtime/test_lifecycle.py`** — 3 new tests:
  - First RUNNING transition observes exactly once
  - Non-RUNNING transitions do not observe
  - DRAINING → RUNNING re-entry does not double-count

## Most useful alerts this enables

- `histogram_quantile(0.95, rate(lifecycle_startup_seconds_bucket[1h])) > 20` — p95 boot time over 20 s over the last hour. Catches a deploy that's slow to come up.
- `increase(lifecycle_startup_seconds_count[5m]) > N` — restart loop indicator (the bot is starting too often).

## Test plan

- [x] `pytest tests/unit/runtime/test_lifecycle.py -v` — 31/31 pass
- [x] `pytest tests/unit/` — 4074 passed, 3 skipped
- [x] `black`, `isort`, `ruff`, `mypy` — all clean
- [ ] Sandbox sanity: deploy and confirm `lifecycle_startup_seconds_count` increments by 1 per boot; observe a single sub-10-second observation per healthy boot.

https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea

---
_Generated by [Claude Code](https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea)_