### PR TITLE
BTD6: cap refresh-source embed fields to fit Discord's 25-field limit

### DIFF
--- a/disbot/cogs/btd6/_builders.py
+++ b/disbot/cogs/btd6/_builders.py
@@ -632,13 +632,10 @@ def build_refresh_source_embed(
         counts_str = " · ".join(
             f"{count} {status}" for status, count in sorted(status_counts.items())
         )
-        embed.add_field(
-            name="Summary",
-            value=(
-                f"{len(results)} runs · {total_facts} facts written\n" f"{counts_str}"
-            ),
-            inline=False,
+        summary_value = (
+            f"{len(results)} runs · {total_facts} facts written\n{counts_str}"
         )
+        embed.add_field(name="Summary", value=summary_value, inline=False)
 
     # Discord caps embeds at 25 fields. Reserve room for the summary
     # field above (1) plus any trailing "remaining" / "Known source

--- a/disbot/cogs/btd6/_builders.py
+++ b/disbot/cogs/btd6/_builders.py
@@ -620,8 +620,37 @@ def build_refresh_source_embed(
         )
         return embed
 
+    # Aggregate summary first — gives the operator the big picture
+    # before any per-result drill-down. Always emit this so chain
+    # refreshes are scannable at a glance.
+    if len(results) > 1:
+        status_counts: dict[str, int] = {}
+        total_facts = 0
+        for result in results:
+            status_counts[result.status] = status_counts.get(result.status, 0) + 1
+            total_facts += result.fact_count
+        counts_str = " · ".join(
+            f"{count} {status}" for status, count in sorted(status_counts.items())
+        )
+        embed.add_field(
+            name="Summary",
+            value=(
+                f"{len(results)} runs · {total_facts} facts written\n" f"{counts_str}"
+            ),
+            inline=False,
+        )
+
+    # Discord caps embeds at 25 fields. Reserve room for the summary
+    # field above (1) plus any trailing "remaining" / "Known source
+    # keys" field (up to 1), so render at most 20 per-result fields.
+    # Chain refreshes for nk_btd6_maps / nk_btd6_challenges currently
+    # produce up to 34 results — without this cap, .add_field exceeds
+    # the 25-field limit and Discord rejects the message with 400.
+    max_per_result_fields = 20
+    rendered_results = results[:max_per_result_fields]
+
     multi = len(results) > 1
-    for idx, result in enumerate(results):
+    for idx, result in enumerate(rendered_results):
         prefix = ""
         if multi:
             prefix = "parent · " if idx == 0 else "child · "
@@ -640,6 +669,18 @@ def build_refresh_source_embed(
         embed.add_field(
             name=f"{prefix}`{result.source_key}`",
             value=value,
+            inline=False,
+        )
+
+    truncated = len(results) - len(rendered_results)
+    if truncated > 0:
+        embed.add_field(
+            name="…",
+            value=(
+                f"+{truncated} more child runs omitted to stay within "
+                f"Discord's 25-field embed limit. Run "
+                f"`!btd6 source-health` for the full per-source picture."
+            ),
             inline=False,
         )
 

--- a/tests/unit/cogs/test_btd6_api_refresh_command.py
+++ b/tests/unit/cogs/test_btd6_api_refresh_command.py
@@ -124,10 +124,54 @@ def test_refresh_source_embed_dependency_chain_labels_each_child_by_its_key():
     child = _ok_result(source_key="nk_btd6_ct_tiles")
     embed = build_refresh_source_embed("nk_btd6_ct", [parent, child])
     names = [f.name or "" for f in embed.fields]
-    assert names[0].startswith("parent · ")
-    assert "`nk_btd6_ct`" in names[0]
-    assert names[1].startswith("child · ")
-    assert "`nk_btd6_ct_tiles`" in names[1]
+    # The first field is the aggregate "Summary" when there are >1
+    # results; per-result fields start at index 1.
+    assert names[0] == "Summary"
+    assert names[1].startswith("parent · ")
+    assert "`nk_btd6_ct`" in names[1]
+    assert names[2].startswith("child · ")
+    assert "`nk_btd6_ct_tiles`" in names[2]
+
+
+def test_refresh_source_embed_caps_fields_under_discord_limit():
+    """Chain refreshes for nk_btd6_maps return up to 34 results.
+    Without a cap, embed.fields would exceed Discord's 25-field max
+    and the message would be rejected with HTTP 400. Cap rendered
+    per-result fields and surface the rest in a summary."""
+    parent = _ok_result(source_key="nk_btd6_maps")
+    children = [_ok_result(source_key=f"nk_btd6_maps_one_{i}") for i in range(33)]
+    embed = build_refresh_source_embed("nk_btd6_maps", [parent, *children])
+
+    # Discord's per-embed field limit is 25.
+    assert len(embed.fields) <= 25
+
+    names = [f.name or "" for f in embed.fields]
+    assert names[0] == "Summary"
+    # When truncated, a "…" field explains the omission.
+    assert "…" in names
+    truncation_field = next(f for f in embed.fields if f.name == "…")
+    value = truncation_field.value or ""
+    assert "more child runs omitted" in value
+    assert "source-health" in value
+
+
+def test_refresh_source_embed_summary_aggregates_counts():
+    """Multi-result embeds include a Summary field with status counts."""
+    ok = _ok_result(source_key="nk_btd6_maps")
+    err = btd6_ingestion_service.IngestionResult(
+        source_key="nk_btd6_maps_filter",
+        status="parse_error",
+        fact_count=0,
+        duration_ms=10,
+        error_code="parse_exception",
+        run_id=2,
+    )
+    embed = build_refresh_source_embed("nk_btd6_maps", [ok, err])
+    summary = next(f for f in embed.fields if f.name == "Summary")
+    value = summary.value or ""
+    assert "2 runs" in value
+    assert "1 ok" in value
+    assert "1 parse_error" in value
 
 
 def test_refresh_source_embed_unknown_source_shows_known_keys():


### PR DESCRIPTION
## Summary

Live testing on the bot caught a Discord 400 the moment recursion actually filled `nk_btd6_maps` with 34 results:

```
HTTPException: 400 Bad Request (error code: 50035): Invalid Form Body
In embeds.0.fields: Must be 25 or fewer in length.
```

`build_refresh_source_embed` was adding one field per `IngestionResult` with no cap. CT (~9 results) fit, but `nk_btd6_maps` and `nk_btd6_challenges` both hit 34 after #357's recursion landed, so the command became unusable on those sources.

## Fix

1. Prepend an aggregate **Summary** field on multi-result embeds:
   ```
   34 runs · 109 facts written
   1 parse_error · 33 ok
   ```
2. Cap rendered per-result fields at **20**. When truncated, append a short `…` field directing the operator to `!btd6 source-health` for the full picture.

That leaves 25 - 1 (Summary) - 1 (truncation note) - 1 (optional "Known source keys" on unknown-source) = 22 fields' worth of headroom while staying under Discord's 25-field cap.

## Test plan

- [x] `python3.10 -m pytest tests/unit/cogs/test_btd6_api_refresh_command.py -q` — 30 pass (2 new + 1 updated existing).
- [x] New test `test_refresh_source_embed_caps_fields_under_discord_limit` constructs a 34-result embed (parent + 33 children) and asserts `len(embed.fields) <= 25` plus the `…` summary field is present.
- [x] New test `test_refresh_source_embed_summary_aggregates_counts` pins the aggregate Summary line (run count + per-status counts).
- [x] Updated `test_refresh_source_embed_dependency_chain_labels_each_child_by_its_key` to expect `Summary` at index 0 and per-result fields starting at index 1.

## Manual verification (post-merge)

`!btd6 refresh-source nk_btd6_maps` should now return a single embed with the Summary at the top, ~20 per-source results, and a `…` field naming the omission. No HTTP 400.

https://claude.ai/code/session_017ECXVdLZMNVNLSFVsYxctK

---
_Generated by [Claude Code](https://claude.ai/code/session_017ECXVdLZMNVNLSFVsYxctK)_