### PR TITLE
Block scheduled_time installs; defer AI routing matrix before I/O

### DIFF
--- a/disbot/services/automation_mutation.py
+++ b/disbot/services/automation_mutation.py
@@ -50,6 +50,7 @@ from services.audit_events import emit_audit_action
 from services.automation_registry import (
     KNOWN_ACTION_KINDS,
     KNOWN_TRIGGER_KINDS,
+    UNSUPPORTED_INSTALLABLE_TRIGGER_KINDS,
     validate_action_config,
     validate_trigger_config,
 )
@@ -131,6 +132,12 @@ class AutomationMutationPipeline:
     ) -> AutomationMutationResult:
         # 1. Input validation.
         self._validate_kinds(trigger_kind, action_kind)
+        if trigger_kind in UNSUPPORTED_INSTALLABLE_TRIGGER_KINDS:
+            raise InvalidAutomationConfigError(
+                f"trigger_kind {trigger_kind!r} is known but not installable yet; "
+                f"{trigger_kind} requires the cron-parser implementation before "
+                "new rules can be created.",
+            )
         errors = list(
             validate_trigger_config(trigger_kind, trigger_config or {}),
         ) + list(validate_action_config(action_kind, action_config or {}))

--- a/disbot/services/automation_registry.py
+++ b/disbot/services/automation_registry.py
@@ -113,6 +113,14 @@ TRIGGERS: tuple[TriggerSpec, ...] = (
 
 KNOWN_TRIGGER_KINDS: frozenset[str] = frozenset(t.kind for t in TRIGGERS)
 
+# Known at the schema/registry level, but temporarily blocked for new
+# rule installation until cron parsing ships. ``automation_mutation``
+# enforces the rejection at the service boundary; ``automation_templates``
+# hides templates whose ``trigger_kind`` lands here from the operator
+# picker but keeps them in the source catalog so the cron-parser PR can
+# re-enable them by removing the kind from this set.
+UNSUPPORTED_INSTALLABLE_TRIGGER_KINDS: frozenset[str] = frozenset({"scheduled_time"})
+
 
 # ---------------------------------------------------------------------------
 # Actions (mirrors migration 032 CHECK)
@@ -254,6 +262,7 @@ __all__ = [
     "KNOWN_ACTION_KINDS",
     "KNOWN_TRIGGER_KINDS",
     "TRIGGERS",
+    "UNSUPPORTED_INSTALLABLE_TRIGGER_KINDS",
     "ActionSpec",
     "TriggerSpec",
     "get_action",

--- a/disbot/services/automation_scheduler.py
+++ b/disbot/services/automation_scheduler.py
@@ -300,14 +300,22 @@ def _in_quiet_hours(rule: dict[str, Any]) -> bool:
 def _compute_next_run_at(rule: dict[str, Any]) -> datetime | None:
     """Compute the rule's next scheduled fire time.
 
-    v1 supports two kinds:
+    v1 supports one installable kind:
 
     * ``interval`` — fire every ``interval_minutes`` minutes.
-    * ``scheduled_time`` — placeholder; returns ``+1 day``
-      until a real cron parser ships.
 
-    Other kinds return ``None`` (rules drop off the schedule
-    queue until something else flips ``next_run_at``).
+    ``scheduled_time`` is not installable for new rules until cron
+    parsing ships (gated by
+    :data:`services.automation_registry.UNSUPPORTED_INSTALLABLE_TRIGGER_KINDS`
+    and enforced in
+    :class:`services.automation_mutation.AutomationMutationPipeline.create_rule`).
+    This branch remains only to avoid crashing the scheduler loop if
+    historical DB rows already exist — it returns ``now + 1 day`` so
+    such rows keep being polled at a coarse cadence without firing in
+    a tight loop.
+
+    Other kinds return ``None`` (rules drop off the schedule queue
+    until something else flips ``next_run_at``).
     """
     trigger_kind = rule.get("trigger_kind")
     cfg = rule.get("trigger_config") or {}
@@ -321,7 +329,8 @@ def _compute_next_run_at(rule: dict[str, Any]) -> datetime | None:
             return None
         return now + timedelta(minutes=minutes)
     if trigger_kind == "scheduled_time":
-        # TODO Track 7 PR 22 — replace with cron parser.
+        # Defensive: tolerate pre-existing rows. New creation is
+        # blocked at the mutation-service boundary.
         return now + timedelta(days=1)
     return None
 

--- a/disbot/services/automation_templates.py
+++ b/disbot/services/automation_templates.py
@@ -31,6 +31,7 @@ from typing import Any
 from services.automation_registry import (
     KNOWN_ACTION_KINDS,
     KNOWN_TRIGGER_KINDS,
+    UNSUPPORTED_INSTALLABLE_TRIGGER_KINDS,
     validate_action_config,
     validate_trigger_config,
 )
@@ -346,8 +347,26 @@ _SERVER_PULSE_TEMPLATES: tuple[AutomationTemplate, ...] = (
 )
 
 
-TEMPLATES: tuple[AutomationTemplate, ...] = (
+_ALL_TEMPLATES: tuple[AutomationTemplate, ...] = (
     _ONBOARDING_TEMPLATES + _SERVER_PULSE_TEMPLATES
+)
+
+
+def is_installable_template(template: AutomationTemplate) -> bool:
+    """Return True if the template's trigger kind is currently installable.
+
+    Templates whose trigger kind lands in
+    :data:`services.automation_registry.UNSUPPORTED_INSTALLABLE_TRIGGER_KINDS`
+    stay in :data:`_ALL_TEMPLATES` (so :func:`get_template` and the
+    future cron-parser PR can still find them) but are hidden from the
+    operator picker. Re-enabling them is a one-line change in the
+    registry once the underlying scheduler support ships.
+    """
+    return template.trigger_kind not in UNSUPPORTED_INSTALLABLE_TRIGGER_KINDS
+
+
+TEMPLATES: tuple[AutomationTemplate, ...] = tuple(
+    t for t in _ALL_TEMPLATES if is_installable_template(t)
 )
 
 
@@ -758,7 +777,11 @@ def preview_preset(
 
 
 def get_template(slug: str) -> AutomationTemplate | None:
-    for tmpl in TEMPLATES:
+    # Searches the full source catalog so internal callers (preset
+    # preview, tests) can still resolve hidden templates by slug. The
+    # operator-facing picker lists :data:`TEMPLATES` which is filtered
+    # via :func:`is_installable_template`.
+    for tmpl in _ALL_TEMPLATES:
         if tmpl.slug == slug:
             return tmpl
     return None
@@ -782,6 +805,7 @@ __all__ = [
     "ServerPreset",
     "get_preset",
     "get_template",
+    "is_installable_template",
     "known_preset_slugs",
     "known_slugs",
     "list_templates_by_category",

--- a/disbot/views/ai/routing/matrix.py
+++ b/disbot/views/ai/routing/matrix.py
@@ -19,6 +19,8 @@ from typing import Any
 
 import discord
 
+from core.runtime.interaction_helpers import safe_defer, safe_followup
+
 logger = logging.getLogger("bot.views.ai.routing.matrix")
 
 _TIMEOUT_SECONDS = 180
@@ -135,10 +137,16 @@ class _MatrixChannelSelect(discord.ui.ChannelSelect):
 
     async def callback(self, interaction: discord.Interaction) -> None:
         if interaction.guild is None:
+            # No I/O — direct response stays inside the ack window.
             await interaction.response.send_message(
                 "❌ This requires a guild context.",
                 ephemeral=True,
             )
+            return
+        # build_routing_matrix_embed awaits the policy resolver and the
+        # behavior-preset catalog (both DB-backed). Defer first so the
+        # 3-second ack window never expires before the followup lands.
+        if not await safe_defer(interaction, ephemeral=True, thinking=True):
             return
         picked = self.values[0]
         embed = await build_routing_matrix_embed(
@@ -146,7 +154,7 @@ class _MatrixChannelSelect(discord.ui.ChannelSelect):
             channel_id=picked.id,
             user_id=interaction.user.id,
         )
-        await interaction.response.send_message(embed=embed, ephemeral=True)
+        await safe_followup(interaction, embed=embed, ephemeral=True)
 
 
 class RoutingMatrixSelectView(discord.ui.View):

--- a/tests/unit/services/test_automation_mutation_pipeline.py
+++ b/tests/unit/services/test_automation_mutation_pipeline.py
@@ -120,6 +120,30 @@ async def test_create_rejects_missing_required_config_key(pipeline, _mock_db):
         )
 
 
+@pytest.mark.asyncio
+async def test_create_rule_rejects_scheduled_time(pipeline, _mock_db):
+    # scheduled_time is a registered trigger kind but installation is
+    # gated until the cron parser ships. The rejection MUST happen at
+    # the service boundary, before any DB write, so operators see a
+    # clear validation error rather than a rule that silently misfires.
+    with pytest.raises(
+        InvalidAutomationConfigError,
+        match="not installable",
+    ):
+        await pipeline.create_rule(
+            guild_id=1,
+            guild_owner_id=99,
+            name="x",
+            trigger_kind="scheduled_time",
+            action_kind="send_message",
+            action_config={"channel_id": 555, "template": "hi"},
+            actor_id=99,
+        )
+    _mock_db["insert_rule"].assert_not_awaited()
+    _mock_db["emit_audit"].assert_not_awaited()
+    _mock_db["bus_emit"].assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # Authority
 # ---------------------------------------------------------------------------
@@ -142,7 +166,9 @@ async def test_create_rejects_unknown_actor_type(pipeline, _mock_db):
 
 @pytest.mark.asyncio
 async def test_create_rejects_non_owner(pipeline, _mock_db):
-    with pytest.raises(UnauthorizedAutomationMutationError, match="not the guild owner"):
+    with pytest.raises(
+        UnauthorizedAutomationMutationError, match="not the guild owner"
+    ):
         await pipeline.create_rule(
             guild_id=1,
             guild_owner_id=99,

--- a/tests/unit/services/test_automation_templates.py
+++ b/tests/unit/services/test_automation_templates.py
@@ -25,9 +25,11 @@ from services.automation_mutation import (
     InvalidAutomationConfigError,
 )
 from services.automation_templates import (
+    SERVER_PRESETS,
     TEMPLATES,
     AutomationTemplate,
     get_template,
+    is_installable_template,
     known_slugs,
     list_templates_by_category,
 )
@@ -38,9 +40,7 @@ from services.automation_templates import (
 
 
 def test_onboarding_slugs_match_documented_set():
-    onboarding_slugs = {
-        t.slug for t in list_templates_by_category("onboarding")
-    }
+    onboarding_slugs = {t.slug for t in list_templates_by_category("onboarding")}
     assert onboarding_slugs == {
         "welcome-message",
         "rules-channel-binding",
@@ -58,6 +58,45 @@ def test_get_template_returns_match():
 
 def test_get_template_returns_none_for_unknown_slug():
     assert get_template("does-not-exist") is None
+
+
+def test_get_template_can_still_find_hidden_unsupported_template():
+    """Templates whose trigger kind isn't installable yet stay in the
+    source catalog so internal callers (preset preview, future
+    cron-parser PR) can still resolve them by slug. They're only
+    hidden from the operator picker / ``TEMPLATES`` listing.
+    """
+    # ``daily-readiness-reminder`` ships with trigger_kind=scheduled_time.
+    tmpl = get_template("daily-readiness-reminder")
+    assert tmpl is not None
+    assert not is_installable_template(tmpl)
+    # Picker-facing listing excludes it.
+    assert tmpl not in TEMPLATES
+    assert tmpl.slug not in known_slugs()
+
+
+def test_server_presets_do_not_reference_unsupported_templates():
+    """Bundled :data:`SERVER_PRESETS` must not point any ``add_rule``
+    operation at a non-installable template. Otherwise an operator
+    applying the preset would get an ``InvalidAutomationConfigError``
+    from the mutation pipeline mid-apply.
+    """
+    for preset in SERVER_PRESETS:
+        for index, op in enumerate(preset.operations):
+            if op.kind != "add_rule":
+                continue
+            slug = str(op.payload.get("template_slug") or "")
+            tmpl = get_template(slug)
+            assert tmpl is not None, (
+                f"preset {preset.slug!r} operation[{index}] references "
+                f"unknown template slug {slug!r}"
+            )
+            assert is_installable_template(tmpl), (
+                f"preset {preset.slug!r} operation[{index}] references "
+                f"non-installable template {slug!r} (trigger_kind="
+                f"{tmpl.trigger_kind!r}); the apply would fail at the "
+                "mutation-pipeline boundary."
+            )
 
 
 def test_list_templates_by_category_filters():

--- a/tests/unit/services/test_server_pulse_templates.py
+++ b/tests/unit/services/test_server_pulse_templates.py
@@ -16,29 +16,47 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from services.automation_mutation import AutomationMutationPipeline
+from services.automation_mutation import (
+    AutomationMutationPipeline,
+    InvalidAutomationConfigError,
+)
 from services.automation_templates import (
     AutomationTemplate,
     get_template,
+    is_installable_template,
     list_templates_by_category,
 )
 
-_SERVER_PULSE_SLUGS = {
-    "daily-readiness-reminder",
+# Templates the operator picker should currently surface (every kind
+# the scheduler supports for installation).
+_INSTALLABLE_SERVER_PULSE_SLUGS = {
     "weekly-server-health-summary",
     "weekly-leaderboard",
-    "daily-game-prompt",
     "inactive-channel-nudge",
     "moderation-digest",
     "economy-summary",
-    "tournament-reminder",
     "bot-update-changelog-post",
 }
+# Templates that live in the source catalog (so the cron-parser PR can
+# re-enable them) but are blocked at the mutation-service boundary.
+_NON_INSTALLABLE_SERVER_PULSE_SLUGS = {
+    "daily-readiness-reminder",
+    "daily-game-prompt",
+    "tournament-reminder",
+}
+_SERVER_PULSE_SLUGS = (
+    _INSTALLABLE_SERVER_PULSE_SLUGS | _NON_INSTALLABLE_SERVER_PULSE_SLUGS
+)
 
 
 def test_server_pulse_slug_set_matches_documented():
-    actual = {t.slug for t in list_templates_by_category("server_pulse")}
-    assert actual == _SERVER_PULSE_SLUGS
+    # Picker-facing list only exposes installable templates.
+    actual_listed = {t.slug for t in list_templates_by_category("server_pulse")}
+    assert actual_listed == _INSTALLABLE_SERVER_PULSE_SLUGS
+    # Full catalog still resolves every documented slug via get_template
+    # so internal callers (preset preview, future re-enable) keep working.
+    for slug in _SERVER_PULSE_SLUGS:
+        assert get_template(slug) is not None, slug
 
 
 @pytest.mark.parametrize("slug", sorted(_SERVER_PULSE_SLUGS))
@@ -68,10 +86,11 @@ def test_template_requires_channel_override(slug):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("slug", sorted(_SERVER_PULSE_SLUGS))
-async def test_template_round_trip_through_pipeline(slug):
+@pytest.mark.parametrize("slug", sorted(_INSTALLABLE_SERVER_PULSE_SLUGS))
+async def test_installable_template_round_trip_through_pipeline(slug):
     tmpl = get_template(slug)
     assert tmpl is not None
+    assert is_installable_template(tmpl)
     action_cfg = tmpl.merged_action_config(_meaningful_overrides(tmpl))
     trigger_cfg = tmpl.merged_trigger_config()
     with (
@@ -100,14 +119,51 @@ async def test_template_round_trip_through_pipeline(slug):
     assert result.rule_id == 1
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("slug", sorted(_NON_INSTALLABLE_SERVER_PULSE_SLUGS))
+async def test_non_installable_template_is_rejected_by_pipeline(slug):
+    tmpl = get_template(slug)
+    assert tmpl is not None
+    assert not is_installable_template(tmpl)
+    action_cfg = tmpl.merged_action_config(_meaningful_overrides(tmpl))
+    trigger_cfg = tmpl.merged_trigger_config()
+    with (
+        patch(
+            "services.automation_mutation.db.insert_rule",
+            new_callable=AsyncMock,
+        ) as insert_rule,
+        patch(
+            "services.automation_mutation.emit_audit_action",
+            new_callable=AsyncMock,
+        ),
+        patch("core.events.bus.emit", new_callable=AsyncMock),
+    ):
+        with pytest.raises(InvalidAutomationConfigError):
+            await AutomationMutationPipeline().create_rule(
+                guild_id=10,
+                guild_owner_id=99,
+                name=tmpl.slug,
+                trigger_kind=tmpl.trigger_kind,
+                action_kind=tmpl.action_kind,
+                trigger_config=trigger_cfg,
+                action_config=action_cfg,
+                actor_id=99,
+            )
+        insert_rule.assert_not_awaited()
+
+
 def test_all_server_pulse_templates_default_to_disabled():
     """The mutation pipeline always inserts ``enabled=False`` —
     operators opt in explicitly. The template definitions
     deliberately don't carry an ``enabled`` field so the default
     survives."""
-    # Pin via structure: no template has an "enabled" key in its
-    # default config.
-    for tmpl in list_templates_by_category("server_pulse"):
+    # Pin via structure across the full catalog: no template has an
+    # "enabled" key in its default config — including the hidden
+    # scheduled_time ones so a future re-enable doesn't accidentally
+    # bypass the disabled-by-default invariant.
+    for slug in _SERVER_PULSE_SLUGS:
+        tmpl = get_template(slug)
+        assert tmpl is not None
         assert "enabled" not in tmpl.default_trigger_config
         assert "enabled" not in tmpl.default_action_config
 

--- a/tests/unit/views/ai/test_routing_matrix.py
+++ b/tests/unit/views/ai/test_routing_matrix.py
@@ -141,3 +141,72 @@ def test_matrix_view_admin_gate_allows_admin():
     children = list(view.children)
     # There should be exactly one channel-select child.
     assert any(isinstance(c, discord.ui.ChannelSelect) for c in children)
+
+
+@pytest.mark.asyncio
+async def test_matrix_callback_defers_before_building_embed(monkeypatch):
+    """The channel-select callback must defer the interaction BEFORE
+    awaiting the policy resolver + preset catalog — both DB-backed.
+    Without the defer the 3-second ack window can expire under normal
+    latency, producing "This interaction failed".
+    """
+    from views.ai.routing import matrix as matrix_mod
+
+    call_order: list[str] = []
+
+    async def _build_embed(**_kwargs):
+        call_order.append("build_embed")
+        return discord.Embed(title="x")
+
+    async def _defer(*_args, **_kwargs):
+        call_order.append("defer")
+
+    async def _followup_send(*_args, **_kwargs):
+        call_order.append("followup_send")
+
+    async def _response_send(*_args, **_kwargs):
+        # Should NOT be called on the normal guild path after the fix.
+        call_order.append("response_send_message")
+
+    monkeypatch.setattr(
+        matrix_mod,
+        "build_routing_matrix_embed",
+        _build_embed,
+    )
+
+    interaction = MagicMock()
+    interaction.guild = SimpleNamespace(id=1)
+    interaction.user = SimpleNamespace(id=2)
+    interaction.response = MagicMock()
+    # Model the response lifecycle: is_done flips True once defer is
+    # awaited so the followup helper routes through followup.send (the
+    # production path) rather than retrying response.send_message.
+    deferred = {"flag": False}
+
+    def _is_done() -> bool:
+        return deferred["flag"]
+
+    async def _defer_and_flip(*_args, **_kwargs):
+        await _defer()
+        deferred["flag"] = True
+
+    interaction.response.is_done = _is_done
+    interaction.response.defer = AsyncMock(side_effect=_defer_and_flip)
+    interaction.response.send_message = AsyncMock(side_effect=_response_send)
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock(side_effect=_followup_send)
+
+    # discord.ui.ChannelSelect.values is a non-settable property on a
+    # real select instance, so invoke the callback function with a
+    # plain stand-in carrying the .values attribute the body reads.
+    select_stub = SimpleNamespace(values=[SimpleNamespace(id=42)])
+    # _MatrixChannelSelect is module-internal; reach it via the view.
+    view = RoutingMatrixSelectView()
+    real_select = next(
+        c for c in view.children if isinstance(c, discord.ui.ChannelSelect)
+    )
+    callback_func = type(real_select).callback
+    await callback_func(select_stub, interaction)
+
+    assert call_order == ["defer", "build_embed", "followup_send"], call_order
+    interaction.response.send_message.assert_not_awaited()

--- a/tests/unit/views/setup/test_template_picker.py
+++ b/tests/unit/views/setup/test_template_picker.py
@@ -47,10 +47,7 @@ def test_build_picker_embed_lists_categories_with_counts():
     cat_field = next((f for f in fields if "categories" in f.name.lower()), None)
     assert cat_field is not None
     # At least one of the documented categories appears.
-    assert (
-        "Onboarding" in cat_field.value
-        or "Server pulse" in cat_field.value
-    )
+    assert "Onboarding" in cat_field.value or "Server pulse" in cat_field.value
 
 
 def test_picker_view_seeds_one_select_with_template_options():
@@ -68,9 +65,7 @@ def test_template_config_embed_pre_apply_lists_required_overrides():
     template = next(t for t in TEMPLATES if t.required_overrides)
     embed = build_template_config_embed(template)
     field = next(f for f in embed.fields if "Required" in f.name)
-    assert any(
-        f"`{key}`" in field.value for key in template.required_overrides
-    )
+    assert any(f"`{key}`" in field.value for key in template.required_overrides)
 
 
 def test_template_config_embed_post_apply_success_is_green():
@@ -103,9 +98,7 @@ def test_template_config_embed_post_apply_failure_is_red():
 @pytest.mark.asyncio
 async def test_apply_routes_through_mutation_pipeline_with_disabled_default():
     """Apply must call the pipeline and never pass ``enabled=True``."""
-    template = next(
-        t for t in TEMPLATES if "channel_id" in t.required_overrides
-    )
+    template = next(t for t in TEMPLATES if "channel_id" in t.required_overrides)
 
     fake_result = AutomationMutationResult(
         mutation_id="m1",
@@ -160,9 +153,7 @@ async def test_apply_routes_through_mutation_pipeline_with_disabled_default():
 
 @pytest.mark.asyncio
 async def test_apply_returns_validation_error_when_pipeline_rejects():
-    template = next(
-        t for t in TEMPLATES if "channel_id" in t.required_overrides
-    )
+    template = next(t for t in TEMPLATES if "channel_id" in t.required_overrides)
 
     from services.automation_mutation import InvalidAutomationConfigError
 
@@ -193,9 +184,7 @@ async def test_apply_returns_validation_error_when_pipeline_rejects():
 @pytest.mark.asyncio
 async def test_apply_button_short_circuits_when_required_override_missing():
     """Apply with required ``channel_id`` unset must not call the pipeline."""
-    template = next(
-        t for t in TEMPLATES if "channel_id" in t.required_overrides
-    )
+    template = next(t for t in TEMPLATES if "channel_id" in t.required_overrides)
     view = TemplateConfigView(_author(), template=template)
     # channel_id was never selected.
     assert view.selected_channel_id is None
@@ -220,9 +209,7 @@ async def test_apply_button_short_circuits_when_required_override_missing():
 
 @pytest.mark.asyncio
 async def test_apply_button_calls_pipeline_when_overrides_filled():
-    template = next(
-        t for t in TEMPLATES if "channel_id" in t.required_overrides
-    )
+    template = next(t for t in TEMPLATES if "channel_id" in t.required_overrides)
     view = TemplateConfigView(_author(), template=template)
     view.selected_channel_id = 12345
 
@@ -257,3 +244,25 @@ def test_picker_select_options_never_exceed_25():
     view = TemplatePickerView(_author())
     selects = [c for c in view.children if hasattr(c, "options")]
     assert len(selects[0].options) <= 25
+
+
+def test_picker_omits_unsupported_trigger_kinds():
+    """Templates whose trigger kind isn't installable yet must not
+    appear in the picker — operators would otherwise install a rule
+    the scheduler treats as a 24h-drift placeholder.
+    """
+    from services.automation_registry import (
+        UNSUPPORTED_INSTALLABLE_TRIGGER_KINDS,
+    )
+
+    view = TemplatePickerView(_author())
+    select = next(c for c in view.children if hasattr(c, "options"))
+    listed_slugs = {opt.value for opt in select.options}
+    for slug in listed_slugs:
+        tmpl = get_template(slug)
+        assert tmpl is not None
+        assert tmpl.trigger_kind not in UNSUPPORTED_INSTALLABLE_TRIGGER_KINDS
+    # Belt-and-braces: TEMPLATES (the source of the options) carries no
+    # unsupported kinds either.
+    for tmpl in TEMPLATES:
+        assert tmpl.trigger_kind not in UNSUPPORTED_INSTALLABLE_TRIGGER_KINDS


### PR DESCRIPTION
## Summary

Two P0 production-safety fixes verified against the codebase after PRs #341–#350.

- **`scheduled_time` automation rules were operator-installable but silently misbehaved.** Three production templates (`daily-readiness-reminder`, `daily-game-prompt`, `tournament-reminder`) shipped with `trigger_kind="scheduled_time"`, the registry accepted it, the mutation pipeline didn't block it, and the scheduler treated it as a `now + 1 day` placeholder — an operator enabling "Daily readiness reminder" would get a rule that drifts to a random time of day instead of firing on a schedule. Now blocked at the service boundary; templates split into `_ALL_TEMPLATES` (full source catalog) and filtered `TEMPLATES` (operator-facing list); the three templates stay in source so the cron-parser PR can re-enable them by removing the kind from `UNSUPPORTED_INSTALLABLE_TRIGGER_KINDS`.
- **AI routing matrix select callback ran two DB-backed awaits before the first interaction response.** `_MatrixChannelSelect.callback` awaited `nlp.resolve` and `list_presets()` before `interaction.response.send_message`, risking the 3-second ack window. Now defers first via `safe_defer`, then builds the embed, then sends via `safe_followup`. Guild-None fast path unchanged.

## Files changed

| File | Change |
|---|---|
| `disbot/services/automation_registry.py` | Add `UNSUPPORTED_INSTALLABLE_TRIGGER_KINDS = frozenset({"scheduled_time"})` as the single source of truth. |
| `disbot/services/automation_mutation.py` | Reject the unsupported kind in `create_rule` after `_validate_kinds`, before any DB write. |
| `disbot/services/automation_templates.py` | Introduce `_ALL_TEMPLATES`; filter `TEMPLATES`; `get_template` searches the full catalog; add `is_installable_template`. |
| `disbot/services/automation_scheduler.py` | Document the `scheduled_time` branch as backwards-tolerance for historical rows only. |
| `disbot/views/ai/routing/matrix.py` | `safe_defer` → build embed → `safe_followup` in the channel-select callback. |

## Test plan

- [x] `pytest tests/unit/services/test_automation_mutation_pipeline.py` — new `test_create_rule_rejects_scheduled_time` asserts the rejection happens before DB / audit / event paths.
- [x] `pytest tests/unit/services/test_automation_templates.py` — new `test_get_template_can_still_find_hidden_unsupported_template` and `test_server_presets_do_not_reference_unsupported_templates` (stronger invariant than the previous unknown-slug check).
- [x] `pytest tests/unit/services/test_server_pulse_templates.py` — split parametrized pipeline round-trip into installable (succeeds) and non-installable (rejected without insert).
- [x] `pytest tests/unit/views/setup/test_template_picker.py` — new `test_picker_omits_unsupported_trigger_kinds`.
- [x] `pytest tests/unit/views/ai/test_routing_matrix.py` — new `test_matrix_callback_defers_before_building_embed` asserts call order `defer → build_embed → followup.send` and that `response.send_message` is not used in the guild path.
- [x] `pytest tests/unit/runtime/test_command_access*.py tests/unit/services/test_command_access_service.py tests/unit/db/test_command_access_db.py tests/unit/slash/test_slash_access_check.py` regression net — 78 passed.
- [x] `pytest tests/` full suite — 5424 passed, 3 skipped, 0 failed.
- [x] `python3.10 scripts/check_architecture.py --mode strict` — 0 errors, no new violations.
- [x] `black --check / isort --check / ruff / mypy` on the five touched source files — all green.

## Follow-ups (not this PR)

- Implement the real cron parser for `scheduled_time` — removing the kind from `UNSUPPORTED_INSTALLABLE_TRIGGER_KINDS` re-enables the hidden templates with no further change.
- Diagnostic for historical `scheduled_time` rule rows in `automation_rules` so operators can clean them up.
- Startup diagnostic for migration 051 silent-fallback (very-low-probability edge case where the main server's `panel_anchors` rows are missing at upgrade time).
- Docstring cleanup at `disbot/core/runtime/command_access.py:466-471` about component-interaction behavior that cannot actually reach the resolver (`tree.interaction_check` only fires for application_command/autocomplete).

https://claude.ai/code/session_01Nj4ZSysv2xXEdVx8wcjU1G

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nj4ZSysv2xXEdVx8wcjU1G)_