### PR TITLE
Fix empty setup wizard: populate section registry + depth prompt on first run

### DIFF
--- a/disbot/cogs/setup_cog.py
+++ b/disbot/cogs/setup_cog.py
@@ -29,6 +29,13 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+# Imported for its registration side effect: section modules register
+# themselves into services.setup_sections.REGISTRY at import time. The
+# wizard / launcher entry paths read that registry but do not import the
+# sections package, so without this the registry is empty at startup and
+# the wizard renders "No setup sections available for this depth" until
+# the hub (historically the only other importer) is opened.
+import views.setup.sections  # noqa: F401
 from cogs.setup._helpers import build_status_embed as _build_status_embed
 from cogs.setup._helpers import resolve_hub_entry as _resolve_hub_entry
 from cogs.setup._helpers import toggle_delegate as _toggle_delegate

--- a/disbot/views/setup/depth_panel.py
+++ b/disbot/views/setup/depth_panel.py
@@ -91,9 +91,14 @@ class DepthPanelView(BaseView):
         author: discord.Member | discord.User,
         *,
         session: SetupSession | None = None,
+        after: str = "hub",
         timeout: int = 180,
     ) -> None:
         super().__init__(author, timeout=timeout)
+        # Where to go after a depth is chosen: "hub" (default, used by the
+        # hub's Change depth button) or "wizard" (the first-run wizard
+        # entry, which transitions this anchor straight into the steps).
+        self._after = after
         current = session.depth if session is not None else None
         for slug in ("quick", "standard", "advanced"):
             label, _ = _DEPTH_DESCRIPTIONS[slug]
@@ -143,15 +148,41 @@ class DepthPanelView(BaseView):
             )
             return
 
-        # Open the hub at the selected depth.
-        from services import setup_draft
-        from views.setup.hub import SetupHubView, build_hub_embed
-
         try:
             session = await setup_session.resume_session(interaction.guild_id)
         except Exception:
             logger.exception("depth_panel._select: resume_session failed")
             session = None
+
+        if self._after == "wizard":
+            # Transition this same anchor into the linear wizard at the
+            # first step of the chosen depth.
+            member = interaction.user
+            if isinstance(member, discord.Member):
+                from views.setup.wizard_nav import render_wizard_step
+
+                ok = await render_wizard_step(
+                    interaction,
+                    guild=guild,
+                    member=member,
+                    session=session,
+                    step_index=0,
+                )
+                if ok:
+                    self.stop()
+                    return
+            if not interaction.response.is_done():
+                await interaction.response.send_message(
+                    "Saved your depth — re-run `/setup` to open the wizard.",
+                    ephemeral=True,
+                )
+            self.stop()
+            return
+
+        # Default: open the hub at the selected depth.
+        from services import setup_draft
+        from views.setup.hub import SetupHubView, build_hub_embed
+
         try:
             draft_ops = await setup_draft.list_ops(interaction.guild_id)
         except Exception:

