### PR TITLE
Add wizard-native detail views and anchor navigation helpers

### DIFF
--- a/disbot/services/setup_sections.py
+++ b/disbot/services/setup_sections.py
@@ -81,6 +81,20 @@ class SetupSection:
             every section's safe default in one click. ``None`` means
             the section has no auto-recommended path; operators must
             customise it manually.
+        detail_embed_builder: Optional async callable returning the
+            embed shown when the wizard swaps its durable anchor into
+            step-detail mode for this section. Signature:
+            ``async (guild, *, session, draft_rows) -> discord.Embed``.
+            Paired with ``detail_view_builder``; when either is ``None``
+            the wizard falls back to the legacy ephemeral ``customize``
+            callback.
+        detail_view_builder: Optional sync callable that returns the
+            ``discord.ui.View`` mounted on the wizard anchor in
+            step-detail mode. Signature:
+            ``(author, *, section, guild, session) -> discord.ui.View``.
+            Must use rows 0–3 only — ``row=4`` is reserved by
+            ``views.setup.wizard_nav.render_step_detail`` for the
+            injected "↩ Back to step" button.
     """
 
     slug: str
@@ -95,6 +109,8 @@ class SetupSection:
     depths: frozenset[str] = frozenset({"quick", "standard", "advanced"})
     recommended_ops_builder: Any = None  # async (Guild) -> list[SetupOperation]
     customize: Any = None  # CustomizeCallback | None — see section_card.py
+    detail_embed_builder: Any = None  # async (guild, *, session, draft_rows) -> Embed
+    detail_view_builder: Any = None  # (author, *, section, guild, session) -> View
 
     @property
     def session_step(self) -> str:

--- a/disbot/views/setup/hub.py
+++ b/disbot/views/setup/hub.py
@@ -237,6 +237,7 @@ class SetupHubView(BaseView):
         if any(s.recommended_ops_builder is not None for s in depth_sections):
             self.add_item(self._build_apply_all_recommended_button())
         self.add_item(self._build_change_depth_button())
+        self.add_item(self._build_back_to_wizard_button())
 
     def _build_apply_all_recommended_button(self) -> discord.ui.Button:
         button: discord.ui.Button = discord.ui.Button(  # type: ignore[var-annotated]
@@ -414,6 +415,42 @@ class SetupHubView(BaseView):
                 embed=build_depth_embed(),
                 view=view,
             )
+
+        button.callback = _callback  # type: ignore[method-assign]
+        return button
+
+    def _build_back_to_wizard_button(self) -> discord.ui.Button:
+        button: discord.ui.Button = discord.ui.Button(  # type: ignore[var-annotated]
+            label="↩ Back to wizard",
+            style=discord.ButtonStyle.secondary,
+            custom_id="setup_hub:back_to_wizard",
+            row=4,
+        )
+
+        async def _callback(interaction: discord.Interaction) -> None:
+            member = interaction.user
+            guild = interaction.guild
+            if guild is None or not isinstance(member, discord.Member):
+                await interaction.response.send_message(
+                    "Use this from inside the server.",
+                    ephemeral=True,
+                )
+                return
+            await self._refresh_session()
+            from views.setup.wizard_nav import render_wizard_step
+
+            ok = await render_wizard_step(
+                interaction,
+                guild=guild,
+                member=member,
+                session=self.session,
+                step_index=None,
+            )
+            if not ok and not interaction.response.is_done():
+                await interaction.response.send_message(
+                    "Could not restore the wizard view — see logs.",
+                    ephemeral=True,
+                )
 
         button.callback = _callback  # type: ignore[method-assign]
         return button

--- a/disbot/views/setup/sections/channels.py
+++ b/disbot/views/setup/sections/channels.py
@@ -558,6 +558,40 @@ async def run(interaction: discord.Interaction, hub: SetupHubView) -> None:
     )
 
 
+async def _build_detail_embed(
+    guild: discord.Guild,
+    *,
+    session: Any = None,
+    draft_rows: Any = None,
+) -> discord.Embed:
+    """Wizard-native detail embed for the channels step."""
+    try:
+        from services import guild_snapshot
+
+        snapshot: GuildSnapshot | None = await guild_snapshot.collect(guild)
+    except Exception:
+        logger.exception("channels._build_detail_embed: snapshot collect failed")
+        snapshot = None
+    return build_channels_embed(snapshot)
+
+
+def _build_detail_view(
+    author: discord.Member | discord.User,
+    *,
+    section: SetupSection,
+    guild: discord.Guild,
+    session: Any = None,
+) -> ChannelsSectionView:
+    """Wizard-native detail view for the channels step.
+
+    The snapshot is fetched lazily inside the picker callback when
+    needed; constructing the view itself only requires the author.
+    Mirrors the snapshot-less fallback path the legacy
+    ``_customize_run`` already handled.
+    """
+    return ChannelsSectionView(author, snapshot=None)
+
+
 REGISTRY.register(
     SetupSection(
         slug=SLUG,
@@ -575,6 +609,8 @@ REGISTRY.register(
         depths=frozenset({"standard", "advanced"}),
         recommended_ops_builder=_recommended_channel_ops,
         customize=_customize_run,
+        detail_embed_builder=_build_detail_embed,
+        detail_view_builder=_build_detail_view,
     ),
 )
 

--- a/disbot/views/setup/sections/cleanup.py
+++ b/disbot/views/setup/sections/cleanup.py
@@ -551,6 +551,29 @@ async def run(interaction: discord.Interaction, hub: SetupHubView) -> None:
     )
 
 
+async def _build_detail_embed(
+    guild: discord.Guild,
+    *,
+    session: object = None,
+    draft_rows: object = None,
+) -> discord.Embed:
+    """Wizard-native detail embed for the cleanup step."""
+    del guild, session, draft_rows
+    return build_cleanup_embed()
+
+
+def _build_detail_view(
+    author: discord.Member | discord.User,
+    *,
+    section: SetupSection,
+    guild: discord.Guild,
+    session: object = None,
+) -> CleanupSectionView:
+    """Wizard-native detail view for the cleanup step."""
+    del section, guild, session
+    return CleanupSectionView(author)
+
+
 REGISTRY.register(
     SetupSection(
         slug=SLUG,
@@ -568,6 +591,8 @@ REGISTRY.register(
         depths=frozenset({"standard", "advanced"}),
         recommended_ops_builder=_recommended_cleanup_ops,
         customize=_customize_run,
+        detail_embed_builder=_build_detail_embed,
+        detail_view_builder=_build_detail_view,
     ),
 )
 

--- a/disbot/views/setup/sections/cog_routing.py
+++ b/disbot/views/setup/sections/cog_routing.py
@@ -584,6 +584,29 @@ async def run(interaction: discord.Interaction, hub: SetupHubView) -> None:
     )
 
 
+async def _build_detail_embed(
+    guild: discord.Guild,
+    *,
+    session: object = None,
+    draft_rows: object = None,
+) -> discord.Embed:
+    """Wizard-native detail embed for the cog-routing step."""
+    del guild, session, draft_rows
+    return build_cog_routing_embed()
+
+
+def _build_detail_view(
+    author: discord.Member | discord.User,
+    *,
+    section: SetupSection,
+    guild: discord.Guild,
+    session: object = None,
+) -> CogRoutingSectionView:
+    """Wizard-native detail view for the cog-routing step."""
+    del section, guild, session
+    return CogRoutingSectionView(author)
+
+
 REGISTRY.register(
     SetupSection(
         slug=SLUG,
@@ -600,6 +623,8 @@ REGISTRY.register(
         ),
         depths=frozenset({"advanced"}),
         customize=_customize_run,
+        detail_embed_builder=_build_detail_embed,
+        detail_view_builder=_build_detail_view,
     ),
 )
 

--- a/disbot/views/setup/sections/identity.py
+++ b/disbot/views/setup/sections/identity.py
@@ -285,6 +285,30 @@ async def run(interaction: discord.Interaction, hub: SetupHubView) -> None:
     )
 
 
+async def _build_detail_embed(
+    guild: discord.Guild,
+    *,
+    session: object = None,
+    draft_rows: object = None,
+) -> discord.Embed:
+    """Wizard-native detail embed for the identity step."""
+    del session, draft_rows
+    current = await _read_current_warn_threshold(guild.id)
+    return _build_identity_embed(guild, current_warn_threshold=current)
+
+
+def _build_detail_view(
+    author: discord.Member | discord.User,
+    *,
+    section: SetupSection,
+    guild: discord.Guild,
+    session: object = None,
+) -> IdentitySectionView:
+    """Wizard-native detail view for the identity step."""
+    del section, guild, session
+    return IdentitySectionView(author)
+
+
 REGISTRY.register(
     SetupSection(
         slug=SLUG,
@@ -299,6 +323,8 @@ REGISTRY.register(
         ),
         depths=frozenset({"advanced"}),
         customize=_customize_run,
+        detail_embed_builder=_build_detail_embed,
+        detail_view_builder=_build_detail_view,
     ),
 )
 # Identity stages `set_setting` ops but `set_setting` is shared with

--- a/disbot/views/setup/sections/logging_presets.py
+++ b/disbot/views/setup/sections/logging_presets.py
@@ -671,6 +671,37 @@ async def run(interaction: discord.Interaction, hub: SetupHubView) -> None:
     )
 
 
+async def _build_detail_embed(
+    guild: discord.Guild,
+    *,
+    session: object = None,
+    draft_rows: object = None,
+) -> discord.Embed:
+    """Wizard-native detail embed for the logging-presets step."""
+    del session, guild
+    supported = _supported_bindings()
+    rows = list(draft_rows) if draft_rows is not None else []
+    current = infer_current_preset(rows)
+    return build_logging_presets_embed(supported, current_preset=current)
+
+
+def _build_detail_view(
+    author: discord.Member | discord.User,
+    *,
+    section: SetupSection,
+    guild: discord.Guild,
+    session: object = None,
+) -> LoggingPresetsView:
+    """Wizard-native detail view for the logging-presets step."""
+    del section, guild, session
+    return LoggingPresetsView(
+        author,
+        hub=None,
+        supported=_supported_bindings(),
+        current_preset=None,
+    )
+
+
 REGISTRY.register(
     SetupSection(
         slug=SLUG,
@@ -694,6 +725,8 @@ REGISTRY.register(
         depths=frozenset({"standard", "advanced"}),
         recommended_ops_builder=_recommended_logging_ops,
         customize=_customize_run,
+        detail_embed_builder=_build_detail_embed,
+        detail_view_builder=_build_detail_view,
     ),
 )
 

--- a/disbot/views/setup/wizard.py
+++ b/disbot/views/setup/wizard.py
@@ -19,10 +19,10 @@ Architecture
   (Phase 0 / Phase 2 helper), reads progress via
   :mod:`services.setup_progress`, and gates every mutating button
   through :func:`services.setup_access.can_apply_setup`.
-* The hub continues to exist; the wizard's ``Open hub`` button posts
-  the hub-style embed as a transient reply so operators who prefer
-  the section-list UI still get it.  ``/setup-hub`` remains as the
-  explicit hub entry point.
+* The hub continues to exist as an expert / advanced entry point
+  reached via ``/setup-hub``.  The wizard no longer carries a button
+  to it — the hub's own ``↩ Back to wizard`` button is the return
+  path for operators who chose to open the hub explicitly.
 
 Lifecycle
 ---------
@@ -227,12 +227,12 @@ class LinearWizardView(BaseView):
     :func:`services.setup_access.can_apply_setup` against a fresh
     session snapshot, mirroring the section card's per-button gate
     from Phase 1.  Navigation buttons (``Back``, ``Continue``,
-    ``Open hub``, ``Cancel``) are not gated — they only mutate
-    view-local state.
+    ``Cancel``) are not gated — they only mutate view-local state.
 
     The view does not own the anchor message; the caller (typically
     :func:`open_setup_workspace`) edits the message after each
-    button press to re-render the new step.
+    button press to re-render the new step. Anchor rebuilds go
+    through :func:`views.setup.wizard_nav.render_wizard_step`.
     """
 
     def __init__(
@@ -288,11 +288,18 @@ class LinearWizardView(BaseView):
         apply_recommended.callback = self._on_apply_recommended  # type: ignore[method-assign]
         self.add_item(apply_recommended)
 
+        customize_disabled = section is None or (
+            section.customize is None
+            and (
+                section.detail_embed_builder is None
+                or section.detail_view_builder is None
+            )
+        )
         customize: discord.ui.Button = discord.ui.Button(  # type: ignore[var-annotated]
             label="Customize",
             style=discord.ButtonStyle.primary,
             custom_id="setup_wizard:customize",
-            disabled=(section is None or section.customize is None),
+            disabled=customize_disabled,
             row=0,
         )
         customize.callback = self._on_customize  # type: ignore[method-assign]
@@ -322,15 +329,6 @@ class LinearWizardView(BaseView):
         )
         continue_btn.callback = self._on_continue  # type: ignore[method-assign]
         self.add_item(continue_btn)
