### PR TITLE
BTD6: adopt safe interaction helpers + tighten staff reject chokepoint

### DIFF
--- a/disbot/cogs/btd6_cog.py
+++ b/disbot/cogs/btd6_cog.py
@@ -35,6 +35,7 @@ from cogs.btd6._embeds import (
 from cogs.btd6._embeds import response_to_embed as _response_to_embed
 from cogs.btd6.stage import STAGE_NAME as BTD6_STAGE_NAME
 from core.runtime import message_pipeline, tasks
+from core.runtime.interaction_helpers import safe_defer, safe_followup
 from services import btd6_ai_service, btd6_ingestion_supervisor
 from services.btd6_resolver_service import resolve
 from views.btd6.panel import BTD6PanelView, build_btd6_panel_embed
@@ -480,10 +481,10 @@ class BTD6Cog(commands.Cog):
     ) -> None:
         from cogs.btd6._builders import build_source_health_embed
 
-        await interaction.response.send_message(
-            embed=await build_source_health_embed(limit=limit),
-            ephemeral=True,
-        )
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        embed = await build_source_health_embed(limit=limit)
+        await safe_followup(interaction, embed=embed, ephemeral=True)
 
     @btd6_app_group.command(
         name="latest-data",
@@ -542,10 +543,10 @@ class BTD6Cog(commands.Cog):
     ) -> None:
         from views.btd6.strategy_browse import build_browse_embed
 
