### PR TITLE
fix(pipeline): 🍃 egg fires on bot mentions + renumber/document stage orders

### DIFF
--- a/disbot/cogs/btd6/stage.py
+++ b/disbot/cogs/btd6/stage.py
@@ -46,7 +46,9 @@ from services.btd6_resolver_service import resolve
 logger = logging.getLogger("bot.cogs.btd6.stage")
 
 STAGE_NAME = "btd6_assistant"
-STAGE_ORDER = 80  # after cleanup/counting; before observability stages
+# Conversational tier, after the AI natural-language stage (70). See the
+# canonical stage-order table in core/runtime/message_pipeline.py.
+STAGE_ORDER = 80
 
 _TRUTHY = frozenset({"1", "true", "yes", "on"})
 _DEFAULT_CONFIDENCE_THRESHOLD = 0.34  # ≥ 1 of 3 entities matched

--- a/disbot/cogs/chain_cog.py
+++ b/disbot/cogs/chain_cog.py
@@ -18,7 +18,9 @@ from utils import db
 from views.base import HubView, send_panel
 
 CHAIN_STAGE_NAME = "chain"
-CHAIN_STAGE_ORDER = 10  # moderation tier per plan §3.2
+# Auto-mod tier — last within the tier (after cleanup=10, counting=15). See
+# the canonical stage-order table in core/runtime/message_pipeline.py.
+CHAIN_STAGE_ORDER = 20
 
 logger = logging.getLogger("bot.cogs.chain")
 
@@ -26,7 +28,7 @@ logger = logging.getLogger("bot.cogs.chain")
 class ChainStage:
     """Message-pipeline stage enforcing chain rules + word limits.
 
-    Auto-mod tier (order=10).  Short-circuits the pipeline when a
+    Auto-mod tier (order=20).  Short-circuits the pipeline when a
     message is deleted so xp / game_input stages skip a removed
     message.
 

--- a/disbot/cogs/cleanup_cog.py
+++ b/disbot/cogs/cleanup_cog.py
@@ -21,7 +21,10 @@ from utils.ui_constants import ADMIN_COLOR
 from views.base import HubView, send_panel
 
 CLEANUP_STAGE_NAME = "cleanup"
-CLEANUP_STAGE_ORDER = 10  # moderation tier per plan §3.2
+# Auto-mod tier — runs first within the tier so a banned word is deleted
+# before counting/chain try to validate the same message. See the canonical
+# stage-order table in core/runtime/message_pipeline.py.
+CLEANUP_STAGE_ORDER = 10
 MAX_CLEANUP_HISTORY_LIMIT = 1000
 SPAM_DUPLICATE_WINDOW_SECONDS = 15
 HELPER_DELETE_DELAY_SECONDS = 3

--- a/disbot/cogs/counting/_stage.py
+++ b/disbot/cogs/counting/_stage.py
@@ -29,13 +29,15 @@ if TYPE_CHECKING:
 
 
 COUNTING_STAGE_NAME = "counting"
-COUNTING_STAGE_ORDER = 10
+# Auto-mod tier — after cleanup (10), before chain (20). See the canonical
+# stage-order table in core/runtime/message_pipeline.py.
+COUNTING_STAGE_ORDER = 15
 
 
 class CountingStage:
     """Validate counts in active channels; short-circuit on rule violation.
 
-    Auto-mod tier (order=10).  Returns
+    Auto-mod tier (order=15).  Returns
     ``StageResult(deleted=True, short_circuit=True)`` when the count
     was invalid and the message was deleted, so XP/game stages skip
     a message that's gone.  Returns an empty result for valid counts

--- a/disbot/cogs/four_twenty_cog.py
+++ b/disbot/cogs/four_twenty_cog.py
@@ -8,8 +8,13 @@ Two surfaces, no cross-cog reach and no state mutation:
   (``FourTwentyStage``) watches every message and drops a 🍃 reaction +
   one-liner when someone types ``420`` / ``4:20`` / ``blaze it`` /
   ``four twenty``.  The stage is **observe-only**: it never deletes,
