### PR TITLE
Move classify_channel_name to utils/ (fix services→views breach)

### DIFF
--- a/architecture_rules/layers.yaml
+++ b/architecture_rules/layers.yaml
@@ -63,24 +63,6 @@ layers:
 
 # Known module-level violations tracked for follow-up, reported as WARN.
 known_violations:
-  # services → views (the core rule being enforced)
-  - file: services/cleanup_profiles.py
-    import: views.setup.scan_panel
-    reason: >
-      classify_channel_name() lives in views but is needed by this service.
-      Fix: move the function to services/ or utils/.
-    ticket: arch-fix-1
-
-  - file: services/cog_routing_profiles.py
-    import: views.setup.scan_panel
-    reason: Same — classify_channel_name() misplaced in views layer.
-    ticket: arch-fix-1
-
-  - file: services/channel_recommender.py
-    import: views.setup.scan_panel
-    reason: Same — classify_channel_name() misplaced in views layer.
-    ticket: arch-fix-1
-
   # services → cogs
   - file: services/automation_executor.py
     import: cogs.diagnostic._platform_embeds

--- a/disbot/services/channel_recommender.py
+++ b/disbot/services/channel_recommender.py
@@ -15,7 +15,7 @@ these to:
 The scorer is intentionally simple and deterministic:
 
 * +50 if the channel's name matches a classifier tag the intent
