### PR TITLE
BTD6: admin panel + live data on main panel + event detail lookup

### DIFF
--- a/disbot/cogs/btd6/_builders.py
+++ b/disbot/cogs/btd6/_builders.py
@@ -695,7 +695,334 @@ def build_refresh_source_embed(
     return embed
 
 
+# ---------------------------------------------------------------------------
+# event-detail builder + _towers restriction decoder
+# ---------------------------------------------------------------------------
+
+
+def _render_tower_restrictions(
+    towers: list[dict[str, Any]],
+) -> dict[str, list[str]]:
+    """Group ``_towers`` entries into UI-ready categories.
+
+    The race / boss / odyssey ``_btd6challengedocument`` body carries a
+    ``_towers`` array (43 entries in the Reversed Loop fixture). Each
+    entry has ``tower`` (name), ``max`` (0 = banned, N>=1 = limited,
+    missing = unlimited), ``path1NumBlockedTiers`` / ``path2`` /
+    ``path3`` (top-N tier blocks per path), and ``isHero`` (True for
+    hero entries).
+
+    Returns ``{category: [human strings]}`` covering: ``banned``,
+    ``limited``, ``path_blocked``, ``heroes_banned``. Empty categories
+    are omitted from the result so the caller can `if foo:` cleanly.
+    """
+    banned: list[str] = []
+    limited: list[str] = []
+    path_blocked: list[str] = []
+    heroes_banned: list[str] = []
+
+    for entry in towers:
+        if not isinstance(entry, dict):
+            continue
+        tower = entry.get("tower")
+        if not isinstance(tower, str) or not tower:
+            continue
+        is_hero = bool(entry.get("isHero", False))
+        max_val = entry.get("max")
+        max_int = max_val if isinstance(max_val, int) else None
+        p1 = entry.get("path1NumBlockedTiers") or 0
+        p2 = entry.get("path2NumBlockedTiers") or 0
+        p3 = entry.get("path3NumBlockedTiers") or 0
+
+        if is_hero and max_int == 0:
+            heroes_banned.append(tower)
+            continue
+        if max_int == 0:
+            banned.append(tower)
+            continue
+        if max_int is not None and max_int >= 1:
+            limited.append(f"{tower} (max {max_int})")
+            continue
+        if p1 > 0 or p2 > 0 or p3 > 0:
+            parts = []
+            if p1:
+                parts.append(f"path1 top {p1}")
+            if p2:
+                parts.append(f"path2 top {p2}")
+            if p3:
+                parts.append(f"path3 top {p3}")
+            path_blocked.append(f"{tower} ({', '.join(parts)})")
+            # No `continue` — path-blocked is independent of max,
+            # but we already handled max=0 / max>=1 above.
+
+    out: dict[str, list[str]] = {}
+    if banned:
+        out["banned"] = banned
+    if limited:
+        out["limited"] = limited
+    if path_blocked:
+        out["path_blocked"] = path_blocked
+    if heroes_banned:
+        out["heroes_banned"] = heroes_banned
+    return out
+
+
+_EVENT_KIND_TITLE = {
+    "btd6_race": "🏁 BTD6 Race",
+    "btd6_boss": "👑 BTD6 Boss",
+    "btd6_ct": "🗺️ BTD6 Contested Territory",
+    "btd6_odyssey": "🌊 BTD6 Odyssey",
+    "btd6_event": "🎪 BTD6 Event",
+}
+
+
+def _format_window_status(body: dict[str, Any]) -> str:
+    """Render 'live / ended / upcoming · ends Xh' from start/end ms."""
+    from datetime import datetime, timezone
+
+    now = datetime.now(tz=timezone.utc)
+    start = body.get("start_ms")
+    end = body.get("end_ms")
+    start_dt = (
+        datetime.fromtimestamp(start / 1000.0, tz=timezone.utc)
+        if isinstance(start, (int, float)) and start > 0
+        else None
+    )
+    end_dt = (
+        datetime.fromtimestamp(end / 1000.0, tz=timezone.utc)
+        if isinstance(end, (int, float)) and end > 0
+        else None
+    )
+    if start_dt is None and end_dt is None:
+        return "status: `unknown`"
+    if start_dt is not None and now < start_dt:
+        delta = start_dt - now
+        return f"status: `upcoming` · starts in {delta.days}d {delta.seconds // 3600}h"
+    if end_dt is not None and now > end_dt:
+        return "status: `ended`"
+    if end_dt is not None:
+        delta = end_dt - now
+        h = delta.seconds // 3600
+        return f"status: `live` · ends in {delta.days}d {h}h"
+    return "status: `live`"
+
+
+def build_event_detail_embed(
+    entity_kind: str,
+    entity_key: str,
+    row: dict[str, Any] | None,
+    *,
+    metadata_row: dict[str, Any] | None = None,
+) -> discord.Embed:
+    """Render one specific BTD6 event from ``btd6_facts``.
+
+    ``row`` is the index-fact (carries name + window + scores);
+    ``metadata_row`` is the deeper ``*_metadata`` fact that carries
+    ``_towers`` restrictions and mode flags. Either may be ``None``;
+    the embed degrades gracefully.
+
+    Builders stay synchronous — the cog does both async fetches before
+    calling this function.
+    """
+    title = f"{_EVENT_KIND_TITLE.get(entity_kind, entity_kind)} — {entity_key}"
+
+    if row is None and metadata_row is None:
+        return discord.Embed(
+            title=title,
+            description=(
+                f"No event found for kind=`{entity_kind}` id=`{entity_key}`. "
+                f"Try `!btd6 live {entity_kind.removeprefix('btd6_')}` to "
+                "list active events of this kind."
+            ),
+            color=discord.Color.red(),
+        )
+
+    primary = row if row is not None else metadata_row
+    primary_body = _coerce_body((primary or {}).get("body_json"))
+
+    name = primary_body.get("name") or entity_key
+    embed = discord.Embed(
+        title=f"{_EVENT_KIND_TITLE.get(entity_kind, entity_kind)} — {name}",
+        color=discord.Color.gold(),
+    )
+
+    # Window / status from start_ms+end_ms (in either row or metadata).
+    window_body = primary_body
+    if not window_body.get("start_ms") and metadata_row is not None:
+        window_body = _coerce_body(metadata_row.get("body_json"))
+    embed.add_field(
+        name="Window", value=_format_window_status(window_body), inline=False,
+    )
+
+    # Score fragments from the index row.
+    score_fragments = []
+    if isinstance(primary_body.get("total_scores"), int):
+        score_fragments.append(f"scores={primary_body['total_scores']}")
+    for key, label in (
+        ("total_scores_standard", "standard"),
+        ("total_scores_elite", "elite"),
+    ):
+        v = primary_body.get(key)
+        if isinstance(v, int):
+            score_fragments.append(f"{label}={v}")
+    if isinstance(primary_body.get("boss_type"), str) and primary_body["boss_type"]:
+        score_fragments.append(f"type=`{primary_body['boss_type']}`")
+    if score_fragments:
+        embed.add_field(name="Scores", value=" · ".join(score_fragments), inline=False)
+
+    # Mode flags + round/lives from metadata (when present).
+    if metadata_row is not None:
+        md = _coerce_body(metadata_row.get("body_json"))
+        rules_parts = []
+        if isinstance(md.get("startRound"), int) and isinstance(
+            md.get("endRound"), int,
+        ):
+            rules_parts.append(f"rounds {md['startRound']}–{md['endRound']}")
+        if isinstance(md.get("lives"), int):
+            rules_parts.append(f"lives {md['lives']}")
+        if isinstance(md.get("maxLives"), int):
+            rules_parts.append(f"max lives {md['maxLives']}")
+        if isinstance(md.get("maxTowers"), int):
+            rules_parts.append(f"max towers {md['maxTowers']}")
+        if isinstance(md.get("maxParagons"), int):
+            rules_parts.append(f"max paragons {md['maxParagons']}")
+        if isinstance(md.get("difficulty"), str) and md["difficulty"]:
+            rules_parts.append(f"difficulty `{md['difficulty']}`")
+        if rules_parts:
+            embed.add_field(name="Rules", value=" · ".join(rules_parts), inline=False)
+
+        disabled_flags = []
+        for k, label in (
+            ("disableDoubleCash", "double cash"),
+            ("disableInstas", "instas"),
+            ("disableMK", "MK"),
+            ("disablePowers", "powers"),
+            ("disableSelling", "selling"),
+        ):
+            if md.get(k):
+                disabled_flags.append(label)
+        if disabled_flags:
+            embed.add_field(
+                name="Disabled",
+                value=", ".join(disabled_flags),
+                inline=False,
+            )
+
+        # Tower restrictions decoded from _towers.
+        towers = md.get("_towers")
+        if isinstance(towers, list) and towers:
+            restrictions = _render_tower_restrictions(towers)
+            for category, label in (
+                ("banned", "🚫 Banned towers"),
+                ("limited", "⚠️ Limited towers"),
+                ("path_blocked", "🪜 Path-blocked"),
+                ("heroes_banned", "🧙 Heroes banned"),
+            ):
+                entries = restrictions.get(category)
+                if not entries:
+                    continue
+                value = ", ".join(entries)
+                if len(value) > 1024:
+                    # Truncate to fit the 1024-char field-value cap.
+                    cut: list[str] = []
+                    running = 0
+                    for entry in entries:
+                        sep = ", " if cut else ""
+                        chunk = sep + entry
+                        if running + len(chunk) > 990:
+                            break
+                        cut.append(entry)
+                        running += len(chunk)
+                    dropped = len(entries) - len(cut)
+                    value = ", ".join(cut) + f"… (+{dropped} more)"
+                embed.add_field(name=label, value=value, inline=False)
+
+    when = primary.get("fetched_at") if primary else None
+    if when is not None:
+        embed.set_footer(text=f"fetched={when.isoformat(timespec='minutes')}")
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# admin Fetch-All / Fetch-Selected summary
+# ---------------------------------------------------------------------------
+
+
+def build_admin_refresh_summary_embed(
+    results_by_source: list[tuple[str, list[Any]]],
+    *,
+    title_suffix: str = "",
+) -> discord.Embed:
+    """Aggregate multi-chain refresh results into one embed.
+
+    ``results_by_source`` is a list of ``(source_key, [IngestionResult])``
+    pairs — one entry per top-level chain executed. The embed summarises
+    per-status counts and total facts written, then renders one line per
+    chain so operators can see which ones succeeded / failed.
+    """
+    total_runs = 0
+    total_facts = 0
+    status_counts: dict[str, int] = {}
+    chain_lines: list[str] = []
+
+    for source_key, results in results_by_source:
+        chain_status = "ok"
+        chain_facts = 0
+        chain_errors: list[str] = []
+        for r in results:
+            total_runs += 1
+            total_facts += r.fact_count
+            chain_facts += r.fact_count
+            status_counts[r.status] = status_counts.get(r.status, 0) + 1
+            if r.status in _REFRESH_ERROR_STATUSES:
+                chain_status = "fail"
+                if r.error_code:
+                    chain_errors.append(f"{r.source_key}={r.error_code}")
+        emoji = "✅" if chain_status == "ok" else "⚠️"
+        line = f"{emoji} `{source_key}` · {chain_facts} facts · {len(results)} runs"
+        if chain_errors:
+            line += f"\n   errors: {', '.join(chain_errors[:3])}"
+            if len(chain_errors) > 3:
+                line += f" (+{len(chain_errors) - 3} more)"
+        chain_lines.append(line)
+
+    color = (
+        discord.Color.green()
+        if all(s == "ok" for s in status_counts)
+        else discord.Color.gold() if status_counts.get("ok", 0) else discord.Color.red()
+    )
+    embed = discord.Embed(
+        title=f"🛠️ BTD6 Admin — Refresh Summary{title_suffix}",
+        color=color,
+    )
+    counts_str = " · ".join(f"{n} {s}" for s, n in sorted(status_counts.items()))
+    embed.add_field(
+        name="Aggregate",
+        value=(
+            f"{len(results_by_source)} chains · {total_runs} runs · "
+            f"{total_facts} facts written\n{counts_str}"
+        ),
+        inline=False,
+    )
+    body = "\n".join(chain_lines)
+    # Discord field-value cap.
+    if len(body) > 1024:
+        keep: list[str] = []
+        running = 0
+        for line in chain_lines:
+            if running + len(line) + 1 > 990:
+                break
+            keep.append(line)
+            running += len(line) + 1
+        dropped = len(chain_lines) - len(keep)
+        body = "\n".join(keep) + f"\n… (+{dropped} more chains omitted)"
+    embed.add_field(name="Chains", value=body or "—", inline=False)
+    return embed
+
+
 __all__ = [
+    "build_admin_refresh_summary_embed",
+    "build_event_detail_embed",
     "build_grounding_embed",
     "build_hero_embed",
     "build_latest_data_embed",

--- a/disbot/cogs/btd6/_embeds.py
+++ b/disbot/cogs/btd6/_embeds.py
@@ -279,6 +279,21 @@ def build_modes_embed() -> discord.Embed:
     return embed
 
 
+def build_heroes_embed() -> discord.Embed:
+    """Hero catalogue — mirrors build_towers_embed shape."""
+    embed = discord.Embed(
+        title="🐵 BTD6 — Heroes",
+        color=discord.Color.green(),
+    )
+    for hero in btd6_knowledge_service.list_heroes():
+        embed.add_field(
+            name=hero.canonical,
+            value=f"Cost: {hero.base_cost} • {hero.description[:80]}",
+            inline=False,
+        )
+    return embed
+
+
 def build_test_intent_embed(text: str) -> discord.Embed:
     """Resolver introspection — useful for operators tuning the cog."""
     intent = resolve(text)
@@ -318,6 +333,7 @@ def build_test_intent_embed(text: str) -> discord.Embed:
 
 __all__ = [
     "build_diagnostics_embed",
+    "build_heroes_embed",
     "build_modes_embed",
     "build_status_embed",
     "build_test_intent_embed",

--- a/disbot/cogs/btd6/_event_helpers.py
+++ b/disbot/cogs/btd6/_event_helpers.py
@@ -1,0 +1,135 @@
+"""Helpers extracted from ``btd6_cog`` so the cog file stays under the
+S4.6 800-LOC cap.
+
+Two payload builders live here:
+
+* :func:`build_refresh_source_payload` — manual ``refresh-source``
+  command (was previously :meth:`BTD6Cog._build_refresh_source_payload`;
+  moved as part of the admin-panel PR). Behaviour unchanged.
+* :func:`build_event_payload` — new ``!btd6 event <kind> <id>`` lookup;
+  fetches both the index fact and (when applicable) the ``*_metadata``
+  fact so the embed can render ``_towers`` restrictions.
+
+These are deliberately module-level functions, not methods, so the
+admin view in ``views/btd6/admin_panel.py`` can also call
+``build_refresh_source_payload`` without depending on the cog instance.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+logger = logging.getLogger("bot.cogs.btd6")
+
+
+async def build_refresh_source_payload(
+    source_key: str,
+    *,
+    started_by_user_id: int,
+    include_exception_detail: bool,
+) -> discord.Embed:
+    """Run one manual refresh and render the result embed.
+
+    Routes through the public orchestration helper so we never reach
+    into ``btd6_ingestion_service._DEPENDENCY_CHAINS``. Exception
+    handling and the unknown-source known-keys fallback are unified
+    here so prefix / slash / admin-panel surfaces can't drift.
+    """
+    from cogs.btd6._builders import build_refresh_source_embed
+    from services import btd6_ingestion_service, btd6_source_registry
+
+    try:
+        results = await btd6_ingestion_service.refresh_source_or_dependencies(
+            source_key,
+            reason="manual",
+            started_by_user_id=started_by_user_id,
+        )
+    except Exception as exc:  # noqa: BLE001 — surfaced via embed
+        logger.exception("manual refresh failed for %s", source_key)
+        return build_refresh_source_embed(
+            source_key,
+            results=[],
+            exception=exc,
+            include_exception_detail=include_exception_detail,
+        )
+
+    known_keys: list[str] | None = None
+    if len(results) == 1 and results[0].error_code == "source_not_registered":
+        try:
+            rows = await btd6_source_registry.list_all()
+        except Exception:  # noqa: BLE001 — best-effort enrichment
+            logger.exception("failed to load BTD6 known source keys")
+            rows = []
+        known_keys = [row["source_key"] for row in rows]
+
+    return build_refresh_source_embed(
+        source_key,
+        results,
+        known_source_keys=known_keys,
+    )
+
+
+async def build_event_payload(kind: str, entity_key: str) -> discord.Embed:
+    """Fetch the index fact + metadata fact for one event and render it.
+
+    Accepts either the full ``btd6_<kind>`` form or the short
+    ``<kind>`` form (race / boss / ct / odyssey / event). The
+    ``*_metadata`` fact is only queried for kinds that have one in the
+    registry — race, boss, odyssey. Missing data degrades gracefully:
+    if neither row exists the builder renders an empty-state embed.
+    """
+    from cogs.btd6._builders import build_event_detail_embed
+    from utils.db import btd6_sources as btd6_db
+
+    norm = kind if kind.startswith("btd6_") else f"btd6_{kind}"
+
+    row = await btd6_db.get_latest_fact(None, norm, entity_key)
+
+    metadata_row = None
+    metadata_fact_type = {
+        "btd6_race": "btd6.race_metadata",
+        "btd6_boss": "btd6.boss_metadata",
+        "btd6_odyssey": "btd6.odyssey_diff",
+    }.get(norm)
+    if metadata_fact_type is not None:
+        # Odyssey uses a different entity_kind for its metadata
+        # (btd6_odyssey_difficulty); race / boss reuse the index kind.
+        if norm == "btd6_odyssey":
+            metadata_row = await btd6_db.get_latest_fact(
+                metadata_fact_type,
+                "btd6_odyssey_difficulty",
+                entity_key,
+            )
+            # Try entity_key with the hardcoded difficulty suffix too —
+            # the parser composes f"{odysseyID}" as the entity_key for
+            # odyssey_diff facts. Best effort; either form is fine.
+            if metadata_row is None:
+                metadata_row = await btd6_db.get_latest_fact(
+                    metadata_fact_type,
+                    "btd6_odyssey_difficulty",
+                    f"{entity_key}_easy",
+                )
+        else:
+            md_entity_key = entity_key
+            if norm == "btd6_boss":
+                md_entity_key = f"{entity_key}_normal"  # difficulty hardcoded
+            metadata_row = await btd6_db.get_latest_fact(
+                metadata_fact_type,
+                "btd6_boss_difficulty" if norm == "btd6_boss" else norm,
+                md_entity_key,
+            )
+
+    return build_event_detail_embed(
+        norm,
+        entity_key,
+        row,
+        metadata_row=metadata_row,
+    )
+
+
+__all__ = [
+    "build_event_payload",
+    "build_refresh_source_payload",
+]

--- a/disbot/cogs/btd6_cog.py
+++ b/disbot/cogs/btd6_cog.py
@@ -83,7 +83,7 @@ class BTD6Cog(commands.Cog):
     @commands.group(name="btd6", invoke_without_command=True)
     async def btd6_group(self, ctx: commands.Context) -> None:
         """Open the BTD6 panel."""
-        await ctx.send(embed=build_btd6_panel_embed(), view=BTD6PanelView())
+        await ctx.send(embed=await build_btd6_panel_embed(), view=BTD6PanelView())
 
     @btd6_group.command(name="status")  # type: ignore[arg-type]
     async def btd6_status(self, ctx: commands.Context) -> None:
@@ -195,49 +195,6 @@ class BTD6Cog(commands.Cog):
 
         await ctx.send(embed=await build_source_health_embed(limit=limit))
 
-    async def _build_refresh_source_payload(
-        self,
-        source_key: str,
-        *,
-        started_by_user_id: int,
-        include_exception_detail: bool,
-    ) -> discord.Embed:
-        """Shared logic for the prefix + slash refresh-source surfaces.
-
-        Routes through the public orchestration helper so we never reach
-        into ``btd6_ingestion_service._DEPENDENCY_CHAINS``. Exception
-        handling and the unknown-source known-keys fallback are unified
-        here so prefix and slash can't drift.
-        """
-        from cogs.btd6._builders import build_refresh_source_embed
-        from services import btd6_ingestion_service, btd6_source_registry
-
-        try:
-            results = await btd6_ingestion_service.refresh_source_or_dependencies(
-                source_key,
-                reason="manual",
-                started_by_user_id=started_by_user_id,
-            )
-        except Exception as exc:  # noqa: BLE001 — surfaced via embed
-            logger.exception("manual refresh failed for %s", source_key)
-            return build_refresh_source_embed(
-                source_key,
-                results=[],
-                exception=exc,
-                include_exception_detail=include_exception_detail,
-            )
-
-        known_keys: list[str] | None = None
-        if len(results) == 1 and results[0].error_code == "source_not_registered":
-            rows = await btd6_source_registry.list_all()
-            known_keys = [row["source_key"] for row in rows]
-
-        return build_refresh_source_embed(
-            source_key,
-            results,
-            known_source_keys=known_keys,
-        )
-
     @btd6_group.command(name="refresh-source")  # type: ignore[arg-type]
     @commands.has_guild_permissions(manage_guild=True)
     async def btd6_refresh_source(
@@ -251,12 +208,31 @@ class BTD6Cog(commands.Cog):
         sources return one result. Exception detail is suppressed in the
         prefix surface because the embed is posted to the channel.
         """
-        embed = await self._build_refresh_source_payload(
+        from cogs.btd6._event_helpers import build_refresh_source_payload
+
+        embed = await build_refresh_source_payload(
             source_key,
             started_by_user_id=ctx.author.id,
             include_exception_detail=False,
         )
         await ctx.send(embed=embed)
+
+    @btd6_group.command(name="event")  # type: ignore[arg-type]
+    async def btd6_event(
+        self,
+        ctx: commands.Context,
+        kind: str,
+        entity_key: str,
+    ) -> None:
+        """Show one specific BTD6 event with its tower restrictions.
+
+        ``kind`` is one of race / boss / ct / odyssey / event.
+        ``entity_key`` is the event's API id (use ``!btd6 live <kind>``
+        to discover ids).
+        """
+        from cogs.btd6._event_helpers import build_event_payload
+
+        await ctx.send(embed=await build_event_payload(kind, entity_key))
 
     @btd6_group.command(name="latest-data")  # type: ignore[arg-type]
     async def btd6_latest_data(self, ctx: commands.Context) -> None:
@@ -382,7 +358,7 @@ class BTD6Cog(commands.Cog):
     @commands.command(name="btd6menu")
     async def btd6menu(self, ctx: commands.Context) -> None:
         """Open the BTD6 panel (alias for ``!btd6``)."""
-        await ctx.send(embed=build_btd6_panel_embed(), view=BTD6PanelView())
+        await ctx.send(embed=await build_btd6_panel_embed(), view=BTD6PanelView())
 
     # ------------------------------------------------------------------
     # App commands — mirror the prefix surface.
@@ -603,13 +579,32 @@ class BTD6Cog(commands.Cog):
         interaction: discord.Interaction,
         source_key: str,
     ) -> None:
+        from cogs.btd6._event_helpers import build_refresh_source_payload
+
         if not await safe_defer(interaction, ephemeral=True):
             return
-        embed = await self._build_refresh_source_payload(
+        embed = await build_refresh_source_payload(
             source_key,
             started_by_user_id=interaction.user.id,
             include_exception_detail=True,
         )
+        await safe_followup(interaction, embed=embed, ephemeral=True)
+
+    @btd6_app_group.command(
+        name="event",
+        description="Show one specific BTD6 event with tower restrictions.",
+    )
+    async def btd6_event_slash(
+        self,
+        interaction: discord.Interaction,
+        kind: str,
+        entity_key: str,
+    ) -> None:
+        from cogs.btd6._event_helpers import build_event_payload
+
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        embed = await build_event_payload(kind, entity_key)
         await safe_followup(interaction, embed=embed, ephemeral=True)
 
     @btd6_app_group.command(
@@ -775,7 +770,7 @@ class BTD6Cog(commands.Cog):
     @app_commands.command(name="btd6menu", description="Open the BTD6 panel.")
     async def btd6menu_slash(self, interaction: discord.Interaction) -> None:
         await interaction.response.send_message(
-            embed=build_btd6_panel_embed(),
+            embed=await build_btd6_panel_embed(),
             view=BTD6PanelView(),
             ephemeral=True,
         )
@@ -788,7 +783,7 @@ class BTD6Cog(commands.Cog):
         self,
         interaction: discord.Interaction,
     ) -> tuple[discord.Embed, discord.ui.View]:
-        return build_btd6_panel_embed(), BTD6PanelView()
+        return await build_btd6_panel_embed(), BTD6PanelView()
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/disbot/utils/db/btd6_sources.py
+++ b/disbot/utils/db/btd6_sources.py
@@ -321,28 +321,77 @@ async def upsert_fact(
 
 
 async def get_latest_fact(
-    fact_type: str,
+    fact_type: str | None,
     entity_kind: str,
     entity_key: str,
 ) -> dict[str, Any] | None:
-    row = await pool.get().fetchrow(
-        """
-        SELECT f.id, f.source_id, f.fact_type, f.entity_kind, f.entity_key,
-               f.body_json, f.game_version, f.fetched_at, f.validated_at,
-               f.confidence, f.version, r.source_key, r.trust_tier
-        FROM btd6_facts f
-        JOIN btd6_source_registry r ON r.id = f.source_id
-        WHERE f.fact_type = $1
-          AND f.entity_kind = $2
-          AND f.entity_key = $3
-        ORDER BY f.version DESC
-        LIMIT 1
-        """,
-        fact_type,
-        entity_kind,
-        entity_key,
-    )
+    """Newest fact for an entity, optionally filtered by ``fact_type``.
+
+    ``fact_type=None`` matches any fact_type for the (entity_kind,
+    entity_key) pair — useful when a caller has the entity but doesn't
+    know which fact_type carries the answer (e.g. index vs metadata).
+    """
+    if fact_type is None:
+        row = await pool.get().fetchrow(
+            """
+            SELECT f.id, f.source_id, f.fact_type, f.entity_kind, f.entity_key,
+                   f.body_json, f.game_version, f.fetched_at, f.validated_at,
+                   f.confidence, f.version, r.source_key, r.trust_tier
+            FROM btd6_facts f
+            JOIN btd6_source_registry r ON r.id = f.source_id
+            WHERE f.entity_kind = $1
+              AND f.entity_key = $2
+            ORDER BY f.fetched_at DESC, f.version DESC
+            LIMIT 1
+            """,
+            entity_kind,
+            entity_key,
+        )
+    else:
+        row = await pool.get().fetchrow(
+            """
+            SELECT f.id, f.source_id, f.fact_type, f.entity_kind, f.entity_key,
+                   f.body_json, f.game_version, f.fetched_at, f.validated_at,
+                   f.confidence, f.version, r.source_key, r.trust_tier
+            FROM btd6_facts f
+            JOIN btd6_source_registry r ON r.id = f.source_id
+            WHERE f.fact_type = $1
+              AND f.entity_kind = $2
+              AND f.entity_key = $3
+            ORDER BY f.version DESC
+            LIMIT 1
+            """,
+            fact_type,
+            entity_kind,
+            entity_key,
+        )
     return dict(row) if row else None
+
+
+async def latest_fact_per_entity_kind(
+    kinds: list[str],
+) -> dict[str, dict[str, Any]]:
+    """For each entity_kind, the single newest fact row.
+
+    One round-trip via DISTINCT ON. Kinds absent from ``btd6_facts``
+    are absent from the returned dict (no ``None`` placeholders).
+    Empty ``kinds`` returns ``{}`` without hitting the DB.
+    """
+    if not kinds:
+        return {}
+    rows = await pool.get().fetch(
+        """
+        SELECT DISTINCT ON (entity_kind)
+               id, source_id, fact_type, entity_kind, entity_key,
+               body_json, game_version, fetched_at, validated_at,
+               confidence, version
+        FROM btd6_facts
+        WHERE entity_kind = ANY($1::text[])
+        ORDER BY entity_kind, fetched_at DESC, version DESC
+        """,
+        kinds,
+    )
+    return {row["entity_kind"]: dict(row) for row in rows}
 
 
 async def aggregate_facts_by_entity_kind() -> list[dict[str, Any]]:

--- a/disbot/views/btd6/admin_panel.py
+++ b/disbot/views/btd6/admin_panel.py
@@ -1,0 +1,344 @@
+"""BTD6 admin panel — ephemeral staff-only sub-view.
+
+Opened by the **🛠️ Admin** button on the main :class:`BTD6PanelView`.
+A fresh instance per click; not persistent across bot restarts.
+
+Layout (5 buttons per row max):
+
+* Row 0 — fetch controls: **Fetch All**, **Fetch Selected**.
+* Row 1 — diagnostics: **Source Health**, **Latest Data**, **Close**.
+* Row 2 — multi-select dropdown of registered enabled source keys.
+
+Every action is gated to ``manage_guild`` / ``administrator``.
+Fetch buttons drive ``btd6_ingestion_service.refresh_source_or_dependencies``
+— the same service entry point the prefix / slash ``refresh-source``
+commands use, so chain expansion / audit / locks all just work.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import discord
+
+from core.runtime.interaction_helpers import safe_defer
+from services import btd6_ingestion_service, btd6_source_registry
+from views.btd6.panel import _is_staff
+
+logger = logging.getLogger("bot.views.btd6.admin")
+
+
+# ---------------------------------------------------------------------------
+# Initial embed
+# ---------------------------------------------------------------------------
+
+
+async def build_admin_embed() -> discord.Embed:
+    """The static admin-panel intro embed.
+
+    Lists the 7 parent sources the supervisor schedules so staff know
+    what 'Fetch All' will hit, and explains the multi-select.
+    """
+    embed = discord.Embed(
+        title="🛠️ BTD6 Admin",
+        description=(
+            "Manual data fetches and diagnostics. Use **Fetch All** to "
+            "run every parent chain in one click, or pick specific "
+            "sources from the dropdown and use **Fetch Selected**."
+        ),
+        color=discord.Color.blurple(),
+    )
+    embed.add_field(
+        name="Parent sources",
+        value=(
+            "`nk_btd6_events` · `nk_btd6_races` · `nk_btd6_bosses` · "
+            "`nk_btd6_odyssey` · `nk_btd6_ct` · `nk_btd6_maps` · "
+            "`nk_btd6_challenges`"
+        ),
+        inline=False,
+    )
+    embed.set_footer(
+        text="Source Health = freshness per source · Latest Data = newest fact per kind",
+    )
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# View
+# ---------------------------------------------------------------------------
+
+
+# Parent sources the supervisor schedules. "Fetch All" iterates this
+# list — must stay in sync with
+# ``btd6_ingestion_supervisor._SOURCE_INTERVALS``.
+_PARENT_SOURCES: tuple[str, ...] = (
+    "nk_btd6_events",
+    "nk_btd6_races",
+    "nk_btd6_bosses",
+    "nk_btd6_odyssey",
+    "nk_btd6_ct",
+    "nk_btd6_maps",
+    "nk_btd6_challenges",
+)
+
+
+class BTD6AdminView(discord.ui.View):
+    """Ephemeral staff-only admin panel. Fresh instance per click."""
+
+    def __init__(self, opener_user_id: int, source_keys: list[str]) -> None:
+        super().__init__(timeout=600)  # 10 min
+        self.opener_user_id = opener_user_id
+        self._source_keys = source_keys
+        # Hold the multi-select so the action buttons can read its
+        # current ``values``. Stored on `self` rather than queried via
+        # `self.children` so the typing stays explicit.
+        self.source_select = _SourceMultiSelect(source_keys)
+        self.add_item(_FetchAllButton())
+        self.add_item(_FetchSelectedButton())
+        self.add_item(_SourceHealthButton())
+        self.add_item(_LatestDataButton())
+        self.add_item(_CloseButton())
+        self.add_item(self.source_select)
+
+    @classmethod
+    async def create(cls, opener_user_id: int) -> BTD6AdminView:
+        """Async factory — populates the multi-select from the live registry."""
+        try:
+            rows = await btd6_source_registry.list_enabled_sources(limit=100)
+        except Exception:  # noqa: BLE001 — degrade gracefully
+            logger.exception("admin panel: failed to load source registry")
+            rows = []
+        keys = sorted({row["source_key"] for row in rows})
+        # Discord caps `discord.ui.Select` at 25 options. Truncate
+        # gracefully — if the registry ever grows past 25 enabled
+        # sources, "Fetch All" still covers all parents and the
+        # multi-select shows the first 25 alphabetically.
+        return cls(opener_user_id, keys[:25])
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.opener_user_id:
+            await interaction.response.send_message(
+                "This admin panel isn't yours.",
+                ephemeral=True,
+            )
+            return False
+        if not _is_staff(interaction.user):
+            await interaction.response.send_message(
+                "❌ Staff role required.",
+                ephemeral=True,
+            )
+            return False
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Multi-select
+# ---------------------------------------------------------------------------
+
+
+class _SourceMultiSelect(discord.ui.Select):
+    def __init__(self, source_keys: list[str]) -> None:
+        options = [discord.SelectOption(label=key, value=key) for key in source_keys]
+        if not options:
+            # Discord requires at least one option; if the registry
+            # returned nothing show a disabled placeholder.
+            options = [
+                discord.SelectOption(
+                    label="(no enabled sources)",
+                    value="__none__",
+                    default=False,
+                ),
+            ]
+        super().__init__(
+            placeholder="Pick sources to fetch…",
+            min_values=0,
+            max_values=len(options),
+            options=options,
+            row=2,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        # The select itself is just a state holder — the action buttons
+        # read `.values` when clicked. ACK without changing the view so
+        # Discord doesn't show "Interaction failed". Use safe_defer so
+        # the no-raw-defer invariant stays clean.
+        await safe_defer(interaction, ephemeral=True)
+
+
+# ---------------------------------------------------------------------------
+# Action buttons
+# ---------------------------------------------------------------------------
+
+
+class _FetchAllButton(discord.ui.Button):
+    def __init__(self) -> None:
+        super().__init__(
+            label="Fetch All",
+            style=discord.ButtonStyle.success,
+            row=0,
+            custom_id="btd6_admin:fetch_all",
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await _run_fetch(
+            interaction,
+            list(_PARENT_SOURCES),
+            user_id=interaction.user.id,
+            label="Fetch All",
+        )
+
+
+class _FetchSelectedButton(discord.ui.Button):
+    def __init__(self) -> None:
+        super().__init__(
+            label="Fetch Selected",
+            style=discord.ButtonStyle.primary,
+            row=0,
+            custom_id="btd6_admin:fetch_selected",
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: BTD6AdminView = self.view  # type: ignore[assignment]
+        selected = [v for v in view.source_select.values if v != "__none__"]
+        if not selected:
+            await interaction.response.send_message(
+                "Pick at least one source from the dropdown first.",
+                ephemeral=True,
+            )
+            return
+        await _run_fetch(
+            interaction,
+            selected,
+            user_id=interaction.user.id,
+            label="Fetch Selected",
+        )
+
+
+class _SourceHealthButton(discord.ui.Button):
+    def __init__(self) -> None:
+        super().__init__(
+            label="Source Health",
+            style=discord.ButtonStyle.secondary,
+            row=1,
+            custom_id="btd6_admin:source_health",
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from cogs.btd6._builders import build_source_health_embed
+
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        embed = await build_source_health_embed(limit=25)
+        await interaction.followup.send(embed=embed, ephemeral=True)
+
+
+class _LatestDataButton(discord.ui.Button):
+    def __init__(self) -> None:
+        super().__init__(
+            label="Latest Data",
+            style=discord.ButtonStyle.secondary,
+            row=1,
+            custom_id="btd6_admin:latest_data",
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from cogs.btd6._builders import build_latest_data_embed
+
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        embed = await build_latest_data_embed()
+        await interaction.followup.send(embed=embed, ephemeral=True)
+
+
+class _CloseButton(discord.ui.Button):
+    def __init__(self) -> None:
+        super().__init__(
+            label="Close",
+            style=discord.ButtonStyle.danger,
+            row=1,
+            custom_id="btd6_admin:close",
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await interaction.response.edit_message(
+            embed=discord.Embed(
+                title="🛠️ BTD6 Admin",
+                description="Closed.",
+                color=discord.Color.greyple(),
+            ),
+            view=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fetch driver — live progress edits + final summary
+# ---------------------------------------------------------------------------
+
+
+async def _run_fetch(
+    interaction: discord.Interaction,
+    source_keys: list[str],
+    *,
+    user_id: int,
+    label: str,
+) -> None:
+    """Sequentially refresh ``source_keys`` and edit the response after
+    each chain completes so the operator sees live progress.
+
+    Uses ``interaction.edit_original_response`` between chains and
+    posts the combined summary embed at the end.
+    """
+    from cogs.btd6._builders import build_admin_refresh_summary_embed
+
+    if not await safe_defer(interaction, ephemeral=True):
+        return
+
+    results_by_source: list[tuple[str, list[Any]]] = []
+    total_facts = 0
+
+    for idx, source_key in enumerate(source_keys, start=1):
+        progress_embed = discord.Embed(
+            title=f"🛠️ {label}",
+            description=(
+                f"Running `{source_key}` ({idx}/{len(source_keys)})…\n"
+                f"Total facts written so far: **{total_facts}**"
+            ),
+            color=discord.Color.blurple(),
+        )
+        try:
+            await interaction.edit_original_response(
+                embed=progress_embed,
+                view=None,
+            )
+        except discord.HTTPException:  # noqa: BLE001
+            logger.debug("admin fetch progress edit failed (non-fatal)")
+
+        try:
+            results = await btd6_ingestion_service.refresh_source_or_dependencies(
+                source_key,
+                reason="manual",
+                started_by_user_id=user_id,
+            )
+        except Exception:  # noqa: BLE001 — surfaced via summary embed
+            logger.exception("admin fetch failed for %s", source_key)
+            results = []
+
+        results_by_source.append((source_key, results))
+        total_facts += sum(r.fact_count for r in results)
+
+    summary = build_admin_refresh_summary_embed(
+        results_by_source,
+        title_suffix=f" — {label}",
+    )
+    try:
+        await interaction.edit_original_response(embed=summary, view=None)
+    except discord.HTTPException:
+        # Fallback: post the summary as a followup if editing failed.
+        await interaction.followup.send(embed=summary, ephemeral=True)
+
+
+__all__ = [
+    "BTD6AdminView",
+    "build_admin_embed",
+]

--- a/disbot/views/btd6/panel.py
+++ b/disbot/views/btd6/panel.py
@@ -6,13 +6,16 @@ decorator side-effect on :class:`BTD6PanelView`; the persistent
 view registry then resolves the ``btd6`` subsystem when
 ``on_ready`` restores anchors.
 
-Panel buttons render deterministic embeds from
-:mod:`services.btd6_knowledge_service` and the BTD6 response
-builder. Natural-language replies are owned by the AI Platform's
-central stage — this panel never invokes a provider directly.
+User actions: Ask / Towers / Heroes / Modes / Status. Staff actions
+sit behind the **🛠️ Admin** button — opens an ephemeral
+:class:`views.btd6.admin_panel.BTD6AdminView` with manual fetch
+controls and diagnostics. Natural-language replies are owned by the
+AI Platform's central stage — this panel never invokes a provider.
 """
 
 from __future__ import annotations
+
+from typing import Any
 
 import discord
 
@@ -20,6 +23,25 @@ from core.runtime.persistent_views import PersistentView, register
 from services import btd6_ai_service, btd6_knowledge_service
 
 _PANEL_COLOR = discord.Color.green()
+
+
+# ---------------------------------------------------------------------------
+# Staff gate (mirrors disbot/views/btd6/strategy_review.py:41-47)
+# ---------------------------------------------------------------------------
+
+
+def _is_staff(member: Any) -> bool:
+    perms = getattr(member, "guild_permissions", None)
+    if perms is None:
+        return False
+    return bool(
+        getattr(perms, "administrator", False) or getattr(perms, "manage_guild", False),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ask modal
+# ---------------------------------------------------------------------------
 
 
 class BTD6AskModal(discord.ui.Modal, title="Ask BTD6 Assistant"):
@@ -42,35 +64,102 @@ class BTD6AskModal(discord.ui.Modal, title="Ask BTD6 Assistant"):
         )
 
 
-def build_btd6_panel_embed() -> discord.Embed:
+# ---------------------------------------------------------------------------
+# Panel embed
+# ---------------------------------------------------------------------------
+
+
+# Useful-first ordering for the Currently active block.
+_ACTIVE_KINDS: tuple[tuple[str, str, str], ...] = (
+    ("btd6_race", "🏁", "race"),
+    ("btd6_boss", "👑", "boss"),
+    ("btd6_ct", "🗺️", "ct"),
+    ("btd6_odyssey", "🌊", "odyssey"),
+    ("btd6_event", "🎪", "event"),
+)
+
+
+def _format_ends_relative(end_ms: Any) -> str:
+    """Render ``end_ms`` as ``ends Xh / Xd``.
+
+    ``None`` / non-numeric / past timestamps render as the empty
+    string so the line stays compact. Reuses the same ms-since-epoch
+    convention as the live-event reader.
+    """
+    from datetime import datetime, timezone
+
+    if not isinstance(end_ms, (int, float)) or end_ms <= 0:
+        return ""
+    try:
+        end = datetime.fromtimestamp(end_ms / 1000.0, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return ""
+    delta = end - datetime.now(tz=timezone.utc)
+    seconds = int(delta.total_seconds())
+    if seconds <= 0:
+        return "· ended"
+    if seconds < 3600:
+        return f"· ends {seconds // 60}m"
+    if seconds < 86_400:
+        return f"· ends {seconds // 3600}h"
+    return f"· ends {seconds // 86_400}d"
+
+
+def _format_currently_active(
+    rows: dict[str, dict[str, Any]],
+) -> str:
+    """One line per kind in useful-first order; '—' for missing kinds.
+
+    Names pulled from ``body_json.name`` with ``entity_key`` fallback.
+    Renders an end-time hint when ``body_json.end_ms`` is positive.
+    """
+    from cogs.btd6._builders import _coerce_body
+
+    lines: list[str] = []
+    for entity_kind, emoji, short in _ACTIVE_KINDS:
+        row = rows.get(entity_kind)
+        if row is None:
+            lines.append(f"{emoji} `{short:<8}` —")
+            continue
+        body = _coerce_body(row.get("body_json"))
+        name = body.get("name") or row.get("entity_key") or "—"
+        ends = _format_ends_relative(body.get("end_ms"))
+        # Cap displayed name so a freakishly long event name doesn't
+        # blow the field-value cap. 60 chars is plenty for any real
+        # NK event name.
+        name_str = str(name)[:60]
+        suffix = f" {ends}" if ends else ""
+        lines.append(f"{emoji} `{short:<8}` `{name_str}`{suffix}")
+    return "\n".join(lines)
+
+
+async def build_btd6_panel_embed() -> discord.Embed:
     """BTD6 panel embed.
 
-    Pulls the dataset version + game version so operators can see at
-    a glance which patch the assistant is pinned to.
+    Two information blocks:
+
+    * Reference (seed) — data/game version + entity counts; what the
+      deterministic resolver answers from.
+    * Currently active — the latest race/boss/CT/odyssey/event by name
+      from ``btd6_facts``, so opening ``!btd6`` immediately reflects
+      whether ingestion is producing data.
     """
+    from utils.db import btd6_sources as btd6_db
+
     embed = discord.Embed(
         title="🐵 BTD6 Assistant",
         description=(
-            "Ask BTD6 questions. The buttons below render "
-            "tower / round / mode lookups. The Refresh Panel button "
-            "only redraws this screen; it does not fetch new Ninja "
-            "Kiwi data. Use Source Health to check data freshness."
+            "Ask BTD6 questions or browse tower / hero / mode / round "
+            "info. Staff can open the **🛠️ Admin** panel for manual "
+            "data fetches and diagnostics."
         ),
         color=_PANEL_COLOR,
     )
     embed.add_field(
-        name="Data version",
-        value=btd6_knowledge_service.data_version(),
-        inline=True,
-    )
-    embed.add_field(
-        name="Game version",
-        value=btd6_knowledge_service.game_version(),
-        inline=True,
-    )
-    embed.add_field(
-        name="Entities",
+        name="📚 Reference (seed)",
         value=(
+            f"Data version: `{btd6_knowledge_service.data_version()}` · "
+            f"Game version: `{btd6_knowledge_service.game_version()}`\n"
             f"{len(btd6_knowledge_service.list_towers())} towers • "
             f"{len(btd6_knowledge_service.list_heroes())} heroes • "
             f"{len(btd6_knowledge_service.list_maps())} maps • "
@@ -79,18 +168,34 @@ def build_btd6_panel_embed() -> discord.Embed:
         ),
         inline=False,
     )
+    active_rows = await btd6_db.latest_fact_per_entity_kind(
+        [kind for kind, _, _ in _ACTIVE_KINDS],
+    )
+    embed.add_field(
+        name="🎯 Currently active",
+        value=_format_currently_active(active_rows),
+        inline=False,
+    )
     embed.set_footer(
-        text="!btd6 ask <q> / !btd6 tower <n> / !btd6 round <N> / !btd6 status",
+        text="!btd6 ask <q> · !btd6 tower <n> · !btd6 round <N> · !btd6 status",
     )
     return embed
 
 
+# ---------------------------------------------------------------------------
+# Persistent view
+# ---------------------------------------------------------------------------
+
+
 @register
 class BTD6PanelView(PersistentView):
-    """BTD6 Assistant panel. Anyone can interact."""
+    """BTD6 Assistant panel. Anyone can use the user buttons; the
+    Admin button is gated to ``manage_guild`` / ``administrator``.
+    """
 
     SUBSYSTEM = "btd6"
 
+    # Row 0 — user actions (5 buttons fill the row)
     @discord.ui.button(
         label="Ask",
         style=discord.ButtonStyle.success,
@@ -102,24 +207,7 @@ class BTD6PanelView(PersistentView):
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        """Open the Ask modal — the actionable entry point for the panel."""
         await interaction.response.send_modal(BTD6AskModal())
-
-    @discord.ui.button(
-        label="Refresh Panel",
-        style=discord.ButtonStyle.secondary,
-        row=0,
-        custom_id="btd6:refresh",
-    )
-    async def refresh_btn(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        await interaction.response.edit_message(
-            embed=build_btd6_panel_embed(),
-            view=self,
-        )
 
     @discord.ui.button(
         label="Towers",
@@ -136,6 +224,24 @@ class BTD6PanelView(PersistentView):
 
         await interaction.response.edit_message(
             embed=build_towers_embed(),
+            view=self,
+        )
+
+    @discord.ui.button(
+        label="Heroes",
+        style=discord.ButtonStyle.primary,
+        row=0,
+        custom_id="btd6:heroes",
+    )
+    async def heroes_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        from cogs.btd6._embeds import build_heroes_embed
+
+        await interaction.response.edit_message(
+            embed=build_heroes_embed(),
             view=self,
         )
 
@@ -173,4 +279,32 @@ class BTD6PanelView(PersistentView):
         await interaction.response.edit_message(
             embed=await build_status_embed(),
             view=self,
+        )
+
+    # Row 1 — staff actions
+    @discord.ui.button(
+        label="🛠️ Admin",
+        style=discord.ButtonStyle.secondary,
+        row=1,
+        custom_id="btd6:admin",
+    )
+    async def admin_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if not _is_staff(interaction.user):
+            await interaction.response.send_message(
+                "❌ The Admin panel requires `manage_guild` or administrator.",
+                ephemeral=True,
+            )
+            return
+        from views.btd6.admin_panel import BTD6AdminView, build_admin_embed
+
+        view = await BTD6AdminView.create(interaction.user.id)
+        embed = await build_admin_embed()
+        await interaction.response.send_message(
+            embed=embed,
+            view=view,
+            ephemeral=True,
         )

--- a/tests/unit/cogs/test_btd6_api_refresh_command.py
+++ b/tests/unit/cogs/test_btd6_api_refresh_command.py
@@ -20,7 +20,6 @@ from cogs.btd6._builders import (
 )
 from cogs.btd6_cog import BTD6Cog
 from services import btd6_ingestion_service
-from views.btd6.panel import BTD6PanelView, build_btd6_panel_embed
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -63,27 +62,10 @@ def _slash_interaction() -> MagicMock:
 
 
 # ---------------------------------------------------------------------------
-# Panel button + copy pins
+# (Panel button + copy pins for "Refresh Panel" removed — the button was
+# dropped in the admin-panel restructure. New panel-layout pins live in
+# tests/unit/cogs/test_btd6_panel_admin_button.py.)
 # ---------------------------------------------------------------------------
-
-
-def test_panel_refresh_button_renamed_and_id_stable():
-    view = BTD6PanelView()
-    matched = [
-        child
-        for child in view.children
-        if getattr(child, "custom_id", None) == "btd6:refresh"
-    ]
-    assert len(matched) == 1, "expected exactly one btd6:refresh button"
-    assert matched[0].label == "Refresh Panel"
-
-
-def test_panel_description_mentions_ui_only():
-    embed = build_btd6_panel_embed()
-    description = embed.description or ""
-    assert "Refresh Panel" in description
-    assert "does not fetch" in description
-    assert "Source Health" in description
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cogs/test_btd6_boundaries.py
+++ b/tests/unit/cogs/test_btd6_boundaries.py
@@ -145,6 +145,8 @@ def _expected_parity_names() -> set[str]:
         "refresh-source",
         # Live-event reader (parametrized by kind):
         "live",
+        # Event-detail lookup (parametrized by kind + entity_key):
+        "event",
         # PR-F additions:
         "browse",
         "mine",
@@ -205,8 +207,15 @@ async def test_status_embed_has_no_stale_strings(monkeypatch):
         assert stale not in blob, f"Stale string {stale!r} in status embed"
 
 
-def test_panel_embed_has_no_stale_strings():
-    embed = build_btd6_panel_embed()
+@pytest.mark.asyncio
+async def test_panel_embed_has_no_stale_strings(monkeypatch):
+    from utils.db import btd6_sources as btd6_db
+
+    async def _empty(_kinds):
+        return {}
+
+    monkeypatch.setattr(btd6_db, "latest_fact_per_entity_kind", _empty)
+    embed = await build_btd6_panel_embed()
     blob = (embed.title or "") + " " + (embed.description or "")
     for stale in _STALE_STRINGS:
         assert stale not in blob, f"Stale string {stale!r} in panel embed"

--- a/tests/unit/cogs/test_btd6_cog.py
+++ b/tests/unit/cogs/test_btd6_cog.py
@@ -106,11 +106,20 @@ def test_test_intent_embed_renders_resolver_state():
     assert "Rounds" in field_names
 
 
-def test_panel_embed_uses_dataset_versions():
-    embed = build_btd6_panel_embed()
+@pytest.mark.asyncio
+async def test_panel_embed_includes_reference_and_active_blocks(monkeypatch):
+    """Panel embed: seed reference block + 'Currently active' block."""
+    from utils.db import btd6_sources as btd6_db
+
+    async def _empty(_kinds):
+        return {}
+
+    monkeypatch.setattr(btd6_db, "latest_fact_per_entity_kind", _empty)
+    embed = await build_btd6_panel_embed()
     assert isinstance(embed, discord.Embed)
     field_names = {field.name for field in embed.fields}
-    assert {"Data version", "Game version", "Entities"} <= field_names
+    assert any("Reference" in n for n in field_names)
+    assert any("Currently active" in n for n in field_names)
 
 
 def test_persistent_view_registered_under_btd6_subsystem():

--- a/tests/unit/cogs/test_btd6_event_detail_command.py
+++ b/tests/unit/cogs/test_btd6_event_detail_command.py
@@ -1,0 +1,193 @@
+"""Tests for the new ``!btd6 event <kind> <id>`` command.
+
+Both prefix and slash invoke the same ``build_event_payload`` helper
+from ``cogs/btd6/_event_helpers.py``. The empty-state path renders a
+red embed with a hint pointing at ``!btd6 live <kind>``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from cogs.btd6_cog import BTD6Cog
+
+
+def _index_row(entity_kind: str, entity_key: str, name: str | None = None) -> dict:
+    body: dict = {"id": entity_key, "start_ms": 1779019200000, "end_ms": 1779105600000}
+    if name is not None:
+        body["name"] = name
+    return {
+        "id": 1,
+        "source_id": 1,
+        "fact_type": "btd6.races_index",
+        "entity_kind": entity_kind,
+        "entity_key": entity_key,
+        "body_json": body,
+        "game_version": "44.0",
+        "fetched_at": datetime.now(tz=timezone.utc),
+        "validated_at": None,
+        "confidence": 1.0,
+        "version": 1,
+    }
+
+
+def _metadata_row(towers: list[dict]) -> dict:
+    return {
+        "id": 2,
+        "source_id": 1,
+        "fact_type": "btd6.race_metadata",
+        "entity_kind": "btd6_race",
+        "entity_key": "Reversed_Loop",
+        "body_json": {
+            "race_id": "Reversed_Loop",
+            "startRound": 1,
+            "endRound": 60,
+            "lives": 100,
+            "_towers": towers,
+        },
+        "game_version": "44.0",
+        "fetched_at": datetime.now(tz=timezone.utc),
+        "validated_at": None,
+        "confidence": 1.0,
+        "version": 1,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Prefix command
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prefix_event_command_renders_index_only(monkeypatch):
+    from utils.db import btd6_sources as btd6_db
+
+    async def _fact(fact_type, entity_kind, entity_key):
+        if fact_type is None:
+            return _index_row(entity_kind, entity_key, name="Reversed Loop")
+        return None
+
+    monkeypatch.setattr(btd6_db, "get_latest_fact", _fact)
+
+    cog = BTD6Cog(MagicMock())
+    ctx = MagicMock()
+    ctx.send = AsyncMock()
+
+    await cog.btd6_event.callback(cog, ctx, "race", "Reversed_Loop")
+
+    embed = ctx.send.await_args.kwargs.get("embed")
+    assert embed is not None
+    assert "Reversed Loop" in (embed.title or "")
+    # Status field present
+    field_names = [f.name for f in embed.fields]
+    assert "Window" in field_names
+
+
+@pytest.mark.asyncio
+async def test_prefix_event_command_renders_tower_restrictions(monkeypatch):
+    from utils.db import btd6_sources as btd6_db
+
+    async def _fact(fact_type, entity_kind, entity_key):
+        if fact_type is None:
+            return _index_row(entity_kind, entity_key, name="Reversed Loop")
+        if fact_type == "btd6.race_metadata":
+            return _metadata_row(
+                [
+                    {"tower": "BananaFarm", "max": 0, "isHero": False},
+                    {"tower": "Alchemist", "max": 1, "isHero": False},
+                ],
+            )
+        return None
+
+    monkeypatch.setattr(btd6_db, "get_latest_fact", _fact)
+
+    cog = BTD6Cog(MagicMock())
+    ctx = MagicMock()
+    ctx.send = AsyncMock()
+
+    await cog.btd6_event.callback(cog, ctx, "race", "Reversed_Loop")
+
+    embed = ctx.send.await_args.kwargs.get("embed")
+    field_names = [f.name for f in embed.fields]
+    assert any("Banned" in n for n in field_names)
+    assert any("Limited" in n for n in field_names)
+    banned_field = next(f for f in embed.fields if "Banned" in (f.name or ""))
+    assert "BananaFarm" in (banned_field.value or "")
+
+
+@pytest.mark.asyncio
+async def test_prefix_event_command_empty_state(monkeypatch):
+    from utils.db import btd6_sources as btd6_db
+
+    async def _fact(fact_type, entity_kind, entity_key):
+        return None
+
+    monkeypatch.setattr(btd6_db, "get_latest_fact", _fact)
+
+    cog = BTD6Cog(MagicMock())
+    ctx = MagicMock()
+    ctx.send = AsyncMock()
+
+    await cog.btd6_event.callback(cog, ctx, "race", "nonsense")
+
+    embed = ctx.send.await_args.kwargs.get("embed")
+    assert embed.color == discord.Color.red()
+    desc = embed.description or ""
+    assert "No event found" in desc
+    assert "!btd6 live race" in desc
+
+
+# ---------------------------------------------------------------------------
+# Slash command — defers before DB
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_slash_event_command_defers_before_db_calls(monkeypatch):
+    call_order: list[str] = []
+
+    from cogs import btd6_cog as cog_mod
+    from utils.db import btd6_sources as btd6_db
+
+    async def _fact(fact_type, entity_kind, entity_key):
+        call_order.append("db")
+        return _index_row(entity_kind, entity_key, name="X")
+
+    monkeypatch.setattr(btd6_db, "get_latest_fact", _fact)
+
+    async def _defer(interaction, **kw):
+        call_order.append("defer")
+        return True
+
+    async def _followup(*a, **kw):
+        call_order.append("followup")
+        return None
+
+    monkeypatch.setattr(cog_mod, "safe_defer", _defer)
+    monkeypatch.setattr(cog_mod, "safe_followup", _followup)
+
+    cog = BTD6Cog(MagicMock())
+    interaction = MagicMock()
+    interaction.response.is_done = lambda: False
+
+    await cog.btd6_event_slash.callback(cog, interaction, "race", "X")
+
+    # defer must come before any db call.
+    assert call_order[0] == "defer"
+    assert "db" in call_order
+    assert call_order[-1] == "followup"
+
+
+# ---------------------------------------------------------------------------
+# Parity pin
+# ---------------------------------------------------------------------------
+
+
+def test_event_command_in_parity_pin():
+    from tests.unit.cogs.test_btd6_boundaries import _expected_parity_names
+
+    assert "event" in _expected_parity_names()

--- a/tests/unit/cogs/test_btd6_event_detail_render_towers.py
+++ b/tests/unit/cogs/test_btd6_event_detail_render_towers.py
@@ -1,0 +1,97 @@
+"""Unit tests for ``_render_tower_restrictions``.
+
+Decode the ``_towers`` array preserved verbatim in race/boss/odyssey
+metadata bodies into UI categories. Tested in isolation so the
+rendering logic can't drift relative to the parser shape.
+"""
+
+from __future__ import annotations
+
+from cogs.btd6._builders import _render_tower_restrictions
+
+
+def _entry(
+    tower: str,
+    *,
+    max: int | None = None,
+    p1: int = 0,
+    p2: int = 0,
+    p3: int = 0,
+    is_hero: bool = False,
+) -> dict:
+    out: dict = {
+        "tower": tower,
+        "path1NumBlockedTiers": p1,
+        "path2NumBlockedTiers": p2,
+        "path3NumBlockedTiers": p3,
+        "isHero": is_hero,
+    }
+    if max is not None:
+        out["max"] = max
+    return out
+
+
+def test_empty_list_returns_empty_dict():
+    assert _render_tower_restrictions([]) == {}
+
+
+def test_max_zero_non_hero_is_banned():
+    out = _render_tower_restrictions([_entry("BananaFarm", max=0)])
+    assert out == {"banned": ["BananaFarm"]}
+
+
+def test_max_positive_is_limited_with_count():
+    out = _render_tower_restrictions([_entry("Alchemist", max=1)])
+    assert out == {"limited": ["Alchemist (max 1)"]}
+
+
+def test_hero_with_max_zero_is_heroes_banned():
+    out = _render_tower_restrictions(
+        [_entry("ChosenPrimaryHero", max=0, is_hero=True)],
+    )
+    assert out == {"heroes_banned": ["ChosenPrimaryHero"]}
+
+
+def test_path_blocked_renders_per_path():
+    out = _render_tower_restrictions(
+        [_entry("DartMonkey", p1=2, p2=0, p3=4)],
+    )
+    assert "path_blocked" in out
+    rendered = out["path_blocked"][0]
+    assert "DartMonkey" in rendered
+    assert "path1 top 2" in rendered
+    assert "path3 top 4" in rendered
+    assert "path2" not in rendered
+
+
+def test_mixed_array_groups_into_all_categories():
+    out = _render_tower_restrictions(
+        [
+            _entry("BananaFarm", max=0),
+            _entry("Alchemist", max=1),
+            _entry("DartMonkey", p1=3),
+            _entry("ChosenPrimaryHero", max=0, is_hero=True),
+            _entry("Quincy", max=1, is_hero=True),
+        ],
+    )
+    assert out["banned"] == ["BananaFarm"]
+    assert "Alchemist (max 1)" in out["limited"]
+    # Quincy is a hero with max=1 — `isHero=True` only matters when
+    # combined with max=0 (banned). With max>=1 the entry falls into
+    # the regular "limited" bucket so the operator still sees the cap.
+    assert "Quincy (max 1)" in out["limited"]
+    assert any("DartMonkey" in s for s in out["path_blocked"])
+    assert out["heroes_banned"] == ["ChosenPrimaryHero"]
+
+
+def test_entries_without_tower_field_are_skipped():
+    out = _render_tower_restrictions(
+        [{"max": 0, "isHero": False}, _entry("DartMonkey", max=0)],
+    )
+    assert out == {"banned": ["DartMonkey"]}
+
+
+def test_missing_max_with_no_path_block_is_no_op():
+    """Entry with max=missing and no path blocks → no restriction."""
+    out = _render_tower_restrictions([_entry("Ninja")])
+    assert out == {}

--- a/tests/unit/cogs/test_btd6_panel_embed_currently_active.py
+++ b/tests/unit/cogs/test_btd6_panel_embed_currently_active.py
@@ -1,0 +1,127 @@
+"""Pin the new 'Currently active' field on the BTD6 panel embed.
+
+The plan is to make ``build_btd6_panel_embed`` async and add a field
+that lists the latest race / boss / CT / odyssey / event by name with
+a ``ends Xh/Xd`` hint.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+import discord
+import pytest
+
+from views.btd6.panel import build_btd6_panel_embed
+
+
+def _now_ms(delta_hours: int = 0) -> int:
+    when = datetime.now(tz=timezone.utc) + timedelta(hours=delta_hours)
+    return int(when.timestamp() * 1000)
+
+
+def _fact_row(
+    *,
+    entity_kind: str,
+    entity_key: str,
+    name: str | None = None,
+    end_ms: int | None = None,
+) -> dict:
+    body: dict = {}
+    if name is not None:
+        body["name"] = name
+    if end_ms is not None:
+        body["end_ms"] = end_ms
+    return {
+        "entity_kind": entity_kind,
+        "entity_key": entity_key,
+        "body_json": body,
+        "fetched_at": datetime.now(tz=timezone.utc),
+    }
+
+
+@pytest.mark.asyncio
+async def test_panel_embed_includes_currently_active_field(monkeypatch):
+    from utils.db import btd6_sources as btd6_db
+
+    async def _rows(kinds):
+        return {
+            "btd6_race": _fact_row(
+                entity_kind="btd6_race",
+                entity_key="Reversed_Loop",
+                name="Reversed Loop",
+                end_ms=_now_ms(48),
+            ),
+            "btd6_boss": _fact_row(
+                entity_kind="btd6_boss",
+                entity_key="Diamondback5",
+                name="Diamondback v5",
+                end_ms=_now_ms(5),
+            ),
+        }
+
+    monkeypatch.setattr(btd6_db, "latest_fact_per_entity_kind", _rows)
+
+    embed = await build_btd6_panel_embed()
+    assert isinstance(embed, discord.Embed)
+    names = [f.name for f in embed.fields]
+    assert any("Currently active" in (n or "") for n in names)
+
+    active_field = next(f for f in embed.fields if "Currently active" in (f.name or ""))
+    value = active_field.value or ""
+    assert "Reversed Loop" in value
+    assert "Diamondback v5" in value
+    # End-time hint renders for present kinds.
+    assert "ends" in value
+
+
+@pytest.mark.asyncio
+async def test_panel_embed_renders_dash_for_missing_kinds(monkeypatch):
+    from utils.db import btd6_sources as btd6_db
+
+    async def _empty(kinds):
+        return {}
+
+    monkeypatch.setattr(btd6_db, "latest_fact_per_entity_kind", _empty)
+
+    embed = await build_btd6_panel_embed()
+    active_field = next(f for f in embed.fields if "Currently active" in (f.name or ""))
+    value = active_field.value or ""
+    # All 5 kinds render '—' when no facts exist.
+    assert value.count("—") >= 5
+
+
+@pytest.mark.asyncio
+async def test_panel_embed_falls_back_to_entity_key_when_no_name(monkeypatch):
+    from utils.db import btd6_sources as btd6_db
+
+    async def _rows(kinds):
+        return {
+            "btd6_ct": _fact_row(entity_kind="btd6_ct", entity_key="ct_abc123"),
+        }
+
+    monkeypatch.setattr(btd6_db, "latest_fact_per_entity_kind", _rows)
+
+    embed = await build_btd6_panel_embed()
+    active_field = next(f for f in embed.fields if "Currently active" in (f.name or ""))
+    value = active_field.value or ""
+    assert "ct_abc123" in value
+
+
+@pytest.mark.asyncio
+async def test_panel_embed_keeps_seed_reference_block(monkeypatch):
+    from utils.db import btd6_sources as btd6_db
+
+    async def _empty(kinds):
+        return {}
+
+    monkeypatch.setattr(btd6_db, "latest_fact_per_entity_kind", _empty)
+
+    embed = await build_btd6_panel_embed()
+    names = [f.name for f in embed.fields]
+    assert any("Reference" in (n or "") for n in names)
+    ref_field = next(f for f in embed.fields if "Reference" in (f.name or ""))
+    value = ref_field.value or ""
+    assert "towers" in value.lower()
+    assert "heroes" in value.lower()

--- a/tests/unit/utils/db/test_btd6_sources_latest_fact_per_kind.py
+++ b/tests/unit/utils/db/test_btd6_sources_latest_fact_per_kind.py
@@ -1,0 +1,143 @@
+"""Pin the new ``latest_fact_per_entity_kind`` DB helper.
+
+DISTINCT ON returns one row per kind, newest by ``fetched_at``. Kinds
+absent from ``btd6_facts`` are absent from the dict. Empty input
+returns ``{}`` without hitting the DB.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from utils.db import btd6_sources as btd6_db
+
+
+@pytest.mark.asyncio
+async def test_empty_kinds_returns_empty_dict_without_db_call(monkeypatch):
+    """Fast-path: no SQL round-trip when ``kinds`` is empty."""
+    fake_pool = MagicMock()
+    fake_pool.fetch = AsyncMock()
+    monkeypatch.setattr(btd6_db.pool, "get", lambda: fake_pool)
+
+    result = await btd6_db.latest_fact_per_entity_kind([])
+
+    assert result == {}
+    fake_pool.fetch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_one_row_per_kind_keyed_by_entity_kind(monkeypatch):
+    now = datetime.now(tz=timezone.utc)
+
+    canned = [
+        {
+            "id": 1,
+            "source_id": 7,
+            "fact_type": "btd6.races_index",
+            "entity_kind": "btd6_race",
+            "entity_key": "Reversed_Loop",
+            "body_json": {"name": "Reversed Loop"},
+            "game_version": "44.0",
+            "fetched_at": now,
+            "validated_at": None,
+            "confidence": 1.0,
+            "version": 1,
+        },
+        {
+            "id": 2,
+            "source_id": 8,
+            "fact_type": "btd6.bosses_index",
+            "entity_kind": "btd6_boss",
+            "entity_key": "Diamondback5",
+            "body_json": {"name": "Diamondback v5"},
+            "game_version": "44.0",
+            "fetched_at": now,
+            "validated_at": None,
+            "confidence": 1.0,
+            "version": 1,
+        },
+    ]
+    fake_pool = MagicMock()
+    fake_pool.fetch = AsyncMock(return_value=canned)
+    monkeypatch.setattr(btd6_db.pool, "get", lambda: fake_pool)
+
+    result = await btd6_db.latest_fact_per_entity_kind(["btd6_race", "btd6_boss"])
+
+    assert set(result) == {"btd6_race", "btd6_boss"}
+    assert result["btd6_race"]["entity_key"] == "Reversed_Loop"
+    assert result["btd6_boss"]["entity_key"] == "Diamondback5"
+
+    # SQL must use DISTINCT ON + ANY ordering by fetched_at DESC.
+    sql_call = fake_pool.fetch.call_args
+    sql = sql_call.args[0]
+    assert "DISTINCT ON (entity_kind)" in sql
+    assert "entity_kind = ANY" in sql
+    assert "ORDER BY entity_kind, fetched_at DESC" in sql
+
+
+@pytest.mark.asyncio
+async def test_missing_kinds_are_absent_not_none(monkeypatch):
+    """When the registry has no facts for a kind, the dict simply lacks the key."""
+    fake_pool = MagicMock()
+    fake_pool.fetch = AsyncMock(return_value=[])
+    monkeypatch.setattr(btd6_db.pool, "get", lambda: fake_pool)
+
+    result = await btd6_db.latest_fact_per_entity_kind(["btd6_race"])
+
+    assert result == {}
+    assert "btd6_race" not in result
+
+
+# ---------------------------------------------------------------------------
+# get_latest_fact: extended to accept ``fact_type=None``
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_latest_fact_with_none_fact_type_omits_clause(monkeypatch):
+    captured: dict = {}
+
+    async def _fetchrow(sql, *args):
+        captured["sql"] = sql
+        captured["args"] = args
+        return None
+
+    fake_pool = MagicMock()
+    fake_pool.fetchrow = _fetchrow
+    monkeypatch.setattr(btd6_db.pool, "get", lambda: fake_pool)
+
+    await btd6_db.get_latest_fact(None, "btd6_race", "Reversed_Loop")
+
+    # No ``f.fact_type = $1`` filter clause when fact_type is None.
+    # (``f.fact_type`` still appears in the SELECT projection.)
+    assert "f.fact_type = $1" not in captured["sql"]
+    # entity_kind + entity_key are the only filter params.
+    assert captured["args"] == ("btd6_race", "Reversed_Loop")
+
+
+@pytest.mark.asyncio
+async def test_get_latest_fact_with_fact_type_keeps_clause(monkeypatch):
+    captured: dict = {}
+
+    async def _fetchrow(sql, *args):
+        captured["sql"] = sql
+        captured["args"] = args
+        return None
+
+    fake_pool = MagicMock()
+    fake_pool.fetchrow = _fetchrow
+    monkeypatch.setattr(btd6_db.pool, "get", lambda: fake_pool)
+
+    await btd6_db.get_latest_fact(
+        "btd6.race_metadata", "btd6_race", "Reversed_Loop",
+    )
+
+    assert "f.fact_type = $1" in captured["sql"]
+    assert captured["args"] == (
+        "btd6.race_metadata",
+        "btd6_race",
+        "Reversed_Loop",
+    )

--- a/tests/unit/views/test_btd6_admin_panel.py
+++ b/tests/unit/views/test_btd6_admin_panel.py
@@ -1,0 +1,299 @@
+"""Tests for the new ephemeral admin sub-view."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from views.btd6.admin_panel import (
+    _PARENT_SOURCES,
+    BTD6AdminView,
+    build_admin_embed,
+)
+
+# ---------------------------------------------------------------------------
+# build_admin_embed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_embed_lists_parent_sources():
+    embed = await build_admin_embed()
+    assert isinstance(embed, discord.Embed)
+    blob = " ".join(f.value or "" for f in embed.fields)
+    for src in _PARENT_SOURCES:
+        assert src in blob
+
+
+# ---------------------------------------------------------------------------
+# BTD6AdminView.create — async factory + multi-select population
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_populates_multiselect_from_registry(monkeypatch):
+    from services import btd6_source_registry
+
+    async def _list_enabled(*, limit=100):
+        return [
+            {"source_key": "nk_btd6_events"},
+            {"source_key": "nk_btd6_races"},
+            {"source_key": "nk_btd6_maps"},
+        ]
+
+    monkeypatch.setattr(btd6_source_registry, "list_enabled_sources", _list_enabled)
+
+    view = await BTD6AdminView.create(opener_user_id=42)
+    option_values = [o.value for o in view.source_select.options]
+    assert set(option_values) == {
+        "nk_btd6_events",
+        "nk_btd6_races",
+        "nk_btd6_maps",
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_handles_registry_failure_gracefully(monkeypatch):
+    from services import btd6_source_registry
+
+    async def _boom(*, limit=100):
+        raise RuntimeError("DB down")
+
+    monkeypatch.setattr(btd6_source_registry, "list_enabled_sources", _boom)
+
+    # No exception escapes; the view still builds with a placeholder.
+    view = await BTD6AdminView.create(opener_user_id=42)
+    assert isinstance(view, BTD6AdminView)
+    # The multi-select must have at least one option to satisfy discord.py.
+    assert view.source_select.options
+
+
+@pytest.mark.asyncio
+async def test_create_caps_options_at_discord_max_25(monkeypatch):
+    from services import btd6_source_registry
+
+    async def _many(*, limit=100):
+        return [{"source_key": f"nk_btd6_src_{i:02d}"} for i in range(40)]
+
+    monkeypatch.setattr(btd6_source_registry, "list_enabled_sources", _many)
+
+    view = await BTD6AdminView.create(opener_user_id=42)
+    assert len(view.source_select.options) == 25
+
+
+# ---------------------------------------------------------------------------
+# interaction_check — non-opener / non-staff are rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_interaction_check_rejects_non_opener(monkeypatch):
+    from services import btd6_source_registry
+
+    async def _list_enabled(*, limit=100):
+        return [{"source_key": "nk_btd6_events"}]
+
+    monkeypatch.setattr(btd6_source_registry, "list_enabled_sources", _list_enabled)
+
+    view = await BTD6AdminView.create(opener_user_id=42)
+
+    interaction = MagicMock()
+    interaction.user.id = 999  # not the opener
+    interaction.response.send_message = AsyncMock()
+
+    allowed = await view.interaction_check(interaction)
+    assert allowed is False
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "isn't yours" in msg
+
+
+@pytest.mark.asyncio
+async def test_interaction_check_rejects_non_staff(monkeypatch):
+    from services import btd6_source_registry
+
+    async def _list_enabled(*, limit=100):
+        return [{"source_key": "nk_btd6_events"}]
+
+    monkeypatch.setattr(btd6_source_registry, "list_enabled_sources", _list_enabled)
+
+    view = await BTD6AdminView.create(opener_user_id=42)
+
+    interaction = MagicMock()
+    interaction.user.id = 42  # the opener
+    interaction.user.guild_permissions.administrator = False
+    interaction.user.guild_permissions.manage_guild = False
+    interaction.response.send_message = AsyncMock()
+
+    allowed = await view.interaction_check(interaction)
+    assert allowed is False
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "Staff" in msg
+
+
+@pytest.mark.asyncio
+async def test_interaction_check_accepts_staff_opener(monkeypatch):
+    from services import btd6_source_registry
+
+    async def _list_enabled(*, limit=100):
+        return [{"source_key": "nk_btd6_events"}]
+
+    monkeypatch.setattr(btd6_source_registry, "list_enabled_sources", _list_enabled)
+
+    view = await BTD6AdminView.create(opener_user_id=42)
+
+    interaction = MagicMock()
+    interaction.user.id = 42
+    interaction.user.guild_permissions.administrator = False
+    interaction.user.guild_permissions.manage_guild = True
+    interaction.response.send_message = AsyncMock()
+
+    allowed = await view.interaction_check(interaction)
+    assert allowed is True
+    interaction.response.send_message.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Fetch buttons — calls per source, progress edits, summary
+# ---------------------------------------------------------------------------
+
+
+def _make_result(source_key: str, *, ok: bool = True):
+    from services import btd6_ingestion_service
+
+    return btd6_ingestion_service.IngestionResult(
+        source_key=source_key,
+        status="ok" if ok else "fetch_error",
+        fact_count=3 if ok else 0,
+        duration_ms=1,
+        error_code=None if ok else "503",
+        run_id=1,
+        written_entity_keys=("a", "b", "c") if ok else (),
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_button_runs_each_parent_source(monkeypatch):
+    from services import btd6_ingestion_service, btd6_source_registry
+    from views.btd6 import admin_panel
+
+    async def _list_enabled(*, limit=100):
+        return [{"source_key": "nk_btd6_events"}]
+
+    monkeypatch.setattr(btd6_source_registry, "list_enabled_sources", _list_enabled)
+
+    calls: list[str] = []
+
+    async def _stub(source_key, *, reason, started_by_user_id):
+        calls.append(source_key)
+        return [_make_result(source_key)]
+
+    monkeypatch.setattr(
+        btd6_ingestion_service, "refresh_source_or_dependencies", _stub,
+    )
+
+    view = await BTD6AdminView.create(opener_user_id=42)
+
+    interaction = MagicMock()
+    interaction.user.id = 42
+    interaction.user.guild_permissions.manage_guild = True
+    interaction.response.is_done = lambda: False
+    interaction.response.defer = AsyncMock()
+    interaction.edit_original_response = AsyncMock()
+    interaction.followup.send = AsyncMock()
+
+    # Find the Fetch All button instance and invoke its callback directly.
+    fetch_all = next(
+        c for c in view.children
+        if isinstance(c, discord.ui.Button) and c.label == "Fetch All"
+    )
+    # discord.py binds the parent view via Item._view; emulate that.
+    fetch_all._view = view
+
+    await fetch_all.callback(interaction)
+
+    # One service call per parent source.
+    assert calls == list(_PARENT_SOURCES)
+
+
+@pytest.mark.asyncio
+async def test_fetch_selected_button_uses_dropdown_values(monkeypatch):
+    from services import btd6_ingestion_service, btd6_source_registry
+
+    async def _list_enabled(*, limit=100):
+        return [
+            {"source_key": "nk_btd6_events"},
+            {"source_key": "nk_btd6_races"},
+            {"source_key": "nk_btd6_maps"},
+        ]
+
+    monkeypatch.setattr(btd6_source_registry, "list_enabled_sources", _list_enabled)
+
+    calls: list[str] = []
+
+    async def _stub(source_key, *, reason, started_by_user_id):
+        calls.append(source_key)
+        return [_make_result(source_key)]
+
+    monkeypatch.setattr(
+        btd6_ingestion_service, "refresh_source_or_dependencies", _stub,
+    )
+
+    view = await BTD6AdminView.create(opener_user_id=42)
+    # Simulate the operator picking two from the dropdown.
+    view.source_select._values = ["nk_btd6_races", "nk_btd6_maps"]
+    # discord.py reads `Select.values` from the underlying data; mock it
+    # directly since we're not going through the gateway.
+    type(view.source_select).values = property(lambda self: self._values)
+
+    interaction = MagicMock()
+    interaction.user.id = 42
+    interaction.user.guild_permissions.manage_guild = True
+    interaction.response.is_done = lambda: False
+    interaction.response.defer = AsyncMock()
+    interaction.edit_original_response = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+
+    fetch_sel = next(
+        c for c in view.children
+        if isinstance(c, discord.ui.Button) and c.label == "Fetch Selected"
+    )
+    fetch_sel._view = view
+
+    await fetch_sel.callback(interaction)
+
+    assert calls == ["nk_btd6_races", "nk_btd6_maps"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_selected_button_with_no_picks_complains(monkeypatch):
+    from services import btd6_source_registry
+
+    async def _list_enabled(*, limit=100):
+        return [{"source_key": "nk_btd6_events"}]
+
+    monkeypatch.setattr(btd6_source_registry, "list_enabled_sources", _list_enabled)
+
+    view = await BTD6AdminView.create(opener_user_id=42)
+    view.source_select._values = []
+    type(view.source_select).values = property(lambda self: self._values)
+
+    interaction = MagicMock()
+    interaction.user.id = 42
+    interaction.user.guild_permissions.manage_guild = True
+    interaction.response.send_message = AsyncMock()
+
+    fetch_sel = next(
+        c for c in view.children
+        if isinstance(c, discord.ui.Button) and c.label == "Fetch Selected"
+    )
+    fetch_sel._view = view
+
+    await fetch_sel.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "Pick at least one" in msg


### PR DESCRIPTION
## Summary

PR 1 of the BTD6 cog production-readiness roadmap. Three threads in one focused PR — what the user explicitly asked for plus the minimum companion pieces that make the panel feel live.

### What changed

**Main panel restructure (`views/btd6/panel.py`)**

- ❌ **"Refresh Panel" button removed** (operators flagged it as confusing in live testing; the panel auto-refreshes when reopened).
- ➕ **Heroes button** added so the hero catalogue is reachable without typing.
- 🛠️ **Admin button** (row 1, `manage_guild`/`administrator`-gated) opens the new ephemeral admin sub-view.
- 🎯 **Currently active** field on the main embed lists the latest race / boss / CT / odyssey / event by name with an `ends Xh / Xd` hint. Pulled from a new DB helper (`latest_fact_per_entity_kind`). Missing kinds render `—`.

**New `BTD6AdminView` (`views/btd6/admin_panel.py`)**

Ephemeral staff-only sub-view. Layout matches the screenshot pattern:

- **Row 0**: Fetch All, Fetch Selected
- **Row 1**: Source Health, Latest Data, Close
- **Row 2**: multi-select dropdown of registered enabled source keys (Discord-native picker, `min_values=0`, `max_values=25`, capped at the 25-option Discord limit)

Fetch buttons drive `refresh_source_or_dependencies` — the same service chokepoint as the existing `refresh-source` commands — so chain expansion, audit semantics, and per-source locks all just work. **Live progress edits** between chains via `interaction.edit_original_response`, then a combined summary embed at the end. `interaction_check` rejects non-opener clicks and defence-checks the staff role on every click.

**`!btd6 event <kind> <id>` (+ slash twin)**

Drills into one specific event from `btd6_facts` and renders both the index row and the corresponding `*_metadata` row. The metadata's `_towers` array (preserved verbatim by parsers since day one but never surfaced) decodes into **banned / limited / path-blocked / heroes-banned** sections via `_render_tower_restrictions`. Empty-state path returns a red embed with a `!btd6 live <kind>` hint.

### Refactor

`BTD6Cog._build_refresh_source_payload` (shipped in #353) moved into `cogs/btd6/_event_helpers.py` alongside the new `build_event_payload`. Pure refactor — both prefix and slash `refresh-source` paths still work end-to-end. Cog file drops from ~795 LOC to **790 LOC**, under the 800 cap with headroom for PR 2/3.

### Locked decisions (from plan revision)

| Decision | Chosen |
|---|---|
| Fetch All progress | Live progress edits (defer once, edit response between chains, post combined summary at the end) |
| Refactor scope | Move both `_build_refresh_source_payload` and `_build_event_payload` into `_event_helpers.py` |
| PR shape | One PR (everything above in one ~600-line diff) |
| Refresh Panel button | Drop entirely |

### Verification

- [x] `python3.10 -m pytest tests/ -q` → **5696 passed**, 3 skipped (was 5549 before; +147 from 32 new tests across 5 files plus the existing-suite untouched by my refactor)
- [x] `python3.10 -m black --check . --exclude '(\.github|tests|venv|env|build|dist)'` (CI invocation) — clean
- [x] `python3.10 -m isort --check-only . --skip-glob '*/(\.github|tests|venv|env|build|dist)/*'` — clean
- [x] `python3.10 -m ruff check . --exclude .github,tests,venv,env,build,dist` — clean
- [x] `python3.10 -m mypy disbot/` — 0 errors
- [x] `python3.10 scripts/check_architecture.py --mode strict` — 0 errors
- [x] Cog file at 790 LOC, under the 800 cap

### Manual smoke (post-merge)

1. `!btd6` → panel embed shows the new 🎯 Currently active block alongside the seed counts.
2. Panel has Ask / Towers / Heroes / Modes / Status / 🛠️ Admin buttons. **No Refresh Panel.**
3. Non-staff clicks 🛠️ Admin → ephemeral "manage_guild required" message.
4. Staff clicks 🛠️ Admin → ephemeral sub-view with Fetch All / Fetch Selected / multi-select / Source Health / Latest Data / Close.
5. Click Fetch All → progress message updates as each chain finishes ("Running nk_btd6_X (4/7)…"), then summary embed.
6. Pick 2 sources in the multi-select → Fetch Selected → summary covers only those 2.
7. `!btd6 event race Reversed_Loop_mpbd7tcu` → embed with window, status, rules, plus 🚫 Banned / ⚠️ Limited / 🧙 Heroes banned sections from `_towers`.
8. `!btd6 event race nonsense` → red empty-state embed with `!btd6 live race` hint.

### What's next (sketched in the plan file, NOT in this PR)

- **PR 2**: parser fixes (`parse_boss_metadata` 100% fail, `parse_race_leaderboard` partial fail) + `_towers` decomposition into queryable per-tower facts.
- **PR 3**: `!btd6 tower X` enriched with "restricted in current Race Y" lines + slash autocomplete on source keys + `/help` + hub discoverability.

https://claude.ai/code/session_017ECXVdLZMNVNLSFVsYxctK

---
_Generated by [Claude Code](https://claude.ai/code/session_017ECXVdLZMNVNLSFVsYxctK)_