### PR TITLE
Role automation: per-role XP/time exemptions + independent stacking toggles

### DIFF
--- a/disbot/cogs/role/__init__.py
+++ b/disbot/cogs/role/__init__.py
@@ -1,0 +1,7 @@
+"""Role subsystem package — schema declarations alongside cogs.role_cog.
+
+``cogs.role_cog`` remains the flat cog module (commands, listeners,
+lifecycle). This package hosts the subsystem's ``SettingSpec`` schema so
+the role-automation stacking toggles render in the Settings hub, mirroring
+the ``cogs/moderation`` + ``moderation_cog.py`` split.
+"""

--- a/disbot/cogs/role/schemas.py
+++ b/disbot/cogs/role/schemas.py
@@ -1,0 +1,81 @@
+"""Role subsystem schemas — the two role-automation stacking toggles.
+
+These booleans control whether each role-automation engine KEEPS or
+REMOVES previously-earned tier roles. Both default to the historical
+behaviour so existing guilds see no change until an operator flips them.
+
+The per-role exemptions (``exempt_xp`` / ``exempt_time``) are NOT scalar
+settings — they are structured, role-id-keyed rows in the
+``role_automation_exemptions`` table (migration 052) and are edited
+through the Roles settings UI (``views/roles/exemptions_panel.py``), not
+through these specs.
+"""
+
+from __future__ import annotations
+
+from core.runtime.subsystem_schema import (
+    SettingSpec,
+    SubsystemSchema,
+)
+from utils.settings_keys import TIME_ROLES_STACK, XP_ROLES_STACK
+
+_CAPABILITY = "role.settings.configure"
+
+
+def _validate_bool(value: object) -> None:
+    if not isinstance(value, bool):
+        raise ValueError(f"expected bool, got {type(value).__name__}")
+
+
+ROLE_SETTINGS: tuple[SettingSpec, ...] = (
+    SettingSpec(
+        name="time_roles_stack",
+        value_type=bool,
+        default=False,
+        settings_key=TIME_ROLES_STACK,
+        capability_required=_CAPABILITY,
+        hint=(
+            "When ON, members keep every tenure (time-based) role they have "
+            "earned. When OFF (default), reaching a new tenure tier removes "
+            "the previous one, so a member holds a single tenure role."
+        ),
+        validator=_validate_bool,
+    ),
+    SettingSpec(
+        name="xp_roles_stack",
+        value_type=bool,
+        default=True,
+        settings_key=XP_ROLES_STACK,
+        capability_required=_CAPABILITY,
+        hint=(
+            "When ON (default), members keep every XP/level role they earn — "
+            "the roles stack. When OFF, reaching a higher level role removes "
+            "the lower level roles, so a member holds a single level role."
+        ),
+        validator=_validate_bool,
+    ),
+)
+
+
+ROLE_CONFIG_SCHEMA = SubsystemSchema(
+    subsystem="role",
+    settings=ROLE_SETTINGS,
+    version=1,
+)
+
+
+def register_schemas() -> None:
+    """Register the Role subsystem schema. Called from ``RoleCog.cog_load``.
+
+    Re-registration-safe (the underlying registry logs and replaces).
+    """
+    from core.runtime import subsystem_schema
+
+    subsystem_schema.register(ROLE_CONFIG_SCHEMA)
+
+
+__all__ = [
+    "ROLE_CONFIG_SCHEMA",
+    "ROLE_SETTINGS",
+    "register_schemas",
+]

--- a/disbot/cogs/role_cog.py
+++ b/disbot/cogs/role_cog.py
@@ -28,6 +28,7 @@ def _build_role_hub_embed() -> discord.Embed:
             ("⚡ XP Roles", "Level-based auto-assignment", True),
             ("💬 Reaction Roles", "Emoji reaction role bindings", True),
             ("🔧 Diagnostics", "System status & debug tools", True),
+            ("🚫 Exemptions", "Exempt roles from XP/time automation", True),
         ],
         ROLE_COLOR,
     )
@@ -207,11 +208,43 @@ class RoleHubPanelView(PersistentView):
             view=panel,
         )
 
