### PR TITLE
feat(blackjack): instant replay + back-to-Blackjack on solo result view

### DIFF
--- a/disbot/views/blackjack/solo_view.py
+++ b/disbot/views/blackjack/solo_view.py
@@ -5,6 +5,15 @@ per-player half of a PvP match.  PvP coordination is done via an
 ``on_finish`` callback supplied by ``_start_pvp``.  Tournament rounds
 use a separate view (``_TournBlackjackView``) because the chip / round
 bookkeeping differs.
+
+Solo end-of-hand UX: when a solo hand finishes (i.e. no PvP
+``on_finish`` callback and no ``tournament_chips``), ``_finish``
+appends a ``🔁 Play again`` / ``◀ Back to Blackjack`` row before
+re-rendering. ``Play again`` re-enters ``start_solo_blackjack``
+with the same user/guild/bet (after the same balance check the
+typed ``!blackjack`` command performs), so the active-game map and
+persistence path stay in one place. PvP and tournament views are
+untouched by the replay path.
 """
 
 from __future__ import annotations
@@ -88,11 +97,91 @@ class BlackjackView(discord.ui.View):
         else:
             embed.add_field(name=result, value="​", inline=False)
 
+        # Solo-only: attach replay + back action row before the edit so
+        # the user has an enabled escape from the result message.
+        if self.game.tournament_chips is None and self.on_finish is None:
+            self._attach_solo_result_actions()
+
         await safe_edit(interaction, embed=embed, view=self)
         self.stop()
 
         if self.on_finish:
             await self.on_finish(self.game, hand_value)
+
+    def _attach_solo_result_actions(self) -> None:
+        """Append Play again + Back to Blackjack buttons on row 1.
+
+        Called once at end-of-hand for solo games only. The original
+        hit/stand/double buttons on row 0 stay visible-but-disabled.
+        """
+        replay_btn = discord.ui.Button(  # type: ignore[var-annotated]
+            label="🔁 Play again",
+            style=discord.ButtonStyle.success,
+            custom_id="blackjack:solo:replay",
+            row=1,
+        )
+        replay_btn.callback = self._replay  # type: ignore[method-assign]
+        self.add_item(replay_btn)
+
+        # Late import: blackjack_panel imports BlackjackView indirectly
+        # via the actions helpers, so importing it at module level
+        # would create a cycle.
+        from views.games.blackjack_panel import _make_blackjack_back_button
+
+        back_btn = _make_blackjack_back_button()
+        back_btn.row = 1
+        self.add_item(back_btn)
+
+    async def _replay(self, interaction: discord.Interaction) -> None:
+        """Re-enter ``start_solo_blackjack`` with the same user/guild/bet.
+
+        Reuses the canonical entry point so the active-game map (``_active``),
+        persistence (``_save_game_state``), and natural-blackjack auto-payout
+        all behave identically to a fresh ``!blackjack`` invocation.
+        Balance is checked inside ``start_solo_blackjack``; insufficient
+        balance surfaces as an ephemeral nudge here.
+        """
+        if not await safe_defer(interaction):
+            return
+
+        # Late imports — actions imports BlackjackView at module level.
+        from cogs.blackjack.actions import (
+            commit_solo_blackjack,
+            start_solo_blackjack,
+        )
+
+        user = interaction.user
+        guild = interaction.guild
+        if guild is None:
+            await safe_followup(
+                interaction,
+                "❌ Replay isn't available in DMs.",
+                ephemeral=True,
+            )
+            return
+
+        result = await start_solo_blackjack(
+            user,
+            guild,
+            interaction.channel,  # type: ignore[arg-type]
+            self.game.bet,
+        )
+        if result.ephemeral_message is not None:
+            await safe_followup(
+                interaction,
+                result.ephemeral_message,
+                ephemeral=True,
+            )
+            return
+
+        # Natural blackjack auto-payout path: short-circuits with an
+        # embed but no playable view. Render the result and stop here.
+        if result.view is None:
+            await safe_edit(interaction, embed=result.embed, view=None)
+            return
+
+        await safe_edit(interaction, embed=result.embed, view=result.view)
+        await commit_solo_blackjack(result.view, interaction.message)  # type: ignore[arg-type]
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         if interaction.user.id != self.game.user_id:
@@ -125,6 +214,10 @@ class BlackjackView(discord.ui.View):
 
     @discord.ui.button(label="Hit", style=discord.ButtonStyle.green, emoji="👊")
     async def hit_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        # Defer up front — _save_game_state below races the 3 s
+        # interaction token once the I/O completes.
+        if not await safe_defer(interaction):
+            return
         self.game.hit()
         pv = _hand_value(self.game.player)
         if pv > 21:
@@ -142,7 +235,7 @@ class BlackjackView(discord.ui.View):
         # ``cog_load`` will clear either kind on next restart.
         await _save_game_state(self.game)
         self.double_btn.disabled = True
-        await interaction.response.edit_message(embed=_game_embed(self.game), view=self)
+        await safe_edit(interaction, embed=_game_embed(self.game), view=self)
 
     @discord.ui.button(label="Stand", style=discord.ButtonStyle.grey, emoji="✋")
     async def stand_btn(self, interaction: discord.Interaction, _: discord.ui.Button):

--- a/tests/unit/views/test_blackjack_solo_replay.py
+++ b/tests/unit/views/test_blackjack_solo_replay.py
@@ -1,0 +1,322 @@
+"""Regression tests for solo Blackjack instant-replay (Smooth Interaction Pass PR 7).
+
+Before this PR ``BlackjackView._finish`` disabled every child after
+the hand resolved and stopped the view — leaving the user with no
+way to play again without retyping ``!blackjack`` or re-opening the
+panel.
+
+These tests pin the new contract:
+
+* Solo end-of-hand appends two new buttons on row 1: ``🔁 Play
+  again`` and ``◀ Back to Blackjack``. PvP / tournament hands are
+  unchanged (no replay row).
+* ``Play again`` re-enters ``start_solo_blackjack`` (the canonical
+  entry point) and commits the new hand via the existing
+  ``commit_solo_blackjack`` helper, so ``_active`` and persistence
+  stay correct.
+* ``hit_btn`` now defers up front and uses ``safe_edit`` (the
+  pre-PR-7 raw ``response.edit_message`` after I/O was flagged in
+  the UI adoption audit's "partial" hotspots).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from cogs.blackjack._state import _Game
+from cogs.blackjack.actions import SoloStartResult
+from views.blackjack.solo_view import BlackjackView
+
+
+def _make_solo_game(user_id: int = 1, guild_id: int = 99, bet: int = 10) -> _Game:
+    return _Game(user_id, guild_id, bet, channel_id=42)
+
+
+def _interaction(user_id: int = 1, *, is_done: bool = False) -> MagicMock:
+    interaction = MagicMock()
+    interaction.user = MagicMock()
+    interaction.user.id = user_id
+    interaction.guild = MagicMock()
+    interaction.guild.id = 99
+    interaction.guild_id = 99
+    interaction.channel = MagicMock()
+    interaction.message = MagicMock()
+    interaction.message.id = 4242
+    interaction.response.is_done = MagicMock(return_value=is_done)
+    interaction.response.defer = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    interaction.followup.edit_original_response = AsyncMock()
+    interaction.edit_original_response = AsyncMock()
+    interaction.original_response = AsyncMock(return_value=MagicMock())
+    return interaction
+
+
+# ---------------------------------------------------------------------------
+# Solo _finish appends the replay+back row; PvP does not
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_solo_finish_appends_replay_and_back_buttons():
+    game = _make_solo_game()
+    view = BlackjackView(game, on_finish=None)
+    interaction = _interaction()
+
+    # Stub balance + economy calls — solo settle path runs inside _finish.
+    with (
+        patch(
+            "views.blackjack.solo_view.economy_service.credit",
+            new_callable=AsyncMock,
+            return_value=500,
+        ),
+        patch(
+            "views.blackjack.solo_view.db.get_coins",
+            new_callable=AsyncMock,
+            return_value=500,
+        ),
+        patch(
+            "views.blackjack.solo_view._clear_solo_game",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await view._finish(
+            interaction,
+            "🎉 You win!",
+            discord.Color.green(),
+            coin_delta=10,
+            hand_value=20,
+        )
+
+    labels = [getattr(c, "label", None) for c in view.children]
+    assert any(label and "Play again" in label for label in labels), labels
+    assert any(label and "Back to Blackjack" in label for label in labels), labels
+
+
+@pytest.mark.asyncio
+async def test_pvp_finish_does_not_append_replay_row():
+    """PvP path (on_finish callback present) must NOT gain replay
+    buttons — replay is solo-only.
+    """
+    game = _make_solo_game()
+    on_finish = AsyncMock()
+    view = BlackjackView(game, on_finish=on_finish)
+    interaction = _interaction()
+
+    with (
+        patch(
+            "views.blackjack.solo_view.economy_service.credit",
+            new_callable=AsyncMock,
+            return_value=500,
+        ),
+        patch(
+            "views.blackjack.solo_view.db.get_coins",
+            new_callable=AsyncMock,
+            return_value=500,
+        ),
+        patch(
+            "views.blackjack.solo_view._clear_solo_game",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await view._finish(
+            interaction,
+            "🎉 You win!",
+            discord.Color.green(),
+            coin_delta=10,
+            hand_value=20,
+        )
+
+    labels = [getattr(c, "label", None) for c in view.children]
+    assert not any(label and "Play again" in label for label in labels), labels
+    assert not any(label and "Back to Blackjack" in label for label in labels), labels
+    on_finish.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_tournament_finish_does_not_append_replay_row():
+    """Tournament path (tournament_chips != None) must NOT gain
+    replay buttons either.
+    """
+    game = _make_solo_game()
+    game.tournament_chips = 100  # mark as tournament
+    view = BlackjackView(game, on_finish=None)
+    interaction = _interaction()
+
+    with patch(
+        "views.blackjack.solo_view._clear_solo_game",
+        new_callable=AsyncMock,
+    ):
+        await view._finish(
+            interaction,
+            "🎉 You win!",
+            discord.Color.green(),
+            coin_delta=10,
+            hand_value=20,
+        )
+
+    labels = [getattr(c, "label", None) for c in view.children]
+    assert not any(label and "Play again" in label for label in labels), labels
+
+
+# ---------------------------------------------------------------------------
+# Replay button re-enters start_solo_blackjack
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_replay_calls_start_solo_blackjack_with_same_bet():
+    game = _make_solo_game(bet=25)
+    view = BlackjackView(game, on_finish=None)
+    interaction = _interaction()
+
+    new_game = _make_solo_game(bet=25)
+    new_view = BlackjackView(new_game, on_finish=None)
+    fake_result = SoloStartResult(
+        embed=discord.Embed(title="new hand"),
+        view=new_view,
+        game=new_game,
+    )
+
+    with (
+        patch(
+            "cogs.blackjack.actions.start_solo_blackjack",
+            new_callable=AsyncMock,
+            return_value=fake_result,
+        ) as start_mock,
+        patch(
+            "cogs.blackjack.actions.commit_solo_blackjack",
+            new_callable=AsyncMock,
+        ) as commit_mock,
+    ):
+        await view._replay(interaction)
+
+    start_mock.assert_awaited_once()
+    args, kwargs = start_mock.await_args
+    # Positional: user, guild, channel, bet
+    assert args[3] == 25  # bet
+    commit_mock.assert_awaited_once_with(new_view, interaction.message)
+
+
+@pytest.mark.asyncio
+async def test_replay_surfaces_short_circuit_message_ephemerally():
+    """When start_solo_blackjack returns an ephemeral message
+    (e.g. "You already have a game running!", "❌ You only have N 🪙."),
+    the replay handler must surface it as an ephemeral followup and
+    NOT edit the message.
+    """
+    game = _make_solo_game(bet=1000)
+    view = BlackjackView(game, on_finish=None)
+    interaction = _interaction()
+
+    fake_result = SoloStartResult(
+        embed=None,
+        view=None,
+        game=None,
+        ephemeral_message="❌ You only have 5 🪙.",
+    )
+
+    with patch(
+        "cogs.blackjack.actions.start_solo_blackjack",
+        new_callable=AsyncMock,
+        return_value=fake_result,
+    ):
+        await view._replay(interaction)
+
+    # Some path must have sent the ephemeral — followup.send (post-defer).
+    sent = (
+        interaction.response.send_message.await_count
+        + interaction.followup.send.await_count
+    )
+    assert sent == 1
+    # Message was NOT edited to a new game state.
+    interaction.response.edit_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_replay_handles_natural_blackjack_auto_payout():
+    """If the new deal is a natural blackjack, start_solo_blackjack
+    returns ``view=None`` with the payout embed; the replay handler
+    must render that embed without trying to commit a non-existent
+    view.
+    """
+    game = _make_solo_game(bet=10)
+    view = BlackjackView(game, on_finish=None)
+    interaction = _interaction()
+
+    auto_embed = discord.Embed(title="natural-blackjack")
+    fake_result = SoloStartResult(embed=auto_embed, view=None, game=None)
+
+    with (
+        patch(
+            "cogs.blackjack.actions.start_solo_blackjack",
+            new_callable=AsyncMock,
+            return_value=fake_result,
+        ),
+        patch(
+            "cogs.blackjack.actions.commit_solo_blackjack",
+            new_callable=AsyncMock,
+        ) as commit_mock,
+    ):
+        await view._replay(interaction)
+
+    commit_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# hit_btn now defers up front
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hit_btn_defers_before_save_game_state():
+    """Pre-PR-7, hit_btn called _save_game_state (DB I/O) and then
+    raw response.edit_message — risking 3 s token expiry. The fix
+    defers up front; this test pins the defer happens before the
+    persistence call.
+    """
+    game = _make_solo_game()
+    view = BlackjackView(game, on_finish=None)
+    interaction = _interaction()
+
+    call_order: list[str] = []
+
+    async def fake_defer(_i, **_kw):
+        call_order.append("defer")
+        return True
+
+    async def fake_save(_game):
+        call_order.append("save")
+
+    async def fake_edit(_i, **_kw):
+        call_order.append("edit")
+        return True
+
+    # @discord.ui.button stores the original async function on the class
+    # as the descriptor; reach the raw coroutine and call it with
+    # self=view explicitly.
+    hit_callback = type(view).hit_btn
+
+    with (
+        patch(
+            "views.blackjack.solo_view.safe_defer",
+            new=fake_defer,
+        ),
+        patch(
+            "views.blackjack.solo_view._save_game_state",
+            new=fake_save,
+        ),
+        patch(
+            "views.blackjack.solo_view.safe_edit",
+            new=fake_edit,
+        ),
+    ):
+        await hit_callback(view, interaction, MagicMock())
+
+    # Defer must come before save (and edit).
+    assert call_order.index("defer") < call_order.index("save")
+    assert call_order.index("save") < call_order.index("edit")


### PR DESCRIPTION
## Summary

PR 7 of the "Smooth Interaction Pass" plan.

Before this PR, `BlackjackView._finish` disabled every child after the hand resolved and stopped the view — leaving the user with no way to play again without retyping `!blackjack` or re-opening the panel. Also, `hit_btn` called `_save_game_state` (DB I/O) and then raw `response.edit_message` — flagged in the UI adoption audit as a "partial" hotspot (3 s token-expiry race after I/O).

## Changes (`views/blackjack/solo_view.py`)

- **Solo gate.** `_finish` only appends the replay row when `tournament_chips is None AND on_finish is None`. PvP and tournament hands are completely untouched.
- **Result actions.** `_attach_solo_result_actions()` appends two buttons on row 1: **🔁 Play again** and **◀ Back to Blackjack** (reuses the existing `_make_blackjack_back_button` from `views/games/blackjack_panel.py`; late-imported to avoid the cycle).
- **Replay via canonical entry point.** `_replay()` re-enters `cogs.blackjack.actions.start_solo_blackjack` with the same user/guild/bet, then commits via the existing `commit_solo_blackjack` helper. Keeps the active-game map (`_active`) and persistence (`_save_game_state`) in one place — no inline `_Game` construction.
- **Edge cases handled.** Natural-blackjack auto-payout (`view=None`) and short-circuit messages ("already playing", "insufficient balance") surface correctly without corrupting the message.
- **hit_btn safety fix.** Now defers up front (`safe_defer`) and uses `safe_edit` instead of raw `response.edit_message` after `_save_game_state`.

## Out of scope

PvP and tournament Blackjack views are not modified. Blackjack engine and payout rules unchanged.

## Test plan

- [x] `tests/unit/views/test_blackjack_solo_replay.py` — 7 new tests pin: solo-only result row, PvP/tournament unchanged, replay routes through `start_solo_blackjack` with the same bet, ephemeral short-circuit surfacing, natural-blackjack auto-payout, `hit_btn` defer-before-save ordering
- [x] `python -m pytest tests/` — **4147 passed**, 3 skipped
- [x] `ruff check disbot/views/blackjack/solo_view.py` — clean
- [x] `black --check ...` — clean
- [ ] Manual: `!blackjack 10`, bust → click 🔁 Play again → fresh hand at same bet
- [ ] Manual: `!blackjack` (free), push → click 🔁 Play again → fresh free hand
- [ ] Manual: lose down to <bet, click Play again → ephemeral "❌ You only have N 🪙."
- [ ] Manual: get a natural blackjack on replay → auto-payout embed renders cleanly
- [ ] Manual: click ◀ Back to Blackjack → lands on `BlackjackPanelView`
- [ ] Manual: PvP and tournament hands still finish normally with no replay buttons

https://claude.ai/code/session_01CJgGhmCjeixzmoaMtjEjrZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJgGhmCjeixzmoaMtjEjrZ)_