### PR TITLE
Mining/exploration foundation + brainstorm (additive, no behaviour change)

### DIFF
--- a/disbot/cogs/mining/exploration.py
+++ b/disbot/cogs/mining/exploration.py
@@ -1,0 +1,333 @@
+"""Exploration engine — pure, loadout-aware outcome catalog (foundation).
+
+This module is the structured successor to the flat five-entry
+``EXPLORE_OUTCOMES`` table in :mod:`cogs.mining.rewards`.  It models
+exploration as *depth-banded* (a :class:`Biome`) and *loadout-aware* (the
+tools a player has equipped change which outcomes are reachable and how
+generous they are), while staying a **pure** domain module: no Discord,
+no DB, no I/O.  Randomness is injected so every roll is deterministic
+under test.
+
+Design intent (see ``docs/mining_exploration_brainstorm.md``):
+
+* The engine owns the *catalog* of possible outcomes and the math that
+  selects and scales one.  A future exploration **service** would own
+  state/mutations, and a registered **renderer** (or the read-only AI
+  layer) would turn a :class:`ExploreResult` into buttons / an embed /
+  an image.  Keeping selection pure here is what lets the AI "narrate
+  and theme" an outcome it is *given* without ever writing state.
+* Tool-gating (`requires`) is how a loadout meaningfully drives results:
+  a torch unlocks deep finds, dynamite unlocks high-payoff blasted
+  veins, a lucky charm scales amounts.  This replaces the current binary
+  "owns pickaxe → double".
+
+Nothing in this module is wired into a command yet — it is additive
+foundation.  ``resolve_to_legacy_tuple`` returns the exact
+``(text, item, amount)`` shape the existing ``!explore`` handler already
+consumes, so adoption later is a drop-in, not a rewrite.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class Biome(Enum):
+    """Depth bands.  Deeper biomes carry richer (and riskier) outcomes."""
+
+    SURFACE = "surface"
+    CAVERN = "cavern"
+    DEEP = "deep"
+    MAGMA = "magma"
+
+
+# Depth ordering for "this outcome is available at this biome or deeper".
+_BIOME_DEPTH: dict[Biome, int] = {
+    Biome.SURFACE: 0,
+    Biome.CAVERN: 1,
+    Biome.DEEP: 2,
+    Biome.MAGMA: 3,
+}
+
+
+class Rarity(Enum):
+    COMMON = "common"
+    UNCOMMON = "uncommon"
+    RARE = "rare"
+    LEGENDARY = "legendary"
+
+
+# Tool names recognised by the gating / scaling logic.  Kept as plain
+# strings so a loadout is just "the set of tool item-names the player
+# owns" — no coupling to a separate enum the inventory would have to map.
+PICKAXE = "pickaxe"
+TORCH = "torch"
+LANTERN = "lantern"
+DYNAMITE = "dynamite"
+LUCKY_CHARM = "lucky charm"
+MAP = "map"
+
+
+@dataclass(frozen=True)
+class Loadout:
+    """The tools a player has available for an exploration roll.
+
+    Built from an inventory elsewhere (``Loadout.from_inventory``) so this
+    module never touches the DB.  ``consumes`` on an outcome can later tell
+    the caller which tools to decrement — the engine itself mutates
+    nothing.
+    """
+
+    tools: frozenset[str] = frozenset()
+
+    @classmethod
+    def from_inventory(cls, inventory: dict[str, int]) -> Loadout:
+        """Derive a loadout from an ``{item_name: qty}`` inventory map.
+
+        A tool counts as equipped when its quantity is positive.  Item
+        names are lower-cased to match the inventory's storage convention.
+        """
+        owned = {
+            name.lower()
+            for name, qty in inventory.items()
+            if qty > 0 and name.lower() in _KNOWN_TOOLS
+        }
+        return cls(tools=frozenset(owned))
+
+    def has(self, tool: str) -> bool:
+        return tool.lower() in self.tools
+
+
+_KNOWN_TOOLS: frozenset[str] = frozenset(
+    {PICKAXE, TORCH, LANTERN, DYNAMITE, LUCKY_CHARM, MAP},
+)
+
+
+@dataclass(frozen=True)
+class ExploreOutcome:
+    """One catalog entry.  ``narration`` is a flavour template; the engine
+    fills ``{amount}`` / ``{item}`` when a roll resolves it.
+    """
+
+    key: str
+    narration: str
+    item: str | None
+    amount: int
+    rarity: Rarity = Rarity.COMMON
+    min_biome: Biome = Biome.SURFACE
+    weight: float = 1.0
+    # Tools required for this outcome to even be reachable.
+    requires: frozenset[str] = field(default_factory=frozenset)
+    # Tools this outcome would consume if applied (advisory; engine is pure).
+    consumes: frozenset[str] = field(default_factory=frozenset)
+    tags: frozenset[str] = field(default_factory=frozenset)
+
+
+@dataclass(frozen=True)
+class ExploreResult:
+    """The resolved result of one exploration roll."""
+
+    outcome: ExploreOutcome
+    biome: Biome
+    final_amount: int
+    narration: str
+
+    def to_legacy_tuple(self) -> tuple[str, str | None, int]:
+        """Return ``(text, item_or_None, delta)`` — the shape the existing
+        ``!explore`` handler already consumes.
+        """
+        return self.narration, self.outcome.item, self.final_amount
+
+
+# ---------------------------------------------------------------------------
+# The catalog.  Deliberately data, not code: extend by appending entries.
+# ---------------------------------------------------------------------------
+CATALOG: tuple[ExploreOutcome, ...] = (
+    # --- surface ---------------------------------------------------------
+    ExploreOutcome(
+        key="abandoned_camp",
+        narration="found {amount} gold in an abandoned camp!",
+        item="gold",
+        amount=1,
+        rarity=Rarity.UNCOMMON,
+        min_biome=Biome.SURFACE,
+        weight=2.0,
+    ),
+    ExploreOutcome(
+        key="secret_chest",
+        narration="found a secret chest with {amount} wood!",
+        item="wood",
+        amount=3,
+        rarity=Rarity.COMMON,
+        min_biome=Biome.SURFACE,
+        weight=3.0,
+    ),
+    ExploreOutcome(
+        key="got_lost",
+        narration="got lost and found nothing...",
+        item=None,
+        amount=0,
+        rarity=Rarity.COMMON,
+        min_biome=Biome.SURFACE,
+        weight=3.0,
+    ),
+    ExploreOutcome(
+        key="monster_ambush",
+        narration="was attacked by monsters and lost {amount} stone...",
+        item="stone",
+        amount=-2,
+        rarity=Rarity.COMMON,
+        min_biome=Biome.SURFACE,
+        weight=2.0,
+        tags=frozenset({"hazard"}),
+    ),
+    # --- cavern / deep (often torch-gated) -------------------------------
+    ExploreOutcome(
+        key="hidden_diamond_vein",
+        narration="stumbled upon a hidden diamond vein and got {amount} diamond!",
+        item="diamond",
+        amount=1,
+        rarity=Rarity.RARE,
+        min_biome=Biome.CAVERN,
+        weight=1.0,
+        requires=frozenset({TORCH}),
+        tags=frozenset({"torch_only"}),
+    ),
+    ExploreOutcome(
+        key="iron_pocket",
+        narration="chipped {amount} iron out of a glittering pocket!",
+        item="iron",
+        amount=2,
+        rarity=Rarity.UNCOMMON,
+        min_biome=Biome.CAVERN,
+        weight=2.0,
+    ),
+    # --- deep / magma (dynamite-gated high payoff) -----------------------
+    ExploreOutcome(
+        key="blasted_vein",
+        narration="blew open a sealed vein and hauled out {amount} gold!",
+        item="gold",
+        amount=5,
+        rarity=Rarity.RARE,
+        min_biome=Biome.DEEP,
+        weight=1.0,
+        requires=frozenset({DYNAMITE}),
+        consumes=frozenset({DYNAMITE}),
+        tags=frozenset({"dynamite_only"}),
+    ),
+    ExploreOutcome(
+        key="molten_geode",
+        narration="cracked a molten geode and recovered {amount} diamond!",
+        item="diamond",
+        amount=2,
+        rarity=Rarity.LEGENDARY,
+        min_biome=Biome.MAGMA,
+        weight=0.5,
+        requires=frozenset({TORCH}),
+    ),
+)
+
+
+def eligible_outcomes(biome: Biome, loadout: Loadout) -> list[ExploreOutcome]:
+    """Outcomes reachable at *biome* (or shallower) with *loadout*.
+
+    An outcome is eligible when the current biome is at least as deep as
+    its ``min_biome`` and the loadout contains every tool in ``requires``.
+    """
+    depth = _BIOME_DEPTH[biome]
+    return [
+        o
+        for o in CATALOG
+        if _BIOME_DEPTH[o.min_biome] <= depth and o.requires <= loadout.tools
+    ]
+
+
+def _scale_amount(outcome: ExploreOutcome, loadout: Loadout) -> int:
+    """Apply loadout-driven scaling to a positive payout.
+
+    A pickaxe doubles ore gains (mirrors the existing !mine bonus); a
+    lucky charm adds +1 on top.  Penalties (negative amounts) are never
+    scaled — gear protects gains, it does not amplify losses.
+    """
+    amount = outcome.amount
+    if amount <= 0:
+        return amount
+    if loadout.has(PICKAXE) and outcome.item in {"stone", "iron", "gold", "diamond"}:
+        amount *= 2
+    if loadout.has(LUCKY_CHARM):
+        amount += 1
+    return amount
+
+
+def resolve(
+    biome: Biome,
+    loadout: Loadout,
+    *,
+    rng: random.Random | None = None,
+) -> ExploreResult:
+    """Pick and resolve one weighted exploration outcome.
+
+    *rng* is injected for deterministic tests; defaults to the module
+    :mod:`random`.  Always returns a result — if nothing is eligible
+    (should not happen given the surface fallbacks), a benign "nothing"
+    result is produced.
+    """
+    chooser = rng or random
+    candidates = eligible_outcomes(biome, loadout)
+    if not candidates:
+        empty = ExploreOutcome(
+            key="empty",
+            narration="found nothing of note...",
+            item=None,
+            amount=0,
+        )
+        return ExploreResult(empty, biome, 0, empty.narration)
+
+    outcome = chooser.choices(candidates, weights=[o.weight for o in candidates], k=1)[
+        0
+    ]
+    final_amount = _scale_amount(outcome, loadout)
+    narration = outcome.narration.format(
+        amount=abs(final_amount),
+        item=outcome.item or "",
+    )
+    return ExploreResult(outcome, biome, final_amount, narration)
+
+
+def resolve_to_legacy_tuple(
+    biome: Biome = Biome.SURFACE,
+    loadout: Loadout | None = None,
+    *,
+    rng: random.Random | None = None,
+) -> tuple[str, str | None, int]:
+    """Drop-in replacement for ``rewards.roll_explore_outcome``.
+
+    Returns ``(text, item_or_None, delta)`` so a future wiring step can
+    swap the call site with no change to the cog's downstream code.
+    """
+    return resolve(biome, loadout or Loadout(), rng=rng).to_legacy_tuple()
+
+
+# Mutation-application is intentionally NOT here: applying ``final_amount``
+# and ``outcome.consumes`` to an inventory is a write, which must flow
+# through the DB/mutation layer the cog already uses.  This module only
+# decides *what* happened, never *commits* it.
+__all__ = [
+    "Biome",
+    "Rarity",
+    "Loadout",
+    "ExploreOutcome",
+    "ExploreResult",
+    "CATALOG",
+    "eligible_outcomes",
+    "resolve",
+    "resolve_to_legacy_tuple",
+    "PICKAXE",
+    "TORCH",
+    "LANTERN",
+    "DYNAMITE",
+    "LUCKY_CHARM",
+    "MAP",
+]

--- a/disbot/cogs/mining/items.py
+++ b/disbot/cogs/mining/items.py
@@ -1,0 +1,205 @@
+"""Item taxonomy — pure classification of mining items (foundation).
+
+Today every mining item (ore, wood, a built structure, a tool, a
+consumable) is an undifferentiated string key in ``mining_inventory``.
+That works for storage but means no layer can answer "is this a tool?",
+"what tier is this pickaxe?", or "sort my inventory sensibly" without
+hard-coding name lists at each call site.
+
+This module is the single, pure source of truth for that taxonomy.  It
+classifies known items, exposes tool tiers (the backbone of a crafting
+progression), and provides display/sorting helpers.  No Discord, no DB.
+
+It is additive foundation: nothing imports it in a command path yet.  A
+future crafting service / cog and the exploration renderer would consume
+:func:`classify`, :func:`tool_tier`, and :func:`sort_inventory`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class ItemKind(Enum):
+    RESOURCE = "resource"  # raw materials: stone, iron, gold, diamond, wood
+    TOOL = "tool"  # pickaxe, axe, torch, lantern, dynamite
+    CONSUMABLE = "consumable"  # used up on use: dynamite, torch
+    STRUCTURE = "structure"  # built via recipes: stone hut, gold statue
+    TREASURE = "treasure"  # high-value finds with no crafting use
+
+
+@dataclass(frozen=True)
+class ItemDef:
+    name: str
+    kind: ItemKind
+    # 0 for non-tiered items; 1..5 for a tool/material progression.
+    tier: int = 0
+    # Relative display/economy value; used by total_value + sorting.
+    value: int = 1
+    stackable: bool = True
+    tags: frozenset[str] = field(default_factory=frozenset)
+
+
+# Canonical catalog.  Names are stored lower-cased to match inventory keys.
+_CATALOG: dict[str, ItemDef] = {
+    # resources (ordered by value / depth)
+    "wood": ItemDef("wood", ItemKind.RESOURCE, tier=1, value=1),
+    "stone": ItemDef("stone", ItemKind.RESOURCE, tier=1, value=1),
+    "iron": ItemDef("iron", ItemKind.RESOURCE, tier=2, value=3),
+    "gold": ItemDef("gold", ItemKind.RESOURCE, tier=3, value=6),
+    "diamond": ItemDef("diamond", ItemKind.RESOURCE, tier=4, value=12),
+    # tools (tier drives crafting upgrades / loadout strength)
+    "axe": ItemDef("axe", ItemKind.TOOL, tier=1, value=5),
+    "pickaxe": ItemDef("pickaxe", ItemKind.TOOL, tier=1, value=5),
+    "torch": ItemDef(
+        "torch",
+        ItemKind.CONSUMABLE,
+        tier=1,
+        value=2,
+        tags=frozenset({"light"}),
+    ),
+    "lantern": ItemDef(
+        "lantern",
+        ItemKind.TOOL,
+        tier=2,
+        value=10,
+        tags=frozenset({"light"}),
+    ),
+    "dynamite": ItemDef(
+        "dynamite",
+        ItemKind.CONSUMABLE,
+        tier=2,
+        value=8,
+        tags=frozenset({"blast"}),
+    ),
+    "lucky charm": ItemDef(
+        "lucky charm",
+        ItemKind.TREASURE,
+        tier=3,
+        value=20,
+        tags=frozenset({"luck"}),
+    ),
+    # Structures are built via recipes rather than mined.
+    "stone hut": ItemDef("stone hut", ItemKind.STRUCTURE, value=10, stackable=False),
+    "iron pickaxe": ItemDef("iron pickaxe", ItemKind.TOOL, tier=2, value=15),
+    "gold statue": ItemDef(
+        "gold statue",
+        ItemKind.STRUCTURE,
+        value=30,
+        stackable=False,
+    ),
+    "diamond throne": ItemDef(
+        "diamond throne",
+        ItemKind.STRUCTURE,
+        value=80,
+        stackable=False,
+    ),
+    "wooden house": ItemDef(
+        "wooden house",
+        ItemKind.STRUCTURE,
+        value=12,
+        stackable=False,
+    ),
+}
+
+# Tool upgrade ladder — the spine of a future crafting progression.  Each
+# entry maps a tool family to its ordered tiers (lowest → highest).
+TOOL_LADDERS: dict[str, tuple[str, ...]] = {
+    "pickaxe": ("pickaxe", "iron pickaxe"),
+    "light": ("torch", "lantern"),
+}
+
+
+def lookup(name: str) -> ItemDef | None:
+    """Return the :class:`ItemDef` for *name*, or None if unknown."""
+    return _CATALOG.get(name.lower())
+
+
+def classify(name: str) -> ItemKind:
+    """Classify *name*.  Unknown items default to RESOURCE — the safest
+    assumption for an inventory total (counts toward totals, no special
+    behaviour).
+    """
+    item = _CATALOG.get(name.lower())
+    return item.kind if item else ItemKind.RESOURCE
+
+
+def is_tool(name: str) -> bool:
+    return classify(name) is ItemKind.TOOL
+
+
+def is_consumable(name: str) -> bool:
+    return classify(name) is ItemKind.CONSUMABLE
+
+
+def tool_tier(name: str) -> int:
+    """Tier of *name* (0 if unknown or non-tiered)."""
+    item = _CATALOG.get(name.lower())
+    return item.tier if item else 0
+
+
+def item_value(name: str) -> int:
+    """Per-unit value of *name* (1 for unknown items)."""
+    item = _CATALOG.get(name.lower())
+    return item.value if item else 1
+
+
+def total_value(inventory: dict[str, int]) -> int:
+    """Sum the economic value of an ``{item_name: qty}`` inventory."""
+    return sum(item_value(name) * qty for name, qty in inventory.items() if qty > 0)
+
+
+def next_tool_upgrade(name: str) -> str | None:
+    """Return the next tier up from *name* in its ladder, or None if *name*
+    is already top-tier / not on a ladder.
+    """
+    lowered = name.lower()
+    for ladder in TOOL_LADDERS.values():
+        if lowered in ladder:
+            idx = ladder.index(lowered)
+            if idx + 1 < len(ladder):
+                return ladder[idx + 1]
+            return None
+    return None
+
+
+def sort_inventory(inventory: dict[str, int]) -> list[tuple[str, int]]:
+    """Return inventory items ordered for display.
+
+    Sort key: kind (resources, then tools, then consumables, then
+    structures, then treasure), then descending value, then name.  Items
+    with zero quantity are dropped.
+    """
+    kind_order = {
+        ItemKind.RESOURCE: 0,
+        ItemKind.TOOL: 1,
+        ItemKind.CONSUMABLE: 2,
+        ItemKind.STRUCTURE: 3,
+        ItemKind.TREASURE: 4,
+    }
+    rows = [(name, qty) for name, qty in inventory.items() if qty > 0]
+    rows.sort(
+        key=lambda kv: (
+            kind_order[classify(kv[0])],
+            -item_value(kv[0]),
+            kv[0].lower(),
+        ),
+    )
+    return rows
+
+
+__all__ = [
+    "ItemKind",
+    "ItemDef",
+    "TOOL_LADDERS",
+    "lookup",
+    "classify",
+    "is_tool",
+    "is_consumable",
+    "tool_tier",
+    "item_value",
+    "total_value",
+    "next_tool_upgrade",
+    "sort_inventory",
+]

