### PR TITLE
fix(channels): defer before Discord permission writes; use safe_edit

### DIFF
--- a/disbot/views/channels/delete_panel.py
+++ b/disbot/views/channels/delete_panel.py
@@ -14,7 +14,7 @@ import discord
 from discord.ext import commands
 
 from core.runtime import resources
-from core.runtime.interaction_helpers import safe_followup
+from core.runtime.interaction_helpers import safe_defer, safe_edit, safe_followup
 from core.runtime.panel_recovery import restore_parent_or_send_fresh
 from utils.ui_constants import ERROR_COLOR, SUCCESS_COLOR, WARNING_COLOR
 from views.base import BaseView
@@ -162,6 +162,12 @@ class _DeleteConfirmView(BaseView):
         row=0,
     )
     async def confirm_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        # Defer before the Discord delete: channel.delete() is not
+        # instant and the subsequent edit_message would race the 3 s
+        # interaction token.
+        if not await safe_defer(interaction):
+            return
+
         channel = resources.resolve_channel(
             interaction.guild,
             channel_id=self.channel_id,
@@ -197,7 +203,7 @@ class _DeleteConfirmView(BaseView):
         for item in self.children:
             item.disabled = True
         result_embed.set_footer(text="Returning to the management panel…")
-        await interaction.response.edit_message(embed=result_embed, view=self)
+        await safe_edit(interaction, embed=result_embed, view=self)
         self.stop()
 
         await asyncio.sleep(2)

--- a/disbot/views/channels/restrict_panel.py
+++ b/disbot/views/channels/restrict_panel.py
@@ -14,7 +14,7 @@ import discord
 from discord.ext import commands
 
 from core.runtime import resources
-from core.runtime.interaction_helpers import safe_followup
+from core.runtime.interaction_helpers import safe_defer, safe_edit, safe_followup
 from core.runtime.panel_recovery import restore_parent_or_send_fresh
 from utils.ui_constants import CHANNEL_COLOR, ERROR_COLOR, SUCCESS_COLOR
 from views.base import BaseView
@@ -111,19 +111,27 @@ class _RestrictSubView(BaseView):
             )
             return
 
+        # Defer before the Discord permission write: set_permissions is
+        # not instant under load and the subsequent edit_message would
+        # race the 3 s interaction token.
+        if not await safe_defer(interaction):
+            return
+
         try:
             await channel.set_permissions(
                 interaction.guild.default_role,
                 send_messages=send_messages,
             )
         except discord.Forbidden:
-            await interaction.response.send_message(
+            await safe_followup(
+                interaction,
                 "❌ I don't have permission to change that channel's permissions.",
                 ephemeral=True,
             )
             return
         except discord.HTTPException as exc:
-            await interaction.response.send_message(
+            await safe_followup(
+                interaction,
                 f"❌ Failed to update permissions: {exc}",
                 ephemeral=True,
             )
@@ -139,7 +147,7 @@ class _RestrictSubView(BaseView):
         for item in self.children:
             item.disabled = True
 
-        await interaction.response.edit_message(embed=result_embed, view=self)
+        await safe_edit(interaction, embed=result_embed, view=self)
         self.stop()
 
         await asyncio.sleep(2)


### PR DESCRIPTION
## Summary

Executes the #3 behaviour fix from `docs/ui-view-adoption-audit.md` § 3.3. Closes the last drift hotspot in the audit's safe_* section.

**Problem:** The channel restrict/delete confirmation flows both call a Discord write API and then a bare `interaction.response.edit_message` — under load the API write eats the 3 s interaction token.

- `disbot/views/channels/restrict_panel.py:85` `_RestrictSubView._apply_restriction` — `await channel.set_permissions(...)` followed by raw `edit_message`. Lock/Unlock buttons both route through this.
- `disbot/views/channels/delete_panel.py:168` `_DeleteConfirmView.confirm_btn` — `await channel.delete()` followed by raw `edit_message`.

**Fix:**

- **restrict_panel:** defer after the cheap selection validation but *before* `set_permissions`. Route the `Forbidden`/`HTTPException` ephemeral replies through `safe_followup` (the response is deferred by then). Route the success result-edit through `safe_edit`.
- **delete_panel:** defer before `channel.delete()`. Route the success/error result-edit through `safe_edit`.

Pre-defer validation ephemerals ("Please select a channel first.", "Channel not found.") stay on `response.send_message` — they run before defer is even considered. Back/cancel buttons stay bare — those are no-I/O view swaps.

## Test plan

- [x] `tests/unit/views/test_panel_recovery.py::test_channel_subpanels_import_recovery_helper[views.channels.{restrict,delete}_panel]` — passes. The test only checks each module still imports `restore_parent_or_send_fresh`; both still do.
- [x] `pytest tests/ -q` — 4140 passed, 3 skipped, 0 failed.
- [x] `black --check`, `isort --check-only`, `ruff check`, `mypy` — all clean on both modified files.

Source for the audit decision: `docs/ui-view-adoption-audit.md` § 3.3 row #3.

https://claude.ai/code/session_016Dhk72MEA2gtS3NFvVRe4q

---
_Generated by [Claude Code](https://claude.ai/code/session_016Dhk72MEA2gtS3NFvVRe4q)_