### PR TITLE
Add ai_permission_service.forget_guild + wire into teardown (audit P1-9)

### DIFF
--- a/disbot/guild_lifecycle.py
+++ b/disbot/guild_lifecycle.py
@@ -603,18 +603,21 @@ async def _teardown_ai_platform(guild_id: int) -> None:
     ``ai_decision_audit``, and per-guild ``ai_instruction_profile``
     rows). Global instruction profiles (``guild_id IS NULL``) are
     preserved. Also invalidates the resolver cache and drops the
-    process-local conversation buffers for the guild.
+    process-local conversation buffers AND the permission-service
+    cooldown / fresh-allowance trackers for the guild.
     """
     try:
         from services import (
             ai_conversation_service,
             ai_natural_language_policy,
+            ai_permission_service,
         )
         from utils.db import ai as ai_db
 
         deleted = await ai_db.delete_for_guild(guild_id)
         ai_natural_language_policy.invalidate(guild_id)
         ai_conversation_service.forget_guild(guild_id)
+        ai_permission_service.forget_guild(guild_id)
         if deleted:
             logger.debug(
                 "guild_lifecycle: deleted %d AI Platform row(s) for guild=%d",

--- a/disbot/services/ai_permission_service.py
+++ b/disbot/services/ai_permission_service.py
@@ -97,6 +97,24 @@ def consume_fresh_allowance(guild_id: int, user_id: int) -> None:
     _FRESH_ALLOWANCE_USED[(guild_id, user_id)] += 1
 
 
+def forget_guild(guild_id: int) -> int:
+    """Drop the process-local cooldown + fresh-allowance entries for
+    ``guild_id``; return the number of entries removed.
+
+    Called from :func:`guild_lifecycle.teardown` when the bot leaves a
+    guild. Without it these ``(guild_id, user_id)``-keyed dicts grow
+    unbounded across the bot's lifetime, and a re-invited guild inherits
+    stale cooldown / mention-allowance state from before it left.
+    """
+    removed = 0
+    for tracker in (_LAST_REPLY_AT, _FRESH_ALLOWANCE_USED):
+        drop = [key for key in tracker if key[0] == guild_id]
+        for key in drop:
+            del tracker[key]
+        removed += len(drop)
+    return removed
+
+
 def _reset_for_tests() -> None:
     _LAST_REPLY_AT.clear()
     _FRESH_ALLOWANCE_USED.clear()
@@ -105,6 +123,7 @@ def _reset_for_tests() -> None:
 __all__ = [
     "UserPermissionSnapshot",
     "consume_fresh_allowance",
+    "forget_guild",
     "fresh_allowance_remaining",
     "is_on_cooldown",
     "mark_reply_sent",

--- a/tests/unit/services/test_ai_permission_service.py
+++ b/tests/unit/services/test_ai_permission_service.py
@@ -93,3 +93,36 @@ async def test_snapshot_zero_xp_but_real_row_is_not_fresh():
         snap = await ai_permission_service.snapshot(guild_id=1, user_id=7)
     assert snap.level == 0
     assert snap.is_fresh_user is False
+
+
+def test_forget_guild_removes_only_that_guilds_trackers():
+    """guild_lifecycle teardown must drop a departed guild's cooldown +
+    fresh-allowance entries without touching other guilds (audit P1-9 —
+    prevents unbounded dict growth + stale state on re-invite).
+    """
+    ai_permission_service._reset_for_tests()
+    # Guild 100 — two users; one also consumed a fresh-mention allowance.
+    ai_permission_service.mark_reply_sent(100, 1)
+    ai_permission_service.mark_reply_sent(100, 2)
+    ai_permission_service.consume_fresh_allowance(100, 1)
+    # Guild 200 — must survive the sweep.
+    ai_permission_service.mark_reply_sent(200, 3)
+    ai_permission_service.consume_fresh_allowance(200, 3)
+
+    removed = ai_permission_service.forget_guild(100)
+
+    # 2 cooldown rows + 1 allowance row for guild 100.
+    assert removed == 3
+    # Membership checks only — `in` does not trip the defaultdict factory.
+    assert (100, 1) not in ai_permission_service._LAST_REPLY_AT
+    assert (100, 2) not in ai_permission_service._LAST_REPLY_AT
+    assert (100, 1) not in ai_permission_service._FRESH_ALLOWANCE_USED
+    # Guild 200 untouched.
+    assert (200, 3) in ai_permission_service._LAST_REPLY_AT
+    assert (200, 3) in ai_permission_service._FRESH_ALLOWANCE_USED
+    ai_permission_service._reset_for_tests()
+
+
+def test_forget_guild_returns_zero_for_unknown_guild():
+    ai_permission_service._reset_for_tests()
+    assert ai_permission_service.forget_guild(999) == 0


### PR DESCRIPTION
## What & why

Audit finding **P1-9**. `ai_permission_service` keeps two process-local dicts keyed by `(guild_id, user_id)`:
- `_LAST_REPLY_AT` — cooldown tracker
- `_FRESH_ALLOWANCE_USED` — fresh-user mention allowance

It had no production `forget_guild` (only `_reset_for_tests`). `guild_lifecycle._teardown_ai_platform` already forgets the conversation buffers and NL policy but **not** these two, so they grew unbounded over the bot's lifetime, and a **re-invited guild inherited stale cooldown / allowance state** from before it left.

## Change

- Add `forget_guild(guild_id) -> int` to `ai_permission_service` (mirrors `ai_conversation_service.forget_guild` — sweeps both trackers, returns the count).
- Call it from `guild_lifecycle._teardown_ai_platform` alongside the existing AI-platform teardown, and update that step's docstring.

## Tests

`test_forget_guild_removes_only_that_guilds_trackers` populates two guilds, forgets one, and asserts only that guild's entries are removed from **both** dicts (membership checks, to avoid tripping the `defaultdict` factory) while the other guild survives; `test_forget_guild_returns_zero_for_unknown_guild` covers the empty case.

## Gates (CI-exact, `python3.10 -m`)

- `check_architecture.py --mode strict`: 0 errors.
- black / isort / ruff / mypy: clean.
- `pytest tests/ -q`: **6305 passed, 3 skipped**.

https://claude.ai/code/session_0174rirKZ5dtHaJSZc7kMkfP

---
_Generated by [Claude Code](https://claude.ai/code/session_0174rirKZ5dtHaJSZc7kMkfP)_