### PR TITLE
Fix back-chain propagation: attach_back_target now sets _back_target on rebuilt views

### DIFF
--- a/disbot/views/games/blackjack_panel.py
+++ b/disbot/views/games/blackjack_panel.py
@@ -496,7 +496,8 @@ class BlackjackPanelView(HubView):
         await interaction.response.edit_message(
             embed=build_blackjack_challenge_picker_embed(),
             view=_BlackjackChallengeSelectView(
-                interaction.user, back_target=back_target
+                interaction.user,
+                back_target=back_target,
             ),
         )
 

--- a/disbot/views/games/blackjack_panel.py
+++ b/disbot/views/games/blackjack_panel.py
@@ -38,6 +38,7 @@ from utils.ui_constants import GAME_COLOR
 from views.base import HubView
 from views.blackjack.embeds import _tourn_embed
 from views.games.common import BackToPanelButton
+from views.navigation import BackTarget, attach_back_target
 
 logger = logging.getLogger("bot.views.games.blackjack_panel")
 
@@ -172,12 +173,18 @@ def build_blackjack_rules_embed() -> discord.Embed:
 class _BlackjackBetPresetView(HubView):
     """Bet-preset picker: 10/25/50/100/Custom + Back."""
 
-    def __init__(self, author: discord.Member | discord.User) -> None:
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        back_target: BackTarget | None = None,
+    ) -> None:
         super().__init__(author)
         for preset in _BET_PRESETS:
             self.add_item(_BlackjackBetPresetButton(preset))
         self.add_item(_BlackjackBetCustomButton())
-        self.add_item(_make_blackjack_back_button())
+        self.add_item(_make_blackjack_back_button(grandparent=back_target))
+        if back_target is not None:
+            attach_back_target(self, back_target)
 
 
 class _BlackjackBetPresetButton(discord.ui.Button):
@@ -286,10 +293,16 @@ async def _spawn_solo(interaction: discord.Interaction, bet: int) -> None:
 
 
 class _BlackjackChallengeSelectView(HubView):
-    def __init__(self, author: discord.Member | discord.User) -> None:
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        back_target: BackTarget | None = None,
+    ) -> None:
         super().__init__(author)
         self.add_item(_BlackjackOpponentSelect())
-        self.add_item(_make_blackjack_back_button())
+        self.add_item(_make_blackjack_back_button(grandparent=back_target))
+        if back_target is not None:
+            attach_back_target(self, back_target)
 
 
 class _BlackjackOpponentSelect(discord.ui.UserSelect):
@@ -341,11 +354,14 @@ class _BlackjackTournamentSubView(HubView):
         *,
         is_admin: bool,
         has_active: bool,
+        back_target: BackTarget | None = None,
     ) -> None:
         super().__init__(author)
         if is_admin and not has_active:
             self.add_item(_BlackjackTournamentOpenButton())
-        self.add_item(_make_blackjack_back_button())
+        self.add_item(_make_blackjack_back_button(grandparent=back_target))
+        if back_target is not None:
+            attach_back_target(self, back_target)
 
 
 class _BlackjackTournamentOpenButton(discord.ui.Button):
@@ -400,7 +416,9 @@ class _BlackjackTournamentOpenButton(discord.ui.Button):
             result.tournament.reg_message = interaction.message
 
 
