### PR TITLE
btd6: surface all 24 CT relics in AI grounding (lift the 14-tile cap)

### DIFF
--- a/disbot/services/btd6_context_service.py
+++ b/disbot/services/btd6_context_service.py
@@ -777,6 +777,17 @@ def _mentions_ct_topic(intent: Any) -> bool:
     return False
 
 
+# CT relic listing bounds. The relic catalog has 24 entries
+# (btd6_data_service.list_ct_relics) and a CT map places at most one tile per
+# relic, so a full active map is ~24 relic tiles. Bound the broad live listing
+# generously above that — enough for even two concurrently-active CT events —
+# so a real full map is never truncated (the prior cap of 14 silently dropped
+# 10 of 24 relics). The static catalog fallback below already lists every relic
+# uncapped, so a complete live listing is consistent.
+_CT_TILE_LINE_CAP = 48
+_CT_RELIC_EFFECT_CAP = 24
+
+
 async def _ct_active_tile_lines(intent: Any) -> list[str]:
     """Relic→tile map for the active CT on a *general* CT relic/tile question.
 
@@ -784,8 +795,9 @@ async def _ct_active_tile_lines(intent: Any) -> list[str]:
     the targeted answer, so this broad listing is skipped to avoid
     duplication. Otherwise it lists the relic tiles of the newest active CT
     event(s) — exactly the "tiles and relics" breakdown the model is
-    missing — plus the effect of each distinct relic found. Bounded so a
-    full 169-tile map can't flood the prompt.
+    missing — plus the effect of each distinct relic found. Bounded by the
+    relic catalog size so a full active map (~24 relics) lists completely
+    without flooding the prompt.
     """
     if getattr(intent, "ct_relics", ()):  # specific relic handled elsewhere
         return []
@@ -819,16 +831,16 @@ async def _ct_active_tile_lines(intent: Any) -> list[str]:
                 )
                 if tile.relic_id and tile.relic_id not in seen_relics:
                     seen_relics.append(tile.relic_id)
-                if len(out) >= 14:
+                if len(out) >= _CT_TILE_LINE_CAP:
                     break
-            if len(out) >= 14:
+            if len(out) >= _CT_TILE_LINE_CAP:
                 break
     except Exception as exc:  # noqa: BLE001 — degrade to the static catalog
         logger.debug("btd6_context_service: ct live tiles unavailable (%s)", exc)
 
     # The effect of each distinct relic actually on the map, so the model
     # can answer "what does it do" follow-ups without a second round-trip.
-    for relic_id in seen_relics[:8]:
+    for relic_id in seen_relics[:_CT_RELIC_EFFECT_CAP]:
         entry = btd6_data_service.get_ct_relic(relic_id)
         if entry is not None:
             out.extend(_render_ct_relic(entry))

--- a/tests/unit/services/test_btd6_ct_grounding.py
+++ b/tests/unit/services/test_btd6_ct_grounding.py
@@ -164,3 +164,58 @@ async def test_relic_tile_location_line_present(monkeypatch):
     assert tile_lines
     assert "tile DEC" in tile_lines[0]
     assert "mpejg5d0" in tile_lines[0]
+
+
+@pytest.mark.asyncio
+async def test_general_ct_question_lists_all_relics_without_14_cap(monkeypatch):
+    """Regression: a full CT map must surface ALL its relic tiles in grounding.
+
+    The API can return 24 active relics, but ``_ct_active_tile_lines`` used to
+    hard-cap the broad listing at 14 — so the model only ever saw 14 of 24.
+    Build one tile per catalog relic and assert every one survives into facts
+    (tiles AND distinct relic effects, the latter previously capped at 8).
+    """
+    from services import btd6_data_service
+    from services import btd6_live_query_service as live
+
+    relics = btd6_data_service.list_ct_relics()
+    n = len(relics)
+    assert n > 14, "relic catalog must exceed the old cap for this test to bite"
+
+    async def _active(kinds=None):
+        return (
+            live.ActiveEventHeadline(
+                "btd6_ct",
+                "mpejg5d0",
+                "mpejg5d0",
+                None,
+                None,
+                datetime.now(tz=timezone.utc),
+            ),
+        )
+
+    async def _tiles(ct_id, *, relic=None, relics_only=False):
+        return tuple(
+            live.CTTilePlacement(
+                ct_id="mpejg5d0",
+                tile_id=f"T{i:02d}",
+                tile_type="Relic",
+                game_type="Race",
+                relic_name=getattr(r, "canonical", None) or str(getattr(r, "id", "")),
+                relic_id=str(getattr(r, "id", "")),
+                relic_canonical=getattr(r, "canonical", None),
+                fetched_at=datetime.now(tz=timezone.utc),
+                position=None,
+            )
+            for i, r in enumerate(relics)
+        )
+
+    monkeypatch.setattr(live, "get_active_events", _active)
+    monkeypatch.setattr(live, "get_ct_tiles", _tiles)
+    out = await ctx.build("Do you have specific information about the tiles and relics")
+    tile_lines = [f for f in out.facts if f.startswith("[btd6_ct_tile]")]
+    relic_lines = [f for f in out.facts if f.startswith("[btd6_ct_relic]")]
+    # Every relic tile surfaces — not just the first 14.
+    assert len(tile_lines) == n, (len(tile_lines), n)
+    # Distinct relic effects are no longer capped at 8 either.
+    assert len(relic_lines) > 8, len(relic_lines)


### PR DESCRIPTION
## Summary

The AI could only ever surface **14 of 24** Contested Territory relics, even though the fetch/parse/store path and the API return all 24. Root cause: the loss was **purely in the grounding builder** — `btd6_context_service._ct_active_tile_lines()` hard-capped the broad CT relic/tile listing at `len(out) >= 14`, with a sibling `seen_relics[:8]` cap on the per-relic effect lines. Everything downstream was already generous (`list_ct_tiles_for_event` defaults to 256; `btd6_lookup` allows 25 facts), so the truncation happened before facts ever reached the model.

## Fix

Replaced the magic `14` cap (and the `[:8]` effect cap) with CT-catalog-sized bounds:

```
_CT_TILE_LINE_CAP   = 48   # ~2× the 24-relic catalog → never truncates a real map
_CT_RELIC_EFFECT_CAP = 24  # all distinct relics, matching the catalog
```

The relic catalog has exactly **24** entries (`btd6_data_service.list_ct_relics()`) and a CT map places at most one tile per relic, so a full active map is ~24 relic tiles. The bound is generous enough to cover even two concurrently-active CT events while still guarding against pathological duplicate-tile data. This is consistent with the existing **static-catalog fallback**, which already lists every relic uncapped.

## Test

New regression test (`test_general_ct_question_lists_all_relics_without_14_cap`) builds one tile per catalog relic and asserts **all** of them survive into the grounding facts — both the `[btd6_ct_tile]` placements and the distinct `[btd6_ct_relic]` effect lines (the latter previously capped at 8). It would fail at 14/8 with the old caps.

## Verification

- `python3.10 scripts/check_quality.py --full` — black/isort/ruff + `mypy disbot/` + full pytest (**6855 passed, 3 skipped**), all green.
- `python3.10 scripts/check_architecture.py --mode strict` — exit 0, no new violations.
- The existing CT grounding/format tests still pass unchanged (the fix only lifts the count caps; line format is untouched).

https://claude.ai/code/session_01LDQWpHmwXLkw2v5ZMow6GV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDQWpHmwXLkw2v5ZMow6GV)_