### PR TITLE
fix: regression repair — terminal game views, shared response policy, setup ephemerals, command-surface guard

### DIFF
--- a/disbot/cogs/setup_cog.py
+++ b/disbot/cogs/setup_cog.py
@@ -523,7 +523,25 @@ class SetupCog(commands.Cog):
             pending_ops = 0
 
         embed = _build_status_embed(session, pending_ops=pending_ops)
-        await interaction.response.send_message(embed=embed, ephemeral=True)
+        # Aggressive ephemeral policy: post the status snapshot to the
+        # workspace as a durable notice (event log) rather than a
+        # per-user ephemeral. The wizard anchor stays in place, so
+        # running /setup-status mid-wizard does not clobber state.
+        # Reply with a short ephemeral pointer.
+        from views.setup._anchor import push_setup_notice
+
+        posted = await push_setup_notice(guild, embed=embed)
+        if posted:
+            channel_id = session.setup_channel_id if session is not None else None
+            ref = f"<#{channel_id}>" if channel_id else "the setup workspace"
+            await interaction.response.send_message(
+                f"📋 Setup status posted in {ref}.",
+                ephemeral=True,
+            )
+        else:
+            # Fall back to the historic ephemeral when the workspace is
+            # unreachable so the operator still sees the snapshot.
+            await interaction.response.send_message(embed=embed, ephemeral=True)
 
     @commands.Cog.listener()
     async def on_guild_join(self, guild: discord.Guild) -> None:

