### PR TITLE
btd6: hand-curation scaffold for towers/heroes data

### DIFF
--- a/data/btd6/README.md
+++ b/data/btd6/README.md
@@ -1,0 +1,111 @@
+# BTD6 Data Scaffold
+
+Hand-curated source data for SuperBot's BTD6 cog. Editable here as CSV
+(human-friendly, spreadsheet-compatible). The runtime reads JSON from
+`disbot/data/btd6/`; the import script converts CSV → JSON when the
+team is ready to ship.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `towers.csv` | All 24 BTD6 towers. Identity columns prefilled (`id`, `canonical`, `category`, `aliases`, `wiki_url`). Content columns blank — your team fills these. |
+| `heroes.csv` | 16 heroes through Rosalia (v45.0). Identity columns prefilled. |
+| `README.md` | This file. |
+
+## Workflow
+
+### Editing in a spreadsheet
+
+The CSVs are designed for collaborative editing in Google Sheets / Excel
+/ Numbers. Recommended flow:
+
+1. Upload `towers.csv` and `heroes.csv` to a shared Google Sheet.
+2. Distribute rows across the team (one tower per person, or by
+   category).
+3. Fill in the empty columns:
+   - **`base_cost`** — integer, Medium difficulty default (verify in
+     game info screen)
+   - **`description`** — short prose in your team's voice (do NOT
+     copy/paste from the wiki; the wiki is CC-BY-SA and copying
+     verbatim creates an attribution obligation)
+   - **`top_1`..`top_5`**, **`mid_1`..`mid_5`**, **`bot_1`..`bot_5`** —
+     the 5 upgrade names per path, in tier order (verify in game)
+   - **Heroes**: `ability_3_name`, `ability_3_summary`,
+     `ability_10_name`, `ability_10_summary` — the two ability levels
+     standard heroes get
+4. Export back to CSV. **Important:** keep the column order identical
+   to the scaffold — the import script reads columns by header name,
+   but treat preserving order as belt-and-braces.
+5. Commit the updated CSV files to the repo.
+
+### Importing CSV → JSON
+
+```bash
+python3.10 scripts/import_btd6_data_from_csv.py
+```
+
+The script:
+
+- Reads `data/btd6/towers.csv` and `data/btd6/heroes.csv`
+- Validates every row (category whitelist, cost > 0, exactly 5 tiers
+  per path, no empty required fields)
+- Writes `disbot/data/btd6/towers.json` and
+  `disbot/data/btd6/heroes.json` in the shape the runtime expects
+- On validation error, prints the offending row + column with a
+  human-readable reason; nothing is written
+
+After a successful import, commit the regenerated JSON files alongside
+the CSV changes so the runtime picks them up on next deploy.
+
+## Schema reminders
+
+### `towers.csv` columns
+
+| Column | Type | Required | Notes |
+|---|---|---|---|
+| `id` | snake_case | yes | Must be unique. Used in URLs, logs, the API-key map. |
+| `canonical` | string | yes | The official tower name (e.g. "Super Monkey"). |
+| `category` | enum | yes | One of `primary`, `military`, `magic`, `support`. |
+| `aliases` | comma-separated list | yes | Community nicknames the resolver should match. Must not collide with any other tower/hero/map/mode alias. |
+| `base_cost` | positive int | yes | Medium difficulty base cost. |
+| `description` | string | yes | Short prose, your team's voice. |
+| `top_1`..`top_5` | string | yes | Tier 1–5 upgrade names on the top path. |
+| `mid_1`..`mid_5` | string | yes | Same, middle path. |
+| `bot_1`..`bot_5` | string | yes | Same, bottom path. |
+| `wiki_url` | URL | yes | Link to the tower's wiki page (already prefilled). |
+
+### `heroes.csv` columns
+
+| Column | Type | Required | Notes |
+|---|---|---|---|
+| `id` | snake_case | yes | Must be unique. |
+| `canonical` | string | yes | Official hero name. |
+| `aliases` | comma-separated list | yes | Community nicknames. |
+| `base_cost` | positive int | yes | Medium difficulty base cost. |
+| `description` | string | yes | Short prose. |
+| `ability_3_name` | string | yes | Name of the level-3 ability. |
+| `ability_3_summary` | string | yes | One-line summary. |
+| `ability_10_name` | string | yes | Name of the level-10 ability. |
+| `ability_10_summary` | string | yes | One-line summary. |
+| `wiki_url` | URL | yes | Already prefilled. |
+
+## Roster note
+
+The scaffold lists 24 towers and 16 heroes — accurate as of BTD6 v45.0
+(Rosalia release). If Ninja Kiwi has shipped a new tower/hero in
+v46–v54 that we missed, add a row in the CSV and the matching API-key
+mapping in `disbot/services/btd6_live_query_service.py` (`_TOWER_ID_TO_API_KEY`
+or `_HERO_ID_TO_API_KEY`) — the coverage test in
+`tests/unit/services/test_btd6_live_query_service_mapping_coverage.py`
+will fail loudly if you forget the mapping.
+
+## Why CSV instead of editing JSON directly
+
+- **Multi-person editing.** Google Sheets handles concurrent edits;
+  JSON merge conflicts on a single file are painful.
+- **Diff visibility.** Spreadsheet cells make missing data obvious at
+  a glance.
+- **No JSON syntax errors.** No bracket / comma debugging.
+- **One-way derivation.** The CSV is the source of truth; the JSON is
+  generated. If the CSV is wrong, the JSON regenerates cleanly.

--- a/data/btd6/heroes.csv
+++ b/data/btd6/heroes.csv
@@ -1,0 +1,17 @@
+id,canonical,aliases,base_cost,description,ability_3_name,ability_3_summary,ability_10_name,ability_10_summary,wiki_url
+quincy,Quincy,"q,default hero",,,,,,,https://bloons.fandom.com/wiki/Quincy
+gwendolin,Gwendolin,"gwen,gwendo",,,,,,,https://bloons.fandom.com/wiki/Gwendolin
+striker_jones,Striker Jones,"striker,jones",,,,,,,https://bloons.fandom.com/wiki/Striker_Jones
+obyn_greenfoot,Obyn Greenfoot,"obyn,greenfoot",,,,,,,https://bloons.fandom.com/wiki/Obyn_Greenfoot
+captain_churchill,Captain Churchill,"churchill,tank hero",,,,,,,https://bloons.fandom.com/wiki/Captain_Churchill
+benjamin,Benjamin,"ben,benji,hacker hero",,,,,,,https://bloons.fandom.com/wiki/Benjamin
+ezili,Ezili,"ezi,voodoo",,,,,,,https://bloons.fandom.com/wiki/Ezili
+pat_fusty,Pat Fusty,"pat,fusty,patrick",,,,,,,https://bloons.fandom.com/wiki/Pat_Fusty
+adora,Adora,"ado,sun queen",,,,,,,https://bloons.fandom.com/wiki/Adora
+admiral_brickell,Admiral Brickell,"brickell,admiral,mines hero",,,,,,,https://bloons.fandom.com/wiki/Admiral_Brickell
+etienne,Etienne,"eti,drone master",,,,,,,https://bloons.fandom.com/wiki/Etienne
+sauda,Sauda,"saud,blade master",,,,,,,https://bloons.fandom.com/wiki/Sauda
+psi,Psi,"psy,psyc,psychic",,,,,,,https://bloons.fandom.com/wiki/Psi
+geraldo,Geraldo,"ger,gera,wizard merchant",,,,,,,https://bloons.fandom.com/wiki/Geraldo
+corvus,Corvus,"cor,raven hero",,,,,,,https://bloons.fandom.com/wiki/Corvus
+rosalia,Rosalia,"rosa",,,,,,,https://bloons.fandom.com/wiki/Rosalia

