### PR TITLE
Fix AI panel interaction routing and audit display (PR1)

### DIFF
--- a/disbot/cogs/ai_cog.py
+++ b/disbot/cogs/ai_cog.py
@@ -179,11 +179,46 @@ class AICog(commands.Cog):
 
         message_pipeline.register(get_stage())
 
+        # Claim the "ai" prefix on the interaction router so button
+        # clicks from views.ai.panel.AIPanelView don't emit
+        # "Unhandled interaction prefix 'ai'" warnings. The View's own
+        # @discord.ui.button callbacks remain the primary dispatcher;
+        # the router handler is a safety net that bails when
+        # interaction.response.is_done() is true.
+        #
+        # interaction_router has no unregister() API; registrations are
+        # process-lifetime. The guard below makes cog_load idempotent so
+        # repeated reloads do not trigger spurious overwrite WARNINGs
+        # and do not silently replace a handler set by another path.
+        from core.runtime import interaction_router
+        from views.ai.panel import AI_ROUTER_PREFIX, handle_ai_interaction
+
+        existing = interaction_router._handlers.get(AI_ROUTER_PREFIX)
+        if existing is handle_ai_interaction:
+            pass  # already registered to the correct handler; skip
+        elif existing is not None:
+            logger.warning(
+                "AICog.cog_load: replacing unexpected handler for "
+                "interaction-router prefix %r",
+                AI_ROUTER_PREFIX,
+            )
+            interaction_router.register(AI_ROUTER_PREFIX, handle_ai_interaction)
+        else:
+            interaction_router.register(AI_ROUTER_PREFIX, handle_ai_interaction)
+
     async def cog_unload(self) -> None:
         from core.runtime import message_pipeline
         from core.runtime.ai.natural_language_stage import STAGE_NAME
 
         message_pipeline.unregister(STAGE_NAME)
+
+        # interaction_router exposes no unregister() API — the module-level
+        # _handlers dict holds registrations for the lifetime of the
+        # process by design. We cannot remove the "ai" prefix here. The
+        # handler reference remains valid because it dispatches to
+        # module-level build_* functions that stay importable. On reload,
+        # cog_load's idempotency guard detects that the handler is already
+        # handle_ai_interaction and skips re-registration.
 
     # ------------------------------------------------------------------
     # Prefix commands — `!ai`, `!ai status`, `!ai diagnostics`, ...

--- a/disbot/cogs/ai_cog.py
+++ b/disbot/cogs/ai_cog.py
@@ -16,6 +16,7 @@ and a parallel ``app_commands`` family with the same gating. The
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import discord
@@ -27,6 +28,45 @@ from services import ai_diagnostics_service
 from views.ai.panel import AIPanelView, build_ai_panel_embed
 
 logger = logging.getLogger("bot")
+
+
+def _relative_time(ts: datetime, *, now: datetime | None = None) -> str:
+    """Format ``ts`` as a relative-time string like ``"2m ago"``.
+
+    Returns ``"in the future"`` if ``ts`` is later than ``now``; the
+    audit table writes ``created_at`` server-side so this should not
+    happen in practice, but the renderer must not raise on clock skew.
+    """
+    reference = now or datetime.now(timezone.utc)
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    delta = (reference - ts).total_seconds()
+    if delta < 0:
+        return "in the future"
+    if delta < 60:
+        return f"{int(delta)}s ago"
+    if delta < 3600:
+        return f"{int(delta // 60)}m ago"
+    if delta < 86400:
+        return f"{int(delta // 3600)}h ago"
+    return f"{int(delta // 86400)}d ago"
+
+
+def _format_audit_row(row: dict) -> str:
+    """Format one ``ai_decision_audit`` row for the why-no-response embed.
+
+    Includes relative timestamp, decision, reason_code, task, route,
+    channel link, user mention, provider, model. No raw message content
+    is rendered (the audit table does not store any).
+    """
+    created_at = row.get("created_at")
+    when = _relative_time(created_at) if isinstance(created_at, datetime) else "—"
+    return (
+        f"`{when:<8}` · `{row['decision']:<8}` · `{row['reason_code']}` · "
+        f"task={row.get('task') or '—'} · route={row.get('route') or '—'} · "
+        f"<#{row['channel_id']}> · <@{row['user_id']}> · "
+        f"provider={row.get('provider') or '—'} model={row.get('model') or '—'}"
+    )
 
 
 async def _build_ai_settings_panel(
@@ -264,17 +304,27 @@ class AICog(commands.Cog):
             r
             for r in rows
             if r["decision"] in ("denied", "skipped", "errored", "degraded")
-        ]
+        ][:25]
         if not denials:
             await ctx.send("No recent denials or skips for this guild.")
             return
