### PR TITLE
Ground BTD6 paragon names (fetch + data + AI surfacing)

### DIFF
--- a/disbot/data/btd6/stats/bomb_shooter.json
+++ b/disbot/data/btd6/stats/bomb_shooter.json
@@ -6,6 +6,7 @@
   "base_cost": 375,
   "category": "primary",
   "paragon_cost": 600000,
+  "paragon_name": "Ballistic Obliteration Missile Bunker",
   "upgrades": [
     {
       "path": 1,

--- a/disbot/data/btd6/stats/boomerang_monkey.json
+++ b/disbot/data/btd6/stats/boomerang_monkey.json
@@ -6,6 +6,7 @@
   "base_cost": 315,
   "category": "primary",
   "paragon_cost": 375000,
+  "paragon_name": "Glaive Dominus",
   "upgrades": [
     {
       "path": 1,

--- a/disbot/data/btd6/stats/dart_monkey.json
+++ b/disbot/data/btd6/stats/dart_monkey.json
@@ -6,6 +6,7 @@
   "base_cost": 200,
   "category": "primary",
   "paragon_cost": 150000,
+  "paragon_name": "Apex Plasma Master",
   "upgrades": [
     {
       "path": 1,

--- a/disbot/data/btd6/stats/druid.json
+++ b/disbot/data/btd6/stats/druid.json
@@ -6,6 +6,7 @@
   "base_cost": 400,
   "category": "magic",
   "paragon_cost": 475000,
+  "paragon_name": "Root of all Nature",
   "upgrades": [
     {
       "path": 1,

--- a/disbot/data/btd6/stats/engineer_monkey.json
+++ b/disbot/data/btd6/stats/engineer_monkey.json
@@ -6,6 +6,7 @@
   "base_cost": 350,
   "category": "support",
   "paragon_cost": 650000,
+  "paragon_name": "Master Builder",
   "upgrades": [
     {
       "path": 1,

--- a/disbot/data/btd6/stats/ice_monkey.json
+++ b/disbot/data/btd6/stats/ice_monkey.json
@@ -6,6 +6,7 @@
   "base_cost": 400,
   "category": "primary",
   "paragon_cost": 300000,
+  "paragon_name": "Herald of Everfrost",
   "upgrades": [
     {
       "path": 1,

--- a/disbot/data/btd6/stats/monkey_ace.json
+++ b/disbot/data/btd6/stats/monkey_ace.json
@@ -6,6 +6,7 @@
   "base_cost": 800,
   "category": "military",
   "paragon_cost": 900000,
+  "paragon_name": "Goliath Doomship",
   "upgrades": [
     {
       "path": 1,

--- a/disbot/data/btd6/stats/monkey_buccaneer.json
+++ b/disbot/data/btd6/stats/monkey_buccaneer.json
@@ -6,6 +6,7 @@
   "base_cost": 400,
   "category": "military",
   "paragon_cost": 550000,
+  "paragon_name": "Navarch of the Seas",
   "upgrades": [
     {
       "path": 1,

--- a/disbot/data/btd6/stats/monkey_sub.json
+++ b/disbot/data/btd6/stats/monkey_sub.json
@@ -6,6 +6,7 @@
   "base_cost": 325,
   "category": "military",
   "paragon_cost": 400000,
+  "paragon_name": "Nautic Siege Core",
   "upgrades": [
     {
       "path": 1,

--- a/disbot/data/btd6/stats/ninja_monkey.json
+++ b/disbot/data/btd6/stats/ninja_monkey.json
@@ -6,6 +6,7 @@
   "base_cost": 400,
   "category": "magic",
   "paragon_cost": 500000,
+  "paragon_name": "Ascended Shadow",
   "upgrades": [
     {
       "path": 1,

--- a/disbot/data/btd6/stats/spike_factory.json
+++ b/disbot/data/btd6/stats/spike_factory.json
@@ -6,6 +6,7 @@
   "base_cost": 1000,
   "category": "support",
   "paragon_cost": 750000,
+  "paragon_name": "Mega Massive Munitions Factory",
   "upgrades": [
     {
       "path": 1,

--- a/disbot/data/btd6/stats/tack_shooter.json
+++ b/disbot/data/btd6/stats/tack_shooter.json
@@ -6,6 +6,7 @@
   "base_cost": 260,
   "category": "primary",
   "paragon_cost": 200000,
+  "paragon_name": "Crucible of Steel and Flame",
   "upgrades": [
     {
       "path": 1,

--- a/disbot/data/btd6/stats/wizard_monkey.json
+++ b/disbot/data/btd6/stats/wizard_monkey.json
@@ -6,6 +6,7 @@
   "base_cost": 250,
   "category": "magic",
   "paragon_cost": 800000,
+  "paragon_name": "Magus Perfectus",
   "upgrades": [
     {
       "path": 1,

--- a/disbot/services/btd6_context_service.py
+++ b/disbot/services/btd6_context_service.py
@@ -325,8 +325,30 @@ def _render_fixture_tower(entry: Any) -> list[str]:
             ),
         )
 
+    lines.extend(_render_paragon(getattr(entry, "id", ""), canonical))
     lines.extend(_render_tower_stats(getattr(entry, "id", ""), canonical))
     return lines
+
+
+def _render_paragon(tower_id: str, canonical: str) -> list[str]:
+    """One grounding line naming this tower's Paragon (tier 6) + Medium cost.
+
+    Returns nothing for the towers that have no paragon. Tagged
+    ``[btd6_paragon]`` so the assistant uses the verified name instead of
+    guessing one (or claiming a paragon for a tower that has none).
+    """
+    from services import btd6_stats_service
+
+    stats = btd6_stats_service.get_tower_stats(tower_id)
+    if stats is None or not stats.paragon_cost:
+        return []
+    name = stats.paragon_name or f"{canonical} Paragon"
+    return [
+        _cap(
+            f"[btd6_paragon] {canonical}'s Paragon (tier 6) is {name}, costing "
+            f"{stats.paragon_cost} on Medium (source: bloonswiki)",
+        ),
+    ]
 
 
 def _render_tower_stats(tower_id: str, canonical: str) -> list[str]:

--- a/disbot/services/btd6_stats_service.py
+++ b/disbot/services/btd6_stats_service.py
@@ -58,6 +58,7 @@ class TowerStats:
     base_cost: int | None
     category: str | None
     paragon_cost: int | None
+    paragon_name: str | None
     upgrades: tuple[dict[str, Any], ...]
     tiers: dict[str, dict[str, Any]]
 
@@ -119,6 +120,7 @@ def _load(tower_id: str) -> TowerStats | None:
         base_cost=data.get("base_cost"),
         category=data.get("category"),
         paragon_cost=data.get("paragon_cost"),
+        paragon_name=data.get("paragon_name"),
         upgrades=tuple(data.get("upgrades", ())),
         tiers=data.get("tiers", {}),
     )

--- a/disbot/services/btd6_superlative_service.py
+++ b/disbot/services/btd6_superlative_service.py
@@ -62,10 +62,15 @@ def _paragon_rows() -> list[SuperlativeHit]:
     for tower in btd6_data_service.get_dataset().towers:
         stats = btd6_stats_service.get_tower_stats(tower.id)
         if stats is not None and stats.paragon_cost:
+            label = (
+                f"{stats.paragon_name} ({tower.canonical} Paragon)"
+                if stats.paragon_name
+                else f"{tower.canonical} Paragon"
+            )
             rows.append(
                 SuperlativeHit(
                     cost=int(stats.paragon_cost),
-                    what=f"{tower.canonical} Paragon",
+                    what=label,
                     tower_id=tower.id,
                 ),
             )

--- a/scripts/fetch_bloonswiki.py
+++ b/scripts/fetch_bloonswiki.py
@@ -119,6 +119,7 @@ class TowerData:
     base_cost: int | None = None
     category: str | None = None
     paragon_cost: int | None = None
+    paragon_name: str | None = None
     upgrades: list[dict] = field(default_factory=list)
     tiers: dict[str, dict] = field(default_factory=dict)
     game_version: str = ""
@@ -159,9 +160,10 @@ def fetch_tower(tower_id: str, canonical: str, *, delay: float) -> TowerData:
         )
     time.sleep(delay)
 
-    paragons = _cargo_query("btd6_paragons", "cost", f"tower='{safe}'")
+    paragons = _cargo_query("btd6_paragons", "name,cost", f"tower='{safe}'")
     if paragons:
         td.paragon_cost = _int(paragons[0].get("cost"))
+        td.paragon_name = str(paragons[0].get("name", "")).strip() or None
     time.sleep(delay)
 
     try:
@@ -275,6 +277,7 @@ def stats_document(td: TowerData) -> dict:
         "base_cost": td.base_cost,
         "category": td.category,
         "paragon_cost": td.paragon_cost,
+        "paragon_name": td.paragon_name,
         "upgrades": td.upgrades,
         "tiers": td.tiers,
     }

--- a/tests/unit/services/test_btd6_paragon_names.py
+++ b/tests/unit/services/test_btd6_paragon_names.py
@@ -1,0 +1,82 @@
+"""BTD6 paragon names are grounded (fetched from bloonswiki's btd6_paragons).
+
+The per-tower stats files carried ``paragon_cost`` but not the paragon's
+name, because ``fetch_bloonswiki.py`` only queried the ``cost`` column.
+The bot therefore answered "list the paragons" from memory and
+hallucinated names (and paragons for towers that have none). These tests
+pin that the 13 real paragons now carry their verified name end-to-end:
+data file -> btd6_stats_service -> superlative ranking -> grounding line.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_DISBOT = Path(__file__).parents[3] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+from services import (  # noqa: E402
+    btd6_context_service,
+    btd6_stats_service,
+    btd6_superlative_service,
+)
+
+_STATS = _DISBOT / "data" / "btd6" / "stats"
+
+
+def test_stats_service_loads_paragon_name():
+    stats = btd6_stats_service.get_tower_stats("dart_monkey")
+    assert stats is not None
+    assert stats.paragon_name == "Apex Plasma Master"
+    assert stats.paragon_cost == 150000
+
+
+def test_every_paragon_cost_tower_has_a_name():
+    """Data integrity: each of the towers with a paragon_cost carries the
+    verified paragon_name (and towers without a paragon claim neither).
+    """
+    named = 0
+    for f in _STATS.glob("*.json"):
+        d = json.loads(f.read_text(encoding="utf-8"))
+        if d.get("paragon_cost"):
+            assert d.get("paragon_name"), f"{f.name} has paragon_cost but no name"
+            named += 1
+        else:
+            assert not d.get("paragon_name"), f"{f.name} names a non-existent paragon"
+    # BTD6 has exactly 13 monkey paragons.
+    assert named == 13
+
+
+def test_super_monkey_has_no_paragon():
+    """Refutes the model's hallucinated 'Super Monkey Paragon' — there is
+    no Super Monkey paragon in the data.
+    """
+    stats = btd6_stats_service.get_tower_stats("super_monkey")
+    assert stats is not None
+    assert stats.paragon_cost is None
+    assert stats.paragon_name is None
+
+
+def test_superlative_paragon_rows_carry_real_names():
+    rows = btd6_superlative_service.rank("paragon_cost", limit=25)
+    assert len(rows) == 13
+    whats = " | ".join(h.what for h in rows)
+    assert "Apex Plasma Master" in whats
+    assert "Goliath Doomship" in whats  # priciest (Monkey Ace, 900k)
+    # The tower name is still present so "X Paragon" phrasing keeps working.
+    assert all("Paragon" in h.what for h in rows)
+
+
+def test_render_paragon_grounding_line_names_the_paragon():
+    lines = btd6_context_service._render_paragon("dart_monkey", "Dart Monkey")
+    assert len(lines) == 1
+    assert "btd6_paragon" in lines[0]
+    assert "Apex Plasma Master" in lines[0]
+    assert "150000" in lines[0]
+
+
+def test_render_paragon_returns_nothing_for_non_paragon_tower():
+    assert btd6_context_service._render_paragon("super_monkey", "Super Monkey") == []


### PR DESCRIPTION
## What & why

You were right — the paragon data **is** there, and I'd checked the wrong file. The per-tower stats files (sourced `bloonswiki.com`) carry `paragon_cost` for all **13 real paragons**, but **not the paragon name**, because `fetch_bloonswiki.py:162` only queried the `cost` column from bloonswiki's `btd6_paragons` cargo table. So the bot answered "what paragons are available" from memory — hallucinating names and inventing paragons for towers that have none (Super Monkey, Glue Gunner, …) while missing real ones.

The names exist at the source (`btd6_paragons` has `name`+`cost`). This wires them through end-to-end.

## Change

- **`scripts/fetch_bloonswiki.py`** — query `name,cost` and capture `paragon_name` (future fetches include it).
- **`data/btd6/stats/*.json`** — backfill `paragon_name` into the 13 paragon towers, **fetched live from bloonswiki's `btd6_paragons` table** (authoritative, not transcribed) — one-line surgical insert per file (clean diffs).
- **`btd6_stats_service.TowerStats`** — load `paragon_name`.
- **`btd6_superlative_service`** — `paragon_cost` rows now read e.g. `Apex Plasma Master (Dart Monkey Paragon)`, so "list the paragons" / "priciest paragon" return real names.
- **`btd6_context_service`** — a new `[btd6_paragon]` grounding line names a tower's paragon + Medium cost on lookup, and emits **nothing** for towers with no paragon (so the model stops inventing them).

### The 13 authoritative names
Apex Plasma Master (Dart), Glaive Dominus (Boomerang), Ballistic Obliteration Missile Bunker (Bomb), Crucible of Steel and Flame (Tack), Herald of Everfrost (Ice), Magus Perfectus (Wizard), Ascended Shadow (Ninja), Master Builder (Engineer), Mega Massive Munitions Factory (Spike Factory), Nautic Siege Core (Sub), Navarch of the Seas (Buccaneer), Goliath Doomship (Ace), Root of all Nature (Druid).

## Tests

`tests/unit/services/test_btd6_paragon_names.py`: stats loads the name; **all 13** paragon-cost towers carry a name and non-paragon towers carry none (Super Monkey's hallucinated paragon explicitly refuted); superlative rows carry real names; the grounding line names the paragon and is empty for non-paragon towers. Existing `"Paragon" in h.what` pin still holds.

## Gates (CI-exact, `python3.10 -m`)

- `check_architecture.py --mode strict`: 0 errors.
- black / isort / ruff / mypy: clean.
- `pytest tests/ -q`: **6370 passed, 3 skipped**.

> Reliability note (unchanged): the grounding now exists, but whether the model *calls* the lookup for a bare "list paragons" is model-dependent — Claude (via #402: provider=anthropic, blank model) calls these tools reliably; `gpt-4o-mini` does not.

https://claude.ai/code/session_0174rirKZ5dtHaJSZc7kMkfP

---
_Generated by [Claude Code](https://claude.ai/code/session_0174rirKZ5dtHaJSZc7kMkfP)_