### PR TITLE
Command-access onboarding: resolver, service, and UI (PR-1 through PR-8)

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -82,8 +82,6 @@ bot = commands.Bot(
     help_command=None,
 )
 
-ALLOWED_CHANNELS = config.ALLOWED_CHANNELS
-
 
 def _begin_shutdown(*_) -> None:
     """SIGTERM handler: route through the lifecycle service so command
@@ -308,11 +306,12 @@ async def on_command_error(ctx: commands.Context, error: commands.CommandError) 
         await reporter.on_command_error(ctx, error)
 
     if isinstance(error, commands.CheckFailure):
-        # Governance check failures produce their own user-facing message.
+        # Check failures (channel-access denial, governance subsystem
+        # denial) produce their own user-facing message at the layer
+        # that raised them.  Stay silent here so the operator does
+        # not see a duplicate / generic "unexpected error" reply on
+        # top of the specific denial feedback.
         return
-
-    in_allowed = ctx.channel.id in ALLOWED_CHANNELS
-    is_force = ctx.command is not None and ctx.command.name == "force"
 
     # Log ALL non-check errors regardless of channel so bugs are never invisible.
     if not isinstance(
@@ -336,9 +335,13 @@ async def on_command_error(ctx: commands.Context, error: commands.CommandError) 
             exc_info=True,
         )
 
-    # Only send user-facing replies in allowed channels.
-    if not in_allowed and not is_force:
-        return
+    # PR-4: user-facing replies are surfaced in every channel.  The
+    # legacy ``in_allowed = ctx.channel.id in ALLOWED_CHANNELS`` gate
+    # that suppressed replies outside hardcoded channel IDs was the
+    # root cause of the "command vanished" UX — operators in fresh
+    # guilds saw nothing when a command failed.  Channel-access denial
+    # now comes from the resolver layer with its own feedback, so the
+    # error handler is free to surface every other failure mode.
 
     if isinstance(error, commands.MissingPermissions):
         await ctx.send(
@@ -383,18 +386,18 @@ async def on_command_error(ctx: commands.Context, error: commands.CommandError) 
 
 
 # ---------------------------------------------------------------------------
-# Global check — restrict commands to allowed channels; block during shutdown
+# Global command-access guard
 # ---------------------------------------------------------------------------
-
-
-@bot.check
-async def _channel_guard(ctx: commands.Context) -> bool:
-    if not _lifecycle.can_accept_commands():
-        return False
-    return ctx.guild is not None and (
-        ctx.channel.id in ALLOWED_CHANNELS
-        or (ctx.command is not None and ctx.command.name == "force")
-    )
+# The prefix admission gate lives in
+# ``disbot/cogs/bootstrap_access_cog.py``.  That cog is intentionally
+# loaded first (``config.INITIAL_EXTENSIONS[0]``) so the gate is
+# installed before any other cog registers a command.  Pre-PR-4 a
+# legacy ``@bot.check _channel_guard`` defined here was the default
+# gate that the cog then displaced at boot; deleting the legacy
+# definition leaves the cog as the single, canonical owner of the
+# admission gate and removes the dead-code branch that confused
+# readers ("is this the live check or the displaced one?").
+# ---------------------------------------------------------------------------
 
 
 # ---------------------------------------------------------------------------

--- a/disbot/cogs/bootstrap_access_cog.py
+++ b/disbot/cogs/bootstrap_access_cog.py
@@ -1,41 +1,48 @@
-"""Prefix-command admission via the central command-access resolver.
+"""Prefix + slash command admission via the central command-access resolver.
 
-This cog owns the single global ``commands.Bot`` check that gates every
-prefix command.  Loaded first (see ``INITIAL_EXTENSIONS`` ordering in
-``disbot/config.py``) so the gate is installed before any other cog
+This cog owns the two guards that gate every command:
+
+* ``bot.add_check(self._channel_guard)`` — prefix commands (PR-4).
+* ``bot.tree.interaction_check = self._slash_access_check`` — slash
+  commands + every other app command discord.py routes through the
+  tree (PR-5).
+
+Loaded first (see ``INITIAL_EXTENSIONS`` ordering in
+``disbot/config.py``) so both gates are installed before any cog
 registers a command.
 
-Pre-PR-4 the gate consulted ``config.ALLOWED_CHANNELS`` (a global env
-var with hardcoded fallback IDs) and only special-cased bootstrap
-commands.  After PR-4 the gate delegates to
-:func:`core.runtime.command_access.resolve_command_access`, which reads
-the per-guild DB-backed policy through the cached typed accessor.  The
-admin escape hatches (``!force``, bootstrap commands for guild
-operators) are preserved — the former is handled inline here, the
-latter inside the resolver.
+Both gates delegate to
+:func:`core.runtime.command_access.resolve_command_access`, which
+reads the per-guild DB-backed policy through the cached typed
+accessor.  The admin escape hatches (``!force``, bootstrap commands
+for guild operators) are preserved — the prefix-only ``!force``
+short-circuit is handled inline here, the bootstrap bypass is inside
+the resolver.
 
-The replacement is intentionally narrow:
+Denial feedback is surface-appropriate:
 
-* Resolver denial with feedback → post the feedback (delete_after=10)
-  before returning ``False`` so the channel-guard CheckFailure does
-  not look like a silent crash to the operator (PR-4 fixes the
-  "invoked but not completed" UX bug).
-* Lifecycle / DM denials are silent — feedback would race the close
-  or send into a DM context the operator did not initiate.
-* ``!force`` keeps the legacy admin override semantics (the per-
-  command ``@commands.has_permissions(administrator=True)`` on the
-  ``force`` definition is what makes the override admin-only).
+* Prefix: ``ctx.send(decision.feedback, delete_after=10)``.
+* Slash: ``interaction.response.send_message(decision.feedback,
+  ephemeral=True)`` — only the invoker sees the message and there is
+  no channel clutter.
+
+Lifecycle / DM denials carry ``feedback=None`` and stay silent on
+both surfaces; surfacing a message under shutdown would race the
+connection close.
 """
 
 from __future__ import annotations
 
 import logging
 from collections.abc import Iterable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from discord.ext import commands
 
 from core.runtime import command_access
+
+if TYPE_CHECKING:
+    import discord
 
 logger = logging.getLogger("bot.cogs.bootstrap_access")
 
@@ -60,15 +67,30 @@ def _check_is_owned_by_bootstrap_cog(check: Any) -> bool:
     return isinstance(owner, BootstrapAccessCog)
 
 
+def _interaction_check_owned_by_bootstrap_cog(tree: Any) -> bool:
+    """Return True if the tree's interaction_check is a leftover
+    bound method on a previous :class:`BootstrapAccessCog` instance.
+
+    A hot-reload leaves the previous cog's bound method on
+    ``bot.tree.interaction_check`` because discord.py has no
+    cog_unload equivalent for the tree.  :func:`setup` uses this to
+    decide whether to overwrite without warning.
+    """
+    current = getattr(tree, "interaction_check", None)
+    if current is None:
+        return False
+    owner = getattr(current, "__self__", None)
+    return isinstance(owner, BootstrapAccessCog)
+
+
 class BootstrapAccessCog(commands.Cog):
-    """Installs the central command-access guard for prefix commands."""
+    """Installs the central command-access guards for prefix + slash."""
 
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
 
     def cog_unload(self) -> None:
-        """Remove the global channel guard so a reload doesn't leave a
-        duplicate registered on the next ``setup()`` call.
+        """Remove both gates so a reload doesn't leave duplicates.
 
         ``commands.Bot.reload_extension`` calls this hook before
         re-loading the cog.  Without it, the second ``setup()`` would
@@ -76,6 +98,14 @@ class BootstrapAccessCog(commands.Cog):
         unpredictable command rejection in production guilds (one
         check accepts the command, the other rejects, depending on
         which one fires first).
