### PR TITLE
Make local quality checks mirror CI exactly to stop false-signal churn

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -47,11 +47,28 @@ CI runs **Python 3.10** (`.github/workflows/code-quality.yml`). Running formatte
 1. Always run formatters / mypy / pytest via `python3.10 -m <tool>` — never bare `black`, `mypy`, `pytest`, or `python3 -m …`. The Stop hook (`scripts/claude_stop_check.py`) already does this.
 2. Before pushing, run the full pre-PR suite:
    ```
-   python3.10 scripts/check_quality.py --check-only && python3.10 -m pytest tests/ -q
+   python3.10 scripts/check_quality.py --full
    ```
-   The Stop hook prints this same command at end of every turn touching `disbot/*.py`.
-3. The `PostToolUse` hook (`scripts/claude_post_edit.py`) auto-fixes black/isort/ruff on every edit and **prints a loud warning** when it changes the file. Read the warning — it means something landed that wasn't already CI-clean.
-4. Pin third-party packages where the public API has churned (see `youtube-transcript-api<1.0` in `requirements.txt` for the canonical example). Unpinned `>=X.Y` resolves to whatever's latest in CI's fresh install, even if your local env still has the old version cached.
+   This is a **true CI mirror**: it runs black / isort / ruff over CI's exact
+   scope (`.` minus the `tests/`, `.github/`, … excludes), then `mypy disbot/`
+   and the full pytest suite — every tool via `python3.10 -m`. Green here means
+   green in CI, and red means red. `--check-only` runs just the formatters/lint
+   (no mypy/pytest) for a fast pass. The Stop hook prints the command at the end
+   of every turn touching `disbot/*.py`.
+   - **Do not** hand-run bare `black .` / `pytest` to "double-check": bare exes
+     on PATH resolve to a different interpreter/version (a uv-installed pytest on
+     Python 3.11, an older black) and produce false failures. Trust
+     `check_quality.py`, which pins the interpreter.
+   - The script's scope is pinned to the workflow on purpose. CI **excludes
+     `tests/`** from black/isort/ruff, so don't reformat test files to chase a
+     red signal that came from running a formatter over `tests/` directly.
+3. Tool versions are pinned to identical values in three places —
+   `.github/workflows/code-quality.yml`, `requirements-dev.txt`, and
+   `.pre-commit-config.yaml`. When bumping a formatter/linter, change all three
+   in the same commit, or local and CI silently drift (black/ruff reformat
+   differently across releases).
+4. The `PostToolUse` hook (`scripts/claude_post_edit.py`) auto-fixes black/isort/ruff on every edit and **prints a loud warning** when it changes the file. Read the warning — it means something landed that wasn't already CI-clean.
+5. Pin third-party packages where the public API has churned (see `youtube-transcript-api<1.0` in `requirements.txt` for the canonical example). Unpinned `>=X.Y` resolves to whatever's latest in CI's fresh install, even if your local env still has the old version cached.
 <!-- CI_PARITY_END -->
 
 <!-- CODEGRAPH_START -->

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,28 +10,34 @@ repos:
         pass_filenames: true
         files: ^disbot/
 
