### PR TITLE
refactor(views): migrate 12 hand-rolled back buttons to attach_back_button

### DIFF
--- a/disbot/views/channels/create_panel.py
+++ b/disbot/views/channels/create_panel.py
@@ -20,6 +20,7 @@ from utils.channels import get_or_create_category, safe_channel_name
 from utils.ui_constants import SUCCESS_COLOR
 from views.base import BaseView
 from views.channels._helpers import _CATEGORY_PRESETS, _NAME_PRESETS
+from views.navigation import attach_back_button
 
 logger = logging.getLogger("bot")
 
@@ -57,6 +58,23 @@ class _CreateSubView(BaseView):
         self.cat_select = _CategorySelect(cat_options, self)
         self.add_item(self.name_select)
         self.add_item(self.cat_select)
+
+        async def _build_parent(
+            _interaction: discord.Interaction,
+        ) -> tuple[discord.Embed, discord.ui.View]:
+            from views.channels.main_panel import _ChannelManagerView
+
+            manager = _ChannelManagerView(self.ctx)
+            manager.message = self.manager_message
+            return manager.build_embed(), manager
+
+        attach_back_button(
+            self,
+            label="↩️ Back",
+            custom_id="channels:create:back",
+            parent_builder=_build_parent,
+            row=2,
+        )
 
     async def on_error(
         self,
@@ -211,18 +229,6 @@ class _CreateSubView(BaseView):
 
     @discord.ui.button(label="Cancel", style=discord.ButtonStyle.red, emoji="❌", row=2)
     async def cancel_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
-        from views.channels.main_panel import _ChannelManagerView
-
-        manager = _ChannelManagerView(self.ctx)
-        manager.message = self.manager_message
-        await interaction.response.edit_message(
-            embed=manager.build_embed(),
-            view=manager,
-        )
-        self.stop()
-
-    @discord.ui.button(label="↩️ Back", style=discord.ButtonStyle.grey, row=2)
-    async def back_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
         from views.channels.main_panel import _ChannelManagerView
 
         manager = _ChannelManagerView(self.ctx)

--- a/disbot/views/channels/delete_panel.py
+++ b/disbot/views/channels/delete_panel.py
@@ -19,6 +19,7 @@ from core.runtime.panel_recovery import restore_parent_or_send_fresh
 from utils.ui_constants import ERROR_COLOR, SUCCESS_COLOR, WARNING_COLOR
 from views.base import BaseView
 from views.channels._helpers import _build_channel_options, _ChannelSelect
+from views.navigation import attach_back_button
 
 logger = logging.getLogger("bot")
 
@@ -45,6 +46,23 @@ class _DeleteSubView(BaseView):
             placeholder="Select a channel to delete…",
         )
         self.add_item(self.channel_select)
+
+        async def _build_parent(
+            _interaction: discord.Interaction,
+        ) -> tuple[discord.Embed, discord.ui.View]:
+            from views.channels.main_panel import _ChannelManagerView
+
+            manager = _ChannelManagerView(self.ctx)
+            manager.message = self.manager_message
+            return manager.build_embed(), manager
+
+        attach_back_button(
+            self,
+            label="↩️ Back",
+            custom_id="channels:delete:back",
+            parent_builder=_build_parent,
+            row=1,
+        )
 
     async def on_error(
         self,
@@ -111,18 +129,6 @@ class _DeleteSubView(BaseView):
         await interaction.response.edit_message(
             embed=self._confirm_embed(),
             view=confirm_view,
-        )
-        self.stop()
-
-    @discord.ui.button(label="↩️ Back", style=discord.ButtonStyle.grey, row=1)
-    async def back_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
-        from views.channels.main_panel import _ChannelManagerView
-
-        manager = _ChannelManagerView(self.ctx)
-        manager.message = self.manager_message
-        await interaction.response.edit_message(
-            embed=manager.build_embed(),
-            view=manager,
         )
         self.stop()
 

--- a/disbot/views/channels/restrict_panel.py
+++ b/disbot/views/channels/restrict_panel.py
@@ -19,6 +19,7 @@ from core.runtime.panel_recovery import restore_parent_or_send_fresh
 from utils.ui_constants import CHANNEL_COLOR, ERROR_COLOR, SUCCESS_COLOR
 from views.base import BaseView
 from views.channels._helpers import _ChannelSelect
+from views.navigation import attach_back_button
 
 logger = logging.getLogger("bot")
 
@@ -45,6 +46,23 @@ class _RestrictSubView(BaseView):
             placeholder="Select a channel to manage…",
         )
         self.add_item(self.channel_select)