--- a/disbot/utils/mining_render.py
+++ b/disbot/utils/mining_render.py
@@ -1,0 +1,140 @@
+"""Optional image rendering for mining cards (foundation).
+
+Renders an inventory / exploration "card" as a PNG.  Pillow is an
+**optional** dependency: this module lazy-imports it and degrades
+gracefully (``render_inventory_card`` returns ``None``) when it is not
+installed, so importing this module never breaks the bot and the project
+gains no hard dependency.
+
+> To activate image rendering in production, add ``Pillow`` to
+> ``requirements.txt``.  That one-line dependency decision is deliberately
+> left to the maintainer — until then the helper is dormant and any
+> caller should fall back to an embed when it returns ``None``.
+
+The layout math (:func:`build_card_spec`) is pure and fully unit-tested
+regardless of whether Pillow is present; only the final pixel-pushing in
+:func:`render_inventory_card` needs the library.
+"""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass, field
+
+# Quantity-coloured rows give the card an at-a-glance rarity feel without
+# needing per-item art.  RGB tuples so the renderer can pass them straight
+# to Pillow.
+_KIND_COLOR: dict[str, tuple[int, int, int]] = {
+    "resource": (210, 210, 210),
+    "tool": (130, 200, 255),
+    "consumable": (255, 200, 120),
+    "structure": (180, 160, 255),
+    "treasure": (255, 215, 90),
+}
+_DEFAULT_COLOR = (210, 210, 210)
+_BG = (24, 26, 32)
+_TITLE_COLOR = (240, 240, 240)
+
+
+@dataclass(frozen=True)
+class CardRow:
+    label: str
+    quantity: int
+    color: tuple[int, int, int]
+
+
+@dataclass(frozen=True)
+class CardSpec:
+    """A resolution-independent description of the card to draw."""
+
+    title: str
+    rows: tuple[CardRow, ...]
+    footer: str = ""
+    width: int = 420
+    row_height: int = 34
+    padding: int = 18
+    header_height: int = 48
+    meta: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def height(self) -> int:
+        body = max(len(self.rows), 1) * self.row_height
+        footer_h = self.row_height if self.footer else 0
+        return self.header_height + body + footer_h + self.padding * 2
+
+
+def build_card_spec(
+    title: str,
+    inventory_rows: list[tuple[str, int]],
+    *,
+    classify_kind=None,
+    footer: str = "",
+) -> CardSpec:
+    """Build a :class:`CardSpec` from ordered ``(item_name, qty)`` rows.
+
+    *classify_kind* is an optional ``name -> kind_string`` callable (e.g.
+    ``lambda n: cogs.mining.items.classify(n).value``) used to colour
+    rows.  Kept as an injected callable so this ``utils`` module never
+    imports the ``cogs`` layer (respecting the layer boundary) and stays
+    trivially testable.
+    """
+    rows: list[CardRow] = []
+    for name, qty in inventory_rows:
+        kind = classify_kind(name) if classify_kind else "resource"
+        color = _KIND_COLOR.get(kind, _DEFAULT_COLOR)
+        rows.append(CardRow(label=name.title(), quantity=qty, color=color))
+    return CardSpec(title=title, rows=tuple(rows), footer=footer)
+
+
+def render_inventory_card(spec: CardSpec) -> bytes | None:
+    """Render *spec* to PNG bytes, or ``None`` if Pillow is unavailable.
+
+    Callers MUST treat ``None`` as "rendering unavailable" and fall back
+    to a text/embed representation.
+    """
+    try:
+        from PIL import Image, ImageDraw  # lazy: optional dependency
+    except Exception:  # noqa: BLE001 — any import failure → graceful no-op
+        return None
+
+    img = Image.new("RGB", (spec.width, spec.height), _BG)
+    draw = ImageDraw.Draw(img)
+    pad = spec.padding
+
+    # Title.
+    draw.text((pad, pad), spec.title, fill=_TITLE_COLOR)
+
+    # Rows.
+    y = spec.header_height + pad
+    for row in spec.rows:
+        draw.text((pad, y), row.label, fill=row.color)
+        qty_text = f"x{row.quantity}"
+        # Right-align the quantity within the card width.
+        draw.text((spec.width - pad - 8 * len(qty_text), y), qty_text, fill=row.color)
+        y += spec.row_height
+
+    if spec.footer:
+        draw.text((pad, y), spec.footer, fill=(150, 150, 150))
+
+    buffer = io.BytesIO()
+    img.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def pillow_available() -> bool:
+    """Return True when Pillow can be imported (image rendering is live)."""
+    try:
+        import PIL  # noqa: F401
+
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+__all__ = [
+    "CardRow",
+    "CardSpec",
+    "build_card_spec",
+    "render_inventory_card",
+    "pillow_available",
+]