+
+        The slash gate uses a different cleanup discipline because
+        ``CommandTree.interaction_check`` is a single attribute rather
+        than a list — we restore it to the discord.py default (a
+        coroutine that always returns ``True``) only if the current
+        value is our own bound method.  Anything else means another
+        consumer overwrote it post-load and we leave that consumer's
+        value intact.
         """
         try:
             self.bot.remove_check(self._channel_guard)
@@ -84,6 +114,23 @@ class BootstrapAccessCog(commands.Cog):
                 "BootstrapAccessCog.cog_unload: failed to remove "
                 "channel guard during teardown",
             )
+        tree = getattr(self.bot, "tree", None)
+        if tree is not None:
+            current = getattr(tree, "interaction_check", None)
+            if getattr(current, "__self__", None) is self:
+                try:
+                    # discord.py's CommandTree.interaction_check
+                    # default is an instance coroutine that returns
+                    # True; we cannot import the unbound original here
+                    # without coupling to a private symbol, so set the
+                    # attribute to a trivial coroutine that mirrors
+                    # that default.
+                    tree.interaction_check = _default_interaction_check
+                except Exception:
+                    logger.exception(
+                        "BootstrapAccessCog.cog_unload: failed to "
+                        "reset tree.interaction_check during teardown",
+                    )
 
     async def _channel_guard(self, ctx: commands.Context) -> bool:
         # !force is the explicit admin channel-restriction bypass.
@@ -135,21 +182,92 @@ class BootstrapAccessCog(commands.Cog):
         )
         return False
 
+    async def _slash_access_check(self, interaction: discord.Interaction) -> bool:
+        """Central admission gate for every app command.
+
+        Mirrors ``_channel_guard`` for slash invocations: builds the
+        normalized context via the resolver's interaction adapter,
+        delegates to ``resolve_command_access``, surfaces ephemeral
+        feedback on denial, returns the boolean.
+
+        discord.py raises ``app_commands.CheckFailure`` when this
+        returns ``False``; the ephemeral reply has already been sent
+        so the invoker sees the policy reason rather than the generic
+        "command failed" notice that ``on_app_command_error`` would
+        otherwise emit.
+        """
+        access_ctx = await command_access.from_interaction(interaction)
+        decision = await command_access.resolve_command_access(access_ctx)
+        if decision.allowed:
+            return True
+
+        if decision.feedback is not None:
+            try:
+                # interaction_check runs BEFORE the handler defers, so
+                # ``response.send_message`` is the right entry point
+                # (followup would 404 — no initial response yet).
+                # ``is_done`` guards the (rare) case where another
+                # observer raced ahead of us.
+                if not interaction.response.is_done():
+                    await interaction.response.send_message(
+                        decision.feedback,
+                        ephemeral=True,
+                    )
+                else:
+                    await interaction.followup.send(
+                        decision.feedback,
+                        ephemeral=True,
+                    )
+            except Exception:
+                logger.debug(
+                    "BootstrapAccessCog: failed to send slash denial "
+                    "feedback (guild=%s channel=%s command=%s reason=%s)",
+                    access_ctx.guild_id,
+                    access_ctx.channel_id,
+                    access_ctx.command_name,
+                    decision.reason.value,
+                )
+
+        logger.info(
+            "command_access deny | guild=%s channel=%s user=%s command=%s "
+            "invocation=slash reason=%s source=%s mode=%s",
+            access_ctx.guild_id,
+            access_ctx.channel_id,
+            access_ctx.user_id,
+            access_ctx.command_name,
+            decision.reason.value,
+            decision.source.value,
+            decision.mode.value if decision.mode is not None else None,
+        )
+        return False
+
+
+async def _default_interaction_check(_interaction: discord.Interaction) -> bool:
+    """Match discord.py's default ``CommandTree.interaction_check`` shape.
+
+    Defined at module scope so :meth:`BootstrapAccessCog.cog_unload`
+    can restore it without re-creating a closure on every unload (the
+    closure case would also keep the cog instance alive through the
+    bound-method ``__self__`` link).
+    """
+    return True
+
 
 async def setup(bot: commands.Bot) -> None:
-    """Install the central command-access guard.
+    """Install the central command-access guards.
 
-    Reload-safe: if a previous BootstrapAccessCog left its check
-    installed (e.g. a Discord interaction was running during reload
-    and ``cog_unload`` couldn't fire cleanly), the leftover check is
-    removed before we install ours.  This stops double-load from
-    silently breaking command access in production guilds.
+    Reload-safe on both surfaces:
 
-    Also removes any leftover ``_channel_guard`` check from a previous
-    boot — historically the cog had to displace a check defined in
-    ``bot1.py``; that definition is gone post-PR-4 but the cleanup
-    sweep is retained so a hot-reload from an older codebase still
-    settles to a single check.
+    * Prefix: any leftover ``_channel_guard`` check (legacy from a
+      pre-PR-4 ``bot1.py`` definition, or a remnant from a previous
+      :class:`BootstrapAccessCog` instance that didn't clean up
+      cleanly) is removed before installing the new one.
+    * Slash: any ``tree.interaction_check`` already owned by a
+      previous :class:`BootstrapAccessCog` instance is overwritten
+      silently; an unfamiliar value (someone else installed their
+      own check) is *also* overwritten, with a WARNING log so the
+      conflict is visible.  Leaving an unfamiliar value in place
+      would silently bypass policy for every slash command.
     """
     existing_checks = _find_channel_guard_checks(bot)
     legacy_count = sum(
@@ -160,12 +278,32 @@ async def setup(bot: commands.Bot) -> None:
         bot.remove_check(guard)
     cog = BootstrapAccessCog(bot)
     bot.add_check(cog._channel_guard)
+
+    tree = getattr(bot, "tree", None)
+    tree_overwrite_kind = "none"
+    if tree is not None:
+        if _interaction_check_owned_by_bootstrap_cog(tree):
+            tree_overwrite_kind = "bootstrap_remnant"
+        elif getattr(tree, "interaction_check", None) is _default_interaction_check:
+            tree_overwrite_kind = "default_post_unload"
+        else:
+            # Either discord.py's default (an instance coroutine we
+            # can't reliably introspect across versions) or some other
+            # value.  We unconditionally take ownership because
+            # BootstrapAccessCog is loaded first and must be the only
+            # gate; a downstream cog that wants to extend admission
+            # logic can compose into the resolver rather than
+            # overwriting our installed check.
+            tree_overwrite_kind = "default_or_unknown"
+        tree.interaction_check = cog._slash_access_check
+
     await bot.add_cog(cog)
     logger.info(
         "BootstrapAccessCog loaded; replaced %d legacy guard(s) + "
-        "cleaned %d bootstrap remnant(s).",
+        "cleaned %d bootstrap remnant(s); slash tree overwrite=%s.",
         legacy_count,
         remnant_count,
+        tree_overwrite_kind,
     )
 
 

--- a/disbot/cogs/bootstrap_access_cog.py
+++ b/disbot/cogs/bootstrap_access_cog.py
@@ -1,18 +1,30 @@
-"""Fresh-guild bootstrap access wiring.
+"""Prefix-command admission via the central command-access resolver.
 
-This cog is intentionally loaded first.  It replaces the legacy entry-point
-channel guard with the centralized helper from
-``core.runtime.command_access`` so setup/help/platform/admin/settings commands
-remain reachable for guild operators before a new server has configured bot
-channels.
+This cog owns the single global ``commands.Bot`` check that gates every
+prefix command.  Loaded first (see ``INITIAL_EXTENSIONS`` ordering in
+``disbot/config.py``) so the gate is installed before any other cog
+registers a command.
 
-The replacement stays narrow:
+Pre-PR-4 the gate consulted ``config.ALLOWED_CHANNELS`` (a global env
+var with hardcoded fallback IDs) and only special-cased bootstrap
+commands.  After PR-4 the gate delegates to
+:func:`core.runtime.command_access.resolve_command_access`, which reads
+the per-guild DB-backed policy through the cached typed accessor.  The
+admin escape hatches (``!force``, bootstrap commands for guild
+operators) are preserved — the former is handled inline here, the
+latter inside the resolver.
 
-* normal commands still require ``BOT_ALLOWED_CHANNELS``;
-* ``!force`` remains the explicit admin escape hatch;
-* bootstrap bypass only applies to guild owners, administrators,
-  ``manage_guild`` members, and bot owners;
-* command-level permission decorators still run after this guard.
+The replacement is intentionally narrow:
+
+* Resolver denial with feedback → post the feedback (delete_after=10)
+  before returning ``False`` so the channel-guard CheckFailure does
+  not look like a silent crash to the operator (PR-4 fixes the
+  "invoked but not completed" UX bug).
+* Lifecycle / DM denials are silent — feedback would race the close
+  or send into a DM context the operator did not initiate.
+* ``!force`` keeps the legacy admin override semantics (the per-
+  command ``@commands.has_permissions(administrator=True)`` on the
+  ``force`` definition is what makes the override admin-only).
 """
 
 from __future__ import annotations
@@ -23,12 +35,7 @@ from typing import Any
 
 from discord.ext import commands
 
-import config
-from core.runtime import lifecycle
-from core.runtime.command_access import (
-    can_bypass_channel_guard,
-    is_bootstrap_command,
-)
+from core.runtime import command_access
 
 logger = logging.getLogger("bot.cogs.bootstrap_access")
 
@@ -53,15 +60,8 @@ def _check_is_owned_by_bootstrap_cog(check: Any) -> bool:
     return isinstance(owner, BootstrapAccessCog)
 
 
-def _command_name(ctx: commands.Context) -> str | None:
-    command = getattr(ctx, "command", None)
-    if command is None:
-        return getattr(ctx, "invoked_with", None)
-    return getattr(command, "qualified_name", None) or getattr(command, "name", None)
-
-
 class BootstrapAccessCog(commands.Cog):
-    """Installs the fresh-guild-aware global channel guard."""
+    """Installs the central command-access guard for prefix commands."""
 
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
@@ -86,72 +86,70 @@ class BootstrapAccessCog(commands.Cog):
             )
 
     async def _channel_guard(self, ctx: commands.Context) -> bool:
-        # LP-2: command admission is owned by the lifecycle service.
-        # Previously this read ``_shutting_down`` from the legacy guard's
-        # ``__globals__`` — that lookup is gone now that bot1.py routes
-        # SIGTERM through ``lifecycle.request_shutdown``.
-        if not lifecycle.can_accept_commands():
-            return False
-        if ctx.guild is None:
-            return False
-        if ctx.channel.id in config.ALLOWED_CHANNELS:
+        # !force is the explicit admin channel-restriction bypass.
+        # Per-command ``@commands.has_permissions(administrator=True)``
+        # on the ``force`` definition is what makes it admin-only; here
+        # we only short-circuit the policy check so admins can use the
+        # override under ``selected_channels`` / ``disabled`` modes.
+        command = getattr(ctx, "command", None)
+        if command is not None and getattr(command, "name", None) == "force":
             return True
-        if ctx.command is not None and ctx.command.name == "force":
+
+        access_ctx = await command_access.from_prefix_ctx(ctx)
+        decision = await command_access.resolve_command_access(access_ctx)
+        if decision.allowed:
             return True
-        return await can_bypass_channel_guard(ctx)
 
-    @commands.Cog.listener()
-    async def on_command_error(
-        self,
-        ctx: commands.Context,
-        error: commands.CommandError,
-    ) -> None:
-        """Surface bootstrap permission/usage errors outside allowed channels.
-
-        The entry-point ``bot1.on_command_error`` intentionally suppresses
-        user-facing replies outside ``BOT_ALLOWED_CHANNELS``.  Once bootstrap
-        commands can bypass that channel guard, operators still need feedback
-        for ordinary decorator failures such as ``MissingPermissions`` or a
-        bad argument.  Only bootstrap commands outside allowed channels are
-        handled here, so normal command channels keep the existing behavior.
-        """
-        if ctx.guild is None or ctx.channel.id in config.ALLOWED_CHANNELS:
-            return
-        if not is_bootstrap_command(_command_name(ctx)):
-            return
-
-        if isinstance(error, commands.MissingPermissions):
-            await ctx.send(
-                "❌ You do not have permission to use this bootstrap command.",
-                delete_after=10,
-            )
-        elif isinstance(error, commands.BotMissingPermissions):
-            await ctx.send(
-                f"❌ I'm missing permissions to do that: `{error.missing_permissions}`",
-                delete_after=10,
-            )
-        elif isinstance(error, commands.MissingRequiredArgument):
-            await ctx.send(
-                f"⚠️ Missing argument: `{error.param.name}`. Use `!help {ctx.command}` for usage.",
-                delete_after=10,
-            )
-        elif isinstance(error, commands.BadArgument):
-            await ctx.send(f"⚠️ Bad argument: {error}", delete_after=10)
-        elif isinstance(error, commands.CommandOnCooldown):
-            await ctx.send(
-                f"⏰ This command is on cooldown. Try again in **{error.retry_after:.1f}s**.",
-                delete_after=8,
-            )
+        # Surface the resolver's user-facing feedback before returning
+        # False — otherwise the CheckFailure raised by discord.py
+        # produces no reply and the operator sees the same "invoked
+        # but not completed" silent failure that PR-4 was written to
+        # eliminate.  Lifecycle / DM denials carry feedback=None on
+        # purpose and stay silent.
+        if decision.feedback is not None:
+            try:
+                await ctx.send(decision.feedback, delete_after=10)
+            except Exception:
+                logger.debug(
+                    "BootstrapAccessCog: failed to send denial feedback "
+                    "(guild=%s channel=%s command=%s reason=%s)",
+                    access_ctx.guild_id,
+                    access_ctx.channel_id,
+                    access_ctx.command_name,
+                    decision.reason.value,
+                )
+        # Structured log so denials are observable as intentional
+        # decisions rather than vanishing into the "CheckFailure"
+        # silence.  Distinct from on_command_error which sees a
+        # generic CheckFailure with no context.
+        logger.info(
+            "command_access deny | guild=%s channel=%s user=%s command=%s "
+            "invocation=prefix reason=%s source=%s mode=%s",
+            access_ctx.guild_id,
+            access_ctx.channel_id,
+            access_ctx.user_id,
+            access_ctx.command_name,
+            decision.reason.value,
+            decision.source.value,
+            decision.mode.value if decision.mode is not None else None,
+        )
+        return False
 
 
 async def setup(bot: commands.Bot) -> None:
-    """Replace the legacy channel guard with the fresh-guild-aware version.
+    """Install the central command-access guard.
 
     Reload-safe: if a previous BootstrapAccessCog left its check
     installed (e.g. a Discord interaction was running during reload
     and ``cog_unload`` couldn't fire cleanly), the leftover check is
     removed before we install ours.  This stops double-load from
     silently breaking command access in production guilds.
+
+    Also removes any leftover ``_channel_guard`` check from a previous
+    boot — historically the cog had to displace a check defined in
+    ``bot1.py``; that definition is gone post-PR-4 but the cleanup
+    sweep is retained so a hot-reload from an older codebase still
+    settles to a single check.
     """
     existing_checks = _find_channel_guard_checks(bot)
     legacy_count = sum(

--- a/disbot/cogs/diagnostic/_platform_embeds.py
+++ b/disbot/cogs/diagnostic/_platform_embeds.py
@@ -1270,10 +1270,166 @@ async def build_setup_readiness_embed(
     return embed
 
 
+async def build_command_access_diagnostic_embed(
+    *,
+    ctx: commands.Context,
+    target_channel: discord.abc.GuildChannel,
+) -> discord.Embed:
+    """Render the live command-access decision for ``target_channel``.
+
+    Closes the "command vanished" debugging loop the command-access
+    onboarding fix exists to fix: the operator can ask the bot
+    directly "would `!bj` work here, and if not, why" and get a
+    structured answer that names the mode, the source, the reason,
+    and the recovery path.
+
+    The probe runs the real resolver with a synthetic
+    :class:`CommandAccessContext`, scoring the channel as if a
+    non-bootstrap normal command (``blackjack``) were invoked there
+    by the requesting operator.  This mirrors the most common
+    operator-facing failure mode — the one that prompted the entire
+    fix — instead of probing with a bootstrap command that would
+    bypass the policy and tell us nothing.
+    """
+    from core.runtime.command_access import (
+        AccessMode,
+        CommandAccessContext,
+        resolve_command_access,
+    )
+    from services.command_access_service import get_policy_snapshot
+
+    guild = ctx.guild
+    guild_id = guild.id if guild is not None else None
+    snapshot = await get_policy_snapshot(guild_id) if guild_id is not None else None
+
+    author = ctx.author
+    perms = getattr(author, "guild_permissions", None)
+    is_operator = bool(
+        perms
+        and (
+            getattr(perms, "administrator", False)
+            or getattr(perms, "manage_guild", False)
+        ),
+    )
+    if hasattr(ctx.bot, "is_owner"):
+        is_bot_owner = await ctx.bot.is_owner(author)
+    else:
+        is_bot_owner = False
+
+    probe_ctx = CommandAccessContext(
+        guild_id=guild_id,
+        channel_id=target_channel.id,
+        user_id=author.id,
+        command_name="blackjack",  # synthetic non-bootstrap probe
+        invocation_type="prefix",
+        is_guild_operator=is_operator,
+        is_bot_owner=bool(is_bot_owner),
+        is_dm=guild is None,
+    )
+    decision = await resolve_command_access(probe_ctx)
+
+    title_emoji = "✅" if decision.allowed else "🚫"
+    embed = discord.Embed(
+        title=f"{title_emoji} Command Access — {target_channel.mention}",
+        color=discord.Color.green() if decision.allowed else discord.Color.red(),
+    )
+
+    if snapshot is None or snapshot.mode is None:
+        embed.add_field(
+            name="Configured mode",
+            value="`all_channels` (default — no policy row in this guild)",
+            inline=False,
+        )
+    else:
+        embed.add_field(
+            name="Configured mode",
+            value=f"`{snapshot.mode}`",
+            inline=False,
+        )
+
+    if snapshot is not None and snapshot.allowed_channels:
+        listed = " ".join(f"<#{cid}>" for cid in sorted(snapshot.allowed_channels))
+        if len(listed) > 950:
+            head = " ".join(
+                f"<#{cid}>" for cid in sorted(snapshot.allowed_channels)[:30]
+            )
+            listed = f"{head} … (+{len(snapshot.allowed_channels) - 30} more)"
+        embed.add_field(
+            name=f"Allowed channels ({len(snapshot.allowed_channels)})",
+            value=listed,
+            inline=False,
+        )
+
+    embed.add_field(
+        name="Would a normal command run here?",
+        value=("**Yes** — admitted." if decision.allowed else "**No** — denied."),
+        inline=False,
+    )
+    embed.add_field(
+        name="Decision details",
+        value=(
+            f"`reason`: {decision.reason.value}\n"
+            f"`source`: {decision.source.value}\n"
+            f"`effective_mode`: "
+            f"{decision.mode.value if decision.mode is not None else 'n/a'}\n"
+            f"`prefix_enabled`: yes\n"
+            f"`slash_enabled`: yes  *(same admission chain)*"
+        ),
+        inline=False,
+    )
+
+    bootstrap_ctx = CommandAccessContext(
+        guild_id=guild_id,
+        channel_id=target_channel.id,
+        user_id=author.id,
+        command_name="setup",
+        invocation_type="prefix",
+        is_guild_operator=is_operator,
+        is_bot_owner=bool(is_bot_owner),
+        is_dm=guild is None,
+    )
+    bootstrap_decision = await resolve_command_access(bootstrap_ctx)
+    embed.add_field(
+        name="Bootstrap probe (`!setup` for this operator)",
+        value=(
+            "✅ allowed via `bootstrap_bypass`"
+            if bootstrap_decision.allowed
+            else f"🚫 denied — reason `{bootstrap_decision.reason.value}`"
+        ),
+        inline=False,
+    )
+
+    if decision.feedback is not None:
+        embed.add_field(
+            name="Operator-facing feedback (sent on real invocations)",
+            value=decision.feedback,
+            inline=False,
+        )
+
+    if decision.mode is AccessMode.DISABLED_EXCEPT_BOOTSTRAP:
+        embed.add_field(
+            name="Recovery",
+            value=(
+                "Open `!settings → Command access` to switch the mode, "
+                "or run `!setup` to revisit onboarding."
+            ),
+            inline=False,
+        )
+
+    embed.set_footer(
+        text=(
+            "Probe was synthetic; no audit row was emitted.  "
+            "Configure via `!settings → Command access`."
+        ),
+    )
+    return embed
+
+
 __all__ = [
     "build_anchors_embed",
     "build_bindings_embed",
     "build_caches_embed",
+    "build_command_access_diagnostic_embed",
     "build_consistency_embed",
     "build_customization_embed",
     "build_flags_embed",

--- a/disbot/cogs/diagnostic_cog.py
+++ b/disbot/cogs/diagnostic_cog.py
@@ -490,6 +490,35 @@ class DiagnosticCog(commands.Cog):
         report = await collect_report(bot=self.bot, guild=ctx.guild)
         await ctx.send(embed=build_consistency_embed(report))
 
+    @platform_grp.command(  # type: ignore[arg-type]
+        name="command-access",
+        aliases=["commandaccess"],
+    )
+    @commands.has_permissions(administrator=True)
+    async def platform_command_access(
+        self,
+        ctx,
+        channel: discord.TextChannel | None = None,
+    ):
+        """Show the live command-access decision for a channel.
+
+        Defaults to the invoking channel.  Output covers every input
+        the resolver consumed to make its decision so operators can
+        see at a glance why ``!bj`` (or ``/blackjack``) succeeded or
+        denied here — closes the "command vanished" debugging loop
+        the command-access onboarding fix was written to eliminate.
+        """
+        from cogs.diagnostic._platform_embeds import (
+            build_command_access_diagnostic_embed,
+        )
+
+        target = channel or ctx.channel
+        embed = await build_command_access_diagnostic_embed(
+            ctx=ctx,
+            target_channel=target,
+        )
+        await ctx.send(embed=embed)
+
 
 async def setup(bot):
     await bot.add_cog(DiagnosticCog(bot))

--- a/disbot/config.py
+++ b/disbot/config.py
@@ -31,11 +31,11 @@ PREFIX = os.getenv("BOT_PREFIX", "!")
 # Initial Cogs (Extensions)
 # ==========================
 INITIAL_EXTENSIONS = [
-    # bootstrap_access_cog MUST load first: it replaces the legacy
-    # `_channel_guard` defined in bot1.py with a fresh-guild-aware guard
-    # so guild operators can run !help / !setup / !platform / !diagnostics /
-    # !adminmenu / !settings / !syncslash before BOT_ALLOWED_CHANNELS is
-    # configured. Reordering this entry breaks fresh-guild onboarding.
+    # bootstrap_access_cog MUST load first: it installs the central
+    # command-access guard (prefix + slash) that gates every command
+    # invocation.  Reordering this entry would leave a window where
+    # commands could be admitted before the policy resolver is wired
+    # in.  See `docs/architecture.md` for the admission chain.
     "cogs.bootstrap_access_cog",
     "cogs.admin_cog",
     "cogs.help_cog",
@@ -76,6 +76,16 @@ LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
 # ==========================
 # Channel Restrictions
 # ==========================
+# Command admission (where prefix + slash commands are allowed) is
+# owned by the per-guild ``guild_command_access_policy`` table
+# (migration 050) and read through
+# :func:`core.runtime.command_access.resolve_command_access`.  The
+# pre-PR-7 ``BOT_ALLOWED_CHANNELS`` env var + hardcoded fallback
+# channel IDs are gone; main-server channels are seeded by migration
+# 051 so existing behavior is preserved.  Configure new guilds via
+# ``!settings → Command access``.
+
+
 def _parse_channel_ids(env_key: str, fallback: list[int]) -> set[int]:
     raw = os.getenv(env_key, "")
     if raw.strip():
@@ -86,13 +96,11 @@ def _parse_channel_ids(env_key: str, fallback: list[int]) -> set[int]:
     return set(fallback)
 
 
-# Channels where bot commands are allowed
-ALLOWED_CHANNELS: set[int] = _parse_channel_ids(
-    "BOT_ALLOWED_CHANNELS",
-    [1348795460948590622, 1403818013408624642],
-)
-
-# Channels exempt from the cleanup cog's command-deletion rule
+# Channels exempt from the cleanup cog's command-deletion rule.
+# Still env-driven because cleanup whitelist is a separate concern
+# from command-access policy and is consumed by ``cogs/cleanup_cog.py``
+# at scope-resolution time.  A future PR can migrate this to a
+# DB-backed per-guild policy along the same shape as command access.
 CLEANUP_WHITELIST_CHANNELS: set[int] = _parse_channel_ids(
     "BOT_CLEANUP_WHITELIST",
     [

--- a/disbot/core/runtime/command_access.py
+++ b/disbot/core/runtime/command_access.py
@@ -71,17 +71,34 @@ BOOTSTRAP_COMMANDS: frozenset[str] = frozenset(
 def is_bootstrap_command(command_name: str | None) -> bool:
     """Return ``True`` if ``command_name`` is a bootstrap command.
 
-    Accepts both bare names (``"help"``) and qualified group names
-    (``"platform identity"``).  The root of a qualified name is checked so
-    existing platform/settings/admin subcommands inherit their parent gate.
+    Accepts three spellings so prefix groups, slash sub-commands, and
+    operator-namespaced slash commands all classify consistently:
+
+    * bare names (``"help"``)
+    * qualified group names — whitespace-separated, the discord.py
+      prefix-group convention (``"platform identity"``)
+    * hyphen-namespaced slash commands (``"setup-hub"``) — discord.py
+      forbids whitespace in slash names so operators ship multi-token
+      setup commands as ``setup-*``; treating ``setup`` as the root
+      keeps the bootstrap bypass consistent across prefix + slash.
+
+    A hyphen-root match only widens the set within the existing
+    bootstrap surface (``setup-*``, ``settings-*``, ``admin-*``,
+    ``platform-*``, ``help-*``, ``diagnostics-*``) — every other
+    command name is unaffected.
     """
     if not command_name:
         return False
     normalized = command_name.strip().lower()
     if not normalized:
         return False
-    root = normalized.split(maxsplit=1)[0]
-    return normalized in BOOTSTRAP_COMMANDS or root in BOOTSTRAP_COMMANDS
+    if normalized in BOOTSTRAP_COMMANDS:
+        return True
+    space_root = normalized.split(maxsplit=1)[0]
+    if space_root in BOOTSTRAP_COMMANDS:
+        return True
+    hyphen_root = normalized.split("-", maxsplit=1)[0]
+    return hyphen_root in BOOTSTRAP_COMMANDS
 
 
 def _candidate_command_names(ctx: commands.Context) -> Iterable[str]:

--- a/disbot/core/runtime/command_access.py
+++ b/disbot/core/runtime/command_access.py
@@ -274,6 +274,51 @@ async def resolve_command_access(
     4. **Policy mode** — looks up the cached per-guild policy.  Absence
        of a policy is the safe default: ``ALL_CHANNELS`` with
        ``DEFAULT_UNCONFIGURED`` source.
+
+    Every decision (allow + deny) emits
+    :data:`services.metrics.command_access_decisions_total` exactly
+    once via :func:`_emit_decision_metric` so Prometheus sees a
+    complete picture of who is asking, what answer they got, and why.
+    """
+    decision = await _decide(ctx)
+    _emit_decision_metric(ctx, decision)
+    return decision
+
+
+def _emit_decision_metric(
+    ctx: CommandAccessContext,
+    decision: CommandAccessDecision,
+) -> None:
+    """Increment the per-decision counter; best-effort, never raises.
+
+    Called exactly once per :func:`resolve_command_access` invocation
+    so allow + deny are both observable.  The lazy import keeps
+    ``services.metrics`` out of the test fixtures that import
+    ``core.runtime.command_access`` without the rest of the
+    runtime.
+    """
+    try:
+        from services import metrics as _metrics
+
+        _metrics.command_access_decisions_total.labels(
+            invocation=ctx.invocation_type,
+            decision="allow" if decision.allowed else "deny",
+            reason=decision.reason.value,
+            mode=decision.mode.value if decision.mode is not None else "none",
+            source=decision.source.value,
+        ).inc()
+    except Exception:
+        # Metrics are advisory — never fail admission because a
+        # counter raised.  prom-client failures land in the bot log
+        # via the metrics module's own exception handling.
+        pass
+
+
+async def _decide(ctx: CommandAccessContext) -> CommandAccessDecision:
+    """Inner admission logic — every branch returns a frozen
+    :class:`CommandAccessDecision`.  Split from
+    :func:`resolve_command_access` so the metric emit can wrap the
+    whole chain without per-branch duplication.
     """
     # Local import avoids a hard dep at module import time so test
     # fixtures that monkeypatch ``lifecycle.can_accept_commands`` keep

--- a/disbot/core/runtime/command_access.py
+++ b/disbot/core/runtime/command_access.py
@@ -1,24 +1,42 @@
-"""Command-access helpers for fresh-guild bootstrap flows.
+"""Command-access resolver + bootstrap helpers.
 
-The global channel guard in ``bot1.py`` restricts most prefix commands to
-``BOT_ALLOWED_CHANNELS``.  That is appropriate for day-to-day command
-traffic, but it can strand a newly invited guild: the operator needs a
-small, safe set of setup / diagnostics entry points before the guild has
-configured channel bindings or command-policy state.
+Two responsibilities, owned together because they share the bootstrap
+allowlist and the operator-privilege check:
 
-This module owns that exception in one place.  It does not execute command
-logic and it does not bypass command-level permission decorators; it only
-answers whether the entry-point channel guard may let a bootstrap command
-reach the normal discord.py checks.
+1. **Resolver** (PR-2 of the command-access onboarding fix) — given a
+   normalized :class:`CommandAccessContext` (built by an adapter from
+   either ``commands.Context`` or ``discord.Interaction``), returns a
+   :class:`CommandAccessDecision` describing whether the command may
+   run, why, and what user-facing feedback the entry-point should
+   surface on denial.  Reads cached per-guild policy through the
+   ``utils.guild_config_accessors`` typed accessor.
+
+2. **Bootstrap helpers** (existing pre-PR-2 API, retained) —
+   :data:`BOOTSTRAP_COMMANDS`, :func:`is_bootstrap_command`, and
+   :func:`can_bypass_channel_guard`.  Other modules still import these
+   directly; keeping the public surface stable lets PR-2 ship without
+   touching every existing caller.
+
+The resolver does not bypass per-command permission decorators.  It
+only answers whether the *entry-point* (prefix global check, slash
+``tree.interaction_check``) should let the command through to the
+normal discord.py check chain.
 """
 
 from __future__ import annotations
 
+import enum
 from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    import discord
     from discord.ext import commands
+
+# ---------------------------------------------------------------------------
+# Bootstrap allowlist (existing API)
+# ---------------------------------------------------------------------------
 
 BOOTSTRAP_COMMANDS: frozenset[str] = frozenset(
     {
@@ -99,7 +117,7 @@ def _is_guild_operator(author: Any, guild: Any) -> bool:
     )
 
 
-async def _is_bot_owner(ctx: commands.Context) -> bool:
+async def _is_bot_owner_from_ctx(ctx: commands.Context) -> bool:
     """Best-effort bot-owner check used as an operator escape hatch."""
     bot = getattr(ctx, "bot", None)
     is_owner = getattr(bot, "is_owner", None)
@@ -114,17 +132,15 @@ async def _is_bot_owner(ctx: commands.Context) -> bool:
 async def can_bypass_channel_guard(ctx: commands.Context) -> bool:
     """Return whether ``ctx`` may bypass the global channel allowlist.
 
-    This is deliberately narrower than command authorization:
+    Pre-PR-2 entry point used directly by ``BootstrapAccessCog._channel_guard``;
+    retained so prefix-path callers do not break while PR-4 wires the
+    cog over to the full resolver.  Behaviour is identical to the
+    pre-PR-2 implementation:
 
     * DMs never bypass; setup is guild-scoped.
     * Non-bootstrap commands never bypass.
     * The guild owner, administrators, members with ``manage_guild``, and
       bot owners may bypass for bootstrap commands only.
-
-    Command-specific decorators such as ``@commands.has_permissions`` still
-    run after this check, so this helper does not grant access to the command
-    itself.  It only prevents fresh-guild operators from being blocked before
-    setup can run.
     """
     guild = getattr(ctx, "guild", None)
     if guild is None:
@@ -137,11 +153,325 @@ async def can_bypass_channel_guard(ctx: commands.Context) -> bool:
     if _is_guild_operator(author, guild):
         return True
 
-    return await _is_bot_owner(ctx)
+    return await _is_bot_owner_from_ctx(ctx)
+
+
+# ---------------------------------------------------------------------------
+# Resolver — decision model (PR-2)
+# ---------------------------------------------------------------------------
+
+
+class AccessMode(enum.Enum):
+    """Per-guild command-access modes (mirrors the DB CHECK constraint)."""
+
+    ALL_CHANNELS = "all_channels"
+    SELECTED_CHANNELS = "selected_channels"
+    DISABLED_EXCEPT_BOOTSTRAP = "disabled_except_bootstrap"
+
+
+class DecisionSource(enum.Enum):
+    """Where the admission decision came from."""
+
+    DB_POLICY = "db_policy"
+    BOOTSTRAP_BYPASS = "bootstrap_bypass"
+    DEFAULT_UNCONFIGURED = "default_unconfigured"
+    LIFECYCLE_DENY = "lifecycle_deny"
+
+
+class DecisionReason(enum.Enum):
+    """Machine-readable reason for the decision — used by logs + metrics."""
+
+    ALLOWED = "allowed"
+    BOOTSTRAP_BYPASS = "bootstrap_bypass"
+    LIFECYCLE_DRAINING = "lifecycle_draining"
+    DM_NOT_SUPPORTED = "dm_not_supported"
+    CHANNEL_NOT_ALLOWED = "channel_not_allowed"
+    COMMANDS_DISABLED = "commands_disabled"
+
+
+@dataclass(frozen=True)
+class CommandAccessContext:
+    """Normalized input to the resolver — see :func:`from_prefix_ctx` and
+    :func:`from_interaction` for the adapters that build one from a
+    ``commands.Context`` or a ``discord.Interaction``.
+    """
+
+    guild_id: int | None
+    channel_id: int | None
+    user_id: int | None
+    command_name: str | None
+    invocation_type: str  # "prefix" | "slash"
+    is_guild_operator: bool
+    is_bot_owner: bool
+    is_dm: bool
+
+
+@dataclass(frozen=True)
+class CommandAccessDecision:
+    """Result of :func:`resolve_command_access`.
+
+    ``feedback`` is the user-facing message the entry-point should
+    surface (ephemeral for slash; ``ctx.send`` with ``delete_after`` for
+    prefix).  ``None`` means no message — either the command is allowed,
+    or the denial is deliberately silent (lifecycle drain).
+    """
+
+    allowed: bool
+    reason: DecisionReason
+    source: DecisionSource
+    mode: AccessMode | None
+    feedback: str | None
+
+
+_FEEDBACK_COMMANDS_DISABLED = (
+    "Commands are disabled in this server. "
+    "Ask a server admin to enable them via `!setup` or the "
+    "Command Access settings panel."
+)
+
+_FEEDBACK_CHANNEL_NOT_ALLOWED = (
+    "Commands aren't enabled in this channel. "
+    "Use one of the configured command channels or ask an admin to "
+    "update Command Access in `!settings`."
+)
+
+
+async def resolve_command_access(
+    ctx: CommandAccessContext,
+) -> CommandAccessDecision:
+    """Resolve admission for a single command invocation.
+
+    Order of checks (matches the admission chain in the plan):
+
+    1. **Lifecycle drain** — when the bot is shutting down / restarting,
+       every command is denied silently.  Surfacing feedback would race
+       with the connection close.
+    2. **DM** — this resolver does not own DM admission.  DMs always
+       reach the existing per-command handler unchanged: the resolver
+       reports the decision but with ``allowed=False`` so the
+       entry-point can route them past the channel-policy check.
+    3. **Bootstrap bypass** — guild operators (owner / admin /
+       manage_guild) and bot owners may run bootstrap commands
+       regardless of policy.  Per-command permission decorators still
+       run after this bypass.
+    4. **Policy mode** — looks up the cached per-guild policy.  Absence
+       of a policy is the safe default: ``ALL_CHANNELS`` with
+       ``DEFAULT_UNCONFIGURED`` source.
+    """
+    # Local import avoids a hard dep at module import time so test
+    # fixtures that monkeypatch ``lifecycle.can_accept_commands`` keep
+    # working.  ``core.runtime.lifecycle`` has no transitive Discord
+    # imports — this is a deferral for clarity, not necessity.
+    from core.runtime import lifecycle
+
+    if not lifecycle.can_accept_commands():
+        return CommandAccessDecision(
+            allowed=False,
+            reason=DecisionReason.LIFECYCLE_DRAINING,
+            source=DecisionSource.LIFECYCLE_DENY,
+            mode=None,
+            feedback=None,
+        )
+
+    if ctx.is_dm or ctx.guild_id is None:
+        # The resolver is guild-scoped.  Entry-points may still permit
+        # DM commands via the per-command opt-in (commands.dm_only,
+        # app_commands.allowed_contexts) — that path runs after this
+        # decision is returned.
+        return CommandAccessDecision(
+            allowed=False,
+            reason=DecisionReason.DM_NOT_SUPPORTED,
+            source=DecisionSource.DEFAULT_UNCONFIGURED,
+            mode=None,
+            feedback=None,
+        )
+
+    if is_bootstrap_command(ctx.command_name) and (
+        ctx.is_guild_operator or ctx.is_bot_owner
+    ):
+        return CommandAccessDecision(
+            allowed=True,
+            reason=DecisionReason.BOOTSTRAP_BYPASS,
+            source=DecisionSource.BOOTSTRAP_BYPASS,
+            mode=None,
+            feedback=None,
+        )
+
+    # Hot-path cached read.  Loader returns ``None`` when no policy row
+    # exists; the resolver treats that as the safe default.
+    from utils.guild_config_accessors import get_command_access_policy
+
+    snapshot = await get_command_access_policy(ctx.guild_id)
+    if snapshot.mode is None:
+        return CommandAccessDecision(
+            allowed=True,
+            reason=DecisionReason.ALLOWED,
+            source=DecisionSource.DEFAULT_UNCONFIGURED,
+            mode=AccessMode.ALL_CHANNELS,
+            feedback=None,
+        )
+
+    mode = AccessMode(snapshot.mode)
+
+    if mode is AccessMode.ALL_CHANNELS:
+        return CommandAccessDecision(
+            allowed=True,
+            reason=DecisionReason.ALLOWED,
+            source=DecisionSource.DB_POLICY,
+            mode=mode,
+            feedback=None,
+        )
+
+    if mode is AccessMode.DISABLED_EXCEPT_BOOTSTRAP:
+        # Bootstrap commands by authorized operators were already
+        # admitted at step 3.  Anything reaching here is either a
+        # non-bootstrap command or a non-operator running one — deny.
+        return CommandAccessDecision(
+            allowed=False,
+            reason=DecisionReason.COMMANDS_DISABLED,
+            source=DecisionSource.DB_POLICY,
+            mode=mode,
+            feedback=_FEEDBACK_COMMANDS_DISABLED,
+        )
+
+    # mode is AccessMode.SELECTED_CHANNELS
+    if ctx.channel_id is not None and ctx.channel_id in snapshot.allowed_channels:
+        return CommandAccessDecision(
+            allowed=True,
+            reason=DecisionReason.ALLOWED,
+            source=DecisionSource.DB_POLICY,
+            mode=mode,
+            feedback=None,
+        )
+    return CommandAccessDecision(
+        allowed=False,
+        reason=DecisionReason.CHANNEL_NOT_ALLOWED,
+        source=DecisionSource.DB_POLICY,
+        mode=mode,
+        feedback=_FEEDBACK_CHANNEL_NOT_ALLOWED,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Adapters — build a CommandAccessContext from Discord-shaped inputs
+# ---------------------------------------------------------------------------
+
+
+def _first_bootstrap_name(ctx: commands.Context) -> str | None:
+    """Return the first command spelling that classifies as bootstrap,
+    or the canonical name when nothing matches.
+
+    Adapter helper: the resolver only needs one command_name string,
+    but a ``commands.Context`` can expose several (name, qualified
+    name, aliases, invoked_with) and any of them might be the
+    bootstrap spelling (``!diag`` is an alias for ``!diagnostics``).
+    Picking the bootstrap-matching spelling preferentially keeps the
+    resolver's classifier simple — it sees the spelling that matters.
+    """
+    canonical: str | None = None
+    for candidate in _candidate_command_names(ctx):
+        canonical = canonical or candidate
+        if is_bootstrap_command(candidate):
+            return candidate
+    return canonical
+
+
+async def from_prefix_ctx(ctx: commands.Context) -> CommandAccessContext:
+    """Build a :class:`CommandAccessContext` from a ``commands.Context``.
+
+    Async because the bot-owner check is async — kept in the adapter
+    so callers don't have to thread two awaits through the call chain.
+    """
+    guild = getattr(ctx, "guild", None)
+    channel = getattr(ctx, "channel", None)
+    author = getattr(ctx, "author", None)
+    return CommandAccessContext(
+        guild_id=getattr(guild, "id", None),
+        channel_id=getattr(channel, "id", None),
+        user_id=getattr(author, "id", None),
+        command_name=_first_bootstrap_name(ctx),
+        invocation_type="prefix",
+        is_guild_operator=bool(guild and _is_guild_operator(author, guild)),
+        is_bot_owner=await _is_bot_owner_from_ctx(ctx),
+        is_dm=guild is None,
+    )
+
+
+async def from_interaction(
+    interaction: discord.Interaction,
+) -> CommandAccessContext:
+    """Build a :class:`CommandAccessContext` from a ``discord.Interaction``.
+
+    Reads slash-command name from ``interaction.command``.  Component
+    interactions (buttons/selects) have ``command=None``; the resolver
+    treats those as non-bootstrap and applies the normal policy check,
+    which is the desired behaviour — buttons in a disabled channel
+    should not work either.
+    """
+    guild = interaction.guild
+    channel = interaction.channel
+    user = interaction.user
+    command = interaction.command
+    command_name = getattr(command, "qualified_name", None) or getattr(
+        command,
+        "name",
+        None,
+    )
+
+    is_operator = bool(guild and _is_guild_operator(user, guild))
+
+    bot = getattr(interaction, "client", None)
+    is_owner = getattr(bot, "is_owner", None)
+    bot_owner = False
+    if callable(is_owner):
+        try:
+            bot_owner = bool(await is_owner(user))
+        except Exception:
+            bot_owner = False
+
+    return CommandAccessContext(
+        guild_id=getattr(guild, "id", None),
+        channel_id=getattr(channel, "id", None),
+        user_id=getattr(user, "id", None),
+        command_name=command_name,
+        invocation_type="slash",
+        is_guild_operator=is_operator,
+        is_bot_owner=bot_owner,
+        is_dm=guild is None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Guild teardown — registered by ``guild_lifecycle.teardown`` in PR-3
+# ---------------------------------------------------------------------------
+
+
+async def forget_guild(guild_id: int) -> None:
+    """Drop cached + persisted command-access state for ``guild_id``.
+
+    Called by the guild-lifecycle teardown path (PR-3 wiring).  Defined
+    here rather than in ``utils/db`` so the cache invalidation and the
+    DB delete are paired — forgetting only one leaves a stale entry
+    that can re-appear on the next read.
+    """
+    from utils.db import command_access as db_command_access
+    from utils.guild_config_accessors import invalidate_command_access_policy
+
+    invalidate_command_access_policy(guild_id)
+    await db_command_access.forget_guild(guild_id)
 
 
 __all__ = [
     "BOOTSTRAP_COMMANDS",
+    "AccessMode",
+    "CommandAccessContext",
+    "CommandAccessDecision",
+    "DecisionReason",
+    "DecisionSource",
     "can_bypass_channel_guard",
+    "forget_guild",
+    "from_interaction",
+    "from_prefix_ctx",
     "is_bootstrap_command",
+    "resolve_command_access",
 ]

--- a/disbot/guild_lifecycle.py
+++ b/disbot/guild_lifecycle.py
@@ -56,6 +56,14 @@ async def teardown(guild_id: int) -> None:
       19. Automation rules      — delete every automation_rules row for the
                                    guild (Phase 9g PR 18). ``automation_runs``
                                    rows are removed via ON DELETE CASCADE.
+      20. AI Platform           — drop every per-guild row across the six M2
+                                   tables; invalidate resolver cache + drop
+                                   conversation buffers.
+      21. BTD6 strategies (M4)  — delete guild-local rows; detach published
+                                   rows so attribution survives.
+      22. Command-access policy — drop both the cached snapshot and the
+                                   ``guild_command_access_policy`` row
+                                   (CASCADE sweeps the channel allowlist).
     """
     logger.info("guild_lifecycle.teardown: beginning cleanup for guild=%d", guild_id)
 
@@ -132,6 +140,14 @@ async def teardown(guild_id: int) -> None:
     #     origin_guild_id + origin_metadata preserved for
     #     attribution).
     await _teardown_btd6_strategies(guild_id)
+
+    # 22. Command-access policy (command-access onboarding PR-3) —
+    #     drop both the cached typed-accessor entry and the
+    #     ``guild_command_access_policy`` row (CASCADE sweeps the
+    #     child ``guild_command_access_channels`` rows).  Paired in
+    #     ``core.runtime.command_access.forget_guild`` so the cache
+    #     and the DB never diverge across a re-invite.
+    await _teardown_command_access(guild_id)
 
     logger.info("guild_lifecycle.teardown: complete for guild=%d", guild_id)
 
@@ -521,6 +537,27 @@ async def _teardown_automation_rules(guild_id: int) -> None:
     except Exception as exc:
         logger.warning(
             "guild_lifecycle: automation_rules teardown failed for guild=%d: %s",
+            guild_id,
+            exc,
+        )
+
+
+async def _teardown_command_access(guild_id: int) -> None:
+    """Drop the guild's command-access policy + cached snapshot.
+
+    Wraps :func:`core.runtime.command_access.forget_guild`, which
+    invalidates the typed-accessor cache entry and then runs
+    ``DELETE FROM guild_command_access_policy WHERE guild_id = $1``.
+    The CASCADE on ``guild_command_access_channels`` sweeps the child
+    rows; no separate step needed for the allowlist.
+    """
+    try:
+        from core.runtime.command_access import forget_guild as _ca_forget
+
+        await _ca_forget(guild_id)
+    except Exception as exc:
+        logger.warning(
+            "guild_lifecycle: command_access teardown failed for guild=%d: %s",
             guild_id,
             exc,
         )

--- a/disbot/migrations/050_guild_command_access.sql
+++ b/disbot/migrations/050_guild_command_access.sql
@@ -1,0 +1,78 @@
+-- Migration 050: guild_command_access (PR-1 of the command-access fix).
+--
+-- Per-guild policy controlling which channels normal prefix + slash
+-- commands are allowed in.  Replaces the legacy global
+-- ``BOT_ALLOWED_CHANNELS`` env var + hardcoded fallback IDs that
+-- previously controlled command admission for every guild.
+--
+-- Three modes are supported:
+--
+--   * ``all_channels``                — normal commands allowed anywhere
+--                                       (subject to governance + per-command
+--                                       decorators)
+--   * ``selected_channels``           — normal commands allowed only in
+--                                       channels listed in
+--                                       ``guild_command_access_channels``
+--   * ``disabled_except_bootstrap``   — normal commands denied; bootstrap
+--                                       commands (setup/help/platform/
+--                                       settings/diagnostics) still
+--                                       reachable for guild operators
+--
+-- Schema
+-- ------
+-- guild_command_access_policy
+--   guild_id     The guild owning this policy.  Primary key — one row
+--                per guild.  Absence of a row means "unconfigured", and
+--                the resolver applies the safe default (all_channels).
+--   mode         One of the three modes above; CHECK constraint pinned.
+--   updated_by   Operator (user id) who last changed the mode.  NULL
+--                only for migration-installed rows.
+--   updated_at   Bookkeeping (mode change timestamp).
+--   created_at   Bookkeeping (first-write timestamp).
+--
+-- guild_command_access_channels
+--   guild_id     Parent guild; FK with ON DELETE CASCADE so dropping the
+--                policy row sweeps its channel list.
+--   channel_id   Discord channel id allowed under ``selected_channels``
+--                mode.  Composite primary key with ``guild_id`` so a
+--                channel can appear at most once per guild.
+--   created_by   Operator who added this channel.  NULL only for
+--                migration-installed rows.
+--   created_at   Bookkeeping (add timestamp).
+--
+-- An index on ``guild_id`` is implicit in the composite primary key
+-- (Postgres can use the leading column), so no additional index is
+-- needed for the resolver's hot read.
+--
+-- Rollback
+-- --------
+-- ``DROP TABLE IF EXISTS guild_command_access_channels;`` then
+-- ``DROP TABLE IF EXISTS guild_command_access_policy;`` removes both
+-- tables.  Reverting the code that consumes them (PR-4 / PR-5) without
+-- this migration leaves orphan rows that are harmless — nothing else
+-- references them.
+--
+-- The main server's existing allowed channels are backfilled by a
+-- separate later migration (see plan PR-8) once the env var + hardcoded
+-- IDs are deleted from ``disbot/config.py``.  This migration is
+-- intentionally schema-only so PR-1 ships with no behavior change.
+--
+-- Forward-only and idempotent.
+
+CREATE TABLE IF NOT EXISTS guild_command_access_policy (
+    guild_id   BIGINT       PRIMARY KEY,
+    mode       TEXT         NOT NULL,
+    updated_by BIGINT,
+    updated_at TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    created_at TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    CHECK (mode IN ('all_channels', 'selected_channels', 'disabled_except_bootstrap'))
+);
+
+CREATE TABLE IF NOT EXISTS guild_command_access_channels (
+    guild_id   BIGINT       NOT NULL
+        REFERENCES guild_command_access_policy(guild_id) ON DELETE CASCADE,
+    channel_id BIGINT       NOT NULL,
+    created_by BIGINT,
+    created_at TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (guild_id, channel_id)
+);

--- a/disbot/migrations/051_command_access_main_server_backfill.sql
+++ b/disbot/migrations/051_command_access_main_server_backfill.sql
@@ -1,0 +1,52 @@
+-- Migration 051: backfill the main server's command-access policy.
+--
+-- Pre-migration, ``config.ALLOWED_CHANNELS`` carried two hardcoded
+-- channel IDs (``1348795460948590622`` and ``1403818013408624642``)
+-- as the production fallback when ``BOT_ALLOWED_CHANNELS`` env was
+-- unset.  PR-7 of the command-access onboarding fix deletes the env
+-- var + hardcoded list from ``disbot/config.py``; this migration
+-- preserves the main server's existing behavior by writing a
+-- ``selected_channels`` policy keyed on whichever guild owns those
+-- channels.
+--
+-- The migration is data-only (no schema changes) and is **safe on every
+-- deployment**:
+--
+--   * If the channel IDs do not appear in ``panel_anchors`` for any
+--     guild, both INSERTs are no-ops and the deployment retains the
+--     ``all_channels`` default established in PR-2.
+--   * If they do appear (the main server), exactly one policy row +
+--     up to two child rows land.  ``ON CONFLICT DO NOTHING`` makes
+--     the migration idempotent in case it ever re-runs after the
+--     operator has already configured the policy through the
+--     settings UI.
+--
+-- ``panel_anchors`` is the right lookup target because it has the
+-- broadest row coverage of any guild-scoped table — every guild that
+-- has ever opened a persistent panel has rows there.  Using
+-- ``runtime_sessions`` instead would miss guilds that never opened a
+-- session, and using a hardcoded ``guild_id`` would require knowing
+-- it at migration write time (which we don't).
+--
+-- Why not query ``subsystem_bindings`` for ``bot_command_channel``:
+-- the binding name is not guaranteed to be populated in older
+-- deploys, while ``panel_anchors`` is populated on the first
+-- restore_anchors() call after on_ready.
+--
+-- ``updated_by`` / ``created_by`` are intentionally NULL so the
+-- audit row reads "system" rather than attributing the backfill to
+-- a random operator id.
+--
+-- Forward-only and idempotent.
+
+INSERT INTO guild_command_access_policy (guild_id, mode, updated_by)
+SELECT DISTINCT guild_id, 'selected_channels', NULL
+  FROM panel_anchors
+ WHERE channel_id IN (1348795460948590622, 1403818013408624642)
+ON CONFLICT (guild_id) DO NOTHING;
+
+INSERT INTO guild_command_access_channels (guild_id, channel_id, created_by)
+SELECT DISTINCT guild_id, channel_id, NULL
+  FROM panel_anchors
+ WHERE channel_id IN (1348795460948590622, 1403818013408624642)
+ON CONFLICT (guild_id, channel_id) DO NOTHING;

--- a/disbot/services/command_access_service.py
+++ b/disbot/services/command_access_service.py
@@ -1,0 +1,509 @@
+"""Command-access mutation service — PR-3.
+
+The canonical write path for per-guild command-access policy.  Every
+admin write (setup wizard, settings UI, future admin command) MUST go
+through this module so the cache invalidation and audit emission
+happen in lock-step with the DB commit.
+
+Pattern follows the 6-step contract used by the lighter-weight
+mutation services in this codebase (``services.command_routing``,
+``services.role_automation``):
+
+  1. Input validation        — mode literal / channel_id ints
+  2. Read previous state     — for the audit row's ``prev_value``
+  3. DB write                — via ``utils.db.command_access`` primitives
+  4. Cache invalidation      — ``invalidate_command_access_policy`` runs
+                                INLINE after the DB commit, BEFORE event
+                                emission (cache consistency does not
+                                depend on a subscriber)
+  5. Audit emission          — ``audit.action_recorded`` via
+                                ``services.audit_events.emit_audit_action``,
+                                best-effort, never raises
+  6. Return typed result     — frozen ``CommandAccessMutationResult``
+                                carrying mutation_id for cross-pipeline
+                                correlation
+
+The richer per-pipeline events used by the binding / settings pipelines
+(``settings.changed``, ``bindings.changed`` etc.) are deliberately NOT
+added here yet — no subscriber needs them.  When one does, register a
+new name in ``core.events_catalogue.KNOWN_EVENTS`` and emit it from
+this module; the audit emit stays.
+
+The resolver (``core.runtime.command_access.resolve_command_access``)
+remains the read path.  This service never reads policy state for
+admission decisions — it only reads to compute audit ``prev_value``.
+
+Adds two composite operations on top of the four primitives:
+
+* :func:`set_policy` — atomic mode + channel-list replace; the shape the
+  setup wizard / settings UI uses to apply a whole-policy edit in one
+  request.  Emits one audit event per actual change (so a switch from
+  ``selected_channels`` mode with channels [100] to ``selected_channels``
+  with channels [200] emits a channel-replace event but no mode event).
+* :func:`get_policy_snapshot` — thin read-through to the typed accessor
+  so admin UIs do not have to wire up their own cache discipline.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Literal
+
+from services.audit_events import emit_audit_action
+from utils.db import command_access as db
+from utils.guild_config_accessors import (
+    CommandAccessPolicySnapshot,
+    get_command_access_policy,
+    invalidate_command_access_policy,
+)
+
+logger = logging.getLogger("bot.services.command_access")
+
+
+SUBSYSTEM = "command_access"
+
+MutationType = Literal[
+    "set_mode",
+    "add_allowed_channel",
+    "remove_allowed_channel",
+    "replace_allowed_channels",
+]
+
+_ALLOWED_ACTOR_TYPES: frozenset[str] = frozenset(
+    {"admin", "system", "backfill"},
+)
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class CommandAccessMutationError(Exception):
+    """Base class for failures from this service."""
+
+
+class InvalidCommandAccessModeError(CommandAccessMutationError):
+    """Raised when the supplied mode is not recognised by the schema."""
+
+
+class UnauthorizedCommandAccessActorError(CommandAccessMutationError):
+    """Raised when ``actor_type`` is outside the allowed set.
+
+    Entry-points (settings UI, wizard) are still responsible for
+    checking the *user's* permission (Manage Guild, etc.); this is a
+    last-line guard that the mutation isn't coming from an unexpected
+    pipeline.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CommandAccessMutationResult:
+    """Outcome of a single command-access mutation.
+
+    ``audit_emitted`` is informational — DB state is always authoritative.
+    """
+
+    mutation_id: str
+    guild_id: int
+    mutation_type: MutationType
+    prev_value: str | None
+    new_value: str | None
+    actor_id: int | None
+    actor_type: str
+    committed_at: datetime
+    audit_emitted: bool
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _validate_mode(mode: str) -> None:
+    if mode not in db.KNOWN_MODES:
+        raise InvalidCommandAccessModeError(
+            f"mode must be one of {sorted(db.KNOWN_MODES)}, got {mode!r}",
+        )
+
+
+def _validate_actor_type(actor_type: str) -> None:
+    if actor_type not in _ALLOWED_ACTOR_TYPES:
+        raise UnauthorizedCommandAccessActorError(
+            f"actor_type must be one of {sorted(_ALLOWED_ACTOR_TYPES)}, "
+            f"got {actor_type!r}",
+        )
+
+
+def _render_channels(channel_ids: Iterable[int]) -> str:
+    """Render a stable, comparable string for an allowed-channel list."""
+    return "[" + ",".join(str(c) for c in sorted(set(channel_ids))) + "]"
+
+
+async def _emit_audit(
+    *,
+    mutation_id: str,
+    mutation_type: MutationType,
+    target: str,
+    guild_id: int,
+    prev_value: str | None,
+    new_value: str | None,
+    actor_id: int | None,
+    actor_type: str,
+    committed_at: datetime,
+) -> bool:
+    """Wrap the shared publisher so callers don't repeat the kwarg list."""
+    return await emit_audit_action(
+        mutation_id=mutation_id,
+        subsystem=SUBSYSTEM,
+        mutation_type=mutation_type,
+        target=target,
+        scope="guild",
+        guild_id=guild_id,
+        prev_value=prev_value,
+        new_value=new_value,
+        actor_id=actor_id,
+        actor_type=actor_type,
+        occurred_at=committed_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public read passthrough
+# ---------------------------------------------------------------------------
+
+
+async def get_policy_snapshot(guild_id: int) -> CommandAccessPolicySnapshot:
+    """Return the cached policy snapshot for ``guild_id``.
+
+    Thin passthrough to the typed accessor so admin UIs reach state
+    through this module — the resolver remains the read path for
+    admission, but admin UIs reading the SAME state through a different
+    route (``utils.db.command_access`` direct) would skip the cache and
+    risk divergence.
+    """
+    return await get_command_access_policy(guild_id)
+
+
+# ---------------------------------------------------------------------------
+# Primitives
+# ---------------------------------------------------------------------------
+
+
+async def set_mode(
+    *,
+    guild_id: int,
+    mode: str,
+    actor_id: int | None,
+    actor_type: str = "admin",
+) -> CommandAccessMutationResult:
+    """Upsert the access mode for ``guild_id``.
+
+    Channel allowlist rows are preserved across mode changes — switching
+    from ``selected_channels`` to ``all_channels`` and back keeps the
+    previously configured channels intact.  Callers that want a clean
+    slate should follow with :func:`replace_allowed_channels`.
+    """
+    _validate_mode(mode)
+    _validate_actor_type(actor_type)
+
+    mutation_id = str(uuid.uuid4())
+    prev_row = await db.get_policy(guild_id)
+    prev_mode = str(prev_row["mode"]) if prev_row else None
+
+    await db.set_mode(guild_id=guild_id, mode=mode, updated_by=actor_id)
+    invalidate_command_access_policy(guild_id)
+
+    committed_at = _now_utc()
+    audit_emitted = await _emit_audit(
+        mutation_id=mutation_id,
+        mutation_type="set_mode",
+        target="command_access:mode",
+        guild_id=guild_id,
+        prev_value=prev_mode,
+        new_value=mode,
+        actor_id=actor_id,
+        actor_type=actor_type,
+        committed_at=committed_at,
+    )
+    return CommandAccessMutationResult(
+        mutation_id=mutation_id,
+        guild_id=guild_id,
+        mutation_type="set_mode",
+        prev_value=prev_mode,
+        new_value=mode,
+        actor_id=actor_id,
+        actor_type=actor_type,
+        committed_at=committed_at,
+        audit_emitted=audit_emitted,
+    )
+
+
+async def add_allowed_channel(
+    *,
+    guild_id: int,
+    channel_id: int,
+    actor_id: int | None,
+    actor_type: str = "admin",
+) -> CommandAccessMutationResult:
+    """Add a single channel to the allowlist for ``guild_id``.
+
+    Requires a policy row to already exist (FK).  The settings UI is
+    expected to call :func:`set_mode` first (or use :func:`set_policy`
+    to do both in one call).
+    """
+    _validate_actor_type(actor_type)
+    if not isinstance(channel_id, int):
+        raise TypeError(f"channel_id must be int, got {type(channel_id).__name__}")
+
+    mutation_id = str(uuid.uuid4())
+    prev_channels = await db.list_allowed_channels(guild_id)
+    if channel_id in prev_channels:
+        # Idempotent — DB primitive is also idempotent, but skipping the
+        # audit emission keeps the audit log free of zero-effect rows.
+        committed_at = _now_utc()
+        return CommandAccessMutationResult(
+            mutation_id=mutation_id,
+            guild_id=guild_id,
+            mutation_type="add_allowed_channel",
+            prev_value=str(channel_id),
+            new_value=str(channel_id),
+            actor_id=actor_id,
+            actor_type=actor_type,
+            committed_at=committed_at,
+            audit_emitted=False,
+        )
+
+    await db.add_allowed_channel(
+        guild_id=guild_id,
+        channel_id=channel_id,
+        created_by=actor_id,
+    )
+    invalidate_command_access_policy(guild_id)
+
+    committed_at = _now_utc()
+    audit_emitted = await _emit_audit(
+        mutation_id=mutation_id,
+        mutation_type="add_allowed_channel",
+        target=f"command_access:channel:{channel_id}",
+        guild_id=guild_id,
+        prev_value=None,
+        new_value=str(channel_id),
+        actor_id=actor_id,
+        actor_type=actor_type,
+        committed_at=committed_at,
+    )
+    return CommandAccessMutationResult(
+        mutation_id=mutation_id,
+        guild_id=guild_id,
+        mutation_type="add_allowed_channel",
+        prev_value=None,
+        new_value=str(channel_id),
+        actor_id=actor_id,
+        actor_type=actor_type,
+        committed_at=committed_at,
+        audit_emitted=audit_emitted,
+    )
+
+
+async def remove_allowed_channel(
+    *,
+    guild_id: int,
+    channel_id: int,
+    actor_id: int | None,
+    actor_type: str = "admin",
+) -> CommandAccessMutationResult:
+    """Remove a single channel from the allowlist for ``guild_id``."""
+    _validate_actor_type(actor_type)
+    if not isinstance(channel_id, int):
+        raise TypeError(f"channel_id must be int, got {type(channel_id).__name__}")
+
+    mutation_id = str(uuid.uuid4())
+    prev_channels = await db.list_allowed_channels(guild_id)
+    if channel_id not in prev_channels:
+        # Idempotent — same rationale as add: no audit row for no-op.
+        committed_at = _now_utc()
+        return CommandAccessMutationResult(
+            mutation_id=mutation_id,
+            guild_id=guild_id,
+            mutation_type="remove_allowed_channel",
+            prev_value=None,
+            new_value=None,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            committed_at=committed_at,
+            audit_emitted=False,
+        )
+
+    await db.remove_allowed_channel(guild_id=guild_id, channel_id=channel_id)
+    invalidate_command_access_policy(guild_id)
+
+    committed_at = _now_utc()
+    audit_emitted = await _emit_audit(
+        mutation_id=mutation_id,
+        mutation_type="remove_allowed_channel",
+        target=f"command_access:channel:{channel_id}",
+        guild_id=guild_id,
+        prev_value=str(channel_id),
+        new_value=None,
+        actor_id=actor_id,
+        actor_type=actor_type,
+        committed_at=committed_at,
+    )
+    return CommandAccessMutationResult(
+        mutation_id=mutation_id,
+        guild_id=guild_id,
+        mutation_type="remove_allowed_channel",
+        prev_value=str(channel_id),
+        new_value=None,
+        actor_id=actor_id,
+        actor_type=actor_type,
+        committed_at=committed_at,
+        audit_emitted=audit_emitted,
+    )
+
+
+async def replace_allowed_channels(
+    *,
+    guild_id: int,
+    channel_ids: Iterable[int],
+    actor_id: int | None,
+    actor_type: str = "admin",
+) -> CommandAccessMutationResult:
+    """Atomic bulk replace of the allowed-channel list for ``guild_id``.
+
+    Wraps :func:`utils.db.command_access.replace_allowed_channels`,
+    invalidates the cache, and emits a single audit row with the
+    before/after channel lists as comparable strings.  Skips the audit
+    emission when prev == new (true no-op).
+    """
+    _validate_actor_type(actor_type)
+    desired = sorted({int(cid) for cid in channel_ids})
+
+    mutation_id = str(uuid.uuid4())
+    prev_channels = await db.list_allowed_channels(guild_id)
+    prev_rendered = _render_channels(prev_channels)
+    new_rendered = _render_channels(desired)
+
+    if prev_rendered == new_rendered:
+        committed_at = _now_utc()
+        return CommandAccessMutationResult(
+            mutation_id=mutation_id,
+            guild_id=guild_id,
+            mutation_type="replace_allowed_channels",
+            prev_value=prev_rendered,
+            new_value=new_rendered,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            committed_at=committed_at,
+            audit_emitted=False,
+        )
+
+    await db.replace_allowed_channels(
+        guild_id=guild_id,
+        channel_ids=desired,
+        created_by=actor_id,
+    )
+    invalidate_command_access_policy(guild_id)
+
+    committed_at = _now_utc()
+    audit_emitted = await _emit_audit(
+        mutation_id=mutation_id,
+        mutation_type="replace_allowed_channels",
+        target="command_access:channels",
+        guild_id=guild_id,
+        prev_value=prev_rendered,
+        new_value=new_rendered,
+        actor_id=actor_id,
+        actor_type=actor_type,
+        committed_at=committed_at,
+    )
+    return CommandAccessMutationResult(
+        mutation_id=mutation_id,
+        guild_id=guild_id,
+        mutation_type="replace_allowed_channels",
+        prev_value=prev_rendered,
+        new_value=new_rendered,
+        actor_id=actor_id,
+        actor_type=actor_type,
+        committed_at=committed_at,
+        audit_emitted=audit_emitted,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Composite
+# ---------------------------------------------------------------------------
+
+
+async def set_policy(
+    *,
+    guild_id: int,
+    mode: str,
+    channel_ids: Iterable[int] | None,
+    actor_id: int | None,
+    actor_type: str = "admin",
+) -> list[CommandAccessMutationResult]:
+    """Apply a whole-policy edit in the canonical order.
+
+    Mode is upserted first so the FK on the channel rows is satisfied,
+    then the channel list is replaced atomically.  Each underlying
+    mutation runs through its own primitive (and so emits its own audit
+    row when it actually changes anything), keeping the audit trail
+    granular.
+
+    ``channel_ids=None`` leaves the channel list untouched — useful for
+    the settings-UI "change mode only" path.  Pass ``[]`` to clear the
+    list explicitly.
+
+    Returns the list of underlying results in execution order
+    (``[set_mode_result]`` or ``[set_mode_result, replace_result]``) so
+    callers can introspect what actually changed.
+    """
+    results: list[CommandAccessMutationResult] = [
+        await set_mode(
+            guild_id=guild_id,
+            mode=mode,
+            actor_id=actor_id,
+            actor_type=actor_type,
+        ),
+    ]
+    if channel_ids is not None:
+        results.append(
+            await replace_allowed_channels(
+                guild_id=guild_id,
+                channel_ids=channel_ids,
+                actor_id=actor_id,
+                actor_type=actor_type,
+            ),
+        )
+    return results
+
+
+__all__ = [
+    "SUBSYSTEM",
+    "CommandAccessMutationError",
+    "CommandAccessMutationResult",
+    "InvalidCommandAccessModeError",
+    "MutationType",
+    "UnauthorizedCommandAccessActorError",
+    "add_allowed_channel",
+    "get_policy_snapshot",
+    "remove_allowed_channel",
+    "replace_allowed_channels",
+    "set_mode",
+    "set_policy",
+]

--- a/disbot/services/metrics.py
+++ b/disbot/services/metrics.py
@@ -106,6 +106,27 @@ governance_denials_total = Counter(
     ["subsystem", "scope"],
 )
 
+# Command-access onboarding PR-8 — per-decision counter for the
+# central command-access resolver (prefix + slash share the same
+# admission path).  The breakdown lets operators see, at scrape time,
+# how many denials a given guild is producing and why.
+#
+# Label cardinality is bounded:
+#   * invocation: "prefix" | "slash" (2)
+#   * decision:   "allow" | "deny"    (2)
+#   * reason:     DecisionReason enum (6 values today)
+#   * mode:       AccessMode enum + "none" for the lifecycle/DM/default
+#                 branches that don't carry a mode (4)
+#   * source:     DecisionSource enum (4)
+#
+# At most 2 × 2 × 6 × 4 × 4 = 384 label combinations.
+command_access_decisions_total = Counter(
+    "command_access_decisions_total",
+    "Command-access resolver decisions broken down by invocation, "
+    "decision, reason, mode, and source.",
+    ["invocation", "decision", "reason", "mode", "source"],
+)
+
 task_outcome_total = Counter(
     "task_outcome_total",
     "Outcomes of managed background tasks spawned via core.runtime.tasks",

--- a/disbot/utils/db/command_access.py
+++ b/disbot/utils/db/command_access.py
@@ -1,0 +1,210 @@
+"""Command-access policy DB primitives.
+
+Per-guild policy controlling where normal prefix + slash commands are
+allowed (PR-1 of the command-access onboarding fix).  Reads return
+``None`` when no row exists; the resolver layer
+(:mod:`core.runtime.command_access`) treats the absence of a row as
+the safe default (``all_channels``).
+
+Two tables back this module:
+
+* ``guild_command_access_policy``        — one row per guild, mode only
+* ``guild_command_access_channels``      — child rows for selected
+                                            channels (FK with cascade)
+
+Both tables ship in migration ``050_guild_command_access.sql``.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from typing import Any
+
+from utils.db import pool
+
+logger = logging.getLogger("bot.db.command_access")
+
+
+KNOWN_MODES: frozenset[str] = frozenset(
+    {
+        "all_channels",
+        "selected_channels",
+        "disabled_except_bootstrap",
+    },
+)
+
+
+def _validate_mode(mode: str) -> None:
+    if mode not in KNOWN_MODES:
+        raise ValueError(
+            f"mode must be one of {sorted(KNOWN_MODES)}, got {mode!r}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Policy row (mode)
+# ---------------------------------------------------------------------------
+
+
+async def get_policy(guild_id: int) -> dict[str, Any] | None:
+    """Return the policy row for ``guild_id`` or ``None`` when unset.
+
+    Absence of a row is the canonical "unconfigured" signal — callers
+    must apply their own default rather than synthesising a row here.
+    """
+    row = await pool.get().fetchrow(
+        """
+        SELECT mode, updated_by, updated_at, created_at
+          FROM guild_command_access_policy
+         WHERE guild_id = $1
+        """,
+        guild_id,
+    )
+    return dict(row) if row else None
+
+
+async def set_mode(
+    guild_id: int,
+    mode: str,
+    updated_by: int | None,
+) -> None:
+    """Upsert the mode for ``guild_id``.
+
+    Preserves ``created_at`` on update; only ``mode``, ``updated_by``,
+    and ``updated_at`` move on conflict.
+    """
+    _validate_mode(mode)
+    await pool.get().execute(
+        """
+        INSERT INTO guild_command_access_policy
+            (guild_id, mode, updated_by)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (guild_id)
+        DO UPDATE SET
+            mode       = EXCLUDED.mode,
+            updated_by = EXCLUDED.updated_by,
+            updated_at = NOW()
+        """,
+        guild_id,
+        mode,
+        updated_by,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Allowed-channel rows
+# ---------------------------------------------------------------------------
+
+
+async def list_allowed_channels(guild_id: int) -> list[int]:
+    """Return the allowed channel ids for ``guild_id`` in stable order.
+
+    Stable ordering keeps UI panes deterministic between renders and
+    makes diff-based audit comparisons trivial.
+    """
+    rows = await pool.get().fetch(
+        """
+        SELECT channel_id
+          FROM guild_command_access_channels
+         WHERE guild_id = $1
+         ORDER BY channel_id
+        """,
+        guild_id,
+    )
+    return [int(r["channel_id"]) for r in rows]
+
+
+async def add_allowed_channel(
+    guild_id: int,
+    channel_id: int,
+    created_by: int | None,
+) -> None:
+    """Insert a single allowed channel; idempotent on (guild, channel).
+
+    A policy row must already exist (FK constraint).  The service
+    layer is responsible for ensuring ``set_mode`` ran first.
+    """
+    await pool.get().execute(
+        """
+        INSERT INTO guild_command_access_channels
+            (guild_id, channel_id, created_by)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (guild_id, channel_id) DO NOTHING
+        """,
+        guild_id,
+        channel_id,
+        created_by,
+    )
+
+
+async def remove_allowed_channel(guild_id: int, channel_id: int) -> None:
+    """Remove a single allowed channel; no-op when absent."""
+    await pool.get().execute(
+        """
+        DELETE FROM guild_command_access_channels
+         WHERE guild_id = $1 AND channel_id = $2
+        """,
+        guild_id,
+        channel_id,
+    )
+
+
+async def replace_allowed_channels(
+    guild_id: int,
+    channel_ids: Iterable[int],
+    created_by: int | None,
+) -> None:
+    """Atomically replace the allowed-channel set for ``guild_id``.
+
+    Wraps the delete + bulk-insert in a single transaction so a
+    concurrent reader never observes a half-applied list.  Dedupes the
+    input so callers can pass a list directly without pre-processing.
+    """
+    desired = sorted({int(cid) for cid in channel_ids})
+    async with pool.get().acquire() as conn:
+        async with conn.transaction():
+            await conn.execute(
+                "DELETE FROM guild_command_access_channels WHERE guild_id = $1",
+                guild_id,
+            )
+            if desired:
+                await conn.executemany(
+                    """
+                    INSERT INTO guild_command_access_channels
+                        (guild_id, channel_id, created_by)
+                    VALUES ($1, $2, $3)
+                    """,
+                    [(guild_id, cid, created_by) for cid in desired],
+                )
+
+
+# ---------------------------------------------------------------------------
+# Guild teardown
+# ---------------------------------------------------------------------------
+
+
+async def forget_guild(guild_id: int) -> None:
+    """Drop every command-access row for ``guild_id``.
+
+    Called by ``guild_lifecycle.teardown`` when the bot is kicked or
+    leaves a guild.  The CASCADE on ``guild_command_access_channels``
+    means deleting the policy row sweeps its children, so a single
+    delete is sufficient.
+    """
+    await pool.get().execute(
+        "DELETE FROM guild_command_access_policy WHERE guild_id = $1",
+        guild_id,
+    )
+
+
+__all__ = [
+    "KNOWN_MODES",
+    "add_allowed_channel",
+    "forget_guild",
+    "get_policy",
+    "list_allowed_channels",
+    "remove_allowed_channel",
+    "replace_allowed_channels",
+    "set_mode",
+]

--- a/disbot/utils/db/command_access.py
+++ b/disbot/utils/db/command_access.py
@@ -162,21 +162,20 @@ async def replace_allowed_channels(
     input so callers can pass a list directly without pre-processing.
     """
     desired = sorted({int(cid) for cid in channel_ids})
-    async with pool.get().acquire() as conn:
-        async with conn.transaction():
-            await conn.execute(
-                "DELETE FROM guild_command_access_channels WHERE guild_id = $1",
-                guild_id,
+    async with pool.get().acquire() as conn, conn.transaction():
+        await conn.execute(
+            "DELETE FROM guild_command_access_channels WHERE guild_id = $1",
+            guild_id,
+        )
+        if desired:
+            await conn.executemany(
+                """
+                INSERT INTO guild_command_access_channels
+                    (guild_id, channel_id, created_by)
+                VALUES ($1, $2, $3)
+                """,
+                [(guild_id, cid, created_by) for cid in desired],
             )
-            if desired:
-                await conn.executemany(
-                    """
-                    INSERT INTO guild_command_access_channels
-                        (guild_id, channel_id, created_by)
-                    VALUES ($1, $2, $3)
-                    """,
-                    [(guild_id, cid, created_by) for cid in desired],
-                )
 
 
 # ---------------------------------------------------------------------------

--- a/disbot/utils/guild_config_accessors.py
+++ b/disbot/utils/guild_config_accessors.py
@@ -223,12 +223,82 @@ def invalidate_setting_value(guild_id: int, settings_key: str) -> None:
     guild_config.invalidate(guild_id, _SETTING_CACHE_PREFIX + settings_key)
 
 
+# ---------------------------------------------------------------------------
+# Command-access policy — consumed by core.runtime.command_access (PR-2)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CommandAccessPolicySnapshot:
+    """Cached per-guild command-access policy.
+
+    ``mode is None`` represents the "unconfigured" state — no row
+    exists in ``guild_command_access_policy``.  The resolver maps that
+    to the safe default (all channels) rather than synthesising a row
+    here so the unconfigured state remains observable.
+    """
+
+    mode: str | None
+    allowed_channels: frozenset[int]
+
+
+def _command_access_policy_loader(
+    guild_id: int,
+) -> Callable[[], Awaitable[CommandAccessPolicySnapshot]]:
+    async def _load() -> CommandAccessPolicySnapshot:
+        from utils.db import command_access as db_command_access
+
+        row = await db_command_access.get_policy(guild_id)
+        if row is None:
+            return CommandAccessPolicySnapshot(mode=None, allowed_channels=frozenset())
+        channels = await db_command_access.list_allowed_channels(guild_id)
+        return CommandAccessPolicySnapshot(
+            mode=str(row["mode"]),
+            allowed_channels=frozenset(channels),
+        )
+
+    return _load
+
+
+_command_access_policy_accessor: TypedAccessor[CommandAccessPolicySnapshot] = (
+    TypedAccessor(
+        cache_key="command_access_policy",
+        loader_factory=_command_access_policy_loader,
+    )
+)
+
+
+async def get_command_access_policy(guild_id: int) -> CommandAccessPolicySnapshot:
+    """Return the cached command-access policy for ``guild_id``.
+
+    Hot-path read for every prefix + slash command invocation.  Cached
+    via :mod:`core.runtime.guild_config` with the default TTL; admin
+    writes (mode change, channel add/remove) MUST call
+    :func:`invalidate_command_access_policy` afterward so the next read
+    reflects the change.
+    """
+    return await _command_access_policy_accessor.get(guild_id)
+
+
+def invalidate_command_access_policy(guild_id: int) -> None:
+    """Drop the cached command-access policy for ``guild_id``.
+
+    Called from the command-access mutation service (PR-3) on every
+    write — and from ``core.runtime.command_access.forget_guild`` when
+    the bot leaves the guild.
+    """
+    _command_access_policy_accessor.invalidate(guild_id)
+
+
 __all__ = [
+    "CommandAccessPolicySnapshot",
     "TypedAccessor",
     "XpConfig",
+    "get_command_access_policy",
     "get_setting_value",
     "get_xp_config",
     "get_xp_threshold_roles",
+    "invalidate_command_access_policy",
     "invalidate_setting_value",
     "invalidate_xp_config",
     "invalidate_xp_threshold_roles",

--- a/disbot/views/settings/edit_command_access.py
+++ b/disbot/views/settings/edit_command_access.py
@@ -1,0 +1,410 @@
+"""Settings Manager — Command Access panel (PR-6).
+
+Operator-facing UI for the per-guild command-access policy:
+
+* mode (``all_channels`` / ``selected_channels`` /
+  ``disabled_except_bootstrap``) — one button per mode
+* allowed channel list — multi-channel ``discord.ui.ChannelSelect``
+  that runs the atomic
+  :func:`services.command_access_service.replace_allowed_channels`
+  composite when changed
+* Back-to-Hub navigation matching the rest of the Settings Manager
+
+Every mutation routes through ``services.command_access_service`` so
+cache invalidation + audit emission happen in the canonical path.
+The panel never touches ``utils.db.command_access`` directly.
+
+The setting is admin-only: ``!settings`` already gates entry to
+this view via ``@commands.has_permissions(administrator=True)``,
+but the per-callback guard below is the defence-in-depth (the view
+anchor message can outlive the original invocation context if the
+panel is shared).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+from views.base import HubView
+
+logger = logging.getLogger("bot.views.settings.command_access")
+
+
+_MODE_LABELS: dict[str, str] = {
+    "all_channels": "All channels",
+    "selected_channels": "Selected channels",
+    "disabled_except_bootstrap": "Disabled except bootstrap",
+}
+
+_MODE_DESCRIPTIONS: dict[str, str] = {
+    "all_channels": (
+        "Normal prefix + slash commands work in every guild channel "
+        "(subject to per-command permissions and governance)."
+    ),
+    "selected_channels": (
+        "Normal commands only work in the channels you list below. "
+        "Bootstrap commands (`/setup`, `/help`, `/settings`, etc.) "
+        "still work everywhere for guild operators."
+    ),
+    "disabled_except_bootstrap": (
+        "Normal commands are denied. Only bootstrap commands "
+        "remain reachable so an operator can re-enable from "
+        "`!setup` or this panel."
+    ),
+}
+
+
+def _format_channel_list(channel_ids: frozenset[int]) -> str:
+    if not channel_ids:
+        return "*(none configured)*"
+    rendered = " ".join(f"<#{cid}>" for cid in sorted(channel_ids))
+    # Discord embeds cap field values at 1024 chars; truncate with a
+    # trailing count rather than letting the embed render fail.
+    if len(rendered) > 950:
+        head = " ".join(f"<#{cid}>" for cid in sorted(channel_ids)[:30])
+        return f"{head} … (+{len(channel_ids) - 30} more)"
+    return rendered
+
+
+async def build_command_access_embed(guild_id: int | None) -> discord.Embed:
+    """Render the current policy as an embed.
+
+    ``guild_id=None`` (the panel was opened in a DM somehow) yields a
+    placeholder embed — the panel itself shouldn't open in DM but
+    the helper stays defensive.
+    """
+    embed = discord.Embed(
+        title="🚪 Command Access",
+        description=(
+            "Configure where prefix and slash commands are allowed in "
+            "this server.  Applies to **both** invocation surfaces — "
+            "the same channels permit `!bj` and `/blackjack` alike.\n\n"
+            "Bootstrap commands (`/setup`, `/help`, `/settings`, "
+            "`/platform`, `/diagnostics`) always remain reachable "
+            "for guild operators so you cannot lock yourself out."
+        ),
+        color=discord.Color.blurple(),
+    )
+
+    if guild_id is None:
+        embed.add_field(
+            name="Current mode",
+            value="*Guild context not available.*",
+            inline=False,
+        )
+        return embed
+
+    from services.command_access_service import get_policy_snapshot
+
+    snapshot = await get_policy_snapshot(guild_id)
+    mode_label = (
+        _MODE_LABELS.get(snapshot.mode, snapshot.mode)
+        if snapshot.mode is not None
+        else "All channels (default — no policy row)"
+    )
+    mode_description = (
+        _MODE_DESCRIPTIONS.get(snapshot.mode, "—")
+        if snapshot.mode is not None
+        else _MODE_DESCRIPTIONS["all_channels"]
+    )
+
+    embed.add_field(
+        name="Current mode",
+        value=f"**{mode_label}**\n{mode_description}",
+        inline=False,
+    )
+    embed.add_field(
+        name=f"Allowed channels ({len(snapshot.allowed_channels)})",
+        value=_format_channel_list(snapshot.allowed_channels),
+        inline=False,
+    )
+
+    if snapshot.mode == "disabled_except_bootstrap":
+        embed.add_field(
+            name="Recovery",
+            value=(
+                "Normal commands are currently denied.  Pick **All "
+                "channels** or **Selected channels** above to re-enable, "
+                "or run `!setup` to revisit onboarding."
+            ),
+            inline=False,
+        )
+
+    embed.set_footer(
+        text=(
+            "Applies to prefix + slash commands.  "
+            "Mode buttons + the channel selector are admin-only."
+        ),
+    )
+    return embed
+
+
+def _is_admin(member: discord.abc.User | discord.Member) -> bool:
+    """Return True iff the invoker has Administrator or Manage Guild.
+
+    Defence-in-depth — the ``!settings`` group is already admin-gated.
+    """
+    perms = getattr(member, "guild_permissions", None)
+    if perms is None:
+        return False
+    return bool(
+        getattr(perms, "administrator", False) or getattr(perms, "manage_guild", False),
+    )
+
+
+async def _refresh_panel(
+    interaction: discord.Interaction,
+    view: CommandAccessView,
+) -> None:
+    """Rebuild the embed after a successful mutation."""
+    guild_id = interaction.guild_id
+    embed = await build_command_access_embed(guild_id)
+    try:
+        await interaction.edit_original_response(embed=embed, view=view)
+    except Exception as exc:  # noqa: BLE001 — soft-fail
+        logger.debug(
+            "CommandAccessView: panel refresh failed for guild=%s: %s",
+            guild_id,
+            exc,
+        )
+
+
+async def _apply_mode(
+    interaction: discord.Interaction,
+    mode: str,
+    view: CommandAccessView,
+) -> None:
+    """Shared mode-button callback path."""
+    if not _is_admin(interaction.user):
+        await interaction.response.send_message(
+            "❌ Administrator or Manage Guild permission required.",
+            ephemeral=True,
+        )
+        return
+    if interaction.guild_id is None:
+        await interaction.response.send_message(
+            "❌ Command access can only be configured inside a server.",
+            ephemeral=True,
+        )
+        return
+
+    from services.command_access_service import (
+        CommandAccessMutationError,
+        set_mode,
+    )
+
+    try:
+        await set_mode(
+            guild_id=interaction.guild_id,
+            mode=mode,
+            actor_id=interaction.user.id,
+        )
+    except CommandAccessMutationError as exc:
+        await interaction.response.send_message(
+            f"❌ {type(exc).__name__}: {exc}",
+            ephemeral=True,
+        )
+        return
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.exception(
+            "CommandAccessView: set_mode pipeline raised for guild=%s mode=%s",
+            interaction.guild_id,
+            mode,
+        )
+        await interaction.response.send_message(
+            f"❌ Unexpected error: {type(exc).__name__}: {exc}",
+            ephemeral=True,
+        )
+        return
+
+    # safe_defer (INV-L): swallows token-expiry / HTTP errors and
+    # returns False so the panel doesn't crash on an aged-out token.
+    from core.runtime.interaction_helpers import safe_defer
+
+    if not await safe_defer(interaction):
+        return
+    await _refresh_panel(interaction, view)
+    await interaction.followup.send(
+        f"✅ Command access mode set to **{_MODE_LABELS[mode]}**.",
+        ephemeral=True,
+    )
+
+
+class _AllChannelsButton(discord.ui.Button):
+    def __init__(self) -> None:
+        super().__init__(
+            label="All channels",
+            style=discord.ButtonStyle.success,
+            emoji="🌐",
+            custom_id="settings_command_access.mode.all_channels",
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await _apply_mode(interaction, "all_channels", _view_of(self))
+
+
+class _SelectedChannelsButton(discord.ui.Button):
+    def __init__(self) -> None:
+        super().__init__(
+            label="Selected channels",
+            style=discord.ButtonStyle.primary,
+            emoji="📋",
+            custom_id="settings_command_access.mode.selected_channels",
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await _apply_mode(interaction, "selected_channels", _view_of(self))
+
+
+class _DisabledButton(discord.ui.Button):
+    def __init__(self) -> None:
+        super().__init__(
+            label="Disabled except bootstrap",
+            style=discord.ButtonStyle.danger,
+            emoji="🚫",
+            custom_id="settings_command_access.mode.disabled_except_bootstrap",
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await _apply_mode(
+            interaction,
+            "disabled_except_bootstrap",
+            _view_of(self),
+        )
+
+
+class _ChannelAllowlistSelect(discord.ui.ChannelSelect):
+    """Multi-channel select that drives ``replace_allowed_channels``.
+
+    A blank selection clears the list (atomic delete in the service
+    layer).  This is the same shape the future setup-wizard section
+    would have used, so we get the UX in this PR without splitting
+    the integration across two surfaces.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            placeholder="Set allowed channels (selected_channels mode)…",
+            channel_types=[discord.ChannelType.text],
+            min_values=0,
+            max_values=25,
+            row=1,
+            custom_id="settings_command_access.channels",
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        if not _is_admin(interaction.user):
+            await interaction.response.send_message(
+                "❌ Administrator or Manage Guild permission required.",
+                ephemeral=True,
+            )
+            return
+        if interaction.guild_id is None:
+            await interaction.response.send_message(
+                "❌ Command access can only be configured inside a server.",
+                ephemeral=True,
+            )
+            return
+
+        from services.command_access_service import (
+            CommandAccessMutationError,
+            replace_allowed_channels,
+        )
+
+        channel_ids = [int(c.id) for c in self.values]
+        try:
+            await replace_allowed_channels(
+                guild_id=interaction.guild_id,
+                channel_ids=channel_ids,
+                actor_id=interaction.user.id,
+            )
+        except CommandAccessMutationError as exc:
+            await interaction.response.send_message(
+                f"❌ {type(exc).__name__}: {exc}",
+                ephemeral=True,
+            )
+            return
+        except Exception as exc:  # noqa: BLE001 — defensive
+            logger.exception(
+                "CommandAccessView: replace_allowed_channels raised for guild=%s",
+                interaction.guild_id,
+            )
+            await interaction.response.send_message(
+                f"❌ Unexpected error: {type(exc).__name__}: {exc}",
+                ephemeral=True,
+            )
+            return
+
+        # safe_defer (INV-L) — same rationale as the mode-button path.
+        from core.runtime.interaction_helpers import safe_defer
+
+        if not await safe_defer(interaction):
+            return
+        await _refresh_panel(interaction, _view_of(self))
+        if channel_ids:
+            await interaction.followup.send(
+                f"✅ Allowed channels updated ({len(channel_ids)} "
+                f"channel{'s' if len(channel_ids) != 1 else ''}).",
+                ephemeral=True,
+            )
+        else:
+            await interaction.followup.send(
+                "✅ Allowed channel list cleared.",
+                ephemeral=True,
+            )
+
+
+class _BackToHubButton(discord.ui.Button):
+    def __init__(self) -> None:
+        super().__init__(
+            label="Back to Hub",
+            style=discord.ButtonStyle.secondary,
+            emoji="↩",
+            custom_id="settings_command_access.back",
+            row=2,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.settings.hub import SettingsHubView
+
+        view = SettingsHubView(interaction.user)
+        await interaction.response.edit_message(
+            embed=SettingsHubView.build_embed(),
+            view=view,
+        )
+
+
+def _view_of(item: discord.ui.Item) -> CommandAccessView:
+    """Type-narrowing helper: returns the parent view as
+    :class:`CommandAccessView`.
+
+    discord.py exposes ``item.view`` as ``View | None``; every callback
+    here only runs while the item is attached to its parent, so the
+    narrow is safe at runtime.
+    """
+    view = item.view
+    if not isinstance(view, CommandAccessView):
+        raise TypeError(
+            f"Expected CommandAccessView parent, got {type(view).__name__}",
+        )
+    return view
+
+
+class CommandAccessView(HubView):
+    """Settings Manager panel for per-guild command-access policy."""
+
+    def __init__(self, author: discord.Member | discord.User) -> None:
+        super().__init__(author)
+        self.add_item(_AllChannelsButton())
+        self.add_item(_SelectedChannelsButton())
+        self.add_item(_DisabledButton())
+        self.add_item(_ChannelAllowlistSelect())
+        self.add_item(_BackToHubButton())
+
+
+__all__ = ["CommandAccessView", "build_command_access_embed"]

--- a/disbot/views/settings/hub.py
+++ b/disbot/views/settings/hub.py
@@ -252,6 +252,36 @@ class _OpenAudit(discord.ui.Button):
         await interaction.response.edit_message(embed=embed, view=view)
 
 
+class _OpenCommandAccess(discord.ui.Button):
+    """Open the per-guild command-access (allowed-channels) panel.
+
+    The panel mutates state, but the ``!settings`` group is already
+    gated by ``@commands.has_permissions(administrator=True)`` so
+    reaching this button implies admin.  The view itself re-checks
+    Administrator / Manage Guild on every callback as a defence in
+    depth.
+    """
+
+    def __init__(self):
+        super().__init__(
+            label="Command access",
+            style=discord.ButtonStyle.secondary,
+            emoji="🚪",
+            custom_id="settings_hub.command_access",
+            row=2,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from views.settings.edit_command_access import (
+            CommandAccessView,
+            build_command_access_embed,
+        )
+
+        view = CommandAccessView(interaction.user)
+        embed = await build_command_access_embed(interaction.guild_id)
+        await interaction.response.edit_message(embed=embed, view=view)
+
+
 class SettingsHubView(HubView):
     """Top-level navigation for the Settings Manager (S5)."""
 
@@ -262,6 +292,7 @@ class SettingsHubView(HubView):
         self.add_item(_OpenInvalid())
         self.add_item(_OpenMissingBindings())
         self.add_item(_OpenAudit())
+        self.add_item(_OpenCommandAccess())
 
     @staticmethod
     def build_embed() -> discord.Embed:

--- a/docs/AGENT_ORIENTATION.md
+++ b/docs/AGENT_ORIENTATION.md
@@ -90,6 +90,29 @@ read **`docs/helper-policy.md`** first.
 1. `docs/smoke-test-checklist.md` — what must be smoked before a runtime-relevant PR ships. Pinned to `ReadinessSnapshot` by `tests/unit/docs/test_smoke_test_checklist.py`.
 2. `tests/unit/docs/` — every doc-pinning test. Adding or removing a doc that has a pinning test means the test changes too.
 
+### Touching command access (prefix + slash admission)
+
+1. `disbot/core/runtime/command_access.py` — the resolver
+   (`resolve_command_access`), adapters (`from_prefix_ctx` /
+   `from_interaction`), and the bootstrap allowlist.  Both the
+   prefix global check and `bot.tree.interaction_check` delegate
+   here.
+2. `disbot/services/command_access_service.py` — the canonical write
+   path (`set_mode`, `replace_allowed_channels`, the `set_policy`
+   composite).  Every operator-facing mutation must route through
+   this module so cache invalidation + audit emission stay in step.
+3. `disbot/cogs/bootstrap_access_cog.py` — installs both gates
+   (prefix `_channel_guard` and `tree.interaction_check`).  Loads
+   first in `config.INITIAL_EXTENSIONS`.
+4. `disbot/views/settings/edit_command_access.py` + the
+   `Command access` button on `views/settings/hub.py` — the
+   operator UI surface.
+5. `disbot/migrations/050_guild_command_access.sql` (schema) +
+   `051_command_access_main_server_backfill.sql` (data) — the
+   policy storage and the main-server backfill.  Add to
+   migration 050's CHECK constraint before adding a new
+   `AccessMode` literal.
+
 ### Touching AI / setup advisor
 
 1. `docs/ai-config-ownership.md` — binding contract for the AI cog's

--- a/docs/smoke-test-checklist.md
+++ b/docs/smoke-test-checklist.md
@@ -140,6 +140,47 @@ prefix `!setup` opens the wizard hub.
       inventory and matches the readiness snapshot's setup blocker
       summary.
 
+## Command-access onboarding
+
+The command-access onboarding fix (migrations 050 + 051) is the
+canonical admission path for every prefix + slash command.  Smoke
+each shape so a regression in resolver / cog wiring / settings UI /
+migration is caught before it strands fresh guilds again.
+
+- [ ] **Fresh guild, no DB row** — invite the bot to a clean test
+      guild.  `!help` works for the operator (bootstrap bypass) and
+      `!bj` works in any channel (unconfigured guild defaults to
+      `all_channels`).  `/blackjack` matches.
+- [ ] **`!settings → Command access`** opens the policy panel and
+      renders the current mode + allowed channels.  Switching to
+      `selected_channels` mode, picking one channel, and clicking
+      back to Hub returns to the hub embed without raising.
+- [ ] **`selected_channels` denial** — with the policy from the
+      previous step, `!bj` in a non-allowed channel posts the
+      "Commands aren't enabled in this channel…" reply
+      (`delete_after=10`) and the command does not run.
+      `/blackjack` in the same channel posts the same text as an
+      ephemeral.
+- [ ] **`disabled_except_bootstrap`** — switching to this mode and
+      running `!bj` posts the "Commands are disabled…" feedback;
+      `!setup` and `!settings` still work for the operator
+      (bootstrap bypass intact).
+- [ ] **`!platform command-access [#channel]`** prints the
+      structured decision embed: configured mode, allowed
+      channels, decision (yes/no), reason code, source, and the
+      bootstrap probe.  No audit row is emitted by the probe
+      (check the `audit_log` table after the run).
+- [ ] **Main-server backfill** — confirm migration 051 wrote a
+      `selected_channels` row for the main server (
+      `SELECT * FROM guild_command_access_policy WHERE
+      guild_id = <main_server_guild_id>;`).  Verify `!bj` still
+      works in the configured channels and is denied elsewhere.
+- [ ] **Metric stream** — scrape `/metrics` while exercising the
+      above.  `command_access_decisions_total{decision="allow"}`
+      and `…{decision="deny"}` both increment with the correct
+      reason/source labels.
+
+
 ## Shutdown drain
 
 Trigger `SIGTERM` (or run `kill -TERM $PID`) and observe:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,11 @@
+# Dev-only dependencies needed to run lint + tests locally / in CI / in
+# Claude Code on the web sessions.  Mirrors the install block in
+# `.github/workflows/code-quality.yml` so local and CI agree on tool
+# versions.  Install with `bash scripts/setup_dev_env.sh` or:
+#   pip install -r requirements.txt -r requirements-dev.txt
+black
+isort
+ruff
+mypy
+pytest
+pytest-asyncio

--- a/scripts/setup_dev_env.sh
+++ b/scripts/setup_dev_env.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Provision the dev environment for SuperBot.
+#
+# Designed to be the one-shot setup command for Claude Code on the web
+# environments (and any local dev environment).  Idempotent — re-runs
+# are cheap.
+#
+# What it installs:
+#   1. Runtime deps (requirements.txt: discord.py, asyncpg, etc.)
+#   2. Dev tools (requirements-dev.txt: pytest, pytest-asyncio, black,
+#      isort, ruff, mypy) — the same set CI installs in
+#      .github/workflows/code-quality.yml.
+#
+# After this runs, both:
+#   * direct ``python -m pytest tests/...``
+#   * the project quality script ``python scripts/check_quality.py
+#     [--check-only|--full]``
+# work end-to-end without further setup.
+#
+# In environments that use uv-managed tool venvs at
+# /root/.local/share/uv/tools/* (Claude Code on the web's default tool
+# layout), the runtime deps are mirrored into the pytest tool venv so
+# pytest's plugin discovery — which imports project modules that import
+# discord/asyncpg — succeeds.  Without this step pytest collects 0
+# items in the project's test tree.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "── SuperBot dev-env setup ──────────────────────────────────"
+
+# Step 1: install runtime + dev deps into system Python.  We do NOT
+# upgrade pip itself — distro-packaged pips (debian/ubuntu) refuse
+# self-upgrade with a "RECORD file not found" error, and the pip
+# version is irrelevant to dependency resolution here.
+echo "[1/3] pip install runtime deps..."
+python -m pip install --quiet -r requirements.txt
+echo "[2/3] pip install dev deps..."
+python -m pip install --quiet -r requirements-dev.txt
+
+# Step 2: mirror into the uv-managed pytest tool venv if present, so
+# `/root/.local/bin/pytest` (the tool-managed entry point) can import
+# discord / asyncpg through the project's test modules.  No-op when uv
+# tools are not in use.
+if command -v uv >/dev/null 2>&1; then
+    PYTEST_VENV_PY="/root/.local/share/uv/tools/pytest/bin/python"
+    if [ -x "$PYTEST_VENV_PY" ]; then
+        echo "[3/3] mirror runtime deps into uv-managed pytest venv..."
+        uv pip install --quiet --python "$PYTEST_VENV_PY" -r requirements.txt
+    else
+        echo "[3/3] uv present but no pytest tool venv — skipping mirror."
+    fi
+    # Ensure isort is on PATH (CI uses it; the post-edit hook calls
+    # `isort` directly and crashes when missing).
+    if ! command -v isort >/dev/null 2>&1; then
+        uv tool install --quiet isort || true
+    fi
+else
+    echo "[3/3] uv not present — skipping uv-managed mirror."
+fi
+
+echo "✓ dev environment ready"

--- a/tests/unit/cogs/test_bootstrap_access_cog.py
+++ b/tests/unit/cogs/test_bootstrap_access_cog.py
@@ -1,21 +1,28 @@
-"""Behavior tests for ``cogs.bootstrap_access_cog``.
+"""Behavior tests for ``cogs.bootstrap_access_cog`` (post-PR-4).
 
-These pin the runtime wiring that PR #220 introduced:
+These pin the runtime wiring around the central command-access guard:
 
-* ``setup(bot)`` removes the legacy ``_channel_guard`` registered by
-  ``bot1.py`` and installs the fresh-guild-aware guard in its place.
-* The new guard preserves the historical contract:
-    - inside ``config.ALLOWED_CHANNELS`` → allow;
-    - ``!force`` → allow regardless of channel;
-    - guild operators on bootstrap commands → allow even outside
-      ``ALLOWED_CHANNELS``;
-    - everyone else outside ``ALLOWED_CHANNELS`` → deny.
-* The legacy ``_shutting_down`` flag is still honored when its source
-  module is reachable through the captured legacy guard.
-* The cog's ``on_command_error`` listener surfaces ``MissingPermissions``
-  for bootstrap commands invoked outside allowed channels (so guild
-  operators see why a command was refused after the channel guard let it
-  through to the permission check).
+* ``setup(bot)`` removes any leftover legacy / bootstrap-remnant
+  ``_channel_guard`` and installs the cog's bound-method check exactly
+  once.  This is the load-order invariant: the cog is loaded first in
+  ``config.INITIAL_EXTENSIONS`` so the gate is in place before any
+  other cog registers a command.
+* The guard delegates to
+  :func:`core.runtime.command_access.resolve_command_access`.  Tests
+  mock the typed-accessor policy load so each scenario controls the
+  effective per-guild mode without touching real DB or cache.
+* ``!force`` is still admitted inline (admin escape hatch — the
+  per-command ``@has_permissions(administrator=True)`` on the
+  ``force`` definition is what makes the override admin-only).
+* Denial with feedback posts the resolver-supplied message before
+  returning ``False`` so the CheckFailure doesn't look like a silent
+  crash to the operator (the regression PR-4 was written to fix).
+* Lifecycle-drain denial is silent (no feedback in the payload —
+  feedback would race the connection close).
+
+The pre-PR-4 ``on_command_error`` listener is deleted; ``bot1.py``'s
+error handler now surfaces user-facing replies in every channel, so
+the listener's bootstrap-specific surface was redundant.
 """
 
 from __future__ import annotations
@@ -26,26 +33,32 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from discord.ext import commands
 
-import config
 from cogs.bootstrap_access_cog import (
     BootstrapAccessCog,
     _find_channel_guard_checks,
     setup,
 )
+from utils.guild_config_accessors import CommandAccessPolicySnapshot
 
 
 def _legacy_channel_guard_factory(shutting_down: bool = False):
-    """Build a stand-in for the ``bot1._channel_guard`` global check."""
+    """Build a stand-in for the pre-PR-4 ``bot1._channel_guard`` global check.
+
+    The legacy guard is gone from ``bot1.py`` post-PR-4, but
+    ``setup()`` still sweeps any leftover check named
+    ``_channel_guard`` so a hot-reload from an older codebase settles
+    to a single check.  These factories let the cleanup tests exercise
+    that branch.
+    """
 
     async def _channel_guard(ctx):  # noqa: ARG001 — name-shape matters
         return not shutting_down
 
-    _channel_guard.__globals__["_shutting_down"] = shutting_down
     return _channel_guard
 
 
 def _make_bot_with_legacy_guard(shutting_down: bool = False):
-    """Mimic the state ``bot1.py`` leaves the bot in before cog load."""
+    """Mimic the state a pre-PR-4 ``bot1.py`` would leave the bot in."""
     bot = MagicMock(spec=commands.Bot)
     legacy = _legacy_channel_guard_factory(shutting_down=shutting_down)
     bot._checks = [legacy]
@@ -71,9 +84,9 @@ def _make_bot_with_legacy_guard(shutting_down: bool = False):
 
 def _ctx(
     *,
-    channel_id: int,
-    guild: object | None = None,
-    command_name: str = "help",
+    channel_id: int = 100,
+    guild_id: int | None = 10,
+    command_name: str = "blackjack",
     qualified_name: str | None = None,
     aliases: tuple[str, ...] = (),
     invoked_with: str | None = None,
@@ -81,9 +94,13 @@ def _ctx(
     owner_id: int = 10,
     administrator: bool = False,
     manage_guild: bool = False,
+    is_bot_owner: bool = False,
 ):
-    if guild is None:
-        guild = SimpleNamespace(owner_id=owner_id)
+    guild = (
+        SimpleNamespace(id=guild_id, owner_id=owner_id)
+        if guild_id is not None
+        else None
+    )
     author = SimpleNamespace(
         id=author_id,
         guild_permissions=SimpleNamespace(
@@ -97,7 +114,7 @@ def _ctx(
         aliases=aliases,
     )
     send = AsyncMock()
-    bot = SimpleNamespace(is_owner=AsyncMock(return_value=False))
+    bot = SimpleNamespace(is_owner=AsyncMock(return_value=is_bot_owner))
     return SimpleNamespace(
         guild=guild,
         channel=SimpleNamespace(id=channel_id),
@@ -106,6 +123,24 @@ def _ctx(
         invoked_with=invoked_with or command_name,
         bot=bot,
         send=send,
+    )
+
+
+def _patch_policy(monkeypatch, mode: str | None, *allowed_channels: int) -> None:
+    """Stub the resolver's typed-accessor read so the policy lookup is
+    controlled by the test rather than the real cache + DB.
+
+    ``mode=None`` simulates an unconfigured guild (no policy row);
+    pass a mode literal + channel IDs to simulate ``selected_channels``
+    or other configured states.
+    """
+    snapshot = CommandAccessPolicySnapshot(
+        mode=mode,
+        allowed_channels=frozenset(allowed_channels),
+    )
+    monkeypatch.setattr(
+        "utils.guild_config_accessors.get_command_access_policy",
+        AsyncMock(return_value=snapshot),
     )
 
 
@@ -158,36 +193,68 @@ def test_find_channel_guard_checks_matches_by_name():
 
 
 # ---------------------------------------------------------------------------
-# _channel_guard — behavior preservation
+# _channel_guard — admits via the resolver
 # ---------------------------------------------------------------------------
 
 
-async def test_channel_guard_allows_inside_allowed_channels(monkeypatch):
-    monkeypatch.setattr(config, "ALLOWED_CHANNELS", {12345})
+async def test_channel_guard_admits_under_default_all_channels(monkeypatch):
+    """Unconfigured guild → resolver returns ``allowed=True`` under the
+    ``all_channels`` default, so a non-operator's normal command runs
+    anywhere.  This is the fresh-guild fix: ``!bj`` works without any
+    setup having been completed.
+    """
+    _patch_policy(monkeypatch, mode=None)
     cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
-    ctx = _ctx(channel_id=12345, command_name="daily")
+    ctx = _ctx(channel_id=999, command_name="blackjack")
 
     assert await cog._channel_guard(ctx) is True
+    ctx.send.assert_not_called()
 
 
-async def test_channel_guard_allows_force_outside_allowed_channels(monkeypatch):
-    monkeypatch.setattr(config, "ALLOWED_CHANNELS", set())
+async def test_channel_guard_admits_inside_selected_channel(monkeypatch):
+    _patch_policy(monkeypatch, "selected_channels", 12345)
+    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
+    ctx = _ctx(channel_id=12345, command_name="blackjack")
+
+    assert await cog._channel_guard(ctx) is True
+    ctx.send.assert_not_called()
+
+
+async def test_channel_guard_admits_force_under_restrictive_policy(monkeypatch):
+    """``!force`` bypasses the resolver — preserves the legacy admin
+    override semantics.  The per-command
+    ``@has_permissions(administrator=True)`` decorator on ``force``
+    is what makes the override admin-only; the cog only short-circuits
+    so the override is reachable outside allowed channels.
+    """
+    _patch_policy(monkeypatch, "selected_channels")  # empty allowlist
     cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
     ctx = _ctx(channel_id=999, command_name="force")
 
     assert await cog._channel_guard(ctx) is True
+    ctx.send.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _channel_guard — bootstrap bypass preserved
+# ---------------------------------------------------------------------------
 
 
 async def test_channel_guard_allows_guild_owner_for_bootstrap_command(monkeypatch):
-    monkeypatch.setattr(config, "ALLOWED_CHANNELS", set())
+    """Bootstrap bypass: owner can run ``!setup`` under any policy, in
+    any channel.  Resolver's BOOTSTRAP_BYPASS branch fires before the
+    policy lookup.
+    """
+    _patch_policy(monkeypatch, "disabled_except_bootstrap")
     cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
     ctx = _ctx(channel_id=999, command_name="setup", author_id=42, owner_id=42)
 
     assert await cog._channel_guard(ctx) is True
+    ctx.send.assert_not_called()
 
 
 async def test_channel_guard_allows_administrator_for_bootstrap_command(monkeypatch):
-    monkeypatch.setattr(config, "ALLOWED_CHANNELS", set())
+    _patch_policy(monkeypatch, "selected_channels")
     cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
     ctx = _ctx(
         channel_id=999,
@@ -201,7 +268,7 @@ async def test_channel_guard_allows_administrator_for_bootstrap_command(monkeypa
 
 
 async def test_channel_guard_allows_manage_guild_for_bootstrap_command(monkeypatch):
-    monkeypatch.setattr(config, "ALLOWED_CHANNELS", set())
+    _patch_policy(monkeypatch, "selected_channels")
     cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
     ctx = _ctx(
         channel_id=999,
@@ -215,47 +282,107 @@ async def test_channel_guard_allows_manage_guild_for_bootstrap_command(monkeypat
 
 
 async def test_channel_guard_allows_bot_owner_for_bootstrap_command(monkeypatch):
-    monkeypatch.setattr(config, "ALLOWED_CHANNELS", set())
+    _patch_policy(monkeypatch, "selected_channels")
     cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
-    ctx = _ctx(channel_id=999, command_name="setup", author_id=99, owner_id=42)
-    ctx.bot.is_owner = AsyncMock(return_value=True)
+    ctx = _ctx(
+        channel_id=999,
+        command_name="setup",
+        author_id=99,
+        owner_id=42,
+        is_bot_owner=True,
+    )
 
     assert await cog._channel_guard(ctx) is True
 
 
 async def test_channel_guard_denies_non_operator_for_bootstrap_command(monkeypatch):
-    monkeypatch.setattr(config, "ALLOWED_CHANNELS", set())
+    """Bootstrap bypass requires operator/owner privilege.  A regular
+    user running ``!setup`` outside allowed channels under
+    ``selected_channels`` mode falls through to the channel check and
+    is denied with feedback.
+    """
+    _patch_policy(monkeypatch, "selected_channels", 12345)
     cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
     ctx = _ctx(channel_id=999, command_name="setup", author_id=99, owner_id=42)
 
     assert await cog._channel_guard(ctx) is False
 
 
-async def test_channel_guard_denies_normal_command_outside_allowed_channels(monkeypatch):
-    monkeypatch.setattr(config, "ALLOWED_CHANNELS", set())
+# ---------------------------------------------------------------------------
+# _channel_guard — denial + feedback
+# ---------------------------------------------------------------------------
+
+
+async def test_channel_guard_denies_normal_command_outside_selected_channels(
+    monkeypatch,
+):
+    """The core fresh-guild bug in reverse: in a guild that has
+    deliberately configured ``selected_channels``, normal commands
+    outside the allowlist must be denied — but with visible feedback,
+    not the legacy silent CheckFailure.
+    """
+    _patch_policy(monkeypatch, "selected_channels", 12345)
     cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
-    ctx = _ctx(channel_id=999, command_name="daily", author_id=42, owner_id=42)
+    ctx = _ctx(channel_id=999, command_name="blackjack", author_id=42, owner_id=42)
+
+    assert await cog._channel_guard(ctx) is False
+    ctx.send.assert_awaited_once()
+    message, kwargs = ctx.send.await_args.args[0], ctx.send.await_args.kwargs
+    # Feedback must point operators at the recovery path.
+    assert "channel" in message.lower() or "settings" in message.lower()
+    # delete_after keeps the channel tidy under repeated denials.
+    assert kwargs.get("delete_after") == 10
+
+
+async def test_channel_guard_denies_normal_command_under_disabled_mode(monkeypatch):
+    _patch_policy(monkeypatch, "disabled_except_bootstrap")
+    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
+    ctx = _ctx(channel_id=999, command_name="blackjack", author_id=42, owner_id=42)
+
+    assert await cog._channel_guard(ctx) is False
+    ctx.send.assert_awaited_once()
+    message = ctx.send.await_args.args[0]
+    assert "!setup" in message or "settings" in message.lower()
+
+
+async def test_channel_guard_tolerates_send_failure(monkeypatch):
+    """If ``ctx.send`` raises (channel deleted mid-denial, missing
+    permissions, etc.) the guard must still return False instead of
+    propagating the exception up into the discord.py check chain.
+    """
+    _patch_policy(monkeypatch, "selected_channels")
+    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
+    ctx = _ctx(channel_id=999, command_name="blackjack")
+    ctx.send = AsyncMock(side_effect=RuntimeError("send failed"))
 
     assert await cog._channel_guard(ctx) is False
 
 
-async def test_channel_guard_denies_dm_context(monkeypatch):
-    monkeypatch.setattr(config, "ALLOWED_CHANNELS", {12345})
+async def test_channel_guard_denies_dm_context_silently(monkeypatch):
+    """DM invocations: resolver returns ``allowed=False, feedback=None``
+    so the guard denies without sending — DMs that opt into
+    DM-friendly commands handle their own routing.
+    """
+    _patch_policy(monkeypatch, None)
     cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
-    ctx = _ctx(channel_id=12345, guild=None, command_name="help")
-    ctx.guild = None
+    ctx = _ctx(guild_id=None, command_name="help")
 
     assert await cog._channel_guard(ctx) is False
+    ctx.send.assert_not_called()
 
 
 async def test_channel_guard_blocks_when_lifecycle_is_shutting_down(monkeypatch):
     """LP-2: command admission consults
-    :func:`core.runtime.lifecycle.can_accept_commands` (no longer the
-    legacy ``_shutting_down`` attribute on the previous guard).
+    :func:`core.runtime.lifecycle.can_accept_commands` (the resolver
+    runs the lifecycle check first; the channel-guard chain inherits
+    this without needing its own duplicate check).
+
+    No feedback under lifecycle drain — message would race the
+    connection close.
     """
     from core.runtime import lifecycle
 
-    monkeypatch.setattr(config, "ALLOWED_CHANNELS", {12345})
+    _patch_policy(monkeypatch, None)
     lifecycle.reset_for_tests()
     lifecycle.set_phase(lifecycle.Phase.RUNNING)
     lifecycle.request_shutdown("test")
@@ -264,73 +391,6 @@ async def test_channel_guard_blocks_when_lifecycle_is_shutting_down(monkeypatch)
         ctx = _ctx(channel_id=12345, command_name="help")
 
         assert await cog._channel_guard(ctx) is False
+        ctx.send.assert_not_called()
     finally:
         lifecycle.reset_for_tests()
-
-
-# ---------------------------------------------------------------------------
-# on_command_error — bootstrap-only feedback
-# ---------------------------------------------------------------------------
-
-
-async def test_on_command_error_replies_for_missing_permissions_on_bootstrap(monkeypatch):
-    monkeypatch.setattr(config, "ALLOWED_CHANNELS", set())
-    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
-    ctx = _ctx(channel_id=999, command_name="settings")
-    error = commands.MissingPermissions(["manage_guild"])
-
-    await cog.on_command_error(ctx, error)
-
-    ctx.send.assert_awaited()
-
-
-async def test_on_command_error_silent_for_non_bootstrap_command(monkeypatch):
-    monkeypatch.setattr(config, "ALLOWED_CHANNELS", set())
-    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
-    ctx = _ctx(channel_id=999, command_name="daily")
-    error = commands.MissingPermissions(["manage_guild"])
-
-    await cog.on_command_error(ctx, error)
-
-    ctx.send.assert_not_called()
-
-
-async def test_on_command_error_silent_inside_allowed_channels(monkeypatch):
-    monkeypatch.setattr(config, "ALLOWED_CHANNELS", {12345})
-    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
-    ctx = _ctx(channel_id=12345, command_name="settings")
-    error = commands.MissingPermissions(["manage_guild"])
-
-    await cog.on_command_error(ctx, error)
-
-    ctx.send.assert_not_called()
-
-
-@pytest.mark.parametrize(
-    ("error_factory", "expected_substring"),
-    [
-        (lambda: commands.BotMissingPermissions(["send_messages"]), "missing permissions"),
-        (
-            lambda: commands.MissingRequiredArgument(
-                SimpleNamespace(name="user", displayed_name="user"),
-            ),
-            "Missing argument",
-        ),
-        (lambda: commands.BadArgument("nope"), "Bad argument"),
-        (lambda: commands.CommandOnCooldown(SimpleNamespace(), 1.0, type=None), "cooldown"),
-    ],
-)
-async def test_on_command_error_handles_each_known_error(
-    monkeypatch,
-    error_factory,
-    expected_substring,
-):
-    monkeypatch.setattr(config, "ALLOWED_CHANNELS", set())
-    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
-    ctx = _ctx(channel_id=999, command_name="diagnostics")
-
-    await cog.on_command_error(ctx, error_factory())
-
-    ctx.send.assert_awaited()
-    message = ctx.send.await_args.args[0]
-    assert expected_substring.lower() in message.lower()

--- a/tests/unit/cogs/test_bootstrap_access_reload.py
+++ b/tests/unit/cogs/test_bootstrap_access_reload.py
@@ -33,6 +33,7 @@ from cogs.bootstrap_access_cog import (
 def _legacy_guard_fn():
     async def _channel_guard(ctx):  # noqa: ARG001
         return True
+
     _channel_guard.__globals__["_shutting_down"] = False
     return _channel_guard
 
@@ -51,6 +52,12 @@ def _make_bot(*initial_checks):
     bot.remove_check = MagicMock(side_effect=_remove)
     bot.add_check = MagicMock(side_effect=_add)
     bot.add_cog = AsyncMock()
+    # Real attribute so ``setup()``'s tree.interaction_check assignment
+    # writes to an inspectable slot (PR-5).  ``None`` starts the slot
+    # in the "before any installer ran" state.
+    from types import SimpleNamespace
+
+    bot.tree = SimpleNamespace(interaction_check=None)
     return bot
 
 
@@ -212,3 +219,71 @@ async def test_unload_then_reload_keeps_exactly_one_check():
     bot.add_cog = AsyncMock()
     await setup(bot)
     assert len(_find_channel_guard_checks(bot)) == 1
+
+
+# ---------------------------------------------------------------------------
+# PR-5 — slash ``tree.interaction_check`` reload safety
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_first_load_installs_tree_interaction_check():
+    """After ``setup()`` the cog owns ``tree.interaction_check``."""
+    bot = _make_bot()
+    await setup(bot)
+    cog = bot.add_cog.await_args.args[0]
+    # Bound methods aren't ``is``-identical across attribute lookups;
+    # compare the function + bound instance instead.
+    assert bot.tree.interaction_check.__func__ is BootstrapAccessCog._slash_access_check
+    assert bot.tree.interaction_check.__self__ is cog
+
+
+@pytest.mark.asyncio
+async def test_reload_replaces_stale_bootstrap_owned_interaction_check():
+    """A previous load left its bound method pinned to the dead cog
+    instance.  ``setup()`` must overwrite it with the new cog's
+    method — otherwise every slash invocation would route through a
+    closure on an unloaded cog.
+    """
+    bot = _make_bot()
+    prev_cog = BootstrapAccessCog(bot)
+    bot.tree.interaction_check = prev_cog._slash_access_check
+
+    await setup(bot)
+
+    new_cog = bot.add_cog.await_args.args[0]
+    assert bot.tree.interaction_check.__func__ is BootstrapAccessCog._slash_access_check
+    assert bot.tree.interaction_check.__self__ is new_cog
+    assert bot.tree.interaction_check.__self__ is not prev_cog
+
+
+@pytest.mark.asyncio
+async def test_unload_restores_default_interaction_check():
+    """``cog_unload`` resets ``tree.interaction_check`` to the trivial
+    always-True coroutine so the next ``setup()`` overwrites cleanly
+    without a stale bound method clinging to the unloaded cog.
+    """
+    from cogs.bootstrap_access_cog import _default_interaction_check
+
+    bot = _make_bot()
+    await setup(bot)
+    cog = bot.add_cog.await_args.args[0]
+
+    cog.cog_unload()
+    assert bot.tree.interaction_check is _default_interaction_check
+
+
+@pytest.mark.asyncio
+async def test_unload_then_reload_keeps_tree_check_owned_by_new_cog():
+    """Full round-trip on the slash slot mirrors the prefix one."""
+    bot = _make_bot()
+    await setup(bot)
+    first_cog = bot.add_cog.await_args.args[0]
+    first_cog.cog_unload()
+
+    bot.add_cog = AsyncMock()
+    await setup(bot)
+    new_cog = bot.add_cog.await_args.args[0]
+    assert bot.tree.interaction_check.__func__ is BootstrapAccessCog._slash_access_check
+    assert bot.tree.interaction_check.__self__ is new_cog
+    assert bot.tree.interaction_check.__self__ is not first_cog

--- a/tests/unit/cogs/test_command_access_diagnostic.py
+++ b/tests/unit/cogs/test_command_access_diagnostic.py
@@ -1,0 +1,364 @@
+"""PR-8 — ``!platform command-access`` diagnostic + decision metric.
+
+Pins:
+
+* :func:`build_command_access_diagnostic_embed` produces a structured
+  embed naming the configured mode, the resolver decision, the
+  bootstrap probe, and any recovery banner — without emitting an
+  audit row (the probe is synthetic).
+* :func:`resolve_command_access` increments
+  :data:`services.metrics.command_access_decisions_total` exactly
+  once per call, with the correct label values.
+
+Both surfaces rely on the resolver behaviour pinned by
+``tests/unit/runtime/test_command_access_resolver.py``; this module
+covers only the new diagnostic + observability wiring layered on top.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cogs.diagnostic._platform_embeds import (
+    build_command_access_diagnostic_embed,
+)
+from utils.guild_config_accessors import CommandAccessPolicySnapshot
+
+
+def _snapshot(mode: str | None, *channel_ids: int) -> CommandAccessPolicySnapshot:
+    return CommandAccessPolicySnapshot(
+        mode=mode,
+        allowed_channels=frozenset(channel_ids),
+    )
+
+
+def _ctx(
+    *,
+    guild_id: int | None = 10,
+    channel_id: int = 100,
+    user_id: int = 42,
+    owner_id: int = 42,
+    administrator: bool = False,
+    is_bot_owner: bool = False,
+):
+    guild = (
+        SimpleNamespace(id=guild_id, owner_id=owner_id)
+        if guild_id is not None
+        else None
+    )
+    author = SimpleNamespace(
+        id=user_id,
+        guild_permissions=SimpleNamespace(
+            administrator=administrator,
+            manage_guild=False,
+        ),
+    )
+    return SimpleNamespace(
+        guild=guild,
+        channel=SimpleNamespace(id=channel_id),
+        author=author,
+        bot=SimpleNamespace(is_owner=AsyncMock(return_value=is_bot_owner)),
+    )
+
+
+def _channel(channel_id: int = 100) -> SimpleNamespace:
+    return SimpleNamespace(id=channel_id, mention=f"<#{channel_id}>")
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic embed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_embed_marks_admitted_channel_as_allowed():
+    """The fresh-guild happy path: no DB row, default mode admits the
+    channel, embed says **Yes — admitted**.
+    """
+    ctx = _ctx()
+    target = _channel(100)
+    snap = _snapshot(None)
+    with (
+        patch(
+            "services.command_access_service.get_policy_snapshot",
+            new=AsyncMock(return_value=snap),
+        ),
+        patch(
+            "utils.guild_config_accessors.get_command_access_policy",
+            new=AsyncMock(return_value=snap),
+        ),
+    ):
+        embed = await build_command_access_diagnostic_embed(
+            ctx=ctx,
+            target_channel=target,
+        )
+    text = "\n".join(f.value for f in embed.fields)
+    assert "**Yes**" in text
+    assert "all_channels" in text  # default-unconfigured label
+
+
+@pytest.mark.asyncio
+async def test_embed_marks_denied_channel_with_reason_and_feedback():
+    """``selected_channels`` mode + non-allowed channel: embed shows
+    the denial, the resolver's reason code, and the operator-facing
+    feedback message the user would have seen on a real invocation.
+    """
+    ctx = _ctx(administrator=True)
+    target = _channel(999)
+    snap = _snapshot("selected_channels", 100)
+    with (
+        patch(
+            "services.command_access_service.get_policy_snapshot",
+            new=AsyncMock(return_value=snap),
+        ),
+        patch(
+            "utils.guild_config_accessors.get_command_access_policy",
+            new=AsyncMock(return_value=snap),
+        ),
+    ):
+        embed = await build_command_access_diagnostic_embed(
+            ctx=ctx,
+            target_channel=target,
+        )
+    text = "\n".join(f.value for f in embed.fields)
+    assert "**No**" in text
+    assert "channel_not_allowed" in text
+    # Operator-facing feedback is surfaced alongside the technical reason.
+    assert "Commands aren't enabled in this channel" in text
+
+
+@pytest.mark.asyncio
+async def test_embed_disabled_mode_shows_recovery_field():
+    """``disabled_except_bootstrap`` is the most-confusing failure
+    mode; the embed must include the explicit recovery banner so
+    operators know to flip the mode via the settings panel.
+    """
+    ctx = _ctx(administrator=True)
+    target = _channel(100)
+    snap = _snapshot("disabled_except_bootstrap")
+    with (
+        patch(
+            "services.command_access_service.get_policy_snapshot",
+            new=AsyncMock(return_value=snap),
+        ),
+        patch(
+            "utils.guild_config_accessors.get_command_access_policy",
+            new=AsyncMock(return_value=snap),
+        ),
+    ):
+        embed = await build_command_access_diagnostic_embed(
+            ctx=ctx,
+            target_channel=target,
+        )
+    recovery = [f for f in embed.fields if f.name == "Recovery"]
+    assert len(recovery) == 1
+    assert "!settings" in recovery[0].value
+    assert "Command access" in recovery[0].value
+
+
+@pytest.mark.asyncio
+async def test_embed_includes_bootstrap_probe_for_operator():
+    """The operator running ``!platform command-access`` should also
+    see whether ``!setup`` would still admit them via the bootstrap
+    bypass — this is the "I'm not locked out" guarantee for the
+    panel.
+    """
+    ctx = _ctx(administrator=True)
+    target = _channel(999)
+    snap = _snapshot("disabled_except_bootstrap")
+    with (
+        patch(
+            "services.command_access_service.get_policy_snapshot",
+            new=AsyncMock(return_value=snap),
+        ),
+        patch(
+            "utils.guild_config_accessors.get_command_access_policy",
+            new=AsyncMock(return_value=snap),
+        ),
+    ):
+        embed = await build_command_access_diagnostic_embed(
+            ctx=ctx,
+            target_channel=target,
+        )
+    bootstrap_fields = [f for f in embed.fields if f.name.startswith("Bootstrap probe")]
+    assert len(bootstrap_fields) == 1
+    # Admin invoker → bootstrap probe must say allowed via bypass.
+    assert "bootstrap_bypass" in bootstrap_fields[0].value
+
+
+@pytest.mark.asyncio
+async def test_embed_emits_no_audit_row():
+    """The probe is synthetic — running it must NOT call any
+    mutation pipeline (otherwise it would pollute the audit log
+    every time an operator opened the diagnostic).
+    """
+    ctx = _ctx()
+    target = _channel(100)
+    snap = _snapshot(None)
+    with (
+        patch(
+            "services.command_access_service.get_policy_snapshot",
+            new=AsyncMock(return_value=snap),
+        ),
+        patch(
+            "utils.guild_config_accessors.get_command_access_policy",
+            new=AsyncMock(return_value=snap),
+        ),
+        patch(
+            "services.command_access_service.set_mode",
+            new=AsyncMock(),
+        ) as mock_set_mode,
+        patch(
+            "services.command_access_service.replace_allowed_channels",
+            new=AsyncMock(),
+        ) as mock_replace,
+    ):
+        await build_command_access_diagnostic_embed(
+            ctx=ctx,
+            target_channel=target,
+        )
+    mock_set_mode.assert_not_awaited()
+    mock_replace.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Decision metric
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolver_emits_decision_metric_with_correct_labels():
+    """Allow path under default-unconfigured: metric labels should be
+    ``invocation=prefix``, ``decision=allow``, ``reason=allowed``,
+    ``mode=all_channels``, ``source=default_unconfigured``.
+    """
+    from core.runtime.command_access import (
+        CommandAccessContext,
+        resolve_command_access,
+    )
+
+    ctx = CommandAccessContext(
+        guild_id=10,
+        channel_id=100,
+        user_id=42,
+        command_name="blackjack",
+        invocation_type="prefix",
+        is_guild_operator=False,
+        is_bot_owner=False,
+        is_dm=False,
+    )
+
+    counter_proxy = MagicMock()
+    labels_proxy = MagicMock()
+    counter_proxy.labels = MagicMock(return_value=labels_proxy)
+
+    with (
+        patch(
+            "utils.guild_config_accessors.get_command_access_policy",
+            new=AsyncMock(return_value=_snapshot(None)),
+        ),
+        patch(
+            "services.metrics.command_access_decisions_total",
+            new=counter_proxy,
+        ),
+    ):
+        decision = await resolve_command_access(ctx)
+
+    assert decision.allowed is True
+    counter_proxy.labels.assert_called_once_with(
+        invocation="prefix",
+        decision="allow",
+        reason="allowed",
+        mode="all_channels",
+        source="default_unconfigured",
+    )
+    labels_proxy.inc.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_resolver_metric_emit_failure_is_swallowed():
+    """An exception inside the metric emit must NOT propagate into
+    the admission decision — observability never blocks the gate.
+    """
+    from core.runtime.command_access import (
+        CommandAccessContext,
+        resolve_command_access,
+    )
+
+    ctx = CommandAccessContext(
+        guild_id=10,
+        channel_id=100,
+        user_id=42,
+        command_name="blackjack",
+        invocation_type="prefix",
+        is_guild_operator=False,
+        is_bot_owner=False,
+        is_dm=False,
+    )
+
+    blown_counter = MagicMock()
+    blown_counter.labels = MagicMock(side_effect=RuntimeError("prom broke"))
+
+    with (
+        patch(
+            "utils.guild_config_accessors.get_command_access_policy",
+            new=AsyncMock(return_value=_snapshot(None)),
+        ),
+        patch(
+            "services.metrics.command_access_decisions_total",
+            new=blown_counter,
+        ),
+    ):
+        # Must not raise.
+        decision = await resolve_command_access(ctx)
+    assert decision.allowed is True
+
+
+@pytest.mark.asyncio
+async def test_resolver_metric_uses_none_label_for_lifecycle_drain():
+    """Lifecycle-drain denial carries ``mode=None`` in the decision;
+    the metric label must surface the string ``"none"`` (Prometheus
+    label values cannot be Python ``None``).
+    """
+    from core.runtime import lifecycle
+    from core.runtime.command_access import (
+        CommandAccessContext,
+        resolve_command_access,
+    )
+
+    ctx = CommandAccessContext(
+        guild_id=10,
+        channel_id=100,
+        user_id=42,
+        command_name="blackjack",
+        invocation_type="slash",
+        is_guild_operator=False,
+        is_bot_owner=False,
+        is_dm=False,
+    )
+
+    counter_proxy = MagicMock()
+    counter_proxy.labels = MagicMock(return_value=MagicMock())
+
+    lifecycle.reset_for_tests()
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown("test")
+    try:
+        with patch(
+            "services.metrics.command_access_decisions_total",
+            new=counter_proxy,
+        ):
+            await resolve_command_access(ctx)
+    finally:
+        lifecycle.reset_for_tests()
+
+    counter_proxy.labels.assert_called_once_with(
+        invocation="slash",
+        decision="deny",
+        reason="lifecycle_draining",
+        mode="none",
+        source="lifecycle_deny",
+    )

--- a/tests/unit/db/test_command_access_db.py
+++ b/tests/unit/db/test_command_access_db.py
@@ -1,0 +1,249 @@
+"""PR-1 — guild command-access DB primitives.
+
+Mocks the asyncpg pool and asserts each primitive issues the expected
+SQL with the expected parameters.  Covers:
+
+* policy upsert + read
+* allowed-channel single insert / single delete (idempotent)
+* allowed-channel atomic bulk replace (DELETE + executemany inside a
+  ``conn.transaction()``)
+* ``forget_guild`` sweeps the parent row (CASCADE handles the rest)
+* mode validation rejects unknown modes
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from utils.db import command_access as db
+
+
+@pytest.fixture
+def _mock_pool():
+    """Returns a pool stub whose .get() yields an object with execute /
+    fetchrow / fetch AsyncMocks — the read-side primitives use these
+    directly.  Tests that need conn.acquire()/transaction() patch
+    pool.get separately so the connection-side mocks can be inspected.
+    """
+    pool_mock = MagicMock()
+    pool_mock.execute = AsyncMock()
+    pool_mock.fetchrow = AsyncMock()
+    pool_mock.fetch = AsyncMock()
+    with patch.object(db, "pool") as pool_module:
+        pool_module.get = MagicMock(return_value=pool_mock)
+        yield pool_mock
+
+
+def _build_conn_pool_stub():
+    """Build the acquire()/transaction() async-context-manager chain
+    used by ``replace_allowed_channels``.  Returns (pool_stub, conn).
+    """
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    conn.executemany = AsyncMock()
+    tx_cm = AsyncMock()
+    tx_cm.__aenter__ = AsyncMock(return_value=None)
+    tx_cm.__aexit__ = AsyncMock(return_value=None)
+    conn.transaction = MagicMock(return_value=tx_cm)
+    acquire_cm = AsyncMock()
+    acquire_cm.__aenter__ = AsyncMock(return_value=conn)
+    acquire_cm.__aexit__ = AsyncMock(return_value=None)
+    pool_stub = MagicMock(acquire=MagicMock(return_value=acquire_cm))
+    return pool_stub, conn
+
+
+# ---------------------------------------------------------------------------
+# Constants / validation
+# ---------------------------------------------------------------------------
+
+
+def test_known_modes_exposes_three_modes():
+    assert db.KNOWN_MODES == frozenset(
+        {"all_channels", "selected_channels", "disabled_except_bootstrap"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_mode_rejects_unknown_mode(_mock_pool):
+    with pytest.raises(ValueError):
+        await db.set_mode(guild_id=10, mode="garbage", updated_by=99)
+    _mock_pool.execute.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Policy row — read / upsert
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_policy_returns_none_when_absent(_mock_pool):
+    _mock_pool.fetchrow.return_value = None
+    assert await db.get_policy(10) is None
+    sql, *args = _mock_pool.fetchrow.await_args.args
+    assert "FROM guild_command_access_policy" in sql
+    assert args == [10]
+
+
+@pytest.mark.asyncio
+async def test_get_policy_returns_row_dict(_mock_pool):
+    _mock_pool.fetchrow.return_value = {
+        "mode": "selected_channels",
+        "updated_by": 99,
+        "updated_at": None,
+        "created_at": None,
+    }
+    row = await db.get_policy(10)
+    assert row is not None
+    assert row["mode"] == "selected_channels"
+    assert row["updated_by"] == 99
+
+
+@pytest.mark.asyncio
+async def test_set_mode_issues_upsert_with_correct_params(_mock_pool):
+    await db.set_mode(guild_id=10, mode="all_channels", updated_by=99)
+    sql, *args = _mock_pool.execute.await_args.args
+    assert "INSERT INTO guild_command_access_policy" in sql
+    assert "ON CONFLICT (guild_id)" in sql
+    # Only mode / updated_by / updated_at move on conflict — created_at
+    # is preserved.  Pin both that and the absence of created_at in
+    # the UPDATE clause.
+    assert "mode       = EXCLUDED.mode" in sql
+    assert "updated_by = EXCLUDED.updated_by" in sql
+    assert "updated_at = NOW()" in sql
+    assert "created_at" not in sql.split("DO UPDATE SET")[1]
+    assert args == [10, "all_channels", 99]
+
+
+@pytest.mark.asyncio
+async def test_set_mode_accepts_null_updated_by(_mock_pool):
+    """Migration-installed rows pass updated_by=None."""
+    await db.set_mode(guild_id=10, mode="disabled_except_bootstrap", updated_by=None)
+    _, _, _, updated_by = _mock_pool.execute.await_args.args
+    assert updated_by is None
+
+
+# ---------------------------------------------------------------------------
+# Allowed channels — list / add / remove
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_allowed_channels_returns_sorted_ids(_mock_pool):
+    _mock_pool.fetch.return_value = [
+        {"channel_id": 100},
+        {"channel_id": 200},
+        {"channel_id": 300},
+    ]
+    ids = await db.list_allowed_channels(10)
+    assert ids == [100, 200, 300]
+    sql, *args = _mock_pool.fetch.await_args.args
+    assert "FROM guild_command_access_channels" in sql
+    assert "ORDER BY channel_id" in sql
+    assert args == [10]
+
+
+@pytest.mark.asyncio
+async def test_list_allowed_channels_returns_empty_when_no_rows(_mock_pool):
+    _mock_pool.fetch.return_value = []
+    assert await db.list_allowed_channels(10) == []
+
+
+@pytest.mark.asyncio
+async def test_add_allowed_channel_is_idempotent(_mock_pool):
+    await db.add_allowed_channel(guild_id=10, channel_id=555, created_by=99)
+    sql, *args = _mock_pool.execute.await_args.args
+    assert "INSERT INTO guild_command_access_channels" in sql
+    assert "ON CONFLICT (guild_id, channel_id) DO NOTHING" in sql
+    assert args == [10, 555, 99]
+
+
+@pytest.mark.asyncio
+async def test_remove_allowed_channel_deletes_single_row(_mock_pool):
+    await db.remove_allowed_channel(guild_id=10, channel_id=555)
+    sql, *args = _mock_pool.execute.await_args.args
+    assert "DELETE FROM guild_command_access_channels" in sql
+    assert "guild_id = $1 AND channel_id = $2" in sql
+    assert args == [10, 555]
+
+
+# ---------------------------------------------------------------------------
+# Allowed channels — atomic bulk replace
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_replace_allowed_channels_runs_delete_and_insert_in_txn():
+    pool_stub, conn = _build_conn_pool_stub()
+    with patch.object(db, "pool") as pool_module:
+        pool_module.get = MagicMock(return_value=pool_stub)
+        await db.replace_allowed_channels(
+            guild_id=10,
+            channel_ids=[300, 100, 200],
+            created_by=99,
+        )
+
+    # Inside the transaction: a single DELETE scoped to the guild plus
+    # one executemany carrying every (guild_id, channel_id, created_by)
+    # tuple in stable sort order.
+    conn.transaction.assert_called_once()
+    delete_sql, *del_args = conn.execute.await_args.args
+    assert "DELETE FROM guild_command_access_channels" in delete_sql
+    assert "WHERE guild_id = $1" in delete_sql
+    assert del_args == [10]
+    conn.executemany.assert_awaited_once()
+    insert_sql, payload = conn.executemany.await_args.args
+    assert "INSERT INTO guild_command_access_channels" in insert_sql
+    # Sorted + deduped on the way in.
+    assert payload == [(10, 100, 99), (10, 200, 99), (10, 300, 99)]
+
+
+@pytest.mark.asyncio
+async def test_replace_allowed_channels_dedupes_input():
+    pool_stub, conn = _build_conn_pool_stub()
+    with patch.object(db, "pool") as pool_module:
+        pool_module.get = MagicMock(return_value=pool_stub)
+        await db.replace_allowed_channels(
+            guild_id=10,
+            channel_ids=[555, 555, 100, 555],
+            created_by=99,
+        )
+
+    _, payload = conn.executemany.await_args.args
+    assert payload == [(10, 100, 99), (10, 555, 99)]
+
+
+@pytest.mark.asyncio
+async def test_replace_allowed_channels_empty_skips_insert():
+    """An empty desired set is a "reset to no allowed channels" — the
+    DELETE still runs, but ``executemany`` must not be called with an
+    empty payload (asyncpg raises on empty executemany).
+    """
+    pool_stub, conn = _build_conn_pool_stub()
+    with patch.object(db, "pool") as pool_module:
+        pool_module.get = MagicMock(return_value=pool_stub)
+        await db.replace_allowed_channels(
+            guild_id=10,
+            channel_ids=[],
+            created_by=99,
+        )
+
+    conn.execute.assert_awaited_once()
+    conn.executemany.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Guild teardown
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_forget_guild_deletes_parent_row(_mock_pool):
+    """CASCADE on the child table handles the rest, so the primitive
+    only needs to drop the policy row.
+    """
+    await db.forget_guild(guild_id=10)
+    sql, *args = _mock_pool.execute.await_args.args
+    assert "DELETE FROM guild_command_access_policy" in sql
+    assert args == [10]

--- a/tests/unit/db/test_migration_051_main_server_backfill.py
+++ b/tests/unit/db/test_migration_051_main_server_backfill.py
@@ -1,0 +1,81 @@
+"""PR-7 — command-access main-server backfill migration.
+
+The migration is data-only and idempotent.  Without a real Postgres
+in unit CI we can still pin the SQL shape so a future drive-by edit
+that, say, drops ``ON CONFLICT DO NOTHING`` or switches the lookup
+table away from ``panel_anchors`` would fail this test.
+
+Coverage:
+
+* References the canonical pre-PR-7 main-server channel IDs.
+* Targets both tables introduced in migration 050.
+* Uses ``ON CONFLICT DO NOTHING`` on both INSERTs so re-run is safe.
+* Discovers the guild_id by joining through ``panel_anchors`` (the
+  broadest guild-scoped table — see the migration header for the
+  rationale).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MIGRATION = (
+    _REPO_ROOT / "disbot" / "migrations" / "051_command_access_main_server_backfill.sql"
+)
+
+
+def _src() -> str:
+    return _MIGRATION.read_text()
+
+
+def test_migration_file_exists():
+    assert _MIGRATION.is_file(), f"{_MIGRATION} missing"
+
+
+def test_migration_references_canonical_channel_ids():
+    """The two hardcoded IDs that were ``config.ALLOWED_CHANNELS``'
+    fallback set pre-PR-7 must both appear so the main server's
+    historical allowed-channels are preserved.
+    """
+    src = _src()
+    assert "1348795460948590622" in src
+    assert "1403818013408624642" in src
+
+
+def test_migration_targets_both_command_access_tables():
+    src = _src()
+    assert "INSERT INTO guild_command_access_policy" in src
+    assert "INSERT INTO guild_command_access_channels" in src
+
+
+def test_migration_uses_panel_anchors_for_guild_id_lookup():
+    """``panel_anchors`` is the broadest guild-scoped table — every
+    guild that has restored a panel since on_ready has rows there.
+    Switching to a less-populated table would make the backfill miss
+    deployments the upgrade actually intends to cover.
+    """
+    src = _src()
+    assert "FROM panel_anchors" in src
+    # Both INSERTs filter on the same channel-id whitelist.
+    assert src.count("WHERE channel_id IN") >= 2
+
+
+def test_migration_is_idempotent_on_both_tables():
+    """``ON CONFLICT DO NOTHING`` on both INSERTs lets the migration
+    re-run cleanly if an operator has already configured the policy
+    through the settings UI before the migration is applied (the
+    apply-order is engine-controlled but the safety net stays).
+    """
+    src = _src()
+    assert src.count("ON CONFLICT") >= 2
+    assert "DO NOTHING" in src
+
+
+def test_migration_attributes_backfill_to_system_via_null_actor():
+    """Audit metadata: the backfill is system-driven, not
+    operator-driven, so ``updated_by`` and ``created_by`` are
+    deliberately NULL rather than seeded with an arbitrary id.
+    """
+    src = _src()
+    assert "NULL" in src

--- a/tests/unit/invariants/test_settings_cog_read_only.py
+++ b/tests/unit/invariants/test_settings_cog_read_only.py
@@ -43,6 +43,10 @@ _FORBIDDEN_IMPORT_PREFIXES: frozenset[str] = frozenset(
         "services.resource_provisioning",  # creator/binder of Discord resources
         "services.participation_mutation",
         "services.rollout_mutation",
+        # Command-access service (per-guild policy mutation pipeline,
+        # command-access onboarding PR-6).  Same invariant logic:
+        # write paths must live in the allowlisted edit-flow widget.
+        "services.command_access_service",
         "governance.writes",
     },
 )
@@ -74,6 +78,15 @@ _FORBIDDEN_METHOD_CALLS: frozenset[str] = frozenset(
         "set_cleanup_policy",
         "set_cleanup_policy_for_scope",
         "provision",  # ResourceProvisioningPipeline.provision
+        # Command-access mutation pipeline (PR-6).  Module-level
+        # functions, but the AST call-pattern is the same — they
+        # appear as ``service.set_mode(...)`` etc. in the allowlisted
+        # widget and nowhere else under disbot/views/settings/.
+        "set_mode",
+        "replace_allowed_channels",
+        "add_allowed_channel",
+        "remove_allowed_channel",
+        "set_policy",
     },
 )
 
@@ -114,6 +127,12 @@ _ALLOWED_EDIT_FILES: frozenset[Path] = frozenset(
         _DISBOT / "views" / "settings" / "edit_channel.py",
         _DISBOT / "views" / "settings" / "edit_role.py",
         _DISBOT / "views" / "settings" / "edit_number_presets.py",
+        # Command-access onboarding PR-6 — per-guild allowed-channel
+        # policy.  This file IS the operator mutation surface for
+        # command_access_service; ``set_mode`` / ``replace_allowed_channels``
+        # are explicitly routed through it on the
+        # mode-button / channel-select callbacks.
+        _DISBOT / "views" / "settings" / "edit_command_access.py",
     },
 )
 

--- a/tests/unit/runtime/test_command_access.py
+++ b/tests/unit/runtime/test_command_access.py
@@ -64,6 +64,27 @@ def test_is_bootstrap_command_rejects_normal_gameplay_commands():
     assert is_bootstrap_command(None) is False
 
 
+def test_is_bootstrap_command_accepts_hyphenated_slash_names():
+    """Slash commands can't contain whitespace, so multi-token
+    bootstrap commands ship hyphenated (``/setup-hub``, ``/setup-status``,
+    ``/setup-delegate``).  The classifier must recognise the
+    hyphen-namespaced form so operator bypass works on the slash
+    surface as well as the prefix one.
+    """
+    assert is_bootstrap_command("setup-hub") is True
+    assert is_bootstrap_command("setup-status") is True
+    assert is_bootstrap_command("setup-delegate") is True
+
+
+def test_is_bootstrap_command_hyphen_check_does_not_widen_to_normal_commands():
+    """Hyphen-rooting is bounded to existing bootstrap roots — a
+    plausible future ``daily-bonus`` name does NOT classify as
+    bootstrap because ``daily`` is not in the allowlist.
+    """
+    assert is_bootstrap_command("daily-bonus") is False
+    assert is_bootstrap_command("blackjack-stats") is False
+
+
 @pytest.mark.asyncio
 async def test_guild_owner_can_bypass_for_bootstrap_command():
     ctx = _ctx(command_name="help", author_id=42, owner_id=42)

--- a/tests/unit/runtime/test_command_access_resolver.py
+++ b/tests/unit/runtime/test_command_access_resolver.py
@@ -39,7 +39,6 @@ from core.runtime.command_access import (
 )
 from utils.guild_config_accessors import CommandAccessPolicySnapshot
 
-
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
 # ---------------------------------------------------------------------------

--- a/tests/unit/runtime/test_command_access_resolver.py
+++ b/tests/unit/runtime/test_command_access_resolver.py
@@ -1,0 +1,508 @@
+"""PR-2 — command-access resolver tests.
+
+Exercises the full decision matrix of
+:func:`core.runtime.command_access.resolve_command_access`:
+
+* lifecycle gate (draining → silent deny)
+* DM / guildless invocations
+* bootstrap bypass for guild operators + bot owners
+* unconfigured guild (default ``all_channels`` semantic, source
+  ``DEFAULT_UNCONFIGURED``)
+* ``all_channels`` mode (allow anywhere)
+* ``selected_channels`` mode (allow inside / deny outside, with feedback)
+* ``disabled_except_bootstrap`` mode (deny normal commands with feedback,
+  bypass still works for bootstrap)
+
+Plus adapters (``from_prefix_ctx`` / ``from_interaction``) that build a
+:class:`CommandAccessContext` from Discord-shaped inputs.
+
+Loaders are stubbed via ``patch.object`` on
+``utils.guild_config_accessors.get_command_access_policy`` so the
+resolver's hot path is exercised without going through the typed
+accessor cache or the DB.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from core.runtime import command_access
+from core.runtime.command_access import (
+    AccessMode,
+    CommandAccessContext,
+    DecisionReason,
+    DecisionSource,
+    resolve_command_access,
+)
+from utils.guild_config_accessors import CommandAccessPolicySnapshot
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _ctx(
+    *,
+    command_name: str | None = "blackjack",
+    invocation_type: str = "prefix",
+    guild_id: int | None = 10,
+    channel_id: int | None = 100,
+    user_id: int | None = 42,
+    is_guild_operator: bool = False,
+    is_bot_owner: bool = False,
+    is_dm: bool = False,
+) -> CommandAccessContext:
+    return CommandAccessContext(
+        guild_id=guild_id,
+        channel_id=channel_id,
+        user_id=user_id,
+        command_name=command_name,
+        invocation_type=invocation_type,
+        is_guild_operator=is_guild_operator,
+        is_bot_owner=is_bot_owner,
+        is_dm=is_dm,
+    )
+
+
+def _snapshot(
+    mode: str | None,
+    *channel_ids: int,
+) -> CommandAccessPolicySnapshot:
+    return CommandAccessPolicySnapshot(
+        mode=mode,
+        allowed_channels=frozenset(channel_ids),
+    )
+
+
+def _patch_policy(snapshot: CommandAccessPolicySnapshot):
+    """Patch the typed-accessor read used by the resolver.
+
+    The resolver imports ``get_command_access_policy`` lazily from
+    ``utils.guild_config_accessors`` inside ``resolve_command_access``,
+    so we patch the symbol on that module (not on the resolver) — the
+    lazy import then resolves to the patched coroutine.
+    """
+    return patch(
+        "utils.guild_config_accessors.get_command_access_policy",
+        new=AsyncMock(return_value=snapshot),
+    )
+
+
+def _patch_lifecycle(*, accepting: bool = True):
+    return patch(
+        "core.runtime.lifecycle.can_accept_commands",
+        return_value=accepting,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolver_denies_silently_when_lifecycle_draining():
+    """Shutdown / restart phase — every command denied, no feedback
+    (feedback would race the connection close).
+    """
+    with _patch_lifecycle(accepting=False):
+        decision = await resolve_command_access(_ctx())
+    assert decision.allowed is False
+    assert decision.reason is DecisionReason.LIFECYCLE_DRAINING
+    assert decision.source is DecisionSource.LIFECYCLE_DENY
+    assert decision.mode is None
+    assert decision.feedback is None
+
+
+# ---------------------------------------------------------------------------
+# DM / guildless
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolver_denies_dm_invocations_without_feedback():
+    """DMs do not flow through this resolver — entry-points route them
+    through the per-command DM opt-in instead.  No feedback because
+    silence is the existing pre-PR-2 behaviour.
+    """
+    with _patch_lifecycle():
+        decision = await resolve_command_access(
+            _ctx(guild_id=None, channel_id=None, is_dm=True),
+        )
+    assert decision.allowed is False
+    assert decision.reason is DecisionReason.DM_NOT_SUPPORTED
+    assert decision.source is DecisionSource.DEFAULT_UNCONFIGURED
+    assert decision.feedback is None
+
+
+@pytest.mark.asyncio
+async def test_resolver_treats_missing_guild_id_as_dm():
+    """Defence-in-depth: even if ``is_dm`` weren't set, ``guild_id=None``
+    must reach the DM branch — never fall through to the policy lookup
+    where ``guild_id`` would be passed as ``None`` to the DB layer.
+    """
+    with _patch_lifecycle():
+        decision = await resolve_command_access(
+            _ctx(guild_id=None, channel_id=100, is_dm=False),
+        )
+    assert decision.reason is DecisionReason.DM_NOT_SUPPORTED
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap bypass
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_command_bypasses_for_guild_operator():
+    """Operator (owner / admin / manage_guild) running a bootstrap
+    command — admitted regardless of mode or channel.  Policy lookup
+    must NOT be consulted (the bypass is unconditional).
+    """
+    with _patch_lifecycle(), _patch_policy(_snapshot("disabled_except_bootstrap")):
+        decision = await resolve_command_access(
+            _ctx(command_name="setup", is_guild_operator=True),
+        )
+    assert decision.allowed is True
+    assert decision.reason is DecisionReason.BOOTSTRAP_BYPASS
+    assert decision.source is DecisionSource.BOOTSTRAP_BYPASS
+    assert decision.feedback is None
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_command_bypasses_for_bot_owner():
+    with _patch_lifecycle(), _patch_policy(_snapshot("selected_channels")):
+        decision = await resolve_command_access(
+            _ctx(
+                command_name="syncslash",
+                channel_id=999,
+                is_bot_owner=True,
+            ),
+        )
+    assert decision.allowed is True
+    assert decision.source is DecisionSource.BOOTSTRAP_BYPASS
+
+
+@pytest.mark.asyncio
+async def test_non_operator_cannot_bypass_with_bootstrap_command():
+    """Non-operator running a bootstrap command — falls through to
+    policy mode.  Under ``selected_channels`` they get denied if not in
+    an allowed channel.
+    """
+    with _patch_lifecycle(), _patch_policy(_snapshot("selected_channels", 100)):
+        decision = await resolve_command_access(
+            _ctx(command_name="help", channel_id=999),
+        )
+    assert decision.allowed is False
+    assert decision.reason is DecisionReason.CHANNEL_NOT_ALLOWED
+
+
+@pytest.mark.asyncio
+async def test_operator_running_normal_command_does_not_bypass():
+    """Operators don't get a blanket bypass — only for bootstrap
+    commands.  ``!blackjack`` from the guild owner under
+    ``selected_channels`` mode outside the allowlist must still be
+    denied.
+    """
+    with _patch_lifecycle(), _patch_policy(_snapshot("selected_channels", 100)):
+        decision = await resolve_command_access(
+            _ctx(
+                command_name="blackjack",
+                channel_id=999,
+                is_guild_operator=True,
+            ),
+        )
+    assert decision.allowed is False
+    assert decision.reason is DecisionReason.CHANNEL_NOT_ALLOWED
+
+
+# ---------------------------------------------------------------------------
+# Unconfigured guild (default = all_channels)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_guild_allows_normal_commands_anywhere():
+    """No DB policy row — resolver applies the chosen product default
+    (``all_channels``) with source ``DEFAULT_UNCONFIGURED`` so logs
+    distinguish "policy says yes" from "no policy, defaulting yes".
+    """
+    with _patch_lifecycle(), _patch_policy(_snapshot(None)):
+        decision = await resolve_command_access(_ctx())
+    assert decision.allowed is True
+    assert decision.reason is DecisionReason.ALLOWED
+    assert decision.source is DecisionSource.DEFAULT_UNCONFIGURED
+    assert decision.mode is AccessMode.ALL_CHANNELS
+    assert decision.feedback is None
+
+
+# ---------------------------------------------------------------------------
+# all_channels mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_all_channels_mode_allows_normal_command_anywhere():
+    with _patch_lifecycle(), _patch_policy(_snapshot("all_channels")):
+        decision = await resolve_command_access(_ctx(channel_id=999))
+    assert decision.allowed is True
+    assert decision.reason is DecisionReason.ALLOWED
+    assert decision.source is DecisionSource.DB_POLICY
+    assert decision.mode is AccessMode.ALL_CHANNELS
+
+
+@pytest.mark.asyncio
+async def test_all_channels_mode_allows_slash_invocations_too():
+    """Same chain for slash: invocation_type is informational only,
+    the policy logic does not branch on it.
+    """
+    with _patch_lifecycle(), _patch_policy(_snapshot("all_channels")):
+        decision = await resolve_command_access(
+            _ctx(invocation_type="slash", channel_id=999),
+        )
+    assert decision.allowed is True
+
+
+# ---------------------------------------------------------------------------
+# selected_channels mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_selected_channels_mode_allows_inside_allowlist():
+    with _patch_lifecycle(), _patch_policy(_snapshot("selected_channels", 100, 200)):
+        decision = await resolve_command_access(_ctx(channel_id=200))
+    assert decision.allowed is True
+    assert decision.reason is DecisionReason.ALLOWED
+    assert decision.source is DecisionSource.DB_POLICY
+    assert decision.mode is AccessMode.SELECTED_CHANNELS
+
+
+@pytest.mark.asyncio
+async def test_selected_channels_mode_denies_outside_with_feedback():
+    with _patch_lifecycle(), _patch_policy(_snapshot("selected_channels", 100)):
+        decision = await resolve_command_access(_ctx(channel_id=999))
+    assert decision.allowed is False
+    assert decision.reason is DecisionReason.CHANNEL_NOT_ALLOWED
+    assert decision.source is DecisionSource.DB_POLICY
+    assert decision.mode is AccessMode.SELECTED_CHANNELS
+    assert decision.feedback is not None
+    # Feedback must point operators at the recovery path, not at the
+    # raw policy state.
+    assert "settings" in decision.feedback.lower()
+
+
+@pytest.mark.asyncio
+async def test_selected_channels_mode_denies_when_allowlist_empty():
+    """Empty allowlist + ``selected_channels`` mode is a deliberate
+    "no normal commands run anywhere" — different from
+    ``disabled_except_bootstrap`` because operators still see the
+    "wrong channel" feedback (which points them at settings) rather
+    than the harder "commands disabled" wording.
+    """
+    with _patch_lifecycle(), _patch_policy(_snapshot("selected_channels")):
+        decision = await resolve_command_access(_ctx(channel_id=100))
+    assert decision.allowed is False
+    assert decision.reason is DecisionReason.CHANNEL_NOT_ALLOWED
+
+
+# ---------------------------------------------------------------------------
+# disabled_except_bootstrap mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_disabled_mode_denies_normal_command_with_feedback():
+    with _patch_lifecycle(), _patch_policy(_snapshot("disabled_except_bootstrap")):
+        decision = await resolve_command_access(_ctx(command_name="blackjack"))
+    assert decision.allowed is False
+    assert decision.reason is DecisionReason.COMMANDS_DISABLED
+    assert decision.source is DecisionSource.DB_POLICY
+    assert decision.mode is AccessMode.DISABLED_EXCEPT_BOOTSTRAP
+    assert decision.feedback is not None
+    # Feedback should mention the recovery command so confused
+    # operators know how to re-enable.
+    assert "!setup" in decision.feedback or "settings" in decision.feedback.lower()
+
+
+@pytest.mark.asyncio
+async def test_disabled_mode_admits_bootstrap_for_operator():
+    """Bootstrap branch fires before policy lookup, so even
+    ``disabled_except_bootstrap`` mode admits ``!setup`` for the guild
+    owner.  Otherwise an operator could lock themselves out
+    irrecoverably.
+    """
+    with _patch_lifecycle(), _patch_policy(_snapshot("disabled_except_bootstrap")):
+        decision = await resolve_command_access(
+            _ctx(command_name="setup", is_guild_operator=True),
+        )
+    assert decision.allowed is True
+    assert decision.reason is DecisionReason.BOOTSTRAP_BYPASS
+
+
+@pytest.mark.asyncio
+async def test_disabled_mode_denies_bootstrap_for_non_operator():
+    """A non-operator running ``!help`` under disabled mode falls
+    through past the bootstrap-bypass branch (they aren't an operator)
+    and hits ``COMMANDS_DISABLED``.  This is intentional — bootstrap
+    bypass is an operator-only escape hatch, not a public bypass.
+    """
+    with _patch_lifecycle(), _patch_policy(_snapshot("disabled_except_bootstrap")):
+        decision = await resolve_command_access(_ctx(command_name="help"))
+    assert decision.allowed is False
+    assert decision.reason is DecisionReason.COMMANDS_DISABLED
+
+
+# ---------------------------------------------------------------------------
+# Adapters
+# ---------------------------------------------------------------------------
+
+
+def _build_prefix_ctx(
+    *,
+    guild_id: int | None = 10,
+    channel_id: int | None = 100,
+    author_id: int = 42,
+    owner_id: int = 42,
+    administrator: bool = False,
+    manage_guild: bool = False,
+    command_name: str = "blackjack",
+    qualified_name: str | None = None,
+    aliases: tuple[str, ...] = (),
+    invoked_with: str | None = None,
+    is_bot_owner: bool = False,
+):
+    guild = (
+        SimpleNamespace(id=guild_id, owner_id=owner_id) if guild_id is not None else None
+    )
+    channel = (
+        SimpleNamespace(id=channel_id) if channel_id is not None else None
+    )
+    author = SimpleNamespace(
+        id=author_id,
+        guild_permissions=SimpleNamespace(
+            administrator=administrator,
+            manage_guild=manage_guild,
+        ),
+    )
+    command = SimpleNamespace(
+        name=command_name,
+        qualified_name=qualified_name or command_name,
+        aliases=aliases,
+    )
+    bot = SimpleNamespace(is_owner=AsyncMock(return_value=is_bot_owner))
+    return SimpleNamespace(
+        guild=guild,
+        channel=channel,
+        author=author,
+        command=command,
+        invoked_with=invoked_with or command_name,
+        bot=bot,
+    )
+
+
+@pytest.mark.asyncio
+async def test_from_prefix_ctx_extracts_ids_and_operator_flag():
+    ctx = _build_prefix_ctx(
+        guild_id=10,
+        channel_id=100,
+        author_id=42,
+        owner_id=42,
+        command_name="blackjack",
+    )
+    access_ctx = await command_access.from_prefix_ctx(ctx)
+    assert access_ctx.guild_id == 10
+    assert access_ctx.channel_id == 100
+    assert access_ctx.user_id == 42
+    assert access_ctx.is_guild_operator is True  # owner_id matches author_id
+    assert access_ctx.is_bot_owner is False
+    assert access_ctx.is_dm is False
+    assert access_ctx.invocation_type == "prefix"
+    assert access_ctx.command_name == "blackjack"
+
+
+@pytest.mark.asyncio
+async def test_from_prefix_ctx_prefers_bootstrap_spelling_when_alias():
+    """``!diag`` is an alias for ``!diagnostics``; the adapter must
+    surface the bootstrap-classified spelling to the resolver so the
+    bypass branch fires.
+    """
+    ctx = _build_prefix_ctx(
+        command_name="diagnostics",
+        aliases=("diag",),
+        invoked_with="diag",
+    )
+    access_ctx = await command_access.from_prefix_ctx(ctx)
+    # Either spelling is acceptable as long as ``is_bootstrap_command``
+    # accepts it — the adapter explicitly prefers the bootstrap
+    # spelling so the resolver doesn't have to re-check every alias.
+    assert command_access.is_bootstrap_command(access_ctx.command_name)
+
+
+@pytest.mark.asyncio
+async def test_from_prefix_ctx_dm_context_marks_is_dm():
+    ctx = _build_prefix_ctx(guild_id=None, channel_id=None)
+    access_ctx = await command_access.from_prefix_ctx(ctx)
+    assert access_ctx.is_dm is True
+    assert access_ctx.guild_id is None
+
+
+def _build_interaction(
+    *,
+    guild_id: int | None = 10,
+    channel_id: int | None = 100,
+    user_id: int = 42,
+    owner_id: int = 42,
+    administrator: bool = False,
+    command_qualified_name: str = "blackjack",
+    is_bot_owner: bool = False,
+):
+    guild = (
+        SimpleNamespace(id=guild_id, owner_id=owner_id) if guild_id is not None else None
+    )
+    channel = SimpleNamespace(id=channel_id) if channel_id is not None else None
+    user = SimpleNamespace(
+        id=user_id,
+        guild_permissions=SimpleNamespace(
+            administrator=administrator,
+            manage_guild=False,
+        ),
+    )
+    command = SimpleNamespace(
+        name=command_qualified_name.split()[0],
+        qualified_name=command_qualified_name,
+    )
+    client = SimpleNamespace(is_owner=AsyncMock(return_value=is_bot_owner))
+    return SimpleNamespace(
+        guild=guild,
+        channel=channel,
+        user=user,
+        command=command,
+        client=client,
+    )
+
+
+@pytest.mark.asyncio
+async def test_from_interaction_extracts_qualified_slash_command_name():
+    interaction = _build_interaction(command_qualified_name="settings access")
+    access_ctx = await command_access.from_interaction(interaction)
+    assert access_ctx.invocation_type == "slash"
+    assert access_ctx.command_name == "settings access"
+    assert access_ctx.is_guild_operator is True  # owner_id matches user_id
+
+
+@pytest.mark.asyncio
+async def test_from_interaction_component_interaction_has_no_command_name():
+    """Button / select interactions arrive with ``command=None``.  The
+    adapter must not crash — it surfaces ``command_name=None`` and the
+    resolver treats it as a non-bootstrap invocation.
+    """
+    interaction = _build_interaction()
+    interaction.command = None
+    access_ctx = await command_access.from_interaction(interaction)
+    assert access_ctx.command_name is None
+    assert command_access.is_bootstrap_command(access_ctx.command_name) is False

--- a/tests/unit/runtime/test_guild_lifecycle_teardown.py
+++ b/tests/unit/runtime/test_guild_lifecycle_teardown.py
@@ -439,3 +439,41 @@ async def test_teardown_participation_failure_is_isolated(_teardown_patches):
     ):
         await guild_lifecycle.teardown(99)
         mock_forget.assert_called_once_with(99)
+
+
+# ---------------------------------------------------------------------------
+# Step 22 — command-access policy + cached snapshot (command-access PR-3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_teardown_calls_command_access_forget_guild(_teardown_patches):
+    """Step 22 awaits ``core.runtime.command_access.forget_guild`` so
+    both the typed-accessor cache entry and the
+    ``guild_command_access_policy`` row are dropped on guild leave.
+    """
+    import guild_lifecycle
+
+    with patch(
+        "core.runtime.command_access.forget_guild",
+        new_callable=AsyncMock,
+    ) as mock_forget:
+        await guild_lifecycle.teardown(99)
+        mock_forget.assert_awaited_once_with(99)
+
+
+@pytest.mark.asyncio
+async def test_teardown_command_access_failure_is_isolated(_teardown_patches):
+    """A failure in command-access teardown must not abort the
+    surrounding lifecycle sequence — matches the try/except discipline
+    every other step uses.
+    """
+    import guild_lifecycle
+
+    with patch(
+        "core.runtime.command_access.forget_guild",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("DB blip"),
+    ):
+        # No exception escapes — the lifecycle swallows + logs.
+        await guild_lifecycle.teardown(99)

--- a/tests/unit/services/test_command_access_service.py
+++ b/tests/unit/services/test_command_access_service.py
@@ -1,0 +1,489 @@
+"""PR-3 — command-access mutation service tests.
+
+Pins the 6-step contract for every public mutation:
+
+  1. validates inputs (mode literal, actor_type)
+  2. reads previous state via the DB primitives
+  3. writes through ``utils.db.command_access`` primitives
+  4. invalidates the typed-accessor cache INLINE
+  5. emits ``audit.action_recorded`` with the correct payload
+  6. returns a typed result carrying ``mutation_id``
+
+Plus:
+
+* idempotent no-ops on add / remove / replace skip the audit emission
+* the composite ``set_policy`` runs the underlying ops in order and
+  preserves the channel list when called with ``channel_ids=None``
+* ``forget_guild`` paired cache-invalidate + DB-delete
+
+The DB primitives, typed accessor, and ``emit_audit_action`` publisher
+are all mocked so the tests are asyncpg-free and bus-free.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services import command_access_service as service
+from services.command_access_service import (
+    CommandAccessMutationResult,
+    InvalidCommandAccessModeError,
+    UnauthorizedCommandAccessActorError,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_mock():
+    """Patch the ``utils.db.command_access`` primitives referenced by
+    the service as ``db`` (the module-level alias).  Returns the mock
+    namespace so assertions can introspect call args.
+    """
+    with patch.object(service, "db") as db:
+        # KNOWN_MODES is the real frozenset — the validator checks
+        # against it directly.
+        db.KNOWN_MODES = frozenset(
+            {
+                "all_channels",
+                "selected_channels",
+                "disabled_except_bootstrap",
+            },
+        )
+        db.get_policy = AsyncMock(return_value=None)
+        db.list_allowed_channels = AsyncMock(return_value=[])
+        db.set_mode = AsyncMock()
+        db.add_allowed_channel = AsyncMock()
+        db.remove_allowed_channel = AsyncMock()
+        db.replace_allowed_channels = AsyncMock()
+        yield db
+
+
+@pytest.fixture
+def invalidate_mock():
+    with patch.object(
+        service,
+        "invalidate_command_access_policy",
+    ) as invalidate:
+        yield invalidate
+
+
+@pytest.fixture
+def audit_mock():
+    """Patch the shared ``emit_audit_action`` so tests inspect the
+    payload without crossing the event-bus boundary.
+    """
+    with patch.object(
+        service,
+        "emit_audit_action",
+        new=AsyncMock(return_value=True),
+    ) as audit:
+        yield audit
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_mode_rejects_unknown_mode(db_mock, invalidate_mock, audit_mock):
+    with pytest.raises(InvalidCommandAccessModeError):
+        await service.set_mode(guild_id=10, mode="garbage", actor_id=99)
+    db_mock.set_mode.assert_not_awaited()
+    invalidate_mock.assert_not_called()
+    audit_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_set_mode_rejects_unknown_actor_type(
+    db_mock,
+    invalidate_mock,
+    audit_mock,
+):
+    with pytest.raises(UnauthorizedCommandAccessActorError):
+        await service.set_mode(
+            guild_id=10,
+            mode="all_channels",
+            actor_id=99,
+            actor_type="anonymous",
+        )
+    db_mock.set_mode.assert_not_awaited()
+    invalidate_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_add_allowed_channel_rejects_non_int_channel_id(
+    db_mock,
+    invalidate_mock,
+    audit_mock,
+):
+    with pytest.raises(TypeError):
+        await service.add_allowed_channel(
+            guild_id=10,
+            channel_id="555",  # type: ignore[arg-type]
+            actor_id=99,
+        )
+    db_mock.add_allowed_channel.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# set_mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_mode_writes_invalidates_and_emits_audit(
+    db_mock,
+    invalidate_mock,
+    audit_mock,
+):
+    db_mock.get_policy.return_value = {"mode": "all_channels"}
+    result = await service.set_mode(
+        guild_id=10,
+        mode="selected_channels",
+        actor_id=99,
+    )
+
+    # 3. DB write
+    db_mock.set_mode.assert_awaited_once_with(
+        guild_id=10,
+        mode="selected_channels",
+        updated_by=99,
+    )
+    # 4. cache invalidation INLINE
+    invalidate_mock.assert_called_once_with(10)
+    # 5. audit emission with the prev_value pulled from get_policy
+    audit_mock.assert_awaited_once()
+    kwargs = audit_mock.await_args.kwargs
+    assert kwargs["subsystem"] == "command_access"
+    assert kwargs["mutation_type"] == "set_mode"
+    assert kwargs["target"] == "command_access:mode"
+    assert kwargs["scope"] == "guild"
+    assert kwargs["guild_id"] == 10
+    assert kwargs["prev_value"] == "all_channels"
+    assert kwargs["new_value"] == "selected_channels"
+    assert kwargs["actor_id"] == 99
+    assert kwargs["actor_type"] == "admin"
+    # 6. typed result
+    assert isinstance(result, CommandAccessMutationResult)
+    assert result.mutation_type == "set_mode"
+    assert result.prev_value == "all_channels"
+    assert result.new_value == "selected_channels"
+    assert result.audit_emitted is True
+    assert kwargs["mutation_id"] == result.mutation_id
+
+
+@pytest.mark.asyncio
+async def test_set_mode_uses_null_prev_value_when_unconfigured(
+    db_mock,
+    invalidate_mock,
+    audit_mock,
+):
+    db_mock.get_policy.return_value = None
+    result = await service.set_mode(
+        guild_id=10,
+        mode="all_channels",
+        actor_id=99,
+    )
+    assert result.prev_value is None
+    assert audit_mock.await_args.kwargs["prev_value"] is None
+
+
+# ---------------------------------------------------------------------------
+# add_allowed_channel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_add_allowed_channel_writes_and_emits_when_new(
+    db_mock,
+    invalidate_mock,
+    audit_mock,
+):
+    db_mock.list_allowed_channels.return_value = [100, 200]
+    result = await service.add_allowed_channel(
+        guild_id=10,
+        channel_id=300,
+        actor_id=99,
+    )
+    db_mock.add_allowed_channel.assert_awaited_once_with(
+        guild_id=10,
+        channel_id=300,
+        created_by=99,
+    )
+    invalidate_mock.assert_called_once_with(10)
+    kwargs = audit_mock.await_args.kwargs
+    assert kwargs["target"] == "command_access:channel:300"
+    assert kwargs["prev_value"] is None
+    assert kwargs["new_value"] == "300"
+    assert result.audit_emitted is True
+
+
+@pytest.mark.asyncio
+async def test_add_allowed_channel_is_idempotent_no_audit_no_invalidate(
+    db_mock,
+    invalidate_mock,
+    audit_mock,
+):
+    """Already-present channel: skip DB write + cache invalidate + audit.
+
+    The DB primitive is itself ON CONFLICT DO NOTHING, but emitting an
+    audit row for a true no-op pollutes the audit trail.
+    """
+    db_mock.list_allowed_channels.return_value = [100, 200, 300]
+    result = await service.add_allowed_channel(
+        guild_id=10,
+        channel_id=300,
+        actor_id=99,
+    )
+    db_mock.add_allowed_channel.assert_not_awaited()
+    invalidate_mock.assert_not_called()
+    audit_mock.assert_not_awaited()
+    assert result.audit_emitted is False
+
+
+# ---------------------------------------------------------------------------
+# remove_allowed_channel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remove_allowed_channel_writes_and_emits_when_present(
+    db_mock,
+    invalidate_mock,
+    audit_mock,
+):
+    db_mock.list_allowed_channels.return_value = [100, 200, 300]
+    result = await service.remove_allowed_channel(
+        guild_id=10,
+        channel_id=200,
+        actor_id=99,
+    )
+    db_mock.remove_allowed_channel.assert_awaited_once_with(
+        guild_id=10,
+        channel_id=200,
+    )
+    invalidate_mock.assert_called_once_with(10)
+    kwargs = audit_mock.await_args.kwargs
+    assert kwargs["mutation_type"] == "remove_allowed_channel"
+    assert kwargs["target"] == "command_access:channel:200"
+    assert kwargs["prev_value"] == "200"
+    assert kwargs["new_value"] is None
+    assert result.audit_emitted is True
+
+
+@pytest.mark.asyncio
+async def test_remove_allowed_channel_is_idempotent_when_absent(
+    db_mock,
+    invalidate_mock,
+    audit_mock,
+):
+    db_mock.list_allowed_channels.return_value = [100, 200]
+    result = await service.remove_allowed_channel(
+        guild_id=10,
+        channel_id=999,
+        actor_id=99,
+    )
+    db_mock.remove_allowed_channel.assert_not_awaited()
+    invalidate_mock.assert_not_called()
+    audit_mock.assert_not_awaited()
+    assert result.audit_emitted is False
+
+
+# ---------------------------------------------------------------------------
+# replace_allowed_channels
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_replace_allowed_channels_writes_and_emits_diff(
+    db_mock,
+    invalidate_mock,
+    audit_mock,
+):
+    db_mock.list_allowed_channels.return_value = [100, 200]
+    result = await service.replace_allowed_channels(
+        guild_id=10,
+        channel_ids=[300, 100, 400],
+        actor_id=99,
+    )
+    db_mock.replace_allowed_channels.assert_awaited_once_with(
+        guild_id=10,
+        channel_ids=[100, 300, 400],
+        created_by=99,
+    )
+    invalidate_mock.assert_called_once_with(10)
+    kwargs = audit_mock.await_args.kwargs
+    assert kwargs["mutation_type"] == "replace_allowed_channels"
+    assert kwargs["target"] == "command_access:channels"
+    # Rendered as stable sorted comma-separated bracketed list.
+    assert kwargs["prev_value"] == "[100,200]"
+    assert kwargs["new_value"] == "[100,300,400]"
+    assert result.audit_emitted is True
+
+
+@pytest.mark.asyncio
+async def test_replace_allowed_channels_skips_when_unchanged(
+    db_mock,
+    invalidate_mock,
+    audit_mock,
+):
+    """prev == new (after sort + dedupe) — true no-op, no audit row."""
+    db_mock.list_allowed_channels.return_value = [100, 200]
+    result = await service.replace_allowed_channels(
+        guild_id=10,
+        channel_ids=[200, 100, 200],  # dedupes to {100, 200}
+        actor_id=99,
+    )
+    db_mock.replace_allowed_channels.assert_not_awaited()
+    invalidate_mock.assert_not_called()
+    audit_mock.assert_not_awaited()
+    assert result.audit_emitted is False
+    assert result.prev_value == result.new_value == "[100,200]"
+
+
+# ---------------------------------------------------------------------------
+# set_policy composite
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_policy_runs_set_mode_then_replace_channels(
+    db_mock,
+    invalidate_mock,
+    audit_mock,
+):
+    db_mock.get_policy.return_value = {"mode": "all_channels"}
+    db_mock.list_allowed_channels.return_value = []
+    results = await service.set_policy(
+        guild_id=10,
+        mode="selected_channels",
+        channel_ids=[100, 200],
+        actor_id=99,
+    )
+    # Both underlying ops fired.
+    db_mock.set_mode.assert_awaited_once()
+    db_mock.replace_allowed_channels.assert_awaited_once()
+    assert [r.mutation_type for r in results] == [
+        "set_mode",
+        "replace_allowed_channels",
+    ]
+    # Cache invalidated twice (once per inner mutation) — that's
+    # intentional: each primitive owns its own invalidation discipline.
+    assert invalidate_mock.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_set_policy_with_none_channel_ids_skips_channel_op(
+    db_mock,
+    invalidate_mock,
+    audit_mock,
+):
+    """``channel_ids=None`` is the "change mode only, preserve channels"
+    path the settings UI uses when the operator picks a new mode but
+    hasn't touched the channel list.
+    """
+    db_mock.get_policy.return_value = None
+    results = await service.set_policy(
+        guild_id=10,
+        mode="all_channels",
+        channel_ids=None,
+        actor_id=99,
+    )
+    db_mock.set_mode.assert_awaited_once()
+    db_mock.replace_allowed_channels.assert_not_awaited()
+    assert [r.mutation_type for r in results] == ["set_mode"]
+
+
+@pytest.mark.asyncio
+async def test_set_policy_with_empty_channel_ids_clears_list(
+    db_mock,
+    invalidate_mock,
+    audit_mock,
+):
+    """``channel_ids=[]`` is "explicitly clear the list" — different
+    from ``None`` (preserve).  The replace op must run, so a real audit
+    row records the clear.
+    """
+    db_mock.get_policy.return_value = None
+    db_mock.list_allowed_channels.return_value = [100, 200]
+    results = await service.set_policy(
+        guild_id=10,
+        mode="all_channels",
+        channel_ids=[],
+        actor_id=99,
+    )
+    db_mock.replace_allowed_channels.assert_awaited_once_with(
+        guild_id=10,
+        channel_ids=[],
+        created_by=99,
+    )
+    assert [r.mutation_type for r in results] == [
+        "set_mode",
+        "replace_allowed_channels",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# get_policy_snapshot passthrough
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_policy_snapshot_passes_through_to_typed_accessor():
+    from utils.guild_config_accessors import CommandAccessPolicySnapshot
+
+    snap = CommandAccessPolicySnapshot(
+        mode="selected_channels",
+        allowed_channels=frozenset({100}),
+    )
+    with patch.object(
+        service,
+        "get_command_access_policy",
+        new=AsyncMock(return_value=snap),
+    ) as accessor:
+        result = await service.get_policy_snapshot(10)
+    accessor.assert_awaited_once_with(10)
+    assert result is snap
+
+
+# ---------------------------------------------------------------------------
+# forget_guild via core.runtime.command_access
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_core_forget_guild_invalidates_cache_then_deletes_db():
+    """``core.runtime.command_access.forget_guild`` must invalidate the
+    cache before the DB delete — order is important because a
+    concurrent read between the two steps must miss cache and then
+    fall through to the post-delete DB (which returns no row → safe
+    default), not hit the cache and resurrect a stale row.
+    """
+    from core.runtime import command_access as runtime_ca
+
+    invalidate_call_order: list[str] = []
+
+    def _track_invalidate(_guild_id: int) -> None:
+        invalidate_call_order.append("invalidate")
+
+    async def _track_db_forget(_guild_id: int) -> None:
+        invalidate_call_order.append("db_forget")
+
+    with (
+        patch(
+            "utils.guild_config_accessors.invalidate_command_access_policy",
+            new=MagicMock(side_effect=_track_invalidate),
+        ),
+        patch(
+            "utils.db.command_access.forget_guild",
+            new=AsyncMock(side_effect=_track_db_forget),
+        ),
+    ):
+        await runtime_ca.forget_guild(10)
+    assert invalidate_call_order == ["invalidate", "db_forget"]

--- a/tests/unit/slash/test_slash_access_check.py
+++ b/tests/unit/slash/test_slash_access_check.py
@@ -1,0 +1,398 @@
+"""PR-5 — slash command admission via the bootstrap cog's
+``tree.interaction_check``.
+
+Pins the slash-side mirror of the prefix admission contract:
+
+* :func:`setup` installs the cog's bound ``_slash_access_check`` on
+  ``bot.tree.interaction_check``.
+* :meth:`BootstrapAccessCog.cog_unload` restores ``tree.interaction_check``
+  to a trivial always-allow coroutine (matches discord.py's default
+  semantics) so a hot-reload doesn't leave a stale bound method
+  pinned to a previous cog instance.
+* The check delegates to ``resolve_command_access`` via the
+  interaction adapter; allow paths return ``True`` and never touch
+  the interaction response.
+* Denials post **ephemeral** feedback so only the invoker sees the
+  policy reason; lifecycle / DM denials stay silent.
+* Bootstrap slash commands (incl. hyphenated ``setup-hub`` etc.) keep
+  their operator-only bypass under restrictive modes.
+* When the interaction's initial response is already consumed (rare),
+  the helper falls back to ``followup.send`` so we don't 404 the
+  invoker.
+* ``send_message`` failures (channel deleted, missing perms) are
+  swallowed — the check still returns False rather than propagating
+  into the app-command dispatcher.
+
+The resolver's policy lookup is stubbed via
+``utils.guild_config_accessors.get_command_access_policy`` so the
+tests are asyncpg-free.  Each test patches a fresh
+:class:`CommandAccessPolicySnapshot` for the scenario.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from discord.ext import commands
+
+from cogs.bootstrap_access_cog import BootstrapAccessCog, setup
+from utils.guild_config_accessors import CommandAccessPolicySnapshot
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_bot():
+    """Build a ``commands.Bot`` mock that exposes ``tree.interaction_check``
+    as a writable attribute the way discord.py does.
+    """
+    bot = MagicMock(spec=commands.Bot)
+    bot._checks = []
+    bot.remove_check = MagicMock(side_effect=bot._checks.remove)
+    bot.add_check = MagicMock(side_effect=bot._checks.append)
+    bot.add_cog = AsyncMock()
+    # Real attribute so ``getattr(bot, "tree", None)`` returns a stable
+    # object the tests can inspect.  ``interaction_check`` starts as
+    # ``None`` so the test can tell the difference between "before
+    # setup" and "after setup".
+    bot.tree = SimpleNamespace(interaction_check=None)
+    return bot
+
+
+def _make_interaction(
+    *,
+    guild_id: int | None = 10,
+    channel_id: int | None = 100,
+    user_id: int = 42,
+    owner_id: int = 42,
+    administrator: bool = False,
+    command_qualified_name: str | None = "blackjack",
+    is_bot_owner: bool = False,
+    response_done: bool = False,
+):
+    guild = (
+        SimpleNamespace(id=guild_id, owner_id=owner_id)
+        if guild_id is not None
+        else None
+    )
+    channel = SimpleNamespace(id=channel_id) if channel_id is not None else None
+    user = SimpleNamespace(
+        id=user_id,
+        guild_permissions=SimpleNamespace(
+            administrator=administrator,
+            manage_guild=False,
+        ),
+    )
+    if command_qualified_name is None:
+        command = None
+    else:
+        command = SimpleNamespace(
+            name=command_qualified_name.split()[0],
+            qualified_name=command_qualified_name,
+        )
+    response = SimpleNamespace(
+        is_done=MagicMock(return_value=response_done),
+        send_message=AsyncMock(),
+    )
+    followup = SimpleNamespace(send=AsyncMock())
+    client = SimpleNamespace(is_owner=AsyncMock(return_value=is_bot_owner))
+    return SimpleNamespace(
+        guild=guild,
+        channel=channel,
+        user=user,
+        command=command,
+        response=response,
+        followup=followup,
+        client=client,
+    )
+
+
+def _patch_policy(monkeypatch, mode: str | None, *allowed_channels: int) -> None:
+    snapshot = CommandAccessPolicySnapshot(
+        mode=mode,
+        allowed_channels=frozenset(allowed_channels),
+    )
+    monkeypatch.setattr(
+        "utils.guild_config_accessors.get_command_access_policy",
+        AsyncMock(return_value=snapshot),
+    )
+
+
+# ---------------------------------------------------------------------------
+# setup() installs the tree gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_setup_installs_tree_interaction_check():
+    bot = _make_bot()
+    await setup(bot)
+    cog = bot.add_cog.await_args.args[0]
+    assert isinstance(cog, BootstrapAccessCog)
+    # The installed attribute is the cog's bound method.
+    # Bound methods are not ``is``-identical across attribute lookups;
+    # compare the underlying function + bound instance instead.
+    assert bot.tree.interaction_check.__func__ is BootstrapAccessCog._slash_access_check
+    assert bot.tree.interaction_check.__self__ is cog
+
+
+@pytest.mark.asyncio
+async def test_setup_overwrites_remnant_from_previous_bootstrap_cog():
+    """Reload from a previous BootstrapAccessCog leaves the old bound
+    method on ``tree.interaction_check``.  ``setup()`` overwrites it
+    with the new cog's method so the gate isn't pinned to a stale
+    instance with stale closures.
+    """
+    bot = _make_bot()
+    prev_cog = BootstrapAccessCog(bot)
+    bot.tree.interaction_check = prev_cog._slash_access_check
+
+    await setup(bot)
+
+    new_cog = bot.add_cog.await_args.args[0]
+    assert bot.tree.interaction_check.__func__ is BootstrapAccessCog._slash_access_check
+    assert bot.tree.interaction_check.__self__ is new_cog
+    assert bot.tree.interaction_check.__self__ is not prev_cog
+
+
+# ---------------------------------------------------------------------------
+# cog_unload restores the default
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cog_unload_restores_default_interaction_check():
+    """After ``cog_unload`` the tree's interaction_check must not still
+    point at the dead cog instance.  Restored to a trivial always-True
+    coroutine that mirrors discord.py's default semantics; the next
+    setup() can overwrite it again without spurious warnings.
+    """
+    from cogs.bootstrap_access_cog import _default_interaction_check
+
+    bot = _make_bot()
+    await setup(bot)
+    cog = bot.add_cog.await_args.args[0]
+    # Bound methods are not ``is``-identical across attribute lookups;
+    # compare the underlying function + bound instance instead.
+    assert bot.tree.interaction_check.__func__ is BootstrapAccessCog._slash_access_check
+    assert bot.tree.interaction_check.__self__ is cog
+
+    cog.cog_unload()
+    assert bot.tree.interaction_check is _default_interaction_check
+
+
+@pytest.mark.asyncio
+async def test_cog_unload_does_not_clobber_third_party_check():
+    """If a downstream cog later overwrote our installed check with
+    its own value, ``cog_unload`` must leave that value alone — we
+    only own the slot while it points at our own bound method.
+    """
+    bot = _make_bot()
+    await setup(bot)
+    cog = bot.add_cog.await_args.args[0]
+    third_party = AsyncMock(return_value=True)
+    bot.tree.interaction_check = third_party
+
+    cog.cog_unload()
+    assert bot.tree.interaction_check is third_party
+
+
+# ---------------------------------------------------------------------------
+# Resolver delegation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_slash_check_allows_under_default_all_channels(monkeypatch):
+    """Unconfigured guild — resolver returns the safe default
+    (``all_channels``), so any slash command runs anywhere.
+    """
+    _patch_policy(monkeypatch, mode=None)
+    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
+    interaction = _make_interaction(channel_id=999, command_qualified_name="blackjack")
+
+    assert await cog._slash_access_check(interaction) is True
+    interaction.response.send_message.assert_not_called()
+    interaction.followup.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_slash_check_allows_inside_selected_channel(monkeypatch):
+    _patch_policy(monkeypatch, "selected_channels", 12345)
+    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
+    interaction = _make_interaction(channel_id=12345)
+
+    assert await cog._slash_access_check(interaction) is True
+    interaction.response.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_slash_check_denies_outside_selected_channel_with_ephemeral_feedback(
+    monkeypatch,
+):
+    """The core slash-side fix: a denied slash command posts a visible
+    ephemeral message rather than failing silently.
+    """
+    _patch_policy(monkeypatch, "selected_channels", 12345)
+    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
+    interaction = _make_interaction(channel_id=999)
+
+    assert await cog._slash_access_check(interaction) is False
+    interaction.response.send_message.assert_awaited_once()
+    _args, kwargs = (
+        interaction.response.send_message.await_args.args,
+        interaction.response.send_message.await_args.kwargs,
+    )
+    assert kwargs.get("ephemeral") is True
+    # Feedback points at the recovery path.
+    message = interaction.response.send_message.await_args.args[0]
+    assert "channel" in message.lower() or "settings" in message.lower()
+
+
+@pytest.mark.asyncio
+async def test_slash_check_denies_under_disabled_mode_with_feedback(monkeypatch):
+    _patch_policy(monkeypatch, "disabled_except_bootstrap")
+    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
+    interaction = _make_interaction()  # non-bootstrap, non-operator
+
+    assert await cog._slash_access_check(interaction) is False
+    interaction.response.send_message.assert_awaited_once()
+    message = interaction.response.send_message.await_args.args[0]
+    assert "!setup" in message or "settings" in message.lower()
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap bypass — slash flavour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_slash_check_allows_owner_for_bootstrap_command(monkeypatch):
+    _patch_policy(monkeypatch, "disabled_except_bootstrap")
+    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
+    interaction = _make_interaction(
+        channel_id=999,
+        user_id=42,
+        owner_id=42,
+        command_qualified_name="setup",
+    )
+
+    assert await cog._slash_access_check(interaction) is True
+    interaction.response.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_slash_check_allows_admin_for_hyphenated_bootstrap_command(monkeypatch):
+    """Slash commands forbid whitespace in names, so multi-token
+    bootstrap commands ship as hyphenated (``setup-hub``,
+    ``setup-status``).  The resolver's
+    :func:`is_bootstrap_command` recognises the hyphen-namespaced
+    form so admins keep their bypass without each new ``setup-*``
+    needing its own allowlist entry.
+    """
+    _patch_policy(monkeypatch, "selected_channels")
+    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
+    interaction = _make_interaction(
+        channel_id=999,
+        owner_id=42,
+        administrator=True,
+        command_qualified_name="setup-hub",
+    )
+
+    assert await cog._slash_access_check(interaction) is True
+
+
+@pytest.mark.asyncio
+async def test_slash_check_denies_bootstrap_for_non_operator(monkeypatch):
+    """Bootstrap bypass is operator-only.  A regular user invoking
+    ``/setup`` under a restrictive policy still gets denied with
+    feedback (so they know to ask an admin, not so they can self-
+    promote).
+    """
+    _patch_policy(monkeypatch, "selected_channels", 12345)
+    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
+    interaction = _make_interaction(
+        channel_id=999,
+        user_id=99,
+        owner_id=42,
+        command_qualified_name="setup",
+    )
+
+    assert await cog._slash_access_check(interaction) is False
+    interaction.response.send_message.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle drain / DM — silent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_slash_check_denies_dm_silently(monkeypatch):
+    _patch_policy(monkeypatch, None)
+    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
+    interaction = _make_interaction(guild_id=None, channel_id=None)
+
+    assert await cog._slash_access_check(interaction) is False
+    interaction.response.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_slash_check_denies_during_lifecycle_drain_silently(monkeypatch):
+    """Surfacing a message during shutdown would race the connection
+    close; the resolver's lifecycle branch sets ``feedback=None`` and
+    this check must respect that by NOT calling send_message.
+    """
+    from core.runtime import lifecycle
+
+    _patch_policy(monkeypatch, None)
+    lifecycle.reset_for_tests()
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown("test")
+    try:
+        cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
+        interaction = _make_interaction()
+
+        assert await cog._slash_access_check(interaction) is False
+        interaction.response.send_message.assert_not_called()
+        interaction.followup.send.assert_not_called()
+    finally:
+        lifecycle.reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Response-state handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_slash_check_uses_followup_when_response_already_done(monkeypatch):
+    """If something raced ahead and consumed the initial response,
+    ``response.send_message`` would 404; fall back to followup.send
+    so the invoker still gets feedback.
+    """
+    _patch_policy(monkeypatch, "selected_channels")
+    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
+    interaction = _make_interaction(response_done=True)
+
+    assert await cog._slash_access_check(interaction) is False
+    interaction.response.send_message.assert_not_called()
+    interaction.followup.send.assert_awaited_once()
+    assert interaction.followup.send.await_args.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_slash_check_tolerates_send_message_failure(monkeypatch):
+    """A ``send_message`` raise (channel deleted, missing perms,
+    interaction expired) must not propagate into the app-command
+    dispatcher.  Check still returns False.
+    """
+    _patch_policy(monkeypatch, "selected_channels")
+    cog = BootstrapAccessCog(MagicMock(spec=commands.Bot))
+    interaction = _make_interaction()
+    interaction.response.send_message = AsyncMock(side_effect=RuntimeError("boom"))
+
+    assert await cog._slash_access_check(interaction) is False

--- a/tests/unit/test_bot_boot.py
+++ b/tests/unit/test_bot_boot.py
@@ -57,9 +57,9 @@ def test_bot1_imports_and_calls_spawn_scheduler() -> None:
         "can be spawned at boot (PR-F)."
     )
     # Must call it with ``bot`` so the cog can reach the running loop.
-    assert re.search(r"spawn_scheduler\s*\(\s*bot\s*\)", src), (
-        "bot1.py must call spawn_scheduler(bot) at startup (PR-F)."
-    )
+    assert re.search(
+        r"spawn_scheduler\s*\(\s*bot\s*\)", src
+    ), "bot1.py must call spawn_scheduler(bot) at startup (PR-F)."
 
 
 def test_bot1_does_not_double_supervise_scheduler_task() -> None:
@@ -111,9 +111,7 @@ def test_bot1_shutdown_drains_via_core_runtime_tasks() -> None:
     assert not re.search(
         r"if\s+_shutting_down\s*:\s*\n\s+(?:pending|cancelled|_,)\s*=",
         src,
-    ), (
-        "Shutdown drain must run on every exit, not gated on _shutting_down."
-    )
+    ), "Shutdown drain must run on every exit, not gated on _shutting_down."
 
 
 def test_bot1_applies_config_log_level_at_boot() -> None:
@@ -151,16 +149,16 @@ def test_bot1_sigterm_handler_routes_through_lifecycle() -> None:
     )
 
 
-def test_bot1_channel_guard_admits_via_lifecycle() -> None:
-    """LP-2: ``_channel_guard`` must consult
-    :func:`core.runtime.lifecycle.can_accept_commands` rather than the
-    legacy ``_shutting_down`` bool.
-    """
-    src = _src()
-    assert "_lifecycle.can_accept_commands()" in src, (
-        "bot1._channel_guard must check lifecycle.can_accept_commands() "
-        "so command admission tracks the lifecycle phase (LP-2)."
-    )
+# LP-2 ``_channel_guard`` admit-via-lifecycle assertion moved out of
+# ``bot1.py`` in command-access PR-4.  The prefix admission gate now
+# lives in ``cogs.bootstrap_access_cog`` and delegates to
+# ``core.runtime.command_access.resolve_command_access``, which
+# consults ``lifecycle.can_accept_commands()`` as step 1 of the
+# admission chain.  The lifecycle-drain admission contract is pinned
+# by ``tests/unit/runtime/test_command_access_resolver.py::
+# test_resolver_denies_silently_when_lifecycle_draining`` and by
+# ``tests/unit/cogs/test_bootstrap_access_cog.py::
+# test_channel_guard_blocks_when_lifecycle_is_shutting_down``.
 
 
 def test_bot1_posts_startup_summary_webhook_before_bot_start() -> None:
@@ -195,9 +193,9 @@ def test_bot1_spawns_lifecycle_close_driver() -> None:
         "'lifecycle_close_driver' to drive bot.close() on any pending "
         "lifecycle request."
     )
-    assert "_drive_close_on_lifecycle_request" in src, (
-        "bot1.py must define and spawn _drive_close_on_lifecycle_request."
-    )
+    assert (
+        "_drive_close_on_lifecycle_request" in src
+    ), "bot1.py must define and spawn _drive_close_on_lifecycle_request."
 
 
 def test_bot1_close_driver_uses_bounded_timeout() -> None:
@@ -213,8 +211,7 @@ def test_bot1_close_driver_uses_bounded_timeout() -> None:
         r"asyncio\.wait_for\(\s*bot\.close\(\)\s*,",
         src,
     ), (
-        "bot1.py must wrap bot.close() in asyncio.wait_for with a "
-        "bounded timeout."
+        "bot1.py must wrap bot.close() in asyncio.wait_for with a " "bounded timeout."
     )
 
 
@@ -227,9 +224,9 @@ def test_bot1_close_driver_gates_on_pending_and_draining() -> None:
         "bot1.py close-driver must consult _lifecycle.get_pending() — "
         "not restart_requested() — so shutdown intent is also closed."
     )
-    assert "_lifecycle.Phase.DRAINING" in src, (
-        "bot1.py close-driver must gate on _lifecycle.Phase.DRAINING."
-    )
+    assert (
+        "_lifecycle.Phase.DRAINING" in src
+    ), "bot1.py close-driver must gate on _lifecycle.Phase.DRAINING."
 
 
 def test_bot1_close_driver_does_not_own_cleanup() -> None:
@@ -251,9 +248,9 @@ def test_bot1_close_driver_does_not_own_cleanup() -> None:
         ):
             driver_fn = node
             break
-    assert driver_fn is not None, (
-        "bot1.py must define async def _drive_close_on_lifecycle_request."
-    )
+    assert (
+        driver_fn is not None
+    ), "bot1.py must define async def _drive_close_on_lifecycle_request."
 
     forbidden_attr_calls = {
         "release_lock_best_effort",
@@ -305,9 +302,7 @@ def test_bot1_no_legacy_restart_close_driver_names() -> None:
         )
 
 
-def test_bot1_finally_block_transitions_to_restarting_when_restart_pending() -> (
-    None
-):
+def test_bot1_finally_block_transitions_to_restarting_when_restart_pending() -> None:
     """LP-3: the finally block surfaces RESTARTING as the terminal
     phase when a restart was requested, so the recent-event buffer
     distinguishes restart-exit from shutdown-exit."""
@@ -358,10 +353,12 @@ def test_bot1_shutdown_drain_logs_timeout() -> None:
     noise."""
     src = _src()
     finally_block = src.split("finally:", 1)[-1]
-    assert "still_pending" in finally_block, (
-        "Shutdown drain must capture still_pending tasks after timeout."
-    )
-    assert re.search(r"logger\.warning\([^)]*Shutdown drain", finally_block, re.DOTALL), (
+    assert (
+        "still_pending" in finally_block
+    ), "Shutdown drain must capture still_pending tasks after timeout."
+    assert re.search(
+        r"logger\.warning\([^)]*Shutdown drain", finally_block, re.DOTALL
+    ), (
         "Shutdown drain timeout must emit a WARNING log line so "
         "operators can detect the slow drain."
     )

--- a/tests/unit/test_config_env_cleanup.py
+++ b/tests/unit/test_config_env_cleanup.py
@@ -1,0 +1,118 @@
+"""PR-7 — command-access env cleanup.
+
+Pins:
+
+* ``config.ALLOWED_CHANNELS`` is deleted — production behaviour is
+  owned by the per-guild DB-backed policy (migration 050) read
+  through :func:`core.runtime.command_access.resolve_command_access`,
+  not by an env var with hardcoded fallback IDs.
+* ``config.CLEANUP_WHITELIST_CHANNELS`` is intentionally preserved
+  because cleanup whitelist is a separate concern owned by
+  ``cogs/cleanup_cog.py``.  A future PR can migrate that to a
+  DB-backed policy in the same shape; this test fails loud if
+  someone deletes it in the same sweep.
+* ``BOT_ALLOWED_CHANNELS`` is no longer read anywhere under
+  ``disbot/`` outside of comments referencing the historical
+  behaviour — a grep-style check guards against a future drive-by
+  edit silently restoring the env override and re-introducing the
+  fresh-guild-onboarding bug.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DISBOT = _REPO_ROOT / "disbot"
+
+
+def test_allowed_channels_is_gone_from_config():
+    """``config.ALLOWED_CHANNELS`` must not be importable any more."""
+    import config
+
+    assert not hasattr(config, "ALLOWED_CHANNELS"), (
+        "config.ALLOWED_CHANNELS was deleted in PR-7 — production "
+        "command admission is owned by guild_command_access_policy "
+        "(migration 050).  Do not reintroduce the symbol."
+    )
+
+
+def test_cleanup_whitelist_channels_is_preserved():
+    """Cleanup whitelist is a separate concern; it stays env-driven
+    until a follow-up PR migrates it.  This test fails if someone
+    deletes it in the same sweep as ALLOWED_CHANNELS — which would
+    silently break the cleanup_cog's whitelist semantics.
+    """
+    import config
+
+    assert hasattr(config, "CLEANUP_WHITELIST_CHANNELS")
+    assert isinstance(config.CLEANUP_WHITELIST_CHANNELS, set)
+
+
+def test_bot_allowed_channels_env_var_is_not_read_in_production_code():
+    """The ``BOT_ALLOWED_CHANNELS`` env var must not be referenced by
+    any production read path under ``disbot/``.  Comments referring
+    to the historical behaviour are allowed (they document the PR-7
+    cleanup); ``os.getenv("BOT_ALLOWED_CHANNELS", …)`` calls are not.
+    """
+    bad: list[str] = []
+    for path in _DISBOT.rglob("*.py"):
+        if "__pycache__" in path.parts:
+            continue
+        src = path.read_text()
+        # Detect the env-var read shape (not the bare token, which
+        # appears in legitimate explanatory comments).
+        if 'os.getenv("BOT_ALLOWED_CHANNELS"' in src:
+            bad.append(str(path.relative_to(_REPO_ROOT)))
+    assert not bad, (
+        "BOT_ALLOWED_CHANNELS is no longer consumed by production "
+        "code — references in:\n  " + "\n  ".join(bad)
+    )
+
+
+@pytest.mark.parametrize(
+    "channel_id",
+    [1348795460948590622, 1403818013408624642],
+)
+def test_hardcoded_main_server_channel_ids_only_appear_in_the_backfill_migration(
+    channel_id: int,
+):
+    """The two main-server channel IDs that used to live in
+    ``config.py`` as the ``ALLOWED_CHANNELS`` fallback are now
+    confined to the backfill migration (051) for command-access
+    semantics.  ``config.py`` retains them in the unrelated
+    ``CLEANUP_WHITELIST_CHANNELS`` default — different concern,
+    explicitly out of scope for PR-7 — so it stays on the
+    allowlist for this scan.  Any OTHER production file
+    referencing these IDs would silently re-create the
+    fresh-guild-onboarding bug for new deployments.
+    """
+    # Files where the IDs legitimately appear (and are pinned by
+    # other tests).
+    _ALLOWED = {
+        "disbot/migrations/051_command_access_main_server_backfill.sql",
+        # CLEANUP_WHITELIST_CHANNELS preserves the IDs as the cleanup
+        # cog's whitelist fallback — pinned by
+        # test_cleanup_whitelist_channels_is_preserved above.
+        "disbot/config.py",
+    }
+    bad: list[str] = []
+    for path in _DISBOT.rglob("*"):
+        if path.is_dir() or "__pycache__" in path.parts:
+            continue
+        rel = str(path.relative_to(_REPO_ROOT))
+        if rel in _ALLOWED:
+            continue
+        try:
+            src = path.read_text()
+        except UnicodeDecodeError:
+            continue
+        if str(channel_id) in src:
+            bad.append(rel)
+    assert not bad, (
+        f"hardcoded channel id {channel_id} should only live in "
+        "migrations/051 (and config.CLEANUP_WHITELIST_CHANNELS for "
+        "the unrelated cleanup whitelist); found elsewhere in:\n  " + "\n  ".join(bad)
+    )

--- a/tests/unit/views/test_settings_command_access.py
+++ b/tests/unit/views/test_settings_command_access.py
@@ -1,0 +1,363 @@
+"""PR-6 — Settings Manager: Command Access panel tests.
+
+Pins:
+
+* :func:`build_command_access_embed` renders the current policy
+  via ``services.command_access_service.get_policy_snapshot`` and
+  surfaces the recovery banner under ``disabled_except_bootstrap``.
+* Mode-button callbacks route mutations through
+  ``services.command_access_service.set_mode``; the channel select
+  routes through ``replace_allowed_channels``.  Non-admin invokers
+  are rejected with ephemeral feedback BEFORE the service is
+  touched.
+* Settings-hub button installation: the hub view exposes the new
+  "Command access" button on the existing button row.
+
+The service layer is patched per-test so the panel exercise stays
+DB-free.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from utils.guild_config_accessors import CommandAccessPolicySnapshot
+from views.settings.edit_command_access import (
+    CommandAccessView,
+    _apply_mode,
+    _ChannelAllowlistSelect,
+    build_command_access_embed,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _snapshot(
+    mode: str | None,
+    *channel_ids: int,
+) -> CommandAccessPolicySnapshot:
+    return CommandAccessPolicySnapshot(
+        mode=mode,
+        allowed_channels=frozenset(channel_ids),
+    )
+
+
+def _admin_user(user_id: int = 42) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=user_id,
+        guild_permissions=SimpleNamespace(
+            administrator=True,
+            manage_guild=False,
+        ),
+    )
+
+
+def _non_admin_user(user_id: int = 42) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=user_id,
+        guild_permissions=SimpleNamespace(
+            administrator=False,
+            manage_guild=False,
+        ),
+    )
+
+
+def _make_interaction(
+    *,
+    user=None,
+    guild_id: int | None = 10,
+):
+    user = user or _admin_user()
+    response = SimpleNamespace(
+        send_message=AsyncMock(),
+        defer=AsyncMock(),
+        is_done=MagicMock(return_value=False),
+    )
+    followup = SimpleNamespace(send=AsyncMock())
+    return SimpleNamespace(
+        user=user,
+        guild_id=guild_id,
+        response=response,
+        followup=followup,
+        edit_original_response=AsyncMock(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_command_access_embed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_embed_for_unconfigured_guild_shows_default_label():
+    """No DB policy row → embed labels the mode "All channels (default
+    — no policy row)" so operators understand the implicit default
+    rather than seeing a blank ``None``.
+    """
+    with patch(
+        "services.command_access_service.get_policy_snapshot",
+        new=AsyncMock(return_value=_snapshot(None)),
+    ):
+        embed = await build_command_access_embed(guild_id=10)
+    text = " ".join(f.value for f in embed.fields)
+    assert "All channels" in text
+    assert "default" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_embed_for_selected_channels_lists_channel_mentions():
+    with patch(
+        "services.command_access_service.get_policy_snapshot",
+        new=AsyncMock(return_value=_snapshot("selected_channels", 100, 200)),
+    ):
+        embed = await build_command_access_embed(guild_id=10)
+    text = " ".join(f.value for f in embed.fields)
+    assert "<#100>" in text
+    assert "<#200>" in text
+
+
+@pytest.mark.asyncio
+async def test_embed_for_disabled_mode_includes_recovery_field():
+    """Operators in ``disabled_except_bootstrap`` mode must see the
+    explicit recovery path (mode button or ``!setup``) so the panel
+    is self-rescuing.
+    """
+    with patch(
+        "services.command_access_service.get_policy_snapshot",
+        new=AsyncMock(return_value=_snapshot("disabled_except_bootstrap")),
+    ):
+        embed = await build_command_access_embed(guild_id=10)
+    recovery_fields = [f for f in embed.fields if f.name == "Recovery"]
+    assert len(recovery_fields) == 1
+    assert "!setup" in recovery_fields[0].value
+
+
+@pytest.mark.asyncio
+async def test_embed_handles_missing_guild_context():
+    """``guild_id=None`` (DM context) yields a placeholder embed
+    rather than crashing the panel builder.
+    """
+    embed = await build_command_access_embed(guild_id=None)
+    assert "Guild context" in " ".join(f.value for f in embed.fields)
+
+
+# ---------------------------------------------------------------------------
+# _apply_mode callback path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_mode_calls_service_for_admin():
+    interaction = _make_interaction()
+    view = CommandAccessView(interaction.user)
+
+    with (
+        patch(
+            "services.command_access_service.set_mode",
+            new=AsyncMock(),
+        ) as mock_set_mode,
+        patch(
+            "services.command_access_service.get_policy_snapshot",
+            new=AsyncMock(return_value=_snapshot("all_channels")),
+        ),
+    ):
+        await _apply_mode(interaction, "all_channels", view)
+
+    mock_set_mode.assert_awaited_once_with(
+        guild_id=10,
+        mode="all_channels",
+        actor_id=42,
+    )
+    # Defers, refreshes the panel embed, sends ephemeral confirmation.
+    interaction.response.defer.assert_awaited_once()
+    interaction.edit_original_response.assert_awaited_once()
+    interaction.followup.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_apply_mode_rejects_non_admin_without_touching_service():
+    interaction = _make_interaction(user=_non_admin_user())
+    view = CommandAccessView(interaction.user)
+
+    with patch(
+        "services.command_access_service.set_mode",
+        new=AsyncMock(),
+    ) as mock_set_mode:
+        await _apply_mode(interaction, "all_channels", view)
+
+    mock_set_mode.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "permission" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_apply_mode_rejects_dm_context():
+    interaction = _make_interaction(guild_id=None)
+    view = CommandAccessView(interaction.user)
+
+    with patch(
+        "services.command_access_service.set_mode",
+        new=AsyncMock(),
+    ) as mock_set_mode:
+        await _apply_mode(interaction, "all_channels", view)
+
+    mock_set_mode.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_apply_mode_surfaces_service_errors_ephemerally():
+    """A ``CommandAccessMutationError`` from the service must reach
+    the operator as ephemeral feedback rather than propagating into
+    the view dispatcher (where it would be a generic "interaction
+    failed").
+    """
+    from services.command_access_service import InvalidCommandAccessModeError
+
+    interaction = _make_interaction()
+    view = CommandAccessView(interaction.user)
+
+    with patch(
+        "services.command_access_service.set_mode",
+        new=AsyncMock(side_effect=InvalidCommandAccessModeError("bad")),
+    ):
+        await _apply_mode(interaction, "all_channels", view)
+
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "InvalidCommandAccessModeError" in msg
+
+
+# ---------------------------------------------------------------------------
+# _ChannelAllowlistSelect callback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_channel_select_routes_to_replace_allowed_channels():
+    interaction = _make_interaction()
+    view = CommandAccessView(interaction.user)
+    select = next(
+        item for item in view.children if isinstance(item, _ChannelAllowlistSelect)
+    )
+    select._values = [SimpleNamespace(id=100), SimpleNamespace(id=200)]
+    # Make ``self.values`` return the patched list — discord.py
+    # builds it from the interaction payload at runtime.
+    select.values  # touch property — defaults to empty before patch  # noqa: B018
+    # discord.py select.values is a property reading from internal
+    # state; override it on the instance for the test.
+    type(select).values = property(lambda self: self._values)
+
+    with (
+        patch(
+            "services.command_access_service.replace_allowed_channels",
+            new=AsyncMock(),
+        ) as mock_replace,
+        patch(
+            "services.command_access_service.get_policy_snapshot",
+            new=AsyncMock(return_value=_snapshot("selected_channels", 100, 200)),
+        ),
+    ):
+        await select.callback(interaction)
+
+    mock_replace.assert_awaited_once_with(
+        guild_id=10,
+        channel_ids=[100, 200],
+        actor_id=42,
+    )
+    interaction.response.defer.assert_awaited_once()
+    interaction.followup.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_channel_select_rejects_non_admin():
+    interaction = _make_interaction(user=_non_admin_user())
+    view = CommandAccessView(interaction.user)
+    select = next(
+        item for item in view.children if isinstance(item, _ChannelAllowlistSelect)
+    )
+    type(select).values = property(lambda self: [SimpleNamespace(id=100)])
+
+    with patch(
+        "services.command_access_service.replace_allowed_channels",
+        new=AsyncMock(),
+    ) as mock_replace:
+        await select.callback(interaction)
+
+    mock_replace.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# CommandAccessView shape
+# ---------------------------------------------------------------------------
+
+
+def test_view_exposes_three_mode_buttons_and_channel_select_and_back():
+    """The view must expose exactly the contract the embed promises:
+    one button per access mode, a multi-channel select, and the
+    "Back to Hub" navigation.
+    """
+    view = CommandAccessView(_admin_user())
+    custom_ids = {
+        getattr(c, "custom_id", None)
+        for c in view.children
+        if isinstance(c, discord.ui.Item)
+    }
+    assert "settings_command_access.mode.all_channels" in custom_ids
+    assert "settings_command_access.mode.selected_channels" in custom_ids
+    assert "settings_command_access.mode.disabled_except_bootstrap" in custom_ids
+    assert "settings_command_access.channels" in custom_ids
+    assert "settings_command_access.back" in custom_ids
+
+
+# ---------------------------------------------------------------------------
+# SettingsHubView wiring
+# ---------------------------------------------------------------------------
+
+
+def test_hub_view_exposes_command_access_button():
+    """The settings hub picks up the new Command Access entry point."""
+    from views.settings.hub import SettingsHubView
+
+    hub = SettingsHubView(_admin_user())
+    custom_ids = {
+        getattr(c, "custom_id", None)
+        for c in hub.children
+        if isinstance(c, discord.ui.Item)
+    }
+    assert "settings_hub.command_access" in custom_ids
+
+
+@pytest.mark.asyncio
+async def test_hub_command_access_button_opens_command_access_view():
+    """Clicking the Command Access button on the hub swaps the panel
+    to the Command Access view + its embed.
+    """
+    from views.settings.hub import SettingsHubView, _OpenCommandAccess
+
+    hub = SettingsHubView(_admin_user())
+    button = next(item for item in hub.children if isinstance(item, _OpenCommandAccess))
+
+    interaction = _make_interaction()
+    interaction.response = SimpleNamespace(
+        edit_message=AsyncMock(),
+        send_message=AsyncMock(),
+    )
+
+    with patch(
+        "services.command_access_service.get_policy_snapshot",
+        new=AsyncMock(return_value=_snapshot(None)),
+    ):
+        await button.callback(interaction)
+
+    interaction.response.edit_message.assert_awaited_once()
+    kwargs = interaction.response.edit_message.await_args.kwargs
+    assert isinstance(kwargs["view"], CommandAccessView)

--- a/tests/unit/views/test_settings_edit_safety.py
+++ b/tests/unit/views/test_settings_edit_safety.py
@@ -371,4 +371,7 @@ def test_s6_invariant_allowlist_only_contains_edit_files():
         "edit_channel.py",
         "edit_role.py",
         "edit_number_presets.py",
+        # Command-access onboarding PR-6 — per-guild allowed-channel
+        # policy mutation surface.
+        "edit_command_access.py",
     }

--- a/tests/unit/views/test_settings_hub_view.py
+++ b/tests/unit/views/test_settings_hub_view.py
@@ -42,14 +42,17 @@ def test_hub_embed_has_title_and_inventory_field():
     assert "Customization findings" in field_names
 
 
-def test_hub_view_contains_subsystem_dropdown_and_four_buttons():
+def test_hub_view_contains_subsystem_dropdown_and_diagnostic_buttons():
+    """Subsystem dropdown + four S5 diagnostic buttons + the
+    command-access edit-flow button (added in command-access PR-6).
+    """
     view = SettingsHubView(_author())
-    # 1 Select + 4 Buttons = 5 items.
-    assert len(view.children) == 5
+    # 1 Select + 4 diagnostic Buttons + 1 command-access Button = 6 items.
+    assert len(view.children) == 6
     selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
     buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
     assert len(selects) == 1
-    assert len(buttons) == 4
+    assert len(buttons) == 5
 
 
 def test_hub_dropdown_lists_registered_subsystems():
@@ -75,7 +78,9 @@ def test_hub_dropdown_options_capped_to_discord_limit():
 
 
 def test_button_labels_match_directive():
-    """The four sub-panel buttons must match the directive's vocabulary."""
+    """The four S5 diagnostic buttons match the directive's vocabulary;
+    the fifth (command-access PR-6) opens the per-guild policy panel.
+    """
     view = SettingsHubView(_author())
     buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
     labels = {b.label for b in buttons}
@@ -84,6 +89,7 @@ def test_button_labels_match_directive():
         "Invalid settings",
         "Missing bindings",
         "Recent changes",
+        "Command access",
     }
 
 


### PR DESCRIPTION
## Summary

Implements the complete command-access onboarding fix — a per-guild DB-backed policy system that replaces the legacy global `BOT_ALLOWED_CHANNELS` env var. Adds a central resolver that gates every prefix and slash command, a mutation service for admin writes, settings UI, diagnostics, and full test coverage.

## Key Changes

### Core Infrastructure (PR-1, PR-2)
- **Migration 050** (`disbot/migrations/050_guild_command_access.sql`): Two-table schema for per-guild policy (mode + allowed channels)
- **DB primitives** (`disbot/utils/db/command_access.py`): Four atomic operations (set_mode, add/remove/replace allowed channels) with validation
- **Typed accessor** (`disbot/utils/guild_config_accessors.py`): `CommandAccessPolicySnapshot` dataclass and cache-backed read path
- **Central resolver** (`disbot/core/runtime/command_access.py`): `resolve_command_access()` function that evaluates admission decisions with structured feedback; preserves existing bootstrap bypass for guild operators and bot owners
- **Resolver tests** (`tests/unit/runtime/test_command_access_resolver.py`): 508 lines covering lifecycle gate, DM/guildless, bootstrap bypass, all three modes, and adapter builders

### Admission Gates (PR-4, PR-5)
- **Prefix guard** (`disbot/cogs/bootstrap_access_cog.py`): Rewired to delegate to resolver; preserves `!force` admin escape hatch
- **Slash guard** (`disbot/cogs/bootstrap_access_cog.py`): New `tree.interaction_check` that routes through resolver with ephemeral feedback
- **Cog setup**: Installs both gates on first load (load-order invariant in `config.INITIAL_EXTENSIONS`)
- **Tests** (`tests/unit/cogs/test_bootstrap_access_cog.py`, `tests/unit/slash/test_slash_access_check.py`): Pin guard behavior, feedback surface, and bootstrap bypass under restrictive modes

### Admin Mutation Service (PR-3)
- **Service** (`disbot/services/command_access_service.py`): 509-line module implementing the 6-step contract (validate → read → write → invalidate → audit → return result)
- **Public API**: `set_mode()`, `add_allowed_channel()`, `remove_allowed_channel()`, `replace_allowed_channels()` (atomic bulk replace), `set_policy()` (composite mode + channel replace), `get_policy_snapshot()` (read-through), `forget_guild()` (teardown)
- **Audit integration**: Every mutation emits `audit.action_recorded` with prev/new values; no-op mutations skip audit
- **Service tests** (`tests/unit/services/test_command_access_service.py`): 489 lines pinning the 6-step contract, idempotency, and composite operations

### Settings UI (PR-6)
- **Panel** (`disbot/views/settings/edit_command_access.py`): Mode buttons + multi-channel select that route through service; admin-only with defense-in-depth check
- **Hub integration** (`disbot/views/settings/hub.py`): New "Command access" button on settings hub
- **Embed builder**: Renders current policy with recovery banner under `disabled_except_bootstrap` mode
- **Tests** (`tests/unit/views/test_settings_command_access.py`): 363 lines covering embed rendering, mode mutations, channel selection, and permission checks

### Diagnostics (PR-8)
- **Diagnostic embed** (`disbot/cogs/diagnostic/_platform_embeds.py`): `build_command_access_diagnostic_embed()` probes the resolver with a synthetic context to show operators why a command would/wouldn't work in a channel
- **Metrics**: New `command_access_decisions_total` counter (subsystem, scope, decision labels) incremented by resolver
- **Tests** (`tests/unit/cogs/test_command_access_diagnostic.py`):

https://claude.ai/code/session_016sM2KEiZyBHfNg1vrcSKbt