### PR TITLE
Extend counting parser with advanced math formulas

### DIFF
--- a/disbot/cogs/counting/_constants.py
+++ b/disbot/cogs/counting/_constants.py
@@ -8,8 +8,11 @@ parser is a pure-function pipeline.
 from __future__ import annotations
 
 import ast
+import math
 import operator as op
 import re
+from collections.abc import Callable
+from typing import Any
 
 # Compiled regex patterns
 NUMBER_PATTERN = re.compile(r"\d+")
@@ -155,15 +158,114 @@ EMOJI_NUMBER_MAPPING: dict[str, str] = {
     "🔟": "10",
 }
 
+# ---------------------------------------------------------------------------
+# DoS guards.  The parser runs on the on_message hot path for every message
+# in a counting channel, so a single crafted expression must never be able
+# to burn CPU or RAM.  Exponentiation and factorial are the only operations
+# that grow super-linearly in the size of their (small) operands, so both
+# are routed through bounded wrappers.  Everything else is linear in the
+# (length-capped) expression and needs no guard.
+# ---------------------------------------------------------------------------
+MAX_POW_EXPONENT = 1000  # reject ``a ** b`` / ``a ^ b`` when ``abs(b)`` exceeds this
+MAX_FACTORIAL = 1000  # reject ``n!`` / ``factorial(n)`` when ``n`` exceeds this
+
+
+def safe_pow(base: Any, exponent: Any) -> Any:
+    """``base ** exponent`` with a bound on the exponent.
+
+    Without this, ``9 ^ 9 ^ 9`` (right-associative) asks Python to build a
+    ~370-million-digit integer and hangs the event loop.  Capping the
+    exponent magnitude keeps every power bounded; nested towers are caught
+    because each inner power is evaluated (and bounded) before it becomes the
+    exponent of the next one.
+    """
+    if abs(exponent) > MAX_POW_EXPONENT:
+        raise ValueError(f"exponent {exponent!r} exceeds limit {MAX_POW_EXPONENT}")
+    return op.pow(base, exponent)
+
+
+def safe_factorial(n: Any) -> int:
+    """``math.factorial`` with a bound, rejecting non-integers and negatives."""
+    if isinstance(n, float):
+        if not n.is_integer():
+            raise ValueError("factorial of a non-integer")
+        n = int(n)
+    if not isinstance(n, int):
+        raise TypeError("factorial expects an integer")
+    if n < 0 or n > MAX_FACTORIAL:
+        raise ValueError(f"factorial argument {n} outside 0..{MAX_FACTORIAL}")
+    return math.factorial(n)
+
+
 # AST node type → Python operator.  Used by ``parsing.eval_expr``.
