### PR TITLE
BTD6: schedule all sources + live event reader + grounding on !btd6 ask

### DIFF
--- a/disbot/cogs/btd6/_builders.py
+++ b/disbot/cogs/btd6/_builders.py
@@ -368,6 +368,147 @@ async def build_grounding_embed(
 
 
 # ---------------------------------------------------------------------------
+# live-event builders (race / boss / ct / odyssey / event)
+# ---------------------------------------------------------------------------
+
+
+def _ms_to_human(ms: Any) -> str:
+    """Render a milliseconds-since-epoch value as ``YYYY-MM-DD HH:MM UTC``.
+
+    Returns ``"—"`` for missing / non-numeric inputs. Live event APIs
+    use ms timestamps consistently across race / boss / odyssey / CT.
+    """
+    if not isinstance(ms, (int, float)) or ms <= 0:
+        return "—"
+    try:
+        from datetime import datetime, timezone
+
+        return datetime.fromtimestamp(ms / 1000.0, tz=timezone.utc).strftime(
+            "%Y-%m-%d %H:%M UTC",
+        )
+    except (OverflowError, OSError, ValueError):
+        return "—"
+
+
+def _event_window(body: dict[str, Any]) -> str:
+    """Render ``start_ms`` → ``end_ms`` as a single human window string."""
+    start = _ms_to_human(body.get("start_ms"))
+    end = _ms_to_human(body.get("end_ms"))
+    if start == "—" and end == "—":
+        return "—"
+    return f"{start} → {end}"
+
+
+_LIVE_EVENT_SPECS: dict[str, dict[str, str]] = {
+    # entity_kind → display config
+    "btd6_race": {
+        "title": "🐵 BTD6 — Races",
+        "noun": "race",
+        "source_key": "nk_btd6_races",
+    },
+    "btd6_boss": {
+        "title": "🐵 BTD6 — Bosses",
+        "noun": "boss event",
+        "source_key": "nk_btd6_bosses",
+    },
+    "btd6_ct": {
+        "title": "🐵 BTD6 — Contested Territory",
+        "noun": "CT event",
+        "source_key": "nk_btd6_ct",
+    },
+    "btd6_odyssey": {
+        "title": "🐵 BTD6 — Odysseys",
+        "noun": "odyssey",
+        "source_key": "nk_btd6_odyssey",
+    },
+    "btd6_event": {
+        "title": "🐵 BTD6 — Events",
+        "noun": "event",
+        "source_key": "nk_btd6_events",
+    },
+}
+
+
+async def build_live_events_embed(
+    entity_kind: str,
+    *,
+    limit: int = 5,
+) -> discord.Embed:
+    """Render the most-recent live events for an entity_kind.
+
+    Accepts either the full ``btd6_<kind>`` form or the short ``<kind>``
+    form (race / boss / ct / odyssey / event). Unknown kinds yield a
+    user-facing error embed rather than raising — surfaces just pass
+    user input straight through.
+    """
+    if not entity_kind.startswith("btd6_"):
+        entity_kind = f"btd6_{entity_kind}"
+    spec = _LIVE_EVENT_SPECS.get(entity_kind)
+    if spec is None:
+        return discord.Embed(
+            title="🐵 BTD6 — Unknown kind",
+            description=(
+                f"`{entity_kind}` isn't a known live-event kind. Try one of: "
+                "`race`, `boss`, `ct`, `odyssey`, `event`."
+            ),
+            color=discord.Color.red(),
+        )
+
+    from utils.db import btd6_sources as btd6_db
+
+    rows = await btd6_db.search_facts(entity_kind=entity_kind, limit=limit)
+    embed = discord.Embed(
+        title=spec["title"],
+        description=(
+            f"Most recent {spec['noun']} envelopes from `btd6_facts` "
+            f"(source `{spec['source_key']}`). No provider involvement."
+        ),
+        color=discord.Color.gold(),
+    )
+    if not rows:
+        embed.description = (
+            f"No {spec['noun']} facts recorded yet. Try "
+            f"`!btd6 refresh-source {spec['source_key']}` to fetch live data."
+        )
+        return embed
+
+    for row in rows:
+        body = row.get("body_json") if isinstance(row.get("body_json"), dict) else {}
+        name = body.get("name") or row.get("entity_key") or "—"
+        window = _event_window(body)
+        lines = [
+            f"id=`{row['entity_key']}`",
+            f"window: {window}",
+        ]
+        score_fragments = []
+        if isinstance(body.get("total_scores"), int):
+            score_fragments.append(f"scores={body['total_scores']}")
+        for key, label in (
+            ("total_scores_standard", "standard"),
+            ("total_scores_elite", "elite"),
+        ):
+            value = body.get(key)
+            if isinstance(value, int):
+                score_fragments.append(f"{label}={value}")
+        if isinstance(body.get("boss_type"), str) and body["boss_type"]:
+            score_fragments.append(f"type=`{body['boss_type']}`")
+        if score_fragments:
+            lines.append(" · ".join(score_fragments))
+        when = (
+            row["fetched_at"].isoformat(timespec="minutes")
+            if row.get("fetched_at")
+            else "—"
+        )
+        lines.append(f"fetched=`{when}` · v{row['version']}")
+        embed.add_field(
+            name=str(name)[:256],
+            value="\n".join(lines),
+            inline=False,
+        )
+    return embed
+
+
+# ---------------------------------------------------------------------------
 # refresh-source result builder
 # ---------------------------------------------------------------------------
 
@@ -499,6 +640,7 @@ __all__ = [
     "build_grounding_embed",
     "build_hero_embed",
     "build_latest_data_embed",
+    "build_live_events_embed",
     "build_pending_review_payload",
     "build_refresh_source_embed",
     "build_source_health_embed",

--- a/disbot/cogs/btd6/_embeds.py
+++ b/disbot/cogs/btd6/_embeds.py
@@ -52,6 +52,21 @@ def response_to_embed(response: Any) -> discord.Embed:
             value=response.version_sensitivity,
             inline=False,
         )
+    live_facts = getattr(response, "live_facts", ()) or ()
+    if live_facts:
+        value = "\n".join(f"• {fact}" for fact in live_facts)
+        if len(value) > 1024:
+            kept: list[str] = []
+            running = 0
+            for fact in live_facts:
+                line = f"• {fact}"
+                if running + len(line) + 1 > 990:
+                    break
+                kept.append(line)
+                running += len(line) + 1
+            dropped = len(live_facts) - len(kept)
+            value = "\n".join(kept) + f"\n… ({dropped} more)"
+        embed.add_field(name="Live data", value=value, inline=False)
     if response.follow_up:
         embed.add_field(name="Follow-up", value=response.follow_up, inline=False)
     if response.sources:

--- a/disbot/cogs/btd6_cog.py
+++ b/disbot/cogs/btd6_cog.py
@@ -265,6 +265,18 @@ class BTD6Cog(commands.Cog):
 
         await ctx.send(embed=await build_latest_data_embed())
 
+    @btd6_group.command(name="live")  # type: ignore[arg-type]
+    async def btd6_live(
+        self,
+        ctx: commands.Context,
+        kind: str = "race",
+        limit: int = 5,
+    ) -> None:
+        """Show recent live events for ``kind`` (race / boss / ct / odyssey / event)."""
+        from cogs.btd6._builders import build_live_events_embed
+
+        await ctx.send(embed=await build_live_events_embed(kind, limit=limit))
+
     @btd6_group.command(name="grounding")  # type: ignore[arg-type]
     async def btd6_grounding(
         self,
@@ -562,6 +574,23 @@ class BTD6Cog(commands.Cog):
         if not await safe_defer(interaction, ephemeral=True):
             return
         embed = await build_latest_data_embed()
+        await safe_followup(interaction, embed=embed, ephemeral=True)
+
+    @btd6_app_group.command(
+        name="live",
+        description="Show recent live events (race/boss/ct/odyssey/event).",
+    )
+    async def btd6_live_slash(
+        self,
+        interaction: discord.Interaction,
+        kind: str = "race",
+        limit: int = 5,
+    ) -> None:
+        from cogs.btd6._builders import build_live_events_embed
+
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        embed = await build_live_events_embed(kind, limit=limit)
         await safe_followup(interaction, embed=embed, ephemeral=True)
 
     @btd6_app_group.command(

--- a/disbot/services/btd6_ai_service.py
+++ b/disbot/services/btd6_ai_service.py
@@ -143,12 +143,37 @@ async def answer_question(
     resolver via the M2 stage). The deterministic baseline is always
     produced first; ``btd6_ai_enabled`` is a no-op shim kept for
     backwards-compatible callers.
+
+    Live grounding from ``btd6_context_service`` is best-effort: any
+    failure leaves the deterministic response unchanged. The bundle is
+    already sanitised + provenance-labelled before reaching this layer.
     """
     intent = resolve(text)
     response = deterministic_answer(intent)
+    response = await _attach_live_grounding(text, response)
     if augment_with_ai and btd6_ai_enabled() and task_enabled(AITask.HELP_ANSWER):
         return await _augment_with_ai(intent, response, guild_id=guild_id)
     return response
+
+
+async def _attach_live_grounding(text: str, response: BTD6Response) -> BTD6Response:
+    """Populate ``response.live_facts`` from ``btd6_context_service``.
+
+    Best-effort: any exception (DB unavailable, context build failure)
+    falls back to the unchanged ``response``. The same service backs
+    the AI Platform natural-language stage so the two surfaces share
+    one grounding pipeline rather than each maintaining its own.
+    """
+    try:
+        from services import btd6_context_service
+
+        ctx = await btd6_context_service.build(text)
+    except Exception:  # noqa: BLE001 — never block on grounding
+        logger.debug("btd6_ai_service: live grounding unavailable", exc_info=True)
+        return response
+    if not ctx.facts:
+        return response
+    return replace(response, live_facts=ctx.facts)
 
 
 def _augmentation_payload(
@@ -180,6 +205,10 @@ def _augmentation_payload(
             "version_sensitivity": response.version_sensitivity,
             "confidence": response.confidence,
         },
+        # Already-sanitised live grounding strings. The provider sees
+        # these only as untrusted data; deterministic fields above stay
+        # authoritative.
+        "live_facts": list(response.live_facts),
     }
 
 

--- a/disbot/services/btd6_ingestion_supervisor.py
+++ b/disbot/services/btd6_ingestion_supervisor.py
@@ -36,8 +36,19 @@ _DEFAULT_INTERVAL_S: int = int(os.getenv("BTD6_INGESTION_DEFAULT_INTERVAL_S", "3
 _STOP_TIMEOUT_S: int = 30
 
 _SOURCE_INTERVALS: dict[str, int] = {
+    # Live rotations — refresh frequently so the bot sees the current
+    # race / boss / odyssey / event within ~one cycle.
+    "nk_btd6_events": 1800,
+    "nk_btd6_races": 1800,
+    "nk_btd6_bosses": 1800,
+    "nk_btd6_odyssey": 1800,
+    # CT runs as a dependency parent: the supervisor calls
+    # refresh_with_dependencies(nk_btd6_ct), which expands into the
+    # per-tile child fetch automatically.
     "nk_btd6_ct": 1800,
-    # races, bosses, odyssey added in later ingestion expansion PRs
+    # Map directory is comparatively static; long backoff decay so a
+    # single failure doesn't pin it offline for the rest of the day.
+    "nk_btd6_maps": 86400,
 }
 
 _BACKOFF_BASE_S: int = 30

--- a/disbot/services/btd6_response_builder.py
+++ b/disbot/services/btd6_response_builder.py
@@ -41,6 +41,10 @@ class BTD6Response:
     fields: tuple[tuple[str, str], tuple[str, str]] | tuple = field(
         default_factory=tuple,
     )
+    # Optional live grounding bundle from btd6_context_service. Already
+    # sanitised + provenance-labelled; the renderer surfaces these as a
+    # dedicated "Live data" field separate from the deterministic body.
+    live_facts: tuple[str, ...] = ()
 
 
 def _source_label() -> str:

--- a/tests/unit/cogs/test_btd6_boundaries.py
+++ b/tests/unit/cogs/test_btd6_boundaries.py
@@ -143,6 +143,8 @@ def _expected_parity_names() -> set[str]:
         "latest-data",
         "grounding",
         "refresh-source",
+        # Live-event reader (parametrized by kind):
+        "live",
         # PR-F additions:
         "browse",
         "mine",

--- a/tests/unit/cogs/test_btd6_live_events_command.py
+++ b/tests/unit/cogs/test_btd6_live_events_command.py
@@ -1,0 +1,443 @@
+"""Tests for the live-event read-only surfaces.
+
+Covers the shared `build_live_events_embed` builder plus the five
+`!btd6 race / boss / ct / odyssey / event` prefix commands and their
+slash twins.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from cogs.btd6._builders import (
+    _event_window,
+    _ms_to_human,
+    build_live_events_embed,
+)
+from cogs.btd6_cog import BTD6Cog
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fact_row(
+    *,
+    entity_kind: str,
+    entity_key: str,
+    body: dict,
+    fetched_at: datetime | None = None,
+) -> dict:
+    return {
+        "id": 1,
+        "source_id": 1,
+        "fact_type": "btd6.live",
+        "entity_kind": entity_kind,
+        "entity_key": entity_key,
+        "body_json": body,
+        "game_version": "47.0",
+        "fetched_at": fetched_at or datetime(2026, 5, 27, 12, 0, tzinfo=timezone.utc),
+        "validated_at": None,
+        "confidence": 1.0,
+        "version": 1,
+    }
+
+
+def _slash_interaction() -> MagicMock:
+    interaction = MagicMock()
+    interaction.guild = MagicMock()
+    interaction.guild.id = 555
+    interaction.user = MagicMock()
+    interaction.user.id = 7777
+    interaction.response.is_done = lambda: False
+    interaction.response.defer = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def test_ms_to_human_handles_missing_or_invalid_values():
+    assert _ms_to_human(None) == "—"
+    assert _ms_to_human("not-a-number") == "—"
+    assert _ms_to_human(0) == "—"
+    assert _ms_to_human(-1) == "—"
+
+
+def test_ms_to_human_formats_unix_ms():
+    # Format check, not exact-date check — leap-second / epoch math
+    # is the stdlib's job. 1779019200000 → 2026-05-17 12:00 UTC.
+    rendered = _ms_to_human(1779019200000)
+    assert rendered.endswith(" UTC")
+    assert rendered.startswith("2026-")
+
+
+def test_event_window_renders_both_ends():
+    body = {"start_ms": 1779019200000, "end_ms": 1779105600000}
+    assert "→" in _event_window(body)
+
+
+def test_event_window_dash_when_both_missing():
+    assert _event_window({}) == "—"
+
+
+# ---------------------------------------------------------------------------
+# build_live_events_embed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_live_events_embed_unknown_kind_returns_error_embed():
+    embed = await build_live_events_embed("not_a_kind")
+    assert embed.color == discord.Color.red()
+    assert "Unknown" in (embed.title or "")
+    assert "race" in (embed.description or "")
+
+
+@pytest.mark.asyncio
+async def test_build_live_events_embed_accepts_short_form(monkeypatch):
+    from utils.db import btd6_sources as btd6_db
+
+    seen: dict = {}
+
+    async def _fake(*, entity_kind=None, fact_type=None, limit=50):
+        seen["entity_kind"] = entity_kind
+        return []
+
+    monkeypatch.setattr(btd6_db, "search_facts", _fake)
+    # ``race`` (short) should be normalised to ``btd6_race``.
+    await build_live_events_embed("race")
+    assert seen["entity_kind"] == "btd6_race"
+
+
+@pytest.mark.asyncio
+async def test_build_live_events_embed_empty_shows_hint(monkeypatch):
+    from utils.db import btd6_sources as btd6_db
+
+    async def _empty(*, entity_kind=None, fact_type=None, limit=50):
+        return []
+
+    monkeypatch.setattr(btd6_db, "search_facts", _empty)
+    embed = await build_live_events_embed("btd6_race")
+    desc = embed.description or ""
+    assert "No race facts" in desc
+    assert "refresh-source nk_btd6_races" in desc
+
+
+@pytest.mark.asyncio
+async def test_build_live_events_embed_race_renders_fields(monkeypatch):
+    from utils.db import btd6_sources as btd6_db
+
+    async def _fake(*, entity_kind=None, fact_type=None, limit=50):
+        assert entity_kind == "btd6_race"
+        return [
+            _fact_row(
+                entity_kind="btd6_race",
+                entity_key="reversed_loop_2026_05",
+                body={
+                    "id": "reversed_loop_2026_05",
+                    "name": "Reversed Loop",
+                    "start_ms": 1779019200000,
+                    "end_ms": 1779105600000,
+                    "total_scores": 9_321,
+                },
+            ),
+        ]
+
+    monkeypatch.setattr(btd6_db, "search_facts", _fake)
+
+    embed = await build_live_events_embed("btd6_race", limit=1)
+    assert embed.title == "🐵 BTD6 — Races"
+    assert len(embed.fields) == 1
+    field = embed.fields[0]
+    assert field.name == "Reversed Loop"
+    value = field.value or ""
+    assert "`reversed_loop_2026_05`" in value
+    assert "scores=9321" in value
+    assert "→" in value  # window separator
+
+
+@pytest.mark.asyncio
+async def test_build_live_events_embed_boss_renders_standard_and_elite(monkeypatch):
+    from utils.db import btd6_sources as btd6_db
+
+    async def _fake(*, entity_kind=None, fact_type=None, limit=50):
+        return [
+            _fact_row(
+                entity_kind="btd6_boss",
+                entity_key="diamondback5",
+                body={
+                    "id": "diamondback5",
+                    "name": "Diamondback Tier 5",
+                    "boss_type": "diamondback",
+                    "total_scores_standard": 100,
+                    "total_scores_elite": 50,
+                    "start_ms": 1779019200000,
+                    "end_ms": 1779105600000,
+                },
+            ),
+        ]
+
+    monkeypatch.setattr(btd6_db, "search_facts", _fake)
+
+    embed = await build_live_events_embed("btd6_boss", limit=1)
+    value = embed.fields[0].value or ""
+    assert "standard=100" in value
+    assert "elite=50" in value
+    assert "type=`diamondback`" in value
+
+
+@pytest.mark.asyncio
+async def test_build_live_events_embed_falls_back_to_entity_key_when_no_name(
+    monkeypatch,
+):
+    from utils.db import btd6_sources as btd6_db
+
+    async def _fake(*, entity_kind=None, fact_type=None, limit=50):
+        return [
+            _fact_row(
+                entity_kind="btd6_ct",
+                entity_key="ct_42",
+                body={"start_ms": 0, "end_ms": 0},
+            ),
+        ]
+
+    monkeypatch.setattr(btd6_db, "search_facts", _fake)
+
+    embed = await build_live_events_embed("btd6_ct", limit=1)
+    assert embed.fields[0].name == "ct_42"
+
+
+# ---------------------------------------------------------------------------
+# Prefix commands
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kind_arg,entity_kind",
+    [
+        ("race", "btd6_race"),
+        ("boss", "btd6_boss"),
+        ("ct", "btd6_ct"),
+        ("odyssey", "btd6_odyssey"),
+        ("event", "btd6_event"),
+    ],
+)
+async def test_live_prefix_routes_each_kind_to_entity_kind(
+    monkeypatch,
+    kind_arg,
+    entity_kind,
+):
+    seen: dict = {}
+
+    async def _fake(*, entity_kind=None, fact_type=None, limit=50):
+        seen["entity_kind"] = entity_kind
+        seen["limit"] = limit
+        return []
+
+    from utils.db import btd6_sources as btd6_db
+
+    monkeypatch.setattr(btd6_db, "search_facts", _fake)
+
+    cog = BTD6Cog(MagicMock())
+    ctx = MagicMock()
+    ctx.send = AsyncMock()
+    await cog.btd6_live.callback(cog, ctx, kind_arg, 7)
+
+    assert seen == {"entity_kind": entity_kind, "limit": 7}
+    ctx.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_live_prefix_unknown_kind_returns_error_embed(monkeypatch):
+    from utils.db import btd6_sources as btd6_db
+
+    async def _fake(**_kw):
+        return []
+
+    monkeypatch.setattr(btd6_db, "search_facts", _fake)
+
+    cog = BTD6Cog(MagicMock())
+    ctx = MagicMock()
+    ctx.send = AsyncMock()
+    await cog.btd6_live.callback(cog, ctx, "nonsense", 5)
+
+    embed = ctx.send.await_args.kwargs.get("embed")
+    assert embed is not None
+    assert "Unknown" in (embed.title or "")
+
+
+# ---------------------------------------------------------------------------
+# Slash commands
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_live_slash_defers_before_db_call(monkeypatch):
+    call_order: list[str] = []
+
+    async def _fake(*, entity_kind=None, fact_type=None, limit=50):
+        call_order.append("db")
+        return []
+
+    from cogs import btd6_cog as cog_mod
+    from utils.db import btd6_sources as btd6_db
+
+    monkeypatch.setattr(btd6_db, "search_facts", _fake)
+
+    async def _defer_capture(interaction, **_kw):
+        call_order.append("defer")
+        return True
+
+    async def _followup_capture(*_a, **_kw):
+        call_order.append("followup")
+        return None
+
+    monkeypatch.setattr(cog_mod, "safe_defer", _defer_capture)
+    monkeypatch.setattr(cog_mod, "safe_followup", _followup_capture)
+
+    cog = BTD6Cog(MagicMock())
+    interaction = _slash_interaction()
+    await cog.btd6_live_slash.callback(cog, interaction, "race", 3)
+
+    assert call_order == ["defer", "db", "followup"]
+
+
+@pytest.mark.asyncio
+async def test_live_slash_unknown_kind_followups_with_error_embed(monkeypatch):
+    from cogs import btd6_cog as cog_mod
+    from utils.db import btd6_sources as btd6_db
+
+    async def _fake(**_kw):
+        return []
+
+    monkeypatch.setattr(btd6_db, "search_facts", _fake)
+
+    async def _defer(*_a, **_kw):
+        return True
+
+    sent: list[dict] = []
+
+    async def _followup(_interaction, *_a, **kwargs):
+        sent.append(kwargs)
+
+    monkeypatch.setattr(cog_mod, "safe_defer", _defer)
+    monkeypatch.setattr(cog_mod, "safe_followup", _followup)
+
+    cog = BTD6Cog(MagicMock())
+    interaction = _slash_interaction()
+    await cog.btd6_live_slash.callback(cog, interaction, "nonsense", 5)
+
+    embed = sent[0].get("embed") if sent else None
+    assert embed is not None
+    assert "Unknown" in (embed.title or "")
+
+
+# ---------------------------------------------------------------------------
+# Scheduler coverage — pin the expanded source list
+# ---------------------------------------------------------------------------
+
+
+def test_supervisor_source_intervals_cover_live_sources():
+    from services.btd6_ingestion_supervisor import _SOURCE_INTERVALS
+
+    expected = {
+        "nk_btd6_maps",
+        "nk_btd6_events",
+        "nk_btd6_races",
+        "nk_btd6_bosses",
+        "nk_btd6_odyssey",
+        "nk_btd6_ct",
+    }
+    missing = expected - set(_SOURCE_INTERVALS)
+    assert not missing, f"scheduler is missing sources: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Live grounding wired into !btd6 ask
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_answer_question_attaches_live_facts(monkeypatch):
+    from services import btd6_ai_service, btd6_context_service
+
+    async def _ctx(_text):
+        return btd6_context_service.BTD6Context(
+            facts=("Reversed Loop — type=race (source: data.ninjakiwi.com)",),
+            source_summary="data.ninjakiwi.com (Tier 1)",
+            confidence=0.5,
+        )
+
+    monkeypatch.setattr(btd6_context_service, "build", _ctx)
+
+    response = await btd6_ai_service.answer_question("when is the next race?")
+    assert response.live_facts == (
+        "Reversed Loop — type=race (source: data.ninjakiwi.com)",
+    )
+
+
+@pytest.mark.asyncio
+async def test_answer_question_survives_context_service_failure(monkeypatch):
+    from services import btd6_ai_service, btd6_context_service
+
+    async def _boom(_text):
+        raise RuntimeError("DB down")
+
+    monkeypatch.setattr(btd6_context_service, "build", _boom)
+
+    response = await btd6_ai_service.answer_question("dart monkey")
+    assert response.live_facts == ()  # falls back to deterministic only
+
+
+def test_response_to_embed_renders_live_facts():
+    from cogs.btd6._embeds import response_to_embed
+    from services.btd6_response_builder import BTD6Response
+
+    response = BTD6Response(
+        title="Test",
+        short_answer="Body",
+        live_facts=(
+            "Race #1 — type=race (source: data.ninjakiwi.com)",
+            "Race #2 — type=race (source: data.ninjakiwi.com)",
+        ),
+    )
+    embed = response_to_embed(response)
+    names = [f.name for f in embed.fields]
+    assert "Live data" in names
+    value = next(f.value for f in embed.fields if f.name == "Live data")
+    assert "Race #1" in (value or "")
+    assert "Race #2" in (value or "")
+
+
+def test_response_to_embed_no_live_field_when_empty():
+    from cogs.btd6._embeds import response_to_embed
+    from services.btd6_response_builder import BTD6Response
+
+    response = BTD6Response(title="Test", short_answer="Body")
+    embed = response_to_embed(response)
+    names = [f.name for f in embed.fields]
+    assert "Live data" not in names
+
+
+def test_augmentation_payload_includes_live_facts():
+    from services.btd6_ai_service import _augmentation_payload
+    from services.btd6_resolver_service import resolve
+    from services.btd6_response_builder import BTD6Response
+
+    intent = resolve("dart monkey")
+    response = BTD6Response(
+        title="Test",
+        short_answer="Body",
+        live_facts=("Live A", "Live B"),
+    )
+    payload = _augmentation_payload(intent, response)
+    assert payload["live_facts"] == ["Live A", "Live B"]


### PR DESCRIPTION
## Summary

Builds on the refresh-source foundation (PR #353) to actually leverage the ingested live data. Three logical changes:

1. **Expand the ingestion scheduler** — only `nk_btd6_ct` was on the cadence; the comment literally said "races, bosses, odyssey added in later ingestion expansion PRs." This adds events/races/bosses/odyssey at 30 min and maps at 1 day.
2. **`!btd6 live <kind>` reader** (+ slash twin) — one parametrized prefix+slash command that surfaces race/boss/CT/odyssey/event facts from `btd6_facts` to users. These have no static fallback, so it's pure value-add on top of the ingestion pipeline.
3. **Wire live grounding into `!btd6 ask`** — the passive natural-language stage already routes through `btd6_context_service` for live grounding; the explicit `!btd6 ask` was only reading the static dataset. Both surfaces now share one grounding pipeline.

## Architecture

- **Supervisor:** behavioural change only — adds entries to `_SOURCE_INTERVALS`. Static maps directory gets 1-day cadence so a single failure doesn't pin it offline for a day; live rotations stay at 30 min.
- **`build_live_events_embed(kind)`:** accepts both short (`race`) and full (`btd6_race`) forms. Unknown kinds yield a user-facing error embed (no exception escape). Empty results print a `refresh-source <key>` hint pointing at the right source key so staff can manually kick a source if the supervisor hasn't run yet.
- **Cog surface:** one prefix + one slash command, parametrized by kind. Consolidated (not five separate commands) so the cog stays under the 800-LOC ceiling. Slash defers via `safe_defer` before the DB read.
- **AI grounding:** `BTD6Response` gains an optional `live_facts: tuple[str, ...]` field. `answer_question()` calls `btd6_context_service.build()` (the same service the passive natural-language stage uses) and attaches the sanitised facts. The embed renderer adds a "Live data" section under Discord's 1024-char field cap. The AI augmentation payload also includes them as untrusted-data input. Best-effort: any `build()` failure leaves the deterministic response untouched.

## Test plan

- [x] `python3.10 -m pytest tests/ -q` — 5494 passed, 3 skipped.
- [x] `python3.10 scripts/check_architecture.py --mode strict` — 0 errors.
- [x] `python3.10 -m black --check` / `isort --check-only` / `ruff check` — clean on every touched file.
- [x] Cog size invariant — `btd6_cog.py` at 795 LOC, under the 800 ceiling.
- [x] New tests cover: unknown-kind error embed, short/long form normalisation, empty-state hint, race/boss field rendering, fall-back to entity_key when no name, prefix parametrize over all five kinds, slash defer-before-DB order, parity-pin includes `live`, scheduler-pin includes all five new sources, `answer_question` attaches `live_facts`, context_service failure is swallowed, `_response_to_embed` renders `Live data`, augmentation payload carries `live_facts`.

## Manual verification

```
!btd6 live race                # recent races: name, window, score count
!btd6 live boss                # recent bosses: standard / elite totals, boss_type
!btd6 live ct
!btd6 live odyssey
!btd6 live event
!btd6 live nonsense            # red "Unknown kind" embed
!btd6 ask "when is the next race?"   # answer embed should include a "Live data" section
```

Leave the bot running ~30 min, then check `!btd6 source-health` — `last_fetched_at` for events/races/bosses/odyssey/maps should advance without anyone typing `refresh-source`.

https://claude.ai/code/session_017ECXVdLZMNVNLSFVsYxctK

---
_Generated by [Claude Code](https://claude.ai/code/session_017ECXVdLZMNVNLSFVsYxctK)_