### PR TITLE
docs: expand CodeGraph usage guide with trust matrix and blind spots

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7,6 +7,25 @@ This project has a CodeGraph MCP server (`mcp__codegraph__*` tools) configured. 
 
 MCP startup: pinned via `npx -y @optave/codegraph@3.10.0 mcp` — no global install required. Build/rebuild index: `npx -y @optave/codegraph@3.10.0 build .` from the project root.
 
+### Use CodeGraph automatically — no prompt required
+
+Reach for CodeGraph **without being asked** whenever the task involves any of the following. Do not wait for the user to mention it.
+
+| Situation | What to do first |
+|---|---|
+| Finding where a symbol is defined | `mcp__codegraph__where("symbol_name")` before any grep or Read |
+| Reading a function you haven't seen before | `mcp__codegraph__context("name")` for source + signature in one call |
+| Understanding what calls a function | `mcp__codegraph__fn_impact("name", depth=1)` then grep-verify |
+| Listing what exists in a file or directory | `mcp__codegraph__list_functions(file="path/")` before opening files blindly |
+| Assessing complexity before a refactor | `mcp__codegraph__complexity(file="path/")` or `mcp__codegraph__triage(level=function, sort=complexity)` |
+| Planning any edit to shared code | `mcp__codegraph__context` to read source + get starting caller list, then grep |
+| Bug investigation across multiple functions | `mcp__codegraph__context` on each candidate — faster than chained Read calls |
+| Checking which functions are most complex in a service or cog | `mcp__codegraph__complexity(file="disbot/services/name.py")` |
+
+**Default order for any unfamiliar code:** `where` → `context` → grep-verify → `Read` the file only if source detail is needed beyond what `context` returned.
+
+Do not start with `Read` or `grep` for symbol lookups when `where` or `context` would answer the question in one call.
+
 ### What CodeGraph can and cannot do in this codebase
 
 SuperBot uses function-body lazy imports, module-alias calls, and Discord decorator callbacks pervasively. These patterns are **invisible to CodeGraph's call-graph parser**. The result is that roughly half of all real call edges are missing from the graph.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,41 +1,73 @@
 <!-- CODEGRAPH_START -->
 ## CodeGraph
 
-This project has a CodeGraph MCP server (`mcp__codegraph__*` tools) configured. CodeGraph is a tree-sitter-parsed knowledge graph of every symbol, edge, and file. Reads are sub-millisecond and return structural information grep cannot.
+This project has a CodeGraph MCP server (`mcp__codegraph__*` tools) configured. CodeGraph is a tree-sitter-parsed knowledge graph of every symbol, edge, and file.
+
+**Full trust matrix and verification rules: `docs/codegraph-usage.md` — read it before any refactor or dead-code decision.**
 
 MCP startup: pinned via `npx -y @optave/codegraph@3.10.0 mcp` — no global install required. Build/rebuild index: `npx -y @optave/codegraph@3.10.0 build .` from the project root.
 
-### Use CodeGraph first for structural exploration
+### What CodeGraph can and cannot do in this codebase
 
-Use CodeGraph for **structural** questions — what calls what, what would break, where is X defined, what is X's signature. Use native grep/Read only for **literal text** queries (string contents, comments, log messages) or after you already have a specific file open.
+SuperBot uses function-body lazy imports, module-alias calls, and Discord decorator callbacks pervasively. These patterns are **invisible to CodeGraph's call-graph parser**. The result is that roughly half of all real call edges are missing from the graph.
+
+**Reliable** — use freely:
 
 | Question | Tool |
 |---|---|