+
+        async def _build_parent(
+            _interaction: discord.Interaction,
+        ) -> tuple[discord.Embed, discord.ui.View]:
+            from views.channels.main_panel import _ChannelManagerView
+
+            manager = _ChannelManagerView(self.ctx)
+            manager.message = self.manager_message
+            return manager.build_embed(), manager
+
+        attach_back_button(
+            self,
+            label="↩️ Back",
+            custom_id="channels:restrict:back",
+            parent_builder=_build_parent,
+            row=2,
+        )
 
     async def on_error(
         self,
@@ -187,15 +205,3 @@ class _RestrictSubView(BaseView):
             past_tense="unlocked (send messages restored for @everyone)",
             embed_color=SUCCESS_COLOR,
         )
-
-    @discord.ui.button(label="↩️ Back", style=discord.ButtonStyle.grey, row=2)
-    async def back_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
-        from views.channels.main_panel import _ChannelManagerView
-
-        manager = _ChannelManagerView(self.ctx)
-        manager.message = self.manager_message
-        await interaction.response.edit_message(
-            embed=manager.build_embed(),
-            view=manager,
-        )
-        self.stop()

--- a/disbot/views/channels/visibility_panel.py
+++ b/disbot/views/channels/visibility_panel.py
@@ -22,6 +22,7 @@ from services.governance_service import GovernanceContext
 from utils.subsystem_registry import all_subsystems_sorted
 from utils.ui_constants import CHANNEL_COLOR
 from views.base import BaseView
+from views.navigation import attach_back_button
 
 logger = logging.getLogger("bot")
 
@@ -79,6 +80,23 @@ class _VisibilitySubView(BaseView):
         self.manager_message = manager_message
         self.add_item(_ChannelSelectForVisibility(ctx.guild))
 
+        async def _build_parent(
+            _interaction: discord.Interaction,
+        ) -> tuple[discord.Embed, discord.ui.View]:
+            from views.channels.main_panel import _ChannelManagerView
+
+            manager = _ChannelManagerView(self.ctx)
+            manager.message = self.manager_message
+            return manager.build_embed(), manager
+
+        attach_back_button(
+            self,
+            label="↩ Back",
+            custom_id="channels:visibility:back",
+            parent_builder=_build_parent,
+            row=1,
+        )
+
     def build_embed(self) -> discord.Embed:
         return discord.Embed(
             title="🔍 Subsystem Visibility",
@@ -89,14 +107,6 @@ class _VisibilitySubView(BaseView):
             ),
             color=CHANNEL_COLOR,
         )
-
-    @discord.ui.button(label="↩ Back", style=discord.ButtonStyle.grey, row=1)
-    async def back_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
-        from views.channels.main_panel import _ChannelManagerView
-
-        view = _ChannelManagerView(self.ctx)
-        view.message = self.manager_message
-        await interaction.response.edit_message(embed=view.build_embed(), view=view)
 
 
 class _SubsystemToggleView(BaseView):

--- a/disbot/views/economy/shop_panel.py
+++ b/disbot/views/economy/shop_panel.py
@@ -16,6 +16,7 @@ from services import economy_service
 from utils import db
 from utils.helpers import post_log_embed
 from utils.ui_constants import SUCCESS_COLOR, WARNING_COLOR
