### PR TITLE
feat(ai): audit memory + effective-source columns (PR-5)

### DIFF
--- a/disbot/cogs/ai_cog.py
+++ b/disbot/cogs/ai_cog.py
@@ -156,16 +156,24 @@ def _format_audit_row(row: dict) -> str:
     """Format one ``ai_decision_audit`` row for the why-no-response embed.
 
     Includes relative timestamp, decision, reason_code, task, route,
-    channel link, user mention, provider, model. No raw message content
-    is rendered (the audit table does not store any).
+    channel link, user mention, provider, model, plus the migration-045
+    ``effective_source`` / ``effective_mode`` fields. Pre-045 rows
+    (and post-045 rows on branches that did not populate the new
+    fields — denial rows, error rows on the cooldown branch, etc.)
+    render the new fields as ``—`` per the I-4 legacy-NULL rendering
+    rule. No raw message content is rendered — the audit table never
+    stores any.
     """
     created_at = row.get("created_at")
     when = _relative_time(created_at) if isinstance(created_at, datetime) else "—"
+    eff_source = row.get("effective_source") or "—"
+    eff_mode = row.get("effective_mode") or "—"
     return (
         f"`{when:<8}` · `{row['decision']:<8}` · `{row['reason_code']}` · "
         f"task={row.get('task') or '—'} · route={row.get('route') or '—'} · "
         f"<#{row['channel_id']}> · <@{row['user_id']}> · "
-        f"provider={row.get('provider') or '—'} model={row.get('model') or '—'}"
+        f"provider={row.get('provider') or '—'} model={row.get('model') or '—'} · "
+        f"effective={eff_source}/{eff_mode}"
     )
 
 

--- a/disbot/core/runtime/ai/natural_language_stage.py
+++ b/disbot/core/runtime/ai/natural_language_stage.py
@@ -143,6 +143,8 @@ class AINaturalLanguageStage:
                 reason_code=decision.reason_code,
                 policy_snapshot_hash=decision.policy_snapshot_hash,
                 instruction_profile_ids=list(decision.instruction_profile_ids) or None,
+                effective_source=decision.effective_source or None,
+                effective_mode=decision.effective_mode or None,
             )
             return StageResult()
 
@@ -164,8 +166,18 @@ class AINaturalLanguageStage:
                 decision="denied",
                 reason_code=PolicyDenialReason.COOLDOWN_ACTIVE,
                 policy_snapshot_hash=decision.policy_snapshot_hash,
+                effective_source=decision.effective_source or None,
+                effective_mode=decision.effective_mode or None,
             )
             return StageResult()
+
+        # Memory metadata captured here so the `replied` audit row can
+        # record what context was actually supplied to the prompt. The
+        # other branches (error / cooldown / skip / degraded) leave the
+        # memory columns NULL — they did not produce a reply.
+        memory_window_minutes: int | None = None
+        memory_scan_attempted: bool | None = None
+        memory_scan_added_turns: int | None = None
 
         try:
             feature_facts = await _gather_feature_facts(routed.task, text)
@@ -176,7 +188,7 @@ class AINaturalLanguageStage:
             try:
                 from services import ai_memory_service
 
-                recent_turns = await ai_memory_service.gather_recent_turns(
+                result = await ai_memory_service.gather_recent_turns_with_metadata(
                     guild_id=guild_id,
                     channel_id=channel_id,
                     channel=getattr(message, "channel", None),
@@ -186,6 +198,10 @@ class AINaturalLanguageStage:
                         None,
                     ),
                 )
+                recent_turns = result.turns
+                memory_window_minutes = result.window_minutes
+                memory_scan_attempted = result.scan_attempted
+                memory_scan_added_turns = result.scan_added_turns
             except Exception as exc:  # noqa: BLE001 — defensive
                 logger.debug(
                     "ai_natural_language_stage: memory unavailable: %s",
@@ -231,6 +247,8 @@ class AINaturalLanguageStage:
                 instruction_profile_ids=(
                     list(stack.instruction_profile_ids) if "stack" in locals() else None
                 ),
+                effective_source=decision.effective_source or None,
+                effective_mode=decision.effective_mode or None,
             )
             return StageResult()
 
@@ -259,6 +277,8 @@ class AINaturalLanguageStage:
                 instruction_profile_ids=list(stack.instruction_profile_ids) or None,
                 provider=response.provider or None,
                 model=response.model or None,
+                effective_source=decision.effective_source or None,
+                effective_mode=decision.effective_mode or None,
             )
             return StageResult()
 
@@ -286,6 +306,8 @@ class AINaturalLanguageStage:
                 instruction_profile_ids=list(stack.instruction_profile_ids) or None,
                 provider=response.provider or None,
                 model=response.model or None,
+                effective_source=decision.effective_source or None,
+                effective_mode=decision.effective_mode or None,
             )
             return StageResult()
 
@@ -316,6 +338,12 @@ class AINaturalLanguageStage:
             instruction_profile_ids=list(stack.instruction_profile_ids) or None,
             provider=response.provider or None,
             model=response.model or None,
+            memory_turns_used=len(recent_turns) if recent_turns else 0,
+            memory_window_minutes=memory_window_minutes,
+            memory_scan_attempted=memory_scan_attempted,
+            memory_scan_added_turns=memory_scan_added_turns,
+            effective_source=decision.effective_source or None,
+            effective_mode=decision.effective_mode or None,
         )
 
         ctx.metadata["handled_by"] = STAGE_NAME

