### PR TITLE
feat(ai): guild-scope behavior preset + instruction-profile cleanup (PR-6)

### DIFF
--- a/disbot/cogs/ai/schemas.py
+++ b/disbot/cogs/ai/schemas.py
@@ -209,12 +209,20 @@ AI_SETTINGS: tuple[SettingSpec, ...] = (
         capability_required=_CAPABILITY,
         hint=(
             "Free-text guild-wide instruction body that prefixes every "
-            "AI prompt for this guild. Transitional scalar seed: M2 "
-            "backfills this into a typed ai_instruction_profile row "
-            "named 'default' and the typed table becomes the runtime "
-            "source of truth."
+            "AI prompt for this guild. **Edited via the AI Behavior "
+            "chooser** — the typed `ai_instruction_profile` row is the "
+            "authoritative source. This scalar is retained for "
+            "backcompat reads only and is hidden from the primary "
+            "settings panel."
         ),
         validator=_validate_str,
+        # PR-6: hide from the auto-rendered settings panel. The
+        # Behavior chooser's "Edit guild instruction" modal is the
+        # authoritative editor — it writes through
+        # ai_instruction_mutation.upsert_profile and binds the resulting
+        # profile id via ai_policy_mutation.set_guild_policy. See
+        # docs/ai-config-ownership.md § "Resolved semantics".
+        hidden_from_panel=True,
     ),
     SettingSpec(
         name="ai_memory_window_minutes",

--- a/disbot/core/runtime/subsystem_schema.py
+++ b/disbot/core/runtime/subsystem_schema.py
@@ -177,6 +177,13 @@ class SettingSpec:
     allowed_values: tuple[Any, ...] = ()
     input_hint: str = ""
     presets: tuple[Any, ...] = ()
+    # True when the setting should NOT be rendered or editable through
+    # the generic per-subsystem settings panel — the subsystem provides
+    # a dedicated editor surface (e.g. a modal in the Behavior chooser).
+    # The KV row is preserved for backcompat reads but operators must
+    # use the dedicated surface to write to it. Defaults to False so
+    # existing settings stay visible.
+    hidden_from_panel: bool = False
 
 
 @dataclass(frozen=True)

--- a/disbot/services/ai_behavior_profile_service.py
+++ b/disbot/services/ai_behavior_profile_service.py
@@ -54,6 +54,17 @@ class InvalidBehaviorPresetScopeError(BehaviorPresetError):
     pass
 
 
+class GuildScopeNotSupportedError(BehaviorPresetError):
+    """Raised when a preset's recommended mode cannot be expressed at
+    guild scope.
+
+    The typed ``ai_guild_policy.natural_language_enabled`` column is
+    boolean — it has no third state for ``mention_only``. Operators
+    who want mention-only behavior must apply the preset to a
+    category or channel instead.
+    """
+
+
 # ---------------------------------------------------------------------------
 # Catalog metadata
 # ---------------------------------------------------------------------------
@@ -148,7 +159,15 @@ class BehaviorApplyResult:
 # ---------------------------------------------------------------------------
 
 
-_SUPPORTED_SCOPES: frozenset[str] = frozenset({"channel", "category"})
+_SUPPORTED_SCOPES: frozenset[str] = frozenset({"channel", "category", "guild"})
+
+# Fields the guild preset application owns. Every other column on
+# ``ai_guild_policy`` is read from the current row and passed through
+# ``set_guild_policy`` unchanged — the preservation invariant in PR-6.
+_PRESET_OWNED_GUILD_FIELDS: tuple[str, ...] = (
+    "guild_instruction_profile_id",
+    "natural_language_enabled",
+)
 
 
 async def list_presets() -> list[BehaviorPresetSummary]:
@@ -203,21 +222,40 @@ async def apply_preset(
     *,
     guild_id: int,
     scope: str,
-    target_id: int,
+    target_id: int | None,
     preset_id: int,
     actor: Any,
 ) -> BehaviorApplyResult:
     """Bind a preset id into the matching policy scope.
 
-    ``scope`` must be one of :data:`_SUPPORTED_SCOPES`. The preset's
-    recommended mode and the preset id are written; other optional
-    columns (``min_level``, ``cooldown_seconds``) are passed as
+    ``scope`` must be one of :data:`_SUPPORTED_SCOPES`. For
+    ``channel`` / ``category`` scopes the preset's recommended mode
+    and the preset id are written; other optional columns
+    (``min_level``, ``cooldown_seconds``) are passed as
     :data:`ai_policy_mutation.UNCHANGED` so any existing per-scope
-    overrides are preserved across preset applies.
+    overrides are preserved.
+
+    For ``scope='guild'`` this delegates to
+    :func:`apply_preset_to_guild` (``target_id`` ignored). The guild
+    path enforces the preservation invariant: every existing
+    ``ai_guild_policy`` field NOT owned by the preset is passed
+    through unchanged.
     """
     if scope not in _SUPPORTED_SCOPES:
         raise InvalidBehaviorPresetScopeError(
             f"scope must be one of {sorted(_SUPPORTED_SCOPES)}, got {scope!r}",
+        )
+
+    if scope == "guild":
+        return await apply_preset_to_guild(
+            guild_id=guild_id,
+            preset_id=preset_id,
+            actor=actor,
+        )
+
+    if target_id is None:
+        raise InvalidBehaviorPresetScopeError(
+            f"scope={scope!r} requires a target_id",
         )
 
     summary = await describe_preset(preset_id)
@@ -257,15 +295,87 @@ async def apply_preset(
     )
 
 
+async def apply_preset_to_guild(
+    *,
+    guild_id: int,
+    preset_id: int,
+    actor: Any,
+) -> BehaviorApplyResult:
+    """Bind a preset id into ``ai_guild_policy.guild_instruction_profile_id``.
+
+    Preservation invariant (PR-6):
+
+    1. Read the current ``ai_guild_policy`` row.
+    2. Apply only the preset-owned fields
+       (:data:`_PRESET_OWNED_GUILD_FIELDS`):
+       ``guild_instruction_profile_id`` and ``natural_language_enabled``.
+    3. Pass every other field through
+       :func:`ai_policy_mutation.set_guild_policy` **unchanged** from
+       the current row (or its declared default when the row is empty).
+
+    ``mention_only`` presets are rejected with
+    :class:`GuildScopeNotSupportedError` because the typed
+    ``natural_language_enabled`` column has no third state. The UI
+    hides ``mention_only`` cards from the guild button per the same
+    rule; the service-side check is the safety net.
+    """
+    summary = await describe_preset(preset_id)
+    if summary is None:
+        raise UnknownBehaviorPresetError(
+            f"preset_id={preset_id} not found or not flagged is_preset=True",
+        )
+
+    mode = summary.recommended_mode
+    if mode == "mention_only":
+        raise GuildScopeNotSupportedError(
+            "mention_only is not supported at guild scope — apply this "
+            "preset to a category or channel instead. The typed "
+            "ai_guild_policy.natural_language_enabled column is boolean; "
+            "mention-only behavior must come from a scoped override.",
+        )
+    nl_enabled = mode == "always_reply"  # disabled → False
+
+    # Read current row so we can preserve every non-preset-owned field.
+    current = await ai_db.get_guild_policy(guild_id) or {}
+
+    result = await ai_policy_mutation.set_guild_policy(
+        guild_id,
+        enabled=bool(current.get("enabled", False)),
+        natural_language_enabled=nl_enabled,
+        default_provider=str(
+            current.get("default_provider", "deterministic") or "deterministic"
+        ),
+        default_model=str(current.get("default_model", "") or ""),
+        minimum_level_default=int(current.get("minimum_level_default", 2)),
+        cooldown_seconds=int(current.get("cooldown_seconds", 30)),
+        fresh_user_mention_allowance=int(
+            current.get("fresh_user_mention_allowance", 1)
+        ),
+        guild_instruction_profile_id=preset_id,
+        actor=actor,
+    )
+
+    return BehaviorApplyResult(
+        scope="guild",
+        target_id=guild_id,
+        preset_id=preset_id,
+        preset_key=summary.key,
+        recommended_mode=summary.recommended_mode,
+        policy_mutation_id=result.mutation_id,
+    )
+
+
 __all__ = [
     "BehaviorApplyResult",
     "BehaviorPresetCatalogEntry",
     "BehaviorPresetError",
     "BehaviorPresetSummary",
+    "GuildScopeNotSupportedError",
     "InvalidBehaviorPresetScopeError",
     "PRESET_KEYS",
     "UnknownBehaviorPresetError",
     "apply_preset",
+    "apply_preset_to_guild",
     "describe_preset",
     "list_presets",
 ]

--- a/disbot/views/ai/behavior/chooser.py
+++ b/disbot/views/ai/behavior/chooser.py
@@ -133,6 +133,57 @@ class BehaviorChooserView(discord.ui.View):
         )
 
     @discord.ui.button(
+        label="Guild",
+        style=discord.ButtonStyle.primary,
+        row=0,
+    )
+    async def guild_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        # PR-6: open the guild-scope preset picker. The picker filters
+        # out ``mention_only`` presets — the typed guild policy has no
+        # third state, so mention-only behavior must come from a
+        # scoped override.
+        from views.ai.behavior.preset_picker import PresetPickerView
+
+        guild_id = interaction.guild_id
+        await interaction.response.send_message(
+            "Pick a preset to bind at **guild scope**. `mention_only` "
+            "presets are hidden — apply those to a category or channel "
+            "instead. Other policy fields (provider, model, cooldown, "
+            "min level) are preserved.",
+            view=PresetPickerView(
+                scope="guild",
+                target_id=guild_id if guild_id is not None else 0,
+                target_label="this guild",
+            ),
+            ephemeral=True,
+        )
+
+    @discord.ui.button(
+        label="Edit guild instruction",
+        style=discord.ButtonStyle.secondary,
+        row=2,
+    )
+    async def edit_guild_instruction_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        # PR-6: open the guild instruction-profile editor modal. The
+        # ``ai_guild_instruction_profile`` legacy scalar is hidden from
+        # the primary settings panel; this modal is the authoritative
+        # editor and writes through ``ai_instruction_mutation`` +
+        # ``ai_policy_mutation``.
+        from views.ai.behavior.instruction_modal import (
+            GuildInstructionProfileModal,
+        )
+
+        await interaction.response.send_modal(GuildInstructionProfileModal())
+
+    @discord.ui.button(
         label="Preview (dry-run)",
         style=discord.ButtonStyle.secondary,
         row=1,

--- a/disbot/views/ai/behavior/instruction_modal.py
+++ b/disbot/views/ai/behavior/instruction_modal.py
@@ -1,0 +1,151 @@
+"""Guild instruction-profile editor modal (PR-6).
+
+Authoritative writer for guild-scope AI instruction bodies. The
+legacy ``ai_guild_instruction_profile`` scalar is hidden from the
+primary settings panel (see ``cogs/ai/schemas.py:hidden_from_panel``);
+operators edit the typed-table row through this modal instead.
+
+Write path: ``ai_instruction_mutation.upsert_profile`` → captures the
+returned profile id → ``ai_policy_mutation.set_guild_policy`` to bind
+the profile id into ``ai_guild_policy.guild_instruction_profile_id``
+(preserving every other guild-policy field per PR-6's preservation
+invariant).
+
+Read path: the modal pre-fills its body from the current
+``ai_instruction_profile`` row (if one is bound), so the operator
+sees what they are editing rather than a blank field.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import discord
+
+logger = logging.getLogger("bot.views.ai.behavior.instruction_modal")
+
+# Discord modal TextInput max-length cap (paragraph style).
+_BODY_MAX_LENGTH = 4000
+
+# Canonical name for the guild-default profile row. Mirrors the
+# planned M2 backfill ("default") so the typed table has one well-
+# known row per guild.
+_GUILD_PROFILE_NAME = "default"
+
+
+class GuildInstructionProfileModal(discord.ui.Modal):
+    """Edit (or create) the guild's default instruction profile.
+
+    The modal renders a single paragraph-style text input. On submit:
+
+    1. Build (or refresh) the typed ``ai_instruction_profile`` row
+       via :func:`ai_instruction_mutation.upsert_profile`.
+    2. Bind the returned profile id into
+       ``ai_guild_policy.guild_instruction_profile_id`` via
+       :func:`ai_policy_mutation.set_guild_policy` — preserving every
+       other guild-policy field per PR-6's preservation invariant.
+    3. Send an ephemeral confirmation back to the operator.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(title="Edit guild instruction profile")
+        self.body_input: discord.ui.TextInput = discord.ui.TextInput(
+            label="Instruction body",
+            style=discord.TextStyle.paragraph,
+            placeholder=(
+                "Free-text instructions that prefix every AI prompt "
+                "for this guild. Leave blank to clear."
+            ),
+            required=False,
+            max_length=_BODY_MAX_LENGTH,
+        )
+        self.add_item(self.body_input)
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        if interaction.guild_id is None:
+            await interaction.response.send_message(
+                "❌ This editor requires a guild context.",
+                ephemeral=True,
+            )
+            return
+
+        body = str(self.body_input.value or "").strip()
+
+        try:
+            profile_id = await _write_profile_and_bind(
+                guild_id=interaction.guild_id,
+                body=body,
+                actor=interaction.user,
+            )
+        except Exception as exc:  # noqa: BLE001 — surface the failure
+            logger.exception(
+                "GuildInstructionProfileModal: write failed for guild=%s",
+                interaction.guild_id,
+            )
+            await interaction.response.send_message(
+                f"❌ {type(exc).__name__}: {exc}",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.response.send_message(
+            (
+                f"✅ Guild instruction profile updated "
+                f"(profile_id=`{profile_id}`, name=`{_GUILD_PROFILE_NAME}`). "
+                "Other guild policy fields (provider, model, cooldown, "
+                "min level) were preserved."
+            ),
+            ephemeral=True,
+        )
+
+
+async def _write_profile_and_bind(
+    *,
+    guild_id: int,
+    body: str,
+    actor: Any,
+) -> int:
+    """Upsert the profile row, then bind its id into the guild policy.
+
+    Preservation invariant (PR-6): every guild-policy field NOT owned
+    by this write (everything except ``guild_instruction_profile_id``)
+    is read from the current row and passed through
+    :func:`ai_policy_mutation.set_guild_policy` unchanged.
+
+    Returns the profile id so the modal can confirm it to the operator.
+    """
+    from services import ai_instruction_mutation, ai_policy_mutation
+    from utils.db import ai as ai_db
+
+    profile_result = await ai_instruction_mutation.upsert_profile(
+        guild_id=guild_id,
+        name=_GUILD_PROFILE_NAME,
+        body=body,
+        scope="guild",
+        actor=actor,
+    )
+
+    current = await ai_db.get_guild_policy(guild_id) or {}
+    await ai_policy_mutation.set_guild_policy(
+        guild_id,
+        enabled=bool(current.get("enabled", False)),
+        natural_language_enabled=bool(
+            current.get("natural_language_enabled", False),
+        ),
+        default_provider=str(
+            current.get("default_provider", "deterministic") or "deterministic",
+        ),
+        default_model=str(current.get("default_model", "") or ""),
+        minimum_level_default=int(current.get("minimum_level_default", 2)),
+        cooldown_seconds=int(current.get("cooldown_seconds", 30)),
+        fresh_user_mention_allowance=int(
+            current.get("fresh_user_mention_allowance", 1),
+        ),
+        guild_instruction_profile_id=profile_result.profile_id,
+        actor=actor,
+    )
+    return profile_result.profile_id
+
+
+__all__ = ["GuildInstructionProfileModal"]

--- a/disbot/views/ai/behavior/preset_picker.py
+++ b/disbot/views/ai/behavior/preset_picker.py
@@ -165,6 +165,13 @@ class PresetPickerView(discord.ui.View):
         options: list[discord.SelectOption] = []
         lookup: dict[str, int] = {}
         for preset in presets[:_MAX_OPTIONS]:
+            # PR-6: hide ``mention_only`` cards from the guild button.
+            # The typed ``ai_guild_policy.natural_language_enabled``
+            # column is boolean — mention-only behavior needs a scoped
+            # override, not a guild baseline. The service-side check
+            # in ``apply_preset_to_guild`` is the safety net.
+            if self._scope == "guild" and preset.recommended_mode == "mention_only":
+                continue
             options.append(
                 discord.SelectOption(
                     label=preset.key,

--- a/disbot/views/settings/subsystem_view.py
+++ b/disbot/views/settings/subsystem_view.py
@@ -67,6 +67,8 @@ async def _resolve_settings_block(
     lines: list[str] = []
     if guild_id is None:
         for spec in schema.settings:
+            if getattr(spec, "hidden_from_panel", False):
+                continue
             lines.append(
                 f"`{spec.name}` — type=`{spec.value_type.__name__}` "
                 f"default=`{spec.default!r}` *(no guild context)*",
@@ -75,6 +77,8 @@ async def _resolve_settings_block(
     from services.settings_resolution import resolve_setting
 
     for spec in schema.settings:
+        if getattr(spec, "hidden_from_panel", False):
+            continue
         try:
             resolution = await resolve_setting(guild_id, subsystem, spec.name)
         except Exception as exc:  # noqa: BLE001 — fail-soft per panel field
@@ -381,13 +385,22 @@ def _build_no_panel_embed(subsystem: str) -> discord.Embed:
 
 
 def _editable_specs(subsystem: str) -> list:
-    """Return SettingSpec instances we can edit (subset that has a settings_key)."""
+    """Return SettingSpec instances we can edit (subset that has a settings_key).
+
+    Specs flagged ``hidden_from_panel=True`` are also excluded — they
+    declare a dedicated editor surface elsewhere (e.g. the AI Behavior
+    chooser's instruction-profile modal).
+    """
     from core.runtime.subsystem_schema import get_schema
 
     schema = get_schema(subsystem)
     if schema is None:
         return []
-    return [spec for spec in schema.settings if spec.settings_key]
+    return [
+        spec
+        for spec in schema.settings
+        if spec.settings_key and not getattr(spec, "hidden_from_panel", False)
+    ]
 
 
 class _EditSettingSelect(discord.ui.Select):

--- a/docs/ai-config-ownership.md
+++ b/docs/ai-config-ownership.md
@@ -218,17 +218,26 @@ do not relitigate them.
   The setting hint reads "Minimal — last 3 messages only" (PR-3). The
   floor is a deliberate basic-conversational-handle guarantee, not a
   bug.
-- **Instruction-profile scalar.** `ai_guild_instruction_profile` is
-  hidden from the auto-rendered subsystem settings panel (PR-6). The
-  Behavior chooser hosts the only authoritative editor; writes go
-  through `ai_instruction_mutation.upsert_profile` and then bind the
-  resulting profile id via `ai_policy_mutation.set_guild_policy`. The
-  legacy KV row is retained for backcompat reads only.
-- **`mention_only` at guild scope.** Not supported. The Behavior
-  chooser hides preset cards whose mode is `mention_only` from the
-  guild button with a tooltip explaining the restriction; the service
-  raises `GuildScopeNotSupportedError` if a caller asks for it (PR-6).
-  Apply `mention_only` to a category or channel instead.
+- **Instruction-profile scalar (PR-6, shipped).**
+  `ai_guild_instruction_profile` is hidden from the auto-rendered
+  subsystem settings panel via the new `SettingSpec.hidden_from_panel`
+  flag. The Behavior chooser's "Edit guild instruction" modal is the
+  authoritative editor; it writes through
+  `ai_instruction_mutation.upsert_profile` and then binds the resulting
+  profile id via `ai_policy_mutation.set_guild_policy` (preservation
+  invariant applies). The legacy KV row is retained for backcompat
+  reads only.
+- **`mention_only` at guild scope (PR-6, shipped).** Not supported.
+  The Behavior chooser's preset picker hides cards whose mode is
+  `mention_only` when scope=`guild`; the service raises
+  `GuildScopeNotSupportedError` if a caller asks for it. Apply
+  `mention_only` to a category or channel instead.
+- **Guild preset preservation invariant (PR-6, shipped).** A guild
+  preset application reads the current `ai_guild_policy` row, applies
+  only the two preset-owned fields
+  (`guild_instruction_profile_id`, `natural_language_enabled`), and
+  passes every other field through `set_guild_policy` unchanged.
+  Pinned by `tests/unit/services/test_ai_behavior_profile_guild_scope.py`.
 
 ---
 

--- a/tests/unit/cogs/test_ai_instruction_profile_hidden.py
+++ b/tests/unit/cogs/test_ai_instruction_profile_hidden.py
@@ -1,0 +1,75 @@
+"""PR-6 — ``ai_guild_instruction_profile`` is hidden from the primary
+settings panel.
+
+Pin: The auto-rendered subsystem settings panel (``!settings → AI``)
+must NOT list the ``ai_guild_instruction_profile`` scalar. The
+typed-table editor in the Behavior chooser is the authoritative
+write path (see ``docs/ai-config-ownership.md`` § "Resolved
+semantics" + § "Mutation seam").
+
+The setting key is retained for backcompat KV reads — schema removal
+would break the projection-trip tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cogs.ai.schemas import AI_CONFIG_SCHEMA
+
+
+@pytest.fixture(autouse=True)
+def _register_ai_schema():
+    """The AI schema is normally registered by ``AICog.cog_load``; in
+    tests we register directly so :func:`get_schema('ai')` resolves."""
+    from core.runtime import subsystem_schema
+
+    subsystem_schema.register(AI_CONFIG_SCHEMA)
+    yield
+
+
+def test_ai_guild_instruction_profile_is_hidden_from_panel():
+    """The setting is flagged ``hidden_from_panel=True``."""
+    spec = next(
+        s for s in AI_CONFIG_SCHEMA.settings if s.name == "ai_guild_instruction_profile"
+    )
+    assert getattr(spec, "hidden_from_panel", False) is True
+
+
+def test_other_ai_settings_remain_visible():
+    """Every other AI setting stays visible in the auto-rendered panel."""
+    hidden = [
+        s.name
+        for s in AI_CONFIG_SCHEMA.settings
+        if getattr(s, "hidden_from_panel", False)
+    ]
+    assert hidden == ["ai_guild_instruction_profile"]
+
+
+def test_hidden_specs_not_returned_by_editable_helper():
+    """The editable-spec helper in the settings UI filters out hidden
+    specs so the dropdown can't surface them."""
+    from views.settings.subsystem_view import _editable_specs
+
+    specs = _editable_specs("ai")
+    names = {s.name for s in specs}
+    assert "ai_guild_instruction_profile" not in names
+    # A regular scalar that IS editable stays in the list.
+    assert "ai_enabled" in names
+
+
+@pytest.mark.asyncio
+async def test_subsystem_embed_omits_hidden_scalar():
+    """``!settings → AI`` rendered embed must not show the legacy
+    free-text scalar — operators use the Behavior chooser modal."""
+    from types import SimpleNamespace
+
+    from views.settings.subsystem_view import _resolve_settings_block
+
+    # Resolve in DM context (guild_id=None) — avoids the DB read path.
+    lines = await _resolve_settings_block(None, "ai")
+    blob = "\n".join(lines)
+    assert "ai_guild_instruction_profile" not in blob
+    # Cross-check a regular setting still renders.
+    assert "ai_enabled" in blob
+    del SimpleNamespace  # silence unused-import on some linters

--- a/tests/unit/services/test_ai_behavior_profile_guild_scope.py
+++ b/tests/unit/services/test_ai_behavior_profile_guild_scope.py
@@ -1,0 +1,337 @@
+"""PR-6 — apply_preset_to_guild + guild-scope preset routing.
+
+Pins:
+
+* ``apply_preset_to_guild`` calls ``ai_policy_mutation.set_guild_policy``
+  exactly once with the two preset-owned fields
+  (``guild_instruction_profile_id``, ``natural_language_enabled``)
+  and **every other field preserved verbatim** from the current
+  ``ai_guild_policy`` row.
+* The same preservation invariant applies when ``apply_preset(scope="guild")``
+  is used as a unified dispatcher.
+* ``mention_only`` presets raise :class:`GuildScopeNotSupportedError`
+  rather than silently mapping to either bool.
+* ``_SUPPORTED_SCOPES`` includes ``"guild"`` (PR-6) — channel/category
+  also still supported.
+* ``ai_behavior_profile_service`` exports the new symbols.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from services import ai_behavior_profile_service as svc
+
+
+def _admin_actor(actor_id: int = 42):
+    actor = MagicMock()
+    actor.id = actor_id
+    actor.guild_permissions = SimpleNamespace(administrator=True)
+    return actor
+
+
+def _preset_summary(*, key: str, mode: str, preset_id: int = 7):
+    return svc.BehaviorPresetSummary(
+        preset_id=preset_id,
+        key=key,
+        headline="test preset",
+        recommended_mode=mode,
+        body="test body",
+    )
+
+
+def _current_policy_row(**overrides):
+    row = {
+        "guild_id": 1,
+        "enabled": True,
+        "natural_language_enabled": False,
+        "default_provider": "openai",
+        "default_model": "gpt-4o-mini",
+        "minimum_level_default": 5,
+        "cooldown_seconds": 45,
+        "fresh_user_mention_allowance": 2,
+        "guild_instruction_profile_id": None,
+        "generation": 4,
+    }
+    row.update(overrides)
+    return row
+
+
+@pytest.fixture
+def captured_set_guild(monkeypatch):
+    """Replace ``set_guild_policy`` with a kwargs capturer."""
+    from services import ai_policy_mutation
+
+    captured: list[dict] = []
+
+    async def _capture(guild_id, **kwargs):
+        captured.append({"guild_id": guild_id, **kwargs})
+        return ai_policy_mutation.AIPolicyMutationResult(
+            mutation_id="mut-1",
+            table="ai_guild_policy",
+            guild_id=guild_id,
+            target_id=None,
+            generation=5,
+            event_emitted=True,
+        )
+
+    monkeypatch.setattr(ai_policy_mutation, "set_guild_policy", _capture)
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# _SUPPORTED_SCOPES inventory
+# ---------------------------------------------------------------------------
+
+
+def test_supported_scopes_includes_guild():
+    """PR-6 contract: guild is a first-class scope."""
+    assert "guild" in svc._SUPPORTED_SCOPES
+    assert "channel" in svc._SUPPORTED_SCOPES
+    assert "category" in svc._SUPPORTED_SCOPES
+
+
+def test_module_exports_pr6_symbols():
+    assert hasattr(svc, "apply_preset_to_guild")
+    assert hasattr(svc, "GuildScopeNotSupportedError")
+    assert issubclass(svc.GuildScopeNotSupportedError, svc.BehaviorPresetError)
+
+
+# ---------------------------------------------------------------------------
+# apply_preset_to_guild — happy path + preservation invariant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_preset_to_guild_preserves_all_other_fields(
+    monkeypatch, captured_set_guild,
+):
+    """The preservation invariant: every field NOT owned by the preset
+    is passed through unchanged from the current row."""
+    monkeypatch.setattr(
+        svc,
+        "describe_preset",
+        AsyncMock(
+            return_value=_preset_summary(key="helpful_channel", mode="always_reply"),
+        ),
+    )
+    from utils.db import ai as ai_db
+
+    monkeypatch.setattr(
+        ai_db,
+        "get_guild_policy",
+        AsyncMock(return_value=_current_policy_row()),
+    )
+
+    result = await svc.apply_preset_to_guild(
+        guild_id=1,
+        preset_id=7,
+        actor=_admin_actor(),
+    )
+
+    assert len(captured_set_guild) == 1
+    call = captured_set_guild[0]
+    # Preset-owned fields are written.
+    assert call["natural_language_enabled"] is True  # always_reply → True
+    assert call["guild_instruction_profile_id"] == 7
+    # Every other field is preserved verbatim.
+    assert call["enabled"] is True
+    assert call["default_provider"] == "openai"
+    assert call["default_model"] == "gpt-4o-mini"
+    assert call["minimum_level_default"] == 5
+    assert call["cooldown_seconds"] == 45
+    assert call["fresh_user_mention_allowance"] == 2
+
+    assert isinstance(result, svc.BehaviorApplyResult)
+    assert result.scope == "guild"
+    assert result.preset_key == "helpful_channel"
+
+
+@pytest.mark.asyncio
+async def test_apply_preset_to_guild_disabled_preset_sets_nl_false(
+    monkeypatch, captured_set_guild,
+):
+    """The ``disabled`` preset maps to ``natural_language_enabled=False``."""
+    monkeypatch.setattr(
+        svc,
+        "describe_preset",
+        AsyncMock(
+            return_value=_preset_summary(key="disabled", mode="disabled"),
+        ),
+    )
+    from utils.db import ai as ai_db
+
+    # Start with NL enabled — the preset must override it to False.
+    monkeypatch.setattr(
+        ai_db,
+        "get_guild_policy",
+        AsyncMock(return_value=_current_policy_row(natural_language_enabled=True)),
+    )
+
+    await svc.apply_preset_to_guild(
+        guild_id=1,
+        preset_id=7,
+        actor=_admin_actor(),
+    )
+    assert captured_set_guild[0]["natural_language_enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_apply_preset_to_guild_with_no_existing_row(
+    monkeypatch, captured_set_guild,
+):
+    """When no ``ai_guild_policy`` row exists yet, set_guild_policy is
+    called with sensible defaults — preservation can't preserve what
+    doesn't exist, but the write must not raise on None lookups."""
+    monkeypatch.setattr(
+        svc,
+        "describe_preset",
+        AsyncMock(
+            return_value=_preset_summary(key="helpful_channel", mode="always_reply"),
+        ),
+    )
+    from utils.db import ai as ai_db
+
+    monkeypatch.setattr(ai_db, "get_guild_policy", AsyncMock(return_value=None))
+
+    await svc.apply_preset_to_guild(
+        guild_id=1,
+        preset_id=7,
+        actor=_admin_actor(),
+    )
+    call = captured_set_guild[0]
+    # Preset-owned fields are written.
+    assert call["natural_language_enabled"] is True
+    assert call["guild_instruction_profile_id"] == 7
+    # Unset fields fall back to schema defaults rather than raising.
+    assert call["enabled"] is False
+    assert call["default_provider"] == "deterministic"
+
+
+# ---------------------------------------------------------------------------
+# mention_only rejection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_preset_to_guild_rejects_mention_only(
+    monkeypatch, captured_set_guild,
+):
+    """``mention_only`` presets must raise — the typed
+    natural_language_enabled column has no third state."""
+    monkeypatch.setattr(
+        svc,
+        "describe_preset",
+        AsyncMock(
+            return_value=_preset_summary(
+                key="mention_only_helper", mode="mention_only",
+            ),
+        ),
+    )
+    from utils.db import ai as ai_db
+
+    monkeypatch.setattr(
+        ai_db,
+        "get_guild_policy",
+        AsyncMock(return_value=_current_policy_row()),
+    )
+
+    with pytest.raises(svc.GuildScopeNotSupportedError):
+        await svc.apply_preset_to_guild(
+            guild_id=1,
+            preset_id=7,
+            actor=_admin_actor(),
+        )
+    # set_guild_policy was never called — the policy is unchanged.
+    assert captured_set_guild == []
+
+
+# ---------------------------------------------------------------------------
+# Dispatch via apply_preset(scope="guild")
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_preset_scope_guild_delegates_to_guild_helper(
+    monkeypatch, captured_set_guild,
+):
+    monkeypatch.setattr(
+        svc,
+        "describe_preset",
+        AsyncMock(
+            return_value=_preset_summary(key="helpful_channel", mode="always_reply"),
+        ),
+    )
+    from utils.db import ai as ai_db
+
+    monkeypatch.setattr(
+        ai_db,
+        "get_guild_policy",
+        AsyncMock(return_value=_current_policy_row()),
+    )
+
+    result = await svc.apply_preset(
+        guild_id=1,
+        scope="guild",
+        target_id=None,  # ignored for guild scope
+        preset_id=7,
+        actor=_admin_actor(),
+    )
+    assert result.scope == "guild"
+    assert len(captured_set_guild) == 1
+
+
+@pytest.mark.asyncio
+async def test_apply_preset_scope_guild_rejects_mention_only(
+    monkeypatch, captured_set_guild,
+):
+    """The unified dispatcher must surface GuildScopeNotSupportedError
+    for ``mention_only`` presets when scope='guild'."""
+    monkeypatch.setattr(
+        svc,
+        "describe_preset",
+        AsyncMock(
+            return_value=_preset_summary(
+                key="mention_only_helper", mode="mention_only",
+            ),
+        ),
+    )
+    from utils.db import ai as ai_db
+
+    monkeypatch.setattr(
+        ai_db,
+        "get_guild_policy",
+        AsyncMock(return_value=_current_policy_row()),
+    )
+
+    with pytest.raises(svc.GuildScopeNotSupportedError):
+        await svc.apply_preset(
+            guild_id=1,
+            scope="guild",
+            target_id=None,
+            preset_id=7,
+            actor=_admin_actor(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Unknown preset raises before any DB write
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_preset_to_guild_unknown_preset(
+    monkeypatch, captured_set_guild,
+):
+    monkeypatch.setattr(svc, "describe_preset", AsyncMock(return_value=None))
+
+    with pytest.raises(svc.UnknownBehaviorPresetError):
+        await svc.apply_preset_to_guild(
+            guild_id=1,
+            preset_id=9999,
+            actor=_admin_actor(),
+        )
+    assert captured_set_guild == []

--- a/tests/unit/services/test_ai_behavior_profile_service.py
+++ b/tests/unit/services/test_ai_behavior_profile_service.py
@@ -250,10 +250,12 @@ async def test_apply_preset_to_category_calls_set_category_policy(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_apply_preset_refuses_unsupported_scope():
+    """Guild scope is supported as of PR-6 — refuse a genuinely
+    invalid scope name instead."""
     with pytest.raises(svc.InvalidBehaviorPresetScopeError):
         await svc.apply_preset(
             guild_id=1,
-            scope="guild",  # not supported
+            scope="role",  # not supported
             target_id=1,
             preset_id=1,
             actor=_admin_actor(),


### PR DESCRIPTION
## Summary

Stacked on **#326 (PR-5)**. Final PR of the AI cog refinement plan — closes the "configuration ownership" gap by:

1. Adding first-class **guild-scope** preset support (was only channel/category before).
2. Removing the free-text `ai_guild_instruction_profile` scalar from the primary settings panel; the typed-table editor in the Behavior chooser is the authoritative write path.

Merge stack: #323 → #324 → #325 → #326 → #327 → main.

## Service changes

- **`services/ai_behavior_profile_service.py`**
  - New `apply_preset_to_guild(*, guild_id, preset_id, actor)` enforces the **preservation invariant**: read current `ai_guild_policy` row → apply only the two preset-owned fields (`guild_instruction_profile_id`, `natural_language_enabled`) → pass every other field through `set_guild_policy` unchanged.
  - New `GuildScopeNotSupportedError` raised when a `mention_only` preset is applied at guild scope (the typed `natural_language_enabled` column has no third state).
  - `_SUPPORTED_SCOPES` now includes `"guild"`.
  - `apply_preset(scope='guild', ...)` delegates to the guild-scoped helper for callers that prefer the unified dispatcher.

## UI changes

- **`views/ai/behavior/chooser.py`** — new **Guild** preset button + new **Edit guild instruction** button.
- **`views/ai/behavior/preset_picker.py`** — preset cards with `recommended_mode='mention_only'` are hidden from the guild button's dropdown; the service-side check is the safety net.
- **New `views/ai/behavior/instruction_modal.py`** — `GuildInstructionProfileModal` writes through `ai_instruction_mutation.upsert_profile` then binds the resulting profile id via `ai_policy_mutation.set_guild_policy` (same preservation invariant applies).

## Schema / settings panel

- **`core/runtime/subsystem_schema.py`** — `SettingSpec` gains a new `hidden_from_panel: bool = False` field. When True, the auto-rendered subsystem settings panel skips the setting (both in the read embed AND the edit-dropdown). Default False keeps every existing spec visible.
- **`cogs/ai/schemas.py`** — `ai_guild_instruction_profile` is flagged `hidden_from_panel=True`. Hint copy points operators at the Behavior chooser.
- **`views/settings/subsystem_view.py`** — both `_resolve_settings_block` and `_editable_specs` filter out hidden specs.

## Doc

`docs/ai-config-ownership.md` § "Resolved semantics" expanded with the PR-6 shipped contracts:
- instruction-profile scalar moved out of the panel (linked to the Behavior chooser modal)
- `mention_only` rejected at guild scope (UI hides cards, service raises)
- guild preset preservation invariant — pinned by test

## Tests

- **New** `tests/unit/services/test_ai_behavior_profile_guild_scope.py` (9 cases):
  - Preservation invariant pinned: every non-preset-owned field passes through unchanged
  - `disabled` preset maps to `natural_language_enabled=False`
  - Empty-row defaults work without raising
  - `mention_only` raises `GuildScopeNotSupportedError`; no `set_guild_policy` call is made
  - `apply_preset(scope='guild')` delegates correctly
  - Same `mention_only` rejection surface through the unified dispatcher
  - Unknown preset raises before any DB write
  - `_SUPPORTED_SCOPES` includes `guild`; module exports the new symbols
- **New** `tests/unit/cogs/test_ai_instruction_profile_hidden.py` (4 cases):
  - The scalar is flagged `hidden_from_panel=True`
  - Every other AI setting remains visible
  - `_editable_specs` filters out hidden settings
  - The resolved settings block omits the hidden setting
- **Updated** `tests/unit/services/test_ai_behavior_profile_service.py` — `test_apply_preset_refuses_unsupported_scope` now uses `scope='role'` since `guild` is supported as of PR-6.

## Compatibility

- Persistent custom_ids are additive (the new buttons land on existing view rows without changing handler names per I-5).
- `SettingSpec.hidden_from_panel` defaults to False — every existing schema is unaffected.
- The `ai_guild_instruction_profile` setting key is retained in `utils/settings_keys/ai.py` for backcompat KV reads; only the panel surface is hidden.
- No schema migrations.

## Test plan

- [x] All PR-1–6 tests: 301 / 301 passing
- [x] black / isort / ruff / mypy clean locally
- [ ] CI
- [ ] Manual smoke: open Behavior chooser → Guild → pick `helpful_channel` → confirm `ai.policy.guild_changed` emits and `!ai policy` reflects the new baseline. Pick `mention_only` at guild scope and verify the UI rejection. Confirm `ai_guild_instruction_profile` no longer renders in `!ai settings`; open the new instruction-profile modal and verify the typed-table row is updated.

https://claude.ai/code/session_01Y5cC77Jyce8JEyt8HtTK6S

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5cC77Jyce8JEyt8HtTK6S)_