### PR TITLE
AI PR2: re-widen BTD6 router keywords (grounding-gating regression)

### DIFF
--- a/disbot/services/ai_task_router.py
+++ b/disbot/services/ai_task_router.py
@@ -44,11 +44,30 @@ def _has_question_intent(text: str) -> bool:
 #
 # Curated to avoid over-routing: bare "event" / "active" / "right now" /
 # "leaderboard" / "stale" must NOT be here (they'd over-route server events,
-# "is the bot active", XP leaderboard, etc.). Individual hero names are omitted
-# on purpose — the entity-alias matcher below already covers them. The live-
+# "is the bot active", XP leaderboard, etc.). Most hero names are omitted on
+# purpose — the entity-alias matcher below already covers them. The live-
 # state phrases (current/what/active boss/race/event/odyssey) are pinned by
 # tests/unit/services/test_ai_task_router_btd6_natural.py because they also gate
 # the richer enrichment in services.btd6_ai_knowledge_block_service.
+#
+# Specific entries below are explicit because the entity-alias matcher provably
+# misses them (verified against the dataset):
+#   * "obyn"      — the hero is "Obyn Greenfoot"; the bare "obyn" alias is 4
+#                   chars and dropped by the matcher's ``len(al) > 4`` filter.
+#   * "desperado" — a real tower, but the matcher skips single-word tower names
+#                   as too generic, so "desperado" alone never matched.
+#   * "impoppable" / "half cash" — difficulty / mode tokens (same class as
+#                   "deflation" / "apopalypse" already here) that route a clear
+#                   BTD6 question to auto-grounding.
+# "paragon" is deliberately NOT here — it is legitimate English ("a paragon of
+# virtue") so a bare substring would over-route; paragon questions usually name
+# a tower ("paragon dart monkey" → "monkey") or fall to the tool path.
+# NOTE: multi-word upgrade and paragon *proper names* (e.g. "grand saboteur",
+# "apex plasma master") are still not in the fast-path — many upgrade names are
+# generic ("triple shot", "quick shots") so loading them wholesale would
+# over-route. Those questions rely on the model's ``btd6_lookup`` tool call
+# (reliable on Claude after AI PR1); a curated distinctive-name pass is a
+# follow-up.
 _BTD6_KEYWORDS = (
     "btd6",
     "bloons",
@@ -65,6 +84,8 @@ _BTD6_KEYWORDS = (
     "freeplay",
     "deflation",
     "apopalypse",
+    "impoppable",
+    "half cash",
     "primary only",
     "military only",
     "magic only",
@@ -86,6 +107,8 @@ _BTD6_KEYWORDS = (
     "race ",
     "banned hero",
     "banned tower",
+    "obyn",
+    "desperado",
 )
 
 

--- a/tests/unit/services/test_ai_task_router_btd6_natural.py
+++ b/tests/unit/services/test_ai_task_router_btd6_natural.py
@@ -108,3 +108,49 @@ def test_generic_words_do_not_over_route(text):
     assert (
         decision.task is AITask.GENERAL_NL_ANSWER
     ), f"{text!r} routed to {decision.task!r} instead of GENERAL_NL_ANSWER"
+
+
+@pytest.mark.parametrize(
+    "text",
+    # Distinctive BTD6 terms the entity-alias matcher provably MISSES, so
+    # they fell through to GENERAL_NL_ANSWER (no grounding) — the AI PR2
+    # grounding-gating regression. Verified against the dataset:
+    #   * "obyn"      — hero "Obyn Greenfoot"; bare 4-char alias dropped by
+    #                   the matcher's len(al) > 4 filter.
+    #   * "desperado" — a real tower; single-word tower names are skipped.
+    #   * impoppable / half cash — difficulty / mode.
+    [
+        "how do I use obyn",
+        "is obyn good on chimps",
+        "is desperado a sniper upgrade",
+        "tell me about desperado",
+        "impoppable tips",
+        "half cash strategy",
+    ],
+)
+def test_rewidened_btd6_terms_route_to_answer(text):
+    """Re-widen #388's over-slim: these route back to BTD6_ANSWER so the
+    grounding context is injected even when the model doesn't call the
+    btd6_lookup tool.
+    """
+    decision = ai_task_router.classify(text)
+    assert (
+        decision.task is AITask.BTD6_ANSWER
+    ), f"{text!r} routed to {decision.task!r} instead of BTD6_ANSWER"
+
+
+@pytest.mark.parametrize(
+    "text",
+    # The re-widened terms must not over-route nearby general chatter.
+    # "paragon" was deliberately left OUT of the keyword set precisely so
+    # this legitimate English usage stays general.
+    [
+        "she is a paragon of virtue",
+        "i only have half my cash left",  # not the exact 'half cash' phrase
+    ],
+)
+def test_rewidened_terms_do_not_over_route_general_chat(text):
+    decision = ai_task_router.classify(text)
+    assert (
+        decision.task is AITask.GENERAL_NL_ANSWER
+    ), f"{text!r} routed to {decision.task!r} instead of GENERAL_NL_ANSWER"


### PR DESCRIPTION
## What & why

`docs/ai-provider-and-grounding-fix-plan.md` **PR2**. BTD6 grounding only runs when `ai_task_router` routes a message to `AITask.BTD6_ANSWER` (`natural_language_stage._gather_feature_facts` gates `btd6_context_service.build` on it). PR #388 slimmed `_BTD6_KEYWORDS` on the theory the model self-fetches via the `btd6_lookup` tool — but `gpt-4o-mini` doesn't reliably call tools, so those questions routed to `general.nl_answer` with **no grounding injected**.

## Verified against the dataset (not from memory)

I checked which terms #388 removed actually fall through:
- `psi` / `ezili` / `geraldo` / `etienne` **are** caught by the entity-alias matcher → route to BTD6_ANSWER correctly (**no regression there** — the plan was partly mistaken).
- Provably **missed**:
  - **`obyn`** — hero "Obyn Greenfoot"; the bare 4-char alias is dropped by the matcher's `len(al) > 4` filter.
  - **`desperado`** — a real tower (confirmed in the dataset), but single-word tower names are skipped by the matcher as "too generic".
  - **`impoppable` / `half cash`** — difficulty / mode tokens, same class as `deflation` / `apopalypse` already in the list.

## Change

Re-add those **four** to `_BTD6_KEYWORDS`. **`paragon` deliberately left out** — it's legitimate English ("a paragon of virtue") and a bare substring would over-route; paragon questions usually name a tower (`paragon dart monkey` → `monkey`) or fall to the tool path.

## Tests

- Pin the four route to BTD6_ANSWER.
- Over-route guards: `"she is a paragon of virtue"` and `"i only have half my cash left"` stay general.
- All existing router pins (boss/race/event live-state, entity-name, generic-word guards) still pass.

## Deliberately deferred + noted (not this PR)

- **Multi-word upgrade/paragon proper names** (`grand saboteur`, `apex plasma master`) — verified `grand saboteur`/`tech terror` exist in `upgrade_paths`, but many upgrade names are generic (`triple shot`, `quick shots`), so loading them wholesale would over-route. Needs a curated distinctive-name pass. **Claude's `btd6_lookup` tool (reliable after AI PR1) is the primary grounding path for these.**
- **Eval cases** (`tests/evals`) and the **"two contradictory answers" double-reply** investigation — separate follow-ups; eval expectations need per-fact data verification.

## Gates (CI-exact, `python3.10 -m`)

- `check_architecture.py --mode strict`: 0 errors.
- black / ruff / mypy: clean.
- `pytest tests/ -q`: **6311 passed, 3 skipped**.

https://claude.ai/code/session_0174rirKZ5dtHaJSZc7kMkfP

---
_Generated by [Claude Code](https://claude.ai/code/session_0174rirKZ5dtHaJSZc7kMkfP)_