### PR TITLE
Return the asker's Discord permission role from the get_user_standing tool

### DIFF
--- a/disbot/services/ai_tools.py
+++ b/disbot/services/ai_tools.py
@@ -61,19 +61,43 @@ def _scope_allows(caller: AIScope, required: AIScope) -> bool:
 _USER_STANDING_SPEC = AIToolSpec(
     name="get_user_standing",
     description=(
-        "Return the current user's standing in this server: their XP "
-        "level and whether they are a brand-new user. Call this when the "
-        "answer depends on who is asking or on their level/permissions."
+        "Return the asking user's standing in THIS server: their Discord "
+        "permission role (server_owner / administrator / moderator / regular "
+        "member) with owner/admin flags, plus their XP level and whether they "
+        "are a brand-new user. This is the authoritative live answer for "
+        "'what are my permissions / am I an admin / am I the owner'. Call it "
+        "when the answer depends on who is asking, their permissions, or "
+        "their level."
     ),
     parameters=_NO_ARGS_SCHEMA,
     min_scope=AIScope.USER,
 )
 
 
-def _make_user_standing(guild_id: int, actor_id: int) -> ToolHandler:
+def _make_user_standing(
+    guild_id: int,
+    actor_id: int,
+    member: Any = None,
+) -> ToolHandler:
     async def handler(_arguments: dict[str, Any]) -> dict[str, Any]:
         snap = await ai_permission_service.snapshot(guild_id, actor_id)
-        return {"level": snap.level, "is_new_user": snap.is_fresh_user}
+        result: dict[str, Any] = {
+            "level": snap.level,
+            "is_new_user": snap.is_fresh_user,
+        }
+        # Resolve the Discord permission standing from the live member using
+        # the SAME resolver the bot_user_identity span uses, so the tool can
+        # never contradict the span. Without this the tool returned only XP
+        # data and the model inferred "no admin status" from its silence —
+        # telling a server owner they were a regular member.
+        if member is not None:
+            from services.bot_knowledge_service import resolve_user_tier
+
+            tier = resolve_user_tier(member)
+            result["server_role"] = tier
+            result["is_server_owner"] = tier == "server_owner"
+            result["has_admin_access"] = tier in ("server_owner", "administrator")
+        return result
 
     return handler
 
