### PR TITLE
ai: fix mention-reply bug — task contract, no duplication, ID redaction

### DIFF
--- a/disbot/core/runtime/ai/natural_language_stage.py
+++ b/disbot/core/runtime/ai/natural_language_stage.py
@@ -23,6 +23,7 @@ Every code path through this stage produces exactly one
 from __future__ import annotations
 
 import logging
+import re
 import time
 import uuid
 from dataclasses import dataclass
@@ -55,6 +56,52 @@ STAGE_NAME = "ai_natural_language"
 STAGE_ORDER = 70
 
 
+def _strip_bot_mention(text: str, *, bot_user_id: int | None) -> str:
+    """Remove all mentions of the bot from ``text``.
+
+    Discord mentions are ``<@id>`` or ``<@!id>``. ``re.sub`` replaces
+    every match. The returned string is stripped of surrounding
+    whitespace so a bare-mention message collapses to ``""``.
+    """
+    if bot_user_id is None:
+        return text
+    return re.sub(rf"<@!?{bot_user_id}>", "", text).strip()
+
+
+def _record_user_turn_if_visible(
+    message: discord.Message,
+    text: str,
+    *,
+    guild_id: int,
+    channel_id: int,
+    user_id: int,
+    is_mention: bool,
+    include_mentions: bool,
+) -> bool:
+    """Append ``text`` to the conversation buffer when visibility rules allow.
+
+    Single deterministic owner for memory writes from the stage. The
+    raw ``text`` (not the mention-stripped form) is what gets stored
+    so memory reflects what the user actually typed.
+
+    Returns ``True`` if the turn was appended.
+    """
+    if getattr(message.author, "bot", False):
+        return False
+    if text.startswith("!") or text.startswith("/"):
+        return False
+    if is_mention and not include_mentions:
+        return False
+    ai_conversation_service.append(
+        guild_id,
+        channel_id,
+        user_id=user_id,
+        role="user",
+        text=text,
+    )
+    return True
+
+
 @dataclass
 class AINaturalLanguageStage:
     """Single passive natural-language responder.
@@ -75,8 +122,8 @@ class AINaturalLanguageStage:
         message: discord.Message = ctx.message
 
         # Cheap pre-filter: only flow through when there is text.
-        text = (message.content or "").strip()
-        if not text:
+        raw_text = (message.content or "").strip()
+        if not raw_text:
             return StageResult()
 
         # Earlier stages may already have handled this message.
@@ -93,25 +140,28 @@ class AINaturalLanguageStage:
         )
         user_id = message.author.id
         is_mention = ctx.bot.user is not None and ctx.bot.user.mentioned_in(message)
+        bot_user_id = getattr(getattr(ctx.bot, "user", None), "id", None)
 
-        # Chat memory: record every human message the stage sees,
-        # whether or not the bot ends up replying. Skip command
-        # prefixes so operator typos don't pollute the conversational
-        # context. Bot messages are skipped by the earlier
-        # ``handled_by`` short-circuit + the pipeline's own filtering;
-        # we also guard against ``author.bot`` defensively here.
-        if (
-            not getattr(message.author, "bot", False)
-            and not text.startswith("!")
-            and not text.startswith("/")
-        ):
-            ai_conversation_service.append(
-                guild_id,
-                channel_id,
-                user_id=user_id,
-                role="user",
-                text=text,
-            )
+        # The model sees the message with the bot mention stripped out
+        # so the ``current_user_message`` span is the user's actual
+        # question — never a noisy ``<@id>`` token. Memory still
+        # records the raw form below.
+        user_text = _strip_bot_mention(raw_text, bot_user_id=bot_user_id)
+
+        # Chat memory (bystander pre-record): record non-mention
+        # messages the stage sees, whether or not the bot ends up
+        # replying. The triggering mention is recorded later — once,
+        # after ``gather_recent_turns`` has run — so it cannot appear
+        # in the recent-turn context for its own response.
+        _record_user_turn_if_visible(
+            message,
+            raw_text,
+            guild_id=guild_id,
+            channel_id=channel_id,
+            user_id=user_id,
+            is_mention=is_mention,
+            include_mentions=False,
+        )
 
         snap = await ai_permission_service.snapshot(guild_id, user_id)
 
@@ -131,9 +181,21 @@ class AINaturalLanguageStage:
 
         # Route classification first so the audit row records both
         # the routed task and the resolver decision even when denied.
-        routed = ai_task_router.classify(text)
+        routed = ai_task_router.classify(raw_text)
 
         if not decision.allowed:
+            # Record the triggering mention exactly once before the
+            # denial return so future turns retain context. Non-mention
+            # bystander messages were already recorded above.
+            _record_user_turn_if_visible(
+                message,
+                raw_text,
+                guild_id=guild_id,
+                channel_id=channel_id,
+                user_id=user_id,
+                is_mention=is_mention,
+                include_mentions=True,
+            )
             await ai_decision_audit_service.record(
                 guild_id=guild_id,
                 channel_id=channel_id,
@@ -156,6 +218,15 @@ class AINaturalLanguageStage:
             user_id,
             decision.effective_cooldown,
         ):
+            _record_user_turn_if_visible(
+                message,
+                raw_text,
+                guild_id=guild_id,
+                channel_id=channel_id,
+                user_id=user_id,
+                is_mention=is_mention,
+                include_mentions=True,
+            )
             await ai_decision_audit_service.record(
                 guild_id=guild_id,
                 channel_id=channel_id,
@@ -170,10 +241,39 @@ class AINaturalLanguageStage:
             )
             return StageResult()
 
+        # Bare-mention guard: a message like "<@BOT_ID>" collapses to
+        # empty after mention-stripping. Do not send an empty
+        # current_user_message to the model. Record the mention to
+        # memory and audit a clean skip.
+        if not user_text:
+            _record_user_turn_if_visible(
+                message,
+                raw_text,
+                guild_id=guild_id,
+                channel_id=channel_id,
+                user_id=user_id,
+                is_mention=is_mention,
+                include_mentions=True,
+            )
+            await ai_decision_audit_service.record(
+                guild_id=guild_id,
+                channel_id=channel_id,
+                category_id=category_id,
+                user_id=user_id,
+                message_id=message.id,
+                task=routed.task.value,
+                route=routed.route,
+                decision="skipped",
+                reason_code=PolicyDenialReason.NO_ROUTE_MATCHED,
+                policy_snapshot_hash=decision.policy_snapshot_hash,
+                instruction_profile_ids=list(decision.instruction_profile_ids) or None,
+            )
+            return StageResult()
+
         try:
             _fact_req = FeatureFactRequest(
                 task=routed.task,
-                text=text,
+                text=raw_text,
                 guild_id=guild_id,
                 channel_id=channel_id,
                 author_id=user_id,
@@ -228,11 +328,7 @@ class AINaturalLanguageStage:
                     guild_id=guild_id,
                     channel_id=channel_id,
                     channel=getattr(message, "channel", None),
-                    bot_user_id=getattr(
-                        getattr(ctx, "bot_user", None),
-                        "id",
-                        None,
-                    ),
+                    bot_user_id=bot_user_id,
                 )
             except Exception as exc:  # noqa: BLE001 — defensive
                 logger.debug(
@@ -240,12 +336,27 @@ class AINaturalLanguageStage:
                     exc,
                 )
                 recent_turns = []
+
+            # Record the triggering mention exactly once, AFTER the
+            # gather above has captured the prior buffer. The mention
+            # therefore cannot appear in its own recent-turn context.
+            _record_user_turn_if_visible(
+                message,
+                raw_text,
+                guild_id=guild_id,
+                channel_id=channel_id,
+                user_id=user_id,
+                is_mention=is_mention,
+                include_mentions=True,
+            )
+
             stack = await ai_instruction_service.assemble(
                 guild_id=guild_id,
-                user_message=text,
+                user_message=user_text,
                 profile_ids=decision.instruction_profile_ids,
                 retrieved_facts=list(feature.facts),
                 recent_turns=recent_turns,
+                bot_user_id=bot_user_id,
             )
             correlation_id = uuid.uuid4().hex
             built = ai_context_service.build(
@@ -310,6 +421,15 @@ class AINaturalLanguageStage:
             )
             return StageResult()
 
+        # Outbound redaction: scrub Discord snowflakes and other
+        # sensitive-token patterns from the model's reply before it
+        # is sent to Discord OR recorded into conversation memory.
+        # Placed after the empty-reply guard so empty responses still
+        # take the degraded/skipped path above unchanged.
+        from core.runtime.ai.redaction import redact_text
+
+        reply_text = redact_text(reply_text).value
+
         from core.runtime.ai import response_renderer_registry
 
         rendered = await response_renderer_registry.render(
@@ -362,9 +482,9 @@ class AINaturalLanguageStage:
             return StageResult()
 
         ai_permission_service.mark_reply_sent(guild_id, user_id)
-        # The AI cog's on_message listener owns user-message recording
-        # so chat memory captures bystander messages too. The stage
-        # only records its own assistant reply.
+        # User-message recording happens earlier via
+        # ``_record_user_turn_if_visible``. Here the stage records
+        # only its own (sanitized) assistant reply.
         ai_conversation_service.append(
             guild_id,
             channel_id,

--- a/disbot/core/runtime/ai/redaction.py
+++ b/disbot/core/runtime/ai/redaction.py
@@ -1,10 +1,16 @@
-"""Redaction helpers for future AI request preparation.
+"""Redaction helpers for AI request preparation and outbound reply scrubbing.
 
-Inert scaffold: not imported by production runtime yet.
+Wired on two hot paths:
 
-The future AI gateway should run payloads through these helpers before
-provider calls.  Keep the helpers deterministic and conservative: they
-should reduce risk without requiring network access or external state.
+* :mod:`core.runtime.ai.gateway` runs every inbound provider payload
+  through :func:`redact_payload` / :func:`redact_text` before calling
+  the model.
+* :mod:`core.runtime.ai.natural_language_stage` runs every outbound
+  AI reply through :func:`redact_text` before sending it to Discord
+  and before recording it in conversation memory.
+
+Keep the helpers deterministic and conservative: they should reduce
+risk without requiring network access or external state.
 """
 
 from __future__ import annotations
