### PR TITLE
ai+btd6: AI gateway, AI Cog, BTD6 Cog, passive stage (Modules 0-6)

### DIFF
--- a/disbot/cogs/ai_cog.py
+++ b/disbot/cogs/ai_cog.py
@@ -1,0 +1,253 @@
+"""AI Platform cog — Module 2 of the AI/BTD6 plan.
+
+Provides read-only diagnostics for the AI gateway. Owns no provider
+logic; all source-of-truth lives under :mod:`core.runtime.ai` and
+:mod:`services.ai_gateway`. Commands consume
+:mod:`services.ai_diagnostics_service` and surface the gateway's
+state without ever invoking a provider.
+
+The cog matches the standard SuperBot admin-tier shape: a prefix
+``@commands.command`` family gated by ``has_permissions(administrator=True)``
+and a parallel ``app_commands`` family with the same gating. The
+``aimenu`` entry point opens the persistent panel (see
+:mod:`views.ai.panel`).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from core.runtime.ai.contracts import AITask
+from services import ai_diagnostics_service
+from views.ai.panel import AIPanelView, build_ai_panel_embed
+
+logger = logging.getLogger("bot")
+
+
+# ---------------------------------------------------------------------------
+# Embed builders — used by both the slash/prefix commands and the panel
+# buttons. Centralised here so the panel and the explicit commands always
+# render the same data.
+# ---------------------------------------------------------------------------
+
+
+def build_status_embed() -> discord.Embed:
+    """Compact status: enabled / default provider / last call outcome."""
+    snap = ai_diagnostics_service.snapshot_for_cog()
+    embed = discord.Embed(
+        title="AI Gateway — Status",
+        color=discord.Color.blurple(),
+    )
+    embed.add_field(name="Enabled", value="yes" if snap["enabled"] else "no")
+    embed.add_field(name="Default provider", value=str(snap["default_provider"]))
+    embed.add_field(
+        name="Setup advisor provider",
+        value=str(snap["setup_advisor_provider"]),
+    )
+    embed.add_field(name="Active provider", value=str(snap["provider_active"]))
+    embed.add_field(name="Requests", value=str(snap["requests_observed"]))
+    embed.add_field(name="Failures", value=str(snap["failures_observed"]))
+    return embed
+
+
+def build_diagnostics_embed() -> discord.Embed:
+    """Full diagnostics snapshot — every counter the gateway exposes."""
+    snap = ai_diagnostics_service.snapshot_for_cog()
+    embed = discord.Embed(
+        title="AI Gateway — Diagnostics",
+        color=discord.Color.blurple(),
+    )
+    for key, value in snap.items():
+        embed.add_field(name=key.replace("_", " "), value=str(value), inline=True)
+    return embed
+
+
+def build_providers_embed() -> discord.Embed:
+    """List of configured providers and which is active right now."""
+    snap = ai_diagnostics_service.snapshot_for_cog()
+    embed = discord.Embed(
+        title="AI Gateway — Providers",
+        description=(
+            "Configured providers. The active provider is the one the "
+            "gateway selected for the most recent request; the default "
+            "provider is the env-driven choice for new requests."
+        ),
+        color=discord.Color.blurple(),
+    )
+    embed.add_field(name="Default", value=str(snap["default_provider"]))
+    embed.add_field(name="Active (last call)", value=str(snap["provider_active"]))
+    embed.add_field(name="Setup advisor", value=str(snap["setup_advisor_provider"]))
+    return embed
+
+
+def build_routing_embed(task_name: str | None = None) -> discord.Embed:
+    """Per-task routing table. With ``task_name``, narrows to one row."""
+    rows = ai_diagnostics_service.list_task_routing()
+    if task_name:
+        rows = [r for r in rows if r["task"] == task_name]
+    embed = discord.Embed(
+        title="AI Gateway — Routing",
+        description=(
+            "Resolved provider/model/timeout for each AI task. This view "
+            "does not invoke any provider."
+        ),
+        color=discord.Color.blurple(),
+    )
+    if not rows:
+        embed.add_field(
+            name="No matching task",
+            value=f"Known tasks: {', '.join(t.value for t in AITask)}",
+            inline=False,
+        )
+        return embed
+    for row in rows:
+        embed.add_field(
+            name=str(row["task"]),
+            value=(
+                f"provider: `{row['provider']}`\n"
+                f"model: `{row['model']}`\n"
+                f"timeout: `{row['timeout_seconds']}s`\n"
+                f"enabled: `{row['enabled']}`"
+            ),
+            inline=True,
+        )
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# Cog
+# ---------------------------------------------------------------------------
+
+
+class AICog(commands.Cog):
+    """Read-only diagnostics surface for the AI gateway."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    # ------------------------------------------------------------------
+    # Prefix commands — `!ai`, `!ai status`, `!ai diagnostics`, ...
+    # ------------------------------------------------------------------
+
+    @commands.group(name="ai", invoke_without_command=True)
+    @commands.has_permissions(administrator=True)
+    async def ai_group(self, ctx: commands.Context) -> None:
+        """Open the AI Platform panel."""
+        await ctx.send(embed=build_ai_panel_embed(), view=AIPanelView())
+
+    @ai_group.command(name="status")
+    @commands.has_permissions(administrator=True)
+    async def ai_status(self, ctx: commands.Context) -> None:
+        await ctx.send(embed=build_status_embed())
+
+    @ai_group.command(name="diagnostics")
+    @commands.has_permissions(administrator=True)
+    async def ai_diagnostics(self, ctx: commands.Context) -> None:
+        await ctx.send(embed=build_diagnostics_embed())
+
+    @ai_group.command(name="providers")
+    @commands.has_permissions(administrator=True)
+    async def ai_providers(self, ctx: commands.Context) -> None:
+        await ctx.send(embed=build_providers_embed())
+
+    @ai_group.command(name="routing")
+    @commands.has_permissions(administrator=True)
+    async def ai_routing(
+        self,
+        ctx: commands.Context,
+        task: str | None = None,
+    ) -> None:
+        await ctx.send(embed=build_routing_embed(task))
+
+    @commands.command(name="aimenu")
+    @commands.has_permissions(administrator=True)
+    async def aimenu(self, ctx: commands.Context) -> None:
+        """Open the AI Platform panel (alias for ``!ai``)."""
+        await ctx.send(embed=build_ai_panel_embed(), view=AIPanelView())
+
+    # ------------------------------------------------------------------
+    # App commands (slash). Mirror the prefix group, admin-gated.
+    # ------------------------------------------------------------------
+
+    ai_app_group = app_commands.Group(
+        name="ai",
+        description="AI Platform diagnostics (administrator only).",
+        default_permissions=discord.Permissions(administrator=True),
+    )
+
+    @ai_app_group.command(name="status", description="AI gateway status summary.")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def ai_status_slash(self, interaction: discord.Interaction) -> None:
+        await interaction.response.send_message(
+            embed=build_status_embed(),
+            ephemeral=True,
+        )
+
+    @ai_app_group.command(
+        name="diagnostics",
+        description="Full AI gateway diagnostics snapshot.",
+    )
+    @app_commands.checks.has_permissions(administrator=True)
+    async def ai_diagnostics_slash(self, interaction: discord.Interaction) -> None:
+        await interaction.response.send_message(
+            embed=build_diagnostics_embed(),
+            ephemeral=True,
+        )
+
+    @ai_app_group.command(
+        name="providers",
+        description="List configured AI providers.",
+    )
+    @app_commands.checks.has_permissions(administrator=True)
+    async def ai_providers_slash(self, interaction: discord.Interaction) -> None:
+        await interaction.response.send_message(
+            embed=build_providers_embed(),
+            ephemeral=True,
+        )
+
+    @ai_app_group.command(
+        name="routing",
+        description="Show the routing table for AI tasks.",
+    )
+    @app_commands.checks.has_permissions(administrator=True)
+    async def ai_routing_slash(
+        self,
+        interaction: discord.Interaction,
+        task: str | None = None,
+    ) -> None:
+        await interaction.response.send_message(
+            embed=build_routing_embed(task),
+            ephemeral=True,
+        )
+
+    @app_commands.command(
+        name="aimenu",
+        description="Open the AI Platform panel (administrator only).",
+    )
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.checks.has_permissions(administrator=True)
+    async def aimenu_slash(self, interaction: discord.Interaction) -> None:
+        await interaction.response.send_message(
+            embed=build_ai_panel_embed(),
+            view=AIPanelView(),
+            ephemeral=True,
+        )
+
+    # ------------------------------------------------------------------
+    # Help-menu hook (the standard SuperBot pattern).
+    # ------------------------------------------------------------------
+
+    async def build_help_menu_view(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        """Direct-navigation hook used by ``help_cog.route``."""
+        return build_ai_panel_embed(), AIPanelView()
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(AICog(bot))

--- a/disbot/cogs/ai_cog.py
+++ b/disbot/cogs/ai_cog.py
@@ -139,22 +139,22 @@ class AICog(commands.Cog):
         """Open the AI Platform panel."""
         await ctx.send(embed=build_ai_panel_embed(), view=AIPanelView())
 
-    @ai_group.command(name="status")
+    @ai_group.command(name="status")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def ai_status(self, ctx: commands.Context) -> None:
         await ctx.send(embed=build_status_embed())
 
-    @ai_group.command(name="diagnostics")
+    @ai_group.command(name="diagnostics")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def ai_diagnostics(self, ctx: commands.Context) -> None:
         await ctx.send(embed=build_diagnostics_embed())
 
-    @ai_group.command(name="providers")
+    @ai_group.command(name="providers")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def ai_providers(self, ctx: commands.Context) -> None:
         await ctx.send(embed=build_providers_embed())
 
-    @ai_group.command(name="routing")
+    @ai_group.command(name="routing")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def ai_routing(
         self,

--- a/disbot/cogs/btd6/__init__.py
+++ b/disbot/cogs/btd6/__init__.py
@@ -1,0 +1,13 @@
+"""BTD6 cog package — domain helpers and the passive message stage.
+
+Module 6 of the AI/BTD6 plan introduces ``BTD6AssistantMessageStage``
+here. The cog entry point (``disbot/cogs/btd6_cog.py``) registers
+the stage with ``core.runtime.message_pipeline`` in ``cog_load`` and
+unregisters it in ``cog_unload``. No ``on_message`` listener is
+ever installed — the platform pipeline is the only entry point for
+message handling.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/disbot/cogs/btd6/stage.py
+++ b/disbot/cogs/btd6/stage.py
@@ -1,0 +1,333 @@
+"""Passive BTD6 message stage — Module 6 of the AI/BTD6 plan.
+
+The stage runs as part of the platform message pipeline (registered
+in ``btd6_cog.cog_load`` via
+``core.runtime.message_pipeline.register``). It NEVER installs a
+direct ``on_message`` listener — the invariant test
+``tests/unit/invariants/test_ai_btd6_boundaries.py::test_btd6_does_not_install_on_message_listener``
+forbids that.
+
+Behaviour is opt-in. Every skip is recorded with a structured
+reason so ``!btd6 why-no-response`` can explain (without leaking
+the original message body) why a recent message in the channel
+was not handled.
+
+Skip stack (all must pass to reply):
+
+1. author is a bot or webhook
+2. message is empty / system message
+3. message starts with the bot's command prefix
+4. process-level ``BTD6_PASSIVE_ENABLED`` is on
+5. channel is in ``BTD6_PASSIVE_CHANNELS`` (id list)
+6. earlier pipeline stage marked ``ctx.metadata["handled_by"]``
+7. per-user/per-channel cooldown OK
+8. resolver confidence >= ``BTD6_CONFIDENCE_THRESHOLD``
+
+All thresholds are env-driven defaults; Module 6 deliberately does
+not introduce a new persistence path (per the AI/BTD6 plan's
+"existing settings infrastructure only" rule). Per-guild gating is
+a follow-up once SuperBot's settings layer exposes a BTD6 schema.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from collections import deque
+from dataclasses import dataclass
+
+import discord
+
+from core.runtime.message_pipeline import MessagePipelineContext, StageResult
+from services import btd6_ai_service
+from services.btd6_resolver_service import resolve
+
+logger = logging.getLogger("bot.cogs.btd6.stage")
+
+STAGE_NAME = "btd6_assistant"
+STAGE_ORDER = 80  # after cleanup/counting; before observability stages
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+_DEFAULT_CONFIDENCE_THRESHOLD = 0.34  # ≥ 1 of 3 entities matched
+_DEFAULT_COOLDOWN_SECONDS = 10.0
+_SKIP_BUFFER_PER_CHANNEL = 8
+
+
+@dataclass(frozen=True)
+class SkipRecord:
+    """One per-channel skip explanation, surfaced by ``!btd6 why-no-response``."""
+
+    channel_id: int
+    timestamp: float
+    reason: str  # short reason code, no user content
+    confidence: float  # resolver confidence (0..1) at decision time
+
+
+def _env_truthy(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in _TRUTHY
+
+
+def passive_enabled() -> bool:
+    """Process-level flag. Default off."""
+    return _env_truthy("BTD6_PASSIVE_ENABLED")
+
+
+def passive_channel_ids() -> set[int]:
+    """Comma-separated channel id list from ``BTD6_PASSIVE_CHANNELS``."""
+    raw = os.getenv("BTD6_PASSIVE_CHANNELS", "")
+    out: set[int] = set()
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        try:
+            out.add(int(entry))
+        except ValueError:
+            continue
+    return out
+
+
+def confidence_threshold() -> float:
+    raw = os.getenv("BTD6_CONFIDENCE_THRESHOLD", "").strip()
+    try:
+        return max(0.0, min(1.0, float(raw))) if raw else _DEFAULT_CONFIDENCE_THRESHOLD
+    except ValueError:
+        return _DEFAULT_CONFIDENCE_THRESHOLD
+
+
+def cooldown_seconds() -> float:
+    raw = os.getenv("BTD6_COOLDOWN_SECONDS", "").strip()
+    try:
+        return max(0.0, float(raw)) if raw else _DEFAULT_COOLDOWN_SECONDS
+    except ValueError:
+        return _DEFAULT_COOLDOWN_SECONDS
+
+
+# ---------------------------------------------------------------------------
+# Skip reasons — surfaced by !btd6 why-no-response. Never include message
+# body or user content; reasons are short stable identifiers.
+# ---------------------------------------------------------------------------
+
+REASON_BOT_AUTHOR = "skip:bot_author"
+REASON_WEBHOOK = "skip:webhook"
+REASON_SYSTEM_MESSAGE = "skip:system_message"
+REASON_EMPTY = "skip:empty_message"
+REASON_COMMAND_PREFIX = "skip:command_prefix"
+REASON_DISABLED = "skip:passive_disabled"
+REASON_CHANNEL_NOT_CONFIGURED = "skip:channel_not_configured"
+REASON_ALREADY_HANDLED = "skip:already_handled"
+REASON_COOLDOWN = "skip:cooldown"
+REASON_LOW_CONFIDENCE = "skip:low_confidence"
+
+
+class BTD6AssistantMessageStage:
+    """Default-off passive BTD6 assistant.
+
+    Cooldown state and the skip-reason ring buffer live as instance
+    attributes; the stage is created once when the cog loads and
+    persists for the lifetime of the bot process. Tests can build a
+    fresh instance to start from clean state.
+    """
+
+    name = STAGE_NAME
+    order = STAGE_ORDER
+
+    def __init__(self) -> None:
+        self._cooldowns: dict[tuple[int, int], float] = {}
+        self._recent_skips: dict[int, deque[SkipRecord]] = {}
+
+    # ------------------------------------------------------------------
+    # Public introspection — used by /btd6 why-no-response
+    # ------------------------------------------------------------------
+
+    def latest_skips(self, channel_id: int) -> tuple[SkipRecord, ...]:
+        """Return the channel's recorded skip ring buffer (oldest → newest)."""
+        return tuple(self._recent_skips.get(channel_id, ()))
+
+    # ------------------------------------------------------------------
+    # Pipeline entry
+    # ------------------------------------------------------------------
+
+    async def process(self, ctx: MessagePipelineContext) -> StageResult:
+        message = ctx.message
+        channel_id = message.channel.id if message.channel else 0
+
+        # Pipeline already strips bot authors and DMs, but re-assert
+        # so unit tests that bypass the pipeline still see safe behaviour.
+        if message.author.bot:
+            self._record_skip(channel_id, REASON_BOT_AUTHOR, confidence=0.0)
+            return StageResult()
+        if getattr(message, "webhook_id", None):
+            self._record_skip(channel_id, REASON_WEBHOOK, confidence=0.0)
+            return StageResult()
+        if _is_system_message(message):
+            self._record_skip(channel_id, REASON_SYSTEM_MESSAGE, confidence=0.0)
+            return StageResult()
+        if not message.content or not message.content.strip():
+            self._record_skip(channel_id, REASON_EMPTY, confidence=0.0)
+            return StageResult()
+
+        bot = ctx.bot
+        if _looks_like_command(message.content, bot):
+            self._record_skip(channel_id, REASON_COMMAND_PREFIX, confidence=0.0)
+            return StageResult()
+
+        if not passive_enabled():
+            self._record_skip(channel_id, REASON_DISABLED, confidence=0.0)
+            return StageResult()
+
+        configured = passive_channel_ids()
+        if configured and channel_id not in configured:
+            self._record_skip(
+                channel_id,
+                REASON_CHANNEL_NOT_CONFIGURED,
+                confidence=0.0,
+            )
+            return StageResult()
+
+        if ctx.metadata.get("handled_by"):
+            self._record_skip(channel_id, REASON_ALREADY_HANDLED, confidence=0.0)
+            return StageResult()
+
+        if self._cooldown_active(message.author.id, channel_id):
+            self._record_skip(channel_id, REASON_COOLDOWN, confidence=0.0)
+            return StageResult()
+
+        intent = resolve(message.content)
+        if intent.confidence < confidence_threshold():
+            self._record_skip(
+                channel_id,
+                REASON_LOW_CONFIDENCE,
+                confidence=intent.confidence,
+            )
+            return StageResult()
+
+        # Made it through every gate — deliver a deterministic answer.
+        try:
+            response = await btd6_ai_service.answer_question(
+                message.content,
+                augment_with_ai=True,
+                guild_id=message.guild.id if message.guild else None,
+            )
+            await message.reply(
+                embed=_response_to_embed(response),
+                mention_author=False,
+            )
+            self._record_cooldown(message.author.id, channel_id)
+            ctx.metadata["handled_by"] = STAGE_NAME
+        except Exception:  # noqa: BLE001 — never crash the pipeline
+            logger.exception(
+                "btd6_stage: handling message %s raised",
+                message.id,
+            )
+
+        return StageResult()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _record_skip(
+        self,
+        channel_id: int,
+        reason: str,
+        *,
+        confidence: float,
+    ) -> None:
+        if channel_id <= 0:
+            return
+        buffer = self._recent_skips.setdefault(
+            channel_id,
+            deque(maxlen=_SKIP_BUFFER_PER_CHANNEL),
+        )
+        buffer.append(
+            SkipRecord(
+                channel_id=channel_id,
+                timestamp=time.time(),
+                reason=reason,
+                confidence=confidence,
+            ),
+        )
+
+    def _cooldown_active(self, user_id: int, channel_id: int) -> bool:
+        cooldown = cooldown_seconds()
+        if cooldown <= 0:
+            return False
+        last = self._cooldowns.get((user_id, channel_id))
+        if last is None:
+            return False
+        return (time.time() - last) < cooldown
+
+    def _record_cooldown(self, user_id: int, channel_id: int) -> None:
+        self._cooldowns[(user_id, channel_id)] = time.time()
+
+
+def _looks_like_command(content: str, bot: object) -> bool:
+    """True if ``content`` starts with the bot's command prefix.
+
+    Discord.py's command_prefix may be a string, a list of strings,
+    or a callable. The callable form needs (bot, message), so we
+    fall back to ``"!"`` (SuperBot's default) if extraction fails.
+    """
+    prefix_attr = getattr(bot, "command_prefix", "!")
+    candidates: list[str] = []
+    if isinstance(prefix_attr, str):
+        candidates.append(prefix_attr)
+    elif isinstance(prefix_attr, (list, tuple)):
+        candidates.extend(str(p) for p in prefix_attr if isinstance(p, str))
+    else:
+        candidates.append("!")
+    if not candidates:
+        candidates.append("!")
+    stripped = content.lstrip()
+    return any(stripped.startswith(p) for p in candidates)
+
+
+def _is_system_message(message: discord.Message) -> bool:
+    """True if ``message.type`` indicates a system event (pin/join/boost/...)."""
+    msg_type = getattr(message, "type", None)
+    if msg_type is None:
+        return False
+    default_type = getattr(discord.MessageType, "default", None)
+    if default_type is not None and msg_type == default_type:
+        return False
+    reply_type = getattr(discord.MessageType, "reply", None)
+    # Anything else (pins_add, new_member, premium_guild_subscription, ...) is system.
+    return not (reply_type is not None and msg_type == reply_type)
+
+
+def _response_to_embed(response) -> discord.Embed:
+    """Lightweight embed renderer for the passive stage.
+
+    We deliberately do not import from ``cogs.btd6_cog`` at module
+    load so this stage stays importable without touching the cog
+    module. The conversion is the same shape used by the cog.
+    """
+    color = {
+        "high": discord.Color.green(),
+        "medium": discord.Color.gold(),
+        "low": discord.Color.light_grey(),
+    }.get(response.confidence, discord.Color.light_grey())
+    embed = discord.Embed(
+        title=response.title,
+        description=response.short_answer,
+        color=color,
+    )
+    if response.why_it_matters:
+        embed.add_field(
+            name="Why it matters",
+            value=response.why_it_matters,
+            inline=False,
+        )
+    if response.recommended_options:
+        embed.add_field(
+            name="Recommended options",
+            value="\n".join(f"• {opt}" for opt in response.recommended_options),
+            inline=False,
+        )
+    if response.follow_up:
+        embed.add_field(name="Follow-up", value=response.follow_up, inline=False)
+    if response.sources:
+        embed.set_footer(text="Sources: " + " · ".join(response.sources))
+    return embed

--- a/disbot/cogs/btd6_cog.py
+++ b/disbot/cogs/btd6_cog.py
@@ -1,0 +1,423 @@
+"""BTD6 Assistant cog — Module 4 of the AI/BTD6 plan.
+
+Provides deterministic Bloons Tower Defense 6 lookups and a
+provider-free ``ask`` command. The cog is intentionally
+deterministic-only; Module 5 wires optional AI augmentation.
+
+Architecture:
+
+* The cog never imports the AI cog. When AI augmentation lands in
+  Module 5 it will go through ``services.ai_gateway``.
+* All facts come from :mod:`services.btd6_data_service` via the
+  knowledge / response-builder services. Nothing in the cog
+  invents BTD6 data.
+* Commands match the SuperBot convention (prefix + slash side by
+  side; both forms gated as user-tier per the SUBSYSTEMS entry).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from services import btd6_ai_service, btd6_knowledge_service
+from services.btd6_resolver_service import resolve
+from views.btd6.panel import BTD6PanelView, build_btd6_panel_embed
+
+logger = logging.getLogger("bot")
+
+
+# ---------------------------------------------------------------------------
+# Embed builders — shared by panel buttons and explicit commands.
+# ---------------------------------------------------------------------------
+
+
+def _response_to_embed(response: Any) -> discord.Embed:
+    """Convert a :class:`BTD6Response` into a Discord embed."""
+    color = {
+        "high": discord.Color.green(),
+        "medium": discord.Color.gold(),
+        "low": discord.Color.light_grey(),
+    }.get(response.confidence, discord.Color.light_grey())
+    embed = discord.Embed(
+        title=response.title,
+        description=response.short_answer,
+        color=color,
+    )
+    if response.why_it_matters:
+        embed.add_field(
+            name="Why it matters",
+            value=response.why_it_matters,
+            inline=False,
+        )
+    if response.recommended_options:
+        embed.add_field(
+            name="Recommended options",
+            value="\n".join(f"• {opt}" for opt in response.recommended_options),
+            inline=False,
+        )
+    if response.common_mistakes:
+        embed.add_field(
+            name="Common mistakes",
+            value="\n".join(f"• {m}" for m in response.common_mistakes),
+            inline=False,
+        )
+    if response.version_sensitivity:
+        embed.add_field(
+            name="Version sensitivity",
+            value=response.version_sensitivity,
+            inline=False,
+        )
+    if response.follow_up:
+        embed.add_field(name="Follow-up", value=response.follow_up, inline=False)
+    if response.sources:
+        embed.set_footer(text="Sources: " + " · ".join(response.sources))
+    return embed
+
+
+def build_status_embed() -> discord.Embed:
+    """BTD6 status: data version + entity counts."""
+    embed = discord.Embed(
+        title="🐵 BTD6 Assistant — Status",
+        description="Deterministic-only mode (Module 4). AI augmentation off.",
+        color=discord.Color.green(),
+    )
+    embed.add_field(
+        name="Data version",
+        value=btd6_knowledge_service.data_version(),
+        inline=True,
+    )
+    embed.add_field(
+        name="Game version",
+        value=btd6_knowledge_service.game_version(),
+        inline=True,
+    )
+    embed.add_field(
+        name="Towers",
+        value=str(len(btd6_knowledge_service.list_towers())),
+        inline=True,
+    )
+    embed.add_field(
+        name="Heroes",
+        value=str(len(btd6_knowledge_service.list_heroes())),
+        inline=True,
+    )
+    embed.add_field(
+        name="Maps",
+        value=str(len(btd6_knowledge_service.list_maps())),
+        inline=True,
+    )
+    embed.add_field(
+        name="Rounds",
+        value=str(len(btd6_knowledge_service.list_rounds())),
+        inline=True,
+    )
+    return embed
+
+
+def build_diagnostics_embed() -> discord.Embed:
+    """Detailed diagnostics: source labels and entry catalogues."""
+    embed = discord.Embed(
+        title="🐵 BTD6 Assistant — Diagnostics",
+        color=discord.Color.green(),
+    )
+    embed.add_field(
+        name="Towers",
+        value=", ".join(t.canonical for t in btd6_knowledge_service.list_towers()),
+        inline=False,
+    )
+    embed.add_field(
+        name="Heroes",
+        value=", ".join(h.canonical for h in btd6_knowledge_service.list_heroes()),
+        inline=False,
+    )
+    embed.add_field(
+        name="Maps",
+        value=", ".join(m.canonical for m in btd6_knowledge_service.list_maps()),
+        inline=False,
+    )
+    embed.add_field(
+        name="Modes",
+        value=", ".join(m.canonical for m in btd6_knowledge_service.list_modes()),
+        inline=False,
+    )
+    rounds = ", ".join(
+        str(r.round_number) for r in btd6_knowledge_service.list_rounds()
+    )
+    embed.add_field(name="Rounds tracked", value=rounds, inline=False)
+    return embed
+
+
+def build_towers_embed() -> discord.Embed:
+    embed = discord.Embed(
+        title="🐵 BTD6 — Towers",
+        color=discord.Color.green(),
+    )
+    for tower in btd6_knowledge_service.list_towers():
+        embed.add_field(
+            name=tower.canonical,
+            value=f"Cost: {tower.base_cost} • Category: {tower.category}",
+            inline=True,
+        )
+    return embed
+
+
+def build_modes_embed() -> discord.Embed:
+    embed = discord.Embed(
+        title="🐵 BTD6 — Modes",
+        color=discord.Color.green(),
+    )
+    for mode in btd6_knowledge_service.list_modes():
+        embed.add_field(
+            name=mode.canonical,
+            value=(
+                f"Starting cash: {mode.starting_cash} • "
+                f"Lives: {mode.starting_lives}"
+            ),
+            inline=False,
+        )
+    return embed
+
+
+def build_test_intent_embed(text: str) -> discord.Embed:
+    """Resolver introspection — useful for operators tuning the cog."""
+    intent = resolve(text)
+    embed = discord.Embed(
+        title="🐵 BTD6 — test-intent",
+        description=f"Resolved intent for: ``{text[:200]}``",
+        color=discord.Color.green(),
+    )
+    embed.add_field(name="Confidence", value=f"{intent.confidence:.2f}")
+    embed.add_field(
+        name="Towers",
+        value=", ".join(t.canonical for t in intent.towers) or "—",
+        inline=False,
+    )
+    embed.add_field(
+        name="Heroes",
+        value=", ".join(h.canonical for h in intent.heroes) or "—",
+        inline=False,
+    )
+    embed.add_field(
+        name="Maps",
+        value=", ".join(m.canonical for m in intent.maps) or "—",
+        inline=False,
+    )
+    embed.add_field(
+        name="Modes",
+        value=", ".join(m.canonical for m in intent.modes) or "—",
+        inline=False,
+    )
+    embed.add_field(
+        name="Rounds",
+        value=", ".join(str(n) for n in intent.candidate_round_numbers) or "—",
+        inline=False,
+    )
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# Cog
+# ---------------------------------------------------------------------------
+
+
+class BTD6Cog(commands.Cog):
+    """Deterministic BTD6 assistant. User-tier; no provider calls."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    # ------------------------------------------------------------------
+    # Prefix commands
+    # ------------------------------------------------------------------
+
+    @commands.group(name="btd6", invoke_without_command=True)
+    async def btd6_group(self, ctx: commands.Context) -> None:
+        """Open the BTD6 panel."""
+        await ctx.send(embed=build_btd6_panel_embed(), view=BTD6PanelView())
+
+    @btd6_group.command(name="status")
+    async def btd6_status(self, ctx: commands.Context) -> None:
+        await ctx.send(embed=build_status_embed())
+
+    @btd6_group.command(name="diagnostics")
+    async def btd6_diagnostics(self, ctx: commands.Context) -> None:
+        await ctx.send(embed=build_diagnostics_embed())
+
+    @btd6_group.command(name="ask")
+    async def btd6_ask(self, ctx: commands.Context, *, question: str) -> None:
+        """Deterministic Q&A. Module 5 adds optional AI augmentation."""
+        response = await btd6_ai_service.answer_question(question)
+        await ctx.send(embed=_response_to_embed(response))
+
+    @btd6_group.command(name="tower")
+    async def btd6_tower(self, ctx: commands.Context, *, name: str) -> None:
+        intent = resolve(name)
+        if not intent.towers:
+            await ctx.send(
+                embed=_response_to_embed(
+                    btd6_ai_service.deterministic_answer(intent),
+                ),
+            )
+            return
+        from services.btd6_knowledge_service import tower_fact
+        from services.btd6_response_builder import for_tower
+
+        fact = tower_fact(intent.towers[0].id)
+        if fact is None:
+            await ctx.send(content=f"No deterministic data for {name!r}.")
+            return
+        await ctx.send(embed=_response_to_embed(for_tower(fact)))
+
+    @btd6_group.command(name="hero")
+    async def btd6_hero(self, ctx: commands.Context, *, name: str) -> None:
+        intent = resolve(name)
+        if not intent.heroes:
+            await ctx.send(
+                embed=_response_to_embed(
+                    btd6_ai_service.deterministic_answer(intent),
+                ),
+            )
+            return
+        from services.btd6_response_builder import for_hero
+
+        await ctx.send(embed=_response_to_embed(for_hero(intent.heroes[0])))
+
+    @btd6_group.command(name="round")
+    async def btd6_round(self, ctx: commands.Context, number: int) -> None:
+        from services.btd6_knowledge_service import round_fact
+        from services.btd6_response_builder import for_round, for_unresolved
+
+        fact = round_fact(number)
+        if fact is None:
+            intent = resolve(f"round {number}")
+            await ctx.send(embed=_response_to_embed(for_unresolved(intent)))
+            return
+        await ctx.send(embed=_response_to_embed(for_round(fact)))
+
+    @btd6_group.command(name="test-intent")
+    async def btd6_test_intent(self, ctx: commands.Context, *, text: str) -> None:
+        await ctx.send(embed=build_test_intent_embed(text))
+
+    @commands.command(name="btd6menu")
+    async def btd6menu(self, ctx: commands.Context) -> None:
+        """Open the BTD6 panel (alias for ``!btd6``)."""
+        await ctx.send(embed=build_btd6_panel_embed(), view=BTD6PanelView())
+
+    # ------------------------------------------------------------------
+    # App commands — mirror the prefix surface.
+    # ------------------------------------------------------------------
+
+    btd6_app_group = app_commands.Group(
+        name="btd6",
+        description="BTD6 Assistant — deterministic tower/round/mode lookups.",
+    )
+
+    @btd6_app_group.command(name="status", description="BTD6 assistant status.")
+    async def btd6_status_slash(self, interaction: discord.Interaction) -> None:
+        await interaction.response.send_message(
+            embed=build_status_embed(),
+            ephemeral=True,
+        )
+
+    @btd6_app_group.command(
+        name="diagnostics",
+        description="BTD6 dataset diagnostics.",
+    )
+    async def btd6_diagnostics_slash(self, interaction: discord.Interaction) -> None:
+        await interaction.response.send_message(
+            embed=build_diagnostics_embed(),
+            ephemeral=True,
+        )
+
+    @btd6_app_group.command(name="ask", description="Ask a BTD6 question.")
+    async def btd6_ask_slash(
+        self,
+        interaction: discord.Interaction,
+        question: str,
+    ) -> None:
+        response = await btd6_ai_service.answer_question(question)
+        await interaction.response.send_message(
+            embed=_response_to_embed(response),
+            ephemeral=True,
+        )
+
+    @btd6_app_group.command(name="tower", description="Look up a tower.")
+    async def btd6_tower_slash(
+        self,
+        interaction: discord.Interaction,
+        name: str,
+    ) -> None:
+        intent = resolve(name)
+        from services.btd6_knowledge_service import tower_fact
+        from services.btd6_response_builder import for_tower, for_unresolved
+
+        if not intent.towers:
+            response = for_unresolved(intent)
+        else:
+            fact = tower_fact(intent.towers[0].id)
+            response = for_tower(fact) if fact is not None else for_unresolved(intent)
+        await interaction.response.send_message(
+            embed=_response_to_embed(response),
+            ephemeral=True,
+        )
+
+    @btd6_app_group.command(name="round", description="Look up a round.")
+    async def btd6_round_slash(
+        self,
+        interaction: discord.Interaction,
+        number: int,
+    ) -> None:
+        from services.btd6_knowledge_service import round_fact
+        from services.btd6_response_builder import for_round, for_unresolved
+
+        fact = round_fact(number)
+        if fact is None:
+            intent = resolve(f"round {number}")
+            response = for_unresolved(intent)
+        else:
+            response = for_round(fact)
+        await interaction.response.send_message(
+            embed=_response_to_embed(response),
+            ephemeral=True,
+        )
+
+    @btd6_app_group.command(
+        name="test-intent",
+        description="Show what the resolver extracted from a message.",
+    )
+    async def btd6_test_intent_slash(
+        self,
+        interaction: discord.Interaction,
+        text: str,
+    ) -> None:
+        await interaction.response.send_message(
+            embed=build_test_intent_embed(text),
+            ephemeral=True,
+        )
+
+    @app_commands.command(name="btd6menu", description="Open the BTD6 panel.")
+    async def btd6menu_slash(self, interaction: discord.Interaction) -> None:
+        await interaction.response.send_message(
+            embed=build_btd6_panel_embed(),
+            view=BTD6PanelView(),
+            ephemeral=True,
+        )
+
+    # ------------------------------------------------------------------
+    # Help-menu hook
+    # ------------------------------------------------------------------
+
+    async def build_help_menu_view(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        return build_btd6_panel_embed(), BTD6PanelView()
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(BTD6Cog(bot))

--- a/disbot/cogs/btd6_cog.py
+++ b/disbot/cogs/btd6_cog.py
@@ -24,6 +24,8 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+from cogs.btd6.stage import BTD6AssistantMessageStage, STAGE_NAME as BTD6_STAGE_NAME
+from core.runtime import message_pipeline
 from services import btd6_ai_service, btd6_knowledge_service
 from services.btd6_resolver_service import resolve
 from views.btd6.panel import BTD6PanelView, build_btd6_panel_embed
@@ -183,6 +185,44 @@ def build_modes_embed() -> discord.Embed:
     return embed
 
 
+def build_why_no_response_embed(
+    stage: BTD6AssistantMessageStage | None,
+    channel_id: int,
+) -> discord.Embed:
+    """Render the latest passive-stage skip reasons for a channel.
+
+    The buffer carries only skip-reason codes + confidence scores —
+    never message content — so this command is safe to run in
+    public channels.
+    """
+    embed = discord.Embed(
+        title="🐵 BTD6 — Why no response?",
+        color=discord.Color.light_grey(),
+    )
+    if stage is None:
+        embed.description = (
+            "Passive stage is not loaded. Reload the BTD6 cog and try again."
+        )
+        return embed
+    skips = stage.latest_skips(channel_id)
+    if not skips:
+        embed.description = (
+            "No recent skip records for this channel. Either the passive "
+            "stage has not seen a message here yet, or it replied to the "
+            "last eligible one."
+        )
+        return embed
+    lines: list[str] = []
+    for record in reversed(skips):  # newest first
+        lines.append(
+            f"`{record.reason}` • confidence={record.confidence:.2f} "
+            f"• <t:{int(record.timestamp)}:R>",
+        )
+    embed.description = "\n".join(lines)
+    embed.set_footer(text="No message content is stored — only skip reasons.")
+    return embed
+
+
 def build_test_intent_embed(text: str) -> discord.Embed:
     """Resolver introspection — useful for operators tuning the cog."""
     intent = resolve(text)
@@ -230,6 +270,22 @@ class BTD6Cog(commands.Cog):
 
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
+        self._passive_stage: BTD6AssistantMessageStage | None = None
+
+    async def cog_load(self) -> None:
+        """Register the passive message stage with the platform pipeline.
+
+        Default-off (`BTD6_PASSIVE_ENABLED` controls behaviour). Even
+        when disabled, the stage is registered so `!btd6 why-no-response`
+        has a place to read skip reasons from.
+        """
+        self._passive_stage = BTD6AssistantMessageStage()
+        message_pipeline.register(self._passive_stage)
+
+    async def cog_unload(self) -> None:
+        """Remove the passive stage so reload/test cycles stay clean."""
+        message_pipeline.unregister(BTD6_STAGE_NAME)
+        self._passive_stage = None
 
     # ------------------------------------------------------------------
     # Prefix commands
@@ -302,6 +358,16 @@ class BTD6Cog(commands.Cog):
     @btd6_group.command(name="test-intent")
     async def btd6_test_intent(self, ctx: commands.Context, *, text: str) -> None:
         await ctx.send(embed=build_test_intent_embed(text))
+
+    @btd6_group.command(name="why-no-response")
+    async def btd6_why_no_response(self, ctx: commands.Context) -> None:
+        """Show the latest passive-stage skip reasons for this channel."""
+        await ctx.send(
+            embed=build_why_no_response_embed(
+                self._passive_stage,
+                ctx.channel.id if ctx.channel else 0,
+            ),
+        )
 
     @commands.command(name="btd6menu")
     async def btd6menu(self, ctx: commands.Context) -> None:

--- a/disbot/cogs/btd6_cog.py
+++ b/disbot/cogs/btd6_cog.py
@@ -297,21 +297,21 @@ class BTD6Cog(commands.Cog):
         """Open the BTD6 panel."""
         await ctx.send(embed=build_btd6_panel_embed(), view=BTD6PanelView())
 
-    @btd6_group.command(name="status")
+    @btd6_group.command(name="status")  # type: ignore[arg-type]
     async def btd6_status(self, ctx: commands.Context) -> None:
         await ctx.send(embed=build_status_embed())
 
-    @btd6_group.command(name="diagnostics")
+    @btd6_group.command(name="diagnostics")  # type: ignore[arg-type]
     async def btd6_diagnostics(self, ctx: commands.Context) -> None:
         await ctx.send(embed=build_diagnostics_embed())
 
-    @btd6_group.command(name="ask")
+    @btd6_group.command(name="ask")  # type: ignore[arg-type]
     async def btd6_ask(self, ctx: commands.Context, *, question: str) -> None:
         """Deterministic Q&A. Module 5 adds optional AI augmentation."""
         response = await btd6_ai_service.answer_question(question)
         await ctx.send(embed=_response_to_embed(response))
 
-    @btd6_group.command(name="tower")
+    @btd6_group.command(name="tower")  # type: ignore[arg-type]
     async def btd6_tower(self, ctx: commands.Context, *, name: str) -> None:
         intent = resolve(name)
         if not intent.towers:
@@ -330,7 +330,7 @@ class BTD6Cog(commands.Cog):
             return
         await ctx.send(embed=_response_to_embed(for_tower(fact)))
 
-    @btd6_group.command(name="hero")
+    @btd6_group.command(name="hero")  # type: ignore[arg-type]
     async def btd6_hero(self, ctx: commands.Context, *, name: str) -> None:
         intent = resolve(name)
         if not intent.heroes:
@@ -344,7 +344,7 @@ class BTD6Cog(commands.Cog):
 
         await ctx.send(embed=_response_to_embed(for_hero(intent.heroes[0])))
 
-    @btd6_group.command(name="round")
+    @btd6_group.command(name="round")  # type: ignore[arg-type]
     async def btd6_round(self, ctx: commands.Context, number: int) -> None:
         from services.btd6_knowledge_service import round_fact
         from services.btd6_response_builder import for_round, for_unresolved
@@ -356,11 +356,11 @@ class BTD6Cog(commands.Cog):
             return
         await ctx.send(embed=_response_to_embed(for_round(fact)))
 
-    @btd6_group.command(name="test-intent")
+    @btd6_group.command(name="test-intent")  # type: ignore[arg-type]
     async def btd6_test_intent(self, ctx: commands.Context, *, text: str) -> None:
         await ctx.send(embed=build_test_intent_embed(text))
 
-    @btd6_group.command(name="why-no-response")
+    @btd6_group.command(name="why-no-response")  # type: ignore[arg-type]
     async def btd6_why_no_response(self, ctx: commands.Context) -> None:
         """Show the latest passive-stage skip reasons for this channel."""
         await ctx.send(

--- a/disbot/cogs/btd6_cog.py
+++ b/disbot/cogs/btd6_cog.py
@@ -24,7 +24,8 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-from cogs.btd6.stage import BTD6AssistantMessageStage, STAGE_NAME as BTD6_STAGE_NAME
+from cogs.btd6.stage import STAGE_NAME as BTD6_STAGE_NAME
+from cogs.btd6.stage import BTD6AssistantMessageStage
 from core.runtime import message_pipeline
 from services import btd6_ai_service, btd6_knowledge_service
 from services.btd6_resolver_service import resolve

--- a/disbot/config.py
+++ b/disbot/config.py
@@ -55,6 +55,7 @@ INITIAL_EXTENSIONS = [
     "cogs.mining_cog",
     "cogs.diagnostic_cog",
     "cogs.ai_cog",
+    "cogs.btd6_cog",
     "cogs.chain_cog",
     "cogs.general_cog",
     "cogs.leaderboard_cog",

--- a/disbot/config.py
+++ b/disbot/config.py
@@ -118,3 +118,20 @@ SETUP_ADVISOR_PROVIDER = os.getenv("SETUP_ADVISOR_PROVIDER", "deterministic").lo
 SETUP_ADVISOR_OPENAI_MODEL = os.getenv("SETUP_ADVISOR_OPENAI_MODEL", "gpt-4o-mini")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
 ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY", "")
+
+# ==========================
+# AI platform (core/runtime/ai/gateway.py)
+# ==========================
+# ``AI_ENABLED``           — global on/off switch. Default off so the
+#                            gateway is boot-safe in dev/CI and
+#                            never makes external calls by accident.
+# ``AI_DEFAULT_PROVIDER``  — provider name for tasks that do not
+#                            override it. One of ``deterministic`` /
+#                            ``openai``. Default ``deterministic``.
+# Per-task overrides use ``AI_TASK_<NAME>_ENABLED`` and
+# ``AI_ROUTING_<NAME>=<provider>:<model>``; consult
+# ``core.runtime.ai.feature_flags`` / ``core.runtime.ai.routing``.
+# ``SETUP_ADVISOR_PROVIDER`` remains the authoritative env var for
+# the setup advisor's provider choice (back-compat).
+AI_ENABLED = os.getenv("AI_ENABLED", "").strip().lower() in {"1", "true", "yes", "on"}
+AI_DEFAULT_PROVIDER = os.getenv("AI_DEFAULT_PROVIDER", "deterministic").lower()

--- a/disbot/config.py
+++ b/disbot/config.py
@@ -54,6 +54,7 @@ INITIAL_EXTENSIONS = [
     "cogs.proof_channel_cog",
     "cogs.mining_cog",
     "cogs.diagnostic_cog",
+    "cogs.ai_cog",
     "cogs.chain_cog",
     "cogs.general_cog",
     "cogs.leaderboard_cog",

--- a/disbot/core/runtime/ai/__init__.py
+++ b/disbot/core/runtime/ai/__init__.py
@@ -1,10 +1,50 @@
-"""AI runtime contract scaffold for future SuperBot AI features.
+"""AI runtime — the provider-neutral platform layer.
 
-This package is intentionally inert in the scaffold PR.  Nothing imports it
-from production runtime yet.  Future PRs can wire these contracts into an
-AI gateway, diagnostics provider, and optional AI cog.
+This package owns the AI gateway and its contract types. Cogs and
+services consume AI through ``services.ai_gateway`` (a service-layer
+shim) rather than importing this package directly, keeping the
+dependency direction cogs → services → core/runtime.
+
+Public API:
+    AIGateway, get_default_gateway, reset_default_gateway
+    AIRequest, AIResponse, AIRequestContext, AISuggestion,
+    AIDiagnosticsSnapshot, AITask, AIScope, AIResponseMode,
+    AISuggestionKind
+    redact_text, redact_payload
 """
 
 from __future__ import annotations
 
-__all__ = []
+from core.runtime.ai.contracts import (
+    AIDiagnosticsSnapshot,
+    AIRequest,
+    AIRequestContext,
+    AIResponse,
+    AIResponseMode,
+    AIScope,
+    AISuggestion,
+    AISuggestionKind,
+    AITask,
+)
+from core.runtime.ai.gateway import (
+    AIGateway,
+    get_default_gateway,
+    reset_default_gateway,
+)
+from core.runtime.ai.redaction import redact_text
+
+__all__ = [
+    "AIDiagnosticsSnapshot",
+    "AIGateway",
+    "AIRequest",
+    "AIRequestContext",
+    "AIResponse",
+    "AIResponseMode",
+    "AIScope",
+    "AISuggestion",
+    "AISuggestionKind",
+    "AITask",
+    "get_default_gateway",
+    "redact_text",
+    "reset_default_gateway",
+]

--- a/disbot/core/runtime/ai/diagnostics.py
+++ b/disbot/core/runtime/ai/diagnostics.py
@@ -1,0 +1,91 @@
+"""Read-only diagnostics surface for the AI gateway.
+
+The gateway updates an in-process :class:`DiagnosticsCollector` on
+every call. The AI Cog (Module 2) and ``services.ai_diagnostics_service``
+read snapshots to render ``/ai status`` and ``/ai diagnostics``.
+
+A snapshot is a :class:`AIDiagnosticsSnapshot` (defined in
+:mod:`core.runtime.ai.contracts`). The collector lives here so the
+gateway's update path and the cog's read path agree on the same
+in-memory representation.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from core.runtime.ai.contracts import AIDiagnosticsSnapshot
+from core.runtime.ai.feature_flags import ai_default_provider, ai_enabled
+
+
+class DiagnosticsCollector:
+    """Counts requests and failures observed by the gateway.
+
+    Thread-safe via a coarse lock — call counts are negligible
+    compared to the cost of an LLM round-trip.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._requests = 0
+        self._failures = 0
+        self._last_provider_active = ai_default_provider()
+        self._last_error_type: str | None = None
+        self._last_fallback_reason: str | None = None
+        self._degraded = False
+
+    def record_request(self, *, provider_active: str) -> None:
+        with self._lock:
+            self._requests += 1
+            self._last_provider_active = provider_active
+
+    def record_failure(
+        self,
+        *,
+        provider_active: str,
+        error_type: str,
+        fallback_reason: str,
+    ) -> None:
+        with self._lock:
+            self._failures += 1
+            self._last_provider_active = provider_active
+            self._last_error_type = error_type
+            self._last_fallback_reason = fallback_reason
+            self._degraded = True
+
+    def record_success(self, *, provider_active: str) -> None:
+        with self._lock:
+            self._last_provider_active = provider_active
+            self._degraded = False
+
+    def snapshot(self) -> AIDiagnosticsSnapshot:
+        with self._lock:
+            return AIDiagnosticsSnapshot(
+                provider_requested=ai_default_provider(),
+                provider_active=self._last_provider_active,
+                model="",  # populated by the cog from routing on demand
+                enabled=ai_enabled(),
+                redaction_enabled=True,
+                degraded=self._degraded,
+                last_error_type=self._last_error_type,
+                last_fallback_reason=self._last_fallback_reason,
+                requests_observed=self._requests,
+                failures_observed=self._failures,
+            )
+
+
+_DEFAULT_COLLECTOR: DiagnosticsCollector | None = None
+
+
+def get_default_collector() -> DiagnosticsCollector:
+    """Process-wide singleton collector. Lazy-initialised."""
+    global _DEFAULT_COLLECTOR
+    if _DEFAULT_COLLECTOR is None:
+        _DEFAULT_COLLECTOR = DiagnosticsCollector()
+    return _DEFAULT_COLLECTOR
+
+
+def reset_default_collector() -> None:
+    """Test seam — drop the process-wide collector so tests start fresh."""
+    global _DEFAULT_COLLECTOR
+    _DEFAULT_COLLECTOR = None

--- a/disbot/core/runtime/ai/feature_flags.py
+++ b/disbot/core/runtime/ai/feature_flags.py
@@ -1,0 +1,83 @@
+"""Env-driven feature flags for the AI platform.
+
+The gateway consults these on every call. Defaults are designed for
+boot safety: AI is disabled unless an operator opts in, and the
+default provider is ``deterministic`` so no external call is ever
+made by accident.
+
+Recognised env vars:
+
+* ``AI_ENABLED``                 — ``"1"``/``"true"`` to enable the
+  platform globally. Default off.
+* ``AI_DEFAULT_PROVIDER``        — provider name; one of
+  ``deterministic`` / ``openai``. Default ``deterministic``.
+* ``AI_TASK_<NAME>_ENABLED``     — per-:class:`AITask` opt-in. The
+  ``<NAME>`` portion is the uppercase enum name (e.g.
+  ``AI_TASK_SETUP_SUGGEST_ENABLED``). Default off, except for
+  setup-advisor compatibility tasks which respect
+  ``SETUP_ADVISOR_PROVIDER`` (legacy).
+
+Compatibility note: ``SETUP_ADVISOR_PROVIDER`` remains the
+authoritative env var for the setup advisor's provider choice. The
+new flags are additive; existing operators see no behavior change.
+"""
+
+from __future__ import annotations
+
+import os
+
+from core.runtime.ai.contracts import AITask
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def _bool_env(name: str, *, default: bool = False) -> bool:
+    raw = os.getenv(name, "")
+    if not raw:
+        return default
+    return raw.strip().lower() in _TRUTHY
+
+
+def ai_enabled() -> bool:
+    """True if the AI platform is globally enabled.
+
+    When false, the gateway returns degraded responses without
+    invoking any provider. The setup advisor's deterministic
+    fallback path is preserved separately via
+    :func:`setup_advisor_provider`.
+    """
+    return _bool_env("AI_ENABLED", default=False)
+
+
+def ai_default_provider() -> str:
+    """Return the configured default provider name."""
+    value = os.getenv("AI_DEFAULT_PROVIDER", "").strip().lower()
+    if value:
+        return value
+    return "deterministic"
+
+
+def task_enabled(task: AITask) -> bool:
+    """True if a specific :class:`AITask` is allowed to call a provider.
+
+    Per-task gating layers on top of :func:`ai_enabled`: the global
+    flag must also be on. When ``ai_enabled()`` is false this
+    function returns false regardless of the task flag.
+    """
+    if not ai_enabled():
+        return False
+    env_name = f"AI_TASK_{task.name}_ENABLED"
+    return _bool_env(env_name, default=True)
+
+
+def setup_advisor_provider() -> str:
+    """Authoritative provider choice for the setup advisor.
+
+    Honours the legacy ``SETUP_ADVISOR_PROVIDER`` env var so existing
+    operators see no behavior change. Falls back to
+    :func:`ai_default_provider` when unset.
+    """
+    legacy = os.getenv("SETUP_ADVISOR_PROVIDER", "").strip().lower()
+    if legacy:
+        return legacy
+    return ai_default_provider()

--- a/disbot/core/runtime/ai/gateway.py
+++ b/disbot/core/runtime/ai/gateway.py
@@ -1,0 +1,322 @@
+"""AI gateway — the single chokepoint for provider calls.
+
+Responsibilities (in pipeline order):
+
+1. Feature-flag check (:mod:`feature_flags`) — return degraded
+   without invoking a provider when AI is disabled or the task is
+   gated off.
+2. Safety prechecks (:mod:`safety`) — empty prompt / oversized
+   payload → degraded.
+3. Redaction (:mod:`redaction`) — scrub the payload before any
+   external call.
+4. Routing (:mod:`routing`) — task → provider, model, timeout.
+5. Provider call wrapped in ``asyncio.wait_for`` for the timeout.
+6. Metrics observation (counters + histogram).
+7. Parse text into :class:`AIResponse` (JSON parse when
+   ``AIResponseMode.JSON``).
+8. On any exception or timeout: convert to degraded
+   :class:`AIResponse` (never raises to caller).
+
+The gateway is the only place a cog or service should ask "talk to
+an AI provider". Consumers import via ``services.ai_gateway`` (the
+service-layer shim) — never directly from this module — so the
+dependency direction stays cogs → services → core/runtime.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from typing import Any
+
+from core.runtime.ai import redaction
+from core.runtime.ai.contracts import AIRequest, AIResponse, AIResponseMode
+from core.runtime.ai.diagnostics import DiagnosticsCollector, get_default_collector
+from core.runtime.ai.feature_flags import task_enabled
+from core.runtime.ai.providers import (
+    DeterministicFallbackError,
+    DeterministicProvider,
+    OpenAIProvider,
+    Provider,
+    ProviderUnavailableError,
+)
+from core.runtime.ai.routing import resolve
+from core.runtime.ai.safety import precheck
+from services import metrics
+
+logger = logging.getLogger("bot.runtime.ai.gateway")
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Redact secrets from every string value in ``payload``."""
+    result = redaction.redact_payload(payload)
+    return result.value if isinstance(result.value, dict) else dict(result.value)
+
+
+def _redact_string(value: str) -> str:
+    """Run redaction on a plain string and return the scrubbed value."""
+    return redaction.redact_text(value).value
+
+
+def _degraded_response(
+    request: AIRequest,
+    *,
+    provider_name: str,
+    reason: str,
+    latency_ms: float | None = None,
+) -> AIResponse:
+    return AIResponse(
+        task=request.context.task,
+        provider=provider_name,
+        model="",
+        text=None,
+        data=None,
+        suggestions=(),
+        latency_ms=latency_ms,
+        degraded=True,
+        fallback_reason=reason,
+    )
+
+
+class AIGateway:
+    """Provider-neutral entry point for AI requests."""
+
+    def __init__(
+        self,
+        *,
+        providers: dict[str, Provider] | None = None,
+        collector: DiagnosticsCollector | None = None,
+    ) -> None:
+        self._providers: dict[str, Provider] = providers or {
+            "openai": OpenAIProvider(),
+            "deterministic": DeterministicProvider(),
+        }
+        self._collector = collector or get_default_collector()
+
+    def get_provider(self, name: str) -> Provider | None:
+        return self._providers.get(name)
+
+    def register_provider(self, provider: Provider) -> None:
+        """Install or replace a provider by ``provider.name``."""
+        self._providers[provider.name] = provider
+
+    async def execute(
+        self,
+        request: AIRequest,
+        *,
+        provider_override: Provider | None = None,
+    ) -> AIResponse:
+        """Run a request through the pipeline; never raises."""
+        target = resolve(request.context.task)
+        provider_name = provider_override.name if provider_override else target.provider
+
+        if provider_override is None and not task_enabled(request.context.task):
+            return _degraded_response(
+                request,
+                provider_name=provider_name,
+                reason=f"feature_flag:disabled:{request.context.task.value}",
+            )
+
+        safety_reason = precheck(request)
+        if safety_reason is not None:
+            self._collector.record_failure(
+                provider_active=provider_name,
+                error_type="SafetyCheck",
+                fallback_reason=safety_reason,
+            )
+            return _degraded_response(
+                request,
+                provider_name=provider_name,
+                reason=safety_reason,
+            )
+
+        redacted_payload = _redact_payload(request.payload)
+        redacted_system = _redact_string(request.system_prompt)
+        redacted_request = AIRequest(
+            context=request.context,
+            system_prompt=redacted_system,
+            payload=redacted_payload,
+            mode=request.mode,
+            response_schema=request.response_schema,
+            max_output_tokens=request.max_output_tokens,
+            timeout_seconds=request.timeout_seconds,
+        )
+
+        provider = provider_override or self._providers.get(target.provider)
+        if provider is None:
+            reason = f"provider_missing:{target.provider}"
+            self._collector.record_failure(
+                provider_active=target.provider,
+                error_type="ProviderMissing",
+                fallback_reason=reason,
+            )
+            return _degraded_response(
+                request,
+                provider_name=target.provider,
+                reason=reason,
+            )
+
+        self._collector.record_request(provider_active=provider.name)
+        timeout = request.timeout_seconds or target.timeout_seconds
+        outcome = "success"
+        started = time.perf_counter()
+        try:
+            raw_text = await asyncio.wait_for(
+                provider.execute(redacted_request, model=target.model),
+                timeout=timeout,
+            )
+        except asyncio.TimeoutError:
+            latency_ms = (time.perf_counter() - started) * 1000.0
+            outcome = "timeout"
+            metrics.ai_request_total.labels(
+                task=request.context.task.value,
+                outcome=outcome,
+            ).inc()
+            metrics.ai_request_seconds.labels(
+                task=request.context.task.value,
+                provider=provider.name,
+            ).observe(latency_ms / 1000.0)
+            self._collector.record_failure(
+                provider_active=provider.name,
+                error_type="TimeoutError",
+                fallback_reason=f"timeout:{timeout}s",
+            )
+            return _degraded_response(
+                request,
+                provider_name=provider.name,
+                reason=f"timeout:{timeout}s",
+                latency_ms=latency_ms,
+            )
+        except DeterministicFallbackError as exc:
+            latency_ms = (time.perf_counter() - started) * 1000.0
+            outcome = "deterministic"
+            metrics.ai_request_total.labels(
+                task=request.context.task.value,
+                outcome=outcome,
+            ).inc()
+            metrics.ai_request_seconds.labels(
+                task=request.context.task.value,
+                provider=provider.name,
+            ).observe(latency_ms / 1000.0)
+            self._collector.record_failure(
+                provider_active=provider.name,
+                error_type="DeterministicFallbackError",
+                fallback_reason=str(exc),
+            )
+            return _degraded_response(
+                request,
+                provider_name=provider.name,
+                reason=f"provider={provider.name}",
+                latency_ms=latency_ms,
+            )
+        except ProviderUnavailableError as exc:
+            latency_ms = (time.perf_counter() - started) * 1000.0
+            outcome = "unavailable"
+            metrics.ai_request_total.labels(
+                task=request.context.task.value,
+                outcome=outcome,
+            ).inc()
+            metrics.ai_request_seconds.labels(
+                task=request.context.task.value,
+                provider=provider.name,
+            ).observe(latency_ms / 1000.0)
+            self._collector.record_failure(
+                provider_active=provider.name,
+                error_type=type(exc).__name__,
+                fallback_reason=str(exc),
+            )
+            return _degraded_response(
+                request,
+                provider_name=provider.name,
+                reason=str(exc),
+                latency_ms=latency_ms,
+            )
+        except Exception as exc:  # noqa: BLE001 — provider exception boundary
+            latency_ms = (time.perf_counter() - started) * 1000.0
+            outcome = "error"
+            metrics.ai_request_total.labels(
+                task=request.context.task.value,
+                outcome=outcome,
+            ).inc()
+            metrics.ai_request_seconds.labels(
+                task=request.context.task.value,
+                provider=provider.name,
+            ).observe(latency_ms / 1000.0)
+            logger.exception(
+                "AI provider %r raised on task %s",
+                provider.name,
+                request.context.task.value,
+            )
+            self._collector.record_failure(
+                provider_active=provider.name,
+                error_type=type(exc).__name__,
+                fallback_reason=f"{type(exc).__name__}: {exc}",
+            )
+            return _degraded_response(
+                request,
+                provider_name=provider.name,
+                reason=f"{type(exc).__name__}: {exc}",
+                latency_ms=latency_ms,
+            )
+
+        latency_ms = (time.perf_counter() - started) * 1000.0
+        metrics.ai_request_total.labels(
+            task=request.context.task.value,
+            outcome=outcome,
+        ).inc()
+        metrics.ai_request_seconds.labels(
+            task=request.context.task.value,
+            provider=provider.name,
+        ).observe(latency_ms / 1000.0)
+
+        text: str | None = raw_text
+        data: dict[str, Any] | None = None
+        degraded = False
+        fallback_reason: str | None = None
+        if request.mode is AIResponseMode.JSON:
+            try:
+                parsed = json.loads(raw_text)
+            except json.JSONDecodeError as exc:
+                degraded = True
+                fallback_reason = f"invalid_json:{exc}"
+                self._collector.record_failure(
+                    provider_active=provider.name,
+                    error_type="JSONDecodeError",
+                    fallback_reason=fallback_reason,
+                )
+            else:
+                data = parsed if isinstance(parsed, dict) else {"value": parsed}
+                self._collector.record_success(provider_active=provider.name)
+        else:
+            self._collector.record_success(provider_active=provider.name)
+
+        return AIResponse(
+            task=request.context.task,
+            provider=provider.name,
+            model=target.model,
+            text=text,
+            data=data,
+            suggestions=(),
+            latency_ms=latency_ms,
+            degraded=degraded,
+            fallback_reason=fallback_reason,
+        )
+
+
+_DEFAULT_GATEWAY: AIGateway | None = None
+
+
+def get_default_gateway() -> AIGateway:
+    """Process-wide singleton gateway. Lazy-initialised."""
+    global _DEFAULT_GATEWAY
+    if _DEFAULT_GATEWAY is None:
+        _DEFAULT_GATEWAY = AIGateway()
+    return _DEFAULT_GATEWAY
+
+
+def reset_default_gateway() -> None:
+    """Test seam — drop the singleton so tests start with a fresh gateway."""
+    global _DEFAULT_GATEWAY
+    _DEFAULT_GATEWAY = None

--- a/disbot/core/runtime/ai/providers/__init__.py
+++ b/disbot/core/runtime/ai/providers/__init__.py
@@ -1,0 +1,27 @@
+"""AI provider adapters.
+
+The ``providers/`` subpackage is the only place in the codebase that
+imports external LLM SDKs (``openai``, ``anthropic`` later). The
+gateway in :mod:`core.runtime.ai.gateway` holds typed
+:class:`Provider` instances and never touches an SDK directly. The
+invariant test
+``tests/unit/invariants/test_ai_btd6_boundaries.py::test_provider_sdk_imports_only_in_providers``
+enforces this rule.
+"""
+
+from __future__ import annotations
+
+from core.runtime.ai.providers.base import Provider, ProviderUnavailableError
+from core.runtime.ai.providers.deterministic_provider import (
+    DeterministicFallbackError,
+    DeterministicProvider,
+)
+from core.runtime.ai.providers.openai_provider import OpenAIProvider
+
+__all__ = [
+    "DeterministicFallbackError",
+    "DeterministicProvider",
+    "OpenAIProvider",
+    "Provider",
+    "ProviderUnavailableError",
+]

--- a/disbot/core/runtime/ai/providers/base.py
+++ b/disbot/core/runtime/ai/providers/base.py
@@ -1,0 +1,67 @@
+"""Provider protocol for the AI gateway.
+
+A provider implements one method, ``execute``, that converts a typed
+:class:`AIRequest` into raw response text (JSON or plain text,
+depending on ``AIRequest.mode``). The gateway handles redaction,
+routing, timeout, parsing, metrics, and degradation around this
+method.
+
+Providers may raise:
+
+* :class:`ProviderUnavailableError` — the provider cannot run (missing
+  SDK, missing API key, configuration error). The gateway converts
+  this into a degraded :class:`AIResponse` with a descriptive
+  ``fallback_reason``.
+* Any other exception — the gateway logs it, increments the failure
+  counter, and converts it into a degraded response. Provider
+  implementations should not swallow exceptions silently; the
+  gateway is the single fault boundary.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from core.runtime.ai.contracts import AIRequest
+
+
+class ProviderUnavailableError(RuntimeError):
+    """Raised when a provider cannot execute the request.
+
+    Typical causes: missing SDK package, missing API key,
+    configuration mismatch. The gateway converts this into a
+    degraded :class:`AIResponse` rather than propagating it.
+    """
+
+
+@runtime_checkable
+class Provider(Protocol):
+    """Provider adapter contract.
+
+    Implementations live under ``core/runtime/ai/providers/`` and are
+    the only modules permitted to import external LLM SDKs.
+    """
+
+    name: str
+
+    async def execute(self, request: AIRequest, *, model: str) -> str:
+        """Run the provider call and return the raw text response.
+
+        Args:
+            request: The typed :class:`AIRequest` (already redacted by
+                the gateway before this is called).
+            model: The provider-specific model identifier resolved by
+                :mod:`core.runtime.ai.routing`.
+
+        Returns:
+            The raw assistant text. For ``AIResponseMode.JSON`` the
+            text is expected to be a JSON document; the gateway
+            parses it. For ``AIResponseMode.TEXT`` the text is
+            returned as-is on the :attr:`AIResponse.text` field.
+
+        Raises:
+            ProviderUnavailableError: if the provider cannot serve this
+                request (no API key, missing SDK).
+            Exception: any other failure is caught by the gateway.
+        """
+        ...

--- a/disbot/core/runtime/ai/providers/deterministic_provider.py
+++ b/disbot/core/runtime/ai/providers/deterministic_provider.py
@@ -1,0 +1,37 @@
+"""Deterministic fallback provider.
+
+The deterministic provider never makes an external call. It always
+raises :class:`DeterministicFallbackError`, which the gateway converts
+into a degraded :class:`AIResponse` with ``fallback_reason``
+``provider=deterministic``. Consumers that want a deterministic
+baseline (e.g. the setup advisor) check for ``degraded`` and apply
+their own local logic.
+
+This provider is the default in CI/dev environments where no LLM
+API key is configured. Its existence keeps the gateway boot-safe:
+``get_default_gateway()`` always returns a usable instance.
+"""
+
+from __future__ import annotations
+
+from core.runtime.ai.contracts import AIRequest
+
+
+class DeterministicFallbackError(RuntimeError):
+    """Signal that no LLM provider is willing or able to serve this request."""
+
+
+class DeterministicProvider:
+    """Always-available no-op provider.
+
+    ``execute`` raises :class:`DeterministicFallbackError`. The gateway
+    catches it and returns a degraded :class:`AIResponse` so callers
+    have a uniform "degrade gracefully" code path.
+    """
+
+    name = "deterministic"
+
+    async def execute(self, request: AIRequest, *, model: str) -> str:
+        raise DeterministicFallbackError(
+            "deterministic provider selected; no external call performed",
+        )

--- a/disbot/core/runtime/ai/providers/openai_provider.py
+++ b/disbot/core/runtime/ai/providers/openai_provider.py
@@ -1,0 +1,97 @@
+"""OpenAI provider adapter — the only module that imports ``openai``.
+
+The invariant test
+``tests/unit/invariants/test_ai_btd6_boundaries.py::test_provider_sdk_imports_only_in_providers``
+fails if any other production module imports the ``openai`` SDK
+directly. All consumers route through
+:class:`core.runtime.ai.gateway.AIGateway`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+from core.runtime.ai.contracts import AIRequest, AIResponseMode
+from core.runtime.ai.providers.base import ProviderUnavailableError
+
+logger = logging.getLogger("bot.runtime.ai.openai_provider")
+
+
+class OpenAIProvider:
+    """Async OpenAI chat-completions adapter with strict JSON schema.
+
+    The adapter is constructed once per gateway. A test can inject a
+    duck-typed ``client`` (e.g. a ``MagicMock`` shaped like
+    ``AsyncOpenAI``) without importing the SDK.
+    """
+
+    name = "openai"
+
+    def __init__(
+        self,
+        *,
+        client: Any = None,
+        api_key: str | None = None,
+    ) -> None:
+        self._client = client
+        self._api_key = api_key
+
+    def _ensure_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        try:
+            from openai import AsyncOpenAI
+        except ImportError as exc:
+            raise ProviderUnavailableError(
+                "openai package is not installed; install ``openai>=1.40.0`` "
+                "or set AI provider to ``deterministic``.",
+            ) from exc
+        api_key = self._api_key or os.getenv("OPENAI_API_KEY", "")
+        if not api_key:
+            raise ProviderUnavailableError(
+                "OPENAI_API_KEY is not set; cannot construct OpenAI client.",
+            )
+        self._client = AsyncOpenAI(api_key=api_key)
+        return self._client
+
+    async def execute(self, request: AIRequest, *, model: str) -> str:
+        client = self._ensure_client()
+        user_payload = json.dumps(request.payload, default=str)
+        messages = [
+            {"role": "system", "content": request.system_prompt},
+            {"role": "user", "content": user_payload},
+        ]
+        kwargs: dict[str, Any] = {"model": model, "messages": messages}
+        if request.mode is AIResponseMode.JSON and request.response_schema:
+            kwargs["response_format"] = {
+                "type": "json_schema",
+                "json_schema": request.response_schema,
+            }
+        elif request.mode is AIResponseMode.JSON:
+            # JSON requested but no schema provided — fall back to the
+            # SDK's loose JSON mode so callers still get parseable output.
+            kwargs["response_format"] = {"type": "json_object"}
+
+        response = await client.chat.completions.create(**kwargs)
+        text = _extract_response_text(response)
+        if text is None:
+            raise RuntimeError("openai: empty response (no choices/message/content)")
+        return text
+
+
+def _extract_response_text(response: Any) -> str | None:
+    """Pull the assistant message text out of a Chat Completions response."""
+    choices = getattr(response, "choices", None)
+    if not choices:
+        return None
+    first = choices[0]
+    message = getattr(first, "message", None)
+    if message is None:
+        return None
+    content = getattr(message, "content", None)
+    if not content:
+        return None
+    return content

--- a/disbot/core/runtime/ai/redaction.py
+++ b/disbot/core/runtime/ai/redaction.py
@@ -20,7 +20,10 @@ _TOKEN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ),
     (
         "api_key_like",
-        re.compile(r"\b(?:sk|pk|rk|xoxb|ghp)_[A-Za-z0-9_\-]{12,}\b"),
+        # Matches both underscore (legacy: ``sk_secret``) and hyphen
+        # (OpenAI-style: ``sk-proj-...``) prefixes, plus the common
+        # GitHub / Slack token prefixes.
+        re.compile(r"\b(?:sk|pk|rk|xoxb|ghp)[_-][A-Za-z0-9_\-]{12,}\b"),
     ),
     (
         "database_url",

--- a/disbot/core/runtime/ai/routing.py
+++ b/disbot/core/runtime/ai/routing.py
@@ -1,0 +1,88 @@
+"""Task → (provider, model, timeout) resolution.
+
+Routing keeps provider/model decisions out of the gateway core so
+the gateway stays focused on safety, redaction, and fault handling.
+Each :class:`AITask` resolves to a typed :class:`RoutingTarget`.
+
+Resolution order:
+
+1. Explicit override stored via :func:`override` (test seam; cleared
+   by :func:`clear_overrides`).
+2. Per-task env var: ``AI_ROUTING_<TASK_NAME>=<provider>:<model>``.
+3. Default registry built from :func:`feature_flags.ai_default_provider`.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from core.runtime.ai.contracts import AITask
+from core.runtime.ai.feature_flags import ai_default_provider
+
+DEFAULT_TIMEOUT_SECONDS = 20.0
+
+# Default per-task model. Kept conservative; operators can override
+# via env var or :func:`override` without code change. The setup
+# advisor used gpt-4o-mini historically; that's the safe default.
+_DEFAULT_MODELS: dict[AITask, str] = {
+    AITask.SETUP_SUGGEST: "gpt-4o-mini",
+    AITask.SETUP_EXPLAIN: "gpt-4o-mini",
+    AITask.PLATFORM_EXPLAIN_STATUS: "gpt-4o-mini",
+    AITask.PLATFORM_EXPLAIN_CONSISTENCY: "gpt-4o-mini",
+    AITask.LOGS_TRIAGE: "gpt-4o-mini",
+    AITask.SETTINGS_EXPLAIN: "gpt-4o-mini",
+    AITask.SETTINGS_PROPOSE: "gpt-4o-mini",
+    AITask.HELP_ANSWER: "gpt-4o-mini",
+    AITask.CODE_CONTEXT_EXPLAIN: "gpt-4o-mini",
+    AITask.MODERATION_ASSIST: "gpt-4o-mini",
+}
+
+
+@dataclass(frozen=True)
+class RoutingTarget:
+    """Resolved provider + model + timeout for a single AI call."""
+
+    provider: str
+    model: str
+    timeout_seconds: float
+
+
+_OVERRIDES: dict[AITask, RoutingTarget] = {}
+
+
+def override(task: AITask, target: RoutingTarget) -> None:
+    """Install a routing override; primarily a test seam.
+
+    Production code does not call this; tests use it to direct a
+    task at a fake provider without touching env vars.
+    """
+    _OVERRIDES[task] = target
+
+
+def clear_overrides() -> None:
+    """Reset every routing override; restores env/default resolution."""
+    _OVERRIDES.clear()
+
+
+def resolve(task: AITask) -> RoutingTarget:
+    """Resolve the provider, model, and timeout for ``task``."""
+    if task in _OVERRIDES:
+        return _OVERRIDES[task]
+
+    env_name = f"AI_ROUTING_{task.name}"
+    env_value = os.getenv(env_name, "").strip()
+    if env_value:
+        provider, _, model = env_value.partition(":")
+        if provider:
+            return RoutingTarget(
+                provider=provider.strip().lower(),
+                model=(model.strip() or _DEFAULT_MODELS.get(task, "gpt-4o-mini")),
+                timeout_seconds=DEFAULT_TIMEOUT_SECONDS,
+            )
+
+    return RoutingTarget(
+        provider=ai_default_provider(),
+        model=_DEFAULT_MODELS.get(task, "gpt-4o-mini"),
+        timeout_seconds=DEFAULT_TIMEOUT_SECONDS,
+    )

--- a/disbot/core/runtime/ai/safety.py
+++ b/disbot/core/runtime/ai/safety.py
@@ -1,0 +1,47 @@
+"""Pre-provider safety checks for AI requests.
+
+These checks run synchronously inside the gateway before any
+external call. They are deterministic and cheap; they never depend
+on an LLM. A check that fires returns a textual reason; the gateway
+short-circuits with a degraded :class:`AIResponse` and never sends
+the request.
+
+Checks (composable, ordered):
+
+1. Empty / whitespace-only ``system_prompt`` — guards against
+   misconfigured callers that build prompts dynamically.
+2. Empty ``payload`` — same.
+3. Payload size cap — JSON-serialised size in bytes must stay below
+   :data:`MAX_PAYLOAD_BYTES`. Protects against accidental large
+   dumps (e.g. an entire guild snapshot pasted in).
+
+Future hooks: more sophisticated prompt-injection heuristics. The
+plan defers those until a real abuse signal exists; deterministic
+size/empty checks are the conservative baseline.
+"""
+
+from __future__ import annotations
+
+import json
+
+from core.runtime.ai.contracts import AIRequest
+
+# Conservative ceiling for the serialised payload size in bytes.
+# Setup advisor snapshots run well under 100 KiB; this rejects
+# obvious mistakes without blocking legitimate use.
+MAX_PAYLOAD_BYTES = 256 * 1024
+
+
+def precheck(request: AIRequest) -> str | None:
+    """Run safety checks; return the first failure reason or ``None``."""
+    if not request.system_prompt or not request.system_prompt.strip():
+        return "safety: empty system_prompt"
+    if not request.payload:
+        return "safety: empty payload"
+    try:
+        size = len(json.dumps(request.payload, default=str).encode("utf-8"))
+    except (TypeError, ValueError):
+        return "safety: payload is not JSON-serialisable"
+    if size > MAX_PAYLOAD_BYTES:
+        return f"safety: payload {size}B exceeds {MAX_PAYLOAD_BYTES}B cap"
+    return None

--- a/disbot/data/btd6/heroes.json
+++ b/disbot/data/btd6/heroes.json
@@ -1,0 +1,47 @@
+{
+  "data_version": "1.0",
+  "game_version": "41.3",
+  "source": "Bloons Wiki — representative sample (Module 3 of AI/BTD6 plan)",
+  "heroes": [
+    {
+      "id": "quincy",
+      "canonical": "Quincy",
+      "aliases": ["q", "default hero"],
+      "base_cost": 540,
+      "description": "Free starter hero. Reliable single-target archer.",
+      "abilities": [
+        {
+          "level": 3,
+          "name": "Rapid Shot",
+          "summary": "Briefly increased attack speed."
+        },
+        {
+          "level": 10,
+          "name": "Storm of Arrows",
+          "summary": "Massive AoE arrow rain."
+        }
+      ],
+      "wiki_url": "https://bloons.fandom.com/wiki/Quincy"
+    },
+    {
+      "id": "sauda",
+      "canonical": "Sauda",
+      "aliases": ["saud", "blade master"],
+      "base_cost": 800,
+      "description": "Melee swordmaster, strong vs leads and ceramics in the early-to-mid game.",
+      "abilities": [
+        {
+          "level": 3,
+          "name": "Sword Charge",
+          "summary": "Dashes through bloons in a line."
+        },
+        {
+          "level": 10,
+          "name": "Leaping Sword",
+          "summary": "Spinning leap with high damage AoE."
+        }
+      ],
+      "wiki_url": "https://bloons.fandom.com/wiki/Sauda"
+    }
+  ]
+}

--- a/disbot/data/btd6/maps.json
+++ b/disbot/data/btd6/maps.json
@@ -1,0 +1,34 @@
+{
+  "data_version": "1.0",
+  "game_version": "41.3",
+  "source": "Bloons Wiki — representative sample (Module 3 of AI/BTD6 plan)",
+  "maps": [
+    {
+      "id": "logs",
+      "canonical": "Logs",
+      "aliases": ["log"],
+      "difficulty": "Beginner",
+      "description": "Single river-and-logs track. Heavy water coverage in places.",
+      "lines_of_sight_notes": "Open central area; water tile presence allows naval towers.",
+      "wiki_url": "https://bloons.fandom.com/wiki/Logs"
+    },
+    {
+      "id": "cubism",
+      "canonical": "Cubism",
+      "aliases": ["cube", "cubes"],
+      "difficulty": "Intermediate",
+      "description": "Tight quartered paths with cubes obstructing line of sight.",
+      "lines_of_sight_notes": "Cubes block towers; consider towers that ignore LoS or place near gaps.",
+      "wiki_url": "https://bloons.fandom.com/wiki/Cubism"
+    },
+    {
+      "id": "cornfield",
+      "canonical": "Cornfield",
+      "aliases": ["corn"],
+      "difficulty": "Beginner",
+      "description": "Open field with a winding path. Forgiving placement.",
+      "lines_of_sight_notes": "Open layout; nearly any tower works.",
+      "wiki_url": "https://bloons.fandom.com/wiki/Cornfield"
+    }
+  ]
+}

--- a/disbot/data/btd6/modes.json
+++ b/disbot/data/btd6/modes.json
@@ -1,0 +1,31 @@
+{
+  "data_version": "1.0",
+  "game_version": "41.3",
+  "source": "Bloons Wiki — representative sample (Module 3 of AI/BTD6 plan)",
+  "modes": [
+    {
+      "id": "standard",
+      "canonical": "Standard",
+      "aliases": ["easy_standard", "medium_standard", "hard_standard"],
+      "starting_cash": 650,
+      "starting_lives": 100,
+      "description": "Default progression. Rounds 1-40 (Easy), 3-60 (Medium), 3-80 (Hard).",
+      "restrictions": []
+    },
+    {
+      "id": "chimps",
+      "canonical": "CHIMPS",
+      "aliases": ["chimp", "chimp mode"],
+      "starting_cash": 650,
+      "starting_lives": 1,
+      "description": "Hard-mode endgame challenge. 1 life, no continues, no income towers, no powers.",
+      "restrictions": [
+        "No income (no banana farms or city)",
+        "No abilities outside what towers already provide",
+        "No powers / monkey knowledge bonuses",
+        "No continues",
+        "No selling towers"
+      ]
+    }
+  ]
+}

--- a/disbot/data/btd6/rounds.json
+++ b/disbot/data/btd6/rounds.json
@@ -1,0 +1,67 @@
+{
+  "data_version": "1.0",
+  "game_version": "41.3",
+  "source": "Bloons Wiki — representative sample (Module 3 of AI/BTD6 plan)",
+  "rounds": [
+    {
+      "round": 1,
+      "summary": "20 Reds. Very easy.",
+      "danger": "trivial",
+      "common_threats": []
+    },
+    {
+      "round": 5,
+      "summary": "Mix of Reds and Blues.",
+      "danger": "trivial",
+      "common_threats": []
+    },
+    {
+      "round": 10,
+      "summary": "First Pinks. Pinks are fast — make sure you have something with reach.",
+      "danger": "low",
+      "common_threats": ["Pink"]
+    },
+    {
+      "round": 21,
+      "summary": "First Lead bloons in a fast wave. Need sharp-piercing damage or explosive.",
+      "danger": "medium",
+      "common_threats": ["Lead"]
+    },
+    {
+      "round": 28,
+      "summary": "First Ceramic rush. Need consistent ceramic damage.",
+      "danger": "medium",
+      "common_threats": ["Ceramic"]
+    },
+    {
+      "round": 40,
+      "summary": "First BAD-class threat in Standard Easy ending — first BFB on Medium/Hard. Bring serious DPS.",
+      "danger": "high",
+      "common_threats": ["BFB"]
+    },
+    {
+      "round": 63,
+      "summary": "Long Ceramic-Lead wave with Camo Lead mixed in. Pierce-heavy ceramic answers AND camo detection both required.",
+      "danger": "high",
+      "common_threats": ["Ceramic", "Camo Lead"]
+    },
+    {
+      "round": 78,
+      "summary": "Two BADs back-to-back. Need at least one tower or hero capable of high DPS to BAD-class bloons.",
+      "danger": "very_high",
+      "common_threats": ["BAD"]
+    },
+    {
+      "round": 95,
+      "summary": "Lots of DDTs in waves. Camo lead detection essential; sharp/shatter damage helpful.",
+      "danger": "very_high",
+      "common_threats": ["DDT"]
+    },
+    {
+      "round": 100,
+      "summary": "BAD + heavy support. The hardest standard freeplay round most players reach.",
+      "danger": "extreme",
+      "common_threats": ["BAD", "DDT"]
+    }
+  ]
+}

--- a/disbot/data/btd6/towers.json
+++ b/disbot/data/btd6/towers.json
@@ -1,0 +1,135 @@
+{
+  "data_version": "1.0",
+  "game_version": "41.3",
+  "source": "Bloons Wiki — representative sample (Module 3 of AI/BTD6 plan)",
+  "towers": [
+    {
+      "id": "dart_monkey",
+      "canonical": "Dart Monkey",
+      "aliases": ["dart", "darts", "darty"],
+      "category": "primary",
+      "base_cost": 200,
+      "description": "Throws a single dart at the nearest bloon.",
+      "upgrade_paths": {
+        "top": [
+          "Sharp Shots",
+          "Razor Sharp Shots",
+          "Spike-O-Pult",
+          "Juggernaut",
+          "Ultra-Juggernaut"
+        ],
+        "mid": [
+          "Quick Shots",
+          "Very Quick Shots",
+          "Triple Shot",
+          "Super Monkey Fan Club",
+          "Plasma Monkey Fan Club"
+        ],
+        "bot": [
+          "Long Range Darts",
+          "Enhanced Eyesight",
+          "Crossbow",
+          "Sharp Shooter",
+          "Crossbow Master"
+        ]
+      },
+      "wiki_url": "https://bloons.fandom.com/wiki/Dart_Monkey"
+    },
+    {
+      "id": "boomerang_monkey",
+      "canonical": "Boomerang Monkey",
+      "aliases": ["boomer", "boomerang", "boomy"],
+      "category": "primary",
+      "base_cost": 325,
+      "description": "Throws boomerangs that curve through tracks.",
+      "upgrade_paths": {
+        "top": [
+          "Improved Rangs",
+          "Glaives",
+          "Glaive Ricochet",
+          "M.O.A.R Glaives",
+          "Glaive Lord"
+        ],
+        "mid": [
+          "Faster Throwing",
+          "Faster Rangs",
+          "Bionic Boomerang",
+          "Turbo Charge",
+          "Perma Charge"
+        ],
+        "bot": [
+          "Long Range Rangs",
+          "Red Hot Rangs",
+          "Kylie Boomerang",
+          "MOAB Press",
+          "MOAB Domination"
+        ]
+      },
+      "wiki_url": "https://bloons.fandom.com/wiki/Boomerang_Monkey"
+    },
+    {
+      "id": "tack_shooter",
+      "canonical": "Tack Shooter",
+      "aliases": ["tack", "tacks", "tackshooter"],
+      "category": "primary",
+      "base_cost": 280,
+      "description": "Shoots eight tacks outward in a radial burst.",
+      "upgrade_paths": {
+        "top": [
+          "Faster Shooting",
+          "Even Faster Shooting",
+          "Hot Shots",
+          "Ring of Fire",
+          "Inferno Ring"
+        ],
+        "mid": [
+          "Long Range Tacks",
+          "Super Range Tacks",
+          "Blade Shooter",
+          "Blade Maelstrom",
+          "Super Maelstrom"
+        ],
+        "bot": [
+          "More Tacks",
+          "Even More Tacks",
+          "Tack Sprayer",
+          "Overdrive",
+          "The Tack Zone"
+        ]
+      },
+      "wiki_url": "https://bloons.fandom.com/wiki/Tack_Shooter"
+    },
+    {
+      "id": "bomb_shooter",
+      "canonical": "Bomb Shooter",
+      "aliases": ["bomb", "bombs", "bombshooter"],
+      "category": "military",
+      "base_cost": 525,
+      "description": "Lobs slow bombs that explode and damage groups of bloons.",
+      "upgrade_paths": {
+        "top": [
+          "Bigger Bombs",
+          "Heavy Bombs",
+          "Really Big Bombs",
+          "Bloon Impact",
+          "Bloon Crush"
+        ],
+        "mid": [
+          "Faster Reload",
+          "Missile Launcher",
+          "MOAB Mauler",
+          "MOAB Assassin",
+          "MOAB Eliminator"
+        ],
+        "bot": [
+          "Extra Range",
+          "Frag Bombs",
+          "Cluster Bombs",
+          "Recursive Cluster",
+          "Bomb Blitz"
+        ]
+      },
+      "wiki_url": "https://bloons.fandom.com/wiki/Bomb_Shooter"
+    }
+  ]
+}

--- a/disbot/services/ai_diagnostics_service.py
+++ b/disbot/services/ai_diagnostics_service.py
@@ -1,0 +1,69 @@
+"""Read-only AI diagnostics surface.
+
+Module 2 (AI Cog) reads from here to render ``/ai status``,
+``/ai diagnostics``, and ``/ai providers``. The cog never touches
+:mod:`core.runtime.ai.diagnostics` directly — that boundary keeps
+the dependency direction clean.
+"""
+
+from __future__ import annotations
+
+from core.runtime.ai.contracts import AIDiagnosticsSnapshot, AITask
+from core.runtime.ai.diagnostics import get_default_collector
+from core.runtime.ai.feature_flags import (
+    ai_default_provider,
+    ai_enabled,
+    setup_advisor_provider,
+    task_enabled,
+)
+from core.runtime.ai.routing import resolve
+
+__all__ = [
+    "list_task_routing",
+    "snapshot",
+    "snapshot_for_cog",
+]
+
+
+def snapshot() -> AIDiagnosticsSnapshot:
+    """Return the latest read-only diagnostics snapshot."""
+    return get_default_collector().snapshot()
+
+
+def snapshot_for_cog() -> dict[str, object]:
+    """Snapshot in a shape convenient for the AI Cog's embed builder."""
+    snap = snapshot()
+    return {
+        "enabled": snap.enabled,
+        "default_provider": ai_default_provider(),
+        "setup_advisor_provider": setup_advisor_provider(),
+        "provider_active": snap.provider_active,
+        "degraded": snap.degraded,
+        "last_error_type": snap.last_error_type,
+        "last_fallback_reason": snap.last_fallback_reason,
+        "requests_observed": snap.requests_observed,
+        "failures_observed": snap.failures_observed,
+        "redaction_enabled": snap.redaction_enabled,
+    }
+
+
+def list_task_routing() -> list[dict[str, object]]:
+    """List how each :class:`AITask` is currently routed.
+
+    Cogs use this to render ``/ai routing`` without invoking any
+    provider. Each entry is ``{task, provider, model, timeout,
+    enabled}``.
+    """
+    rows: list[dict[str, object]] = []
+    for task in AITask:
+        target = resolve(task)
+        rows.append(
+            {
+                "task": task.value,
+                "provider": target.provider,
+                "model": target.model,
+                "timeout_seconds": target.timeout_seconds,
+                "enabled": task_enabled(task) and ai_enabled(),
+            },
+        )
+    return rows

--- a/disbot/services/ai_gateway.py
+++ b/disbot/services/ai_gateway.py
@@ -1,0 +1,48 @@
+"""Service-layer shim for the AI gateway.
+
+Cogs and services consume the AI gateway through this module — not
+directly from :mod:`core.runtime.ai.gateway` — so the dependency
+direction stays ``cogs → services → core/runtime``. Anything
+exported here is provider-neutral and safe to import from any cog
+or service.
+"""
+
+from __future__ import annotations
+
+from core.runtime.ai.contracts import (
+    AIDiagnosticsSnapshot,
+    AIRequest,
+    AIRequestContext,
+    AIResponse,
+    AIResponseMode,
+    AIScope,
+    AISuggestion,
+    AISuggestionKind,
+    AITask,
+)
+from core.runtime.ai.gateway import AIGateway, get_default_gateway
+
+__all__ = [
+    "AIDiagnosticsSnapshot",
+    "AIGateway",
+    "AIRequest",
+    "AIRequestContext",
+    "AIResponse",
+    "AIResponseMode",
+    "AIScope",
+    "AISuggestion",
+    "AISuggestionKind",
+    "AITask",
+    "execute",
+    "get_default_gateway",
+]
+
+
+async def execute(request: AIRequest) -> AIResponse:
+    """Run ``request`` through the default gateway.
+
+    Convenience wrapper around ``get_default_gateway().execute(request)``
+    for callers that do not need to construct or replace the gateway
+    instance themselves.
+    """
+    return await get_default_gateway().execute(request)

--- a/disbot/services/btd6_ai_service.py
+++ b/disbot/services/btd6_ai_service.py
@@ -1,0 +1,97 @@
+"""BTD6 AI orchestrator — deterministic-first.
+
+Brings resolver, knowledge, and response-builder together. Module 4
+(BTD6 Cog command MVP) only uses the deterministic path. Module 5
+(optional AI augmentation) is opt-in via :func:`answer_question`'s
+``augment_with_ai`` parameter and ``services.ai_gateway``.
+
+The orchestrator never invents BTD6 facts. Deterministic services
+own canonical names, costs, upgrade-path tier names, round
+contents, and source labels. When AI augmentation is enabled it
+adds explanatory prose only — the deterministic fields stay as-is.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from services.btd6_knowledge_service import (
+    hero_fact,
+    map_fact,
+    mode_fact,
+    round_fact,
+    tower_fact,
+)
+from services.btd6_resolver_service import ResolvedIntent, resolve
+from services.btd6_response_builder import (
+    BTD6Response,
+    for_hero,
+    for_map,
+    for_mode,
+    for_round,
+    for_tower,
+    for_unresolved,
+)
+
+
+def deterministic_answer(intent: ResolvedIntent) -> BTD6Response:
+    """Return the deterministic-only :class:`BTD6Response` for ``intent``.
+
+    The first recognised entity wins (towers → heroes → maps →
+    modes → rounds). If nothing was resolved, returns the
+    "unresolved" response so the cog can surface a helpful hint.
+    """
+    if intent.towers:
+        fact = tower_fact(intent.towers[0].id)
+        if fact is not None:
+            return for_tower(fact)
+    if intent.heroes:
+        hero = hero_fact(intent.heroes[0].id)
+        if hero is not None:
+            return for_hero(hero)
+    if intent.maps:
+        game_map = map_fact(intent.maps[0].id)
+        if game_map is not None:
+            return for_map(game_map)
+    if intent.modes:
+        mode = mode_fact(intent.modes[0].id)
+        if mode is not None:
+            return for_mode(mode)
+    if intent.rounds:
+        fact = round_fact(intent.rounds[0].round_number)
+        if fact is not None:
+            return for_round(fact)
+    return for_unresolved(intent)
+
+
+async def answer_question(
+    text: str,
+    *,
+    augment_with_ai: bool = False,
+) -> BTD6Response:
+    """Resolve free-form ``text`` and return a typed response.
+
+    ``augment_with_ai`` is wired in Module 5. In Module 3/4 it is
+    forced to ``False`` so this service is provably deterministic.
+    """
+    intent = resolve(text)
+    response = deterministic_answer(intent)
+    if augment_with_ai:
+        return await _augment_with_ai(intent, response)
+    return response
+
+
+async def _augment_with_ai(
+    intent: ResolvedIntent,
+    response: BTD6Response,
+) -> BTD6Response:
+    """Stub for Module 5. Returns the deterministic response unchanged.
+
+    Module 5 will replace this with a guarded ``services.ai_gateway``
+    call that adds explanatory prose to ``response.why_it_matters``
+    or appends an AI-sourced ``follow_up``. Deterministic fields
+    (cost, stats, sources, version label) remain unmodified.
+    """
+    # Module 5 hook: keep the contract stable so swapping the body
+    # in does not change ``answer_question``'s call sites.
+    return replace(response)

--- a/disbot/services/btd6_ai_service.py
+++ b/disbot/services/btd6_ai_service.py
@@ -1,20 +1,42 @@
 """BTD6 AI orchestrator — deterministic-first.
 
-Brings resolver, knowledge, and response-builder together. Module 4
-(BTD6 Cog command MVP) only uses the deterministic path. Module 5
-(optional AI augmentation) is opt-in via :func:`answer_question`'s
-``augment_with_ai`` parameter and ``services.ai_gateway``.
+Brings resolver, knowledge, and response-builder together.
 
-The orchestrator never invents BTD6 facts. Deterministic services
-own canonical names, costs, upgrade-path tier names, round
-contents, and source labels. When AI augmentation is enabled it
-adds explanatory prose only — the deterministic fields stay as-is.
+* Module 3+4 use deterministic-only mode.
+* Module 5 (this module) adds optional AI augmentation through
+  ``services.ai_gateway``. AI receives structured deterministic
+  context, NEVER a raw user prompt, and only contributes
+  explanation prose. Deterministic facts (cost, stats, sources,
+  version label) remain owned by deterministic services.
+
+Gate stack (all must be true to call the gateway):
+
+1. Caller passes ``augment_with_ai=True``.
+2. ``BTD6_AI_ENABLED`` env var is truthy.
+3. The AI platform itself is enabled (``AI_ENABLED``) and the
+   ``HELP_ANSWER`` task is allowed.
+
+Any failure mode — gateway disabled, provider unavailable, timeout,
+invalid output, exception — yields the deterministic baseline
+without raising. The orchestrator is provably safe to call from
+the cog regardless of provider state.
 """
 
 from __future__ import annotations
 
+import logging
+import os
 from dataclasses import replace
 
+from core.runtime.ai.contracts import (
+    AIRequest,
+    AIRequestContext,
+    AIResponseMode,
+    AIScope,
+    AITask,
+)
+from core.runtime.ai.feature_flags import task_enabled
+from services import ai_gateway
 from services.btd6_knowledge_service import (
     hero_fact,
     map_fact,
@@ -32,6 +54,46 @@ from services.btd6_response_builder import (
     for_tower,
     for_unresolved,
 )
+
+logger = logging.getLogger("bot.services.btd6_ai_service")
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def btd6_ai_enabled() -> bool:
+    """Return True if BTD6 AI augmentation is enabled in the env.
+
+    The Module 5 implementation gates on a process-level env var.
+    Module 6 of the AI/BTD6 plan adds per-guild gating on top of
+    this once guild settings infrastructure ships.
+    """
+    return os.getenv("BTD6_AI_ENABLED", "").strip().lower() in _TRUTHY
+
+
+_AUGMENT_SYSTEM_PROMPT = (
+    "You are a Bloons Tower Defense 6 assistant. The user has asked a "
+    "question and a deterministic SuperBot service has already produced "
+    "a factually-grounded answer from validated game data. Your job is "
+    "to add a SHORT explanatory paragraph (under 80 words) that helps "
+    "the player understand WHY the deterministic answer is correct or "
+    "what to look out for. Never invent stats, costs, or tier names — "
+    "rely only on the deterministic fields supplied in the payload. "
+    "Reply with strict JSON of the form "
+    '{"explanation": "<your paragraph>"}.'
+)
+
+_AUGMENT_SCHEMA: dict = {
+    "name": "BTD6Augmentation",
+    "schema": {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "explanation": {"type": "string"},
+        },
+        "required": ["explanation"],
+    },
+    "strict": True,
+}
 
 
 def deterministic_answer(intent: ResolvedIntent) -> BTD6Response:
@@ -68,30 +130,99 @@ async def answer_question(
     text: str,
     *,
     augment_with_ai: bool = False,
+    guild_id: int | None = None,
 ) -> BTD6Response:
     """Resolve free-form ``text`` and return a typed response.
 
-    ``augment_with_ai`` is wired in Module 5. In Module 3/4 it is
-    forced to ``False`` so this service is provably deterministic.
+    Augmentation is opt-in AND gated by env: ``BTD6_AI_ENABLED`` and
+    the AI platform's ``HELP_ANSWER`` task flag both have to be on
+    for any provider call to happen. The deterministic baseline is
+    always produced first.
     """
     intent = resolve(text)
     response = deterministic_answer(intent)
-    if augment_with_ai:
-        return await _augment_with_ai(intent, response)
+    if augment_with_ai and btd6_ai_enabled() and task_enabled(AITask.HELP_ANSWER):
+        return await _augment_with_ai(intent, response, guild_id=guild_id)
     return response
+
+
+def _augmentation_payload(
+    intent: ResolvedIntent,
+    response: BTD6Response,
+) -> dict[str, object]:
+    """Structured deterministic context for the LLM.
+
+    The provider never sees raw user prose. It receives the resolved
+    intent (canonical entity ids only) and the deterministic response
+    fields. This guarantees AI output cannot drift outside the
+    grounded set.
+    """
+    return {
+        "query_summary": {
+            "resolved_towers": [t.id for t in intent.towers],
+            "resolved_heroes": [h.id for h in intent.heroes],
+            "resolved_maps": [m.id for m in intent.maps],
+            "resolved_modes": [m.id for m in intent.modes],
+            "resolved_rounds": list(intent.candidate_round_numbers),
+            "resolver_confidence": intent.confidence,
+        },
+        "deterministic_answer": {
+            "title": response.title,
+            "short_answer": response.short_answer,
+            "why_it_matters": response.why_it_matters,
+            "recommended_options": list(response.recommended_options),
+            "common_mistakes": list(response.common_mistakes),
+            "version_sensitivity": response.version_sensitivity,
+            "confidence": response.confidence,
+        },
+    }
 
 
 async def _augment_with_ai(
     intent: ResolvedIntent,
     response: BTD6Response,
+    *,
+    guild_id: int | None,
 ) -> BTD6Response:
-    """Stub for Module 5. Returns the deterministic response unchanged.
+    """Try to add an AI-authored explanation paragraph.
 
-    Module 5 will replace this with a guarded ``services.ai_gateway``
-    call that adds explanatory prose to ``response.why_it_matters``
-    or appends an AI-sourced ``follow_up``. Deterministic fields
-    (cost, stats, sources, version label) remain unmodified.
+    Returns the deterministic ``response`` unchanged on any failure:
+    gateway degraded, invalid JSON, missing ``explanation`` key,
+    empty explanation, or exception. Deterministic fields are never
+    mutated; only ``follow_up`` is appended (if it would otherwise
+    be empty) or replaced with the AI prose.
     """
-    # Module 5 hook: keep the contract stable so swapping the body
-    # in does not change ``answer_question``'s call sites.
-    return replace(response)
+    request = AIRequest(
+        context=AIRequestContext(
+            task=AITask.HELP_ANSWER,
+            scope=AIScope.USER,
+            guild_id=guild_id,
+            source="btd6_ai_service",
+        ),
+        system_prompt=_AUGMENT_SYSTEM_PROMPT,
+        payload=_augmentation_payload(intent, response),
+        mode=AIResponseMode.JSON,
+        response_schema=_AUGMENT_SCHEMA,
+    )
+    try:
+        ai_response = await ai_gateway.execute(request)
+    except Exception:  # noqa: BLE001 — defensive boundary
+        logger.exception("btd6_ai_service: gateway raised; using deterministic")
+        return replace(response)
+
+    if ai_response.degraded or not ai_response.data:
+        return replace(response)
+
+    explanation = ai_response.data.get("explanation") if ai_response.data else None
+    if not isinstance(explanation, str) or not explanation.strip():
+        return replace(response)
+
+    # Compose: append the AI prose into follow_up. The deterministic
+    # follow_up (if any) wins over AI prose to preserve operator-
+    # authored navigation hints.
+    new_follow_up = response.follow_up if response.follow_up else explanation.strip()
+    if response.follow_up:
+        # Append AI prose after the deterministic hint so callers see both.
+        new_follow_up = f"{response.follow_up}\n\n{explanation.strip()}"
+
+    return replace(response, follow_up=new_follow_up)

--- a/disbot/services/btd6_data_service.py
+++ b/disbot/services/btd6_data_service.py
@@ -1,0 +1,439 @@
+"""BTD6 deterministic data loader and query API.
+
+Loads representative game-data fixtures from ``disbot/data/btd6/``
+and exposes typed read accessors. The service is the source of
+truth for every deterministic BTD6 fact (towers, heroes, maps,
+modes, rounds). Higher layers (resolver, knowledge, response
+builder) consume this module — they do not parse JSON themselves.
+
+Boundary: loading is synchronous, lazy, and cached. The first call
+to any accessor runs validation; subsequent calls return cached
+results. Tests can call :func:`reset_cache` to force a reload.
+
+Validation guarantees:
+
+* Each fixture carries ``data_version``, ``game_version``, ``source``.
+* Canonical names are unique within a category.
+* Alias lists are deduplicated; no alias collides with another
+  canonical name OR another alias within the same category.
+* Required fields per entry kind are present (see ``_VALIDATORS``).
+* Cross-category alias collisions raise ``BTD6DataValidationError``
+  with the colliding entries listed.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+DATA_ROOT = Path(__file__).resolve().parents[1] / "data" / "btd6"
+
+
+class BTD6DataValidationError(ValueError):
+    """Raised when a fixture file fails validation."""
+
+
+# ---------------------------------------------------------------------------
+# Typed view of one fixture entry
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TowerEntry:
+    id: str
+    canonical: str
+    aliases: tuple[str, ...]
+    category: str
+    base_cost: int
+    description: str
+    upgrade_paths: dict[str, tuple[str, ...]]
+    wiki_url: str
+
+
+@dataclass(frozen=True)
+class HeroAbility:
+    level: int
+    name: str
+    summary: str
+
+
+@dataclass(frozen=True)
+class HeroEntry:
+    id: str
+    canonical: str
+    aliases: tuple[str, ...]
+    base_cost: int
+    description: str
+    abilities: tuple[HeroAbility, ...]
+    wiki_url: str
+
+
+@dataclass(frozen=True)
+class MapEntry:
+    id: str
+    canonical: str
+    aliases: tuple[str, ...]
+    difficulty: str
+    description: str
+    lines_of_sight_notes: str
+    wiki_url: str
+
+
+@dataclass(frozen=True)
+class ModeEntry:
+    id: str
+    canonical: str
+    aliases: tuple[str, ...]
+    starting_cash: int
+    starting_lives: int
+    description: str
+    restrictions: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class RoundEntry:
+    round_number: int
+    summary: str
+    danger: str
+    common_threats: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class BTD6DataSet:
+    data_version: str
+    game_version: str
+    sources: dict[str, str] = field(default_factory=dict)
+    towers: tuple[TowerEntry, ...] = ()
+    heroes: tuple[HeroEntry, ...] = ()
+    maps: tuple[MapEntry, ...] = ()
+    modes: tuple[ModeEntry, ...] = ()
+    rounds: tuple[RoundEntry, ...] = ()
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+
+
+_REQUIRED_TOP_LEVEL = ("data_version", "game_version", "source")
+_REQUIRED_TOWER_FIELDS = (
+    "id",
+    "canonical",
+    "aliases",
+    "category",
+    "base_cost",
+    "description",
+    "upgrade_paths",
+    "wiki_url",
+)
+_REQUIRED_HERO_FIELDS = (
+    "id",
+    "canonical",
+    "aliases",
+    "base_cost",
+    "description",
+    "abilities",
+    "wiki_url",
+)
+_REQUIRED_MAP_FIELDS = (
+    "id",
+    "canonical",
+    "aliases",
+    "difficulty",
+    "description",
+    "lines_of_sight_notes",
+    "wiki_url",
+)
+_REQUIRED_MODE_FIELDS = (
+    "id",
+    "canonical",
+    "aliases",
+    "starting_cash",
+    "starting_lives",
+    "description",
+    "restrictions",
+)
+_REQUIRED_ROUND_FIELDS = ("round", "summary", "danger", "common_threats")
+_REQUIRED_HERO_ABILITY_FIELDS = ("level", "name", "summary")
+
+
+def _require_keys(entry: dict[str, Any], keys: tuple[str, ...], where: str) -> None:
+    missing = [k for k in keys if k not in entry]
+    if missing:
+        raise BTD6DataValidationError(
+            f"{where}: missing required fields {missing!r}",
+        )
+
+
+def _check_unique(items: list[str], where: str) -> None:
+    seen: set[str] = set()
+    dupes: set[str] = set()
+    for item in items:
+        if item in seen:
+            dupes.add(item)
+        seen.add(item)
+    if dupes:
+        raise BTD6DataValidationError(
+            f"{where}: duplicate values {sorted(dupes)!r}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Parsers — one per fixture
+# ---------------------------------------------------------------------------
+
+
+def _normalise_alias(value: str) -> str:
+    return value.strip().lower()
+
+
+def _parse_tower(raw: dict[str, Any]) -> TowerEntry:
+    _require_keys(raw, _REQUIRED_TOWER_FIELDS, where=f"tower {raw.get('id')!r}")
+    upgrade_paths_raw = raw["upgrade_paths"]
+    if not isinstance(upgrade_paths_raw, dict):
+        raise BTD6DataValidationError(
+            f"tower {raw['id']!r}: upgrade_paths must be a dict",
+        )
+    upgrade_paths: dict[str, tuple[str, ...]] = {}
+    for path_key, tiers in upgrade_paths_raw.items():
+        if not isinstance(tiers, list):
+            raise BTD6DataValidationError(
+                f"tower {raw['id']!r}: upgrade_paths.{path_key} must be a list",
+            )
+        upgrade_paths[path_key] = tuple(str(t) for t in tiers)
+    aliases = tuple(_normalise_alias(a) for a in raw["aliases"])
+    return TowerEntry(
+        id=str(raw["id"]),
+        canonical=str(raw["canonical"]),
+        aliases=aliases,
+        category=str(raw["category"]),
+        base_cost=int(raw["base_cost"]),
+        description=str(raw["description"]),
+        upgrade_paths=upgrade_paths,
+        wiki_url=str(raw["wiki_url"]),
+    )
+
+
+def _parse_hero(raw: dict[str, Any]) -> HeroEntry:
+    _require_keys(raw, _REQUIRED_HERO_FIELDS, where=f"hero {raw.get('id')!r}")
+    abilities_raw = raw["abilities"]
+    if not isinstance(abilities_raw, list):
+        raise BTD6DataValidationError(
+            f"hero {raw['id']!r}: abilities must be a list",
+        )
+    abilities: list[HeroAbility] = []
+    for ability in abilities_raw:
+        _require_keys(
+            ability,
+            _REQUIRED_HERO_ABILITY_FIELDS,
+            where=f"hero {raw['id']!r} ability",
+        )
+        abilities.append(
+            HeroAbility(
+                level=int(ability["level"]),
+                name=str(ability["name"]),
+                summary=str(ability["summary"]),
+            ),
+        )
+    return HeroEntry(
+        id=str(raw["id"]),
+        canonical=str(raw["canonical"]),
+        aliases=tuple(_normalise_alias(a) for a in raw["aliases"]),
+        base_cost=int(raw["base_cost"]),
+        description=str(raw["description"]),
+        abilities=tuple(abilities),
+        wiki_url=str(raw["wiki_url"]),
+    )
+
+
+def _parse_map(raw: dict[str, Any]) -> MapEntry:
+    _require_keys(raw, _REQUIRED_MAP_FIELDS, where=f"map {raw.get('id')!r}")
+    return MapEntry(
+        id=str(raw["id"]),
+        canonical=str(raw["canonical"]),
+        aliases=tuple(_normalise_alias(a) for a in raw["aliases"]),
+        difficulty=str(raw["difficulty"]),
+        description=str(raw["description"]),
+        lines_of_sight_notes=str(raw["lines_of_sight_notes"]),
+        wiki_url=str(raw["wiki_url"]),
+    )
+
+
+def _parse_mode(raw: dict[str, Any]) -> ModeEntry:
+    _require_keys(raw, _REQUIRED_MODE_FIELDS, where=f"mode {raw.get('id')!r}")
+    return ModeEntry(
+        id=str(raw["id"]),
+        canonical=str(raw["canonical"]),
+        aliases=tuple(_normalise_alias(a) for a in raw["aliases"]),
+        starting_cash=int(raw["starting_cash"]),
+        starting_lives=int(raw["starting_lives"]),
+        description=str(raw["description"]),
+        restrictions=tuple(str(r) for r in raw["restrictions"]),
+    )
+
+
+def _parse_round(raw: dict[str, Any]) -> RoundEntry:
+    _require_keys(raw, _REQUIRED_ROUND_FIELDS, where=f"round {raw.get('round')!r}")
+    return RoundEntry(
+        round_number=int(raw["round"]),
+        summary=str(raw["summary"]),
+        danger=str(raw["danger"]),
+        common_threats=tuple(str(t) for t in raw["common_threats"]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+
+def _load_file(name: str) -> dict[str, Any]:
+    path = DATA_ROOT / name
+    if not path.exists():
+        raise BTD6DataValidationError(
+            f"missing fixture file: {path}",
+        )
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    _require_keys(raw, _REQUIRED_TOP_LEVEL, where=str(path))
+    return raw
+
+
+def _load_dataset() -> BTD6DataSet:
+    towers_raw = _load_file("towers.json")
+    heroes_raw = _load_file("heroes.json")
+    maps_raw = _load_file("maps.json")
+    modes_raw = _load_file("modes.json")
+    rounds_raw = _load_file("rounds.json")
+
+    towers = tuple(_parse_tower(t) for t in towers_raw.get("towers", []))
+    heroes = tuple(_parse_hero(h) for h in heroes_raw.get("heroes", []))
+    maps = tuple(_parse_map(m) for m in maps_raw.get("maps", []))
+    modes = tuple(_parse_mode(m) for m in modes_raw.get("modes", []))
+    rounds = tuple(_parse_round(r) for r in rounds_raw.get("rounds", []))
+
+    # Per-category canonical uniqueness.
+    _check_unique([t.id for t in towers], where="towers.id")
+    _check_unique([t.canonical for t in towers], where="towers.canonical")
+    _check_unique([h.id for h in heroes], where="heroes.id")
+    _check_unique([h.canonical for h in heroes], where="heroes.canonical")
+    _check_unique([m.id for m in maps], where="maps.id")
+    _check_unique([m.canonical for m in maps], where="maps.canonical")
+    _check_unique([m.id for m in modes], where="modes.id")
+    _check_unique([m.canonical for m in modes], where="modes.canonical")
+    _check_unique([r.round_number for r in rounds], where="rounds.round")
+
+    # Alias collision check across every category — the resolver depends
+    # on aliases being globally unique.
+    alias_owners: dict[str, str] = {}
+    for tower in towers:
+        for alias in (*tower.aliases, _normalise_alias(tower.canonical)):
+            owner = f"tower:{tower.id}"
+            if alias in alias_owners and alias_owners[alias] != owner:
+                raise BTD6DataValidationError(
+                    f"alias collision: {alias!r} owned by both "
+                    f"{alias_owners[alias]} and {owner}",
+                )
+            alias_owners[alias] = owner
+    for hero in heroes:
+        for alias in (*hero.aliases, _normalise_alias(hero.canonical)):
+            owner = f"hero:{hero.id}"
+            if alias in alias_owners and alias_owners[alias] != owner:
+                raise BTD6DataValidationError(
+                    f"alias collision: {alias!r} owned by both "
+                    f"{alias_owners[alias]} and {owner}",
+                )
+            alias_owners[alias] = owner
+    for game_map in maps:
+        for alias in (*game_map.aliases, _normalise_alias(game_map.canonical)):
+            owner = f"map:{game_map.id}"
+            if alias in alias_owners and alias_owners[alias] != owner:
+                raise BTD6DataValidationError(
+                    f"alias collision: {alias!r} owned by both "
+                    f"{alias_owners[alias]} and {owner}",
+                )
+            alias_owners[alias] = owner
+    for mode in modes:
+        for alias in (*mode.aliases, _normalise_alias(mode.canonical)):
+            owner = f"mode:{mode.id}"
+            if alias in alias_owners and alias_owners[alias] != owner:
+                raise BTD6DataValidationError(
+                    f"alias collision: {alias!r} owned by both "
+                    f"{alias_owners[alias]} and {owner}",
+                )
+            alias_owners[alias] = owner
+
+    return BTD6DataSet(
+        data_version=str(towers_raw["data_version"]),
+        game_version=str(towers_raw["game_version"]),
+        sources={
+            "towers": str(towers_raw["source"]),
+            "heroes": str(heroes_raw["source"]),
+            "maps": str(maps_raw["source"]),
+            "modes": str(modes_raw["source"]),
+            "rounds": str(rounds_raw["source"]),
+        },
+        towers=towers,
+        heroes=heroes,
+        maps=maps,
+        modes=modes,
+        rounds=rounds,
+    )
+
+
+_DATASET: BTD6DataSet | None = None
+
+
+def get_dataset() -> BTD6DataSet:
+    """Return the validated dataset (cached after first call)."""
+    global _DATASET
+    if _DATASET is None:
+        _DATASET = _load_dataset()
+    return _DATASET
+
+
+def reset_cache() -> None:
+    """Test seam — drop the cached dataset so a fresh load runs."""
+    global _DATASET
+    _DATASET = None
+
+
+# ---------------------------------------------------------------------------
+# Convenience accessors
+# ---------------------------------------------------------------------------
+
+
+def get_tower(tower_id: str) -> TowerEntry | None:
+    for tower in get_dataset().towers:
+        if tower.id == tower_id:
+            return tower
+    return None
+
+
+def get_hero(hero_id: str) -> HeroEntry | None:
+    for hero in get_dataset().heroes:
+        if hero.id == hero_id:
+            return hero
+    return None
+
+
+def get_map(map_id: str) -> MapEntry | None:
+    for game_map in get_dataset().maps:
+        if game_map.id == map_id:
+            return game_map
+    return None
+
+
+def get_mode(mode_id: str) -> ModeEntry | None:
+    for mode in get_dataset().modes:
+        if mode.id == mode_id:
+            return mode
+    return None
+
+
+def get_round(round_number: int) -> RoundEntry | None:
+    for entry in get_dataset().rounds:
+        if entry.round_number == round_number:
+            return entry
+    return None

--- a/disbot/services/btd6_data_service.py
+++ b/disbot/services/btd6_data_service.py
@@ -167,9 +167,9 @@ def _require_keys(entry: dict[str, Any], keys: tuple[str, ...], where: str) -> N
         )
 
 
-def _check_unique(items: list[str], where: str) -> None:
-    seen: set[str] = set()
-    dupes: set[str] = set()
+def _check_unique(items: list, where: str) -> None:
+    seen: set = set()
+    dupes: set = set()
     for item in items:
         if item in seen:
             dupes.add(item)

--- a/disbot/services/btd6_knowledge_service.py
+++ b/disbot/services/btd6_knowledge_service.py
@@ -1,0 +1,108 @@
+"""BTD6 deterministic knowledge queries.
+
+Thin query API over :mod:`services.btd6_data_service`. Answers the
+kind of question a BTD6 cog command needs to render an embed:
+"what does this tower cost", "what's on this round", "what are the
+restrictions for this mode". All answers come from the validated
+fixture set; nothing is invented.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from services.btd6_data_service import (
+    HeroEntry,
+    MapEntry,
+    ModeEntry,
+    RoundEntry,
+    TowerEntry,
+    get_dataset,
+    get_hero,
+    get_map,
+    get_mode,
+    get_round,
+    get_tower,
+)
+
+
+@dataclass(frozen=True)
+class TowerFact:
+    """A query result for a tower lookup."""
+
+    tower: TowerEntry
+    base_cost: int
+    upgrade_paths: dict[str, tuple[str, ...]]
+
+
+@dataclass(frozen=True)
+class RoundFact:
+    """A query result for a round lookup."""
+
+    round_number: int
+    summary: str
+    danger: str
+    common_threats: tuple[str, ...]
+
+
+def tower_fact(tower_id: str) -> TowerFact | None:
+    tower = get_tower(tower_id)
+    if tower is None:
+        return None
+    return TowerFact(
+        tower=tower,
+        base_cost=tower.base_cost,
+        upgrade_paths=dict(tower.upgrade_paths),
+    )
+
+
+def hero_fact(hero_id: str) -> HeroEntry | None:
+    return get_hero(hero_id)
+
+
+def map_fact(map_id: str) -> MapEntry | None:
+    return get_map(map_id)
+
+
+def mode_fact(mode_id: str) -> ModeEntry | None:
+    return get_mode(mode_id)
+
+
+def round_fact(round_number: int) -> RoundFact | None:
+    entry = get_round(round_number)
+    if entry is None:
+        return None
+    return RoundFact(
+        round_number=entry.round_number,
+        summary=entry.summary,
+        danger=entry.danger,
+        common_threats=entry.common_threats,
+    )
+
+
+def list_towers() -> tuple[TowerEntry, ...]:
+    return get_dataset().towers
+
+
+def list_heroes() -> tuple[HeroEntry, ...]:
+    return get_dataset().heroes
+
+
+def list_maps() -> tuple[MapEntry, ...]:
+    return get_dataset().maps
+
+
+def list_modes() -> tuple[ModeEntry, ...]:
+    return get_dataset().modes
+
+
+def list_rounds() -> tuple[RoundEntry, ...]:
+    return get_dataset().rounds
+
+
+def data_version() -> str:
+    return get_dataset().data_version
+
+
+def game_version() -> str:
+    return get_dataset().game_version

--- a/disbot/services/btd6_resolver_service.py
+++ b/disbot/services/btd6_resolver_service.py
@@ -1,0 +1,164 @@
+"""Deterministic NL → structured intent resolver for BTD6.
+
+Takes a free-form message and returns a typed :class:`ResolvedIntent`
+that downstream services consume. No AI involved: aliases come from
+the validated dataset in :mod:`services.btd6_data_service`.
+
+The resolver is intentionally narrow:
+
+* It recognises tower / hero / map / mode references by canonical
+  name or alias (case-insensitive, word-boundary aware).
+* It extracts an integer round number when the text mentions
+  ``round <N>`` or ``r<N>``.
+* It computes a confidence score in ``[0.0, 1.0]`` based on how
+  many entities matched and how unambiguous the match was.
+* It surfaces ambiguous matches when two different aliases share a
+  prefix (e.g. operator typed ``"bom"`` matching both bomb and a
+  hypothetical boomerang abbreviation).
+
+Higher layers decide what to do with the intent — the resolver is
+read-only and never calls a provider.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from services.btd6_data_service import (
+    HeroEntry,
+    MapEntry,
+    ModeEntry,
+    RoundEntry,
+    TowerEntry,
+    get_dataset,
+    get_round,
+)
+
+_ROUND_PATTERNS = (
+    re.compile(r"\bround\s+(\d{1,3})\b", re.IGNORECASE),
+    re.compile(r"\br\s*(\d{1,3})\b", re.IGNORECASE),
+)
+
+
+@dataclass(frozen=True)
+class ResolvedIntent:
+    """Structured view of what the user appears to be asking about."""
+
+    raw_text: str
+    confidence: float
+    towers: tuple[TowerEntry, ...] = ()
+    heroes: tuple[HeroEntry, ...] = ()
+    maps: tuple[MapEntry, ...] = ()
+    modes: tuple[ModeEntry, ...] = ()
+    rounds: tuple[RoundEntry, ...] = ()
+    ambiguous_terms: tuple[str, ...] = ()
+    candidate_round_numbers: tuple[int, ...] = field(default_factory=tuple)
+
+
+def _word_iter(text: str) -> list[str]:
+    """Lowercase tokens for whole-word matching, with punctuation stripped."""
+    return re.findall(r"[a-z0-9_]+", text.lower())
+
+
+def _match_terms(
+    text: str,
+    name_aliases: dict[str, str],
+) -> tuple[set[str], list[str]]:
+    """Return matching ids and any ambiguous-prefix terms.
+
+    ``name_aliases`` maps each lowercase alias / canonical token to
+    its owner id. Multi-word aliases are matched as a substring;
+    single-word aliases are matched on word boundaries.
+    """
+    text_lower = text.lower()
+    tokens = set(_word_iter(text))
+    found: set[str] = set()
+    for alias, owner_id in name_aliases.items():
+        if " " in alias:
+            # Multi-word alias: substring search.
+            if alias in text_lower:
+                found.add(owner_id)
+        else:
+            if alias in tokens:
+                found.add(owner_id)
+    return found, []
+
+
+def _build_alias_map() -> tuple[
+    dict[str, str],
+    dict[str, str],
+    dict[str, str],
+    dict[str, str],
+]:
+    dataset = get_dataset()
+    towers = {}
+    for tower in dataset.towers:
+        towers[tower.canonical.lower()] = tower.id
+        for alias in tower.aliases:
+            towers[alias.lower()] = tower.id
+    heroes = {}
+    for hero in dataset.heroes:
+        heroes[hero.canonical.lower()] = hero.id
+        for alias in hero.aliases:
+            heroes[alias.lower()] = hero.id
+    maps = {}
+    for game_map in dataset.maps:
+        maps[game_map.canonical.lower()] = game_map.id
+        for alias in game_map.aliases:
+            maps[alias.lower()] = game_map.id
+    modes = {}
+    for mode in dataset.modes:
+        modes[mode.canonical.lower()] = mode.id
+        for alias in mode.aliases:
+            modes[alias.lower()] = mode.id
+    return towers, heroes, maps, modes
+
+
+def resolve(text: str) -> ResolvedIntent:
+    """Resolve free-form ``text`` into a :class:`ResolvedIntent`."""
+    if not text or not text.strip():
+        return ResolvedIntent(raw_text=text, confidence=0.0)
+
+    tower_map, hero_map, map_map, mode_map = _build_alias_map()
+    dataset = get_dataset()
+
+    tower_ids, _ = _match_terms(text, tower_map)
+    hero_ids, _ = _match_terms(text, hero_map)
+    map_ids, _ = _match_terms(text, map_map)
+    mode_ids, _ = _match_terms(text, mode_map)
+
+    candidate_rounds: list[int] = []
+    rounds: list[RoundEntry] = []
+    for pattern in _ROUND_PATTERNS:
+        for match in pattern.finditer(text):
+            try:
+                value = int(match.group(1))
+            except ValueError:
+                continue
+            if 1 <= value <= 200 and value not in candidate_rounds:
+                candidate_rounds.append(value)
+                entry = get_round(value)
+                if entry is not None:
+                    rounds.append(entry)
+
+    matched_count = (
+        len(tower_ids)
+        + len(hero_ids)
+        + len(map_ids)
+        + len(mode_ids)
+        + len(candidate_rounds)
+    )
+    # Confidence model: linear scale up to 3 matched entities, capped at 1.0.
+    confidence = min(1.0, matched_count / 3.0) if matched_count else 0.0
+
+    return ResolvedIntent(
+        raw_text=text,
+        confidence=confidence,
+        towers=tuple(t for t in dataset.towers if t.id in tower_ids),
+        heroes=tuple(h for h in dataset.heroes if h.id in hero_ids),
+        maps=tuple(m for m in dataset.maps if m.id in map_ids),
+        modes=tuple(m for m in dataset.modes if m.id in mode_ids),
+        rounds=tuple(rounds),
+        candidate_round_numbers=tuple(candidate_rounds),
+    )

--- a/disbot/services/btd6_response_builder.py
+++ b/disbot/services/btd6_response_builder.py
@@ -1,0 +1,152 @@
+"""BTD6 response builder.
+
+Renders deterministic knowledge into a stable domain object the
+BTD6 Cog (Module 4) turns into a Discord embed. Keeping the shape
+in a single place lets later modules (AI augmentation in Module 5)
+add explanatory text without changing the deterministic fields.
+
+The shape mirrors the user's plan: short answer, why it matters,
+recommended options, common mistakes, version sensitivity,
+confidence, sources, follow-up. Fields not relevant to a given
+query stay empty rather than carrying placeholder prose.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from services.btd6_data_service import HeroEntry, MapEntry, ModeEntry
+from services.btd6_knowledge_service import (
+    RoundFact,
+    TowerFact,
+    data_version,
+    game_version,
+)
+from services.btd6_resolver_service import ResolvedIntent
+
+
+@dataclass(frozen=True)
+class BTD6Response:
+    """Stable BTD6 response shape consumed by the Cog renderer."""
+
+    title: str
+    short_answer: str
+    why_it_matters: str = ""
+    recommended_options: tuple[str, ...] = ()
+    common_mistakes: tuple[str, ...] = ()
+    version_sensitivity: str = ""
+    confidence: str = "medium"
+    sources: tuple[str, ...] = ()
+    follow_up: str = ""
+    fields: tuple[tuple[str, str], tuple[str, str]] | tuple = field(
+        default_factory=tuple,
+    )
+
+
+def _source_label() -> str:
+    return f"BTD6 data v{data_version()} (game v{game_version()})"
+
+
+def for_tower(fact: TowerFact) -> BTD6Response:
+    tower = fact.tower
+    recommended: list[str] = []
+    for path, tiers in tower.upgrade_paths.items():
+        recommended.append(
+            f"{path}: "
+            + " → ".join(tiers[:3])
+            + (f" (… {len(tiers) - 3} more)" if len(tiers) > 3 else ""),
+        )
+    return BTD6Response(
+        title=f"{tower.canonical} — overview",
+        short_answer=tower.description,
+        why_it_matters=(f"Base cost: {fact.base_cost}. Category: {tower.category}."),
+        recommended_options=tuple(recommended),
+        common_mistakes=(
+            "Buying high-tier upgrades on the wrong path can stall economy.",
+        ),
+        version_sensitivity=(
+            "Tower stats and crosspath interactions can change patch-to-patch; "
+            "always confirm against the latest patch notes for competitive play."
+        ),
+        confidence="high",
+        sources=(tower.wiki_url, _source_label()),
+        follow_up="Ask about a specific upgrade tier with `!btd6 tower <name>`.",
+    )
+
+
+def for_hero(hero: HeroEntry) -> BTD6Response:
+    abilities = tuple(
+        f"L{ability.level}: {ability.name} — {ability.summary}"
+        for ability in hero.abilities
+    )
+    return BTD6Response(
+        title=f"{hero.canonical} — overview",
+        short_answer=hero.description,
+        why_it_matters=f"Base cost: {hero.base_cost}.",
+        recommended_options=abilities,
+        version_sensitivity=(
+            "Hero balance changes are common; check patch notes for buffs/nerfs."
+        ),
+        confidence="medium",
+        sources=(hero.wiki_url, _source_label()),
+        follow_up="Try `!btd6 round <N>` to see what waves the hero faces.",
+    )
+
+
+def for_map(game_map: MapEntry) -> BTD6Response:
+    return BTD6Response(
+        title=f"{game_map.canonical} ({game_map.difficulty})",
+        short_answer=game_map.description,
+        why_it_matters=game_map.lines_of_sight_notes,
+        sources=(game_map.wiki_url, _source_label()),
+        confidence="high",
+        follow_up="Pair with `!btd6 mode <name>` for mode-specific advice.",
+    )
+
+
+def for_mode(mode: ModeEntry) -> BTD6Response:
+    return BTD6Response(
+        title=f"{mode.canonical} mode",
+        short_answer=mode.description,
+        why_it_matters=(
+            f"Starting cash: {mode.starting_cash}. "
+            f"Starting lives: {mode.starting_lives}."
+        ),
+        recommended_options=mode.restrictions,
+        confidence="high",
+        sources=(_source_label(),),
+    )
+
+
+def for_round(fact: RoundFact) -> BTD6Response:
+    return BTD6Response(
+        title=f"Round {fact.round_number} — danger: {fact.danger}",
+        short_answer=fact.summary,
+        why_it_matters=(
+            "Threats this round: "
+            + (", ".join(fact.common_threats) if fact.common_threats else "—")
+        ),
+        version_sensitivity=(
+            "Round composition is stable but can shift slightly during major patches."
+        ),
+        confidence="high",
+        sources=(_source_label(),),
+        follow_up="Use `!btd6 ask` for strategy advice on a specific round.",
+    )
+
+
+def for_unresolved(intent: ResolvedIntent) -> BTD6Response:
+    return BTD6Response(
+        title="No BTD6 entities recognised",
+        short_answer=(
+            "I couldn't find a tower, hero, map, mode, or round in your message."
+        ),
+        why_it_matters=(
+            f"Confidence: {intent.confidence:.2f}. Try mentioning a tower "
+            "by name (e.g. ``Dart Monkey``), a map, or a round number "
+            "like ``round 63``."
+        ),
+        confidence="low",
+        sources=(_source_label(),),
+        follow_up=("Use `!btd6 status` to confirm the BTD6 assistant is enabled."),
+    )

--- a/disbot/services/metrics.py
+++ b/disbot/services/metrics.py
@@ -391,3 +391,28 @@ process_memory_rss_bytes = Gauge(
     "process_memory_rss_bytes",
     "Resident set size of the bot process in bytes, sampled periodically.",
 )
+
+# ---------------------------------------------------------------------------
+# AI gateway — core/runtime/ai/gateway.py
+# Every request that reaches the gateway lands one observation on the
+# histogram (success and failure alike) and increments the counter with
+# the outcome label.  ``outcome`` values: success | timeout | error |
+# unavailable | deterministic.  Sustained non-zero ``timeout``/``error``
+# rates indicate provider-side instability; sustained ``deterministic``
+# is expected when ``AI_DEFAULT_PROVIDER=deterministic`` (the safe
+# default for CI and operators who have not opted in).
+# ---------------------------------------------------------------------------
+
+ai_request_seconds = Histogram(
+    "ai_request_seconds",
+    "Duration of AI provider calls dispatched through the gateway "
+    "(measured around asyncio.wait_for, includes timeout cases).",
+    ["task", "provider"],
+    buckets=(0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 20.0, 60.0),
+)
+
+ai_request_total = Counter(
+    "ai_request_total",
+    "AI gateway requests by task and outcome.",
+    ["task", "outcome"],
+)

--- a/disbot/services/setup_ai_advisor.py
+++ b/disbot/services/setup_ai_advisor.py
@@ -32,15 +32,39 @@ The OpenAI implementation uses strict JSON Schema response format
 then re-validate the parsed objects against our local schema
 catalogue. Both layers run; CI does not have an OPENAI_API_KEY so
 the path is exercised through mock objects.
+
+Gateway migration (Module 1, AI/BTD6 plan)
+------------------------------------------
+The OpenAI provider call no longer happens in this module. It is
+routed through :class:`core.runtime.ai.gateway.AIGateway` so:
+
+* The ``openai`` SDK import lives only in
+  :mod:`core.runtime.ai.providers.openai_provider`.
+* Redaction, timeout, metrics, and failure handling are uniform
+  across every AI consumer.
+* The advisor's public API is unchanged: ``OpenAISetupAdvisor``
+  still accepts an injected ``client`` for tests, and
+  ``build_advisor`` still resolves the provider via
+  ``SETUP_ADVISOR_PROVIDER``. When a test injects a ``client``, the
+  advisor wraps it in an ``OpenAIProvider`` and feeds the gateway,
+  so the legacy injection contract continues to work end-to-end.
 """
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
+from core.runtime.ai.contracts import (
+    AIRequest,
+    AIRequestContext,
+    AIResponseMode,
+    AIScope,
+    AITask,
+)
+from core.runtime.ai.providers import OpenAIProvider
+from services import ai_gateway as _ai_gateway_service
 from services.guild_snapshot import GuildSnapshot
 from services.setup_plan import (
     CONFIDENCES,
@@ -129,9 +153,13 @@ _SYSTEM_PROMPT = (
 class OpenAISetupAdvisor:
     """OpenAI structured-output adapter.
 
-    Construction is lazy: the SDK + API key are resolved on first
-    use so a session that never invokes the advisor never pulls in
-    the dependency.
+    The adapter is a thin wrapper around the AI gateway. The
+    ``client`` constructor argument is preserved for test injection:
+    when set, the advisor builds a one-off :class:`OpenAIProvider`
+    bound to the injected client and feeds it to the gateway via
+    ``provider_override`` — every other test path stays identical.
+    Without an injected client, the advisor uses the gateway's
+    default OpenAI provider.
     """
 
     def __init__(
@@ -144,69 +172,68 @@ class OpenAISetupAdvisor:
         self._client = client
         self._model = model or os.getenv("SETUP_ADVISOR_OPENAI_MODEL", "gpt-4o-mini")
         self._api_key = api_key
-
-    def _ensure_client(self) -> Any:
-        if self._client is not None:
-            return self._client
-        try:
-            from openai import AsyncOpenAI
-        except Exception as exc:  # noqa: BLE001 — import boundary
-            raise RuntimeError(
-                "openai package not installed; install ``openai>=1.40.0`` or "
-                "set SETUP_ADVISOR_PROVIDER=deterministic.",
-            ) from exc
-        api_key = self._api_key or os.getenv("OPENAI_API_KEY", "")
-        if not api_key:
+        if client is None and not (api_key or os.getenv("OPENAI_API_KEY", "")):
+            # Preserve the legacy constructor contract: build_advisor()
+            # only reaches this branch when api_key is present, and
+            # tests always inject either ``client`` or ``api_key``.
+            # Raising here keeps backwards compatibility with code that
+            # introspected the failure mode.
             raise RuntimeError(
                 "OPENAI_API_KEY is not set; cannot build OpenAISetupAdvisor.",
             )
-        self._client = AsyncOpenAI(api_key=api_key)
-        return self._client
 
     async def suggest(self, snapshot: GuildSnapshot) -> SetupPlanDraft:
-        client = self._ensure_client()
-        user_payload = json.dumps(_snapshot_to_prompt(snapshot), default=str)
-        try:
-            response = await client.chat.completions.create(
-                model=self._model,
-                messages=[
-                    {"role": "system", "content": _SYSTEM_PROMPT},
-                    {"role": "user", "content": user_payload},
-                ],
-                response_format={
-                    "type": "json_schema",
-                    "json_schema": _RECOMMENDATION_JSON_SCHEMA,
-                },
-            )
-        except Exception as exc:  # noqa: BLE001 — network boundary
-            logger.exception(
-                "OpenAISetupAdvisor.suggest: chat.completions.create failed; "
-                "falling back to empty draft.",
-            )
+        provider_override = None
+        if self._client is not None:
+            provider_override = OpenAIProvider(client=self._client)
+
+        request = AIRequest(
+            context=AIRequestContext(
+                task=AITask.SETUP_SUGGEST,
+                scope=AIScope.ADMIN,
+                guild_id=snapshot.guild_id,
+                source="setup_ai_advisor",
+            ),
+            system_prompt=_SYSTEM_PROMPT,
+            payload=_snapshot_to_prompt(snapshot),
+            mode=AIResponseMode.JSON,
+            response_schema=_RECOMMENDATION_JSON_SCHEMA,
+        )
+
+        gateway = _ai_gateway_service.get_default_gateway()
+        response = await gateway.execute(
+            request,
+            provider_override=provider_override,
+        )
+
+        if response.degraded:
+            reason = response.fallback_reason or "openai: degraded response"
+            if "invalid_json" in reason:
+                return SetupPlanDraft(
+                    recommendations=(),
+                    dropped=(f"openai: invalid JSON ({reason})",),
+                    source=OPENAI,
+                )
+            if "empty response" in reason or "no choices" in reason:
+                return SetupPlanDraft(
+                    recommendations=(),
+                    dropped=("openai: empty response",),
+                    source=OPENAI,
+                )
             return SetupPlanDraft(
                 recommendations=(),
-                dropped=(f"openai: {type(exc).__name__}: {exc}",),
+                dropped=(f"openai: {reason}",),
                 source=OPENAI,
             )
 
-        raw = _extract_response_text(response)
-        if raw is None:
+        if response.data is None:
             return SetupPlanDraft(
                 recommendations=(),
                 dropped=("openai: empty response",),
                 source=OPENAI,
             )
 
-        try:
-            parsed = json.loads(raw)
-        except json.JSONDecodeError as exc:
-            return SetupPlanDraft(
-                recommendations=(),
-                dropped=(f"openai: invalid JSON ({exc})",),
-                source=OPENAI,
-            )
-
-        return _validate_ai_payload(parsed)
+        return _validate_ai_payload(response.data)
 
 
 def _snapshot_to_prompt(snapshot: GuildSnapshot) -> dict[str, Any]:
@@ -238,21 +265,6 @@ def _snapshot_to_prompt(snapshot: GuildSnapshot) -> dict[str, Any]:
         "settings_snapshot": snapshot.settings_snapshot,
         "bindings_snapshot": snapshot.bindings_snapshot,
     }
-
-
-def _extract_response_text(response: Any) -> str | None:
-    """Pull the assistant message text out of an OpenAI ChatCompletion."""
-    choices = getattr(response, "choices", None)
-    if not choices:
-        return None
-    first = choices[0]
-    message = getattr(first, "message", None)
-    if message is None:
-        return None
-    content = getattr(message, "content", None)
-    if not content:
-        return None
-    return content
 
 
 def _validate_ai_payload(parsed: Any) -> SetupPlanDraft:

--- a/disbot/utils/hub_registry.py
+++ b/disbot/utils/hub_registry.py
@@ -98,6 +98,7 @@ HUBS: tuple[HubEntry, ...] = (
         entry_command="!games",
         primary_children=(
             "blackjack",
+            "btd6",
             "deathmatch",
             "rps_tournament",
             "mining",

--- a/disbot/utils/subsystem_registry.py
+++ b/disbot/utils/subsystem_registry.py
@@ -583,6 +583,35 @@ SUBSYSTEMS: dict[str, dict] = {
             "diagnostic.latency.check",
         ],
     },
+    "ai": {
+        "display_name": "AI Platform",
+        "description": (
+            "Read-only AI gateway diagnostics: provider state, feature "
+            "flags, task routing, and request/failure counters. "
+            "Does not own AI provider logic — that lives in "
+            "core/runtime/ai/."
+        ),
+        "emoji": "🤖",
+        "color": ADMIN_COLOR.value,
+        "visibility_tier": "administrator",
+        "visibility_mode": "normal",
+        "category": "admin",
+        "tags": ["ai", "platform", "diagnostics", "providers"],
+        "entry_points": ["ai", "aimenu"],
+        "default_channels": ["staff", "bot-spam"],
+        "related_subsystems": ["diagnostic", "admin"],
+        "dependencies": [],
+        "soft_dependencies": [],
+        "supports_dm": False,
+        "has_cleanup_rules": False,
+        "ui_priority": 88,
+        "capabilities": [
+            "ai.platform.view",
+            "ai.diagnostics.view",
+            "ai.provider.view",
+            "ai.routing.view",
+        ],
+    },
     "settings": {
         "display_name": "Settings Manager",
         "description": (

--- a/disbot/utils/subsystem_registry.py
+++ b/disbot/utils/subsystem_registry.py
@@ -351,6 +351,36 @@ SUBSYSTEMS: dict[str, dict] = {
             "blackjack.tournament.manage",
         ],
     },
+    "btd6": {
+        "display_name": "BTD6 Assistant",
+        "description": (
+            "Deterministic Bloons Tower Defense 6 assistant — tower/hero/map "
+            "lookups, round threat summaries, and CHIMPS-mode guidance. "
+            "Built on validated fixtures; consumes the AI gateway only when "
+            "explicitly enabled (Module 5)."
+        ),
+        "emoji": "🐵",
+        "color": GAME_COLOR.value,
+        "visibility_tier": "user",
+        "visibility_mode": "normal",
+        "category": "games",
+        "tags": ["games", "btd6", "bloons", "tower defense"],
+        "entry_points": ["btd6", "btd6menu"],
+        "default_channels": ["games", "bot-commands"],
+        "related_subsystems": ["ai"],
+        "dependencies": [],
+        "soft_dependencies": [],
+        "supports_dm": False,
+        "has_cleanup_rules": False,
+        "ui_priority": 35,
+        "parent_hub": "games",
+        "hub_group": "activities",
+        "capabilities": [
+            "btd6.query.ask",
+            "btd6.strategy.view",
+            "btd6.diagnostics.view",
+        ],
+    },
     "deathmatch": {
         "display_name": "Deathmatch",
         "description": "1v1 duel battles",

--- a/disbot/views/ai/__init__.py
+++ b/disbot/views/ai/__init__.py
@@ -1,0 +1,7 @@
+"""Views for the AI Platform cog (Module 2 of the AI/BTD6 plan)."""
+
+from __future__ import annotations
+
+from views.ai.panel import AIPanelView, build_ai_panel_embed
+
+__all__ = ["AIPanelView", "build_ai_panel_embed"]

--- a/disbot/views/ai/panel.py
+++ b/disbot/views/ai/panel.py
@@ -1,0 +1,170 @@
+"""AI Platform persistent panel — Module 2 of the AI/BTD6 plan.
+
+Pattern B placement per ``docs/architecture.md`` §"PersistentView
+placement": the view lives in ``views/ai/`` so the cog file stays
+small. Importing this module triggers the ``@register`` decorator
+on :class:`AIPanelView` so the persistent-view registry sees the
+``ai`` subsystem before ``on_ready`` runs ``restore_anchors``.
+
+Custom_ids use the ``ai:<action>`` prefix. The cog wires a single
+interaction-router handler for prefix ``ai`` that dispatches to
+embed-building helpers in :mod:`services.ai_diagnostics_service` —
+no provider logic ever runs from a button.
+"""
+
+from __future__ import annotations
+
+import discord
+
+from core.runtime.persistent_views import PersistentView, register
+from services import ai_diagnostics_service
+
+_PANEL_COLOR = discord.Color.blurple()
+
+
+def build_ai_panel_embed() -> discord.Embed:
+    """Build the read-only AI Platform overview embed.
+
+    Reads ``ai_diagnostics_service.snapshot_for_cog()`` so the
+    overview reflects the latest counters without invoking any
+    provider.
+    """
+    snap = ai_diagnostics_service.snapshot_for_cog()
+    enabled = snap["enabled"]
+    degraded = snap["degraded"]
+    status_emoji = "✅" if enabled and not degraded else ("⚠️" if degraded else "💤")
+
+    embed = discord.Embed(
+        title=f"{status_emoji} AI Platform",
+        description=(
+            "Read-only diagnostics for the AI gateway. The buttons "
+            "below open the matching subcommands without making a "
+            "provider call."
+        ),
+        color=_PANEL_COLOR,
+    )
+    embed.add_field(name="Enabled", value="yes" if enabled else "no", inline=True)
+    embed.add_field(
+        name="Default provider",
+        value=str(snap["default_provider"]),
+        inline=True,
+    )
+    embed.add_field(
+        name="Setup advisor provider",
+        value=str(snap["setup_advisor_provider"]),
+        inline=True,
+    )
+    embed.add_field(
+        name="Active provider (last call)",
+        value=str(snap["provider_active"]),
+        inline=True,
+    )
+    embed.add_field(
+        name="Requests / failures",
+        value=f"{snap['requests_observed']} / {snap['failures_observed']}",
+        inline=True,
+    )
+    embed.add_field(
+        name="Redaction",
+        value="on" if snap["redaction_enabled"] else "off",
+        inline=True,
+    )
+    if degraded:
+        embed.add_field(
+            name="Last fallback reason",
+            value=str(snap["last_fallback_reason"] or "—"),
+            inline=False,
+        )
+    embed.set_footer(text="!ai status / !ai diagnostics / !ai providers / !ai routing")
+    return embed
+
+
+@register
+class AIPanelView(PersistentView):
+    """Persistent AI Platform panel — administrator-only.
+
+    The panel is intentionally read-only. Every button refreshes one
+    of the existing diagnostic views; no button performs a provider
+    call or any state mutation.
+    """
+
+    SUBSYSTEM = "ai"
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        member = interaction.user
+        if not getattr(member, "guild_permissions", None) or not (
+            member.guild_permissions.administrator  # type: ignore[union-attr]
+        ):
+            await interaction.response.send_message(
+                "❌ You need the Administrator permission to use the AI panel.",
+                ephemeral=True,
+            )
+            return False
+        return True
+
+    @discord.ui.button(
+        label="Refresh",
+        style=discord.ButtonStyle.secondary,
+        row=0,
+        custom_id="ai:refresh",
+    )
+    async def refresh_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        await interaction.response.edit_message(embed=build_ai_panel_embed(), view=self)
+
+    @discord.ui.button(
+        label="Diagnostics",
+        style=discord.ButtonStyle.primary,
+        row=0,
+        custom_id="ai:diagnostics",
+    )
+    async def diagnostics_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        from cogs.ai_cog import build_diagnostics_embed
+
+        await interaction.response.edit_message(
+            embed=build_diagnostics_embed(),
+            view=self,
+        )
+
+    @discord.ui.button(
+        label="Providers",
+        style=discord.ButtonStyle.primary,
+        row=0,
+        custom_id="ai:providers",
+    )
+    async def providers_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        from cogs.ai_cog import build_providers_embed
+
+        await interaction.response.edit_message(
+            embed=build_providers_embed(),
+            view=self,
+        )
+
+    @discord.ui.button(
+        label="Routing",
+        style=discord.ButtonStyle.primary,
+        row=0,
+        custom_id="ai:routing",
+    )
+    async def routing_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        from cogs.ai_cog import build_routing_embed
+
+        await interaction.response.edit_message(
+            embed=build_routing_embed(),
+            view=self,
+        )

--- a/disbot/views/btd6/__init__.py
+++ b/disbot/views/btd6/__init__.py
@@ -1,0 +1,7 @@
+"""Views for the BTD6 Assistant cog (Module 4 of the AI/BTD6 plan)."""
+
+from __future__ import annotations
+
+from views.btd6.panel import BTD6PanelView, build_btd6_panel_embed
+
+__all__ = ["BTD6PanelView", "build_btd6_panel_embed"]

--- a/disbot/views/btd6/panel.py
+++ b/disbot/views/btd6/panel.py
@@ -1,0 +1,175 @@
+"""BTD6 persistent panel — Module 4 of the AI/BTD6 plan.
+
+The view lives under ``views/btd6/`` (Pattern B) so the cog file
+stays small. Importing this module triggers the ``@register``
+decorator side-effect on :class:`BTD6PanelView`; the persistent
+view registry then resolves the ``btd6`` subsystem when
+``on_ready`` restores anchors.
+
+The panel is read-only and entirely deterministic: every button
+renders an embed built from the validated fixtures in
+:mod:`services.btd6_data_service`. No provider, no network, no AI.
+Module 5 will add an optional augmentation toggle gated by guild
+config.
+"""
+
+from __future__ import annotations
+
+import discord
+
+from core.runtime.persistent_views import PersistentView, register
+from services import btd6_ai_service, btd6_knowledge_service
+
+_PANEL_COLOR = discord.Color.green()
+
+
+class BTD6AskModal(discord.ui.Modal, title="Ask BTD6 Assistant"):
+    """Modal that takes a free-form BTD6 question and renders a deterministic answer."""
+
+    question = discord.ui.TextInput(
+        label="Your question",
+        placeholder="e.g. how do I survive round 63?",
+        max_length=300,
+        required=True,
+    )
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        from cogs.btd6_cog import _response_to_embed
+
+        response = await btd6_ai_service.answer_question(str(self.question.value))
+        await interaction.response.send_message(
+            embed=_response_to_embed(response),
+            ephemeral=True,
+        )
+
+
+def build_btd6_panel_embed() -> discord.Embed:
+    """Deterministic BTD6 panel embed.
+
+    Pulls the dataset version + game version so operators can see at
+    a glance which patch the assistant is pinned to.
+    """
+    embed = discord.Embed(
+        title="🐵 BTD6 Assistant",
+        description=(
+            "Ask deterministic BTD6 questions. The buttons below render "
+            "tower / round / mode lookups from the pinned fixtures."
+        ),
+        color=_PANEL_COLOR,
+    )
+    embed.add_field(
+        name="Data version",
+        value=btd6_knowledge_service.data_version(),
+        inline=True,
+    )
+    embed.add_field(
+        name="Game version",
+        value=btd6_knowledge_service.game_version(),
+        inline=True,
+    )
+    embed.add_field(
+        name="Entities",
+        value=(
+            f"{len(btd6_knowledge_service.list_towers())} towers • "
+            f"{len(btd6_knowledge_service.list_heroes())} heroes • "
+            f"{len(btd6_knowledge_service.list_maps())} maps • "
+            f"{len(btd6_knowledge_service.list_modes())} modes • "
+            f"{len(btd6_knowledge_service.list_rounds())} rounds"
+        ),
+        inline=False,
+    )
+    embed.set_footer(
+        text="!btd6 ask <q> / !btd6 tower <n> / !btd6 round <N> / !btd6 status",
+    )
+    return embed
+
+
+@register
+class BTD6PanelView(PersistentView):
+    """BTD6 Assistant panel. Anyone can interact."""
+
+    SUBSYSTEM = "btd6"
+
+    @discord.ui.button(
+        label="Ask",
+        style=discord.ButtonStyle.success,
+        row=0,
+        custom_id="btd6:ask",
+    )
+    async def ask_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        """Open the Ask modal — the actionable entry point for the panel."""
+        await interaction.response.send_modal(BTD6AskModal())
+
+    @discord.ui.button(
+        label="Refresh",
+        style=discord.ButtonStyle.secondary,
+        row=0,
+        custom_id="btd6:refresh",
+    )
+    async def refresh_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        await interaction.response.edit_message(
+            embed=build_btd6_panel_embed(),
+            view=self,
+        )
+
+    @discord.ui.button(
+        label="Towers",
+        style=discord.ButtonStyle.primary,
+        row=0,
+        custom_id="btd6:towers",
+    )
+    async def towers_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        from cogs.btd6_cog import build_towers_embed
+
+        await interaction.response.edit_message(
+            embed=build_towers_embed(),
+            view=self,
+        )
+
+    @discord.ui.button(
+        label="Modes",
+        style=discord.ButtonStyle.primary,
+        row=0,
+        custom_id="btd6:modes",
+    )
+    async def modes_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        from cogs.btd6_cog import build_modes_embed
+
+        await interaction.response.edit_message(
+            embed=build_modes_embed(),
+            view=self,
+        )
+
+    @discord.ui.button(
+        label="Status",
+        style=discord.ButtonStyle.primary,
+        row=0,
+        custom_id="btd6:status",
+    )
+    async def status_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        from cogs.btd6_cog import build_status_embed
+
+        await interaction.response.edit_message(
+            embed=build_status_embed(),
+            view=self,
+        )

--- a/disbot/views/btd6/panel.py
+++ b/disbot/views/btd6/panel.py
@@ -26,7 +26,7 @@ _PANEL_COLOR = discord.Color.green()
 class BTD6AskModal(discord.ui.Modal, title="Ask BTD6 Assistant"):
     """Modal that takes a free-form BTD6 question and renders a deterministic answer."""
 
-    question = discord.ui.TextInput(
+    question: discord.ui.TextInput = discord.ui.TextInput(
         label="Your question",
         placeholder="e.g. how do I survive round 63?",
         max_length=300,

--- a/disbot/views/setup/sections/__init__.py
+++ b/disbot/views/setup/sections/__init__.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 # each section's `order` field, not import order — but keep this list stable
 # so it doubles as a manifest of which sections ship today.
 from views.setup.sections import (  # noqa: F401 — import side-effect
+    btd6,
     channels,
     cleanup,
     cog_routing,
@@ -26,6 +27,7 @@ from views.setup.sections import (  # noqa: F401 — import side-effect
 )
 
 __all__ = [
+    "btd6",
     "channels",
     "cleanup",
     "cog_routing",

--- a/disbot/views/setup/sections/btd6.py
+++ b/disbot/views/setup/sections/btd6.py
@@ -1,0 +1,78 @@
+"""BTD6 setup section — announce the BTD6 assistant during setup.
+
+Read-only for Module 4: the assistant has no per-guild settings
+yet, so this section simply confirms BTD6 is loaded and points the
+operator at the panel command. Module 6 will extend this section
+when guild settings (channels, mention behaviour, AI augmentation
+toggle) come online.
+
+The section registers itself at import time via
+:data:`services.setup_sections.REGISTRY`, matching the convention
+of every other section.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import discord
+
+from services.setup_sections import REGISTRY, SetupSection
+
+if TYPE_CHECKING:
+    from views.setup.hub import SetupHubView
+
+logger = logging.getLogger("bot.views.setup.sections.btd6")
+
+SLUG = "btd6"
+
+
+async def run(interaction: discord.Interaction, hub: SetupHubView) -> None:
+    del hub
+    from services import btd6_knowledge_service
+
+    embed = discord.Embed(
+        title="🐵 BTD6 Assistant",
+        description=(
+            "BTD6 assistant is loaded and reachable via `!btd6` / `/btd6`. "
+            "The assistant answers deterministic tower/round/hero/map/mode "
+            "questions from the pinned game-data fixtures.\n\n"
+            "Per-guild settings (channel routing, mention behaviour, AI "
+            "augmentation toggle) are not yet exposed in setup — they land "
+            "with Module 6 of the AI/BTD6 plan."
+        ),
+        color=discord.Color.green(),
+    )
+    embed.add_field(
+        name="Data version",
+        value=btd6_knowledge_service.data_version(),
+        inline=True,
+    )
+    embed.add_field(
+        name="Game version",
+        value=btd6_knowledge_service.game_version(),
+        inline=True,
+    )
+    embed.set_footer(text="!btd6 status / !btd6 ask <question> / !btd6menu")
+    await interaction.response.send_message(embed=embed, ephemeral=True)
+
+
+REGISTRY.register(
+    SetupSection(
+        slug=SLUG,
+        label="BTD6 Assistant",
+        style=discord.ButtonStyle.secondary,
+        run=run,
+        order=80,
+        # No SetupOperation kinds — the section is announcement-only in
+        # Module 4. Module 6 swaps this for the real op-kind set when
+        # per-guild BTD6 settings land.
+        op_kinds=frozenset(),
+        description_if_skipped="BTD6 commands remain available; defaults apply.",
+        depths=frozenset({"standard", "advanced"}),
+    ),
+)
+
+
+__all__ = ["SLUG", "run"]

--- a/docs/help-command-surface-map.md
+++ b/docs/help-command-surface-map.md
@@ -43,7 +43,7 @@ Post-PR-#142 routing summary (relevant to every row in §2):
 
 ## 2. Subsystem inventory
 
-24 cogs in `disbot/config.py:33-58`. 23 of 24 expose
+25 cogs in `disbot/config.py:33-58`. 24 of 25 expose
 `build_help_menu_view`; only `help_cog` itself does not. The Help route
 resolver therefore opens a real panel for every subsystem except `help`,
 and only falls back to the command-list embed when the hook is missing
@@ -52,6 +52,7 @@ or raises.
 | subsystem | owner | public commands (sample) | hidden / legacy | panel hook | Help route today | Hub route today | Recommendation |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `admin` | `admin_cog.py` | `adminmenu`, `serverstats`, `cog`, `loadall`, `unloadall`, `restart`, `loglevel` | — | `_AdminPanelView` | `!help admin` → opens Admin panel (shared resolver) | dropdown Admin → panel | hub top-level (Admin) |
+| `ai` | `ai_cog.py` | `ai`, `aimenu`, `ai status`, `ai diagnostics`, `ai providers`, `ai routing` | — | `AIPanelView` | `!help ai` → opens AI Platform panel (shared resolver) | reached via Admin / Diagnostics | hub child (Admin / Platform) |
 | `blackjack` | `blackjack_cog.py:95` | `blackjack`, `bj`, `bjtournament`, `bjstart`, `bjstatus` | — | `BlackjackPanelView` | `!help blackjack` → opens Blackjack panel (shared resolver) | reached via Games | hub child (Games) |
 | `chain` | `chain_cog.py` | `chain`, `chainmenu` | — | `_ChainMenuView` | `!help chain` → opens Chain panel (shared resolver) | reached via Games / Community | hub child |
 | `channel` | `channel_cog.py:144` | `lock`, `unlock` | several `*_channel`-family commands | `_ChannelManagerView` | `!help channel` → opens Channel panel (shared resolver) | reached via Admin | hub child (Admin) |

--- a/docs/help-command-surface-map.md
+++ b/docs/help-command-surface-map.md
@@ -43,7 +43,7 @@ Post-PR-#142 routing summary (relevant to every row in §2):
 
 ## 2. Subsystem inventory
 
-25 cogs in `disbot/config.py:33-58`. 24 of 25 expose
+26 cogs in `disbot/config.py:33-58`. 25 of 26 expose
 `build_help_menu_view`; only `help_cog` itself does not. The Help route
 resolver therefore opens a real panel for every subsystem except `help`,
 and only falls back to the command-list embed when the hook is missing
@@ -53,6 +53,7 @@ or raises.
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `admin` | `admin_cog.py` | `adminmenu`, `serverstats`, `cog`, `loadall`, `unloadall`, `restart`, `loglevel` | — | `_AdminPanelView` | `!help admin` → opens Admin panel (shared resolver) | dropdown Admin → panel | hub top-level (Admin) |
 | `ai` | `ai_cog.py` | `ai`, `aimenu`, `ai status`, `ai diagnostics`, `ai providers`, `ai routing` | — | `AIPanelView` | `!help ai` → opens AI Platform panel (shared resolver) | reached via Admin / Diagnostics | hub child (Admin / Platform) |
+| `btd6` | `btd6_cog.py` | `btd6`, `btd6menu`, `btd6 ask`, `btd6 tower`, `btd6 round`, `btd6 status`, `btd6 diagnostics`, `btd6 test-intent` | — | `BTD6PanelView` | `!help btd6` → opens BTD6 panel (shared resolver) | reached via Games (`parent_hub="games"`) | hub child (Games) |
 | `blackjack` | `blackjack_cog.py:95` | `blackjack`, `bj`, `bjtournament`, `bjstart`, `bjstatus` | — | `BlackjackPanelView` | `!help blackjack` → opens Blackjack panel (shared resolver) | reached via Games | hub child (Games) |
 | `chain` | `chain_cog.py` | `chain`, `chainmenu` | — | `_ChainMenuView` | `!help chain` → opens Chain panel (shared resolver) | reached via Games / Community | hub child |
 | `channel` | `channel_cog.py:144` | `lock`, `unlock` | several `*_channel`-family commands | `_ChannelManagerView` | `!help channel` → opens Channel panel (shared resolver) | reached via Admin | hub child (Admin) |

--- a/docs/settings-customization-command-map.md
+++ b/docs/settings-customization-command-map.md
@@ -1006,6 +1006,52 @@ Subsystems (22): `admin`, `moderation`, `economy`, `inventory`, `mining`,
     plan.
 
 
+### btd6
+
+1. **cog_module**: `disbot/cogs/btd6_cog.py`
+2. **subsystem**: `btd6`
+3. **current_commands**: `!btd6` (group), `!btd6 status`,
+   `!btd6 diagnostics`, `!btd6 ask <question>`, `!btd6 tower <name>`,
+   `!btd6 hero <name>`, `!btd6 round <N>`, `!btd6 test-intent <text>`,
+   `!btd6menu`. Slash equivalents (`/btd6 ...`, `/btd6menu`) mirror
+   the prefix surface.
+4. **current_command_groups**: `!btd6` group (user-tier).
+5. **current_command_panel_or_menu**: `!btd6menu` (alias for `!btd6`)
+   opens the persistent panel `BTD6PanelView`.
+6. **help_menu_discoverable**: Yes — `BTD6Cog.build_help_menu_view`
+   returns the panel embed + view.
+7. **dedicated_panel_command**: `!btd6menu`.
+8. **help_menu_direct_navigation_hook**: `build_help_menu_view` →
+   `BTD6PanelView`.
+9. **existing_SettingSpec_declarations**: none yet. Module 6 of the
+   AI/BTD6 plan will add per-guild settings (channel list, mention
+   behaviour, AI augmentation toggle).
+10. **existing_settings_keys**: none.
+11. **existing_BindingSpec_entries**: none.
+12. **existing_ResourceRequirement_entries**: none.
+13. **current_access_policy_behavior**: `visibility_tier=user`;
+    capabilities `btd6.query.ask`, `btd6.strategy.view`,
+    `btd6.diagnostics.view`.
+14. **hardcoded_or_env_only_behavior**: game-data fixtures pinned in
+    `disbot/data/btd6/*.json` (version metadata in each file).
+15. **missing_customization_commands**: `!btd6 settings` lands with
+    Module 6 once channels/mention behaviour are persisted.
+16. **missing_settings_pages**: per-guild BTD6 settings page —
+    deferred to Module 6.
+17. **missing_menu_buttons_selects_modals**: AI-augmentation toggle
+    button (Module 5/6).
+18. **setting_class_per_value**: n/a in Module 4 (no settings yet).
+19. **target_Settings_Manager_page**: Module 6.
+20. **target_mutation_path**: Module 6 — guild settings mutation via
+    existing settings infrastructure.
+21. **target_help_or_menu_route**: existing; BTD6 reachable via Games
+    hub (`parent_hub="games"`).
+22. **provisionable_resources**: none.
+23. **priority**: `P1` — Module 4 of the AI/BTD6 plan.
+24. **recommended_PR_phase**: lands with Module 4; settings expand in
+    Module 6.
+
+
 ### settings
 
 1. **cog_module**: `disbot/cogs/settings_cog.py` (added in S5).

--- a/docs/settings-customization-command-map.md
+++ b/docs/settings-customization-command-map.md
@@ -960,6 +960,52 @@ Subsystems (22): `admin`, `moderation`, `economy`, `inventory`, `mining`,
     (`!platform resources`).
 
 
+### ai
+
+1. **cog_module**: `disbot/cogs/ai_cog.py`
+2. **subsystem**: `ai`
+3. **current_commands**: `!ai` (group), `!ai status`, `!ai diagnostics`,
+   `!ai providers`, `!ai routing`, `!aimenu`. Slash equivalents
+   (`/ai status`, `/ai diagnostics`, `/ai providers`, `/ai routing`,
+   `/aimenu`) mirror the prefix surface.
+4. **current_command_groups**: `!ai` group (administrator-only).
+5. **current_command_panel_or_menu**: `!aimenu` (alias of `!ai`) opens the
+   persistent panel `AIPanelView`.
+6. **help_menu_discoverable**: Yes — `AICog.build_help_menu_view`
+   returns the panel embed + view.
+7. **dedicated_panel_command**: `!aimenu`.
+8. **help_menu_direct_navigation_hook**: `build_help_menu_view` →
+   `AIPanelView` (read-only).
+9. **existing_SettingSpec_declarations**: none. AI configuration is
+   driven by process env vars (`AI_ENABLED`, `AI_DEFAULT_PROVIDER`,
+   `SETUP_ADVISOR_PROVIDER`), not per-guild settings — see
+   `core.runtime.ai.feature_flags`.
+10. **existing_settings_keys**: none.
+11. **existing_BindingSpec_entries**: none.
+12. **existing_ResourceRequirement_entries**: none.
+13. **current_access_policy_behavior**: `visibility_tier=administrator`;
+    capabilities `ai.platform.view`, `ai.diagnostics.view`,
+    `ai.provider.view`, `ai.routing.view` (all read-only).
+14. **hardcoded_or_env_only_behavior**: provider/model resolution lives
+    in `core.runtime.ai.routing` (env-overridable via
+    `AI_ROUTING_<TASK>=<provider>:<model>`); request budgets and
+    timeouts default in `core.runtime.ai.routing`/`safety`.
+15. **missing_customization_commands**: per-task enable/disable surface
+    (currently env-only via `AI_TASK_<NAME>_ENABLED`).
+16. **missing_settings_pages**: none for the read-only MVP.
+17. **missing_menu_buttons_selects_modals**: none (panel is read-only).
+18. **setting_class_per_value**: n/a (process-level platform settings).
+19. **target_Settings_Manager_page**: optional future page that mirrors
+    the AI diagnostics snapshot read-only.
+20. **target_mutation_path**: none (read-only).
+21. **target_help_or_menu_route**: existing; AI Platform reachable via
+    Admin / Diagnostics hubs (`related_subsystems`).
+22. **provisionable_resources**: none.
+23. **priority**: `P1` — surfaces platform AI state for operators.
+24. **recommended_PR_phase**: lands with Module 2 of the AI/BTD6
+    plan.
+
+
 ### settings
 
 1. **cog_module**: `disbot/cogs/settings_cog.py` (added in S5).

--- a/tests/unit/cogs/test_ai_cog.py
+++ b/tests/unit/cogs/test_ai_cog.py
@@ -1,0 +1,125 @@
+"""AI Cog smoke and INV-B alignment — Module 2 of the AI/BTD6 plan.
+
+These tests pin:
+
+* The cog is importable in CI (no API keys required).
+* The cog declares the entry-point commands the SUBSYSTEMS registry
+  promises (``ai`` group + ``aimenu``), and the registry has the
+  matching ``ai`` row.
+* Embed builders return :class:`discord.Embed` instances without
+  invoking any provider (no env keys, no network).
+* The persistent view registers under ``SUBSYSTEM = "ai"``.
+* The help-surface-map invariants (pinned in
+  ``tests/unit/docs/test_help_surface_map_doc.py``) continue to hold
+  with the new ``ai`` row.
+"""
+
+from __future__ import annotations
+
+import discord
+import pytest
+
+from cogs.ai_cog import (
+    AICog,
+    build_diagnostics_embed,
+    build_providers_embed,
+    build_routing_embed,
+    build_status_embed,
+)
+from core.runtime.ai.contracts import AITask
+from core.runtime.persistent_views import _REGISTRY as _PERSISTENT_VIEW_REGISTRY
+from utils.subsystem_registry import SUBSYSTEMS
+from views.ai.panel import AIPanelView, build_ai_panel_embed
+
+
+def test_subsystem_registry_has_ai_entry():
+    meta = SUBSYSTEMS["ai"]
+    assert meta["visibility_tier"] == "administrator"
+    assert set(meta["entry_points"]) == {"ai", "aimenu"}
+    assert "ai.platform.view" in meta["capabilities"]
+
+
+def test_ai_cog_declares_entry_point_commands():
+    """``walk_commands`` over the cog must reveal `ai` and `aimenu`."""
+
+    class _FakeBot:
+        pass
+
+    cog = AICog(_FakeBot())
+    names = {cmd.name for cmd in cog.walk_commands()}
+    # ``walk_commands`` yields the group, the subcommands, and the
+    # top-level ``aimenu`` command. The entry-points the registry
+    # promises are ``ai`` and ``aimenu``.
+    assert "ai" in names
+    assert "aimenu" in names
+
+
+def test_status_embed_builder_returns_embed():
+    embed = build_status_embed()
+    assert isinstance(embed, discord.Embed)
+    assert embed.title == "AI Gateway — Status"
+
+
+def test_diagnostics_embed_builder_returns_embed():
+    embed = build_diagnostics_embed()
+    assert isinstance(embed, discord.Embed)
+    assert embed.title == "AI Gateway — Diagnostics"
+
+
+def test_providers_embed_builder_returns_embed():
+    embed = build_providers_embed()
+    assert isinstance(embed, discord.Embed)
+    assert embed.title == "AI Gateway — Providers"
+
+
+def test_routing_embed_lists_all_tasks_by_default():
+    embed = build_routing_embed()
+    assert isinstance(embed, discord.Embed)
+    # One field per AITask, plus zero overflow when no filter given.
+    field_names = {field.name for field in embed.fields}
+    for task in AITask:
+        assert task.value in field_names
+
+
+def test_routing_embed_narrows_to_one_task():
+    embed = build_routing_embed(AITask.SETUP_SUGGEST.value)
+    assert isinstance(embed, discord.Embed)
+    field_names = {field.name for field in embed.fields}
+    assert field_names == {AITask.SETUP_SUGGEST.value}
+
+
+def test_routing_embed_handles_unknown_task_gracefully():
+    embed = build_routing_embed("does.not.exist")
+    assert isinstance(embed, discord.Embed)
+    assert any(
+        "No matching task" in (field.name or "") for field in embed.fields
+    )
+
+
+def test_ai_panel_embed_renders_without_provider_call():
+    """Building the panel must not trigger a gateway request."""
+    embed = build_ai_panel_embed()
+    assert isinstance(embed, discord.Embed)
+    assert "AI Platform" in (embed.title or "")
+
+
+def test_persistent_view_registered_under_ai_subsystem():
+    """The @register decorator side-effect must populate the view registry."""
+    assert "ai" in _PERSISTENT_VIEW_REGISTRY
+    assert _PERSISTENT_VIEW_REGISTRY["ai"] is AIPanelView
+
+
+@pytest.mark.asyncio
+async def test_setup_adds_cog_to_bot():
+    """``cogs.ai_cog.setup`` must add the cog instance to the bot."""
+    added: list = []
+
+    class _FakeBot:
+        async def add_cog(self, cog):
+            added.append(cog)
+
+    from cogs.ai_cog import setup
+
+    await setup(_FakeBot())
+    assert len(added) == 1
+    assert isinstance(added[0], AICog)

--- a/tests/unit/cogs/test_btd6_cog.py
+++ b/tests/unit/cogs/test_btd6_cog.py
@@ -1,0 +1,153 @@
+"""BTD6 Cog smoke + INV-B alignment — Module 4 of the AI/BTD6 plan.
+
+Pins:
+
+* SUBSYSTEMS["btd6"] is consistent with the cog's entry_points
+  (``btd6`` and ``btd6menu``).
+* The cog loads without API keys (deterministic-only).
+* ``!btd6 ask`` returns a deterministic answer and does NOT call
+  ``services.ai_gateway`` (Module 4 must not exercise the AI path
+  — that belongs to Module 5).
+* Embed builders are pure: no provider, no DB.
+* The persistent view registers under ``SUBSYSTEM = "btd6"``.
+* The BTD6 setup section appears in the registry.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+# Force the setup-sections package to import every section module so the
+# REGISTRY contains the production set during the test run.
+import views.setup.sections  # noqa: F401 — import side-effect
+
+from cogs.btd6_cog import (
+    BTD6Cog,
+    build_diagnostics_embed,
+    build_modes_embed,
+    build_status_embed,
+    build_test_intent_embed,
+    build_towers_embed,
+)
+from core.runtime.persistent_views import _REGISTRY as _PERSISTENT_VIEW_REGISTRY
+from services.setup_sections import REGISTRY as SETUP_REGISTRY
+from utils.subsystem_registry import SUBSYSTEMS
+from views.btd6.panel import BTD6PanelView, build_btd6_panel_embed
+
+
+def test_subsystem_registry_has_btd6_entry():
+    meta = SUBSYSTEMS["btd6"]
+    assert meta["visibility_tier"] == "user"
+    assert meta["parent_hub"] == "games"
+    assert set(meta["entry_points"]) == {"btd6", "btd6menu"}
+    assert "btd6.query.ask" in meta["capabilities"]
+
+
+def test_btd6_cog_declares_entry_point_commands():
+    class _FakeBot:
+        pass
+
+    cog = BTD6Cog(_FakeBot())
+    names = {cmd.name for cmd in cog.walk_commands()}
+    assert "btd6" in names
+    assert "btd6menu" in names
+
+
+def test_status_embed_builder_returns_embed():
+    embed = build_status_embed()
+    assert isinstance(embed, discord.Embed)
+    assert "Status" in (embed.title or "")
+
+
+def test_diagnostics_embed_lists_entities():
+    embed = build_diagnostics_embed()
+    assert isinstance(embed, discord.Embed)
+    names = {field.name for field in embed.fields}
+    assert {"Towers", "Heroes", "Maps", "Modes", "Rounds tracked"} <= names
+
+
+def test_towers_embed_has_entries():
+    embed = build_towers_embed()
+    assert isinstance(embed, discord.Embed)
+    assert len(embed.fields) >= 4  # at least the fixture's 4 towers
+
+
+def test_modes_embed_has_entries():
+    embed = build_modes_embed()
+    assert isinstance(embed, discord.Embed)
+    assert len(embed.fields) >= 2
+
+
+def test_test_intent_embed_renders_resolver_state():
+    embed = build_test_intent_embed("Dart Monkey on round 63")
+    assert isinstance(embed, discord.Embed)
+    field_names = {field.name for field in embed.fields}
+    assert "Towers" in field_names
+    assert "Rounds" in field_names
+
+
+def test_panel_embed_uses_dataset_versions():
+    embed = build_btd6_panel_embed()
+    assert isinstance(embed, discord.Embed)
+    field_names = {field.name for field in embed.fields}
+    assert {"Data version", "Game version", "Entities"} <= field_names
+
+
+def test_persistent_view_registered_under_btd6_subsystem():
+    assert "btd6" in _PERSISTENT_VIEW_REGISTRY
+    assert _PERSISTENT_VIEW_REGISTRY["btd6"] is BTD6PanelView
+
+
+def test_btd6_setup_section_registered():
+    assert "btd6" in SETUP_REGISTRY
+    section = SETUP_REGISTRY.get("btd6")
+    assert section is not None
+    assert section.label == "BTD6 Assistant"
+    # Module 4 declares no SetupOperation kinds — Module 6 fills these in.
+    assert section.op_kinds == frozenset()
+
+
+@pytest.mark.asyncio
+async def test_btd6_ask_runs_deterministically_without_ai_gateway(monkeypatch):
+    """`!btd6 ask` must not exercise services.ai_gateway in Module 4."""
+    import services.ai_gateway as ai_gateway
+
+    called = False
+
+    async def _fail_if_called(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("Module 4 must not call the AI gateway")
+
+    monkeypatch.setattr(ai_gateway, "execute", _fail_if_called)
+
+    cog = BTD6Cog(MagicMock())
+    fake_ctx = MagicMock()
+    fake_ctx.send = AsyncMock()
+
+    callback = cog.btd6_ask.callback
+    await callback(cog, fake_ctx, question="Dart Monkey")
+
+    assert called is False
+    fake_ctx.send.assert_awaited_once()
+    sent_embed = fake_ctx.send.await_args.kwargs.get("embed")
+    assert sent_embed is not None
+    assert "Dart Monkey" in (sent_embed.title or "")
+
+
+@pytest.mark.asyncio
+async def test_setup_adds_cog_to_bot():
+    added: list = []
+
+    class _FakeBot:
+        async def add_cog(self, cog):
+            added.append(cog)
+
+    from cogs.btd6_cog import setup
+
+    await setup(_FakeBot())
+    assert len(added) == 1
+    assert isinstance(added[0], BTD6Cog)

--- a/tests/unit/cogs/test_btd6_cog.py
+++ b/tests/unit/cogs/test_btd6_cog.py
@@ -23,7 +23,6 @@ import pytest
 # Force the setup-sections package to import every section module so the
 # REGISTRY contains the production set during the test run.
 import views.setup.sections  # noqa: F401 — import side-effect
-
 from cogs.btd6_cog import (
     BTD6Cog,
     build_diagnostics_embed,

--- a/tests/unit/cogs/test_btd6_stage.py
+++ b/tests/unit/cogs/test_btd6_stage.py
@@ -1,0 +1,222 @@
+"""Passive BTD6 message stage tests — Module 6 of the AI/BTD6 plan.
+
+Each skip condition gets its own test so a regression that
+accidentally enables passive behaviour by default shows up
+exactly where the gate broke.
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import discord
+import pytest
+
+from cogs.btd6.stage import (
+    REASON_ALREADY_HANDLED,
+    REASON_BOT_AUTHOR,
+    REASON_CHANNEL_NOT_CONFIGURED,
+    REASON_COMMAND_PREFIX,
+    REASON_COOLDOWN,
+    REASON_DISABLED,
+    REASON_EMPTY,
+    REASON_LOW_CONFIDENCE,
+    REASON_SYSTEM_MESSAGE,
+    REASON_WEBHOOK,
+    BTD6AssistantMessageStage,
+    STAGE_NAME,
+    STAGE_ORDER,
+)
+from core.runtime.message_pipeline import MessagePipelineContext
+
+
+def _make_message(
+    *,
+    content: str = "Dart Monkey on round 63?",
+    author_bot: bool = False,
+    webhook_id: int | None = None,
+    channel_id: int = 1234,
+    guild_id: int | None = 9999,
+    msg_type: discord.MessageType = discord.MessageType.default,
+):
+    author = SimpleNamespace(id=42, bot=author_bot, name="alice")
+    channel = SimpleNamespace(id=channel_id)
+    guild = SimpleNamespace(id=guild_id) if guild_id is not None else None
+    message = SimpleNamespace(
+        id=99,
+        content=content,
+        author=author,
+        channel=channel,
+        guild=guild,
+        webhook_id=webhook_id,
+        type=msg_type,
+    )
+    message.reply = AsyncMock()
+    return message
+
+
+def _make_ctx(message, *, command_prefix: str = "!", metadata: dict | None = None):
+    bot = SimpleNamespace(command_prefix=command_prefix)
+    ctx = MessagePipelineContext(bot=bot, message=message)
+    if metadata:
+        ctx.metadata.update(metadata)
+    return ctx
+
+
+@pytest.fixture
+def stage(monkeypatch):
+    monkeypatch.delenv("BTD6_PASSIVE_ENABLED", raising=False)
+    monkeypatch.delenv("BTD6_PASSIVE_CHANNELS", raising=False)
+    monkeypatch.delenv("BTD6_CONFIDENCE_THRESHOLD", raising=False)
+    monkeypatch.delenv("BTD6_COOLDOWN_SECONDS", raising=False)
+    monkeypatch.delenv("BTD6_AI_ENABLED", raising=False)
+    monkeypatch.delenv("AI_ENABLED", raising=False)
+    yield BTD6AssistantMessageStage()
+
+
+def test_stage_has_correct_name_and_order(stage):
+    assert stage.name == STAGE_NAME
+    assert stage.order == STAGE_ORDER
+
+
+@pytest.mark.asyncio
+async def test_default_config_does_not_respond(stage):
+    """`BTD6_PASSIVE_ENABLED` unset means we never reply."""
+    message = _make_message()
+    ctx = _make_ctx(message)
+    result = await stage.process(ctx)
+    assert not message.reply.await_count
+    assert result.deleted is False
+    assert result.short_circuit is False
+    skips = stage.latest_skips(message.channel.id)
+    assert skips and skips[-1].reason == REASON_DISABLED
+
+
+@pytest.mark.asyncio
+async def test_bot_author_skipped(stage):
+    message = _make_message(author_bot=True)
+    await stage.process(_make_ctx(message))
+    assert stage.latest_skips(message.channel.id)[-1].reason == REASON_BOT_AUTHOR
+
+
+@pytest.mark.asyncio
+async def test_webhook_message_skipped(stage):
+    message = _make_message(webhook_id=12345)
+    await stage.process(_make_ctx(message))
+    assert stage.latest_skips(message.channel.id)[-1].reason == REASON_WEBHOOK
+
+
+@pytest.mark.asyncio
+async def test_system_message_skipped(stage):
+    message = _make_message(msg_type=discord.MessageType.pins_add)
+    await stage.process(_make_ctx(message))
+    assert (
+        stage.latest_skips(message.channel.id)[-1].reason == REASON_SYSTEM_MESSAGE
+    )
+
+
+@pytest.mark.asyncio
+async def test_command_prefix_message_skipped(stage):
+    message = _make_message(content="!btd6 status")
+    await stage.process(_make_ctx(message, command_prefix="!"))
+    assert (
+        stage.latest_skips(message.channel.id)[-1].reason == REASON_COMMAND_PREFIX
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_message_skipped(stage):
+    message = _make_message(content="   ")
+    await stage.process(_make_ctx(message))
+    assert stage.latest_skips(message.channel.id)[-1].reason == REASON_EMPTY
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_channel_skipped(stage, monkeypatch):
+    monkeypatch.setenv("BTD6_PASSIVE_ENABLED", "1")
+    monkeypatch.setenv("BTD6_PASSIVE_CHANNELS", "111,222")
+    message = _make_message(channel_id=999)  # not in the configured list
+    await stage.process(_make_ctx(message))
+    assert (
+        stage.latest_skips(message.channel.id)[-1].reason
+        == REASON_CHANNEL_NOT_CONFIGURED
+    )
+
+
+@pytest.mark.asyncio
+async def test_already_handled_metadata_skipped(stage, monkeypatch):
+    monkeypatch.setenv("BTD6_PASSIVE_ENABLED", "1")
+    message = _make_message()
+    ctx = _make_ctx(message, metadata={"handled_by": "some_other_stage"})
+    await stage.process(ctx)
+    assert (
+        stage.latest_skips(message.channel.id)[-1].reason == REASON_ALREADY_HANDLED
+    )
+
+
+@pytest.mark.asyncio
+async def test_low_confidence_skipped(stage, monkeypatch):
+    monkeypatch.setenv("BTD6_PASSIVE_ENABLED", "1")
+    message = _make_message(content="hello everyone how are we doing today")
+    await stage.process(_make_ctx(message))
+    last = stage.latest_skips(message.channel.id)[-1]
+    assert last.reason == REASON_LOW_CONFIDENCE
+    assert last.confidence < 0.34
+
+
+@pytest.mark.asyncio
+async def test_cooldown_skipped_after_handled(stage, monkeypatch):
+    """After handling once, the same user gets a cooldown skip."""
+    monkeypatch.setenv("BTD6_PASSIVE_ENABLED", "1")
+    monkeypatch.setenv("BTD6_COOLDOWN_SECONDS", "60")
+
+    message1 = _make_message()
+    await stage.process(_make_ctx(message1))
+    assert message1.reply.await_count == 1  # the first message was answered
+
+    message2 = _make_message()
+    await stage.process(_make_ctx(message2))
+    assert message2.reply.await_count == 0  # cooldown blocked it
+    assert stage.latest_skips(message2.channel.id)[-1].reason == REASON_COOLDOWN
+
+
+@pytest.mark.asyncio
+async def test_configured_channel_high_confidence_replies(stage, monkeypatch):
+    """All gates pass → the stage replies and marks ctx.metadata."""
+    monkeypatch.setenv("BTD6_PASSIVE_ENABLED", "1")
+    monkeypatch.setenv("BTD6_PASSIVE_CHANNELS", "1234")
+    monkeypatch.setenv("BTD6_COOLDOWN_SECONDS", "0")
+
+    message = _make_message(content="Dart Monkey on round 63 in CHIMPS")
+    ctx = _make_ctx(message)
+    await stage.process(ctx)
+
+    assert message.reply.await_count == 1
+    embed = message.reply.await_args.kwargs.get("embed")
+    assert embed is not None
+    assert ctx.metadata.get("handled_by") == STAGE_NAME
+
+
+def test_skip_buffer_never_includes_message_content(stage):
+    """`why-no-response` must not leak user content. The buffer is reason-only."""
+    msg = _make_message(content="my secret strategy goes here")
+    import asyncio
+
+    asyncio.run(stage.process(_make_ctx(msg)))
+    skips = stage.latest_skips(msg.channel.id)
+    for record in skips:
+        assert "secret" not in record.reason.lower()
+
+
+def test_skip_buffer_is_bounded(stage):
+    """The per-channel buffer caps at the configured size."""
+    # Spam many empty messages to fill the buffer.
+    import asyncio
+
+    for _ in range(20):
+        msg = _make_message(content="")
+        asyncio.run(stage.process(_make_ctx(msg)))
+    skips = stage.latest_skips(1234)
+    assert len(skips) <= 8  # _SKIP_BUFFER_PER_CHANNEL

--- a/tests/unit/cogs/test_btd6_stage.py
+++ b/tests/unit/cogs/test_btd6_stage.py
@@ -25,9 +25,9 @@ from cogs.btd6.stage import (
     REASON_LOW_CONFIDENCE,
     REASON_SYSTEM_MESSAGE,
     REASON_WEBHOOK,
-    BTD6AssistantMessageStage,
     STAGE_NAME,
     STAGE_ORDER,
+    BTD6AssistantMessageStage,
 )
 from core.runtime.message_pipeline import MessagePipelineContext
 

--- a/tests/unit/help/test_help_actionability_contract.py
+++ b/tests/unit/help/test_help_actionability_contract.py
@@ -332,6 +332,10 @@ async def _build_panel_for(
         from cogs.chain_cog import ChainCog
 
         cog = ChainCog(MagicMock())
+    elif subsystem == "btd6":
+        from cogs.btd6_cog import BTD6Cog
+
+        cog = BTD6Cog(MagicMock())
     else:
         raise NotImplementedError(
             f"No cog mapping for actionability target {subsystem!r}. "
@@ -358,6 +362,7 @@ async def _build_panel_for(
         pytest.param("mining"),
         pytest.param("counting"),
         pytest.param("chain"),
+        pytest.param("btd6"),
     ],
 )
 async def test_games_subsystem_panel_is_actionable(subsystem: str) -> None:
@@ -545,6 +550,7 @@ def test_actionability_targets_match_registry_games_children() -> None:
         "mining",
         "counting",
         "chain",
+        "btd6",
     }
     new_in_registry = registry_games - expected
     removed_from_registry = expected - registry_games

--- a/tests/unit/invariants/test_ai_btd6_boundaries.py
+++ b/tests/unit/invariants/test_ai_btd6_boundaries.py
@@ -38,13 +38,11 @@ import pytest
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _DISBOT = _REPO_ROOT / "disbot"
 
-# Paths permitted to import the OpenAI or Anthropic SDK. The plan
-# eventually narrows this to ``providers/`` only; the setup-advisor
-# entry is a transitional exception removed by Module 1.
+# Paths permitted to import the OpenAI or Anthropic SDK. After
+# Module 1 of the AI/BTD6 plan migrates the setup advisor behind the
+# gateway, ``providers/`` is the only allowed location.
 _PROVIDER_DIR = _DISBOT / "core" / "runtime" / "ai" / "providers"
-_OPENAI_ALLOWLIST_TRANSITIONAL = {
-    _DISBOT / "services" / "setup_ai_advisor.py",
-}
+_OPENAI_ALLOWLIST_TRANSITIONAL: set[Path] = set()
 
 _PROVIDER_SDKS = ("openai", "anthropic")
 

--- a/tests/unit/invariants/test_ai_btd6_boundaries.py
+++ b/tests/unit/invariants/test_ai_btd6_boundaries.py
@@ -1,0 +1,350 @@
+"""Architectural boundaries for the AI platform layer and the BTD6 cog.
+
+Five static checks enforce the dependency direction promised by the
+"Separate AI Cog + BTD6 Cog, Shared AI Platform Helpers" plan:
+
+1. Provider SDK imports (``openai``/``anthropic``) only inside
+   ``disbot/core/runtime/ai/providers/`` — the gateway is the single
+   external-provider chokepoint.
+2. ``disbot/core/runtime/ai/`` never imports from ``cogs/`` or from
+   any BTD6 service. AI runtime is product-agnostic.
+3. ``disbot/services/ai_*.py`` never imports BTD6 services or BTD6
+   cogs. AI services are reusable, not domain-coupled.
+4. BTD6 modules (``cogs/btd6*``, ``services/btd6_*.py``) never import
+   the AI cog. They consume AI through ``services.ai_gateway`` and
+   ``core.runtime.ai.*`` only — never via cog-to-cog imports.
+5. No BTD6 module installs its own ``on_message`` listener. BTD6
+   message handling, when added, goes through the existing
+   ``core.runtime.message_pipeline.register(stage)`` API.
+
+The tests scan production files with ``ast`` (same convention as
+``test_inv_f_economy_service.py`` and ``test_no_direct_bindings_primary_branch.py``).
+Vacuous-true is fine: until BTD6 modules exist, the BTD6 checks
+simply scan an empty file set.
+
+The setup advisor temporarily appears in the OpenAI allowlist
+because Module 1 of the plan migrates it behind the gateway. After
+Module 1 lands, ``_OPENAI_ALLOWLIST_TRANSITIONAL`` is removed; the
+only remaining allowed path is ``providers/openai_provider.py``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DISBOT = _REPO_ROOT / "disbot"
+
+# Paths permitted to import the OpenAI or Anthropic SDK. The plan
+# eventually narrows this to ``providers/`` only; the setup-advisor
+# entry is a transitional exception removed by Module 1.
+_PROVIDER_DIR = _DISBOT / "core" / "runtime" / "ai" / "providers"
+_OPENAI_ALLOWLIST_TRANSITIONAL = {
+    _DISBOT / "services" / "setup_ai_advisor.py",
+}
+
+_PROVIDER_SDKS = ("openai", "anthropic")
+
+
+def _iter_production_py_files() -> list[Path]:
+    return [
+        p
+        for p in _DISBOT.rglob("*.py")
+        if "__pycache__" not in p.parts
+    ]
+
+
+def _files_under(*roots: Path) -> list[Path]:
+    out: list[Path] = []
+    for root in roots:
+        if not root.exists():
+            continue
+        if root.is_file() and root.suffix == ".py":
+            out.append(root)
+            continue
+        for p in root.rglob("*.py"):
+            if "__pycache__" in p.parts:
+                continue
+            out.append(p)
+    return out
+
+
+def _btd6_files() -> list[Path]:
+    """Every BTD6 production file (cogs and services)."""
+    out: list[Path] = []
+    cogs_dir = _DISBOT / "cogs"
+    if cogs_dir.exists():
+        for p in cogs_dir.rglob("*.py"):
+            if "__pycache__" in p.parts:
+                continue
+            name = p.name
+            rel = p.relative_to(cogs_dir)
+            if name.startswith("btd6") or rel.parts[0].startswith("btd6"):
+                out.append(p)
+    services_dir = _DISBOT / "services"
+    if services_dir.exists():
+        for p in services_dir.glob("btd6_*.py"):
+            out.append(p)
+    return out
+
+
+def _ai_service_files() -> list[Path]:
+    """Every ``services/ai_*.py`` production file."""
+    services_dir = _DISBOT / "services"
+    if not services_dir.exists():
+        return []
+    return [p for p in services_dir.glob("ai_*.py")]
+
+
+def _imported_modules(tree: ast.AST) -> list[str]:
+    """Return every imported module name (from-imports and plain imports)."""
+    out: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module:
+                out.append(node.module)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                out.append(alias.name)
+    return out
+
+
+def _imports_root(module: str) -> str:
+    """Return the top-level package of an imported module."""
+    return module.split(".", 1)[0]
+
+
+def _parse(path: Path) -> ast.AST:
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def _matches_btd6_import(module: str) -> bool:
+    """True if ``module`` resolves to a BTD6 cog or BTD6 service."""
+    parts = module.split(".")
+    # Accept absolute (``disbot.cogs.btd6_cog``) and runtime forms
+    # (``cogs.btd6_cog``, ``services.btd6_knowledge_service``).
+    if parts and parts[0] == "disbot":
+        parts = parts[1:]
+    if len(parts) < 2:
+        return False
+    if parts[0] == "cogs" and (
+        parts[1].startswith("btd6") or (len(parts) > 2 and parts[1] == "btd6")
+    ):
+        return True
+    if parts[0] == "services" and parts[1].startswith("btd6_"):
+        return True
+    return False
+
+
+def _matches_ai_cog_import(module: str) -> bool:
+    """True if ``module`` resolves to the AI cog (forbidden for BTD6)."""
+    parts = module.split(".")
+    if parts and parts[0] == "disbot":
+        parts = parts[1:]
+    if len(parts) < 2:
+        return False
+    if parts[0] != "cogs":
+        return False
+    # Forbid the AI cog package and module entry.
+    return parts[1] in {"ai_cog", "ai"}
+
+
+def _matches_cogs_import(module: str) -> bool:
+    """True if ``module`` resolves to anything under ``cogs/`` (forbidden for AI runtime)."""
+    parts = module.split(".")
+    if parts and parts[0] == "disbot":
+        parts = parts[1:]
+    return bool(parts) and parts[0] == "cogs"
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — provider SDK imports
+# ---------------------------------------------------------------------------
+
+
+def test_provider_sdk_imports_only_in_providers() -> None:
+    """``from openai``/``from anthropic`` only inside ``core/runtime/ai/providers/``.
+
+    Transitional exception: ``services/setup_ai_advisor.py`` is allowed
+    until Module 1 of the AI/BTD6 plan migrates it behind the gateway.
+    """
+    violations: list[str] = []
+    for path in _iter_production_py_files():
+        if path == _DISBOT / "core" / "runtime" / "ai" / "providers" / "__init__.py":
+            continue
+        if path.is_relative_to(_PROVIDER_DIR):
+            continue
+        if path in _OPENAI_ALLOWLIST_TRANSITIONAL:
+            continue
+        try:
+            tree = _parse(path)
+        except SyntaxError:
+            continue
+        for module in _imported_modules(tree):
+            root = _imports_root(module)
+            if root in _PROVIDER_SDKS:
+                violations.append(f"{path.relative_to(_REPO_ROOT)}: imports {module!r}")
+    if violations:
+        pytest.fail(
+            "Provider SDK imports must live only under "
+            "disbot/core/runtime/ai/providers/. Violations:\n  "
+            + "\n  ".join(violations),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — AI runtime is product-agnostic
+# ---------------------------------------------------------------------------
+
+
+def test_core_runtime_ai_does_not_import_cogs_or_btd6() -> None:
+    """``disbot/core/runtime/ai/`` must not import any cog or any BTD6 service."""
+    ai_dir = _DISBOT / "core" / "runtime" / "ai"
+    if not ai_dir.exists():
+        pytest.skip("core/runtime/ai not present yet")
+    violations: list[str] = []
+    for path in _files_under(ai_dir):
+        try:
+            tree = _parse(path)
+        except SyntaxError:
+            continue
+        for module in _imported_modules(tree):
+            if _matches_cogs_import(module):
+                violations.append(
+                    f"{path.relative_to(_REPO_ROOT)}: imports cog module {module!r}",
+                )
+                continue
+            if _matches_btd6_import(module):
+                violations.append(
+                    f"{path.relative_to(_REPO_ROOT)}: imports BTD6 module {module!r}",
+                )
+    if violations:
+        pytest.fail(
+            "core/runtime/ai/ must not depend on cogs or BTD6 services. "
+            "Violations:\n  " + "\n  ".join(violations),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — AI services must not import BTD6
+# ---------------------------------------------------------------------------
+
+
+def test_ai_services_do_not_import_btd6() -> None:
+    """Any ``services/ai_*.py`` must not import BTD6 cogs or services."""
+    violations: list[str] = []
+    for path in _ai_service_files():
+        try:
+            tree = _parse(path)
+        except SyntaxError:
+            continue
+        for module in _imported_modules(tree):
+            if _matches_btd6_import(module):
+                violations.append(
+                    f"{path.relative_to(_REPO_ROOT)}: imports BTD6 module {module!r}",
+                )
+    if violations:
+        pytest.fail(
+            "services/ai_*.py must not depend on BTD6 cogs or BTD6 services. "
+            "Violations:\n  " + "\n  ".join(violations),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — BTD6 must consume AI only through service boundaries
+# ---------------------------------------------------------------------------
+
+
+def test_btd6_does_not_import_ai_cog() -> None:
+    """BTD6 cogs and services must not import the AI cog directly.
+
+    BTD6 reaches AI through ``services.ai_gateway`` and ``core.runtime.ai.*``.
+    Cog-to-cog imports are forbidden per the global architecture rule.
+    """
+    violations: list[str] = []
+    for path in _btd6_files():
+        try:
+            tree = _parse(path)
+        except SyntaxError:
+            continue
+        for module in _imported_modules(tree):
+            if _matches_ai_cog_import(module):
+                violations.append(
+                    f"{path.relative_to(_REPO_ROOT)}: imports AI cog module {module!r}",
+                )
+    if violations:
+        pytest.fail(
+            "BTD6 modules must not import the AI cog directly. "
+            "Use services.ai_gateway / core.runtime.ai instead. "
+            "Violations:\n  " + "\n  ".join(violations),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — BTD6 must use the message pipeline, not a direct listener
+# ---------------------------------------------------------------------------
+
+
+def _declares_on_message_listener(tree: ast.AST) -> list[str]:
+    """Return the locations of any ``on_message`` listener registration.
+
+    Catches three patterns:
+      * ``@bot.event`` / ``@self.bot.event`` decorating ``async def on_message``
+      * ``@commands.Cog.listener("on_message")`` /
+        ``@commands.Cog.listener()`` decorating ``async def on_message``
+      * Plain ``async def on_message`` inside a ``commands.Cog`` subclass
+        (discord.py auto-binds ``on_message`` methods on cogs)
+    """
+    findings: list[str] = []
+
+    def _decorator_targets_on_message(dec: ast.expr) -> bool:
+        # @<x>.event, @<x>.listener, @commands.Cog.listener(...)
+        if isinstance(dec, ast.Attribute):
+            return dec.attr in {"event", "listener"}
+        if isinstance(dec, ast.Call):
+            return _decorator_targets_on_message(dec.func)
+        return False
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "on_message":
+            findings.append(f"async def on_message at line {node.lineno}")
+            continue
+        if isinstance(node, ast.FunctionDef) and node.name == "on_message":
+            findings.append(f"def on_message at line {node.lineno}")
+            continue
+
+    # Also scan for explicit bot.add_listener("on_message", ...) calls.
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr == "add_listener"
+                and any(
+                    isinstance(arg, ast.Constant) and arg.value == "on_message"
+                    for arg in node.args
+                )
+            ):
+                findings.append(f"add_listener('on_message', ...) at line {node.lineno}")
+    return findings
+
+
+def test_btd6_does_not_install_on_message_listener() -> None:
+    """BTD6 must register via ``message_pipeline.register()`` only."""
+    violations: list[str] = []
+    for path in _btd6_files():
+        try:
+            tree = _parse(path)
+        except SyntaxError:
+            continue
+        for finding in _declares_on_message_listener(tree):
+            violations.append(f"{path.relative_to(_REPO_ROOT)}: {finding}")
+    if violations:
+        pytest.fail(
+            "BTD6 modules must not declare on_message listeners. "
+            "Register a MessageStage via core.runtime.message_pipeline.register(). "
+            "Violations:\n  " + "\n  ".join(violations),
+        )

--- a/tests/unit/runtime/ai/test_feature_flags.py
+++ b/tests/unit/runtime/ai/test_feature_flags.py
@@ -1,0 +1,64 @@
+"""Feature-flag resolution for the AI gateway."""
+
+from __future__ import annotations
+
+from core.runtime.ai.contracts import AITask
+from core.runtime.ai.feature_flags import (
+    ai_default_provider,
+    ai_enabled,
+    setup_advisor_provider,
+    task_enabled,
+)
+
+
+def test_ai_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("AI_ENABLED", raising=False)
+    assert ai_enabled() is False
+
+
+def test_ai_enabled_via_env(monkeypatch):
+    monkeypatch.setenv("AI_ENABLED", "1")
+    assert ai_enabled() is True
+    monkeypatch.setenv("AI_ENABLED", "true")
+    assert ai_enabled() is True
+    monkeypatch.setenv("AI_ENABLED", "no")
+    assert ai_enabled() is False
+
+
+def test_default_provider_falls_back_to_deterministic(monkeypatch):
+    monkeypatch.delenv("AI_DEFAULT_PROVIDER", raising=False)
+    assert ai_default_provider() == "deterministic"
+
+
+def test_default_provider_respects_env(monkeypatch):
+    monkeypatch.setenv("AI_DEFAULT_PROVIDER", "OPENAI")
+    assert ai_default_provider() == "openai"
+
+
+def test_task_disabled_when_global_off(monkeypatch):
+    monkeypatch.setenv("AI_ENABLED", "0")
+    assert task_enabled(AITask.SETUP_SUGGEST) is False
+
+
+def test_task_enabled_default_when_global_on(monkeypatch):
+    monkeypatch.setenv("AI_ENABLED", "1")
+    monkeypatch.delenv("AI_TASK_SETUP_SUGGEST_ENABLED", raising=False)
+    assert task_enabled(AITask.SETUP_SUGGEST) is True
+
+
+def test_task_can_be_individually_disabled(monkeypatch):
+    monkeypatch.setenv("AI_ENABLED", "1")
+    monkeypatch.setenv("AI_TASK_SETUP_SUGGEST_ENABLED", "0")
+    assert task_enabled(AITask.SETUP_SUGGEST) is False
+
+
+def test_setup_advisor_provider_honours_legacy_env(monkeypatch):
+    monkeypatch.setenv("SETUP_ADVISOR_PROVIDER", "openai")
+    monkeypatch.setenv("AI_DEFAULT_PROVIDER", "deterministic")
+    assert setup_advisor_provider() == "openai"
+
+
+def test_setup_advisor_provider_falls_back_to_default(monkeypatch):
+    monkeypatch.delenv("SETUP_ADVISOR_PROVIDER", raising=False)
+    monkeypatch.setenv("AI_DEFAULT_PROVIDER", "deterministic")
+    assert setup_advisor_provider() == "deterministic"

--- a/tests/unit/runtime/ai/test_gateway.py
+++ b/tests/unit/runtime/ai/test_gateway.py
@@ -1,0 +1,268 @@
+"""AIGateway pipeline tests — Module 1 of the AI/BTD6 plan.
+
+The gateway is the single chokepoint for AI provider calls. These
+tests pin the behaviour the plan requires:
+
+* Typed :class:`AIResponse` returned for every code path.
+* Degrades on provider exception (never re-raises).
+* Degrades on timeout.
+* Degrades when feature-flag is off.
+* Redaction is invoked before the provider sees the payload.
+* JSON-mode parses successfully into ``response.data``.
+* JSON-mode flags ``degraded`` on bad JSON without raising.
+* Safety prechecks short-circuit oversized payloads.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from core.runtime.ai.contracts import (
+    AIRequest,
+    AIRequestContext,
+    AIResponseMode,
+    AIScope,
+    AITask,
+)
+from core.runtime.ai.diagnostics import DiagnosticsCollector
+from core.runtime.ai.gateway import AIGateway
+from core.runtime.ai.providers.base import ProviderUnavailableError
+
+
+_DEFAULT_PAYLOAD = {"hello": "world"}
+
+
+def _make_request(
+    *,
+    mode: AIResponseMode = AIResponseMode.JSON,
+    payload: dict | None = None,
+    system_prompt: str = "Test system prompt.",
+    timeout: float = 5.0,
+) -> AIRequest:
+    return AIRequest(
+        context=AIRequestContext(
+            task=AITask.SETUP_SUGGEST,
+            scope=AIScope.ADMIN,
+            source="test",
+        ),
+        system_prompt=system_prompt,
+        payload=_DEFAULT_PAYLOAD if payload is None else payload,
+        mode=mode,
+        timeout_seconds=timeout,
+    )
+
+
+class _FakeProvider:
+    """Provider that returns a configurable text or raises."""
+
+    name = "fake"
+
+    def __init__(self, *, text: str | None = None, exc: Exception | None = None) -> None:
+        self._text = text
+        self._exc = exc
+        self.received_request: AIRequest | None = None
+        self.received_model: str | None = None
+
+    async def execute(self, request: AIRequest, *, model: str) -> str:
+        self.received_request = request
+        self.received_model = model
+        if self._exc is not None:
+            raise self._exc
+        if self._text is None:
+            raise RuntimeError("FakeProvider configured with neither text nor exc")
+        return self._text
+
+
+@pytest.fixture(autouse=True)
+def _enable_ai(monkeypatch):
+    """Module 1 ships AI disabled by default; enable for these tests."""
+    monkeypatch.setenv("AI_ENABLED", "1")
+    yield
+
+
+def _gateway_with(provider: _FakeProvider) -> tuple[AIGateway, DiagnosticsCollector]:
+    collector = DiagnosticsCollector()
+    gateway = AIGateway(providers={"fake": provider}, collector=collector)
+    return gateway, collector
+
+
+@pytest.mark.asyncio
+async def test_gateway_returns_typed_ai_response():
+    provider = _FakeProvider(text='{"answer": 42}')
+    gateway, _ = _gateway_with(provider)
+
+    request = _make_request()
+    response = await gateway.execute(request, provider_override=provider)
+
+    assert response.task is AITask.SETUP_SUGGEST
+    assert response.provider == "fake"
+    assert response.degraded is False
+    assert response.data == {"answer": 42}
+    assert response.text == '{"answer": 42}'
+
+
+@pytest.mark.asyncio
+async def test_gateway_degrades_on_provider_exception():
+    provider = _FakeProvider(exc=RuntimeError("upstream rate limit"))
+    gateway, collector = _gateway_with(provider)
+
+    response = await gateway.execute(
+        _make_request(), provider_override=provider,
+    )
+
+    assert response.degraded is True
+    assert "rate limit" in (response.fallback_reason or "")
+    snap = collector.snapshot()
+    assert snap.failures_observed == 1
+    assert snap.degraded is True
+
+
+@pytest.mark.asyncio
+async def test_gateway_degrades_on_timeout():
+    class _SlowProvider:
+        name = "fake"
+
+        async def execute(self, request: AIRequest, *, model: str) -> str:
+            await asyncio.sleep(10)  # well past the 0.05s timeout below
+            return "never"
+
+    provider = _SlowProvider()
+    gateway = AIGateway(providers={"fake": provider}, collector=DiagnosticsCollector())
+
+    request = _make_request(timeout=0.05)
+    response = await gateway.execute(request, provider_override=provider)
+
+    assert response.degraded is True
+    assert response.fallback_reason is not None
+    assert "timeout" in response.fallback_reason
+
+
+@pytest.mark.asyncio
+async def test_gateway_degrades_on_provider_unavailable():
+    provider = _FakeProvider(exc=ProviderUnavailableError("OPENAI_API_KEY missing"))
+    gateway, _ = _gateway_with(provider)
+
+    response = await gateway.execute(_make_request(), provider_override=provider)
+
+    assert response.degraded is True
+    assert "OPENAI_API_KEY missing" in (response.fallback_reason or "")
+
+
+@pytest.mark.asyncio
+async def test_gateway_redacts_payload_before_provider_call():
+    """The provider must never see un-redacted strings."""
+    provider = _FakeProvider(text='{"ok": true}')
+    gateway, _ = _gateway_with(provider)
+
+    sensitive_payload = {
+        "user_email": "alice@example.com",
+        "api_key": "sk-1234567890abcdefghi",
+        "nested": {"db_url": "postgres://user:secret@host/db"},
+    }
+    request = _make_request(payload=sensitive_payload)
+    await gateway.execute(request, provider_override=provider)
+
+    assert provider.received_request is not None
+    received = provider.received_request.payload
+    assert "alice@example.com" not in str(received)
+    assert "sk-1234567890" not in str(received)
+    assert "postgres://" not in str(received)
+
+
+@pytest.mark.asyncio
+async def test_gateway_json_mode_parses_data():
+    provider = _FakeProvider(text='{"recommendations": [{"id": 1}]}')
+    gateway, _ = _gateway_with(provider)
+
+    response = await gateway.execute(
+        _make_request(mode=AIResponseMode.JSON), provider_override=provider,
+    )
+
+    assert response.degraded is False
+    assert response.data == {"recommendations": [{"id": 1}]}
+
+
+@pytest.mark.asyncio
+async def test_gateway_json_mode_marks_degraded_on_bad_json():
+    provider = _FakeProvider(text="not actually json {{")
+    gateway, collector = _gateway_with(provider)
+
+    response = await gateway.execute(
+        _make_request(mode=AIResponseMode.JSON), provider_override=provider,
+    )
+
+    assert response.degraded is True
+    assert response.fallback_reason is not None
+    assert "invalid_json" in response.fallback_reason
+    snap = collector.snapshot()
+    assert snap.failures_observed == 1
+
+
+@pytest.mark.asyncio
+async def test_gateway_text_mode_returns_raw_text():
+    provider = _FakeProvider(text="plain prose answer")
+    gateway, _ = _gateway_with(provider)
+
+    response = await gateway.execute(
+        _make_request(mode=AIResponseMode.TEXT), provider_override=provider,
+    )
+
+    assert response.degraded is False
+    assert response.text == "plain prose answer"
+    assert response.data is None
+
+
+@pytest.mark.asyncio
+async def test_gateway_short_circuits_oversized_payload():
+    provider = _FakeProvider(text='{"ok": true}')
+    gateway, _ = _gateway_with(provider)
+
+    big = {"data": "x" * (300 * 1024)}  # 300 KiB — over the 256 KiB cap
+    request = _make_request(payload=big)
+    response = await gateway.execute(request, provider_override=provider)
+
+    assert response.degraded is True
+    assert "safety" in (response.fallback_reason or "")
+    assert provider.received_request is None  # provider never invoked
+
+
+@pytest.mark.asyncio
+async def test_gateway_short_circuits_empty_payload():
+    provider = _FakeProvider(text='{"ok": true}')
+    gateway, _ = _gateway_with(provider)
+
+    request = _make_request(payload={})
+    response = await gateway.execute(request, provider_override=provider)
+
+    assert response.degraded is True
+    assert "empty payload" in (response.fallback_reason or "")
+    assert provider.received_request is None
+
+
+@pytest.mark.asyncio
+async def test_gateway_respects_feature_flag(monkeypatch):
+    monkeypatch.setenv("AI_ENABLED", "0")
+    provider = _FakeProvider(text='{"ok": true}')
+    gateway = AIGateway(providers={"fake": provider}, collector=DiagnosticsCollector())
+
+    # No override: routing resolves to default provider, but the feature
+    # flag check should fire first and degrade without calling anyone.
+    request = _make_request()
+    response = await gateway.execute(request)
+
+    assert response.degraded is True
+    assert "feature_flag" in (response.fallback_reason or "")
+    assert provider.received_request is None
+
+
+@pytest.mark.asyncio
+async def test_gateway_provider_override_bypasses_feature_flag():
+    """provider_override is the test/test-injection seam; flag does not apply."""
+    provider = _FakeProvider(text='{"ok": true}')
+    gateway, _ = _gateway_with(provider)
+
+    response = await gateway.execute(_make_request(), provider_override=provider)
+    assert response.degraded is False
+    assert provider.received_request is not None

--- a/tests/unit/runtime/ai/test_gateway.py
+++ b/tests/unit/runtime/ai/test_gateway.py
@@ -30,7 +30,6 @@ from core.runtime.ai.diagnostics import DiagnosticsCollector
 from core.runtime.ai.gateway import AIGateway
 from core.runtime.ai.providers.base import ProviderUnavailableError
 
-
 _DEFAULT_PAYLOAD = {"hello": "world"}
 
 

--- a/tests/unit/runtime/ai/test_openai_provider.py
+++ b/tests/unit/runtime/ai/test_openai_provider.py
@@ -1,0 +1,134 @@
+"""OpenAIProvider unit tests.
+
+The provider is the only module that imports the OpenAI SDK
+directly. These tests inject a duck-typed client (``MagicMock``
+shaped like ``AsyncOpenAI``) and verify:
+
+* The provider passes the schema to ``chat.completions.create``
+  when ``AIResponseMode.JSON`` is requested.
+* It falls back to ``response_format={"type": "json_object"}``
+  when no schema is provided.
+* It raises :class:`ProviderUnavailableError` when no client and no API
+  key are available.
+* It extracts the assistant message text correctly.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from core.runtime.ai.contracts import (
+    AIRequest,
+    AIRequestContext,
+    AIResponseMode,
+    AIScope,
+    AITask,
+)
+from core.runtime.ai.providers.base import ProviderUnavailableError
+from core.runtime.ai.providers.openai_provider import OpenAIProvider
+
+
+def _response(content: str | None) -> MagicMock:
+    message = MagicMock()
+    message.content = content
+    choice = MagicMock()
+    choice.message = message
+    response = MagicMock()
+    response.choices = [choice] if content is not None else []
+    return response
+
+
+def _make_request(
+    *,
+    mode: AIResponseMode = AIResponseMode.JSON,
+    response_schema: dict | None = None,
+) -> AIRequest:
+    return AIRequest(
+        context=AIRequestContext(
+            task=AITask.SETUP_SUGGEST, scope=AIScope.ADMIN, source="test",
+        ),
+        system_prompt="system",
+        payload={"hello": "world"},
+        mode=mode,
+        response_schema=response_schema,
+    )
+
+
+@pytest.mark.asyncio
+async def test_provider_uses_json_schema_when_provided():
+    client = MagicMock()
+    client.chat = MagicMock()
+    client.chat.completions = MagicMock()
+    client.chat.completions.create = AsyncMock(
+        return_value=_response('{"ok": true}'),
+    )
+    provider = OpenAIProvider(client=client)
+
+    schema = {"name": "Recs", "schema": {"type": "object"}, "strict": True}
+    request = _make_request(response_schema=schema)
+    out = await provider.execute(request, model="gpt-4o-mini")
+
+    assert out == '{"ok": true}'
+    call_kwargs = client.chat.completions.create.await_args.kwargs
+    assert call_kwargs["model"] == "gpt-4o-mini"
+    assert call_kwargs["response_format"] == {
+        "type": "json_schema",
+        "json_schema": schema,
+    }
+
+
+@pytest.mark.asyncio
+async def test_provider_falls_back_to_json_object_without_schema():
+    client = MagicMock()
+    client.chat = MagicMock()
+    client.chat.completions = MagicMock()
+    client.chat.completions.create = AsyncMock(
+        return_value=_response('{"ok": true}'),
+    )
+    provider = OpenAIProvider(client=client)
+
+    out = await provider.execute(_make_request(), model="gpt-4o-mini")
+    assert out == '{"ok": true}'
+    call_kwargs = client.chat.completions.create.await_args.kwargs
+    assert call_kwargs["response_format"] == {"type": "json_object"}
+
+
+@pytest.mark.asyncio
+async def test_provider_text_mode_omits_response_format():
+    client = MagicMock()
+    client.chat = MagicMock()
+    client.chat.completions = MagicMock()
+    client.chat.completions.create = AsyncMock(
+        return_value=_response("plain text"),
+    )
+    provider = OpenAIProvider(client=client)
+
+    out = await provider.execute(
+        _make_request(mode=AIResponseMode.TEXT), model="gpt-4o-mini",
+    )
+    assert out == "plain text"
+    call_kwargs = client.chat.completions.create.await_args.kwargs
+    assert "response_format" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_provider_raises_provider_unavailable_without_api_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    provider = OpenAIProvider()  # no client, no api_key
+
+    with pytest.raises(ProviderUnavailableError):
+        await provider.execute(_make_request(), model="gpt-4o-mini")
+
+
+@pytest.mark.asyncio
+async def test_provider_raises_on_empty_choices():
+    client = MagicMock()
+    client.chat = MagicMock()
+    client.chat.completions = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=_response(None))
+    provider = OpenAIProvider(client=client)
+
+    with pytest.raises(RuntimeError, match="empty response"):
+        await provider.execute(_make_request(), model="gpt-4o-mini")

--- a/tests/unit/runtime/ai/test_safety_and_routing.py
+++ b/tests/unit/runtime/ai/test_safety_and_routing.py
@@ -1,0 +1,90 @@
+"""Safety prechecks and routing resolution."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.runtime.ai.contracts import (
+    AIRequest,
+    AIRequestContext,
+    AIResponseMode,
+    AIScope,
+    AITask,
+)
+from core.runtime.ai.routing import (
+    RoutingTarget,
+    clear_overrides,
+    override,
+    resolve,
+)
+from core.runtime.ai.safety import MAX_PAYLOAD_BYTES, precheck
+
+
+def _req(payload: dict, *, system: str = "system") -> AIRequest:
+    return AIRequest(
+        context=AIRequestContext(
+            task=AITask.SETUP_SUGGEST, scope=AIScope.ADMIN, source="test",
+        ),
+        system_prompt=system,
+        payload=payload,
+        mode=AIResponseMode.JSON,
+    )
+
+
+# ----- safety -----------------------------------------------------------
+
+
+def test_safety_rejects_empty_system_prompt():
+    assert precheck(_req({"ok": 1}, system="")) is not None
+    assert precheck(_req({"ok": 1}, system="   ")) is not None
+
+
+def test_safety_rejects_empty_payload():
+    assert precheck(_req({})) is not None
+
+
+def test_safety_rejects_oversized_payload():
+    big = {"data": "x" * (MAX_PAYLOAD_BYTES + 1024)}
+    result = precheck(_req(big))
+    assert result is not None
+    assert "exceeds" in result
+
+
+def test_safety_allows_normal_payload():
+    assert precheck(_req({"channels": [1, 2, 3]})) is None
+
+
+# ----- routing ----------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides_after_test():
+    yield
+    clear_overrides()
+
+
+def test_routing_default_uses_deterministic(monkeypatch):
+    monkeypatch.delenv("AI_DEFAULT_PROVIDER", raising=False)
+    monkeypatch.delenv("AI_ROUTING_SETUP_SUGGEST", raising=False)
+    target = resolve(AITask.SETUP_SUGGEST)
+    assert target.provider == "deterministic"
+    assert target.model
+    assert target.timeout_seconds > 0
+
+
+def test_routing_env_var_overrides_default(monkeypatch):
+    monkeypatch.setenv("AI_ROUTING_SETUP_SUGGEST", "openai:gpt-4o")
+    target = resolve(AITask.SETUP_SUGGEST)
+    assert target.provider == "openai"
+    assert target.model == "gpt-4o"
+
+
+def test_routing_override_takes_precedence(monkeypatch):
+    monkeypatch.setenv("AI_DEFAULT_PROVIDER", "openai")
+    override(
+        AITask.SETUP_SUGGEST,
+        RoutingTarget(provider="fake", model="fake-1", timeout_seconds=1.0),
+    )
+    target = resolve(AITask.SETUP_SUGGEST)
+    assert target.provider == "fake"
+    assert target.model == "fake-1"

--- a/tests/unit/services/test_btd6_ai_augmentation.py
+++ b/tests/unit/services/test_btd6_ai_augmentation.py
@@ -1,0 +1,183 @@
+"""BTD6 AI augmentation tests (Module 5).
+
+Pins:
+
+* When ``BTD6_AI_ENABLED`` is unset, ``augment_with_ai=True`` does
+  NOT call the gateway.
+* When ``BTD6_AI_ENABLED=1`` AND ``AI_ENABLED=1``, the gateway is
+  called with a structured deterministic payload.
+* When the gateway returns degraded, the deterministic response
+  comes back unchanged.
+* When the gateway returns a valid explanation, follow_up is
+  populated with the AI prose.
+* When the gateway raises, the deterministic response comes back
+  unchanged.
+* No provider SDK imports appear outside ``providers/`` (covered by
+  the existing invariant test).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from core.runtime.ai.contracts import (
+    AIResponse,
+    AITask,
+)
+from services import ai_gateway, btd6_ai_service
+
+
+def _ai_response(
+    *, data: dict | None = None, degraded: bool = False, reason: str | None = None,
+) -> AIResponse:
+    return AIResponse(
+        task=AITask.HELP_ANSWER,
+        provider="fake",
+        model="fake-1",
+        text=None,
+        data=data,
+        suggestions=(),
+        latency_ms=12.3,
+        degraded=degraded,
+        fallback_reason=reason,
+    )
+
+
+@pytest.mark.asyncio
+async def test_augmentation_disabled_skips_gateway(monkeypatch):
+    monkeypatch.delenv("BTD6_AI_ENABLED", raising=False)
+    monkeypatch.setenv("AI_ENABLED", "1")
+
+    spy = AsyncMock()
+    monkeypatch.setattr(ai_gateway, "execute", spy)
+
+    response = await btd6_ai_service.answer_question(
+        "Dart Monkey", augment_with_ai=True,
+    )
+
+    spy.assert_not_awaited()
+    assert "Dart Monkey" in response.title
+
+
+@pytest.mark.asyncio
+async def test_ai_platform_disabled_skips_gateway(monkeypatch):
+    monkeypatch.setenv("BTD6_AI_ENABLED", "1")
+    monkeypatch.delenv("AI_ENABLED", raising=False)
+
+    spy = AsyncMock()
+    monkeypatch.setattr(ai_gateway, "execute", spy)
+
+    response = await btd6_ai_service.answer_question(
+        "Dart Monkey", augment_with_ai=True,
+    )
+
+    spy.assert_not_awaited()
+    assert "Dart Monkey" in response.title
+
+
+@pytest.mark.asyncio
+async def test_augmentation_passes_deterministic_payload_to_gateway(monkeypatch):
+    monkeypatch.setenv("BTD6_AI_ENABLED", "1")
+    monkeypatch.setenv("AI_ENABLED", "1")
+
+    called_request: list = []
+
+    async def _capture(request):
+        called_request.append(request)
+        return _ai_response(data={"explanation": "Dart Monkey is the cheapest."})
+
+    monkeypatch.setattr(ai_gateway, "execute", _capture)
+
+    response = await btd6_ai_service.answer_question(
+        "Dart Monkey", augment_with_ai=True,
+    )
+
+    assert len(called_request) == 1
+    payload = called_request[0].payload
+    # Provider sees the resolved IDs, not raw user prose verbatim.
+    assert "deterministic_answer" in payload
+    assert "query_summary" in payload
+    assert "dart_monkey" in payload["query_summary"]["resolved_towers"]
+    # Augmentation appended.
+    assert "cheapest" in response.follow_up.lower()
+
+
+@pytest.mark.asyncio
+async def test_gateway_degraded_returns_deterministic(monkeypatch):
+    monkeypatch.setenv("BTD6_AI_ENABLED", "1")
+    monkeypatch.setenv("AI_ENABLED", "1")
+
+    async def _degraded(_request):
+        return _ai_response(degraded=True, reason="timeout:5s")
+
+    monkeypatch.setattr(ai_gateway, "execute", _degraded)
+
+    response = await btd6_ai_service.answer_question(
+        "Dart Monkey", augment_with_ai=True,
+    )
+    # Deterministic follow_up untouched.
+    assert "Ask about a specific upgrade tier" in (response.follow_up or "")
+
+
+@pytest.mark.asyncio
+async def test_gateway_exception_returns_deterministic(monkeypatch):
+    monkeypatch.setenv("BTD6_AI_ENABLED", "1")
+    monkeypatch.setenv("AI_ENABLED", "1")
+
+    async def _raise(_request):
+        raise RuntimeError("network blip")
+
+    monkeypatch.setattr(ai_gateway, "execute", _raise)
+
+    response = await btd6_ai_service.answer_question(
+        "Dart Monkey", augment_with_ai=True,
+    )
+    assert "Dart Monkey" in response.title
+
+
+@pytest.mark.asyncio
+async def test_gateway_invalid_payload_returns_deterministic(monkeypatch):
+    """Missing 'explanation' key or non-string → deterministic baseline."""
+    monkeypatch.setenv("BTD6_AI_ENABLED", "1")
+    monkeypatch.setenv("AI_ENABLED", "1")
+
+    async def _bad(_request):
+        return _ai_response(data={"unexpected": "shape"})
+
+    monkeypatch.setattr(ai_gateway, "execute", _bad)
+
+    response = await btd6_ai_service.answer_question(
+        "Dart Monkey", augment_with_ai=True,
+    )
+    assert "Ask about a specific upgrade tier" in (response.follow_up or "")
+
+
+@pytest.mark.asyncio
+async def test_empty_explanation_does_not_overwrite_follow_up(monkeypatch):
+    monkeypatch.setenv("BTD6_AI_ENABLED", "1")
+    monkeypatch.setenv("AI_ENABLED", "1")
+
+    async def _empty(_request):
+        return _ai_response(data={"explanation": "   "})
+
+    monkeypatch.setattr(ai_gateway, "execute", _empty)
+
+    response = await btd6_ai_service.answer_question(
+        "Dart Monkey", augment_with_ai=True,
+    )
+    assert "Ask about a specific upgrade tier" in (response.follow_up or "")
+
+
+@pytest.mark.asyncio
+async def test_default_path_does_not_call_gateway(monkeypatch):
+    """augment_with_ai defaults to False; never call the gateway."""
+    monkeypatch.setenv("BTD6_AI_ENABLED", "1")
+    monkeypatch.setenv("AI_ENABLED", "1")
+
+    spy = AsyncMock()
+    monkeypatch.setattr(ai_gateway, "execute", spy)
+
+    await btd6_ai_service.answer_question("Dart Monkey")
+    spy.assert_not_awaited()

--- a/tests/unit/services/test_btd6_ai_service.py
+++ b/tests/unit/services/test_btd6_ai_service.py
@@ -1,0 +1,46 @@
+"""BTD6 orchestrator tests — deterministic-only mode (Modules 3+4)."""
+
+from __future__ import annotations
+
+import pytest
+
+from services.btd6_ai_service import answer_question, deterministic_answer
+from services.btd6_resolver_service import resolve
+
+
+def test_deterministic_answer_for_tower_intent():
+    intent = resolve("Dart Monkey costs how much?")
+    response = deterministic_answer(intent)
+    assert "Dart Monkey" in response.title
+    assert response.confidence == "high"
+    assert response.sources  # at least one source label
+
+
+def test_deterministic_answer_for_round_intent():
+    intent = resolve("any tips for round 63?")
+    response = deterministic_answer(intent)
+    assert "Round 63" in response.title
+    assert response.confidence == "high"
+
+
+def test_unresolved_intent_yields_helpful_response():
+    intent = resolve("anyway, hello there friend")
+    response = deterministic_answer(intent)
+    assert response.confidence == "low"
+    assert "couldn" in response.short_answer.lower()
+
+
+@pytest.mark.asyncio
+async def test_answer_question_runs_without_ai_gateway():
+    """Default path (no AI augmentation) must not call the gateway."""
+    response = await answer_question("Sauda on round 28")
+    assert "Sauda" in response.title
+
+
+@pytest.mark.asyncio
+async def test_augment_with_ai_falls_through_to_module_5_stub():
+    """Module 3+4: augmentation is a no-op stub. Same shape returns."""
+    base = await answer_question("Boomerang Monkey", augment_with_ai=False)
+    augmented = await answer_question("Boomerang Monkey", augment_with_ai=True)
+    assert augmented.title == base.title
+    assert augmented.short_answer == base.short_answer

--- a/tests/unit/services/test_btd6_data_service.py
+++ b/tests/unit/services/test_btd6_data_service.py
@@ -8,8 +8,8 @@ from pathlib import Path
 import pytest
 
 from services.btd6_data_service import (
-    BTD6DataValidationError,
     DATA_ROOT,
+    BTD6DataValidationError,
     get_dataset,
     reset_cache,
 )

--- a/tests/unit/services/test_btd6_data_service.py
+++ b/tests/unit/services/test_btd6_data_service.py
@@ -1,0 +1,143 @@
+"""Validation tests for the BTD6 deterministic dataset."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from services.btd6_data_service import (
+    BTD6DataValidationError,
+    DATA_ROOT,
+    get_dataset,
+    reset_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_dataset_cache():
+    """Each test starts from a fresh dataset load."""
+    reset_cache()
+    yield
+    reset_cache()
+
+
+def test_dataset_loads_with_metadata():
+    dataset = get_dataset()
+    assert dataset.data_version
+    assert dataset.game_version
+    for category in ("towers", "heroes", "maps", "modes", "rounds"):
+        assert category in dataset.sources, f"missing source for {category}"
+
+
+def test_dataset_has_representative_entries():
+    dataset = get_dataset()
+    assert len(dataset.towers) >= 4
+    assert len(dataset.heroes) >= 2
+    assert len(dataset.maps) >= 3
+    assert len(dataset.modes) >= 2
+    assert len(dataset.rounds) >= 5
+
+
+def test_tower_upgrade_paths_have_five_tiers():
+    dataset = get_dataset()
+    for tower in dataset.towers:
+        for path_name, tiers in tower.upgrade_paths.items():
+            assert len(tiers) == 5, (
+                f"{tower.id}.{path_name} should have 5 tiers, got {len(tiers)}"
+            )
+
+
+def test_chimps_mode_has_no_income_restriction():
+    dataset = get_dataset()
+    chimps = next((m for m in dataset.modes if m.id == "chimps"), None)
+    assert chimps is not None, "CHIMPS mode must be in the fixture"
+    assert any("income" in r.lower() or "farm" in r.lower() for r in chimps.restrictions)
+
+
+def test_alias_collision_fails_loudly(tmp_path):
+    """A duplicate alias across categories must abort dataset loading."""
+    bad_root = tmp_path / "btd6"
+    bad_root.mkdir()
+    for filename in ("towers", "heroes", "maps", "modes", "rounds"):
+        source = DATA_ROOT / f"{filename}.json"
+        target = bad_root / f"{filename}.json"
+        target.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+
+    # Inject a colliding alias: make a hero alias collide with a tower alias.
+    heroes_path = bad_root / "heroes.json"
+    heroes = json.loads(heroes_path.read_text(encoding="utf-8"))
+    heroes["heroes"][0]["aliases"].append("dart")  # collides with Dart Monkey
+    heroes_path.write_text(json.dumps(heroes), encoding="utf-8")
+
+    # Point the loader at the broken copy by patching DATA_ROOT.
+    import services.btd6_data_service as data_service
+
+    original = data_service.DATA_ROOT
+    data_service.DATA_ROOT = bad_root
+    try:
+        reset_cache()
+        with pytest.raises(BTD6DataValidationError, match="alias collision"):
+            get_dataset()
+    finally:
+        data_service.DATA_ROOT = original
+        reset_cache()
+
+
+def test_duplicate_canonical_name_fails_loudly(tmp_path):
+    """Two towers with the same canonical name must fail validation."""
+    bad_root = tmp_path / "btd6"
+    bad_root.mkdir()
+    for filename in ("towers", "heroes", "maps", "modes", "rounds"):
+        source = DATA_ROOT / f"{filename}.json"
+        target = bad_root / f"{filename}.json"
+        target.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+
+    towers_path = bad_root / "towers.json"
+    towers = json.loads(towers_path.read_text(encoding="utf-8"))
+    # Duplicate canonical name with a different id.
+    clone = dict(towers["towers"][0])
+    clone["id"] = "dart_monkey_copy"
+    clone["aliases"] = ["dart-monkey-copy-alias"]
+    towers["towers"].append(clone)
+    towers_path.write_text(json.dumps(towers), encoding="utf-8")
+
+    import services.btd6_data_service as data_service
+
+    original = data_service.DATA_ROOT
+    data_service.DATA_ROOT = bad_root
+    try:
+        reset_cache()
+        with pytest.raises(BTD6DataValidationError, match="duplicate"):
+            get_dataset()
+    finally:
+        data_service.DATA_ROOT = original
+        reset_cache()
+
+
+def test_missing_required_field_fails_loudly(tmp_path):
+    """A tower entry missing required fields must fail validation."""
+    bad_root = tmp_path / "btd6"
+    bad_root.mkdir()
+    for filename in ("towers", "heroes", "maps", "modes", "rounds"):
+        source = DATA_ROOT / f"{filename}.json"
+        target = bad_root / f"{filename}.json"
+        target.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+
+    towers_path = bad_root / "towers.json"
+    towers = json.loads(towers_path.read_text(encoding="utf-8"))
+    del towers["towers"][0]["base_cost"]
+    towers_path.write_text(json.dumps(towers), encoding="utf-8")
+
+    import services.btd6_data_service as data_service
+
+    original = data_service.DATA_ROOT
+    data_service.DATA_ROOT = bad_root
+    try:
+        reset_cache()
+        with pytest.raises(BTD6DataValidationError, match="missing required"):
+            get_dataset()
+    finally:
+        data_service.DATA_ROOT = original
+        reset_cache()

--- a/tests/unit/services/test_btd6_knowledge_service.py
+++ b/tests/unit/services/test_btd6_knowledge_service.py
@@ -1,0 +1,61 @@
+"""Knowledge-service tests."""
+
+from __future__ import annotations
+
+from services.btd6_knowledge_service import (
+    data_version,
+    game_version,
+    hero_fact,
+    list_modes,
+    list_rounds,
+    map_fact,
+    mode_fact,
+    round_fact,
+    tower_fact,
+)
+
+
+def test_tower_fact_returns_costs_and_paths():
+    fact = tower_fact("dart_monkey")
+    assert fact is not None
+    assert fact.base_cost == 200
+    assert "top" in fact.upgrade_paths
+    assert len(fact.upgrade_paths["top"]) == 5
+
+
+def test_unknown_tower_returns_none():
+    assert tower_fact("not_a_real_tower") is None
+
+
+def test_hero_fact_has_abilities():
+    quincy = hero_fact("quincy")
+    assert quincy is not None
+    assert len(quincy.abilities) >= 1
+
+
+def test_map_fact_includes_difficulty():
+    logs = map_fact("logs")
+    assert logs is not None
+    assert logs.difficulty
+
+
+def test_mode_fact_chimps_includes_restrictions():
+    chimps = mode_fact("chimps")
+    assert chimps is not None
+    assert any("no income" in r.lower() or "no powers" in r.lower() for r in chimps.restrictions)
+
+
+def test_round_fact_includes_threats():
+    fact = round_fact(63)
+    assert fact is not None
+    assert "Ceramic" in fact.common_threats or "Camo Lead" in fact.common_threats
+
+
+def test_version_accessors():
+    assert data_version()
+    assert game_version()
+
+
+def test_list_accessors_return_tuples():
+    assert isinstance(list_modes(), tuple)
+    assert isinstance(list_rounds(), tuple)

--- a/tests/unit/services/test_btd6_resolver_service.py
+++ b/tests/unit/services/test_btd6_resolver_service.py
@@ -1,0 +1,64 @@
+"""Resolver-service tests — deterministic NL → intent."""
+
+from __future__ import annotations
+
+from services.btd6_resolver_service import resolve
+
+
+def test_resolves_dart_monkey_by_canonical_name():
+    intent = resolve("Tell me about the Dart Monkey")
+    assert any(t.id == "dart_monkey" for t in intent.towers)
+    assert intent.confidence > 0.0
+
+
+def test_resolves_dart_monkey_by_alias():
+    intent = resolve("Is the dart good vs ceramics?")
+    assert any(t.id == "dart_monkey" for t in intent.towers)
+
+
+def test_resolves_round_number():
+    intent = resolve("How do I survive round 63?")
+    assert 63 in intent.candidate_round_numbers
+    assert any(r.round_number == 63 for r in intent.rounds)
+
+
+def test_resolves_short_round_form():
+    intent = resolve("any tips for r78?")
+    assert 78 in intent.candidate_round_numbers
+
+
+def test_resolves_chimps_mode_alias():
+    intent = resolve("What's a good CHIMPS start?")
+    assert any(m.id == "chimps" for m in intent.modes)
+
+
+def test_resolves_multiple_entities_boosts_confidence():
+    single = resolve("Dart Monkey")
+    triple = resolve("Dart Monkey on Logs in CHIMPS on round 28")
+    assert triple.confidence >= single.confidence
+    assert triple.confidence > 0.5
+
+
+def test_no_matches_returns_zero_confidence():
+    intent = resolve("hello there friend")
+    assert intent.confidence == 0.0
+    assert not intent.towers and not intent.rounds
+
+
+def test_empty_input_returns_zero_confidence():
+    intent = resolve("")
+    assert intent.confidence == 0.0
+
+
+def test_round_filter_drops_unknown_round():
+    intent = resolve("round 200")  # outside the representative fixture
+    assert 200 in intent.candidate_round_numbers
+    # No matching round in the fixture → empty rounds tuple.
+    assert not intent.rounds
+
+
+def test_resolver_is_case_insensitive():
+    upper = resolve("DART MONKEY ON LOGS")
+    lower = resolve("dart monkey on logs")
+    assert {t.id for t in upper.towers} == {t.id for t in lower.towers}
+    assert {m.id for m in upper.maps} == {m.id for m in lower.maps}

--- a/tests/unit/services/test_setup_ai_advisor_via_gateway.py
+++ b/tests/unit/services/test_setup_ai_advisor_via_gateway.py
@@ -1,0 +1,66 @@
+"""Module-1 invariant: the setup advisor consumes the AI gateway.
+
+Two checks:
+
+* AST scan — ``setup_ai_advisor`` must not import the ``openai`` SDK
+  directly anymore. The provider chokepoint owns that import.
+* Behavioural — when ``OpenAISetupAdvisor.suggest`` runs, the
+  gateway's ``execute`` path is invoked (proven by an injected
+  duck-typed client appearing as the provider override).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from services.guild_snapshot import GuildSnapshot
+from services.setup_ai_advisor import OpenAISetupAdvisor
+
+
+def test_setup_ai_advisor_does_not_import_openai_sdk():
+    """Module 1 moves the OpenAI SDK import into the provider package."""
+    path = Path(__file__).resolve().parents[3] / "disbot" / "services" / "setup_ai_advisor.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "openai":
+            pytest.fail(
+                f"services/setup_ai_advisor.py imports openai at line "
+                f"{node.lineno}; it must consume the gateway instead.",
+            )
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "openai":
+                    pytest.fail(
+                        f"services/setup_ai_advisor.py imports openai at line "
+                        f"{node.lineno}; it must consume the gateway instead.",
+                    )
+
+
+@pytest.mark.asyncio
+async def test_setup_advisor_routes_through_gateway():
+    """The injected client must end up driving the OpenAIProvider call."""
+    fake_client = MagicMock()
+    fake_client.chat = MagicMock()
+    fake_client.chat.completions = MagicMock()
+    fake_response = MagicMock()
+    fake_message = MagicMock()
+    fake_message.content = '{"recommendations": []}'
+    fake_choice = MagicMock()
+    fake_choice.message = fake_message
+    fake_response.choices = [fake_choice]
+    fake_client.chat.completions.create = AsyncMock(return_value=fake_response)
+
+    advisor = OpenAISetupAdvisor(client=fake_client, api_key="sk-test")
+    snap = GuildSnapshot(guild_id=1, guild_name="X", owner_id=9)
+
+    draft = await advisor.suggest(snap)
+
+    # The fake client's chat.completions.create was awaited exactly once —
+    # proving the gateway → OpenAIProvider → client.chat.completions
+    # chain runs end-to-end.
+    fake_client.chat.completions.create.assert_awaited_once()
+    assert draft.source == "openai"


### PR DESCRIPTION
## Summary

Lands the "Separate AI Cog + BTD6 Cog, Shared AI Platform Helpers" plan,
end-to-end. Every module is independently testable; the branch boots cleanly
with no API keys.

**Plan progress: 6 of 7 modules complete (Module 7 is intentionally deferred).**

| # | Module | State |
|---|---|---|
| 0 | Guardrails & invariant tests | ✅ landed (`b9d6734`) |
| 1 | AI gateway + setup advisor migration | ✅ landed (`dbc96f1`) |
| 2 | AI Platform Cog (read-only diagnostics) | ✅ landed (`3637a6c`) |
| 3 | BTD6 deterministic data + services | ✅ landed (`21751b3`) |
| 4 | BTD6 Cog command MVP (full INV-B) | ✅ landed (`8f567ef`) |
| 5 | Optional BTD6 AI augmentation via gateway | ✅ landed (`fefd514`) |
| 6 | Passive BTD6 message-pipeline stage | ✅ landed (`2055eaf`) |
| 7 | Live sources / cache / patches / YouTube / support flow | ⏸ deferred by plan |

## What this PR adds

- **AI gateway** (`disbot/core/runtime/ai/`) — provider-neutral chokepoint with
  feature flags, routing, safety prechecks, redaction, timeout, metrics, and
  typed degraded responses. Provider SDK imports (`openai`/`anthropic`) are
  confined to `core/runtime/ai/providers/`.
- **Setup advisor migration** — `services/setup_ai_advisor.py` no longer
  imports the OpenAI SDK directly; the existing public API and all 20 legacy
  tests continue to work unchanged.
- **AI Cog** — new admin-tier subsystem `ai` with `!ai status`,
  `!ai diagnostics`, `!ai providers`, `!ai routing`, plus slash equivalents
  and a `PersistentView`. Read-only.
- **BTD6 deterministic backbone** — validated fixtures
  (`disbot/data/btd6/*.json`), data/resolver/knowledge/response/orchestrator
  services. Representative scope (4 towers, 2 heroes, 3 maps, 2 modes, 10
  rounds); expandable without architectural change.
- **BTD6 Cog** — new user-tier subsystem `btd6` under the Games hub with
  status/diagnostics/ask/tower/hero/round/test-intent commands, slash forms,
  panel with an `Ask` modal, setup section.
- **AI augmentation for BTD6** — gated by `BTD6_AI_ENABLED` AND `AI_ENABLED`
  AND the per-task flag. AI receives structured deterministic context (never
  raw user prose); any failure mode returns the deterministic baseline.
- **Passive message stage** — `cogs/btd6/stage.py` registered via
  `message_pipeline.register` in `cog_load` / `unregister` in `cog_unload`.
  Default off. Skip stack covers bots, webhooks, system messages, command
  prefix, empty content, disabled flag, unconfigured channels, already-handled
  metadata, cooldown, low confidence. `!btd6 why-no-response` exposes recent
  skip reasons without leaking message content.

## Boundary guarantees (enforced by AST invariant tests)

- ✅ `from openai` / `from anthropic` only inside `core/runtime/ai/providers/`
- ✅ `core/runtime/ai/` never imports cogs or BTD6 services
- ✅ `services/ai_*.py` never imports BTD6 services
- ✅ `cogs/btd6*` / `services/btd6_*.py` never import the AI cog
- ✅ No `on_message` handlers declared in BTD6 modules — the pipeline is the
  only entry point

## Compatibility

- Setup advisor public API (`build_advisor`, `OpenAISetupAdvisor`,
  `SetupAdvisor` protocol, `KNOWN_PROVIDERS`, etc.) is unchanged.
- All 20 existing `test_setup_ai_advisor.py` cases pass without modification.
- `SETUP_ADVISOR_PROVIDER` remains the authoritative env var for the setup
  advisor; new `AI_ENABLED` / `AI_DEFAULT_PROVIDER` are additive.

## Tests

- Full unit suite: **4288 passed, 3 skipped, 0 failed** (~43 s).
- New tests (104 cases total across the 6 modules), grouped:
  - 5 boundary invariants (`tests/unit/invariants/test_ai_btd6_boundaries.py`)
  - 32 AI runtime (`tests/unit/runtime/ai/`)
  - 2 setup-advisor-via-gateway (`tests/unit/services/test_setup_ai_advisor_via_gateway.py`)
  - 11 AI Cog (`tests/unit/cogs/test_ai_cog.py`)
  - 30 BTD6 services
  - 11 BTD6 Cog
  - 8 BTD6 AI augmentation
  - 12 BTD6 passive stage
- Pinned doc tests (`help-command-surface-map`,
  `settings-customization-command-map`, help-actionability-contract,
  hub-registry) updated and green.

## Test plan

- [ ] Smoke-test the bot in a staging guild with no AI keys configured.
- [ ] Confirm `!ai status` renders the deterministic provider summary.
- [ ] Confirm `!btd6 ask "Dart Monkey on round 63"` returns a deterministic
      answer.
- [ ] With `AI_ENABLED=1 AI_DEFAULT_PROVIDER=openai OPENAI_API_KEY=...` set,
      re-run setup advisor and confirm the gateway path is active.
- [ ] With `BTD6_PASSIVE_ENABLED=1 BTD6_PASSIVE_CHANNELS=<id>`, post a BTD6
      question in the configured channel and confirm the assistant replies
      via the pipeline stage (not a duplicate listener).
- [ ] Run `!btd6 why-no-response` in a non-configured channel after posting,
      and confirm only skip-reason codes are reported (no message body).

## What's intentionally NOT in this PR (deferred Module 7)

- Live source fetching (`btd6_source_service.py`, `btd6_fetch_service.py`)
- Source-cache DB tables (`btd6_cache_service.py`)
- Patch/version live refresh
- Support report flow + DB tables
- YouTube discovery + community content as source-of-truth
- Saved-strategy library, team event planning, email delivery
- Per-guild BTD6 settings persisted via SubsystemSchema (deferred to a
  follow-up; Module 6 uses env-var gating for now per the plan's
  "no new persistence path" rule)

https://claude.ai/code/session_01K6UhwdcPEx1ToHnnG3E6aU

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6UhwdcPEx1ToHnnG3E6aU)_