-  never short-circuits, runs after the game/mod stages, and self-rate-
-  limits per channel so it can never become noise.
+  never short-circuits, and self-rate-limits per channel so it can never
+  become noise.  It runs at ``order=50`` (the passive tier) — after the
+  auto-mod (10/15/20) and rewards (30/40) tiers so it never leafs a
+  message that's about to be deleted, but **before** the AI
+  natural-language stage (``order=70``), which
+  short-circuits the pipeline on a bot mention.  Sitting ahead of it is
+  what lets ``@bot … 420 …`` messages still get their 🍃.
 
 Design notes
 ------------
@@ -58,11 +63,16 @@ _CONTENT_PATH = os.path.join(
 _FOUR_TWENTY_COLOR = discord.Color.from_rgb(0x4C, 0xAF, 0x50)  # leafy green
 _LEAF = "🍃"
 
-# Stage ordering: observe-only, so it sits at the very back behind every
-# game / moderation / XP stage. A high number keeps it last regardless of
-# future stage additions in the 10–90 band.
+# Stage ordering: observe-only, so it can sit anywhere — but it must run
+# BEFORE the AI natural-language stage (order=70), which short-circuits the
+# pipeline when it handles a bot mention.  At the old order=95 a message
+# like "@bot blaze it" was consumed by AI before we ever saw it, so the
+# egg silently never fired on mentions.  order=50 (the "passive" tier) keeps
+# us after the auto-mod (10/15/20) and rewards (30/40) tiers — so we never
+# leaf a message counting/cleanup is about to delete — yet ahead of AI.
+# See the canonical stage-order table in core/runtime/message_pipeline.py.
 FOUR_TWENTY_STAGE_NAME = "four_twenty"
-FOUR_TWENTY_STAGE_ORDER = 95
+FOUR_TWENTY_STAGE_ORDER = 50
 
 # Per-channel cooldown (seconds) so the easter egg can never be spammed
 # into noise — at most one wink per channel per window.

--- a/disbot/cogs/rps_tournament/_stage.py
+++ b/disbot/cogs/rps_tournament/_stage.py
@@ -5,10 +5,11 @@ on the cog) as a :class:`core.runtime.message_pipeline.MessageStage`.
 The cog registers an instance in ``cog_load`` and unregisters on
 ``cog_unload`` for hot-reload safety.
 
-Order: 30.  Per plan §3.2, RPS sits in the *game_input* tier — after
-auto-mod (order=10) and the XP reward stage (order=20).  The stage
-never deletes or short-circuits; it's pure capture of player moves
-in tournament match channels.
+Order: 40.  RPS sits in the *rewards / game-input* tier — after the
+auto-mod tier (cleanup=10, counting=15, chain=20) and the XP reward
+stage (order=30).  The stage never deletes or short-circuits; it's
+pure capture of player moves in tournament match channels.  See the
+canonical stage-order table in ``core/runtime/message_pipeline.py``.
 """
 
 from __future__ import annotations
@@ -25,13 +26,13 @@ if TYPE_CHECKING:
 
 
 RPS_STAGE_NAME = "rps_tournament"
-RPS_STAGE_ORDER = 30
+RPS_STAGE_ORDER = 40
 
 
 class RpsTournamentStage:
     """Capture player moves in tournament match channels.
 
-    Game-input tier (order=30).  No deletion, no short-circuit — just
+    Game-input tier (order=40).  No deletion, no short-circuit — just
     routes the message to the cog's tournament-state dispatch.
 
     Holds a cog reference because the tournament state

--- a/disbot/cogs/xp/stage.py
+++ b/disbot/cogs/xp/stage.py
@@ -5,14 +5,10 @@ Wraps the existing ``cogs.xp.listener.handle_message`` body as a
 registers an instance of this class in ``cog_load`` and unregisters
 on ``cog_unload`` so hot reloads remain clean.
 
