### PR TITLE
Fix XP reward roles stripped on boot + let superlative tool list all

### DIFF
--- a/disbot/cogs/role_cog.py
+++ b/disbot/cogs/role_cog.py
@@ -262,6 +262,12 @@ class RoleCog(commands.Cog):
                 days_required=row["days_required"],
             )
             for row in thresholds
+            # XP reward roles (xp_auto_assign) are granted by the XP listener
+            # at a level threshold — they are NOT time-based. Excluding them
+            # stops the time-based reconciliation from stripping a level-earned
+            # role from members who haven't met a days_required threshold (the
+            # "lost testrole on restart" regression).
+            if not row.get("xp_auto_assign") and row.get("days_required") is not None
         )
 
         assignments = role_automation.compute_assignments(
@@ -558,6 +564,12 @@ class RoleCog(commands.Cog):
                 days_required=row["days_required"],
             )
             for row in thresholds
+            # XP reward roles (xp_auto_assign) are granted by the XP listener
+            # at a level threshold — they are NOT time-based. Excluding them
+            # stops the time-based reconciliation from stripping a level-earned
+            # role from members who haven't met a days_required threshold (the
+            # "lost testrole on restart" regression).
+            if not row.get("xp_auto_assign") and row.get("days_required") is not None
         )
         plan = role_automation.explain_assignment_for(
             member.guild,

--- a/disbot/services/ai_tools.py
+++ b/disbot/services/ai_tools.py
@@ -328,6 +328,13 @@ _BTD6_SUPERLATIVE_SPEC = AIToolSpec(
                 "type": "boolean",
                 "description": "Least expensive when true (default false).",
             },
+            "limit": {
+                "type": "integer",
+                "description": (
+                    "How many to return (default 3). Use a large value to "
+                    "list them all, e.g. every paragon (max 25)."
+                ),
+            },
         },
         "required": ["metric"],
         "additionalProperties": False,
@@ -351,7 +358,8 @@ async def _btd6_superlative_lookup(arguments: dict[str, Any]) -> dict[str, Any]:
     except (TypeError, ValueError):
         tier = None
     cheapest = bool(arguments.get("cheapest", False))
