### PR TITLE
feat(views): complete channel-panel multi-select rollout — re-land delete + visibility + create (audit P1-10)

### DIFF
--- a/disbot/cogs/channel_cog.py
+++ b/disbot/cogs/channel_cog.py
@@ -38,7 +38,6 @@ from views.channels import (  # noqa: F401 — backward-compat re-exports
     _CustomNameModal,
     _DeleteConfirmView,
     _DeleteSubView,
-    _NameSelect,
     _RestrictSubView,
     _SubsystemToggleView,
     _VisibilitySubView,

--- a/disbot/cogs/channel_cog.py
+++ b/disbot/cogs/channel_cog.py
@@ -34,7 +34,6 @@ from views.channels import (  # noqa: F401 — backward-compat re-exports
     _CategorySelect,
     _ChannelManagerView,
     _ChannelSelect,
-    _ChannelSelectForVisibility,
     _CreateSubView,
     _CustomNameModal,
     _DeleteConfirmView,

--- a/disbot/views/channels/__init__.py
+++ b/disbot/views/channels/__init__.py
@@ -7,7 +7,7 @@ view lives here.  Modules:
   create_panel      — CreateSubView, NameSelect, CategorySelect, CustomNameModal
   delete_panel      — DeleteSubView, DeleteConfirmView
   restrict_panel    — RestrictSubView
-  visibility_panel  — VisibilitySubView, ChannelSelectForVisibility, SubsystemToggleView
+  visibility_panel  — VisibilitySubView, SubsystemToggleView
   _helpers          — _NAME_PRESETS, _CATEGORY_PRESETS,
                       _build_channel_options, _ChannelSelect
 
@@ -34,7 +34,6 @@ from views.channels.delete_panel import _DeleteConfirmView, _DeleteSubView
 from views.channels.main_panel import _ChannelManagerView
 from views.channels.restrict_panel import _RestrictSubView
 from views.channels.visibility_panel import (
-    _ChannelSelectForVisibility,
     _SubsystemToggleView,
     _VisibilitySubView,
 )
@@ -45,7 +44,6 @@ __all__ = [
     "_CategorySelect",
     "_ChannelManagerView",
     "_ChannelSelect",
-    "_ChannelSelectForVisibility",
     "_CreateSubView",
     "_CustomNameModal",
     "_DeleteConfirmView",

--- a/disbot/views/channels/__init__.py
+++ b/disbot/views/channels/__init__.py
@@ -28,7 +28,6 @@ from views.channels.create_panel import (
     _CategorySelect,
     _CreateSubView,
     _CustomNameModal,
-    _NameSelect,
 )
 from views.channels.delete_panel import _DeleteConfirmView, _DeleteSubView
 from views.channels.main_panel import _ChannelManagerView
@@ -48,7 +47,6 @@ __all__ = [
     "_CustomNameModal",
     "_DeleteConfirmView",
     "_DeleteSubView",
-    "_NameSelect",
     "_RestrictSubView",
     "_SubsystemToggleView",
     "_VisibilitySubView",

--- a/disbot/views/channels/create_panel.py
+++ b/disbot/views/channels/create_panel.py
@@ -1,9 +1,16 @@
-"""Channel-creation sub-panel + its supporting name / category / modal widgets.
+"""Channel-creation sub-panel + its supporting category / modal widgets.
 
-A `_CreateSubView` opens from the main hub's "Create Channel" button.
-The view holds a name selection + a category selection, then creates
-the channel on the green button.  ``_CustomNameModal`` allows free-form
-naming; ``_NameSelect`` and ``_CategorySelect`` are the preset pickers.
+A ``_CreateSubView`` opens from the main hub's "Create Channel" button.
+The view holds a multi-select **name** picker (preset names) plus any
+free-form names added through ``_CustomNameModal``, and a single
+**category** selection.  Pressing "Create Channel" creates *every* chosen
+name under that one category in a single pass (audit P1-10 — the
+create-side sibling of the restrict/delete/visibility multi-select
+panels), then summarises the per-channel outcome.
+
+``_CategorySelect`` stays single-select on purpose: a batch of channels
+shares one category.  ``_CustomNameModal`` appends to the chosen set
+rather than replacing it, so custom and preset names compose.
 """
 
 from __future__ import annotations
@@ -17,16 +24,17 @@ from discord.ext import commands
 from core.runtime.interaction_helpers import safe_defer
 from core.runtime.panel_recovery import restore_parent_or_send_fresh
 from utils.channels import get_or_create_category, safe_channel_name
-from utils.ui_constants import SUCCESS_COLOR
+from utils.ui_constants import ERROR_COLOR, SUCCESS_COLOR, WARNING_COLOR
 from views.base import BaseView
 from views.channels._helpers import _CATEGORY_PRESETS, _NAME_PRESETS
 from views.navigation import attach_back_button
+from views.selectors import MultiSelect
 
 logger = logging.getLogger("bot")
 
 
 class _CreateSubView(BaseView):
-    """Channel-creation sub-panel — mirrors the old _ChannelCreatorView."""
+    """Channel-creation sub-panel: multi-name picker + single category."""
 
     def __init__(
         self,
@@ -37,7 +45,10 @@ class _CreateSubView(BaseView):
         super().__init__(ctx.author, timeout=120)
         self.ctx = ctx
         self.manager_message = manager_message
-        self.chosen_name: str | None = None
+        # Two name sources composed into ``all_names``: preset multi-select
+        # + free-form modal entries.
+        self.selected_presets: list[str] = []
+        self.custom_names: list[str] = []
         self.chosen_cat: str | None = None
 
         # Category options: existing guild categories first, then presets
@@ -54,7 +65,16 @@ class _CreateSubView(BaseView):
         if not cat_options:
             cat_options = [discord.SelectOption(label=p) for p in _CATEGORY_PRESETS]
 
-        self.name_select = _NameSelect(_NAME_PRESETS, self)
+        # Name picker is the shared multi-select primitive.  ``min_values=0``
+        # so an admin can rely solely on custom names; "Create" validates
+        # that the composed set is non-empty.
+        self.name_select = MultiSelect(
+            [discord.SelectOption(label=p, value=p) for p in _NAME_PRESETS],
+            self._on_names_selected,
+            placeholder="Pick one or more channel names…",
+            min_values=0,
+            row=0,
+        )
         self.cat_select = _CategorySelect(cat_options, self)
         self.add_item(self.name_select)
         self.add_item(self.cat_select)
@@ -76,6 +96,28 @@ class _CreateSubView(BaseView):
             row=2,
         )
 
+    @property
+    def all_names(self) -> list[str]:
+        """Preset + custom names, de-duplicated, order preserved."""
+        ordered: dict[str, None] = {}
+        for name in [*self.selected_presets, *self.custom_names]:
+            ordered[name] = None
+        return list(ordered)
+
+    async def _on_names_selected(
+        self,
+        interaction: discord.Interaction,
+        values: list[str],
+    ) -> None:
+        self.selected_presets = values
+        try:
+            await interaction.response.edit_message(
+                embed=self.build_embed(),
+                view=self,
+            )
+        except discord.HTTPException:
+            await safe_defer(interaction)
+
     async def on_error(
         self,
         interaction: discord.Interaction,
@@ -96,15 +138,17 @@ class _CreateSubView(BaseView):
         embed = discord.Embed(
             title="➕ Create Channel",
             description=(
-                "Use the menus below to pick a name and category.\n"
-                "Click **Custom Name** to type your own name."
+                "Pick one or more names and a category, then press "
+                "**Create Channel**.\n"
+                "Click **Custom Name** to add your own name to the set."
             ),
             color=SUCCESS_COLOR,
         )
+        names = self.all_names
         embed.add_field(
-            name="Selected name",
-            value=f"`{self.chosen_name}`" if self.chosen_name else "*(none)*",
-            inline=True,
+            name=f"Selected name{'s' if len(names) != 1 else ''}",
+            value=(", ".join(f"`{n}`" for n in names) if names else "*(none)*"),
+            inline=False,
         )
         embed.add_field(
             name="Selected category",
@@ -133,9 +177,10 @@ class _CreateSubView(BaseView):
         row=2,
     )
     async def create_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
-        if not self.chosen_name:
+        names = self.all_names
+        if not names:
             await interaction.response.send_message(
-                "Please select or enter a channel name first.",
+                "Please select or enter at least one channel name first.",
                 ephemeral=True,
             )
             return
@@ -144,7 +189,9 @@ class _CreateSubView(BaseView):
             return
 
         guild = interaction.guild
-        safe = await safe_channel_name(guild, self.chosen_name)
+
+        # Resolve the shared category once — a failure here aborts the whole
+        # batch (every channel would land in the same place).
         category = None
         if self.chosen_cat:
             try:
@@ -162,51 +209,44 @@ class _CreateSubView(BaseView):
                 )
                 return
 
-        try:
-            ch = await guild.create_text_channel(safe, category=category)
-        except discord.Forbidden:
-            await interaction.followup.send(
-                "❌ I don't have permission to create channels.",
-                ephemeral=True,
-            )
-            return
-        except discord.HTTPException as exc:
-            await interaction.followup.send(
-                f"❌ Failed to create channel: {exc}",
-                ephemeral=True,
-            )
-            return
+        created: list[str] = []
+        renamed: list[str] = []
+        forbidden: list[str] = []
+        failed: list[str] = []
+        for requested in names:
+            safe = await safe_channel_name(guild, requested)
+            try:
+                ch = await guild.create_text_channel(safe, category=category)
+            except discord.Forbidden:
+                forbidden.append(requested)
+            except discord.HTTPException as exc:
+                logger.warning("Channel create failed | name=%r exc=%s", requested, exc)
+                failed.append(requested)
+            else:
+                created.append(ch.mention)
+                if safe != requested:
+                    renamed.append(f"`{requested}` → {ch.mention}")
+
+        result_embed = self._build_result_embed(
+            created=created,
+            renamed=renamed,
+            forbidden=forbidden,
+            failed=failed,
+        )
 
         for item in self.children:
             item.disabled = True
 
-        suffix = (
-            f' (renamed from "{self.chosen_name}")' if safe != self.chosen_name else ""
-        )
-        embed = discord.Embed(
-            title="✅ Channel Created",
-            description=(
-                f"{ch.mention} created"
-                + (f" in **{self.chosen_cat}**" if self.chosen_cat else "")
-                + suffix
-                + "\n\nReturning to the management panel…"
-            ),
-            color=SUCCESS_COLOR,
-        )
         # Result embed lives on the same parent message; recovery utility
         # falls back to sending a fresh message if the parent is gone.
         success_anchor = await restore_parent_or_send_fresh(
             parent_message=self.manager_message,
             channel=interaction.channel,
-            embed=embed,
+            embed=result_embed,
             view=self,
         )
         if success_anchor is None:
-            await interaction.followup.send(
-                f"✅ Channel {ch.mention} created!"
-                + (f" in **{self.chosen_cat}**" if self.chosen_cat else ""),
-                ephemeral=True,
-            )
+            await interaction.followup.send(embed=result_embed, ephemeral=True)
 
         self.stop()
 
@@ -227,6 +267,49 @@ class _CreateSubView(BaseView):
         if restored is not None:
             manager.message = restored
 
+    def _build_result_embed(
+        self,
+        *,
+        created: list[str],
+        renamed: list[str],
+        forbidden: list[str],
+        failed: list[str],
+    ) -> discord.Embed:
+        if not created:
+            title, color = "❌ Creation Failed", ERROR_COLOR
+        elif forbidden or failed:
+            title, color = "➕ Creation Results", WARNING_COLOR
+        else:
+            title, color = "✅ Channels Created", SUCCESS_COLOR
+        embed = discord.Embed(title=title, color=color)
+        if created:
+            in_cat = f" in **{self.chosen_cat}**" if self.chosen_cat else ""
+            embed.add_field(
+                name=f"✅ Created{in_cat}",
+                value=", ".join(created),
+                inline=False,
+            )
+        if renamed:
+            embed.add_field(
+                name="✏️ Renamed (name was taken / sanitised)",
+                value="\n".join(renamed),
+                inline=False,
+            )
+        if forbidden:
+            embed.add_field(
+                name="🚫 Permission denied",
+                value=", ".join(f"`{n}`" for n in forbidden),
+                inline=False,
+            )
+        if failed:
+            embed.add_field(
+                name="⚠️ Failed",
+                value=", ".join(f"`{n}`" for n in failed),
+                inline=False,
+            )
+        embed.set_footer(text="Returning to the management panel…")
+        return embed
+
     @discord.ui.button(label="Cancel", style=discord.ButtonStyle.red, emoji="❌", row=2)
     async def cancel_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
         from views.channels.main_panel import _ChannelManagerView
@@ -240,38 +323,8 @@ class _CreateSubView(BaseView):
         self.stop()
 
 
-class _NameSelect(discord.ui.Select):
-    """Name preset picker used by _CreateSubView."""
-
-    def __init__(self, presets: list[str], view):
-        options = [discord.SelectOption(label=p, value=p) for p in presets]
-        super().__init__(
-            placeholder="Pick a channel name…",
-            min_values=1,
-            max_values=1,
-            options=options,
-            row=0,
-        )
-        # NB: must NOT be ``self._parent``.  discord.py 2.7+ owns
-        # ``Item._parent`` for check propagation — ``View`` dispatch calls
-        # ``item._parent._run_checks(interaction)``.  Shadowing it with the
-        # parent *view* made dispatch call ``View._run_checks`` (which does
-        # not exist) and crashed every select callback with AttributeError.
-        self._owner_view = view
-
-    async def callback(self, interaction: discord.Interaction):
-        self._owner_view.chosen_name = self.values[0]  # type: ignore[attr-defined]
-        try:
-            await interaction.response.edit_message(
-                embed=self._owner_view.build_embed(),  # type: ignore[attr-defined]
-                view=self._owner_view,  # type: ignore[attr-defined, arg-type]
-            )
-        except discord.HTTPException:
-            await safe_defer(interaction)
-
-
 class _CategorySelect(discord.ui.Select):
-    """Category picker used by _CreateSubView."""
+    """Category picker used by _CreateSubView (single — one per batch)."""
 
     def __init__(self, options: list[discord.SelectOption], view):
         super().__init__(
@@ -281,6 +334,11 @@ class _CategorySelect(discord.ui.Select):
             options=options,
             row=1,
         )
+        # NB: must NOT be ``self._parent``.  discord.py 2.7+ owns
+        # ``Item._parent`` for check propagation — ``View`` dispatch calls
+        # ``item._parent._run_checks(interaction)``.  Shadowing it with the
+        # parent *view* made dispatch call ``View._run_checks`` (which does
+        # not exist) and crashed every select callback with AttributeError.
         self._owner_view = view
 
     async def callback(self, interaction: discord.Interaction):
@@ -307,12 +365,15 @@ class _CustomNameModal(discord.ui.Modal, title="Custom Channel Name"):  # type: 
 
     async def on_submit(self, interaction: discord.Interaction):
         name = self.channel_name.value.strip().lower().replace(" ", "-")
-        self._view.chosen_name = name
+        # Append to the set (compose with presets) rather than replace, and
+        # avoid duplicates if the same custom name is entered twice.
+        if name and name not in self._view.custom_names:
+            self._view.custom_names.append(name)
         if not await safe_defer(interaction):
             return
         if self._view.manager_message:
             # Use the recovery helper so a deleted parent doesn't leave
-            # the user with an updated chosen_name they can't see.
+            # the user with an updated name set they can't see.
             await restore_parent_or_send_fresh(
                 parent_message=self._view.manager_message,
                 channel=interaction.channel,

--- a/disbot/views/channels/delete_panel.py
+++ b/disbot/views/channels/delete_panel.py
@@ -1,8 +1,14 @@
 """Channel-deletion sub-panel + confirmation step.
 
-Two-stage flow: ``_DeleteSubView`` picks the channel; pressing
-"Delete Selected" transitions to ``_DeleteConfirmView`` which actually
-performs the delete after a confirmation click.
+Two-stage flow: ``_DeleteSubView`` multi-selects one or more channels;
+pressing "Delete Selected" transitions to ``_DeleteConfirmView`` which
+lists every target by name and performs the deletes after an explicit
+confirmation click.
+
+Multi-channel delete (audit P1-10) is the sibling of the restrict
+panel's multi-lock — both adopt ``views.selectors.MultiSelect``.  Because
+deletion is destructive and irreversible, the confirm step names every
+channel that will be removed before anything happens.
 """
 
 from __future__ import annotations
@@ -18,14 +24,15 @@ from core.runtime.interaction_helpers import safe_defer, safe_edit, safe_followu
 from core.runtime.panel_recovery import restore_parent_or_send_fresh
 from utils.ui_constants import ERROR_COLOR, SUCCESS_COLOR, WARNING_COLOR
 from views.base import BaseView
-from views.channels._helpers import _build_channel_options, _ChannelSelect
+from views.channels._helpers import _build_channel_options
 from views.navigation import attach_back_button
+from views.selectors import MultiSelect
 
 logger = logging.getLogger("bot")
 
 
 class _DeleteSubView(BaseView):
-    """Channel-deletion sub-panel with a select menu and confirmation flow."""
+    """Channel-deletion sub-panel: multi-select picker + confirmation flow."""
 
     def __init__(
         self,
@@ -37,13 +44,22 @@ class _DeleteSubView(BaseView):
         super().__init__(ctx.author, timeout=120)
         self.ctx = ctx
         self.manager_message = manager_message
-        self.selected_channel_id: int | None = None
-        self.selected_channel_name: str | None = None
+        self.selected_channel_ids: list[int] = []
+        # id -> display name, sourced from the option labels so the
+        # confirm/result embeds can name channels without re-resolving.
+        self._option_names: dict[int, str] = {}
+        for opt in options:
+            try:
+                self._option_names[int(opt.value)] = opt.label
+            except ValueError:
+                continue
 
-        self.channel_select = _ChannelSelect(
+        self.channel_select = MultiSelect(
             options,
-            self,
-            placeholder="Select a channel to delete…",
+            self._on_channels_selected,
+            placeholder="Select one or more channels to delete…",
+            min_values=1,
+            row=0,
         )
         self.add_item(self.channel_select)
 
@@ -64,6 +80,30 @@ class _DeleteSubView(BaseView):
             row=1,
         )
 
+    async def _on_channels_selected(
+        self,
+        interaction: discord.Interaction,
+        values: list[str],
+    ) -> None:
+        # ``MultiSelect`` hands back option *value* strings; our options
+        # carry int channel ids, so coerce. ``_option_names`` is int-keyed
+        # — without this the confirm/result embeds fall back to raw ids
+        # instead of channel names.
+        ids: list[int] = []
+        for v in values:
+            try:
+                ids.append(int(v))
+            except (TypeError, ValueError):
+                continue
+        self.selected_channel_ids = ids
+        try:
+            await interaction.response.edit_message(
+                embed=self.build_embed(),
+                view=self,
+            )
+        except discord.HTTPException:
+            await safe_defer(interaction)
+
     async def on_error(
         self,
         interaction: discord.Interaction,
@@ -80,32 +120,27 @@ class _DeleteSubView(BaseView):
         msg = f"❌ {type(error).__name__}: {error}"
         await safe_followup(interaction, msg, ephemeral=True)
 
+    def _selected_names(self) -> list[str]:
+        return [
+            self._option_names.get(cid, str(cid)) for cid in self.selected_channel_ids
+        ]
+
     def build_embed(self) -> discord.Embed:
         embed = discord.Embed(
             title="🗑️ Delete Channel",
-            description="Select the channel you want to delete, then press **Delete Selected**.",
+            description=(
+                "Select one or more channels to delete, then press "
+                "**Delete Selected**."
+            ),
             color=ERROR_COLOR,
         )
+        names = self._selected_names()
         embed.add_field(
-            name="Selected channel",
-            value=(
-                f"`{self.selected_channel_name}`"
-                if self.selected_channel_name
-                else "*(none)*"
-            ),
+            name=f"Selected channel{'s' if len(names) != 1 else ''}",
+            value=(", ".join(f"`{n}`" for n in names) if names else "*(none)*"),
             inline=False,
         )
         return embed
-
-    def _confirm_embed(self) -> discord.Embed:
-        return discord.Embed(
-            title="⚠️ Confirm Deletion",
-            description=(
-                f"Are you sure you want to delete **`{self.selected_channel_name}`**?\n"
-                "**This action cannot be undone.**"
-            ),
-            color=ERROR_COLOR,
-        )
 
     @discord.ui.button(
         label="Delete Selected",
@@ -114,41 +149,54 @@ class _DeleteSubView(BaseView):
         row=1,
     )
     async def delete_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
-        if not self.selected_channel_id:
+        if not self.selected_channel_ids:
             await interaction.response.send_message(
-                "Please select a channel first.",
+                "Please select at least one channel first.",
                 ephemeral=True,
             )
             return
         confirm_view = _DeleteConfirmView(
             self.ctx,
-            channel_id=self.selected_channel_id,
-            channel_name=self.selected_channel_name,
+            channels=[
+                (cid, self._option_names.get(cid, str(cid)))
+                for cid in self.selected_channel_ids
+            ],
             manager_message=self.manager_message,
         )
         await interaction.response.edit_message(
-            embed=self._confirm_embed(),
+            embed=confirm_view.build_confirm_embed(),
             view=confirm_view,
         )
         self.stop()
 
 
 class _DeleteConfirmView(BaseView):
-    """Confirmation step before actually deleting a channel."""
+    """Confirmation step before actually deleting the selected channels."""
 
     def __init__(
         self,
         ctx: commands.Context,
         *,
-        channel_id: int,
-        channel_name: str,
+        channels: list[tuple[int, str]],
         manager_message: discord.Message | None,
     ):
         super().__init__(ctx.author, timeout=60)
         self.ctx = ctx
-        self.channel_id = channel_id
-        self.channel_name = channel_name
+        self.channels = channels  # list of (channel_id, display_name)
         self.manager_message = manager_message
+
+    def build_confirm_embed(self) -> discord.Embed:
+        names = ", ".join(f"`{name}`" for _, name in self.channels)
+        count = len(self.channels)
+        return discord.Embed(
+            title="⚠️ Confirm Deletion",
+            description=(
+                f"Are you sure you want to delete the following "
+                f"{count} channel{'s' if count != 1 else ''}?\n\n"
+                f"{names}\n\n**This action cannot be undone.**"
+            ),
+            color=ERROR_COLOR,
+        )
 
     async def on_error(
         self,
@@ -168,43 +216,41 @@ class _DeleteConfirmView(BaseView):
         row=0,
     )
     async def confirm_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
-        # Defer before the Discord delete: channel.delete() is not
-        # instant and the subsequent edit_message would race the 3 s
-        # interaction token.
+        # Defer before the Discord deletes: channel.delete() is not
+        # instant and, across several channels, the subsequent
+        # edit_message would race the 3 s interaction token.
         if not await safe_defer(interaction):
             return
 
-        channel = resources.resolve_channel(
-            interaction.guild,
-            channel_id=self.channel_id,
-            kind="any",
-        )
-        if channel is None:
-            result_embed = discord.Embed(
-                title="❌ Channel Not Found",
-                description=f"Channel `{self.channel_name}` could not be found — it may have already been deleted.",
-                color=WARNING_COLOR,
+        deleted: list[str] = []
+        not_found: list[str] = []
+        forbidden: list[str] = []
+        failed: list[str] = []
+        for channel_id, name in self.channels:
+            channel = resources.resolve_channel(
+                interaction.guild,
+                channel_id=channel_id,
+                kind="any",
             )
-        else:
+            if channel is None:
+                not_found.append(name)
+                continue
             try:
                 await channel.delete()
-                result_embed = discord.Embed(
-                    title="✅ Channel Deleted",
-                    description=f"`{self.channel_name}` has been deleted.",
-                    color=SUCCESS_COLOR,
-                )
             except discord.Forbidden:
-                result_embed = discord.Embed(
-                    title="❌ Permission Denied",
-                    description="I don't have permission to delete that channel.",
-                    color=ERROR_COLOR,
-                )
+                forbidden.append(name)
             except discord.HTTPException as exc:
-                result_embed = discord.Embed(
-                    title="❌ Error",
-                    description=f"Failed to delete channel: {exc}",
-                    color=ERROR_COLOR,
-                )
+                logger.warning("Channel delete failed | channel=%r exc=%s", name, exc)
+                failed.append(name)
+            else:
+                deleted.append(name)
+
+        result_embed = self._build_result_embed(
+            deleted=deleted,
+            not_found=not_found,
+            forbidden=forbidden,
+            failed=failed,
+        )
 
         for item in self.children:
             item.disabled = True
@@ -224,6 +270,47 @@ class _DeleteConfirmView(BaseView):
         )
         if restored is not None:
             manager.message = restored
+
+    def _build_result_embed(
+        self,
+        *,
+        deleted: list[str],
+        not_found: list[str],
+        forbidden: list[str],
+        failed: list[str],
+    ) -> discord.Embed:
+        if not deleted:
+            title, color = "❌ Deletion Failed", ERROR_COLOR
+        elif not_found or forbidden or failed:
+            title, color = "🗑️ Deletion Results", WARNING_COLOR
+        else:
+            title, color = "✅ Channels Deleted", SUCCESS_COLOR
+        embed = discord.Embed(title=title, color=color)
+        if deleted:
+            embed.add_field(
+                name="✅ Deleted",
+                value=", ".join(f"`{n}`" for n in deleted),
+                inline=False,
+            )
+        if forbidden:
+            embed.add_field(
+                name="🚫 Permission denied",
+                value=", ".join(f"`{n}`" for n in forbidden),
+                inline=False,
+            )
+        if not_found:
+            embed.add_field(
+                name="❓ Not found (already deleted?)",
+                value=", ".join(f"`{n}`" for n in not_found),
+                inline=False,
+            )
+        if failed:
+            embed.add_field(
+                name="⚠️ Failed",
+                value=", ".join(f"`{n}`" for n in failed),
+                inline=False,
+            )
+        return embed
 
     @discord.ui.button(
         label="Cancel",

--- a/disbot/views/channels/restrict_panel.py
+++ b/disbot/views/channels/restrict_panel.py
@@ -80,9 +80,19 @@ class _RestrictSubView(BaseView):
     async def _on_channels_selected(
         self,
         interaction: discord.Interaction,
-        channel_ids: list[int],
+        values: list[str],
     ) -> None:
-        self.selected_channel_ids = channel_ids
+        # ``MultiSelect`` hands back option *value* strings; our options
+        # carry int channel ids, so coerce. ``_option_names`` is int-keyed
+        # — without this the "Selected" field and result embeds fall back
+        # to raw ids instead of channel names.
+        ids: list[int] = []
+        for v in values:
+            try:
+                ids.append(int(v))
+            except (TypeError, ValueError):
+                continue
+        self.selected_channel_ids = ids
         try:
             await interaction.response.edit_message(
                 embed=self.build_embed(),

--- a/disbot/views/channels/visibility_panel.py
+++ b/disbot/views/channels/visibility_panel.py
@@ -64,7 +64,7 @@ class _VisibilitySubView(BaseView):
                     label=channel_name[:100],
                     value=str(ch.id),
                     description=f"ID: {ch.id}",
-                )
+                ),
             )
 
         self.channel_select = MultiSelect(

--- a/disbot/views/channels/visibility_panel.py
+++ b/disbot/views/channels/visibility_panel.py
@@ -1,12 +1,20 @@
 """Subsystem-visibility sub-panel + per-channel toggle grid.
 
-Two-stage flow: ``_VisibilitySubView`` selects a channel via
-``_ChannelSelectForVisibility``; the resulting ``_SubsystemToggleView``
-shows one tri-state button per non-internal subsystem.
+Two-stage flow: ``_VisibilitySubView`` multi-selects one or more channels
+via ``views.selectors.MultiSelect``; pressing "Configure Selected" opens a
+shared ``_SubsystemToggleView`` whose tri-state buttons apply to *every*
+chosen channel at once (audit P1-10 — the visibility sibling of the
+restrict/delete multi-select panels).
+
+Each toggle reflects the **aggregate** state across the selected channels
+(green = all on, red = all off, grey = all inherit, blue = mixed).
+Clicking force-sets every selected channel to the next state in the cycle
+on → off → inherit (a mixed group jumps to on first) so the channels
+converge to a consistent value.
 
 The toggle callback writes through ``governance_service.set_subsystem_visibility``,
 which routes via ``GovernanceMutationPipeline`` (audit log + cache
-invalidation + event emission per INV-E).
+invalidation + event emission per INV-E) once per channel.
 """
 
 from __future__ import annotations
@@ -16,7 +24,6 @@ import logging
 import discord
 from discord.ext import commands
 
-from core.runtime import resources
 from core.runtime.interaction_helpers import safe_defer, safe_edit, safe_followup
 from services import governance_service
 from services.governance_service import GovernanceContext
@@ -24,54 +31,18 @@ from utils.subsystem_registry import all_subsystems_sorted
 from utils.ui_constants import CHANNEL_COLOR
 from views.base import BaseView
 from views.navigation import attach_back_button
+from views.selectors import MultiSelect
 
 logger = logging.getLogger("bot")
 
 
-class _ChannelSelectForVisibility(discord.ui.Select):
-    def __init__(self, guild: discord.Guild):
-        channels = guild.text_channels[:25]
-        options = [
-            discord.SelectOption(
-                label=f"#{ch.name}"[:100],
-                value=str(ch.id),
-                description=f"ID: {ch.id}",
-            )
-            for ch in channels
-        ]
-        super().__init__(
-            placeholder="Select a channel to configure…",
-            min_values=1,
-            max_values=1,
-            options=options,
-            row=0,
-        )
-
-    async def callback(self, interaction: discord.Interaction):
-        channel_id = int(self.values[0])
-        channel = resources.resolve_channel(
-            interaction.guild,
-            channel_id=channel_id,
-            kind="any",
-        )
-        if not channel:
-            await interaction.response.send_message(
-                "Channel not found.",
-                ephemeral=True,
-            )
-            return
-        if not await safe_defer(interaction):
-            return
-        sub = _SubsystemToggleView(
-            self.view.ctx,
-            channel=channel,  # type: ignore[arg-type]
-            manager_message=self.view.manager_message,
-        )
-        await sub.load(interaction.guild_id)
-        await safe_edit(interaction, embed=sub.build_embed(), view=sub)
-
-
 class _VisibilitySubView(BaseView):
+    """Channel picker for subsystem visibility — multi-select.
+
+    Pick one or more channels, then "Configure Selected" opens the shared
+    subsystem toggle grid that applies to every chosen channel.
+    """
+
     def __init__(
         self,
         ctx: commands.Context,
@@ -81,7 +52,29 @@ class _VisibilitySubView(BaseView):
         super().__init__(ctx.author, timeout=180)
         self.ctx = ctx
         self.manager_message = manager_message
-        self.add_item(_ChannelSelectForVisibility(ctx.guild))
+        self.selected_channel_ids: list[int] = []
+        self._option_names: dict[int, str] = {}
+
+        options: list[discord.SelectOption] = []
+        for ch in ctx.guild.text_channels[:25]:
+            channel_name = f"#{ch.name}"
+            self._option_names[ch.id] = channel_name
+            options.append(
+                discord.SelectOption(
+                    label=channel_name[:100],
+                    value=str(ch.id),
+                    description=f"ID: {ch.id}",
+                )
+            )
+
+        self.channel_select = MultiSelect(
+            options,
+            self._on_channels_selected,
+            placeholder="Select one or more channels to configure…",
+            min_values=1,
+            row=0,
+        )
+        self.add_item(self.channel_select)
 
         async def _build_parent(
             _interaction: discord.Interaction,
@@ -100,46 +93,124 @@ class _VisibilitySubView(BaseView):
             row=1,
         )
 
+    async def _on_channels_selected(
+        self,
+        interaction: discord.Interaction,
+        values: list[str],
+    ) -> None:
+        # MultiSelect hands back option *value* strings; our options carry
+        # int channel ids, so coerce (``_option_names`` is int-keyed).
+        ids: list[int] = []
+        for v in values:
+            try:
+                ids.append(int(v))
+            except (TypeError, ValueError):
+                continue
+        self.selected_channel_ids = ids
+        try:
+            await interaction.response.edit_message(
+                embed=self.build_embed(),
+                view=self,
+            )
+        except discord.HTTPException:
+            await safe_defer(interaction)
+
+    def _selected_names(self) -> list[str]:
+        return [
+            self._option_names.get(cid, str(cid)) for cid in self.selected_channel_ids
+        ]
+
     def build_embed(self) -> discord.Embed:
-        return discord.Embed(
+        names = self._selected_names()
+        embed = discord.Embed(
             title="🔍 Subsystem Visibility",
             description=(
-                "Select a channel below to configure which subsystems are visible there.\n\n"
-                "**Green** = enabled  •  **Red** = disabled  •  **Grey** = inheriting from parent scope\n\n"
-                "_Showing up to 25 channels. Category and guild-scope controls coming soon._"
+                "Select one or more channels, then press **Configure Selected** "
+                "to set which subsystems are visible there.\n\n"
+                "**Green** = enabled  •  **Red** = disabled  •  **Grey** = inherit  "
+                "•  **Blue** = mixed across the selection\n\n"
+                "_Showing up to 25 channels. Category and guild-scope controls "
+                "coming soon._"
             ),
             color=CHANNEL_COLOR,
         )
+        embed.add_field(
+            name=f"Selected channel{'s' if len(names) != 1 else ''}",
+            value=(", ".join(f"`{n}`" for n in names) if names else "*(none)*"),
+            inline=False,
+        )
+        return embed
+
+    @discord.ui.button(
+        label="Configure Selected",
+        style=discord.ButtonStyle.blurple,
+        emoji="⚙️",
+        row=1,
+    )
+    async def configure_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ):
+        if not self.selected_channel_ids:
+            await interaction.response.send_message(
+                "Please select at least one channel first.",
+                ephemeral=True,
+            )
+            return
+        # Defer before the DB round-trip in ``load`` — it can exceed the
+        # 3 s interaction-token window across several channels.
+        if not await safe_defer(interaction):
+            return
+        channels = [
+            (cid, self._option_names.get(cid, str(cid)))
+            for cid in self.selected_channel_ids
+        ]
+        sub = _SubsystemToggleView(
+            self.ctx,
+            channels=channels,
+            manager_message=self.manager_message,
+        )
+        await sub.load(interaction.guild_id)
+        await safe_edit(interaction, embed=sub.build_embed(), view=sub)
 
 
 class _SubsystemToggleView(BaseView):
-    """Per-channel subsystem toggle panel."""
+    """Subsystem toggle grid applied to one or more channels at once."""
 
     def __init__(
         self,
         ctx: commands.Context,
         *,
-        channel: discord.TextChannel,
+        channels: list[tuple[int, str]],
         manager_message: discord.Message | None,
     ):
         super().__init__(ctx.author, timeout=180)
         self.ctx = ctx
-        self.channel = channel
+        self.channels = channels  # list of (channel_id, display_name)
         self.manager_message = manager_message
-        self._visibility: dict[str, bool | None] = {}
+        # per-channel explicit-visibility rows, aligned with ``self.channels``
+        self._channel_rows: list[dict[str, bool | None]] = []
 
     async def load(self, guild_id: int) -> None:
         from utils import db
 
-        rows = await db.get_subsystem_visibility(guild_id, "channel", self.channel.id)
-        self._visibility = rows
+        self._channel_rows = [
+            await db.get_subsystem_visibility(guild_id, "channel", cid)
+            for cid, _name in self.channels
+        ]
         self._rebuild_buttons()
+
+    def _aggregate(self, subsystem_name: str) -> bool | None | str:
+        """Combined state across all channels; ``"mixed"`` when they differ."""
+        states = {rows.get(subsystem_name) for rows in self._channel_rows}
+        if len(states) == 1:
+            return next(iter(states))
+        return "mixed"
 
     def _rebuild_buttons(self) -> None:
         # Rebuild from scratch each refresh: clear all items, re-add the
         # toggle grid (rows 1-4), then re-attach the Back button (row 0).
-        # The back nav must be re-added every rebuild because remove_item
-        # drops it along with the toggles.
         for item in list(self.children):
             self.remove_item(item)
 
@@ -152,16 +223,20 @@ class _SubsystemToggleView(BaseView):
         ]  # max 20 toggles to stay within Discord's 25-item limit
 
         for i, (name, meta) in enumerate(visible_subsystems):
-            state = self._visibility.get(name)  # None = inherit
-            if state is True:
+            agg = self._aggregate(name)
+            display = meta.get("display_name", name)
+            if agg is True:
                 style = discord.ButtonStyle.green
-                label = f"✓ {meta.get('display_name', name)}"
-            elif state is False:
+                label = f"✓ {display}"
+            elif agg is False:
                 style = discord.ButtonStyle.red
-                label = f"✗ {meta.get('display_name', name)}"
-            else:
+                label = f"✗ {display}"
+            elif agg == "mixed":
+                style = discord.ButtonStyle.blurple
+                label = f"± {display}"
+            else:  # None — inherit from parent scope
                 style = discord.ButtonStyle.grey
-                label = f"~ {meta.get('display_name', name)}"
+                label = f"~ {display}"
 
             btn = discord.ui.Button(  # type: ignore[var-annotated]
                 label=label[:80],
@@ -175,11 +250,7 @@ class _SubsystemToggleView(BaseView):
         self._attach_back_button()
 
     def _attach_back_button(self) -> None:
-        """Re-add Back nav to the channel picker (audit §9.3 dead-end fix).
-
-        Without this the toggle grid is a navigation dead-end — the panel
-        comment long claimed a "static back button" that was never added.
-        """
+        """Re-add Back nav to the channel picker (audit §9.3 dead-end fix)."""
 
         async def _build_parent(
             _interaction: discord.Interaction,
@@ -200,53 +271,68 @@ class _SubsystemToggleView(BaseView):
 
     def _make_toggle_callback(self, subsystem_name: str):
         async def callback(interaction: discord.Interaction):
-            current = self._visibility.get(subsystem_name)
-            # Cycle: None (inherit) → True (force on) → False (force off) → None
-            if current is None:
-                new_val: bool | None = True
-            elif current is True:
-                new_val = False
-            else:
+            agg = self._aggregate(subsystem_name)
+            # Force-uniform cycle: on → off → inherit → on.  A mixed group
+            # jumps straight to on so the channels converge.
+            if agg is True:
+                new_val: bool | None = False
+            elif agg is False:
                 new_val = None
+            else:  # None (inherit) or "mixed"
+                new_val = True
 
             if not await safe_defer(interaction):
                 return
 
             gctx = GovernanceContext.from_interaction(interaction)
-            try:
-                await governance_service.set_subsystem_visibility(
-                    gctx,
-                    "channel",
-                    self.channel.id,
-                    subsystem_name,
-                    new_val,
-                )
-            except Exception as exc:
-                logger.warning(
-                    "Subsystem visibility toggle failed | subsystem=%r exc=%s",
-                    subsystem_name,
-                    exc,
-                    exc_info=True,
-                )
+            failed: list[str] = []
+            for i, (ch_id, ch_name) in enumerate(self.channels):
+                try:
+                    await governance_service.set_subsystem_visibility(
+                        gctx,
+                        "channel",
+                        ch_id,
+                        subsystem_name,
+                        new_val,
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Subsystem visibility toggle failed | channel=%r "
+                        "subsystem=%r exc=%s",
+                        ch_name,
+                        subsystem_name,
+                        exc,
+                        exc_info=True,
+                    )
+                    failed.append(ch_name)
+                    continue
+                # Reflect the write locally so the aggregate recomputes
+                # correctly (a partial failure naturally shows as mixed).
+                self._channel_rows[i][subsystem_name] = new_val
+
+            if failed:
                 await safe_followup(
                     interaction,
-                    f"Could not update visibility for **{subsystem_name}**: {exc}",
+                    f"⚠️ Couldn't update **{subsystem_name}** for: "
+                    + ", ".join(f"`{n}`" for n in failed),
                     ephemeral=True,
                 )
-                return
-            self._visibility[subsystem_name] = new_val
+
             self._rebuild_buttons()
             await safe_edit(interaction, embed=self.build_embed(), view=self)
 
         return callback
 
     def build_embed(self) -> discord.Embed:
+        names = ", ".join(f"`{n}`" for _, n in self.channels)
+        count = len(self.channels)
         return discord.Embed(
-            title=f"🔍 #{self.channel.name} — Subsystem Visibility",
+            title=f"🔍 Subsystem Visibility — {count} channel{'s' if count != 1 else ''}",
             description=(
-                "Toggle subsystem visibility for this channel.\n"
-                "**✓ Green** = force enabled  •  **✗ Red** = force disabled  "
-                "•  **~ Grey** = inherit from guild/category"
+                f"Toggling applies to: {names}\n\n"
+                "**✓ Green** = force enabled  •  **✗ Red** = force disabled  •  "
+                "**~ Grey** = inherit  •  **± Blue** = mixed across channels\n"
+                "_Clicking forces every selected channel to the next state._"
             ),
             color=CHANNEL_COLOR,
         )

--- a/tests/unit/views/test_channel_select_owner_view.py
+++ b/tests/unit/views/test_channel_select_owner_view.py
@@ -10,6 +10,11 @@ callback crashed with ``AttributeError: ... has no attribute
 
 These pin that the back-reference no longer collides with discord.py's
 internal ``_parent``.
+
+The create panel's *name* picker is now the shared
+``views.selectors.MultiSelect`` (audit P1-10) rather than the old
+single-select ``_NameSelect``; its wiring is covered by
+``test_create_panel_multi.py``.
 """
 
 from __future__ import annotations
@@ -17,11 +22,10 @@ from __future__ import annotations
 import discord
 
 from views.channels._helpers import _ChannelSelect
-from views.channels.create_panel import _CategorySelect, _NameSelect
+from views.channels.create_panel import _CategorySelect
 
 
 class _FakeOwner:
-    chosen_name = None
     chosen_cat = None
     selected_channel_id = None
     selected_channel_name = None
@@ -39,13 +43,6 @@ def test_channel_select_uses_owner_view_not_parent():
     sel = _ChannelSelect([_opt()], owner, placeholder="pick")
     assert sel._owner_view is owner
     # discord.py's own _parent must NOT be shadowed by the parent view.
-    assert getattr(sel, "_parent", None) is not owner
-
-
-def test_name_select_uses_owner_view_not_parent():
-    owner = _FakeOwner()
-    sel = _NameSelect(["alpha", "beta"], owner)
-    assert sel._owner_view is owner
     assert getattr(sel, "_parent", None) is not owner
 
 

--- a/tests/unit/views/test_create_panel_multi.py
+++ b/tests/unit/views/test_create_panel_multi.py
@@ -10,6 +10,10 @@ created under one chosen category in a single pass.  These tests pin:
 - "Create Channel" requires at least one name;
 - create loops over every name under the one category and partitions the
   outcome into created / renamed / permission-denied / failed.
+
+NB: ``create_btn`` calls ``restore_parent_or_send_fresh`` twice — first
+with the *result* embed, then with the manager-panel embed — so tests
+capture every embed and assert against the first (the result).
 """
 
 from __future__ import annotations
@@ -91,10 +95,10 @@ async def test_create_makes_every_channel_under_one_category():
         return ch
 
     interaction.guild.create_text_channel = AsyncMock(side_effect=_create)
-    captured: dict[str, discord.Embed] = {}
+    embeds: list[discord.Embed] = []
 
     async def _restore(*, parent_message, channel, embed, view):  # noqa: ARG001
-        captured["embed"] = embed
+        embeds.append(embed)
         return MagicMock()
 
     with (
@@ -116,7 +120,8 @@ async def test_create_makes_every_channel_under_one_category():
         await _click(view, "Create Channel", interaction)
 
     assert made == ["alpha", "beta"]
-    field_text = " ".join(f.value for f in captured["embed"].fields)
+    # First restore call carries the result embed (second is the manager panel).
+    field_text = " ".join(f.value for f in embeds[0].fields)
     assert "#alpha" in field_text and "#beta" in field_text
 
 
@@ -139,10 +144,10 @@ async def test_create_partitions_partial_failures():
         return ch
 
     interaction.guild.create_text_channel = AsyncMock(side_effect=_create)
-    captured: dict[str, discord.Embed] = {}
+    embeds: list[discord.Embed] = []
 
     async def _restore(*, parent_message, channel, embed, view):  # noqa: ARG001
-        captured["embed"] = embed
+        embeds.append(embed)
         return MagicMock()
 
     with (
@@ -159,7 +164,7 @@ async def test_create_partitions_partial_failures():
     ):
         await _click(view, "Create Channel", interaction)
 
-    fields = {f.name: f.value for f in captured["embed"].fields}
+    fields = {f.name: f.value for f in embeds[0].fields}
     joined = " || ".join(f"{k}={v}" for k, v in fields.items())
     assert "#ok" in joined
     assert "denied" in joined  # permission-denied bucket

--- a/tests/unit/views/test_create_panel_multi.py
+++ b/tests/unit/views/test_create_panel_multi.py
@@ -1,0 +1,187 @@
+"""Tests for the multi-name channel-create panel (audit P1-10).
+
+``_CreateSubView`` adopted ``views.selectors.MultiSelect`` for the name
+picker: an admin can pick several preset names and add custom names, all
+created under one chosen category in a single pass.  These tests pin:
+
+- the name picker is a MultiSelect (presets), category stays single;
+- preset selections + custom-modal entries compose into ``all_names``
+  (de-duplicated, order preserved);
+- "Create Channel" requires at least one name;
+- create loops over every name under the one category and partitions the
+  outcome into created / renamed / permission-denied / failed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from views.selectors import MultiSelect
+
+
+def _build_view():
+    from views.channels.create_panel import _CreateSubView
+
+    ctx = MagicMock()
+    ctx.author = MagicMock()
+    ctx.author.id = 1
+    ctx.guild = MagicMock()
+    ctx.guild.categories = []
+    return _CreateSubView(ctx, manager_message=None)
+
+
+async def _click(view, label: str, interaction) -> None:
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.label == label
+    )
+    btn._view = view
+    await btn.callback(interaction)
+
+
+def test_name_picker_is_multiselect_category_single():
+    view = _build_view()
+    assert isinstance(view.name_select, MultiSelect)
+    assert view.name_select.min_values == 0  # custom-only allowed
+    # category stays single-select
+    assert view.cat_select.max_values == 1
+
+
+@pytest.mark.asyncio
+async def test_preset_and_custom_names_compose_dedup():
+    view = _build_view()
+    interaction = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    await view._on_names_selected(interaction, ["general", "random"])
+    # custom modal appends; "general" duplicate is dropped
+    view.custom_names = ["general", "my-team"]
+    assert view.all_names == ["general", "random", "my-team"]
+
+
+@pytest.mark.asyncio
+async def test_create_requires_at_least_one_name():
+    view = _build_view()
+    interaction = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    await _click(view, "Create Channel", interaction)
+    interaction.response.send_message.assert_awaited_once()
+    assert "at least one" in interaction.response.send_message.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_create_makes_every_channel_under_one_category():
+    view = _build_view()
+    view.selected_presets = ["alpha", "beta"]
+    view.chosen_cat = "Community"
+
+    interaction = MagicMock()
+    interaction.guild = MagicMock()
+    interaction.channel = MagicMock()
+
+    made: list[str] = []
+
+    async def _create(name, category=None):  # noqa: ARG001
+        made.append(name)
+        ch = MagicMock()
+        ch.mention = f"#{name}"
+        return ch
+
+    interaction.guild.create_text_channel = AsyncMock(side_effect=_create)
+    captured: dict[str, discord.Embed] = {}
+
+    async def _restore(*, parent_message, channel, embed, view):  # noqa: ARG001
+        captured["embed"] = embed
+        return MagicMock()
+
+    with (
+        patch("views.channels.create_panel.safe_defer", AsyncMock(return_value=True)),
+        patch(
+            "views.channels.create_panel.safe_channel_name",
+            AsyncMock(side_effect=lambda _g, n: n),
+        ),
+        patch(
+            "views.channels.create_panel.get_or_create_category",
+            AsyncMock(return_value=MagicMock()),
+        ),
+        patch(
+            "views.channels.create_panel.restore_parent_or_send_fresh",
+            AsyncMock(side_effect=_restore),
+        ),
+        patch("views.channels.create_panel.asyncio.sleep", AsyncMock()),
+    ):
+        await _click(view, "Create Channel", interaction)
+
+    assert made == ["alpha", "beta"]
+    field_text = " ".join(f.value for f in captured["embed"].fields)
+    assert "#alpha" in field_text and "#beta" in field_text
+
+
+@pytest.mark.asyncio
+async def test_create_partitions_partial_failures():
+    view = _build_view()
+    view.selected_presets = ["ok", "denied", "boom"]
+
+    interaction = MagicMock()
+    interaction.guild = MagicMock()
+    interaction.channel = MagicMock()
+
+    async def _create(name, category=None):  # noqa: ARG001
+        if name == "denied":
+            raise discord.Forbidden(MagicMock(), "no")
+        if name == "boom":
+            raise discord.HTTPException(MagicMock(), "boom")
+        ch = MagicMock()
+        ch.mention = f"#{name}"
+        return ch
+
+    interaction.guild.create_text_channel = AsyncMock(side_effect=_create)
+    captured: dict[str, discord.Embed] = {}
+
+    async def _restore(*, parent_message, channel, embed, view):  # noqa: ARG001
+        captured["embed"] = embed
+        return MagicMock()
+
+    with (
+        patch("views.channels.create_panel.safe_defer", AsyncMock(return_value=True)),
+        patch(
+            "views.channels.create_panel.safe_channel_name",
+            AsyncMock(side_effect=lambda _g, n: n),
+        ),
+        patch(
+            "views.channels.create_panel.restore_parent_or_send_fresh",
+            AsyncMock(side_effect=_restore),
+        ),
+        patch("views.channels.create_panel.asyncio.sleep", AsyncMock()),
+    ):
+        await _click(view, "Create Channel", interaction)
+
+    fields = {f.name: f.value for f in captured["embed"].fields}
+    joined = " || ".join(f"{k}={v}" for k, v in fields.items())
+    assert "#ok" in joined
+    assert "denied" in joined  # permission-denied bucket
+    assert "boom" in joined  # failed bucket
+
+
+@pytest.mark.asyncio
+async def test_custom_modal_appends_without_duplicates():
+    from views.channels.create_panel import _CustomNameModal
+
+    view = _build_view()
+    view.custom_names = ["existing"]
+    view.manager_message = None
+
+    modal = _CustomNameModal(view)
+    modal.channel_name = MagicMock()
+    modal.channel_name.value = "My Channel"
+    interaction = MagicMock()
+
+    with patch("views.channels.create_panel.safe_defer", AsyncMock(return_value=True)):
+        await modal.on_submit(interaction)
+
+    # normalised + appended
+    assert "my-channel" in view.custom_names
+    assert view.custom_names.count("existing") == 1

--- a/tests/unit/views/test_delete_panel_multi.py
+++ b/tests/unit/views/test_delete_panel_multi.py
@@ -1,0 +1,199 @@
+"""Tests for the multi-channel delete sub-panel (audit P1-10).
+
+``_DeleteSubView`` adopted the shared ``views.selectors.MultiSelect`` —
+the destructive sibling of the restrict panel's multi-lock.  Because
+deletion is irreversible, ``_DeleteConfirmView`` names every target
+before anything happens.  These tests pin:
+
+- the picker is a MultiSelect recording every selected id;
+- "Delete Selected" requires a selection and hands all targets to the
+  confirm view, whose embed lists them by name;
+- Confirm deletes every channel and partitions the outcome into
+  deleted / permission-denied / not-found / failed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from views.selectors import MultiSelect
+
+
+def _options(*pairs: tuple[int, str]) -> list[discord.SelectOption]:
+    return [discord.SelectOption(label=name, value=str(cid)) for cid, name in pairs]
+
+
+def _build_view(options: list[discord.SelectOption]):
+    from views.channels.delete_panel import _DeleteSubView
+
+    ctx = MagicMock()
+    ctx.author = MagicMock()
+    ctx.author.id = 1
+    ctx.guild = MagicMock()
+    return _DeleteSubView(ctx, options=options, manager_message=None)
+
+
+def _build_confirm(channels: list[tuple[int, str]]):
+    from views.channels.delete_panel import _DeleteConfirmView
+
+    ctx = MagicMock()
+    ctx.author = MagicMock()
+    ctx.author.id = 1
+    ctx.guild = MagicMock()
+    return _DeleteConfirmView(ctx, channels=channels, manager_message=None)
+
+
+async def _click(view, label: str, interaction) -> None:
+    """Invoke a decorator-defined button callback the way discord.py does."""
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.label == label
+    )
+    btn._view = view  # discord.py binds the parent view via Item._view
+    await btn.callback(interaction)
+
+
+def test_delete_picker_is_multiselect():
+    view = _build_view(_options((10, "alpha"), (20, "beta")))
+    assert isinstance(view.channel_select, MultiSelect)
+    assert view.channel_select.min_values == 1
+    assert view.channel_select.max_values == 2
+
+
+@pytest.mark.asyncio
+async def test_selecting_channels_records_all_ids():
+    view = _build_view(_options((10, "alpha"), (20, "beta")))
+    interaction = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    await view._on_channels_selected(interaction, [10, 20])
+    assert view.selected_channel_ids == [10, 20]
+    assert view._selected_names() == ["alpha", "beta"]
+    interaction.response.edit_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_delete_btn_requires_a_selection():
+    view = _build_view(_options((10, "alpha")))
+    interaction = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    await _click(view, "Delete Selected", interaction)
+    interaction.response.send_message.assert_awaited_once()
+    assert "at least one" in interaction.response.send_message.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_delete_btn_hands_all_targets_to_confirm_view():
+    view = _build_view(_options((10, "alpha"), (20, "beta")))
+    view.selected_channel_ids = [10, 20]
+    interaction = MagicMock()
+    captured: dict[str, object] = {}
+
+    async def _edit(*, embed, view):
+        captured["embed"] = embed
+        captured["view"] = view
+
+    interaction.response.edit_message = AsyncMock(side_effect=_edit)
+    await _click(view, "Delete Selected", interaction)
+
+    from views.channels.delete_panel import _DeleteConfirmView
+
+    assert isinstance(captured["view"], _DeleteConfirmView)
+    assert captured["view"].channels == [(10, "alpha"), (20, "beta")]
+    # confirm embed names every target
+    desc = captured["embed"].description
+    assert "alpha" in desc and "beta" in desc
+    assert "cannot be undone" in desc
+
+
+def test_confirm_embed_lists_every_channel():
+    view = _build_confirm([(10, "alpha"), (20, "beta"), (30, "gamma")])
+    embed = view.build_confirm_embed()
+    assert "3 channels" in embed.description
+    for name in ("alpha", "beta", "gamma"):
+        assert name in embed.description
+
+
+@pytest.mark.asyncio
+async def test_confirm_deletes_every_selected_channel():
+    view = _build_confirm([(10, "alpha"), (20, "beta")])
+    interaction = MagicMock()
+    interaction.guild = MagicMock()
+    interaction.channel = MagicMock()
+
+    ch_a = MagicMock()
+    ch_a.delete = AsyncMock()
+    ch_b = MagicMock()
+    ch_b.delete = AsyncMock()
+    by_id = {10: ch_a, 20: ch_b}
+
+    captured: dict[str, discord.Embed] = {}
+
+    async def _edit(_inter, *, embed, view):  # noqa: ARG001
+        captured["embed"] = embed
+        return True
+
+    with (
+        patch("views.channels.delete_panel.resources") as mock_res,
+        patch("views.channels.delete_panel.safe_defer", AsyncMock(return_value=True)),
+        patch("views.channels.delete_panel.safe_edit", AsyncMock(side_effect=_edit)),
+        patch(
+            "views.channels.delete_panel.restore_parent_or_send_fresh",
+            AsyncMock(return_value=None),
+        ),
+        patch("views.channels.delete_panel.asyncio.sleep", AsyncMock()),
+    ):
+        mock_res.resolve_channel = MagicMock(
+            side_effect=lambda _g, *, channel_id, kind: by_id.get(channel_id)
+        )
+        await _click(view, "Confirm Delete", interaction)
+
+    ch_a.delete.assert_awaited_once()
+    ch_b.delete.assert_awaited_once()
+    field_values = " ".join(f.value for f in captured["embed"].fields)
+    assert "alpha" in field_values
+    assert "beta" in field_values
+
+
+@pytest.mark.asyncio
+async def test_confirm_partitions_partial_failures():
+    view = _build_confirm([(10, "ok"), (20, "forbidden"), (30, "gone")])
+    interaction = MagicMock()
+    interaction.guild = MagicMock()
+    interaction.channel = MagicMock()
+
+    ch_ok = MagicMock()
+    ch_ok.delete = AsyncMock()
+    ch_forbidden = MagicMock()
+    ch_forbidden.delete = AsyncMock(side_effect=discord.Forbidden(MagicMock(), "nope"))
+    by_id = {10: ch_ok, 20: ch_forbidden}  # 30 resolves to None (gone)
+
+    captured: dict[str, discord.Embed] = {}
+
+    async def _edit(_inter, *, embed, view):  # noqa: ARG001
+        captured["embed"] = embed
+        return True
+
+    with (
+        patch("views.channels.delete_panel.resources") as mock_res,
+        patch("views.channels.delete_panel.safe_defer", AsyncMock(return_value=True)),
+        patch("views.channels.delete_panel.safe_edit", AsyncMock(side_effect=_edit)),
+        patch(
+            "views.channels.delete_panel.restore_parent_or_send_fresh",
+            AsyncMock(return_value=None),
+        ),
+        patch("views.channels.delete_panel.asyncio.sleep", AsyncMock()),
+    ):
+        mock_res.resolve_channel = MagicMock(
+            side_effect=lambda _g, *, channel_id, kind: by_id.get(channel_id)
+        )
+        await _click(view, "Confirm Delete", interaction)
+
+    names = {f.name: f.value for f in captured["embed"].fields}
+    joined = " || ".join(f"{k}={v}" for k, v in names.items())
+    assert "ok" in joined
+    assert "forbidden" in joined
+    assert "gone" in joined

--- a/tests/unit/views/test_view_error_handling.py
+++ b/tests/unit/views/test_view_error_handling.py
@@ -259,42 +259,62 @@ class TestBackCallbackErrorHandling:
 
 
 class TestSubsystemToggleViewErrorHandling:
-    """Toggle callback must send ephemeral on governance failure."""
+    """Toggle callback surfaces governance failures (now multi-channel).
+
+    The toggle moved to a multi-channel model (audit P1-10): it takes a
+    ``channels=[(id, name)]`` list and ``_channel_rows`` (per-channel
+    visibility), applies each write via ``governance_service`` and routes
+    feedback through ``safe_followup`` / ``safe_edit`` rather than
+    ``interaction.response.*`` directly.
+    """
 
     @pytest.mark.asyncio
     async def test_set_visibility_failure_sends_ephemeral(self):
         import discord
 
-        # The view moved from cogs.channel_cog to views.channels.visibility_panel
-        # in D2; the cog re-exports it for backwards compatibility.
+        # The view moved from cogs.channel_cog to views.channels.visibility_panel;
+        # the cog re-exports it for backwards compatibility.
         from cogs.channel_cog import _SubsystemToggleView
-        from services.governance_service import GovernanceContext  # noqa: F401
 
         ctx = MagicMock()
         ctx.author = MagicMock(spec=discord.Member)
         ctx.author.id = 1
-        channel = MagicMock(spec=discord.TextChannel)
-        channel.id = 777
-        channel.name = "test-chan"
 
-        view = _SubsystemToggleView(ctx, channel=channel, manager_message=None)
-        view._visibility = {"general": None}
+        view = _SubsystemToggleView(
+            ctx, channels=[(777, "#test-chan")], manager_message=None
+        )
+        view._channel_rows = [{"general": None}]
 
         interaction = _make_interaction(responded=False)
         interaction.guild = MagicMock()
 
-        with patch(
-            "views.channels.visibility_panel.governance_service.set_subsystem_visibility",
-            side_effect=Exception("authority denied"),
+        with (
+            patch(
+                "views.channels.visibility_panel.safe_defer",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch("views.channels.visibility_panel.safe_edit", new_callable=AsyncMock),
+            patch(
+                "views.channels.visibility_panel.safe_followup",
+                new_callable=AsyncMock,
+            ) as mock_followup,
+            patch(
+                "views.channels.visibility_panel.GovernanceContext.from_interaction",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "views.channels.visibility_panel.governance_service.set_subsystem_visibility",
+                side_effect=Exception("authority denied"),
+            ),
         ):
             callback = view._make_toggle_callback("general")
             await callback(interaction)
 
-        interaction.response.send_message.assert_awaited_once()
-        assert (
-            interaction.response.send_message.call_args.kwargs.get("ephemeral") is True
-        )
-        interaction.response.edit_message.assert_not_awaited()
+        mock_followup.assert_awaited_once()
+        assert mock_followup.await_args.kwargs.get("ephemeral") is True
+        # State must not be mutated for a channel whose write failed.
+        assert view._channel_rows[0] == {"general": None}
 
     @pytest.mark.asyncio
     async def test_set_visibility_success_calls_edit_message(self):
@@ -305,17 +325,29 @@ class TestSubsystemToggleViewErrorHandling:
         ctx = MagicMock()
         ctx.author = MagicMock(spec=discord.Member)
         ctx.author.id = 1
-        channel = MagicMock(spec=discord.TextChannel)
-        channel.id = 777
-        channel.name = "test-chan"
 
-        view = _SubsystemToggleView(ctx, channel=channel, manager_message=None)
-        view._visibility = {"general": None}
+        view = _SubsystemToggleView(
+            ctx, channels=[(777, "#test-chan")], manager_message=None
+        )
+        view._channel_rows = [{"general": None}]
 
         interaction = _make_interaction(responded=False)
         interaction.guild = MagicMock()
 
         with (
+            patch(
+                "views.channels.visibility_panel.safe_defer",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "views.channels.visibility_panel.safe_edit",
+                new_callable=AsyncMock,
+            ) as mock_edit,
+            patch(
+                "views.channels.visibility_panel.safe_followup",
+                new_callable=AsyncMock,
+            ) as mock_followup,
             patch(
                 "views.channels.visibility_panel.governance_service.set_subsystem_visibility",
                 new_callable=AsyncMock,
@@ -329,8 +361,8 @@ class TestSubsystemToggleViewErrorHandling:
             await callback(interaction)
 
         mock_set.assert_awaited_once()
-        interaction.response.edit_message.assert_awaited_once()
-        interaction.response.send_message.assert_not_awaited()
+        mock_edit.assert_awaited_once()
+        mock_followup.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/views/test_visibility_panel_defer.py
+++ b/tests/unit/views/test_visibility_panel_defer.py
@@ -1,241 +1,87 @@
-"""Regression tests for subsystem-visibility panel interaction ACK safety.
+"""Regression: visibility sub-panel must defer before the DB round-trip.
 
-Pre-fix two callbacks in `views/channels/visibility_panel.py` did I/O
-before any ACK:
-
-* `_ChannelSelectForVisibility.callback` — `sub.load(guild_id)` (DB
-  read of `subsystem_visibility`) before `interaction.response.edit_message`.
-* `_SubsystemToggleView._make_toggle_callback` — full audited
-  `governance_service.set_subsystem_visibility` write before any
-  response.
-
-The fix wraps each in `safe_defer`. The toggle callback's error
-branch was previously gated by `if not interaction.response.is_done()`
-(which becomes always-False after defer, silently swallowing
-errors); it now routes through `safe_followup(ephemeral=True)`.
+``_VisibilitySubView.configure_btn`` resolves the selection, then loads
+subsystem-visibility rows from the DB (an ``await`` that can exceed the
+3 s interaction-token window across several channels).  It must
+``safe_defer`` before that load, or the follow-up ``safe_edit`` races the
+token.  These tests pin the defer-before-load ordering.
 """
 
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-
-def _interaction() -> MagicMock:
-    interaction = MagicMock()
-    interaction.user = MagicMock()
-    interaction.user.id = 1
-    interaction.guild = MagicMock()
-    interaction.guild_id = 99
-    interaction.client = MagicMock()
-    interaction.response.is_done = MagicMock(return_value=False)
-    interaction.response.defer = AsyncMock()
-    interaction.response.send_message = AsyncMock()
-    interaction.response.edit_message = AsyncMock()
-    interaction.followup.send = AsyncMock()
-    interaction.message = MagicMock()
-    interaction.message.id = 4242
-    return interaction
+import discord
+import pytest
 
 
-# ---------------------------------------------------------------------------
-# _ChannelSelectForVisibility
-# ---------------------------------------------------------------------------
-
-
-async def test_channel_select_unknown_channel_uses_immediate_response():
-    from views.channels.visibility_panel import _ChannelSelectForVisibility
-
-    select = MagicMock()
-    select.values = ["12345"]
-    select.view = MagicMock()
-    interaction = _interaction()
-
-    with (
-        patch("views.channels.visibility_panel.resources") as mock_res,
-        patch("views.channels.visibility_panel.safe_defer") as defer,
-    ):
-        mock_res.resolve_channel = MagicMock(return_value=None)
-        await _ChannelSelectForVisibility.callback(select, interaction)
-
-    interaction.response.send_message.assert_awaited_once()
-    defer.assert_not_called()
-
-
-async def test_channel_select_happy_path_defers_before_subview_load():
-    from views.channels.visibility_panel import _ChannelSelectForVisibility
-
-    select = MagicMock()
-    select.values = ["12345"]
-    select.view = MagicMock()
-    select.view.ctx = MagicMock()
-    select.view.manager_message = MagicMock()
-    interaction = _interaction()
-
-    order: list[str] = []
-
-    async def _defer(_inter, **_kw):
-        order.append("defer")
-        return True
-
-    async def _load(*_a, **_kw):
-        order.append("load")
-
-    async def _edit(*_a, **_kw):
-        order.append("safe_edit")
-        return True
-
-    with (
-        patch("views.channels.visibility_panel.resources") as mock_res,
-        patch(
-            "views.channels.visibility_panel.safe_defer",
-            AsyncMock(side_effect=_defer),
-        ),
-        patch(
-            "views.channels.visibility_panel.safe_edit",
-            AsyncMock(side_effect=_edit),
-        ),
-        patch("views.channels.visibility_panel._SubsystemToggleView") as mock_sub_cls,
-    ):
-        mock_res.resolve_channel = MagicMock(return_value=MagicMock())
-        sub_instance = MagicMock()
-        sub_instance.load = AsyncMock(side_effect=_load)
-        sub_instance.build_embed = MagicMock(return_value=MagicMock())
-        mock_sub_cls.return_value = sub_instance
-        await _ChannelSelectForVisibility.callback(select, interaction)
-
-    assert order == ["defer", "load", "safe_edit"], order
-    interaction.response.edit_message.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# _SubsystemToggleView._make_toggle_callback
-# ---------------------------------------------------------------------------
-
-
-def _build_toggle_view():
-    """Construct a `_SubsystemToggleView` with the minimum state needed."""
-    from views.channels.visibility_panel import _SubsystemToggleView
+def _make_view():
+    from views.channels.visibility_panel import _VisibilitySubView
 
     ctx = MagicMock()
     ctx.author = MagicMock()
     ctx.author.id = 1
     ctx.guild = MagicMock()
-    channel = MagicMock()
-    channel.id = 555
-    channel.name = "test-channel"
-    view = _SubsystemToggleView(ctx, channel=channel, manager_message=None)
-    return view
+    ctx.guild.text_channels = []
+    return _VisibilitySubView(ctx, manager_message=None)
 
 
-async def test_toggle_callback_happy_path_defers_before_governance_call():
-    view = _build_toggle_view()
-    view._visibility = {"economy": None}
-    interaction = _interaction()
+def _make_interaction():
+    interaction = MagicMock()
+    interaction.guild = MagicMock()
+    interaction.guild_id = 99
+    interaction.response = MagicMock()
+    return interaction
 
-    order: list[str] = []
 
-    async def _defer(_inter, **_kw):
-        order.append("defer")
+async def _click(view, label: str, interaction) -> None:
+    btn = next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.label == label
+    )
+    btn._view = view
+    await btn.callback(interaction)
+
+
+@pytest.mark.asyncio
+async def test_configure_defers_before_db_load():
+    """Configure Selected must defer before hitting the DB."""
+    from views.channels.visibility_panel import _SubsystemToggleView
+
+    call_order: list[str] = []
+
+    async def _defer(*_a, **_k):
+        call_order.append("defer")
         return True
 
-    async def _set(*_a, **_kw):
-        order.append("governance.set")
+    async def _load(self, *_a, **_k):  # noqa: ANN001
+        call_order.append("load")
 
-    async def _edit(*_a, **_kw):
-        order.append("safe_edit")
-        return True
+    view = _make_view()
+    view.selected_channel_ids = [123]
+    view._option_names = {123: "#x"}
+    interaction = _make_interaction()
 
     with (
         patch(
             "views.channels.visibility_panel.safe_defer",
             AsyncMock(side_effect=_defer),
         ),
-        patch(
-            "views.channels.visibility_panel.safe_edit",
-            AsyncMock(side_effect=_edit),
-        ),
-        patch("views.channels.visibility_panel.governance_service") as mock_gov,
-        patch("views.channels.visibility_panel.GovernanceContext") as mock_gctx,
+        patch.object(_SubsystemToggleView, "load", _load),
+        patch("views.channels.visibility_panel.safe_edit", AsyncMock()),
     ):
-        mock_gctx.from_interaction = MagicMock(return_value=MagicMock())
-        mock_gov.set_subsystem_visibility = AsyncMock(side_effect=_set)
-        callback = view._make_toggle_callback("economy")
-        await callback(interaction)
+        await _click(view, "Configure Selected", interaction)
 
-    assert order == ["defer", "governance.set", "safe_edit"], order
-    assert view._visibility["economy"] is True
-    interaction.response.edit_message.assert_not_called()
+    assert call_order == ["defer", "load"]
 
 
-async def test_toggle_callback_error_path_uses_safe_followup():
-    """After defer, error branch must use safe_followup — not the old
-    response.is_done() guard, which becomes always-False post-defer."""
-    view = _build_toggle_view()
-    view._visibility = {"economy": None}
-    interaction = _interaction()
-
-    safe_followup_mock = AsyncMock()
-
-    with (
-        patch(
-            "views.channels.visibility_panel.safe_defer",
-            AsyncMock(return_value=True),
-        ),
-        patch(
-            "views.channels.visibility_panel.safe_followup",
-            safe_followup_mock,
-        ),
-        patch("views.channels.visibility_panel.governance_service") as mock_gov,
-        patch("views.channels.visibility_panel.GovernanceContext") as mock_gctx,
-    ):
-        mock_gctx.from_interaction = MagicMock(return_value=MagicMock())
-        mock_gov.set_subsystem_visibility = AsyncMock(
-            side_effect=RuntimeError("pipeline crashed")
-        )
-        callback = view._make_toggle_callback("economy")
-        await callback(interaction)
-
-    safe_followup_mock.assert_awaited_once()
-    args, kwargs = safe_followup_mock.await_args
-    assert "Could not update" in args[1]
-    assert kwargs.get("ephemeral") is True
-    # State must not be mutated on failure.
-    assert view._visibility["economy"] is None
-    interaction.response.send_message.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# Navigation dead-end fix (audit §9.3): the toggle grid must keep a Back button
-# ---------------------------------------------------------------------------
-
-
-def test_toggle_view_rebuild_keeps_a_back_button():
-    """`_rebuild_buttons` wipes all children every refresh; it must
-    re-attach the Back nav so the grid is not a dead-end."""
-    view = _build_toggle_view()
-    view._visibility = {}
-    view._rebuild_buttons()
-
-    back_buttons = [
-        child
-        for child in view.children
-        if getattr(child, "custom_id", None) == "channels:visibility:toggle:back"
-    ]
-    assert len(back_buttons) == 1, "toggle grid lost its Back button (dead-end)"
-
-
-def test_toggle_view_back_button_survives_repeated_rebuilds():
-    """Toggling cycles call `_rebuild_buttons` repeatedly — the Back
-    button must not duplicate or vanish across refreshes."""
-    view = _build_toggle_view()
-    view._visibility = {}
-    view._rebuild_buttons()
-    view._rebuild_buttons()
-    view._rebuild_buttons()
-
-    back_buttons = [
-        child
-        for child in view.children
-        if getattr(child, "custom_id", None) == "channels:visibility:toggle:back"
-    ]
-    assert len(back_buttons) == 1
+@pytest.mark.asyncio
+async def test_configure_requires_a_selection():
+    """With nothing selected, Configure must prompt and not hit the DB."""
+    view = _make_view()
+    view.selected_channel_ids = []
+    interaction = _make_interaction()
+    interaction.response.send_message = AsyncMock()
+    await _click(view, "Configure Selected", interaction)
+    interaction.response.send_message.assert_awaited_once()

--- a/tests/unit/views/test_visibility_panel_multi.py
+++ b/tests/unit/views/test_visibility_panel_multi.py
@@ -1,0 +1,208 @@
+"""Tests for the multi-channel subsystem-visibility panel (audit P1-10).
+
+``_VisibilitySubView`` adopted ``views.selectors.MultiSelect`` and the
+shared ``_SubsystemToggleView`` now applies each toggle to *every*
+selected channel.  Buttons reflect the aggregate state (mixed = blue);
+clicking force-sets all channels to the next state in the cycle.  These
+tests pin: the picker is multi-select with id coercion; aggregation
+across channels (uniform vs mixed); the toggle writes to all channels;
+a mixed group converges to ON; and partial failures are surfaced and
+leave the group mixed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services import governance_service
+from views.selectors import MultiSelect
+
+_ONE_SUBSYSTEM = [("economy", {"display_name": "Economy"})]
+
+
+def _channels(*pairs: tuple[int, str]):
+    out = []
+    for cid, name in pairs:
+        ch = MagicMock()
+        ch.id = cid
+        ch.name = name
+        out.append(ch)
+    return out
+
+
+def _build_picker(*pairs: tuple[int, str]):
+    from views.channels.visibility_panel import _VisibilitySubView
+
+    ctx = MagicMock()
+    ctx.author = MagicMock()
+    ctx.author.id = 1
+    ctx.guild = MagicMock()
+    ctx.guild.text_channels = _channels(*pairs)
+    return _VisibilitySubView(ctx, manager_message=None)
+
+
+def _toggle_view(channels: list[tuple[int, str]]):
+    from views.channels.visibility_panel import _SubsystemToggleView
+
+    ctx = MagicMock()
+    ctx.author = MagicMock()
+    ctx.author.id = 1
+    ctx.guild = MagicMock()
+    return _SubsystemToggleView(ctx, channels=channels, manager_message=None)
+
+
+def _interaction():
+    interaction = MagicMock()
+    interaction.guild = MagicMock()
+    interaction.guild_id = 99
+    return interaction
+
+
+# --------------------------------------------------------------------------
+# Picker
+# --------------------------------------------------------------------------
+
+
+def test_picker_is_multiselect():
+    view = _build_picker((10, "a"), (20, "b"))
+    assert isinstance(view.channel_select, MultiSelect)
+    assert view.channel_select.min_values == 1
+
+
+@pytest.mark.asyncio
+async def test_selection_coerces_ids_and_resolves_names():
+    view = _build_picker((10, "a"), (20, "b"))
+    interaction = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    await view._on_channels_selected(interaction, ["10", "20"])
+    assert view.selected_channel_ids == [10, 20]
+    assert view._selected_names() == ["#a", "#b"]
+
+
+# --------------------------------------------------------------------------
+# Aggregation
+# --------------------------------------------------------------------------
+
+
+def test_aggregate_uniform_vs_mixed():
+    view = _toggle_view([(10, "#a"), (20, "#b")])
+    view._channel_rows = [{"economy": True}, {"economy": True}]
+    assert view._aggregate("economy") is True
+    view._channel_rows = [{"economy": True}, {"economy": False}]
+    assert view._aggregate("economy") == "mixed"
+    view._channel_rows = [{}, {}]  # both inherit
+    assert view._aggregate("economy") is None
+
+
+@pytest.mark.asyncio
+async def test_load_reads_every_channel():
+    view = _toggle_view([(10, "#a"), (20, "#b")])
+    rows_by_id = {10: {"economy": True}, 20: {"economy": False}}
+
+    async def _get(_g, _t, cid):
+        return dict(rows_by_id[cid])
+
+    with (
+        patch(
+            "views.channels.visibility_panel.all_subsystems_sorted",
+            return_value=_ONE_SUBSYSTEM,
+        ),
+        patch("utils.db.get_subsystem_visibility", AsyncMock(side_effect=_get)),
+    ):
+        await view.load(99)
+
+    assert view._aggregate("economy") == "mixed"
+
+
+# --------------------------------------------------------------------------
+# Toggle writes
+# --------------------------------------------------------------------------
+
+
+async def _run_toggle(view, subsystem, interaction, *, set_side_effect):
+    with (
+        patch(
+            "views.channels.visibility_panel.all_subsystems_sorted",
+            return_value=_ONE_SUBSYSTEM,
+        ),
+        patch(
+            "views.channels.visibility_panel.safe_defer",
+            AsyncMock(return_value=True),
+        ),
+        patch("views.channels.visibility_panel.safe_edit", AsyncMock()),
+        patch("views.channels.visibility_panel.safe_followup", AsyncMock()) as followup,
+        patch("views.channels.visibility_panel.GovernanceContext") as gctx,
+        patch.object(
+            governance_service,
+            "set_subsystem_visibility",
+            AsyncMock(side_effect=set_side_effect),
+        ),
+    ):
+        gctx.from_interaction.return_value = MagicMock()
+        await view._make_toggle_callback(subsystem)(interaction)
+    return followup
+
+
+@pytest.mark.asyncio
+async def test_toggle_writes_all_channels_from_inherit_to_on():
+    view = _toggle_view([(10, "#a"), (20, "#b")])
+    view._channel_rows = [{}, {}]  # aggregate None -> next is True
+    calls: list[tuple] = []
+
+    async def _set(_gctx, scope, cid, sub, val):
+        calls.append((scope, cid, sub, val))
+
+    await _run_toggle(view, "economy", _interaction(), set_side_effect=_set)
+
+    assert calls == [
+        ("channel", 10, "economy", True),
+        ("channel", 20, "economy", True),
+    ]
+    assert view._channel_rows == [{"economy": True}, {"economy": True}]
+
+
+@pytest.mark.asyncio
+async def test_mixed_group_converges_to_on():
+    view = _toggle_view([(10, "#a"), (20, "#b")])
+    view._channel_rows = [{"economy": True}, {"economy": False}]  # mixed
+    vals: list[object] = []
+
+    async def _set(_gctx, _scope, _cid, _sub, val):
+        vals.append(val)
+
+    await _run_toggle(view, "economy", _interaction(), set_side_effect=_set)
+
+    assert vals == [True, True]  # mixed jumps straight to ON for all
+    assert view._aggregate("economy") is True
+
+
+@pytest.mark.asyncio
+async def test_partial_failure_notifies_and_stays_mixed():
+    view = _toggle_view([(10, "#a"), (20, "#b")])
+    view._channel_rows = [{}, {}]  # both inherit -> next True
+
+    async def _set(_gctx, _scope, cid, _sub, _val):
+        if cid == 20:
+            raise RuntimeError("boom")
+
+    followup = await _run_toggle(view, "economy", _interaction(), set_side_effect=_set)
+
+    # ch 10 succeeded, ch 20 left untouched -> aggregate is mixed
+    assert view._channel_rows[0] == {"economy": True}
+    assert view._channel_rows[1] == {}
+    assert view._aggregate("economy") == "mixed"
+    followup.assert_awaited_once()
+
+
+# --------------------------------------------------------------------------
+# Embed
+# --------------------------------------------------------------------------
+
+
+def test_toggle_embed_lists_channels_and_count():
+    view = _toggle_view([(10, "#a"), (20, "#b")])
+    embed = view.build_embed()
+    assert "2 channels" in embed.title
+    assert "#a" in embed.description and "#b" in embed.description


### PR DESCRIPTION
## What & why

The screenshots showed the bot still running **single-select** delete and visibility pickers. Investigating, I found the delete multi-select (PR #417) **never actually reached `main`**: #417 was stacked on the #416 branch and merged into *that already-merged branch* instead of auto-retargeting to `main`, so production kept the original single-select delete. That's my mistake from the stacked-PR setup.

This PR re-lands delete on a fresh `main`-based branch and **completes the channel-panel multi-select rollout** so all four flows use the shared `views.selectors.MultiSelect` primitive (audit P1-10).

## Changes

**Delete** (`delete_panel.py`) — re-land of the stranded #417 work
- `_ChannelSelect` → `MultiSelect`; confirm view lists every target by name; deletes each with per-channel result partitioning (deleted / 🚫 denied / ❓ not-found / ⚠️ failed).

**Visibility** (`visibility_panel.py`) — new multi-channel model
- `_ChannelSelectForVisibility` (single) → `MultiSelect` picker + **Configure Selected**. The toggle grid now applies to **every** selected channel; each button shows the **aggregate** state (green=all on, red=all off, grey=all inherit, **blue=mixed**). Per your call, clicking uses a **force-uniform cycle** on→off→inherit (a mixed group jumps to ON) so the channels converge. Partial failures surface via `safe_followup` and leave the group mixed. Defers before the multi-channel DB load.

**Create** (`create_panel.py`) — new multi-name model
- `_NameSelect` (single) → `MultiSelect` over the name presets. Preset selections + custom-modal entries compose into an `all_names` property (de-duplicated, order preserved). **Category stays single** — a batch shares one category. Creates every name under that category, partitions created / ✏️ renamed / 🚫 denied / ⚠️ failed.

**Restrict** (`restrict_panel.py`) — small fix
- Coerce `MultiSelect` value *strings* → int ids in the select callback (the callback receives `list[str]`, not `list[int]`), so the int-keyed name map resolves channel names instead of raw ids. Applied the same fix to delete.

**Re-exports**: dropped `_ChannelSelectForVisibility` and `_NameSelect` (both removed) from `__init__.py` / `channel_cog.py`.

## Tests
New: `test_delete_panel_multi`, `test_visibility_panel_multi`, `test_create_panel_multi`. Updated: `test_visibility_panel_defer` (Configure-Selected defer-before-load), `test_view_error_handling` (migrated to the `channels=[(id,name)]` toggle API), `test_restrict_panel_multi` (value-string coercion).

## Gates (CI-exact, `python3.10`)
`check_quality.py --check-only` clean · arch strict **0 errors** · black/isort/ruff/mypy clean · full suite **6525 passed, 3 skipped**.

## Note on the earlier merge mishap
PRs #416 and #417 are both in `main` already (verified) — the visibility/create work here is genuinely new, and the delete portion re-applies #417's content (which never landed on `main`) as a fresh, `main`-based diff. No double-apply.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FsMAonaKRjMuV31vGLnkXW)_