### PR TITLE
docs: add binding contracts for helpers, navigation, and orientation

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,3 +1,30 @@
+<!-- READ_FIRST_START -->
+## Read first — agent orientation
+
+Before proposing or implementing **any** non-trivial change, open
+**`docs/AGENT_ORIENTATION.md`** and follow the "Reading order by
+task" section that matches what you are doing. It is short, points
+you at the binding contracts, and distinguishes them from the
+historical roadmap docs.
+
+Three binding docs underlie almost every decision in this codebase:
+
+1. **`docs/architecture.md`** — layering, invariants, decomposition rules.
+2. **`docs/ownership.md`** — which service / pipeline owns each table, event, and write.
+3. **`docs/runtime_contracts.md`** — lifecycle guarantees and failure modes.
+
+Two more bind common operations:
+
+- **`docs/repo-navigation-map.md`** — where things live; where new code goes.
+- **`docs/helper-policy.md`** — when to create / move / promote a helper. Read this **before** putting a function in `utils/`, `services/`, or `views/base.py`.
+
+When a doc and a source file disagree, the source file wins (see
+"Source files win" below). Documents are pinned to the registry where
+practical (`tests/unit/docs/`), but the layering rules are enforced
+by review, not by CI.
+
+<!-- READ_FIRST_END -->
+
 <!-- CODEGRAPH_START -->
 ## CodeGraph
 

--- a/docs/AGENT_ORIENTATION.md
+++ b/docs/AGENT_ORIENTATION.md
@@ -1,0 +1,226 @@
+# SuperBot — Agent Orientation (Read This First)
+
+> **Status:** binding (reference material, not implementation approval).
+> Future Claude / Codex / human contributors should read this page
+> before proposing or implementing changes. It is the only file in
+> `docs/` that exists to orient a brand-new session; everything else
+> is consumed on-demand once you know where to look.
+>
+> **Scope:** orientation only. This document does not define
+> architecture, ownership, or runtime contracts — it tells you which
+> existing documents do.
+
+---
+
+## Why this file exists
+
+SuperBot has 23 markdown files in `docs/` plus three ADRs plus seven
+sub-roadmap docs plus `.claude/CLAUDE.md`. A new agent that opens the
+folder and starts reading top-to-bottom will hit roadmap and audit
+material before reaching the binding contracts. This file fixes that
+by stating, up front:
+
+1. Which docs are **binding** (treat as authoritative).
+2. Which docs are **reference inventories** (consult per-task).
+3. Which docs are **historical plans** (read for context only — do
+   not treat as the current end-state).
+4. Which docs are **how-to-work-in-this-repo** material.
+
+If you only read three files before touching code, read:
+
+1. **`docs/architecture.md`** — layering, invariants, decomposition rules.
+2. **`docs/ownership.md`** — who owns which tables, services, events.
+3. **`docs/runtime_contracts.md`** — lifecycle guarantees + failure modes.
+
+If you are about to add, move, or extract a helper function, also
+read **`docs/helper-policy.md`** first.
+
+---
+
+## Reading order by task
+
+### Any task
+
+| Order | Doc | Why |
+|---|---|---|
+| 1 | `.claude/CLAUDE.md` | CodeGraph rules — what the static index can and cannot tell you about this codebase. Auto-loaded. |
+| 2 | `docs/codegraph-usage.md` | Full trust matrix behind the short CLAUDE.md rules. Skim once, refer back when CodeGraph surprises you. |
+| 3 | `docs/AGENT_ORIENTATION.md` (this file) | What to read next, based on what you are doing. |
+| 4 | `docs/repo-navigation-map.md` | Where things live in the tree. Use as a folder-to-purpose lookup. |
+
+### Adding a new subsystem / cog
+
+1. `docs/architecture.md` § "Where to add a new subsystem" + § "Subsystem decomposition" + § "PersistentView placement".
+2. `docs/ownership.md` § "Subsystem ownership" + § "Dependency direction".
+3. `docs/runtime_contracts.md` § 1 ("Subsystem identity contract") + § 3 ("PersistentView contract") + § 7 ("Managed task lifecycle").
+4. `docs/building-roadmap/command-integration-standard.md` — required panel / Help / settings wiring.
+5. `docs/building-roadmap/mother-hub-map.md` — where the new subsystem fits in the hub tree.
+6. `docs/helper-policy.md` — where to put any new helpers you write along the way.
+
+### Editing an existing cog
+
+1. `docs/repo-navigation-map.md` — find the cog's package, view package, service, DB module.
+2. `docs/ownership.md` — confirm which service/pipeline mutations must go through.
+3. `docs/help-command-surface-map.md` — confirm the cog's Help route and hub.
+4. `docs/runtime_contracts.md` § 6 (interaction lifecycle) + § 7 (managed tasks).
+5. Source files (always authoritative when in doubt).
+
+### Touching shared runtime / `core/runtime/*`
+
+1. `docs/architecture.md` § "Ownership boundary" + § "Single-process assumption" + § "State classification".
+2. `docs/runtime_contracts.md` (all sections).
+3. `docs/platform-consistency-ledger.md` § 1 (domain contract ledger).
+4. `docs/decisions/001-no-redis-backed-state.md` — before adding any "we should cache this in Redis" plan.
+
+### Touching governance / mutation pipelines
+
+1. `docs/ownership.md` § "Service ownership" + § "Direct DB writes — explicit blocklist".
+2. `docs/architecture.md` § "Runtime invariants (CI-enforced)" — INV-E, INV-F, INV-G are AST-checked.
+3. `docs/runtime_contracts.md` § 9 (mutation contract checklist).
+
+### Touching settings / bindings / resource provisioning
+
+1. `docs/settings-customization-roadmap.md` — the three lanes (settings / binding / provisioning) and which pipeline owns which.
+2. `docs/resource-provisioning-overview.md` — the RPM lane.
+3. `docs/platform-consistency-ledger.md` § 1 — current state of each domain.
+4. `docs/building-roadmap/config-input-standard.md` — UI rules for setting widgets.
+
+### Touching tests / docs / smoke
+
+1. `docs/smoke-test-checklist.md` — what must be smoked before a runtime-relevant PR ships. Pinned to `ReadinessSnapshot` by `tests/unit/docs/test_smoke_test_checklist.py`.
+2. `tests/unit/docs/` — every doc-pinning test. Adding or removing a doc that has a pinning test means the test changes too.
+
+### Touching AI / setup advisor
+
+1. `docs/ai-readiness-plan.md` — the inert scaffold + planned layer.
+2. `docs/ai-service-integration-map.md` — current setup advisor integration shape.
+3. `disbot/core/runtime/ai/README.md` — package-level intent.
+
+---
+
+## Document classification
+
+The taxonomy below is the only reliable way to tell "what does the
+project still care about?" from "what was the plan a year ago?". When
+in doubt, treat the source files as authoritative over any doc.
+
+### Binding (treat as authoritative)
+
+These define the platform contract. Changing them is an architecture
+change — open an issue or a separate doc-only PR before implementing
+something that conflicts with them.
+
+- `.claude/CLAUDE.md`
+- `docs/architecture.md`
+- `docs/ownership.md`
+- `docs/runtime_contracts.md`
+- `docs/codegraph-usage.md`
+- `docs/AGENT_ORIENTATION.md` (this file)
+- `docs/repo-navigation-map.md`
+- `docs/helper-policy.md`
+- `docs/decisions/*.md` (ADRs — immutable once landed)
+- `docs/server-logging.md` (shipped feature reference)
+- `docs/smoke-test-checklist.md` (pinned to code by doc-test)
+- `docs/help-command-surface-map.md` (pinned to code by doc-test)
+
+### Living inventories / status ledgers
+
+Updated as work lands. Always check the date / referenced PRs at the
+top before trusting the contents.
+
+- `docs/platform-consistency-ledger.md`
+- `docs/phase-2-completion-readiness.md`
+- `docs/settings-customization-command-map.md`
+- `docs/operator-settings-presets.md`
+- `docs/games-actionability-roadmap.md` (status: complete — historical now)
+
+### Standards / reference guides
+
+Read once when relevant. They describe how to do something, not what
+has already been done.
+
+- `docs/building-roadmap/command-integration-standard.md`
+- `docs/building-roadmap/hub-ui-standard.md`
+- `docs/building-roadmap/config-input-standard.md`
+- `docs/building-roadmap/mother-hub-map.md`
+- `docs/settings-customization-roadmap.md`
+- `docs/resource-provisioning-overview.md`
+
+### Plans / roadmaps (read for context only)
+
+These describe **planned** end-states. They do **not** describe what
+exists today. Do not implement against them as if they were specs —
+cross-check the source and the consistency ledger first.
+
+- `docs/roadmap_setup_platform.md`
+- `docs/loose-ends-audit-roadmap.md`
+- `docs/phase_2b_bindings_plan.md`
+- `docs/building-roadmap/interface-completion-roadmap.md`
+- `docs/building-roadmap/command-expansion-backlog.md`
+- `docs/building-roadmap/admin-powers-config-coverage.md`
+- `docs/ai-readiness-plan.md`
+- `docs/ai-readiness-pr-notes.md`
+- `docs/ai-service-integration-map.md`
+
+### Subsystem-specific scaffold notes
+
+- `disbot/core/runtime/ai/README.md`
+
+---
+
+## "Read first" mandate for agents
+
+Before proposing or implementing any non-trivial change:
+
+1. Open this file (`docs/AGENT_ORIENTATION.md`) and follow the
+   "Reading order by task" section that matches your work.
+2. Open the relevant binding doc(s) before editing the corresponding
+   code. Do not synthesize the contract from memory or from a roadmap.
+3. If you are about to put a function somewhere "general" (in
+   `utils/`, in `services/`, in `views/base.py`), open
+   `docs/helper-policy.md` first.
+4. If CodeGraph and a source file disagree, the **source file wins**
+   (`.claude/CLAUDE.md` § "Source files win"). Re-read the actual file
+   you are about to edit.
+
+This is not a courtesy — repeated rediscovery is the main reason
+SuperBot accumulates duplicate helpers and orphan plans. The minutes
+spent reading these docs pay back at PR review.
+
+---
+
+## What this document does **not** cover
+
+- Architecture. That is `docs/architecture.md`.
+- Ownership. That is `docs/ownership.md`.
+- Runtime guarantees. That is `docs/runtime_contracts.md`.
+- Helper rules. That is `docs/helper-policy.md`.
+- Where things live. That is `docs/repo-navigation-map.md`.
+- CodeGraph caveats. That is `.claude/CLAUDE.md` and
+  `docs/codegraph-usage.md`.
+
+If you have to choose between this file and any of the above for a
+given question, the specific doc wins.
+
+---
+
+## Updating this file
+
+This file is **orientation**, not architecture. Update it when:
+
+- A new binding doc lands → add it to the classification list.
+- An existing doc graduates from "plan" to "binding" → move it.
+- A binding doc is renamed or split → fix the path.
+- A new common task pattern emerges that needs its own reading order
+  → add a row to "Reading order by task".
+
+Do **not** update it for:
+
+- Phase progress (use `docs/phase-2-completion-readiness.md` or
+  the consistency ledger).
+- Specific PR notes (those belong in the PR description).
+- Long-form architecture rationale (those belong in
+  `docs/architecture.md` or an ADR).
+
+Keep this file short. If it grows past ~250 lines it has become a
+duplicate architecture doc and the additions belong elsewhere.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,6 +3,12 @@
 > **Status:** binding. This document defines the platform's layering
 > and dependency rules.  CI invariants (`tests/unit/invariants/`) +
 > ruff config enforce a subset; everything else is enforced by review.
