### PR TITLE
hardening: service ownership reference, mutation audit, setup_session audit coverage

### DIFF
--- a/disbot/services/setup_session.py
+++ b/disbot/services/setup_session.py
@@ -20,7 +20,9 @@ the embed / view orchestration.
 from __future__ import annotations
 
 import logging
+import uuid
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any
 
 from utils.db import setup_session as db
@@ -90,6 +92,13 @@ async def start_session(
             f"setup_session.start_session: row for guild_id={guild_id} "
             "missing immediately after upsert.",
         )
+    await _emit_session_audit(
+        guild_id=guild_id,
+        mutation_type="setup.session.started",
+        new_value="pending",
+        actor_id=owner_id,
+        actor_type="user",
+    )
     return SetupSession.from_row(row)
 
 
@@ -121,6 +130,13 @@ async def mark_complete(guild_id: int) -> None:
     await db.set_step(guild_id, None)
     await db.clear_skipped_sections(guild_id)
     await _clear_draft(guild_id)
+    await _emit_session_audit(
+        guild_id=guild_id,
+        mutation_type="setup.session.completed",
+        new_value="complete",
+        actor_id=None,
+        actor_type="system",
+    )
 
 
 async def dismiss(guild_id: int) -> None:
@@ -136,6 +152,50 @@ async def dismiss(guild_id: int) -> None:
     await db.set_step(guild_id, None)
     await db.clear_skipped_sections(guild_id)
     await _clear_draft(guild_id)
+    await _emit_session_audit(
+        guild_id=guild_id,
+        mutation_type="setup.session.dismissed",
+        new_value="dismissed",
+        actor_id=None,
+        actor_type="system",
+    )
+
+
+async def _emit_session_audit(
+    *,
+    guild_id: int,
+    mutation_type: str,
+    new_value: str,
+    actor_id: int | None,
+    actor_type: str,
+) -> None:
+    """Best-effort ``audit.action_recorded`` emission for setup session lifecycle.
+
+    Lazy-imported to avoid a circular dependency (same pattern as _clear_draft).
+    Failure is logged at WARNING and swallowed — the DB transition is authoritative.
+    """
+    try:
+        from services import audit_events
+
+        await audit_events.emit_audit_action(
+            mutation_id=str(uuid.uuid4()),
+            subsystem="setup",
+            mutation_type=mutation_type,
+            target=f"setup_session:{guild_id}",
+            scope="guild",
+            guild_id=guild_id,
+            prev_value=None,
+            new_value=new_value,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            occurred_at=datetime.now(timezone.utc),
+        )
+    except Exception:
+        logger.warning(
+            "setup_session: audit emission failed for guild_id=%s mutation_type=%s",
+            guild_id,
+            mutation_type,
+        )
 
 
 async def _clear_draft(guild_id: int) -> None:

--- a/docs/AGENT_ORIENTATION.md
+++ b/docs/AGENT_ORIENTATION.md
@@ -135,6 +135,8 @@ top before trusting the contents.
 - `docs/games-actionability-roadmap.md` (status: complete — historical now)
 - `docs/helper-debt-inventory.md` (snapshot — companion to `helper-policy.md`)
 - `docs/ui-view-adoption-audit.md` (snapshot — companion to `helper-debt-inventory.md`)
+- `docs/audits/mutation_boundary_audit.md` — mutation boundary audit results.
+  Run against the codebase post-hardening session (2026-05-24).
 
 ### Standards / reference guides
 
@@ -147,6 +149,9 @@ has already been done.
 - `docs/building-roadmap/mother-hub-map.md`
 - `docs/settings-customization-roadmap.md`
 - `docs/resource-provisioning-overview.md`
+- `docs/architecture/service_ownership.md` — enriched "at a glance" ownership lookup.
+  Quick-reference companion to `docs/ownership.md`; `ownership.md` is authoritative
+  when the two disagree.
 
 ### Plans / roadmaps (read for context only)
 