--- a/data/btd6/towers.csv
+++ b/data/btd6/towers.csv
@@ -1,0 +1,25 @@
+id,canonical,category,aliases,base_cost,description,top_1,top_2,top_3,top_4,top_5,mid_1,mid_2,mid_3,mid_4,mid_5,bot_1,bot_2,bot_3,bot_4,bot_5,wiki_url
+dart_monkey,Dart Monkey,primary,"dart,darts,darty",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Dart_Monkey
+boomerang_monkey,Boomerang Monkey,primary,"boomer,boomerang,boomy",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Boomerang_Monkey
+bomb_shooter,Bomb Shooter,primary,"bomb,bombs,bombshooter",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Bomb_Shooter
+tack_shooter,Tack Shooter,primary,"tack,tacks,tackshooter",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Tack_Shooter
+ice_monkey,Ice Monkey,primary,"ice,icicle",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Ice_Monkey
+glue_gunner,Glue Gunner,primary,"glue,gluey",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Glue_Gunner
+sniper_monkey,Sniper Monkey,military,"sniper",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Sniper_Monkey
+monkey_sub,Monkey Sub,military,"sub,subs,submarine",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Monkey_Sub
+monkey_buccaneer,Monkey Buccaneer,military,"bucc,buccaneer,boat,pirate",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Monkey_Buccaneer
+monkey_ace,Monkey Ace,military,"ace,plane,monkey plane",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Monkey_Ace
+heli_pilot,Heli Pilot,military,"heli,helicopter,helipilot",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Heli_Pilot
+mortar_monkey,Mortar Monkey,military,"mortar,mortars",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Mortar_Monkey
+dartling_gunner,Dartling Gunner,military,"dartling,dartlings,dart gun",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Dartling_Gunner
+wizard_monkey,Wizard Monkey,magic,"wiz,wizard",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Wizard_Monkey
+super_monkey,Super Monkey,magic,"super,smonkey,supermonkey",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Super_Monkey
+ninja_monkey,Ninja Monkey,magic,"ninja,ninjas,shinobi",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Ninja_Monkey
+alchemist,Alchemist,magic,"alch,alchy,alchemist",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Alchemist
+druid,Druid,magic,"dru,druids",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Druid
+mermonkey,Mermonkey,magic,"merm,mer monkey,fishy",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Mermonkey
+banana_farm,Banana Farm,support,"farm,farms,bf,banana",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Banana_Farm
+spike_factory,Spike Factory,support,"spike,spikes,spac",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Spike_Factory
+monkey_village,Monkey Village,support,"village,vil,monkey vil",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Monkey_Village
+engineer_monkey,Engineer Monkey,support,"engi,engineer,eng",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Engineer_Monkey
+beast_handler,Beast Handler,support,"beast,handler,bh",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Beast_Handler

--- a/disbot/services/btd6_data_service.py
+++ b/disbot/services/btd6_data_service.py
@@ -128,6 +128,9 @@ _REQUIRED_TOWER_FIELDS = (
     "upgrade_paths",
     "wiki_url",
 )
