### PR TITLE
fix(channels): collapse on_error is_done() ladders to safe_followup

### DIFF
--- a/disbot/views/channels/delete_panel.py
+++ b/disbot/views/channels/delete_panel.py
@@ -14,6 +14,7 @@ import discord
 from discord.ext import commands
 
 from core.runtime import resources
+from core.runtime.interaction_helpers import safe_followup
 from core.runtime.panel_recovery import restore_parent_or_send_fresh
 from utils.ui_constants import ERROR_COLOR, SUCCESS_COLOR, WARNING_COLOR
 from views.base import BaseView
@@ -51,15 +52,15 @@ class _DeleteSubView(BaseView):
         error: Exception,
         item: discord.ui.Item,
     ) -> None:
+        # Channel-management views intentionally surface
+        # ``type(error).__name__`` to admins for diagnosability — see
+        # ``views.base.handle_view_error`` docstring. ``safe_followup``
+        # collapses the legacy ``is_done()`` ladder to a single call
+        # that routes through ``followup.send`` or ``response.send_message``
+        # as appropriate, and swallows the recoverable errors itself.
         logger.error("DeleteSubView error on %s: %s", item, error, exc_info=True)
         msg = f"❌ {type(error).__name__}: {error}"
-        try:
-            if not interaction.response.is_done():
-                await interaction.response.send_message(msg, ephemeral=True)
-            else:
-                await interaction.followup.send(msg, ephemeral=True)
-        except Exception:
-            pass
+        await safe_followup(interaction, msg, ephemeral=True)
 
     def build_embed(self) -> discord.Embed:
         embed = discord.Embed(
@@ -149,15 +150,10 @@ class _DeleteConfirmView(BaseView):
         error: Exception,
         item: discord.ui.Item,
     ) -> None:
+        # See _DeleteSubView.on_error for the channels-view rationale.
         logger.error("DeleteConfirmView error on %s: %s", item, error, exc_info=True)
         msg = f"❌ {type(error).__name__}: {error}"
-        try:
-            if not interaction.response.is_done():
-                await interaction.response.send_message(msg, ephemeral=True)
-            else:
-                await interaction.followup.send(msg, ephemeral=True)
-        except Exception:
-            pass
+        await safe_followup(interaction, msg, ephemeral=True)
 
     @discord.ui.button(
         label="Confirm Delete",

--- a/disbot/views/channels/restrict_panel.py
+++ b/disbot/views/channels/restrict_panel.py
@@ -14,6 +14,7 @@ import discord
 from discord.ext import commands
 
 from core.runtime import resources
+from core.runtime.interaction_helpers import safe_followup
 from core.runtime.panel_recovery import restore_parent_or_send_fresh
 from utils.ui_constants import CHANNEL_COLOR, ERROR_COLOR, SUCCESS_COLOR
 from views.base import BaseView
@@ -51,15 +52,15 @@ class _RestrictSubView(BaseView):
         error: Exception,
         item: discord.ui.Item,
     ) -> None:
+        # Channel-management views intentionally surface
+        # ``type(error).__name__`` to admins for diagnosability — see
+        # ``views.base.handle_view_error`` docstring. ``safe_followup``
+        # collapses the legacy ``is_done()`` ladder to a single call
+        # that routes through ``followup.send`` or ``response.send_message``
+        # as appropriate, and swallows the recoverable errors itself.
         logger.error("RestrictSubView error on %s: %s", item, error, exc_info=True)
         msg = f"❌ {type(error).__name__}: {error}"
-        try:
-            if not interaction.response.is_done():
-                await interaction.response.send_message(msg, ephemeral=True)
-            else:
-                await interaction.followup.send(msg, ephemeral=True)
-        except Exception:
-            pass
+        await safe_followup(interaction, msg, ephemeral=True)
 
     def build_embed(self) -> discord.Embed:
         embed = discord.Embed(


### PR DESCRIPTION
## Summary

Executes follow-up #6 from `docs/ui-view-adoption-audit.md` § 7, with a deliberate scope refinement (see below).

**Problem:** Three custom `on_error` handlers in `views/channels/{delete,restrict}_panel.py` (`_DeleteSubView`, `_DeleteConfirmView`, `_RestrictSubView`) pre-date the `safe_*` helpers. Each one:

1. Manually checks `interaction.response.is_done()`.
2. Dispatches to `response.send_message` or `followup.send` based on that check.
3. Wraps the whole thing in `try/except Exception: pass` to swallow token-expiry / HTTPException races.

**Scope refinement vs the audit text:** The audit said "Replace … with `handle_view_error` + `safe_followup`." But `views.base.handle_view_error`'s own docstring carves out channel-management views: they intentionally surface `type(error).__name__` to admins for diagnosability, while `handle_view_error` returns a generic "An error occurred. Please try again." message. Routing channels views through `handle_view_error` would be a regression for ops.

The middle path adopted here keeps the rich admin-facing message and routes the actual send through `safe_followup`, which:

- Picks `response.send_message` vs `followup.send` based on `is_done`.
- Swallows `discord.NotFound` (token expiry) and `HTTPException` internally with WARNING logs.
- Returns `Message | None` rather than raising — so the per-handler `try/except: pass` becomes unnecessary.

Net effect per handler: 12 lines collapse to 2 (one log call, one `await safe_followup(...)`), while the user-visible error surface is unchanged.

## Merge interaction with #296

`#296` (channels delete/restrict safe_defer) also adds `safe_defer`, `safe_edit`, and `safe_followup` imports to both files. If `#296` lands first, this PR's `from core.runtime.interaction_helpers import safe_followup` line is already in the file and git resolves the import conflict trivially. If this PR lands first, `#296` extends the same import. No business-logic conflict.

## Test plan

- [x] `pytest tests/ -q` — 4140 passed, 3 skipped, 0 failed.
- [x] `black --check`, `isort --check-only`, `ruff check`, `mypy` — all clean on both modified files.

Source for the audit decision: `docs/ui-view-adoption-audit.md` § 3.5 + § 7 row #6.

https://claude.ai/code/session_016Dhk72MEA2gtS3NFvVRe4q

---
_Generated by [Claude Code](https://claude.ai/code/session_016Dhk72MEA2gtS3NFvVRe4q)_