### PR TITLE
PR5: Add staff strategy review view with mutation-driven buttons

### DIFF
--- a/disbot/cogs/btd6_cog.py
+++ b/disbot/cogs/btd6_cog.py
@@ -402,6 +402,40 @@ class BTD6Cog(commands.Cog):
             )
         await ctx.send("\n".join(lines))
 
+    @btd6_group.command(name="pending")  # type: ignore[arg-type]
+    @commands.has_guild_permissions(manage_guild=True)
+    async def btd6_pending(self, ctx: commands.Context, limit: int = 5) -> None:
+        """List pending strategy submissions with review buttons (PR5).
+
+        Staff-only (manage_guild). Each pending strategy gets its own
+        review embed + button row (Approve guild / Publish / Reject /
+        Unpublish). All actions funnel through
+        ``services.btd6_strategy_mutation``.
+        """
+        if not ctx.guild:
+            await ctx.send("This command requires a guild context.")
+            return
+        from utils.db import btd6_strategies as db
+        from views.btd6.strategy_review import (
+            StrategyReviewView,
+            build_strategy_embed,
+        )
+
+        limit = max(1, min(10, int(limit)))
+        rows = await db.search_strategies(
+            guild_id=ctx.guild.id,
+            approval_status="draft",
+            limit=limit,
+        )
+        if not rows:
+            await ctx.send("No pending strategies awaiting review for this guild.")
+            return
+        for row in rows:
+            await ctx.send(
+                embed=build_strategy_embed(row),
+                view=StrategyReviewView(row),
+            )
+
     @commands.command(name="btd6menu")
     async def btd6menu(self, ctx: commands.Context) -> None:
         """Open the BTD6 panel (alias for ``!btd6``)."""

--- a/disbot/services/btd6_strategy_mutation.py
+++ b/disbot/services/btd6_strategy_mutation.py
@@ -173,6 +173,57 @@ async def ai_approve_guild(
     )
 
 