--- a/docs/mining_exploration_brainstorm.md
+++ b/docs/mining_exploration_brainstorm.md
@@ -1,0 +1,120 @@
+# Mining & Exploration — Brainstorm & Roadmap
+
+> Status: **brainstorm / design notes**, not a binding contract. The
+> binding docs (`architecture.md`, `ownership.md`, `runtime_contracts.md`)
+> win on any conflict. This document captures ideas for growing the
+> mining/exploration subsystem and records the safe, additive foundation
+> shipped alongside it.
+
+## 1. Where the subsystem is today
+
+| Layer | File | Role |
+|---|---|---|
+| Cog | `cogs/mining_cog.py` (283 LOC) | Commands: `minemenu`, `mine`, `chop`, `mineinv`, `minestats`, `build`, `buildlist`, `buildable`, `explore`, `use`, `reset_inventory`, `give`. Most are `hidden=True`. |
+| Domain | `cogs/mining/rewards.py` | Pure loot math: `ORE_WEIGHTS`, `roll_mine_loot(has_pickaxe)`, `roll_harvest_amount(has_axe)`, `EXPLORE_OUTCOMES` (5 flat entries), `roll_explore_outcome()`. |
+| Domain | `cogs/mining/recipes.py` | JSON-loaded structure recipes with hard-coded fallback. |
+| DB | `utils/db/games/mining.py` | `mining_inventory` CRUD, guild-scoped (PR M3). `user_id` is legacy `TEXT`. |
+| DB | `utils/db/inventory.py` | A *separate* unified `inventory` table (`user_id` is `BIGINT`). |
+| Views | `views/mining/main_panel.py` | `MiningHubView` persistent panel (Mine/Harvest/Explore/Inventory/Stats/Build). |
+| Views | `views/mining/mine_view.py` | `MineView` ephemeral 3-button session + `_MineResultsView`. |
+
+### What works well
+- Clean pure/impure split: loot math is already testable without a Discord harness.
+- Guild-scoped storage (the cross-guild wipe bomb was fixed in PR M3).
+- Button-first UX via the hub panel — consistent with "the whole bot is reachable in 3 taps".
+
+### Honest limitations (the brainstorm fuel)
+1. **`explore` is flat.** Five outcomes, uniform `random.choice`, zero awareness of what gear you carry or how deep you are. Owning a pickaxe only ever "doubles" `mine`; the explore path ignores gear entirely.
+2. **Gear is binary.** "Owns pickaxe → ×2", "owns axe → ×2". No tiers, no durability, no loadout, no trade-offs.
+3. **Consumables are cosmetic.** `!use torch` / `!use dynamite` print flavour text and decrement the item, but change *no* outcome. They are mechanically inert.
+4. **Items are untyped strings.** Ore, wood, tools, built structures, and consumables are all undifferentiated keys in `mining_inventory`. No layer can ask "is this a tool?" or "what tier is this?" without re-hard-coding name lists.
+5. **Two inventory tables** (`mining_inventory` TEXT vs `inventory` BIGINT) — latent fragmentation; unifying is its own migration and explicitly out of scope here.
+6. **No session/state.** Each explore is independent; there is no depth, no run, no risk/return arc.
+7. **Rendering is embed-only.** No images; no way to give an explore a visual identity.
+8. **The AI layer is a spectator.** `services/ai_tools.py` is strictly read-only and scope-gated ("Adding a write-capable tool is deliberately out of scope: mutations must go through services"). The `response_renderer_registry` (see `views/youtube_renderers.py`) is the seam for AI-driven *presentation*, but nothing exploration-related is wired to it.
+
+## 2. Feature brainstorm
+
+Naming things makes them discussable. None of these exist yet; this is the menu.
+
+### 2.1 Depth & biomes — "the Descent"
+Exploration becomes *banded by depth*: **Surface → Cavern → Deep → Magma**. Deeper bands carry rarer ore, bigger payoffs, and nastier hazards. Depth is the natural pacing mechanism and the hook for everything below.
+- *Implemented as foundation:* `cogs/mining/exploration.Biome` + `min_biome` gating in the catalog.
+
+### 2.2 Loadout-aware outcomes
+The tools you carry change *which* outcomes are reachable and *how generous* they are:
+- **Torch / Lantern** → unlocks deep finds that are dark-gated (`hidden_diamond_vein`, `molten_geode`).
+- **Dynamite** → unlocks high-payoff "blasted vein" outcomes (consumed on use).
+- **Lucky Charm** → +1 to positive yields.
+- **Pickaxe** → doubles ore gains (mirrors the existing `!mine` bonus, now applied to explore too).
+- *Implemented as foundation:* `Loadout`, `requires`/`consumes` on outcomes, `_scale_amount`.
+
+### 2.3 Item taxonomy & tool tiers — "the Forge ladder"
+Give items *kinds* (`RESOURCE / TOOL / CONSUMABLE / STRUCTURE / TREASURE`), *tiers*, and *values*. Then a crafting progression falls out naturally: `pickaxe → iron pickaxe`, `torch → lantern`. Tiering also powers sensible inventory sorting and an inventory "net worth" stat.
+- *Implemented as foundation:* `cogs/mining/items.py` (`classify`, `tool_tier`, `total_value`, `next_tool_upgrade`, `sort_inventory`, `TOOL_LADDERS`).
+
+### 2.4 Crafting cog — "the Workshop"
+A dedicated, additive **crafting subsystem** sitting on top of recipes + the tool ladder:
+- Upgrade tools by spending lower-tier materials (`iron pickaxe` from `iron + wood`, already a recipe).
+- Tool **durability**: tools wear and need repair/recraft — gives resources a sink.
+- A `WorkshopView` panel parallel to the mining hub.
+- Owns its own writes through a `crafting_mutation.py` service; emits audit actions; never writes the DB directly from the view/cog.
+
+### 2.5 Consumables that actually do something
+Wire `!use` into the exploration engine: a torch consumed *this run* temporarily grants the torch loadout; dynamite spends on a blast outcome. The engine already models `consumes`; only the wiring + a mutation call are missing.
+
+### 2.6 AI-active exploration — "the Guide"
+The architecturally interesting one, and the one to do **last and carefully**. The AI layer is read-only by contract, so the clean shape is:
+- The exploration **service** owns the catalog and all state/mutations.
+- The AI's role is to **pick from and narrate** a catalog of outcomes the service defines — it returns a *structured choice + flavour text*, never a write.
+- A registered **renderer** (`response_renderer_registry`) turns that choice into an embed / buttons / an image.
+- Result: AI-driven custom buttons, themed narration, even per-run art — all while mutations stay deterministic and auditable. This respects the zero-tolerance `services/ → views/` rule and the read-only AI-tools contract.
+
+> ⚠️ Trade-off to decide explicitly: letting the AI emit UI or write state directly would create new `services/ → views/` violations and unaudited mutations. The "narrate a service-owned catalog" approach is the one that passes `check_architecture.py`.
+
+### 2.7 Image cards — "the Postcard"
+Render an inventory or explore result as a PNG card (depth-themed background, kind-coloured rows, a "net worth" footer). Optional dependency, graceful fallback to embed.
+- *Implemented as foundation:* `utils/mining_render.py` (pure `build_card_spec` + lazy/optional `render_inventory_card`).
+
+### 2.8 Smaller ideas worth a line
+- **Expeditions**: a multi-step explore "run" with escalating depth and a bank-or-push-your-luck choice.
+- **Daily vein**: a once-per-day rich node, ties into existing cooldown/economy patterns.
+- **Hazard mitigation**: a hazard outcome is reduced/negated if the right tool is equipped (lantern vs cave-in).
+- **Leaderboard by net worth** instead of raw item count (reuses `items.total_value`).
+- **Shared guild dig site**: a server-wide vein everyone contributes to (collaborative, fits the social bot).
+
+## 3. Architecture fit (how these land without breaking rules)
+
+```
+cogs/mining/exploration.py   (pure)   ← outcome catalog + selection math   [shipped]
+cogs/mining/items.py         (pure)   ← taxonomy, tiers, values            [shipped]
+utils/mining_render.py       (pure+lazy PIL) ← image card spec + render    [shipped]
+        │
+        ▼  (future, separate approved PRs)
+services/exploration_service.py        ← owns state, applies outcomes (writes)
+services/crafting_mutation.py          ← tool upgrades/durability (writes + audit)
+core/runtime/ai/...  + a renderer      ← AI narrates a service-owned catalog
+views/mining/explore_view.py           ← buttons/embed/image surface
+```
+
+- **Pure foundation in `cogs/mining/` and `utils/`** — imports only stdlib (and lazy PIL). No layer violations; no new production dependency.
+- **All future writes** flow through a `*_mutation.py` service and call `emit_audit_action()` — never a direct DB write from cog/view (per `CLAUDE.md`).
+- **Naming caution:** do **not** name an exploration module/cog `explorer` — it collides with `views/access/explorer.py` (governance). Use `exploration`.
+
+## 4. Shipped in this PR (additive only — zero behaviour change)
+
+New files only; no existing file modified; nothing wired into a command yet:
+
+- `cogs/mining/exploration.py` — depth/loadout-aware outcome engine. `resolve_to_legacy_tuple()` returns the exact `(text, item, amount)` shape `!explore` already consumes, so future adoption is a one-line swap, not a rewrite.
+- `cogs/mining/items.py` — item taxonomy, tool tiers, value + sorting helpers.
+- `utils/mining_render.py` — pure card-spec builder + optional Pillow renderer (returns `None` when Pillow is absent; callers fall back to an embed).
+- Tests for all three (`tests/unit/cogs/test_mining_exploration.py`, `tests/unit/cogs/test_mining_items.py`, `tests/unit/utils/test_mining_render.py`).
+
+## 5. Suggested sequencing (future, each its own approved PR)
+
+1. **Wire exploration** — swap `!explore` to build a `Loadout` from inventory and call `exploration.resolve(...)`, applying results through the existing inventory mutation path. Add a depth notion (start at Surface; torch/lantern/depth items push deeper). *Touches `mining_cog.py` — behaviour change, so it's its own PR.*
+2. **Workshop / crafting** — `services/crafting_mutation.py` + `WorkshopView` + tool durability, built on `items.TOOL_LADDERS`.
+3. **AI-active "Guide" + image cards** — renderer + read-only AI tool that narrates the service-owned catalog; opt-in Pillow for art.
+
+### To activate image rendering
+Add `Pillow` to `requirements.txt`. Until then `utils/mining_render.render_inventory_card` returns `None` by design and the dependency footprint is unchanged.