-Order: 20.  Per the plan §3.2, XP runs in the *rewards* tier (after
-*moderation* at order=10).  This means once auto-mod stages migrate,
-XP will no longer reward a message that was deleted by an upstream
-stage in the same dispatch — that's the intended behavior shift.
-
-In this PR only XP has migrated, so order=20 has no other neighbors;
-the value is set per the plan so future migrations slot in without
-re-numbering.
+Order: 30.  XP runs in the *rewards* tier, after the auto-mod tier
+(cleanup=10, counting=15, chain=20), so XP never rewards a message that
+an upstream stage deleted in the same dispatch.  See the canonical
+stage-order table in ``core/runtime/message_pipeline.py``.
 """
 
 from __future__ import annotations
@@ -23,7 +19,7 @@ from core.runtime.message_pipeline import (
 )
 
 XP_STAGE_NAME = "xp"
-XP_STAGE_ORDER = 20
+XP_STAGE_ORDER = 30
 
 
 class XpStage:

--- a/disbot/core/runtime/message_pipeline.py
+++ b/disbot/core/runtime/message_pipeline.py
@@ -30,6 +30,42 @@ Stages should be pure-Python objects (a dataclass or hand-rolled
 class).  The orchestrator never instantiates them — register an
 already-constructed instance via :func:`register`.
 
+Canonical stage-order table
+---------------------------
+
+**This is the single source of truth for stage ordering.**  Stages run
+in ascending ``order``; the value lives next to each stage class as a
+``*_STAGE_ORDER`` constant.  Tiers are spaced so new stages slot in
+without renumbering, and every value is distinct so ordering never
+depends on cog load order (enforced by
+``tests/unit/runtime/test_message_pipeline.py::
+test_registered_stage_orders_are_distinct``).
+
+==========  =====  =========================================  ============
+order       tier   stage (constant)                           short-circuits?
+==========  =====  =========================================  ============
+10          auto-mod   cleanup    (``CLEANUP_STAGE_ORDER``)    on delete
+15          auto-mod   counting   (``COUNTING_STAGE_ORDER``)   on delete
+20          auto-mod   chain      (``CHAIN_STAGE_ORDER``)      on delete
+30          rewards    xp         (``XP_STAGE_ORDER``)         no
+40          rewards    rps        (``RPS_STAGE_ORDER``)        no
+50          passive    four_twenty(``FOUR_TWENTY_STAGE_ORDER``) no
+70          conv.      ai_nl      (``ai…STAGE_ORDER``)         on bot mention
+80          conv.      btd6       (``btd6…STAGE_ORDER``)       on handle
+==========  =====  =========================================  ============
+
+Tier rationale:
+
+* **auto-mod (10–20)** — may delete the message; cleanup runs first so a
+  banned word is gone before counting/chain validate it.
+* **rewards (30–40)** — award/capture; must run after auto-mod so a
+  deleted message is never rewarded.
+* **passive (50–69)** — observe-only side effects (e.g. the 🍃 egg).
+  Must precede any short-circuiting conversational stage so a message
+  the AI consumes still gets passive treatment.
+* **conversational (70+)** — may *handle* the message and short-circuit
+  (AI reply, BTD6 assistant).
+
 Built-in pre-filter
 -------------------
 

--- a/tests/unit/cogs/test_chain_stage.py
+++ b/tests/unit/cogs/test_chain_stage.py
@@ -49,7 +49,7 @@ class TestChainStageContract:
     def test_metadata(self):
         stage = ChainStage(_make_cog())
         assert stage.name == CHAIN_STAGE_NAME == "chain"
-        assert stage.order == CHAIN_STAGE_ORDER == 10
+        assert stage.order == CHAIN_STAGE_ORDER == 20
 
     @pytest.mark.asyncio
     async def test_delete_short_circuits(self):

--- a/tests/unit/cogs/test_counting_stage.py
+++ b/tests/unit/cogs/test_counting_stage.py
@@ -24,7 +24,7 @@ class TestCountingStage:
     def test_metadata(self):
         stage = CountingStage(MagicMock())
         assert stage.name == COUNTING_STAGE_NAME == "counting"
-        assert stage.order == COUNTING_STAGE_ORDER == 10
+        assert stage.order == COUNTING_STAGE_ORDER == 15
 
     @pytest.mark.asyncio
     async def test_delete_short_circuits(self):

--- a/tests/unit/cogs/test_four_twenty_cog.py
+++ b/tests/unit/cogs/test_four_twenty_cog.py
@@ -85,8 +85,23 @@ def _ctx(content: str, channel_id: int = 1):
 def test_stage_identity():
     stage = FourTwentyStage()
     assert stage.name == FOUR_TWENTY_STAGE_NAME
-    # Observe-only stage runs late, behind game/mod/xp stages.
-    assert stage.order == FOUR_TWENTY_STAGE_ORDER >= 90
+    assert stage.order == FOUR_TWENTY_STAGE_ORDER
+    # Must run after the auto-mod / game tiers (10–30) so it never leafs a
+    # message that's about to be deleted, but BEFORE the AI natural-language
+    # stage (order=70), which short-circuits the pipeline on a bot mention.
+    # That ordering is the whole fix for "@bot … 420" not getting a 🍃.
+    assert 30 < stage.order < 70
+
+
+def test_runs_before_ai_stage_so_mentions_still_get_leafed():
+    """Regression guard: the AI natural-language stage short-circuits the
+    pipeline on a bot mention, so the 🍃 stage MUST be ordered ahead of it
+    or ``@bot … 420`` messages silently never fire. Pin the live order
+    relationship against the AI stage itself, not a magic number.
+    """
+    from core.runtime.ai.natural_language_stage import STAGE_ORDER as AI_ORDER
+
+    assert FOUR_TWENTY_STAGE_ORDER < AI_ORDER
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cogs/test_rps_tournament_stage.py
+++ b/tests/unit/cogs/test_rps_tournament_stage.py
@@ -26,7 +26,7 @@ class TestRpsTournamentStage:
         cog = MagicMock()
         stage = RpsTournamentStage(cog)
         assert stage.name == RPS_STAGE_NAME == "rps_tournament"
-        assert stage.order == RPS_STAGE_ORDER == 30
+        assert stage.order == RPS_STAGE_ORDER == 40
 
     @pytest.mark.asyncio
     async def test_process_delegates_to_cog(self):

--- a/tests/unit/runtime/test_message_pipeline.py
+++ b/tests/unit/runtime/test_message_pipeline.py
@@ -339,3 +339,72 @@ class TestSetup:
         message_pipeline.setup(bot)
         # Second call should be a no-op — listener registered only once.
         assert bot.listen.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Canonical stage-order contract
+# ---------------------------------------------------------------------------
+
+
+class TestStageOrderContract:
+    """Pin the canonical stage-order table documented in the module
+    docstring. Every registered stage must have a DISTINCT order so the
+    run sequence never depends on cog load order (the pre-pipeline bug
+    these tests guard against), and the documented tier relationships
+    must hold.
+    """
+
+    def _all_orders(self) -> dict[str, int]:
+        """Import every stage-order constant by its canonical name."""
+        from cogs.btd6.stage import STAGE_ORDER as BTD6
+        from cogs.chain_cog import CHAIN_STAGE_ORDER as CHAIN
+        from cogs.cleanup_cog import CLEANUP_STAGE_ORDER as CLEANUP
+        from cogs.counting._stage import COUNTING_STAGE_ORDER as COUNTING
+        from cogs.four_twenty_cog import FOUR_TWENTY_STAGE_ORDER as FOUR_TWENTY
+        from cogs.rps_tournament._stage import RPS_STAGE_ORDER as RPS
+        from cogs.xp.stage import XP_STAGE_ORDER as XP
+        from core.runtime.ai.natural_language_stage import STAGE_ORDER as AI
+
+        return {
+            "cleanup": CLEANUP,
+            "counting": COUNTING,
+            "chain": CHAIN,
+            "xp": XP,
+            "rps": RPS,
+            "four_twenty": FOUR_TWENTY,
+            "ai": AI,
+            "btd6": BTD6,
+        }
+
+    def test_registered_stage_orders_are_distinct(self):
+        orders = self._all_orders()
+        values = list(orders.values())
+        assert len(values) == len(set(values)), (
+            f"stage orders must be distinct so run order never depends on "
+            f"cog load order — got duplicates in {orders}"
+        )
+
+    def test_tier_relationships_hold(self):
+        o = self._all_orders()
+        # auto-mod tier, cleanup first (deletes a banned word before
+        # counting/chain validate it).
+        assert o["cleanup"] < o["counting"] < o["chain"]
+        # rewards run after every auto-mod stage (never reward a deleted msg).
+        assert o["chain"] < o["xp"] < o["rps"]
+        # passive observe-only sits after rewards, before conversational.
+        assert o["rps"] < o["four_twenty"] < o["ai"]
+        # the regression that started this: passive 🍃 must precede the
+        # short-circuiting AI stage or bot-mentions never get leafed.
+        assert o["four_twenty"] < o["ai"] < o["btd6"]
+
+    def test_orders_match_documented_table(self):
+        assert self._all_orders() == {
+            "cleanup": 10,
+            "counting": 15,
+            "chain": 20,
+            "xp": 30,
+            "rps": 40,
+            "four_twenty": 50,
+            "ai": 70,
+            "btd6": 80,
+        }


### PR DESCRIPTION
Two related message-pipeline ordering fixes.

## 1. The 🍃 420 egg never fired on bot mentions

You reported `@bot … 420` getting no leaf. Root cause was **stage ordering, not the regex** (the regex already matched mid-message — verified against real sentences):

- The AI natural-language stage runs at `order=70` and returns `short_circuit=True` when it handles a bot mention, stopping the pipeline.
- The `four_twenty` stage was at `order=95` — *after* AI — so a mention was consumed by the AI stage before the egg ever ran.

**Fix:** moved `four_twenty` into the new *passive* tier at `order=50`, ahead of AI. A regression test pins `four_twenty.order < ai.order` so this can't silently come back.

## 2. Renumber + document all stage orders

While in here: the orders were **undocumented**, and three stages (cleanup/counting/chain) **all tied at `order=10`** — so their relative order was decided by cog load order. Fragile and invisible (this is exactly the "I never knew about those orders" problem).

New scheme — distinct, tier-spaced, room to insert:

| order | tier | stage | short-circuits? |
|---|---|---|---|
| 10 | auto-mod | cleanup | on delete |
| 15 | auto-mod | counting | on delete |
| 20 | auto-mod | chain | on delete |
| 30 | rewards | xp | no |
| 40 | rewards | rps | no |
| 50 | passive | four_twenty | no |
| 70 | conv. | ai | on mention |
| 80 | conv. | btd6 | on handle |

**cleanup runs first** within the auto-mod tier (your call) — a banned word is deleted before counting/chain validate it, so a deleted message isn't double-processed.

The **canonical table now lives in `core/runtime/message_pipeline.py`'s module docstring** as the single source of truth, and three new contract tests pin it: orders are **distinct** (run order never again depends on load order), tier relationships hold, and values match the documented table.

## Behavior preservation
Every existing tier relationship is unchanged. The only new orderings are (a) `four_twenty` now before AI — the fix — and (b) cleanup→counting→chain within the auto-mod tier, which was previously undefined.

## Gates (CI-exact, python3.10)
black / isort / ruff / mypy clean · arch strict **0 errors** · `pytest tests/` **6562 passed, 3 skipped** (+4: 3 contract tests + 1 mention regression guard).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FsMAonaKRjMuV31vGLnkXW)_