-def _make_blackjack_back_button() -> BackToPanelButton:
+def _make_blackjack_back_button(
+    grandparent: BackTarget | None = None,
+) -> BackToPanelButton:
     """Return a fresh "◀ Back to Blackjack" button for any Blackjack
     sub-view. Follow-up to PR 7 — Blackjack now uses the shared
     helper from ``views.games.common`` alongside RPS.
@@ -410,6 +428,7 @@ def _make_blackjack_back_button() -> BackToPanelButton:
         custom_id="blackjack_panel:back",
         panel_builder=BlackjackPanelView,
         overview_builder=build_blackjack_overview_embed,
+        grandparent=grandparent,
     )
 
 
@@ -456,9 +475,10 @@ class BlackjackPanelView(HubView):
         interaction: discord.Interaction,
         _button: discord.ui.Button,
     ) -> None:
+        back_target: BackTarget | None = getattr(self, "_back_target", None)
         await interaction.response.edit_message(
             embed=build_blackjack_bet_preset_embed(),
-            view=_BlackjackBetPresetView(interaction.user),
+            view=_BlackjackBetPresetView(interaction.user, back_target=back_target),
         )
 
     @discord.ui.button(
@@ -472,9 +492,12 @@ class BlackjackPanelView(HubView):
         interaction: discord.Interaction,
         _button: discord.ui.Button,
     ) -> None:
+        back_target: BackTarget | None = getattr(self, "_back_target", None)
         await interaction.response.edit_message(
             embed=build_blackjack_challenge_picker_embed(),
-            view=_BlackjackChallengeSelectView(interaction.user),
+            view=_BlackjackChallengeSelectView(
+                interaction.user, back_target=back_target
+            ),
         )
 
     @discord.ui.button(
@@ -492,6 +515,7 @@ class BlackjackPanelView(HubView):
         is_admin = bool(guild_perms and guild_perms.administrator)
         guild_id = interaction.guild_id or 0
         has_active = get_active_tournament(guild_id) is not None
+        back_target: BackTarget | None = getattr(self, "_back_target", None)
         await interaction.response.edit_message(
             embed=build_blackjack_tournament_overview_embed(
                 is_admin=is_admin,
@@ -501,6 +525,7 @@ class BlackjackPanelView(HubView):
                 interaction.user,
                 is_admin=is_admin,
                 has_active=has_active,
+                back_target=back_target,
             ),
         )
 

--- a/disbot/views/games/common.py
+++ b/disbot/views/games/common.py
@@ -27,6 +27,7 @@ from collections.abc import Callable
 import discord
 
 from core.runtime.interaction_helpers import safe_defer, safe_edit
+from views.navigation import BackTarget, attach_back_target
 
 ParentBuilder = Callable[
     [discord.Member | discord.User],
@@ -57,6 +58,7 @@ class BackToPanelButton(discord.ui.Button):
         panel_builder: ParentBuilder,
         overview_builder: OverviewEmbedBuilder,
         row: int = 4,
+        grandparent: BackTarget | None = None,
     ) -> None:
         super().__init__(
             label=label,
@@ -66,6 +68,7 @@ class BackToPanelButton(discord.ui.Button):
         )
         self._panel_builder = panel_builder
         self._overview_builder = overview_builder
+        self._grandparent = grandparent
 
     async def callback(self, interaction: discord.Interaction) -> None:
         # Canonical "component defer then edit clicked message" pattern:
@@ -79,6 +82,8 @@ class BackToPanelButton(discord.ui.Button):
         parent_view = self.view
         author = getattr(parent_view, "_author", interaction.user)
         new_view = self._panel_builder(author)
+        if self._grandparent is not None:
+            attach_back_target(new_view, self._grandparent)
         await safe_edit(
             interaction,
             embed=self._overview_builder(),

--- a/disbot/views/games/hub.py
+++ b/disbot/views/games/hub.py
@@ -410,14 +410,12 @@ class GamesHubView(HubView):
         cog = _cog_for_subsystem(interaction.client, sub_name)  # type: ignore[arg-type]
         if cog is None:
             embed = _build_no_panel_embed(sub_name, dict(meta))
-            attach_back_to_games_button(self, self._author)
             await interaction.response.edit_message(embed=embed, view=self)
             return
 
         build_panel = getattr(cog, "build_help_menu_view", None)
         if not callable(build_panel):
             embed = _build_no_panel_embed(sub_name, dict(meta))
-            attach_back_to_games_button(self, self._author)
             await interaction.response.edit_message(embed=embed, view=self)
             return
 
@@ -431,7 +429,6 @@ class GamesHubView(HubView):
                 exc_info=True,
             )
             fallback = _build_no_panel_embed(sub_name, dict(meta))
-            attach_back_to_games_button(self, self._author)
             await interaction.response.edit_message(embed=fallback, view=self)
             return
 
@@ -439,4 +436,5 @@ class GamesHubView(HubView):
         attach_back_to_games_button(sub_view, self._author, grandparent=back_target)
         if back_target is not None:
             attach_back_target(sub_view, back_target)
+        sub_view._back_target = back_target  # type: ignore[attr-defined]
         await interaction.response.edit_message(embed=embed, view=sub_view)

--- a/disbot/views/games/rps_panel.py
+++ b/disbot/views/games/rps_panel.py
@@ -29,6 +29,7 @@ import discord
 from utils.ui_constants import GAME_COLOR
 from views.base import HubView
 from views.games.common import BackToPanelButton
+from views.navigation import BackTarget, attach_back_target
 from views.rps import _RpsPvpChallengeView, _RpsView
 
 logger = logging.getLogger("bot.views.games.rps_panel")
@@ -201,12 +202,18 @@ def _spawn_solo_view(
 class _RpsBetPresetView(HubView):
     """Bet-preset picker: 10/25/50/100/Custom + Back."""
 
-    def __init__(self, author: discord.Member | discord.User) -> None:
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        back_target: BackTarget | None = None,
+    ) -> None:
         super().__init__(author)
         for preset in _BET_PRESETS:
             self.add_item(_RpsBetPresetButton(preset))
         self.add_item(_RpsBetCustomButton())
-        self.add_item(_make_rps_back_button())
+        self.add_item(_make_rps_back_button(grandparent=back_target))
+        if back_target is not None:
+            attach_back_target(self, back_target)
 
 
 class _RpsBetPresetButton(discord.ui.Button):
@@ -276,10 +283,16 @@ class _RpsCustomBetModal(discord.ui.Modal, title="Custom Bet"):
 class _RpsChallengeSelectView(HubView):
     """User-select picker for PvP challenge target."""
 
-    def __init__(self, author: discord.Member | discord.User) -> None:
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        back_target: BackTarget | None = None,
+    ) -> None:
         super().__init__(author)
         self.add_item(_RpsOpponentSelect())
-        self.add_item(_make_rps_back_button())
+        self.add_item(_make_rps_back_button(grandparent=back_target))
+        if back_target is not None:
+            attach_back_target(self, back_target)
 
 
 class _RpsOpponentSelect(discord.ui.UserSelect):
@@ -339,13 +352,16 @@ class _RpsTournamentSubView(HubView):
         is_admin: bool,
         registration_active: bool,
         tournament_active: bool,
+        back_target: BackTarget | None = None,
     ) -> None:
         super().__init__(author)
         if registration_active and not tournament_active:
             self.add_item(_RpsTournamentJoinButton())
         elif is_admin and not tournament_active:
             self.add_item(_RpsTournamentStartButton())
-        self.add_item(_make_rps_back_button())
+        self.add_item(_make_rps_back_button(grandparent=back_target))
+        if back_target is not None:
+            attach_back_target(self, back_target)
 
 
 class _RpsTournamentStartButton(discord.ui.Button):
@@ -416,7 +432,9 @@ class _RpsTournamentJoinButton(discord.ui.Button):
             )
 
 
-def _make_rps_back_button() -> BackToPanelButton:
+def _make_rps_back_button(
+    grandparent: BackTarget | None = None,
+) -> BackToPanelButton:
     """Return a fresh "◀ Back to RPS" button for any RPS sub-view.
 
     Thin wrapper over the shared :class:`BackToPanelButton` helper —
