### PR TITLE
Read-only AI tool-calling (provider-neutral function calling)

### DIFF
--- a/disbot/core/runtime/ai/contracts.py
+++ b/disbot/core/runtime/ai/contracts.py
@@ -115,6 +115,27 @@ class AIRequestContext:
 
 
 @dataclass(frozen=True)
+class AIToolSpec:
+    """Provider-neutral declaration of a read-only tool the model may call.
+
+    Specs are pure data (no handler): they describe the tool to the
+    provider so the model can decide to call it. The live handler is
+    supplied separately to the gateway via ``tool_handlers`` so this
+    contract stays a clean, redaction-safe data object. ``parameters``
+    is a JSON-Schema object describing the tool's arguments.
+
+    ``min_scope`` is the least-privileged :class:`AIScope` allowed to be
+    offered this tool; the natural-language stage filters the offered
+    toolset by the caller's scope before the request is built.
+    """
+
+    name: str
+    description: str
+    parameters: dict[str, Any]
+    min_scope: AIScope = AIScope.USER
+
+
+@dataclass(frozen=True)
 class AIRequest:
     """Provider-neutral request passed to a future AI gateway."""
 
@@ -125,6 +146,7 @@ class AIRequest:
     response_schema: dict[str, Any] | None = None
     max_output_tokens: int = 800
     timeout_seconds: float = 20.0
+    tools: tuple[AIToolSpec, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -188,6 +210,7 @@ __all__ = [
     "AISuggestion",
     "AISuggestionKind",
     "AITask",
+    "AIToolSpec",
     "Confidence",
     "PolicyDenialReason",
     "Severity",

--- a/disbot/core/runtime/ai/feature_flags.py
+++ b/disbot/core/runtime/ai/feature_flags.py
@@ -16,6 +16,10 @@ Recognised env vars:
   ``AI_TASK_SETUP_SUGGEST_ENABLED``). Default off, except for
   setup-advisor compatibility tasks which respect
   ``SETUP_ADVISOR_PROVIDER`` (legacy).
+* ``AI_TOOLS_ENABLED``           — ``"1"``/``"true"`` to let the
+  gateway offer read-only tools to the model (function calling).
+  Layers under :func:`ai_enabled`; default off, so tool calling is
+  inert until an operator opts in.
 
 Compatibility note: ``SETUP_ADVISOR_PROVIDER`` remains the
 authoritative env var for the setup advisor's provider choice. The
@@ -68,6 +72,19 @@ def task_enabled(task: AITask) -> bool:
         return False
     env_name = f"AI_TASK_{task.name}_ENABLED"
     return _bool_env(env_name, default=True)
+
+
+def ai_tools_enabled() -> bool:
+    """True if the gateway may offer read-only tools to the model.
+
+    Layers on top of :func:`ai_enabled`: the global flag must also be
+    on. When false (the default), the gateway never passes a tool
+    dispatch to the provider, so behaviour is identical to the
+    no-tools path regardless of what tools a caller supplies.
+    """
+    if not ai_enabled():
+        return False
+    return _bool_env("AI_TOOLS_ENABLED", default=False)
 
 
 def setup_advisor_provider() -> str:

--- a/disbot/core/runtime/ai/gateway.py
+++ b/disbot/core/runtime/ai/gateway.py
@@ -29,12 +29,13 @@ import asyncio
 import json
 import logging
 import time
+from collections.abc import Mapping
 from typing import Any
 
 from core.runtime.ai import redaction
 from core.runtime.ai.contracts import AIRequest, AIResponse, AIResponseMode
 from core.runtime.ai.diagnostics import DiagnosticsCollector, get_default_collector
-from core.runtime.ai.feature_flags import task_enabled
+from core.runtime.ai.feature_flags import ai_tools_enabled, task_enabled
 from core.runtime.ai.providers import (
     DeterministicFallbackError,
     DeterministicProvider,
@@ -42,6 +43,7 @@ from core.runtime.ai.providers import (
     Provider,
     ProviderUnavailableError,
 )
+from core.runtime.ai.providers.base import ToolDispatch, ToolHandler
 from core.runtime.ai.routing import RoutingTarget, resolve
 from core.runtime.ai.safety import precheck
 from services import metrics
@@ -150,8 +152,18 @@ class AIGateway:
         request: AIRequest,
         *,
         provider_override: Provider | None = None,
+        tool_handlers: Mapping[str, ToolHandler] | None = None,
     ) -> AIResponse:
-        """Run a request through the pipeline; never raises."""
+        """Run a request through the pipeline; never raises.
+
+        When ``tool_handlers`` is supplied, ``request.tools`` is
+        non-empty, and ``feature_flags.ai_tools_enabled()`` is true, the
+        gateway hands the provider a redaction-wrapped dispatch callback
+        so the model can call those read-only tools. Tool outputs are
+        redacted before they re-enter the model context, and tool faults
+        are returned to the model as a JSON error string (the gateway's
+        never-raise contract still holds).
+        """
         target = resolve(request.context.task)
         if provider_override is None and request.context.guild_id is not None:
             target = await _overlay_guild_policy(target, request.context.guild_id)
@@ -187,6 +199,7 @@ class AIGateway:
             response_schema=request.response_schema,
             max_output_tokens=request.max_output_tokens,
             timeout_seconds=request.timeout_seconds,
+            tools=request.tools,
         )
 
         provider = provider_override or self._providers.get(target.provider)
@@ -204,14 +217,32 @@ class AIGateway:
             )
 
         self._collector.record_request(provider_active=provider.name)
+        dispatch: ToolDispatch | None = None
+        if tool_handlers is not None and request.tools and ai_tools_enabled():
+            dispatch = self._build_dispatch(
+                redacted_request,
+                tool_handlers,
+                provider.name,
+            )
         timeout = request.timeout_seconds or target.timeout_seconds
         outcome = "success"
         started = time.perf_counter()
         try:
-            raw_text = await asyncio.wait_for(
-                provider.execute(redacted_request, model=target.model),
-                timeout=timeout,
-            )
+            # Only pass ``dispatch`` when tools are active so the no-tools
+            # path stays identical to a provider with the legacy
+            # ``execute(request, *, model)`` signature.
+            if dispatch is None:
+                provider_call = provider.execute(
+                    redacted_request,
+                    model=target.model,
+                )
+            else:
+                provider_call = provider.execute(
+                    redacted_request,
+                    model=target.model,
+                    dispatch=dispatch,
+                )
+            raw_text = await asyncio.wait_for(provider_call, timeout=timeout)
         except asyncio.TimeoutError:
             latency_ms = (time.perf_counter() - started) * 1000.0
             outcome = "timeout"