+from views.navigation import attach_back_button, attach_back_target
 
 
 class _ShopView(discord.ui.View):
@@ -130,6 +131,28 @@ class _ShopSubView(discord.ui.View):
         ]
         self.add_item(_ShopPanelSelect(user_id, guild_id, options, self))
 
+        async def _build_parent(
+            interaction: discord.Interaction,
+        ) -> tuple[discord.Embed, discord.ui.View]:
+            from views.economy.main_panel import EconomyPanelView
+
+            embed = await _build_economy_embed(interaction.user, interaction.guild_id)
+            view = EconomyPanelView()
+            # AB2: re-attach any propagated grandparent (typically Help)
+            # so the rebuilt Economy panel keeps the back-to-Help chain.
+            origin = getattr(self, "_back_target", None)
+            if origin is not None:
+                attach_back_target(view, origin)
+            return embed, view
+
+        attach_back_button(
+            self,
+            label="↩ Back",
+            custom_id="economy:shop:back",
+            parent_builder=_build_parent,
+            row=1,
+        )
+
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         if interaction.user.id != self.user_id:
             await interaction.response.send_message(
@@ -138,22 +161,6 @@ class _ShopSubView(discord.ui.View):
             )
             return False
         return True
-
-    @discord.ui.button(label="↩ Back", style=discord.ButtonStyle.grey, row=1)
-    async def back_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
-        from views.economy.main_panel import EconomyPanelView
-        from views.navigation import attach_back_target
-
-        embed = await _build_economy_embed(interaction.user, interaction.guild_id)
-        view = EconomyPanelView()
-        # AB2: if a grandparent was propagated from the opener
-        # (typically Help's back target), re-attach it so the rebuilt
-        # Economy panel keeps the back-to-Help chain.
-        origin = getattr(self, "_back_target", None)
-        if origin is not None:
-            attach_back_target(view, origin)
-        await interaction.response.edit_message(embed=embed, view=view)
-        self.stop()
 
     async def on_timeout(self):
         for item in self.children:

--- a/disbot/views/economy/work_panel.py
+++ b/disbot/views/economy/work_panel.py
@@ -26,6 +26,7 @@ from utils import db
 from utils.cooldowns import check_cooldown, format_remaining
 from utils.helpers import post_log_embed
 from utils.ui_constants import SUCCESS_COLOR
+from views.navigation import attach_back_button
 
 
 class _WorkView(discord.ui.View):
@@ -179,14 +180,22 @@ class _WorkSubView(_WorkView):
     def __init__(self, user_id: int, guild_id: int, available: list[str]):
         super().__init__(user_id, guild_id, available)
 
-    @discord.ui.button(label="↩ Back", style=discord.ButtonStyle.grey, row=1)
-    async def back_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
-        # Late import — main_panel imports from this module.
-        from views.economy.main_panel import EconomyPanelView
+        async def _build_parent(
+            interaction: discord.Interaction,
+        ) -> tuple[discord.Embed, discord.ui.View]:
+            # Late import — main_panel imports from this module.
+            from views.economy.main_panel import EconomyPanelView
 
-        embed = await _build_economy_embed(interaction.user, interaction.guild_id)
-        await interaction.response.edit_message(embed=embed, view=EconomyPanelView())
-        self.stop()
+            embed = await _build_economy_embed(interaction.user, interaction.guild_id)
+            return embed, EconomyPanelView()
+
+        attach_back_button(
+            self,
+            label="↩ Back",
+            custom_id="economy:work:back",
+            parent_builder=_build_parent,
+            row=1,
+        )
 
 
 class _WorkResultView(discord.ui.View):
@@ -201,6 +210,23 @@ class _WorkResultView(discord.ui.View):
         super().__init__(timeout=60)
         self._author = author
         self.message: discord.Message | None = None
