### PR TITLE
Setup wizard Phase 1: workspace + access consistency

### DIFF
--- a/disbot/cogs/setup/_helpers.py
+++ b/disbot/cogs/setup/_helpers.py
@@ -21,7 +21,7 @@ import logging
 
 import discord
 
-from services import setup_access, setup_session
+from services import setup_access, setup_channel, setup_session
 from services.setup_session import SetupSession
 
 logger = logging.getLogger("bot.cogs.setup.helpers")
@@ -183,7 +183,134 @@ def build_status_embed(
     return embed
 
 
+async def toggle_delegate(
+    interaction: discord.Interaction,
+    member: discord.Member,
+    *,
+    grant: bool,
+) -> None:
+    """Owner-only grant or revoke of delegated setup-admin authority.
+
+    Body of ``/setup-delegate`` and ``/setup-undelegate``.  Extracted
+    out of :mod:`cogs.setup_cog` so the cog file stays under the
+    S4.6 800-LOC ceiling enforced by
+    ``tests/unit/invariants/test_cog_size.py``.
+
+    Flow:
+
+    1. Reject non-server-channel context, non-owner actors, bot
+       targets, and the self-grant edge case (delegating the owner
+       is a no-op).
+    2. Resume the session row, starting one if necessary.
+    3. Call :func:`services.setup_session.add_delegated_admin` or
+       :func:`services.setup_session.remove_delegated_admin`; surface
+       DB errors as ephemeral failure replies.
+    4. Recompute setup-channel overwrites so the new delegate gains
+       explicit channel access (or the revoked one loses it).  This
+       step is best-effort — a failure does not roll back the
+       delegation; the next ``ensure_setup_channel`` will repair the
+       overwrites.
+    5. Reply ephemerally with the privacy disclaimer.
+    """
+    guild = interaction.guild
+    actor = interaction.user
+    if guild is None or not isinstance(actor, discord.Member):
+        cmd = "delegate" if grant else "undelegate"
+        await interaction.response.send_message(
+            f"Use `/setup-{cmd}` from inside the server.",
+            ephemeral=True,
+        )
+        return
+
+    if not setup_access.is_server_owner(actor):
+        await interaction.response.send_message(
+            "Only the server owner can grant or revoke delegated "
+            "setup-admin authority.",
+            ephemeral=True,
+        )
+        return
+
+    if member.bot:
+        await interaction.response.send_message(
+            "Setup-admin delegation does not apply to bots.",
+            ephemeral=True,
+        )
+        return
+
+    if member.id == guild.owner_id:
+        await interaction.response.send_message(
+            "The server owner already has full setup authority — "
+            "no delegation needed.",
+            ephemeral=True,
+        )
+        return
+
+    try:
+        session = await setup_session.resume_session(guild.id)
+    except Exception:
+        logger.exception("toggle_delegate: resume failed")
+        session = None
+
+    if session is None:
+        try:
+            session = await setup_session.start_session(
+                guild_id=guild.id,
+                guild_name=guild.name,
+                owner_id=guild.owner_id or 0,
+            )
+        except Exception:
+            logger.exception("toggle_delegate: start_session failed")
+            await interaction.response.send_message(
+                "Could not initialise the setup session — see logs.",
+                ephemeral=True,
+            )
+            return
+
+    try:
+        if grant:
+            await setup_session.add_delegated_admin(
+                guild.id,
+                member.id,
+                actor_id=actor.id,
+            )
+        else:
+            await setup_session.remove_delegated_admin(
+                guild.id,
+                member.id,
+                actor_id=actor.id,
+            )
+    except Exception:
+        verb = "grant" if grant else "revoke"
+        logger.exception("toggle_delegate: %s failed", verb)
+        await interaction.response.send_message(
+            "Could not update delegated-admin set — see logs.",
+            ephemeral=True,
+        )
+        return
+
+    try:
+        refreshed = await setup_session.resume_session(guild.id)
+    except Exception:
+        logger.exception("toggle_delegate: refresh failed")
+        refreshed = session
+
+    try:
+        await setup_channel.recompute_setup_channel_overwrites(
+            guild,
+            refreshed,
+        )
+    except Exception:
+        logger.exception("toggle_delegate: recompute_overwrites failed")
+
+    verb = "delegated" if grant else "un-delegated"
+    await interaction.response.send_message(
+        f"✅ {member.mention} {verb}. {setup_channel.PRIVACY_NOTE}",
+        ephemeral=True,
+    )
+
+
 __all__ = [
     "build_status_embed",
     "resolve_hub_entry",
+    "toggle_delegate",
 ]

--- a/disbot/cogs/setup_cog.py
+++ b/disbot/cogs/setup_cog.py
@@ -31,6 +31,7 @@ from discord.ext import commands
 
 from cogs.setup._helpers import build_status_embed as _build_status_embed
 from cogs.setup._helpers import resolve_hub_entry as _resolve_hub_entry
+from cogs.setup._helpers import toggle_delegate as _toggle_delegate
 from services import setup_access, setup_session
 from views.setup.launcher import (
     SetupLauncherView,
@@ -419,6 +420,62 @@ class SetupCog(commands.Cog):
             f"continue.",
             ephemeral=True,
         )
+
+    @app_commands.command(
+        name="setup-delegate",
+        description="Grant a member delegated setup-admin authority (owner only).",
+    )
+    @app_commands.describe(
+        member="Member to grant delegated setup-admin authority.",
+    )
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.guild_only()
+    async def setup_delegate_slash(
+        self,
+        interaction: discord.Interaction,
+        member: discord.Member,
+    ) -> None:
+        """Add ``member`` to the guild's ``delegated_admins`` set.
+
+        Owner-only on purpose: delegation is a capability-significant
+        change and must not be self-granted by other administrators.
+        Idempotent — re-granting an existing delegate is a no-op at
+        the DB layer.  After the grant succeeds the private setup
+        channel's overwrites are recomputed so the new delegate gets
+        explicit channel access.
+
+        Body lives in :func:`cogs.setup._helpers.toggle_delegate` so
+        the cog file stays under the S4.6 LOC ceiling.
+        """
+        await _toggle_delegate(interaction, member, grant=True)
+
+    @app_commands.command(
+        name="setup-undelegate",
+        description="Revoke delegated setup-admin authority (owner only).",
+    )
+    @app_commands.describe(
+        member="Member to revoke delegated setup-admin authority from.",
+    )
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.guild_only()
+    async def setup_undelegate_slash(
+        self,
+        interaction: discord.Interaction,
+        member: discord.Member,
+    ) -> None:
+        """Drop ``member`` from the guild's ``delegated_admins`` set.
+
+        Owner-only.  Idempotent.  After the revoke succeeds the private
+        setup channel's overwrites are recomputed so the revoked
+        delegate loses explicit channel access (Discord administrator
+        permissions may still let them view — see PRIVACY_NOTE on
+        :mod:`services.setup_channel`).
+
+        Body lives in :func:`cogs.setup._helpers.toggle_delegate`.
+        """
+        await _toggle_delegate(interaction, member, grant=False)
 
     @app_commands.command(
         name="setup-status",

--- a/disbot/services/setup_channel.py
+++ b/disbot/services/setup_channel.py
@@ -2,14 +2,34 @@
 
 When SuperBot joins a guild and has Manage Channels permission, it
 creates a private ``#superbot-setup`` channel visible only to the bot
-itself and the guild owner. The launcher cog posts the setup launcher
+itself, the guild owner, and any delegated setup admins recorded on
+the :class:`SetupSession`.  The launcher cog posts the setup launcher
 in that channel and @mentions the owner so they discover the wizard
 immediately.
 
-This module owns the idempotent "ensure" operation. The actual Discord
-channel creation routes through
+This module owns the idempotent "ensure" operation.  The actual
+Discord channel creation routes through
 :func:`core.runtime.guild_resources.ensure_channel` — the canonical
 infrastructure primitive on the S4.5 no-silent-auto-create allowlist.
+
+Best-effort privacy contract:
+
+* ``@everyone`` is denied ``view_channel``.
+* Every role whose Discord permission set includes ``administrator``
+  is denied ``view_channel`` explicitly (defence-in-depth — Discord's
+  admin override means admins can still see the channel via role
+  permissions, but the explicit overwrite is what an audit reads).
+* Bot, server owner, and every delegated setup admin id get a
+  positive overwrite granting view + send + history.
+
+Operator-visible copy must say:
+
+    Admins may still see this channel depending on Discord permissions.
+    Setup actions are protected by interaction checks.
+
+— because Discord's administrator permission can override a
+view-channel denial regardless of overwrite order.  The real security
+boundary is :func:`services.setup_access.can_apply_setup`.
 
 Constraints preserved:
 
@@ -29,10 +49,14 @@ operator-named "setup" channels.
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 import discord
 
 from core.runtime.guild_resources import ensure_channel
+
+if TYPE_CHECKING:
+    from services.setup_session import SetupSession
 
 logger = logging.getLogger("bot.services.setup_channel")
 
@@ -40,33 +64,93 @@ logger = logging.getLogger("bot.services.setup_channel")
 #: operator-created "setup" channels are not accidentally adopted.
 SETUP_CHANNEL_NAME = "superbot-setup"
 
+#: Public note rendered alongside any UI that surfaces the setup
+#: channel.  Discord's administrator permission can override a
+#: ``view_channel`` denial regardless of overwrite order, so the
+#: explicit admin-role denial is best-effort.  The actual security
+#: boundary for setup actions is
+#: :func:`services.setup_access.can_apply_setup` — the interaction
+#: checks on every mutating button.
+PRIVACY_NOTE = (
+    "Admins may still see this channel depending on Discord permissions. "
+    "Setup actions are protected by interaction checks."
+)
+
+
+def _allow_overwrite() -> discord.PermissionOverwrite:
+    """Standard "may use the setup channel" overwrite."""
+    return discord.PermissionOverwrite(
+        view_channel=True,
+        send_messages=True,
+        read_message_history=True,
+    )
+
+
+def _bot_overwrite() -> discord.PermissionOverwrite:
+    """Standard bot overwrite (includes manage_messages for clean-up)."""
+    return discord.PermissionOverwrite(
+        view_channel=True,
+        send_messages=True,
+        embed_links=True,
+        read_message_history=True,
+        manage_messages=True,
+    )
+
+
+def _deny_view_overwrite() -> discord.PermissionOverwrite:
+    """Standard "do not see this channel" overwrite."""
+    return discord.PermissionOverwrite(view_channel=False)
+
 
 def _private_overwrites(
     guild: discord.Guild,
+    *,
+    session: SetupSession | None = None,
 ) -> dict[discord.Member | discord.Role, discord.PermissionOverwrite]:
     """Build the permission overwrite set for the private setup channel.
 
-    Visible to the bot and the guild owner; hidden from @everyone.
-    Administrator-tier members keep their global view permission via
-    Discord's own permission resolver — we only restrict ``@everyone``.
+    Layout:
+
+    * ``@everyone`` — denied ``view_channel``.
+    * Every role flagged ``administrator=True`` — denied
+      ``view_channel`` explicitly.  Discord's admin override can still
+      reveal the channel; this is defence-in-depth that an audit
+      reader can see.
+    * Bot — full read/write/manage.
+    * Server owner — read/write.
+    * Every delegated setup admin id on ``session`` — read/write.
+      Ids that don't resolve to a current member are skipped (the
+      member may have left the guild).
+
+    Pass ``session=None`` (legacy call sites) for the owner-and-bot-only
+    layout.  All Phase 1+ call sites should pass the resolved session
+    so the overwrites match the access tier.
     """
     overwrites: dict[discord.Member | discord.Role, discord.PermissionOverwrite] = {
-        guild.default_role: discord.PermissionOverwrite(view_channel=False),
+        guild.default_role: _deny_view_overwrite(),
     }
+    # Deny administrator roles explicitly so an audit reading the
+    # overwrite set sees the intent.  Discord may still let admins
+    # view via the admin permission flag — see PRIVACY_NOTE.
+    for role in getattr(guild, "roles", ()):
+        if role.id == guild.default_role.id:
+            continue
+        perms = getattr(role, "permissions", None)
+        if perms is not None and getattr(perms, "administrator", False):
+            overwrites[role] = _deny_view_overwrite()
     if guild.me is not None:
-        overwrites[guild.me] = discord.PermissionOverwrite(
-            view_channel=True,
-            send_messages=True,
-            embed_links=True,
-            read_message_history=True,
-            manage_messages=True,
-        )
+        overwrites[guild.me] = _bot_overwrite()
     if guild.owner is not None:
-        overwrites[guild.owner] = discord.PermissionOverwrite(
-            view_channel=True,
-            send_messages=True,
-            read_message_history=True,
-        )
+        overwrites[guild.owner] = _allow_overwrite()
+    if session is not None:
+        for delegated_id in session.delegated_admins:
+            member = guild.get_member(delegated_id)
+            if member is None:
+                # Member left the guild or is uncached — skip; the
+                # session row still holds the id so a future
+                # recompute picks them up if they rejoin.
+                continue
+            overwrites[member] = _allow_overwrite()
     return overwrites
 
 
@@ -82,18 +166,24 @@ async def ensure_setup_channel(
     guild: discord.Guild,
     *,
     existing_channel_id: int | None = None,
+    session: SetupSession | None = None,
 ) -> tuple[discord.TextChannel | None, bool]:
     """Return the private setup channel for ``guild``, creating if absent.
 
-    Idempotent. The function tries the following, in order:
+    Idempotent.  Tries, in order:
 
     1. If ``existing_channel_id`` is given and the channel is still in
-       the guild cache, return it unchanged.
-    2. Look up by canonical name (``superbot-setup``) — covers the
-       restart case where the cog lost track of the channel id.
-    3. Create the channel with private overwrites via
-       :func:`core.runtime.guild_resources.ensure_channel`. Requires
-       the bot to hold Manage Channels.
+       the guild cache, return it after recomputing overwrites so the
+       reused channel reflects the current session's delegated-admin
+       set (and any newly-added admin roles get denied).
+    2. Otherwise create the channel with the private overwrite set
+       via :func:`core.runtime.guild_resources.ensure_channel`.
+
+    ``session`` is the resolved :class:`SetupSession` snapshot
+    (``None`` is accepted for legacy call sites that don't yet pass
+    it).  When provided, the channel's overwrite set is built from
+    its ``delegated_admins`` list; when ``None``, the layout falls
+    back to owner-and-bot-only.
 
     Returns:
         ``(channel, was_just_created)`` where ``channel`` is ``None``
@@ -104,6 +194,12 @@ async def ensure_setup_channel(
     if existing_channel_id is not None:
         existing = guild.get_channel(existing_channel_id)
         if isinstance(existing, discord.TextChannel):
+            # Reuse the channel, but repair its overwrites from the
+            # current session snapshot — admin roles created since
+            # last run get denied, newly-delegated admins gain
+            # access, and revoked admins lose theirs.  Best-effort:
+            # a failure is logged and the channel is still returned.
+            await _apply_overwrites(existing, guild, session=session)
             return existing, False
 
     if not _bot_can_manage_channels(guild):
@@ -119,7 +215,7 @@ async def ensure_setup_channel(
             SETUP_CHANNEL_NAME,
             kind="text",
             category=None,
-            overwrites=_private_overwrites(guild),
+            overwrites=_private_overwrites(guild, session=session),
         )
     except discord.Forbidden as exc:
         logger.warning(
@@ -146,6 +242,85 @@ async def ensure_setup_channel(
         return None, False
 
     return channel, True
+
+
+async def recompute_setup_channel_overwrites(
+    guild: discord.Guild,
+    session: SetupSession | None,
+    *,
+    channel: discord.TextChannel | None = None,
+) -> bool:
+    """Rebuild and apply the setup channel's permission overwrites.
+
+    Called from the delegate / undelegate flows so the channel's
+    overwrites stay in sync with ``session.delegated_admins``, and
+    from :func:`ensure_setup_channel` when reusing a cached channel
+    so admin-role denials and delegate grants follow the latest
+    membership snapshot.
+
+    ``channel`` may be passed explicitly; otherwise the helper looks
+    it up via ``session.setup_channel_id``.  When the channel cannot
+    be resolved, the function returns ``False`` (caller can decide
+    to re-create the channel).
+    """
+    target = channel
+    if target is None and session is not None and session.setup_channel_id is not None:
+        cached = guild.get_channel(session.setup_channel_id)
+        if isinstance(cached, discord.TextChannel):
+            target = cached
+    if target is None:
+        logger.info(
+            "setup_channel: recompute skipped — no channel resolved (guild=%d)",
+            guild.id,
+        )
+        return False
+    return await _apply_overwrites(target, guild, session=session)
+
+
+async def _apply_overwrites(
+    channel: discord.TextChannel,
+    guild: discord.Guild,
+    *,
+    session: SetupSession | None,
+) -> bool:
+    """Apply the computed overwrite set to ``channel``.  Best-effort.
+
+    Returns ``True`` on a successful edit (or no-op when there is
+    nothing to apply), ``False`` when Discord refused / errored.
+    """
+    # discord.TextChannel.edit accepts a wider Mapping union than the
+    # dict[Member | Role, ...] our builder returns; cast to the
+    # builder's narrower shape so mypy accepts the call without
+    # losing the runtime structure check.
+    from typing import cast
+
+    overwrites_dict = _private_overwrites(guild, session=session)
+    overwrites = cast(
+        "dict[discord.Role | discord.Member | discord.Object, discord.PermissionOverwrite]",
+        overwrites_dict,
+    )
+    try:
+        await channel.edit(
+            overwrites=overwrites,
+            reason="setup_channel.recompute_overwrites",
+        )
+    except discord.Forbidden as exc:
+        logger.warning(
+            "setup_channel: forbidden editing overwrites on #%s (guild=%d): %s",
+            channel.name,
+            guild.id,
+            exc,
+        )
+        return False
+    except discord.HTTPException as exc:
+        logger.warning(
+            "setup_channel: HTTP error editing overwrites on #%s (guild=%d): %s",
+            channel.name,
+            guild.id,
+            exc,
+        )
+        return False
+    return True
 
 
 async def delete_setup_channel(
@@ -204,7 +379,9 @@ async def delete_setup_channel(
 
 
 __all__ = [
+    "PRIVACY_NOTE",
     "SETUP_CHANNEL_NAME",
     "delete_setup_channel",
     "ensure_setup_channel",
+    "recompute_setup_channel_overwrites",
 ]

--- a/disbot/services/setup_channel.py
+++ b/disbot/services/setup_channel.py
@@ -53,7 +53,7 @@ from typing import TYPE_CHECKING
 
 import discord
 
-from core.runtime.guild_resources import ensure_channel
+from core.runtime.guild_resources import ensure_channel, resolve_member
 
 if TYPE_CHECKING:
     from services.setup_session import SetupSession
@@ -144,7 +144,10 @@ def _private_overwrites(
         overwrites[guild.owner] = _allow_overwrite()
     if session is not None:
         for delegated_id in session.delegated_admins:
-            member = guild.get_member(delegated_id)
+            # Cache-only lookup via the project's canonical resolver
+            # (S5 invariant — no raw guild.get_member outside
+            # core.runtime.guild_resources).
+            member = resolve_member(guild, delegated_id)
             if member is None:
                 # Member left the guild or is uncached — skip; the
                 # session row still holds the id so a future

--- a/disbot/services/setup_session.py
+++ b/disbot/services/setup_session.py
@@ -244,6 +244,64 @@ async def set_depth(guild_id: int, depth: str | None) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Delegated-admin lifecycle
+# ---------------------------------------------------------------------------
+#
+# DB primitives ``utils.db.setup_session.add_delegated_admin`` and
+# ``remove_delegated_admin`` already exist (PostgreSQL set semantics on
+# the ``setup_session.delegated_admins`` TEXT[] column).  These
+# service-level wrappers add the canonical audit emission and the
+# uniform call signature the setup cog's ``/setup-delegate`` /
+# ``/setup-undelegate`` slash commands consume.
+
+
+async def add_delegated_admin(
+    guild_id: int,
+    user_id: int,
+    *,
+    actor_id: int | None,
+) -> None:
+    """Append ``user_id`` to the guild's ``delegated_admins`` set.
+
+    Idempotent — repeated calls leave the set unchanged.  Emits
+    ``setup.delegated_admin.added`` so the audit pipeline sees the
+    promotion.  ``actor_id`` is the user who performed the grant
+    (typically the server owner via ``/setup-delegate``).
+    """
+    await db.add_delegated_admin(guild_id, user_id)
+    await _emit_session_audit(
+        guild_id=guild_id,
+        mutation_type="setup.delegated_admin.added",
+        new_value=str(user_id),
+        actor_id=actor_id,
+        actor_type="user",
+    )
+
+
+async def remove_delegated_admin(
+    guild_id: int,
+    user_id: int,
+    *,
+    actor_id: int | None,
+) -> None:
+    """Drop ``user_id`` from the guild's ``delegated_admins`` set.
+
+    Idempotent.  Emits ``setup.delegated_admin.removed``.  The
+    private setup channel's overwrites should be recomputed by the
+    caller (see :func:`services.setup_channel.recompute_setup_channel_overwrites`)
+    so the revoked admin loses explicit channel access too.
+    """
+    await db.remove_delegated_admin(guild_id, user_id)
+    await _emit_session_audit(
+        guild_id=guild_id,
+        mutation_type="setup.delegated_admin.removed",
+        new_value=str(user_id),
+        actor_id=actor_id,
+        actor_type="user",
+    )
+
+
+# ---------------------------------------------------------------------------
 # Drift detection (Phase 9i / Track 8 PR 24)
 # ---------------------------------------------------------------------------
 
@@ -341,12 +399,14 @@ def detect_drift(
 __all__ = [
     "DriftReport",
     "SetupSession",
+    "add_delegated_admin",
     "detect_drift",
     "dismiss",
     "mark_complete",
     "mark_in_progress",
     "mark_section_skipped",
     "record_readiness_score",
+    "remove_delegated_admin",
     "resume_session",
     "set_depth",
     "start_session",

--- a/disbot/views/setup/final_review.py
+++ b/disbot/views/setup/final_review.py
@@ -47,6 +47,7 @@ from typing import TYPE_CHECKING, Any
 
 import discord
 
+from services import setup_access, setup_session
 from services.setup_plan import SetupRecommendation
 from views.base import BaseView
 
@@ -54,6 +55,43 @@ if TYPE_CHECKING:
     pass
 
 logger = logging.getLogger("bot.views.setup.final_review")
+
+
+async def _gate_apply(interaction: discord.Interaction) -> bool:
+    """Reject callers who don't satisfy ``can_apply_setup`` now.
+
+    Module-level helper shared by :class:`FinalReviewView` and
+    :class:`PartialApplyRecoveryView`.  The :class:`BaseView` author
+    gate already restricts the panel to the user who opened it, but
+    this layer re-checks the access tier against a fresh
+    :class:`SetupSession` so a delegated admin who lost delegation
+    between opening Final Review and pressing the button cannot
+    apply.
+    """
+    member = interaction.user
+    if not isinstance(member, discord.Member):
+        await interaction.response.send_message(
+            "Use this from inside the server.",
+            ephemeral=True,
+        )
+        return False
+    session = None
+    guild_id = interaction.guild_id
+    if guild_id is not None:
+        try:
+            session = await setup_session.resume_session(guild_id)
+        except Exception:
+            logger.exception("final_review._gate_apply: resume failed")
+            session = None
+    if not setup_access.can_apply_setup(member, session):
+        await interaction.response.send_message(
+            "Only the server owner or a delegated setup admin can apply "
+            "staged setup operations. Ask the server owner to grant you "
+            "`/setup-delegate`.",
+            ephemeral=True,
+        )
+        return False
+    return True
 
 
 @dataclass
@@ -247,6 +285,8 @@ class FinalReviewView(BaseView):
                 "Final review requires a guild context.",
                 ephemeral=True,
             )
+            return
+        if not await _gate_apply(interaction):
             return
         from core.runtime.interaction_helpers import safe_defer
         from services.setup_operations import (
@@ -563,6 +603,8 @@ class PartialApplyRecoveryView(BaseView):
                 "Retry requires a guild context.",
                 ephemeral=True,
             )
+            return
+        if not await _gate_apply(interaction):
             return
         from core.runtime.interaction_helpers import safe_defer
         from services.setup_operations import (

--- a/disbot/views/setup/hub.py
+++ b/disbot/views/setup/hub.py
@@ -9,8 +9,12 @@ the live registry.
 
 The hub owns three responsibilities for every section:
 
-* **Owner gating** — every section button rejects non-owners with an
-  ephemeral message before the section's `run` callback fires.
+* **Apply gating** — every section button rejects callers who do not
+  satisfy :func:`services.setup_access.can_apply_setup` (server owner
+  or delegated setup admin).  Administrators without delegation get
+  a read-only readiness embed from the launcher, so they never reach
+  the hub in the first place; this gate is defence-in-depth in case
+  the launcher path is bypassed.
 * **Error isolation** — exceptions inside a section's `run` are caught,
   logged, and surfaced as an ephemeral error if the section hasn't
   already responded.  A buggy section cannot take the hub down.
@@ -242,7 +246,7 @@ class SetupHubView(BaseView):
         )
 
         async def _callback(interaction: discord.Interaction) -> None:
-            if not await self._gate_owner(interaction):
+            if not await self._gate_apply(interaction):
                 return
             if interaction.guild is None or interaction.guild_id is None:
                 await interaction.response.send_message(
@@ -336,7 +340,7 @@ class SetupHubView(BaseView):
         )
 
         async def _callback(interaction: discord.Interaction) -> None:
-            if not await self._gate_owner(interaction):
+            if not await self._gate_apply(interaction):
                 return
             from views.setup.depth_panel import (
                 DepthPanelView,
@@ -360,10 +364,18 @@ class SetupHubView(BaseView):
         if refreshed is not None:
             self.session = refreshed
 
-    async def _gate_owner(
+    async def _gate_apply(
         self,
         interaction: discord.Interaction,
     ) -> bool:
+        """Reject callers who can't apply setup operations.
+
+        Pre-Phase-1 this method only allowed the server owner, even
+        though hub entry already accepted delegated setup admins —
+        causing those delegates to bounce off every hub button.  Now
+        defers to :func:`setup_access.can_apply_setup` so the same
+        ladder gates entry, mutation, and Final Review.
+        """
         member = interaction.user
         if not isinstance(member, discord.Member):
             await interaction.response.send_message(
@@ -371,9 +383,10 @@ class SetupHubView(BaseView):
                 ephemeral=True,
             )
             return False
-        if not setup_access.is_server_owner(member):
+        if not setup_access.can_apply_setup(member, self.session):
             await interaction.response.send_message(
-                "Only the server owner can run the wizard.",
+                "Only the server owner or a delegated setup admin can run the "
+                "wizard. Ask the server owner to grant you `/setup-delegate`.",
                 ephemeral=True,
             )
             return False
@@ -392,7 +405,7 @@ class SetupHubView(BaseView):
             *,
             sec: SetupSection = section,
         ) -> None:
-            if not await self._gate_owner(interaction):
+            if not await self._gate_apply(interaction):
                 return
             try:
                 await sec.run(interaction, self)

--- a/disbot/views/setup/section_card.py
+++ b/disbot/views/setup/section_card.py
@@ -44,7 +44,7 @@ from typing import TYPE_CHECKING
 
 import discord
 
-from services import setup_draft, setup_progress, setup_session
+from services import setup_access, setup_draft, setup_progress, setup_session
 from services.setup_operations import SetupOperation
 from services.setup_progress import SectionProgress, badge_for
 from services.setup_sections import REGISTRY, SetupSection
@@ -160,7 +160,16 @@ def build_section_card(
 
 
 class SectionCardView(BaseView):
-    """Card view that owns the four-button section panel."""
+    """Card view that owns the four-button section panel.
+
+    Mutating buttons (Apply Recommended, Skip) re-check
+    :func:`services.setup_access.can_apply_setup` against the live
+    session snapshot before doing any work — so a delegated admin
+    who lost delegation between opening the card and pressing a
+    button cannot mutate the draft.  The :class:`BaseView` author
+    gate already restricts the panel to the user who opened it, but
+    that gate does not catch revoked delegations.
+    """
 
     def __init__(
         self,
@@ -211,7 +220,41 @@ class SectionCardView(BaseView):
         self._hub_button.callback = self._return_to_hub  # type: ignore[method-assign]
         self.add_item(self._hub_button)
 
+    async def _gate_apply(self, interaction: discord.Interaction) -> bool:
+        """Reject callers who don't satisfy ``can_apply_setup`` now.
+
+        The author gate from :class:`BaseView` already filters to the
+        user who opened the card; this layer additionally re-checks
+        the access tier against a fresh ``SetupSession`` snapshot.
+        """
+        member = interaction.user
+        if not isinstance(member, discord.Member):
+            await interaction.response.send_message(
+                "Use this from inside the server.",
+                ephemeral=True,
+            )
+            return False
+        session = None
+        guild_id = interaction.guild_id
+        if guild_id is not None:
+            try:
+                session = await setup_session.resume_session(guild_id)
+            except Exception:
+                logger.exception("section_card._gate_apply: resume failed")
+                session = None
+        if not setup_access.can_apply_setup(member, session):
+            await interaction.response.send_message(
+                "Only the server owner or a delegated setup admin can stage "
+                "or skip setup operations. Ask the server owner to grant "
+                "you `/setup-delegate`.",
+                ephemeral=True,
+            )
+            return False
+        return True
+
     async def _apply_recommended(self, interaction: discord.Interaction) -> None:
+        if not await self._gate_apply(interaction):
+            return
         if self._recommended_ops_builder is None:
             await interaction.response.send_message(
                 "This section has no recommended defaults.",
@@ -294,6 +337,8 @@ class SectionCardView(BaseView):
                 )
 
     async def _skip(self, interaction: discord.Interaction) -> None:
+        if not await self._gate_apply(interaction):
+            return
         if interaction.guild_id is None:
             await interaction.response.send_message(
                 "Skip requires a guild context.",

--- a/tests/unit/cogs/test_setup_cog.py
+++ b/tests/unit/cogs/test_setup_cog.py
@@ -1911,3 +1911,273 @@ async def test_setup_depth_slash_denies_random_member():
     set_depth_mock.assert_not_awaited()
     msg = interaction.response.send_message.await_args.args[0]
     assert "owner" in msg.lower()
+
+
+# ---------------------------------------------------------------------------
+# /setup-delegate and /setup-undelegate slash commands (Phase 1)
+# ---------------------------------------------------------------------------
+
+
+def _target_member(member_id: int = 77):
+    """Member object passed to /setup-delegate as the grant target."""
+    import discord
+
+    m = MagicMock(spec=discord.Member)
+    m.id = member_id
+    m.mention = f"<@{member_id}>"
+    m.bot = False
+    return m
+
+
+def _bot_target_member(member_id: int = 88):
+    import discord
+
+    m = MagicMock(spec=discord.Member)
+    m.id = member_id
+    m.mention = f"<@{member_id}>"
+    m.bot = True
+    return m
+
+
+def _delegate_interaction(actor, *, guild_id: int = 1, guild_owner_id: int = 99):
+    """Mock interaction with a guild.id / guild.owner_id pair used by
+    /setup-delegate / /setup-undelegate.
+    """
+    interaction = _mock_interaction(actor, guild_id=guild_id)
+    interaction.guild.owner_id = guild_owner_id
+    interaction.guild.name = "Test"
+    return interaction
+
+
+@pytest.mark.asyncio
+async def test_setup_delegate_slash_grants_owner_can_promote():
+    from cogs.setup_cog import SetupCog
+
+    cog = SetupCog(MagicMock())
+    actor = _owner_member()
+    target = _target_member(77)
+    interaction = _delegate_interaction(actor)
+
+    with (
+        patch(
+            "cogs.setup._helpers.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_delegated_session(delegated=()),
+        ),
+        patch(
+            "cogs.setup._helpers.setup_session.add_delegated_admin",
+            new_callable=AsyncMock,
+        ) as add_mock,
+        patch(
+            "services.setup_channel.recompute_setup_channel_overwrites",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as recompute_mock,
+    ):
+        await cog.setup_delegate_slash.callback(cog, interaction, member=target)
+
+    add_mock.assert_awaited_once_with(1, 77, actor_id=99)
+    # Channel overwrites recomputed so the new delegate gets explicit
+    # channel access without needing to wait for the next ensure call.
+    recompute_mock.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "delegated" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_setup_undelegate_slash_owner_can_revoke():
+    from cogs.setup_cog import SetupCog
+
+    cog = SetupCog(MagicMock())
+    actor = _owner_member()
+    target = _target_member(77)
+    interaction = _delegate_interaction(actor)
+
+    with (
+        patch(
+            "cogs.setup._helpers.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_delegated_session(delegated=(77,)),
+        ),
+        patch(
+            "cogs.setup._helpers.setup_session.remove_delegated_admin",
+            new_callable=AsyncMock,
+        ) as remove_mock,
+        patch(
+            "services.setup_channel.recompute_setup_channel_overwrites",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as recompute_mock,
+    ):
+        await cog.setup_undelegate_slash.callback(cog, interaction, member=target)
+
+    remove_mock.assert_awaited_once_with(1, 77, actor_id=99)
+    recompute_mock.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "un-delegated" in msg.lower() or "undelegated" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_setup_delegate_slash_denies_non_owner():
+    """Plain admin (not owner) cannot grant delegation — capability-
+    significant promotion is owner-only on purpose.
+    """
+    from cogs.setup_cog import SetupCog
+
+    cog = SetupCog(MagicMock())
+    actor = _admin_member()  # admin=True but id=42, not owner=99
+    target = _target_member(77)
+    interaction = _delegate_interaction(actor)
+
+    with (
+        patch(
+            "cogs.setup._helpers.setup_session.add_delegated_admin",
+            new_callable=AsyncMock,
+        ) as add_mock,
+        patch(
+            "services.setup_channel.recompute_setup_channel_overwrites",
+            new_callable=AsyncMock,
+        ) as recompute_mock,
+    ):
+        await cog.setup_delegate_slash.callback(cog, interaction, member=target)
+
+    add_mock.assert_not_awaited()
+    recompute_mock.assert_not_awaited()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "owner" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_setup_undelegate_slash_denies_non_owner():
+    from cogs.setup_cog import SetupCog
+
+    cog = SetupCog(MagicMock())
+    actor = _admin_member()
+    target = _target_member(77)
+    interaction = _delegate_interaction(actor)
+
+    with (
+        patch(
+            "cogs.setup._helpers.setup_session.remove_delegated_admin",
+            new_callable=AsyncMock,
+        ) as remove_mock,
+    ):
+        await cog.setup_undelegate_slash.callback(cog, interaction, member=target)
+
+    remove_mock.assert_not_awaited()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "owner" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_setup_delegate_slash_rejects_bot_target():
+    from cogs.setup_cog import SetupCog
+
+    cog = SetupCog(MagicMock())
+    actor = _owner_member()
+    target = _bot_target_member(88)
+    interaction = _delegate_interaction(actor)
+
+    with patch(
+        "cogs.setup._helpers.setup_session.add_delegated_admin",
+        new_callable=AsyncMock,
+    ) as add_mock:
+        await cog.setup_delegate_slash.callback(cog, interaction, member=target)
+
+    add_mock.assert_not_awaited()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "bot" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_setup_delegate_slash_rejects_owner_target():
+    """Granting the owner delegation is a no-op the slash command
+    rejects with a friendly message rather than silently succeeding.
+    """
+    from cogs.setup_cog import SetupCog
+
+    cog = SetupCog(MagicMock())
+    actor = _owner_member()  # id=99
+    target = _target_member(99)  # also id=99, matches guild.owner_id
+    interaction = _delegate_interaction(actor)
+
+    with patch(
+        "cogs.setup._helpers.setup_session.add_delegated_admin",
+        new_callable=AsyncMock,
+    ) as add_mock:
+        await cog.setup_delegate_slash.callback(cog, interaction, member=target)
+
+    add_mock.assert_not_awaited()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "owner" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_setup_delegate_slash_starts_session_when_missing():
+    """If no session row exists yet, the command initialises one so the
+    delegation actually persists.
+    """
+    from cogs.setup_cog import SetupCog
+
+    cog = SetupCog(MagicMock())
+    actor = _owner_member()
+    target = _target_member(77)
+    interaction = _delegate_interaction(actor)
+
+    # First resume_session call returns None; start_session then runs;
+    # second resume_session (for the recompute) returns the new session.
+    with (
+        patch(
+            "cogs.setup._helpers.setup_session.resume_session",
+            new_callable=AsyncMock,
+            side_effect=[None, _delegated_session(delegated=(77,))],
+        ),
+        patch(
+            "cogs.setup._helpers.setup_session.start_session",
+            new_callable=AsyncMock,
+            return_value=_delegated_session(delegated=()),
+        ) as start_mock,
+        patch(
+            "cogs.setup._helpers.setup_session.add_delegated_admin",
+            new_callable=AsyncMock,
+        ) as add_mock,
+        patch(
+            "services.setup_channel.recompute_setup_channel_overwrites",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+    ):
+        await cog.setup_delegate_slash.callback(cog, interaction, member=target)
+
+    start_mock.assert_awaited_once()
+    add_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_setup_delegate_slash_surfaces_db_failure():
+    """A DB error during delegation surfaces as an error reply, not a
+    fake success.
+    """
+    from cogs.setup_cog import SetupCog
+
+    cog = SetupCog(MagicMock())
+    actor = _owner_member()
+    target = _target_member(77)
+    interaction = _delegate_interaction(actor)
+
+    with (
+        patch(
+            "cogs.setup._helpers.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_delegated_session(delegated=()),
+        ),
+        patch(
+            "cogs.setup._helpers.setup_session.add_delegated_admin",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("DB exploded"),
+        ),
+    ):
+        await cog.setup_delegate_slash.callback(cog, interaction, member=target)
+
+    msg = interaction.response.send_message.await_args.args[0].lower()
+    assert "could not" in msg

--- a/tests/unit/services/test_setup_channel.py
+++ b/tests/unit/services/test_setup_channel.py
@@ -12,6 +12,28 @@ from services.setup_channel import (
     SETUP_CHANNEL_NAME,
     ensure_setup_channel,
 )
+from services.setup_session import SetupSession
+
+
+def _session(
+    *,
+    guild_id: int = 1,
+    delegated_admins: tuple[int, ...] = (),
+    setup_channel_id: int | None = None,
+) -> SetupSession:
+    return SetupSession(
+        guild_id=guild_id,
+        guild_name="Test",
+        owner_id=99,
+        setup_status="in_progress",
+        setup_channel_id=setup_channel_id,
+        setup_message_id=None,
+        last_readiness_score=None,
+        current_step=None,
+        delegated_admins=delegated_admins,
+        skipped_sections=frozenset(),
+        depth=None,
+    )
 
 
 def _make_guild(
@@ -21,6 +43,8 @@ def _make_guild(
     me_present: bool = True,
     owner_present: bool = True,
     cached_channel: discord.TextChannel | None = None,
+    roles: list | None = None,
+    delegated_members: dict[int, discord.Member] | None = None,
 ):
     g = MagicMock(spec=discord.Guild)
     g.id = guild_id
@@ -39,11 +63,35 @@ def _make_guild(
     else:
         g.owner = None
 
-    g.default_role = MagicMock()
+    default_role = MagicMock()
+    default_role.id = 0
+    g.default_role = default_role
+    g.roles = roles if roles is not None else [default_role]
     g.get_channel = MagicMock(
         return_value=cached_channel if cached_channel is not None else None,
     )
+    delegated_members = delegated_members or {}
+    g.get_member = MagicMock(side_effect=lambda uid: delegated_members.get(uid))
     return g
+
+
+def _make_role(
+    *,
+    role_id: int,
+    administrator: bool,
+    name: str = "role",
+) -> MagicMock:
+    role = MagicMock(spec=discord.Role)
+    role.id = role_id
+    role.name = name
+    role.permissions = SimpleNamespace(administrator=administrator)
+    return role
+
+
+def _make_member(member_id: int) -> MagicMock:
+    member = MagicMock(spec=discord.Member)
+    member.id = member_id
+    return member
 
 
 def _make_text_channel(channel_id: int = 7000):
@@ -189,6 +237,212 @@ async def test_ensure_setup_channel_passes_private_overwrites():
     assert guild.me in overwrites
     # Owner must be granted access when present
     assert guild.owner in overwrites
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — admin-role denial, delegated-admin allow, recompute on reuse
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ensure_setup_channel_denies_administrator_roles_explicitly():
+    """Roles with the administrator permission are denied view_channel
+    explicitly so an audit reading the overwrite set sees the intent.
+    """
+    admin_role = _make_role(role_id=100, administrator=True, name="Admin")
+    non_admin_role = _make_role(role_id=200, administrator=False, name="Member")
+    guild = _make_guild(roles=[_make_role(role_id=0, administrator=False), admin_role, non_admin_role])
+    # default_role id must match the one we passed
+    guild.default_role = guild.roles[0]
+    created = _make_text_channel(7000)
+
+    with patch(
+        "services.setup_channel.ensure_channel",
+        new_callable=AsyncMock,
+        return_value=created,
+    ) as ensure_mock:
+        await ensure_setup_channel(guild)
+
+    overwrites = ensure_mock.await_args.kwargs["overwrites"]
+    assert admin_role in overwrites
+    assert overwrites[admin_role].view_channel is False
+    # Non-admin roles do NOT get an explicit overwrite — they fall
+    # through @everyone's denial.
+    assert non_admin_role not in overwrites
+
+
+@pytest.mark.asyncio
+async def test_ensure_setup_channel_grants_delegated_admins_explicit_access():
+    delegate = _make_member(42)
+    guild = _make_guild(delegated_members={42: delegate})
+    session = _session(delegated_admins=(42,))
+    created = _make_text_channel(7000)
+
+    with patch(
+        "services.setup_channel.ensure_channel",
+        new_callable=AsyncMock,
+        return_value=created,
+    ) as ensure_mock:
+        await ensure_setup_channel(guild, session=session)
+
+    overwrites = ensure_mock.await_args.kwargs["overwrites"]
+    assert delegate in overwrites
+    grant = overwrites[delegate]
+    assert grant.view_channel is True
+    assert grant.send_messages is True
+
+
+@pytest.mark.asyncio
+async def test_ensure_setup_channel_skips_delegated_admins_who_left_guild():
+    """A delegated id that doesn't resolve to a current member is
+    skipped silently — they may have left the guild.  The session row
+    keeps the id for the next recompute when they rejoin.
+    """
+    # delegated_members map has no entry for id 42
+    guild = _make_guild(delegated_members={})
+    session = _session(delegated_admins=(42,))
+    created = _make_text_channel(7000)
+
+    with patch(
+        "services.setup_channel.ensure_channel",
+        new_callable=AsyncMock,
+        return_value=created,
+    ) as ensure_mock:
+        await ensure_setup_channel(guild, session=session)
+
+    overwrites = ensure_mock.await_args.kwargs["overwrites"]
+    member_ids = [getattr(k, "id", None) for k in overwrites]
+    assert 42 not in member_ids
+
+
+@pytest.mark.asyncio
+async def test_ensure_setup_channel_recomputes_overwrites_on_cached_reuse():
+    """When the cached channel id resolves, overwrites are still
+    re-applied so admin-role denials and delegate grants follow the
+    latest membership snapshot.  Pre-Phase 1 this was a silent
+    no-op.
+    """
+    delegate = _make_member(42)
+    cached = _make_text_channel(7000)
+    cached.edit = AsyncMock()
+    guild = _make_guild(cached_channel=cached, delegated_members={42: delegate})
+    session = _session(delegated_admins=(42,))
+
+    with patch(
+        "services.setup_channel.ensure_channel",
+        new_callable=AsyncMock,
+    ) as ensure_mock:
+        channel, was_created = await ensure_setup_channel(
+            guild,
+            existing_channel_id=7000,
+            session=session,
+        )
+
+    # The create path is not invoked because the channel was cached.
+    ensure_mock.assert_not_called()
+    assert channel is cached
+    assert was_created is False
+    # But edit() WAS called to recompute overwrites.
+    cached.edit.assert_awaited_once()
+    edit_kwargs = cached.edit.await_args.kwargs
+    overwrites = edit_kwargs["overwrites"]
+    assert delegate in overwrites
+    assert overwrites[delegate].view_channel is True
+
+
+@pytest.mark.asyncio
+async def test_ensure_setup_channel_recompute_on_reuse_is_idempotent():
+    """Recompute on reuse can run repeatedly without error or duplicate
+    side effects beyond a single edit per call.
+    """
+    delegate = _make_member(42)
+    cached = _make_text_channel(7000)
+    cached.edit = AsyncMock()
+    guild = _make_guild(cached_channel=cached, delegated_members={42: delegate})
+    session = _session(delegated_admins=(42,))
+
+    with patch(
+        "services.setup_channel.ensure_channel",
+        new_callable=AsyncMock,
+    ):
+        for _ in range(3):
+            await ensure_setup_channel(
+                guild,
+                existing_channel_id=7000,
+                session=session,
+            )
+
+    # One edit per call — no batching, no skipping.
+    assert cached.edit.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_recompute_setup_channel_overwrites_uses_session_channel_id():
+    from services.setup_channel import recompute_setup_channel_overwrites
+
+    cached = _make_text_channel(7000)
+    cached.edit = AsyncMock()
+    guild = _make_guild(cached_channel=cached)
+    session = _session(setup_channel_id=7000)
+
+    ok = await recompute_setup_channel_overwrites(guild, session)
+    assert ok is True
+    cached.edit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_recompute_setup_channel_overwrites_returns_false_when_unresolvable():
+    """No channel id, no explicit channel arg, no recompute possible."""
+    from services.setup_channel import recompute_setup_channel_overwrites
+
+    guild = _make_guild(cached_channel=None)
+    session = _session(setup_channel_id=None)
+
+    ok = await recompute_setup_channel_overwrites(guild, session)
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_recompute_setup_channel_overwrites_with_explicit_channel():
+    """An explicit channel arg bypasses the session.setup_channel_id lookup."""
+    from services.setup_channel import recompute_setup_channel_overwrites
+
+    cached = _make_text_channel(7000)
+    cached.edit = AsyncMock()
+    guild = _make_guild(cached_channel=None)
+    session = _session(setup_channel_id=None)
+
+    ok = await recompute_setup_channel_overwrites(
+        guild,
+        session,
+        channel=cached,
+    )
+    assert ok is True
+    cached.edit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_recompute_setup_channel_overwrites_handles_forbidden():
+    """A Forbidden during edit returns False but does not raise."""
+    from services.setup_channel import recompute_setup_channel_overwrites
+
+    cached = _make_text_channel(7000)
+    cached.edit = AsyncMock(
+        side_effect=discord.Forbidden(MagicMock(), "denied"),
+    )
+    guild = _make_guild(cached_channel=cached)
+    session = _session(setup_channel_id=7000)
+
+    ok = await recompute_setup_channel_overwrites(guild, session)
+    assert ok is False
+
+
+def test_privacy_note_is_exported_and_mentions_interaction_checks():
+    from services.setup_channel import PRIVACY_NOTE
+
+    text = PRIVACY_NOTE.lower()
+    assert "admins" in text
+    assert "interaction checks" in text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_setup_session.py
+++ b/tests/unit/services/test_setup_session.py
@@ -242,3 +242,73 @@ async def test_resume_session_hydrates_skipped_sections(_mock_db):
     session = await svc.resume_session(1)
     assert session is not None
     assert session.skipped_sections == frozenset({"cleanup", "cog_routing"})
+
+
+# ---------------------------------------------------------------------------
+# Delegated-admin lifecycle wrappers (Phase 1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_add_delegated_admin_routes_to_db_layer():
+    with (
+        patch(
+            "services.setup_session.db.add_delegated_admin",
+            new_callable=AsyncMock,
+        ) as add_mock,
+        patch(
+            "services.setup_session._emit_session_audit",
+            new_callable=AsyncMock,
+        ) as audit_mock,
+    ):
+        await svc.add_delegated_admin(guild_id=1, user_id=42, actor_id=99)
+    add_mock.assert_awaited_once_with(1, 42)
+    audit_mock.assert_awaited_once()
+    kwargs = audit_mock.await_args.kwargs
+    assert kwargs["guild_id"] == 1
+    assert kwargs["mutation_type"] == "setup.delegated_admin.added"
+    assert kwargs["new_value"] == "42"
+    assert kwargs["actor_id"] == 99
+    assert kwargs["actor_type"] == "user"
+
+
+@pytest.mark.asyncio
+async def test_remove_delegated_admin_routes_to_db_layer():
+    with (
+        patch(
+            "services.setup_session.db.remove_delegated_admin",
+            new_callable=AsyncMock,
+        ) as remove_mock,
+        patch(
+            "services.setup_session._emit_session_audit",
+            new_callable=AsyncMock,
+        ) as audit_mock,
+    ):
+        await svc.remove_delegated_admin(guild_id=1, user_id=42, actor_id=99)
+    remove_mock.assert_awaited_once_with(1, 42)
+    audit_mock.assert_awaited_once()
+    kwargs = audit_mock.await_args.kwargs
+    assert kwargs["mutation_type"] == "setup.delegated_admin.removed"
+    assert kwargs["new_value"] == "42"
+
+
+@pytest.mark.asyncio
+async def test_add_delegated_admin_does_not_double_emit_audit_on_idempotent_grant():
+    """Calling add_delegated_admin twice for the same user emits the
+    audit event each time — the DB layer is idempotent on the
+    underlying set, but the audit trail records every operator action
+    (the owner pressed delegate again; that's still an action).
+    """
+    with (
+        patch(
+            "services.setup_session.db.add_delegated_admin",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "services.setup_session._emit_session_audit",
+            new_callable=AsyncMock,
+        ) as audit_mock,
+    ):
+        await svc.add_delegated_admin(guild_id=1, user_id=42, actor_id=99)
+        await svc.add_delegated_admin(guild_id=1, user_id=42, actor_id=99)
+    assert audit_mock.await_count == 2

--- a/tests/unit/views/setup/test_wizard_hub.py
+++ b/tests/unit/views/setup/test_wizard_hub.py
@@ -195,6 +195,99 @@ def test_build_hub_embed_marks_skipped_sections_with_warning_badge():
     assert "⚠️" in value
 
 
+# ---------------------------------------------------------------------------
+# Phase 1 — _gate_apply (replaces _gate_owner) accepts delegated admins
+# ---------------------------------------------------------------------------
+
+
+def _delegated_member(member_id: int = 42, guild_owner_id: int = 99):
+    """Member who is not the server owner but is in delegated_admins."""
+    import discord
+
+    m = MagicMock(spec=discord.Member)
+    m.id = member_id
+    m.guild = SimpleNamespace(owner_id=guild_owner_id)
+    m.guild_permissions = SimpleNamespace(administrator=False)
+    return m
+
+
+def _session_with_delegated(delegated_admins=(42,)):
+    return SetupSession(
+        guild_id=1,
+        guild_name="Test",
+        owner_id=99,
+        setup_status="in_progress",
+        setup_channel_id=None,
+        setup_message_id=None,
+        last_readiness_score=None,
+        current_step=None,
+        delegated_admins=delegated_admins,
+        skipped_sections=frozenset(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_hub_section_button_accepts_delegated_admin():
+    """A delegated admin (non-owner) can press section buttons.
+
+    Pre-Phase-1 the hub's _gate_owner allowed only the server owner,
+    blocking delegated admins even though hub entry accepted them.
+    The replacement _gate_apply defers to can_apply_setup.
+    """
+    delegated = _delegated_member(42)
+    view = SetupHubView(delegated, session=_session_with_delegated((42,)))
+    interaction = _interaction(delegated)
+    fake_embed = MagicMock()
+    with (
+        patch(
+            "cogs.diagnostic._platform_embeds.build_setup_readiness_embed",
+            new_callable=AsyncMock,
+            return_value=fake_embed,
+        ),
+        patch(
+            "services.setup_session.mark_in_progress",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await _section_button(view, "readiness").callback(interaction)
+    # Section ran (readiness embed was sent) — not the access-denied embed.
+    interaction.response.send_message.assert_awaited_once()
+    sent_kwargs = interaction.response.send_message.await_args.kwargs
+    assert sent_kwargs.get("embed") is fake_embed
+
+
+@pytest.mark.asyncio
+async def test_hub_section_button_rejects_non_delegated_admin():
+    """A plain administrator (not delegated, not owner) is rejected."""
+    other = _other_member()  # admin=True, id=42, owner=99, no delegation
+    view = SetupHubView(other, session=_session_with_delegated(()))
+    interaction = _interaction(other)
+    await _section_button(view, "readiness").callback(interaction)
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0].lower()
+    # Reject message now mentions delegation as the recovery path.
+    assert "delegate" in msg or "owner" in msg
+
+
+@pytest.mark.asyncio
+async def test_hub_section_button_rejects_member_without_delegation_when_session_changes():
+    """Even if the hub was constructed with a session granting delegation,
+    a later session without that delegation must NOT be silently used —
+    the gate reads the live ``self.session``.  We verify by mutating
+    the view's session in-place.
+    """
+    delegated = _delegated_member(42)
+    session_granting = _session_with_delegated((42,))
+    view = SetupHubView(delegated, session=session_granting)
+    # Mutate the session to revoke delegation.
+    view.session = _session_with_delegated(())
+    interaction = _interaction(delegated)
+    await _section_button(view, "readiness").callback(interaction)
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0].lower()
+    assert "delegate" in msg or "owner" in msg
+
+
 @pytest.mark.asyncio
 async def test_hub_readiness_button_owner_only():
     view = SetupHubView(_other_member())


### PR DESCRIPTION
## Summary

Phase 1 of the setup-wizard plan. Brings the hub, section cards, Final Review, the setup channel, and the cog's slash commands in line with the documented access model: **owner + delegated setup admins can stage and apply; plain administrators get read-only**.

Phase 0 (Final Review safety foundation) landed in #328. This PR builds on that and unblocks the Phase 2 builder adapter work.

### What changed

- **`services.setup_channel`** — `_private_overwrites` now denies `@everyone` and every administrator-permission role explicitly, and allows the owner, the bot, and every delegated setup admin id from the session snapshot. New `recompute_setup_channel_overwrites(guild, session)`; `ensure_setup_channel` calls it on reuse so existing channels are repaired rather than returned unchanged. `PRIVACY_NOTE` documents that Discord's admin-permission override can still reveal the channel — the real boundary is `can_apply_setup`.
- **`services.setup_session`** — new `add_delegated_admin` / `remove_delegated_admin` wrappers around the existing `utils.db.setup_session` primitives. Wrappers emit `setup.delegated_admin.added` / `.removed` audit events.
- **`cogs.setup_cog`** — owner-only `/setup-delegate` and `/setup-undelegate` slash commands. Bodies live in `cogs.setup._helpers.toggle_delegate` to keep `setup_cog.py` under the S4.6 800-LOC ceiling. Both commands reject bot targets and the owner-self-grant edge case, start a session row if missing, and trigger `recompute_setup_channel_overwrites` after the DB write.
- **`views.setup.hub`** — `_gate_owner` (server-owner-only) → `_gate_apply` using `setup_access.can_apply_setup` against the live `self.session`. Pre-Phase-1 the hub bounced every delegated admin off every button even though hub entry already accepted them.
- **`views.setup.section_card` and `views.setup.final_review`** — per-button `_gate_apply` on every mutating button (Apply Recommended, Skip, Apply staged setup, Retry). `BaseView`'s author gate already restricts the panel to its opener; this layer additionally re-reads the session on each press so a delegated admin who lost delegation between opening the panel and pressing a button cannot mutate the draft.

### What did NOT change

No wizard UX, no command-surface routing changes (`/setup` / `!setup` semantics stay as-is), no logging presets, no AI setup, no cleanup work. Those are Phases 3–8.

## Test plan

- [x] `pytest tests/unit/services/test_setup_session.py tests/unit/services/test_setup_channel.py tests/unit/views/setup/test_wizard_hub.py tests/unit/cogs/test_setup_cog.py` — all pass (159 + the prior suites).
- [x] Wider sweep `pytest tests/unit/views/setup/ tests/unit/services/ tests/unit/db/ tests/unit/cogs/ tests/unit/invariants/` — 2990 pass, 2 skipped, the 11 failures all reproduce on `main` (test_runtime, test_webhook_reporter, test_lifecycle_observability_contract — unrelated to setup).
- [x] `black --check`, `isort --check-only`, `ruff check`, `mypy disbot/` — clean.
- [x] Cog-size invariant (S4.6) — `setup_cog.py` is 720 LOC after extracting `toggle_delegate` into `_helpers.py`.

### Manual checks deferred to a real Discord run (UI work)

- Owner pressing a hub button still works.
- Delegated admin can press hub / section card / Final Review buttons (Pre-Phase-1 they were bounced).
- Plain administrator gets the rejection message naming `/setup-delegate` as the recovery path.
- `/setup-delegate @user` grants the delegate and re-computes the setup channel overwrites so the new delegate gains channel access.
- `/setup-undelegate @user` revokes and re-computes.
- `/setup-delegate @bot` and `/setup-delegate @owner` are rejected with friendly messages.


---
_Generated by [Claude Code](https://claude.ai/code/session_018hiDeqzURZ1GEmNfssQd64)_