### PR TITLE
Setup wizard Phase 3: linear wizard shell

### DIFF
--- a/disbot/cogs/setup/_wizard_entry.py
+++ b/disbot/cogs/setup/_wizard_entry.py
@@ -1,0 +1,200 @@
+"""Workspace-anchor entry points for ``/setup`` and ``!setup``.
+
+Phase 3 of the setup-wizard plan.  Routes both slash and prefix
+invocations through the same flow:
+
+1. Resolve / start the session row.
+2. For owners + delegated admins → open the linear wizard via
+   :func:`views.setup.wizard.open_setup_workspace` (posts / edits one
+   anchor message in ``#superbot-setup``), then reply transiently in
+   the invoking channel with a jump link.
+3. For plain administrators → render the read-only readiness embed
+   (mirror of the legacy ``_resolve_hub_entry`` "readiness" mode).
+4. For everyone else → deny.
+
+Extracted from :mod:`cogs.setup_cog` to keep the cog file under the
+S4.6 800-LOC ceiling.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import discord
+from discord.ext import commands
+
+from services import setup_access, setup_session
+from views.setup.wizard import jump_link, open_setup_workspace
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger("bot.cogs.setup.wizard_entry")
+
+
+async def open_wizard_from_slash(interaction: discord.Interaction) -> None:
+    """Slash-command entry point.  Ephemeral throughout."""
+    guild = interaction.guild
+    member = interaction.user
+    if guild is None or not isinstance(member, discord.Member):
+        await interaction.response.send_message(
+            "Use `/setup` from inside the server.",
+            ephemeral=True,
+        )
+        return
+
+    session = await _resume_or_start(guild, owner_id=member.id)
+    if setup_access.can_apply_setup(member, session):
+        await _open_wizard_workspace_for_slash(interaction, guild, member, session)
+        return
+
+    if setup_access.is_setup_admin(member, session):
+        from cogs.diagnostic._platform_embeds import build_setup_readiness_embed
+
+        embed = await build_setup_readiness_embed(guild.id, guild=guild)
+        if embed is None:
+            await interaction.response.send_message(
+                "Could not build the readiness scan.",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+        return
+
+    await interaction.response.send_message(
+        "Only the server owner, an administrator, or a delegated "
+        "setup admin can open the setup wizard.",
+        ephemeral=True,
+    )
+
+
+async def open_wizard_from_prefix(ctx: commands.Context) -> None:
+    """Prefix-command entry point.  Posts a transient confirmation in the
+    invoking channel (prefix replies can't be ephemeral; we keep the
+    channel-side noise minimal).
+    """
+    guild = ctx.guild
+    member = ctx.author
+    if guild is None or not isinstance(member, discord.Member):
+        await ctx.send("Run `!setup` from inside the server.")
+        return
+
+    session = await _resume_or_start(guild, owner_id=member.id)
+    if setup_access.can_apply_setup(member, session):
+        await _open_wizard_workspace_for_prefix(ctx, guild, member, session)
+        return
+
+    if setup_access.is_setup_admin(member, session):
+        from cogs.diagnostic._platform_embeds import build_setup_readiness_embed
+
+        embed = await build_setup_readiness_embed(guild.id, guild=guild)
+        if embed is None:
+            await ctx.send("Could not build the readiness scan.")
+            return
+        await ctx.send(embed=embed)
+        return
+
+    await ctx.send(
+        "Only the server owner, an administrator, or a delegated "
+        "setup admin can open the setup wizard.",
+    )
+
+
+async def _resume_or_start(
+    guild: discord.Guild,
+    *,
+    owner_id: int,
+) -> setup_session.SetupSession | None:
+    """Return the existing session row, starting one if missing.
+
+    Best-effort: a DB failure on start_session is logged and ``None``
+    is returned so the caller continues with the "denied" path.
+    """
+    try:
+        session = await setup_session.resume_session(guild.id)
+    except Exception:
+        logger.exception("_wizard_entry.resume failed")
+        session = None
+    if session is None:
+        try:
+            session = await setup_session.start_session(
+                guild_id=guild.id,
+                guild_name=guild.name,
+                owner_id=guild.owner_id or owner_id,
+            )
+        except Exception:
+            logger.exception("_wizard_entry.start_session failed")
+            session = None
+    return session
+
+
+async def _open_wizard_workspace_for_slash(
+    interaction: discord.Interaction,
+    guild: discord.Guild,
+    member: discord.Member,
+    session: setup_session.SetupSession | None,
+) -> None:
+    channel, message, reason = await open_setup_workspace(
+        guild,
+        member=member,
+        session=session,
+    )
+    if reason == "no_channel" or channel is None:
+        await interaction.response.send_message(
+            "I couldn't ensure the private `#superbot-setup` channel — "
+            "I need the **Manage Channels** permission.  Grant it and "
+            "re-run `/setup`.",
+            ephemeral=True,
+        )
+        return
+    if reason == "post_failed" or message is None:
+        await interaction.response.send_message(
+            f"The `#superbot-setup` channel exists ({channel.mention}) "
+            "but I couldn't post the wizard there — check my permissions "
+            "in that channel.",
+            ephemeral=True,
+        )
+        return
+
+    await interaction.response.send_message(
+        f"Setup wizard is open in {channel.mention} — {jump_link(message)}.",
+        ephemeral=True,
+    )
+
+
+async def _open_wizard_workspace_for_prefix(
+    ctx: commands.Context,
+    guild: discord.Guild,
+    member: discord.Member,
+    session: setup_session.SetupSession | None,
+) -> None:
+    channel, message, reason = await open_setup_workspace(
+        guild,
+        member=member,
+        session=session,
+    )
+    if reason == "no_channel" or channel is None:
+        await ctx.send(
+            "I couldn't ensure the private `#superbot-setup` channel — "
+            "I need the **Manage Channels** permission.  Grant it and "
+            "re-run `!setup`.",
+        )
+        return
+    if reason == "post_failed" or message is None:
+        await ctx.send(
+            f"The `#superbot-setup` channel exists ({channel.mention}) "
+            "but I couldn't post the wizard there — check my permissions "
+            "in that channel.",
+        )
+        return
+
+    await ctx.send(
+        f"Setup wizard is open in {channel.mention} — {jump_link(message)}.",
+    )
+
+
+__all__ = [
+    "open_wizard_from_prefix",
+    "open_wizard_from_slash",
+]

--- a/disbot/cogs/setup_cog.py
+++ b/disbot/cogs/setup_cog.py
@@ -72,41 +72,18 @@ class SetupCog(commands.Cog):
     @commands.command(name="setup")
     @commands.guild_only()
     async def setup_cmd(self, ctx: commands.Context) -> None:
-        """Open or resume the setup wizard from any channel.
+        """Open or resume the linear setup wizard.
 
-        Owners and delegated setup admins get the hub; administrators
+        Routes through :func:`views.setup.wizard.open_setup_workspace`
+        so the wizard message lives in ``#superbot-setup`` and the
+        invoking channel only receives a transient pointer reply.
+        Owners and delegated setup admins get the wizard; administrators
         without delegation get a read-only readiness embed; everyone
         else is denied.
         """
-        guild = ctx.guild
-        member = ctx.author
-        if guild is None or not isinstance(member, discord.Member):
-            await ctx.send("Run `!setup` from inside the server.")
-            return
+        from cogs.setup._wizard_entry import open_wizard_from_prefix
 
