### PR TITLE
BTD6: upgrades as first-class resolvable entities (resolver foundation)

### DIFF
--- a/disbot/services/btd6_upgrade_service.py
+++ b/disbot/services/btd6_upgrade_service.py
@@ -1,0 +1,359 @@
+"""Deterministic BTD6 *upgrade* resolver — upgrades as first-class entities.
+
+The existing :mod:`services.btd6_resolver_service` recognises towers, heroes,
+maps, modes, bloons, relics, and live entities — but **not upgrades**. So a
+natural-language query like ``"PMFC stats"``, ``"POD cooldown"``, or
+``"Prince of Darkness damage"`` resolves to nothing unless the message also
+names the tower (``"wizard ..."``). This module fills that gap with a small,
+deterministic registry + resolver — no AI, no I/O beyond the committed dataset.
+
+Every upgrade in the game is a ``(tower, path, tier)`` triple with a unique
+name; this builds an :class:`UpgradeIdentity` for each from
+``btd6_data_service`` (``upgrade_paths`` / ``upgrade_costs``) and resolves a
+query to one via, in order:
+
+1. an exact upgrade **name** mentioned in the text (``Prince of Darkness``);
+2. a curated **alias / abbreviation / nickname** (``PMFC``, ``POD``,
+   ``Phoenix Lord``);
+3. **path notation** alongside a tower (``wizard 005`` / ``050 dart``);
+
+returning :class:`UpgradeResolution` with the match type, the resolved upgrade,
+or — when a term maps to several upgrades — the ambiguous candidates. Wiring
+this into the resolver / AI grounding / panel is a separate step; this layer is
+deliberately self-contained and behaviour-neutral on its own.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from services.btd6_data_service import get_dataset
+
+_KEY_BY_PATH = {1: "top", 2: "mid", 3: "bot"}
+_PATH_BY_KEY = {"top": 1, "mid": 2, "bot": 3}
+
+# A single-path tier code in text: three digits 0-5, optionally hyphenated,
+# bounded so it won't fire inside a longer number (game versions etc.).
+_CODE_RE = re.compile(r"(?<![\d-])([0-5])-?([0-5])-?([0-5])(?![\d-])")
+
+
+@dataclass(frozen=True)
+class UpgradeIdentity:
+    """One BTD6 upgrade (a tower's path+tier), joined into a stable identity."""
+
+    upgrade_id: str  # "wizard_monkey:005"
+    tower_id: str
+    tower_name: str
+    path: str  # "top" | "mid" | "bot"
+    path_index: int  # 1 | 2 | 3
+    tier: int  # 1..5
+    code: str  # "005"
+    crosspath: str  # "0-0-5"
+    canonical: str  # "Prince of Darkness"
+    cost: int | None
+    aliases: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class UpgradeResolution:
+    """Outcome of :func:`resolve_upgrade` — match metadata for callers."""
+
+    query: str
+    match_type: str  # exact_name | alias | path_notation | ambiguous | none
+    upgrade: UpgradeIdentity | None = None
+    candidates: tuple[UpgradeIdentity, ...] = ()
+
+    @property
+    def found(self) -> bool:
+        return self.upgrade is not None
+
+
+# Curated alias / abbreviation / nickname -> exact canonical upgrade name. Only
+# clearly-correct community terms; anything uncertain is left out so it yields a
+# clean no-match rather than a guess. Validated against the live registry by
+# tests (every value must name a real upgrade).
+_CURATED_ALIASES: dict[str, str] = {
+    # Dart Monkey
+    "pmfc": "Plasma Monkey Fan Club",
+    # Super Monkey
+    "smfc": "Super Monkey Fan Club",
+    "sun avatar": "Sun Avatar",
+    "sav": "Sun Avatar",
+    "tsg": "True Sun God",
+    "lotn": "Legend of the Night",
+    # Wizard Monkey
+    "pod": "Prince of Darkness",
+    "wlp": "Wizard Lord Phoenix",
+    "phoenix lord": "Wizard Lord Phoenix",
+    # Dartling Gunner
+    "mad": "M.A.D",
+    "bez": "Bloon Exclusion Zone",
+    "rod": "Ray of Doom",
+    # Mortar Monkey
+    "paa": "Pop and Awe",
+    # Druid
+    "aow": "Avatar of Wrath",
+    "sotf": "Spirit of the Forest",
+    # Alchemist
+    "bma": "Bloon Master Alchemist",
+    # Mermonkey
+    "abyss lord": "Lord of the Abyss",
+    # Spike Factory
+    "perma spike": "Perma-Spike",
+    "permaspike": "Perma-Spike",
+    # Glue Gunner
+    "bloon solver": "The Bloon Solver",
+    # Tack Shooter
+    "tack zone": "The Tack Zone",
+    # Ninja Monkey
+    "gm ninja": "Grandmaster Ninja",
+    # Banana Farm
+    "monkey wall street": "Monkey Wall Street",
+    "mws": "Monkey Wall Street",
+}
+
+
+def _tokens(text: str) -> list[str]:
+    """Lowercase alphanumeric word tokens."""
+    return [t for t in re.split(r"[^a-z0-9]+", (text or "").lower()) if t]
+
+
+def _contains_subsequence(haystack: list[str], needle: list[str]) -> bool:
+    """True if ``needle`` appears as a contiguous run inside ``haystack``."""
+    if not needle or len(needle) > len(haystack):
+        return False
+    first = needle[0]
+    for i in range(len(haystack) - len(needle) + 1):
+        if haystack[i] == first and haystack[i : i + len(needle)] == needle:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Registry (built once from the dataset, cached)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _Registry:
+    upgrades: tuple[UpgradeIdentity, ...]
+    by_id: dict[str, UpgradeIdentity]
+    by_tower: dict[str, dict[str, UpgradeIdentity]]  # tower_id -> code -> identity
+    # surface (token tuple) -> identity, for name + alias matching
+    name_index: dict[tuple[str, ...], UpgradeIdentity]
+    alias_index: dict[tuple[str, ...], UpgradeIdentity]
+    tower_surfaces: dict[tuple[str, ...], str]  # tower alias tokens -> tower_id
+
+
+_REGISTRY: _Registry | None = None
+
+
+def _build_registry() -> _Registry:
+    dataset = get_dataset()
+    upgrades: list[UpgradeIdentity] = []
+    by_tower: dict[str, dict[str, UpgradeIdentity]] = {}
+    name_to_identity: dict[str, UpgradeIdentity] = {}
+
+    for tower in dataset.towers:
+        paths = tower.upgrade_paths or {}
+        costs = tower.upgrade_costs or {}
+        for pkey, names in paths.items():
+            path_index = _PATH_BY_KEY.get(pkey)
+            if path_index is None:
+                continue
+            path_costs = costs.get(pkey, ())
+            for tier_idx, name in enumerate(names):
+                if not name:
+                    continue
+                tier = tier_idx + 1
+                digits = ["0", "0", "0"]
+                digits[path_index - 1] = str(tier)
+                code = "".join(digits)
+                cost = (
+                    path_costs[tier_idx]
+                    if tier_idx < len(path_costs) and path_costs[tier_idx]
+                    else None
+                )
+                identity = UpgradeIdentity(
+                    upgrade_id=f"{tower.id}:{code}",
+                    tower_id=tower.id,
+                    tower_name=tower.canonical,
+                    path=pkey,
+                    path_index=path_index,
+                    tier=tier,
+                    code=code,
+                    crosspath="-".join(code),
+                    canonical=name,
+                    cost=cost,
+                )
+                upgrades.append(identity)
+                by_tower.setdefault(tower.id, {})[code] = identity
+                name_to_identity[name.lower()] = identity
+
+    # Attach curated aliases (and a per-identity alias tuple).
+    alias_index: dict[tuple[str, ...], UpgradeIdentity] = {}
+    aliases_for: dict[str, list[str]] = {}
+    for alias, canonical in _CURATED_ALIASES.items():
+        identity = name_to_identity.get(canonical.lower())
+        if identity is None:
+            continue  # a typo'd curated name; tests assert this never happens
+        alias_index[tuple(_tokens(alias))] = identity
+        aliases_for.setdefault(identity.upgrade_id, []).append(alias)
+
+    # Rebuild identities with their alias tuples filled in.
+    final: list[UpgradeIdentity] = []
+    by_id: dict[str, UpgradeIdentity] = {}
+    name_index: dict[tuple[str, ...], UpgradeIdentity] = {}
+    for identity in upgrades:
+        al = tuple(aliases_for.get(identity.upgrade_id, ()))
+        if al:
+            identity = UpgradeIdentity(**{**identity.__dict__, "aliases": al})
+        final.append(identity)
+        by_id[identity.upgrade_id] = identity
+        by_tower[identity.tower_id][identity.code] = identity
+        name_index[tuple(_tokens(identity.canonical))] = identity
+    # Re-point alias_index at the alias-filled identities.
+    alias_index = {toks: by_id[ident.upgrade_id] for toks, ident in alias_index.items()}
+
+    tower_surfaces: dict[tuple[str, ...], str] = {}
+    for tower in dataset.towers:
+        for surface in (tower.id, tower.canonical, *tower.aliases):
+            toks = tuple(_tokens(surface))
+            if toks:
+                tower_surfaces[toks] = tower.id
+
+    return _Registry(
+        upgrades=tuple(final),
+        by_id=by_id,
+        by_tower=by_tower,
+        name_index=name_index,
+        alias_index=alias_index,
+        tower_surfaces=tower_surfaces,
+    )
+
+
+def _registry() -> _Registry:
+    global _REGISTRY
+    if _REGISTRY is None:
+        _REGISTRY = _build_registry()
+    return _REGISTRY
+
+
+def reset_cache() -> None:
+    """Test seam: drop the built registry."""
+    global _REGISTRY
+    _REGISTRY = None
+
+
+def all_upgrades() -> tuple[UpgradeIdentity, ...]:
+    """Every upgrade identity (375: 25 towers x 3 paths x 5 tiers)."""
+    return _registry().upgrades
+
+
+def get_upgrade(upgrade_id: str) -> UpgradeIdentity | None:
+    """Look up an upgrade by its ``tower_id:code`` id."""
+    return _registry().by_id.get(upgrade_id)
+
+
+# ---------------------------------------------------------------------------
+# Resolution
+# ---------------------------------------------------------------------------
+
+
+def _match_surfaces(
+    query_tokens: list[str],
+    index: dict[tuple[str, ...], UpgradeIdentity],
+) -> set[str]:
+    """Upgrade ids whose name/alias surface appears in ``query_tokens``.
+
+    Single-token surfaces match an exact token (so ``mad`` never fires inside
+    ``madness``); multi-token surfaces match a contiguous run.
+    """
+    token_set = set(query_tokens)
+    hits: set[str] = set()
+    for surface, identity in index.items():
+        if len(surface) == 1:
+            if surface[0] in token_set:
+                hits.add(identity.upgrade_id)
+        elif _contains_subsequence(query_tokens, list(surface)):
+            hits.add(identity.upgrade_id)
+    return hits
+
+
+def _single_path_code(query: str) -> str | None:
+    """The first single-path tier code in ``query`` (e.g. ``005``), or None.
+
+    Crosspath codes (two non-zero digits) are not a single upgrade, so they are
+    ignored here — the existing crosspath grounding owns those.
+    """
+    for match in _CODE_RE.finditer(query or ""):
+        digits = match.groups()
+        nonzero = [d for d in digits if d != "0"]
+        if len(nonzero) == 1:
+            return "".join(digits)
+    return None
+
+
+def _tower_in_query(query_tokens: list[str], reg: _Registry) -> str | None:
+    token_set = set(query_tokens)
+    for surface, tower_id in reg.tower_surfaces.items():
+        if len(surface) == 1:
+            if surface[0] in token_set:
+                return tower_id
+        elif _contains_subsequence(query_tokens, list(surface)):
+            return tower_id
+    return None
+
+
+def resolve_upgrade(query: str) -> UpgradeResolution:
+    """Resolve free-form ``query`` to a single BTD6 upgrade (or ambiguity/none).
+
+    Deterministic and order-stable: an explicit upgrade **name** wins over a
+    curated **alias**, which wins over **path notation** (a tower + tier code).
+    A term that maps to several distinct upgrades returns ``ambiguous`` with the
+    candidates so callers can ask for clarification rather than guess.
+    """
+    reg = _registry()
+    tokens = _tokens(query)
+    if not tokens and not (query or "").strip():
+        return UpgradeResolution(query=query or "", match_type="none")
+
+    name_hits = _match_surfaces(tokens, reg.name_index)
+    if len(name_hits) == 1:
+        return UpgradeResolution(query, "exact_name", reg.by_id[next(iter(name_hits))])
+
+    alias_hits = _match_surfaces(tokens, reg.alias_index)
+    combined = name_hits | alias_hits
+    if len(combined) == 1:
+        match_type = "exact_name" if name_hits else "alias"
+        return UpgradeResolution(query, match_type, reg.by_id[next(iter(combined))])
+    if len(combined) > 1:
+        candidates = tuple(
+            sorted(
+                (reg.by_id[uid] for uid in combined),
+                key=lambda u: u.upgrade_id,
+            ),
+        )
+        return UpgradeResolution(query, "ambiguous", None, candidates)
+
+    # Path notation: a tower + a single-path code (e.g. "wizard 005", "050 dart").
+    code = _single_path_code(query)
+    if code is not None:
+        tower_id = _tower_in_query(tokens, reg)
+        if tower_id is not None:
+            identity = reg.by_tower.get(tower_id, {}).get(code)
+            if identity is not None:
+                return UpgradeResolution(query, "path_notation", identity)
+
+    return UpgradeResolution(query, "none")
+
+
+__all__ = [
+    "UpgradeIdentity",
+    "UpgradeResolution",
+    "all_upgrades",
+    "get_upgrade",
+    "reset_cache",
+    "resolve_upgrade",
+]

--- a/tests/unit/services/test_btd6_upgrade_service.py
+++ b/tests/unit/services/test_btd6_upgrade_service.py
@@ -1,0 +1,128 @@
+"""Deterministic upgrade resolution — upgrades as first-class BTD6 entities.
+
+Pins the reported failures (PMFC / POD / Prince of Darkness / Wizard Lord
+Phoenix / path notation), the curated-alias integrity (no typo'd names), and the
+no-match / ambiguity behaviour so the resolver can't silently regress.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from services import btd6_upgrade_service as up
+
+
+@pytest.fixture(autouse=True)
+def _fresh():
+    up.reset_cache()
+    yield
+    up.reset_cache()
+
+
+def test_registry_covers_every_upgrade():
+    upgrades = up.all_upgrades()
+    # 25 towers x 3 paths x 5 tiers.
+    assert len(upgrades) == 375
+    ids = {u.upgrade_id for u in upgrades}
+    assert len(ids) == 375  # unique
+    for u in upgrades:
+        assert u.upgrade_id == f"{u.tower_id}:{u.code}"
+        assert u.crosspath == "-".join(u.code)
+        assert 1 <= u.tier <= 5
+        assert u.canonical
+
+
+def test_every_curated_alias_names_a_real_upgrade():
+    # Guards against a typo in the curated alias table.
+    for alias, canonical in up._CURATED_ALIASES.items():
+        res = up.resolve_upgrade(alias)
+        assert res.found, f"{alias!r} -> {canonical!r} did not resolve"
+        assert res.upgrade.canonical == canonical
+
+
+@pytest.mark.parametrize(
+    ("query", "expected_id", "expected_type"),
+    [
+        ("What are PMFC's stats?", "dart_monkey:050", "alias"),
+        ("POD cooldown?", "wizard_monkey:005", "alias"),
+        ("PoD", "wizard_monkey:005", "alias"),
+        ("Prince of Darkness damage", "wizard_monkey:005", "exact_name"),
+        ("Wizard Lord Phoenix", "wizard_monkey:050", "exact_name"),
+        ("Phoenix Lord", "wizard_monkey:050", "alias"),
+        ("Abyss Lord", "mermonkey:500", "alias"),
+        ("MAD stats", "dartling_gunner:050", "alias"),
+        ("M.A.D", "dartling_gunner:050", "exact_name"),
+        ("BEZ", "dartling_gunner:005", "alias"),
+        ("Bloon Master Alchemist", "alchemist:005", "exact_name"),
+        ("Pop and Awe", "mortar_monkey:050", "exact_name"),
+    ],
+)
+def test_named_and_alias_queries_resolve(query, expected_id, expected_type):
+    res = up.resolve_upgrade(query)
+    assert res.found, query
+    assert res.upgrade.upgrade_id == expected_id
+    assert res.match_type == expected_type
+
+
+@pytest.mark.parametrize(
+    ("query", "expected_id"),
+    [
+        ("005 wizard", "wizard_monkey:005"),
+        ("wizard 005", "wizard_monkey:005"),
+        ("050 dart", "dart_monkey:050"),
+        ("0-0-5 wizard", "wizard_monkey:005"),
+        ("dart 500", "dart_monkey:500"),
+        ("wizard 003", "wizard_monkey:003"),  # lower tier via notation
+    ],
+)
+def test_path_notation_resolves_with_a_tower(query, expected_id):
+    res = up.resolve_upgrade(query)
+    assert res.found, query
+    assert res.match_type == "path_notation"
+    assert res.upgrade.upgrade_id == expected_id
+
+
+def test_lower_tier_single_word_name_resolves():
+    # 'Nomad' is a real Desperado 0-0-2 upgrade — full-tree coverage, not just T5.
+    res = up.resolve_upgrade("nomad")
+    assert res.found
+    assert res.upgrade.upgrade_id == "desperado:002"
+    assert res.upgrade.canonical == "Nomad"
+
+
+def test_ambiguous_query_returns_candidates():
+    res = up.resolve_upgrade("wizard lord phoenix vs prince of darkness")
+    assert not res.found
+    assert res.match_type == "ambiguous"
+    ids = {c.upgrade_id for c in res.candidates}
+    assert ids == {"wizard_monkey:050", "wizard_monkey:005"}
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "",
+        "   ",
+        "005",  # bare code, no tower -> can't disambiguate
+        "0-2-5",  # crosspath, not a single upgrade
+        "what is the best tower",
+        "madness",  # must not match the 'mad' alias
+        "supercalifragilistic",
+    ],
+)
+def test_non_matches_return_none(query):
+    res = up.resolve_upgrade(query)
+    assert not res.found
+    assert res.match_type == "none"
+    assert res.candidates == ()
+
+
+def test_get_upgrade_round_trips():
+    pod = up.get_upgrade("wizard_monkey:005")
+    assert pod is not None
+    assert pod.canonical == "Prince of Darkness"
+    assert pod.tower_name == "Wizard Monkey"
+    assert pod.path == "bot" and pod.path_index == 3 and pod.tier == 5
+    assert pod.cost == 26500
+    assert "pod" in pod.aliases
+    assert up.get_upgrade("does_not:999") is None


### PR DESCRIPTION
## Problem
The BTD6 AI lookup (`btd6_lookup` → `btd6_context_service.build` → `btd6_resolver_service.resolve`) recognises towers, heroes, maps, modes, bloons, relics, and live entities — **but not upgrades**. So natural‑language queries resolve to nothing unless the tower is also named:

```
PMFC                  → no match
POD                   → no match
Prince of Darkness    → no facts unless "wizard" is also present
```

The data exists (tower fixtures carry `upgrade_paths`/`upgrade_costs`; stats files carry per‑tier combat data) — it just isn't resolvable as a first‑class entity. (Verified: Wizard `005` = Prince of Darkness, cooldown `0.275`, cost `$26,500`.)

## This PR — the foundation (behaviour‑neutral)
Per the agreed plan, the smallest durable fix first: make upgrades first‑class, **without** touching the AI prompt or rewiring the subsystem yet.

`services/btd6_upgrade_service.py`:
- **`UpgradeIdentity`** — every upgrade as a stable `(tower, path, tier)` identity (`wizard_monkey:005`, code `005`, crosspath `0-0-5`, canonical name, cost). Built from the dataset → all **375** upgrades (25 towers × 3 paths × 5 tiers).
- **Curated alias table** — clear community abbreviations/nicknames only (`PMFC`, `POD`, `WLP`, `MAD`, `BEZ`, `Phoenix Lord`, `Abyss Lord → Lord of the Abyss`, …). Uncertain terms are deliberately omitted → clean no‑match, never an AI guess.
- **`resolve_upgrade(query) → UpgradeResolution`** — deterministic, order‑stable: exact upgrade **name** → curated **alias** → **path notation** with a tower (`wizard 005` / `050 dart`) → `ambiguous` (with candidates) → `none`. Token‑boundary matching, so `mad` never fires inside `madness`.

Nothing else calls it yet, so existing flows are untouched.

## Tests (30)
The reported failures now resolve, plus integrity/negative coverage:

| Query | → |
|---|---|
| `PMFC stats` | Plasma Monkey Fan Club / dart_monkey:050 |
| `POD cooldown` / `PoD` | Prince of Darkness / wizard_monkey:005 |
| `Prince of Darkness` / `Wizard Lord Phoenix` / `Phoenix Lord` | wizard_monkey 005 / 050 |
| `M.A.D` / `MAD` / `BEZ` | dartling_gunner 050 / 005 |
| `Abyss Lord` | Lord of the Abyss / mermonkey:500 |
| `005 wizard` / `wizard 005` / `050 dart` | path_notation |
| `nomad` | Nomad / desperado:002 (full‑tree, not just T5) |
| bare `005`, `0-2-5`, `madness`, nonsense | `none` |
| naming two upgrades | `ambiguous` + candidates |

Also asserts every curated alias maps to a real upgrade (typo guard).

## Next (PR 2)
Wire it in: populate `ResolvedIntent.upgrades`, render `[btd6_upgrade]` grounding (identity + tier normal stats + targeted minion/projectile extraction so "PoD minion pierce → 1" works), structured `btd6_lookup` metadata + no‑match suggestions, and the AI‑instruction discipline (prefer verified, ambiguity → clarify, missing → say so, never guess).

Local gates green: `check_quality.py --check-only`, `mypy`, `check_architecture --mode strict` (0 errors), 30 tests.

https://claude.ai/code/session_01EVXenpTc3mbfzeTMNCfUXk

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVXenpTc3mbfzeTMNCfUXk)_