### PR TITLE
feat(diagnostics): !lifecycle / !lc top-level shortcut for !platform lifecycle

### DIFF
--- a/disbot/cogs/diagnostic_cog.py
+++ b/disbot/cogs/diagnostic_cog.py
@@ -69,6 +69,17 @@ class DiagnosticCog(commands.Cog):
         view = _DiagnosticsHubView(ctx.author)
         await send_panel(ctx, embed=view.build_embed(), view=view)
 
+    @commands.command(name="lifecycle", aliases=["lc"])
+    @commands.has_permissions(administrator=True)
+    async def lifecycle_shortcut(self, ctx):
+        """Lifecycle state (phase, pending request, recent events).
+
+        Shortcut for ``!platform lifecycle`` — operators don't need to
+        remember the ``platform`` prefix during an incident.  Mirrors
+        the existing ``!diag`` → ``!diagnostics`` shortcut pattern.
+        """
+        await ctx.send(embed=build_lifecycle_embed())
+
     async def build_help_menu_view(
         self,
         interaction: discord.Interaction,

--- a/tests/unit/runtime/test_platform_diagnostics_commands.py
+++ b/tests/unit/runtime/test_platform_diagnostics_commands.py
@@ -481,3 +481,37 @@ async def test_platform_lifecycle_degrades_gracefully_when_provider_unregistered
 
     embed = ctx.send.call_args.kwargs["embed"]
     assert "not registered" in (embed.description or "")
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_shortcut_command_reuses_build_lifecycle_embed():
+    """``!lifecycle`` (alias ``!lc``) is a top-level shortcut for
+    ``!platform lifecycle``.  Operators don't need to remember the
+    ``platform`` prefix during an incident.  Verifies the command
+    produces the same lifecycle embed as the platform subcommand."""
+    cog = _make_cog()
+    ctx = _make_ctx()
+
+    snap = {
+        "phase": "RUNNING",
+        "can_accept_commands": True,
+        "pending": None,
+        "remaining_shutdown_seconds": None,
+        "recent_events": [],
+    }
+    with patch("services.diagnostics_service.snapshot", return_value=snap):
+        await cog.lifecycle_shortcut.callback(cog, ctx)
+
+    ctx.send.assert_awaited_once()
+    embed = ctx.send.call_args.kwargs["embed"]
+    assert "RUNNING" in (embed.description or "")
+
+
+def test_lifecycle_shortcut_exposes_lc_alias():
+    """The ``lc`` alias is the expected operator shorthand — assert it
+    explicitly so a future refactor cannot drop it without notice."""
+    from cogs.diagnostic_cog import DiagnosticCog
+
+    cmd = DiagnosticCog.lifecycle_shortcut
+    assert "lc" in cmd.aliases
+    assert cmd.name == "lifecycle"


### PR DESCRIPTION
## Summary

Operators in an incident don't want to remember the `platform` prefix. This adds `!lifecycle` (alias `!lc`) as a top-level command that produces the same embed as `!platform lifecycle`.

Mirrors the existing `!diag` → `!diagnostics` shortcut pattern, and reuses `build_lifecycle_embed()` from PR #270 so the embed contents stay consistent across both invocation paths.

## Design choices

- **`lc` alias** — the typical "quick check during an incident" form factor. Asserted explicitly in tests so a future refactor cannot silently drop it.
- **Admin-gated** — same as the platform subcommand. Lifecycle state isn't sensitive, but the audience for the embed is operators only.
- **No new builder** — reuses `build_lifecycle_embed()` so the embed format stays single-sourced. The platform subcommand and the shortcut produce byte-identical embeds.

## What changed

- **`disbot/cogs/diagnostic_cog.py`** — `lifecycle_shortcut` command after `diagnostics_hub`.
- **`tests/unit/runtime/test_platform_diagnostics_commands.py`** — 2 new tests:
  - The command produces the same lifecycle embed as `!platform lifecycle`
  - The `lc` alias is asserted explicitly

## Test plan

- [x] `pytest tests/unit/runtime/test_platform_diagnostics_commands.py -v -k lifecycle` — 6/6 pass (4 existing + 2 new)
- [x] `pytest tests/unit/` — 4070 passed, 3 skipped
- [x] `black`, `isort`, `ruff`, `mypy disbot/cogs/diagnostic_cog.py` — all clean
- [ ] Sandbox sanity: type `!lc` in a channel and confirm the same embed appears as `!platform lifecycle`.

https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea

---
_Generated by [Claude Code](https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea)_