### PR TITLE
Setup wizard Phase 8: guarded setup-channel cleanup

### DIFF
--- a/disbot/services/setup_channel.py
+++ b/disbot/services/setup_channel.py
@@ -49,11 +49,13 @@ operator-named "setup" channels.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
 
 import discord
 
 from core.runtime.guild_resources import ensure_channel, resolve_member
+from services import setup_access
 
 if TYPE_CHECKING:
     from services.setup_session import SetupSession
@@ -381,9 +383,218 @@ async def delete_setup_channel(
     return True
 
 
+CleanupReason = Literal[
+    "ok",
+    "not_complete",
+    "draft_not_empty",
+    "channel_id_mismatch",
+    "channel_renamed",
+    "channel_missing",
+    "unauthorized",
+    "delete_failed",
+]
+
+
+@dataclass(frozen=True)
+class CleanupResult:
+    """Outcome of :func:`cleanup_setup_channel_after_completion`.
+
+    ``reason="ok"`` is the only success state; any other value
+    surfaces an operator-facing explanation of why the cleanup was
+    refused.  ``detail`` is a short human-readable string suitable
+    for an ephemeral reply.
+    """
+
+    reason: CleanupReason
+    detail: str
+
+
+async def cleanup_setup_channel_after_completion(
+    guild: discord.Guild,
+    session: SetupSession | None,
+    *,
+    actor: discord.Member,
+) -> CleanupResult:
+    """Delete ``#superbot-setup`` after a successful Final Review apply.
+
+    Phase 8 of the setup-wizard plan.  Mandatory guards, checked in
+    order — any failure short-circuits with an operator-facing
+    explanation rather than proceeding to the delete:
+
+    1. ``session.setup_status == "complete"`` — the wizard must have
+       finished a Final Review apply.  Without this, the operator
+       hasn't actually applied their staged ops yet.
+    2. ``setup_draft.count(guild_id) == 0`` — partial-recovery state
+       always preserves the draft; an empty draft is the proxy for
+       "no recovery in progress".  Cleaning up mid-recovery would
+       strand the operator without an anchor message.
+    3. ``session.setup_channel_id`` matches the channel id we're
+       about to delete.  Belt-and-braces protection: callers pass
+       the channel id implicitly via the session, but a future
+       caller passing the wrong session would otherwise delete the
+       wrong channel.
+    4. The channel name is still ``#superbot-setup``.  An operator
+       who renamed the channel signaled "this is mine now"; we
+       refuse to delete a renamed channel even if the id still
+       matches (mirrors :func:`delete_setup_channel`'s own guard).
+    5. ``setup_access.can_apply_setup(actor, session)`` — only the
+       server owner or a delegated setup admin can trigger the
+       delete.
+
+    Only if every guard passes:
+
+    * Call :func:`delete_setup_channel` to perform the Discord-side
+      delete (which has its own name guard, kept as defence in
+      depth).
+    * Null both ``setup_channel_id`` and ``setup_message_id`` on the
+      session row so the next ``/setup`` re-creates a fresh channel.
+
+    Returns a typed :class:`CleanupResult`.  The caller (typically
+    the Final Review completion view) surfaces ``detail`` in an
+    ephemeral reply.
+    """
+    if session is None or session.setup_status != "complete":
+        return CleanupResult(
+            reason="not_complete",
+            detail=(
+                "Setup isn't complete yet — finish a Final Review apply "
+                "before deleting the setup channel."
+            ),
+        )
+
+    try:
+        from services import setup_draft as _draft
+
+        pending = await _draft.count(guild.id)
+    except Exception:
+        logger.exception(
+            "cleanup_setup_channel: setup_draft.count failed (guild=%d)",
+            guild.id,
+        )
+        return CleanupResult(
+            reason="delete_failed",
+            detail=(
+                "Couldn't read the staged-ops count — see logs.  Re-run "
+                "Final Review or try again later."
+            ),
+        )
+    if pending > 0:
+        return CleanupResult(
+            reason="draft_not_empty",
+            detail=(
+                f"There are still **{pending}** staged operation(s) — "
+                "Final Review left them in the draft for recovery.  "
+                "Apply them (or run `/setup-reset`) before deleting the "
+                "channel."
+            ),
+        )
+
+    if session.setup_channel_id is None:
+        return CleanupResult(
+            reason="channel_missing",
+            detail=("No setup channel is recorded for this guild — nothing to delete."),
+        )
+
+    channel = guild.get_channel(session.setup_channel_id)
+    if not isinstance(channel, discord.TextChannel):
+        # The channel may have already been deleted out-of-band; null
+        # the pointer for consistency and return a non-error reason.
+        try:
+            await set_session_channel_id(guild.id, None)
+        except Exception:
+            logger.exception(
+                "cleanup_setup_channel: nulling channel id failed (guild=%d)",
+                guild.id,
+            )
+        return CleanupResult(
+            reason="channel_missing",
+            detail=(
+                "The setup channel is already gone — cleared the "
+                "session pointer for you."
+            ),
+        )
+
+    if channel.id != session.setup_channel_id:
+        return CleanupResult(
+            reason="channel_id_mismatch",
+            detail=(
+                "The session's setup_channel_id doesn't match the "
+                "resolved channel; refusing to delete."
+            ),
+        )
+
+    if channel.name != SETUP_CHANNEL_NAME:
+        return CleanupResult(
+            reason="channel_renamed",
+            detail=(
+                f"The channel has been renamed to `#{channel.name}` — "
+                "refusing to delete an operator-renamed channel."
+            ),
+        )
+
+    if not setup_access.can_apply_setup(actor, session):
+        return CleanupResult(
+            reason="unauthorized",
+            detail=(
+                "Only the server owner or a delegated setup admin can "
+                "delete the setup channel."
+            ),
+        )
+
+    deleted = await delete_setup_channel(guild, channel.id)
+    if not deleted:
+        return CleanupResult(
+            reason="delete_failed",
+            detail=(
+                "Discord refused the delete — check the bot's Manage "
+                "Channels permission and see logs."
+            ),
+        )
+
+    try:
+        await set_session_channel_id(guild.id, None)
+    except Exception:
+        logger.exception(
+            "cleanup_setup_channel: nulling channel id failed after delete",
+        )
+    try:
+        await set_session_message_id(guild.id, None)
+    except Exception:
+        logger.exception(
+            "cleanup_setup_channel: nulling message id failed after delete",
+        )
+
+    return CleanupResult(
+        reason="ok",
+        detail="Setup channel deleted.  Re-run `/setup` later to recreate it.",
+    )
+
+
+async def set_session_channel_id(guild_id: int, channel_id: int | None) -> None:
+    """Thin shim around :func:`services.setup_session.set_setup_channel_id`.
+
+    Defined here so the cleanup helper can defer the lazy import to
+    a single seam (avoiding the cyclic-import risk of pulling
+    ``services.setup_session`` at module-load time).
+    """
+    from services import setup_session as svc
+
+    await svc.set_setup_channel_id(guild_id, channel_id)
+
+
+async def set_session_message_id(guild_id: int, message_id: int | None) -> None:
+    """Thin shim around :func:`services.setup_session.set_setup_message_id`."""
+    from services import setup_session as svc
+
+    await svc.set_setup_message_id(guild_id, message_id)
+
+
 __all__ = [
     "PRIVACY_NOTE",
     "SETUP_CHANNEL_NAME",
+    "CleanupReason",
+    "CleanupResult",
+    "cleanup_setup_channel_after_completion",
     "delete_setup_channel",
     "ensure_setup_channel",
     "recompute_setup_channel_overwrites",

--- a/disbot/services/setup_session.py
+++ b/disbot/services/setup_session.py
@@ -230,6 +230,18 @@ async def record_readiness_score(guild_id: int, score: int | None) -> None:
     await db.set_readiness_score(guild_id, score)
 
 
+async def set_setup_channel_id(guild_id: int, channel_id: int | None) -> None:
+    """Persist (or clear) the workspace's setup channel id (Phase 8).
+
+    Used by :func:`services.setup_channel.cleanup_setup_channel_after_completion`
+    after a successful Discord-side delete to null
+    ``session.setup_channel_id`` so the next ``/setup`` re-creates the
+    channel cleanly.  Service-layer wrapper around
+    :func:`utils.db.setup_session.set_setup_channel_id`.
+    """
+    await db.set_setup_channel_id(guild_id, channel_id)
+
+
 async def set_setup_message_id(guild_id: int, message_id: int | None) -> None:
     """Persist (or clear) the wizard's anchor message id for ``guild_id``.
 
@@ -472,6 +484,7 @@ __all__ = [
     "resume_session",
     "set_depth",
     "set_purpose",
+    "set_setup_channel_id",
     "set_setup_message_id",
     "start_session",
     "unack_section",

--- a/disbot/utils/db/setup_session.py
+++ b/disbot/utils/db/setup_session.py
@@ -272,6 +272,31 @@ async def clear_acknowledged_sections(guild_id: int) -> None:
     )
 
 
+async def set_setup_channel_id(guild_id: int, channel_id: int | None) -> None:
+    """Persist (or clear) the workspace's setup channel id.
+
+    The setup wizard creates ``#superbot-setup`` and remembers its id
+    on ``setup_session.setup_channel_id``; Phase 8's guarded cleanup
+    service calls this with ``channel_id=None`` after a successful
+    ``delete_setup_channel`` so a future ``/setup`` re-creates the
+    channel cleanly rather than reusing the now-stale id.
+
+    A dedicated setter is required because :func:`upsert` COALESCEs
+    its ``setup_channel_id`` argument with the existing value, so
+    the upsert path cannot clear a stale id.
+    """
+    await pool.get().execute(
+        """
+        UPDATE setup_session
+           SET setup_channel_id = $2,
+               updated_at       = NOW()
+         WHERE guild_id = $1
+        """,
+        guild_id,
+        channel_id,
+    )
+
+
 async def set_setup_message_id(guild_id: int, message_id: int | None) -> None:
     """Persist (or clear) the workspace wizard's anchor message id.
 
@@ -380,6 +405,7 @@ __all__ = [
     "set_depth",
     "set_purpose",
     "set_readiness_score",
+    "set_setup_channel_id",
     "set_setup_message_id",
     "set_status",
     "set_step",

--- a/disbot/views/setup/final_review.py
+++ b/disbot/views/setup/final_review.py
@@ -378,15 +378,28 @@ class FinalReviewView(BaseView):
             self.accepted if self.accepted else self.ops,
             summary=summary,
         )
-        if full_success or not self.ops:
+        if full_success and self.ops:
+            # Phase 8: full-success draft-driven branch mounts the
+            # SetupCompleteView so the operator can either delete
+            # the now-empty setup channel or keep it.  The legacy
+            # recommendation-driven full-success path (``self.ops``
+            # empty) just disables the original buttons — there's
+            # no per-guild setup channel to clean up in that flow.
+            view: discord.ui.View | None = SetupCompleteView(
+                interaction.user,
+                summary=summary,
+            )
+        elif full_success or not self.ops:
             for child in self.children:
                 child.disabled = True  # type: ignore[attr-defined]
-            view: discord.ui.View | None = self
+            view = self
         else:
             # Partial-failure draft-driven branch: replace the view
             # with the recovery surface so the operator can retry
             # or cancel.  The original Apply / Cancel buttons go
             # away — they are no longer the right next actions.
+            # Partial-recovery flows NEVER offer the cleanup buttons
+            # (the plan explicitly forbids that).
             view = PartialApplyRecoveryView(
                 interaction.user,
                 ops=self.ops,
@@ -725,10 +738,144 @@ class PartialApplyRecoveryView(BaseView):
         self.stop()
 
 
+class SetupCompleteView(BaseView):
+    """Post-apply view shown when Final Review applies cleanly.
+
+    Phase 8 of the setup-wizard plan.  Two buttons:
+
+    * **Delete now** — calls
+      :func:`services.setup_channel.cleanup_setup_channel_after_completion`.
+      On success the embed flips to "Setup channel deleted" and the
+      view stops; on a guard failure the operator sees an ephemeral
+      with the typed reason and the buttons stay clickable.
+    * **Keep setup channel** — closes the view without deletion; the
+      channel stays around for the next ``/setup``.
+
+    Both buttons re-check :func:`services.setup_access.can_apply_setup`
+    against a fresh session snapshot.  The plan explicitly forbids
+    showing these buttons on the partial-failure / recovery branch —
+    :meth:`FinalReviewView._run_apply` only mounts this view on the
+    ``full_success and self.ops`` branch.
+    """
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        *,
+        summary: ApplySummary,
+        timeout: int = 300,
+    ) -> None:
+        super().__init__(author, public=False, timeout=timeout)
+        self.summary = summary
+        self._populate_buttons()
+
+    def _populate_buttons(self) -> None:
+        delete_btn: discord.ui.Button = discord.ui.Button(  # type: ignore[var-annotated]
+            label="Delete now",
+            style=discord.ButtonStyle.danger,
+            custom_id="setup_complete:delete",
+            row=0,
+        )
+        delete_btn.callback = self._on_delete  # type: ignore[method-assign]
+        self.add_item(delete_btn)
+
+        keep_btn: discord.ui.Button = discord.ui.Button(  # type: ignore[var-annotated]
+            label="Keep setup channel",
+            style=discord.ButtonStyle.secondary,
+            custom_id="setup_complete:keep",
+            row=0,
+        )
+        keep_btn.callback = self._on_keep  # type: ignore[method-assign]
+        self.add_item(keep_btn)
+
+    async def _on_delete(self, interaction: discord.Interaction) -> None:
+        if not await _gate_apply(interaction):
+            return
+        guild = interaction.guild
+        if guild is None:
+            await interaction.response.send_message(
+                "Delete requires a guild context.",
+                ephemeral=True,
+            )
+            return
+        from services import setup_channel as _setup_channel
+        from services import setup_session as _setup_session
+
+        try:
+            session = await _setup_session.resume_session(guild.id)
+        except Exception:
+            logger.exception("SetupCompleteView._on_delete: resume failed")
+            await interaction.response.send_message(
+                "Couldn't read the setup session — see logs.",
+                ephemeral=True,
+            )
+            return
+
+        result = await _setup_channel.cleanup_setup_channel_after_completion(
+            guild,
+            session,
+            actor=interaction.user,
+        )
+        if result.reason != "ok":
+            await interaction.response.send_message(
+                f"⚠️ {result.detail}",
+                ephemeral=True,
+            )
+            return
+
+        # Success — disable the buttons, flip the embed to a final
+        # "Setup channel deleted" line.  We do NOT call self.stop()
+        # before editing because discord.py won't render a stopped
+        # view; just disable the children.
+        for child in self.children:
+            child.disabled = True  # type: ignore[attr-defined]
+        new_embed = discord.Embed(
+            title="🛰 Setup complete",
+            description=(
+                "**Setup channel deleted.**  "
+                f"Applied **{len(self.summary.applied)}** operation(s); "
+                "the workspace channel is gone.  Re-run `/setup` "
+                "later to recreate it."
+            ),
+            color=discord.Color.green(),
+        )
+        try:
+            await interaction.response.edit_message(
+                embed=new_embed,
+                view=self,
+            )
+        except discord.HTTPException:
+            # Editing the original message may fail because that
+            # message lived in #superbot-setup, which we just
+            # deleted.  Fall back to an ephemeral confirmation.
+            logger.info(
+                "SetupCompleteView._on_delete: edit_message failed (channel gone?)",
+            )
+            await interaction.followup.send(
+                "✅ Setup channel deleted.",
+                ephemeral=True,
+            )
+        self.stop()
+
+    async def _on_keep(self, interaction: discord.Interaction) -> None:
+        if not await _gate_apply(interaction):
+            return
+        for child in self.children:
+            child.disabled = True  # type: ignore[attr-defined]
+        await interaction.response.edit_message(view=self)
+        await interaction.followup.send(
+            "✅ Setup channel kept.  Re-run `/setup` any time to revisit "
+            "the wizard.",
+            ephemeral=True,
+        )
+        self.stop()
+
+
 __all__ = [
     "ApplySummary",
     "FinalReviewView",
     "PartialApplyRecoveryView",
+    "SetupCompleteView",
     "_apply_ops_in_order",
     "_sort_ops_for_apply",
     "build_final_review_embed",

--- a/tests/unit/services/test_setup_channel.py
+++ b/tests/unit/services/test_setup_channel.py
@@ -518,3 +518,295 @@ async def test_delete_setup_channel_returns_false_on_forbidden():
 
     ok = await delete_setup_channel(guild, 7000)
     assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# Phase 8 — guarded cleanup after Final Review apply
+# ---------------------------------------------------------------------------
+
+
+def _complete_session(
+    *,
+    channel_id: int | None = 7000,
+    delegated=(),
+):
+    """Session in the 'complete' state — the precondition for cleanup."""
+    return SetupSession(
+        guild_id=1,
+        guild_name="Test",
+        owner_id=99,
+        setup_status="complete",
+        setup_channel_id=channel_id,
+        setup_message_id=None,
+        last_readiness_score=None,
+        current_step=None,
+        delegated_admins=delegated,
+        skipped_sections=frozenset(),
+        depth=None,
+    )
+
+
+def _owner_member(user_id: int = 99) -> MagicMock:
+    m = MagicMock(spec=discord.Member)
+    m.id = user_id
+    m.guild = SimpleNamespace(owner_id=user_id)
+    m.guild_permissions = SimpleNamespace(administrator=False)
+    return m
+
+
+def _random_member(user_id: int = 42) -> MagicMock:
+    m = MagicMock(spec=discord.Member)
+    m.id = user_id
+    m.guild = SimpleNamespace(owner_id=99)
+    m.guild_permissions = SimpleNamespace(administrator=False)
+    return m
+
+
+@pytest.mark.asyncio
+async def test_cleanup_refuses_when_session_not_complete():
+    from services.setup_channel import cleanup_setup_channel_after_completion
+
+    guild = _make_guild()
+    session = _complete_session()
+    # Force the not-complete branch.
+    session = SetupSession(
+        guild_id=session.guild_id,
+        guild_name=session.guild_name,
+        owner_id=session.owner_id,
+        setup_status="in_progress",  # not complete
+        setup_channel_id=session.setup_channel_id,
+        setup_message_id=session.setup_message_id,
+        last_readiness_score=None,
+        current_step=None,
+        delegated_admins=session.delegated_admins,
+        skipped_sections=frozenset(),
+        depth=None,
+    )
+
+    result = await cleanup_setup_channel_after_completion(
+        guild,
+        session,
+        actor=_owner_member(),
+    )
+    assert result.reason == "not_complete"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_refuses_when_session_is_none():
+    from services.setup_channel import cleanup_setup_channel_after_completion
+
+    result = await cleanup_setup_channel_after_completion(
+        _make_guild(),
+        None,
+        actor=_owner_member(),
+    )
+    assert result.reason == "not_complete"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_refuses_when_draft_not_empty():
+    from services.setup_channel import cleanup_setup_channel_after_completion
+
+    guild = _make_guild()
+    session = _complete_session()
+    with patch(
+        "services.setup_draft.count",
+        new_callable=AsyncMock,
+        return_value=3,  # staged ops still in draft
+    ):
+        result = await cleanup_setup_channel_after_completion(
+            guild,
+            session,
+            actor=_owner_member(),
+        )
+    assert result.reason == "draft_not_empty"
+    assert "3" in result.detail
+
+
+@pytest.mark.asyncio
+async def test_cleanup_refuses_when_channel_already_renamed():
+    from services.setup_channel import cleanup_setup_channel_after_completion
+
+    renamed = _make_text_channel(7000)
+    renamed.name = "operator-took-over"
+    guild = _make_guild(cached_channel=renamed)
+    session = _complete_session(channel_id=7000)
+    with patch(
+        "services.setup_draft.count",
+        new_callable=AsyncMock,
+        return_value=0,
+    ):
+        result = await cleanup_setup_channel_after_completion(
+            guild,
+            session,
+            actor=_owner_member(),
+        )
+    assert result.reason == "channel_renamed"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_refuses_when_unauthorized():
+    from services.setup_channel import cleanup_setup_channel_after_completion
+
+    channel = _make_text_channel(7000)
+    guild = _make_guild(cached_channel=channel)
+    # Random member, not the owner and not delegated.
+    session = _complete_session(channel_id=7000, delegated=())
+    with patch(
+        "services.setup_draft.count",
+        new_callable=AsyncMock,
+        return_value=0,
+    ):
+        result = await cleanup_setup_channel_after_completion(
+            guild,
+            session,
+            actor=_random_member(),
+        )
+    assert result.reason == "unauthorized"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_refuses_when_channel_missing_from_cache():
+    """Channel cached as None (already deleted out-of-band) returns the
+    channel_missing reason and nulls the session pointer for cleanliness.
+    """
+    from services.setup_channel import cleanup_setup_channel_after_completion
+
+    guild = _make_guild(cached_channel=None)
+    session = _complete_session(channel_id=7000)
+    with (
+        patch(
+            "services.setup_draft.count",
+            new_callable=AsyncMock,
+            return_value=0,
+        ),
+        patch(
+            "services.setup_session.set_setup_channel_id",
+            new_callable=AsyncMock,
+        ) as null_mock,
+    ):
+        result = await cleanup_setup_channel_after_completion(
+            guild,
+            session,
+            actor=_owner_member(),
+        )
+    assert result.reason == "channel_missing"
+    null_mock.assert_awaited_once_with(1, None)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_refuses_when_setup_channel_id_not_set():
+    from services.setup_channel import cleanup_setup_channel_after_completion
+
+    guild = _make_guild()
+    session = _complete_session(channel_id=None)
+    with patch(
+        "services.setup_draft.count",
+        new_callable=AsyncMock,
+        return_value=0,
+    ):
+        result = await cleanup_setup_channel_after_completion(
+            guild,
+            session,
+            actor=_owner_member(),
+        )
+    assert result.reason == "channel_missing"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_succeeds_and_nulls_session_pointers():
+    from services.setup_channel import cleanup_setup_channel_after_completion
+
+    channel = _make_text_channel(7000)
+    channel.delete = AsyncMock()
+    guild = _make_guild(cached_channel=channel)
+    session = _complete_session(channel_id=7000)
+    with (
+        patch(
+            "services.setup_draft.count",
+            new_callable=AsyncMock,
+            return_value=0,
+        ),
+        patch(
+            "services.setup_session.set_setup_channel_id",
+            new_callable=AsyncMock,
+        ) as null_channel_mock,
+        patch(
+            "services.setup_session.set_setup_message_id",
+            new_callable=AsyncMock,
+        ) as null_message_mock,
+    ):
+        result = await cleanup_setup_channel_after_completion(
+            guild,
+            session,
+            actor=_owner_member(),
+        )
+    assert result.reason == "ok"
+    channel.delete.assert_awaited_once()
+    # Both session pointers nulled so the next /setup re-creates fresh.
+    null_channel_mock.assert_awaited_once_with(1, None)
+    null_message_mock.assert_awaited_once_with(1, None)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_returns_delete_failed_when_delete_refused():
+    """Discord-side delete refuses → delete_failed reason; pointers stay."""
+    from services.setup_channel import cleanup_setup_channel_after_completion
+
+    channel = _make_text_channel(7000)
+    channel.delete = AsyncMock(
+        side_effect=discord.Forbidden(MagicMock(), "denied"),
+    )
+    guild = _make_guild(cached_channel=channel)
+    session = _complete_session(channel_id=7000)
+    with (
+        patch(
+            "services.setup_draft.count",
+            new_callable=AsyncMock,
+            return_value=0,
+        ),
+        patch(
+            "services.setup_session.set_setup_channel_id",
+            new_callable=AsyncMock,
+        ) as null_mock,
+    ):
+        result = await cleanup_setup_channel_after_completion(
+            guild,
+            session,
+            actor=_owner_member(),
+        )
+    assert result.reason == "delete_failed"
+    # No nulling on failure — pointers stay so the operator can retry.
+    null_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_delegated_admin_can_trigger_deletion():
+    """Delegated setup admins (not just owners) pass the cleanup gate."""
+    from services.setup_channel import cleanup_setup_channel_after_completion
+
+    channel = _make_text_channel(7000)
+    channel.delete = AsyncMock()
+    guild = _make_guild(cached_channel=channel)
+    session = _complete_session(channel_id=7000, delegated=(42,))
+    with (
+        patch(
+            "services.setup_draft.count",
+            new_callable=AsyncMock,
+            return_value=0,
+        ),
+        patch(
+            "services.setup_session.set_setup_channel_id",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "services.setup_session.set_setup_message_id",
+            new_callable=AsyncMock,
+        ),
+    ):
+        result = await cleanup_setup_channel_after_completion(
+            guild,
+            session,
+            actor=_random_member(user_id=42),
+        )
+    assert result.reason == "ok"

--- a/tests/unit/views/setup/sections/test_final_review_draft.py
+++ b/tests/unit/views/setup/sections/test_final_review_draft.py
@@ -224,8 +224,10 @@ def _interaction_with_guild():
     interaction.response.send_message = AsyncMock()
     interaction.response.edit_message = AsyncMock()
     interaction.response.defer = AsyncMock()
+    interaction.response.is_done = MagicMock(return_value=False)
     interaction.followup = MagicMock()
     interaction.followup.edit_message = AsyncMock()
+    interaction.followup.send = AsyncMock()
     return interaction
 
 
@@ -364,9 +366,12 @@ async def test_view_apply_preserves_draft_on_skipped_result():
 
 @pytest.mark.asyncio
 async def test_view_apply_full_success_clears_and_marks_complete():
-    """Full success: draft is cleared, session is marked complete, the
-    view is disabled (no recovery view mount).
+    """Full success: draft is cleared, session is marked complete, and
+    (Phase 8) the SetupCompleteView is mounted so the operator can
+    delete the now-empty setup channel or keep it.
     """
+    from views.setup.final_review import SetupCompleteView
+
     view = FinalReviewView(_owner_member(), ops=[_op("bind_channel")])
     interaction = _interaction_with_guild()
 
@@ -395,9 +400,11 @@ async def test_view_apply_full_success_clears_and_marks_complete():
 
     clear_mock.assert_awaited_once_with(1)
     complete_mock.assert_awaited_once_with(1)
-    # Same view re-rendered with all buttons disabled, no recovery view.
+    # Phase 8: on full success the SetupCompleteView is mounted with
+    # the Delete / Keep cleanup buttons.  Partial-recovery NEVER gets
+    # these buttons (pinned separately).
     edit_kwargs = interaction.followup.edit_message.await_args.kwargs
-    assert edit_kwargs["view"] is view
+    assert isinstance(edit_kwargs["view"], SetupCompleteView)
 
 
 @pytest.mark.asyncio
@@ -907,3 +914,217 @@ async def test_back_button_closes_with_back_message():
     await back_btn.callback(interaction)
 
     interaction.response.edit_message.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Phase 8 — SetupCompleteView cleanup buttons
+# ---------------------------------------------------------------------------
+
+
+def test_setup_complete_view_has_delete_and_keep_buttons():
+    from views.setup.final_review import ApplySummary, SetupCompleteView
+
+    view = SetupCompleteView(_owner_member(), summary=ApplySummary(applied=["x"]))
+    custom_ids = {
+        c.custom_id
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+    }
+    assert custom_ids == {"setup_complete:delete", "setup_complete:keep"}
+
+
+@pytest.mark.asyncio
+async def test_setup_complete_delete_calls_cleanup_service():
+    """Pressing Delete invokes the guarded cleanup service and edits the
+    embed to the post-deletion state on success.
+    """
+    from services.setup_channel import CleanupResult
+    from views.setup.final_review import ApplySummary, SetupCompleteView
+
+    view = SetupCompleteView(_owner_member(), summary=ApplySummary(applied=["x"]))
+    interaction = _interaction_with_guild()
+    fake_session = MagicMock()
+    fake_session.delegated_admins = ()
+    fake_session.guild = SimpleNamespace(owner_id=99)
+
+    with (
+        patch(
+            "services.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=fake_session,
+        ),
+        patch(
+            "services.setup_channel.cleanup_setup_channel_after_completion",
+            new_callable=AsyncMock,
+            return_value=CleanupResult(
+                reason="ok",
+                detail="Setup channel deleted.",
+            ),
+        ) as cleanup_mock,
+        patch(
+            "services.setup_session.set_setup_message_id",
+            new_callable=AsyncMock,
+        ),
+        # _gate_apply uses resume_session + can_apply_setup; the
+        # owner member always passes can_apply_setup against the
+        # session.owner_id.
+        patch(
+            "views.setup.final_review.setup_access.can_apply_setup",
+            return_value=True,
+        ),
+    ):
+        delete_btn = next(
+            c
+            for c in view.children
+            if isinstance(c, discord.ui.Button)
+            and c.custom_id == "setup_complete:delete"
+        )
+        await delete_btn.callback(interaction)
+
+    cleanup_mock.assert_awaited_once()
+    # Embed flipped to the post-deletion success state.
+    edit_kwargs = interaction.response.edit_message.await_args.kwargs
+    new_embed = edit_kwargs.get("embed")
+    assert new_embed is not None
+    assert "deleted" in (new_embed.description or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_setup_complete_delete_surfaces_guard_failure_as_ephemeral():
+    """Guard failure (e.g. channel renamed) shows the reason
+    ephemerally and leaves the buttons clickable for retry.
+    """
+    from services.setup_channel import CleanupResult
+    from views.setup.final_review import ApplySummary, SetupCompleteView
+
+    view = SetupCompleteView(_owner_member(), summary=ApplySummary(applied=["x"]))
+    interaction = _interaction_with_guild()
+    fake_session = MagicMock()
+    fake_session.delegated_admins = ()
+    fake_session.guild = SimpleNamespace(owner_id=99)
+
+    with (
+        patch(
+            "services.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=fake_session,
+        ),
+        patch(
+            "services.setup_channel.cleanup_setup_channel_after_completion",
+            new_callable=AsyncMock,
+            return_value=CleanupResult(
+                reason="channel_renamed",
+                detail="Channel renamed; refusing to delete.",
+            ),
+        ),
+        patch(
+            "views.setup.final_review.setup_access.can_apply_setup",
+            return_value=True,
+        ),
+    ):
+        delete_btn = next(
+            c
+            for c in view.children
+            if isinstance(c, discord.ui.Button)
+            and c.custom_id == "setup_complete:delete"
+        )
+        await delete_btn.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "renamed" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_setup_complete_delete_rejects_non_delegated_admin():
+    from views.setup.final_review import ApplySummary, SetupCompleteView
+
+    # Use _owner_member here just for the BaseView author check;
+    # _gate_apply patches can_apply_setup to False below.
+    view = SetupCompleteView(_owner_member(), summary=ApplySummary(applied=["x"]))
+    interaction = _interaction_with_guild()
+
+    with (
+        patch(
+            "services.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ),
+        patch(
+            "views.setup.final_review.setup_access.can_apply_setup",
+            return_value=False,
+        ),
+        patch(
+            "services.setup_channel.cleanup_setup_channel_after_completion",
+            new_callable=AsyncMock,
+        ) as cleanup_mock,
+    ):
+        delete_btn = next(
+            c
+            for c in view.children
+            if isinstance(c, discord.ui.Button)
+            and c.custom_id == "setup_complete:delete"
+        )
+        await delete_btn.callback(interaction)
+
+    cleanup_mock.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_setup_complete_keep_closes_view_without_deletion():
+    from views.setup.final_review import ApplySummary, SetupCompleteView
+
+    view = SetupCompleteView(_owner_member(), summary=ApplySummary(applied=["x"]))
+    interaction = _interaction_with_guild()
+
+    with (
+        patch(
+            "services.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ),
+        patch(
+            "views.setup.final_review.setup_access.can_apply_setup",
+            return_value=True,
+        ),
+        patch(
+            "services.setup_channel.cleanup_setup_channel_after_completion",
+            new_callable=AsyncMock,
+        ) as cleanup_mock,
+    ):
+        keep_btn = next(
+            c
+            for c in view.children
+            if isinstance(c, discord.ui.Button)
+            and c.custom_id == "setup_complete:keep"
+        )
+        await keep_btn.callback(interaction)
+
+    cleanup_mock.assert_not_awaited()
+    interaction.response.edit_message.assert_awaited_once()
+    interaction.followup.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_partial_recovery_view_does_not_offer_cleanup_buttons():
+    """Phase 8: partial-recovery flows NEVER offer the Delete / Keep
+    buttons.  Pinned because the plan explicitly forbids it.
+    """
+    from views.setup.final_review import ApplySummary
+
+    summary = ApplySummary(applied=["one"], failed=["two: boom"])
+    recovery = PartialApplyRecoveryView(
+        _owner_member(),
+        ops=[_op("bind_channel")],
+        accepted=[],
+        summary=summary,
+    )
+    custom_ids = {
+        getattr(c, "custom_id", None) or c.label
+        for c in recovery.children
+        if isinstance(c, discord.ui.Button)
+    }
+    # Neither cleanup-button custom_id appears on the recovery view.
+    assert "setup_complete:delete" not in custom_ids
+    assert "setup_complete:keep" not in custom_ids


### PR DESCRIPTION
## Summary

Final phase of the setup-wizard plan. Adds the guarded cleanup service for `#superbot-setup` and Final Review completion buttons so an operator who finishes setup can either delete the now-empty workspace channel or keep it. **Phase 8 closes the nine-PR setup-wizard sequence.**

Builds on Phases 0–7 (all merged).

### What changed

- **`services.setup_channel.cleanup_setup_channel_after_completion(guild, session, *, actor)`** — guarded delete. Mandatory checks in order:
  1. `session.setup_status == "complete"` (Final Review applied).
  2. `setup_draft.count(guild_id) == 0` — empty-draft proxy for "no partial-recovery in progress". The plan's "if a recovery marker exists, also check it" branch falls through because Phase 0 didn't introduce one.
  3. `session.setup_channel_id` is set AND resolves to a real text channel.
  4. Channel id matches the resolved channel.
  5. Channel name still `superbot-setup`.
  6. `setup_access.can_apply_setup(actor, session)`.
  
  Returns a typed `CleanupResult(reason, detail)` with seven discriminator values (`ok` / `not_complete` / `draft_not_empty` / `channel_id_mismatch` / `channel_renamed` / `channel_missing` / `unauthorized` / `delete_failed`). The caller surfaces `detail` ephemerally. On success: routes through the existing `delete_setup_channel` (which has its own name guard, kept as defence in depth) and nulls both `setup_channel_id` and `setup_message_id` so the next `/setup` re-creates a fresh channel.
- **`utils.db.setup_session.set_setup_channel_id` + service wrapper** — dedicated setter so the cleanup path can null the channel id (upsert's COALESCE can't clear a value).
- **`views.setup.final_review.SetupCompleteView`** — post-apply view shown ONLY on the full-success draft-driven branch. Two buttons:
  - **Delete now** — gates on `can_apply_setup`; invokes the cleanup service; on success edits the embed to a final "Setup channel deleted" line, on guard failure surfaces the typed reason in an ephemeral and leaves the buttons clickable for retry.
  - **Keep setup channel** — dismisses without deletion; confirmation ephemeral.
- **Final Review branch selection** — `_run_apply` now:
  - full-success + ops → `SetupCompleteView`,
  - full-success + only accepted (legacy AI flow) → disable existing buttons,
  - partial → `PartialApplyRecoveryView` (unchanged, never sees the cleanup buttons — pinned by a test).

### What did NOT change

- No new migration; reuses the existing `setup_session` columns.
- No auto-delete-after-inactivity scheduling — the plan documented this as deferred because the codebase has no cancel-on-activity scheduler.
- No partial-recovery marker added (none exists; the empty-draft proxy is sufficient per the plan).

## Test plan

- [x] `pytest tests/unit/services/test_setup_channel.py` — 33 tests pass, including 9 new Phase 8 tests covering every `CleanupReason` discriminator.
- [x] `pytest tests/unit/views/setup/sections/test_final_review_draft.py` — 33 tests pass, including 6 new Phase 8 tests for `SetupCompleteView` (button layout, delete success + flipped embed, delete guard-failure ephemeral, delete `can_apply_setup` gate, keep close-without-delete, partial-recovery never offering the cleanup buttons).
- [x] Full sweep `pytest tests/` — 5198 pass, 3 skipped, no failures.
- [x] `black --check`, `isort --check-only`, `ruff check`, `mypy disbot/` — clean.

### Manual smoke checks (UI work — deferred to a real Discord run)

- Owner completes a full-success Final Review apply → SetupCompleteView appears with **Delete now** / **Keep setup channel** buttons.
- **Delete now** deletes `#superbot-setup`; the ephemeral embed flips to "Setup channel deleted"; re-running `/setup` recreates the channel cleanly (session pointers are nulled).
- **Delete now** with a renamed channel surfaces "refusing to delete an operator-renamed channel" ephemerally; buttons stay clickable.
- **Keep setup channel** closes the view without touching the channel; "/setup" still resumes inside the existing channel.
- A partial-failure apply mounts `PartialApplyRecoveryView` (Retry / Cancel only) — the cleanup buttons never appear there.
- A non-delegated admin pressing Delete (impossible via the BaseView author gate in normal flow, but verified defence-in-depth) gets the can_apply_setup rejection.

## Closing the sequence

This is PR 9 of the nine-PR setup-wizard plan. The merged sequence:

| PR | Phase | Title |
|---|---|---|
| #328 | 0 | Final Review safety foundation |
| #329 | 1 | Workspace + access consistency |
| #330 | 2 | Builder adapter + progress alignment |
| #331 | 3 | Linear wizard shell |
| #332 | 4 | Server purpose section |
| #333 | 5 | Logging presets section |
| #334 | 6 | AI setup link-only section |
| #335 | 7 | Recovery embeds + Final Review copy polish |
| this | 8 | Guarded setup-channel cleanup |

Open follow-ups (out of the plan's strict scope but called out in earlier PRs): navigation-host adapter + section card Customize from the wizard (Phase 3.5), and any operator-driven AI-policy operation kind (deferred from Phase 6).

---
_Generated by [Claude Code](https://claude.ai/code/session_018hiDeqzURZ1GEmNfssQd64)_