### PR TITLE
feat(platform-hub): expose lifecycle, setup-readiness, and flag manager

### DIFF
--- a/disbot/views/diagnostic/platform_panel.py
+++ b/disbot/views/diagnostic/platform_panel.py
@@ -1,10 +1,11 @@
-"""Interactive ``!platform`` admin panel (read-only).
+"""Interactive ``!platform`` admin panel.
 
 ``_PlatformHubView`` is the ephemeral hub opened by ``!platform`` with
 no subcommand. It groups every existing ``!platform <subcommand>``
 into four category Selects (Runtime/status, Catalogues,
-Resources/rollout, Validation), plus an Overview button that returns
-to the category listing.
+Resources/rollout, Validation), an Overview button that returns
+to the category listing, and a Flag manager button that opens the
+editable per-guild flag manager.
 
 Selects update the panel in place via ``safe_defer`` +
 ``safe_edit``, identical to ``_DiagnosticsHubView`` and
@@ -13,8 +14,12 @@ produced by the existing builders in
 ``cogs.diagnostic._platform_embeds`` so the panel and the typed
 commands render byte-identical embeds.
 
-The panel is strictly read-only: no mutation, no resource creation,
-no setting writes. Typed ``!platform <subcommand>`` commands are
+The four category Selects remain strictly read-only. The
+"Mutations / managers" row (currently the Flag manager button) is
+the single segregated write surface — every click still routes
+through the canonical mutation pipeline (e.g.
+``services.rollout_mutation.RolloutMutationPipeline`` for flag
+state changes). Typed ``!platform <subcommand>`` commands are
 preserved and continue to support their existing filter/limit
 arguments which the panel does not expose (those remain text-only
 power-user paths).
