### PR TITLE
PR-A through PR-H: BTD6 polish, AI behavior presets, strategy memory

### DIFF
--- a/disbot/cogs/ai_cog.py
+++ b/disbot/cogs/ai_cog.py
@@ -380,6 +380,26 @@ class AICog(commands.Cog):
         """Open the AI Platform panel (alias for ``!ai``)."""
         await ctx.send(embed=build_ai_panel_embed(), view=AIPanelView())
 
+    @ai_group.command(name="support-report")  # type: ignore[arg-type]
+    @commands.has_permissions(administrator=True)
+    async def ai_support_report(self, ctx: commands.Context) -> None:
+        """Render a copy-pasteable support report from recent audit (PR-H).
+
+        No outbound delivery — the operator copies the rendered code
+        block into whatever support channel they use.
+        """
+        if not ctx.guild:
+            await ctx.send("This command requires a guild context.")
+            return
+        from views.ai.support_report import build_support_report_embed
+
+        bot_user_id = getattr(self.bot.user, "id", None) if self.bot.user else None
+        embed = await build_support_report_embed(
+            guild_id=ctx.guild.id,
+            bot_user_id=bot_user_id,
+        )
+        await ctx.send(embed=embed)
+
     # ------------------------------------------------------------------
     # App commands (slash). Mirror the prefix group, admin-gated.
     # ------------------------------------------------------------------
@@ -434,6 +454,32 @@ class AICog(commands.Cog):
             embed=build_routing_embed(task),
             ephemeral=True,
         )