--- a/docs/architecture/service_ownership.md
+++ b/docs/architecture/service_ownership.md
@@ -1,0 +1,88 @@
+# SuperBot — Service Ownership Quick Reference
+
+> **Status:** reference (not binding). This is a quick-lookup companion to
+> `docs/ownership.md`. When this table and `docs/ownership.md` disagree,
+> **`docs/ownership.md` is authoritative.** Update this table when
+> `docs/ownership.md` changes, not the other way around.
+>
+> **Purpose:** Give an agent or contributor a single-glance answer to "how must
+> I route this mutation?" without reading the full binding doc. Use this to
+> pick the write path; use `docs/ownership.md` to understand the contract.
+
+---
+
+## How to use
+
+1. Find the domain row for the state you want to change.
+2. Confirm your caller is in the "Allowed callers" list.
+3. Call the documented write path — nothing else.
+4. Verify the required side effects happen automatically through that path.
+5. If your caller is not listed, route through an allowed caller or propose a
+   contract change in `docs/ownership.md` first.
+
+---
+
+## Mutation ownership matrix
+
+| Domain | Owner module | Allowed callers | Write path | Audit / event / cache side effects | Documented exceptions |
+|---|---|---|---|---|---|
+| **Economy** | `services/economy_service.py` | cogs, views, setup pipeline | `credit()` / `debit()` / `transfer()` / `bet_and_settle()` / `refund()` | `economy_audit_log` row (same txn) + `economy.balance_changed` event | none — INV-F (AST test) enforces this |
+| **XP** | `services/xp_service.py` | cogs, listeners, jobs | `award()` / `reset()` | `xp.awarded` / `xp.level_up` / `xp.reset` events; level recalculation included | none — INV-G (AST test) enforces this |
+| **Governance** | `governance/writes.py:GovernanceMutationPipeline` | governance cog, admin views, setup pipeline | pipeline methods (`set_visibility`, `set_cleanup_policy_for_scope`) | `governance_audit_log` row + 3 `governance.*` events + `guild_config` cache invalidate | `governance/execution.py:_audit_internal_bypass` — append-only audit row for internal bypasses; documented in `docs/ownership.md` |
+| **Moderation** | `services/moderation_service.py` | mod cog, views, scheduled jobs | `warn()` / `timeout()` / `kick()` / `ban()` / `unban()` / `clear_warnings()` | `mod_logs` row + `moderation.action_taken` event | none |
+| **Settings** | `services/settings_mutation.py:SettingsMutationPipeline` | setup pipeline, settings cog/views | `set_value()` | `settings_audit` row + `audit.action_recorded` event + `guild_config` cache invalidate | none |
+| **Bindings** | `services/binding_mutation.py:BindingMutationPipeline` | setup pipeline, binding cog/views | `set_binding()` / `clear_binding()` | `binding_audit_log` row + `audit.action_recorded` event + `guild_config` cache invalidate | none |
+| **Resources** | `services/resource_provisioning.py:ResourceProvisioningPipeline` | setup pipeline, admin | `provision(confirmed=True)` | `resource_provisioning_audit` row + `EVT_RESOURCE_PROVISIONED` event | none (no production callers yet — planned for S7/S10) |
+| **Game state** | `services/game_state_service.py` | game cogs, game views | `save()` / `load()` / `clear()` / `list_active_for_subsystem()` | none — checkpoint frequency makes audit rows noisy; see ADR-002 | none |
+| **Setup session** | `services/setup_session.py` | setup cog, launcher view | `start_session()` / `mark_complete()` / `dismiss()` | best-effort `audit.action_recorded` event after DB write; failure is logged and swallowed | none |
+| **Flags / rollout** | `services/rollout_mutation.py:RolloutMutationPipeline` | operator scripts (Phase 3 only — no Discord-facing UI yet) | `set_flag_state()` / `advance_rollout()` / `set_environment_tier()` | `feature_flag_audit` row + `EVT_FEATURE_FLAGS_CHANGED` / `EVT_ROLLOUT_ADVANCED` / `EVT_ENVIRONMENT_TIER_CHANGED` events + flag cache invalidate | none |
+| **Participation** | `services/participation_mutation.py:ParticipationMutationPipeline` | cogs, views (self-write only — actor must equal user) | `set_participation()` / `set_subscription()` / `set_preference()` / `set_visibility()` | per-table audit rows + `audit.action_recorded` + synchronous user-config cache invalidate (inline, before event) + domain events | none |
+| **Automation rules** | `services/automation_mutation.py:AutomationMutationPipeline` | admin cog/views, setup pipeline | `create_rule()` / `set_enabled()` / `delete_rule()` | config validation + `EVT_AUTOMATION_RULE_CHANGED` event | none |
+| **Inventory** | `utils/db/inventory.py` | `cogs/inventory_cog.py` only | direct `utils/db/inventory.*` calls | none — simple CRUD, no cross-subsystem impact | intentional — documented in `docs/ownership.md` subsystem table |
+| **Counting / Chain / Mining / Deathmatch** | `utils/db/games/<sub>.py` per subsystem | the subsystem's own cog only | direct `utils/db/games/<sub>.*` calls | none — single-subsystem state, simple CRUD | intentional — documented in `docs/ownership.md` subsystem table |
+
+---
+
+## Platform-owned surfaces
+
+These are not domain mutations — they are infrastructure writes owned by
+`core/runtime/` or `governance/`. Do not call them from cogs or views directly.
+
+| Surface | Owner | Allowed writers | Write method |
+|---|---|---|---|
+| `panel_anchors` | `core.runtime.message_anchor_manager` | panel manager only | `upsert_panel_anchor` / `mark_panel_anchor_stale` |
+| `runtime_sessions` | `core.runtime.session_manager` | session manager only | session lifecycle methods |
+| `runtime_session_state` | `core.runtime.state_store` | state store only | `set` / `set_many` / `delete` / `invalidate_guild_state` |
+| `game_state` | `services/game_state_service.py` | game cogs, game views | `save` / `load` / `clear` |
+| `economy_audit_log` | `services/economy_service.py` | service only (append-only) | inside economy service methods |
+| `governance_audit_log` | `GovernanceMutationPipeline` | pipeline only (append-only) | `_audit_internal_bypass` carve-out documented |
+
+---
+
+## What "correct" looks like end-to-end
+
+```
+cog / view / setup pipeline
+  │
+  └─▶  service / pipeline
+          ├─ 1. validate inputs
+          ├─ 2. open transaction (if multi-row)
+          ├─ 3. apply DB write
+          ├─ 4. append audit row (same transaction)
+          └─ 5. after commit: invalidate cache → emit catalogued event
+```
+
+The side effects in step 5 are automatic when you use the service/pipeline.
+Callers do not need to invalidate caches or emit events themselves.
+
+---
+
+## Adding a new mutation domain
+
+1. Add a row to `docs/ownership.md`'s **Service ownership** and **Subsystem
+   ownership** tables — that is the binding contract.
+2. Add a row to this table as a convenience.
+3. Add the new catalogued event to `core/events_catalogue.KNOWN_EVENTS` and to
+   `docs/ownership.md`'s event table.
+4. Add an AST-enforcement test in `tests/unit/invariants/` if the blocklist
+   should be machine-checked (follow the INV-F / INV-G pattern).