--- a/disbot/migrations/045_ai_decision_audit_memory.sql
+++ b/disbot/migrations/045_ai_decision_audit_memory.sql
@@ -1,0 +1,31 @@
+-- Migration 045: ai_decision_audit memory + effective-source columns (PR-5).
+--
+-- Adds six nullable columns to ``ai_decision_audit``:
+--
+--   memory_turns_used        INTEGER   — turns supplied to the prompt on
+--                                        a `replied` row.
+--   memory_window_minutes    INTEGER   — active memory window at decision time.
+--   memory_scan_attempted    BOOLEAN   — whether the Discord history-scan
+--                                        backfill was attempted.
+--   memory_scan_added_turns  INTEGER   — turns appended by the scan, if any.
+--   effective_source         TEXT      — precedence scope that won
+--                                        (channel / category / guild).
+--   effective_mode           TEXT      — mode the winning source produced
+--                                        (always_reply / mention_only / disabled).
+--
+-- All nullable so the migration is non-destructive — legacy rows keep
+-- their existing values and the new columns stay NULL. Audit readers
+-- in ``disbot/cogs/ai_cog.py`` and the support-report renderer render
+-- "—" for NULL fields per ``docs/ai-config-ownership.md`` § "Audit
+-- fields" (the I-4 legacy-NULL rendering rule).
+--
+-- Forward-only and idempotent. Safe to apply after migration 039
+-- (the original ai_decision_audit definition).
+
+ALTER TABLE ai_decision_audit
+    ADD COLUMN IF NOT EXISTS memory_turns_used       INTEGER,
+    ADD COLUMN IF NOT EXISTS memory_window_minutes   INTEGER,
+    ADD COLUMN IF NOT EXISTS memory_scan_attempted   BOOLEAN,
+    ADD COLUMN IF NOT EXISTS memory_scan_added_turns INTEGER,
+    ADD COLUMN IF NOT EXISTS effective_source        TEXT,
+    ADD COLUMN IF NOT EXISTS effective_mode          TEXT;

