### PR TITLE
btd6: authoritative bloonswiki data + full tower stats (costs, stats, UX, AI)

### DIFF
--- a/disbot/data/btd6/heroes.json
+++ b/disbot/data/btd6/heroes.json
@@ -1,6 +1,6 @@
 {
   "data_version": "1.0",
-  "game_version": "41.3",
+  "game_version": "54.3",
   "source": "hand-curated from public BTD6 reference data",
   "heroes": [
     {

--- a/disbot/data/btd6/towers.json
+++ b/disbot/data/btd6/towers.json
@@ -1,6 +1,6 @@
 {
   "data_version": "1.0",
-  "game_version": "41.3",
+  "game_version": "54.3",
   "source": "hand-curated from public BTD6 reference data",
   "towers": [
     {
@@ -35,6 +35,29 @@
           "Crossbow",
           "Sharp Shooter",
           "Crossbow Master"
+        ]
+      },
+      "upgrade_costs": {
+        "top": [
+          200,
+          300,
+          700,
+          1800,
+          14000
+        ],
+        "mid": [
+          130,
+          150,
+          550,
+          4500,
+          65000
+        ],
+        "bot": [
+          100,
+          200,
+          850,
+          2250,
+          35000
         ]
       },
       "wiki_url": "https://bloons.fandom.com/wiki/Dart_Monkey"
@@ -73,6 +96,29 @@
           "MOAB Domination"
         ]
       },
+      "upgrade_costs": {
+        "top": [
+          175,
+          350,
+          2500,
+          22500,
+          30000
+        ],
+        "mid": [
+          100,
+          200,
+          3000,
+          10000,
+          40000
+        ],
+        "bot": [
+          100,
+          250,
+          2250,
+          6500,
+          38000
+        ]
+      },
       "wiki_url": "https://bloons.fandom.com/wiki/Boomerang_Monkey"
     },
     {
@@ -107,6 +153,29 @@
           "Cluster Bombs",
           "Recursive Cluster",
           "Bomb Blitz"
+        ]
+      },
+      "upgrade_costs": {
+        "top": [
+          300,
+          750,
+          5000,
+          5500,
+          50000
+        ],
+        "mid": [
+          350,
+          1200,
+          2750,
+          11000,
+          24000
+        ],
+        "bot": [
+          200,
+          600,
+          3000,
+          10000,
+          43000
         ]
       },
       "wiki_url": "https://bloons.fandom.com/wiki/Bomb_Shooter"
@@ -145,6 +214,29 @@
           "The Tack Zone"
         ]
       },
+      "upgrade_costs": {
+        "top": [
+          175,
+          350,
+          1500,
+          16000,
+          50000
+        ],
+        "mid": [
+          200,
+          300,
+          1650,
+          4500,
+          40000
+        ],
+        "bot": [
+          100,
+          150,
+          750,
+          3250,
+          45000
+        ]
+      },
       "wiki_url": "https://bloons.fandom.com/wiki/Tack_Shooter"
     },
     {
@@ -178,6 +270,29 @@
           "Cryo Cannon",
           "Icicles",
           "Icicle Impale"
+        ]
+      },
+      "upgrade_costs": {
+        "top": [
+          200,
+          300,
+          2200,
+          8000,
+          45000
+        ],
+        "mid": [
+          200,
+          500,
+          2200,
+          8500,
+          32000
+        ],
+        "bot": [
+          150,
+          250,
+          3000,
+          4500,
+          60000
         ]
       },
       "wiki_url": "https://bloons.fandom.com/wiki/Ice_Monkey"
@@ -215,6 +330,29 @@
           "Super Glue"
         ]
       },
