### PR TITLE
Harden back-button lifecycle: defer before build, use safe_edit

### DIFF
--- a/disbot/views/navigation.py
+++ b/disbot/views/navigation.py
@@ -125,6 +125,9 @@ def attach_back_button(
     exception is logged with ``exc_info=True`` and the user receives an
     ephemeral fallback. The original message is NOT edited (preserving
     whatever the user was looking at).
+
+    The callback defers before invoking ``parent_builder`` so slow
+    rebuilds do not exhaust Discord's initial response window.
     """
     if len(view.children) >= MAX_COMPONENTS:
         logger.warning(
@@ -144,6 +147,10 @@ def attach_back_button(
     )
 
     async def _back_callback(interaction: discord.Interaction) -> None:
+        from core.runtime.interaction_helpers import safe_defer, safe_edit
+
+        if not await safe_defer(interaction):
+            return
         try:
             embed, parent_view = await parent_builder(interaction)
         except Exception as exc:  # noqa: BLE001 — navigation must not crash
@@ -153,42 +160,15 @@ def attach_back_button(
                 exc,
                 exc_info=True,
             )
-            if not interaction.response.is_done():
-                try:
-                    await interaction.response.send_message(
-                        error_message,
-                        ephemeral=True,
-                    )
-                except Exception as send_exc:  # noqa: BLE001 — log + swallow
-                    logger.warning(
-                        "navigation back-button: ephemeral fallback also failed: %s",
-                        send_exc,
-                    )
-            return
-        # Use response.edit_message when we haven't been deferred yet;
-        # otherwise fall through to edit_original_response.
-        if interaction.response.is_done():
             try:
-                await interaction.edit_original_response(
-                    embed=embed,
-                    view=parent_view,
-                )
-            except Exception as exc:  # noqa: BLE001 — log + swallow
+                await interaction.followup.send(error_message, ephemeral=True)
+            except Exception as send_exc:  # noqa: BLE001 — log + swallow
                 logger.warning(
-                    "navigation back-button: edit_original_response failed "
-                    "(custom_id=%r): %s",
-                    custom_id,
-                    exc,
+                    "navigation back-button: ephemeral fallback also failed: %s",
+                    send_exc,
                 )
             return
-        try:
-            await interaction.response.edit_message(embed=embed, view=parent_view)
-        except Exception as exc:  # noqa: BLE001 — log + swallow
-            logger.warning(
-                "navigation back-button: edit_message failed (custom_id=%r): %s",
-                custom_id,
-                exc,
-            )
+        await safe_edit(interaction, embed=embed, view=parent_view)
 
     btn.callback = _back_callback  # type: ignore[method-assign]
     view.add_item(btn)

--- a/tests/unit/cogs/test_cleanup_panel.py
+++ b/tests/unit/cogs/test_cleanup_panel.py
@@ -460,6 +460,7 @@ async def test_back_button_returns_to_same_cleanup_panel_instance():
     next_interaction.client = MagicMock()
     next_interaction.response = MagicMock()
     next_interaction.response.is_done = MagicMock(return_value=False)
+    next_interaction.response.defer = AsyncMock()
     next_interaction.response.edit_message = AsyncMock()
     next_interaction.response.send_message = AsyncMock()
     next_interaction.edit_original_response = AsyncMock()

--- a/tests/unit/views/test_economy_work_result.py
+++ b/tests/unit/views/test_economy_work_result.py
@@ -196,6 +196,7 @@ async def test_work_result_back_button_returns_to_economy_panel():
     interaction.user = _author(id_=1)
     interaction.guild_id = 2
     interaction.response.is_done = MagicMock(return_value=False)
+    interaction.response.defer = AsyncMock()
     interaction.response.edit_message = AsyncMock()
 
     with patch(

--- a/tests/unit/views/test_games_hub_view.py
+++ b/tests/unit/views/test_games_hub_view.py
@@ -520,6 +520,7 @@ async def test_back_button_callback_rebuilds_games_hub_with_original_author():
     interaction = MagicMock(spec=discord.Interaction)
     interaction.response = MagicMock()
     interaction.response.is_done = MagicMock(return_value=False)
+    interaction.response.defer = AsyncMock()
     interaction.response.edit_message = AsyncMock()
     interaction.response.send_message = AsyncMock()
     interaction.edit_original_response = AsyncMock()

--- a/tests/unit/views/test_navigation.py
+++ b/tests/unit/views/test_navigation.py
@@ -7,11 +7,15 @@ Covers:
 * ``attach_back_button`` returns ``False`` and logs a WARNING when
   the view is already at Discord's 25-component cap; the button is
   not added.
-* The button's callback calls ``parent_builder`` at click time.
-* If ``parent_builder`` raises, the user gets an ephemeral fallback
-  and the original message is NOT edited.
-* If ``parent_builder`` succeeds, the message is edited in place
-  with the new ``(embed, view)``.
+* The button's callback follows defer → build → edit-in-place,
+  routing through ``safe_defer`` / ``safe_edit`` so slow rebuilds
+  don't exhaust Discord's 3-second response window.
+* If ``safe_defer`` returns ``False`` the callback bails silently.
+* If ``parent_builder`` raises after defer, the user gets an
+  ephemeral via ``followup.send`` and the original message is NOT
+  edited.
+* If ``parent_builder`` succeeds, ``safe_edit`` swaps in the new
+  ``(embed, view)``.
 * ``transition_to`` defers, builds, and edits via ``safe_edit``.
 * ``transition_to`` surfaces builder errors as ephemerals without
   crashing.
@@ -151,15 +155,29 @@ def test_attach_back_button_warns_when_skipping(caplog):
 
 
 @pytest.mark.asyncio
-async def test_attach_back_button_callback_calls_parent_builder_at_click_time():
+async def test_attach_back_button_callback_defers_before_calling_builder():
+    """The Back callback must follow defer → build → edit-in-place.
+
+    A shared ``order`` list records every step; the final assertion
+    catches both "builder before defer" and "edit before build"
+    regressions in one check.
+    """
     view = discord.ui.View()
-    captured_interaction: list[discord.Interaction] = []
     parent_embed = discord.Embed(title="parent")
     parent_view = discord.ui.View()
+    order: list[str] = []
 
-    async def fake_builder(interaction):
-        captured_interaction.append(interaction)
+    async def fake_defer(_interaction, **_kwargs):
+        order.append("defer")
+        return True
+
+    async def fake_builder(_interaction):
+        order.append("builder")
         return parent_embed, parent_view
+
+    async def fake_edit(_interaction, **_kwargs):
+        order.append("edit")
+        return True
 
     attach_back_button(
         view,
@@ -170,18 +188,67 @@ async def test_attach_back_button_callback_calls_parent_builder_at_click_time():
 
     interaction = _interaction()
     btn = view.children[0]
-    await btn.callback(interaction)  # type: ignore[union-attr,misc]
+    with (
+        patch(
+            "core.runtime.interaction_helpers.safe_defer",
+            AsyncMock(side_effect=fake_defer),
+        ),
+        patch(
+            "core.runtime.interaction_helpers.safe_edit",
+            AsyncMock(side_effect=fake_edit),
+        ) as patched_edit,
+    ):
+        await btn.callback(interaction)  # type: ignore[union-attr,misc]
 
-    assert len(captured_interaction) == 1
-    assert captured_interaction[0] is interaction
-    interaction.response.edit_message.assert_awaited_once()
-    _args, kwargs = interaction.response.edit_message.call_args
+    assert order == ["defer", "builder", "edit"]
+    _args, kwargs = patched_edit.call_args
     assert kwargs["embed"] is parent_embed
     assert kwargs["view"] is parent_view
 
 
 @pytest.mark.asyncio
-async def test_attach_back_button_callback_surfaces_builder_error_as_ephemeral():
+async def test_attach_back_button_callback_aborts_when_defer_fails():
+    """When ``safe_defer`` returns ``False`` the callback must bail
+    silently: no builder call, no edit, no followup.
+    """
+    view = discord.ui.View()
+
+    async def fake_builder(_interaction):
+        raise AssertionError("builder must not be called when defer fails")
+
+    attach_back_button(
+        view,
+        label="↩ Back",
+        custom_id="test:back",
+        parent_builder=fake_builder,
+    )
+
+    interaction = _interaction()
+    btn = view.children[0]
+    with (
+        patch(
+            "core.runtime.interaction_helpers.safe_defer",
+            AsyncMock(return_value=False),
+        ),
+        patch(
+            "core.runtime.interaction_helpers.safe_edit",
+            AsyncMock(),
+        ) as fake_edit,
+    ):
+        await btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    fake_edit.assert_not_called()
+    interaction.followup.send.assert_not_called()
+    interaction.response.edit_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_attach_back_button_callback_surfaces_builder_error_as_followup_ephemeral():
+    """When the builder raises after defer, the user must see an
+    ephemeral via ``followup.send`` and the original message must be
+    left untouched. The old pre-defer ``response.send_message`` route
+    must not be reachable.
+    """
     view = discord.ui.View()
 
     async def fake_builder(_interaction):
@@ -195,28 +262,43 @@ async def test_attach_back_button_callback_surfaces_builder_error_as_ephemeral()
         error_message="Couldn't load help — please retry.",
     )
 
-    interaction = _interaction(is_done=False)
+    interaction = _interaction()
     btn = view.children[0]
-    await btn.callback(interaction)  # type: ignore[union-attr,misc]
+    with (
+        patch(
+            "core.runtime.interaction_helpers.safe_defer",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "core.runtime.interaction_helpers.safe_edit",
+            AsyncMock(),
+        ) as fake_edit,
+    ):
+        await btn.callback(interaction)  # type: ignore[union-attr,misc]
 
-    interaction.response.send_message.assert_awaited_once()
-    args, kwargs = interaction.response.send_message.call_args
+    interaction.followup.send.assert_awaited_once()
+    args, kwargs = interaction.followup.send.call_args
     assert "Couldn't load help" in (args[0] if args else kwargs.get("content", ""))
     assert kwargs.get("ephemeral") is True
-    # The original message is NOT edited.
+    fake_edit.assert_not_called()
     interaction.response.edit_message.assert_not_called()
+    interaction.response.send_message.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_attach_back_button_callback_uses_edit_original_when_deferred():
-    """If the interaction was already deferred before the button fires
-    (e.g. by an upstream handler), edit_message would 4xx — fall through
-    to edit_original_response."""
+async def test_attach_back_button_callback_success_calls_safe_defer_and_safe_edit():
+    """Happy path: ``safe_defer`` and ``safe_edit`` are both awaited,
+    the builder receives the click interaction, and the raw
+    ``response.edit_message`` / ``edit_original_response`` routes are
+    not touched.
+    """
     view = discord.ui.View()
     parent_embed = discord.Embed(title="parent")
     parent_view = discord.ui.View()
+    captured: list[discord.Interaction] = []
 
-    async def fake_builder(_interaction):
+    async def fake_builder(interaction):
+        captured.append(interaction)
         return parent_embed, parent_view
 
     attach_back_button(
@@ -225,12 +307,30 @@ async def test_attach_back_button_callback_uses_edit_original_when_deferred():
         custom_id="test:back",
         parent_builder=fake_builder,
     )
-    interaction = _interaction(is_done=True)
-    btn = view.children[0]
-    await btn.callback(interaction)  # type: ignore[union-attr,misc]
 
-    interaction.edit_original_response.assert_awaited_once()
+    interaction = _interaction()
+    btn = view.children[0]
+    with (
+        patch(
+            "core.runtime.interaction_helpers.safe_defer",
+            AsyncMock(return_value=True),
+        ) as fake_defer,
+        patch(
+            "core.runtime.interaction_helpers.safe_edit",
+            AsyncMock(return_value=True),
+        ) as fake_edit,
+    ):
+        await btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    fake_defer.assert_awaited_once()
+    assert len(captured) == 1
+    assert captured[0] is interaction
+    fake_edit.assert_awaited_once()
+    _args, kwargs = fake_edit.call_args
+    assert kwargs["embed"] is parent_embed
+    assert kwargs["view"] is parent_view
     interaction.response.edit_message.assert_not_called()
+    interaction.edit_original_response.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -248,13 +348,16 @@ async def test_transition_to_defers_then_builds_then_edits():
         return parent_embed, parent_view
 
     # Patch the in-module imports used by transition_to.
-    with patch(
-        "core.runtime.interaction_helpers.safe_defer",
-        AsyncMock(return_value=True),
-    ) as fake_defer, patch(
-        "core.runtime.interaction_helpers.safe_edit",
-        AsyncMock(),
-    ) as fake_edit:
+    with (
+        patch(
+            "core.runtime.interaction_helpers.safe_defer",
+            AsyncMock(return_value=True),
+        ) as fake_defer,
+        patch(
+            "core.runtime.interaction_helpers.safe_edit",
+            AsyncMock(),
+        ) as fake_edit,
+    ):
         await transition_to(interaction, builder=fake_builder)
 
     fake_defer.assert_awaited_once()
@@ -268,13 +371,16 @@ async def test_transition_to_aborts_when_defer_fails():
     async def fake_builder(_interaction):
         raise AssertionError("builder must not be called when defer fails")
 
-    with patch(
-        "core.runtime.interaction_helpers.safe_defer",
-        AsyncMock(return_value=False),
-    ), patch(
-        "core.runtime.interaction_helpers.safe_edit",
-        AsyncMock(),
-    ) as fake_edit:
+    with (
+        patch(
+            "core.runtime.interaction_helpers.safe_defer",
+            AsyncMock(return_value=False),
+        ),
+        patch(
+            "core.runtime.interaction_helpers.safe_edit",
+            AsyncMock(),
+        ) as fake_edit,
+    ):
         await transition_to(interaction, builder=fake_builder)
 
     fake_edit.assert_not_called()
@@ -287,13 +393,16 @@ async def test_transition_to_surfaces_builder_error_as_ephemeral():
     async def fake_builder(_interaction):
         raise RuntimeError("boom")
 
-    with patch(
-        "core.runtime.interaction_helpers.safe_defer",
-        AsyncMock(return_value=True),
-    ), patch(
-        "core.runtime.interaction_helpers.safe_edit",
-        AsyncMock(),
-    ) as fake_edit:
+    with (
+        patch(
+            "core.runtime.interaction_helpers.safe_defer",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "core.runtime.interaction_helpers.safe_edit",
+            AsyncMock(),
+        ) as fake_edit,
+    ):
         await transition_to(
             interaction,
             builder=fake_builder,

--- a/tests/unit/views/test_view_error_handling.py
+++ b/tests/unit/views/test_view_error_handling.py
@@ -39,8 +39,11 @@ def _make_interaction(*, responded: bool = False) -> MagicMock:
     interaction.message.id = 22222
     interaction.response = MagicMock()
     interaction.response.is_done = MagicMock(return_value=responded)
+    interaction.response.defer = AsyncMock()
     interaction.response.send_message = AsyncMock()
     interaction.response.edit_message = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
     return interaction
 
 
@@ -219,10 +222,12 @@ class TestBackCallbackErrorHandling:
             back_btn = sub_view.add_item.call_args[0][0]
             await back_btn.callback(interaction)
 
-        interaction.response.send_message.assert_awaited_once()
-        assert (
-            interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
-        )
+        # After Phase 3.5 lifecycle hardening the Back callback defers
+        # before invoking parent_builder, so a builder failure surfaces
+        # via ``followup.send`` rather than ``response.send_message``.
+        interaction.followup.send.assert_awaited_once()
+        assert interaction.followup.send.call_args.kwargs.get("ephemeral") is True
+        interaction.response.send_message.assert_not_awaited()
         interaction.response.edit_message.assert_not_awaited()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Refactor the back-button callback in `attach_back_button()` to follow a strict defer → build → edit-in-place lifecycle, eliminating race conditions where slow builder functions could exhaust Discord's 3-second response window. The callback now routes through `safe_defer` and `safe_edit` helpers, and surfaces builder errors via `followup.send` (ephemeral) instead of `response.send_message`.

## Key Changes

- **Back-button callback lifecycle hardening:**
  - Now calls `safe_defer()` before invoking `parent_builder()`, ensuring the interaction is acknowledged before any potentially slow rebuild logic
  - Bails silently if `safe_defer()` returns `False` (interaction already responded or deferred)
  - Routes the final message edit through `safe_edit()` instead of direct `response.edit_message()` or `edit_original_response()` calls
  - Removes the conditional logic that chose between `response.edit_message()` and `edit_original_response()` based on `interaction.response.is_done()`

- **Error handling improvement:**
  - Builder exceptions now surface via `interaction.followup.send()` (ephemeral) instead of `response.send_message()`
  - This is safe because `safe_defer()` has already acknowledged the interaction
  - Eliminates the pre-defer error path entirely

- **Test suite updates:**
  - Rewrote `test_attach_back_button_callback_calls_parent_builder_at_click_time()` → `test_attach_back_button_callback_defers_before_calling_builder()` to verify defer → build → edit ordering via a shared order list
  - Added `test_attach_back_button_callback_aborts_when_defer_fails()` to verify silent abort when defer fails
  - Renamed `test_attach_back_button_callback_surfaces_builder_error_as_ephemeral()` → `test_attach_back_button_callback_surfaces_builder_error_as_followup_ephemeral()` and updated to expect `followup.send()` instead of `response.send_message()`
  - Removed `test_attach_back_button_callback_uses_edit_original_when_deferred()` (no longer needed; `safe_edit` handles both cases)
  - Added `test_attach_back_button_callback_success_calls_safe_defer_and_safe_edit()` to verify the happy path uses the safe helpers and not raw response methods
  - Updated `transition_to` tests to use parenthesized context managers for consistency

- **Integration test updates:**
  - Updated `test_resolve_visibility_failure_sends_ephemeral()` in `test_view_error_handling.py` to expect `followup.send()` instead of `response.send_message()`
  - Updated mock interaction fixtures in affected test files to include `interaction.followup` and `interaction.response.defer` mocks

## Implementation Details

The refactored `_back_callback()` now:
1. Imports `safe_defer` and `safe_edit` at callback time (lazy import pattern)
2. Calls `safe_defer(interaction)` and returns early if it fails
3. Invokes `parent_builder(interaction)` within a try-except
4. On builder exception: logs the error and sends an ephemeral via `followup.send()`
5. On builder success: calls `safe_edit(interaction, embed=embed, view=parent_view)` to swap the message in place

This ensures slow rebuilds cannot exhaust Discord's response window, and all error paths are safe because the interaction has already been deferred.

https://claude.ai/code/session_011R25fVJTK9pekprA2bPMCk