-    hits = sup.rank(metric, tier=tier, cheapest=cheapest)
+    limit = _coerce_limit(arguments.get("limit"), default=3, lo=1, hi=25)
+    hits = sup.rank(metric, tier=tier, cheapest=cheapest, limit=limit)
     return {
         "found": bool(hits),
         "metric": metric,

--- a/tests/unit/cogs/test_role_cog_routing.py
+++ b/tests/unit/cogs/test_role_cog_routing.py
@@ -37,7 +37,9 @@ async def test_assign_roles_delegates_to_role_automation():
     guild.members = []
 
     fake_apply_result = role_automation.ApplyResult(
-        attempted=2, succeeded=2, failed=0,
+        attempted=2,
+        succeeded=2,
+        failed=0,
     )
 
     with (
@@ -76,6 +78,65 @@ async def test_assign_roles_delegates_to_role_automation():
     # The cog must pass a tuple of RoleThreshold objects, not raw rows.
     threshold_arg = compute_mock.call_args.args[1]
     assert all(isinstance(t, role_automation.RoleThreshold) for t in threshold_arg)
+
+
+@pytest.mark.asyncio
+async def test_assign_roles_excludes_xp_auto_assign_roles():
+    """XP reward roles must NOT be reconciled by the time-based loop.
+
+    Regression: ``role_thresholds`` holds both time-based and XP roles. The
+    time-based ``role_check`` runs on boot; if an ``xp_auto_assign`` role is
+    fed into it, members who hold the level-earned role but don't meet a
+    ``days_required`` threshold get it stripped (the "lost testrole on
+    restart" bug). The XP role must be filtered out before compute_assignments.
+    """
+    bot = MagicMock()
+    cog = RoleCog(bot)
+    guild = MagicMock(id=1)
+    guild.members = []
+
+    with (
+        patch("cogs.role_cog._ensure_defaults", new_callable=AsyncMock),
+        patch(
+            "cogs.role_cog.db.get_role_thresholds",
+            new_callable=AsyncMock,
+            return_value=[
+                {
+                    "role_name": "Veteran",
+                    "days_required": 30,
+                    "level_required": None,
+                    "xp_auto_assign": False,
+                },
+                {
+                    "role_name": "testrole",
+                    "days_required": 0,
+                    "level_required": 6,
+                    "xp_auto_assign": True,
+                },
+            ],
+        ),
+        patch(
+            "cogs.role_cog.db.get_setting",
+            new_callable=AsyncMock,
+            return_value="Admin",
+        ),
+        patch(
+            "cogs.role_cog.role_automation.compute_assignments",
+            return_value=(),
+        ) as compute_mock,
+        patch(
+            "cogs.role_cog.role_automation.apply",
+            new_callable=AsyncMock,
+            return_value=role_automation.ApplyResult(
+                attempted=0, succeeded=0, failed=0
+            ),
+        ),
+    ):
+        await cog._assign_roles(guild)
+
+    names = {t.role_name for t in compute_mock.call_args.args[1]}
+    assert "Veteran" in names  # time-based role still reconciled
+    assert "testrole" not in names  # XP reward role excluded from time-based loop
 
 
 @pytest.mark.asyncio
@@ -210,18 +271,12 @@ def test_role_cog_threshold_paths_do_not_call_member_role_apis_directly():
         _extract_method(src, "on_member_join"),
     ]
     for body in threshold_methods:
-        assert body is not None, (
-            "Expected to find the threshold method in role_cog.py"
-        )
-        assert (
-            "member.add_roles" not in body
-        ), (
+        assert body is not None, "Expected to find the threshold method in role_cog.py"
+        assert "member.add_roles" not in body, (
             "Threshold path must not call member.add_roles directly — "
             "route through services.role_automation.apply (PR-G)."
         )
-        assert (
-            "member.remove_roles" not in body
-        ), (
+        assert "member.remove_roles" not in body, (
             "Threshold path must not call member.remove_roles directly — "
             "route through services.role_automation.apply (PR-G)."
         )

--- a/tests/unit/services/test_ai_tools.py
+++ b/tests/unit/services/test_ai_tools.py
@@ -129,6 +129,19 @@ async def test_btd6_superlative_lookup_answers_cost_rankings():
     )
     assert cheapest["results"][0]["tower_id"] == "dart_monkey"
 
+    # limit lets the model list them all (incl. the Dart Monkey paragon).
+    default_n = await registry.handlers["btd6_superlative_lookup"](
+        {"metric": "paragon_cost", "cheapest": True},
+    )
+    assert len(default_n["results"]) == 3  # default top-3
+    full = await registry.handlers["btd6_superlative_lookup"](
+        {"metric": "paragon_cost", "cheapest": True, "limit": 25},
+    )
+    assert len(full["results"]) > 3
+    assert any(
+        r["tower_id"] == "dart_monkey" and r["cost"] == 150000 for r in full["results"]
+    )
+
     bad = await registry.handlers["btd6_superlative_lookup"]({"metric": "nope"})
     assert bad["found"] is False
 


### PR DESCRIPTION
## 1. Fix: XP reward roles stripped on boot (the "lost testrole" bug)

**Symptom:** after a restart, members lost the level-6 auto-role ("testrole").

**Root cause (verified in code, not from any recent merge):** `role_thresholds` is one table holding **both** time-based roles (`days_required`) **and** XP reward roles (`xp_auto_assign` + `level_required`) — migration 003 added the XP columns to it. `RoleCog.role_check` is a `@tasks.loop` whose `before_loop` does `wait_until_ready()`, so its **first tick fires on every boot**. `_assign_roles` fed **all** rows — including `xp_auto_assign` ones — into the **time-based** `compute_assignments`, which removes any progression role the member doesn't currently qualify for *by days*. A member who earned the XP role at level 6 but doesn't meet a `days_required` threshold hits the *"no longer earns any progression role → remove"* branch, so it's stripped on restart. `on_member_join` had the same flaw.

**Fix:** exclude `xp_auto_assign` rows (and rows with no `days_required`) from the time-based reconciliation in both paths. XP reward roles are managed solely by the XP listener (add-only); the time-based loop now leaves them alone. Regression test asserts a mixed config keeps the time-based role and drops the XP role from `compute_assignments`.

**Recovery:** this stops *future* stripping. The two members already stripped need testrole **re-added manually** — the XP listener only grants on level-*up*, so it won't auto-return at their current level.

## 2. `btd6_superlative_lookup` can list all (limit param)
The tool returned a fixed top-3, so "list all paragons" only showed 3. Added a `limit` param (default 3, capped 25) so the model can return the full set — e.g. all 13 paragons including the Dart Monkey Paragon (Apex Plasma Master, $150k, which *is* in our data — it was always correct).

## Tests
Full suite **6303 passed**, arch 0 errors, lint clean. Added: the XP-role-exclusion regression test, and a superlative `limit` assertion (full paragon list incl. Dart $150k).

https://claude.ai/code/session_016y6vLfZYXoS4tfuchdbo7a

---
_Generated by [Claude Code](https://claude.ai/code/session_016y6vLfZYXoS4tfuchdbo7a)_