### PR TITLE
feat(metrics): webhook_dispatch_seconds histogram for send latency

### DIFF
--- a/disbot/services/metrics.py
+++ b/disbot/services/metrics.py
@@ -262,6 +262,18 @@ lifecycle_event_total = Counter(
     ["event"],
 )
 
+# Duration of each WebhookReporter._send dispatch.  Observed on every
+# attempt (success AND error) so DB-style latency drift is visible
+# even when most posts succeed.  Buckets stop at 10s — Discord's
+# webhook API typically responds well under 1s; anything past 2s
+# indicates either a slow Discord region or a stalled connection
+# pool worth investigating.
+webhook_dispatch_seconds = Histogram(
+    "webhook_dispatch_seconds",
+    "Duration of WebhookReporter._send dispatches (success or caught exception).",
+    buckets=(0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0),
+)
+
 # ---------------------------------------------------------------------------
 # F-1 guild_config cache (core/runtime/guild_config.py) — Phase S1.1
 # ---------------------------------------------------------------------------

--- a/disbot/services/webhook_reporter.py
+++ b/disbot/services/webhook_reporter.py
@@ -88,15 +88,24 @@ class WebhookReporter:
         counts = _redact_embed(embed)
         if counts:
             logger.debug("Webhook embed redacted: %s", counts)
+        import time as _time
+
         from services import metrics as _metrics
 
+        dispatch_started_at = _time.monotonic()
         try:
             wh = discord.Webhook.from_url(self.url, session=self._session)
             await wh.send(embed=embed, username=username)
         except Exception as exc:
+            _metrics.webhook_dispatch_seconds.observe(
+                _time.monotonic() - dispatch_started_at,
+            )
             _metrics.webhook_dispatch_total.labels(outcome="error").inc()
             logger.debug("Webhook send failed: %s", exc)
         else:
+            _metrics.webhook_dispatch_seconds.observe(
+                _time.monotonic() - dispatch_started_at,
+            )
             _metrics.webhook_dispatch_total.labels(outcome="success").inc()
 
     async def on_startup(self, bot) -> None:

--- a/tests/unit/services/test_webhook_reporter.py
+++ b/tests/unit/services/test_webhook_reporter.py
@@ -153,6 +153,62 @@ async def test_send_records_error_outcome_when_send_raises() -> None:
     assert _webhook_dispatch_counter("error") == before + 1
 
 
+def _dispatch_seconds_count_and_sum() -> tuple[float, float]:
+    """Return (count, sum) for webhook_dispatch_seconds."""
+    from services import metrics as _metrics
+
+    samples = next(iter(_metrics.webhook_dispatch_seconds.collect())).samples
+    count = next(s.value for s in samples if s.name.endswith("_count"))
+    total = next(s.value for s in samples if s.name.endswith("_sum"))
+    return count, total
+
+
+@pytest.mark.asyncio
+async def test_send_observes_dispatch_duration_on_success() -> None:
+    """Healthy posts observe their duration in the histogram so
+    operators can graph p50/p95 dispatch latency."""
+    reporter = WebhookReporter("https://discord.com/api/webhooks/123/abc")
+    reporter._session = MagicMock()
+
+    before_count, before_sum = _dispatch_seconds_count_and_sum()
+
+    wh_mock = MagicMock()
+    wh_mock.send = AsyncMock()
+    with patch(
+        "services.webhook_reporter.discord.Webhook.from_url",
+        return_value=wh_mock,
+    ):
+        await reporter._send(discord.Embed(title="ok"))
+
+    after_count, after_sum = _dispatch_seconds_count_and_sum()
+    assert after_count == before_count + 1
+    # AsyncMock returns instantly so the observation is near-zero but
+    # non-negative.
+    assert (after_sum - before_sum) >= 0
+
+
+@pytest.mark.asyncio
+async def test_send_observes_dispatch_duration_on_error_too() -> None:
+    """Exception path STILL observes — the time spent in a failing
+    send is itself a useful signal (a slow connection-pool timeout
+    looks different from an instant network error)."""
+    reporter = WebhookReporter("https://discord.com/api/webhooks/123/abc")
+    reporter._session = MagicMock()
+
+    before_count, _ = _dispatch_seconds_count_and_sum()
+
+    wh_mock = MagicMock()
+    wh_mock.send = AsyncMock(side_effect=RuntimeError("network down"))
+    with patch(
+        "services.webhook_reporter.discord.Webhook.from_url",
+        return_value=wh_mock,
+    ):
+        await reporter._send(discord.Embed(title="ok"))
+
+    after_count, _ = _dispatch_seconds_count_and_sum()
+    assert after_count == before_count + 1
+
+
 @pytest.mark.asyncio
 async def test_send_no_dispatch_outcome_when_session_missing() -> None:
     """The early-return guard (no URL or no session) must NOT increment


### PR DESCRIPTION
## Summary

PR #278 added a success/error counter for webhook dispatches; this histogram tracks **how long** each one took. Together they let operators distinguish "Discord is unreachable" (counter spikes on error) from "Discord is slow" (latency drifts towards higher buckets even while counter stays on success).

```
webhook_dispatch_seconds   histogram, observed per attempt
```

Buckets `(0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0)`. Discord's webhook API typically responds well under 1 s; anything past 2 s indicates either a slow Discord region or a stalled connection pool worth investigating.

## Stacked on PR #278

Base is `claude/webhook-reporter-metric` (PR #278). Both PRs touch `_send`; stacking keeps the diff minimal.

## Observed on success AND error

Skipping exception-path samples would bias the distribution towards the happy path only, hiding cases where a slow connection-pool timeout is the real problem. The exception branch observes the duration **before** incrementing the error counter, so both metrics agree on the same attempt.

## Most useful alert

`histogram_quantile(0.95, rate(webhook_dispatch_seconds_bucket[5m])) > 1.0` — p95 webhook latency over 1 s. Catches Discord-side degradation before it surfaces as outright errors.

## What changed

- **`disbot/services/metrics.py`** — histogram definition with rationale.
- **`disbot/services/webhook_reporter.py`** — capture `dispatch_started_at` per call, observe duration on both success and exception branches.
- **`tests/unit/services/test_webhook_reporter.py`** — 2 new tests covering the success-path observation and the exception-path observation.

## Test plan

- [x] `pytest tests/unit/services/test_webhook_reporter.py -v -k dispatch` — 5/5 pass
- [x] `pytest tests/unit/` — 4073 passed, 3 skipped
- [x] `black`, `isort`, `ruff`, `mypy` — all clean
- [ ] Sandbox sanity: `curl /metrics | grep webhook_dispatch_seconds_bucket` shows observations climbing under the small buckets during normal operation.

https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea

---
_Generated by [Claude Code](https://claude.ai/code/session_01JivN94gxQUJW61BB5beKea)_