--- a/tests/unit/cogs/test_mining_exploration.py
+++ b/tests/unit/cogs/test_mining_exploration.py
@@ -1,0 +1,119 @@
+"""Tests for cogs.mining.exploration — pure, loadout-aware engine.
+
+These exercise eligibility gating, loadout scaling, and the legacy-tuple
+compatibility shim with an injected RNG so every assertion is stable.
+"""
+
+from __future__ import annotations
+
+import random
+
+from cogs.mining import exploration as exp
+
+
+def _rng() -> random.Random:
+    return random.Random(42)
+
+
+def test_surface_outcomes_need_no_tools():
+    elig = exp.eligible_outcomes(exp.Biome.SURFACE, exp.Loadout())
+    keys = {o.key for o in elig}
+    assert "secret_chest" in keys
+    # Torch/dynamite-gated outcomes are not reachable empty-handed.
+    assert "hidden_diamond_vein" not in keys
+    assert "blasted_vein" not in keys
+
+
+def test_torch_unlocks_deep_finds():
+    loadout = exp.Loadout(tools=frozenset({exp.TORCH}))
+    elig = exp.eligible_outcomes(exp.Biome.CAVERN, loadout)
+    assert "hidden_diamond_vein" in {o.key for o in elig}
+
+
+def test_dynamite_gated_outcome_requires_dynamite():
+    without = exp.eligible_outcomes(exp.Biome.DEEP, exp.Loadout())
+    with_dyn = exp.eligible_outcomes(
+        exp.Biome.DEEP, exp.Loadout(tools=frozenset({exp.DYNAMITE})),
+    )
+    assert "blasted_vein" not in {o.key for o in without}
+    assert "blasted_vein" in {o.key for o in with_dyn}
+
+
+def test_deeper_biome_includes_shallower_outcomes():
+    deep = exp.eligible_outcomes(exp.Biome.MAGMA, exp.Loadout())
+    assert "secret_chest" in {o.key for o in deep}  # a surface outcome
+
+
+def test_pickaxe_doubles_ore_gain():
+    # abandoned_camp grants gold; pickaxe should double a positive ore gain.
+    base = exp.Loadout()
+    geared = exp.Loadout(tools=frozenset({exp.PICKAXE}))
+    outcome = next(o for o in exp.CATALOG if o.key == "abandoned_camp")
+    from cogs.mining.exploration import _scale_amount
+
+    assert _scale_amount(outcome, geared) == _scale_amount(outcome, base) * 2
+
+
+def test_penalties_are_never_scaled():
+    geared = exp.Loadout(tools=frozenset({exp.PICKAXE, exp.LUCKY_CHARM}))
+    hazard = next(o for o in exp.CATALOG if o.key == "monster_ambush")
+    from cogs.mining.exploration import _scale_amount
+
+    # Negative amount stays exactly as authored — gear protects gains only.
+    assert _scale_amount(hazard, geared) == hazard.amount
+
+
+def test_lucky_charm_adds_one():
+    geared = exp.Loadout(tools=frozenset({exp.LUCKY_CHARM}))
+    outcome = next(o for o in exp.CATALOG if o.key == "secret_chest")
+    from cogs.mining.exploration import _scale_amount
+
+    assert _scale_amount(outcome, geared) == outcome.amount + 1
+
+
+def test_resolve_is_deterministic_with_seeded_rng():
+    a = exp.resolve(exp.Biome.CAVERN, exp.Loadout(), rng=_rng())
+    b = exp.resolve(exp.Biome.CAVERN, exp.Loadout(), rng=_rng())
+    assert a.outcome.key == b.outcome.key
+    assert a.final_amount == b.final_amount
+
+
+def test_narration_fills_amount_with_absolute_value():
+    # monster_ambush narration says "lost {amount} stone"; the filled text
+    # must show a positive number even though the delta is negative.
+    loadout = exp.Loadout()
+    # Force the hazard by building a result directly.
+    hazard = next(o for o in exp.CATALOG if o.key == "monster_ambush")
+    result = exp.ExploreResult(
+        hazard,
+        exp.Biome.SURFACE,
+        hazard.amount,
+        hazard.narration.format(amount=2, item="stone"),
+    )
+    assert "2 stone" in result.narration
+    assert "-" not in result.narration
+
+
+def test_legacy_tuple_shape_matches_old_explore():
+    text, item, amount = exp.resolve_to_legacy_tuple(rng=_rng())
+    assert isinstance(text, str)
+    assert item is None or isinstance(item, str)
+    assert isinstance(amount, int)
+
+
+def test_loadout_from_inventory_picks_up_only_known_tools():
+    inv = {"pickaxe": 1, "torch": 2, "gold": 50, "made_up_thing": 9, "dynamite": 0}
+    loadout = exp.Loadout.from_inventory(inv)
+    assert loadout.has(exp.PICKAXE)
+    assert loadout.has(exp.TORCH)
+    assert not loadout.has(exp.DYNAMITE)  # quantity 0 → not equipped
+    assert "gold" not in loadout.tools  # resource, not a tool
+    assert "made_up_thing" not in loadout.tools
+
+
+def test_resolve_always_returns_result_even_when_catalog_filtered():
+    # An empty loadout at the surface still has fallbacks, so resolve must
+    # never raise and always produce a usable narration.
+    result = exp.resolve(exp.Biome.SURFACE, exp.Loadout(), rng=_rng())
+    assert result.narration
+    assert isinstance(result.final_amount, int)