@@ -32,6 +38,13 @@ _TOKEN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "bearer_token",
         re.compile(r"\bBearer\s+[A-Za-z0-9._\-]+", re.IGNORECASE),
+    ),
+    # Discord snowflakes are 17–20 decimal digits. Placed last so that
+    # genuine secrets which happen to contain a long numeric tail are
+    # still labelled by the more specific patterns above.
+    (
+        "discord_id",
+        re.compile(r"\b\d{17,20}\b"),
     ),
 )
 

--- a/disbot/services/ai_instruction_service.py
+++ b/disbot/services/ai_instruction_service.py
@@ -42,6 +42,24 @@ _BOT_AI_POLICY = (
     " producing factual answers. Refuse politely when policy denies."
 )
 
+_TASK_CONTRACT = (
+    "Task contract for THIS request:\n"
+    "- The 'current_user_message' span at the END of the payload is the"
+    " message you must answer. Treat it as the single triggering user"
+    " turn.\n"
+    "- The 'recent_channel_turns' span is BACKGROUND CONTEXT ONLY —"
+    " recent activity in the channel from various participants. Do"
+    " not summarize it unless the current_user_message explicitly"
+    " asks for a summary. Do not roleplay other participants.\n"
+    "- Speakers in the context are labeled user_A, user_B, ... and"
+    " 'assistant' (you). Refer to them in those terms; do NOT echo"
+    " any numeric IDs.\n"
+    "- Reply directly and concisely to the current_user_message. If a"
+    " needed fact is not present, say so. Do not invent facts.\n"
+    "- Output plain prose unless a feature profile explicitly"
+    " requested a structured format."
+)
+
 
 @dataclass(frozen=True)
 class InstructionStack:
@@ -62,17 +80,36 @@ class InstructionStack:
         return self.user_message
 
 
-def _render_recent_turn(turn: object) -> str:
+def _speaker_label(non_bot_index: int) -> str:
+    """Map ``0..25 → 'user_A'..'user_Z'``, ``26 → 'user_AA'``, etc.
+
+    The label generator keeps inline alphabet math out of
+    :func:`assemble` and gives the redaction story a stable, opaque
+    speaker identifier that contains no Discord snowflakes.
+    """
+    if non_bot_index < 0:
+        raise ValueError("non_bot_index must be non-negative")
+    letters = ""
+    n = non_bot_index
+    while True:
+        letters = chr(ord("A") + (n % 26)) + letters
+        n = n // 26 - 1
+        if n < 0:
+            break
+    return f"user_{letters}"
+
+
+def _render_recent_turn(turn: object, label: str) -> str:
     """Format one ConversationTurn for inclusion in the data layer.
 
-    Accepts any object exposing ``user_id``, ``role``, and ``text``
-    attributes so the assembler stays decoupled from the conversation
-    service's concrete dataclass.
+    ``label`` is a pseudonymous identifier (``user_A``,
+    ``assistant``, ...) supplied by :func:`assemble`. Raw Discord
+    user IDs are deliberately not rendered here — see the task
+    contract in :data:`_TASK_CONTRACT` for the matching prompt
+    language.
     """
