### PR TITLE
BTD6: status panel reflects btd6_facts + fan-out chains + recursion

### DIFF
--- a/disbot/cogs/btd6/_embeds.py
+++ b/disbot/cogs/btd6/_embeds.py
@@ -1,13 +1,18 @@
 """Embed builders for BTD6 (extracted from btd6_cog.py for size).
 
-Pure functions that take BTD6 service output and produce
-:class:`discord.Embed` instances. No DB access, no provider calls.
+Most builders are pure functions over BTD6 service output and never
+touch I/O. The exception is :func:`build_status_embed`, which is
+``async`` and reads ``btd6_facts`` aggregates via
+``btd6_knowledge_service.fact_summary_by_kind`` so the status panel
+reflects live ingestion. No provider calls anywhere.
+
 The cog and the panel view both consume from here so the cog itself
 stays small enough to satisfy the S4.6 cog-size invariant.
 """
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any
 
 import discord
@@ -74,8 +79,112 @@ def response_to_embed(response: Any) -> discord.Embed:
     return embed
 
 
-def build_status_embed() -> discord.Embed:
-    """BTD6 status: data version + entity counts."""
+_BUCKET_EMOJI = {
+    "fresh": "🟢",
+    "aging": "🟡",
+    "stale": "🔴",
+    "never": "⚪",
+}
+
+
+# Useful-first display order for the Live facts block. Kinds not in
+# this tuple are appended alphabetically — operators see the most
+# relevant rotations first as the API grows.
+_LIVE_KIND_ORDER = (
+    "btd6_event",
+    "btd6_map",
+    "btd6_boss",
+    "btd6_race",
+    "btd6_challenge",
+    "btd6_odyssey",
+    "btd6_ct",
+)
+
+
+def _live_kind_sort_key(entity_kind: str) -> tuple[int, str]:
+    """Useful-first ordering for live facts.
+
+    Known kinds get their explicit rank; everything else falls through
+    to an alphabetical tail so new kinds don't disappear from the panel.
+    """
+    try:
+        return (_LIVE_KIND_ORDER.index(entity_kind), entity_kind)
+    except ValueError:
+        return (len(_LIVE_KIND_ORDER), entity_kind)
+
+
+def _short_kind(entity_kind: str) -> str:
+    """Strip the leading ``btd6_`` so the panel doesn't shout it 12 times."""
+    if entity_kind.startswith("btd6_"):
+        return entity_kind[len("btd6_") :]
+    return entity_kind
+
+
+def _format_age(last_fetched_at: datetime | None) -> str:
+    """Render newest-fact age as ``Xm ago`` / ``Xh ago`` / ``Xd ago``.
+
+    ``None`` → ``"never fetched"`` so the placeholder is grammatical.
+    Naive datetimes are interpreted as UTC.
+    """
+    if last_fetched_at is None:
+        return "never fetched"
+    if last_fetched_at.tzinfo is None:
+        last_fetched_at = last_fetched_at.replace(tzinfo=timezone.utc)
+    seconds = int((datetime.now(tz=timezone.utc) - last_fetched_at).total_seconds())
+    if seconds < 0:
+        return "just now"
+    if seconds < 60:
+        return f"{seconds}s ago"
+    if seconds < 3600:
+        return f"{seconds // 60}m ago"
+    if seconds < 86_400:
+        return f"{seconds // 3600}h ago"
+    return f"{seconds // 86_400}d ago"
+
+
+def _format_live_facts_value(
+    summaries: tuple[btd6_knowledge_service.FactKindSummary, ...],
+    *,
+    max_rows: int = 12,
+) -> str:
+    """Render the Live facts field value, ordered useful-first.
+
+    Caps at ``max_rows`` so the embed never exceeds Discord's 1024-char
+    field-value limit even with many kinds; the cap is well below the
+    25-row embed-field maximum.
+    """
+    if not summaries:
+        return (
+            "No facts ingested yet. Run `!btd6 refresh-source <key>` "
+            "or wait for the next supervisor cycle."
+        )
+    ordered = sorted(summaries, key=lambda s: _live_kind_sort_key(s.entity_kind))
+    kept = ordered[:max_rows]
+    lines = []
+    for summary in kept:
+        emoji = _BUCKET_EMOJI.get(summary.bucket, "⚪")
+        age = _format_age(summary.last_fetched_at)
+        count = f"{summary.fact_count} facts" if summary.fact_count != 1 else "1 fact"
+        lines.append(
+            f"{emoji} `{_short_kind(summary.entity_kind):<10}` "
+            f"{count} · newest fact {age}",
+        )
+    dropped = len(ordered) - len(kept)
+    if dropped > 0:
+        lines.append(f"… (+{dropped} more)")
+    return "\n".join(lines)
+
+
+async def build_status_embed() -> discord.Embed:
+    """BTD6 status: seed taxonomy + live ``btd6_facts`` aggregates.
+
+    Two blocks. The "Reference (seed)" block reflects the static
+    fixture set — towers, heroes, modes, rounds — and is what the
+    deterministic resolver answers from. The "Live facts" block
+    aggregates ``btd6_facts`` by ``entity_kind`` and bucketizes the
+    newest-fact age via the central freshness helper. Per-source-key
+    health stays in ``!btd6 source-health``.
+    """
     embed = discord.Embed(
         title="🐵 BTD6 Assistant — Status",
         description=(
@@ -85,34 +194,23 @@ def build_status_embed() -> discord.Embed:
         color=discord.Color.green(),
     )
     embed.add_field(
-        name="Data version",
-        value=btd6_knowledge_service.data_version(),
-        inline=True,
+        name="📚 Reference (seed)",
+        value=(
+            f"Data version: `{btd6_knowledge_service.data_version()}` · "
+            f"Game version: `{btd6_knowledge_service.game_version()}`\n"
+            f"Towers: **{len(btd6_knowledge_service.list_towers())}** · "
+            f"Heroes: **{len(btd6_knowledge_service.list_heroes())}** · "
+            f"Maps: **{len(btd6_knowledge_service.list_maps())}** · "
+            f"Modes: **{len(btd6_knowledge_service.list_modes())}** · "
+            f"Rounds: **{len(btd6_knowledge_service.list_rounds())}**"
+        ),
+        inline=False,
     )
+    summaries = await btd6_knowledge_service.fact_summary_by_kind()
     embed.add_field(
-        name="Game version",
-        value=btd6_knowledge_service.game_version(),
-        inline=True,
-    )
-    embed.add_field(
-        name="Towers",
-        value=str(len(btd6_knowledge_service.list_towers())),
-        inline=True,
-    )
-    embed.add_field(
-        name="Heroes",
-        value=str(len(btd6_knowledge_service.list_heroes())),
-        inline=True,
-    )
-    embed.add_field(
-        name="Maps",
-        value=str(len(btd6_knowledge_service.list_maps())),
-        inline=True,
-    )
-    embed.add_field(
-        name="Rounds",
-        value=str(len(btd6_knowledge_service.list_rounds())),
-        inline=True,
+        name="📊 Live facts (btd6_facts)",
+        value=_format_live_facts_value(summaries),
+        inline=False,
     )
     return embed
 

--- a/disbot/cogs/btd6_cog.py
+++ b/disbot/cogs/btd6_cog.py
@@ -87,7 +87,7 @@ class BTD6Cog(commands.Cog):
 
     @btd6_group.command(name="status")  # type: ignore[arg-type]
     async def btd6_status(self, ctx: commands.Context) -> None:
-        await ctx.send(embed=build_status_embed())
+        await ctx.send(embed=await build_status_embed())
 
     @btd6_group.command(name="diagnostics")  # type: ignore[arg-type]
     async def btd6_diagnostics(self, ctx: commands.Context) -> None:
@@ -395,10 +395,10 @@ class BTD6Cog(commands.Cog):
 
     @btd6_app_group.command(name="status", description="BTD6 assistant status.")
     async def btd6_status_slash(self, interaction: discord.Interaction) -> None:
-        await interaction.response.send_message(
-            embed=build_status_embed(),
-            ephemeral=True,
-        )
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        embed = await build_status_embed()
+        await safe_followup(interaction, embed=embed, ephemeral=True)
 
     @btd6_app_group.command(
         name="diagnostics",

--- a/disbot/services/btd6_ingestion_service.py
+++ b/disbot/services/btd6_ingestion_service.py
@@ -290,7 +290,7 @@ async def _run_ingestion(
 
 
 # ---------------------------------------------------------------------------
-# Dependency chains (PR 3)
+# Dependency chains
 # ---------------------------------------------------------------------------
 
 
@@ -298,55 +298,164 @@ async def _run_ingestion(
 class _DependencySpec:
     child_source: str
     path_param_builder: Callable[[str], dict[str, str]]
+    # Cap on the number of parent entity_keys expanded into child runs.
+    # ``None`` means no cap — use only when the upstream fanout is
+    # bounded by the API itself (e.g. ``nk_btd6_maps`` always returns
+    # 3 filter names).
+    max_child_keys: int | None = None
 
 
+# Two-level chains (parent → filter → one) use one entry per hop;
+# ``refresh_with_dependencies`` is recursive (depth cap ``_MAX_DEPTH``)
+# so the leaf source is reached in a single supervisor cycle.
+#
+# ``difficulty="normal"`` / ``"easy"`` defaults are documented limitations:
+# the boss / odyssey metadata endpoints require a difficulty in the path,
+# and a richer multi-difficulty fan-out needs a typed path-param builder
+# that is deferred to a follow-up PR.
 _DEPENDENCY_CHAINS: dict[str, list[_DependencySpec]] = {
+    # CT: 1-level (parent → per-tile child).
     "nk_btd6_ct": [
         _DependencySpec(
             child_source="nk_btd6_ct_tiles",
             path_param_builder=lambda ct_id: {"ctID": ct_id},
         ),
     ],
-    # nk_btd6_races: added in next PR
-    # nk_btd6_bosses, nk_btd6_odyssey: deferred (multi-param path builders needed)
+    # Maps: 2-level (parent → filter → one).
+    "nk_btd6_maps": [
+        _DependencySpec(
+            child_source="nk_btd6_maps_filter",
+            path_param_builder=lambda filter_name: {"mapFilter": filter_name},
+        ),
+    ],
+    "nk_btd6_maps_filter": [
+        _DependencySpec(
+            child_source="nk_btd6_maps_one",
+            path_param_builder=lambda map_id: {"mapID": map_id},
+            max_child_keys=10,
+        ),
+    ],
+    # Challenges: same 2-level shape as maps.
+    "nk_btd6_challenges": [
+        _DependencySpec(
+            child_source="nk_btd6_challenges_filter",
+            path_param_builder=lambda filter_name: {
+                "challengeFilter": filter_name,
+            },
+        ),
+    ],
+    "nk_btd6_challenges_filter": [
+        _DependencySpec(
+            child_source="nk_btd6_challenges_one",
+            path_param_builder=lambda ch_id: {"challengeID": ch_id},
+            max_child_keys=10,
+        ),
+    ],
+    # Races: 1-level fan-out into two child kinds (metadata + leaderboard).
+    "nk_btd6_races": [
+        _DependencySpec(
+            child_source="nk_btd6_races_metadata",
+            path_param_builder=lambda race_id: {"raceID": race_id},
+            max_child_keys=5,
+        ),
+        _DependencySpec(
+            child_source="nk_btd6_races_leaderboard",
+            path_param_builder=lambda race_id: {"raceID": race_id},
+            max_child_keys=3,
+        ),
+    ],
+    # Bosses: 1-level; difficulty hardcoded (see deferred list above).
+    "nk_btd6_bosses": [
+        _DependencySpec(
+            child_source="nk_btd6_bosses_metadata",
+            path_param_builder=lambda boss_id: {
+                "bossID": boss_id,
+                "difficulty": "normal",
+            },
+            max_child_keys=5,
+        ),
+    ],
+    # Odyssey: 1-level; difficulty hardcoded.
+    "nk_btd6_odyssey": [
+        _DependencySpec(
+            child_source="nk_btd6_odyssey_diff",
+            path_param_builder=lambda odyssey_id: {
+                "odysseyID": odyssey_id,
+                "difficulty": "easy",
+            },
+            max_child_keys=5,
+        ),
+    ],
+    # Events: parent-only — no child parsers exist.
 }
+
+
+# Recursion cap. Depth 0 = top-level parent; depth 1 = first child level;
+# depth 2 = the leaf in the two-level chains (maps_one, challenges_one).
+# Guard is placed AFTER child execution at this depth so the leaf runs.
+_MAX_DEPTH = 2
 
 
 async def refresh_with_dependencies(
     source_key: str,
     *,
+    path_params: dict[str, str] | None = None,
     reason: IngestionReason = "scheduled",
     started_by_user_id: int | None = None,
+    _depth: int = 0,
 ) -> list[IngestionResult]:
-    """Refresh a source and any declared child sources.
+    """Refresh a source and recursively expand declared dependency chains.
 
-    Child fetches use entity_key values from the current index run —
-    not stale DB rows — so only IDs present in the latest fetch are expanded.
+    Child fetches use entity_key values from the current parent run —
+    not stale DB rows — so only IDs present in the latest fetch are
+    expanded. Recursion is capped at ``_MAX_DEPTH`` so the two-level
+    chains (parent → filter → one) reach the leaf but can't run away.
 
-    Children inherit the parent's ``reason`` and ``started_by_user_id`` so
-    audit queries against ``btd6_ingestion_runs`` see the whole chain as a
-    single operator-triggered (or scheduled) operation.
+    The ``_depth`` kwarg is internal; callers must not pass it.
+
+    Child runs always record ``reason="dependency"`` (independent of the
+    parent's reason). Operator attribution flows through
+    ``started_by_user_id``, which is propagated unchanged at every depth.
+    This keeps ``triggered_by`` meaning "this run's role" and lets audit
+    queries distinguish operator-initiated child fan-out from a child
+    that was scheduled as part of a cron cycle.
     """
     results: list[IngestionResult] = []
-    index_result = await refresh_source(
+    parent_result = await refresh_source(
         source_key,
+        path_params=path_params,
         reason=reason,
         started_by_user_id=started_by_user_id,
     )
-    results.append(index_result)
-    if index_result.status != "ok":
+    results.append(parent_result)
+    if parent_result.status != "ok":
         return results
-    specs = _DEPENDENCY_CHAINS.get(source_key, [])
-    for spec in specs:
-        for entity_key in index_result.written_entity_keys:
-            path_params = spec.path_param_builder(entity_key)
-            child = await refresh_source(
+    if _depth >= _MAX_DEPTH:
+        logger.debug(
+            "btd6 ingestion chain depth cap reached at %s (depth=%d)",
+            source_key,
+            _depth,
+        )
+        return results
+    for spec in _DEPENDENCY_CHAINS.get(source_key, []):
+        entity_keys = parent_result.written_entity_keys
+        if spec.max_child_keys is not None:
+            entity_keys = entity_keys[: spec.max_child_keys]
+        for entity_key in entity_keys:
+            child_results = await refresh_with_dependencies(
                 spec.child_source,
-                path_params=path_params,
-                reason=reason,
+                path_params=spec.path_param_builder(entity_key),
+                reason="dependency",
                 started_by_user_id=started_by_user_id,
+                _depth=_depth + 1,
             )
-            results.append(child)
+            results.extend(child_results)
+    if _depth == 0:
+        logger.info(
+            "btd6 ingestion chain parent=%s total=%d",
+            source_key,
+            len(results),
+        )
     return results
 
 

--- a/disbot/services/btd6_ingestion_supervisor.py
+++ b/disbot/services/btd6_ingestion_supervisor.py
@@ -49,6 +49,8 @@ _SOURCE_INTERVALS: dict[str, int] = {
     # Map directory is comparatively static; long backoff decay so a
     # single failure doesn't pin it offline for the rest of the day.
     "nk_btd6_maps": 86400,
+    # Challenge directory also rotates daily.
+    "nk_btd6_challenges": 86400,
 }
 
 _BACKOFF_BASE_S: int = 30

--- a/disbot/services/btd6_knowledge_service.py
+++ b/disbot/services/btd6_knowledge_service.py
@@ -10,6 +10,7 @@ fixture set; nothing is invented.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 
 from services.btd6_data_service import (
     HeroEntry,
@@ -24,6 +25,7 @@ from services.btd6_data_service import (
     get_round,
     get_tower,
 )
+from services.btd6_source_registry import FreshnessBucket, bucket_freshness
 
 
 @dataclass(frozen=True)
@@ -106,3 +108,43 @@ def data_version() -> str:
 
 def game_version() -> str:
     return get_dataset().game_version
+
+
+# ---------------------------------------------------------------------------
+# Live fact summary (entity_kind aggregates over ``btd6_facts``)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FactKindSummary:
+    """One row per entity_kind in ``btd6_facts``.
+
+    ``last_fetched_at`` is the newest ``fetched_at`` across all rows of
+    that kind. ``bucket`` is the centrally-defined freshness bucket so
+    the UI doesn't reinvent thresholds.
+    """
+
+    entity_kind: str
+    fact_count: int
+    last_fetched_at: datetime | None
+    bucket: FreshnessBucket
+
+
+async def fact_summary_by_kind() -> tuple[FactKindSummary, ...]:
+    """Aggregate ``btd6_facts`` by entity_kind for the status panel.
+
+    DB layer returns rows sorted by entity_kind (stable for tests);
+    UI consumers re-sort by useful-first.
+    """
+    from utils.db.btd6_sources import aggregate_facts_by_entity_kind
+
+    rows = await aggregate_facts_by_entity_kind()
+    return tuple(
+        FactKindSummary(
+            entity_kind=row["entity_kind"],
+            fact_count=int(row["fact_count"]),
+            last_fetched_at=row.get("last_fetched_at"),
+            bucket=bucket_freshness(row.get("last_fetched_at")),
+        )
+        for row in rows
+    )

--- a/disbot/services/btd6_source_registry.py
+++ b/disbot/services/btd6_source_registry.py
@@ -34,18 +34,31 @@ _FRESH_THRESHOLD = timedelta(hours=6)
 _AGING_THRESHOLD = timedelta(days=2)
 
 
-def _bucket_for(last_fetched_at: datetime | None) -> FreshnessBucket:
+def bucket_freshness(last_fetched_at: datetime | None) -> FreshnessBucket:
+    """Public freshness bucketing helper.
+
+    Single source of truth for the fresh/aging/stale/never buckets.
+    Source-health (per source key) and the BTD6 fact summary (per
+    entity_kind) both depend on this — do not duplicate thresholds
+    elsewhere.
+
+    Naive datetimes are interpreted as UTC.
+    """
     if last_fetched_at is None:
         return "never"
-    now = datetime.now(tz=timezone.utc)
     if last_fetched_at.tzinfo is None:
         last_fetched_at = last_fetched_at.replace(tzinfo=timezone.utc)
-    age = now - last_fetched_at
+    age = datetime.now(tz=timezone.utc) - last_fetched_at
     if age <= _FRESH_THRESHOLD:
         return "fresh"
     if age <= _AGING_THRESHOLD:
         return "aging"
     return "stale"
+
+
+# Internal alias kept for any in-module readers; new code should call
+# ``bucket_freshness`` directly.
+_bucket_for = bucket_freshness
 
 
 @dataclass(frozen=True)
@@ -145,6 +158,7 @@ async def is_source_usable(source_key: str) -> tuple[bool, str]:
 __all__ = [
     "FreshnessBucket",
     "SourceHealth",
+    "bucket_freshness",
     "get_by_id",
     "get_by_key",
     "is_source_usable",

--- a/disbot/utils/db/btd6_sources.py
+++ b/disbot/utils/db/btd6_sources.py
@@ -345,6 +345,22 @@ async def get_latest_fact(
     return dict(row) if row else None
 
 
+async def aggregate_facts_by_entity_kind() -> list[dict[str, Any]]:
+    """One row per entity_kind in ``btd6_facts`` with count + max(fetched_at).
+
+    Stable SQL ordering (by entity_kind) so unit tests can assert
+    deterministic shape; UI consumers re-order by useful-first.
+    """
+    rows = await pool.get().fetch(
+        "SELECT entity_kind, COUNT(*)::int AS fact_count, "
+        "MAX(fetched_at) AS last_fetched_at "
+        "FROM btd6_facts "
+        "GROUP BY entity_kind "
+        "ORDER BY entity_kind",
+    )
+    return [dict(r) for r in rows]
+
+
 async def search_facts(
     *,
     fact_type: str | None = None,

--- a/disbot/views/btd6/panel.py
+++ b/disbot/views/btd6/panel.py
@@ -171,6 +171,6 @@ class BTD6PanelView(PersistentView):
         from cogs.btd6._embeds import build_status_embed
 
         await interaction.response.edit_message(
-            embed=build_status_embed(),
+            embed=await build_status_embed(),
             view=self,
         )

--- a/tests/unit/cogs/test_btd6_api_refresh_command.py
+++ b/tests/unit/cogs/test_btd6_api_refresh_command.py
@@ -605,6 +605,10 @@ def test_refresh_source_or_dependencies_exported_in_all():
 
 @pytest.mark.asyncio
 async def test_refresh_source_or_dependencies_routes_single_source(monkeypatch):
+    # ``nk_btd6_events`` is intentionally NOT in _DEPENDENCY_CHAINS
+    # (no child parsers exist for the events endpoint) so this is the
+    # canonical single-source test case. Don't switch to a chain
+    # parent like ``nk_btd6_maps`` — that would now fan out.
     async def _mock_refresh(
         source_key,
         *,
@@ -621,12 +625,12 @@ async def test_refresh_source_or_dependencies_routes_single_source(monkeypatch):
     )
 
     results = await btd6_ingestion_service.refresh_source_or_dependencies(
-        "nk_btd6_maps",
+        "nk_btd6_events",
         reason="manual",
         started_by_user_id=1,
     )
     assert len(results) == 1
-    assert results[0].source_key == "nk_btd6_maps"
+    assert results[0].source_key == "nk_btd6_events"
 
 
 @pytest.mark.asyncio
@@ -730,7 +734,14 @@ async def test_refresh_source_or_dependencies_propagates_started_by(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_refresh_with_dependencies_child_reason_inherits_parent(monkeypatch):
+async def test_refresh_with_dependencies_child_role_is_dependency(monkeypatch):
+    """Child runs always record ``triggered_by="dependency"`` (their role
+    in the chain) regardless of the parent's reason. Operator
+    attribution lives in ``started_by_user_id``.
+
+    This replaces the post-#353 inherit-parent-reason behaviour — see
+    the audit-semantic section in the production-readiness plan.
+    """
     reasons: list[str] = []
 
     async def _mock_refresh(
@@ -764,4 +775,5 @@ async def test_refresh_with_dependencies_child_reason_inherits_parent(monkeypatc
         reason="manual",
         started_by_user_id=1,
     )
-    assert reasons == ["manual", "manual"]
+    # Parent role flows through; child role is "dependency".
+    assert reasons == ["manual", "dependency"]

--- a/tests/unit/cogs/test_btd6_boundaries.py
+++ b/tests/unit/cogs/test_btd6_boundaries.py
@@ -187,8 +187,19 @@ _STALE_STRINGS = (
 )
 
 
-def test_status_embed_has_no_stale_strings():
-    embed = build_status_embed()
+@pytest.mark.asyncio
+async def test_status_embed_has_no_stale_strings(monkeypatch):
+    from services import btd6_knowledge_service
+
+    async def _empty_summary():
+        return ()
+
+    monkeypatch.setattr(
+        btd6_knowledge_service,
+        "fact_summary_by_kind",
+        _empty_summary,
+    )
+    embed = await build_status_embed()
     blob = (embed.title or "") + " " + (embed.description or "")
     for stale in _STALE_STRINGS:
         assert stale not in blob, f"Stale string {stale!r} in status embed"

--- a/tests/unit/cogs/test_btd6_cog.py
+++ b/tests/unit/cogs/test_btd6_cog.py
@@ -62,8 +62,19 @@ def test_btd6_cog_declares_entry_point_commands():
     assert "btd6menu" in names
 
 
-def test_status_embed_builder_returns_embed():
-    embed = build_status_embed()
+@pytest.mark.asyncio
+async def test_status_embed_builder_returns_embed(monkeypatch):
+    from services import btd6_knowledge_service
+
+    async def _empty_summary():
+        return ()
+
+    monkeypatch.setattr(
+        btd6_knowledge_service,
+        "fact_summary_by_kind",
+        _empty_summary,
+    )
+    embed = await build_status_embed()
     assert isinstance(embed, discord.Embed)
     assert "Status" in (embed.title or "")
 

--- a/tests/unit/cogs/test_btd6_status_embed_live.py
+++ b/tests/unit/cogs/test_btd6_status_embed_live.py
@@ -1,0 +1,213 @@
+"""Tests for the async ``build_status_embed`` Live facts block."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import discord
+import pytest
+
+from cogs.btd6._embeds import build_status_embed
+
+
+@pytest.mark.asyncio
+async def test_status_embed_has_seed_and_live_blocks(monkeypatch):
+    from services import btd6_knowledge_service
+
+    now = datetime.now(tz=timezone.utc)
+
+    async def _summary():
+        return (
+            btd6_knowledge_service.FactKindSummary(
+                entity_kind="btd6_event",
+                fact_count=14,
+                last_fetched_at=now - timedelta(minutes=45),
+                bucket="fresh",
+            ),
+            btd6_knowledge_service.FactKindSummary(
+                entity_kind="btd6_map",
+                fact_count=78,
+                last_fetched_at=now - timedelta(hours=2),
+                bucket="fresh",
+            ),
+        )
+
+    monkeypatch.setattr(
+        btd6_knowledge_service,
+        "fact_summary_by_kind",
+        _summary,
+    )
+
+    embed = await build_status_embed()
+    assert isinstance(embed, discord.Embed)
+    names = [f.name for f in embed.fields]
+    assert any("📚" in n for n in names), "expected a seed block"
+    assert any("📊" in n for n in names), "expected a live-facts block"
+
+
+@pytest.mark.asyncio
+async def test_status_embed_empty_db_renders_placeholder(monkeypatch):
+    from services import btd6_knowledge_service
+
+    async def _empty():
+        return ()
+
+    monkeypatch.setattr(
+        btd6_knowledge_service,
+        "fact_summary_by_kind",
+        _empty,
+    )
+
+    embed = await build_status_embed()
+    live_field = next(f for f in embed.fields if "📊" in (f.name or ""))
+    value = live_field.value or ""
+    assert "No facts ingested yet" in value
+    assert "refresh-source" in value
+
+
+@pytest.mark.asyncio
+async def test_status_embed_uses_useful_first_order(monkeypatch):
+    """event → map → boss → race → challenge → odyssey → ct."""
+    from services import btd6_knowledge_service
+
+    now = datetime.now(tz=timezone.utc)
+
+    # Intentionally pass them in reverse alphabetical / random order;
+    # the builder must re-sort by useful-first.
+    async def _summary():
+        return tuple(
+            btd6_knowledge_service.FactKindSummary(
+                entity_kind=kind,
+                fact_count=1,
+                last_fetched_at=now,
+                bucket="fresh",
+            )
+            for kind in (
+                "btd6_ct",
+                "btd6_odyssey",
+                "btd6_challenge",
+                "btd6_race",
+                "btd6_boss",
+                "btd6_map",
+                "btd6_event",
+            )
+        )
+
+    monkeypatch.setattr(
+        btd6_knowledge_service,
+        "fact_summary_by_kind",
+        _summary,
+    )
+
+    embed = await build_status_embed()
+    live_field = next(f for f in embed.fields if "📊" in (f.name or ""))
+    value = live_field.value or ""
+
+    # Each kind appears on its own line. Walk lines in display order and
+    # assert event < map < boss < race < challenge < odyssey < ct.
+    indices = {}
+    for i, line in enumerate(value.splitlines()):
+        for kind in (
+            "event",
+            "map",
+            "boss",
+            "race",
+            "challenge",
+            "odyssey",
+            "ct",
+        ):
+            if f"`{kind:<10}`" in line:
+                indices[kind] = i
+    assert indices["event"] < indices["map"] < indices["boss"]
+    assert indices["boss"] < indices["race"] < indices["challenge"]
+    assert indices["challenge"] < indices["odyssey"] < indices["ct"]
+
+
+@pytest.mark.asyncio
+async def test_status_embed_uses_newest_fact_wording_not_source_health(monkeypatch):
+    """Labels must distinguish entity-kind freshness from source-key health."""
+    from services import btd6_knowledge_service
+
+    async def _summary():
+        return (
+            btd6_knowledge_service.FactKindSummary(
+                entity_kind="btd6_map",
+                fact_count=10,
+                last_fetched_at=datetime.now(tz=timezone.utc),
+                bucket="fresh",
+            ),
+        )
+
+    monkeypatch.setattr(
+        btd6_knowledge_service,
+        "fact_summary_by_kind",
+        _summary,
+    )
+
+    embed = await build_status_embed()
+    live_field = next(f for f in embed.fields if "📊" in (f.name or ""))
+    value = (live_field.value or "").lower()
+    assert "newest fact" in value, "expected 'newest fact X ago' wording"
+    assert "source-health" not in value
+    assert "source health" not in value
+
+
+@pytest.mark.asyncio
+async def test_status_embed_caps_rows_for_many_kinds(monkeypatch):
+    """Many entity_kinds must stay within Discord's field-value limit."""
+    from services import btd6_knowledge_service
+
+    now = datetime.now(tz=timezone.utc)
+
+    async def _summary():
+        return tuple(
+            btd6_knowledge_service.FactKindSummary(
+                entity_kind=f"btd6_kind_{i:02d}",
+                fact_count=1,
+                last_fetched_at=now,
+                bucket="fresh",
+            )
+            for i in range(25)
+        )
+
+    monkeypatch.setattr(
+        btd6_knowledge_service,
+        "fact_summary_by_kind",
+        _summary,
+    )
+
+    embed = await build_status_embed()
+    live_field = next(f for f in embed.fields if "📊" in (f.name or ""))
+    value = live_field.value or ""
+    # Stays under Discord's 1024-char field-value cap.
+    assert len(value) <= 1024
+    # And tells the user something was elided.
+    assert "more)" in value
+
+
+@pytest.mark.asyncio
+async def test_status_embed_renders_never_bucket(monkeypatch):
+    """A kind that has never been fetched renders with the ⚪ emoji."""
+    from services import btd6_knowledge_service
+
+    async def _summary():
+        return (
+            btd6_knowledge_service.FactKindSummary(
+                entity_kind="btd6_race",
+                fact_count=0,
+                last_fetched_at=None,
+                bucket="never",
+            ),
+        )
+
+    monkeypatch.setattr(
+        btd6_knowledge_service,
+        "fact_summary_by_kind",
+        _summary,
+    )
+
+    embed = await build_status_embed()
+    live_field = next(f for f in embed.fields if "📊" in (f.name or ""))
+    value = live_field.value or ""
+    assert "⚪" in value
+    assert "never fetched" in value

--- a/tests/unit/services/parsers/test_parser_written_keys_contract.py
+++ b/tests/unit/services/parsers/test_parser_written_keys_contract.py
@@ -1,0 +1,127 @@
+"""Pin the parser → dependency-chain contract.
+
+``refresh_with_dependencies`` builds child path_params from each
+parent's ``written_entity_keys`` (the tuple of ``entity_key`` values
+the parent's facts wrote). If a parser changes which field it stores
+as ``entity_key``, the chain silently produces wrong children — every
+downstream lookup misses.
+
+These tests assert each chain-parent parser produces ``entity_key``
+values in the shape the next-hop spec consumes.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from services.parsers.ninjakiwi_challenges import parse_challenge_filters
+from services.parsers.ninjakiwi_maps import parse_map_filters
+
+_FIXTURES = Path(__file__).resolve().parents[3] / "fixtures" / "ninjakiwi"
+
+
+def _load(name: str) -> dict:
+    with (_FIXTURES / name).open() as f:
+        return json.load(f)
+
+
+def _entity_keys(facts: list[dict]) -> set[str]:
+    return {f["entity_key"] for f in facts}
+
+
+# ---------------------------------------------------------------------------
+# Maps: parser produces filter names that the chain wraps as {"mapFilter": k}
+# ---------------------------------------------------------------------------
+
+
+def test_parse_maps_index_emits_filter_names_as_entity_keys():
+    facts = parse_map_filters(_load("btd6_maps.json"))
+    keys = _entity_keys(facts)
+    # nk_btd6_maps_filter expects entity_key to be a filter name (newest,
+    # trending, mostLiked). The chain wraps it as {"mapFilter": k}.
+    assert keys <= {"newest", "trending", "mostLiked"}
+    assert keys, "expected at least one filter name from the maps index"
+    for fact in facts:
+        assert fact["entity_kind"] == "btd6_map_filter"
+        assert isinstance(fact["entity_key"], str)
+        assert fact["entity_key"], "filter entity_key must be non-empty"
+
+
+# ---------------------------------------------------------------------------
+# Challenges: same shape as maps (parser → filter type names)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_challenges_index_emits_filter_names_as_entity_keys():
+    facts = parse_challenge_filters(_load("btd6_challenges.json"))
+    keys = _entity_keys(facts)
+    assert keys, "expected at least one filter name from the challenges index"
+    for fact in facts:
+        assert fact["entity_kind"] == "btd6_challenge_filter"
+        assert isinstance(fact["entity_key"], str)
+        assert fact["entity_key"], "filter entity_key must be non-empty"
+
+
+# ---------------------------------------------------------------------------
+# Maps_filter parser: writes map IDs that the chain wraps as {"mapID": k}
+# ---------------------------------------------------------------------------
+
+
+def test_parse_map_list_emits_map_ids_as_entity_keys():
+    from services.parsers.ninjakiwi_maps import parse_map_list
+
+    facts = parse_map_list(_load("btd6_maps_filter_newest.json"))
+    assert facts, "fixture should produce at least one map fact"
+    for fact in facts:
+        assert fact["entity_kind"] == "btd6_map"
+        assert isinstance(fact["entity_key"], str)
+        # Map ids are non-empty and don't contain whitespace — they're
+        # safe to interpolate into a URL path.
+        assert fact["entity_key"], "map entity_key must be non-empty"
+        assert " " not in fact["entity_key"]
+
+
+# ---------------------------------------------------------------------------
+# Races / bosses / odyssey: index parsers emit ID-shaped entity_keys
+# ---------------------------------------------------------------------------
+
+
+def test_parse_races_index_emits_string_ids():
+    from services.parsers.ninjakiwi_races import parse_races_index
+
+    facts = parse_races_index(_load("btd6_races.json"))
+    assert facts, "races index fixture should produce at least one fact"
+    for fact in facts:
+        assert fact["entity_kind"] == "btd6_race"
+        assert isinstance(fact["entity_key"], str) and fact["entity_key"]
+
+
+def test_parse_bosses_index_emits_string_ids():
+    from services.parsers.ninjakiwi_bosses import parse_bosses_index
+
+    facts = parse_bosses_index(_load("btd6_bosses.json"))
+    assert facts, "bosses index fixture should produce at least one fact"
+    for fact in facts:
+        assert fact["entity_kind"] == "btd6_boss"
+        assert isinstance(fact["entity_key"], str) and fact["entity_key"]
+
+
+def test_parse_odyssey_index_emits_string_ids():
+    from services.parsers.ninjakiwi_odyssey import parse_odyssey_index
+
+    facts = parse_odyssey_index(_load("btd6_odyssey.json"))
+    assert facts, "odyssey index fixture should produce at least one fact"
+    for fact in facts:
+        assert fact["entity_kind"] == "btd6_odyssey"
+        assert isinstance(fact["entity_key"], str) and fact["entity_key"]
+
+
+def test_parse_ct_index_emits_string_ids():
+    from services.parsers.ninjakiwi_ct import parse_ct_index
+
+    facts = parse_ct_index(_load("btd6_ct.json"))
+    assert facts, "ct index fixture should produce at least one fact"
+    for fact in facts:
+        assert fact["entity_kind"] == "btd6_ct"
+        assert isinstance(fact["entity_key"], str) and fact["entity_key"]

--- a/tests/unit/services/test_btd6_ai_service_grounding_pin.py
+++ b/tests/unit/services/test_btd6_ai_service_grounding_pin.py
@@ -1,0 +1,93 @@
+"""Regression pin for #354's always-on live grounding in answer_question.
+
+The grounding flow is best-effort and ALWAYS attached: every call to
+``answer_question`` invokes ``btd6_context_service.build`` and tries to
+populate ``BTD6Response.live_facts``. Failures are swallowed and the
+deterministic baseline is returned unchanged.
+
+A previous plan revision suggested making this opt-in via a kwarg —
+this test file pins the current behaviour so that suggestion can't be
+silently re-introduced.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from services import btd6_ai_service, btd6_context_service
+
+
+@pytest.mark.asyncio
+async def test_answer_question_calls_build_exactly_once(monkeypatch):
+    spy = AsyncMock(
+        return_value=btd6_context_service.BTD6Context(
+            facts=(),
+            source_summary="ignored",
+            confidence=0.0,
+        ),
+    )
+    monkeypatch.setattr(btd6_context_service, "build", spy)
+
+    await btd6_ai_service.answer_question("dart monkey")
+
+    assert spy.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_empty_facts_leaves_response_unchanged(monkeypatch):
+    async def _empty(_text):
+        return btd6_context_service.BTD6Context(
+            facts=(),
+            source_summary="ignored",
+            confidence=0.0,
+        )
+
+    monkeypatch.setattr(btd6_context_service, "build", _empty)
+
+    response = await btd6_ai_service.answer_question("dart monkey")
+    assert response.live_facts == ()
+
+
+@pytest.mark.asyncio
+async def test_build_raising_does_not_break_answer(monkeypatch):
+    async def _boom(_text):
+        raise RuntimeError("DB down")
+
+    monkeypatch.setattr(btd6_context_service, "build", _boom)
+
+    response = await btd6_ai_service.answer_question("dart monkey")
+    # The deterministic baseline is preserved.
+    assert response is not None
+    assert response.live_facts == ()
+
+
+@pytest.mark.asyncio
+async def test_non_empty_facts_flow_into_response(monkeypatch):
+    async def _facts(_text):
+        return btd6_context_service.BTD6Context(
+            facts=("Reversed Loop — type=race (source: data.ninjakiwi.com)",),
+            source_summary="data.ninjakiwi.com (Tier 1)",
+            confidence=0.5,
+        )
+
+    monkeypatch.setattr(btd6_context_service, "build", _facts)
+
+    response = await btd6_ai_service.answer_question("current race?")
+    assert response.live_facts == (
+        "Reversed Loop — type=race (source: data.ninjakiwi.com)",
+    )
+
+
+def test_no_opt_in_kwarg_on_answer_question():
+    """Defensive pin: a previous plan suggested ``include_facts_context``;
+    if that ever lands, it would silently regress the always-on
+    grounding shipped in #354."""
+    import inspect
+
+    sig = inspect.signature(btd6_ai_service.answer_question)
+    assert "include_facts_context" not in sig.parameters, (
+        "answer_question must keep grounding always-on; do not add "
+        "include_facts_context kwarg"
+    )

--- a/tests/unit/services/test_btd6_ingestion_dependency_chains.py
+++ b/tests/unit/services/test_btd6_ingestion_dependency_chains.py
@@ -1,0 +1,488 @@
+"""Recursion + dependency-chain tests for refresh_with_dependencies.
+
+These tests pin the three invariants the revision report flagged:
+
+1. Parent parsers emit the exact keys child sources consume.
+2. Recursive refresh executes depth-N leaves, blocks descent FROM depth N.
+3. Child runs record ``reason="dependency"`` regardless of parent reason;
+   ``started_by_user_id`` is propagated through every depth level.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from services import btd6_ingestion_service
+
+
+def _ok(source_key: str, *keys: str) -> btd6_ingestion_service.IngestionResult:
+    """Build an OK IngestionResult with the given ``written_entity_keys``."""
+    return btd6_ingestion_service.IngestionResult(
+        source_key=source_key,
+        status="ok",
+        fact_count=len(keys) or 1,
+        duration_ms=1,
+        error_code=None,
+        run_id=1,
+        written_entity_keys=tuple(keys),
+    )
+
+
+def _bad(source_key: str) -> btd6_ingestion_service.IngestionResult:
+    return btd6_ingestion_service.IngestionResult(
+        source_key=source_key,
+        status="fetch_error",
+        fact_count=0,
+        duration_ms=1,
+        error_code="503",
+        run_id=2,
+        written_entity_keys=(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Chain shape: maps → filter → one (two-level recursion)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_maps_chain_executes_three_levels(monkeypatch):
+    """Refreshing nk_btd6_maps should reach nk_btd6_maps_one for every map id."""
+    calls: list[tuple[str, dict | None]] = []
+
+    # Per-source canned responses. Each call records the (source_key,
+    # path_params) tuple so we can assert exact call counts and the
+    # path params each level produced.
+    map_ids_per_filter = {
+        "newest": [f"map_n_{i}" for i in range(15)],  # > cap of 10
+        "trending": ["map_t_a", "map_t_b"],
+        "mostLiked": ["map_l_x"],
+    }
+
+    async def _refresh_source_stub(source_key, *, path_params=None, **kw):
+        calls.append((source_key, path_params))
+        if source_key == "nk_btd6_maps":
+            return _ok(source_key, "newest", "trending", "mostLiked")
+        if source_key == "nk_btd6_maps_filter":
+            filter_name = (path_params or {}).get("mapFilter")
+            return _ok(source_key, *map_ids_per_filter.get(filter_name, []))
+        if source_key == "nk_btd6_maps_one":
+            return _ok(source_key, (path_params or {}).get("mapID", ""))
+        return _ok(source_key)
+
+    monkeypatch.setattr(
+        btd6_ingestion_service,
+        "refresh_source",
+        _refresh_source_stub,
+    )
+
+    results = await btd6_ingestion_service.refresh_with_dependencies(
+        "nk_btd6_maps",
+        reason="manual",
+        started_by_user_id=42,
+    )
+
+    # Bucket calls by source_key for exact counting.
+    by_source: dict[str, list[dict | None]] = {}
+    for src, params in calls:
+        by_source.setdefault(src, []).append(params)
+
+    # 1 parent + 3 filter children (one per filter name).
+    assert len(by_source["nk_btd6_maps"]) == 1
+    assert len(by_source["nk_btd6_maps_filter"]) == 3
+    filters_passed = {p["mapFilter"] for p in by_source["nk_btd6_maps_filter"]}
+    assert filters_passed == {"newest", "trending", "mostLiked"}
+
+    # maps_one: 10 from newest (cap), 2 from trending, 1 from mostLiked = 13.
+    assert len(by_source["nk_btd6_maps_one"]) == 13
+    map_ids_called = [p["mapID"] for p in by_source["nk_btd6_maps_one"]]
+    # The cap drops map_n_10..14 — only first 10 from "newest".
+    assert "map_n_0" in map_ids_called
+    assert "map_n_9" in map_ids_called
+    assert "map_n_10" not in map_ids_called
+    assert "map_t_a" in map_ids_called
+    assert "map_l_x" in map_ids_called
+
+    # Results aggregate parent + every successful child.
+    assert len(results) == 1 + 3 + 13
+
+
+# ---------------------------------------------------------------------------
+# Chain shape: challenges (same two-level pattern as maps)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_challenges_chain_same_shape(monkeypatch):
+    calls: list[tuple[str, dict | None]] = []
+
+    async def _stub(source_key, *, path_params=None, **kw):
+        calls.append((source_key, path_params))
+        if source_key == "nk_btd6_challenges":
+            return _ok(source_key, "daily", "newest")
+        if source_key == "nk_btd6_challenges_filter":
+            return _ok(source_key, "ch_1", "ch_2")
+        return _ok(source_key)
+
+    monkeypatch.setattr(btd6_ingestion_service, "refresh_source", _stub)
+
+    await btd6_ingestion_service.refresh_with_dependencies("nk_btd6_challenges")
+
+    by_source: dict[str, list[dict | None]] = {}
+    for src, params in calls:
+        by_source.setdefault(src, []).append(params)
+
+    assert len(by_source["nk_btd6_challenges"]) == 1
+    assert len(by_source["nk_btd6_challenges_filter"]) == 2
+    # 2 filters × 2 challenge ids = 4 leaf calls.
+    assert len(by_source["nk_btd6_challenges_one"]) == 4
+
+
+# ---------------------------------------------------------------------------
+# Chain shape: races (two children of the same parent: metadata + leaderboard)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_races_fans_into_metadata_and_leaderboard(monkeypatch):
+    calls: list[tuple[str, dict | None]] = []
+
+    async def _stub(source_key, *, path_params=None, **kw):
+        calls.append((source_key, path_params))
+        if source_key == "nk_btd6_races":
+            # 8 race ids — caps will trim per child.
+            return _ok(source_key, *(f"race_{i}" for i in range(8)))
+        return _ok(source_key)
+
+    monkeypatch.setattr(btd6_ingestion_service, "refresh_source", _stub)
+
+    await btd6_ingestion_service.refresh_with_dependencies("nk_btd6_races")
+
+    by_source: dict[str, list[dict | None]] = {}
+    for src, params in calls:
+        by_source.setdefault(src, []).append(params)
+
+    # Caps: metadata=5, leaderboard=3.
+    assert len(by_source["nk_btd6_races_metadata"]) == 5
+    assert len(by_source["nk_btd6_races_leaderboard"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# Single-source helper uses an intentionally unchained source
+# (per second revision report: don't use nk_btd6_maps — it's a chain
+# parent now.)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_single_source_helper_returns_one_result_for_events(monkeypatch):
+    """events is parent-only — no child parsers exist in the registry."""
+    calls: list[str] = []
+
+    async def _stub(source_key, *, path_params=None, **kw):
+        calls.append(source_key)
+        return _ok(source_key, "evt_1", "evt_2")
+
+    monkeypatch.setattr(btd6_ingestion_service, "refresh_source", _stub)
+
+    results = await btd6_ingestion_service.refresh_source_or_dependencies(
+        "nk_btd6_events",
+    )
+
+    assert calls == ["nk_btd6_events"]
+    assert len(results) == 1
+    assert results[0].source_key == "nk_btd6_events"
+
+
+# ---------------------------------------------------------------------------
+# Depth guard: a→b→c→d with _MAX_DEPTH=2 executes a, b, c; blocks d
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_depth_guard_blocks_only_beyond_max_depth(monkeypatch):
+    """Synthetic 4-level chain to prove the guard runs depth-2 leaves."""
+    fake_chains = {
+        "a": [
+            btd6_ingestion_service._DependencySpec(
+                child_source="b",
+                path_param_builder=lambda k: {"k": k},
+            )
+        ],
+        "b": [
+            btd6_ingestion_service._DependencySpec(
+                child_source="c",
+                path_param_builder=lambda k: {"k": k},
+            )
+        ],
+        "c": [
+            btd6_ingestion_service._DependencySpec(
+                child_source="d",
+                path_param_builder=lambda k: {"k": k},
+            )
+        ],
+    }
+    monkeypatch.setattr(
+        btd6_ingestion_service,
+        "_DEPENDENCY_CHAINS",
+        fake_chains,
+    )
+
+    calls: list[str] = []
+
+    async def _stub(source_key, *, path_params=None, **kw):
+        calls.append(source_key)
+        return _ok(source_key, "x")
+
+    monkeypatch.setattr(btd6_ingestion_service, "refresh_source", _stub)
+
+    await btd6_ingestion_service.refresh_with_dependencies("a")
+
+    # _MAX_DEPTH = 2 means: a (depth 0) → b (depth 1) → c (depth 2) are
+    # all executed, but the recursion does NOT descend from c into d.
+    assert calls == ["a", "b", "c"]
+
+
+# ---------------------------------------------------------------------------
+# Cycle safety: a → b → a self-cycle hits the depth cap, doesn't loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cycle_blocked_by_depth_cap(monkeypatch):
+    fake_chains = {
+        "a": [
+            btd6_ingestion_service._DependencySpec(
+                child_source="b",
+                path_param_builder=lambda k: {"k": k},
+            )
+        ],
+        "b": [
+            btd6_ingestion_service._DependencySpec(
+                child_source="a",
+                path_param_builder=lambda k: {"k": k},
+            )
+        ],
+    }
+    monkeypatch.setattr(
+        btd6_ingestion_service,
+        "_DEPENDENCY_CHAINS",
+        fake_chains,
+    )
+
+    calls: list[str] = []
+
+    async def _stub(source_key, *, path_params=None, **kw):
+        calls.append(source_key)
+        return _ok(source_key, "x")
+
+    monkeypatch.setattr(btd6_ingestion_service, "refresh_source", _stub)
+
+    await btd6_ingestion_service.refresh_with_dependencies("a")
+
+    # Depth 0: a → depth 1: b → depth 2: a (executed, no descent).
+    assert calls == ["a", "b", "a"]
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_parent_failure_blocks_child_calls(monkeypatch):
+    calls: list[str] = []
+
+    async def _stub(source_key, *, path_params=None, **kw):
+        calls.append(source_key)
+        return _bad(source_key) if source_key == "nk_btd6_maps" else _ok(source_key)
+
+    monkeypatch.setattr(btd6_ingestion_service, "refresh_source", _stub)
+
+    results = await btd6_ingestion_service.refresh_with_dependencies("nk_btd6_maps")
+
+    assert calls == ["nk_btd6_maps"]
+    assert len(results) == 1
+    assert results[0].status == "fetch_error"
+
+
+@pytest.mark.asyncio
+async def test_empty_written_keys_means_no_child_calls(monkeypatch):
+    calls: list[str] = []
+
+    async def _stub(source_key, *, path_params=None, **kw):
+        calls.append(source_key)
+        # Parent succeeds but writes nothing.
+        return _ok(source_key)  # no extra keys → written_entity_keys=()
+
+    monkeypatch.setattr(btd6_ingestion_service, "refresh_source", _stub)
+
+    await btd6_ingestion_service.refresh_with_dependencies("nk_btd6_maps")
+
+    assert calls == ["nk_btd6_maps"]
+
+
+@pytest.mark.asyncio
+async def test_max_child_keys_none_means_no_cap(monkeypatch):
+    """nk_btd6_maps spec has max_child_keys=None — all 3 filters expand."""
+    spec_under_test = btd6_ingestion_service._DEPENDENCY_CHAINS["nk_btd6_maps"][0]
+    assert spec_under_test.max_child_keys is None
+    assert spec_under_test.child_source == "nk_btd6_maps_filter"
+
+
+# ---------------------------------------------------------------------------
+# Child run role: reason="dependency" + started_by_user_id propagation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_child_runs_use_dependency_reason_and_inherit_user_id(monkeypatch):
+    """Audit semantics: parent role flows to ``triggered_by``; users come
+    from ``started_by_user_id``. This is the regression pin against the
+    post-#353 ``reason=reason`` inheritance."""
+    seen: list[dict] = []
+
+    async def _stub(
+        source_key, *, path_params=None, reason="scheduled", started_by_user_id=None
+    ):
+        seen.append(
+            {
+                "source_key": source_key,
+                "reason": reason,
+                "started_by_user_id": started_by_user_id,
+            }
+        )
+        if source_key == "nk_btd6_maps":
+            return _ok(source_key, "newest")
+        if source_key == "nk_btd6_maps_filter":
+            return _ok(source_key, "the_map")
+        return _ok(source_key)
+
+    monkeypatch.setattr(btd6_ingestion_service, "refresh_source", _stub)
+
+    await btd6_ingestion_service.refresh_with_dependencies(
+        "nk_btd6_maps",
+        reason="manual",
+        started_by_user_id=12345,
+    )
+
+    # Parent gets the caller's reason.
+    parent_call = next(c for c in seen if c["source_key"] == "nk_btd6_maps")
+    assert parent_call["reason"] == "manual"
+    assert parent_call["started_by_user_id"] == 12345
+
+    # Children get reason="dependency" but inherit the user id.
+    children = [c for c in seen if c["source_key"] != "nk_btd6_maps"]
+    assert children, "expected at least one child call"
+    for child in children:
+        assert child["reason"] == "dependency", (
+            f"child {child['source_key']!r} should be 'dependency', "
+            f"got {child['reason']!r}"
+        )
+        assert child["started_by_user_id"] == 12345
+
+
+@pytest.mark.asyncio
+async def test_scheduled_parent_also_produces_dependency_children(monkeypatch):
+    """Scheduler path: parent='scheduled', children still get 'dependency'."""
+    seen: list[dict] = []
+
+    async def _stub(
+        source_key, *, path_params=None, reason="scheduled", started_by_user_id=None
+    ):
+        seen.append({"source_key": source_key, "reason": reason})
+        if source_key == "nk_btd6_ct":
+            return _ok(source_key, "tile_1", "tile_2")
+        return _ok(source_key)
+
+    monkeypatch.setattr(btd6_ingestion_service, "refresh_source", _stub)
+
+    await btd6_ingestion_service.refresh_with_dependencies(
+        "nk_btd6_ct",
+        reason="scheduled",
+    )
+
+    parent = next(c for c in seen if c["source_key"] == "nk_btd6_ct")
+    children = [c for c in seen if c["source_key"] == "nk_btd6_ct_tiles"]
+    assert parent["reason"] == "scheduled"
+    assert len(children) == 2
+    assert all(c["reason"] == "dependency" for c in children)
+
+
+# ---------------------------------------------------------------------------
+# Supervisor pin: scheduler uses the dependency-aware entry point
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_supervisor_calls_dependency_aware_refresh(monkeypatch):
+    """Regression pin against accidentally bypassing _DEPENDENCY_CHAINS."""
+    from services import btd6_ingestion_supervisor
+
+    # _SOURCE_INTERVALS covers exactly the 7 parents (per the plan).
+    assert set(btd6_ingestion_supervisor._SOURCE_INTERVALS) == {
+        "nk_btd6_events",
+        "nk_btd6_races",
+        "nk_btd6_bosses",
+        "nk_btd6_odyssey",
+        "nk_btd6_ct",
+        "nk_btd6_maps",
+        "nk_btd6_challenges",
+    }
+
+    # The supervisor loop spawns refresh_with_dependencies for each
+    # source — not raw refresh_source. We grep here as a structural
+    # pin (a regression to refresh_source would still pass type
+    # checking but break dependency expansion).
+    import inspect
+
+    source = inspect.getsource(btd6_ingestion_supervisor._run_loop)
+    assert (
+        "refresh_with_dependencies" in source
+    ), "supervisor must invoke the dependency-aware refresh helper"
+
+
+# ---------------------------------------------------------------------------
+# Spec registry covers every chain claimed by the plan
+# ---------------------------------------------------------------------------
+
+
+def test_dependency_chains_cover_expected_parents():
+    chains = btd6_ingestion_service._DEPENDENCY_CHAINS
+    expected_parents = {
+        "nk_btd6_ct",
+        "nk_btd6_maps",
+        "nk_btd6_maps_filter",
+        "nk_btd6_challenges",
+        "nk_btd6_challenges_filter",
+        "nk_btd6_races",
+        "nk_btd6_bosses",
+        "nk_btd6_odyssey",
+    }
+    assert expected_parents.issubset(chains.keys())
+
+    # events is intentionally parent-only — no chain.
+    assert "nk_btd6_events" not in chains
+
+
+def test_max_child_keys_caps_match_plan():
+    chains = btd6_ingestion_service._DEPENDENCY_CHAINS
+    # Plan caps to keep one cycle from chewing through unbounded fan-out.
+    caps_by_child = {
+        spec.child_source: spec.max_child_keys
+        for specs in chains.values()
+        for spec in specs
+    }
+    assert caps_by_child["nk_btd6_maps_one"] == 10
+    assert caps_by_child["nk_btd6_challenges_one"] == 10
+    assert caps_by_child["nk_btd6_races_metadata"] == 5
+    assert caps_by_child["nk_btd6_races_leaderboard"] == 3
+    assert caps_by_child["nk_btd6_bosses_metadata"] == 5
+    assert caps_by_child["nk_btd6_odyssey_diff"] == 5
+    # No-cap entries: filter-level expansions where the parent API
+    # itself already bounds the result.
+    assert caps_by_child["nk_btd6_ct_tiles"] is None
+    assert caps_by_child["nk_btd6_maps_filter"] is None
+    assert caps_by_child["nk_btd6_challenges_filter"] is None

--- a/tests/unit/services/test_btd6_knowledge_service_fact_summary.py
+++ b/tests/unit/services/test_btd6_knowledge_service_fact_summary.py
@@ -1,0 +1,98 @@
+"""Tests for ``btd6_knowledge_service.fact_summary_by_kind``."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from services import btd6_knowledge_service
+
+
+@pytest.mark.asyncio
+async def test_empty_table_returns_empty_tuple(monkeypatch):
+    from utils.db import btd6_sources as btd6_db
+
+    async def _empty():
+        return []
+
+    monkeypatch.setattr(btd6_db, "aggregate_facts_by_entity_kind", _empty)
+
+    assert await btd6_knowledge_service.fact_summary_by_kind() == ()
+
+
+@pytest.mark.asyncio
+async def test_one_row_per_entity_kind(monkeypatch):
+    from utils.db import btd6_sources as btd6_db
+
+    now = datetime.now(tz=timezone.utc)
+
+    async def _agg():
+        return [
+            {
+                "entity_kind": "btd6_event",
+                "fact_count": 14,
+                "last_fetched_at": now - timedelta(minutes=45),
+            },
+            {
+                "entity_kind": "btd6_map",
+                "fact_count": 78,
+                "last_fetched_at": now - timedelta(hours=2),
+            },
+        ]
+
+    monkeypatch.setattr(btd6_db, "aggregate_facts_by_entity_kind", _agg)
+
+    summary = await btd6_knowledge_service.fact_summary_by_kind()
+    assert len(summary) == 2
+    kinds = {s.entity_kind for s in summary}
+    assert kinds == {"btd6_event", "btd6_map"}
+
+    event_row = next(s for s in summary if s.entity_kind == "btd6_event")
+    assert event_row.fact_count == 14
+    assert event_row.bucket == "fresh"
+
+
+@pytest.mark.asyncio
+async def test_bucket_assignment_uses_public_helper(monkeypatch):
+    """fact_summary_by_kind delegates bucketing to bucket_freshness."""
+    from utils.db import btd6_sources as btd6_db
+
+    now = datetime.now(tz=timezone.utc)
+
+    async def _agg():
+        return [
+            {
+                "entity_kind": "btd6_race",
+                "fact_count": 1,
+                "last_fetched_at": now - timedelta(days=5),  # stale
+            },
+            {
+                "entity_kind": "btd6_unknown",
+                "fact_count": 0,
+                "last_fetched_at": None,  # never
+            },
+        ]
+
+    monkeypatch.setattr(btd6_db, "aggregate_facts_by_entity_kind", _agg)
+
+    summary = await btd6_knowledge_service.fact_summary_by_kind()
+    by_kind = {s.entity_kind: s for s in summary}
+    assert by_kind["btd6_race"].bucket == "stale"
+    assert by_kind["btd6_unknown"].bucket == "never"
+    assert by_kind["btd6_unknown"].last_fetched_at is None
+
+
+def test_no_private_threshold_imports():
+    """fact_summary_by_kind must not import private threshold constants."""
+    import inspect
+
+    from services import btd6_knowledge_service as ks
+
+    source = inspect.getsource(ks)
+    assert "_FRESH_THRESHOLD" not in source, (
+        "btd6_knowledge_service must use bucket_freshness, not private "
+        "threshold constants"
+    )
+    assert "_AGING_THRESHOLD" not in source
+    assert "_bucket_for" not in source

--- a/tests/unit/services/test_btd6_source_registry_bucket_freshness.py
+++ b/tests/unit/services/test_btd6_source_registry_bucket_freshness.py
@@ -1,0 +1,61 @@
+"""Tests for the public ``bucket_freshness`` helper.
+
+Source-health (per source_key) and the fact-summary panel (per
+entity_kind) both depend on this — single source of truth for the
+fresh/aging/stale/never buckets.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from services import btd6_source_registry
+
+
+def test_bucket_freshness_is_exported():
+    """Pin against accidental privatisation."""
+    assert "bucket_freshness" in btd6_source_registry.__all__
+    assert callable(btd6_source_registry.bucket_freshness)
+
+
+def test_none_maps_to_never():
+    assert btd6_source_registry.bucket_freshness(None) == "never"
+
+
+def test_fresh_under_six_hours():
+    now = datetime.now(tz=timezone.utc)
+    assert btd6_source_registry.bucket_freshness(now) == "fresh"
+    # Use 5h59m to stay safely under the 6h threshold despite the
+    # microseconds of drift between the timestamp construction and
+    # the bucket_freshness call.
+    assert (
+        btd6_source_registry.bucket_freshness(now - timedelta(hours=5, minutes=59))
+        == "fresh"
+    )
+
+
+def test_aging_between_six_hours_and_two_days():
+    now = datetime.now(tz=timezone.utc)
+    assert btd6_source_registry.bucket_freshness(now - timedelta(hours=7)) == "aging"
+    assert btd6_source_registry.bucket_freshness(now - timedelta(days=1)) == "aging"
+
+
+def test_stale_beyond_two_days():
+    now = datetime.now(tz=timezone.utc)
+    assert (
+        btd6_source_registry.bucket_freshness(now - timedelta(days=2, hours=1))
+        == "stale"
+    )
+    assert btd6_source_registry.bucket_freshness(now - timedelta(days=10)) == "stale"
+
+
+def test_naive_datetime_treated_as_utc():
+    """Naive datetimes are interpreted as UTC, not local time."""
+    now_utc_naive = datetime.utcnow()
+    # Should bucket exactly the same as a tz-aware UTC now.
+    assert btd6_source_registry.bucket_freshness(now_utc_naive) == "fresh"
+
+
+def test_bucket_for_alias_still_works():
+    """``_bucket_for`` is kept as an alias for in-module readers."""
+    assert btd6_source_registry._bucket_for is btd6_source_registry.bucket_freshness


### PR DESCRIPTION
## Summary

Closes the visible "Maps: 3 forever" gap end-to-end. Three commits on top of #355 (JSONB fix — depends on it landing first):

1. **`1a0973d`** — fan-out chains + recursive `refresh_with_dependencies`. Maps now reach `maps_one`, challenges reach `challenges_one`, races fan into metadata + leaderboard, bosses/odyssey reach metadata.
2. **`4148b24`** — public `bucket_freshness` helper on `btd6_source_registry` + new `fact_summary_by_kind` service helper.
3. **`5698adf`** — async `build_status_embed` with a "📊 Live facts" block, plus a regression pin for the always-on grounding shipped in #354.

## Why

The BTD6 ingestion pipeline writes facts correctly, but the UI never reflected them: status panel showed only seed JSON, and `!btd6 refresh-source nk_btd6_maps` wrote 3 rows and stopped because only `nk_btd6_ct → nk_btd6_ct_tiles` was declared. This PR aggregates `btd6_facts` into the status panel, declares the seven missing chains, and adds recursion so the two-level `parent → filter → one` shape actually reaches the leaf.

## Three locked invariants (per the original revision report)

| # | Invariant | Pinned by |
|---|---|---|
| 1 | Parent parsers emit the keys child sources consume | `test_parser_written_keys_contract.py` (7 tests) |
| 2 | Recursive refresh executes depth-N leaves; guard blocks descent FROM depth N | `test_depth_guard_blocks_only_beyond_max_depth`, `test_cycle_blocked_by_depth_cap` |
| 3 | Supervisor calls `refresh_with_dependencies`, not raw `refresh_source` | `test_supervisor_calls_dependency_aware_refresh` |

## Audit semantics (from the second revision report)

Reverts the post-#354 inherit-parent-reason behaviour. `triggered_by` now means "this run's role":

| `triggered_by` | Meaning |
|---|---|
| `manual` | Top-of-chain run, operator-initiated |
| `scheduled` | Top-of-chain run, supervisor-initiated |
| `dependency` | Child run spawned by a parent's dependency chain |

Operator attribution flows through `started_by_user_id`, which propagates unchanged through every recursion level. So "all runs a user caused (directly or indirectly)" is now `WHERE started_by_user_id = $1` instead of being conflated with `triggered_by`.

Pinned by `test_child_runs_use_dependency_reason_and_inherit_user_id` and `test_refresh_with_dependencies_child_role_is_dependency` (replaces the old inherit-parent-reason pin).

## Test plan

- [x] `python3.10 -m pytest tests/ -q` — **5549 passed**, 3 skipped (was 5506 before).
- [x] `python3.10 scripts/check_architecture.py --mode strict` — 0 errors.
- [x] black / isort / ruff clean on every touched file.
- [x] 33 new tests across 6 files; existing tests that asserted the now-reverted inherit-parent-reason behaviour updated.

## Defer / not in this PR

- Flipping `BTD6_INGESTION_ENABLED=true` default — operator change.
- Per-source cadence enforcement (supervisor outer loop still uses one `_DEFAULT_INTERVAL_S`; per-source intervals only drive backoff). TODO comment, no fix.
- `nk_btd6_bosses_leaderboard` + `nk_btd6_odyssey_diff_maps` chains — need composite path-builders.
- Hardcoded `difficulty=normal` / `difficulty=easy` defaults — documented limitation in `_DEPENDENCY_CHAINS`.
- The 5 disabled sources (`nk_btd6_users`, `nk_btd6_guild`, `nk_btd6_ct_lb_*`) — parser scope unapproved.

## Manual verification (post-deploy, requires #355 merged + `BTD6_INGESTION_ENABLED=true`)

1. Wait ~90s after restart. `!btd6` → status panel shows non-empty "📊 Live facts" block with event / map / boss / race / challenge / odyssey / ct rows.
2. `!btd6 source-health` → all 7 parents green; child sources go green/yellow as cycles complete.
3. `!btd6 live map` → real map names with populated `window: …` (proves the chain wrote map facts AND the #355 JSONB fix round-trips).
4. `!btd6 ask "what is logs map difficulty"` → response includes a "Live data" section.
5. Tail logs for `btd6 ingestion chain parent=… total=…` lines — confirms recursion fired.

https://claude.ai/code/session_017ECXVdLZMNVNLSFVsYxctK

---
_Generated by [Claude Code](https://claude.ai/code/session_017ECXVdLZMNVNLSFVsYxctK)_