+
+        async def _build_parent(
+            interaction: discord.Interaction,
+        ) -> tuple[discord.Embed, discord.ui.View]:
+            # Late import — main_panel imports from this module.
+            from views.economy.main_panel import EconomyPanelView
+
+            embed = await _build_economy_embed(interaction.user, interaction.guild_id)
+            return embed, EconomyPanelView()
+
+        attach_back_button(
+            self,
+            label="↩ Back to Economy",
+            custom_id="economy:back",
+            parent_builder=_build_parent,
+            row=0,
+        )
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         if interaction.user.id != self._author.id:
@@ -219,17 +245,3 @@ class _WorkResultView(discord.ui.View):
                 await self.message.edit(view=self)
         except Exception:
             pass
-
-    @discord.ui.button(
-        label="↩ Back to Economy",
-        style=discord.ButtonStyle.secondary,
-        custom_id="economy:back",
-        row=0,
-    )
-    async def back_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
-        # Late import — main_panel imports from this module.
-        from views.economy.main_panel import EconomyPanelView
-
-        embed = await _build_economy_embed(interaction.user, interaction.guild_id)
-        await interaction.response.edit_message(embed=embed, view=EconomyPanelView())
-        self.stop()

--- a/disbot/views/roles/diagnostics_panel.py
+++ b/disbot/views/roles/diagnostics_panel.py
@@ -8,6 +8,7 @@ from utils import db
 from utils.settings_keys import SKIP_ROLES
 from utils.ui_constants import WARNING_COLOR
 from views.base import BaseView
+from views.navigation import attach_back_button
 
 
 class DiagnosticsPanel(BaseView):
@@ -17,6 +18,21 @@ class DiagnosticsPanel(BaseView):
         super().__init__(ctx.author, timeout=300)
         self.ctx = ctx
         self.parent = parent
+
+        if parent is not None:
+
+            async def _build_parent(
+                _interaction: discord.Interaction,
+            ) -> tuple[discord.Embed, discord.ui.View]:
+                return parent.build_embed(), parent
+
+            attach_back_button(
+                self,
+                label="↩ Back",
+                custom_id="role:diagnostics:back",
+                parent_builder=_build_parent,
+                row=1,
+            )
 
     async def build_embed(self) -> discord.Embed:
         guild = self.ctx.guild
@@ -75,18 +91,3 @@ class DiagnosticsPanel(BaseView):
             f"✅ Assignment complete — {count} role(s) assigned.",
             ephemeral=True,
         )
-
-    @discord.ui.button(label="↩ Back", style=discord.ButtonStyle.secondary, row=1)
-    async def back_btn(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        if self.parent:
-            await interaction.response.edit_message(
-                embed=self.parent.build_embed(),
-                view=self.parent,
-            )
-        else:
-            await interaction.response.edit_message(view=None)
-        self.stop()

--- a/disbot/views/roles/management_panel.py
+++ b/disbot/views/roles/management_panel.py
@@ -7,6 +7,7 @@ from core.runtime import resources
 from core.runtime.interaction_helpers import safe_defer
 from utils.ui_constants import ROLE_COLOR
 from views.base import BaseView
+from views.navigation import attach_back_button
 from views.roles._helpers import _find_role_normalized, _parse_color
 
 
@@ -17,6 +18,21 @@ class ManagementPanel(BaseView):
         super().__init__(ctx.author, timeout=300)
         self.ctx = ctx
         self.parent = parent
+
+        if parent is not None:
+
+            async def _build_parent(
+                _interaction: discord.Interaction,
+            ) -> tuple[discord.Embed, discord.ui.View]:
+                return parent.build_embed(), parent
+
+            attach_back_button(
+                self,
+                label="↩ Back",
+                custom_id="role:management:back",
+                parent_builder=_build_parent,
+                row=1,
+            )
 
     async def build_embed(self) -> discord.Embed:
         guild = self.ctx.guild
@@ -77,21 +93,6 @@ class ManagementPanel(BaseView):
             view=view,
             ephemeral=True,
         )
