### PR TITLE
Route xp_service.reset through emit_audit_action (audit P1-1)

### DIFF
--- a/disbot/cogs/xp_cog.py
+++ b/disbot/cogs/xp_cog.py
@@ -157,6 +157,7 @@ class XpCog(commands.Cog):
             user_id=member.id,
             source="admin:resetxp",
             actor_id=ctx.author.id,
+            actor_type="admin",
         )
         await ctx.send(f"✅ Reset XP for {member.mention}.")
 

--- a/disbot/services/xp_service.py
+++ b/disbot/services/xp_service.py
@@ -27,8 +27,10 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass
+from datetime import datetime, timezone
 
 from core.events import bus
+from services.audit_events import emit_audit_action
 from utils import db
 
 logger = logging.getLogger("bot.xp_service")
@@ -144,6 +146,7 @@ async def reset(
     *,
     source: str,
     actor_id: int | None = None,
+    actor_type: str = "system",
 ) -> None:
     """Clear all XP for *user_id* in *guild_id* and emit ``EVT_XP_RESET``.
 
@@ -154,9 +157,16 @@ async def reset(
             "admin:modal_reset", ...).  Surfaces in the event payload
             so subscribers can attribute the action.
         actor_id: optional ID of the admin who triggered the reset.
+        actor_type: capability-resolver actor token for the shared audit
+            event ("admin" for operator-initiated resets, "system" for
+            scripted/automated purges).
 
-    Emits ``EVT_XP_RESET`` after the row is deleted so panel-refresh,
-    audit, and level-role subscribers can react.
+    Emits ``EVT_XP_RESET`` after the row is deleted so panel-refresh and
+    level-role subscribers can react, then publishes the generic
+    ``audit.action_recorded`` event via :func:`emit_audit_action` so an
+    XP wipe — a sensitive, operator-initiated mutation — reaches the
+    shared audit stream that feeds server logging (it previously did
+    not).
     """
     await db.delete_xp(user_id, guild_id)
     await bus.emit(
@@ -165,4 +175,18 @@ async def reset(
         user_id=user_id,
         actor_id=actor_id,
         source=source,
+    )
+    occurred_at = datetime.now(tz=timezone.utc)
+    await emit_audit_action(
+        mutation_id=f"xp_reset:{guild_id}:{user_id}:{occurred_at.timestamp()}",
+        subsystem="xp",
+        mutation_type="reset_xp",
+        target=f"member:{user_id}",
+        scope="guild",
+        guild_id=guild_id,
+        prev_value=None,
+        new_value=None,
+        actor_id=actor_id,
+        actor_type=actor_type,
+        occurred_at=occurred_at,
     )

--- a/disbot/views/xp/modals.py
+++ b/disbot/views/xp/modals.py
@@ -189,6 +189,7 @@ class _ResetXpModal(discord.ui.Modal, title="Reset XP"):  # type: ignore[call-ar
             user_id=member.id,
             source="admin:modal_reset",
             actor_id=interaction.user.id,
+            actor_type="admin",
         )
         await interaction.response.send_message(
             f"✅ Reset XP for {member.mention}.",

--- a/tests/unit/cogs/test_xp_cog_admin_routes.py
+++ b/tests/unit/cogs/test_xp_cog_admin_routes.py
@@ -162,6 +162,7 @@ async def test_reset_xp_modal_calls_xp_service_reset():
         user_id=member.id,
         source="admin:modal_reset",
         actor_id=interaction.user.id,
+        actor_type="admin",
     )
 
 
@@ -207,6 +208,7 @@ async def test_resetxp_command_calls_xp_service_reset():
         user_id=member.id,
         source="admin:resetxp",
         actor_id=ctx.author.id,
+        actor_type="admin",
     )
 
 

--- a/tests/unit/services/test_xp_service.py
+++ b/tests/unit/services/test_xp_service.py
@@ -101,6 +101,10 @@ async def test_reset_deletes_row_and_emits_event():
             "services.xp_service.bus.emit",
             new_callable=AsyncMock,
         ) as emit,
