### PR TITLE
Lifecycle observability: close-outcome recording & timeout webhook

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -647,15 +647,40 @@ async def _drive_close_on_lifecycle_request() -> None:
             _metrics.lifecycle_close_duration_seconds.labels(
                 kind=kind_label,
             ).observe(LIFECYCLE_CLOSE_TIMEOUT_SECONDS)
+            if pending is not None:
+                _lifecycle.record_close_timeout(
+                    pending,
+                    timeout_seconds=LIFECYCLE_CLOSE_TIMEOUT_SECONDS,
+                )
+            if reporter is not None and pending is not None:
+                try:
+                    await asyncio.wait_for(
+                        reporter.on_lifecycle_close_timeout(
+                            pending,
+                            timeout_seconds=LIFECYCLE_CLOSE_TIMEOUT_SECONDS,
+                        ),
+                        timeout=1.0,
+                    )
+                except Exception as report_err:
+                    logger.debug(
+                        "Lifecycle close-timeout webhook skipped: %s",
+                        report_err,
+                    )
             logger.critical(
                 "bot.close() exceeded %.1fs timeout — force-exiting "
                 "so the orchestration platform respawns.",
                 LIFECYCLE_CLOSE_TIMEOUT_SECONDS,
             )
             os._exit(1)
+        close_duration = time.monotonic() - close_started_at
         _metrics.lifecycle_close_duration_seconds.labels(
             kind=kind_label,
-        ).observe(time.monotonic() - close_started_at)
+        ).observe(close_duration)
+        if pending is not None:
+            _lifecycle.record_close_completed(
+                pending,
+                duration_seconds=close_duration,
+            )
         return
 
 

--- a/disbot/cogs/diagnostic/_platform_embeds.py
+++ b/disbot/cogs/diagnostic/_platform_embeds.py
@@ -545,6 +545,35 @@ _LIFECYCLE_PHASE_COLORS: dict[str, discord.Color] = {
 }
 
 
+def _fmt_lifecycle_event_metadata(event: dict[str, object]) -> str:
+    """Render the close_executing / close_completed / close_timeout
+    metadata payload as a compact ``[k=v k=v]`` suffix, or "" for
+    events without renderable metadata.
+
+    Kept here (not in :mod:`core.runtime.lifecycle`) because the
+    formatting is presentation, not state.  Discord's per-field 1024
+    char limit means we cannot afford full JSON dumps; this picks the
+    keys operators actually care about during an incident.
+    """
+    name = str(event.get("name", ""))
+    metadata = event.get("metadata") or {}
+    if not isinstance(metadata, dict) or not metadata:
+        return ""
+    parts: list[str] = []
+    kind = metadata.get("kind")
+    if kind and name in {"close_executing", "close_completed", "close_timeout"}:
+        parts.append(f"kind={kind}")
+    if name == "close_completed":
+        duration = metadata.get("duration_seconds")
+        if isinstance(duration, (int, float)):
+            parts.append(f"dur={float(duration):.2f}s")
+    if name == "close_timeout":
+        timeout = metadata.get("timeout_seconds")
+        if isinstance(timeout, (int, float)):
+            parts.append(f"timeout={float(timeout):.2f}s")
+    return f" [{' '.join(parts)}]" if parts else ""
+
+
 def build_lifecycle_embed() -> discord.Embed:
     """Build the embed for ``!platform lifecycle``.
 
@@ -552,9 +581,11 @@ def build_lifecycle_embed() -> discord.Embed:
     pending shutdown/restart request if any (with grace remaining),
     and the most recent events from the ring buffer, newest first.
     The events include ``shutdown_requested`` / ``restart_requested``
-    (intent), ``close_executing`` (close-driver invocation), and the
-    ``phase:<NAME>`` transitions, so operators get a one-screen view
-    of what the lifecycle has done lately.
+    (intent), ``close_executing`` / ``close_completed`` /
+    ``close_timeout`` (close-driver outcomes), and the ``phase:<NAME>``
+    transitions, so operators get a one-screen view of what the
+    lifecycle has done lately.  Metadata on the close outcomes (kind,
+    close duration, timeout value) is rendered compactly inline.
 
     Falls back to a degraded embed if the ``lifecycle`` provider is
     not registered, matching the ``build_caches_embed`` pattern.
@@ -572,9 +603,17 @@ def build_lifecycle_embed() -> discord.Embed:
 
     phase = str(snap.get("phase", "unknown"))
     can_accept = bool(snap.get("can_accept_commands", False))
+    description_parts = [
+        f"Phase: **{phase}** · Accepting commands: **{can_accept}**",
+    ]
+    startup_observed = snap.get("startup_duration_observed")
+    if isinstance(startup_observed, bool):
+        description_parts.append(
+            f"Startup observed: **{'yes' if startup_observed else 'no'}**",
+        )
     embed = discord.Embed(
         title="🔄 Lifecycle",
-        description=(f"Phase: **{phase}** · Accepting commands: **{can_accept}**"),
+        description=" · ".join(description_parts),
         color=_LIFECYCLE_PHASE_COLORS.get(phase, discord.Color.greyple()),
     )
 
@@ -606,9 +645,10 @@ def build_lifecycle_embed() -> discord.Embed:
         for event in reversed(events[-10:]):
             actor_part = f" by `{event['actor']}`" if event.get("actor") else ""
             reason_part = f" — {event['reason']}" if event.get("reason") else ""
+            meta_part = _fmt_lifecycle_event_metadata(event)
             lines.append(
                 f"• `{event.get('name', '?')}` @ "
-                f"{event.get('phase', '?')}{actor_part}{reason_part}",
+                f"{event.get('phase', '?')}{actor_part}{reason_part}{meta_part}",
             )
         embed.add_field(
             name=f"Recent events ({len(events)})",

--- a/disbot/core/runtime/lifecycle.py
+++ b/disbot/core/runtime/lifecycle.py
@@ -93,6 +93,14 @@ _phase: Phase = Phase.STARTING
 _pending: PendingShutdown | None = None
 _events: deque[LifecycleEvent] = deque(maxlen=_EVENT_BUFFER_SIZE)
 
+# Wall-clock anchor for the lifecycle_startup_seconds histogram: stamped
+# at module import (before any phase transition) and observed exactly
+# once when the bot first reaches RUNNING.  A second on_ready (e.g. a
+# Discord gateway reconnect) must not re-observe; the flag below guards
+# the one-shot behaviour.  ``reset_for_tests`` re-stamps both.
+_module_loaded_at: float = time.monotonic()
+_startup_duration_observed: bool = False
+
 
 def get_phase() -> Phase:
     """Return the current lifecycle phase."""
@@ -130,6 +138,30 @@ def set_phase(phase: Phase, *, reason: str | None = None) -> None:
     _phase = phase
     _record_event(f"phase:{phase.value}", reason=reason)
     _publish_phase_gauge(phase)
+    if phase is Phase.RUNNING:
+        _maybe_observe_startup_duration()
+
+
+def _maybe_observe_startup_duration() -> None:
+    """Observe ``lifecycle_startup_seconds`` exactly once per process.
+
+    Called from :func:`set_phase` on every transition to ``RUNNING``;
+    the module-level flag enforces the one-shot semantic so a Discord
+    gateway reconnect (which re-fires ``on_ready``) cannot double-count.
+    Wrapped in try/except — observability never blocks a transition.
+    """
+    global _startup_duration_observed
+    if _startup_duration_observed:
+        return
+    _startup_duration_observed = True
+    try:
+        from services import metrics as _metrics
+
+        _metrics.lifecycle_startup_seconds.observe(
+            time.monotonic() - _module_loaded_at,
+        )
+    except Exception:  # noqa: BLE001 — metrics are observability only
+        pass
 
 
 def is_shutting_down() -> bool:
@@ -243,6 +275,55 @@ def record_close_executing(pending: PendingShutdown) -> None:
     )
 
 
+def record_close_completed(
+    pending: PendingShutdown,
+    *,
+    duration_seconds: float,
+) -> None:
+    """Record that ``bot.close()`` returned successfully.
+
+    Companion to :func:`record_close_executing`: if ``close_executing``
+    is present but ``close_completed`` is not, the close-driver started
+    teardown but did not return within the timeout window (the timeout
+    branch records :func:`record_close_timeout` instead).  Operators
+    reading the ring buffer can confirm a clean handoff to the finalizer
+    without inspecting Prometheus.
+    """
+    _record_event(
+        "close_completed",
+        reason=pending.reason,
+        actor=pending.actor,
+        metadata={
+            "kind": pending.kind,
+            "duration_seconds": float(duration_seconds),
+        },
+    )
+
+
+def record_close_timeout(
+    pending: PendingShutdown,
+    *,
+    timeout_seconds: float,
+) -> None:
+    """Record that ``bot.close()`` exceeded the close-driver timeout.
+
+    Emitted in the wedged-close branch immediately before the driver
+    posts the timeout webhook and force-exits via ``os._exit(1)``.  The
+    timeout value is preserved in metadata so post-mortem operators can
+    distinguish "we used the default 20s budget" from "the timeout was
+    tuned" without crossing back to the close-driver constant.
+    """
+    _record_event(
+        "close_timeout",
+        reason=pending.reason,
+        actor=pending.actor,
+        metadata={
+            "kind": pending.kind,
+            "timeout_seconds": float(timeout_seconds),
+        },
+    )
+
+
 def get_pending() -> PendingShutdown | None:
     """Return the current pending request, or ``None`` if none."""
     return _pending
@@ -304,10 +385,12 @@ def reset_for_tests() -> None:
 
     Test-only entry point — production code must not call this.
     """