-
-        open_hub: discord.ui.Button = discord.ui.Button(  # type: ignore[var-annotated]
-            label="Open hub",
-            style=discord.ButtonStyle.secondary,
-            custom_id="setup_wizard:open_hub",
-            row=1,
-        )
-        open_hub.callback = self._on_open_hub  # type: ignore[method-assign]
-        self.add_item(open_hub)
 
         cancel: discord.ui.Button = discord.ui.Button(  # type: ignore[var-annotated]
             label="Cancel",
@@ -425,60 +423,34 @@ class LinearWizardView(BaseView):
                 )
 
     async def _refresh_and_edit(self, interaction: discord.Interaction) -> None:
-        """Refresh the session + draft state and edit the anchor message.
+        """Refresh state and edit the anchor message at ``self.step_index``.
 
-        Used by every button callback that needs to repaint the embed
-        with new step / progress data.  Edits in place so the anchor's
-        id remains stable.
+        Thin delegate over :func:`views.setup.wizard_nav.render_wizard_step`
+        so every wizard callback uses the same anchor-rebuild path
+        (also used by the hub's ↩ Back to wizard button).
         """
-        guild_id = interaction.guild_id
-        if guild_id is not None:
-            try:
-                self.session = await setup_session.resume_session(guild_id)
-            except Exception:
-                logger.exception("wizard._refresh_and_edit: resume failed")
-        # Re-resolve sections in case depth changed.
-        self.sections = _resolve_sections(self.session)
-        # Clamp step index in case the section list shrank.
-        if self.step_index >= len(self.sections):
-            self.step_index = max(0, len(self.sections) - 1)
-        self._rebuild_buttons()
+        guild = interaction.guild
+        member = interaction.user
+        if guild is None or not isinstance(member, discord.Member):
+            # Without a Member context we can't construct a new wizard
+            # view; fall back to the same ephemeral hint the apply gate
+            # uses.
+            if not interaction.response.is_done():
+                await interaction.response.send_message(
+                    "Use this from inside the server.",
+                    ephemeral=True,
+                )
+            return
 
-        draft_rows: list[DraftOperationRow] = []
-        if guild_id is not None:
-            try:
-                draft_rows = await setup_draft.list_rows(guild_id)
-            except Exception:
-                logger.exception("wizard._refresh_and_edit: list_rows failed")
+        from views.setup.wizard_nav import render_wizard_step
 
-        section = self.current_section
-        if section is None:
-            embed = discord.Embed(
-                title=_WIZARD_TITLE,
-                description=(
-                    "No setup sections are available for this depth. "
-                    "Pick a different depth via `/setup-depth` or open "
-                    "the hub for the full section list."
-                ),
-                color=discord.Color.dark_grey(),
-            )
-        else:
-            embed = build_wizard_step_embed(
-                session=self.session,
-                section=section,
-                step_index=self.step_index,
-                total_steps=len(self.sections),
-                draft_rows=draft_rows,
-            )
-
-        if interaction.response.is_done():
-            await interaction.followup.edit_message(
-                message_id=interaction.message.id,
-                embed=embed,
-                view=self,
-            )
-        else:
-            await interaction.response.edit_message(embed=embed, view=self)
+        await render_wizard_step(
+            interaction,
+            guild=guild,
+            member=member,
+            session=self.session,
+            step_index=self.step_index,
+        )
 
     async def _on_back(self, interaction: discord.Interaction) -> None:
         if self.step_index > 0:
@@ -492,54 +464,6 @@ class LinearWizardView(BaseView):
             return
         # Last step → open Final Review as a transient ephemeral.
         await self._open_final_review(interaction)
-
-    async def _on_open_hub(self, interaction: discord.Interaction) -> None:
-        # Aggressive ephemeral policy: swap the anchor view to the hub
-        # view so the operator can browse the section list inside the
-        # durable workspace message, not in a per-user ephemeral that
-        # cannot be deleted/revisited/shared.
-        from views.setup.hub import SetupHubView, build_hub_embed
-
-        guild = interaction.guild
-        if guild is None:
-            await interaction.response.send_message(
-                "Open hub requires a guild context.",
-                ephemeral=True,
-            )
-            return
-
-        member = interaction.user
-        if not isinstance(member, discord.Member):
-            await interaction.response.send_message(
-                "Use this from inside the server.",
-                ephemeral=True,
-            )
-            return
-
-        if not await safe_defer(interaction):
-            return
-
-        try:
-            session = await setup_session.resume_session(guild.id)
-        except Exception:
-            logger.exception("wizard._on_open_hub: resume failed")
-            session = self.session
-
-        try:
-            draft_rows = await setup_draft.list_rows(guild.id)
-        except Exception:
-            logger.exception("wizard._on_open_hub: list_rows failed")
-            draft_rows = []
-
-        hub_view = SetupHubView(member, session=session)
-        embed = build_hub_embed(
-            session,
-            pending_ops=len(draft_rows),
-            draft_ops=draft_rows,
-        )
-        # safe_edit after defer edits the clicked anchor via
-        # followup.edit_message(message_id=interaction.message.id).
-        await safe_edit(interaction, embed=embed, view=hub_view)
 
     async def _on_cancel(self, interaction: discord.Interaction) -> None:
         for child in self.children:
@@ -784,7 +708,17 @@ class LinearWizardView(BaseView):
 
     async def _on_customize(self, interaction: discord.Interaction) -> None:
         section = self.current_section
-        if section is None or section.customize is None:
+        if section is None:
+            await interaction.response.send_message(
+                "This step has no detail view.",
+                ephemeral=True,
+            )
+            return
+        has_detail = (
+            section.detail_embed_builder is not None
+            and section.detail_view_builder is not None
+        )
+        if not has_detail and section.customize is None:
             await interaction.response.send_message(
                 "This step has no detail view.",
                 ephemeral=True,
@@ -793,8 +727,47 @@ class LinearWizardView(BaseView):
         # Gate before opening — detail views can stage draft operations.
         if not await self._gate_apply(interaction):
             return
+
+        if has_detail:
+            # Wizard-native path: swap the anchor into detail mode with
+            # an injected ↩ Back to step button.  No ephemeral side
+            # panel, no stranding.
+            guild = interaction.guild
+            member = interaction.user
+            if guild is None or not isinstance(member, discord.Member):
+                await interaction.response.send_message(
+                    "Use this from inside the server.",
+                    ephemeral=True,
+                )
+                return
+            from views.setup.wizard_nav import render_step_detail
+
+            try:
+                ok = await render_step_detail(
+                    interaction,
+                    guild=guild,
+                    member=member,
+                    session=self.session,
+                    section=section,
+                    step_index=self.step_index,
+                )
+            except Exception:
+                logger.exception(
+                    "wizard._on_customize: render_step_detail failed (%s)",
+                    section.slug,
+                )
+                ok = False
+            if not ok and not interaction.response.is_done():
+                await interaction.response.send_message(
+                    "Could not open the detail view — see logs.",
+                    ephemeral=True,
+                )
+            return
+
+        # Legacy fallback: section provides only the ephemeral customize
+        # callback.  After it consumes the interaction we refresh the
+        # anchor so the operator sees any newly staged state.
         try:
-            # Pass None as hub; all registered customizers handle hub=None.
             await section.customize(interaction, None)
         except Exception:
             logger.exception(
@@ -807,11 +780,6 @@ class LinearWizardView(BaseView):
                     ephemeral=True,
                 )
             return
-        # The section's customize callback consumed the interaction response
-        # (ephemeral detail view).  Refresh the anchor to show current state.
-        # For detail views that stage ops asynchronously (user picks options
-        # inside the ephemeral), the anchor updates again on the next wizard
-        # button press — this is intentional and documented.
         try:
             await self._refresh_and_edit(interaction)
         except Exception:
@@ -928,7 +896,7 @@ async def open_setup_workspace(
             title=_WIZARD_TITLE,
             description=(
                 "No setup sections are available for this depth. "
-                "Pick a depth via `/setup-depth` or open the hub."
+                "Pick a depth via `/setup-depth` to populate the wizard."
             ),
             color=discord.Color.dark_grey(),
         )

--- a/disbot/views/setup/wizard_nav.py
+++ b/disbot/views/setup/wizard_nav.py
@@ -61,8 +61,8 @@ async def render_wizard_step(
     Returns ``True`` on a successful anchor edit.
     """
     from views.setup.wizard import (
-        LinearWizardView,
         _WIZARD_TITLE,
+        LinearWizardView,
         _resolve_sections,
         _step_index_for,
         build_wizard_step_embed,

--- a/disbot/views/setup/wizard_nav.py
+++ b/disbot/views/setup/wizard_nav.py
@@ -1,0 +1,250 @@
+"""Setup-wizard anchor navigation helpers.
+
+Single owner of two operations on the durable workspace anchor:
+
+* :func:`render_wizard_step` — rebuild the wizard embed + view at a
+  given step (or at ``session.current_step``) and edit the clicked
+  interaction's anchor in place.
+* :func:`render_step_detail` — swap the wizard anchor into a section's
+  detail mode by calling the section's ``detail_embed_builder`` and
+  ``detail_view_builder`` and injecting an ``↩ Back to step`` button
+  that re-runs :func:`render_wizard_step` at the originating step.
+
+Both functions go through
+:func:`core.runtime.interaction_helpers.safe_edit` so the anchor
+message id is preserved. The durable-anchor first-post and the
+persisted ``setup_message_id`` row are owned by
+:func:`views.setup.wizard.open_setup_workspace`; nothing in this
+module clears or rewrites the session row's anchor id.
+
+Callgraph note: detail builders are stored as attributes on a frozen
+``SetupSection`` dataclass and invoked via
+``await section.detail_embed_builder(...)``. CodeGraph cannot see
+these as edges from this module to e.g.
+``views.setup.sections.channels.build_channels_embed``. When
+reviewing dead-code claims for section builder helpers, grep-verify.
+
+Row layout: ``render_step_detail`` injects the Back button on
+``row=4``. Section ``detail_view_builder`` implementations must keep
+rows 0–3 free for their own components (selects, buttons).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+from core.runtime.interaction_helpers import safe_defer, safe_edit
+from services import setup_draft, setup_session
+from services.setup_sections import SetupSection
+from services.setup_session import SetupSession
+
+logger = logging.getLogger("bot.views.setup.wizard_nav")
+
+
+async def render_wizard_step(
+    interaction: discord.Interaction,
+    *,
+    guild: discord.Guild,
+    member: discord.Member,
+    session: SetupSession | None,
+    step_index: int | None = None,
+) -> bool:
+    """Rebuild the wizard anchor at ``step_index`` and edit it in place.
+
+    When ``step_index`` is ``None`` the step is resolved from
+    ``session.current_step`` via the wizard's existing
+    ``_step_index_for`` helper. The session is refreshed from the DB
+    so depth changes and skipped/acknowledged updates are reflected.
+
+    Returns ``True`` on a successful anchor edit.
+    """
+    from views.setup.wizard import (
+        LinearWizardView,
+        _WIZARD_TITLE,
+        _resolve_sections,
+        _step_index_for,
+        build_wizard_step_embed,
+    )
+
+    try:
+        refreshed = await setup_session.resume_session(guild.id)
+        if refreshed is not None:
+            session = refreshed
+    except Exception:
+        logger.exception("wizard_nav.render_wizard_step: resume failed")
+
+    sections = _resolve_sections(session)
+    if step_index is None:
+        step_index = _step_index_for(session, sections)
+    if sections:
+        if step_index < 0:
+            step_index = 0
+        elif step_index >= len(sections):
+            step_index = len(sections) - 1
+    else:
+        step_index = 0
+
+    try:
+        draft_rows = await setup_draft.list_rows(guild.id)
+    except Exception:
+        logger.exception("wizard_nav.render_wizard_step: list_rows failed")
+        draft_rows = []
+
+    if sections:
+        embed = build_wizard_step_embed(
+            session=session,
+            section=sections[step_index],
+            step_index=step_index,
+            total_steps=len(sections),
+            draft_rows=draft_rows,
+        )
+    else:
+        embed = discord.Embed(
+            title=_WIZARD_TITLE,
+            description=(
+                "No setup sections are available for this depth. "
+                "Pick a different depth via `/setup-depth`."
+            ),
+            color=discord.Color.dark_grey(),
+        )
+
+    view = LinearWizardView(
+        member,
+        session=session,
+        sections=sections,
+        step_index=step_index,
+    )
+
+    return await safe_edit(interaction, embed=embed, view=view)
+
+
+async def render_step_detail(
+    interaction: discord.Interaction,
+    *,
+    guild: discord.Guild,
+    member: discord.Member,
+    session: SetupSession | None,
+    section: SetupSection,
+    step_index: int,
+) -> bool:
+    """Swap the wizard anchor to ``section``'s detail embed + view.
+
+    Calls ``section.detail_embed_builder`` and
+    ``section.detail_view_builder`` (both required for wizard-native
+    Customize), injects an ``↩ Back to step`` button on row 4, then
+    edits the anchor in place. The Back button restores the wizard
+    view at ``step_index``.
+
+    Returns ``True`` when the anchor was edited successfully.
+    """
+    if section.detail_embed_builder is None or section.detail_view_builder is None:
+        logger.error(
+            "wizard_nav.render_step_detail: section %s missing detail builders",
+            section.slug,
+        )
+        return False
+
+    if not await safe_defer(interaction):
+        return False
+
+    try:
+        draft_rows = await setup_draft.list_rows(guild.id)
+    except Exception:
+        logger.exception("wizard_nav.render_step_detail: list_rows failed")
+        draft_rows = []
+
+    try:
+        embed = await section.detail_embed_builder(
+            guild,
+            session=session,
+            draft_rows=draft_rows,
+        )
+    except Exception:
+        logger.exception(
+            "wizard_nav.render_step_detail: detail_embed_builder failed (slug=%s)",
+            section.slug,
+        )
+        return False
+
+    try:
+        view = section.detail_view_builder(
+            member,
+            section=section,
+            guild=guild,
+            session=session,
+        )
+    except Exception:
+        logger.exception(
+            "wizard_nav.render_step_detail: detail_view_builder failed (slug=%s)",
+            section.slug,
+        )
+        return False
+
+    back_button = _build_back_to_step_button(step_index=step_index)
+    try:
+        view.add_item(back_button)
+    except Exception:
+        logger.exception(
+            "wizard_nav.render_step_detail: add_item(back_button) failed (slug=%s)",
+            section.slug,
+        )
+        return False
+
+    try:
+        await setup_session.mark_in_progress(guild.id, step=section.session_step)
+    except Exception:
+        logger.exception(
+            "wizard_nav.render_step_detail: mark_in_progress failed",
+        )
+
+    return await safe_edit(interaction, embed=embed, view=view)
+
+
+def _build_back_to_step_button(*, step_index: int) -> discord.ui.Button:
+    """Build the row-4 Back button injected into every step-detail view."""
+    button: discord.ui.Button = discord.ui.Button(  # type: ignore[var-annotated]
+        label="↩ Back to step",
+        style=discord.ButtonStyle.secondary,
+        custom_id=f"setup_wizard:back_to_step:{step_index}",
+        row=4,
+    )
+
+    async def _callback(interaction: discord.Interaction) -> None:
+        guild = interaction.guild
+        member = interaction.user
+        if guild is None or not isinstance(member, discord.Member):
+            await interaction.response.send_message(
+                "Use this from inside the server.",
+                ephemeral=True,
+            )
+            return
+        session: SetupSession | None = None
+        try:
+            session = await setup_session.resume_session(guild.id)
+        except Exception:
+            logger.exception(
+                "wizard_nav.back_to_step: resume failed",
+            )
+        ok = await render_wizard_step(
+            interaction,
+            guild=guild,
+            member=member,
+            session=session,
+            step_index=step_index,
+        )
+        if not ok and not interaction.response.is_done():
+            await interaction.response.send_message(
+                "Could not restore the wizard view — see logs.",
+                ephemeral=True,
+            )
+
+    button.callback = _callback  # type: ignore[method-assign]
+    return button
+
+
+__all__ = [
+    "render_step_detail",
+    "render_wizard_step",
+]

--- a/tests/unit/views/setup/test_wizard.py
+++ b/tests/unit/views/setup/test_wizard.py
@@ -242,7 +242,8 @@ def test_view_has_navigation_buttons_in_layout():
     assert "setup_wizard:customize" in custom_ids
     assert "setup_wizard:skip" in custom_ids
     assert "setup_wizard:continue" in custom_ids
-    assert "setup_wizard:open_hub" in custom_ids
+    # Open hub button removed — hub reachable only via /setup-hub now.
+    assert "setup_wizard:open_hub" not in custom_ids
     assert "setup_wizard:cancel" in custom_ids
 
 
@@ -1046,3 +1047,298 @@ async def test_apply_recommended_refreshes_anchor_after_staging():
     interaction.followup.edit_message.assert_awaited_once()
     kw = interaction.followup.edit_message.await_args.kwargs
     assert kw.get("message_id") == interaction.message.id
+
+
+# ---------------------------------------------------------------------------
+# Wizard-native Customize contract (detail_embed_builder + detail_view_builder)
+# ---------------------------------------------------------------------------
+
+
+def _section_with_detail(
+    slug: str = "channels",
+) -> SetupSection:
+    """Build a SetupSection with detail builders set."""
+    embed = discord.Embed(title=f"{slug} detail")
+    detail_view = discord.ui.View()
+    embed_builder = AsyncMock(return_value=embed)
+    view_builder = MagicMock(return_value=detail_view)
+    return SetupSection(
+        slug=slug,
+        label=slug.replace("_", " ").title(),
+        style=discord.ButtonStyle.secondary,
+        run=_noop_run,
+        emoji="📡",
+        order=40,
+        op_kinds=frozenset(),
+        detail_embed_builder=embed_builder,
+        detail_view_builder=view_builder,
+    )
+
+
+def test_customize_button_enabled_when_detail_builders_set_without_legacy():
+    """A section with detail builders but no legacy customize still has
+    Customize enabled — the wizard-native path is preferred."""
+    section = _section_with_detail("channels")
+    view = LinearWizardView(
+        _owner_member(),
+        session=_session(),
+        sections=[section],
+        step_index=0,
+    )
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "setup_wizard:customize"
+    )
+    assert btn.disabled is False
+
+
+@pytest.mark.asyncio
+async def test_on_customize_prefers_wizard_native_when_detail_builders_set():
+    """When a section provides both detail builders, the wizard calls
+    render_step_detail and skips the legacy ephemeral customize."""
+    legacy_customize = AsyncMock()
+    base = _section_with_detail("channels")
+    section = SetupSection(
+        slug=base.slug,
+        label=base.label,
+        style=base.style,
+        run=base.run,
+        emoji=base.emoji,
+        order=base.order,
+        op_kinds=base.op_kinds,
+        customize=legacy_customize,
+        detail_embed_builder=base.detail_embed_builder,
+        detail_view_builder=base.detail_view_builder,
+    )
+    view = LinearWizardView(
+        _owner_member(),
+        session=_session(),
+        sections=[section],
+        step_index=0,
+    )
+    interaction = _interaction(_owner_member())
+
+    with (
+        patch(
+            "views.setup.wizard.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_session(),
+        ),
+        patch(
+            "views.setup.wizard_nav.render_step_detail",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as render_detail,
+    ):
+        await view._on_customize(interaction)
+
+    legacy_customize.assert_not_called()
+    render_detail.assert_awaited_once()
+    kw = render_detail.await_args.kwargs
+    assert kw["section"] is section
+    assert kw["step_index"] == 0
+
+
+@pytest.mark.asyncio
+async def test_on_customize_falls_back_to_legacy_when_detail_unset():
+    """A section with only legacy customize still uses the ephemeral path."""
+
+    async def legacy_customize(interaction, hub):
+        interaction.response.is_done.return_value = True
+        await interaction.response.send_message("legacy", ephemeral=True)
+
+    sections = [_section("cleanup", customize=legacy_customize)]
+    view = LinearWizardView(
+        _owner_member(),
+        session=_session(),
+        sections=sections,
+        step_index=0,
+    )
+    interaction = _interaction(_owner_member())
+
+    with (
+        patch(
+            "views.setup.wizard.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_session(),
+        ),
+        patch(
+            "views.setup.wizard.setup_draft.list_rows",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "views.setup.wizard_nav.render_step_detail",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as render_detail,
+    ):
+        await view._on_customize(interaction)
+
+    render_detail.assert_not_called()
+    interaction.followup.edit_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_full_linear_path_never_constructs_hub():
+    """Walking Apply Recommended → Continue → ... → Final Review must
+    not touch SetupHubView or build_hub_embed."""
+    from views.setup import hub as hub_module
+
+    sections = [
+        _section("cleanup_a", builder=_builder_one_op, order=10),
+        _section("cleanup_b", builder=_builder_one_op, order=20),
+    ]
+    view = LinearWizardView(
+        _owner_member(),
+        session=_session(),
+        sections=sections,
+        step_index=0,
+    )
+    interaction = _interaction(_owner_member())
+
+    def _mark_done(*args, **kwargs):
+        interaction.response.is_done.return_value = True
+
+    interaction.response.defer = AsyncMock(side_effect=_mark_done)
+
+    with (
+        patch.object(hub_module, "SetupHubView") as hub_view_mock,
+        patch.object(hub_module, "build_hub_embed") as hub_embed_mock,
+        patch(
+            "views.setup.wizard.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_session(),
+        ),
+        patch(
+            "views.setup.wizard.setup_draft.replace_recommended_for_section",
+            new_callable=AsyncMock,
+            return_value=ReplaceRecommendedResult(
+                inserted_seqs=[1],
+                deleted_count=0,
+                conflicts=[],
+            ),
+        ),
+        patch(
+            "views.setup.wizard.setup_draft.list_rows",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "views.setup.wizard.setup_draft.list_ops",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "views.setup.wizard.setup_session.unmark_section_skipped",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "views.setup.wizard.push_setup_notice",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+    ):
+        apply_btn = next(
+            c
+            for c in view.children
+            if isinstance(c, discord.ui.Button)
+            and c.custom_id == "setup_wizard:apply_recommended"
+        )
+        await apply_btn.callback(interaction)
+
+        interaction.response.is_done.return_value = False
+        cont_btn = next(
+            c
+            for c in view.children
+            if isinstance(c, discord.ui.Button)
+            and c.custom_id == "setup_wizard:continue"
+        )
+        await cont_btn.callback(interaction)
+
+        interaction.response.is_done.return_value = False
+        cont_btn = next(
+            c
+            for c in view.children
+            if isinstance(c, discord.ui.Button)
+            and c.custom_id == "setup_wizard:continue"
+        )
+        await cont_btn.callback(interaction)
+
+    hub_view_mock.assert_not_called()
+    hub_embed_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resume_picks_session_current_step():
+    """open_setup_workspace mounts the wizard at session.current_step."""
+    from views.setup import wizard as wizard_module
+
+    first = _section("zz_one", order=10)
+    second = _section("zz_two", order=20)
+    REGISTRY.register(first)
+    REGISTRY.register(second)
+    try:
+        guild = MagicMock(spec=discord.Guild)
+        guild.id = 1
+        guild.name = "Test"
+        member = _owner_member()
+        channel = _make_text_channel(7000)
+        channel.send = AsyncMock(return_value=MagicMock(id=8888))
+        session = _session(
+            current_step="zz_two",
+            setup_channel_id=channel.id,
+            setup_message_id=None,
+            depth=None,
+        )
+
+        captured: list[LinearWizardView] = []
+        original_init = LinearWizardView.__init__
+
+        def _capture_init(self, *args, **kwargs):
+            original_init(self, *args, **kwargs)
+            captured.append(self)
+
+        with (
+            patch.object(
+                wizard_module.setup_channel,
+                "ensure_setup_channel",
+                new_callable=AsyncMock,
+                return_value=(channel, False),
+            ),
+            patch.object(
+                wizard_module.setup_session,
+                "set_setup_channel_id",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                wizard_module.setup_session,
+                "set_setup_message_id",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                wizard_module.setup_session,
+                "mark_in_progress",
+                new_callable=AsyncMock,
+            ),
+            patch.object(
+                wizard_module.setup_draft,
+                "list_rows",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch.object(LinearWizardView, "__init__", _capture_init),
+        ):
+            await wizard_module.open_setup_workspace(
+                guild,
+                member=member,
+                session=session,
+            )
+
+        assert captured, "LinearWizardView was not constructed"
+        wizard_view = captured[-1]
+        assert wizard_view.sections[wizard_view.step_index].slug == "zz_two"
+    finally:
+        REGISTRY.unregister("zz_one")
+        REGISTRY.unregister("zz_two")

--- a/tests/unit/views/setup/test_wizard_hub.py
+++ b/tests/unit/views/setup/test_wizard_hub.py
@@ -1007,3 +1007,75 @@ def test_hub_embed_omits_depth_marker_when_unset():
     embed = build_hub_embed(session)
     description = (embed.description or "").lower()
     assert "depth:" not in description
+
+
+# ---------------------------------------------------------------------------
+# Hub ↩ Back to wizard button
+# ---------------------------------------------------------------------------
+
+
+def test_back_to_wizard_button_present_on_hub():
+    """Every hub view exposes the ↩ Back to wizard button."""
+    view = SetupHubView(_owner_member())
+    custom_ids = {
+        getattr(c, "custom_id", None)
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+    }
+    assert "setup_hub:back_to_wizard" in custom_ids
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+        and c.custom_id == "setup_hub:back_to_wizard"
+    )
+    assert btn.label is not None and btn.label.startswith("↩")
+
+
+@pytest.mark.asyncio
+async def test_back_to_wizard_button_invokes_render_wizard_step():
+    """Clicking ↩ Back to wizard calls wizard_nav.render_wizard_step."""
+    session = SetupSession(
+        guild_id=1,
+        guild_name="Test",
+        owner_id=99,
+        setup_status="in_progress",
+        setup_channel_id=None,
+        setup_message_id=None,
+        last_readiness_score=None,
+        current_step="identity",
+        delegated_admins=(),
+        depth="advanced",
+    )
+    member = _owner_member()
+    view = SetupHubView(member, session=session)
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 1
+    interaction = _interaction(member, guild=guild)
+
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+        and c.custom_id == "setup_hub:back_to_wizard"
+    )
+
+    with (
+        patch(
+            "views.setup.hub.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=session,
+        ),
+        patch(
+            "views.setup.wizard_nav.render_wizard_step",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as render_step,
+    ):
+        await btn.callback(interaction)
+
+    render_step.assert_awaited_once()
+    kw = render_step.await_args.kwargs
+    assert kw["guild"] is guild
+    assert kw["member"] is member
+    assert kw["step_index"] is None  # resume at current_step

--- a/tests/unit/views/setup/test_wizard_nav.py
+++ b/tests/unit/views/setup/test_wizard_nav.py
@@ -1,0 +1,313 @@
+"""Tests for the wizard navigation/rendering helper.
+
+Covers the two public functions in :mod:`views.setup.wizard_nav`:
+
+* :func:`render_wizard_step` — rebuilds the wizard anchor at a given
+  step and edits it in place via :func:`safe_edit`.
+* :func:`render_step_detail` — swaps the anchor to a section's detail
+  embed + view, with an injected ``↩ Back to step`` button on row 4
+  whose callback restores the wizard view.
+
+All tests follow the existing setup test style (``MagicMock`` + ``AsyncMock``,
+patching service modules, no real Discord or DB).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+import views.setup.sections  # noqa: F401 — populate REGISTRY for tests
+from services.setup_sections import SetupSection
+from services.setup_session import SetupSession
+from views.setup import wizard_nav
+
+
+async def _noop_run(interaction, hub):  # pragma: no cover
+    return None
+
+
+def _section(slug: str = "fake", *, with_detail: bool = False) -> SetupSection:
+    embed_builder = (
+        AsyncMock(return_value=discord.Embed(title=f"{slug} detail"))
+        if with_detail
+        else None
+    )
+    view_builder = MagicMock(return_value=discord.ui.View()) if with_detail else None
+    return SetupSection(
+        slug=slug,
+        label=slug.title(),
+        style=discord.ButtonStyle.secondary,
+        run=_noop_run,
+        emoji="🛰",
+        order=10,
+        op_kinds=frozenset(),
+        detail_embed_builder=embed_builder,
+        detail_view_builder=view_builder,
+    )
+
+
+def _session(current_step: str | None = None) -> SetupSession:
+    return SetupSession(
+        guild_id=1,
+        guild_name="Test",
+        owner_id=99,
+        setup_status="in_progress",
+        setup_channel_id=None,
+        setup_message_id=None,
+        last_readiness_score=None,
+        current_step=current_step,
+        delegated_admins=(),
+        depth=None,
+    )
+
+
+def _owner_member():
+    m = MagicMock(spec=discord.Member)
+    m.id = 99
+    m.guild = SimpleNamespace(owner_id=99)
+    m.guild_permissions = SimpleNamespace(administrator=False)
+    return m
+
+
+def _interaction(member):
+    interaction = MagicMock()
+    interaction.user = member
+    interaction.guild_id = 1
+    interaction.guild = MagicMock(id=1, name="Test", owner_id=99)
+    interaction.message = MagicMock(id=4242)
+    interaction.response = MagicMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.edit_message = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+# ---------------------------------------------------------------------------
+# render_wizard_step
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_render_wizard_step_edits_anchor_inline():
+    """render_wizard_step builds a wizard embed + view and calls safe_edit."""
+    from services.setup_sections import REGISTRY
+
+    section = _section("zz_render_test")
+    REGISTRY.register(section)
+    try:
+        guild = MagicMock(spec=discord.Guild)
+        guild.id = 1
+        member = _owner_member()
+        interaction = _interaction(member)
+        session = _session(current_step="zz_render_test")
+
+        with (
+            patch(
+                "views.setup.wizard_nav.setup_session.resume_session",
+                new_callable=AsyncMock,
+                return_value=session,
+            ),
+            patch(
+                "views.setup.wizard_nav.setup_draft.list_rows",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "views.setup.wizard_nav.safe_edit",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as safe_edit_mock,
+        ):
+            ok = await wizard_nav.render_wizard_step(
+                interaction,
+                guild=guild,
+                member=member,
+                session=session,
+                step_index=None,
+            )
+
+        assert ok is True
+        safe_edit_mock.assert_awaited_once()
+        kw = safe_edit_mock.await_args.kwargs
+        # safe_edit receives both an embed and the new wizard view.
+        assert isinstance(kw["embed"], discord.Embed)
+        from views.setup.wizard import LinearWizardView
+
+        assert isinstance(kw["view"], LinearWizardView)
+    finally:
+        REGISTRY.unregister("zz_render_test")
+
+
+# ---------------------------------------------------------------------------
+# render_step_detail
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_render_step_detail_swaps_anchor_to_detail_embed_and_view():
+    """render_step_detail edits the anchor with the section's detail
+    embed + view, with an injected Back-to-step button on row 4."""
+    section = _section("zz_detail_test", with_detail=True)
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 1
+    member = _owner_member()
+    interaction = _interaction(member)
+    session = _session()
+
+    with (
+        patch(
+            "views.setup.wizard_nav.setup_draft.list_rows",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "views.setup.wizard_nav.setup_session.mark_in_progress",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "views.setup.wizard_nav.safe_edit",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as safe_edit_mock,
+        patch(
+            "views.setup.wizard_nav.safe_defer",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+    ):
+        ok = await wizard_nav.render_step_detail(
+            interaction,
+            guild=guild,
+            member=member,
+            session=session,
+            section=section,
+            step_index=2,
+        )
+
+    assert ok is True
+    section.detail_embed_builder.assert_awaited_once()
+    section.detail_view_builder.assert_called_once()
+    safe_edit_mock.assert_awaited_once()
+    kw = safe_edit_mock.await_args.kwargs
+    view = kw["view"]
+    # The injected Back button lives on row 4 with a back_to_step custom_id.
+    back_buttons = [
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+        and c.custom_id
+        and c.custom_id.startswith("setup_wizard:back_to_step:")
+    ]
+    assert len(back_buttons) == 1
+    assert back_buttons[0].custom_id == "setup_wizard:back_to_step:2"
+    assert back_buttons[0].row == 4
+
+
+@pytest.mark.asyncio
+async def test_render_step_detail_returns_false_when_builders_missing():
+    """A section without detail builders returns False (no anchor edit)."""
+    section = _section("zz_no_detail", with_detail=False)
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 1
+    member = _owner_member()
+    interaction = _interaction(member)
+
+    with patch(
+        "views.setup.wizard_nav.safe_edit",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as safe_edit_mock:
+        ok = await wizard_nav.render_step_detail(
+            interaction,
+            guild=guild,
+            member=member,
+            session=_session(),
+            section=section,
+            step_index=0,
+        )
+
+    assert ok is False
+    safe_edit_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_back_to_step_button_callback_restores_wizard():
+    """The injected Back-to-step button calls render_wizard_step with the
+    originating step_index."""
+    section = _section("zz_back_test", with_detail=True)
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 1
+    member = _owner_member()
+    interaction = _interaction(member)
+
+    captured_view: list[discord.ui.View] = []
+
+    async def _capture_safe_edit(_interaction, *, embed=None, view=None, content=None):
+        captured_view.append(view)
+        return True
+
+    with (
+        patch(
+            "views.setup.wizard_nav.setup_draft.list_rows",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "views.setup.wizard_nav.setup_session.mark_in_progress",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "views.setup.wizard_nav.safe_edit",
+            side_effect=_capture_safe_edit,
+        ),
+        patch(
+            "views.setup.wizard_nav.safe_defer",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+    ):
+        await wizard_nav.render_step_detail(
+            interaction,
+            guild=guild,
+            member=member,
+            session=_session(),
+            section=section,
+            step_index=3,
+        )
+
+    assert captured_view, "safe_edit was not called"
+    detail_view = captured_view[0]
+    back_btn = next(
+        c
+        for c in detail_view.children
+        if isinstance(c, discord.ui.Button)
+        and c.custom_id == "setup_wizard:back_to_step:3"
+    )
+
+    # Click the Back button; assert render_wizard_step gets called.
+    back_interaction = _interaction(member)
+    with (
+        patch(
+            "views.setup.wizard_nav.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_session(),
+        ),
+        patch(
+            "views.setup.wizard_nav.render_wizard_step",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as render_wizard_mock,
+    ):
+        await back_btn.callback(back_interaction)
+
+    render_wizard_mock.assert_awaited_once()
+    kw = render_wizard_mock.await_args.kwargs
+    assert kw["step_index"] == 3


### PR DESCRIPTION
## Summary

Introduces a new wizard-native customization path for setup sections, allowing operators to view and edit section details directly within the durable workspace anchor message. This replaces the previous ephemeral "Open hub" button with a more integrated experience.

## Key Changes

### New Module: `views/setup/wizard_nav.py`
- **`render_wizard_step()`** — Rebuilds the wizard embed and view at a given step, editing the anchor message in place. Handles session refresh, section resolution, and step index clamping.
- **`render_step_detail()`** — Swaps the anchor to a section's detail embed and view by calling `section.detail_embed_builder` and `section.detail_view_builder`. Injects a "↩ Back to step" button on row 4 that restores the wizard view.
- **`_build_back_to_step_button()`** — Factory for the injected back button with a callback that re-invokes `render_wizard_step` at the originating step index.

### Updated: `views/setup/wizard.py`
- Removed the "Open hub" button from the wizard view (no longer needed; hub is reached via `/setup-hub`).
- Updated Customize button logic to enable when a section provides `detail_embed_builder` and `detail_view_builder`, even without legacy `customize` callback.
- Refactored `_on_customize()` to prefer wizard-native detail rendering when builders are present, falling back to legacy ephemeral customize only when detail builders are absent.
- Refactored `_refresh_and_edit()` to delegate to `render_wizard_step()` so all anchor rebuilds use the same code path.
- Removed `_on_open_hub()` callback entirely.

### Updated: `views/setup/hub.py`
- Added "↩ Back to wizard" button to the hub view (row 4) that calls `render_wizard_step()` to restore the wizard at the current step.

### Section Detail Builders
Added `detail_embed_builder` and `detail_view_builder` to all setup sections:
- **`channels.py`** — `_build_detail_embed()` and `_build_detail_view()` for channel configuration.
- **`logging_presets.py`** — `_build_detail_embed()` and `_build_detail_view()` for logging preset selection.
- **`identity.py`** — `_build_detail_embed()` and `_build_detail_view()` for identity/warn-threshold settings.
- **`cleanup.py`** — `_build_detail_embed()` and `_build_detail_view()` for cleanup options.
- **`cog_routing.py`** — `_build_detail_embed()` and `_build_detail_view()` for cog routing configuration.

### Updated: `services/setup_sections.py`
- Added `detail_embed_builder` and `detail_view_builder` optional fields to the `SetupSection` dataclass with documentation.

### Tests
- **`tests/unit/views/setup/test_wizard_nav.py`** (new) — Comprehensive test suite for `render_wizard_step()` and `render_step_detail()`, including back-button callback behavior and error handling.
- **`tests/unit/views/setup/test_wizard.py`** — Added tests for wizard-native customize path, Customize button enablement logic, and verification that the linear wizard path never constructs the hub.
- **`tests/unit/views/setup/test_wizard_hub.py`** — Added tests for the hub's "↩ Back to wizard" button.

## Implementation Details

- **Anchor stability**: Both `render_wizard_step()` and `render_step_detail()` use `safe_edit()` to preserve the message ID across edits.
- **Row layout**: The injected back button uses `row=4`, requiring section detail views to keep rows 0–3 free for their own components.
- **Session refresh**: `render_wizard_step()` refreshes the session from the database to reflect depth changes and skipped/acknowledged updates.
- **Error handling**: Both functions

https://claude.ai/code/session_01N4SyGWcTbUq95y9a8sfuvG