-| "Where is X defined?" / "Find symbol named X" | `mcp__codegraph__where` |
-| "Full source + callers + callees for Y" | `mcp__codegraph__context` |
-| "What calls function Y?" (direct callers) | `mcp__codegraph__fn_impact` Level 1 |
-| "What does Y call?" (callees) | `mcp__codegraph__execution_flow` |
-| "What would break if I changed Z?" | `mcp__codegraph__fn_impact` |
-| "What files/functions exist under path/" | `mcp__codegraph__list_functions` |
-| "What does this file import/export?" | grep (file_deps is broken — see limitations) |
-| "Is the index healthy? / graph stats" | `mcp__codegraph__audit` |
+| "Where is X defined?" | `mcp__codegraph__where` |
+| "Show me the source + signature of Y" | `mcp__codegraph__context` |
+| "List all symbols in this file/directory" | `mcp__codegraph__list_functions` or `mcp__codegraph__where` with `file_mode=true` |
+| "How complex is function Y?" | `mcp__codegraph__complexity` |
+| "Which functions exceed complexity thresholds?" | `mcp__codegraph__check` (manifesto mode) |
+| "What is the risk-ranked list of complex functions?" | `mcp__codegraph__triage` with `level=function` and `sort=complexity` |
+
+**Use as hints only — always grep-verify before acting:**
+
+| Question | Tool | Caveat |
+|---|---|---|
+| "What are the direct callers of Y?" | `mcp__codegraph__fn_impact` depth=1 or `mcp__codegraph__context` | Undercounts — lazy imports and aliased imports are invisible |
+| "What does this file import/export?" | grep only (`file_deps` is broken) | Never use `file_deps`, `module_map`, or `impact_analysis` |
+
+**Do not use — broken or requires unavailable pre-work:**
+
+- `mcp__codegraph__execution_flow` — returns 0 entries regardless of target (confirmed broken)
+- `mcp__codegraph__find_cycles` — always returns 0 cycles (file-level edges broken)
+- `mcp__codegraph__communities` — always returns 0 communities (same root cause)
+- `mcp__codegraph__co_changes` — requires `codegraph co-change --analyze` pre-run; returns nothing without it
+- `mcp__codegraph__module_map` — returns 0 in/out edges for every file
+- `mcp__codegraph__file_deps` — returns 0 imports and 0 imported-by for every file
+- `mcp__codegraph__impact_analysis` — returns 0 file dependents
+- `mcp__codegraph__triage` with `level=directory` — fanIn/fanOut always 0
+- `mcp__codegraph__semantic_search` — requires `codegraph embed` pre-run
+
+### Critical rules — non-negotiable
+
+**1. `dead-unresolved` does not mean dead.**
+The false-positive rate for the `dead-unresolved` role label is ~100% in this codebase. Verified active functions that CodeGraph incorrectly marks dead: `validate_registry`, `apply_operations`, `parse_message`, `request_shutdown`, `dispatch` (interaction_router), `resolve_execution`, `BlackjackCog.blackjack`, all `@bot.event` handlers, all `@commands.command` handlers. **Never delete or remove code based on this label alone.**
+
+**2. Caller lists are lower bounds — always grep.**
+After getting a caller list from `fn_impact` or `context`, run:
+```
+grep -rn "function_name\b" disbot/ --include="*.py"
+```
+Callers that use `from module import func` inside a function body, or call via `module.func()`, or import under an alias (`from base import X as _X`) are all invisible to CodeGraph.
+
+**3. Name-collision false positives are dangerous.**
+When two functions share the same short name in different classes or modules (e.g. `_resolve_channel` exists in both `chain_cog.py` as a module function and `channel_cog.py` as a class method), CodeGraph merges their caller graphs. Verified case: CodeGraph claimed 14 callers for `chain_cog._resolve_channel`; the true count is 3. The other 11 were callers of `ChannelCog._resolve_channel` — a completely separate method. **When caller files look unexpected, check for same-name functions in those files.**
+
+**4. Discord decorators create invisible entry points.**
+`@bot.event`, `@commands.command`, `@commands.group`, `@app_commands.command`, and Cog listener methods are all `dead-unresolved` in CodeGraph regardless of whether they are active. Never treat a command handler or event handler as dead.
+
+**5. `callees` lists are often empty — read the source.**
+Functions that contain `from X import Y` inside their body will show `callees: []` even if they call many things. Always read the source directly to find what a function calls.
 
 ### Rules of thumb
 
-- **Use CodeGraph first** for structural exploration; then verify with source files before editing.
-- **Don't grep first** when looking up a symbol by name. `mcp__codegraph__where` is faster and returns kind + location + signature in one call.
-- **`context` is the workhorse** — it returns source, direct callers, callees, and signature in one call. Prefer it over chaining `where` + `fn_impact`.
-- **Index lag**: after editing a file run `npx -y @optave/codegraph@3.10.0 build .` to rebuild; don't re-query immediately after editing in the same turn without rebuilding.
-
-### Known limitations — do not trust these uncritically
-
-- **`mcp__codegraph__module_map` is broken for this codebase.** It returns 0 in/out edges for every file despite 22 000+ edges existing in the index. Do not use it for connectivity analysis.
-- **`mcp__codegraph__brief` reports transitive impact count, not direct caller count.** The number shown as "callers" equals the total transitive dependent count (same as `fn_impact` total), not just the distinct functions that directly call the symbol. Use `mcp__codegraph__fn_impact` Level 1 or `mcp__codegraph__context` for accurate direct-caller counts.
-- **`mcp__codegraph__file_deps` shows 0 imports and 0 imported-by for every file.** The file-level edge traversal is broken; it returns symbol definitions correctly but import/dependency edges are always empty. Do not use it for import graph analysis.
-- **`mcp__codegraph__impact_analysis` returns 0 file dependents.** File-level transitive impact is broken by the same underlying edge issue. Use `mcp__codegraph__fn_impact` for function-level blast-radius instead.
-- **`mcp__codegraph__structure` shows `<-0 ->0` connectivity for all files.** The per-file in/out edge counts are always zero. The symbol counts and line counts are accurate; the connectivity data is not.
-- **`mcp__codegraph__semantic_search` requires embeddings to be built first.** Run `npx -y @optave/codegraph@3.10.0 embed` from the project root before using it; without embeddings it returns an error. Embeddings are not built by default.
-- **Python lazy/function-body imports are not resolved.** When a function is imported inside a function body (`from services.X import Y` inside a method), CodeGraph cannot trace the call edge. Affected symbols are labelled `dead-unresolved` with 0 callers even when they are widely used. Always grep-verify when a symbol is marked `dead-unresolved`.
+- **Use CodeGraph first for finding and reading code**, not for proving code is safe to delete.
+- **`context` is the workhorse** for source + callers. Treat callers as a starting list, not a complete list.
+- **Grep-verify every caller list** before changing a function signature or moving a function.
+- **Index lag**: after editing, run `npx -y @optave/codegraph@3.10.0 build .` before re-querying.
 
 ### Source files win
 

