### PR TITLE
Fix wrong command prefix in chain_cog (?chain → !chain) (audit §9.9)

### DIFF
--- a/disbot/cogs/chain_cog.py
+++ b/disbot/cogs/chain_cog.py
@@ -70,7 +70,7 @@ class ChainCog(commands.Cog):
         Use subcommands to create, delete, set limits, or list chains.
         """
         await ctx.send(
-            "❓ Please specify a subcommand. Use `?chain create`, `?chain delete`, `?chain setlimit`, `?chain removelimit`, or `?chain list`.",
+            "❓ Please specify a subcommand. Use `!chain create`, `!chain delete`, `!chain setlimit`, `!chain removelimit`, or `!chain list`.",
         )
 
     @chain.command(name="create")  # type: ignore[arg-type]
@@ -86,11 +86,11 @@ class ChainCog(commands.Cog):
 
         Only the specified word will be allowed in that channel. All other messages will be deleted.
 
-        **Usage:** `?chain create [channel] <word>`
+        **Usage:** `!chain create [channel] <word>`
         """
         if word is None:
             await ctx.send(
-                "❌ Please specify the word to enforce in the chain.\n**Usage:** `?chain create [channel] <word>`",
+                "❌ Please specify the word to enforce in the chain.\n**Usage:** `!chain create [channel] <word>`",
             )
             return
 
@@ -126,7 +126,7 @@ class ChainCog(commands.Cog):
     async def delete_chain(self, ctx, channel: discord.TextChannel = None):
         """Delete a chain from a specified channel or the current channel if none is provided.
 
-        **Usage:** `?chain delete [channel]`
+        **Usage:** `!chain delete [channel]`
         """
         target_channel = channel or ctx.channel
         channel_id = target_channel.id
@@ -163,11 +163,11 @@ class ChainCog(commands.Cog):
     ):
         """Set a word limit in a specified channel or the current channel if none is provided.
 
-        **Usage:** `?chain setlimit [channel] <number>`
+        **Usage:** `!chain setlimit [channel] <number>`
         """
         if limit is None or limit <= 0:
             await ctx.send(
-                "❌ Please specify a valid word limit greater than 0.\n**Usage:** `?chain setlimit [channel] <number>`",
+                "❌ Please specify a valid word limit greater than 0.\n**Usage:** `!chain setlimit [channel] <number>`",
             )
             return
 
@@ -177,7 +177,7 @@ class ChainCog(commands.Cog):
         existing = await db.get_chain_channel(channel_id)
         if not existing:
             await ctx.send(
-                f"❌ No active chain found in {target_channel.mention}. Create one first with `?chain create`.",
+                f"❌ No active chain found in {target_channel.mention}. Create one first with `!chain create`.",
             )
             return
 
@@ -205,7 +205,7 @@ class ChainCog(commands.Cog):
     async def remove_limit(self, ctx, channel: discord.TextChannel = None):
         """Remove the word limit from a specified channel or the current channel if none is provided.
 
-        **Usage:** `?chain removelimit [channel]`
+        **Usage:** `!chain removelimit [channel]`
         """
         target_channel = channel or ctx.channel
         channel_id = target_channel.id
@@ -254,7 +254,7 @@ class ChainCog(commands.Cog):
     async def list_chains(self, ctx):
         """List all active chains and word limits in the server.
 
-        **Usage:** `?chain list`
+        **Usage:** `!chain list`
         """
         channels = await db.get_all_chain_channels(ctx.guild.id)
 

--- a/tests/unit/cogs/test_chain_cog_prefix.py
+++ b/tests/unit/cogs/test_chain_cog_prefix.py
@@ -1,0 +1,20 @@
+"""Chain cog must show the bot's real prefix (``!``) in usage text.
+
+Regression (audit §9.9): ``chain_cog`` hard-coded ``?chain`` in 9 usage
+strings and command docstrings while the bot prefix is ``!``
+(``config.PREFIX`` default), so every chain help/usage line told users to
+type a command that does not work. The convention across the codebase is
+a hard-coded ``!`` (``!platform``, ``!setup``, …); this pins chain to it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_CHAIN_COG = Path(__file__).resolve().parents[3] / "disbot" / "cogs" / "chain_cog.py"
+
+
+def test_chain_cog_uses_bang_prefix_not_question_mark():
+    src = _CHAIN_COG.read_text(encoding="utf-8")
+    assert "?chain" not in src, "chain_cog must not show the wrong '?' prefix"
+    assert "!chain" in src, "chain_cog usage strings should reference !chain"


### PR DESCRIPTION
## What & why

Audit finding **§9.9 / P2**. `chain_cog` hard-coded `?chain` in **9** user-facing usage strings and command docstrings, but the bot prefix is `!` (`config.PREFIX` defaults to `!`). Every chain help/usage line told users to type a command that doesn't work.

Verified: `config.py` → `PREFIX = os.getenv("BOT_PREFIX", "!")`; the codebase convention is a hard-coded `!` in these strings (29 `!platform`, 13 `!setup`, 13 `!btd`, …) rather than dynamic `config.PREFIX`. So `?chain` → `!chain` matches the established convention.

## Change

- Replace all 9 `?chain` → `!chain`.
- Add a source-level regression pin (`chain` is one of the audit's "18 cog entry-points with zero dedicated tests").

## Gates (CI-exact, `python3.10 -m`)

- `check_architecture.py --mode strict`: 0 errors.
- black / ruff: clean.
- `pytest tests/ -q`: **6304 passed, 3 skipped**.

https://claude.ai/code/session_0174rirKZ5dtHaJSZc7kMkfP

---
_Generated by [Claude Code](https://claude.ai/code/session_0174rirKZ5dtHaJSZc7kMkfP)_