### PR TITLE
Fix evals harness: pair forced provider with a model it serves; fail on degraded

### DIFF
--- a/disbot/core/runtime/ai/gateway.py
+++ b/disbot/core/runtime/ai/gateway.py
@@ -166,6 +166,7 @@ class AIGateway:
         *,
         provider_override: Provider | None = None,
         tool_handlers: Mapping[str, ToolHandler] | None = None,
+        model_override: str | None = None,
     ) -> AIResponse:
         """Run a request through the pipeline; never raises.
 
@@ -176,6 +177,11 @@ class AIGateway:
         redacted before they re-enter the model context, and tool faults
         are returned to the model as a JSON error string (the gateway's
         never-raise contract still holds).
+
+        ``model_override`` forces a specific model for this call,
+        independent of routing — used to pair a forced ``provider_override``
+        with a model that provider actually serves (evals, A/B, fallback
+        escalation). Defaults to the routed model.
         """
         target = resolve(request.context.task)
         if provider_override is None and request.context.guild_id is not None:
@@ -185,6 +191,7 @@ class AIGateway:
                 request.context.task,
             )
         provider_name = provider_override.name if provider_override else target.provider
+        effective_model = model_override or target.model
 
         if provider_override is None and not task_enabled(request.context.task):
             return _degraded_response(
@@ -251,12 +258,12 @@ class AIGateway:
             if dispatch is None:
                 provider_call = provider.execute(
                     redacted_request,
-                    model=target.model,
+                    model=effective_model,
                 )
             else:
                 provider_call = provider.execute(
                     redacted_request,
-                    model=target.model,
+                    model=effective_model,
                     dispatch=dispatch,
                 )
             raw_text = await asyncio.wait_for(provider_call, timeout=timeout)
@@ -388,7 +395,7 @@ class AIGateway:
         return AIResponse(
             task=request.context.task,
             provider=provider.name,
-            model=target.model,
+            model=effective_model,
             text=text,
             data=data,
             suggestions=(),

--- a/tests/evals/harness.py
+++ b/tests/evals/harness.py
@@ -37,6 +37,7 @@ from core.runtime.ai.contracts import (
 )
 from core.runtime.ai.gateway import AIGateway, get_default_gateway
 from core.runtime.ai.providers.base import Provider
+from core.runtime.ai.routing import default_model_for
 
 # Fixed fake identity for eval requests. Tools are stubbed (see _spy_handlers),
 # so no DB or real service is touched — the harness probes the *model*, not the
@@ -159,7 +160,7 @@ class Scorecard:
             cats = self._group_for(provider)
             for category, (cdone, ctotal) in sorted(cats.items()):
                 lines.append(
-                    f"    {category:<16} {cdone}/{ctotal}  ({_pct(cdone, ctotal)})"
+                    f"    {category:<16} {cdone}/{ctotal}  ({_pct(cdone, ctotal)})",
                 )
             for run in self.runs:
                 if run.provider == provider and not run.passed:
@@ -167,7 +168,7 @@ class Scorecard:
                     lines.append(f"      ✗ {run.case_id} [{mark}] {run.detail[:90]}")
         lines.append("\n" + "-" * 60)
         lines.append(
-            f"TOTAL  {self.passed}/{self.total}  ({_pct(self.passed, self.total)})"
+            f"TOTAL  {self.passed}/{self.total}  ({_pct(self.passed, self.total)})",
         )
         return "\n".join(lines)
 
@@ -243,11 +244,19 @@ async def run_case(
         max_output_tokens=case.max_output_tokens,
         tools=case.tools,
     )
+    # Force the model that the (overridden) provider actually serves, so an
+    # OpenAI run never gets a Claude model name (or vice versa).
+    model_override = (
+        default_model_for(provider_override.name, case.task)
+        if provider_override is not None
+        else None
+    )
     started = time.perf_counter()
     response = await gw.execute(
         request,
         provider_override=provider_override,
         tool_handlers=handlers,
+        model_override=model_override,
     )
     latency_ms = (time.perf_counter() - started) * 1000.0
     outcome = EvalOutcome(
@@ -255,6 +264,10 @@ async def run_case(
         tool_calls=tuple(recorder),
         latency_ms=latency_ms,
     )
+    # A degraded response is a non-answer (timeout / provider error / 404) —
+    # never credit it as a pass, regardless of what the grader would say.
+    if outcome.degraded:
+        return outcome, GradeResult(False, f"degraded: {response.fallback_reason}")
     grade = case.grader(outcome)
     if inspect.isawaitable(grade):
         grade = await grade

--- a/tests/evals/test_evals_harness.py
+++ b/tests/evals/test_evals_harness.py
@@ -157,3 +157,58 @@ def test_golden_set_is_well_formed():
     assert {"tool_use", "tool_restraint", "structured", "safety"} <= categories
     for case in CASES:
         assert case.id and case.category and callable(case.grader)
+
+
+class _ModelRecordingProvider:
+    """Fake provider that records the model string it was called with."""
+
+    def __init__(self, name):
+        self.name = name
+        self.model = None
+
+    async def execute(self, request, *, model, dispatch=None):
+        self.model = model
+        return "ok"
+
+
+class _FailingProvider:
+    name = "openai"
+
+    async def execute(self, request, *, model, dispatch=None):
+        raise RuntimeError("boom")
+
+
+async def test_run_case_forces_provider_appropriate_model(monkeypatch):
+    # Regression: forcing a provider must also force a model it serves —
+    # an OpenAI run must never be handed a Claude model name (or vice versa).
+    monkeypatch.setenv("AI_ENABLED", "1")
+    openai_p = _ModelRecordingProvider("openai")
+    anthropic_p = _ModelRecordingProvider("anthropic")
+    gateway = AIGateway(providers={"openai": openai_p, "anthropic": anthropic_p})
+    case = EvalCase(id="m", category="format", user_message="hi", grader=contains("ok"))
+
+    await run_case(case, gateway=gateway, provider_override=openai_p)
+    await run_case(case, gateway=gateway, provider_override=anthropic_p)
+
+    assert openai_p.model == "gpt-4o-mini"
+    assert anthropic_p.model.startswith("claude-")
+
+
+async def test_run_case_treats_degraded_as_failure(monkeypatch):
+    # no_tool_called() would trivially "pass" on an empty/errored response;
+    # the degraded short-circuit must override that so a non-answer fails.
+    monkeypatch.setenv("AI_ENABLED", "1")
+    provider = _FailingProvider()
+    gateway = AIGateway(providers={"openai": provider})
+    case = EvalCase(
+        id="d",
+        category="format",
+        user_message="hi",
+        grader=no_tool_called(),
+    )
+
+    outcome, grade = await run_case(case, gateway=gateway, provider_override=provider)
+
+    assert outcome.degraded is True
+    assert grade.passed is False
+    assert "degraded" in grade.detail


### PR DESCRIPTION
## Fix: the eval harness fed OpenAI a Claude model name

The scorecard's OpenAI column was bogus — every OpenAI case showed `[DEGRADED]` with `404 - The model 'claude-sonnet…'`. Root cause: the harness forced the provider via `provider_override`, but the **model** still came from routing (`AI_DEFAULT_PROVIDER=anthropic`, which the workflow pins for the judge). So the OpenAI runs were asked to use a Claude model → 404 → no answer. Claude's 13/13 was real; OpenAI's 2/13 was an artifact (and the "2 passed" were false positives where a degraded/empty response trivially satisfied `no_tool_called` / `not_contains`).

> The **live bot is unaffected** — it always pairs provider+model together from routing; the mismatch only existed in the eval harness.

### Changes
- **gateway** — additive `model_override` on `AIGateway.execute`, so a forced provider can be paired with a model it actually serves (independent of routing). Defaults to the routed model → **no behavior change** for the live bot or the `services.ai_gateway` shim.
- **evals/harness** — `run_case` now derives the model via `default_model_for(provider.name, task)` and passes it as `model_override` (OpenAI → `gpt-4o-mini`, Anthropic → Claude). A **degraded outcome short-circuits to a failing grade** so a non-answer can never "pass."
- **tests** — regression coverage: forcing a provider forces a model it serves; degraded ⇒ failure.

### After merging — re-run for a fair comparison
The workflow runs `main`, so **merge this, then re-run "AI Evals (manual)"**. You'll then get a real OpenAI-vs-Claude scorecard instead of OpenAI 404ing.

### Checks
`mypy disbot/` clean; full `pytest` green (**6228 passed, 3 skipped**); ruff / isort / arch-strict pass.

https://claude.ai/code/session_016y6vLfZYXoS4tfuchdbo7a

---
_Generated by [Claude Code](https://claude.ai/code/session_016y6vLfZYXoS4tfuchdbo7a)_