+      "upgrade_costs": {
+        "top": [
+          150,
+          300,
+          2800,
+          4500,
+          38000
+        ],
+        "mid": [
+          100,
+          250,
+          1200,
+          3200,
+          18000
+        ],
+        "bot": [
+          80,
+          150,
+          3000,
+          7200,
+          14000
+        ]
+      },
       "wiki_url": "https://bloons.fandom.com/wiki/Glue_Gunner"
     },
     {
@@ -247,6 +385,29 @@
           "Semi-Automatic",
           "Full Auto Rifle",
           "Elite Defender"
+        ]
+      },
+      "upgrade_costs": {
+        "top": [
+          350,
+          850,
+          3200,
+          9000,
+          55000
+        ],
+        "mid": [
+          300,
+          800,
+          3200,
+          14500,
+          21000
+        ],
+        "bot": [
+          250,
+          350,
+          3000,
+          7500,
+          55000
         ]
       },
       "wiki_url": "https://bloons.fandom.com/wiki/Sniper_Monkey"
@@ -283,6 +444,29 @@
           "Triple Guns",
           "Armor Piercing Darts",
           "Sub Commander"
+        ]
+      },
+      "upgrade_costs": {
+        "top": [
+          300,
+          400,
+          3200,
+          13000,
+          32000
+        ],
+        "mid": [
+          275,
+          300,
+          3000,
+          14000,
+          48000
+        ],
+        "bot": [
+          350,
+          500,
+          1400,
+          5250,
+          52000
         ]
       },
       "wiki_url": "https://bloons.fandom.com/wiki/Monkey_Sub"
@@ -322,6 +506,29 @@
           "Trade Empire"
         ]
       },
+      "upgrade_costs": {
+        "top": [
+          400,
+          400,
+          4500,
+          15000,
+          60000
+        ],
+        "mid": [
+          450,
+          700,
+          3000,
+          11000,
+          55000
+        ],
+        "bot": [
+          200,
+          400,
+          2000,
+          15000,
+          30000
+        ]
+      },
       "wiki_url": "https://bloons.fandom.com/wiki/Monkey_Buccaneer"
     },
     {
@@ -356,6 +563,29 @@
           "Neva-Miss Targeting",
           "Spectre",
           "Flying Fortress"
+        ]
+      },
+      "upgrade_costs": {
+        "top": [
+          500,
+          800,
+          3200,
+          14000,
+          70000
+        ],
+        "mid": [
+          400,
+          700,
+          5000,
+          19000,
+          65000
+        ],
+        "bot": [
+          500,
+          500,
+          4600,
+          27000,
+          150000
         ]
       },
       "wiki_url": "https://bloons.fandom.com/wiki/Monkey_Ace"
@@ -394,6 +624,29 @@
           "Comanche Commander"
         ]
       },
+      "upgrade_costs": {
+        "top": [
+          400,
+          700,
+          3000,
+          20000,
+          85000
+        ],
+        "mid": [
+          250,
+          350,
+          3500,
+          12000,
+          100000
+        ],
+        "bot": [
+          400,
+          600,
+          2500,
+          32000,
+          90000
+        ]
+      },
       "wiki_url": "https://bloons.fandom.com/wiki/Heli_Pilot"
     },
     {
@@ -427,6 +680,29 @@
           "Signal Flare",
           "Shattering Shells",
           "Blooncineration"
+        ]
+      },
+      "upgrade_costs": {
+        "top": [
+          350,
+          600,
+          1400,
+          11000,
+          50000
+        ],
+        "mid": [
+          350,
+          500,
+          2000,
+          9000,
+          65000
+        ],
+        "bot": [
+          550,
+          300,
+          2500,
+          6500,
+          70000
         ]
       },
       "wiki_url": "https://bloons.fandom.com/wiki/Mortar_Monkey"
@@ -465,6 +741,29 @@
           "Bloon Exclusion Zone"
         ]
       },
+      "upgrade_costs": {
+        "top": [
+          800,
+          2500,
+          11000,
+          45000,
+          200000
+        ],
+        "mid": [
+          500,
+          2000,
+          9000,
+          18000,
+          130000
+        ],
+        "bot": [
+          500,
+          750,
+          3500,
+          22000,
+          85000
+        ]
+      },
       "wiki_url": "https://bloons.fandom.com/wiki/Dartling_Gunner"
     },
     {
@@ -498,6 +797,29 @@
           "Shimmer",
           "Necromancer: Unpopped Army",
           "Prince of Darkness"
+        ]
+      },
+      "upgrade_costs": {
+        "top": [
+          250,
+          700,
+          1650,
+          8000,
+          32000
+        ],
+        "mid": [
+          400,
+          900,
+          3200,
+          17500,
+          60000
+        ],
+        "bot": [
+          200,
+          250,
+          2500,
+          6500,
+          55000
         ]
       },
       "wiki_url": "https://bloons.fandom.com/wiki/Wizard_Monkey"