+  # Formatter / linter versions are PINNED to match the CI workflow
+  # (.github/workflows/code-quality.yml) and requirements-dev.txt exactly.
+  # Black/ruff change their output between releases, so a stale pin here
+  # reformats code in a way CI then rejects (and vice versa). When bumping
+  # any tool, bump it in all three places in the same change.
+
   # Black - format
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 26.5.1
     hooks:
       - id: black
 
   # isort - import order
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 8.0.1
     hooks:
       - id: isort
 
   # Ruff - lint + autofix, fail commit if it had to fix anything
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.3
+    rev: v0.15.14
     hooks:
       - id: ruff
         args: ["--fix", "--exit-non-zero-on-fix"]
 
   # Mypy - strict types
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v2.1.0
     hooks:
       - id: mypy
         additional_dependencies: ["types-requests", "types-PyYAML"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,9 +3,15 @@
 # `.github/workflows/code-quality.yml` so local and CI agree on tool
 # versions.  Install with `bash scripts/setup_dev_env.sh` or:
 #   pip install -r requirements.txt -r requirements-dev.txt
-black
-isort
-ruff
-mypy
-pytest
-pytest-asyncio
+#
+# Versions are PINNED to match the CI workflow exactly. Formatters change
+# their output between releases, so an unpinned install silently drifts
+# from CI and produces "passes locally, fails in CI" churn (and vice
+# versa). When bumping a tool here, bump it in code-quality.yml AND
+# .pre-commit-config.yaml in the same change.
+black==26.5.1
+isort==8.0.1
+ruff==0.15.14
+mypy==2.1.0
+pytest==9.0.3
+pytest-asyncio==1.4.0

--- a/scripts/check_quality.py
+++ b/scripts/check_quality.py
@@ -14,12 +14,43 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import shutil
 import subprocess
 import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DISBOT_ROOT = REPO_ROOT / "disbot"
+
+# Always invoke tools as `python3.10 -m <tool>`, never as the bare
+# executable. CI runs Python 3.10, and a bare `black` / `pytest` / etc. on
+# PATH can resolve to a DIFFERENT interpreter (e.g. a uv-installed
+# standalone pytest on its own isolated env that lacks the project's
+# dependencies — which produces thousands of bogus import-error
+# "failures"). Routing through python3.10 -m guarantees the same
+# interpreter + installed packages CI and the Claude Code hooks use.
+# See .claude/CLAUDE.md "Match CI exactly" and the PR #338 post-mortem.
+_PY = "python3.10" if shutil.which("python3.10") else sys.executable
+
+
+def _tool(name: str, *args: str) -> list[str]:
+    """Build a ``python3.10 -m <name> ...`` command (never the bare exe)."""
+    return [_PY, "-m", name, *args]
+
+
+# CI parity (see .github/workflows/code-quality.yml). These MUST match the
+# workflow's invocations exactly, or this script reports failures CI will
+# never see (or misses ones it will). The canonical traps this prevents:
+#   * CI excludes tests/ from black/isort/ruff — checking tests/ here too
+#     surfaced ~196 pre-existing test-file reformats that CI ignores, which
+#     turned the prescribed pre-push check permanently red for no real
+#     reason and caused wasted back-and-forth.
+#   * CI runs mypy only against disbot/.
+# black --exclude / ruff --exclude take a regex / comma-list; isort uses
+# --skip-glob. Kept byte-for-byte aligned with the workflow.
+_BLACK_EXCLUDE = r"(\.github|tests|venv|env|build|dist)"
+_ISORT_SKIP_GLOB = r"*/(\.github|tests|venv|env|build|dist)/*"
+_RUFF_EXCLUDE = ".github,tests,venv,env,build,dist"
 
 
 def _run(label: str, cmd: list[str], *, check: bool = False) -> int:
@@ -34,15 +65,27 @@ def _run(label: str, cmd: list[str], *, check: bool = False) -> int:
 
 
 def run_formatters(*, check_only: bool) -> list[tuple[str, int]]:
+    """Run black / isort / ruff over CI's exact scope.
+
+    Scope and exclude flags mirror ``.github/workflows/code-quality.yml``
+    so a pass here means a pass in CI (and vice versa). In ``--check-only``
+    mode the invocations are byte-for-byte the workflow's; in fix mode the
+    only difference is the auto-fix flag.
+    """
     results = []
-    flag = ["--check"] if check_only else []
 
     results.append(
         (
             "black",
             _run(
                 "black" + (" --check" if check_only else " --fix"),
-                ["black", *flag, "disbot/", "scripts/", "tests/"],
+                _tool(
+                    "black",
+                    *(["--check"] if check_only else []),
+                    ".",
+                    "--exclude",
+                    _BLACK_EXCLUDE,
+                ),
             ),
         ),
     )
@@ -51,13 +94,13 @@ def run_formatters(*, check_only: bool) -> list[tuple[str, int]]:
             "isort",
             _run(
                 "isort" + (" --check-only" if check_only else ""),
-                [
+                _tool(
                     "isort",
                     *(["--check-only"] if check_only else []),
-                    "disbot/",
-                    "scripts/",
-                    "tests/",
-                ],
+                    ".",
+                    "--skip-glob",
+                    _ISORT_SKIP_GLOB,
+                ),
             ),
         ),
     )
