### PR TITLE
btd6(ct): render the current CT map as a PNG hex grid

### DIFF
--- a/disbot/core/runtime/interaction_helpers.py
+++ b/disbot/core/runtime/interaction_helpers.py
@@ -179,6 +179,7 @@ async def safe_followup(
     *,
     embed: discord.Embed | None = None,
     view: discord.ui.View | None = None,
+    file: discord.File | None = None,
     ephemeral: bool = False,
 ) -> discord.Message | None:
     """Send a response message regardless of deferred state.
@@ -200,6 +201,8 @@ async def safe_followup(
         kwargs["embed"] = clamp_embed(embed)
     if view is not None:
         kwargs["view"] = view
+    if file is not None:
+        kwargs["file"] = file
     if ephemeral:
         kwargs["ephemeral"] = True
 

--- a/disbot/utils/btd6/ct_map_render.py
+++ b/disbot/utils/btd6/ct_map_render.py
@@ -1,0 +1,169 @@
+"""Render a Contested Territory hex map to a PNG.
+
+Pillow is an **optional** dependency: this module lazy-imports it and
+:func:`render_ct_map` returns ``None`` when it is absent, so importing the
+module never breaks the bot and callers fall back to a text browser. The
+layout math (axial hex → pixel, image bounds) is pure and runs regardless
+of whether Pillow is installed; only the final pixel-pushing needs it.
+
+Pure ``utils`` module — no service/data imports. The caller (a view) is
+responsible for turning live tile rows into :class:`MapTile` records,
+including each tile's colour bucket and short label, so this module never
+needs the BTD6 data layer.
+"""
+
+from __future__ import annotations
+
+import io
+import math
+from dataclasses import dataclass
+
+# Colour buckets by tile kind. RGB tuples ready for Pillow.
+KIND_COLORS: dict[str, tuple[int, int, int]] = {
+    "relic": (245, 200, 70),
+    "banner": (95, 145, 225),
+    "team": (110, 200, 135),
+    "regular": (85, 90, 105),
+    "unknown": (70, 72, 84),
+}
+_DEFAULT_COLOR = (70, 72, 84)
+_BG = (22, 24, 30)
+_OUTLINE = (28, 30, 38)
+_TITLE_COLOR = (235, 235, 240)
+_LABEL_COLOR = (20, 20, 26)
+_CENTER_RING = (240, 240, 245)
+
+_HEX_SIZE = 26  # circumradius of one tile, px
+_PADDING = 22
+_HEADER = 34
+_LEGEND_H = 26
+
+
+@dataclass(frozen=True)
+class MapTile:
+    """One CT tile positioned in axial hex coordinates.
+
+    ``kind`` keys into :data:`KIND_COLORS`; ``label`` is a short string
+    (relic abbreviation, ≤4 chars) drawn centred on relic tiles.
+    """
+
+    q: int
+    r: int
+    kind: str
+    label: str = ""
+    is_center: bool = False
+
+
+def _axial_to_pixel(q: int, r: int, size: int) -> tuple[float, float]:
+    """Pointy-top axial → pixel centre (relative to the grid origin)."""
+    x = size * math.sqrt(3) * (q + r / 2)
+    y = size * 1.5 * r
+    return x, y
+
+
+def _hex_corners(cx: float, cy: float, size: int) -> list[tuple[float, float]]:
+    """Six pointy-top corners around ``(cx, cy)``."""
+    pts: list[tuple[float, float]] = []
+    for i in range(6):
+        angle = math.radians(60 * i - 30)
+        pts.append((cx + size * math.cos(angle), cy + size * math.sin(angle)))
+    return pts
+
+
+def _layout(
+    tiles: list[MapTile],
+    size: int,
+) -> tuple[dict[int, tuple[float, float]], int, int]:
+    """Map tile index → pixel centre (already offset into the image) + canvas size."""
+    raw = [_axial_to_pixel(t.q, t.r, size) for t in tiles]
+    if not raw:
+        return {}, _PADDING * 2, _HEADER + _PADDING * 2 + _LEGEND_H
+    min_x = min(x for x, _ in raw) - size
+    max_x = max(x for x, _ in raw) + size
+    min_y = min(y for _, y in raw) - size
+    max_y = max(y for _, y in raw) + size
+    grid_w = max_x - min_x
+    grid_h = max_y - min_y
+    width = int(grid_w + _PADDING * 2)
+    height = int(grid_h + _HEADER + _LEGEND_H + _PADDING * 2)
+    off_x = _PADDING - min_x
+    off_y = _HEADER + _PADDING - min_y
+    centres = {i: (x + off_x, y + off_y) for i, (x, y) in enumerate(raw)}
+    return centres, width, height
+
+
+def render_ct_map(
+    tiles: list[MapTile],
+    *,
+    title: str,
+    size: int = _HEX_SIZE,
+) -> bytes | None:
+    """Render ``tiles`` to PNG bytes, or ``None`` when Pillow is unavailable."""
+    if not tiles:
+        return None
+    try:
+        from PIL import Image, ImageDraw  # lazy: optional dependency
+    except Exception:  # noqa: BLE001 — any import failure → graceful no-op
+        return None
+
+    centres, width, height = _layout(tiles, size)
+    img = Image.new("RGB", (width, height), _BG)
+    draw = ImageDraw.Draw(img)
+
+    draw.text((_PADDING, _PADDING // 2), title, fill=_TITLE_COLOR)
+
+    for i, tile in enumerate(tiles):
+        cx, cy = centres[i]
+        color = KIND_COLORS.get(tile.kind, _DEFAULT_COLOR)
+        draw.polygon(_hex_corners(cx, cy, size), fill=color, outline=_OUTLINE)
+        if tile.is_center:
+            draw.ellipse(
+                (cx - size * 0.4, cy - size * 0.4, cx + size * 0.4, cy + size * 0.4),
+                outline=_CENTER_RING,
+                width=2,
+            )
+        if tile.label:
+            _draw_centered(draw, cx, cy, tile.label)
+
+    _draw_legend(draw, width, height)
+
+    buffer = io.BytesIO()
+    img.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def _draw_centered(draw, cx: float, cy: float, text: str) -> None:
+    try:
+        bbox = draw.textbbox((0, 0), text)
+        tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]
+    except Exception:  # noqa: BLE001 — very old Pillow without textbbox
+        tw, th = len(text) * 6, 11
+    draw.text((cx - tw / 2, cy - th / 2), text, fill=_LABEL_COLOR)
+
+
+def _draw_legend(draw, width: int, height: int) -> None:
+    items = [
+        ("Relic", "relic"),
+        ("Banner", "banner"),
+        ("Team", "team"),
+        ("Regular", "regular"),
+    ]
+    x = _PADDING
+    y = height - _LEGEND_H + 4
+    for label, kind in items:
+        draw.rectangle((x, y, x + 14, y + 14), fill=KIND_COLORS[kind], outline=_OUTLINE)
+        draw.text((x + 18, y + 2), label, fill=_TITLE_COLOR)
+        x += 18 + 8 * len(label) + 22
+
+
+def pillow_available() -> bool:
+    """True when Pillow can be imported (image rendering is live)."""
+    try:
+        import PIL  # noqa: F401
+
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+__all__ = ["KIND_COLORS", "MapTile", "render_ct_map", "pillow_available"]

--- a/disbot/views/btd6/ct_map_view.py
+++ b/disbot/views/btd6/ct_map_view.py
@@ -1,0 +1,105 @@
+"""Render the current Contested Territory map as a PNG for Discord.
+
+Bridges the live tile data (``services.btd6_live_query_service``) and the
+pure hex renderer (``utils.btd6.ct_map_render``): it classifies each tile
+into a colour bucket and a short relic label, then returns a
+``discord.File`` ready to attach. Returns ``None`` when Pillow is absent
+or no CT tile data is loaded, so callers degrade to the text browser.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+
+import discord
+
+from utils.btd6.ct_map_render import MapTile, render_ct_map
+
+logger = logging.getLogger("bot.views.btd6.ct_map")
+
+_MAP_FILENAME = "ct_map.png"
+
+
+def _tile_kind(placement: object) -> str:
+    if getattr(placement, "relic_name", None):
+        return "relic"
+    tile_type = (getattr(placement, "tile_type", None) or "").lower()
+    if tile_type == "relic":
+        return "relic"
+    if "banner" in tile_type:
+        return "banner"
+    if "team" in tile_type:
+        return "team"
+    if "regular" in tile_type:
+        return "regular"
+    return "unknown"
+
+
+def _relic_label(placement: object) -> str:
+    """A ≤4-char tag for a relic tile (abbreviation, else initials)."""
+    relic_id = getattr(placement, "relic_id", None)
+    if relic_id:
+        from services import btd6_data_service
+
+        entry = btd6_data_service.get_ct_relic(relic_id)
+        if entry is not None and entry.abbrev:
+            return entry.abbrev[:4]
+    name = getattr(placement, "relic_canonical", None) or getattr(
+        placement,
+        "relic_name",
+        "",
+    )
+    words = [w for w in str(name).replace("-", " ").split() if w]
+    if len(words) >= 2:
+        return "".join(w[0] for w in words[:4]).upper()
+    return str(name)[:3].upper()
+
+
+def _placement_to_tile(placement: object) -> MapTile | None:
+    pos = getattr(placement, "position", None)
+    if pos is None:
+        return None
+    kind = _tile_kind(placement)
+    label = _relic_label(placement) if kind == "relic" else ""
+    return MapTile(
+        q=pos.axial[0],
+        r=pos.axial[1],
+        kind=kind,
+        label=label,
+        is_center=bool(getattr(pos, "is_center", False)),
+    )
+
+
+async def build_ct_map_file(
+    ct_id: str | None = None,
+) -> tuple[discord.File | None, str | None]:
+    """Render the newest active CT (or ``ct_id``) to a ``discord.File``.
+
+    Returns ``(file, event_id)``. ``file`` is ``None`` when Pillow is
+    unavailable, no CT event is active, or the tile data isn't loaded;
+    ``event_id`` is still returned (when known) so the caller can word a
+    fallback message.
+    """
+    from services import btd6_live_query_service as btd6_live
+
+    try:
+        if ct_id is None:
+            events = await btd6_live.get_active_events(("btd6_ct",))
+            if not events:
+                return None, None
+            ct_id = events[0].entity_key
+        placements = await btd6_live.get_ct_tiles(ct_id)
+    except Exception:  # noqa: BLE001 — degrade to text browser
+        logger.exception("ct map: live tile fetch failed for %s", ct_id)
+        return None, ct_id
+
+    tiles = [t for t in (_placement_to_tile(p) for p in placements) if t is not None]
+    # ASCII hyphen: the default Pillow bitmap font has no em-dash glyph.
+    png = render_ct_map(tiles, title=f"Contested Territory - {ct_id}")
+    if png is None:
+        return None, ct_id
+    return discord.File(io.BytesIO(png), filename=_MAP_FILENAME), ct_id
+
+
+__all__ = ["build_ct_map_file"]