+_TOWER_CATEGORIES = frozenset({"primary", "military", "magic", "support"})
+_TOWER_UPGRADE_PATHS = ("top", "mid", "bot")
+_TOWER_UPGRADE_TIERS_PER_PATH = 5
 _REQUIRED_HERO_FIELDS = (
     "id",
     "canonical",
@@ -191,10 +194,32 @@ def _normalise_alias(value: str) -> str:
 
 def _parse_tower(raw: dict[str, Any]) -> TowerEntry:
     _require_keys(raw, _REQUIRED_TOWER_FIELDS, where=f"tower {raw.get('id')!r}")
+    category = str(raw["category"])
+    if category not in _TOWER_CATEGORIES:
+        raise BTD6DataValidationError(
+            f"tower {raw['id']!r}: category {category!r} not one of "
+            f"{sorted(_TOWER_CATEGORIES)}",
+        )
+    base_cost = int(raw["base_cost"])
+    if base_cost <= 0:
+        raise BTD6DataValidationError(
+            f"tower {raw['id']!r}: base_cost must be > 0, got {base_cost}",
+        )
     upgrade_paths_raw = raw["upgrade_paths"]
     if not isinstance(upgrade_paths_raw, dict):
         raise BTD6DataValidationError(
             f"tower {raw['id']!r}: upgrade_paths must be a dict",
+        )
+    missing_paths = [p for p in _TOWER_UPGRADE_PATHS if p not in upgrade_paths_raw]
+    if missing_paths:
+        raise BTD6DataValidationError(
+            f"tower {raw['id']!r}: upgrade_paths missing keys {missing_paths!r}",
+        )
+    extra_paths = [p for p in upgrade_paths_raw if p not in _TOWER_UPGRADE_PATHS]
+    if extra_paths:
+        raise BTD6DataValidationError(
+            f"tower {raw['id']!r}: upgrade_paths has unexpected keys "
+            f"{extra_paths!r}; only {list(_TOWER_UPGRADE_PATHS)} allowed",
         )
     upgrade_paths: dict[str, tuple[str, ...]] = {}
     for path_key, tiers in upgrade_paths_raw.items():
@@ -202,14 +227,28 @@ def _parse_tower(raw: dict[str, Any]) -> TowerEntry:
             raise BTD6DataValidationError(
                 f"tower {raw['id']!r}: upgrade_paths.{path_key} must be a list",
             )
-        upgrade_paths[path_key] = tuple(str(t) for t in tiers)
+        if len(tiers) != _TOWER_UPGRADE_TIERS_PER_PATH:
+            raise BTD6DataValidationError(
+                f"tower {raw['id']!r}: upgrade_paths.{path_key} must have "
+                f"exactly {_TOWER_UPGRADE_TIERS_PER_PATH} tiers, got {len(tiers)}",
+            )
+        tier_tuple: list[str] = []
+        for index, tier in enumerate(tiers, start=1):
+            tier_name = str(tier).strip()
+            if not tier_name:
+                raise BTD6DataValidationError(
+                    f"tower {raw['id']!r}: upgrade_paths.{path_key} tier "
+                    f"{index} is empty",
+                )
+            tier_tuple.append(tier_name)
+        upgrade_paths[path_key] = tuple(tier_tuple)
     aliases = tuple(_normalise_alias(a) for a in raw["aliases"])
     return TowerEntry(
         id=str(raw["id"]),
         canonical=str(raw["canonical"]),
         aliases=aliases,
-        category=str(raw["category"]),
-        base_cost=int(raw["base_cost"]),
+        category=category,
+        base_cost=base_cost,
         description=str(raw["description"]),
         upgrade_paths=upgrade_paths,
         wiki_url=str(raw["wiki_url"]),
@@ -218,6 +257,11 @@ def _parse_tower(raw: dict[str, Any]) -> TowerEntry:
 
 def _parse_hero(raw: dict[str, Any]) -> HeroEntry:
     _require_keys(raw, _REQUIRED_HERO_FIELDS, where=f"hero {raw.get('id')!r}")
+    base_cost = int(raw["base_cost"])
+    if base_cost <= 0:
+        raise BTD6DataValidationError(
+            f"hero {raw['id']!r}: base_cost must be > 0, got {base_cost}",
+        )
     abilities_raw = raw["abilities"]
     if not isinstance(abilities_raw, list):
         raise BTD6DataValidationError(
@@ -241,7 +285,7 @@ def _parse_hero(raw: dict[str, Any]) -> HeroEntry:
         id=str(raw["id"]),
         canonical=str(raw["canonical"]),
         aliases=tuple(_normalise_alias(a) for a in raw["aliases"]),
-        base_cost=int(raw["base_cost"]),
+        base_cost=base_cost,
         description=str(raw["description"]),
         abilities=tuple(abilities),
         wiki_url=str(raw["wiki_url"]),

--- a/disbot/services/btd6_live_query_service.py
+++ b/disbot/services/btd6_live_query_service.py
@@ -81,15 +81,53 @@ class LeaderboardRow:
 # self-documenting safety net for irregular future keys (e.g. ``Psi``,
 # ``HeliPilot``, ``BombShooter``).
 _TOWER_ID_TO_API_KEY: dict[str, str] = {
+    # Primary
     "dart_monkey": "DartMonkey",
     "boomerang_monkey": "BoomerangMonkey",
-    "tack_shooter": "TackShooter",
     "bomb_shooter": "BombShooter",
+    "tack_shooter": "TackShooter",
+    "ice_monkey": "IceMonkey",
+    "glue_gunner": "GlueGunner",
+    # Military
+    "sniper_monkey": "SniperMonkey",
+    "monkey_sub": "MonkeySub",
+    "monkey_buccaneer": "MonkeyBuccaneer",
+    "monkey_ace": "MonkeyAce",
+    "heli_pilot": "HeliPilot",
+    "mortar_monkey": "MortarMonkey",
+    "dartling_gunner": "DartlingGunner",
+    # Magic
+    "wizard_monkey": "WizardMonkey",
+    "super_monkey": "SuperMonkey",
+    "ninja_monkey": "NinjaMonkey",
+    "alchemist": "Alchemist",
+    "druid": "Druid",
+    "mermonkey": "Mermonkey",
+    # Support
+    "banana_farm": "BananaFarm",
+    "spike_factory": "SpikeFactory",
+    "monkey_village": "MonkeyVillage",
+    "engineer_monkey": "EngineerMonkey",
+    "beast_handler": "BeastHandler",
 }
 
 _HERO_ID_TO_API_KEY: dict[str, str] = {
     "quincy": "Quincy",
+    "gwendolin": "Gwendolin",
+    "striker_jones": "StrikerJones",
+    "obyn_greenfoot": "ObynGreenfoot",
+    "captain_churchill": "CaptainChurchill",
+    "benjamin": "Benjamin",
+    "ezili": "Ezili",
+    "pat_fusty": "PatFusty",
+    "adora": "Adora",
+    "admiral_brickell": "AdmiralBrickell",
+    "etienne": "Etienne",
     "sauda": "Sauda",
+    "psi": "Psi",
+    "geraldo": "Geraldo",
+    "corvus": "Corvus",
+    "rosalia": "Rosalia",
 }
 
 _CHOSEN_PRIMARY_HERO_KEY = "ChosenPrimaryHero"

--- a/scripts/import_btd6_data_from_csv.py
+++ b/scripts/import_btd6_data_from_csv.py
@@ -1,0 +1,673 @@
+"""Convert ``data/btd6/*.csv`` scaffolds into runtime JSON fixtures.
+
+The team edits ``data/btd6/towers.csv`` and ``data/btd6/heroes.csv``
+collaboratively (typically in Google Sheets). This script converts the
+CSVs into the JSON shape that ``disbot/services/btd6_data_service`` reads
+at boot.
+
+Validation runs before any file is written: if anything fails, nothing
+is touched and the error message points at the offending row + column.
+The validation mirrors what ``btd6_data_service._parse_*`` would catch
+later, so a successful import guarantees the runtime loader will accept
+the result.
+
+Usage::
+
+    python3.10 scripts/import_btd6_data_from_csv.py
+
+Optional flags::
+
+    --towers-csv PATH      Override the towers CSV path
+    --heroes-csv PATH      Override the heroes CSV path
+    --towers-json PATH     Override the towers JSON output path
+    --heroes-json PATH     Override the heroes JSON output path
+    --game-version 54.0    Stamp this game_version into the JSON envelopes
+                           (default: read from existing towers.json if present,
+                           else "TBD")
+    --check                Validate the CSVs and report errors without
+                           writing any output. Exit non-zero on any error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_DEFAULT_TOWERS_CSV = _REPO_ROOT / "data" / "btd6" / "towers.csv"
+_DEFAULT_HEROES_CSV = _REPO_ROOT / "data" / "btd6" / "heroes.csv"
+_DEFAULT_TOWERS_JSON = _REPO_ROOT / "disbot" / "data" / "btd6" / "towers.json"
+_DEFAULT_HEROES_JSON = _REPO_ROOT / "disbot" / "data" / "btd6" / "heroes.json"
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+_TOWER_CATEGORIES = frozenset({"primary", "military", "magic", "support"})
+
+_TOWER_COLUMNS: tuple[str, ...] = (
+    "id",
+    "canonical",
+    "category",
+    "aliases",
+    "base_cost",
+    "description",
+    "top_1",
+    "top_2",
+    "top_3",
+    "top_4",
+    "top_5",
+    "mid_1",
+    "mid_2",
+    "mid_3",
+    "mid_4",
+    "mid_5",
+    "bot_1",
+    "bot_2",
+    "bot_3",
+    "bot_4",
+    "bot_5",
+    "wiki_url",
+)
+
+_HERO_COLUMNS: tuple[str, ...] = (
+    "id",
+    "canonical",
+    "aliases",
+    "base_cost",
+    "description",
+    "ability_3_name",
+    "ability_3_summary",
+    "ability_10_name",
+    "ability_10_summary",
+    "wiki_url",
+)
+
+
+# ---------------------------------------------------------------------------
+# Conversion
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ConversionError:
+    """One row-level validation failure with enough context to fix it."""
+
+    file: str
+    row: int  # 1-indexed including header (so the first data row is row 2)
+    field: str
+    reason: str
+
+    def render(self) -> str:
+        return f"  {self.file}: row {self.row}, column {self.field!r}: {self.reason}"
+
+
+def _split_aliases(raw: str) -> list[str]:
+    """Parse the ``aliases`` cell: comma-separated, trimmed, deduped."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for piece in raw.split(","):
+        clean = piece.strip()
+        if not clean:
+            continue
+        lowered = clean.lower()
+        if lowered in seen:
+            continue
+        seen.add(lowered)
+        out.append(clean)
+    return out
+
+
+def _read_csv(
+    path: Path,
+    expected_columns: tuple[str, ...],
+) -> tuple[list[dict[str, str]], list[ConversionError]]:
+    """Read a CSV; verify column set; return rows + any header errors."""
+    if not path.exists():
+        return [], [
+            ConversionError(
+                file=str(path),
+                row=0,
+                field="<file>",
+                reason=f"CSV not found: {path}",
+            ),
+        ]
+    with path.open(newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        if reader.fieldnames is None:
+            return [], [
+                ConversionError(
+                    file=str(path),
+                    row=1,
+                    field="<header>",
+                    reason="empty CSV (no header row)",
+                ),
+            ]
+        missing = [c for c in expected_columns if c not in reader.fieldnames]
+        if missing:
+            return [], [
+                ConversionError(
+                    file=str(path),
+                    row=1,
+                    field="<header>",
+                    reason=f"missing columns: {missing}",
+                ),
+            ]
+        rows = list(reader)
+    return rows, []
+
+
+def _validate_required_string(
+    value: str | None,
+    *,
+    file: str,
+    row: int,
+    field: str,
+    errors: list[ConversionError],
+) -> str:
+    cleaned = (value or "").strip()
+    if not cleaned:
+        errors.append(
+            ConversionError(
+                file=file,
+                row=row,
+                field=field,
+                reason="required field is empty",
+            ),
+        )
+    return cleaned
+
+
+def _validate_positive_int(
+    value: str | None,
+    *,
+    file: str,
+    row: int,
+    field: str,
+    errors: list[ConversionError],
+) -> int:
+    raw = (value or "").strip()
+    if not raw:
+        errors.append(
+            ConversionError(
+                file=file,
+                row=row,
+                field=field,
+                reason="required positive integer is empty",
+            ),
+        )
+        return 0
+    try:
+        parsed = int(raw)
+    except ValueError:
+        errors.append(
+            ConversionError(
+                file=file,
+                row=row,
+                field=field,
+                reason=f"not a valid integer: {raw!r}",
+            ),
+        )
+        return 0
+    if parsed <= 0:
+        errors.append(
+            ConversionError(
+                file=file,
+                row=row,
+                field=field,
+                reason=f"must be > 0, got {parsed}",
+            ),
+        )
+    return parsed
+
+
+def _convert_tower_row(
+    row: dict[str, str],
+    *,
+    file: str,
+    row_number: int,
+    errors: list[ConversionError],
+) -> dict[str, Any]:
+    tower_id = _validate_required_string(
+        row.get("id"),
+        file=file,
+        row=row_number,
+        field="id",
+        errors=errors,
+    )
+    canonical = _validate_required_string(
+        row.get("canonical"),
+        file=file,
+        row=row_number,
+        field="canonical",
+        errors=errors,
+    )
+    category = _validate_required_string(
+        row.get("category"),
+        file=file,
+        row=row_number,
+        field="category",
+        errors=errors,
+    )
+    if category and category not in _TOWER_CATEGORIES:
+        errors.append(
+            ConversionError(
+                file=file,
+                row=row_number,
+                field="category",
+                reason=(
+                    f"must be one of {sorted(_TOWER_CATEGORIES)}; got {category!r}"
+                ),
+            ),
+        )
+    base_cost = _validate_positive_int(
+        row.get("base_cost"),
+        file=file,
+        row=row_number,
+        field="base_cost",
+        errors=errors,
+    )
+    description = _validate_required_string(
+        row.get("description"),
+        file=file,
+        row=row_number,
+        field="description",
+        errors=errors,
+    )
+    wiki_url = _validate_required_string(
+        row.get("wiki_url"),
+        file=file,
+        row=row_number,
+        field="wiki_url",
+        errors=errors,
+    )
+    aliases = _split_aliases(row.get("aliases") or "")
+
+    upgrade_paths: dict[str, list[str]] = {}
+    for path_key, prefix in (("top", "top_"), ("mid", "mid_"), ("bot", "bot_")):
+        tiers: list[str] = []
+        for tier in range(1, 6):
+            field = f"{prefix}{tier}"
+            tier_value = _validate_required_string(
+                row.get(field),
+                file=file,
+                row=row_number,
+                field=field,
+                errors=errors,
+            )
+            tiers.append(tier_value)
+        upgrade_paths[path_key] = tiers
+
+    return {
+        "id": tower_id,
+        "canonical": canonical,
+        "aliases": aliases,
+        "category": category,
+        "base_cost": base_cost,
+        "description": description,
+        "upgrade_paths": upgrade_paths,
+        "wiki_url": wiki_url,
+    }
+
+
+def _convert_hero_row(
+    row: dict[str, str],
+    *,
+    file: str,
+    row_number: int,
+    errors: list[ConversionError],
+) -> dict[str, Any]:
+    hero_id = _validate_required_string(
+        row.get("id"),
+        file=file,
+        row=row_number,
+        field="id",
+        errors=errors,
+    )
+    canonical = _validate_required_string(
+        row.get("canonical"),
+        file=file,
+        row=row_number,
+        field="canonical",
+        errors=errors,
+    )
+    base_cost = _validate_positive_int(
+        row.get("base_cost"),
+        file=file,
+        row=row_number,
+        field="base_cost",
+        errors=errors,
+    )
+    description = _validate_required_string(
+        row.get("description"),
+        file=file,
+        row=row_number,
+        field="description",
+        errors=errors,
+    )
+    wiki_url = _validate_required_string(
+        row.get("wiki_url"),
+        file=file,
+        row=row_number,
+        field="wiki_url",
+        errors=errors,
+    )
+    aliases = _split_aliases(row.get("aliases") or "")
+
+    abilities: list[dict[str, Any]] = []
+    for level, name_field, summary_field in (
+        (3, "ability_3_name", "ability_3_summary"),
+        (10, "ability_10_name", "ability_10_summary"),
+    ):
+        name = _validate_required_string(
+            row.get(name_field),
+            file=file,
+            row=row_number,
+            field=name_field,
+            errors=errors,
+        )
+        summary = _validate_required_string(
+            row.get(summary_field),
+            file=file,
+            row=row_number,
+            field=summary_field,
+            errors=errors,
+        )
+        abilities.append({"level": level, "name": name, "summary": summary})
+
+    return {
+        "id": hero_id,
+        "canonical": canonical,
+        "aliases": aliases,
+        "base_cost": base_cost,
+        "description": description,
+        "abilities": abilities,
+        "wiki_url": wiki_url,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Cross-row validation (uniqueness, alias collisions)
+# ---------------------------------------------------------------------------
+
+
+def _check_unique_ids(
+    entries: list[dict[str, Any]],
+    *,
+    file: str,
+    errors: list[ConversionError],
+) -> None:
+    seen: dict[str, int] = {}
+    for idx, entry in enumerate(entries, start=2):  # row 2 = first data row
+        entry_id = entry.get("id")
+        if not entry_id:
+            continue
+        if entry_id in seen:
+            errors.append(
+                ConversionError(
+                    file=file,
+                    row=idx,
+                    field="id",
+                    reason=(
+                        f"duplicate id {entry_id!r} (first seen at row {seen[entry_id]})"
+                    ),
+                ),
+            )
+        else:
+            seen[entry_id] = idx
+
+
+def _check_alias_collisions(
+    *,
+    towers: list[dict[str, Any]],
+    heroes: list[dict[str, Any]],
+    errors: list[ConversionError],
+    towers_file: str,
+    heroes_file: str,
+) -> None:
+    """Catch alias collisions before they reach the runtime validator."""
+    owners: dict[str, tuple[str, str, int]] = {}
+    for idx, tower in enumerate(towers, start=2):
+        all_terms = [*tower.get("aliases", [])]
+        canonical = tower.get("canonical")
+        if canonical:
+            all_terms.append(canonical)
+        for term in all_terms:
+            key = term.strip().lower()
+            if not key:
+                continue
+            owner_label = f"tower:{tower.get('id')}"
+            if key in owners and owners[key][0] != owner_label:
+                existing_owner, existing_file, existing_row = owners[key]
+                errors.append(
+                    ConversionError(
+                        file=towers_file,
+                        row=idx,
+                        field="aliases",
+                        reason=(
+                            f"alias collision: {key!r} also owned by "
+                            f"{existing_owner} ({existing_file} row {existing_row})"
+                        ),
+                    ),
+                )
+            else:
+                owners[key] = (owner_label, towers_file, idx)
+    for idx, hero in enumerate(heroes, start=2):
+        all_terms = [*hero.get("aliases", [])]
+        canonical = hero.get("canonical")
+        if canonical:
+            all_terms.append(canonical)
+        for term in all_terms:
+            key = term.strip().lower()
+            if not key:
+                continue
+            owner_label = f"hero:{hero.get('id')}"
+            if key in owners and owners[key][0] != owner_label:
+                existing_owner, existing_file, existing_row = owners[key]
+                errors.append(
+                    ConversionError(
+                        file=heroes_file,
+                        row=idx,
+                        field="aliases",
+                        reason=(
+                            f"alias collision: {key!r} also owned by "
+                            f"{existing_owner} ({existing_file} row {existing_row})"
+                        ),
+                    ),
+                )
+            else:
+                owners[key] = (owner_label, heroes_file, idx)
+
+
+# ---------------------------------------------------------------------------
+# Top-level convert
+# ---------------------------------------------------------------------------
+
+
+def _existing_game_version(json_path: Path) -> str:
+    if not json_path.exists():
+        return "TBD"
+    try:
+        data = json.loads(json_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return "TBD"
+    value = data.get("game_version")
+    return str(value) if value else "TBD"
+
+
+def convert(
+    *,
+    towers_csv: Path,
+    heroes_csv: Path,
+    towers_json: Path,
+    heroes_json: Path,
+    game_version: str | None,
+    check_only: bool,
+) -> int:
+    """Run a full CSV→JSON conversion. Return process exit code."""
+    errors: list[ConversionError] = []
+
+    tower_rows, header_errors = _read_csv(towers_csv, _TOWER_COLUMNS)
+    errors.extend(header_errors)
+    hero_rows, header_errors = _read_csv(heroes_csv, _HERO_COLUMNS)
+    errors.extend(header_errors)
+
+    converted_towers: list[dict[str, Any]] = []
+    for offset, row in enumerate(tower_rows):
+        converted_towers.append(
+            _convert_tower_row(
+                row,
+                file=str(towers_csv),
+                row_number=offset + 2,
+                errors=errors,
+            ),
+        )
+
+    converted_heroes: list[dict[str, Any]] = []
+    for offset, row in enumerate(hero_rows):
+        converted_heroes.append(
+            _convert_hero_row(
+                row,
+                file=str(heroes_csv),
+                row_number=offset + 2,
+                errors=errors,
+            ),
+        )
+
+    _check_unique_ids(
+        converted_towers,
+        file=str(towers_csv),
+        errors=errors,
+    )
+    _check_unique_ids(
+        converted_heroes,
+        file=str(heroes_csv),
+        errors=errors,
+    )
+    _check_alias_collisions(
+        towers=converted_towers,
+        heroes=converted_heroes,
+        errors=errors,
+        towers_file=str(towers_csv),
+        heroes_file=str(heroes_csv),
+    )
+
+    if errors:
+        print(f"Refusing to write — {len(errors)} validation error(s):")
+        for err in errors:
+            print(err.render())
+        return 1
+
+    resolved_game_version = (
+        game_version if game_version else _existing_game_version(towers_json)
+    )
+    source_label = "hand-curated from public BTD6 reference data"
+
+    towers_envelope = {
+        "data_version": "1.0",
+        "game_version": resolved_game_version,
+        "source": source_label,
+        "towers": converted_towers,
+    }
+    heroes_envelope = {
+        "data_version": "1.0",
+        "game_version": resolved_game_version,
+        "source": source_label,
+        "heroes": converted_heroes,
+    }
+
+    if check_only:
+        print(
+            f"OK — {len(converted_towers)} tower(s) and "
+            f"{len(converted_heroes)} hero(es) validated. "
+            "No files written (--check).",
+        )
+        return 0
+
+    towers_json.parent.mkdir(parents=True, exist_ok=True)
+    heroes_json.parent.mkdir(parents=True, exist_ok=True)
+    towers_json.write_text(
+        json.dumps(towers_envelope, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    heroes_json.write_text(
+        json.dumps(heroes_envelope, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    print(
+        f"Wrote {towers_json} ({len(converted_towers)} towers) and "
+        f"{heroes_json} ({len(converted_heroes)} heroes) "
+        f"at game_version={resolved_game_version}.",
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Convert data/btd6/*.csv scaffolds into runtime JSON.",
+    )
+    parser.add_argument(
+        "--towers-csv",
+        type=Path,
+        default=_DEFAULT_TOWERS_CSV,
+    )
+    parser.add_argument(
+        "--heroes-csv",
+        type=Path,
+        default=_DEFAULT_HEROES_CSV,
+    )
+    parser.add_argument(
+        "--towers-json",
+        type=Path,
+        default=_DEFAULT_TOWERS_JSON,
+    )
+    parser.add_argument(
+        "--heroes-json",
+        type=Path,
+        default=_DEFAULT_HEROES_JSON,
+    )
+    parser.add_argument(
+        "--game-version",
+        type=str,
+        default=None,
+        help="Game version stamp for the JSON envelopes.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Validate without writing.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return convert(
+        towers_csv=args.towers_csv,
+        heroes_csv=args.heroes_csv,
+        towers_json=args.towers_json,
+        heroes_json=args.heroes_json,
+        game_version=args.game_version,
+        check_only=args.check,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_import_btd6_data_from_csv.py
+++ b/tests/unit/scripts/test_import_btd6_data_from_csv.py
@@ -1,0 +1,408 @@
+"""Tests for ``scripts/import_btd6_data_from_csv.py``.
+
+Covers happy path, every validation failure mode, alias-collision
+detection, and that the produced JSON round-trips through the same
+loader the runtime uses (``services.btd6_data_service``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO_ROOT / "scripts" / "import_btd6_data_from_csv.py"
+
+
+@pytest.fixture(scope="module")
+def importer():
+    """Load the import script as a module under a unique name."""
+    spec = importlib.util.spec_from_file_location(
+        "import_btd6_data_from_csv_under_test",
+        _SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_TOWER_HEADER = (
+    "id,canonical,category,aliases,base_cost,description,"
+    "top_1,top_2,top_3,top_4,top_5,"
+    "mid_1,mid_2,mid_3,mid_4,mid_5,"
+    "bot_1,bot_2,bot_3,bot_4,bot_5,"
+    "wiki_url\n"
+)
+_HERO_HEADER = (
+    "id,canonical,aliases,base_cost,description,"
+    "ability_3_name,ability_3_summary,"
+    "ability_10_name,ability_10_summary,wiki_url\n"
+)
+
+
+def _valid_tower_row(
+    *,
+    tower_id: str = "dart_monkey",
+    canonical: str = "Dart Monkey",
+    category: str = "primary",
+    aliases: str = "dart,darts",
+    base_cost: str = "200",
+    description: str = "Throws a dart.",
+    wiki_url: str = "https://example.invalid/Dart_Monkey",
+) -> str:
+    tiers = ",".join([f"u{i}" for i in range(1, 16)])
+    return (
+        f'{tower_id},{canonical},{category},"{aliases}",'
+        f"{base_cost},{description},{tiers},{wiki_url}\n"
+    )
+
+
+def _valid_hero_row(
+    *,
+    hero_id: str = "quincy",
+    canonical: str = "Quincy",
+    aliases: str = "q",
+    base_cost: str = "540",
+    description: str = "Starter hero.",
+    ability_3_name: str = "Rapid Shot",
+    ability_3_summary: str = "Briefly fast.",
+    ability_10_name: str = "Storm of Arrows",
+    ability_10_summary: str = "Massive AoE.",
+    wiki_url: str = "https://example.invalid/Quincy",
+) -> str:
+    return (
+        f'{hero_id},{canonical},"{aliases}",'
+        f"{base_cost},{description},"
+        f"{ability_3_name},{ability_3_summary},"
+        f"{ability_10_name},{ability_10_summary},{wiki_url}\n"
+    )
+
+
+def _write_csvs(
+    tmp_path: Path,
+    *,
+    tower_rows: list[str],
+    hero_rows: list[str],
+) -> tuple[Path, Path]:
+    towers_csv = tmp_path / "towers.csv"
+    heroes_csv = tmp_path / "heroes.csv"
+    towers_csv.write_text(_TOWER_HEADER + "".join(tower_rows), encoding="utf-8")
+    heroes_csv.write_text(_HERO_HEADER + "".join(hero_rows), encoding="utf-8")
+    return towers_csv, heroes_csv
+
+
+def _run(
+    importer,
+    tmp_path: Path,
+    *,
+    tower_rows: list[str],
+    hero_rows: list[str],
+    check_only: bool = False,
+    game_version: str | None = "test-1.0",
+) -> tuple[int, Path, Path]:
+    towers_csv, heroes_csv = _write_csvs(
+        tmp_path,
+        tower_rows=tower_rows,
+        hero_rows=hero_rows,
+    )
+    towers_json = tmp_path / "towers.json"
+    heroes_json = tmp_path / "heroes.json"
+    rc = importer.convert(
+        towers_csv=towers_csv,
+        heroes_csv=heroes_csv,
+        towers_json=towers_json,
+        heroes_json=heroes_json,
+        game_version=game_version,
+        check_only=check_only,
+    )
+    return rc, towers_json, heroes_json
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_writes_valid_json(importer, tmp_path, capsys):
+    rc, towers_json, heroes_json = _run(
+        importer,
+        tmp_path,
+        tower_rows=[_valid_tower_row()],
+        hero_rows=[_valid_hero_row()],
+    )
+    assert rc == 0
+    assert towers_json.exists() and heroes_json.exists()
+
+    towers = json.loads(towers_json.read_text())
+    heroes = json.loads(heroes_json.read_text())
+    assert towers["data_version"] == "1.0"
+    assert towers["game_version"] == "test-1.0"
+    assert len(towers["towers"]) == 1
+    tower = towers["towers"][0]
+    assert tower["id"] == "dart_monkey"
+    assert tower["category"] == "primary"
+    assert tower["base_cost"] == 200
+    assert tower["upgrade_paths"]["top"] == ["u1", "u2", "u3", "u4", "u5"]
+    assert tower["upgrade_paths"]["mid"] == ["u6", "u7", "u8", "u9", "u10"]
+    assert tower["upgrade_paths"]["bot"] == ["u11", "u12", "u13", "u14", "u15"]
+    assert tower["aliases"] == ["dart", "darts"]
+
+    assert len(heroes["heroes"]) == 1
+    hero = heroes["heroes"][0]
+    assert hero["id"] == "quincy"
+    assert hero["base_cost"] == 540
+    assert hero["abilities"] == [
+        {"level": 3, "name": "Rapid Shot", "summary": "Briefly fast."},
+        {"level": 10, "name": "Storm of Arrows", "summary": "Massive AoE."},
+    ]
+
+
+def test_happy_path_round_trips_through_runtime_loader(importer, tmp_path, monkeypatch):
+    """JSON the script produces must load cleanly via btd6_data_service."""
+    rc, towers_json, heroes_json = _run(
+        importer,
+        tmp_path,
+        tower_rows=[_valid_tower_row()],
+        hero_rows=[_valid_hero_row()],
+    )
+    assert rc == 0
+
+    # Stage the JSON into a fresh data root, plus the other fixtures we don't
+    # touch (maps / modes / rounds) from the repo.
+    fake_root = tmp_path / "data_root"
+    fake_root.mkdir()
+    real_data = _REPO_ROOT / "disbot" / "data" / "btd6"
+    (fake_root / "towers.json").write_text(towers_json.read_text())
+    (fake_root / "heroes.json").write_text(heroes_json.read_text())
+    for filename in ("maps.json", "modes.json", "rounds.json"):
+        (fake_root / filename).write_text((real_data / filename).read_text())
+
+    from services import btd6_data_service
+
+    monkeypatch.setattr(btd6_data_service, "DATA_ROOT", fake_root)
+    btd6_data_service.reset_cache()
+    try:
+        dataset = btd6_data_service.get_dataset()
+        assert len(dataset.towers) == 1
+        assert dataset.towers[0].id == "dart_monkey"
+        assert dataset.towers[0].category == "primary"
+        assert dataset.heroes[0].id == "quincy"
+    finally:
+        btd6_data_service.reset_cache()
+
+
+def test_check_mode_validates_without_writing(importer, tmp_path):
+    rc, towers_json, heroes_json = _run(
+        importer,
+        tmp_path,
+        tower_rows=[_valid_tower_row()],
+        hero_rows=[_valid_hero_row()],
+        check_only=True,
+    )
+    assert rc == 0
+    assert not towers_json.exists()
+    assert not heroes_json.exists()
+
+
+# ---------------------------------------------------------------------------
+# Per-field validation failures
+# ---------------------------------------------------------------------------
+
+
+def test_empty_required_field_fails(importer, tmp_path, capsys):
+    rc, towers_json, _ = _run(
+        importer,
+        tmp_path,
+        tower_rows=[_valid_tower_row(description="")],
+        hero_rows=[_valid_hero_row()],
+    )
+    assert rc == 1
+    assert not towers_json.exists()
+    output = capsys.readouterr().out
+    assert "description" in output
+
+
+def test_invalid_category_fails(importer, tmp_path, capsys):
+    rc, _, _ = _run(
+        importer,
+        tmp_path,
+        tower_rows=[_valid_tower_row(category="primay")],
+        hero_rows=[_valid_hero_row()],
+    )
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "category" in out
+    assert "primay" in out
+
+
+def test_zero_base_cost_fails(importer, tmp_path, capsys):
+    rc, _, _ = _run(
+        importer,
+        tmp_path,
+        tower_rows=[_valid_tower_row(base_cost="0")],
+        hero_rows=[_valid_hero_row()],
+    )
+    assert rc == 1
+    assert "base_cost" in capsys.readouterr().out
+
+
+def test_non_integer_base_cost_fails(importer, tmp_path, capsys):
+    rc, _, _ = _run(
+        importer,
+        tmp_path,
+        tower_rows=[_valid_tower_row(base_cost="not-a-number")],
+        hero_rows=[_valid_hero_row()],
+    )
+    assert rc == 1
+    assert "base_cost" in capsys.readouterr().out
+
+
+def test_empty_upgrade_tier_fails(importer, tmp_path, capsys):
+    bad_row = (
+        'dart_monkey,Dart Monkey,primary,"d",200,Desc.,'
+        ",t2,t3,t4,t5,m1,m2,m3,m4,m5,b1,b2,b3,b4,b5,"
+        "https://example.invalid/d\n"
+    )
+    rc, _, _ = _run(
+        importer,
+        tmp_path,
+        tower_rows=[bad_row],
+        hero_rows=[_valid_hero_row()],
+    )
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "top_1" in out
+
+
+# ---------------------------------------------------------------------------
+# Cross-row validation
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_tower_id_fails(importer, tmp_path, capsys):
+    rc, _, _ = _run(
+        importer,
+        tmp_path,
+        tower_rows=[
+            _valid_tower_row(tower_id="dart_monkey", canonical="Dart Monkey"),
+            _valid_tower_row(tower_id="dart_monkey", canonical="Dart Monkey 2"),
+        ],
+        hero_rows=[_valid_hero_row()],
+    )
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "duplicate" in out.lower()
+    assert "dart_monkey" in out
+
+
+def test_tower_hero_alias_collision_fails(importer, tmp_path, capsys):
+    rc, _, _ = _run(
+        importer,
+        tmp_path,
+        tower_rows=[_valid_tower_row(aliases="shared")],
+        hero_rows=[_valid_hero_row(aliases="shared")],
+    )
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "alias collision" in out.lower()
+    assert "shared" in out
+
+
+def test_aliases_split_and_dedup(importer, tmp_path):
+    rc, towers_json, _ = _run(
+        importer,
+        tmp_path,
+        tower_rows=[_valid_tower_row(aliases="A, b , B,  c")],
+        hero_rows=[_valid_hero_row()],
+    )
+    assert rc == 0
+    aliases = json.loads(towers_json.read_text())["towers"][0]["aliases"]
+    # Dedup is case-insensitive, preserves first-seen casing.
+    assert aliases == ["A", "b", "c"]
+
+
+# ---------------------------------------------------------------------------
+# Header / file errors
+# ---------------------------------------------------------------------------
+
+
+def test_missing_column_fails(importer, tmp_path, capsys):
+    # Drop the `category` column from header.
+    towers_csv = tmp_path / "towers.csv"
+    heroes_csv = tmp_path / "heroes.csv"
+    towers_csv.write_text("id,canonical\n", encoding="utf-8")
+    heroes_csv.write_text(_HERO_HEADER + _valid_hero_row(), encoding="utf-8")
+    rc = importer.convert(
+        towers_csv=towers_csv,
+        heroes_csv=heroes_csv,
+        towers_json=tmp_path / "towers.json",
+        heroes_json=tmp_path / "heroes.json",
+        game_version="x",
+        check_only=False,
+    )
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "missing columns" in out
+
+
+def test_missing_file_fails(importer, tmp_path, capsys):
+    rc = importer.convert(
+        towers_csv=tmp_path / "no-such.csv",
+        heroes_csv=tmp_path / "no-such-2.csv",
+        towers_json=tmp_path / "towers.json",
+        heroes_json=tmp_path / "heroes.json",
+        game_version="x",
+        check_only=False,
+    )
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "not found" in out
+
+
+# ---------------------------------------------------------------------------
+# Scaffold integrity — the prefilled CSVs must parse without crashing
+# ---------------------------------------------------------------------------
+
+
+def test_scaffold_csvs_are_well_formed(importer):
+    """The committed scaffold CSVs should validate cleanly at the header
+    level even though content cells are blank — every row should still
+    parse and emit per-field errors rather than crashing.
+    """
+    towers_csv = _REPO_ROOT / "data" / "btd6" / "towers.csv"
+    heroes_csv = _REPO_ROOT / "data" / "btd6" / "heroes.csv"
+    assert towers_csv.exists()
+    assert heroes_csv.exists()
+    tower_rows, errors = importer._read_csv(towers_csv, importer._TOWER_COLUMNS)
+    assert errors == [], f"unexpected header errors: {errors}"
+    assert len(tower_rows) >= 20, "scaffold should list the full roster"
+    hero_rows, errors = importer._read_csv(heroes_csv, importer._HERO_COLUMNS)
+    assert errors == []
+    assert len(hero_rows) >= 10
+
+
+def test_scaffold_roster_matches_api_key_mappings(importer):
+    """Every tower / hero in the CSV must already have an API-key mapping —
+    otherwise the live-query coverage test will fail once the import runs.
+    """
+    from services import btd6_live_query_service as live
+
+    towers_csv = _REPO_ROOT / "data" / "btd6" / "towers.csv"
+    heroes_csv = _REPO_ROOT / "data" / "btd6" / "heroes.csv"
+    tower_rows, _ = importer._read_csv(towers_csv, importer._TOWER_COLUMNS)
+    hero_rows, _ = importer._read_csv(heroes_csv, importer._HERO_COLUMNS)
+
+    missing_towers = [
+        row["id"] for row in tower_rows if row["id"] not in live._TOWER_ID_TO_API_KEY
+    ]
+    missing_heroes = [
+        row["id"] for row in hero_rows if row["id"] not in live._HERO_ID_TO_API_KEY
+    ]
+    assert not missing_towers, missing_towers
+    assert not missing_heroes, missing_heroes

--- a/tests/unit/services/test_btd6_data_service.py
+++ b/tests/unit/services/test_btd6_data_service.py
@@ -44,16 +44,18 @@ def test_tower_upgrade_paths_have_five_tiers():
     dataset = get_dataset()
     for tower in dataset.towers:
         for path_name, tiers in tower.upgrade_paths.items():
-            assert len(tiers) == 5, (
-                f"{tower.id}.{path_name} should have 5 tiers, got {len(tiers)}"
-            )
+            assert (
+                len(tiers) == 5
+            ), f"{tower.id}.{path_name} should have 5 tiers, got {len(tiers)}"
 
 
 def test_chimps_mode_has_no_income_restriction():
     dataset = get_dataset()
     chimps = next((m for m in dataset.modes if m.id == "chimps"), None)
     assert chimps is not None, "CHIMPS mode must be in the fixture"
-    assert any("income" in r.lower() or "farm" in r.lower() for r in chimps.restrictions)
+    assert any(
+        "income" in r.lower() or "farm" in r.lower() for r in chimps.restrictions
+    )
 
 
 def test_alias_collision_fails_loudly(tmp_path):
@@ -141,3 +143,104 @@ def test_missing_required_field_fails_loudly(tmp_path):
     finally:
         data_service.DATA_ROOT = original
         reset_cache()
+
+
+# ---------------------------------------------------------------------------
+# Extended validation: category, base_cost, upgrade-path shape
+# ---------------------------------------------------------------------------
+
+
+def _stage_data(tmp_path: Path) -> Path:
+    """Copy every fixture into a fresh root so tests can mutate one safely."""
+    root = tmp_path / "btd6"
+    root.mkdir()
+    for filename in ("towers", "heroes", "maps", "modes", "rounds"):
+        source = DATA_ROOT / f"{filename}.json"
+        (root / f"{filename}.json").write_text(
+            source.read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+    return root
+
+
+def _expect_validation_error(
+    bad_root: Path,
+    *,
+    match: str,
+) -> None:
+    import services.btd6_data_service as data_service
+
+    original = data_service.DATA_ROOT
+    data_service.DATA_ROOT = bad_root
+    try:
+        reset_cache()
+        with pytest.raises(BTD6DataValidationError, match=match):
+            get_dataset()
+    finally:
+        data_service.DATA_ROOT = original
+        reset_cache()
+
+
+def test_invalid_tower_category_fails(tmp_path):
+    bad_root = _stage_data(tmp_path)
+    towers_path = bad_root / "towers.json"
+    towers = json.loads(towers_path.read_text(encoding="utf-8"))
+    towers["towers"][0]["category"] = "primay"  # deliberate typo
+    towers_path.write_text(json.dumps(towers), encoding="utf-8")
+    _expect_validation_error(bad_root, match="category 'primay'")
+
+
+def test_zero_tower_base_cost_fails(tmp_path):
+    bad_root = _stage_data(tmp_path)
+    towers_path = bad_root / "towers.json"
+    towers = json.loads(towers_path.read_text(encoding="utf-8"))
+    towers["towers"][0]["base_cost"] = 0
+    towers_path.write_text(json.dumps(towers), encoding="utf-8")
+    _expect_validation_error(bad_root, match="base_cost must be > 0")
+
+
+def test_negative_hero_base_cost_fails(tmp_path):
+    bad_root = _stage_data(tmp_path)
+    heroes_path = bad_root / "heroes.json"
+    heroes = json.loads(heroes_path.read_text(encoding="utf-8"))
+    heroes["heroes"][0]["base_cost"] = -100
+    heroes_path.write_text(json.dumps(heroes), encoding="utf-8")
+    _expect_validation_error(bad_root, match="base_cost must be > 0")
+
+
+def test_missing_upgrade_path_key_fails(tmp_path):
+    bad_root = _stage_data(tmp_path)
+    towers_path = bad_root / "towers.json"
+    towers = json.loads(towers_path.read_text(encoding="utf-8"))
+    del towers["towers"][0]["upgrade_paths"]["bot"]
+    towers_path.write_text(json.dumps(towers), encoding="utf-8")
+    _expect_validation_error(bad_root, match="upgrade_paths missing keys")
+
+
+def test_extra_upgrade_path_key_fails(tmp_path):
+    bad_root = _stage_data(tmp_path)
+    towers_path = bad_root / "towers.json"
+    towers = json.loads(towers_path.read_text(encoding="utf-8"))
+    towers["towers"][0]["upgrade_paths"]["extra"] = ["x"] * 5
+    towers_path.write_text(json.dumps(towers), encoding="utf-8")
+    _expect_validation_error(bad_root, match="unexpected keys")
+
+
+def test_wrong_tier_count_fails(tmp_path):
+    bad_root = _stage_data(tmp_path)
+    towers_path = bad_root / "towers.json"
+    towers = json.loads(towers_path.read_text(encoding="utf-8"))
+    towers["towers"][0]["upgrade_paths"]["top"] = ["a", "b", "c"]
+    towers_path.write_text(json.dumps(towers), encoding="utf-8")
+    _expect_validation_error(bad_root, match="must have exactly 5 tiers")
+
+
+def test_empty_upgrade_tier_name_fails(tmp_path):
+    bad_root = _stage_data(tmp_path)
+    towers_path = bad_root / "towers.json"
+    towers = json.loads(towers_path.read_text(encoding="utf-8"))
+    tiers = towers["towers"][0]["upgrade_paths"]["top"]
+    tiers[2] = "   "
+    towers["towers"][0]["upgrade_paths"]["top"] = tiers
+    towers_path.write_text(json.dumps(towers), encoding="utf-8")
+    _expect_validation_error(bad_root, match="tier 3 is empty")


### PR DESCRIPTION
## Summary

The Ninja Kiwi Open Data API does not expose tower/hero stats (verified by direct 404 probes against `/btd6/towers` and `/btd6/heroes`). This PR sets up the workflow for the team to hand-curate the full roster, without adding any AI-fabricated numbers.

Three pieces:

1. **Pre-populated scaffold CSVs** — `data/btd6/towers.csv` (24 towers) and `data/btd6/heroes.csv` (16 heroes through Rosalia / v45.0). Identity columns (`id`, `canonical`, `category`, `aliases`, `wiki_url`) prefilled; content columns blank for the team to fill from in-game.
2. **CSV → JSON import script** — `scripts/import_btd6_data_from_csv.py` validates every row before writing and reports row + column for any error.
3. **Extended runtime validation** — `services.btd6_data_service` now rejects bad data the same way the import script does, plus pre-populated API-key mappings so the coverage test stays green the moment the team imports.

The runtime JSON files (`disbot/data/btd6/{towers,heroes}.json`) are NOT modified by this PR. The bot keeps working with the existing 4-tower / 2-hero sample until the team runs the import.

## Workflow for the team

1. Open the CSVs in Google Sheets (or any spreadsheet tool).
2. Distribute rows across the team (one tower per person, or by category).
3. Fill in `base_cost`, `description`, the 15 upgrade names per tower (5 tiers × 3 paths), and hero ability fields. Verify against in-game info screens.
4. Export back to CSV, replace `data/btd6/*.csv` in the repo.
5. Run `python3.10 scripts/import_btd6_data_from_csv.py`. On success it writes `disbot/data/btd6/{towers,heroes}.json`; on failure it prints `file: row N, column 'X': reason` for every problem and writes nothing.
6. Commit the regenerated JSON alongside the CSV changes.

## Validation rules added

- `category` must be one of `{primary, military, magic, support}`
- `base_cost` must be a positive integer
- `upgrade_paths` must have exactly `{top, mid, bot}` keys
- Each path must have exactly 5 tiers
- No empty tier names (whitespace counts as empty)
- Hero `base_cost` must be a positive integer

All enforced both in the import script (before writing) and in `services.btd6_data_service` (at runtime boot) so a successful import guarantees the runtime will accept the result.

## API-key mappings expanded

Pre-populated `_TOWER_ID_TO_API_KEY` and `_HERO_ID_TO_API_KEY` in `btd6_live_query_service.py` with all 24 towers and 16 heroes (snake_case → CamelCase, e.g. `mermonkey` → `Mermonkey`). The mapping-coverage test (`test_btd6_live_query_service_mapping_coverage.py`) will stay green the moment the team's data lands.

## Verification

- `python3.10 -m pytest tests/unit/scripts/ tests/unit/services/test_btd6_data_service.py tests/unit/services/test_btd6_live_query_service_mapping_coverage.py -q` → **36 passed**
- `python3.10 -m pytest tests/unit/services/ -k "btd6" -q` → **430 passed** (full BTD6 service regression)
- `python3.10 scripts/check_architecture.py --mode strict` → **0 errors**
- Smoke test: `python3.10 scripts/import_btd6_data_from_csv.py --check` against the empty scaffold correctly refuses with 504 per-cell errors (one per blank cell) and writes nothing
- Black / isort / ruff clean on all new and edited files

## What I deliberately did NOT do

- Did not generate stat numbers from training data (too high a hallucination risk for specific numeric values)
- Did not scrape the wiki automatically (CC-BY-SA territory; the team chose hand-curation)
- Did not modify the runtime JSON files (the team owns the rollout)

## Test plan

- [ ] CI green
- [ ] The team can open the CSVs in their preferred spreadsheet tool and fill them out
- [ ] After import, `/btd6 tower Mermonkey` (or any tower in the new dataset) returns a real result instead of "I don't have information about that"

https://claude.ai/code/session_01MVqPyLbtcZAjdSbmhrLEkg

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVqPyLbtcZAjdSbmhrLEkg)_