### PR TITLE
AI PR3: assert SuperBot identity in the system prompt

### DIFF
--- a/disbot/services/ai_instruction_service.py
+++ b/disbot/services/ai_instruction_service.py
@@ -40,7 +40,13 @@ _SYSTEM_SAFETY = (
 
 _BOT_AI_POLICY = (
     "Persona: helpful, terse, factual. Cite source and freshness when"
-    " producing factual answers. Refuse politely when policy denies."
+    " producing factual answers. Refuse politely when policy denies.\n"
+    "Identity: you are SuperBot, a Discord bot for this server. If asked"
+    " who or what you are, who made or created you, or which AI/model you"
+    " are, answer as SuperBot. Do not claim to be ChatGPT or Claude, and"
+    " do not say you were created by OpenAI, Anthropic, Google, or any"
+    " other model vendor. You may note in general terms that you run on a"
+    " large language model, but your name and identity are SuperBot."
 )
 
 _TASK_CONTRACT = (

--- a/tests/unit/services/test_ai_instruction_identity.py
+++ b/tests/unit/services/test_ai_instruction_identity.py
@@ -1,0 +1,41 @@
+"""SuperBot identity must be asserted in the AI system prompt.
+
+Live testing showed the bot answering "I was created by OpenAI" when
+asked who/what it is. The system prompt named the bot ("You are
+SuperBot") but never told the model to override its training-based
+vendor attribution, so identity questions leaked the underlying model's
+maker. These tests pin the explicit identity guard so the leak can't
+silently return.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from services import ai_instruction_service
+
+
+def test_bot_ai_policy_asserts_superbot_identity_over_model_vendor():
+    policy = ai_instruction_service._BOT_AI_POLICY
+    assert "SuperBot" in policy
+    # The model must not attribute itself to its training vendor / product.
+    flattened = policy.replace("\n", " ")
+    assert "OpenAI" in flattened
+    assert "Anthropic" in flattened
+    assert "ChatGPT" in flattened or "Claude" in flattened
+
+
+@pytest.mark.asyncio
+async def test_assembled_system_prompt_carries_identity_guard():
+    """Every turn's system prompt (built by assemble) carries the identity
+    guard — assemble always includes _BOT_AI_POLICY in the system layer.
+    """
+    stack = await ai_instruction_service.assemble(
+        guild_id=1,
+        user_message="who created you?",
+        profile_ids=(),
+    )
+    sys_prompt = stack.render_system_prompt()
+    assert "SuperBot" in sys_prompt
+    assert "OpenAI" in sys_prompt
+    assert "Anthropic" in sys_prompt


### PR DESCRIPTION
## What & why

`docs/ai-provider-and-grounding-fix-plan.md` **PR3 — identity slice (item 5)**. Live testing showed the bot answering *"I was created by OpenAI"* when asked who/what it is. The system prompt named the bot (`"You are SuperBot"`) but never told the model to override its **training-based vendor attribution**, so identity questions leaked the underlying model's maker — and would leak *"Claude / Anthropic"* once switched via AI PR1.

## Change

Add an explicit identity guard to `_BOT_AI_POLICY` (always included in the system layer by `assemble()`): when asked who/what it is, who made it, or which model it is, the bot answers as **SuperBot** and must not claim to be ChatGPT/Claude or made by OpenAI/Anthropic/Google. It may note in general terms that it runs on an LLM, but its identity is SuperBot.

## Tests

Pin the guard at the constant level and in the assembled system prompt (`assemble(profile_ids=())` does no DB I/O). The `_TASK_CONTRACT` BTD6-discipline pins are unaffected.

## Other PR3 items — scoped out (separate follow-ups), assessed

Per "keep PRs small and single-purpose" + "leave large/ambiguous work and note it":

- **Ability sub-stats ingestion** (uptime/crit/DoT) + **RBE data** — data-pipeline work (`scripts/fetch_bloonswiki.py` + `data/btd6/bloons.json`); larger, needs careful scraping + per-fact verification.
- **"what are the AI commands" returns BTD6 commands** — command-catalog subsystem-scoping bug; needs tracing `bot_knowledge_service` retrieval/filtering before a safe fix.
- **Verify `btd6_superlative_lookup` limit (#392) + hunt other hard 3-caps** — verification + possible small fix.

## Gates (CI-exact, `python3.10 -m`)

- `check_architecture.py --mode strict`: 0 errors.
- black / ruff / mypy: clean.
- `pytest tests/ -q`: **6305 passed, 3 skipped**.

https://claude.ai/code/session_0174rirKZ5dtHaJSZc7kMkfP

---
_Generated by [Claude Code](https://claude.ai/code/session_0174rirKZ5dtHaJSZc7kMkfP)_