--- a/docs/audits/mutation_boundary_audit.md
+++ b/docs/audits/mutation_boundary_audit.md
@@ -1,0 +1,146 @@
+# SuperBot — Mutation Boundary Audit
+
+> **Status:** living inventory. Run against the codebase after the
+> Service Ownership Hardening session (2026-05-24). Update this document
+> when new mutation paths are introduced or existing paths change.
+>
+> **Authority:** `docs/ownership.md` is the binding ownership contract.
+> This document records audit findings against that contract — it does not
+> define new rules.
+
+---
+
+## Summary
+
+| Status | Count | Domains |
+|---|---|---|
+| `correct` | 9 | Economy, XP, Governance, Moderation, Settings, Bindings, Resources, Setup apply path, Game state |
+| `missing side effect` | 1 | Setup session lifecycle — **fixed in this session** |
+| `documented exception` | 5 | Inventory, Counting, Chain, Mining, Deathmatch |
+| `violation` | 0 | — |
+
+**No blocking violations found.** The one `missing side effect` gap (setup_session
+audit emission) was closed in the same session as this audit.
+
+---
+
+## Status definitions
+
+| Status | Meaning |
+|---|---|
+| `correct` | Routes through declared owner with all required side effects (validate → write → audit → cache → event) |
+| `missing side effect` | Correct owner is used, but audit / cache / event / rollback behavior is incomplete |
+| `documented exception` | Direct write path is explicitly allowed and documented in `docs/ownership.md` |
+| `legacy tolerated` | Imperfect but low-risk and not worth fixing yet; tracked separately |
+| `violation` | Writes through the wrong layer — must be fixed before next feature PR |
+
+## Risk levels
+
+| Risk | Criteria |
+|---|---|
+| P0 | Can corrupt money, XP, moderation records, governance permissions, or production startup/shutdown safety |
+| P1 | Can create inconsistent guild configuration or stale caches |
+| P2 | Can create confusing UX, duplicate behavior, or incomplete diagnostics |
+| P3 | Cleanup / observability only — no correctness impact |
+
+---
+
+## Audit table
+
+| Domain | Caller | Mutation | Current path | Correct owner | Required side effects | Status | Risk | Fix applied |
+|---|---|---|---|---|---|---|---|---|
+| Economy — credit | cogs, views, setup pipeline | coin credit | `economy_service.credit()` | `services/economy_service.py` | `economy_audit_log` row + `economy.balance_changed` | `correct` | — | — |
+| Economy — debit | cogs, views, setup pipeline | coin debit | `economy_service.debit()` | `services/economy_service.py` | `economy_audit_log` row + `economy.balance_changed` | `correct` | — | — |
+| Economy — transfer | economy cog, views | peer transfer | `economy_service.transfer()` | `services/economy_service.py` | two `economy_audit_log` rows + event | `correct` | — | — |
+| Economy — bet/settle | game views (BJ, RPS) | game payout | `economy_service.bet_and_settle()` | `services/economy_service.py` | `economy_audit_log` rows + event | `correct` | — | — |
+| XP — award | cogs, listeners, work view | XP grant | `xp_service.award()` | `services/xp_service.py` | `xp.awarded` + `xp.level_up` events | `correct` | — | — |
+| XP — reset | admin cog | XP reset | `xp_service.reset()` | `services/xp_service.py` | `xp.reset` event | `correct` | — | — |
+| Governance — visibility | governance cog, admin views, setup pipeline | subsystem visibility | `GovernanceMutationPipeline.set_visibility()` | `governance/writes.py` | `governance_audit_log` + events + cache invalidate | `correct` | — | — |
+| Governance — cleanup policy | governance cog, setup pipeline | cleanup policy | `GovernanceMutationPipeline.set_cleanup_policy_for_scope()` | `governance/writes.py` | `governance_audit_log` + events + cache invalidate | `correct` | — | — |
+| Governance — internal bypass audit | `governance/execution.py` | bypass audit row only | `_audit_internal_bypass()` (carve-out) | `governance/writes.py` (carve-out) | append-only row, no events | `documented exception` | — | — |
+| Moderation — warn | mod cog, views | warning record | `moderation_service.warn()` | `services/moderation_service.py` | `mod_logs` row + `moderation.action_taken` | `correct` | — | — |
+| Moderation — timeout/kick/ban/unban | mod cog, views | Discord action + record | `moderation_service.timeout()` / `.kick()` / `.ban()` / `.unban()` | `services/moderation_service.py` | `mod_logs` row + Discord API call + `moderation.action_taken` | `correct` | — | — |
+| Moderation — clear warnings | mod cog, admin views | warning bulk clear | `moderation_service.clear_warnings()` | `services/moderation_service.py` | `mod_logs` row + `moderation.action_taken` | `correct` | — | — |
+| Settings — set value | setup pipeline, settings cog/views | guild setting write | `SettingsMutationPipeline.set_value()` | `services/settings_mutation.py` | `settings_audit` row + `audit.action_recorded` + cache invalidate | `correct` | — | — |
+| Bindings — set binding | setup pipeline, binding views | channel/role binding | `BindingMutationPipeline.set_binding()` | `services/binding_mutation.py` | `binding_audit_log` row + `audit.action_recorded` + cache invalidate | `correct` | — | — |
+| Bindings — clear binding | setup pipeline | binding removal | `BindingMutationPipeline.clear_binding()` | `services/binding_mutation.py` | `binding_audit_log` row + `audit.action_recorded` + cache invalidate | `correct` | — | — |
+| Resources — provision | setup pipeline | channel/role/category creation | `ResourceProvisioningPipeline.provision(confirmed=True)` | `services/resource_provisioning.py` | `resource_provisioning_audit` row + `EVT_RESOURCE_PROVISIONED` | `correct` | — | — |
+| Setup apply path | final review view | staged operation apply | `setup_operations.apply_operations()` dispatcher → domain pipelines | setup is orchestrator; domain pipelines own writes | depends on operation kind (each routes correctly) | `correct` | — | — |
+| Game state — checkpoints | game cogs, game views | in-flight game state | `game_state_service.save()` / `.clear()` | `services/game_state_service.py` | none (audit-free by design — ADR-002) | `correct` | — | — |
+| Game state — balance settlements | game views (BJ, RPS, proof_channel) | coin delta on game outcome | `economy_service.credit()` / `.debit()` / `.bet_and_settle()` | `services/economy_service.py` | full economy side effects | `correct` | — | — |
+| Setup session — start | setup cog, launcher | `setup_session` row upsert | `setup_session.start_session()` → `utils/db/setup_session.*` | `services/setup_session.py` | **was missing `audit.action_recorded`** | `missing side effect` → **fixed** | P3 | Added `audit.action_recorded` emission (best-effort) |
+| Setup session — complete | final review view | status → "complete" | `setup_session.mark_complete()` → `utils/db/setup_session.*` | `services/setup_session.py` | **was missing `audit.action_recorded`** | `missing side effect` → **fixed** | P3 | Added `audit.action_recorded` emission (best-effort) |
+| Setup session — dismiss | launcher view | status → "dismissed" | `setup_session.dismiss()` → `utils/db/setup_session.*` | `services/setup_session.py` | **was missing `audit.action_recorded`** | `missing side effect` → **fixed** | P3 | Added `audit.action_recorded` emission (best-effort) |
+| Inventory | inventory cog | inventory CRUD | `utils/db/inventory.*` direct | `utils/db/inventory.py` | none | `documented exception` | — | Intentional — single-subsystem CRUD |
+| Counting | counting cog | counting state | `utils/db/games/counting.*` direct | `utils/db/games/counting.py` | none | `documented exception` | — | Intentional — single-subsystem CRUD |
+| Chain | chain cog | chain channel state | `utils/db/games/chain.*` direct | `utils/db/games/chain.py` | none | `documented exception` | — | Intentional — single-subsystem CRUD |
+| Mining | mining cog | mining inventory | `utils/db/games/mining.*` direct | `utils/db/games/mining.py` | none | `documented exception` | — | Intentional — single-subsystem CRUD |
+| Deathmatch | deathmatch cog | deathmatch stats | `utils/db/games/deathmatch.*` direct | `utils/db/games/deathmatch.py` | none | `documented exception` | — | Intentional — single-subsystem CRUD |
+
+---
+
+## Domain notes
+
+### Economy
+
+INV-F (AST test in `tests/unit/invariants/`) enforces that `db.add_coins` and
+`db.set_coins` appear only inside `services/economy_service.py` and
+`utils/db/economy.py`. All game views confirmed to use `economy_service` for
+balance mutations — no direct balance writes found in views or cogs.
+
+### XP
+
+INV-G (AST test) enforces no `db.add_xp` / `db.delete_xp` outside the service
+and its DB module. Level recalculation is bundled inside `xp_service.award()`.
+
+### Governance
+
+INV-E (`test_apply_template_uses_pipeline`) enforces pipeline use for visibility
+and cleanup writes. The `_audit_internal_bypass` carve-out is fully documented
+in `docs/ownership.md` including why it is not routed through the pipeline.
+
+### Setup session
+
+`setup_session.py` is not a domain mutation pipeline — it manages wizard
+lifecycle state (`pending` / `in_progress` / `complete` / `dismissed`). Its DB
+path (`utils/db/setup_session`) is correct. The missing side effect was that
+lifecycle transitions did not emit `audit.action_recorded`, so setup session
+activity was invisible to the audit channel subscriber.
+
+**Fix applied:** `start_session`, `mark_complete`, and `dismiss` now emit
+`audit.action_recorded` via `services/audit_events.emit_audit_action()`.
+Emission is best-effort (failure is logged at WARNING and swallowed) because
+the DB transition is authoritative and a dropped audit event is non-fatal.
+`mutation_type` tokens: `"setup.session.started"`, `"setup.session.completed"`,
+`"setup.session.dismissed"`.
+
+### Inventory / Counting / Chain / Mining / Deathmatch
+
+These subsystems use direct `utils/db/games/*.py` calls. This is explicitly
+documented in `docs/ownership.md`'s subsystem ownership table and is intentional:
+- Single-subsystem state — no cross-subsystem impact.
+- Simple CRUD — no audit, event, or cache requirements at this time.
+- Adding a full mutation pipeline would be an architecture change requiring a
+  doc-first proposal, not a hardening fix.
+
+### Game state (blackjack, RPS)
+
+Two-layer ownership: coin mutations go through `economy_service` (correct);
+game progress checkpoints go through `game_state_service` (correct). The
+`_persistence.py` helpers inside cog packages are thin wrappers that call
+`game_state_service` — they do not bypass it.
+
+---
+
+## Known future work (not in scope of this session)
+
+These are tracked in `docs/platform-consistency-ledger.md` and the
+phase-2 PR sequence, not in this audit.
+
+- `setup_session.mark_in_progress()` — does not emit audit. Low value
+  (in-progress is transient state); revisit if setup observability is requested.
+- `tournament_state_service.py` — audit-free by design (same rationale as
+  `game_state_service`; ADR-002).
+- Inventory/counting/chain/mining/deathmatch direct-db paths — correct as
+  documented; promote to service layer only when cross-subsystem mutation
+  or auditability becomes a real requirement.

