### PR TITLE
Correct verified-stale facts in reference docs (audit P1-12)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,7 +38,7 @@ platform concerns the cog simply *uses*.
          ┌──────────────────────────────┴────────────────────────────┐
          │                                                           │
    ┌─────▼─────────────┐    ┌──────────────────────┐    ┌────────────▼────────┐
-   │   cogs/  (×20)    │    │  core/runtime/       │    │   governance/      │
+   │   cogs/  (×28)    │    │  core/runtime/       │    │   governance/      │
    │  thin dispatchers │◀──▶│  platform primitives │◀──▶│   policy engine    │
    └─────┬─────────────┘    └──────────┬───────────┘    └──────────┬─────────┘
          │                             │                            │

--- a/docs/repo-navigation-map.md
+++ b/docs/repo-navigation-map.md
@@ -35,7 +35,7 @@ superbot/
 ├── tests/                   # pytest tree, mirrors disbot/ layout
 ├── .claude/                 # Claude Code config (CLAUDE.md, settings.json)
 ├── .codegraph/              # CodeGraph index (built artifact; not in git)
-├── .github/workflows/       # CI (one file: code-quality.yml)
+├── .github/workflows/       # CI (code-quality.yml + ai-evals.yml)
 ├── pyproject.toml           # black, isort, ruff, mypy, pytest config
 ├── requirements.txt         # runtime deps
 └── Procfile                 # process declaration (deployment)

--- a/docs/ui-view-adoption-audit.md
+++ b/docs/ui-view-adoption-audit.md
@@ -1,7 +1,12 @@
 # SuperBot — UI / View Adoption Audit
 
-> **Status:** inventory snapshot, dated 2026-05-24, `main` at
-> `948f539` (post-PR-#289).
+> **Status:** ⚠️ SUPERSEDED inventory snapshot, dated 2026-05-24, `main` at
+> `948f539` (post-PR-#289). The PR 1–7 backlog in §7 / §9.3 has all
+> shipped; **`docs/audits/repo-wide-audit-2026-05-29.md` reconciles this
+> snapshot against current code and supersedes its open backlog.** Do
+> not action items from this doc without re-verifying against the
+> source — e.g. `views/economy/work_panel.py:86` is no longer "bare"
+> (it now defers before I/O).
 > Companion to `docs/helper-policy.md`, `docs/building-roadmap/hub-ui-standard.md`,
 > `docs/help-command-surface-map.md`, and `docs/helper-debt-inventory.md`.
 >


### PR DESCRIPTION
## What & why

Audit finding **P1-12** — "stale docs that actively mislead future agents." Three factual errors, **each verified against current code**:

- **`architecture.md`** — layer diagram said `cogs/ (×20)`; actual is **28** top-level `*_cog.py`. (The "51 migrations" figure is correct, left as-is.)
- **`repo-navigation-map.md`** — ".github/workflows: one file"; there are **two** (`code-quality.yml` + `ai-evals.yml`).
- **`ui-view-adoption-audit.md`** — marked **SUPERSEDED**. Its PR 1–7 backlog has shipped and the new repo-wide audit reconciles it. E.g. the doc still flagged `views/economy/work_panel.py:86` as "bare", but that callback now defers before I/O (verified). Banner points readers to the current audit so they don't re-action shipped work.

## Deliberately NOT touched (left for follow-up to keep this low-risk)

Per the "if ambiguous or sensitive, leave it and note it" rule:

- **ADR-003 §2** "open, blocked by canary" status on #253/#255/#256 — ADRs are immutable-once-landed; updating shipped status warrants per-PR merge verification + maintainer signoff.
- **`navigation.py`** "migrate one PR at a time" docstring — confirming the admin/settings/games back-button factories are *fully* converted is a code audit, not a quick fact-check.
- **`runtime_contracts.md` → `docs/runbook.md`** — the reference is explicitly labelled *"future work in Phase T"*, so it reads as an intentional forward-reference rather than a dead link.

## Gates

- `pytest tests/unit/docs/ -q`: 49 passed; full suite **6303 passed, 3 skipped**. (No `.py` changes — arch/mypy unaffected.)

Docs only.

https://claude.ai/code/session_0174rirKZ5dtHaJSZc7kMkfP

---
_Generated by [Claude Code](https://claude.ai/code/session_0174rirKZ5dtHaJSZc7kMkfP)_