+async def staff_approve_guild(
+    strategy_id: int,
+    *,
+    staff_actor: Any,
+    detail: dict[str, Any] | None = None,
+) -> StrategyMutationResult:
+    """Staff approves a draft strategy at guild-local visibility.
+
+    Separate from :func:`staff_publish`: this records staff approval
+    without flipping ``visibility`` to ``published``. The plan
+    explicitly keeps guild-local approval separated from staff-
+    confirmed global publishing, so two distinct button clicks are
+    required before a strategy goes global.
+    """
+    actor_id = _check_actor(staff_actor)
+    if not _is_staff(staff_actor):
+        raise UnauthorizedStrategyMutationError(
+            "staff approval requires manage_guild or administrator permission",
+        )
+    before = await db.get_strategy(strategy_id)
+    if before is None:
+        raise InvalidStrategyValueError(f"strategy {strategy_id} not found")
+    if before["visibility"] == "published":
+        raise InvalidStrategyValueError(
+            "strategy is already published — use unpublish to revert",
+        )
+
+    await db.update_strategy_state(
+        strategy_id,
+        approval_status="approved",
+        visibility="guild",
+        approved_by="staff",
+        approved_by_id=actor_id,
+        current_guild_id=before["current_guild_id"],
+        bump_version=True,
+    )
+    await db.record_strategy_audit(
+        strategy_id,
+        actor_kind="staff",
+        actor_id=actor_id,
+        action="staff_approved_guild",
+        detail=detail,
+    )
+    return StrategyMutationResult(
+        mutation_id=uuid.uuid4().hex,
+        strategy_id=strategy_id,
+        action="staff_approved_guild",
+        actor_kind="staff",
+    )
+
+
 async def staff_publish(
     strategy_id: int,
     *,
@@ -322,6 +373,7 @@ __all__ = [
     "ai_approve_guild",
     "anonymise_submitter",
     "reject",
+    "staff_approve_guild",
     "staff_publish",
     "submit_strategy",
     "unpublish",

--- a/disbot/views/btd6/strategy_review.py
+++ b/disbot/views/btd6/strategy_review.py
@@ -1,0 +1,259 @@
+"""Staff strategy-review view for ``!btd6 strategies pending`` (PR5).
+
+Per the plan: pending strategies need a staff review surface that
+funnels every state transition through
+:mod:`services.btd6_strategy_mutation`. The view does not write to
+the DB directly; each button is a thin wrapper over a mutation call.
+
+Button matrix per strategy embed:
+
+* **Approve (guild)** — calls ``staff_approve_guild``. Keeps the
+  strategy at ``visibility='guild'``; the global publish action
+  stays a separate click so guild-local approval is explicitly
+  decoupled from staff-confirmed global publishing.
+* **Publish (global)** — calls ``staff_publish``. Flips
+  ``visibility='published'``.
+* **Reject** — calls ``reject``.
+* **Unpublish** — calls ``unpublish``; visible only when the
+  strategy is currently published.
+
+All four actions require ``manage_guild`` or ``administrator``
+permissions; the mutation service enforces this server-side, and the
+view's ``interaction_check`` mirrors it client-side so non-staff get
+a clear ephemeral denial.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import discord
+
+logger = logging.getLogger("bot.views.btd6.strategy_review")
+
+_VIEW_TIMEOUT_SECONDS = 300
+_PANEL_COLOR = discord.Color.gold()
+
+
+def _is_staff(member: Any) -> bool:
+    perms = getattr(member, "guild_permissions", None)
+    if perms is None:
+        return False
+    return bool(
+        getattr(perms, "administrator", False) or getattr(perms, "manage_guild", False),
+    )
+
+
+def build_strategy_embed(strategy: dict[str, Any]) -> discord.Embed:
+    """Render one strategy as a review-friendly embed.
+
+    The body fields are surfaced inline for the reviewer's benefit but
+    the strategy itself stays as untrusted text — no markdown beyond
+    the field labels that the staff control.
+    """
+    title = strategy.get("title") or f"Strategy #{strategy.get('id')}"
+    embed = discord.Embed(
+        title=f"📜 {title}"[:256],
+        description=(strategy.get("summary") or "")[:2048],
+        color=_PANEL_COLOR,
+    )
+    inline_keys = (
+        ("map", "Map"),
+        ("mode", "Mode"),
+        ("difficulty", "Difficulty"),
+        ("hero", "Hero"),
+    )
+    for key, label in inline_keys:
+        value = strategy.get(key)
+        if value:
+            embed.add_field(name=label, value=str(value)[:128], inline=True)
+    state_bits = [
+        f"approval=`{strategy.get('approval_status')}`",
+        f"visibility=`{strategy.get('visibility')}`",
+        f"v{strategy.get('version', 0)}",
+    ]
+    embed.add_field(name="State", value=" · ".join(state_bits), inline=False)
+    snapshot = strategy.get("submitter_display_snapshot")
+    submitted_by = strategy.get("submitted_by")
+    if snapshot or submitted_by:
+        actor = snapshot or f"<@{submitted_by}>"
+        embed.set_footer(text=f"id={strategy.get('id')} · submitted by {actor}")
+    else:
+        embed.set_footer(text=f"id={strategy.get('id')}")
+    return embed
+
+
+async def _refresh_or_followup(
+    interaction: discord.Interaction,
+    *,
+    strategy_id: int,
+    confirm_message: str,
+) -> None:
+    """Re-fetch the strategy and refresh the parent embed, plus an
+    ephemeral confirmation so the staff actor sees what happened.
+    """
+    try:
+        from utils.db import btd6_strategies as db
+
+        refreshed = await db.get_strategy(strategy_id)
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.exception("strategy_review: refresh fetch failed for id=%s", strategy_id)
+        refreshed = None
+        await interaction.followup.send(
+            f"⚠️ {confirm_message} (refresh failed: {type(exc).__name__})",
+            ephemeral=True,
+        )
+        return
+
+    if refreshed is None:
+        await interaction.response.send_message(
+            f"✅ {confirm_message} (the strategy is gone from the table now).",
+            ephemeral=True,
+        )
+        return
+
+    embed = build_strategy_embed(refreshed)
+    view = StrategyReviewView(refreshed)
+    await interaction.response.edit_message(embed=embed, view=view)
+    await interaction.followup.send(f"✅ {confirm_message}", ephemeral=True)
+
+
+class StrategyReviewView(discord.ui.View):
+    """Per-strategy review controls. Staff-only."""
+
+    def __init__(self, strategy: dict[str, Any]) -> None:
+        super().__init__(timeout=_VIEW_TIMEOUT_SECONDS)
+        self.strategy_id = int(strategy["id"])
+        self.visibility = str(strategy.get("visibility") or "guild")
+        # The Unpublish button only makes sense for currently-published
+        # rows; remove it when visibility is guild-local so the staff
+        # doesn't try to "unpublish" a guild draft.
+        if self.visibility != "published":
+            self.remove_item(self.unpublish_btn)
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if not _is_staff(interaction.user):
+            await interaction.response.send_message(
+                "❌ Strategy review requires `manage_guild` or administrator.",
+                ephemeral=True,
+            )
+            return False
+        return True
+
+    async def _mutate(
+        self,
+        interaction: discord.Interaction,
+        *,
+        action_callable: Any,
+        kwargs: dict[str, Any],
+        confirm: str,
+    ) -> None:
+        from services.btd6_strategy_mutation import BTD6StrategyMutationError
+
+        try:
+            await action_callable(self.strategy_id, **kwargs)
+        except BTD6StrategyMutationError as exc:
+            await interaction.response.send_message(
+                f"❌ {type(exc).__name__}: {exc}",
+                ephemeral=True,
+            )
+            return
+        except Exception as exc:  # noqa: BLE001 — surface unexpected errors
+            logger.exception(
+                "StrategyReviewView: mutation %s raised for strategy=%s",
+                action_callable.__name__,
+                self.strategy_id,
+            )
+            await interaction.response.send_message(
+                f"❌ Unexpected error: {type(exc).__name__}: {exc}",
+                ephemeral=True,
+            )
+            return
+        await _refresh_or_followup(
+            interaction,
+            strategy_id=self.strategy_id,
+            confirm_message=confirm,
+        )
+
+    @discord.ui.button(
+        label="Approve (guild)",
+        style=discord.ButtonStyle.success,
+        row=0,
+    )
+    async def approve_guild_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        from services import btd6_strategy_mutation
+
+        await self._mutate(
+            interaction,
+            action_callable=btd6_strategy_mutation.staff_approve_guild,
+            kwargs={"staff_actor": interaction.user},
+            confirm=f"Approved strategy #{self.strategy_id} at guild visibility.",
+        )
+
+    @discord.ui.button(
+        label="Publish (global)",
+        style=discord.ButtonStyle.primary,
+        row=0,
+    )
+    async def publish_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        from services import btd6_strategy_mutation
+
+        await self._mutate(
+            interaction,
+            action_callable=btd6_strategy_mutation.staff_publish,
+            kwargs={"staff_actor": interaction.user},
+            confirm=f"Published strategy #{self.strategy_id} globally.",
+        )
+
+    @discord.ui.button(
+        label="Reject",
+        style=discord.ButtonStyle.danger,
+        row=0,
+    )
+    async def reject_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        from services import btd6_strategy_mutation
+
+        await self._mutate(
+            interaction,
+            action_callable=btd6_strategy_mutation.reject,
+            kwargs={"actor": interaction.user, "actor_kind": "staff"},
+            confirm=f"Rejected strategy #{self.strategy_id}.",
+        )
+
+    @discord.ui.button(
+        label="Unpublish",
+        style=discord.ButtonStyle.secondary,
+        row=1,
+    )
+    async def unpublish_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        from services import btd6_strategy_mutation
+
+        await self._mutate(
+            interaction,
+            action_callable=btd6_strategy_mutation.unpublish,
+            kwargs={"staff_actor": interaction.user},
+            confirm=f"Unpublished strategy #{self.strategy_id} (back to guild).",
+        )
+
+
+__all__ = [
+    "StrategyReviewView",
+    "build_strategy_embed",
+]

--- a/tests/unit/services/test_btd6_strategy_staff_approve_guild.py
+++ b/tests/unit/services/test_btd6_strategy_staff_approve_guild.py
@@ -1,0 +1,155 @@
+"""PR5 — staff_approve_guild keeps strategies guild-local + audits."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_DISBOT = Path(__file__).parents[3] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+from services import btd6_strategy_mutation as mut  # noqa: E402
+from utils.db import btd6_strategies as db  # noqa: E402
+
+
+def _staff_actor(actor_id: int = 12345) -> MagicMock:
+    actor = MagicMock()
+    actor.id = actor_id
+    actor.guild_permissions.administrator = False
+    actor.guild_permissions.manage_guild = True
+    return actor
+
+
+def _admin_actor(actor_id: int = 12345) -> MagicMock:
+    actor = MagicMock()
+    actor.id = actor_id
+    actor.guild_permissions.administrator = True
+    return actor
+
+
+def _non_staff_actor(actor_id: int = 99) -> MagicMock:
+    actor = MagicMock()
+    actor.id = actor_id
+    actor.guild_permissions.administrator = False
+    actor.guild_permissions.manage_guild = False
+    return actor
+
+
+def _strategy_row(
+    *,
+    sid: int = 1,
+    visibility: str = "guild",
+    approval_status: str = "draft",
+) -> dict:
+    return {
+        "id": sid,
+        "title": "test",
+        "summary": "s",
+        "origin_guild_id": 100,
+        "current_guild_id": 100,
+        "visibility": visibility,
+        "approval_status": approval_status,
+        "version": 1,
+    }
+
+
+async def test_staff_approve_guild_writes_state_and_audit(monkeypatch):
+    update_calls: list[dict] = []
+    audit_calls: list[dict] = []
+
+    async def _get(sid):
+        return _strategy_row(sid=sid)
+
+    async def _update(strategy_id, **kw):
+        update_calls.append({"id": strategy_id, **kw})
+
+    async def _audit(strategy_id, **kw):
+        audit_calls.append({"id": strategy_id, **kw})
+
+    monkeypatch.setattr(db, "get_strategy", _get)
+    monkeypatch.setattr(db, "update_strategy_state", _update)
+    monkeypatch.setattr(db, "record_strategy_audit", _audit)
+
+    result = await mut.staff_approve_guild(
+        7,
+        staff_actor=_staff_actor(actor_id=42),
+    )
+    assert result.action == "staff_approved_guild"
+    assert result.actor_kind == "staff"
+
+    # State update must promote to approved at GUILD visibility (NOT
+    # published) — that's the entire point of this mutation.
+    assert update_calls[0]["approval_status"] == "approved"
+    assert update_calls[0]["visibility"] == "guild"
+    assert update_calls[0]["approved_by"] == "staff"
+    assert update_calls[0]["approved_by_id"] == 42
+    assert update_calls[0]["bump_version"] is True
+
+    # Audit row recorded with the staff actor.
+    assert audit_calls[0]["actor_kind"] == "staff"
+    assert audit_calls[0]["actor_id"] == 42
+    assert audit_calls[0]["action"] == "staff_approved_guild"
+
+
+async def test_staff_approve_guild_admin_is_also_staff(monkeypatch):
+    async def _get(sid):
+        return _strategy_row(sid=sid)
+
+    monkeypatch.setattr(db, "get_strategy", _get)
+    monkeypatch.setattr(db, "update_strategy_state", AsyncMock())
+    monkeypatch.setattr(db, "record_strategy_audit", AsyncMock())
+    result = await mut.staff_approve_guild(
+        7,
+        staff_actor=_admin_actor(actor_id=99),
+    )
+    assert result.actor_kind == "staff"
+
+
+async def test_staff_approve_guild_rejects_non_staff(monkeypatch):
+    async def _get(sid):
+        return _strategy_row(sid=sid)
+
+    # The mutation must refuse before any DB write fires.
+    explode = AsyncMock()
+    monkeypatch.setattr(db, "get_strategy", _get)
+    monkeypatch.setattr(db, "update_strategy_state", explode)
+    monkeypatch.setattr(db, "record_strategy_audit", explode)
+    with pytest.raises(mut.UnauthorizedStrategyMutationError):
+        await mut.staff_approve_guild(7, staff_actor=_non_staff_actor())
+    explode.assert_not_awaited()
+
+
+async def test_staff_approve_guild_refuses_when_already_published(monkeypatch):
+    async def _get(sid):
+        return _strategy_row(sid=sid, visibility="published", approval_status="approved")
+
+    explode = AsyncMock()
+    monkeypatch.setattr(db, "get_strategy", _get)
+    monkeypatch.setattr(db, "update_strategy_state", explode)
+    monkeypatch.setattr(db, "record_strategy_audit", explode)
+    with pytest.raises(mut.InvalidStrategyValueError, match="already published"):
+        await mut.staff_approve_guild(7, staff_actor=_staff_actor())
+    explode.assert_not_awaited()
+
+
+async def test_staff_approve_guild_refuses_when_strategy_missing(monkeypatch):
+    async def _get(sid):
+        return None
+
+    explode = AsyncMock()
+    monkeypatch.setattr(db, "get_strategy", _get)
+    monkeypatch.setattr(db, "update_strategy_state", explode)
+    monkeypatch.setattr(db, "record_strategy_audit", explode)
+    with pytest.raises(mut.InvalidStrategyValueError, match="strategy 7 not found"):
+        await mut.staff_approve_guild(7, staff_actor=_staff_actor())
+    explode.assert_not_awaited()
+
+
+def test_module_exports_staff_approve_guild():
+    """The new mutation is in __all__ so callers can import without
+    relying on internal attribute access."""
+    assert "staff_approve_guild" in mut.__all__

--- a/tests/unit/views/btd6/test_strategy_review.py
+++ b/tests/unit/views/btd6/test_strategy_review.py
@@ -1,0 +1,330 @@
+"""PR5 — strategy review view drives every action through ai_strategy_mutation."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_DISBOT = Path(__file__).parents[4] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+from services import btd6_strategy_mutation  # noqa: E402
+from utils.db import btd6_strategies as db  # noqa: E402
+from views.btd6.strategy_review import (  # noqa: E402
+    StrategyReviewView,
+    build_strategy_embed,
+)
+
+
+def _strategy(
+    *,
+    sid: int = 42,
+    visibility: str = "guild",
+    approval_status: str = "draft",
+    title: str = "Round 100 push",
+    summary: str = "Drop dart at corner, upgrade to 4xx, etc.",
+    submitter_display: str = "alice#1234",
+) -> dict:
+    return {
+        "id": sid,
+        "title": title,
+        "summary": summary,
+        "map": "TreeStump",
+        "mode": "Standard",
+        "difficulty": "Medium",
+        "hero": "Quincy",
+        "origin_guild_id": 100,
+        "current_guild_id": 100,
+        "visibility": visibility,
+        "approval_status": approval_status,
+        "version": 1,
+        "submitter_display_snapshot": submitter_display,
+        "submitted_by": 12345,
+    }
+
+
+def _staff_interaction(*, manage_guild: bool = True) -> MagicMock:
+    interaction = MagicMock()
+    interaction.user.guild_permissions.administrator = False
+    interaction.user.guild_permissions.manage_guild = manage_guild
+    interaction.user.id = 7777
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+# ---------------------------------------------------------------------------
+# build_strategy_embed
+# ---------------------------------------------------------------------------
+
+
+def test_embed_includes_title_summary_and_state():
+    embed = build_strategy_embed(_strategy())
+    assert "Round 100 push" in (embed.title or "")
+    assert "Drop dart" in (embed.description or "")
+    fields = {f.name: f.value for f in embed.fields}
+    assert "Map" in fields and "TreeStump" in fields["Map"]
+    assert "Hero" in fields and "Quincy" in fields["Hero"]
+    assert "State" in fields
+    assert "approval=`draft`" in fields["State"]
+    assert "visibility=`guild`" in fields["State"]
+
+
+def test_embed_footer_carries_id_and_submitter():
+    embed = build_strategy_embed(_strategy())
+    assert "id=42" in (embed.footer.text or "")
+    assert "alice#1234" in (embed.footer.text or "")
+
+
+def test_embed_handles_long_title_and_summary():
+    strategy = _strategy(title="X" * 500, summary="Y" * 5000)
+    embed = build_strategy_embed(strategy)
+    # Discord caps the title at 256 and description at 4096; the
+    # renderer must not break.
+    assert len(embed.title) <= 256
+    assert embed.description is not None
+    assert len(embed.description) <= 2048
+
+
+# ---------------------------------------------------------------------------
+# StrategyReviewView — button matrix + staff gate
+# ---------------------------------------------------------------------------
+
+
+def test_guild_strategy_does_not_show_unpublish_button():
+    view = StrategyReviewView(_strategy(visibility="guild"))
+    labels = {item.label for item in view.children if hasattr(item, "label")}
+    assert "Unpublish" not in labels
+    # The other three actions are always available.
+    assert "Approve (guild)" in labels
+    assert "Publish (global)" in labels
+    assert "Reject" in labels
+
+
+def test_published_strategy_shows_unpublish_button():
+    view = StrategyReviewView(_strategy(visibility="published"))
+    labels = {item.label for item in view.children if hasattr(item, "label")}
+    assert "Unpublish" in labels
+    assert "Approve (guild)" in labels
+
+
+async def test_view_rejects_non_staff():
+    view = StrategyReviewView(_strategy())
+    interaction = _staff_interaction(manage_guild=False)
+    allowed = await view.interaction_check(interaction)
+    assert allowed is False
+    interaction.response.send_message.assert_awaited_once()
+    args, kwargs = interaction.response.send_message.call_args
+    assert "manage_guild" in args[0] or "administrator" in args[0]
+    assert kwargs.get("ephemeral") is True
+
+
+async def test_view_admits_admin_even_without_manage_guild():
+    view = StrategyReviewView(_strategy())
+    interaction = _staff_interaction(manage_guild=False)
+    interaction.user.guild_permissions.administrator = True
+    allowed = await view.interaction_check(interaction)
+    assert allowed is True
+
+
+# ---------------------------------------------------------------------------
+# Button callbacks route to mutation service ONLY (no direct DB writes).
+# ---------------------------------------------------------------------------
+
+
+async def test_approve_guild_button_calls_staff_approve_guild(monkeypatch):
+    captured: dict = {}
+
+    async def _capture(strategy_id, *, staff_actor, detail=None):
+        captured["id"] = strategy_id
+        captured["actor"] = staff_actor
+        result = MagicMock()
+        result.action = "staff_approved_guild"
+        return result
+
+    monkeypatch.setattr(
+        btd6_strategy_mutation,
+        "staff_approve_guild",
+        _capture,
+    )
+
+    async def _refresh(sid):
+        return _strategy(sid=sid, approval_status="approved")
+
+    monkeypatch.setattr(db, "get_strategy", _refresh)
+
+    view = StrategyReviewView(_strategy(sid=42))
+    interaction = _staff_interaction()
+    await view.approve_guild_btn.callback(interaction)
+    assert captured["id"] == 42
+    assert captured["actor"] is interaction.user
+    interaction.response.edit_message.assert_awaited_once()
+    interaction.followup.send.assert_awaited_once()
+    args, _ = interaction.followup.send.call_args
+    assert "Approved" in args[0]
+    assert "#42" in args[0]
+
+
+async def test_publish_button_calls_staff_publish(monkeypatch):
+    captured: dict = {}
+
+    async def _capture(strategy_id, *, staff_actor, detail=None):
+        captured["id"] = strategy_id
+        result = MagicMock()
+        result.action = "published"
+        return result
+
+    monkeypatch.setattr(btd6_strategy_mutation, "staff_publish", _capture)
+
+    async def _refresh(sid):
+        return _strategy(sid=sid, visibility="published")
+
+    monkeypatch.setattr(db, "get_strategy", _refresh)
+
+    view = StrategyReviewView(_strategy(sid=11))
+    interaction = _staff_interaction()
+    await view.publish_btn.callback(interaction)
+    assert captured["id"] == 11
+    args, _ = interaction.followup.send.call_args
+    assert "Published" in args[0]
+
+
+async def test_reject_button_calls_reject_with_staff_actor_kind(monkeypatch):
+    captured: dict = {}
+
+    async def _capture(strategy_id, *, actor, actor_kind, reason=None):
+        captured["id"] = strategy_id
+        captured["actor"] = actor
+        captured["actor_kind"] = actor_kind
+        result = MagicMock()
+        result.action = "rejected"
+        return result
+
+    monkeypatch.setattr(btd6_strategy_mutation, "reject", _capture)
+
+    async def _refresh(sid):
+        return _strategy(sid=sid, approval_status="rejected")
+
+    monkeypatch.setattr(db, "get_strategy", _refresh)
+
+    view = StrategyReviewView(_strategy(sid=5))
+    interaction = _staff_interaction()
+    await view.reject_btn.callback(interaction)
+    assert captured["id"] == 5
+    assert captured["actor_kind"] == "staff"
+
+
+async def test_unpublish_button_calls_unpublish_on_published_strategy(monkeypatch):
+    captured: dict = {}
+
+    async def _capture(strategy_id, *, staff_actor, reason=None):
+        captured["id"] = strategy_id
+        result = MagicMock()
+        result.action = "unpublished"
+        return result
+
+    monkeypatch.setattr(btd6_strategy_mutation, "unpublish", _capture)
+
+    async def _refresh(sid):
+        return _strategy(sid=sid, visibility="guild", approval_status="unpublished")
+
+    monkeypatch.setattr(db, "get_strategy", _refresh)
+
+    view = StrategyReviewView(_strategy(sid=99, visibility="published"))
+    interaction = _staff_interaction()
+    await view.unpublish_btn.callback(interaction)
+    assert captured["id"] == 99
+    args, _ = interaction.followup.send.call_args
+    assert "Unpublished" in args[0]
+
+
+async def test_mutation_error_surfaces_as_typed_ephemeral_reply(monkeypatch):
+    async def _raise(strategy_id, **kw):
+        raise btd6_strategy_mutation.InvalidStrategyValueError("bad value")
+
+    monkeypatch.setattr(btd6_strategy_mutation, "staff_publish", _raise)
+
+    view = StrategyReviewView(_strategy(sid=42))
+    interaction = _staff_interaction()
+    await view.publish_btn.callback(interaction)
+    interaction.response.send_message.assert_awaited_once()
+    args, kwargs = interaction.response.send_message.call_args
+    assert "InvalidStrategyValueError" in args[0]
+    assert "bad value" in args[0]
+    assert kwargs.get("ephemeral") is True
+    # No refresh / followup happened because the mutation failed.
+    interaction.response.edit_message.assert_not_awaited()
+    interaction.followup.send.assert_not_awaited()
+
+
+async def test_unauthorized_mutation_error_uses_ephemeral_branch(monkeypatch):
+    """Server-side gate (mutation service) is the source of truth; the
+    view's interaction_check is just a UX courtesy."""
+    async def _raise(strategy_id, **kw):
+        raise btd6_strategy_mutation.UnauthorizedStrategyMutationError("nope")
+
+    monkeypatch.setattr(
+        btd6_strategy_mutation,
+        "staff_approve_guild",
+        _raise,
+    )
+
+    view = StrategyReviewView(_strategy(sid=42))
+    interaction = _staff_interaction()
+    await view.approve_guild_btn.callback(interaction)
+    args, _ = interaction.response.send_message.call_args
+    assert "UnauthorizedStrategyMutationError" in args[0]
+
+
+# ---------------------------------------------------------------------------
+# Pin: every button calls THROUGH btd6_strategy_mutation, never the DB
+# directly. Catches accidental future regressions where someone wires a
+# button to utils.db.btd6_strategies for "convenience".
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("button_attr", "mutation_attr"),
+    [
+        ("approve_guild_btn", "staff_approve_guild"),
+        ("publish_btn", "staff_publish"),
+        ("reject_btn", "reject"),
+    ],
+)
+async def test_button_only_writes_via_mutation_service(
+    monkeypatch,
+    button_attr,
+    mutation_attr,
+):
+    called_mutation = {"hit": False}
+
+    async def _capture(strategy_id, **kw):
+        called_mutation["hit"] = True
+        result = MagicMock()
+        result.action = mutation_attr
+        return result
+
+    monkeypatch.setattr(btd6_strategy_mutation, mutation_attr, _capture)
+
+    # If anyone writes to update_strategy_state or record_strategy_audit
+    # directly from the view, this AsyncMock raises before the test ends.
+    db_explode = AsyncMock(side_effect=AssertionError("view must not call DB directly"))
+    monkeypatch.setattr(db, "update_strategy_state", db_explode)
+    monkeypatch.setattr(db, "record_strategy_audit", db_explode)
+
+    async def _refresh(sid):
+        return _strategy(sid=sid)
+
+    monkeypatch.setattr(db, "get_strategy", _refresh)
+
+    view = StrategyReviewView(_strategy(sid=7))
+    interaction = _staff_interaction()
+    handler = getattr(view, button_attr)
+    await handler.callback(interaction)
+    assert called_mutation["hit"] is True
+    db_explode.assert_not_awaited()


### PR DESCRIPTION
## Summary

Implements the staff strategy review surface for `!btd6 strategies pending` (PR5). Adds a new `StrategyReviewView` that provides four action buttons (Approve guild, Publish global, Reject, Unpublish) for reviewing pending strategy submissions. All state transitions are routed exclusively through the `btd6_strategy_mutation` service, with no direct database writes from the view layer.

## Key Changes

- **New view: `disbot/views/btd6/strategy_review.py`**
  - `StrategyReviewView`: Discord UI view with four staff-only buttons
  - `build_strategy_embed()`: Renders strategy metadata as a review-friendly embed
  - All buttons call through `btd6_strategy_mutation` service (never direct DB writes)
  - Staff gate via `interaction_check()` requiring `manage_guild` or `administrator`
  - Unpublish button conditionally hidden for non-published strategies

- **New mutation: `disbot/services/btd6_strategy_mutation.py`**
  - `staff_approve_guild()`: Approves a draft strategy at guild-local visibility (separate from global publish)
  - Validates staff permissions server-side before any state change
  - Records audit trail with staff actor metadata
  - Added to `__all__` for public API

- **New command: `disbot/cogs/btd6_cog.py`**
  - `!btd6 strategies pending [limit]`: Lists pending strategies with review embeds and buttons
  - Staff-only (manage_guild permission required)
  - Configurable limit (1–10, default 5)

- **Comprehensive test coverage: `tests/unit/views/btd6/test_strategy_review.py`**
  - Embed rendering (title, summary, state fields, footer)
  - Button matrix visibility (Unpublish only for published strategies)
  - Staff permission enforcement (interaction_check)
  - All four button callbacks route through mutation service
  - Error handling (InvalidStrategyValueError, UnauthorizedStrategyMutationError)
  - Regression guard: buttons must not call DB directly

- **Mutation service tests: `tests/unit/services/test_btd6_strategy_staff_approve_guild.py`**
  - State update correctness (approval_status, visibility, version bump)
  - Audit trail recording
  - Permission validation (staff vs. non-staff)
  - Precondition checks (already published, missing strategy)

## Implementation Details

- **Separation of concerns**: Guild-local approval (`staff_approve_guild`) is explicitly decoupled from global publishing (`staff_publish`), requiring two distinct button clicks per the design plan
- **Error handling**: Mutation errors surface as typed ephemeral replies; server-side authorization is the source of truth (view's `interaction_check` is UX courtesy only)
- **Refresh pattern**: After successful mutation, the view re-fetches the strategy and updates the embed in-place, with an ephemeral confirmation to the staff actor
- **Lazy imports**: All service and DB imports are deferred to avoid circular dependencies

https://claude.ai/code/session_019vY4SECGtTT5xXdFAr6a9Q