### PR TITLE
feat(ai): effective-policy embed via resolver dry-run (PR-2)

### DIFF
--- a/disbot/cogs/ai_cog.py
+++ b/disbot/cogs/ai_cog.py
@@ -438,32 +438,41 @@ class AICog(commands.Cog):
 
     @ai_group.command(name="policy")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
-    async def ai_policy(self, ctx: commands.Context) -> None:
-        """Show the typed policy row for this guild."""
+    async def ai_policy(
+        self,
+        ctx: commands.Context,
+        channel: discord.TextChannel | None = None,
+    ) -> None:
+        """Show the effective AI policy for a channel (dry-run resolver).
+
+        With no argument, dry-runs against the current channel; with
+        ``#channel`` dry-runs against the named one. The embed renders
+        the precedence trace produced by
+        :func:`ai_natural_language_policy.resolve(dry_run=True)` so
+        operators can see exactly which scope won.
+        """
         if not ctx.guild:
             await ctx.send("This command requires a guild context.")
             return
-        from utils.db import ai as ai_db
-
-        policy = await ai_db.get_guild_policy(ctx.guild.id)
-        if not policy:
+        target_channel = channel if channel is not None else ctx.channel
+        if not isinstance(target_channel, discord.TextChannel):
             await ctx.send(
-                "No typed AI policy row yet — set `ai.enabled` via `!settings`"
-                " to create one.",
+                "This command needs a text-channel context. Pass `#channel`"
+                " or run it from a regular text channel.",
             )
             return
-        lines = [
-            f"**enabled** = `{policy['enabled']}`",
-            f"**natural_language_enabled** = `{policy['natural_language_enabled']}`",
-            f"**default_provider** = `{policy['default_provider']}`",
-            f"**default_model** = `{policy['default_model'] or '—'}`",
-            f"**minimum_level_default** = `{policy['minimum_level_default']}`",
-            f"**cooldown_seconds** = `{policy['cooldown_seconds']}`",
-            f"**fresh_user_mention_allowance** ="
-            f" `{policy['fresh_user_mention_allowance']}`",
-            f"**generation** = `{policy['generation']}`",
-        ]
-        await ctx.send("\n".join(lines))
+        from services import ai_config_projection_service
+        from views.ai.policy.preview_view import build_effective_policy_embed
+
+        snapshot = await ai_config_projection_service.build_snapshot(ctx.guild.id)
+        embed = await build_effective_policy_embed(
+            guild=ctx.guild,
+            member=ctx.author,
+            channel=target_channel,
+            snapshot=snapshot,
+            title="AI Effective Policy",
+        )
+        await ctx.send(embed=embed)
 
     @ai_group.command(name="diagnostics")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
@@ -677,6 +686,48 @@ class AICog(commands.Cog):
         embed = await build_support_report_embed(
             guild_id=interaction.guild.id,
             bot_user_id=bot_user_id,
+        )
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+
+    @ai_app_group.command(
+        name="policy",
+        description=("Show the effective AI policy for a channel (dry-run resolver)."),
+    )
+    @app_commands.describe(
+        channel="Channel to dry-run against (defaults to here).",
+    )
+    @app_commands.checks.has_permissions(administrator=True)
+    async def ai_policy_slash(
+        self,
+        interaction: discord.Interaction,
+        channel: discord.TextChannel | None = None,
+    ) -> None:
+        if interaction.guild is None:
+            await interaction.response.send_message(
+                "This command requires a guild context.",
+                ephemeral=True,
+            )
+            return
+        target_channel = channel if channel is not None else interaction.channel
+        if not isinstance(target_channel, discord.TextChannel):
+            await interaction.response.send_message(
+                "This command needs a text-channel context. Pass `channel:`"
+                " or run it from a regular text channel.",
+                ephemeral=True,
+            )
+            return
+        from services import ai_config_projection_service
+        from views.ai.policy.preview_view import build_effective_policy_embed
+
+        snapshot = await ai_config_projection_service.build_snapshot(
+            interaction.guild.id,
+        )
+        embed = await build_effective_policy_embed(
+            guild=interaction.guild,
+            member=interaction.user,
+            channel=target_channel,
+            snapshot=snapshot,
+            title="AI Effective Policy",
         )
         await interaction.response.send_message(embed=embed, ephemeral=True)
 