-        await interaction.response.send_message(
-            embed=await build_browse_embed(limit=limit),
-            ephemeral=True,
-        )
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        embed = await build_browse_embed(limit=limit)
+        await safe_followup(interaction, embed=embed, ephemeral=True)
 
     @btd6_app_group.command(
         name="mine",
@@ -564,14 +565,14 @@ class BTD6Cog(commands.Cog):
             return
         from views.btd6.strategy_browse import build_mine_embed
 
-        await interaction.response.send_message(
-            embed=await build_mine_embed(
-                interaction.guild.id,
-                interaction.user.id,
-                limit=limit,
-            ),
-            ephemeral=True,
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        embed = await build_mine_embed(
+            interaction.guild.id,
+            interaction.user.id,
+            limit=limit,
         )
+        await safe_followup(interaction, embed=embed, ephemeral=True)
 
     @btd6_app_group.command(
         name="strategy",
@@ -584,12 +585,14 @@ class BTD6Cog(commands.Cog):
     ) -> None:
         from views.btd6.strategy_browse import build_detail_embed
 
+        if not await safe_defer(interaction, ephemeral=True):
+            return
         viewer_guild = interaction.guild.id if interaction.guild else None
         payload = await build_detail_embed(strategy_id, viewer_guild_id=viewer_guild)
         if isinstance(payload, str):
-            await interaction.response.send_message(payload, ephemeral=True)
+            await safe_followup(interaction, payload, ephemeral=True)
         else:
-            await interaction.response.send_message(embed=payload, ephemeral=True)
+            await safe_followup(interaction, embed=payload, ephemeral=True)
 
     @btd6_app_group.command(
         name="strategy-audit",
@@ -640,22 +643,23 @@ class BTD6Cog(commands.Cog):
             return
         from cogs.btd6._builders import build_pending_review_payload
 
+        if not await safe_defer(interaction, ephemeral=True):
+            return
         payload = await build_pending_review_payload(
             interaction.guild.id,
             limit=limit,
         )
         if isinstance(payload, str):
-            await interaction.response.send_message(payload, ephemeral=True)
+            await safe_followup(interaction, payload, ephemeral=True)
             return
-        # First embed responds; remaining embeds go as followups.
-        first_embed, first_view = payload[0]
-        await interaction.response.send_message(
-            embed=first_embed,
-            view=first_view,
-            ephemeral=True,
-        )
-        for embed, view in payload[1:]:
-            await interaction.followup.send(embed=embed, view=view, ephemeral=True)
+        # Uniform: every page goes through safe_followup after one defer.
+        for embed, view in payload:
+            await safe_followup(
+                interaction,
+                embed=embed,
+                view=view,
+                ephemeral=True,
+            )
 
     @app_commands.command(name="btd6menu", description="Open the BTD6 panel.")
     async def btd6menu_slash(self, interaction: discord.Interaction) -> None:

--- a/disbot/services/btd6_strategy_mutation.py
+++ b/disbot/services/btd6_strategy_mutation.py
@@ -314,6 +314,12 @@ async def reject(
     actor_kind: str = "staff",
     reason: str | None = None,
 ) -> StrategyMutationResult:
+    """Low-level rejection primitive. This function preserves the
+    historical write path and does NOT enforce staff permissions or
+    strategy existence. UI / admin / staff callers must use
+    :func:`staff_reject`. Keep this only for future non-staff actor
+    flows that add their own authorization before calling it.
+    """
     actor_id = _check_actor(actor)
     await db.update_strategy_state(
         strategy_id,
@@ -333,6 +339,49 @@ async def reject(
         strategy_id=strategy_id,
         action="rejected",
         actor_kind=actor_kind,
+    )
+
+
+async def staff_reject(
+    strategy_id: int,
+    *,
+    staff_actor: Any,
+    reason: str | None = None,
+) -> StrategyMutationResult:
+    """Staff rejects a strategy.
+
+    Mirrors :func:`reject`'s write semantics and adds the staff
+    permission + strategy-existence guards that the other staff_*
+    mutations enforce. UI / admin paths must call this rather than
+    :func:`reject` so the chokepoint stays authorized.
+    """
+    actor_id = _check_actor(staff_actor)
+    if not _is_staff(staff_actor):
+        raise UnauthorizedStrategyMutationError(
+            "rejection requires manage_guild or administrator permission",
+        )
+    before = await db.get_strategy(strategy_id)
+    if before is None:
+        raise InvalidStrategyValueError(f"strategy {strategy_id} not found")
+
+    await db.update_strategy_state(
+        strategy_id,
+        approval_status="rejected",
+        bump_version=True,
+        current_guild_id=None,
+    )
+    await db.record_strategy_audit(
+        strategy_id,
+        actor_kind="staff",
+        actor_id=actor_id,
+        action="rejected",
+        detail={"reason": reason} if reason else None,
+    )
+    return StrategyMutationResult(
+        mutation_id=uuid.uuid4().hex,
+        strategy_id=strategy_id,
+        action="rejected",
+        actor_kind="staff",
     )
 
 
@@ -375,6 +424,7 @@ __all__ = [
     "reject",
     "staff_approve_guild",
     "staff_publish",
+    "staff_reject",
     "submit_strategy",
     "unpublish",
 ]

--- a/disbot/views/btd6/strategy_review.py
+++ b/disbot/views/btd6/strategy_review.py
@@ -30,6 +30,8 @@ from typing import Any
 
 import discord
 
+from core.runtime.interaction_helpers import safe_defer, safe_edit, safe_followup
+
 logger = logging.getLogger("bot.views.btd6.strategy_review")
 
 _VIEW_TIMEOUT_SECONDS = 300
@@ -92,22 +94,28 @@ async def _refresh_or_followup(
 ) -> None:
     """Re-fetch the strategy and refresh the parent embed, plus an
     ephemeral confirmation so the staff actor sees what happened.
+
+    Assumes the caller has already deferred the interaction so the
+    safe helpers route through ``followup.send`` /
+    ``followup.edit_message``.
     """
     try:
         from utils.db import btd6_strategies as db
 
         refreshed = await db.get_strategy(strategy_id)
-    except Exception as exc:  # noqa: BLE001 — defensive
+    except Exception:  # noqa: BLE001 — defensive
         logger.exception("strategy_review: refresh fetch failed for id=%s", strategy_id)
-        refreshed = None
-        await interaction.followup.send(
-            f"⚠️ {confirm_message} (refresh failed: {type(exc).__name__})",
+        await safe_followup(
+            interaction,
+            f"⚠️ {confirm_message} (refresh failed — the change went through "
+            "but the panel could not reload).",
             ephemeral=True,
         )
         return
 
     if refreshed is None:
-        await interaction.response.send_message(
+        await safe_followup(
+            interaction,
             f"✅ {confirm_message} (the strategy is gone from the table now).",
             ephemeral=True,
         )
@@ -115,8 +123,15 @@ async def _refresh_or_followup(
 
     embed = build_strategy_embed(refreshed)
     view = StrategyReviewView(refreshed)
-    await interaction.response.edit_message(embed=embed, view=view)
-    await interaction.followup.send(f"✅ {confirm_message}", ephemeral=True)
+    edited = await safe_edit(interaction, embed=embed, view=view)
+    if not edited:
+        await safe_followup(
+            interaction,
+            f"⚠️ {confirm_message} but the review panel could not be refreshed.",
+            ephemeral=True,
+        )
+        return
+    await safe_followup(interaction, f"✅ {confirm_message}", ephemeral=True)
 
 
 class StrategyReviewView(discord.ui.View):
@@ -151,22 +166,34 @@ class StrategyReviewView(discord.ui.View):
     ) -> None:
         from services.btd6_strategy_mutation import BTD6StrategyMutationError
 
+        # Defer first (component defer_update — silent ack on the
+        # parent message) so we have the full 15-minute followup
+        # window for the mutation + refresh round-trip.
+        if not await safe_defer(interaction):
+            return
+
         try:
             await action_callable(self.strategy_id, **kwargs)
         except BTD6StrategyMutationError as exc:
-            await interaction.response.send_message(
-                f"❌ {type(exc).__name__}: {exc}",
+            # Typed mutation errors expose the service message but
+            # not the class name — service messages are already
+            # user-facing.
+            await safe_followup(
+                interaction,
+                f"❌ Could not update strategy #{self.strategy_id}: {exc}",
                 ephemeral=True,
             )
             return
-        except Exception as exc:  # noqa: BLE001 — surface unexpected errors
+        except Exception:  # noqa: BLE001 — surface unexpected errors
             logger.exception(
                 "StrategyReviewView: mutation %s raised for strategy=%s",
                 action_callable.__name__,
                 self.strategy_id,
             )
-            await interaction.response.send_message(
-                f"❌ Unexpected error: {type(exc).__name__}: {exc}",
+            await safe_followup(
+                interaction,
+                "❌ Unexpected error while updating this strategy. "
+                "Check logs for details.",
                 ephemeral=True,
             )
             return
@@ -228,8 +255,8 @@ class StrategyReviewView(discord.ui.View):
 
         await self._mutate(
             interaction,
-            action_callable=btd6_strategy_mutation.reject,
-            kwargs={"actor": interaction.user, "actor_kind": "staff"},
+            action_callable=btd6_strategy_mutation.staff_reject,
+            kwargs={"staff_actor": interaction.user},
             confirm=f"Rejected strategy #{self.strategy_id}.",
         )
 

--- a/disbot/views/btd6/strategy_submit.py
+++ b/disbot/views/btd6/strategy_submit.py
@@ -17,6 +17,8 @@ from typing import Any
 
 import discord
 
+from core.runtime.interaction_helpers import safe_defer, safe_followup
+
 logger = logging.getLogger("bot.views.btd6.strategy_submit")
 
 
@@ -59,17 +61,25 @@ class StrategySubmitModal(discord.ui.Modal, title="Submit BTD6 strategy"):
             submit_strategy,
         )
 
+        # Synchronous guild-context check — fast, no I/O, so respond
+        # immediately without deferring.
         if interaction.guild is None:
             await interaction.response.send_message(
                 "❌ Submitting a strategy requires a guild context.",
                 ephemeral=True,
             )
             return
+
         title = (self.title_input.value or "").strip()
         summary = (self.summary_input.value or "").strip()
         map_name = (self.map_input.value or "").strip() or None
         mode = (self.mode_input.value or "").strip() or None
         hero = (self.hero_input.value or "").strip() or None
+
+        # Defer before the DB insert so the 3-second window doesn't
+        # expire under load.
+        if not await safe_defer(interaction, ephemeral=True):
+            return
 
         try:
             result = await submit_strategy(
@@ -82,23 +92,26 @@ class StrategySubmitModal(discord.ui.Modal, title="Submit BTD6 strategy"):
                 hero=hero,
             )
         except InvalidStrategyValueError as exc:
-            await interaction.response.send_message(
+            await safe_followup(
+                interaction,
                 f"❌ {exc}",
                 ephemeral=True,
             )
             return
-        except Exception as exc:  # noqa: BLE001 — defensive
+        except Exception:  # noqa: BLE001 — defensive
             logger.exception(
                 "StrategySubmitModal: submission failed for guild=%s",
                 interaction.guild.id,
             )
-            await interaction.response.send_message(
-                f"❌ Unexpected error: {type(exc).__name__}: {exc}",
+            await safe_followup(
+                interaction,
+                "❌ Unexpected error while submitting. Check logs for details.",
                 ephemeral=True,
             )
             return
 
-        await interaction.response.send_message(
+        await safe_followup(
+            interaction,
             f"✅ Submitted as strategy `#{result.strategy_id}` "
             f"(`{result.action}`). Staff can review with `!btd6 pending`.",
             ephemeral=True,

--- a/tests/unit/cogs/test_btd6_cog.py
+++ b/tests/unit/cogs/test_btd6_cog.py
@@ -157,3 +157,129 @@ async def test_setup_adds_cog_to_bot():
     await setup(_FakeBot())
     assert len(added) == 1
     assert isinstance(added[0], BTD6Cog)
+
+
+# ---------------------------------------------------------------------------
+# Blocker PR-1: every BTD6 slash command that touches DB must defer
+# BEFORE invoking the builder so the 3-second token window doesn't
+# expire under load.
+# ---------------------------------------------------------------------------
+
+
+def _slash_interaction():
+    """Interaction mock for slash commands. Guild present (for /mine
+    and /pending), defer flips response.is_done so safe_followup
+    routes through followup.send."""
+    interaction = MagicMock()
+    interaction.guild = MagicMock()
+    interaction.guild.id = 555
+    interaction.user = MagicMock()
+    interaction.user.id = 7777
+
+    deferred = {"done": False}
+    interaction.response.is_done = lambda: deferred["done"]
+
+    async def _defer(**_kw):
+        deferred["done"] = True
+
+    interaction.response.defer = AsyncMock(side_effect=_defer)
+    interaction.response.send_message = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    interaction.original_response = AsyncMock()
+    return interaction
+
+
+@pytest.mark.parametrize(
+    ("command_attr", "builder_module", "builder_name", "kwargs", "return_kind"),
+    [
+        (
+            "btd6_pending_slash",
+            "cogs.btd6._builders",
+            "build_pending_review_payload",
+            {"limit": 5},
+            "pending_list",
+        ),
+        (
+            "btd6_source_health_slash",
+            "cogs.btd6._builders",
+            "build_source_health_embed",
+            {"limit": 25},
+            "embed",
+        ),
+        (
+            "btd6_browse_slash",
+            "views.btd6.strategy_browse",
+            "build_browse_embed",
+            {"limit": 10},
+            "embed",
+        ),
+        (
+            "btd6_mine_slash",
+            "views.btd6.strategy_browse",
+            "build_mine_embed",
+            {"limit": 10},
+            "embed",
+        ),
+        (
+            "btd6_strategy_slash",
+            "views.btd6.strategy_browse",
+            "build_detail_embed",
+            {"strategy_id": 1},
+            "embed",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_slash_command_defers_before_db_work(
+    monkeypatch,
+    command_attr,
+    builder_module,
+    builder_name,
+    kwargs,
+    return_kind,
+):
+    """Every named BTD6 slash command must call ``safe_defer`` before
+    invoking its builder so DB latency doesn't trip the interaction
+    token. Patch targets are the source modules because the cog uses
+    function-body lazy imports — ``from cogs.btd6._builders import
+    build_…`` re-resolves at call time.
+    """
+    import importlib
+
+    builder_mod = importlib.import_module(builder_module)
+
+    call_order: list[str] = []
+
+    async def _build_capture(*_a, **_kw):
+        call_order.append("build")
+        # Match the real return shape per builder so the cog's
+        # downstream branching (e.g. ``isinstance(payload, str)``,
+        # ``for embed, view in payload``) doesn't TypeError.
+        if return_kind == "pending_list":
+            return [(MagicMock(spec=discord.Embed), MagicMock())]
+        return MagicMock(spec=discord.Embed)
+
+    monkeypatch.setattr(builder_mod, builder_name, _build_capture)
+
+    # Patch safe_defer / safe_followup at the cog's import site.
+    from cogs import btd6_cog as cog_mod
+
+    async def _defer_capture(interaction, **_kw):
+        call_order.append("defer")
+        # Mirror the real helper: flip is_done so any subsequent
+        # safe_followup routes through followup.send.
+        interaction.response.is_done = lambda: True
+        return True
+
+    async def _followup_capture(*_a, **_kw):
+        return None
+
+    monkeypatch.setattr(cog_mod, "safe_defer", _defer_capture)
+    monkeypatch.setattr(cog_mod, "safe_followup", _followup_capture)
+
+    cog = BTD6Cog(MagicMock())
+    interaction = _slash_interaction()
+    callback = getattr(cog, command_attr).callback
+    await callback(cog, interaction, **kwargs)
+
+    assert call_order[:2] == ["defer", "build"], call_order

--- a/tests/unit/services/test_btd6_strategy_staff_reject.py
+++ b/tests/unit/services/test_btd6_strategy_staff_reject.py
@@ -1,0 +1,181 @@
+"""Blocker PR-1 — staff_reject mirrors reject() writes + adds guards.
+
+These tests pin the new ``staff_reject`` chokepoint:
+
+* It mirrors the historical ``reject`` write semantics
+  (``approval_status='rejected'``, ``bump_version=True``,
+  ``current_guild_id=None``; matching audit row).
+* It enforces ``_is_staff`` permissions at the service layer
+  (independent of the view's ``interaction_check``).
+* It refuses missing strategies before any DB write.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_DISBOT = Path(__file__).parents[3] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+from services import btd6_strategy_mutation as mut  # noqa: E402
+from utils.db import btd6_strategies as db  # noqa: E402
+
+
+def _staff_actor(actor_id: int = 12345) -> MagicMock:
+    actor = MagicMock()
+    actor.id = actor_id
+    actor.guild_permissions.administrator = False
+    actor.guild_permissions.manage_guild = True
+    return actor
+
+
+def _admin_actor(actor_id: int = 12345) -> MagicMock:
+    actor = MagicMock()
+    actor.id = actor_id
+    actor.guild_permissions.administrator = True
+    return actor
+
+
+def _non_staff_actor(actor_id: int = 99) -> MagicMock:
+    actor = MagicMock()
+    actor.id = actor_id
+    actor.guild_permissions.administrator = False
+    actor.guild_permissions.manage_guild = False
+    return actor
+
+
+def _strategy_row(
+    *,
+    sid: int = 1,
+    visibility: str = "guild",
+    approval_status: str = "draft",
+) -> dict:
+    return {
+        "id": sid,
+        "title": "test",
+        "summary": "s",
+        "origin_guild_id": 100,
+        "current_guild_id": 100,
+        "visibility": visibility,
+        "approval_status": approval_status,
+        "version": 1,
+    }
+
+
+async def test_staff_reject_writes_state_and_audit(monkeypatch):
+    update_calls: list[dict] = []
+    audit_calls: list[dict] = []
+
+    async def _get(sid):
+        return _strategy_row(sid=sid)
+
+    async def _update(strategy_id, **kw):
+        update_calls.append({"id": strategy_id, **kw})
+
+    async def _audit(strategy_id, **kw):
+        audit_calls.append({"id": strategy_id, **kw})
+
+    monkeypatch.setattr(db, "get_strategy", _get)
+    monkeypatch.setattr(db, "update_strategy_state", _update)
+    monkeypatch.setattr(db, "record_strategy_audit", _audit)
+
+    result = await mut.staff_reject(7, staff_actor=_staff_actor(actor_id=42))
+    assert result.action == "rejected"
+    assert result.actor_kind == "staff"
+
+    # Mirror the existing reject() write contract exactly.
+    assert update_calls[0]["approval_status"] == "rejected"
+    assert update_calls[0]["bump_version"] is True
+    assert update_calls[0]["current_guild_id"] is None
+
+    assert audit_calls[0]["actor_kind"] == "staff"
+    assert audit_calls[0]["actor_id"] == 42
+    assert audit_calls[0]["action"] == "rejected"
+
+
+async def test_staff_reject_admin_is_also_staff(monkeypatch):
+    async def _get(sid):
+        return _strategy_row(sid=sid)
+
+    monkeypatch.setattr(db, "get_strategy", _get)
+    monkeypatch.setattr(db, "update_strategy_state", AsyncMock())
+    monkeypatch.setattr(db, "record_strategy_audit", AsyncMock())
+
+    result = await mut.staff_reject(7, staff_actor=_admin_actor(actor_id=99))
+    assert result.actor_kind == "staff"
+    assert result.action == "rejected"
+
+
+async def test_staff_reject_rejects_non_staff(monkeypatch):
+    """Service-layer authorization pin — independent of any view check."""
+
+    async def _get(sid):
+        return _strategy_row(sid=sid)
+
+    explode = AsyncMock()
+    monkeypatch.setattr(db, "get_strategy", _get)
+    monkeypatch.setattr(db, "update_strategy_state", explode)
+    monkeypatch.setattr(db, "record_strategy_audit", explode)
+
+    with pytest.raises(mut.UnauthorizedStrategyMutationError):
+        await mut.staff_reject(7, staff_actor=_non_staff_actor())
+    explode.assert_not_awaited()
+
+
+async def test_staff_reject_refuses_when_strategy_missing(monkeypatch):
+    async def _get(sid):
+        return None
+
+    explode = AsyncMock()
+    monkeypatch.setattr(db, "get_strategy", _get)
+    monkeypatch.setattr(db, "update_strategy_state", explode)
+    monkeypatch.setattr(db, "record_strategy_audit", explode)
+
+    with pytest.raises(mut.InvalidStrategyValueError, match="strategy 7 not found"):
+        await mut.staff_reject(7, staff_actor=_staff_actor())
+    explode.assert_not_awaited()
+
+
+def test_module_exports_staff_reject():
+    """The new mutation is in __all__ so callers can import without
+    relying on internal attribute access."""
+    assert "staff_reject" in mut.__all__
+
+
+async def test_staff_reject_matches_reject_state_writes(monkeypatch):
+    """Both reject() and staff_reject() must converge on identical
+    ``update_strategy_state`` kwargs — protects against silent drift
+    if either path is later edited."""
+
+    async def _get(sid):
+        return _strategy_row(sid=sid)
+
+    monkeypatch.setattr(db, "get_strategy", _get)
+
+    staff_calls: list[dict] = []
+    reject_calls: list[dict] = []
+
+    async def _update_staff(strategy_id, **kw):
+        staff_calls.append({"id": strategy_id, **kw})
+
+    async def _audit_noop(*_a, **_kw):
+        return None
+
+    monkeypatch.setattr(db, "update_strategy_state", _update_staff)
+    monkeypatch.setattr(db, "record_strategy_audit", _audit_noop)
+
+    await mut.staff_reject(7, staff_actor=_staff_actor(actor_id=42))
+
+    async def _update_reject(strategy_id, **kw):
+        reject_calls.append({"id": strategy_id, **kw})
+
+    monkeypatch.setattr(db, "update_strategy_state", _update_reject)
+    await mut.reject(7, actor=_staff_actor(actor_id=42), actor_kind="staff")
+
+    assert staff_calls and reject_calls
+    assert staff_calls[0] == reject_calls[0]

--- a/tests/unit/views/btd6/test_strategy_review.py
+++ b/tests/unit/views/btd6/test_strategy_review.py
@@ -48,13 +48,31 @@ def _strategy(
 
 
 def _staff_interaction(*, manage_guild: bool = True) -> MagicMock:
+    """Build an interaction mock that flips ``response.is_done`` after
+    ``defer()`` is awaited so the safe_* helpers route correctly:
+    pre-defer → ``response.send_message`` / ``response.edit_message``,
+    post-defer → ``followup.send`` / ``followup.edit_message``.
+    """
     interaction = MagicMock()
     interaction.user.guild_permissions.administrator = False
     interaction.user.guild_permissions.manage_guild = manage_guild
     interaction.user.id = 7777
+
+    deferred = {"done": False}
+
+    interaction.response.is_done = lambda: deferred["done"]
+
+    async def _defer(**_kw):
+        deferred["done"] = True
+
+    interaction.response.defer = AsyncMock(side_effect=_defer)
     interaction.response.send_message = AsyncMock()
     interaction.response.edit_message = AsyncMock()
     interaction.followup.send = AsyncMock()
+    interaction.followup.edit_message = AsyncMock()
+    interaction.original_response = AsyncMock()
+    interaction.message = MagicMock()
+    interaction.message.id = 99999
     return interaction
 
 
@@ -163,11 +181,15 @@ async def test_approve_guild_button_calls_staff_approve_guild(monkeypatch):
     await view.approve_guild_btn.callback(interaction)
     assert captured["id"] == 42
     assert captured["actor"] is interaction.user
-    interaction.response.edit_message.assert_awaited_once()
+    # Post-defer: panel update goes through followup.edit_message,
+    # confirmation through followup.send (content is a kwarg because
+    # safe_followup unpacks via **kwargs).
+    interaction.response.defer.assert_awaited_once()
+    interaction.followup.edit_message.assert_awaited_once()
     interaction.followup.send.assert_awaited_once()
-    args, _ = interaction.followup.send.call_args
-    assert "Approved" in args[0]
-    assert "#42" in args[0]
+    content = interaction.followup.send.await_args.kwargs["content"]
+    assert "Approved" in content
+    assert "#42" in content
 
 
 async def test_publish_button_calls_staff_publish(monkeypatch):
@@ -190,22 +212,24 @@ async def test_publish_button_calls_staff_publish(monkeypatch):
     interaction = _staff_interaction()
     await view.publish_btn.callback(interaction)
     assert captured["id"] == 11
-    args, _ = interaction.followup.send.call_args
-    assert "Published" in args[0]
+    content = interaction.followup.send.await_args.kwargs["content"]
+    assert "Published" in content
 
 
-async def test_reject_button_calls_reject_with_staff_actor_kind(monkeypatch):
+async def test_reject_button_calls_staff_reject(monkeypatch):
+    """The reject button must route through staff_reject (the
+    permission-checked variant), not the low-level reject primitive.
+    """
     captured: dict = {}
 
-    async def _capture(strategy_id, *, actor, actor_kind, reason=None):
+    async def _capture(strategy_id, *, staff_actor, reason=None):
         captured["id"] = strategy_id
-        captured["actor"] = actor
-        captured["actor_kind"] = actor_kind
+        captured["actor"] = staff_actor
         result = MagicMock()
         result.action = "rejected"
         return result
 
-    monkeypatch.setattr(btd6_strategy_mutation, "reject", _capture)
+    monkeypatch.setattr(btd6_strategy_mutation, "staff_reject", _capture)
 
     async def _refresh(sid):
         return _strategy(sid=sid, approval_status="rejected")
@@ -216,7 +240,9 @@ async def test_reject_button_calls_reject_with_staff_actor_kind(monkeypatch):
     interaction = _staff_interaction()
     await view.reject_btn.callback(interaction)
     assert captured["id"] == 5
-    assert captured["actor_kind"] == "staff"
+    assert captured["actor"] is interaction.user
+    interaction.response.defer.assert_awaited_once()
+    interaction.followup.edit_message.assert_awaited_once()
 
 
 async def test_unpublish_button_calls_unpublish_on_published_strategy(monkeypatch):
@@ -239,11 +265,16 @@ async def test_unpublish_button_calls_unpublish_on_published_strategy(monkeypatc
     interaction = _staff_interaction()
     await view.unpublish_btn.callback(interaction)
     assert captured["id"] == 99
-    args, _ = interaction.followup.send.call_args
-    assert "Unpublished" in args[0]
+    content = interaction.followup.send.await_args.kwargs["content"]
+    assert "Unpublished" in content
 
 
 async def test_mutation_error_surfaces_as_typed_ephemeral_reply(monkeypatch):
+    """Typed mutation errors route through safe_followup (post-defer)
+    with stable user-facing wording — the service's message is
+    surfaced, but the exception class name is not leaked.
+    """
+
     async def _raise(strategy_id, **kw):
         raise btd6_strategy_mutation.InvalidStrategyValueError("bad value")
 
@@ -252,19 +283,25 @@ async def test_mutation_error_surfaces_as_typed_ephemeral_reply(monkeypatch):
     view = StrategyReviewView(_strategy(sid=42))
     interaction = _staff_interaction()
     await view.publish_btn.callback(interaction)
-    interaction.response.send_message.assert_awaited_once()
-    args, kwargs = interaction.response.send_message.call_args
-    assert "InvalidStrategyValueError" in args[0]
-    assert "bad value" in args[0]
+    interaction.response.defer.assert_awaited_once()
+    interaction.followup.send.assert_awaited_once()
+    kwargs = interaction.followup.send.await_args.kwargs
+    content = kwargs["content"]
+    assert "Could not update strategy #42" in content
+    assert "bad value" in content
+    assert "InvalidStrategyValueError" not in content
     assert kwargs.get("ephemeral") is True
-    # No refresh / followup happened because the mutation failed.
-    interaction.response.edit_message.assert_not_awaited()
-    interaction.followup.send.assert_not_awaited()
+    # No refresh / panel edit happened because the mutation failed.
+    interaction.followup.edit_message.assert_not_awaited()
+    interaction.response.send_message.assert_not_awaited()
 
 
 async def test_unauthorized_mutation_error_uses_ephemeral_branch(monkeypatch):
     """Server-side gate (mutation service) is the source of truth; the
-    view's interaction_check is just a UX courtesy."""
+    view's interaction_check is just a UX courtesy. The error message
+    surfaces the service's text but not the exception class name.
+    """
+
     async def _raise(strategy_id, **kw):
         raise btd6_strategy_mutation.UnauthorizedStrategyMutationError("nope")
 
@@ -277,8 +314,11 @@ async def test_unauthorized_mutation_error_uses_ephemeral_branch(monkeypatch):
     view = StrategyReviewView(_strategy(sid=42))
     interaction = _staff_interaction()
     await view.approve_guild_btn.callback(interaction)
-    args, _ = interaction.response.send_message.call_args
-    assert "UnauthorizedStrategyMutationError" in args[0]
+    interaction.followup.send.assert_awaited_once()
+    content = interaction.followup.send.await_args.kwargs["content"]
+    assert "Could not update strategy #42" in content
+    assert "nope" in content
+    assert "UnauthorizedStrategyMutationError" not in content
 
 
 # ---------------------------------------------------------------------------
@@ -293,7 +333,7 @@ async def test_unauthorized_mutation_error_uses_ephemeral_branch(monkeypatch):
     [
         ("approve_guild_btn", "staff_approve_guild"),
         ("publish_btn", "staff_publish"),
-        ("reject_btn", "reject"),
+        ("reject_btn", "staff_reject"),
     ],
 )
 async def test_button_only_writes_via_mutation_service(
@@ -327,4 +367,170 @@ async def test_button_only_writes_via_mutation_service(
     handler = getattr(view, button_attr)
     await handler.callback(interaction)
     assert called_mutation["hit"] is True
+    db_explode.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Blocker PR-1: defer-before-work and refresh-failure recovery pins.
+# ---------------------------------------------------------------------------
+
+
+async def test_mutate_defers_before_calling_mutation_service(monkeypatch):
+    """The 3-second token must be acknowledged with defer() BEFORE the
+    mutation service is invoked. Pattern from
+    tests/unit/views/test_shop_select_defer.py.
+    """
+    call_order: list[str] = []
+
+    async def _capture(strategy_id, **kw):
+        call_order.append("mutate")
+        result = MagicMock()
+        result.action = "staff_approved_guild"
+        return result
+
+    monkeypatch.setattr(btd6_strategy_mutation, "staff_approve_guild", _capture)
+
+    async def _refresh(sid):
+        return _strategy(sid=sid, approval_status="approved")
+
+    monkeypatch.setattr(db, "get_strategy", _refresh)
+
+    view = StrategyReviewView(_strategy(sid=42))
+    interaction = _staff_interaction()
+
+    async def _defer(**_kw):
+        call_order.append("defer")
+        # Mirror _staff_interaction's stateful flip so post-defer
+        # routing still works.
+        interaction.response.is_done = lambda: True
+
+    interaction.response.defer.side_effect = _defer
+
+    await view.approve_guild_btn.callback(interaction)
+    assert call_order[:2] == ["defer", "mutate"]
+
+
+async def test_refresh_failure_after_successful_mutation_uses_followup(monkeypatch):
+    """If the post-mutation refresh DB fetch raises, the user still
+    gets a clean ephemeral followup — no raw discord.py exception
+    escapes.
+    """
+
+    async def _ok(strategy_id, **kw):
+        result = MagicMock()
+        result.action = "staff_approved_guild"
+        return result
+
+    monkeypatch.setattr(btd6_strategy_mutation, "staff_approve_guild", _ok)
+
+    async def _fail(sid):
+        raise RuntimeError("db went away")
+
+    monkeypatch.setattr(db, "get_strategy", _fail)
+
+    view = StrategyReviewView(_strategy(sid=42))
+    interaction = _staff_interaction()
+    # Must not raise.
+    await view.approve_guild_btn.callback(interaction)
+
+    interaction.response.defer.assert_awaited_once()
+    interaction.followup.send.assert_awaited_once()
+    kwargs = interaction.followup.send.await_args.kwargs
+    assert "refresh failed" in kwargs["content"]
+    assert kwargs.get("ephemeral") is True
+    interaction.response.send_message.assert_not_awaited()
+
+
+async def test_missing_strategy_refresh_uses_followup(monkeypatch):
+    """If the strategy row is gone post-mutation, the user gets a
+    clean ephemeral acknowledgement via followup.send."""
+
+    async def _ok(strategy_id, **kw):
+        result = MagicMock()
+        result.action = "rejected"
+        return result
+
+    monkeypatch.setattr(btd6_strategy_mutation, "staff_reject", _ok)
+
+    async def _none(sid):
+        return None
+
+    monkeypatch.setattr(db, "get_strategy", _none)
+
+    view = StrategyReviewView(_strategy(sid=42))
+    interaction = _staff_interaction()
+    await view.reject_btn.callback(interaction)
+
+    interaction.followup.send.assert_awaited_once()
+    kwargs = interaction.followup.send.await_args.kwargs
+    assert "gone from the table" in kwargs["content"]
+    assert kwargs.get("ephemeral") is True
+
+
+async def test_safe_edit_failure_still_sends_followup_warning(monkeypatch):
+    """If the panel edit fails (token expired mid-mutation, message
+    deleted, etc.) the user still gets a warning followup so the
+    mutation result is acknowledged.
+    """
+
+    async def _ok(strategy_id, **kw):
+        result = MagicMock()
+        result.action = "staff_approved_guild"
+        return result
+
+    monkeypatch.setattr(btd6_strategy_mutation, "staff_approve_guild", _ok)
+
+    async def _refresh(sid):
+        return _strategy(sid=sid, approval_status="approved")
+
+    monkeypatch.setattr(db, "get_strategy", _refresh)
+
+    from views.btd6 import strategy_review as sr_mod
+
+    async def _edit_fails(*_args, **_kwargs):
+        return False
+
+    monkeypatch.setattr(sr_mod, "safe_edit", _edit_fails)
+
+    view = StrategyReviewView(_strategy(sid=42))
+    interaction = _staff_interaction()
+    await view.approve_guild_btn.callback(interaction)
+
+    interaction.followup.send.assert_awaited_once()
+    content = interaction.followup.send.await_args.kwargs["content"]
+    assert "panel could not be refreshed" in content
+
+
+async def test_mutate_bails_when_defer_fails(monkeypatch):
+    """If safe_defer returns False (token expired before defer
+    reached Discord) the mutation, refresh, and followup paths must
+    all be skipped — there's no usable interaction left.
+    """
+    mutation_called = {"hit": False}
+
+    async def _capture(*_a, **_kw):
+        mutation_called["hit"] = True
+        return MagicMock(action="staff_approved_guild")
+
+    monkeypatch.setattr(btd6_strategy_mutation, "staff_approve_guild", _capture)
+
+    from views.btd6 import strategy_review as sr_mod
+
+    async def _defer_fails(*_args, **_kwargs):
+        return False
+
+    monkeypatch.setattr(sr_mod, "safe_defer", _defer_fails)
+
+    db_explode = AsyncMock(
+        side_effect=AssertionError("DB must not be touched after defer failure"),
+    )
+    monkeypatch.setattr(db, "get_strategy", db_explode)
+
+    view = StrategyReviewView(_strategy(sid=42))
+    interaction = _staff_interaction()
+    await view.approve_guild_btn.callback(interaction)
+
+    assert mutation_called["hit"] is False
+    interaction.followup.send.assert_not_awaited()
+    interaction.followup.edit_message.assert_not_awaited()
     db_explode.assert_not_awaited()

--- a/tests/unit/views/btd6/test_strategy_submit.py
+++ b/tests/unit/views/btd6/test_strategy_submit.py
@@ -1,4 +1,10 @@
-"""PR-F tests for the strategy submission modal."""
+"""PR-F + Blocker PR-1 tests for the strategy submission modal.
+
+The modal now defers before the DB insert and delivers every result
+through ``safe_followup`` to avoid 3-second token expiry. Only the
+synchronous guild-context check still uses
+``interaction.response.send_message`` (pre-defer, no I/O).
+"""
 
 from __future__ import annotations
 
@@ -18,10 +24,23 @@ def _set_inputs(modal, **fields):
 
 
 def _interaction(guild_id: int = 100):
+    """Build an interaction mock that flips ``response.is_done``
+    after ``defer()`` so the safe_* helpers route correctly.
+    """
     interaction = MagicMock()
     interaction.guild = SimpleNamespace(id=guild_id) if guild_id else None
     interaction.user = SimpleNamespace(id=555, display_name="alice", name="alice")
+
+    deferred = {"done": False}
+    interaction.response.is_done = lambda: deferred["done"]
+
+    async def _defer(**_kw):
+        deferred["done"] = True
+
+    interaction.response.defer = AsyncMock(side_effect=_defer)
     interaction.response.send_message = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    interaction.original_response = AsyncMock()
     return interaction
 
 
@@ -53,24 +72,36 @@ async def test_submit_calls_chokepoint(monkeypatch):
     assert captured["map_name"] == "Bloody Puddles"
     assert captured["mode"] == "CHIMPS"
     assert captured["hero"] == "Geraldo"
-    interaction.response.send_message.assert_awaited_once()
-    msg = interaction.response.send_message.await_args.args[0]
+    # Post-defer: success message arrives via safe_followup (content
+    # passed as kwarg because safe_followup unpacks via **kwargs).
+    interaction.response.defer.assert_awaited_once()
+    interaction.followup.send.assert_awaited_once()
+    msg = interaction.followup.send.await_args.kwargs["content"]
     assert "#42" in msg
 
 
 @pytest.mark.asyncio
 async def test_submit_requires_guild_context():
+    """The guild-context check is synchronous and runs BEFORE defer,
+    so it still uses interaction.response.send_message."""
     modal = StrategySubmitModal()
     _set_inputs(modal, title="x", summary="y", map="", mode="", hero="")
     interaction = _interaction(guild_id=0)
     interaction.guild = None
     await modal.on_submit(interaction)
+    interaction.response.send_message.assert_awaited_once()
     msg = interaction.response.send_message.await_args.args[0]
     assert "guild context" in msg
+    # No defer happened — the validation refused before any I/O.
+    interaction.response.defer.assert_not_awaited()
+    interaction.followup.send.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_submit_surfaces_validation_error(monkeypatch):
+    """Validation errors come out via safe_followup (post-defer),
+    surfacing the typed exc message but not the class name."""
+
     async def _submit(**_kw):
         raise btd6_strategy_mutation.InvalidStrategyValueError("missing field")
 
@@ -80,5 +111,61 @@ async def test_submit_surfaces_validation_error(monkeypatch):
     _set_inputs(modal, title="", summary="", map="", mode="", hero="")
     interaction = _interaction()
     await modal.on_submit(interaction)
-    msg = interaction.response.send_message.await_args.args[0]
+    interaction.followup.send.assert_awaited_once()
+    msg = interaction.followup.send.await_args.kwargs["content"]
     assert "missing field" in msg
+    assert "InvalidStrategyValueError" not in msg
+
+
+@pytest.mark.asyncio
+async def test_modal_defers_before_submit_strategy(monkeypatch):
+    """defer() must be awaited BEFORE submit_strategy runs so the
+    3-second token doesn't expire under DB load.
+    """
+    call_order: list[str] = []
+
+    async def _submit(**_kw):
+        call_order.append("submit")
+        return MagicMock(strategy_id=42, action="submitted")
+
+    monkeypatch.setattr(btd6_strategy_mutation, "submit_strategy", _submit)
+
+    modal = StrategySubmitModal()
+    _set_inputs(modal, title="t", summary="s", map="", mode="", hero="")
+    interaction = _interaction()
+
+    deferred = {"done": False}
+
+    async def _defer(**_kw):
+        call_order.append("defer")
+        deferred["done"] = True
+        interaction.response.is_done = lambda: True
+
+    interaction.response.defer.side_effect = _defer
+
+    await modal.on_submit(interaction)
+    assert call_order[:2] == ["defer", "submit"]
+
+
+@pytest.mark.asyncio
+async def test_modal_unexpected_error_uses_safe_followup(monkeypatch):
+    """Unexpected exceptions are surfaced via safe_followup with a
+    generic user-facing message — no class name leakage.
+    """
+
+    async def _submit(**_kw):
+        raise RuntimeError("database connection died")
+
+    monkeypatch.setattr(btd6_strategy_mutation, "submit_strategy", _submit)
+
+    modal = StrategySubmitModal()
+    _set_inputs(modal, title="t", summary="s", map="", mode="", hero="")
+    interaction = _interaction()
+    # Must not raise.
+    await modal.on_submit(interaction)
+
+    interaction.followup.send.assert_awaited_once()
+    msg = interaction.followup.send.await_args.kwargs["content"]
+    assert "Unexpected error" in msg
+    assert "RuntimeError" not in msg
+    assert "database connection died" not in msg


### PR DESCRIPTION
## Summary

First blocker PR for the BTD6 cog. Discord's 3-second interaction token expired under DB latency in every BTD6 slash command and view callback — every path did its DB/service work **before** calling `response.send_message`, so the user saw "Interaction failed" with no recovery path. Also `reject()` was the only staff write that skipped both `_is_staff()` and the existence check that `staff_approve_guild` / `staff_publish` / `unpublish` all enforce.

### Confirmed blockers fixed

1. **Slash commands without defer** — `/btd6 pending`, `/browse`, `/mine`, `/strategy`, `/source-health` now `safe_defer` before any DB work.
2. **`_refresh_or_followup` calling `followup.send` without prior defer** — `StrategyReviewView._mutate` now defers first (component `defer_update`); the refresh helper assumes the caller deferred and uses `safe_followup` / `safe_edit`.
3. **`reject()` missing staff/existence checks** — new `staff_reject()` mirrors `reject()`'s exact write semantics plus adds `_is_staff()` and `get_strategy()-is-None` guards. `reject()` body unchanged; docstring marks it the low-level primitive reserved for future non-staff actor flows.
4. **Live source/cache/ingestion surfaces untouched** — out-of-scope commands (`ask`, `tower`, `hero`, `round`, `grounding`, `latest-data`, `sources`, `strategies`, `strategy-audit`, `why-no-response`, `BTD6AskModal`, etc.) left as-is for follow-up PRs.

### Files changed

| Area | File | Change |
|---|---|---|
| Service | `disbot/services/btd6_strategy_mutation.py` | Add `staff_reject()`; docstring on `reject()`; extend `__all__` |
| View | `disbot/views/btd6/strategy_review.py` | `_mutate` defers first, stable error wording via `safe_followup`; `_refresh_or_followup` uses `safe_followup` + `safe_edit` with bool-return fallback; `reject_btn` routes through `staff_reject` |
| View | `disbot/views/btd6/strategy_submit.py` | Guild check stays pre-defer; then defer + `safe_followup` for every error/success |
| Cog | `disbot/cogs/btd6_cog.py` | Five named slash commands defer before builder work; `/btd6 pending` uses uniform `safe_followup` loop (no more illegal `response.send_message` + `followup.send` mix) |
| Tests | `tests/unit/services/test_btd6_strategy_staff_reject.py` (new) | Pins write-semantics match with `reject()`, staff/admin permission gate, refusal on missing strategy, `__all__` membership |
| Tests | `tests/unit/views/btd6/test_strategy_review.py` | Interaction mock now flips `response.is_done` after defer; assertions moved to `followup.edit_message` / `followup.send`; added defer-ordering, refresh-failure, missing-strategy, `safe_edit`-failure, and defer-failure recovery tests |
| Tests | `tests/unit/views/btd6/test_strategy_submit.py` | Same mock upgrade; added defer-ordering test and unexpected-error `safe_followup` test |
| Tests | `tests/unit/cogs/test_btd6_cog.py` | Parametrized defer-ordering test across all five slash commands, patching builders at their source module (cog uses function-body lazy imports) |

Stable user-facing wording throughout: error messages surface the typed service text but never the exception class name.

## Test plan

Automated (all green):
- [x] `python3.10 -m pytest tests/unit/services/test_btd6_strategy_staff_reject.py tests/unit/services/test_btd6_strategy_mutation.py tests/unit/views/btd6/test_strategy_review.py tests/unit/views/btd6/test_strategy_submit.py tests/unit/cogs/test_btd6_cog.py -q` → **57 passed**
- [x] `python3.10 -m pytest tests/ -q` → **5446 passed, 3 skipped** (prefix/slash parity, command surface ledger unaffected)
- [x] `python3.10 scripts/check_architecture.py --mode strict` → exit 0 (no new layer violations)
- [x] `black --check` / `isort --check-only` / `ruff check` / `mypy` → clean on all changed files
- [x] Grep verification: zero unsafe `followup.send` in scoped files; zero qualified `btd6_strategy_mutation.reject` or `from … import reject` callers; zero bare `reject(` calls in scope

Manual smoke (requires live Discord guild — for the reviewer):
- [ ] `/btd6 pending` with several pending rows — confirm multi-embed renders without "Interaction failed"
- [ ] `/btd6 browse`, `/btd6 mine`, `/btd6 strategy <id>`, `/btd6 source-health` — each renders cleanly
- [ ] `StrategyReviewView` buttons (Approve guild / Publish global / Reject / Unpublish) — panel updates and ephemeral confirmation appears
- [ ] Timeout-path smoke: artificially delay a builder/mutation by > 3 s (e.g. `asyncio.sleep(4)` patch) — confirm no "Interaction failed", followup still appears
- [ ] Force a refresh failure (drop the strategy row mid-click) — "refresh failed" ephemeral appears
- [ ] Non-staff click on a review button — ephemeral denial, no DB write

## Out of scope (separate PRs)

- AI natural-language routing ownership (`/btd6 ask`, `BTD6AskModal`)
- Ninja Kiwi endpoint expansion
- Cache cadence redesign
- Full strategy authoring flow
- Global setup/settings expansion
- Whether to eventually rename `reject()` → `_reject_unchecked()` (deferred to a follow-up)

https://claude.ai/code/session_019W6Njrg1GRVQhi3JjSXNn2

---
_Generated by [Claude Code](https://claude.ai/code/session_019W6Njrg1GRVQhi3JjSXNn2)_