### PR TITLE
docs(ownership): carve out the internal-bypass audit-write exception

### DIFF
--- a/docs/ownership.md
+++ b/docs/ownership.md
@@ -162,10 +162,52 @@ These calls are **forbidden** outside their owning module:
 | Raw SQL `UPDATE xp ... coins` / `INSERT INTO xp (..., coins ...)` | `services/economy_service.py` + `utils/db/economy.py` | every other production file. |
 | `db.set_subsystem_visibility` / raw writes to `subsystem_visibility` | `GovernanceMutationPipeline` | every cog, every other service. |
 | `db.set_cleanup_policy` / raw writes to `cleanup_policies` | `GovernanceMutationPipeline` | every cog, every other service. |
-| `db.write_governance_audit` | `GovernanceMutationPipeline` | direct write only inside the pipeline. |
+| `db.write_governance_audit` | `GovernanceMutationPipeline` + `governance/execution._audit_internal_bypass` | every other module.  See "Audit-write carve-out" below. |
 
-The first row is enforced by INV-F (AST test).  Add to that test
-when introducing future forbid-lists.
+The first two row-pairs are enforced by INV-F (AST test) for economy
+and INV-E (`test_apply_template_uses_pipeline`) for visibility /
+cleanup pipeline writes.  Add to those tests when introducing future
+forbid-lists.
+
+### Audit-write carve-out
+
+`db.write_governance_audit` has **one** allowed caller outside the
+pipeline: `governance.execution._audit_internal_bypass`
+(`disbot/governance/execution.py:111`), invoked from
+`resolve_execution()` only when `check_visibility=False`
+(`disbot/governance/execution.py:249` — the internal / AI-triggered
+bypass path).
+
+Why it exists:
+
+- Internal bypasses skip the visibility gate, so the only in-memory
+  record is the `EVT_EXECUTION_ALLOWED` event with `bypass: True`.
+  A durable row in `governance_audit_log` keeps the bypass
+  reconstructable from the DB alone (DEBT-002 — required before
+  AI / plugin expansion).
+- The write is **append-only** and matches the same audit-row shape
+  the pipeline emits.  No governed state (`subsystem_visibility`,
+  `cleanup_policies`, `capability_execution_overrides`) is mutated.
+- The call is **best-effort**: failures are logged at WARNING and
+  swallowed, so a broken audit write cannot block the legitimate
+  execution that the bypass already authorised.
+
+Why it isn't routed through the pipeline:
+
+- The pipeline owns visibility / cleanup / override mutations, all of
+  which take templates and emit `governance.*.changed` events.  An
+  internal-bypass audit row is a **fact**, not a mutation — there is
+  no template to validate, no cache to invalidate, no consumer event
+  to emit beyond the `EVT_EXECUTION_ALLOWED` already fired by
+  `resolve_execution`.  Forcing it through the pipeline would mean
+  inventing a synthetic mutation just to write the row.
+
+If a second non-pipeline caller appears, **promote the
+`_audit_internal_bypass` helper** (move it next to the pipeline, give
+it a public name, document the new caller here) rather than scattering
+direct `db.write_governance_audit` calls across the codebase.  INV-E
+does not currently AST-scan `write_governance_audit`; if you tighten
+it later, exempt this one file by path.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds an "Audit-write carve-out" section to `docs/ownership.md` and updates the blocklist row for `db.write_governance_audit`.
- Documents the single allowed caller outside the pipeline: `governance.execution._audit_internal_bypass` (`disbot/governance/execution.py:111`), invoked from `resolve_execution()` at `disbot/governance/execution.py:249` only when `check_visibility=False` (AI / internal bypass path).
- Explains why the call is allowed (append-only fact row, no governed-state mutation, best-effort with swallowed errors, DEBT-002), why it isn't routed through the pipeline (no template, no cache invalidation, no consumer event beyond `EVT_EXECUTION_ALLOWED` already fired), and the rule for any future second caller (promote the helper, don't scatter direct writes).
- Notes that INV-E does not currently AST-scan `write_governance_audit`; if it's tightened later, exempt that one file by path.

No code changes. Audit was done as part of the plan in `current-state-verification-lively-cocke.md`: of the symbols listed in the blocklist, INV-F (economy) and INV-G (XP) are CI-enforced and clean, INV-E (visibility/cleanup) is enforced for visibility/cleanup, and the one outside-pipeline call to `write_governance_audit` is the documented exception this PR names.

## Test plan

- [x] Read `disbot/governance/execution.py` to confirm line numbers (`_audit_internal_bypass` at `:111`, call site at `:249`).
- [x] `grep -rn "write_governance_audit" docs/` — only `docs/ownership.md` references it, no other doc needs updating.
- [x] No code under `disbot/` or `tests/` modified; pytest/mypy/ruff/black/isort all unaffected.

https://claude.ai/code/session_016Dhk72MEA2gtS3NFvVRe4q

---
_Generated by [Claude Code](https://claude.ai/code/session_016Dhk72MEA2gtS3NFvVRe4q)_