### PR TITLE
feat(xp): add back button to XpConfigView when opened from XP hub

### DIFF
--- a/disbot/views/xp/config_panel.py
+++ b/disbot/views/xp/config_panel.py
@@ -17,12 +17,35 @@ from utils import db
 from utils.settings_keys import XP_ANNOUNCE_CHANNEL
 from utils.ui_constants import UTILITY_COLOR
 from views.base import BaseView
+from views.navigation import attach_back_button
 
 
 class XpConfigView(BaseView):
-    def __init__(self, ctx: commands.Context):
+    def __init__(
+        self,
+        ctx: commands.Context,
+        parent: BaseView | None = None,
+    ) -> None:
         super().__init__(ctx.author, timeout=300)
         self.ctx = ctx
+        self.parent = parent
+
+        if parent is not None:
+
+            async def _build_parent(
+                _interaction: discord.Interaction,
+            ) -> tuple[discord.Embed, discord.ui.View]:
+                # Parent (XP hub) has an async build_embed.
+                embed = await parent.build_embed()  # type: ignore[attr-defined]
+                return embed, parent
+
+            attach_back_button(
+                self,
+                label="↩ Back",
+                custom_id="xp:config:back",
+                parent_builder=_build_parent,
+                row=1,
+            )
 
     async def build_embed(self) -> discord.Embed:
         gid = self.ctx.guild.id

--- a/disbot/views/xp/main_panel.py
+++ b/disbot/views/xp/main_panel.py
@@ -63,7 +63,7 @@ class _XpHubView(HubView):
             return
         from views.xp.config_panel import XpConfigView
 
-        config_view = XpConfigView(self.ctx)
+        config_view = XpConfigView(self.ctx, parent=self)
         config_view.message = self.message
         await interaction.response.edit_message(
             embed=await config_view.build_embed(),


### PR DESCRIPTION
## Summary

PR 5 of the "Smooth Interaction Pass" plan. Adds the one **missing** back button flagged P0 in the audit (`docs/ui-view-adoption-audit.md` §9.2).

`XpConfigView` was opened from `_XpHubView`'s "⚙️ Configure" button, then a dead-end with no return path. Operators had to abandon the panel and re-type `!xpmenu`.

## Changes

- `XpConfigView.__init__` now accepts an optional `parent` kwarg.
- When `parent` is provided, attaches a canonical `↩ Back` button via `views/navigation.attach_back_button` that rebuilds the parent's embed on click.
- The typed `!xpconfig` command does not pass a parent — so it remains parentless (no back button), consistent with `attach_back_button`'s contract and with how the roles subpanels work post-PR 4.
- `_XpHubView.btn_config` now passes `parent=self`.

## Test plan

- [x] `python -m pytest tests/` — 4140 passed
- [x] `ruff check disbot/views/xp/` — clean
- [x] `black --check disbot/views/xp/` — clean
- [ ] Manual smoke: `!xpmenu` → ⚙️ Configure → ↩ Back returns to XP hub
- [ ] Manual smoke: `!xpconfig` directly → no back button (as expected)

https://claude.ai/code/session_01CJgGhmCjeixzmoaMtjEjrZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJgGhmCjeixzmoaMtjEjrZ)_