### PR TITLE
btd6(ct): add CT button to the panel + surface per-tile game mode

### DIFF
--- a/disbot/services/btd6_context_service.py
+++ b/disbot/services/btd6_context_service.py
@@ -762,11 +762,16 @@ async def _ct_relic_location_lines(intent: Any) -> list[str]:
                 placement.position.describe() if placement.position else "position n/a"
             )
             rel = _relative_time(placement.fetched_at)
+            mode = (
+                f", {_sanitise(placement.game_type)} battle"
+                if placement.game_type
+                else ""
+            )
             out.append(
                 _cap(
                     f"[btd6_ct_tile] {canonical} is on tile {placement.tile_id} "
-                    f"({pos}) in CT event {placement.ct_id}; captured-tile relic "
-                    f"bonus (source: data.ninjakiwi.com, fetched {rel})",
+                    f"({pos}{mode}) in CT event {placement.ct_id}; captured-tile "
+                    f"relic bonus (source: data.ninjakiwi.com, fetched {rel})",
                 ),
             )
             if len(out) >= 8:
@@ -821,10 +826,13 @@ async def _ct_active_tile_lines(intent: Any) -> list[str]:
             for tile in tiles:
                 canonical = _sanitise(tile.relic_canonical or tile.relic_name or "?")
                 pos = tile.position.describe() if tile.position else "position n/a"
+                mode = (
+                    f" — {_sanitise(tile.game_type)} battle" if tile.game_type else ""
+                )
                 out.append(
                     _cap(
                         f"[btd6_ct_tile] CT {_sanitise(evt.entity_key)}: {canonical} "
-                        f"on tile {_sanitise(tile.tile_id)} ({pos}) "
+                        f"on tile {_sanitise(tile.tile_id)} ({pos}){mode} "
                         f"(source: data.ninjakiwi.com)",
                     ),
                 )

--- a/disbot/views/btd6/panel.py
+++ b/disbot/views/btd6/panel.py
@@ -275,6 +275,28 @@ class BTD6PanelView(PersistentView):
 
     # Row 1 — secondary actions + staff
     @discord.ui.button(
+        label="🗺️ CT",
+        style=discord.ButtonStyle.secondary,
+        row=1,
+        custom_id="btd6:ct",
+    )
+    async def ct_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        # Contested Territory browser: active CT events + their relic tiles.
+        from cogs.btd6._builders import build_ct_browser_embed
+
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        await safe_followup(
+            interaction,
+            embed=await build_ct_browser_embed(),
+            ephemeral=True,
+        )
+
+    @discord.ui.button(
         label="Modes",
         style=discord.ButtonStyle.secondary,
         row=1,

--- a/tests/unit/views/btd6/test_btd6_panel_legacy_custom_ids.py
+++ b/tests/unit/views/btd6/test_btd6_panel_legacy_custom_ids.py
@@ -33,6 +33,7 @@ _NEW_CUSTOM_IDS = frozenset(
         "btd6:events",
         "btd6:leaderboards",
         "btd6:paragon",
+        "btd6:ct",
     },
 )
 


### PR DESCRIPTION
## Why

Live feedback: the bot now returns relics + tiles, but (1) there was **no CT button** in the BTD6 hub panel — only the `!btd6 ct` command — and (2) it never showed any per-tile "rules."

## Changes

- **`🗺️ CT` panel button** (`BTD6PanelView`, row 1, `custom_id="btd6:ct"`) opening the CT browser, mirroring the Modes button's ephemeral `safe_defer`/`safe_followup` + lazy cog-builder import (which the arch checker treats as a non-flagged in-function import, like the existing Modes/`_embeds` one). Declared in the panel `custom_id` contract test.
- **Per-tile game mode in grounding** — CT tile lines now include `gameType` (e.g. *"… on tile DEC (sector D, ring 3 of 7) — LeastTiers battle"*), the closest thing to per-tile rules the feed exposes.

## On "tower restrictions" (the other half of the feedback)

I verified against the **live** Ninja Kiwi API that both `/btd6/ct` and `/btd6/ct/<id>/tiles` expose only `id`, `type`, `gameType` per tile — **there are no tower-restriction / ban / modifier fields anywhere in the feed**. So the bot's *"the verified data doesn't include tower restrictions"* is accurate; it's a data-source limitation, not a bug. The added game-mode line gives the model the per-tile rule info that *is* available. (The only thing worth tightening separately is the model's phrasing implying a tool update could fetch restrictions — there's no upstream source to fetch them from.)

## Verified

- Panel loads with `btd6:ct`; grounding shows the game mode.
- `check_quality.py --full` green (lint + mypy + 6801 tests); `check_architecture.py --mode strict` 0 errors (panel's lazy cog import not flagged).

https://claude.ai/code/session_019XbZRmKGXyMwVYLTBqAkZh

---
_Generated by [Claude Code](https://claude.ai/code/session_019XbZRmKGXyMwVYLTBqAkZh)_