--- a/docs/codegraph-usage.md
+++ b/docs/codegraph-usage.md
@@ -1,104 +1,289 @@
-# CodeGraph Usage Guide
+# CodeGraph Usage Guide — SuperBot
 
-CodeGraph provides a tree-sitter-parsed knowledge graph of every symbol, edge,
-and file in the codebase. It is exposed to Claude Code via an MCP server.
+> **This is the full trust matrix. `.claude/CLAUDE.md` contains the mandatory
+> short rules; this document contains the evidence behind them.**
+>
+> Last evaluated: 2026-05-24, codegraph 3.10.0, against the live repo.
+> Evaluation method: every claim below was verified by running the tool, then
+> grep-searching or source-reading to confirm or refute the result.
+
+---
+
+## Why CodeGraph is partially unreliable for SuperBot
+
+SuperBot uses three import patterns that are invisible to CodeGraph's
+tree-sitter parser:
+
+1. **Function-body lazy imports** — `from services.X import Y` *inside* a
+   function or method body. The most common pattern in this codebase.
+2. **Module-alias calls** — `_lifecycle.request_shutdown()`,
+   `interaction_router.dispatch()`, `parsing.parse_message()`. The target
+   module is imported at the top but called via attribute access on the alias;
+   CodeGraph cannot resolve the call.
+3. **Discord decorator callbacks** — `@bot.event`, `@commands.command`,
+   `@commands.group`, `@app_commands.command`. These register methods as live
+   entry points through the Discord framework; CodeGraph sees no call edge.
+
+These are not edge cases. Every cog command handler, every bot event handler,
+every DB pool call (`pool.get().fetchrow(...)`), and large portions of the
+lifecycle, governance, and view layers rely on at least one of these patterns.
+
+Consequence: roughly **40–60 % of real call edges are absent from the graph**,
+and the `dead-unresolved` role label has a **~100 % false-positive rate** for
+functions called through any of these patterns.
 
 ---
 
 ## Activation checklist
 
-No global install is required. The MCP server starts via pinned `npx` on every Claude Code launch.
+No global install is required. The MCP server starts via pinned `npx` on every
+Claude Code launch.
 
 1. Verify the package resolves: `npx -y @optave/codegraph@3.10.0 --version`
-2. Build the index (first time or fresh clone): `npx -y @optave/codegraph@3.10.0 build .`
-3. Confirm the index: `npx -y @optave/codegraph@3.10.0 stats` — look for `Active engine: native`
-4. Inside Claude Code, confirm MCP tools are loaded by calling `mcp__codegraph__audit`, `mcp__codegraph__where`, or `mcp__codegraph__context`.
-5. Restart Claude Code only if this is the first session after the `.claude.json` change was pulled.
+2. Build the index (first time or fresh clone):
+   `npx -y @optave/codegraph@3.10.0 build .`
+3. Confirm the index: `npx -y @optave/codegraph@3.10.0 stats` — look for
+   `Active engine: native`
+4. Inside Claude Code, confirm MCP tools load by calling
+   `mcp__codegraph__where` on any known symbol.
 
-### Fresh-session quick-check
-
-```bash
-npx -y @optave/codegraph@3.10.0 --version
-npx -y @optave/codegraph@3.10.0 stats || npx -y @optave/codegraph@3.10.0 build .
-```
-
-Then inside Claude Code verify these MCP tools respond:
-- `mcp__codegraph__audit`
-- `mcp__codegraph__where`
-- `mcp__codegraph__context`
-
-> If MCP tools are available but the index is missing, run the `build` command above — a Claude restart is **not** needed.
-> If MCP tools are absent entirely, restart Claude Code (the `npx` startup is loaded once at session init).
+> If MCP tools are available but results are empty, the index is missing.
+> Run the `build` command — a Claude restart is **not** needed.
+> If MCP tools are absent entirely, restart Claude Code.
 
 ---
 
-## Known-good MCP tools
+## Trust matrix
 
-These tools are confirmed to produce accurate results (verified 2026-05-20, codegraph 3.10.0):
+### Tier 1 — Reliable: use freely, no mandatory verification
 
