### PR TITLE
feat(metrics): webhook_dispatch_total for reporter health

### DIFF
--- a/disbot/services/metrics.py
+++ b/disbot/services/metrics.py
@@ -171,6 +171,18 @@ identity_contract_findings_total = Counter(
     # view_subsystem_unknown | db_anchor_subsystem_unknown
 )
 
+# Webhook reporter dispatch outcomes.  ``success`` = embed posted to
+# discord.Webhook.send without exception; ``error`` = the send raised
+# (network failure, 4xx/5xx, malformed payload, etc.) and was caught
+# and logged at DEBUG.  Without this metric, webhook outages are silent
+# — operators only notice when expected operator-channel embeds stop
+# appearing in Discord.
+webhook_dispatch_total = Counter(
+    "webhook_dispatch_total",
+    "WebhookReporter dispatch outcomes (success or caught exception).",
+    ["outcome"],  # success | error
+)
+
 # ---------------------------------------------------------------------------
 # F-1 guild_config cache (core/runtime/guild_config.py) — Phase S1.1
 # ---------------------------------------------------------------------------

--- a/disbot/services/webhook_reporter.py
+++ b/disbot/services/webhook_reporter.py
@@ -88,11 +88,16 @@ class WebhookReporter:
         counts = _redact_embed(embed)
         if counts:
             logger.debug("Webhook embed redacted: %s", counts)
+        from services import metrics as _metrics
+
         try:
             wh = discord.Webhook.from_url(self.url, session=self._session)
             await wh.send(embed=embed, username=username)
         except Exception as exc:
+            _metrics.webhook_dispatch_total.labels(outcome="error").inc()
             logger.debug("Webhook send failed: %s", exc)
+        else:
+            _metrics.webhook_dispatch_total.labels(outcome="success").inc()
 
     async def on_startup(self, bot) -> None:
         embed = discord.Embed(

--- a/tests/unit/services/test_webhook_reporter.py
+++ b/tests/unit/services/test_webhook_reporter.py
@@ -103,6 +103,73 @@ async def test_send_no_session_returns_early_without_redaction_or_dispatch() -> 
     assert embed.description == "postgres://u:p@h/db"
 
 
+def _webhook_dispatch_counter(outcome: str) -> float:
+    from services import metrics as _metrics
+
+    return _metrics.webhook_dispatch_total.labels(outcome=outcome)._value.get()
+
+
+@pytest.mark.asyncio
+async def test_send_records_success_outcome_in_metric() -> None:
+    """Successful dispatch increments ``webhook_dispatch_total{outcome=success}``
+    so operators can graph healthy posts."""
+    reporter = WebhookReporter("https://discord.com/api/webhooks/123/abc")
+    reporter._session = MagicMock()
+
+    before = _webhook_dispatch_counter("success")
+
+    wh_mock = MagicMock()
+    wh_mock.send = AsyncMock()
+    with patch(
+        "services.webhook_reporter.discord.Webhook.from_url",
+        return_value=wh_mock,
+    ):
+        await reporter._send(discord.Embed(title="ok"))
+
+    assert _webhook_dispatch_counter("success") == before + 1
+
+
+@pytest.mark.asyncio
+async def test_send_records_error_outcome_when_send_raises() -> None:
+    """A network failure / 4xx / 5xx raises out of ``wh.send`` and is
+    caught + logged at DEBUG.  Without this metric, webhook outages
+    were silent — only visible as the absence of expected embeds.
+    Now operators can alert on
+    ``rate(webhook_dispatch_total{outcome="error"}[5m]) > 0``."""
+    reporter = WebhookReporter("https://discord.com/api/webhooks/123/abc")
+    reporter._session = MagicMock()
+
+    before = _webhook_dispatch_counter("error")
+
+    wh_mock = MagicMock()
+    wh_mock.send = AsyncMock(side_effect=RuntimeError("network down"))
+    with patch(
+        "services.webhook_reporter.discord.Webhook.from_url",
+        return_value=wh_mock,
+    ):
+        # _send swallows the exception (best-effort observability).
+        await reporter._send(discord.Embed(title="ok"))
+
+    assert _webhook_dispatch_counter("error") == before + 1
+
+
+@pytest.mark.asyncio
+async def test_send_no_dispatch_outcome_when_session_missing() -> None:
+    """The early-return guard (no URL or no session) must NOT increment
+    either outcome — those are "no attempt made" not "attempt
+    succeeded/failed"."""
+    reporter = WebhookReporter("https://discord.com/api/webhooks/123/abc")
+    # No _session set — _send bails before reaching dispatch.
+
+    before_success = _webhook_dispatch_counter("success")
+    before_error = _webhook_dispatch_counter("error")
+
+    await reporter._send(discord.Embed(title="ok"))
+
+    assert _webhook_dispatch_counter("success") == before_success
+    assert _webhook_dispatch_counter("error") == before_error
+
+
 @pytest.mark.asyncio
 async def test_on_command_error_redacts_traceback_secret_end_to_end() -> None:
     """Construct a real exception whose message contains a Postgres URL,


### PR DESCRIPTION
## Summary

`WebhookReporter._send` catches and DEBUG-logs every send exception (network failure, 4xx/5xx, malformed payload) — there was no Prometheus signal for webhook outages. Operators only noticed when expected operator-channel embeds stopped appearing in Discord, which is hours-to-days too late for diagnostics, command-error, and lifecycle embeds.

```
webhook_dispatch_total{outcome="success"}   ← embed posted OK
webhook_dispatch_total{outcome="error"}     ← send raised, caught
```

## Most useful alert

`rate(webhook_dispatch_total{outcome="error"}[5m]) > 0` — fires immediately when webhook posts start failing, well before the absence-of-embeds signal would surface in Discord.

## Design choices

- **Two-outcome counter, not a single counter + error counter** — keeps the success/error ratio computable as a single PromQL expression (`outcome="error" / (outcome="success" + outcome="error")`).
- **Early-return guard does NOT increment either outcome** — no URL or no session is "no attempt made", distinct from "attempt succeeded/failed". A test asserts this explicitly so a future refactor cannot regress the no-op semantics.
- **Lazy import** of `services.metrics` inside `_send` matches the existing pattern used elsewhere in the codebase (e.g. close-driver in PR #271).

## What changed

- **`disbot/services/metrics.py`** — counter definition with rationale and alerting guidance.
- **`disbot/services/webhook_reporter.py`** — `try` / `except` / `else` split inside `_send` to land the increment on the right branch.
- **`tests/unit/services/test_webhook_reporter.py`** — 3 new tests covering:
  - Success → `success` counter +1
  - Send raises → `error` counter +1, exception still swallowed
  - Early-return (no session) → neither counter changes

## Test plan

- [x] `pytest tests/unit/services/test_webhook_reporter.py -v` — 8/8 pass
- [x] `pytest tests/unit/` — 4071 passed, 3 skipped
- [x] `black`, `isort`, `ruff`, `mypy` — all clean
- [ ] Sandbox sanity: `curl /metrics | grep webhook_dispatch_total` after a few normal operations shows `success` climbing. Revoke the webhook URL (simulate 404) and confirm `error` starts climbing on the next embed attempt.

https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea

---
_Generated by [Claude Code](https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea)_