### PR TITLE
Scope deathmatch stats to the originating guild (audit P0-2)

### DIFF
--- a/disbot/cogs/deathmatch_cog.py
+++ b/disbot/cogs/deathmatch_cog.py
@@ -87,7 +87,11 @@ class _DuelView(discord.ui.View):
         opponent = duel.player2 if duel.turn == duel.player1 else duel.player1
         duel.is_over = True
         self.cog.active_duels.pop(self.duel_key, None)
-        await self.cog.update_leaderboard(winner_id=opponent.id, loser_id=duel.turn.id)
+        await self.cog.update_leaderboard(
+            winner_id=opponent.id,
+            loser_id=duel.turn.id,
+            guild_id=self.ctx.guild.id if self.ctx.guild else 0,
+        )
         for item in self.children:
             item.disabled = True  # type: ignore[attr-defined]
         embed = discord.Embed(
@@ -144,7 +148,11 @@ class _DuelView(discord.ui.View):
         if winner:
             duel.is_over = True
             self.cog.active_duels.pop(self.duel_key, None)
-            await self.cog.update_leaderboard(winner_id=winner.id, loser_id=loser.id)
+            await self.cog.update_leaderboard(
+                winner_id=winner.id,
+                loser_id=loser.id,
+                guild_id=self.ctx.guild.id if self.ctx.guild else 0,
+            )
             for item in self.children:
                 item.disabled = True  # type: ignore[attr-defined]
             embed = discord.Embed(
@@ -315,8 +323,13 @@ class Deathmatch(commands.Cog):
         view = _ChallengeView(self, ctx.author, opponent, duel_key, ctx)  # type: ignore[arg-type]
         view.message = await ctx.send(embed=embed, view=view)
 
-    async def update_leaderboard(self, winner_id: int, loser_id: int) -> None:
-        await db.update_deathmatch(winner_id, loser_id)
+    async def update_leaderboard(
+        self,
+        winner_id: int,
+        loser_id: int,
+        guild_id: int = 0,
+    ) -> None:
+        await db.update_deathmatch(winner_id, loser_id, guild_id)
 
     @challenge.error
     async def challenge_error(self, ctx, error):

--- a/disbot/services/rank_providers.py
+++ b/disbot/services/rank_providers.py
@@ -203,7 +203,7 @@ class DeathmatchProvider(RankProvider):
     )
 
     async def top(self, guild: discord.Guild) -> list[RankEntry]:
-        rows = await db.get_deathmatch_leaderboard()
+        rows = await db.get_deathmatch_leaderboard(guild.id)
         return [
             RankEntry(
                 label=(
@@ -219,7 +219,7 @@ class DeathmatchProvider(RankProvider):
         guild: discord.Guild,
         user_id: int,
     ) -> tuple[int | None, str | None]:
-        rows = await db.get_deathmatch_leaderboard()
+        rows = await db.get_deathmatch_leaderboard(guild.id)
         for i, row in enumerate(rows):
             if row["user_id"] == user_id:
                 return i + 1, f"{row['wins']}W / {row['losses']}L"

--- a/tests/unit/cogs/test_deathmatch_guild_scope.py
+++ b/tests/unit/cogs/test_deathmatch_guild_scope.py
@@ -1,0 +1,75 @@
+"""Audit P0-2 — deathmatch stats must be scoped to the originating guild.
+
+The ``deathmatch_stats`` table has a composite primary key
+``(user_id, guild_id)`` and the leaderboard query filters
+``WHERE guild_id=$1`` — per-guild stats were the schema's design
+intent.  The cog's write path historically omitted ``guild_id``, so
+every result landed under the global ``guild_id=0`` bucket (cross-guild
+leakage).  These tests pin that the duel flow now threads the
+originating guild id through to ``db.update_deathmatch``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_DISBOT = Path(__file__).parents[3] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+
+def _player(id_: int, name: str = "P") -> SimpleNamespace:
+    return SimpleNamespace(
+        id=id_,
+        display_name=name,
+        mention=f"<@{id_}>",
+        bot=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_leaderboard_forwards_guild_id_to_db():
+    """The write seam forwards its ``guild_id`` to ``db.update_deathmatch``."""
+    from cogs.deathmatch_cog import Deathmatch
+
+    cog = Deathmatch(MagicMock())
+    with patch(
+        "cogs.deathmatch_cog.db.update_deathmatch",
+        new_callable=AsyncMock,
+    ) as mock_db:
+        await cog.update_leaderboard(winner_id=1, loser_id=2, guild_id=99)
+    mock_db.assert_awaited_once_with(1, 2, 99)
+
+
+@pytest.mark.asyncio
+async def test_duel_timeout_records_result_under_originating_guild():
+    """A real duel timeout threads ``ctx.guild.id`` into the write path."""
+    from cogs.deathmatch_cog import Deathmatch, _Duel, _DuelView
+
+    cog = Deathmatch(MagicMock())
+    p1, p2 = _player(100, "One"), _player(200, "Two")
+    duel = _Duel(p1, p2)  # type: ignore[arg-type]
+    duel_key = tuple(sorted([p1.id, p2.id]))
+    cog.active_duels[duel_key] = duel
+
+    ctx = MagicMock()
+    ctx.guild.id = 777
+    view = _DuelView(cog, duel, duel_key, ctx)
+
+    with patch(
+        "cogs.deathmatch_cog.Deathmatch.update_leaderboard",
+        new_callable=AsyncMock,
+    ) as mock_update:
+        # turn == player1, so on timeout player1 loses to player2.
+        await view.on_timeout()
+
+    mock_update.assert_awaited_once_with(
+        winner_id=p2.id,
+        loser_id=p1.id,
+        guild_id=777,
+    )

--- a/tests/unit/services/test_rank_providers.py
+++ b/tests/unit/services/test_rank_providers.py
@@ -214,6 +214,28 @@ async def test_deathmatch_member_rank_finds_w_l_record():
 
 
 @pytest.mark.asyncio
+async def test_deathmatch_top_forwards_guild_id():
+    """Regression (audit P0-2): the deathmatch board must query the
+    caller's guild, not the global ``guild_id=0`` pool.
+    """
+    provider = get_provider("deathmatch")
+    mock_lb = AsyncMock(return_value=[])
+    with patch("services.rank_providers.db.get_deathmatch_leaderboard", mock_lb):
+        await provider.top(_guild())
+    mock_lb.assert_awaited_once_with(42)
+
+
+@pytest.mark.asyncio
+async def test_deathmatch_member_rank_forwards_guild_id():
+    """Regression (audit P0-2): member_rank must also scope by guild."""
+    provider = get_provider("deathmatch")
+    mock_lb = AsyncMock(return_value=[])
+    with patch("services.rank_providers.db.get_deathmatch_leaderboard", mock_lb):
+        await provider.member_rank(_guild(), 7)
+    mock_lb.assert_awaited_once_with(42)
+
+
+@pytest.mark.asyncio
 async def test_rps_top_uses_pre_resolved_name():
     provider = get_provider("rps")
     rows = [{"name": "Bob", "wins": 4, "losses": 1, "ties": 2}]


### PR DESCRIPTION
## What & why

Audit finding **P0-2**. The `deathmatch_stats` table has a composite PK `(user_id, guild_id)` and the leaderboard query filters `WHERE guild_id=$1` — **per-guild stats were the schema's design intent**. But the cog write path (`Deathmatch.update_leaderboard → db.update_deathmatch`) omitted `guild_id`, so every result landed in the global `guild_id=0` bucket. The provider read (`DeathmatchProvider.top` / `.member_rank`) also defaulted to `guild_id=0`.

## Correction to the audit's stated fix

The audit framed this as *"reads default to `guild_id=0` → empty in real guilds; fix = pass `guild.id` to the read."* Verifying against the code (`cogs/deathmatch_cog.py:319`, `utils/db/games/deathmatch.py`) shows **the write path also used `guild_id=0`**. Reads and writes were therefore *consistent* at 0 — the board showed cross-guild-mixed global data, not an empty board. The audit's literal read-only fix would have made the board **permanently blank**. The correct fix threads `guild_id` through **both** sides.

## Change

- `DeathmatchProvider.top` / `.member_rank` → `db.get_deathmatch_leaderboard(guild.id)`.
- `_DuelView.on_timeout` / `._resolve` → `update_leaderboard(..., guild_id=self.ctx.guild.id if self.ctx.guild else 0)`.
- `Deathmatch.update_leaderboard(winner_id, loser_id, guild_id=0)` forwards to `db.update_deathmatch`.

Pre-existing rows under `guild_id=0` are not migratable (their true guild is unknown) and simply stop appearing on per-guild boards — acceptable for a game leaderboard. The bot-duel isolation invariant (bot duels never record) is unchanged and still pinned.

## Tests

- `tests/unit/services/test_rank_providers.py`: `top` / `member_rank` forward `guild.id` (== 42) to the read.
- `tests/unit/cogs/test_deathmatch_guild_scope.py`: the write seam forwards `guild_id`, and a real duel-timeout flow threads `ctx.guild.id` (== 777) through.
- All **4 new tests fail pre-fix** (`Expected: mock(42)` / `Actual: mock()`), pass post-fix.

## Gates (CI-exact, `python3.10 -m`)

- `check_architecture.py --mode strict`: 0 errors.
- black / isort / ruff / mypy: clean.
- `pytest tests/ -q`: **6307 passed, 3 skipped**.

https://claude.ai/code/session_0174rirKZ5dtHaJSZc7kMkfP

---
_Generated by [Claude Code](https://claude.ai/code/session_0174rirKZ5dtHaJSZc7kMkfP)_