### PR TITLE
BTD6: fix double-encoded body_json round-trip in btd6_facts

### DIFF
--- a/disbot/cogs/btd6/_builders.py
+++ b/disbot/cogs/btd6/_builders.py
@@ -399,6 +399,27 @@ def _event_window(body: dict[str, Any]) -> str:
     return f"{start} → {end}"
 
 
+def _coerce_body(value: Any) -> dict[str, Any]:
+    """Normalise ``body_json`` to a dict.
+
+    Defensive shim for rows written by the legacy double-encoded
+    ``json.dumps`` path: those round-trip as a JSON string instead of a
+    dict, so we json.loads them on read. Returns ``{}`` for anything we
+    can't decode (e.g. malformed text, non-mapping JSON).
+    """
+    import json
+
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            decoded = json.loads(value)
+        except (ValueError, TypeError):
+            return {}
+        return decoded if isinstance(decoded, dict) else {}
+    return {}
+
+
 _LIVE_EVENT_SPECS: dict[str, dict[str, str]] = {
     # entity_kind → display config
     "btd6_race": {
@@ -473,7 +494,7 @@ async def build_live_events_embed(
         return embed
 
     for row in rows:
-        body = row.get("body_json") if isinstance(row.get("body_json"), dict) else {}
+        body = _coerce_body(row.get("body_json"))
         name = body.get("name") or row.get("entity_key") or "—"
         window = _event_window(body)
         lines = [

--- a/disbot/services/btd6_context_service.py
+++ b/disbot/services/btd6_context_service.py
@@ -96,6 +96,27 @@ _EXTRA_KEYS = (
 )
 
 
+def _coerce_body(value: Any) -> dict[str, Any]:
+    """Normalise ``body_json`` to a dict.
+
+    Legacy ``btd6_facts`` rows were written via a double-encoded
+    ``json.dumps`` path (fixed in utils.db.btd6_sources) and so
+    round-trip as JSON strings. We decode on read so the grounding
+    bundle keeps working for those rows until they're rewritten.
+    """
+    import json
+
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            decoded = json.loads(value)
+        except (ValueError, TypeError):
+            return {}
+        return decoded if isinstance(decoded, dict) else {}
+    return {}
+
+
 def _render_fact(row: dict[str, Any]) -> str:
     """Turn one fact row into a single labeled context string.
 
@@ -105,7 +126,7 @@ def _render_fact(row: dict[str, Any]) -> str:
     body, but bare links in a context string can encourage the LLM
     to follow them.
     """
-    body = row.get("body_json") if isinstance(row.get("body_json"), dict) else {}
+    body = _coerce_body(row.get("body_json"))
     headline = ""
     for key in _HEADLINE_KEYS:
         value = body.get(key)

--- a/disbot/utils/db/btd6_sources.py
+++ b/disbot/utils/db/btd6_sources.py
@@ -11,7 +11,6 @@ BTD6 facts are global (not guild-scoped) so there is no
 
 from __future__ import annotations
 
-import json
 import logging
 from datetime import datetime
 from typing import Any
@@ -217,9 +216,12 @@ async def record_source_audit(
     guild_id: int | None,
     reason: str | None,
 ) -> int:
-    """Insert one ``btd6_source_audit`` row; returns the new id."""
-    import json
+    """Insert one ``btd6_source_audit`` row; returns the new id.
 
+    ``old_value`` and ``new_value`` are passed as dicts; the JSONB codec
+    on the connection handles encoding. Pre-encoding via ``json.dumps``
+    here would double-wrap them.
+    """
     row = await pool.get().fetchrow(
         """
         INSERT INTO btd6_source_audit (
@@ -232,8 +234,8 @@ async def record_source_audit(
         guild_id,
         source_key,
         action,
-        json.dumps(old_value) if old_value is not None else None,
-        json.dumps(new_value) if new_value is not None else None,
+        old_value,
+        new_value,
         reason,
     )
     return int(row["id"])
@@ -287,8 +289,10 @@ async def upsert_fact(
     confidence: float = 1.0,
     version: int = 1,
 ) -> int:
-    import json
-
+    # body_json is passed as a dict; the JSONB codec on the connection
+    # (utils.db.codec.init_connection) handles json.dumps on the wire.
+    # Don't pre-encode here — doing so double-wraps the value and the
+    # row reads back as a JSON string instead of a dict.
     row = await pool.get().fetchrow(
         """
         INSERT INTO btd6_facts (
@@ -308,7 +312,7 @@ async def upsert_fact(
         fact_type,
         entity_kind,
         entity_key,
-        json.dumps(body_json),
+        body_json,
         game_version,
         confidence,
         version,
@@ -475,7 +479,12 @@ async def insert_ingestion_run(
     path_params_json: dict[str, Any] | None,
     started_by_user_id: int | None,
 ) -> int:
-    """INSERT a new ingestion run row; returns the new id."""
+    """INSERT a new ingestion run row; returns the new id.
+
+    ``path_params_json`` is passed as a dict; the JSONB codec on the
+    connection handles encoding. Pre-encoding via ``json.dumps`` here
+    would double-wrap the value.
+    """
     row = await pool.get().fetchrow(
         """
         INSERT INTO btd6_ingestion_runs (
@@ -487,7 +496,7 @@ async def insert_ingestion_run(
         source_key,
         status,
         triggered_by,
-        json.dumps(path_params_json) if path_params_json is not None else None,
+        path_params_json,
         started_by_user_id,
     )
     return int(row["id"])

--- a/tests/unit/cogs/test_btd6_live_events_command.py
+++ b/tests/unit/cogs/test_btd6_live_events_command.py
@@ -14,6 +14,7 @@ import discord
 import pytest
 
 from cogs.btd6._builders import (
+    _coerce_body,
     _event_window,
     _ms_to_human,
     build_live_events_embed,
@@ -213,6 +214,70 @@ async def test_build_live_events_embed_falls_back_to_entity_key_when_no_name(
 
     embed = await build_live_events_embed("btd6_ct", limit=1)
     assert embed.fields[0].name == "ct_42"
+
+
+# ---------------------------------------------------------------------------
+# body_json defensive coercion
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_body_dict_passes_through():
+    body = {"id": "x", "start_ms": 123}
+    assert _coerce_body(body) is body
+
+
+def test_coerce_body_json_string_decodes():
+    body_text = '{"id": "x", "start_ms": 123}'
+    assert _coerce_body(body_text) == {"id": "x", "start_ms": 123}
+
+
+def test_coerce_body_malformed_string_returns_empty():
+    assert _coerce_body("not json {") == {}
+
+
+def test_coerce_body_non_object_returns_empty():
+    # A JSON-encoded scalar is still valid JSON but not a mapping.
+    assert _coerce_body('"just a string"') == {}
+    assert _coerce_body("42") == {}
+    assert _coerce_body("[1, 2]") == {}
+
+
+def test_coerce_body_none_returns_empty():
+    assert _coerce_body(None) == {}
+
+
+@pytest.mark.asyncio
+async def test_build_live_events_embed_decodes_legacy_string_body(monkeypatch):
+    """Legacy rows store body_json as a JSON string. We must still render."""
+    import json as _json
+
+    from utils.db import btd6_sources as btd6_db
+
+    async def _fake(*, entity_kind=None, fact_type=None, limit=50):
+        row = _fact_row(
+            entity_kind="btd6_race",
+            entity_key="Reversed_Loop_mpbd7tcu",
+            body={
+                "id": "Reversed_Loop_mpbd7tcu",
+                "name": "Reversed Loop",
+                "start_ms": 1779019200000,
+                "end_ms": 1779105600000,
+                "total_scores": 12,
+            },
+        )
+        # Simulate the legacy double-encoded shape: body_json arrives
+        # as a JSON string instead of a dict.
+        row["body_json"] = _json.dumps(row["body_json"])
+        return [row]
+
+    monkeypatch.setattr(btd6_db, "search_facts", _fake)
+
+    embed = await build_live_events_embed("btd6_race", limit=1)
+    field = embed.fields[0]
+    assert field.name == "Reversed Loop"
+    value = field.value or ""
+    assert "scores=12" in value
+    assert "→" in value
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/db/test_btd6_sources_jsonb_writers.py
+++ b/tests/unit/db/test_btd6_sources_jsonb_writers.py
@@ -1,0 +1,131 @@
+"""Pin that BTD6 JSONB writers don't pre-encode their dict args.
+
+The asyncpg pool registers a JSONB codec at init
+(``utils.db.codec.init_connection``) which calls ``json.dumps`` on the
+wire. Pre-encoding via ``json.dumps`` in the writer caused the codec to
+re-encode the resulting string, so rows round-tripped through the
+``body_json`` column as a JSON string instead of a dict — silently
+breaking every reader that did ``isinstance(body, dict) else {}``.
+
+These tests assert the writer passes the dict through as-is.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from utils.db import btd6_sources as btd6_db
+
+
+@pytest.mark.asyncio
+async def test_upsert_fact_passes_body_json_as_dict(monkeypatch):
+    seen: dict = {}
+
+    async def _fetchrow(_sql, *args):
+        seen["args"] = args
+        return {"id": 1}
+
+    fake_pool = MagicMock()
+    fake_pool.fetchrow = _fetchrow
+    monkeypatch.setattr(btd6_db.pool, "get", lambda: fake_pool)
+
+    body = {"id": "x", "start_ms": 1779019200000, "name": "Reversed Loop"}
+    await btd6_db.upsert_fact(
+        source_id=1,
+        fact_type="btd6.test",
+        entity_kind="btd6_test",
+        entity_key="x",
+        body_json=body,
+        game_version=None,
+    )
+
+    # The 5th positional arg ($5) is body_json. It must be the dict
+    # itself — pre-encoding to a string was the historical bug.
+    assert (
+        seen["args"][4] is body
+    ), f"upsert_fact pre-encoded body_json (got {type(seen['args'][4]).__name__})"
+
+
+@pytest.mark.asyncio
+async def test_insert_ingestion_run_passes_path_params_as_dict(monkeypatch):
+    seen: dict = {}
+
+    async def _fetchrow(_sql, *args):
+        seen["args"] = args
+        return {"id": 1}
+
+    fake_pool = MagicMock()
+    fake_pool.fetchrow = _fetchrow
+    monkeypatch.setattr(btd6_db.pool, "get", lambda: fake_pool)
+
+    params = {"raceID": "Reversed_Loop_mpbd7tcu"}
+    await btd6_db.insert_ingestion_run(
+        source_key="nk_btd6_races_metadata",
+        status="ok",
+        triggered_by="manual",
+        path_params_json=params,
+        started_by_user_id=None,
+    )
+
+    # The 4th positional arg ($4) is path_params_json. Must be the
+    # dict, not a JSON string.
+    assert seen["args"][3] is params, (
+        f"insert_ingestion_run pre-encoded path_params_json "
+        f"(got {type(seen['args'][3]).__name__})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_insert_ingestion_run_passes_none_when_no_params(monkeypatch):
+    """``path_params_json=None`` must propagate as None (not as 'null')."""
+    seen: dict = {}
+
+    async def _fetchrow(_sql, *args):
+        seen["args"] = args
+        return {"id": 1}
+
+    fake_pool = MagicMock()
+    fake_pool.fetchrow = _fetchrow
+    monkeypatch.setattr(btd6_db.pool, "get", lambda: fake_pool)
+
+    await btd6_db.insert_ingestion_run(
+        source_key="nk_btd6_maps",
+        status="ok",
+        triggered_by="scheduled",
+        path_params_json=None,
+        started_by_user_id=None,
+    )
+
+    assert seen["args"][3] is None
+
+
+@pytest.mark.asyncio
+async def test_record_source_audit_passes_values_as_dicts(monkeypatch):
+    seen: dict = {}
+
+    async def _fetchrow(_sql, *args):
+        seen["args"] = args
+        return {"id": 1}
+
+    fake_pool = MagicMock()
+    fake_pool.fetchrow = _fetchrow
+    monkeypatch.setattr(btd6_db.pool, "get", lambda: fake_pool)
+
+    old_value = {"enabled": True}
+    new_value = {"enabled": False}
+    await btd6_db.record_source_audit(
+        action="disable",
+        source_key="nk_btd6_test",
+        old_value=old_value,
+        new_value=new_value,
+        actor_id=1,
+        guild_id=None,
+        reason=None,
+    )
+
+    # Args order: actor_id, guild_id, source_key, action, old_value, new_value, reason
+    args = seen["args"]
+    assert args[4] is old_value
+    assert args[5] is new_value

--- a/tests/unit/services/test_btd6_context_live_entities.py
+++ b/tests/unit/services/test_btd6_context_live_entities.py
@@ -100,3 +100,37 @@ async def test_no_live_entities_skips_lookup(monkeypatch):
     rows = await btd6_context_service._fetch_live_entity_rows(_Intent())
     assert rows == []
     assert called is False
+
+
+def test_coerce_body_handles_legacy_string_form():
+    """Legacy btd6_facts rows store body_json as a JSON string — the
+    grounding renderer must still decode them so it doesn't fall back
+    to '(no summary)' for every fact in the bundle."""
+    import json as _json
+
+    from services import btd6_context_service
+
+    body = {"name": "Reversed Loop", "type": "race"}
+    assert btd6_context_service._coerce_body(body) is body
+    assert btd6_context_service._coerce_body(_json.dumps(body)) == body
+    assert btd6_context_service._coerce_body("not-json {") == {}
+    assert btd6_context_service._coerce_body(None) == {}
+
+
+def test_render_fact_decodes_legacy_string_body():
+    """When body_json is a JSON-string (legacy double-encoded row),
+    _render_fact must still produce a meaningful headline."""
+    import json as _json
+
+    from services import btd6_context_service
+
+    body = {"name": "Reversed Loop", "type": "race"}
+    row = {
+        "body_json": _json.dumps(body),
+        "source_name": "Ninja Kiwi /races",
+        "fetched_at": datetime(2026, 5, 27, 12, 0, tzinfo=timezone.utc),
+        "version": 1,
+    }
+    rendered = btd6_context_service._render_fact(row)
+    assert "Reversed Loop" in rendered
+    assert "(no summary)" not in rendered


### PR DESCRIPTION
## Summary

Verified live on the bot after #354 merged: `!btd6 live race` / `live boss` show `window: —` on every row, and the new "Live data" section in `!btd6 ask` shows `(no summary)` for every fact. Root cause is a long-standing JSONB encoding bug in `utils/db/btd6_sources.py` — surfaced now because the new commands actually exercise `body_json` reads end-to-end.

## Root cause

The asyncpg connection registers a JSONB codec at pool init (`utils/db/codec.py:init_connection`) that calls `json.dumps` to encode dict→wire. But the writers in `utils/db/btd6_sources.py` were ALSO calling `json.dumps` on their dict args before passing them. The double-wrap stored each row's `body_json` as a **JSON-encoded string** (not a JSONB object), so every reader got back a string instead of a dict.

Every reader did `body = row.get("body_json") if isinstance(body_json, dict) else {}` and silently fell back to `{}` — which is why every event card has empty fields and every grounded fact has no summary.

Repro (the wire path):

```python
arg = json.dumps(body_json)                  # writer pre-encodes (BUG)
codec_encoded = json.dumps(arg)              # codec wraps the string again
pg_stored = json.loads(codec_encoded)        # PG parses one layer → still a string
sent_back = json.dumps(pg_stored)            # PG → wire
decoded = json.loads(sent_back)              # codec decodes → string, not dict
```

Three writers are affected:
- `upsert_fact` (drives `btd6_facts.body_json`)
- `insert_ingestion_run` (drives `btd6_ingestion_runs.path_params_json`)
- `record_source_audit` (drives `btd6_source_audit.old_value` / `.new_value`)

## Fix

1. **Stop pre-encoding** in all three writers; let the codec encode the dict once. Affects new writes only.
2. **Defensive read shim** — `_coerce_body(value)` in both `cogs/btd6/_builders.py` and `services/btd6_context_service.py` that `json.loads`-decodes strings at read time. Existing already-broken rows render correctly without needing a migration; they self-repair the next time the supervisor (or a manual `refresh-source`) overwrites them.
3. **Writer pin test** — new `tests/unit/db/test_btd6_sources_jsonb_writers.py` asserts the dict is passed through positionally, not a `json.dumps(...)` string. Catches a future re-add.

## Test plan

- [x] `python3.10 -m pytest tests/ -q` — 5506 passed, 3 skipped.
- [x] `python3.10 scripts/check_architecture.py --mode strict` — 0 errors.
- [x] black / isort / ruff clean on every touched file.
- [x] New tests: dict-passthrough, JSON-string-decodes-to-dict, malformed-string-returns-empty, non-object-returns-empty, None-returns-empty, end-to-end `build_live_events_embed` with a legacy string body renders the window + score correctly, end-to-end `_render_fact` with a legacy string body produces a real summary (not `(no summary)`).
- [x] Writer pin tests assert each of the three writers passes the dict as-is.

## Manual verification (post-deploy)

After redeploying + one supervisor cycle (or a manual `!btd6 refresh-source nk_btd6_races`), the existing rows for that source overwrite with the new clean encoding. Then:

- `!btd6 live race` should show `window: 2026-05-XX … → 2026-05-XX …` instead of `—`, and `scores=N` instead of nothing.
- `!btd6 ask "current race?"` should render meaningful headlines in the "Live data" section (e.g. `Reversed Loop — type=race (source: data.ninjakiwi.com, fetched 2m ago)`) instead of `(no summary)`.
- Until a source is re-fetched, the defensive read shim keeps its already-stored rows rendering correctly — no broken middle state.

https://claude.ai/code/session_017ECXVdLZMNVNLSFVsYxctK

---
_Generated by [Claude Code](https://claude.ai/code/session_017ECXVdLZMNVNLSFVsYxctK)_