-| MCP tool name | CLI equivalent | Purpose |
+| Tool | What it does | Why it is reliable |
 |---|---|---|
-| `mcp__codegraph__where` | `npx -y @optave/codegraph@3.10.0 where <name>` | Find a symbol by name — returns kind, file, line, signature |
-| `mcp__codegraph__context` | `npx -y @optave/codegraph@3.10.0 context <name>` | Full source + direct callers + callees + signature |
-| `mcp__codegraph__fn_impact` | `npx -y @optave/codegraph@3.10.0 fn-impact <name>` | Blast-radius analysis — what breaks if this changes |
-| `mcp__codegraph__execution_flow` | `npx -y @optave/codegraph@3.10.0 flow <name>` | Forward execution trace (callees) |
-| `mcp__codegraph__query` | `npx -y @optave/codegraph@3.10.0 query <name>` | Dependency chain / shortest path between symbols |
-| `mcp__codegraph__audit` | `npx -y @optave/codegraph@3.10.0 audit <target>` | Per-function health metrics + impact |
-| `mcp__codegraph__complexity` | `npx -y @optave/codegraph@3.10.0 complexity <name>` | Cognitive / cyclomatic complexity |
-| `mcp__codegraph__list_functions` | `npx -y @optave/codegraph@3.10.0 brief <path>` | Symbols in a file or directory (see caveat on caller counts below) |
+| `mcp__codegraph__where` | Locate a symbol — file, line, kind, signature | Definition location is parsed directly from the AST; no edge traversal |
+| `mcp__codegraph__list_functions` | Enumerate all symbols in a file or path | Same — pure AST enumeration |
+| `mcp__codegraph__where` (file_mode=true) | List all symbols in a specific file | Accurate; ignore `imports`/`importedBy` fields (always empty) |
+| `mcp__codegraph__context` — source text | Read the source code of a function | Source extraction is reliable |
+| `mcp__codegraph__context` — signature | Read the function signature | Reliable |
+| `mcp__codegraph__complexity` | Cognitive, cyclomatic, nesting, MI per function | Pure AST metric; no edge data required |
+| `mcp__codegraph__check` (manifesto mode) | Complexity and nesting threshold violations | Reliable for function-level metrics; file-level thresholds are unconfigured so always pass |
+| `mcp__codegraph__triage` (`level=function`, `sort=complexity`) | Rank functions by complexity | Complexity signal is accurate; use for prioritisation |
+| `mcp__codegraph__audit` (function target) — source, complexity, health | Source text and metrics for a named function | Reliable for the same reasons as `context` and `complexity` |
 
-Note: `mcp__codegraph__diff_impact` (`npx -y @optave/codegraph@3.10.0 diff-impact`) is a valid CLI command but is
-**not in the `.claude/settings.json` allow list** and has not been verified via the MCP server.
-Add it to settings.json before relying on it.
+### Tier 2 — Hints only: use as a starting point, always grep-verify
 
----
+| Tool | What it returns | What it misses | Rule |
+|---|---|---|---|
+| `mcp__codegraph__fn_impact` (depth=1) | Direct callers — **lower bound only** | Lazy-import callers, aliased-import callers, `self.method()` calls | After getting the list, grep the full repo for the symbol name before acting |
+| `mcp__codegraph__context` — callers list | Same as fn_impact level 1 | Same | Same |
+| `mcp__codegraph__fn_impact` (depth > 1) | Transitive blast radius — lower bound | Cascades all the Level-1 misses | Use for relative ranking only; do not treat as complete |
+| `mcp__codegraph__audit` (function target) — callers/impact | Same as fn_impact | Same | Same |
+| `mcp__codegraph__triage` (`level=function`, `sort=risk`) | Risk-ranked list by fanIn + complexity | fanIn undercounts; churn is always 0 (no co-change pre-analysis) | Useful for hot-spot identification; ignore fanIn absolute value |
 
-## Known-bad / unreliable tool names
+### Tier 3 — Do not use: confirmed broken or requires unavailable pre-work
 
-Do not use these, or use only with the caveats noted:
-
-| Name | Problem |
+| Tool | Problem |
 |---|---|