+        patch(
+            "services.xp_service.emit_audit_action",
+            new_callable=AsyncMock,
+        ),
     ):
         await xp_service.reset(
             guild_id=42,
@@ -125,7 +129,41 @@ async def test_reset_actor_defaults_to_none():
     with (
         patch("services.xp_service.db.delete_xp", new_callable=AsyncMock),
         patch("services.xp_service.bus.emit", new_callable=AsyncMock) as emit,
+        patch("services.xp_service.emit_audit_action", new_callable=AsyncMock),
     ):
         await xp_service.reset(guild_id=1, user_id=2, source="system:purge")
 
     assert emit.await_args.kwargs["actor_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_reset_emits_audit_action_for_server_logging():
+    """An XP wipe must reach the shared ``audit.action_recorded`` stream
+    (audit P1-1) so server logging is no longer blind to it.
+    """
+    with (
+        patch("services.xp_service.db.delete_xp", new_callable=AsyncMock),
+        patch("services.xp_service.bus.emit", new_callable=AsyncMock),
+        patch(
+            "services.xp_service.emit_audit_action",
+            new_callable=AsyncMock,
+        ) as audit,
+    ):
+        await xp_service.reset(
+            guild_id=42,
+            user_id=7,
+            source="admin:resetxp",
+            actor_id=99,
+            actor_type="admin",
+        )
+
+    audit.assert_awaited_once()
+    kwargs = audit.await_args.kwargs
+    assert kwargs["subsystem"] == "xp"
+    assert kwargs["mutation_type"] == "reset_xp"
+    assert kwargs["target"] == "member:7"
+    assert kwargs["scope"] == "guild"
+    assert kwargs["guild_id"] == 42
+    assert kwargs["actor_id"] == 99
+    assert kwargs["actor_type"] == "admin"
+    assert kwargs["new_value"] is None

--- a/tests/unit/services/test_xp_service_concurrent.py
+++ b/tests/unit/services/test_xp_service_concurrent.py
@@ -93,6 +93,10 @@ async def test_reset_under_concurrency_emits_per_call():
             "services.xp_service.bus.emit",
             new_callable=AsyncMock,
         ) as emit,
+        patch(
+            "services.xp_service.emit_audit_action",
+            new_callable=AsyncMock,
+        ),
     ):
         await asyncio.gather(
             *(


### PR DESCRIPTION
## What & why

Audit finding **P1-1** (the xp-reset slice). An XP reset wipes a member's entire XP/level row — a sensitive, operator-initiated mutation — but `xp_service.reset` only emitted the subsystem-local `xp.reset` event, which `server_logging` does **not** subscribe to. So XP wipes were invisible to the shared `audit.action_recorded` stream that feeds server logging.

## Change

- `reset()` now also publishes `audit.action_recorded` via `emit_audit_action` (`subsystem="xp"`, `mutation_type="reset_xp"`, `target="member:<id>"`, `scope="guild"`).
- Threads an `actor_type` token — `"admin"` from the two admin-gated callers (`xp_cog.resetxp`, `views/xp/modals._ResetXpModal`), default `"system"`.
- `emit_audit_action` is failure-safe, so a bus hiccup never blocks the delete.

## Deliberately scoped OUT (same audit item, different reasons)

The audit grouped economy/xp/moderation together, but verifying against the code shows the other two need separate handling:

- **economy_service** — `credit`/`debit`/`bet_and_settle` fire on **every game bet**. Routing all of them to the audit channel is a volume/design decision the audit didn't resolve (operator-adjustment-only filtering is the likely answer). Left for a focused PR.
- **moderation_service** — already emits `moderation.action_taken`, which `server_logging` **does** subscribe to (`_on_moderation_action`). Adding `emit_audit_action` there would **double-log** every mod action. Its real gap (**P1-2**: modals/prefix bypassing the service entirely) is a separate behavioral rewire.
- The **`emit_audit_action` AST invariant** is deferred until all in-scope services emit — added now it would false-fail while economy/moderation remain.

## Tests

- New `test_reset_emits_audit_action_for_server_logging` asserts the audit payload (subsystem/type/target/scope/guild/actor). It **errors on stock `main`** (`emit_audit_action` not imported in old `xp_service`), confirming it pins the new behavior.
- Existing reset tests updated for the second emit + `actor_type` kwarg (`test_xp_cog_admin_routes`, `test_xp_service`, `test_xp_service_concurrent`).

## Gates (CI-exact, `python3.10 -m`)

- `check_architecture.py --mode strict`: 0 errors.
- black / isort / ruff / mypy: clean.
- `pytest tests/ -q`: **6304 passed, 3 skipped**.

https://claude.ai/code/session_0174rirKZ5dtHaJSZc7kMkfP

---
_Generated by [Claude Code](https://claude.ai/code/session_0174rirKZ5dtHaJSZc7kMkfP)_