### PR TITLE
Fix AI memory scan seeding the channel's oldest messages instead of recent ones

### DIFF
--- a/disbot/services/ai_memory_service.py
+++ b/disbot/services/ai_memory_service.py
@@ -151,11 +151,17 @@ async def _seed_from_history(
     history_fn = getattr(channel, "history", None)
     if history_fn is None:
         return 0
+    # Fetch the MOST RECENT messages. ``history(limit=N)`` defaults to
+    # newest-first; passing ``oldest_first=True`` with no before/after
+    # anchor instead paginates FORWARD from the channel's very beginning
+    # and returns its OLDEST N messages — the bug that made the scan seed
+    # ancient history (e.g. the channel's first posts) instead of the
+    # messages from just before the restart. Collect newest-first, then
+    # reverse so the buffer ends up oldest->newest like live appends.
+    recent_messages = [msg async for msg in history_fn(limit=_SCAN_LIMIT)]
+    recent_messages.reverse()
     appended = 0
-    # ``oldest_first=True`` so the buffer ends up chronologically
-    # ordered after the seed (the buffer is a FIFO deque under the
-    # hood).
-    async for msg in history_fn(limit=_SCAN_LIMIT, oldest_first=True):
+    for msg in recent_messages:
         author_id = getattr(getattr(msg, "author", None), "id", None)
         body = getattr(msg, "content", "") or ""
         if not body or author_id is None:

--- a/tests/unit/services/test_ai_memory_service.py
+++ b/tests/unit/services/test_ai_memory_service.py
@@ -84,17 +84,31 @@ class _FakeMessage:
 
 
 class _FakeChannel:
-    """Async-iterable history mock."""
+    """Async-iterable history mock modelling discord.py semantics.
+
+    ``_messages`` is the channel's full history, oldest-first. discord.py's
+    ``history`` with no before/after anchor paginates from one end:
+
+    * ``oldest_first=True``  → forward from the channel's start: the OLDEST
+      ``limit`` messages, oldest-first.
+    * ``oldest_first=False`` (the default) → backward from now: the most
+      RECENT ``limit`` messages, newest-first.
+
+    The previous mock ignored ``limit`` and returned the same set either
+    way, which hid the real bug — the scan pulling the channel's oldest
+    messages instead of the recent ones before a restart.
+    """
 
     def __init__(self, messages: list[_FakeMessage]):
-        self._messages = messages
+        self._messages = messages  # oldest -> newest
         self.calls: list[dict] = []
 
     def history(self, *, limit: int = 100, oldest_first: bool = False):
         self.calls.append({"limit": limit, "oldest_first": oldest_first})
-        seq = list(self._messages)
-        if not oldest_first:
-            seq.reverse()
+        if oldest_first:
+            seq = self._messages[:limit]  # oldest N, oldest-first
+        else:
+            seq = list(reversed(self._messages[-limit:]))  # recent N, newest-first
 
         async def _gen():
             for m in seq:
@@ -141,6 +155,50 @@ async def test_gather_scans_when_enabled_and_cache_short(monkeypatch):
     )
     assert len(channel.calls) == 1
     assert {t.text for t in out} == {"first", "second", "third"}
+
+
+@pytest.mark.asyncio
+async def test_gather_scan_seeds_most_recent_not_oldest(monkeypatch):
+    """Regression: the scan must backfill the messages from just before the
+    restart (the channel tail), not the channel's oldest messages.
+
+    discord.py ``history(limit=N, oldest_first=True)`` with no anchor returns
+    the channel's OLDEST N messages — it paginates from the start. The scan
+    used that, so on any channel with more than ``_SCAN_LIMIT`` messages it
+    seeded ancient history and the bot's "memory" of the channel looked
+    broken after every restart. It must fetch the most recent messages.
+    """
+
+    async def _settings(_gid):
+        return (60, True)
+
+    monkeypatch.setattr(ai_memory_service, "read_memory_settings", _settings)
+
+    # Full channel history, oldest -> newest, longer than the scan limit.
+    total = ai_memory_service._SCAN_LIMIT + 10
+    history = [
+        _FakeMessage(mid=i, author_id=100 + (i % 3), content=f"msg-{i}")
+        for i in range(total)
+    ]
+    channel = _FakeChannel(history)
+
+    out = await ai_memory_service.gather_recent_turns(
+        guild_id=1,
+        channel_id=2,
+        channel=channel,
+    )
+    texts = {t.text for t in out}
+    # The newest message is present; the oldest is NOT (it is far past the
+    # most-recent _SCAN_LIMIT window).
+    assert f"msg-{total - 1}" in texts
+    assert "msg-0" not in texts
+    # Exactly the scan-limit window of most-recent messages was seeded.
+    assert len(out) == ai_memory_service._SCAN_LIMIT
+    # The fetch asked for the recent tail (default newest-first), NOT the
+    # oldest-first-from-start pagination that caused the bug.
+    assert channel.calls == [
+        {"limit": ai_memory_service._SCAN_LIMIT, "oldest_first": False},
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

After a restart, with `ai_memory_channel_scan_enabled` **on**, the bot's recollection of a channel looked broken — it referenced ancient/irrelevant messages instead of the conversation from just before the restart. (Reported in chat: "I have memory scan enabled, but it doesn't seem to work properly.")

## Root cause

Chat memory is an in-process buffer that's dropped on restart (by design — ADR-001, no Redis state). The only way to recover pre-restart context is the Discord history scan in `ai_memory_service._seed_from_history`, which backfilled the buffer with:

```python
async for msg in history_fn(limit=_SCAN_LIMIT, oldest_first=True):
```

With **no `before`/`after` anchor, discord.py treats `oldest_first=True` as "paginate forward from the channel's start"** — so this returns the **oldest 30 messages in the channel**, not the 30 most recent. On any channel with more than 30 messages, the scan seeded the channel's first-ever posts. The in-code comment ("so the buffer ends up chronologically ordered") shows the original misconception.

## Fix

Fetch the most recent messages (`history(limit=30)`, the newest-first default) and reverse into chronological order before seeding:

```python
recent_messages = [msg async for msg in history_fn(limit=_SCAN_LIMIT)]
recent_messages.reverse()
```

## Why the tests didn't catch it

The `_FakeChannel.history` mock returned the **same** messages regardless of `oldest_first` and **ignored `limit`** entirely — so it couldn't distinguish "oldest N" from "recent N." I made the mock faithful to discord.py (applies `limit`; `oldest_first=True` pages from the start, the default pages from the end) and added a regression test with more than `_SCAN_LIMIT` messages asserting the **recent tail** is seeded (the newest message present, the oldest absent). That test fails on the old code and passes on the fix.

## Note on scan limits (unchanged, by design)

Even with the fix, the scan recovers the **last ~30 messages** (`_SCAN_LIMIT`) and only fires when the in-process buffer is below the 3-message floor. So it restores *recent* pre-restart context, not unlimited history — the buffer remains in-process per ADR-001.

## Verification

- `pytest tests/ -q` → **6675 passed, 3 skipped**
- `check_architecture.py --mode strict` → exit 0
- CI gates (their scope): black/isort/ruff exit 0, `mypy disbot/` clean (527 files)

https://claude.ai/code/session_01Jh6DEuRHvQJc87VJh5yGPG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jh6DEuRHvQJc87VJh5yGPG)_