--- a/disbot/views/ai/policy/chooser.py
+++ b/disbot/views/ai/policy/chooser.py
@@ -129,7 +129,7 @@ class PolicyChooserView(discord.ui.View):
         )
 
     @discord.ui.button(
-        label="Preview",
+        label="Effective policy",
         style=discord.ButtonStyle.secondary,
         row=1,
     )
@@ -138,12 +138,14 @@ class PolicyChooserView(discord.ui.View):
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        # PR4B: open the dry-run preview channel picker. The resolver
-        # runs in dry_run mode so cooldown / audit are untouched.
+        # PR-2: open the dry-run preview channel picker. The resolver
+        # runs in dry_run mode so cooldown / audit are untouched. Same
+        # underlying view as before — only the button label changed; the
+        # callback name (preview_btn) is its custom_id contract.
         from views.ai.policy.preview_view import PreviewChannelSelectView
 
         await interaction.response.send_message(
-            "Pick a channel to preview the effective AI policy as your user.",
+            "Pick a channel to see the effective AI policy as your user.",
             view=PreviewChannelSelectView(),
             ephemeral=True,
         )

--- a/disbot/views/ai/policy/preview_view.py
+++ b/disbot/views/ai/policy/preview_view.py
@@ -50,22 +50,33 @@ _BASELINE_DISABLED_REASONS = frozenset(
 )
 
 