-OPERATORS: dict[type, object] = {
+OPERATORS: dict[type, Callable[..., Any]] = {
     ast.Add: op.add,
     ast.Sub: op.sub,
     ast.Mult: op.mul,
     ast.Div: op.truediv,
-    ast.Pow: op.pow,
-    ast.BitXor: op.pow,  # allow '^' as exponentiation
+    ast.FloorDiv: op.floordiv,
+    ast.Mod: op.mod,
+    ast.Pow: safe_pow,
+    ast.BitXor: safe_pow,  # allow '^' as exponentiation
     ast.USub: op.neg,
+    ast.UAdd: op.pos,
+}
+
+# Named constants usable in expressions, e.g. ``2 * pi`` or ``tau / 4``.
+MATH_CONSTANTS: dict[str, float] = {
+    "pi": math.pi,
+    "e": math.e,
+    "tau": math.tau,
+}
+
+
+def _signum(x: Any) -> int:
+    return (x > 0) - (x < 0)
+
+
+def _cbrt(x: Any) -> float:
+    # ``x ** (1/3)`` returns a complex number for negative x; preserve sign.
+    return math.copysign(abs(x) ** (1.0 / 3.0), x)
+
+
+# Whitelisted callables.  Only alphabetic names are usable: the tokenizer
+# splits a letter+digit run such as ``log2`` into ``log`` + ``2``, so any
+# function with a digit in its name is unreachable from user input by design.
+# Variadic builtins (min/max/sum) are wrapped so they accept positional args.
+MATH_FUNCTIONS: dict[str, Callable[..., Any]] = {
+    "abs": abs,
+    "round": lambda x, ndigits=0: round(x, int(ndigits)),
+    "min": lambda *args: min(args),
+    "max": lambda *args: max(args),
+    "sum": lambda *args: sum(args),
+    "sqrt": math.sqrt,
+    "cbrt": _cbrt,
+    "factorial": safe_factorial,
+    "floor": math.floor,
+    "ceil": math.ceil,
+    "trunc": math.trunc,
+    "sign": _signum,
+    "exp": math.exp,
+    "ln": math.log,
+    "log": math.log10,
+    "sin": math.sin,
+    "cos": math.cos,
+    "tan": math.tan,
+    "asin": math.asin,
+    "acos": math.acos,
+    "atan": math.atan,
+    "sinh": math.sinh,
+    "cosh": math.cosh,
+    "tanh": math.tanh,
+    "degrees": math.degrees,
+    "radians": math.radians,
+    "gcd": math.gcd,
+    "lcm": math.lcm,
+    "hypot": math.hypot,
+    "pow": safe_pow,
+    "comb": math.comb,
+    "perm": math.perm,
+    "fmod": math.fmod,
 }
 
 # Word/symbol → arithmetic operator replacement.
@@ -182,6 +284,8 @@ OPERATOR_MAPPING: dict[str, str] = {
     "over": "/",
     "powerof": "**",
     "tothepowerof": "**",
+    "mod": "%",
+    "modulo": "%",
     "equals": "=",
     "equal": "=",
     "and": "+",

--- a/disbot/cogs/counting/parsing.py
+++ b/disbot/cogs/counting/parsing.py
@@ -9,8 +9,18 @@ and returns either an integer count or ``None`` (unrecognised input).
 It tolerates word numbers ("twenty-one"), phrases ("a dozen"), Roman
 numerals, emojis, and arithmetic expressions ("3 + 4 = 7").
 
-Adopted from the previous CountingCog instance methods of the same
-names.  Behaviour is preserved exactly; only ``self`` was removed.
+Expressions go well beyond the four basic operators: alongside
+``+ - * /`` it understands integer/float division (``//``), modulo
+(``%``), exponentiation (``**`` / ``^``), postfix factorial (``5!``),
+named constants (``pi``, ``e``, ``tau``), and a whitelist of math
+functions (``sqrt``, ``floor``, ``gcd``, ``comb``, ``min``/``max``, …
+— see ``_constants.MATH_FUNCTIONS``).  Evaluation walks a hardened AST
+(never ``eval``); exponentiation and factorial are bounded so a crafted
+message cannot stall the on_message hot path.
+
+Originally adopted from the previous CountingCog instance methods of
+the same names (only ``self`` was removed); later extended with the
+function / constant / factorial support described above.
 """
 
 from __future__ import annotations
@@ -19,9 +29,12 @@ import ast
 import difflib
 import logging
 import re
+from typing import Any
 
 from cogs.counting._constants import (
     EMOJI_NUMBER_MAPPING,
+    MATH_CONSTANTS,
+    MATH_FUNCTIONS,
     NUMBER_WORDS_SET,
     OPERATOR_MAPPING,
     OPERATORS,
@@ -54,8 +67,9 @@ def parse_message(content: str) -> int | None:
     # Split concatenated number words
     content = split_concatenated_numbers(content)
 
-    # Define all operator symbols, including '×' and 'x'
-    operator_symbols = "+-*/^()=.×x"
+    # Define all operator symbols, including '×' and 'x'.  ',' separates
+    # function arguments, '%' is modulo, and '!' is postfix factorial.
+    operator_symbols = "+-*/^()=.×x,%!"
 
     # Tokenize the content into numbers, words, and operators
     tokens = re.findall(r"\d+|[^\W\d_]+|[^\w\s]", content, re.UNICODE)
@@ -92,6 +106,34 @@ def parse_message(content: str) -> int | None:
             if prev_token_type == "number":
                 processed_tokens.append("+")
             processed_tokens.append(token)
+            prev_token_type = "number"
+        elif lower_token in MATH_FUNCTIONS:
+            # A function name (``sqrt``, ``gcd``, …).  Flush any pending
+            # number words, then emit the name so the AST sees an ast.Call.
+            if number_word_tokens:
+                number_word_str = " ".join(number_word_tokens)
+                number = parse_number_word(number_word_str)
+                if number is None:
+                    return None
+                processed_tokens.append(str(number))
+                number_word_tokens = []
+                prev_token_type = "number"
+            if prev_token_type == "number":
+                processed_tokens.append("+")
+            processed_tokens.append(lower_token)
+            prev_token_type = "function"
+        elif lower_token in MATH_CONSTANTS:
+            # A named constant (``pi``, ``e``, ``tau``) — behaves like a number.
+            if number_word_tokens:
+                number_word_str = " ".join(number_word_tokens)
+                number = parse_number_word(number_word_str)
+                if number is None:
+                    return None
+                processed_tokens.append(str(number))
+                number_word_tokens = []
+            if prev_token_type == "number":
+                processed_tokens.append("+")
+            processed_tokens.append(lower_token)
             prev_token_type = "number"
         elif lower_token in NUMBER_WORDS_SET:
             number_word_tokens.append(lower_token)
@@ -175,19 +217,28 @@ def roman_to_int(s: str) -> int | None:
     return num
 
 
-def eval_expr(expr: str) -> int | None:
-    """Safely evaluate a basic arithmetic expression.  Returns int or None."""
+def eval_expr(expr: str) -> int | float | None:
+    """Safely evaluate an arithmetic expression.  Returns a number or None.
+
+    Supports ``+ - * / // % ** ^``, parentheses, postfix factorial (``5!``),
+    named constants (``pi``, ``e``, ``tau``), and the whitelisted callables in
+    ``MATH_FUNCTIONS`` (``sqrt``, ``gcd``, ``comb``, …).  Evaluation is done
+    over a hardened AST walk — never ``eval`` — and exponentiation / factorial
+    are bounded so a crafted message cannot stall the event loop.
+    """
     try:
         expr = expr.replace(" ", "")
-        if not re.match(r"^[0-9+\-*/^().=]+$", expr):
+        # Coarse gate: lowercase letters (function/constant names) plus the
+        # arithmetic symbols.  The AST walk below is the real safety boundary.
+        if not re.match(r"^[0-9a-z+\-*/^%!().,=]+$", expr):
             return None
-        if len(expr) > 50:
+        if len(expr) > 120:
             return None
         if "=" in expr:
             left_expr, right_expr = expr.split("=", 1)
             left_val = safe_eval(left_expr)
             right_val = safe_eval(right_expr)
-            if left_val == right_val:
+            if left_val is not None and left_val == right_val:
                 return right_val
             return None
         return safe_eval(expr)
@@ -196,9 +247,10 @@ def eval_expr(expr: str) -> int | None:
         return None
 
 
-def safe_eval(expr: str) -> int | None:
+def safe_eval(expr: str) -> int | float | None:
     """Parse + evaluate ``expr`` via the AST whitelist in OPERATORS."""
     try:
+        expr = _expand_factorials(expr)
         node = ast.parse(expr, mode="eval").body
         return _eval_ast(node)
     except Exception as exc:
@@ -206,11 +258,64 @@ def safe_eval(expr: str) -> int | None:
         return None
 
 
-def _eval_ast(node):
+def _expand_factorials(expr: str) -> str:
+    """Rewrite postfix factorial (``5!``, ``(2+3)!``) into ``factorial(...)``.
+
+    Python's grammar has no ``!`` operator, so the postfix form is desugared
+    to a call before ``ast.parse`` sees it.  The factorial binds to the
+    immediately preceding number or parenthesised group; ``5!!`` becomes
+    ``factorial(factorial(5))``.
+    """
+    while "!" in expr:
+        idx = expr.index("!")
+        end = idx  # operand is expr[start:end]
+        if end == 0:
+            raise ValueError("'!' has no operand")
+        if expr[end - 1] == ")":
+            # Walk back over the balanced parenthesised group.
+            depth = 0
+            k = end - 1
+            while k >= 0:
+                if expr[k] == ")":
+                    depth += 1
+                elif expr[k] == "(":
+                    depth -= 1
+                    if depth == 0:
+                        break
+                k -= 1
+            if depth != 0:
+                raise ValueError("unbalanced parentheses before '!'")
+            start = k
+        else:
+            # Walk back over a run of digits / decimal point.
+            k = end - 1
+            while k >= 0 and (expr[k].isdigit() or expr[k] == "."):
+                k -= 1
+            start = k + 1
+            if start == end:
+                raise ValueError("'!' has no numeric operand")
+        operand = expr[start:end]
+        expr = f"{expr[:start]}factorial({operand}){expr[idx + 1:]}"
+    return expr
+
+
+def _eval_ast(node: ast.AST) -> Any:
     if isinstance(node, ast.Constant):
         return node.value
     if isinstance(node, ast.Num):  # Python < 3.8 compat
         return node.n
+    if isinstance(node, ast.Name):
+        if node.id in MATH_CONSTANTS:
+            return MATH_CONSTANTS[node.id]
+        raise NameError(f"Unknown name: {node.id}")
+    if isinstance(node, ast.Call):
+        if node.keywords or not isinstance(node.func, ast.Name):
+            raise TypeError("Unsupported call")
+        func = MATH_FUNCTIONS.get(node.func.id)
+        if func is None:
+            raise NameError(f"Unknown function: {node.func.id}")
+        args = [_eval_ast(arg) for arg in node.args]
+        return func(*args)
     if isinstance(node, ast.BinOp):
         left = _eval_ast(node.left)
         right = _eval_ast(node.right)

--- a/tests/unit/cogs/test_counting_parsing.py
+++ b/tests/unit/cogs/test_counting_parsing.py
@@ -1,0 +1,117 @@
+"""Tests for the counting expression parser (``cogs.counting.parsing``).
+
+Covers the original behaviour (word numbers, Roman numerals, basic
+arithmetic, equality checks) plus the extended "complicated formula"
+support: whitelisted math functions, named constants, modulo / floor
+division, and postfix factorial — and the DoS guards that keep a crafted
+message from stalling the on_message hot path.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from cogs.counting import _constants
+from cogs.counting.parsing import parse_message
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        # --- pre-existing behaviour (regression) ---
+        ("5", 5),
+        ("twenty three", 23),
+        ("5 + 3", 8),
+        ("2 ** 3", 8),
+        ("2 ^ 3", 8),
+        ("(4 + 2) * 3", 18),
+        ("ten times five", 50),
+        ("5 + 3 = 8", 8),
+        ("-5", -5),
+        ("IV", 4),
+        ("a dozen", 12),
+    ],
+)
+def test_basic_and_word_numbers(text: str, expected: int) -> None:
+    assert parse_message(text) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        # --- new: math functions ---
+        ("sqrt(16)", 4),
+        ("factorial(5)", 120),
+        ("gcd(12, 8)", 4),
+        ("lcm(4, 6)", 12),
+        ("comb(5, 2)", 10),
+        ("perm(5, 2)", 20),
+        ("abs(-7)", 7),
+        ("max(3, 9, 5)", 9),
+        ("min(3, 9, 5)", 3),
+        ("floor(7 / 2)", 3),
+        ("ceil(7 / 2)", 4),
+        ("round(sqrt(50))", 7),
+        ("hypot(3, 4)", 5),
+        ("cbrt(27)", 3),
+        # --- new: modulo / floor division ---
+        ("10 % 3", 1),
+        ("17 // 5", 3),
+        ("10 mod 3", 1),
+        # --- new: postfix factorial ---
+        ("5!", 120),
+        ("(2 + 3)!", 120),
+        ("3! + 4!", 30),
+        # --- new: named constants ---
+        ("floor(2 * pi)", 6),
+        ("floor(tau)", 6),
+        # --- nested / "complicated" combinations ---
+        ("2 ** 10 + factorial(4)", 1048),
+        ("sqrt(144) + 5!", 132),
+        ("gcd(comb(6, 2), 9)", 3),
+    ],
+)
+def test_complicated_formulas(text: str, expected: int) -> None:
+    assert parse_message(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "not a number",
+        "sqrt(16",  # unbalanced
+        "!5",  # factorial without operand
+        "frobnicate(5)",  # unknown function
+        "[1, 2, 3]",  # disallowed syntax
+    ],
+)
+def test_invalid_input_returns_none(text: str) -> None:
+    assert parse_message(text) is None
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "2 ** 999999999",  # exponent blows past the cap
+        "factorial(999999)",  # factorial argument past the cap
+        "9 ** 9 ** 9",  # nested power tower (right-associative)
+    ],
+)
+def test_dos_guards_reject_without_hanging(text: str) -> None:
+    """Crafted blow-up expressions must return None quickly, not hang."""
+    start = time.monotonic()
+    assert parse_message(text) is None
+    assert time.monotonic() - start < 1.0
+
+
+def test_pow_cap_boundary() -> None:
+    # Exactly at the limit is allowed; one past it is rejected.
+    assert parse_message(f"2 ** {_constants.MAX_POW_EXPONENT}") is not None
+    assert parse_message(f"2 ** {_constants.MAX_POW_EXPONENT + 1}") is None
+
+
+def test_factorial_cap_boundary() -> None:
+    assert parse_message(f"factorial({_constants.MAX_FACTORIAL})") is not None
+    assert parse_message(f"factorial({_constants.MAX_FACTORIAL + 1})") is None