-| `mcp__codegraph__module_map` | Returns 0 in/out edges for every file despite 22 000+ edges in the graph. Broken for connectivity analysis. |
-| `mcp__codegraph__brief` (caller counts) | The "caller" count shown is the **transitive** dependent total (same as `fn_impact` total), not direct distinct callers. Use `fn_impact` Level 1 or `context` for accurate direct-caller counts. |
-| `mcp__codegraph__file_deps` | Returns 0 imports and 0 imported-by for every file. File-level edge traversal is broken. Definitions section is accurate; import graph is not. |
-| `mcp__codegraph__impact_analysis` | Returns 0 file dependents. Same underlying file-edge issue as `file_deps` and `module_map`. Use `fn_impact` for function-level blast-radius instead. |
-| `mcp__codegraph__structure` | Per-file `<-0 ->0` connectivity is always zero. Symbol counts and line counts are accurate; connectivity data is not. |
-| `mcp__codegraph__semantic_search` | Requires `codegraph embed` to be run first. Returns an error without embeddings. Not usable in a fresh clone until embed is run. |
-| `mcp__codegraph__codegraph_status` | Does not exist. No tool in this server uses the `codegraph_` name prefix. |
-| `mcp__codegraph__codegraph_search` | Does not exist. Use `mcp__codegraph__where` or `mcp__codegraph__semantic_search`. |
-| `mcp__codegraph__codegraph_callers` | Does not exist. Use `mcp__codegraph__fn_impact` (Level 1) or `mcp__codegraph__context`. |
-| `mcp__codegraph__codegraph_callees` | Does not exist. Use `mcp__codegraph__execution_flow`. |
-| `mcp__codegraph__codegraph_impact` | Does not exist. Use `mcp__codegraph__fn_impact`. |
-| `mcp__codegraph__codegraph_node` | Does not exist. Use `mcp__codegraph__where` + `mcp__codegraph__context`. |
+| `mcp__codegraph__execution_flow` (list=true or forward trace) | Returns 0 entries regardless of target. Confirmed broken. |
+| `mcp__codegraph__find_cycles` | Always returns 0 cycles. File-level edge traversal is broken; no edges means no cycles detected. |
+| `mcp__codegraph__communities` | Always returns 0 communities, 0 modularity. Same root cause as find_cycles. |
+| `mcp__codegraph__co_changes` | Requires `codegraph co-change --analyze` pre-run. Returns 0 pairs without it. Not run in this repo. |
+| `mcp__codegraph__module_map` | Returns 0 in/out edges for every file. File-level connectivity is broken. |
+| `mcp__codegraph__file_deps` | Returns 0 imports and 0 imported-by for every file. |
+| `mcp__codegraph__impact_analysis` | Returns 0 file dependents. Same underlying broken file-edge issue. |
+| `mcp__codegraph__structure` (connectivity) | Per-file `<-0 ->0` always. Symbol counts and line counts are accurate; connectivity is not. |
+| `mcp__codegraph__triage` (`level=directory`) | fanIn and fanOut are always 0. Coupling is always 0. |
+| `mcp__codegraph__semantic_search` | Requires `codegraph embed` pre-run. Returns an error without embeddings. |
+| `mcp__codegraph__brief` (caller counts) | The count is the transitive total, not direct callers. Use `fn_impact` Level 1 instead. |
+| `mcp__codegraph__triage` (`role=dead`) | False-positive rate ~100 %. See dead-code section below. |
 
 ---
 
-## Rule: CodeGraph for exploration, source files for final truth
+## Dead code: do not trust `dead-unresolved`
 
-Use CodeGraph to orient yourself — find symbols, trace edges, understand blast
-radius. Before making any edit, confirm the exact content with `Read` on the
-target source file. If CodeGraph output conflicts with the source file, the
-source file is authoritative.
+The `dead-unresolved` role label marks symbols with 0 traceable callers. In
+this codebase, that label is almost always wrong because the patterns that call
+these functions are invisible to CodeGraph.
 
-### Python lazy-import limitation
+**Verified false positives — all marked `dead-unresolved`, all actively used:**
 
