### PR TITLE
fix(work-panel): defer before I/O in _JobSelect.callback

### DIFF
--- a/disbot/views/economy/work_panel.py
+++ b/disbot/views/economy/work_panel.py
@@ -20,6 +20,7 @@ import time
 import discord
 
 from cogs.economy._helpers import _WORK_COOLDOWN, JOBS, _build_economy_embed, _job_pay
+from core.runtime.interaction_helpers import safe_defer, safe_edit, safe_followup
 from services import economy_service, xp_service
 from utils import db
 from utils.cooldowns import check_cooldown, format_remaining
@@ -88,10 +89,18 @@ class _JobSelect(discord.ui.Select):
         uid, gid = self._user_id, self._guild_id
         now = int(time.time())
 
+        # Defer before any I/O: this handler does 4 DB ops + 2 service
+        # calls (credit, award) + a webhook post before the final edit.
+        # The cumulative work blows past the 3s interaction-token window
+        # on a normal day.
+        if not await safe_defer(interaction):
+            return
+
         eco = await db.get_economy(uid, gid)
         on_cd, secs = check_cooldown(eco["last_worked"], _WORK_COOLDOWN)
         if on_cd:
-            await interaction.response.send_message(
+            await safe_followup(
+                interaction,
                 f"⏰ Still on cooldown! {format_remaining(secs)} left.",
                 ephemeral=True,
             )
@@ -147,7 +156,7 @@ class _JobSelect(discord.ui.Select):
         # disabled every child on ``_work_view`` (including Back),
         # leaving the user on a dead-end result screen.
         result_view = _WorkResultView(interaction.user)
-        await interaction.response.edit_message(embed=embed, view=result_view)
+        await safe_edit(interaction, embed=embed, view=result_view)
         result_view.message = interaction.message
         self._work_view.stop()
 

--- a/tests/unit/views/test_economy_work_result.py
+++ b/tests/unit/views/test_economy_work_result.py
@@ -46,6 +46,11 @@ async def test_job_select_replaces_subview_with_fresh_result_view():
     """After a successful work transaction the response view must be a
     fresh ``_WorkResultView`` — not the dropdown sub-view with every
     child disabled. This pins the dead-end fix from Bug #2.
+
+    The callback defers immediately (handler does 4 DB ops + 2 service
+    calls before the final edit), so the response edit lands via
+    ``followup.edit_message`` rather than the inline
+    ``response.edit_message``.
     """
     # ``janitor`` is a real job in cogs.economy._helpers.JOBS so the
     # _WorkSubView constructor (which looks up each available job in
@@ -61,7 +66,12 @@ async def test_job_select_replaces_subview_with_fresh_result_view():
     interaction.user = _author(id_=1)
     interaction.guild_id = 2
     interaction.message = MagicMock()
-    interaction.response.edit_message = AsyncMock()
+    interaction.message.id = 1234
+    # safe_defer: is_done() == False on first check → defer is called.
+    # safe_edit: is_done() == True on the next check → followup path.
+    interaction.response.is_done = MagicMock(side_effect=[False, True])
+    interaction.response.defer = AsyncMock()
+    interaction.followup.edit_message = AsyncMock()
     interaction.client = MagicMock()
 
     eco_row = {"last_worked": 0}
@@ -105,12 +115,14 @@ async def test_job_select_replaces_subview_with_fresh_result_view():
     ):
         await select.callback(interaction)
 
-    interaction.response.edit_message.assert_awaited_once()
-    kwargs = interaction.response.edit_message.await_args.kwargs
+    interaction.response.defer.assert_awaited_once()
+    interaction.followup.edit_message.assert_awaited_once()
+    kwargs = interaction.followup.edit_message.await_args.kwargs
     rendered_view = kwargs["view"]
     assert isinstance(rendered_view, _WorkResultView), (
         f"Expected _WorkResultView after job completion, got {type(rendered_view).__name__}"
     )
+    assert kwargs["message_id"] == 1234
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Executes the #1 behaviour fix from `docs/ui-view-adoption-audit.md` § 3.3 (top drift hotspot). Single-callback change with regression-test update.

**Problem:** `_JobSelect.callback` in `disbot/views/economy/work_panel.py:86` runs the entire work transaction before responding:

- `db.get_economy(uid, gid)` — DB read
- `db.get_job_times(uid, gid, job_name)` — DB read
- `db.increment_job(uid, gid, job_name)` — DB write
- `economy_service.credit(...)` — DB write + audit row + event emission
- `xp_service.award(...)` — DB write + audit row + event emission + possible level-up event
- `db.set_last_worked(uid, gid, now)` — DB write
- `post_log_embed(...)` — Discord API send to the audit channel

…then calls raw `interaction.response.edit_message(...)`. The cumulative work easily exceeds the 3 s interaction-token window, leaving users with "Interaction Failed".

**Fix:**

- Add `safe_defer` at the top of the callback. If defer fails (token expired before we got there), bail out cleanly.
- Replace the cooldown branch's `interaction.response.send_message` with `safe_followup` (the response is deferred by then).
- Replace the final `interaction.response.edit_message` with `safe_edit`. After defer the helper routes through `followup.edit_message(message_id=...)`.

No behaviour change for the happy path beyond the deferred latency — the result view, the dead-end fix from Bug #2, the ephemeral cooldown reply, and the audit-channel log embed all stay identical.

## Test plan

- [x] `tests/unit/views/test_economy_work_result.py` updated to drive the new pattern:
  - `interaction.response.is_done` returns `False` → `True` via `side_effect`.
  - Assertion moves from `interaction.response.edit_message` to `interaction.followup.edit_message`.
  - New assertion: `message_id` equals the anchor message id (proves we're going via the followup-edit path).
  - Shape contract (a fresh `_WorkResultView` is rendered, not the disabled `_WorkSubView`) is unchanged.
- [x] `pytest tests/unit/views/test_economy_work_result.py -v` — 4/4 pass.
- [x] Full `pytest tests/ -q` — 4140 passed, 3 skipped, 0 failed (same skips as pre-PR).
- [x] `black --check`, `isort --check-only`, `ruff check`, `mypy disbot/views/economy/work_panel.py` — all clean.

Source for the audit decision: `docs/ui-view-adoption-audit.md` § 3.3 row #1.

https://claude.ai/code/session_016Dhk72MEA2gtS3NFvVRe4q

---
_Generated by [Claude Code](https://claude.ai/code/session_016Dhk72MEA2gtS3NFvVRe4q)_