### PR DESCRIPTION
## What

Teaches the counting game's expression parser (`disbot/cogs/counting/`) to evaluate the kind of difficult/complicated formulas players actually reach for. Previously it only handled `+ - * / ** ^`, parentheses, and an equality check.

### New capabilities
- **Math functions** (whitelisted): `sqrt`, `cbrt`, `factorial`, `floor`, `ceil`, `trunc`, `round`, `sign`, `abs`, `exp`, `ln`, `log`, trig + hyperbolic (`sin`/`cos`/`tan`/`asin`/…/`tanh`), `degrees`, `radians`, `gcd`, `lcm`, `hypot`, `pow`, `comb`, `perm`, `fmod`, and variadic `min`/`max`/`sum`.
- **Named constants**: `pi`, `e`, `tau`.
- **Modulo** (`%`, word `mod`) and **floor division** (`//`).
- **Postfix factorial**: `5!`, `(2+3)!` — desugared to `factorial(...)` before parsing.

So inputs like `sqrt(144) + 5!`, `gcd(comb(6,2), 9)`, `floor(2 * pi)`, `2 ** 10 + factorial(4)`, and `17 // 5` now resolve to a count.

## Safety

Evaluation still walks a **hardened AST** (never `eval`) — the AST whitelist of operators, constant names, and callables is the real boundary; the widened character whitelist / length cap is only a coarse gate.

Because this runs on the `on_message` hot path, the two super-linear operations are bounded:
- `safe_pow` rejects exponents past `MAX_POW_EXPONENT` (1000), so `2 ** 999999999` and nested power towers can't build a multi-million-digit int and stall the event loop.
- `safe_factorial` rejects arguments past `MAX_FACTORIAL` (1000) and non-integers.

Both return `None` (rejected) quickly rather than hanging — covered by tests.

## Tests

New `tests/unit/cogs/test_counting_parsing.py` (46 cases): regression for existing word-number / Roman / equality behaviour, all new operators/functions/constants/factorial, invalid-input rejection, and the DoS guards (including a `< 1s` wall-clock assertion and cap-boundary checks).

## Verification

- `python3.10 scripts/check_quality.py --full` → black, isort, ruff, mypy all green; **6771 passed, 4 skipped**.
- `python3.10 scripts/check_architecture.py --mode strict` → exit 0 (no new violations; change is contained within the counting cog package).

https://claude.ai/code/session_01RSJswN4c3zeS9R5nLFGKJK

---
_Generated by [Claude Code](https://claude.ai/code/session_01RSJswN4c3zeS9R5nLFGKJK)_