### PR TITLE
fix(db): cast NULL to bigint in migration 051 backfill

### DIFF
--- a/disbot/migrations/051_command_access_main_server_backfill.sql
+++ b/disbot/migrations/051_command_access_main_server_backfill.sql
@@ -35,18 +35,22 @@
 --
 -- ``updated_by`` / ``created_by`` are intentionally NULL so the
 -- audit row reads "system" rather than attributing the backfill to
--- a random operator id.
+-- a random operator id. The ``::bigint`` cast on each NULL is
+-- required because Postgres infers a bare NULL literal as ``text``
+-- in a SELECT projection, which would clash with the ``BIGINT``
+-- column type and fail the INSERT with "column is of type bigint
+-- but expression is of type text".
 --
 -- Forward-only and idempotent.
 
 INSERT INTO guild_command_access_policy (guild_id, mode, updated_by)
-SELECT DISTINCT guild_id, 'selected_channels', NULL
+SELECT DISTINCT guild_id, 'selected_channels', NULL::bigint
   FROM panel_anchors
  WHERE channel_id IN (1348795460948590622, 1403818013408624642)
 ON CONFLICT (guild_id) DO NOTHING;
 
 INSERT INTO guild_command_access_channels (guild_id, channel_id, created_by)
-SELECT DISTINCT guild_id, channel_id, NULL
+SELECT DISTINCT guild_id, channel_id, NULL::bigint
   FROM panel_anchors
  WHERE channel_id IN (1348795460948590622, 1403818013408624642)
 ON CONFLICT (guild_id, channel_id) DO NOTHING;

--- a/tests/unit/db/test_migration_051_main_server_backfill.py
+++ b/tests/unit/db/test_migration_051_main_server_backfill.py
@@ -76,6 +76,30 @@ def test_migration_attributes_backfill_to_system_via_null_actor():
     """Audit metadata: the backfill is system-driven, not
     operator-driven, so ``updated_by`` and ``created_by`` are
     deliberately NULL rather than seeded with an arbitrary id.
+
+    Each NULL must be explicitly cast to ``bigint`` because Postgres
+    otherwise infers a bare NULL literal in a SELECT projection as
+    ``text``, which clashes with the BIGINT columns and aborts the
+    INSERT at runtime. Pre-fix this took the bot down in production.
     """
-    src = _src()
-    assert "NULL" in src
+    # Strip ``-- ...`` comments so the scan only sees executable SQL.
+    sql_lines = [
+        line.split("--", 1)[0]
+        for line in _src().splitlines()
+        if not line.startswith("--")
+    ]
+    executable_sql = "\n".join(sql_lines)
+
+    # Both NULLs (updated_by + created_by) must be cast, not just one.
+    assert (
+        executable_sql.count("NULL::bigint") >= 2
+    ), "Migration 051 must cast both NULL projections to bigint."
+    # And no bare NULL literal survives in a projection — only the
+    # cast form is acceptable.
+    import re
+
+    bare_nulls = re.findall(r"NULL(?!::)", executable_sql)
+    assert not bare_nulls, (
+        "Bare NULL literal in migration 051 — every NULL in a SELECT "
+        "projection must be cast to bigint to match the BIGINT column."
+    )


### PR DESCRIPTION
## Summary

- Production startup is crash-looping with `column "updated_by" is of type bigint but expression is of type text` from migration 051. Postgres infers a bare `NULL` literal in a SELECT projection as `text`, which clashes with the `BIGINT` columns on `guild_command_access_policy.updated_by` and `guild_command_access_channels.created_by`.
- Cast both NULL projections to `bigint` explicitly (`NULL::bigint`). Pure data-only fix; migration semantics, idempotency, and `ON CONFLICT DO NOTHING` safety are unchanged.
- Strengthen `tests/unit/db/test_migration_051_main_server_backfill.py` so the cast is required and no uncast `NULL` in executable SQL can slip back in.

## Repro

From production logs (21:56 / 22:02 UTC):

```
Migration 051 failed: column "updated_by" is of type bigint but expression is of type text
HINT:  You will need to rewrite or cast the expression.
Critical startup error: column "updated_by" is of type bigint but expression is of type text
```

Repeats every container restart — the migration runner aborts before `on_ready`.

## Test plan

- [x] `python3.10 -m pytest tests/unit/db/test_migration_051_main_server_backfill.py -q` — all 6 pass
- [x] `python3.10 -m pytest tests/ -q` — 5393 passed, 3 skipped, no regressions
- [x] Strengthened shape test fails when reverting the cast (verified during authoring)
- [ ] Deploy + confirm the migration applies cleanly and the bot reaches `on_ready`

https://claude.ai/code/session_011R25fVJTK9pekprA2bPMCk

---
_Generated by [Claude Code](https://claude.ai/code/session_011R25fVJTK9pekprA2bPMCk)_