-  cares about (uses :func:`views.setup.scan_panel.classify_channel_name`
+  cares about (uses :func:`utils.channel_classify.classify_channel_name`
   so improvements there flow into recommendations).
 * +20 if the bot has view + send + embed permission.
 * +10 if the bot can view but not send (still helpful for log-only
@@ -33,7 +33,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 from services.guild_snapshot import ChannelMeta, GuildSnapshot
-from views.setup.scan_panel import classify_channel_name
+from utils.channel_classify import classify_channel_name
 
 Confidence = Literal["high", "medium", "low"]
 Action = Literal["bind", "create"]

--- a/disbot/services/cleanup_profiles.py
+++ b/disbot/services/cleanup_profiles.py
@@ -19,10 +19,11 @@ channel set → same op order. They never call Discord write APIs
 themselves; ops are staged through
 :func:`services.setup_draft.append` by the caller.
 
-Channel detection re-uses :func:`views.setup.scan_panel.classify_channel_name`
-which is already the canonical name-heuristic surface for the
-wizard. Adding new patterns there is the right place to broaden
-detection — profiles inherit the improvement automatically.
+Channel detection re-uses :func:`utils.channel_classify.classify_channel_name`
+which is the canonical name-heuristic surface shared by the setup
+wizard, cleanup profiles, and channel recommendations. Adding new
+patterns there is the right place to broaden detection — profiles
+inherit the improvement automatically.
 """
 
 from __future__ import annotations
@@ -34,7 +35,7 @@ import discord
 
 from services.cleanup_levels import known_level_names
 from services.setup_operations import SetupOperation
-from views.setup.scan_panel import classify_channel_name
+from utils.channel_classify import classify_channel_name
 
 ProfileBuilder = Callable[[discord.Guild], list[SetupOperation]]
 

--- a/disbot/services/cog_routing_profiles.py
+++ b/disbot/services/cog_routing_profiles.py
@@ -13,7 +13,7 @@ existing dispatcher routes each through
 ``services.command_routing.set_policy`` at Final Review time.
 
 Channel detection re-uses
-:func:`views.setup.scan_panel.classify_channel_name` — the same
+:func:`utils.channel_classify.classify_channel_name` — the same
 heuristic that powers cleanup profiles and channel recommendations.
 """
 
@@ -25,7 +25,7 @@ from dataclasses import dataclass
 import discord
 
 from services.setup_operations import SetupOperation
-from views.setup.scan_panel import classify_channel_name
+from utils.channel_classify import classify_channel_name
 
 ProfileBuilder = Callable[[discord.Guild], list[SetupOperation]]
 

--- a/disbot/utils/channel_classify.py
+++ b/disbot/utils/channel_classify.py
@@ -1,0 +1,111 @@
+"""Channel-name classifier — pure text heuristics, no I/O.
+
+Given a Discord channel name, :func:`classify_channel_name` returns the
+opinionated "this looks like a …" tags that match it (log / mod-log /
+bot-command / admin / game / welcome / …).  The result is a *suggestion*
+only — it never reads or writes anything.
+
+This lives in ``utils/`` because it is needed by both ``views/`` (the
+setup wizard's server-scan panel renders the tags) and ``services/``
+(channel recommendation, cleanup profiling, and cog-routing all score
+channels by these tags).  A function needed by both layers belongs in
+``utils/`` — keeping it in ``views/`` forced three services to import
+``views.setup.scan_panel`` (the zero-tolerance ``services/ → views/``
+boundary breach tracked as arch-fix-1).
+
+Tests pin the patterns directly against this module so the name
+heuristics stay stable independent of any UI surface.
+"""
+
+from __future__ import annotations
+
+import re
+
+# ---------------------------------------------------------------------------
+# Channel classifier
+# ---------------------------------------------------------------------------
+
+
+# Each tag's pattern set is anchored at word boundaries so "general" doesn't
+# match "general-store" by accident.  Multiple patterns per tag widen the
+# match — e.g. both "log" and "audit" suggest a log channel.
+_NAME_PATTERNS: dict[str, tuple[re.Pattern[str], ...]] = {
+    "likely_log": (
+        re.compile(r"\blogs?\b"),
+        re.compile(r"\baudit\b"),
+        re.compile(r"\bmod[-_]?logs?\b"),
+        re.compile(r"\bbot[-_]?logs?\b"),
+    ),
+    "likely_mod_log": (
+        re.compile(r"\bmod[-_]?logs?\b"),
+        re.compile(r"\bmoderation[-_]?logs?\b"),
+        re.compile(r"\bstaff[-_]?logs?\b"),
+    ),
+    "likely_bot_cmd": (
+        re.compile(r"\bbot[-_]?(?:cmd|cmds|commands?|spam)\b"),
+        re.compile(r"\bcmds?\b"),
+        re.compile(r"\bcommands?\b"),
+    ),
+    "likely_admin": (
+        re.compile(r"\badmin\b"),
+        re.compile(r"\bowner\b"),
+        re.compile(r"\bstaff[-_]?only\b"),
+    ),
+    "likely_mod": (
+        re.compile(r"\bmods?\b"),
+        re.compile(r"\bmoderation\b"),
+        re.compile(r"\bstaff\b"),
+    ),
+    "likely_proof": (
+        re.compile(r"\bproofs?\b"),
+        re.compile(r"\bevidence\b"),
+    ),
+    "likely_counting": (
+        re.compile(r"\bcounting\b"),
+        re.compile(r"\bcount\b"),
+    ),
+    "likely_mining": (
+        re.compile(r"\bmining\b"),
+        re.compile(r"\bmine\b"),
+    ),
+    "likely_game": (
+        re.compile(r"\bgames?\b"),
+        re.compile(r"\bbet(?:s|ting)?\b"),
+        re.compile(r"\bcasino\b"),
+        re.compile(r"\bblackjack\b"),
+        re.compile(r"\brps\b"),
+        re.compile(r"\bdeathmatch\b"),
+        re.compile(r"\btournament\b"),
+    ),
+    "likely_general": (
+        re.compile(r"\bgeneral\b"),
+        re.compile(r"\blobby\b"),
+        re.compile(r"\bchat\b"),
+    ),
+    "likely_welcome": (
+        re.compile(r"\bwelcome\b"),
+        re.compile(r"\bintro\b"),
+        re.compile(r"\bgreetings?\b"),
+    ),
+}
+
+
+def classify_channel_name(name: str) -> tuple[str, ...]:
+    """Return the classifier tags that match ``name`` (lowercased).
+
+    A channel can match multiple tags (a ``mod-log`` channel matches
+    ``likely_log`` AND ``likely_mod_log``).  Returned tags are sorted
+    for deterministic embed output.
+    """
+    if not name:
+        return ()
+    lowered = name.lower()
+    tags = [
+        tag
+        for tag, patterns in _NAME_PATTERNS.items()
+        if any(p.search(lowered) for p in patterns)
+    ]
+    return tuple(sorted(tags))
+
+
+__all__ = ["classify_channel_name"]

--- a/disbot/views/setup/scan_panel.py
+++ b/disbot/views/setup/scan_panel.py
@@ -22,7 +22,6 @@ no Discord create calls — strictly view-rendering.
 
 from __future__ import annotations
 
-import re
 from collections.abc import Iterable
 from dataclasses import dataclass
 
@@ -32,93 +31,7 @@ from services.guild_snapshot import (
     ChannelMeta,
     GuildSnapshot,
 )
-
-# ---------------------------------------------------------------------------
-# Channel classifier
-# ---------------------------------------------------------------------------
-
-
-# Each tag's pattern set is anchored at word boundaries so "general" doesn't
-# match "general-store" by accident.  Multiple patterns per tag widen the
-# match — e.g. both "log" and "audit" suggest a log channel.
-_NAME_PATTERNS: dict[str, tuple[re.Pattern[str], ...]] = {
-    "likely_log": (
-        re.compile(r"\blogs?\b"),
-        re.compile(r"\baudit\b"),
-        re.compile(r"\bmod[-_]?logs?\b"),
-        re.compile(r"\bbot[-_]?logs?\b"),
-    ),
-    "likely_mod_log": (
-        re.compile(r"\bmod[-_]?logs?\b"),
-        re.compile(r"\bmoderation[-_]?logs?\b"),
-        re.compile(r"\bstaff[-_]?logs?\b"),
-    ),
-    "likely_bot_cmd": (
-        re.compile(r"\bbot[-_]?(?:cmd|cmds|commands?|spam)\b"),
-        re.compile(r"\bcmds?\b"),
-        re.compile(r"\bcommands?\b"),
-    ),
-    "likely_admin": (
-        re.compile(r"\badmin\b"),
-        re.compile(r"\bowner\b"),
-        re.compile(r"\bstaff[-_]?only\b"),
-    ),
-    "likely_mod": (
-        re.compile(r"\bmods?\b"),
-        re.compile(r"\bmoderation\b"),
-        re.compile(r"\bstaff\b"),
-    ),
-    "likely_proof": (
-        re.compile(r"\bproofs?\b"),
-        re.compile(r"\bevidence\b"),
-    ),
-    "likely_counting": (
-        re.compile(r"\bcounting\b"),
-        re.compile(r"\bcount\b"),
-    ),
-    "likely_mining": (
-        re.compile(r"\bmining\b"),
-        re.compile(r"\bmine\b"),
-    ),
-    "likely_game": (
-        re.compile(r"\bgames?\b"),
-        re.compile(r"\bbet(?:s|ting)?\b"),
-        re.compile(r"\bcasino\b"),
-        re.compile(r"\bblackjack\b"),
-        re.compile(r"\brps\b"),
-        re.compile(r"\bdeathmatch\b"),
-        re.compile(r"\btournament\b"),
-    ),
-    "likely_general": (
-        re.compile(r"\bgeneral\b"),
-        re.compile(r"\blobby\b"),
-        re.compile(r"\bchat\b"),
-    ),
-    "likely_welcome": (
-        re.compile(r"\bwelcome\b"),
-        re.compile(r"\bintro\b"),
-        re.compile(r"\bgreetings?\b"),
-    ),
-}
-
-
-def classify_channel_name(name: str) -> tuple[str, ...]:
-    """Return the classifier tags that match ``name`` (lowercased).
-
-    A channel can match multiple tags (a ``mod-log`` channel matches
-    ``likely_log`` AND ``likely_mod_log``).  Returned tags are sorted
-    for deterministic embed output.
-    """
-    if not name:
-        return ()
-    lowered = name.lower()
-    tags = [
-        tag
-        for tag, patterns in _NAME_PATTERNS.items()
-        if any(p.search(lowered) for p in patterns)
-    ]
-    return tuple(sorted(tags))
-
+from utils.channel_classify import classify_channel_name
 
 # ---------------------------------------------------------------------------
 # Scan classification — aggregates per-channel hits

--- a/tests/unit/utils/test_channel_classify.py
+++ b/tests/unit/utils/test_channel_classify.py
@@ -1,0 +1,90 @@
+"""Tests for the canonical channel-name classifier (``utils.channel_classify``).
+
+The classifier moved here from ``views.setup.scan_panel`` to remove the
+zero-tolerance ``services/ → views/`` import (arch-fix-1).  These tests
+pin the canonical home directly and assert the legacy re-export still
+resolves to the *same* object, so a regression that re-copies the
+function back into ``views/`` is caught.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from utils.channel_classify import classify_channel_name
+
+
+@pytest.mark.parametrize(
+    ("name", "expected_tag"),
+    [
+        ("mod-log", "likely_log"),
+        ("mod-log", "likely_mod_log"),
+        ("audit-log", "likely_log"),
+        ("bot-logs", "likely_log"),
+        ("bot-commands", "likely_bot_cmd"),
+        ("bot-cmd", "likely_bot_cmd"),
+        ("bot-spam", "likely_bot_cmd"),
+        ("admin-only", "likely_admin"),
+        ("owner", "likely_admin"),
+        ("staff", "likely_mod"),
+        ("moderation", "likely_mod"),
+        ("counting", "likely_counting"),
+        ("mining", "likely_mining"),
+        ("games", "likely_game"),
+        ("casino", "likely_game"),
+        ("blackjack", "likely_game"),
+        ("general", "likely_general"),
+        ("lobby", "likely_general"),
+        ("welcome", "likely_welcome"),
+        ("proofs", "likely_proof"),
+    ],
+)
+def test_classifier_matches_documented_patterns(name: str, expected_tag: str):
+    assert expected_tag in classify_channel_name(name)
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["off-topic", "introductions", "random", "deals", "art"],
+)
+def test_classifier_returns_empty_for_unmatched_names(name: str):
+    assert classify_channel_name(name) == ()
+
+
+def test_classifier_returns_empty_for_empty_name():
+    assert classify_channel_name("") == ()
+
+
+def test_classifier_is_case_insensitive():
+    assert "likely_log" in classify_channel_name("MOD-LOG")
+    assert "likely_general" in classify_channel_name("General")
+
+
+def test_classifier_returns_tags_sorted():
+    """Sort guarantees deterministic embed output."""
+    tags = classify_channel_name("mod-log")
+    assert list(tags) == sorted(tags)
+
+
+def test_legacy_scan_panel_reexport_is_same_object():
+    """The setup scan panel re-exports the canonical function, not a copy.
+
+    Guards against re-introducing the ``services/ → views/`` breach by
+    copying the classifier back into ``views/``.
+    """
+    from views.setup import scan_panel
+
+    assert scan_panel.classify_channel_name is classify_channel_name
+
+
+def test_consumers_import_from_utils_not_views():
+    """The three services use the canonical ``utils`` home directly."""
+    from services import (
+        channel_recommender,
+        cleanup_profiles,
+        cog_routing_profiles,
+    )
+
+    assert channel_recommender.classify_channel_name is classify_channel_name
+    assert cleanup_profiles.classify_channel_name is classify_channel_name
+    assert cog_routing_profiles.classify_channel_name is classify_channel_name


### PR DESCRIPTION
## What & why

Audit finding **P0-1** (`docs/audits/repo-wide-audit-2026-05-29.md` §8, §12, §6-item-1): the channel-name classifier `classify_channel_name` lived in `views/setup/scan_panel.py` but is needed by three services, forcing each to import from `views/` — the **zero-tolerance `services/ → views/`** boundary breach (tracked as `arch-fix-1`):

- `services/channel_recommender.py`
- `services/cleanup_profiles.py`
- `services/cog_routing_profiles.py`

## Change

- Move the pure text heuristic (`classify_channel_name` + `_NAME_PATTERNS`, no I/O, only `re`) to **`utils/channel_classify.py`** — the correct home per `helper-policy.md` §3.9 / CLAUDE.md ("a function needed by both `services/` and `views/` belongs in `utils/`").
- `views/setup/scan_panel.py` now imports and re-exports it, so the existing `from views.setup.scan_panel import classify_channel_name` surface is unchanged (its tests still pass unmodified).
- The three services import from `utils/`.
- Remove the three resolved `arch-fix-1` `known_violations` from `architecture_rules/layers.yaml`.

## Tests

New `tests/unit/utils/test_channel_classify.py`:
- Mirrors the classifier coverage at the canonical home.
- **Identity guard**: asserts `scan_panel.classify_channel_name is utils.channel_classify.classify_channel_name` and that all three services bind the same object — catches any regression that re-copies the function back into `views/`.

## Gates (CI-exact, `python3.10 -m`)

- `check_architecture.py --mode strict`: **0 errors** (the 3 `services → views` warnings are gone).
- black 26.5.1 / isort 8.0.1 / ruff 0.15.14 / mypy 2.1.0: clean.
- `pytest tests/ -q`: **6333 passed, 3 skipped**.

> Note: `scripts/check_quality.py --check-only` reports spurious black failures in this environment because it shells out to a stray bare `black` 26.3.1 (Python 3.11) instead of the CI-pinned `python3.10 -m black 26.5.1` — a separate, pre-existing tooling-drift issue documented in the audit §11. Verified clean with the CI-exact commands.

Single-purpose, independent, revertible per-file.

https://claude.ai/code/session_0174rirKZ5dtHaJSZc7kMkfP

---
_Generated by [Claude Code](https://claude.ai/code/session_0174rirKZ5dtHaJSZc7kMkfP)_