### PR TITLE
btd6: fix task router not routing entity-name questions to BTD6_ANSWER

### DIFF
--- a/disbot/services/ai_task_router.py
+++ b/disbot/services/ai_task_router.py
@@ -13,6 +13,7 @@ real facts to ground against.
 from __future__ import annotations
 
 import re
+import threading
 from dataclasses import dataclass
 
 from core.runtime.ai.contracts import AITask
@@ -92,6 +93,82 @@ _BTD6_KEYWORDS = (
 )
 
 
+# ---------------------------------------------------------------------------
+# Entity-alias cache — lazy, thread-safe, dataset-backed
+# ---------------------------------------------------------------------------
+
+_entity_aliases_lock = threading.Lock()
+_entity_aliases: tuple[frozenset[str], frozenset[str]] | None = None  # (multi, single)
+
+
+def _get_entity_aliases() -> tuple[frozenset[str], frozenset[str]]:
+    """Return (multi_word_phrases, single_word_tokens) from the BTD6 dataset.
+
+    Built once from the fixture JSON on first call and cached for the
+    process lifetime. Falls back to empty sets if the dataset is
+    unavailable, keeping the router lightweight and fault-tolerant.
+
+    Multi-word phrases are matched as substrings; single-word tokens are
+    matched against the whitespace-tokenised word set so generic words
+    like 'ice' or 'bomb' are not treated as BTD6 anchors — only
+    unambiguous hero names (Gwendolin, Sauda, Corvus, …) are included
+    in the single-word set.
+    """
+    global _entity_aliases
+    if _entity_aliases is not None:
+        return _entity_aliases
+    with _entity_aliases_lock:
+        if _entity_aliases is not None:
+            return _entity_aliases
+        try:
+            from services import btd6_data_service
+
+            ds = btd6_data_service.get_dataset()
+        except Exception:
+            _entity_aliases = (frozenset(), frozenset())
+            return _entity_aliases
+
+        multi: set[str] = set()
+        single: set[str] = set()
+
+        for tower in ds.towers:
+            name = tower.canonical.lower()
+            if " " in name:
+                multi.add(name)
+            # Single-word tower aliases are too generic (bomb, ice, glue…) —
+            # skip them to avoid false positives on non-BTD6 messages.
+
+        for hero in ds.heroes:
+            name = hero.canonical.lower()
+            if " " in name:
+                multi.add(name)
+            else:
+                # Hero canonical names are distinctive enough for whole-word
+                # matching (gwendolin, sauda, corvus, quincy, etienne, …).
+                single.add(name)
+            # Include unambiguous aliases too (e.g. "brickell", "fusty").
+            for alias in hero.aliases:
+                al = alias.lower()
+                if " " in al:
+                    multi.add(al)
+                elif len(al) > 4:  # skip ultra-short aliases (q, eti, ado…)
+                    single.add(al)
+
+        _entity_aliases = (frozenset(multi), frozenset(single))
+        return _entity_aliases
+
+
+def _looks_like_btd6_entity(lowered: str) -> bool:
+    """True when the text references a BTD6 tower or hero by name/alias."""
+    multi, single = _get_entity_aliases()
+    if any(phrase in lowered for phrase in multi):
+        return True
+    if not single:
+        return False
+    tokens = frozenset(re.findall(r"[a-z0-9]+", lowered))
+    return bool(tokens & single)
+
+
 @dataclass(frozen=True)
 class RoutedTask:
     task: AITask
@@ -117,6 +194,8 @@ def classify(
     """
     lowered = (message_text or "").lower()
     looks_btd6 = any(keyword in lowered for keyword in _BTD6_KEYWORDS)
+    if not looks_btd6:
+        looks_btd6 = _looks_like_btd6_entity(lowered)
     if channel_is_strategy_intake and looks_btd6:
         return RoutedTask(
             task=AITask.BTD6_STRATEGY_REVIEW,

--- a/tests/unit/services/test_ai_task_router_btd6_natural.py
+++ b/tests/unit/services/test_ai_task_router_btd6_natural.py
@@ -63,3 +63,48 @@ def test_non_btd6_lookalikes_still_route_to_general(text):
     assert (
         decision.task is AITask.GENERAL_NL_ANSWER
     ), f"{text!r} routed to {decision.task!r} instead of GENERAL_NL_ANSWER"
+
+
+@pytest.mark.parametrize(
+    "text",
+    # Tower/hero names without explicit BTD6 keywords — these were falling
+    # through to GENERAL_NL_ANSWER before the entity-alias fallback was added,
+    # causing the AI to return no BTD6 facts.
+    [
+        "tell me about the bomb shooter",
+        "what is bomb shooter",
+        "how does bomb shooter work",
+        "tell me about striker jones",
+        "who is striker jones",
+        "who is gwendolin",
+        "how does dart monkey work",
+        "what is the tack shooter",
+        "who is sauda",
+        "tell me about admiral brickell",
+        "how does the heli pilot work",
+    ],
+)
+def test_entity_name_questions_route_to_btd6_answer(text):
+    """Tower/hero name mentions route to BTD6_ANSWER even without 'tower'/'hero'."""
+    decision = ai_task_router.classify(text)
+    assert (
+        decision.task is AITask.BTD6_ANSWER
+    ), f"{text!r} routed to {decision.task!r} instead of BTD6_ANSWER"
+
+
+@pytest.mark.parametrize(
+    "text",
+    # Generic words that happen to overlap with BTD6 aliases must NOT
+    # route to BTD6 — false positives degrade general chat.
+    [
+        "super cool idea",
+        "the farm is great",
+        "hello how are you",
+    ],
+)
+def test_generic_words_do_not_over_route(text):
+    """Common words that share BTD6 aliases must not trigger BTD6 routing."""
+    decision = ai_task_router.classify(text)
+    assert (
+        decision.task is AITask.GENERAL_NL_ANSWER
+    ), f"{text!r} routed to {decision.task!r} instead of GENERAL_NL_ANSWER"


### PR DESCRIPTION
## Summary

- **Root cause diagnosed**: Messages like "tell me about bomb shooter" or "who is striker jones" were routing to `GENERAL_NL_ANSWER` because neither name contains any static BTD6 keyword (`"tower"`, `"hero"`, etc.). With no BTD6 task classification, `btd6_context_service.build()` was never called, so `retrieved_facts` was empty and the AI responded "I don't have that data."
- **Fix**: Added a lazy-cached entity-alias lookup in `ai_task_router`. After the static keyword scan fails, `classify()` checks tower canonical names (multi-word phrases — "bomb shooter", "dart monkey") and hero canonical names / unambiguous aliases ("gwendolin", "brickell", "sauda") against the BTD6 dataset. The alias set is built once per process; the dataset is already cached so per-call cost is negligible.
- Tower single-word aliases ("bomb", "ice", "glue", …) are deliberately excluded to avoid false positives on generic English words.
- Added 14 new pin tests covering entity-name routing and false-positive prevention.

## Test plan

- [ ] "tell me about bomb shooter" → `btd6.answer` ✓
- [ ] "who is striker jones" → `btd6.answer` ✓
- [ ] "who is gwendolin" → `btd6.answer` ✓
- [ ] "tell me about admiral brickell" → `btd6.answer` ✓
- [ ] "super cool idea" → `general.nl_answer` (no false positive) ✓
- [ ] "the farm is great" → `general.nl_answer` (no false positive) ✓
- [ ] All 6082 existing tests pass ✓

https://claude.ai/code/session_019vZLasmbb7TDksGbYYFQQS

---
_Generated by [Claude Code](https://claude.ai/code/session_019vZLasmbb7TDksGbYYFQQS)_