@@ -348,6 +379,50 @@ class AIGateway:
             degraded=degraded,
             fallback_reason=fallback_reason,
         )
+
+    def _build_dispatch(
+        self,
+        request: AIRequest,
+        tool_handlers: Mapping[str, ToolHandler],
+        provider_name: str,
+    ) -> ToolDispatch:
+        """Wrap ``tool_handlers`` in a redaction- and fault-safe dispatch.
+
+        Only tools actually offered on ``request.tools`` are callable (a
+        model that names an un-offered tool gets an error back). Each
+        result is JSON-encoded and run through redaction before it
+        re-enters the model context. Handler exceptions are converted to
+        a JSON error string so the tool loop never breaks the gateway's
+        never-raise contract.
+        """
+        offered = {spec.name for spec in request.tools}
+
+        async def dispatch(name: str, arguments: dict[str, Any]) -> str:
+            if name not in offered or name not in tool_handlers:
+                return json.dumps({"error": "tool_not_available", "tool": name})
+            try:
+                result = await tool_handlers[name](arguments)
+            except (
+                Exception
+            ) as exc:  # noqa: BLE001 — tool faults must not break the loop
+                logger.warning(
+                    "ai gateway: tool %r raised: %s",
+                    name,
+                    exc,
+                    exc_info=True,
+                )
+                self._collector.record_failure(
+                    provider_active=provider_name,
+                    error_type="ToolError",
+                    fallback_reason=f"tool:{name}",
+                )
+                return json.dumps({"error": "tool_failed", "tool": name})
+            payload = (
+                result if isinstance(result, str) else json.dumps(result, default=str)
+            )
+            return _redact_string(payload)
+
+        return dispatch
 
 
 _DEFAULT_GATEWAY: AIGateway | None = None

--- a/disbot/core/runtime/ai/natural_language_stage.py
+++ b/disbot/core/runtime/ai/natural_language_stage.py
@@ -31,7 +31,7 @@ from typing import TYPE_CHECKING
 
 import discord
 
-from core.runtime.ai.contracts import AITask, PolicyDenialReason
+from core.runtime.ai.contracts import AIScope, AITask, PolicyDenialReason
 from core.runtime.ai.feature_facts import FeatureFactRequest, FeatureFactsResult
 from core.runtime.message_pipeline import MessagePipelineContext, StageResult
 from services import (
@@ -455,6 +455,7 @@ class AINaturalLanguageStage:
                 actor_id=user_id,
                 channel_id=channel_id,
                 correlation_id=correlation_id,
+                scope=_derive_scope(message),
             )
 
             response = await _invoke_gateway(stack, built, ctx)
@@ -632,6 +633,37 @@ async def _gather_feature_facts(req: FeatureFactRequest) -> FeatureFactsResult:
     return FeatureFactsResult(facts=())
 
 
