### PR TITLE
Polish: align four on_timeout callbacks with the codebase contract

### DIFF
--- a/disbot/views/blackjack/pvp_view.py
+++ b/disbot/views/blackjack/pvp_view.py
@@ -80,12 +80,16 @@ class _ChallengeView(discord.ui.View):
         self.stop()
 
     async def on_timeout(self):
+        if self.message is None:
+            self.stop()
+            return
         for item in self.children:
             item.disabled = True  # type: ignore[attr-defined]
         try:
             await self.message.edit(content="⏰ Challenge timed out.", view=self)
         except Exception:
             pass
+        self.stop()
 
     async def on_error(
         self,

--- a/disbot/views/rps/pvp_challenge.py
+++ b/disbot/views/rps/pvp_challenge.py
@@ -127,9 +127,13 @@ class _RpsPvpChallengeView(discord.ui.View):
         self.stop()
 
     async def on_timeout(self):
+        if self.message is None:
+            self.stop()
+            return
         for item in self.children:
             item.disabled = True  # type: ignore[attr-defined]
         try:
             await self.message.edit(content="⏰ Challenge timed out.", view=self)
         except Exception:
             pass
+        self.stop()

--- a/disbot/views/rps/solo_play.py
+++ b/disbot/views/rps/solo_play.py
@@ -128,6 +128,8 @@ class _RpsView(discord.ui.View):
         await self._play(i, "scissors")
 
     async def on_timeout(self):
+        if self.message is None:
+            return
         for item in self.children:
             item.disabled = True  # type: ignore[attr-defined]
         try:

--- a/disbot/views/xp/rank_view.py
+++ b/disbot/views/xp/rank_view.py
@@ -28,11 +28,15 @@ class _RankView(discord.ui.View):
         self.add_item(_RankSelect(self, current_stat))
 
     async def on_timeout(self) -> None:
-        if self.message:
-            try:
-                await self.message.edit(view=None)
-            except Exception:
-                pass
+        if self.message is None:
+            return
+        for item in self.children:
+            item.disabled = True  # type: ignore[attr-defined]
+        try:
+            await self.message.edit(view=self)
+        except Exception:
+            pass
+        self.stop()
 
 
 class _RankSelect(discord.ui.Select):

--- a/tests/unit/views/test_timeout_cleanup.py
+++ b/tests/unit/views/test_timeout_cleanup.py
@@ -1,0 +1,186 @@
+"""Regression tests for Tier 3 view-timeout cleanup contracts.
+
+Four `on_timeout` callbacks across four views were inconsistent with
+the rest of the codebase:
+
+* `_RankView.on_timeout` used ``await self.message.edit(view=None)``
+  which strips the dropdown entirely.  Users had to re-run ``/rank``
+  to switch stat view.  Fixed to match the standard disable-and-edit
+  shape (greyed-out select stays on the card).
+* `_RpsPvpChallengeView.on_timeout` and `_ChallengeView.on_timeout`
+  (blackjack PvP) disabled children and edited the message but never
+  called ``self.stop()`` — the Python-side view object lingered in
+  discord.py's dispatch table after the message went terminal.
+* `_RpsView.on_timeout` (solo) was missing the ``self.message is
+  None`` guard that ``_RpsSoloResultView.on_timeout`` already has;
+  the bare ``try/except`` caught the AttributeError but the explicit
+  guard matches the canonical shape elsewhere.
+
+These tests pin each contract.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+
+def _member(id_: int = 1) -> MagicMock:
+    m = MagicMock(spec=discord.Member)
+    m.id = id_
+    m.display_name = f"User{id_}"
+    m.mention = f"<@{id_}>"
+    return m
+
+
+# ---------------------------------------------------------------------------
+# _RankView.on_timeout
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rank_view_timeout_disables_select_in_place():
+    """`on_timeout` must keep the dropdown visible but disabled —
+    not strip it via ``view=None`` (which forces a re-run of /rank)."""
+    from views.xp.rank_view import _RankView
+
+    member = _member()
+    guild = MagicMock(spec=discord.Guild)
+    view = _RankView(member, guild, current_stat="both")
+    view.message = MagicMock()
+    view.message.edit = AsyncMock()
+
+    await view.on_timeout()
+
+    view.message.edit.assert_awaited_once()
+    kwargs = view.message.edit.await_args.kwargs
+    assert kwargs.get("view") is view, "must edit with view=self, not view=None"
+    for child in view.children:
+        assert child.disabled is True
+    assert view.is_finished()
+
+
+@pytest.mark.asyncio
+async def test_rank_view_timeout_noops_when_message_unset():
+    from views.xp.rank_view import _RankView
+
+    member = _member()
+    guild = MagicMock(spec=discord.Guild)
+    view = _RankView(member, guild, current_stat="both")
+    assert view.message is None
+    await view.on_timeout()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# _RpsPvpChallengeView.on_timeout
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rps_pvp_challenge_timeout_disables_and_stops():
+    from views.rps.pvp_challenge import _RpsPvpChallengeView
+
+    view = _RpsPvpChallengeView(
+        challenger=_member(1),
+        opponent=_member(2),
+        guild_id=99,
+        bet=0,
+    )
+    view.message = MagicMock()
+    view.message.edit = AsyncMock()
+
+    await view.on_timeout()
+
+    view.message.edit.assert_awaited_once()
+    for child in view.children:
+        assert child.disabled is True
+    assert view.is_finished(), "missing self.stop() — view stays in dispatch table"
+
+
+@pytest.mark.asyncio
+async def test_rps_pvp_challenge_timeout_stops_even_when_message_unset():
+    from views.rps.pvp_challenge import _RpsPvpChallengeView
+
+    view = _RpsPvpChallengeView(
+        challenger=_member(1),
+        opponent=_member(2),
+        guild_id=99,
+        bet=0,
+    )
+    assert view.message is None
+    await view.on_timeout()  # must not raise
+    assert view.is_finished()
+
+
+# ---------------------------------------------------------------------------
+# Blackjack _ChallengeView.on_timeout
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_blackjack_challenge_timeout_disables_and_stops():
+    from views.blackjack.pvp_view import _ChallengeView
+
+    view = _ChallengeView(
+        challenger=_member(1),
+        opponent=_member(2),
+        guild_id=99,
+        bet=10,
+    )
+    view.message = MagicMock()
+    view.message.edit = AsyncMock()
+
+    await view.on_timeout()
+
+    view.message.edit.assert_awaited_once()
+    for child in view.children:
+        assert child.disabled is True
+    assert view.is_finished()
+
+
+@pytest.mark.asyncio
+async def test_blackjack_challenge_timeout_stops_even_when_message_unset():
+    from views.blackjack.pvp_view import _ChallengeView
+
+    view = _ChallengeView(
+        challenger=_member(1),
+        opponent=_member(2),
+        guild_id=99,
+        bet=10,
+    )
+    assert view.message is None
+    await view.on_timeout()  # must not raise
+    assert view.is_finished()
+
+
+# ---------------------------------------------------------------------------
+# _RpsView.on_timeout (solo) — message-None guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rps_solo_view_timeout_noops_when_message_unset():
+    """Mirrors the explicit guard already present on
+    ``_RpsSoloResultView.on_timeout``."""
+    from views.rps.solo_play import _RpsView
+
+    view = _RpsView(_member(1), guild_id=99, bet=0)
+    assert view.message is None
+    await view.on_timeout()  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_rps_solo_view_timeout_disables_when_message_set():
+    from views.rps.solo_play import _RpsView
+
+    view = _RpsView(_member(1), guild_id=99, bet=0)
+    view.message = MagicMock()
+    view.message.edit = AsyncMock()
+
+    await view.on_timeout()
+
+    view.message.edit.assert_awaited_once()
+    for child in view.children:
+        assert child.disabled is True


### PR DESCRIPTION
Tier 3 of the audit plan — four small polish fixes to bring view
timeout cleanup in line with the rest of the codebase. Single commit
(`9770e58`) that was pushed to the branch after PR #348 was already
merged, so it needs its own PR.

## Summary

- **`views/xp/rank_view.py:_RankView.on_timeout`** — replaces
  `await self.message.edit(view=None)` (which strips the dropdown and
  forces users to re-run `/rank`) with the standard disable-children
  + `view=self` shape, plus `self.stop()`.
- **`views/rps/pvp_challenge.py:_RpsPvpChallengeView.on_timeout`** —
  appends `self.stop()` so the view leaves discord.py's dispatch
  table after the message goes terminal. Also adds the explicit
  `message is None` early return matching the canonical shape.
- **`views/blackjack/pvp_view.py:_ChallengeView.on_timeout`** — same
  `self.stop()` fix.
- **`views/rps/solo_play.py:_RpsView.on_timeout`** — adds the
  explicit `if self.message is None: return` guard already present
  on `_RpsSoloResultView.on_timeout`.

## Test plan

- [x] `python3.10 -m pytest tests/unit/views/ -q` — 1066 passed, 2 skipped
- [x] `python3.10 scripts/check_architecture.py --mode strict` — exit 0
- [x] Black-clean for all modified files
- [x] New regression file `tests/unit/views/test_timeout_cleanup.py`
      (8 tests) pins each contract: disabled-in-place edit,
      `is_finished()` after stop, no-raise when message was never
      bound.

## Out of scope

- Tier 4 (architectural drift — raw `discord.ui.View` subclasses,
  inline back buttons, raw `interaction.response.*` migration). Per
  the plan, this is a multi-PR effort that needs its own scoping
  pass.

Plan file: `/root/.claude/plans/audit-the-current-superbot-ticklish-rose.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_014uqHfLWf5QFzVN4yDL27Q3)_