-
-    @discord.ui.button(label="↩ Back", style=discord.ButtonStyle.secondary, row=1)
-    async def back_btn(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        if self.parent:
-            await interaction.response.edit_message(
-                embed=self.parent.build_embed(),
-                view=self.parent,
-            )
-        else:
-            await interaction.response.edit_message(view=None)
-        self.stop()
 
 
 class EditRoleModal(discord.ui.Modal, title="Edit Role"):  # type: ignore[call-arg]

--- a/disbot/views/roles/reaction_panel.py
+++ b/disbot/views/roles/reaction_panel.py
@@ -7,6 +7,7 @@ from core.runtime import resources
 from utils import db
 from utils.ui_constants import ROLE_COLOR
 from views.base import BaseView
+from views.navigation import attach_back_button
 
 
 class ReactionRolesPanel(BaseView):
@@ -16,6 +17,21 @@ class ReactionRolesPanel(BaseView):
         super().__init__(ctx.author, timeout=300)
         self.ctx = ctx
         self.parent = parent
+
+        if parent is not None:
+
+            async def _build_parent(
+                _interaction: discord.Interaction,
+            ) -> tuple[discord.Embed, discord.ui.View]:
+                return parent.build_embed(), parent
+
+            attach_back_button(
+                self,
+                label="↩ Back",
+                custom_id="role:reaction:back",
+                parent_builder=_build_parent,
+                row=0,
+            )
 
     async def build_embed(self) -> discord.Embed:
         rows = await db.get_all_reaction_roles(self.ctx.guild.id)
@@ -46,18 +62,3 @@ class ReactionRolesPanel(BaseView):
             embed=await self.build_embed(),
             view=self,
         )
-
-    @discord.ui.button(label="↩ Back", style=discord.ButtonStyle.secondary, row=0)
-    async def back_btn(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        if self.parent:
-            await interaction.response.edit_message(
-                embed=self.parent.build_embed(),
-                view=self.parent,
-            )
-        else:
-            await interaction.response.edit_message(view=None)
-        self.stop()

--- a/disbot/views/roles/time_roles_panel.py
+++ b/disbot/views/roles/time_roles_panel.py
@@ -8,6 +8,7 @@ from utils import db
 from utils.guild_config_accessors import invalidate_xp_threshold_roles
 from utils.ui_constants import ROLE_COLOR
 from views.base import BaseView
+from views.navigation import attach_back_button
 from views.roles._helpers import _DEFAULT_THRESHOLDS, _find_role_normalized
 
 
@@ -18,6 +19,21 @@ class TimeRolesPanel(BaseView):
         super().__init__(ctx.author, timeout=300)
         self.ctx = ctx
         self.parent = parent
+
+        if parent is not None:
+
+            async def _build_parent(
+                _interaction: discord.Interaction,
+            ) -> tuple[discord.Embed, discord.ui.View]:
+                return parent.build_embed(), parent
+
+            attach_back_button(
+                self,
+                label="↩ Back",
+                custom_id="role:time:back",
+                parent_builder=_build_parent,
+                row=1,
+            )
 
     async def build_embed(self) -> discord.Embed:
         thresholds = await db.get_role_thresholds(self.ctx.guild.id)
@@ -93,21 +109,6 @@ class TimeRolesPanel(BaseView):
                 f"✅ Assignment complete — {count} role(s) assigned.",
                 ephemeral=True,
             )
