### PR TITLE
docs(audit): correct Phase 3.5 back-button false positives (depends on #297)

### DIFF
--- a/docs/helper-debt-inventory.md
+++ b/docs/helper-debt-inventory.md
@@ -69,24 +69,28 @@ Canonical § 3.5 module. All 7 exports are correctly placed:
 `attach_back_target`, `chain_back`, `transition_to`. **No debt inside
 this file.**
 
-The debt is **outside it** — 4 legacy `attach_back_to_*` factories
-still exist after Phase 3.5 consolidation. The helper-policy preamble
-specifically cites this duplication as the reason the policy was
-written:
+The debt is **outside it** — two `attach_back_to_*` factories
+duplicated the canonical helper at the time of audit (admin and
+settings). The other four cited in the original table turned out to
+be already-migrated and were mis-classified — see the "Correction"
+note below the table.
 
-| Location | Lines | Status |
+| Location | Lines | Status (as of 2026-05-24, post-PR-#297) |
 |---|---|---|
 | `disbot/views/games/hub.py:212-245` (`attach_back_to_games_button`) | thin wrapper | **already migrated** — calls `attach_back_button` internally. |
-| `disbot/cogs/admin_cog.py:367-410` (`attach_back_to_admin_button`) | ~44 lines | **active duplicate**. Used by 3 cleanup-panel call sites. |
-| `disbot/views/settings/subsystem_view.py:244-277` (`attach_back_to_settings_button`) | ~34 lines | **active duplicate**. One internal call site. |
-| `disbot/views/community/hub.py:189-210` (`attach_back_to_community_button`) | ~22 lines | **active duplicate**. One internal call site. |
-| `disbot/cogs/cleanup/panel.py:100-127` (`_attach_back_to_cleanup_button`) | private | **active duplicate**. Subsystem-private; lowest priority. |
-| `disbot/cogs/help_cog.py:190-240` (`_attach_back_to_help_button`) | private | **active duplicate**. Subsystem-private; lowest priority. |
+| `disbot/cogs/admin_cog.py:367-410` (`attach_back_to_admin_button`) | thin wrapper | **migrated in PR #297** — calls `attach_back_button` internally. |
+| `disbot/views/settings/subsystem_view.py:244-277` (`attach_back_to_settings_button`) | thin wrapper | **migrated in PR #297** — calls `attach_back_button` internally. |
+| `disbot/views/community/hub.py:189-214` (`attach_back_to_community_button`) | thin wrapper | **already migrated** — calls `attach_back_button` internally (the original audit listed this as a duplicate; it was not). |
+| `disbot/cogs/cleanup/panel.py:100-130` (`_attach_back_to_cleanup_button`) | thin wrapper | **already migrated** — calls `attach_back_button` internally (the original audit listed this as a duplicate; it was not). |
+| `disbot/cogs/help_cog.py:190-243` (`_attach_back_to_help_button`) | thin wrapper | **already migrated** — calls `attach_back_button` internally (the original audit listed this as a duplicate; it was not). |
 
-Recommendation: open a follow-up PR that migrates the four public
-duplicates to call `attach_back_button` with a `parent_builder`
-closure. The two private duplicates can stay until the public ones
-land; demoting them is § 4 demotion territory.
+**Correction:** the original audit treated every file whose name
+contained `attach_back_to_*` as a duplicate without opening each
+source file. Three of those (community/hub, cleanup/panel, help_cog)
+had already been migrated when the audit was written — each is a
+small wrapper around `attach_back_button` with a parent-builder
+closure, not a hand-rolled button. Phase 3.5 is now complete; no
+further migration is needed.
 
 ---
 

--- a/docs/ui-view-adoption-audit.md
+++ b/docs/ui-view-adoption-audit.md
@@ -22,7 +22,7 @@
 |---|---|---|---|
 | Panel command dispatch | `views/base.py:send_panel` | 18 cogs, ~5 ad-hoc holdouts in one-off confirmation dialogs | **healthy** |
 | Hub view base | `views/base.py:HubView` (extends `BaseView`) | 51 view files inherit `BaseView` / `HubView`; ~6 game-state views extend `discord.ui.View` directly with justified custom timeout | **healthy** |
-| Back-button factory | `views/navigation.py:attach_back_button` | 1 of 5 wrappers migrated (`views/games/hub.py`); 4 legacy `attach_back_to_*` factories remain | **drift** — see § 4 |
+| Back-button factory | `views/navigation.py:attach_back_button` | **complete** as of PR #297 — all 6 known wrappers (`games`, `community`, `cleanup`, `help`, `admin`, `settings`) now delegate to the canonical helper. See § 4 for the correction history. | clean |
 | Interaction safety wrappers | `core/runtime/interaction_helpers.py:safe_defer/safe_edit/safe_followup` | 146 call sites across 14 files; ~60% of inspected I/O callbacks adopted, ~25% partial, ~15% bare | **drift** — see § 5 |
 | Help-route panel class names | `cogs/help/route.py` + `docs/help-command-surface-map.md` § 2 | Structural routing correct; 4 panel class names in the surface map drifted from code | **fixed in this PR** — see § 6 |
 
@@ -124,19 +124,21 @@ intentionally subsystem-diverse.
 
 See `docs/helper-debt-inventory.md` § 3 for the full list. Summary:
 
-| Location | Status |
+| Location | Status (post-PR-#297) |
 |---|---|
 | `views/games/hub.py:212-245` `attach_back_to_games_button` | already migrated |
-| `cogs/admin_cog.py:367-410` `attach_back_to_admin_button` | **active duplicate** |
-| `views/settings/subsystem_view.py:244-277` `attach_back_to_settings_button` | **active duplicate** |
-| `views/community/hub.py:189-210` `attach_back_to_community_button` | **active duplicate** |
-| `cogs/cleanup/panel.py:100-127` `_attach_back_to_cleanup_button` | active duplicate (private) |
-| `cogs/help_cog.py:190-240` `_attach_back_to_help_button` | active duplicate (private) |
+| `cogs/admin_cog.py:367-410` `attach_back_to_admin_button` | migrated in PR #297 |
+| `views/settings/subsystem_view.py:244-277` `attach_back_to_settings_button` | migrated in PR #297 |
+| `views/community/hub.py:189-214` `attach_back_to_community_button` | already migrated (original audit mis-classified) |
+| `cogs/cleanup/panel.py:100-130` `_attach_back_to_cleanup_button` | already migrated (original audit mis-classified) |
+| `cogs/help_cog.py:190-243` `_attach_back_to_help_button` | already migrated (original audit mis-classified) |
 
-The public three should be migrated to thin wrappers around
-`views/navigation.py:attach_back_button` with a `parent_builder`
-closure. The private two can stay until the public ones land
-(§ 4 demotion rule from `docs/helper-policy.md`).
+**Correction:** the original audit assumed every `attach_back_to_*`
+factory was a hand-rolled duplicate without opening each source
+file. Three (community, cleanup, help) were already wrappers around
+`attach_back_button` with parent-builder closures. PR #297 closed
+the two real duplicates (admin, settings). Phase 3.5 is now
+complete; no further migration is queued for this area.
 
 ---
 
@@ -191,9 +193,9 @@ reward / risk, smallest first.
 | 2 | **Fix `views/economy/work_panel.py:86`** | Wrap `_JobSelect.callback` with `safe_defer` → `safe_edit`. Single-file change. | S |
 | 3 | **Fix RPS / blackjack PvP accept callbacks** | `views/rps/pvp_challenge.py:49` and `views/blackjack/pvp_view.py:47`. Two-file change. | S |
 | 4 | **Fix `channels/{delete,restrict}_panel.py`** | Add `safe_defer` before the Discord permission API call; route the edit through `safe_edit`. Two-file change. | S |
-| 5 | **Phase 3.5 back-button finish — public three** | Migrate `attach_back_to_admin_button`, `attach_back_to_settings_button`, `attach_back_to_community_button` to wrap `views/navigation.py:attach_back_button`. Each is one file with a small closure. | S–M |
+| 5 | ~~**Phase 3.5 back-button finish — public three**~~ | **Complete** as of PR #297 (admin + settings migrated; community / cleanup / help were already migrated and only mis-classified by this audit). |
 | 6 | **Standardise view `on_error` paths** | Replace the custom `is_done()` ladders in `channels/{delete,restrict}_panel.py:48-62` (and any similar) with `handle_view_error` + `safe_followup`. | M |
-| 7 | **Phase 3.5 back-button finish — private two** | Migrate `cogs/cleanup/panel.py:100-127` and `cogs/help_cog.py:190-240` after the public three land. | S |
+| 7 | ~~**Phase 3.5 back-button finish — private two**~~ | **Withdrawn** — both private factories were already migrated before this audit was written; the audit mis-classified them. |
 
 PR 1 is recommended **first**: it's a one-line test addition that
 prevents the same drift from happening again. PR 2–4 are the


### PR DESCRIPTION
## Summary

**Depends on #297 — please merge that first** so the "migrated in PR #297" annotations are accurate.

When PR #289 and PR #290 shipped, both audits listed five `attach_back_to_*` factories as duplicates of `views/navigation.attach_back_button`. Re-checking the source by opening each file shows three of them were already migrated when the audit was written and were mis-classified by a name-only grep:

| File | Originally claimed | Actual state at time of audit |
|---|---|---|
| `views/community/hub.py:189-214` | "active duplicate" | already a wrapper around `attach_back_button` |
| `cogs/cleanup/panel.py:100-130` | "active duplicate (private)" | already a wrapper around `attach_back_button` |
| `cogs/help_cog.py:190-243` | "active duplicate (private)" | already a wrapper around `attach_back_button` (uses `BackTarget` chaining too) |

The only real duplicates were `attach_back_to_admin_button` (`cogs/admin_cog.py:367`) and `attach_back_to_settings_button` (`views/settings/subsystem_view.py:244`) — both migrated in PR #297.

## What this PR changes

- `docs/helper-debt-inventory.md` § 3: status table reflects post-#297 reality (six known wrappers, all canonical). Adds an explicit "Correction" callout under the table so a future reader sees the mis-classification history rather than re-discovering it.
- `docs/helper-debt-inventory.md` § 9 follow-up #3: marked complete; explains why three of the originally listed entries were never needed.
- `docs/ui-view-adoption-audit.md` § 1 status row: back-button factory is now "clean".
- `docs/ui-view-adoption-audit.md` § 4: matching factory table + correction callout.
- `docs/ui-view-adoption-audit.md` § 7 backlog rows #5 and #7: both withdrawn — the work is complete (admin/settings via #297) or never required (community/cleanup/help).

## Merge dependency

If this lands **before** #297, the doc text "migrated in PR #297" overstates reality for the brief window between merges. The author of this PR recommends:

1. Merge #297 first (the actual code migration).
2. Then merge this PR (the doc correction).

If both PRs end up merging close together, the doc remains internally accurate after both land.

## Test plan

- [x] Doc-only PR; no code changes, no test impact.
- [x] CI lint excludes `docs/` from black/ruff/mypy.

https://claude.ai/code/session_016Dhk72MEA2gtS3NFvVRe4q

---
_Generated by [Claude Code](https://claude.ai/code/session_016Dhk72MEA2gtS3NFvVRe4q)_