### PR TITLE
AI PR1: unblock Anthropic in the policy/settings layer

### DIFF
--- a/disbot/cogs/ai/schemas.py
+++ b/disbot/cogs/ai/schemas.py
@@ -47,9 +47,10 @@ def _validate_bool(value: object) -> None:
 
 
 def _validate_provider(value: object) -> None:
-    if value not in ("deterministic", "openai"):
+    if value not in ("deterministic", "openai", "anthropic"):
         raise ValueError(
-            f"default_provider must be 'deterministic' or 'openai', got {value!r}",
+            "default_provider must be 'deterministic', 'openai', or "
+            f"'anthropic', got {value!r}",
         )
 
 
@@ -141,10 +142,12 @@ AI_SETTINGS: tuple[SettingSpec, ...] = (
         hint=(
             "Default provider used by AI tasks that don't specify "
             "their own. 'deterministic' keeps responses local; "
-            "'openai' routes through the configured OpenAI account."
+            "'openai' / 'anthropic' route through the configured "
+            "OpenAI / Anthropic account. Leave the model empty so each "
+            "task auto-picks the right model for the provider."
         ),
         validator=_validate_provider,
-        allowed_values=("deterministic", "openai"),
+        allowed_values=("deterministic", "openai", "anthropic"),
     ),
     SettingSpec(
         name="ai_default_model",

--- a/disbot/core/runtime/ai/gateway.py
+++ b/disbot/core/runtime/ai/gateway.py
@@ -84,6 +84,29 @@ def _degraded_response(
     )
 
 
+def _model_matches_provider(provider: str, model: str) -> bool:
+    """True if ``model`` looks like it belongs to ``provider``'s family.
+
+    A crude prefix check used to catch a stored model that can't work
+    with the resolved provider — a stale cross-provider value
+    (``gpt-4o-mini`` under ``anthropic``) or a typo'd id (``sonnet-4-6``
+    instead of ``claude-sonnet-4-6``). Either 404s at the provider and
+    degrades the response.
+
+    Only the two real network providers are constrained; ``deterministic``
+    (and any unknown provider) impose no constraint — deterministic
+    ignores the model entirely. An empty model is treated as a match;
+    "auto-pick" is handled by the caller.
+    """
+    if not model:
+        return True
+    if provider == "anthropic":
+        return model.startswith("claude")
+    if provider == "openai":
+        return model.startswith("gpt")
+    return True
+
+
 async def _overlay_guild_policy(
     target: RoutingTarget,
     guild_id: int,
@@ -130,6 +153,19 @@ async def _overlay_guild_policy(
         resolved_model = default_model_for(resolved_provider, task)
     else:
         resolved_model = target.model
+    # Provider-aware safety net: a stored model that doesn't belong to the
+    # resolved provider's family (stale cross-provider value, or a typo'd
+    # id) would 404 at the provider. Fall back to the per-task default for
+    # the resolved provider rather than forwarding a model that can't work.
+    if not _model_matches_provider(resolved_provider, resolved_model):
+        logger.warning(
+            "ai gateway: guild=%s default_model=%r does not match provider "
+            "%r; using the per-task default instead",
+            guild_id,
+            resolved_model,
+            resolved_provider,
+        )
+        resolved_model = default_model_for(resolved_provider, task)
     return RoutingTarget(
         provider=resolved_provider,
         model=resolved_model,

--- a/disbot/services/ai_policy_mutation.py
+++ b/disbot/services/ai_policy_mutation.py
@@ -136,10 +136,10 @@ async def set_guild_policy(
     actor: Any,
 ) -> AIPolicyMutationResult:
     actor_id = _check_admin(actor)
-    if default_provider not in ("deterministic", "openai"):
+    if default_provider not in ("deterministic", "openai", "anthropic"):
         raise InvalidAIPolicyValueError(
-            f"default_provider must be 'deterministic' or 'openai', got "
-            f"{default_provider!r}",
+            "default_provider must be 'deterministic', 'openai', or "
+            f"'anthropic', got {default_provider!r}",
         )
     if minimum_level_default < 0:
         raise InvalidAIPolicyValueError("minimum_level_default must be >= 0")

--- a/tests/unit/cogs/ai/test_schemas.py
+++ b/tests/unit/cogs/ai/test_schemas.py
@@ -83,13 +83,24 @@ def test_ai_default_provider_is_enum_with_known_values():
     spec = _spec("ai_default_provider")
     assert spec.value_type is str
     assert spec.default == "deterministic"
-    assert spec.allowed_values == ("deterministic", "openai")
+    assert spec.allowed_values == ("deterministic", "openai", "anthropic")
+
+
+def test_ai_default_provider_validator_accepts_supported_providers():
+    """anthropic is a first-class provider (the runtime already supports
+    it via routing + AnthropicProvider); the policy/settings layer must
+    offer it too.
+    """
+    spec = _spec("ai_default_provider")
+    spec.validator("deterministic")  # type: ignore[misc]
+    spec.validator("openai")  # type: ignore[misc]
+    spec.validator("anthropic")  # type: ignore[misc]
 
 
 def test_ai_default_provider_validator_rejects_unknown_provider():
     spec = _spec("ai_default_provider")
     with pytest.raises(ValueError):
-        spec.validator("anthropic")  # type: ignore[misc]
+        spec.validator("gemini")  # type: ignore[misc]
 
 
 def test_ai_minimum_level_default_is_two_with_presets():

--- a/tests/unit/runtime/ai/test_gateway_overlay_guild_policy.py
+++ b/tests/unit/runtime/ai/test_gateway_overlay_guild_policy.py
@@ -159,6 +159,115 @@ async def test_overlay_uses_typed_model_only(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_overlay_anthropic_with_empty_model_auto_picks_claude(monkeypatch):
+    """Recommended path: provider=anthropic, model empty → the per-task
+    claude model is auto-picked (no operator model typing required).
+    """
+    from utils.db import ai as ai_db
+
+    monkeypatch.setattr(
+        ai_db,
+        "get_guild_policy",
+        AsyncMock(
+            return_value={"default_provider": "anthropic", "default_model": ""},
+        ),
+    )
+
+    result = await _overlay_guild_policy(
+        _target(),
+        guild_id=99,
+        task=AITask.BTD6_ANSWER,
+    )
+
+    assert result.provider == "anthropic"
+    assert result.model == "claude-sonnet-4-6"  # per-task anthropic default
+
+
+@pytest.mark.asyncio
+async def test_overlay_coerces_cross_provider_model_to_default(monkeypatch):
+    """A stale openai model under anthropic would 404 — coerce it to the
+    per-task claude default instead of forwarding it.
+    """
+    from utils.db import ai as ai_db
+
+    monkeypatch.setattr(
+        ai_db,
+        "get_guild_policy",
+        AsyncMock(
+            return_value={
+                "default_provider": "anthropic",
+                "default_model": "gpt-4o-mini",
+            },
+        ),
+    )
+
+    result = await _overlay_guild_policy(
+        _target(),
+        guild_id=99,
+        task=AITask.BTD6_ANSWER,
+    )
+
+    assert result.provider == "anthropic"
+    assert result.model == "claude-sonnet-4-6"
+
+
+@pytest.mark.asyncio
+async def test_overlay_coerces_typo_model_to_default(monkeypatch):
+    """A typo'd claude id (missing the ``claude-`` prefix) 404s — coerce
+    it to the per-task default rather than forwarding the typo.
+    """
+    from utils.db import ai as ai_db
+
+    monkeypatch.setattr(
+        ai_db,
+        "get_guild_policy",
+        AsyncMock(
+            return_value={
+                "default_provider": "anthropic",
+                "default_model": "sonnet-4-6",
+            },
+        ),
+    )
+
+    result = await _overlay_guild_policy(
+        _target(),
+        guild_id=99,
+        task=AITask.HELP_ANSWER,
+    )
+
+    assert result.provider == "anthropic"
+    assert result.model == "claude-haiku-4-5"  # HELP_ANSWER anthropic default
+
+
+@pytest.mark.asyncio
+async def test_overlay_coerces_claude_model_under_openai(monkeypatch):
+    """The mirror case: a claude model stored under openai is coerced to
+    the openai per-task default.
+    """
+    from utils.db import ai as ai_db
+
+    monkeypatch.setattr(
+        ai_db,
+        "get_guild_policy",
+        AsyncMock(
+            return_value={
+                "default_provider": "openai",
+                "default_model": "claude-sonnet-4-6",
+            },
+        ),
+    )
+
+    result = await _overlay_guild_policy(
+        _target(),
+        guild_id=99,
+        task=AITask.SETUP_SUGGEST,
+    )
+
+    assert result.provider == "openai"
+    assert result.model == "gpt-4o-mini"
+
+
+@pytest.mark.asyncio
 async def test_overlay_swallows_db_failure(monkeypatch):
     """A DB read failure must NOT raise — gateway contract requires
     ``execute`` to never propagate exceptions to callers.

--- a/tests/unit/services/test_ai_policy_mutation_provider_allowlist.py
+++ b/tests/unit/services/test_ai_policy_mutation_provider_allowlist.py
@@ -1,0 +1,79 @@
+"""AI provider unblock — set_guild_policy must accept 'anthropic'.
+
+The runtime already supports Anthropic (routing has per-task claude
+defaults; the gateway registers AnthropicProvider). The policy/settings
+layer was the only thing blocking it: the mutation chokepoint rejected
+any provider other than deterministic/openai, so a guild could never be
+switched to Claude. These tests pin that anthropic is now a first-class
+provider and that genuinely-unknown providers are still rejected.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from services import ai_policy_mutation
+from services.ai_policy_mutation import InvalidAIPolicyValueError
+from utils.db import ai as ai_db
+
+
+def _admin_actor(actor_id: int = 555):
+    return SimpleNamespace(
+        id=actor_id,
+        guild_permissions=SimpleNamespace(administrator=True),
+    )
+
+
+def _patch_db(monkeypatch):
+    monkeypatch.setattr(ai_db, "upsert_guild_policy", AsyncMock(return_value=1))
+    monkeypatch.setattr(ai_db, "bump_generation", AsyncMock(return_value=1))
+    monkeypatch.setattr(ai_policy_mutation, "_emit", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        "services.ai_natural_language_policy.invalidate", lambda _gid: None,
+    )
+
+
+async def _set(monkeypatch, provider: str, model: str = ""):
+    _patch_db(monkeypatch)
+    return await ai_policy_mutation.set_guild_policy(
+        guild_id=11,
+        enabled=True,
+        natural_language_enabled=True,
+        default_provider=provider,
+        default_model=model,
+        minimum_level_default=2,
+        cooldown_seconds=30,
+        fresh_user_mention_allowance=1,
+        guild_instruction_profile_id=None,
+        actor=_admin_actor(),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["deterministic", "openai", "anthropic"])
+async def test_set_guild_policy_accepts_supported_providers(monkeypatch, provider):
+    result = await _set(monkeypatch, provider)
+    assert result.table == "ai_guild_policy"
+    # The provider value was forwarded to the DB write unchanged.
+    ai_db.upsert_guild_policy.assert_awaited_once()
+    assert ai_db.upsert_guild_policy.await_args.kwargs["default_provider"] == provider
+
+
+@pytest.mark.asyncio
+async def test_set_guild_policy_rejects_unknown_provider(monkeypatch):
+    _patch_db(monkeypatch)
+    with pytest.raises(InvalidAIPolicyValueError, match="anthropic"):
+        await _set(monkeypatch, "gemini")
+
+
+@pytest.mark.asyncio
+async def test_set_guild_policy_anthropic_with_empty_model_is_allowed(monkeypatch):
+    """The recommended path — provider=anthropic, model empty (the gateway
+    auto-picks the per-task claude model) — must be accepted.
+    """
+    result = await _set(monkeypatch, "anthropic", model="")
+    assert result.table == "ai_guild_policy"
+    assert ai_db.upsert_guild_policy.await_args.kwargs["default_model"] == ""


### PR DESCRIPTION
## What & why

`docs/ai-provider-and-grounding-fix-plan.md` **PR1** (the highest-value item — unblocks the live bot from `gpt-4o-mini`). The runtime **already fully supports Anthropic**: `routing.py` has per-task Claude defaults (`claude-sonnet-4-6` / `claude-haiku-4-5`) and the gateway registers `AnthropicProvider`. But the **policy/settings layer** hard-coded an allowlist of only `{deterministic, openai}`, so the `!ai` provider dropdown could never offer Claude and the mutation chokepoint rejected it.

## Change

- **`cogs/ai/schemas.py`** — add `"anthropic"` to `_validate_provider` + `allowed_values`; clarify the hint (leave model empty to auto-pick).
- **`services/ai_policy_mutation.set_guild_policy`** — accept `"anthropic"` (still rejects genuinely-unknown providers).
- **`core/runtime/ai/gateway._overlay_guild_policy`** — provider-aware model safety net. A stored `default_model` that doesn't match the resolved provider's family — a stale cross-provider value (`gpt-*` under anthropic) or a typo'd id (`sonnet-4-6` vs `claude-sonnet-4-6`) — would 404 and degrade. Coerce it to the per-task default for the resolved provider instead.

## Why the model check is at the gateway, not a `set_guild_policy` rejection

`set_guild_policy` is reached **only** via `project_from_legacy_settings` (the UI writes scalars, then projects). A hard rejection there would make a UI provider-switch **silently fail** (scalar=anthropic but typed row stays openai → drift) — defeating PR1's whole point. The gateway overlay is the last line before the API call and fixes the mismatch without drift. (This is a deliberate refinement of the plan's "reject non-claude ids" — same intent, drift-free realization.)

**Recommended operator path:** set provider=anthropic, leave model **empty** → each task auto-picks the right claude model. Precedence unchanged: guild policy overrides env.

## Tests

- Schema accepts anthropic / rejects unknown (**updated the two tests that pinned the old `{deterministic, openai}` allowlist**).
- `set_guild_policy` accepts all three providers + rejects bogus + accepts anthropic-with-empty-model.
- Overlay: empty model auto-picks claude; cross-provider + typo'd models coerce to the per-task default **both ways** (anthropic↔openai). All existing overlay tests still pass.

## Gates (CI-exact, `python3.10 -m`)

- `check_architecture.py --mode strict`: 0 errors.
- black / isort / ruff / mypy: clean.
- `pytest tests/ -q`: **6313 passed, 3 skipped**.

## Follow-ups (per the plan)

PR2 (decouple BTD6 grounding from the keyword router) and PR3 (coverage + self-knowledge) are separate branches.

https://claude.ai/code/session_0174rirKZ5dtHaJSZc7kMkfP

---
_Generated by [Claude Code](https://claude.ai/code/session_0174rirKZ5dtHaJSZc7kMkfP)_