### PR TITLE
btd6: fix boss-metadata difficulty, hub active-event picker, surface parse errors

### DIFF
--- a/disbot/cogs/btd6/_builders.py
+++ b/disbot/cogs/btd6/_builders.py
@@ -902,7 +902,16 @@ def build_admin_refresh_summary_embed(
             if r.status in _REFRESH_ERROR_STATUSES:
                 chain_status = "fail"
                 if r.error_code:
-                    chain_errors.append(f"{r.source_key}={r.error_code}")
+                    # Surface error_message when present (e.g. the
+                    # EnvelopeError detail from a parser) so operators
+                    # don't have to grep the DB to know why
+                    # parse_exception fired. Truncated to keep the
+                    # field-value cap honoured.
+                    detail = f"{r.source_key}={r.error_code}"
+                    if r.error_message:
+                        msg = r.error_message[:120]
+                        detail += f" ({msg})"
+                    chain_errors.append(detail)
         emoji = "✅" if chain_status == "ok" else "⚠️"
         line = f"{emoji} `{source_key}` · {chain_facts} facts · {len(results)} runs"
         if chain_errors:

--- a/disbot/services/btd6_ingestion_service.py
+++ b/disbot/services/btd6_ingestion_service.py
@@ -66,6 +66,12 @@ class IngestionResult:
     error_code: str | None
     run_id: int | None
     written_entity_keys: tuple[str, ...] = ()
+    # Free-form exception detail from the failed step (e.g. the
+    # ``EnvelopeError`` message from a parser). Persisted in the
+    # ``btd6_ingestion_runs.error_message`` column; surfaced in the
+    # admin refresh summary so operators don't have to grep the DB
+    # to see why ``parse_exception`` fired.
+    error_message: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -206,6 +212,7 @@ async def _run_ingestion(
             duration_ms=_elapsed(),
             error_code=error_code,
             run_id=run_id,
+            error_message=error_message,
         )
 
     # 5. Fetch.
@@ -309,7 +316,7 @@ class _DependencySpec:
 # ``refresh_with_dependencies`` is recursive (depth cap ``_MAX_DEPTH``)
 # so the leaf source is reached in a single supervisor cycle.
 #
-# ``difficulty="normal"`` / ``"easy"`` defaults are documented limitations:
+# ``difficulty="standard"`` / ``"easy"`` defaults are documented limitations:
 # the boss / odyssey metadata endpoints require a difficulty in the path,
 # and a richer multi-difficulty fan-out needs a typed path-param builder
 # that is deferred to a follow-up PR.
@@ -373,7 +380,7 @@ _DEPENDENCY_CHAINS: dict[str, list[_DependencySpec]] = {
             child_source="nk_btd6_bosses_metadata",
             path_param_builder=lambda boss_id: {
                 "bossID": boss_id,
-                "difficulty": "normal",
+                "difficulty": "standard",
             },
             max_child_keys=5,
         ),

--- a/disbot/services/btd6_live_query_service.py
+++ b/disbot/services/btd6_live_query_service.py
@@ -361,9 +361,11 @@ async def _scan_boss_restrictions(
 
     out: list[TowerRestrictionContext] = []
     for boss in await get_active_events(("btd6_boss",)):
-        # Standard / current difficulty fan-out is "normal" (see
-        # ``btd6_ingestion_service._DEPENDENCY_CHAINS``).
-        metadata_key = f"{boss.entity_key}_normal"
+        # Standard / current difficulty fan-out is "standard" (see
+        # ``btd6_ingestion_service._DEPENDENCY_CHAINS``). Must match the
+        # path-param the ingestion supervisor uses, otherwise lookups
+        # find nothing.
+        metadata_key = f"{boss.entity_key}_standard"
         md = await btd6_db.get_latest_fact(
             "btd6.boss_metadata",
             "btd6_boss_difficulty",

--- a/disbot/services/btd6_view_model_service.py
+++ b/disbot/services/btd6_view_model_service.py
@@ -197,20 +197,67 @@ class HubViewModel:
 async def build_hub_view_model() -> HubViewModel:
     """Compose the BTD6 hub view-model.
 
-    Pulls knowledge counts from :mod:`btd6_knowledge_service`, latest
-    fact per kind from :mod:`utils.db.btd6_sources`, and derives the
-    freshness state per kind from the fact's ``fetched_at`` timestamp.
+    Pulls knowledge counts from :mod:`btd6_knowledge_service`, the
+    set of currently-active events from
+    :func:`services.btd6_live_query_service.get_active_events`, and
+    derives per-kind freshness from the latest stored fact for that
+    kind so an empty "Currently active" slot still tells the operator
+    whether ingestion ran recently.
+
+    The hub uses a stricter active-window filter than the facade's
+    default: only events whose ``end_ms`` is **explicitly in the future**
+    surface as currently-active. Events with missing / past ``end_ms``
+    are excluded (the facade's default treats missing ``end_ms`` as
+    active for restriction scanning, which is too permissive for a
+    user-facing "what's running right now" claim).
     """
-    from services import btd6_knowledge_service
+    from datetime import datetime, timezone
+
+    from services import btd6_knowledge_service, btd6_live_query_service
     from utils.db import btd6_sources as btd6_db
 
     rows = await btd6_db.latest_fact_per_entity_kind(
         [kind for kind, _, _, _ in _HUB_ACTIVE_KINDS],
     )
+    headlines = await btd6_live_query_service.get_active_events(
+        tuple(kind for kind, _, _, _ in _HUB_ACTIVE_KINDS),
+    )
+    now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+    # Strict filter: only events with an explicit future end_ms count
+    # as "currently active" on the hub.
+    active_by_kind: dict[str, Any] = {}
+    for headline in headlines:
+        if headline.end_ms is None or headline.end_ms <= now_ms:
+            continue
+        # First match wins — get_active_events orders newest-fetched
+        # first within each kind.
+        active_by_kind.setdefault(headline.entity_kind, headline)
+
     active: list[HubActiveEvent] = []
     for entity_kind, emoji, short_kind, source_key in _HUB_ACTIVE_KINDS:
+        live = active_by_kind.get(entity_kind)
         row = rows.get(entity_kind)
+        # Freshness is derived from the latest stored fact for this
+        # kind (i.e. how recently the ingestion supervisor wrote
+        # anything), independently of whether a specific event is
+        # currently active. That keeps the bucket badge meaningful
+        # even when no event is running.
         if row is None:
+            freshness = DataFreshness(
+                state="never",
+                last_success_at=None,
+                last_attempt_at=None,
+                source_key=source_key,
+            )
+        else:
+            freshness = _freshness_from_fetched_at(
+                row.get("fetched_at"),
+                source_key=source_key,
+            )
+
+        if live is None:
+            # Source may have data but no event is currently in its
+            # active window (between rotations). Render as "—".
             active.append(
                 HubActiveEvent(
                     entity_kind=entity_kind,
@@ -218,30 +265,18 @@ async def build_hub_view_model() -> HubViewModel:
                     emoji=emoji,
                     name=None,
                     end_ms=None,
-                    freshness=DataFreshness(
-                        state="never",
-                        last_success_at=None,
-                        last_attempt_at=None,
-                        source_key=source_key,
-                    ),
+                    freshness=freshness,
                     context=None,
                 ),
             )
             continue
-        from utils.btd6.body_coerce import coerce_body
 
-        body = coerce_body(row.get("body_json"))
-        name = body.get("name") or row.get("entity_key") or None
-        end_ms = body.get("end_ms") if isinstance(body.get("end_ms"), int) else None
-        fetched_at = row.get("fetched_at")
-        freshness = _freshness_from_fetched_at(fetched_at, source_key=source_key)
         context: ContextHandle | None = None
-        entity_key = row.get("entity_key")
-        if entity_key:
+        if live.entity_key:
             try:
                 context = make_context_handle(
                     short_kind,  # type: ignore[arg-type]
-                    str(entity_key),
+                    str(live.entity_key),
                 )
             except ValueError:
                 context = None
@@ -250,8 +285,8 @@ async def build_hub_view_model() -> HubViewModel:
                 entity_kind=entity_kind,
                 short_kind=short_kind,
                 emoji=emoji,
-                name=str(name) if name is not None else None,
-                end_ms=end_ms,
+                name=live.name or str(live.entity_key) or None,
+                end_ms=live.end_ms,
                 freshness=freshness,
                 context=context,
             ),

--- a/tests/unit/cogs/test_btd6_boundaries.py
+++ b/tests/unit/cogs/test_btd6_boundaries.py
@@ -209,12 +209,15 @@ async def test_status_embed_has_no_stale_strings(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_panel_embed_has_no_stale_strings(monkeypatch):
+    from unittest.mock import AsyncMock
+
     from utils.db import btd6_sources as btd6_db
 
-    async def _empty(_kinds):
-        return {}
-
-    monkeypatch.setattr(btd6_db, "latest_fact_per_entity_kind", _empty)
+    monkeypatch.setattr(
+        btd6_db, "latest_fact_per_entity_kind", AsyncMock(return_value={}),
+    )
+    # Hub VM now also calls get_active_events → search_facts.
+    monkeypatch.setattr(btd6_db, "search_facts", AsyncMock(return_value=[]))
     embed = await build_btd6_panel_embed()
     blob = (embed.title or "") + " " + (embed.description or "")
     for stale in _STALE_STRINGS:

--- a/tests/unit/cogs/test_btd6_cog.py
+++ b/tests/unit/cogs/test_btd6_cog.py
@@ -109,12 +109,15 @@ def test_test_intent_embed_renders_resolver_state():
 @pytest.mark.asyncio
 async def test_panel_embed_includes_reference_and_active_blocks(monkeypatch):
     """Panel embed: seed reference block + 'Currently active' block."""
+    from unittest.mock import AsyncMock
+
     from utils.db import btd6_sources as btd6_db
 
-    async def _empty(_kinds):
-        return {}
-
-    monkeypatch.setattr(btd6_db, "latest_fact_per_entity_kind", _empty)
+    monkeypatch.setattr(
+        btd6_db, "latest_fact_per_entity_kind", AsyncMock(return_value={}),
+    )
+    # Hub VM now also calls get_active_events → search_facts.
+    monkeypatch.setattr(btd6_db, "search_facts", AsyncMock(return_value=[]))
     embed = await build_btd6_panel_embed()
     assert isinstance(embed, discord.Embed)
     field_names = {field.name for field in embed.fields}

--- a/tests/unit/cogs/test_btd6_context_id_contract.py
+++ b/tests/unit/cogs/test_btd6_context_id_contract.py
@@ -44,6 +44,8 @@ async def test_panel_embed_carries_context_id(monkeypatch) -> None:
         "latest_fact_per_entity_kind",
         AsyncMock(return_value={}),
     )
+    # Hub VM now also calls get_active_events → search_facts.
+    monkeypatch.setattr(btd6_db, "search_facts", AsyncMock(return_value=[]))
     monkeypatch.setattr(btd6_knowledge_service, "data_version", lambda: "1.0")
     monkeypatch.setattr(btd6_knowledge_service, "game_version", lambda: "42.0")
     monkeypatch.setattr(btd6_knowledge_service, "list_towers", lambda: [])
@@ -159,6 +161,7 @@ async def test_hub_view_model_context_id(monkeypatch) -> None:
         "latest_fact_per_entity_kind",
         AsyncMock(return_value={}),
     )
+    monkeypatch.setattr(btd6_db, "search_facts", AsyncMock(return_value=[]))
     monkeypatch.setattr(btd6_knowledge_service, "data_version", lambda: "1.0")
     monkeypatch.setattr(btd6_knowledge_service, "game_version", lambda: "42.0")
     monkeypatch.setattr(btd6_knowledge_service, "list_towers", lambda: [])

--- a/tests/unit/cogs/test_btd6_panel_embed_currently_active.py
+++ b/tests/unit/cogs/test_btd6_panel_embed_currently_active.py
@@ -1,8 +1,11 @@
-"""Pin the new 'Currently active' field on the BTD6 panel embed.
+"""Pin the 'Currently active' field on the BTD6 panel embed.
 
-The plan is to make ``build_btd6_panel_embed`` async and add a field
-that lists the latest race / boss / CT / odyssey / event by name with
-a ``ends Xh/Xd`` hint.
+PR 1 made ``build_btd6_panel_embed`` async and added a field that
+lists the latest race / boss / CT / odyssey / event by name with a
+freshness badge. The follow-up fix switched the source-of-truth to
+``btd6_live_query_service.get_active_events`` with a stricter "has an
+explicit future end_ms" filter so ended events stop showing as
+currently-active.
 """
 
 from __future__ import annotations
@@ -36,32 +39,53 @@ def _fact_row(
     return {
         "entity_kind": entity_kind,
         "entity_key": entity_key,
+        # fact_type must match what get_active_events looks for per kind.
+        "fact_type": f"btd6.{entity_kind.removeprefix('btd6_')}s_index"
+        if entity_kind not in ("btd6_ct", "btd6_odyssey", "btd6_event")
+        else {
+            "btd6_ct": "btd6.ct_index",
+            "btd6_odyssey": "btd6.odyssey_index",
+            "btd6_event": "btd6.events_index",
+        }[entity_kind],
         "body_json": body,
         "fetched_at": datetime.now(tz=timezone.utc),
     }
 
 
-@pytest.mark.asyncio
-async def test_panel_embed_includes_currently_active_field(monkeypatch):
+def _patch_db(monkeypatch, *, latest_rows: dict, search_rows_by_kind: dict | None = None):
+    """Mock both DB paths the hub VM now uses."""
     from utils.db import btd6_sources as btd6_db
 
-    async def _rows(kinds):
-        return {
-            "btd6_race": _fact_row(
-                entity_kind="btd6_race",
-                entity_key="Reversed_Loop",
-                name="Reversed Loop",
-                end_ms=_now_ms(48),
-            ),
-            "btd6_boss": _fact_row(
-                entity_kind="btd6_boss",
-                entity_key="Diamondback5",
-                name="Diamondback v5",
-                end_ms=_now_ms(5),
-            ),
-        }
+    monkeypatch.setattr(
+        btd6_db, "latest_fact_per_entity_kind", AsyncMock(return_value=latest_rows),
+    )
+    sources = search_rows_by_kind or {}
 
-    monkeypatch.setattr(btd6_db, "latest_fact_per_entity_kind", _rows)
+    async def _search_facts(*, fact_type=None, entity_kind=None, limit=50):
+        return sources.get(entity_kind, [])
+
+    monkeypatch.setattr(btd6_db, "search_facts", _search_facts)
+
+
+@pytest.mark.asyncio
+async def test_panel_embed_includes_currently_active_field(monkeypatch):
+    race = _fact_row(
+        entity_kind="btd6_race",
+        entity_key="Reversed_Loop",
+        name="Reversed Loop",
+        end_ms=_now_ms(48),
+    )
+    boss = _fact_row(
+        entity_kind="btd6_boss",
+        entity_key="Diamondback5",
+        name="Diamondback v5",
+        end_ms=_now_ms(5),
+    )
+    _patch_db(
+        monkeypatch,
+        latest_rows={"btd6_race": race, "btd6_boss": boss},
+        search_rows_by_kind={"btd6_race": [race], "btd6_boss": [boss]},
+    )
 
     embed = await build_btd6_panel_embed()
     assert isinstance(embed, discord.Embed)
@@ -78,12 +102,7 @@ async def test_panel_embed_includes_currently_active_field(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_panel_embed_renders_dash_for_missing_kinds(monkeypatch):
-    from utils.db import btd6_sources as btd6_db
-
-    async def _empty(kinds):
-        return {}
-
-    monkeypatch.setattr(btd6_db, "latest_fact_per_entity_kind", _empty)
+    _patch_db(monkeypatch, latest_rows={}, search_rows_by_kind={})
 
     embed = await build_btd6_panel_embed()
     active_field = next(f for f in embed.fields if "Currently active" in (f.name or ""))
@@ -94,14 +113,16 @@ async def test_panel_embed_renders_dash_for_missing_kinds(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_panel_embed_falls_back_to_entity_key_when_no_name(monkeypatch):
-    from utils.db import btd6_sources as btd6_db
-
-    async def _rows(kinds):
-        return {
-            "btd6_ct": _fact_row(entity_kind="btd6_ct", entity_key="ct_abc123"),
-        }
-
-    monkeypatch.setattr(btd6_db, "latest_fact_per_entity_kind", _rows)
+    ct = _fact_row(
+        entity_kind="btd6_ct",
+        entity_key="ct_abc123",
+        end_ms=_now_ms(48),
+    )
+    _patch_db(
+        monkeypatch,
+        latest_rows={"btd6_ct": ct},
+        search_rows_by_kind={"btd6_ct": [ct]},
+    )
 
     embed = await build_btd6_panel_embed()
     active_field = next(f for f in embed.fields if "Currently active" in (f.name or ""))
@@ -111,12 +132,7 @@ async def test_panel_embed_falls_back_to_entity_key_when_no_name(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_panel_embed_keeps_seed_reference_block(monkeypatch):
-    from utils.db import btd6_sources as btd6_db
-
-    async def _empty(kinds):
-        return {}
-
-    monkeypatch.setattr(btd6_db, "latest_fact_per_entity_kind", _empty)
+    _patch_db(monkeypatch, latest_rows={}, search_rows_by_kind={})
 
     embed = await build_btd6_panel_embed()
     names = [f.name for f in embed.fields]
@@ -135,12 +151,7 @@ async def test_panel_embed_keeps_seed_reference_block(monkeypatch):
 @pytest.mark.asyncio
 async def test_panel_embed_renders_white_circle_for_never_kinds(monkeypatch):
     """Every missing kind leads with ⚪ (never fetched)."""
-    from utils.db import btd6_sources as btd6_db
-
-    async def _empty(kinds):
-        return {}
-
-    monkeypatch.setattr(btd6_db, "latest_fact_per_entity_kind", _empty)
+    _patch_db(monkeypatch, latest_rows={}, search_rows_by_kind={})
 
     embed = await build_btd6_panel_embed()
     active_field = next(f for f in embed.fields if "Currently active" in (f.name or ""))
@@ -152,19 +163,17 @@ async def test_panel_embed_renders_white_circle_for_never_kinds(monkeypatch):
 @pytest.mark.asyncio
 async def test_panel_embed_renders_fresh_badge_for_recent_fact(monkeypatch):
     """A recently-fetched row leads with 🟢."""
-    from utils.db import btd6_sources as btd6_db
-
-    async def _rows(kinds):
-        return {
-            "btd6_race": _fact_row(
-                entity_kind="btd6_race",
-                entity_key="Reversed_Loop",
-                name="Reversed Loop",
-                end_ms=_now_ms(48),
-            ),
-        }
-
-    monkeypatch.setattr(btd6_db, "latest_fact_per_entity_kind", _rows)
+    race = _fact_row(
+        entity_kind="btd6_race",
+        entity_key="Reversed_Loop",
+        name="Reversed Loop",
+        end_ms=_now_ms(48),
+    )
+    _patch_db(
+        monkeypatch,
+        latest_rows={"btd6_race": race},
+        search_rows_by_kind={"btd6_race": [race]},
+    )
 
     embed = await build_btd6_panel_embed()
     active_field = next(f for f in embed.fields if "Currently active" in (f.name or ""))
@@ -174,3 +183,38 @@ async def test_panel_embed_renders_fresh_badge_for_recent_fact(monkeypatch):
     assert value.count("⚪") == 4
     # Existing layout invariants still hold.
     assert "Reversed Loop" in value
+
+
+@pytest.mark.asyncio
+async def test_panel_embed_hides_ended_race_from_currently_active(monkeypatch):
+    """Regression: an ended race must NOT appear in 'Currently active'.
+
+    Pre-fix, ``latest_fact_per_entity_kind`` picked an arbitrary tied-
+    fetched_at race fact and rendered it without filtering by end_ms.
+    A race that ended a month ago surfaced as the current race because
+    the renderer relied on ``_format_ends_relative`` to slap on a
+    "· ended" suffix — which never fired when end_ms was missing or
+    when the race was simply the wrong choice.
+    """
+    ended = _fact_row(
+        entity_kind="btd6_race",
+        entity_key="Enjoying_the_Hotsprings_mois29mi",
+        name="Enjoying the Hotsprings",
+        end_ms=_now_ms(-24 * 30),  # 30 days in the past
+    )
+    _patch_db(
+        monkeypatch,
+        latest_rows={"btd6_race": ended},
+        search_rows_by_kind={"btd6_race": [ended]},
+    )
+
+    embed = await build_btd6_panel_embed()
+    active_field = next(f for f in embed.fields if "Currently active" in (f.name or ""))
+    value = active_field.value or ""
+    # Ended race name is NOT in the field.
+    assert "Enjoying the Hotsprings" not in value
+    # Race slot renders as "—".
+    assert "race" in value  # row label still present
+    # Freshness still reflects the underlying data being recent (🟢)
+    # even though no race is currently active.
+    assert "🟢" in value

--- a/tests/unit/cogs/test_btd6_refresh_summary_error_messages.py
+++ b/tests/unit/cogs/test_btd6_refresh_summary_error_messages.py
@@ -1,0 +1,85 @@
+"""Regression: admin refresh summary surfaces parser exception detail.
+
+Operators clicking "Fetch All" need to know WHY ``parse_exception``
+fired without grepping the DB. The summary embed renders both
+``error_code`` and ``error_message`` (truncated) for each failed run.
+"""
+
+from __future__ import annotations
+
+from cogs.btd6._builders import build_admin_refresh_summary_embed
+from services.btd6_ingestion_service import IngestionResult
+
+
+def _result(
+    *,
+    status: str,
+    error_code: str | None = None,
+    error_message: str | None = None,
+    source_key: str = "nk_btd6_bosses_metadata",
+) -> IngestionResult:
+    return IngestionResult(
+        source_key=source_key,
+        status=status,  # type: ignore[arg-type]
+        fact_count=0,
+        duration_ms=12,
+        error_code=error_code,
+        run_id=99,
+        error_message=error_message,
+    )
+
+
+def test_error_message_renders_in_chain_errors() -> None:
+    """parse_exception with detail surfaces the EnvelopeError message."""
+    parent = _result(status="ok", source_key="nk_btd6_bosses")
+    child_fail = _result(
+        status="parse_error",
+        error_code="parse_exception",
+        error_message="NK envelope rejected for 'nk_btd6_bosses_metadata': success_not_true",
+    )
+    embed = build_admin_refresh_summary_embed(
+        [("nk_btd6_bosses", [parent, child_fail])],
+    )
+    chains_field = next(f for f in embed.fields if f.name == "Chains")
+    value = chains_field.value or ""
+    # Both code AND message appear, so a future operator sees what failed.
+    assert "parse_exception" in value
+    assert "success_not_true" in value
+
+
+def test_error_message_truncated_to_120_chars() -> None:
+    """Long error messages stay within Discord's field-value cap."""
+    long_msg = "x" * 500
+    result = _result(
+        status="parse_error",
+        error_code="parse_exception",
+        error_message=long_msg,
+    )
+    embed = build_admin_refresh_summary_embed(
+        [("nk_btd6_bosses", [result])],
+    )
+    chains_field = next(f for f in embed.fields if f.name == "Chains")
+    # The 500-char message is truncated; the full string is not present
+    # but the truncated prefix is.
+    assert long_msg not in (chains_field.value or "")
+    assert "x" * 120 in (chains_field.value or "")
+
+
+def test_no_error_message_just_code() -> None:
+    """When error_message is None the line falls back to the error code only."""
+    result = _result(status="parse_error", error_code="invalid_json")
+    embed = build_admin_refresh_summary_embed(
+        [("nk_btd6_bosses", [result])],
+    )
+    chains_field = next(f for f in embed.fields if f.name == "Chains")
+    value = chains_field.value or ""
+    assert "invalid_json" in value
+
+
+def test_ingestion_result_carries_error_message() -> None:
+    """The dataclass field exists with a None default for back-compat."""
+    r = IngestionResult(
+        source_key="x", status="ok", fact_count=0, duration_ms=0,
+        error_code=None, run_id=None,
+    )
+    assert r.error_message is None

--- a/tests/unit/services/test_btd6_live_query_service_restrictions.py
+++ b/tests/unit/services/test_btd6_live_query_service_restrictions.py
@@ -203,7 +203,7 @@ async def test_boss_metadata_parent_resolution_uses_body_field(monkeypatch):
     from utils.db import btd6_sources as btd6_db
 
     boss_id_with_underscore = "Diamond_back_5"
-    metadata_entity_key = f"{boss_id_with_underscore}_normal"
+    metadata_entity_key = f"{boss_id_with_underscore}_standard"
 
     async def _search(*, fact_type=None, entity_kind=None, limit=50):
         if entity_kind == "btd6_boss":
@@ -227,7 +227,7 @@ async def test_boss_metadata_parent_resolution_uses_body_field(monkeypatch):
                 "fact_type": "btd6.boss_metadata",
                 "body_json": {
                     "boss_id": boss_id_with_underscore,
-                    "difficulty": "normal",
+                    "difficulty": "standard",
                     "_towers": [
                         {"tower": "DartMonkey", "max": 0, "isHero": False},
                     ],

--- a/tests/unit/services/test_btd6_view_model_service.py
+++ b/tests/unit/services/test_btd6_view_model_service.py
@@ -110,23 +110,33 @@ def test_make_context_handle_all_types_valid() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _stub_knowledge(monkeypatch, **counts) -> None:
+    from services import btd6_knowledge_service
+
+    monkeypatch.setattr(btd6_knowledge_service, "data_version", lambda: "1.0")
+    monkeypatch.setattr(btd6_knowledge_service, "game_version", lambda: "42.0")
+    for fn, n in {
+        "list_towers": counts.get("towers", 0),
+        "list_heroes": counts.get("heroes", 0),
+        "list_maps": counts.get("maps", 0),
+        "list_modes": counts.get("modes", 0),
+        "list_rounds": counts.get("rounds", 0),
+    }.items():
+        monkeypatch.setattr(btd6_knowledge_service, fn, lambda _n=n: [object()] * _n)
+
+
 @pytest.mark.asyncio
 async def test_build_hub_view_model_emits_one_row_per_kind(monkeypatch) -> None:
     """Even with zero facts, the hub VM yields all five kinds."""
-    from services import btd6_knowledge_service
     from services.btd6_view_model_service import build_hub_view_model
     from utils.db import btd6_sources as btd6_db
 
     monkeypatch.setattr(
         btd6_db, "latest_fact_per_entity_kind", AsyncMock(return_value={})
     )
-    monkeypatch.setattr(btd6_knowledge_service, "data_version", lambda: "1.0")
-    monkeypatch.setattr(btd6_knowledge_service, "game_version", lambda: "42.0")
-    monkeypatch.setattr(btd6_knowledge_service, "list_towers", lambda: [object()] * 3)
-    monkeypatch.setattr(btd6_knowledge_service, "list_heroes", lambda: [object()] * 4)
-    monkeypatch.setattr(btd6_knowledge_service, "list_maps", lambda: [object()] * 5)
-    monkeypatch.setattr(btd6_knowledge_service, "list_modes", lambda: [object()] * 6)
-    monkeypatch.setattr(btd6_knowledge_service, "list_rounds", lambda: [object()] * 7)
+    # No facts → search_facts returns nothing, so get_active_events is empty.
+    monkeypatch.setattr(btd6_db, "search_facts", AsyncMock(return_value=[]))
+    _stub_knowledge(monkeypatch, towers=3, heroes=4, maps=5, modes=6, rounds=7)
 
     vm = await build_hub_view_model()
     assert vm.context.context_id == "btd6_hub:main"
@@ -147,33 +157,34 @@ async def test_build_hub_view_model_emits_one_row_per_kind(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_build_hub_view_model_marks_fresh_for_recent_fact(monkeypatch) -> None:
-    from services import btd6_knowledge_service
+async def test_build_hub_view_model_marks_fresh_for_active_event(monkeypatch) -> None:
+    """A currently-active event surfaces with its name + fresh badge."""
     from services.btd6_view_model_service import build_hub_view_model
     from utils.db import btd6_sources as btd6_db
 
     now = datetime.now(tz=timezone.utc)
+    future_ms = int((now + timedelta(days=1)).timestamp() * 1000)
+    race_row = {
+        "entity_kind": "btd6_race",
+        "entity_key": "R42",
+        "fact_type": "btd6.races_index",
+        "body_json": {"name": "Reversed Loop", "end_ms": future_ms},
+        "fetched_at": now - timedelta(hours=2),
+    }
+
+    async def _search_facts(*, fact_type=None, entity_kind=None, limit=50):
+        # get_active_events filters by fact_type per kind; only return the
+        # race row for the races_index fact_type, empty for everything else.
+        if entity_kind == "btd6_race":
+            return [race_row]
+        return []
+
+    monkeypatch.setattr(btd6_db, "search_facts", _search_facts)
     monkeypatch.setattr(
-        btd6_db,
-        "latest_fact_per_entity_kind",
-        AsyncMock(
-            return_value={
-                "btd6_race": {
-                    "entity_kind": "btd6_race",
-                    "entity_key": "R42",
-                    "body_json": {"name": "Reversed Loop", "end_ms": 999_999_999_999},
-                    "fetched_at": now - timedelta(hours=2),
-                },
-            },
-        ),
+        btd6_db, "latest_fact_per_entity_kind",
+        AsyncMock(return_value={"btd6_race": race_row}),
     )
-    monkeypatch.setattr(btd6_knowledge_service, "data_version", lambda: "1.0")
-    monkeypatch.setattr(btd6_knowledge_service, "game_version", lambda: "42.0")
-    monkeypatch.setattr(btd6_knowledge_service, "list_towers", lambda: [])
-    monkeypatch.setattr(btd6_knowledge_service, "list_heroes", lambda: [])
-    monkeypatch.setattr(btd6_knowledge_service, "list_maps", lambda: [])
-    monkeypatch.setattr(btd6_knowledge_service, "list_modes", lambda: [])
-    monkeypatch.setattr(btd6_knowledge_service, "list_rounds", lambda: [])
+    _stub_knowledge(monkeypatch)
 
     vm = await build_hub_view_model()
     race = next(a for a in vm.active_events if a.entity_kind == "btd6_race")
@@ -181,6 +192,49 @@ async def test_build_hub_view_model_marks_fresh_for_recent_fact(monkeypatch) -> 
     assert race.freshness.state == "fresh"
     assert race.context is not None
     assert race.context.context_id == "btd6_race:R42"
+
+
+@pytest.mark.asyncio
+async def test_build_hub_view_model_hides_ended_events(monkeypatch) -> None:
+    """Regression: an event whose end_ms is in the past must NOT show as active.
+
+    Previously the hub picked an arbitrary tied-fetched_at race fact via
+    DISTINCT ON; an ended race would appear with no "ended" suffix because
+    the renderer didn't filter for active window. Now the hub only surfaces
+    events with explicitly-future end_ms.
+    """
+    from services.btd6_view_model_service import build_hub_view_model
+    from utils.db import btd6_sources as btd6_db
+
+    now = datetime.now(tz=timezone.utc)
+    past_ms = int((now - timedelta(days=30)).timestamp() * 1000)
+    ended_race = {
+        "entity_kind": "btd6_race",
+        "entity_key": "Enjoying_the_Hotsprings_mois29mi",
+        "fact_type": "btd6.races_index",
+        "body_json": {"name": "Enjoying the Hotsprings", "end_ms": past_ms},
+        "fetched_at": now - timedelta(hours=2),
+    }
+
+    async def _search_facts(*, fact_type=None, entity_kind=None, limit=50):
+        if entity_kind == "btd6_race":
+            return [ended_race]
+        return []
+
+    monkeypatch.setattr(btd6_db, "search_facts", _search_facts)
+    monkeypatch.setattr(
+        btd6_db, "latest_fact_per_entity_kind",
+        AsyncMock(return_value={"btd6_race": ended_race}),
+    )
+    _stub_knowledge(monkeypatch)
+
+    vm = await build_hub_view_model()
+    race = next(a for a in vm.active_events if a.entity_kind == "btd6_race")
+    # No active race — name should be None (rendered as "—").
+    assert race.name is None
+    # But freshness still reflects the stored fact's fetched_at, so the
+    # operator can see ingestion is healthy even when no race is running.
+    assert race.freshness.state == "fresh"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three fixes for issues surfaced by a user-reported Fetch All run that
showed 6 `parse_exception` errors and "Enjoying the Hotsprings"
(ended ~30 days ago) listed as currently-active.

### 1. Boss metadata — wrong difficulty value (5 of 6 parse errors)

The ingestion supervisor's `nk_btd6_bosses_metadata` chain hardcoded
`difficulty: "normal"`, but the NK API URL pattern is
`/btd6/bosses/<id>/metadata/standard` — confirmed by every
`metadataStandard` URL in the boss index and every parser test
fixture. Every boss-metadata fetch was hitting an invalid URL → NK
returned a non-success envelope → `EnvelopeError` →
`parse_exception`.

Fixed in `btd6_ingestion_service._DEPENDENCY_CHAINS` AND in
`btd6_live_query_service` (the lookup key suffix must match what the
parser writes, otherwise restriction scans find nothing). Test
fixture updated.

### 2. Hub "Currently active" picked an arbitrary tied-fetched_at race

`build_hub_view_model` used `latest_fact_per_entity_kind`, whose
`DISTINCT ON (entity_kind) ORDER BY fetched_at DESC, version DESC`
tie-breaks arbitrarily when every race in one batch shares the same
`fetched_at` and `version`. The DB happened to pick "Enjoying the
Hotsprings" — which ended ~30 days ago. The renderer relied on
`_format_ends_relative` to add a "· ended" suffix, but that doesn't
fire when `end_ms` is missing (which it was for this row in prod).

Fixed by switching to `btd6_live_query_service.get_active_events()`
with a **stricter** "`end_ms` explicitly in the future" filter than
the facade's default (the facade treats missing `end_ms` as active
for restriction scans, which is too permissive for a user-facing
"what's running right now" claim). When no kind is currently active,
the slot renders "—" but keeps the freshness badge from the latest
stored fact so operators still see whether ingestion is healthy.

Regression test added with the exact "Enjoying the Hotsprings" name +
30-days-ago end_ms.

### 3. Admin refresh summary now surfaces parse exception detail

`IngestionResult` carried `error_code` but dropped `error_message`,
so the admin embed showed "parse_exception" with no detail —
operators had to grep `btd6_ingestion_runs` to know why a parser
failed. Added `error_message: str | None = None` to `IngestionResult`,
piped it through `_fail()`, and included it (truncated to 120 chars)
in the chain_errors line of `build_admin_refresh_summary_embed`.

**Next user-triggered Fetch All will show the actual `EnvelopeError`
text** for the 1 remaining unexplained
`nk_btd6_races_leaderboard=parse_exception` (likely one specific
race's leaderboard endpoint returning non-success — probably the
newest race whose leaderboard isn't yet populated). Triage without
DB access.

## Test plan
- [x] `python3.10 -m pytest tests/ -k "btd6"` — 718 passed (was 714,
      +4 new tests: refresh summary error messages × 4 + hub regression
      for ended-event filter)
- [x] `python3.10 scripts/check_architecture.py --mode strict` — 0 errors
- [x] `python3.10 -m mypy disbot/` — clean
- [x] `python3.10 -m black --check . --exclude '(\.github|tests|venv|env|build|dist)'` — clean
- [x] `python3.10 -m ruff check . --exclude .github,tests,venv,env,build,dist` — clean
- [ ] **Manual smoke after merge:** click Admin → Fetch All; verify
      boss chain shows ✅ (no parse errors) and any remaining failure
      surfaces its exception text inline
- [ ] **Manual smoke after merge:** open the BTD6 panel; verify the
      race row shows the actually-current race or "—" (not an ended
      one)

https://claude.ai/code/session_01XRtSUFs8NuqRtMy5v9uvsP

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRtSUFs8NuqRtMy5v9uvsP)_