-        lines = [
-            f"`{r['decision']:<8}` `{r['reason_code']}` · "
-            f"channel=<#{r['channel_id']}> · user=<@{r['user_id']}> · "
-            f"task={r.get('task') or '—'}"
-            for r in denials[:25]
-        ]
-        await ctx.send("\n".join(lines))
+        lines = [_format_audit_row(r) for r in denials]
+        embed = discord.Embed(
+            title="AI — why no response",
+            description="\n".join(lines),
+            color=discord.Color.orange(),
+        )
+        oldest = denials[-1].get("created_at")
+        if isinstance(oldest, datetime):
+            embed.set_footer(
+                text=(
+                    f"Showing {len(denials)} most recent · "
+                    f"oldest: {oldest.isoformat()}"
+                ),
+            )
+        else:
+            embed.set_footer(text=f"Showing {len(denials)} most recent")
+        await ctx.send(embed=embed)
 
     @ai_group.command(name="policy")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)

--- a/disbot/services/ai_permission_service.py
+++ b/disbot/services/ai_permission_service.py
@@ -14,6 +14,8 @@ import time
 from collections import defaultdict
 from dataclasses import dataclass
 
+import asyncpg
+
 logger = logging.getLogger("bot.services.ai_permission")
 
 
@@ -40,6 +42,11 @@ async def snapshot(guild_id: int, user_id: int) -> UserPermissionSnapshot:
     user with no XP row yet is treated as level 0 and ``is_fresh_user
     = True``; the cooldown / mention-allowance rules in the resolver
     decide whether that prevents a reply.
+
+    Only real DB-layer failures are caught — programming errors
+    (AttributeError, TypeError, ImportError, …) propagate so they
+    surface during development rather than silently downgrading every
+    permission check to "fresh user, level 0".
     """
     level = 0
     is_fresh = True
@@ -48,15 +55,15 @@ async def snapshot(guild_id: int, user_id: int) -> UserPermissionSnapshot:
 
         record = await xp_service.get_user_record(guild_id, user_id)
         if record is not None:
-            level = int(getattr(record, "level", 0) or 0)
-            is_fresh = level == 0 and int(getattr(record, "xp", 0) or 0) == 0
-    except Exception as exc:  # noqa: BLE001 — defensive
-        logger.debug(
-            "ai_permission_service: xp lookup failed (%s); treating "
-            "guild=%s user=%s as fresh",
-            exc,
+            level = record.level
+            is_fresh = record.level == 0 and record.xp == 0
+    except (asyncpg.PostgresError, ConnectionError, TimeoutError, OSError) as exc:
+        logger.warning(
+            "ai_permission_service: xp lookup failed guild=%s user=%s "
+            "exc_type=%s; treating as fresh user (level=0)",
             guild_id,
             user_id,
+            type(exc).__name__,
         )
     return UserPermissionSnapshot(
         user_id=user_id,

--- a/disbot/services/xp_service.py
+++ b/disbot/services/xp_service.py
@@ -49,6 +49,36 @@ class XpAward:
     source: str
 
 
+@dataclass(frozen=True)
+class UserXPRecord:
+    """Typed read-only view of an XP row for permission/level checks."""
+
+    xp: int
+    level: int
+    messages: int
+
+
+async def get_user_record(
+    guild_id: int,
+    user_id: int,
+) -> UserXPRecord | None:
+    """Return the typed XP record for ``user_id`` in ``guild_id``.
+
+    ``utils.db.xp.get_xp`` synthesises an all-zeros dict when no row
+    exists; ``add_xp`` always inserts ``messages=1`` on first grant, so
+    ``messages == 0`` distinguishes the synthesised sentinel from any
+    real row. Returns ``None`` for that sentinel so callers can branch
+    on "no row yet" without inspecting fields.
+    """
+    row = await db.get_xp(user_id, guild_id)
+    messages = int(row.get("messages", 0) or 0)
+    xp = int(row.get("xp", 0) or 0)
+    level = int(row.get("level", 0) or 0)
+    if messages == 0 and xp == 0 and level == 0:
+        return None
+    return UserXPRecord(xp=xp, level=level, messages=messages)
+
+
 async def award(
     guild_id: int,
     user_id: int,

--- a/disbot/views/ai/panel.py
+++ b/disbot/views/ai/panel.py
@@ -6,20 +6,31 @@ small. Importing this module triggers the ``@register`` decorator
 on :class:`AIPanelView` so the persistent-view registry sees the
 ``ai`` subsystem before ``on_ready`` runs ``restore_anchors``.
 
-Custom_ids use the ``ai:<action>`` prefix. The cog wires a single
-interaction-router handler for prefix ``ai`` that dispatches to
-embed-building helpers in :mod:`services.ai_diagnostics_service` —
-no provider logic ever runs from a button.
+Custom_ids use the ``ai:<action>`` prefix. ``AICog.cog_load``
+registers :func:`handle_ai_interaction` with
+:mod:`core.runtime.interaction_router` so the router does not log
+"Unhandled interaction prefix 'ai'" warnings when a button is
+clicked. The View's own ``@discord.ui.button`` callbacks remain the
+primary dispatcher for ``PersistentView`` buttons; the router
+handler is a safety net that bails immediately when
+``interaction.response.is_done()`` is true.
 """
 
 from __future__ import annotations