-
-    @discord.ui.button(label="↩ Back", style=discord.ButtonStyle.secondary, row=1)
-    async def back_btn(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        if self.parent:
-            await interaction.response.edit_message(
-                embed=self.parent.build_embed(),
-                view=self.parent,
-            )
-        else:
-            await interaction.response.edit_message(view=None)
-        self.stop()
 
 
 class TimeThresholdAddModal(

--- a/disbot/views/roles/xp_roles_panel.py
+++ b/disbot/views/roles/xp_roles_panel.py
@@ -10,6 +10,7 @@ from utils import db
 from utils.guild_config_accessors import invalidate_xp_threshold_roles
 from utils.ui_constants import ECONOMY_COLOR
 from views.base import BaseView
+from views.navigation import attach_back_button
 from views.roles._helpers import _find_role_normalized
 
 logger = logging.getLogger("bot")
@@ -22,6 +23,21 @@ class XpRolesPanel(BaseView):
         super().__init__(ctx.author, timeout=300)
         self.ctx = ctx
         self.parent = parent
+
+        if parent is not None:
+
+            async def _build_parent(
+                _interaction: discord.Interaction,
+            ) -> tuple[discord.Embed, discord.ui.View]:
+                return parent.build_embed(), parent
+
+            attach_back_button(
+                self,
+                label="↩ Back",
+                custom_id="role:xp:back",
+                parent_builder=_build_parent,
+                row=1,
+            )
 
     async def build_embed(self) -> discord.Embed:
         all_rows = await db.get_role_thresholds(self.ctx.guild.id)
@@ -75,21 +91,6 @@ class XpRolesPanel(BaseView):
             view=view,
             ephemeral=True,
         )
-
-    @discord.ui.button(label="↩ Back", style=discord.ButtonStyle.secondary, row=1)
-    async def back_btn(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        if self.parent:
-            await interaction.response.edit_message(
-                embed=self.parent.build_embed(),
-                view=self.parent,
-            )
-        else:
-            await interaction.response.edit_message(view=None)
-        self.stop()
 
 
 class XpThresholdModal(

--- a/tests/unit/views/test_economy_work_result.py
+++ b/tests/unit/views/test_economy_work_result.py
@@ -80,38 +80,48 @@ async def test_job_select_replaces_subview_with_fresh_result_view():
     xp_result.new_level = 1
     xp_result.leveled_up = False
 
-    with patch(
-        "views.economy.work_panel.db.get_economy",
-        new_callable=AsyncMock,
-        return_value=eco_row,
-    ), patch(
-        "views.economy.work_panel.check_cooldown",
-        return_value=(False, 0),
-    ), patch(
-        "views.economy.work_panel.db.get_job_times",
-        new_callable=AsyncMock,
-        return_value=0,
-    ), patch(
-        "views.economy.work_panel._job_pay",
-        return_value=100,
-    ), patch(
-        "views.economy.work_panel.db.increment_job",
-        new_callable=AsyncMock,
-        return_value=1,
-    ), patch(
-        "views.economy.work_panel.economy_service.credit",
-        new_callable=AsyncMock,
-        return_value=500,
-    ), patch(
-        "views.economy.work_panel.xp_service.award",
-        new_callable=AsyncMock,
-        return_value=xp_result,
-    ), patch(
-        "views.economy.work_panel.db.set_last_worked",
-        new_callable=AsyncMock,
-    ), patch(
-        "views.economy.work_panel.post_log_embed",
-        new_callable=AsyncMock,
+    with (
+        patch(
+            "views.economy.work_panel.db.get_economy",
+            new_callable=AsyncMock,
+            return_value=eco_row,
+        ),
+        patch(
+            "views.economy.work_panel.check_cooldown",
+            return_value=(False, 0),
+        ),
+        patch(
+            "views.economy.work_panel.db.get_job_times",
+            new_callable=AsyncMock,
+            return_value=0,
+        ),
+        patch(
+            "views.economy.work_panel._job_pay",
+            return_value=100,
+        ),
+        patch(
+            "views.economy.work_panel.db.increment_job",
+            new_callable=AsyncMock,
+            return_value=1,
+        ),
+        patch(
+            "views.economy.work_panel.economy_service.credit",
+            new_callable=AsyncMock,
+            return_value=500,
+        ),
+        patch(
+            "views.economy.work_panel.xp_service.award",
+            new_callable=AsyncMock,
+            return_value=xp_result,
+        ),
+        patch(
+            "views.economy.work_panel.db.set_last_worked",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "views.economy.work_panel.post_log_embed",
+            new_callable=AsyncMock,
+        ),
     ):
         await select.callback(interaction)
 
@@ -119,9 +129,9 @@ async def test_job_select_replaces_subview_with_fresh_result_view():
     interaction.followup.edit_message.assert_awaited_once()
     kwargs = interaction.followup.edit_message.await_args.kwargs
     rendered_view = kwargs["view"]
-    assert isinstance(rendered_view, _WorkResultView), (
-        f"Expected _WorkResultView after job completion, got {type(rendered_view).__name__}"
-    )
+    assert isinstance(
+        rendered_view, _WorkResultView
+    ), f"Expected _WorkResultView after job completion, got {type(rendered_view).__name__}"
     assert kwargs["message_id"] == 1234
 
 
@@ -169,6 +179,13 @@ async def test_work_result_view_rejects_other_user_ephemerally():
 async def test_work_result_back_button_returns_to_economy_panel():
     """Clicking Back returns to a fresh ``EconomyPanelView`` with the
     economy overview embed.
+
+    The back button is constructed via
+    ``views.navigation.attach_back_button``, which calls the
+    parent-builder closure and then routes the edit through
+    ``response.edit_message`` (when the interaction is not yet
+    deferred) or ``edit_original_response`` (when deferred). This
+    test pins the not-yet-deferred path.
     """
     from views.economy.main_panel import EconomyPanelView
 
@@ -178,6 +195,7 @@ async def test_work_result_back_button_returns_to_economy_panel():
     interaction = MagicMock()
     interaction.user = _author(id_=1)
     interaction.guild_id = 2
+    interaction.response.is_done = MagicMock(return_value=False)
     interaction.response.edit_message = AsyncMock()
 
     with patch(


### PR DESCRIPTION
## Summary

PR 4 of the "Smooth Interaction Pass" plan. Closes the back-button adoption sweep started by PR #297 (helper consolidation).

All hand-rolled `@discord.ui.button("↩ Back")` handlers in channels, roles, and economy subpanels now route through `views/navigation.attach_back_button`.

**Channels (4):** `_CreateSubView`, `_DeleteSubView`, `_RestrictSubView`, `_VisibilitySubView`
**Roles (5):** `ManagementPanel`, `DiagnosticsPanel`, `XpRolesPanel`, `TimeRolesPanel`, `ReactionRolesPanel`
**Economy (3):** `_ShopSubView` (preserves the AB2 back-target chain to Help), `_WorkSubView`, `_WorkResultView`

Each parent-builder is a closure inside the subpanel's `__init__` that captures the necessary state (`ctx`, `manager_message`, `user_id`, …) and re-resolves the parent embed on click. **No new helpers introduced** per `docs/helper-policy.md`.

User behavior is unchanged — the click now just goes through the canonical helper's defer/edit-or-followup ladder and 25-component cap check.

## Test plan

- [x] `python -m pytest tests/` — **4140 passed**, 3 skipped
- [x] `ruff check disbot/views/channels/ disbot/views/roles/ disbot/views/economy/` — clean
- [x] `black --check ...` — clean
- [x] `test_economy_work_result.py` updated: pins the new not-yet-deferred path explicitly (`response.is_done=False`) so the assertion targets `response.edit_message` rather than `edit_original_response`.
- [ ] Manual smoke: enter each subpanel, click Back, verify lands on the correct parent
- [ ] Manual smoke: Economy → Help back-chain still works (`_ShopSubView._back_target` AB2)

## Roles `parent=None` cleanup note

The `if self.parent:` / `else: edit_message(view=None)` fallback in roles back buttons was dead code — both call sites always pass a parent. After migration the back button is only attached when `parent is not None`. If a future caller drops the parent, the panel simply doesn't render a back button (consistent with `attach_back_button`'s contract).

https://claude.ai/code/session_01CJgGhmCjeixzmoaMtjEjrZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJgGhmCjeixzmoaMtjEjrZ)_