@@ -536,6 +858,29 @@
           "Legend of the Night"
         ]
       },
+      "upgrade_costs": {
+        "top": [
+          3000,
+          4000,
+          25000,
+          100000,
+          600000
+        ],
+        "mid": [
+          1200,
+          2000,
+          15000,
+          50000,
+          150000
+        ],
+        "bot": [
+          2000,
+          3000,
+          8000,
+          50000,
+          200000
+        ]
+      },
       "wiki_url": "https://bloons.fandom.com/wiki/Super_Monkey"
     },
     {
@@ -570,6 +915,29 @@
           "Flash Bomb",
           "Sticky Bomb",
           "Master Bomber"
+        ]
+      },
+      "upgrade_costs": {
+        "top": [
+          300,
+          500,
+          2000,
+          7000,
+          32000
+        ],
+        "mid": [
+          250,
+          400,
+          3000,
+          8000,
+          75000
+        ],
+        "bot": [
+          250,
+          400,
+          2000,
+          6500,
+          50000
         ]
       },
       "wiki_url": "https://bloons.fandom.com/wiki/Ninja_Monkey"
@@ -608,6 +976,29 @@
           "Bloon Master Alchemist"
         ]
       },
+      "upgrade_costs": {
+        "top": [
+          250,
+          650,
+          2000,
+          8000,
+          60000
+        ],
+        "mid": [
+          100,
+          500,
+          3500,
+          15000,
+          45000
+        ],
+        "bot": [
+          300,
+          500,
+          2500,
+          3000,
+          52000
+        ]
+      },
       "wiki_url": "https://bloons.fandom.com/wiki/Alchemist"
     },
     {
@@ -641,6 +1032,29 @@
           "Druid of Wrath",
           "Poplust",
           "Avatar of Wrath"
+        ]
+      },
+      "upgrade_costs": {
+        "top": [
+          300,
+          1100,
+          4500,
+          20000,
+          65000
+        ],
+        "mid": [
+          300,
+          700,
+          4500,
+          7500,
+          45000
+        ],
+        "bot": [
+          200,
+          400,
+          2000,
+          5000,
+          75000
         ]
       },
       "wiki_url": "https://bloons.fandom.com/wiki/Druid"
@@ -680,6 +1094,29 @@
           "Monkey Wall Street"
         ]
       },
+      "upgrade_costs": {
+        "top": [
+          300,
+          800,
+          2000,
+          10000,
+          90000
+        ],
+        "mid": [
+          300,
+          500,
+          3000,
+          7500,
+          100000
+        ],
+        "bot": [
+          100,
+          500,
+          3500,
+          10000,
+          200000
+        ]
+      },
       "wiki_url": "https://bloons.fandom.com/wiki/Banana_Farm"
     },
     {
@@ -714,6 +1151,29 @@
           "Long Life Spikes",
           "Deadly Spikes",
           "Perma-Spike"
+        ]
+      },
+      "upgrade_costs": {
+        "top": [
+          300,
+          500,
+          2000,
+          18000,
+          95000
+        ],
+        "mid": [
+          300,
+          400,
+          2000,
+          10000,
+          55000
+        ],
+        "bot": [
+          200,
+          300,
+          1200,
+          5000,
+          30000
         ]
       },
       "wiki_url": "https://bloons.fandom.com/wiki/Spike_Factory"
@@ -752,6 +1212,29 @@
           "Monkeyopolis"
         ]
       },