-async def _build_preview_embed(
-    interaction: discord.Interaction,
+async def build_effective_policy_embed(
+    *,
+    guild: discord.Guild,
+    member: Any,
     channel: Any,
+    snapshot: Any = None,
+    title: str = "AI policy preview",
 ) -> discord.Embed:
-    """Run resolve(dry_run=True) twice (with/without mention) and
+    """Run ``resolve(dry_run=True)`` twice (with/without mention) and
     render both decisions in one embed.
+
+    Reused by:
+
+    * the policy-chooser **Preview** button (still labelled
+      ``Effective policy`` after PR-2; the channel-select picks a
+      target channel and renders this same embed).
+    * the ``!ai policy [#channel]`` prefix command + slash twin.
+
+    ``snapshot`` is the optional :class:`AIConfigSnapshot` from
+    :mod:`services.ai_config_projection_service`. When supplied, the
+    embed adds an ancillary footer line listing override counts +
+    provider/model. The resolved precedence still comes from the
+    resolver dry-run — the snapshot is never used to compute "is the
+    channel reachable?".
     """
     from services import ai_natural_language_policy as nlp
     from services import xp_service
-
-    guild = interaction.guild
-    member = interaction.user
-    if guild is None:
-        # Caller is supposed to have checked; defensive fallback so
-        # we never deref None at .id below.
-        raise RuntimeError("preview_view requires a guild context")
 
     record = None
     try:
@@ -83,7 +94,7 @@ async def _build_preview_embed(
         category_id = int(category_id)
 
     embed = discord.Embed(
-        title="AI policy preview",
+        title=title,
         description=(
             f"Resolving for {getattr(channel, 'mention', f'<#{channel.id}>')} "
             f"as {member.mention} (level `{user_level}`, "
@@ -117,8 +128,68 @@ async def _build_preview_embed(
             body = body[:1020] + "\n…"
         embed.add_field(name=label, value=body, inline=False)
 
+    if snapshot is not None:
+        _attach_ancillary_field(embed, snapshot)
+
     embed.set_footer(text="dry_run=True · administrator-only")
     return embed
+
+
+async def _build_preview_embed(
+    interaction: discord.Interaction,
+    channel: Any,
+) -> discord.Embed:
+    """Back-compat shim — adapts the original interaction-coupled
+    signature to :func:`build_effective_policy_embed`.
+
+    Retained so existing tests + internal callers continue to work.
+    New code should call :func:`build_effective_policy_embed` directly
+    with the explicit ``guild`` / ``member`` keyword arguments.
+    """
+    guild = interaction.guild
+    if guild is None:
+        raise RuntimeError("preview_view requires a guild context")
+    return await build_effective_policy_embed(
+        guild=guild,
+        member=interaction.user,
+        channel=channel,
+    )
+
+
+def _attach_ancillary_field(embed: discord.Embed, snapshot: Any) -> None:
+    """Add an "Overrides + provider" field sourced from the snapshot.
+
+    The snapshot is read-only orchestration; this helper renders the
+    counts and provider/model without re-querying any DB. Resolver
+    precedence comes from the dry-run above, never from the snapshot.
+    """
+    policy = getattr(snapshot, "policy", None)
+    provider = getattr(snapshot, "provider", None)
+    if policy is None and provider is None:
+        return
+    parts: list[str] = []
+    if policy is not None:
+        parts.append(
+            f"Overrides: {policy.channel_override_count} channel · "
+            f"{policy.category_override_count} category · "
+            f"{policy.role_override_count} role",
+        )
+        model = getattr(policy, "default_model", None) or "—"
+        provider_name = (
+            getattr(policy, "default_provider", None)
+            or (getattr(provider, "default_provider", None) if provider else None)
+            or "—"
+        )
+        parts.append(f"Provider: `{provider_name}` · model: `{model}`")
+    elif provider is not None:
+        parts.append(
+            f"Provider: `{getattr(provider, 'default_provider', None) or '—'}`",
+        )
+    embed.add_field(
+        name="Context",
+        value="\n".join(parts) or "—",
+        inline=False,
+    )
 
 
 def _render_verdict(decision: Any) -> str:
@@ -182,7 +253,11 @@ class _PreviewChannelSelect(discord.ui.ChannelSelect):
         if full is not None:
             channel = full
 
-        embed = await _build_preview_embed(interaction, channel)
+        embed = await build_effective_policy_embed(
+            guild=interaction.guild,
+            member=interaction.user,
+            channel=channel,
+        )
         await interaction.response.send_message(embed=embed, ephemeral=True)
 
 
@@ -206,5 +281,5 @@ class PreviewChannelSelectView(discord.ui.View):
 
 __all__ = [
     "PreviewChannelSelectView",
-    "_build_preview_embed",
+    "build_effective_policy_embed",
 ]

--- a/docs/ai-config-ownership.md
+++ b/docs/ai-config-ownership.md
@@ -144,7 +144,7 @@ applicable, the resolver's `dry_run=True` trace). No surface reads raw
 |---|---|---|
 | `!ai status` | `provider`, `policy`, `readiness_summary` | — |
 | `!ai readiness` | full snapshot | `services.ai_readiness_service.scan` |
-| `!ai policy` | `policy` (overrides), `provider` (header) | resolver `dry_run=True` for the effective decision; optional `[#channel]` arg dry-runs against that channel (PR-2) |
+| `!ai policy` | `policy` (overrides), `provider` (header) | resolver `dry_run=True` is the source of resolved precedence; optional `[#channel]` arg dry-runs against that channel. Snapshot is ancillary only — used for override counts + provider/model header, never for the resolved decision. |
 | `!ai memory` | `memory`, `audit.latest` (last reply memory) | — (PR-3) |
 | `!ai settings` | `policy`, `projection`, `instruction` | grouped renderer (PR-4B) |
 | `!ai routing` | `provider` | `services.ai_diagnostics_service.list_task_routing`; optional `[task]` arg filters to one row |

--- a/tests/unit/cogs/test_ai_policy_command.py
+++ b/tests/unit/cogs/test_ai_policy_command.py
@@ -1,0 +1,314 @@
+"""Tests for !ai policy — effective-policy embed via resolver dry-run.
+
+PR-2 contract:
+
+* The prefix command + slash twin call
+  ``ai_natural_language_policy.resolve(ctx, dry_run=True)`` to compute
+  the effective policy for a channel.
+* DM context (no guild) returns a friendly error.
+* A non-text-channel context returns a friendly error.
+* The optional channel argument is honored — when omitted, the current
+  channel is used.
+* The embed renders the resolver's precedence trace.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from cogs.ai_cog import AICog
+from core.runtime.ai.contracts import PolicyDenialReason
+from services import (
+    ai_config_projection_service,
+)
+from services import ai_natural_language_policy as nlp
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+class _FakeTextChannel:
+    """Stand-in that the cog's ``isinstance(_, discord.TextChannel)``
+    check accepts after we monkeypatch ``discord.TextChannel`` to this
+    class for the test.
+    """
+
+    def __init__(self, channel_id: int = 555, category_id: int | None = 200) -> None:
+        self.id = channel_id
+        self.name = "general"
+        self.mention = f"<#{channel_id}>"
+        self.category_id = category_id
+
+
+def _fake_member(member_id: int = 99, roles: list[int] | None = None) -> MagicMock:
+    member = MagicMock()
+    member.id = member_id
+    member.mention = f"<@{member_id}>"
+    member.guild_permissions.administrator = True
+    role_objs = []
+    for role_id in roles or []:
+        role = MagicMock()
+        role.id = role_id
+        role_objs.append(role)
+    member.roles = role_objs
+    return member
+
+
+def _ctx(
+    *,
+    guild_id: int | None = 1,
+    channel: _FakeTextChannel | None = None,
+    author: MagicMock | None = None,
+):
+    ctx = MagicMock()
+    ctx.guild = SimpleNamespace(id=guild_id) if guild_id else None
+    ctx.channel = channel if channel is not None else _FakeTextChannel()
+    ctx.author = author if author is not None else _fake_member()
+    ctx.send = AsyncMock()
+    return ctx
+
+
+def _stub_snapshot() -> ai_config_projection_service.AIConfigSnapshot:
+    """Minimal snapshot — populated enough for the ancillary field."""
+    return ai_config_projection_service.AIConfigSnapshot(
+        guild_id=1,
+        policy=ai_config_projection_service.PolicySnapshot(
+            guild_id=1,
+            enabled=True,
+            natural_language_enabled=True,
+            default_provider="openai",
+            default_model="gpt-4o-mini",
+            channel_override_count=2,
+            category_override_count=1,
+            role_override_count=0,
+        ),
+        memory=ai_config_projection_service.MemorySnapshot(
+            window_minutes=30,
+            scan_enabled=False,
+            cached_channel_count=0,
+            cached_total_turns=0,
+            per_channel_cap=200,
+            channel_lru_cap=50,
+            min_floor_turns=3,
+        ),
+        provider=ai_config_projection_service.ProviderSnapshot(
+            enabled=True,
+            default_provider="openai",
+            setup_advisor_provider="openai",
+            provider_active="openai",
+            degraded=False,
+            last_error_type=None,
+            last_fallback_reason=None,
+            requests_observed=0,
+            failures_observed=0,
+            redaction_enabled=True,
+        ),
+        projection=ai_config_projection_service.ProjectionSnapshot(),
+        instruction=ai_config_projection_service.InstructionSnapshot(),
+        audit=ai_config_projection_service.AuditSnapshot(),
+    )
+
+
+def _patch_resolve(monkeypatch, *, allowed: bool = True) -> dict[str, object]:
+    """Stub ``nlp.resolve`` and return a dict recording the dry_run flag."""
+    captured: dict[str, object] = {"calls": []}
+
+    async def _fake_resolve(ctx, *, dry_run=False):
+        captured["calls"].append(dry_run)
+        return nlp.PolicyDecision(
+            allowed=allowed,
+            reason_code=(
+                PolicyDenialReason.NONE
+                if allowed
+                else PolicyDenialReason.CHANNEL_DISABLED
+            ),
+            effective_min_level=2,
+            effective_cooldown=30,
+            effective_mode="always_reply" if allowed else "disabled",
+            effective_source="channel",
+            precedence_trace=(
+                "guild_ai_gate: AI enabled=true",
+                "channel_policy: mode=always_reply min_level=2 cooldown=30s",
+                "final_decision: allowed min_level=2 cooldown=30s",
+            ),
+        )
+
+    monkeypatch.setattr(nlp, "resolve", _fake_resolve)
+    return captured
+
+
+def _patch_xp(monkeypatch, level: int = 10) -> None:
+    async def _xp(_g, _u):
+        record = MagicMock()
+        record.level = level
+        return record
+
+    monkeypatch.setattr("services.xp_service.get_user_record", _xp)
+
+
+def _patch_snapshot(monkeypatch) -> None:
+    monkeypatch.setattr(
+        ai_config_projection_service,
+        "build_snapshot",
+        AsyncMock(return_value=_stub_snapshot()),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Failure modes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_policy_requires_guild_context():
+    cog = AICog(bot=MagicMock())
+    ctx = _ctx(guild_id=None)
+    await cog.ai_policy.callback(cog, ctx)
+    msg = ctx.send.await_args.args[0]
+    assert "guild context" in msg
+
+
+@pytest.mark.asyncio
+async def test_policy_rejects_non_text_channel(monkeypatch):
+    """If the current channel is not a TextChannel (DM, voice, etc.),
+    the command sends a friendly error rather than crashing."""
+    cog = AICog(bot=MagicMock())
+    # Use a SimpleNamespace channel that does NOT pass isinstance(_, discord.TextChannel).
+    ctx = _ctx(channel=SimpleNamespace(id=999))
+    await cog.ai_policy.callback(cog, ctx)
+    msg = ctx.send.await_args.args[0]
+    assert "text-channel" in msg
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_policy_invokes_resolver_with_dry_run_true(monkeypatch):
+    """Both with/without-mention resolutions pass dry_run=True."""
+    monkeypatch.setattr(
+        "cogs.ai_cog.discord.TextChannel",
+        _FakeTextChannel,
+    )
+    monkeypatch.setattr(
+        "views.ai.policy.preview_view.discord.TextChannel",
+        _FakeTextChannel,
+    )
+    captured = _patch_resolve(monkeypatch)
+    _patch_xp(monkeypatch)
+    _patch_snapshot(monkeypatch)
+
+    cog = AICog(bot=MagicMock())
+    ctx = _ctx()
+    await cog.ai_policy.callback(cog, ctx)
+
+    # Exactly two resolves (with/without mention), both dry_run=True.
+    assert captured["calls"] == [True, True]
+
+
+@pytest.mark.asyncio
+async def test_policy_embed_renders_trace(monkeypatch):
+    monkeypatch.setattr("cogs.ai_cog.discord.TextChannel", _FakeTextChannel)
+    monkeypatch.setattr(
+        "views.ai.policy.preview_view.discord.TextChannel",
+        _FakeTextChannel,
+    )
+    _patch_resolve(monkeypatch)
+    _patch_xp(monkeypatch)
+    _patch_snapshot(monkeypatch)
+
+    cog = AICog(bot=MagicMock())
+    ctx = _ctx()
+    await cog.ai_policy.callback(cog, ctx)
+
+    # Embed sent
+    _, kwargs = ctx.send.await_args
+    embed: discord.Embed = kwargs["embed"]
+    assert "Effective Policy" in (embed.title or "")
+    body = "\n".join(f"{f.name}\n{f.value}" for f in embed.fields)
+    # Trace lines from the stubbed resolver appear in the embed.
+    assert "channel_policy: mode=always_reply" in body
+    assert "final_decision: allowed" in body
+    # Ancillary "Context" field carries override counts from the snapshot.
+    assert "Overrides:" in body
+    assert "2 channel" in body
+    assert "1 category" in body
+
+
+@pytest.mark.asyncio
+async def test_policy_honours_explicit_channel_argument(monkeypatch):
+    """When ``channel=...`` is passed, the resolver runs against THAT
+    channel (not ctx.channel)."""
+    monkeypatch.setattr("cogs.ai_cog.discord.TextChannel", _FakeTextChannel)
+    monkeypatch.setattr(
+        "views.ai.policy.preview_view.discord.TextChannel",
+        _FakeTextChannel,
+    )
+
+    captured_ctx: list[nlp.MessageContext] = []
+
+    async def _fake_resolve(ctx, *, dry_run=False):
+        captured_ctx.append(ctx)
+        return nlp.PolicyDecision(
+            allowed=True,
+            reason_code=PolicyDenialReason.NONE,
+            effective_min_level=2,
+            effective_cooldown=30,
+            effective_mode="always_reply",
+            effective_source="channel",
+            precedence_trace=("ok",),
+        )
+
+    monkeypatch.setattr(nlp, "resolve", _fake_resolve)
+    _patch_xp(monkeypatch)
+    _patch_snapshot(monkeypatch)
+
+    cog = AICog(bot=MagicMock())
+    here = _FakeTextChannel(channel_id=100)
+    there = _FakeTextChannel(channel_id=999)
+    ctx = _ctx(channel=here)
+    await cog.ai_policy.callback(cog, ctx, channel=there)
+
+    # Both resolves target channel_id=999, the explicit argument.
+    assert all(c.channel_id == 999 for c in captured_ctx)
+
+
+@pytest.mark.asyncio
+async def test_policy_defaults_to_current_channel(monkeypatch):
+    monkeypatch.setattr("cogs.ai_cog.discord.TextChannel", _FakeTextChannel)
+    monkeypatch.setattr(
+        "views.ai.policy.preview_view.discord.TextChannel",
+        _FakeTextChannel,
+    )
+    captured_ctx: list[nlp.MessageContext] = []
+
+    async def _fake_resolve(ctx, *, dry_run=False):
+        captured_ctx.append(ctx)
+        return nlp.PolicyDecision(
+            allowed=True,
+            reason_code=PolicyDenialReason.NONE,
+            effective_min_level=2,
+            effective_cooldown=30,
+            effective_mode="always_reply",
+            effective_source="channel",
+            precedence_trace=("ok",),
+        )
+
+    monkeypatch.setattr(nlp, "resolve", _fake_resolve)
+    _patch_xp(monkeypatch)
+    _patch_snapshot(monkeypatch)
+
+    cog = AICog(bot=MagicMock())
+    here = _FakeTextChannel(channel_id=42)
+    ctx = _ctx(channel=here)
+    await cog.ai_policy.callback(cog, ctx)
+
+    # Resolver targeted ctx.channel since no explicit channel argument.
+    assert all(c.channel_id == 42 for c in captured_ctx)

--- a/tests/unit/views/ai/test_policy_chooser.py
+++ b/tests/unit/views/ai/test_policy_chooser.py
@@ -100,7 +100,11 @@ async def test_all_scope_buttons_have_real_implementations():
 
 def test_chooser_view_has_one_button_per_scope():
     """Smoke check: five buttons (Channel / Category / Role on row 0,
-    Preview / List overrides on row 1) sit on the chooser."""
+    Effective policy / List overrides on row 1) sit on the chooser.
+    The Preview button was renamed to Effective policy in PR-2; the
+    underlying ``preview_btn`` handler (and its custom_id contract)
+    is unchanged.
+    """
     view = PolicyChooserView()
     labels = sorted(
         item.label
@@ -110,7 +114,7 @@ def test_chooser_view_has_one_button_per_scope():
     assert labels == [
         "Category",
         "Channel",
+        "Effective policy",
         "List overrides",
-        "Preview",
         "Role",
     ]

--- a/tests/unit/views/ai/test_policy_preview_view.py
+++ b/tests/unit/views/ai/test_policy_preview_view.py
@@ -229,8 +229,11 @@ async def test_chooser_preview_button_opens_preview_view():
 
 
 def test_chooser_has_preview_button_on_row_one_with_list():
-    """Preview is an admin-only secondary action — same row as List
-    so the layout stays predictable."""
+    """The "Effective policy" button (renamed from Preview in PR-2)
+    is an admin-only secondary action — same row as List so the
+    layout stays predictable. The handler name (``preview_btn``)
+    is the persistent custom_id contract and is unchanged.
+    """
     from views.ai.policy.chooser import PolicyChooserView
 
     view = PolicyChooserView()
@@ -239,9 +242,9 @@ def test_chooser_has_preview_button_on_row_one_with_list():
         for item in view.children
         if isinstance(item, discord.ui.Button)
     }
-    assert "Preview" in btns
+    assert "Effective policy" in btns
     assert "List overrides" in btns
-    assert btns["Preview"].row == btns["List overrides"].row
+    assert btns["Effective policy"].row == btns["List overrides"].row
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Rewrites `!ai policy` from a raw typed-row dump into an **effective-policy embed** sourced from the resolver's dry-run trace. PR-2 of the AI cog refinement plan (`/root/.claude/plans/audit-conclusion-the-ai-enchanted-gadget.md`).

The plan's invariant for this PR: resolved precedence comes from `ai_natural_language_policy.resolve(ctx, dry_run=True)` — never re-derived from the snapshot. The snapshot is **ancillary only** (override counts + provider/model header).

## Changes

- **`disbot/cogs/ai_cog.py`** — `ai_policy` accepts optional `channel` arg (`!ai policy [#channel]`); dry-runs against the named channel or `ctx.channel`. New `ai_policy_slash` mirrors the prefix shape with `channel:` option. DM and non-text-channel contexts return friendly errors.
- **`disbot/views/ai/policy/preview_view.py`** — lifts module-private `_build_preview_embed` to public `build_effective_policy_embed(*, guild, member, channel, snapshot=None, title=...)`. Adds optional "Context" field rendered from the snapshot (override counts + provider/model from typed `ai_guild_policy`). Keeps `_build_preview_embed` as a back-compat shim so existing tests + the panel button callback still work unchanged.
- **`disbot/views/ai/policy/chooser.py`** — Preview button label renamed to "Effective policy". Handler name (`preview_btn`) is the persistent custom_id contract and is unchanged per the `docs/ai-config-ownership.md` § 7 compatibility rule (I-5).
- **`docs/ai-config-ownership.md`** — § "UI surfaces" row for `!ai policy` updated to spell out resolver-driven precedence vs. snapshot-as-ancillary.

## Tests

- **New** `tests/unit/cogs/test_ai_policy_command.py` (6 tests):
  - DM context returns friendly error
  - Non-text-channel context returns friendly error
  - Resolver is invoked with `dry_run=True` on both with/without-mention probes
  - Embed renders the precedence trace + override counts
  - Explicit `channel=` argument targets that channel
  - Default to `ctx.channel` when no arg is passed
- **Updated** `tests/unit/views/ai/test_policy_chooser.py` and `test_policy_preview_view.py` — label assertions flipped from "Preview" → "Effective policy" with rationale in docstrings.

## Compatibility

- Persistent panel custom_ids unchanged (I-5).
- `_build_preview_embed` retained as a back-compat shim — existing panel-button callback + 7 existing tests still pass.
- No schema changes; no new mutation paths.

## Test plan

- [x] `pytest tests/unit/cogs/test_ai_policy_command.py` — 6 passing
- [x] `pytest tests/unit/views/ai/test_policy_chooser.py tests/unit/views/ai/test_policy_preview_view.py` — 18 passing
- [x] black / isort / ruff / mypy clean locally
- [x] Broader cogs+views+services+docs suite — 3079 passing (1 unrelated pre-existing failure: `test_settings_edit_round_trip::test_coverage_spans_allowed_values_str_specs` test-ordering flake; passes in isolation, fails on main too)
- [ ] CI re-runs on push

https://claude.ai/code/session_01Y5cC77Jyce8JEyt8HtTK6S

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5cC77Jyce8JEyt8HtTK6S)_