### PR TITLE
feat(rps): instant replay + back-to-RPS on solo result view

### DIFF
--- a/disbot/views/rps/solo_play.py
+++ b/disbot/views/rps/solo_play.py
@@ -7,6 +7,13 @@ The bet is not pre-escrowed (the user can play with zero balance and
 lose nothing more than they already have).  Win credits, loss debits
 with overdraft allowed to preserve the original floor-at-zero
 behaviour.
+
+After resolution the move buttons stay visible-but-disabled and a
+``Play again`` / ``↩ Back to RPS`` row is appended. ``Play again``
+spawns a fresh :class:`_RpsView` with the same user/guild/bet
+(after a balance pre-check when ``bet > 0``); ``Back to RPS``
+returns to :class:`views.games.rps_panel.RPSPanelView` via the
+shared :class:`views.games.common.BackToPanelButton`.
 """
 
 from __future__ import annotations
@@ -15,6 +22,7 @@ import random
 
 import discord
 
+from core.runtime.interaction_helpers import safe_defer, safe_edit, safe_followup
 from services import economy_service
 from utils import db as global_db
 from utils.ui_constants import ERROR_COLOR, GAME_COLOR, SUCCESS_COLOR
@@ -39,6 +47,11 @@ class _RpsView(discord.ui.View):
         return True
 
     async def _play(self, interaction: discord.Interaction, player_move: str):
+        # Defer up front — the economy write below races the 3 s
+        # interaction token under load.
+        if not await safe_defer(interaction):
+            return
+
         for item in self.children:
             item.disabled = True  # type: ignore[attr-defined]
 
@@ -91,8 +104,72 @@ class _RpsView(discord.ui.View):
             ),
             color=color,
         )
-        await interaction.response.edit_message(embed=embed, view=self)
+
+        self._attach_result_actions()
+
+        await safe_edit(interaction, embed=embed, view=self)
+        # Stop the original game's timeout. The newly-added result-action
+        # buttons remain clickable indefinitely (they have their own
+        # ownership check via interaction_check above).
         self.stop()
+
+    def _attach_result_actions(self) -> None:
+        """Append Play again + Back to RPS buttons on row 1.
+
+        Called once at end-of-game, after the move buttons on row 0 are
+        disabled.
+        """
+        replay_btn = discord.ui.Button(  # type: ignore[var-annotated]
+            label="🔁 Play again",
+            style=discord.ButtonStyle.success,
+            custom_id="rps:solo:replay",
+            row=1,
+        )
+        replay_btn.callback = self._replay  # type: ignore[method-assign]
+        self.add_item(replay_btn)
+
+        # Late import: rps_panel imports _RpsView, so importing it at
+        # module level would create a cycle.
+        from views.games.rps_panel import _make_rps_back_button
+
+        back_btn = _make_rps_back_button()
+        back_btn.row = 1
+        self.add_item(back_btn)
+
+    async def _replay(self, interaction: discord.Interaction) -> None:
+        """Spawn a fresh ``_RpsView`` with the same user/guild/bet.
+
+        If ``self.bet > 0`` the user's balance is pre-checked; if it
+        cannot cover the bet, an ephemeral nudge is sent and the
+        current result view is left in place so the user can use
+        Back to RPS instead.
+        """
+        if not await safe_defer(interaction):
+            return
+
+        if self.bet > 0:
+            bal = await global_db.get_coins(self.user.id, self.guild_id)
+            if bal < self.bet:
+                await safe_followup(
+                    interaction,
+                    (
+                        f"❌ Need **{self.bet}** 🪙 to replay at the same bet "
+                        f"(you have **{bal}**). Use **↩ Back to RPS** to pick "
+                        "a new bet or play free."
+                    ),
+                    ephemeral=True,
+                )
+                return
+
+        from views.games.rps_panel import build_rps_solo_embed
+
+        new_view = _RpsView(self.user, self.guild_id, self.bet)
+        await safe_edit(
+            interaction,
+            embed=build_rps_solo_embed(self.bet),
+            view=new_view,
+        )
+        new_view.message = interaction.message
 
     @discord.ui.button(label="Rock", emoji="🪨", style=discord.ButtonStyle.grey)
     async def rock(self, i: discord.Interaction, _: discord.ui.Button):

--- a/tests/unit/views/test_rps_solo_replay.py
+++ b/tests/unit/views/test_rps_solo_replay.py
@@ -1,0 +1,214 @@
+"""Regression tests for solo RPS instant-replay (Smooth Interaction Pass PR 6).
+
+Before this PR ``_RpsView._play`` disabled every child after the
+round resolved and stopped the view — leaving the user with no way
+to play again without retyping ``!rps`` or re-opening the panel.
+
+These tests pin the new contract:
+
+* After resolution the move buttons are disabled but two new
+  result-action buttons appear on row 1: ``🔁 Play again`` and
+  ``◀ Back to RPS``.
+* ``Play again`` spawns a *fresh* ``_RpsView`` (same user / guild /
+  bet) and edits the message in place. The old view stays stopped.
+* When ``bet > 0`` and balance is insufficient, replay sends an
+  ephemeral nudge and does NOT spawn a new game.
+* Wrong-user replay attempts are rejected ephemerally
+  (re-uses the existing ``interaction_check``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from views.rps.solo_play import _RpsView
+
+
+def _member(id_: int = 1) -> MagicMock:
+    user = MagicMock(spec=discord.Member)
+    user.id = id_
+    user.display_name = f"user{id_}"
+    user.mention = f"<@{id_}>"
+    return user
+
+
+def _interaction(user: MagicMock, *, is_done: bool = False) -> MagicMock:
+    interaction = MagicMock()
+    interaction.user = user
+    interaction.guild_id = 99
+    interaction.message = MagicMock()
+    interaction.message.id = 4242
+    interaction.response.is_done = MagicMock(return_value=is_done)
+    interaction.response.defer = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    interaction.followup.edit_original_response = AsyncMock()
+    interaction.edit_original_response = AsyncMock()
+    interaction.original_response = AsyncMock(return_value=MagicMock())
+    return interaction
+
+
+# ---------------------------------------------------------------------------
+# End-of-game: result row appended
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_play_appends_replay_and_back_buttons():
+    user = _member(id_=1)
+    view = _RpsView(user, guild_id=99, bet=0)
+    interaction = _interaction(user)
+
+    with (
+        patch(
+            "views.rps.solo_play.economy_service.credit",
+            new_callable=AsyncMock,
+            return_value=500,
+        ),
+        patch(
+            "views.rps.solo_play.economy_service.debit",
+            new_callable=AsyncMock,
+            return_value=500,
+        ),
+        patch(
+            "views.rps.solo_play.global_db.get_coins",
+            new_callable=AsyncMock,
+            return_value=500,
+        ),
+        patch(
+            "views.rps.solo_play.random.choice",
+            return_value="rock",
+        ),
+    ):
+        await view._play(interaction, "paper")  # paper beats rock → win
+
+    labels = [getattr(c, "label", None) for c in view.children]
+    assert any(label and "Play again" in label for label in labels), labels
+    assert any(label and "Back to RPS" in label for label in labels), labels
+
+    # Move buttons remain visible but disabled.
+    move_btns = [
+        c
+        for c in view.children
+        if getattr(c, "label", None) in ("Rock", "Paper", "Scissors")
+    ]
+    assert len(move_btns) == 3
+    for btn in move_btns:
+        assert btn.disabled is True
+
+
+@pytest.mark.asyncio
+async def test_play_disables_move_buttons_and_uses_safe_edit():
+    """Result edit uses ``safe_edit`` — not the raw response.edit_message
+    that the pre-PR-6 implementation used after I/O.
+    """
+    user = _member(id_=1)
+    view = _RpsView(user, guild_id=99, bet=10)
+    interaction = _interaction(user)
+
+    with (
+        patch(
+            "views.rps.solo_play.economy_service.credit",
+            new_callable=AsyncMock,
+            return_value=510,
+        ),
+        patch(
+            "views.rps.solo_play.global_db.get_coins",
+            new_callable=AsyncMock,
+            return_value=510,
+        ),
+        patch(
+            "views.rps.solo_play.random.choice",
+            return_value="rock",
+        ),
+    ):
+        await view._play(interaction, "paper")
+
+    interaction.response.defer.assert_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Replay: spawns fresh _RpsView
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_replay_spawns_fresh_view_for_free_play():
+    user = _member(id_=1)
+    finished = _RpsView(user, guild_id=99, bet=0)
+    interaction = _interaction(user, is_done=False)
+
+    await finished._replay(interaction)
+
+    interaction.response.defer.assert_awaited_once()
+    interaction.response.edit_message.assert_awaited_once()
+    kwargs = interaction.response.edit_message.await_args.kwargs
+    new_view = kwargs["view"]
+    assert isinstance(new_view, _RpsView)
+    assert new_view is not finished
+    assert new_view.bet == 0
+    assert new_view.user is user
+    assert new_view.guild_id == 99
+
+
+@pytest.mark.asyncio
+async def test_replay_spawns_fresh_view_when_bet_covered():
+    user = _member(id_=1)
+    finished = _RpsView(user, guild_id=99, bet=10)
+    interaction = _interaction(user)
+
+    with patch(
+        "views.rps.solo_play.global_db.get_coins",
+        new_callable=AsyncMock,
+        return_value=50,  # plenty
+    ):
+        await finished._replay(interaction)
+
+    interaction.response.edit_message.assert_awaited_once()
+    kwargs = interaction.response.edit_message.await_args.kwargs
+    new_view = kwargs["view"]
+    assert isinstance(new_view, _RpsView)
+    assert new_view.bet == 10
+
+
+@pytest.mark.asyncio
+async def test_replay_blocked_when_balance_too_low():
+    user = _member(id_=1)
+    finished = _RpsView(user, guild_id=99, bet=100)
+    interaction = _interaction(user)
+
+    with patch(
+        "views.rps.solo_play.global_db.get_coins",
+        new_callable=AsyncMock,
+        return_value=5,  # nowhere near 100
+    ):
+        await finished._replay(interaction)
+
+    # No view swap.
+    interaction.response.edit_message.assert_not_called()
+    # Ephemeral nudge via safe_followup → response.send_message (not deferred path)
+    # ...or followup.send (deferred path). One of them must fire.
+    sent = (
+        interaction.response.send_message.await_count
+        + interaction.followup.send.await_count
+    )
+    assert sent == 1
+
+
+@pytest.mark.asyncio
+async def test_replay_rejects_wrong_user():
+    """A different user clicking Play again gets the standard
+    interaction-check ephemeral, identical to a wrong-user move click.
+    """
+    owner = _member(id_=1)
+    finished = _RpsView(owner, guild_id=99, bet=0)
+    intruder = _member(id_=99)
+    interaction = _interaction(intruder)
+
+    allowed = await finished.interaction_check(interaction)
+    assert allowed is False
+    interaction.response.send_message.assert_awaited_once()


### PR DESCRIPTION
## Summary

PR 6 of the "Smooth Interaction Pass" plan.

Before this PR, `_RpsView._play` disabled every child after the round resolved and stopped the view — leaving the user with no way to play again without retyping `!rps` or re-opening the panel.

## Changes (`views/rps/solo_play.py`)

- Add `safe_defer` at the top of `_play`; replace raw `response.edit_message` with `safe_edit`. Eliminates the 3 s token-expiry race after `economy_service.{credit,debit}` writes (was listed in the UI adoption audit's "partial" hotspots).
- After resolution, `_attach_result_actions()` appends two buttons on row 1: **🔁 Play again** and **◀ Back to RPS** (reuses `_make_rps_back_button` from `views/games/rps_panel.py`; late-imported to avoid the cycle).
- Move buttons (row 0) remain visible-but-disabled — preserves the last-game context.
- `_replay()` creates a *fresh* `_RpsView` with the same user/guild/bet and edits the message in place. The old view stays stopped (no message corruption, no infinite-replay leak).
- **Same-bet rule:** when `bet > 0`, balance is pre-checked via `global_db.get_coins`. Insufficient balance → ephemeral nudge and the result view stays in place so the user can use Back to RPS.

## Out of scope

PvP and tournament RPS views are untouched.

## Test plan

- [x] `tests/unit/views/test_rps_solo_replay.py` — 6 new tests pin: result-row presence + disabled move buttons, fresh-view-on-replay for free + bet, balance gating when bet > 0, wrong-user rejection
- [x] `python -m pytest tests/` — **4146 passed**, 3 skipped
- [x] `ruff check disbot/views/rps/solo_play.py` — clean
- [x] `black --check ...` — clean
- [ ] Manual: `!rps 5`, click Rock, lose → click 🔁 Play again → fresh playable round
- [ ] Manual: `!rps 0` (free), tie → click 🔁 Play again → fresh free round
- [ ] Manual: lose all coins, click Play again with bet > 0 → ephemeral nudge, no view swap
- [ ] Manual: click ◀ Back to RPS → lands on `RPSPanelView`

https://claude.ai/code/session_01CJgGhmCjeixzmoaMtjEjrZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJgGhmCjeixzmoaMtjEjrZ)_