--- a/tests/unit/cogs/test_mining_items.py
+++ b/tests/unit/cogs/test_mining_items.py
@@ -1,0 +1,69 @@
+"""Tests for cogs.mining.items — pure item taxonomy."""
+
+from __future__ import annotations
+
+from cogs.mining import items
+
+
+def test_classify_known_kinds():
+    assert items.classify("gold") is items.ItemKind.RESOURCE
+    assert items.classify("pickaxe") is items.ItemKind.TOOL
+    assert items.classify("dynamite") is items.ItemKind.CONSUMABLE
+    assert items.classify("stone hut") is items.ItemKind.STRUCTURE
+    assert items.classify("lucky charm") is items.ItemKind.TREASURE
+
+
+def test_classify_unknown_defaults_to_resource():
+    assert items.classify("mystery_dust") is items.ItemKind.RESOURCE
+
+
+def test_classify_is_case_insensitive():
+    assert items.classify("GOLD") is items.ItemKind.RESOURCE
+    assert items.classify("PickAxe") is items.ItemKind.TOOL
+
+
+def test_tool_predicates():
+    assert items.is_tool("pickaxe")
+    assert not items.is_tool("gold")
+    assert items.is_consumable("torch")
+    assert not items.is_consumable("pickaxe")
+
+
+def test_tool_tier_and_value():
+    assert items.tool_tier("diamond") == 4
+    assert items.tool_tier("unknown") == 0
+    assert items.item_value("diamond") > items.item_value("stone")
+    assert items.item_value("unknown") == 1
+
+
+def test_total_value_sums_and_ignores_nonpositive():
+    inv = {"gold": 2, "diamond": 1, "stone": 0, "unknown": 3}
+    expected = (
+        items.item_value("gold") * 2
+        + items.item_value("diamond") * 1
+        + items.item_value("unknown") * 3
+    )
+    assert items.total_value(inv) == expected
+
+
+def test_next_tool_upgrade_ladder():
+    assert items.next_tool_upgrade("pickaxe") == "iron pickaxe"
+    assert items.next_tool_upgrade("iron pickaxe") is None  # top of ladder
+    assert items.next_tool_upgrade("torch") == "lantern"
+    assert items.next_tool_upgrade("gold") is None  # not on a ladder
+
+
+def test_sort_inventory_orders_by_kind_then_value():
+    inv = {"diamond throne": 1, "gold": 3, "torch": 2, "pickaxe": 1, "stone": 5}
+    ordered = [name for name, _ in items.sort_inventory(inv)]
+    # resources first (gold before stone by value), then tool, consumable,
+    # then structure last.
+    assert ordered.index("gold") < ordered.index("stone")
+    assert ordered.index("stone") < ordered.index("pickaxe")
+    assert ordered.index("pickaxe") < ordered.index("torch")
+    assert ordered[-1] == "diamond throne"
+
+
+def test_sort_inventory_drops_zero_quantities():
+    inv = {"gold": 0, "stone": 2}
+    assert items.sort_inventory(inv) == [("stone", 2)]

