### PR TITLE
fix(pvp): route RPS/blackjack challenge accept+decline edits through safe_edit

### DIFF
--- a/disbot/views/blackjack/pvp_view.py
+++ b/disbot/views/blackjack/pvp_view.py
@@ -12,6 +12,7 @@ import discord
 
 from cogs.blackjack._persistence import _clear_pvp_match, _save_pvp_match
 from cogs.blackjack._state import FREE_WIN_COINS, _active, _Game, _pvp, _PvPState
+from core.runtime.interaction_helpers import safe_edit
 from services import economy_service
 from services.blackjack_engine import is_blackjack as _is_blackjack
 from utils.ui_constants import ECONOMY_COLOR, GAME_COLOR
@@ -48,10 +49,16 @@ class _ChallengeView(discord.ui.View):
     async def accept(self, interaction: discord.Interaction, _: discord.ui.Button):
         for item in self.children:
             item.disabled = True  # type: ignore[attr-defined]
-        await interaction.response.edit_message(
+        # Bail if the edit fails: _start_pvp deals both hands and sends
+        # per-player messages to the channel — if the accept edit was
+        # rejected by Discord (token expired, channel gone) we'd end up
+        # with two live blackjack hands and no acknowledged challenge.
+        if not await safe_edit(
+            interaction,
             content="✅ Challenge accepted — dealing hands…",
             view=self,
-        )
+        ):
+            return
         self.stop()
         await _start_pvp(
             interaction,
@@ -65,7 +72,8 @@ class _ChallengeView(discord.ui.View):
     async def decline(self, interaction: discord.Interaction, _: discord.ui.Button):
         for item in self.children:
             item.disabled = True  # type: ignore[attr-defined]
-        await interaction.response.edit_message(
+        await safe_edit(
+            interaction,
             content=f"❌ {self.opponent.display_name} declined the challenge.",
             view=self,
         )

--- a/disbot/views/rps/pvp_challenge.py
+++ b/disbot/views/rps/pvp_challenge.py
@@ -11,6 +11,7 @@ import logging
 
 import discord
 
+from core.runtime.interaction_helpers import safe_edit
 from services import game_state_service
 from views.rps._helpers import (
     RPS_PVP_PENDING_SUBSYSTEM,
@@ -54,10 +55,16 @@ class _RpsPvpChallengeView(discord.ui.View):
 
         for item in self.children:
             item.disabled = True  # type: ignore[attr-defined]
-        await interaction.response.edit_message(
+        # Bail if the edit fails: the rest of this handler persists the
+        # pending match and spawns the play view in the channel, and
+        # an already-failed interaction means the players won't see the
+        # accepted state.
+        if not await safe_edit(
+            interaction,
             content="✅ Challenge accepted — both players, choose your move!",
             view=self,
-        )
+        ):
+            return
         key = frozenset({self.challenger.id, self.opponent.id})
         _rps_pvp_pending[key] = {
             "choices": {},
@@ -112,7 +119,8 @@ class _RpsPvpChallengeView(discord.ui.View):
     async def decline(self, interaction: discord.Interaction, _: discord.ui.Button):
         for item in self.children:
             item.disabled = True  # type: ignore[attr-defined]
-        await interaction.response.edit_message(
+        await safe_edit(
+            interaction,
             content=f"❌ {self.opponent.display_name} declined the challenge.",
             view=self,
         )


### PR DESCRIPTION
## Summary

Executes the #2 behaviour fix from `docs/ui-view-adoption-audit.md` § 3.3. Touches two analogous accept/decline patterns in different subsystems; small enough to bundle since the change is identical in shape.

**Problem:** Both PvP challenge views — `disbot/views/rps/pvp_challenge.py:49` (`_RpsPvpChallengeView.accept`) and `disbot/views/blackjack/pvp_view.py:47` (`_ChallengeView.accept`) — call raw `interaction.response.edit_message(...)` before dispatching substantial async work:

- **RPS:** `game_state_service.save(...)` (DB write + audit) → `channel.send(...)` (Discord API).
- **Blackjack:** `_start_pvp(...)` (deals both hands, writes per-player game state, sends two `channel.send` messages, then `_save_pvp_match(...)`).

If the raw edit fails (token expired, channel deleted, duplicate-click race), the bare `edit_message` raises, the async work either fires anyway (leaving in-memory match state without a player-visible ack) or never fires at all (orphan pending row). Either way the displayed UI state and the persisted match state desynchronise.

**Fix:**

- Route the `accept` edit through `safe_edit`. **Bail out** if it returns `False` — that means Discord rejected the edit and we should not proceed with persistence or channel sends.
- Route the `decline` edit through `safe_edit` for consistency. No follow-up work to gate, so no bail-out needed.
- Imports `safe_edit` from `core.runtime.interaction_helpers` in both files.

## Test plan

- [x] `tests/unit/cogs/test_rps_pvp_pending_persistence.py::test_pvp_challenge_accept_wired_to_save` — passes. The test is a source-grep on `rps_pvp_canonical_user_id`, `game_state_service.save`, `RPS_PVP_PENDING_SUBSYSTEM`, `RPS_PVP_PENDING_VERSION` — all of which remain in the file.
- [x] `pytest tests/ -q` — 4140 passed, 3 skipped, 0 failed.
- [x] `black --check`, `isort --check-only`, `ruff check`, `mypy` — all clean on both modified files.

Source for the audit decision: `docs/ui-view-adoption-audit.md` § 3.3 row #2.

https://claude.ai/code/session_016Dhk72MEA2gtS3NFvVRe4q

---
_Generated by [Claude Code](https://claude.ai/code/session_016Dhk72MEA2gtS3NFvVRe4q)_