-    global _phase, _pending
+    global _phase, _pending, _module_loaded_at, _startup_duration_observed
     _phase = Phase.STARTING
     _pending = None
     _events.clear()
+    _module_loaded_at = time.monotonic()
+    _startup_duration_observed = False
     _publish_phase_gauge(_phase)
 
 
@@ -327,6 +410,8 @@ def diagnostics_snapshot() -> dict[str, Any]:
         "can_accept_commands": can_accept_commands(),
         "restart_requested": restart_requested(),
         "remaining_shutdown_seconds": remaining_shutdown_seconds(),
+        "startup_duration_observed": _startup_duration_observed,
+        "module_load_age_seconds": time.monotonic() - _module_loaded_at,
         "pending": (
             {
                 "kind": pending.kind,
@@ -345,6 +430,7 @@ def diagnostics_snapshot() -> dict[str, Any]:
                 "at_monotonic": event.at,
                 "actor": event.actor,
                 "reason": event.reason,
+                "metadata": dict(event.metadata),
             }
             for event in events
         ],
@@ -379,7 +465,9 @@ __all__ = [
     "get_phase",
     "get_recent_events",
     "is_shutting_down",
+    "record_close_completed",
     "record_close_executing",
+    "record_close_timeout",
     "remaining_shutdown_seconds",
     "request_restart",
     "request_shutdown",

--- a/disbot/services/metrics.py
+++ b/disbot/services/metrics.py
@@ -179,6 +179,22 @@ lifecycle_close_duration_seconds = Histogram(
     buckets=(0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 15.0, 20.0),
 )
 
+# Wall-clock seconds between Python interpreter handing control to
+# ``core.runtime.lifecycle`` (module import) and the first
+# STARTING → RUNNING transition (``on_ready`` returning success).
+# Observed exactly once per process: a second on_ready (e.g. after a
+# Discord gateway reconnect) does NOT re-observe, so the histogram
+# represents cold-boot health, not connection churn.  Buckets span
+# sub-second (cached cog graph, no DB migrations) to 60 s (cold pool +
+# many migrations + slow gateway handshake); anything past 30 s is a
+# leading indicator the next deploy may breach the orchestrator's boot
+# deadline.
+lifecycle_startup_seconds = Histogram(
+    "lifecycle_startup_seconds",
+    "Time from process import to first STARTING → RUNNING transition.",
+    buckets=(0.5, 1.0, 2.5, 5.0, 10.0, 20.0, 30.0, 60.0),
+)
+
 # Duration of each ``runtime_lock.heartbeat`` UPDATE call.  Observed on
 # every attempt — success and exception alike — so operators can graph
 # DB latency trends without being blinded by exception-path samples

--- a/disbot/services/webhook_reporter.py
+++ b/disbot/services/webhook_reporter.py
@@ -370,6 +370,45 @@ class WebhookReporter:
             )
         await self._send(embed, username="Bot Lifecycle")
 