--- a/tests/unit/utils/test_mining_render.py
+++ b/tests/unit/utils/test_mining_render.py
@@ -1,0 +1,59 @@
+"""Tests for utils.mining_render.
+
+The layout math is tested unconditionally; the actual PNG rendering is
+guarded by ``importorskip`` so the suite stays green whether or not the
+optional Pillow dependency is installed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from utils import mining_render as mr
+
+
+def test_build_card_spec_colours_by_kind():
+    rows = [("gold", 3), ("pickaxe", 1)]
+    spec = mr.build_card_spec(
+        "Inventory",
+        rows,
+        classify_kind=lambda n: "tool" if n == "pickaxe" else "resource",
+    )
+    assert spec.title == "Inventory"
+    assert len(spec.rows) == 2
+    by_label = {r.label: r for r in spec.rows}
+    # Title-cased labels.
+    assert "Gold" in by_label
+    assert by_label["Pickaxe"].color == mr._KIND_COLOR["tool"]
+    assert by_label["Gold"].color == mr._KIND_COLOR["resource"]
+
+
+def test_build_card_spec_defaults_to_resource_colour_without_classifier():
+    spec = mr.build_card_spec("Inv", [("widget", 1)])
+    assert spec.rows[0].color == mr._KIND_COLOR["resource"]
+
+
+def test_card_height_grows_with_rows():
+    small = mr.build_card_spec("t", [("a", 1)])
+    big = mr.build_card_spec("t", [("a", 1), ("b", 2), ("c", 3)])
+    assert big.height > small.height
+
+
+def test_card_height_handles_empty_rows():
+    spec = mr.build_card_spec("empty", [])
+    assert spec.height > 0  # must not divide-by-zero / go negative
+
+
+def test_render_returns_bytes_or_none():
+    spec = mr.build_card_spec("Inv", [("gold", 2)])
+    result = mr.render_inventory_card(spec)
+    # Contract: bytes when Pillow is present, None when it is not.
+    assert result is None or isinstance(result, bytes)
+
+
+def test_render_produces_png_when_pillow_present():
+    pytest.importorskip("PIL")
+    spec = mr.build_card_spec("Inv", [("gold", 2), ("diamond", 1)], footer="value: 24")
+    data = mr.render_inventory_card(spec)
+    assert isinstance(data, bytes)
+    assert data[:8] == b"\x89PNG\r\n\x1a\n"  # PNG magic number


### PR DESCRIPTION
## What

Purely **additive** scaffolding for a richer mining/exploration system, plus a brainstorm/roadmap doc. **No existing file is modified and nothing is wired into a command yet** — current mining behaviour is unchanged. This is the "foundation" PR; wiring it up (which *does* change behaviour) is deliberately deferred to follow-up PRs.

## New files only

### Pure domain modules (`cogs/mining/`)
- **`exploration.py`** — the structured successor to the flat 5-entry `EXPLORE_OUTCOMES` table. Exploration is now depth-banded (`Biome`: Surface → Cavern → Deep → Magma) and **loadout-aware**: outcomes are tool-gated (`requires`/`consumes`) and scaled by the player's gear (torch unlocks deep finds, dynamite unlocks blast payoffs, pickaxe doubles ore, lucky charm +1). RNG is injected for deterministic tests. `resolve_to_legacy_tuple()` returns the exact `(text, item, amount)` shape the existing `!explore` handler already consumes, so future adoption is a one-line swap, not a rewrite. **Mutation is intentionally absent** — the engine decides *what* happened, never *commits* it.
- **`items.py`** — item taxonomy (`RESOURCE / TOOL / CONSUMABLE / STRUCTURE / TREASURE`), tool tiers + upgrade ladders (`pickaxe → iron pickaxe`), and value/sorting helpers. The single source of truth that lets any layer ask "is this a tool?" / "what's this inventory worth?" without hard-coding name lists.

### Optional render helper (`utils/`)
- **`mining_render.py`** — pure `CardSpec` builder + a **lazy, optional** Pillow renderer. Returns `None` when Pillow is absent, so the project gains **no new production dependency** and importing the module never breaks the bot. Callers fall back to an embed. Activating image rendering is a one-line `requirements.txt` change, deliberately left to you. (The `utils → stdlib + discord` layer rule is respected — the arch checker only tracks first-party layers, and the kind→colour classifier is injected so this module never imports `cogs`.)

### Docs
- **`docs/mining_exploration_brainstorm.md`** — current-state map, honest limitations, a *named* feature brainstorm (depth/biomes, loadouts, the "Workshop" crafting cog, consumables that actually do something, the AI-active **"Guide"** that narrates a service-owned catalog while staying read-only, image "Postcard" cards, expeditions, net-worth leaderboards), architecture-fit notes (incl. the `services/ → views/` and read-only-AI constraints, and the `explorer` naming-collision warning), and a phased roadmap.

## Why it's safe

- Only new files; zero edits to existing modules → no path that current behaviour flows through is touched.
- New modules are pure (stdlib only; PIL lazy/optional). No layer-boundary violations.
- Nothing is registered as a command, view, or service yet.

## Tests

`tests/unit/cogs/test_mining_exploration.py`, `test_mining_items.py`, `tests/unit/utils/test_mining_render.py` — gating/scaling/legacy-shim, taxonomy helpers, and render layout math (actual PNG generation guarded by `pytest.importorskip("PIL")` so the suite is green with or without Pillow).

## Verification

- `python3.10 scripts/check_architecture.py --mode strict` → 0 errors
- `python3.10 scripts/check_quality.py --full` → black/isort/ruff clean, mypy clean, **6725 passed, 4 skipped**

## Suggested follow-ups (each its own PR)

1. Wire `!explore` to build a `Loadout` from inventory and call `exploration.resolve(...)`, applying results through the existing mutation path (behaviour change → separate PR).
2. Workshop/crafting service + view + tool durability on top of `items.TOOL_LADDERS`.
3. AI-active "Guide" renderer + read-only AI tool; opt-in Pillow for art.

https://claude.ai/code/session_01RYkvBd2vxbXS3zNAK3LDhv

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYkvBd2vxbXS3zNAK3LDhv)_