### PR TITLE
Fix settings/doc inconsistencies: remove broken CodeGraph tools, sync orientation docs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,16 +5,11 @@
       "mcp__codegraph__where",
       "mcp__codegraph__context",
       "mcp__codegraph__query",
-      "mcp__codegraph__execution_flow",
       "mcp__codegraph__fn_impact",
-      "mcp__codegraph__impact_analysis",
-      "mcp__codegraph__structure",
-      "mcp__codegraph__module_map",
       "mcp__codegraph__list_functions",
-      "mcp__codegraph__file_deps",
       "mcp__codegraph__complexity",
-      "mcp__codegraph__semantic_search",
-      "mcp__codegraph__brief",
+      "mcp__codegraph__check",
+      "mcp__codegraph__triage",
       "mcp__codegraph__audit"
     ]
   },

--- a/docs/AGENT_ORIENTATION.md
+++ b/docs/AGENT_ORIENTATION.md
@@ -43,7 +43,7 @@ read **`docs/helper-policy.md`** first.
 
 | Order | Doc | Why |
 |---|---|---|
-| 1 | `.claude/CLAUDE.md` | CodeGraph rules — what the static index can and cannot tell you about this codebase. Auto-loaded. |
+| 1 | `.claude/CLAUDE.md` | Session workflow, CI parity rules, CodeGraph quick-reference, and architecture invariants. Auto-loaded every session. |
 | 2 | `docs/codegraph-usage.md` | Full trust matrix behind the short CLAUDE.md rules. Skim once, refer back when CodeGraph surprises you. |
 | 3 | `docs/AGENT_ORIENTATION.md` (this file) | What to read next, based on what you are doing. |
 | 4 | `docs/repo-navigation-map.md` | Where things live in the tree. Use as a folder-to-purpose lookup. |
@@ -214,8 +214,12 @@ Before proposing or implementing any non-trivial change:
    `utils/`, in `services/`, in `views/base.py`), open
    `docs/helper-policy.md` first.
 4. If CodeGraph and a source file disagree, the **source file wins**
-   (`.claude/CLAUDE.md` § "Source files win"). Re-read the actual file
-   you are about to edit.
+   (`.claude/CLAUDE.md` § "Read first — agent orientation"). Re-read
+   the actual file you are about to edit.
+5. **At the end of every session, create a PR** — do not wait to be
+   asked. Plans span 2–3 PRs max (foundation first, implementation
+   second). Plan approval means full execution in one session — do not
+   stop for confirmation or wait for merges between PRs.
 
 This is not a courtesy — repeated rediscovery is the main reason
 SuperBot accumulates duplicate helpers and orphan plans. The minutes

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,7 +57,7 @@ platform concerns the cog simply *uses*.
                                                     ▼
                                           ┌────────────────────┐
                                           │ PostgreSQL         │
-                                          │ (15 migrations)    │
+                                          │ (51 migrations)    │
                                           └────────────────────┘
 ```
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **settings.json**: removed 7 broken/misleading CodeGraph tools from the permissions allowlist (`execution_flow`, `impact_analysis`, `module_map`, `file_deps`, `semantic_search`, `brief`, `structure`); added `check` and `triage` which are Tier 1 reliable per `docs/codegraph-usage.md`
- **architecture.md**: fixed stale migration count in layer diagram (15 → 51)
- **AGENT_ORIENTATION.md**: updated CLAUDE.md description to reflect it now covers session workflow, CI parity, and architecture rules; fixed stale `§ "Source files win"` section reference; added session workflow mandate as item 5 in the "Read first" list

Also includes the preceding commit which trimmed CLAUDE.md (allowlist-only CodeGraph section, added session/PR workflow rules, added decision-making preference).

## Test plan

- [ ] Verify settings.json is valid JSON and loads without error
- [ ] Confirm removed tools no longer auto-approved (will prompt if accidentally called)
- [ ] Read through AGENT_ORIENTATION.md to confirm session workflow mandate reads clearly

https://claude.ai/code/session_011gp1nuVZqDfHGfBwPZoKdf
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011gp1nuVZqDfHGfBwPZoKdf)_