@@ -32,6 +37,7 @@ from cogs.diagnostic._platform_embeds import (
     build_customization_embed,
     build_flags_embed,
     build_identity_embed,
+    build_lifecycle_embed,
     build_locks_embed,
     build_migrations_embed,
     build_participation_schemas_embed,
@@ -42,6 +48,7 @@ from cogs.diagnostic._platform_embeds import (
     build_schemas_embed,
     build_sessions_embed,
     build_settings_registry_embed,
+    build_setup_readiness_embed,
     build_slow_embed,
     build_status_embed,
     build_tasks_embed,
@@ -53,6 +60,7 @@ from views.base import HubView
 _RUNTIME_OPTIONS = (
     ("status", "🛠", "Uptime, cogs, guilds, scheduler, failed subsystems"),
     ("runtime", "🛰", "snapshot_all roll-up across every provider"),
+    ("lifecycle", "♻️", "Lifecycle phase, pending requests, recent events"),
     ("caches", "🧠", "F-1 guild_config + governance cache state"),
     ("locks", "🔒", "scope_locks snapshot (no filter)"),
     ("tasks", "🔁", "Managed background-task snapshot"),
@@ -82,6 +90,15 @@ _VALIDATION_OPTIONS = (
     ("identity", "🪪", "Identity-contract validator findings"),
     ("consistency", "🛡", "Unified platform readiness diagnostic"),
     ("anchors", "📌", "Panel anchor restoration + active counts"),
+    ("setup-readiness", "✅", "Per-guild setup-readiness inventory"),
+)
+
+
+# Mutations / managers — write surfaces, rendered as buttons rather than
+# folded into the read-only category Selects. Each entry maps a button
+# label to the panel-opening dispatch key handled by ``_open_manager``.
+_MUTATION_BUTTONS = (
+    ("flag-manager", "🚩 Flag manager", "Open the editable per-guild flag manager"),
 )
 
 
@@ -90,9 +107,11 @@ def build_platform_hub_embed() -> discord.Embed:
     embed = discord.Embed(
         title="🛰 Platform hub",
         description=(
-            "Read-only diagnostics. Pick a surface from one of the "
+            "Diagnostics + managers. Pick a surface from one of the "
             "category dropdowns below — every entry maps to an "
-            "existing `!platform <subcommand>`."
+            "existing `!platform <subcommand>`. The four category "
+            "dropdowns are **read-only**; mutation surfaces live under "
+            "Mutations / managers."
         ),
         color=discord.Color.blurple(),
     )
@@ -124,6 +143,13 @@ def build_platform_hub_embed() -> discord.Embed:
         ),
         inline=False,
     )
+    embed.add_field(
+        name="Mutations / managers",
+        value="\n".join(
+            f"{label} — {desc}" for _name, label, desc in _MUTATION_BUTTONS
+        ),
+        inline=False,
+    )
     embed.set_footer(
         text=(
             "Typed `!platform <name>` commands keep working with their "
@@ -141,6 +167,8 @@ async def _dispatch(name: str, interaction: discord.Interaction) -> discord.Embe
         return build_status_embed(bot)  # type: ignore[arg-type]
     if name == "runtime":
         return build_runtime_embed()
+    if name == "lifecycle":
+        return build_lifecycle_embed()
     if name == "caches":
         return build_caches_embed()
     if name == "locks":
@@ -193,6 +221,9 @@ async def _dispatch(name: str, interaction: discord.Interaction) -> discord.Embe
         return build_consistency_embed(report)
     if name == "anchors":
         return await build_anchors_embed()
+    if name == "setup-readiness":
+        guild_id = guild.id if guild is not None else 0
+        return await build_setup_readiness_embed(guild_id, guild=guild)
     return discord.Embed(
         title="Unknown surface",
         description=f"`{name}` is not a known platform surface.",
@@ -289,8 +320,38 @@ class _PlatformHubView(HubView):
             return
         await safe_edit(interaction, embed=build_platform_hub_embed(), view=self)
 
+    @discord.ui.button(
+        label="🚩 Flag manager",
+        style=discord.ButtonStyle.primary,
+        row=4,
+        custom_id="platform_hub.flag_manager",
+    )
+    async def btn_flag_manager(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        # Mutation surface: opens the editable per-guild flag manager.
+        # Every write inside FlagManagerView still routes through the
+        # RolloutMutationPipeline (audit + cache invalidation + event).
+        if not await safe_defer(interaction):
+            return
+        from views.diagnostic.flag_manager import (
+            FlagManagerView,
+            build_flag_manager_overview_embed,
+        )
+
+        guild_id = interaction.guild.id if interaction.guild else None
+        manager = FlagManagerView(self._author, guild_id=guild_id)
+        await safe_edit(
+            interaction,
+            embed=build_flag_manager_overview_embed(),
+            view=manager,
+        )
+
 
 __all__ = [
+    "_MUTATION_BUTTONS",
     "_PlatformHubView",
     "build_platform_hub_embed",
 ]

--- a/tests/unit/views/test_platform_hub_view.py
+++ b/tests/unit/views/test_platform_hub_view.py
@@ -1,14 +1,15 @@
 """Unit tests for ``_PlatformHubView`` — the !platform admin panel.
 
-The view is the read-only hub opened by ``!platform`` with no
-subcommand.  These tests cover:
+The view is the hub opened by ``!platform`` with no subcommand.
+These tests cover:
 
-- the overview embed structure;
-- the view shape (4 category Selects + 1 Overview button);
-- Select option coverage of every grouped subcommand;
+- the overview embed structure (4 read-only sections + 1 mutations section);
+- the view shape (4 category Selects on rows 0-3 + buttons on row 4);
+- Select option coverage of every grouped read-only subcommand;
 - ``_dispatch`` mapping each Select value to its existing builder;
 - sessions DB-failure rendering as a red embed (no plain-text path);
 - the Overview button returning to the overview embed;
+- the Flag-manager button opening the editable manager;
 - the canonical invoker-restriction contract from ``BaseView``.
 
 All embeds returned by the panel are produced by the existing
@@ -26,6 +27,7 @@ from discord.ext import commands
 
 from views.diagnostic.platform_panel import (
     _CATALOGUES_OPTIONS,
+    _MUTATION_BUTTONS,
     _RESOURCES_OPTIONS,
     _RUNTIME_OPTIONS,
     _VALIDATION_OPTIONS,
@@ -46,7 +48,7 @@ def _author(id_: int = 1) -> MagicMock:
 # ---------------------------------------------------------------------------
 
 
-def test_overview_embed_has_title_and_four_category_fields():
+def test_overview_embed_has_title_and_five_section_fields():
     embed = build_platform_hub_embed()
     assert "Platform hub" in (embed.title or "")
     names = [f.name for f in embed.fields]
@@ -55,12 +57,15 @@ def test_overview_embed_has_title_and_four_category_fields():
         "Catalogues",
         "Resources / rollout",
         "Validation",
+        "Mutations / managers",
     ]
 
 
-def test_overview_embed_describes_read_only_intent():
+def test_overview_embed_separates_readonly_from_mutations():
     embed = build_platform_hub_embed()
-    assert "Read-only" in (embed.description or "")
+    description = embed.description or ""
+    assert "read-only" in description.lower()
+    assert "Mutations" in description
 
 
 def test_overview_embed_footer_mentions_typed_commands():
@@ -74,21 +79,23 @@ def test_overview_embed_footer_mentions_typed_commands():
 # ---------------------------------------------------------------------------
 
 
-def test_view_has_four_selects_and_one_button():
+def test_view_has_four_selects_overview_and_mutation_buttons():
     view = _PlatformHubView(_author())
     selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
     buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
     assert len(selects) == 4
-    assert len(buttons) == 1
-    assert len(view.children) == 5
+    # One Overview button + one button per mutation entry.
+    assert len(buttons) == 1 + len(_MUTATION_BUTTONS)
 
 
 def test_view_selects_fit_within_discord_row_budget():
     view = _PlatformHubView(_author())
-    rows = {c.row for c in view.children}
-    # Discord allows rows 0-4 (5 total); 4 selects + 1 button must each
-    # claim a unique row so the panel renders without overflow.
-    assert rows == {0, 1, 2, 3, 4}
+    selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
+    buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+    # Discord allows rows 0-4 (5 total); 4 selects must each claim a
+    # unique row (0-3) and all buttons share the bottom row 4.
+    assert {c.row for c in selects} == {0, 1, 2, 3}
+    assert {c.row for c in buttons} == {4}
 
 
 def test_view_select_option_counts_match_category_inventories():
@@ -112,6 +119,7 @@ def test_select_values_cover_every_platform_subcommand():
         # Runtime / status
         "status",
         "runtime",
+        "lifecycle",
         "caches",
         "locks",
         "tasks",
@@ -135,17 +143,32 @@ def test_select_values_cover_every_platform_subcommand():
         "identity",
         "consistency",
         "anchors",
+        "setup-readiness",
     }
     assert seen == expected, seen.symmetric_difference(expected)
 
 
 def test_overview_button_is_on_last_row_and_secondary_style():
     view = _PlatformHubView(_author())
-    button = next(c for c in view.children if isinstance(c, discord.ui.Button))
-    assert button.row == 4
-    assert button.style == discord.ButtonStyle.secondary
-    assert button.label is not None
-    assert "Overview" in button.label
+    overview = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and (c.label or "").endswith("Overview")
+    )
+    assert overview.row == 4
+    assert overview.style == discord.ButtonStyle.secondary
+
+
+def test_flag_manager_button_is_primary_on_last_row():
+    view = _PlatformHubView(_author())
+    flag_btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and "Flag manager" in (c.label or "")
+    )
+    assert flag_btn.row == 4
+    assert flag_btn.style == discord.ButtonStyle.primary
+    assert flag_btn.custom_id == "platform_hub.flag_manager"
 
 
 # ---------------------------------------------------------------------------
@@ -185,6 +208,45 @@ async def test_dispatch_runtime_uses_runtime_builder():
         embed = await _dispatch("runtime", interaction)
     builder.assert_called_once_with()
     assert embed.title == "rt"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_lifecycle_uses_lifecycle_builder():
+    interaction = _fake_interaction()
+    with patch(
+        "views.diagnostic.platform_panel.build_lifecycle_embed",
+        return_value=discord.Embed(title="lc"),
+    ) as builder:
+        embed = await _dispatch("lifecycle", interaction)
+    builder.assert_called_once_with()
+    assert embed.title == "lc"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_setup_readiness_passes_guild_and_id():
+    guild = MagicMock()
+    guild.id = 4242
+    interaction = _fake_interaction(guild=guild)
+    with patch(
+        "views.diagnostic.platform_panel.build_setup_readiness_embed",
+        new_callable=AsyncMock,
+        return_value=discord.Embed(title="setup"),
+    ) as builder:
+        embed = await _dispatch("setup-readiness", interaction)
+    builder.assert_awaited_once_with(4242, guild=guild)
+    assert embed.title == "setup"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_setup_readiness_falls_back_to_zero_in_dm():
+    interaction = _fake_interaction(guild=None)
+    with patch(
+        "views.diagnostic.platform_panel.build_setup_readiness_embed",
+        new_callable=AsyncMock,
+        return_value=discord.Embed(title="setup-dm"),
+    ) as builder:
+        await _dispatch("setup-readiness", interaction)
+    builder.assert_awaited_once_with(0, guild=None)
 
 
 @pytest.mark.asyncio
@@ -280,14 +342,17 @@ async def test_dispatch_consistency_uses_collect_report():
         guild=MagicMock(),
     )
     fake_report = MagicMock()
-    with patch(
-        "services.platform_consistency.collect_report",
-        new_callable=AsyncMock,
-        return_value=fake_report,
-    ) as collector, patch(
-        "views.diagnostic.platform_panel.build_consistency_embed",
-        return_value=discord.Embed(title="consistency"),
-    ) as builder:
+    with (
+        patch(
+            "services.platform_consistency.collect_report",
+            new_callable=AsyncMock,
+            return_value=fake_report,
+        ) as collector,
+        patch(
+            "views.diagnostic.platform_panel.build_consistency_embed",
+            return_value=discord.Embed(title="consistency"),
+        ) as builder,
+    ):
         embed = await _dispatch("consistency", interaction)
     collector.assert_awaited_once_with(bot=interaction.client, guild=interaction.guild)
     builder.assert_called_once_with(fake_report)


### PR DESCRIPTION
## Summary

PR 1 of the "Smooth Interaction Pass" plan. The interactive Platform hub (`!platform`) claimed to map every typed `!platform <sub>` command, but was missing three: `lifecycle`, `setup-readiness`, and the editable `flag` manager. Operators had to fall back to typed commands for these.

- Add `lifecycle` to the Runtime/status Select; add `setup-readiness` to Validation.
- Add a `🚩 Flag manager` primary button on row 4 next to Overview; opens the same `FlagManagerView` the typed `!platform flag` command opens.
- Document the read-only vs mutations split in the hub overview embed (new "Mutations / managers" field).
- Extend `_dispatch` with both new branches, reusing the existing `build_lifecycle_embed` / `build_setup_readiness_embed` builders — no new diagnostics, no new builders.
- Cover the new options + button + dispatch paths in the unit tests.

## Test plan

- [x] `python -m pytest tests/unit/views/test_platform_hub_view.py` — 24 passed
- [x] `python -m pytest tests/unit/views/ tests/unit/runtime/test_platform_commands.py tests/unit/runtime/test_platform_diagnostics_commands.py tests/unit/help/test_platform_diagnostics_split.py` — 724 passed, 2 skipped
- [x] `ruff check disbot/views/diagnostic/platform_panel.py` — clean
- [x] `black --check disbot/views/diagnostic/platform_panel.py` — clean
- [ ] Manual smoke: `!platform`, open lifecycle / setup-readiness from the dropdowns, click 🚩 Flag manager
- [ ] Manual smoke: typed `!platform lifecycle`, `!platform setup-readiness`, `!platform flag` still work

https://claude.ai/code/session_01CJgGhmCjeixzmoaMtjEjrZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJgGhmCjeixzmoaMtjEjrZ)_