-        embed, view, mode = await _resolve_hub_entry(member, guild)
-        if mode == "denied":
-            await ctx.send(
-                "Only the server owner, an administrator, or a delegated "
-                "setup admin can open the setup wizard.",
-            )
-            return
-        if mode == "readiness":
-            if embed is None:
-                await ctx.send("Could not build the readiness scan.")
-                return
-            await ctx.send(embed=embed)
-            return
-
-        if embed is None or view is None:
-            await ctx.send("Could not build the setup hub. See logs.")
-            return
-        await ctx.send(embed=embed, view=view)
-        if mode == "hub":
-            try:
-                await setup_session.mark_in_progress(guild.id, step="hub")
-            except Exception:
-                logger.exception("setup_cog.setup_cmd: mark_in_progress failed")
+        await open_wizard_from_prefix(ctx)
 
     @app_commands.command(
         name="setup",
@@ -116,15 +93,37 @@ class SetupCog(commands.Cog):
     @app_commands.checks.has_permissions(administrator=True)
     @app_commands.guild_only()
     async def setup_slash(self, interaction: discord.Interaction) -> None:
-        """Ephemeral slash front door for the setup wizard.
+        """Ephemeral slash front door for the linear setup wizard.
 
-        Mirrors the access ladder of the prefix command.
+        Routes through :func:`views.setup.wizard.open_setup_workspace`
+        so the wizard message lives in ``#superbot-setup`` and the
+        slash response is a transient ephemeral pointer reply.
+        """
+        from cogs.setup._wizard_entry import open_wizard_from_slash
+
+        await open_wizard_from_slash(interaction)
+
+    @app_commands.command(
+        name="setup-hub",
+        description="Open the legacy section-list hub (compat).",
+    )
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.guild_only()
+    async def setup_hub_slash(self, interaction: discord.Interaction) -> None:
+        """Legacy section-list hub.
+
+        Preserved as a compatibility command for operators (and tests)
+        that want the registry-driven section list as the entry point
+        instead of the linear wizard.  Same access ladder as ``/setup``
+        used to use: owner / delegated admin → hub; plain admin →
+        readiness; otherwise denied.
         """
         guild = interaction.guild
         member = interaction.user
         if guild is None or not isinstance(member, discord.Member):
             await interaction.response.send_message(
-                "Use `/setup` from inside the server.",
+                "Use `/setup-hub` from inside the server.",
                 ephemeral=True,
             )
             return
@@ -133,7 +132,7 @@ class SetupCog(commands.Cog):
         if mode == "denied":
             await interaction.response.send_message(
                 "Only the server owner, an administrator, or a delegated "
-                "setup admin can open the setup wizard.",
+                "setup admin can open the setup hub.",
                 ephemeral=True,
             )
             return
@@ -162,7 +161,7 @@ class SetupCog(commands.Cog):
             try:
                 await setup_session.mark_in_progress(guild.id, step="hub")
             except Exception:
-                logger.exception("setup_cog.setup_slash: mark_in_progress failed")
+                logger.exception("setup_cog.setup_hub_slash: mark_in_progress failed")
 
     @app_commands.command(
         name="setup-depth",

--- a/disbot/services/setup_session.py
+++ b/disbot/services/setup_session.py
@@ -228,6 +228,20 @@ async def record_readiness_score(guild_id: int, score: int | None) -> None:
     await db.set_readiness_score(guild_id, score)
 
 
+async def set_setup_message_id(guild_id: int, message_id: int | None) -> None:
+    """Persist (or clear) the wizard's anchor message id for ``guild_id``.
+
+    The setup wizard's workspace flow (Phase 3) posts a single message
+    in ``#superbot-setup`` and re-edits it across the session lifetime;
+    ``message_id`` is the Discord snowflake of that anchor.  Passing
+    ``None`` clears the pointer — used when the launcher cog's resume
+    sweep can't refetch the message and the next ``/setup`` reposts.
+
+    Idempotent.  Side-effect-free above the DB layer.
+    """
+    await db.set_setup_message_id(guild_id, message_id)
+
+
 async def mark_section_skipped(guild_id: int, slug: str) -> None:
     """Record that ``slug`` was explicitly skipped during the current run.
 
@@ -443,6 +457,7 @@ __all__ = [
     "remove_delegated_admin",
     "resume_session",
     "set_depth",
+    "set_setup_message_id",
     "start_session",
     "unack_section",
     "unmark_section_skipped",

--- a/disbot/utils/db/setup_session.py
+++ b/disbot/utils/db/setup_session.py
@@ -272,6 +272,31 @@ async def clear_acknowledged_sections(guild_id: int) -> None:
     )
 
 
+async def set_setup_message_id(guild_id: int, message_id: int | None) -> None:
+    """Persist (or clear) the workspace wizard's anchor message id.
+
+    The setup wizard posts a single message in the private setup channel
+    and re-edits it across the session lifetime; ``message_id`` is the
+    Discord snowflake of that anchor.  Passing ``None`` clears the
+    pointer (e.g. when the launcher cog's resume sweep can't refetch
+    the message and chooses to repost on the next ``/setup``).
+
+    A dedicated setter is required because :func:`upsert` COALESCEs
+    its ``setup_message_id`` argument with the existing value, so the
+    upsert path cannot clear a stale id.
+    """
+    await pool.get().execute(
+        """
+        UPDATE setup_session
+           SET setup_message_id = $2,
+               updated_at       = NOW()
+         WHERE guild_id = $1
+        """,
+        guild_id,
+        message_id,
+    )
+
+
 KNOWN_DEPTHS: frozenset[str] = frozenset({"quick", "standard", "advanced"})
 
 
@@ -313,6 +338,7 @@ __all__ = [
     "remove_skipped_section",
     "set_depth",
     "set_readiness_score",
+    "set_setup_message_id",
     "set_status",
     "set_step",
     "upsert",

--- a/disbot/views/setup/wizard.py
+++ b/disbot/views/setup/wizard.py
@@ -1,0 +1,889 @@
+"""Linear setup wizard — step-by-step section walkthrough.
+
+Phase 3 of the setup-wizard plan.  Replaces the registry-driven hub
+as the default ``/setup`` / ``!setup`` entry point with a guided
+linear UX: one section per step, navigation buttons, "nothing
+changes until Final Review" reassurance, and a final step that opens
+:class:`views.setup.final_review.FinalReviewView`.
+
+Architecture
+------------
+
+* :class:`LinearWizardView` is the short-lived per-interaction view.
+  It does NOT persist across bot restarts; on a stale interaction
+  after restart, the launcher cog falls back to "this setup message
+  has expired — run ``/setup`` again" and the next ``/setup``
+  edits the existing anchor message in place.
+* The wizard is the **view layer only** — it stages draft operations
+  through :func:`services.setup_draft.replace_recommended_for_section`
+  (Phase 0 / Phase 2 helper), reads progress via
+  :mod:`services.setup_progress`, and gates every mutating button
+  through :func:`services.setup_access.can_apply_setup`.
+* The hub continues to exist; the wizard's ``Open hub`` button posts
+  the hub-style embed as a transient reply so operators who prefer
+  the section-list UI still get it.  ``/setup-hub`` remains as the
+  explicit hub entry point.
+
+Lifecycle
+---------
+
+1. ``/setup`` / ``!setup`` resolves the session, ensures
+   ``#superbot-setup`` exists, and routes through
+   :func:`open_setup_workspace`.
+2. :func:`open_setup_workspace` posts (or edits in place) one
+   anchor message in ``#superbot-setup`` and writes its id back to
+   the session via :func:`services.setup_session.set_setup_message_id`.
+3. The invoking channel receives an ephemeral / transient pointer
+   reply with a jump link to the anchor.
+4. Button presses on the anchor update :attr:`LinearWizardView.step`
+   in place; the helpers re-render the embed without changing the
+   anchor's id.
+
+Skip semantics (Phase 3)
+------------------------
+
+``Skip`` writes the section's slug to
+:attr:`SetupSession.skipped_sections` via
+:func:`services.setup_session.mark_section_skipped`.  When the
+section has Phase-0 provenance (rows with ``section_slug`` set),
+those rows are also deleted from the draft so Final Review never
+applies an op the operator chose to skip.  Without provenance the
+delete is best-effort and a confirmation message warns the operator
+that stale rows may remain (Phase 4+ removes that gap).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import discord
+
+from services import (
+    setup_access,
+    setup_channel,
+    setup_draft,
+    setup_progress,
+    setup_session,
+)
+from services.setup_sections import REGISTRY, SetupSection
+from services.setup_session import SetupSession
+from views.base import BaseView
+from views.setup.section_card import call_recommended_ops_builder
+
+if TYPE_CHECKING:
+    from services.setup_draft import DraftOperationRow
+
+logger = logging.getLogger("bot.views.setup.wizard")
+
+
+_WIZARD_TITLE = "🛰 SuperBot setup wizard"
+_FOOTER_HINT = "Nothing changes until Final Review applies the staged operations."
+
+
+def _resolve_sections(session: SetupSession | None) -> list[SetupSection]:
+    """Return the depth-filtered section list for ``session``."""
+    depth = session.depth if session is not None else None
+    return REGISTRY.for_depth(depth)
+
+
+def _step_index_for(
+    session: SetupSession | None,
+    sections: list[SetupSection],
+) -> int:
+    """Return the index of ``session.current_step`` in ``sections``.
+
+    Falls back to 0 (first step) when the session is missing, has no
+    ``current_step``, or the recorded step no longer exists in the
+    depth-filtered registry (e.g. operator switched depth between runs).
+    """
+    if session is None or not session.current_step:
+        return 0
+    for idx, section in enumerate(sections):
+        if section.slug == session.current_step:
+            return idx
+    return 0
+
+
+def _short_state_for(
+    section: SetupSection,
+    draft_rows: list[DraftOperationRow],
+) -> str:
+    """Return a one-line summary of the section's current staged state.
+
+    Reads provenance-matched rows from ``draft_rows`` (the typed
+    wrapper) and returns ``"N op(s) staged"`` plus a hint when the
+    rows are recommended-staged.  Empty for sections with no matching
+    rows so the embed stays compact.
+    """
+    matching = [
+        row
+        for row in draft_rows
+        if (row.section_slug == section.slug)
+        or (row.section_slug is None and row.op.kind in section.op_kinds)
+    ]
+    if not matching:
+        return ""
+    count = len(matching)
+    noun = "operation" if count == 1 else "operations"
+    if all(row.staging_kind == "recommended" for row in matching):
+        return f"{count} recommended {noun} staged"
+    if all((row.staging_kind or "manual") != "recommended" for row in matching):
+        return f"{count} customised {noun} staged"
+    return f"{count} {noun} staged ({count} mixed)"
+
+
+def build_wizard_step_embed(
+    *,
+    session: SetupSession | None,
+    section: SetupSection,
+    step_index: int,
+    total_steps: int,
+    draft_rows: list[DraftOperationRow],
+) -> discord.Embed:
+    """Build the embed shown at wizard step ``step_index``.
+
+    Fields:
+
+    * **Detected** — one-line summary of the section's current staged
+      state, derived from ``draft_rows``.
+    * **Recommended action** — copy that describes what
+      ``Apply Recommended`` will do for this section.  Empty when the
+      section has no ``recommended_ops_builder``.
+    * **If you skip this** — pulled from
+      :attr:`SetupSection.description_if_skipped`.  Empty when the
+      section author hasn't supplied skip-impact text yet.
+    """
+    glyph_status = setup_progress.compute_section_status(
+        section,
+        session=session,
+        draft_ops=draft_rows,
+    )
+    glyph = setup_progress.badge_for(glyph_status.status)
+    skipped = session is not None and section.slug in session.skipped_sections
+    completed = session is not None and section.slug in session.acknowledged_sections
+
+    title = f"{_WIZARD_TITLE} · Step {step_index + 1}/{total_steps}"
+    if skipped:
+        accent = discord.Color.dark_grey()
+    elif completed or glyph_status.status.value == "recommended":
+        accent = discord.Color.green()
+    elif glyph_status.status.value == "customized":
+        accent = discord.Color.gold()
+    else:
+        accent = discord.Color.blurple()
+    embed = discord.Embed(
+        title=title,
+        description=(
+            f"{glyph} **{section.label}** "
+            f"({glyph_status.status.value.replace('_', ' ')})"
+        ),
+        color=accent,
+    )
+
+    detected = _short_state_for(section, draft_rows)
+    embed.add_field(
+        name="Current state",
+        value=detected or "_(nothing staged for this step yet)_",
+        inline=False,
+    )
+
+    if section.recommended_ops_builder is not None:
+        embed.add_field(
+            name="Recommended action",
+            value=(
+                "Click **Apply Recommended** to stage this section's safe "
+                "defaults.  Nothing applies until **Final Review** confirms."
+            ),
+            inline=False,
+        )
+    else:
+        embed.add_field(
+            name="Recommended action",
+            value=(
+                "_(no recommended defaults — use Customize to open the "
+                "section's detail view.)_"
+            ),
+            inline=False,
+        )
+
+    if section.description_if_skipped:
+        embed.add_field(
+            name="If you skip this",
+            value=section.description_if_skipped,
+            inline=False,
+        )
+
+    embed.set_footer(text=_FOOTER_HINT)
+    return embed
+
+
+class LinearWizardView(BaseView):
+    """One-step-at-a-time wizard view.
+
+    Mutating buttons (``Apply Recommended``, ``Skip``) re-check
+    :func:`services.setup_access.can_apply_setup` against a fresh
+    session snapshot, mirroring the section card's per-button gate
+    from Phase 1.  Navigation buttons (``Back``, ``Continue``,
+    ``Open hub``, ``Cancel``) are not gated — they only mutate
+    view-local state.
+
+    The view does not own the anchor message; the caller (typically
+    :func:`open_setup_workspace`) edits the message after each
+    button press to re-render the new step.
+    """
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        *,
+        session: SetupSession | None,
+        sections: list[SetupSection],
+        step_index: int,
+        timeout: int = 600,
+    ) -> None:
+        super().__init__(author, public=False, timeout=timeout)
+        self.session = session
+        self.sections = sections
+        self.step_index = step_index
+        self._rebuild_buttons()
+
+    @property
+    def current_section(self) -> SetupSection | None:
+        if not self.sections:
+            return None
+        if self.step_index < 0 or self.step_index >= len(self.sections):
+            return None
+        return self.sections[self.step_index]
+
+    def _rebuild_buttons(self) -> None:
+        """Repopulate the button row based on the current step.
+
+        Called at construction and after every navigation step so the
+        button enabled/disabled state and the conditional last-step
+        ``Final review`` button reflect the operator's position.
+        """
+        self.clear_items()
+        section = self.current_section
+
+        back: discord.ui.Button = discord.ui.Button(  # type: ignore[var-annotated]
+            label="◀ Back",
+            style=discord.ButtonStyle.secondary,
+            custom_id="setup_wizard:back",
+            disabled=self.step_index <= 0,
+            row=0,
+        )
+        back.callback = self._on_back  # type: ignore[method-assign]
+        self.add_item(back)
+
+        apply_recommended: discord.ui.Button = discord.ui.Button(  # type: ignore[var-annotated]
+            label="Apply Recommended",
+            style=discord.ButtonStyle.success,
+            custom_id="setup_wizard:apply_recommended",
+            disabled=(section is None or section.recommended_ops_builder is None),
+            row=0,
+        )
+        apply_recommended.callback = self._on_apply_recommended  # type: ignore[method-assign]
+        self.add_item(apply_recommended)
+
+        customize: discord.ui.Button = discord.ui.Button(  # type: ignore[var-annotated]
+            label="Customize",
+            style=discord.ButtonStyle.primary,
+            custom_id="setup_wizard:customize",
+            disabled=True,
+            row=0,
+        )
+        customize.callback = self._on_customize  # type: ignore[method-assign]
+        self.add_item(customize)
+
+        skip: discord.ui.Button = discord.ui.Button(  # type: ignore[var-annotated]
+            label="Skip",
+            style=discord.ButtonStyle.secondary,
+            custom_id="setup_wizard:skip",
+            disabled=(section is None),
+            row=0,
+        )
+        skip.callback = self._on_skip  # type: ignore[method-assign]
+        self.add_item(skip)
+
+        is_last_step = self.step_index >= len(self.sections) - 1
+        continue_btn: discord.ui.Button = discord.ui.Button(  # type: ignore[var-annotated]
+            label="Continue ▶" if not is_last_step else "Final Review",
+            style=(
+                discord.ButtonStyle.primary
+                if is_last_step
+                else discord.ButtonStyle.secondary
+            ),
+            custom_id="setup_wizard:continue",
+            disabled=False,
+            row=1,
+        )
+        continue_btn.callback = self._on_continue  # type: ignore[method-assign]
+        self.add_item(continue_btn)
+
+        open_hub: discord.ui.Button = discord.ui.Button(  # type: ignore[var-annotated]
+            label="Open hub",
+            style=discord.ButtonStyle.secondary,
+            custom_id="setup_wizard:open_hub",
+            row=1,
+        )
+        open_hub.callback = self._on_open_hub  # type: ignore[method-assign]
+        self.add_item(open_hub)
+
+        cancel: discord.ui.Button = discord.ui.Button(  # type: ignore[var-annotated]
+            label="Cancel",
+            style=discord.ButtonStyle.danger,
+            custom_id="setup_wizard:cancel",
+            row=1,
+        )
+        cancel.callback = self._on_cancel  # type: ignore[method-assign]
+        self.add_item(cancel)
+
+    async def _gate_apply(self, interaction: discord.Interaction) -> bool:
+        member = interaction.user
+        if not isinstance(member, discord.Member):
+            await interaction.response.send_message(
+                "Use this from inside the server.",
+                ephemeral=True,
+            )
+            return False
+        session = None
+        guild_id = interaction.guild_id
+        if guild_id is not None:
+            try:
+                session = await setup_session.resume_session(guild_id)
+            except Exception:
+                logger.exception("wizard._gate_apply: resume failed")
+                session = None
+        if not setup_access.can_apply_setup(member, session):
+            await interaction.response.send_message(
+                "Only the server owner or a delegated setup admin can stage "
+                "or skip setup operations. Ask the server owner to grant "
+                "you `/setup-delegate`.",
+                ephemeral=True,
+            )
+            return False
+        return True
+
+    async def _refresh_and_edit(self, interaction: discord.Interaction) -> None:
+        """Refresh the session + draft state and edit the anchor message.
+
+        Used by every button callback that needs to repaint the embed
+        with new step / progress data.  Edits in place so the anchor's
+        id remains stable.
+        """
+        guild_id = interaction.guild_id
+        if guild_id is not None:
+            try:
+                self.session = await setup_session.resume_session(guild_id)
+            except Exception:
+                logger.exception("wizard._refresh_and_edit: resume failed")
+        # Re-resolve sections in case depth changed.
+        self.sections = _resolve_sections(self.session)
+        # Clamp step index in case the section list shrank.
+        if self.step_index >= len(self.sections):
+            self.step_index = max(0, len(self.sections) - 1)
+        self._rebuild_buttons()
+
+        draft_rows: list[DraftOperationRow] = []
+        if guild_id is not None:
+            try:
+                draft_rows = await setup_draft.list_rows(guild_id)
+            except Exception:
+                logger.exception("wizard._refresh_and_edit: list_rows failed")
+
+        section = self.current_section
+        if section is None:
+            embed = discord.Embed(
+                title=_WIZARD_TITLE,
+                description=(
+                    "No setup sections are available for this depth. "
+                    "Pick a different depth via `/setup-depth` or open "
+                    "the hub for the full section list."
+                ),
+                color=discord.Color.dark_grey(),
+            )
+        else:
+            embed = build_wizard_step_embed(
+                session=self.session,
+                section=section,
+                step_index=self.step_index,
+                total_steps=len(self.sections),
+                draft_rows=draft_rows,
+            )
+
+        if interaction.response.is_done():
+            await interaction.followup.edit_message(
+                message_id=interaction.message.id,
+                embed=embed,
+                view=self,
+            )
+        else:
+            await interaction.response.edit_message(embed=embed, view=self)
+
+    async def _on_back(self, interaction: discord.Interaction) -> None:
+        if self.step_index > 0:
+            self.step_index -= 1
+        await self._refresh_and_edit(interaction)
+
+    async def _on_continue(self, interaction: discord.Interaction) -> None:
+        if self.step_index < len(self.sections) - 1:
+            self.step_index += 1
+            await self._refresh_and_edit(interaction)
+            return
+        # Last step → open Final Review as a transient ephemeral.
+        await self._open_final_review(interaction)
+
+    async def _on_open_hub(self, interaction: discord.Interaction) -> None:
+        # Surface the existing hub-style embed as an ephemeral follow-up
+        # so the operator can browse the section list without losing
+        # the wizard anchor.
+        from views.setup.hub import SetupHubView, build_hub_embed
+
+        guild = interaction.guild
+        if guild is None:
+            await interaction.response.send_message(
+                "Open hub requires a guild context.",
+                ephemeral=True,
+            )
+            return
+
+        member = interaction.user
+        if not isinstance(member, discord.Member):
+            await interaction.response.send_message(
+                "Use this from inside the server.",
+                ephemeral=True,
+            )
+            return
+
+        try:
+            session = await setup_session.resume_session(guild.id)
+        except Exception:
+            logger.exception("wizard._on_open_hub: resume failed")
+            session = self.session
+
+        try:
+            draft_rows = await setup_draft.list_rows(guild.id)
+        except Exception:
+            logger.exception("wizard._on_open_hub: list_rows failed")
+            draft_rows = []
+
+        hub_view = SetupHubView(member, session=session)
+        embed = build_hub_embed(
+            session,
+            pending_ops=len(draft_rows),
+            draft_ops=draft_rows,
+        )
+        await interaction.response.send_message(
+            embed=embed,
+            view=hub_view,
+            ephemeral=True,
+        )
+
+    async def _on_cancel(self, interaction: discord.Interaction) -> None:
+        for child in self.children:
+            child.disabled = True  # type: ignore[attr-defined]
+        embed = discord.Embed(
+            title=_WIZARD_TITLE,
+            description=(
+                "Wizard closed.  Re-open with `/setup` or `!setup`; your "
+                "draft is preserved."
+            ),
+            color=discord.Color.dark_grey(),
+        )
+        if interaction.response.is_done():
+            await interaction.followup.edit_message(
+                message_id=interaction.message.id,
+                embed=embed,
+                view=self,
+            )
+        else:
+            await interaction.response.edit_message(embed=embed, view=self)
+        self.stop()
+
+    async def _on_apply_recommended(
+        self,
+        interaction: discord.Interaction,
+    ) -> None:
+        if not await self._gate_apply(interaction):
+            return
+        section = self.current_section
+        if section is None:
+            await interaction.response.send_message(
+                "No section selected.",
+                ephemeral=True,
+            )
+            return
+        builder = section.recommended_ops_builder
+        if builder is None:
+            await interaction.response.send_message(
+                "This step has no recommended defaults — use Customize "
+                "to open the detail view.",
+                ephemeral=True,
+            )
+            return
+        guild = interaction.guild
+        if guild is None or interaction.guild_id is None:
+            await interaction.response.send_message(
+                "Apply Recommended requires a guild context.",
+                ephemeral=True,
+            )
+            return
+        try:
+            session = await setup_session.resume_session(interaction.guild_id)
+        except Exception:
+            logger.exception("wizard._on_apply_recommended: resume failed")
+            session = self.session
+        try:
+            ops = await call_recommended_ops_builder(
+                builder,
+                guild=guild,
+                session=session,
+                depth=session.depth if session is not None else None,
+                section_slug=section.slug,
+            )
+        except Exception:
+            logger.exception(
+                "wizard._on_apply_recommended: builder failed (%s)",
+                section.slug,
+            )
+            await interaction.response.send_message(
+                "Could not build the recommended defaults — see logs.",
+                ephemeral=True,
+            )
+            return
+        if not ops:
+            await interaction.response.send_message(
+                "No recommended operations were generated for this step.",
+                ephemeral=True,
+            )
+            return
+        try:
+            result = await setup_draft.replace_recommended_for_section(
+                interaction.guild_id,
+                section.slug,
+                ops,
+                actor_id=interaction.user.id,
+                labels={
+                    idx: f"[wizard] {section.slug}.{op.kind}"
+                    for idx, op in enumerate(ops)
+                },
+            )
+        except Exception:
+            logger.exception(
+                "wizard._on_apply_recommended: replace_recommended failed",
+            )
+            await interaction.response.send_message(
+                "Could not stage the recommended operations — see logs.",
+                ephemeral=True,
+            )
+            return
+        try:
+            await setup_session.unmark_section_skipped(
+                interaction.guild_id,
+                section.slug,
+            )
+        except Exception:
+            logger.exception("wizard._on_apply_recommended: unmark skip failed")
+
+        count = len(result.inserted_seqs)
+        noun = "operation" if count == 1 else "operations"
+        conflict_text = ""
+        if result.conflicts:
+            cn = len(result.conflicts)
+            conflict_word = "row" if cn == 1 else "rows"
+            conflict_text = (
+                f"\n\n⚠️ Preserved **{cn} custom / preset {conflict_word}** "
+                "at conflicting slot(s); no overwrite."
+            )
+        await interaction.response.send_message(
+            f"✅ Staged **{count} recommended {noun}** for "
+            f"{section.label}.{conflict_text}",
+            ephemeral=True,
+        )
+
+    async def _on_skip(self, interaction: discord.Interaction) -> None:
+        if not await self._gate_apply(interaction):
+            return
+        section = self.current_section
+        if section is None or interaction.guild_id is None:
+            await interaction.response.send_message(
+                "No step to skip.",
+                ephemeral=True,
+            )
+            return
+        try:
+            await setup_session.mark_section_skipped(
+                interaction.guild_id,
+                section.slug,
+            )
+        except Exception:
+            logger.exception(
+                "wizard._on_skip: mark_section_skipped failed (%s)",
+                section.slug,
+            )
+            await interaction.response.send_message(
+                "Could not record the skip — see logs.",
+                ephemeral=True,
+            )
+            return
+
+        # Provenance-aware delete: drop any rows the section owns so
+        # Final Review never applies an op the operator skipped.
+        deleted_count = 0
+        try:
+            existing_rows = await setup_draft.list_by_section(
+                interaction.guild_id,
+                section.slug,
+            )
+            if existing_rows:
+                deleted_count = await setup_draft.delete_by_ids(
+                    interaction.guild_id,
+                    [row.id for row in existing_rows],
+                )
+        except Exception:
+            logger.exception(
+                "wizard._on_skip: provenance delete failed (%s)",
+                section.slug,
+            )
+
+        # Advance to the next step.
+        if self.step_index < len(self.sections) - 1:
+            self.step_index += 1
+
+        followup = (
+            f"\n\nRemoved {deleted_count} staged op(s) for this section."
+            if deleted_count
+            else ""
+        )
+        # Ephemeral reply first; then refresh the anchor in a follow-up.
+        await interaction.response.send_message(
+            f"⏭ Skipped **{section.label}**.{followup}",
+            ephemeral=True,
+        )
+        # Refresh the anchor message in place.
+        try:
+            await self._refresh_anchor_after_skip(interaction)
+        except Exception:
+            logger.exception("wizard._on_skip: anchor refresh failed")
+
+    async def _refresh_anchor_after_skip(
+        self,
+        interaction: discord.Interaction,
+    ) -> None:
+        """Re-render the wizard anchor message after a Skip.
+
+        Skip's first response is the ephemeral confirmation; the anchor
+        edit happens via ``interaction.followup.edit_message`` so the
+        operator sees both the confirmation and the updated step.
+        """
+        guild_id = interaction.guild_id
+        if guild_id is not None:
+            try:
+                self.session = await setup_session.resume_session(guild_id)
+            except Exception:
+                logger.exception("wizard.skip-refresh: resume failed")
+        self.sections = _resolve_sections(self.session)
+        if self.step_index >= len(self.sections):
+            self.step_index = max(0, len(self.sections) - 1)
+        self._rebuild_buttons()
+        draft_rows: list[DraftOperationRow] = []
+        if guild_id is not None:
+            try:
+                draft_rows = await setup_draft.list_rows(guild_id)
+            except Exception:
+                logger.exception("wizard.skip-refresh: list_rows failed")
+        section = self.current_section
+        if section is None:
+            return
+        embed = build_wizard_step_embed(
+            session=self.session,
+            section=section,
+            step_index=self.step_index,
+            total_steps=len(self.sections),
+            draft_rows=draft_rows,
+        )
+        await interaction.followup.edit_message(
+            message_id=interaction.message.id,
+            embed=embed,
+            view=self,
+        )
+
+    async def _on_customize(self, interaction: discord.Interaction) -> None:
+        # Customize delegation is the navigation-host adapter from the
+        # plan; it lands in its own PR.  For now the button is disabled
+        # but its callback surface exists so Phase 3.5 can wire it
+        # without changing the button row layout.
+        await interaction.response.send_message(
+            "Customize lands in a follow-up PR.  Use **Open hub** to "
+            "reach the section's detail view in the meantime.",
+            ephemeral=True,
+        )
+
+    async def _open_final_review(
+        self,
+        interaction: discord.Interaction,
+    ) -> None:
+        """Open Final Review as an ephemeral follow-up on the last step."""
+        guild = interaction.guild
+        if guild is None:
+            await interaction.response.send_message(
+                "Final Review requires a guild context.",
+                ephemeral=True,
+            )
+            return
+        from views.setup.final_review import (
+            FinalReviewView,
+            build_final_review_embed,
+        )
+
+        try:
+            ops = await setup_draft.list_ops(guild.id)
+        except Exception:
+            logger.exception("wizard._open_final_review: list_ops failed")
+            ops = []
+        final = FinalReviewView(interaction.user, ops=ops)
+        await interaction.response.send_message(
+            embed=build_final_review_embed(final.ops),
+            view=final,
+            ephemeral=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Workspace anchor — /setup and !setup route through this helper.
+# ---------------------------------------------------------------------------
+
+
+async def open_setup_workspace(
+    guild: discord.Guild,
+    *,
+    member: discord.Member,
+    session: SetupSession | None,
+) -> tuple[discord.TextChannel | None, discord.Message | None, str]:
+    """Ensure ``#superbot-setup`` exists and (re)post the wizard anchor.
+
+    Returns ``(channel, message, reason)``:
+
+    * On success — ``(channel, message, "ok")``.  ``message`` is the
+      anchor that was either edited in place (when ``setup_message_id``
+      pointed to a still-fetchable message) or newly posted.
+    * On missing perms — ``(None, None, "no_channel")``.  Caller
+      surfaces the privacy / permissions hint in its invoking-channel
+      reply.
+    * On Discord HTTP failure during post / edit — ``(channel, None,
+      "post_failed")``.  Channel was resolved but the message couldn't
+      be posted; caller surfaces an error.
+
+    Side effects:
+
+    * Persists the new message id via
+      :func:`services.setup_session.set_setup_message_id` whenever
+      a fresh message is posted.
+    * Records ``current_step="wizard"`` via
+      :func:`services.setup_session.mark_in_progress` so the launcher
+      surfaces the right label across restarts.
+    """
+    channel, _was_created = await setup_channel.ensure_setup_channel(
+        guild,
+        existing_channel_id=(session.setup_channel_id if session is not None else None),
+        session=session,
+    )
+    if channel is None:
+        return None, None, "no_channel"
+
+    sections = _resolve_sections(session)
+    step_index = _step_index_for(session, sections)
+
+    try:
+        draft_rows = await setup_draft.list_rows(guild.id)
+    except Exception:
+        logger.exception("open_setup_workspace: list_rows failed")
+        draft_rows = []
+
+    if sections:
+        embed = build_wizard_step_embed(
+            session=session,
+            section=sections[step_index],
+            step_index=step_index,
+            total_steps=len(sections),
+            draft_rows=draft_rows,
+        )
+    else:
+        embed = discord.Embed(
+            title=_WIZARD_TITLE,
+            description=(
+                "No setup sections are available for this depth. "
+                "Pick a depth via `/setup-depth` or open the hub."
+            ),
+            color=discord.Color.dark_grey(),
+        )
+
+    view = LinearWizardView(
+        member,
+        session=session,
+        sections=sections,
+        step_index=step_index,
+    )
+
+    message: discord.Message | None = None
+    existing_id = session.setup_message_id if session is not None else None
+    if existing_id is not None:
+        # Best-effort edit-in-place.  When the message has been
+        # deleted (or the bot lost access to the channel), fall
+        # through to the post path.
+        try:
+            existing_msg = await channel.fetch_message(existing_id)
+            message = await existing_msg.edit(embed=embed, view=view)
+        except (discord.NotFound, discord.Forbidden, discord.HTTPException):
+            logger.info(
+                "open_setup_workspace: anchor %s no longer fetchable; "
+                "reposting in guild %d",
+                existing_id,
+                guild.id,
+            )
+            message = None
+            try:
+                await setup_session.set_setup_message_id(guild.id, None)
+            except Exception:
+                logger.exception(
+                    "open_setup_workspace: clearing stale message_id failed",
+                )
+
+    if message is None:
+        try:
+            message = await channel.send(embed=embed, view=view)
+        except discord.HTTPException:
+            logger.exception(
+                "open_setup_workspace: failed to post anchor in guild %d",
+                guild.id,
+            )
+            return channel, None, "post_failed"
+        try:
+            await setup_session.set_setup_message_id(guild.id, message.id)
+        except Exception:
+            logger.exception(
+                "open_setup_workspace: persist message id failed",
+            )
+
+    try:
+        await setup_session.mark_in_progress(guild.id, step="wizard")
+    except Exception:
+        logger.exception(
+            "open_setup_workspace: mark_in_progress failed",
+        )
+
+    return channel, message, "ok"
+
+
+def jump_link(message: discord.Message) -> str:
+    """Return a Discord jump URL for ``message`` (markdown link wrap)."""
+    return f"[Open setup workspace]({message.jump_url})"
+
+
+__all__ = [
+    "LinearWizardView",
+    "build_wizard_step_embed",
+    "jump_link",
+    "open_setup_workspace",
+]

--- a/tests/unit/cogs/test_setup_cog.py
+++ b/tests/unit/cogs/test_setup_cog.py
@@ -1075,13 +1075,132 @@ def _delegated_session(
     )
 
 
+def _mock_channel_for_workspace(mention: str = "<#7000>") -> MagicMock:
+    """Mock target channel returned by open_setup_workspace."""
+    ch = MagicMock()
+    ch.mention = mention
+    return ch
+
+
+def _mock_workspace_message(jump_url: str = "https://discord.com/x/y/z") -> MagicMock:
+    """Mock anchor message returned by open_setup_workspace."""
+    msg = MagicMock()
+    msg.jump_url = jump_url
+    return msg
+
+
 @pytest.mark.asyncio
-async def test_setup_cmd_opens_hub_for_owner():
+async def test_setup_cmd_opens_wizard_for_owner():
+    """Phase 3: !setup posts the wizard in #superbot-setup and replies
+    in the invoking channel with a jump link.  No hub view is sent
+    in-channel anymore — that lives in /setup-hub.
+    """
+    from cogs.setup_cog import SetupCog
+
+    cog = SetupCog(MagicMock())
+    ctx = _mock_ctx(_owner_member())
+
+    channel = _mock_channel_for_workspace()
+    message = _mock_workspace_message()
+    with (
+        patch(
+            "cogs.setup._wizard_entry.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_delegated_session(),
+        ),
+        patch(
+            "cogs.setup._wizard_entry.open_setup_workspace",
+            new_callable=AsyncMock,
+            return_value=(channel, message, "ok"),
+        ) as open_mock,
+    ):
+        await cog.setup_cmd.callback(cog, ctx)
+
+    open_mock.assert_awaited_once()
+    # Invoking channel reply mentions the workspace channel and the
+    # jump link to the anchor message.
+    ctx.send.assert_awaited_once()
+    sent = ctx.send.await_args.args[0]
+    assert channel.mention in sent
+    assert message.jump_url in sent
+    # No hub view is sent into the invoking channel anymore.
+    assert "view" not in ctx.send.await_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_setup_cmd_starts_session_when_missing():
+    """No session row → !setup starts one before opening the wizard."""
+    from cogs.setup_cog import SetupCog
+
+    cog = SetupCog(MagicMock())
+    ctx = _mock_ctx(_owner_member())
+
+    channel = _mock_channel_for_workspace()
+    message = _mock_workspace_message()
+    with (
+        patch(
+            "cogs.setup._wizard_entry.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "cogs.setup._wizard_entry.setup_session.start_session",
+            new_callable=AsyncMock,
+            return_value=_delegated_session(),
+        ) as start_mock,
+        patch(
+            "cogs.setup._wizard_entry.open_setup_workspace",
+            new_callable=AsyncMock,
+            return_value=(channel, message, "ok"),
+        ),
+    ):
+        await cog.setup_cmd.callback(cog, ctx)
+
+    start_mock.assert_awaited_once()
+    ctx.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_setup_cmd_handles_missing_setup_channel():
+    """If ensure_setup_channel fails (no Manage Channels perm),
+    !setup surfaces the recovery hint in the invoking channel.
+    """
+    from cogs.setup_cog import SetupCog
+
+    cog = SetupCog(MagicMock())
+    ctx = _mock_ctx(_owner_member())
+
+    with (
+        patch(
+            "cogs.setup._wizard_entry.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_delegated_session(),
+        ),
+        patch(
+            "cogs.setup._wizard_entry.open_setup_workspace",
+            new_callable=AsyncMock,
+            return_value=(None, None, "no_channel"),
+        ),
+    ):
+        await cog.setup_cmd.callback(cog, ctx)
+
+    ctx.send.assert_awaited_once()
+    msg = ctx.send.await_args.args[0].lower()
+    assert "manage channels" in msg
+
+
+@pytest.mark.asyncio
+async def test_setup_hub_slash_opens_hub_for_owner():
+    """The new /setup-hub compatibility command preserves the
+    pre-Phase-3 behavior: opens the hub view ephemerally in the
+    invoking channel.  Used by operators / tests that prefer the
+    section-list UI to the linear wizard.
+    """
     from cogs.setup_cog import SetupCog
     from views.setup.hub import SetupHubView
 
     cog = SetupCog(MagicMock())
-    ctx = _mock_ctx(_owner_member())
+    interaction = _mock_interaction(_owner_member())
 
     with (
         patch(
@@ -1099,58 +1218,27 @@ async def test_setup_cmd_opens_hub_for_owner():
             new_callable=AsyncMock,
         ) as mark_mock,
     ):
-        await cog.setup_cmd.callback(cog, ctx)
+        await cog.setup_hub_slash.callback(cog, interaction)
 
-    ctx.send.assert_awaited_once()
-    sent_view = ctx.send.await_args.kwargs.get("view")
-    assert isinstance(sent_view, SetupHubView)
+    interaction.response.send_message.assert_awaited_once()
+    kwargs = interaction.response.send_message.await_args.kwargs
+    assert kwargs.get("ephemeral") is True
+    assert isinstance(kwargs.get("view"), SetupHubView)
     mark_mock.assert_awaited_once()
     assert mark_mock.await_args.kwargs.get("step") == "hub"
 
 
 @pytest.mark.asyncio
-async def test_setup_cmd_starts_session_when_missing():
-    from cogs.setup_cog import SetupCog
-
-    cog = SetupCog(MagicMock())
-    ctx = _mock_ctx(_owner_member())
-
-    with (
-        patch(
-            "cogs.setup_cog.setup_session.resume_session",
-            new_callable=AsyncMock,
-            return_value=None,
-        ),
-        patch(
-            "cogs.setup_cog.setup_session.start_session",
-            new_callable=AsyncMock,
-            return_value=_delegated_session(),
-        ) as start_mock,
-        patch(
-            "services.setup_draft.count",
-            new_callable=AsyncMock,
-            return_value=0,
-        ),
-        patch(
-            "cogs.setup_cog.setup_session.mark_in_progress",
-            new_callable=AsyncMock,
-        ),
-    ):
-        await cog.setup_cmd.callback(cog, ctx)
-
-    start_mock.assert_awaited_once()
-    ctx.send.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_setup_cmd_shows_depth_picker_when_depth_unset():
-    """First-time entry (session.depth=None) routes the operator
-    through the depth picker before opening the hub."""
+async def test_setup_hub_slash_shows_depth_picker_when_depth_unset():
+    """The hub compat command still routes through the depth picker
+    when no depth has been chosen yet (preserves the pre-Phase-3
+    behavior under its new name).
+    """
     from cogs.setup_cog import SetupCog
     from views.setup.depth_panel import DepthPanelView
 
     cog = SetupCog(MagicMock())
-    ctx = _mock_ctx(_owner_member())
+    interaction = _mock_interaction(_owner_member())
 
     with (
         patch(
@@ -1163,10 +1251,10 @@ async def test_setup_cmd_shows_depth_picker_when_depth_unset():
             new_callable=AsyncMock,
         ) as mark_mock,
     ):
-        await cog.setup_cmd.callback(cog, ctx)
+        await cog.setup_hub_slash.callback(cog, interaction)
 
-    ctx.send.assert_awaited_once()
-    sent_view = ctx.send.await_args.kwargs.get("view")
+    interaction.response.send_message.assert_awaited_once()
+    sent_view = interaction.response.send_message.await_args.kwargs.get("view")
     assert isinstance(sent_view, DepthPanelView)
     # mark_in_progress should NOT fire — the operator hasn't reached
     # the hub yet.
@@ -1176,7 +1264,9 @@ async def test_setup_cmd_shows_depth_picker_when_depth_unset():
 @pytest.mark.asyncio
 async def test_setup_cmd_returns_readiness_for_plain_admin():
     """A Discord administrator with no delegation gets the readiness embed,
-    not the hub — they may scan but not apply."""
+    not the wizard — they may scan but not apply.  The new prefix
+    flow preserves this branch.
+    """
     from cogs.setup_cog import SetupCog
 
     cog = SetupCog(MagicMock())
@@ -1185,7 +1275,7 @@ async def test_setup_cmd_returns_readiness_for_plain_admin():
     fake_embed = MagicMock()
     with (
         patch(
-            "cogs.setup_cog.setup_session.resume_session",
+            "cogs.setup._wizard_entry.setup_session.resume_session",
             new_callable=AsyncMock,
             return_value=_delegated_session(delegated=()),
         ),
@@ -1198,15 +1288,15 @@ async def test_setup_cmd_returns_readiness_for_plain_admin():
         await cog.setup_cmd.callback(cog, ctx)
 
     ctx.send.assert_awaited_once()
-    # Readiness path sends an embed but no hub view.
+    # Readiness path sends an embed but no view.
     assert ctx.send.await_args.kwargs.get("embed") is fake_embed
     assert ctx.send.await_args.kwargs.get("view") is None
 
 
 @pytest.mark.asyncio
-async def test_setup_cmd_opens_hub_for_delegated_admin():
+async def test_setup_cmd_opens_wizard_for_delegated_admin():
+    """Delegated admin (non-owner) gets the wizard workspace flow."""
     from cogs.setup_cog import SetupCog
-    from views.setup.hub import SetupHubView
 
     cog = SetupCog(MagicMock())
     # Delegated admin: not the owner, not a Discord administrator, but
@@ -1214,26 +1304,26 @@ async def test_setup_cmd_opens_hub_for_delegated_admin():
     member = _random_member(user_id=42)
     ctx = _mock_ctx(member)
 
+    channel = _mock_channel_for_workspace()
+    message = _mock_workspace_message()
     with (
         patch(
-            "cogs.setup_cog.setup_session.resume_session",
+            "cogs.setup._wizard_entry.setup_session.resume_session",
             new_callable=AsyncMock,
             return_value=_delegated_session(delegated=(42,)),
         ),
         patch(
-            "services.setup_draft.count",
+            "cogs.setup._wizard_entry.open_setup_workspace",
             new_callable=AsyncMock,
-            return_value=0,
-        ),
-        patch(
-            "cogs.setup_cog.setup_session.mark_in_progress",
-            new_callable=AsyncMock,
-        ),
+            return_value=(channel, message, "ok"),
+        ) as open_mock,
     ):
         await cog.setup_cmd.callback(cog, ctx)
 
-    sent_view = ctx.send.await_args.kwargs.get("view")
-    assert isinstance(sent_view, SetupHubView)
+    open_mock.assert_awaited_once()
+    ctx.send.assert_awaited_once()
+    sent = ctx.send.await_args.args[0]
+    assert channel.mention in sent
 
 
 @pytest.mark.asyncio
@@ -1244,7 +1334,7 @@ async def test_setup_cmd_denies_random_member():
     ctx = _mock_ctx(_random_member())
 
     with patch(
-        "cogs.setup_cog.setup_session.resume_session",
+        "cogs.setup._wizard_entry.setup_session.resume_session",
         new_callable=AsyncMock,
         return_value=_delegated_session(delegated=()),
     ):
@@ -1273,36 +1363,38 @@ async def test_setup_cmd_requires_guild_context():
 
 
 @pytest.mark.asyncio
-async def test_setup_slash_opens_hub_for_owner():
+async def test_setup_slash_opens_wizard_for_owner():
+    """Phase 3: /setup opens the wizard via the workspace flow and
+    replies ephemerally in the invoking channel with a jump link.
+    """
     from cogs.setup_cog import SetupCog
-    from views.setup.hub import SetupHubView
 
     cog = SetupCog(MagicMock())
     interaction = _mock_interaction(_owner_member())
 
+    channel = _mock_channel_for_workspace()
+    message = _mock_workspace_message()
     with (
         patch(
-            "cogs.setup_cog.setup_session.resume_session",
+            "cogs.setup._wizard_entry.setup_session.resume_session",
             new_callable=AsyncMock,
             return_value=_delegated_session(),
         ),
         patch(
-            "services.setup_draft.count",
+            "cogs.setup._wizard_entry.open_setup_workspace",
             new_callable=AsyncMock,
-            return_value=0,
-        ),
-        patch(
-            "cogs.setup_cog.setup_session.mark_in_progress",
-            new_callable=AsyncMock,
-        ) as mark_mock,
+            return_value=(channel, message, "ok"),
+        ) as open_mock,
     ):
         await cog.setup_slash.callback(cog, interaction)
 
+    open_mock.assert_awaited_once()
     interaction.response.send_message.assert_awaited_once()
     kwargs = interaction.response.send_message.await_args.kwargs
     assert kwargs.get("ephemeral") is True
-    assert isinstance(kwargs.get("view"), SetupHubView)
-    mark_mock.assert_awaited_once()
+    sent = interaction.response.send_message.await_args.args[0]
+    assert channel.mention in sent
+    assert message.jump_url in sent
 
 
 @pytest.mark.asyncio
@@ -1315,7 +1407,7 @@ async def test_setup_slash_returns_readiness_for_plain_admin():
     fake_embed = MagicMock()
     with (
         patch(
-            "cogs.setup_cog.setup_session.resume_session",
+            "cogs.setup._wizard_entry.setup_session.resume_session",
             new_callable=AsyncMock,
             return_value=_delegated_session(delegated=()),
         ),

--- a/tests/unit/services/test_setup_session.py
+++ b/tests/unit/services/test_setup_session.py
@@ -372,3 +372,30 @@ async def test_resume_session_hydrates_acknowledged_sections(_mock_db):
     session = await svc.resume_session(1)
     assert session is not None
     assert session.acknowledged_sections == frozenset({"purpose", "ai_setup"})
+
+
+# ---------------------------------------------------------------------------
+# set_setup_message_id (Phase 3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_setup_message_id_routes_to_db_layer():
+    with patch(
+        "services.setup_session.db.set_setup_message_id",
+        new_callable=AsyncMock,
+    ) as set_mock:
+        await svc.set_setup_message_id(1, 5555)
+    set_mock.assert_awaited_once_with(1, 5555)
+
+
+@pytest.mark.asyncio
+async def test_set_setup_message_id_accepts_none_to_clear():
+    """Passing None clears the pointer — used after the launcher cog's
+    resume sweep finds a stale message it can't refetch."""
+    with patch(
+        "services.setup_session.db.set_setup_message_id",
+        new_callable=AsyncMock,
+    ) as set_mock:
+        await svc.set_setup_message_id(1, None)
+    set_mock.assert_awaited_once_with(1, None)

--- a/tests/unit/views/setup/test_wizard.py
+++ b/tests/unit/views/setup/test_wizard.py
@@ -1,0 +1,743 @@
+"""Tests for :mod:`views.setup.wizard` — the linear setup wizard.
+
+Pins Phase 3 invariants:
+
+* ``LinearWizardView`` renders the current step embed.
+* Navigation buttons (``Back`` / ``Continue``) update ``step_index``
+  in place; the last step's ``Continue`` opens Final Review.
+* Mutating buttons (``Apply Recommended`` / ``Skip``) re-check
+  :func:`services.setup_access.can_apply_setup`.
+* ``Apply Recommended`` routes through
+  :func:`services.setup_draft.replace_recommended_for_section`
+  (no bare ``setup_draft.append`` loops).
+* ``Skip`` writes ``mark_section_skipped`` AND deletes the section's
+  Phase-0 provenance rows so Final Review never applies what was
+  skipped.
+* ``open_setup_workspace`` ensures the setup channel, posts /
+  edits the anchor message, and persists the message id via
+  :func:`services.setup_session.set_setup_message_id`.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+import views.setup.sections  # noqa: F401 — populate REGISTRY for tests
+from services.setup_draft import (
+    DraftOperationRow,
+    ReplaceRecommendedResult,
+)
+from services.setup_operations import SetupOperation
+from services.setup_sections import REGISTRY, SetupSection
+from services.setup_session import SetupSession
+from views.setup.wizard import (
+    LinearWizardView,
+    build_wizard_step_embed,
+    open_setup_workspace,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _noop_run(_interaction, _hub):  # pragma: no cover — never invoked
+    return None
+
+
+async def _builder_one_op(_guild):
+    return [
+        SetupOperation(
+            kind="set_cleanup_policy",
+            subsystem="cleanup",
+            target_kind="guild",
+            target_id=1,
+            value="Light",
+        ),
+    ]
+
+
+def _section(
+    slug: str = "cleanup",
+    *,
+    op_kinds: frozenset[str] = frozenset({"set_cleanup_policy"}),
+    description_if_skipped: str = "",
+    builder=None,
+    order: int = 60,
+) -> SetupSection:
+    return SetupSection(
+        slug=slug,
+        label=slug.replace("_", " ").title(),
+        style=discord.ButtonStyle.secondary,
+        run=_noop_run,
+        emoji="🧹",
+        order=order,
+        op_kinds=op_kinds,
+        description_if_skipped=description_if_skipped,
+        recommended_ops_builder=builder,
+    )
+
+
+def _session(
+    *,
+    depth: str | None = "standard",
+    delegated: tuple[int, ...] = (),
+    setup_message_id: int | None = None,
+    setup_channel_id: int | None = None,
+    current_step: str | None = None,
+    skipped: frozenset[str] = frozenset(),
+    acknowledged: frozenset[str] = frozenset(),
+    status: str = "in_progress",
+) -> SetupSession:
+    return SetupSession(
+        guild_id=1,
+        guild_name="Test",
+        owner_id=99,
+        setup_status=status,
+        setup_channel_id=setup_channel_id,
+        setup_message_id=setup_message_id,
+        last_readiness_score=None,
+        current_step=current_step,
+        delegated_admins=delegated,
+        skipped_sections=skipped,
+        acknowledged_sections=acknowledged,
+        depth=depth,
+    )
+
+
+def _owner_member(user_id: int = 99) -> MagicMock:
+    m = MagicMock(spec=discord.Member)
+    m.id = user_id
+    m.guild = SimpleNamespace(owner_id=user_id)
+    m.guild_permissions = SimpleNamespace(administrator=False)
+    return m
+
+
+def _interaction(member, *, guild_id: int = 1) -> MagicMock:
+    interaction = MagicMock()
+    interaction.user = member
+    interaction.guild_id = guild_id
+    interaction.guild = MagicMock(id=guild_id, name="Test", owner_id=99)
+    interaction.message = MagicMock(id=4242)
+    interaction.response = MagicMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.edit_message = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _make_text_channel(channel_id: int = 7000) -> MagicMock:
+    ch = MagicMock(spec=discord.TextChannel)
+    ch.id = channel_id
+    ch.name = "superbot-setup"
+    ch.mention = f"<#{channel_id}>"
+    ch.send = AsyncMock()
+    ch.fetch_message = AsyncMock()
+    return ch
+
+
+# ---------------------------------------------------------------------------
+# build_wizard_step_embed
+# ---------------------------------------------------------------------------
+
+
+def test_wizard_step_embed_shows_step_counter():
+    sections = [_section("cleanup"), _section("channels", order=70)]
+    embed = build_wizard_step_embed(
+        session=_session(),
+        section=sections[0],
+        step_index=0,
+        total_steps=len(sections),
+        draft_rows=[],
+    )
+    title = (embed.title or "")
+    assert "Step 1/2" in title
+    assert "Cleanup" in (embed.description or "")
+
+
+def test_wizard_step_embed_indicates_no_recommended_when_builder_missing():
+    section = _section("readonly", op_kinds=frozenset(), builder=None)
+    embed = build_wizard_step_embed(
+        session=_session(),
+        section=section,
+        step_index=0,
+        total_steps=1,
+        draft_rows=[],
+    )
+    fields = {(f.name or "").lower(): (f.value or "") for f in embed.fields}
+    assert "no recommended" in fields["recommended action"].lower()
+
+
+def test_wizard_step_embed_renders_skip_impact():
+    section = _section(
+        "cleanup",
+        description_if_skipped="Cleanup keeps the legacy defaults.",
+        builder=_builder_one_op,
+    )
+    embed = build_wizard_step_embed(
+        session=_session(),
+        section=section,
+        step_index=0,
+        total_steps=1,
+        draft_rows=[],
+    )
+    fields = {(f.name or "").lower(): (f.value or "") for f in embed.fields}
+    assert "if you skip this" in fields
+    assert "legacy defaults" in fields["if you skip this"].lower()
+
+
+def test_wizard_step_embed_surfaces_staged_op_count():
+    section = _section("cleanup", builder=_builder_one_op)
+    row = DraftOperationRow(
+        id=1,
+        seq=1,
+        section_slug="cleanup",
+        staging_kind="recommended",
+        group_id=None,
+        parent_seq=None,
+        label="x",
+        op=SetupOperation(kind="set_cleanup_policy", subsystem="cleanup"),
+    )
+    embed = build_wizard_step_embed(
+        session=_session(),
+        section=section,
+        step_index=0,
+        total_steps=1,
+        draft_rows=[row],
+    )
+    fields = {(f.name or "").lower(): (f.value or "") for f in embed.fields}
+    assert "1 recommended" in fields["current state"]
+
+
+# ---------------------------------------------------------------------------
+# LinearWizardView — buttons + navigation
+# ---------------------------------------------------------------------------
+
+
+def test_view_has_navigation_buttons_in_layout():
+    sections = [_section("cleanup", builder=_builder_one_op)]
+    view = LinearWizardView(
+        _owner_member(),
+        session=_session(),
+        sections=sections,
+        step_index=0,
+    )
+    custom_ids = {
+        getattr(c, "custom_id", None)
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+    }
+    assert "setup_wizard:back" in custom_ids
+    assert "setup_wizard:apply_recommended" in custom_ids
+    assert "setup_wizard:customize" in custom_ids
+    assert "setup_wizard:skip" in custom_ids
+    assert "setup_wizard:continue" in custom_ids
+    assert "setup_wizard:open_hub" in custom_ids
+    assert "setup_wizard:cancel" in custom_ids
+
+
+def test_view_back_button_disabled_on_first_step():
+    sections = [_section("cleanup", builder=_builder_one_op), _section("channels", order=70)]
+    view = LinearWizardView(
+        _owner_member(),
+        session=_session(),
+        sections=sections,
+        step_index=0,
+    )
+    back = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+        and c.custom_id == "setup_wizard:back"
+    )
+    assert back.disabled is True
+
+
+def test_view_apply_recommended_disabled_when_no_builder():
+    sections = [_section("readonly", op_kinds=frozenset(), builder=None)]
+    view = LinearWizardView(
+        _owner_member(),
+        session=_session(),
+        sections=sections,
+        step_index=0,
+    )
+    apply_btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+        and c.custom_id == "setup_wizard:apply_recommended"
+    )
+    assert apply_btn.disabled is True
+
+
+def test_view_continue_button_label_is_final_review_on_last_step():
+    sections = [_section("cleanup", builder=_builder_one_op)]
+    view = LinearWizardView(
+        _owner_member(),
+        session=_session(),
+        sections=sections,
+        step_index=0,
+    )
+    cont = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+        and c.custom_id == "setup_wizard:continue"
+    )
+    assert "Final" in (cont.label or "")
+
+
+def test_view_continue_label_is_continue_when_not_last_step():
+    sections = [_section("cleanup", builder=_builder_one_op), _section("channels", order=70)]
+    view = LinearWizardView(
+        _owner_member(),
+        session=_session(),
+        sections=sections,
+        step_index=0,
+    )
+    cont = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+        and c.custom_id == "setup_wizard:continue"
+    )
+    assert "Continue" in (cont.label or "")
+
+
+@pytest.mark.asyncio
+async def test_apply_recommended_routes_through_replace_recommended():
+    sections = [_section("cleanup", builder=_builder_one_op)]
+    view = LinearWizardView(
+        _owner_member(),
+        session=_session(),
+        sections=sections,
+        step_index=0,
+    )
+    interaction = _interaction(_owner_member())
+
+    with (
+        patch(
+            "views.setup.wizard.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_session(),
+        ),
+        patch(
+            "views.setup.wizard.setup_draft.replace_recommended_for_section",
+            new_callable=AsyncMock,
+            return_value=ReplaceRecommendedResult(
+                inserted_seqs=[1],
+                deleted_count=0,
+                conflicts=[],
+            ),
+        ) as replace_mock,
+        patch(
+            "views.setup.wizard.setup_session.unmark_section_skipped",
+            new_callable=AsyncMock,
+        ),
+    ):
+        # The view's first button callback for apply_recommended.
+        apply_btn = next(
+            c
+            for c in view.children
+            if isinstance(c, discord.ui.Button)
+            and c.custom_id == "setup_wizard:apply_recommended"
+        )
+        await apply_btn.callback(interaction)
+
+    replace_mock.assert_awaited_once()
+    args = replace_mock.await_args.args
+    assert args[0] == 1
+    assert args[1] == "cleanup"
+    assert len(args[2]) == 1
+    interaction.response.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_apply_recommended_rejects_non_delegated_admin():
+    """Non-applicants can't stage anything via the wizard either."""
+    sections = [_section("cleanup", builder=_builder_one_op)]
+    view = LinearWizardView(
+        _owner_member(),
+        session=_session(),
+        sections=sections,
+        step_index=0,
+    )
+    interaction = _interaction(_owner_member())
+
+    with (
+        patch(
+            "views.setup.wizard.setup_session.resume_session",
+            new_callable=AsyncMock,
+            # Different session: no delegation, no owner match.
+            return_value=_session(delegated=()),
+        ),
+        # Patch can_apply_setup to reject.
+        patch(
+            "views.setup.wizard.setup_access.can_apply_setup",
+            return_value=False,
+        ),
+        patch(
+            "views.setup.wizard.setup_draft.replace_recommended_for_section",
+            new_callable=AsyncMock,
+        ) as replace_mock,
+    ):
+        apply_btn = next(
+            c
+            for c in view.children
+            if isinstance(c, discord.ui.Button)
+            and c.custom_id == "setup_wizard:apply_recommended"
+        )
+        await apply_btn.callback(interaction)
+
+    replace_mock.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0].lower()
+    assert "delegate" in msg or "owner" in msg
+
+
+@pytest.mark.asyncio
+async def test_skip_deletes_section_rows_when_provenance_present():
+    """Skip writes mark_section_skipped AND drops the section's
+    provenance-tagged rows so Final Review never applies them.
+    """
+    sections = [
+        _section("cleanup", builder=_builder_one_op),
+        _section("channels", order=70),
+    ]
+    view = LinearWizardView(
+        _owner_member(),
+        session=_session(),
+        sections=sections,
+        step_index=0,
+    )
+    interaction = _interaction(_owner_member())
+
+    rows = [
+        DraftOperationRow(
+            id=11,
+            seq=1,
+            section_slug="cleanup",
+            staging_kind="recommended",
+            group_id=None,
+            parent_seq=None,
+            label="x",
+            op=SetupOperation(kind="set_cleanup_policy", subsystem="cleanup"),
+        ),
+    ]
+
+    with (
+        patch(
+            "views.setup.wizard.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_session(),
+        ),
+        patch(
+            "views.setup.wizard.setup_session.mark_section_skipped",
+            new_callable=AsyncMock,
+        ) as skip_mock,
+        patch(
+            "views.setup.wizard.setup_draft.list_by_section",
+            new_callable=AsyncMock,
+            return_value=rows,
+        ),
+        patch(
+            "views.setup.wizard.setup_draft.delete_by_ids",
+            new_callable=AsyncMock,
+            return_value=1,
+        ) as delete_mock,
+        patch(
+            "views.setup.wizard.setup_draft.list_rows",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+    ):
+        skip_btn = next(
+            c
+            for c in view.children
+            if isinstance(c, discord.ui.Button)
+            and c.custom_id == "setup_wizard:skip"
+        )
+        await skip_btn.callback(interaction)
+
+    skip_mock.assert_awaited_once_with(1, "cleanup")
+    delete_mock.assert_awaited_once_with(1, [11])
+    interaction.response.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_continue_on_last_step_opens_final_review():
+    sections = [_section("cleanup", builder=_builder_one_op)]
+    view = LinearWizardView(
+        _owner_member(),
+        session=_session(),
+        sections=sections,
+        step_index=0,  # only step → last step
+    )
+    interaction = _interaction(_owner_member())
+
+    with patch(
+        "views.setup.wizard.setup_draft.list_ops",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        cont = next(
+            c
+            for c in view.children
+            if isinstance(c, discord.ui.Button)
+            and c.custom_id == "setup_wizard:continue"
+        )
+        await cont.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    from views.setup.final_review import FinalReviewView
+
+    sent_view = interaction.response.send_message.await_args.kwargs["view"]
+    assert isinstance(sent_view, FinalReviewView)
+
+
+@pytest.mark.asyncio
+async def test_continue_on_non_last_step_advances():
+    sections = [
+        _section("cleanup", builder=_builder_one_op),
+        _section("channels", order=70),
+    ]
+    view = LinearWizardView(
+        _owner_member(),
+        session=_session(),
+        sections=sections,
+        step_index=0,
+    )
+    interaction = _interaction(_owner_member())
+
+    with (
+        patch(
+            "views.setup.wizard.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_session(),
+        ),
+        patch(
+            "views.setup.wizard.setup_draft.list_rows",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+    ):
+        cont = next(
+            c
+            for c in view.children
+            if isinstance(c, discord.ui.Button)
+            and c.custom_id == "setup_wizard:continue"
+        )
+        await cont.callback(interaction)
+
+    assert view.step_index == 1
+    interaction.response.edit_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_back_button_decrements_step():
+    sections = [
+        _section("cleanup", builder=_builder_one_op),
+        _section("channels", order=70),
+    ]
+    view = LinearWizardView(
+        _owner_member(),
+        session=_session(),
+        sections=sections,
+        step_index=1,
+    )
+    interaction = _interaction(_owner_member())
+
+    with (
+        patch(
+            "views.setup.wizard.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_session(),
+        ),
+        patch(
+            "views.setup.wizard.setup_draft.list_rows",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+    ):
+        back = next(
+            c
+            for c in view.children
+            if isinstance(c, discord.ui.Button)
+            and c.custom_id == "setup_wizard:back"
+        )
+        await back.callback(interaction)
+
+    assert view.step_index == 0
+
+
+# ---------------------------------------------------------------------------
+# open_setup_workspace
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_open_workspace_returns_no_channel_when_ensure_fails():
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 1
+    member = _owner_member()
+    with patch(
+        "views.setup.wizard.setup_channel.ensure_setup_channel",
+        new_callable=AsyncMock,
+        return_value=(None, False),
+    ):
+        channel, message, reason = await open_setup_workspace(
+            guild, member=member, session=_session(),
+        )
+    assert channel is None
+    assert message is None
+    assert reason == "no_channel"
+
+
+@pytest.mark.asyncio
+async def test_open_workspace_posts_new_anchor_when_id_missing():
+    """No prior message id → post a new anchor and persist its id."""
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 1
+    member = _owner_member()
+    channel = _make_text_channel()
+    posted_msg = MagicMock(id=5555, jump_url="https://x/y/z")
+    channel.send = AsyncMock(return_value=posted_msg)
+
+    with (
+        patch(
+            "views.setup.wizard.setup_channel.ensure_setup_channel",
+            new_callable=AsyncMock,
+            return_value=(channel, True),
+        ),
+        patch(
+            "views.setup.wizard.setup_draft.list_rows",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "views.setup.wizard.setup_session.set_setup_message_id",
+            new_callable=AsyncMock,
+        ) as set_id_mock,
+        patch(
+            "views.setup.wizard.setup_session.mark_in_progress",
+            new_callable=AsyncMock,
+        ) as mark_mock,
+    ):
+        ch, msg, reason = await open_setup_workspace(
+            guild,
+            member=member,
+            session=_session(setup_message_id=None),
+        )
+
+    assert reason == "ok"
+    assert ch is channel
+    assert msg is posted_msg
+    channel.send.assert_awaited_once()
+    set_id_mock.assert_awaited_once_with(1, 5555)
+    mark_mock.assert_awaited_once_with(1, step="wizard")
+
+
+@pytest.mark.asyncio
+async def test_open_workspace_edits_existing_anchor_in_place():
+    """When a fetchable anchor id is on the session, edit in place
+    instead of posting a new message (idempotency of /setup re-runs).
+    """
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 1
+    member = _owner_member()
+    channel = _make_text_channel()
+    existing_msg = MagicMock(id=5555)
+    edited_msg = MagicMock(id=5555, jump_url="https://x/y/z")
+    existing_msg.edit = AsyncMock(return_value=edited_msg)
+    channel.fetch_message = AsyncMock(return_value=existing_msg)
+
+    with (
+        patch(
+            "views.setup.wizard.setup_channel.ensure_setup_channel",
+            new_callable=AsyncMock,
+            return_value=(channel, False),
+        ),
+        patch(
+            "views.setup.wizard.setup_draft.list_rows",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "views.setup.wizard.setup_session.set_setup_message_id",
+            new_callable=AsyncMock,
+        ) as set_id_mock,
+        patch(
+            "views.setup.wizard.setup_session.mark_in_progress",
+            new_callable=AsyncMock,
+        ),
+    ):
+        ch, msg, reason = await open_setup_workspace(
+            guild,
+            member=member,
+            session=_session(setup_message_id=5555),
+        )
+
+    assert reason == "ok"
+    existing_msg.edit.assert_awaited_once()
+    # No new id persisted — the message was edited in place.
+    set_id_mock.assert_not_awaited()
+    channel.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_open_workspace_recovers_when_anchor_404():
+    """A stale message id (404 on fetch) triggers a fresh post and
+    persists the new id.  This is the restart / "expired" recovery
+    Option B from the plan.
+    """
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 1
+    member = _owner_member()
+    channel = _make_text_channel()
+    channel.fetch_message = AsyncMock(
+        side_effect=discord.NotFound(MagicMock(), "gone"),
+    )
+    posted_msg = MagicMock(id=7777, jump_url="https://x/y/z")
+    channel.send = AsyncMock(return_value=posted_msg)
+
+    with (
+        patch(
+            "views.setup.wizard.setup_channel.ensure_setup_channel",
+            new_callable=AsyncMock,
+            return_value=(channel, False),
+        ),
+        patch(
+            "views.setup.wizard.setup_draft.list_rows",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "views.setup.wizard.setup_session.set_setup_message_id",
+            new_callable=AsyncMock,
+        ) as set_id_mock,
+        patch(
+            "views.setup.wizard.setup_session.mark_in_progress",
+            new_callable=AsyncMock,
+        ),
+    ):
+        ch, msg, reason = await open_setup_workspace(
+            guild,
+            member=member,
+            session=_session(setup_message_id=5555),
+        )
+
+    assert reason == "ok"
+    assert msg is posted_msg
+    # The stale id was cleared and the fresh one persisted (two
+    # set_setup_message_id calls: clear None + set new).
+    assert set_id_mock.await_count == 2
+    assert set_id_mock.await_args_list[0].args == (1, None)
+    assert set_id_mock.await_args_list[1].args == (1, 7777)


### PR DESCRIPTION
## Summary

Phase 3 of the setup-wizard plan. Adds the linear-wizard surface and routes `/setup` + `!setup` through a single workspace-anchor flow that posts and edits **one** message in `#superbot-setup` rather than dropping setup controls into the invoking channel. The legacy section-list hub is preserved as `/setup-hub` for operators (and tests) that prefer it.

Builds on Phases 0–2 (merged: #328, #329, #330).

### What changed

- **`services.setup_session.set_setup_message_id`** (+ DB primitive) — dedicated setter for the wizard's anchor message id so `/setup` can clear stale ids (which `upsert`'s `COALESCE` couldn't do).
- **`views.setup.wizard`** (new module):
  - `LinearWizardView` — per-interaction view iterating `REGISTRY.for_depth(session.depth)` with one section per step. Buttons: `Back`, `Apply Recommended`, `Customize` (disabled — lands in a follow-up), `Skip`, `Continue` / `Final Review`, `Open hub`, `Cancel`. Mutating buttons re-check `can_apply_setup` against a fresh session snapshot.
  - `build_wizard_step_embed` — step embed surfacing the section's current staged state (via Phase-0 provenance), recommended-action copy, skip-impact, and "Nothing changes until Final Review applies" reassurance.
  - `open_setup_workspace` — workspace-anchor helper. Ensures `#superbot-setup` exists (via the Phase 1 `ensure_setup_channel` repair flow), edits the existing anchor in place when fetchable, posts a fresh anchor otherwise, and persists the message id via `set_setup_message_id`. Returns `(channel, message, reason)` so callers can render the right invoking-channel hint.
- **`cogs.setup_cog`** — `/setup` (slash) and `!setup` (prefix) switch to the workspace flow. Bodies live in `cogs.setup._wizard_entry` to keep the cog under the S4.6 800-LOC ceiling. New `/setup-hub` slash command preserves the pre-Phase-3 hub-entry behavior under its own name.
- **Skip semantics** — when the skipped section has Phase-0 provenance (rows with `section_slug` set), those rows are deleted from the draft via `delete_by_ids` so Final Review never applies them. Sections without provenance fall back to `mark_section_skipped` only.

### What's deferred to follow-ups

- **Customize button delegation** — currently rendered but disabled, with a pointer to "Open hub" in its callback. The plan's "section navigation host adapter" (the protocol that lets section callbacks live under both the hub and the wizard) is its own Phase 3.5 PR.
- **Restart-safe persistent view** — Phase 3 uses the plan's Option B (short-lived view + `/setup` repairs the anchor). Option A (persistent view with stable custom_ids) is deferred.
- **Depth picker in `/setup`** — the wizard runs with `depth=None` meaning all sections render. The depth picker remains accessible via `/setup-depth` and via `/setup-hub`'s depth-picker path.

## Test plan

- [x] `pytest tests/unit/views/setup/test_wizard.py` — 19 new tests covering embed render, button layout, navigation, mutating-button gating, skip with provenance, Final Review hand-off, `open_setup_workspace` edit-in-place + 404-recovery.
- [x] `pytest tests/unit/cogs/test_setup_cog.py` — 82 tests; updated 5 existing `/setup` tests to validate the new workspace flow; added 2 `/setup-hub` tests for the legacy behavior.
- [x] Full sweep `pytest tests/` — 5077 pass, 3 skipped, no failures.
- [x] `black --check`, `isort --check-only`, `ruff check`, `mypy disbot/` — clean.
- [x] Cog-size invariant — `setup_cog.py` is 719 LOC after extracting `_wizard_entry.py`.

### Manual smoke checks (UI work — deferred to a real Discord run)

- Owner runs `/setup` → wizard posts in `#superbot-setup`; slash reply is an ephemeral with channel mention + jump link.
- Owner runs `!setup` → same anchor flow; transient channel reply with jump link.
- Owner runs `/setup` a second time → anchor message is edited in place; no duplicate message in the channel.
- Wizard `Continue` advances; `Back` regresses; last step's button reads "Final Review" and opens `FinalReviewView`.
- `Apply Recommended` stages via `replace_recommended_for_section`; pressing twice doesn't duplicate rows.
- `Skip` removes the section's provenance rows from the draft; Final Review confirms they're absent.
- Plain admin runs `/setup` → readiness embed only; no wizard, no anchor message.
- `/setup-hub` still opens the legacy section-list hub.

## Follow-ups

Phase 3.5: navigation-host adapter + Customize button delegation.
Phase 4: Server purpose section (uses the wizard).


---
_Generated by [Claude Code](https://claude.ai/code/session_018hiDeqzURZ1GEmNfssQd64)_