--- a/disbot/views/base.py
+++ b/disbot/views/base.py
@@ -55,9 +55,13 @@ async def handle_view_error(
     ``on_error`` because they intentionally surface ``type(error).__name__``
     to admins for diagnosability.
     """
+    # response_done distinguishes "raised before first response" from
+    # "raised after defer" — these need different remediation in callbacks
+    # (the former is a missing safe_defer; the latter is a service bug).
+    response_done = interaction.response.is_done()
     logger.error(
         "View error | view=%s item_type=%s custom_id=%r label=%r "
-        "user=%s guild=%s channel=%s message=%s",
+        "user=%s guild=%s channel=%s message=%s response_done=%s",
         type(view).__name__,
         type(item).__name__,
         getattr(item, "custom_id", None),
@@ -66,9 +70,10 @@ async def handle_view_error(
         interaction.guild_id,
         interaction.channel_id,
         interaction.message.id if interaction.message else None,
+        response_done,
         exc_info=error,
     )
-    if not interaction.response.is_done():
+    if not response_done:
         try:
             await interaction.response.send_message(
                 "An error occurred. Please try again.",

--- a/disbot/views/blackjack/solo_view.py
+++ b/disbot/views/blackjack/solo_view.py
@@ -7,13 +7,16 @@ use a separate view (``_TournBlackjackView``) because the chip / round
 bookkeeping differs.
 
 Solo end-of-hand UX: when a solo hand finishes (i.e. no PvP
-``on_finish`` callback and no ``tournament_chips``), ``_finish``
-appends a ``🔁 Play again`` / ``◀ Back to Blackjack`` row before
-re-rendering. ``Play again`` re-enters ``start_solo_blackjack``
-with the same user/guild/bet (after the same balance check the
-typed ``!blackjack`` command performs), so the active-game map and
-persistence path stay in one place. PvP and tournament views are
-untouched by the replay path.
+``on_finish`` callback and no ``tournament_chips``), ``_finish`` swaps
+the live ``BlackjackView`` for a fresh ``_BlackjackSoloResultView`` —
+the same disabled hit/stand/double shells on row 0, plus enabled
+``🔁 Play again`` / ``◀ Back to Blackjack`` on row 1.  Replacing
+the view (instead of appending buttons and calling ``stop()`` on the
+original) keeps the terminal-state buttons dispatchable: the original
+view's stop unregisters its callbacks from discord.py, and any
+buttons still bound to it would fail to respond. PvP and tournament
+paths keep their original ``BlackjackView`` until ``stop()`` — they
+never expose replay/back.
 """
 
 from __future__ import annotations
@@ -97,91 +100,27 @@ class BlackjackView(discord.ui.View):
         else:
             embed.add_field(name=result, value="​", inline=False)
 
-        # Solo-only: attach replay + back action row before the edit so
-        # the user has an enabled escape from the result message.
+        # Solo-only: hand the message off to a fresh result view so the
+        # Play again / Back buttons remain dispatchable. Calling
+        # self.stop() on a view that still exposes enabled buttons
+        # un-registers it from discord.py's dispatch table — those
+        # buttons would then surface "interaction failed" on click.
         if self.game.tournament_chips is None and self.on_finish is None:
-            self._attach_solo_result_actions()
+            result_view = _BlackjackSoloResultView(
+                self.game.user_id,
+                self.game.guild_id,
+                self.game.bet,
+                self.game,
+            )
+            await safe_edit(interaction, embed=embed, view=result_view)
+            result_view.message = interaction.message
+        else:
+            await safe_edit(interaction, embed=embed, view=self)
 
-        await safe_edit(interaction, embed=embed, view=self)
         self.stop()
 
         if self.on_finish:
             await self.on_finish(self.game, hand_value)
-
-    def _attach_solo_result_actions(self) -> None:
-        """Append Play again + Back to Blackjack buttons on row 1.
-
-        Called once at end-of-hand for solo games only. The original
-        hit/stand/double buttons on row 0 stay visible-but-disabled.
-        """
-        replay_btn = discord.ui.Button(  # type: ignore[var-annotated]
-            label="🔁 Play again",
-            style=discord.ButtonStyle.success,
-            custom_id="blackjack:solo:replay",
-            row=1,
-        )
-        replay_btn.callback = self._replay  # type: ignore[method-assign]
-        self.add_item(replay_btn)
-
-        # Late import: blackjack_panel imports BlackjackView indirectly
-        # via the actions helpers, so importing it at module level
-        # would create a cycle.
-        from views.games.blackjack_panel import _make_blackjack_back_button
-
-        back_btn = _make_blackjack_back_button()
-        back_btn.row = 1
-        self.add_item(back_btn)
-
-    async def _replay(self, interaction: discord.Interaction) -> None:
-        """Re-enter ``start_solo_blackjack`` with the same user/guild/bet.
-
-        Reuses the canonical entry point so the active-game map (``_active``),
-        persistence (``_save_game_state``), and natural-blackjack auto-payout
-        all behave identically to a fresh ``!blackjack`` invocation.
-        Balance is checked inside ``start_solo_blackjack``; insufficient
-        balance surfaces as an ephemeral nudge here.
-        """
-        if not await safe_defer(interaction):
-            return
-
-        # Late imports — actions imports BlackjackView at module level.
-        from cogs.blackjack.actions import (
-            commit_solo_blackjack,
-            start_solo_blackjack,
-        )
-
-        user = interaction.user
-        guild = interaction.guild
-        if guild is None:
-            await safe_followup(
-                interaction,
-                "❌ Replay isn't available in DMs.",
-                ephemeral=True,
-            )
-            return
-
-        result = await start_solo_blackjack(
-            user,
-            guild,
-            interaction.channel,  # type: ignore[arg-type]
-            self.game.bet,
-        )
-        if result.ephemeral_message is not None:
-            await safe_followup(
-                interaction,
-                result.ephemeral_message,
-                ephemeral=True,
-            )
-            return
-
-        # Natural blackjack auto-payout path: short-circuits with an
-        # embed but no playable view. Render the result and stop here.
-        if result.view is None:
-            await safe_edit(interaction, embed=result.embed, view=None)
-            return
-
-        await safe_edit(interaction, embed=result.embed, view=result.view)
-        await commit_solo_blackjack(result.view, interaction.message)  # type: ignore[arg-type]
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         if interaction.user.id != self.game.user_id:
@@ -301,3 +240,141 @@ class BlackjackView(discord.ui.View):
         else:
             loss = -effective if effective else 0
             await self._finish(interaction, "😞 Dealer wins.", ERROR_COLOR, loss, pv)
+
+
+class _BlackjackSoloResultView(discord.ui.View):
+    """Terminal-state view shown after a solo blackjack hand resolves.
+
+    Replaces the live ``BlackjackView`` once ``_finish`` settles so that
+    Play again / Back buttons stay independently dispatchable. The
+    previous design appended these buttons to the still-attached
+    ``BlackjackView`` and called ``self.stop()`` — which removes the
+    view from discord.py's component dispatch table and leaves the
+    visible buttons unable to respond (Discord then renders
+    "interaction failed" after the 3 s response window).
+    """
+
+    def __init__(
+        self,
+        user_id: int,
+        guild_id: int,
+        bet: int,
+        game: _Game,
+    ) -> None:
+        super().__init__(timeout=120)
+        self.user_id = user_id
+        self.guild_id = guild_id
+        self.bet = bet
+        self.game = game
+        self.message: discord.Message | None = None
+
+        for label, emoji, style in (
+            ("Hit", "👊", discord.ButtonStyle.green),
+            ("Stand", "✋", discord.ButtonStyle.grey),
+            ("Double Down", "✌️", discord.ButtonStyle.blurple),
+        ):
+            self.add_item(
+                discord.ui.Button(
+                    label=label,
+                    emoji=emoji,
+                    style=style,
+                    disabled=True,
+                    row=0,
+                ),
+            )
+
+        replay_btn = discord.ui.Button(  # type: ignore[var-annotated]
+            label="🔁 Play again",
+            style=discord.ButtonStyle.success,
+            custom_id="blackjack:solo:replay",
+            row=1,
+        )
+        replay_btn.callback = self._replay  # type: ignore[method-assign]
+        self.add_item(replay_btn)
+
+        # Late import: blackjack_panel imports BlackjackView indirectly
+        # via the actions helpers, so importing it at module level
+        # would create a cycle.
+        from views.games.blackjack_panel import _make_blackjack_back_button
+
+        back_btn = _make_blackjack_back_button()
+        back_btn.row = 1
+        self.add_item(back_btn)
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.user_id:
+            await interaction.response.send_message(
+                "This isn't your hand.",
+                ephemeral=True,
+            )
+            return False
+        return True
+
+    async def on_timeout(self) -> None:
+        if self.message is None:
+            return
+        for item in self.children:
+            item.disabled = True  # type: ignore[attr-defined]
+        try:
+            await self.message.edit(view=self)
+        except Exception:
+            pass
+
+    async def on_error(
+        self,
+        interaction: discord.Interaction,
+        error: Exception,
+        item: discord.ui.Item,  # type: ignore[type-arg]
+    ) -> None:
+        await _on_view_error(self, interaction, error, item)
+
+    async def _replay(self, interaction: discord.Interaction) -> None:
+        """Re-enter ``start_solo_blackjack`` with the same user/guild/bet.
+
+        Delegates to the canonical solo entry point so the active-game
+        map (``_active``), persistence, and natural-blackjack auto-payout
+        behave identically to a fresh ``!blackjack`` invocation. Balance
+        is checked inside ``start_solo_blackjack``; insufficient balance
+        surfaces as an ephemeral nudge here.
+        """
+        if not await safe_defer(interaction):
+            return
+
+        # Late imports — actions imports BlackjackView at module level.
+        from cogs.blackjack.actions import (
+            commit_solo_blackjack,
+            start_solo_blackjack,
+        )
+
+        user = interaction.user
+        guild = interaction.guild
+        if guild is None:
+            await safe_followup(
+                interaction,
+                "❌ Replay isn't available in DMs.",
+                ephemeral=True,
+            )
+            return
+
+        result = await start_solo_blackjack(
+            user,
+            guild,
+            interaction.channel,  # type: ignore[arg-type]
+            self.bet,
+        )
+        if result.ephemeral_message is not None:
+            await safe_followup(
+                interaction,
+                result.ephemeral_message,
+                ephemeral=True,
+            )
+            return
+
+        # Natural blackjack auto-payout path: short-circuits with an
+        # embed but no playable view. Render the result and stop here.
+        if result.view is None:
+            await safe_edit(interaction, embed=result.embed, view=None)
+            return
+
+        await safe_edit(interaction, embed=result.embed, view=result.view)
+        await commit_solo_blackjack(result.view, interaction.message)  # type: ignore[arg-type]

--- a/disbot/views/games/common.py
+++ b/disbot/views/games/common.py
@@ -26,6 +26,8 @@ from collections.abc import Callable
 
 import discord
 
+from core.runtime.interaction_helpers import safe_defer, safe_edit
+
 ParentBuilder = Callable[
     [discord.Member | discord.User],
     discord.ui.View,
@@ -66,10 +68,19 @@ class BackToPanelButton(discord.ui.Button):
         self._overview_builder = overview_builder
 
     async def callback(self, interaction: discord.Interaction) -> None:
+        # Canonical "component defer then edit clicked message" pattern:
+        # safe_defer is idempotent and bails cleanly on token expiry, and
+        # safe_edit routes through followup.edit_message(message_id=
+        # interaction.message.id) once deferred. Without this, a raw
+        # response.edit_message after token expiry surfaces "interaction
+        # failed" to the user.
+        if not await safe_defer(interaction):
+            return
         parent_view = self.view
         author = getattr(parent_view, "_author", interaction.user)
         new_view = self._panel_builder(author)
-        await interaction.response.edit_message(
+        await safe_edit(
+            interaction,
             embed=self._overview_builder(),
             view=new_view,
         )

--- a/disbot/views/rps/solo_play.py
+++ b/disbot/views/rps/solo_play.py
@@ -8,12 +8,17 @@ lose nothing more than they already have).  Win credits, loss debits
 with overdraft allowed to preserve the original floor-at-zero
 behaviour.
 
-After resolution the move buttons stay visible-but-disabled and a
-``Play again`` / ``↩ Back to RPS`` row is appended. ``Play again``
-spawns a fresh :class:`_RpsView` with the same user/guild/bet
-(after a balance pre-check when ``bet > 0``); ``Back to RPS``
-returns to :class:`views.games.rps_panel.RPSPanelView` via the
-shared :class:`views.games.common.BackToPanelButton`.
+After resolution ``_RpsView`` hands the message off to a fresh
+``_RpsSoloResultView`` — same three disabled Rock/Paper/Scissors
+shells on row 0, plus ``🔁 Play again`` / ``↩ Back to RPS`` on row
+1. Swapping the view (rather than appending buttons and calling
+``stop()`` on the original) keeps the terminal-state buttons
+dispatchable: the original view's ``stop()`` un-registers it from
+discord.py's component dispatch table, and any buttons still bound
+to it would surface "interaction failed" on click. ``Play again``
+spawns a fresh ``_RpsView`` with the same user/guild/bet (after a
+balance pre-check when ``bet > 0``); ``Back to RPS`` returns to
+``RPSPanelView`` via the shared ``BackToPanelButton``.
 """
 
 from __future__ import annotations
@@ -105,20 +110,65 @@ class _RpsView(discord.ui.View):
             color=color,
         )
 
-        self._attach_result_actions()
-
-        await safe_edit(interaction, embed=embed, view=self)
-        # Stop the original game's timeout. The newly-added result-action
-        # buttons remain clickable indefinitely (they have their own
-        # ownership check via interaction_check above).
+        result_view = _RpsSoloResultView(self.user, self.guild_id, self.bet)
+        await safe_edit(interaction, embed=embed, view=result_view)
+        result_view.message = interaction.message
         self.stop()
 
-    def _attach_result_actions(self) -> None:
-        """Append Play again + Back to RPS buttons on row 1.
+    @discord.ui.button(label="Rock", emoji="🪨", style=discord.ButtonStyle.grey)
+    async def rock(self, i: discord.Interaction, _: discord.ui.Button):
+        await self._play(i, "rock")
 
-        Called once at end-of-game, after the move buttons on row 0 are
-        disabled.
-        """
+    @discord.ui.button(label="Paper", emoji="📄", style=discord.ButtonStyle.grey)
+    async def paper(self, i: discord.Interaction, _: discord.ui.Button):
+        await self._play(i, "paper")
+
+    @discord.ui.button(label="Scissors", emoji="✂️", style=discord.ButtonStyle.grey)
+    async def scissors(self, i: discord.Interaction, _: discord.ui.Button):
+        await self._play(i, "scissors")
+
+    async def on_timeout(self):
+        for item in self.children:
+            item.disabled = True  # type: ignore[attr-defined]
+        try:
+            await self.message.edit(content="Game timed out.", view=self)
+        except Exception:
+            pass
+
+
+class _RpsSoloResultView(discord.ui.View):
+    """Terminal-state view shown after a solo RPS round resolves.
+
+    Replaces the live ``_RpsView`` once ``_play`` settles so that Play
+    again / Back stay independently dispatchable. The previous design
+    appended these buttons to the still-attached ``_RpsView`` and
+    called ``self.stop()`` on it — which removes the view from
+    discord.py's component dispatch table and leaves the visible
+    buttons unable to respond (Discord renders "interaction failed").
+    """
+
+    def __init__(self, user: discord.Member, guild_id: int, bet: int) -> None:
+        super().__init__(timeout=60)
+        self.user = user
+        self.guild_id = guild_id
+        self.bet = bet
+        self.message: discord.Message | None = None
+
+        for label, emoji in (
+            ("Rock", "🪨"),
+            ("Paper", "📄"),
+            ("Scissors", "✂️"),
+        ):
+            self.add_item(
+                discord.ui.Button(
+                    label=label,
+                    emoji=emoji,
+                    style=discord.ButtonStyle.grey,
+                    disabled=True,
+                    row=0,
+                ),
+            )
+
         replay_btn = discord.ui.Button(  # type: ignore[var-annotated]
             label="🔁 Play again",
             style=discord.ButtonStyle.success,
@@ -128,21 +178,42 @@ class _RpsView(discord.ui.View):
         replay_btn.callback = self._replay  # type: ignore[method-assign]
         self.add_item(replay_btn)
 
-        # Late import: rps_panel imports _RpsView, so importing it at
-        # module level would create a cycle.
+        # Late import: rps_panel imports _RpsView, so a module-level
+        # import would create a cycle.
         from views.games.rps_panel import _make_rps_back_button
 
         back_btn = _make_rps_back_button()
         back_btn.row = 1
         self.add_item(back_btn)
 
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.user.id:
+            await interaction.response.send_message(
+                "This game isn't yours.",
+                ephemeral=True,
+            )
+            return False
+        return True
+
+    async def on_timeout(self) -> None:
+        if self.message is None:
+            return
+        for item in self.children:
+            item.disabled = True  # type: ignore[attr-defined]
+        try:
+            await self.message.edit(view=self)
+        except Exception:
+            pass
+
     async def _replay(self, interaction: discord.Interaction) -> None:
         """Spawn a fresh ``_RpsView`` with the same user/guild/bet.
 
-        If ``self.bet > 0`` the user's balance is pre-checked; if it
-        cannot cover the bet, an ephemeral nudge is sent and the
-        current result view is left in place so the user can use
-        Back to RPS instead.
+        Mirrors the canonical RPS solo start shape used by
+        ``cogs.rps_tournament._quickplay`` and
+        ``views.games.rps_panel`` — balance check when ``bet > 0``
+        then construct ``_RpsView(user, guild_id, bet)``. No public
+        ``start_solo_rps`` exists; this construction *is* the
+        canonical entry surface (helper-policy: single caller).
         """
         if not await safe_defer(interaction):
             return
@@ -170,23 +241,3 @@ class _RpsView(discord.ui.View):
             view=new_view,
         )
         new_view.message = interaction.message
-
-    @discord.ui.button(label="Rock", emoji="🪨", style=discord.ButtonStyle.grey)
-    async def rock(self, i: discord.Interaction, _: discord.ui.Button):
-        await self._play(i, "rock")
-
-    @discord.ui.button(label="Paper", emoji="📄", style=discord.ButtonStyle.grey)
-    async def paper(self, i: discord.Interaction, _: discord.ui.Button):
-        await self._play(i, "paper")
-
-    @discord.ui.button(label="Scissors", emoji="✂️", style=discord.ButtonStyle.grey)
-    async def scissors(self, i: discord.Interaction, _: discord.ui.Button):
-        await self._play(i, "scissors")
-
-    async def on_timeout(self):
-        for item in self.children:
-            item.disabled = True  # type: ignore[attr-defined]
-        try:
-            await self.message.edit(content="Game timed out.", view=self)
-        except Exception:
-            pass

--- a/disbot/views/setup/_anchor.py
+++ b/disbot/views/setup/_anchor.py
@@ -1,0 +1,195 @@
+"""Thin renderer for the setup workspace anchor.
+
+Two public helpers:
+
+* :func:`render_setup_state` — replace the canonical setup anchor with
+  ``embed`` + ``view`` (state replacement). Used by hub, final review,
+  status snapshot, depth, reset, and delegation flows so admins always
+  see the current setup state in a durable, deletable, sharable
+  ``#superbot-setup`` message rather than a per-user ephemeral.
+* :func:`push_setup_notice` — append a one-shot durable notice into
+  the workspace channel (event log). Used for "Apply Recommended
+  succeeded", "section X failed", and other post-event records that
+  must not overwrite anchor state.
+
+Both helpers fail safely: on any Discord error (missing perms, anchor
+not fetchable, channel deleted between calls) they swallow the
+exception, log at WARNING, and return ``False``. Callers check the
+return value and surface a controlled ephemeral fallback.
+
+This module is a *thin* renderer per the implementation guardrails:
+
+* Inputs are ``discord.Guild`` + plain embed/view — no wizard internals.
+* It imports only from :mod:`services.setup_session` (channel/message
+  id storage) and :mod:`services.setup_channel` (channel ensure).
+* It does not import from ``views/setup/wizard.py`` or
+  ``views/setup/hub.py`` and owns no setup state.
+
+This split (state replacement vs. event notice) is deliberate. The
+anchor must remain the source of truth for "where is setup right
+now"; notices accumulate around it as an event trail.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+from services import setup_channel, setup_session
+
+logger = logging.getLogger("bot.views.setup.anchor")
+
+
+async def render_setup_state(
+    guild: discord.Guild,
+    *,
+    embed: discord.Embed,
+    view: discord.ui.View | None = None,
+) -> bool:
+    """Replace the setup workspace anchor with ``embed`` + ``view``.
+
+    Resolves the workspace channel via
+    :func:`services.setup_channel.ensure_setup_channel` and the anchor
+    message id via the session's ``setup_message_id``. Edits in place
+    when the anchor is still fetchable; otherwise posts a new message
+    and updates the persisted id so subsequent renders reuse it.
+
+    Returns ``True`` on success, ``False`` when the channel is
+    unavailable or every Discord write failed. Never raises — callers
+    rely on the boolean to decide whether to surface an ephemeral
+    fallback to the user.
+    """
+    try:
+        session = await setup_session.resume_session(guild.id)
+    except Exception:
+        logger.exception(
+            "render_setup_state: resume_session failed (guild=%d)",
+            guild.id,
+        )
+        session = None
+
+    try:
+        channel, _was_created = await setup_channel.ensure_setup_channel(
+            guild,
+            existing_channel_id=(
+                session.setup_channel_id if session is not None else None
+            ),
+            session=session,
+        )
+    except Exception:
+        logger.exception(
+            "render_setup_state: ensure_setup_channel failed (guild=%d)",
+            guild.id,
+        )
+        return False
+    if channel is None:
+        logger.warning(
+            "render_setup_state: no workspace channel resolvable (guild=%d)",
+            guild.id,
+        )
+        return False
+
+    if session is None or session.setup_channel_id != channel.id:
+        try:
+            await setup_session.set_setup_channel_id(guild.id, channel.id)
+        except Exception:
+            logger.exception(
+                "render_setup_state: set_setup_channel_id failed (guild=%d)",
+                guild.id,
+            )
+
+    existing_id = session.setup_message_id if session is not None else None
+    if existing_id is not None:
+        try:
+            existing_msg = await channel.fetch_message(existing_id)
+            await existing_msg.edit(embed=embed, view=view)
+            return True
+        except (discord.NotFound, discord.Forbidden, discord.HTTPException):
+            logger.info(
+                "render_setup_state: anchor %s not fetchable; reposting (guild=%d)",
+                existing_id,
+                guild.id,
+            )
+            try:
+                await setup_session.set_setup_message_id(guild.id, None)
+            except Exception:
+                logger.exception(
+                    "render_setup_state: clearing stale message id failed",
+                )
+
+    try:
+        message = await channel.send(embed=embed, view=view)
+    except discord.HTTPException:
+        logger.exception(
+            "render_setup_state: failed to post anchor (guild=%d)",
+            guild.id,
+        )
+        return False
+
+    try:
+        await setup_session.set_setup_message_id(guild.id, message.id)
+    except Exception:
+        logger.exception(
+            "render_setup_state: persist message id failed (guild=%d)",
+            guild.id,
+        )
+
+    return True
+
+
+async def push_setup_notice(
+    guild: discord.Guild,
+    *,
+    embed: discord.Embed,
+) -> bool:
+    """Append a one-shot durable notice into the workspace channel.
+
+    Resolves the workspace channel only — does not touch the anchor
+    message id. Used for event records (e.g. "Apply Recommended
+    succeeded", "section X failed") that must not overwrite canonical
+    state.
+
+    Returns ``True`` on success, ``False`` on any failure.
+    """
+    try:
+        session = await setup_session.resume_session(guild.id)
+    except Exception:
+        logger.exception(
+            "push_setup_notice: resume_session failed (guild=%d)",
+            guild.id,
+        )
+        session = None
+
+    try:
+        channel, _was_created = await setup_channel.ensure_setup_channel(
+            guild,
+            existing_channel_id=(
+                session.setup_channel_id if session is not None else None
+            ),
+            session=session,
+        )
+    except Exception:
+        logger.exception(
+            "push_setup_notice: ensure_setup_channel failed (guild=%d)",
+            guild.id,
+        )
+        return False
+    if channel is None:
+        return False
+
+    try:
+        await channel.send(embed=embed)
+        return True
+    except discord.HTTPException:
+        logger.exception(
+            "push_setup_notice: send failed (guild=%d)",
+            guild.id,
+        )
+        return False
+
+
+__all__ = [
+    "push_setup_notice",
+    "render_setup_state",
+]

--- a/disbot/views/setup/hub.py
+++ b/disbot/views/setup/hub.py
@@ -41,6 +41,7 @@ from services.setup_progress import SectionProgress, badge_for
 from services.setup_sections import REGISTRY, SetupSection
 from services.setup_session import SetupSession
 from views.base import BaseView
+from views.setup._anchor import push_setup_notice
 
 logger = logging.getLogger("bot.views.setup.hub")
 
@@ -330,6 +331,8 @@ class SetupHubView(BaseView):
                 conflicts_total += len(result.conflicts)
 
             if not section_totals and not conflicts_total:
+                # No state change → no durable record needed; keep the
+                # short ephemeral validation notice.
                 await interaction.followup.send(
                     "No recommended operations were generated. Most likely "
                     "the guild has no high-confidence channel matches or "
@@ -343,21 +346,48 @@ class SetupHubView(BaseView):
                 for slug, count in section_totals.items()
             )
             word = "operation" if total == 1 else "operations"
-            msg = (
-                f"✅ Staged **{total} {word}** across "
-                f"{len(section_totals)} section(s). Open Final review "
-                f"to apply."
+            description = (
+                f"Staged **{total} {word}** across "
+                f"{len(section_totals)} section(s). Open Final review to apply."
             )
             if lines:
-                msg += f"\n\n{lines}"
+                description += f"\n\n{lines}"
             if conflicts_total:
                 conflict_word = "row" if conflicts_total == 1 else "rows"
-                msg += (
+                description += (
                     f"\n\n⚠️ Preserved **{conflicts_total} custom / preset "
                     f"{conflict_word}** at conflicting slot(s); no overwrite. "
                     "Edit Final review to swap them out if needed."
                 )
-            await interaction.followup.send(msg, ephemeral=True)
+            # Aggressive ephemeral policy: this is durable setup state —
+            # admins need to see what apply-all changed, share it, and
+            # reference it later. Post a workspace notice and ack the
+            # ephemeral defer with a short pointer.
+            notice_embed = discord.Embed(
+                title=f"✅ Apply all recommended — {total} {word}",
+                description=description,
+                color=discord.Color.green(),
+            )
+            posted = False
+            if interaction.guild is not None:
+                try:
+                    posted = await push_setup_notice(
+                        interaction.guild,
+                        embed=notice_embed,
+                    )
+                except Exception:
+                    logger.exception(
+                        "hub.apply_all_recommended: push_setup_notice failed",
+                    )
+            if posted:
+                await interaction.followup.send(
+                    "📋 Apply-all results posted in the setup workspace.",
+                    ephemeral=True,
+                )
+            else:
+                # Fall back to the original ephemeral so the operator
+                # still sees the outcome.
+                await interaction.followup.send(description, ephemeral=True)
 
         button.callback = _callback  # type: ignore[method-assign]
         return button
@@ -442,6 +472,23 @@ class SetupHubView(BaseView):
                 await sec.run(interaction, self)
             except Exception:
                 logger.exception("setup hub section %s failed", sec.slug)
+                # Section failures are real setup events — push a
+                # durable notice so admins can trace what failed and
+                # when. The ephemeral kept here is the minimal user
+                # feedback because the section already started writing
+                # state and the interaction is not deferred.
+                if interaction.guild is not None:
+                    notice = discord.Embed(
+                        title=f"⚠️ Section `{sec.slug}` failed",
+                        description="See logs for details.",
+                        color=discord.Color.red(),
+                    )
+                    try:
+                        await push_setup_notice(interaction.guild, embed=notice)
+                    except Exception:
+                        logger.exception(
+                            "hub.section_callback: push_setup_notice failed",
+                        )
                 if not interaction.response.is_done():
                     await interaction.response.send_message(
                         f"Section `{sec.slug}` failed. Check logs.",

--- a/disbot/views/setup/wizard.py
+++ b/disbot/views/setup/wizard.py
@@ -59,6 +59,7 @@ from typing import TYPE_CHECKING
 
 import discord
 
+from core.runtime.interaction_helpers import safe_defer, safe_edit
 from services import (
     setup_access,
     setup_channel,
@@ -69,6 +70,7 @@ from services import (
 from services.setup_sections import REGISTRY, SetupSection
 from services.setup_session import SetupSession
 from views.base import BaseView
+from views.setup._anchor import push_setup_notice
 from views.setup.section_card import call_recommended_ops_builder
 
 if TYPE_CHECKING:
@@ -492,9 +494,10 @@ class LinearWizardView(BaseView):
         await self._open_final_review(interaction)
 
     async def _on_open_hub(self, interaction: discord.Interaction) -> None:
-        # Surface the existing hub-style embed as an ephemeral follow-up
-        # so the operator can browse the section list without losing
-        # the wizard anchor.
+        # Aggressive ephemeral policy: swap the anchor view to the hub
+        # view so the operator can browse the section list inside the
+        # durable workspace message, not in a per-user ephemeral that
+        # cannot be deleted/revisited/shared.
         from views.setup.hub import SetupHubView, build_hub_embed
 
         guild = interaction.guild
@@ -511,6 +514,9 @@ class LinearWizardView(BaseView):
                 "Use this from inside the server.",
                 ephemeral=True,
             )
+            return
+
+        if not await safe_defer(interaction):
             return
 
         try:
@@ -531,11 +537,9 @@ class LinearWizardView(BaseView):
             pending_ops=len(draft_rows),
             draft_ops=draft_rows,
         )
-        await interaction.response.send_message(
-            embed=embed,
-            view=hub_view,
-            ephemeral=True,
-        )
+        # safe_edit after defer edits the clicked anchor via
+        # followup.edit_message(message_id=interaction.message.id).
+        await safe_edit(interaction, embed=embed, view=hub_view)
 
     async def _on_cancel(self, interaction: discord.Interaction) -> None:
         for child in self.children:
@@ -648,13 +652,22 @@ class LinearWizardView(BaseView):
                 f"\n\n⚠️ Preserved **{cn} custom / preset {conflict_word}** "
                 "at conflicting slot(s); no overwrite."
             )
-        await interaction.response.send_message(
-            f"✅ Staged **{count} recommended {noun}** for "
-            f"{section.label}.{conflict_text}",
-            ephemeral=True,
+        # Aggressive ephemeral policy: post the apply-recommended record
+        # as a durable workspace notice (event log) and let the anchor
+        # refresh reflect the new state. defer() is the interaction ack.
+        await safe_defer(interaction)
+        notice_embed = discord.Embed(
+            title=f"✅ Recommended staged · {section.label}",
+            description=f"Staged **{count} {noun}**.{conflict_text}",
+            color=discord.Color.green(),
         )
+        try:
+            await push_setup_notice(guild, embed=notice_embed)
+        except Exception:
+            logger.exception(
+                "wizard._on_apply_recommended: push_setup_notice failed",
+            )
         # Refresh the anchor to show the updated section status badge.
-        # response.is_done() is True above, so _refresh_and_edit uses followup.
         try:
             await self._refresh_and_edit(interaction)
         except Exception:
@@ -808,7 +821,13 @@ class LinearWizardView(BaseView):
         self,
         interaction: discord.Interaction,
     ) -> None:
-        """Open Final Review as an ephemeral follow-up on the last step."""
+        """Swap the wizard anchor to the Final Review embed + view.
+
+        Aggressive ephemeral policy: Final Review is canonical setup
+        state — admins need to revisit it, share it, and delete it
+        from the source-of-truth workspace channel rather than from
+        a private ephemeral that's tied to one operator.
+        """
         guild = interaction.guild
         if guild is None:
             await interaction.response.send_message(
@@ -821,24 +840,20 @@ class LinearWizardView(BaseView):
             build_final_review_embed,
         )
 
+        if not await safe_defer(interaction):
+            return
+
         try:
             ops = await setup_draft.list_ops(guild.id)
         except Exception:
             logger.exception("wizard._open_final_review: list_ops failed")
             ops = []
         final = FinalReviewView(interaction.user, ops=ops)
-        await interaction.response.send_message(
+        await safe_edit(
+            interaction,
             embed=build_final_review_embed(final.ops),
             view=final,
-            ephemeral=True,
         )
-        # Refresh the wizard anchor so it reflects the current staged state
-        # before the operator reviews.  response.is_done() is True, so
-        # _refresh_and_edit uses followup.edit_message.
-        try:
-            await self._refresh_and_edit(interaction)
-        except Exception:
-            logger.exception("wizard._open_final_review: anchor refresh failed")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cogs/test_setup_cog.py
+++ b/tests/unit/cogs/test_setup_cog.py
@@ -464,7 +464,9 @@ async def test_start_button_refuses_non_owner():
     interaction = _mock_interaction(_admin_member())
 
     with patch("services.setup_session.resume_session", AsyncMock(return_value=None)):
-        with patch("services.setup_session.start_session", AsyncMock(return_value=None)):
+        with patch(
+            "services.setup_session.start_session", AsyncMock(return_value=None)
+        ):
             await view._start.callback(interaction)
 
     interaction.response.send_message.assert_awaited_once()
@@ -485,7 +487,9 @@ async def test_start_button_opens_wizard_for_owner():
     mock_message.jump_url = "https://discord.com/channels/1/2/3"
 
     with patch("services.setup_session.resume_session", AsyncMock(return_value=None)):
-        with patch("services.setup_session.start_session", AsyncMock(return_value=None)):
+        with patch(
+            "services.setup_session.start_session", AsyncMock(return_value=None)
+        ):
             with patch(
                 "views.setup.wizard.open_setup_workspace",
                 AsyncMock(return_value=(mock_channel, mock_message, "ok")),
@@ -1837,7 +1841,9 @@ async def test_setup_unskip_slash_unmarks_section():
         ) as unskip_mock,
     ):
         await cog.setup_unskip_slash.callback(
-            cog, interaction, section="cleanup",
+            cog,
+            interaction,
+            section="cleanup",
         )
 
     unskip_mock.assert_awaited_once_with(1, "cleanup")
@@ -1865,7 +1871,9 @@ async def test_setup_skip_slash_rejects_unknown_section():
         ) as skip_mock,
     ):
         await cog.setup_skip_slash.callback(
-            cog, interaction, section="bogus-section",
+            cog,
+            interaction,
+            section="bogus-section",
         )
 
     skip_mock.assert_not_awaited()
@@ -1892,7 +1900,9 @@ async def test_setup_skip_slash_denies_random_member():
         ) as skip_mock,
     ):
         await cog.setup_skip_slash.callback(
-            cog, interaction, section="cleanup",
+            cog,
+            interaction,
+            section="cleanup",
         )
 
     skip_mock.assert_not_awaited()