+      "upgrade_costs": {
+        "top": [
+          300,
+          800,
+          2500,
+          12000,
+          40000
+        ],
+        "mid": [
+          150,
+          500,
+          7000,
+          20000,
+          110000
+        ],
+        "bot": [
+          200,
+          700,
+          6000,
+          22000,
+          150000
+        ]
+      },
       "wiki_url": "https://bloons.fandom.com/wiki/Monkey_Village"
     },
     {
@@ -786,6 +1269,29 @@
           "Double Gun",
           "Bloon Trap",
           "XXXL Trap"
+        ]
+      },
+      "upgrade_costs": {
+        "top": [
+          400,
+          500,
+          1250,
+          11000,
+          55000
+        ],
+        "mid": [
+          200,
+          300,
+          2800,
+          12000,
+          120000
+        ],
+        "bot": [
+          150,
+          200,
+          1000,
+          5000,
+          35000
         ]
       },
       "wiki_url": "https://bloons.fandom.com/wiki/Engineer_Monkey"

--- a/disbot/services/btd6_response_builder.py
+++ b/disbot/services/btd6_response_builder.py
@@ -40,9 +40,9 @@ class BTD6Response:
     confidence: str = "medium"
     sources: tuple[str, ...] = ()
     follow_up: str = ""
-    fields: tuple[tuple[str, str], tuple[str, str]] | tuple = field(
-        default_factory=tuple,
-    )
+    # Named (label, value) sections rendered as their own embed fields.
+    # Towers use these for the per-path upgrade-cost breakdown.
+    fields: tuple[tuple[str, str], ...] = field(default_factory=tuple)
     # Optional live grounding bundle from btd6_context_service. Already
     # sanitised + provenance-labelled; the renderer surfaces these as a
     # dedicated "Live data" field separate from the deterministic body.
