### PR TITLE
Add on_member_join XP-role regression test (audit P1-3)

### DIFF
--- a/tests/unit/cogs/test_role_cog_routing.py
+++ b/tests/unit/cogs/test_role_cog_routing.py
@@ -256,6 +256,54 @@ async def test_on_member_join_skips_when_no_plan():
     apply_mock.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_on_member_join_excludes_xp_auto_assign_roles():
+    """The join path must also keep XP reward roles out of the time-based
+    reconciliation. The "lost testrole on restart" regression lived in BOTH
+    role_check/_assign_roles AND on_member_join; this is the join-path mirror
+    of test_assign_roles_excludes_xp_auto_assign_roles so neither half can
+    silently re-regress.
+    """
+    bot = MagicMock()
+    cog = RoleCog(bot)
+    member = MagicMock()
+    member.bot = False
+    member.guild = MagicMock(id=1)
+
+    with (
+        patch("cogs.role_cog._ensure_defaults", new_callable=AsyncMock),
+        patch(
+            "cogs.role_cog.db.get_role_thresholds",
+            new_callable=AsyncMock,
+            return_value=[
+                {
+                    "role_name": "Veteran",
+                    "days_required": 30,
+                    "level_required": None,
+                    "xp_auto_assign": False,
+                },
+                {
+                    "role_name": "testrole",
+                    "days_required": 0,
+                    "level_required": 6,
+                    "xp_auto_assign": True,
+                },
+            ],
+        ),
+        patch(
+            "cogs.role_cog.role_automation.explain_assignment_for",
+            return_value=None,
+        ) as explain_mock,
+    ):
+        await cog.on_member_join(member)
+
+    # explain_assignment_for(guild, member, threshold_objs) — args[2] is the
+    # filtered threshold tuple fed into the time-based reconciliation.
+    names = {t.role_name for t in explain_mock.call_args.args[2]}
+    assert "Veteran" in names  # time-based role still reconciled on join
+    assert "testrole" not in names  # XP reward role excluded from join path
+
+
 def test_role_cog_threshold_paths_do_not_call_member_role_apis_directly():
     """Static check: the threshold path must not call Discord member.add_roles
     / member.remove_roles directly. Reaction-role and admin role create/delete


### PR DESCRIPTION
## What & why

Audit finding **P1-3** (residual half). The "XP reward roles stripped on boot" bug (`b13ed56`) lived in **both** the time-based `role_check`/`_assign_roles` loop **and** `on_member_join`. The fix filtered `xp_auto_assign` rows out of the time-based reconciliation in both paths — but only the `_assign_roles` exclusion was pinned by a test (`test_assign_roles_excludes_xp_auto_assign_roles`). The `on_member_join` exclusion was unverified (its existing test used a threshold list with no `xp_auto_assign` row).

> Note: the audit listed P1-3 as "no regression test" — the primary boot-loop test actually *does* exist in `main` (added by the same fix commit), so the audit was partly stale. This PR closes the genuine remaining gap: the **join-path** mirror.

## Change (test-only)

Adds `test_on_member_join_excludes_xp_auto_assign_roles`: feeds both a time-based row (`Veteran`, `days_required=30`) and an XP reward row (`testrole`, `xp_auto_assign=True`) and asserts only the time-based one reaches `explain_assignment_for`.

Verified it **fails when the `on_member_join` filter is removed** (`assert 'testrole' not in {'Veteran', 'testrole'}`) and passes with it present — a real regression guard.

## Gates

- `pytest tests/ -q`: **6304 passed, 3 skipped**. (`check_architecture`/mypy unaffected — no `disbot/` change.)

https://claude.ai/code/session_0174rirKZ5dtHaJSZc7kMkfP

---
_Generated by [Claude Code](https://claude.ai/code/session_0174rirKZ5dtHaJSZc7kMkfP)_