### PR TITLE
feat(ai): memory status command + panel button + "Minimal" copy (PR-3)

### DIFF
--- a/disbot/cogs/ai/schemas.py
+++ b/disbot/cogs/ai/schemas.py
@@ -225,11 +225,11 @@ AI_SETTINGS: tuple[SettingSpec, ...] = (
         hint=(
             "How many minutes of recent channel messages the bot "
             "should keep in its in-process memory and include as "
-            "context on each AI reply. ``0`` keeps only the last 3 "
-            "messages per channel (the always-on minimum so basic "
-            "conversational handles still work). Hard cap 120 "
-            "minutes; the cache is in-process only and dropped on "
-            "restart."
+            "context on each AI reply. ``0`` = **Minimal — last 3 "
+            "messages only** (the always-on 3-turn floor so basic "
+            "conversational handles work even with memory 'off'). "
+            "Other choices set a time window in minutes; hard cap "
+            "120. The cache is in-process only and dropped on restart."
         ),
         validator=_validate_memory_window,
         input_hint="numeric_presets",

--- a/disbot/cogs/ai_cog.py
+++ b/disbot/cogs/ai_cog.py
@@ -266,6 +266,102 @@ def build_routing_embed(task_name: str | None = None) -> discord.Embed:
     return embed
 
 
+def build_memory_embed(
+    snapshot: object,
+    *,
+    channel_id: int | None = None,
+    channel_turn_count: int | None = None,
+) -> discord.Embed:
+    """Render an :class:`AIConfigSnapshot.memory` slice as an embed.
+
+    ``channel_id`` + ``channel_turn_count`` are the current-channel
+    context the snapshot itself does not carry (the snapshot is
+    guild-scoped). The cog command fills them in from ``ctx.channel``;
+    panel-button paths pass ``None`` and the embed renders ``—``.
+
+    "Last memory used in reply" reads from
+    ``snapshot.audit.latest['memory_turns_used']`` if PR-5 has shipped
+    and the audit row carries that field; otherwise renders ``—``.
+    Accepts the snapshot as ``object`` so this builder can also be
+    called from the panel-button path without coupling on the
+    projection-service type.
+    """
+    memory = getattr(snapshot, "memory", None)
+    audit = getattr(snapshot, "audit", None)
+    if memory is None:
+        return discord.Embed(
+            title="AI Memory",
+            description="No memory snapshot available.",
+            color=discord.Color.greyple(),
+        )
+
+    if memory.window_minutes <= 0:
+        mode_value = f"Minimal — last {memory.min_floor_turns} messages only"
+    else:
+        mode_value = f"Time window: {memory.window_minutes} min"
+
+    embed = discord.Embed(
+        title="AI Memory",
+        description=(
+            "In-process chat memory the bot includes as context on AI "
+            "replies. Dropped on restart and on `!ai forget`."
+        ),
+        color=discord.Color.blurple(),
+    )
+    embed.add_field(name="Mode", value=mode_value, inline=True)
+    embed.add_field(
+        name="Storage",
+        value="in-process only · dropped on restart",
+        inline=True,
+    )
+    embed.add_field(
+        name="Discord history scan",
+        value="on" if memory.scan_enabled else "off",
+        inline=True,
+    )
+    if channel_id is not None:
+        embed.add_field(
+            name="This channel cached turns",
+            value=(
+                f"<#{channel_id}>: {channel_turn_count if channel_turn_count is not None else 0}"
+            ),
+            inline=True,
+        )
+    embed.add_field(
+        name="Guild cached channels",
+        value=f"{memory.guild_channel_count}",
+        inline=True,
+    )
+    embed.add_field(
+        name="Process LRU",
+        value=(
+            f"{memory.cached_channel_count} / {memory.channel_lru_cap} channels · "
+            f"{memory.cached_total_turns} turns"
+        ),
+        inline=True,
+    )
+
+    last_reply_turns: object = "—"
+    if audit is not None:
+        latest = getattr(audit, "latest", None) or {}
+        # PR-5 will populate memory_turns_used on `replied` rows.
+        # Until then we render "—" — render rule per
+        # docs/ai-config-ownership.md § I-4.
+        value = latest.get("memory_turns_used") if isinstance(latest, dict) else None
+        if value is not None:
+            last_reply_turns = str(value)
+    embed.add_field(
+        name="Last reply used memory",
+        value=str(last_reply_turns),
+        inline=True,
+    )
+
+    embed.set_footer(
+        text=("Setting: ai_memory_window_minutes · 0 = Minimal (3-turn floor)."),
+    )
+    return embed
+
+
 # ---------------------------------------------------------------------------
 # Cog
 # ---------------------------------------------------------------------------
@@ -471,6 +567,32 @@ class AICog(commands.Cog):
             channel=target_channel,
             snapshot=snapshot,
             title="AI Effective Policy",
+        )
+        await ctx.send(embed=embed)
+
+    @ai_group.command(name="memory")  # type: ignore[arg-type]
+    @commands.has_permissions(administrator=True)
+    async def ai_memory(self, ctx: commands.Context) -> None:
+        """Show the chat-memory status for this guild + channel.
+
+        Sources from :func:`ai_config_projection_service.build_snapshot`
+        (memory + audit slices) plus a per-channel lookup against
+        ``ai_conversation_service.channel_stats`` for the "this
+        channel cached turns" line.
+        """
+        if not ctx.guild:
+            await ctx.send("This command requires a guild context.")
+            return
+        from services import ai_config_projection_service, ai_conversation_service
+
+        snapshot = await ai_config_projection_service.build_snapshot(ctx.guild.id)
+        channel_id = getattr(ctx.channel, "id", None)
+        per_guild = ai_conversation_service.channel_stats(ctx.guild.id)
+        turn_count = per_guild.get(channel_id) if channel_id is not None else None
+        embed = build_memory_embed(
+            snapshot,
+            channel_id=channel_id,
+            channel_turn_count=turn_count,
         )
         await ctx.send(embed=embed)
 