+def _derive_scope(message: discord.Message) -> AIScope:
+    """Map the message author's Discord permissions to an :class:`AIScope`.
+
+    Used only to decide which read-only tools the model may be offered
+    (see :mod:`services.ai_tools`). It does NOT influence whether the bot
+    replies — the policy resolver owns that decision. Anything
+    unrecognised (e.g. a missing permissions object) defaults to ``USER``.
+    """
+    author = getattr(message, "author", None)
+    guild = getattr(message, "guild", None)
+    if (
+        guild is not None
+        and author is not None
+        and getattr(guild, "owner_id", None) == getattr(author, "id", None)
+    ):
+        return AIScope.SERVER_OWNER
+    perms = getattr(author, "guild_permissions", None)
+    if perms is None:
+        return AIScope.USER
+    if getattr(perms, "administrator", False) or getattr(perms, "manage_guild", False):
+        return AIScope.ADMIN
+    if (
+        getattr(perms, "manage_messages", False)
+        or getattr(perms, "kick_members", False)
+        or getattr(perms, "ban_members", False)
+        or getattr(perms, "moderate_members", False)
+    ):
+        return AIScope.MODERATOR
+    return AIScope.USER
+
+
 async def _invoke_gateway(
     stack: ai_instruction_service.InstructionStack,
     built: ai_context_service.BuiltContext,
@@ -645,17 +677,43 @@ async def _invoke_gateway(
     violation and propagates to the outer handler in
     :meth:`AINaturalLanguageStage.process` which audits it as
     ``errored / PROVIDER_UNAVAILABLE``.
+
+    When ``AI_TOOLS_ENABLED`` is on we attach the read-only tool set the
+    caller's scope permits; the gateway decides whether to actually offer
+    them to the model. When off, ``tools`` is empty and ``tool_handlers``
+    is ``None`` — byte-for-byte identical to the no-tools path.
     """
-    from core.runtime.ai.contracts import AIRequest, AIResponseMode
-    from services import ai_gateway
+    from collections.abc import Mapping
+
+    from core.runtime.ai.contracts import AIRequest, AIResponseMode, AIToolSpec
+    from core.runtime.ai.feature_flags import ai_tools_enabled
+    from core.runtime.ai.providers.base import ToolHandler
+    from services import ai_gateway, ai_tools
+
+    ctx = built.request_context
+    specs: tuple[AIToolSpec, ...] = ()
+    handlers: Mapping[str, ToolHandler] | None = None
+    if ai_tools_enabled() and ctx.guild_id is not None and ctx.actor_id is not None:
+        registry = ai_tools.build_registry(
+            scope=ctx.scope,
+            guild_id=ctx.guild_id,
+            actor_id=ctx.actor_id,
+        )
+        specs = registry.specs
+        handlers = registry.handlers
 
     request = AIRequest(
-        context=built.request_context,
+        context=ctx,
         system_prompt=stack.render_system_prompt(),
         payload={"text": stack.render_payload_text()},
         mode=AIResponseMode.TEXT,
+        tools=specs,
     )
-    return await ai_gateway.execute(request)
+    # Pass tool_handlers only when tools are active so the no-tools path
+    # matches the legacy single-argument ``execute(request)`` call.
+    if handlers is None:
+        return await ai_gateway.execute(request)
+    return await ai_gateway.execute(request, tool_handlers=handlers)
 
 
 # Convenience export used by AICog.cog_load when wiring the stage in.

--- a/disbot/core/runtime/ai/providers/base.py
+++ b/disbot/core/runtime/ai/providers/base.py
@@ -20,9 +20,23 @@ Providers may raise:
 
 from __future__ import annotations
 
-from typing import Protocol, runtime_checkable
+from collections.abc import Awaitable, Callable
+from typing import Any, Protocol, runtime_checkable
 
 from core.runtime.ai.contracts import AIRequest
+
+#: A read-only tool handler: receives parsed arguments and returns a
+#: JSON-serialisable result (or a string). Handlers live in the
+#: services layer; the alias is declared here so the gateway and
+#: providers can reference the type without importing ``services``.
+ToolHandler = Callable[[dict[str, Any]], Awaitable[Any]]
+
+#: Gateway-provided callback a provider invokes during a tool loop.
+#: Given a tool name and parsed arguments, it returns the (already
+#: redacted) tool result as a string to feed back into the model
+#: context. It never raises — tool failures come back as a JSON error
+#: string so the loop can continue and the model can react.
+ToolDispatch = Callable[[str, dict[str, Any]], Awaitable[str]]
 
 
 class ProviderUnavailableError(RuntimeError):
@@ -44,7 +58,13 @@ class Provider(Protocol):
 
     name: str
 
-    async def execute(self, request: AIRequest, *, model: str) -> str:
+    async def execute(
+        self,
+        request: AIRequest,
+        *,
+        model: str,
+        dispatch: ToolDispatch | None = None,
+    ) -> str:
         """Run the provider call and return the raw text response.
 
         Args:
@@ -52,6 +72,13 @@ class Provider(Protocol):
                 the gateway before this is called).
             model: The provider-specific model identifier resolved by
                 :mod:`core.runtime.ai.routing`.
+            dispatch: Optional tool-dispatch callback. When provided
+                *and* ``request.tools`` is non-empty, the provider may
+                offer those tools to the model and run a bounded
+                tool-call loop, invoking ``dispatch`` for each call.
+                When ``None`` (the default), the provider behaves
+                exactly as the no-tools path. Providers that do not
+                support tools ignore this argument.
 
         Returns:
             The raw assistant text. For ``AIResponseMode.JSON`` the

--- a/disbot/core/runtime/ai/providers/deterministic_provider.py
+++ b/disbot/core/runtime/ai/providers/deterministic_provider.py
@@ -15,6 +15,7 @@ API key is configured. Its existence keeps the gateway boot-safe:
 from __future__ import annotations
 
 from core.runtime.ai.contracts import AIRequest
+from core.runtime.ai.providers.base import ToolDispatch
 
 
 class DeterministicFallbackError(RuntimeError):
@@ -31,7 +32,13 @@ class DeterministicProvider:
 
     name = "deterministic"
 
-    async def execute(self, request: AIRequest, *, model: str) -> str:
+    async def execute(
+        self,
+        request: AIRequest,
+        *,
+        model: str,
+        dispatch: ToolDispatch | None = None,
+    ) -> str:
         raise DeterministicFallbackError(
             "deterministic provider selected; no external call performed",
         )

--- a/disbot/core/runtime/ai/providers/openai_provider.py
+++ b/disbot/core/runtime/ai/providers/openai_provider.py
@@ -14,10 +14,15 @@ import logging
 import os
 from typing import Any
 
-from core.runtime.ai.contracts import AIRequest, AIResponseMode
-from core.runtime.ai.providers.base import ProviderUnavailableError
+from core.runtime.ai.contracts import AIRequest, AIResponseMode, AIToolSpec
+from core.runtime.ai.providers.base import ProviderUnavailableError, ToolDispatch
 
 logger = logging.getLogger("bot.runtime.ai.openai_provider")
+
+# Maximum number of model<->tool round-trips before the adapter forces
+# a final, tool-free answer. Bounds latency and cost; also a safety
+# stop against a model that loops on tool calls indefinitely.
+_TOOL_HOP_LIMIT = 4
 
 
 class OpenAIProvider:
@@ -26,6 +31,12 @@ class OpenAIProvider:
     The adapter is constructed once per gateway. A test can inject a
     duck-typed ``client`` (e.g. a ``MagicMock`` shaped like
     ``AsyncOpenAI``) without importing the SDK.
+
+    When the gateway supplies a ``dispatch`` callback and the request
+    carries ``tools``, the adapter offers those tools to the model and
+    runs a bounded tool-call loop (see :data:`_TOOL_HOP_LIMIT`). When
+    ``dispatch`` is ``None`` the behaviour is identical to a plain
+    single-shot completion.
     """
 
     name = "openai"
@@ -57,38 +68,141 @@ class OpenAIProvider:
         self._client = AsyncOpenAI(api_key=api_key)
         return self._client
 
-    async def execute(self, request: AIRequest, *, model: str) -> str:
+    async def execute(
+        self,
+        request: AIRequest,
+        *,
+        model: str,
+        dispatch: ToolDispatch | None = None,
+    ) -> str:
         client = self._ensure_client()
-        user_payload = json.dumps(request.payload, default=str)
-        messages = [
+        messages: list[dict[str, Any]] = [
             {"role": "system", "content": request.system_prompt},
-            {"role": "user", "content": user_payload},
+            {"role": "user", "content": json.dumps(request.payload, default=str)},
         ]
-        kwargs: dict[str, Any] = {"model": model, "messages": messages}
-        if request.mode is AIResponseMode.JSON and request.response_schema:
-            kwargs["response_format"] = {
-                "type": "json_schema",
-                "json_schema": request.response_schema,
-            }
-        elif request.mode is AIResponseMode.JSON:
-            # JSON requested but no schema provided — fall back to the
-            # SDK's loose JSON mode so callers still get parseable output.
-            kwargs["response_format"] = {"type": "json_object"}
+        response_format = _response_format(request)
+        offer_tools = bool(request.tools) and dispatch is not None
+        tool_params = _to_openai_tools(request.tools) if offer_tools else None
 
-        response = await client.chat.completions.create(**kwargs)
-        text = _extract_response_text(response)
-        if text is None:
-            raise RuntimeError("openai: empty response (no choices/message/content)")
-        return text
+        for hop in range(_TOOL_HOP_LIMIT + 1):
+            allow_tools = tool_params is not None and hop < _TOOL_HOP_LIMIT
+            kwargs: dict[str, Any] = {"model": model, "messages": messages}
+            if response_format is not None:
+                kwargs["response_format"] = response_format
+            if allow_tools:
+                kwargs["tools"] = tool_params
+                kwargs["tool_choice"] = "auto"
+
+            response = await client.chat.completions.create(**kwargs)
+            message = _message_of(response)
+            tool_calls = getattr(message, "tool_calls", None) if message else None
+
+            if not allow_tools or not tool_calls:
+                text = _extract_response_text(response)
+                if text is None:
+                    raise RuntimeError(
+                        "openai: empty response (no choices/message/content)",
+                    )
+                return text
+
+            # The model asked for one or more tools. Echo its tool-call
+            # turn, then append each tool result, then loop for the
+            # follow-up completion. ``dispatch`` never raises — failures
+            # come back as a JSON error string the model can react to.
+            messages.append(_assistant_tool_call_turn(message, tool_calls))
+            for call in tool_calls:
+                result = await dispatch(  # type: ignore[misc]
+                    _call_name(call),
+                    _call_arguments(call),
+                )
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": getattr(call, "id", ""),
+                        "content": result,
+                    },
+                )
+
+        # Unreachable: the final hop sets ``allow_tools=False`` and
+        # returns above. Guard anyway so a contract change is loud.
+        raise RuntimeError("openai: tool loop did not terminate")
+
+
+def _response_format(request: AIRequest) -> dict[str, Any] | None:
+    """Build the ``response_format`` kwarg for ``request.mode``."""
+    if request.mode is not AIResponseMode.JSON:
+        return None
+    if request.response_schema:
+        return {"type": "json_schema", "json_schema": request.response_schema}
+    # JSON requested but no schema provided — fall back to the SDK's
+    # loose JSON mode so callers still get parseable output.
+    return {"type": "json_object"}
+
+
+def _to_openai_tools(specs: tuple[AIToolSpec, ...]) -> list[dict[str, Any]]:
+    """Translate provider-neutral specs into OpenAI ``tools`` entries."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": spec.name,
+                "description": spec.description,
+                "parameters": spec.parameters,
+            },
+        }
+        for spec in specs
+    ]
+
+
+def _assistant_tool_call_turn(message: Any, tool_calls: Any) -> dict[str, Any]:
+    """Reconstruct the assistant message that requested ``tool_calls``."""
+    return {
+        "role": "assistant",
+        "content": getattr(message, "content", None),
+        "tool_calls": [
+            {
+                "id": getattr(call, "id", ""),
+                "type": "function",
+                "function": {
+                    "name": _call_name(call),
+                    "arguments": getattr(
+                        getattr(call, "function", None),
+                        "arguments",
+                        "",
+                    )
+                    or "{}",
+                },
+            }
+            for call in tool_calls
+        ],
+    }
+
+
+def _call_name(call: Any) -> str:
+    return getattr(getattr(call, "function", None), "name", "") or ""
+
+
+def _call_arguments(call: Any) -> dict[str, Any]:
+    """Parse a tool call's JSON arguments into a dict (never raises)."""
+    raw = getattr(getattr(call, "function", None), "arguments", "") or "{}"
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _message_of(response: Any) -> Any:
+    """Return the first choice's message object, or ``None``."""
+    choices = getattr(response, "choices", None)
+    if not choices:
+        return None
+    return getattr(choices[0], "message", None)
 
 
 def _extract_response_text(response: Any) -> str | None:
     """Pull the assistant message text out of a Chat Completions response."""
