### PR TITLE
AI PR3: scope the command catalog by subsystem (item 2)

### DIFF
--- a/disbot/services/bot_knowledge_service.py
+++ b/disbot/services/bot_knowledge_service.py
@@ -213,19 +213,32 @@ def _command_catalog_block(user_tier: str) -> BotKnowledgeBlock | None:
     if not visible:
         return None
 
+    # Group by subsystem before the entry cap so a "what are the <subsystem>
+    # commands?" question sees a coherent run (and so an alphabetically-early
+    # subsystem like "ai" survives the _MAX_CATALOG_ENTRIES cap rather than
+    # being truncated out behind, e.g., the BTD6 entries). The per-line
+    # [subsystem] tag below then lets the model filter — previously the
+    # rendered lines dropped the subsystem entirely, so the model could not
+    # tell, e.g., AI commands from BTD6 ones.
+    visible.sort(key=lambda e: ((e.subsystem or "").lower(), e.display_name or ""))
+
     n_visible = len(visible)
     truncated = False
     if n_visible > _MAX_CATALOG_ENTRIES:
         visible = visible[:_MAX_CATALOG_ENTRIES]
         truncated = True
 
-    header = "Commands you can ask about (filtered by your access):"
+    header = (
+        "Commands you can ask about (filtered by your access). Each line is"
+        " tagged with its [subsystem] — use that tag to answer questions about"
+        " a specific subsystem's commands:"
+    )
     lines: list[str] = []
     total_chars = len(header)
     for entry in visible:
         sig = f" {entry.signature}" if entry.signature else ""
         desc = entry.description or "(no description)"
-        line = f"- {entry.display_name}{sig} — {desc}"
+        line = f"- [{entry.subsystem}] {entry.display_name}{sig} — {desc}"
         if total_chars + len(line) + 1 > _MAX_CATALOG_CHARS:
             truncated = True
             break

--- a/tests/unit/services/test_bot_knowledge_service.py
+++ b/tests/unit/services/test_bot_knowledge_service.py
@@ -295,6 +295,61 @@ async def test_catalog_administrator_does_not_see_owner_tier(monkeypatch) -> Non
 
 
 @pytest.mark.asyncio
+async def test_catalog_lines_carry_subsystem_tag(monkeypatch) -> None:
+    """Each catalog line is tagged [subsystem] so the model can answer
+    'what are the <subsystem> commands?' — previously the rendered lines
+    dropped the subsystem entirely (AI PR3 item 2).
+    """
+    _install_catalog(
+        monkeypatch,
+        (
+            _entry("aichat", subsystem="ai"),
+            _entry("btdstats", subsystem="btd6"),
+        ),
+    )
+
+    block = (
+        await bot_knowledge_service.gather(
+            guild_id=1,
+            channel_id=2,
+            user_id=3,
+            user_text="what commands are there",
+            user_tier="user",
+            accessible_channel_ids=frozenset(),
+        )
+    )[0]
+    assert "[ai] !aichat" in block.text
+    assert "[btd6] !btdstats" in block.text
+
+
+@pytest.mark.asyncio
+async def test_catalog_groups_by_subsystem_so_early_subsystem_survives_cap(
+    monkeypatch,
+) -> None:
+    """With more than the entry cap of commands, grouping by subsystem keeps
+    an alphabetically-early subsystem ('ai') in the block instead of it being
+    truncated out behind a flood of later-subsystem entries.
+    """
+    entries = (_entry("aichat", subsystem="ai"),) + tuple(
+        _entry(f"btd{i}", subsystem="btd6") for i in range(60)
+    )
+    _install_catalog(monkeypatch, entries)
+
+    block = (
+        await bot_knowledge_service.gather(
+            guild_id=1,
+            channel_id=2,
+            user_id=3,
+            user_text="what are the ai commands",
+            user_tier="user",
+            accessible_channel_ids=frozenset(),
+        )
+    )[0]
+    # 'ai' sorts before 'btd6', so the single AI command must survive the cap.
+    assert "[ai] !aichat" in block.text
+
+
+@pytest.mark.asyncio
 async def test_unknown_caller_tier_defaults_to_user_does_not_raise(
     monkeypatch,
 ) -> None:
@@ -384,7 +439,8 @@ async def test_catalog_truncates_at_entry_cap(monkeypatch) -> None:
             accessible_channel_ids=frozenset(),
         )
     )[0]
-    visible_count = block.text.count("\n- !cmd")
+    # Lines are now "- [economy] !cmdNNN — …" (subsystem-tagged).
+    visible_count = block.text.count("] !cmd")
     assert visible_count == 40
     assert "40 of 60" in block.text
 


### PR DESCRIPTION
## What & why

`docs/ai-provider-and-grounding-fix-plan.md` **PR3 — item 2**. Live testing: *"what are the AI commands"* returned **BTD6** commands. The `bot_command_catalog` block fed to the model rendered each command as `- <name> — <desc>` with **no subsystem tag**, even though every catalog entry carries `entry.subsystem`. So the model had no way to tell AI commands from BTD6 ones. Worse, the block is capped at **40 entries in registration order**, so a whole subsystem's commands could be truncated out entirely.

## Change (`_command_catalog_block`)

- **Sort** visible entries by `(subsystem, display_name)` *before* the entry cap — groups each subsystem's commands together, and keeps an alphabetically-early subsystem (e.g. `ai`) in the block instead of it being dropped behind a flood of later entries.
- **Tag** each line `- [subsystem] <name> — <desc>`, with a header telling the model the `[subsystem]` tag is how to answer "what are the `<subsystem>` commands?".

## Tests

- Lines carry the `[subsystem]` tag (`[ai] !aichat`, `[btd6] !btdstats`).
- An early-sorting subsystem survives the 40-entry cap even behind 60 later-subsystem entries.
- Updated the truncation test for the new tagged line format. Existing tier/visibility pins unaffected (substring-presence based).

## Gates (CI-exact, `python3.10 -m`)

- `check_architecture.py --mode strict`: 0 errors.
- black / ruff / mypy: clean.
- `pytest tests/ -q`: **6305 passed, 3 skipped**.

https://claude.ai/code/session_0174rirKZ5dtHaJSZc7kMkfP

---
_Generated by [Claude Code](https://claude.ai/code/session_0174rirKZ5dtHaJSZc7kMkfP)_