### PR TITLE
feat(views): multi-channel delete with explicit confirm (audit P1-10)

### DIFF
--- a/disbot/views/channels/delete_panel.py
+++ b/disbot/views/channels/delete_panel.py
@@ -1,8 +1,14 @@
 """Channel-deletion sub-panel + confirmation step.
 
-Two-stage flow: ``_DeleteSubView`` picks the channel; pressing
-"Delete Selected" transitions to ``_DeleteConfirmView`` which actually
-performs the delete after a confirmation click.
+Two-stage flow: ``_DeleteSubView`` multi-selects one or more channels;
+pressing "Delete Selected" transitions to ``_DeleteConfirmView`` which
+lists every target by name and performs the deletes after an explicit
+confirmation click.
+
+Multi-channel delete (audit P1-10) is the sibling of the restrict
+panel's multi-lock — both adopt ``views.selectors.MultiSelect``.  Because
+deletion is destructive and irreversible, the confirm step names every
+channel that will be removed before anything happens.
 """
 
 from __future__ import annotations
@@ -18,14 +24,15 @@ from core.runtime.interaction_helpers import safe_defer, safe_edit, safe_followu
 from core.runtime.panel_recovery import restore_parent_or_send_fresh
 from utils.ui_constants import ERROR_COLOR, SUCCESS_COLOR, WARNING_COLOR
 from views.base import BaseView
-from views.channels._helpers import _build_channel_options, _ChannelSelect
+from views.channels._helpers import _build_channel_options
 from views.navigation import attach_back_button
+from views.selectors import MultiSelect
 
 logger = logging.getLogger("bot")
 
 
 class _DeleteSubView(BaseView):
