### PR TITLE
feat(views): multi-select primitive + adopt in channel restrict panel (audit P1-10)

### DIFF
--- a/disbot/views/channels/restrict_panel.py
+++ b/disbot/views/channels/restrict_panel.py
@@ -1,8 +1,12 @@
 """Channel-restriction sub-panel.
 
-Pick a channel, then lock (deny send_messages for @everyone) or unlock
-(restore send_messages).  Auto-returns to the manager hub after the
-action lands.
+Pick one or more channels, then lock (deny send_messages for @everyone)
+or unlock (restore send_messages).  Auto-returns to the manager hub
+after the action lands.
+
+The channel picker is the shared ``views.selectors.MultiSelect``
+primitive (repo-wide audit P1-10): admins routinely lock/unlock a batch
+of channels at once, so forcing one-at-a-time was needless friction.
 """
 
 from __future__ import annotations
@@ -18,14 +22,14 @@ from core.runtime.interaction_helpers import safe_defer, safe_edit, safe_followu
 from core.runtime.panel_recovery import restore_parent_or_send_fresh
 from utils.ui_constants import CHANNEL_COLOR, ERROR_COLOR, SUCCESS_COLOR
 from views.base import BaseView
-from views.channels._helpers import _ChannelSelect
 from views.navigation import attach_back_button
+from views.selectors import MultiSelect
 
 logger = logging.getLogger("bot")
 
 
 class _RestrictSubView(BaseView):