+>
+> **Orientation:** new agent? Read `docs/AGENT_ORIENTATION.md` first
+> — it indexes the binding docs and distinguishes them from the
+> historical roadmap material. Looking for "where does this code
+> live"? See `docs/repo-navigation-map.md`. Adding or moving a
+> helper? See `docs/helper-policy.md`.
 
 SuperBot is a Discord-native application platform built on a single
 Python process running `discord.py` + `asyncpg`.  The codebase is

--- a/docs/helper-policy.md
+++ b/docs/helper-policy.md
@@ -1,0 +1,362 @@
+# SuperBot — Helper Discipline & Placement Policy
+
+> **Status:** binding. The rules below govern when a helper may exist,
+> where it must live, when it may be promoted, and what review must
+> precede every new helper. Companion to `docs/architecture.md`
+> (layering), `docs/ownership.md` (which service owns which write),
+> and `docs/repo-navigation-map.md` (where things live today).
+>
+> **Why this exists:** the codebase already shows three signs of
+> helper sprawl: `utils/helpers.py` is a grab-bag of unrelated
+> functions, `utils/embeds.py` ships embed builders that two cogs use
+> while every other cog builds embeds inline, and at least one
+> back-button factory was duplicated across five view modules before
+> `views/navigation.py` consolidated it. The rules here exist to stop
+> the next instance, not to relitigate the existing ones.
+
+---
+
+## 1. When you may create a helper
+
+Create a helper **only** when at least one of the following is true.
+If none apply, inline the logic.
+
+- **Reuse.** Two or more existing call sites would have identical (or
+  near-identical) logic. Two is the trigger; one is not.
+- **Single-responsibility clarity.** The helper has one obvious name,
+  one obvious return shape, and removes a meaningful chunk of
+  branching from the caller.
+- **Stable domain operation.** The helper encapsulates a primitive
+  the domain already names (e.g. "value the hand", "resolve the
+  cleanup channel", "format a duration"). The name comes from the
+  domain, not from "the code that happens to be here".
+- **Audited mutation seam.** The helper is the place INV-E / INV-F /
+  INV-G is enforced (governance, economy, XP). These are services,
+  not utilities; see § 3.
+- **Cross-cog coordination.** The helper is the seam through which
+  two cogs talk without importing each other (the EventBus or a
+  service — never a third cog).
+
+The bar for **moving** an existing helper is higher: even if reuse
+exists, do not move a helper unless the new location is one of the
+allowed ones in § 3 *and* the caller's understanding improves.
+
+---
+
+## 2. When you must **not** create a helper
+
+If any of the following is true, do not create the helper. Inline the
+logic or reuse what exists.
+
+- **One-line wrapper.** `def x(a): return f(a)` adds a name without
+  adding meaning.
+- **Hides control flow.** If the caller now reads `await
+  do_the_thing(ctx)` and there is no way to tell what `do_the_thing`
+  decides, defers, or sends, the helper is opaque.
+- **Mixes responsibilities.** Helpers that "log and also send and
+  also delete" have at least three callers' worth of edge cases
+  inside them. Split them or leave them inline.
+- **Makes a function look shorter.** Length is not a quality metric.
+  A 60-line function with one responsibility is fine.
+- **Duplicates an existing helper / service.** Search before adding.
+  The duplication rate in `utils/helpers.py`, `utils/embeds.py`, and
+  the back-button factories is high enough that "I will check later"
+  reliably becomes "I will not check".
+- **Bypasses a registry, pipeline, or owner.** If a helper writes
+  directly to a governed table, the helper is illegal regardless of
+  how convenient it is. Re-read `docs/ownership.md` § "Direct DB
+  writes — explicit blocklist".
+- **Captures cog-specific behaviour in a shared utility.** A
+  formatter that only the blackjack cog will ever call does not
+  belong in `utils/`. Put it in `cogs/blackjack/_helpers.py` or
+  `services/blackjack_engine.py`.
+- **Creates a parallel abstraction.** If `views/navigation.py`
+  exists, the next back-button helper goes there or stays inline.
+  Do not create `views/navigation_v2.py` or
+  `views/<subsystem>/back_buttons.py`.
+- **Permanentizes a temporary path.** Migration shims (e.g. a wrapper
+  that flips between legacy `guild_settings` and new `bindings`)
+  belong in `core/runtime/config_arbitration.py` and have a finite
+  life. Do not stamp them into `utils/`.
+
+---
+
+## 3. Where helpers belong
+
+Pick the **most local** category that fits. Promotion happens in one
+direction (local → shared); demotion does not happen, so an
+overpromoted helper sticks around forever.
+
+### 3.1 Inline (no helper)
+
+Default. Logic stays in the function that needs it until § 1's
+triggers fire.
+
+- **Where:** the calling function.
+- **Allowed dependencies:** anything the caller already imports.
+- **Promotion path:** § 3.2 once one of § 1's triggers fires.
+
+### 3.2 Subsystem-private function
+
+A private (`_underscored`) function in the same module as the caller,
+or a sibling module under the cog's package
+(`cogs/<name>/<topic>.py`).
+
+- **Where:** the cog's own file, or `cogs/<name>/<topic>.py` for
+  pure-domain logic (no Discord).
+- **Allowed dependencies:** the same surface the cog file already
+  uses. Pure-domain modules (`cogs/<name>/parsing.py`,
+  `cogs/<name>/state_machine.py`) **must not** import `discord`,
+  `views/*`, or other cogs.
+- **Forbidden dependencies:** other cogs (use EventBus or a service).
+- **Promotion path:** § 3.3 once a second function in the same cog
+  starts reusing it.
+
+### 3.3 Cog-local helper module
+
+`cogs/<name>/_helpers.py` (leading underscore signals "private to
+this subsystem"). Existing examples: `admin`, `blackjack`,
+`counting`, `diagnostic`, `economy`, `moderation`, `rps_tournament`,
+`setup`, `xp`.
+
+- **Where:** `disbot/cogs/<subsystem>/_helpers.py`.
+- **Allowed dependencies:** `utils/`, `services/`, `core/runtime/`,
+  `utils/db/` (read-side), `discord`. May import from other files in
+  the same subsystem package.
+- **Forbidden dependencies:** other cogs; other subsystems'
+  `_helpers.py`; `views/<other>/`.
+- **Promotion path:** § 3.4 once a second cog or `views/` package
+  needs the same helper.
+
+### 3.4 View-private helper
+
+`views/<subsystem>/_helpers.py` for UI-only shared logic within one
+subsystem's view package (currently used by `channels`, `roles`,
+`rps`).
+
+- **Where:** `disbot/views/<subsystem>/_helpers.py`.
+- **Allowed dependencies:** `discord`, `views/base.py`,
+  `views/navigation.py`, `services/`, `utils/`.
+- **Forbidden dependencies:** other cogs; `utils/db/` (writes go
+  through services).
+- **Promotion path:** § 3.5 if a second subsystem's views need the
+  same logic.
+
+### 3.5 Shared view primitive
+
+`views/base.py` (`BaseView`, `HubView`, `send_panel`,
+`handle_view_error`), `views/navigation.py` (back buttons,
+`BackTarget`), or `views/selectors/` (shared modal selectors).
+
+- **Where:** the existing files above. **Do not create a new
+  top-level view-helpers module** without an ADR — the codebase has
+  one canonical navigation module and adding a second is the kind of
+  duplication this policy exists to prevent.
+- **Allowed dependencies:** `discord`, `core/runtime/` for safe
+  interaction helpers.
+- **Forbidden dependencies:** `cogs/`, `services/` (callers pass
+  builders in as callables instead — see `views/navigation.py`).
+- **Promotion path:** none beyond this. If something graduates past
+  here, it has become a service.
+
+### 3.6 Service helper
+
+`services/<name>_service.py` (audited mutation) or
+`services/<name>_engine.py` / `services/<name>_catalogue.py` (pure
+domain). The service layer is the **only** legitimate writer of
+shared state — INV-E / INV-F / INV-G are AST-enforced.
+
+- **Where:** `disbot/services/`.
+- **Allowed dependencies:** `utils/db/*`, `core/events`, other
+  `services/`, `core/runtime/` (read primitives).
+- **Forbidden dependencies:** `cogs/`, `views/`, `discord` (services
+  are headless — they do not render UI). Audited mutation services
+  may accept Discord IDs but must not call Discord API methods.
+- **Promotion path:** none. A service is the terminal node.
+
+### 3.7 Runtime / lifecycle primitive
+
+`core/runtime/*` — sessions, panels, anchors, interaction router,
+EventBus consumers, tasks supervisor, navigation_stack,
+persistent_views registry, scope_locks, guild_config cache, identity
+contract validator, scheduler. These are **platform primitives** —
+they outlive every feature.
+
+- **Where:** add a new file under `disbot/core/runtime/` only if no
+  existing primitive owns the concern. Promoting a helper here is
+  almost always wrong unless the helper has become a primitive that
+  every subsystem depends on.
+- **Allowed dependencies:** `utils/db/*`, `core/events`,
+  `services/metrics` only (everything else in services is too
+  feature-aware to belong here).
+- **Forbidden dependencies:** `cogs/`, `services/*` other than
+  `metrics`, `views/`, `governance/` (governance uses runtime, not
+  the reverse).
+- **Promotion path:** none. This is the bottom.
+
+### 3.8 DB helper
+
+`utils/db/<feature>.py` — per-table CRUD. Every asyncpg call in the
+codebase happens here. The package re-exports symbols so the
+historical `from utils import db; db.func(...)` and
+`from utils.db import func` patterns both keep working.
+
+- **Where:** `disbot/utils/db/<feature>.py`. New tables get a new
+  file plus an entry in `utils/db/__init__.py`.
+- **Allowed dependencies:** `utils/db.pool`, `utils/db.codec`,
+  standard library.
+- **Forbidden dependencies:** anything outside `utils/` (see
+  `docs/ownership.md` § "Dependency direction").
+- **Promotion path:** none. DB helpers are leaves.
+
+### 3.9 Leaf utility
+
+`utils/<topic>.py` — pure helpers with no I/O (except `utils/db/`,
+which is the DB layer).
+
+- **Where:** the existing files: `cooldowns.py`, `channels.py`,
+  `visibility_rules.py`, `synonyms.py`, `tournaments.py`,
+  `ui_constants.py`, `hub_registry.py`, `subsystem_registry.py`.
+- **Allowed dependencies:** standard library, `discord` (no I/O —
+  type and constant use only), other `utils/` modules.
+- **Forbidden dependencies:** `cogs/`, `services/`,
+  `core/runtime/`, `views/`.
+- **Promotion path:** none.
+
+#### Special cases inside `utils/`
+
+- **`utils/helpers.py`** is a legacy grab-bag (currently five
+  unrelated public surfaces). **Do not add to it.** New leaf
+  helpers go in a dedicated topic file (`utils/<topic>.py`); new
+  cog-aware helpers go to § 3.3 instead.
+- **`utils/embeds.py`** has two consumers (`utility_cog`, `xp_cog`)
+  while every other cog builds embeds inline. **Do not invest in
+  it** — neither by extending nor by routing other cogs through it.
+  If embed-builder consolidation is ever the goal, it needs its own
+  PR with a clear migration plan, not opportunistic additions here.
+
+### 3.10 Test helper
+
+`tests/unit/<area>/conftest.py` (pytest fixtures) or
+`tests/unit/<area>/_helpers.py` for shared test scaffolding inside
+one area.
+
+- **Where:** test-tree only.
+- **Allowed dependencies:** anything the tests in that area use.
+- **Forbidden dependencies:** none from production source code into
+  test helpers.
+- **Promotion path:** none — test helpers stay in tests.
+
+---
+
+## 4. Promotion ladder
+
+Helpers move **one rung at a time**, only when evidence demands it.
+Skipping rungs ("this looks like it could be useful elsewhere") is
+how `utils/helpers.py` ended up the way it is.
+
+| Rung | Trigger to move up |
+|---|---|
+| 1. Inline | A second function in the **same file** wants the same logic. |
+| 2. Private function in the same file | A second file in the **same subsystem package** wants it. |
+| 3. `cogs/<name>/<topic>.py` (pure) **or** `cogs/<name>/_helpers.py` | A second subsystem **or** the corresponding `views/<name>/` package wants it. |
+| 4. `views/<subsystem>/_helpers.py` | A second `views/*` package wants the same UI primitive. |
+| 5. `views/base.py` / `views/navigation.py` / `views/selectors/` | The helper is a UI primitive that every subsystem could use. **Or** it is going the other way and becomes a service. |
+| 6. `services/<name>_*` | The helper carries state-mutation, audit, or cross-subsystem coordination. |
+| 7. `core/runtime/*` | The helper is a platform primitive that every subsystem depends on. (Promotion to here is rare and needs an ADR.) |
+
+**Evidence rule:** "needs" means an existing PR makes the second
+caller. Speculative promotion ("I think someone might use this
+later") is forbidden — it is how parallel abstractions appear.
+
+**Demotion:** if you find an overpromoted helper (e.g. a
+subsystem-specific function in `utils/`), do not relocate it during
+an unrelated PR. File it in the "Follow-up recommendations" section
+of a docs PR (or open an issue) so the move happens with intent.
+
+---
+
+## 5. Helper review checklist
+
+Run this before merging any PR that adds or moves a helper. CI does
+not check most of it; the safety net is review.
+
+- [ ] **Existing surface?** Did you grep for an existing helper /
+  service with the same name or shape? (`grep -rn "def
+  <name_or_synonym>" disbot/ --include="*.py"`)
+- [ ] **Name is domain-specific.** "format_money", not "format_str".
+  "resolve_cleanup_channel", not "get_channel".
+- [ ] **One responsibility.** A reviewer can describe the helper's
+  purpose in one sentence without using "and".
+- [ ] **Correct rung.** It is in the most local rung from § 3 that
+  still satisfies its callers. (If it is in `utils/`, can two
+  unrelated subsystems honestly use it?)
+- [ ] **Dependencies flow downward.** Imports stay within the
+  allowed-deps list for its rung (§ 3). No new cycles. No new lazy
+  function-body imports added to "make the rule work".
+- [ ] **Caller reads better.** Open the longest call site and check
+  that the helper makes the caller easier to read, not just shorter.
+- [ ] **Testable in isolation.** Pure-domain helpers have a unit
+  test in `tests/unit/<area>/`. UI helpers have a smoke or a
+  pinning test where one exists.
+- [ ] **Does not bypass ownership.** Never writes a governed table
+  outside its service. Never emits an uncatalogued event.
+- [ ] **Not a temporary path made permanent.** Migration shims live
+  in `core/runtime/config_arbitration.py` (or equivalent) and have
+  a documented removal trigger.
+- [ ] **No second navigation/router/registry created.** The
+  canonical ones are: `views/navigation.py` (back buttons),
+  `cogs/help/route.py` (Help resolver), `core/runtime/interaction_router.py`
+  (interaction dispatch), `utils/subsystem_registry.py`
+  (subsystem metadata), `utils/hub_registry.py` (hub presentation),
+  `core/runtime/persistent_views.py` (panel registry). If the
+  helper resembles any of these, it goes **in** them, not next to
+  them.
+- [ ] **No new `_v2` / `_new` / `_helpers2.py`.** Suffixed names
+  signal a parallel abstraction. Update the canonical surface
+  instead.
+
+---
+
+## 6. Quick reference — common mistakes to avoid
+
+| Anti-pattern | Why it is wrong | Do this instead |
+|---|---|---|
+| Adding a one-line helper to `utils/helpers.py` | Grows the grab-bag. | Inline it, or put it in a topic-named file (`utils/<topic>.py`) or the cog's `_helpers.py`. |
+| New back-button factory in a cog | Duplicates `views/navigation.py:attach_back_button`. | Call the canonical helper; pass a `parent_builder` callable. |
+| New `*_router.py` or `*_dispatch.py` in a cog | Bypasses `core/runtime/interaction_router.py`. | Register the prefix with the canonical router. |
+| New "settings cache" in a cog | Bypasses `core/runtime/guild_config`. | Use the canonical guild_config cache; emit invalidation on write. |
+| New `add_coins` / `set_coins` wrapper anywhere | Violates INV-F (AST-checked). | Call `services/economy_service` directly. |
+| New embed-builder file under `utils/` | Adds to the underused `utils/embeds.py` problem. | Build `discord.Embed` inline at the call site, or extend a single existing builder if the case already lives there. |
+| New "we'll need it for X later" helper | Speculative promotion. Never the right call. | Wait until X exists; then promote with evidence. |
+| Helper that imports a cog from a service | Reverses the dependency graph (§ "Dependency direction" in `docs/ownership.md`). | Emit a catalogued event; let the cog subscribe. |
+| Helper that does Discord I/O inside a `scope_locks.lock_for` block | Violates the V/M/A pattern. | Compute under the lock; apply outside it. |
+
+---
+
+## 7. When in doubt
+
+1. Re-read **`docs/ownership.md`** — most "where does this go?"
+   questions are answered by "which owner already owns this concern?"
+2. Re-read **`docs/architecture.md`** § "Subsystem decomposition" —
+   most helpers belong inside a subsystem package, not in `utils/`.
+3. If two owners both seem to qualify, the rule from
+   `docs/ownership.md` § "What to do when the boundary is unclear"
+   applies: extract a third (service) that mediates rather than
+   coupling the two.
+4. If the helper is genuinely new platform territory (does not fit
+   any existing rung), it is an architectural change. Write an ADR
+   under `docs/decisions/` before the implementation PR.
+
+---
+
+## 8. Updating this file
+
+This policy is binding. Change it by PR with reviewer signoff. When
+you change it:
+
+- If you tighten a rule, update existing references in `docs/architecture.md`
+  and `docs/repo-navigation-map.md` to match.
+- If you relax a rule, explain the relaxation in the commit body.
+- Do not extend this file into a "best practices" essay — every rule
+  must map to an actual pattern observed in this codebase.

--- a/docs/ownership.md
+++ b/docs/ownership.md
@@ -4,6 +4,12 @@
 > single owner that decides what is or isn't legal to do with it.
 > Touching state owned by another subsystem requires going through
 > that subsystem's service layer (or proposing a contract change).
+>
+> **Companions:** `docs/architecture.md` (layering + invariants),
+> `docs/runtime_contracts.md` (lifecycle guarantees),
+> `docs/helper-policy.md` (placement / promotion rules for any new
+> helper introduced while applying these ownership rules),
+> `docs/AGENT_ORIENTATION.md` (which doc to read for which task).
 
 ---
 

--- a/docs/repo-navigation-map.md
+++ b/docs/repo-navigation-map.md
@@ -1,0 +1,242 @@
+# SuperBot — Repo Navigation Map
+
+> **Status:** binding (reference material). Describes the current
+> layout of the bot tree, who owns which directory, and where to put
+> new code. Companion to `docs/architecture.md` (conceptual layering)
+> and `docs/ownership.md` (per-table / per-service ownership). This
+> file is **path-level** orientation; the other two are
+> **contract-level**.
+>
+> **How to use:** when you do not know which folder a piece of code
+> belongs in, find the row here that matches the responsibility and
+> follow the link. When a row says "see X for rules", do not put new
+> code there before reading X.
+
+---
+
+## Top-level tree
+
+```
+superbot/
+├── disbot/                  # Python source — everything that runs in production
+│   ├── bot1.py              # entry point; commands.Bot construction; cog loading
+│   ├── config.py            # env-loaded config + INITIAL_EXTENSIONS list
+│   ├── guild_lifecycle.py   # join/leave teardown, forget_guild fan-out
+│   ├── healthserver.py      # /health, /ready, /metrics HTTP probes
+│   ├── cogs/                # discord.py extensions — subsystem entry points
+│   ├── core/                # platform primitives (runtime, resources)
+│   ├── data/                # static JSON data (general_content.json, …)
+│   ├── governance/          # per-guild visibility/cleanup/capability engine
+│   ├── migrations/          # numbered .sql files; idempotent; advisory-locked
+│   ├── services/            # audited mutation paths + cross-subsystem logic
+│   ├── utils/               # leaf helpers + DB access + settings keys
+│   └── views/               # Discord UI: panels, modals, selectors, hubs
+├── docs/                    # reference docs — see AGENT_ORIENTATION.md
+├── tests/                   # pytest tree, mirrors disbot/ layout
+├── .claude/                 # Claude Code config (CLAUDE.md, settings.json)
+├── .codegraph/              # CodeGraph index (built artifact; not in git)
+├── .github/workflows/       # CI (one file: code-quality.yml)
+├── pyproject.toml           # black, isort, ruff, mypy, pytest config
+├── requirements.txt         # runtime deps
+└── Procfile                 # process declaration (deployment)
+```
+
+There is intentionally **no top-level README** — `docs/` is the
+documentation surface. There is intentionally **no `__init__.py`
+content in `disbot/` itself** — `core/`, `services/`, and `views/`
+have empty package inits; `cogs/__init__.py` carries the canonical
+subsystem-decomposition pointer; `governance/__init__.py` re-exports
+the public governance API; `utils/db/__init__.py` re-exports the DB
+layer.
+
+---
+
+## Where major systems live
+
+| Concern | Path | Owner notes |
+|---|---|---|
+| Process entry point | `disbot/bot1.py` | Cog loading, global checks, governance gate, signal handling, identity-contract validation. **Do not add subsystem logic here.** |
+| Static config | `disbot/config.py` | Env vars, `INITIAL_EXTENSIONS`, channel allow-lists. **Order of `INITIAL_EXTENSIONS` matters** (`bootstrap_access_cog` first — see comment). |
+| HTTP probes | `disbot/healthserver.py` | `/health`, `/ready`, `/metrics`. |
+| Guild lifecycle | `disbot/guild_lifecycle.py` | `teardown` fans `forget_guild` and `delete_for_guild` calls across every guild-keyed surface. **Every new guild-scoped cache or table must register here.** |
+| Cogs | `disbot/cogs/<name>_cog.py` (+ `disbot/cogs/<name>/`) | One file per subsystem entry; private domain logic in the sibling package. See `docs/architecture.md` § "Subsystem decomposition". |
+| Services (mutation) | `disbot/services/<name>_service.py` or `<name>_mutation.py` | Audited writers. See `docs/ownership.md` § "Service ownership". |
+| Pure-domain services | `disbot/services/blackjack_engine.py`, `disbot/services/cog_routing_profiles.py`, … | Stateless math / catalogue logic. May be called from cogs and other services. |
+| Platform runtime | `disbot/core/runtime/` | EventBus consumers, session_manager, panel_manager, interaction_router, navigation_stack, tasks supervisor, persistent_views, identity contract, etc. **Must not import cogs or services.** |
+| Resources runtime | `disbot/core/resources/` | Typed Discord-resource discovery / mutation / status. |
+| Governance | `disbot/governance/` | Visibility, cleanup, capability resolution + the `GovernanceMutationPipeline`. Strict internal layer order (see `governance/__init__.py` docstring). |
+| Database (CRUD) | `disbot/utils/db/<feature>.py` | All asyncpg use. Submodules are leaves of the dep graph. See `docs/ownership.md` § "Dependency direction". |
+| DB pool | `disbot/utils/db/pool.py` | The only place that opens an asyncpg pool. |
+| Migrations | `disbot/migrations/NNN_*.sql` | Idempotent; advisory-locked; run by `utils/db/migrations.py`. **Next free number is the highest existing + 1.** |
+| Settings keys | `disbot/utils/settings_keys/*.py` | Typed constants for `guild_settings` rows. |
+| Subsystem registry | `disbot/utils/subsystem_registry.py` | Single source of truth for subsystem metadata. Frozen after `validate_registry()`. |
+| Hub registry | `disbot/utils/hub_registry.py` | Mother-hub presentation metadata (Help category index). Display only — no business logic. |
+| UI views | `disbot/views/<subsystem>/` | Per-subsystem panels, modals, selectors. **Must not import other cogs.** |
+| Shared view primitives | `disbot/views/base.py` | `BaseView`, `HubView`, `send_panel`, `handle_view_error`. |
+| Shared navigation | `disbot/views/navigation.py` | `attach_back_button`, `BackTarget`. Canonical back-button helper. **No second navigation helper module.** |
+| Shared selectors | `disbot/views/selectors/` | Re-usable Discord selector primitives. |
+| Tests | `tests/unit/<area>/` | Mirrors the source tree. Doc-pin tests live in `tests/unit/docs/`. |
+| Architecture invariant tests | `tests/unit/invariants/` | INV-F, INV-G, INV-L AST checks. |
+| ADRs | `docs/decisions/NNN-*.md` | Architecture Decision Records. Immutable once landed. |
+
+---
+
+## Helper locations at a glance
+
+Helper rules live in `docs/helper-policy.md`. The map below is just
+"where do existing helpers live today?" so you can find prior art.
+
+### Currently in `disbot/utils/` (leaf helpers, no I/O except DB layer)
+
+| File | Contains | Notes |
+|---|---|---|
+| `utils/helpers.py` | `_parse_member`, `safe_select_emoji`, `post_log_embed`, `normalize_name`, `CogMenuView` | **Grab-bag — do not add new helpers here.** See `docs/helper-policy.md` for routing rules. |
+| `utils/embeds.py` | `success`, `error`, `info`, `warning`, `server_info_embed`, `user_info_embed` | Underused — most cogs build `discord.Embed` inline. Treat as legacy; do not promote into. |
+| `utils/channels.py` | `safe_channel_name`, `get_or_create_category`, `create_private_channel`, `cleanup_category` | Direct Discord channel manipulation. Prefer `services/resource_provisioning.py` for any **new** channel creation. |
+| `utils/cooldowns.py` | `check_cooldown`, `format_remaining` | Time-window math. Pure. |
+| `utils/visibility_rules.py` | tier helpers | Read-only governance helpers. |
+| `utils/synonyms.py` | `find_command` | Command-name fuzzy matching. |
+| `utils/tournaments.py` | tournament math | Pure helpers shared between RPS / blackjack tournament cogs. |
+| `utils/ui_constants.py` | color constants | UI palette. |
+| `utils/hub_registry.py` | `HubEntry`, `HUBS` | Mother-hub presentation metadata. |
+| `utils/subsystem_registry.py` | `SUBSYSTEMS`, validators | The canonical subsystem manifest. |
+| `utils/guild_config_accessors.py` | typed read accessors | Guild config read surface (over `core.runtime.guild_config`). |
+| `utils/user_config_accessors.py` | typed read accessors | Per-user / participation read surface. |
+| `utils/db/<feature>.py` | per-table CRUD | The only place asyncpg lives. |
+| `utils/settings_keys/*.py` | typed key constants | One file per subsystem. |
+
+### Subsystem-private helpers (`disbot/cogs/<name>/_helpers.py`)
+
+Used today by: `admin`, `blackjack` (split into `_persistence.py`,
+`_state.py`, `actions.py`, `schemas.py`), `counting`
+(`_constants.py`, `_stage.py`, `game_logic.py`, `handler.py`,
+`parsing.py`), `diagnostic`, `economy`, `moderation`,
+`rps_tournament`, `setup`, `xp`. The leading underscore signals
+"private to this subsystem" — do not import these from another
+subsystem.
+
+### View-private helpers (`disbot/views/<name>/_helpers.py`)
+
+Used today by: `views/channels/`, `views/roles/`, `views/rps/`. Same
+underscore convention.
+
+### Shared view primitives
+
+- `disbot/views/base.py` — `BaseView`, `HubView`, `send_panel`,
+  `handle_view_error`. Imported by ~73 files.
+- `disbot/views/navigation.py` — back-button helper +
+  `BackTarget`. Canonical. **Do not create a parallel
+  navigation module.**
+- `disbot/views/selectors/` — shared modal selectors.
+
+### Help / routing helpers
+
+- `disbot/cogs/help/route.py` — `HelpRoute`, `HelpOpener`,
+  `resolve_route`, `open_route`. The shared resolver behind typed
+  `!help <category>` and the Help dropdown. **No second resolver.**
+
+---
+
+## Where to put new code
+
+Match the row in the table; if no row matches, the request likely
+crosses a layer boundary and needs a contract decision (open an ADR
+or read `docs/architecture.md` § "Ownership boundary" again).
+
+| You want to add… | Put it in… | Mandatory references |
+|---|---|---|
+| A new Discord command for an existing cog | The cog file (or its sibling package if the cog is decomposed) | `docs/architecture.md` § "Subsystem decomposition"; `docs/building-roadmap/command-integration-standard.md` |
+| A new subsystem | `disbot/cogs/<name>_cog.py` + `disbot/cogs/<name>/` + (if UI) `disbot/views/<name>/` | `docs/architecture.md` § "Where to add a new subsystem"; `docs/building-roadmap/mother-hub-map.md` |
+| A new persistent panel (re-attached on restart) | A `PersistentView` subclass in the cog file (Pattern A) or `views/<name>/main_panel.py` (Pattern B) | `docs/architecture.md` § "PersistentView placement"; `docs/runtime_contracts.md` § 3 |
+| A new modal / selector / child panel | `disbot/views/<subsystem>/` | `disbot/views/base.py` for `BaseView`; `disbot/views/navigation.py` for back buttons |
+| A pure-domain rule / scoring function | `disbot/cogs/<name>/<topic>.py` (subsystem-local) or `disbot/services/<name>_engine.py` (shared) | `docs/architecture.md` § "Subsystem decomposition" step 1–2 |
+| A new audited mutation | New method on the existing `services/<name>_service.py` or `<name>_mutation.py`, or a new service if no owner exists | `docs/ownership.md` § "Service ownership"; `docs/runtime_contracts.md` § 9 |
+| A new DB table | `disbot/migrations/NNN_<name>.sql` (next free number) + new file in `disbot/utils/db/<name>.py` + register a `delete_for_guild` hook in `disbot/guild_lifecycle.py` if guild-keyed | `docs/architecture.md` INV-I; `docs/platform-consistency-ledger.md` § 3 |
+| A new EventBus event | Add literal to `disbot/core/events_catalogue.KNOWN_EVENTS`; document in `docs/ownership.md` § "Event ownership"; emit from a service (never a cog) | `docs/architecture.md` INV-A; `docs/runtime_contracts.md` § 2 |
+| A new background task | `core.runtime.tasks.spawn(name, coro)` | `docs/architecture.md` INV-K; `docs/runtime_contracts.md` § 7 |
+| A new platform diagnostic | Register a provider in `services/diagnostics_service.py`; surface via `!platform <subcommand>` | `docs/platform-consistency-ledger.md` § 1 "Diagnostics"; `docs/smoke-test-checklist.md` |
+| A new setting key | `disbot/utils/settings_keys/<subsystem>.py`; declare a `SettingSpec` in the cog or its service; write via `SettingsMutationPipeline` | `docs/settings-customization-roadmap.md`; `docs/building-roadmap/config-input-standard.md` |
+| A new binding (Discord resource pointer) | Declare a `BindingSpec`; write via `BindingMutationPipeline`; never store IDs in `SettingSpec` | `docs/settings-customization-roadmap.md` § "Ownership invariants" |
+| A new resource creation flow | Use `services/resource_provisioning.py` (`ResourceProvisioningPipeline`) | `docs/resource-provisioning-overview.md` |
+| A new governance write | Use `governance/writes.py:GovernanceMutationPipeline` | `docs/ownership.md` INV-E |
+| A new helper (any kind) | Read `docs/helper-policy.md` **first**. The default answer is "inline it" or "put it in the cog's own package". | `docs/helper-policy.md` |
+
+---
+
+## Where to look when something breaks
+
+This duplicates `docs/runtime_contracts.md` § 11, but is reproduced
+here as the navigation entry-point. The canonical table lives there.
+
+| Symptom | First file | Most likely owner |
+|---|---|---|
+| "Interaction Failed" UX error | `core/runtime/interaction_router.py` | missing `safe_defer`, missing handler registration |
+| Panel buttons unresponsive | `core/runtime/persistent_views.py` + `core/runtime/message_anchor_manager.py` | cog failed to load, view subsystem renamed |
+| Help category shows commands that don't run | `utils/subsystem_registry.py:validate_identity_contract` + `!platform identity` | identity-contract drift |
+| Balance "lost" coins | `services/economy_service.py` + `economy_audit_log` table | overdraft path; missing debit reason |
+| Tournament didn't pay out | `services/economy_service.py` filtered on `tournament:*` reasons | service exception silenced |
+| Bot eats CPU | `core/runtime/tasks.py` + `task_outcome_total` metric | runaway `tasks.spawn` loop |
+| Migrations stuck | `utils/db/migrations.py` + `pg_stat_activity` | concurrent deploy holding the advisory lock |
+| Boot aborts with `entry_point_missing_command` | `utils/subsystem_registry.py` + the cog that failed to load | identity-contract STRICT mode caught a real regression (see `docs/runtime_contracts.md` § 12) |
+
+---
+
+## Subsystem cheat sheet (cog → owning paths)
+
+A condensed version of `docs/help-command-surface-map.md` and
+`docs/ownership.md`. The full inventory lives in those files.
+
+| Subsystem | Cog file | View package | Service / mutation path | DB module |
+|---|---|---|---|---|
+| admin | `cogs/admin_cog.py` (+ `cogs/admin/`) | — | n/a (uses governance) | n/a |
+| blackjack | `cogs/blackjack_cog.py` (+ `cogs/blackjack/`) | `views/blackjack/` | `services/economy_service.py` (coins); `services/blackjack_engine.py` (math) | n/a |
+| channel | `cogs/channel_cog.py` | `views/channels/` | `governance/writes.py` | n/a |
+| chain | `cogs/chain_cog.py` | — | direct CRUD | `utils/db/games/chain.py` |
+| cleanup | `cogs/cleanup_cog.py` (+ `cogs/cleanup/`) | — | direct CRUD | `utils/db/moderation.py` |
+| community | `cogs/community_cog.py` | `views/community/` | n/a (hub) | n/a |
+| counting | `cogs/counting_cog.py` (+ `cogs/counting/`) | `views/counting/` | direct CRUD | `utils/db/games/counting.py` |
+| deathmatch | `cogs/deathmatch_cog.py` (+ `cogs/deathmatch/`) | — | direct CRUD | `utils/db/games/deathmatch.py` |
+| diagnostic | `cogs/diagnostic_cog.py` (+ `cogs/diagnostic/`) | `views/diagnostic/` | `services/diagnostics_service.py` (read-only providers) | n/a |
+| economy | `cogs/economy_cog.py` (+ `cogs/economy/`) | `views/economy/` | `services/economy_service.py` | `utils/db/economy.py` |
+| general | `cogs/general_cog.py` | — | reads `data/json/general_content.json` | n/a |
+| help | `cogs/help_cog.py` (+ `cogs/help/`) | — | `cogs/help/route.py` (resolver) | n/a |
+| inventory | `cogs/inventory_cog.py` | — | direct CRUD | `utils/db/inventory.py` |
+| leaderboard | `cogs/leaderboard_cog.py` | — | read-only | reads multiple |
+| logging | `cogs/logging_cog.py` (+ `cogs/logging/`) | — | `services/server_logging.py` | `utils/db/settings.py` |
+| mining | `cogs/mining_cog.py` (+ `cogs/mining/`) | `views/mining/` | direct CRUD | `utils/db/games/mining.py` |
+| moderation | `cogs/moderation_cog.py` (+ `cogs/moderation/`) | `views/moderation/` | `services/moderation_service.py` | `utils/db/moderation.py` |
+| proof_channel | `cogs/proof_channel_cog.py` | — | `services/economy_service.py` (coins) | n/a |
+| role | `cogs/role_cog.py` | `views/roles/` | direct CRUD | `utils/db/roles.py` |
+| rps_tournament | `cogs/rps_tournament_cog.py` (+ `cogs/rps_tournament/`) | `views/rps/` | direct CRUD + `economy_service` | `utils/db/games/rps.py` |
+| settings | `cogs/settings_cog.py` (+ `cogs/settings/`) | `views/settings/` | `services/settings_mutation.py` | `utils/db/settings.py` |
+| setup | `cogs/setup_cog.py` (+ `cogs/setup/`) | `views/setup/` | `services/setup_operations.py` (+ companion services) | `utils/db/setup_session.py`, `utils/db/setup_draft.py` |
+| utility | `cogs/utility_cog.py` | — | n/a | n/a |
+| xp | `cogs/xp_cog.py` (+ `cogs/xp/`) | `views/xp/` | `services/xp_service.py` | `utils/db/xp.py` |
+
+When this table and `docs/help-command-surface-map.md` disagree, the
+latter is authoritative (it is pinned to the registry by
+`tests/unit/docs/test_help_surface_map_doc.py`).
+
+---
+
+## Updating this file
+
+Update this map when:
+
+- A new top-level directory appears under `disbot/`.
+- A subsystem is added, removed, or split.
+- A helper category that did not exist is created (e.g. a new
+  `services/` companion package).
+- A "where to put new code" row becomes wrong because the canonical
+  pipeline / location moved.
+
+Do **not** update it for:
+
+- New individual files inside an existing package.
+- New subsystem-private helpers (those follow the helper policy and
+  do not need a path-level callout).
+- New commands within an existing cog.
+
+If you find this file disagrees with reality, fix it in the same PR
+that changes reality. There is no doc-pin test for this map; staleness
+is the main risk.


### PR DESCRIPTION
## Summary

Adds three new binding documentation files that establish clear rules for helper creation, placement, and promotion; provide a complete repository navigation map; and orient new agents on which documents are authoritative before touching code.

## Key changes

- **`docs/helper-policy.md`** (362 lines): Binding policy governing when helpers may exist, where they must live, promotion rules, and a review checklist. Addresses observed helper sprawl in `utils/helpers.py`, `utils/embeds.py`, and duplicated back-button factories. Establishes a 10-rung promotion ladder (inline → private function → subsystem-private → cog-local → view-private → shared view → service → runtime → DB → leaf utility) with evidence-based triggers for each promotion.

- **`docs/repo-navigation-map.md`** (242 lines): Binding reference material mapping the current repository layout, ownership by directory, and where new code belongs. Includes a top-level tree, major systems table, helper locations inventory, and a "where to put new code" decision table keyed to responsibility. Companion to architecture and ownership docs.

- **`docs/AGENT_ORIENTATION.md`** (226 lines): Binding orientation document for new agents. Classifies all 23+ docs into four categories (binding, living inventories, standards, plans) and provides task-specific reading orders. Establishes that `docs/architecture.md`, `docs/ownership.md`, and `docs/runtime_contracts.md` are the three foundational binding contracts, with `docs/helper-policy.md` and `docs/repo-navigation-map.md` as secondary bindings for common operations.

- **`.claude/CLAUDE.md`** (modified): Adds a "Read first" section at the top (before CodeGraph rules) that points agents to `docs/AGENT_ORIENTATION.md` and lists the five binding documents with one-line summaries. Emphasizes that source files win when docs and code disagree.

- **`docs/architecture.md`** (modified): Adds orientation pointer to `docs/AGENT_ORIENTATION.md` in the status block.

- **`docs/ownership.md`** (modified): Adds companion pointers to `docs/architecture.md`, `docs/runtime_contracts.md`, and `docs/repo-navigation-map.md` in the status block.

## Notable implementation details

- Helper policy establishes a **single evidence rule**: "needs" means an existing PR makes the second caller. Speculative promotion is forbidden.
- Demotion is explicitly not allowed — overpromoted helpers are documented in follow-up issues rather than moved during unrelated PRs.
- The promotion ladder is asymmetric: helpers move up one rung at a time when evidence demands it; they never move down.
- Navigation map includes a "where to look when something breaks" table keyed to symptoms (e.g., "Interaction Failed" → `core/runtime/interaction_router.py`).
- Orientation doc distinguishes **binding** (architecture, ownership, runtime contracts, helper policy, navigation, decisions) from **living inventories** (consistency ledger, phase readiness) from **plans** (roadmaps, not current end-state).
- All three new docs are marked `Status: binding` and are intended to be pinned to code via doc-test assertions where practical.

https://claude.ai/code/session_01DyrdVjguem4716HYVQj2oj