### PR TITLE
refactor(nav): migrate admin / settings back-buttons to attach_back_button

### DIFF
--- a/disbot/cogs/admin_cog.py
+++ b/disbot/cogs/admin_cog.py
@@ -19,6 +19,7 @@ from core.runtime import lifecycle, resources
 from core.runtime.interaction_helpers import help_ctx_shim, safe_defer, safe_edit
 from utils.ui_constants import ADMIN_COLOR, INFO_COLOR, SUCCESS_COLOR  # noqa: F401
 from views.base import HubView, send_panel
+from views.navigation import attach_back_button
 
 
 class AdminCog(commands.Cog):
@@ -370,45 +371,33 @@ def attach_back_to_admin_button(
 ) -> None:
     """Append a "↩ Back to Admin" control to a sub-view opened from the panel.
 
-    Mirrors :func:`cogs.help_cog._attach_back_to_help_button`: the
-    cog's panel class is not mutated — only the live view instance
-    receives the extra button.  No-op if the view already has 25
-    components (Discord cap).  When the back button is clicked a
-    fresh ``_AdminPanelView`` is constructed so the embed reflects
-    current cog load state.
+    Thin wrapper around
+    :func:`disbot.views.navigation.attach_back_button` — the parent
+    builder constructs a fresh ``_AdminPanelView`` at click time so
+    the embed reflects current cog-load state.  No-op if the view is
+    already at the 25-component Discord cap (``attach_back_button``
+    logs and returns False in that case).
     """
-    if len(view.children) >= 25:
-        logging.getLogger("bot.cogs.admin").warning(
-            "Back-to-admin button skipped — %s already has 25 children.",
-            type(view).__name__,
-        )
-        return
 