@@ -429,6 +447,7 @@ def _make_rps_back_button() -> BackToPanelButton:
         custom_id="rps_panel:back",
         panel_builder=RPSPanelView,
         overview_builder=build_rps_overview_embed,
+        grandparent=grandparent,
     )
 
 
@@ -491,7 +510,8 @@ class RPSPanelView(HubView):
         interaction: discord.Interaction,
         _button: discord.ui.Button,
     ) -> None:
-        bet_view = _RpsBetPresetView(interaction.user)
+        back_target: BackTarget | None = getattr(self, "_back_target", None)
+        bet_view = _RpsBetPresetView(interaction.user, back_target=back_target)
         await interaction.response.edit_message(
             embed=build_rps_bet_preset_embed(),
             view=bet_view,
@@ -508,7 +528,8 @@ class RPSPanelView(HubView):
         interaction: discord.Interaction,
         _button: discord.ui.Button,
     ) -> None:
-        select_view = _RpsChallengeSelectView(interaction.user)
+        back_target: BackTarget | None = getattr(self, "_back_target", None)
+        select_view = _RpsChallengeSelectView(interaction.user, back_target=back_target)
         await interaction.response.edit_message(
             embed=build_rps_challenge_picker_embed(),
             view=select_view,
@@ -531,11 +552,13 @@ class RPSPanelView(HubView):
         registration_active = bool(getattr(cog, "registration_active", False))
         tournament_active = bool(getattr(cog, "tournament_active", False))
         player_count = len(getattr(cog, "players", []) or [])
+        back_target: BackTarget | None = getattr(self, "_back_target", None)
         sub_view = _RpsTournamentSubView(
             interaction.user,
             is_admin=is_admin,
             registration_active=registration_active,
             tournament_active=tournament_active,
+            back_target=back_target,
         )
         await interaction.response.edit_message(
             embed=build_rps_tournament_status_embed(

--- a/disbot/views/navigation.py
+++ b/disbot/views/navigation.py
@@ -229,16 +229,25 @@ def attach_back_target(view: discord.ui.View, target: BackTarget) -> bool:
             parent_builder=target.builder,
         )
 
+    Also sets ``view._back_target = target`` when the button is added so
+    that views rebuilt via :func:`chain_back` can propagate the back chain
+    to their own children on subsequent navigation (e.g. Games hub rebuilt
+    by Back-to-Games still exposes ``_back_target`` so Blackjack can add
+    "Back to Help").
+
     Returns the same value as :func:`attach_back_button` — ``True`` if
     the button was added, ``False`` if the view was at the 25-component
     cap.
     """
-    return attach_back_button(
+    result = attach_back_button(
         view,
         label=target.label,
         custom_id=target.custom_id,
         parent_builder=target.builder,
     )
+    if result:
+        view._back_target = target  # type: ignore[attr-defined]
+    return result
 
 
 def chain_back(


### PR DESCRIPTION
## Summary

- `attach_back_target` in `views/navigation.py` now sets `view._back_target = target` whenever it successfully adds the button
- Fixes "Back to Help" disappearing from game panels after pressing "Back to Games" and re-navigating

## Root cause

When pressing "Back to Games", `chain_back`'s internal builder called `attach_back_target` to re-attach the "Back to Help" button on the rebuilt Games hub. The button was added correctly, but `_back_target` was never set on the rebuilt view. So the next time a game was selected from that rebuilt hub, `handle_select` read `_back_target = None` and skipped adding "Back to Help" to the game panel.

This only manifested on the *second* navigation through the chain (Help → Games → Blackjack → Back to Games → Blackjack again) — the first trip worked because `_attach_back_to_help_button` in `help_cog.py` sets `_back_target` directly.

## Fix

```python
# navigation.py — attach_back_target
result = attach_back_button(view, label=target.label, custom_id=target.custom_id, parent_builder=target.builder)
if result:
    view._back_target = target  # NEW: propagate for children to read
return result
```

## Test plan

- [ ] `!help` → Games → Blackjack: "Back to Help" visible
- [ ] Press "Back to Games" → select Blackjack again: "Back to Help" still visible
- [ ] Same flow for RPS
- [ ] `python3.10 -m pytest tests/ -q` — all pass (5393 passed)

https://claude.ai/code/session_01LHpcfLkWLqTP7kphPGDzsc

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHpcfLkWLqTP7kphPGDzsc)_