### PR TITLE
feat(healthserver): /lifecycle endpoint for HTTP-side diagnostic dump

### DIFF
--- a/disbot/healthserver.py
+++ b/disbot/healthserver.py
@@ -1,14 +1,19 @@
 """Minimal HTTP health server for container orchestration probes.
 
-Exposes two endpoints on 0.0.0.0:8080 (configurable via HEALTH_PORT env var):
+Exposes these endpoints on 0.0.0.0:8080 (configurable via HEALTH_PORT env var):
 
-  GET /health  — liveness probe; returns 200 while the event loop is running
-  GET /ready   — readiness probe; returns 200 only when the bot is logged in
-                 to Discord AND the lifecycle service is admitting commands.
-                 Returns 503 during STARTING (gateway not connected yet) or
-                 any draining/terminal phase (DRAINING, SHUTTING_DOWN,
-                 RESTARTING, STOPPED) so the orchestrator routes traffic
-                 away during graceful shutdown / restart.
+  GET /health     — liveness probe; returns 200 while the event loop is running
+  GET /ready      — readiness probe; returns 200 only when the bot is logged in
+                    to Discord AND the lifecycle service is admitting commands.
+                    Returns 503 during STARTING (gateway not connected yet) or
+                    any draining/terminal phase (DRAINING, SHUTTING_DOWN,
+                    RESTARTING, STOPPED) so the orchestrator routes traffic
+                    away during graceful shutdown / restart.
+  GET /lifecycle  — diagnostic dump of the full lifecycle snapshot (phase,
+                    pending request, recent events).  Always returns 200 with
+                    the snapshot JSON.  Operators ``curl`` this during an
+                    incident when the bot is unresponsive in Discord but the
+                    HTTP server is still serving.
 
 The server runs as a background asyncio task alongside the bot, sharing the
 same event loop. It adds no threads and has negligible overhead.
@@ -127,6 +132,26 @@ async def _ready_handler(request: web.Request) -> web.Response:
     )
 
 
+async def _lifecycle_handler(request: web.Request) -> web.Response:
+    """Diagnostic dump of the full lifecycle snapshot as JSON.
+
+    Always returns 200 — this is a diagnostic endpoint, not a probe.
+    The same data is available via ``!platform lifecycle`` and the
+    ``!lc`` shortcut, but those require the bot to be responsive in
+    Discord.  This endpoint works as long as the aiohttp server is
+    serving, so operators can ``curl`` the bot during an incident
+    where the Discord gateway is wedged but the HTTP listener is up.
+
+    The payload is the same shape returned by
+    :func:`core.runtime.lifecycle.diagnostics_snapshot`, suitable
+    for piping into ``jq`` for ad-hoc queries.
+    """
+    return web.Response(
+        text=json.dumps(lifecycle.diagnostics_snapshot()),
+        content_type="application/json",
+    )
+
+
 async def _metrics_handler(request: web.Request) -> web.Response:
     """Prometheus metrics exposition endpoint."""
     return web.Response(body=generate_latest(), content_type=CONTENT_TYPE_LATEST)
@@ -156,6 +181,7 @@ async def start_health_server(
     app["bot"] = bot
     app.router.add_get("/health", _health_handler)
     app.router.add_get("/ready", _ready_handler)
+    app.router.add_get("/lifecycle", _lifecycle_handler)
     app.router.add_get("/metrics", _metrics_handler)
 
     runner = web.AppRunner(app, access_log=None)

--- a/tests/unit/runtime/test_healthserver.py
+++ b/tests/unit/runtime/test_healthserver.py
@@ -307,3 +307,100 @@ async def test_ready_returns_503_in_every_terminal_phase(
     assert body["accepting_commands"] is False
     assert body["phase"] == phase
     assert body["reason"] == f"lifecycle_{phase}"
+
+
+# ---------------------------------------------------------------------------
+# /lifecycle — diagnostic dump of full lifecycle snapshot
+#
+# Always 200 (not a probe, just a diagnostic).  Operators curl this
+# during incidents when Discord is wedged but HTTP is still serving.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_endpoint_returns_full_snapshot_as_json(_reset_lifecycle):
+    """The endpoint returns 200 with the same payload shape as
+    ``diagnostics_snapshot()`` — phase, pending, recent_events, etc."""
+    import json as _json
+
+    from core.runtime import lifecycle
+    from healthserver import _lifecycle_handler
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown("sigterm", actor="signal_handler")
+
+    request = MagicMock()
+    response = await _lifecycle_handler(request)
+
+    assert response.status == 200
+    body = _json.loads(response.text)
+    assert body["phase"] == "DRAINING"
+    assert body["pending"]["kind"] == "shutdown"
+    assert body["pending"]["actor"] == "signal_handler"
+    # Recent events should include the shutdown_requested and DRAINING
+    # transition.
+    event_names = [e["name"] for e in body["recent_events"]]
+    assert "shutdown_requested" in event_names
+    assert "phase:DRAINING" in event_names
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_endpoint_returns_200_even_in_terminal_phase(_reset_lifecycle):
+    """Unlike /ready (which returns 503 in terminal phases), /lifecycle
+    is always 200 — operators need to query it precisely WHEN the bot
+    is in a terminal phase, to understand why."""
+    import json as _json
+
+    from core.runtime import lifecycle
+    from healthserver import _lifecycle_handler
+
+    lifecycle.set_phase(lifecycle.Phase.STOPPED)
+
+    request = MagicMock()
+    response = await _lifecycle_handler(request)
+
+    assert response.status == 200
+    body = _json.loads(response.text)
+    assert body["phase"] == "STOPPED"
+    assert body["can_accept_commands"] is False
+    assert body["is_shutting_down"] is True
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_endpoint_is_registered_on_the_router():
+    """Belt-and-suspenders: assert the route is actually registered so a
+    future refactor doesn't quietly drop the endpoint."""
+    import asyncio
+
+    from healthserver import start_health_server
+
+    runner = MagicMock()
+    runner.setup = AsyncMock()
+    runner.cleanup = AsyncMock()
+    site = MagicMock()
+    site.start = AsyncMock()
+    app_captured: list = []
+
+    real_app_runner_cls = None
+
+    def _capture_app(app, *args, **kwargs):
+        app_captured.append(app)
+        return runner
+
+    with (
+        patch("healthserver.web.AppRunner", side_effect=_capture_app),
+        patch("healthserver.web.TCPSite", return_value=site),
+    ):
+        ready = asyncio.Event()
+        task = asyncio.create_task(
+            start_health_server(_make_bot(), ready_event=ready),
+        )
+        await asyncio.wait_for(ready.wait(), timeout=1.0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert app_captured, "AppRunner was not constructed"
+    app = app_captured[0]
+    paths = {route.resource.canonical for route in app.router.routes()}
+    assert "/lifecycle" in paths


### PR DESCRIPTION
## Summary

Operators can inspect lifecycle state via `!platform lifecycle` (PR #270) or `!lc` (PR #279) in Discord — but those require the bot to be responsive in Discord. If the Discord gateway is wedged, the channel is misconfigured, or operators are paged via PagerDuty/email without Discord access, there was no way to inspect lifecycle state without trawling process logs.

This adds `GET /lifecycle` to the health server. Returns the full `diagnostics_snapshot()` payload as JSON, always with status **200** — diagnostic endpoint, not a probe.

```bash
curl -s :8080/lifecycle | jq .phase
curl -s :8080/lifecycle | jq '.recent_events[-5:]'
curl -s :8080/lifecycle | jq '.pending'
```

## Why always-200

`/ready` returns 503 in terminal phases because it's a load-balancer probe — its job is to route traffic away. `/lifecycle` returns 200 in every phase because its job is to **explain** the state, including the terminal ones. Operators query `/lifecycle` precisely WHEN the bot is in `DRAINING`/`STOPPED`/etc, to understand why.

## Same payload shape across surfaces

The HTTP endpoint, the `!platform lifecycle` embed, and the `!lc` shortcut all source from `lifecycle.diagnostics_snapshot()`, so operators can build runbook scripts that work whether the bot is reachable in Discord or only via HTTP.

## What changed

- **`disbot/healthserver.py`** — `_lifecycle_handler` returning the snapshot as JSON, route registration, updated module docstring.
- **`tests/unit/runtime/test_healthserver.py`** — 3 new tests:
  - Endpoint returns 200 with snapshot fields populated correctly (RUNNING + pending shutdown)
  - Endpoint returns 200 even in terminal STOPPED phase (unlike `/ready` which would 503) — diagnostic vs probe semantics
  - Route is actually registered on the aiohttp router so a future refactor cannot quietly drop it

## Test plan

- [x] `pytest tests/unit/runtime/test_healthserver.py -v -k lifecycle_endpoint` — 3/3 new tests pass
- [x] `pytest tests/unit/` — 4071 passed, 3 skipped
- [x] `black`, `isort`, `ruff`, `mypy disbot/healthserver.py` — all clean
- [ ] Sandbox sanity: `curl localhost:8080/lifecycle` returns the snapshot; send SIGTERM and `curl` again to confirm the phase moved to DRAINING with a pending shutdown.

https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea

---
_Generated by [Claude Code](https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea)_