-    choices = getattr(response, "choices", None)
-    if not choices:
-        return None
-    first = choices[0]
-    message = getattr(first, "message", None)
+    message = _message_of(response)
     if message is None:
         return None
     content = getattr(message, "content", None)

--- a/disbot/services/ai_gateway.py
+++ b/disbot/services/ai_gateway.py
@@ -9,6 +9,8 @@ or service.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 from core.runtime.ai.contracts import (
     AIDiagnosticsSnapshot,
     AIRequest,
@@ -21,6 +23,7 @@ from core.runtime.ai.contracts import (
     AITask,
 )
 from core.runtime.ai.gateway import AIGateway, get_default_gateway
+from core.runtime.ai.providers.base import ToolHandler
 
 __all__ = [
     "AIDiagnosticsSnapshot",
@@ -38,11 +41,20 @@ __all__ = [
 ]
 
 
-async def execute(request: AIRequest) -> AIResponse:
+async def execute(
+    request: AIRequest,
+    *,
+    tool_handlers: Mapping[str, ToolHandler] | None = None,
+) -> AIResponse:
     """Run ``request`` through the default gateway.
 
-    Convenience wrapper around ``get_default_gateway().execute(request)``
-    for callers that do not need to construct or replace the gateway
-    instance themselves.
+    Convenience wrapper around ``get_default_gateway().execute(...)`` for
+    callers that do not need to construct or replace the gateway instance
+    themselves. ``tool_handlers`` is forwarded so callers can offer the
+    model read-only tools (see :mod:`services.ai_tools`); it is ignored
+    unless ``request.tools`` is set and ``AI_TOOLS_ENABLED`` is on.
     """
-    return await get_default_gateway().execute(request)
+    return await get_default_gateway().execute(
+        request,
+        tool_handlers=tool_handlers,
+    )

--- a/disbot/services/ai_tools.py
+++ b/disbot/services/ai_tools.py
@@ -27,7 +27,11 @@ from typing import Any
 
 from core.runtime.ai.contracts import AIScope, AIToolSpec
 from core.runtime.ai.providers.base import ToolHandler
-from services import ai_permission_service
+from services import (
+    ai_config_projection_service,
+    ai_decision_audit_service,
+    ai_permission_service,
+)
 
 # Least-privilege ordering for AIScope. A caller may be offered a tool
 # when their rank is >= the tool's ``min_scope`` rank.
@@ -97,6 +101,96 @@ async def _server_time(_arguments: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+# --- get_guild_ai_config (admin) ---------------------------------------
+
+_GUILD_AI_CONFIG_SPEC = AIToolSpec(
+    name="get_guild_ai_config",
+    description=(
+        "Return this server's AI configuration: whether AI and natural-"
+        "language replies are enabled, the active provider and model, the "
+        "minimum level and cooldown, and the memory window. Admin only. "
+        "Use this to answer questions about how the bot is set up here."
+    ),
+    parameters=_NO_ARGS_SCHEMA,
+    min_scope=AIScope.ADMIN,
+)
+
+
+def _make_guild_ai_config(guild_id: int) -> ToolHandler:
+    async def handler(_arguments: dict[str, Any]) -> dict[str, Any]:
+        snap = await ai_config_projection_service.build_snapshot(guild_id)
+        return {
+            "ai_enabled": snap.policy.enabled,
+            "natural_language_enabled": snap.policy.natural_language_enabled,
+            "provider": snap.policy.default_provider or snap.provider.provider_active,
+            "model": snap.policy.default_model,
+            "minimum_level": snap.policy.minimum_level_default,
+            "cooldown_seconds": snap.policy.cooldown_seconds,
+            "memory_window_minutes": snap.memory.window_minutes,
+        }
+
+    return handler
+
+
+# --- recent_audit (admin) ----------------------------------------------
+
+_RECENT_AUDIT_SPEC = AIToolSpec(
+    name="recent_audit",
+    description=(
+        "Return the most recent AI decision-audit rows for this server — "
+        "what the bot decided to do with recent messages and why. Admin "
+        "only. Use to explain recent AI behaviour, e.g. why the bot did or "
+        "did not reply."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 20,
+                "description": "How many recent rows to return (default 5).",
+            },
+        },
+        "additionalProperties": False,
+    },
+    min_scope=AIScope.ADMIN,
+)
+
+
+def _make_recent_audit(guild_id: int) -> ToolHandler:
+    async def handler(arguments: dict[str, Any]) -> dict[str, Any]:
+        limit = _coerce_limit(arguments.get("limit"), default=5, lo=1, hi=20)
+        rows = await ai_decision_audit_service.query(guild_id, limit=limit)
+        return {"rows": [_audit_row_summary(row) for row in rows]}
+
+    return handler
+
+
+def _coerce_limit(value: Any, *, default: int, lo: int, hi: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(lo, min(hi, parsed))
+
+
+def _audit_row_summary(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "decision": row.get("decision"),
+        "reason": row.get("reason_code"),
+        "task": row.get("task"),
+        "at": _ts(row.get("created_at")),
+    }
+
+
+def _ts(value: Any) -> str | None:
+    if value is None:
+        return None
+    iso = getattr(value, "isoformat", None)
+    return iso() if callable(iso) else str(value)
+
+
 @dataclass(frozen=True)
 class ToolRegistry:
     """The tools offered for one request: specs (data) + live handlers."""
@@ -121,6 +215,8 @@ def build_registry(
     catalog: list[tuple[AIToolSpec, ToolHandler]] = [
         (_USER_STANDING_SPEC, _make_user_standing(guild_id, actor_id)),
         (_SERVER_TIME_SPEC, _server_time),
+        (_GUILD_AI_CONFIG_SPEC, _make_guild_ai_config(guild_id)),
+        (_RECENT_AUDIT_SPEC, _make_recent_audit(guild_id)),
     ]
     specs: list[AIToolSpec] = []
     handlers: dict[str, ToolHandler] = {}

--- a/disbot/services/ai_tools.py
+++ b/disbot/services/ai_tools.py
@@ -1,0 +1,134 @@
+"""Read-only AI tools the model may call during a natural-language turn.
+
+Handlers live in the services layer (not ``core/runtime``) because they
+read from other services. For a given request the gateway is handed the
+``{name: handler}`` map; the matching :class:`AIToolSpec` objects travel
+on the request as pure data. Every tool here is **read-only** and returns
+a small, JSON-serialisable dict.
+
+Adding a write-capable tool is deliberately out of scope: mutations must
+continue to flow through the deterministic mutation services after
+explicit confirmation (see ``docs/ai-service-integration-map.md`` and
+``docs/ai-config-ownership.md`` § "Mutation seam"). Tools added here must
+stay read-only.
+
+Scope gating: ``build_registry`` only includes a tool when the caller's
+:class:`AIScope` satisfies the tool's ``min_scope``. A tool above the
+caller's privilege is never offered to the model at all, so the model
+cannot even attempt to call it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from core.runtime.ai.contracts import AIScope, AIToolSpec
+from core.runtime.ai.providers.base import ToolHandler
+from services import ai_permission_service
+
+# Least-privilege ordering for AIScope. A caller may be offered a tool
+# when their rank is >= the tool's ``min_scope`` rank.
+_SCOPE_RANK: dict[AIScope, int] = {
+    AIScope.USER: 0,
+    AIScope.MODERATOR: 1,
+    AIScope.ADMIN: 2,
+    AIScope.SERVER_OWNER: 3,
+    AIScope.PLATFORM_OWNER: 4,
+    AIScope.SYSTEM: 5,
+}
+
+_NO_ARGS_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+
+def _scope_allows(caller: AIScope, required: AIScope) -> bool:
+    """True if ``caller`` is privileged enough to be offered ``required``."""
+    return _SCOPE_RANK.get(caller, 0) >= _SCOPE_RANK.get(required, 0)
+
+
+# --- get_user_standing -------------------------------------------------
+
+_USER_STANDING_SPEC = AIToolSpec(
+    name="get_user_standing",
+    description=(
+        "Return the current user's standing in this server: their XP "
+        "level and whether they are a brand-new user. Call this when the "
+        "answer depends on who is asking or on their level/permissions."
+    ),
+    parameters=_NO_ARGS_SCHEMA,
+    min_scope=AIScope.USER,
+)
+
+
+def _make_user_standing(guild_id: int, actor_id: int) -> ToolHandler:
+    async def handler(_arguments: dict[str, Any]) -> dict[str, Any]:
+        snap = await ai_permission_service.snapshot(guild_id, actor_id)
+        return {"level": snap.level, "is_new_user": snap.is_fresh_user}
+
+    return handler
+
+
+# --- get_server_time ---------------------------------------------------
+
+_SERVER_TIME_SPEC = AIToolSpec(
+    name="get_server_time",
+    description=(
+        "Return the bot's current UTC date and time. Call this before "
+        "stating or computing anything time-relative (today's date, how "
+        "long ago something happened) so the answer is grounded, not "
+        "guessed."
+    ),
+    parameters=_NO_ARGS_SCHEMA,
+    min_scope=AIScope.USER,
+)
+
+
+async def _server_time(_arguments: dict[str, Any]) -> dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    return {
+        "utc": now.isoformat(timespec="seconds"),
+        "note": "Authoritative server clock; use instead of guessing dates.",
+    }
+
+
+@dataclass(frozen=True)
+class ToolRegistry:
+    """The tools offered for one request: specs (data) + live handlers."""
+
+    specs: tuple[AIToolSpec, ...]
+    handlers: Mapping[str, ToolHandler]
+
+
+def build_registry(
+    *,
+    scope: AIScope,
+    guild_id: int,
+    actor_id: int,
+) -> ToolRegistry:
+    """Build the read-only tool set the caller's ``scope`` may be offered.
+
+    ``specs`` are attached to the :class:`AIRequest` (the model sees
+    them); ``handlers`` are passed to ``ai_gateway.execute`` as
+    ``tool_handlers``. Only tools whose ``min_scope`` the caller
+    satisfies are included.
+    """
+    catalog: list[tuple[AIToolSpec, ToolHandler]] = [
+        (_USER_STANDING_SPEC, _make_user_standing(guild_id, actor_id)),
+        (_SERVER_TIME_SPEC, _server_time),
+    ]
+    specs: list[AIToolSpec] = []
+    handlers: dict[str, ToolHandler] = {}
+    for spec, handler in catalog:
+        if _scope_allows(scope, spec.min_scope):
+            specs.append(spec)
+            handlers[spec.name] = handler
+    return ToolRegistry(specs=tuple(specs), handlers=handlers)
+
+
+__all__ = ["ToolRegistry", "build_registry"]

--- a/tests/unit/runtime/ai/test_tool_calling.py
+++ b/tests/unit/runtime/ai/test_tool_calling.py
@@ -19,9 +19,11 @@ from __future__ import annotations
 import json
 from types import SimpleNamespace
 
+from core.runtime.ai import natural_language_stage as nls
 from core.runtime.ai.contracts import (
     AIRequest,
     AIRequestContext,
+    AIResponse,
     AIResponseMode,
     AIScope,
     AITask,
@@ -29,6 +31,7 @@ from core.runtime.ai.contracts import (
 )
 from core.runtime.ai.gateway import AIGateway
 from core.runtime.ai.providers.openai_provider import _TOOL_HOP_LIMIT, OpenAIProvider
+from services import ai_context_service
 
 # --- fakes -------------------------------------------------------------
 
@@ -266,3 +269,80 @@ async def test_gateway_end_to_end_tool_loop(monkeypatch):
     assert response.degraded is False
     assert response.text == "Done at noon."
     assert seen.get("called") is True
+
+
+# --- live natural-language-stage wiring -------------------------------
+
+
+def _fake_stack():
+    return SimpleNamespace(
+        render_system_prompt=lambda: "system",
+        render_payload_text=lambda: "hi",
+    )
+
+
+async def test_stage_invoke_gateway_attaches_scoped_tools(monkeypatch):
+    monkeypatch.setenv("AI_ENABLED", "1")
+    monkeypatch.setenv("AI_TOOLS_ENABLED", "1")
+    captured: dict = {}
+
+    async def fake_execute(request, *, tool_handlers=None):
+        captured["tools"] = request.tools
+        captured["handlers"] = tool_handlers
+        return AIResponse(
+            task=request.context.task,
+            provider="x",
+            model="m",
+            text="ok",
+        )
+
+    monkeypatch.setattr("services.ai_gateway.execute", fake_execute)
+    built = ai_context_service.build(
+        task=AITask.GENERAL_NL_ANSWER,
+        guild_id=1,
+        actor_id=2,
+        channel_id=3,
+        correlation_id="c",
+        scope=AIScope.ADMIN,
+    )
+
+    response = await nls._invoke_gateway(_fake_stack(), built, object())
+
+    assert response.text == "ok"
+    names = {spec.name for spec in captured["tools"]}
+    # Admin scope is offered the admin tools too.
+    assert "get_user_standing" in names
+    assert "get_guild_ai_config" in names
+    assert captured["handlers"] is not None
+    assert set(captured["handlers"]) == names
+
+
+async def test_stage_invoke_gateway_no_tools_when_flag_off(monkeypatch):
+    monkeypatch.setenv("AI_ENABLED", "1")
+    monkeypatch.delenv("AI_TOOLS_ENABLED", raising=False)
+    captured: dict = {}
+
+    async def fake_execute(request, *, tool_handlers=None):
+        captured["tools"] = request.tools
+        captured["handlers"] = tool_handlers
+        return AIResponse(
+            task=request.context.task,
+            provider="x",
+            model="m",
+            text="ok",
+        )
+
+    monkeypatch.setattr("services.ai_gateway.execute", fake_execute)
+    built = ai_context_service.build(
+        task=AITask.GENERAL_NL_ANSWER,
+        guild_id=1,
+        actor_id=2,
+        channel_id=3,
+        correlation_id="c",
+        scope=AIScope.ADMIN,
+    )
+
+    await nls._invoke_gateway(_fake_stack(), built, object())
+
+    assert captured["tools"] == ()
+    assert captured["handlers"] is None

--- a/tests/unit/runtime/ai/test_tool_calling.py
+++ b/tests/unit/runtime/ai/test_tool_calling.py
@@ -1,0 +1,268 @@
+"""Read-only tool-calling tests — PR-1 foundation.
+
+Pins the behaviour the tool-calling plan requires:
+
+* The OpenAI adapter runs a bounded model<->tool loop when handed a
+  dispatch callback and tool specs, and returns the final text.
+* With ``dispatch=None`` the adapter never offers tools — identical to
+  the legacy single-shot path (the inertness guarantee).
+* The loop is bounded by ``_TOOL_HOP_LIMIT`` and forces a final,
+  tool-free answer.
+* The gateway only builds a dispatch when ``AI_TOOLS_ENABLED`` is on.
+* The gateway's dispatch enforces the offered-tool allowlist, redacts
+  tool output before it re-enters context, and converts tool faults
+  into a JSON error string (never raising).
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from core.runtime.ai.contracts import (
+    AIRequest,
+    AIRequestContext,
+    AIResponseMode,
+    AIScope,
+    AITask,
+    AIToolSpec,
+)
+from core.runtime.ai.gateway import AIGateway
+from core.runtime.ai.providers.openai_provider import _TOOL_HOP_LIMIT, OpenAIProvider
+
+# --- fakes -------------------------------------------------------------
+
+
+def _msg(*, content=None, tool_calls=None):
+    return SimpleNamespace(content=content, tool_calls=tool_calls)
+
+
+def _response(message):
+    return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+def _tool_call(call_id, name, arguments):
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+class _FakeCompletions:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls: list[dict] = []
+
+    async def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return self._responses.pop(0)
+
+
+class _FakeClient:
+    def __init__(self, responses):
+        self.chat = SimpleNamespace(completions=_FakeCompletions(responses))
+
+
+class _CapturingProvider:
+    """Records the ``dispatch`` it was handed; returns fixed text."""
+
+    name = "openai"
+
+    def __init__(self):
+        self.dispatch = "unset"
+
+    async def execute(self, request, *, model, dispatch=None):
+        self.dispatch = dispatch
+        return "ok"
+
+
+def _tool_request(*names: str) -> AIRequest:
+    specs = tuple(
+        AIToolSpec(
+            name=name,
+            description=f"{name} description",
+            parameters={"type": "object", "properties": {}},
+        )
+        for name in names
+    )
+    return AIRequest(
+        context=AIRequestContext(
+            task=AITask.GENERAL_NL_ANSWER,
+            scope=AIScope.USER,
+            source="test",
+        ),
+        system_prompt="system",
+        payload={"text": "hi"},
+        mode=AIResponseMode.TEXT,
+        timeout_seconds=5.0,
+        tools=specs,
+    )
+
+
+# --- provider-level loop ----------------------------------------------
+
+
+async def test_provider_runs_tool_loop_and_returns_final_text():
+    client = _FakeClient(
+        [
+            _response(_msg(tool_calls=[_tool_call("c1", "get_server_time", "{}")])),
+            _response(_msg(content="It is noon.")),
+        ],
+    )
+    provider = OpenAIProvider(client=client)
+    calls: list[tuple[str, dict]] = []
+
+    async def dispatch(name, args):
+        calls.append((name, args))
+        return '{"utc": "2026-05-29T12:00:00+00:00"}'
+
+    text = await provider.execute(
+        _tool_request("get_server_time"),
+        model="m",
+        dispatch=dispatch,
+    )
+
+    assert text == "It is noon."
+    assert calls == [("get_server_time", {})]
+    # First call offered tools; second call carried the tool result back.
+    assert "tools" in client.chat.completions.calls[0]
+    second = client.chat.completions.calls[1]["messages"]
+    assert any(
+        m.get("role") == "tool" and m.get("tool_call_id") == "c1" for m in second
+    )
+
+
+async def test_provider_without_dispatch_never_offers_tools():
+    client = _FakeClient([_response(_msg(content="plain answer"))])
+    provider = OpenAIProvider(client=client)
+
+    text = await provider.execute(
+        _tool_request("get_server_time"),
+        model="m",
+        dispatch=None,
+    )
+
+    assert text == "plain answer"
+    assert len(client.chat.completions.calls) == 1
+    assert "tools" not in client.chat.completions.calls[0]
+
+
+async def test_provider_tool_loop_is_bounded():
+    # Model keeps asking for a tool; after _TOOL_HOP_LIMIT hops the
+    # adapter forces a tool-free final completion.
+    responses = [
+        _response(_msg(tool_calls=[_tool_call(f"c{i}", "t", "{}")]))
+        for i in range(_TOOL_HOP_LIMIT)
+    ]
+    responses.append(_response(_msg(content="forced final")))
+    client = _FakeClient(responses)
+    provider = OpenAIProvider(client=client)
+
+    hops = 0
+
+    async def dispatch(name, args):
+        nonlocal hops
+        hops += 1
+        return "{}"
+
+    text = await provider.execute(_tool_request("t"), model="m", dispatch=dispatch)
+
+    assert text == "forced final"
+    assert hops == _TOOL_HOP_LIMIT
+    assert "tools" not in client.chat.completions.calls[-1]
+
+
+# --- gateway dispatch wiring ------------------------------------------
+
+
+async def test_gateway_no_dispatch_when_tools_flag_off(monkeypatch):
+    monkeypatch.setenv("AI_ENABLED", "1")
+    monkeypatch.delenv("AI_TOOLS_ENABLED", raising=False)
+    provider = _CapturingProvider()
+    gateway = AIGateway(providers={"openai": provider})
+
+    async def handler(_args):
+        return {"ok": True}
+
+    await gateway.execute(
+        _tool_request("get_server_time"),
+        provider_override=provider,
+        tool_handlers={"get_server_time": handler},
+    )
+
+    assert provider.dispatch is None
+
+
+async def test_gateway_dispatch_routes_redacts_and_isolates(monkeypatch):
+    monkeypatch.setenv("AI_ENABLED", "1")
+    monkeypatch.setenv("AI_TOOLS_ENABLED", "1")
+    provider = _CapturingProvider()
+    gateway = AIGateway(providers={"openai": provider})
+    seen: dict = {}
+
+    async def standing(args):
+        seen["args"] = args
+        return {"level": 7}
+
+    async def leaky(_args):
+        # A Discord-snowflake-like value must be scrubbed before the
+        # result re-enters the model context.
+        return {"trace_id": 123456789012345678}
+
+    async def boom(_args):
+        raise ValueError("kaboom")
+
+    await gateway.execute(
+        _tool_request("get_user_standing", "leaky", "boom"),
+        provider_override=provider,
+        tool_handlers={"get_user_standing": standing, "leaky": leaky, "boom": boom},
+    )
+
+    dispatch = provider.dispatch
+    assert dispatch is not None
+
+    # A clean result round-trips as JSON; arguments reach the handler.
+    out = await dispatch("get_user_standing", {"x": 1})
+    assert json.loads(out)["level"] == 7
+    assert seen["args"] == {"x": 1}
+
+    # A secret-looking value is redacted (the raw value never appears).
+    leaked = await dispatch("leaky", {})
+    assert "123456789012345678" not in leaked
+    assert "redacted" in leaked
+
+    # A tool not on the offered allowlist is refused.
+    refused = await dispatch("not_offered", {})
+    assert json.loads(refused)["error"] == "tool_not_available"
+
+    # A handler that raises is isolated into an error string.
+    failed = await dispatch("boom", {})
+    assert json.loads(failed)["error"] == "tool_failed"
+
+
+async def test_gateway_end_to_end_tool_loop(monkeypatch):
+    monkeypatch.setenv("AI_ENABLED", "1")
+    monkeypatch.setenv("AI_TOOLS_ENABLED", "1")
+    monkeypatch.setenv("AI_DEFAULT_PROVIDER", "openai")
+    client = _FakeClient(
+        [
+            _response(_msg(tool_calls=[_tool_call("c1", "get_server_time", "{}")])),
+            _response(_msg(content="Done at noon.")),
+        ],
+    )
+    gateway = AIGateway(providers={"openai": OpenAIProvider(client=client)})
+    seen: dict = {}
+
+    async def time_handler(_args):
+        seen["called"] = True
+        return {"utc": "2026-05-29T12:00:00+00:00"}
+
+    response = await gateway.execute(
+        _tool_request("get_server_time"),
+        tool_handlers={"get_server_time": time_handler},
+    )
+
+    assert response.degraded is False
+    assert response.text == "Done at noon."
+    assert seen.get("called") is True

--- a/tests/unit/services/test_ai_tools.py
+++ b/tests/unit/services/test_ai_tools.py
@@ -1,0 +1,60 @@
+"""Tests for the read-only AI tool registry — PR-1 foundation.
+
+Pins:
+
+* ``build_registry`` returns provider-neutral specs plus a matching
+  handler map.
+* Scope gating (``_scope_allows``) is least-privilege: a caller is only
+  offered tools at or below their scope.
+* The shipped handlers are read-only and return small JSON-serialisable
+  dicts.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+
+from core.runtime.ai.contracts import AIScope
+from services import ai_tools
+from services.ai_tools import _scope_allows, build_registry
+
+
+def test_build_registry_returns_specs_and_matching_handlers():
+    registry = build_registry(scope=AIScope.USER, guild_id=1, actor_id=2)
+
+    spec_names = {spec.name for spec in registry.specs}
+    assert spec_names == {"get_user_standing", "get_server_time"}
+    assert set(registry.handlers) == spec_names
+    assert isinstance(registry.specs, tuple)
+
+
+def test_scope_gating_is_least_privilege():
+    assert _scope_allows(AIScope.USER, AIScope.USER) is True
+    assert _scope_allows(AIScope.USER, AIScope.ADMIN) is False
+    assert _scope_allows(AIScope.ADMIN, AIScope.USER) is True
+    assert _scope_allows(AIScope.ADMIN, AIScope.ADMIN) is True
+    assert _scope_allows(AIScope.PLATFORM_OWNER, AIScope.ADMIN) is True
+
+
+async def test_server_time_handler_returns_parseable_utc():
+    registry = build_registry(scope=AIScope.USER, guild_id=1, actor_id=2)
+
+    result = await registry.handlers["get_server_time"]({})
+
+    assert "utc" in result
+    # Parses as an ISO-8601 timestamp.
+    datetime.fromisoformat(result["utc"])
+
+
+async def test_user_standing_handler_reads_permission_snapshot(monkeypatch):
+    async def fake_snapshot(guild_id, user_id):
+        assert (guild_id, user_id) == (10, 20)
+        return SimpleNamespace(level=5, is_fresh_user=False)
+
+    monkeypatch.setattr(ai_tools.ai_permission_service, "snapshot", fake_snapshot)
+    registry = build_registry(scope=AIScope.USER, guild_id=10, actor_id=20)
+
+    result = await registry.handlers["get_user_standing"]({})
+
+    assert result == {"level": 5, "is_new_user": False}

--- a/tests/unit/services/test_ai_tools.py
+++ b/tests/unit/services/test_ai_tools.py
@@ -58,3 +58,91 @@ async def test_user_standing_handler_reads_permission_snapshot(monkeypatch):
     result = await registry.handlers["get_user_standing"]({})
 
     assert result == {"level": 5, "is_new_user": False}
+
+
+def test_admin_scope_offers_all_read_only_tools():
+    registry = build_registry(scope=AIScope.ADMIN, guild_id=1, actor_id=2)
+
+    names = {spec.name for spec in registry.specs}
+    assert names == {
+        "get_user_standing",
+        "get_server_time",
+        "get_guild_ai_config",
+        "recent_audit",
+    }
+    assert set(registry.handlers) == names
+
+
+def test_user_scope_excludes_admin_tools():
+    registry = build_registry(scope=AIScope.USER, guild_id=1, actor_id=2)
+
+    names = {spec.name for spec in registry.specs}
+    assert "get_guild_ai_config" not in names
+    assert "recent_audit" not in names
+
+
+async def test_guild_ai_config_handler_reads_snapshot(monkeypatch):
+    fake = SimpleNamespace(
+        policy=SimpleNamespace(
+            enabled=True,
+            natural_language_enabled=True,
+            default_provider="openai",
+            default_model="gpt-4o-mini",
+            minimum_level_default=5,
+            cooldown_seconds=30,
+        ),
+        provider=SimpleNamespace(provider_active="openai"),
+        memory=SimpleNamespace(window_minutes=60),
+    )
+
+    async def fake_build(guild_id, **_kwargs):
+        assert guild_id == 99
+        return fake
+
+    monkeypatch.setattr(
+        ai_tools.ai_config_projection_service,
+        "build_snapshot",
+        fake_build,
+    )
+    registry = build_registry(scope=AIScope.ADMIN, guild_id=99, actor_id=1)
+
+    result = await registry.handlers["get_guild_ai_config"]({})
+
+    assert result["ai_enabled"] is True
+    assert result["provider"] == "openai"
+    assert result["model"] == "gpt-4o-mini"
+    assert result["memory_window_minutes"] == 60
+
+
+async def test_recent_audit_handler_summarises_and_clamps_limit(monkeypatch):
+    captured: dict = {}
+
+    async def fake_query(guild_id, *, limit=50, **_kwargs):
+        captured["guild_id"] = guild_id
+        captured["limit"] = limit
+        return [
+            {
+                "decision": "replied",
+                "reason_code": "none",
+                "task": "general.nl_answer",
+                "created_at": "2026-05-29T12:00:00+00:00",
+            },
+            {
+                "decision": "skipped",
+                "reason_code": "not_a_question",
+                "task": None,
+                "created_at": None,
+            },
+        ]
+
+    monkeypatch.setattr(ai_tools.ai_decision_audit_service, "query", fake_query)
+    registry = build_registry(scope=AIScope.ADMIN, guild_id=7, actor_id=1)
+
+    # A limit above the cap is clamped to 20.
+    result = await registry.handlers["recent_audit"]({"limit": 999})
+
+    assert captured["guild_id"] == 7
+    assert captured["limit"] == 20
+    assert result["rows"][0]["decision"] == "replied"
+    assert result["rows"][0]["reason"] == "none"
+    assert result["rows"][1]["task"] is None


### PR DESCRIPTION
## Summary

Adds a provider-neutral, **read-only function-calling** capability to the AI gateway so the assistant can pull live context on demand instead of relying only on a pre-stuffed payload — the main "not aware enough" gap in the current pipeline.

**Inert by default.** Nothing changes for users unless both `AI_ENABLED=1` and the new `AI_TOOLS_ENABLED=1` are set. The no-tools path is byte-for-byte unchanged.

## Design

- `AIToolSpec` + `AIRequest.tools` — pure-data, provider-neutral tool declarations (redaction-safe).
- The **gateway** owns a dispatch closure: enforces an offered-tool allowlist, **redacts tool output** before it re-enters model context, and isolates handler faults into a JSON error string (never raises).
- The **OpenAI adapter** runs a bounded (≤4-hop) model↔tool loop on `chat.completions`; the deterministic provider ignores tools.
- Tool **handlers live in `services/ai_tools.py`** (per the layering rule: `core/runtime` may not import `services`); the stage builds a scope-filtered registry and passes handlers down.
- **Scope-gated**: a tool above the caller's `AIScope` is never even offered to the model.

## Commits

1. **Foundation** — contracts, flag, gateway/provider loop, the tool service with two read-only tools (`get_user_standing`, `get_server_time`), and tests.
2. **Live wiring** — connect the registry to the natural-language stage (scope derived from the caller's Discord permissions) and add admin-scoped `get_guild_ai_config` + `recent_audit` tools.

## Tests / checks

`mypy disbot/` clean; full `pytest tests/` green (6197 passed); ruff / isort / `check_architecture --mode strict` pass. New tests cover the tool loop, hop bound, flag gating, allowlist, output redaction, fault isolation, and scope filtering.

## Mutations stay out of scope

All tools are read-only. Per `docs/ai-service-integration-map.md`, state-changing actions must continue to flow through the deterministic mutation services after explicit confirmation.

https://claude.ai/code/session_016y6vLfZYXoS4tfuchdbo7a

---
_Generated by [Claude Code](https://claude.ai/code/session_016y6vLfZYXoS4tfuchdbo7a)_