### PR TITLE
docs(smoke): pin Smooth Interaction Pass UX guarantees

### DIFF
--- a/docs/smoke-test-checklist.md
+++ b/docs/smoke-test-checklist.md
@@ -151,6 +151,76 @@ Trigger `SIGTERM` (or run `kill -TERM $PID`) and observe:
 - [ ] **DB pool closed** — final log line "Bot exiting cleanly" or
       no `asyncpg` warnings on stderr.
 
+## Smooth Interaction Pass — UX guarantees
+
+These bullets pin the user-facing guarantees of the Smooth Pass
+PRs (Platform hub completeness, back-button coverage, solo-game
+instant replay). Smoke any UI-touching PR against them.
+
+### Platform hub completeness
+
+- [ ] **`!platform` overview** shows five sections: Runtime/status,
+      Catalogues, Resources/rollout, Validation, Mutations/managers.
+- [ ] **`lifecycle`** appears in the Runtime/status dropdown and
+      renders the same embed as typed `!platform lifecycle`.
+- [ ] **`setup-readiness`** appears in the Validation dropdown and
+      renders the same embed as typed `!platform setup-readiness`.
+- [ ] **`🚩 Flag manager` button** on row 4 opens the editable
+      `FlagManagerView`, identical to typed `!platform flag`.
+- [ ] **Overview** button on row 4 returns to the platform hub
+      overview embed.
+
+### Back-button coverage
+
+Pinned by `docs/ui-view-adoption-audit.md` §9 — every user-facing
+subpanel has either an `attach_back_button`-driven Back or is
+classified as none-needed.
+
+- [ ] **Channels subpanels** (`Create / Delete / Restrict /
+      Visibility`) all return to `_ChannelManagerView` via Back.
+- [ ] **Roles subpanels** (`Management / Diagnostics / XpRoles /
+      TimeRoles / ReactionRoles`) all return to `RoleHubView` via
+      Back when opened from the hub.
+- [ ] **Economy subpanels** (`Shop / Work / Work-result`) all
+      return to `EconomyPanelView` via Back; `_ShopSubView`
+      preserves the AB2 back-target chain to Help when present.
+- [ ] **`XpConfigView`** opened from `!xpmenu` → ⚙️ Configure
+      returns to `_XpHubView` via Back; typed `!xpconfig`
+      intentionally has no Back (no parent).
+
+### Solo-game instant replay
+
+- [ ] **Solo RPS result view** (`!rps 0` or `!rps <bet>`) shows
+      `🔁 Play again` + `◀ Back to RPS` on row 1. Move buttons on
+      row 0 remain visible-but-disabled.
+- [ ] **Solo RPS replay** spawns a fresh playable round at the
+      same bet. Insufficient balance → ephemeral nudge, no view
+      swap.
+- [ ] **Solo Blackjack result view** (`!blackjack 0` or
+      `!blackjack <bet>`) shows `🔁 Play again` + `◀ Back to
+      Blackjack` on row 1. Hit/Stand/Double buttons remain
+      visible-but-disabled.
+- [ ] **Solo Blackjack replay** routes through
+      `cogs.blackjack.actions.start_solo_blackjack` — `_active`
+      map is cleared first, persistence (`_save_game_state`) lands
+      on the new hand. Insufficient balance / "already playing" /
+      natural-blackjack auto-payout all surface correctly.
+- [ ] **PvP / tournament** Blackjack and RPS hands finish with no
+      replay row attached (gate is solo-only:
+      `tournament_chips is None AND on_finish is None`).
+
+### Interaction-safety wrappers
+
+Pinned by `docs/ui-view-adoption-audit.md` §3 — hotspots converted
+to `safe_defer` + `safe_edit`.
+
+- [ ] **`_RpsView._play`** defers up front and uses `safe_edit`
+      (no raw `response.edit_message` after the
+      `economy_service.{credit,debit}` writes).
+- [ ] **`BlackjackView.hit_btn`** defers up front and uses
+      `safe_edit` (no raw `response.edit_message` after
+      `_save_game_state`).
+
 ---
 
 ## Updating this checklist


### PR DESCRIPTION
## Summary

PR 8 of the "Smooth Interaction Pass" plan. Final PR in the sequence — doc-only.

Adds a **Smooth Interaction Pass — UX guarantees** section to `docs/smoke-test-checklist.md` covering the four user-facing guarantees from PRs 1-7 of the pass:

1. **Platform hub completeness** — `!platform` shows `lifecycle`, `setup-readiness`, and the `🚩 Flag manager` button (PR 1).
2. **Back-button coverage** — every subpanel listed in §9 of the UI adoption audit has a working Back via `attach_back_button` (or is none-needed) (PR 4 + PR 5).
3. **Solo-game instant replay** — RPS and Blackjack solo result views expose Play again + Back to <game>; PvP/tournament are excluded by the solo gate (PR 6 + PR 7).
4. **Interaction-safety wrappers** — the two new `safe_defer`/`safe_edit` hotspots fixed in PRs 6-7 (`_RpsView._play` and `BlackjackView.hit_btn`).

Existing checklist sections (boot, health probes, consistency, startup outcomes, catalogues, tasks, setup wizard, help, shutdown drain) are unchanged — doc-pin tests in `tests/unit/docs/test_smoke_test_checklist.py` still pass.

## Helper-promotion decision

No new shared helper. RPS and Blackjack result-action shapes differ enough (different back-button factories, different replay strategies — inline view spawn vs canonical `start_solo_blackjack` delegation) that abstracting a shared helper would be premature per `docs/helper-policy.md`. The original plan flagged this PR as conditional on both shipping near-identical code; they did not.

## Test plan

- [x] `python -m pytest tests/unit/docs/` — 44 passed
- [x] Doc renders cleanly
- [x] No code changes, no new helpers

## Plan completion

This closes the 8-PR "Smooth Interaction Pass" sequence:

| PR | Title | Status |
|---|---|---|
| #300 | Platform hub: lifecycle / setup-readiness / flag manager | merged |
| #301 | Back-button coverage audit (doc) | merged |
| #302 | Cog-hub coverage audit (doc) | merged |
| #303 | Migrate 12 hand-rolled back buttons to attach_back_button | merged |
| #304 | XpConfigView back button | merged |
| #305 | RPS solo instant replay | open |
| #306 | Blackjack solo instant replay | open |
| **this** | Smoke checklist UX guarantees | open |

https://claude.ai/code/session_01CJgGhmCjeixzmoaMtjEjrZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJgGhmCjeixzmoaMtjEjrZ)_