### PR TITLE
feat(ai): snapshot drives !ai status + support report (PR-4A)

### DIFF
--- a/disbot/cogs/ai_cog.py
+++ b/disbot/cogs/ai_cog.py
@@ -103,6 +103,29 @@ def build_readiness_embed(
     return embed
 
 
+async def _safe_build_snapshot(guild: discord.Guild | None) -> Any:
+    """Best-effort snapshot fetch for command handlers.
+
+    Returns ``None`` when ``guild`` is ``None`` (DM context) or when
+    the snapshot build raises. The embed builders that accept a
+    snapshot all tolerate ``None`` and fall back to their existing
+    direct-read path, so renderers never raise on a partial snapshot.
+    """
+    if guild is None:
+        return None
+    try:
+        from services import ai_config_projection_service
+
+        return await ai_config_projection_service.build_snapshot(guild.id)
+    except Exception:
+        logger.debug(
+            "ai_cog: snapshot build failed for guild=%d",
+            guild.id,
+            exc_info=True,
+        )
+        return None
+
+
 async def _attach_readiness_summary(
     embed: discord.Embed,
     guild: discord.Guild,
@@ -176,22 +199,54 @@ async def _build_ai_settings_panel(
 # ---------------------------------------------------------------------------
 
 
-def build_status_embed() -> discord.Embed:
-    """Compact status: enabled / default provider / last call outcome."""
-    snap = ai_diagnostics_service.snapshot_for_cog()
+def build_status_embed(snapshot: object | None = None) -> discord.Embed:
+    """Compact status: enabled / default provider / last call outcome.
+
+    When ``snapshot`` is supplied (the
+    :class:`AIConfigSnapshot.provider` slice), the embed sources every
+    provider/counter field from it — every operator-facing AI surface
+    funnels through one read model.
+
+    When ``snapshot`` is ``None`` the builder falls back to the direct
+    diagnostics call so panel-header callsites that lack a guild
+    context still work (the panel header is anchored before
+    ``interaction.guild_id`` is known).
+    """
+    provider = getattr(snapshot, "provider", None) if snapshot is not None else None
+    if provider is not None:
+        values: dict[str, str] = {
+            "enabled": "yes" if provider.enabled else "no",
+            "default_provider": str(provider.default_provider or "—"),
+            "setup_advisor_provider": str(
+                provider.setup_advisor_provider or "—",
+            ),
+            "provider_active": str(provider.provider_active or "—"),
+            "requests": str(provider.requests_observed),
+            "failures": str(provider.failures_observed),
+        }
+    else:
+        snap = ai_diagnostics_service.snapshot_for_cog()
+        values = {
+            "enabled": "yes" if snap["enabled"] else "no",
+            "default_provider": str(snap["default_provider"]),
+            "setup_advisor_provider": str(snap["setup_advisor_provider"]),
+            "provider_active": str(snap["provider_active"]),
+            "requests": str(snap["requests_observed"]),
+            "failures": str(snap["failures_observed"]),
+        }
     embed = discord.Embed(
         title="AI Gateway — Status",
         color=discord.Color.blurple(),
     )
-    embed.add_field(name="Enabled", value="yes" if snap["enabled"] else "no")
-    embed.add_field(name="Default provider", value=str(snap["default_provider"]))
+    embed.add_field(name="Enabled", value=values["enabled"])
+    embed.add_field(name="Default provider", value=values["default_provider"])
     embed.add_field(
         name="Setup advisor provider",
-        value=str(snap["setup_advisor_provider"]),
+        value=values["setup_advisor_provider"],
     )
-    embed.add_field(name="Active provider", value=str(snap["provider_active"]))
-    embed.add_field(name="Requests", value=str(snap["requests_observed"]))
-    embed.add_field(name="Failures", value=str(snap["failures_observed"]))
+    embed.add_field(name="Active provider", value=values["provider_active"])
+    embed.add_field(name="Requests", value=values["requests"])
+    embed.add_field(name="Failures", value=values["failures"])
     return embed
 
 
@@ -446,7 +501,8 @@ class AICog(commands.Cog):
     @ai_group.command(name="status")  # type: ignore[arg-type]
     @commands.has_permissions(administrator=True)
     async def ai_status(self, ctx: commands.Context) -> None:
-        embed = build_status_embed()
+        snapshot = await _safe_build_snapshot(ctx.guild)
+        embed = build_status_embed(snapshot)
         if ctx.guild is not None:
             await _attach_readiness_summary(embed, ctx.guild, self.bot)
         await ctx.send(embed=embed)
@@ -663,9 +719,11 @@ class AICog(commands.Cog):
         from views.ai.support_report import build_support_report_embed
 
         bot_user_id = getattr(self.bot.user, "id", None) if self.bot.user else None
+        snapshot = await _safe_build_snapshot(ctx.guild)
         embed = await build_support_report_embed(
             guild_id=ctx.guild.id,
             bot_user_id=bot_user_id,
+            snapshot=snapshot,
         )
         await ctx.send(embed=embed)
 
@@ -682,7 +740,8 @@ class AICog(commands.Cog):
     @ai_app_group.command(name="status", description="AI gateway status summary.")
     @app_commands.checks.has_permissions(administrator=True)
     async def ai_status_slash(self, interaction: discord.Interaction) -> None:
-        embed = build_status_embed()
+        snapshot = await _safe_build_snapshot(interaction.guild)
+        embed = build_status_embed(snapshot)
         if interaction.guild is not None:
             await _attach_readiness_summary(embed, interaction.guild, self.bot)
         await interaction.response.send_message(embed=embed, ephemeral=True)
@@ -805,9 +864,11 @@ class AICog(commands.Cog):
         from views.ai.support_report import build_support_report_embed
 
         bot_user_id = getattr(self.bot.user, "id", None) if self.bot.user else None
+        snapshot = await _safe_build_snapshot(interaction.guild)
         embed = await build_support_report_embed(
             guild_id=interaction.guild.id,
             bot_user_id=bot_user_id,
+            snapshot=snapshot,
         )
         await interaction.response.send_message(embed=embed, ephemeral=True)
 

--- a/disbot/views/ai/support_report.py
+++ b/disbot/views/ai/support_report.py
@@ -36,6 +36,7 @@ async def build_support_report_draft(
     *,
     guild_id: int,
     bot_user_id: int | None,
+    snapshot: Any = None,
 ) -> str:
     """Return a fenced markdown code block summarising recent audit
     rows for the guild.
@@ -43,6 +44,13 @@ async def build_support_report_draft(
     Every line uses only the columns ``ai_decision_audit`` already
     holds: no message content, no DMs, no user identifiers beyond
     the user ids already in the audit row.
+
+    ``snapshot`` is the optional :class:`AIConfigSnapshot` from
+    :mod:`services.ai_config_projection_service`. When supplied, the
+    draft header adds operator-readable provider / model / memory /
+    projection-drift lines so the report is self-contained without
+    requiring the recipient to re-query the runtime. The audit-row
+    body is unchanged either way.
     """
     from services import ai_decision_audit_service
 
@@ -56,6 +64,7 @@ async def build_support_report_draft(
     if bot_user_id is not None:
         lines.append(f"# bot_user_id: {bot_user_id}")
     lines.append(f"# python: {sys.version.split()[0]} on {platform.system()}")
+    lines.extend(_snapshot_header_lines(snapshot))
     lines.append("# fields below come ONLY from ai_decision_audit; no message text.")
     lines.append("")
     if not rows:
@@ -71,15 +80,65 @@ async def build_support_report_draft(
     return "\n".join(lines)
 
 
+def _snapshot_header_lines(snapshot: Any) -> list[str]:
+    """Header lines sourced from the snapshot. Empty when no snapshot.
+
+    Renders provider / model / memory mode / projection drift status
+    as ``# key: value`` lines that fit inside the draft's existing
+    comment block. All fields tolerate ``None`` and render ``—`` per
+    the snapshot's general contract.
+    """
+    if snapshot is None:
+        return []
+    out: list[str] = []
+    provider = getattr(snapshot, "provider", None)
+    policy = getattr(snapshot, "policy", None)
+    memory = getattr(snapshot, "memory", None)
+    projection = getattr(snapshot, "projection", None)
+    if provider is not None:
+        provider_name = (
+            getattr(policy, "default_provider", None)
+            or getattr(provider, "default_provider", None)
+            or "—"
+        )
+        model = getattr(policy, "default_model", None) or "—"
+        out.append(f"# provider: {provider_name}")
+        out.append(f"# model: {model}")
+        if getattr(provider, "degraded", False):
+            out.append(
+                f"# gateway: degraded "
+                f"(last_error={provider.last_error_type or 'unknown'})",
+            )
+    if memory is not None:
+        mode = (
+            f"minimal ({memory.min_floor_turns}-turn floor)"
+            if memory.window_minutes <= 0
+            else f"{memory.window_minutes} min"
+        )
+        out.append(
+            f"# memory: {mode}, scan={'on' if memory.scan_enabled else 'off'}",
+        )
+    drift_count = (
+        int(getattr(projection, "drift_count", 0) or 0) if projection is not None else 0
+    )
+    if drift_count:
+        out.append(
+            f"# projection_drift: {drift_count} field(s) disagree with typed policy",
+        )
+    return out
+
+
 async def build_support_report_embed(
     *,
     guild_id: int,
     bot_user_id: int | None,
+    snapshot: Any = None,
 ) -> discord.Embed:
     """Wrap :func:`build_support_report_draft` in an explanatory embed."""
     draft = await build_support_report_draft(
         guild_id=guild_id,
         bot_user_id=bot_user_id,
+        snapshot=snapshot,
     )
     embed = discord.Embed(
         title="📋 AI Support report — draft",

--- a/tests/unit/cogs/test_ai_status_snapshot.py
+++ b/tests/unit/cogs/test_ai_status_snapshot.py
@@ -1,0 +1,292 @@
+"""Snapshot-driven consistency: !ai status + !ai support-report.
+
+PR-4A pin:
+
+* ``build_status_embed`` sources every provider/counter field from the
+  snapshot when one is supplied; falls back to the legacy diagnostics
+  call when ``snapshot=None`` (panel-header callsite).
+* ``build_support_report_draft`` adds operator-readable header lines
+  (provider / model / memory / projection drift) sourced from the
+  snapshot. Audit-row body is unchanged.
+* Both surfaces produce the same provider/model fields for the same
+  snapshot input — no parallel re-derivation.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cogs.ai_cog import build_status_embed
+from services import ai_config_projection_service, ai_diagnostics_service
+from views.ai.support_report import build_support_report_draft
+
+
+def _snapshot(
+    *,
+    provider_name: str = "openai",
+    model: str = "gpt-4o-mini",
+    requests: int = 17,
+    failures: int = 2,
+    enabled: bool = True,
+    window_minutes: int = 30,
+    scan_enabled: bool = True,
+    degraded: bool = False,
+    last_error: str | None = None,
+    drift_count: int = 0,
+):
+    """Build a fully-populated snapshot for the consistency checks."""
+    return ai_config_projection_service.AIConfigSnapshot(
+        guild_id=1,
+        policy=ai_config_projection_service.PolicySnapshot(
+            guild_id=1,
+            enabled=enabled,
+            natural_language_enabled=True,
+            default_provider=provider_name,
+            default_model=model,
+        ),
+        memory=ai_config_projection_service.MemorySnapshot(
+            window_minutes=window_minutes,
+            scan_enabled=scan_enabled,
+            cached_channel_count=0,
+            cached_total_turns=0,
+            per_channel_cap=200,
+            channel_lru_cap=50,
+            min_floor_turns=3,
+        ),
+        provider=ai_config_projection_service.ProviderSnapshot(
+            enabled=enabled,
+            default_provider=provider_name,
+            setup_advisor_provider=provider_name,
+            provider_active=provider_name,
+            degraded=degraded,
+            last_error_type=last_error,
+            last_fallback_reason=None,
+            requests_observed=requests,
+            failures_observed=failures,
+            redaction_enabled=True,
+        ),
+        projection=ai_config_projection_service.ProjectionSnapshot(
+            drift_count=drift_count,
+        ),
+        instruction=ai_config_projection_service.InstructionSnapshot(),
+        audit=ai_config_projection_service.AuditSnapshot(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_status_embed
+# ---------------------------------------------------------------------------
+
+
+def test_status_embed_with_snapshot_sources_provider_fields():
+    snap = _snapshot(provider_name="openai", requests=42, failures=3)
+    embed = build_status_embed(snap)
+    fields = {f.name: f.value for f in embed.fields}
+    assert fields["Default provider"] == "openai"
+    assert fields["Active provider"] == "openai"
+    assert fields["Requests"] == "42"
+    assert fields["Failures"] == "3"
+    assert fields["Enabled"] == "yes"
+
+
+def test_status_embed_without_snapshot_falls_back_to_diagnostics(monkeypatch):
+    """Panel-header callsite has no guild context — the builder still
+    works by reading directly from ``ai_diagnostics_service``."""
+    monkeypatch.setattr(
+        ai_diagnostics_service,
+        "snapshot_for_cog",
+        lambda: {
+            "enabled": True,
+            "default_provider": "deterministic",
+            "setup_advisor_provider": "deterministic",
+            "provider_active": "deterministic",
+            "requests_observed": 5,
+            "failures_observed": 0,
+        },
+    )
+    embed = build_status_embed(None)
+    fields = {f.name: f.value for f in embed.fields}
+    assert fields["Default provider"] == "deterministic"
+    assert fields["Requests"] == "5"
+
+
+def test_status_embed_handles_none_provider_gracefully():
+    """A guild with no provider configured renders ``—`` rather than
+    raising. Snapshot fields are typed as ``str | None``."""
+    snap = _snapshot(provider_name="")
+    # Replace default_provider with None to exercise the dash branch.
+    snap = ai_config_projection_service.AIConfigSnapshot(
+        guild_id=snap.guild_id,
+        policy=snap.policy,
+        memory=snap.memory,
+        provider=ai_config_projection_service.ProviderSnapshot(
+            enabled=False,
+            default_provider=None,
+            setup_advisor_provider=None,
+            provider_active=None,
+            degraded=False,
+            last_error_type=None,
+            last_fallback_reason=None,
+            requests_observed=0,
+            failures_observed=0,
+            redaction_enabled=True,
+        ),
+        projection=snap.projection,
+        instruction=snap.instruction,
+        audit=snap.audit,
+    )
+    embed = build_status_embed(snap)
+    fields = {f.name: f.value for f in embed.fields}
+    assert fields["Default provider"] == "—"
+    assert fields["Active provider"] == "—"
+    assert fields["Enabled"] == "no"
+
+
+# ---------------------------------------------------------------------------
+# build_support_report_draft with snapshot
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_support_report_draft_includes_snapshot_header(monkeypatch):
+    from services import ai_decision_audit_service
+
+    monkeypatch.setattr(
+        ai_decision_audit_service, "query", AsyncMock(return_value=[]),
+    )
+
+    snap = _snapshot(window_minutes=30, scan_enabled=True)
+    draft = await build_support_report_draft(
+        guild_id=1, bot_user_id=42, snapshot=snap,
+    )
+    assert "# provider: openai" in draft
+    assert "# model: gpt-4o-mini" in draft
+    assert "# memory: 30 min" in draft
+    assert "scan=on" in draft
+
+
+@pytest.mark.asyncio
+async def test_support_report_draft_without_snapshot_skips_header(monkeypatch):
+    """When no snapshot is supplied, the draft has no provider/memory
+    header lines — backwards compatible with the original output."""
+    from services import ai_decision_audit_service
+
+    monkeypatch.setattr(
+        ai_decision_audit_service, "query", AsyncMock(return_value=[]),
+    )
+
+    draft = await build_support_report_draft(guild_id=1, bot_user_id=42)
+    assert "# provider:" not in draft
+    assert "# memory:" not in draft
+
+
+@pytest.mark.asyncio
+async def test_support_report_draft_renders_memory_minimal(monkeypatch):
+    """``window_minutes=0`` renders 'minimal (N-turn floor)'."""
+    from services import ai_decision_audit_service
+
+    monkeypatch.setattr(
+        ai_decision_audit_service, "query", AsyncMock(return_value=[]),
+    )
+
+    snap = _snapshot(window_minutes=0)
+    draft = await build_support_report_draft(
+        guild_id=1, bot_user_id=42, snapshot=snap,
+    )
+    assert "# memory: minimal (3-turn floor)" in draft
+
+
+@pytest.mark.asyncio
+async def test_support_report_draft_renders_degraded_gateway(monkeypatch):
+    from services import ai_decision_audit_service
+
+    monkeypatch.setattr(
+        ai_decision_audit_service, "query", AsyncMock(return_value=[]),
+    )
+
+    snap = _snapshot(degraded=True, last_error="HTTPTimeout")
+    draft = await build_support_report_draft(
+        guild_id=1, bot_user_id=42, snapshot=snap,
+    )
+    assert "# gateway: degraded" in draft
+    assert "HTTPTimeout" in draft
+
+
+@pytest.mark.asyncio
+async def test_support_report_draft_renders_projection_drift(monkeypatch):
+    from services import ai_decision_audit_service
+
+    monkeypatch.setattr(
+        ai_decision_audit_service, "query", AsyncMock(return_value=[]),
+    )
+
+    snap = _snapshot(drift_count=2)
+    draft = await build_support_report_draft(
+        guild_id=1, bot_user_id=42, snapshot=snap,
+    )
+    assert "projection_drift: 2 field(s)" in draft
+
+
+@pytest.mark.asyncio
+async def test_support_report_audit_body_unchanged_by_snapshot(monkeypatch):
+    """Stop-condition pin: PR-4A is a read-source replacement. The
+    audit-row body lines look the same whether a snapshot is supplied
+    or not."""
+    from services import ai_decision_audit_service
+
+    monkeypatch.setattr(
+        ai_decision_audit_service,
+        "query",
+        AsyncMock(
+            return_value=[
+                {
+                    "decision": "denied",
+                    "reason_code": "below_min_level",
+                    "task": "general.nl_answer",
+                    "route": "openai",
+                    "provider": "openai",
+                    "model": "gpt-4",
+                },
+            ],
+        ),
+    )
+
+    snap = _snapshot()
+    draft_with = await build_support_report_draft(
+        guild_id=1, bot_user_id=42, snapshot=snap,
+    )
+    draft_without = await build_support_report_draft(guild_id=1, bot_user_id=42)
+    # The audit-row body line is identical in both drafts (string match).
+    audit_line = (
+        "- decision=denied reason=below_min_level "
+        "task=general.nl_answer route=openai "
+        "provider=openai model=gpt-4"
+    )
+    assert audit_line in draft_with
+    assert audit_line in draft_without
+
+
+# ---------------------------------------------------------------------------
+# Consistency: same snapshot produces same provider fields across surfaces
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_status_and_support_report_agree_on_provider(monkeypatch):
+    from services import ai_decision_audit_service
+
+    monkeypatch.setattr(
+        ai_decision_audit_service, "query", AsyncMock(return_value=[]),
+    )
+
+    snap = _snapshot(provider_name="openai", model="gpt-4o-mini")
+    status = build_status_embed(snap)
+    draft = await build_support_report_draft(
+        guild_id=1, bot_user_id=42, snapshot=snap,
+    )
+    status_fields = {f.name: f.value for f in status.fields}
+    assert status_fields["Default provider"] == "openai"
+    assert "# provider: openai" in draft
+    assert "# model: gpt-4o-mini" in draft


### PR DESCRIPTION
## Summary

Stacked on **#323 (PR-3)**. PR-4A of the AI cog refinement plan — read-source replacement only, no behavior changes. Both `!ai status` and `!ai support-report` now funnel through the operator-facing `AIConfigSnapshot` instead of each surface re-deriving provider state from the diagnostics module.

Merge #323 first; this PR's base will then auto-retarget to `main`.

## Changes

- **`disbot/cogs/ai_cog.py`**
  - `build_status_embed` accepts an optional snapshot; sources every provider/counter field from `snapshot.provider` when supplied. Falls back to the legacy `ai_diagnostics_service.snapshot_for_cog` call when `snapshot=None` (the panel-header callsite has no guild context, so this preserves it).
  - New `_safe_build_snapshot(guild)` helper — best-effort fetch returns `None` on DM context or build failure, so embed builders that accept a snapshot never raise.
  - `ai_status` + `ai_status_slash` + `ai_support_report` + `ai_support_report_slash` build a snapshot up front and pass it through.

- **`disbot/views/ai/support_report.py`**
  - `build_support_report_draft` and `build_support_report_embed` accept an optional snapshot. New `_snapshot_header_lines` helper adds:
    - `# provider: …`
    - `# model: …`
    - `# memory: minimal (3-turn floor)` or `# memory: N min, scan=on|off`
    - `# gateway: degraded (last_error=...)` when degraded
    - `# projection_drift: N field(s) disagree with typed policy` when `drift_count > 0`
  - Audit-row body is unchanged — pinned by `test_support_report_audit_body_unchanged_by_snapshot`.

## Stop condition (per the plan)

Read-source replacement only. No behavior changes, no new mutation paths, no schema changes. Renderers that need behavior changes beyond data-source migration are explicitly out of scope here and left for follow-up.

## Tests

**New** `tests/unit/cogs/test_ai_status_snapshot.py` — 9 cases:
- Status embed sources provider/counter fields from snapshot
- Status embed falls back to diagnostics call when `snapshot=None`
- Status embed renders `—` for missing provider names
- Support-report draft includes snapshot header lines
- Support-report draft skips header when `snapshot=None`
- Support-report draft renders minimal/time-window memory mode
- Support-report draft renders degraded-gateway and drift lines
- Audit-row body unchanged whether snapshot supplied or not
- Status + support-report agree on provider/model for same snapshot

Existing `tests/unit/views/ai/test_support_report.py` suite (7 cases) still passes — the snapshot parameter is optional, so legacy callsites and tests are unaffected.

## Test plan

- [x] `pytest tests/unit/cogs/test_ai_status_snapshot.py tests/unit/views/ai/` — 16 + new = pass
- [x] black / isort / ruff / mypy clean locally
- [ ] CI

https://claude.ai/code/session_01Y5cC77Jyce8JEyt8HtTK6S

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5cC77Jyce8JEyt8HtTK6S)_