### PR TITLE
btd6: production-ready hub — view-models, drill-down browsers, context_id contract

### DIFF
--- a/disbot/cogs/btd6/_builders.py
+++ b/disbot/cogs/btd6/_builders.py
@@ -20,11 +20,26 @@ from typing import TYPE_CHECKING, Any
 import discord
 
 from core.runtime.ai.contracts import AITask
+from utils.btd6.body_coerce import coerce_body as _coerce_body
+from utils.btd6.event_window import format_ms_human as _ms_to_human  # noqa: F401
+from utils.btd6.event_window import format_window_range as _format_window_range
+from utils.btd6.event_window import format_window_status as _format_window_status
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from services.btd6_ingestion_service import IngestionResult
+
+
+def _event_window(body: dict[str, Any]) -> str:
+    """Render ``start_ms`` → ``end_ms`` from a fact body dict.
+
+    Thin wrapper around :func:`utils.btd6.event_window.format_window_range`
+    that preserves the legacy ``(body) -> str`` calling convention used by
+    the existing embed builders.
+    """
+    return _format_window_range(body.get("start_ms"), body.get("end_ms"))
+
 
 # ---------------------------------------------------------------------------
 # why-no-response
@@ -223,14 +238,6 @@ async def build_pending_review_payload(
 # ---------------------------------------------------------------------------
 
 
-_BUCKET_BADGE = {
-    "fresh": "🟢 fresh",
-    "aging": "🟡 aging",
-    "stale": "🔴 stale",
-    "never": "⚪ never",
-}
-
-
 async def build_source_health_embed(
     *,
     limit: int = 25,
@@ -241,6 +248,7 @@ async def build_source_health_embed(
     Freshness buckets are computed in
     :mod:`services.btd6_source_registry`.
     """
+    from cogs.btd6._freshness_render import BUCKET_BADGE
     from services import btd6_source_registry
 
     health = await btd6_source_registry.list_health(limit=limit)
@@ -266,7 +274,7 @@ async def build_source_health_embed(
         embed.add_field(
             name=f"`{src.source_key}` · tier {src.trust_tier}",
             value=(
-                f"{_BUCKET_BADGE[src.bucket]} · {state} · "
+                f"{BUCKET_BADGE[src.bucket]} · {state} · "
                 f"kind=`{src.source_kind}` · facts={src.fact_count}\n"
                 f"last_fetched=`{when}`"
             ),
@@ -410,54 +418,6 @@ async def build_grounding_embed(
 # ---------------------------------------------------------------------------
 # live-event builders (race / boss / ct / odyssey / event)
 # ---------------------------------------------------------------------------
-
-
-def _ms_to_human(ms: Any) -> str:
-    """Render a milliseconds-since-epoch value as ``YYYY-MM-DD HH:MM UTC``.
-
-    Returns ``"—"`` for missing / non-numeric inputs. Live event APIs
-    use ms timestamps consistently across race / boss / odyssey / CT.
-    """
-    if not isinstance(ms, (int, float)) or ms <= 0:
-        return "—"
-    try:
-        from datetime import datetime, timezone
-
-        return datetime.fromtimestamp(ms / 1000.0, tz=timezone.utc).strftime(
-            "%Y-%m-%d %H:%M UTC",
-        )
-    except (OverflowError, OSError, ValueError):
-        return "—"
-
-
-def _event_window(body: dict[str, Any]) -> str:
-    """Render ``start_ms`` → ``end_ms`` as a single human window string."""
-    start = _ms_to_human(body.get("start_ms"))
-    end = _ms_to_human(body.get("end_ms"))
-    if start == "—" and end == "—":
-        return "—"
-    return f"{start} → {end}"
-
-
-def _coerce_body(value: Any) -> dict[str, Any]:
-    """Normalise ``body_json`` to a dict.
-
-    Defensive shim for rows written by the legacy double-encoded
-    ``json.dumps`` path: those round-trip as a JSON string instead of a
-    dict, so we json.loads them on read. Returns ``{}`` for anything we
-    can't decode (e.g. malformed text, non-mapping JSON).
-    """
-    import json
-
-    if isinstance(value, dict):
-        return value
-    if isinstance(value, str):
-        try:
-            decoded = json.loads(value)
-        except (ValueError, TypeError):
-            return {}
-        return decoded if isinstance(decoded, dict) else {}
-    return {}
 
 
 _LIVE_EVENT_SPECS: dict[str, dict[str, str]] = {
@@ -749,37 +709,6 @@ _EVENT_KIND_TITLE = {
 }
 
 
-def _format_window_status(body: dict[str, Any]) -> str:
-    """Render 'live / ended / upcoming · ends Xh' from start/end ms."""
-    from datetime import datetime, timezone
-
-    now = datetime.now(tz=timezone.utc)
-    start = body.get("start_ms")
-    end = body.get("end_ms")
-    start_dt = (
-        datetime.fromtimestamp(start / 1000.0, tz=timezone.utc)
-        if isinstance(start, (int, float)) and start > 0
-        else None
-    )
-    end_dt = (
-        datetime.fromtimestamp(end / 1000.0, tz=timezone.utc)
-        if isinstance(end, (int, float)) and end > 0
-        else None
-    )
-    if start_dt is None and end_dt is None:
-        return "status: `unknown`"
-    if start_dt is not None and now < start_dt:
-        delta = start_dt - now
-        return f"status: `upcoming` · starts in {delta.days}d {delta.seconds // 3600}h"
-    if end_dt is not None and now > end_dt:
-        return "status: `ended`"
-    if end_dt is not None:
-        delta = end_dt - now
-        h = delta.seconds // 3600
-        return f"status: `live` · ends in {delta.days}d {h}h"
-    return "status: `live`"
-
-
 def build_event_detail_embed(
     entity_kind: str,
     entity_key: str,
@@ -1003,14 +932,6 @@ def build_admin_refresh_summary_embed(
 # ---------------------------------------------------------------------------
 
 
-_FRESHNESS_BADGE = {
-    "fresh": "🟢 fresh",
-    "aging": "🟡 aging",
-    "stale": "🔴 stale",
-    "never": "⚪ never",
-}
-
-
 async def build_leaderboard_embed(
     kind: str,
     event_id: str | None,
@@ -1025,6 +946,7 @@ async def build_leaderboard_embed(
     Empty leaderboard hints at the parent-chain refresh source, not
     the child source (children require path params).
     """
+    from cogs.btd6._freshness_render import BUCKET_BADGE
     from services import btd6_live_query_service as btd6_live
     from services.btd6_source_registry import bucket_freshness
 
@@ -1118,7 +1040,7 @@ async def build_leaderboard_embed(
     if latest_fetched is not None:
         bucket = bucket_freshness(latest_fetched)
         if bucket in ("aging", "stale"):
-            parts.append(f"Data: {_FRESHNESS_BADGE[bucket]}")
+            parts.append(f"Data: {BUCKET_BADGE[bucket]}")
     if parts:
         embed.set_footer(text=" · ".join(parts))
     return embed

--- a/disbot/cogs/btd6/_builders.py
+++ b/disbot/cogs/btd6/_builders.py
@@ -112,6 +112,7 @@ async def build_hero_embed(name: str) -> discord.Embed:
     from services import btd6_ai_service, btd6_live_query_service
     from services.btd6_resolver_service import resolve
     from services.btd6_response_builder import for_hero
+    from utils.btd6.context_footer import append_context_footer
 
     intent = resolve(name)
     if not intent.heroes:
@@ -120,7 +121,8 @@ async def build_hero_embed(name: str) -> discord.Embed:
     restrictions = await btd6_live_query_service.get_active_event_restrictions_for_hero(
         str(hero.id),
     )
-    return _response_to_embed(for_hero(hero, restrictions=restrictions))
+    embed = _response_to_embed(for_hero(hero, restrictions=restrictions))
+    return append_context_footer(embed, f"btd6_hero:{hero.id}")
 
 
 async def build_round_embed(number: int) -> discord.Embed:
@@ -143,6 +145,7 @@ async def build_tower_embed(name: str) -> discord.Embed:
     from services.btd6_knowledge_service import tower_fact
     from services.btd6_resolver_service import resolve
     from services.btd6_response_builder import for_tower
+    from utils.btd6.context_footer import append_context_footer
 
     intent = resolve(name)
     if not intent.towers:
@@ -156,7 +159,8 @@ async def build_tower_embed(name: str) -> discord.Embed:
             str(tower.id),
         )
     )
-    return _response_to_embed(for_tower(fact, restrictions=restrictions))
+    embed = _response_to_embed(for_tower(fact, restrictions=restrictions))
+    return append_context_footer(embed, f"btd6_tower:{tower.id}")
 
 
 # ---------------------------------------------------------------------------
@@ -261,9 +265,11 @@ async def build_source_health_embed(
         ),
         color=discord.Color.gold(),
     )
+    from utils.btd6.context_footer import append_context_footer
+
     if not health:
         embed.description = "No BTD6 sources registered yet."
-        return embed
+        return append_context_footer(embed, "btd6_diagnostics:sources")
     for src in health:
         state = "ON" if src.enabled else "off"
         when = (
@@ -280,7 +286,7 @@ async def build_source_health_embed(
             ),
             inline=False,
         )
-    return embed
+    return append_context_footer(embed, "btd6_diagnostics:sources")
 
 
 # ---------------------------------------------------------------------------
@@ -320,7 +326,9 @@ async def build_latest_data_embed(*, limit_per_kind: int = 1) -> discord.Embed:
     )
     if not by_kind:
         embed.description = "No facts recorded yet."
-        return embed
+        from utils.btd6.context_footer import append_context_footer
+
+        return append_context_footer(embed, "btd6_diagnostics:latest_data")
     for kind in sorted(by_kind.keys()):
         latest = by_kind[kind][:limit_per_kind]
         lines = []
@@ -352,7 +360,9 @@ async def build_latest_data_embed(*, limit_per_kind: int = 1) -> discord.Embed:
             value=value,
             inline=False,
         )
-    return embed
+    from utils.btd6.context_footer import append_context_footer
+
+    return append_context_footer(embed, "btd6_diagnostics:latest_data")
 
 
 # ---------------------------------------------------------------------------
@@ -486,12 +496,17 @@ async def build_live_events_embed(
         ),
         color=discord.Color.gold(),
     )
+    from utils.btd6.context_footer import append_context_footer
+
+    short_kind = entity_kind.removeprefix("btd6_") or "event"
+    context_id = f"btd6_{short_kind}:list"
+
     if not rows:
         embed.description = (
             f"No {spec['noun']} facts recorded yet. Try "
             f"`!btd6 refresh-source {spec['source_key']}` to fetch live data."
         )
-        return embed
+        return append_context_footer(embed, context_id)
 
     for row in rows:
         body = _coerce_body(row.get("body_json"))
@@ -526,7 +541,7 @@ async def build_live_events_embed(
             value="\n".join(lines),
             inline=False,
         )
-    return embed
+    return append_context_footer(embed, context_id)
 
 
 # ---------------------------------------------------------------------------
@@ -847,7 +862,10 @@ def build_event_detail_embed(
     when = primary.get("fetched_at") if primary else None
     if when is not None:
         embed.set_footer(text=f"fetched={when.isoformat(timespec='minutes')}")
-    return embed
+    from utils.btd6.context_footer import append_context_footer
+
+    short_kind = entity_kind.removeprefix("btd6_") or "event"
+    return append_context_footer(embed, f"btd6_{short_kind}:{entity_key}")
 
 
 # ---------------------------------------------------------------------------
@@ -1043,7 +1061,9 @@ async def build_leaderboard_embed(
             parts.append(f"Data: {BUCKET_BADGE[bucket]}")
     if parts:
         embed.set_footer(text=" · ".join(parts))
-    return embed
+    from utils.btd6.context_footer import append_context_footer
+
+    return append_context_footer(embed, f"btd6_leaderboard:{norm}_{resolved_id}")
 
 
 __all__ = [

--- a/disbot/cogs/btd6/_embeds.py
+++ b/disbot/cogs/btd6/_embeds.py
@@ -13,72 +13,13 @@ stays small enough to satisfy the S4.6 cog-size invariant.
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any
 
 import discord
 
-from cogs.btd6._freshness_render import BUCKET_EMOJI as _BUCKET_EMOJI
 from services import btd6_knowledge_service
 from services.btd6_resolver_service import resolve
-
-
-def response_to_embed(response: Any) -> discord.Embed:
-    """Convert a :class:`BTD6Response` into a Discord embed."""
-    color = {
-        "high": discord.Color.green(),
-        "medium": discord.Color.gold(),
-        "low": discord.Color.light_grey(),
-    }.get(response.confidence, discord.Color.light_grey())
-    embed = discord.Embed(
-        title=response.title,
-        description=response.short_answer,
-        color=color,
-    )
-    if response.why_it_matters:
-        embed.add_field(
-            name="Why it matters",
-            value=response.why_it_matters,
-            inline=False,
-        )
-    if response.recommended_options:
-        embed.add_field(
-            name="Recommended options",
-            value="\n".join(f"• {opt}" for opt in response.recommended_options),
-            inline=False,
-        )
-    if response.common_mistakes:
-        embed.add_field(
-            name="Common mistakes",
-            value="\n".join(f"• {m}" for m in response.common_mistakes),
-            inline=False,
-        )
-    if response.version_sensitivity:
-        embed.add_field(
-            name="Version sensitivity",
-            value=response.version_sensitivity,
-            inline=False,
-        )
-    live_facts = getattr(response, "live_facts", ()) or ()
-    if live_facts:
-        value = "\n".join(f"• {fact}" for fact in live_facts)
-        if len(value) > 1024:
-            kept: list[str] = []
-            running = 0
-            for fact in live_facts:
-                line = f"• {fact}"
-                if running + len(line) + 1 > 990:
-                    break
-                kept.append(line)
-                running += len(line) + 1
-            dropped = len(live_facts) - len(kept)
-            value = "\n".join(kept) + f"\n… ({dropped} more)"
-        embed.add_field(name="Live data", value=value, inline=False)
-    if response.follow_up:
-        embed.add_field(name="Follow-up", value=response.follow_up, inline=False)
-    if response.sources:
-        embed.set_footer(text="Sources: " + " · ".join(response.sources))
-    return embed
-
+from utils.btd6.freshness_render import BUCKET_EMOJI as _BUCKET_EMOJI
+from utils.btd6.response_embed import response_to_embed
 
 # Useful-first display order for the Live facts block. Kinds not in
 # this tuple are appended alphabetically — operators see the most

--- a/disbot/cogs/btd6/_embeds.py
+++ b/disbot/cogs/btd6/_embeds.py
@@ -146,7 +146,9 @@ async def build_status_embed() -> discord.Embed:
         value=_format_live_facts_value(summaries),
         inline=False,
     )
-    return embed
+    from utils.btd6.context_footer import append_context_footer
+
+    return append_context_footer(embed, "btd6_status:global")
 
 
 def build_diagnostics_embed() -> discord.Embed:
@@ -179,7 +181,9 @@ def build_diagnostics_embed() -> discord.Embed:
         str(r.round_number) for r in btd6_knowledge_service.list_rounds()
     )
     embed.add_field(name="Rounds tracked", value=rounds, inline=False)
-    return embed
+    from utils.btd6.context_footer import append_context_footer
+
+    return append_context_footer(embed, "btd6_diagnostics:catalog")
 
 
 def build_towers_embed() -> discord.Embed:
@@ -193,7 +197,9 @@ def build_towers_embed() -> discord.Embed:
             value=f"Cost: {tower.base_cost} • Category: {tower.category}",
             inline=True,
         )
-    return embed
+    from utils.btd6.context_footer import append_context_footer
+
+    return append_context_footer(embed, "btd6_tower:catalog")
 
 
 def build_modes_embed() -> discord.Embed:
@@ -210,7 +216,9 @@ def build_modes_embed() -> discord.Embed:
             ),
             inline=False,
         )
-    return embed
+    from utils.btd6.context_footer import append_context_footer
+
+    return append_context_footer(embed, "btd6_diagnostics:modes_catalog")
 
 
 def build_heroes_embed() -> discord.Embed:
@@ -225,7 +233,9 @@ def build_heroes_embed() -> discord.Embed:
             value=f"Cost: {hero.base_cost} • {hero.description[:80]}",
             inline=False,
         )
-    return embed
+    from utils.btd6.context_footer import append_context_footer
+
+    return append_context_footer(embed, "btd6_hero:catalog")
 
 
 def build_test_intent_embed(text: str) -> discord.Embed:

--- a/disbot/cogs/btd6/_embeds.py
+++ b/disbot/cogs/btd6/_embeds.py
@@ -17,6 +17,7 @@ from typing import Any
 
 import discord
 
+from cogs.btd6._freshness_render import BUCKET_EMOJI as _BUCKET_EMOJI
 from services import btd6_knowledge_service
 from services.btd6_resolver_service import resolve
 
@@ -77,14 +78,6 @@ def response_to_embed(response: Any) -> discord.Embed:
     if response.sources:
         embed.set_footer(text="Sources: " + " · ".join(response.sources))
     return embed
-
-
-_BUCKET_EMOJI = {
-    "fresh": "🟢",
-    "aging": "🟡",
-    "stale": "🔴",
-    "never": "⚪",
-}
 
 
 # Useful-first display order for the Live facts block. Kinds not in

--- a/disbot/cogs/btd6/_freshness_render.py
+++ b/disbot/cogs/btd6/_freshness_render.py
@@ -1,98 +1,23 @@
-"""Freshness rendering helpers for BTD6 embeds.
+"""Backwards-compat shim — the real module lives in ``utils.btd6``.
 
-Single source of truth for the bucket emoji + warning copy used across
-BTD6 embeds. Consolidates three duplicate dicts that previously lived
-in ``cogs/btd6/_embeds.py:_BUCKET_EMOJI``,
-``cogs/btd6/_builders.py:_BUCKET_BADGE``, and
-``cogs/btd6/_builders.py:_FRESHNESS_BADGE``.
-
-Pure functions; no I/O. Stale-data and never-fetched copy is locked
-by the plan — do not change without updating the corresponding tests.
+PR 2 moved freshness rendering to ``utils/btd6/freshness_render.py``
+so both views and cogs can import it without layer violations. This
+module re-exports the public surface so existing cog-side callers
+keep working unchanged.
 """
 
 from __future__ import annotations
 
-from typing import Literal
-
-import discord
-
-from services.btd6_source_registry import FreshnessBucket
-
-# ---------------------------------------------------------------------------
-# Bucket badges (single source of truth)
-# ---------------------------------------------------------------------------
-
-# Emoji-only — used in the status embed's "Live facts" block and the
-# panel's "Currently active" block.
-BUCKET_EMOJI: dict[FreshnessBucket, str] = {
-    "fresh": "🟢",
-    "aging": "🟡",
-    "stale": "🔴",
-    "never": "⚪",
-}
-
-# Emoji + label — used in source-health and leaderboard footers.
-BUCKET_BADGE: dict[FreshnessBucket, str] = {
-    "fresh": "🟢 fresh",
-    "aging": "🟡 aging",
-    "stale": "🔴 stale",
-    "never": "⚪ never",
-}
-
-
-# ---------------------------------------------------------------------------
-# Locked copy
-# ---------------------------------------------------------------------------
-
-STALE_WARNING = (
-    "⚠️ This data may be outdated. Last successful update was over "
-    "24 hours ago. Showing the latest stored data."
+from utils.btd6.freshness_render import (
+    BUCKET_BADGE,
+    BUCKET_EMOJI,
+    NEVER_FETCHED_COPY,
+    STALE_WARNING,
+    EmptyStateReason,
+    FreshnessBucket,
+    render_empty_state,
+    render_freshness_warning,
 )
-NEVER_FETCHED_COPY = "This source has not been fetched yet, so no data is available."
-
-
-EmptyStateReason = Literal["never_fetched", "no_active"]
-
-
-# ---------------------------------------------------------------------------
-# Rendering
-# ---------------------------------------------------------------------------
-
-
-def render_freshness_warning(state: FreshnessBucket) -> str | None:
-    """Return the warning copy for a stale/never state, else ``None``.
-
-    Only ``stale`` and ``never`` surface a user warning. ``aging`` is an
-    operator-only signal — surfaced via the per-source badge but not as
-    a user-facing warning in this PR.
-    """
-    if state == "stale":
-        return STALE_WARNING
-    if state == "never":
-        return NEVER_FETCHED_COPY
-    return None
-
-
-def render_empty_state(
-    context_type: str,
-    reason: EmptyStateReason,
-) -> discord.Embed:
-    """Render the empty-state embed.
-
-    ``reason="never_fetched"`` → source has never been fetched.
-    ``reason="no_active"`` → source is fresh but has no active events
-    of this kind right now.
-    """
-    if reason == "never_fetched":
-        description = NEVER_FETCHED_COPY
-    else:
-        description = f"No active {context_type} right now."
-    return discord.Embed(
-        title=f"🐵 BTD6 — {context_type}",
-        description=description,
-        color=discord.Color.greyple(),
-    )
-
 
 __all__ = [
     "BUCKET_BADGE",
@@ -100,6 +25,7 @@ __all__ = [
     "NEVER_FETCHED_COPY",
     "STALE_WARNING",
     "EmptyStateReason",
+    "FreshnessBucket",
     "render_empty_state",
     "render_freshness_warning",
 ]

--- a/disbot/cogs/btd6/_freshness_render.py
+++ b/disbot/cogs/btd6/_freshness_render.py
@@ -1,0 +1,105 @@
+"""Freshness rendering helpers for BTD6 embeds.
+
+Single source of truth for the bucket emoji + warning copy used across
+BTD6 embeds. Consolidates three duplicate dicts that previously lived
+in ``cogs/btd6/_embeds.py:_BUCKET_EMOJI``,
+``cogs/btd6/_builders.py:_BUCKET_BADGE``, and
+``cogs/btd6/_builders.py:_FRESHNESS_BADGE``.
+
+Pure functions; no I/O. Stale-data and never-fetched copy is locked
+by the plan — do not change without updating the corresponding tests.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import discord
+
+from services.btd6_source_registry import FreshnessBucket
+
+# ---------------------------------------------------------------------------
+# Bucket badges (single source of truth)
+# ---------------------------------------------------------------------------
+
+# Emoji-only — used in the status embed's "Live facts" block and the
+# panel's "Currently active" block.
+BUCKET_EMOJI: dict[FreshnessBucket, str] = {
+    "fresh": "🟢",
+    "aging": "🟡",
+    "stale": "🔴",
+    "never": "⚪",
+}
+
+# Emoji + label — used in source-health and leaderboard footers.
+BUCKET_BADGE: dict[FreshnessBucket, str] = {
+    "fresh": "🟢 fresh",
+    "aging": "🟡 aging",
+    "stale": "🔴 stale",
+    "never": "⚪ never",
+}
+
+
+# ---------------------------------------------------------------------------
+# Locked copy
+# ---------------------------------------------------------------------------
+
+STALE_WARNING = (
+    "⚠️ This data may be outdated. Last successful update was over "
+    "24 hours ago. Showing the latest stored data."
+)
+NEVER_FETCHED_COPY = "This source has not been fetched yet, so no data is available."
+
+
+EmptyStateReason = Literal["never_fetched", "no_active"]
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def render_freshness_warning(state: FreshnessBucket) -> str | None:
+    """Return the warning copy for a stale/never state, else ``None``.
+
+    Only ``stale`` and ``never`` surface a user warning. ``aging`` is an
+    operator-only signal — surfaced via the per-source badge but not as
+    a user-facing warning in this PR.
+    """
+    if state == "stale":
+        return STALE_WARNING
+    if state == "never":
+        return NEVER_FETCHED_COPY
+    return None
+
+
+def render_empty_state(
+    context_type: str,
+    reason: EmptyStateReason,
+) -> discord.Embed:
+    """Render the empty-state embed.
+
+    ``reason="never_fetched"`` → source has never been fetched.
+    ``reason="no_active"`` → source is fresh but has no active events
+    of this kind right now.
+    """
+    if reason == "never_fetched":
+        description = NEVER_FETCHED_COPY
+    else:
+        description = f"No active {context_type} right now."
+    return discord.Embed(
+        title=f"🐵 BTD6 — {context_type}",
+        description=description,
+        color=discord.Color.greyple(),
+    )
+
+
+__all__ = [
+    "BUCKET_BADGE",
+    "BUCKET_EMOJI",
+    "NEVER_FETCHED_COPY",
+    "STALE_WARNING",
+    "EmptyStateReason",
+    "render_empty_state",
+    "render_freshness_warning",
+]

--- a/disbot/services/btd6_live_query_service.py
+++ b/disbot/services/btd6_live_query_service.py
@@ -13,12 +13,13 @@ without learning the raw fact-store schema. Architecture-clean:
 
 from __future__ import annotations
 
-import json
 import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Literal
+
+from utils.btd6.body_coerce import coerce_body as _coerce_body
 
 logger = logging.getLogger("bot.services.btd6_live_query")
 
@@ -97,23 +98,6 @@ _CHOSEN_PRIMARY_HERO_KEY = "ChosenPrimaryHero"
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
-
-
-def _coerce_body(value: Any) -> dict[str, Any]:
-    """Normalise ``body_json`` to a dict.
-
-    Legacy double-encoded rows round-trip as JSON strings; decode them
-    on read so the facade stays working until those rows age out.
-    """
-    if isinstance(value, dict):
-        return value
-    if isinstance(value, str):
-        try:
-            decoded = json.loads(value)
-        except (ValueError, TypeError):
-            return {}
-        return decoded if isinstance(decoded, dict) else {}
-    return {}
 
 
 def _is_active_window(body: dict[str, Any]) -> bool:

