### PR TITLE
btd6: add Desperado tower and Silas hero to the data scaffold

### DIFF
--- a/data/btd6/heroes.csv
+++ b/data/btd6/heroes.csv
@@ -15,3 +15,4 @@ psi,Psi,"psy,psyc,psychic",,,,,,,https://bloons.fandom.com/wiki/Psi
 geraldo,Geraldo,"ger,gera,wizard merchant",,,,,,,https://bloons.fandom.com/wiki/Geraldo
 corvus,Corvus,"cor,raven hero",,,,,,,https://bloons.fandom.com/wiki/Corvus
 rosalia,Rosalia,"rosa",,,,,,,https://bloons.fandom.com/wiki/Rosalia
+silas,Silas,"si,ice hero",,,,,,,https://bloons.fandom.com/wiki/Silas

--- a/data/btd6/towers.csv
+++ b/data/btd6/towers.csv
@@ -5,6 +5,7 @@ bomb_shooter,Bomb Shooter,primary,"bomb,bombs,bombshooter",,,,,,,,,,,,,,,,,,http
 tack_shooter,Tack Shooter,primary,"tack,tacks,tackshooter",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Tack_Shooter
 ice_monkey,Ice Monkey,primary,"ice,icicle",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Ice_Monkey
 glue_gunner,Glue Gunner,primary,"glue,gluey",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Glue_Gunner
+desperado,Desperado,primary,"des,cowboy,gunslinger",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Desperado
 sniper_monkey,Sniper Monkey,military,"sniper",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Sniper_Monkey
 monkey_sub,Monkey Sub,military,"sub,subs,submarine",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Monkey_Sub
 monkey_buccaneer,Monkey Buccaneer,military,"bucc,buccaneer,boat,pirate",,,,,,,,,,,,,,,,,,https://bloons.fandom.com/wiki/Monkey_Buccaneer

--- a/disbot/services/btd6_live_query_service.py
+++ b/disbot/services/btd6_live_query_service.py
@@ -88,6 +88,7 @@ _TOWER_ID_TO_API_KEY: dict[str, str] = {
     "tack_shooter": "TackShooter",
     "ice_monkey": "IceMonkey",
     "glue_gunner": "GlueGunner",
+    "desperado": "Desperado",
     # Military
     "sniper_monkey": "SniperMonkey",
     "monkey_sub": "MonkeySub",
@@ -128,6 +129,7 @@ _HERO_ID_TO_API_KEY: dict[str, str] = {
     "geraldo": "Geraldo",
     "corvus": "Corvus",
     "rosalia": "Rosalia",
+    "silas": "Silas",
 }
 
 _CHOSEN_PRIMARY_HERO_KEY = "ChosenPrimaryHero"


### PR DESCRIPTION
## Summary

Follow-up to the merged scaffold PR #367. User flagged two roster entries that I missed because they shipped after my training data's confident cutoff:

- **Desperado** — primary tower (cowboy / gunslinger theme)
- **Silas** — ice-themed hero

## Changes

- `data/btd6/towers.csv` — new `desperado` row in the primary section (between `glue_gunner` and `sniper_monkey`). Aliases prefilled: `des`, `cowboy`, `gunslinger`.
- `data/btd6/heroes.csv` — new `silas` row at end of file. Aliases prefilled: `si`, `ice hero`.
- `disbot/services/btd6_live_query_service.py` — matching API-key entries (`desperado` → `Desperado`, `silas` → `Silas`) so the mapping-coverage pin in `test_btd6_live_query_service_mapping_coverage.py` stays green the moment the team imports.

## Caveat on aliases

I'm guessing at community nicknames for both since they postdate my training. If `cowboy` / `gunslinger` aren't actually used in the community, or if Silas has a more common nickname, just edit the `aliases` cell before the team imports — no code change needed.

## Verification

- `python3.10 -m pytest tests/unit/scripts/test_import_btd6_data_from_csv.py tests/unit/services/test_btd6_live_query_service_mapping_coverage.py -q` → **22 passed**

## Test plan

- [ ] CI green
- [ ] After import, `/btd6 tower Desperado` and any `silas` mention in the AI resolves correctly

https://claude.ai/code/session_01MVqPyLbtcZAjdSbmhrLEkg

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVqPyLbtcZAjdSbmhrLEkg)_