+    async def on_lifecycle_close_timeout(
+        self,
+        pending: PendingShutdown,
+        *,
+        timeout_seconds: float,
+    ) -> None:
+        """Posted by the close-driver when ``bot.close()`` exceeds the
+        configured timeout, immediately before ``os._exit(1)``.
+
+        Operators see this embed instead of the paired "complete" embed
+        so a wedged close is unambiguous in the operator channel: the
+        bot did not unwind cleanly and the orchestrator is being asked
+        to respawn the container.  The caller wraps this in
+        ``asyncio.wait_for`` with a small timeout so a stalled webhook
+        cannot delay the force-exit further than it already is.
+        """
+        embed = discord.Embed(
+            title="🛑 Bot Close Timeout",
+            color=discord.Color.dark_red(),
+            timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
+        )
+        embed.add_field(name="Kind", value=pending.kind, inline=True)
+        embed.add_field(
+            name="Reason",
+            value=pending.reason or "<unknown>",
+            inline=True,
+        )
+        embed.add_field(
+            name="Actor",
+            value=pending.actor or "<unknown>",
+            inline=True,
+        )
+        embed.add_field(
+            name="Timeout",
+            value=f"{timeout_seconds:.2f}s",
+            inline=True,
+        )
+        await self._send(embed, username="Bot Lifecycle")
+
     async def on_app_task_died(self, name: str, error: BaseException) -> None:
         """A supervised application task raised after startup.
 

--- a/tests/unit/invariants/test_lifecycle_observability_contract.py
+++ b/tests/unit/invariants/test_lifecycle_observability_contract.py
@@ -64,9 +64,9 @@ def test_webhook_reporter_exposes_required_lifecycle_method(
         f"point.  Restore it or this invariant will fail CI."
     )
     method = getattr(webhook_reporter.WebhookReporter, method_name)
-    assert inspect.iscoroutinefunction(method), (
-        f"WebhookReporter.{method_name} must be an async method."
-    )
+    assert inspect.iscoroutinefunction(
+        method
+    ), f"WebhookReporter.{method_name} must be an async method."
 
 
 # ---------------------------------------------------------------------------
@@ -192,12 +192,12 @@ def test_close_driver_calls_close_timeout_webhook_before_os_exit() -> None:
     # call in the function body.  Use lineno because both live in the
     # same try/except branch.
     timeout_calls = [
-        c for c in _calls_in(fn)
+        c
+        for c in _calls_in(fn)
         if _call_dotted_name(c).endswith("on_lifecycle_close_timeout")
     ]
     exit_calls = [
-        c for c in _calls_in(fn)
-        if _call_dotted_name(c) in {"os._exit", "_exit"}
+        c for c in _calls_in(fn) if _call_dotted_name(c) in {"os._exit", "_exit"}
     ]
     assert timeout_calls, "expected on_lifecycle_close_timeout call"
     assert exit_calls, "expected os._exit call"
@@ -265,9 +265,9 @@ def test_lifecycle_observes_startup_duration_one_shot() -> None:
     lifecycle.set_phase(lifecycle.Phase.RUNNING, reason="on_ready")
     samples = list(metrics.lifecycle_startup_seconds.collect())[0].samples
     after_first = next(s.value for s in samples if s.name.endswith("_count"))
-    assert after_first == before_count + 1, (
-        "First STARTING → RUNNING must observe lifecycle_startup_seconds"
-    )
+    assert (
+        after_first == before_count + 1
+    ), "First STARTING → RUNNING must observe lifecycle_startup_seconds"
 
     # Simulate a second on_ready: go DRAINING and back to RUNNING; the
     # observation must NOT increment again.
@@ -302,9 +302,7 @@ def test_diagnostics_snapshot_includes_event_metadata_and_startup_state() -> Non
     assert "startup_duration_observed" in snap
     assert snap["startup_duration_observed"] is True
     assert isinstance(snap.get("module_load_age_seconds"), float)
-    completed = next(
-        e for e in snap["recent_events"] if e["name"] == "close_completed"
-    )
+    completed = next(e for e in snap["recent_events"] if e["name"] == "close_completed")
     assert completed["metadata"]["kind"] == "shutdown"
     assert completed["metadata"]["duration_seconds"] == pytest.approx(1.25)
 

--- a/tests/unit/invariants/test_lifecycle_observability_contract.py
+++ b/tests/unit/invariants/test_lifecycle_observability_contract.py
@@ -1,0 +1,335 @@
+"""Merged-main lifecycle-observability contract.
+
+After the close-path PR queue lands, runtime lifecycle observability
+lives in a single canonical wiring: lifecycle state in
+``core.runtime.lifecycle``, execution in ``bot1.py``, embed
+construction in ``services.webhook_reporter``, metrics in
+``services.metrics``.  This invariant pins down that wiring so a
+future contributor cannot quietly:
+
+* re-introduce a parallel restart-only close driver
+  (``restart_close_driver`` / ``_drive_close_on_restart_request`` /
+  ``RESTART_CLOSE_TIMEOUT_SECONDS``),
+* drop one of the lifecycle-webhook entry points the operator channel
+  depends on (beginning / completed / timeout / startup summary),
+* remove a Prometheus metric the dashboards rely on
+  (``lifecycle_*``, ``runtime_lock_*``, ``webhook_*``),
+* move cleanup ownership out of ``main()``'s finalizer into the
+  close-driver (which would couple shutdown vs restart cleanup).
+
+The contract is enforced via AST + attribute inspection so it runs in
+under a second and surfaces a meaningful failure message at CI time.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+import pytest
+
+import bot1
+from core.runtime import lifecycle
+from services import metrics, webhook_reporter
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DISBOT = _REPO_ROOT / "disbot"
+_BOT1_SRC = _DISBOT / "bot1.py"
+
+
+# ---------------------------------------------------------------------------
+# Webhook reporter surface — every lifecycle entry point operators expect.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    [
+        "on_lifecycle_close_beginning",
+        "on_lifecycle_close_completed",
+        "on_lifecycle_close_timeout",
+        "on_startup_summary",
+    ],
+)
+def test_webhook_reporter_exposes_required_lifecycle_method(
+    method_name: str,
+) -> None:
+    """Every operator-channel lifecycle signal must have a single
+    canonical entry point on :class:`WebhookReporter`.  Removing one
+    drops a signal from the operator channel and is a regression."""
+    assert hasattr(webhook_reporter.WebhookReporter, method_name), (
+        f"WebhookReporter must expose {method_name!r} so the "
+        f"close-driver / finalizer have a single canonical entry "
+        f"point.  Restore it or this invariant will fail CI."
+    )
+    method = getattr(webhook_reporter.WebhookReporter, method_name)
+    assert inspect.iscoroutinefunction(method), (
+        f"WebhookReporter.{method_name} must be an async method."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Metrics surface — every dashboard series the runbooks rely on.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "metric_name",
+    [
+        "lifecycle_phase",
+        "lifecycle_event_total",
+        "lifecycle_close_driver_total",
+        "lifecycle_close_duration_seconds",
+        "lifecycle_startup_seconds",
+        "runtime_lock_heartbeat_total",
+        "runtime_lock_heartbeat_seconds",
+        "runtime_lock_boot_handoff_total",
+        "runtime_lock_boot_wait_seconds",
+        "webhook_dispatch_total",
+        "webhook_dispatch_seconds",
+    ],
+)
+def test_metrics_module_exposes_required_metric(metric_name: str) -> None:
+    """The dashboards and runbooks reference these names directly.
+    Removing one quietly is a contract break — the panel goes blank
+    and the runbook step fails at the worst possible time.
+    """
+    assert hasattr(metrics, metric_name), (
+        f"services.metrics.{metric_name} must remain exposed — "
+        f"removing it breaks the dashboard / runbook that names it."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Production code must not re-introduce the restart-only close driver
+# symbols that the generalised driver replaced.
+# ---------------------------------------------------------------------------
+
+
+_FORBIDDEN_LEGACY_SYMBOLS: tuple[str, ...] = (
+    "restart_close_driver",
+    "_drive_close_on_restart_request",
+    "RESTART_CLOSE_TIMEOUT_SECONDS",
+)
+
+
+def test_production_code_does_not_resurrect_legacy_close_symbols() -> None:
+    """The pre-merge close-path PRs generalised the restart-only close
+    driver into a single shutdown-or-restart driver.  A future refactor
+    must not re-introduce the old restart-only names — they would
+    create a parallel lifecycle path that diverges from the merged
+    contract."""
+    offenders: dict[str, list[str]] = {}
+    for path in _DISBOT.rglob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        rel = str(path.relative_to(_REPO_ROOT))
+        for symbol in _FORBIDDEN_LEGACY_SYMBOLS:
+            if symbol in text:
+                offenders.setdefault(rel, []).append(symbol)
+    assert not offenders, (
+        "Forbidden legacy close-driver symbols re-introduced. Remove "
+        "them or migrate to the shared close-driver: "
+        f"{offenders!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AST-level contract: the close-driver must call the timeout webhook
+# before os._exit(1), and must not own cleanup that belongs to main().
+# ---------------------------------------------------------------------------
+
+
+def _close_driver_ast() -> ast.AsyncFunctionDef:
+    tree = ast.parse(_BOT1_SRC.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "_drive_close_on_lifecycle_request"
+        ):
+            return node
+    raise AssertionError(
+        "bot1._drive_close_on_lifecycle_request is missing — the "
+        "close-driver must remain in bot1.py per the merged contract.",
+    )
+
+
+def _calls_in(node: ast.AST) -> list[ast.Call]:
+    return [n for n in ast.walk(node) if isinstance(n, ast.Call)]
+
+
+def _call_dotted_name(call: ast.Call) -> str:
+    """Render the called name as ``a.b.c`` if it's an attribute chain
+    or a bare name, or ``""`` otherwise.  Sufficient for AST contract
+    checks against a small, well-known set of names.
+    """
+    func = call.func
+    parts: list[str] = []
+    while isinstance(func, ast.Attribute):
+        parts.append(func.attr)
+        func = func.value
+    if isinstance(func, ast.Name):
+        parts.append(func.id)
+    return ".".join(reversed(parts))
+
+
+def test_close_driver_calls_close_timeout_webhook_before_os_exit() -> None:
+    """The timeout branch must post the dedicated timeout webhook
+    before force-exiting.  Verified by walking the AST: every
+    ``os._exit`` call appears AFTER an ``on_lifecycle_close_timeout``
+    call in the source order of the same function body."""
+    fn = _close_driver_ast()
+    body_text = ast.unparse(fn)
+    assert "on_lifecycle_close_timeout" in body_text, (
+        "Close-driver must call reporter.on_lifecycle_close_timeout "
+        "in the asyncio.TimeoutError branch before os._exit(1)."
+    )
+    assert "os._exit" in body_text, (
+        "Close-driver must still force-exit on timeout — "
+        "os._exit(1) is the contract handoff to the orchestrator."
+    )
+    # Source order: the timeout webhook call must precede the os._exit
+    # call in the function body.  Use lineno because both live in the
+    # same try/except branch.
+    timeout_calls = [
+        c for c in _calls_in(fn)
+        if _call_dotted_name(c).endswith("on_lifecycle_close_timeout")
+    ]
+    exit_calls = [
+        c for c in _calls_in(fn)
+        if _call_dotted_name(c) in {"os._exit", "_exit"}
+    ]
+    assert timeout_calls, "expected on_lifecycle_close_timeout call"
+    assert exit_calls, "expected os._exit call"
+    assert min(c.lineno for c in timeout_calls) < min(
+        c.lineno for c in exit_calls
+    ), "on_lifecycle_close_timeout must be called before os._exit(1)"
+
+
+# ---------------------------------------------------------------------------
+# Cleanup ownership: the close-driver must NOT own finalizer cleanup.
+# Those belong in main()'s finally block so shutdown vs restart share
+# the same cleanup path without duplicating responsibility.
+# ---------------------------------------------------------------------------
+
+
+_DRIVER_FORBIDDEN_CALLS: tuple[str, ...] = (
+    "db.close",
+    "reporter.close",
+    "release_lock_best_effort",
+    "sys.exit",
+    "os.execv",
+)
+
+
+def test_close_driver_does_not_own_finalizer_cleanup() -> None:
+    """``main()``'s ``finally`` block is the canonical owner of:
+      - the runtime-lock release (``release_lock_best_effort``),
+      - the DB pool close (``db.close``),
+      - the reporter HTTP teardown (``reporter.close``),
+      - any process-exit primitive other than the timeout-branch
+        ``os._exit`` (no ``sys.exit`` / ``os.execv`` in the driver).
+
+    A driver that owns any of these forks shutdown vs restart cleanup,
+    which is what the close-path PRs generalised away.  This invariant
+    catches any reversal.
+    """
+    fn = _close_driver_ast()
+    offenders: list[str] = []
+    for call in _calls_in(fn):
+        name = _call_dotted_name(call)
+        for forbidden in _DRIVER_FORBIDDEN_CALLS:
+            if name == forbidden or name.endswith(f".{forbidden}"):
+                offenders.append(name)
+    assert not offenders, (
+        "Close-driver must not own finalizer cleanup. The merged "
+        "contract reserves these for main()'s finally block: "
+        f"{sorted(set(offenders))!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle module surface: startup-duration one-shot + metadata in
+# diagnostics_snapshot.
+# ---------------------------------------------------------------------------
+
+
+def test_lifecycle_observes_startup_duration_one_shot() -> None:
+    """The first STARTING → RUNNING transition observes the histogram
+    exactly once per process.  A second RUNNING transition (e.g. after
+    a gateway reconnect-driven on_ready) must not re-observe."""
+    lifecycle.reset_for_tests()
+    samples = list(metrics.lifecycle_startup_seconds.collect())[0].samples
+    before_count = next(s.value for s in samples if s.name.endswith("_count"))
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING, reason="on_ready")
+    samples = list(metrics.lifecycle_startup_seconds.collect())[0].samples
+    after_first = next(s.value for s in samples if s.name.endswith("_count"))
+    assert after_first == before_count + 1, (
+        "First STARTING → RUNNING must observe lifecycle_startup_seconds"
+    )
+
+    # Simulate a second on_ready: go DRAINING and back to RUNNING; the
+    # observation must NOT increment again.
+    lifecycle.set_phase(lifecycle.Phase.DRAINING)
+    lifecycle.set_phase(lifecycle.Phase.RUNNING, reason="reconnect")
+    samples = list(metrics.lifecycle_startup_seconds.collect())[0].samples
+    after_second = next(s.value for s in samples if s.name.endswith("_count"))
+    assert after_second == after_first, (
+        "Second RUNNING transition must not re-observe the histogram — "
+        "the startup metric is cold-boot health, not connection churn."
+    )
+
+
+def test_diagnostics_snapshot_includes_event_metadata_and_startup_state() -> None:
+    """``diagnostics_snapshot`` is the single source of truth for the
+    lifecycle embed + /lifecycle HTTP endpoint.  It must expose:
+      - per-event ``metadata`` so the embed can render close-outcome
+        kind / duration / timeout,
+      - ``startup_duration_observed`` so operators can confirm the
+        one-shot observation fired,
+      - ``module_load_age_seconds`` for diagnosing late-RUNNING boots.
+    """
+    lifecycle.reset_for_tests()
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown("sigterm", actor="signal_handler")
+    pending = lifecycle.get_pending()
+    assert pending is not None
+    lifecycle.record_close_executing(pending)
+    lifecycle.record_close_completed(pending, duration_seconds=1.25)
+
+    snap = lifecycle.diagnostics_snapshot()
+    assert "startup_duration_observed" in snap
+    assert snap["startup_duration_observed"] is True
+    assert isinstance(snap.get("module_load_age_seconds"), float)
+    completed = next(
+        e for e in snap["recent_events"] if e["name"] == "close_completed"
+    )
+    assert completed["metadata"]["kind"] == "shutdown"
+    assert completed["metadata"]["duration_seconds"] == pytest.approx(1.25)
+
+
+def test_lifecycle_module_exposes_close_outcome_recorders() -> None:
+    """Both outcome recorders must remain on the module surface — they
+    are the canonical writers for the close_completed / close_timeout
+    ring-buffer events."""
+    assert hasattr(lifecycle, "record_close_completed")
+    assert hasattr(lifecycle, "record_close_timeout")
+    assert "record_close_completed" in lifecycle.__all__
+    assert "record_close_timeout" in lifecycle.__all__
+
+
+# ---------------------------------------------------------------------------
+# Wiring: bot1 close-driver imports lifecycle helpers (smoke).
+# ---------------------------------------------------------------------------
+
+
+def test_bot1_module_uses_lifecycle_record_close_helpers() -> None:
+    """The close-driver imports lifecycle as ``_lifecycle`` and must
+    call the new outcome recorders.  This is a smoke check that the
+    wiring did not regress to "metric-only, no ring-buffer event" or
+    vice-versa."""
+    body = _BOT1_SRC.read_text(encoding="utf-8")
+    assert "_lifecycle.record_close_executing" in body
+    assert "_lifecycle.record_close_completed" in body
+    assert "_lifecycle.record_close_timeout" in body

--- a/tests/unit/runtime/test_lifecycle.py
+++ b/tests/unit/runtime/test_lifecycle.py
@@ -351,3 +351,137 @@ def test_lifecycle_event_counter_increments_on_coalesced_shutdown() -> None:
     lifecycle.request_shutdown("second")
     lifecycle.request_shutdown("third")
     assert _lifecycle_event_counter("shutdown_requested_coalesced") == before + 2
+
+
+# ---------------------------------------------------------------------------
+# Startup-duration observation — lifecycle_startup_seconds histogram.
+# ---------------------------------------------------------------------------
+
+
+def _startup_seconds_count() -> float:
+    """Read the +Inf count from lifecycle_startup_seconds."""
+    from services import metrics as _metrics
+
+    samples = next(iter(_metrics.lifecycle_startup_seconds.collect())).samples
+    return next(s.value for s in samples if s.name.endswith("_count"))
+
+
+def test_startup_seconds_observed_on_first_starting_to_running() -> None:
+    """The first STARTING → RUNNING transition observes the histogram
+    exactly once.  Anchored at module import time (or
+    reset_for_tests), so the observation captures cold-boot health."""
+    before = _startup_seconds_count()
+    lifecycle.set_phase(lifecycle.Phase.RUNNING, reason="on_ready")
+    assert _startup_seconds_count() == before + 1
+
+
+def test_startup_seconds_not_re_observed_on_reconnect() -> None:
+    """A second RUNNING transition (e.g. Discord gateway reconnect-
+    driven on_ready) must not re-observe — the histogram tracks
+    cold-boot timing, not connection churn."""
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    after_first = _startup_seconds_count()
+    # Simulate a drain + reconnect cycle.
+    lifecycle.set_phase(lifecycle.Phase.DRAINING)
+    lifecycle.set_phase(lifecycle.Phase.RUNNING, reason="reconnect")
+    assert _startup_seconds_count() == after_first
+
+
+def test_startup_seconds_anchor_resets_in_reset_for_tests() -> None:
+    """``reset_for_tests`` re-stamps the module-load anchor and clears
+    the one-shot flag so subsequent set_phase(RUNNING) calls observe
+    again. Without this every test in the suite would share one
+    process-wide one-shot and only the first ordered test would see an
+    observation."""
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    after_first = _startup_seconds_count()
+    lifecycle.reset_for_tests()
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    assert _startup_seconds_count() == after_first + 1
+
+
+def test_diagnostics_snapshot_exposes_startup_observed_flag() -> None:
+    """``startup_duration_observed`` and ``module_load_age_seconds``
+    are operator-visible signals: the boolean tells you whether the
+    one-shot fired this process, the age tells you how long ago the
+    bot imported lifecycle (useful when investigating a late
+    on_ready)."""
+    snap = lifecycle.diagnostics_snapshot()
+    assert snap["startup_duration_observed"] is False
+    assert isinstance(snap["module_load_age_seconds"], float)
+    assert snap["module_load_age_seconds"] >= 0.0
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+
+    snap = lifecycle.diagnostics_snapshot()
+    assert snap["startup_duration_observed"] is True
+
+
+# ---------------------------------------------------------------------------
+# Close outcome recorders — record_close_completed, record_close_timeout.
+# ---------------------------------------------------------------------------
+
+
+def test_record_close_completed_captures_duration_and_kind() -> None:
+    """``close_completed`` is the canonical "clean unwind" signal in
+    the ring buffer.  Kind + duration_seconds metadata lets the embed
+    render the close cost without re-deriving it from monotonic
+    timestamps."""
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown("sigterm", actor="signal_handler")
+    pending = lifecycle.get_pending()
+    assert pending is not None
+
+    lifecycle.record_close_completed(pending, duration_seconds=2.5)
+
+    event = lifecycle.get_recent_events()[-1]
+    assert event.name == "close_completed"
+    assert event.metadata == {
+        "kind": "shutdown",
+        "duration_seconds": 2.5,
+    }
+
+
+def test_record_close_timeout_captures_timeout_and_kind() -> None:
+    """``close_timeout`` is the wedged-close signal.  ``kind`` lets
+    operators tell shutdown-wedge from restart-wedge; ``timeout_seconds``
+    pins the budget the driver actually used (in case the constant is
+    tuned later)."""
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_restart("!restart", actor="op")
+    pending = lifecycle.get_pending()
+    assert pending is not None
+
+    lifecycle.record_close_timeout(pending, timeout_seconds=20.0)
+
+    event = lifecycle.get_recent_events()[-1]
+    assert event.name == "close_timeout"
+    assert event.metadata == {
+        "kind": "restart",
+        "timeout_seconds": 20.0,
+    }
+
+
+def test_diagnostics_snapshot_exposes_event_metadata() -> None:
+    """Recent events in the snapshot must carry the ``metadata`` dict
+    so embed builders can render kind / duration / timeout without
+    re-importing the lifecycle module."""
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown("sigterm")
+    pending = lifecycle.get_pending()
+    assert pending is not None
+    lifecycle.record_close_executing(pending)
+    lifecycle.record_close_completed(pending, duration_seconds=1.0)
+    lifecycle.record_close_timeout(pending, timeout_seconds=20.0)
+
+    snap = lifecycle.diagnostics_snapshot()
+    metas = {e["name"]: e["metadata"] for e in snap["recent_events"]}
+    assert metas["close_executing"] == {"kind": "shutdown"}
+    assert metas["close_completed"] == {
+        "kind": "shutdown",
+        "duration_seconds": 1.0,
+    }
+    assert metas["close_timeout"] == {
+        "kind": "shutdown",
+        "timeout_seconds": 20.0,
+    }

--- a/tests/unit/runtime/test_lifecycle.py
+++ b/tests/unit/runtime/test_lifecycle.py
@@ -140,7 +140,8 @@ def test_event_buffer_records_coalesce_attempts_separately() -> None:
     assert "shutdown_requested" in names
     assert "shutdown_requested_coalesced" in names
     coalesced = [
-        event for event in lifecycle.get_recent_events()
+        event
+        for event in lifecycle.get_recent_events()
         if event.name == "shutdown_requested_coalesced"
     ]
     assert coalesced[0].reason == "second"

--- a/tests/unit/runtime/test_platform_diagnostics_commands.py
+++ b/tests/unit/runtime/test_platform_diagnostics_commands.py
@@ -515,3 +515,167 @@ def test_lifecycle_shortcut_exposes_lc_alias():
     cmd = DiagnosticCog.lifecycle_shortcut
     assert "lc" in cmd.aliases
     assert cmd.name == "lifecycle"
+
+
+# ---------------------------------------------------------------------------
+# build_lifecycle_embed — close-outcome metadata rendering.
+#
+# The diagnostics_snapshot now carries per-event ``metadata`` so the
+# embed can summarize kind / duration / timeout inline.  These tests
+# pin the rendering so dashboards built on the operator-channel embeds
+# do not silently drop the close-outcome detail.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_platform_lifecycle_renders_close_completed_duration_metadata():
+    """A ``close_completed`` event with ``duration_seconds`` metadata
+    must surface the duration in the Recent events field so the embed
+    is self-contained — no Prometheus lookup required for normal
+    shutdown / restart sequences."""
+    cog = _make_cog()
+    ctx = _make_ctx()
+
+    snap = {
+        "phase": "STOPPED",
+        "can_accept_commands": False,
+        "startup_duration_observed": True,
+        "pending": {
+            "kind": "shutdown",
+            "reason": "sigterm",
+            "actor": "signal_handler",
+        },
+        "remaining_shutdown_seconds": None,
+        "recent_events": [
+            {
+                "name": "close_executing",
+                "phase": "DRAINING",
+                "actor": "signal_handler",
+                "reason": "sigterm",
+                "metadata": {"kind": "shutdown"},
+            },
+            {
+                "name": "close_completed",
+                "phase": "DRAINING",
+                "actor": "signal_handler",
+                "reason": "sigterm",
+                "metadata": {
+                    "kind": "shutdown",
+                    "duration_seconds": 1.234,
+                },
+            },
+        ],
+    }
+    with patch("services.diagnostics_service.snapshot", return_value=snap):
+        await cog.platform_lifecycle.callback(cog, ctx)
+
+    embed = ctx.send.call_args.kwargs["embed"]
+    events_field = next(f for f in embed.fields if f.name.startswith("Recent events"))
+    body = events_field.value
+    assert "close_completed" in body
+    # Duration rendered compactly so it fits the 1024-char field.
+    assert "dur=1.23s" in body
+
+
+@pytest.mark.asyncio
+async def test_platform_lifecycle_renders_close_timeout_metadata():
+    """A ``close_timeout`` event surfaces ``timeout_seconds`` so
+    operators see what budget the driver actually used — useful when
+    the constant has been tuned away from the default 20 s."""
+    cog = _make_cog()
+    ctx = _make_ctx()
+
+    snap = {
+        "phase": "DRAINING",
+        "can_accept_commands": False,
+        "startup_duration_observed": True,
+        "pending": {
+            "kind": "restart",
+            "reason": "!restart",
+            "actor": "op",
+        },
+        "remaining_shutdown_seconds": None,
+        "recent_events": [
+            {
+                "name": "close_timeout",
+                "phase": "DRAINING",
+                "actor": "op",
+                "reason": "!restart",
+                "metadata": {
+                    "kind": "restart",
+                    "timeout_seconds": 20.0,
+                },
+            },
+        ],
+    }
+    with patch("services.diagnostics_service.snapshot", return_value=snap):
+        await cog.platform_lifecycle.callback(cog, ctx)
+
+    embed = ctx.send.call_args.kwargs["embed"]
+    events_field = next(f for f in embed.fields if f.name.startswith("Recent events"))
+    body = events_field.value
+    assert "close_timeout" in body
+    assert "kind=restart" in body
+    assert "timeout=20.00s" in body
+
+
+@pytest.mark.asyncio
+async def test_platform_lifecycle_renders_startup_observed_flag():
+    """The embed description surfaces the one-shot
+    ``startup_duration_observed`` flag so operators can confirm
+    cold-boot timing was captured without scrolling to Prometheus."""
+    cog = _make_cog()
+    ctx = _make_ctx()
+
+    snap = {
+        "phase": "RUNNING",
+        "can_accept_commands": True,
+        "startup_duration_observed": True,
+        "pending": None,
+        "remaining_shutdown_seconds": None,
+        "recent_events": [],
+    }
+    with patch("services.diagnostics_service.snapshot", return_value=snap):
+        await cog.platform_lifecycle.callback(cog, ctx)
+
+    embed = ctx.send.call_args.kwargs["embed"]
+    description = embed.description or ""
+    assert "Startup observed" in description
+    assert "yes" in description
+
+
+@pytest.mark.asyncio
+async def test_platform_lifecycle_events_field_stays_under_discord_limit():
+    """Discord caps embed field values at 1024 chars.  The lifecycle
+    embed must respect that limit even when every event carries
+    metadata (which can balloon the rendered line length)."""
+    cog = _make_cog()
+    ctx = _make_ctx()
+
+    snap = {
+        "phase": "DRAINING",
+        "can_accept_commands": False,
+        "startup_duration_observed": True,
+        "pending": {
+            "kind": "shutdown",
+            "reason": "sigterm",
+            "actor": "signal_handler",
+        },
+        "remaining_shutdown_seconds": None,
+        "recent_events": [
+            {
+                "name": "close_completed",
+                "phase": "DRAINING",
+                "actor": "signal_handler",
+                "reason": "sigterm" * 20,  # long reason
+                "metadata": {"kind": "shutdown", "duration_seconds": 1.0},
+            }
+        ]
+        * 20,  # 20 chunky events
+    }
+    with patch("services.diagnostics_service.snapshot", return_value=snap):
+        await cog.platform_lifecycle.callback(cog, ctx)
+
+    embed = ctx.send.call_args.kwargs["embed"]
+    events_field = next(f for f in embed.fields if f.name.startswith("Recent events"))
+    assert len(events_field.value) <= 1024

--- a/tests/unit/runtime/test_platform_diagnostics_commands.py
+++ b/tests/unit/runtime/test_platform_diagnostics_commands.py
@@ -377,7 +377,10 @@ async def test_platform_lifecycle_renders_running_phase_with_no_pending():
     field_names = {f.name for f in embed.fields}
     assert field_names == {"Pending request", "Recent events"}
     pending_field = next(f for f in embed.fields if f.name == "Pending request")
-    assert pending_field.value.strip().startswith("_none_") or "none" in pending_field.value
+    assert (
+        pending_field.value.strip().startswith("_none_")
+        or "none" in pending_field.value
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_webhook_reporter.py
+++ b/tests/unit/services/test_webhook_reporter.py
@@ -324,3 +324,68 @@ async def test_on_lifecycle_close_completed_renders_restart_embed_without_durati
     assert embed.color == discord.Color.gold()
     field_names = {f.name for f in embed.fields}
     assert "Close duration" not in field_names
+
+
+# ---------------------------------------------------------------------------
+# on_lifecycle_close_timeout — posted in the wedged-close branch before
+# os._exit(1) so operators see why the container respawned.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_lifecycle_close_timeout_renders_dark_red_embed_with_timeout():
+    """Timeout intent → dark-red embed titled 'Bot Close Timeout' with
+    kind, reason, actor, and the configured timeout populated.  The
+    title and color make wedge events unambiguous in the operator
+    channel vs the gold 'Restart Complete' / dark-red 'Shutdown
+    Complete' embeds."""
+    from core.runtime.lifecycle import PendingShutdown
+
+    reporter = WebhookReporter(url="https://example/wh")
+    reporter._send = AsyncMock()  # type: ignore[method-assign]
+    pending = PendingShutdown(
+        kind="shutdown",
+        reason="sigterm",
+        actor="signal_handler",
+        requested_at=0.0,
+        grace_seconds=None,
+    )
+
+    await reporter.on_lifecycle_close_timeout(pending, timeout_seconds=20.0)
+
+    reporter._send.assert_awaited_once()
+    embed = reporter._send.await_args.args[0]
+    assert "Close Timeout" in embed.title
+    assert embed.color == discord.Color.dark_red()
+    field_map = {f.name: f.value for f in embed.fields}
+    assert field_map["Kind"] == "shutdown"
+    assert field_map["Reason"] == "sigterm"
+    assert field_map["Actor"] == "signal_handler"
+    assert field_map["Timeout"] == "20.00s"
+
+
+@pytest.mark.asyncio
+async def test_on_lifecycle_close_timeout_falls_back_for_missing_actor_reason():
+    """Missing actor / reason on the pending request must not blow up
+    embed construction — they fall back to ``<unknown>`` consistently
+    with the beginning / completed embeds."""
+    from core.runtime.lifecycle import PendingShutdown
+
+    reporter = WebhookReporter(url="https://example/wh")
+    reporter._send = AsyncMock()  # type: ignore[method-assign]
+    pending = PendingShutdown(
+        kind="restart",
+        reason="",
+        actor=None,
+        requested_at=0.0,
+        grace_seconds=None,
+    )
+
+    await reporter.on_lifecycle_close_timeout(pending, timeout_seconds=5.5)
+
+    embed = reporter._send.await_args.args[0]
+    field_map = {f.name: f.value for f in embed.fields}
+    assert field_map["Actor"] == "<unknown>"
+    assert field_map["Reason"] == "<unknown>"
+    assert field_map["Kind"] == "restart"
+    assert field_map["Timeout"] == "5.50s"

--- a/tests/unit/services/test_webhook_reporter.py
+++ b/tests/unit/services/test_webhook_reporter.py
@@ -64,7 +64,9 @@ def test_redact_embed_no_secrets_means_no_changes() -> None:
 @pytest.mark.asyncio
 async def test_send_scrubs_embed_before_dispatch_to_webhook() -> None:
     reporter = WebhookReporter("https://discord.com/api/webhooks/123/abc")
-    reporter._session = MagicMock()  # truthy so _send proceeds past the early-return guard
+    reporter._session = (
+        MagicMock()
+    )  # truthy so _send proceeds past the early-return guard
 
     embed = discord.Embed(
         title="Crash",

--- a/tests/unit/test_bot1_lifecycle_close_driver.py
+++ b/tests/unit/test_bot1_lifecycle_close_driver.py
@@ -400,6 +400,194 @@ async def test_close_timeout_force_exits(
     assert exit_calls == [1]
 
 
+@pytest.mark.asyncio
+async def test_close_timeout_posts_timeout_webhook_before_os_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The wedged-close branch must call
+    ``reporter.on_lifecycle_close_timeout`` with the configured timeout
+    before ``os._exit(1)``.  Operators see a single dark-red embed in
+    the operator channel instead of an unexplained respawn."""
+
+    class HangingBot:
+        async def close(self) -> None:
+            await asyncio.sleep(60.0)
+
+    order: list[str] = []
+    timeout_calls: list[dict[str, Any]] = []
+
+    class TimeoutReporter:
+        async def on_lifecycle_close_beginning(self, pending: Any) -> None:
+            order.append("beginning")
+
+        async def on_lifecycle_close_timeout(
+            self,
+            pending: Any,
+            *,
+            timeout_seconds: float,
+        ) -> None:
+            order.append("timeout_webhook")
+            timeout_calls.append(
+                {"pending": pending, "timeout_seconds": timeout_seconds},
+            )
+
+    monkeypatch.setattr(bot1, "bot", HangingBot())
+    monkeypatch.setattr(bot1, "reporter", TimeoutReporter())
+    monkeypatch.setattr(bot1, "LIFECYCLE_CLOSE_TIMEOUT_SECONDS", 0.05)
+    _install_fast_poll(monkeypatch)
+
+    class _ForceExit(BaseException):
+        pass
+
+    def _fake_exit(_code: int) -> None:
+        order.append("os._exit")
+        raise _ForceExit
+
+    monkeypatch.setattr(bot1.os, "_exit", _fake_exit)
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown(reason="sigterm", actor="signal_handler")
+
+    with pytest.raises(_ForceExit):
+        await asyncio.wait_for(
+            bot1._drive_close_on_lifecycle_request(),
+            timeout=2.0,
+        )
+
+    assert order == ["beginning", "timeout_webhook", "os._exit"]
+    assert len(timeout_calls) == 1
+    assert timeout_calls[0]["timeout_seconds"] == 0.05
+    pending = timeout_calls[0]["pending"]
+    assert pending.kind == "shutdown"
+    assert pending.actor == "signal_handler"
+
+
+@pytest.mark.asyncio
+async def test_close_timeout_webhook_failure_does_not_block_os_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stalled / raising timeout webhook must not delay os._exit —
+    the driver wraps the call in asyncio.wait_for + try/except + DEBUG
+    log so the orchestrator handoff is never blocked by the operator
+    channel."""
+
+    class HangingBot:
+        async def close(self) -> None:
+            await asyncio.sleep(60.0)
+
+    class StuckReporter:
+        async def on_lifecycle_close_beginning(self, pending: Any) -> None:
+            return
+
+        async def on_lifecycle_close_timeout(
+            self,
+            pending: Any,
+            *,
+            timeout_seconds: float,
+        ) -> None:
+            await asyncio.sleep(60.0)  # would block forever
+
+    monkeypatch.setattr(bot1, "bot", HangingBot())
+    monkeypatch.setattr(bot1, "reporter", StuckReporter())
+    monkeypatch.setattr(bot1, "LIFECYCLE_CLOSE_TIMEOUT_SECONDS", 0.05)
+    _install_fast_poll(monkeypatch)
+
+    exit_calls: list[int] = []
+
+    class _ForceExit(BaseException):
+        pass
+
+    def _fake_exit(code: int) -> None:
+        exit_calls.append(code)
+        raise _ForceExit
+
+    monkeypatch.setattr(bot1.os, "_exit", _fake_exit)
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown(reason="sigterm")
+
+    with pytest.raises(_ForceExit):
+        await asyncio.wait_for(
+            bot1._drive_close_on_lifecycle_request(),
+            timeout=3.0,
+        )
+
+    assert exit_calls == [1]
+
+
+@pytest.mark.asyncio
+async def test_close_timeout_records_lifecycle_event_with_timeout_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The timeout branch records a ``close_timeout`` event in the
+    ring buffer with ``timeout_seconds`` metadata so the ``!lc`` /
+    /lifecycle dump shows what budget the driver used."""
+
+    class HangingBot:
+        async def close(self) -> None:
+            await asyncio.sleep(60.0)
+
+    monkeypatch.setattr(bot1, "bot", HangingBot())
+    monkeypatch.setattr(bot1, "reporter", None)
+    monkeypatch.setattr(bot1, "LIFECYCLE_CLOSE_TIMEOUT_SECONDS", 0.05)
+    _install_fast_poll(monkeypatch)
+
+    class _ForceExit(BaseException):
+        pass
+
+    def _fake_exit(_code: int) -> None:
+        raise _ForceExit
+
+    monkeypatch.setattr(bot1.os, "_exit", _fake_exit)
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown(reason="sigterm", actor="signal_handler")
+
+    with pytest.raises(_ForceExit):
+        await asyncio.wait_for(
+            bot1._drive_close_on_lifecycle_request(),
+            timeout=2.0,
+        )
+
+    names = [e.name for e in lifecycle.get_recent_events()]
+    assert "close_timeout" in names
+    timeout_event = next(
+        e for e in lifecycle.get_recent_events() if e.name == "close_timeout"
+    )
+    assert timeout_event.metadata == {
+        "kind": "shutdown",
+        "timeout_seconds": 0.05,
+    }
+
+
+@pytest.mark.asyncio
+async def test_close_success_records_close_completed_with_duration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A clean ``bot.close()`` records ``close_completed`` in the ring
+    buffer with the measured duration so an operator can confirm the
+    driver completed without hitting the wedge path."""
+    fake_bot = _FakeBot()
+    monkeypatch.setattr(bot1, "bot", fake_bot)
+    monkeypatch.setattr(bot1, "reporter", None)
+    _install_fast_poll(monkeypatch)
+
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown(reason="sigterm")
+
+    await asyncio.wait_for(bot1._drive_close_on_lifecycle_request(), timeout=2.0)
+
+    names = [e.name for e in lifecycle.get_recent_events()]
+    assert names[-1] == "close_completed"
+    completed = lifecycle.get_recent_events()[-1]
+    assert completed.metadata["kind"] == "shutdown"
+    duration = completed.metadata["duration_seconds"]
+    assert isinstance(duration, float)
+    # Fake bot.close returns instantly; observation is near-zero but
+    # bounded by the configured timeout.
+    assert 0.0 <= duration < bot1.LIFECYCLE_CLOSE_TIMEOUT_SECONDS
+
+
 def test_should_drive_lifecycle_close_predicate() -> None:
     """Predicate-level coverage so the eligibility logic is exercised
     independently of the polling loop.  Used by tests and source


### PR DESCRIPTION
## Summary

This PR completes the lifecycle observability contract by adding close-outcome recording (duration & timeout metadata) and the timeout webhook signal. It pins down the canonical wiring for runtime lifecycle observability across `core.runtime.lifecycle`, `bot1.py`, `services.webhook_reporter`, and `services.metrics` via an invariant test suite.

## Key Changes

### Core Lifecycle Module (`core.runtime.lifecycle`)
- **Startup duration observation**: Added one-shot `lifecycle_startup_seconds` histogram observation on first STARTING → RUNNING transition. Module-load anchor (`_module_loaded_at`) and flag (`_startup_duration_observed`) prevent re-observation on reconnects (e.g., Discord gateway reconnect-driven `on_ready`).
- **Close outcome recorders**: 
  - `record_close_completed(pending, duration_seconds)` — records clean unwind with measured duration
  - `record_close_timeout(pending, timeout_seconds)` — records wedged close with configured timeout budget
  - Both capture `kind` (shutdown/restart) in metadata for embed rendering
- **Diagnostics snapshot**: Exposed `startup_duration_observed` flag and `module_load_age_seconds` for operator visibility; recent events now carry `metadata` dict for kind/duration/timeout rendering

### Close Driver (`bot1._drive_close_on_lifecycle_request`)
- **Timeout branch**: Now calls `reporter.on_lifecycle_close_timeout()` before `os._exit(1)`, wrapped in `asyncio.wait_for(timeout=1.0)` so a stalled webhook cannot delay force-exit
- **Outcome recording**: Calls `_lifecycle.record_close_completed()` on success and `_lifecycle.record_close_timeout()` on timeout to populate ring buffer with duration/timeout metadata
- **Cleanup ownership preserved**: Driver does not own finalizer cleanup (db.close, reporter.close, release_lock_best_effort, sys.exit, os.execv) — all remain in `main()`'s finally block per the merged contract

### Webhook Reporter (`services.webhook_reporter`)
- **`on_lifecycle_close_timeout()` method**: Posts dark-red embed titled "Bot Close Timeout" with kind, reason, actor, and timeout fields. Operators see this instead of "complete" embed when close wedges, making respawn reason unambiguous in operator channel.

### Metrics (`services.metrics`)
- **`lifecycle_startup_seconds` histogram**: Captures cold-boot health (module import → first RUNNING transition). Buckets span sub-second to 60s; one-shot observation prevents connection-churn inflation.

### Diagnostics Embed (`cogs/diagnostic/_platform_embeds.py`)
- **Metadata rendering**: New `_fmt_lifecycle_event_metadata()` compactly renders close-outcome metadata as `[k=v k=v]` suffix (e.g., `[kind=shutdown dur=1.23s]`, `[kind=restart timeout=20.00s]`) while respecting Discord's 1024-char field limit
- **Startup flag display**: Embed description now surfaces `startup_duration_observed` so operators confirm cold-boot timing was captured without Prometheus lookup

### Invariant Test Suite (`tests/unit/invariants/test_lifecycle_observability_contract.py`)
- **Webhook surface contract**: Verifies `WebhookReporter` exposes required async methods (`on_lifecycle_close_beginning`, `on_lifecycle_close_completed`, `on_lifecycle_close_timeout`, `on_startup_summary`)
- **Metrics surface contract**: Pins 11 required Prometheus metrics (`lifecycle_*`, `runtime_lock_*`, `webhook_*`) that dashboards/runbooks reference directly
- **Legacy symbol ban**: Prevents re-introduction of restart-only close driver symbols (`restart_close_driver`, `_drive_close_on_restart_request`, `RESTART_CLOSE_TIMEOUT_SECONDS`)
- **AST-level contracts**:
  - Timeout webhook must be called before `os._exit(1)` (source-order verification via lineno)
  - Close driver must not own finalizer cleanup (forbidden call detection)
- **Lifecycle module contracts**: Ver

https://claude.ai/code/session_01MUdAuXon7zB2SwAXMmsKxt