--- a/disbot/services/btd6_view_model_service.py
+++ b/disbot/services/btd6_view_model_service.py
@@ -1,0 +1,940 @@
+"""BTD6 view-model service — sandwich layer between query services and embeds.
+
+The cog/view layer used to either consume query-service dataclasses
+directly or read DB rows from the embed builders. This service is the
+middle layer: it composes data from the existing read services
+(``btd6_knowledge_service``, ``btd6_source_registry``,
+``btd6_live_query_service``, ``utils.db.btd6_sources``) into typed
+view-model dataclasses that the embed builders + new sub-views consume.
+
+Three public concerns:
+
+1. :class:`DataFreshness` — every read carries one of these. The
+   ``state`` reuses :data:`services.btd6_source_registry.FreshnessBucket`
+   verbatim; thresholds live in ``btd6_source_registry`` (single source
+   of truth, do not duplicate).
+2. :class:`ContextHandle` + :func:`make_context_handle` — the
+   ``context_id`` contract a future Team Panel attaches to. Format
+   ``btd6_<type>:<key>`` (single colon, regex-pinned).
+3. ``build_*_view_model`` async builders — one per area.
+
+Architecture rule (CI-enforced): this module imports only stdlib,
+``services.*``, and ``utils.*``. It must NOT import ``discord``,
+``views/``, or ``cogs/``. Callers unpack what they need from the
+Discord interaction and pass primitives (``guild_id: int``, ``kind: str``,
+etc.) — no ``discord.Interaction`` / ``Member`` / ``Guild`` reaches
+this layer.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Literal
+
+from services.btd6_source_registry import (
+    FreshnessBucket,
+    SourceHealth,
+    bucket_freshness,
+)
+from utils.btd6.event_window import WindowStatus, format_window
+
+logger = logging.getLogger("bot.services.btd6_view_model")
+
+
+# ---------------------------------------------------------------------------
+# Context contract
+# ---------------------------------------------------------------------------
+
+
+BTD6ContextType = Literal[
+    "hub",
+    "race",
+    "boss",
+    "ct",
+    "odyssey",
+    "event",
+    "tower",
+    "hero",
+    "leaderboard",
+    "strategy",
+    "source",
+    "status",
+    "diagnostics",
+]
+
+
+_CONTEXT_ID_RE = re.compile(r"^btd6_[a-z_]+:[A-Za-z0-9_-]+$")
+_KEY_SAFE_RE = re.compile(r"[^A-Za-z0-9_-]")
+
+
+@dataclass(frozen=True)
+class ContextHandle:
+    """Stable handle a future Team Panel attaches notes to.
+
+    ``context_id`` always matches ``^btd6_[a-z_]+:[A-Za-z0-9_-]+$``.
+    """
+
+    context_id: str
+    context_type: BTD6ContextType
+
+
+def make_context_handle(
+    context_type: BTD6ContextType,
+    entity_key: str,
+) -> ContextHandle:
+    """Normalize and validate a context handle.
+
+    ``entity_key`` is sanitized by replacing any character outside
+    ``[A-Za-z0-9_-]`` with ``_`` so external IDs (URLs, names) can be
+    passed straight in. Raises :class:`ValueError` if the resulting
+    ``context_id`` fails the contract regex (e.g. empty key).
+    """
+    if not entity_key:
+        raise ValueError("context entity_key cannot be empty")
+    sanitized = _KEY_SAFE_RE.sub("_", entity_key)
+    context_id = f"btd6_{context_type}:{sanitized}"
+    if not _CONTEXT_ID_RE.match(context_id):
+        raise ValueError(
+            f"context_id {context_id!r} does not match the contract regex",
+        )
+    return ContextHandle(context_id=context_id, context_type=context_type)
+
+
+# ---------------------------------------------------------------------------
+# Freshness
+# ---------------------------------------------------------------------------
+
+
+# Threshold for "stale" surfaces to public users (24h). The bucketing
+# logic in :func:`services.btd6_source_registry.bucket_freshness` uses
+# ``stale`` at >2d — this VM-level threshold is finer-grained for the
+# public-warning trigger. (Aging is not user-facing in PR 1.)
+STALE_AFTER_SECONDS = 86_400
+
+
+@dataclass(frozen=True)
+class DataFreshness:
+    """Per-source freshness snapshot threaded through every VM."""
+
+    state: FreshnessBucket
+    last_success_at: datetime | None
+    last_attempt_at: datetime | None
+    source_key: str
+    stale_after_seconds: int = STALE_AFTER_SECONDS
+
+
+def _freshness_from_health(source: SourceHealth) -> DataFreshness:
+    """Build :class:`DataFreshness` from a :class:`SourceHealth` row."""
+    return DataFreshness(
+        state=source.bucket,
+        last_success_at=source.last_fetched_at,
+        last_attempt_at=source.last_fetched_at,
+        source_key=source.source_key,
+    )
+
+
+def _freshness_from_fetched_at(
+    fetched_at: datetime | None,
+    *,
+    source_key: str,
+) -> DataFreshness:
+    """Build :class:`DataFreshness` from a bare ``fetched_at`` timestamp."""
+    return DataFreshness(
+        state=bucket_freshness(fetched_at),
+        last_success_at=fetched_at,
+        last_attempt_at=fetched_at,
+        source_key=source_key,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hub view-model
+# ---------------------------------------------------------------------------
+
+
+# Each tuple is (entity_kind, emoji, short_kind, source_key) — the
+# panel's "Currently active" block iterates in this order, useful-first.
+_HUB_ACTIVE_KINDS: tuple[tuple[str, str, str, str], ...] = (
+    ("btd6_race", "🏁", "race", "nk_btd6_races"),
+    ("btd6_boss", "👑", "boss", "nk_btd6_bosses"),
+    ("btd6_ct", "🗺️", "ct", "nk_btd6_ct"),
+    ("btd6_odyssey", "🌊", "odyssey", "nk_btd6_odyssey"),
+    ("btd6_event", "🎪", "event", "nk_btd6_events"),
+)
+
+
+@dataclass(frozen=True)
+class HubActiveEvent:
+    """One row in the Hub's 'Currently active' block."""
+
+    entity_kind: str
+    short_kind: str
+    emoji: str
+    name: str | None
+    end_ms: int | None
+    freshness: DataFreshness
+    context: ContextHandle | None  # None when no fact exists for this kind
+
+
+@dataclass(frozen=True)
+class HubViewModel:
+    """Top-level BTD6 panel view-model."""
+
+    data_version: str
+    game_version: str
+    tower_count: int
+    hero_count: int
+    map_count: int
+    mode_count: int
+    round_count: int
+    active_events: tuple[HubActiveEvent, ...]
+    context: ContextHandle
+
+
+async def build_hub_view_model() -> HubViewModel:
+    """Compose the BTD6 hub view-model.
+
+    Pulls knowledge counts from :mod:`btd6_knowledge_service`, latest
+    fact per kind from :mod:`utils.db.btd6_sources`, and derives the
+    freshness state per kind from the fact's ``fetched_at`` timestamp.
+    """
+    from services import btd6_knowledge_service
+    from utils.db import btd6_sources as btd6_db
+
+    rows = await btd6_db.latest_fact_per_entity_kind(
+        [kind for kind, _, _, _ in _HUB_ACTIVE_KINDS],
+    )
+    active: list[HubActiveEvent] = []
+    for entity_kind, emoji, short_kind, source_key in _HUB_ACTIVE_KINDS:
+        row = rows.get(entity_kind)
+        if row is None:
+            active.append(
+                HubActiveEvent(
+                    entity_kind=entity_kind,
+                    short_kind=short_kind,
+                    emoji=emoji,
+                    name=None,
+                    end_ms=None,
+                    freshness=DataFreshness(
+                        state="never",
+                        last_success_at=None,
+                        last_attempt_at=None,
+                        source_key=source_key,
+                    ),
+                    context=None,
+                ),
+            )
+            continue
+        from utils.btd6.body_coerce import coerce_body
+
+        body = coerce_body(row.get("body_json"))
+        name = body.get("name") or row.get("entity_key") or None
+        end_ms = body.get("end_ms") if isinstance(body.get("end_ms"), int) else None
+        fetched_at = row.get("fetched_at")
+        freshness = _freshness_from_fetched_at(fetched_at, source_key=source_key)
+        context: ContextHandle | None = None
+        entity_key = row.get("entity_key")
+        if entity_key:
+            try:
+                context = make_context_handle(
+                    short_kind,  # type: ignore[arg-type]
+                    str(entity_key),
+                )
+            except ValueError:
+                context = None
+        active.append(
+            HubActiveEvent(
+                entity_kind=entity_kind,
+                short_kind=short_kind,
+                emoji=emoji,
+                name=str(name) if name is not None else None,
+                end_ms=end_ms,
+                freshness=freshness,
+                context=context,
+            ),
+        )
+
+    return HubViewModel(
+        data_version=btd6_knowledge_service.data_version(),
+        game_version=btd6_knowledge_service.game_version(),
+        tower_count=len(btd6_knowledge_service.list_towers()),
+        hero_count=len(btd6_knowledge_service.list_heroes()),
+        map_count=len(btd6_knowledge_service.list_maps()),
+        mode_count=len(btd6_knowledge_service.list_modes()),
+        round_count=len(btd6_knowledge_service.list_rounds()),
+        active_events=tuple(active),
+        context=make_context_handle("hub", "main"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Staff diagnostics view-model (status / source-health / latest-data)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StaffDiagnosticsViewModel:
+    """Aggregate for the staff status / diagnostics view.
+
+    Carries the same data the existing ``build_status_embed`` needs:
+    seed counts + per-kind fact summaries from
+    ``btd6_knowledge_service.fact_summary_by_kind()``. Per-source health
+    has its own VM (:class:`SourceHealthViewModel`) — the staff embed
+    today only renders fact summaries, not source rows.
+    """
+
+    data_version: str
+    game_version: str
+    tower_count: int
+    hero_count: int
+    map_count: int
+    mode_count: int
+    round_count: int
+    fact_summaries: tuple[Any, ...]  # tuple[FactKindSummary, ...]
+    context: ContextHandle
+
+
+async def build_staff_diagnostics_view_model(
+    *,
+    guild_id: int | None = None,
+) -> StaffDiagnosticsViewModel:
+    """Compose the staff diagnostics view-model."""
+    from services import btd6_knowledge_service
+
+    summaries = await btd6_knowledge_service.fact_summary_by_kind()
+    key = str(guild_id) if guild_id is not None else "global"
+    return StaffDiagnosticsViewModel(
+        data_version=btd6_knowledge_service.data_version(),
+        game_version=btd6_knowledge_service.game_version(),
+        tower_count=len(btd6_knowledge_service.list_towers()),
+        hero_count=len(btd6_knowledge_service.list_heroes()),
+        map_count=len(btd6_knowledge_service.list_maps()),
+        mode_count=len(btd6_knowledge_service.list_modes()),
+        round_count=len(btd6_knowledge_service.list_rounds()),
+        fact_summaries=tuple(summaries),
+        context=make_context_handle("status", key),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Source health view-model (for source-health / Admin "Source Health" button)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SourceHealthRow:
+    """One row in the Source Health embed."""
+
+    health: SourceHealth
+    freshness: DataFreshness
+    context: ContextHandle
+
+
+@dataclass(frozen=True)
+class SourceHealthViewModel:
+    """Per-source freshness overview."""
+
+    rows: tuple[SourceHealthRow, ...]
+    context: ContextHandle
+
+
+async def build_source_health_view_model(
+    *,
+    limit: int = 25,
+) -> SourceHealthViewModel:
+    """Compose source-health rows."""
+    from services import btd6_source_registry
+
+    health = await btd6_source_registry.list_health(limit=limit)
+    rows: list[SourceHealthRow] = []
+    for src in health:
+        freshness = _freshness_from_health(src)
+        try:
+            ctx = make_context_handle("source", src.source_key)
+        except ValueError:
+            ctx = make_context_handle("source", "unknown")
+        rows.append(SourceHealthRow(health=src, freshness=freshness, context=ctx))
+    return SourceHealthViewModel(
+        rows=tuple(rows),
+        context=make_context_handle("diagnostics", "sources"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Event list / detail view-models
+# ---------------------------------------------------------------------------
+
+
+_EVENT_KIND_TO_CONTEXT_TYPE: dict[str, BTD6ContextType] = {
+    "btd6_race": "race",
+    "btd6_boss": "boss",
+    "btd6_ct": "ct",
+    "btd6_odyssey": "odyssey",
+    "btd6_event": "event",
+}
+
+_EVENT_KIND_TO_SOURCE_KEY: dict[str, str] = {
+    "btd6_race": "nk_btd6_races",
+    "btd6_boss": "nk_btd6_bosses",
+    "btd6_ct": "nk_btd6_ct",
+    "btd6_odyssey": "nk_btd6_odyssey",
+    "btd6_event": "nk_btd6_events",
+}
+
+
+@dataclass(frozen=True)
+class EventListItem:
+    """One row in an event-list view-model."""
+
+    entity_kind: str
+    entity_key: str
+    name: str
+    window: WindowStatus
+    context: ContextHandle
+
+
+@dataclass(frozen=True)
+class EventListViewModel:
+    """List of events for a given kind."""
+
+    kind: str  # "race" / "boss" / etc. (short form)
+    entity_kind: str  # "btd6_race" / "btd6_boss" / etc.
+    items: tuple[EventListItem, ...]
+    total_count: int  # before max_items cap
+    freshness: DataFreshness
+    context: ContextHandle
+
+
+def _normalize_event_kind(kind: str) -> tuple[str, str]:
+    """Return (entity_kind, short_kind) for a user-supplied kind string."""
+    short = kind.removeprefix("btd6_") if kind.startswith("btd6_") else kind
+    entity = f"btd6_{short}"
+    return entity, short
+
+
+async def build_event_list_view_model(
+    kind: str,
+    *,
+    max_items: int = 25,
+) -> EventListViewModel:
+    """Compose an event-list view-model.
+
+    ``kind`` may be either the long form (``"btd6_race"``) or the short
+    form (``"race"``). Capped at ``max_items`` to respect Discord's
+    25-option Select limit; ``total_count`` exposes the pre-cap size.
+    """
+    from utils.btd6.body_coerce import coerce_body
+    from utils.db import btd6_sources as btd6_db
+
+    entity_kind, short = _normalize_event_kind(kind)
+    source_key = _EVENT_KIND_TO_SOURCE_KEY.get(entity_kind, "")
+    context_type = _EVENT_KIND_TO_CONTEXT_TYPE.get(entity_kind, "event")
+
+    rows = await btd6_db.search_facts(entity_kind=entity_kind, limit=max(max_items, 25))
+    items: list[EventListItem] = []
+    latest_fetched: datetime | None = None
+    for row in rows[:max_items]:
+        body = coerce_body(row.get("body_json"))
+        entity_key = str(row.get("entity_key") or "")
+        if not entity_key:
+            continue
+        try:
+            ctx = make_context_handle(context_type, entity_key)
+        except ValueError:
+            continue
+        items.append(
+            EventListItem(
+                entity_kind=entity_kind,
+                entity_key=entity_key,
+                name=str(body.get("name") or entity_key),
+                window=format_window(body.get("start_ms"), body.get("end_ms")),
+                context=ctx,
+            ),
+        )
+        fetched_at = row.get("fetched_at")
+        if isinstance(fetched_at, datetime):
+            if latest_fetched is None or fetched_at > latest_fetched:
+                latest_fetched = fetched_at
+
+    freshness = _freshness_from_fetched_at(latest_fetched, source_key=source_key)
+    return EventListViewModel(
+        kind=short,
+        entity_kind=entity_kind,
+        items=tuple(items),
+        total_count=len(rows),
+        freshness=freshness,
+        context=make_context_handle(context_type, "list"),
+    )
+
+
+@dataclass(frozen=True)
+class EventDetailViewModel:
+    """Detail-view payload for one event."""
+
+    entity_kind: str
+    entity_key: str
+    name: str
+    window: WindowStatus
+    primary_body: dict[str, Any]
+    metadata_body: dict[str, Any]
+    fetched_at: datetime | None
+    freshness: DataFreshness
+    context: ContextHandle
+
+
+async def build_event_detail_view_model(
+    kind: str,
+    entity_key: str,
+) -> EventDetailViewModel | None:
+    """Compose an event-detail view-model.
+
+    Returns ``None`` when no fact exists for the requested key.
+    """
+    from utils.btd6.body_coerce import coerce_body
+    from utils.db import btd6_sources as btd6_db
+
+    entity_kind, _ = _normalize_event_kind(kind)
+    context_type = _EVENT_KIND_TO_CONTEXT_TYPE.get(entity_kind, "event")
+    source_key = _EVENT_KIND_TO_SOURCE_KEY.get(entity_kind, "")
+
+    rows = await btd6_db.search_facts(
+        entity_kind=entity_kind,
+        entity_key=entity_key,
+        limit=2,
+    )
+    primary_row = next(
+        (r for r in rows if not str(r.get("fact_type", "")).endswith("_metadata")),
+        rows[0] if rows else None,
+    )
+    metadata_row = next(
+        (r for r in rows if str(r.get("fact_type", "")).endswith("_metadata")),
+        None,
+    )
+
+    if primary_row is None and metadata_row is None:
+        return None
+
+    primary_body = coerce_body((primary_row or {}).get("body_json"))
+    metadata_body = coerce_body((metadata_row or {}).get("body_json"))
+    name = str(primary_body.get("name") or metadata_body.get("name") or entity_key)
+
+    window_body = primary_body if primary_body.get("start_ms") else metadata_body
+    window = format_window(window_body.get("start_ms"), window_body.get("end_ms"))
+
+    fetched_at = (primary_row or {}).get("fetched_at") or (metadata_row or {}).get(
+        "fetched_at",
+    )
+    if not isinstance(fetched_at, datetime):
+        fetched_at = None
+
+    freshness = _freshness_from_fetched_at(fetched_at, source_key=source_key)
+    return EventDetailViewModel(
+        entity_kind=entity_kind,
+        entity_key=entity_key,
+        name=name,
+        window=window,
+        primary_body=primary_body,
+        metadata_body=metadata_body,
+        fetched_at=fetched_at,
+        freshness=freshness,
+        context=make_context_handle(context_type, entity_key),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tower list / detail view-models
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TowerListItem:
+    tower_id: str
+    canonical: str
+    base_cost: int
+    category: str
+    context: ContextHandle
+
+
+@dataclass(frozen=True)
+class TowerListViewModel:
+    items: tuple[TowerListItem, ...]
+    total_count: int
+    context: ContextHandle
+
+
+@dataclass(frozen=True)
+class TowerDetailViewModel:
+    tower_id: str
+    canonical: str
+    fact: Any  # btd6_knowledge_service.TowerFact | None
+    restrictions: tuple[Any, ...]  # tuple[TowerRestrictionContext, ...]
+    context: ContextHandle
+
+
+async def build_tower_list_view_model(
+    *,
+    max_items: int = 25,
+) -> TowerListViewModel:
+    """Tower catalog list."""
+    from services import btd6_knowledge_service
+
+    towers = btd6_knowledge_service.list_towers()
+    capped = towers[:max_items]
+    items: list[TowerListItem] = []
+    for tower in capped:
+        try:
+            ctx = make_context_handle("tower", str(tower.id))
+        except ValueError:
+            continue
+        items.append(
+            TowerListItem(
+                tower_id=str(tower.id),
+                canonical=tower.canonical,
+                base_cost=tower.base_cost,
+                category=tower.category,
+                context=ctx,
+            ),
+        )
+    return TowerListViewModel(
+        items=tuple(items),
+        total_count=len(towers),
+        context=make_context_handle("tower", "list"),
+    )
+
+
+async def build_tower_detail_view_model(
+    tower_id: str,
+) -> TowerDetailViewModel | None:
+    """Tower detail with live restriction context."""
+    from services import btd6_knowledge_service, btd6_live_query_service
+    from services.btd6_resolver_service import resolve
+
+    intent = resolve(tower_id)
+    if not intent.towers:
+        return None
+    tower = intent.towers[0]
+    fact = btd6_knowledge_service.tower_fact(tower.id)
+    restrictions = (
+        await btd6_live_query_service.get_active_event_restrictions_for_tower(
+            str(tower.id),
+        )
+    )
+    return TowerDetailViewModel(
+        tower_id=str(tower.id),
+        canonical=tower.canonical,
+        fact=fact,
+        restrictions=tuple(restrictions),
+        context=make_context_handle("tower", str(tower.id)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hero list / detail view-models
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class HeroListItem:
+    hero_id: str
+    canonical: str
+    base_cost: int
+    description: str
+    context: ContextHandle
+
+
+@dataclass(frozen=True)
+class HeroListViewModel:
+    items: tuple[HeroListItem, ...]
+    total_count: int
+    context: ContextHandle
+
+
+@dataclass(frozen=True)
+class HeroDetailViewModel:
+    hero_id: str
+    canonical: str
+    restrictions: tuple[Any, ...]
+    context: ContextHandle
+
+
+async def build_hero_list_view_model(
+    *,
+    max_items: int = 25,
+) -> HeroListViewModel:
+    """Hero catalog list."""
+    from services import btd6_knowledge_service
+
+    heroes = btd6_knowledge_service.list_heroes()
+    capped = heroes[:max_items]
+    items: list[HeroListItem] = []
+    for hero in capped:
+        try:
+            ctx = make_context_handle("hero", str(hero.id))
+        except ValueError:
+            continue
+        items.append(
+            HeroListItem(
+                hero_id=str(hero.id),
+                canonical=hero.canonical,
+                base_cost=hero.base_cost,
+                description=hero.description,
+                context=ctx,
+            ),
+        )
+    return HeroListViewModel(
+        items=tuple(items),
+        total_count=len(heroes),
+        context=make_context_handle("hero", "list"),
+    )
+
+
+async def build_hero_detail_view_model(
+    hero_id: str,
+) -> HeroDetailViewModel | None:
+    """Hero detail with live restriction context."""
+    from services import btd6_live_query_service
+    from services.btd6_resolver_service import resolve
+
+    intent = resolve(hero_id)
+    if not intent.heroes:
+        return None
+    hero = intent.heroes[0]
+    restrictions = await btd6_live_query_service.get_active_event_restrictions_for_hero(
+        str(hero.id),
+    )
+    return HeroDetailViewModel(
+        hero_id=str(hero.id),
+        canonical=hero.canonical,
+        restrictions=tuple(restrictions),
+        context=make_context_handle("hero", str(hero.id)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Leaderboard view-models
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LeaderboardListItem:
+    """One race/boss event available to view leaderboard for."""
+
+    event_kind: str  # "race" or "boss"
+    event_id: str
+    event_name: str
+    window: WindowStatus
+    context: ContextHandle
+
+
+@dataclass(frozen=True)
+class LeaderboardListViewModel:
+    event_kind: str
+    items: tuple[LeaderboardListItem, ...]
+    total_count: int
+    freshness: DataFreshness
+    context: ContextHandle
+
+
+@dataclass(frozen=True)
+class LeaderboardDetailViewModel:
+    event_kind: str
+    event_id: str
+    event_name: str | None
+    rows: tuple[Any, ...]  # tuple[LeaderboardRow, ...]
+    freshness: DataFreshness
+    context: ContextHandle
+    footer_hint: str = ""
+
+
+async def build_leaderboard_list_view_model(
+    event_kind: str,
+    *,
+    max_items: int = 25,
+) -> LeaderboardListViewModel:
+    """List recent race/boss events available for leaderboard view."""
+    norm = (event_kind or "").strip().lower()
+    if norm not in {"race", "boss"}:
+        raise ValueError(f"event_kind must be 'race' or 'boss', got {event_kind!r}")
+    entity_kind = "btd6_race" if norm == "race" else "btd6_boss"
+    source_key = _EVENT_KIND_TO_SOURCE_KEY[entity_kind]
+    list_vm = await build_event_list_view_model(norm, max_items=max_items)
+    items: list[LeaderboardListItem] = []
+    for evt in list_vm.items:
+        items.append(
+            LeaderboardListItem(
+                event_kind=norm,
+                event_id=evt.entity_key,
+                event_name=evt.name,
+                window=evt.window,
+                context=make_context_handle(
+                    "leaderboard",
+                    f"{norm}_{evt.entity_key}",
+                ),
+            ),
+        )
+    return LeaderboardListViewModel(
+        event_kind=norm,
+        items=tuple(items),
+        total_count=list_vm.total_count,
+        freshness=DataFreshness(
+            state=list_vm.freshness.state,
+            last_success_at=list_vm.freshness.last_success_at,
+            last_attempt_at=list_vm.freshness.last_attempt_at,
+            source_key=source_key,
+        ),
+        context=make_context_handle("leaderboard", f"{norm}_list"),
+    )
+
+
+async def build_leaderboard_detail_view_model(
+    event_kind: str,
+    event_id: str,
+    *,
+    top_n: int = 10,
+) -> LeaderboardDetailViewModel:
+    """Top-N leaderboard rows for one race/boss event."""
+    from services import btd6_live_query_service as live
+
+    norm = (event_kind or "").strip().lower()
+    if norm not in {"race", "boss"}:
+        raise ValueError(f"event_kind must be 'race' or 'boss', got {event_kind!r}")
+
+    if norm == "race":
+        rows = await live.get_race_leaderboard(event_id, limit=top_n)
+        active = await live.get_newest_active_race()
+        source_key = "nk_btd6_races"
+        footer = ""
+    else:
+        rows = await live.get_boss_leaderboard(event_id, limit=top_n)
+        active = await live.get_newest_active_boss()
+        source_key = "nk_btd6_bosses"
+        footer = (
+            "Showing standard solo leaderboard. "
+            "Elite / team modes are not yet ingested."
+        )
+
+    event_name = active.name if active and active.entity_key == event_id else None
+    freshness = _freshness_from_fetched_at(
+        active.fetched_at if active else None,
+        source_key=source_key,
+    )
+    return LeaderboardDetailViewModel(
+        event_kind=norm,
+        event_id=event_id,
+        event_name=event_name,
+        rows=tuple(rows),
+        freshness=freshness,
+        context=make_context_handle("leaderboard", f"{norm}_{event_id}"),
+        footer_hint=footer,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Latest-data view-model (per-kind newest fact)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LatestDataRow:
+    entity_kind: str
+    entity_key: str
+    source_key: str
+    version: int
+    fetched_at: datetime | None
+    context: ContextHandle
+
+
+@dataclass(frozen=True)
+class LatestDataViewModel:
+    rows_by_kind: dict[str, tuple[LatestDataRow, ...]] = field(default_factory=dict)
+    context: ContextHandle = field(
+        default_factory=lambda: make_context_handle("diagnostics", "latest_data"),
+    )
+
+
+async def build_latest_data_view_model(
+    *,
+    limit_per_kind: int = 1,
+) -> LatestDataViewModel:
+    """Compose the latest-data view-model."""
+    from services import btd6_source_registry
+    from utils.db import btd6_sources as btd6_db
+
+    rows = await btd6_db.search_facts(limit=50)
+    source_rows = await btd6_source_registry.list_all()
+    id_to_key = {int(s["id"]): s["source_key"] for s in source_rows}
+
+    grouped: dict[str, list[LatestDataRow]] = {}
+    for row in rows:
+        entity_kind = str(row.get("entity_kind") or "")
+        if not entity_kind:
+            continue
+        entity_key = str(row.get("entity_key") or "")
+        if not entity_key:
+            continue
+        source_key = id_to_key.get(int(row["source_id"]), "—")
+        try:
+            ctx = make_context_handle("event", entity_key)
+        except ValueError:
+            continue
+        fetched_at = row.get("fetched_at")
+        latest_row = LatestDataRow(
+            entity_kind=entity_kind,
+            entity_key=entity_key,
+            source_key=source_key,
+            version=int(row.get("version") or 0),
+            fetched_at=fetched_at if isinstance(fetched_at, datetime) else None,
+            context=ctx,
+        )
+        grouped.setdefault(entity_kind, []).append(latest_row)
+
+    rows_by_kind = {
+        kind: tuple(items[:limit_per_kind]) for kind, items in sorted(grouped.items())
+    }
+    return LatestDataViewModel(
+        rows_by_kind=rows_by_kind,
+        context=make_context_handle("diagnostics", "latest_data"),
+    )
+
+
+__all__ = [
+    "BTD6ContextType",
+    "ContextHandle",
+    "DataFreshness",
+    "EventDetailViewModel",
+    "EventListItem",
+    "EventListViewModel",
+    "HeroDetailViewModel",
+    "HeroListItem",
+    "HeroListViewModel",
+    "HubActiveEvent",
+    "HubViewModel",
+    "LatestDataRow",
+    "LatestDataViewModel",
+    "LeaderboardDetailViewModel",
+    "LeaderboardListItem",
+    "LeaderboardListViewModel",
+    "SourceHealthRow",
+    "SourceHealthViewModel",
+    "STALE_AFTER_SECONDS",
+    "StaffDiagnosticsViewModel",
+    "TowerDetailViewModel",
+    "TowerListItem",
+    "TowerListViewModel",
+    "build_event_detail_view_model",
+    "build_event_list_view_model",
+    "build_hero_detail_view_model",
+    "build_hero_list_view_model",
+    "build_hub_view_model",
+    "build_latest_data_view_model",
+    "build_leaderboard_detail_view_model",
+    "build_leaderboard_list_view_model",
+    "build_source_health_view_model",
+    "build_staff_diagnostics_view_model",
+    "build_tower_detail_view_model",
+    "build_tower_list_view_model",
+    "make_context_handle",
+]

--- a/disbot/utils/btd6/body_coerce.py
+++ b/disbot/utils/btd6/body_coerce.py
@@ -1,0 +1,33 @@
+"""Coerce ``body_json`` to a dict.
+
+Promoted from duplicate definitions in ``cogs/btd6/_builders.py`` and
+``services/btd6_live_query_service.py``. Per ``docs/helper-policy.md``,
+a helper used by both ``services/`` and ``cogs/`` belongs in ``utils/``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def coerce_body(value: Any) -> dict[str, Any]:
+    """Normalise ``body_json`` to a dict.
+
+    Defensive shim for rows written by the legacy double-encoded
+    ``json.dumps`` path: those round-trip as a JSON string instead of a
+    dict, so we ``json.loads`` them on read. Returns ``{}`` for anything
+    we can't decode (e.g. malformed text, non-mapping JSON).
+    """
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            decoded = json.loads(value)
+        except (ValueError, TypeError):
+            return {}
+        return decoded if isinstance(decoded, dict) else {}
+    return {}
+
+
+__all__ = ["coerce_body"]

--- a/disbot/utils/btd6/context_footer.py
+++ b/disbot/utils/btd6/context_footer.py
@@ -61,9 +61,7 @@ def append_context_footer(
 
     # When there was no prior text, the marker is the entire footer
     # (skip the leading " • " separator).
-    new_text = (
-        f"{existing_text}{new_segment}" if existing_text else f"ctx={context_id}"
-    )
+    new_text = f"{existing_text}{new_segment}" if existing_text else f"ctx={context_id}"
 
     embed.set_footer(text=new_text, icon_url=existing_icon)
     return embed

--- a/disbot/utils/btd6/context_footer.py
+++ b/disbot/utils/btd6/context_footer.py
@@ -1,0 +1,73 @@
+"""Append a stable ``ctx=<context_id>`` segment to an embed footer.
+
+The ``context_id`` contract — pinned by :func:`services.btd6_view_model_service.make_context_handle`
+to ``^btd6_[a-z_]+:[A-Za-z0-9_-]+$`` — is the handle a future Team
+Panel will attach notes / assignments / strategies to. Every
+stable-content BTD6 embed surfaces it in the footer so the contract
+travels with the rendered message.
+
+This module is the single source of truth for footer manipulation.
+Three rules:
+
+1. Preserve existing footer text (e.g. "Sources: x, y").
+2. Preserve footer icon_url if present.
+3. Idempotent — calling twice with the same context_id is a no-op.
+
+Lives in ``utils/`` so both ``cogs/btd6/_builders.py`` (existing
+embed builders) and ``views/btd6/`` (PR 2 drill-down detail views)
+can apply the same footer without crossing layer boundaries.
+"""
+
+from __future__ import annotations
+
+import discord
+
+# The full marker including the leading separator. Used both to format
+# the new segment and to detect idempotent re-application.
+_MARKER_PREFIX = " • ctx="
+
+
+def append_context_footer(
+    embed: discord.Embed,
+    context_id: str,
+) -> discord.Embed:
+    """Append ``" • ctx=<context_id>"`` to ``embed`` footer.
+
+    Returns the same embed for fluent chaining.
+
+    Raises:
+        ValueError: if ``context_id`` is empty (callers must opt out
+            by simply not calling this helper).
+    """
+    if not context_id:
+        raise ValueError("context_id must not be empty")
+
+    existing_text = embed.footer.text or ""
+    existing_icon = embed.footer.icon_url
+
+    new_segment = f"{_MARKER_PREFIX}{context_id}"
+
+    # Idempotent: if the footer already ends with this exact segment,
+    # don't append again.
+    if existing_text.endswith(new_segment):
+        return embed
+
+    # If a different ctx segment exists, replace it rather than
+    # appending a second one — callers that re-render the same embed
+    # with a refreshed context_id deserve a single live segment.
+    marker_idx = existing_text.rfind(_MARKER_PREFIX)
+    if marker_idx != -1:
+        existing_text = existing_text[:marker_idx]
+
+    if existing_text:
+        new_text = f"{existing_text}{new_segment}"
+    else:
+        # Skip the leading " • " when there was no prior text — the
+        # marker is the entire footer.
+        new_text = f"ctx={context_id}"
+
+    embed.set_footer(text=new_text, icon_url=existing_icon)
+    return embed
+
+
+__all__ = ["append_context_footer"]

--- a/disbot/utils/btd6/context_footer.py
+++ b/disbot/utils/btd6/context_footer.py
@@ -59,12 +59,11 @@ def append_context_footer(
     if marker_idx != -1:
         existing_text = existing_text[:marker_idx]
 
-    if existing_text:
-        new_text = f"{existing_text}{new_segment}"
-    else:
-        # Skip the leading " • " when there was no prior text — the
-        # marker is the entire footer.
-        new_text = f"ctx={context_id}"
+    # When there was no prior text, the marker is the entire footer
+    # (skip the leading " • " separator).
+    new_text = (
+        f"{existing_text}{new_segment}" if existing_text else f"ctx={context_id}"
+    )
 
     embed.set_footer(text=new_text, icon_url=existing_icon)
     return embed

--- a/disbot/utils/btd6/event_window.py
+++ b/disbot/utils/btd6/event_window.py
@@ -1,0 +1,182 @@
+"""BTD6 event window formatting.
+
+Converges four overlapping helpers that previously lived in
+``cogs/btd6/_builders.py`` (``_ms_to_human``, ``_event_window``,
+``_format_window_status``) and ``views/btd6/panel.py``
+(``_format_ends_relative``) into one tested module.
+
+Two surfaces:
+
+* :func:`format_window` — canonical typed API. Returns a
+  :class:`WindowStatus` that carries the human / relative / iso forms
+  the new view-model service consumes.
+* Thin string helpers (:func:`format_ms_human`, :func:`format_window_range`,
+  :func:`format_window_status`, :func:`format_ends_relative`) preserve
+  byte-identical output for the existing embed builders that consume
+  them. New code should prefer :func:`format_window`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+WindowState = Literal["upcoming", "active", "ended", "unknown"]
+
+
+@dataclass(frozen=True)
+class WindowStatus:
+    """Computed event window state plus the rendered forms."""
+
+    state: WindowState
+    human: str
+    start_iso: str
+    end_iso: str
+    relative: str
+
+
+def _ms_to_dt(ms: Any) -> datetime | None:
+    if not isinstance(ms, (int, float)) or ms <= 0:
+        return None
+    try:
+        return datetime.fromtimestamp(ms / 1000.0, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def _iso(dt: datetime | None) -> str:
+    if dt is None:
+        return "—"
+    return dt.strftime("%Y-%m-%d %H:%M UTC")
+
+
+def _compact_unit(seconds: int) -> str:
+    """`Xm` / `Xh` / `Xd` — single-unit compact form used by the panel."""
+    if seconds <= 0:
+        return "ended"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    if seconds < 86_400:
+        return f"{seconds // 3600}h"
+    return f"{seconds // 86_400}d"
+
+
+def format_ms_human(ms: Any) -> str:
+    """Render a milliseconds-since-epoch value as ``YYYY-MM-DD HH:MM UTC``.
+
+    Returns ``"—"`` for missing / non-numeric inputs.
+    """
+    return _iso(_ms_to_dt(ms))
+
+
+def format_window_range(start_ms: Any, end_ms: Any) -> str:
+    """Render ``start_ms`` → ``end_ms`` as a single human window string.
+
+    Returns ``"—"`` when both endpoints are missing. Mirrors the
+    previous ``_event_window`` helper.
+    """
+    start = format_ms_human(start_ms)
+    end = format_ms_human(end_ms)
+    if start == "—" and end == "—":
+        return "—"
+    return f"{start} → {end}"
+
+
+def format_window_status(
+    body: dict[str, Any],
+    *,
+    now: datetime | None = None,
+) -> str:
+    """Render ``status: live · ends in 1d 4h`` and friends.
+
+    Mirrors the previous ``_format_window_status`` helper byte-for-byte
+    (days + sub-day hours form, e.g. ``"1d 4h"``). The literal backtick
+    formatting wraps each status keyword in markdown code spans.
+    """
+    current = now if now is not None else datetime.now(tz=timezone.utc)
+    start_dt = _ms_to_dt(body.get("start_ms"))
+    end_dt = _ms_to_dt(body.get("end_ms"))
+    if start_dt is None and end_dt is None:
+        return "status: `unknown`"
+    if start_dt is not None and current < start_dt:
+        delta = start_dt - current
+        return f"status: `upcoming` · starts in {delta.days}d {delta.seconds // 3600}h"
+    if end_dt is not None and current > end_dt:
+        return "status: `ended`"
+    if end_dt is not None:
+        delta = end_dt - current
+        return f"status: `live` · ends in {delta.days}d {delta.seconds // 3600}h"
+    return "status: `live`"
+
+
+def format_ends_relative(
+    end_ms: Any,
+    *,
+    now: datetime | None = None,
+) -> str:
+    """Compact ``· ends Xh`` / ``· ended`` / ``""`` form for the panel.
+
+    Empty string when ``end_ms`` is missing or non-numeric. Mirrors the
+    previous ``_format_ends_relative`` helper byte-for-byte.
+    """
+    end_dt = _ms_to_dt(end_ms)
+    if end_dt is None:
+        return ""
+    current = now if now is not None else datetime.now(tz=timezone.utc)
+    delta = end_dt - current
+    seconds = int(delta.total_seconds())
+    if seconds <= 0:
+        return "· ended"
+    return f"· ends {_compact_unit(seconds)}"
+
+
+def format_window(
+    start_ms: Any,
+    end_ms: Any,
+    *,
+    now: datetime | None = None,
+) -> WindowStatus:
+    """Canonical typed window API. The view-model service consumes this.
+
+    `.human` matches :func:`format_window_status` output.
+    `.relative` matches :func:`format_ends_relative` output.
+    `.start_iso` / `.end_iso` match :func:`format_ms_human` output.
+    `.state` is one of upcoming / active / ended / unknown.
+    """
+    current = now if now is not None else datetime.now(tz=timezone.utc)
+    start_dt = _ms_to_dt(start_ms)
+    end_dt = _ms_to_dt(end_ms)
+    start_iso = _iso(start_dt)
+    end_iso = _iso(end_dt)
+    body = {"start_ms": start_ms, "end_ms": end_ms}
+    human = format_window_status(body, now=current)
+    relative = format_ends_relative(end_ms, now=current)
+
+    if start_dt is None and end_dt is None:
+        state: WindowState = "unknown"
+    elif start_dt is not None and current < start_dt:
+        state = "upcoming"
+    elif end_dt is not None and current > end_dt:
+        state = "ended"
+    else:
+        state = "active"
+
+    return WindowStatus(
+        state=state,
+        human=human,
+        start_iso=start_iso,
+        end_iso=end_iso,
+        relative=relative,
+    )
+
+
+__all__ = [
+    "WindowState",
+    "WindowStatus",
+    "format_ends_relative",
+    "format_ms_human",
+    "format_window",
+    "format_window_range",
+    "format_window_status",
+]

--- a/disbot/utils/btd6/freshness_render.py
+++ b/disbot/utils/btd6/freshness_render.py
@@ -1,0 +1,111 @@
+"""Freshness rendering helpers for BTD6 embeds.
+
+Lives in ``utils/`` (not ``cogs/``) so both ``views/btd6/`` (the new
+drill-down browsers) and ``cogs/btd6/`` (the existing embed builders)
+can import without violating layer rules.
+
+Single source of truth for the bucket emoji + warning copy that used
+to live in three duplicate dicts. Pure functions; no I/O. Stale-data
+and never-fetched copy is locked by the plan — do not change without
+updating the corresponding tests.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import discord
+
+# Mirror the FreshnessBucket alias from services.btd6_source_registry.
+# We can't import it here (utils → services is forbidden), but the
+# Literal type is structurally identical — Python's type system treats
+# the two as compatible as long as the strings match.
+FreshnessBucket = Literal["fresh", "aging", "stale", "never"]
+
+
+# ---------------------------------------------------------------------------
+# Bucket badges (single source of truth)
+# ---------------------------------------------------------------------------
+
+# Emoji-only — used in the status embed's "Live facts" block and the
+# panel's "Currently active" block.
+BUCKET_EMOJI: dict[FreshnessBucket, str] = {
+    "fresh": "🟢",
+    "aging": "🟡",
+    "stale": "🔴",
+    "never": "⚪",
+}
+
+# Emoji + label — used in source-health and leaderboard footers.
+BUCKET_BADGE: dict[FreshnessBucket, str] = {
+    "fresh": "🟢 fresh",
+    "aging": "🟡 aging",
+    "stale": "🔴 stale",
+    "never": "⚪ never",
+}
+
+
+# ---------------------------------------------------------------------------
+# Locked copy
+# ---------------------------------------------------------------------------
+
+STALE_WARNING = (
+    "⚠️ This data may be outdated. Last successful update was over "
+    "24 hours ago. Showing the latest stored data."
+)
+NEVER_FETCHED_COPY = "This source has not been fetched yet, so no data is available."
+
+
+EmptyStateReason = Literal["never_fetched", "no_active"]
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def render_freshness_warning(state: FreshnessBucket) -> str | None:
+    """Return the warning copy for a stale/never state, else ``None``.
+
+    Only ``stale`` and ``never`` surface a user warning. ``aging`` is an
+    operator-only signal — surfaced via the per-source badge but not as
+    a user-facing warning in this PR.
+    """
+    if state == "stale":
+        return STALE_WARNING
+    if state == "never":
+        return NEVER_FETCHED_COPY
+    return None
+
+
+def render_empty_state(
+    context_type: str,
+    reason: EmptyStateReason,
+) -> discord.Embed:
+    """Render the empty-state embed.
+
+    ``reason="never_fetched"`` → source has never been fetched.
+    ``reason="no_active"`` → source is fresh but has no active events
+    of this kind right now.
+    """
+    if reason == "never_fetched":
+        description = NEVER_FETCHED_COPY
+    else:
+        description = f"No active {context_type} right now."
+    return discord.Embed(
+        title=f"🐵 BTD6 — {context_type}",
+        description=description,
+        color=discord.Color.greyple(),
+    )
+
+
+__all__ = [
+    "BUCKET_BADGE",
+    "BUCKET_EMOJI",
+    "NEVER_FETCHED_COPY",
+    "STALE_WARNING",
+    "EmptyStateReason",
+    "FreshnessBucket",
+    "render_empty_state",
+    "render_freshness_warning",
+]

--- a/disbot/utils/btd6/response_embed.py
+++ b/disbot/utils/btd6/response_embed.py
@@ -1,0 +1,78 @@
+"""Convert a BTD6 response object into a Discord embed.
+
+Lives in ``utils/`` so both ``cogs/btd6/`` (the existing tower / hero /
+round prefix+slash commands) and ``views/btd6/`` (the PR 2 drill-down
+detail views) can render the same response shape without crossing
+layer boundaries.
+
+The input ``response`` is duck-typed: any object with the
+:class:`services.btd6_response_builder.BTD6Response` attributes works.
+Typing it as ``Any`` preserves the utils → services boundary.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import discord
+
+
+def response_to_embed(response: Any) -> discord.Embed:
+    """Convert a :class:`BTD6Response` into a Discord embed."""
+    color = {
+        "high": discord.Color.green(),
+        "medium": discord.Color.gold(),
+        "low": discord.Color.light_grey(),
+    }.get(response.confidence, discord.Color.light_grey())
+    embed = discord.Embed(
+        title=response.title,
+        description=response.short_answer,
+        color=color,
+    )
+    if response.why_it_matters:
+        embed.add_field(
+            name="Why it matters",
+            value=response.why_it_matters,
+            inline=False,
+        )
+    if response.recommended_options:
+        embed.add_field(
+            name="Recommended options",
+            value="\n".join(f"• {opt}" for opt in response.recommended_options),
+            inline=False,
+        )
+    if response.common_mistakes:
+        embed.add_field(
+            name="Common mistakes",
+            value="\n".join(f"• {m}" for m in response.common_mistakes),
+            inline=False,
+        )
+    if response.version_sensitivity:
+        embed.add_field(
+            name="Version sensitivity",
+            value=response.version_sensitivity,
+            inline=False,
+        )
+    live_facts = getattr(response, "live_facts", ()) or ()
+    if live_facts:
+        value = "\n".join(f"• {fact}" for fact in live_facts)
+        if len(value) > 1024:
+            kept: list[str] = []
+            running = 0
+            for fact in live_facts:
+                line = f"• {fact}"
+                if running + len(line) + 1 > 990:
+                    break
+                kept.append(line)
+                running += len(line) + 1
+            dropped = len(live_facts) - len(kept)
+            value = "\n".join(kept) + f"\n… ({dropped} more)"
+        embed.add_field(name="Live data", value=value, inline=False)
+    if response.follow_up:
+        embed.add_field(name="Follow-up", value=response.follow_up, inline=False)
+    if response.sources:
+        embed.set_footer(text="Sources: " + " · ".join(response.sources))
+    return embed
+
+
+__all__ = ["response_to_embed"]

--- a/disbot/views/btd6/__init__.py
+++ b/disbot/views/btd6/__init__.py
@@ -1,7 +1,49 @@
-"""Views for the BTD6 Assistant cog (Module 4 of the AI/BTD6 plan)."""
+"""Views for the BTD6 Assistant cog.
+
+PR 2 expanded the panel into a drill-down hub: clicking any button on
+the public anchor now opens an ephemeral sub-view instead of mutating
+the panel for everyone in the channel.
+"""
 
 from __future__ import annotations
 
+from views.btd6.hero_browser_view import (
+    HeroBrowserView,
+    HeroDetailView,
+    open_hero_browser,
+)
+from views.btd6.leaderboard_browser_view import (
+    LeaderboardBrowserView,
+    LeaderboardDetailView,
+    LeaderboardKindListView,
+    open_leaderboard_browser,
+)
+from views.btd6.live_events_view import (
+    EventDetailView,
+    LiveEventsBrowserView,
+    open_live_events_browser,
+)
 from views.btd6.panel import BTD6PanelView, build_btd6_panel_embed
+from views.btd6.tower_browser_view import (
+    TowerBrowserView,
+    TowerDetailView,
+    open_tower_browser,
+)
 
-__all__ = ["BTD6PanelView", "build_btd6_panel_embed"]
+__all__ = [
+    "BTD6PanelView",
+    "EventDetailView",
+    "HeroBrowserView",
+    "HeroDetailView",
+    "LeaderboardBrowserView",
+    "LeaderboardDetailView",
+    "LeaderboardKindListView",
+    "LiveEventsBrowserView",
+    "TowerBrowserView",
+    "TowerDetailView",
+    "build_btd6_panel_embed",
+    "open_hero_browser",
+    "open_leaderboard_browser",
+    "open_live_events_browser",
+    "open_tower_browser",
+]

--- a/disbot/views/btd6/hero_browser_view.py
+++ b/disbot/views/btd6/hero_browser_view.py
@@ -132,7 +132,9 @@ class _HeroSelect(discord.ui.Select):
             parent_builder=_rebuild_list,
         )
         await safe_edit(
-            interaction, embed=build_hero_detail_embed(detail_vm), view=detail_view,
+            interaction,
+            embed=build_hero_detail_embed(detail_vm),
+            view=detail_view,
         )
 
 
@@ -169,7 +171,10 @@ async def open_hero_browser(interaction: discord.Interaction) -> None:
     view = HeroBrowserView(interaction.user)
     view.set_vm(vm)
     await safe_followup(
-        interaction, embed=build_hero_list_embed(vm), view=view, ephemeral=True,
+        interaction,
+        embed=build_hero_list_embed(vm),
+        view=view,
+        ephemeral=True,
     )
 
 

--- a/disbot/views/btd6/hero_browser_view.py
+++ b/disbot/views/btd6/hero_browser_view.py
@@ -1,0 +1,182 @@
+"""Hero browser — ephemeral drill-down opened from the BTD6 hub.
+
+Mirrors :mod:`views.btd6.tower_browser_view` for heroes. Both list +
+detail views extend :class:`HubView`.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+from core.runtime.interaction_helpers import safe_defer, safe_edit, safe_followup
+from services.btd6_view_model_service import (
+    HeroDetailViewModel,
+    HeroListViewModel,
+    build_hero_detail_view_model,
+    build_hero_list_view_model,
+)
+from utils.btd6.response_embed import response_to_embed
+from views.base import HubView
+from views.navigation import attach_back_button
+
+logger = logging.getLogger("bot.views.btd6.hero_browser")
+
+
+# ---------------------------------------------------------------------------
+# Embeds
+# ---------------------------------------------------------------------------
+
+
+def build_hero_list_embed(vm: HeroListViewModel) -> discord.Embed:
+    embed = discord.Embed(
+        title="🐵 BTD6 — Heroes",
+        description=(
+            f"Showing {len(vm.items)} of {vm.total_count} heroes. Pick "
+            "one to view the seed sheet + any active-event restrictions."
+        ),
+        color=discord.Color.green(),
+    )
+    if len(vm.items) < vm.total_count:
+        embed.add_field(
+            name="ℹ️ Pagination",
+            value=(
+                "Discord caps selects at 25 options; refine via "
+                "`/btd6 hero <name>` for off-list heroes."
+            ),
+            inline=False,
+        )
+    for item in vm.items[:10]:
+        embed.add_field(
+            name=item.canonical,
+            value=f"Cost: {item.base_cost} • {item.description[:80]}",
+            inline=False,
+        )
+    return embed
+
+
+def build_hero_detail_embed(vm: HeroDetailViewModel) -> discord.Embed:
+    from services import btd6_ai_service
+    from services.btd6_resolver_service import resolve
+    from services.btd6_response_builder import for_hero
+
+    intent = resolve(vm.hero_id)
+    if not intent.heroes:
+        return response_to_embed(btd6_ai_service.deterministic_answer(intent))
+    hero = intent.heroes[0]
+    return response_to_embed(for_hero(hero, restrictions=tuple(vm.restrictions)))
+
+
+# ---------------------------------------------------------------------------
+# Views
+# ---------------------------------------------------------------------------
+
+
+class _HeroSelect(discord.ui.Select):
+    def __init__(self, vm: HeroListViewModel) -> None:
+        options = [
+            discord.SelectOption(
+                label=item.canonical[:100],
+                value=item.hero_id,
+                description=f"Cost: {item.base_cost}"[:100],
+            )
+            for item in vm.items
+        ]
+        if not options:
+            options = [
+                discord.SelectOption(
+                    label="(no heroes available)",
+                    value="__none__",
+                ),
+            ]
+        super().__init__(
+            placeholder="Pick a hero to view…",
+            min_values=1,
+            max_values=1,
+            options=options[:25],
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        choice = self.values[0]
+        if choice == "__none__":
+            await safe_defer(interaction, ephemeral=True)
+            return
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        detail_vm = await build_hero_detail_view_model(choice)
+        if detail_vm is None:
+            embed = discord.Embed(
+                title="🐵 BTD6 — Hero",
+                description=f"No fact found for hero `{choice}`.",
+                color=discord.Color.red(),
+            )
+            await safe_edit(interaction, embed=embed, view=None)
+            return
+
+        async def _rebuild_list(
+            _i: discord.Interaction,
+        ) -> tuple[discord.Embed, discord.ui.View]:
+            list_vm = await build_hero_list_view_model()
+            parent = HeroBrowserView(interaction.user)
+            parent.set_vm(list_vm)
+            return build_hero_list_embed(list_vm), parent
+
+        detail_view = HeroDetailView(interaction.user)
+        detail_view.set_vm(detail_vm)
+        attach_back_button(
+            detail_view,
+            label="↩ Back",
+            custom_id=f"btd6_hero_detail:back:{detail_vm.hero_id}",
+            parent_builder=_rebuild_list,
+        )
+        await safe_edit(
+            interaction, embed=build_hero_detail_embed(detail_vm), view=detail_view,
+        )
+
+
+class HeroBrowserView(HubView):
+    def __init__(self, author: discord.User | discord.Member) -> None:
+        super().__init__(author)
+        self._vm: HeroListViewModel | None = None
+
+    def set_vm(self, vm: HeroListViewModel) -> None:
+        for child in list(self.children):
+            self.remove_item(child)
+        self._vm = vm
+        self.add_item(_HeroSelect(vm))
+
+
+class HeroDetailView(HubView):
+    def __init__(self, author: discord.User | discord.Member) -> None:
+        super().__init__(author)
+        self._vm: HeroDetailViewModel | None = None
+
+    def set_vm(self, vm: HeroDetailViewModel) -> None:
+        self._vm = vm
+
+
+# ---------------------------------------------------------------------------
+# Public entrypoint
+# ---------------------------------------------------------------------------
+
+
+async def open_hero_browser(interaction: discord.Interaction) -> None:
+    if not await safe_defer(interaction, ephemeral=True):
+        return
+    vm = await build_hero_list_view_model()
+    view = HeroBrowserView(interaction.user)
+    view.set_vm(vm)
+    await safe_followup(
+        interaction, embed=build_hero_list_embed(vm), view=view, ephemeral=True,
+    )
+
+
+__all__ = [
+    "HeroBrowserView",
+    "HeroDetailView",
+    "build_hero_detail_embed",
+    "build_hero_list_embed",
+    "open_hero_browser",
+]

--- a/disbot/views/btd6/leaderboard_browser_view.py
+++ b/disbot/views/btd6/leaderboard_browser_view.py
@@ -1,0 +1,262 @@
+"""Leaderboard browser — race / boss drill-down.
+
+Three-step flow:
+
+1. :class:`LeaderboardBrowserView` — pick race or boss.
+2. :class:`LeaderboardKindListView` — pick a specific event.
+3. :class:`LeaderboardDetailView` — top-N rows.
+
+Detail back returns to the per-kind list (NOT directly to the kind
+picker) so the user can compare neighbouring events without
+re-selecting the kind.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+from core.runtime.interaction_helpers import safe_defer, safe_edit, safe_followup
+from services.btd6_view_model_service import (
+    LeaderboardDetailViewModel,
+    LeaderboardListViewModel,
+    build_leaderboard_detail_view_model,
+    build_leaderboard_list_view_model,
+)
+from utils.btd6.freshness_render import BUCKET_BADGE, render_freshness_warning
+from views.base import HubView
+from views.navigation import attach_back_button
+
+logger = logging.getLogger("bot.views.btd6.leaderboard_browser")
+
+
+# ---------------------------------------------------------------------------
+# Embeds
+# ---------------------------------------------------------------------------
+
+
+def build_kind_picker_embed() -> discord.Embed:
+    return discord.Embed(
+        title="🐵 BTD6 — Leaderboards",
+        description=(
+            "Pick **race** or **boss** to browse stored leaderboards. "
+            "Boss leaderboards show standard solo only."
+        ),
+        color=discord.Color.gold(),
+    )
+
+
+def build_event_list_embed(vm: LeaderboardListViewModel) -> discord.Embed:
+    embed = discord.Embed(
+        title=f"🐵 BTD6 — {vm.event_kind.title()} leaderboards",
+        description=(
+            f"Showing {len(vm.items)} of {vm.total_count} events. Pick one "
+            "to view top-10 rows."
+        ),
+        color=discord.Color.gold(),
+    )
+    warning = render_freshness_warning(vm.freshness.state)
+    if warning:
+        embed.add_field(name="⚠️ Data freshness", value=warning, inline=False)
+    for item in vm.items[:10]:
+        embed.add_field(
+            name=item.event_name[:256],
+            value=f"id=`{item.event_id}` · {item.window.human}",
+            inline=False,
+        )
+    return embed
+
+
+def build_leaderboard_detail_embed(vm: LeaderboardDetailViewModel) -> discord.Embed:
+    label = vm.event_name or vm.event_id
+    embed = discord.Embed(
+        title=f"🐵 BTD6 — {vm.event_kind.title()} leaderboard — {label}",
+        color=discord.Color.gold(),
+    )
+    if not vm.rows:
+        embed.description = (
+            f"No leaderboard rows stored for `{vm.event_id}` yet. "
+            f"Try `!btd6 refresh-source {vm.freshness.source_key}`."
+        )
+    else:
+        lines: list[str] = []
+        for row in vm.rows:
+            if row.score is not None:
+                score_render = f"score=`{row.score}`"
+            elif row.score_parts:
+                score_render = "score=" + "/".join(str(p) for p in row.score_parts)
+            else:
+                score_render = ""
+            lines.append(
+                f"#{row.rank} **{row.display_name or '—'}** · {score_render}".rstrip(
+                    " ·",
+                ),
+            )
+        embed.description = "\n".join(lines)
+
+    parts: list[str] = []
+    if vm.footer_hint:
+        parts.append(vm.footer_hint)
+    if vm.freshness.state in ("aging", "stale"):
+        parts.append(f"Data: {BUCKET_BADGE[vm.freshness.state]}")
+    warning = render_freshness_warning(vm.freshness.state)
+    if warning:
+        embed.add_field(name="⚠️ Data freshness", value=warning, inline=False)
+    if parts:
+        embed.set_footer(text=" · ".join(parts))
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# Views
+# ---------------------------------------------------------------------------
+
+
+class _KindSelect(discord.ui.Select):
+    """Step 1: pick race or boss."""
+
+    def __init__(self) -> None:
+        options = [
+            discord.SelectOption(label="🏁 Race", value="race"),
+            discord.SelectOption(label="👑 Boss", value="boss"),
+        ]
+        super().__init__(
+            placeholder="Pick a leaderboard kind…",
+            min_values=1,
+            max_values=1,
+            options=options,
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        kind = self.values[0]
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        vm = await build_leaderboard_list_view_model(kind)
+        view = LeaderboardKindListView(interaction.user)
+        view.set_vm(kind, vm)
+        await safe_edit(interaction, embed=build_event_list_embed(vm), view=view)
+
+
+class _EventSelect(discord.ui.Select):
+    """Step 2: pick a specific race/boss event."""
+
+    def __init__(self, vm: LeaderboardListViewModel) -> None:
+        options = [
+            discord.SelectOption(
+                label=item.event_name[:100],
+                value=item.event_id,
+                description=f"{item.window.state} · {item.window.human}"[:100],
+            )
+            for item in vm.items
+        ]
+        if not options:
+            options = [
+                discord.SelectOption(label="(no events)", value="__none__"),
+            ]
+        super().__init__(
+            placeholder=f"Pick a {vm.event_kind} to view leaderboard…",
+            min_values=1,
+            max_values=1,
+            options=options[:25],
+            row=1,
+        )
+        self._kind = vm.event_kind
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        choice = self.values[0]
+        if choice == "__none__":
+            await safe_defer(interaction, ephemeral=True)
+            return
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        kind = self._kind
+        detail_vm = await build_leaderboard_detail_view_model(kind, choice)
+
+        async def _rebuild_list(
+            _i: discord.Interaction,
+        ) -> tuple[discord.Embed, discord.ui.View]:
+            list_vm = await build_leaderboard_list_view_model(kind)
+            parent = LeaderboardKindListView(interaction.user)
+            parent.set_vm(kind, list_vm)
+            return build_event_list_embed(list_vm), parent
+
+        detail_view = LeaderboardDetailView(interaction.user)
+        detail_view.set_vm(detail_vm)
+        attach_back_button(
+            detail_view,
+            label="↩ Back to list",
+            custom_id=f"btd6_lb_detail:back:{kind}:{choice}",
+            parent_builder=_rebuild_list,
+        )
+        await safe_edit(
+            interaction,
+            embed=build_leaderboard_detail_embed(detail_vm),
+            view=detail_view,
+        )
+
+
+class LeaderboardBrowserView(HubView):
+    """Step 1 view: pick race or boss."""
+
+    def __init__(self, author: discord.User | discord.Member) -> None:
+        super().__init__(author)
+        self.add_item(_KindSelect())
+
+
+class LeaderboardKindListView(HubView):
+    """Step 2 view: pick a specific race/boss event."""
+
+    def __init__(self, author: discord.User | discord.Member) -> None:
+        super().__init__(author)
+        self._kind: str | None = None
+        self._vm: LeaderboardListViewModel | None = None
+        self.add_item(_KindSelect())
+
+    def set_vm(self, kind: str, vm: LeaderboardListViewModel) -> None:
+        for child in list(self.children):
+            self.remove_item(child)
+        self.add_item(_KindSelect())
+        self._kind = kind
+        self._vm = vm
+        self.add_item(_EventSelect(vm))
+
+
+class LeaderboardDetailView(HubView):
+    """Step 3 view: top-N rows of one leaderboard."""
+
+    def __init__(self, author: discord.User | discord.Member) -> None:
+        super().__init__(author)
+        self._vm: LeaderboardDetailViewModel | None = None
+
+    def set_vm(self, vm: LeaderboardDetailViewModel) -> None:
+        self._vm = vm
+
+
+# ---------------------------------------------------------------------------
+# Public entrypoint
+# ---------------------------------------------------------------------------
+
+
+async def open_leaderboard_browser(interaction: discord.Interaction) -> None:
+    if not await safe_defer(interaction, ephemeral=True):
+        return
+    view = LeaderboardBrowserView(interaction.user)
+    await safe_followup(
+        interaction,
+        embed=build_kind_picker_embed(),
+        view=view,
+        ephemeral=True,
+    )
+
+
+__all__ = [
+    "LeaderboardBrowserView",
+    "LeaderboardDetailView",
+    "LeaderboardKindListView",
+    "build_event_list_embed",
+    "build_kind_picker_embed",
+    "build_leaderboard_detail_embed",
+    "open_leaderboard_browser",
+]

--- a/disbot/views/btd6/live_events_view.py
+++ b/disbot/views/btd6/live_events_view.py
@@ -1,0 +1,280 @@
+"""Live Events browser — race / boss / CT / odyssey / event drill-down.
+
+Opened from the BTD6 hub. Two selects:
+
+1. Event kind (race / boss / ct / odyssey / event) — drives the list.
+2. Event id — opens the detail view.
+
+Detail view's "Back" rebuilds the list with the kind preserved via
+the closure captured by :func:`views.navigation.attach_back_button`.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+from core.runtime.interaction_helpers import safe_defer, safe_edit, safe_followup
+from services.btd6_view_model_service import (
+    EventDetailViewModel,
+    EventListViewModel,
+    build_event_detail_view_model,
+    build_event_list_view_model,
+)
+from utils.btd6.freshness_render import render_freshness_warning
+from views.base import HubView
+from views.navigation import attach_back_button
+
+logger = logging.getLogger("bot.views.btd6.live_events")
+
+
+_KIND_LABELS: tuple[tuple[str, str, str], ...] = (
+    ("race", "🏁 Race", "Active + recent race events"),
+    ("boss", "👑 Boss", "Active + recent boss events"),
+    ("ct", "🗺️ CT", "Contested Territory events"),
+    ("odyssey", "🌊 Odyssey", "Active + recent odysseys"),
+    ("event", "🎪 Event", "Other live events"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Embeds
+# ---------------------------------------------------------------------------
+
+
+def build_kind_picker_embed() -> discord.Embed:
+    """First-step embed: pick an event kind."""
+    return discord.Embed(
+        title="🐵 BTD6 — Live Events",
+        description=(
+            "Pick a category to browse the most-recent events. Use "
+            "**↩ Close** to dismiss the panel."
+        ),
+        color=discord.Color.gold(),
+    )
+
+
+def build_event_list_embed(vm: EventListViewModel) -> discord.Embed:
+    embed = discord.Embed(
+        title=f"🐵 BTD6 — Live {vm.kind.title()} events",
+        description=(
+            f"Showing {len(vm.items)} of {vm.total_count}. Pick an event "
+            "to view detail / restrictions."
+        ),
+        color=discord.Color.gold(),
+    )
+    warning = render_freshness_warning(vm.freshness.state)
+    if warning:
+        embed.add_field(name="⚠️ Data freshness", value=warning, inline=False)
+    if not vm.items:
+        embed.add_field(
+            name="No events",
+            value=(
+                f"No active or recent `{vm.kind}` events stored yet. "
+                f"Try `!btd6 refresh-source {vm.freshness.source_key}`."
+            ),
+            inline=False,
+        )
+    for item in vm.items[:10]:
+        embed.add_field(
+            name=item.name[:256],
+            value=f"id=`{item.entity_key}` · {item.window.human}",
+            inline=False,
+        )
+    return embed
+
+
+def build_event_detail_embed_from_vm(vm: EventDetailViewModel) -> discord.Embed:
+    """Render detail page for one event.
+
+    Reuses the existing ``build_event_detail_embed`` for byte-identical
+    layout. The VM holds the rows the legacy builder reads from, so we
+    construct row dicts and forward them.
+    """
+    from cogs.btd6._builders import build_event_detail_embed
+
+    primary_row: dict | None = None
+    metadata_row: dict | None = None
+    if vm.primary_body:
+        primary_row = {
+            "entity_kind": vm.entity_kind,
+            "entity_key": vm.entity_key,
+            "body_json": vm.primary_body,
+            "fetched_at": vm.fetched_at,
+        }
+    if vm.metadata_body:
+        metadata_row = {
+            "entity_kind": vm.entity_kind,
+            "entity_key": vm.entity_key,
+            "body_json": vm.metadata_body,
+            "fetched_at": vm.fetched_at,
+        }
+    embed = build_event_detail_embed(
+        vm.entity_kind,
+        vm.entity_key,
+        primary_row,
+        metadata_row=metadata_row,
+    )
+    warning = render_freshness_warning(vm.freshness.state)
+    if warning:
+        embed.add_field(name="⚠️ Data freshness", value=warning, inline=False)
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# Views
+# ---------------------------------------------------------------------------
+
+
+class _KindSelect(discord.ui.Select):
+    """Picks the event kind; opens the per-kind list view."""
+
+    def __init__(self) -> None:
+        options = [
+            discord.SelectOption(label=label, value=value, description=desc[:100])
+            for value, label, desc in _KIND_LABELS
+        ]
+        super().__init__(
+            placeholder="Pick an event kind…",
+            min_values=1,
+            max_values=1,
+            options=options,
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        kind = self.values[0]
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        vm = await build_event_list_view_model(kind)
+        view = LiveEventsBrowserView(interaction.user)
+        view.set_kind(kind, vm)
+        await safe_edit(interaction, embed=build_event_list_embed(vm), view=view)
+
+
+class _EventSelect(discord.ui.Select):
+    """Picks one specific event; opens the detail view."""
+
+    def __init__(self, vm: EventListViewModel) -> None:
+        options = [
+            discord.SelectOption(
+                label=item.name[:100],
+                value=item.entity_key,
+                description=(f"{item.window.state} · {item.window.human}")[:100],
+            )
+            for item in vm.items
+        ]
+        if not options:
+            options = [
+                discord.SelectOption(
+                    label="(no events)",
+                    value="__none__",
+                ),
+            ]
+        super().__init__(
+            placeholder="Pick an event to view…",
+            min_values=1,
+            max_values=1,
+            options=options[:25],
+            row=1,
+        )
+        self._kind = vm.kind
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        choice = self.values[0]
+        if choice == "__none__":
+            await safe_defer(interaction, ephemeral=True)
+            return
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        kind = self._kind
+        detail_vm = await build_event_detail_view_model(kind, choice)
+        if detail_vm is None:
+            embed = discord.Embed(
+                title="🐵 BTD6 — Event",
+                description=f"No fact stored for `{kind}` event `{choice}`.",
+                color=discord.Color.red(),
+            )
+            await safe_edit(interaction, embed=embed, view=None)
+            return
+
+        async def _rebuild_list(
+            _i: discord.Interaction,
+        ) -> tuple[discord.Embed, discord.ui.View]:
+            list_vm = await build_event_list_view_model(kind)
+            parent = LiveEventsBrowserView(interaction.user)
+            parent.set_kind(kind, list_vm)
+            return build_event_list_embed(list_vm), parent
+
+        detail_view = EventDetailView(interaction.user)
+        detail_view.set_vm(detail_vm)
+        attach_back_button(
+            detail_view,
+            label="↩ Back to list",
+            custom_id=f"btd6_event_detail:back:{kind}:{detail_vm.entity_key}",
+            parent_builder=_rebuild_list,
+        )
+        await safe_edit(
+            interaction,
+            embed=build_event_detail_embed_from_vm(detail_vm),
+            view=detail_view,
+        )
+
+
+class LiveEventsBrowserView(HubView):
+    """List of events for a given kind. Top-level of the drill-down."""
+
+    def __init__(self, author: discord.User | discord.Member) -> None:
+        super().__init__(author)
+        self._kind: str | None = None
+        self._vm: EventListViewModel | None = None
+        self.add_item(_KindSelect())
+
+    def set_kind(self, kind: str, vm: EventListViewModel) -> None:
+        """Populate the event select for the given kind."""
+        for child in list(self.children):
+            self.remove_item(child)
+        self.add_item(_KindSelect())
+        self._kind = kind
+        self._vm = vm
+        self.add_item(_EventSelect(vm))
+
+
+class EventDetailView(HubView):
+    """One specific event. Reached from :class:`LiveEventsBrowserView`."""
+
+    def __init__(self, author: discord.User | discord.Member) -> None:
+        super().__init__(author)
+        self._vm: EventDetailViewModel | None = None
+
+    def set_vm(self, vm: EventDetailViewModel) -> None:
+        self._vm = vm
+
+
+# ---------------------------------------------------------------------------
+# Public entrypoint
+# ---------------------------------------------------------------------------
+
+
+async def open_live_events_browser(interaction: discord.Interaction) -> None:
+    """Open the live-events browser as an ephemeral followup."""
+    if not await safe_defer(interaction, ephemeral=True):
+        return
+    view = LiveEventsBrowserView(interaction.user)
+    await safe_followup(
+        interaction,
+        embed=build_kind_picker_embed(),
+        view=view,
+        ephemeral=True,
+    )
+
+
+__all__ = [
+    "EventDetailView",
+    "LiveEventsBrowserView",
+    "build_event_detail_embed_from_vm",
+    "build_event_list_embed",
+    "build_kind_picker_embed",
+    "open_live_events_browser",
+]

--- a/disbot/views/btd6/panel.py
+++ b/disbot/views/btd6/panel.py
@@ -21,7 +21,7 @@ import discord
 
 from core.runtime.interaction_helpers import safe_defer, safe_edit, safe_followup
 from core.runtime.persistent_views import PersistentView, register
-from services import btd6_ai_service, btd6_knowledge_service
+from services import btd6_ai_service
 
 _PANEL_COLOR = discord.Color.green()
 
@@ -73,67 +73,32 @@ class BTD6AskModal(discord.ui.Modal, title="Ask BTD6 Assistant"):
 # ---------------------------------------------------------------------------
 
 
-# Useful-first ordering for the Currently active block.
-_ACTIVE_KINDS: tuple[tuple[str, str, str], ...] = (
-    ("btd6_race", "🏁", "race"),
-    ("btd6_boss", "👑", "boss"),
-    ("btd6_ct", "🗺️", "ct"),
-    ("btd6_odyssey", "🌊", "odyssey"),
-    ("btd6_event", "🎪", "event"),
-)
-
-
-def _format_ends_relative(end_ms: Any) -> str:
-    """Render ``end_ms`` as ``ends Xh / Xd``.
-
-    ``None`` / non-numeric / past timestamps render as the empty
-    string so the line stays compact. Reuses the same ms-since-epoch
-    convention as the live-event reader.
-    """
-    from datetime import datetime, timezone
-
-    if not isinstance(end_ms, (int, float)) or end_ms <= 0:
-        return ""
-    try:
-        end = datetime.fromtimestamp(end_ms / 1000.0, tz=timezone.utc)
-    except (OverflowError, OSError, ValueError):
-        return ""
-    delta = end - datetime.now(tz=timezone.utc)
-    seconds = int(delta.total_seconds())
-    if seconds <= 0:
-        return "· ended"
-    if seconds < 3600:
-        return f"· ends {seconds // 60}m"
-    if seconds < 86_400:
-        return f"· ends {seconds // 3600}h"
-    return f"· ends {seconds // 86_400}d"
-
-
-def _format_currently_active(
-    rows: dict[str, dict[str, Any]],
+def _format_currently_active_from_vm(
+    vm_active: tuple[Any, ...],
 ) -> str:
     """One line per kind in useful-first order; '—' for missing kinds.
 
-    Names pulled from ``body_json.name`` with ``entity_key`` fallback.
-    Renders an end-time hint when ``body_json.end_ms`` is positive.
+    Each line now leads with a per-kind freshness badge (PR 1):
+    ``🟢/🟡/🔴/⚪`` reflects how stale the latest fact for that kind is.
+    Missing kinds render ``⚪`` (never fetched).
     """
-    from cogs.btd6._builders import _coerce_body
+    from cogs.btd6._freshness_render import BUCKET_EMOJI
+    from utils.btd6.event_window import format_ends_relative
 
     lines: list[str] = []
-    for entity_kind, emoji, short in _ACTIVE_KINDS:
-        row = rows.get(entity_kind)
-        if row is None:
-            lines.append(f"{emoji} `{short:<8}` —")
+    for active in vm_active:
+        badge = BUCKET_EMOJI.get(active.freshness.state, "⚪")
+        if active.name is None:
+            lines.append(
+                f"{badge} {active.emoji} `{active.short_kind:<8}` —",
+            )
             continue
-        body = _coerce_body(row.get("body_json"))
-        name = body.get("name") or row.get("entity_key") or "—"
-        ends = _format_ends_relative(body.get("end_ms"))
-        # Cap displayed name so a freakishly long event name doesn't
-        # blow the field-value cap. 60 chars is plenty for any real
-        # NK event name.
-        name_str = str(name)[:60]
+        ends = format_ends_relative(active.end_ms)
+        name_str = str(active.name)[:60]
         suffix = f" {ends}" if ends else ""
-        lines.append(f"{emoji} `{short:<8}` `{name_str}`{suffix}")
+        lines.append(
+            f"{badge} {active.emoji} `{active.short_kind:<8}` `{name_str}`{suffix}",
+        )
     return "\n".join(lines)
 
 
@@ -145,10 +110,15 @@ async def build_btd6_panel_embed() -> discord.Embed:
     * Reference (seed) — data/game version + entity counts; what the
       deterministic resolver answers from.
     * Currently active — the latest race/boss/CT/odyssey/event by name
-      from ``btd6_facts``, so opening ``!btd6`` immediately reflects
-      whether ingestion is producing data.
+      from ``btd6_facts``, prefixed with a per-kind freshness badge so
+      operators see at a glance which sources have gone stale.
+
+    PR 1: now built from :class:`HubViewModel`. The badge is the only
+    user-visible change vs. the previous panel embed.
     """
-    from utils.db import btd6_sources as btd6_db
+    from services.btd6_view_model_service import build_hub_view_model
+
+    vm = await build_hub_view_model()
 
     embed = discord.Embed(
         title="🐵 BTD6 Assistant",
@@ -162,22 +132,19 @@ async def build_btd6_panel_embed() -> discord.Embed:
     embed.add_field(
         name="📚 Reference (seed)",
         value=(
-            f"Data version: `{btd6_knowledge_service.data_version()}` · "
-            f"Game version: `{btd6_knowledge_service.game_version()}`\n"
-            f"{len(btd6_knowledge_service.list_towers())} towers • "
-            f"{len(btd6_knowledge_service.list_heroes())} heroes • "
-            f"{len(btd6_knowledge_service.list_maps())} maps • "
-            f"{len(btd6_knowledge_service.list_modes())} modes • "
-            f"{len(btd6_knowledge_service.list_rounds())} rounds"
+            f"Data version: `{vm.data_version}` · "
+            f"Game version: `{vm.game_version}`\n"
+            f"{vm.tower_count} towers • "
+            f"{vm.hero_count} heroes • "
+            f"{vm.map_count} maps • "
+            f"{vm.mode_count} modes • "
+            f"{vm.round_count} rounds"
         ),
         inline=False,
     )
-    active_rows = await btd6_db.latest_fact_per_entity_kind(
-        [kind for kind, _, _ in _ACTIVE_KINDS],
-    )
     embed.add_field(
         name="🎯 Currently active",
-        value=_format_currently_active(active_rows),
+        value=_format_currently_active_from_vm(vm.active_events),
         inline=False,
     )
     embed.set_footer(

--- a/disbot/views/btd6/panel.py
+++ b/disbot/views/btd6/panel.py
@@ -19,7 +19,7 @@ from typing import Any
 
 import discord
 
-from core.runtime.interaction_helpers import safe_defer, safe_edit, safe_followup
+from core.runtime.interaction_helpers import safe_defer, safe_followup
 from core.runtime.persistent_views import PersistentView, register
 from services import btd6_ai_service
 
@@ -163,13 +163,30 @@ async def build_btd6_panel_embed() -> discord.Embed:
 
 @register
 class BTD6PanelView(PersistentView):
-    """BTD6 Assistant panel. Anyone can use the user buttons; the
-    Admin button is gated to ``manage_guild`` / ``administrator``.
+    """BTD6 Assistant panel.
+
+    All non-modal callbacks open ephemeral sub-views via
+    :func:`safe_followup`. The public anchor embed is **never edited**
+    on click — this is a UX upgrade from PR 2 (clicking Towers used to
+    mutate the panel for everyone in the channel).
+
+    Modal exception: the **Ask** button calls
+    ``interaction.response.send_modal`` as the initial response and
+    does no service work before that — modals require the response
+    slot.
+
+    Back-compat: keeps every legacy ``btd6:*`` custom_id so existing
+    panel anchor messages in production keep routing correctly.
+    Discord does not re-render existing anchor messages at restart;
+    the rendered button row is whatever was posted historically. The
+    legacy custom_ids (``btd6:towers`` / ``btd6:heroes`` / ``btd6:modes``)
+    redirect to the new ephemeral browsers.
     """
 
+    # back-compat redirect — drop after 2026-Q3
     SUBSYSTEM = "btd6"
 
-    # Row 0 — user actions (5 buttons fill the row)
+    # Row 0 — primary user actions (5 buttons)
     @discord.ui.button(
         label="Ask",
         style=discord.ButtonStyle.success,
@@ -181,7 +198,26 @@ class BTD6PanelView(PersistentView):
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
+        # Modal exception: send_modal must be the initial response.
+        # Do NOT call safe_defer here.
         await interaction.response.send_modal(BTD6AskModal())
+
+    @discord.ui.button(
+        label="Live Events",
+        style=discord.ButtonStyle.primary,
+        row=0,
+        custom_id="btd6:events",
+    )
+    async def events_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        from views.btd6.live_events_view import open_live_events_browser
+
+        await open_live_events_browser(interaction)
 
     @discord.ui.button(
         label="Towers",
@@ -194,12 +230,11 @@ class BTD6PanelView(PersistentView):
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        from cogs.btd6._embeds import build_towers_embed
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        from views.btd6.tower_browser_view import open_tower_browser
 
-        await interaction.response.edit_message(
-            embed=build_towers_embed(),
-            view=self,
-        )
+        await open_tower_browser(interaction)
 
     @discord.ui.button(
         label="Heroes",
@@ -212,17 +247,34 @@ class BTD6PanelView(PersistentView):
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        from cogs.btd6._embeds import build_heroes_embed
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        from views.btd6.hero_browser_view import open_hero_browser
 
-        await interaction.response.edit_message(
-            embed=build_heroes_embed(),
-            view=self,
-        )
+        await open_hero_browser(interaction)
 
     @discord.ui.button(
-        label="Modes",
+        label="Leaderboards",
         style=discord.ButtonStyle.primary,
         row=0,
+        custom_id="btd6:leaderboards",
+    )
+    async def leaderboards_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        from views.btd6.leaderboard_browser_view import open_leaderboard_browser
+
+        await open_leaderboard_browser(interaction)
+
+    # Row 1 — secondary actions + staff
+    @discord.ui.button(
+        label="Modes",
+        style=discord.ButtonStyle.secondary,
+        row=1,
         custom_id="btd6:modes",
     )
     async def modes_btn(
@@ -230,17 +282,23 @@ class BTD6PanelView(PersistentView):
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
+        # Back-compat redirect: open the modes catalog as an ephemeral.
+        # The old behaviour (editing the public panel in place) was a
+        # UX anti-pattern; PR 2 switches every drill-down to ephemeral.
         from cogs.btd6._embeds import build_modes_embed
 
-        await interaction.response.edit_message(
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        await safe_followup(
+            interaction,
             embed=build_modes_embed(),
-            view=self,
+            ephemeral=True,
         )
 
     @discord.ui.button(
         label="Status",
         style=discord.ButtonStyle.primary,
-        row=0,
+        row=1,
         custom_id="btd6:status",
     )
     async def status_btn(
@@ -250,14 +308,11 @@ class BTD6PanelView(PersistentView):
     ) -> None:
         from cogs.btd6._embeds import build_status_embed
 
-        # Public panel edit — no ephemeral. safe_edit handles both the
-        # pre-defer and post-defer branches via the existing helper.
-        if not await safe_defer(interaction):
+        if not await safe_defer(interaction, ephemeral=True):
             return
         embed = await build_status_embed()
-        await safe_edit(interaction, embed=embed, view=self)
+        await safe_followup(interaction, embed=embed, ephemeral=True)
 
-    # Row 1 — staff actions
     @discord.ui.button(
         label="🛠️ Admin",
         style=discord.ButtonStyle.secondary,

--- a/disbot/views/btd6/panel.py
+++ b/disbot/views/btd6/panel.py
@@ -153,6 +153,9 @@ async def build_btd6_panel_embed() -> discord.Embed:
             "!btd6 leaderboard <race|boss> · !btd6 status"
         ),
     )
+    from utils.btd6.context_footer import append_context_footer
+
+    append_context_footer(embed, vm.context.context_id)
     return embed
 
 

--- a/disbot/views/btd6/strategy_browse.py
+++ b/disbot/views/btd6/strategy_browse.py
@@ -19,6 +19,8 @@ from typing import Any
 
 import discord
 
+from utils.btd6.context_footer import append_context_footer
+
 _DEFAULT_PAGE_SIZE = 10
 _MAX_PAGE_SIZE = 25
 
@@ -70,7 +72,7 @@ async def build_browse_embed(*, limit: int = _DEFAULT_PAGE_SIZE) -> discord.Embe
     )
     if not rows:
         embed.description = "No published strategies yet."
-        return embed
+        return append_context_footer(embed, "btd6_strategy:browse")
     for row in rows:
         embed.add_field(
             name=f"#{row['id']} · {_visibility_badge(row)}",
@@ -80,7 +82,7 @@ async def build_browse_embed(*, limit: int = _DEFAULT_PAGE_SIZE) -> discord.Embe
     embed.set_footer(
         text="!btd6 strategy <id> for detail · staff-only commands gate writes.",
     )
-    return embed
+    return append_context_footer(embed, "btd6_strategy:browse")
 
 
 # ---------------------------------------------------------------------------
@@ -111,14 +113,14 @@ async def build_mine_embed(
     )
     if not rows:
         embed.description = "You have not submitted any strategies in this guild."
-        return embed
+        return append_context_footer(embed, "btd6_strategy:mine")
     for row in rows:
         embed.add_field(
             name=f"#{row['id']} · {_visibility_badge(row)}",
             value=_summarize_row(row),
             inline=False,
         )
-    return embed
+    return append_context_footer(embed, "btd6_strategy:mine")
 
 
 # ---------------------------------------------------------------------------
@@ -190,7 +192,7 @@ async def build_detail_embed(
             f"submitted_by={row.get('submitted_by') or '—'}"
         ),
     )
-    return embed
+    return append_context_footer(embed, f"btd6_strategy:{row['id']}")
 
 
 # ---------------------------------------------------------------------------
@@ -209,7 +211,7 @@ async def build_audit_embed(strategy_id: int) -> discord.Embed:
     )
     if not rows:
         embed.description = f"No audit rows for strategy #{strategy_id}."
-        return embed
+        return append_context_footer(embed, f"btd6_strategy:{strategy_id}")
     for r in rows[:_MAX_PAGE_SIZE]:
         when = r.get("created_at")
         when_str = when.isoformat(timespec="minutes") if when else "—"
@@ -218,7 +220,7 @@ async def build_audit_embed(strategy_id: int) -> discord.Embed:
             value=(f"actor_id=`{r.get('actor_id') or '—'}` · at=`{when_str}`"),
             inline=False,
         )
-    return embed
+    return append_context_footer(embed, f"btd6_strategy:{strategy_id}")
 
 
 __all__ = [

--- a/disbot/views/btd6/tower_browser_view.py
+++ b/disbot/views/btd6/tower_browser_view.py
@@ -1,0 +1,208 @@
+"""Tower browser — ephemeral drill-down opened from the BTD6 hub.
+
+Lives in ``views/btd6/`` so the cog file stays small. Both
+:class:`TowerBrowserView` (list) and :class:`TowerDetailView` (single
+tower) extend :class:`HubView` so they share the standard
+180-second timeout, invoker-only ``interaction_check``, and
+``handle_view_error`` behaviour.
+
+The list view is the ephemeral the panel button opens; the detail
+view is reached via the Select. Detail's "Back" rebuilds the list
+through :func:`views.navigation.attach_back_button`.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+from core.runtime.interaction_helpers import safe_defer, safe_edit, safe_followup
+from services.btd6_view_model_service import (
+    TowerDetailViewModel,
+    TowerListViewModel,
+    build_tower_detail_view_model,
+    build_tower_list_view_model,
+)
+from utils.btd6.response_embed import response_to_embed
+from views.base import HubView
+from views.navigation import attach_back_button
+
+logger = logging.getLogger("bot.views.btd6.tower_browser")
+
+
+# ---------------------------------------------------------------------------
+# Embeds
+# ---------------------------------------------------------------------------
+
+
+def build_tower_list_embed(vm: TowerListViewModel) -> discord.Embed:
+    embed = discord.Embed(
+        title="🐵 BTD6 — Towers",
+        description=(
+            f"Showing {len(vm.items)} of {vm.total_count} towers. Pick "
+            "one to view the deterministic fact sheet + any active-event "
+            "restrictions."
+        ),
+        color=discord.Color.green(),
+    )
+    if len(vm.items) < vm.total_count:
+        embed.add_field(
+            name="ℹ️ Pagination",
+            value=(
+                "Discord caps selects at 25 options; refine via "
+                "`/btd6 tower <name>` for off-list towers."
+            ),
+            inline=False,
+        )
+    for item in vm.items[:10]:
+        embed.add_field(
+            name=item.canonical,
+            value=f"Cost: {item.base_cost} • {item.category}",
+            inline=True,
+        )
+    return embed
+
+
+def build_tower_detail_embed(vm: TowerDetailViewModel) -> discord.Embed:
+    """Render a tower detail.
+
+    Uses ``btd6_response_builder.for_tower`` via the existing
+    ``response_to_embed`` helper to keep the on-screen format identical
+    to ``!btd6 tower <name>``.
+    """
+    from services import btd6_ai_service
+    from services.btd6_resolver_service import resolve
+    from services.btd6_response_builder import for_tower
+
+    if vm.fact is None:
+        return response_to_embed(
+            btd6_ai_service.deterministic_answer(resolve(vm.tower_id)),
+        )
+    return response_to_embed(for_tower(vm.fact, restrictions=tuple(vm.restrictions)))
+
+
+# ---------------------------------------------------------------------------
+# Views
+# ---------------------------------------------------------------------------
+
+
+class _TowerSelect(discord.ui.Select):
+    """The list select that opens TowerDetailView for the chosen tower."""
+
+    def __init__(self, vm: TowerListViewModel) -> None:
+        options = [
+            discord.SelectOption(
+                label=item.canonical[:100],
+                value=item.tower_id,
+                description=f"Cost: {item.base_cost} • {item.category}"[:100],
+            )
+            for item in vm.items
+        ]
+        if not options:
+            # Discord requires at least one option; render a disabled placeholder.
+            options = [
+                discord.SelectOption(
+                    label="(no towers available)",
+                    value="__none__",
+                ),
+            ]
+        super().__init__(
+            placeholder="Pick a tower to view…",
+            min_values=1,
+            max_values=1,
+            options=options[:25],
+            row=0,
+        )
+        self._vm = vm
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        choice = self.values[0]
+        if choice == "__none__":
+            await safe_defer(interaction, ephemeral=True)
+            return
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        detail_vm = await build_tower_detail_view_model(choice)
+        if detail_vm is None:
+            embed = discord.Embed(
+                title="🐵 BTD6 — Tower",
+                description=f"No fact found for tower `{choice}`.",
+                color=discord.Color.red(),
+            )
+            await safe_edit(interaction, embed=embed, view=None)
+            return
+
+        # Rebuild the list as the detail's parent so the Back button works.
+        async def _rebuild_list(
+            _i: discord.Interaction,
+        ) -> tuple[discord.Embed, discord.ui.View]:
+            list_vm = await build_tower_list_view_model()
+            parent = TowerBrowserView(interaction.user)
+            parent.set_vm(list_vm)
+            return build_tower_list_embed(list_vm), parent
+
+        detail_view = TowerDetailView(interaction.user)
+        detail_view.set_vm(detail_vm)
+        attach_back_button(
+            detail_view,
+            label="↩ Back",
+            custom_id=f"btd6_tower_detail:back:{detail_vm.tower_id}",
+            parent_builder=_rebuild_list,
+        )
+        await safe_edit(
+            interaction, embed=build_tower_detail_embed(detail_vm), view=detail_view,
+        )
+
+
+class TowerBrowserView(HubView):
+    """Ephemeral list of towers — opened from the BTD6 hub."""
+
+    def __init__(self, author: discord.User | discord.Member) -> None:
+        super().__init__(author)
+        self._vm: TowerListViewModel | None = None
+
+    def set_vm(self, vm: TowerListViewModel) -> None:
+        # Reset items then re-add the select for the supplied VM.
+        # Called after construction so the async builder doesn't block __init__.
+        for child in list(self.children):
+            self.remove_item(child)
+        self._vm = vm
+        self.add_item(_TowerSelect(vm))
+
+
+class TowerDetailView(HubView):
+    """Detail view for one tower. Reached from :class:`TowerBrowserView`."""
+
+    def __init__(self, author: discord.User | discord.Member) -> None:
+        super().__init__(author)
+        self._vm: TowerDetailViewModel | None = None
+
+    def set_vm(self, vm: TowerDetailViewModel) -> None:
+        self._vm = vm
+
+
+# ---------------------------------------------------------------------------
+# Public entrypoint — called by the panel's Towers button
+# ---------------------------------------------------------------------------
+
+
+async def open_tower_browser(interaction: discord.Interaction) -> None:
+    """Open the tower browser as an ephemeral followup."""
+    if not await safe_defer(interaction, ephemeral=True):
+        return
+    vm = await build_tower_list_view_model()
+    view = TowerBrowserView(interaction.user)
+    view.set_vm(vm)
+    embed = build_tower_list_embed(vm)
+    # Freshness is N/A for the static tower catalog — no warning to render.
+    await safe_followup(interaction, embed=embed, view=view, ephemeral=True)
+
+
+__all__ = [
+    "TowerBrowserView",
+    "TowerDetailView",
+    "build_tower_detail_embed",
+    "build_tower_list_embed",
+    "open_tower_browser",
+]

--- a/disbot/views/btd6/tower_browser_view.py
+++ b/disbot/views/btd6/tower_browser_view.py
@@ -151,7 +151,9 @@ class _TowerSelect(discord.ui.Select):
             parent_builder=_rebuild_list,
         )
         await safe_edit(
-            interaction, embed=build_tower_detail_embed(detail_vm), view=detail_view,
+            interaction,
+            embed=build_tower_detail_embed(detail_vm),
+            view=detail_view,
         )
 
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -255,6 +255,21 @@ for **splitting supporting UI** out of a cog when the cog grows past
 panel entry-point convention; see "Subsystem decomposition" below for
 the full splitting checklist.
 
+For **read-heavy subsystems** (the BTD6 cog is the reference pattern),
+prefer the query → view-model → embed sandwich:
+
+* `services/<name>_query_service.py` (or equivalent) returns typed
+  dataclasses from stored data; no view/cog imports.
+* `services/<name>_view_model_service.py` composes query output into
+  display-ready models that carry `freshness` + `context_id`. Embed
+  builders consume VMs, not raw rows.
+* `cogs/<name>/_*.py` + `views/<name>/*.py` hold the rendering and
+  Discord-interaction logic only.
+
+The BTD6 cog wires this through `build_*_view_model` builders in
+`services/btd6_view_model_service.py` and shared rendering helpers in
+`utils/btd6/` (`freshness_render`, `response_embed`, `context_footer`).
+
 ---
 
 ## Subsystem decomposition

--- a/docs/ownership.md
+++ b/docs/ownership.md
@@ -38,6 +38,7 @@ that service.  No exceptions for cogs or other services.
 | `services/game_state_service.py` | in-flight game state checkpoints (`game_state` table) | call `save`/`load`/`clear`/`list_active_for_subsystem`.  JSONB payload; cogs own their schemas. |
 | `services/governance_service.py` (legacy shim) | the public surface re-exported from `governance/*` | re-exports only.  No business logic should live here. |
 | `governance/writes.py:GovernanceMutationPipeline` | every governance write (subsystem_visibility, cleanup_policies, capability_overrides, audit log) | use the pipeline.  INV-E (`test_apply_template_uses_pipeline`). |
+| `services/btd6_view_model_service.py` | BTD6 view-model construction, the data-freshness contract, and the `context_id` format (`^btd6_[a-z_]+:[A-Za-z0-9_-]+$`) | call `build_*_view_model(...)` instead of reading `btd6_facts` rows directly from cogs/views. The `context_id` regex is the handle a future Team Panel attaches to — never widen it without a migration. Pinned by `tests/unit/cogs/test_btd6_context_id_contract.py`. |
 
 ---
 

--- a/tests/unit/cogs/test_btd6_command_parity.py
+++ b/tests/unit/cogs/test_btd6_command_parity.py
@@ -1,0 +1,222 @@
+"""Pin slash/prefix parity for every BTD6 command.
+
+Every prefix command (``@commands.command``) must have a slash twin
+(``@app_commands.command``) and vice versa — except commands on the
+``SLASH_ONLY`` allowlist (modal-bearing commands, which cannot fire
+from a prefix message).
+
+Twin equivalence: both forms must share at least one common shared
+builder call (``build_*``) so behavioural drift between the two forms
+is contained.
+
+AST-based to keep the test fast and to surface intent at the structural
+level rather than relying on runtime invocation.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_COG_PATH = Path(__file__).resolve().parents[3] / "disbot" / "cogs" / "btd6_cog.py"
+
+# Modal-triggering commands: they need ``send_modal`` as the initial
+# response, which a prefix message can't provide. Document the
+# exemption here so a future reader knows which commands intentionally
+# lack a prefix twin.
+SLASH_ONLY = frozenset(
+    {
+        "submit",
+    },
+)
+
+# Some commands ship only as prefix (e.g. heavy debug helpers). When
+# adding such an entry, document the rationale in the comment above.
+PREFIX_ONLY: frozenset[str] = frozenset()
+
+
+def _tree() -> ast.Module:
+    return ast.parse(_COG_PATH.read_text())
+
+
+def _decorator_call(dec: ast.AST) -> ast.Call | None:
+    if isinstance(dec, ast.Call):
+        return dec
+    return None
+
+
+def _decorator_name(dec: ast.AST) -> tuple[str, str] | None:
+    """Return ``(module, attr)`` of the decorator call's target.
+
+    Examples:
+        ``@commands.command(...)``      → ("commands", "command")
+        ``@app_commands.command(...)``  → ("app_commands", "command")
+        ``@btd6_app_group.command(...)`` → ("btd6_app_group", "command")
+        ``@bot.event``                  → None (not a call)
+    """
+    call = _decorator_call(dec)
+    if call is None:
+        return None
+    func = call.func
+    if not isinstance(func, ast.Attribute):
+        return None
+    if not isinstance(func.value, ast.Name):
+        return None
+    return func.value.id, func.attr
+
+
+# Decorator-prefix groupings: anything in the first set is a prefix
+# command; anything in the second is a slash command. The cog uses
+# ``@btd6_group.command(...)`` for prefix subcommands (a
+# ``commands.Group``) and ``@btd6_app_group.command(...)`` for slash
+# subcommands (an ``app_commands.Group``).
+_PREFIX_REGISTRARS = frozenset({"commands", "btd6_group"})
+_SLASH_REGISTRARS = frozenset({"app_commands", "btd6_app_group"})
+
+
+def _decorator_name_kw(call: ast.Call) -> str | None:
+    """Pull ``name="..."`` from a decorator-call's kwargs."""
+    for kw in call.keywords:
+        if kw.arg == "name" and isinstance(kw.value, ast.Constant):
+            return str(kw.value.value)
+    return None
+
+
+def _collect_commands() -> (
+    tuple[dict[str, ast.AsyncFunctionDef], dict[str, ast.AsyncFunctionDef]]
+):
+    """Walk the cog module and return ``(prefix_cmds, slash_cmds)``.
+
+    Mapping is keyed by command name (the ``name=`` kwarg on the
+    decorator) so prefix/slash twins line up by name even if their
+    Python method names differ.
+    """
+    prefix: dict[str, ast.AsyncFunctionDef] = {}
+    slash: dict[str, ast.AsyncFunctionDef] = {}
+    tree = _tree()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef):
+            continue
+        for dec in node.decorator_list:
+            target = _decorator_name(dec)
+            if target is None:
+                continue
+            module, attr = target
+            if attr != "command":
+                continue
+            cmd_name = _decorator_name_kw(dec)  # type: ignore[arg-type]
+            if cmd_name is None:
+                continue
+            if module in _PREFIX_REGISTRARS:
+                prefix[cmd_name] = node
+            elif module in _SLASH_REGISTRARS:
+                slash[cmd_name] = node
+    return prefix, slash
+
+
+def _called_function_names(node: ast.AST) -> set[str]:
+    """Collect names of all functions called inside a body.
+
+    Resolves ``foo(...)``, ``self.foo(...)``, and ``mod.foo(...)`` to
+    just ``"foo"`` for cross-form comparison.
+    """
+    names: set[str] = set()
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Call):
+            continue
+        func = child.func
+        if isinstance(func, ast.Name):
+            names.add(func.id)
+        elif isinstance(func, ast.Attribute):
+            names.add(func.attr)
+    return names
+
+
+# ---------------------------------------------------------------------------
+# Existence
+# ---------------------------------------------------------------------------
+
+
+def test_every_slash_has_a_prefix_twin() -> None:
+    prefix, slash = _collect_commands()
+    missing: set[str] = set()
+    for name in slash:
+        if name in SLASH_ONLY:
+            continue
+        if name not in prefix:
+            missing.add(name)
+    assert not missing, (
+        f"Slash commands without a prefix twin: {sorted(missing)}. "
+        f"Add them to SLASH_ONLY if intentionally slash-only."
+    )
+
+
+def test_every_prefix_has_a_slash_twin() -> None:
+    prefix, slash = _collect_commands()
+    missing: set[str] = set()
+    for name in prefix:
+        if name in PREFIX_ONLY:
+            continue
+        # The btd6 group decorator emits a prefix-only "btd6" parent
+        # command — exclude it from twin matching.
+        if name == "btd6":
+            continue
+        if name not in slash:
+            missing.add(name)
+    assert not missing, (
+        f"Prefix commands without a slash twin: {sorted(missing)}. "
+        f"Add them to PREFIX_ONLY if intentionally prefix-only."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared backbone
+# ---------------------------------------------------------------------------
+
+# Names that count as "shared backbone" — at least one of these must
+# appear in BOTH the prefix and slash forms of a twin. The set is
+# intentionally broad: anything starting with ``build_`` is considered
+# a shared builder (the entire ``_builders.py`` / ``_embeds.py`` API
+# follows that convention).
+_SHARED_BACKBONE_PREFIXES = ("build_",)
+_SHARED_BACKBONE_NAMES = frozenset(
+    {
+        "_response_to_embed",
+        "answer_question",
+        "response_to_embed",
+        "safe_defer",
+        "safe_edit",
+        "safe_followup",
+    },
+)
+
+
+def _shared_backbone_calls(names: set[str]) -> set[str]:
+    return {
+        n
+        for n in names
+        if n in _SHARED_BACKBONE_NAMES
+        or any(n.startswith(p) for p in _SHARED_BACKBONE_PREFIXES)
+    }
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    sorted(n for n in _collect_commands()[1] if n not in SLASH_ONLY and n != "btd6"),
+)
+def test_twins_share_a_backbone_call(cmd: str) -> None:
+    prefix, slash = _collect_commands()
+    if cmd not in prefix or cmd not in slash:
+        pytest.skip(f"twin missing for {cmd!r}; covered by existence tests")
+    prefix_calls = _shared_backbone_calls(_called_function_names(prefix[cmd]))
+    slash_calls = _shared_backbone_calls(_called_function_names(slash[cmd]))
+    common = prefix_calls & slash_calls
+    assert common, (
+        f"Twins for {cmd!r} share no backbone call. "
+        f"Prefix calls backbone: {sorted(prefix_calls)}; "
+        f"slash calls backbone: {sorted(slash_calls)}. "
+        f"Both forms should route through a shared build_* / safe_* "
+        f"helper to prevent drift."
+    )

--- a/tests/unit/cogs/test_btd6_context_footer.py
+++ b/tests/unit/cogs/test_btd6_context_footer.py
@@ -1,0 +1,73 @@
+"""Coverage for ``utils/btd6/context_footer.py``.
+
+The helper must preserve existing footer text, preserve icon_url,
+and be idempotent. Tests pin each of those rules.
+"""
+
+from __future__ import annotations
+
+import discord
+import pytest
+
+from utils.btd6.context_footer import append_context_footer
+
+
+def test_empty_footer_gets_ctx_only() -> None:
+    embed = discord.Embed(title="x")
+    append_context_footer(embed, "btd6_hub:main")
+    assert embed.footer.text == "ctx=btd6_hub:main"
+
+
+def test_existing_footer_preserved_and_appended() -> None:
+    embed = discord.Embed(title="x")
+    embed.set_footer(text="Sources: BTD6 data v1.0")
+    append_context_footer(embed, "btd6_tower:dart_monkey")
+    assert embed.footer.text == "Sources: BTD6 data v1.0 • ctx=btd6_tower:dart_monkey"
+
+
+def test_existing_command_hint_footer_preserved() -> None:
+    embed = discord.Embed(title="x")
+    embed.set_footer(text="!btd6 ask <q> · !btd6 tower <n>")
+    append_context_footer(embed, "btd6_hub:main")
+    assert "!btd6 ask <q> · !btd6 tower <n>" in (embed.footer.text or "")
+    assert "ctx=btd6_hub:main" in (embed.footer.text or "")
+
+
+def test_idempotent_same_context_id() -> None:
+    embed = discord.Embed(title="x")
+    embed.set_footer(text="Sources: x")
+    append_context_footer(embed, "btd6_tower:dart_monkey")
+    first_text = embed.footer.text
+    append_context_footer(embed, "btd6_tower:dart_monkey")
+    assert embed.footer.text == first_text  # no double-append
+
+
+def test_different_context_id_replaces_marker() -> None:
+    """Re-rendering an embed with a fresh context_id replaces, not appends."""
+    embed = discord.Embed(title="x")
+    embed.set_footer(text="Sources: x")
+    append_context_footer(embed, "btd6_tower:dart_monkey")
+    append_context_footer(embed, "btd6_tower:bomb_shooter")
+    assert (embed.footer.text or "").count("ctx=") == 1
+    assert "btd6_tower:bomb_shooter" in (embed.footer.text or "")
+    assert "btd6_tower:dart_monkey" not in (embed.footer.text or "")
+
+
+def test_icon_url_preserved() -> None:
+    embed = discord.Embed(title="x")
+    embed.set_footer(text="src", icon_url="https://example.com/icon.png")
+    append_context_footer(embed, "btd6_hub:main")
+    assert embed.footer.icon_url == "https://example.com/icon.png"
+    assert "ctx=btd6_hub:main" in (embed.footer.text or "")
+
+
+def test_empty_context_id_raises() -> None:
+    embed = discord.Embed(title="x")
+    with pytest.raises(ValueError, match="empty"):
+        append_context_footer(embed, "")
+
+
+def test_returns_same_embed() -> None:
+    embed = discord.Embed(title="x")
+    result = append_context_footer(embed, "btd6_hub:main")
+    assert result is embed

--- a/tests/unit/cogs/test_btd6_context_id_contract.py
+++ b/tests/unit/cogs/test_btd6_context_id_contract.py
@@ -1,0 +1,212 @@
+"""Regression contract: every VM and stable-content embed surfaces a context_id.
+
+Two assertions:
+
+1. Every VM builder returns a view-model whose ``context.context_id``
+   matches the contract regex ``^btd6_[a-z_]+:[A-Za-z0-9_-]+$``.
+2. Every embed in the documented allowlist carries a
+   ``ctx=<context_id>`` segment in its footer. Embeds in the
+   exclusion list (transient operational / debug) intentionally
+   omit the footer.
+
+The allowlist + exclusion list are defined in this file. Renaming or
+adding an embed without updating one of the lists is an explicit
+test failure — surface the contract gap rather than silently drift.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from services.btd6_view_model_service import make_context_handle
+
+CONTEXT_ID_RE = re.compile(r"^btd6_[a-z_]+:[A-Za-z0-9_-]+$")
+FOOTER_CTX_RE = re.compile(r"(?: • )?ctx=(btd6_[a-z_]+:[A-Za-z0-9_-]+)")
+
+
+# ---------------------------------------------------------------------------
+# Allowlist — every embed below MUST carry a context_id footer.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_panel_embed_carries_context_id(monkeypatch) -> None:
+    from services import btd6_knowledge_service
+    from utils.db import btd6_sources as btd6_db
+    from views.btd6.panel import build_btd6_panel_embed
+
+    monkeypatch.setattr(
+        btd6_db,
+        "latest_fact_per_entity_kind",
+        AsyncMock(return_value={}),
+    )
+    monkeypatch.setattr(btd6_knowledge_service, "data_version", lambda: "1.0")
+    monkeypatch.setattr(btd6_knowledge_service, "game_version", lambda: "42.0")
+    monkeypatch.setattr(btd6_knowledge_service, "list_towers", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_heroes", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_maps", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_modes", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_rounds", lambda: [])
+
+    embed = await build_btd6_panel_embed()
+    match = FOOTER_CTX_RE.search(embed.footer.text or "")
+    assert match, "panel embed footer missing ctx= marker"
+    assert match.group(1) == "btd6_hub:main"
+
+
+@pytest.mark.asyncio
+async def test_status_embed_carries_context_id(monkeypatch) -> None:
+    from cogs.btd6._embeds import build_status_embed
+    from services import btd6_knowledge_service
+
+    monkeypatch.setattr(btd6_knowledge_service, "data_version", lambda: "1.0")
+    monkeypatch.setattr(btd6_knowledge_service, "game_version", lambda: "42.0")
+    monkeypatch.setattr(btd6_knowledge_service, "list_towers", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_heroes", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_maps", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_modes", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_rounds", lambda: [])
+    monkeypatch.setattr(
+        btd6_knowledge_service,
+        "fact_summary_by_kind",
+        AsyncMock(return_value=()),
+    )
+    embed = await build_status_embed()
+    match = FOOTER_CTX_RE.search(embed.footer.text or "")
+    assert match, "status embed footer missing ctx= marker"
+    assert match.group(1) == "btd6_status:global"
+
+
+@pytest.mark.asyncio
+async def test_source_health_embed_carries_context_id(monkeypatch) -> None:
+    from cogs.btd6._builders import build_source_health_embed
+    from services import btd6_source_registry
+
+    monkeypatch.setattr(
+        btd6_source_registry,
+        "list_health",
+        AsyncMock(return_value=[]),
+    )
+    embed = await build_source_health_embed()
+    match = FOOTER_CTX_RE.search(embed.footer.text or "")
+    assert match, "source health embed footer missing ctx= marker"
+    assert match.group(1) == "btd6_diagnostics:sources"
+
+
+@pytest.mark.asyncio
+async def test_latest_data_embed_carries_context_id(monkeypatch) -> None:
+    from cogs.btd6._builders import build_latest_data_embed
+    from services import btd6_source_registry
+    from utils.db import btd6_sources as btd6_db
+
+    monkeypatch.setattr(btd6_db, "search_facts", AsyncMock(return_value=[]))
+    monkeypatch.setattr(
+        btd6_source_registry,
+        "list_all",
+        AsyncMock(return_value=[]),
+    )
+    embed = await build_latest_data_embed()
+    match = FOOTER_CTX_RE.search(embed.footer.text or "")
+    assert match, "latest data embed footer missing ctx= marker"
+    assert match.group(1) == "btd6_diagnostics:latest_data"
+
+
+@pytest.mark.asyncio
+async def test_live_events_embed_carries_context_id(monkeypatch) -> None:
+    from cogs.btd6._builders import build_live_events_embed
+    from utils.db import btd6_sources as btd6_db
+
+    monkeypatch.setattr(btd6_db, "search_facts", AsyncMock(return_value=[]))
+    embed = await build_live_events_embed("race")
+    match = FOOTER_CTX_RE.search(embed.footer.text or "")
+    assert match, "live events embed footer missing ctx= marker"
+    assert match.group(1) == "btd6_race:list"
+
+
+def test_event_detail_embed_carries_context_id() -> None:
+    from cogs.btd6._builders import build_event_detail_embed
+
+    now = datetime.now(tz=timezone.utc)
+    row = {
+        "entity_kind": "btd6_race",
+        "entity_key": "R42",
+        "body_json": {"name": "Reversed Loop", "start_ms": 1, "end_ms": 2**40},
+        "fetched_at": now,
+    }
+    embed = build_event_detail_embed("btd6_race", "R42", row=row)
+    match = FOOTER_CTX_RE.search(embed.footer.text or "")
+    assert match, "event detail embed footer missing ctx= marker"
+    assert match.group(1) == "btd6_race:R42"
+
+
+# ---------------------------------------------------------------------------
+# VM builders — context_id matches regex
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hub_view_model_context_id(monkeypatch) -> None:
+    from services import btd6_knowledge_service
+    from services.btd6_view_model_service import build_hub_view_model
+    from utils.db import btd6_sources as btd6_db
+
+    monkeypatch.setattr(
+        btd6_db,
+        "latest_fact_per_entity_kind",
+        AsyncMock(return_value={}),
+    )
+    monkeypatch.setattr(btd6_knowledge_service, "data_version", lambda: "1.0")
+    monkeypatch.setattr(btd6_knowledge_service, "game_version", lambda: "42.0")
+    monkeypatch.setattr(btd6_knowledge_service, "list_towers", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_heroes", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_maps", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_modes", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_rounds", lambda: [])
+
+    vm = await build_hub_view_model()
+    assert CONTEXT_ID_RE.match(vm.context.context_id)
+
+
+def test_make_context_handle_round_trips_every_type() -> None:
+    """Every BTD6ContextType produces a regex-matching context_id."""
+    for ctx_type in (
+        "hub",
+        "race",
+        "boss",
+        "ct",
+        "odyssey",
+        "event",
+        "tower",
+        "hero",
+        "leaderboard",
+        "strategy",
+        "source",
+        "status",
+        "diagnostics",
+    ):
+        handle = make_context_handle(ctx_type, "test_key_42")  # type: ignore[arg-type]
+        assert CONTEXT_ID_RE.match(handle.context_id), (
+            f"context_id {handle.context_id!r} for type {ctx_type!r} "
+            f"does not match the contract regex"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Exclusion list — every embed below intentionally OMITS the footer.
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_summary_embed_omits_context_id() -> None:
+    """Transient operational embed — no Team Panel attach target."""
+    from cogs.btd6._builders import build_admin_refresh_summary_embed
+
+    embed = build_admin_refresh_summary_embed([])
+    text = embed.footer.text or ""
+    assert "ctx=" not in text, (
+        "Refresh summary embed should NOT carry a context_id footer — "
+        "it's a transient operation result, not a stable entity."
+    )

--- a/tests/unit/cogs/test_btd6_embed_snapshots.py
+++ b/tests/unit/cogs/test_btd6_embed_snapshots.py
@@ -1,0 +1,198 @@
+"""Byte-identical pins for BTD6 embed output (PR 1).
+
+The PR 1 acceptance bar is that every existing user-facing embed
+renders byte-identically after the duplicate-helper consolidation —
+except the panel's "Currently active" block, which now leads each row
+with a per-kind freshness badge. These tests pin the relevant
+invariants.
+
+Snapshot tests for embed text are intentionally light: we assert
+title, description, field count, key fragments, and footer rather than
+storing serialized snapshots. That keeps the tests resilient to
+formatter / dependency churn while still catching layout regressions.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+import discord
+import pytest
+
+# ---------------------------------------------------------------------------
+# source-health
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_source_health_embed_uses_consolidated_badge(monkeypatch) -> None:
+    from cogs.btd6._builders import build_source_health_embed
+    from services import btd6_source_registry
+    from services.btd6_source_registry import SourceHealth
+
+    now = datetime.now(tz=timezone.utc)
+    fake = SourceHealth(
+        source_id=1,
+        source_key="nk_btd6_races",
+        source_name="Races",
+        trust_tier=1,
+        enabled=True,
+        source_kind="api",
+        last_fetched_at=now - timedelta(hours=2),
+        fact_count=42,
+        bucket="fresh",
+    )
+    monkeypatch.setattr(
+        btd6_source_registry,
+        "list_health",
+        AsyncMock(return_value=[fake]),
+    )
+
+    embed = await build_source_health_embed(limit=25)
+    assert isinstance(embed, discord.Embed)
+    assert embed.title == "🐵 BTD6 — Source Health"
+    field_value = embed.fields[0].value or ""
+    # Bucket badge format pinned by _freshness_render.BUCKET_BADGE.
+    assert "🟢 fresh" in field_value
+    assert "facts=42" in field_value
+
+
+# ---------------------------------------------------------------------------
+# latest-data
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_latest_data_embed_renders_header(monkeypatch) -> None:
+    from cogs.btd6._builders import build_latest_data_embed
+    from services import btd6_source_registry
+    from utils.db import btd6_sources as btd6_db
+
+    monkeypatch.setattr(btd6_db, "search_facts", AsyncMock(return_value=[]))
+    monkeypatch.setattr(
+        btd6_source_registry,
+        "list_all",
+        AsyncMock(return_value=[]),
+    )
+
+    embed = await build_latest_data_embed()
+    assert embed.title == "🐵 BTD6 — Latest Data"
+    assert "No facts recorded yet." in (embed.description or "")
+
+
+# ---------------------------------------------------------------------------
+# live-events
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_live_events_embed_unknown_kind_red(monkeypatch) -> None:
+    from cogs.btd6._builders import build_live_events_embed
+
+    embed = await build_live_events_embed("not-a-kind")
+    assert embed.color == discord.Color.red()
+    assert "isn't a known live-event kind" in (embed.description or "")
+
+
+# ---------------------------------------------------------------------------
+# event-detail
+# ---------------------------------------------------------------------------
+
+
+def test_event_detail_unknown_renders_red() -> None:
+    from cogs.btd6._builders import build_event_detail_embed
+
+    embed = build_event_detail_embed("btd6_race", "missing", row=None)
+    assert embed.color == discord.Color.red()
+    assert "No event found" in (embed.description or "")
+
+
+def test_event_detail_window_field_present() -> None:
+    from cogs.btd6._builders import build_event_detail_embed
+
+    now = datetime.now(tz=timezone.utc)
+    row = {
+        "entity_kind": "btd6_race",
+        "entity_key": "R42",
+        "body_json": {
+            "name": "Reversed Loop",
+            "start_ms": int((now - timedelta(hours=1)).timestamp() * 1000),
+            "end_ms": int((now + timedelta(hours=2)).timestamp() * 1000),
+        },
+        "fetched_at": now,
+    }
+    embed = build_event_detail_embed("btd6_race", "R42", row=row)
+    names = [f.name for f in embed.fields]
+    assert "Window" in names
+    window_field = next(f for f in embed.fields if f.name == "Window")
+    # `format_window_status` byte-identity is verified in
+    # tests/unit/utils/test_btd6_event_window.py; here we only assert
+    # the field renders the canonical "status: ..." prefix.
+    assert "status:" in (window_field.value or "")
+
+
+# ---------------------------------------------------------------------------
+# status (build_status_embed uses _BUCKET_EMOJI via _freshness_render)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_status_embed_live_facts_use_consolidated_emoji(monkeypatch) -> None:
+    from cogs.btd6._embeds import build_status_embed
+    from services import btd6_knowledge_service
+    from services.btd6_knowledge_service import FactKindSummary
+
+    monkeypatch.setattr(btd6_knowledge_service, "data_version", lambda: "1.0")
+    monkeypatch.setattr(btd6_knowledge_service, "game_version", lambda: "42.0")
+    monkeypatch.setattr(btd6_knowledge_service, "list_towers", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_heroes", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_maps", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_modes", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_rounds", lambda: [])
+    monkeypatch.setattr(
+        btd6_knowledge_service,
+        "fact_summary_by_kind",
+        AsyncMock(
+            return_value=(
+                FactKindSummary(
+                    entity_kind="btd6_race",
+                    fact_count=5,
+                    last_fetched_at=datetime.now(tz=timezone.utc),
+                    bucket="fresh",
+                ),
+            ),
+        ),
+    )
+
+    embed = await build_status_embed()
+    # Live facts field should render the bucket emoji from the
+    # consolidated _freshness_render.BUCKET_EMOJI mapping.
+    live_field = next(f for f in embed.fields if "Live facts" in (f.name or ""))
+    assert "🟢" in (live_field.value or "")
+
+
+# ---------------------------------------------------------------------------
+# tower / hero embeds — basic shape
+# ---------------------------------------------------------------------------
+
+
+def test_towers_embed_title() -> None:
+    from cogs.btd6._embeds import build_towers_embed
+
+    embed = build_towers_embed()
+    assert embed.title == "🐵 BTD6 — Towers"
+
+
+def test_heroes_embed_title() -> None:
+    from cogs.btd6._embeds import build_heroes_embed
+
+    embed = build_heroes_embed()
+    assert embed.title == "🐵 BTD6 — Heroes"
+
+
+def test_modes_embed_title() -> None:
+    from cogs.btd6._embeds import build_modes_embed
+
+    embed = build_modes_embed()
+    assert embed.title == "🐵 BTD6 — Modes"

--- a/tests/unit/cogs/test_btd6_freshness_render.py
+++ b/tests/unit/cogs/test_btd6_freshness_render.py
@@ -1,0 +1,83 @@
+"""Coverage for ``cogs/btd6/_freshness_render.py``.
+
+The module is the single source of truth for the bucket emoji + warning
+copy that previously lived in three duplicate dicts.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cogs.btd6._freshness_render import (
+    BUCKET_BADGE,
+    BUCKET_EMOJI,
+    NEVER_FETCHED_COPY,
+    STALE_WARNING,
+    render_empty_state,
+    render_freshness_warning,
+)
+
+
+def test_bucket_emoji_covers_all_buckets() -> None:
+    assert set(BUCKET_EMOJI) == {"fresh", "aging", "stale", "never"}
+    assert BUCKET_EMOJI["fresh"] == "🟢"
+    assert BUCKET_EMOJI["aging"] == "🟡"
+    assert BUCKET_EMOJI["stale"] == "🔴"
+    assert BUCKET_EMOJI["never"] == "⚪"
+
+
+def test_bucket_badge_covers_all_buckets() -> None:
+    assert set(BUCKET_BADGE) == {"fresh", "aging", "stale", "never"}
+    assert BUCKET_BADGE["fresh"] == "🟢 fresh"
+    assert BUCKET_BADGE["aging"] == "🟡 aging"
+    assert BUCKET_BADGE["stale"] == "🔴 stale"
+    assert BUCKET_BADGE["never"] == "⚪ never"
+
+
+# ---------------------------------------------------------------------------
+# render_freshness_warning
+# ---------------------------------------------------------------------------
+
+
+def test_warning_none_for_fresh() -> None:
+    assert render_freshness_warning("fresh") is None
+
+
+def test_warning_none_for_aging() -> None:
+    # Aging is an operator-only signal in PR 1; not user-facing copy.
+    assert render_freshness_warning("aging") is None
+
+
+def test_warning_stale_copy() -> None:
+    assert render_freshness_warning("stale") == STALE_WARNING
+    assert "outdated" in STALE_WARNING
+    assert "24 hours" in STALE_WARNING
+
+
+def test_warning_never_copy() -> None:
+    assert render_freshness_warning("never") == NEVER_FETCHED_COPY
+    assert "has not been fetched" in NEVER_FETCHED_COPY
+
+
+# ---------------------------------------------------------------------------
+# render_empty_state
+# ---------------------------------------------------------------------------
+
+
+def test_empty_state_never_fetched_uses_locked_copy() -> None:
+    embed = render_empty_state("race", "never_fetched")
+    assert embed.description == NEVER_FETCHED_COPY
+    assert "race" in (embed.title or "").lower()
+
+
+def test_empty_state_no_active_uses_context_type() -> None:
+    embed = render_empty_state("boss", "no_active")
+    assert "No active boss right now." in (embed.description or "")
+
+
+def test_empty_state_color_is_greyple_for_both_reasons() -> None:
+    # Both empty states render in a neutral color so users don't read
+    # them as errors.
+    for reason in ("never_fetched", "no_active"):
+        embed = render_empty_state("race", reason)
+        assert embed.color is not None

--- a/tests/unit/cogs/test_btd6_panel_embed_currently_active.py
+++ b/tests/unit/cogs/test_btd6_panel_embed_currently_active.py
@@ -125,3 +125,52 @@ async def test_panel_embed_keeps_seed_reference_block(monkeypatch):
     value = ref_field.value or ""
     assert "towers" in value.lower()
     assert "heroes" in value.lower()
+
+
+# ---------------------------------------------------------------------------
+# PR 1 — per-kind freshness badges in 'Currently active'
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_panel_embed_renders_white_circle_for_never_kinds(monkeypatch):
+    """Every missing kind leads with ⚪ (never fetched)."""
+    from utils.db import btd6_sources as btd6_db
+
+    async def _empty(kinds):
+        return {}
+
+    monkeypatch.setattr(btd6_db, "latest_fact_per_entity_kind", _empty)
+
+    embed = await build_btd6_panel_embed()
+    active_field = next(f for f in embed.fields if "Currently active" in (f.name or ""))
+    value = active_field.value or ""
+    # All 5 kinds render with ⚪ since none have facts.
+    assert value.count("⚪") == 5
+
+
+@pytest.mark.asyncio
+async def test_panel_embed_renders_fresh_badge_for_recent_fact(monkeypatch):
+    """A recently-fetched row leads with 🟢."""
+    from utils.db import btd6_sources as btd6_db
+
+    async def _rows(kinds):
+        return {
+            "btd6_race": _fact_row(
+                entity_kind="btd6_race",
+                entity_key="Reversed_Loop",
+                name="Reversed Loop",
+                end_ms=_now_ms(48),
+            ),
+        }
+
+    monkeypatch.setattr(btd6_db, "latest_fact_per_entity_kind", _rows)
+
+    embed = await build_btd6_panel_embed()
+    active_field = next(f for f in embed.fields if "Currently active" in (f.name or ""))
+    value = active_field.value or ""
+    # Race kind has a recent fetch → 🟢. Other four kinds → ⚪.
+    assert "🟢" in value
+    assert value.count("⚪") == 4
+    # Existing layout invariants still hold.
+    assert "Reversed Loop" in value

--- a/tests/unit/cogs/test_btd6_stage.py
+++ b/tests/unit/cogs/test_btd6_stage.py
@@ -112,18 +112,14 @@ async def test_webhook_message_skipped(stage):
 async def test_system_message_skipped(stage):
     message = _make_message(msg_type=discord.MessageType.pins_add)
     await stage.process(_make_ctx(message))
-    assert (
-        stage.latest_skips(message.channel.id)[-1].reason == REASON_SYSTEM_MESSAGE
-    )
+    assert stage.latest_skips(message.channel.id)[-1].reason == REASON_SYSTEM_MESSAGE
 
 
 @pytest.mark.asyncio
 async def test_command_prefix_message_skipped(stage):
     message = _make_message(content="!btd6 status")
     await stage.process(_make_ctx(message, command_prefix="!"))
-    assert (
-        stage.latest_skips(message.channel.id)[-1].reason == REASON_COMMAND_PREFIX
-    )
+    assert stage.latest_skips(message.channel.id)[-1].reason == REASON_COMMAND_PREFIX
 
 
 @pytest.mark.asyncio
@@ -151,9 +147,7 @@ async def test_already_handled_metadata_skipped(stage, monkeypatch):
     message = _make_message()
     ctx = _make_ctx(message, metadata={"handled_by": "some_other_stage"})
     await stage.process(ctx)
-    assert (
-        stage.latest_skips(message.channel.id)[-1].reason == REASON_ALREADY_HANDLED
-    )
+    assert stage.latest_skips(message.channel.id)[-1].reason == REASON_ALREADY_HANDLED
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_btd6_refresh_shared_orchestration.py
+++ b/tests/unit/services/test_btd6_refresh_shared_orchestration.py
@@ -1,0 +1,162 @@
+"""Regression: prefix / slash / admin view share one refresh orchestration call.
+
+All three manual-refresh paths must route through
+``btd6_ingestion_service.refresh_source_or_dependencies`` with the
+same kwargs (``reason="manual"``, ``started_by_user_id`` set). Drift
+between these surfaces would let one form bypass audit / lock
+machinery — this test pins them together.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_prefix_refresh_calls_orchestration(monkeypatch) -> None:
+    from cogs.btd6 import _event_helpers
+    from services import btd6_ingestion_service, btd6_source_registry
+
+    fake_call = AsyncMock(return_value=[])
+    monkeypatch.setattr(
+        btd6_ingestion_service,
+        "refresh_source_or_dependencies",
+        fake_call,
+    )
+    monkeypatch.setattr(
+        btd6_source_registry,
+        "list_all",
+        AsyncMock(return_value=[]),
+    )
+
+    await _event_helpers.build_refresh_source_payload(
+        "nk_btd6_races",
+        started_by_user_id=999,
+        include_exception_detail=False,
+    )
+    fake_call.assert_awaited_once_with(
+        "nk_btd6_races",
+        reason="manual",
+        started_by_user_id=999,
+    )
+
+
+@pytest.mark.asyncio
+async def test_slash_refresh_uses_same_helper(monkeypatch) -> None:
+    """The slash form must call the same payload builder as the prefix form."""
+    from cogs.btd6 import _event_helpers
+    from services import btd6_ingestion_service, btd6_source_registry
+
+    fake_call = AsyncMock(return_value=[])
+    monkeypatch.setattr(
+        btd6_ingestion_service,
+        "refresh_source_or_dependencies",
+        fake_call,
+    )
+    monkeypatch.setattr(
+        btd6_source_registry,
+        "list_all",
+        AsyncMock(return_value=[]),
+    )
+
+    await _event_helpers.build_refresh_source_payload(
+        "nk_btd6_bosses",
+        started_by_user_id=12345,
+        include_exception_detail=True,
+    )
+    fake_call.assert_awaited_once_with(
+        "nk_btd6_bosses",
+        reason="manual",
+        started_by_user_id=12345,
+    )
+
+
+@pytest.mark.asyncio
+async def test_admin_view_refresh_calls_same_orchestration(monkeypatch) -> None:
+    """The admin Fetch Selected path must hit the same service entrypoint."""
+    from services import btd6_ingestion_service
+    from views.btd6 import admin_panel
+
+    fake_call = AsyncMock(return_value=[])
+    monkeypatch.setattr(
+        btd6_ingestion_service,
+        "refresh_source_or_dependencies",
+        fake_call,
+    )
+
+    # Build a minimal interaction stub that ``_run_fetch`` needs.
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = MagicMock()
+    interaction.user.id = 7
+    interaction.response = MagicMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.response.defer = AsyncMock()
+    interaction.edit_original_response = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+
+    await admin_panel._run_fetch(
+        interaction,
+        ["nk_btd6_races"],
+        user_id=7,
+        label="Fetch All",
+    )
+    fake_call.assert_awaited_once_with(
+        "nk_btd6_races",
+        reason="manual",
+        started_by_user_id=7,
+    )
+
+
+@pytest.mark.asyncio
+async def test_all_three_paths_pass_same_kwargs(monkeypatch) -> None:
+    """Hard assertion: prefix, slash twin, and admin view use identical kwargs."""
+    from cogs.btd6 import _event_helpers
+    from services import btd6_ingestion_service, btd6_source_registry
+    from views.btd6 import admin_panel
+
+    fake_call = AsyncMock(return_value=[])
+    monkeypatch.setattr(
+        btd6_ingestion_service,
+        "refresh_source_or_dependencies",
+        fake_call,
+    )
+    monkeypatch.setattr(
+        btd6_source_registry,
+        "list_all",
+        AsyncMock(return_value=[]),
+    )
+
+    await _event_helpers.build_refresh_source_payload(
+        "nk_btd6_races",
+        started_by_user_id=42,
+        include_exception_detail=False,
+    )
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = MagicMock(id=42)
+    interaction.response = MagicMock()
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.response.defer = AsyncMock()
+    interaction.edit_original_response = AsyncMock()
+    interaction.followup = MagicMock(send=AsyncMock())
+
+    await admin_panel._run_fetch(
+        interaction,
+        ["nk_btd6_races"],
+        user_id=42,
+        label="x",
+    )
+
+    calls = fake_call.await_args_list
+    assert len(calls) == 2
+    # Every call uses the same kwargs shape: positional source_key plus
+    # keyword reason="manual" + started_by_user_id=<int>.
+    for call in calls:
+        args, kwargs = call.args, call.kwargs
+        assert args == ("nk_btd6_races",)
+        assert kwargs["reason"] == "manual"
+        assert isinstance(kwargs["started_by_user_id"], int)

--- a/tests/unit/services/test_btd6_view_model_service.py
+++ b/tests/unit/services/test_btd6_view_model_service.py
@@ -1,0 +1,404 @@
+"""Coverage for ``services/btd6_view_model_service.py``.
+
+The VM service is the read sandwich layer between query services and
+embed builders. Tests focus on:
+
+* Context-handle construction (``make_context_handle`` regex contract).
+* Freshness threading through every VM (state propagation from
+  ``btd6_source_registry``).
+* Primitive-only inputs (no ``discord`` import in the module).
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+CONTEXT_ID_RE = re.compile(r"^btd6_[a-z_]+:[A-Za-z0-9_-]+$")
+
+
+# ---------------------------------------------------------------------------
+# Module-level invariants
+# ---------------------------------------------------------------------------
+
+
+def test_service_does_not_import_discord() -> None:
+    # The architecture rule is binding: services/btd6_view_model_service.py
+    # must NEVER import ``discord``. Verify by introspecting the cleanly
+    # imported module's globals — if ``discord`` were in scope, this fails.
+    import services.btd6_view_model_service as vm
+
+    importlib.reload(vm)
+    # ``vm`` should not have ``discord`` in its namespace
+    assert (
+        "discord" not in vm.__dict__
+    ), "btd6_view_model_service must not import discord (services→views boundary)"
+
+
+def test_service_does_not_import_views_or_cogs() -> None:
+    import services.btd6_view_model_service as vm
+
+    src = vm.__file__
+    assert src is not None
+    with open(src) as f:
+        text = f.read()
+    assert "from views" not in text
+    assert "from cogs" not in text
+    assert "import views" not in text
+    assert "import cogs" not in text
+
+
+# ---------------------------------------------------------------------------
+# Context-handle contract
+# ---------------------------------------------------------------------------
+
+
+def test_make_context_handle_basic() -> None:
+    from services.btd6_view_model_service import make_context_handle
+
+    handle = make_context_handle("race", "R123")
+    assert handle.context_id == "btd6_race:R123"
+    assert handle.context_type == "race"
+    assert CONTEXT_ID_RE.match(handle.context_id)
+
+
+def test_make_context_handle_sanitizes_unsafe_chars() -> None:
+    from services.btd6_view_model_service import make_context_handle
+
+    # Slashes, colons, spaces all collapse to underscores.
+    handle = make_context_handle("event", "Boss Rush: vol/2")
+    assert CONTEXT_ID_RE.match(handle.context_id)
+    assert handle.context_id == "btd6_event:Boss_Rush__vol_2"
+
+
+def test_make_context_handle_rejects_empty_key() -> None:
+    from services.btd6_view_model_service import make_context_handle
+
+    with pytest.raises(ValueError, match="empty"):
+        make_context_handle("tower", "")
+
+
+def test_make_context_handle_all_types_valid() -> None:
+    from services.btd6_view_model_service import make_context_handle
+
+    for kind in (
+        "hub",
+        "race",
+        "boss",
+        "ct",
+        "odyssey",
+        "event",
+        "tower",
+        "hero",
+        "leaderboard",
+        "strategy",
+        "source",
+        "status",
+        "diagnostics",
+    ):
+        handle = make_context_handle(kind, "main")  # type: ignore[arg-type]
+        assert CONTEXT_ID_RE.match(handle.context_id)
+
+
+# ---------------------------------------------------------------------------
+# Hub view-model
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_hub_view_model_emits_one_row_per_kind(monkeypatch) -> None:
+    """Even with zero facts, the hub VM yields all five kinds."""
+    from services import btd6_knowledge_service
+    from services.btd6_view_model_service import build_hub_view_model
+    from utils.db import btd6_sources as btd6_db
+
+    monkeypatch.setattr(
+        btd6_db, "latest_fact_per_entity_kind", AsyncMock(return_value={})
+    )
+    monkeypatch.setattr(btd6_knowledge_service, "data_version", lambda: "1.0")
+    monkeypatch.setattr(btd6_knowledge_service, "game_version", lambda: "42.0")
+    monkeypatch.setattr(btd6_knowledge_service, "list_towers", lambda: [object()] * 3)
+    monkeypatch.setattr(btd6_knowledge_service, "list_heroes", lambda: [object()] * 4)
+    monkeypatch.setattr(btd6_knowledge_service, "list_maps", lambda: [object()] * 5)
+    monkeypatch.setattr(btd6_knowledge_service, "list_modes", lambda: [object()] * 6)
+    monkeypatch.setattr(btd6_knowledge_service, "list_rounds", lambda: [object()] * 7)
+
+    vm = await build_hub_view_model()
+    assert vm.context.context_id == "btd6_hub:main"
+    assert vm.tower_count == 3
+    assert vm.hero_count == 4
+    assert {a.entity_kind for a in vm.active_events} == {
+        "btd6_race",
+        "btd6_boss",
+        "btd6_ct",
+        "btd6_odyssey",
+        "btd6_event",
+    }
+    # No rows → every kind is "never" with name=None.
+    for active in vm.active_events:
+        assert active.freshness.state == "never"
+        assert active.name is None
+        assert active.context is None
+
+
+@pytest.mark.asyncio
+async def test_build_hub_view_model_marks_fresh_for_recent_fact(monkeypatch) -> None:
+    from services import btd6_knowledge_service
+    from services.btd6_view_model_service import build_hub_view_model
+    from utils.db import btd6_sources as btd6_db
+
+    now = datetime.now(tz=timezone.utc)
+    monkeypatch.setattr(
+        btd6_db,
+        "latest_fact_per_entity_kind",
+        AsyncMock(
+            return_value={
+                "btd6_race": {
+                    "entity_kind": "btd6_race",
+                    "entity_key": "R42",
+                    "body_json": {"name": "Reversed Loop", "end_ms": 999_999_999_999},
+                    "fetched_at": now - timedelta(hours=2),
+                },
+            },
+        ),
+    )
+    monkeypatch.setattr(btd6_knowledge_service, "data_version", lambda: "1.0")
+    monkeypatch.setattr(btd6_knowledge_service, "game_version", lambda: "42.0")
+    monkeypatch.setattr(btd6_knowledge_service, "list_towers", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_heroes", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_maps", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_modes", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_rounds", lambda: [])
+
+    vm = await build_hub_view_model()
+    race = next(a for a in vm.active_events if a.entity_kind == "btd6_race")
+    assert race.name == "Reversed Loop"
+    assert race.freshness.state == "fresh"
+    assert race.context is not None
+    assert race.context.context_id == "btd6_race:R42"
+
+
+# ---------------------------------------------------------------------------
+# Staff diagnostics view-model
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_staff_diagnostics_context_global_when_no_guild(monkeypatch) -> None:
+    from services import btd6_knowledge_service
+    from services.btd6_view_model_service import (
+        build_staff_diagnostics_view_model,
+    )
+
+    monkeypatch.setattr(
+        btd6_knowledge_service,
+        "fact_summary_by_kind",
+        AsyncMock(return_value=()),
+    )
+    monkeypatch.setattr(btd6_knowledge_service, "data_version", lambda: "1.0")
+    monkeypatch.setattr(btd6_knowledge_service, "game_version", lambda: "42.0")
+    monkeypatch.setattr(btd6_knowledge_service, "list_towers", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_heroes", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_maps", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_modes", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_rounds", lambda: [])
+
+    vm = await build_staff_diagnostics_view_model()
+    assert vm.context.context_id == "btd6_status:global"
+
+
+@pytest.mark.asyncio
+async def test_staff_diagnostics_context_guild_id(monkeypatch) -> None:
+    from services import btd6_knowledge_service
+    from services.btd6_view_model_service import (
+        build_staff_diagnostics_view_model,
+    )
+
+    monkeypatch.setattr(
+        btd6_knowledge_service,
+        "fact_summary_by_kind",
+        AsyncMock(return_value=()),
+    )
+    monkeypatch.setattr(btd6_knowledge_service, "data_version", lambda: "1.0")
+    monkeypatch.setattr(btd6_knowledge_service, "game_version", lambda: "42.0")
+    monkeypatch.setattr(btd6_knowledge_service, "list_towers", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_heroes", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_maps", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_modes", lambda: [])
+    monkeypatch.setattr(btd6_knowledge_service, "list_rounds", lambda: [])
+
+    vm = await build_staff_diagnostics_view_model(guild_id=12345)
+    assert vm.context.context_id == "btd6_status:12345"
+
+
+# ---------------------------------------------------------------------------
+# Event list / detail view-models
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_event_list_view_model_caps_at_25(monkeypatch) -> None:
+    """The browser select cap is enforced at the VM layer."""
+    from services.btd6_view_model_service import build_event_list_view_model
+    from utils.db import btd6_sources as btd6_db
+
+    # 40 mock rows — VM must return ≤25 items and report total_count=40.
+    rows = [
+        {
+            "entity_kind": "btd6_race",
+            "entity_key": f"R{i}",
+            "body_json": {"name": f"Race {i}"},
+            "fetched_at": datetime.now(tz=timezone.utc),
+        }
+        for i in range(40)
+    ]
+    monkeypatch.setattr(btd6_db, "search_facts", AsyncMock(return_value=rows))
+
+    vm = await build_event_list_view_model("race")
+    assert len(vm.items) <= 25
+    assert vm.total_count == 40
+    # Every item carries a valid context handle.
+    for item in vm.items:
+        assert CONTEXT_ID_RE.match(item.context.context_id)
+        assert item.context.context_type == "race"
+
+
+@pytest.mark.asyncio
+async def test_event_list_accepts_short_or_long_kind(monkeypatch) -> None:
+    from services.btd6_view_model_service import build_event_list_view_model
+    from utils.db import btd6_sources as btd6_db
+
+    monkeypatch.setattr(btd6_db, "search_facts", AsyncMock(return_value=[]))
+
+    short_vm = await build_event_list_view_model("race")
+    long_vm = await build_event_list_view_model("btd6_race")
+    assert short_vm.kind == long_vm.kind == "race"
+    assert short_vm.entity_kind == long_vm.entity_kind == "btd6_race"
+
+
+@pytest.mark.asyncio
+async def test_event_detail_returns_none_when_no_fact(monkeypatch) -> None:
+    from services.btd6_view_model_service import build_event_detail_view_model
+    from utils.db import btd6_sources as btd6_db
+
+    monkeypatch.setattr(btd6_db, "search_facts", AsyncMock(return_value=[]))
+
+    vm = await build_event_detail_view_model("race", "missing")
+    assert vm is None
+
+
+@pytest.mark.asyncio
+async def test_event_detail_builds_full_vm(monkeypatch) -> None:
+    from services.btd6_view_model_service import build_event_detail_view_model
+    from utils.db import btd6_sources as btd6_db
+
+    now = datetime.now(tz=timezone.utc)
+    monkeypatch.setattr(
+        btd6_db,
+        "search_facts",
+        AsyncMock(
+            return_value=[
+                {
+                    "entity_kind": "btd6_race",
+                    "entity_key": "R42",
+                    "fact_type": "btd6.races_index",
+                    "body_json": {
+                        "name": "Reversed Loop",
+                        "start_ms": int(now.timestamp() * 1000) - 3_600_000,
+                        "end_ms": int(now.timestamp() * 1000) + 3_600_000,
+                    },
+                    "fetched_at": now,
+                },
+            ],
+        ),
+    )
+
+    vm = await build_event_detail_view_model("race", "R42")
+    assert vm is not None
+    assert vm.name == "Reversed Loop"
+    assert vm.context.context_id == "btd6_race:R42"
+    assert vm.window.state == "active"
+    assert vm.freshness.state == "fresh"
+
+
+# ---------------------------------------------------------------------------
+# Leaderboard list / detail
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_leaderboard_list_rejects_unknown_kind(monkeypatch) -> None:
+    from services.btd6_view_model_service import build_leaderboard_list_view_model
+
+    with pytest.raises(ValueError, match="must be 'race' or 'boss'"):
+        await build_leaderboard_list_view_model("odyssey")
+
+
+@pytest.mark.asyncio
+async def test_leaderboard_detail_context_format(monkeypatch) -> None:
+    from services import btd6_live_query_service as live
+    from services.btd6_view_model_service import build_leaderboard_detail_view_model
+
+    monkeypatch.setattr(live, "get_race_leaderboard", AsyncMock(return_value=()))
+    monkeypatch.setattr(live, "get_newest_active_race", AsyncMock(return_value=None))
+
+    vm = await build_leaderboard_detail_view_model("race", "R42")
+    assert vm.context.context_id == "btd6_leaderboard:race_R42"
+    assert vm.event_kind == "race"
+    assert vm.event_id == "R42"
+
+
+# ---------------------------------------------------------------------------
+# Tower / Hero list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tower_list_caps_at_25(monkeypatch) -> None:
+    from services import btd6_knowledge_service
+    from services.btd6_view_model_service import build_tower_list_view_model
+
+    class _Stub:
+        def __init__(self, ident: str) -> None:
+            self.id = ident
+            self.canonical = ident.title()
+            self.base_cost = 100
+            self.category = "primary"
+
+    monkeypatch.setattr(
+        btd6_knowledge_service,
+        "list_towers",
+        lambda: [_Stub(f"t{i}") for i in range(40)],
+    )
+
+    vm = await build_tower_list_view_model()
+    assert len(vm.items) <= 25
+    assert vm.total_count == 40
+    for item in vm.items:
+        assert CONTEXT_ID_RE.match(item.context.context_id)
+
+
+# ---------------------------------------------------------------------------
+# DataFreshness propagation
+# ---------------------------------------------------------------------------
+
+
+def test_data_freshness_default_stale_after_24h() -> None:
+    from services.btd6_view_model_service import (
+        STALE_AFTER_SECONDS,
+        DataFreshness,
+    )
+
+    fresh = DataFreshness(
+        state="fresh",
+        last_success_at=None,
+        last_attempt_at=None,
+        source_key="nk_btd6_races",
+    )
+    assert fresh.stale_after_seconds == 86_400
+    assert STALE_AFTER_SECONDS == 86_400

--- a/tests/unit/utils/test_btd6_body_coerce.py
+++ b/tests/unit/utils/test_btd6_body_coerce.py
@@ -1,0 +1,42 @@
+"""Coverage for the promoted ``coerce_body`` helper.
+
+Previously duplicated as ``_coerce_body`` in ``cogs/btd6/_builders.py``
+and ``services/btd6_live_query_service.py``. Both call sites now import
+from ``utils.btd6.body_coerce``.
+"""
+
+from __future__ import annotations
+
+from utils.btd6.body_coerce import coerce_body
+
+
+def test_dict_passes_through() -> None:
+    payload = {"a": 1, "b": "two"}
+    assert coerce_body(payload) is payload
+
+
+def test_legacy_double_encoded_string_decodes() -> None:
+    assert coerce_body('{"name":"Reversed Loop","end_ms":12345}') == {
+        "name": "Reversed Loop",
+        "end_ms": 12345,
+    }
+
+
+def test_malformed_json_string_returns_empty_dict() -> None:
+    assert coerce_body("not json") == {}
+
+
+def test_non_mapping_json_returns_empty_dict() -> None:
+    # `[1, 2, 3]` is valid JSON but not a mapping; we cannot project
+    # it onto a dict so the helper falls back to ``{}``.
+    assert coerce_body("[1, 2, 3]") == {}
+    assert coerce_body("42") == {}
+    assert coerce_body('"a string"') == {}
+
+
+def test_none_returns_empty_dict() -> None:
+    assert coerce_body(None) == {}
+
+
+def test_int_returns_empty_dict() -> None:
+    assert coerce_body(123) == {}

--- a/tests/unit/utils/test_btd6_event_window.py
+++ b/tests/unit/utils/test_btd6_event_window.py
@@ -1,0 +1,178 @@
+"""Coverage for the consolidated event-window helpers.
+
+These functions replace four previously-duplicated helpers (``_ms_to_human``,
+``_event_window``, ``_format_window_status``, ``_format_ends_relative``).
+The tests pin byte-identical output for each surface so the embed
+builders that consume them stay stable.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from utils.btd6.event_window import (
+    WindowStatus,
+    format_ends_relative,
+    format_ms_human,
+    format_window,
+    format_window_range,
+    format_window_status,
+)
+
+_NOW = datetime(2026, 5, 27, 12, 0, tzinfo=timezone.utc)
+
+
+def _ms(dt: datetime) -> int:
+    return int(dt.timestamp() * 1000)
+
+
+# ---------------------------------------------------------------------------
+# format_ms_human
+# ---------------------------------------------------------------------------
+
+
+def test_format_ms_human_renders_utc_string() -> None:
+    moment = datetime(2026, 1, 2, 3, 4, tzinfo=timezone.utc)
+    assert format_ms_human(_ms(moment)) == "2026-01-02 03:04 UTC"
+
+
+@pytest.mark.parametrize("bad", [None, 0, -1, "abc", float("nan")])
+def test_format_ms_human_returns_dash_for_bad_inputs(bad) -> None:
+    assert format_ms_human(bad) == "—"
+
+
+# ---------------------------------------------------------------------------
+# format_window_range
+# ---------------------------------------------------------------------------
+
+
+def test_format_window_range_both_present() -> None:
+    a = _ms(datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc))
+    b = _ms(datetime(2026, 1, 2, 0, 0, tzinfo=timezone.utc))
+    assert format_window_range(a, b) == "2026-01-01 00:00 UTC → 2026-01-02 00:00 UTC"
+
+
+def test_format_window_range_both_missing_returns_dash() -> None:
+    assert format_window_range(None, None) == "—"
+    assert format_window_range(0, 0) == "—"
+
+
+def test_format_window_range_one_missing_renders_partial() -> None:
+    a = _ms(datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc))
+    assert format_window_range(a, None) == "2026-01-01 00:00 UTC → —"
+
+
+# ---------------------------------------------------------------------------
+# format_window_status (byte-identical to the previous _format_window_status)
+# ---------------------------------------------------------------------------
+
+
+def test_format_window_status_unknown_when_no_data() -> None:
+    assert format_window_status({}, now=_NOW) == "status: `unknown`"
+
+
+def test_format_window_status_upcoming() -> None:
+    start = _NOW + timedelta(days=1, hours=4)
+    body = {"start_ms": _ms(start), "end_ms": _ms(start + timedelta(hours=2))}
+    assert (
+        format_window_status(body, now=_NOW) == "status: `upcoming` · starts in 1d 4h"
+    )
+
+
+def test_format_window_status_live_with_end() -> None:
+    end = _NOW + timedelta(days=1, hours=4)
+    body = {"start_ms": _ms(_NOW - timedelta(hours=1)), "end_ms": _ms(end)}
+    assert format_window_status(body, now=_NOW) == "status: `live` · ends in 1d 4h"
+
+
+def test_format_window_status_live_without_end() -> None:
+    body = {"start_ms": _ms(_NOW - timedelta(hours=1))}
+    assert format_window_status(body, now=_NOW) == "status: `live`"
+
+
+def test_format_window_status_ended() -> None:
+    body = {
+        "start_ms": _ms(_NOW - timedelta(days=2)),
+        "end_ms": _ms(_NOW - timedelta(hours=1)),
+    }
+    assert format_window_status(body, now=_NOW) == "status: `ended`"
+
+
+# ---------------------------------------------------------------------------
+# format_ends_relative (byte-identical to the previous _format_ends_relative)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", [None, 0, -1, "abc"])
+def test_format_ends_relative_empty_for_bad_input(bad) -> None:
+    assert format_ends_relative(bad, now=_NOW) == ""
+
+
+def test_format_ends_relative_ended() -> None:
+    end = _NOW - timedelta(hours=1)
+    assert format_ends_relative(_ms(end), now=_NOW) == "· ended"
+
+
+def test_format_ends_relative_minutes() -> None:
+    end = _NOW + timedelta(minutes=42)
+    assert format_ends_relative(_ms(end), now=_NOW) == "· ends 42m"
+
+
+def test_format_ends_relative_hours() -> None:
+    end = _NOW + timedelta(hours=5)
+    assert format_ends_relative(_ms(end), now=_NOW) == "· ends 5h"
+
+
+def test_format_ends_relative_days() -> None:
+    end = _NOW + timedelta(days=3)
+    assert format_ends_relative(_ms(end), now=_NOW) == "· ends 3d"
+
+
+# ---------------------------------------------------------------------------
+# format_window — typed canonical API
+# ---------------------------------------------------------------------------
+
+
+def test_format_window_unknown() -> None:
+    status = format_window(None, None, now=_NOW)
+    assert isinstance(status, WindowStatus)
+    assert status.state == "unknown"
+    assert status.relative == ""
+    assert status.human == "status: `unknown`"
+    assert status.start_iso == "—"
+    assert status.end_iso == "—"
+
+
+def test_format_window_upcoming() -> None:
+    start = _NOW + timedelta(days=1)
+    end = start + timedelta(hours=4)
+    status = format_window(_ms(start), _ms(end), now=_NOW)
+    assert status.state == "upcoming"
+    assert "starts in" in status.human
+
+
+def test_format_window_active() -> None:
+    end = _NOW + timedelta(hours=5)
+    status = format_window(_ms(_NOW - timedelta(hours=1)), _ms(end), now=_NOW)
+    assert status.state == "active"
+    assert status.relative == "· ends 5h"
+
+
+def test_format_window_ended() -> None:
+    status = format_window(
+        _ms(_NOW - timedelta(days=2)),
+        _ms(_NOW - timedelta(hours=1)),
+        now=_NOW,
+    )
+    assert status.state == "ended"
+    assert status.relative == "· ended"
+    assert status.human == "status: `ended`"
+
+
+def test_format_window_active_without_end_is_live() -> None:
+    status = format_window(_ms(_NOW - timedelta(hours=1)), None, now=_NOW)
+    assert status.state == "active"
+    assert status.human == "status: `live`"
+    assert status.relative == ""

--- a/tests/unit/views/btd6/test_btd6_panel_legacy_custom_ids.py
+++ b/tests/unit/views/btd6/test_btd6_panel_legacy_custom_ids.py
@@ -1,0 +1,80 @@
+"""Pin every historical ``btd6:*`` custom_id on the persistent panel.
+
+Discord does not re-render existing anchor messages at restart — the
+rendered button row is whatever was posted historically; routing
+matches by ``custom_id``. So even after the PR 2 hub refactor, every
+legacy custom_id must still be present on :class:`BTD6PanelView` or
+clicks on old anchors fall through to "interaction failed".
+
+This regression test catches accidental removal during future layout
+changes.
+"""
+
+from __future__ import annotations
+
+from views.btd6.panel import BTD6PanelView
+
+# Legacy custom_ids that exist on production anchors. NEVER remove
+# without a migration that re-renders all anchor messages.
+_LEGACY_CUSTOM_IDS = frozenset(
+    {
+        "btd6:ask",
+        "btd6:towers",
+        "btd6:heroes",
+        "btd6:modes",
+        "btd6:status",
+        "btd6:admin",
+    },
+)
+
+# New custom_ids introduced by PR 2.
+_NEW_CUSTOM_IDS = frozenset(
+    {
+        "btd6:events",
+        "btd6:leaderboards",
+    },
+)
+
+
+def _view_custom_ids() -> set[str]:
+    view = BTD6PanelView()
+    return {c.custom_id for c in view.children if getattr(c, "custom_id", None)}
+
+
+def test_zero_arg_construction() -> None:
+    # message_anchor_manager.restore_anchors calls view_cls() at startup
+    # with zero args — the persistent-view constructor must remain
+    # zero-arg or every BTD6 anchor goes stale on restart.
+    view = BTD6PanelView()
+    assert view is not None
+
+
+def test_every_legacy_custom_id_present() -> None:
+    ids = _view_custom_ids()
+    missing = _LEGACY_CUSTOM_IDS - ids
+    assert (
+        not missing
+    ), f"Removed legacy custom_ids would break existing anchors: {missing}"
+
+
+def test_every_new_custom_id_present() -> None:
+    ids = _view_custom_ids()
+    missing = _NEW_CUSTOM_IDS - ids
+    assert not missing, f"Missing PR 2 custom_ids: {missing}"
+
+
+def test_subsystem_name_pinned() -> None:
+    # The persistent-view registry routes on SUBSYSTEM. Renaming it
+    # would orphan every BTD6 anchor.
+    assert BTD6PanelView.SUBSYSTEM == "btd6"
+
+
+def test_no_unknown_custom_ids() -> None:
+    # Any new ID introduced after PR 2 should be explicitly added to
+    # the regression sets above so future readers see the scope grow.
+    ids = _view_custom_ids()
+    extra = ids - (_LEGACY_CUSTOM_IDS | _NEW_CUSTOM_IDS)
+    assert not extra, (
+        f"Undeclared custom_ids on BTD6PanelView: {extra}. Add them to "
+        "_LEGACY_CUSTOM_IDS or _NEW_CUSTOM_IDS in this test file."
+    )

--- a/tests/unit/views/btd6/test_hero_browser_view.py
+++ b/tests/unit/views/btd6/test_hero_browser_view.py
@@ -1,0 +1,73 @@
+"""Tests for the HeroBrowserView ephemeral drill-down."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import discord
+
+from services.btd6_view_model_service import (
+    ContextHandle,
+    HeroListItem,
+    HeroListViewModel,
+)
+from views.btd6.hero_browser_view import (
+    HeroBrowserView,
+    HeroDetailView,
+    build_hero_list_embed,
+)
+
+
+def _stub_user() -> discord.User:
+    user = MagicMock(spec=discord.User)
+    user.id = 12345
+    return user
+
+
+def _item(hero_id: str) -> HeroListItem:
+    return HeroListItem(
+        hero_id=hero_id,
+        canonical=hero_id.title(),
+        base_cost=900,
+        description=f"{hero_id} description.",
+        context=ContextHandle(
+            context_id=f"btd6_hero:{hero_id}",
+            context_type="hero",
+        ),
+    )
+
+
+def _vm(items: list[HeroListItem], total: int | None = None) -> HeroListViewModel:
+    return HeroListViewModel(
+        items=tuple(items),
+        total_count=total if total is not None else len(items),
+        context=ContextHandle(context_id="btd6_hero:list", context_type="hero"),
+    )
+
+
+def test_view_starts_empty_then_set_vm_adds_select() -> None:
+    view = HeroBrowserView(_stub_user())
+    assert len(view.children) == 0
+    view.set_vm(_vm([_item("quincy"), _item("sauda")]))
+    selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
+    assert len(selects) == 1
+
+
+def test_select_caps_at_25_options() -> None:
+    items = [_item(f"h{i}") for i in range(40)]
+    view = HeroBrowserView(_stub_user())
+    view.set_vm(_vm(items, total=40))
+    sel = next(c for c in view.children if isinstance(c, discord.ui.Select))
+    assert len(sel.options) <= 25
+
+
+def test_list_embed_title() -> None:
+    embed = build_hero_list_embed(_vm([_item("quincy")]))
+    assert embed.title == "🐵 BTD6 — Heroes"
+
+
+def test_views_are_hubview_subclasses() -> None:
+    from views.base import HubView
+
+    assert issubclass(HeroBrowserView, HubView)
+    assert issubclass(HeroDetailView, HubView)

--- a/tests/unit/views/btd6/test_leaderboard_browser_view.py
+++ b/tests/unit/views/btd6/test_leaderboard_browser_view.py
@@ -1,0 +1,153 @@
+"""Tests for the LeaderboardBrowserView three-step drill-down."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import discord
+
+from services.btd6_view_model_service import (
+    ContextHandle,
+    DataFreshness,
+    LeaderboardDetailViewModel,
+    LeaderboardListItem,
+    LeaderboardListViewModel,
+)
+from utils.btd6.event_window import format_window
+from views.btd6.leaderboard_browser_view import (
+    LeaderboardBrowserView,
+    LeaderboardDetailView,
+    LeaderboardKindListView,
+    build_event_list_embed,
+    build_kind_picker_embed,
+    build_leaderboard_detail_embed,
+)
+
+
+def _stub_user() -> discord.User:
+    user = MagicMock(spec=discord.User)
+    user.id = 12345
+    return user
+
+
+def _item(event_id: str, kind: str = "race") -> LeaderboardListItem:
+    return LeaderboardListItem(
+        event_kind=kind,
+        event_id=event_id,
+        event_name=f"{kind.title()} {event_id}",
+        window=format_window(None, None),
+        context=ContextHandle(
+            context_id=f"btd6_leaderboard:{kind}_{event_id}",
+            context_type="leaderboard",
+        ),
+    )
+
+
+def _list_vm(
+    items: list[LeaderboardListItem], total: int | None = None
+) -> LeaderboardListViewModel:
+    return LeaderboardListViewModel(
+        event_kind="race",
+        items=tuple(items),
+        total_count=total if total is not None else len(items),
+        freshness=DataFreshness(
+            state="fresh",
+            last_success_at=datetime.now(tz=timezone.utc),
+            last_attempt_at=datetime.now(tz=timezone.utc),
+            source_key="nk_btd6_races",
+        ),
+        context=ContextHandle(
+            context_id="btd6_leaderboard:race_list",
+            context_type="leaderboard",
+        ),
+    )
+
+
+def test_browser_view_has_kind_select() -> None:
+    view = LeaderboardBrowserView(_stub_user())
+    selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
+    assert len(selects) == 1
+    values = {opt.value for opt in selects[0].options}
+    assert values == {"race", "boss"}
+
+
+def test_kind_list_view_after_set_vm_has_two_selects() -> None:
+    view = LeaderboardKindListView(_stub_user())
+    view.set_vm("race", _list_vm([_item("R1"), _item("R2")]))
+    selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
+    assert len(selects) == 2
+
+
+def test_kind_list_select_caps_at_25() -> None:
+    items = [_item(f"R{i}") for i in range(40)]
+    view = LeaderboardKindListView(_stub_user())
+    view.set_vm("race", _list_vm(items, total=40))
+    event_selects = [
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Select)
+        and c.placeholder
+        and "leaderboard" in c.placeholder
+    ]
+    assert event_selects
+    assert len(event_selects[0].options) <= 25
+
+
+def test_kind_picker_embed_title() -> None:
+    embed = build_kind_picker_embed()
+    assert "Leaderboards" in (embed.title or "")
+
+
+def test_list_embed_renders_freshness_warning() -> None:
+    items = [_item("R1")]
+    vm = LeaderboardListViewModel(
+        event_kind="race",
+        items=tuple(items),
+        total_count=1,
+        freshness=DataFreshness(
+            state="stale",
+            last_success_at=None,
+            last_attempt_at=None,
+            source_key="nk_btd6_races",
+        ),
+        context=ContextHandle(
+            context_id="btd6_leaderboard:race_list",
+            context_type="leaderboard",
+        ),
+    )
+    embed = build_event_list_embed(vm)
+    field = next(
+        (f for f in embed.fields if "Data freshness" in (f.name or "")),
+        None,
+    )
+    assert field is not None
+
+
+def test_detail_embed_handles_empty_rows() -> None:
+    vm = LeaderboardDetailViewModel(
+        event_kind="race",
+        event_id="R1",
+        event_name="Race R1",
+        rows=(),
+        freshness=DataFreshness(
+            state="fresh",
+            last_success_at=datetime.now(tz=timezone.utc),
+            last_attempt_at=datetime.now(tz=timezone.utc),
+            source_key="nk_btd6_races",
+        ),
+        context=ContextHandle(
+            context_id="btd6_leaderboard:race_R1",
+            context_type="leaderboard",
+        ),
+    )
+    embed = build_leaderboard_detail_embed(vm)
+    assert "No leaderboard rows stored" in (embed.description or "")
+
+
+def test_views_are_hubview_subclasses() -> None:
+    from views.base import HubView
+
+    assert issubclass(LeaderboardBrowserView, HubView)
+    assert issubclass(LeaderboardKindListView, HubView)
+    assert issubclass(LeaderboardDetailView, HubView)

--- a/tests/unit/views/btd6/test_live_events_view.py
+++ b/tests/unit/views/btd6/test_live_events_view.py
@@ -1,0 +1,135 @@
+"""Tests for the LiveEventsBrowserView ephemeral drill-down."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import discord
+
+from services.btd6_view_model_service import (
+    ContextHandle,
+    DataFreshness,
+    EventListItem,
+    EventListViewModel,
+)
+from utils.btd6.event_window import format_window
+from views.btd6.live_events_view import (
+    EventDetailView,
+    LiveEventsBrowserView,
+    build_event_list_embed,
+    build_kind_picker_embed,
+)
+
+
+def _stub_user() -> discord.User:
+    user = MagicMock(spec=discord.User)
+    user.id = 12345
+    return user
+
+
+def _item(entity_key: str, kind: str = "race") -> EventListItem:
+    return EventListItem(
+        entity_kind=f"btd6_{kind}",
+        entity_key=entity_key,
+        name=f"{kind.title()} {entity_key}",
+        window=format_window(None, None),
+        context=ContextHandle(
+            context_id=f"btd6_{kind}:{entity_key}",
+            context_type=kind,
+        ),
+    )
+
+
+def _vm(
+    kind: str, items: list[EventListItem], total: int | None = None
+) -> EventListViewModel:
+    return EventListViewModel(
+        kind=kind,
+        entity_kind=f"btd6_{kind}",
+        items=tuple(items),
+        total_count=total if total is not None else len(items),
+        freshness=DataFreshness(
+            state="fresh",
+            last_success_at=datetime.now(tz=timezone.utc),
+            last_attempt_at=datetime.now(tz=timezone.utc),
+            source_key=f"nk_btd6_{kind}s",
+        ),
+        context=ContextHandle(context_id=f"btd6_{kind}:list", context_type=kind),
+    )
+
+
+def test_kind_picker_starts_with_only_kind_select() -> None:
+    view = LiveEventsBrowserView(_stub_user())
+    selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
+    assert len(selects) == 1
+    assert selects[0].options[0].value in {"race", "boss", "ct", "odyssey", "event"}
+
+
+def test_set_kind_adds_event_select() -> None:
+    view = LiveEventsBrowserView(_stub_user())
+    view.set_kind("race", _vm("race", [_item("R1"), _item("R2")]))
+    selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
+    # Should now have BOTH the kind picker and the event select.
+    assert len(selects) == 2
+
+
+def test_event_select_caps_at_25() -> None:
+    items = [_item(f"R{i}") for i in range(40)]
+    view = LiveEventsBrowserView(_stub_user())
+    view.set_kind("race", _vm("race", items, total=40))
+    event_selects = [
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Select)
+        and c.placeholder
+        and "event to view" in c.placeholder
+    ]
+    assert event_selects, "expected event select after set_kind"
+    assert len(event_selects[0].options) <= 25
+
+
+def test_kind_picker_embed_title() -> None:
+    embed = build_kind_picker_embed()
+    assert embed.title == "🐵 BTD6 — Live Events"
+
+
+def test_list_embed_renders_warning_when_stale() -> None:
+    items = [_item("R1")]
+    vm = EventListViewModel(
+        kind="race",
+        entity_kind="btd6_race",
+        items=tuple(items),
+        total_count=1,
+        freshness=DataFreshness(
+            state="stale",
+            last_success_at=None,
+            last_attempt_at=None,
+            source_key="nk_btd6_races",
+        ),
+        context=ContextHandle(context_id="btd6_race:list", context_type="race"),
+    )
+    embed = build_event_list_embed(vm)
+    field = next(
+        (f for f in embed.fields if "Data freshness" in (f.name or "")),
+        None,
+    )
+    assert field is not None
+    assert "outdated" in (field.value or "")
+
+
+def test_list_embed_renders_empty_state_when_no_items() -> None:
+    vm = _vm("race", [])
+    embed = build_event_list_embed(vm)
+    no_events_field = next(
+        (f for f in embed.fields if f.name == "No events"),
+        None,
+    )
+    assert no_events_field is not None
+
+
+def test_views_are_hubview_subclasses() -> None:
+    from views.base import HubView
+
+    assert issubclass(LiveEventsBrowserView, HubView)
+    assert issubclass(EventDetailView, HubView)

--- a/tests/unit/views/btd6/test_strategy_review.py
+++ b/tests/unit/views/btd6/test_strategy_review.py
@@ -443,7 +443,8 @@ async def test_refresh_failure_after_successful_mutation_uses_followup(monkeypat
 
 async def test_missing_strategy_refresh_uses_followup(monkeypatch):
     """If the strategy row is gone post-mutation, the user gets a
-    clean ephemeral acknowledgement via followup.send."""
+    clean ephemeral acknowledgement via followup.send.
+    """
 
     async def _ok(strategy_id, **kw):
         result = MagicMock()

--- a/tests/unit/views/btd6/test_strategy_submit.py
+++ b/tests/unit/views/btd6/test_strategy_submit.py
@@ -83,7 +83,8 @@ async def test_submit_calls_chokepoint(monkeypatch):
 @pytest.mark.asyncio
 async def test_submit_requires_guild_context():
     """The guild-context check is synchronous and runs BEFORE defer,
-    so it still uses interaction.response.send_message."""
+    so it still uses interaction.response.send_message.
+    """
     modal = StrategySubmitModal()
     _set_inputs(modal, title="x", summary="y", map="", mode="", hero="")
     interaction = _interaction(guild_id=0)
@@ -100,7 +101,8 @@ async def test_submit_requires_guild_context():
 @pytest.mark.asyncio
 async def test_submit_surfaces_validation_error(monkeypatch):
     """Validation errors come out via safe_followup (post-defer),
-    surfacing the typed exc message but not the class name."""
+    surfacing the typed exc message but not the class name.
+    """
 
     async def _submit(**_kw):
         raise btd6_strategy_mutation.InvalidStrategyValueError("missing field")

--- a/tests/unit/views/btd6/test_strategy_view_boundaries.py
+++ b/tests/unit/views/btd6/test_strategy_view_boundaries.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-_STRATEGY_VIEW_DIR = (
-    Path(__file__).resolve().parents[4] / "disbot" / "views" / "btd6"
-)
+_STRATEGY_VIEW_DIR = Path(__file__).resolve().parents[4] / "disbot" / "views" / "btd6"
 
 
 _FORBIDDEN_DB_WRITES = (
@@ -25,16 +23,13 @@ _FORBIDDEN_AI_TABLES = (
 
 
 def _strategy_view_files() -> list[Path]:
-    return [
-        p
-        for p in _STRATEGY_VIEW_DIR.glob("strategy*.py")
-        if p.is_file()
-    ]
+    return [p for p in _STRATEGY_VIEW_DIR.glob("strategy*.py") if p.is_file()]
 
 
 def test_no_strategy_view_imports_db_write_helpers():
     """Strategy views must route every write through
-    ``btd6_strategy_mutation``."""
+    ``btd6_strategy_mutation``.
+    """
     for path in _strategy_view_files():
         src = path.read_text()
         for sym in _FORBIDDEN_DB_WRITES:
@@ -46,20 +41,22 @@ def test_no_strategy_view_imports_db_write_helpers():
 
 def test_no_strategy_view_references_ai_policy_tables():
     """Strategy views are BTD6 territory; AI policy tables are
-    off-limits."""
+    off-limits.
+    """
     for path in _strategy_view_files():
         src = path.read_text()
         for sym in _FORBIDDEN_AI_TABLES:
-            assert sym not in src, (
-                f"{path.name} must not reference AI policy table {sym}"
-            )
+            assert (
+                sym not in src
+            ), f"{path.name} must not reference AI policy table {sym}"
 
 
 def test_no_strategy_view_invokes_ai_approve_from_ui():
     """``ai_approve_guild`` is the system-actor approval path; it
-    must not be reachable from a user-facing UI."""
+    must not be reachable from a user-facing UI.
+    """
     for path in _strategy_view_files():
         src = path.read_text()
-        assert "ai_approve_guild" not in src, (
-            f"{path.name} must not invoke ai_approve_guild from the UI"
-        )
+        assert (
+            "ai_approve_guild" not in src
+        ), f"{path.name} must not invoke ai_approve_guild from the UI"

--- a/tests/unit/views/btd6/test_tower_browser_view.py
+++ b/tests/unit/views/btd6/test_tower_browser_view.py
@@ -1,0 +1,104 @@
+"""Tests for the TowerBrowserView ephemeral drill-down."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import discord
+
+from services.btd6_view_model_service import (
+    ContextHandle,
+    TowerListItem,
+    TowerListViewModel,
+)
+from views.btd6.tower_browser_view import (
+    TowerBrowserView,
+    TowerDetailView,
+    build_tower_list_embed,
+)
+
+
+def _stub_user() -> discord.User:
+    user = MagicMock(spec=discord.User)
+    user.id = 12345
+    return user
+
+
+def _vm(items: list[TowerListItem], total: int | None = None) -> TowerListViewModel:
+    return TowerListViewModel(
+        items=tuple(items),
+        total_count=total if total is not None else len(items),
+        context=ContextHandle(context_id="btd6_tower:list", context_type="tower"),
+    )
+
+
+def _item(tower_id: str) -> TowerListItem:
+    return TowerListItem(
+        tower_id=tower_id,
+        canonical=tower_id.replace("_", " ").title(),
+        base_cost=100,
+        category="primary",
+        context=ContextHandle(
+            context_id=f"btd6_tower:{tower_id}",
+            context_type="tower",
+        ),
+    )
+
+
+def test_view_starts_empty_then_set_vm_adds_select() -> None:
+    view = TowerBrowserView(_stub_user())
+    assert len(view.children) == 0
+    vm = _vm([_item("dart_monkey"), _item("sniper_monkey")])
+    view.set_vm(vm)
+    selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
+    assert len(selects) == 1
+
+
+def test_select_caps_at_25_options() -> None:
+    items = [_item(f"t{i}") for i in range(40)]
+    vm = _vm(items, total=40)
+    view = TowerBrowserView(_stub_user())
+    view.set_vm(vm)
+    sel = next(c for c in view.children if isinstance(c, discord.ui.Select))
+    assert len(sel.options) <= 25
+
+
+def test_empty_vm_renders_disabled_placeholder() -> None:
+    vm = _vm([], total=0)
+    view = TowerBrowserView(_stub_user())
+    view.set_vm(vm)
+    sel = next(c for c in view.children if isinstance(c, discord.ui.Select))
+    assert len(sel.options) >= 1
+    assert sel.options[0].value == "__none__"
+
+
+def test_list_embed_title() -> None:
+    vm = _vm([_item("dart_monkey")])
+    embed = build_tower_list_embed(vm)
+    assert embed.title == "🐵 BTD6 — Towers"
+    assert "1 of 1 towers" in (embed.description or "")
+
+
+def test_list_embed_pagination_hint_when_truncated() -> None:
+    items = [_item(f"t{i}") for i in range(25)]
+    vm = _vm(items, total=40)
+    embed = build_tower_list_embed(vm)
+    pagination_field = next(
+        (f for f in embed.fields if "Pagination" in (f.name or "")),
+        None,
+    )
+    assert pagination_field is not None
+    assert "25 options" in (pagination_field.value or "")
+
+
+def test_detail_view_has_no_children_at_init() -> None:
+    # Children are added by the select callback (attach_back_button).
+    view = TowerDetailView(_stub_user())
+    assert len(view.children) == 0
+
+
+def test_views_are_hubview_subclasses() -> None:
+    from views.base import HubView
+
+    assert issubclass(TowerBrowserView, HubView)
+    assert issubclass(TowerDetailView, HubView)

--- a/tests/unit/views/test_btd6_panel_interaction_safety.py
+++ b/tests/unit/views/test_btd6_panel_interaction_safety.py
@@ -54,15 +54,33 @@ def _collect_awaits_in_source_order(node: ast.AST) -> list[ast.Await]:
     return out
 
 
+# Modal-triggering callbacks are exempt: they MUST NOT call safe_defer
+# before send_modal (the modal needs the initial response slot). The
+# Ask button is the canonical example.
+_MODAL_EXEMPT = frozenset(
+    {
+        ("BTD6PanelView", "ask_btn"),
+    },
+)
+
+
 @pytest.mark.parametrize(
     "class_name,method_name",
     [
         ("BTD6AskModal", "on_submit"),
+        ("BTD6PanelView", "events_btn"),
+        ("BTD6PanelView", "towers_btn"),
+        ("BTD6PanelView", "heroes_btn"),
+        ("BTD6PanelView", "leaderboards_btn"),
+        ("BTD6PanelView", "modes_btn"),
         ("BTD6PanelView", "status_btn"),
         ("BTD6PanelView", "admin_btn"),
     ],
 )
 def test_handler_defers_before_service_work(class_name, method_name):
+    if (class_name, method_name) in _MODAL_EXEMPT:
+        pytest.skip("modal-triggering callback — must not call safe_defer")
+
     node = _load_method(class_name, method_name)
     awaits = _collect_awaits_in_source_order(node)
     assert awaits, f"{class_name}.{method_name}: no awaits found"
@@ -75,3 +93,25 @@ def test_handler_defers_before_service_work(class_name, method_name):
             f"{await_node.lineno} is not safe_defer()."
         )
         return
+
+
+def test_ask_button_calls_send_modal_directly() -> None:
+    """The Ask button must call ``send_modal`` as the initial response.
+
+    Pin the modal exception so a future refactor doesn't accidentally
+    insert a ``safe_defer`` before ``send_modal`` (which would break
+    the modal).
+    """
+    import ast
+
+    node = _load_method("BTD6PanelView", "ask_btn")
+    # First await statement should be on send_modal, NOT on safe_defer.
+    awaits = _collect_awaits_in_source_order(node)
+    assert awaits, "ask_btn must await something"
+    first = awaits[0]
+    assert isinstance(first.value, ast.Call)
+    func = first.value.func
+    assert isinstance(func, ast.Attribute) and func.attr == "send_modal", (
+        "ask_btn must call interaction.response.send_modal as the initial "
+        "await; do not insert safe_defer ahead of it."
+    )


### PR DESCRIPTION
## Summary

Three-part refactor that makes the BTD6 cog production-ready by closing
the three structural gaps in the previously shipped surface: no
view-model layer, no drill-down browsers, no stable `context_id`
contract. Every commit lands behind regression tests; no shipped
feature regresses.

**4 commits, 5920 tests passing, 0 architecture errors**, 712 BTD6
tests (up from 559).

### PR 1 (`a2138b4`) — Foundation
Introduces the sandwich layer between query services and embeds:
- `services/btd6_view_model_service.py` — typed VMs for Hub / Event /
  Tower / Hero / Leaderboard / StaffDiagnostics / SourceHealth /
  LatestData with `DataFreshness` + `ContextHandle` threaded through.
- `make_context_handle(type, key)` enforces the contract regex
  `^btd6_[a-z_]+:[A-Za-z0-9_-]+$`.
- Consolidates 3 duplicate freshness-emoji dicts (`_BUCKET_EMOJI` /
  `_BUCKET_BADGE` / `_FRESHNESS_BADGE`) and 2 duplicate helpers
  (`_coerce_body`, window formatters) into `utils/btd6/`.
- Only user-visible change: per-kind freshness badges in the panel's
  "Currently active" block — a smoke-testable signal in production
  before PR 2 lands.

### PR 2 (`fb25c28`) — Hub refactor + drill-downs
- Refactors `BTD6PanelView` in place. **Every legacy `btd6:*`
  custom_id is preserved** (Discord does not re-render existing
  anchor messages at restart — removing any custom_id orphans old
  anchors). Adds `btd6:events` + `btd6:leaderboards`.
- **UX fix:** every non-modal button click now opens an ephemeral
  sub-view instead of mutating the public panel embed for everyone.
  Modal exception: Ask still calls `send_modal` as the initial
  response.
- New drill-down browsers (`views/btd6/{live_events,tower_browser,
  hero_browser,leaderboard_browser}_view.py`) — all extend `HubView`,
  cap selects at Discord's 25-option limit at the VM layer, render
  freshness warnings, and chain back-buttons to the immediate parent
  (detail → list, list → hub).
- `response_to_embed` + freshness rendering moved to `utils/btd6/`
  so the new views render without crossing the views→cogs boundary.

### PR 3 (`a7d13c9` + `1eef16a`) — Polish + contract tests
**Commit A** — central `utils/btd6/context_footer.py:append_context_footer`
appends `ctx=<context_id>` to every stable-content embed footer:
- Allowlist: hub, status, source health, latest data, event list +
  detail, tower / hero list + detail, leaderboard, strategies.
- Exclusion list (transient operational): refresh summary, why-no-
  response, grounding, test-intent.
- Idempotent, preserves existing footer text + icon_url.

**Commit C** — three regression tests + docs:
- `test_btd6_command_parity.py` — AST-based: every prefix command
  has a slash twin (except `submit` modal exception) and twins share
  a backbone call. Catches drift without forcing massive `_handle_*`
  extraction.
- `test_btd6_context_id_contract.py` — every VM `context_id` matches
  the regex; every allowlisted embed surfaces the `ctx=` footer;
  exclusion-list embeds intentionally omit it.
- `test_btd6_refresh_shared_orchestration.py` — prefix, slash, and
  admin-view manual refresh all call
  `btd6_ingestion_service.refresh_source_or_dependencies` with
  identical kwargs.
- `docs/ownership.md` documents the new VM service.
- `docs/architecture.md` documents the query → VM → embed sandwich
  as the preferred pattern for read-heavy subsystems.

### Deferred (per plan)
- **Paragon Hub** — no stubs, no buttons. The `context_id` contract
  introduced here gives a future paragon service a clean tower
  attach surface.
- **Team Panel UI/tables** — only the `context_id` exposure ships
  now (the future seam). No `team_contexts` / `team_entries` schema.

### Back-compat / orphan risk
The persistent panel's restart contract (zero-arg construction,
custom_id routing) is pinned by `test_btd6_panel_legacy_custom_ids.py`.
Renaming or removing any historical `btd6:*` custom_id would orphan
production anchors — the test catches it.

## Test plan
- [x] `python3.10 scripts/check_architecture.py --mode strict` — 0 errors
- [x] `python3.10 -m pytest tests/ -q` — 5920 passed, 3 skipped
- [x] `python3.10 -m pytest tests/ -k "btd6" -q` — 712 passed (was 559)
- [x] Lint: ruff + black clean on every PR file
- [ ] Manual smoke: open Hub → Live Events → Race detail; click
      Towers / Heroes / Leaderboards; verify freshness badges; staff
      Admin → Fetch Selected
- [ ] Verify legacy anchors (pre-PR 2 messages) still route correctly
      when clicking Towers / Heroes / Modes

https://claude.ai/code/session_01XRtSUFs8NuqRtMy5v9uvsP

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRtSUFs8NuqRtMy5v9uvsP)_