### PR TITLE
btd6(ct): ground relic/tile breakdown for general CT questions

### DIFF
--- a/disbot/services/btd6_context_service.py
+++ b/disbot/services/btd6_context_service.py
@@ -774,6 +774,72 @@ async def _ct_relic_location_lines(intent: Any) -> list[str]:
     return out
 
 
+# A general Contested-Territory topic — the user is asking about CT relics
+# or tile layout without naming a specific relic ("what relics are in the
+# current CT", "tiles and relics", …). Matched on the raw message so the
+# listing fires even when no catalog relic alias appears in the text.
+_CT_TOPIC_RE = re.compile(r"\b(relics?|tiles?|contested\s+territor)", re.IGNORECASE)
+
+
+def _mentions_ct_topic(intent: Any) -> bool:
+    if _CT_TOPIC_RE.search(getattr(intent, "raw_text", "") or ""):
+        return True
+    for entity in getattr(intent, "live_entities", ()) or ():
+        kind = getattr(entity, "entity_kind", entity)
+        if kind in ("btd6_ct", "btd6_ct_tile"):
+            return True
+    return False
+
+
+async def _ct_active_tile_lines(intent: Any) -> list[str]:
+    """Relic→tile map for the active CT on a *general* CT relic/tile question.
+
+    When a specific relic is named, :func:`_ct_relic_location_lines` gives
+    the targeted answer, so this broad listing is skipped to avoid
+    duplication. Otherwise it lists the relic tiles of the newest active CT
+    event(s) — exactly the "tiles and relics" breakdown the model is
+    missing — plus the effect of each distinct relic found. Bounded so a
+    full 169-tile map can't flood the prompt.
+    """
+    if getattr(intent, "ct_relics", ()):  # specific relic handled elsewhere
+        return []
+    if not _mentions_ct_topic(intent):
+        return []
+
+    from services import btd6_data_service
+    from services import btd6_live_query_service as btd6_live
+
+    out: list[str] = []
+    seen_relics: list[str] = []
+    events = await btd6_live.get_active_events(("btd6_ct",))
+    for evt in events[:2]:
+        tiles = await btd6_live.get_ct_tiles(evt.entity_key, relics_only=True)
+        for tile in tiles:
+            canonical = _sanitise(tile.relic_canonical or tile.relic_name or "?")
+            pos = tile.position.describe() if tile.position else "position n/a"
+            out.append(
+                _cap(
+                    f"[btd6_ct_tile] CT {_sanitise(evt.entity_key)}: {canonical} "
+                    f"on tile {_sanitise(tile.tile_id)} ({pos}) "
+                    f"(source: data.ninjakiwi.com)",
+                ),
+            )
+            if tile.relic_id and tile.relic_id not in seen_relics:
+                seen_relics.append(tile.relic_id)
+            if len(out) >= 14:
+                break
+        if len(out) >= 14:
+            break
+
+    # The effect of each distinct relic actually on the map, so the model
+    # can answer "what does it do" follow-ups without a second round-trip.
+    for relic_id in seen_relics[:8]:
+        entry = btd6_data_service.get_ct_relic(relic_id)
+        if entry is not None:
+            out.extend(_render_ct_relic(entry))
+    return out
+
+
 def _fixture_facts_for_intent(intent: Any) -> list[str]:
     """Return fixture-sourced grounding lines for any tower/hero/bloon in ``intent``.
 
@@ -878,6 +944,17 @@ async def build(message_text: str) -> BTD6Context:
         except Exception as exc:  # noqa: BLE001 — defensive
             logger.debug(
                 "btd6_context_service: ct relic locations unavailable (%s)",
+                exc,
+            )
+
+        # General CT relic/tile topic (no specific relic named) — list the
+        # active map's relic tiles so "tiles and relics" questions get the
+        # breakdown the event index alone can't provide.
+        try:
+            facts.extend(await _ct_active_tile_lines(intent))
+        except Exception as exc:  # noqa: BLE001 — defensive
+            logger.debug(
+                "btd6_context_service: ct active tiles unavailable (%s)",
                 exc,
             )
 

--- a/tests/unit/services/test_btd6_ct_grounding.py
+++ b/tests/unit/services/test_btd6_ct_grounding.py
@@ -74,6 +74,57 @@ async def test_relic_effect_line_present(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_general_ct_question_lists_relic_tiles(monkeypatch):
+    """A question that names no specific relic still gets the active CT's
+    relic→tile breakdown (the gap behind 'I don't have per-tile details')."""
+    from services import btd6_live_query_service as live
+    from utils.btd6.ct_tile_geometry import decode_tile
+
+    def _tile(tid, rid, canon, api):
+        return live.CTTilePlacement(
+            ct_id="mpejg5d0",
+            tile_id=tid,
+            tile_type="Relic",
+            game_type="Race",
+            relic_name=api,
+            relic_id=rid,
+            relic_canonical=canon,
+            fetched_at=datetime.now(tz=timezone.utc),
+            position=decode_tile(tid),
+        )
+
+    async def _active(kinds=None):
+        return (
+            live.ActiveEventHeadline(
+                "btd6_ct",
+                "mpejg5d0",
+                "mpejg5d0",
+                None,
+                None,
+                datetime.now(tz=timezone.utc),
+            ),
+        )
+
+    async def _tiles(ct_id, *, relic=None, relics_only=False):
+        return (
+            _tile("DEC", "camo_trap", "Camo Trap", "CamoTrap"),
+            _tile(
+                "AAA", "super_monkey_storm", "Super Monkey Storm", "SuperMonkeyStorm"
+            ),
+        )
+
+    monkeypatch.setattr(live, "get_active_events", _active)
+    monkeypatch.setattr(live, "get_ct_tiles", _tiles)
+    out = await ctx.build("Do you have specific information about the tiles and relics")
+    tile_lines = [f for f in out.facts if f.startswith("[btd6_ct_tile]")]
+    relic_lines = [f for f in out.facts if f.startswith("[btd6_ct_relic]")]
+    assert any("tile DEC" in ln and "Camo Trap" in ln for ln in tile_lines)
+    assert any("tile AAA" in ln and "Super Monkey Storm" in ln for ln in tile_lines)
+    # distinct relic effects are appended too
+    assert relic_lines
+
+
+@pytest.mark.asyncio
 async def test_relic_tile_location_line_present(monkeypatch):
     from services import btd6_live_query_service as live
     from utils.btd6.ct_tile_geometry import decode_tile


### PR DESCRIPTION
## Why

Follow-up to #436. In `#general`, a general question — *"Do you have specific information about the tiles and relics"* — still got the unhelpful *"the events exist but I don't have the granular per-tile relic breakdowns."*

Root cause: the AI grounding added in #436 only surfaced CT tile/relic data when the user named a **specific** relic (`intent.ct_relics`). A general CT question names no relic, so **no CT grounding was added** and the model fell back to the bare event index.

The ingestion side is fine — `nk_btd6_ct_tiles` is enabled (migration 042) and scheduled as a dependency of `nk_btd6_ct`, storing one `btd6_ct_tile` fact per tile. This is purely a read/grounding gap.

## What changed

`btd6_context_service`:
- A CT-topic detector — the words **relic / tile / contested territory** are CT-specific BTD6 vocabulary (towers sit on tracks/spots, not "tiles"), plus a live `btd6_ct` entity match.
- When the topic is CT but **no specific relic is named**, list the active CT map's relic tiles (relic name + decoded hex position) and append the **effect of each distinct relic** found — exactly the "tiles and relics" breakdown the model was missing.
- Bounded (≤14 tile lines, ≤8 effect lines) so a 169-tile map can't flood the prompt; skipped when a specific relic *is* named (that targeted path already exists); isolated in its own try/except so a DB failure can't suppress the rest of the bundle.

Example grounding now produced for *"do you have info about the tiles and relics"*:
```
[btd6_ct_tile] CT mpejg5d0: Camo Trap on tile DEC (sector D, ring 3 of 7, position 3 of 3) (source: data.ninjakiwi.com)
[btd6_ct_tile] CT mpejg5d0: Super Monkey Storm on tile AAA (sector A, outer ring (map edge), position 1 of 7, a corner tile) (source: data.ninjakiwi.com)
[btd6_ct_relic] Camo Trap — Grants up to 2 uses of the Camo Trap power per game … (source: bloonswiki)
[btd6_ct_relic] Super Monkey Storm (SMS) — Grants up to 2 uses of the Super Monkey Storm power … (source: bloonswiki)
```

## Verification

- New regression test `test_general_ct_question_lists_relic_tiles`.
- `python3.10 scripts/check_quality.py --full` — green (lint + mypy + 6800 tests).
- `python3.10 scripts/check_architecture.py --mode strict` — 0 errors.

## If it's *still* empty in Discord

That would mean the live DB has no `btd6_ct_tile` facts (ingestion not yet run / fetch failing), not a grounding bug. Quick check on the bot: run **`!btd6 ct`** — if it shows relic tiles per event, ingestion is working and this grounding will fire; if it says "no relic tiles loaded", the tiles fetch needs a look (e.g. `!btd6 refresh-source nk_btd6_ct`). `!btd6 latest-data` also shows whether a `btd6_ct_tile` envelope exists.

https://claude.ai/code/session_019XbZRmKGXyMwVYLTBqAkZh

---
_Generated by [Claude Code](https://claude.ai/code/session_019XbZRmKGXyMwVYLTBqAkZh)_