### PR TITLE
Setup wizard Phase 6: AI setup link-only section

### DIFF
--- a/disbot/views/setup/sections/__init__.py
+++ b/disbot/views/setup/sections/__init__.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 # each section's `order` field, not import order — but keep this list stable
 # so it doubles as a manifest of which sections ship today.
 from views.setup.sections import (  # noqa: F401 — import side-effect
+    ai_setup,
     btd6,
     channels,
     cleanup,
@@ -29,6 +30,7 @@ from views.setup.sections import (  # noqa: F401 — import side-effect
 )
 
 __all__ = [
+    "ai_setup",
     "btd6",
     "channels",
     "cleanup",

--- a/disbot/views/setup/sections/ai_setup.py
+++ b/disbot/views/setup/sections/ai_setup.py
@@ -1,0 +1,367 @@
+"""AI setup section — Phase 6 of the setup-wizard plan.
+
+Link-only step that points operators at the existing AI Platform
+panel (``/aimenu``) and records the section as either acknowledged
+or skipped.  The wizard does **not** write AI policy values from
+here; a future PR may add a typed ``set_ai_policy`` operation, but
+for now the contract is strict:
+
+* Two buttons: **Open AI policy manager** + **Skip AI setup**.
+* The "Open" button looks up ``/aimenu``'s slash-command id at
+  runtime and emits a Discord ``</aimenu:id>`` mention so clicking
+  it opens the AI panel in place.  When the id can't be resolved
+  (sync delay, command renamed, etc.) the ephemeral reply falls
+  back to the plain ``/aimenu`` text — the operator still knows
+  what to run.
+* On click of either button the section acknowledges via
+  :func:`services.setup_session.ack_section` (Open) or
+  :func:`services.setup_session.mark_section_skipped` (Skip) so the
+  hub / wizard progress badge moves out of ``NOT_STARTED``.
+* The section emits **zero** draft operations.  Final Review never
+  consumes anything from here.
+* A disabled "Ask SuperBot" button is reserved (per the plan) so
+  the row layout stays stable when a mutation-capable AI helper
+  eventually lands as its own PR.  It is **not** wired to any
+  callback today.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import discord
+
+from services import setup_access, setup_session
+from services.setup_sections import REGISTRY, SetupSection
+from views.base import BaseView
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger("bot.views.setup.sections.ai_setup")
+
+SLUG = "ai_setup"
+
+#: Slash-command name we deep-link to.  Defined as a constant so the
+#: test suite + the fallback string + the lookup helper all agree on
+#: the canonical name.
+AI_POLICY_COMMAND_NAME = "aimenu"
+
+
+async def resolve_ai_policy_link(interaction: discord.Interaction) -> str:
+    """Return a clickable ``</aimenu:id>`` mention or fall back to text.
+
+    Discord renders ``</name:id>`` as a clickable command suggestion;
+    the ``id`` is the snowflake assigned at sync time.  We resolve it
+    via ``interaction.client.tree.fetch_commands()`` (a Discord API
+    call returning :class:`discord.app_commands.AppCommand`
+    instances) and match by name.
+
+    The fetch is cheap (one HTTP roundtrip) and called only when the
+    operator presses the **Open AI policy manager** button — so the
+    cost is acceptable without a cache.  When the fetch fails (rate
+    limit, network blip), or the command isn't synced (just-deployed
+    bot, dev environment), or the bot lacks AI commands entirely, we
+    fall back to plain ``/aimenu`` text — the operator still knows
+    what to type.
+    """
+    try:
+        tree = getattr(interaction.client, "tree", None)
+        if tree is None:
+            return f"`/{AI_POLICY_COMMAND_NAME}`"
+        # Try the global command set first; many deployments register
+        # /aimenu globally.  If that comes back empty, fall through to
+        # the guild-scoped set (interaction.guild may be None when
+        # called from a DM context, but the wizard always runs in a
+        # guild so the latter usually succeeds).
+        commands = await tree.fetch_commands()
+        for cmd in commands:
+            if getattr(cmd, "name", None) == AI_POLICY_COMMAND_NAME:
+                cmd_id = getattr(cmd, "id", None)
+                if cmd_id is not None:
+                    return f"</{AI_POLICY_COMMAND_NAME}:{cmd_id}>"
+        if interaction.guild is not None:
+            commands = await tree.fetch_commands(guild=interaction.guild)
+            for cmd in commands:
+                if getattr(cmd, "name", None) == AI_POLICY_COMMAND_NAME:
+                    cmd_id = getattr(cmd, "id", None)
+                    if cmd_id is not None:
+                        return f"</{AI_POLICY_COMMAND_NAME}:{cmd_id}>"
+    except Exception:
+        logger.exception(
+            "ai_setup: resolve_ai_policy_link fetch_commands failed",
+        )
+    return f"`/{AI_POLICY_COMMAND_NAME}`"
+
+
+def build_ai_setup_embed(
+    *,
+    acknowledged: bool,
+    skipped: bool,
+) -> discord.Embed:
+    """Render the AI-setup section card.
+
+    Surfaces the section's purpose (link to AI Platform) and the
+    current state — acknowledged, skipped, or pending.  Acknowledged
+    state highlights green; skipped highlights yellow; pending uses
+    the wizard's neutral blue.
+    """
+    if acknowledged:
+        color = discord.Color.green()
+        state = "✅ Acknowledged — AI panel opened from this step at least once."
+    elif skipped:
+        color = discord.Color.gold()
+        state = "⚠️ Skipped — no AI policy actions taken from the wizard."
+    else:
+        color = discord.Color.blurple()
+        state = "⬜ Not yet acknowledged."
+
+    embed = discord.Embed(
+        title="🤖 AI setup",
+        description=(
+            "SuperBot's AI features (response policy, providers, "
+            "routing, retention) are managed in the dedicated AI "
+            "Platform panel.  This step doesn't change AI policy — "
+            "it just links you there and records that you've seen "
+            "the option.\n\n"
+            "Click **Open AI policy manager** to launch the panel "
+            "(or run `/aimenu`).  Click **Skip AI setup** to leave "
+            "the current policy untouched."
+        ),
+        color=color,
+    )
+    embed.add_field(name="State", value=state, inline=False)
+    embed.add_field(
+        name="What this step stages",
+        value=(
+            "_(nothing)_ — AI setup is link-only.  Final Review "
+            "doesn't apply anything from this step."
+        ),
+        inline=False,
+    )
+    embed.set_footer(
+        text="AI policy edits happen in the AI Platform panel, not the wizard.",
+    )
+    return embed
+
+
+class AISetupView(BaseView):
+    """Two-button picker: Open AI panel + Skip AI setup.
+
+    Mutating callbacks (both buttons write to the session) re-check
+    :func:`services.setup_access.can_apply_setup` against a fresh
+    snapshot — same pattern as Phase 1's section card and Phase 3's
+    wizard.
+    """
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        *,
+        acknowledged: bool,
+        skipped: bool,
+        timeout: int = 300,
+    ) -> None:
+        super().__init__(author, public=False, timeout=timeout)
+        self.acknowledged = acknowledged
+        self.skipped = skipped
+        self._populate_buttons()
+
+    def _populate_buttons(self) -> None:
+        open_btn: discord.ui.Button = discord.ui.Button(  # type: ignore[var-annotated]
+            label="Open AI policy manager",
+            style=(
+                discord.ButtonStyle.success
+                if self.acknowledged
+                else discord.ButtonStyle.primary
+            ),
+            emoji="🤖",
+            custom_id="setup_ai:open",
+            row=0,
+        )
+        open_btn.callback = self._on_open  # type: ignore[method-assign]
+        self.add_item(open_btn)
+
+        skip_btn: discord.ui.Button = discord.ui.Button(  # type: ignore[var-annotated]
+            label="Skip AI setup",
+            style=(
+                discord.ButtonStyle.success
+                if self.skipped
+                else discord.ButtonStyle.secondary
+            ),
+            custom_id="setup_ai:skip",
+            row=0,
+        )
+        skip_btn.callback = self._on_skip  # type: ignore[method-assign]
+        self.add_item(skip_btn)
+
+        # Reserved "Ask SuperBot" slot.  Disabled today; a future PR
+        # may wire it to an in-channel AI helper.  Keeping the button
+        # in the layout now prevents row-shift when that lands.
+        ask_btn: discord.ui.Button = discord.ui.Button(  # type: ignore[var-annotated]
+            label="Ask SuperBot (coming soon)",
+            style=discord.ButtonStyle.secondary,
+            emoji="💬",
+            custom_id="setup_ai:ask",
+            disabled=True,
+            row=1,
+        )
+        self.add_item(ask_btn)
+
+    async def _gate_apply(self, interaction: discord.Interaction) -> bool:
+        member = interaction.user
+        if not isinstance(member, discord.Member):
+            await interaction.response.send_message(
+                "Use this from inside the server.",
+                ephemeral=True,
+            )
+            return False
+        session = None
+        guild_id = interaction.guild_id
+        if guild_id is not None:
+            try:
+                session = await setup_session.resume_session(guild_id)
+            except Exception:
+                logger.exception("ai_setup._gate_apply: resume failed")
+                session = None
+        if not setup_access.can_apply_setup(member, session):
+            await interaction.response.send_message(
+                "Only the server owner or a delegated setup admin can "
+                "acknowledge or skip the AI setup step.  Ask the owner "
+                "to grant you `/setup-delegate`.",
+                ephemeral=True,
+            )
+            return False
+        return True
+
+    async def _on_open(self, interaction: discord.Interaction) -> None:
+        if not await self._gate_apply(interaction):
+            return
+        guild_id = interaction.guild_id
+        if guild_id is None:
+            await interaction.response.send_message(
+                "AI setup requires a guild context.",
+                ephemeral=True,
+            )
+            return
+        link = await resolve_ai_policy_link(interaction)
+        try:
+            await setup_session.ack_section(guild_id, SLUG)
+        except Exception:
+            logger.exception("ai_setup._on_open: ack_section failed")
+            # The ack is best-effort.  The operator still gets the
+            # link — that's the primary deliverable of this button.
+        self.acknowledged = True
+        self.skipped = False
+        self.clear_items()
+        self._populate_buttons()
+        embed = build_ai_setup_embed(acknowledged=True, skipped=False)
+        await interaction.response.edit_message(embed=embed, view=self)
+        await interaction.followup.send(
+            f"🤖 Open the AI Platform panel: {link}\n\n"
+            "AI policy changes happen in that panel — this step just "
+            "linked you there and marked it acknowledged.",
+            ephemeral=True,
+        )
+
+    async def _on_skip(self, interaction: discord.Interaction) -> None:
+        if not await self._gate_apply(interaction):
+            return
+        guild_id = interaction.guild_id
+        if guild_id is None:
+            await interaction.response.send_message(
+                "AI setup requires a guild context.",
+                ephemeral=True,
+            )
+            return
+        try:
+            await setup_session.mark_section_skipped(guild_id, SLUG)
+        except Exception:
+            logger.exception("ai_setup._on_skip: mark_section_skipped failed")
+            await interaction.response.send_message(
+                "Could not record the skip — see logs.",
+                ephemeral=True,
+            )
+            return
+        self.acknowledged = False
+        self.skipped = True
+        self.clear_items()
+        self._populate_buttons()
+        embed = build_ai_setup_embed(acknowledged=False, skipped=True)
+        await interaction.response.edit_message(embed=embed, view=self)
+
+
+async def run(interaction: discord.Interaction, hub) -> None:
+    """Section entry — opens the AI-setup picker ephemerally.
+
+    The ``hub`` argument matches the registry's :class:`RunCallback`
+    signature; this section never edits the hub message so the
+    argument is unused.
+    """
+    del hub
+    guild_id = interaction.guild_id
+    if guild_id is None:
+        await interaction.response.send_message(
+            "AI setup must be opened inside the server.",
+            ephemeral=True,
+        )
+        return
+    try:
+        session = await setup_session.resume_session(guild_id)
+    except Exception:
+        logger.exception("ai_setup.run: resume_session failed")
+        session = None
+    acknowledged = session is not None and SLUG in session.acknowledged_sections
+    skipped = session is not None and SLUG in session.skipped_sections
+    embed = build_ai_setup_embed(
+        acknowledged=acknowledged,
+        skipped=skipped,
+    )
+    view = AISetupView(
+        interaction.user,
+        acknowledged=acknowledged,
+        skipped=skipped,
+    )
+    await interaction.response.send_message(
+        embed=embed,
+        view=view,
+        ephemeral=True,
+    )
+    try:
+        await setup_session.mark_in_progress(guild_id, step=SLUG)
+    except Exception:
+        logger.exception("ai_setup.run: mark_in_progress failed")
+
+
+REGISTRY.register(
+    SetupSection(
+        slug=SLUG,
+        label="AI setup",
+        style=discord.ButtonStyle.secondary,
+        run=run,
+        emoji="🤖",
+        # Renders right after logging_presets (order 45) — both touch
+        # operator-facing platform features, so neighbouring them in
+        # the wizard keeps the step order intuitive.
+        order=50,
+        # Zero op_kinds — AI setup is link-only and stages nothing.
+        op_kinds=frozenset(),
+        description_if_skipped=(
+            "SuperBot keeps the current AI policy and providers.  You "
+            "can revisit `/aimenu` at any time."
+        ),
+        depths=frozenset({"quick", "standard", "advanced"}),
+        # No recommended_ops_builder — AI setup has nothing to stage.
+    ),
+)
+
+
+__all__ = [
+    "AI_POLICY_COMMAND_NAME",
+    "AISetupView",
+    "SLUG",
+    "build_ai_setup_embed",
+    "resolve_ai_policy_link",
+    "run",
+]

--- a/tests/unit/views/setup/sections/test_ai_setup.py
+++ b/tests/unit/views/setup/sections/test_ai_setup.py
@@ -1,0 +1,528 @@
+"""Tests for the Phase 6 AI-setup link-only section.
+
+Pins:
+
+* The section is registered with a stable slug, low op_kinds set
+  (empty — it stages nothing), and runs in every depth.
+* ``resolve_ai_policy_link`` returns ``</aimenu:id>`` when the
+  command id is resolvable; falls back to ``` `/aimenu` ``` text on
+  fetch failure, missing id, or absent tree.
+* The Open button writes ``ack_section`` and surfaces the link in
+  an ephemeral follow-up.
+* The Skip button writes ``mark_section_skipped``.
+* Both mutating buttons re-check ``can_apply_setup``.
+* No draft operation is staged from either button.
+* The reserved "Ask SuperBot" button is present but disabled.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+import views.setup.sections  # noqa: F401 — populate REGISTRY
+from services.setup_sections import REGISTRY
+from services.setup_session import SetupSession
+from views.setup.sections.ai_setup import (
+    AI_POLICY_COMMAND_NAME,
+    SLUG,
+    AISetupView,
+    build_ai_setup_embed,
+    resolve_ai_policy_link,
+    run,
+)
+
+
+def _owner_member(user_id: int = 99) -> MagicMock:
+    m = MagicMock(spec=discord.Member)
+    m.id = user_id
+    m.guild = SimpleNamespace(owner_id=user_id)
+    m.guild_permissions = SimpleNamespace(administrator=False)
+    return m
+
+
+def _random_member(user_id: int = 42) -> MagicMock:
+    m = MagicMock(spec=discord.Member)
+    m.id = user_id
+    m.guild = SimpleNamespace(owner_id=99)
+    m.guild_permissions = SimpleNamespace(administrator=False)
+    return m
+
+
+def _session(
+    *,
+    delegated=(),
+    acknowledged: frozenset[str] = frozenset(),
+    skipped: frozenset[str] = frozenset(),
+):
+    return SetupSession(
+        guild_id=1,
+        guild_name="Test",
+        owner_id=99,
+        setup_status="in_progress",
+        setup_channel_id=None,
+        setup_message_id=None,
+        last_readiness_score=None,
+        current_step=None,
+        delegated_admins=delegated,
+        acknowledged_sections=acknowledged,
+        skipped_sections=skipped,
+    )
+
+
+def _interaction(
+    member,
+    *,
+    guild_id: int = 1,
+    fetched_commands=None,
+) -> MagicMock:
+    interaction = MagicMock()
+    interaction.user = member
+    interaction.guild_id = guild_id
+    interaction.guild = MagicMock(id=guild_id)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.message = MagicMock(id=4000)
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    interaction.client = MagicMock()
+    if fetched_commands is None:
+        interaction.client.tree = None
+    else:
+        interaction.client.tree = MagicMock()
+        interaction.client.tree.fetch_commands = AsyncMock(
+            return_value=fetched_commands,
+        )
+    return interaction
+
+
+# ---------------------------------------------------------------------------
+# Registry invariants
+# ---------------------------------------------------------------------------
+
+
+def test_ai_setup_section_registered():
+    section = REGISTRY.get(SLUG)
+    assert section is not None
+    assert section.label == "AI setup"
+
+
+def test_ai_setup_section_stages_no_ops():
+    """Section's ``op_kinds`` must be empty — Phase 6 is link-only."""
+    section = REGISTRY.get(SLUG)
+    assert section is not None
+    assert section.op_kinds == frozenset()
+
+
+def test_ai_setup_section_runs_in_every_depth():
+    """AI setup is a universal step; runs in every depth."""
+    section = REGISTRY.get(SLUG)
+    assert section is not None
+    assert section.depths == frozenset({"quick", "standard", "advanced"})
+
+
+def test_ai_setup_has_no_recommended_builder():
+    """Link-only sections have nothing to stage — no builder."""
+    section = REGISTRY.get(SLUG)
+    assert section is not None
+    assert section.recommended_ops_builder is None
+
+
+def test_ai_setup_orders_after_logging_presets():
+    """Both touch operator platform features; neighbouring them in
+    the wizard preserves a coherent step order.
+    """
+    section = REGISTRY.get(SLUG)
+    logging_section = REGISTRY.get("logging_presets")
+    assert section is not None
+    assert logging_section is not None
+    assert section.order > logging_section.order
+
+
+# ---------------------------------------------------------------------------
+# resolve_ai_policy_link
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_link_returns_mention_when_command_found():
+    """Happy path: fetch_commands returns a match → ``</aimenu:id>``."""
+    cmd = MagicMock(name="aimenu_cmd")
+    cmd.name = AI_POLICY_COMMAND_NAME
+    cmd.id = 9001
+    interaction = _interaction(_owner_member(), fetched_commands=[cmd])
+    link = await resolve_ai_policy_link(interaction)
+    assert link == f"</{AI_POLICY_COMMAND_NAME}:9001>"
+
+
+@pytest.mark.asyncio
+async def test_resolve_link_falls_back_when_tree_missing():
+    """A client without a tree (test harness, lightweight stand-in)
+    falls back to plain text without raising."""
+    interaction = _interaction(_owner_member(), fetched_commands=None)
+    link = await resolve_ai_policy_link(interaction)
+    assert link == f"`/{AI_POLICY_COMMAND_NAME}`"
+
+
+@pytest.mark.asyncio
+async def test_resolve_link_falls_back_when_fetch_raises():
+    """Network blip / rate-limit during fetch → plain text fallback."""
+    interaction = _interaction(_owner_member(), fetched_commands=[])
+    interaction.client.tree.fetch_commands = AsyncMock(
+        side_effect=RuntimeError("rate limited"),
+    )
+    link = await resolve_ai_policy_link(interaction)
+    assert link == f"`/{AI_POLICY_COMMAND_NAME}`"
+
+
+@pytest.mark.asyncio
+async def test_resolve_link_falls_back_when_no_matching_command():
+    """No aimenu command in the synced set (just-deployed bot) →
+    plain text fallback."""
+    # Fetch returns a different command set.
+    other = MagicMock()
+    other.name = "ping"
+    other.id = 1234
+    interaction = _interaction(_owner_member(), fetched_commands=[other])
+    # Guild fetch returns nothing either.
+    interaction.client.tree.fetch_commands = AsyncMock(side_effect=[[other], []])
+    link = await resolve_ai_policy_link(interaction)
+    assert link == f"`/{AI_POLICY_COMMAND_NAME}`"
+
+
+@pytest.mark.asyncio
+async def test_resolve_link_falls_back_when_id_missing():
+    """A matched command with no .id (improbable, defensive) → fallback."""
+    cmd = MagicMock()
+    cmd.name = AI_POLICY_COMMAND_NAME
+    cmd.id = None
+    interaction = _interaction(_owner_member(), fetched_commands=[cmd])
+    # Guild fetch returns nothing either.
+    interaction.client.tree.fetch_commands = AsyncMock(side_effect=[[cmd], []])
+    link = await resolve_ai_policy_link(interaction)
+    assert link == f"`/{AI_POLICY_COMMAND_NAME}`"
+
+
+# ---------------------------------------------------------------------------
+# build_ai_setup_embed
+# ---------------------------------------------------------------------------
+
+
+def test_embed_pending_state():
+    embed = build_ai_setup_embed(acknowledged=False, skipped=False)
+    state_field = next(f for f in embed.fields if f.name == "State")
+    assert "not yet" in (state_field.value or "").lower()
+
+
+def test_embed_acknowledged_state():
+    embed = build_ai_setup_embed(acknowledged=True, skipped=False)
+    state_field = next(f for f in embed.fields if f.name == "State")
+    assert "acknowledged" in (state_field.value or "").lower()
+
+
+def test_embed_skipped_state():
+    embed = build_ai_setup_embed(acknowledged=False, skipped=True)
+    state_field = next(f for f in embed.fields if f.name == "State")
+    assert "skipped" in (state_field.value or "").lower()
+
+
+def test_embed_always_notes_zero_staging():
+    embed = build_ai_setup_embed(acknowledged=False, skipped=False)
+    staging_field = next(
+        f for f in embed.fields if "stages" in (f.name or "").lower()
+    )
+    assert "nothing" in (staging_field.value or "").lower()
+
+
+# ---------------------------------------------------------------------------
+# AISetupView buttons
+# ---------------------------------------------------------------------------
+
+
+def test_view_has_open_skip_and_disabled_ask_buttons():
+    view = AISetupView(_owner_member(), acknowledged=False, skipped=False)
+    custom_ids = {
+        c.custom_id
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+    }
+    assert "setup_ai:open" in custom_ids
+    assert "setup_ai:skip" in custom_ids
+    assert "setup_ai:ask" in custom_ids
+    ask_btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "setup_ai:ask"
+    )
+    assert ask_btn.disabled is True
+
+
+def test_view_highlights_acknowledged_open_button():
+    view = AISetupView(_owner_member(), acknowledged=True, skipped=False)
+    open_btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "setup_ai:open"
+    )
+    assert open_btn.style is discord.ButtonStyle.success
+
+
+def test_view_highlights_skipped_skip_button():
+    view = AISetupView(_owner_member(), acknowledged=False, skipped=True)
+    skip_btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "setup_ai:skip"
+    )
+    assert skip_btn.style is discord.ButtonStyle.success
+
+
+@pytest.mark.asyncio
+async def test_open_button_writes_ack_and_surfaces_link():
+    view = AISetupView(_owner_member(), acknowledged=False, skipped=False)
+    interaction = _interaction(_owner_member())
+
+    with (
+        patch(
+            "views.setup.sections.ai_setup.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_session(),
+        ),
+        patch(
+            "views.setup.sections.ai_setup.setup_session.ack_section",
+            new_callable=AsyncMock,
+        ) as ack_mock,
+        patch(
+            "views.setup.sections.ai_setup.resolve_ai_policy_link",
+            new_callable=AsyncMock,
+            return_value="</aimenu:9001>",
+        ),
+    ):
+        btn = next(
+            c
+            for c in view.children
+            if isinstance(c, discord.ui.Button)
+            and c.custom_id == "setup_ai:open"
+        )
+        await btn.callback(interaction)
+
+    ack_mock.assert_awaited_once_with(1, SLUG)
+    # The link reply is sent as a followup so the embed edit and the
+    # link reply both make it to the operator.
+    interaction.followup.send.assert_awaited_once()
+    followup_msg = interaction.followup.send.await_args.args[0]
+    assert "</aimenu:9001>" in followup_msg
+
+
+@pytest.mark.asyncio
+async def test_open_button_stages_no_draft_ops():
+    """Open is link-only — pressing it must not touch the draft store."""
+    view = AISetupView(_owner_member(), acknowledged=False, skipped=False)
+    interaction = _interaction(_owner_member())
+
+    with (
+        patch(
+            "views.setup.sections.ai_setup.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_session(),
+        ),
+        patch(
+            "views.setup.sections.ai_setup.setup_session.ack_section",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "views.setup.sections.ai_setup.resolve_ai_policy_link",
+            new_callable=AsyncMock,
+            return_value="</aimenu:1>",
+        ),
+        patch(
+            "services.setup_draft.append",
+            new_callable=AsyncMock,
+        ) as append_mock,
+        patch(
+            "services.setup_draft.replace_recommended_for_section",
+            new_callable=AsyncMock,
+        ) as replace_mock,
+    ):
+        btn = next(
+            c
+            for c in view.children
+            if isinstance(c, discord.ui.Button)
+            and c.custom_id == "setup_ai:open"
+        )
+        await btn.callback(interaction)
+
+    append_mock.assert_not_awaited()
+    replace_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_open_button_rejects_non_delegated_admin():
+    view = AISetupView(_random_member(), acknowledged=False, skipped=False)
+    interaction = _interaction(_random_member())
+
+    with (
+        patch(
+            "views.setup.sections.ai_setup.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_session(delegated=()),
+        ),
+        patch(
+            "views.setup.sections.ai_setup.setup_session.ack_section",
+            new_callable=AsyncMock,
+        ) as ack_mock,
+        patch(
+            "views.setup.sections.ai_setup.resolve_ai_policy_link",
+            new_callable=AsyncMock,
+        ) as link_mock,
+    ):
+        btn = next(
+            c
+            for c in view.children
+            if isinstance(c, discord.ui.Button)
+            and c.custom_id == "setup_ai:open"
+        )
+        await btn.callback(interaction)
+
+    ack_mock.assert_not_awaited()
+    link_mock.assert_not_awaited()
+    msg = interaction.response.send_message.await_args.args[0].lower()
+    assert "owner" in msg or "delegate" in msg
+
+
+@pytest.mark.asyncio
+async def test_skip_button_writes_mark_section_skipped():
+    view = AISetupView(_owner_member(), acknowledged=False, skipped=False)
+    interaction = _interaction(_owner_member())
+
+    with (
+        patch(
+            "views.setup.sections.ai_setup.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_session(),
+        ),
+        patch(
+            "views.setup.sections.ai_setup.setup_session.mark_section_skipped",
+            new_callable=AsyncMock,
+        ) as skip_mock,
+    ):
+        btn = next(
+            c
+            for c in view.children
+            if isinstance(c, discord.ui.Button)
+            and c.custom_id == "setup_ai:skip"
+        )
+        await btn.callback(interaction)
+
+    skip_mock.assert_awaited_once_with(1, SLUG)
+
+
+@pytest.mark.asyncio
+async def test_skip_button_surfaces_db_failure():
+    view = AISetupView(_owner_member(), acknowledged=False, skipped=False)
+    interaction = _interaction(_owner_member())
+
+    with (
+        patch(
+            "views.setup.sections.ai_setup.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_session(),
+        ),
+        patch(
+            "views.setup.sections.ai_setup.setup_session.mark_section_skipped",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("DB down"),
+        ),
+    ):
+        btn = next(
+            c
+            for c in view.children
+            if isinstance(c, discord.ui.Button)
+            and c.custom_id == "setup_ai:skip"
+        )
+        await btn.callback(interaction)
+
+    msg = interaction.response.send_message.await_args.args[0].lower()
+    assert "could not" in msg
+
+
+# ---------------------------------------------------------------------------
+# Section run callback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_opens_view_with_acknowledged_state_from_session():
+    interaction = _interaction(_owner_member())
+
+    with (
+        patch(
+            "views.setup.sections.ai_setup.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_session(acknowledged=frozenset({SLUG})),
+        ),
+        patch(
+            "views.setup.sections.ai_setup.setup_session.mark_in_progress",
+            new_callable=AsyncMock,
+        ) as mark_mock,
+    ):
+        await run(interaction, hub=None)
+
+    interaction.response.send_message.assert_awaited_once()
+    sent_view = interaction.response.send_message.await_args.kwargs["view"]
+    assert isinstance(sent_view, AISetupView)
+    assert sent_view.acknowledged is True
+    assert sent_view.skipped is False
+    mark_mock.assert_awaited_once_with(1, step=SLUG)
+
+
+@pytest.mark.asyncio
+async def test_run_opens_view_with_skipped_state_from_session():
+    interaction = _interaction(_owner_member())
+
+    with (
+        patch(
+            "views.setup.sections.ai_setup.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_session(skipped=frozenset({SLUG})),
+        ),
+        patch(
+            "views.setup.sections.ai_setup.setup_session.mark_in_progress",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await run(interaction, hub=None)
+
+    sent_view = interaction.response.send_message.await_args.kwargs["view"]
+    assert sent_view.skipped is True
+    assert sent_view.acknowledged is False
+
+
+@pytest.mark.asyncio
+async def test_run_tolerates_resume_failure():
+    interaction = _interaction(_owner_member())
+
+    with (
+        patch(
+            "views.setup.sections.ai_setup.setup_session.resume_session",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("DB down"),
+        ),
+        patch(
+            "views.setup.sections.ai_setup.setup_session.mark_in_progress",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await run(interaction, hub=None)
+
+    interaction.response.send_message.assert_awaited_once()
+    sent_view = interaction.response.send_message.await_args.kwargs["view"]
+    assert isinstance(sent_view, AISetupView)
+    # Defaults to pending when resume fails.
+    assert sent_view.acknowledged is False
+    assert sent_view.skipped is False


### PR DESCRIPTION
## Summary

Phase 6 of the setup-wizard plan. Link-only step that points operators at the existing AI Platform panel (`/aimenu`) and records the section as either acknowledged or skipped. The wizard does **not** write AI policy from here; a future PR may add a typed `set_ai_policy` operation.

Builds on Phases 0–5 (all merged).

### What changed

- **`views.setup.sections.ai_setup`** (new module) registered at `order=50`, runs in every depth, `op_kinds=frozenset()`.
- **`resolve_ai_policy_link(interaction)`** — looks up `/aimenu`'s slash-command id via `client.tree.fetch_commands()` and returns Discord's `</aimenu:id>` mention. Falls back to plain `` `/aimenu` `` text on every observable failure path (no tree / fetch raises / no matching command / missing id) so the operator always has actionable guidance.
- **`AISetupView`** — three buttons:
  - **Open AI policy manager** — gates on `can_apply_setup`; writes `setup_session.ack_section`; surfaces the resolved link as an ephemeral follow-up.
  - **Skip AI setup** — gates on `can_apply_setup`; writes `setup_session.mark_section_skipped`.
  - **Ask SuperBot (coming soon)** — reserved (disabled) per the plan so a future mutation-capable AI helper doesn't shift the row layout.
- Section emits **zero** draft operations (pinned by a test).

### What did NOT change

- No new migration.
- No AI cog changes.
- No new operation kind. `set_ai_policy` remains deferred per the plan.

## Test plan

- [x] `pytest tests/unit/views/setup/sections/test_ai_setup.py` — 25 new tests covering registry invariants (empty `op_kinds`, every depth, no recommended builder, order after logging_presets), `resolve_ai_policy_link` happy path + four fallback branches (no tree / fetch raises / no matching command / missing id), embed state rendering (pending / acknowledged / skipped), view button layout + highlight, Open writes ack and surfaces the link, zero-draft-op invariant, `can_apply_setup` gate, Skip writes `mark_section_skipped`, DB failure handling, section-run hydration of view state from session.
- [x] Full sweep `pytest tests/` — 5155 pass, 3 skipped, no failures.
- [x] `black --check`, `isort --check-only`, `ruff check`, `mypy disbot/` — clean.

### Manual smoke checks (UI work — deferred to a real Discord run)

- Wizard step renders the AI-setup card with the embed state matching the session.
- Pressing **Open AI policy manager** shows an ephemeral with a clickable `/aimenu` mention; the embed flips to ✅ Acknowledged.
- Pressing **Skip AI setup** flips the embed to ⚠️ Skipped.
- Pressing again is idempotent (set semantics at the DB layer).
- Plain admin (non-owner, non-delegated) gets the `delegate` rejection on either button.
- The **Ask SuperBot** button is visible but disabled.

## Follow-ups

Phase 7: error-recovery embeds + Final Review copy polish.
Phase 8: guarded setup-channel cleanup service.

---
_Generated by [Claude Code](https://claude.ai/code/session_018hiDeqzURZ1GEmNfssQd64)_