--- a/disbot/views/setup/wizard.py
+++ b/disbot/views/setup/wizard.py
@@ -1089,7 +1089,18 @@ async def open_setup_workspace(
         logger.exception("open_setup_workspace: list_rows failed")
         draft_rows = []
 
-    if sections:
+    depth_unset = session is None or session.depth is None
+    view: discord.ui.View
+    if depth_unset:
+        # First run: ask how deep before showing steps, so the operator
+        # isn't dropped into every section at once. The picker persists
+        # the choice and transitions this same anchor into the wizard.
+        from views.setup.depth_panel import DepthPanelView, build_depth_embed
+
+        embed = build_depth_embed()
+        view = DepthPanelView(member, session=session, after="wizard")
+        anchor_step = "depth"
+    elif sections:
         embed = build_wizard_step_embed(
             session=session,
             section=sections[step_index],
@@ -1097,6 +1108,13 @@ async def open_setup_workspace(
             total_steps=len(sections),
             draft_rows=draft_rows,
         )
+        view = LinearWizardView(
+            member,
+            session=session,
+            sections=sections,
+            step_index=step_index,
+        )
+        anchor_step = "wizard"
     else:
         embed = discord.Embed(
             title=_WIZARD_TITLE,
@@ -1106,13 +1124,13 @@ async def open_setup_workspace(
             ),
             color=discord.Color.dark_grey(),
         )
-
-    view = LinearWizardView(
-        member,
-        session=session,
-        sections=sections,
-        step_index=step_index,
-    )
+        view = LinearWizardView(
+            member,
+            session=session,
+            sections=sections,
+            step_index=step_index,
+        )
+        anchor_step = "wizard"
 
     message: discord.Message | None = None
     existing_id = session.setup_message_id if session is not None else None
@@ -1155,7 +1173,7 @@ async def open_setup_workspace(
             )
 
     try:
-        await setup_session.mark_in_progress(guild.id, step="wizard")
+        await setup_session.mark_in_progress(guild.id, step=anchor_step)
     except Exception:
         logger.exception(
             "open_setup_workspace: mark_in_progress failed",

--- a/disbot/views/setup/wizard.py
+++ b/disbot/views/setup/wizard.py
@@ -84,7 +84,18 @@ _FOOTER_HINT = "Nothing changes until Final Review applies the staged operations
 
 
 def _resolve_sections(session: SetupSession | None) -> list[SetupSection]:
-    """Return the depth-filtered section list for ``session``."""
+    """Return the depth-filtered section list for ``session``.
+
+    Imports the sections package for its registration side effect first.
+    The registry is populated when ``views.setup.sections`` is imported,
+    and the wizard entry path (``/setup`` / ``!setup``) does not otherwise
+    import it — historically only the hub did. Without this, a process
+    that opens the wizard before ever touching the hub sees an empty
+    registry and renders "No setup sections available for this depth".
+    The import is idempotent and cached after the first call.
+    """
+    import views.setup.sections  # noqa: F401 — populate REGISTRY
+
     depth = session.depth if session is not None else None
     return REGISTRY.for_depth(depth)
 

--- a/tests/unit/views/setup/test_depth_panel.py
+++ b/tests/unit/views/setup/test_depth_panel.py
@@ -108,6 +108,37 @@ async def test_depth_panel_select_persists_and_opens_hub():
 
 
 @pytest.mark.asyncio
+async def test_depth_panel_select_after_wizard_transitions_to_wizard():
+    """With after='wizard' (the first-run wizard entry), selecting a depth
+    persists it and transitions the anchor into the linear wizard via
+    render_wizard_step — not the hub."""
+    view = DepthPanelView(_owner_member(), session=_session(), after="wizard")
+    interaction = _interaction()
+
+    with (
+        patch(
+            "views.setup.depth_panel.setup_session.set_depth",
+            new_callable=AsyncMock,
+        ) as set_depth_mock,
+        patch(
+            "views.setup.depth_panel.setup_session.resume_session",
+            new_callable=AsyncMock,
+            return_value=_session(depth="quick"),
+        ),
+        patch(
+            "views.setup.wizard_nav.render_wizard_step",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as render_mock,
+    ):
+        await view._select(interaction, "quick")
+
+    set_depth_mock.assert_awaited_once_with(1, "quick")
+    render_mock.assert_awaited_once()
+    assert render_mock.await_args.kwargs["step_index"] == 0
+
+
+@pytest.mark.asyncio
 async def test_depth_panel_select_handles_set_depth_failure():
     view = DepthPanelView(_owner_member(), session=_session())
     interaction = _interaction()

--- a/tests/unit/views/setup/test_wizard.py
+++ b/tests/unit/views/setup/test_wizard.py
@@ -374,6 +374,48 @@ async def test_apply_all_recommended_stages_via_helper_and_confirms():
     interaction.followup.send.assert_awaited()
 
 
+def test_wizard_entry_populates_section_registry_in_fresh_process():
+    """Regression: opening the wizard must not depend on the hub having
+    been imported first.
+
+    Runs in a fresh interpreter that imports only the wizard entry path
+    (no hub, no sections package) and asserts ``_resolve_sections``
+    returns the production sections.  Before the registration fix the
+    registry was empty here and the wizard rendered "No setup sections
+    available for this depth".
+    """
+    import os
+    import pathlib
+    import subprocess
+    import sys
+
+    repo_root = pathlib.Path(__file__).resolve().parents[4]
+    disbot_dir = repo_root / "disbot"
+    code = (
+        "import views.setup.wizard as w\n"
+        "secs = w._resolve_sections(None)\n"
+        "assert len(secs) > 0, 'registry empty: wizard resolved 0 sections'\n"
+        "print(len(secs))\n"
+    )
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(disbot_dir), env.get("PYTHONPATH", "")],
+    ).strip(os.pathsep)
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=str(repo_root),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        "fresh-process wizard import resolved no sections "
+        f"(registry not populated):\nstdout={result.stdout!r}\n"
+        f"stderr={result.stderr!r}"
+    )
+    assert int(result.stdout.strip()) >= 1
+
+
 def test_view_back_button_disabled_on_first_step():
     sections = [
         _section("cleanup", builder=_builder_one_op),

--- a/tests/unit/views/setup/test_wizard.py
+++ b/tests/unit/views/setup/test_wizard.py
@@ -835,6 +835,52 @@ async def test_open_workspace_posts_new_anchor_when_id_missing():
 
 
 @pytest.mark.asyncio
+async def test_open_workspace_shows_depth_picker_when_depth_unset():
+    """First run (no depth picked yet) shows the depth picker on the
+    anchor instead of dropping the operator into every section, and marks
+    the step as 'depth'."""
+    from views.setup.depth_panel import DepthPanelView
+
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 1
+    member = _owner_member()
+    channel = _make_text_channel()
+    posted_msg = MagicMock(id=4321, jump_url="https://x/y/z")
+    channel.send = AsyncMock(return_value=posted_msg)
+
+    with (
+        patch(
+            "views.setup.wizard.setup_channel.ensure_setup_channel",
+            new_callable=AsyncMock,
+            return_value=(channel, True),
+        ),
+        patch(
+            "views.setup.wizard.setup_draft.list_rows",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "views.setup.wizard.setup_session.set_setup_message_id",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "views.setup.wizard.setup_session.mark_in_progress",
+            new_callable=AsyncMock,
+        ) as mark_mock,
+    ):
+        _ch, _msg, reason = await open_setup_workspace(
+            guild,
+            member=member,
+            session=_session(depth=None, setup_message_id=None),
+        )
+
+    assert reason == "ok"
+    sent_view = channel.send.await_args.kwargs["view"]
+    assert isinstance(sent_view, DepthPanelView)
+    mark_mock.assert_awaited_once_with(1, step="depth")
+
+
+@pytest.mark.asyncio
 async def test_open_workspace_edits_existing_anchor_in_place():
     """When a fetchable anchor id is on the session, edit in place
     instead of posting a new message (idempotency of /setup re-runs).
@@ -1459,7 +1505,7 @@ async def test_resume_picks_session_current_step():
             current_step="zz_two",
             setup_channel_id=channel.id,
             setup_message_id=None,
-            depth=None,
+            depth="standard",
         )
 
         captured: list[LinearWizardView] = []


### PR DESCRIPTION
## Why

Follow-up to #379. On the live bot, `!setup` opened an **empty** wizard — "No setup sections are available for this depth" — even after `setup-reset`, so setup couldn't be started at all (see screenshots in the session).

## Root cause

Section modules register into `services.setup_sections.REGISTRY` as an **import side-effect** of the `views.setup.sections` package — but **only `hub.py` imported it**. The wizard / launcher / `!setup` entry paths never did, so unless the operator had opened `/setup-hub` earlier in the same process, the registry was empty and `for_depth(...)` returned nothing for every depth (including `None → all`). Verified by direct import: importing the wizard left the registry at **0 sections**.

## Fix (2 commits)

**1. Populate the registry on the wizard/cog path** (`9601fa2`)
- Import `views.setup.sections` (for the registration side-effect) in `cogs/setup_cog.py` at module load → registry is populated at startup for **every** setup path (`/setup`, `/setup-skip`, `/setup-status`, …).
- Also import it in `views/setup/wizard.py:_resolve_sections` (the exact read point) so the wizard is correct regardless of import order. Idempotent/cached.
- Regression test: a fresh interpreter that imports only the wizard now asserts `_resolve_sections` returns the production sections (would have failed before — registry empty).

**2. Prompt for depth on first run** (`9e97718`)
- When a session has no depth picked yet, `open_setup_workspace` now shows the depth picker (Quick / Standard / Advanced) on the anchor instead of dumping all 13 sections.
- `DepthPanelView` gains an `after` target: the first-run wizard entry transitions the same anchor straight into the linear wizard after a depth is chosen. The hub's "Change depth" button keeps its existing hub destination (`after="hub"` default), so that flow is unchanged.

## Result
A fresh `/setup` now opens a depth prompt → a populated, depth-filtered wizard, instead of an empty panel.

## Testing
- `check_architecture --mode strict` → **0 errors**
- `black --check disbot/ scripts/` + isort + ruff → clean
- `pytest tests/` → **6190 passed, 3 skipped**

https://claude.ai/code/session_01L1hpQj4MJidZi67Ygry9Pe

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1hpQj4MJidZi67Ygry9Pe)_