@@ -844,7 +868,7 @@ def build_registry(
 
     include_members = ai_server_member_lookup_enabled()
     catalog: list[tuple[AIToolSpec, ToolHandler]] = [
-        (_USER_STANDING_SPEC, _make_user_standing(guild_id, actor_id)),
+        (_USER_STANDING_SPEC, _make_user_standing(guild_id, actor_id, member)),
         (_SERVER_TIME_SPEC, _server_time),
         (_BTD6_LOOKUP_SPEC, _btd6_lookup),
         (_BTD6_CAPABILITY_SPEC, _btd6_capability_lookup),

--- a/tests/unit/services/test_ai_tools.py
+++ b/tests/unit/services/test_ai_tools.py
@@ -66,7 +66,72 @@ async def test_user_standing_handler_reads_permission_snapshot(monkeypatch):
 
     result = await registry.handlers["get_user_standing"]({})
 
+    # No member supplied → XP-only result (permission role omitted).
     assert result == {"level": 5, "is_new_user": False}
+
+
+async def test_user_standing_includes_discord_role_for_owner(monkeypatch):
+    """Regression: 'what are my permissions, use your tools' must return the
+    asker's Discord permission role, not just XP.
+
+    The tool previously returned only level/is_new_user, so when a server
+    owner asked, the model inferred 'no admin status' from the tool's silence
+    and told them they were a regular member — contradicting the (correct)
+    bot_user_identity span. The tool now resolves the live permission tier
+    with the same resolver the span uses, so the two always agree.
+    """
+
+    async def fake_snapshot(guild_id, user_id):
+        return SimpleNamespace(level=39, is_fresh_user=False)
+
+    monkeypatch.setattr(ai_tools.ai_permission_service, "snapshot", fake_snapshot)
+
+    # member.id == guild.owner_id → resolve_user_tier returns "server_owner".
+    owner = SimpleNamespace(
+        id=777,
+        guild=SimpleNamespace(owner_id=777),
+        guild_permissions=SimpleNamespace(administrator=True, manage_guild=True),
+    )
+    registry = build_registry(
+        scope=AIScope.USER,
+        guild_id=1,
+        actor_id=777,
+        member=owner,
+    )
+
+    result = await registry.handlers["get_user_standing"]({})
+
+    assert result["server_role"] == "server_owner"
+    assert result["is_server_owner"] is True
+    assert result["has_admin_access"] is True
+    # XP fields are still present alongside the permission role.
+    assert result["level"] == 39
+    assert result["is_new_user"] is False
+
+
+async def test_user_standing_regular_member_reports_no_admin(monkeypatch):
+    async def fake_snapshot(guild_id, user_id):
+        return SimpleNamespace(level=5, is_fresh_user=False)
+
+    monkeypatch.setattr(ai_tools.ai_permission_service, "snapshot", fake_snapshot)
+
+    member = SimpleNamespace(
+        id=2,
+        guild=SimpleNamespace(owner_id=999),
+        guild_permissions=SimpleNamespace(administrator=False, manage_guild=False),
+    )
+    registry = build_registry(
+        scope=AIScope.USER,
+        guild_id=1,
+        actor_id=2,
+        member=member,
+    )
+
+    result = await registry.handlers["get_user_standing"]({})
+
+    assert result["server_role"] == "user"
+    assert result["is_server_owner"] is False
+    assert result["has_admin_access"] is False
 
 
 async def test_btd6_lookup_handler_grounds_named_entity_and_reports_misses():


### PR DESCRIPTION
## Problem

Asked *"@SuperBot what are my permissions in this server, use your tools"*, the bot — talking to the **server owner** — replied with XP level 39, "Not a new user", and **"No special administrative status (owner, administrator, or moderator)"**, then declared a "discrepancy" with the `bot_user_identity` span and concluded *"You do not have owner or administrative access."*

It told the actual server owner they were a regular member.

## Root cause

The `get_user_standing` tool returns only XP data:

```python
return {"level": snap.level, "is_new_user": snap.is_fresh_user}
```

`UserPermissionSnapshot` carries only `level` and `is_fresh_user` — no Discord permission info. And `_make_user_standing(guild_id, actor_id)` was constructed **without the live member**, even though `build_registry` already receives it. So when the user explicitly asked the bot to "use your tools," the tool returned XP-only data, the model **inferred "no admin status" from the tool's silence**, and treated that as authoritative over the (correct) `bot_user_identity` span — manufacturing a false discrepancy. The tool's description also over-promised ("level/permissions") while returning no permissions.

## Fix

Pass the `member` through to the handler and resolve the Discord permission tier with the **same `resolve_user_tier`** the `bot_user_identity` span uses — so the tool and the span can never disagree:

```python
tier = resolve_user_tier(member)            # server_owner|administrator|moderator|user
result["server_role"] = tier
result["is_server_owner"] = tier == "server_owner"
result["has_admin_access"] = tier in ("server_owner", "administrator")
```

XP fields are unchanged, and the member-less path (no live guild) still returns the prior XP-only shape. The spec description now states the tool is the authoritative live answer for "what are my permissions / am I an admin / am I the owner."

## Tests

- Existing `test_user_standing_handler_reads_permission_snapshot` (no member) still passes — XP-only result preserved.
- New `test_user_standing_includes_discord_role_for_owner` — a server owner gets `server_role="server_owner"`, `is_server_owner=True`, `has_admin_access=True` alongside the XP fields. Fails on the old code.
- New `test_user_standing_regular_member_reports_no_admin` — a regular member gets `has_admin_access=False`.

`test_tool_calling.py` and the eval cases use scripted `get_user_standing` results, so they're unaffected.

## Verification

- `pytest tests/ -q` → **6677 passed, 3 skipped**
- `check_architecture.py --mode strict` → exit 0
- CI gates (their scope): black/isort/ruff exit 0, `mypy disbot/` clean (527 files)

https://claude.ai/code/session_01Jh6DEuRHvQJc87VJh5yGPG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jh6DEuRHvQJc87VJh5yGPG)_