### PR TITLE
test(bootstrap-access): cover bypass matrix for non-owner operators

### DIFF
--- a/tests/unit/cogs/test_bootstrap_access_cog.py
+++ b/tests/unit/cogs/test_bootstrap_access_cog.py
@@ -186,6 +186,51 @@ async def test_channel_guard_allows_guild_owner_for_bootstrap_command(monkeypatc
     assert await cog._channel_guard(ctx) is True
 
 
+async def test_channel_guard_allows_administrator_for_bootstrap_command(monkeypatch):
+    monkeypatch.setattr(config, "ALLOWED_CHANNELS", set())
+    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
+    ctx = _ctx(
+        channel_id=999,
+        command_name="setup",
+        author_id=99,
+        owner_id=42,
+        administrator=True,
+    )
+
+    assert await cog._channel_guard(ctx) is True
+
+
+async def test_channel_guard_allows_manage_guild_for_bootstrap_command(monkeypatch):
+    monkeypatch.setattr(config, "ALLOWED_CHANNELS", set())
+    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
+    ctx = _ctx(
+        channel_id=999,
+        command_name="setup",
+        author_id=99,
+        owner_id=42,
+        manage_guild=True,
+    )
+
+    assert await cog._channel_guard(ctx) is True
+
+
+async def test_channel_guard_allows_bot_owner_for_bootstrap_command(monkeypatch):
+    monkeypatch.setattr(config, "ALLOWED_CHANNELS", set())
+    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
+    ctx = _ctx(channel_id=999, command_name="setup", author_id=99, owner_id=42)
+    ctx.bot.is_owner = AsyncMock(return_value=True)
+
+    assert await cog._channel_guard(ctx) is True
+
+
+async def test_channel_guard_denies_non_operator_for_bootstrap_command(monkeypatch):
+    monkeypatch.setattr(config, "ALLOWED_CHANNELS", set())
+    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
+    ctx = _ctx(channel_id=999, command_name="setup", author_id=99, owner_id=42)
+
+    assert await cog._channel_guard(ctx) is False
+
+
 async def test_channel_guard_denies_normal_command_outside_allowed_channels(monkeypatch):
     monkeypatch.setattr(config, "ALLOWED_CHANNELS", set())
     cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))


### PR DESCRIPTION
## Summary

- Adds 4 targeted tests to `tests/unit/cogs/test_bootstrap_access_cog.py` covering the bootstrap-command bypass matrix for non-owner operators:
  - Administrator permission → allow
  - `manage_guild` permission → allow
  - bot owner (`bot.is_owner`) → allow
  - non-operator → deny
- The existing channel-guard tests only exercised the guild-owner bypass path; the other three bypass branches in `core.runtime.command_access.can_bypass_channel_guard` and the negative case were only covered implicitly. These new tests pin the matrix so future changes to the bypass logic surface as explicit failures.

## Test plan

- [x] `pytest tests/unit/cogs/test_bootstrap_access_cog.py -v` — 20/20 pass (16 existing + 4 new).
- [x] No changes under `disbot/`; mypy / ruff / black / isort scope unchanged.
- [ ] CI green on PR.

https://claude.ai/code/session_016Dhk72MEA2gtS3NFvVRe4q

---
_Generated by [Claude Code](https://claude.ai/code/session_016Dhk72MEA2gtS3NFvVRe4q)_