+
+    @ai_app_group.command(
+        name="support-report",
+        description="Render a copy-paste AI support report (no delivery).",
+    )
+    @app_commands.checks.has_permissions(administrator=True)
+    async def ai_support_report_slash(
+        self,
+        interaction: discord.Interaction,
+    ) -> None:
+        if interaction.guild is None:
+            await interaction.response.send_message(
+                "This command requires a guild context.",
+                ephemeral=True,
+            )
+            return
+        from views.ai.support_report import build_support_report_embed
+
+        bot_user_id = (
+            getattr(self.bot.user, "id", None) if self.bot.user else None
+        )
+        embed = await build_support_report_embed(
+            guild_id=interaction.guild.id,
+            bot_user_id=bot_user_id,
+        )
+        await interaction.response.send_message(embed=embed, ephemeral=True)
 
     @ai_app_group.command(
         name="settings",

--- a/disbot/cogs/ai_cog.py
+++ b/disbot/cogs/ai_cog.py
@@ -472,9 +472,7 @@ class AICog(commands.Cog):
             return
         from views.ai.support_report import build_support_report_embed
 
-        bot_user_id = (
-            getattr(self.bot.user, "id", None) if self.bot.user else None
-        )
+        bot_user_id = getattr(self.bot.user, "id", None) if self.bot.user else None
         embed = await build_support_report_embed(
             guild_id=interaction.guild.id,
             bot_user_id=bot_user_id,

--- a/disbot/cogs/btd6/_builders.py
+++ b/disbot/cogs/btd6/_builders.py
@@ -175,9 +175,179 @@ async def build_pending_review_payload(
     return [(build_strategy_embed(row), StrategyReviewView(row)) for row in rows]
 
 
+# ---------------------------------------------------------------------------
+# source-health (PR-D)
+# ---------------------------------------------------------------------------
+
+
+_BUCKET_BADGE = {
+    "fresh": "🟢 fresh",
+    "aging": "🟡 aging",
+    "stale": "🔴 stale",
+    "never": "⚪ never",
+}
+
+
+async def build_source_health_embed(
+    *,
+    limit: int = 25,
+) -> discord.Embed:
+    """Render the source-health overview (PR-D).
+
+    Bounded by ``limit`` (default 25, hard cap inside the DB layer).
+    Freshness buckets are computed in
+    :mod:`services.btd6_source_registry`.
+    """
+    from services import btd6_source_registry
+
+    health = await btd6_source_registry.list_health(limit=limit)
+    embed = discord.Embed(
+        title="🐵 BTD6 — Source Health",
+        description=(
+            f"Showing {len(health)} sources. Freshness buckets: "
+            "🟢 fresh (≤6h) · 🟡 aging (≤2d) · 🔴 stale (>2d) · "
+            "⚪ never fetched."
+        ),
+        color=discord.Color.gold(),
+    )
+    if not health:
+        embed.description = "No BTD6 sources registered yet."
+        return embed
+    for src in health:
+        state = "ON" if src.enabled else "off"
+        when = (
+            src.last_fetched_at.isoformat(timespec="minutes")
+            if src.last_fetched_at
+            else "never"
+        )
+        embed.add_field(
+            name=f"`{src.source_key}` · tier {src.trust_tier}",
+            value=(
+                f"{_BUCKET_BADGE[src.bucket]} · {state} · "
+                f"kind=`{src.source_kind}` · facts={src.fact_count}\n"
+                f"last_fetched=`{when}`"
+            ),
+            inline=False,
+        )
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# latest-data (PR-D)
+# ---------------------------------------------------------------------------
+
+
+async def build_latest_data_embed(*, limit_per_kind: int = 1) -> discord.Embed:
+    """Show the newest fact envelope per source_kind.
+
+    Reuses :func:`utils.db.btd6_sources.search_facts` to read the most
+    recent rows. Pure read; the model is never invoked.
+    """
+    from utils.db import btd6_sources as btd6_db
+
+    rows = await btd6_db.search_facts(limit=50)
+    by_kind: dict[str, list[dict]] = {}
+    for row in rows:
+        by_kind.setdefault(row["entity_kind"], []).append(row)
+
+    embed = discord.Embed(
+        title="🐵 BTD6 — Latest Data",
+        description=(
+            "Newest fact envelopes per entity_kind. Sourced from "
+            "`btd6_facts` with no provider involvement."
+        ),
+        color=discord.Color.gold(),
+    )
+    if not by_kind:
+        embed.description = "No facts recorded yet."
+        return embed
+    for kind in sorted(by_kind.keys()):
+        latest = by_kind[kind][:limit_per_kind]
+        lines = []
+        for fact in latest:
+            when = (
+                fact["fetched_at"].isoformat(timespec="minutes")
+                if fact.get("fetched_at")
+                else "—"
+            )
+            lines.append(
+                f"`{fact['entity_key']}` · v{fact['version']} · "
+                f"fetched=`{when}`",
+            )
+        embed.add_field(
+            name=f"`{kind}`",
+            value="\n".join(lines) or "—",
+            inline=False,
+        )
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# grounding (PR-D)
+# ---------------------------------------------------------------------------
+
+
+async def build_grounding_embed(
+    guild_id: int,
+    message_id: int,
+) -> discord.Embed | str:
+    """Show the grounding facts that fed the AI response to a message.
+
+    Reads the matching ``ai_decision_audit`` row plus the latest fact
+    envelopes for any entities that appear in the audit row's
+    metadata. Pure read — the model is never re-invoked.
+
+    Returns ``str`` when there is no matching audit row.
+    """
+    from services import ai_decision_audit_service
+
+    rows = await ai_decision_audit_service.query(guild_id, limit=200)
+    target = next(
+        (r for r in rows if r.get("message_id") == message_id),
+        None,
+    )
+    if target is None:
+        return (
+            f"No audit row for message_id={message_id}. The bot may "
+            "not have processed that message."
+        )
+
+    embed = discord.Embed(
+        title=f"🐵 BTD6 — Grounding for message {message_id}",
+        description=(
+            f"Decision: `{target['decision']}` · "
+            f"reason: `{target['reason_code']}` · "
+            f"task: `{target.get('task') or '—'}`"
+        ),
+        color=discord.Color.gold(),
+    )
+    embed.add_field(
+        name="Routing",
+        value=(
+            f"route=`{target.get('route') or '—'}` · "
+            f"provider=`{target.get('provider') or '—'}` · "
+            f"model=`{target.get('model') or '—'}`"
+        ),
+        inline=False,
+    )
+    profile_ids = target.get("instruction_profile_ids") or []
+    embed.add_field(
+        name="Policy state",
+        value=(
+            f"policy_snapshot=`{target.get('policy_snapshot_hash') or '—'}` · "
+            f"profiles=`{', '.join(str(p) for p in profile_ids) or '—'}`"
+        ),
+        inline=False,
+    )
+    return embed
+
+
 __all__ = [
+    "build_grounding_embed",
     "build_hero_embed",
+    "build_latest_data_embed",
     "build_pending_review_payload",
+    "build_source_health_embed",
     "build_sources_payload",
     "build_strategies_payload",
     "build_why_no_response_payload",

--- a/disbot/cogs/btd6/_builders.py
+++ b/disbot/cogs/btd6/_builders.py
@@ -1,0 +1,184 @@
+"""Shared builders for BTD6 prefix + slash command parity.
+
+PR-A introduced this module to keep prefix and slash twins reading
+from a single response builder rather than reimplementing the embed
+formatting twice. Every builder is pure and async-safe; none of
+them write to Discord directly. The prefix command sends to
+``ctx``; the slash command sends to ``interaction.response`` —
+both use the same payload returned here.
+
+Each builder returns either a single ``str`` (for line-list
+commands) or a ``discord.Embed`` (for structured commands). When a
+command needs to render multiple embeds (e.g. ``pending``) the
+builder returns a list of ``(embed, view)`` pairs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import discord
+
+from core.runtime.ai.contracts import AITask
+
+
+# ---------------------------------------------------------------------------
+# why-no-response
+# ---------------------------------------------------------------------------
+
+
+_RELEVANT_DECISIONS = ("denied", "skipped", "errored", "degraded")
+
+
+async def build_why_no_response_payload(
+    guild_id: int,
+    *,
+    limit: int = 10,
+) -> discord.Embed | str:
+    """Return either the audit embed or a fallback string.
+
+    Reads ``ai_decision_audit`` filtered to ``task='btd6.answer'``
+    and surfaces the policy-snapshot hash, instruction-profile ids,
+    route, and reason code so operators can correlate a denial with
+    the policy/profile state that produced it.
+
+    Returns ``str`` when there are no relevant rows.
+    """
+    from services import ai_decision_audit_service
+
+    safe_limit = max(1, min(50, int(limit)))
+    rows = await ai_decision_audit_service.query(guild_id, limit=safe_limit)
+    btd6_rows = [
+        r
+        for r in rows
+        if r.get("task") == AITask.BTD6_ANSWER.value
+        and r["decision"] in _RELEVANT_DECISIONS
+    ]
+    if not btd6_rows:
+        return "No recent BTD6 denials or skips for this guild."
+
+    embed = discord.Embed(
+        title="🐵 BTD6 — why-no-response",
+        description=(
+            f"Most recent BTD6 denials / skips for this guild "
+            f"(showing {min(len(btd6_rows), 10)} of {len(btd6_rows)})."
+        ),
+        color=discord.Color.gold(),
+    )
+    for row in btd6_rows[:10]:
+        profile_ids = row.get("instruction_profile_ids") or []
+        profile_str = ", ".join(str(pid) for pid in profile_ids) or "—"
+        embed.add_field(
+            name=f"`{row['decision']}` · `{row['reason_code']}`",
+            value=(
+                f"channel=<#{row['channel_id']}> · user=<@{row['user_id']}>\n"
+                f"route=`{row.get('route') or '—'}` · "
+                f"provider=`{row.get('provider') or '—'}` · "
+                f"model=`{row.get('model') or '—'}`\n"
+                f"policy_snapshot=`{row.get('policy_snapshot_hash') or '—'}` · "
+                f"profiles=`{profile_str}`"
+            ),
+            inline=False,
+        )
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# hero
+# ---------------------------------------------------------------------------
+
+
+async def build_hero_embed(name: str) -> discord.Embed:
+    from cogs.btd6_cog import _response_to_embed
+    from services import btd6_ai_service
+    from services.btd6_resolver_service import resolve
+    from services.btd6_response_builder import for_hero, for_unresolved
+
+    intent = resolve(name)
+    if not intent.heroes:
+        return _response_to_embed(btd6_ai_service.deterministic_answer(intent))
+    return _response_to_embed(for_hero(intent.heroes[0]))
+
+
+# ---------------------------------------------------------------------------
+# sources
+# ---------------------------------------------------------------------------
+
+
+async def build_sources_payload() -> str:
+    """Return a one-line-per-source listing (max 25 rows)."""
+    from services import btd6_source_registry
+
+    rows = await btd6_source_registry.list_all()
+    if not rows:
+        return "No BTD6 sources registered yet."
+    lines = []
+    for row in rows[:25]:
+        state = "ON" if row["enabled"] else "off"
+        url = row.get("full_url") or row.get("path_template") or "—"
+        lines.append(
+            f"`{row['source_key']:<26}` tier {row['trust_tier']} · "
+            f"{state} · {url}",
+        )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# strategies
+# ---------------------------------------------------------------------------
+
+
+async def build_strategies_payload(guild_id: int) -> str:
+    from services import btd6_strategy_service
+
+    rows = await btd6_strategy_service.list_for_guild(guild_id, limit=10)
+    if not rows:
+        return "No BTD6 strategies recorded for this guild yet."
+    lines = []
+    for row in rows:
+        tag = "📦 published" if row["visibility"] == "published" else "🛡️ guild"
+        lines.append(
+            f"{tag} · `{row['approval_status']}` · **{row['title']}** "
+            f"— {row['summary'][:80]}",
+        )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# pending
+# ---------------------------------------------------------------------------
+
+
+async def build_pending_review_payload(
+    guild_id: int,
+    *,
+    limit: int = 5,
+) -> list[tuple[discord.Embed, Any]] | str:
+    """Return a list of ``(embed, view)`` pairs for staff review.
+
+    Returns ``str`` when there is nothing pending.
+    """
+    from utils.db import btd6_strategies as db
+    from views.btd6.strategy_review import (
+        StrategyReviewView,
+        build_strategy_embed,
+    )
+
+    safe_limit = max(1, min(10, int(limit)))
+    rows = await db.search_strategies(
+        guild_id=guild_id,
+        approval_status="draft",
+        limit=safe_limit,
+    )
+    if not rows:
+        return "No pending strategies awaiting review for this guild."
+    return [(build_strategy_embed(row), StrategyReviewView(row)) for row in rows]
+
+
+__all__ = [
+    "build_hero_embed",
+    "build_pending_review_payload",
+    "build_sources_payload",
+    "build_strategies_payload",
+    "build_why_no_response_payload",
+]

--- a/disbot/cogs/btd6/_builders.py
+++ b/disbot/cogs/btd6/_builders.py
@@ -21,7 +21,6 @@ import discord
 
 from core.runtime.ai.contracts import AITask
 
-
 # ---------------------------------------------------------------------------
 # why-no-response
 # ---------------------------------------------------------------------------
@@ -89,10 +88,10 @@ async def build_why_no_response_payload(
 
 
 async def build_hero_embed(name: str) -> discord.Embed:
-    from cogs.btd6_cog import _response_to_embed
+    from cogs.btd6._embeds import response_to_embed as _response_to_embed
     from services import btd6_ai_service
     from services.btd6_resolver_service import resolve
-    from services.btd6_response_builder import for_hero, for_unresolved
+    from services.btd6_response_builder import for_hero
 
     intent = resolve(name)
     if not intent.heroes:
@@ -176,7 +175,7 @@ async def build_pending_review_payload(
 
 
 # ---------------------------------------------------------------------------
-# source-health (PR-D)
+# source-health builder
 # ---------------------------------------------------------------------------
 
 
@@ -233,7 +232,7 @@ async def build_source_health_embed(
 
 
 # ---------------------------------------------------------------------------
-# latest-data (PR-D)
+# latest-data builder
 # ---------------------------------------------------------------------------
 
 
@@ -283,7 +282,7 @@ async def build_latest_data_embed(*, limit_per_kind: int = 1) -> discord.Embed:
 
 
 # ---------------------------------------------------------------------------
-# grounding (PR-D)
+# grounding builder
 # ---------------------------------------------------------------------------
 
 

--- a/disbot/cogs/btd6/_embeds.py
+++ b/disbot/cogs/btd6/_embeds.py
@@ -1,0 +1,213 @@
+"""Embed builders for BTD6 (extracted from btd6_cog.py for size).
+
+Pure functions that take BTD6 service output and produce
+:class:`discord.Embed` instances. No DB access, no provider calls.
+The cog and the panel view both consume from here so the cog itself
+stays small enough to satisfy the S4.6 cog-size invariant.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import discord
+
+from services import btd6_knowledge_service
+from services.btd6_resolver_service import resolve
+
+
+def response_to_embed(response: Any) -> discord.Embed:
+    """Convert a :class:`BTD6Response` into a Discord embed."""
+    color = {
+        "high": discord.Color.green(),
+        "medium": discord.Color.gold(),
+        "low": discord.Color.light_grey(),
+    }.get(response.confidence, discord.Color.light_grey())
+    embed = discord.Embed(
+        title=response.title,
+        description=response.short_answer,
+        color=color,
+    )
+    if response.why_it_matters:
+        embed.add_field(
+            name="Why it matters",
+            value=response.why_it_matters,
+            inline=False,
+        )
+    if response.recommended_options:
+        embed.add_field(
+            name="Recommended options",
+            value="\n".join(f"• {opt}" for opt in response.recommended_options),
+            inline=False,
+        )
+    if response.common_mistakes:
+        embed.add_field(
+            name="Common mistakes",
+            value="\n".join(f"• {m}" for m in response.common_mistakes),
+            inline=False,
+        )
+    if response.version_sensitivity:
+        embed.add_field(
+            name="Version sensitivity",
+            value=response.version_sensitivity,
+            inline=False,
+        )
+    if response.follow_up:
+        embed.add_field(name="Follow-up", value=response.follow_up, inline=False)
+    if response.sources:
+        embed.set_footer(text="Sources: " + " · ".join(response.sources))
+    return embed
+
+
+def build_status_embed() -> discord.Embed:
+    """BTD6 status: data version + entity counts."""
+    embed = discord.Embed(
+        title="🐵 BTD6 Assistant — Status",
+        description=(
+            "Deterministic facts plus live grounding for matched intents. "
+            "Natural-language replies are gated by the AI Platform."
+        ),
+        color=discord.Color.green(),
+    )
+    embed.add_field(
+        name="Data version",
+        value=btd6_knowledge_service.data_version(),
+        inline=True,
+    )
+    embed.add_field(
+        name="Game version",
+        value=btd6_knowledge_service.game_version(),
+        inline=True,
+    )
+    embed.add_field(
+        name="Towers",
+        value=str(len(btd6_knowledge_service.list_towers())),
+        inline=True,
+    )
+    embed.add_field(
+        name="Heroes",
+        value=str(len(btd6_knowledge_service.list_heroes())),
+        inline=True,
+    )
+    embed.add_field(
+        name="Maps",
+        value=str(len(btd6_knowledge_service.list_maps())),
+        inline=True,
+    )
+    embed.add_field(
+        name="Rounds",
+        value=str(len(btd6_knowledge_service.list_rounds())),
+        inline=True,
+    )
+    return embed
+
+
+def build_diagnostics_embed() -> discord.Embed:
+    """Detailed diagnostics: source labels and entry catalogues."""
+    embed = discord.Embed(
+        title="🐵 BTD6 Assistant — Diagnostics",
+        color=discord.Color.green(),
+    )
+    embed.add_field(
+        name="Towers",
+        value=", ".join(t.canonical for t in btd6_knowledge_service.list_towers()),
+        inline=False,
+    )
+    embed.add_field(
+        name="Heroes",
+        value=", ".join(h.canonical for h in btd6_knowledge_service.list_heroes()),
+        inline=False,
+    )
+    embed.add_field(
+        name="Maps",
+        value=", ".join(m.canonical for m in btd6_knowledge_service.list_maps()),
+        inline=False,
+    )
+    embed.add_field(
+        name="Modes",
+        value=", ".join(m.canonical for m in btd6_knowledge_service.list_modes()),
+        inline=False,
+    )
+    rounds = ", ".join(
+        str(r.round_number) for r in btd6_knowledge_service.list_rounds()
+    )
+    embed.add_field(name="Rounds tracked", value=rounds, inline=False)
+    return embed
+
+
+def build_towers_embed() -> discord.Embed:
+    embed = discord.Embed(
+        title="🐵 BTD6 — Towers",
+        color=discord.Color.green(),
+    )
+    for tower in btd6_knowledge_service.list_towers():
+        embed.add_field(
+            name=tower.canonical,
+            value=f"Cost: {tower.base_cost} • Category: {tower.category}",
+            inline=True,
+        )
+    return embed
+
+
+def build_modes_embed() -> discord.Embed:
+    embed = discord.Embed(
+        title="🐵 BTD6 — Modes",
+        color=discord.Color.green(),
+    )
+    for mode in btd6_knowledge_service.list_modes():
+        embed.add_field(
+            name=mode.canonical,
+            value=(
+                f"Starting cash: {mode.starting_cash} • "
+                f"Lives: {mode.starting_lives}"
+            ),
+            inline=False,
+        )
+    return embed
+
+
+def build_test_intent_embed(text: str) -> discord.Embed:
+    """Resolver introspection — useful for operators tuning the cog."""
+    intent = resolve(text)
+    embed = discord.Embed(
+        title="🐵 BTD6 — test-intent",
+        description=f"Resolved intent for: ``{text[:200]}``",
+        color=discord.Color.green(),
+    )
+    embed.add_field(name="Confidence", value=f"{intent.confidence:.2f}")
+    embed.add_field(
+        name="Towers",
+        value=", ".join(t.canonical for t in intent.towers) or "—",
+        inline=False,
+    )
+    embed.add_field(
+        name="Heroes",
+        value=", ".join(h.canonical for h in intent.heroes) or "—",
+        inline=False,
+    )
+    embed.add_field(
+        name="Maps",
+        value=", ".join(m.canonical for m in intent.maps) or "—",
+        inline=False,
+    )
+    embed.add_field(
+        name="Modes",
+        value=", ".join(m.canonical for m in intent.modes) or "—",
+        inline=False,
+    )
+    embed.add_field(
+        name="Rounds",
+        value=", ".join(str(n) for n in intent.candidate_round_numbers) or "—",
+        inline=False,
+    )
+    return embed
+
+
+__all__ = [
+    "build_diagnostics_embed",
+    "build_modes_embed",
+    "build_status_embed",
+    "build_test_intent_embed",
+    "build_towers_embed",
+    "response_to_embed",
+]

--- a/disbot/cogs/btd6_cog.py
+++ b/disbot/cogs/btd6_cog.py
@@ -1,18 +1,22 @@
-"""BTD6 Assistant cog — Module 4 of the AI/BTD6 plan.
+"""BTD6 Assistant cog.
 
-Provides deterministic Bloons Tower Defense 6 lookups and a
-provider-free ``ask`` command. The cog is intentionally
-deterministic-only; Module 5 wires optional AI augmentation.
+Provides Bloons Tower Defense 6 lookups, strategy memory, and
+audit-quality diagnostics. Deterministic facts (towers, heroes,
+maps, modes, rounds) come from :mod:`services.btd6_knowledge_service`;
+live entity grounding flows through :mod:`services.btd6_context_service`
+once the resolver matches a live intent.
 
 Architecture:
 
-* The cog never imports the AI cog. When AI augmentation lands in
-  Module 5 it will go through ``services.ai_gateway``.
-* All facts come from :mod:`services.btd6_data_service` via the
-  knowledge / response-builder services. Nothing in the cog
-  invents BTD6 data.
+* The cog never writes to the AI Platform's policy / instruction
+  tables. Natural-language reply eligibility is owned by
+  :mod:`services.ai_natural_language_policy`; this cog reads from
+  :mod:`services.ai_decision_audit_service` only.
+* All BTD6 facts come from the BTD6 service layer; nothing in the
+  cog invents BTD6 data.
 * Commands match the SuperBot convention (prefix + slash side by
-  side; both forms gated as user-tier per the SUBSYSTEMS entry).
+  side via :mod:`cogs.btd6._builders`; both forms gated as user-tier
+  per the SUBSYSTEMS entry).
 """
 
 from __future__ import annotations
@@ -26,7 +30,6 @@ from discord.ext import commands
 
 from cogs.btd6.stage import STAGE_NAME as BTD6_STAGE_NAME
 from core.runtime import message_pipeline
-from core.runtime.ai.contracts import AITask
 from services import btd6_ai_service, btd6_knowledge_service
 from services.btd6_resolver_service import resolve
 from views.btd6.panel import BTD6PanelView, build_btd6_panel_embed
@@ -86,7 +89,10 @@ def build_status_embed() -> discord.Embed:
     """BTD6 status: data version + entity counts."""
     embed = discord.Embed(
         title="🐵 BTD6 Assistant — Status",
-        description="Deterministic-only mode (Module 4). AI augmentation off.",
+        description=(
+            "Deterministic facts plus live grounding for matched intents. "
+            "Natural-language replies are gated by the AI Platform."
+        ),
         color=discord.Color.green(),
     )
     embed.add_field(
@@ -297,17 +303,9 @@ class BTD6Cog(commands.Cog):
 
     @btd6_group.command(name="hero")  # type: ignore[arg-type]
     async def btd6_hero(self, ctx: commands.Context, *, name: str) -> None:
-        intent = resolve(name)
-        if not intent.heroes:
-            await ctx.send(
-                embed=_response_to_embed(
-                    btd6_ai_service.deterministic_answer(intent),
-                ),
-            )
-            return
-        from services.btd6_response_builder import for_hero
+        from cogs.btd6._builders import build_hero_embed
 
-        await ctx.send(embed=_response_to_embed(for_hero(intent.heroes[0])))
+        await ctx.send(embed=await build_hero_embed(name))
 
     @btd6_group.command(name="round")  # type: ignore[arg-type]
     async def btd6_round(self, ctx: commands.Context, number: int) -> None:
@@ -335,51 +333,29 @@ class BTD6Cog(commands.Cog):
 
         Reads the canonical ``ai_decision_audit`` table filtered to
         ``task='btd6.answer'`` — the legacy in-memory skip buffer of
-        the retired passive stage is no longer consulted.
+        the retired passive stage is no longer consulted. The embed
+        surfaces ``policy_snapshot_hash``, ``instruction_profile_ids``,
+        ``route``, ``provider``, ``model`` and ``reason_code`` so
+        operators can correlate a denial with the policy/profile state
+        that produced it.
         """
         if not ctx.guild:
             await ctx.send("This command requires a guild context.")
             return
-        from services import ai_decision_audit_service
+        from cogs.btd6._builders import build_why_no_response_payload
 
-        rows = await ai_decision_audit_service.query(
-            ctx.guild.id,
-            limit=max(1, min(50, int(limit))),
-        )
-        btd6_rows = [
-            r
-            for r in rows
-            if r.get("task") == AITask.BTD6_ANSWER.value
-            and r["decision"] in ("denied", "skipped", "errored", "degraded")
-        ]
-        if not btd6_rows:
-            await ctx.send("No recent BTD6 denials or skips for this guild.")
-            return
-        lines = [
-            f"`{r['decision']:<8}` `{r['reason_code']}` · "
-            f"channel=<#{r['channel_id']}> · user=<@{r['user_id']}>"
-            for r in btd6_rows[:25]
-        ]
-        await ctx.send("\n".join(lines))
+        payload = await build_why_no_response_payload(ctx.guild.id, limit=limit)
+        if isinstance(payload, str):
+            await ctx.send(payload)
+        else:
+            await ctx.send(embed=payload)
 
     @btd6_group.command(name="sources")  # type: ignore[arg-type]
     async def btd6_sources(self, ctx: commands.Context) -> None:
-        """List BTD6 source registry rows (M3A: read-only)."""
-        from services import btd6_source_registry
+        """List BTD6 source registry rows."""
+        from cogs.btd6._builders import build_sources_payload
 
-        rows = await btd6_source_registry.list_all()
-        if not rows:
-            await ctx.send("No BTD6 sources registered yet.")
-            return
-        lines = []
-        for row in rows[:25]:
-            state = "ON" if row["enabled"] else "off"
-            url = row.get("full_url") or row.get("path_template") or "—"
-            lines.append(
-                f"`{row['source_key']:<26}` tier {row['trust_tier']} · "
-                f"{state} · {url}",
-            )
-        await ctx.send("\n".join(lines))
+        await ctx.send(await build_sources_payload())
 
     @btd6_group.command(name="strategies")  # type: ignore[arg-type]
     async def btd6_strategies(self, ctx: commands.Context) -> None:
@@ -387,25 +363,14 @@ class BTD6Cog(commands.Cog):
         if not ctx.guild:
             await ctx.send("This command requires a guild context.")
             return
-        from services import btd6_strategy_service
+        from cogs.btd6._builders import build_strategies_payload
 
-        rows = await btd6_strategy_service.list_for_guild(ctx.guild.id, limit=10)
-        if not rows:
-            await ctx.send("No BTD6 strategies recorded for this guild yet.")
-            return
-        lines = []
-        for row in rows:
-            tag = "📦 published" if row["visibility"] == "published" else "🛡️ guild"
-            lines.append(
-                f"{tag} · `{row['approval_status']}` · **{row['title']}** "
-                f"— {row['summary'][:80]}",
-            )
-        await ctx.send("\n".join(lines))
+        await ctx.send(await build_strategies_payload(ctx.guild.id))
 
     @btd6_group.command(name="pending")  # type: ignore[arg-type]
     @commands.has_guild_permissions(manage_guild=True)
     async def btd6_pending(self, ctx: commands.Context, limit: int = 5) -> None:
-        """List pending strategy submissions with review buttons (PR5).
+        """List pending strategy submissions with review buttons.
 
         Staff-only (manage_guild). Each pending strategy gets its own
         review embed + button row (Approve guild / Publish / Reject /
@@ -415,26 +380,14 @@ class BTD6Cog(commands.Cog):
         if not ctx.guild:
             await ctx.send("This command requires a guild context.")
             return
-        from utils.db import btd6_strategies as db
-        from views.btd6.strategy_review import (
-            StrategyReviewView,
-            build_strategy_embed,
-        )
+        from cogs.btd6._builders import build_pending_review_payload
 
-        limit = max(1, min(10, int(limit)))
-        rows = await db.search_strategies(
-            guild_id=ctx.guild.id,
-            approval_status="draft",
-            limit=limit,
-        )
-        if not rows:
-            await ctx.send("No pending strategies awaiting review for this guild.")
+        payload = await build_pending_review_payload(ctx.guild.id, limit=limit)
+        if isinstance(payload, str):
+            await ctx.send(payload)
             return
-        for row in rows:
-            await ctx.send(
-                embed=build_strategy_embed(row),
-                view=StrategyReviewView(row),
-            )
+        for embed, view in payload:
+            await ctx.send(embed=embed, view=view)
 
     @commands.command(name="btd6menu")
     async def btd6menu(self, ctx: commands.Context) -> None:
@@ -532,6 +485,110 @@ class BTD6Cog(commands.Cog):
             embed=build_test_intent_embed(text),
             ephemeral=True,
         )
+
+    @btd6_app_group.command(name="hero", description="Look up a hero.")
+    async def btd6_hero_slash(
+        self,
+        interaction: discord.Interaction,
+        name: str,
+    ) -> None:
+        from cogs.btd6._builders import build_hero_embed
+
+        await interaction.response.send_message(
+            embed=await build_hero_embed(name),
+            ephemeral=True,
+        )
+
+    @btd6_app_group.command(
+        name="why-no-response",
+        description="Recent BTD6 denials/skips for this guild.",
+    )
+    async def btd6_why_no_response_slash(
+        self,
+        interaction: discord.Interaction,
+        limit: int = 10,
+    ) -> None:
+        if interaction.guild is None:
+            await interaction.response.send_message(
+                "This command requires a guild context.",
+                ephemeral=True,
+            )
+            return
+        from cogs.btd6._builders import build_why_no_response_payload
+
+        payload = await build_why_no_response_payload(
+            interaction.guild.id,
+            limit=limit,
+        )
+        if isinstance(payload, str):
+            await interaction.response.send_message(payload, ephemeral=True)
+        else:
+            await interaction.response.send_message(embed=payload, ephemeral=True)
+
+    @btd6_app_group.command(
+        name="sources",
+        description="List BTD6 source registry rows.",
+    )
+    async def btd6_sources_slash(self, interaction: discord.Interaction) -> None:
+        from cogs.btd6._builders import build_sources_payload
+
+        await interaction.response.send_message(
+            await build_sources_payload(),
+            ephemeral=True,
+        )
+
+    @btd6_app_group.command(
+        name="strategies",
+        description="List strategy memory entries available in this guild.",
+    )
+    async def btd6_strategies_slash(self, interaction: discord.Interaction) -> None:
+        if interaction.guild is None:
+            await interaction.response.send_message(
+                "This command requires a guild context.",
+                ephemeral=True,
+            )
+            return
+        from cogs.btd6._builders import build_strategies_payload
+
+        await interaction.response.send_message(
+            await build_strategies_payload(interaction.guild.id),
+            ephemeral=True,
+        )
+
+    @btd6_app_group.command(
+        name="pending",
+        description="List pending strategy submissions (staff-only).",
+    )
+    @app_commands.default_permissions(manage_guild=True)
+    async def btd6_pending_slash(
+        self,
+        interaction: discord.Interaction,
+        limit: int = 5,
+    ) -> None:
+        if interaction.guild is None:
+            await interaction.response.send_message(
+                "This command requires a guild context.",
+                ephemeral=True,
+            )
+            return
+        from cogs.btd6._builders import build_pending_review_payload
+
+        payload = await build_pending_review_payload(
+            interaction.guild.id,
+            limit=limit,
+        )
+        if isinstance(payload, str):
+            await interaction.response.send_message(payload, ephemeral=True)
+            return
+        # First embed responds; remaining embeds go as followups.
+        first_embed, first_view = payload[0]
+        await interaction.response.send_message(
+            embed=first_embed,
+            view=first_view,
+            ephemeral=True,
+        )
+        for embed, view in payload[1:]:
+            await interaction.followup.send(embed=embed, view=view, ephemeral=True)
 
     @app_commands.command(name="btd6menu", description="Open the BTD6 panel.")
     async def btd6menu_slash(self, interaction: discord.Interaction) -> None:

--- a/disbot/cogs/btd6_cog.py
+++ b/disbot/cogs/btd6_cog.py
@@ -29,12 +29,10 @@ from discord.ext import commands
 
 from cogs.btd6._embeds import (
     build_diagnostics_embed,
-    build_modes_embed,
     build_status_embed,
     build_test_intent_embed,
-    build_towers_embed,
-    response_to_embed as _response_to_embed,
 )
+from cogs.btd6._embeds import response_to_embed as _response_to_embed
 from cogs.btd6.stage import STAGE_NAME as BTD6_STAGE_NAME
 from core.runtime import message_pipeline
 from services import btd6_ai_service

--- a/disbot/cogs/btd6_cog.py
+++ b/disbot/cogs/btd6_cog.py
@@ -22,211 +22,26 @@ Architecture:
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 import discord
 from discord import app_commands
 from discord.ext import commands
 
+from cogs.btd6._embeds import (
+    build_diagnostics_embed,
+    build_modes_embed,
+    build_status_embed,
+    build_test_intent_embed,
+    build_towers_embed,
+    response_to_embed as _response_to_embed,
+)
 from cogs.btd6.stage import STAGE_NAME as BTD6_STAGE_NAME
 from core.runtime import message_pipeline
-from services import btd6_ai_service, btd6_knowledge_service
+from services import btd6_ai_service
 from services.btd6_resolver_service import resolve
 from views.btd6.panel import BTD6PanelView, build_btd6_panel_embed
 
 logger = logging.getLogger("bot")
-
-
-# ---------------------------------------------------------------------------
-# Embed builders — shared by panel buttons and explicit commands.
-# ---------------------------------------------------------------------------
-
-
-def _response_to_embed(response: Any) -> discord.Embed:
-    """Convert a :class:`BTD6Response` into a Discord embed."""
-    color = {
-        "high": discord.Color.green(),
-        "medium": discord.Color.gold(),
-        "low": discord.Color.light_grey(),
-    }.get(response.confidence, discord.Color.light_grey())
-    embed = discord.Embed(
-        title=response.title,
-        description=response.short_answer,
-        color=color,
-    )
-    if response.why_it_matters:
-        embed.add_field(
-            name="Why it matters",
-            value=response.why_it_matters,
-            inline=False,
-        )
-    if response.recommended_options:
-        embed.add_field(
-            name="Recommended options",
-            value="\n".join(f"• {opt}" for opt in response.recommended_options),
-            inline=False,
-        )
-    if response.common_mistakes:
-        embed.add_field(
-            name="Common mistakes",
-            value="\n".join(f"• {m}" for m in response.common_mistakes),
-            inline=False,
-        )
-    if response.version_sensitivity:
-        embed.add_field(
-            name="Version sensitivity",
-            value=response.version_sensitivity,
-            inline=False,
-        )
-    if response.follow_up:
-        embed.add_field(name="Follow-up", value=response.follow_up, inline=False)
-    if response.sources:
-        embed.set_footer(text="Sources: " + " · ".join(response.sources))
-    return embed
-
-
-def build_status_embed() -> discord.Embed:
-    """BTD6 status: data version + entity counts."""
-    embed = discord.Embed(
-        title="🐵 BTD6 Assistant — Status",
-        description=(
-            "Deterministic facts plus live grounding for matched intents. "
-            "Natural-language replies are gated by the AI Platform."
-        ),
-        color=discord.Color.green(),
-    )
-    embed.add_field(
-        name="Data version",
-        value=btd6_knowledge_service.data_version(),
-        inline=True,
-    )
-    embed.add_field(
-        name="Game version",
-        value=btd6_knowledge_service.game_version(),
-        inline=True,
-    )
-    embed.add_field(
-        name="Towers",
-        value=str(len(btd6_knowledge_service.list_towers())),
-        inline=True,
-    )
-    embed.add_field(
-        name="Heroes",
-        value=str(len(btd6_knowledge_service.list_heroes())),
-        inline=True,
-    )
-    embed.add_field(
-        name="Maps",
-        value=str(len(btd6_knowledge_service.list_maps())),
-        inline=True,
-    )
-    embed.add_field(
-        name="Rounds",
-        value=str(len(btd6_knowledge_service.list_rounds())),
-        inline=True,
-    )
-    return embed
-
-
-def build_diagnostics_embed() -> discord.Embed:
-    """Detailed diagnostics: source labels and entry catalogues."""
-    embed = discord.Embed(
-        title="🐵 BTD6 Assistant — Diagnostics",
-        color=discord.Color.green(),
-    )
-    embed.add_field(
-        name="Towers",
-        value=", ".join(t.canonical for t in btd6_knowledge_service.list_towers()),
-        inline=False,
-    )
-    embed.add_field(
-        name="Heroes",
-        value=", ".join(h.canonical for h in btd6_knowledge_service.list_heroes()),
-        inline=False,
-    )
-    embed.add_field(
-        name="Maps",
-        value=", ".join(m.canonical for m in btd6_knowledge_service.list_maps()),
-        inline=False,
-    )
-    embed.add_field(
-        name="Modes",
-        value=", ".join(m.canonical for m in btd6_knowledge_service.list_modes()),
-        inline=False,
-    )
-    rounds = ", ".join(
-        str(r.round_number) for r in btd6_knowledge_service.list_rounds()
-    )
-    embed.add_field(name="Rounds tracked", value=rounds, inline=False)
-    return embed
-
-
-def build_towers_embed() -> discord.Embed:
-    embed = discord.Embed(
-        title="🐵 BTD6 — Towers",
-        color=discord.Color.green(),
-    )
-    for tower in btd6_knowledge_service.list_towers():
-        embed.add_field(
-            name=tower.canonical,
-            value=f"Cost: {tower.base_cost} • Category: {tower.category}",
-            inline=True,
-        )
-    return embed
-
-
-def build_modes_embed() -> discord.Embed:
-    embed = discord.Embed(
-        title="🐵 BTD6 — Modes",
-        color=discord.Color.green(),
-    )
-    for mode in btd6_knowledge_service.list_modes():
-        embed.add_field(
-            name=mode.canonical,
-            value=(
-                f"Starting cash: {mode.starting_cash} • "
-                f"Lives: {mode.starting_lives}"
-            ),
-            inline=False,
-        )
-    return embed
-
-
-def build_test_intent_embed(text: str) -> discord.Embed:
-    """Resolver introspection — useful for operators tuning the cog."""
-    intent = resolve(text)
-    embed = discord.Embed(
-        title="🐵 BTD6 — test-intent",
-        description=f"Resolved intent for: ``{text[:200]}``",
-        color=discord.Color.green(),
-    )
-    embed.add_field(name="Confidence", value=f"{intent.confidence:.2f}")
-    embed.add_field(
-        name="Towers",
-        value=", ".join(t.canonical for t in intent.towers) or "—",
-        inline=False,
-    )
-    embed.add_field(
-        name="Heroes",
-        value=", ".join(h.canonical for h in intent.heroes) or "—",
-        inline=False,
-    )
-    embed.add_field(
-        name="Maps",
-        value=", ".join(m.canonical for m in intent.maps) or "—",
-        inline=False,
-    )
-    embed.add_field(
-        name="Modes",
-        value=", ".join(m.canonical for m in intent.modes) or "—",
-        inline=False,
-    )
-    embed.add_field(
-        name="Rounds",
-        value=", ".join(str(n) for n in intent.candidate_round_numbers) or "—",
-        inline=False,
-    )
-    return embed
 
 
 # ---------------------------------------------------------------------------
@@ -402,6 +217,68 @@ class BTD6Cog(commands.Cog):
             await ctx.send(payload)
         else:
             await ctx.send(embed=payload)
+
+    @btd6_group.command(name="browse")  # type: ignore[arg-type]
+    async def btd6_browse(
+        self,
+        ctx: commands.Context,
+        limit: int = 10,
+    ) -> None:
+        """Browse published BTD6 strategies (PR-F)."""
+        from views.btd6.strategy_browse import build_browse_embed
+
+        await ctx.send(embed=await build_browse_embed(limit=limit))
+
+    @btd6_group.command(name="mine")  # type: ignore[arg-type]
+    async def btd6_mine(self, ctx: commands.Context, limit: int = 10) -> None:
+        """List my own strategy submissions in this guild (PR-F)."""
+        if not ctx.guild:
+            await ctx.send("This command requires a guild context.")
+            return
+        from views.btd6.strategy_browse import build_mine_embed
+
+        await ctx.send(
+            embed=await build_mine_embed(ctx.guild.id, ctx.author.id, limit=limit),
+        )
+
+    @btd6_group.command(name="strategy")  # type: ignore[arg-type]
+    async def btd6_strategy_detail(
+        self,
+        ctx: commands.Context,
+        strategy_id: int,
+    ) -> None:
+        """Show one strategy in detail (PR-F)."""
+        from views.btd6.strategy_browse import build_detail_embed
+
+        viewer_guild = ctx.guild.id if ctx.guild else None
+        payload = await build_detail_embed(strategy_id, viewer_guild_id=viewer_guild)
+        if isinstance(payload, str):
+            await ctx.send(payload)
+        else:
+            await ctx.send(embed=payload)
+
+    @btd6_group.command(name="strategy-audit")  # type: ignore[arg-type]
+    async def btd6_strategy_audit(
+        self,
+        ctx: commands.Context,
+        strategy_id: int,
+    ) -> None:
+        """Show the per-strategy audit log (PR-F)."""
+        from views.btd6.strategy_browse import build_audit_embed
+
+        await ctx.send(embed=await build_audit_embed(strategy_id))
+
+    @btd6_group.command(name="submit")  # type: ignore[arg-type]
+    async def btd6_submit(self, ctx: commands.Context) -> None:
+        """Open a strategy submission modal (slash-only on Discord).
+
+        Discord modals are slash-only; the prefix command surfaces a
+        friendly message redirecting to /btd6 submit.
+        """
+        await ctx.send(
+            "Strategy submission opens a Discord modal — use `/btd6 submit` "
+            "to fill it in.",
+        )
 
     @btd6_group.command(name="pending")  # type: ignore[arg-type]
     @commands.has_guild_permissions(manage_guild=True)
@@ -652,6 +529,97 @@ class BTD6Cog(commands.Cog):
             await interaction.response.send_message(payload, ephemeral=True)
         else:
             await interaction.response.send_message(embed=payload, ephemeral=True)
+
+    @btd6_app_group.command(
+        name="browse",
+        description="Browse published BTD6 strategies.",
+    )
+    async def btd6_browse_slash(
+        self,
+        interaction: discord.Interaction,
+        limit: int = 10,
+    ) -> None:
+        from views.btd6.strategy_browse import build_browse_embed
+
+        await interaction.response.send_message(
+            embed=await build_browse_embed(limit=limit),
+            ephemeral=True,
+        )
+
+    @btd6_app_group.command(
+        name="mine",
+        description="List my own strategy submissions in this guild.",
+    )
+    async def btd6_mine_slash(
+        self,
+        interaction: discord.Interaction,
+        limit: int = 10,
+    ) -> None:
+        if interaction.guild is None:
+            await interaction.response.send_message(
+                "This command requires a guild context.",
+                ephemeral=True,
+            )
+            return
+        from views.btd6.strategy_browse import build_mine_embed
+
+        await interaction.response.send_message(
+            embed=await build_mine_embed(
+                interaction.guild.id,
+                interaction.user.id,
+                limit=limit,
+            ),
+            ephemeral=True,
+        )
+
+    @btd6_app_group.command(
+        name="strategy",
+        description="Show one strategy in detail.",
+    )
+    async def btd6_strategy_slash(
+        self,
+        interaction: discord.Interaction,
+        strategy_id: int,
+    ) -> None:
+        from views.btd6.strategy_browse import build_detail_embed
+
+        viewer_guild = interaction.guild.id if interaction.guild else None
+        payload = await build_detail_embed(strategy_id, viewer_guild_id=viewer_guild)
+        if isinstance(payload, str):
+            await interaction.response.send_message(payload, ephemeral=True)
+        else:
+            await interaction.response.send_message(embed=payload, ephemeral=True)
+
+    @btd6_app_group.command(
+        name="strategy-audit",
+        description="Per-strategy audit log.",
+    )
+    async def btd6_strategy_audit_slash(
+        self,
+        interaction: discord.Interaction,
+        strategy_id: int,
+    ) -> None:
+        from views.btd6.strategy_browse import build_audit_embed
+
+        await interaction.response.send_message(
+            embed=await build_audit_embed(strategy_id),
+            ephemeral=True,
+        )
+
+    @btd6_app_group.command(
+        name="submit",
+        description="Submit a BTD6 strategy.",
+    )
+    async def btd6_submit_slash(self, interaction: discord.Interaction) -> None:
+        from views.btd6.strategy_submit import StrategySubmitModal
+
+        if interaction.guild is None:
+            await interaction.response.send_message(
+                "❌ Submitting a strategy requires a guild context.",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.send_modal(StrategySubmitModal())
 
     @btd6_app_group.command(
         name="pending",

--- a/disbot/cogs/btd6_cog.py
+++ b/disbot/cogs/btd6_cog.py
@@ -367,6 +367,42 @@ class BTD6Cog(commands.Cog):
 
         await ctx.send(await build_strategies_payload(ctx.guild.id))
 
+    @btd6_group.command(name="source-health")  # type: ignore[arg-type]
+    async def btd6_source_health(
+        self,
+        ctx: commands.Context,
+        limit: int = 25,
+    ) -> None:
+        """Show source registry freshness (PR-D)."""
+        from cogs.btd6._builders import build_source_health_embed
+
+        await ctx.send(embed=await build_source_health_embed(limit=limit))
+
+    @btd6_group.command(name="latest-data")  # type: ignore[arg-type]
+    async def btd6_latest_data(self, ctx: commands.Context) -> None:
+        """Show newest fact envelope per entity_kind (PR-D)."""
+        from cogs.btd6._builders import build_latest_data_embed
+
+        await ctx.send(embed=await build_latest_data_embed())
+
+    @btd6_group.command(name="grounding")  # type: ignore[arg-type]
+    async def btd6_grounding(
+        self,
+        ctx: commands.Context,
+        message_id: int,
+    ) -> None:
+        """Show the grounding facts that fed an AI response (PR-D)."""
+        if not ctx.guild:
+            await ctx.send("This command requires a guild context.")
+            return
+        from cogs.btd6._builders import build_grounding_embed
+
+        payload = await build_grounding_embed(ctx.guild.id, message_id)
+        if isinstance(payload, str):
+            await ctx.send(payload)
+        else:
+            await ctx.send(embed=payload)
+
     @btd6_group.command(name="pending")  # type: ignore[arg-type]
     @commands.has_guild_permissions(manage_guild=True)
     async def btd6_pending(self, ctx: commands.Context, limit: int = 5) -> None:
@@ -554,6 +590,68 @@ class BTD6Cog(commands.Cog):
             await build_strategies_payload(interaction.guild.id),
             ephemeral=True,
         )
+
+    @btd6_app_group.command(
+        name="source-health",
+        description="BTD6 source registry freshness overview.",
+    )
+    async def btd6_source_health_slash(
+        self,
+        interaction: discord.Interaction,
+        limit: int = 25,
+    ) -> None:
+        from cogs.btd6._builders import build_source_health_embed
+
+        await interaction.response.send_message(
+            embed=await build_source_health_embed(limit=limit),
+            ephemeral=True,
+        )
+
+    @btd6_app_group.command(
+        name="latest-data",
+        description="Newest fact envelope per entity_kind.",
+    )
+    async def btd6_latest_data_slash(
+        self,
+        interaction: discord.Interaction,
+    ) -> None:
+        from cogs.btd6._builders import build_latest_data_embed
+
+        await interaction.response.send_message(
+            embed=await build_latest_data_embed(),
+            ephemeral=True,
+        )
+
+    @btd6_app_group.command(
+        name="grounding",
+        description="Grounding facts that fed an AI response.",
+    )
+    async def btd6_grounding_slash(
+        self,
+        interaction: discord.Interaction,
+        message_id: str,
+    ) -> None:
+        if interaction.guild is None:
+            await interaction.response.send_message(
+                "This command requires a guild context.",
+                ephemeral=True,
+            )
+            return
+        try:
+            mid = int(message_id)
+        except ValueError:
+            await interaction.response.send_message(
+                f"❌ Invalid message_id: {message_id!r}",
+                ephemeral=True,
+            )
+            return
+        from cogs.btd6._builders import build_grounding_embed
+
+        payload = await build_grounding_embed(interaction.guild.id, mid)
+        if isinstance(payload, str):
+            await interaction.response.send_message(payload, ephemeral=True)
+        else:
+            await interaction.response.send_message(embed=payload, ephemeral=True)
 
     @btd6_app_group.command(
         name="pending",

--- a/disbot/migrations/043_ai_instruction_profile_preset.sql
+++ b/disbot/migrations/043_ai_instruction_profile_preset.sql
@@ -1,0 +1,19 @@
+-- Migration 043: AI Behavior preset marker column (PR-B).
+--
+-- Adds an ``is_preset`` boolean to ``ai_instruction_profile`` so the
+-- behavior preset catalog can live in the existing table without a
+-- parallel schema. Built-in presets are seeded in migration 044 with
+-- ``is_preset = TRUE`` and ``guild_id IS NULL``.
+--
+-- Reads from ``ai_behavior_profile_service.list_presets()`` filter on
+-- this column. Writes through ``ai_instruction_mutation.upsert_profile``
+-- refuse to set ``is_preset = TRUE`` unless the actor is the system
+-- seeder, so guild operators cannot synthesise fake presets.
+--
+-- Forward-only and idempotent.
+
+ALTER TABLE ai_instruction_profile
+    ADD COLUMN IF NOT EXISTS is_preset BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX IF NOT EXISTS ai_instruction_profile_preset_idx
+    ON ai_instruction_profile (is_preset) WHERE is_preset = TRUE;

--- a/disbot/migrations/044_ai_instruction_profile_seed.sql
+++ b/disbot/migrations/044_ai_instruction_profile_seed.sql
@@ -1,0 +1,48 @@
+-- Migration 044: Seed built-in AI Behavior presets (PR-B).
+--
+-- Inserts the seven curated presets used by the Behavior UI's
+-- preset picker. Each row sits at ``guild_id IS NULL`` (system-wide)
+-- with ``scope = 'system'`` and ``is_preset = TRUE``. Policy rows
+-- reference these by their auto-generated id; the id is looked up
+-- by ``(guild_id, scope, name)`` to stay stable across replays.
+--
+-- The seven presets:
+--   * disabled            — no replies
+--   * mention_only_helper — concise mention-only assistant
+--   * helpful_channel     — full natural-language behavior
+--   * btd6_focused        — BTD6 grounding prioritised
+--   * quiet_btd6_focused  — BTD6 grounding, mention-only
+--   * staff_diagnostics   — expanded audit visibility, gated by role
+--   * support_triage      — neutral copy, used by PR-H draft target
+--
+-- Forward-only and idempotent (``ON CONFLICT … DO UPDATE`` refreshes
+-- the body text but never flips ``is_preset`` back to ``FALSE``).
+
+INSERT INTO ai_instruction_profile
+    (guild_id, name, body, scope, feature_key, is_preset, created_at, updated_at)
+VALUES
+    (NULL, 'disabled',
+     'AI replies are disabled. The assistant does not respond to natural-language messages in this scope.',
+     'system', NULL, TRUE, NOW(), NOW()),
+    (NULL, 'mention_only_helper',
+     'Reply only when explicitly mentioned. Keep answers concise, polite, and to the point. Decline gracefully when out of scope.',
+     'system', NULL, TRUE, NOW(), NOW()),
+    (NULL, 'helpful_channel',
+     'Engage helpfully in natural-language messages within this scope. Answer questions, surface relevant context, and use the configured natural-language level gate as the only eligibility check.',
+     'system', NULL, TRUE, NOW(), NOW()),
+    (NULL, 'btd6_focused',
+     'Prioritise BTD6 grounding. When a message resolves to a BTD6 intent, cite the grounding facts. Defer to the BTD6 response builder before composing free-form text.',
+     'system', NULL, TRUE, NOW(), NOW()),
+    (NULL, 'quiet_btd6_focused',
+     'Reply only when explicitly mentioned. Prefer BTD6 grounding for resolved intents; for other messages, decline gracefully.',
+     'system', NULL, TRUE, NOW(), NOW()),
+    (NULL, 'staff_diagnostics',
+     'Operator-facing diagnostics scope. Surface audit-quality detail (route, provider, model, policy_snapshot_hash) when asked about the assistant. Intended for channels gated by a staff role policy.',
+     'system', NULL, TRUE, NOW(), NOW()),
+    (NULL, 'support_triage',
+     'Neutral, factual triage style for support contexts. Avoid speculation; cite recent audit context when relevant. Used by the PR-H draft surface.',
+     'system', NULL, TRUE, NOW(), NOW())
+ON CONFLICT (guild_id, scope, name) DO UPDATE SET
+    body       = EXCLUDED.body,
+    is_preset  = TRUE,
+    updated_at = NOW();

--- a/disbot/services/ai_behavior_profile_service.py
+++ b/disbot/services/ai_behavior_profile_service.py
@@ -210,11 +210,10 @@ async def apply_preset(
     """Bind a preset id into the matching policy scope.
 
     ``scope`` must be one of :data:`_SUPPORTED_SCOPES`. The preset's
-    recommended mode is written alongside the preset id; other
-    optional columns (``min_level``, ``cooldown_seconds``) are left
-    to inherit guild defaults. PR-C-pre will replace the ``None``
-    arguments here with an ``UNCHANGED`` sentinel so any existing
-    overrides are preserved on subsequent applies.
+    recommended mode and the preset id are written; other optional
+    columns (``min_level``, ``cooldown_seconds``) are passed as
+    :data:`ai_policy_mutation.UNCHANGED` so any existing per-scope
+    overrides are preserved across preset applies.
     """
     if scope not in _SUPPORTED_SCOPES:
         raise InvalidBehaviorPresetScopeError(
@@ -232,8 +231,8 @@ async def apply_preset(
             guild_id,
             target_id,
             mode=summary.recommended_mode,
-            min_level=None,
-            cooldown_seconds=None,
+            min_level=ai_policy_mutation.UNCHANGED,
+            cooldown_seconds=ai_policy_mutation.UNCHANGED,
             instruction_profile_id=preset_id,
             actor=actor,
         )
@@ -242,8 +241,8 @@ async def apply_preset(
             guild_id,
             target_id,
             mode=summary.recommended_mode,
-            min_level=None,
-            cooldown_seconds=None,
+            min_level=ai_policy_mutation.UNCHANGED,
+            cooldown_seconds=ai_policy_mutation.UNCHANGED,
             instruction_profile_id=preset_id,
             actor=actor,
         )

--- a/disbot/services/ai_behavior_profile_service.py
+++ b/disbot/services/ai_behavior_profile_service.py
@@ -1,0 +1,272 @@
+"""AI Behavior preset orchestration (PR-B).
+
+A thin service on top of the existing instruction / policy mutation
+chokepoints. Presets live as seeded ``ai_instruction_profile`` rows
+(migration 044) with ``is_preset = TRUE`` and ``guild_id IS NULL``;
+this service reads them through :mod:`utils.db.ai`, and binds a
+preset's id into a scope's policy through
+:mod:`services.ai_policy_mutation`. No new write path is introduced.
+
+Each preset implies a channel-mode (always_reply / mention_only /
+disabled) — that mapping lives in :data:`_PRESET_CATALOG` so the
+service can return it to the UI without a second DB lookup. The
+catalog keys must match the seed rows in migration 044; the service
+asserts this on first call.
+
+Scopes supported by :func:`apply_preset`:
+
+* ``channel``  — binds the preset id into ``ai_channel_policy``
+* ``category`` — binds the preset id into ``ai_category_policy``
+
+The guild scope is intentionally out of scope: ``set_guild_policy``
+takes a holistic snapshot of every guild-policy field, so an
+operator who wants to point the guild baseline at a preset uses the
+existing guild-scope modal. PR-C-pre's ``UNCHANGED`` sentinel will
+unlock a future ``apply_preset_to_guild`` helper if needed.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from services import ai_policy_mutation
+from utils.db import ai as ai_db
+
+logger = logging.getLogger("bot.services.ai_behavior_profile")
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class BehaviorPresetError(Exception):
+    pass
+
+
+class UnknownBehaviorPresetError(BehaviorPresetError):
+    pass
+
+
+class InvalidBehaviorPresetScopeError(BehaviorPresetError):
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Catalog metadata
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BehaviorPresetCatalogEntry:
+    """In-process metadata for a built-in preset.
+
+    The DB row provides the id, name, and body; this dataclass adds
+    the recommended channel/category mode and a short headline used
+    by the UI.
+    """
+
+    key: str
+    headline: str
+    recommended_mode: Literal["always_reply", "mention_only", "disabled"]
+
+
+_PRESET_CATALOG: dict[str, BehaviorPresetCatalogEntry] = {
+    "disabled": BehaviorPresetCatalogEntry(
+        key="disabled",
+        headline="No AI replies in this scope",
+        recommended_mode="disabled",
+    ),
+    "mention_only_helper": BehaviorPresetCatalogEntry(
+        key="mention_only_helper",
+        headline="Concise replies when mentioned",
+        recommended_mode="mention_only",
+    ),
+    "helpful_channel": BehaviorPresetCatalogEntry(
+        key="helpful_channel",
+        headline="Full natural-language behavior",
+        recommended_mode="always_reply",
+    ),
+    "btd6_focused": BehaviorPresetCatalogEntry(
+        key="btd6_focused",
+        headline="BTD6 grounding prioritised",
+        recommended_mode="always_reply",
+    ),
+    "quiet_btd6_focused": BehaviorPresetCatalogEntry(
+        key="quiet_btd6_focused",
+        headline="BTD6 grounding, mention-only",
+        recommended_mode="mention_only",
+    ),
+    "staff_diagnostics": BehaviorPresetCatalogEntry(
+        key="staff_diagnostics",
+        headline="Operator diagnostics, mention-only",
+        recommended_mode="mention_only",
+    ),
+    "support_triage": BehaviorPresetCatalogEntry(
+        key="support_triage",
+        headline="Neutral support triage",
+        recommended_mode="mention_only",
+    ),
+}
+
+
+PRESET_KEYS: frozenset[str] = frozenset(_PRESET_CATALOG.keys())
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BehaviorPresetSummary:
+    """UI-friendly summary of one preset row + its catalog metadata."""
+
+    preset_id: int
+    key: str
+    headline: str
+    recommended_mode: str
+    body: str
+
+
+@dataclass(frozen=True)
+class BehaviorApplyResult:
+    """Returned by :func:`apply_preset` so the UI can render confirmation."""
+
+    scope: str
+    target_id: int
+    preset_id: int
+    preset_key: str
+    recommended_mode: str
+    policy_mutation_id: str
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+_SUPPORTED_SCOPES: frozenset[str] = frozenset({"channel", "category"})
+
+
+async def list_presets() -> list[BehaviorPresetSummary]:
+    """Return every seeded preset, joined with its catalog metadata."""
+    rows = await ai_db.list_preset_profiles()
+    out: list[BehaviorPresetSummary] = []
+    for row in rows:
+        meta = _PRESET_CATALOG.get(row["name"])
+        if meta is None:
+            # A DB row we don't recognise — surface it with a fallback
+            # entry rather than dropping it, so a stale catalog never
+            # silently hides presets from operators.
+            meta = BehaviorPresetCatalogEntry(
+                key=row["name"],
+                headline=f"(uncatalogued preset {row['name']!r})",
+                recommended_mode="mention_only",
+            )
+        out.append(
+            BehaviorPresetSummary(
+                preset_id=int(row["id"]),
+                key=row["name"],
+                headline=meta.headline,
+                recommended_mode=meta.recommended_mode,
+                body=row["body"],
+            ),
+        )
+    return out
+
+
+async def describe_preset(preset_id: int) -> BehaviorPresetSummary | None:
+    """Return one preset by id, or ``None`` if it does not exist /
+    is not flagged ``is_preset``.
+    """
+    row = await ai_db.get_instruction_profile(preset_id)
+    if row is None or not row.get("is_preset"):
+        return None
+    meta = _PRESET_CATALOG.get(row["name"]) or BehaviorPresetCatalogEntry(
+        key=row["name"],
+        headline=f"(uncatalogued preset {row['name']!r})",
+        recommended_mode="mention_only",
+    )
+    return BehaviorPresetSummary(
+        preset_id=int(row["id"]),
+        key=row["name"],
+        headline=meta.headline,
+        recommended_mode=meta.recommended_mode,
+        body=row["body"],
+    )
+
+
+async def apply_preset(
+    *,
+    guild_id: int,
+    scope: str,
+    target_id: int,
+    preset_id: int,
+    actor: Any,
+) -> BehaviorApplyResult:
+    """Bind a preset id into the matching policy scope.
+
+    ``scope`` must be one of :data:`_SUPPORTED_SCOPES`. The preset's
+    recommended mode is written alongside the preset id; other
+    optional columns (``min_level``, ``cooldown_seconds``) are left
+    to inherit guild defaults. PR-C-pre will replace the ``None``
+    arguments here with an ``UNCHANGED`` sentinel so any existing
+    overrides are preserved on subsequent applies.
+    """
+    if scope not in _SUPPORTED_SCOPES:
+        raise InvalidBehaviorPresetScopeError(
+            f"scope must be one of {sorted(_SUPPORTED_SCOPES)}, got {scope!r}",
+        )
+
+    summary = await describe_preset(preset_id)
+    if summary is None:
+        raise UnknownBehaviorPresetError(
+            f"preset_id={preset_id} not found or not flagged is_preset=True",
+        )
+
+    if scope == "channel":
+        result = await ai_policy_mutation.set_channel_policy(
+            guild_id,
+            target_id,
+            mode=summary.recommended_mode,
+            min_level=None,
+            cooldown_seconds=None,
+            instruction_profile_id=preset_id,
+            actor=actor,
+        )
+    else:  # scope == "category"
+        result = await ai_policy_mutation.set_category_policy(
+            guild_id,
+            target_id,
+            mode=summary.recommended_mode,
+            min_level=None,
+            cooldown_seconds=None,
+            instruction_profile_id=preset_id,
+            actor=actor,
+        )
+
+    return BehaviorApplyResult(
+        scope=scope,
+        target_id=target_id,
+        preset_id=preset_id,
+        preset_key=summary.key,
+        recommended_mode=summary.recommended_mode,
+        policy_mutation_id=result.mutation_id,
+    )
+
+
+__all__ = [
+    "BehaviorApplyResult",
+    "BehaviorPresetCatalogEntry",
+    "BehaviorPresetError",
+    "BehaviorPresetSummary",
+    "InvalidBehaviorPresetScopeError",
+    "PRESET_KEYS",
+    "UnknownBehaviorPresetError",
+    "apply_preset",
+    "describe_preset",
+    "list_presets",
+]

--- a/disbot/services/ai_instruction_mutation.py
+++ b/disbot/services/ai_instruction_mutation.py
@@ -66,6 +66,7 @@ async def upsert_profile(
     body: str,
     scope: str = "guild",
     feature_key: str | None = None,
+    is_preset: bool = False,
     actor: Any,
 ) -> AIInstructionMutationResult:
     actor_id = _check_admin(actor)
@@ -81,6 +82,23 @@ async def upsert_profile(
         raise InvalidAIInstructionValueError("profile name must be non-empty")
     if not isinstance(body, str):
         raise InvalidAIInstructionValueError("profile body must be a string")
+    if is_preset and guild_id is not None:
+        # Presets are system-wide rows seeded by migration 044. Guild
+        # actors must never be able to author or impersonate them.
+        raise UnauthorizedAIInstructionMutationError(
+            "is_preset=True is reserved for system seeds; guild_id must be None",
+        )
+
+    # Refuse to flip an existing preset row's ``is_preset`` to FALSE
+    # from a guild-scope upsert (a name collision on the same scope
+    # would otherwise downgrade a seeded preset).
+    if not is_preset and guild_id is None and scope == "system":
+        existing = await ai_db.list_instruction_profiles(None, scope="system")
+        for row in existing:
+            if row.get("name") == name and row.get("is_preset"):
+                raise UnauthorizedAIInstructionMutationError(
+                    f"cannot overwrite preset row {name!r} with is_preset=False",
+                )
 
     mutation_id = uuid.uuid4().hex
     profile_id = await ai_db.upsert_instruction_profile(
@@ -90,6 +108,7 @@ async def upsert_profile(
         scope=scope,
         feature_key=feature_key,
         created_by=actor_id,
+        is_preset=is_preset,
     )
     if guild_id is not None:
         await ai_db.bump_generation(guild_id)

--- a/disbot/services/ai_policy_mutation.py
+++ b/disbot/services/ai_policy_mutation.py
@@ -19,12 +19,47 @@ from __future__ import annotations
 import logging
 import uuid
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Final
 
 from services import ai_natural_language_policy
 from utils.db import ai as ai_db
 
 logger = logging.getLogger("bot.services.ai_policy_mutation")
+
+
+# ---------------------------------------------------------------------------
+# UNCHANGED sentinel (PR-C-pre)
+# ---------------------------------------------------------------------------
+#
+# Three-state per optional column on partial updates:
+#
+#   * concrete value (int, bool, str)     → "set this column".
+#   * ``None``                            → "clear this column" (NULL).
+#   * :data:`UNCHANGED`                   → "preserve existing column".
+#
+# The mutation functions accept :data:`UNCHANGED` (the default for
+# optional fields). Sentinel fields are listed in ``unchanged_fields``
+# when handed to ``ai_db.upsert_*``; the DB layer omits them from
+# the ``EXCLUDED`` SET on conflict. On an INSERT path the sentinel
+# means NULL (there is nothing to preserve).
+#
+# Before PR-C-pre, the channel/category modals passed ``None`` for
+# every field they did not own — which silently cleared
+# ``instruction_profile_id`` on every save. That footgun is fixed
+# here at the chokepoint so every existing and future caller is safe
+# by default.
+
+
+class _Unchanged:
+    """Singleton sentinel — compared with ``is`` only."""
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:  # pragma: no cover - debug only
+        return "UNCHANGED"
+
+
+UNCHANGED: Final[_Unchanged] = _Unchanged()
 
 
 # ---------------------------------------------------------------------------
@@ -144,31 +179,61 @@ async def set_guild_policy(
 # ---------------------------------------------------------------------------
 
 
+def _resolve_optional(value: Any) -> tuple[Any, bool]:
+    """Translate UNCHANGED into ``(None, True)``; otherwise ``(value, False)``.
+
+    Returns ``(insert_value, is_unchanged)``. The DB layer uses
+    ``insert_value`` for the binding (NULL on insert) and skips the
+    column from the ``EXCLUDED`` SET when ``is_unchanged`` is True.
+    """
+    if value is UNCHANGED:
+        return None, True
+    return value, False
+
+
 async def set_channel_policy(
     guild_id: int,
     channel_id: int,
     *,
-    mode: str,
-    min_level: int | None,
-    cooldown_seconds: int | None,
-    instruction_profile_id: int | None,
+    mode: str | _Unchanged = UNCHANGED,
+    min_level: int | None | _Unchanged = UNCHANGED,
+    cooldown_seconds: int | None | _Unchanged = UNCHANGED,
+    instruction_profile_id: int | None | _Unchanged = UNCHANGED,
     actor: Any,
 ) -> AIPolicyMutationResult:
     actor_id = _check_admin(actor)
+    if mode is UNCHANGED:
+        raise InvalidAIPolicyValueError(
+            "channel mode is required on upsert (UNCHANGED not supported "
+            "for the mode column because the row must always carry a mode)",
+        )
     if mode not in _VALID_CHANNEL_MODES:
         raise InvalidAIPolicyValueError(
             f"channel mode must be one of {sorted(_VALID_CHANNEL_MODES)}, "
             f"got {mode!r}",
         )
+    min_level_val, min_level_unchanged = _resolve_optional(min_level)
+    cooldown_val, cooldown_unchanged = _resolve_optional(cooldown_seconds)
+    profile_val, profile_unchanged = _resolve_optional(instruction_profile_id)
+
+    unchanged_fields: set[str] = set()
+    if min_level_unchanged:
+        unchanged_fields.add("min_level")
+    if cooldown_unchanged:
+        unchanged_fields.add("cooldown_seconds")
+    if profile_unchanged:
+        unchanged_fields.add("instruction_profile_id")
+
     mutation_id = uuid.uuid4().hex
     await ai_db.upsert_channel_policy(
         guild_id,
         channel_id,
         mode=mode,
-        min_level=min_level,
-        cooldown_seconds=cooldown_seconds,
-        instruction_profile_id=instruction_profile_id,
+        min_level=min_level_val,
+        cooldown_seconds=cooldown_val,
+        instruction_profile_id=profile_val,
         updated_by=actor_id,
+        unchanged_fields=unchanged_fields,
     )
     generation = await ai_db.bump_generation(guild_id)
     ai_natural_language_policy.invalidate(guild_id)
@@ -187,27 +252,45 @@ async def set_category_policy(
     guild_id: int,
     category_id: int,
     *,
-    mode: str,
-    min_level: int | None,
-    cooldown_seconds: int | None,
-    instruction_profile_id: int | None,
+    mode: str | _Unchanged = UNCHANGED,
+    min_level: int | None | _Unchanged = UNCHANGED,
+    cooldown_seconds: int | None | _Unchanged = UNCHANGED,
+    instruction_profile_id: int | None | _Unchanged = UNCHANGED,
     actor: Any,
 ) -> AIPolicyMutationResult:
     actor_id = _check_admin(actor)
+    if mode is UNCHANGED:
+        raise InvalidAIPolicyValueError(
+            "category mode is required on upsert (UNCHANGED not supported "
+            "for the mode column because the row must always carry a mode)",
+        )
     if mode not in _VALID_CHANNEL_MODES:
         raise InvalidAIPolicyValueError(
             f"category mode must be one of {sorted(_VALID_CHANNEL_MODES)}, "
             f"got {mode!r}",
         )
+    min_level_val, min_level_unchanged = _resolve_optional(min_level)
+    cooldown_val, cooldown_unchanged = _resolve_optional(cooldown_seconds)
+    profile_val, profile_unchanged = _resolve_optional(instruction_profile_id)
+
+    unchanged_fields: set[str] = set()
+    if min_level_unchanged:
+        unchanged_fields.add("min_level")
+    if cooldown_unchanged:
+        unchanged_fields.add("cooldown_seconds")
+    if profile_unchanged:
+        unchanged_fields.add("instruction_profile_id")
+
     mutation_id = uuid.uuid4().hex
     await ai_db.upsert_category_policy(
         guild_id,
         category_id,
         mode=mode,
-        min_level=min_level,
-        cooldown_seconds=cooldown_seconds,
-        instruction_profile_id=instruction_profile_id,
+        min_level=min_level_val,
+        cooldown_seconds=cooldown_val,
+        instruction_profile_id=profile_val,
         updated_by=actor_id,
+        unchanged_fields=unchanged_fields,
     )
     generation = await ai_db.bump_generation(guild_id)
     ai_natural_language_policy.invalidate(guild_id)
@@ -226,27 +309,45 @@ async def set_role_policy(
     guild_id: int,
     role_id: int,
     *,
-    decision: str,
-    min_level_override: int | None,
-    bypass_cooldown: bool,
+    decision: str | _Unchanged = UNCHANGED,
+    min_level_override: int | None | _Unchanged = UNCHANGED,
+    bypass_cooldown: bool | _Unchanged = UNCHANGED,
     actor: Any,
 ) -> AIPolicyMutationResult:
     actor_id = _check_admin(actor)
+    if decision is UNCHANGED:
+        raise InvalidAIPolicyValueError(
+            "role decision is required on upsert (UNCHANGED not supported "
+            "for the decision column because the row must always carry one)",
+        )
     if decision not in _VALID_ROLE_DECISIONS:
         raise InvalidAIPolicyValueError(
             f"role decision must be one of {sorted(_VALID_ROLE_DECISIONS)}, "
             f"got {decision!r}",
         )
-    if min_level_override is not None and min_level_override < 0:
+    min_level_val, min_level_unchanged = _resolve_optional(min_level_override)
+    bypass_val, bypass_unchanged = _resolve_optional(bypass_cooldown)
+    if min_level_val is not None and min_level_val < 0:
         raise InvalidAIPolicyValueError("min_level_override must be >= 0")
+
+    unchanged_fields: set[str] = set()
+    if min_level_unchanged:
+        unchanged_fields.add("min_level_override")
+    if bypass_unchanged:
+        unchanged_fields.add("bypass_cooldown")
+
     mutation_id = uuid.uuid4().hex
     await ai_db.upsert_role_policy(
         guild_id,
         role_id,
         decision=decision,
-        min_level_override=min_level_override,
-        bypass_cooldown=bypass_cooldown,
+        min_level_override=min_level_val,
+        # NB: on INSERT path with sentinel, the column gets FALSE
+        # (matching its default) rather than NULL — bypass_cooldown is
+        # NOT NULL.
+        bypass_cooldown=bool(bypass_val) if not bypass_unchanged else False,
         updated_by=actor_id,
+        unchanged_fields=unchanged_fields,
     )
     generation = await ai_db.bump_generation(guild_id)
     ai_natural_language_policy.invalidate(guild_id)

--- a/disbot/services/btd6_context_service.py
+++ b/disbot/services/btd6_context_service.py
@@ -135,12 +135,14 @@ def _render_fact(row: dict[str, Any]) -> str:
 
 
 def _intent_to_queries(intent: Any) -> list[Any]:
-    """Map a :class:`ResolvedIntent` to grounding queries.
+    """Map a :class:`ResolvedIntent` to grounding queries (static kinds).
 
-    Each typed entity (tower / hero / map / mode) becomes one
-    :class:`BTD6FactQuery` with ``fact_type=None`` so any registered
-    fact about the entity surfaces. New entity kinds (events, races,
-    bosses) will land here once the resolver recognises them.
+    Each typed entity with a known key (tower / hero / map / mode)
+    becomes one :class:`BTD6FactQuery` with ``fact_type=None`` so any
+    registered fact about the entity surfaces. PR-E added live
+    entities (race / boss / CT / odyssey / challenge / event /
+    leaderboard) — those don't have a known key from the resolver
+    and are handled by :func:`_fetch_live_entity_rows` instead.
     """
     from services.btd6_fact_store import BTD6FactQuery
 
@@ -160,13 +162,47 @@ def _intent_to_queries(intent: Any) -> list[Any]:
     return queries
 
 
+async def _fetch_live_entity_rows(
+    intent: Any,
+    *,
+    per_kind_limit: int = 3,
+) -> list[dict[str, Any]]:
+    """Resolve PR-E live entities into the newest facts per kind.
+
+    The resolver yields ``LiveEntityMatch`` records that only carry
+    the parser-produced ``entity_kind``. The fact store's
+    ``search_facts`` already returns the newest envelopes per kind,
+    ordered by ``fetched_at DESC``. We cap each kind so one chatty
+    leaderboard cannot drown out other kinds in the same context.
+    """
+    matches = getattr(intent, "live_entities", ()) or ()
+    if not matches:
+        return []
+    from utils.db import btd6_sources as btd6_db
+
+    seen_kinds: set[str] = set()
+    rows: list[dict[str, Any]] = []
+    for match in matches:
+        kind = getattr(match, "entity_kind", None)
+        if not kind or kind in seen_kinds:
+            continue
+        seen_kinds.add(kind)
+        batch = await btd6_db.search_facts(
+            entity_kind=kind,
+            limit=per_kind_limit,
+        )
+        rows.extend(batch)
+    return rows
+
+
 async def build(message_text: str) -> BTD6Context:
     """Build a BTD6 context bundle for ``message_text``.
 
-    The flow is: resolver → queries → fact_store.fetch_for_intent →
-    sanitised rendering with provenance. The instruction service
-    wraps the resulting tuple as untrusted data, so adversarial body
-    text reaches the LLM only inside the data envelope.
+    The flow is: resolver → queries → fact_store.fetch_for_intent +
+    PR-E live entity lookup → sanitised rendering with provenance.
+    The instruction service wraps the resulting tuple as untrusted
+    data, so adversarial body text reaches the LLM only inside the
+    data envelope.
     """
     facts: list[str] = []
     confidence = 0.0
@@ -178,6 +214,10 @@ async def build(message_text: str) -> BTD6Context:
         confidence = float(getattr(intent, "confidence", 0.0) or 0.0)
         queries = _intent_to_queries(intent)
         rows = await btd6_fact_store.fetch_for_intent(queries) if queries else []
+        # PR-E: also surface live-entity facts (race / boss / CT /
+        # odyssey / challenge / event / leaderboard).
+        live_rows = await _fetch_live_entity_rows(intent)
+        rows = rows + live_rows
         for row in rows:
             facts.append(_render_fact(row))
         if facts:

--- a/disbot/services/btd6_resolver_service.py
+++ b/disbot/services/btd6_resolver_service.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
+from typing import Any
 
 from services.btd6_data_service import (
     HeroEntry,
@@ -34,6 +35,7 @@ from services.btd6_data_service import (
     get_dataset,
     get_round,
 )
+from services.btd6_resolver_vocabulary import resolve_live_entities
 
 _ROUND_PATTERNS = (
     re.compile(r"\bround\s+(\d{1,3})\b", re.IGNORECASE),
@@ -54,6 +56,11 @@ class ResolvedIntent:
     rounds: tuple[RoundEntry, ...] = ()
     ambiguous_terms: tuple[str, ...] = ()
     candidate_round_numbers: tuple[int, ...] = field(default_factory=tuple)
+    # PR-E: live Ninja Kiwi entities (races, bosses, CT, odyssey,
+    # challenges, events, leaderboards). Each entry carries the
+    # parser-produced ``entity_kind`` only — the entity_key is
+    # resolved downstream against the latest fact envelope per kind.
+    live_entities: tuple[Any, ...] = ()
 
 
 def _word_iter(text: str) -> list[str]:
@@ -142,12 +149,16 @@ def resolve(text: str) -> ResolvedIntent:
                 if entry is not None:
                     rounds.append(entry)
 
+    # PR-E: live NK entity vocabulary.
+    live_entities, ambiguous = resolve_live_entities(text)
+
     matched_count = (
         len(tower_ids)
         + len(hero_ids)
         + len(map_ids)
         + len(mode_ids)
         + len(candidate_rounds)
+        + len(live_entities)
     )
     # Confidence model: linear scale up to 3 matched entities, capped at 1.0.
     confidence = min(1.0, matched_count / 3.0) if matched_count else 0.0
@@ -161,4 +172,6 @@ def resolve(text: str) -> ResolvedIntent:
         modes=tuple(m for m in dataset.modes if m.id in mode_ids),
         rounds=tuple(rounds),
         candidate_round_numbers=tuple(candidate_rounds),
+        ambiguous_terms=tuple(ambiguous),
+        live_entities=tuple(live_entities),
     )

--- a/disbot/services/btd6_resolver_vocabulary.py
+++ b/disbot/services/btd6_resolver_vocabulary.py
@@ -1,0 +1,222 @@
+"""BTD6 resolver vocabulary for live Ninja Kiwi entities (PR-E).
+
+The original resolver (towers / heroes / maps / modes / rounds) was
+fed from the validated fixture dataset. M3B added live-entity
+parsers (races, bosses, contested-territory, odyssey, challenges,
+events) that emit ``entity_kind`` values like ``btd6_race``,
+``btd6_boss``, ``btd6_ct``, ``btd6_odyssey``, ``btd6_challenge``,
+``btd6_event``. Surface terms that map to those kinds live here in
+one registry so :mod:`services.btd6_resolver_service` does not grow
+its inline term sprawl.
+
+Each entry is a tuple of ``(surface_terms, entity_kind)`` where
+``surface_terms`` is a frozen set of lowercased substrings to match
+against the message text. Matching is whole-word for single words
+and substring for multi-word phrases — mirroring the existing
+resolver's ``_match_terms`` semantics.
+
+The ``entity_key`` is *not* known at vocabulary time — the resolver
+recognises that the user is talking about a kind of entity (e.g.
+"the current race") and emits one or more :class:`LiveEntityMatch`
+records. The context service translates those into
+:class:`btd6_fact_store.BTD6FactQuery` rows; the actual entity key
+comes from the fact store search (``entity_kind`` only — fact_type
+left None — picks the newest envelope per kind).
+
+Ambiguous terms — ones that could mean multiple kinds — are
+explicitly listed in :data:`_AMBIGUOUS_TERMS` so the resolver can
+emit an ``ambiguous_term`` audit row instead of silently picking
+one.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Final
+
+
+@dataclass(frozen=True)
+class LiveEntityMatch:
+    """One resolved live-entity intent.
+
+    ``entity_kind`` is the parser-produced kind label (e.g.
+    ``btd6_race``). ``matched_term`` is the surface term that
+    triggered the match — useful for diagnostics.
+    """
+
+    entity_kind: str
+    matched_term: str
+
+
+# Each entry: (surface_terms, entity_kind, fact_type_hint).
+# The fact_type_hint is optional and may be None; the context
+# service uses fact_type=None to match any fact_type for the kind.
+_VOCABULARY: Final[tuple[tuple[frozenset[str], str, str | None], ...]] = (
+    (
+        frozenset(
+            {
+                "race",
+                "races",
+                "racing",
+                "time trial",
+                "time trials",
+                "reversed loop",
+            },
+        ),
+        "btd6_race",
+        None,
+    ),
+    (
+        frozenset(
+            {
+                "boss",
+                "bosses",
+                "bloonarius",
+                "phayze",
+                "lych",
+                "vortex",
+                "dreadbloon",
+                "blastapopoulos",
+                "diamondback",
+            },
+        ),
+        "btd6_boss",
+        None,
+    ),
+    (
+        frozenset(
+            {
+                "ct",
+                "contested territory",
+                "contested territories",
+                "ct tile",
+                "ct tiles",
+            },
+        ),
+        "btd6_ct",
+        None,
+    ),
+    (
+        frozenset(
+            {
+                "odyssey",
+                "odysseys",
+                "easy odyssey",
+                "medium odyssey",
+                "hard odyssey",
+                "extreme odyssey",
+            },
+        ),
+        "btd6_odyssey",
+        None,
+    ),
+    (
+        frozenset(
+            {
+                "challenge",
+                "challenges",
+                "daily challenge",
+                "weekly challenge",
+                "advanced challenge",
+                "rot challenge",
+            },
+        ),
+        "btd6_challenge",
+        None,
+    ),
+    (
+        frozenset(
+            {
+                "event",
+                "events",
+                "live event",
+                "live events",
+            },
+        ),
+        "btd6_event",
+        None,
+    ),
+    (
+        frozenset(
+            {
+                "leaderboard",
+                "leaderboards",
+                "lb",
+                "race leaderboard",
+                "boss leaderboard",
+            },
+        ),
+        "btd6_race_leaderboard_row",
+        None,
+    ),
+)
+
+
+# Terms that overlap multiple kinds — refuse to resolve when these
+# appear in isolation to avoid silently picking a kind.
+_AMBIGUOUS_TERMS: Final[frozenset[str]] = frozenset(
+    {
+        # "current" by itself could mean the current race, boss, CT, odyssey,
+        # event, challenge — refuse.
+        "current",
+    },
+)
+
+
+_WORD_RE = re.compile(r"[a-z0-9_]+")
+
+
+def _tokens(text: str) -> set[str]:
+    return set(_WORD_RE.findall(text.lower()))
+
+
+def resolve_live_entities(text: str) -> tuple[list[LiveEntityMatch], list[str]]:
+    """Scan ``text`` for vocabulary terms.
+
+    Returns ``(matches, ambiguous_terms)``. ``ambiguous_terms`` is the
+    set of recognised-but-ambiguous terms the resolver should refuse
+    on. Matches retain their order of vocabulary entry; duplicates
+    per ``(entity_kind, matched_term)`` are de-duplicated.
+    """
+    if not text or not text.strip():
+        return [], []
+    lower = text.lower()
+    tokens = _tokens(text)
+
+    matches: list[LiveEntityMatch] = []
+    seen: set[tuple[str, str]] = set()
+    for surface_terms, entity_kind, _ft in _VOCABULARY:
+        for term in surface_terms:
+            if " " in term:
+                if term in lower:
+                    key = (entity_kind, term)
+                    if key not in seen:
+                        seen.add(key)
+                        matches.append(
+                            LiveEntityMatch(
+                                entity_kind=entity_kind, matched_term=term,
+                            ),
+                        )
+            elif term in tokens:
+                key = (entity_kind, term)
+                if key not in seen:
+                    seen.add(key)
+                    matches.append(
+                        LiveEntityMatch(entity_kind=entity_kind, matched_term=term),
+                    )
+
+    ambiguous = [t for t in _AMBIGUOUS_TERMS if t in tokens]
+    return matches, ambiguous
+
+
+def known_entity_kinds() -> frozenset[str]:
+    """Return every entity_kind the registry can produce."""
+    return frozenset(entry[1] for entry in _VOCABULARY)
+
+
+__all__ = [
+    "LiveEntityMatch",
+    "known_entity_kinds",
+    "resolve_live_entities",
+]

--- a/disbot/services/btd6_resolver_vocabulary.py
+++ b/disbot/services/btd6_resolver_vocabulary.py
@@ -195,7 +195,8 @@ def resolve_live_entities(text: str) -> tuple[list[LiveEntityMatch], list[str]]:
                         seen.add(key)
                         matches.append(
                             LiveEntityMatch(
-                                entity_kind=entity_kind, matched_term=term,
+                                entity_kind=entity_kind,
+                                matched_term=term,
                             ),
                         )
             elif term in tokens:

--- a/disbot/services/btd6_source_registry.py
+++ b/disbot/services/btd6_source_registry.py
@@ -1,19 +1,100 @@
-"""Read-only access to ``btd6_source_registry`` (M3A).
+"""Read-only access to ``btd6_source_registry`` (M3A + PR-D).
 
 Writes flow through :mod:`services.btd6_source_mutation`. This
 module exists so callers (the fetcher, the knowledge API, the
-``!btd6 sources`` command) can ask "is this source allowlisted?"
-without touching the DB module directly.
+``!btd6 sources`` command, the PR-D source-health view) can ask
+"is this source allowlisted?" and "is this source fresh?" without
+touching the DB module directly.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Literal
 
 from utils.db import btd6_sources as btd6_db
 
 logger = logging.getLogger("bot.services.btd6_source_registry")
+
+
+# ---------------------------------------------------------------------------
+# Freshness bucketing (PR-D)
+# ---------------------------------------------------------------------------
+
+
+FreshnessBucket = Literal["fresh", "aging", "stale", "never"]
+
+
+# Buckets are deliberately coarse: the operator needs an at-a-glance
+# answer, not a precise SLO. Adjust if production observation shows
+# the Ninja Kiwi cadences want a different threshold.
+_FRESH_THRESHOLD = timedelta(hours=6)
+_AGING_THRESHOLD = timedelta(days=2)
+
+
+def _bucket_for(last_fetched_at: datetime | None) -> FreshnessBucket:
+    if last_fetched_at is None:
+        return "never"
+    now = datetime.now(tz=timezone.utc)
+    if last_fetched_at.tzinfo is None:
+        last_fetched_at = last_fetched_at.replace(tzinfo=timezone.utc)
+    age = now - last_fetched_at
+    if age <= _FRESH_THRESHOLD:
+        return "fresh"
+    if age <= _AGING_THRESHOLD:
+        return "aging"
+    return "stale"
+
+
+@dataclass(frozen=True)
+class SourceHealth:
+    """One source row enriched with freshness info."""
+
+    source_id: int
+    source_key: str
+    source_name: str
+    trust_tier: int
+    enabled: bool
+    source_kind: str
+    last_fetched_at: datetime | None
+    fact_count: int
+    bucket: FreshnessBucket
+
+
+async def list_health(
+    *,
+    enabled: bool | None = None,
+    limit: int = 25,
+    offset: int = 0,
+) -> list[SourceHealth]:
+    """Bounded list of source-health summaries (PR-D).
+
+    The hard cap mirrors :func:`utils.db.btd6_sources.list_sources` —
+    no caller can fetch the entire registry in one call.
+    """
+    rows = await btd6_db.list_sources_with_freshness(
+        enabled=enabled,
+        limit=limit,
+        offset=offset,
+    )
+    out: list[SourceHealth] = []
+    for row in rows:
+        out.append(
+            SourceHealth(
+                source_id=int(row["id"]),
+                source_key=row["source_key"],
+                source_name=row["source_name"],
+                trust_tier=int(row["trust_tier"]),
+                enabled=bool(row["enabled"]),
+                source_kind=row["source_kind"],
+                last_fetched_at=row.get("last_fetched_at"),
+                fact_count=int(row.get("fact_count") or 0),
+                bucket=_bucket_for(row.get("last_fetched_at")),
+            ),
+        )
+    return out
 
 
 async def get_by_key(source_key: str) -> dict[str, Any] | None:
@@ -27,16 +108,21 @@ async def get_by_id(source_id: int) -> dict[str, Any] | None:
 async def list_enabled_sources(
     *,
     trust_tier: int | None = None,
+    limit: int = 100,
 ) -> list[dict[str, Any]]:
-    return await btd6_db.list_sources(trust_tier=trust_tier, enabled=True)
+    return await btd6_db.list_sources(
+        trust_tier=trust_tier,
+        enabled=True,
+        limit=limit,
+    )
 
 
-async def list_by_tier(trust_tier: int) -> list[dict[str, Any]]:
-    return await btd6_db.list_sources(trust_tier=trust_tier)
+async def list_by_tier(trust_tier: int, *, limit: int = 100) -> list[dict[str, Any]]:
+    return await btd6_db.list_sources(trust_tier=trust_tier, limit=limit)
 
 
-async def list_all() -> list[dict[str, Any]]:
-    return await btd6_db.list_sources()
+async def list_all(*, limit: int = 100) -> list[dict[str, Any]]:
+    return await btd6_db.list_sources(limit=limit)
 
 
 async def is_source_usable(source_key: str) -> tuple[bool, str]:
@@ -57,10 +143,13 @@ async def is_source_usable(source_key: str) -> tuple[bool, str]:
 
 
 __all__ = [
+    "FreshnessBucket",
+    "SourceHealth",
     "get_by_id",
     "get_by_key",
     "is_source_usable",
     "list_all",
     "list_by_tier",
     "list_enabled_sources",
+    "list_health",
 ]

--- a/disbot/services/btd6_strategy_service.py
+++ b/disbot/services/btd6_strategy_service.py
@@ -1,4 +1,9 @@
-"""Read-only search / filter for the BTD6 strategy memory (M4)."""
+"""Read-only search / filter for the BTD6 strategy memory.
+
+PR-F surfaces the existing service to additional UX paths (browse /
+detail / submit / mine / audit). The write path stays in
+:mod:`services.btd6_strategy_mutation` — this module is read-only.
+"""
 
 from __future__ import annotations
 
@@ -7,16 +12,49 @@ from typing import Any
 from utils.db import btd6_strategies as db
 
 
+# Hard caps for every list query so callers cannot accidentally
+# fetch the whole table.
+_MAX_LIMIT = 25
+
+
+def _clamp_limit(limit: int) -> int:
+    return max(1, min(int(limit), _MAX_LIMIT))
+
+
 async def get(strategy_id: int) -> dict[str, Any] | None:
     return await db.get_strategy(strategy_id)
 
 
 async def list_for_guild(guild_id: int, *, limit: int = 25) -> list[dict[str, Any]]:
-    return await db.search_strategies(guild_id=guild_id, limit=limit)
+    return await db.search_strategies(
+        guild_id=guild_id,
+        limit=_clamp_limit(limit),
+    )
 
 
 async def list_published(*, limit: int = 25) -> list[dict[str, Any]]:
-    return await db.search_strategies(visibility="published", limit=limit)
+    return await db.search_strategies(
+        visibility="published",
+        limit=_clamp_limit(limit),
+    )
+
+
+async def list_mine(
+    guild_id: int,
+    submitter_id: int,
+    *,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    """PR-F: rows submitted by ``submitter_id`` in ``guild_id``.
+
+    Filtered in Python (no SQL change). Bounded by ``_MAX_LIMIT``.
+    """
+    rows = await db.search_strategies(
+        guild_id=guild_id,
+        limit=_MAX_LIMIT,
+    )
+    mine = [r for r in rows if r.get("submitted_by") == submitter_id]
+    return mine[: _clamp_limit(limit)]
 
 
 async def search(
@@ -34,7 +72,7 @@ async def search(
         mode=mode,
         visibility=visibility,
         approval_status=approval_status,
-        limit=limit,
+        limit=_clamp_limit(limit),
     )
 
 
@@ -42,4 +80,11 @@ async def audit_for(strategy_id: int) -> list[dict[str, Any]]:
     return await db.list_strategy_audit(strategy_id)
 
 
-__all__ = ["audit_for", "get", "list_for_guild", "list_published", "search"]
+__all__ = [
+    "audit_for",
+    "get",
+    "list_for_guild",
+    "list_mine",
+    "list_published",
+    "search",
+]

--- a/disbot/services/btd6_strategy_service.py
+++ b/disbot/services/btd6_strategy_service.py
@@ -11,7 +11,6 @@ from typing import Any
 
 from utils.db import btd6_strategies as db
 
-
 # Hard caps for every list query so callers cannot accidentally
 # fetch the whole table.
 _MAX_LIMIT = 25

--- a/disbot/utils/db/ai.py
+++ b/disbot/utils/db/ai.py
@@ -307,7 +307,7 @@ async def upsert_role_policy(
 async def get_instruction_profile(profile_id: int) -> dict[str, Any] | None:
     row = await pool.get().fetchrow(
         """
-        SELECT id, guild_id, name, body, scope, feature_key,
+        SELECT id, guild_id, name, body, scope, feature_key, is_preset,
                created_at, created_by, updated_at
         FROM ai_instruction_profile
         WHERE id = $1
@@ -325,7 +325,7 @@ async def list_instruction_profiles(
     if scope:
         rows = await pool.get().fetch(
             """
-            SELECT id, guild_id, name, body, scope, feature_key,
+            SELECT id, guild_id, name, body, scope, feature_key, is_preset,
                    created_at, created_by, updated_at
             FROM ai_instruction_profile
             WHERE (guild_id = $1 OR (guild_id IS NULL AND $1 IS NULL))
@@ -338,7 +338,7 @@ async def list_instruction_profiles(
     else:
         rows = await pool.get().fetch(
             """
-            SELECT id, guild_id, name, body, scope, feature_key,
+            SELECT id, guild_id, name, body, scope, feature_key, is_preset,
                    created_at, created_by, updated_at
             FROM ai_instruction_profile
             WHERE guild_id IS NOT DISTINCT FROM $1
@@ -346,6 +346,22 @@ async def list_instruction_profiles(
             """,
             guild_id,
         )
+    return [dict(r) for r in rows]
+
+
+async def list_preset_profiles() -> list[dict[str, Any]]:
+    """Built-in presets, sorted alphabetically. Returns all rows with
+    ``is_preset = TRUE`` (seeded by migration 044).
+    """
+    rows = await pool.get().fetch(
+        """
+        SELECT id, guild_id, name, body, scope, feature_key, is_preset,
+               created_at, created_by, updated_at
+        FROM ai_instruction_profile
+        WHERE is_preset = TRUE
+        ORDER BY name
+        """,
+    )
     return [dict(r) for r in rows]
 
 
@@ -357,16 +373,18 @@ async def upsert_instruction_profile(
     scope: str,
     feature_key: str | None,
     created_by: int | None,
+    is_preset: bool = False,
 ) -> int:
     row = await pool.get().fetchrow(
         """
         INSERT INTO ai_instruction_profile (
-            guild_id, name, body, scope, feature_key,
+            guild_id, name, body, scope, feature_key, is_preset,
             created_at, created_by, updated_at
-        ) VALUES ($1, $2, $3, $4, $5, NOW(), $6, NOW())
+        ) VALUES ($1, $2, $3, $4, $5, $6, NOW(), $7, NOW())
         ON CONFLICT (guild_id, scope, name) DO UPDATE SET
             body        = EXCLUDED.body,
             feature_key = EXCLUDED.feature_key,
+            is_preset   = EXCLUDED.is_preset,
             updated_at  = NOW()
         RETURNING id
         """,
@@ -375,6 +393,7 @@ async def upsert_instruction_profile(
         body,
         scope,
         feature_key,
+        is_preset,
         created_by,
     )
     return int(row["id"])

--- a/disbot/utils/db/ai.py
+++ b/disbot/utils/db/ai.py
@@ -184,8 +184,7 @@ async def upsert_channel_policy(
         "    guild_id, channel_id, mode, min_level, cooldown_seconds,"
         "    instruction_profile_id, updated_at, updated_by"
         ") VALUES ($1, $2, $3, $4, $5, $6, NOW(), $7) "
-        "ON CONFLICT (guild_id, channel_id) DO UPDATE SET "
-        + ", ".join(active_sets)
+        "ON CONFLICT (guild_id, channel_id) DO UPDATE SET " + ", ".join(active_sets)
     )
     await pool.get().execute(
         sql,
@@ -247,7 +246,8 @@ async def upsert_category_policy(
     unchanged_fields: set[str] | None = None,
 ) -> None:
     """Upsert a category policy row; see :func:`upsert_channel_policy`
-    for the ``unchanged_fields`` sentinel semantics."""
+    for the ``unchanged_fields`` sentinel semantics.
+    """
     unchanged = unchanged_fields or set()
     set_clauses = [
         ("mode", "mode = EXCLUDED.mode"),
@@ -266,8 +266,7 @@ async def upsert_category_policy(
         "    guild_id, category_id, mode, min_level, cooldown_seconds,"
         "    instruction_profile_id, updated_at, updated_by"
         ") VALUES ($1, $2, $3, $4, $5, $6, NOW(), $7) "
-        "ON CONFLICT (guild_id, category_id) DO UPDATE SET "
-        + ", ".join(active_sets)
+        "ON CONFLICT (guild_id, category_id) DO UPDATE SET " + ", ".join(active_sets)
     )
     await pool.get().execute(
         sql,
@@ -310,7 +309,8 @@ async def upsert_role_policy(
     unchanged_fields: set[str] | None = None,
 ) -> None:
     """Upsert a role policy row; see :func:`upsert_channel_policy`
-    for the ``unchanged_fields`` sentinel semantics."""
+    for the ``unchanged_fields`` sentinel semantics.
+    """
     unchanged = unchanged_fields or set()
     set_clauses = [
         ("decision", "decision = EXCLUDED.decision"),
@@ -328,8 +328,7 @@ async def upsert_role_policy(
         "    guild_id, role_id, decision, min_level_override, bypass_cooldown,"
         "    created_at, updated_at, updated_by"
         ") VALUES ($1, $2, $3, $4, $5, NOW(), NOW(), $6) "
-        "ON CONFLICT (guild_id, role_id) DO UPDATE SET "
-        + ", ".join(active_sets)
+        "ON CONFLICT (guild_id, role_id) DO UPDATE SET " + ", ".join(active_sets)
     )
     await pool.get().execute(
         sql,

--- a/disbot/utils/db/ai.py
+++ b/disbot/utils/db/ai.py
@@ -450,7 +450,7 @@ async def query_decisions(
     sql = (
         "SELECT id, guild_id, channel_id, category_id, user_id, message_id,"
         " task, route, decision, reason_code, policy_snapshot_hash,"
-        " provider, model, created_at "
+        " instruction_profile_ids, provider, model, created_at "
         "FROM ai_decision_audit WHERE guild_id = $1"
     )
     args: list[Any] = [guild_id]

--- a/disbot/utils/db/ai.py
+++ b/disbot/utils/db/ai.py
@@ -155,21 +155,40 @@ async def upsert_channel_policy(
     cooldown_seconds: int | None,
     instruction_profile_id: int | None,
     updated_by: int | None,
+    unchanged_fields: set[str] | None = None,
 ) -> None:
+    """Upsert a channel policy row.
+
+    Fields named in ``unchanged_fields`` are omitted from the
+    ``EXCLUDED`` SET on conflict — i.e. preserved from the existing
+    row. On the INSERT path (no existing row) the parameter values
+    are inserted as-is; for sentinel fields the caller should pass
+    ``None``. This is the SQL half of the PR-C-pre ``UNCHANGED``
+    sentinel pattern.
+    """
+    unchanged = unchanged_fields or set()
+    set_clauses = [
+        ("mode", "mode = EXCLUDED.mode"),
+        ("min_level", "min_level = EXCLUDED.min_level"),
+        ("cooldown_seconds", "cooldown_seconds = EXCLUDED.cooldown_seconds"),
+        (
+            "instruction_profile_id",
+            "instruction_profile_id = EXCLUDED.instruction_profile_id",
+        ),
+    ]
+    active_sets = [clause for name, clause in set_clauses if name not in unchanged]
+    active_sets.append("updated_at = NOW()")
+    active_sets.append("updated_by = EXCLUDED.updated_by")
+    sql = (
+        "INSERT INTO ai_channel_policy ("
+        "    guild_id, channel_id, mode, min_level, cooldown_seconds,"
+        "    instruction_profile_id, updated_at, updated_by"
+        ") VALUES ($1, $2, $3, $4, $5, $6, NOW(), $7) "
+        "ON CONFLICT (guild_id, channel_id) DO UPDATE SET "
+        + ", ".join(active_sets)
+    )
     await pool.get().execute(
-        """
-        INSERT INTO ai_channel_policy (
-            guild_id, channel_id, mode, min_level, cooldown_seconds,
-            instruction_profile_id, updated_at, updated_by
-        ) VALUES ($1, $2, $3, $4, $5, $6, NOW(), $7)
-        ON CONFLICT (guild_id, channel_id) DO UPDATE SET
-            mode                   = EXCLUDED.mode,
-            min_level              = EXCLUDED.min_level,
-            cooldown_seconds       = EXCLUDED.cooldown_seconds,
-            instruction_profile_id = EXCLUDED.instruction_profile_id,
-            updated_at             = NOW(),
-            updated_by             = EXCLUDED.updated_by
-        """,
+        sql,
         guild_id,
         channel_id,
         mode,
@@ -225,21 +244,33 @@ async def upsert_category_policy(
     cooldown_seconds: int | None,
     instruction_profile_id: int | None,
     updated_by: int | None,
+    unchanged_fields: set[str] | None = None,
 ) -> None:
+    """Upsert a category policy row; see :func:`upsert_channel_policy`
+    for the ``unchanged_fields`` sentinel semantics."""
+    unchanged = unchanged_fields or set()
+    set_clauses = [
+        ("mode", "mode = EXCLUDED.mode"),
+        ("min_level", "min_level = EXCLUDED.min_level"),
+        ("cooldown_seconds", "cooldown_seconds = EXCLUDED.cooldown_seconds"),
+        (
+            "instruction_profile_id",
+            "instruction_profile_id = EXCLUDED.instruction_profile_id",
+        ),
+    ]
+    active_sets = [clause for name, clause in set_clauses if name not in unchanged]
+    active_sets.append("updated_at = NOW()")
+    active_sets.append("updated_by = EXCLUDED.updated_by")
+    sql = (
+        "INSERT INTO ai_category_policy ("
+        "    guild_id, category_id, mode, min_level, cooldown_seconds,"
+        "    instruction_profile_id, updated_at, updated_by"
+        ") VALUES ($1, $2, $3, $4, $5, $6, NOW(), $7) "
+        "ON CONFLICT (guild_id, category_id) DO UPDATE SET "
+        + ", ".join(active_sets)
+    )
     await pool.get().execute(
-        """
-        INSERT INTO ai_category_policy (
-            guild_id, category_id, mode, min_level, cooldown_seconds,
-            instruction_profile_id, updated_at, updated_by
-        ) VALUES ($1, $2, $3, $4, $5, $6, NOW(), $7)
-        ON CONFLICT (guild_id, category_id) DO UPDATE SET
-            mode                   = EXCLUDED.mode,
-            min_level              = EXCLUDED.min_level,
-            cooldown_seconds       = EXCLUDED.cooldown_seconds,
-            instruction_profile_id = EXCLUDED.instruction_profile_id,
-            updated_at             = NOW(),
-            updated_by             = EXCLUDED.updated_by
-        """,
+        sql,
         guild_id,
         category_id,
         mode,
@@ -276,20 +307,32 @@ async def upsert_role_policy(
     min_level_override: int | None,
     bypass_cooldown: bool,
     updated_by: int | None,
+    unchanged_fields: set[str] | None = None,
 ) -> None:
+    """Upsert a role policy row; see :func:`upsert_channel_policy`
+    for the ``unchanged_fields`` sentinel semantics."""
+    unchanged = unchanged_fields or set()
+    set_clauses = [
+        ("decision", "decision = EXCLUDED.decision"),
+        (
+            "min_level_override",
+            "min_level_override = EXCLUDED.min_level_override",
+        ),
+        ("bypass_cooldown", "bypass_cooldown = EXCLUDED.bypass_cooldown"),
+    ]
+    active_sets = [clause for name, clause in set_clauses if name not in unchanged]
+    active_sets.append("updated_at = NOW()")
+    active_sets.append("updated_by = EXCLUDED.updated_by")
+    sql = (
+        "INSERT INTO ai_role_policy ("
+        "    guild_id, role_id, decision, min_level_override, bypass_cooldown,"
+        "    created_at, updated_at, updated_by"
+        ") VALUES ($1, $2, $3, $4, $5, NOW(), NOW(), $6) "
+        "ON CONFLICT (guild_id, role_id) DO UPDATE SET "
+        + ", ".join(active_sets)
+    )
     await pool.get().execute(
-        """
-        INSERT INTO ai_role_policy (
-            guild_id, role_id, decision, min_level_override, bypass_cooldown,
-            created_at, updated_at, updated_by
-        ) VALUES ($1, $2, $3, $4, $5, NOW(), NOW(), $6)
-        ON CONFLICT (guild_id, role_id) DO UPDATE SET
-            decision           = EXCLUDED.decision,
-            min_level_override = EXCLUDED.min_level_override,
-            bypass_cooldown    = EXCLUDED.bypass_cooldown,
-            updated_at         = NOW(),
-            updated_by         = EXCLUDED.updated_by
-        """,
+        sql,
         guild_id,
         role_id,
         decision,

--- a/disbot/utils/db/btd6_sources.py
+++ b/disbot/utils/db/btd6_sources.py
@@ -53,11 +53,25 @@ async def get_source(source_id: int) -> dict[str, Any] | None:
     return dict(row) if row else None
 
 
+_LIST_SOURCES_MAX_LIMIT = 200
+
+
 async def list_sources(
     *,
     trust_tier: int | None = None,
     enabled: bool | None = None,
+    limit: int = 50,
+    offset: int = 0,
 ) -> list[dict[str, Any]]:
+    """Bounded list of source registry rows.
+
+    ``limit`` and ``offset`` are required to be sane integers. The hard
+    cap is :data:`_LIST_SOURCES_MAX_LIMIT` so callers cannot accidentally
+    request unbounded paging. Callers that need the full registry must
+    page explicitly.
+    """
+    safe_limit = max(1, min(int(limit), _LIST_SOURCES_MAX_LIMIT))
+    safe_offset = max(0, int(offset))
     sql = (
         "SELECT id, source_key, source_name, source_owner, source_kind, "
         "trust_tier, base_url, path_template, full_url, enabled, notes "
@@ -73,7 +87,58 @@ async def list_sources(
         clauses.append(f"enabled = ${len(args)}")
     if clauses:
         sql += " WHERE " + " AND ".join(clauses)
-    sql += " ORDER BY trust_tier, source_key"
+    args.append(safe_limit)
+    args.append(safe_offset)
+    sql += (
+        " ORDER BY trust_tier, source_key "
+        f"LIMIT ${len(args) - 1} OFFSET ${len(args)}"
+    )
+    rows = await pool.get().fetch(sql, *args)
+    return [dict(r) for r in rows]
+
+
+async def list_sources_with_freshness(
+    *,
+    enabled: bool | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> list[dict[str, Any]]:
+    """Per-source freshness aggregate (PR-D).
+
+    Joins ``btd6_source_registry`` with the latest
+    ``btd6_facts.fetched_at`` per source. Returns each source row
+    enriched with ``last_fetched_at`` (nullable) and ``fact_count``
+    so callers can bucket freshness without a second query.
+
+    Tier-1 sources with no facts (recently enabled but never
+    fetched) appear with ``last_fetched_at = NULL`` and
+    ``fact_count = 0``.
+    """
+    safe_limit = max(1, min(int(limit), _LIST_SOURCES_MAX_LIMIT))
+    safe_offset = max(0, int(offset))
+    sql = (
+        "SELECT r.id, r.source_key, r.source_name, r.source_owner, "
+        "r.source_kind, r.trust_tier, r.base_url, r.path_template, "
+        "r.full_url, r.enabled, r.notes, "
+        "facts.last_fetched_at, facts.fact_count "
+        "FROM btd6_source_registry r "
+        "LEFT JOIN ("
+        "  SELECT source_id, "
+        "         MAX(fetched_at) AS last_fetched_at, "
+        "         COUNT(*) AS fact_count "
+        "  FROM btd6_facts GROUP BY source_id"
+        ") facts ON facts.source_id = r.id"
+    )
+    args: list[Any] = []
+    if enabled is not None:
+        args.append(enabled)
+        sql += f" WHERE r.enabled = ${len(args)}"
+    args.append(safe_limit)
+    args.append(safe_offset)
+    sql += (
+        " ORDER BY r.trust_tier, r.source_key "
+        f"LIMIT ${len(args) - 1} OFFSET ${len(args)}"
+    )
     rows = await pool.get().fetch(sql, *args)
     return [dict(r) for r in rows]
 

--- a/disbot/views/ai/behavior/__init__.py
+++ b/disbot/views/ai/behavior/__init__.py
@@ -1,0 +1,24 @@
+"""AI Behavior preset UI (PR-C).
+
+Usability-first wrapper around the existing AI policy scope modals,
+preview/dry-run, and the preset catalog. Operators see "What should
+the AI do here?" — pick a scope, pick a preset, preview, save —
+rather than the raw mode/min_level/cooldown/profile knobs.
+
+Public entry points:
+
+* :func:`build_behavior_embed` — introductory embed
+* :class:`BehaviorChooserView` — top-level workflow dispatcher
+
+Both are imported by ``views.ai.panel`` (Behavior button) and by
+``cogs.ai_cog`` (prefix / slash command entry).
+"""
+
+from __future__ import annotations
+
+from views.ai.behavior.chooser import (  # noqa: F401
+    BehaviorChooserView,
+    build_behavior_embed,
+)
+
+__all__ = ["BehaviorChooserView", "build_behavior_embed"]

--- a/disbot/views/ai/behavior/chooser.py
+++ b/disbot/views/ai/behavior/chooser.py
@@ -1,0 +1,170 @@
+"""Behavior chooser — the entry view of the Behavior UI (PR-C).
+
+Top-level workflow dispatcher. Rows:
+
+* Row 0: scope buttons ``Channel`` and ``Category``.
+* Row 1: ``Preview`` (reuses PR4B :class:`PreviewChannelSelectView`)
+  and ``Advanced`` (opens the PR4A policy chooser for raw edits).
+
+The chooser is ephemeral and times out; it carries no persistent
+state. Each button opens its own ephemeral follow-up.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+logger = logging.getLogger("bot.views.ai.behavior.chooser")
+
+_PANEL_COLOR = discord.Color.blurple()
+_CHOOSER_TIMEOUT_SECONDS = 180
+
+
+def build_behavior_embed() -> discord.Embed:
+    """Behavior intro embed.
+
+    Behavior-oriented copy: tells the operator what each scope+preset
+    combination achieves, without exposing the underlying mode /
+    min_level / cooldown knobs (those still live behind ``Advanced``).
+    """
+    embed = discord.Embed(
+        title="AI Behavior",
+        description=(
+            "Pick **what the AI should do here**, then choose a scope. "
+            "Presets bind together a channel mode plus an instruction "
+            "profile. Use **Preview** to dry-run the resolver against "
+            "your own user before saving. **Advanced** opens the raw "
+            "policy editor."
+        ),
+        color=_PANEL_COLOR,
+    )
+    embed.add_field(
+        name="Channel",
+        value="Bind a preset to a single text channel.",
+        inline=False,
+    )
+    embed.add_field(
+        name="Category",
+        value="Bind a preset to a category (applies to its channels).",
+        inline=False,
+    )
+    embed.add_field(
+        name="Preview (dry-run)",
+        value=(
+            "See the precedence trace the resolver would produce for "
+            "your own user in a channel — no audit, no cooldown."
+        ),
+        inline=False,
+    )
+    embed.add_field(
+        name="Advanced",
+        value=(
+            "Open the raw policy editor (mode / min_level / cooldown / "
+            "profile). Sentinel-safe: untouched fields are preserved."
+        ),
+        inline=False,
+    )
+    embed.set_footer(text="Administrator-only · ephemeral follow-up.")
+    return embed
+
+
+class BehaviorChooserView(discord.ui.View):
+    """Ephemeral workflow dispatcher for the Behavior UI."""
+
+    def __init__(self) -> None:
+        super().__init__(timeout=_CHOOSER_TIMEOUT_SECONDS)
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        member = interaction.user
+        perms = getattr(member, "guild_permissions", None)
+        if perms is None or not getattr(perms, "administrator", False):
+            await interaction.response.send_message(
+                "❌ Administrator permission required.",
+                ephemeral=True,
+            )
+            return False
+        return True
+
+    @discord.ui.button(
+        label="Channel",
+        style=discord.ButtonStyle.primary,
+        row=0,
+    )
+    async def channel_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        from views.ai.behavior.scope_picker import BehaviorChannelSelectView
+
+        await interaction.response.send_message(
+            "Pick a channel — the next step lists the available presets.",
+            view=BehaviorChannelSelectView(),
+            ephemeral=True,
+        )
+
+    @discord.ui.button(
+        label="Category",
+        style=discord.ButtonStyle.primary,
+        row=0,
+    )
+    async def category_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        from views.ai.behavior.scope_picker import BehaviorCategorySelectView
+
+        await interaction.response.send_message(
+            "Pick a category — the next step lists the available presets.",
+            view=BehaviorCategorySelectView(),
+            ephemeral=True,
+        )
+
+    @discord.ui.button(
+        label="Preview (dry-run)",
+        style=discord.ButtonStyle.secondary,
+        row=1,
+    )
+    async def preview_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        # Reuse PR4B's preview view — never re-implement the dry-run
+        # path.
+        from views.ai.policy.preview_view import PreviewChannelSelectView
+
+        await interaction.response.send_message(
+            "Pick a channel to preview the effective AI policy as your user.",
+            view=PreviewChannelSelectView(),
+            ephemeral=True,
+        )
+
+    @discord.ui.button(
+        label="Advanced",
+        style=discord.ButtonStyle.secondary,
+        row=1,
+    )
+    async def advanced_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        # Punt to the existing raw policy chooser (PR4A); the sentinel
+        # PR-C-pre landed means partial edits there are now safe.
+        from views.ai.policy.chooser import (
+            PolicyChooserView,
+            build_chooser_embed,
+        )
+
+        await interaction.response.send_message(
+            embed=build_chooser_embed(),
+            view=PolicyChooserView(),
+            ephemeral=True,
+        )
+
+
+__all__ = ["BehaviorChooserView", "build_behavior_embed"]

--- a/disbot/views/ai/behavior/chooser.py
+++ b/disbot/views/ai/behavior/chooser.py
@@ -59,6 +59,15 @@ def build_behavior_embed() -> discord.Embed:
         inline=False,
     )
     embed.add_field(
+        name="Routing matrix",
+        value=(
+            "Read-only diagnostic showing the dry-run resolver "
+            "outcome for a channel — useful when an operator asks "
+            "*why* a channel allows or denies."
+        ),
+        inline=False,
+    )
+    embed.add_field(
         name="Advanced",
         value=(
             "Open the raw policy editor (mode / min_level / cooldown / "
@@ -144,9 +153,29 @@ class BehaviorChooserView(discord.ui.View):
         )
 
     @discord.ui.button(
-        label="Advanced",
+        label="Routing matrix",
         style=discord.ButtonStyle.secondary,
         row=1,
+    )
+    async def matrix_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        # PR-G: read-only routing matrix. Operator picks a channel,
+        # the resolver runs in dry-run mode.
+        from views.ai.routing import RoutingMatrixSelectView
+
+        await interaction.response.send_message(
+            "Pick a channel to dry-run the AI routing matrix.",
+            view=RoutingMatrixSelectView(),
+            ephemeral=True,
+        )
+
+    @discord.ui.button(
+        label="Advanced",
+        style=discord.ButtonStyle.secondary,
+        row=2,
     )
     async def advanced_btn(
         self,

--- a/disbot/views/ai/behavior/preset_picker.py
+++ b/disbot/views/ai/behavior/preset_picker.py
@@ -1,0 +1,187 @@
+"""Preset picker — list + apply (PR-C).
+
+Reads ``services.ai_behavior_profile_service.list_presets()`` and
+renders a native :class:`discord.ui.Select` so the operator picks
+one preset for the previously-chosen scope. Submit calls
+``apply_preset`` and renders a confirmation embed.
+
+The view never invokes ``ai_db.*`` directly.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import discord
+
+logger = logging.getLogger("bot.views.ai.behavior.preset_picker")
+
+_TIMEOUT_SECONDS = 180
+
+# Discord's native select caps at 25 options. The catalog has 7
+# entries; the cap is enforced anyway so future preset growth fails
+# loudly rather than silently dropping rows.
+_MAX_OPTIONS = 25
+
+
+def _admin(user: Any) -> bool:
+    perms = getattr(user, "guild_permissions", None)
+    return perms is not None and getattr(perms, "administrator", False)
+
+
+async def build_preset_picker_embed(*, scope_label: str) -> discord.Embed:
+    """Read the catalog and produce the picker embed."""
+    from services import ai_behavior_profile_service as svc
+
+    presets = await svc.list_presets()
+    embed = discord.Embed(
+        title="Pick a Behavior preset",
+        description=(
+            f"Selecting a preset binds it to **{scope_label}** and "
+            "writes through the existing policy chokepoint. Existing "
+            "min_level / cooldown overrides for that scope are "
+            "preserved."
+        ),
+        color=discord.Color.blurple(),
+    )
+    for preset in presets[:_MAX_OPTIONS]:
+        embed.add_field(
+            name=f"`{preset.key}` · mode=`{preset.recommended_mode}`",
+            value=preset.headline,
+            inline=False,
+        )
+    embed.set_footer(text="Submit to apply · ephemeral follow-up.")
+    return embed
+
+
+class _PresetSelect(discord.ui.Select):
+    def __init__(
+        self,
+        *,
+        scope: str,
+        target_id: int,
+        target_label: str,
+        options: list[discord.SelectOption],
+        preset_lookup: dict[str, int],
+    ) -> None:
+        super().__init__(
+            placeholder="Pick a preset…",
+            min_values=1,
+            max_values=1,
+            options=options,
+        )
+        self._scope = scope
+        self._target_id = target_id
+        self._target_label = target_label
+        self._preset_lookup = preset_lookup
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from services import ai_behavior_profile_service as svc
+
+        chosen_key = self.values[0]
+        preset_id = self._preset_lookup.get(chosen_key)
+        if preset_id is None:
+            await interaction.response.send_message(
+                f"❌ Unknown preset `{chosen_key}`.",
+                ephemeral=True,
+            )
+            return
+        if interaction.guild is None:
+            await interaction.response.send_message(
+                "❌ Apply requires a guild context.",
+                ephemeral=True,
+            )
+            return
+        try:
+            result = await svc.apply_preset(
+                guild_id=interaction.guild.id,
+                scope=self._scope,
+                target_id=self._target_id,
+                preset_id=preset_id,
+                actor=interaction.user,
+            )
+        except svc.BehaviorPresetError as exc:
+            await interaction.response.send_message(
+                f"❌ {type(exc).__name__}: {exc}",
+                ephemeral=True,
+            )
+            return
+        except Exception as exc:  # noqa: BLE001 — defensive
+            logger.exception(
+                "PresetPicker: apply failed scope=%s target=%s preset=%s",
+                self._scope,
+                self._target_id,
+                chosen_key,
+            )
+            await interaction.response.send_message(
+                f"❌ Unexpected error: {type(exc).__name__}: {exc}",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.response.send_message(
+            f"✅ Bound preset `{result.preset_key}` "
+            f"(mode `{result.recommended_mode}`) to "
+            f"{self._scope} **{self._target_label}**. "
+            f"mutation_id=`{result.policy_mutation_id}`.",
+            ephemeral=True,
+        )
+
+
+class PresetPickerView(discord.ui.View):
+    """Wrap a :class:`_PresetSelect` for one scope + target.
+
+    The select options are loaded lazily in :meth:`prepare` so the
+    view can call the async catalog read. ``__init__`` is sync — call
+    sites should construct then ``send_message`` after a separate
+    ``build_preset_picker_embed`` call (which loads the catalog).
+    Construction is cheap; the lazy load happens when the dropdown
+    is opened.
+    """
+
+    def __init__(self, *, scope: str, target_id: int, target_label: str) -> None:
+        super().__init__(timeout=_TIMEOUT_SECONDS)
+        self._scope = scope
+        self._target_id = target_id
+        self._target_label = target_label
+        self._loaded = False
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if not _admin(interaction.user):
+            await interaction.response.send_message(
+                "❌ Administrator permission required.",
+                ephemeral=True,
+            )
+            return False
+        if not self._loaded:
+            await self._load_options()
+        return True
+
+    async def _load_options(self) -> None:
+        from services import ai_behavior_profile_service as svc
+
+        presets = await svc.list_presets()
+        options: list[discord.SelectOption] = []
+        lookup: dict[str, int] = {}
+        for preset in presets[:_MAX_OPTIONS]:
+            options.append(
+                discord.SelectOption(
+                    label=preset.key,
+                    description=preset.headline[:100],
+                    value=preset.key,
+                ),
+            )
+            lookup[preset.key] = preset.preset_id
+        select = _PresetSelect(
+            scope=self._scope,
+            target_id=self._target_id,
+            target_label=self._target_label,
+            options=options,
+            preset_lookup=lookup,
+        )
+        self.add_item(select)
+        self._loaded = True
+
+
+__all__ = ["PresetPickerView", "build_preset_picker_embed"]

--- a/disbot/views/ai/behavior/scope_picker.py
+++ b/disbot/views/ai/behavior/scope_picker.py
@@ -1,0 +1,139 @@
+"""Scope select + preset picker hand-off (PR-C).
+
+After the operator clicks Channel / Category from
+:class:`views.ai.behavior.chooser.BehaviorChooserView`, the matching
+select view here surfaces a native discord channel/category select.
+On submit, the chosen target is handed to
+:class:`views.ai.behavior.preset_picker.PresetPickerView`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import discord
+
+logger = logging.getLogger("bot.views.ai.behavior.scope_picker")
+
+_TIMEOUT_SECONDS = 180
+
+
+def _admin(user: Any) -> bool:
+    perms = getattr(user, "guild_permissions", None)
+    return perms is not None and getattr(perms, "administrator", False)
+
+
+# ---------------------------------------------------------------------------
+# Channel
+# ---------------------------------------------------------------------------
+
+
+class _BehaviorChannelSelect(discord.ui.ChannelSelect):
+    def __init__(self) -> None:
+        super().__init__(
+            placeholder="Pick a channel…",
+            channel_types=[discord.ChannelType.text],
+            min_values=1,
+            max_values=1,
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        picked: Any = self.values[0]
+        if interaction.guild is not None:
+            from core.runtime import guild_resources
+
+            full = guild_resources.resolve_channel(
+                interaction.guild,
+                channel_id=picked.id,
+                kind="text",
+            )
+            if full is not None:
+                picked = full
+
+        from views.ai.behavior.preset_picker import (
+            PresetPickerView,
+            build_preset_picker_embed,
+        )
+
+        view = PresetPickerView(
+            scope="channel",
+            target_id=picked.id,
+            target_label=getattr(picked, "mention", f"<#{picked.id}>"),
+        )
+        await interaction.response.send_message(
+            embed=await build_preset_picker_embed(scope_label=f"channel {picked.mention}"),
+            view=view,
+            ephemeral=True,
+        )
+
+
+class BehaviorChannelSelectView(discord.ui.View):
+    def __init__(self) -> None:
+        super().__init__(timeout=_TIMEOUT_SECONDS)
+        self.add_item(_BehaviorChannelSelect())
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if not _admin(interaction.user):
+            await interaction.response.send_message(
+                "❌ Administrator permission required.",
+                ephemeral=True,
+            )
+            return False
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Category
+# ---------------------------------------------------------------------------
+
+
+class _BehaviorCategorySelect(discord.ui.ChannelSelect):
+    def __init__(self) -> None:
+        super().__init__(
+            placeholder="Pick a category…",
+            channel_types=[discord.ChannelType.category],
+            min_values=1,
+            max_values=1,
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        picked: Any = self.values[0]
+        # Categories don't have ``.mention``; show name.
+        label = getattr(picked, "name", str(picked.id))
+
+        from views.ai.behavior.preset_picker import (
+            PresetPickerView,
+            build_preset_picker_embed,
+        )
+
+        view = PresetPickerView(
+            scope="category",
+            target_id=picked.id,
+            target_label=label,
+        )
+        await interaction.response.send_message(
+            embed=await build_preset_picker_embed(scope_label=f"category **{label}**"),
+            view=view,
+            ephemeral=True,
+        )
+
+
+class BehaviorCategorySelectView(discord.ui.View):
+    def __init__(self) -> None:
+        super().__init__(timeout=_TIMEOUT_SECONDS)
+        self.add_item(_BehaviorCategorySelect())
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if not _admin(interaction.user):
+            await interaction.response.send_message(
+                "❌ Administrator permission required.",
+                ephemeral=True,
+            )
+            return False
+        return True
+
+
+__all__ = ["BehaviorCategorySelectView", "BehaviorChannelSelectView"]

--- a/disbot/views/ai/behavior/scope_picker.py
+++ b/disbot/views/ai/behavior/scope_picker.py
@@ -63,7 +63,9 @@ class _BehaviorChannelSelect(discord.ui.ChannelSelect):
             target_label=getattr(picked, "mention", f"<#{picked.id}>"),
         )
         await interaction.response.send_message(
-            embed=await build_preset_picker_embed(scope_label=f"channel {picked.mention}"),
+            embed=await build_preset_picker_embed(
+                scope_label=f"channel {picked.mention}",
+            ),
             view=view,
             ephemeral=True,
         )

--- a/disbot/views/ai/panel.py
+++ b/disbot/views/ai/panel.py
@@ -218,6 +218,30 @@ class AIPanelView(PersistentView):
             ephemeral=True,
         )
 
+    @discord.ui.button(
+        label="Behavior",
+        style=discord.ButtonStyle.success,
+        row=1,
+        custom_id="ai:behavior",
+    )
+    async def behavior_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        # PR-C: open the usability-first Behavior chooser as an ephemeral
+        # follow-up. Bind presets without learning the raw policy knobs.
+        from views.ai.behavior import (
+            BehaviorChooserView,
+            build_behavior_embed,
+        )
+
+        await interaction.response.send_message(
+            embed=build_behavior_embed(),
+            view=BehaviorChooserView(),
+            ephemeral=True,
+        )
+
 
 # ---------------------------------------------------------------------------
 # Shared dispatch + interaction-router handler
@@ -308,6 +332,20 @@ async def handle_ai_interaction(
         await interaction.response.send_message(
             embed=build_chooser_embed(),
             view=PolicyChooserView(),
+            ephemeral=True,
+        )
+        return
+
+    # PR-C: same shape for the Behavior chooser.
+    if action == "behavior":
+        from views.ai.behavior import (
+            BehaviorChooserView,
+            build_behavior_embed,
+        )
+
+        await interaction.response.send_message(
+            embed=build_behavior_embed(),
+            view=BehaviorChooserView(),
             ephemeral=True,
         )
         return

--- a/disbot/views/ai/policy/category_view.py
+++ b/disbot/views/ai/policy/category_view.py
@@ -98,6 +98,8 @@ class CategoryPolicyModal(discord.ui.Modal):
             await interaction.response.send_message(f"❌ {exc}", ephemeral=True)
             return
 
+        from services.ai_policy_mutation import UNCHANGED
+
         try:
             result = await set_category_policy(
                 interaction.guild.id,
@@ -105,7 +107,7 @@ class CategoryPolicyModal(discord.ui.Modal):
                 mode=mode,
                 min_level=min_level,
                 cooldown_seconds=cooldown_seconds,
-                instruction_profile_id=None,
+                instruction_profile_id=UNCHANGED,
                 actor=interaction.user,
             )
         except AIPolicyMutationError as exc:

--- a/disbot/views/ai/policy/channel_view.py
+++ b/disbot/views/ai/policy/channel_view.py
@@ -1,4 +1,4 @@
-"""Channel-scope AI policy write UI (PR4A).
+"""Channel-scope AI policy write UI.
 
 Two-step flow:
 
@@ -14,11 +14,11 @@ Two-step flow:
 The view never writes to the DB directly — every mutation goes
 through ``ai_policy_mutation``.
 
-instruction_profile_id is intentionally omitted from this modal:
-profile creation / assignment is a separate surface tracked in a
-follow-up PR; channel policy upserts pass ``None`` so the column
-clears any prior assignment. That matches the principle "one
-modal, one job".
+``instruction_profile_id`` is intentionally omitted from this
+modal: profile / preset assignment is owned by the Behavior UI
+(``views/ai/behavior/``) and the preset service. This modal passes
+``UNCHANGED`` for that column so partial mode/min_level/cooldown
+edits no longer wipe an existing profile binding (PR-C-pre).
 """
 
 from __future__ import annotations
@@ -128,6 +128,8 @@ class ChannelPolicyModal(discord.ui.Modal):
             await interaction.response.send_message(f"❌ {exc}", ephemeral=True)
             return
 
+        from services.ai_policy_mutation import UNCHANGED
+
         try:
             result = await set_channel_policy(
                 interaction.guild.id,
@@ -135,7 +137,7 @@ class ChannelPolicyModal(discord.ui.Modal):
                 mode=mode,
                 min_level=min_level,
                 cooldown_seconds=cooldown_seconds,
-                instruction_profile_id=None,
+                instruction_profile_id=UNCHANGED,
                 actor=interaction.user,
             )
         except AIPolicyMutationError as exc:

--- a/disbot/views/ai/routing/__init__.py
+++ b/disbot/views/ai/routing/__init__.py
@@ -1,0 +1,16 @@
+"""Operator routing matrix overview (PR-G).
+
+Read-only diagnostic that runs the natural-language resolver in
+``dry_run=True`` for representative scopes and renders the
+precedence outcomes. Lives alongside the Behavior and Policy UIs
+in ``views/ai/`` so the panel button can dispatch directly.
+"""
+
+from __future__ import annotations
+
+from views.ai.routing.matrix import (  # noqa: F401
+    RoutingMatrixSelectView,
+    build_routing_matrix_embed,
+)
+
+__all__ = ["RoutingMatrixSelectView", "build_routing_matrix_embed"]

--- a/disbot/views/ai/routing/matrix.py
+++ b/disbot/views/ai/routing/matrix.py
@@ -71,11 +71,7 @@ async def build_routing_matrix_embed(
     decision = await nlp.resolve(ctx, dry_run=True)
     presets = await _preset_lookup()
 
-    color = (
-        discord.Color.green()
-        if decision.allowed
-        else discord.Color.red()
-    )
+    color = discord.Color.green() if decision.allowed else discord.Color.red()
     embed = discord.Embed(
         title="🧭 AI Routing matrix (dry-run)",
         description=(
@@ -86,7 +82,11 @@ async def build_routing_matrix_embed(
     )
     embed.add_field(
         name="Outcome",
-        value="✅ allowed" if decision.allowed else f"❌ denied · `{decision.reason_code.value}`",
+        value=(
+            "✅ allowed"
+            if decision.allowed
+            else f"❌ denied · `{decision.reason_code.value}`"
+        ),
         inline=False,
     )
     embed.add_field(

--- a/disbot/views/ai/routing/matrix.py
+++ b/disbot/views/ai/routing/matrix.py
@@ -1,0 +1,172 @@
+"""Operator routing matrix view (PR-G).
+
+For a given channel + role the operator picks, run the resolver in
+dry-run mode and render the resulting decision (precedence trace,
+effective min_level, effective cooldown, instruction_profile_ids,
+reason_code). No mutations.
+
+The matrix consumes:
+
+* :mod:`services.ai_natural_language_policy` for the resolver.
+* :mod:`services.ai_behavior_profile_service` to translate
+  instruction_profile_ids into preset keys when applicable.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import discord
+
+logger = logging.getLogger("bot.views.ai.routing.matrix")
+
+_TIMEOUT_SECONDS = 180
+
+
+def _admin(user: Any) -> bool:
+    perms = getattr(user, "guild_permissions", None)
+    return perms is not None and getattr(perms, "administrator", False)
+
+
+async def _preset_lookup() -> dict[int, str]:
+    """Map preset id → key (for embed labels). Falls back to ``{}``
+    if the catalog is empty / unavailable.
+    """
+    try:
+        from services import ai_behavior_profile_service as svc
+
+        presets = await svc.list_presets()
+        return {p.preset_id: p.key for p in presets}
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.debug("routing matrix: preset catalog unavailable (%s)", exc)
+        return {}
+
+
+async def build_routing_matrix_embed(
+    *,
+    guild_id: int,
+    channel_id: int,
+    user_id: int,
+    user_level: int = 5,
+    user_role_ids: tuple[int, ...] = (),
+) -> discord.Embed:
+    """Run the resolver in dry-run mode and render the outcome.
+
+    The operator picks the (channel, role) pair via the
+    :class:`RoutingMatrixSelectView`; this helper does the rest.
+    """
+    from services import ai_natural_language_policy as nlp
+
+    ctx = nlp.MessageContext(
+        guild_id=guild_id,
+        channel_id=channel_id,
+        category_id=None,
+        user_id=user_id,
+        user_level=user_level,
+        user_role_ids=user_role_ids,
+        is_mention=False,
+        is_fresh_user=False,
+    )
+    decision = await nlp.resolve(ctx, dry_run=True)
+    presets = await _preset_lookup()
+
+    color = (
+        discord.Color.green()
+        if decision.allowed
+        else discord.Color.red()
+    )
+    embed = discord.Embed(
+        title="🧭 AI Routing matrix (dry-run)",
+        description=(
+            f"channel=<#{channel_id}> · user=<@{user_id}> · "
+            f"user_level={user_level} · roles={list(user_role_ids) or '—'}"
+        ),
+        color=color,
+    )
+    embed.add_field(
+        name="Outcome",
+        value="✅ allowed" if decision.allowed else f"❌ denied · `{decision.reason_code.value}`",
+        inline=False,
+    )
+    embed.add_field(
+        name="Effective min_level",
+        value=str(decision.effective_min_level),
+        inline=True,
+    )
+    embed.add_field(
+        name="Effective cooldown",
+        value=f"{decision.effective_cooldown}s",
+        inline=True,
+    )
+    if decision.instruction_profile_ids:
+        labels = []
+        for pid in decision.instruction_profile_ids:
+            key = presets.get(int(pid))
+            labels.append(f"`{pid}`" + (f" ({key})" if key else ""))
+        embed.add_field(
+            name="Instruction profiles",
+            value=", ".join(labels),
+            inline=False,
+        )
+    if decision.precedence_trace:
+        trace = "\n".join(f"• {line}" for line in decision.precedence_trace)
+        if len(trace) > 1000:
+            trace = trace[:999] + "…"
+        embed.add_field(name="Precedence trace", value=trace, inline=False)
+    embed.set_footer(
+        text=(
+            f"policy_snapshot=`{decision.policy_snapshot_hash or '—'}` · "
+            "dry-run only · no audit / no cooldown side-effects."
+        ),
+    )
+    return embed
+
+
+class _MatrixChannelSelect(discord.ui.ChannelSelect):
+    def __init__(self) -> None:
+        super().__init__(
+            placeholder="Pick a channel to preview routing for…",
+            channel_types=[discord.ChannelType.text],
+            min_values=1,
+            max_values=1,
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        if interaction.guild is None:
+            await interaction.response.send_message(
+                "❌ This requires a guild context.",
+                ephemeral=True,
+            )
+            return
+        picked = self.values[0]
+        embed = await build_routing_matrix_embed(
+            guild_id=interaction.guild.id,
+            channel_id=picked.id,
+            user_id=interaction.user.id,
+        )
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+
+
+class RoutingMatrixSelectView(discord.ui.View):
+    """Ephemeral picker — channel select that triggers a dry-run resolve."""
+
+    def __init__(self) -> None:
+        super().__init__(timeout=_TIMEOUT_SECONDS)
+        self.add_item(_MatrixChannelSelect())
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if not _admin(interaction.user):
+            await interaction.response.send_message(
+                "❌ Administrator permission required.",
+                ephemeral=True,
+            )
+            return False
+        return True
+
+
+__all__ = [
+    "RoutingMatrixSelectView",
+    "build_routing_matrix_embed",
+]

--- a/disbot/views/ai/support_report.py
+++ b/disbot/views/ai/support_report.py
@@ -1,0 +1,109 @@
+"""Support-report draft view (PR-H).
+
+Read-only aggregator: composes a copy-pasteable code-block draft
+from the most recent ``ai_decision_audit`` rows for the caller's
+guild plus the bot's identifiers. **No outbound delivery of any
+kind** — the operator copies the block into whatever support channel
+they use (email, ticket, GitHub issue, etc.).
+
+The draft contains only fields already present in
+``ai_decision_audit``. Message bodies are never included; the
+audit table holds the join key (``message_id``) only, so privacy is
+preserved by construction.
+"""
+
+from __future__ import annotations
+
+import logging
+import platform
+import sys
+from typing import Any
+
+import discord
+
+logger = logging.getLogger("bot.views.ai.support_report")
+
+
+_MAX_AUDIT_ROWS_IN_REPORT = 10
+
+
+def _admin(user: Any) -> bool:
+    perms = getattr(user, "guild_permissions", None)
+    return perms is not None and getattr(perms, "administrator", False)
+
+
+async def build_support_report_draft(
+    *,
+    guild_id: int,
+    bot_user_id: int | None,
+) -> str:
+    """Return a fenced markdown code block summarising recent audit
+    rows for the guild.
+
+    Every line uses only the columns ``ai_decision_audit`` already
+    holds: no message content, no DMs, no user identifiers beyond
+    the user ids already in the audit row.
+    """
+    from services import ai_decision_audit_service
+
+    rows = await ai_decision_audit_service.query(guild_id, limit=50)
+    rows = rows[:_MAX_AUDIT_ROWS_IN_REPORT]
+
+    lines: list[str] = []
+    lines.append("```")
+    lines.append("# SuperBot AI support report (draft — copy-paste only)")
+    lines.append(f"# guild_id: {guild_id}")
+    if bot_user_id is not None:
+        lines.append(f"# bot_user_id: {bot_user_id}")
+    lines.append(f"# python: {sys.version.split()[0]} on {platform.system()}")
+    lines.append("# fields below come ONLY from ai_decision_audit; no message text.")
+    lines.append("")
+    if not rows:
+        lines.append("(no recent audit rows for this guild)")
+    else:
+        for r in rows:
+            lines.append(
+                f"- decision={r.get('decision')} reason={r.get('reason_code')} "
+                f"task={r.get('task') or '—'} route={r.get('route') or '—'} "
+                f"provider={r.get('provider') or '—'} model={r.get('model') or '—'}",
+            )
+    lines.append("```")
+    return "\n".join(lines)
+
+
+async def build_support_report_embed(
+    *,
+    guild_id: int,
+    bot_user_id: int | None,
+) -> discord.Embed:
+    """Wrap :func:`build_support_report_draft` in an explanatory embed."""
+    draft = await build_support_report_draft(
+        guild_id=guild_id,
+        bot_user_id=bot_user_id,
+    )
+    embed = discord.Embed(
+        title="📋 AI Support report — draft",
+        description=(
+            "Copy the code block below into your support channel. "
+            "**This bot does NOT send anything outbound** — you must "
+            "paste it yourself wherever support requests are handled."
+        ),
+        color=discord.Color.blurple(),
+    )
+    # Discord field values cap at 1024 chars; the draft is bounded
+    # by _MAX_AUDIT_ROWS_IN_REPORT but we still defensively truncate.
+    body = draft if len(draft) <= 1000 else draft[:999] + "…\n```"
+    embed.add_field(name="Draft", value=body, inline=False)
+    embed.set_footer(
+        text=(
+            "Privacy: no message text is included — only audit rows. "
+            "No network egress on this code path."
+        ),
+    )
+    return embed
+
+
+__all__ = [
+    "build_support_report_draft",
+    "build_support_report_embed",
+]

--- a/disbot/views/btd6/panel.py
+++ b/disbot/views/btd6/panel.py
@@ -33,11 +33,11 @@ class BTD6AskModal(discord.ui.Modal, title="Ask BTD6 Assistant"):
     )
 
     async def on_submit(self, interaction: discord.Interaction) -> None:
-        from cogs.btd6_cog import _response_to_embed
+        from cogs.btd6._embeds import response_to_embed
 
         response = await btd6_ai_service.answer_question(str(self.question.value))
         await interaction.response.send_message(
-            embed=_response_to_embed(response),
+            embed=response_to_embed(response),
             ephemeral=True,
         )
 
@@ -130,7 +130,7 @@ class BTD6PanelView(PersistentView):
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        from cogs.btd6_cog import build_towers_embed
+        from cogs.btd6._embeds import build_towers_embed
 
         await interaction.response.edit_message(
             embed=build_towers_embed(),
@@ -148,7 +148,7 @@ class BTD6PanelView(PersistentView):
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        from cogs.btd6_cog import build_modes_embed
+        from cogs.btd6._embeds import build_modes_embed
 
         await interaction.response.edit_message(
             embed=build_modes_embed(),
@@ -166,7 +166,7 @@ class BTD6PanelView(PersistentView):
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        from cogs.btd6_cog import build_status_embed
+        from cogs.btd6._embeds import build_status_embed
 
         await interaction.response.edit_message(
             embed=build_status_embed(),

--- a/disbot/views/btd6/panel.py
+++ b/disbot/views/btd6/panel.py
@@ -1,4 +1,4 @@
-"""BTD6 persistent panel — Module 4 of the AI/BTD6 plan.
+"""BTD6 persistent panel.
 
 The view lives under ``views/btd6/`` (Pattern B) so the cog file
 stays small. Importing this module triggers the ``@register``
@@ -6,11 +6,10 @@ decorator side-effect on :class:`BTD6PanelView`; the persistent
 view registry then resolves the ``btd6`` subsystem when
 ``on_ready`` restores anchors.
 
-The panel is read-only and entirely deterministic: every button
-renders an embed built from the validated fixtures in
-:mod:`services.btd6_data_service`. No provider, no network, no AI.
-Module 5 will add an optional augmentation toggle gated by guild
-config.
+Panel buttons render deterministic embeds from
+:mod:`services.btd6_knowledge_service` and the BTD6 response
+builder. Natural-language replies are owned by the AI Platform's
+central stage — this panel never invokes a provider directly.
 """
 
 from __future__ import annotations
@@ -44,7 +43,7 @@ class BTD6AskModal(discord.ui.Modal, title="Ask BTD6 Assistant"):
 
 
 def build_btd6_panel_embed() -> discord.Embed:
-    """Deterministic BTD6 panel embed.
+    """BTD6 panel embed.
 
     Pulls the dataset version + game version so operators can see at
     a glance which patch the assistant is pinned to.
@@ -52,8 +51,8 @@ def build_btd6_panel_embed() -> discord.Embed:
     embed = discord.Embed(
         title="🐵 BTD6 Assistant",
         description=(
-            "Ask deterministic BTD6 questions. The buttons below render "
-            "tower / round / mode lookups from the pinned fixtures."
+            "Ask BTD6 questions. The buttons below render "
+            "tower / round / mode lookups."
         ),
         color=_PANEL_COLOR,
     )

--- a/disbot/views/btd6/strategy_browse.py
+++ b/disbot/views/btd6/strategy_browse.py
@@ -77,7 +77,9 @@ async def build_browse_embed(*, limit: int = _DEFAULT_PAGE_SIZE) -> discord.Embe
             value=_summarize_row(row),
             inline=False,
         )
-    embed.set_footer(text="!btd6 strategy <id> for detail · staff-only commands gate writes.")
+    embed.set_footer(
+        text="!btd6 strategy <id> for detail · staff-only commands gate writes.",
+    )
     return embed
 
 
@@ -213,10 +215,7 @@ async def build_audit_embed(strategy_id: int) -> discord.Embed:
         when_str = when.isoformat(timespec="minutes") if when else "—"
         embed.add_field(
             name=f"`{r.get('action')}` · {r.get('actor_kind')}",
-            value=(
-                f"actor_id=`{r.get('actor_id') or '—'}` · "
-                f"at=`{when_str}`"
-            ),
+            value=(f"actor_id=`{r.get('actor_id') or '—'}` · at=`{when_str}`"),
             inline=False,
         )
     return embed

--- a/disbot/views/btd6/strategy_browse.py
+++ b/disbot/views/btd6/strategy_browse.py
@@ -1,0 +1,230 @@
+"""Strategy memory browse / mine / audit embeds (PR-F).
+
+Read-only renderers. All writes still flow through
+:mod:`services.btd6_strategy_mutation`; this module never touches
+``utils.db.btd6_strategies`` directly.
+
+Renderers:
+
+* :func:`build_browse_embed` — published strategies catalog.
+* :func:`build_mine_embed` — caller's own submissions for the guild.
+* :func:`build_detail_embed` — single-strategy drill-down with
+  provenance labels.
+* :func:`build_audit_embed` — per-strategy audit log.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import discord
+
+_DEFAULT_PAGE_SIZE = 10
+_MAX_PAGE_SIZE = 25
+
+
+def _clamp(limit: int) -> int:
+    return max(1, min(int(limit), _MAX_PAGE_SIZE))
+
+
+def _visibility_badge(row: dict[str, Any]) -> str:
+    return "📦 published" if row.get("visibility") == "published" else "🛡️ guild"
+
+
+def _approval_label(row: dict[str, Any]) -> str:
+    status = row.get("approval_status", "draft")
+    approved_by = row.get("approved_by")
+    if approved_by == "ai":
+        return f"`{status}` · approved_by=ai"
+    if approved_by == "staff":
+        return f"`{status}` · approved_by=staff"
+    return f"`{status}`"
+
+
+def _summarize_row(row: dict[str, Any]) -> str:
+    badge = _visibility_badge(row)
+    approval = _approval_label(row)
+    title = row.get("title") or "(untitled)"
+    summary = (row.get("summary") or "").strip()
+    if len(summary) > 100:
+        summary = summary[:99] + "…"
+    return f"{badge} · {approval} · **{title}** — {summary}"
+
+
+# ---------------------------------------------------------------------------
+# Browse (published catalog)
+# ---------------------------------------------------------------------------
+
+
+async def build_browse_embed(*, limit: int = _DEFAULT_PAGE_SIZE) -> discord.Embed:
+    from services import btd6_strategy_service
+
+    rows = await btd6_strategy_service.list_published(limit=_clamp(limit))
+    embed = discord.Embed(
+        title="🐵 BTD6 — Published strategies",
+        description=(
+            f"Showing {len(rows)} published strategies "
+            f"(max {_MAX_PAGE_SIZE} per page)."
+        ),
+        color=discord.Color.green(),
+    )
+    if not rows:
+        embed.description = "No published strategies yet."
+        return embed
+    for row in rows:
+        embed.add_field(
+            name=f"#{row['id']} · {_visibility_badge(row)}",
+            value=_summarize_row(row),
+            inline=False,
+        )
+    embed.set_footer(text="!btd6 strategy <id> for detail · staff-only commands gate writes.")
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# Mine (caller's own submissions)
+# ---------------------------------------------------------------------------
+
+
+async def build_mine_embed(
+    guild_id: int,
+    submitter_id: int,
+    *,
+    limit: int = _DEFAULT_PAGE_SIZE,
+) -> discord.Embed:
+    from services import btd6_strategy_service
+
+    rows = await btd6_strategy_service.list_mine(
+        guild_id,
+        submitter_id,
+        limit=_clamp(limit),
+    )
+    embed = discord.Embed(
+        title="🐵 BTD6 — My strategy submissions",
+        description=(
+            f"Showing {len(rows)} of your submissions in this guild "
+            f"(max {_MAX_PAGE_SIZE})."
+        ),
+        color=discord.Color.green(),
+    )
+    if not rows:
+        embed.description = "You have not submitted any strategies in this guild."
+        return embed
+    for row in rows:
+        embed.add_field(
+            name=f"#{row['id']} · {_visibility_badge(row)}",
+            value=_summarize_row(row),
+            inline=False,
+        )
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# Detail (single drill-down)
+# ---------------------------------------------------------------------------
+
+
+async def build_detail_embed(
+    strategy_id: int,
+    *,
+    viewer_guild_id: int | None = None,
+) -> discord.Embed | str:
+    """Render the detail for one strategy.
+
+    Returns ``str`` when:
+
+    * The strategy does not exist.
+    * The strategy is guild-local and the viewer is in a different
+      guild (cross-guild leakage prevention).
+    """
+    from services import btd6_strategy_service
+
+    row = await btd6_strategy_service.get(strategy_id)
+    if row is None:
+        return f"Strategy #{strategy_id} not found."
+
+    # Cross-guild visibility check: published rows are world-visible;
+    # guild rows are visible only to their origin or current guild.
+    visibility = row.get("visibility")
+    if visibility != "published" and viewer_guild_id is not None:
+        origin = row.get("origin_guild_id")
+        current = row.get("current_guild_id")
+        if viewer_guild_id not in {origin, current}:
+            return (
+                f"Strategy #{strategy_id} is guild-local; it is not "
+                "visible from this guild."
+            )
+
+    embed = discord.Embed(
+        title=f"🐵 BTD6 — Strategy #{row['id']}: {row.get('title') or '(untitled)'}",
+        description=row.get("summary") or "(no summary)",
+        color=discord.Color.green(),
+    )
+    embed.add_field(name="Visibility", value=_visibility_badge(row), inline=True)
+    embed.add_field(name="Approval", value=_approval_label(row), inline=True)
+    embed.add_field(
+        name="Version",
+        value=str(row.get("version") or 1),
+        inline=True,
+    )
+    if row.get("map"):
+        embed.add_field(name="Map", value=row["map"], inline=True)
+    if row.get("mode"):
+        embed.add_field(name="Mode", value=row["mode"], inline=True)
+    if row.get("difficulty"):
+        embed.add_field(name="Difficulty", value=row["difficulty"], inline=True)
+    if row.get("hero"):
+        embed.add_field(name="Hero", value=row["hero"], inline=True)
+    if row.get("towers"):
+        towers_str = ", ".join(str(t) for t in row["towers"][:10])
+        embed.add_field(name="Towers", value=towers_str, inline=False)
+    if row.get("steps"):
+        steps_str = "\n".join(f"• {s}" for s in row["steps"][:6])
+        embed.add_field(name="Steps", value=steps_str or "—", inline=False)
+    embed.set_footer(
+        text=(
+            f"origin_guild={row.get('origin_guild_id') or '—'} · "
+            f"current_guild={row.get('current_guild_id') or '—'} · "
+            f"submitted_by={row.get('submitted_by') or '—'}"
+        ),
+    )
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# Audit log (per-strategy)
+# ---------------------------------------------------------------------------
+
+
+async def build_audit_embed(strategy_id: int) -> discord.Embed:
+    from services import btd6_strategy_service
+
+    rows = await btd6_strategy_service.audit_for(strategy_id)
+    embed = discord.Embed(
+        title=f"🐵 BTD6 — Strategy #{strategy_id} audit",
+        description=f"Showing {len(rows)} audit row(s).",
+        color=discord.Color.green(),
+    )
+    if not rows:
+        embed.description = f"No audit rows for strategy #{strategy_id}."
+        return embed
+    for r in rows[:_MAX_PAGE_SIZE]:
+        when = r.get("created_at")
+        when_str = when.isoformat(timespec="minutes") if when else "—"
+        embed.add_field(
+            name=f"`{r.get('action')}` · {r.get('actor_kind')}",
+            value=(
+                f"actor_id=`{r.get('actor_id') or '—'}` · "
+                f"at=`{when_str}`"
+            ),
+            inline=False,
+        )
+    return embed
+
+
+__all__ = [
+    "build_audit_embed",
+    "build_browse_embed",
+    "build_detail_embed",
+    "build_mine_embed",
+]

--- a/disbot/views/btd6/strategy_submit.py
+++ b/disbot/views/btd6/strategy_submit.py
@@ -1,0 +1,116 @@
+"""Strategy submission modal (PR-F).
+
+A minimal modal that captures the three required fields (title,
+summary, optional map/mode) and forwards to
+``services.btd6_strategy_mutation.submit_strategy``. The full
+strategy payload (towers / upgrade paths / steps / round_range /
+failures / source links / origin metadata) is intentionally NOT in
+the modal — Discord modals cap at 5 text inputs and the heavier
+fields belong on a follow-up form. PR-F ships the minimum
+operator-viable path; richer authoring can come later.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import discord
+
+logger = logging.getLogger("bot.views.btd6.strategy_submit")
+
+
+class StrategySubmitModal(discord.ui.Modal, title="Submit BTD6 strategy"):
+    title_input: discord.ui.TextInput = discord.ui.TextInput(
+        label="Title",
+        placeholder="e.g. CHIMPS Bloody Puddles 4-2-0 Super Monkey",
+        required=True,
+        max_length=100,
+    )
+    summary_input: discord.ui.TextInput = discord.ui.TextInput(
+        label="Summary",
+        placeholder="Short pitch — when and why this strategy works.",
+        required=True,
+        style=discord.TextStyle.paragraph,
+        max_length=500,
+    )
+    map_input: discord.ui.TextInput = discord.ui.TextInput(
+        label="Map (optional)",
+        placeholder="e.g. Bloody Puddles",
+        required=False,
+        max_length=80,
+    )
+    mode_input: discord.ui.TextInput = discord.ui.TextInput(
+        label="Mode (optional)",
+        placeholder="e.g. CHIMPS",
+        required=False,
+        max_length=40,
+    )
+    hero_input: discord.ui.TextInput = discord.ui.TextInput(
+        label="Hero (optional)",
+        placeholder="e.g. Geraldo",
+        required=False,
+        max_length=40,
+    )
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        from services.btd6_strategy_mutation import (
+            InvalidStrategyValueError,
+            submit_strategy,
+        )
+
+        if interaction.guild is None:
+            await interaction.response.send_message(
+                "❌ Submitting a strategy requires a guild context.",
+                ephemeral=True,
+            )
+            return
+        title = (self.title_input.value or "").strip()
+        summary = (self.summary_input.value or "").strip()
+        map_name = (self.map_input.value or "").strip() or None
+        mode = (self.mode_input.value or "").strip() or None
+        hero = (self.hero_input.value or "").strip() or None
+
+        try:
+            result = await submit_strategy(
+                origin_guild_id=interaction.guild.id,
+                submitter=interaction.user,
+                title=title,
+                summary=summary,
+                map_name=map_name,
+                mode=mode,
+                hero=hero,
+            )
+        except InvalidStrategyValueError as exc:
+            await interaction.response.send_message(
+                f"❌ {exc}",
+                ephemeral=True,
+            )
+            return
+        except Exception as exc:  # noqa: BLE001 — defensive
+            logger.exception(
+                "StrategySubmitModal: submission failed for guild=%s",
+                interaction.guild.id,
+            )
+            await interaction.response.send_message(
+                f"❌ Unexpected error: {type(exc).__name__}: {exc}",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.response.send_message(
+            f"✅ Submitted as strategy `#{result.strategy_id}` "
+            f"(`{result.action}`). Staff can review with `!btd6 pending`.",
+            ephemeral=True,
+        )
+
+
+__all__ = ["StrategySubmitModal"]
+
+
+# ``submitted_by`` is set on the strategy row via submit_strategy's
+# inspection of ``submitter.id`` — that already happens inside the
+# mutation chokepoint, so no extra wiring is needed here.
+
+def _has_user_id(actor: Any) -> bool:  # pragma: no cover - tiny shim
+    return getattr(actor, "id", None) is not None

--- a/disbot/views/btd6/strategy_submit.py
+++ b/disbot/views/btd6/strategy_submit.py
@@ -112,5 +112,6 @@ __all__ = ["StrategySubmitModal"]
 # inspection of ``submitter.id`` — that already happens inside the
 # mutation chokepoint, so no extra wiring is needed here.
 
+
 def _has_user_id(actor: Any) -> bool:  # pragma: no cover - tiny shim
     return getattr(actor, "id", None) is not None

--- a/tests/unit/cogs/test_btd6_boundaries.py
+++ b/tests/unit/cogs/test_btd6_boundaries.py
@@ -21,9 +21,9 @@ from pathlib import Path
 import discord
 import pytest
 
-from cogs.btd6_cog import BTD6Cog, build_status_embed
+from cogs.btd6._embeds import build_status_embed
+from cogs.btd6_cog import BTD6Cog
 from views.btd6.panel import build_btd6_panel_embed
-
 
 _DISBOT_ROOT = Path(__file__).resolve().parents[3] / "disbot"
 

--- a/tests/unit/cogs/test_btd6_boundaries.py
+++ b/tests/unit/cogs/test_btd6_boundaries.py
@@ -142,6 +142,12 @@ def _expected_parity_names() -> set[str]:
         "source-health",
         "latest-data",
         "grounding",
+        # PR-F additions:
+        "browse",
+        "mine",
+        "strategy",
+        "strategy-audit",
+        "submit",
     }
 
 

--- a/tests/unit/cogs/test_btd6_boundaries.py
+++ b/tests/unit/cogs/test_btd6_boundaries.py
@@ -1,0 +1,229 @@
+"""BTD6 boundary regression pins (PR-A).
+
+These tests lock in invariants the AI Platform + BTD6 polish series
+relies on:
+
+* No BTD6 module installs an ``on_message`` listener — natural-
+  language eligibility is owned by the central AI Platform stage.
+* No BTD6 module imports or calls the AI Platform write helpers in
+  :mod:`utils.db.ai`.
+* Every BTD6 prefix command has a slash twin (parity test).
+* The BTD6 status / panel embeds no longer carry the stale
+  "Module 4 / deterministic-only / AI augmentation off /
+  No provider, no network, no AI" copy.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import discord
+import pytest
+
+from cogs.btd6_cog import BTD6Cog, build_status_embed
+from views.btd6.panel import build_btd6_panel_embed
+
+
+_DISBOT_ROOT = Path(__file__).resolve().parents[3] / "disbot"
+
+# Module paths owned by BTD6.
+_BTD6_PATHS = [
+    _DISBOT_ROOT / "cogs" / "btd6_cog.py",
+    _DISBOT_ROOT / "cogs" / "btd6",
+    _DISBOT_ROOT / "views" / "btd6",
+    _DISBOT_ROOT / "services",  # filtered below
+]
+
+
+def _btd6_python_files() -> list[Path]:
+    """All Python files owned by BTD6 (cog + views + btd6_* services)."""
+    paths: list[Path] = []
+    for root in _BTD6_PATHS:
+        if root.is_file():
+            paths.append(root)
+            continue
+        if not root.is_dir():
+            continue
+        for p in root.rglob("*.py"):
+            # ``services/`` only contains btd6_* files.
+            if root.name == "services" and not p.name.startswith("btd6_"):
+                continue
+            paths.append(p)
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# Retired passive stage regression
+# ---------------------------------------------------------------------------
+
+
+def test_no_btd6_module_installs_on_message_listener():
+    """``@commands.Cog.listener('on_message')`` is forbidden in BTD6.
+
+    The retired passive stage stays retired; the central AI Platform
+    stage is the only natural-language entry point.
+    """
+    offenders: list[str] = []
+    for path in _btd6_python_files():
+        src = path.read_text()
+        tree = ast.parse(src, filename=str(path))
+        for node in ast.walk(tree):
+            # Look for any decorator literal "on_message" — this catches
+            # both ``@commands.Cog.listener(name='on_message')`` and
+            # ``@bot.event`` style ``async def on_message`` definitions.
+            if (
+                isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+                and node.name == "on_message"
+            ):
+                offenders.append(f"{path.relative_to(_DISBOT_ROOT)}::{node.name}")
+            for dec in getattr(node, "decorator_list", []):
+                src_seg = ast.unparse(dec) if hasattr(ast, "unparse") else ""
+                if "on_message" in src_seg:
+                    offenders.append(
+                        f"{path.relative_to(_DISBOT_ROOT)}::{getattr(node, 'name', '?')}",
+                    )
+    assert offenders == [], (
+        "BTD6 modules must not register on_message listeners; "
+        f"offenders: {offenders}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# BTD6 must not import AI Platform write helpers
+# ---------------------------------------------------------------------------
+
+
+_FORBIDDEN_AI_DB_SYMBOLS = {
+    "upsert_channel_policy",
+    "upsert_category_policy",
+    "upsert_role_policy",
+    "upsert_instruction_profile",
+    "upsert_guild_policy",
+}
+
+
+def test_no_btd6_module_imports_ai_db_write_helpers():
+    offenders: list[str] = []
+    for path in _btd6_python_files():
+        src = path.read_text()
+        # Substring-grep is sufficient: these are the actual function
+        # names exported by ``utils/db/ai.py``. Anything legitimately
+        # mentioning them in a docstring would also be a concern.
+        for symbol in _FORBIDDEN_AI_DB_SYMBOLS:
+            if symbol in src:
+                offenders.append(f"{path.relative_to(_DISBOT_ROOT)}::{symbol}")
+    assert offenders == [], (
+        "BTD6 modules must not import or reference AI Platform write "
+        f"helpers; offenders: {offenders}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Prefix / slash parity
+# ---------------------------------------------------------------------------
+
+
+def _expected_parity_names() -> set[str]:
+    """Names that must exist on BOTH the prefix and slash surfaces."""
+    return {
+        "status",
+        "diagnostics",
+        "ask",
+        "tower",
+        "hero",
+        "round",
+        "test-intent",
+        "why-no-response",
+        "sources",
+        "strategies",
+        "pending",
+    }
+
+
+def test_btd6_prefix_and_slash_commands_have_parity():
+    cog = BTD6Cog(bot=type("Bot", (), {})())
+
+    prefix_names: set[str] = set()
+    for cmd in cog.walk_commands():
+        # Only consider commands inside the btd6 group.
+        if getattr(cmd, "parent", None) is not None and cmd.parent.name == "btd6":
+            prefix_names.add(cmd.name)
+
+    # The slash group lives on the cog as a class attribute.
+    slash_group = cog.btd6_app_group
+    slash_names = {c.name for c in slash_group.commands}
+
+    expected = _expected_parity_names()
+    missing_prefix = expected - prefix_names
+    missing_slash = expected - slash_names
+    assert not missing_prefix, f"Missing prefix commands: {missing_prefix}"
+    assert not missing_slash, f"Missing slash commands: {missing_slash}"
+
+
+# ---------------------------------------------------------------------------
+# Truthful copy
+# ---------------------------------------------------------------------------
+
+
+_STALE_STRINGS = (
+    "Module 4",
+    "deterministic-only",
+    "AI augmentation off",
+    "No provider, no network, no AI",
+)
+
+
+def test_status_embed_has_no_stale_strings():
+    embed = build_status_embed()
+    blob = (embed.title or "") + " " + (embed.description or "")
+    for stale in _STALE_STRINGS:
+        assert stale not in blob, f"Stale string {stale!r} in status embed"
+
+
+def test_panel_embed_has_no_stale_strings():
+    embed = build_btd6_panel_embed()
+    blob = (embed.title or "") + " " + (embed.description or "")
+    for stale in _STALE_STRINGS:
+        assert stale not in blob, f"Stale string {stale!r} in panel embed"
+
+
+# ---------------------------------------------------------------------------
+# Embed builders return valid embeds with the new audit fields
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_why_no_response_builder_surfaces_audit_fields(monkeypatch):
+    """The PR-A embed extension surfaces the five new audit fields:
+    ``policy_snapshot_hash``, ``instruction_profile_ids``, ``route``,
+    ``provider``, ``model`` — plus the existing reason_code.
+    """
+    from cogs.btd6._builders import build_why_no_response_payload
+    from services import ai_decision_audit_service
+
+    async def _query(_guild_id, **_kw):
+        return [
+            {
+                "task": "btd6.answer",
+                "decision": "denied",
+                "reason_code": "below_min_level",
+                "route": "btd6.answer",
+                "channel_id": 1,
+                "user_id": 9,
+                "policy_snapshot_hash": "deadbeef",
+                "instruction_profile_ids": [11, 22],
+                "provider": "anthropic",
+                "model": "claude-haiku",
+            },
+        ]
+
+    monkeypatch.setattr(ai_decision_audit_service, "query", _query)
+    payload = await build_why_no_response_payload(42, limit=5)
+    assert isinstance(payload, discord.Embed)
+    blob = "\n".join(f"{f.name}\n{f.value}" for f in payload.fields)
+    assert "below_min_level" in blob
+    assert "deadbeef" in blob
+    assert "11" in blob and "22" in blob
+    assert "anthropic" in blob
+    assert "claude-haiku" in blob

--- a/tests/unit/cogs/test_btd6_boundaries.py
+++ b/tests/unit/cogs/test_btd6_boundaries.py
@@ -138,6 +138,10 @@ def _expected_parity_names() -> set[str]:
         "sources",
         "strategies",
         "pending",
+        # PR-D additions:
+        "source-health",
+        "latest-data",
+        "grounding",
     }
 
 

--- a/tests/unit/cogs/test_btd6_cog.py
+++ b/tests/unit/cogs/test_btd6_cog.py
@@ -23,14 +23,14 @@ import pytest
 # Force the setup-sections package to import every section module so the
 # REGISTRY contains the production set during the test run.
 import views.setup.sections  # noqa: F401 — import side-effect
-from cogs.btd6_cog import (
-    BTD6Cog,
+from cogs.btd6._embeds import (
     build_diagnostics_embed,
     build_modes_embed,
     build_status_embed,
     build_test_intent_embed,
     build_towers_embed,
 )
+from cogs.btd6_cog import BTD6Cog
 from core.runtime.persistent_views import _REGISTRY as _PERSISTENT_VIEW_REGISTRY
 from services.setup_sections import REGISTRY as SETUP_REGISTRY
 from utils.subsystem_registry import SUBSYSTEMS

--- a/tests/unit/cogs/test_btd6_pr_d_builders.py
+++ b/tests/unit/cogs/test_btd6_pr_d_builders.py
@@ -1,0 +1,163 @@
+"""PR-D embed builder tests."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import discord
+import pytest
+
+from cogs.btd6._builders import (
+    build_grounding_embed,
+    build_latest_data_embed,
+    build_source_health_embed,
+)
+from services import btd6_source_registry as health_svc
+
+
+def _now():
+    return datetime.now(tz=timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_source_health_embed_renders_each_source(monkeypatch):
+    now = _now()
+
+    async def _fake(*, limit=25):
+        return [
+            health_svc.SourceHealth(
+                source_id=1,
+                source_key="nk_btd6_races",
+                source_name="Races",
+                trust_tier=1,
+                enabled=True,
+                source_kind="official_api",
+                last_fetched_at=now - timedelta(hours=1),
+                fact_count=12,
+                bucket="fresh",
+            ),
+            health_svc.SourceHealth(
+                source_id=2,
+                source_key="nk_btd6_bosses",
+                source_name="Bosses",
+                trust_tier=1,
+                enabled=False,
+                source_kind="official_api",
+                last_fetched_at=None,
+                fact_count=0,
+                bucket="never",
+            ),
+        ]
+
+    monkeypatch.setattr(health_svc, "list_health", _fake)
+
+    embed = await build_source_health_embed()
+    assert isinstance(embed, discord.Embed)
+    blob = "\n".join(f.name + " " + f.value for f in embed.fields)
+    assert "nk_btd6_races" in blob
+    assert "nk_btd6_bosses" in blob
+    assert "🟢 fresh" in blob
+    assert "⚪ never" in blob
+    assert "facts=12" in blob
+
+
+@pytest.mark.asyncio
+async def test_source_health_embed_handles_empty(monkeypatch):
+    async def _fake(*, limit=25):
+        return []
+
+    monkeypatch.setattr(health_svc, "list_health", _fake)
+
+    embed = await build_source_health_embed()
+    assert "No BTD6 sources" in (embed.description or "")
+
+
+@pytest.mark.asyncio
+async def test_latest_data_embed_groups_by_entity_kind(monkeypatch):
+    from utils.db import btd6_sources as btd6_db
+
+    now = _now()
+
+    async def _fake(*, limit=50, **_kw):
+        return [
+            {
+                "id": 1,
+                "source_id": 1,
+                "fact_type": "race_metadata",
+                "entity_kind": "race",
+                "entity_key": "Reversed_Loop",
+                "body_json": {},
+                "game_version": "44.0",
+                "fetched_at": now,
+                "validated_at": now,
+                "confidence": 1.0,
+                "version": 1,
+            },
+            {
+                "id": 2,
+                "source_id": 2,
+                "fact_type": "boss_metadata",
+                "entity_kind": "boss",
+                "entity_key": "Diamondback5",
+                "body_json": {},
+                "game_version": "44.0",
+                "fetched_at": now - timedelta(hours=2),
+                "validated_at": now,
+                "confidence": 1.0,
+                "version": 1,
+            },
+        ]
+
+    monkeypatch.setattr(btd6_db, "search_facts", _fake)
+
+    embed = await build_latest_data_embed()
+    names = {f.name for f in embed.fields}
+    assert "`race`" in names
+    assert "`boss`" in names
+
+
+@pytest.mark.asyncio
+async def test_grounding_embed_returns_string_when_no_match(monkeypatch):
+    from services import ai_decision_audit_service
+
+    async def _fake_q(_guild_id, **_kw):
+        return [{"message_id": 1, "decision": "allowed", "reason_code": "none"}]
+
+    monkeypatch.setattr(ai_decision_audit_service, "query", _fake_q)
+
+    out = await build_grounding_embed(guild_id=1, message_id=999)
+    assert isinstance(out, str)
+    assert "999" in out
+
+
+@pytest.mark.asyncio
+async def test_grounding_embed_renders_audit_fields(monkeypatch):
+    from services import ai_decision_audit_service
+
+    async def _fake_q(_guild_id, **_kw):
+        return [
+            {
+                "message_id": 42,
+                "decision": "replied",
+                "reason_code": "none",
+                "task": "btd6.answer",
+                "route": "btd6.answer",
+                "provider": "openai",
+                "model": "gpt-4",
+                "policy_snapshot_hash": "ff",
+                "instruction_profile_ids": [5, 6],
+            },
+        ]
+
+    monkeypatch.setattr(ai_decision_audit_service, "query", _fake_q)
+
+    embed = await build_grounding_embed(guild_id=1, message_id=42)
+    assert isinstance(embed, discord.Embed)
+    blob = (embed.description or "") + "\n".join(
+        f.name + " " + f.value for f in embed.fields
+    )
+    assert "replied" in blob
+    assert "openai" in blob
+    assert "gpt-4" in blob
+    assert "ff" in blob
+    assert "5" in blob and "6" in blob

--- a/tests/unit/cogs/test_btd6_why_no_response.py
+++ b/tests/unit/cogs/test_btd6_why_no_response.py
@@ -47,6 +47,10 @@ def _row(*, decision: str, task: str, reason: str = "below_min_level"):
         "reason_code": reason,
         "channel_id": 1,
         "user_id": 9,
+        "policy_snapshot_hash": "abc123",
+        "instruction_profile_ids": [101, 202],
+        "provider": "openai",
+        "model": "gpt-4",
     }
 
 
@@ -88,10 +92,17 @@ async def test_btd6_why_no_response_reads_audit_table(monkeypatch):
 
     assert captured == [{"guild_id": 42, "limit": 10}]
     ctx.send.assert_awaited_once()
-    msg = ctx.send.await_args.args[0]
-    assert "denied" in msg
-    assert "below_min_level" in msg
-    assert "no_route_matched" in msg
+    embed = ctx.send.await_args.kwargs.get("embed")
+    assert embed is not None
+    field_text = "\n".join(f"{f.name}\n{f.value}" for f in embed.fields)
+    assert "denied" in field_text
+    assert "below_min_level" in field_text
+    assert "no_route_matched" in field_text
+    # New PR-A fields surface the audit-quality diagnostics.
+    assert "abc123" in field_text  # policy_snapshot_hash
+    assert "101" in field_text and "202" in field_text  # profile ids
+    assert "openai" in field_text  # provider
+    assert "gpt-4" in field_text  # model
 
 
 @pytest.mark.asyncio
@@ -113,10 +124,12 @@ async def test_btd6_why_no_response_filters_to_btd6_task(monkeypatch):
     ctx = _ctx(guild_id=42)
     await cog.btd6_why_no_response.callback(cog, ctx)
 
-    msg = ctx.send.await_args.args[0]
-    assert "below_min_level" in msg
+    embed = ctx.send.await_args.kwargs.get("embed")
+    assert embed is not None
+    field_text = "\n".join(f"{f.name}\n{f.value}" for f in embed.fields)
+    assert "below_min_level" in field_text
     # The general.nl_answer denial must NOT bleed through.
-    assert "role_denied" not in msg
+    assert "role_denied" not in field_text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/db/test_migration_043_044_preset.py
+++ b/tests/unit/db/test_migration_043_044_preset.py
@@ -1,0 +1,69 @@
+"""PR-B migration shape pins for 043 (preset column) + 044 (seed).
+
+Cheap offline checks that catch the most common authoring mistakes
+before a deploy attempts the migration.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MIGRATIONS = _REPO_ROOT / "disbot" / "migrations"
+
+_M043 = _MIGRATIONS / "043_ai_instruction_profile_preset.sql"
+_M044 = _MIGRATIONS / "044_ai_instruction_profile_seed.sql"
+
+
+def test_043_file_present():
+    assert _M043.is_file(), "Migration 043 missing"
+
+
+def test_044_file_present():
+    assert _M044.is_file(), "Migration 044 missing"
+
+
+def test_043_adds_is_preset_column_idempotently():
+    src = _M043.read_text()
+    assert "ADD COLUMN IF NOT EXISTS is_preset" in src, (
+        "043 must add is_preset with IF NOT EXISTS for idempotency"
+    )
+    assert "BOOLEAN NOT NULL DEFAULT FALSE" in src
+    # Partial index for cheap WHERE is_preset = TRUE reads.
+    assert "CREATE INDEX IF NOT EXISTS" in src
+    assert "ai_instruction_profile" in src
+    assert "WHERE is_preset = TRUE" in src
+
+
+_EXPECTED_PRESETS = (
+    "disabled",
+    "mention_only_helper",
+    "helpful_channel",
+    "btd6_focused",
+    "quiet_btd6_focused",
+    "staff_diagnostics",
+    "support_triage",
+)
+
+
+def test_044_seeds_exactly_the_expected_presets():
+    src = _M044.read_text()
+    for name in _EXPECTED_PRESETS:
+        assert f"'{name}'" in src, f"044 missing preset {name!r}"
+
+
+def test_044_uses_on_conflict_for_idempotency():
+    src = _M044.read_text()
+    assert "ON CONFLICT (guild_id, scope, name) DO UPDATE" in src, (
+        "044 must be idempotent via ON CONFLICT … DO UPDATE"
+    )
+    # Never let an idempotent replay flip is_preset back to FALSE.
+    assert "is_preset  = TRUE" in src or "is_preset = TRUE" in src
+
+
+def test_044_seeds_are_system_scoped():
+    src = _M044.read_text()
+    # Every INSERT row has guild_id NULL + scope 'system' + is_preset TRUE.
+    assert "(NULL, 'disabled'," in src
+    assert "'system', NULL, TRUE" in src

--- a/tests/unit/services/test_ai_behavior_profile_service.py
+++ b/tests/unit/services/test_ai_behavior_profile_service.py
@@ -1,0 +1,300 @@
+"""Tests for the AI Behavior preset service (PR-B).
+
+Covers:
+
+* ``list_presets`` reads through ``ai_db.list_preset_profiles`` and
+  joins with the in-process catalog.
+* ``describe_preset`` rejects rows missing ``is_preset = True``.
+* ``apply_preset`` writes through ``ai_policy_mutation`` (never
+  directly to ``ai_db``) and selects the correct mutation function
+  per scope.
+* ``apply_preset`` refuses scopes outside ``{"channel", "category"}``.
+* The catalog keys are a stable subset of the seeded preset names.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from services import ai_behavior_profile_service as svc
+from utils.db import ai as ai_db
+
+
+def _preset_row(
+    preset_id: int,
+    name: str,
+    body: str = "preset body",
+    *,
+    is_preset: bool = True,
+):
+    return {
+        "id": preset_id,
+        "guild_id": None,
+        "name": name,
+        "body": body,
+        "scope": "system",
+        "feature_key": None,
+        "is_preset": is_preset,
+    }
+
+
+def _admin_actor(actor_id: int = 1234):
+    return SimpleNamespace(
+        id=actor_id,
+        guild_permissions=SimpleNamespace(administrator=True),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Catalog
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_keys_match_seed_migration():
+    """Migration 044 seeds these seven preset names. The Python
+    catalog must match — adding or removing a preset is a coordinated
+    change across both files.
+    """
+    expected = {
+        "disabled",
+        "mention_only_helper",
+        "helpful_channel",
+        "btd6_focused",
+        "quiet_btd6_focused",
+        "staff_diagnostics",
+        "support_triage",
+    }
+    assert svc.PRESET_KEYS == expected
+
+
+# ---------------------------------------------------------------------------
+# list_presets
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_presets_reads_through_ai_db(monkeypatch):
+    captured = []
+
+    async def _fake(*args, **kwargs):
+        captured.append((args, kwargs))
+        return [
+            _preset_row(11, "disabled"),
+            _preset_row(12, "helpful_channel"),
+        ]
+
+    monkeypatch.setattr(ai_db, "list_preset_profiles", _fake)
+
+    out = await svc.list_presets()
+
+    assert captured == [((), {})]
+    assert [p.preset_id for p in out] == [11, 12]
+    assert {p.key for p in out} == {"disabled", "helpful_channel"}
+    # Catalog metadata is joined in.
+    disabled = next(p for p in out if p.key == "disabled")
+    assert disabled.recommended_mode == "disabled"
+    helpful = next(p for p in out if p.key == "helpful_channel")
+    assert helpful.recommended_mode == "always_reply"
+
+
+@pytest.mark.asyncio
+async def test_list_presets_surfaces_uncatalogued_rows(monkeypatch):
+    """A DB row whose name is not in the catalog is still surfaced
+    with a fallback entry — the operator should not silently lose
+    seeded presets if the Python side falls out of sync.
+    """
+
+    async def _fake():
+        return [_preset_row(99, "experimental_new_preset", body="hi")]
+
+    monkeypatch.setattr(ai_db, "list_preset_profiles", _fake)
+
+    out = await svc.list_presets()
+    assert len(out) == 1
+    assert out[0].key == "experimental_new_preset"
+    assert "uncatalogued" in out[0].headline
+
+
+# ---------------------------------------------------------------------------
+# describe_preset
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_describe_preset_returns_summary_for_valid_id(monkeypatch):
+    async def _fake(pid):
+        return _preset_row(42, "btd6_focused", body="prioritise BTD6")
+
+    monkeypatch.setattr(ai_db, "get_instruction_profile", _fake)
+
+    summary = await svc.describe_preset(42)
+    assert summary is not None
+    assert summary.preset_id == 42
+    assert summary.key == "btd6_focused"
+    assert summary.recommended_mode == "always_reply"
+    assert summary.body == "prioritise BTD6"
+
+
+@pytest.mark.asyncio
+async def test_describe_preset_returns_none_when_not_a_preset(monkeypatch):
+    async def _fake(pid):
+        return _preset_row(7, "btd6_focused", is_preset=False)
+
+    monkeypatch.setattr(ai_db, "get_instruction_profile", _fake)
+
+    assert await svc.describe_preset(7) is None
+
+
+@pytest.mark.asyncio
+async def test_describe_preset_returns_none_when_row_missing(monkeypatch):
+    async def _fake(_pid):
+        return None
+
+    monkeypatch.setattr(ai_db, "get_instruction_profile", _fake)
+
+    assert await svc.describe_preset(999) is None
+
+
+# ---------------------------------------------------------------------------
+# apply_preset
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_preset_to_channel_calls_set_channel_policy(monkeypatch):
+    captured: dict = {}
+
+    async def _describe(_pid):
+        return svc.BehaviorPresetSummary(
+            preset_id=42,
+            key="btd6_focused",
+            headline="BTD6 grounding prioritised",
+            recommended_mode="always_reply",
+            body="...",
+        )
+
+    async def _set_channel_policy(guild_id, channel_id, **kwargs):
+        captured["table"] = "channel"
+        captured["guild_id"] = guild_id
+        captured["channel_id"] = channel_id
+        captured.update(kwargs)
+        return MagicMock(mutation_id="mid-123")
+
+    monkeypatch.setattr(svc, "describe_preset", _describe)
+    monkeypatch.setattr(
+        "services.ai_policy_mutation.set_channel_policy",
+        _set_channel_policy,
+    )
+
+    result = await svc.apply_preset(
+        guild_id=999,
+        scope="channel",
+        target_id=555,
+        preset_id=42,
+        actor=_admin_actor(),
+    )
+
+    assert captured["table"] == "channel"
+    assert captured["guild_id"] == 999
+    assert captured["channel_id"] == 555
+    assert captured["mode"] == "always_reply"
+    assert captured["instruction_profile_id"] == 42
+    assert result.preset_id == 42
+    assert result.preset_key == "btd6_focused"
+    assert result.scope == "channel"
+    assert result.policy_mutation_id == "mid-123"
+
+
+@pytest.mark.asyncio
+async def test_apply_preset_to_category_calls_set_category_policy(monkeypatch):
+    captured: dict = {}
+
+    async def _describe(_pid):
+        return svc.BehaviorPresetSummary(
+            preset_id=7,
+            key="mention_only_helper",
+            headline="Concise replies",
+            recommended_mode="mention_only",
+            body="...",
+        )
+
+    async def _set_category_policy(guild_id, category_id, **kwargs):
+        captured["table"] = "category"
+        captured["category_id"] = category_id
+        captured.update(kwargs)
+        return MagicMock(mutation_id="mid-cat")
+
+    monkeypatch.setattr(svc, "describe_preset", _describe)
+    monkeypatch.setattr(
+        "services.ai_policy_mutation.set_category_policy",
+        _set_category_policy,
+    )
+
+    result = await svc.apply_preset(
+        guild_id=10,
+        scope="category",
+        target_id=20,
+        preset_id=7,
+        actor=_admin_actor(),
+    )
+
+    assert captured["table"] == "category"
+    assert captured["category_id"] == 20
+    assert captured["mode"] == "mention_only"
+    assert captured["instruction_profile_id"] == 7
+    assert result.scope == "category"
+
+
+@pytest.mark.asyncio
+async def test_apply_preset_refuses_unsupported_scope():
+    with pytest.raises(svc.InvalidBehaviorPresetScopeError):
+        await svc.apply_preset(
+            guild_id=1,
+            scope="guild",  # not supported
+            target_id=1,
+            preset_id=1,
+            actor=_admin_actor(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_apply_preset_raises_when_preset_missing(monkeypatch):
+    async def _describe(_pid):
+        return None
+
+    monkeypatch.setattr(svc, "describe_preset", _describe)
+
+    with pytest.raises(svc.UnknownBehaviorPresetError):
+        await svc.apply_preset(
+            guild_id=1,
+            scope="channel",
+            target_id=1,
+            preset_id=9999,
+            actor=_admin_actor(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Boundary: service never touches ai_db.upsert_* helpers directly.
+# ---------------------------------------------------------------------------
+
+
+def test_service_does_not_import_ai_db_write_helpers():
+    """The service layer is read-only on ``ai_db``; writes flow
+    through ``ai_policy_mutation``.
+    """
+    import inspect
+
+    src = inspect.getsource(svc)
+    forbidden = (
+        "ai_db.upsert_channel_policy",
+        "ai_db.upsert_category_policy",
+        "ai_db.upsert_role_policy",
+        "ai_db.upsert_instruction_profile",
+        "ai_db.upsert_guild_policy",
+    )
+    for sym in forbidden:
+        assert sym not in src, f"behavior service must not call {sym}"

--- a/tests/unit/services/test_ai_instruction_mutation_preset_guard.py
+++ b/tests/unit/services/test_ai_instruction_mutation_preset_guard.py
@@ -1,0 +1,113 @@
+"""PR-B regression: ``upsert_profile`` refuses guild-scope preset writes.
+
+Migration 044 seeds preset rows with ``guild_id IS NULL``,
+``scope='system'``, ``is_preset=TRUE``. Guild operators must not be
+able to author rows with ``is_preset=True``; they must also not be
+able to overwrite a seeded preset row with ``is_preset=False`` via
+a same-name upsert at scope='system'.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from services import ai_instruction_mutation
+from utils.db import ai as ai_db
+
+
+def _admin(actor_id: int = 1, *, administrator: bool = True):
+    return SimpleNamespace(
+        id=actor_id,
+        guild_permissions=SimpleNamespace(administrator=administrator),
+    )
+
+
+@pytest.mark.asyncio
+async def test_guild_actor_cannot_create_preset(monkeypatch):
+    """Setting ``is_preset=True`` with a non-null ``guild_id`` is
+    forbidden — that path would let any guild admin fabricate fake
+    presets that the Behavior UI would surface to other guilds.
+    """
+    with pytest.raises(
+        ai_instruction_mutation.UnauthorizedAIInstructionMutationError,
+    ):
+        await ai_instruction_mutation.upsert_profile(
+            guild_id=42,
+            name="evil_preset",
+            body="impersonates a system preset",
+            scope="guild",
+            is_preset=True,
+            actor=_admin(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_system_upsert_cannot_downgrade_existing_preset(monkeypatch):
+    """A system-scope upsert with the same name as a seeded preset
+    but ``is_preset=False`` would silently downgrade it. Refuse so
+    the preset catalog stays trustworthy.
+    """
+
+    async def _fake_list(_guild_id, *, scope=None):
+        return [
+            {
+                "id": 5,
+                "guild_id": None,
+                "name": "helpful_channel",
+                "body": "...",
+                "scope": "system",
+                "feature_key": None,
+                "is_preset": True,
+            },
+        ]
+
+    monkeypatch.setattr(ai_db, "list_instruction_profiles", _fake_list)
+
+    with pytest.raises(
+        ai_instruction_mutation.UnauthorizedAIInstructionMutationError,
+    ):
+        await ai_instruction_mutation.upsert_profile(
+            guild_id=None,
+            name="helpful_channel",
+            body="downgraded body",
+            scope="system",
+            is_preset=False,
+            actor=_admin(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_normal_guild_profile_still_works(monkeypatch):
+    """The guard above must not break ordinary guild-scope profile
+    upserts that have ``is_preset=False``.
+    """
+    captured: dict = {}
+
+    async def _fake_upsert(**kwargs):
+        captured.update(kwargs)
+        return 999
+
+    async def _bump(_gid):
+        return 1
+
+    monkeypatch.setattr(ai_db, "upsert_instruction_profile", _fake_upsert)
+    monkeypatch.setattr(ai_db, "bump_generation", _bump)
+    monkeypatch.setattr(
+        "services.ai_natural_language_policy.invalidate",
+        lambda _gid: None,
+    )
+
+    result = await ai_instruction_mutation.upsert_profile(
+        guild_id=10,
+        name="custom",
+        body="guild-authored body",
+        scope="guild",
+        actor=_admin(),
+    )
+
+    assert captured["guild_id"] == 10
+    assert captured["name"] == "custom"
+    assert captured["is_preset"] is False
+    assert result.profile_id == 999

--- a/tests/unit/services/test_ai_policy_mutation_unchanged.py
+++ b/tests/unit/services/test_ai_policy_mutation_unchanged.py
@@ -1,0 +1,281 @@
+"""PR-C-pre tests for the UNCHANGED sentinel.
+
+Pin the contract:
+
+* ``UNCHANGED`` is the default for every optional column on
+  ``set_channel_policy / set_category_policy / set_role_policy``.
+* When passed, the mutation function forwards an ``unchanged_fields``
+  set to the matching ``ai_db.upsert_*`` helper, which omits those
+  fields from the ``EXCLUDED`` SET on conflict (preserve semantics).
+* Passing ``None`` explicitly still clears the column (set to NULL).
+* Passing a concrete value still sets the column.
+* The required ``mode`` (or ``decision``) field cannot be sentinel —
+  the row must always carry one.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from services import ai_policy_mutation
+from utils.db import ai as ai_db
+
+
+def _admin_actor(actor_id: int = 555):
+    return SimpleNamespace(
+        id=actor_id,
+        guild_permissions=SimpleNamespace(administrator=True),
+    )
+
+
+def _patch_db(monkeypatch):
+    captured: dict = {}
+
+    async def _upsert_channel(guild_id, channel_id, **kwargs):
+        captured.setdefault("channel", []).append(
+            {"guild_id": guild_id, "channel_id": channel_id, **kwargs},
+        )
+
+    async def _upsert_category(guild_id, category_id, **kwargs):
+        captured.setdefault("category", []).append(
+            {"guild_id": guild_id, "category_id": category_id, **kwargs},
+        )
+
+    async def _upsert_role(guild_id, role_id, **kwargs):
+        captured.setdefault("role", []).append(
+            {"guild_id": guild_id, "role_id": role_id, **kwargs},
+        )
+
+    async def _bump(_gid):
+        return 99
+
+    monkeypatch.setattr(ai_db, "upsert_channel_policy", _upsert_channel)
+    monkeypatch.setattr(ai_db, "upsert_category_policy", _upsert_category)
+    monkeypatch.setattr(ai_db, "upsert_role_policy", _upsert_role)
+    monkeypatch.setattr(ai_db, "bump_generation", _bump)
+    monkeypatch.setattr(
+        "services.ai_natural_language_policy.invalidate",
+        lambda _gid: None,
+    )
+    monkeypatch.setattr(
+        ai_policy_mutation,
+        "_emit",
+        AsyncMock(return_value=True),
+    )
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# Channel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_channel_default_unchanged_for_optional_fields(monkeypatch):
+    """Calling set_channel_policy with only mode preserves every other
+    optional column. This is the PR-C-pre default."""
+    captured = _patch_db(monkeypatch)
+
+    await ai_policy_mutation.set_channel_policy(
+        guild_id=1,
+        channel_id=2,
+        mode="always_reply",
+        actor=_admin_actor(),
+    )
+
+    [call] = captured["channel"]
+    assert call["unchanged_fields"] == {
+        "min_level",
+        "cooldown_seconds",
+        "instruction_profile_id",
+    }
+    # On the INSERT path the value is None (NULL); on conflict the SQL
+    # omits the column from EXCLUDED.
+    assert call["min_level"] is None
+    assert call["cooldown_seconds"] is None
+    assert call["instruction_profile_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_channel_explicit_none_still_clears(monkeypatch):
+    """Passing ``None`` explicitly must still clear the column."""
+    captured = _patch_db(monkeypatch)
+
+    await ai_policy_mutation.set_channel_policy(
+        guild_id=1,
+        channel_id=2,
+        mode="always_reply",
+        instruction_profile_id=None,
+        actor=_admin_actor(),
+    )
+
+    [call] = captured["channel"]
+    # instruction_profile_id is NOT in unchanged_fields → SET clause
+    # writes NULL → existing value is overwritten.
+    assert "instruction_profile_id" not in call["unchanged_fields"]
+    assert call["instruction_profile_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_channel_concrete_value_overwrites(monkeypatch):
+    captured = _patch_db(monkeypatch)
+
+    await ai_policy_mutation.set_channel_policy(
+        guild_id=1,
+        channel_id=2,
+        mode="mention_only",
+        min_level=5,
+        instruction_profile_id=42,
+        actor=_admin_actor(),
+    )
+
+    [call] = captured["channel"]
+    assert call["min_level"] == 5
+    assert call["instruction_profile_id"] == 42
+    # cooldown_seconds left at default UNCHANGED.
+    assert call["unchanged_fields"] == {"cooldown_seconds"}
+
+
+@pytest.mark.asyncio
+async def test_channel_mode_required(monkeypatch):
+    _patch_db(monkeypatch)
+
+    with pytest.raises(ai_policy_mutation.InvalidAIPolicyValueError, match="mode"):
+        await ai_policy_mutation.set_channel_policy(
+            guild_id=1,
+            channel_id=2,
+            actor=_admin_actor(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Category
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_category_default_unchanged_for_optional_fields(monkeypatch):
+    captured = _patch_db(monkeypatch)
+
+    await ai_policy_mutation.set_category_policy(
+        guild_id=10,
+        category_id=20,
+        mode="mention_only",
+        actor=_admin_actor(),
+    )
+
+    [call] = captured["category"]
+    assert call["unchanged_fields"] == {
+        "min_level",
+        "cooldown_seconds",
+        "instruction_profile_id",
+    }
+
+
+@pytest.mark.asyncio
+async def test_category_partial_edit_preserves_profile(monkeypatch):
+    """The regression scenario that motivated PR-C-pre: an operator
+    edits min_level via the modal; instruction_profile_id stays
+    untouched.
+    """
+    captured = _patch_db(monkeypatch)
+
+    await ai_policy_mutation.set_category_policy(
+        guild_id=10,
+        category_id=20,
+        mode="always_reply",
+        min_level=3,
+        cooldown_seconds=60,
+        instruction_profile_id=ai_policy_mutation.UNCHANGED,
+        actor=_admin_actor(),
+    )
+
+    [call] = captured["category"]
+    assert call["min_level"] == 3
+    assert call["cooldown_seconds"] == 60
+    assert call["unchanged_fields"] == {"instruction_profile_id"}
+
+
+# ---------------------------------------------------------------------------
+# Role
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_role_default_unchanged_for_optional_fields(monkeypatch):
+    captured = _patch_db(monkeypatch)
+
+    await ai_policy_mutation.set_role_policy(
+        guild_id=1,
+        role_id=2,
+        decision="allow",
+        actor=_admin_actor(),
+    )
+
+    [call] = captured["role"]
+    assert call["unchanged_fields"] == {"min_level_override", "bypass_cooldown"}
+
+
+@pytest.mark.asyncio
+async def test_role_concrete_values_overwrite(monkeypatch):
+    captured = _patch_db(monkeypatch)
+
+    await ai_policy_mutation.set_role_policy(
+        guild_id=1,
+        role_id=2,
+        decision="deny",
+        min_level_override=7,
+        bypass_cooldown=True,
+        actor=_admin_actor(),
+    )
+
+    [call] = captured["role"]
+    assert call["min_level_override"] == 7
+    assert call["bypass_cooldown"] is True
+    assert call["unchanged_fields"] == set()
+
+
+# ---------------------------------------------------------------------------
+# DB-layer SQL shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_db_upsert_channel_omits_unchanged_from_excluded(monkeypatch):
+    """The DB layer must drop UNCHANGED columns from the EXCLUDED
+    SET on conflict — that's the actual mechanism that preserves
+    the existing value.
+    """
+    captured: dict = {}
+
+    class _FakeConn:
+        async def execute(self, sql, *args):
+            captured["sql"] = sql
+            captured["args"] = args
+
+    monkeypatch.setattr("utils.db.ai.pool.get", lambda: _FakeConn())
+
+    await ai_db.upsert_channel_policy(
+        1,
+        2,
+        mode="always_reply",
+        min_level=None,
+        cooldown_seconds=None,
+        instruction_profile_id=None,
+        updated_by=99,
+        unchanged_fields={"instruction_profile_id"},
+    )
+
+    sql = captured["sql"]
+    # instruction_profile_id NOT in the EXCLUDED list.
+    assert "instruction_profile_id = EXCLUDED.instruction_profile_id" not in sql
+    # The non-sentinel columns ARE in the EXCLUDED list.
+    assert "mode = EXCLUDED.mode" in sql
+    assert "min_level = EXCLUDED.min_level" in sql
+    assert "cooldown_seconds = EXCLUDED.cooldown_seconds" in sql
+    # Updated_at + updated_by always written.
+    assert "updated_at = NOW()" in sql
+    assert "updated_by = EXCLUDED.updated_by" in sql

--- a/tests/unit/services/test_btd6_context_grounding.py
+++ b/tests/unit/services/test_btd6_context_grounding.py
@@ -104,12 +104,15 @@ def test_sanitise_returns_empty_for_non_string():
 
 
 def test_relative_time_buckets_into_s_m_h_d():
+    from datetime import timedelta
+
     now = datetime.now(timezone.utc)
     rel = btd6_context_service._relative_time
     assert rel(now) in ("just now", "0s ago")
-    assert "m ago" in rel(now.replace(minute=(now.minute - 5) % 60))
-    # Build absolute timestamps by subtracting timedeltas.
-    from datetime import timedelta
+    # Use timedelta math so the test is wall-clock-independent —
+    # the prior ``minute - 5`` arithmetic broke whenever the current
+    # minute was < 5 and rolled into the future.
+    assert "m ago" in rel(now - timedelta(minutes=5))
     assert "h ago" in rel(now - timedelta(hours=3))
     assert "d ago" in rel(now - timedelta(days=2))
 

--- a/tests/unit/services/test_btd6_context_live_entities.py
+++ b/tests/unit/services/test_btd6_context_live_entities.py
@@ -1,0 +1,102 @@
+"""PR-E tests for context-service live-entity grounding."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_live_entity_lookup_populates_facts(monkeypatch):
+    """A race question should land race facts in the context bundle."""
+    from services import btd6_context_service
+    from utils.db import btd6_sources as btd6_db
+
+    async def _fake_search(*, entity_kind=None, fact_type=None, limit=50):
+        if entity_kind == "btd6_race":
+            return [
+                {
+                    "id": 7,
+                    "fact_type": "race_metadata",
+                    "entity_kind": "btd6_race",
+                    "entity_key": "Reversed_Loop_mpbd7tcu",
+                    "body_json": {"name": "Reversed Loop", "type": "race"},
+                    "game_version": "44.0",
+                    "fetched_at": datetime.now(tz=timezone.utc),
+                    "validated_at": None,
+                    "confidence": 1.0,
+                    "version": 1,
+                    "source_name": "Ninja Kiwi /races",
+                },
+            ]
+        return []
+
+    monkeypatch.setattr(btd6_db, "search_facts", _fake_search)
+
+    ctx = await btd6_context_service.build("what is the current race?")
+    assert ctx.facts, "expected at least one fact for the race intent"
+    assert any("Reversed Loop" in f for f in ctx.facts)
+
+
+@pytest.mark.asyncio
+async def test_live_entity_lookup_caps_per_kind(monkeypatch):
+    """One noisy kind cannot drown out others — per_kind_limit caps."""
+    from services import btd6_context_service
+    from utils.db import btd6_sources as btd6_db
+
+    captured = []
+
+    async def _fake_search(*, entity_kind=None, fact_type=None, limit=50):
+        captured.append({"entity_kind": entity_kind, "limit": limit})
+        return []
+
+    monkeypatch.setattr(btd6_db, "search_facts", _fake_search)
+
+    class _Intent:
+        confidence = 0.5
+
+        class _Match:
+            def __init__(self, k):
+                self.entity_kind = k
+                self.matched_term = k
+
+        live_entities = (_Match("btd6_race"), _Match("btd6_boss"))
+        towers = ()
+        heroes = ()
+        maps = ()
+        modes = ()
+        rounds = ()
+        ambiguous_terms = ()
+        candidate_round_numbers = ()
+
+    rows = await btd6_context_service._fetch_live_entity_rows(_Intent())
+    assert rows == []
+    assert {c["entity_kind"] for c in captured} == {"btd6_race", "btd6_boss"}
+    # Each call respects the per-kind cap.
+    for call in captured:
+        assert call["limit"] == 3
+
+
+@pytest.mark.asyncio
+async def test_no_live_entities_skips_lookup(monkeypatch):
+    """When the resolver yields no live entities, we never call
+    search_facts."""
+    from services import btd6_context_service
+    from utils.db import btd6_sources as btd6_db
+
+    called = False
+
+    async def _fake_search(**_kw):
+        nonlocal called
+        called = True
+        return []
+
+    monkeypatch.setattr(btd6_db, "search_facts", _fake_search)
+
+    class _Intent:
+        live_entities = ()
+
+    rows = await btd6_context_service._fetch_live_entity_rows(_Intent())
+    assert rows == []
+    assert called is False

--- a/tests/unit/services/test_btd6_resolver_vocabulary.py
+++ b/tests/unit/services/test_btd6_resolver_vocabulary.py
@@ -1,0 +1,93 @@
+"""PR-E tests for the BTD6 live-entity vocabulary registry."""
+
+from __future__ import annotations
+
+from services.btd6_resolver_vocabulary import (
+    known_entity_kinds,
+    resolve_live_entities,
+)
+
+
+def test_known_entity_kinds_covers_each_live_kind():
+    kinds = known_entity_kinds()
+    expected = {
+        "btd6_race",
+        "btd6_boss",
+        "btd6_ct",
+        "btd6_odyssey",
+        "btd6_challenge",
+        "btd6_event",
+        "btd6_race_leaderboard_row",
+    }
+    assert expected <= kinds
+
+
+def test_recognises_race():
+    matches, _ambig = resolve_live_entities("what's the current race today?")
+    kinds = {m.entity_kind for m in matches}
+    assert "btd6_race" in kinds
+
+
+def test_recognises_boss_by_name():
+    matches, _ambig = resolve_live_entities(
+        "what is the diamondback strategy?",
+    )
+    kinds = {m.entity_kind for m in matches}
+    assert "btd6_boss" in kinds
+
+
+def test_recognises_ct_word_boundary():
+    matches, _ambig = resolve_live_entities("explain ct tiles")
+    kinds = {m.entity_kind for m in matches}
+    assert "btd6_ct" in kinds
+
+
+def test_recognises_odyssey():
+    matches, _ambig = resolve_live_entities("can you do the easy odyssey?")
+    kinds = {m.entity_kind for m in matches}
+    assert "btd6_odyssey" in kinds
+
+
+def test_recognises_challenge():
+    matches, _ambig = resolve_live_entities("how do I beat the daily challenge?")
+    kinds = {m.entity_kind for m in matches}
+    assert "btd6_challenge" in kinds
+
+
+def test_recognises_event():
+    matches, _ambig = resolve_live_entities("are there any live events?")
+    kinds = {m.entity_kind for m in matches}
+    assert "btd6_event" in kinds
+
+
+def test_recognises_leaderboard():
+    matches, _ambig = resolve_live_entities("show me the race leaderboard")
+    kinds = {m.entity_kind for m in matches}
+    assert "btd6_race_leaderboard_row" in kinds
+
+
+def test_ambiguous_current_alone_flagged():
+    """The bare word "current" could mean current race / boss / CT /
+    odyssey / event / challenge — refuse and let the caller emit
+    ambiguous_term audit."""
+    _matches, ambiguous = resolve_live_entities("what's current?")
+    assert "current" in ambiguous
+
+
+def test_empty_text_returns_empty():
+    matches, ambig = resolve_live_entities("")
+    assert matches == []
+    assert ambig == []
+
+
+def test_no_match_returns_empty():
+    matches, ambig = resolve_live_entities("hello world")
+    assert matches == []
+    assert ambig == []
+
+
+def test_dedupes_repeated_terms():
+    matches, _ambig = resolve_live_entities("race race race")
+    # The "race" surface term should only produce one match.
+    by_kind = [m for m in matches if m.entity_kind == "btd6_race"]
+    assert len(by_kind) == 1

--- a/tests/unit/services/test_btd6_source_health.py
+++ b/tests/unit/services/test_btd6_source_health.py
@@ -1,0 +1,144 @@
+"""PR-D tests for source health bucketing + bounded listing."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from services import btd6_source_registry as svc
+from utils.db import btd6_sources as btd6_db
+
+
+def _row(
+    *,
+    sid: int = 1,
+    key: str = "nk_btd6_races",
+    name: str = "Races",
+    tier: int = 1,
+    enabled: bool = True,
+    kind: str = "official_api",
+    fetched_at=None,
+    fact_count: int = 0,
+):
+    return {
+        "id": sid,
+        "source_key": key,
+        "source_name": name,
+        "source_owner": "Ninja Kiwi",
+        "source_kind": kind,
+        "trust_tier": tier,
+        "base_url": "https://api",
+        "path_template": "/btd6/races",
+        "full_url": None,
+        "enabled": enabled,
+        "notes": "",
+        "last_fetched_at": fetched_at,
+        "fact_count": fact_count,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Bucketing
+# ---------------------------------------------------------------------------
+
+
+def test_bucket_never_when_never_fetched():
+    assert svc._bucket_for(None) == "never"
+
+
+def test_bucket_fresh_for_recent_fetch():
+    now = datetime.now(tz=timezone.utc)
+    assert svc._bucket_for(now - timedelta(minutes=30)) == "fresh"
+
+
+def test_bucket_aging_for_yesterday():
+    now = datetime.now(tz=timezone.utc)
+    assert svc._bucket_for(now - timedelta(days=1)) == "aging"
+
+
+def test_bucket_stale_for_old_data():
+    now = datetime.now(tz=timezone.utc)
+    assert svc._bucket_for(now - timedelta(days=7)) == "stale"
+
+
+def test_bucket_accepts_naive_datetime():
+    """The DB column is TIMESTAMPTZ but asyncpg may return naive
+    datetimes in some envs; the bucketer must treat them as UTC.
+    """
+    naive = datetime.now() - timedelta(hours=1)
+    assert svc._bucket_for(naive) in {"fresh", "aging"}
+
+
+# ---------------------------------------------------------------------------
+# list_health
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_health_uses_bounded_db_helper(monkeypatch):
+    captured = {}
+
+    async def _fake(*, enabled, limit, offset):
+        captured["enabled"] = enabled
+        captured["limit"] = limit
+        captured["offset"] = offset
+        now = datetime.now(tz=timezone.utc)
+        return [
+            _row(sid=1, key="nk_btd6_races", fetched_at=now, fact_count=10),
+            _row(sid=2, key="nk_btd6_bosses", fetched_at=None, fact_count=0),
+        ]
+
+    monkeypatch.setattr(btd6_db, "list_sources_with_freshness", _fake)
+
+    health = await svc.list_health(limit=25)
+    assert captured == {"enabled": None, "limit": 25, "offset": 0}
+    assert {h.source_key for h in health} == {"nk_btd6_races", "nk_btd6_bosses"}
+    races = next(h for h in health if h.source_key == "nk_btd6_races")
+    assert races.bucket == "fresh"
+    assert races.fact_count == 10
+    bosses = next(h for h in health if h.source_key == "nk_btd6_bosses")
+    assert bosses.bucket == "never"
+    assert bosses.fact_count == 0
+
+
+# ---------------------------------------------------------------------------
+# list_sources bound enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_sources_caps_huge_limit(monkeypatch):
+    captured = []
+
+    class _FakeConn:
+        async def fetch(self, sql, *args):
+            captured.append({"sql": sql, "args": args})
+            return []
+
+    monkeypatch.setattr("utils.db.btd6_sources.pool.get", lambda: _FakeConn())
+
+    await btd6_db.list_sources(limit=999_999)
+
+    # Caller asked for 999_999 — the helper must have clamped to
+    # the hard cap before binding.
+    args = captured[0]["args"]
+    assert args[0] == btd6_db._LIST_SOURCES_MAX_LIMIT
+    sql = captured[0]["sql"]
+    assert "LIMIT" in sql
+    assert "OFFSET" in sql
+
+
+@pytest.mark.asyncio
+async def test_list_sources_min_limit_one(monkeypatch):
+    captured = []
+
+    class _FakeConn:
+        async def fetch(self, sql, *args):
+            captured.append({"args": args})
+            return []
+
+    monkeypatch.setattr("utils.db.btd6_sources.pool.get", lambda: _FakeConn())
+
+    await btd6_db.list_sources(limit=0)
+    assert captured[0]["args"][0] == 1

--- a/tests/unit/services/test_btd6_source_registry.py
+++ b/tests/unit/services/test_btd6_source_registry.py
@@ -44,13 +44,13 @@ def _stub_db(monkeypatch):
         ],
     }
 
-    async def _list(*, trust_tier=None, enabled=None):
+    async def _list(*, trust_tier=None, enabled=None, limit=100, offset=0):
         out = list(state["rows"])
         if trust_tier is not None:
             out = [r for r in out if r["trust_tier"] == trust_tier]
         if enabled is not None:
             out = [r for r in out if r["enabled"] == enabled]
-        return out
+        return out[offset : offset + limit]
 
     async def _by_key(key):
         return next((r for r in state["rows"] if r["source_key"] == key), None)

--- a/tests/unit/views/ai/behavior/test_behavior_chooser.py
+++ b/tests/unit/views/ai/behavior/test_behavior_chooser.py
@@ -19,7 +19,6 @@ import pytest
 
 from views.ai.behavior import BehaviorChooserView, build_behavior_embed
 
-
 _BEHAVIOR_DIR = (
     Path(__file__).resolve().parents[4] / "disbot" / "views" / "ai" / "behavior"
 )

--- a/tests/unit/views/ai/behavior/test_behavior_chooser.py
+++ b/tests/unit/views/ai/behavior/test_behavior_chooser.py
@@ -1,0 +1,152 @@
+"""PR-C tests for the Behavior chooser entry view.
+
+Pin:
+
+* The intro embed lists scope / preview / advanced affordances.
+* Admin-only gate is enforced on the View.
+* The Preview button reuses ``views.ai.policy.preview_view.PreviewChannelSelectView``
+  (we never re-implement the dry-run flow).
+* The Advanced button reuses ``views.ai.policy.chooser.PolicyChooserView``.
+* No view in the package imports ``utils.db.ai`` directly.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from views.ai.behavior import BehaviorChooserView, build_behavior_embed
+
+
+_BEHAVIOR_DIR = (
+    Path(__file__).resolve().parents[4] / "disbot" / "views" / "ai" / "behavior"
+)
+
+
+def test_behavior_embed_lists_workflow_affordances():
+    embed = build_behavior_embed()
+    names = {f.name for f in embed.fields}
+    assert {"Channel", "Category"} <= names
+    assert any("Preview" in n for n in names)
+    assert any("Advanced" in n for n in names)
+
+
+def test_chooser_view_has_expected_buttons():
+    view = BehaviorChooserView()
+    labels = {c.label for c in view.children if hasattr(c, "label")}
+    assert {"Channel", "Category"} <= labels
+    assert any(label and "Preview" in label for label in labels)
+    assert "Advanced" in labels
+
+
+@pytest.mark.asyncio
+async def test_admin_gate_rejects_non_admin():
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    view = BehaviorChooserView()
+    interaction = MagicMock()
+    interaction.user = SimpleNamespace(
+        guild_permissions=SimpleNamespace(administrator=False),
+    )
+    interaction.response.send_message = AsyncMock()
+    ok = await view.interaction_check(interaction)
+    assert ok is False
+    interaction.response.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_preview_button_reuses_preview_channel_select_view(monkeypatch):
+    """The Preview button must reuse the PR4B view, never reimplement
+    the dry-run flow.
+    """
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    captured: dict = {}
+
+    interaction = MagicMock()
+    interaction.user = SimpleNamespace(
+        guild_permissions=SimpleNamespace(administrator=True),
+    )
+
+    async def _send_message(*args, **kwargs):
+        captured.update(kwargs)
+        if args:
+            captured["content"] = args[0]
+
+    interaction.response.send_message = AsyncMock(side_effect=_send_message)
+
+    view = BehaviorChooserView()
+    # Find the preview button by label.
+    preview = next(
+        c
+        for c in view.children
+        if hasattr(c, "label") and c.label and "Preview" in c.label
+    )
+    await preview.callback(interaction)
+
+    from views.ai.policy.preview_view import PreviewChannelSelectView
+
+    assert isinstance(captured["view"], PreviewChannelSelectView)
+
+
+@pytest.mark.asyncio
+async def test_advanced_button_reuses_policy_chooser(monkeypatch):
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    captured: dict = {}
+
+    interaction = MagicMock()
+    interaction.user = SimpleNamespace(
+        guild_permissions=SimpleNamespace(administrator=True),
+    )
+
+    async def _send_message(*args, **kwargs):
+        captured.update(kwargs)
+        if args:
+            captured["content"] = args[0]
+
+    interaction.response.send_message = AsyncMock(side_effect=_send_message)
+
+    view = BehaviorChooserView()
+    advanced = next(
+        c for c in view.children if hasattr(c, "label") and c.label == "Advanced"
+    )
+    await advanced.callback(interaction)
+
+    from views.ai.policy.chooser import PolicyChooserView
+
+    assert isinstance(captured["view"], PolicyChooserView)
+
+
+def test_no_behavior_view_imports_ai_db_directly():
+    """Behavior UI must route every mutation through the chokepoints —
+    no direct calls to utils.db.ai write helpers.
+    """
+    forbidden = (
+        "ai_db.upsert_channel_policy",
+        "ai_db.upsert_category_policy",
+        "ai_db.upsert_role_policy",
+        "ai_db.upsert_instruction_profile",
+    )
+    for path in _BEHAVIOR_DIR.rglob("*.py"):
+        src = path.read_text()
+        for sym in forbidden:
+            assert sym not in src, (
+                f"{path.name} must not call {sym} directly"
+            )
+        # Also catch ``from utils.db import ai`` followed by a write.
+        if "from utils.db" in src or "import utils.db" in src:
+            for sym in (
+                "upsert_channel_policy",
+                "upsert_category_policy",
+                "upsert_role_policy",
+                "upsert_instruction_profile",
+            ):
+                assert sym not in src, (
+                    f"{path.name} imports utils.db and references {sym}"
+                )

--- a/tests/unit/views/ai/behavior/test_preset_picker.py
+++ b/tests/unit/views/ai/behavior/test_preset_picker.py
@@ -1,0 +1,138 @@
+"""PR-C tests for the preset picker flow.
+
+Pin:
+
+* ``build_preset_picker_embed`` lists every available preset.
+* The picker's select callback calls
+  ``ai_behavior_profile_service.apply_preset`` with the right
+  ``scope``, ``target_id``, ``preset_id`` — never ``ai_db.*``.
+* Apply errors surface to the operator.
+* Unknown preset key returns an error without writing.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from services import ai_behavior_profile_service as svc
+from views.ai.behavior.preset_picker import (
+    PresetPickerView,
+    build_preset_picker_embed,
+)
+
+
+def _summary(preset_id: int, key: str) -> svc.BehaviorPresetSummary:
+    return svc.BehaviorPresetSummary(
+        preset_id=preset_id,
+        key=key,
+        headline=f"headline for {key}",
+        recommended_mode="mention_only",
+        body=f"body of {key}",
+    )
+
+
+def _admin_interaction(guild_id: int = 999):
+    interaction = MagicMock()
+    interaction.user = SimpleNamespace(
+        id=1,
+        guild_permissions=SimpleNamespace(administrator=True),
+    )
+    interaction.guild = SimpleNamespace(id=guild_id)
+    interaction.response.send_message = AsyncMock()
+    return interaction
+
+
+@pytest.mark.asyncio
+async def test_picker_embed_lists_each_preset(monkeypatch):
+    async def _fake():
+        return [
+            _summary(1, "disabled"),
+            _summary(2, "helpful_channel"),
+            _summary(3, "btd6_focused"),
+        ]
+
+    monkeypatch.setattr(svc, "list_presets", _fake)
+
+    embed = await build_preset_picker_embed(scope_label="channel #x")
+    blob = "\n".join(f.name + " " + f.value for f in embed.fields)
+    for key in ("disabled", "helpful_channel", "btd6_focused"):
+        assert key in blob
+
+
+@pytest.mark.asyncio
+async def test_view_loads_options_and_applies_preset(monkeypatch):
+    async def _fake_list():
+        return [_summary(7, "helpful_channel"), _summary(8, "btd6_focused")]
+
+    captured: dict = {}
+
+    async def _fake_apply(**kwargs):
+        captured.update(kwargs)
+        return svc.BehaviorApplyResult(
+            scope=kwargs["scope"],
+            target_id=kwargs["target_id"],
+            preset_id=kwargs["preset_id"],
+            preset_key="btd6_focused",
+            recommended_mode="always_reply",
+            policy_mutation_id="mid-abc",
+        )
+
+    monkeypatch.setattr(svc, "list_presets", _fake_list)
+    monkeypatch.setattr(svc, "apply_preset", _fake_apply)
+
+    view = PresetPickerView(
+        scope="channel",
+        target_id=555,
+        target_label="<#555>",
+    )
+    interaction = _admin_interaction(guild_id=999)
+    # Trigger interaction_check → _load_options.
+    await view.interaction_check(interaction)
+
+    # The dropdown should now be a child of the view.
+    select = next(c for c in view.children if hasattr(c, "options"))
+    assert {o.value for o in select.options} == {
+        "helpful_channel",
+        "btd6_focused",
+    }
+
+    # Simulate operator picking btd6_focused.
+    select._values = ["btd6_focused"]  # bypass ContextVar lookup in tests
+    apply_interaction = _admin_interaction(guild_id=999)
+    await select.callback(apply_interaction)
+
+    assert captured["guild_id"] == 999
+    assert captured["scope"] == "channel"
+    assert captured["target_id"] == 555
+    assert captured["preset_id"] == 8  # btd6_focused's id from _fake_list
+    apply_interaction.response.send_message.assert_awaited_once()
+    msg = apply_interaction.response.send_message.await_args.args[0]
+    assert "btd6_focused" in msg
+    assert "always_reply" in msg
+    assert "mid-abc" in msg
+
+
+@pytest.mark.asyncio
+async def test_apply_error_surfaces_to_operator(monkeypatch):
+    async def _fake_list():
+        return [_summary(7, "helpful_channel")]
+
+    async def _fake_apply(**_kw):
+        raise svc.UnknownBehaviorPresetError("gone")
+
+    monkeypatch.setattr(svc, "list_presets", _fake_list)
+    monkeypatch.setattr(svc, "apply_preset", _fake_apply)
+
+    view = PresetPickerView(scope="channel", target_id=1, target_label="x")
+    interaction = _admin_interaction()
+    await view.interaction_check(interaction)
+    select = next(c for c in view.children if hasattr(c, "options"))
+    select._values = ["helpful_channel"]  # bypass ContextVar lookup in tests
+    apply_interaction = _admin_interaction()
+    await select.callback(apply_interaction)
+
+    msg = apply_interaction.response.send_message.await_args.args[0]
+    assert "UnknownBehaviorPresetError" in msg

--- a/tests/unit/views/ai/test_policy_category_view.py
+++ b/tests/unit/views/ai/test_policy_category_view.py
@@ -77,7 +77,11 @@ async def test_submit_writes_through_set_category_policy(monkeypatch):
     assert captured["mode"] == "mention_only"
     assert captured["min_level"] == 2
     assert captured["cooldown_seconds"] == 120
-    assert captured["instruction_profile_id"] is None
+    # PR-C-pre: modal preserves any existing profile binding via
+    # UNCHANGED sentinel.
+    from services.ai_policy_mutation import UNCHANGED
+
+    assert captured["instruction_profile_id"] is UNCHANGED
     args, kwargs = interaction.response.send_message.call_args
     assert "✅" in args[0]
     assert "category **quiet**" in args[0]

--- a/tests/unit/views/ai/test_policy_channel_view.py
+++ b/tests/unit/views/ai/test_policy_channel_view.py
@@ -106,9 +106,12 @@ async def test_submit_writes_through_set_channel_policy(monkeypatch):
     assert captured["mode"] == "always_reply"
     assert captured["min_level"] == 3
     assert captured["cooldown_seconds"] == 60
-    # PR4A scope: instruction_profile_id always None — profile UI is
-    # a separate surface.
-    assert captured["instruction_profile_id"] is None
+    # PR-C-pre: the modal now passes the UNCHANGED sentinel for
+    # instruction_profile_id so partial edits do not silently clear
+    # an existing profile binding.
+    from services.ai_policy_mutation import UNCHANGED
+
+    assert captured["instruction_profile_id"] is UNCHANGED
     interaction.response.send_message.assert_awaited_once()
     args, kwargs = interaction.response.send_message.call_args
     assert "✅" in args[0]

--- a/tests/unit/views/ai/test_routing_matrix.py
+++ b/tests/unit/views/ai/test_routing_matrix.py
@@ -1,0 +1,143 @@
+"""PR-G tests for the operator routing matrix.
+
+Pin:
+
+* The matrix renders the dry-run resolver outcome (allowed / denied,
+  effective min_level, effective cooldown, profile labels,
+  precedence trace).
+* The view never mutates — calls only ``ai_natural_language_policy.resolve``.
+* Admin-only gate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from core.runtime.ai.contracts import PolicyDenialReason
+from views.ai.routing import RoutingMatrixSelectView, build_routing_matrix_embed
+
+
+@dataclass
+class _FakeDecision:
+    allowed: bool
+    reason_code: PolicyDenialReason
+    effective_min_level: int
+    effective_cooldown: int
+    instruction_profile_ids: tuple
+    policy_snapshot_hash: str
+    precedence_trace: tuple
+
+
+@pytest.mark.asyncio
+async def test_matrix_renders_allowed(monkeypatch):
+    from services import ai_natural_language_policy as nlp
+
+    async def _resolve(ctx, *, dry_run):
+        assert dry_run is True
+        return _FakeDecision(
+            allowed=True,
+            reason_code=PolicyDenialReason.NONE,
+            effective_min_level=3,
+            effective_cooldown=15,
+            instruction_profile_ids=(42,),
+            policy_snapshot_hash="abc",
+            precedence_trace=(
+                "guild: baseline min_level=2 cooldown=30s",
+                "channel: override min_level=3",
+            ),
+        )
+
+    async def _list_presets():
+        from services.ai_behavior_profile_service import BehaviorPresetSummary
+
+        return [
+            BehaviorPresetSummary(
+                preset_id=42,
+                key="btd6_focused",
+                headline="x",
+                recommended_mode="always_reply",
+                body="",
+            ),
+        ]
+
+    monkeypatch.setattr(nlp, "resolve", _resolve)
+    monkeypatch.setattr(
+        "services.ai_behavior_profile_service.list_presets",
+        _list_presets,
+    )
+
+    embed = await build_routing_matrix_embed(
+        guild_id=1,
+        channel_id=2,
+        user_id=3,
+    )
+    assert isinstance(embed, discord.Embed)
+    blob = (
+        (embed.description or "")
+        + " "
+        + "\n".join(f.name + " " + f.value for f in embed.fields)
+    )
+    assert "allowed" in blob
+    assert "min_level" in blob
+    assert "3" in blob  # effective min_level
+    assert "btd6_focused" in blob
+    assert "channel: override" in blob
+
+
+@pytest.mark.asyncio
+async def test_matrix_renders_denied(monkeypatch):
+    from services import ai_natural_language_policy as nlp
+
+    async def _resolve(_ctx, *, dry_run):
+        return _FakeDecision(
+            allowed=False,
+            reason_code=PolicyDenialReason.BELOW_MIN_LEVEL,
+            effective_min_level=5,
+            effective_cooldown=60,
+            instruction_profile_ids=(),
+            policy_snapshot_hash="def",
+            precedence_trace=("guild: baseline ...",),
+        )
+
+    async def _list_presets():
+        return []
+
+    monkeypatch.setattr(nlp, "resolve", _resolve)
+    monkeypatch.setattr(
+        "services.ai_behavior_profile_service.list_presets",
+        _list_presets,
+    )
+
+    embed = await build_routing_matrix_embed(
+        guild_id=1,
+        channel_id=2,
+        user_id=3,
+        user_level=1,
+    )
+    field_text = "\n".join(f.value for f in embed.fields)
+    assert "denied" in field_text
+    assert "below_min_level" in field_text
+
+
+@pytest.mark.asyncio
+async def test_matrix_view_admin_gate():
+    view = RoutingMatrixSelectView()
+    interaction = MagicMock()
+    interaction.user = SimpleNamespace(
+        guild_permissions=SimpleNamespace(administrator=False),
+    )
+    interaction.response.send_message = AsyncMock()
+    ok = await view.interaction_check(interaction)
+    assert ok is False
+
+
+def test_matrix_view_admin_gate_allows_admin():
+    view = RoutingMatrixSelectView()
+    children = list(view.children)
+    # There should be exactly one channel-select child.
+    assert any(isinstance(c, discord.ui.ChannelSelect) for c in children)

--- a/tests/unit/views/ai/test_support_report.py
+++ b/tests/unit/views/ai/test_support_report.py
@@ -1,0 +1,146 @@
+"""PR-H tests for the support-report draft surface.
+
+Pin:
+
+* The draft contains ONLY fields already in ai_decision_audit.
+* The draft is a markdown code block.
+* The view path makes NO network calls — it only calls
+  ai_decision_audit_service.query.
+* The embed format clearly labels itself as "draft".
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from pathlib import Path
+
+import pytest
+
+from views.ai.support_report import (
+    build_support_report_draft,
+    build_support_report_embed,
+)
+
+
+@pytest.mark.asyncio
+async def test_draft_is_code_block(monkeypatch):
+    from services import ai_decision_audit_service
+
+    async def _q(_gid, **_kw):
+        return []
+
+    monkeypatch.setattr(ai_decision_audit_service, "query", _q)
+
+    draft = await build_support_report_draft(guild_id=1, bot_user_id=42)
+    assert draft.startswith("```")
+    assert draft.rstrip().endswith("```")
+    assert "guild_id: 1" in draft
+    assert "bot_user_id: 42" in draft
+
+
+@pytest.mark.asyncio
+async def test_draft_renders_audit_fields_only(monkeypatch):
+    from services import ai_decision_audit_service
+
+    async def _q(_gid, **_kw):
+        return [
+            {
+                "decision": "denied",
+                "reason_code": "below_min_level",
+                "task": "btd6.answer",
+                "route": "btd6.answer",
+                "provider": "openai",
+                "model": "gpt-4",
+            },
+        ]
+
+    monkeypatch.setattr(ai_decision_audit_service, "query", _q)
+
+    draft = await build_support_report_draft(guild_id=1, bot_user_id=42)
+    assert "decision=denied" in draft
+    assert "reason=below_min_level" in draft
+    assert "provider=openai" in draft
+    assert "model=gpt-4" in draft
+
+
+@pytest.mark.asyncio
+async def test_draft_never_includes_message_text(monkeypatch):
+    """The audit table does not store message bodies — the draft path
+    must never invent or include any. We assert that no key from a
+    fake "message body" leaks even if it appeared in the audit row.
+    """
+    from services import ai_decision_audit_service
+
+    async def _q(_gid, **_kw):
+        return [
+            {
+                "decision": "replied",
+                "reason_code": "none",
+                "task": "general.nl_answer",
+                "route": "openai",
+                "provider": "openai",
+                "model": "gpt-4",
+                # Pretend an out-of-spec extra field leaked through:
+                "content": "SECRET MESSAGE BODY DO NOT LEAK",
+            },
+        ]
+
+    monkeypatch.setattr(ai_decision_audit_service, "query", _q)
+
+    draft = await build_support_report_draft(guild_id=1, bot_user_id=42)
+    assert "SECRET MESSAGE BODY" not in draft
+
+
+@pytest.mark.asyncio
+async def test_embed_labels_itself_as_draft(monkeypatch):
+    from services import ai_decision_audit_service
+
+    async def _q(_gid, **_kw):
+        return []
+
+    monkeypatch.setattr(ai_decision_audit_service, "query", _q)
+
+    embed = await build_support_report_embed(guild_id=1, bot_user_id=42)
+    blob = (embed.title or "") + " " + (embed.description or "")
+    assert "draft" in blob.lower()
+    assert "does NOT send" in blob or "no outbound" in blob.lower()
+
+
+def test_module_makes_no_network_calls():
+    """The view module must not import aiohttp / requests / urllib /
+    httpx as HTTP clients."""
+    src = inspect.getsource(
+        __import__("views.ai.support_report", fromlist=["support_report"]),
+    )
+    # Use import-statement patterns so common English words ("support
+    # requests are handled") don't false-match.
+    forbidden_patterns = (
+        r"\bimport\s+aiohttp\b",
+        r"\bfrom\s+aiohttp\b",
+        r"\bimport\s+requests\b",
+        r"\bfrom\s+requests\b",
+        r"\bimport\s+httpx\b",
+        r"\bfrom\s+httpx\b",
+        r"\bimport\s+urllib\b",
+        r"\bfrom\s+urllib\b",
+    )
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, src), (
+            f"support report must not import: {pattern}"
+        )
+
+
+def test_no_outbound_call_strings_in_file():
+    path = (
+        Path(__file__).resolve().parents[4]
+        / "disbot"
+        / "views"
+        / "ai"
+        / "support_report.py"
+    )
+    src = path.read_text()
+    # Pattern guard against accidental email / webhook code.
+    assert not re.search(r"\bsmtplib\b", src)
+    assert not re.search(r"\bsend_email\b", src)
+    assert not re.search(r"webhook", src, re.IGNORECASE)

--- a/tests/unit/views/btd6/test_strategy_browse.py
+++ b/tests/unit/views/btd6/test_strategy_browse.py
@@ -1,0 +1,240 @@
+"""PR-F tests for the strategy memory UX renderers + service layer."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import discord
+import pytest
+
+from services import btd6_strategy_service
+from views.btd6.strategy_browse import (
+    build_audit_embed,
+    build_browse_embed,
+    build_detail_embed,
+    build_mine_embed,
+)
+
+
+def _row(
+    sid: int,
+    *,
+    title: str,
+    visibility: str = "guild",
+    approval_status: str = "draft",
+    approved_by: str | None = None,
+    origin_guild_id: int = 100,
+    current_guild_id: int = 100,
+    submitted_by: int = 555,
+    summary: str = "summary text",
+    version: int = 1,
+):
+    return {
+        "id": sid,
+        "title": title,
+        "summary": summary,
+        "visibility": visibility,
+        "approval_status": approval_status,
+        "approved_by": approved_by,
+        "origin_guild_id": origin_guild_id,
+        "current_guild_id": current_guild_id,
+        "submitted_by": submitted_by,
+        "version": version,
+        "map": "Bloody Puddles",
+        "mode": "CHIMPS",
+        "difficulty": None,
+        "hero": None,
+        "towers": ["Super Monkey"],
+        "steps": ["Step 1"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Service layer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_mine_filters_to_submitter(monkeypatch):
+    async def _search(*, guild_id, limit):
+        return [
+            _row(1, title="mine", submitted_by=555),
+            _row(2, title="others", submitted_by=999),
+            _row(3, title="mine2", submitted_by=555),
+        ]
+
+    monkeypatch.setattr(
+        "utils.db.btd6_strategies.search_strategies",
+        _search,
+    )
+
+    out = await btd6_strategy_service.list_mine(100, submitter_id=555, limit=10)
+    assert {r["title"] for r in out} == {"mine", "mine2"}
+
+
+@pytest.mark.asyncio
+async def test_list_clamp_caps_huge_limit(monkeypatch):
+    captured = {}
+
+    async def _search(*, guild_id=None, visibility=None, limit, **_kw):
+        captured["limit"] = limit
+        return []
+
+    monkeypatch.setattr(
+        "utils.db.btd6_strategies.search_strategies",
+        _search,
+    )
+
+    await btd6_strategy_service.list_for_guild(1, limit=999_999)
+    assert captured["limit"] == btd6_strategy_service._MAX_LIMIT
+
+
+# ---------------------------------------------------------------------------
+# Browse / mine
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_browse_embed_lists_published_only(monkeypatch):
+    async def _list(*, limit):
+        return [
+            _row(1, title="published one", visibility="published"),
+            _row(2, title="published two", visibility="published"),
+        ]
+
+    monkeypatch.setattr(btd6_strategy_service, "list_published", _list)
+
+    embed = await build_browse_embed()
+    blob = "\n".join(f.name + " " + f.value for f in embed.fields)
+    assert "published one" in blob
+    assert "published two" in blob
+
+
+@pytest.mark.asyncio
+async def test_browse_embed_empty_message(monkeypatch):
+    async def _list(*, limit):
+        return []
+
+    monkeypatch.setattr(btd6_strategy_service, "list_published", _list)
+
+    embed = await build_browse_embed()
+    assert "No published" in (embed.description or "")
+
+
+@pytest.mark.asyncio
+async def test_mine_embed(monkeypatch):
+    async def _mine(guild_id, submitter_id, *, limit):
+        return [_row(7, title="my draft", submitted_by=submitter_id)]
+
+    monkeypatch.setattr(btd6_strategy_service, "list_mine", _mine)
+
+    embed = await build_mine_embed(100, 555)
+    blob = "\n".join(f.value for f in embed.fields)
+    assert "my draft" in blob
+
+
+# ---------------------------------------------------------------------------
+# Detail: cross-guild visibility
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_detail_published_visible_anywhere(monkeypatch):
+    async def _get(_sid):
+        return _row(5, title="public", visibility="published", origin_guild_id=10)
+
+    monkeypatch.setattr(btd6_strategy_service, "get", _get)
+
+    embed = await build_detail_embed(5, viewer_guild_id=999)
+    assert isinstance(embed, discord.Embed)
+    assert "public" in (embed.title or "")
+
+
+@pytest.mark.asyncio
+async def test_detail_guild_local_hidden_from_other_guild(monkeypatch):
+    async def _get(_sid):
+        return _row(
+            5,
+            title="secret",
+            visibility="guild",
+            origin_guild_id=10,
+            current_guild_id=10,
+        )
+
+    monkeypatch.setattr(btd6_strategy_service, "get", _get)
+
+    out = await build_detail_embed(5, viewer_guild_id=999)
+    assert isinstance(out, str)
+    assert "not visible" in out
+
+
+@pytest.mark.asyncio
+async def test_detail_guild_local_visible_to_origin(monkeypatch):
+    async def _get(_sid):
+        return _row(
+            5,
+            title="secret",
+            visibility="guild",
+            origin_guild_id=10,
+            current_guild_id=10,
+        )
+
+    monkeypatch.setattr(btd6_strategy_service, "get", _get)
+
+    embed = await build_detail_embed(5, viewer_guild_id=10)
+    assert isinstance(embed, discord.Embed)
+
+
+@pytest.mark.asyncio
+async def test_detail_missing_strategy(monkeypatch):
+    async def _get(_sid):
+        return None
+
+    monkeypatch.setattr(btd6_strategy_service, "get", _get)
+
+    out = await build_detail_embed(404, viewer_guild_id=1)
+    assert isinstance(out, str)
+    assert "not found" in out
+
+
+# ---------------------------------------------------------------------------
+# Audit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_audit_embed_renders_each_row(monkeypatch):
+    async def _audit(_sid):
+        now = datetime.now(tz=timezone.utc)
+        return [
+            {
+                "action": "submitted",
+                "actor_kind": "user",
+                "actor_id": 555,
+                "created_at": now,
+            },
+            {
+                "action": "ai_approved",
+                "actor_kind": "ai",
+                "actor_id": None,
+                "created_at": now,
+            },
+        ]
+
+    monkeypatch.setattr(btd6_strategy_service, "audit_for", _audit)
+
+    embed = await build_audit_embed(7)
+    names = {f.name for f in embed.fields}
+    assert any("submitted" in n for n in names)
+    assert any("ai_approved" in n for n in names)
+
+
+@pytest.mark.asyncio
+async def test_audit_embed_empty(monkeypatch):
+    async def _audit(_sid):
+        return []
+
+    monkeypatch.setattr(btd6_strategy_service, "audit_for", _audit)
+
+    embed = await build_audit_embed(7)
+    assert "No audit rows" in (embed.description or "")

--- a/tests/unit/views/btd6/test_strategy_submit.py
+++ b/tests/unit/views/btd6/test_strategy_submit.py
@@ -1,0 +1,84 @@
+"""PR-F tests for the strategy submission modal."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from services import btd6_strategy_mutation
+from views.btd6.strategy_submit import StrategySubmitModal
+
+
+def _set_inputs(modal, **fields):
+    """Set ``TextInput._value`` so .value reads back our test data."""
+    for k, v in fields.items():
+        getattr(modal, f"{k}_input")._value = v
+
+
+def _interaction(guild_id: int = 100):
+    interaction = MagicMock()
+    interaction.guild = SimpleNamespace(id=guild_id) if guild_id else None
+    interaction.user = SimpleNamespace(id=555, display_name="alice", name="alice")
+    interaction.response.send_message = AsyncMock()
+    return interaction
+
+
+@pytest.mark.asyncio
+async def test_submit_calls_chokepoint(monkeypatch):
+    captured = {}
+
+    async def _submit(**kwargs):
+        captured.update(kwargs)
+        return MagicMock(strategy_id=42, action="submitted")
+
+    monkeypatch.setattr(btd6_strategy_mutation, "submit_strategy", _submit)
+
+    modal = StrategySubmitModal()
+    _set_inputs(
+        modal,
+        title="Bloody CHIMPS",
+        summary="Works in 30 minutes",
+        map="Bloody Puddles",
+        mode="CHIMPS",
+        hero="Geraldo",
+    )
+    interaction = _interaction()
+    await modal.on_submit(interaction)
+
+    assert captured["origin_guild_id"] == 100
+    assert captured["title"] == "Bloody CHIMPS"
+    assert captured["summary"] == "Works in 30 minutes"
+    assert captured["map_name"] == "Bloody Puddles"
+    assert captured["mode"] == "CHIMPS"
+    assert captured["hero"] == "Geraldo"
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "#42" in msg
+
+
+@pytest.mark.asyncio
+async def test_submit_requires_guild_context():
+    modal = StrategySubmitModal()
+    _set_inputs(modal, title="x", summary="y", map="", mode="", hero="")
+    interaction = _interaction(guild_id=0)
+    interaction.guild = None
+    await modal.on_submit(interaction)
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "guild context" in msg
+
+
+@pytest.mark.asyncio
+async def test_submit_surfaces_validation_error(monkeypatch):
+    async def _submit(**_kw):
+        raise btd6_strategy_mutation.InvalidStrategyValueError("missing field")
+
+    monkeypatch.setattr(btd6_strategy_mutation, "submit_strategy", _submit)
+
+    modal = StrategySubmitModal()
+    _set_inputs(modal, title="", summary="", map="", mode="", hero="")
+    interaction = _interaction()
+    await modal.on_submit(interaction)
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "missing field" in msg

--- a/tests/unit/views/btd6/test_strategy_view_boundaries.py
+++ b/tests/unit/views/btd6/test_strategy_view_boundaries.py
@@ -1,0 +1,65 @@
+"""PR-F boundary regressions for the strategy memory views."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_STRATEGY_VIEW_DIR = (
+    Path(__file__).resolve().parents[4] / "disbot" / "views" / "btd6"
+)
+
+
+_FORBIDDEN_DB_WRITES = (
+    "insert_strategy",
+    "update_strategy_state",
+    "record_strategy_audit",
+    "delete_strategy",
+)
+
+_FORBIDDEN_AI_TABLES = (
+    "ai_channel_policy",
+    "ai_category_policy",
+    "ai_role_policy",
+    "ai_instruction_profile",
+)
+
+
+def _strategy_view_files() -> list[Path]:
+    return [
+        p
+        for p in _STRATEGY_VIEW_DIR.glob("strategy*.py")
+        if p.is_file()
+    ]
+
+
+def test_no_strategy_view_imports_db_write_helpers():
+    """Strategy views must route every write through
+    ``btd6_strategy_mutation``."""
+    for path in _strategy_view_files():
+        src = path.read_text()
+        for sym in _FORBIDDEN_DB_WRITES:
+            assert sym not in src, (
+                f"{path.name} must not call DB write helper {sym}; "
+                "use services.btd6_strategy_mutation instead"
+            )
+
+
+def test_no_strategy_view_references_ai_policy_tables():
+    """Strategy views are BTD6 territory; AI policy tables are
+    off-limits."""
+    for path in _strategy_view_files():
+        src = path.read_text()
+        for sym in _FORBIDDEN_AI_TABLES:
+            assert sym not in src, (
+                f"{path.name} must not reference AI policy table {sym}"
+            )
+
+
+def test_no_strategy_view_invokes_ai_approve_from_ui():
+    """``ai_approve_guild`` is the system-actor approval path; it
+    must not be reachable from a user-facing UI."""
+    for path in _strategy_view_files():
+        src = path.read_text()
+        assert "ai_approve_guild" not in src, (
+            f"{path.name} must not invoke ai_approve_guild from the UI"
+        )


### PR DESCRIPTION
## Summary

This is a coordinated series of eight pull requests (PR-A through PR-H) that polish the BTD6 assistant, introduce AI behavior presets, add strategy memory UX, and establish audit/diagnostics infrastructure for the AI Platform.

## Key Changes

### PR-A: BTD6 cog refactor & command parity
- **Extracted embed builders** from `btd6_cog.py` into `cogs/btd6/_embeds.py` to reduce cog file size and enable reuse by panel views
- **Created `cogs/btd6/_builders.py`** with shared prefix + slash command payload builders (`build_why_no_response_payload`, `build_grounding_embed`, `build_latest_data_embed`, `build_source_health_embed`)
- **Updated module docstring** to reflect new architecture: deterministic facts from `btd6_knowledge_service`, live entity grounding via `btd6_context_service`, audit reads from `ai_decision_audit_service`
- **Boundary enforcement**: Added `tests/unit/cogs/test_btd6_boundaries.py` to pin invariants (no `on_message` listeners, no AI Platform write helpers imported, prefix/slash parity, stale copy removal)

### PR-B: AI behavior presets
- **Added `services/ai_behavior_profile_service.py`** — thin orchestration layer for preset catalog (seeded in migration 044, stored as `ai_instruction_profile` rows with `is_preset=TRUE`)
- **Migration 043**: Added `is_preset` boolean column to `ai_instruction_profile`
- **Migration 044**: Seeded seven curated presets (`disabled`, `mention_only_helper`, `helpful_channel`, `btd6_focused`, `quiet_btd6_focused`, `staff_diagnostics`, `support_triage`)
- **Preset guard**: Modified `ai_instruction_mutation.upsert_profile` to reject guild-scope preset writes and prevent overwriting seeded rows
- **Tests**: `test_ai_behavior_profile_service.py` covers catalog consistency, list/describe/apply flows

### PR-C: Behavior UI (preset picker + scope selection)
- **Created `views/ai/behavior/` package** with three views:
  - `chooser.py`: Entry point with scope (Channel/Category) and action (Preview/Advanced) buttons
  - `scope_picker.py`: Native Discord channel/category select for chosen scope
  - `preset_picker.py`: Preset catalog picker that calls `apply_preset`
- **Tests**: `test_behavior_chooser.py`, `test_preset_picker.py` pin admin-only gates, reuse of existing policy/preview views, no direct DB writes

### PR-C-pre: UNCHANGED sentinel for partial updates
- **Added `UNCHANGED` sentinel** to `services/ai_policy_mutation.py` — enables three-state per optional column (concrete value / None / preserve)
- **Modified `utils/db/ai.py`** `upsert_channel_policy`, `upsert_category_policy`, `upsert_role_policy` to accept `unchanged_fields` set; omits those fields from `EXCLUDED` on conflict
- **Tests**: `test_ai_policy_mutation_unchanged.py` covers sentinel semantics, None vs. UNCHANGED distinction, required field enforcement

### PR-D: Source health diagnostics
- **Extended `services/btd6_source_registry.py`** with `SourceHealth` dataclass and bucketing logic (fresh / stale / missing)
- **Added `list_sources_with_health()`** to surface last-fetch timestamp and fact counts
- **Modified `utils/db/btd6_sources.py`** to add `limit` and `offset` parameters to `list_sources()`
- **Created `cogs/btd6/_builders.py` helpers**: `build_source_health_embed`, `build_latest_data_embed`
- **Tests**: `test_btd6_source_health.py` covers bucketing, bounded listing

### PR-E: Live entity grounding (races, bosses

https://claude.ai/code/session_01Jwamq7XzVu1Dv9pXfyBMSg