-    """Restriction management: pick a channel, then choose lock or unlock."""
+    """Restriction management: pick channel(s), then choose lock or unlock."""
 
     def __init__(
         self,
@@ -37,13 +41,22 @@ class _RestrictSubView(BaseView):
         super().__init__(ctx.author, timeout=120)
         self.ctx = ctx
         self.manager_message = manager_message
-        self.selected_channel_id: int | None = None
-        self.selected_channel_name: str | None = None
+        self.selected_channel_ids: list[int] = []
+        # id -> display name, sourced from the option labels so the result
+        # embed can name channels without re-resolving each one.
+        self._option_names: dict[int, str] = {}
+        for opt in options:
+            try:
+                self._option_names[int(opt.value)] = opt.label
+            except ValueError:
+                continue
 
-        self.channel_select = _ChannelSelect(
+        self.channel_select = MultiSelect(
             options,
-            self,
-            placeholder="Select a channel to manage…",
+            self._on_channels_selected,
+            placeholder="Select one or more channels to manage…",
+            min_values=1,
+            row=0,
         )
         self.add_item(self.channel_select)
 
@@ -64,6 +77,20 @@ class _RestrictSubView(BaseView):
             row=2,
         )
 
+    async def _on_channels_selected(
+        self,
+        interaction: discord.Interaction,
+        channel_ids: list[int],
+    ) -> None:
+        self.selected_channel_ids = channel_ids
+        try:
+            await interaction.response.edit_message(
+                embed=self.build_embed(),
+                view=self,
+            )
+        except discord.HTTPException:
+            await safe_defer(interaction)
+
     async def on_error(
         self,
         interaction: discord.Interaction,
@@ -80,23 +107,25 @@ class _RestrictSubView(BaseView):
         msg = f"❌ {type(error).__name__}: {error}"
         await safe_followup(interaction, msg, ephemeral=True)
 
+    def _selected_names(self) -> list[str]:
+        return [
+            self._option_names.get(cid, str(cid)) for cid in self.selected_channel_ids
+        ]
+
     def build_embed(self) -> discord.Embed:
         embed = discord.Embed(
             title="🔒 Manage Restrictions",
             description=(
-                "Select a channel, then choose a restriction action.\n\n"
+                "Select one or more channels, then choose a restriction action.\n\n"
                 "**🔒 Lock** — disable send messages for @everyone\n"
                 "**🔓 Unlock** — restore send messages for @everyone"
             ),
             color=CHANNEL_COLOR,
         )
+        names = self._selected_names()
         embed.add_field(
-            name="Selected channel",
-            value=(
-                f"`{self.selected_channel_name}`"
-                if self.selected_channel_name
-                else "*(none)*"
-            ),
+            name=f"Selected channel{'s' if len(names) != 1 else ''}",
+            value=(", ".join(f"`{n}`" for n in names) if names else "*(none)*"),
             inline=False,
         )
         return embed
@@ -110,57 +139,57 @@ class _RestrictSubView(BaseView):
         past_tense: str,
         embed_color: discord.Color,
     ) -> None:
-        if not self.selected_channel_id:
+        if not self.selected_channel_ids:
             await interaction.response.send_message(
-                "Please select a channel first.",
+                "Please select at least one channel first.",
                 ephemeral=True,
             )
             return
 
-        channel = resources.resolve_channel(
-            interaction.guild,
-            channel_id=self.selected_channel_id,
-            kind="any",
-        )
-        if channel is None:
-            await interaction.response.send_message(
-                f"Channel `{self.selected_channel_name}` not found.",
-                ephemeral=True,
-            )
-            return
-
-        # Defer before the Discord permission write: set_permissions is
-        # not instant under load and the subsequent edit_message would
-        # race the 3 s interaction token.
+        # Defer before the Discord permission writes: set_permissions is
+        # not instant under load and across several channels the subsequent
+        # edit_message would race the 3 s interaction token.
         if not await safe_defer(interaction):
             return
 
-        try:
-            await channel.set_permissions(
-                interaction.guild.default_role,
-                send_messages=send_messages,
+        succeeded: list[str] = []
+        forbidden: list[str] = []
+        failed: list[str] = []
+        for channel_id in self.selected_channel_ids:
+            name = self._option_names.get(channel_id, str(channel_id))
+            channel = resources.resolve_channel(
+                interaction.guild,
+                channel_id=channel_id,
+                kind="any",
             )
-        except discord.Forbidden:
-            await safe_followup(
-                interaction,
-                "❌ I don't have permission to change that channel's permissions.",
-                ephemeral=True,
-            )
-            return
-        except discord.HTTPException as exc:
-            await safe_followup(
-                interaction,
-                f"❌ Failed to update permissions: {exc}",
-                ephemeral=True,
-            )
-            return
+            if channel is None:
+                failed.append(name)
+                continue
+            try:
+                await channel.set_permissions(
+                    interaction.guild.default_role,
+                    send_messages=send_messages,
+                )
+            except discord.Forbidden:
+                forbidden.append(name)
+            except discord.HTTPException as exc:
+                logger.warning(
+                    "Restrict apply failed | channel=%r exc=%s",
+                    name,
+                    exc,
+                )
+                failed.append(name)
+            else:
+                succeeded.append(name)
 
-        result_embed = discord.Embed(
-            title=f"{action_label} Applied",
-            description=f"`{self.selected_channel_name}` has been {past_tense}.",
-            color=embed_color,
+        result_embed = self._build_result_embed(
+            action_label=action_label,
+            past_tense=past_tense,
+            embed_color=embed_color,
+            succeeded=succeeded,
+            forbidden=forbidden,
+            failed=failed,
         )
-        result_embed.set_footer(text="Returning to the management panel…")
 
         for item in self.children:
             item.disabled = True
@@ -180,6 +209,43 @@ class _RestrictSubView(BaseView):
         )
         if restored is not None:
             manager.message = restored
+
+    def _build_result_embed(
+        self,
+        *,
+        action_label: str,
+        past_tense: str,
+        embed_color: discord.Color,
+        succeeded: list[str],
+        forbidden: list[str],
+        failed: list[str],
+    ) -> discord.Embed:
+        # All failed and nothing succeeded → show an error-coloured embed.
+        any_ok = bool(succeeded)
+        embed = discord.Embed(
+            title=f"{action_label} Applied" if any_ok else f"{action_label} Failed",
+            color=embed_color if any_ok else ERROR_COLOR,
+        )
+        if succeeded:
+            embed.add_field(
+                name=f"✅ {past_tense.capitalize()}",
+                value=", ".join(f"`{n}`" for n in succeeded),
+                inline=False,
+            )
+        if forbidden:
+            embed.add_field(
+                name="🚫 Missing permission",
+                value=", ".join(f"`{n}`" for n in forbidden),
+                inline=False,
+            )
+        if failed:
+            embed.add_field(
+                name="⚠️ Not found / failed",
+                value=", ".join(f"`{n}`" for n in failed),
+                inline=False,
+            )
+        embed.set_footer(text="Returning to the management panel…")
+        return embed
 
     @discord.ui.button(label="Lock", style=discord.ButtonStyle.red, emoji="🔒", row=1)
     async def lock_btn(self, interaction: discord.Interaction, _: discord.ui.Button):

--- a/disbot/views/channels/visibility_panel.py
+++ b/disbot/views/channels/visibility_panel.py
@@ -136,7 +136,10 @@ class _SubsystemToggleView(BaseView):
         self._rebuild_buttons()
 
     def _rebuild_buttons(self) -> None:
-        # Remove all items except the static back button
+        # Rebuild from scratch each refresh: clear all items, re-add the
+        # toggle grid (rows 1-4), then re-attach the Back button (row 0).
+        # The back nav must be re-added every rebuild because remove_item
+        # drops it along with the toggles.
         for item in list(self.children):
             self.remove_item(item)
 
@@ -168,6 +171,32 @@ class _SubsystemToggleView(BaseView):
             )
             btn.callback = self._make_toggle_callback(name)  # type: ignore[method-assign]
             self.add_item(btn)
+
+        self._attach_back_button()
+
+    def _attach_back_button(self) -> None:
+        """Re-add Back nav to the channel picker (audit §9.3 dead-end fix).
+
+        Without this the toggle grid is a navigation dead-end — the panel
+        comment long claimed a "static back button" that was never added.
+        """
+
+        async def _build_parent(
+            _interaction: discord.Interaction,
+        ) -> tuple[discord.Embed, discord.ui.View]:
+            parent = _VisibilitySubView(
+                self.ctx,
+                manager_message=self.manager_message,
+            )
+            return parent.build_embed(), parent
+
+        attach_back_button(
+            self,
+            label="↩ Back",
+            custom_id="channels:visibility:toggle:back",
+            parent_builder=_build_parent,
+            row=0,
+        )
 
     def _make_toggle_callback(self, subsystem_name: str):
         async def callback(interaction: discord.Interaction):

--- a/disbot/views/selectors/__init__.py
+++ b/disbot/views/selectors/__init__.py
@@ -10,6 +10,8 @@ Public surface:
     role.RoleSelector           — guild-role picker
     scope.ScopeSelector         — governance scope picker (guild/category/channel)
     subsystem.SubsystemSelector — registered-subsystem picker
+    multi.MultiSelect           — generic multi-select over caller options
+    multi.MultiChannelSelector  — multi-select channel picker (returns ids)
 
 Adopt these instead of building bespoke ``discord.ui.Select`` widgets
 in cogs.  Adoption is mechanical: replace the local Select subclass
@@ -19,12 +21,15 @@ with a configured selector that calls back into the cog's handler.
 from __future__ import annotations
 
 from views.selectors.channel import ChannelSelector
+from views.selectors.multi import MultiChannelSelector, MultiSelect
 from views.selectors.role import RoleSelector
 from views.selectors.scope import ScopeSelector
 from views.selectors.subsystem import SubsystemSelector
 
 __all__ = [
     "ChannelSelector",
+    "MultiChannelSelector",
+    "MultiSelect",
     "RoleSelector",
     "ScopeSelector",
     "SubsystemSelector",

--- a/disbot/views/selectors/multi.py
+++ b/disbot/views/selectors/multi.py
@@ -1,0 +1,148 @@
+"""Reusable multi-select primitives.
+
+The single-select siblings in this package (channel / role / scope /
+subsystem) all hard-cap ``max_values=1``.  Several admin flows are
+naturally multi-target — locking a handful of channels, granting a
+policy to a set of roles — and were forced into a "pick one → confirm →
+reopen" loop (repo-wide audit 2026-05-29, §5 / §9.1, finding **P1-10**).
+
+``MultiSelect`` is the generic primitive: pass pre-built options and an
+async ``on_select`` that receives the list of chosen values.
+``MultiChannelSelector`` is the channel-typed convenience built on top,
+mirroring :class:`channel.ChannelSelector` but returning *every*
+selected id.
+
+Discord caps Select options at 25 and ``max_values`` at the number of
+options it sees; both are enforced here so callers can pass any-length
+collections without crashing the payload.  An empty option list falls
+back to a single placeholder entry (the same empty-guard the
+``RoleSelector`` / ``SubsystemSelector`` carry) so the widget never
+raises on a guild with nothing to show.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Iterable
+from typing import Any
+
+import discord
+
+# Async callbacks: generic returns the chosen option ``value`` strings;
+# the channel convenience returns parsed integer ids.
+OnSelectValues = Callable[[discord.Interaction, list[str]], Awaitable[None]]
+OnSelectIds = Callable[[discord.Interaction, list[int]], Awaitable[None]]
+
+# Sentinel option used when the caller passes zero options.  Its value is
+# the empty string so ``MultiSelect.callback`` can filter it back out and
+# never hand a phantom selection to the caller.
+_EMPTY_VALUE = ""
+_EMPTY_OPTION = discord.SelectOption(label="— nothing available —", value=_EMPTY_VALUE)
+
+
+class MultiSelect(discord.ui.Select):
+    """Multi-select over caller-supplied options.
+
+    Parameters
+    ----------
+    options:
+        Any iterable of :class:`discord.SelectOption`.  Truncated to 25.
+    on_select:
+        Awaitable invoked with ``(interaction, values)`` — ``values`` is
+        the list of chosen option ``value`` strings (possibly empty when
+        ``min_values=0`` and the user clears the menu).  The caller must
+        reply or defer.
+    min_values / max_values:
+        Selection bounds.  ``max_values`` defaults to "all options" (the
+        whole point of a multi-select) and is clamped to the option
+        count so Discord never rejects the payload.
+    placeholder / custom_id / row:
+        As per :class:`discord.ui.Select`.  For persistent panels pass an
+        explicit ``<subsystem>:<action>`` ``custom_id``.
+    """
+
+    def __init__(
+        self,
+        options: Iterable[discord.SelectOption],
+        on_select: OnSelectValues,
+        *,
+        placeholder: str = "Select one or more…",
+        min_values: int = 0,
+        max_values: int | None = None,
+        custom_id: str | None = None,
+        row: int | None = None,
+    ) -> None:
+        bounded = list(options)[:25]
+        # Discord rejects a Select with zero options.
+        effective = bounded or [_EMPTY_OPTION]
+        # max_values must not exceed the number of options Discord sees;
+        # default to selecting all of them.
+        cap = max_values if max_values is not None else len(effective)
+        cap = max(1, min(cap, len(effective)))
+        # dict[str, Any] (not object) so **kwargs unpacks into Select.__init__
+        # without mypy demanding str|int|list|bool per declared param.
+        kwargs: dict[str, Any] = {
+            "placeholder": placeholder,
+            "options": effective,
+            "min_values": max(0, min(min_values, cap)),
+            "max_values": cap,
+        }
+        if custom_id is not None:
+            kwargs["custom_id"] = custom_id
+        if row is not None:
+            kwargs["row"] = row
+        super().__init__(**kwargs)
+        self._on_select = on_select
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        # Drop the empty-guard sentinel so callers never see a phantom "".
+        values = [v for v in self.values if v != _EMPTY_VALUE]
+        await self._on_select(interaction, values)
+
+
+class MultiChannelSelector(MultiSelect):
+    """Multi-select text/voice-channel picker returning every chosen id.
+
+    Mirrors :class:`channel.ChannelSelector` (which is single-select) for
+    flows that act on several channels at once.  ``on_select`` receives a
+    list of channel ids; unparseable values are skipped defensively.
+    """
+
+    def __init__(
+        self,
+        channels: Iterable[discord.abc.GuildChannel],
+        on_select: OnSelectIds,
+        *,
+        placeholder: str = "Select one or more channels…",
+        min_values: int = 1,
+        max_values: int | None = None,
+        custom_id: str | None = None,
+        row: int | None = None,
+    ) -> None:
+        bounded = list(channels)[:25]
+        options = [
+            discord.SelectOption(label=f"#{ch.name}"[:100], value=str(ch.id))
+            for ch in bounded
+        ]
+        super().__init__(
+            options,
+            self._dispatch_ids,
+            placeholder=placeholder,
+            min_values=min_values,
+            max_values=max_values,
+            custom_id=custom_id,
+            row=row,
+        )
+        self._id_on_select = on_select
+
+    async def _dispatch_ids(
+        self,
+        interaction: discord.Interaction,
+        values: list[str],
+    ) -> None:
+        ids: list[int] = []
+        for v in values:
+            try:
+                ids.append(int(v))
+            except ValueError:
+                continue
+        await self._id_on_select(interaction, ids)

--- a/tests/unit/views/test_restrict_panel_multi.py
+++ b/tests/unit/views/test_restrict_panel_multi.py
@@ -1,0 +1,168 @@
+"""Tests for the multi-channel restrict sub-panel (audit P1-10).
+
+``_RestrictSubView`` adopted the shared ``views.selectors.MultiSelect``
+so admins can lock/unlock several channels in one action.  These tests
+pin:
+
+- the picker is a MultiSelect (not a single-select);
+- selecting channels records every id and refreshes the embed;
+- applying a restriction calls ``set_permissions`` once per channel and
+  partitions the result into succeeded / forbidden / failed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from views.selectors import MultiSelect
+
+
+def _options(*pairs: tuple[int, str]) -> list[discord.SelectOption]:
+    return [discord.SelectOption(label=name, value=str(cid)) for cid, name in pairs]
+
+
+def _build_view(options: list[discord.SelectOption]):
+    from views.channels.restrict_panel import _RestrictSubView
+
+    ctx = MagicMock()
+    ctx.author = MagicMock()
+    ctx.author.id = 1
+    ctx.guild = MagicMock()
+    return _RestrictSubView(ctx, options=options, manager_message=None)
+
+
+def test_restrict_picker_is_multiselect():
+    view = _build_view(_options((10, "alpha"), (20, "beta")))
+    assert isinstance(view.channel_select, MultiSelect)
+    # min 1, and max defaults to "all options".
+    assert view.channel_select.min_values == 1
+    assert view.channel_select.max_values == 2
+
+
+@pytest.mark.asyncio
+async def test_selecting_channels_records_all_ids():
+    view = _build_view(_options((10, "alpha"), (20, "beta")))
+    interaction = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    await view._on_channels_selected(interaction, [10, 20])
+    assert view.selected_channel_ids == [10, 20]
+    assert view._selected_names() == ["alpha", "beta"]
+    interaction.response.edit_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_apply_requires_a_selection():
+    view = _build_view(_options((10, "alpha")))
+    interaction = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    await view._apply_restriction(
+        interaction,
+        send_messages=False,
+        action_label="🔒 Lock",
+        past_tense="locked",
+        embed_color=discord.Color.red(),
+    )
+    interaction.response.send_message.assert_awaited_once()
+    assert "at least one" in interaction.response.send_message.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_lock_applies_to_every_selected_channel():
+    view = _build_view(_options((10, "alpha"), (20, "beta")))
+    view.selected_channel_ids = [10, 20]
+    interaction = MagicMock()
+    interaction.guild = MagicMock()
+    interaction.channel = MagicMock()
+
+    ch_a = MagicMock()
+    ch_a.set_permissions = AsyncMock()
+    ch_b = MagicMock()
+    ch_b.set_permissions = AsyncMock()
+    by_id = {10: ch_a, 20: ch_b}
+
+    captured: dict[str, discord.Embed] = {}
+
+    async def _edit(_inter, *, embed, view):  # noqa: ARG001
+        captured["embed"] = embed
+        return True
+
+    with (
+        patch("views.channels.restrict_panel.resources") as mock_res,
+        patch("views.channels.restrict_panel.safe_defer", AsyncMock(return_value=True)),
+        patch("views.channels.restrict_panel.safe_edit", AsyncMock(side_effect=_edit)),
+        patch(
+            "views.channels.restrict_panel.restore_parent_or_send_fresh",
+            AsyncMock(return_value=None),
+        ),
+        patch("views.channels.restrict_panel.asyncio.sleep", AsyncMock()),
+    ):
+        mock_res.resolve_channel = MagicMock(
+            side_effect=lambda _g, *, channel_id, kind: by_id.get(channel_id)
+        )
+        await view._apply_restriction(
+            interaction,
+            send_messages=False,
+            action_label="🔒 Lock",
+            past_tense="locked",
+            embed_color=discord.Color.red(),
+        )
+
+    ch_a.set_permissions.assert_awaited_once()
+    ch_b.set_permissions.assert_awaited_once()
+    # both channels reported as succeeded
+    field_values = " ".join(f.value for f in captured["embed"].fields)
+    assert "alpha" in field_values
+    assert "beta" in field_values
+
+
+@pytest.mark.asyncio
+async def test_partial_failure_partitions_results():
+    view = _build_view(_options((10, "ok"), (20, "forbidden"), (30, "gone")))
+    view.selected_channel_ids = [10, 20, 30]
+    interaction = MagicMock()
+    interaction.guild = MagicMock()
+    interaction.channel = MagicMock()
+
+    ch_ok = MagicMock()
+    ch_ok.set_permissions = AsyncMock()
+    ch_forbidden = MagicMock()
+    ch_forbidden.set_permissions = AsyncMock(
+        side_effect=discord.Forbidden(MagicMock(), "nope")
+    )
+    by_id = {10: ch_ok, 20: ch_forbidden}  # 30 resolves to None (gone)
+
+    captured: dict[str, discord.Embed] = {}
+
+    async def _edit(_inter, *, embed, view):  # noqa: ARG001
+        captured["embed"] = embed
+        return True
+
+    with (
+        patch("views.channels.restrict_panel.resources") as mock_res,
+        patch("views.channels.restrict_panel.safe_defer", AsyncMock(return_value=True)),
+        patch("views.channels.restrict_panel.safe_edit", AsyncMock(side_effect=_edit)),
+        patch(
+            "views.channels.restrict_panel.restore_parent_or_send_fresh",
+            AsyncMock(return_value=None),
+        ),
+        patch("views.channels.restrict_panel.asyncio.sleep", AsyncMock()),
+    ):
+        mock_res.resolve_channel = MagicMock(
+            side_effect=lambda _g, *, channel_id, kind: by_id.get(channel_id)
+        )
+        await view._apply_restriction(
+            interaction,
+            send_messages=False,
+            action_label="🔒 Lock",
+            past_tense="locked",
+            embed_color=discord.Color.red(),
+        )
+
+    names = {f.name: f.value for f in captured["embed"].fields}
+    joined = " || ".join(f"{k}={v}" for k, v in names.items())
+    assert "ok" in joined
+    assert "forbidden" in joined
+    assert "gone" in joined

--- a/tests/unit/views/test_selectors.py
+++ b/tests/unit/views/test_selectors.py
@@ -15,10 +15,13 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
+import discord
 import pytest
 
 from views.selectors import (
     ChannelSelector,
+    MultiChannelSelector,
+    MultiSelect,
     RoleSelector,
     ScopeSelector,
     SubsystemSelector,
@@ -112,7 +115,10 @@ async def test_role_selector_invokes_callback():
 
 def test_scope_selector_offers_channel_category_guild_when_all_present():
     sel = ScopeSelector(
-        guild_id=10, category_id=20, channel_id=30, on_select=AsyncMock(),
+        guild_id=10,
+        category_id=20,
+        channel_id=30,
+        on_select=AsyncMock(),
     )
     values = [o.value for o in sel.options]
     assert "channel:30" in values
@@ -122,7 +128,10 @@ def test_scope_selector_offers_channel_category_guild_when_all_present():
 
 def test_scope_selector_omits_missing_levels():
     sel = ScopeSelector(
-        guild_id=10, category_id=None, channel_id=None, on_select=AsyncMock(),
+        guild_id=10,
+        category_id=None,
+        channel_id=None,
+        on_select=AsyncMock(),
     )
     values = [o.value for o in sel.options]
     assert values == ["guild:10"]
@@ -132,7 +141,10 @@ def test_scope_selector_omits_missing_levels():
 async def test_scope_selector_parses_value():
     cb = AsyncMock()
     sel = ScopeSelector(
-        guild_id=10, category_id=20, channel_id=30, on_select=cb,
+        guild_id=10,
+        category_id=20,
+        channel_id=30,
+        on_select=cb,
     )
     sel._values = ["category:20"]
     interaction = MagicMock()
@@ -167,3 +179,91 @@ async def test_subsystem_selector_invokes_callback_with_name():
     interaction = MagicMock()
     await sel.callback(interaction)
     cb.assert_awaited_once_with(interaction, "role")
+
+
+# ---------------------------------------------------------------------------
+# MultiSelect (P1-10)
+# ---------------------------------------------------------------------------
+
+
+def _opt(value: str, label: str | None = None) -> discord.SelectOption:
+    return discord.SelectOption(label=label or value, value=value)
+
+
+def test_multiselect_defaults_max_to_all_options():
+    sel = MultiSelect([_opt("a"), _opt("b"), _opt("c")], on_select=AsyncMock())
+    assert sel.max_values == 3
+    assert sel.min_values == 0
+
+
+def test_multiselect_truncates_options_and_clamps_max():
+    sel = MultiSelect([_opt(str(i)) for i in range(40)], on_select=AsyncMock())
+    assert len(sel.options) == 25
+    # max_values can never exceed the option count Discord sees.
+    assert sel.max_values == 25
+
+
+def test_multiselect_explicit_max_is_clamped_to_option_count():
+    sel = MultiSelect([_opt("a"), _opt("b")], on_select=AsyncMock(), max_values=10)
+    assert sel.max_values == 2
+
+
+def test_multiselect_empty_options_fall_back_to_placeholder():
+    # Must not raise on an empty collection (the gap ChannelSelector has).
+    sel = MultiSelect([], on_select=AsyncMock())
+    assert len(sel.options) == 1
+    assert sel.max_values == 1
+
+
+@pytest.mark.asyncio
+async def test_multiselect_invokes_callback_with_selected_values():
+    cb = AsyncMock()
+    sel = MultiSelect([_opt("a"), _opt("b"), _opt("c")], on_select=cb)
+    sel._values = ["a", "c"]
+    interaction = MagicMock()
+    await sel.callback(interaction)
+    cb.assert_awaited_once_with(interaction, ["a", "c"])
+
+
+@pytest.mark.asyncio
+async def test_multiselect_filters_empty_guard_sentinel():
+    cb = AsyncMock()
+    sel = MultiSelect([], on_select=cb)  # only the sentinel option exists
+    sel._values = [""]  # user somehow "picked" the placeholder
+    interaction = MagicMock()
+    await sel.callback(interaction)
+    cb.assert_awaited_once_with(interaction, [])
+
+
+# ---------------------------------------------------------------------------
+# MultiChannelSelector
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_multi_channel_selector_truncates_to_25():
+    channels = [_channel(i, f"c{i}") for i in range(40)]
+    sel = MultiChannelSelector(channels, on_select=AsyncMock())
+    assert len(sel.options) == 25
+
+
+@pytest.mark.asyncio
+async def test_multi_channel_selector_invokes_callback_with_int_ids():
+    channels = [_channel(11, "a"), _channel(22, "b"), _channel(33, "c")]
+    cb = AsyncMock()
+    sel = MultiChannelSelector(channels, on_select=cb)
+    sel._values = ["11", "33"]
+    interaction = MagicMock()
+    await sel.callback(interaction)
+    cb.assert_awaited_once_with(interaction, [11, 33])
+
+
+@pytest.mark.asyncio
+async def test_multi_channel_selector_skips_unparseable_values():
+    channels = [_channel(11, "a")]
+    cb = AsyncMock()
+    sel = MultiChannelSelector(channels, on_select=cb)
+    sel._values = ["11", "not-an-int"]
+    interaction = MagicMock()
+    await sel.callback(interaction)
+    cb.assert_awaited_once_with(interaction, [11])

--- a/tests/unit/views/test_visibility_panel_defer.py
+++ b/tests/unit/views/test_visibility_panel_defer.py
@@ -202,3 +202,40 @@ async def test_toggle_callback_error_path_uses_safe_followup():
     # State must not be mutated on failure.
     assert view._visibility["economy"] is None
     interaction.response.send_message.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Navigation dead-end fix (audit §9.3): the toggle grid must keep a Back button
+# ---------------------------------------------------------------------------
+
+
+def test_toggle_view_rebuild_keeps_a_back_button():
+    """`_rebuild_buttons` wipes all children every refresh; it must
+    re-attach the Back nav so the grid is not a dead-end."""
+    view = _build_toggle_view()
+    view._visibility = {}
+    view._rebuild_buttons()
+
+    back_buttons = [
+        child
+        for child in view.children
+        if getattr(child, "custom_id", None) == "channels:visibility:toggle:back"
+    ]
+    assert len(back_buttons) == 1, "toggle grid lost its Back button (dead-end)"
+
+
+def test_toggle_view_back_button_survives_repeated_rebuilds():
+    """Toggling cycles call `_rebuild_buttons` repeatedly — the Back
+    button must not duplicate or vanish across refreshes."""
+    view = _build_toggle_view()
+    view._visibility = {}
+    view._rebuild_buttons()
+    view._rebuild_buttons()
+    view._rebuild_buttons()
+
+    back_buttons = [
+        child
+        for child in view.children
+        if getattr(child, "custom_id", None) == "channels:visibility:toggle:back"
+    ]
+    assert len(back_buttons) == 1


### PR DESCRIPTION
## What & why

Audit finding **P1-10** (`docs/audits/repo-wide-audit-2026-05-29.md` §5 / §9.1): select UX is single-select everywhere — **2 multi-selects vs 62 `max_values=1`**, and the four shared `views/selectors/*` primitives are all single-select with **zero adoption**. Flows where multi-target is natural (channel restrict/visibility, AI policy/behavior, logging routes, setup) force a "select one → confirm → reopen" loop.

This is the **first slice**: build the reusable primitive and adopt it in one pilot flow so the UX can be eyeballed before rolling wide.

## Changes

**New primitive — `views/selectors/multi.py`**
- `MultiSelect` — generic multi-select over caller-supplied options.
- `MultiChannelSelector` — channel-typed convenience returning every selected id.
- Both clamp `max_values` to the option count, truncate to Discord's 25-option cap, and carry the **empty-option placeholder guard** that single-select `ChannelSelector` lacks (closes the audit's §9.6 `ChannelSelector`-crashes-on-empty concern for the multi path). Exported from `views/selectors/__init__`.

**Pilot adoption — `views/channels/restrict_panel.py`**
- Lock/unlock now act on a **set** of channels in one action (`MultiSelect`, `min_values=1`).
- Results are partitioned into **succeeded / missing-permission / not-found**; defer happens **before** the per-channel `set_permissions` writes (no 3 s token race across N channels).

**Navigation dead-end fix — `views/channels/visibility_panel.py` (audit §9.3)**
- `_SubsystemToggleView._rebuild_buttons` wiped all children every refresh and the long-claimed "static back button" was **never added** — a dead-end. Now re-attaches a Back button (to the channel picker) on every rebuild.

## Tests

- `tests/unit/views/test_selectors.py` — `MultiSelect`/`MultiChannelSelector`: default-max, truncate+clamp, explicit-max clamp, empty-guard, callback value/id parsing, unparseable-skip.
- `tests/unit/views/test_restrict_panel_multi.py` (**new** — the panel was previously untested): picker is multi-select, records all ids, multi-apply calls `set_permissions` per channel, partial-failure partitioning, empty-selection guard.
- `tests/unit/views/test_visibility_panel_defer.py` — back-button present after rebuild + survives repeated rebuilds (dead-end regression guard).

## Gates (CI-exact, `python3.10 -m`)

- `check_architecture.py --mode strict`: **0 errors**.
- black 26.5.1 / isort 8.0.1 / ruff 0.15.14 (disbot scope; `tests/` is in ruff's `extend-exclude`) / mypy 2.1.0: clean.
- `pytest tests/ -q`: **6500 passed, 3 skipped** (+16 new).

## Follow-up

Remaining P1-10 adoptions (next PR): AI policy/behavior pickers, logging routes, setup channels/cog-routing, and a paginated variant for >25 collections.

> Companion docs PR (`claude/audit-status-annotations`) marks P1-10 "partly fixed" + §9.3 "fixed" in the audit — intended to land together.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FsMAonaKRjMuV31vGLnkXW)_