--- a/docs/platform-consistency-ledger.md
+++ b/docs/platform-consistency-ledger.md
@@ -422,6 +422,8 @@ satisfied):
 | `docs/roadmap_setup_platform.md` | ✅ current high-level | this ledger is the operational truth map; the roadmap remains the strategic plan |
 | `docs/phase_2b_bindings_plan.md` | 🟡 **historical** — shipped in PR #73 (see banner) | preserved for context; do not extend |
 | `docs/decisions/*` | ✅ current | add ADR per architectural decision (e.g. `003-binding-audit-preserve.md` would be the next) |
+| `docs/architecture/service_ownership.md` | ✅ created 2026-05-24 | quick-lookup companion to `ownership.md`; update when `ownership.md` changes |
+| `docs/audits/mutation_boundary_audit.md` | ✅ created 2026-05-24 | first formal mutation audit; update as new mutation paths land |
 
 ---
 

--- a/tests/unit/services/test_setup_session_audit.py
+++ b/tests/unit/services/test_setup_session_audit.py
@@ -9,10 +9,9 @@ Covers:
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/unit/services/test_setup_session_audit.py
+++ b/tests/unit/services/test_setup_session_audit.py
@@ -1,0 +1,226 @@
+"""Pins audit.action_recorded emission for setup session lifecycle transitions.
+
+Covers:
+* start_session emits "setup.session.started" with actor_id=owner_id.
+* mark_complete emits "setup.session.completed" with actor_type="system".
+* dismiss emits "setup.session.dismissed" with actor_type="system".
+* Audit emission failure never propagates — the DB transition completes normally.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_db_row(guild_id: int = 1111, status: str = "pending") -> dict:
+    return {
+        "guild_id": guild_id,
+        "guild_name": "Test Guild",
+        "owner_id": 9999,
+        "setup_status": status,
+        "setup_channel_id": None,
+        "setup_message_id": None,
+        "last_readiness_score": None,
+        "current_step": None,
+        "delegated_admins": [],
+        "skipped_sections": [],
+        "depth": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# start_session
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_session_emits_audit():
+    row = _make_db_row()
+    with (
+        patch("utils.db.setup_session.upsert", new_callable=AsyncMock),
+        patch("utils.db.setup_session.get", new_callable=AsyncMock, return_value=row),
+        patch(
+            "services.audit_events.emit_audit_action", new_callable=AsyncMock
+        ) as mock_emit,
+    ):
+        from services.setup_session import start_session
+
+        await start_session(
+            guild_id=1111,
+            guild_name="Test Guild",
+            owner_id=9999,
+        )
+
+    mock_emit.assert_awaited_once()
+    kwargs = mock_emit.await_args.kwargs
+    assert kwargs["mutation_type"] == "setup.session.started"
+    assert kwargs["subsystem"] == "setup"
+    assert kwargs["guild_id"] == 1111
+    assert kwargs["new_value"] == "pending"
+    assert kwargs["actor_id"] == 9999
+    assert kwargs["actor_type"] == "user"
+    assert kwargs["target"] == "setup_session:1111"
+    assert kwargs["scope"] == "guild"
+
+
+# ---------------------------------------------------------------------------
+# mark_complete
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mark_complete_emits_audit():
+    with (
+        patch("utils.db.setup_session.set_status", new_callable=AsyncMock),
+        patch("utils.db.setup_session.set_step", new_callable=AsyncMock),
+        patch(
+            "utils.db.setup_session.clear_skipped_sections", new_callable=AsyncMock
+        ),
+        patch("services.setup_draft.clear", new_callable=AsyncMock),
+        patch(
+            "services.audit_events.emit_audit_action", new_callable=AsyncMock
+        ) as mock_emit,
+    ):
+        from services.setup_session import mark_complete
+
+        await mark_complete(guild_id=2222)
+
+    mock_emit.assert_awaited_once()
+    kwargs = mock_emit.await_args.kwargs
+    assert kwargs["mutation_type"] == "setup.session.completed"
+    assert kwargs["guild_id"] == 2222
+    assert kwargs["new_value"] == "complete"
+    assert kwargs["actor_id"] is None
+    assert kwargs["actor_type"] == "system"
+
+
+# ---------------------------------------------------------------------------
+# dismiss
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dismiss_emits_audit():
+    with (
+        patch("utils.db.setup_session.set_status", new_callable=AsyncMock),
+        patch("utils.db.setup_session.set_step", new_callable=AsyncMock),
+        patch(
+            "utils.db.setup_session.clear_skipped_sections", new_callable=AsyncMock
+        ),
+        patch("services.setup_draft.clear", new_callable=AsyncMock),
+        patch(
+            "services.audit_events.emit_audit_action", new_callable=AsyncMock
+        ) as mock_emit,
+    ):
+        from services.setup_session import dismiss
+
+        await dismiss(guild_id=3333)
+
+    mock_emit.assert_awaited_once()
+    kwargs = mock_emit.await_args.kwargs
+    assert kwargs["mutation_type"] == "setup.session.dismissed"
+    assert kwargs["guild_id"] == 3333
+    assert kwargs["new_value"] == "dismissed"
+    assert kwargs["actor_id"] is None
+    assert kwargs["actor_type"] == "system"
+
+
+# ---------------------------------------------------------------------------
+# Failure isolation — audit failure must never propagate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_session_audit_failure_does_not_raise():
+    row = _make_db_row()
+    with (
+        patch("utils.db.setup_session.upsert", new_callable=AsyncMock),
+        patch("utils.db.setup_session.get", new_callable=AsyncMock, return_value=row),
+        patch(
+            "services.audit_events.emit_audit_action",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("bus down"),
+        ),
+    ):
+        from services.setup_session import start_session
+
+        session = await start_session(
+            guild_id=1111,
+            guild_name="Test Guild",
+            owner_id=9999,
+        )
+
+    assert session is not None
+    assert session.guild_id == 1111
+
+
+@pytest.mark.asyncio
+async def test_mark_complete_audit_failure_does_not_raise():
+    with (
+        patch("utils.db.setup_session.set_status", new_callable=AsyncMock),
+        patch("utils.db.setup_session.set_step", new_callable=AsyncMock),
+        patch(
+            "utils.db.setup_session.clear_skipped_sections", new_callable=AsyncMock
+        ),
+        patch("services.setup_draft.clear", new_callable=AsyncMock),
+        patch(
+            "services.audit_events.emit_audit_action",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("bus down"),
+        ),
+    ):
+        from services.setup_session import mark_complete
+
+        await mark_complete(guild_id=2222)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_dismiss_audit_failure_does_not_raise():
+    with (
+        patch("utils.db.setup_session.set_status", new_callable=AsyncMock),
+        patch("utils.db.setup_session.set_step", new_callable=AsyncMock),
+        patch(
+            "utils.db.setup_session.clear_skipped_sections", new_callable=AsyncMock
+        ),
+        patch("services.setup_draft.clear", new_callable=AsyncMock),
+        patch(
+            "services.audit_events.emit_audit_action",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("bus down"),
+        ),
+    ):
+        from services.setup_session import dismiss
+
+        await dismiss(guild_id=3333)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Audit payload contract — occurred_at is a datetime (not a string or None)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_session_audit_occurred_at_is_datetime():
+    from datetime import datetime
+
+    row = _make_db_row()
+    with (
+        patch("utils.db.setup_session.upsert", new_callable=AsyncMock),
+        patch("utils.db.setup_session.get", new_callable=AsyncMock, return_value=row),
+        patch(
+            "services.audit_events.emit_audit_action", new_callable=AsyncMock
+        ) as mock_emit,
+    ):
+        from services.setup_session import start_session
+
+        await start_session(guild_id=1111, guild_name="G", owner_id=9999)
+
+    kwargs = mock_emit.await_args.kwargs
+    assert isinstance(kwargs["occurred_at"], datetime)


### PR DESCRIPTION
## Summary

Service Ownership Hardening session. The codebase already had mature mutation
infrastructure (all major services/pipelines exist, setup wizard routes through
the dispatcher, zero direct balance/XP writes). This PR closes the remaining
gaps:

- **`docs/architecture/service_ownership.md`** — enriched "at a glance" ownership
  lookup table (14 domains: owner, allowed callers, write path, side effects,
  exceptions). Companion to `docs/ownership.md`, which remains authoritative.
- **`docs/audits/mutation_boundary_audit.md`** — formal mutation boundary audit.
  9 domains `correct`, 1 `missing side effect` (fixed here), 5
  `documented exception`, **0 violations**.
- **`services/setup_session.py`** — `start_session`, `mark_complete`, and
  `dismiss` now emit `audit.action_recorded` via `services/audit_events.py`.
  Best-effort: failure is logged at WARNING and swallowed (DB transition is
  authoritative). This was the only real code gap surfaced by the audit (P3).
- **`tests/unit/services/test_setup_session_audit.py`** — 7 tests pinning the
  emission content, failure-isolation, and `occurred_at` datetime contract.
- **`docs/AGENT_ORIENTATION.md` + `docs/platform-consistency-ledger.md`** —
  classification entries and ledger record for the two new docs.

## Test plan

- [x] `pytest tests/unit/services/test_setup_session_audit.py -v` — 7/7 pass
- [x] `pytest tests/unit/services/` — 1148 passed, 0 regressions
- [x] `grep -rn "db\.add_coins\|db\.set_coins"` outside economy_service — zero
- [x] `grep -rn "db\.add_xp\|db\.delete_xp"` outside xp_service — zero
- [ ] CI green on this PR

## What this PR does NOT touch

- `ownership.md` — already binding and complete; no contract change needed.
- Setup wizard UX — structurally sound, not in scope.
- Inventory / counting / chain / mining / deathmatch — direct-db pattern is
  documented as intentional in `ownership.md`; promoting these to service layer
  would be an architecture change, not a hardening fix.
- Game framework abstractions — games already use `economy_service` for
  settlements and `game_state_service` for checkpoints.
- `tournament_state_service.py` — audit-free by design (ADR-002 rationale).

https://claude.ai/code/session_01NpPYDUMveeRSG5ZbhsZhec

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpPYDUMveeRSG5ZbhsZhec)_