@@ -728,6 +850,33 @@ class AICog(commands.Cog):
             channel=target_channel,
             snapshot=snapshot,
             title="AI Effective Policy",
+        )
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+
+    @ai_app_group.command(
+        name="memory",
+        description=("Show chat-memory status (mode, scan, cached turns, last reply)."),
+    )
+    @app_commands.checks.has_permissions(administrator=True)
+    async def ai_memory_slash(self, interaction: discord.Interaction) -> None:
+        if interaction.guild is None:
+            await interaction.response.send_message(
+                "This command requires a guild context.",
+                ephemeral=True,
+            )
+            return
+        from services import ai_config_projection_service, ai_conversation_service
+
+        snapshot = await ai_config_projection_service.build_snapshot(
+            interaction.guild.id,
+        )
+        channel_id = getattr(interaction.channel, "id", None)
+        per_guild = ai_conversation_service.channel_stats(interaction.guild.id)
+        turn_count = per_guild.get(channel_id) if channel_id is not None else None
+        embed = build_memory_embed(
+            snapshot,
+            channel_id=channel_id,
+            channel_turn_count=turn_count,
         )
         await interaction.response.send_message(embed=embed, ephemeral=True)
 

--- a/disbot/core/runtime/ai/natural_language_stage.py
+++ b/disbot/core/runtime/ai/natural_language_stage.py
@@ -290,9 +290,10 @@ class AINaturalLanguageStage:
             return StageResult()
 
         ai_permission_service.mark_reply_sent(guild_id, user_id)
-        # The AI cog's on_message listener owns user-message recording
-        # so chat memory captures bystander messages too. The stage
-        # only records its own assistant reply.
+        # The stage owns memory recording for both roles: user turns
+        # were appended above (around the policy resolve), and the
+        # bot's own assistant turn is appended here once we know we
+        # actually replied.
         ai_conversation_service.append(
             guild_id,
             channel_id,

--- a/disbot/services/ai_config_projection_service.py
+++ b/disbot/services/ai_config_projection_service.py
@@ -92,6 +92,11 @@ class MemorySnapshot:
     allowed set). ``min_floor_turns`` mirrors
     :data:`ai_conversation_service.MIN_FLOOR_TURNS` so renderers can
     explain the "Minimal" mode.
