### PR TITLE
Fix misleading AI task_enabled docstring (audit P1-4)

### DIFF
--- a/disbot/core/runtime/ai/feature_flags.py
+++ b/disbot/core/runtime/ai/feature_flags.py
@@ -11,11 +11,15 @@ Recognised env vars:
   platform globally. Default off.
 * ``AI_DEFAULT_PROVIDER``        — provider name; one of
   ``deterministic`` / ``openai``. Default ``deterministic``.
-* ``AI_TASK_<NAME>_ENABLED``     — per-:class:`AITask` opt-in. The
+* ``AI_TASK_<NAME>_ENABLED``     — per-:class:`AITask` override. The
   ``<NAME>`` portion is the uppercase enum name (e.g.
-  ``AI_TASK_SETUP_SUGGEST_ENABLED``). Default off, except for
-  setup-advisor compatibility tasks which respect
-  ``SETUP_ADVISOR_PROVIDER`` (legacy).
+  ``AI_TASK_SETUP_SUGGEST_ENABLED``). Once the global ``AI_ENABLED``
+  gate is on, each task defaults to **enabled**; set this var to a
+  falsey value to selectively *disable* a single task. The per-task
+  flags are a kill-switch, not the opt-in gate — boot safety comes
+  from the two layers above (``AI_ENABLED`` defaults off, and the
+  default provider is ``deterministic`` so no external call is made
+  by accident even when the platform is enabled).
 * ``AI_TOOLS_ENABLED``           — ``"1"``/``"true"`` to let the
   gateway offer read-only tools to the model (function calling).
   Layers under :func:`ai_enabled`; default off, so tool calling is
@@ -67,10 +71,19 @@ def task_enabled(task: AITask) -> bool:
     Per-task gating layers on top of :func:`ai_enabled`: the global
     flag must also be on. When ``ai_enabled()`` is false this
     function returns false regardless of the task flag.
+
+    Once the global gate is on, individual tasks default to *enabled*
+    (the per-task flag is a selective kill-switch, not an opt-in gate
+    — see the module docstring for the boot-safety model).
     """
     if not ai_enabled():
         return False
     env_name = f"AI_TASK_{task.name}_ENABLED"
+    # default=True is intentional: the opt-in gate is ai_enabled() above
+    # (plus the deterministic default provider). Pinned by
+    # tests/unit/runtime/ai/test_feature_flags.py::test_task_enabled_default_when_global_on
+    # — do NOT flip to False without updating that contract and the
+    # gateway's expectations (gateway.py:196 gates calls on this).
     return _bool_env(env_name, default=True)
 
 

--- a/tests/unit/runtime/ai/test_feature_flags.py
+++ b/tests/unit/runtime/ai/test_feature_flags.py
@@ -41,6 +41,12 @@ def test_task_disabled_when_global_off(monkeypatch):
 
 
 def test_task_enabled_default_when_global_on(monkeypatch):
+    """Contract: per-task flags are a selective kill-switch, not an
+    opt-in. With the global ``AI_ENABLED`` gate on and no per-task var
+    set, a task defaults to enabled. Boot safety is provided by
+    ``AI_ENABLED`` (default off) + the deterministic default provider,
+    not by this flag — the module docstring must match this default.
+    """
     monkeypatch.setenv("AI_ENABLED", "1")
     monkeypatch.delenv("AI_TASK_SETUP_SUGGEST_ENABLED", raising=False)
     assert task_enabled(AITask.SETUP_SUGGEST) is True


### PR DESCRIPTION
## What & why

Audit finding **P1-4** (security-relevant). `core/runtime/ai/feature_flags.py::task_enabled` uses `default=True` once the global `AI_ENABLED` gate is on, but the module docstring claimed per-task flags are **"Default off"** (and incorrectly tied them to `SETUP_ADVISOR_PROVIDER`, which `task_enabled` doesn't reference).

## Which side is the bug?

The **docstring** — not the code. `default=True` is the *intended, pinned* behavior:
- `tests/unit/runtime/ai/test_feature_flags.py::test_task_enabled_default_when_global_on` already asserts `task_enabled(...) is True` with the global gate on and no per-task var.
- `gateway.py:196` gates provider calls on this; the live AI deployment relies on it.

Flipping the default to `False` (the other option the audit offered) would break that test and silently disable every AI task — actively harmful given the AI-provider work in `docs/ai-provider-and-grounding-fix-plan.md`. Boot safety is already provided by two layers: `AI_ENABLED` defaults off, and the default provider is `deterministic` (no external call by accident even when enabled). The per-task flags are a **selective kill-switch**, not the opt-in gate.

## Change (docs/comments only — no behavioral change)

- Rewrites the `AI_TASK_<NAME>_ENABLED` docstring bullet to describe the actual layered model and drops the inaccurate setup-advisor clause.
- Adds a guard comment at the `default=True` site pointing at the pinning test + the gateway gate, so it isn't "corrected" to `False`.
- Documents the contract in `test_task_enabled_default_when_global_on`.

## Gates (CI-exact, `python3.10 -m`)

- `check_architecture.py --mode strict`: 0 errors.
- black / ruff / mypy: clean.
- `pytest tests/ -q`: **6303 passed, 3 skipped**.

https://claude.ai/code/session_0174rirKZ5dtHaJSZc7kMkfP

---
_Generated by [Claude Code](https://claude.ai/code/session_0174rirKZ5dtHaJSZc7kMkfP)_