-CodeGraph cannot resolve call edges where the import happens inside a function
-body:
+| Symbol | File | Why it appears dead | How it is actually called |
+|---|---|---|---|
+| `validate_registry` | `utils/subsystem_registry.py:736` | Imported inside `main()` body | `bot1.py:689` function-body import |
+| `apply_operations` | `services/setup_operations.py:499` | Imported inside callback bodies | `views/setup/final_review.py:352, 398` function-body imports |
+| `parse_message` | `cogs/counting/parsing.py:37` | Called as `parsing.parse_message(...)` | `cogs/counting/handler.py:93` module-alias call |
+| `request_shutdown` | `core/runtime/lifecycle.py:191` | Called as `_lifecycle.request_shutdown(...)` | `bot1.py:93` module-alias call |
+| `dispatch` | `core/runtime/interaction_router.py:74` | Called via lazy import in `on_interaction` | `bot1.py:212` function-body import + module-alias call |
+| `resolve_execution` | `governance/execution.py:157` | Called as `governance_service.resolve_execution(...)` | `core/runtime/ui_permissions.py:38` |
+| `forget_guild_capabilities` | `governance/execution.py:92` | Lazy import in guild lifecycle | `guild_lifecycle.py:401` function-body import |
+| `forget_guild` | `governance/cache.py:108` | Lazy import in guild lifecycle | `guild_lifecycle.py:411` function-body import |
+| `BlackjackCog.blackjack` | `cogs/blackjack_cog.py:409` | `@commands.command` decorator invisible | Live Discord command |
+| `Cleanup.cleanup_history` | `cogs/cleanup_cog.py:188` | `@commands.command` decorator invisible | Live Discord command |
+| `Cleanup.remove_unwanted_message` | `cogs/cleanup_cog.py:107` | `@bot.listen` invisible | Live message event listener |
+| All `on_ready` handlers | Various cog files | `@bot.event` / Cog listener invisible | Discord gateway event |
+| `ChannelCog._resolve_channel` | `cogs/channel_cog.py:73` | `self.method()` calls not traced | Called as `self._resolve_channel(...)` 12 times within the class |
+
+**Rule: before claiming anything is dead or safe to remove:**
+1. `grep -rn "symbol_name\b" disbot/ --include="*.py"` — look for lazy imports and alias calls
+2. Check whether it has `@commands.command`, `@bot.event`, `@app_commands.command`, or `@tasks.loop`
+3. Check whether it is passed as a callback (signal handler, task spawn, event bus listener)
+4. If all three checks are clean AND it's not a test-only fixture, it *may* be unused — flag for human review before removing
+
+---
+
+## Name-collision false positives
+
+When two functions share the same short name across different modules or
+classes, CodeGraph merges their call graphs under that name.
+
+**Verified case: `_resolve_channel`**
+
+- `chain_cog.py:371` — module-level function `_resolve_channel(interaction, raw)`
+- `channel_cog.py:73` — class method `ChannelCog._resolve_channel(self, guild, query)`
+
+These are completely independent. `channel_cog.py` does not import from
+`chain_cog.py`. Yet CodeGraph's `fn_impact` for `chain_cog._resolve_channel`
+returned 14 callers: the real 3 in `chain_cog.py` plus 11 `self._resolve_channel`
+calls inside `ChannelCog` — a fabricated cross-cog dependency.
+
+**Rule: when callers appear in unexpected files:**
+1. Run `where(ClassName._resolve_channel)` — check if the unexpected file has
+   its own same-named symbol
+2. Read the actual call site in the flagged file to confirm whether it calls
+   the function you care about
+
+Other names at risk in this codebase: `get`, `setup`, `dispatch`, `build_embed`,
+`on_error`, `on_timeout`, `collect`, `clear`.
+
+---
+
+## Blind spots — full catalogue
+
+| Pattern | Example | CodeGraph result |
+|---|---|---|
+| Function-body lazy import | `from services.X import Y` inside a method | Y shows `dead-unresolved`, callers: [] |
+| Module-alias call | `_lifecycle.request_shutdown()` | request_shutdown shows callers: [] |
+| `self.method()` within class | `self._resolve_channel(...)` in ChannelCog | method shows dead-unresolved, uses: [] |
+| Import alias | `from views.base import handle_view_error as _on_view_error` | handle_view_error misses 4 of 5 real callers |
+| `@bot.event` decorator | `@bot.event async def on_ready()` | on_ready: dead-unresolved, callers: [] |
+| `@commands.command` decorator | `@commands.command(name="cleanup")` | method: dead-unresolved |
+| `@app_commands.command` decorator | `@app_commands.command(name="admin")` | method: dead-unresolved |
+| `@commands.group` subcommands | `@settings_root.command(name="access")` | method: dead-unresolved |
+| `signal.signal()` registration | `signal.signal(SIGTERM, _begin_shutdown)` | _begin_shutdown: callers: [] |
+| DB pool chain | `pool.get().fetchrow(...)` | fetchrow callee not traced |
+| Passed as callback | `tasks.spawn("name", coro)` | coro: callers: [] |
+| Optional import (try/except) | `try: from pythonjsonlogger import ...` | import not resolved |
+| Same-name collision | `_resolve_channel` in chain vs channel cog | inflated/merged caller graph |
+| `callees` of lazy-importing fn | Any fn that lazy-imports before calling | callees: [] |
+
+---
+
+## Mandatory verification checklist before editing code
+
+Before changing a function's signature, moving it, or removing it:
+
+- [ ] `grep -rn "function_name\b" disbot/ --include="*.py"` — find all uses
+- [ ] `grep -rn "module_name\.function_name" disbot/ --include="*.py"` — find module-alias calls
+- [ ] Check for import aliasing: `grep -rn "import function_name as"` and `grep -rn "from.*import.*function_name"`
+- [ ] Confirm no `@commands.command`, `@bot.event`, `@app_commands.command` decorators on the target
+- [ ] Read the function body — if it contains `from X import Y`, trace those callees manually
+- [ ] If CodeGraph reported unexpected callers in unrelated files, check for same-named symbols in those files
+
+---
+
+## When CodeGraph caller counts ARE reliable
+
+Caller counts from `fn_impact` / `context` are accurate when callers use
+**top-level module imports and call the function directly by name**:
 
 ```python
-async def _apply(...):
-    from services.setup_operations import apply_operations  # ← inside function
-    batch = await apply_operations(ops, guild=guild, actor=actor)
+# Top of module:
+from views.base import send_panel
+
+# Later in a command handler:
+await send_panel(ctx, embed=embed, view=view)
 ```
 