@@ -66,13 +109,14 @@ def run_formatters(*, check_only: bool) -> list[tuple[str, int]]:
             "ruff",
             _run(
                 "ruff" + (" --no-fix" if check_only else " --fix"),
-                [
+                _tool(
                     "ruff",
                     "check",
                     *(["--no-fix"] if check_only else ["--fix"]),
-                    "disbot/",
-                    "scripts/",
-                ],
+                    ".",
+                    "--exclude",
+                    _RUFF_EXCLUDE,
+                ),
             ),
         ),
     )
@@ -80,11 +124,12 @@ def run_formatters(*, check_only: bool) -> list[tuple[str, int]]:
 
 
 def run_mypy() -> int:
-    return _run("mypy", ["mypy", "disbot/"])
+    # CI runs `mypy disbot/` — match the target exactly.
+    return _run("mypy", _tool("mypy", "disbot/"))
 
 
 def run_pytest() -> int:
-    return _run("pytest", ["pytest", "tests/", "-q", "--tb=short"])
+    return _run("pytest", _tool("pytest", "tests/", "-q", "--tb=short"))
 
 
 def main() -> int:


### PR DESCRIPTION
## Why

You noticed recurring inconsistencies and a lot of wasted back-and-forth (and "extra credit" rate-limit burn) across sessions. The root cause was real: **my prescribed local quality check (`scripts/check_quality.py`) did not match GitHub CI**, so its pass/fail signal couldn't be trusted. I investigated (read-only) and found *three* concrete divergences, all fixed here. No application code changed — tooling/config/docs only.

## The three bugs (each verified)

**1. Scope mismatch — the main credit-waster.** CI excludes `tests/` from black/isort/ruff; the script ran them over `tests/` too.
- `black --check` on CI's scope (`disbot/`, `scripts/`): **0 files** — clean.
- `black --check` as the script ran it (incl. `tests/`): **196 files "would reformat".**

So the prescribed `--check-only` was *permanently red* for reasons CI would never fail on. Every session I either burned turns deciding if it was mine, or "fixed" formatting in files I shouldn't touch.

**2. Wrong interpreter — the scariest.** The script shelled out to bare `black`/`pytest`/etc. On PATH those resolve to a **uv-installed pytest on Python 3.11** and an **older black (26.3.1 on 3.11)** — not the project's `python3.10`. Result, same test file:
- bare `pytest`: **fails** (missing project deps → import errors)
- `python3.10 -m pytest`: **passes**

`check_quality.py --full` reported **~2852 bogus failures**; the real number is **6689 passing**. Following the documented workflow produced thousands of fake failures. (CLAUDE.md already warned "never bare pytest" — but the script itself violated it.)

**3. Unpinned versions.** `requirements-dev.txt` pinned nothing; `.pre-commit-config.yaml` pinned stale majors (black `24.4.2` vs CI's `26.5.1`). Fresh envs silently drift from CI's formatting — the "197 files would reformat" churn.

## Fixes

- **`scripts/check_quality.py`**: every tool runs via `python3.10 -m <tool>`; black/isort/ruff use CI's exact `.`-plus-exclude scope; mypy targets `disbot/`. `--full` now mirrors CI across all five checks.
- **`requirements-dev.txt`**: pin black/isort/ruff/mypy/pytest/pytest-asyncio to CI's exact versions.
- **`.pre-commit-config.yaml`**: bump pins to match CI.
- **`.claude/CLAUDE.md`**: document `check_quality.py --full` as the true CI mirror, warn against bare-exe double-checks, and require version bumps in all three pinned files together.

## Verification (via the now-trustworthy command)

`python3.10 scripts/check_quality.py --full`:
```
✓ black --check   ✓ isort --check-only   ✓ ruff --no-fix
✓ mypy            ✓ pytest — 6689 passed, 3 skipped
All checks passed ✓
```
Plus `check_architecture.py --mode strict` → exit 0. Confirmed each raw CI command (`black --check . --exclude …`, etc.) exits 0 independently, matching the script.

## Effect going forward

One command — `check_quality.py --full` — now gives a signal that means exactly what CI will say. That should eliminate the false-red back-and-forth that was driving the extra usage you saw.

https://claude.ai/code/session_01Jh6DEuRHvQJc87VJh5yGPG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jh6DEuRHvQJc87VJh5yGPG)_