--- a/disbot/services/ai_decision_audit_service.py
+++ b/disbot/services/ai_decision_audit_service.py
@@ -41,12 +41,23 @@ async def record(
     instruction_profile_ids: list[int] | None = None,
     provider: str | None = None,
     model: str | None = None,
+    memory_turns_used: int | None = None,
+    memory_window_minutes: int | None = None,
+    memory_scan_attempted: bool | None = None,
+    memory_scan_added_turns: int | None = None,
+    effective_source: str | None = None,
+    effective_mode: str | None = None,
 ) -> int:
     """Write one row; returns the new ``id``.
 
     Raises ``ValueError`` for unknown ``decision`` values so a typo
     surfaces at the call site rather than silently corrupting the
     audit table.
+
+    Migration 045 added the ``memory_*`` / ``effective_*`` kwargs; they
+    default to ``None`` so the natural-language stage can populate
+    them on the ``decision='replied'`` branch while every other
+    caller (denial / skip / error rows) leaves them NULL.
     """
     if decision not in _VALID_DECISIONS:
         raise ValueError(
@@ -75,6 +86,12 @@ async def record(
         instruction_profile_ids=instruction_profile_ids,
         provider=provider,
         model=model,
+        memory_turns_used=memory_turns_used,
+        memory_window_minutes=memory_window_minutes,
+        memory_scan_attempted=memory_scan_attempted,
+        memory_scan_added_turns=memory_scan_added_turns,
+        effective_source=effective_source,
+        effective_mode=effective_mode,
     )
 
 

--- a/disbot/services/ai_memory_service.py
+++ b/disbot/services/ai_memory_service.py
@@ -22,6 +22,7 @@ restart and on ``forget_guild`` / ``forget_channel``.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import Any
 
 from services import ai_conversation_service
@@ -65,6 +66,81 @@ async def read_memory_settings(guild_id: int) -> tuple[int, bool]:
         window = 0
     scan_enabled = str(raw_scan).strip().lower() in {"true", "1", "yes", "on"}
     return window, scan_enabled
+
+
+@dataclass(frozen=True)
+class MemoryGatherResult:
+    """Outcome of :func:`gather_recent_turns_with_metadata`.
+
+    Carries the turns themselves alongside the metadata the audit
+    row needs to record: the active memory window in minutes,
+    whether the Discord history scan was attempted, and how many
+    turns it appended. The natural-language stage uses this to
+    populate the migration-045 columns on a ``replied`` audit row.
+    """
+
+    turns: list[ai_conversation_service.ConversationTurn]
+    window_minutes: int
+    scan_attempted: bool
+    scan_added_turns: int
+
+
+async def gather_recent_turns_with_metadata(
+    *,
+    guild_id: int,
+    channel_id: int,
+    channel: Any = None,
+    bot_user_id: int | None = None,
+) -> MemoryGatherResult:
+    """Same behavior as :func:`gather_recent_turns` plus scan metadata.
+
+    Introduced in PR-5 so the natural-language stage can audit which
+    fallback path produced the turns. Returns a typed
+    :class:`MemoryGatherResult`. The legacy ``gather_recent_turns``
+    is kept for current callsites; only the NL stage moves to this
+    helper.
+    """
+    window, scan_enabled = await read_memory_settings(guild_id)
+    turns = ai_conversation_service.recent_turns(
+        guild_id,
+        channel_id,
+        window_minutes=window,
+    )
+    scan_attempted = False
+    scan_added = 0
+    if (
+        scan_enabled
+        and channel is not None
+        and len(turns) < ai_conversation_service.MIN_FLOOR_TURNS
+    ):
+        scan_attempted = True
+        try:
+            scan_added = await _seed_from_history(
+                guild_id=guild_id,
+                channel_id=channel_id,
+                channel=channel,
+                bot_user_id=bot_user_id,
+            )
+        except Exception as exc:  # noqa: BLE001 — best-effort fallback
+            logger.debug(
+                "ai_memory: channel scan failed for guild=%s channel=%s: %s",
+                guild_id,
+                channel_id,
+                exc,
+            )
+            scan_added = 0
+        # Re-read after the seed.
+        turns = ai_conversation_service.recent_turns(
+            guild_id,
+            channel_id,
+            window_minutes=window,
+        )
+    return MemoryGatherResult(
+        turns=turns,
+        window_minutes=int(window),
+        scan_attempted=scan_attempted,
+        scan_added_turns=int(scan_added),
+    )
 
 
 async def gather_recent_turns(
@@ -174,6 +250,8 @@ async def _seed_from_history(
 
 
 __all__ = [
+    "MemoryGatherResult",
     "gather_recent_turns",
+    "gather_recent_turns_with_metadata",
     "read_memory_settings",
 ]

--- a/disbot/utils/db/ai.py
+++ b/disbot/utils/db/ai.py
@@ -470,15 +470,32 @@ async def record_decision(
     provider: str | None,
     model: str | None,
     expires_at: Any | None = None,
+    memory_turns_used: int | None = None,
+    memory_window_minutes: int | None = None,
+    memory_scan_attempted: bool | None = None,
+    memory_scan_added_turns: int | None = None,
+    effective_source: str | None = None,
+    effective_mode: str | None = None,
 ) -> int:
+    """Insert one ai_decision_audit row.
+
+    Migration 045 added the ``memory_*`` / ``effective_*`` columns;
+    they are nullable so legacy callers continue to work without
+    changes. The natural-language stage threads these on every
+    record (effective fields always; memory fields on the
+    ``decision='replied'`` branch only).
+    """
     row = await pool.get().fetchrow(
         """
         INSERT INTO ai_decision_audit (
             guild_id, channel_id, category_id, user_id, message_id,
             task, route, decision, reason_code, policy_snapshot_hash,
-            instruction_profile_ids, provider, model, created_at, expires_at
+            instruction_profile_ids, provider, model, created_at, expires_at,
+            memory_turns_used, memory_window_minutes, memory_scan_attempted,
+            memory_scan_added_turns, effective_source, effective_mode
         ) VALUES (
-            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NOW(), $14
+            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NOW(), $14,
+            $15, $16, $17, $18, $19, $20
         )
         RETURNING id
         """,
@@ -496,6 +513,12 @@ async def record_decision(
         provider,
         model,
         expires_at,
+        memory_turns_used,
+        memory_window_minutes,
+        memory_scan_attempted,
+        memory_scan_added_turns,
+        effective_source,
+        effective_mode,
     )
     return int(row["id"])
 
@@ -511,7 +534,9 @@ async def query_decisions(
     sql = (
         "SELECT id, guild_id, channel_id, category_id, user_id, message_id,"
         " task, route, decision, reason_code, policy_snapshot_hash,"
-        " instruction_profile_ids, provider, model, created_at "
+        " instruction_profile_ids, provider, model, created_at,"
+        " memory_turns_used, memory_window_minutes, memory_scan_attempted,"
+        " memory_scan_added_turns, effective_source, effective_mode "
         "FROM ai_decision_audit WHERE guild_id = $1"
     )
     args: list[Any] = [guild_id]

--- a/disbot/views/ai/support_report.py
+++ b/disbot/views/ai/support_report.py
@@ -71,10 +71,13 @@ async def build_support_report_draft(
         lines.append("(no recent audit rows for this guild)")
     else:
         for r in rows:
+            eff_source = r.get("effective_source") or "—"
+            eff_mode = r.get("effective_mode") or "—"
             lines.append(
                 f"- decision={r.get('decision')} reason={r.get('reason_code')} "
                 f"task={r.get('task') or '—'} route={r.get('route') or '—'} "
-                f"provider={r.get('provider') or '—'} model={r.get('model') or '—'}",
+                f"provider={r.get('provider') or '—'} model={r.get('model') or '—'} "
+                f"effective={eff_source}/{eff_mode}",
             )
     lines.append("```")
     return "\n".join(lines)

--- a/docs/ai-config-ownership.md
+++ b/docs/ai-config-ownership.md
@@ -181,23 +181,30 @@ columns are nullable and render as `—` when missing or NULL.
 | `provider`, `model` | LLM invocation metadata |
 | `created_at`, `expires_at` | TTL support |
 
-### Columns added by migration 045 (PR-5)
+### Columns added by migration 045 (PR-5, shipped)
 
 All nullable; legacy rows stay NULL.
 
-| Column | Purpose |
-|---|---|
-| `memory_turns_used` | turns supplied to the prompt on a `replied` row |
-| `memory_window_minutes` | active memory window at decision time |
-| `memory_scan_attempted` | whether the Discord history scan was attempted |
-| `memory_scan_added_turns` | turns appended by the scan, if any |
-| `effective_source` | precedence scope that won (`channel` / `category` / `guild`) |
-| `effective_mode` | mode the winning source produced (`always_reply` / `mention_only` / `disabled`) |
+| Column | Purpose | Populated on |
+|---|---|---|
+| `memory_turns_used` | turns supplied to the prompt on a `replied` row | `replied` only |
+| `memory_window_minutes` | active memory window at decision time | `replied` only |
+| `memory_scan_attempted` | whether the Discord history scan was attempted | `replied` only |
+| `memory_scan_added_turns` | turns appended by the scan, if any | `replied` only |
+| `effective_source` | precedence scope that won (`channel` / `category` / `guild`) | every record() call that has a `PolicyDecision` |
+| `effective_mode` | mode the winning source produced (`always_reply` / `mention_only` / `disabled`) | every record() call that has a `PolicyDecision` |
 
 **Legacy-NULL rendering rule (I-4):** `_format_audit_row` in
-`disbot/cogs/ai_cog.py` and the support-report renderer must render
-`—` when any PR-5 field is NULL on the row being formatted. The cog
-test asserts this on a synthetic legacy row.
+`disbot/cogs/ai_cog.py` and the support-report draft renderer must
+render `—` when any PR-5 field is NULL on the row being formatted.
+Pinned by `tests/unit/cogs/test_format_audit_row_legacy_null.py`.
+
+**Memory helper migration:** PR-5 introduces
+`ai_memory_service.gather_recent_turns_with_metadata` returning a
+`MemoryGatherResult(turns, window_minutes, scan_attempted,
+scan_added_turns)` dataclass. The legacy `gather_recent_turns(...)`
+is kept intact for current callsites; only the natural-language
+stage migrates to the metadata-aware helper.
 
 ---
 

--- a/tests/unit/cogs/test_format_audit_row_legacy_null.py
+++ b/tests/unit/cogs/test_format_audit_row_legacy_null.py
@@ -1,0 +1,120 @@
+"""PR-5 — _format_audit_row renders ``—`` for legacy-NULL columns.
+
+Pin per ``docs/ai-config-ownership.md`` § "Audit fields" (the I-4
+legacy-NULL rendering rule): the cog's audit-row formatter and the
+support-report draft renderer must tolerate rows missing the
+migration-045 ``effective_source`` / ``effective_mode`` columns,
+producing ``—`` placeholders without raising.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cogs.ai_cog import _format_audit_row
+from views.ai.support_report import build_support_report_draft
+
+
+def _legacy_row(**overrides) -> dict:
+    """Pre-migration-045 audit row — none of the new columns present."""
+    base = {
+        "id": 1,
+        "guild_id": 1,
+        "channel_id": 100,
+        "user_id": 42,
+        "task": "general.nl_answer",
+        "route": "openai",
+        "decision": "denied",
+        "reason_code": "below_min_level",
+        "provider": "openai",
+        "model": "gpt-4o-mini",
+        "created_at": datetime(2026, 5, 25, 12, 0, tzinfo=timezone.utc),
+    }
+    base.update(overrides)
+    return base
+
+
+def _post_migration_row_with_nulls(**overrides) -> dict:
+    """Post-migration row where the new columns exist but are NULL —
+    most commonly a denial row that did not produce a reply."""
+    base = _legacy_row(
+        effective_source=None,
+        effective_mode=None,
+        memory_turns_used=None,
+        memory_window_minutes=None,
+        memory_scan_attempted=None,
+        memory_scan_added_turns=None,
+    )
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# _format_audit_row
+# ---------------------------------------------------------------------------
+
+
+def test_format_audit_row_does_not_raise_on_legacy_row():
+    """A pre-migration row has no ``effective_source`` key at all.
+    The formatter must tolerate this without KeyError."""
+    line = _format_audit_row(_legacy_row())
+    assert "—" in line  # the missing effective_*/* fields render as dash
+
+
+def test_format_audit_row_renders_dash_for_null_effective_fields():
+    line = _format_audit_row(_post_migration_row_with_nulls())
+    assert "effective=—/—" in line
+
+
+def test_format_audit_row_renders_populated_effective_fields():
+    line = _format_audit_row(
+        _post_migration_row_with_nulls(
+            effective_source="channel",
+            effective_mode="always_reply",
+        ),
+    )
+    assert "effective=channel/always_reply" in line
+
+
+# ---------------------------------------------------------------------------
+# build_support_report_draft
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_support_report_draft_tolerates_legacy_rows(monkeypatch):
+    from services import ai_decision_audit_service
+
+    monkeypatch.setattr(
+        ai_decision_audit_service,
+        "query",
+        AsyncMock(return_value=[_legacy_row()]),
+    )
+
+    draft = await build_support_report_draft(guild_id=1, bot_user_id=42)
+    # Audit-row body line renders ``effective=—/—`` for the legacy row.
+    assert "effective=—/—" in draft
+
+
+@pytest.mark.asyncio
+async def test_support_report_draft_renders_post_migration_fields(monkeypatch):
+    from services import ai_decision_audit_service
+
+    monkeypatch.setattr(
+        ai_decision_audit_service,
+        "query",
+        AsyncMock(
+            return_value=[
+                _post_migration_row_with_nulls(
+                    effective_source="channel",
+                    effective_mode="mention_only",
+                ),
+            ],
+        ),
+    )
+
+    draft = await build_support_report_draft(guild_id=1, bot_user_id=42)
+    assert "effective=channel/mention_only" in draft

--- a/tests/unit/runtime/ai/test_natural_language_stage_audit_fields.py
+++ b/tests/unit/runtime/ai/test_natural_language_stage_audit_fields.py
@@ -1,0 +1,249 @@
+"""PR-5 — natural-language stage threads effective_source/mode and memory
+metadata into the ai_decision_audit row.
+
+Pins:
+
+* Every ``record(...)`` call from the stage (denied / errored /
+  skipped / degraded / replied) passes ``effective_source`` and
+  ``effective_mode`` derived from the resolver's ``PolicyDecision``.
+* The ``replied`` branch additionally passes
+  ``memory_turns_used``, ``memory_window_minutes``,
+  ``memory_scan_attempted``, ``memory_scan_added_turns`` from the
+  metadata-aware memory helper.
+* Other branches (denied / errored / skipped / degraded) leave the
+  memory_* kwargs unset (None) — they did not produce a reply.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from core.runtime.ai.contracts import AIResponse, AITask, PolicyDenialReason
+from core.runtime.ai.natural_language_stage import AINaturalLanguageStage
+from core.runtime.message_pipeline import MessagePipelineContext
+from services import ai_conversation_service, ai_memory_service
+from services.ai_natural_language_policy import PolicyDecision
+
+
+@pytest.fixture(autouse=True)
+def _reset_buffers():
+    ai_conversation_service._reset_for_tests()
+    yield
+    ai_conversation_service._reset_for_tests()
+
+
+def _make_message(
+    *,
+    content: str = "hello",
+    guild_id: int = 99,
+    channel_id: int = 1,
+    user_id: int = 42,
+):
+    msg = MagicMock()
+    msg.content = content
+    msg.id = 555
+    msg.guild = MagicMock()
+    msg.guild.id = guild_id
+    msg.channel = MagicMock()
+    msg.channel.id = channel_id
+    msg.channel.category_id = None
+    msg.channel.send = AsyncMock()
+    msg.author = MagicMock()
+    msg.author.id = user_id
+    msg.author.bot = False
+    msg.author.roles = []
+    return msg
+
+
+def _make_ctx(message):
+    bot = MagicMock()
+    bot.user = SimpleNamespace(mentioned_in=lambda _msg: False)
+    return MessagePipelineContext(bot=bot, message=message)
+
+
+def _patch_common(monkeypatch):
+    """Stub the snapshot and permission helpers that always run."""
+    from core.runtime.ai import natural_language_stage as mod
+
+    monkeypatch.setattr(
+        mod.ai_permission_service,
+        "snapshot",
+        AsyncMock(return_value=SimpleNamespace(level=10, is_fresh_user=False)),
+    )
+    monkeypatch.setattr(
+        mod.ai_permission_service,
+        "is_on_cooldown",
+        lambda *_a, **_kw: False,
+    )
+    monkeypatch.setattr(
+        mod.ai_permission_service,
+        "mark_reply_sent",
+        lambda *_a, **_kw: None,
+    )
+
+
+def _capture_record(monkeypatch) -> list[dict]:
+    """Replace ai_decision_audit_service.record with a kwargs capturer."""
+    from core.runtime.ai import natural_language_stage as mod
+
+    captured: list[dict] = []
+
+    async def _capture(**kwargs):
+        captured.append(kwargs)
+        return len(captured)
+
+    monkeypatch.setattr(mod.ai_decision_audit_service, "record", _capture)
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# Denied branch — effective fields populated, memory fields absent.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_denied_branch_carries_effective_source_and_mode(monkeypatch):
+    from core.runtime.ai import natural_language_stage as mod
+
+    _patch_common(monkeypatch)
+    captured = _capture_record(monkeypatch)
+    monkeypatch.setattr(
+        mod.ai_natural_language_policy,
+        "resolve",
+        AsyncMock(
+            return_value=PolicyDecision(
+                allowed=False,
+                reason_code=PolicyDenialReason.CHANNEL_DISABLED,
+                effective_min_level=2,
+                effective_cooldown=30,
+                effective_mode="disabled",
+                effective_source="channel",
+                policy_snapshot_hash="h",
+            ),
+        ),
+    )
+
+    stage = AINaturalLanguageStage()
+    msg = _make_message(content="hello world")
+    await stage.process(_make_ctx(msg))
+
+    row = captured[0]
+    assert row["decision"] == "denied"
+    assert row["effective_source"] == "channel"
+    assert row["effective_mode"] == "disabled"
+    # Memory fields are not threaded on the denied branch — they
+    # remain unset (the helper defaults them to None at the DB layer).
+    assert "memory_turns_used" not in row
+    assert "memory_window_minutes" not in row
+
+
+# ---------------------------------------------------------------------------
+# Replied branch — full memory + effective metadata.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_replied_branch_carries_memory_and_effective_metadata(monkeypatch):
+    from core.runtime.ai import natural_language_stage as mod
+
+    _patch_common(monkeypatch)
+    captured = _capture_record(monkeypatch)
+
+    monkeypatch.setattr(
+        mod.ai_natural_language_policy,
+        "resolve",
+        AsyncMock(
+            return_value=PolicyDecision(
+                allowed=True,
+                reason_code=PolicyDenialReason.NONE,
+                effective_min_level=2,
+                effective_cooldown=30,
+                effective_mode="always_reply",
+                effective_source="guild",
+                policy_snapshot_hash="h",
+            ),
+        ),
+    )
+
+    # Memory helper returns metadata with a populated turn list.
+    fake_result = ai_memory_service.MemoryGatherResult(
+        turns=[
+            ai_conversation_service.ConversationTurn(
+                user_id=1, role="user", text="prior", ts=1.0,
+            ),
+            ai_conversation_service.ConversationTurn(
+                user_id=1, role="user", text="more prior", ts=2.0,
+            ),
+            ai_conversation_service.ConversationTurn(
+                user_id=1, role="user", text="hello world", ts=3.0,
+            ),
+        ],
+        window_minutes=30,
+        scan_attempted=True,
+        scan_added_turns=1,
+    )
+    monkeypatch.setattr(
+        mod.ai_memory_service if hasattr(mod, "ai_memory_service") else ai_memory_service,
+        "gather_recent_turns_with_metadata",
+        AsyncMock(return_value=fake_result),
+    )
+    # The stage imports ai_memory_service inside the function body, so
+    # also patch at the source.
+    monkeypatch.setattr(
+        ai_memory_service,
+        "gather_recent_turns_with_metadata",
+        AsyncMock(return_value=fake_result),
+    )
+
+    # Stub the instruction stack assembly and context build to return
+    # minimal valid objects.
+    monkeypatch.setattr(
+        mod.ai_instruction_service,
+        "assemble",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                instruction_profile_ids=(),
+                system_instructions="",
+                feature_instructions="",
+                user_message="hello world",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        mod.ai_context_service,
+        "build",
+        lambda **_kw: SimpleNamespace(),
+    )
+    # Gateway returns a non-empty reply.
+    monkeypatch.setattr(
+        mod,
+        "_invoke_gateway",
+        AsyncMock(
+            return_value=AIResponse(
+                task=AITask.GENERAL_NL_ANSWER,
+                provider="openai",
+                model="gpt-4o-mini",
+                text="hi there",
+                degraded=False,
+            ),
+        ),
+    )
+
+    stage = AINaturalLanguageStage()
+    msg = _make_message(content="hello world")
+    await stage.process(_make_ctx(msg))
+
+    # The last record() call is the `replied` row.
+    row = captured[-1]
+    assert row["decision"] == "replied"
+    assert row["effective_source"] == "guild"
+    assert row["effective_mode"] == "always_reply"
+    assert row["memory_turns_used"] == 3
+    assert row["memory_window_minutes"] == 30
+    assert row["memory_scan_attempted"] is True
+    assert row["memory_scan_added_turns"] == 1
+    assert row["provider"] == "openai"
+    assert row["model"] == "gpt-4o-mini"

--- a/tests/unit/services/test_ai_decision_audit_service.py
+++ b/tests/unit/services/test_ai_decision_audit_service.py
@@ -112,3 +112,61 @@ async def test_no_raw_message_content_is_stored(_stub_db):
     assert "text" not in sig.parameters
     assert "content" not in sig.parameters
     assert "message_text" not in sig.parameters
+
+
+# ---------------------------------------------------------------------------
+# PR-5 (migration 045) — new columns round-trip through record().
+# ---------------------------------------------------------------------------
+
+
+async def test_pr5_memory_and_effective_kwargs_pass_through(_stub_db):
+    """Memory-* and effective-* kwargs reach ai_db.record_decision."""
+    await svc.record(
+        guild_id=1,
+        channel_id=2,
+        category_id=None,
+        user_id=3,
+        message_id=4,
+        task="general.nl_answer",
+        route="openai",
+        decision="replied",
+        reason_code=PolicyDenialReason.NONE,
+        provider="openai",
+        model="gpt-4o-mini",
+        memory_turns_used=7,
+        memory_window_minutes=30,
+        memory_scan_attempted=True,
+        memory_scan_added_turns=2,
+        effective_source="channel",
+        effective_mode="always_reply",
+    )
+    row = _stub_db[0]
+    assert row["memory_turns_used"] == 7
+    assert row["memory_window_minutes"] == 30
+    assert row["memory_scan_attempted"] is True
+    assert row["memory_scan_added_turns"] == 2
+    assert row["effective_source"] == "channel"
+    assert row["effective_mode"] == "always_reply"
+
+
+async def test_pr5_columns_default_to_none(_stub_db):
+    """Legacy callers that omit the new kwargs get NULL (None) for
+    all six migration-045 columns."""
+    await svc.record(
+        guild_id=1,
+        channel_id=2,
+        category_id=None,
+        user_id=3,
+        message_id=4,
+        task=None,
+        route=None,
+        decision="denied",
+        reason_code=PolicyDenialReason.BELOW_MIN_LEVEL,
+    )
+    row = _stub_db[0]
+    assert row["memory_turns_used"] is None
+    assert row["memory_window_minutes"] is None
+    assert row["memory_scan_attempted"] is None
+    assert row["memory_scan_added_turns"] is None
+    assert row["effective_source"] is None
+    assert row["effective_mode"] is None

--- a/tests/unit/services/test_ai_memory_gather_metadata.py
+++ b/tests/unit/services/test_ai_memory_gather_metadata.py
@@ -1,0 +1,171 @@
+"""PR-5 — gather_recent_turns_with_metadata returns scan metadata.
+
+Pins:
+
+* New helper returns a :class:`MemoryGatherResult` dataclass carrying
+  ``turns`` plus ``window_minutes`` / ``scan_attempted`` /
+  ``scan_added_turns``.
+* The legacy ``gather_recent_turns`` is unchanged and still returns a
+  bare list — so existing callsites do not break.
+* When the buffer already has ``MIN_FLOOR_TURNS`` content, no scan is
+  attempted (``scan_attempted=False``, ``scan_added_turns=0``).
+* When the buffer is short and ``channel_scan_enabled=True``, the
+  scan attempt is recorded and the added-turn count reflects what
+  the seed appended.
+* Scan disabled → ``scan_attempted=False`` regardless of buffer state.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from services import ai_conversation_service, ai_memory_service
+
+
+@pytest.fixture(autouse=True)
+def _reset_buffers():
+    ai_conversation_service._reset_for_tests()
+    yield
+    ai_conversation_service._reset_for_tests()
+
+
+def _patch_settings(monkeypatch, *, window: int, scan: bool) -> None:
+    async def _read(_guild_id):
+        return window, scan
+
+    monkeypatch.setattr(ai_memory_service, "read_memory_settings", _read)
+
+
+@pytest.mark.asyncio
+async def test_legacy_helper_signature_unchanged():
+    """``gather_recent_turns`` still returns a bare list."""
+    import inspect
+
+    sig = inspect.signature(ai_memory_service.gather_recent_turns)
+    assert list(sig.parameters.keys()) == [
+        "guild_id",
+        "channel_id",
+        "channel",
+        "bot_user_id",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_metadata_helper_returns_dataclass(monkeypatch):
+    _patch_settings(monkeypatch, window=30, scan=False)
+    ai_conversation_service.append(1, 100, user_id=1, role="user", text="a")
+    ai_conversation_service.append(1, 100, user_id=1, role="user", text="b")
+    ai_conversation_service.append(1, 100, user_id=1, role="user", text="c")
+    ai_conversation_service.append(1, 100, user_id=1, role="user", text="d")
+
+    result = await ai_memory_service.gather_recent_turns_with_metadata(
+        guild_id=1,
+        channel_id=100,
+    )
+    assert isinstance(result, ai_memory_service.MemoryGatherResult)
+    assert len(result.turns) == 4
+    assert result.window_minutes == 30
+    # Buffer is well above MIN_FLOOR_TURNS — no scan attempted.
+    assert result.scan_attempted is False
+    assert result.scan_added_turns == 0
+
+
+@pytest.mark.asyncio
+async def test_metadata_helper_records_window_zero(monkeypatch):
+    _patch_settings(monkeypatch, window=0, scan=False)
+    ai_conversation_service.append(1, 100, user_id=1, role="user", text="a")
+
+    result = await ai_memory_service.gather_recent_turns_with_metadata(
+        guild_id=1,
+        channel_id=100,
+    )
+    assert result.window_minutes == 0
+    assert result.scan_attempted is False
+
+
+@pytest.mark.asyncio
+async def test_metadata_helper_no_scan_when_disabled(monkeypatch):
+    """Even on an empty buffer, scan stays off when ``scan=False``."""
+    _patch_settings(monkeypatch, window=30, scan=False)
+
+    class _FakeChannel:
+        async def history(self, **_kw):
+            # Would yield messages — but the helper must not call this
+            # when scan is disabled. The test asserts via scan_attempted=False.
+            for _ in range(0):
+                yield None
+
+    result = await ai_memory_service.gather_recent_turns_with_metadata(
+        guild_id=1,
+        channel_id=100,
+        channel=_FakeChannel(),
+    )
+    assert result.scan_attempted is False
+    assert result.scan_added_turns == 0
+
+
+@pytest.mark.asyncio
+async def test_metadata_helper_scan_attempted_when_buffer_short(monkeypatch):
+    """Scan enabled + buffer below floor → attempt recorded."""
+    _patch_settings(monkeypatch, window=30, scan=True)
+
+    seeded_messages: list[tuple[int, str]] = [
+        (1, "hello"),
+        (2, "world"),
+    ]
+
+    class _FakeMessage:
+        def __init__(self, author_id, content):
+            self.author = type("A", (), {"id": author_id, "bot": False})()
+            self.content = content
+
+            class _CreatedAt:
+                def timestamp(self):
+                    return 1700000000.0
+
+            self.created_at = _CreatedAt()
+
+    class _FakeChannel:
+        def history(self, **_kw):
+            messages = [_FakeMessage(uid, body) for uid, body in seeded_messages]
+
+            async def _gen():
+                for m in messages:
+                    yield m
+
+            return _gen()
+
+    result = await ai_memory_service.gather_recent_turns_with_metadata(
+        guild_id=1,
+        channel_id=100,
+        channel=_FakeChannel(),
+        bot_user_id=999,
+    )
+    assert result.scan_attempted is True
+    # The seed appended at least the two messages we mocked.
+    assert result.scan_added_turns >= 1
+
+
+@pytest.mark.asyncio
+async def test_metadata_helper_scan_failure_does_not_raise(monkeypatch):
+    """If the scan helper raises, the result still returns the buffer
+    contents with ``scan_attempted=True, scan_added_turns=0``."""
+    _patch_settings(monkeypatch, window=30, scan=True)
+
+    class _BrokenChannel:
+        def history(self, **_kw):
+            async def _gen():
+                yield None
+                raise RuntimeError("network down")
+
+            return _gen()
+
+    result = await ai_memory_service.gather_recent_turns_with_metadata(
+        guild_id=1,
+        channel_id=100,
+        channel=_BrokenChannel(),
+        bot_user_id=999,
+    )
+    assert result.scan_attempted is True
+    # Best-effort: failure surfaces as zero added turns rather than raising.
+    assert result.scan_added_turns == 0


### PR DESCRIPTION
## Summary

Stacked on **#325 (PR-4B)**. PR-5 of the AI cog refinement plan — the **only schema-changing PR** in the sequence. Makes the audit table the post-hoc answer to "what memory did this reply use, and which scope won precedence?".

Merge stack: #323 → #324 → #325 → #326 → main.

## Schema

New migration `disbot/migrations/045_ai_decision_audit_memory.sql` — additive, nullable, idempotent, safe to apply after migration 039. Adds six columns to `ai_decision_audit`:

| Column | Type | Populated on |
|---|---|---|
| `memory_turns_used` | INTEGER | `replied` only |
| `memory_window_minutes` | INTEGER | `replied` only |
| `memory_scan_attempted` | BOOLEAN | `replied` only |
| `memory_scan_added_turns` | INTEGER | `replied` only |
| `effective_source` | TEXT | every record() with a PolicyDecision |
| `effective_mode` | TEXT | every record() with a PolicyDecision |

All nullable; legacy rows stay NULL.

## Writers

- **`utils/db/ai.py`** — `record_decision` accepts the new kwargs; `query_decisions` selects them.
- **`services/ai_decision_audit_service.py`** — `record` passes new kwargs through; default `None` so legacy callers don't break.
- **`services/ai_memory_service.py`** — new `gather_recent_turns_with_metadata` returns a `MemoryGatherResult(turns, window_minutes, scan_attempted, scan_added_turns)` dataclass. The legacy `gather_recent_turns(...)` stays unchanged for current callsites (non-breaking per the plan's revision #5).
- **`core/runtime/ai/natural_language_stage.py`** — switched to the metadata-aware helper; threads `effective_source` + `effective_mode` from `PolicyDecision` on every `record()` call. Memory fields populated on the `replied` branch only.

## Readers (I-4 legacy-NULL rendering rule)

- **`cogs/ai_cog.py:_format_audit_row`** and **`views/ai/support_report.py:build_support_report_draft`** append `effective=<source>/<mode>` to each rendered audit line; legacy rows (and post-045 branches that did not populate the columns) render `—` for both halves rather than raising.

## Doc

`docs/ai-config-ownership.md` § "Audit fields" updated with the full column inventory, the "populated on" column, the I-4 legacy-NULL rendering rule, and the non-breaking memory-helper migration note.

## Tests

- **Extended** `tests/unit/services/test_ai_decision_audit_service.py` — two PR-5 round-trip cases (kwargs pass through; default-None semantics).
- **New** `tests/unit/services/test_ai_memory_gather_metadata.py` (6 cases) — legacy helper signature unchanged, new dataclass returned, scan_attempted/scan_added across disabled / enabled / failure / window=0 / well-stocked-buffer.
- **New** `tests/unit/runtime/ai/test_natural_language_stage_audit_fields.py` (2 cases) — denied branch carries effective_* with no memory_*; replied branch carries the full memory + effective metadata.
- **New** `tests/unit/cogs/test_format_audit_row_legacy_null.py` (5 cases) — formatter tolerates pre-migration rows, renders `—` for NULL post-migration rows, populates the field correctly when present. Same surface check on the support-report draft.

## Test plan

- [x] All new + existing PR-1–5 AI tests: 269 / 269 passing
- [x] black / isort / ruff / mypy clean locally
- [ ] CI
- [ ] **Manual migration smoke before merge:** apply 045 against a throwaway DB post-039, confirm columns are added as nullable, and run `!ai why-no-response` against a pre-045 row to confirm the renderer outputs `—` without raising. (CI does not have a Postgres instance, so this remains an operator check.)

## Compatibility

- Schema migration is additive + nullable + idempotent (mirrors migration 039's pattern).
- The legacy `gather_recent_turns` helper is intact — every existing callsite still works.
- No new mutation paths or service contracts.

https://claude.ai/code/session_01Y5cC77Jyce8JEyt8HtTK6S

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5cC77Jyce8JEyt8HtTK6S)_