### PR TITLE
btd6: fix grounding pipeline, add catalog block + server owner identity

### DIFF
--- a/disbot/services/bot_knowledge_service.py
+++ b/disbot/services/bot_knowledge_service.py
@@ -123,12 +123,19 @@ def looks_like_audit_question(text: str) -> bool:
 
 
 def resolve_user_tier(member: object) -> str:
-    """Map a discord.Member to one of {user, moderator, administrator}.
+    """Map a discord.Member to one of {user, moderator, administrator, server_owner}.
 
-    Defaults to 'user' for DMs / webhooks / missing perms. PR1 does
-    not resolve trusted / staff / owner from Discord permissions, so
-    commands at those tiers are always hidden from the catalog.
+    Checks guild ownership first so a server owner who also has the
+    ``administrator`` permission is surfaced as ``server_owner`` (the
+    more specific tier). Defaults to 'user' for DMs / webhooks /
+    missing perms.
     """
+    guild = getattr(member, "guild", None)
+    if guild is not None:
+        owner_id = getattr(guild, "owner_id", None)
+        member_id = getattr(member, "id", None)
+        if owner_id is not None and member_id is not None and owner_id == member_id:
+            return "server_owner"
     perms = getattr(member, "guild_permissions", None)
     if perms is None:
         return "user"
@@ -137,6 +144,18 @@ def resolve_user_tier(member: object) -> str:
     if getattr(perms, "manage_guild", False):
         return "moderator"
     return "user"
+
+
+def _server_owner_identity_block() -> BotKnowledgeBlock:
+    """Inform the AI that the current message sender is the server owner."""
+    return BotKnowledgeBlock(
+        kind="bot_user_identity",
+        text=(
+            "The person asking this question is the owner of this Discord server "
+            "and the operator of this bot. They have full administrative access "
+            "and may ask about bot internals, configuration, or data."
+        ),
+    )
 
 
 async def gather(
@@ -150,6 +169,8 @@ async def gather(
 ) -> tuple[BotKnowledgeBlock, ...]:
     """Compose every applicable bot-knowledge block for one mention."""
     blocks: list[BotKnowledgeBlock] = []
+    if user_tier == "server_owner":
+        blocks.append(_server_owner_identity_block())
     if looks_like_command_question(user_text):
         block = _command_catalog_block(user_tier)
         if block is not None:

--- a/disbot/services/btd6_ai_knowledge_block_service.py
+++ b/disbot/services/btd6_ai_knowledge_block_service.py
@@ -276,11 +276,86 @@ async def _source_status_block() -> BotKnowledgeBlock | None:
     return BotKnowledgeBlock(kind="bot_btd6_source_status", text="\n".join(lines))
 
 
+# ---------------------------------------------------------------------------
+# BTD6 catalog block
+# ---------------------------------------------------------------------------
+
+_CATALOG_TERMS: tuple[str, ...] = (
+    "list all",
+    "list every",
+    "all towers",
+    "all heroes",
+    "all the towers",
+    "all the heroes",
+    "what do you know",
+    "what data do you have",
+    "what files",
+    "what information do you have",
+    "what can you tell me",
+    "what towers",
+    "what heroes",
+    "your data",
+    "your files",
+    "your knowledge",
+    "show me all",
+    "every tower",
+    "every hero",
+)
+
+
+def looks_like_btd6_catalog_question(text: str) -> bool:
+    """True when the message asks for a list or inventory of BTD6 data."""
+    if not text:
+        return False
+    lowered = text.lower()
+    return any(t in lowered for t in _CATALOG_TERMS)
+
+
+def _btd6_catalog_block() -> BotKnowledgeBlock | None:
+    """Compact tower + hero catalog from the fixture JSON files."""
+    try:
+        from services import btd6_data_service
+
+        dataset = btd6_data_service.get_dataset()
+    except Exception:  # noqa: BLE001 — defensive
+        return None
+
+    if not dataset.towers and not dataset.heroes:
+        return None
+
+    lines: list[str] = [
+        f"BTD6 data available (game version {dataset.game_version}):",
+    ]
+
+    # Group towers by category.
+    by_cat: dict[str, list[str]] = {}
+    for t in dataset.towers:
+        entry = f"{t.canonical} (cost: {t.base_cost})"
+        by_cat.setdefault(t.category, []).append(entry)
+    for cat, entries in sorted(by_cat.items()):
+        lines.append(f"  {cat.title()} towers: {', '.join(entries)}")
+
+    # Heroes.
+    if dataset.heroes:
+        hero_parts = [f"{h.canonical} (cost: {h.base_cost})" for h in dataset.heroes]
+        lines.append(f"  Heroes: {', '.join(hero_parts)}")
+
+    lines.append(
+        "Each tower has upgrade path names; each hero has ability names. "
+        "Ask about a specific tower or hero for full details.",
+    )
+
+    text = "\n".join(lines)
+    if len(text) > 3000:
+        text = text[:2999] + "…"
+    return BotKnowledgeBlock(kind="bot_btd6_catalog", text=text)
+
+
 async def gather_btd6_bot_knowledge_blocks(
     *,
     user_text: str,
 ) -> tuple[BotKnowledgeBlock, ...]:
-    """Emit zero, one, or two BTD6 BotKnowledgeBlocks for ``user_text``.
+    """Emit zero or more BTD6 BotKnowledgeBlocks for ``user_text``.
 
     Best-effort: any failure logs and returns ``()`` rather than
     propagating into the AI stage.
@@ -295,6 +370,10 @@ async def gather_btd6_bot_knowledge_blocks(
             block = await _source_status_block()
             if block is not None:
                 blocks.append(block)
+        if looks_like_btd6_catalog_question(user_text):
+            block = _btd6_catalog_block()
+            if block is not None:
+                blocks.append(block)
     except Exception:  # noqa: BLE001 — defensive
         logger.exception(
             "gather_btd6_bot_knowledge_blocks failed; returning no blocks",
@@ -306,6 +385,7 @@ async def gather_btd6_bot_knowledge_blocks(
 
 __all__ = [
     "gather_btd6_bot_knowledge_blocks",
+    "looks_like_btd6_catalog_question",
     "looks_like_btd6_freshness_question",
     "looks_like_btd6_state_question",
 ]

--- a/disbot/services/btd6_context_service.py
+++ b/disbot/services/btd6_context_service.py
@@ -398,56 +398,59 @@ def _fixture_facts_for_intent(intent: Any) -> list[str]:
 async def build(message_text: str) -> BTD6Context:
     """Build a BTD6 context bundle for ``message_text``.
 
