### PR TITLE
feat(metrics): runtime_lock_heartbeat_seconds histogram

### DIFF
--- a/disbot/services/metrics.py
+++ b/disbot/services/metrics.py
@@ -179,6 +179,17 @@ lifecycle_close_duration_seconds = Histogram(
     buckets=(0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 15.0, 20.0),
 )
 
+# Duration of each ``runtime_lock.heartbeat`` UPDATE call.  Observed on
+# every attempt — success and exception alike — so operators can graph
+# DB latency trends without being blinded by exception-path samples
+# being skipped.  Buckets stop at 30 s (the heartbeat interval) since a
+# single heartbeat exceeding the interval is already pathological.
+runtime_lock_heartbeat_seconds = Histogram(
+    "runtime_lock_heartbeat_seconds",
+    "Duration of the runtime-lock heartbeat UPDATE call (success or error).",
+    buckets=(0.005, 0.025, 0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0),
+)
+
 governance_fail_open_total = Counter(
     "governance_fail_open_total",
     "Interaction-router governance gate fell open due to resolver error. "

--- a/disbot/services/runtime.py
+++ b/disbot/services/runtime.py
@@ -263,12 +263,16 @@ async def run_heartbeat_loop(
 
     consecutive_failures = 0
     while not stop_event.is_set():
+        heartbeat_started_at = time.monotonic()
         try:
             owned = await runtime_lock.heartbeat(
                 boot_id,
                 lock_name=lock_name,
             )
         except Exception as exc:
+            _metrics.runtime_lock_heartbeat_seconds.observe(
+                time.monotonic() - heartbeat_started_at,
+            )
             consecutive_failures += 1
             _metrics.runtime_lock_heartbeat_total.labels(outcome="error").inc()
             logger.warning(
@@ -285,6 +289,9 @@ async def run_heartbeat_loop(
                 )
                 os._exit(1)
         else:
+            _metrics.runtime_lock_heartbeat_seconds.observe(
+                time.monotonic() - heartbeat_started_at,
+            )
             if not owned:
                 _metrics.runtime_lock_heartbeat_total.labels(outcome="lost").inc()
                 logger.critical(

--- a/tests/unit/services/test_runtime.py
+++ b/tests/unit/services/test_runtime.py
@@ -348,3 +348,68 @@ async def test_heartbeat_metric_increments_lost_when_peer_reclaims():
 
     assert _heartbeat_counter_value("lost") == before + 1
     exit_mock.assert_called_with(1)
+
+
+# ---------------------------------------------------------------------------
+# runtime_lock_heartbeat_seconds — duration of each heartbeat UPDATE call,
+# observed on every attempt (success AND exception) so DB latency trends
+# are not blinded by exception-path samples being skipped.
+# ---------------------------------------------------------------------------
+
+
+def _heartbeat_seconds_count_and_sum() -> tuple[float, float]:
+    """Return (count, sum) of the heartbeat-seconds histogram."""
+    from services import metrics as _metrics
+
+    samples = next(iter(_metrics.runtime_lock_heartbeat_seconds.collect())).samples
+    count = next(s.value for s in samples if s.name.endswith("_count"))
+    total = next(s.value for s in samples if s.name.endswith("_sum"))
+    return count, total
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_seconds_histogram_observes_each_successful_call():
+    """Every successful heartbeat call observes a duration so operators
+    can graph the latency distribution without gaps."""
+    stop = asyncio.Event()
+    before_count, _ = _heartbeat_seconds_count_and_sum()
+
+    async def _hb(*_a, **_kw):
+        stop.set()
+        return True
+
+    with patch.object(rl_db, "heartbeat", side_effect=_hb):
+        await runtime.run_heartbeat_loop(stop, interval_seconds=0)
+
+    after_count, after_sum = _heartbeat_seconds_count_and_sum()
+    assert after_count == before_count + 1
+    # Duration must be non-negative; a real DB UPDATE in a healthy
+    # process completes in well under a second.
+    assert after_sum >= 0
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_seconds_histogram_observes_failed_calls_too():
+    """Exception path must STILL observe the duration — the time spent
+    inside an erroring DB call is itself a useful signal (e.g. a slow
+    connection-pool timeout) and skipping it would bias the
+    distribution towards the happy path only."""
+    stop = asyncio.Event()
+    before_count, _ = _heartbeat_seconds_count_and_sum()
+    side_effects = [RuntimeError("blip"), True]
+
+    async def _hb(*_a, **_kw):
+        v = side_effects.pop(0)
+        if isinstance(v, Exception):
+            raise v
+        stop.set()
+        return v
+
+    with patch.object(rl_db, "heartbeat", side_effect=_hb), patch(
+        "services.runtime.os._exit",
+    ):
+        await runtime.run_heartbeat_loop(stop, interval_seconds=0)
+
+    after_count, _ = _heartbeat_seconds_count_and_sum()
+    # Two observations: one for the failed call, one for the recovery.
+    assert after_count == before_count + 2


### PR DESCRIPTION
## Summary

The heartbeat counter from PR #274 tracks **whether** each refresh succeeded; this histogram tracks **how long** each one took. Together they let operators distinguish "DB is unreachable" (counter spikes on `error`) from "DB is overloaded" (latency drifts towards higher buckets even while counter stays on `ok`).

```
runtime_lock_heartbeat_seconds   histogram, observed per attempt
```

Buckets `(0.005, 0.025, 0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0)`. The 30 s upper bucket aligns with `DEFAULT_HEARTBEAT_SECONDS` so a single observation in that bucket means a heartbeat exceeded the interval itself — pathological.

## Stacked on PR #274

Base is `claude/runtime-lock-heartbeat-metric` (PR #274). Both PRs touch the heartbeat loop; stacking keeps the diff minimal.

## Observed on success AND exception

Skipping exception-path samples would bias the distribution towards the happy path only, hiding cases where a slow connection-pool timeout is the real problem. The exception branch observes the duration **before** incrementing the error counter, so both metrics agree on the same attempt.

## Most useful alerts this enables

- `histogram_quantile(0.95, rate(runtime_lock_heartbeat_seconds_bucket[5m])) > 1.0` — p95 heartbeat latency over 1 s. Catches DB degradation before it triggers `_HEARTBEAT_FAILURE_LIMIT` force-exits.
- `rate(runtime_lock_heartbeat_seconds_bucket{le="30.0"}[5m]) - rate(runtime_lock_heartbeat_seconds_bucket{le="10.0"}[5m]) > 0` — any single heartbeat between 10 s and 30 s in the last 5 m. Definitionally pathological.

## What changed

- **`disbot/services/metrics.py`** — histogram definition with rationale.
- **`disbot/services/runtime.py`** — capture `heartbeat_started_at` per iteration, observe duration on both success and exception branches.
- **`tests/unit/services/test_runtime.py`** — 2 new tests covering the success-path observation and the exception-path observation (verified by mocking heartbeat to raise then recover and asserting 2 observations).

## Test plan

- [x] `pytest tests/unit/services/test_runtime.py -v` — 20/20 pass
- [x] `pytest tests/unit/` — 4073 passed, 3 skipped
- [x] `black`, `isort`, `ruff`, `mypy` — all clean
- [ ] Sandbox sanity: `curl /metrics | grep runtime_lock_heartbeat_seconds_bucket` shows observations climbing under the small buckets during normal operation.

https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea

---
_Generated by [Claude Code](https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea)_