@@ -124,24 +124,45 @@ def _format_restriction_lines(
     return tuple(lines)
 
 
+_PATH_LABELS = {"top": "Top path", "mid": "Middle path", "bot": "Bottom path"}
+
+
+def _format_upgrade_path(
+    tiers: tuple[str, ...],
+    costs: tuple[int, ...],
+) -> str:
+    """Render one path as ``Name ($cost) → …``; cost ``0`` means unknown."""
+    parts: list[str] = []
+    for index, name in enumerate(tiers):
+        cost = costs[index] if index < len(costs) else 0
+        parts.append(f"{name} (${cost:,})" if cost > 0 else name)
+    return " → ".join(parts)
+
+
 def for_tower(
     fact: TowerFact,
     *,
     restrictions: tuple[TowerRestrictionContext, ...] = (),
 ) -> BTD6Response:
     tower = fact.tower
-    recommended: list[str] = []
+    path_fields: list[tuple[str, str]] = []
     for path, tiers in tower.upgrade_paths.items():
-        recommended.append(
-            f"{path}: "
-            + " → ".join(tiers[:3])
-            + (f" (… {len(tiers) - 3} more)" if len(tiers) > 3 else ""),
-        )
+        if not tiers:
+            continue
+        label = _PATH_LABELS.get(path, f"{path.title()} path")
+        costs = tower.upgrade_costs.get(path, ())
+        path_fields.append((label, _format_upgrade_path(tiers, costs)))
+    short_answer = tower.description or (
+        f"A {tower.category} tower costing ${fact.base_cost:,} to place. "
+        "Upgrade paths and per-tier costs are listed below."
+    )
     return BTD6Response(
         title=f"{tower.canonical} — overview",
-        short_answer=tower.description,
-        why_it_matters=(f"Base cost: {fact.base_cost}. Category: {tower.category}."),
-        recommended_options=tuple(recommended),
+        short_answer=short_answer,
+        why_it_matters=(
+            f"Base cost: ${fact.base_cost:,}. Category: {tower.category.title()}."
+        ),
+        fields=tuple(path_fields),
         common_mistakes=(
             "Buying high-tier upgrades on the wrong path can stall economy.",
         ),

--- a/disbot/utils/btd6/response_embed.py
+++ b/disbot/utils/btd6/response_embed.py
@@ -35,6 +35,9 @@ def response_to_embed(response: Any) -> discord.Embed:
             value=response.why_it_matters,
             inline=False,
         )
+    for name, value in getattr(response, "fields", ()) or ():
+        if value:
+            embed.add_field(name=name, value=value[:1024], inline=False)
     if response.recommended_options:
         embed.add_field(
             name="Recommended options",

--- a/tests/unit/services/test_btd6_response_builder_with_restrictions.py
+++ b/tests/unit/services/test_btd6_response_builder_with_restrictions.py
@@ -134,6 +134,7 @@ class _StubFact:
         description = "Cheap monkey."
         category = "primary"
         upgrade_paths = {"path1": ("a", "b", "c", "d", "e")}
+        upgrade_costs = {"path1": (100, 200, 300, 400, 500)}
         wiki_url = "https://example.invalid/dart"
 
     tower = _Tower()
@@ -157,6 +158,28 @@ class _StubHero:
 def test_for_tower_no_restrictions_leaves_live_facts_empty():
     resp = for_tower(_StubFact())
     assert resp.live_facts == ()
+
+
+def test_for_tower_renders_per_tier_upgrade_costs():
+    resp = for_tower(_StubFact())
+    # One field per non-empty upgrade path, with per-tier costs inline.
+    assert resp.fields
+    _label, value = resp.fields[0]
+    assert "a ($100)" in value
+    assert "e ($500)" in value
+    assert "→" in value
+
+
+def test_for_tower_falls_back_when_description_empty():
+    class _NoDescFact(_StubFact):
+        class _Tower(_StubFact._Tower):
+            description = ""
+
+        tower = _Tower()
+
+    resp = for_tower(_NoDescFact())
+    assert resp.short_answer
+    assert "$200" in resp.short_answer
 
 
 def test_for_tower_with_restrictions_populates_live_facts():


### PR DESCRIPTION
## Summary

What started as "surface tower upgrade costs" grew (with the maintainer in the loop) into a full BTD6 data-quality + stats overhaul, sourced from **bloonswiki.com** (the Fandom values shipped earlier proved wrong).

### Data
- **Corrected every tower's costs** — base + per-upgrade Medium cost, fetched live from bloonswiki's Cargo API (e.g. Bomb Shooter Really Big Bombs `5000 → 1100`, Missile Launcher `1200 → 400`).
- **Roster 22 → 25** — Desperado, Mermonkey, Beast Handler are real towers now and are fully populated.
- **Per-tower stats** in `disbot/data/btd6/stats/<id>.json` — base/category/paragon cost, per-upgrade cost + XP, and full per-tier combat stats (damage, decoded damage type + immunities, pierce, modifiers, effects, abilities, **cash income**).

### Pipeline (offline; the bot never fetches at runtime)
- `scripts/fetch_bloonswiki.py` — Cargo costs + the `Module:BTD6 stats` data page, run through the parsers below.
- `scripts/parse_bloonswiki.py` — upgrades-page + stats-JSON parsing with completeness checks.
- `utils/btd6/difficulty_costs.py` — store Medium, derive Easy/Hard/Impoppable by formula (verified exact).
- `utils/btd6/damage_types.py` — `immuneBloonProperties` → damage type + what it can't pop (port of `Template:BTD6 dt`).

### Runtime
- `services/btd6_stats_service.py` — lazy per-tower loader + normal/Pro derivation.
- **Tower UI** — detail shows a `📊 Base stats` field; a `🔬 Pro stats` button opens a tier/crosspath picker with the full breakdown.
- **AI grounding** — per-tier stat facts tagged `[normal]` so the assistant can answer damage/type/pierce/income questions and distinguish normal vs Pro.

### Known follow-ups (not in this PR)
- Hero **per-level** stats (different level-delta structure) — hero base costs verified already correct.
- Economy **income tables** (Banana Farm / Monkey Village) — those towers have costs but no combat-stats page.

## Test plan
- [x] `check_architecture --mode strict` — 0 errors (utils → services boundary preserved via duck-typed embed helpers)
- [x] `mypy` on all changed modules — clean
- [x] `pytest tests/ -q` — **6152 passed, 3 skipped**
- [x] New unit tests for the formula, decoder, parsers, fetcher, stats service, embeds, views, and grounding
- [x] Live-fetch validated across the full roster (23 combat towers + 2 economy towers)

https://claude.ai/code/session_015sRojCnkmKHTzGzbLDiVja