-    The flow is: resolver → queries → fact_store.fetch_for_intent +
-    PR-E live entity lookup → tower/hero active-event restrictions →
-    sanitised rendering with provenance. The instruction service wraps
-    the resulting tuple as untrusted data, so adversarial body text
-    reaches the LLM only inside the data envelope.
+    Three independent passes, each isolated so one failure cannot
+    suppress the others:
 
-    When the DB has no rows for a resolved tower or hero entity the
-    context falls back to the JSON fixture files (btd6_data_service)
-    so cost, category, and upgrade/ability data always reach the LLM.
+    1. Resolver (sync, no DB) — extracts towers/heroes/maps/modes from
+       the text.
+    2. DB-backed facts — live event rows from ``btd6_facts`` +
+       active-event restriction lines.  Skipped silently when the DB is
+       unavailable.
+    3. Fixture fallback (always) — injects cost / upgrade / ability data
+       from the JSON fixture files for every resolved tower/hero entity.
+       This pass is deliberately OUTSIDE the DB try/except so a missing
+       or misconfigured ``btd6_facts`` table never suppresses it.
     """
     facts: list[str] = []
     confidence = 0.0
     source_summary = _FALLBACK_SOURCE_SUMMARY
+
+    # Pass 1: resolve intent (synchronous, no DB required).
+    intent = None
     try:
-        from services import btd6_fact_store, btd6_resolver_service
+        from services import btd6_resolver_service
 
         intent = btd6_resolver_service.resolve(message_text)
         confidence = float(getattr(intent, "confidence", 0.0) or 0.0)
-        queries = _intent_to_queries(intent)
-        rows = await btd6_fact_store.fetch_for_intent(queries) if queries else []
-        # PR-E: also surface live-entity facts (race / boss / CT /
-        # odyssey / challenge / event / leaderboard).
-        live_rows = await _fetch_live_entity_rows(intent)
-        rows = rows + live_rows
-        for row in rows:
-            facts.append(_render_fact(row))
-        # Fixture fallback: when the DB has no rows for a resolved
-        # tower/hero, inject static data from the JSON fixture files
-        # so cost and upgrade/ability info always reach the LLM.
-        db_entity_keys = {(r.get("entity_kind"), r.get("entity_key")) for r in rows}
-        has_db_rows = bool(db_entity_keys - {(None, None)})
-        if not has_db_rows or any(
-            (
-                f"btd6_{ek}",
-                str(getattr(e, "id", "")),
-            )
-            not in db_entity_keys
-            for ek, entities in (
-                ("tower", getattr(intent, "towers", ())),
-                ("hero", getattr(intent, "heroes", ())),
-            )
-            for e in (entities or ())
-        ):
-            facts.extend(_fixture_facts_for_intent(intent))
-        # PR 2: tower/hero-specific active-event restriction lines.
-        facts.extend(await _restriction_lines_for_intent(intent))
-        if facts:
-            source_summary = _DEFAULT_SOURCE_SUMMARY
     except Exception as exc:  # noqa: BLE001 — defensive
-        logger.debug("btd6_context_service: grounding unavailable (%s)", exc)
+        logger.debug("btd6_context_service: resolver unavailable (%s)", exc)
+
+    if intent is not None:
+        # Pass 2: DB-backed live facts + active-event restrictions.
+        try:
+            from services import btd6_fact_store
+
+            queries = _intent_to_queries(intent)
+            rows = await btd6_fact_store.fetch_for_intent(queries) if queries else []
+            # PR-E: race / boss / CT / odyssey / challenge / event /
+            # leaderboard facts.
+            live_rows = await _fetch_live_entity_rows(intent)
+            rows = rows + live_rows
+            for row in rows:
+                facts.append(_render_fact(row))
+            # PR 2: tower/hero active-event restriction lines.
+            facts.extend(await _restriction_lines_for_intent(intent))
+        except Exception as exc:  # noqa: BLE001 — defensive
+            logger.debug("btd6_context_service: db grounding unavailable (%s)", exc)
+
+        # Pass 3: fixture fallback — always runs so cost, category,
+        # and upgrade/ability data reach the LLM even when the DB has
+        # no rows for tower/hero entities (the common state before live
+        # ingestion populates btd6_facts).
+        facts.extend(_fixture_facts_for_intent(intent))
+
+    if facts:
+        source_summary = _DEFAULT_SOURCE_SUMMARY
     return BTD6Context(
         facts=tuple(facts),
         source_summary=source_summary,


### PR DESCRIPTION
## Summary

- **Fix grounding silenced by DB errors** — `btd6_context_service.build()` was one big `try/except` so any exception from the `btd6_facts` table (missing table, connection issue, etc.) silently swallowed the fixture fallback too. Restructured into three independent passes: resolver (sync), DB-backed facts, and fixture fallback. The fixture pass now always runs for resolved tower/hero entities regardless of DB state, so cost/upgrade/ability data reliably reaches the AI.

- **BTD6 catalog knowledge block** — Added `_btd6_catalog_block()` in `btd6_ai_knowledge_block_service`. Fires when the user asks "what do you know", "list all towers", "what data do you have access to", etc. Injects a compact tower roster grouped by category (with base costs) and full hero list so the AI can answer inventory questions correctly.

- **Server owner identity** — `bot_knowledge_service.resolve_user_tier()` now returns `"server_owner"` when the message author is the Discord guild owner. `gather()` injects a `bot_user_identity` block for that tier so the AI knows it is speaking with the bot operator.

## Test plan

- [ ] Ask bot "tell me about the bomb shooter" → should include base cost (375), category, all three upgrade paths
- [ ] Ask bot "tell me about gwendolin" → should include base cost, abilities
- [ ] Ask bot "list all towers in btd6" → should get full catalog grouped by category
- [ ] Ask bot "what do you know?" → should describe available BTD6 data
- [ ] As server owner, ask bot anything → AI response should acknowledge owner context

https://claude.ai/code/session_019vZLasmbb7TDksGbYYFQQS

---
_Generated by [Claude Code](https://claude.ai/code/session_019vZLasmbb7TDksGbYYFQQS)_