@@ -2277,3 +2287,85 @@ async def test_setup_delegate_slash_surfaces_db_failure():
 
     msg = interaction.response.send_message.await_args.args[0].lower()
     assert "could not" in msg
+
+
+# ---------------------------------------------------------------------------
+# PR 3 — /setup-status posts to workspace as durable notice
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_setup_status_slash_posts_durable_notice_in_workspace():
+    """Aggressive ephemeral policy: /setup-status pushes the snapshot
+    to #superbot-setup as a durable notice; the interaction reply is
+    a short ephemeral pointer ("📋 Setup status posted in <#…>").
+    """
+    from cogs.setup_cog import SetupCog
+
+    cog = SetupCog(MagicMock())
+    interaction = _mock_interaction(_owner_member())
+
+    with (
+        patch(
+            "cogs.setup_cog.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_delegated_session(),
+        ),
+        patch(
+            "services.setup_draft.count",
+            new_callable=AsyncMock,
+            return_value=3,
+        ),
+        patch(
+            "views.setup._anchor.push_setup_notice",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as push_mock,
+    ):
+        await cog.setup_status_slash.callback(cog, interaction)
+
+    push_mock.assert_awaited_once()
+    # Pointer reply is ephemeral and references the workspace channel.
+    interaction.response.send_message.assert_awaited_once()
+    call = interaction.response.send_message.await_args
+    assert call.kwargs.get("ephemeral") is True
+    # Pointer carries the workspace mention.
+    msg = call.args[0]
+    assert "posted in" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_setup_status_slash_falls_back_to_ephemeral_when_workspace_unreachable():
+    """If push_setup_notice returns False (no workspace channel),
+    fall back to the historic ephemeral embed reply so the operator
+    still sees the snapshot.
+    """
+    from cogs.setup_cog import SetupCog
+
+    cog = SetupCog(MagicMock())
+    interaction = _mock_interaction(_owner_member())
+
+    with (
+        patch(
+            "cogs.setup_cog.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_delegated_session(),
+        ),
+        patch(
+            "services.setup_draft.count",
+            new_callable=AsyncMock,
+            return_value=0,
+        ),
+        patch(
+            "views.setup._anchor.push_setup_notice",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+    ):
+        await cog.setup_status_slash.callback(cog, interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    call_kwargs = interaction.response.send_message.await_args.kwargs
+    # Fallback path sends the embed itself, still ephemeral.
+    assert call_kwargs.get("ephemeral") is True
+    assert call_kwargs.get("embed") is not None

--- a/tests/unit/runtime/test_legacy_command_surface.py
+++ b/tests/unit/runtime/test_legacy_command_surface.py
@@ -1,0 +1,221 @@
+"""Legacy command-surface snapshot guard.
+
+The :mod:`core.runtime.command_surface_ledger` already enumerates every
+prefix + slash entrypoint at startup, but nothing currently asserts
+*which* commands must remain registered. Lost prefix commands —
+especially old typing shortcuts like ``!bj`` or top-level prefix
+groups like ``!ai`` — can regress silently across refactors.
+
+This module pins two sets:
+
+* ``EXPECTED_LIVE`` — commands that must currently appear in the
+  cogs' decorator-registered surface. A missing entry means a
+  regression: either restore the binding or, if the removal was
+  intentional, move it into ``LEGACY_DEPRECATED`` with a replacement
+  documented.
+* ``LEGACY_DEPRECATED`` — commands intentionally retired. Each entry
+  carries a replacement and the PR/commit that removed it. The test
+  asserts these stay absent so a resurrected binding is flagged
+  during review.
+
+Discovery is via AST scanning of ``disbot/cogs/**/*.py`` rather than
+building a live ``commands.Bot`` because cog ``cog_load`` paths touch
+DB and external services that the unit-test sandbox does not have.
+This guards the *decorator surface* — the same surface the live ledger
+walks at startup — which is the regression to catch.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+COGS_ROOT = Path(__file__).resolve().parents[3] / "disbot" / "cogs"
+
+# ---------------------------------------------------------------------------
+# EXPECTED_LIVE — commands the audit pinned as visible / typed by users.
+#
+# Each entry is (name, surface) where surface ∈ {"prefix", "slash"}.
+# Aliases register as their own (alias_name, "prefix") entry so renames
+# are also detected.
+# ---------------------------------------------------------------------------
+
+EXPECTED_LIVE: frozenset[tuple[str, str]] = frozenset(
+    {
+        # Game prefix commands typed in the screenshots.
+        ("blackjack", "prefix"),
+        ("bj", "prefix"),  # alias of blackjack
+        ("games", "prefix"),
+        ("ai", "prefix"),
+        # Setup surface (prefix + slash).
+        ("setup", "prefix"),
+        ("setup", "slash"),
+        ("setup-status", "slash"),
+        ("setup-skip", "slash"),
+        ("setup-unskip", "slash"),
+        ("setup-depth", "slash"),
+        ("setup-reset", "slash"),
+        ("setup-hub", "slash"),
+        # Top-level slash command panels referenced by /games etc.
+        ("games", "slash"),
+        ("help", "slash"),
+    }
+)
+
+# ---------------------------------------------------------------------------
+# LEGACY_DEPRECATED — intentionally retired commands. Add an entry here
+# when removing a command instead of letting it disappear silently.
+#
+# Each entry is (name, surface, replacement). The replacement value is
+# informational only (read by humans during review); the test only
+# asserts the name does not re-appear in the live decorator surface.
+# ---------------------------------------------------------------------------
+
+LEGACY_DEPRECATED: tuple[tuple[str, str, str], ...] = ()
+
+
+# ---------------------------------------------------------------------------
+# AST visitor: extract @commands.command / @app_commands.command names.
+# ---------------------------------------------------------------------------
+
+
+def _decorator_call_name(dec: ast.expr) -> str | None:
+    """Return ``"<module>.<attr>"`` for ``@module.attr(...)`` decorators.
+
+    Examples:
+      ``@commands.command(...)``       → ``"commands.command"``
+      ``@app_commands.command(...)``   → ``"app_commands.command"``
+      ``@commands.hybrid_command(...)``→ ``"commands.hybrid_command"``
+      ``@bot.event``                   → ``None``  (no call)
+    """
+    if not isinstance(dec, ast.Call):
+        return None
+    func = dec.func
+    if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+        return f"{func.value.id}.{func.attr}"
+    return None
+
+
+def _name_kwarg(dec: ast.Call) -> str | None:
+    for kw in dec.keywords:
+        if kw.arg == "name" and isinstance(kw.value, ast.Constant):
+            value = kw.value.value
+            if isinstance(value, str):
+                return value
+    return None
+
+
+def _aliases_kwarg(dec: ast.Call) -> list[str]:
+    for kw in dec.keywords:
+        if kw.arg == "aliases" and isinstance(kw.value, (ast.List, ast.Tuple)):
+            out: list[str] = []
+            for el in kw.value.elts:
+                if isinstance(el, ast.Constant) and isinstance(el.value, str):
+                    out.append(el.value)
+            return out
+    return []
+
+
+_PREFIX_DECORATORS = frozenset(
+    {
+        "commands.command",
+        "commands.group",
+        "commands.hybrid_command",
+        "commands.hybrid_group",
+    }
+)
+
+_SLASH_DECORATORS = frozenset(
+    {
+        "app_commands.command",
+        "app_commands.group",
+    }
+)
+
+
+def _scan_cogs_for_decorator_surface() -> set[tuple[str, str]]:
+    surface: set[tuple[str, str]] = set()
+    for py_file in COGS_ROOT.rglob("*.py"):
+        try:
+            tree = ast.parse(py_file.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for dec in node.decorator_list:
+                call_name = _decorator_call_name(dec)
+                if call_name is None:
+                    continue
+                assert isinstance(dec, ast.Call)
+                cmd_name = _name_kwarg(dec) or node.name
+                if call_name in _PREFIX_DECORATORS:
+                    surface.add((cmd_name, "prefix"))
+                    for alias in _aliases_kwarg(dec):
+                        surface.add((alias, "prefix"))
+                elif call_name in _SLASH_DECORATORS:
+                    # app_commands.command sometimes uses the function
+                    # name as a fallback; honor either source.
+                    surface.add((cmd_name, "slash"))
+    return surface
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def decorator_surface() -> set[tuple[str, str]]:
+    return _scan_cogs_for_decorator_surface()
+
+
+def test_expected_live_commands_remain_registered(decorator_surface):
+    """Every command in ``EXPECTED_LIVE`` must appear in the live
+    decorator surface scanned from ``disbot/cogs/``.
+
+    Failure means a typed-by-users command vanished without making it
+    into ``LEGACY_DEPRECATED`` — a silent regression. Restore the
+    binding or, if removal is intended, move it into
+    ``LEGACY_DEPRECATED`` with a replacement.
+    """
+    missing = sorted(EXPECTED_LIVE - decorator_surface)
+    assert not missing, (
+        "Legacy commands missing from disbot/cogs/ decorator surface:\n"
+        + "\n".join(f"  - {name} ({surface})" for name, surface in missing)
+        + "\n\nIf the removal was intentional, add an entry to "
+        "LEGACY_DEPRECATED in tests/unit/runtime/test_legacy_command_surface.py "
+        "naming the replacement command."
+    )
+
+
+def test_deprecated_commands_do_not_reappear(decorator_surface):
+    """Commands moved to ``LEGACY_DEPRECATED`` must stay absent.
+
+    Catches accidental re-registration of an intentionally retired
+    command (e.g. someone copy-pastes an old cog without realizing the
+    binding was retired).
+    """
+    resurrected = [
+        (name, surface, replacement)
+        for (name, surface, replacement) in LEGACY_DEPRECATED
+        if (name, surface) in decorator_surface
+    ]
+    assert (
+        not resurrected
+    ), "Retired commands have reappeared in the decorator surface:\n" + "\n".join(
+        f"  - {n} ({s}) → replaced by {repl}" for n, s, repl in resurrected
+    )
+
+
+def test_decorator_surface_has_no_obvious_gaps():
+    """Sanity: the AST scan finds *some* commands. If the scan returns
+    empty the test would pass vacuously on a missing-cogs disaster.
+    """
+    surface = _scan_cogs_for_decorator_surface()
+    assert len(surface) >= 50, (
+        f"AST scan found only {len(surface)} decorated commands — "
+        "expected dozens. The scan or the cogs tree is broken."
+    )

--- a/tests/unit/views/setup/test_anchor_renderer.py
+++ b/tests/unit/views/setup/test_anchor_renderer.py
@@ -1,0 +1,282 @@
+"""Tests for the setup workspace anchor renderer.
+
+``views/setup/_anchor.py`` is the thin renderer that backs the
+aggressive "no ephemeral setup panels" policy. These tests cover:
+
+* ``render_setup_state`` edits an existing anchor when fetchable.
+* ``render_setup_state`` posts a new anchor and persists the id when
+  the existing one is missing.
+* ``render_setup_state`` returns False when the workspace channel is
+  unresolvable (no perms / kicked).
+* ``push_setup_notice`` appends a one-shot message and never touches
+  the anchor id.
+* Both helpers swallow discord.HTTPException and return False rather
+  than raising.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from views.setup._anchor import push_setup_notice, render_setup_state
+
+
+def _guild(guild_id: int = 99) -> MagicMock:
+    g = MagicMock(spec=discord.Guild)
+    g.id = guild_id
+    return g
+
+
+def _channel(channel_id: int = 555) -> MagicMock:
+    c = MagicMock(spec=discord.TextChannel)
+    c.id = channel_id
+    c.send = AsyncMock()
+    c.fetch_message = AsyncMock()
+    return c
+
+
+def _session(
+    *,
+    channel_id: int | None = 555,
+    message_id: int | None = 4242,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        setup_channel_id=channel_id,
+        setup_message_id=message_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# render_setup_state — edit-in-place when anchor is fetchable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_render_setup_state_edits_existing_anchor():
+    guild = _guild()
+    channel = _channel()
+    session = _session()
+    existing_msg = MagicMock()
+    existing_msg.edit = AsyncMock()
+    channel.fetch_message.return_value = existing_msg
+
+    embed = discord.Embed(title="Hub")
+    view = MagicMock(spec=discord.ui.View)
+
+    with (
+        patch(
+            "views.setup._anchor.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=session,
+        ),
+        patch(
+            "views.setup._anchor.setup_channel.ensure_setup_channel",
+            new_callable=AsyncMock,
+            return_value=(channel, False),
+        ),
+        patch(
+            "views.setup._anchor.setup_session.set_setup_channel_id",
+            new_callable=AsyncMock,
+        ),
+    ):
+        ok = await render_setup_state(guild, embed=embed, view=view)
+
+    assert ok is True
+    channel.fetch_message.assert_awaited_once_with(4242)
+    existing_msg.edit.assert_awaited_once_with(embed=embed, view=view)
+    channel.send.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# render_setup_state — repost when anchor missing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_render_setup_state_reposts_when_anchor_missing():
+    guild = _guild()
+    channel = _channel()
+    session = _session()
+    channel.fetch_message.side_effect = discord.NotFound(MagicMock(), "gone")
+    new_msg = MagicMock()
+    new_msg.id = 9999
+    channel.send.return_value = new_msg
+
+    embed = discord.Embed(title="Hub")
+
+    with (
+        patch(
+            "views.setup._anchor.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=session,
+        ),
+        patch(
+            "views.setup._anchor.setup_channel.ensure_setup_channel",
+            new_callable=AsyncMock,
+            return_value=(channel, False),
+        ),
+        patch(
+            "views.setup._anchor.setup_session.set_setup_channel_id",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "views.setup._anchor.setup_session.set_setup_message_id",
+            new_callable=AsyncMock,
+        ) as set_msg_id,
+    ):
+        ok = await render_setup_state(guild, embed=embed)
+
+    assert ok is True
+    channel.send.assert_awaited_once_with(embed=embed, view=None)
+    # Cleared stale id then persisted the fresh one.
+    set_msg_id.assert_any_call(guild.id, None)
+    set_msg_id.assert_any_call(guild.id, 9999)
+
+
+# ---------------------------------------------------------------------------
+# render_setup_state — controlled failure when workspace unreachable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_render_setup_state_returns_false_when_channel_missing():
+    """When ensure_setup_channel returns None (missing perms / kicked),
+    the renderer must report failure cleanly so callers can surface a
+    controlled ephemeral.
+    """
+    guild = _guild()
+    session = _session()
+
+    with (
+        patch(
+            "views.setup._anchor.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=session,
+        ),
+        patch(
+            "views.setup._anchor.setup_channel.ensure_setup_channel",
+            new_callable=AsyncMock,
+            return_value=(None, False),
+        ),
+    ):
+        ok = await render_setup_state(guild, embed=discord.Embed(title="x"))
+
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_render_setup_state_returns_false_on_http_failure_during_send():
+    """If both fetch and send fail, the helper must swallow the
+    HTTPException and return False — never raise.
+    """
+    guild = _guild()
+    channel = _channel()
+    session = _session(message_id=None)  # no existing anchor → goes straight to send
+    channel.send.side_effect = discord.HTTPException(MagicMock(), "rate limited")
+
+    with (
+        patch(
+            "views.setup._anchor.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=session,
+        ),
+        patch(
+            "views.setup._anchor.setup_channel.ensure_setup_channel",
+            new_callable=AsyncMock,
+            return_value=(channel, False),
+        ),
+        patch(
+            "views.setup._anchor.setup_session.set_setup_channel_id",
+            new_callable=AsyncMock,
+        ),
+    ):
+        ok = await render_setup_state(guild, embed=discord.Embed(title="x"))
+
+    assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# push_setup_notice — append-only, never touches anchor id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_push_setup_notice_appends_one_off_message():
+    guild = _guild()
+    channel = _channel()
+    session = _session()
+    embed = discord.Embed(title="Apply Recommended succeeded")
+
+    with (
+        patch(
+            "views.setup._anchor.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=session,
+        ),
+        patch(
+            "views.setup._anchor.setup_channel.ensure_setup_channel",
+            new_callable=AsyncMock,
+            return_value=(channel, False),
+        ),
+        patch(
+            "views.setup._anchor.setup_session.set_setup_message_id",
+            new_callable=AsyncMock,
+        ) as set_msg_id,
+    ):
+        ok = await push_setup_notice(guild, embed=embed)
+
+    assert ok is True
+    channel.send.assert_awaited_once_with(embed=embed)
+    # push_setup_notice must NEVER touch the anchor id — anchor stays
+    # the source of truth.
+    set_msg_id.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_push_setup_notice_returns_false_when_channel_missing():
+    guild = _guild()
+    session = _session()
+
+    with (
+        patch(
+            "views.setup._anchor.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=session,
+        ),
+        patch(
+            "views.setup._anchor.setup_channel.ensure_setup_channel",
+            new_callable=AsyncMock,
+            return_value=(None, False),
+        ),
+    ):
+        ok = await push_setup_notice(guild, embed=discord.Embed(title="x"))
+
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_push_setup_notice_swallows_http_failure():
+    guild = _guild()
+    channel = _channel()
+    channel.send.side_effect = discord.HTTPException(MagicMock(), "fail")
+    session = _session()
+
+    with (
+        patch(
+            "views.setup._anchor.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=session,
+        ),
+        patch(
+            "views.setup._anchor.setup_channel.ensure_setup_channel",
+            new_callable=AsyncMock,
+            return_value=(channel, False),
+        ),
+    ):
+        ok = await push_setup_notice(guild, embed=discord.Embed(title="x"))
+
+    assert ok is False

--- a/tests/unit/views/setup/test_wizard.py
+++ b/tests/unit/views/setup/test_wizard.py
@@ -160,7 +160,7 @@ def test_wizard_step_embed_shows_step_counter():
         total_steps=len(sections),
         draft_rows=[],
     )
-    title = (embed.title or "")
+    title = embed.title or ""
     assert "Step 1/2" in title
     assert "Cleanup" in (embed.description or "")
 
@@ -247,7 +247,10 @@ def test_view_has_navigation_buttons_in_layout():
 
 
 def test_view_back_button_disabled_on_first_step():
-    sections = [_section("cleanup", builder=_builder_one_op), _section("channels", order=70)]
+    sections = [
+        _section("cleanup", builder=_builder_one_op),
+        _section("channels", order=70),
+    ]
     view = LinearWizardView(
         _owner_member(),
         session=_session(),
@@ -257,8 +260,7 @@ def test_view_back_button_disabled_on_first_step():
     back = next(
         c
         for c in view.children
-        if isinstance(c, discord.ui.Button)
-        and c.custom_id == "setup_wizard:back"
+        if isinstance(c, discord.ui.Button) and c.custom_id == "setup_wizard:back"
     )
     assert back.disabled is True
 
@@ -291,14 +293,16 @@ def test_view_continue_button_label_is_final_review_on_last_step():
     cont = next(
         c
         for c in view.children
-        if isinstance(c, discord.ui.Button)
-        and c.custom_id == "setup_wizard:continue"
+        if isinstance(c, discord.ui.Button) and c.custom_id == "setup_wizard:continue"
     )
     assert "Final" in (cont.label or "")
 
 
 def test_view_continue_label_is_continue_when_not_last_step():
-    sections = [_section("cleanup", builder=_builder_one_op), _section("channels", order=70)]
+    sections = [
+        _section("cleanup", builder=_builder_one_op),
+        _section("channels", order=70),
+    ]
     view = LinearWizardView(
         _owner_member(),
         session=_session(),
@@ -308,8 +312,7 @@ def test_view_continue_label_is_continue_when_not_last_step():
     cont = next(
         c
         for c in view.children
-        if isinstance(c, discord.ui.Button)
-        and c.custom_id == "setup_wizard:continue"
+        if isinstance(c, discord.ui.Button) and c.custom_id == "setup_wizard:continue"
     )
     assert "Continue" in (cont.label or "")
 
@@ -344,6 +347,14 @@ async def test_apply_recommended_routes_through_replace_recommended():
             "views.setup.wizard.setup_session.unmark_section_skipped",
             new_callable=AsyncMock,
         ),
+        # PR 3 — apply-recommended success no longer sends an ephemeral
+        # confirmation; the outcome lands as a durable workspace notice
+        # via push_setup_notice, and the anchor refresh repaints state.
+        patch(
+            "views.setup.wizard.push_setup_notice",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as push_mock,
     ):
         # The view's first button callback for apply_recommended.
         apply_btn = next(
@@ -359,7 +370,9 @@ async def test_apply_recommended_routes_through_replace_recommended():
     assert args[0] == 1
     assert args[1] == "cleanup"
     assert len(args[2]) == 1
-    interaction.response.send_message.assert_awaited_once()
+    push_mock.assert_awaited_once()
+    # Aggressive ephemeral policy: no ephemeral success message.
+    interaction.response.send_message.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -464,8 +477,7 @@ async def test_skip_deletes_section_rows_when_provenance_present():
         skip_btn = next(
             c
             for c in view.children
-            if isinstance(c, discord.ui.Button)
-            and c.custom_id == "setup_wizard:skip"
+            if isinstance(c, discord.ui.Button) and c.custom_id == "setup_wizard:skip"
         )
         await skip_btn.callback(interaction)
 
@@ -498,10 +510,14 @@ async def test_continue_on_last_step_opens_final_review():
         )
         await cont.callback(interaction)
 
-    interaction.response.send_message.assert_awaited_once()
+    # PR 3 — Final Review is now durable: defer + edit the anchor view
+    # to FinalReviewView, not an ephemeral send_message.
+    interaction.response.defer.assert_awaited_once()
+    interaction.response.edit_message.assert_awaited_once()
+    interaction.response.send_message.assert_not_called()
     from views.setup.final_review import FinalReviewView
 
-    sent_view = interaction.response.send_message.await_args.kwargs["view"]
+    sent_view = interaction.response.edit_message.await_args.kwargs["view"]
     assert isinstance(sent_view, FinalReviewView)
 
 
@@ -572,8 +588,7 @@ async def test_back_button_decrements_step():
         back = next(
             c
             for c in view.children
-            if isinstance(c, discord.ui.Button)
-            and c.custom_id == "setup_wizard:back"
+            if isinstance(c, discord.ui.Button) and c.custom_id == "setup_wizard:back"
         )
         await back.callback(interaction)
 
@@ -596,7 +611,9 @@ async def test_open_workspace_returns_no_channel_when_ensure_fails():
         return_value=(None, False),
     ):
         channel, message, reason = await open_setup_workspace(
-            guild, member=member, session=_session(),
+            guild,
+            member=member,
+            session=_session(),
         )
     assert channel is None
     assert message is None
@@ -965,7 +982,9 @@ async def test_on_customize_sends_error_when_no_customize():
 
 @pytest.mark.asyncio
 async def test_apply_recommended_refreshes_anchor_after_staging():
-    """After staging ops the anchor embed is updated via followup.edit_message."""
+    """After staging ops the wizard defers (ack), pushes a workspace
+    notice, and refreshes the anchor embed via followup.edit_message.
+    """
     sections = [_section("cleanup", builder=_builder_one_op)]
     view = LinearWizardView(
         _owner_member(),
@@ -974,12 +993,13 @@ async def test_apply_recommended_refreshes_anchor_after_staging():
         step_index=0,
     )
     interaction = _interaction(_owner_member())
-    # Simulate discord.py marking the response as done after send_message
-    # (as it would after posting the ephemeral confirmation).
+
+    # Simulate discord.py marking the response as done after defer
+    # (as it would after the safe_defer ack).
     def _mark_done(*args, **kwargs):
         interaction.response.is_done.return_value = True
 
-    interaction.response.send_message = AsyncMock(side_effect=_mark_done)
+    interaction.response.defer = AsyncMock(side_effect=_mark_done)
 
     with (
         patch(
@@ -1005,6 +1025,11 @@ async def test_apply_recommended_refreshes_anchor_after_staging():
             new_callable=AsyncMock,
             return_value=[],
         ),
+        patch(
+            "views.setup.wizard.push_setup_notice",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
     ):
         apply_btn = next(
             c
@@ -1014,9 +1039,10 @@ async def test_apply_recommended_refreshes_anchor_after_staging():
         )
         await apply_btn.callback(interaction)
 
-    # Ephemeral confirmation sent first.
-    interaction.response.send_message.assert_awaited_once()
-    # Anchor refreshed via followup after staging.
+    # PR 3 — defer is the interaction ack (replaces the prior ephemeral
+    # send_message). Anchor refreshed via followup.edit_message.
+    interaction.response.defer.assert_awaited_once()
+    interaction.response.send_message.assert_not_called()
     interaction.followup.edit_message.assert_awaited_once()
     kw = interaction.followup.edit_message.await_args.kwargs
     assert kw.get("message_id") == interaction.message.id

--- a/tests/unit/views/test_blackjack_solo_replay.py
+++ b/tests/unit/views/test_blackjack_solo_replay.py
@@ -1,22 +1,28 @@
-"""Regression tests for solo Blackjack instant-replay (Smooth Interaction Pass PR 7).
+"""Regression tests for solo Blackjack terminal-state lifecycle.
 
-Before this PR ``BlackjackView._finish`` disabled every child after
-the hand resolved and stopped the view — leaving the user with no
-way to play again without retyping ``!blackjack`` or re-opening the
-panel.
+Originally added in Smooth Interaction Pass PR 7 to pin the
+"end-of-hand replay row" contract; updated when the terminal state
+moved off the live ``BlackjackView`` and onto a dedicated
+``_BlackjackSoloResultView``. The previous design appended Play
+again / Back buttons to the live game view and then called
+``self.stop()`` — which un-registers the view from discord.py's
+component dispatch table and surfaces "interaction failed" on the
+visible buttons. The fix swaps the live view for a fresh result
+view in ``safe_edit`` before stopping the original.
 
 These tests pin the new contract:
 
-* Solo end-of-hand appends two new buttons on row 1: ``🔁 Play
-  again`` and ``◀ Back to Blackjack``. PvP / tournament hands are
-  unchanged (no replay row).
+* Solo end-of-hand swaps in ``_BlackjackSoloResultView`` whose row 0
+  is three disabled hit/stand/double shells and row 1 is ``🔁 Play
+  again`` + ``◀ Back to Blackjack``. PvP / tournament hands keep
+  the original view (no swap).
 * ``Play again`` re-enters ``start_solo_blackjack`` (the canonical
   entry point) and commits the new hand via the existing
   ``commit_solo_blackjack`` helper, so ``_active`` and persistence
   stay correct.
-* ``hit_btn`` now defers up front and uses ``safe_edit`` (the
-  pre-PR-7 raw ``response.edit_message`` after I/O was flagged in
-  the UI adoption audit's "partial" hotspots).
+* ``hit_btn`` defers up front and uses ``safe_edit`` (the pre-PR-7
+  raw ``response.edit_message`` after I/O was flagged in the UI
+  adoption audit's "partial" hotspots).
 """
 
 from __future__ import annotations
@@ -28,7 +34,7 @@ import pytest
 
 from cogs.blackjack._state import _Game
 from cogs.blackjack.actions import SoloStartResult
-from views.blackjack.solo_view import BlackjackView
+from views.blackjack.solo_view import BlackjackView, _BlackjackSoloResultView
 
 
 def _make_solo_game(user_id: int = 1, guild_id: int = 99, bet: int = 10) -> _Game:
@@ -57,8 +63,19 @@ def _interaction(user_id: int = 1, *, is_done: bool = False) -> MagicMock:
 
 
 # ---------------------------------------------------------------------------
-# Solo _finish appends the replay+back row; PvP does not
+# Solo _finish swaps in result view; PvP / tournament keep the original view
 # ---------------------------------------------------------------------------
+
+
+def _capture_safe_edit() -> tuple[AsyncMock, dict]:
+    """Return a patched ``safe_edit`` that records its kwargs."""
+    captured: dict = {}
+
+    async def fake_edit(_interaction, **kwargs):
+        captured.update(kwargs)
+        return True
+
+    return fake_edit, captured  # type: ignore[return-value]
 
 
 @pytest.mark.asyncio
@@ -67,7 +84,8 @@ async def test_solo_finish_appends_replay_and_back_buttons():
     view = BlackjackView(game, on_finish=None)
     interaction = _interaction()
 
-    # Stub balance + economy calls — solo settle path runs inside _finish.
+    fake_edit, captured = _capture_safe_edit()
+
     with (
         patch(
             "views.blackjack.solo_view.economy_service.credit",
@@ -83,6 +101,7 @@ async def test_solo_finish_appends_replay_and_back_buttons():
             "views.blackjack.solo_view._clear_solo_game",
             new_callable=AsyncMock,
         ),
+        patch("views.blackjack.solo_view.safe_edit", new=fake_edit),
     ):
         await view._finish(
             interaction,
@@ -92,20 +111,24 @@ async def test_solo_finish_appends_replay_and_back_buttons():
             hand_value=20,
         )
 
-    labels = [getattr(c, "label", None) for c in view.children]
+    result_view = captured["view"]
+    assert isinstance(result_view, _BlackjackSoloResultView)
+    labels = [getattr(c, "label", None) for c in result_view.children]
     assert any(label and "Play again" in label for label in labels), labels
     assert any(label and "Back to Blackjack" in label for label in labels), labels
 
 
 @pytest.mark.asyncio
 async def test_pvp_finish_does_not_append_replay_row():
-    """PvP path (on_finish callback present) must NOT gain replay
-    buttons — replay is solo-only.
+    """PvP path (on_finish callback present) keeps the original
+    ``BlackjackView`` — replay is solo-only.
     """
     game = _make_solo_game()
     on_finish = AsyncMock()
     view = BlackjackView(game, on_finish=on_finish)
     interaction = _interaction()
+
+    fake_edit, captured = _capture_safe_edit()
 
     with (
         patch(
@@ -122,6 +145,7 @@ async def test_pvp_finish_does_not_append_replay_row():
             "views.blackjack.solo_view._clear_solo_game",
             new_callable=AsyncMock,
         ),
+        patch("views.blackjack.solo_view.safe_edit", new=fake_edit),
     ):
         await view._finish(
             interaction,
@@ -131,25 +155,28 @@ async def test_pvp_finish_does_not_append_replay_row():
             hand_value=20,
         )
 
-    labels = [getattr(c, "label", None) for c in view.children]
-    assert not any(label and "Play again" in label for label in labels), labels
-    assert not any(label and "Back to Blackjack" in label for label in labels), labels
+    assert captured["view"] is view
     on_finish.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_tournament_finish_does_not_append_replay_row():
-    """Tournament path (tournament_chips != None) must NOT gain
-    replay buttons either.
+    """Tournament path (tournament_chips != None) keeps the original
+    ``BlackjackView`` — replay is solo-only.
     """
     game = _make_solo_game()
     game.tournament_chips = 100  # mark as tournament
     view = BlackjackView(game, on_finish=None)
     interaction = _interaction()
 
-    with patch(
-        "views.blackjack.solo_view._clear_solo_game",
-        new_callable=AsyncMock,
+    fake_edit, captured = _capture_safe_edit()
+
+    with (
+        patch(
+            "views.blackjack.solo_view._clear_solo_game",
+            new_callable=AsyncMock,
+        ),
+        patch("views.blackjack.solo_view.safe_edit", new=fake_edit),
     ):
         await view._finish(
             interaction,
@@ -159,8 +186,7 @@ async def test_tournament_finish_does_not_append_replay_row():
             hand_value=20,
         )
 
-    labels = [getattr(c, "label", None) for c in view.children]
-    assert not any(label and "Play again" in label for label in labels), labels
+    assert captured["view"] is view
 
 
 # ---------------------------------------------------------------------------
@@ -168,10 +194,14 @@ async def test_tournament_finish_does_not_append_replay_row():
 # ---------------------------------------------------------------------------
 
 
+def _result_view(bet: int = 10) -> _BlackjackSoloResultView:
+    game = _make_solo_game(bet=bet)
+    return _BlackjackSoloResultView(game.user_id, game.guild_id, game.bet, game)
+
+
 @pytest.mark.asyncio
 async def test_replay_calls_start_solo_blackjack_with_same_bet():
-    game = _make_solo_game(bet=25)
-    view = BlackjackView(game, on_finish=None)
+    view = _result_view(bet=25)
     interaction = _interaction()
 
     new_game = _make_solo_game(bet=25)
@@ -209,8 +239,7 @@ async def test_replay_surfaces_short_circuit_message_ephemerally():
     the replay handler must surface it as an ephemeral followup and
     NOT edit the message.
     """
-    game = _make_solo_game(bet=1000)
-    view = BlackjackView(game, on_finish=None)
+    view = _result_view(bet=1000)
     interaction = _interaction()
 
     fake_result = SoloStartResult(
@@ -244,8 +273,7 @@ async def test_replay_handles_natural_blackjack_auto_payout():
     must render that embed without trying to commit a non-existent
     view.
     """
-    game = _make_solo_game(bet=10)
-    view = BlackjackView(game, on_finish=None)
+    view = _result_view(bet=10)
     interaction = _interaction()
 
     auto_embed = discord.Embed(title="natural-blackjack")
@@ -265,6 +293,70 @@ async def test_replay_handles_natural_blackjack_auto_payout():
         await view._replay(interaction)
 
     commit_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Result view: ownership, terminal disabled shells, on_timeout
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_result_view_disables_move_button_shells():
+    """Row 0 of the result view is three disabled hit/stand/double
+    shells (visual continuity with the in-progress game view).
+    """
+    view = _result_view(bet=10)
+    move_shells = [
+        c
+        for c in view.children
+        if getattr(c, "label", None) in ("Hit", "Stand", "Double Down")
+    ]
+    assert len(move_shells) == 3
+    for shell in move_shells:
+        assert shell.disabled is True
+
+
+@pytest.mark.asyncio
+async def test_result_view_rejects_wrong_user():
+    """A different user clicking any result-view button gets the
+    standard ownership ephemeral.
+    """
+    owner_view = _result_view(bet=10)
+    intruder = _interaction(user_id=owner_view.user_id + 1)
+
+    allowed = await owner_view.interaction_check(intruder)
+    assert allowed is False
+    intruder.response.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_result_view_on_timeout_disables_remaining_items():
+    """``on_timeout`` disables every child (including the previously
+    enabled Play again / Back) and edits the bound message. Guards
+    cleanly when ``self.message`` is unset.
+    """
+    view = _result_view(bet=10)
+    view.message = MagicMock()
+    view.message.edit = AsyncMock()
+
+    await view.on_timeout()
+
+    for child in view.children:
+        assert child.disabled is True
+    view.message.edit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_result_view_on_timeout_skips_when_message_unset():
+    """If the message reference was never assigned, ``on_timeout``
+    must not raise (defensive against the result view being
+    constructed but never published).
+    """
+    view = _result_view(bet=10)
+    assert view.message is None
+
+    # Must not raise.
+    await view.on_timeout()
 
 
 # ---------------------------------------------------------------------------
@@ -314,6 +406,9 @@ async def test_hit_btn_defers_before_save_game_state():
             "views.blackjack.solo_view.safe_edit",
             new=fake_edit,
         ),
+        # Pin a non-bust value so the test exercises the save-path,
+        # not the bust → _finish branch that hits the real DB.
+        patch("views.blackjack.solo_view._hand_value", return_value=15),
     ):
         await hit_callback(view, interaction, MagicMock())
 

--- a/tests/unit/views/test_games_common.py
+++ b/tests/unit/views/test_games_common.py
@@ -31,7 +31,18 @@ def _stub_interaction(user: SimpleNamespace) -> MagicMock:
     interaction = MagicMock(spec=discord.Interaction)
     interaction.user = user
     interaction.response = MagicMock()
+    # safe_defer calls is_done() then defer(); safe_edit branches on
+    # is_done() again. The mock doesn't track state across calls, so a
+    # constant False keeps the test on the "not-yet-deferred" branch
+    # of safe_edit (response.edit_message) — same surface the helper
+    # picks for a freshly-clicked button at run time.
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.response.defer = AsyncMock()
     interaction.response.edit_message = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.edit_message = AsyncMock()
+    interaction.followup.send = AsyncMock()
     interaction.message = MagicMock(id=444)
     return interaction
 
@@ -58,11 +69,7 @@ def test_back_button_renders_with_label_and_custom_id():
 async def test_back_button_callback_returns_panel_and_overview_embed():
     author = _author(42)
     parent_view = _RpsBetPresetView(author)  # type: ignore[arg-type]
-    btn = next(
-        c
-        for c in parent_view.children
-        if isinstance(c, BackToPanelButton)
-    )
+    btn = next(c for c in parent_view.children if isinstance(c, BackToPanelButton))
     interaction = _stub_interaction(author)
     await btn.callback(interaction)
 
@@ -78,6 +85,44 @@ async def test_back_button_callback_returns_panel_and_overview_embed():
     # Author preserved across the back nav (invoker-restriction stays
     # bound to the original opener).
     assert new_view._author is author
+
+
+@pytest.mark.asyncio
+async def test_back_button_callback_defers_before_editing():
+    """Hardened callback: safe_defer fires before any rebuild work, so
+    a token-expiry race or upstream service exception cannot surface as
+    a raw "interaction failed" — the helpers swallow the recoverable
+    failure modes and log instead.
+    """
+    author = _author(42)
+    parent_view = _RpsBetPresetView(author)  # type: ignore[arg-type]
+    btn = next(c for c in parent_view.children if isinstance(c, BackToPanelButton))
+    interaction = _stub_interaction(author)
+    await btn.callback(interaction)
+
+    interaction.response.defer.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_back_button_callback_bails_when_defer_fails():
+    """If safe_defer returns False (token expired before defer reached
+    Discord), the callback aborts cleanly without attempting an edit.
+    """
+    from unittest.mock import patch
+
+    author = _author(42)
+    parent_view = _RpsBetPresetView(author)  # type: ignore[arg-type]
+    btn = next(c for c in parent_view.children if isinstance(c, BackToPanelButton))
+    interaction = _stub_interaction(author)
+
+    async def fake_defer(_i, **_kw):
+        return False
+
+    with patch("views.games.common.safe_defer", new=fake_defer):
+        await btn.callback(interaction)
+
+    interaction.response.edit_message.assert_not_called()
+    interaction.followup.edit_message.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/views/test_rps_solo_replay.py
+++ b/tests/unit/views/test_rps_solo_replay.py
@@ -1,20 +1,28 @@
-"""Regression tests for solo RPS instant-replay (Smooth Interaction Pass PR 6).
+"""Regression tests for solo RPS terminal-state lifecycle.
 
-Before this PR ``_RpsView._play`` disabled every child after the
-round resolved and stopped the view — leaving the user with no way
-to play again without retyping ``!rps`` or re-opening the panel.
+Originally added in Smooth Interaction Pass PR 6 to pin the
+"end-of-round replay row" contract; updated when the terminal state
+moved off the live ``_RpsView`` and onto a dedicated
+``_RpsSoloResultView``. The previous design appended Play again /
+Back to the live game view and then called ``self.stop()`` — which
+un-registers the view from discord.py's component dispatch table and
+surfaces "interaction failed" on the visible buttons. The fix swaps
+the live view for a fresh result view in ``safe_edit`` before
+stopping the original.
 
 These tests pin the new contract:
 
-* After resolution the move buttons are disabled but two new
-  result-action buttons appear on row 1: ``🔁 Play again`` and
-  ``◀ Back to RPS``.
-* ``Play again`` spawns a *fresh* ``_RpsView`` (same user / guild /
-  bet) and edits the message in place. The old view stays stopped.
+* After resolution ``_play`` swaps the view for a fresh
+  ``_RpsSoloResultView`` whose row 0 is three disabled
+  Rock/Paper/Scissors shells and row 1 is ``🔁 Play again`` +
+  ``↩ Back to RPS``.
+* ``Play again`` (now on the result view) spawns a *fresh* ``_RpsView``
+  (same user / guild / bet) and edits the message in place. The old
+  view stays stopped.
 * When ``bet > 0`` and balance is insufficient, replay sends an
   ephemeral nudge and does NOT spawn a new game.
-* Wrong-user replay attempts are rejected ephemerally
-  (re-uses the existing ``interaction_check``).
+* Wrong-user replay attempts are rejected ephemerally on the result
+  view's ``interaction_check``.
 """
 
 from __future__ import annotations
@@ -24,7 +32,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import discord
 import pytest
 
-from views.rps.solo_play import _RpsView
+from views.rps.solo_play import _RpsSoloResultView, _RpsView
 
 
 def _member(id_: int = 1) -> MagicMock:
@@ -53,8 +61,18 @@ def _interaction(user: MagicMock, *, is_done: bool = False) -> MagicMock:
 
 
 # ---------------------------------------------------------------------------
-# End-of-game: result row appended
+# End-of-game: result view swapped in
 # ---------------------------------------------------------------------------
+
+
+def _capture_safe_edit() -> tuple[AsyncMock, dict]:
+    captured: dict = {}
+
+    async def fake_edit(_interaction, **kwargs):
+        captured.update(kwargs)
+        return True
+
+    return fake_edit, captured  # type: ignore[return-value]
 
 
 @pytest.mark.asyncio
@@ -62,6 +80,8 @@ async def test_play_appends_replay_and_back_buttons():
     user = _member(id_=1)
     view = _RpsView(user, guild_id=99, bet=0)
     interaction = _interaction(user)
+
+    fake_edit, captured = _capture_safe_edit()
 
     with (
         patch(
@@ -83,17 +103,19 @@ async def test_play_appends_replay_and_back_buttons():
             "views.rps.solo_play.random.choice",
             return_value="rock",
         ),
+        patch("views.rps.solo_play.safe_edit", new=fake_edit),
     ):
         await view._play(interaction, "paper")  # paper beats rock → win
 
-    labels = [getattr(c, "label", None) for c in view.children]
+    result_view = captured["view"]
+    assert isinstance(result_view, _RpsSoloResultView)
+    labels = [getattr(c, "label", None) for c in result_view.children]
     assert any(label and "Play again" in label for label in labels), labels
     assert any(label and "Back to RPS" in label for label in labels), labels
 
-    # Move buttons remain visible but disabled.
     move_btns = [
         c
-        for c in view.children
+        for c in result_view.children
         if getattr(c, "label", None) in ("Rock", "Paper", "Scissors")
     ]
     assert len(move_btns) == 3
@@ -139,7 +161,7 @@ async def test_play_disables_move_buttons_and_uses_safe_edit():
 @pytest.mark.asyncio
 async def test_replay_spawns_fresh_view_for_free_play():
     user = _member(id_=1)
-    finished = _RpsView(user, guild_id=99, bet=0)
+    finished = _RpsSoloResultView(user, guild_id=99, bet=0)
     interaction = _interaction(user, is_done=False)
 
     await finished._replay(interaction)
@@ -149,7 +171,6 @@ async def test_replay_spawns_fresh_view_for_free_play():
     kwargs = interaction.response.edit_message.await_args.kwargs
     new_view = kwargs["view"]
     assert isinstance(new_view, _RpsView)
-    assert new_view is not finished
     assert new_view.bet == 0
     assert new_view.user is user
     assert new_view.guild_id == 99
@@ -158,7 +179,7 @@ async def test_replay_spawns_fresh_view_for_free_play():
 @pytest.mark.asyncio
 async def test_replay_spawns_fresh_view_when_bet_covered():
     user = _member(id_=1)
-    finished = _RpsView(user, guild_id=99, bet=10)
+    finished = _RpsSoloResultView(user, guild_id=99, bet=10)
     interaction = _interaction(user)
 
     with patch(
@@ -178,7 +199,7 @@ async def test_replay_spawns_fresh_view_when_bet_covered():
 @pytest.mark.asyncio
 async def test_replay_blocked_when_balance_too_low():
     user = _member(id_=1)
-    finished = _RpsView(user, guild_id=99, bet=100)
+    finished = _RpsSoloResultView(user, guild_id=99, bet=100)
     interaction = _interaction(user)
 
     with patch(
@@ -201,14 +222,66 @@ async def test_replay_blocked_when_balance_too_low():
 
 @pytest.mark.asyncio
 async def test_replay_rejects_wrong_user():
-    """A different user clicking Play again gets the standard
-    interaction-check ephemeral, identical to a wrong-user move click.
+    """A different user clicking Play again on the result view gets
+    the standard ownership ephemeral.
     """
     owner = _member(id_=1)
-    finished = _RpsView(owner, guild_id=99, bet=0)
+    finished = _RpsSoloResultView(owner, guild_id=99, bet=0)
     intruder = _member(id_=99)
     interaction = _interaction(intruder)
 
     allowed = await finished.interaction_check(interaction)
     assert allowed is False
     interaction.response.send_message.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Result view: ownership / shells / on_timeout
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_result_view_disables_move_button_shells():
+    """Row 0 of the result view is three disabled Rock/Paper/Scissors
+    shells (visual continuity with the in-progress game view).
+    """
+    user = _member(id_=1)
+    view = _RpsSoloResultView(user, guild_id=99, bet=10)
+    move_shells = [
+        c
+        for c in view.children
+        if getattr(c, "label", None) in ("Rock", "Paper", "Scissors")
+    ]
+    assert len(move_shells) == 3
+    for shell in move_shells:
+        assert shell.disabled is True
+
+
+@pytest.mark.asyncio
+async def test_result_view_on_timeout_disables_remaining_items():
+    """``on_timeout`` disables every child (including the previously
+    enabled Play again / Back) and edits the bound message.
+    """
+    user = _member(id_=1)
+    view = _RpsSoloResultView(user, guild_id=99, bet=10)
+    view.message = MagicMock()
+    view.message.edit = AsyncMock()
+
+    await view.on_timeout()
+
+    for child in view.children:
+        assert child.disabled is True
+    view.message.edit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_result_view_on_timeout_skips_when_message_unset():
+    """If the message reference was never assigned, ``on_timeout``
+    must not raise.
+    """
+    user = _member(id_=1)
+    view = _RpsSoloResultView(user, guild_id=99, bet=10)
+    assert view.message is None
+
+    # Must not raise.
+    await view.on_timeout()

--- a/tests/unit/views/test_view_error_handling.py
+++ b/tests/unit/views/test_view_error_handling.py
@@ -84,6 +84,30 @@ class TestBaseViewOnError:
         ), "on_error must log the custom_id"
 
     @pytest.mark.asyncio
+    async def test_log_payload_includes_response_done(self, caplog):
+        """Distinguishing "raised before defer" from "raised after defer"
+        is important enough to keep in the structured log. Pin that the
+        payload includes ``response_done`` for both paths.
+        """
+        import logging
+
+        import discord
+
+        from views.base import BaseView
+
+        author = MagicMock(spec=discord.Member)
+        view = BaseView(author)
+
+        for responded in (False, True):
+            caplog.clear()
+            interaction = _make_interaction(responded=responded)
+            with caplog.at_level(logging.ERROR, logger="bot.views"):
+                await view.on_error(interaction, RuntimeError("x"), _make_item())
+            assert any(
+                f"response_done={responded}" in r.message for r in caplog.records
+            ), f"response_done={responded} missing from log payload"
+
+    @pytest.mark.asyncio
     async def test_sends_ephemeral_when_not_responded(self):
         import discord
 


### PR DESCRIPTION
## Summary

Four staged fixes for the regression audit. Each commit is independently reviewable.

### PR 1 — Terminal result view for Blackjack & RPS solo (`e0babb7`)

`BlackjackView._finish` and `_RpsView._play` were calling `self.stop()` *after* `safe_edit` published the message with newly-added enabled replay/back buttons. `View.stop()` un-registers the view from discord.py's component dispatch table — subsequent clicks no longer routed, and Discord surfaced "interaction failed" after the 3 s response window. The stale comment in `solo_play.py` claiming buttons "remain clickable indefinitely" was factually wrong.

Fix: swap the live game view for a fresh `_BlackjackSoloResultView` / `_RpsSoloResultView` via `safe_edit(view=result_view)` before calling `self.stop()` on the original. The result view owns disabled move-button shells on row 0 and enabled Play again / Back on row 1, with its own ownership check and `on_timeout` (guarded against `self.message is None`).

Replay delegates through the canonical game-start surface:
- Blackjack: `start_solo_blackjack` + `commit_solo_blackjack` (unchanged).
- RPS: the same `_RpsView(user, guild_id, bet)` construction shape used by `cogs/rps_tournament/_quickplay.py` and `views/games/rps_panel.py`.

PvP and tournament blackjack paths are untouched.

### PR 2 — Shared interaction-response policy hardening (`ed8391c`)

- `BackToPanelButton.callback` (`views/games/common.py`) now uses the canonical `safe_defer` → `safe_edit` pattern. Raw `interaction.response.edit_message` under token expiry / pre-edit I/O races now fails into the helpers' controlled WARN log instead of surfacing "interaction failed".
- `views.base.handle_view_error` log payload now carries `response_done=<bool>` so "raised before defer" vs "raised after defer" failures are distinguishable in incident review.

### PR 3 — Setup ephemeral normalization (aggressive) (`0712335`)

Setup state belongs in the durable workspace anchor in `#superbot-setup`, not in per-user ephemerals that admins can't delete, revisit, share, or debug.

New `disbot/views/setup/_anchor.py` (thin renderer):
- `render_setup_state(guild, *, embed, view)` — replace the workspace anchor (state replacement). Falls back to `channel.send` if the anchor is missing. Returns `False` on failure so callers surface a controlled ephemeral.
- `push_setup_notice(guild, *, embed)` — append a one-shot durable notice (event log) without touching anchor id.

Both helpers swallow `discord.HTTPException` / `Forbidden` / `NotFound`, log at WARNING, and return `False`. The renderer imports only from `services.setup_session` / `services.setup_channel` — never from `views/setup/wizard.py` or `views/setup/hub.py`.

Migrations:
- `wizard.Open Hub` → swap anchor to `SetupHubView` (was ephemeral follow-up).
- `wizard.Apply Recommended` success → `push_setup_notice` for the event record; `safe_defer` is the ack; anchor refresh handles state.
- `wizard.Continue → Final Review` on last step → swap anchor to `FinalReviewView` (was ephemeral follow-up).
- `hub.Apply all recommended` success → `push_setup_notice` + short ephemeral pointer.
- `hub.section` failure → `push_setup_notice` for the durable failure record.
- `/setup-status` → `push_setup_notice` + ephemeral pointer (wizard anchor stays intact mid-status check).

Ephemerals intentionally retained for permission denials, outside-guild gates, validation errors, workspace-unavailable fallbacks, and short pointer/ack replies — all audit-allowed patterns.

### PR 4 — Snapshot guard for legacy prefix + slash command surface (`eb18800`)

New `tests/unit/runtime/test_legacy_command_surface.py`. AST-based scan of `disbot/cogs/**/*.py` for `@commands.command`, `@commands.group`, `@commands.hybrid_command`, `@app_commands.command`, `@app_commands.group` decorators. Asserts every name in `EXPECTED_LIVE` (blackjack/bj, games, ai, setup, all `/setup-*`, /games, /help) is registered. Symmetric `LEGACY_DEPRECATED` allowlist catches accidental re-registration of intentionally retired commands.

AST scanning is deliberate: building a live `commands.Bot` in the unit-test sandbox would require DB and external services that the `cog_load` paths touch. The decorator surface is the same surface `command_surface_ledger` walks at runtime.

## Test plan

- [x] `python3.10 -m pytest tests/ -q` → **5274 passed, 3 skipped**.
- [x] `python3.10 scripts/check_architecture.py --mode strict` → no new errors.
- [x] `black --check` + `ruff check` clean.
- [ ] Manual: Blackjack solo → bust → click every terminal button. No "interaction failed". Replay starts a fresh hand against the same bet; Back returns to the panel.
- [ ] Manual: RPS solo → finish round → click Play again + Back to RPS. No "interaction failed". Replay spawns a fresh round.
- [ ] Manual: `/setup` → click Open Hub. Anchor in `#superbot-setup` swaps to the hub view (not an ephemeral).
- [ ] Manual: Reach Final Review via Continue on last step. Anchor swaps to FinalReviewView durably.
- [ ] Manual: `/setup-status` from a non-setup channel. Snapshot lands as a durable notice in `#superbot-setup`; reply is "📋 Setup status posted in #superbot-setup".

https://claude.ai/code/session_0187GfYU7TzBthHwAz7VQhrv

---
_Generated by [Claude Code](https://claude.ai/code/session_0187GfYU7TzBthHwAz7VQhrv)_