--- a/disbot/views/btd6/panel.py
+++ b/disbot/views/btd6/panel.py
@@ -285,14 +285,21 @@ class BTD6PanelView(PersistentView):
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        # Contested Territory browser: active CT events + their relic tiles.
+        # Contested Territory browser: active CT events + their relic tiles,
+        # with a rendered hex map of the current event when Pillow is present.
         from cogs.btd6._builders import build_ct_browser_embed
+        from views.btd6.ct_map_view import build_ct_map_file
 
         if not await safe_defer(interaction, ephemeral=True):
             return
+        embed = await build_ct_browser_embed()
+        map_file, _ = await build_ct_map_file()
+        if map_file is not None:
+            embed.set_image(url="attachment://ct_map.png")
         await safe_followup(
             interaction,
-            embed=await build_ct_browser_embed(),
+            embed=embed,
+            file=map_file,
             ephemeral=True,
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ openai>=1.40,<2.0
 anthropic>=0.40,<1.0
 youtube-transcript-api>=0.6.0,<1.0
 PyYAML>=6.0
+Pillow>=10.0,<12

--- a/tests/unit/utils/btd6/test_ct_map_render.py
+++ b/tests/unit/utils/btd6/test_ct_map_render.py
@@ -1,0 +1,63 @@
+"""CT hex-map renderer (utils.btd6.ct_map_render).
+
+Layout math is pure and always runs; the PNG path is exercised only when
+Pillow is installed (it ships in requirements, so CI covers it), and the
+no-Pillow path degrades to None.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_DISBOT = Path(__file__).parents[4] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+from utils.btd6.ct_map_render import (  # noqa: E402
+    KIND_COLORS,
+    MapTile,
+    _layout,
+    pillow_available,
+    render_ct_map,
+)
+
+_PNG_MAGIC = bytes([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+
+
+def _sample_tiles() -> list[MapTile]:
+    return [
+        MapTile(0, 0, "relic", "ABI", is_center=True),
+        MapTile(-7, 7, "banner"),
+        MapTile(1, -3, "relic", "CT"),
+        MapTile(3, 0, "team"),
+        MapTile(-2, 2, "regular"),
+    ]
+
+
+def test_kind_colors_cover_buckets():
+    for kind in ("relic", "banner", "team", "regular", "unknown"):
+        assert kind in KIND_COLORS
+
+
+def test_layout_is_deterministic_and_bounded():
+    tiles = _sample_tiles()
+    centres, w, h = _layout(tiles, 26)
+    assert len(centres) == len(tiles)
+    # Every centre sits inside the canvas.
+    for cx, cy in centres.values():
+        assert 0 <= cx <= w
+        assert 0 <= cy <= h
+
+
+def test_empty_returns_none():
+    assert render_ct_map([], title="x") is None
+
+
+def test_render_png_when_pillow_present():
+    out = render_ct_map(_sample_tiles(), title="Contested Territory - test")
+    if pillow_available():
+        assert isinstance(out, bytes)
+        assert out[:8] == _PNG_MAGIC
+    else:  # pragma: no cover - depends on env
+        assert out is None

--- a/tests/unit/views/btd6/test_ct_map_view.py
+++ b/tests/unit/views/btd6/test_ct_map_view.py
@@ -1,0 +1,97 @@
+"""CT map view: tile classification + discord.File assembly."""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+_DISBOT = Path(__file__).parents[4] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+from utils.btd6.ct_tile_geometry import decode_tile  # noqa: E402
+from views.btd6 import ct_map_view  # noqa: E402
+
+_NOW = datetime.now(tz=timezone.utc)
+
+
+def _placement(
+    tile_id, tile_type, relic_name=None, relic_id=None, relic_canonical=None
+):
+    from services import btd6_live_query_service as live
+
+    return live.CTTilePlacement(
+        ct_id="mpejg5d0",
+        tile_id=tile_id,
+        tile_type=tile_type,
+        game_type="Race",
+        relic_name=relic_name,
+        relic_id=relic_id,
+        relic_canonical=relic_canonical,
+        fetched_at=_NOW,
+        position=decode_tile(tile_id),
+    )
+
+
+def test_tile_classification_and_label():
+    relic = _placement(
+        "DEC", "Relic", "SuperMonkeyStorm", "super_monkey_storm", "Super Monkey Storm"
+    )
+    tile = ct_map_view._placement_to_tile(relic)
+    assert tile is not None
+    assert tile.kind == "relic"
+    assert tile.label == "SMS"  # catalog abbreviation
+    banner = ct_map_view._placement_to_tile(_placement("AAA", "Banner"))
+    assert banner.kind == "banner"
+    assert banner.label == ""
+    assert (
+        ct_map_view._placement_to_tile(_placement("MRX", "Regular")).is_center is True
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_ct_map_file_none_when_no_active_event(monkeypatch):
+    from services import btd6_live_query_service as live
+
+    async def _none(kinds=None):
+        return ()
+
+    monkeypatch.setattr(live, "get_active_events", _none)
+    file, event_id = await ct_map_view.build_ct_map_file()
+    assert file is None
+    assert event_id is None
+
+
+@pytest.mark.asyncio
+async def test_build_ct_map_file_renders_when_data_present(monkeypatch):
+    from services import btd6_live_query_service as live
+    from utils.btd6.ct_map_render import pillow_available
+
+    async def _active(kinds=None):
+        return (
+            live.ActiveEventHeadline(
+                "btd6_ct", "mpejg5d0", "mpejg5d0", None, None, _NOW
+            ),
+        )
+
+    async def _tiles(ct_id, *, relic=None, relics_only=False):
+        return (
+            _placement("DEC", "Relic", "CamoTrap", "camo_trap", "Camo Trap"),
+            _placement("AAA", "Banner"),
+            _placement("ABA", "Regular"),
+        )
+
+    monkeypatch.setattr(live, "get_active_events", _active)
+    monkeypatch.setattr(live, "get_ct_tiles", _tiles)
+    file, event_id = await ct_map_view.build_ct_map_file()
+    assert event_id == "mpejg5d0"
+    if pillow_available():
+        import discord
+
+        assert isinstance(file, discord.File)
+        assert file.filename == "ct_map.png"
+    else:  # pragma: no cover - depends on env
+        assert file is None


### PR DESCRIPTION
## What

Renders the **current Contested Territory map** as a PNG hex grid (you asked for the PIL render). The `🗺️ CT` panel button now attaches the rendered map of the newest active CT event above the text browser.

Verified by rendering the captured `mpejg5d0` fixture — a 169-tile hexagon, gold relic tiles (labeled with abbreviations like SMS / SHA / BBS), blue banner tiles, green team tiles, gray regular tiles, the centre `MRX` ringed, and a legend. (Screenshot shared in the session.)

## How

- **`utils/btd6/ct_map_render.py`** — pure hex renderer. Axial→pixel layout and image bounds are pure and unit-tested; the actual PNG drawing lazy-imports Pillow and returns `None` when it's absent (same optional-dependency pattern as `utils/mining_render.py`), so the module never breaks the bot. No service/data imports — the caller passes in `MapTile(q, r, kind, label, is_center)` records.
- **`views/btd6/ct_map_view.py`** — classifies live tile rows into colour buckets + a short relic label (catalog abbreviation, else initials) and returns a `discord.File` for the newest active CT. Degrades to `None` (text-only browser) when Pillow or tile data is missing.
- **`views/btd6/panel.py`** — the `🗺️ CT` button attaches the map when available (`set_image(attachment://ct_map.png)`).
- **`interaction_helpers.safe_followup`** — gains an optional `file=` parameter.
- **`requirements.txt`** — adds `Pillow>=10,<12` so rendering is live in prod/CI (without it, everything still works, just text-only).

## Layering / safety

- Renderer stays in `utils/` (no service imports); view does the data→colour mapping. No `views/ → cogs/` imports added. `check_architecture --mode strict`: 0 errors.
- `check_quality.py --full` green with Pillow installed: lint + mypy + **6809 tests** (incl. new renderer + view tests covering the pure layout, PNG output when Pillow is present, and the graceful-None fallbacks).

## Notes

- Surface is the **panel button** (the `btd6_cog` is at its 800-LOC ceiling, so no new command); the existing `!btd6 ct` text browser is unchanged. A `!btd6 ctmap` command can follow once/if the cog is decomposed.
- As before, the live map only renders if `btd6_ct_tile` facts are ingested; with no data it cleanly falls back to the text browser.

https://claude.ai/code/session_019XbZRmKGXyMwVYLTBqAkZh

---
_Generated by [Claude Code](https://claude.ai/code/session_019XbZRmKGXyMwVYLTBqAkZh)_