+
+    ``cached_channel_count`` and ``cached_total_turns`` are
+    **process-wide** — the conversation buffer is shared across all
+    guilds in the LRU cap. ``guild_channel_count`` and
+    ``guild_total_turns`` count only this guild's buffers.
     """
 
     window_minutes: int
@@ -101,6 +106,8 @@ class MemorySnapshot:
     per_channel_cap: int
     channel_lru_cap: int
     min_floor_turns: int
+    guild_channel_count: int = 0
+    guild_total_turns: int = 0
 
 
 @dataclass(frozen=True)
@@ -307,6 +314,14 @@ async def _build_memory_snapshot(guild_id: int) -> MemorySnapshot:
         )
         window, scan_enabled = 0, False
     stats = ai_conversation_service.stats()
+    try:
+        per_guild = ai_conversation_service.channel_stats(guild_id)
+    except Exception:
+        logger.exception(
+            "ai_config_projection: channel_stats failed for guild=%d",
+            guild_id,
+        )
+        per_guild = {}
     return MemorySnapshot(
         window_minutes=int(window),
         scan_enabled=bool(scan_enabled),
@@ -315,6 +330,8 @@ async def _build_memory_snapshot(guild_id: int) -> MemorySnapshot:
         per_channel_cap=int(stats.per_channel_cap),
         channel_lru_cap=int(stats.channel_lru_cap),
         min_floor_turns=int(ai_conversation_service.MIN_FLOOR_TURNS),
+        guild_channel_count=len(per_guild),
+        guild_total_turns=sum(per_guild.values()),
     )
 
 

--- a/disbot/views/ai/panel.py
+++ b/disbot/views/ai/panel.py
@@ -242,10 +242,55 @@ class AIPanelView(PersistentView):
             ephemeral=True,
         )
 
+    @discord.ui.button(
+        label="Memory",
+        style=discord.ButtonStyle.secondary,
+        row=2,
+        custom_id="ai:memory",
+    )
+    async def memory_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        # PR-3: open the chat-memory status embed in place. Reads
+        # snapshot.memory + audit; never writes.
+        embed = await _build_memory_embed_for_interaction(interaction)
+        if embed is None:
+            await interaction.response.send_message(
+                "❌ Memory status needs a guild context.",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.edit_message(embed=embed, view=self)
+
 
 # ---------------------------------------------------------------------------
 # Shared dispatch + interaction-router handler
 # ---------------------------------------------------------------------------
+
+
+async def _build_memory_embed_for_interaction(
+    interaction: discord.Interaction,
+) -> discord.Embed | None:
+    """Build the memory-status embed using the snapshot + per-channel
+    lookup. Returns ``None`` when the interaction lacks a guild
+    context — callers send the friendly error themselves.
+    """
+    if interaction.guild_id is None:
+        return None
+    from cogs.ai_cog import build_memory_embed
+    from services import ai_config_projection_service, ai_conversation_service
+
+    snapshot = await ai_config_projection_service.build_snapshot(interaction.guild_id)
+    channel_id = getattr(interaction.channel, "id", None)
+    per_guild = ai_conversation_service.channel_stats(interaction.guild_id)
+    turn_count = per_guild.get(channel_id) if channel_id is not None else None
+    return build_memory_embed(
+        snapshot,
+        channel_id=channel_id,
+        channel_turn_count=turn_count,
+    )
 
 
 def _embed_for_ai_panel_action(action: str) -> discord.Embed | None:
@@ -348,6 +393,18 @@ async def handle_ai_interaction(
             view=BehaviorChooserView(),
             ephemeral=True,
         )
+        return
+
+    # PR-3: memory status reads snapshot + per-channel cache stats.
+    if action == "memory":
+        embed = await _build_memory_embed_for_interaction(interaction)
+        if embed is None:
+            await interaction.response.send_message(
+                "❌ Memory status needs a guild context.",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.edit_message(embed=embed, view=AIPanelView())
         return
 
     embed = _embed_for_ai_panel_action(action)

--- a/docs/ai-config-ownership.md
+++ b/docs/ai-config-ownership.md
@@ -145,7 +145,7 @@ applicable, the resolver's `dry_run=True` trace). No surface reads raw
 | `!ai status` | `provider`, `policy`, `readiness_summary` | — |
 | `!ai readiness` | full snapshot | `services.ai_readiness_service.scan` |
 | `!ai policy` | `policy` (overrides), `provider` (header) | resolver `dry_run=True` is the source of resolved precedence; optional `[#channel]` arg dry-runs against that channel. Snapshot is ancillary only — used for override counts + provider/model header, never for the resolved decision. |
-| `!ai memory` | `memory`, `audit.latest` (last reply memory) | — (PR-3) |
+| `!ai memory` | `memory` (full), `audit.latest['memory_turns_used']` for "last reply used memory" | Per-channel turn count comes from `ai_conversation_service.channel_stats(guild_id)` for the current channel (snapshot is guild-scoped). "Last reply used memory" renders `—` until PR-5 ships and populates the audit field. |
 | `!ai settings` | `policy`, `projection`, `instruction` | grouped renderer (PR-4B) |
 | `!ai routing` | `provider` | `services.ai_diagnostics_service.list_task_routing`; optional `[task]` arg filters to one row |
 | `!ai why-no-response` | `audit` | — |
@@ -236,8 +236,8 @@ is allowed; PR descriptions should verify no test asserts a fixed
 `len(view.children)`.
 
 The AI panel's button custom_ids today: `ai:refresh`, `ai:diagnostics`,
-`ai:providers`, `ai:routing`, `ai:settings`, `ai:policy`, `ai:behavior`.
-PR-3 adds `ai:memory`.
+`ai:providers`, `ai:routing`, `ai:settings`, `ai:policy`, `ai:behavior`,
+`ai:memory` (added in PR-3, row 2).
 
 ### Additive nullable migrations (I-4)
 

--- a/tests/unit/cogs/test_ai_memory_command.py
+++ b/tests/unit/cogs/test_ai_memory_command.py
@@ -1,0 +1,255 @@
+"""Tests for !ai memory — chat-memory status embed.
+
+PR-3 contract:
+
+* The command needs a guild context; refuses in DMs.
+* "Mode" field reads from ``snapshot.memory.window_minutes`` (0 →
+  "Minimal — last 3 messages only"; >0 → "Time window: N min").
+* "This channel cached turns" reads from
+  ``ai_conversation_service.channel_stats(guild_id)`` for ``ctx.channel.id``.
+* "Last reply used memory" renders ``—`` until PR-5 populates
+  ``audit.latest['memory_turns_used']``.
+* Empty cache + populated cache both render without raising.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from cogs.ai_cog import AICog, build_memory_embed
+from services import ai_config_projection_service, ai_conversation_service
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_buffers():
+    ai_conversation_service._reset_for_tests()
+    yield
+    ai_conversation_service._reset_for_tests()
+
+
+def _ctx(guild_id: int | None = 1, channel_id: int = 100):
+    ctx = MagicMock()
+    ctx.guild = SimpleNamespace(id=guild_id) if guild_id else None
+    ctx.channel = SimpleNamespace(id=channel_id, mention=f"<#{channel_id}>")
+    ctx.author = SimpleNamespace(id=42)
+    ctx.send = AsyncMock()
+    return ctx
+
+
+def _snapshot(
+    *,
+    window_minutes: int = 0,
+    scan_enabled: bool = False,
+    guild_channel_count: int = 0,
+    guild_total_turns: int = 0,
+    cached_channel_count: int = 0,
+    cached_total_turns: int = 0,
+    audit_latest: dict | None = None,
+) -> ai_config_projection_service.AIConfigSnapshot:
+    """Build a snapshot with the memory / audit fields we exercise."""
+    return ai_config_projection_service.AIConfigSnapshot(
+        guild_id=1,
+        policy=ai_config_projection_service.PolicySnapshot(guild_id=1),
+        memory=ai_config_projection_service.MemorySnapshot(
+            window_minutes=window_minutes,
+            scan_enabled=scan_enabled,
+            cached_channel_count=cached_channel_count,
+            cached_total_turns=cached_total_turns,
+            per_channel_cap=200,
+            channel_lru_cap=50,
+            min_floor_turns=3,
+            guild_channel_count=guild_channel_count,
+            guild_total_turns=guild_total_turns,
+        ),
+        provider=ai_config_projection_service.ProviderSnapshot(
+            enabled=False,
+            default_provider="deterministic",
+            setup_advisor_provider=None,
+            provider_active=None,
+            degraded=False,
+            last_error_type=None,
+            last_fallback_reason=None,
+            requests_observed=0,
+            failures_observed=0,
+            redaction_enabled=True,
+        ),
+        projection=ai_config_projection_service.ProjectionSnapshot(),
+        instruction=ai_config_projection_service.InstructionSnapshot(),
+        audit=ai_config_projection_service.AuditSnapshot(latest=audit_latest),
+    )
+
+
+def _patch_snapshot(monkeypatch, snap) -> None:
+    monkeypatch.setattr(
+        ai_config_projection_service,
+        "build_snapshot",
+        AsyncMock(return_value=snap),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Embed builder (sync) — exercised directly so we don't need cog state.
+# ---------------------------------------------------------------------------
+
+
+def test_memory_embed_window_zero_renders_minimal():
+    snap = _snapshot(window_minutes=0)
+    embed = build_memory_embed(snap, channel_id=100, channel_turn_count=0)
+    blob = "\n".join(f"{f.name}\n{f.value}" for f in embed.fields)
+    assert "Minimal — last 3 messages only" in blob
+
+
+def test_memory_embed_window_positive_renders_time_window():
+    snap = _snapshot(window_minutes=30)
+    embed = build_memory_embed(snap, channel_id=100, channel_turn_count=12)
+    blob = "\n".join(f"{f.name}\n{f.value}" for f in embed.fields)
+    assert "Time window: 30 min" in blob
+    # Channel turn count rendered.
+    assert "12" in blob
+
+
+def test_memory_embed_last_reply_renders_dash_when_field_missing():
+    """When the audit row has no ``memory_turns_used`` (pre-PR-5), the
+    embed renders the dash placeholder rather than raising."""
+    snap = _snapshot(audit_latest={"decision": "replied"})
+    embed = build_memory_embed(snap, channel_id=100, channel_turn_count=0)
+    last_reply_field = next(
+        f for f in embed.fields if f.name == "Last reply used memory"
+    )
+    assert last_reply_field.value == "—"
+
+
+def test_memory_embed_last_reply_renders_value_when_field_present():
+    snap = _snapshot(
+        audit_latest={"decision": "replied", "memory_turns_used": 7},
+    )
+    embed = build_memory_embed(snap, channel_id=100, channel_turn_count=0)
+    last_reply_field = next(
+        f for f in embed.fields if f.name == "Last reply used memory"
+    )
+    assert last_reply_field.value == "7"
+
+
+def test_memory_embed_scan_status():
+    snap_on = _snapshot(scan_enabled=True)
+    embed_on = build_memory_embed(snap_on, channel_id=100, channel_turn_count=0)
+    scan_on_field = next(f for f in embed_on.fields if f.name == "Discord history scan")
+    assert scan_on_field.value == "on"
+
+    snap_off = _snapshot(scan_enabled=False)
+    embed_off = build_memory_embed(snap_off, channel_id=100, channel_turn_count=0)
+    scan_off_field = next(
+        f for f in embed_off.fields if f.name == "Discord history scan"
+    )
+    assert scan_off_field.value == "off"
+
+
+# ---------------------------------------------------------------------------
+# Command — DM rejection.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_memory_requires_guild_context(monkeypatch):
+    cog = AICog(bot=MagicMock())
+    ctx = _ctx(guild_id=None)
+    await cog.ai_memory.callback(cog, ctx)
+    msg = ctx.send.await_args.args[0]
+    assert "guild context" in msg
+
+
+# ---------------------------------------------------------------------------
+# Command — happy paths.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_memory_command_empty_cache(monkeypatch):
+    """With no cached turns, the embed renders 0 for this channel +
+    0 for the guild total without raising."""
+    _patch_snapshot(monkeypatch, _snapshot(window_minutes=30))
+
+    cog = AICog(bot=MagicMock())
+    ctx = _ctx(guild_id=1, channel_id=100)
+    await cog.ai_memory.callback(cog, ctx)
+
+    embed = ctx.send.await_args.kwargs["embed"]
+    this_channel_field = next(
+        f for f in embed.fields if f.name == "This channel cached turns"
+    )
+    assert "0" in this_channel_field.value
+
+
+@pytest.mark.asyncio
+async def test_memory_command_populated_cache(monkeypatch):
+    """The current channel's cached-turn count comes from
+    ai_conversation_service.channel_stats — populate the buffer and
+    confirm the embed shows the right count."""
+    ai_conversation_service.append(
+        1,
+        100,
+        user_id=1,
+        role="user",
+        text="hello",
+    )
+    ai_conversation_service.append(
+        1,
+        100,
+        user_id=1,
+        role="user",
+        text="world",
+    )
+    # Different channel — should NOT count toward this-channel field.
+    ai_conversation_service.append(
+        1,
+        200,
+        user_id=1,
+        role="user",
+        text="elsewhere",
+    )
+    _patch_snapshot(
+        monkeypatch,
+        _snapshot(
+            window_minutes=30,
+            guild_channel_count=2,
+            guild_total_turns=3,
+        ),
+    )
+
+    cog = AICog(bot=MagicMock())
+    ctx = _ctx(guild_id=1, channel_id=100)
+    await cog.ai_memory.callback(cog, ctx)
+
+    embed = ctx.send.await_args.kwargs["embed"]
+    this_channel_field = next(
+        f for f in embed.fields if f.name == "This channel cached turns"
+    )
+    # Channel 100 has 2 turns; channel 200 is excluded.
+    assert "2" in this_channel_field.value
+    # Guild count reflects the snapshot value.
+    guild_field = next(f for f in embed.fields if f.name == "Guild cached channels")
+    assert "2" in guild_field.value
+
+
+# ---------------------------------------------------------------------------
+# Schema hint copy — the operator-facing "Minimal" rename.
+# ---------------------------------------------------------------------------
+
+
+def test_memory_window_setting_hint_mentions_minimal():
+    """``ai_memory_window_minutes`` hint copy explains the 'Minimal'
+    semantics so operators understand that 0 ≠ off."""
+    from cogs.ai.schemas import AI_CONFIG_SCHEMA
+
+    spec = next(
+        s for s in AI_CONFIG_SCHEMA.settings if s.name == "ai_memory_window_minutes"
+    )
+    assert "Minimal" in spec.hint
+    assert "3 messages only" in spec.hint or "3-turn floor" in spec.hint


### PR DESCRIPTION
## Summary

Stacked on **#322 (PR-2)** — makes the in-process chat memory observable to operators and reframes the `ai_memory_window_minutes=0` choice as **"Minimal"** (3-turn floor) instead of "off", so the setting label matches the code's `MIN_FLOOR_TURNS = 3` reality. PR-3 of the AI cog refinement plan.

Merge PR-2 first; this PR's base will then auto-retarget to `main`.

## Changes

- **`services/ai_config_projection_service.py`** — extends `MemorySnapshot` with guild-scoped `guild_channel_count` + `guild_total_turns`. Process-wide counters stay.
- **`cogs/ai_cog.py`** — `build_memory_embed(snapshot, *, channel_id, channel_turn_count)` + new `!ai memory` prefix and `/ai memory` slash. Per-channel turn count comes from `ai_conversation_service.channel_stats(guild_id)`; everything else reads from `snapshot.memory` + `snapshot.audit.latest`. "Last reply used memory" reads `audit.latest['memory_turns_used']` — renders `—` until PR-5 adds the column (per the I-4 legacy-NULL rendering rule in `docs/ai-config-ownership.md`).
- **`views/ai/panel.py`** — new **Memory** button (custom_id `ai:memory`, row 2). The router-side handler in `handle_ai_interaction` mirrors the button callback so restored panels keep working after restart.
- **`cogs/ai/schemas.py`** — `ai_memory_window_minutes` hint copy reframed: `0` = "Minimal — last 3 messages only" (the floor), not "off". `MIN_FLOOR_TURNS` unchanged in code; this is a copy-only fix to stop the setting from lying.
- **`core/runtime/ai/natural_language_stage.py`** — drops the stale comment claiming the AI cog's `on_message` listener owns user-turn recording. The stage owns both user (line ~100) and assistant (line ~296) appends.

## Tests

- **New** `tests/unit/cogs/test_ai_memory_command.py` (9 cases):
  - `window=0` renders "Minimal — last 3 messages only"
  - `window=30` renders "Time window: 30 min"
  - Last-reply dash placeholder when the audit field is missing
  - Last-reply value rendered when the audit field is present (forward-compat with PR-5)
  - Scan on/off rendering
  - DM context rejection
  - Empty-cache rendering
  - Populated-cache rendering: the current-channel turn count comes from `channel_stats`, isolated from other channels
  - Hint copy contains "Minimal" and the floor count

## Compatibility

- New panel custom_id `ai:memory` is additive (I-5 permits new buttons).
- No schema migrations; no new mutation paths.
- `MIN_FLOOR_TURNS = 3` behavior unchanged — this PR only updates copy + observability.
- All existing AI panel tests still pass (26 / 26).

## Test plan

- [x] `pytest tests/unit/cogs/test_ai_memory_command.py` — 9 passing
- [x] `pytest tests/unit/cogs tests/unit/views tests/unit/services tests/unit/docs` — 3088 passing (same unrelated `test_settings_edit_round_trip::test_coverage_spans_allowed_values_str_specs` test-ordering flake observed on main)
- [x] black / isort / ruff / mypy clean locally
- [ ] CI

https://claude.ai/code/session_01Y5cC77Jyce8JEyt8HtTK6S

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5cC77Jyce8JEyt8HtTK6S)_