-    role = str(getattr(turn, "role", "user"))
-    user_id = getattr(turn, "user_id", "?")
     text = str(getattr(turn, "text", "")).strip()
-    return f"[{role} user={user_id}] {text}"
+    return f"[{label}] {text}"
 
 
 async def assemble(
@@ -83,6 +120,7 @@ async def assemble(
     feature_profile_id: int | None = None,
     retrieved_facts: list[str] | None = None,
     recent_turns: list[object] | None = None,
+    bot_user_id: int | None = None,
 ) -> InstructionStack:
     """Build the layered :class:`InstructionStack`.
 
@@ -90,8 +128,13 @@ async def assemble(
     messages (see :mod:`services.ai_conversation_service`). Each turn
     is wrapped as untrusted data so adversarial text in a prior
     message can never escape the data envelope.
+
+    ``bot_user_id`` lets the assembler label the bot's own prior
+    turns as ``assistant`` and everyone else as ``user_A`` /
+    ``user_B`` / ... — opaque pseudonyms that keep raw Discord
+    snowflakes out of the model-visible prompt.
     """
-    system: list[str] = [_SYSTEM_SAFETY, _BOT_AI_POLICY]
+    system: list[str] = [_SYSTEM_SAFETY, _BOT_AI_POLICY, _TASK_CONTRACT]
 
     # Load each referenced profile body and wrap as data.
     seen: set[int] = set()
@@ -113,12 +156,40 @@ async def assemble(
 
     data: list[str] = []
     if recent_turns:
-        joined = "\n".join(_render_recent_turn(t) for t in recent_turns)
+        speaker_map: dict[int, str] = {}
+        non_bot_index = 0
+        rendered_lines: list[str] = []
+        for turn in recent_turns:
+            turn_user_id = getattr(turn, "user_id", None)
+            try:
+                turn_user_id_int = (
+                    int(turn_user_id) if turn_user_id is not None else None
+                )
+            except (TypeError, ValueError):
+                turn_user_id_int = None
+
+            if turn_user_id_int is not None and turn_user_id_int in speaker_map:
+                label = speaker_map[turn_user_id_int]
+            elif (
+                bot_user_id is not None
+                and turn_user_id_int is not None
+                and turn_user_id_int == bot_user_id
+            ):
+                label = "assistant"
+                speaker_map[turn_user_id_int] = label
+            else:
+                label = _speaker_label(non_bot_index)
+                non_bot_index += 1
+                if turn_user_id_int is not None:
+                    speaker_map[turn_user_id_int] = label
+
+            rendered_lines.append(_render_recent_turn(turn, label))
+        joined = "\n".join(rendered_lines)
         data.append(wrap_untrusted_text(joined, kind="recent_channel_turns"))
     for fact in retrieved_facts or ():
         data.append(wrap_untrusted_text(str(fact), kind="retrieved_fact"))
 
-    wrapped_user = wrap_untrusted_text(user_message, kind="user_message")
+    wrapped_user = wrap_untrusted_text(user_message, kind="current_user_message")
 
     return InstructionStack(
         system=tuple(system),

--- a/tests/unit/runtime/ai/test_natural_language_stage.py
+++ b/tests/unit/runtime/ai/test_natural_language_stage.py
@@ -35,7 +35,19 @@ from core.runtime.ai.natural_language_stage import (
     _invoke_gateway,
 )
 from core.runtime.message_pipeline import MessagePipelineContext
+
+# Capture the real implementations at import time so the new PR-1
+# tests can restore them after ``stub_services`` swaps them out for
+# mocks. Importing inside a fixture would re-read the (already
+# mocked) module attribute and produce a no-op.
+from services.ai_conversation_service import (  # noqa: E402
+    _reset_for_tests as _real_reset_buffers,
+)
+from services.ai_conversation_service import append as _real_conversation_append
+from services.ai_conversation_service import recent_turns as _real_recent_turns
+from services.ai_instruction_service import assemble as _real_assemble  # noqa: E402
 from services.ai_natural_language_policy import PolicyDecision
+from services.ai_task_router import classify as _real_router_classify  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -174,7 +186,10 @@ def stub_services(monkeypatch):
     monkeypatch.setattr(mod.ai_decision_audit_service, "record", _capture)
 
     from core.runtime.ai import response_renderer_registry
-    monkeypatch.setattr(response_renderer_registry, "render", AsyncMock(return_value=None))
+
+    monkeypatch.setattr(
+        response_renderer_registry, "render", AsyncMock(return_value=None)
+    )
 
     return audit_calls
 
@@ -428,7 +443,11 @@ async def test_send_failure_video_task_writes_video_send_failed(
     monkeypatch.setattr(
         mod,
         "_gather_feature_facts",
-        AsyncMock(return_value=FeatureFactsResult(facts=("title: Test Video",), render_context=None)),
+        AsyncMock(
+            return_value=FeatureFactsResult(
+                facts=("title: Test Video",), render_context=None
+            )
+        ),
     )
 
     async def fake_execute(_request):
@@ -438,7 +457,9 @@ async def test_send_failure_video_task_writes_video_send_failed(
 
     stage = AINaturalLanguageStage()
     msg = _make_message()
-    msg.channel.send = AsyncMock(side_effect=discord.HTTPException(MagicMock(), "send failed"))
+    msg.channel.send = AsyncMock(
+        side_effect=discord.HTTPException(MagicMock(), "send failed")
+    )
     await stage.process(_make_ctx(msg))
 
     assert len(stub_services) == 1
@@ -462,10 +483,397 @@ async def test_send_failure_non_video_task_writes_response_send_failed(
 
     stage = AINaturalLanguageStage()
     msg = _make_message()
-    msg.channel.send = AsyncMock(side_effect=discord.HTTPException(MagicMock(), "send failed"))
+    msg.channel.send = AsyncMock(
+        side_effect=discord.HTTPException(MagicMock(), "send failed")
+    )
     await stage.process(_make_ctx(msg))
 
     assert len(stub_services) == 1
     row = stub_services[0]
     assert row["decision"] == "errored"
     assert row["reason_code"] == "response_send_failed"
+
+
+# ---------------------------------------------------------------------------
+# PR 1 — AI mention-reply bug fixes:
+#   * task contract framing (T1, T2)
+#   * outbound snowflake redaction (T4b, T4c)
+#   * triggering message not duplicated in payload (T5)
+#   * triggering mention recorded exactly once for future context (T6, T7)
+#   * multiple bot mentions stripped (T11)
+#   * bare-mention messages do not call the provider (T12)
+# ---------------------------------------------------------------------------
+
+
+_BOT_ID = 555000000000000111
+
+
+def _make_message_with_mention(content: str, *, user_id: int = 42):
+    """Discord message whose content is exactly ``content``."""
+    msg = _make_message(user_id=user_id)
+    msg.content = content
+    return msg
+
+
+def _make_ctx_with_bot_id(message):
+    """Pipeline context whose ``bot.user`` has both ``mentioned_in`` and ``id``.
+
+    The default ``_make_ctx`` does not give ``bot.user`` an ``id``, so
+    mention-stripping is a no-op there. These tests need the real
+    bot-id plumbing to verify the strip behaviour.
+    """
+    bot = MagicMock()
+    bot.user = SimpleNamespace(
+        id=_BOT_ID,
+        mentioned_in=lambda _msg: True,
+    )
+    return MessagePipelineContext(bot=bot, message=message)
+
+
+def _use_real_assemble(monkeypatch):
+    """Override ``stub_services``'s SimpleNamespace stub of ``assemble`` so
+    the real instruction-service builder runs and the captured request
+    reflects the new task contract + speaker pseudonymization."""
+    from core.runtime.ai import natural_language_stage as mod
+    from utils.db import ai as ai_db
+
+    async def _no_profile(_pid):
+        return None
+
+    monkeypatch.setattr(ai_db, "get_instruction_profile", _no_profile)
+    monkeypatch.setattr(mod.ai_instruction_service, "assemble", _real_assemble)
+
+
+def _use_real_conversation_buffer(monkeypatch):
+    """Re-enable the in-process conversation buffer (``stub_services`` no-ops it)."""
+    from core.runtime.ai import natural_language_stage as mod
+
+    _real_reset_buffers()
+    monkeypatch.setattr(
+        mod.ai_conversation_service, "append", _real_conversation_append
+    )
+
+
+def _gather_recent_turns_returns(monkeypatch, turns):
+    """Force ``ai_memory_service.gather_recent_turns`` to return ``turns``."""
+    from services import ai_memory_service
+
+    async def _gather(**_kw):
+        return list(turns)
+
+    monkeypatch.setattr(ai_memory_service, "gather_recent_turns", _gather)
+
+
+@pytest.mark.asyncio
+async def test_payload_frames_current_user_message_directly(
+    monkeypatch,
+    stub_services,
+):
+    """T1: payload contains the task contract and the triggering
+    message in the ``current_user_message`` span. Recent turns are
+    background-only and precede the current message."""
+    from services import ai_gateway
+
+    _use_real_assemble(monkeypatch)
+    _gather_recent_turns_returns(
+        monkeypatch,
+        [
+            SimpleNamespace(user_id=11, role="user", text="bystander one"),
+            SimpleNamespace(user_id=22, role="user", text="bot-dev chatter"),
+            SimpleNamespace(user_id=33, role="user", text="another aside"),
+        ],
+    )
+
+    captured: dict = {}
+
+    async def fake_execute(request):
+        captured["request"] = request
+        return _make_response(text="ok")
+
+    monkeypatch.setattr(ai_gateway, "execute", fake_execute)
+
+    stage = AINaturalLanguageStage()
+    msg = _make_message_with_mention(f"<@{_BOT_ID}> are you there")
+    await stage.process(_make_ctx_with_bot_id(msg))
+
+    assert "request" in captured
+    system_prompt = captured["request"].system_prompt
+    payload = captured["request"].payload["text"]
+
+    # Task contract is present and names the new spans.
+    assert "Task contract" in system_prompt
+    assert "current_user_message" in system_prompt
+    assert "recent_channel_turns" in system_prompt
+
+    # Triggering message is wrapped as current_user_message and contains
+    # the user's actual question, with the bot mention stripped.
+    assert "UNTRUSTED_DATA__current_user_message__BEGIN" in payload
+    assert "are you there" in payload
+    assert f"<@{_BOT_ID}>" not in payload
+    assert "@SuperBot" not in payload  # no display-form leak either
+
+    # Recent turns precede the current message in the payload.
+    assert payload.index("recent_channel_turns") < payload.index("current_user_message")
+
+
+@pytest.mark.asyncio
+async def test_summarizable_context_does_not_select_summary(
+    monkeypatch,
+    stub_services,
+):
+    """T2: even with a verbose summarizable context, a normal question
+    routes to GENERAL_NL_ANSWER (no summary task exists) and the
+    contract instructs the model not to summarize unless asked."""
+    from services import ai_gateway
+
+    _use_real_assemble(monkeypatch)
+    _gather_recent_turns_returns(
+        monkeypatch,
+        [
+            SimpleNamespace(user_id=i, role="user", text=f"discussion item {i}")
+            for i in range(11, 20)
+        ],
+    )
+
+    captured: dict = {}
+
+    async def fake_execute(request):
+        captured["request"] = request
+        return _make_response(text="response")
+
+    monkeypatch.setattr(ai_gateway, "execute", fake_execute)
+
+    # Drop the SimpleNamespace router stub so the real router runs.
+    from core.runtime.ai import natural_language_stage as mod
+
+    monkeypatch.setattr(mod.ai_task_router, "classify", _real_router_classify)
+
+    stage = AINaturalLanguageStage()
+    msg = _make_message_with_mention(f"<@{_BOT_ID}> what is the weather")
+    await stage.process(_make_ctx_with_bot_id(msg))
+
+    assert "request" in captured
+    system_prompt = captured["request"].system_prompt
+    assert "Do not summarize" in system_prompt
+
+    # The route the audit row carries reflects the real router's pick.
+    assert stub_services[0]["task"] == AITask.GENERAL_NL_ANSWER.value
+
+
+@pytest.mark.asyncio
+async def test_outbound_reply_redacts_raw_snowflakes(
+    monkeypatch,
+    stub_services,
+):
+    """T4b: snowflakes in the model's reply are scrubbed before the
+    text is sent to Discord."""
+    from services import ai_gateway
+
+    async def fake_execute(_request):
+        return _make_response(
+            text="Hi <@987654321098765432> see 123456789012345678",
+        )
+
+    monkeypatch.setattr(ai_gateway, "execute", fake_execute)
+
+    stage = AINaturalLanguageStage()
+    msg = _make_message()
+    await stage.process(_make_ctx(msg))
+
+    msg.channel.send.assert_awaited_once()
+    sent_text = msg.channel.send.call_args.args[0]
+    assert "987654321098765432" not in sent_text
+    assert "123456789012345678" not in sent_text
+
+
+@pytest.mark.asyncio
+async def test_outbound_redacted_text_is_what_lands_in_memory(
+    monkeypatch, stub_services
+):
+    """T4c: the assistant reply written to conversation memory is the
+    sanitized form, not the raw provider output."""
+    from services import ai_gateway
+
+    _use_real_conversation_buffer(monkeypatch)
+
+    async def fake_execute(_request):
+        return _make_response(text="ack <@987654321098765432>")
+
+    monkeypatch.setattr(ai_gateway, "execute", fake_execute)
+
+    stage = AINaturalLanguageStage()
+    msg = _make_message()
+    await stage.process(_make_ctx(msg))
+
+    turns = _real_recent_turns(msg.guild.id, msg.channel.id)
+    assistant_turns = [t for t in turns if t.role == "assistant"]
+    assert len(assistant_turns) == 1
+    assert "987654321098765432" not in assistant_turns[0].text
+
+
+@pytest.mark.asyncio
+async def test_triggering_message_appears_only_once_in_payload(
+    monkeypatch,
+    stub_services,
+):
+    """T5: a unique sentinel in the triggering message appears exactly
+    once in the rendered payload (no duplication via recent_turns)."""
+    from services import ai_gateway
+
+    _use_real_assemble(monkeypatch)
+    _use_real_conversation_buffer(monkeypatch)
+    # Pre-seed unrelated bystander chatter so recent_turns is non-empty.
+    _real_conversation_append(99, 1, user_id=11, role="user", text="prior unrelated 1")
+    _real_conversation_append(99, 1, user_id=22, role="user", text="prior unrelated 2")
+
+    captured: dict = {}
+
+    async def fake_execute(request):
+        captured["request"] = request
+        return _make_response(text="ok")
+
+    monkeypatch.setattr(ai_gateway, "execute", fake_execute)
+
+    stage = AINaturalLanguageStage()
+    msg = _make_message_with_mention(f"<@{_BOT_ID}> unique-sentinel-XYZ")
+    await stage.process(_make_ctx_with_bot_id(msg))
+
+    payload = captured["request"].payload["text"]
+    assert payload.count("unique-sentinel-XYZ") == 1
+
+
+@pytest.mark.asyncio
+async def test_triggering_mention_recorded_exactly_once_after_success(
+    monkeypatch,
+    stub_services,
+):
+    """T6: after a successful reply, the triggering mention is in
+    conversation memory exactly once, in its raw form."""
+    from services import ai_gateway
+
+    _use_real_conversation_buffer(monkeypatch)
+
+    async def fake_execute(_request):
+        return _make_response(text="ok")
+
+    monkeypatch.setattr(ai_gateway, "execute", fake_execute)
+
+    stage = AINaturalLanguageStage()
+    msg_content = f"<@{_BOT_ID}> unique-sentinel-XYZ"
+    msg = _make_message_with_mention(msg_content)
+    await stage.process(_make_ctx_with_bot_id(msg))
+
+    turns = _real_recent_turns(msg.guild.id, msg.channel.id)
+    user_turns = [t for t in turns if t.role == "user"]
+    matching = [t for t in user_turns if "unique-sentinel-XYZ" in t.text]
+    assert len(matching) == 1
+    # Memory stores the raw (unstripped) content.
+    assert matching[0].text == msg_content
+
+
+@pytest.mark.asyncio
+async def test_triggering_mention_recorded_exactly_once_after_denied(monkeypatch):
+    """T7: when the policy denies, the triggering mention is still
+    captured in memory exactly once."""
+    from core.runtime.ai import natural_language_stage as mod
+
+    _real_reset_buffers()
+
+    monkeypatch.setattr(
+        mod.ai_permission_service,
+        "snapshot",
+        AsyncMock(return_value=SimpleNamespace(level=0, is_fresh_user=False)),
+    )
+    monkeypatch.setattr(
+        mod.ai_natural_language_policy,
+        "resolve",
+        AsyncMock(
+            return_value=PolicyDecision(
+                allowed=False,
+                reason_code=PolicyDenialReason.BELOW_MIN_LEVEL,
+                effective_min_level=5,
+                effective_cooldown=0,
+                policy_snapshot_hash="h",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        mod.ai_decision_audit_service,
+        "record",
+        AsyncMock(return_value=1),
+    )
+
+    stage = AINaturalLanguageStage()
+    msg_content = f"<@{_BOT_ID}> blocked-sentinel"
+    msg = _make_message_with_mention(msg_content)
+    await stage.process(_make_ctx_with_bot_id(msg))
+
+    turns = _real_recent_turns(msg.guild.id, msg.channel.id)
+    matching = [t for t in turns if "blocked-sentinel" in t.text]
+    assert len(matching) == 1
+    assert matching[0].text == msg_content
+
+
+@pytest.mark.asyncio
+async def test_multiple_bot_mentions_are_removed_from_current_user_message(
+    monkeypatch,
+    stub_services,
+):
+    """T11: every occurrence of the bot mention is stripped from the
+    text the model sees, not just the first."""
+    from services import ai_gateway
+
+    _use_real_assemble(monkeypatch)
+
+    captured: dict = {}
+
+    async def fake_execute(request):
+        captured["request"] = request
+        return _make_response(text="ok")
+
+    monkeypatch.setattr(ai_gateway, "execute", fake_execute)
+
+    stage = AINaturalLanguageStage()
+    msg = _make_message_with_mention(f"<@{_BOT_ID}> are you there <@{_BOT_ID}>")
+    await stage.process(_make_ctx_with_bot_id(msg))
+
+    payload = captured["request"].payload["text"]
+    assert "are you there" in payload
+    assert f"<@{_BOT_ID}>" not in payload
+
+
+@pytest.mark.asyncio
+async def test_empty_message_after_bot_mention_strip_does_not_call_provider(
+    monkeypatch,
+    stub_services,
+):
+    """T12: a bare-mention message ('<@BOT>' alone) is recorded to
+    memory but never reaches the provider. Audit row is
+    skipped/NO_ROUTE_MATCHED."""
+    from services import ai_gateway
+
+    _use_real_conversation_buffer(monkeypatch)
+    called = {"v": False}
+
+    async def fake_execute(_request):
+        called["v"] = True
+        return _make_response(text="should not be sent")
+
+    monkeypatch.setattr(ai_gateway, "execute", fake_execute)
+
+    stage = AINaturalLanguageStage()
+    msg_content = f"<@{_BOT_ID}>"
+    msg = _make_message_with_mention(msg_content)
+    await stage.process(_make_ctx_with_bot_id(msg))
+
+    assert called["v"] is False
+    # Audit row is a clean skip.
+    assert len(stub_services) == 1
+    row = stub_services[0]
+    assert row["decision"] == "skipped"
+    assert row["reason_code"] is PolicyDenialReason.NO_ROUTE_MATCHED
+
+    # Raw mention is still in memory for future context.
+    turns = _real_recent_turns(msg.guild.id, msg.channel.id)
+    matching = [t for t in turns if t.text == msg_content]
+    assert len(matching) == 1

--- a/tests/unit/runtime/ai/test_natural_language_stage_memory.py
+++ b/tests/unit/runtime/ai/test_natural_language_stage_memory.py
@@ -134,3 +134,33 @@ async def test_stage_skips_empty_text(monkeypatch):
     await stage.process(_make_ctx(msg))
 
     assert ai_conversation_service.recent_turns(99, 1) == []
+
+
+# ---------------------------------------------------------------------------
+# PR 1: the triggering mention is recorded exactly once, NOT via the
+# top-of-process bystander append (which would put it into its own
+# recent_turns and break the "not in own context" invariant).
+# ---------------------------------------------------------------------------
+
+
+def _make_mention_ctx(message, *, bot_id: int = 555000000000000111):
+    bot = MagicMock()
+    bot.user = SimpleNamespace(id=bot_id, mentioned_in=lambda _msg: True)
+    return MessagePipelineContext(bot=bot, message=message)
+
+
+@pytest.mark.asyncio
+async def test_stage_skips_top_path_append_for_mentions_records_once(monkeypatch):
+    """When the message is a bot mention, the top-of-process bystander
+    append is skipped (``include_mentions=False``). The mention enters
+    memory exactly once via the denial-path append (because we patch
+    the resolver to deny here)."""
+    _patch_denied(monkeypatch)
+    stage = AINaturalLanguageStage()
+    msg = _make_message(content="<@555000000000000111> blocked-with-mention")
+    await stage.process(_make_mention_ctx(msg))
+
+    turns = ai_conversation_service.recent_turns(99, 1)
+    matching = [t for t in turns if "blocked-with-mention" in t.text]
+    # Exactly one entry — the top-path append did NOT also fire.
+    assert len(matching) == 1

--- a/tests/unit/runtime/ai/test_redaction.py
+++ b/tests/unit/runtime/ai/test_redaction.py
@@ -45,6 +45,9 @@ _POSITIVE_CASES = [
         "url_secret_query",
         "&password=[redacted]",
     ),
+    # discord_id — bare 17-20 digit snowflakes
+    ("123456789012345678", "discord_id", "[discord_id:redacted]"),
+    ("12345678901234567890", "discord_id", "[discord_id:redacted]"),
 ]
 
 
@@ -53,12 +56,12 @@ def test_redact_text_matches_known_secret_shapes(
     text: str, label: str, marker: str
 ) -> None:
     result = redact_text(text)
-    assert result.replacements.get(label) == 1, (
-        f"expected one match for {label!r} in {text!r}; got {result.replacements}"
-    )
-    assert marker in result.value, (
-        f"marker {marker!r} missing from redacted output {result.value!r}"
-    )
+    assert (
+        result.replacements.get(label) == 1
+    ), f"expected one match for {label!r} in {text!r}; got {result.replacements}"
+    assert (
+        marker in result.value
+    ), f"marker {marker!r} missing from redacted output {result.value!r}"
 
 
 _NEGATIVE_CASES = [
@@ -71,6 +74,13 @@ _NEGATIVE_CASES = [
     "Hello world.",
     "1234567890",
     "",
+    # discord_id — 16 digits is below the 17-digit threshold, common
+    # domain numbers must not be redacted.
+    "1234567890123456",
+    "round 140",
+    "at 1:23:45",
+    "page 2",
+    "42",
 ]
 
 
@@ -118,3 +128,41 @@ def test_redact_payload_preserves_non_string_leaves() -> None:
     result = redact_payload(payload)
     assert result.value == payload
     assert not result.replacements
+
+
+# ---------------------------------------------------------------------------
+# Discord-mention shapes — the bare-snowflake regex must catch the ID
+# inside each of the standard Discord mention wrappers. The safety
+# invariant is "no raw 17–20 digit snowflake survives"; we deliberately
+# do NOT pin the exact bracket-stripping cosmetic form so the test
+# stays resilient to future regex tweaks.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "<@123456789012345678>",  # user mention
+        "<@!123456789012345678>",  # legacy nickname mention
+        "<#123456789012345678>",  # channel mention
+        "<@&123456789012345678>",  # role mention
+        "Hi <@123456789012345678> see <@!987654321098765432>",
+        "see id 123456789012345678 here",
+    ],
+)
+def test_redact_text_strips_snowflakes_from_discord_mentions(text: str) -> None:
+    result = redact_text(text)
+    assert "123456789012345678" not in result.value
+    assert "987654321098765432" not in result.value
+    assert result.replacements.get("discord_id", 0) >= 1
+
+
+def test_redact_text_precedence_keeps_secret_label_over_snowflake() -> None:
+    """An ``sk-…`` token whose tail looks numeric is still labelled
+    ``api_key_like`` rather than ``discord_id``."""
+    result = redact_text("token sk_live_1234567890123456789")
+    assert result.replacements.get("api_key_like") == 1
+    # The secret pattern consumed the entire blob; the snowflake
+    # pattern should not also match on the same span.
+    assert result.replacements.get("discord_id", 0) == 0
+    assert "[api_key_like:redacted]" in result.value

--- a/tests/unit/services/test_ai_instruction_service_memory.py
+++ b/tests/unit/services/test_ai_instruction_service_memory.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import pytest
 
 from services import ai_instruction_service
+from services.ai_instruction_service import _speaker_label
 from utils.db import ai as ai_db
 
 
@@ -34,6 +35,9 @@ async def test_assemble_with_no_recent_turns_unchanged(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_assemble_renders_recent_turns_as_untrusted_data(monkeypatch):
+    """Recent turns are wrapped + pseudonymized; raw user IDs never reach
+    the model-visible block."""
+
     async def _get(_pid):
         return None
 
@@ -49,18 +53,23 @@ async def test_assemble_renders_recent_turns_as_untrusted_data(monkeypatch):
         user_message="follow-up",
         profile_ids=(),
         recent_turns=turns,
+        bot_user_id=999,
     )
-    # The recent-turns block is the FIRST data entry.
     recent_block = stack.data[0]
-    # Untrusted wrapper present.
     assert "UNTRUSTED_DATA__recent_channel_turns__BEGIN" in recent_block
-    # All three rendered.
     assert "prior question" in recent_block
     assert "prior reply" in recent_block
     assert "bystander comment" in recent_block
-    # Role + user_id appears in each line.
-    assert "[user user=10]" in recent_block
-    assert "[assistant user=999]" in recent_block
+    # Pseudonymous labels — bot=999 is 'assistant', the two humans get
+    # user_A / user_B in first-seen order.
+    assert "[assistant] prior reply" in recent_block
+    assert "[user_A] prior question" in recent_block
+    assert "[user_B] bystander comment" in recent_block
+    # Raw user_id metadata is gone.
+    assert "user_id=" not in recent_block
+    assert "user=10" not in recent_block
+    assert "user=20" not in recent_block
+    assert "999" not in recent_block
 
 
 @pytest.mark.asyncio
@@ -96,9 +105,7 @@ async def test_assemble_empty_recent_turns_skipped(monkeypatch):
         profile_ids=(),
         recent_turns=[],
     )
-    assert all(
-        "recent_channel_turns" not in block for block in stack.data
-    )
+    assert all("recent_channel_turns" not in block for block in stack.data)
 
 
 @pytest.mark.asyncio
@@ -121,3 +128,200 @@ async def test_assemble_recent_turns_propagate_into_payload(monkeypatch):
     payload = stack.render_payload_text()
     assert "LOOK_FOR_ME" in payload
     assert "now" in payload  # user message still appended at the end.
+
+
+# ---------------------------------------------------------------------------
+# T3: task contract is included even when the user asks for a summary.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_assemble_renders_task_contract_with_summary_intent(monkeypatch):
+    """Summary intent is handled by prompt language, not by routing.
+
+    The task contract must always be present so the model decides
+    summary-vs-direct-reply from the current_user_message text.
+    """
+
+    async def _get(_pid):
+        return None
+
+    monkeypatch.setattr(ai_db, "get_instruction_profile", _get)
+
+    turns = [
+        SimpleNamespace(user_id=11, role="user", text="alpha"),
+        SimpleNamespace(user_id=22, role="user", text="beta"),
+        SimpleNamespace(user_id=33, role="user", text="gamma"),
+    ]
+    stack = await ai_instruction_service.assemble(
+        guild_id=1,
+        user_message="summarize recent chat",
+        profile_ids=(),
+        recent_turns=turns,
+    )
+    system_prompt = stack.render_system_prompt()
+    payload = stack.render_payload_text()
+
+    assert "Task contract" in system_prompt
+    assert "current_user_message" in system_prompt
+    assert "Do not summarize" in system_prompt
+    # The triggering message is the LAST untrusted span, framed as
+    # current_user_message (not the legacy user_message label).
+    assert "UNTRUSTED_DATA__current_user_message__BEGIN" in payload
+    assert "summarize recent chat" in payload
+    # Recent-turns block precedes the current_user_message block.
+    assert payload.rindex("recent_channel_turns") < payload.rindex(
+        "current_user_message"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T4a: assembler does not render a user_id= field; body-text scrubbing is
+#      redaction's job (tested separately in test_redaction.py).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_assemble_does_not_render_user_id_field(monkeypatch):
+    async def _get(_pid):
+        return None
+
+    monkeypatch.setattr(ai_db, "get_instruction_profile", _get)
+
+    turns = [
+        SimpleNamespace(
+            user_id=123456789012345678,
+            role="user",
+            text="see <@987654321098765432>",
+        ),
+    ]
+    stack = await ai_instruction_service.assemble(
+        guild_id=1,
+        user_message="hi",
+        profile_ids=(),
+        recent_turns=turns,
+        bot_user_id=999000000000000001,
+    )
+    recent_block = stack.data[0]
+    # Speaker metadata is labelled, not raw.
+    assert "[user_A]" in recent_block
+    assert "user_id=" not in recent_block
+    assert "123456789012345678" not in recent_block
+    # NOTE: <@987654321098765432> inside turn.text is NOT scrubbed by
+    # the assembler — that is the redaction layer's responsibility
+    # (gateway-side inbound + stage-side outbound).
+
+
+# ---------------------------------------------------------------------------
+# T8: pseudonym stability — same speaker → same label across turns.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_speaker_label_stability_within_assemble(monkeypatch):
+    async def _get(_pid):
+        return None
+
+    monkeypatch.setattr(ai_db, "get_instruction_profile", _get)
+
+    turns = [
+        SimpleNamespace(user_id=10, role="user", text="one"),
+        SimpleNamespace(user_id=20, role="user", text="two"),
+        SimpleNamespace(user_id=10, role="user", text="three"),
+        SimpleNamespace(user_id=20, role="user", text="four"),
+        SimpleNamespace(user_id=10, role="user", text="five"),
+    ]
+    stack = await ai_instruction_service.assemble(
+        guild_id=1,
+        user_message="x",
+        profile_ids=(),
+        recent_turns=turns,
+    )
+    block = stack.data[0]
+    # user=10 always renders with the same label; user=20 with a different stable one.
+    assert "[user_A] one" in block
+    assert "[user_B] two" in block
+    assert "[user_A] three" in block
+    assert "[user_B] four" in block
+    assert "[user_A] five" in block
+
+
+# ---------------------------------------------------------------------------
+# T9: bot id mapped to 'assistant' even when it appears before any human.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bot_id_maps_to_assistant_even_if_appears_first(monkeypatch):
+    async def _get(_pid):
+        return None
+
+    monkeypatch.setattr(ai_db, "get_instruction_profile", _get)
+
+    bot_id = 555000000000000000
+    turns = [
+        SimpleNamespace(user_id=bot_id, role="assistant", text="bot first"),
+        SimpleNamespace(user_id=10, role="user", text="human after"),
+    ]
+    stack = await ai_instruction_service.assemble(
+        guild_id=1,
+        user_message="x",
+        profile_ids=(),
+        recent_turns=turns,
+        bot_user_id=bot_id,
+    )
+    block = stack.data[0]
+    assert "[assistant] bot first" in block
+    # The first non-bot human is user_A (not user_B — the bot does
+    # not consume an index in the user_X sequence).
+    assert "[user_A] human after" in block
+
+
+# ---------------------------------------------------------------------------
+# T10: no bot_user_id → no 'assistant' label is guessed.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_bot_user_id_does_not_guess_assistant_label(monkeypatch):
+    async def _get(_pid):
+        return None
+
+    monkeypatch.setattr(ai_db, "get_instruction_profile", _get)
+
+    turns = [
+        SimpleNamespace(user_id=10, role="user", text="one"),
+        SimpleNamespace(user_id=999, role="assistant", text="two"),
+    ]
+    stack = await ai_instruction_service.assemble(
+        guild_id=1,
+        user_message="x",
+        profile_ids=(),
+        recent_turns=turns,
+        bot_user_id=None,
+    )
+    block = stack.data[0]
+    assert "[assistant]" not in block
+    assert "[user_A] one" in block
+    assert "[user_B] two" in block
+
+
+# ---------------------------------------------------------------------------
+# T13: direct unit test for the alphabet helper.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("index", "expected"),
+    [
+        (0, "user_A"),
+        (1, "user_B"),
+        (25, "user_Z"),
+        (26, "user_AA"),
+        (27, "user_AB"),
+        (51, "user_AZ"),
+        (52, "user_BA"),
+    ],
+)
+def test_speaker_label_alphabet_progression(index: int, expected: str) -> None:
+    assert _speaker_label(index) == expected


### PR DESCRIPTION
## Summary

Fixes the long-standing AI mention-reply bug where `@SuperBot are you there` was answered as a summary of recent channel chatter, and where raw Discord user IDs leaked into both the model prompt and user-visible replies.

The cog itself is unchanged — all fixes are in the AI pipeline (stage → instruction service → redaction). Provider serialization is unchanged so the JSON-schema callers (`setup_ai_advisor`, `btd6_ai_service`) keep working.

### Six causes fixed in one PR

| Cause | Fix |
|---|---|
| Triggering message appended to memory **before** `gather_recent_turns` ran, so it appeared in both the recent-turns block and the user-message span | New `_record_user_turn_if_visible(include_mentions=…)` helper records bystanders at the top of `process()` and the triggering mention exactly once, **after** `gather_recent_turns` |
| `@SuperBot` literal token reached the model in the `current_user_message` span | `_strip_bot_mention(text, bot_user_id=…)` removes every `<@id>` / `<@!id>` of the bot before assembly; memory still stores the raw form |
| Bare-mention messages (`<@BOT>` alone) sent an empty current message to the provider | New guard records to memory and audits as `skipped/NO_ROUTE_MATCHED` without invoking the provider |
| No trusted task contract — only safety rules. The model treated recent chatter as a summarization brief | New `_TASK_CONTRACT` system frame names the `current_user_message` span as the task and tells the model not to summarize recent context unless explicitly asked |
| `_render_recent_turn` emitted `[role user=<snowflake>] text`, leaking raw IDs | Speaker pseudonymization via `_speaker_label` → `[user_A]` / `[user_B]` / `[assistant]`, stable within one `assemble()` call. New `bot_user_id` kwarg on `assemble` is threaded from the stage |
| `redaction.py` ran on inbound only and did not catch Discord snowflakes; outbound replies were sent verbatim | New `discord_id` regex (`\b\d{17,20}\b`); stage runs `redact_text` on `reply_text` after the empty-reply guard and before `send` + memory append. Stale "inert scaffold" docstring fixed |

### Test plan

- [x] Stage payload contains task contract + `current_user_message` span, with the triggering message and no bot mention
- [x] Verbose summarizable context + normal question routes to `GENERAL_NL_ANSWER` and contract instructs no-summarize
- [x] Explicit summary intent flows through the contract (no router change needed)
- [x] Raw IDs absent from model-visible context (assembler) and outbound reply (stage + redaction)
- [x] Triggering message appears exactly once in the rendered payload (no duplication)
- [x] Triggering mention recorded exactly once on success path AND denial path
- [x] Multiple bot mentions stripped, not just the first
- [x] Bare `<@BOT>` message does not call the provider
- [x] Speaker label stability across repeated user IDs; bot-first ordering still labels human as `user_A`; `bot_user_id=None` doesn't guess `assistant`
- [x] `_speaker_label` alphabet generator: 0→`user_A`, 25→`user_Z`, 26→`user_AA`, 52→`user_BA`
- [x] Snowflake redaction covers `<@id>`, `<@!id>`, `<#id>`, `<@&id>`, bare digits; 16-digit numbers and short domain numbers (round counts, time codes) are NOT redacted
- [x] Precedence: an `sk_…` token whose tail looks numeric is still labelled `api_key_like`, not `discord_id`
- [x] Outbound assistant turn written to conversation memory is the sanitized form
- [x] Full suite: `python3.10 -m pytest tests/ -q` → 5506 passed, 3 skipped (pre-existing)
- [x] `python3.10 scripts/check_architecture.py --mode strict` → 0 errors

### Out of scope (intentionally)

- AI cog (read-only diagnostics)
- Policy resolver / task router
- Provider serialization contract
- DB schema / migrations
- New settings keys

https://claude.ai/code/session_01AxDZdVNwVdqmDd62rZTYQp

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxDZdVNwVdqmDd62rZTYQp)_