+
+import logging
+from typing import Any
 
 import discord
 
 from core.runtime.persistent_views import PersistentView, register
 from services import ai_diagnostics_service
 
+logger = logging.getLogger("bot.views.ai.panel")
+
 _PANEL_COLOR = discord.Color.blurple()
+
+AI_ROUTER_PREFIX = "ai"
 
 
 def build_ai_panel_embed() -> discord.Embed:
@@ -113,7 +124,8 @@ class AIPanelView(PersistentView):
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        await interaction.response.edit_message(embed=build_ai_panel_embed(), view=self)
+        embed = _embed_for_ai_panel_action("refresh")
+        await interaction.response.edit_message(embed=embed, view=self)
 
     @discord.ui.button(
         label="Diagnostics",
@@ -126,12 +138,8 @@ class AIPanelView(PersistentView):
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        from cogs.ai_cog import build_diagnostics_embed
-
-        await interaction.response.edit_message(
-            embed=build_diagnostics_embed(),
-            view=self,
-        )
+        embed = _embed_for_ai_panel_action("diagnostics")
+        await interaction.response.edit_message(embed=embed, view=self)
 
     @discord.ui.button(
         label="Providers",
@@ -144,12 +152,8 @@ class AIPanelView(PersistentView):
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        from cogs.ai_cog import build_providers_embed
-
-        await interaction.response.edit_message(
-            embed=build_providers_embed(),
-            view=self,
-        )
+        embed = _embed_for_ai_panel_action("providers")
+        await interaction.response.edit_message(embed=embed, view=self)
 
     @discord.ui.button(
         label="Routing",
@@ -162,12 +166,8 @@ class AIPanelView(PersistentView):
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        from cogs.ai_cog import build_routing_embed
-
-        await interaction.response.edit_message(
-            embed=build_routing_embed(),
-            view=self,
-        )
+        embed = _embed_for_ai_panel_action("routing")
+        await interaction.response.edit_message(embed=embed, view=self)
 
     @discord.ui.button(
         label="Settings",
@@ -181,6 +181,9 @@ class AIPanelView(PersistentView):
         _: discord.ui.Button,
     ) -> None:
         # M1: open the AI subsystem settings panel in place.
+        # Settings is the only action that requires an async call —
+        # _embed_for_ai_panel_action handles the four sync actions; this
+        # branch is special-cased here and in handle_ai_interaction below.
         from cogs.ai_cog import _build_ai_settings_panel
 
         embed, view = await _build_ai_settings_panel(
@@ -188,3 +191,97 @@ class AIPanelView(PersistentView):
             interaction.guild_id,
         )
         await interaction.response.edit_message(embed=embed, view=view)
+
+
+# ---------------------------------------------------------------------------
+# Shared dispatch + interaction-router handler
+# ---------------------------------------------------------------------------
+
+
+def _embed_for_ai_panel_action(action: str) -> discord.Embed | None:
+    """Single source of truth for sync AI panel action → embed mapping.
+
+    Returns the embed for refresh / diagnostics / providers / routing.
+    Returns ``None`` for "settings" (async, special-cased by callers) and
+    for unknown actions. Callers decide which ``view`` to attach (the
+    View buttons reuse ``self``; the router handler creates a fresh
+    ``AIPanelView()``).
+    """
+    if action == "refresh":
+        return build_ai_panel_embed()
+    # Lazy imports keep this module importable from cogs.ai_cog without
+    # introducing a circular dependency at module load time.
+    if action == "diagnostics":
+        from cogs.ai_cog import build_diagnostics_embed
+
+        return build_diagnostics_embed()
+    if action == "providers":
+        from cogs.ai_cog import build_providers_embed
+
+        return build_providers_embed()
+    if action == "routing":
+        from cogs.ai_cog import build_routing_embed
+
+        return build_routing_embed()
+    return None
+
+
+async def handle_ai_interaction(
+    interaction: discord.Interaction,
+    action: str,
+    session: Any,
+    request_id: str,
+) -> None:
+    """Interaction-router handler for prefix ``"ai"``.
+
+    The View's own ``@discord.ui.button`` callbacks are the primary
+    dispatcher for ``PersistentView`` button clicks — discord.py
+    dispatches them in the connection layer before ``on_interaction``
+    fires. This handler runs only after that path completes, so it
+    bails immediately when the response has already been sent.
+    """
+    # PersistentView may already have handled this interaction.
+    # Check is_done() BEFORE any permission check or action handling.
+    if interaction.response.is_done():
+        return
+
+    # Admin gate — mirrors AIPanelView.interaction_check so the router
+    # path enforces the same authorization as the View path.
+    member = interaction.user
+    if not getattr(member, "guild_permissions", None) or not (
+        member.guild_permissions.administrator  # type: ignore[union-attr]
+    ):
+        await interaction.response.send_message(
+            "❌ You need the Administrator permission to use the AI panel.",
+            ephemeral=True,
+        )
+        return
+
+    # Settings requires an async call to _build_ai_settings_panel; the
+    # synchronous _embed_for_ai_panel_action helper cannot serve it.
+    if action == "settings":
+        from cogs.ai_cog import _build_ai_settings_panel
+
+        embed, view = await _build_ai_settings_panel(
+            interaction.user,
+            interaction.guild_id,
+        )
+        await interaction.response.edit_message(embed=embed, view=view)
+        return
+
+    embed = _embed_for_ai_panel_action(action)
+    if embed is None:
+        await interaction.response.send_message(
+            f"❌ Unknown AI panel action: {action!r}",
+            ephemeral=True,
+        )
+        return
+    await interaction.response.edit_message(embed=embed, view=AIPanelView())
+
+
+__all__ = [
+    "AI_ROUTER_PREFIX",
+    "AIPanelView",
+    "build_ai_panel_embed",
+    "handle_ai_interaction",
+]

--- a/tests/unit/cogs/test_ai_panel_router_registration.py
+++ b/tests/unit/cogs/test_ai_panel_router_registration.py
@@ -1,0 +1,188 @@
+"""Tests for the AI interaction-router handler registered by ``AICog`` (PR1).
+
+Before PR1, button clicks on the AI panel produced a WARNING
+("Unhandled interaction prefix 'ai'") on every process restart because
+no cog claimed the ``ai`` prefix. PR1 adds an idempotent registration
+in ``AICog.cog_load`` and a thin ``handle_ai_interaction`` dispatcher
+in ``views.ai.panel`` that bails when the PersistentView has already
+handled the interaction.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from cogs.ai_cog import AICog
+from core.runtime import interaction_router
+from views.ai.panel import (
+    AI_ROUTER_PREFIX,
+    handle_ai_interaction,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_router_handler():
+    """Each test starts with a clean ``ai`` prefix in the router."""
+    interaction_router._handlers.pop(AI_ROUTER_PREFIX, None)
+    yield
+    interaction_router._handlers.pop(AI_ROUTER_PREFIX, None)
+
+
+def _make_interaction(*, admin: bool, is_done: bool = False) -> MagicMock:
+    """Build a minimal discord.Interaction stub for handler tests."""
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.guild_id = 1
+    interaction.user = MagicMock()
+    interaction.user.guild_permissions = SimpleNamespace(administrator=admin)
+    interaction.response = MagicMock()
+    interaction.response.is_done = MagicMock(return_value=is_done)
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    return interaction
+
+
+# ---------------------------------------------------------------------------
+# Registration lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ai_prefix_registered_after_cog_load():
+    bot = MagicMock()
+    cog = AICog(bot)
+    # cog_load also touches message_pipeline; that path is fine to exercise
+    # against the real registry — it dedupes by name.
+    await cog.cog_load()
+    assert interaction_router._handlers.get(AI_ROUTER_PREFIX) is handle_ai_interaction
+
+
+@pytest.mark.asyncio
+async def test_ai_prefix_registration_is_idempotent_on_repeated_cog_load(caplog):
+    """Reloading the cog must not produce an overwrite WARNING."""
+    bot = MagicMock()
+    cog = AICog(bot)
+    await cog.cog_load()
+    caplog.set_level(logging.WARNING, logger="bot.runtime.router")
+    caplog.set_level(logging.WARNING, logger="bot")
+    caplog.clear()
+    await cog.cog_load()
+    # Handler must remain handle_ai_interaction.
+    assert interaction_router._handlers.get(AI_ROUTER_PREFIX) is handle_ai_interaction
+    # No overwrite-related WARNING should have fired on the second load.
+    assert not any(
+        "Overwriting existing handler" in r.message
+        or "replacing unexpected handler" in r.message
+        for r in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_ai_prefix_registration_replaces_foreign_handler(caplog):
+    """A handler set by some other path is replaced with a WARNING."""
+
+    async def foreign(*_args, **_kwargs):
+        return None
+
+    interaction_router._handlers[AI_ROUTER_PREFIX] = foreign
+    bot = MagicMock()
+    cog = AICog(bot)
+    caplog.set_level(logging.WARNING)
+    await cog.cog_load()
+    assert interaction_router._handlers.get(AI_ROUTER_PREFIX) is handle_ai_interaction
+    assert any("replacing unexpected handler" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# handle_ai_interaction behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handler_returns_early_when_response_is_done():
+    """If the PersistentView already handled it, the router bails."""
+    interaction = _make_interaction(admin=True, is_done=True)
+    await handle_ai_interaction(interaction, "diagnostics", None, "req-1")
+    # No send / edit happened.
+    interaction.response.send_message.assert_not_called()
+    interaction.response.edit_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handler_admin_only_gate():
+    """Non-admins see an ephemeral denial — no edit_message."""
+    interaction = _make_interaction(admin=False, is_done=False)
+    await handle_ai_interaction(interaction, "diagnostics", None, "req-1")
+    interaction.response.send_message.assert_awaited_once()
+    args, kwargs = interaction.response.send_message.call_args
+    assert kwargs.get("ephemeral") is True
+    interaction.response.edit_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handler_dispatches_diagnostics_action():
+    """Admin + sync action: edit_message with an Embed."""
+    interaction = _make_interaction(admin=True, is_done=False)
+    await handle_ai_interaction(interaction, "diagnostics", None, "req-1")
+    interaction.response.edit_message.assert_awaited_once()
+    args, kwargs = interaction.response.edit_message.call_args
+    embed = kwargs["embed"]
+    assert isinstance(embed, discord.Embed)
+    assert "Diagnostics" in (embed.title or "")
+
+
+@pytest.mark.asyncio
+async def test_handler_dispatches_refresh_action():
+    interaction = _make_interaction(admin=True, is_done=False)
+    await handle_ai_interaction(interaction, "refresh", None, "req-1")
+    interaction.response.edit_message.assert_awaited_once()
+    embed = interaction.response.edit_message.call_args.kwargs["embed"]
+    assert "AI Platform" in (embed.title or "")
+
+
+@pytest.mark.asyncio
+async def test_handler_dispatches_providers_and_routing():
+    for action, expected_in_title in (
+        ("providers", "Providers"),
+        ("routing", "Routing"),
+    ):
+        interaction = _make_interaction(admin=True, is_done=False)
+        await handle_ai_interaction(interaction, action, None, "req-1")
+        interaction.response.edit_message.assert_awaited_once()
+        embed = interaction.response.edit_message.call_args.kwargs["embed"]
+        assert expected_in_title in (embed.title or "")
+
+
+@pytest.mark.asyncio
+async def test_handler_settings_action_uses_async_builder():
+    """The "settings" branch must await _build_ai_settings_panel."""
+    interaction = _make_interaction(admin=True, is_done=False)
+    fake_embed = discord.Embed(title="AI Settings")
+    fake_view = MagicMock()
+    with patch(
+        "cogs.ai_cog._build_ai_settings_panel",
+        new_callable=AsyncMock,
+        return_value=(fake_embed, fake_view),
+    ) as builder:
+        await handle_ai_interaction(interaction, "settings", None, "req-1")
+    builder.assert_awaited_once_with(interaction.user, interaction.guild_id)
+    interaction.response.edit_message.assert_awaited_once_with(
+        embed=fake_embed,
+        view=fake_view,
+    )
+
+
+@pytest.mark.asyncio
+async def test_handler_unknown_action_replies_gracefully():
+    """An unrecognised action returns an ephemeral error, not a crash."""
+    interaction = _make_interaction(admin=True, is_done=False)
+    await handle_ai_interaction(interaction, "explode", None, "req-1")
+    interaction.response.send_message.assert_awaited_once()
+    args, kwargs = interaction.response.send_message.call_args
+    assert kwargs.get("ephemeral") is True
+    assert "Unknown" in args[0] or "Unknown" in kwargs.get("content", "")
+    interaction.response.edit_message.assert_not_called()

--- a/tests/unit/cogs/test_ai_why_no_response_format.py
+++ b/tests/unit/cogs/test_ai_why_no_response_format.py
@@ -1,0 +1,122 @@
+"""Tests for the ``!ai why-no-response`` embed format (PR1).
+
+Before PR1 the command rendered ``decision | reason_code | channel |
+user | task`` only. PR1 adds the columns that the audit table already
+contains — relative timestamp, provider, model, route — and switches
+from a bare ``ctx.send`` text block to a titled embed.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from cogs.ai_cog import _format_audit_row, _relative_time
+
+# ---------------------------------------------------------------------------
+# _relative_time
+# ---------------------------------------------------------------------------
+
+
+def test_relative_time_seconds():
+    now = datetime(2026, 5, 25, 12, 0, 0, tzinfo=timezone.utc)
+    ts = now - timedelta(seconds=12)
+    assert _relative_time(ts, now=now) == "12s ago"
+
+
+def test_relative_time_minutes():
+    now = datetime(2026, 5, 25, 12, 0, 0, tzinfo=timezone.utc)
+    ts = now - timedelta(minutes=5)
+    assert _relative_time(ts, now=now) == "5m ago"
+
+
+def test_relative_time_hours():
+    now = datetime(2026, 5, 25, 12, 0, 0, tzinfo=timezone.utc)
+    ts = now - timedelta(hours=3)
+    assert _relative_time(ts, now=now) == "3h ago"
+
+
+def test_relative_time_days():
+    now = datetime(2026, 5, 25, 12, 0, 0, tzinfo=timezone.utc)
+    ts = now - timedelta(days=2)
+    assert _relative_time(ts, now=now) == "2d ago"
+
+
+def test_relative_time_handles_naive_datetime():
+    """Naive datetimes are treated as UTC."""
+    now = datetime(2026, 5, 25, 12, 0, 0, tzinfo=timezone.utc)
+    ts_naive = datetime(2026, 5, 25, 11, 30, 0)
+    assert _relative_time(ts_naive, now=now) == "30m ago"
+
+
+def test_relative_time_future_returns_sentinel():
+    """Clock skew must not raise."""
+    now = datetime(2026, 5, 25, 12, 0, 0, tzinfo=timezone.utc)
+    ts = now + timedelta(seconds=10)
+    assert _relative_time(ts, now=now) == "in the future"
+
+
+# ---------------------------------------------------------------------------
+# _format_audit_row
+# ---------------------------------------------------------------------------
+
+
+def _row(**overrides):
+    base = {
+        "id": 1,
+        "guild_id": 1,
+        "channel_id": 12345,
+        "category_id": None,
+        "user_id": 67890,
+        "message_id": None,
+        "task": "BTD6_ANSWER",
+        "route": "primary",
+        "decision": "denied",
+        "reason_code": "POLICY_CHANNEL_DENY",
+        "policy_snapshot_hash": None,
+        "instruction_profile_ids": None,
+        "provider": "openai",
+        "model": "gpt-4o-mini",
+        "created_at": datetime.now(timezone.utc) - timedelta(minutes=2),
+    }
+    base.update(overrides)
+    return base
+
+
+def test_format_audit_row_includes_all_required_columns():
+    line = _format_audit_row(_row())
+    assert "denied" in line
+    assert "POLICY_CHANNEL_DENY" in line
+    assert "task=BTD6_ANSWER" in line
+    assert "route=primary" in line
+    assert "<#12345>" in line
+    assert "<@67890>" in line
+    assert "provider=openai" in line
+    assert "model=gpt-4o-mini" in line
+
+
+def test_format_audit_row_renders_relative_timestamp():
+    line = _format_audit_row(_row())
+    assert re.search(r"\d+[smhd] ago", line), f"no relative-time pattern in {line!r}"
+
+
+def test_format_audit_row_handles_null_optionals():
+    line = _format_audit_row(_row(task=None, route=None, provider=None, model=None))
+    assert "task=—" in line
+    assert "route=—" in line
+    assert "provider=—" in line
+    assert "model=—" in line
+
+
+def test_format_audit_row_handles_missing_created_at():
+    """A row without a parseable timestamp falls back to '—'."""
+    line = _format_audit_row(_row(created_at=None))
+    assert "`—       `" in line or "—" in line
+
+
+def test_format_audit_row_does_not_leak_message_content():
+    """The audit table has no content column; the renderer must not pretend it."""
+    line = _format_audit_row(_row())
+    assert "content" not in line.lower()

--- a/tests/unit/services/test_ai_permission_service.py
+++ b/tests/unit/services/test_ai_permission_service.py
@@ -1,0 +1,95 @@
+"""Tests for ``services.ai_permission_service.snapshot`` (PR1).
+
+The XP-lookup bug fixed in PR1: previously ``snapshot`` called a
+non-existent ``xp_service.get_user_record`` and silently fell back to
+``level=0, is_fresh_user=True``, so every permission check below the
+guild's minimum level passed the fresh-user gate regardless of the
+real XP row. These tests pin the corrected behaviour.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, patch
+
+import asyncpg
+import pytest
+
+from services import ai_permission_service
+from services.xp_service import UserXPRecord
+
+
+@pytest.mark.asyncio
+async def test_snapshot_level_32_passes_min_level_2(caplog):
+    """A real level-32 row must surface as level=32, is_fresh_user=False."""
+    with patch(
+        "services.xp_service.get_user_record",
+        new_callable=AsyncMock,
+        return_value=UserXPRecord(xp=12345, level=32, messages=500),
+    ):
+        snap = await ai_permission_service.snapshot(guild_id=1, user_id=7)
+    assert snap.level == 32
+    assert snap.is_fresh_user is False
+    # No log lines from a successful read.
+    assert not any("xp lookup failed" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_no_row_returns_fresh_user(caplog):
+    """A None record (no XP row yet) is the silent fresh-user path."""
+    caplog.set_level(logging.DEBUG, logger="bot.services.ai_permission")
+    with patch(
+        "services.xp_service.get_user_record",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        snap = await ai_permission_service.snapshot(guild_id=1, user_id=7)
+    assert snap.level == 0
+    assert snap.is_fresh_user is True
+    # The no-row path must not emit a WARNING.
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings == []
+
+
+@pytest.mark.asyncio
+async def test_snapshot_db_error_logs_warning_not_debug(caplog):
+    """A real asyncpg failure produces a WARNING (not silent DEBUG)."""
+    caplog.set_level(logging.DEBUG, logger="bot.services.ai_permission")
+    with patch(
+        "services.xp_service.get_user_record",
+        new_callable=AsyncMock,
+        side_effect=asyncpg.PostgresError("connection lost"),
+    ):
+        snap = await ai_permission_service.snapshot(guild_id=1, user_id=7)
+    # Fallback is still safe (level=0, fresh=True) for availability,
+    # but the WARNING surfaces the failure to operators.
+    assert snap.level == 0
+    assert snap.is_fresh_user is True
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("xp lookup failed" in r.message for r in warnings)
+    assert any("PostgresError" in r.getMessage() for r in warnings)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_propagates_programming_errors():
+    """AttributeError / TypeError must NOT be caught — they signal bugs."""
+
+    async def boom(*_, **__):
+        raise AttributeError("xp_service has no attribute foo")
+
+    with patch("services.xp_service.get_user_record", side_effect=boom):
+        with pytest.raises(AttributeError):
+            await ai_permission_service.snapshot(guild_id=1, user_id=7)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_zero_xp_but_real_row_is_not_fresh():
+    """Level 0 with positive XP is still not a fresh user."""
+    with patch(
+        "services.xp_service.get_user_record",
+        new_callable=AsyncMock,
+        return_value=UserXPRecord(xp=50, level=0, messages=3),
+    ):
+        snap = await ai_permission_service.snapshot(guild_id=1, user_id=7)
+    assert snap.level == 0
+    assert snap.is_fresh_user is False

--- a/tests/unit/services/test_xp_service_get_user_record.py
+++ b/tests/unit/services/test_xp_service_get_user_record.py
@@ -1,0 +1,93 @@
+"""Tests for ``services.xp_service.get_user_record`` (PR1).
+
+The helper is the canonical XP read for permission/level checks.
+``ai_permission_service.snapshot`` calls through here so its consumers
+never learn the underlying row shape from ``utils.db.xp.get_xp``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services import xp_service
+from services.xp_service import UserXPRecord
+
+
+@pytest.mark.asyncio
+async def test_returns_record_for_existing_xp_row():
+    """A real row (messages >= 1) returns a typed UserXPRecord."""
+    row = {
+        "user_id": 7,
+        "guild_id": 42,
+        "xp": 1234,
+        "level": 32,
+        "messages": 250,
+        "last_xp": 0,
+        "coins": 0,
+    }
+    with patch(
+        "services.xp_service.db.get_xp",
+        new_callable=AsyncMock,
+        return_value=row,
+    ):
+        record = await xp_service.get_user_record(42, 7)
+    assert record == UserXPRecord(xp=1234, level=32, messages=250)
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_no_row_sentinel():
+    """The synthesised all-zeros dict from get_xp signals "no row yet"."""
+    synthesised = {
+        "user_id": 7,
+        "guild_id": 42,
+        "xp": 0,
+        "level": 0,
+        "messages": 0,
+        "last_xp": 0,
+        "coins": 0,
+    }
+    with patch(
+        "services.xp_service.db.get_xp",
+        new_callable=AsyncMock,
+        return_value=synthesised,
+    ):
+        record = await xp_service.get_user_record(42, 7)
+    assert record is None
+
+
+@pytest.mark.asyncio
+async def test_returns_record_for_real_row_with_zero_xp():
+    """A row with xp=0 but messages>=1 is still a real row."""
+    row = {
+        "user_id": 7,
+        "guild_id": 42,
+        "xp": 0,
+        "level": 0,
+        "messages": 1,
+        "last_xp": 0,
+        "coins": 0,
+    }
+    with patch(
+        "services.xp_service.db.get_xp",
+        new_callable=AsyncMock,
+        return_value=row,
+    ):
+        record = await xp_service.get_user_record(42, 7)
+    assert record is not None
+    assert record.messages == 1
+
+
+@pytest.mark.asyncio
+async def test_propagates_db_error():
+    """Real DB failures must propagate — the helper does not catch them."""
+    import asyncpg
+
+    with patch(
+        "services.xp_service.db.get_xp",
+        new_callable=AsyncMock,
+        side_effect=asyncpg.PostgresError("connection lost"),
+    ):
+        with pytest.raises(asyncpg.PostgresError):
+            await xp_service.get_user_record(42, 7)


### PR DESCRIPTION
## Summary

This PR fixes three issues in the AI subsystem:

1. **Interaction router registration** — The AI panel buttons now register a handler with the interaction router to prevent "Unhandled interaction prefix 'ai'" warnings on every process restart.
2. **XP permission lookup bug** — `ai_permission_service.snapshot` was calling a non-existent method and silently falling back to treating all users as fresh/level-0, bypassing permission checks.
3. **Audit display enhancement** — The `!ai why-no-response` command now shows a formatted embed with relative timestamps, provider, model, and route information.

## Key Changes

### Interaction Router Registration
- Added `handle_ai_interaction` dispatcher in `views/ai/panel.py` that safely bails when the PersistentView has already handled the interaction
- Registered the handler in `AICog.cog_load` with idempotency guards to prevent spurious warnings on cog reload
- Extracted sync action dispatch logic into `_embed_for_ai_panel_action` helper to avoid duplication between View buttons and router handler
- Updated View button callbacks to use the shared helper

### XP Permission Service Fix
- Created `UserXPRecord` dataclass in `xp_service.py` as the canonical typed read for permission checks
- Implemented `xp_service.get_user_record()` that properly distinguishes between "no row yet" (returns `None`) and real rows with zero XP
- Fixed `ai_permission_service.snapshot()` to call the correct method and only catch DB-layer exceptions (not programming errors)
- Improved error logging to distinguish between missing rows (silent) and actual DB failures (WARNING)

### Audit Display Enhancement
- Added `_relative_time()` helper to format timestamps as "2m ago" style strings
- Added `_format_audit_row()` to render audit table rows with all relevant columns: timestamp, decision, reason_code, task, route, channel, user, provider, model
- Updated `ai_why_no_response` command to display results in a titled embed with footer showing count and oldest timestamp
- Limited results to 25 most recent denials/skips

## Implementation Details

- The interaction router handler is registered once per process lifetime (no unregister API exists); `cog_load` idempotency guard detects if already registered to the correct handler
- Settings action remains special-cased as it requires async `_build_ai_settings_panel` call; other four actions (refresh, diagnostics, providers, routing) use the sync helper
- XP record detection uses `messages == 0` as the sentinel for "no row yet" since `add_xp` always inserts `messages=1` on first grant
- Permission service only catches `asyncpg.PostgresError` and similar DB exceptions; programming errors (AttributeError, TypeError) propagate to surface bugs during development

## Tests Added

- `test_ai_panel_router_registration.py` — 9 tests covering registration lifecycle, idempotency, handler dispatch, and permission gates
- `test_ai_why_no_response_format.py` — 8 tests for relative time formatting and audit row rendering
- `test_ai_permission_service.py` — 5 tests for XP lookup and permission snapshot behavior
- `test_xp_service_get_user_record.py` — 5 tests for the new typed XP record helper

https://claude.ai/code/session_019vY4SECGtTT5xXdFAr6a9Q