-    """Channel-deletion sub-panel with a select menu and confirmation flow."""
+    """Channel-deletion sub-panel: multi-select picker + confirmation flow."""
 
     def __init__(
         self,
@@ -37,13 +44,22 @@ class _DeleteSubView(BaseView):
         super().__init__(ctx.author, timeout=120)
         self.ctx = ctx
         self.manager_message = manager_message
-        self.selected_channel_id: int | None = None
-        self.selected_channel_name: str | None = None
+        self.selected_channel_ids: list[int] = []
+        # id -> display name, sourced from the option labels so the
+        # confirm/result embeds can name channels without re-resolving.
+        self._option_names: dict[int, str] = {}
+        for opt in options:
+            try:
+                self._option_names[int(opt.value)] = opt.label
+            except ValueError:
+                continue
 
-        self.channel_select = _ChannelSelect(
+        self.channel_select = MultiSelect(
             options,
-            self,
-            placeholder="Select a channel to delete…",
+            self._on_channels_selected,
+            placeholder="Select one or more channels to delete…",
+            min_values=1,
+            row=0,
         )
         self.add_item(self.channel_select)
 
@@ -64,6 +80,20 @@ class _DeleteSubView(BaseView):
             row=1,
         )
 
+    async def _on_channels_selected(
+        self,
+        interaction: discord.Interaction,
+        channel_ids: list[int],
+    ) -> None:
+        self.selected_channel_ids = channel_ids
+        try:
+            await interaction.response.edit_message(
+                embed=self.build_embed(),
+                view=self,
+            )
+        except discord.HTTPException:
+            await safe_defer(interaction)
+
     async def on_error(
         self,
         interaction: discord.Interaction,
@@ -80,32 +110,27 @@ class _DeleteSubView(BaseView):
         msg = f"❌ {type(error).__name__}: {error}"
         await safe_followup(interaction, msg, ephemeral=True)
 
+    def _selected_names(self) -> list[str]:
+        return [
+            self._option_names.get(cid, str(cid)) for cid in self.selected_channel_ids
+        ]
+
     def build_embed(self) -> discord.Embed:
         embed = discord.Embed(
             title="🗑️ Delete Channel",
-            description="Select the channel you want to delete, then press **Delete Selected**.",
+            description=(
+                "Select one or more channels to delete, then press "
+                "**Delete Selected**."
+            ),
             color=ERROR_COLOR,
         )
+        names = self._selected_names()
         embed.add_field(
-            name="Selected channel",
-            value=(
-                f"`{self.selected_channel_name}`"
-                if self.selected_channel_name
-                else "*(none)*"
-            ),
+            name=f"Selected channel{'s' if len(names) != 1 else ''}",
+            value=(", ".join(f"`{n}`" for n in names) if names else "*(none)*"),
             inline=False,
         )
         return embed
-
-    def _confirm_embed(self) -> discord.Embed:
-        return discord.Embed(
-            title="⚠️ Confirm Deletion",
-            description=(
-                f"Are you sure you want to delete **`{self.selected_channel_name}`**?\n"
-                "**This action cannot be undone.**"
-            ),
-            color=ERROR_COLOR,
-        )
 
     @discord.ui.button(
         label="Delete Selected",
@@ -114,41 +139,54 @@ class _DeleteSubView(BaseView):
         row=1,
     )
     async def delete_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
-        if not self.selected_channel_id:
+        if not self.selected_channel_ids:
             await interaction.response.send_message(
-                "Please select a channel first.",
+                "Please select at least one channel first.",
                 ephemeral=True,
             )
             return
         confirm_view = _DeleteConfirmView(
             self.ctx,
-            channel_id=self.selected_channel_id,
-            channel_name=self.selected_channel_name,
+            channels=[
+                (cid, self._option_names.get(cid, str(cid)))
+                for cid in self.selected_channel_ids
+            ],
             manager_message=self.manager_message,
         )
         await interaction.response.edit_message(
-            embed=self._confirm_embed(),
+            embed=confirm_view.build_confirm_embed(),
             view=confirm_view,
         )
         self.stop()
 
 
 class _DeleteConfirmView(BaseView):
-    """Confirmation step before actually deleting a channel."""
+    """Confirmation step before actually deleting the selected channels."""
 
     def __init__(
         self,
         ctx: commands.Context,
         *,
-        channel_id: int,
-        channel_name: str,
+        channels: list[tuple[int, str]],
         manager_message: discord.Message | None,
     ):
         super().__init__(ctx.author, timeout=60)
         self.ctx = ctx
-        self.channel_id = channel_id
-        self.channel_name = channel_name
+        self.channels = channels  # list of (channel_id, display_name)
         self.manager_message = manager_message
+
+    def build_confirm_embed(self) -> discord.Embed:
+        names = ", ".join(f"`{name}`" for _, name in self.channels)
+        count = len(self.channels)
+        return discord.Embed(
+            title="⚠️ Confirm Deletion",
+            description=(
+                f"Are you sure you want to delete the following "
+                f"{count} channel{'s' if count != 1 else ''}?\n\n"
+                f"{names}\n\n**This action cannot be undone.**"
+            ),
+            color=ERROR_COLOR,
+        )
 
     async def on_error(
         self,
@@ -168,43 +206,41 @@ class _DeleteConfirmView(BaseView):
         row=0,
     )
     async def confirm_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
-        # Defer before the Discord delete: channel.delete() is not
-        # instant and the subsequent edit_message would race the 3 s
-        # interaction token.
+        # Defer before the Discord deletes: channel.delete() is not
+        # instant and, across several channels, the subsequent
+        # edit_message would race the 3 s interaction token.
         if not await safe_defer(interaction):
             return
 
-        channel = resources.resolve_channel(
-            interaction.guild,
-            channel_id=self.channel_id,
-            kind="any",
-        )
-        if channel is None:
-            result_embed = discord.Embed(
-                title="❌ Channel Not Found",
-                description=f"Channel `{self.channel_name}` could not be found — it may have already been deleted.",
-                color=WARNING_COLOR,
+        deleted: list[str] = []
+        not_found: list[str] = []
+        forbidden: list[str] = []
+        failed: list[str] = []
+        for channel_id, name in self.channels:
+            channel = resources.resolve_channel(
+                interaction.guild,
+                channel_id=channel_id,
+                kind="any",
             )
-        else:
+            if channel is None:
+                not_found.append(name)
+                continue
             try:
                 await channel.delete()
-                result_embed = discord.Embed(
-                    title="✅ Channel Deleted",
-                    description=f"`{self.channel_name}` has been deleted.",
-                    color=SUCCESS_COLOR,
-                )
             except discord.Forbidden:
-                result_embed = discord.Embed(
-                    title="❌ Permission Denied",
-                    description="I don't have permission to delete that channel.",
-                    color=ERROR_COLOR,
-                )
+                forbidden.append(name)
             except discord.HTTPException as exc:
-                result_embed = discord.Embed(
-                    title="❌ Error",
-                    description=f"Failed to delete channel: {exc}",
-                    color=ERROR_COLOR,
-                )
+                logger.warning("Channel delete failed | channel=%r exc=%s", name, exc)
+                failed.append(name)
+            else:
+                deleted.append(name)
+
+        result_embed = self._build_result_embed(
+            deleted=deleted,
+            not_found=not_found,
+            forbidden=forbidden,
+            failed=failed,
+        )
 
         for item in self.children:
             item.disabled = True
@@ -224,6 +260,47 @@ class _DeleteConfirmView(BaseView):
         )
         if restored is not None:
             manager.message = restored
+
+    def _build_result_embed(
+        self,
+        *,
+        deleted: list[str],
+        not_found: list[str],
+        forbidden: list[str],
+        failed: list[str],
+    ) -> discord.Embed:
+        if not deleted:
+            title, color = "❌ Deletion Failed", ERROR_COLOR
+        elif not_found or forbidden or failed:
+            title, color = "🗑️ Deletion Results", WARNING_COLOR
+        else:
+            title, color = "✅ Channels Deleted", SUCCESS_COLOR
+        embed = discord.Embed(title=title, color=color)
+        if deleted:
+            embed.add_field(
+                name="✅ Deleted",
+                value=", ".join(f"`{n}`" for n in deleted),
+                inline=False,
+            )
+        if forbidden:
+            embed.add_field(
+                name="🚫 Permission denied",
+                value=", ".join(f"`{n}`" for n in forbidden),
+                inline=False,
+            )
+        if not_found:
+            embed.add_field(
+                name="❓ Not found (already deleted?)",
+                value=", ".join(f"`{n}`" for n in not_found),
+                inline=False,
+            )
+        if failed:
+            embed.add_field(
+                name="⚠️ Failed",
+                value=", ".join(f"`{n}`" for n in failed),
+                inline=False,
+            )
+        return embed
 
     @discord.ui.button(
         label="Cancel",

--- a/tests/unit/views/test_delete_panel_multi.py
+++ b/tests/unit/views/test_delete_panel_multi.py
@@ -1,0 +1,199 @@
+"""Tests for the multi-channel delete sub-panel (audit P1-10).
+
+``_DeleteSubView`` adopted the shared ``views.selectors.MultiSelect`` —
+the destructive sibling of the restrict panel's multi-lock.  Because
+deletion is irreversible, ``_DeleteConfirmView`` names every target
+before anything happens.  These tests pin:
+
+- the picker is a MultiSelect recording every selected id;
+- "Delete Selected" requires a selection and hands all targets to the
+  confirm view, whose embed lists them by name;
+- Confirm deletes every channel and partitions the outcome into
+  deleted / permission-denied / not-found / failed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from views.selectors import MultiSelect
+
+
+def _options(*pairs: tuple[int, str]) -> list[discord.SelectOption]:
+    return [discord.SelectOption(label=name, value=str(cid)) for cid, name in pairs]
+
+
+def _build_view(options: list[discord.SelectOption]):
+    from views.channels.delete_panel import _DeleteSubView
+
+    ctx = MagicMock()
+    ctx.author = MagicMock()
+    ctx.author.id = 1
+    ctx.guild = MagicMock()
+    return _DeleteSubView(ctx, options=options, manager_message=None)
+
+
+def _build_confirm(channels: list[tuple[int, str]]):
+    from views.channels.delete_panel import _DeleteConfirmView
+
+    ctx = MagicMock()
+    ctx.author = MagicMock()
+    ctx.author.id = 1
+    ctx.guild = MagicMock()
+    return _DeleteConfirmView(ctx, channels=channels, manager_message=None)
+
+
+async def _click(view, label: str, interaction) -> None:
+    """Invoke a decorator-defined button callback the way discord.py does."""
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.label == label
+    )
+    btn._view = view  # discord.py binds the parent view via Item._view
+    await btn.callback(interaction)
+
+
+def test_delete_picker_is_multiselect():
+    view = _build_view(_options((10, "alpha"), (20, "beta")))
+    assert isinstance(view.channel_select, MultiSelect)
+    assert view.channel_select.min_values == 1
+    assert view.channel_select.max_values == 2
+
+
+@pytest.mark.asyncio
+async def test_selecting_channels_records_all_ids():
+    view = _build_view(_options((10, "alpha"), (20, "beta")))
+    interaction = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    await view._on_channels_selected(interaction, [10, 20])
+    assert view.selected_channel_ids == [10, 20]
+    assert view._selected_names() == ["alpha", "beta"]
+    interaction.response.edit_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_delete_btn_requires_a_selection():
+    view = _build_view(_options((10, "alpha")))
+    interaction = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    await _click(view, "Delete Selected", interaction)
+    interaction.response.send_message.assert_awaited_once()
+    assert "at least one" in interaction.response.send_message.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_delete_btn_hands_all_targets_to_confirm_view():
+    view = _build_view(_options((10, "alpha"), (20, "beta")))
+    view.selected_channel_ids = [10, 20]
+    interaction = MagicMock()
+    captured: dict[str, object] = {}
+
+    async def _edit(*, embed, view):
+        captured["embed"] = embed
+        captured["view"] = view
+
+    interaction.response.edit_message = AsyncMock(side_effect=_edit)
+    await _click(view, "Delete Selected", interaction)
+
+    from views.channels.delete_panel import _DeleteConfirmView
+
+    assert isinstance(captured["view"], _DeleteConfirmView)
+    assert captured["view"].channels == [(10, "alpha"), (20, "beta")]
+    # confirm embed names every target
+    desc = captured["embed"].description
+    assert "alpha" in desc and "beta" in desc
+    assert "cannot be undone" in desc
+
+
+def test_confirm_embed_lists_every_channel():
+    view = _build_confirm([(10, "alpha"), (20, "beta"), (30, "gamma")])
+    embed = view.build_confirm_embed()
+    assert "3 channels" in embed.description
+    for name in ("alpha", "beta", "gamma"):
+        assert name in embed.description
+
+
+@pytest.mark.asyncio
+async def test_confirm_deletes_every_selected_channel():
+    view = _build_confirm([(10, "alpha"), (20, "beta")])
+    interaction = MagicMock()
+    interaction.guild = MagicMock()
+    interaction.channel = MagicMock()
+
+    ch_a = MagicMock()
+    ch_a.delete = AsyncMock()
+    ch_b = MagicMock()
+    ch_b.delete = AsyncMock()
+    by_id = {10: ch_a, 20: ch_b}
+
+    captured: dict[str, discord.Embed] = {}
+
+    async def _edit(_inter, *, embed, view):  # noqa: ARG001
+        captured["embed"] = embed
+        return True
+
+    with (
+        patch("views.channels.delete_panel.resources") as mock_res,
+        patch("views.channels.delete_panel.safe_defer", AsyncMock(return_value=True)),
+        patch("views.channels.delete_panel.safe_edit", AsyncMock(side_effect=_edit)),
+        patch(
+            "views.channels.delete_panel.restore_parent_or_send_fresh",
+            AsyncMock(return_value=None),
+        ),
+        patch("views.channels.delete_panel.asyncio.sleep", AsyncMock()),
+    ):
+        mock_res.resolve_channel = MagicMock(
+            side_effect=lambda _g, *, channel_id, kind: by_id.get(channel_id)
+        )
+        await _click(view, "Confirm Delete", interaction)
+
+    ch_a.delete.assert_awaited_once()
+    ch_b.delete.assert_awaited_once()
+    field_values = " ".join(f.value for f in captured["embed"].fields)
+    assert "alpha" in field_values
+    assert "beta" in field_values
+
+
+@pytest.mark.asyncio
+async def test_confirm_partitions_partial_failures():
+    view = _build_confirm([(10, "ok"), (20, "forbidden"), (30, "gone")])
+    interaction = MagicMock()
+    interaction.guild = MagicMock()
+    interaction.channel = MagicMock()
+
+    ch_ok = MagicMock()
+    ch_ok.delete = AsyncMock()
+    ch_forbidden = MagicMock()
+    ch_forbidden.delete = AsyncMock(side_effect=discord.Forbidden(MagicMock(), "nope"))
+    by_id = {10: ch_ok, 20: ch_forbidden}  # 30 resolves to None (gone)
+
+    captured: dict[str, discord.Embed] = {}
+
+    async def _edit(_inter, *, embed, view):  # noqa: ARG001
+        captured["embed"] = embed
+        return True
+
+    with (
+        patch("views.channels.delete_panel.resources") as mock_res,
+        patch("views.channels.delete_panel.safe_defer", AsyncMock(return_value=True)),
+        patch("views.channels.delete_panel.safe_edit", AsyncMock(side_effect=_edit)),
+        patch(
+            "views.channels.delete_panel.restore_parent_or_send_fresh",
+            AsyncMock(return_value=None),
+        ),
+        patch("views.channels.delete_panel.asyncio.sleep", AsyncMock()),
+    ):
+        mock_res.resolve_channel = MagicMock(
+            side_effect=lambda _g, *, channel_id, kind: by_id.get(channel_id)
+        )
+        await _click(view, "Confirm Delete", interaction)
+
+    names = {f.name: f.value for f in captured["embed"].fields}
+    joined = " || ".join(f"{k}={v}" for k, v in names.items())
+    assert "ok" in joined
+    assert "forbidden" in joined
+    assert "gone" in joined


### PR DESCRIPTION
## What & why

Second P1-10 adoption: the channel **delete** panel now uses the shared `views.selectors.MultiSelect`, so admins can remove **several channels in one pass** — the destructive sibling of the multi-lock shipped in #416.

Because deletion is irreversible, the confirm step **names every channel** that will be removed before anything happens, and the result embed partitions the outcome.

## Changes — `views/channels/delete_panel.py`

- **`_DeleteSubView`**: single `_ChannelSelect` → `MultiSelect` (`min_values=1`). Tracks `selected_channel_ids` + an id→name map for the embeds. Embed shows "Selected channels (N)".
- **`_DeleteConfirmView`**: takes the full `(id, name)` list, **lists every target** in the confirm embed ("Are you sure you want to delete the following 3 channels? … This action cannot be undone."), deletes each (defer **before** the writes so N deletes don't race the 3 s token), and summarises results as **deleted / 🚫 permission-denied / ❓ not-found / ⚠️ failed**.
- `_ChannelSelect` import dropped here (still used by `channel_cog`); the shared helper is untouched.

## Tests — `tests/unit/views/test_delete_panel_multi.py` (new)

picker is multi-select; records all ids; **Delete Selected** requires a selection and hands every target to the confirm view; confirm embed names all targets; confirm deletes each channel; partial-failure partitioning. (7 tests.)

## Why only this flow

I verified the audit's other named P1-10 candidates against the code and most aren't clean swaps — AI policy/behavior use **native `discord.ui.ChannelSelect`/`RoleSelect`** (already paginated) feeding **per-target modals**, so multi-select there is an architectural change to the `ai_policy_mutation` seam (binding doc + pin tests), not a primitive adoption; logging routes/channel-bind are navigation/single-target by nature. `delete_panel` is the one genuinely clean sibling of the restrict panel.

## Gates (CI-exact, `python3.10 -m`)

arch strict **0 errors**; black/isort/ruff(disbot scope)/mypy clean; `pytest tests/` **6507 passed, 3 skipped** (+7).

> **Stacked on #416** (the `MultiSelect` primitive). Base is `claude/multiselect-primitive-restrict`; will auto-retarget to `main` once #416 merges. Review/merge #416 first.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FsMAonaKRjMuV31vGLnkXW)_