### PR TITLE
feat(metrics): lifecycle_event_total counter for ring-buffer event rates

### DIFF
--- a/disbot/core/runtime/lifecycle.py
+++ b/disbot/core/runtime/lifecycle.py
@@ -277,6 +277,16 @@ def _record_event(
     actor: str | None = None,
     metadata: dict[str, Any] | None = None,
 ) -> None:
+    # Mirror the ring-buffer append into Prometheus so operators can
+    # graph event rates by name.  Wrapped in try/except so a missing
+    # or partially-initialized metrics module never blocks event
+    # recording (observability, not control plane).
+    try:
+        from services import metrics as _metrics
+
+        _metrics.lifecycle_event_total.labels(event=name).inc()
+    except Exception:  # noqa: BLE001 — metrics are observability only
+        pass
     _events.append(
         LifecycleEvent(
             name=name,

--- a/disbot/services/metrics.py
+++ b/disbot/services/metrics.py
@@ -209,6 +209,23 @@ webhook_dispatch_total = Counter(
     ["outcome"],  # success | error
 )
 
+# Lifecycle ring-buffer events as a Prometheus counter, broken out by
+# event name.  The event names are a bounded set (~10): phase:<NAME>
+# for each Phase value, shutdown_requested[_coalesced],
+# restart_requested[_coalesced], and close_executing.  Most valuable
+# series:
+#   - lifecycle_event_total{event="shutdown_requested_coalesced"} —
+#     multiple SIGTERMs in quick succession (probably a healthcheck
+#     spam or an orchestrator misconfiguration).
+#   - lifecycle_event_total{event="restart_requested"} — operator-
+#     triggered restart rate; non-zero unexpected rate = operator
+#     thrashing or an automated restart loop.
+lifecycle_event_total = Counter(
+    "lifecycle_event_total",
+    "Lifecycle events recorded in the ring buffer, by event name.",
+    ["event"],
+)
+
 # ---------------------------------------------------------------------------
 # F-1 guild_config cache (core/runtime/guild_config.py) — Phase S1.1
 # ---------------------------------------------------------------------------

--- a/tests/unit/runtime/test_lifecycle.py
+++ b/tests/unit/runtime/test_lifecycle.py
@@ -310,3 +310,44 @@ def test_lifecycle_phase_gauge_terminal_state_reflects_stopped() -> None:
     # SHUTTING_DOWN, must be 0.
     nonzero = {phase for phase, value in values.items() if value > 0}
     assert nonzero == {"STOPPED"}
+
+
+def _lifecycle_event_counter(event: str) -> float:
+    """Return the current value of ``lifecycle_event_total{event=...}``."""
+    from services import metrics as _metrics
+
+    return _metrics.lifecycle_event_total.labels(event=event)._value.get()
+
+
+def test_lifecycle_event_counter_increments_on_phase_transition() -> None:
+    """Every ``set_phase`` to a new phase records a ring-buffer event
+    AND increments the Prometheus counter for that event name."""
+    before = _lifecycle_event_counter("phase:RUNNING")
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    assert _lifecycle_event_counter("phase:RUNNING") == before + 1
+
+
+def test_lifecycle_event_counter_increments_on_shutdown_request() -> None:
+    """``request_shutdown`` increments shutdown_requested AND the phase
+    transition counter for DRAINING."""
+    before_req = _lifecycle_event_counter("shutdown_requested")
+    before_drain = _lifecycle_event_counter("phase:DRAINING")
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown("sigterm")
+    assert _lifecycle_event_counter("shutdown_requested") == before_req + 1
+    assert _lifecycle_event_counter("phase:DRAINING") == before_drain + 1
+
+
+def test_lifecycle_event_counter_increments_on_coalesced_shutdown() -> None:
+    """The MOST valuable series: multiple SIGTERMs in quick succession
+    surface as shutdown_requested_coalesced.  Operators alerting on
+    rate(lifecycle_event_total{event="shutdown_requested_coalesced"}[5m])
+    catch SIGTERM-storm misconfigurations (e.g. an orchestrator sending
+    SIGTERM faster than the bot drains)."""
+    before = _lifecycle_event_counter("shutdown_requested_coalesced")
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown("first")
+    # Second and third requests coalesce.
+    lifecycle.request_shutdown("second")
+    lifecycle.request_shutdown("third")
+    assert _lifecycle_event_counter("shutdown_requested_coalesced") == before + 2


### PR DESCRIPTION
## Summary

The lifecycle ring buffer records every event (phase transitions, `request_shutdown`, `request_restart`, coalesced requests, `close_executing`) but those event **rates** were not visible in Prometheus. Operators had to inspect the in-memory ring buffer (via `!platform lifecycle` or `curl /lifecycle`) to see counts, and even then only the most recent 128 events were visible.

```
lifecycle_event_total{event="phase:STARTING"}
lifecycle_event_total{event="phase:RUNNING"}
lifecycle_event_total{event="phase:DRAINING"}
lifecycle_event_total{event="phase:SHUTTING_DOWN"}
lifecycle_event_total{event="phase:RESTARTING"}
lifecycle_event_total{event="phase:STOPPED"}
lifecycle_event_total{event="phase:FAILED_STARTUP"}
lifecycle_event_total{event="shutdown_requested"}
lifecycle_event_total{event="shutdown_requested_coalesced"}
lifecycle_event_total{event="restart_requested"}
lifecycle_event_total{event="restart_requested_coalesced"}
lifecycle_event_total{event="close_executing"}
```

## Most valuable series

- **`shutdown_requested_coalesced`** — multiple SIGTERMs in quick succession. Alert on `rate > 0` catches SIGTERM-storm misconfigurations (e.g. an orchestrator sending SIGTERM faster than the bot drains).
- **`restart_requested`** — operator-triggered restart rate. An automated restart loop or operator thrashing shows up as a sustained non-zero rate.
- **`phase:FAILED_STARTUP`** — non-zero rate = startup failures, currently invisible to Prometheus.

## Why not just use the existing close-driver/phase metrics?

- `lifecycle_phase` gauge captures the **current** phase, not transition rates.
- `lifecycle_close_driver_total` only counts close executions, not requests (and certainly not coalesced ones).
- `lifecycle_event_total{event="phase:X"}` rates show how often each phase was entered, which the gauge cannot.

## Cardinality

Bounded set of ~10-12 event names (7 phases + 5 request/coalesce/close events). Safe for high-frequency dashboards.

## What changed

- **`disbot/services/metrics.py`** — counter definition with rationale and alerting guidance.
- **`disbot/core/runtime/lifecycle.py`** — increment inside `_record_event` so every ring-buffer append also increments the counter. Wrapped in try/except so metrics never block event recording.
- **`tests/unit/runtime/test_lifecycle.py`** — 3 new tests:
  - Phase transition increments `phase:<NAME>` counter
  - `request_shutdown` increments both `shutdown_requested` and `phase:DRAINING`
  - **Coalesced shutdown** test — the most valuable series — asserts the counter rises by exactly 2 for 2 coalesced requests (the original first request lands as `shutdown_requested`, not coalesced)

## Test plan

- [x] `pytest tests/unit/runtime/test_lifecycle.py -v` — 28/28 pass (25 existing + 3 new)
- [x] `pytest tests/unit/` — 4071 passed, 3 skipped
- [x] `black`, `isort`, `ruff`, `mypy` — all clean
- [ ] Sandbox sanity: `curl /metrics | grep lifecycle_event_total` shows the expected series climbing as the bot transitions through phases.

https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea

---
_Generated by [Claude Code](https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea)_