-Any function imported only via function-body imports will appear as
-`dead-unresolved` with 0 callers even if it is widely used. When you see
-`dead-unresolved`, grep for the symbol name to find its actual callers.
+`send_panel` was verified to have exactly 22 callers this way — all confirmed
+correct by source inspection. This is the pattern where CodeGraph is reliable.
 
-**Verified example**: `apply_operations` (setup_operations.py:215) is called
-from `views/setup/final_review.py:235` and `views/setup/sections/identity.py:160`
-but CodeGraph reports 0 callers because both call sites use function-body imports.
+The pattern fails when callers use:
+```python
+# Inside a function body (lazy):
+from services.setup_operations import apply_operations
+# OR via module alias:
+await interaction_router.dispatch(interaction)
+# OR via import alias:
+from views.base import handle_view_error as _on_view_error
+```
+
+---
+
+## Dry-run: safe CodeGraph workflow for a refactor
+
+**Goal:** Change the signature of `send_panel` in `views/base.py`.
+
+```
+Step 1 — Locate
+  mcp__codegraph__where("send_panel")
+  → views/base.py:23, kind=function  ✓
+
+Step 2 — Read source
+  mcp__codegraph__context("send_panel", depth=1, no_tests=True)
+  → Source: 19 lines. Takes (ctx, *, embed, view). Returns discord.Message.
+  → Callers: 22 methods listed.
+
+Step 3 — Grep-verify callers (MANDATORY)
+  grep -rn "send_panel(" disbot/ --include="*.py" | grep -v "test_"
+  → Returns 22 matches — matches CodeGraph exactly.
+  ✓ Caller list is complete in this case (all use top-level imports).
+
+Step 4 — Check for aliased imports
+  grep -rn "import send_panel as\|send_panel as " disbot/ --include="*.py"
+  → 0 results. No aliasing.
+
+Step 5 — Confirm callees by reading body
+  Source shows: ctx.send(embed=embed, view=view) + view.message = msg
+  → Callees are on Discord objects — not traceable by CodeGraph. Expected.
+
+Step 6 — Assess safety
+  All 22 callers use keyword args (embed=..., view=...).
+  Adding a keyword param with a default is safe.
+  Changing any existing param name or making a param required → list all 22
+  callers and stop for human review.
+
+Step 7 — Stop condition
+  If the change makes a param required AND callers span multiple cogs and
+  views → do not proceed without explicit approval. The blast radius is real.
+```
+
+---
+
+## Prompt snippet for future agents
+
+Paste this into any refactor-focused session prompt to enforce safe CodeGraph usage:
+
+```
+CodeGraph rules for this session:
+
+TRUSTED (use freely): mcp__codegraph__where, mcp__codegraph__list_functions,
+mcp__codegraph__context (source/signature only), mcp__codegraph__complexity,
+mcp__codegraph__check (manifesto), mcp__codegraph__triage (level=function, sort=complexity).
+
+HINTS ONLY (always grep-verify after): mcp__codegraph__fn_impact (depth=1),
+mcp__codegraph__context callers list.
+
+DO NOT USE: execution_flow, find_cycles, communities, co_changes, module_map,
+file_deps, impact_analysis, triage(level=directory), triage(role=dead).
+
+BEFORE any edit:
+1. grep -rn "symbol_name\b" disbot/ --include="*.py"
+2. Check for @commands.command / @bot.event / @app_commands.command decorators
+3. Check the function body for lazy imports (from X import Y inside the body)
+4. If callers appear in unexpected files, check those files for a same-named symbol
+
+dead-unresolved = CodeGraph limitation, NOT evidence the code is unused.
+Caller lists are lower bounds. Callee lists are empty when lazy imports are used.
+```
 
 ---
 
@@ -108,11 +293,15 @@ but CodeGraph reports 0 callers because both call sites use function-body import
 |---|---|
 | MCP tools unavailable and index present | Restart Claude Code — the `npx` MCP server is loaded once at session init |
 | MCP tools available but empty results | Index is missing. Run `npx -y @optave/codegraph@3.10.0 build .` — no restart needed |