-    back_btn = discord.ui.Button(  # type: ignore[var-annotated]
-        label="↩ Back to Admin",
-        custom_id="admin:back",
-        style=discord.ButtonStyle.secondary,
-        row=4,
-    )
-
-    async def _back_callback(interaction: discord.Interaction) -> None:
+    async def _build_admin_parent(
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
         cog = interaction.client.get_cog("AdminCog")  # type: ignore[attr-defined]
         if cog is None:
-            await interaction.response.send_message(
-                "Admin cog unavailable.",
-                ephemeral=True,
-            )
-            return
+            raise RuntimeError("Admin cog unavailable.")
         ctx_shim = help_ctx_shim(interaction)
         new_view = _AdminPanelView(ctx_shim, cog)  # type: ignore[arg-type]
         new_view._author = author  # preserve invoker identity
-        await interaction.response.edit_message(
-            embed=new_view.build_embed(),
-            view=new_view,
-        )
+        return new_view.build_embed(), new_view
 
-    back_btn.callback = _back_callback  # type: ignore[method-assign]
-    view.add_item(back_btn)
+    attach_back_button(
+        view,
+        label="↩ Back to Admin",
+        custom_id="admin:back",
+        parent_builder=_build_admin_parent,
+        row=4,
+        error_message="Admin cog unavailable — please try again.",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/disbot/views/settings/subsystem_view.py
+++ b/disbot/views/settings/subsystem_view.py
@@ -34,6 +34,7 @@ import discord
 
 from utils.subsystem_registry import SUBSYSTEMS
 from views.base import HubView
+from views.navigation import attach_back_button
 
 logger = logging.getLogger("bot.views.settings.subsystem_view")
 
@@ -248,33 +249,29 @@ def attach_back_to_settings_button(
 ) -> None:
     """Append a "↩ Back to Settings" control to a sub-view opened from this panel.
 
-    Mirrors :func:`cogs.help_cog._attach_back_to_help_button` and
-    :func:`cogs.admin_cog.attach_back_to_admin_button`.  The button
-    rebuilds a fresh :class:`SubsystemSettingsView` on click so the
-    embed reflects current setting / binding state.  No-op if the
-    sub-view already has 25 components (Discord cap).
+    Thin wrapper around
+    :func:`disbot.views.navigation.attach_back_button` — the parent
+    builder constructs a fresh :class:`SubsystemSettingsView` on
+    click so the embed reflects current setting / binding state.
+    No-op if the view is already at the 25-component Discord cap
+    (``attach_back_button`` logs and returns False in that case).
     """
-    if len(view.children) >= 25:
-        logger.warning(
-            "Back-to-settings button skipped — %s already has 25 children.",
-            type(view).__name__,
-        )
-        return
 
-    btn = discord.ui.Button(  # type: ignore[var-annotated]
-        label="↩ Back to Settings",
-        custom_id="settings:back",
-        style=discord.ButtonStyle.secondary,
-        row=4,
-    )
-
-    async def _back_callback(interaction: discord.Interaction) -> None:
+    async def _build_settings_parent(
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
         new_view = SubsystemSettingsView(author, subsystem)
         embed = await build_subsystem_embed(interaction, subsystem)
-        await interaction.response.edit_message(embed=embed, view=new_view)
+        return embed, new_view
 
-    btn.callback = _back_callback  # type: ignore[method-assign]
-    view.add_item(btn)
+    attach_back_button(
+        view,
+        label="↩ Back to Settings",
+        custom_id="settings:back",
+        parent_builder=_build_settings_parent,
+        row=4,
+        error_message="Could not reload Settings — please try again.",
+    )
 
 
 class _OpenRelatedPanelButton(discord.ui.Button):


### PR DESCRIPTION
## Summary

Executes Phase 3.5 back-button-finish from `docs/ui-view-adoption-audit.md` § 4 and `docs/helper-debt-inventory.md` § 3.

Of the originally listed legacy `attach_back_to_*_button` factories:

| Location | Status before this PR | Status after |
|---|---|---|
| `views/games/hub.py:212-245` | already migrated | unchanged |
| `views/community/hub.py:189-214` | **already migrated** (audit mis-categorised) | unchanged |
| `views/settings/subsystem_view.py:244-277` | active duplicate | **migrated to `attach_back_button`** |
| `cogs/admin_cog.py:367-411` | active duplicate | **migrated to `attach_back_button`** |
| `cogs/cleanup/panel.py:100-127` (private) | active duplicate | unchanged — defer per § 4 demotion rule |
| `cogs/help_cog.py:190-240` (private) | active duplicate | unchanged — defer per § 4 demotion rule |

## Behaviour preservation

- Label, custom_id (`admin:back` / `settings:back`), row (4), and button style are unchanged.
- 25-component cap is now enforced inside `attach_back_button` (which logs a WARNING). The two per-factory cap checks are deleted.
- Parent-builder semantics preserved: `_build_admin_parent` rebuilds `_AdminPanelView` with a fresh `help_ctx_shim` so the cog-load state refreshes on click; `_build_settings_parent` rebuilds `SubsystemSettingsView` and re-resolves the embed via `build_subsystem_embed`.
- Edge case: the old admin back-button replied "Admin cog unavailable" via an ephemeral if `bot.get_cog("AdminCog")` returned `None`. The new path raises `RuntimeError` from `_build_admin_parent`, which `attach_back_button` catches and surfaces via the `error_message` ephemeral. User-visible effect is the same; bonus is the original message isn't edited away.

## Test plan

- [x] `tests/unit/cogs/test_admin_menu_integration.py::test_attach_back_to_admin_button_adds_a_button` and `…_noop_when_view_full` — pass. They assert on label, custom_id, row, and 25-cap behaviour, all of which `attach_back_button` preserves.
- [x] `tests/unit/views/test_settings_cog_navigation.py::test_attach_back_to_settings_button_adds_a_button` and `…_noop_when_view_full` — pass.
- [x] `pytest tests/ -q` — 4140 passed, 3 skipped, 0 failed.
- [x] `black --check`, `isort --check-only`, `ruff check`, `mypy` — all clean on both modified files.

Source for the audit decision: `docs/ui-view-adoption-audit.md` § 4 + § 7 row #5.

https://claude.ai/code/session_016Dhk72MEA2gtS3NFvVRe4q

---
_Generated by [Claude Code](https://claude.ai/code/session_016Dhk72MEA2gtS3NFvVRe4q)_