### PR TITLE
Fix runtime crashes + counting skip/random modes (found in live testing)

### DIFF
--- a/disbot/cogs/counting/game_logic.py
+++ b/disbot/cogs/counting/game_logic.py
@@ -6,6 +6,7 @@ Pure functions, no Discord or DB dependencies — testable in isolation.
 from __future__ import annotations
 
 import math
+import random
 
 
 def calculate_expected_count(
@@ -22,10 +23,13 @@ def calculate_expected_count(
     if mode == "reverse":
         return current_count - channel_data.get("step", 1)
     if mode == "skip":
-        expected = current_count + channel_data.get("step", 1)
-        while expected in channel_data.get("skip_numbers", []):
-            expected += channel_data.get("step", 1)
-        return expected
+        # "skip N": the count climbs by N each step, anchored at 1 —
+        # 1, 1+N, 1+2N, …  (e.g. ``!start_match skip 5`` → 1, 6, 11, 16).
+        # N is stored as ``step``; the first valid number is always 1.
+        step = channel_data.get("step", 1)
+        if current_count < 1:
+            return 1
+        return current_count + step
     if mode == "random":
         # Use the pre-rolled value so it doesn't change between calls.
         return channel_data.get("next_expected", current_count + 1)
@@ -60,3 +64,54 @@ def is_prime(number: int) -> bool:
     if number % 2 == 0:
         return False
     return all(number % i != 0 for i in range(3, int(number**0.5) + 1, 2))
+
+
+# ---------------------------------------------------------------------------
+# Random mode — "guess the secret number in a shrinking range"
+# ---------------------------------------------------------------------------
+# The bot rolls a secret target above the current count and announces a wide
+# window that contains it.  Each wrong guess halves the window toward the
+# target (never below a width of 10); a correct guess advances the count and
+# rolls a fresh target + window.  The target sits at a random (non-centred)
+# position inside the window so it can't be solved by always guessing the
+# midpoint.
+_RANDOM_MIN_GAP = 10  # smallest announced range width
+_RANDOM_MIN_JUMP = 10  # target is at least this far above the current count
+_RANDOM_MAX_JUMP = 60  # ...and at most this far
+_RANDOM_MIN_INIT_GAP = 30  # initial window is wide and randomly sized
+_RANDOM_MAX_INIT_GAP = 180
+
+
+def _random_window(target: int, width: int, *, floor: int) -> tuple[int, int]:
+    """A window of ``max(width, 10)`` containing *target* at a random
+    position, with the low bound never below *floor*.
+    """
+    width = max(_RANDOM_MIN_GAP, width)
+    lo_min = max(floor, target - width)
+    lo = random.randint(lo_min, target) if lo_min < target else target
+    hi = lo + width
+    if hi < target:  # safety — keep the target strictly inside the window
+        hi = target
+    return lo, hi
+
+
+def start_random_round(current_count: int) -> tuple[int, int, int]:
+    """Roll a fresh secret target above *current_count* plus its initial
+    (wide, randomly sized) window.  Returns ``(target, range_lo, range_hi)``.
+    """
+    target = current_count + random.randint(_RANDOM_MIN_JUMP, _RANDOM_MAX_JUMP)
+    width = random.randint(_RANDOM_MIN_INIT_GAP, _RANDOM_MAX_INIT_GAP)
+    lo, hi = _random_window(target, width, floor=current_count + 1)
+    return target, lo, hi
+
+
+def narrow_random_range(
+    range_lo: int,
+    range_hi: int,
+    target: int,
+) -> tuple[int, int]:
+    """Halve the announced window toward *target* after a wrong guess,
+    never below a width of 10.  Returns the new ``(range_lo, range_hi)``.
+    """
+    width = max(_RANDOM_MIN_GAP, (range_hi - range_lo) // 2)
+    return _random_window(target, width, floor=0)

--- a/disbot/cogs/counting/handler.py
+++ b/disbot/cogs/counting/handler.py
@@ -67,6 +67,10 @@ class CountingDecision:
     reply: str | None = None
     add_reaction: str | None = None
     state_mutated: bool = False
+    # Seconds before the bot's reply auto-deletes; ``None`` keeps it.
+    # Random mode's range hints must persist so players can see the
+    # current window between guesses.
+    reply_delete_after: int | None = 5
 
 
 def compute_decision(
@@ -100,6 +104,9 @@ def compute_decision(
                 f"or mathematical expression."
             ),
         )
+
+    if mode == "random":
+        return _decide_random(channel_data, parsed, user_id)
 
     expected = game_logic.calculate_expected_count(channel_data, current_count, mode)
 
@@ -184,6 +191,63 @@ def _reset_channel_data(channel_data: dict[str, Any], mode: str) -> None:
     channel_data["last_count_time"] = datetime.now(tz=timezone.utc).timestamp()
 
 
+def _decide_random(
+    channel_data: dict[str, Any],
+    parsed: int,
+    user_id: str,
+) -> CountingDecision:
+    """Decision for ``random`` mode — a guess-the-secret-number game.
+
+    A hidden ``next_expected`` target sits inside an announced
+    ``[range_lo, range_hi]`` window.  A correct guess advances the count
+    and rolls a fresh target + wide window; a wrong guess halves the
+    window toward the target (min width 10) and re-announces it with a
+    higher/lower hint.  Wrong guesses do NOT reset the count — players
+    keep narrowing until they land it, and their guesses stay in the
+    channel as part of play.
+    """
+    target = channel_data.get("next_expected")
+    lo = channel_data.get("range_lo")
+    hi = channel_data.get("range_hi")
+    if not (isinstance(target, int) and isinstance(lo, int) and isinstance(hi, int)):
+        # Legacy / missing state — (re)initialise a round so play continues.
+        target, lo, hi = game_logic.start_random_round(
+            int(channel_data.get("current_count", 0) or 0),
+        )
+        channel_data["next_expected"] = target
+        channel_data["range_lo"], channel_data["range_hi"] = lo, hi
+
+    if parsed == target:
+        channel_data["current_count"] = parsed
+        channel_data["last_user"] = user_id
+        leaderboard = channel_data.get("leaderboard", {})
+        leaderboard[user_id] = leaderboard.get(user_id, 0) + 1
+        channel_data["leaderboard"] = leaderboard
+        n_target, n_lo, n_hi = game_logic.start_random_round(parsed)
+        channel_data["next_expected"] = n_target
+        channel_data["range_lo"], channel_data["range_hi"] = n_lo, n_hi
+        return CountingDecision(
+            accepted=True,
+            add_reaction="✅",
+            state_mutated=True,
+            reply=(
+                f"✅ Correct — it was **{parsed}**! "
+                f"Next secret number is between **{n_lo}–{n_hi}**."
+            ),
+            reply_delete_after=None,
+        )
+
+    n_lo, n_hi = game_logic.narrow_random_range(lo, hi, target)
+    channel_data["range_lo"], channel_data["range_hi"] = n_lo, n_hi
+    direction = "Higher" if parsed < target else "Lower"
+    return CountingDecision(
+        accepted=False,
+        state_mutated=True,
+        reply=f"❌ Not **{parsed}**. {direction} — it's between **{n_lo}–{n_hi}**.",
+        reply_delete_after=None,
+    )
+
+
 async def apply_decision(
     decision: CountingDecision,
     message: discord.Message,
@@ -207,7 +271,10 @@ async def apply_decision(
         )
     if decision.reply:
         try:
-            await message.channel.send(decision.reply, delete_after=5)
+            await message.channel.send(
+                decision.reply,
+                delete_after=decision.reply_delete_after,
+            )
         except discord.Forbidden:
             pass
     if decision.add_reaction:

--- a/disbot/cogs/counting_cog.py
+++ b/disbot/cogs/counting_cog.py
@@ -19,13 +19,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import random
 from datetime import datetime, timezone
 
 import discord
 from discord.ext import commands
 
-from cogs.counting import handler
+from cogs.counting import game_logic, handler
 from cogs.counting._stage import COUNTING_STAGE_NAME, CountingStage
 from core.runtime import resources, scope_locks, tasks
 from core.runtime.interaction_helpers import help_ctx_shim
@@ -171,6 +170,7 @@ class CountingCog(commands.Cog):
 
         multiple = None
         custom_sequence = None
+        skip_step = 5
         if mode == "multiples":
             if not args:
                 await ctx.send(
@@ -201,6 +201,17 @@ class CountingCog(commands.Cog):
             except ValueError:
                 await ctx.send(
                     "Invalid sequence. Please provide a comma-separated list of integers.",
+                    delete_after=10,
+                )
+                return
+        elif mode == "skip" and args:
+            try:
+                skip_step = int(args[0])
+                if skip_step < 1:
+                    raise ValueError
+            except ValueError:
+                await ctx.send(
+                    "Skip step must be a positive integer, e.g. `!start_match skip 5`.",
                     delete_after=10,
                 )
                 return
@@ -268,23 +279,26 @@ class CountingCog(commands.Cog):
                 ]
                 else 1000
             )
+            rand_target = rand_lo = rand_hi = None
+            if mode == "random":
+                rand_target, rand_lo, rand_hi = game_logic.start_random_round(
+                    starting_count,
+                )
             channel_config = {
                 "current_count": starting_count,
                 "last_user": None,
                 "taking_turns": False,
                 "leaderboard": {},
                 "mode": mode,
-                "step": 1,
-                "skip_numbers": [5, 10],
-                "random_range": [1, 3],
+                "step": skip_step if mode == "skip" else 1,
                 "multiple": multiple if mode == "multiples" else None,
                 "custom_sequence": custom_sequence if mode == "custom" else None,
                 "sequence_index": 0,
                 "last_count_time": datetime.now(tz=timezone.utc).timestamp(),
                 "reset_on_wrong_count": False,
-                "next_expected": (
-                    starting_count + random.randint(1, 3) if mode == "random" else None
-                ),
+                "next_expected": rand_target,
+                "range_lo": rand_lo,
+                "range_hi": rand_hi,
             }
 
             if mode == "prime":
@@ -293,8 +307,17 @@ class CountingCog(commands.Cog):
             self.count_data[guild_id]["channels"][channel_id] = channel_config
             tasks.spawn(f"counting:save:{guild_id}", self._save_guild(guild_id))
 
+        if mode == "skip":
+            extra = (
+                f" Count up by **{skip_step}** — 1, {1 + skip_step}, "
+                f"{1 + 2 * skip_step}, …"
+            )
+        elif mode == "random":
+            extra = f" Guess the secret number — it's between **{rand_lo}–{rand_hi}**."
+        else:
+            extra = ""
         await ctx.send(
-            f"Started a **{mode.capitalize()}** counting match in {channel.mention}!",
+            f"Started a **{mode.capitalize()}** counting match in {channel.mention}!{extra}",
             delete_after=10,
         )
 
@@ -392,8 +415,9 @@ class CountingCog(commands.Cog):
             channel_data["leaderboard"] = {}
             channel_data["last_count_time"] = datetime.now(tz=timezone.utc).timestamp()
             if mode == "random":
-                rand_range = channel_data.get("random_range", [1, 3])
-                channel_data["next_expected"] = start + random.randint(*rand_range)
+                target, lo, hi = game_logic.start_random_round(start)
+                channel_data["next_expected"] = target
+                channel_data["range_lo"], channel_data["range_hi"] = lo, hi
             tasks.spawn(f"counting:save:{guild_id}", self._save_guild(guild_id))
 
         await ctx.send(
@@ -466,7 +490,18 @@ class CountingCog(commands.Cog):
             value=str(reset_on_wrong_count),
             inline=False,
         )
-        embed.add_field(name="Step", value=str(step), inline=False)
+        if mode == "Random":
+            lo = channel_data.get("range_lo")
+            hi = channel_data.get("range_hi")
+            embed.add_field(
+                name="Secret number is between",
+                value=(f"{lo}–{hi}" if lo is not None and hi is not None else "—"),
+                inline=False,
+            )
+        elif mode == "Skip":
+            embed.add_field(name="Skip step", value=str(step), inline=False)
+        else:
+            embed.add_field(name="Step", value=str(step), inline=False)
 
         await ctx.send(embed=embed)
 
@@ -510,7 +545,7 @@ class CountingCog(commands.Cog):
         *,
         numbers: str = "",
     ):
-        """Sets the skip numbers for 'skip' mode."""
+        """Set the skip step N for a 'skip' match (count climbs 1, 1+N, 1+2N, …)."""
         if not channel:
             channel = ctx.channel
 
@@ -530,24 +565,27 @@ class CountingCog(commands.Cog):
             channel_data = self.count_data[guild_id]["channels"][channel_id]
             if channel_data.get("mode") != "skip":
                 await ctx.send(
-                    "Skip numbers can only be set for 'skip' mode.",
+                    "The skip step can only be set for a 'skip' match.",
                     delete_after=10,
                 )
                 return
 
             try:
-                skip_numbers = [int(num.strip()) for num in numbers.split(",")]
-                channel_data["skip_numbers"] = skip_numbers
-                tasks.spawn(f"counting:save:{guild_id}", self._save_guild(guild_id))
-                await ctx.send(
-                    f"Skip numbers updated to: {skip_numbers}",
-                    delete_after=10,
-                )
+                step = int(numbers.strip())
+                if step < 1:
+                    raise ValueError
             except ValueError:
                 await ctx.send(
-                    "Invalid input. Please provide a comma-separated list of integers.",
+                    "Please provide a single positive integer, e.g. `!set_skip_numbers 5`.",
                     delete_after=10,
                 )
+                return
+            channel_data["step"] = step
+            tasks.spawn(f"counting:save:{guild_id}", self._save_guild(guild_id))
+            await ctx.send(
+                f"Skip step updated to **{step}** — 1, {1 + step}, {1 + 2 * step}, …",
+                delete_after=10,
+            )
 
     @commands.command(name="toggle_reset_on_wrong_count", aliases=["trwc"])
     @staff_or_owner()

--- a/disbot/cogs/diagnostic/_helpers.py
+++ b/disbot/cogs/diagnostic/_helpers.py
@@ -169,6 +169,32 @@ def build_system_info_embed() -> discord.Embed:
 # ---------------------------------------------------------------------------
 
 
+def _format_table_set(names: set[str], *, limit: int = 1024) -> str:
+    """Render a set of table names as a comma list that fits one embed
+    field.
+
+    Discord caps embed field values at 1024 chars; a raw
+    ``", ".join(...)`` of every table overflowed once the schema grew
+    past ~50 tables and made Discord reject the whole embed (the panel
+    edit then silently failed).  This trims to as many names as fit and
+    appends a ``+N more`` marker.
+    """
+    if not names:
+        return "None"
+    ordered = sorted(names)
+    joined = ", ".join(ordered)
+    if len(joined) <= limit:
+        return joined
+    kept = list(ordered)
+    while kept:
+        suffix = f", … (+{len(ordered) - len(kept)} more)"
+        candidate = ", ".join(kept)
+        if len(candidate) + len(suffix) <= limit:
+            return candidate + suffix
+        kept.pop()
+    return f"(+{len(ordered)} more)"
+
+
 async def build_check_database_embed() -> discord.Embed:
     """Verify expected PostgreSQL tables exist."""
     expected = {
@@ -208,12 +234,12 @@ async def build_check_database_embed() -> discord.Embed:
     embed = discord.Embed(title="Database Schema Check", color=discord.Color.purple())
     embed.add_field(
         name="Missing Tables",
-        value=", ".join(sorted(missing)) or "None",
+        value=_format_table_set(missing),
         inline=False,
     )
     embed.add_field(
-        name="Unexpected Tables",
-        value=", ".join(sorted(extra)) or "None",
+        name=f"Unexpected Tables ({len(extra)})",
+        value=_format_table_set(extra),
         inline=False,
     )
     if not missing:

--- a/disbot/core/runtime/interaction_helpers.py
+++ b/disbot/core/runtime/interaction_helpers.py
@@ -62,6 +62,81 @@ def help_ctx_shim(interaction: discord.Interaction) -> SimpleNamespace:
     )
 
 
+# Discord embed size limits.
+# https://discord.com/developers/docs/resources/message#embed-object-embed-limits
+_EMBED_TITLE_LIMIT = 256
+_EMBED_DESCRIPTION_LIMIT = 4096
+_EMBED_FIELD_NAME_LIMIT = 256
+_EMBED_FIELD_VALUE_LIMIT = 1024
+_EMBED_FOOTER_LIMIT = 2048
+_EMBED_AUTHOR_LIMIT = 256
+_EMBED_MAX_FIELDS = 25
+
+
+def _clip(text: str, limit: int) -> str:
+    """Truncate ``text`` to ``limit`` chars (ellipsis-terminated)."""
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def clamp_embed(embed: discord.Embed) -> discord.Embed:
+    """Truncate ``embed`` in place to Discord's hard size limits.
+
+    A single over-limit component — most commonly a field ``value``
+    over 1024 chars, but also an over-long ``description`` / title /
+    footer — makes Discord reject the *entire* message with
+    ``400 Invalid Form Body``.  Inside a panel edit that means the edit
+    never lands and the UI silently freezes (observed: the diagnostics
+    "Database" panel, whose "Unexpected Tables" field overflowed once
+    the schema grew past ~50 tables).  Clamping each component to its
+    documented maximum degrades an oversized payload to a
+    truncated-but-rendered panel instead of a hard failure.
+
+    Only mutates when a value actually exceeds its limit, so well-formed
+    embeds pass through unchanged.  Returns the same object for
+    call-site convenience.
+    """
+    if not isinstance(embed, discord.Embed):
+        # Defensive: callers should pass a discord.Embed, but never choke
+        # on a non-embed (e.g. a test double) — just hand it back.
+        return embed
+    if embed.title and len(embed.title) > _EMBED_TITLE_LIMIT:
+        embed.title = _clip(embed.title, _EMBED_TITLE_LIMIT)
+    if embed.description and len(embed.description) > _EMBED_DESCRIPTION_LIMIT:
+        embed.description = _clip(embed.description, _EMBED_DESCRIPTION_LIMIT)
+
+    for idx, field in enumerate(embed.fields):
+        name = field.name or ""
+        value = field.value or ""
+        if len(name) > _EMBED_FIELD_NAME_LIMIT or len(value) > _EMBED_FIELD_VALUE_LIMIT:
+            embed.set_field_at(
+                idx,
+                name=_clip(name, _EMBED_FIELD_NAME_LIMIT),
+                value=_clip(value, _EMBED_FIELD_VALUE_LIMIT),
+                inline=field.inline,
+            )
+
+    # Guard the field-count cap too: drop the overflow rather than let
+    # the API reject the whole embed.
+    while len(embed.fields) > _EMBED_MAX_FIELDS:
+        embed.remove_field(_EMBED_MAX_FIELDS)
+
+    footer = embed.footer
+    if footer.text and len(footer.text) > _EMBED_FOOTER_LIMIT:
+        embed.set_footer(
+            text=_clip(footer.text, _EMBED_FOOTER_LIMIT),
+            icon_url=footer.icon_url,
+        )
+
+    author = embed.author
+    if author.name and len(author.name) > _EMBED_AUTHOR_LIMIT:
+        embed.set_author(
+            name=_clip(author.name, _EMBED_AUTHOR_LIMIT),
+            url=author.url,
+            icon_url=author.icon_url,
+        )
+    return embed
+
+
 async def safe_defer(
     interaction: discord.Interaction,
     *,
@@ -122,7 +197,7 @@ async def safe_followup(
     if content is not None:
         kwargs["content"] = content
     if embed is not None:
-        kwargs["embed"] = embed
+        kwargs["embed"] = clamp_embed(embed)
     if view is not None:
         kwargs["view"] = view
     if ephemeral:
@@ -170,7 +245,7 @@ async def safe_edit(
     if content is not None:
         kwargs["content"] = content
     if embed is not None:
-        kwargs["embed"] = embed
+        kwargs["embed"] = clamp_embed(embed)
     if view is not None:
         kwargs["view"] = view
 

--- a/disbot/utils/db/moderation.py
+++ b/disbot/utils/db/moderation.py
@@ -50,7 +50,12 @@ async def log_mod_action(
 ) -> None:
     from datetime import datetime, timezone
 
-    ts = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    # ``mod_logs.timestamp`` is ``timestamp with time zone``; asyncpg
+    # needs a real ``datetime`` for that column.  Passing a strftime
+    # string raised ``asyncpg.DataError`` at insert time, which silently
+    # broke the mod-action audit log for every action type and crashed
+    # the counting stage's auto-delete path.  Bind the tz-aware datetime.
+    ts = datetime.now(tz=timezone.utc)
     await pool.execute(
         "INSERT INTO mod_logs (timestamp, guild_id, action, target_id, "
         "moderator_id, reason) VALUES ($1, $2, $3, $4, $5, $6)",

--- a/disbot/views/channels/_helpers.py
+++ b/disbot/views/channels/_helpers.py
@@ -70,19 +70,23 @@ class _ChannelSelect(discord.ui.Select):
             options=options,
             row=0,
         )
-        self._parent = parent_view
+        # NB: must NOT be ``self._parent`` — discord.py 2.7+ owns that
+        # attribute for check propagation (``item._parent._run_checks(...)``).
+        # Shadowing it with the parent view crashed every select callback
+        # with ``AttributeError: ... has no attribute '_run_checks'``.
+        self._owner_view = parent_view
 
     async def callback(self, interaction: discord.Interaction):
-        self._parent.selected_channel_id = int(self.values[0])  # type: ignore[attr-defined]
+        self._owner_view.selected_channel_id = int(self.values[0])  # type: ignore[attr-defined]
         # Resolve the display name from the options list
         chosen_opt = next((o for o in self.options if o.value == self.values[0]), None)
-        self._parent.selected_channel_name = (  # type: ignore[attr-defined]
+        self._owner_view.selected_channel_name = (  # type: ignore[attr-defined]
             chosen_opt.label if chosen_opt else self.values[0]
         )
         try:
             await interaction.response.edit_message(
-                embed=self._parent.build_embed(),  # type: ignore[attr-defined]
-                view=self._parent,  # type: ignore[attr-defined, arg-type]
+                embed=self._owner_view.build_embed(),  # type: ignore[attr-defined]
+                view=self._owner_view,  # type: ignore[attr-defined, arg-type]
             )
         except discord.HTTPException:
             await safe_defer(interaction)

--- a/disbot/views/channels/create_panel.py
+++ b/disbot/views/channels/create_panel.py
@@ -252,14 +252,19 @@ class _NameSelect(discord.ui.Select):
             options=options,
             row=0,
         )
-        self._parent = view
+        # NB: must NOT be ``self._parent``.  discord.py 2.7+ owns
+        # ``Item._parent`` for check propagation — ``View`` dispatch calls
+        # ``item._parent._run_checks(interaction)``.  Shadowing it with the
+        # parent *view* made dispatch call ``View._run_checks`` (which does
+        # not exist) and crashed every select callback with AttributeError.
+        self._owner_view = view
 
     async def callback(self, interaction: discord.Interaction):
-        self._parent.chosen_name = self.values[0]  # type: ignore[attr-defined]
+        self._owner_view.chosen_name = self.values[0]  # type: ignore[attr-defined]
         try:
             await interaction.response.edit_message(
-                embed=self._parent.build_embed(),  # type: ignore[attr-defined]
-                view=self._parent,  # type: ignore[attr-defined, arg-type]
+                embed=self._owner_view.build_embed(),  # type: ignore[attr-defined]
+                view=self._owner_view,  # type: ignore[attr-defined, arg-type]
             )
         except discord.HTTPException:
             await safe_defer(interaction)
@@ -276,14 +281,14 @@ class _CategorySelect(discord.ui.Select):
             options=options,
             row=1,
         )
-        self._parent = view
+        self._owner_view = view
 
     async def callback(self, interaction: discord.Interaction):
-        self._parent.chosen_cat = self.values[0]  # type: ignore[attr-defined]
+        self._owner_view.chosen_cat = self.values[0]  # type: ignore[attr-defined]
         try:
             await interaction.response.edit_message(
-                embed=self._parent.build_embed(),  # type: ignore[attr-defined]
-                view=self._parent,  # type: ignore[attr-defined, arg-type]
+                embed=self._owner_view.build_embed(),  # type: ignore[attr-defined]
+                view=self._owner_view,  # type: ignore[attr-defined, arg-type]
             )
         except discord.HTTPException:
             await safe_defer(interaction)

--- a/disbot/views/counting/hub_panel.py
+++ b/disbot/views/counting/hub_panel.py
@@ -8,7 +8,6 @@ preserve the existing concurrency contract.
 
 from __future__ import annotations
 
-import random
 from datetime import datetime, timezone
 
 import discord
@@ -156,8 +155,11 @@ class _CountingHubView(HubView):
             ch_data["leaderboard"] = {}
             ch_data["last_count_time"] = datetime.now(tz=timezone.utc).timestamp()
             if mode == "random":
-                rand_range = ch_data.get("random_range", [1, 3])
-                ch_data["next_expected"] = start + random.randint(*rand_range)
+                # Clear the round; the next guess rolls a fresh target +
+                # window via the handler (avoids a views->cogs import here).
+                ch_data["next_expected"] = None
+                ch_data["range_lo"] = None
+                ch_data["range_hi"] = None
             tasks.spawn(f"counting:save:{gid}", self.cog._save_guild(gid))
         await interaction.response.edit_message(
             embed=await self.build_embed(),

--- a/disbot/views/setup/final_review.py
+++ b/disbot/views/setup/final_review.py
@@ -855,6 +855,22 @@ class SetupCompleteView(BaseView):
                 ephemeral=True,
             )
             return
+
+        # ACK the interaction *before* the destructive delete below.
+        # ``cleanup_setup_channel_after_completion`` deletes the very
+        # channel this view's message lives in.  Once that channel is
+        # gone, ``response.edit_message`` 404s (message gone) AND a
+        # not-yet-acknowledged ``followup`` 404s with "Unknown Webhook"
+        # (10015) — the interaction was never ACKed, so its webhook is
+        # invalid.  Deferring ephemerally while the channel + token are
+        # still live keeps the followup webhook alive for the
+        # confirmation message.  (Regression: clicking "Delete now"
+        # crashed with NotFound 404 Unknown Webhook.)
+        from core.runtime.interaction_helpers import safe_defer
+
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+
         from services import setup_channel as _setup_channel
         from services import setup_session as _setup_session
 
@@ -862,7 +878,7 @@ class SetupCompleteView(BaseView):
             session = await _setup_session.resume_session(guild.id)
         except Exception:
             logger.exception("SetupCompleteView._on_delete: resume failed")
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 "Couldn't read the setup session — see logs.",
                 ephemeral=True,
             )
@@ -874,43 +890,30 @@ class SetupCompleteView(BaseView):
             actor=interaction.user,
         )
         if result.reason != "ok":
-            await interaction.response.send_message(
+            # Channel was NOT deleted (typed guard failure).  The original
+            # message + buttons survive; surface the reason ephemerally and
+            # leave the buttons clickable so the operator can retry.
+            await interaction.followup.send(
                 f"⚠️ {result.detail}",
                 ephemeral=True,
             )
             return
 
-        # Success — disable the buttons, flip the embed to a final
-        # "Setup channel deleted" line.  We do NOT call self.stop()
-        # before editing because discord.py won't render a stopped
-        # view; just disable the children.
+        # Success — the setup channel (and this view's message) is gone,
+        # so there is nothing left to edit.  Confirm via an ephemeral
+        # followup and stop the view.
         for child in self.children:
             child.disabled = True  # type: ignore[attr-defined]
-        new_embed = discord.Embed(
-            title="🛰 Setup complete",
-            description=(
-                "**Setup channel deleted.**  "
-                f"Applied **{len(self.summary.applied)}** operation(s); "
-                "the workspace channel is gone.  Re-run `/setup` "
-                "later to recreate it."
-            ),
-            color=discord.Color.green(),
-        )
         try:
-            await interaction.response.edit_message(
-                embed=new_embed,
-                view=self,
+            await interaction.followup.send(
+                "✅ Setup channel deleted.  "
+                f"Applied **{len(self.summary.applied)}** operation(s); "
+                "re-run `/setup` later to recreate it.",
+                ephemeral=True,
             )
         except discord.HTTPException:
-            # Editing the original message may fail because that
-            # message lived in #superbot-setup, which we just
-            # deleted.  Fall back to an ephemeral confirmation.
             logger.info(
-                "SetupCompleteView._on_delete: edit_message failed (channel gone?)",
-            )
-            await interaction.followup.send(
-                "✅ Setup channel deleted.",
-                ephemeral=True,
+                "SetupCompleteView._on_delete: confirmation followup failed",
             )
         self.stop()
 

--- a/tests/unit/cogs/test_counting_modes.py
+++ b/tests/unit/cogs/test_counting_modes.py
@@ -1,0 +1,121 @@
+"""Regression tests for counting game modes: skip and random.
+
+skip: ``skip N`` must step by N anchored at 1 (1, 1+N, 1+2N, …).
+Previously it counted +1 and merely omitted a hardcoded ``[5,10]`` list,
+so it was visually identical to normal counting.
+
+random: a guess-the-secret-number game — the bot announces a window
+containing a hidden target; a wrong guess halves the window toward the
+target (min width 10) WITHOUT resetting the count; a correct guess
+advances the count and rolls a fresh target + window.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from cogs.counting import game_logic
+from cogs.counting.handler import compute_decision
+
+
+def _msg(content: str):
+    return SimpleNamespace(
+        content=content,
+        author=SimpleNamespace(id=1, mention="<@1>", bot=False),
+    )
+
+
+def _state(mode: str, **over) -> dict:
+    base = {
+        "mode": mode,
+        "current_count": 0,
+        "last_user": None,
+        "taking_turns": False,
+        "reset_on_wrong_count": False,
+        "leaderboard": {},
+        "sequence_index": 0,
+        "step": 1,
+    }
+    base.update(over)
+    return base
+
+
+# --- skip -------------------------------------------------------------------
+
+
+def test_skip_steps_by_n_from_one():
+    cd = _state("skip", step=5)
+    seq = []
+    for _ in range(5):
+        nxt = game_logic.calculate_expected_count(cd, cd["current_count"], "skip")
+        cd["current_count"] = nxt  # simulate accepting nxt
+        seq.append(nxt)
+    assert seq == [1, 6, 11, 16, 21]
+
+
+def test_skip_rejects_off_step_number():
+    cd = _state("skip", step=5, current_count=1)
+    d = compute_decision(message=_msg("2"), channel_data=cd, user_id="1")
+    assert d.accepted is False
+    assert "6" in (d.reply or "")
+
+
+def test_skip_accepts_on_step_number():
+    cd = _state("skip", step=5, current_count=1)
+    d = compute_decision(message=_msg("6"), channel_data=cd, user_id="1")
+    assert d.accepted is True
+    assert cd["current_count"] == 6
+
+
+# --- random -----------------------------------------------------------------
+
+
+def test_start_random_round_target_inside_window_above_count():
+    for _ in range(50):
+        target, lo, hi = game_logic.start_random_round(7)
+        assert lo <= target <= hi
+        assert target > 7
+        assert lo > 7  # the whole window sits above the current count
+        assert hi - lo >= 10
+
+
+def test_narrow_random_range_halves_keeps_target_floors_at_10():
+    lo, hi = 0, 200
+    target = 123
+    prev = hi - lo
+    for _ in range(12):
+        lo, hi = game_logic.narrow_random_range(lo, hi, target)
+        assert lo <= target <= hi  # target stays inside
+        assert hi - lo >= 10  # never below width 10
+        assert hi - lo <= prev  # never widens
+        prev = hi - lo
+    assert hi - lo == 10  # converges to the floor
+
+
+def test_random_correct_guess_advances_and_rerolls():
+    cd = _state("random", next_expected=42, range_lo=30, range_hi=60)
+    d = compute_decision(message=_msg("42"), channel_data=cd, user_id="1")
+    assert d.accepted is True
+    assert cd["current_count"] == 42
+    assert cd["next_expected"] > 42  # fresh target above the new count
+    assert cd["range_lo"] <= cd["next_expected"] <= cd["range_hi"]
+    assert cd["leaderboard"]["1"] == 1
+
+
+def test_random_wrong_guess_narrows_without_reset():
+    cd = _state("random", current_count=0, next_expected=42, range_lo=30, range_hi=60)
+    d = compute_decision(message=_msg("31"), channel_data=cd, user_id="1")
+    assert d.accepted is False
+    assert d.delete_message is False  # guesses are part of play, not deleted
+    assert cd["current_count"] == 0  # a wrong guess does NOT reset
+    assert cd["range_lo"] <= 42 <= cd["range_hi"]
+    assert (cd["range_hi"] - cd["range_lo"]) <= 30  # window narrowed
+
+
+def test_random_reinitialises_when_state_missing():
+    cd = _state("random", next_expected=None, range_lo=None, range_hi=None)
+    compute_decision(message=_msg("5"), channel_data=cd, user_id="1")
+    assert isinstance(cd["next_expected"], int)
+    assert isinstance(cd["range_lo"], int)
+    assert isinstance(cd["range_hi"], int)
+    assert cd["range_lo"] <= cd["next_expected"] <= cd["range_hi"]

--- a/tests/unit/db/test_moderation_db.py
+++ b/tests/unit/db/test_moderation_db.py
@@ -1,0 +1,38 @@
+"""Regression test for ``utils.db.moderation.log_mod_action``.
+
+``mod_logs.timestamp`` is ``timestamp with time zone``; asyncpg requires
+a real ``datetime`` instance for that column.  A previous revision bound
+``datetime.now(...).strftime("%Y-%m-%d %H:%M:%S")`` — a *string* — which
+raised ``asyncpg.DataError`` at insert time and silently broke the audit
+log for every moderation action (warn / timeout / kick / ban / unban /
+clear_warnings) and crashed the counting stage's auto-delete path.
+
+This pins the contract: ``log_mod_action`` must bind a tz-aware
+``datetime``, not a formatted string.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+
+from utils.db import moderation
+
+
+@pytest.mark.asyncio
+async def test_log_mod_action_binds_datetime_not_string(monkeypatch):
+    captured: dict = {}
+
+    async def fake_execute(sql, params):
+        captured["sql"] = sql
+        captured["params"] = params
+
+    monkeypatch.setattr(moderation.pool, "execute", fake_execute)
+
+    await moderation.log_mod_action(1, "ban", 2, 3, "spam")
+
+    ts = captured["params"][0]
+    assert isinstance(ts, dt.datetime), f"timestamp must be datetime, got {type(ts)!r}"
+    assert ts.tzinfo is not None, "timestamp must be tz-aware for a timestamptz column"
+    assert "INSERT INTO mod_logs" in captured["sql"]

--- a/tests/unit/runtime/test_interaction_helpers.py
+++ b/tests/unit/runtime/test_interaction_helpers.py
@@ -34,7 +34,9 @@ def _make_interaction(*, responded: bool = False) -> MagicMock:
     interaction.followup = MagicMock()
     interaction.followup.send = AsyncMock(return_value=MagicMock(spec=discord.Message))
     interaction.followup.edit_message = AsyncMock()
-    interaction.original_response = AsyncMock(return_value=MagicMock(spec=discord.Message))
+    interaction.original_response = AsyncMock(
+        return_value=MagicMock(spec=discord.Message)
+    )
     interaction.message = MagicMock()
     interaction.message.id = 99999
     return interaction
@@ -130,3 +132,69 @@ class TestSafeEdit:
         i.response.edit_message.side_effect = discord.NotFound(MagicMock(), "gone")
         ok = await ih.safe_edit(i, content="updated")
         assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_clamps_oversized_embed_before_edit(self):
+        # Regression: a field value > 1024 chars made Discord reject the
+        # whole edit (400 Invalid Form Body) and the panel silently
+        # froze.  safe_edit must clamp before sending.
+        i = _make_interaction(responded=False)
+        embed = discord.Embed(title="x")
+        embed.add_field(name="big", value="A" * 2000, inline=False)
+        ok = await ih.safe_edit(i, embed=embed)
+        assert ok is True
+        sent = i.response.edit_message.await_args.kwargs["embed"]
+        assert len(sent.fields[0].value) == 1024
+
+
+class TestClampEmbed:
+    """Regression tests for clamp_embed (embed size-limit hardening)."""
+
+    def test_wellformed_embed_passes_through_unchanged(self):
+        embed = discord.Embed(title="t", description="d")
+        embed.add_field(name="n", value="v", inline=False)
+        ih.clamp_embed(embed)
+        assert embed.title == "t"
+        assert embed.description == "d"
+        assert embed.fields[0].name == "n"
+        assert embed.fields[0].value == "v"
+
+    def test_field_value_truncated_to_1024(self):
+        embed = discord.Embed()
+        embed.add_field(name="big", value="A" * 5000, inline=False)
+        ih.clamp_embed(embed)
+        assert len(embed.fields[0].value) == 1024
+        assert embed.fields[0].value.endswith("…")
+
+    def test_field_inline_preserved_on_truncation(self):
+        embed = discord.Embed()
+        embed.add_field(name="big", value="A" * 5000, inline=True)
+        ih.clamp_embed(embed)
+        assert embed.fields[0].inline is True
+
+    def test_description_truncated_to_4096(self):
+        embed = discord.Embed(description="D" * 9000)
+        ih.clamp_embed(embed)
+        assert len(embed.description) == 4096
+
+    def test_title_truncated_to_256(self):
+        embed = discord.Embed(title="T" * 400)
+        ih.clamp_embed(embed)
+        assert len(embed.title) == 256
+
+    def test_footer_truncated_to_2048(self):
+        embed = discord.Embed()
+        embed.set_footer(text="F" * 4000)
+        ih.clamp_embed(embed)
+        assert len(embed.footer.text) == 2048
+
+    def test_excess_fields_dropped_to_25(self):
+        embed = discord.Embed()
+        for idx in range(30):
+            embed.add_field(name=f"f{idx}", value=str(idx))
+        ih.clamp_embed(embed)
+        assert len(embed.fields) == 25
+
+    def test_returns_same_embed_instance(self):
+        embed = discord.Embed(title="ok")
+        assert ih.clamp_embed(embed) is embed

--- a/tests/unit/views/setup/sections/test_final_review_draft.py
+++ b/tests/unit/views/setup/sections/test_final_review_draft.py
@@ -970,8 +970,9 @@ def test_setup_complete_view_has_delete_and_keep_buttons():
 
 @pytest.mark.asyncio
 async def test_setup_complete_delete_calls_cleanup_service():
-    """Pressing Delete invokes the guarded cleanup service and edits the
-    embed to the post-deletion state on success.
+    """Pressing Delete ACKs the interaction (defer) before the
+    destructive delete, invokes the guarded cleanup service, and
+    confirms via an ephemeral followup on success.
     """
     from services.setup_channel import CleanupResult
     from views.setup.final_review import ApplySummary, SetupCompleteView
@@ -1017,11 +1018,15 @@ async def test_setup_complete_delete_calls_cleanup_service():
         await delete_btn.callback(interaction)
 
     cleanup_mock.assert_awaited_once()
-    # Embed flipped to the post-deletion success state.
-    edit_kwargs = interaction.response.edit_message.await_args.kwargs
-    new_embed = edit_kwargs.get("embed")
-    assert new_embed is not None
-    assert "deleted" in (new_embed.description or "").lower()
+    # The interaction is ACKed (deferred) before the destructive delete,
+    # then confirmed via an ephemeral followup.  The setup channel (and
+    # this view's message) is gone, so response.edit_message must NOT be
+    # used — that path 404'd with "Unknown Webhook".
+    interaction.response.defer.assert_awaited_once()
+    interaction.response.edit_message.assert_not_awaited()
+    interaction.followup.send.assert_awaited_once()
+    confirm = interaction.followup.send.await_args.args[0]
+    assert "deleted" in confirm.lower()
 
 
 @pytest.mark.asyncio
@@ -1065,8 +1070,10 @@ async def test_setup_complete_delete_surfaces_guard_failure_as_ephemeral():
         )
         await delete_btn.callback(interaction)
 
-    interaction.response.send_message.assert_awaited_once()
-    msg = interaction.response.send_message.await_args.args[0]
+    # Guard failure is surfaced via an ephemeral followup (the
+    # interaction was deferred first); buttons stay clickable for retry.
+    interaction.followup.send.assert_awaited_once()
+    msg = interaction.followup.send.await_args.args[0]
     assert "renamed" in msg.lower()
 
 

--- a/tests/unit/views/setup/test_setup_complete_delete_defer.py
+++ b/tests/unit/views/setup/test_setup_complete_delete_defer.py
@@ -1,0 +1,84 @@
+"""Regression test for ``SetupCompleteView._on_delete`` (final_review).
+
+Pre-fix, ``_on_delete`` deleted the setup channel (where the view's
+message lives) *before* acknowledging the interaction, then tried
+``response.edit_message`` (message gone) with a ``followup`` fallback.
+Because the interaction was never ACKed, the followup 404'd with
+"Unknown Webhook" (10015) and the click crashed.
+
+The fix defers the interaction (ACK) BEFORE the destructive delete, then
+replies via ``followup``.  These pin: defer happens before cleanup, and
+the success reply uses ``followup.send`` (never ``response.*``, since the
+message's channel is gone).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from views.setup import final_review
+from views.setup.final_review import ApplySummary, SetupCompleteView
+
+
+def _interaction() -> MagicMock:
+    i = MagicMock()
+    i.user = MagicMock(spec=discord.Member)
+    i.user.id = 1
+    i.guild = MagicMock()
+    i.guild.id = 99
+    i.response = MagicMock()
+    i.response.is_done = MagicMock(return_value=False)
+    i.response.defer = AsyncMock()
+    i.response.send_message = AsyncMock()
+    i.response.edit_message = AsyncMock()
+    i.followup = MagicMock()
+    i.followup.send = AsyncMock()
+    return i
+
+
+@pytest.mark.asyncio
+async def test_delete_defers_before_destructive_delete(monkeypatch):
+    order: list[str] = []
+
+    async def fake_gate(_interaction):
+        return True
+
+    async def fake_defer(interaction, **_kw):
+        order.append("defer")
+        interaction.response.is_done = MagicMock(return_value=True)
+        return True
+
+    async def fake_resume(_gid):
+        return SimpleNamespace()
+
+    async def fake_cleanup(_guild, _session, *, actor):
+        order.append("cleanup")
+        return SimpleNamespace(reason="ok", detail="")
+
+    monkeypatch.setattr(final_review, "_gate_apply", fake_gate)
+    monkeypatch.setattr("core.runtime.interaction_helpers.safe_defer", fake_defer)
+    monkeypatch.setattr("services.setup_session.resume_session", fake_resume)
+    monkeypatch.setattr(
+        "services.setup_channel.cleanup_setup_channel_after_completion",
+        fake_cleanup,
+    )
+
+    view = SetupCompleteView(
+        MagicMock(spec=discord.Member),
+        summary=ApplySummary(applied=["x"]),
+    )
+    interaction = _interaction()
+
+    await view._on_delete(interaction)
+
+    # The ACK (defer) MUST precede the channel delete.
+    assert order == ["defer", "cleanup"]
+    # Success confirmation goes via followup (the message's channel is
+    # gone); response.* must not be used on the success path.
+    interaction.followup.send.assert_awaited_once()
+    interaction.response.send_message.assert_not_awaited()
+    interaction.response.edit_message.assert_not_awaited()

--- a/tests/unit/views/test_channel_select_owner_view.py
+++ b/tests/unit/views/test_channel_select_owner_view.py
@@ -1,0 +1,56 @@
+"""Regression test for the channel-panel select widgets.
+
+discord.py 2.7+ owns ``Item._parent`` for check propagation — ``View``
+dispatch calls ``item._parent._run_checks(interaction)``.  The channel
+Create / Delete / Restrict select widgets used to store their parent
+*view* in ``self._parent``, shadowing the library attribute; dispatch
+then called ``View._run_checks`` (which does not exist) and every select
+callback crashed with ``AttributeError: ... has no attribute
+'_run_checks'``.  The fix renames the back-reference to ``_owner_view``.
+
+These pin that the back-reference no longer collides with discord.py's
+internal ``_parent``.
+"""
+
+from __future__ import annotations
+
+import discord
+
+from views.channels._helpers import _ChannelSelect
+from views.channels.create_panel import _CategorySelect, _NameSelect
+
+
+class _FakeOwner:
+    chosen_name = None
+    chosen_cat = None
+    selected_channel_id = None
+    selected_channel_name = None
+
+    def build_embed(self) -> discord.Embed:
+        return discord.Embed()
+
+
+def _opt(label: str = "general", value: str = "1") -> discord.SelectOption:
+    return discord.SelectOption(label=label, value=value)
+
+
+def test_channel_select_uses_owner_view_not_parent():
+    owner = _FakeOwner()
+    sel = _ChannelSelect([_opt()], owner, placeholder="pick")
+    assert sel._owner_view is owner
+    # discord.py's own _parent must NOT be shadowed by the parent view.
+    assert getattr(sel, "_parent", None) is not owner
+
+
+def test_name_select_uses_owner_view_not_parent():
+    owner = _FakeOwner()
+    sel = _NameSelect(["alpha", "beta"], owner)
+    assert sel._owner_view is owner
+    assert getattr(sel, "_parent", None) is not owner
+
+
+def test_category_select_uses_owner_view_not_parent():
+    owner = _FakeOwner()
+    sel = _CategorySelect([_opt(label="Gaming", value="Gaming")], owner)
+    assert sel._owner_view is owner
+    assert getattr(sel, "_parent", None) is not owner


### PR DESCRIPTION
## Summary

Bugs surfaced by booting the bot from this environment and watching `bot.log` while exercising commands and buttons. Two groups: **4 runtime crashes** and **2 counting-mode logic bugs**. Each is root-caused with a regression test.

---

## Group A — runtime crashes

### 1. Moderation audit + counting auto-delete crashed — `asyncpg.DataError`
`utils/db/moderation.log_mod_action` bound a `strftime` **string** to `mod_logs.timestamp` (`timestamp with time zone`); asyncpg requires a real `datetime`. Broke the audit row for **every** moderation action (`warn`/`timeout`/`kick`/`ban`/`unban`/`clearwarnings`) and crashed the **counting** stage's auto-delete path. **Fix:** bind the tz-aware `datetime` (verified live against the DB).

### 2. Channel Create/Delete/Restrict selects crashed — `AttributeError: ... '_run_checks'`
discord.py resolved to **2.7.1** (unpinned `>=2.3.0`). 2.7 added `Item._run_checks()` dispatched via `self._parent._run_checks(...)`; the select widgets stored their parent **view** in `self._parent`, shadowing discord.py's internal attribute. **Fix:** rename the back-reference to `_owner_view` in `views/channels/create_panel.py` + `_helpers.py`.

### 3. Setup "Delete now" crashed — `404 (10015) Unknown Webhook`
`SetupCompleteView._on_delete` deleted the setup channel (containing the interaction's message) **before** ACK-ing the interaction. **Fix:** defer first, then delete, then `followup`.

### 4. Panel edits silently failed on embed field > 1024 chars — `400 Invalid Form Body`
Diagnostics **Database** panel: "Unexpected Tables" joined every table not in a hardcoded 16-table set (>1024 chars at 66 tables). **Fix (general):** `clamp_embed()` in `safe_edit`/`safe_followup` so over-limit embeds degrade to truncated-but-rendered; **(targeted):** trim the offending field with `+N more`.

---

## Group B — counting game modes

### 5. `skip` mode never skipped; `random` mode looked like 1,2,3
Reported in testing: `skip 5` counted 1,2,3 (not 1,6,11) and `random` followed normal steps.

- **skip** was implemented as "+1 each, omit a hardcoded `[5,10]` list" — visually identical to normal counting until you reached 5. Now **`skip N` steps by N anchored at 1** (1, 1+N, 1+2N, …); N is set at start (`!start_match skip 5`) and adjustable via `!set_skip_numbers <N>`.
- **random** was a hidden `+1..+3` step (≈⅓ of steps were +1, so short runs looked normal). Now it's a **guess-the-secret-number game**: the bot announces a window containing a hidden target; each wrong guess **halves the window toward the target** (min width 10) with a higher/lower hint and **without resetting** the count; a correct guess advances and rolls a fresh wide window.

> Note: Group A's bug #1 was also masking these — a wrong count crashed in `log_mod_action` before the "next number should be X" feedback could send. #1's fix restores that signal, which is what makes the modes discoverable.

---

## Tests
- New: `test_moderation_db.py`, `test_channel_select_owner_view.py`, `test_setup_complete_delete_defer.py`, `test_counting_modes.py`, plus `TestClampEmbed` + a `safe_edit` clamp case in `test_interaction_helpers.py`.
- Updated the two existing `SetupCompleteView._on_delete` tests to the corrected defer→followup contract.
- **Full suite: 6281 passed, 3 skipped.** `black`/`isort`/`ruff`/`mypy` clean on `disbot/` (CI's exact commands + versions); architecture check clean.

## Notes
- The unpinned `discord.py>=2.3.0` is what let 2.7's `_parent` change land silently — worth pinning in a follow-up.
- `/chop` slash command is out of sync with its prefix command (separate, not addressed here).

https://claude.ai/code/session_01Cy2fv1rgD6a57uoAyorAk2