-| "index not initialized" or empty results | `npx -y @optave/codegraph@3.10.0 build .` from the project root |
-| Stale index after editing files | `npx -y @optave/codegraph@3.10.0 build .` to rebuild, or run `npx -y @optave/codegraph@3.10.0 watch` for incremental updates |
-| `Active engine: wasm` in `codegraph stats` | Performance is degraded. Rebuild the native binding: ensure `node-gyp` prerequisites are installed, then `npm rebuild better-sqlite3` inside the codegraph package. |
-| `module_map` returns all zeros | Known bug for this codebase. Use `mcp__codegraph__fn_impact` or `mcp__codegraph__context` for function-level connectivity. |
-| `file_deps` shows 0 imports/imported-by | Known file-level edge bug. Use grep or `fn_impact`/`context` to trace cross-file references. |
-| `impact_analysis` returns 0 dependents | Same file-level edge bug as `file_deps`. Use `mcp__codegraph__fn_impact` for blast-radius. |
-| `semantic_search` returns "No embeddings found" | Run `npx -y @optave/codegraph@3.10.0 embed` from the project root. |
-| `brief` caller count seems too high | The count is the transitive total, not direct callers. Use `mcp__codegraph__fn_impact` Level 1 for direct callers. |
+| Stale index after editing files | `npx -y @optave/codegraph@3.10.0 build .` to rebuild |
+| `Active engine: wasm` in stats | Performance degraded. Rebuild the native binding (`npm rebuild better-sqlite3` inside the codegraph package). |
+| `execution_flow` returns 0 entries | Known broken — do not use. Use grep for forward tracing. |
+| `find_cycles` / `communities` return 0 | Known broken — file-level edges are broken in this index. Do not use. |
+| `co_changes` returns 0 pairs | Requires `codegraph co-change --analyze` pre-run. Not run in this repo. |
+| `module_map` returns all zeros | Known broken. Use `fn_impact` or `context` for function-level connectivity. |
+| `file_deps` shows 0 imports | Known broken. Use grep to trace cross-file references. |
+| `impact_analysis` returns 0 dependents | Known broken. Use `fn_impact` for blast-radius. |
+| `semantic_search` returns "No embeddings" | Run `npx -y @optave/codegraph@3.10.0 embed` first. |
+| `brief` caller count seems too high | Count is transitive total, not direct callers. Use `fn_impact` Level 1. |
+| Caller list misses known callers | Callers use lazy imports or module-alias calls — grep-verify always. |
+| Unexpected callers in unrelated files | Name-collision: check whether those files have a same-named function/method. |


### PR DESCRIPTION
## Summary

Expanded `docs/codegraph-usage.md` from a brief activation checklist into a comprehensive trust matrix and verification guide. Added detailed documentation of CodeGraph's limitations in this codebase, verified false positives, and mandatory verification workflows before code edits.

Updated `.claude/CLAUDE.md` to reference the full guide and enforce safe CodeGraph usage patterns.

## Key Changes

- **Trust matrix (Tier 1–3)**: Categorized all MCP tools by reliability with specific caveats for each
  - Tier 1 (reliable): `where`, `list_functions`, `context` (source/signature), `complexity`, `check`, `triage` (function-level)
  - Tier 2 (hints only): `fn_impact`, `context` (callers), requires grep-verification
  - Tier 3 (broken): `execution_flow`, `find_cycles`, `communities`, `co_changes`, `module_map`, `file_deps`, `impact_analysis`, `semantic_search`

- **Blind spots catalogue**: Documented three pervasive patterns invisible to CodeGraph's parser:
  - Function-body lazy imports (`from X import Y` inside method bodies)
  - Module-alias calls (`_lifecycle.request_shutdown()`)
  - Discord decorator callbacks (`@bot.event`, `@commands.command`, etc.)
  - Quantified impact: ~40–60% of real call edges are absent; `dead-unresolved` has ~100% false-positive rate

- **Dead code section**: Listed 13 verified false positives (all marked `dead-unresolved`, all actively used), with evidence of how each is actually called

- **Name-collision false positives**: Documented the `_resolve_channel` case where CodeGraph merged caller graphs across two independent functions in different cogs

- **Mandatory verification checklist**: Added pre-edit workflow (grep-verify, decorator checks, lazy-import tracing, same-name collision detection)

- **Dry-run example**: Provided step-by-step safe refactor workflow for `send_panel` showing when CodeGraph is reliable vs. when grep-verification is required

- **Prompt snippet**: Added copy-paste guidance for future agent sessions to enforce safe CodeGraph usage

- **Updated `.claude/CLAUDE.md`**: 
  - Added reference to full guide
  - Expanded "Use CodeGraph automatically" section with concrete situations
  - Elevated critical rules (dead-unresolved, caller lists, name collisions, decorators, callees) to non-negotiable status
  - Clarified which tools are reliable vs. hints-only vs. broken

## Notable Implementation Details

- All claims in the trust matrix were verified by running the tool and grep-searching or source-reading to confirm/refute results (evaluation date: 2026-05-24, codegraph 3.10.0)
- Documented the root cause of file-level edge breakage affecting `module_map`, `file_deps`, `impact_analysis`, `structure`, and `triage(level=directory)`
- Provided grep patterns for each blind spot to help agents work around CodeGraph limitations
- Emphasized that caller lists are lower bounds, not complete inventories, and that source files are authoritative

https://claude.ai/code/session_01Hmpa3jbnkDcZpgYFwcVCpy