+    @discord.ui.button(
+        label="🚫 Exemptions",
+        style=discord.ButtonStyle.grey,
+        row=2,
+        custom_id="role:exemptions",
+    )
+    async def exemptions_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if not interaction.user.guild_permissions.administrator:  # type: ignore[union-attr]
+            await interaction.response.send_message(
+                "❌ You need **Administrator** permission.",
+                ephemeral=True,
+            )
+            return
+        from views.roles.exemptions_panel import RoleExemptionsPanel
+
+        self.message = interaction.message
+        panel = RoleExemptionsPanel(_CtxAdapter(interaction), parent=self)
+        panel.message = interaction.message
+        await interaction.response.edit_message(
+            embed=await panel.build_embed(),
+            view=panel,
+        )
+
 
 class RoleCog(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
         self.role_check.start()
+
+    async def cog_load(self) -> None:
+        from cogs.role.schemas import register_schemas
+
+        register_schemas()  # role-automation stacking toggles (Settings hub).
 
     def cog_unload(self) -> None:
         self.role_check.cancel()
@@ -250,11 +283,10 @@ class RoleCog(commands.Cog):
                 await ctx.send("✅ Role check complete — 0 assignment(s) made.")
             return 0
 
-        skip_role_names = tuple(
-            n.strip()
-            for n in (await db.get_setting(guild.id, "skip_roles", "Admin")).split(",")
-            if n.strip()
-        )
+        from services import role_exemption_service
+
+        exempt = await role_exemption_service.get_exempt_role_ids(guild.id)
+        keep_previous = await role_exemption_service.time_roles_stack(guild.id)
 
         threshold_objs = tuple(
             role_automation.RoleThreshold(
@@ -273,7 +305,8 @@ class RoleCog(commands.Cog):
         assignments = role_automation.compute_assignments(
             guild,
             threshold_objs,
-            skip_role_names=skip_role_names,
+            exempt_role_ids=exempt.time,
+            keep_previous_tier=keep_previous,
         )
         result = await role_automation.apply(
             guild,
@@ -571,10 +604,16 @@ class RoleCog(commands.Cog):
             # "lost testrole on restart" regression).
             if not row.get("xp_auto_assign") and row.get("days_required") is not None
         )
+        from services import role_exemption_service
+
+        exempt = await role_exemption_service.get_exempt_role_ids(member.guild.id)
+        keep_previous = await role_exemption_service.time_roles_stack(member.guild.id)
         plan = role_automation.explain_assignment_for(
             member.guild,
             member,
             threshold_objs,
+            exempt_role_ids=exempt.time,
+            keep_previous_tier=keep_previous,
         )
         if plan is None:
             return

--- a/disbot/cogs/xp/listener.py
+++ b/disbot/cogs/xp/listener.py
@@ -191,35 +191,75 @@ async def _apply_xp_threshold_roles(
     is at most one DB read per (TTL × guild) instead of per-level-up.
     """
     try:
-        xp_roles = await get_xp_threshold_roles(message.guild.id)
+        from services import role_exemption_service
+
+        guild = message.guild
+        member = message.author
+        member_role_ids = {r.id for r in getattr(member, "roles", ())}
+
+        exempt = await role_exemption_service.get_exempt_role_ids(guild.id)
+        if member_role_ids & exempt.xp:
+            return  # member holds an XP-exempt role — grant nothing
+
+        xp_roles = await get_xp_threshold_roles(guild.id)
+        qualifying: list = []  # earned roles (level_required <= new_level)
+        configured: list = []  # every configured XP role that resolves
         for role_cfg in xp_roles:
+            discord_role = resources.resolve_role(guild, name=role_cfg["role_name"])
+            if discord_role is None:
+                continue
+            configured.append(discord_role)
             if role_cfg["level_required"] <= new_level:
-                discord_role = resources.resolve_role(
-                    message.guild,
-                    name=role_cfg["role_name"],
+                qualifying.append(discord_role)
+        if not qualifying:
+            return
+
+        member_roles = member.roles  # type: ignore[union-attr]
+        if await role_exemption_service.xp_roles_stack(guild.id):
+            to_add = [r for r in qualifying if r not in member_roles]
+            to_remove: list = []
+        else:
+            # Single-role mode: keep only the highest earned level role
+            # (xp_roles is ordered by level_required ascending).
+            target = qualifying[-1]
+            to_add = [] if target in member_roles else [target]
+            to_remove = [r for r in configured if r != target and r in member_roles]
+
+        if to_add:
+            try:
+                await member.add_roles(  # type: ignore[union-attr]
+                    *to_add,
+                    reason=f"XP level-up: reached level {new_level}",
                 )
-                if (
-                    discord_role
-                    and discord_role not in message.author.roles  # type: ignore[union-attr]
-                ):
-                    try:
-                        await message.author.add_roles(  # type: ignore[union-attr]
-                            discord_role,
-                            reason=f"XP level-up: reached level {new_level}",
-                        )
-                        logger.info(
-                            "XP role assigned: %s → %s (level %d)",
-                            message.author.display_name,
-                            discord_role.name,
-                            new_level,
-                        )
-                    except (discord.Forbidden, discord.HTTPException) as role_err:
-                        logger.warning(
-                            "Could not assign XP role %s to %s: %s",
-                            discord_role.name,
-                            message.author.display_name,
-                            role_err,
-                        )
+                logger.info(
+                    "XP roles assigned: %s → %s (level %d)",
+                    member.display_name,
+                    [r.name for r in to_add],
+                    new_level,
+                )
+            except (discord.Forbidden, discord.HTTPException) as role_err:
+                logger.warning(
+                    "Could not assign XP roles to %s: %s",
+                    member.display_name,
+                    role_err,
+                )
+        if to_remove:
+            try:
+                await member.remove_roles(  # type: ignore[union-attr]
+                    *to_remove,
+                    reason=f"XP single-role mode: level {new_level}",
+                )
+                logger.info(
+                    "XP roles removed (single-role mode): %s → %s",
+                    member.display_name,
+                    [r.name for r in to_remove],
+                )
+            except (discord.Forbidden, discord.HTTPException) as role_err:
+                logger.warning(
+                    "Could not remove XP roles from %s: %s",
+                    member.display_name,
+                    role_err,
+                )
     except Exception:
         logger.error(
             "XP role assignment check failed for guild %d",

--- a/disbot/migrations/052_role_automation_exemptions.sql
+++ b/disbot/migrations/052_role_automation_exemptions.sql
@@ -1,0 +1,49 @@
+-- Migration 052: role_automation_exemptions.
+--
+-- Per-guild, per-role exemptions from the two role-automation systems.
+-- Replaces the flat, name-based ``skip_roles`` setting (which only ever
+-- affected the time-based engine) with a structured, role-id-keyed table
+-- that exempts a role from the XP and the time engines INDEPENDENTLY.
+--
+-- Schema
+-- ------
+-- role_automation_exemptions
+--   guild_id     The guild owning this exemption row.
+--   role_id      Discord role id.  Id-keyed (not name-keyed like the old
+--                skip_roles) so a role rename never silently breaks the
+--                exemption.  Composite primary key with guild_id so a role
+--                appears at most once per guild.
+--   exempt_xp    When TRUE, members holding this role are NOT granted
+--                XP/level (xp_auto_assign) roles by the XP listener.
+--   exempt_time  When TRUE, members holding this role are skipped entirely
+--                by the time-based (days-in-guild) progression engine.
+--
+-- A row with both flags FALSE carries no meaning; the write path deletes
+-- the row instead of storing all-false (so the table only ever lists
+-- roles that are exempt from something).
+--
+-- An index on ``guild_id`` is implicit in the composite primary key
+-- (Postgres uses the leading column), so the per-guild read needs no
+-- extra index.
+--
+-- Backward compatibility
+-- ----------------------
+-- The legacy ``skip_roles`` KV setting is intentionally NOT migrated
+-- (clean break — operators re-add exemptions via the new Roles settings
+-- UI).  The runtime read paths stop consulting ``skip_roles`` entirely.
+--
+-- Rollback
+-- --------
+-- ``DROP TABLE IF EXISTS role_automation_exemptions;``.  Reverting the
+-- consuming code without this migration leaves an orphan table that is
+-- harmless — nothing else references it.
+--
+-- Forward-only and idempotent.
+
+CREATE TABLE IF NOT EXISTS role_automation_exemptions (
+    guild_id    BIGINT  NOT NULL,
+    role_id     BIGINT  NOT NULL,
+    exempt_xp   BOOLEAN NOT NULL DEFAULT FALSE,
+    exempt_time BOOLEAN NOT NULL DEFAULT FALSE,
+    PRIMARY KEY (guild_id, role_id)
+);

--- a/disbot/services/role_automation.py
+++ b/disbot/services/role_automation.py
@@ -119,13 +119,20 @@ def compute_assignments(
     guild: Any,
     thresholds: list[RoleThreshold] | tuple[RoleThreshold, ...],
     *,
-    skip_role_names: tuple[str, ...] = (),
+    exempt_role_ids: frozenset[int] = frozenset(),
+    keep_previous_tier: bool = False,
     now: datetime | None = None,
 ) -> tuple[Assignment, ...]:
     """Walk ``guild.members`` and produce planned operations.
 
     Pure: no Discord API mutation, no DB writes. The result is what
     :func:`apply` would do if invoked with ``dry_run=False``.
+
+    ``exempt_role_ids`` — members holding any of these roles are skipped
+    entirely (the time-exempt set from ``role_automation_exemptions``).
+    ``keep_previous_tier`` — when ``True`` the previously-earned tier
+    roles are kept instead of being removed on promotion (the
+    ``time_roles_stack`` toggle).
     """
     if now is None:
         now = datetime.now(tz=timezone.utc)
@@ -135,15 +142,14 @@ def compute_assignments(
     role_map = {t.role_name: t.days_required for t in thresholds}
     progression = sorted(role_map, key=lambda r: role_map[r])
 
-    skip_roles = tuple(
-        r for n in skip_role_names if (r := _resolve_role(guild, n)) is not None
-    )
-
     out: list[Assignment] = []
     for member in getattr(guild, "members", ()) or ():
         if getattr(member, "bot", False):
             continue
-        if any(role in getattr(member, "roles", ()) for role in skip_roles):
+        if any(
+            getattr(r, "id", None) in exempt_role_ids
+            for r in getattr(member, "roles", ())
+        ):
             continue
         joined_at = getattr(member, "joined_at", None)
         if joined_at is None:
@@ -181,12 +187,16 @@ def compute_assignments(
         ):
             continue  # never demote
 
-        to_remove = [
-            r
-            for r in member_roles
-            if any(_normalize(r.name) == _normalize(n) for n in role_map)
-            and r != target_role
-        ]
+        to_remove = (
+            []
+            if keep_previous_tier
+            else [
+                r
+                for r in member_roles
+                if any(_normalize(r.name) == _normalize(n) for n in role_map)
+                and r != target_role
+            ]
+        )
 
         add_role_id = target_role.id if target_role else None
         add_role_name = target_role.name if target_role else None
@@ -240,7 +250,8 @@ def explain_assignment_for(
     member: Any,
     thresholds: list[RoleThreshold] | tuple[RoleThreshold, ...],
     *,
-    skip_role_names: tuple[str, ...] = (),
+    exempt_role_ids: frozenset[int] = frozenset(),
+    keep_previous_tier: bool = False,
     now: datetime | None = None,
 ) -> Assignment | None:
     """Return the planned operation for one member, or ``None`` if
@@ -250,7 +261,8 @@ def explain_assignment_for(
     plans = compute_assignments(
         fake_guild,
         thresholds,
-        skip_role_names=skip_role_names,
+        exempt_role_ids=exempt_role_ids,
+        keep_previous_tier=keep_previous_tier,
         now=now,
     )
     return plans[0] if plans else None

--- a/disbot/services/role_exemption_service.py
+++ b/disbot/services/role_exemption_service.py
@@ -1,0 +1,114 @@
+"""Role-automation exemptions + stacking-toggle access (read + write).
+
+The read side composes the cached exemption rows
+(:func:`utils.guild_config_accessors.get_role_exemptions`) into role-id
+sets and resolves the two stacking toggles, so the XP listener and the
+time-based engine share a single interpretation. The write side is the
+only sanctioned path for mutating exemptions: it persists, invalidates
+the cache, and emits an ``audit.action_recorded`` event.
+
+Cycle discipline: cross-package imports of ``services.*`` are
+function-local (mirrors the rest of ``services``); top-level imports are
+limited to stdlib + ``utils`` (which this layer may depend on).
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from utils import db
+from utils import guild_config_accessors as gca
+
+
+@dataclass(frozen=True)
+class ExemptRoleIds:
+    """Role ids exempted from each automation engine for one guild."""
+
+    xp: frozenset[int]
+    time: frozenset[int]
+
+
+async def get_exempt_role_ids(guild_id: int) -> ExemptRoleIds:
+    """Return the ``(xp, time)`` exempt role-id sets for ``guild_id`` (cached)."""
+    rows = await gca.get_role_exemptions(guild_id)
+    return ExemptRoleIds(
+        xp=frozenset(int(r["role_id"]) for r in rows if r["exempt_xp"]),
+        time=frozenset(int(r["role_id"]) for r in rows if r["exempt_time"]),
+    )
+
+
+async def time_roles_stack(guild_id: int) -> bool:
+    """Whether tenure roles stack (keep the previous tier) for ``guild_id``."""
+    from services.settings_resolution import resolve_value
+
+    return bool(await resolve_value(guild_id, "role", "time_roles_stack", False))
+
+
+async def xp_roles_stack(guild_id: int) -> bool:
+    """Whether XP/level roles stack (keep lower roles) for ``guild_id``."""
+    from services.settings_resolution import resolve_value
+
+    return bool(await resolve_value(guild_id, "role", "xp_roles_stack", True))
+
+
+def _flags_for(rows: list[dict], role_id: int) -> tuple[bool, bool]:
+    for row in rows:
+        if int(row["role_id"]) == role_id:
+            return bool(row["exempt_xp"]), bool(row["exempt_time"])
+    return False, False
+
+
+async def set_exemption(
+    guild_id: int,
+    role_id: int,
+    *,
+    exempt_xp: bool,
+    exempt_time: bool,
+    actor_id: int | None,
+) -> None:
+    """Persist a role's exemption flags (audited + cache-invalidated).
+
+    A row with neither flag set is deleted rather than stored, so the
+    table only ever lists roles that are exempt from something.
+    """
+    rows = await db.get_role_exemptions(guild_id)
+    prev_xp, prev_time = _flags_for(rows, role_id)
+
+    if not exempt_xp and not exempt_time:
+        await db.clear_role_exemption(guild_id, role_id)
+    else:
+        await db.set_role_exemption(
+            guild_id,
+            role_id,
+            exempt_xp=exempt_xp,
+            exempt_time=exempt_time,
+        )
+
+    gca.invalidate_role_exemptions(guild_id)
+
+    from services.audit_events import emit_audit_action
+
+    await emit_audit_action(
+        mutation_id=str(uuid.uuid4()),
+        subsystem="role",
+        mutation_type="set_role_exemption",
+        target=f"role:{role_id}",
+        scope="guild",
+        guild_id=guild_id,
+        prev_value=f"xp={prev_xp},time={prev_time}",
+        new_value=f"xp={exempt_xp},time={exempt_time}",
+        actor_id=actor_id,
+        actor_type="admin",
+        occurred_at=datetime.now(tz=timezone.utc),
+    )
+
+
+__all__ = [
+    "ExemptRoleIds",
+    "get_exempt_role_ids",
+    "set_exemption",
+    "time_roles_stack",
+    "xp_roles_stack",
+]

--- a/disbot/utils/db/__init__.py
+++ b/disbot/utils/db/__init__.py
@@ -114,12 +114,15 @@ from utils.db.moderation import (
 from utils.db.pool import close, execute, fetchall, fetchone, get, init
 from utils.db.roles import (
     add_reaction_role,
+    clear_role_exemption,
     get_all_reaction_roles,
     get_reaction_role,
+    get_role_exemptions,
     get_role_thresholds,
     get_xp_threshold_roles,
     remove_reaction_role,
     remove_role_threshold,
+    set_role_exemption,
     set_role_threshold,
     set_role_xp_threshold,
 )
@@ -162,12 +165,15 @@ __all__ = [
     "set_setting",
     # roles
     "add_reaction_role",
+    "clear_role_exemption",
     "get_all_reaction_roles",
     "get_reaction_role",
+    "get_role_exemptions",
     "get_role_thresholds",
     "get_xp_threshold_roles",
     "remove_reaction_role",
     "remove_role_threshold",
+    "set_role_exemption",
     "set_role_threshold",
     "set_role_xp_threshold",
     # moderation

--- a/disbot/utils/db/roles.py
+++ b/disbot/utils/db/roles.py
@@ -75,6 +75,47 @@ async def set_role_xp_threshold(
 
 
 # ---------------------------------------------------------------------------
+# Role-automation exemptions (per-role, id-keyed) — migration 052
+# ---------------------------------------------------------------------------
+
+
+async def get_role_exemptions(guild_id: int) -> list[dict]:
+    """Return every exemption row for ``guild_id`` (role_id + both flags)."""
+    return await pool.fetchall(
+        "SELECT role_id, exempt_xp, exempt_time "
+        "FROM role_automation_exemptions WHERE guild_id=$1 ORDER BY role_id",
+        (guild_id,),
+    )
+
+
+async def set_role_exemption(
+    guild_id: int,
+    role_id: int,
+    *,
+    exempt_xp: bool,
+    exempt_time: bool,
+) -> None:
+    """Upsert the exemption flags for a single role."""
+    await pool.execute(
+        """INSERT INTO role_automation_exemptions
+               (guild_id, role_id, exempt_xp, exempt_time)
+           VALUES ($1, $2, $3, $4)
+           ON CONFLICT (guild_id, role_id) DO UPDATE SET
+               exempt_xp = EXCLUDED.exempt_xp,
+               exempt_time = EXCLUDED.exempt_time""",
+        (guild_id, role_id, exempt_xp, exempt_time),
+    )
+
+
+async def clear_role_exemption(guild_id: int, role_id: int) -> None:
+    """Delete the exemption row for a role (used when both flags clear)."""
+    await pool.execute(
+        "DELETE FROM role_automation_exemptions WHERE guild_id=$1 AND role_id=$2",
+        (guild_id, role_id),
+    )
+
+
+# ---------------------------------------------------------------------------
 # Reaction roles
 # ---------------------------------------------------------------------------
 

--- a/disbot/utils/guild_config_accessors.py
+++ b/disbot/utils/guild_config_accessors.py
@@ -176,6 +176,36 @@ def invalidate_xp_threshold_roles(guild_id: int) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Role-automation exemptions — consumed by the XP listener (hot) + role_cog
+# ---------------------------------------------------------------------------
+
+
+def _role_exemptions_loader(
+    guild_id: int,
+) -> Callable[[], Awaitable[list[dict]]]:
+    async def _load() -> list[dict]:
+        return await db.get_role_exemptions(guild_id)
+
+    return _load
+
+
+_role_exemptions_accessor: TypedAccessor[list[dict]] = TypedAccessor(
+    cache_key="role_exemptions",
+    loader_factory=_role_exemptions_loader,
+)
+
+
+async def get_role_exemptions(guild_id: int) -> list[dict]:
+    """Return cached role-automation exemption rows for ``guild_id``."""
+    return await _role_exemptions_accessor.get(guild_id)
+
+
+def invalidate_role_exemptions(guild_id: int) -> None:
+    """Drop cached exemptions — call from every exemption write."""
+    _role_exemptions_accessor.invalidate(guild_id)
+
+
+# ---------------------------------------------------------------------------
 # SettingSpec scalar lane — consumed by services/settings_resolution (S3)
 # ---------------------------------------------------------------------------
 

--- a/disbot/utils/settings_keys/__init__.py
+++ b/disbot/utils/settings_keys/__init__.py
@@ -48,7 +48,7 @@ from utils.settings_keys.logging import (
     LOGGING_MOD_CHANNEL,
 )
 from utils.settings_keys.moderation import WARN_THRESHOLD, WARN_TIMEOUT_MINS
-from utils.settings_keys.role import SKIP_ROLES
+from utils.settings_keys.role import SKIP_ROLES, TIME_ROLES_STACK, XP_ROLES_STACK
 from utils.settings_keys.xp import (
     XP_ANNOUNCE_CHANNEL,
     XP_COOLDOWN,
@@ -84,6 +84,8 @@ __all__ = [
     "LOGGING_MOD_CHANNEL",
     "RPS_DEFAULT_ENTRY_FEE",
     "SKIP_ROLES",
+    "TIME_ROLES_STACK",
+    "XP_ROLES_STACK",
     "TRUSTED_TIER_ROLE_ID",
     "WARN_THRESHOLD",
     "WARN_TIMEOUT_MINS",

--- a/disbot/utils/settings_keys/role.py
+++ b/disbot/utils/settings_keys/role.py
@@ -1,3 +1,15 @@
 """Settings keys owned by the Role subsystem (cogs.role_cog)."""
 
+# Legacy, name-based, time-only exemption list. Superseded by the
+# role_automation_exemptions table (migration 052); retained as a stable
+# key only so historical KV rows do not error. No longer read at runtime.
 SKIP_ROLES = "skip_roles"
+
+# When TRUE, time-based (tenure) progression KEEPS previously-earned tier
+# roles instead of removing them on promotion. Default FALSE preserves the
+# historical single-role behaviour.
+TIME_ROLES_STACK = "time_roles_stack"
+
+# When TRUE (default), XP/level roles STACK — every earned level role is
+# kept. When FALSE, earning a higher level role removes the lower ones.
+XP_ROLES_STACK = "xp_roles_stack"

--- a/disbot/utils/subsystem_registry.py
+++ b/disbot/utils/subsystem_registry.py
@@ -223,6 +223,7 @@ SUBSYSTEMS: dict[str, dict] = {
         "ui_priority": 70,
         "parent_hub": "community",
         "capabilities": [
+            "role.settings.configure",
             "role.threshold.configure",
             "role.assignment.manage",
             "role.reaction.manage",

--- a/disbot/views/roles/diagnostics_panel.py
+++ b/disbot/views/roles/diagnostics_panel.py
@@ -3,16 +3,16 @@ from __future__ import annotations
 import discord
 from discord.ext import commands
 
+from core.runtime import resources
 from core.runtime.interaction_helpers import safe_defer
 from utils import db
-from utils.settings_keys import SKIP_ROLES
 from utils.ui_constants import WARNING_COLOR
 from views.base import BaseView
 from views.navigation import attach_back_button
 
 
 class DiagnosticsPanel(BaseView):
-    """Role system diagnostics — counts, skip_roles, member cache status."""
+    """Role system diagnostics — counts, exemptions, member cache status."""
 
     def __init__(self, ctx: commands.Context, parent: BaseView | None = None) -> None:
         super().__init__(ctx.author, timeout=300)
@@ -39,7 +39,7 @@ class DiagnosticsPanel(BaseView):
         thresholds = await db.get_role_thresholds(guild.id)
         xp_rows = [r for r in thresholds if r.get("level_required") is not None]
         reaction_rows = await db.get_all_reaction_roles(guild.id)
-        skip_roles = await db.get_setting(guild.id, SKIP_ROLES, "Admin")
+        exemptions = await db.get_role_exemptions(guild.id)
 
         embed = discord.Embed(title="🔧 Role System Diagnostics", color=WARNING_COLOR)
         embed.add_field(name="Time Thresholds", value=str(len(thresholds)), inline=True)
@@ -49,7 +49,24 @@ class DiagnosticsPanel(BaseView):
             value=str(len(reaction_rows)),
             inline=True,
         )
-        embed.add_field(name="Skip Roles", value=skip_roles or "*(none)*", inline=False)
+        if exemptions:
+            exempt_lines = []
+            for row in exemptions:
+                role = resources.resolve_role(guild, role_id=row["role_id"])
+                rname = role.name if role else f"id:{row['role_id']}"
+                tags = [
+                    tag
+                    for tag, on in (
+                        ("xp", row["exempt_xp"]),
+                        ("time", row["exempt_time"]),
+                    )
+                    if on
+                ]
+                exempt_lines.append(f"{rname} ({', '.join(tags)})")
+            exempt_value = "\n".join(exempt_lines)[:1024]
+        else:
+            exempt_value = "*(none)*"
+        embed.add_field(name="Role Exemptions", value=exempt_value, inline=False)
         embed.add_field(
             name="Members Cached",
             value=str(len([m for m in guild.members if not m.bot])),

--- a/disbot/views/roles/exemptions_panel.py
+++ b/disbot/views/roles/exemptions_panel.py
@@ -1,0 +1,239 @@
+"""Role-automation exemptions panel — Settings UI for per-role exemptions.
+
+Lets an operator pick one or more server roles and mark them exempt from
+the XP and/or time-based role automation independently, and flip the two
+"stack vs. single" tier toggles. Reads/writes route through
+:mod:`services.role_exemption_service` (audited + cache-invalidated); the
+stacking toggles flip through the canonical settings toggle helper.
+"""
+
+from __future__ import annotations
+
+import discord
+from discord.ext import commands
+
+from core.runtime import resources
+from utils import db
+from utils.ui_constants import ROLE_COLOR
+from views.base import BaseView
+from views.navigation import attach_back_button
+
+
+class _ExemptRoleSelect(discord.ui.RoleSelect):
+    """Multi-role picker — stores the selection on the parent panel."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            placeholder="Select role(s) to configure…",
+            min_values=0,
+            max_values=25,
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        if not isinstance(view, RoleExemptionsPanel):
+            return
+        view.selected_role_ids = [role.id for role in self.values]
+        await interaction.response.edit_message(
+            embed=await view.build_embed(),
+            view=view,
+        )
+
+
+class RoleExemptionsPanel(BaseView):
+    """Per-role automation exemptions + the two tier-stacking toggles."""
+
+    def __init__(self, ctx: commands.Context, parent: BaseView | None = None) -> None:
+        super().__init__(ctx.author, timeout=300)
+        self.ctx = ctx
+        self.parent = parent
+        self.selected_role_ids: list[int] = []
+        self.add_item(_ExemptRoleSelect())
+
+        if parent is not None:
+
+            async def _build_parent(
+                _interaction: discord.Interaction,
+            ) -> tuple[discord.Embed, discord.ui.View]:
+                return parent.build_embed(), parent
+
+            attach_back_button(
+                self,
+                label="↩ Back",
+                custom_id="role:exemptions:back",
+                parent_builder=_build_parent,
+                row=4,
+            )
+
+    async def build_embed(self) -> discord.Embed:
+        from services.settings_resolution import resolve_value
+
+        guild = self.ctx.guild
+        rows = await db.get_role_exemptions(guild.id)
+        time_stack = bool(
+            await resolve_value(guild.id, "role", "time_roles_stack", False),
+        )
+        xp_stack = bool(await resolve_value(guild.id, "role", "xp_roles_stack", True))
+
+        embed = discord.Embed(
+            title="🚫 Role Automation Exemptions",
+            description=(
+                "Pick role(s) from the dropdown, then mark them exempt from "
+                "the XP and/or time-based role automation. Members holding an "
+                "XP-exempt role earn no level roles; members holding a "
+                "time-exempt role get no tenure (days-in-server) roles."
+            ),
+            color=ROLE_COLOR,
+        )
+
+        if rows:
+            lines = []
+            for row in rows:
+                role = resources.resolve_role(guild, role_id=row["role_id"])
+                rname = role.mention if role else f"`id:{row['role_id']}`"
+                tags = [
+                    tag
+                    for tag, on in (
+                        ("XP", row["exempt_xp"]),
+                        ("Time", row["exempt_time"]),
+                    )
+                    if on
+                ]
+                lines.append(f"{rname} — exempt: {', '.join(tags)}")
+            value = "\n".join(lines)[:1024]
+        else:
+            value = "*(none)*"
+        embed.add_field(name="Current exemptions", value=value, inline=False)
+
+        if self.selected_role_ids:
+            parts = []
+            for rid in self.selected_role_ids:
+                role = resources.resolve_role(guild, role_id=rid)
+                parts.append(role.mention if role else f"id:{rid}")
+            selected = ", ".join(parts)
+        else:
+            selected = "*(none — pick from the dropdown first)*"
+        embed.add_field(name="Selected", value=selected[:1024], inline=False)
+
+        embed.add_field(
+            name="Tier stacking",
+            value=(
+                f"Time roles: **{'stack (keep all)' if time_stack else 'single (replace)'}**\n"
+                f"XP roles: **{'stack (keep all)' if xp_stack else 'single (replace)'}**"
+            ),
+            inline=False,
+        )
+        return embed
+
+    async def _apply(
+        self,
+        interaction: discord.Interaction,
+        *,
+        field: str,
+        value: bool,
+    ) -> None:
+        if not self.selected_role_ids:
+            await interaction.response.send_message(
+                "Pick one or more roles from the dropdown first.",
+                ephemeral=True,
+            )
+            return
+
+        from services import role_exemption_service
+
+        guild = self.ctx.guild
+        rows = await db.get_role_exemptions(guild.id)
+        current = {
+            int(r["role_id"]): (bool(r["exempt_xp"]), bool(r["exempt_time"]))
+            for r in rows
+        }
+        for role_id in self.selected_role_ids:
+            exempt_xp, exempt_time = current.get(role_id, (False, False))
+            if field == "xp":
+                exempt_xp = value
+            else:
+                exempt_time = value
+            await role_exemption_service.set_exemption(
+                guild.id,
+                role_id,
+                exempt_xp=exempt_xp,
+                exempt_time=exempt_time,
+                actor_id=interaction.user.id,
+            )
+        await interaction.response.edit_message(
+            embed=await self.build_embed(),
+            view=self,
+        )
+
+    @discord.ui.button(label="Exempt XP", style=discord.ButtonStyle.danger, row=1)
+    async def exempt_xp_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        await self._apply(interaction, field="xp", value=True)
+
+    @discord.ui.button(label="Allow XP", style=discord.ButtonStyle.secondary, row=1)
+    async def allow_xp_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        await self._apply(interaction, field="xp", value=False)
+
+    @discord.ui.button(label="Exempt Time", style=discord.ButtonStyle.danger, row=2)
+    async def exempt_time_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        await self._apply(interaction, field="time", value=True)
+
+    @discord.ui.button(label="Allow Time", style=discord.ButtonStyle.secondary, row=2)
+    async def allow_time_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        await self._apply(interaction, field="time", value=False)
+
+    async def _toggle_stack(
+        self,
+        interaction: discord.Interaction,
+        setting_name: str,
+    ) -> None:
+        from views.settings.edit_boolean import toggle_setting
+
+        await toggle_setting(interaction, "role", setting_name)
+        # toggle_setting consumes the interaction response (ephemeral
+        # confirmation); refresh the panel message directly so the
+        # displayed stacking state stays in sync.
+        try:
+            await interaction.message.edit(embed=await self.build_embed(), view=self)
+        except discord.HTTPException:
+            pass
+
+    @discord.ui.button(
+        label="Toggle time stacking",
+        style=discord.ButtonStyle.blurple,
+        row=3,
+    )
+    async def toggle_time_stack_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        await self._toggle_stack(interaction, "time_roles_stack")
+
+    @discord.ui.button(
+        label="Toggle XP stacking",
+        style=discord.ButtonStyle.blurple,
+        row=3,
+    )
+    async def toggle_xp_stack_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        await self._toggle_stack(interaction, "xp_roles_stack")

--- a/docs/settings-customization-command-map.md
+++ b/docs/settings-customization-command-map.md
@@ -375,23 +375,30 @@ Subsystems (22): `admin`, `moderation`, `economy`, `inventory`, `mining`,
 6. **help_menu_discoverable**: Yes.
 7. **dedicated_panel_command**: `none`.
 8. **help_menu_direct_navigation_hook**: `none`.
-9. **existing_SettingSpec_declarations**: none.
-10. **existing_settings_keys**: `SKIP_ROLES`
+9. **existing_SettingSpec_declarations**: `time_roles_stack`,
+   `xp_roles_stack` (`disbot/cogs/role/schemas.py`).
+10. **existing_settings_keys**: `SKIP_ROLES` (legacy — no longer read at
+    runtime), `TIME_ROLES_STACK`, `XP_ROLES_STACK`
     (`disbot/utils/settings_keys/role.py`).
 11. **existing_BindingSpec_entries**: none.
 12. **existing_ResourceRequirement_entries**: none.
 13. **current_access_policy_behavior**: `visibility_tier=administrator`;
-    capabilities `role.threshold.configure`, `role.assignment.manage`,
-    `role.reaction.manage`.
-14. **hardcoded_or_env_only_behavior**: time-based role thresholds, default
-    self-role list, reaction-role channels.
+    capabilities `role.settings.configure`, `role.threshold.configure`,
+    `role.assignment.manage`, `role.reaction.manage`.
+14. **hardcoded_or_env_only_behavior**: time-based role thresholds;
+    reaction-role channels. Per-role XP/time exemptions are stored in the
+    `role_automation_exemptions` table (migration 052), edited via the
+    Roles → Exemptions panel.
 15. **missing_customization_commands**: `!settings role thresholds set ...`,
-    self-role list editor, reaction-role manager UI.
-16. **missing_settings_pages**: Settings Manager role page.
-17. **missing_menu_buttons_selects_modals**: SKIP_ROLES list editor,
-    default-role RoleSelectView, role_menu_channel BindingSelectView.
-18. **setting_class_per_value**: SKIP_ROLES → list; thresholds → scalar /
-    list; default_role → binding; role_menu_channel → binding.
+    reaction-role manager UI.
+16. **missing_settings_pages**: thresholds editor page (stacking toggles +
+    exemptions shipped).
+17. **missing_menu_buttons_selects_modals**: time/XP threshold editor
+    parity; reaction-role manager.
+18. **setting_class_per_value**: `time_roles_stack` / `xp_roles_stack` →
+    scalar bool (Settings hub toggle); per-role `exempt_xp` / `exempt_time`
+    → typed `role_automation_exemptions` rows (Roles → Exemptions panel);
+    thresholds → scalar / list.
 19. **target_Settings_Manager_page**: `!settings subsystem role`.
 20. **target_mutation_path**: `SettingsMutationPipeline` (scalars / lists);
     `BindingMutationPipeline` (role / channel bindings);

--- a/tests/unit/cogs/test_role_cog_routing.py
+++ b/tests/unit/cogs/test_role_cog_routing.py
@@ -26,6 +26,25 @@ _REPO_ROOT = Path(__file__).resolve().parents[3]
 _ROLE_COG = _REPO_ROOT / "disbot" / "cogs" / "role_cog.py"
 
 
+@pytest.fixture(autouse=True)
+def _stub_role_exemptions():
+    """Stub the role-exemption reads (DB-backed) so the routing tests stay
+    pure. ``_assign_roles`` / ``on_member_join`` now consult
+    ``role_exemption_service`` for the time-exempt set + stacking toggle.
+    """
+    from services import role_exemption_service as res
+
+    with (
+        patch.object(
+            res,
+            "get_exempt_role_ids",
+            new=AsyncMock(return_value=res.ExemptRoleIds(frozenset(), frozenset())),
+        ),
+        patch.object(res, "time_roles_stack", new=AsyncMock(return_value=False)),
+    ):
+        yield
+
+
 @pytest.mark.asyncio
 async def test_assign_roles_delegates_to_role_automation():
     """_assign_roles must call compute_assignments + apply, not Discord directly."""

--- a/tests/unit/cogs/test_xp_listener_roles.py
+++ b/tests/unit/cogs/test_xp_listener_roles.py
@@ -1,0 +1,117 @@
+"""XP level-role grants honour exemptions + the xp_roles_stack toggle."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cogs.xp import listener
+from services.role_exemption_service import ExemptRoleIds
+
+_XP_ROWS = [
+    {"role_name": "Lvl5", "level_required": 5},
+    {"role_name": "Lvl10", "level_required": 10},
+]
+
+
+def _role(rid: int, name: str) -> SimpleNamespace:
+    return SimpleNamespace(id=rid, name=name)
+
+
+def _message(member_roles: list) -> tuple[MagicMock, MagicMock]:
+    member = MagicMock()
+    member.roles = list(member_roles)
+    member.add_roles = AsyncMock()
+    member.remove_roles = AsyncMock()
+    member.display_name = "u"
+    msg = MagicMock()
+    msg.author = member
+    msg.guild = MagicMock(id=1)
+    return msg, member
+
+
+@pytest.mark.asyncio
+async def test_exempt_xp_member_gets_no_level_roles():
+    admin = _role(99, "Admin")
+    msg, member = _message([admin])
+    with (
+        patch(
+            "services.role_exemption_service.get_exempt_role_ids",
+            new=AsyncMock(
+                return_value=ExemptRoleIds(xp=frozenset({99}), time=frozenset())
+            ),
+        ),
+        patch(
+            "services.role_exemption_service.xp_roles_stack",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "cogs.xp.listener.get_xp_threshold_roles",
+            new=AsyncMock(return_value=_XP_ROWS),
+        ),
+        patch("cogs.xp.listener.resources") as res_mock,
+    ):
+        res_mock.resolve_role.return_value = _role(5, "Lvl5")
+        await listener._apply_xp_threshold_roles(msg, 10)
+
+    member.add_roles.assert_not_awaited()
+    member.remove_roles.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_xp_roles_stack_adds_all_qualifying():
+    lvl5, lvl10 = _role(5, "Lvl5"), _role(10, "Lvl10")
+    roles_by_name = {"Lvl5": lvl5, "Lvl10": lvl10}
+    msg, member = _message([])  # holds nothing
+    with (
+        patch(
+            "services.role_exemption_service.get_exempt_role_ids",
+            new=AsyncMock(return_value=ExemptRoleIds(frozenset(), frozenset())),
+        ),
+        patch(
+            "services.role_exemption_service.xp_roles_stack",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "cogs.xp.listener.get_xp_threshold_roles",
+            new=AsyncMock(return_value=_XP_ROWS),
+        ),
+        patch("cogs.xp.listener.resources") as res_mock,
+    ):
+        res_mock.resolve_role.side_effect = lambda guild, name: roles_by_name.get(name)
+        await listener._apply_xp_threshold_roles(msg, 10)
+
+    member.add_roles.assert_awaited_once()
+    assert {r.id for r in member.add_roles.await_args.args} == {5, 10}
+    member.remove_roles.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_xp_roles_single_mode_keeps_highest_removes_lower():
+    lvl5, lvl10 = _role(5, "Lvl5"), _role(10, "Lvl10")
+    roles_by_name = {"Lvl5": lvl5, "Lvl10": lvl10}
+    msg, member = _message([lvl5])  # already holds the lower role
+    with (
+        patch(
+            "services.role_exemption_service.get_exempt_role_ids",
+            new=AsyncMock(return_value=ExemptRoleIds(frozenset(), frozenset())),
+        ),
+        patch(
+            "services.role_exemption_service.xp_roles_stack",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "cogs.xp.listener.get_xp_threshold_roles",
+            new=AsyncMock(return_value=_XP_ROWS),
+        ),
+        patch("cogs.xp.listener.resources") as res_mock,
+    ):
+        res_mock.resolve_role.side_effect = lambda guild, name: roles_by_name.get(name)
+        await listener._apply_xp_threshold_roles(msg, 10)
+
+    member.add_roles.assert_awaited_once()
+    assert {r.id for r in member.add_roles.await_args.args} == {10}
+    member.remove_roles.assert_awaited_once()
+    assert {r.id for r in member.remove_roles.await_args.args} == {5}

--- a/tests/unit/services/test_role_automation.py
+++ b/tests/unit/services/test_role_automation.py
@@ -117,7 +117,7 @@ def test_compute_assignments_skips_bots_and_missing_joined_at():
     assert plans == ()
 
 
-def test_compute_assignments_skips_members_in_skip_roles():
+def test_compute_assignments_skips_members_with_time_exempt_role():
     admin = _role(99, "Admin")
     threshold_role = _role(100, "Veteran")
     member = _member(
@@ -130,9 +130,35 @@ def test_compute_assignments_skips_members_in_skip_roles():
     plans = compute_assignments(
         g,
         [RoleThreshold("Veteran", 30)],
-        skip_role_names=("Admin",),
+        exempt_role_ids=frozenset({99}),  # Admin role id is time-exempt
     )
     assert plans == ()
+
+
+def test_compute_assignments_keeps_previous_tier_when_stacking():
+    """With keep_previous_tier=True (time_roles_stack ON), promotion adds the
+    new tier but does NOT remove the previous one.
+    """
+    veteran = _role(100, "Veteran", position=2)
+    legendary = _role(101, "Legendary", position=3)
+    member = _member(
+        mid=1,
+        display="u1",
+        roles=[veteran],
+        joined_days_ago=120,
+    )
+    g = _guild(roles=[veteran, legendary], members=[member])
+    plans = compute_assignments(
+        g,
+        [
+            RoleThreshold("Veteran", 30),
+            RoleThreshold("Legendary", 90),
+        ],
+        keep_previous_tier=True,
+    )
+    assert len(plans) == 1
+    assert plans[0].add_role_name == "Legendary"
+    assert plans[0].remove_role_names == ()  # Veteran kept (stacking on)
 
 
 def test_compute_assignments_promotes_member_who_crosses_threshold():

--- a/tests/unit/services/test_role_exemption_service.py
+++ b/tests/unit/services/test_role_exemption_service.py
@@ -1,0 +1,80 @@
+"""Tests for services.role_exemption_service (read composition + audited writes)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services import role_exemption_service as res
+
+
+@pytest.mark.asyncio
+async def test_get_exempt_role_ids_composes_xp_and_time_sets():
+    rows = [
+        {"role_id": 10, "exempt_xp": True, "exempt_time": False},
+        {"role_id": 20, "exempt_xp": False, "exempt_time": True},
+        {"role_id": 30, "exempt_xp": True, "exempt_time": True},
+    ]
+    with patch.object(res.gca, "get_role_exemptions", new=AsyncMock(return_value=rows)):
+        out = await res.get_exempt_role_ids(1)
+    assert out.xp == frozenset({10, 30})
+    assert out.time == frozenset({20, 30})
+
+
+@pytest.mark.asyncio
+async def test_set_exemption_upserts_invalidates_and_audits():
+    with (
+        patch.object(res.db, "get_role_exemptions", new=AsyncMock(return_value=[])),
+        patch.object(res.db, "set_role_exemption", new=AsyncMock()) as set_mock,
+        patch.object(res.db, "clear_role_exemption", new=AsyncMock()) as clear_mock,
+        patch.object(res.gca, "invalidate_role_exemptions") as inval_mock,
+        patch(
+            "services.audit_events.emit_audit_action",
+            new=AsyncMock(return_value=True),
+        ) as audit_mock,
+    ):
+        await res.set_exemption(1, 10, exempt_xp=True, exempt_time=False, actor_id=99)
+
+    set_mock.assert_awaited_once()
+    clear_mock.assert_not_awaited()
+    inval_mock.assert_called_once_with(1)
+    audit_mock.assert_awaited_once()
+    # The audit row names the role + the new flags.
+    kwargs = audit_mock.await_args.kwargs
+    assert kwargs["subsystem"] == "role"
+    assert kwargs["target"] == "role:10"
+    assert "xp=True" in kwargs["new_value"]
+
+
+@pytest.mark.asyncio
+async def test_set_exemption_deletes_row_when_both_flags_clear():
+    rows = [{"role_id": 10, "exempt_xp": True, "exempt_time": False}]
+    with (
+        patch.object(res.db, "get_role_exemptions", new=AsyncMock(return_value=rows)),
+        patch.object(res.db, "set_role_exemption", new=AsyncMock()) as set_mock,
+        patch.object(res.db, "clear_role_exemption", new=AsyncMock()) as clear_mock,
+        patch.object(res.gca, "invalidate_role_exemptions"),
+        patch(
+            "services.audit_events.emit_audit_action",
+            new=AsyncMock(return_value=True),
+        ),
+    ):
+        await res.set_exemption(1, 10, exempt_xp=False, exempt_time=False, actor_id=99)
+
+    clear_mock.assert_awaited_once_with(1, 10)
+    set_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stacking_toggles_resolve_with_correct_defaults():
+    with patch(
+        "services.settings_resolution.resolve_value",
+        new=AsyncMock(side_effect=[True, False]),
+    ) as rv:
+        assert await res.time_roles_stack(1) is True
+        assert await res.xp_roles_stack(1) is False
+
+    # time default is False (single), xp default is True (stack).
+    assert rv.await_args_list[0].args == (1, "role", "time_roles_stack", False)
+    assert rv.await_args_list[1].args == (1, "role", "xp_roles_stack", True)

--- a/tests/unit/views/test_role_exemptions_panel.py
+++ b/tests/unit/views/test_role_exemptions_panel.py
@@ -1,0 +1,87 @@
+"""Tests for the role-automation exemptions settings panel."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from views.roles.exemptions_panel import RoleExemptionsPanel
+
+
+def _ctx(guild_roles: list | None = None) -> SimpleNamespace:
+    guild = MagicMock()
+    guild.id = 1
+    roles = {r.id: r for r in (guild_roles or [])}
+    guild.get_role.side_effect = lambda rid: roles.get(rid)
+    return SimpleNamespace(author=MagicMock(id=99), guild=guild, bot=MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_build_embed_lists_exemptions_and_stacking_state():
+    role = SimpleNamespace(id=10, name="Admin", mention="@Admin")
+    panel = RoleExemptionsPanel(_ctx([role]))
+    rows = [{"role_id": 10, "exempt_xp": True, "exempt_time": False}]
+    with (
+        patch("utils.db.get_role_exemptions", new=AsyncMock(return_value=rows)),
+        patch(
+            "services.settings_resolution.resolve_value",
+            new=AsyncMock(side_effect=[False, True]),  # time=single, xp=stack
+        ),
+    ):
+        embed = await panel.build_embed()
+
+    fields = {f.name: f.value for f in embed.fields}
+    assert "XP" in fields["Current exemptions"]
+    assert "single" in fields["Tier stacking"].lower()
+    assert "stack" in fields["Tier stacking"].lower()
+
+
+@pytest.mark.asyncio
+async def test_apply_writes_each_selected_role_through_service():
+    panel = RoleExemptionsPanel(_ctx())
+    panel.selected_role_ids = [10, 20]
+    interaction = MagicMock()
+    interaction.user.id = 99
+    interaction.response.edit_message = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+
+    with (
+        patch("utils.db.get_role_exemptions", new=AsyncMock(return_value=[])),
+        patch(
+            "services.settings_resolution.resolve_value",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "services.role_exemption_service.set_exemption",
+            new=AsyncMock(),
+        ) as set_mock,
+    ):
+        await panel._apply(interaction, field="xp", value=True)
+
+    assert set_mock.await_count == 2
+    for call in set_mock.await_args_list:
+        assert call.kwargs["exempt_xp"] is True
+        assert call.kwargs["exempt_time"] is False  # untouched (no prior row)
+        assert call.kwargs["actor_id"] == 99
+    interaction.response.edit_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_apply_without_selection_warns_and_does_not_write():
+    panel = RoleExemptionsPanel(_ctx())
+    panel.selected_role_ids = []
+    interaction = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+
+    with patch(
+        "services.role_exemption_service.set_exemption",
+        new=AsyncMock(),
+    ) as set_mock:
+        await panel._apply(interaction, field="time", value=True)
+
+    set_mock.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once()
+    interaction.response.edit_message.assert_not_called()


### PR DESCRIPTION
Replaces the flat, name-based `skip_roles` setting (time-only, DB-edit-only) with a structured, operator-editable role-automation model, and makes the keep-vs-remove behaviour of each engine independently configurable. Everything is editable from the settings UI (no new prefix commands), per the design we agreed.

### What you get
- **Per-role exemptions, two independent flags.** Each role can be `exempt_xp` and/or `exempt_time` independently — pick roles from a multi-select and toggle each. XP-exempt members earn no level roles; time-exempt members get no tenure (days-in-server) roles.
- **Independent stacking toggles.** `time_roles_stack` (default **off** → one tenure role, replaces previous) and `xp_roles_stack` (default **on** → level roles stack) — flip either independently. Defaults preserve today's behaviour, so nothing changes until you flip something.

### How it's built
**Data model** — migration `052` adds `role_automation_exemptions(guild_id, role_id, exempt_xp, exempt_time)`, **role-id-keyed** so a role rename can't silently break an exemption. Accessors in `utils/db/roles.py`; cached read via `guild_config_accessors.get_role_exemptions` (the XP listener is a hot path). `services/role_exemption_service.py` owns the audited write path (delete-if-both-clear, cache-invalidate, `audit.action_recorded`).

**Settings** — a new `role` subsystem schema (`cogs/role/schemas.py`) declares the two bool toggles, so they auto-render in `!settings → Role`. Adds the `role.settings.configure` capability.

**Runtime** — the time engine (`role_automation.compute_assignments`) takes exempt role-ids + a keep-previous-tier flag; the XP listener (`_apply_xp_threshold_roles`) skips XP-exempt members and, when stacking is off, keeps only the highest earned level role. Both keep their audit emissions. The legacy `skip_roles` read is removed.

**UI** — `views/roles/exemptions_panel.py`: multi-role select + Exempt/Allow ×(XP, Time) buttons + the two stacking toggles + a live exemption list, reached from a new **Exemptions** button on the Roles hub. The roles diagnostics panel now lists exemptions instead of `skip_roles`.

### A couple of things to confirm
- **Behaviour answers (verified in the code).** Today's automation only ever adds/removes the *configured threshold roles* — it never touched arbitrary roles like `Admin`, so `skip_roles` was really "don't grant tenure roles to holders," not "protect Admin from removal." That intent is preserved (now per-role + per-engine).
- **Clean break on `skip_roles`** (your call): the legacy KV key is no longer read (constant kept so old rows don't error); set exemptions fresh in the new panel. The previous default exempted a role literally named `Admin` from tenure roles — re-add it via the panel if you want that.

### Verification
`black`/`isort`/`ruff` (CI scope) clean · `mypy disbot/` clean (518 files) · `check_architecture --mode strict` exit 0 · **6498 passed, 3 skipped**. New tests cover the service, both runtime engines (exempt-skip + stack-vs-single removal), and the panel; existing role-cog routing tests updated for the new read path.

https://claude.ai/code/session_01C1tb7wzHdcHYZJze2vWpN9

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1tb7wzHdcHYZJze2vWpN9)_