### PR TITLE
CI: manual GitHub Actions workflow to run the AI evals from mobile

### DIFF
--- a/.github/workflows/ai-evals.yml
+++ b/.github/workflows/ai-evals.yml
@@ -1,0 +1,63 @@
+name: AI Evals (manual)
+
+# Manually-triggered OpenAI-vs-Claude capability comparison.
+#
+# Requires two repository secrets (Settings -> Secrets and variables ->
+# Actions -> New repository secret):
+#   * OPENAI_API_KEY
+#   * ANTHROPIC_API_KEY
+#
+# Makes real, paid API calls — it runs ONLY when you press "Run workflow",
+# never on push or pull_request. The scorecard prints to the run log and to
+# the run Summary page. The job stays green regardless of the pass rate;
+# read the scorecard for the actual result.
+
+on:
+  workflow_dispatch:
+    inputs:
+      provider:
+        description: Provider(s) to compare
+        type: choice
+        options:
+          - both
+          - openai
+          - anthropic
+        default: both
+      threshold:
+        description: Pass-rate threshold (0-1), informational only
+        type: string
+        default: "0.8"
+
+jobs:
+  evals:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run evals
+        env:
+          RUN_EVALS: "1"
+          # The LLM-as-judge uses the default-routed provider; pin it to
+          # Claude so grading is consistent across both candidate providers.
+          AI_DEFAULT_PROVIDER: anthropic
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          PROVIDER: ${{ inputs.provider }}
+          THRESHOLD: ${{ inputs.threshold }}
+        run: |
+          {
+            echo '### AI eval scorecard'
+            echo ''
+            echo '```text'
+            python scripts/run_evals.py --provider "$PROVIDER" --threshold "$THRESHOLD" || true
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Manual AI-evals workflow (run from your phone)

Adds `.github/workflows/ai-evals.yml` — a **`workflow_dispatch`-only** job (never runs on push/PR) that executes `scripts/run_evals.py` across providers and prints the **OpenAI-vs-Claude scorecard** to both the run log and the run **Summary** page. The LLM-as-judge is pinned to Claude so grading is consistent across both candidates.

### One-time setup (mobile browser)
Add two repository secrets — **Settings → Secrets and variables → Actions → New repository secret**:
- `OPENAI_API_KEY`
- `ANTHROPIC_API_KEY`

(Encrypted; masked in logs.)

### How to run it (after merging)
> `workflow_dispatch` only shows up once the workflow is on the default branch — so **merge this first**.

GitHub app (or github.com) → **Actions → "AI Evals (manual)" → Run workflow** → pick `both` → open the run → read the scorecard on the **Summary** page. Re-runnable anytime with a tap; it makes real (cheap) API calls only when you press Run.

The job stays **green regardless of pass rate** — it's a comparison, so read the scorecard numbers, not the check mark.

### Notes
- No database or Discord token needed — `run_evals.py` sets a placeholder and the harness uses DB-free tool stubs.
- Doesn't touch the running bot.

https://claude.ai/code/session_016y6vLfZYXoS4tfuchdbo7a

---
_Generated by [Claude Code](https://claude.ai/code/session_016y6vLfZYXoS4tfuchdbo7a)_