### PR TITLE
BTD6: upgrade detail + wire grounding into AI lookup (fixes POD/BEZ/MAD/Prince of Darkness)

### DIFF
--- a/disbot/services/btd6_context_service.py
+++ b/disbot/services/btd6_context_service.py
@@ -1198,6 +1198,24 @@ async def build(message_text: str) -> BTD6Context:
         }
         facts.extend(_paragon_name_facts(message_text, resolved_tower_ids))
 
+        # Pass 3c: upgrade grounding — an upgrade named in the text by name,
+        # abbreviation / nickname (PMFC / POD / BEZ / Prince of Darkness), or
+        # path notation ("wizard 005"). Grounds its identity + per-attack /
+        # minion / buff detail so upgrade-specific questions resolve even when
+        # the tower isn't also named. Isolated so a failure can't suppress the
+        # rest; the resolver underneath is deterministic and dataset-only.
+        try:
+            from services import btd6_upgrade_detail_service
+
+            facts.extend(
+                btd6_upgrade_detail_service.grounding_for_query(message_text),
+            )
+        except Exception as exc:  # noqa: BLE001 — defensive
+            logger.debug(
+                "btd6_context_service: upgrade grounding unavailable (%s)",
+                exc,
+            )
+
         # Pass 4: coverage + freshness signals (raw lines; the instruction
         # stack wraps the whole bundle as untrusted data). Paired with the
         # _TASK_CONTRACT live-event directive.

--- a/disbot/services/btd6_upgrade_detail_service.py
+++ b/disbot/services/btd6_upgrade_detail_service.py
@@ -1,0 +1,375 @@
+"""Targeted BTD6 *upgrade detail* read model — the deep, queryable layer.
+
+:mod:`services.btd6_upgrade_service` resolves a query to an
+:class:`~services.btd6_upgrade_service.UpgradeIdentity` (which tower / path /
+tier). This module joins that identity to the per-tier combat data in
+:mod:`services.btd6_stats_service` and exposes a structured
+:class:`UpgradeDetail` — every named attack with its projectiles, spawned
+subtowers ("minions"), activated abilities, buffs, and damage zones — plus a
+grounding renderer for the AI.
+
+Why a separate layer: the existing normal-stat view distils a tier to a single
+"main projectile" (highest damage), which is why a question like *"Prince of
+Darkness minion pierce?"* can't be answered from it — the answer (``1``) lives
+on the **Reanimate** attack's projectile, not the main one. This model keeps
+every attack/minion/buff addressable so those questions resolve.
+
+Purely additive and read-only: it reads the two services above and changes
+neither. Wiring :func:`grounding_for_query` into the AI grounding path is a
+separate, behaviour-changing step left for review.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from services import btd6_stats_service, btd6_upgrade_service
+from services.btd6_stats_service import NormalStats
+from services.btd6_upgrade_service import UpgradeIdentity
+
+_MAX_LINE = 320
+_PATH_LABEL = {"top": "top", "mid": "middle", "bot": "bottom"}
+
+
+@dataclass(frozen=True)
+class ProjectileSpec:
+    """One projectile fired by an attack."""
+
+    name: str
+    pierce: int | None
+    damage: int | None
+    damage_type: str | None
+    cannot_pop: str | None
+    radius: float | None
+    lifespan: float | None
+    can_see_camo: bool
+    moab_bonus: int | None
+
+
+@dataclass(frozen=True)
+class AttackSpec:
+    """One named attack on a tier (``Attack``, ``Reanimate``, ``MOAB`` …)."""
+
+    name: str
+    cooldown: float | None  # the raw ``rate`` field, in seconds
+    count: int | None
+    can_see_camo: bool
+    projectiles: tuple[ProjectileSpec, ...]
+
+
+@dataclass(frozen=True)
+class SubtowerSpec:
+    """A spawned sub-tower / minion (alchemist's Transformed Monkey, etc.)."""
+
+    name: str
+    attacks: tuple[AttackSpec, ...]
+
+
+@dataclass(frozen=True)
+class AbilitySpec:
+    """An activated ability on a tier."""
+
+    name: str
+    cooldown: float | None
+    lifespan: float | None
+
+
+@dataclass(frozen=True)
+class UpgradeDetail:
+    """The full, structured detail for one upgrade."""
+
+    identity: UpgradeIdentity
+    game_version: str
+    normal: NormalStats | None
+    attacks: tuple[AttackSpec, ...]
+    subtowers: tuple[SubtowerSpec, ...]
+    abilities: tuple[AbilitySpec, ...]
+    buffs: tuple[str, ...]
+    zones: tuple[str, ...]
+
+    @property
+    def has_combat_stats(self) -> bool:
+        return bool(self.attacks or self.subtowers or self.abilities or self.zones)
+
+    @property
+    def coverage(self) -> tuple[str, ...]:
+        """Which detail sections are populated — for missing-data signalling."""
+        present = []
+        if self.normal is not None:
+            present.append("normal")
+        for name in ("attacks", "subtowers", "abilities", "buffs", "zones"):
+            if getattr(self, name):
+                present.append(name)
+        return tuple(present)
+
+
+# ---------------------------------------------------------------------------
+# Parsing (stats JSON node -> spec)
+# ---------------------------------------------------------------------------
+
+
+def _camo(node: dict[str, Any]) -> bool:
+    """``filterInvisible`` means the attack/projectile cannot target Camo."""
+    return not bool(node.get("filterInvisible"))
+
+
+def _projectile(proj: dict[str, Any]) -> ProjectileSpec:
+    return ProjectileSpec(
+        name=str(proj.get("name") or "Projectile"),
+        pierce=proj.get("pierce"),
+        damage=proj.get("damage"),
+        damage_type=proj.get("damage_type"),
+        cannot_pop=proj.get("cannot_pop"),
+        radius=proj.get("radius"),
+        lifespan=proj.get("lifespan"),
+        can_see_camo=_camo(proj),
+        moab_bonus=proj.get("damageModifierForMoabs"),
+    )
+
+
+def _attack(attack: dict[str, Any]) -> AttackSpec:
+    return AttackSpec(
+        name=str(attack.get("name") or "Attack"),
+        cooldown=attack.get("rate"),
+        count=attack.get("count"),
+        can_see_camo=_camo(attack),
+        projectiles=tuple(_projectile(p) for p in attack.get("projectiles", [])),
+    )
+
+
+def _subtower(sub: dict[str, Any]) -> SubtowerSpec:
+    return SubtowerSpec(
+        name=str(sub.get("name") or "Minion"),
+        attacks=tuple(_attack(a) for a in sub.get("attacks", [])),
+    )
+
+
+def _ability(ability: dict[str, Any]) -> AbilitySpec:
+    return AbilitySpec(
+        name=str(ability.get("name") or "Ability"),
+        cooldown=ability.get("cooldown"),
+        lifespan=ability.get("lifespan"),
+    )
+
+
+# Buff field -> readable formatter. Only the headline effect fields; structural
+# fields (isGlobal, maxStackSize, filters) are intentionally omitted.
+_BUFF_FIELDS: tuple[tuple[str, str], ...] = (
+    ("damageAdditive", "+{} damage"),
+    ("damageMultiplier", "x{} damage"),
+    ("damageAdditiveForMoabs", "+{} damage vs MOAB-class"),
+    ("damageAdditiveForCeramic", "+{} damage vs Ceramic"),
+    ("damageAdditiveForBad", "+{} damage vs BAD"),
+    ("pierceAdditive", "+{} pierce"),
+    ("pierceMultiplier", "x{} pierce"),
+    ("piercePercentage", "+{}% pierce"),
+    ("rateMultiplier", "x{} attack cooldown"),
+    ("ratePercentage", "{}% attack speed"),
+    ("rangeAdditive", "+{} range"),
+    ("rangeMultiplier", "x{} range"),
+    ("rangePercentage", "+{}% range"),
+    ("lifespanMultiplier", "x{} lifespan"),
+    ("abilityCooldownMultiplier", "x{} ability cooldown"),
+)
+
+
+def _buff_text(buff: dict[str, Any]) -> str:
+    parts = [
+        tmpl.format(buff[field])
+        for field, tmpl in _BUFF_FIELDS
+        if buff.get(field) is not None
+    ]
+    name = str(buff.get("name") or "").strip()
+    body = ", ".join(parts) if parts else "buff"
+    return f"{name}: {body}" if name else body
+
+
+def _zone_text(zone: dict[str, Any]) -> str:
+    name = str(zone.get("name") or "Zone")
+    dmg = zone.get("damage")
+    dtype = zone.get("damage_type")
+    interval = zone.get("interval")
+    bits = []
+    if dmg is not None:
+        bits.append(f"{dmg} {dtype} dmg" if dtype else f"{dmg} dmg")
+    if interval is not None:
+        bits.append(f"every {interval}s")
+    return f"{name} ({', '.join(bits)})" if bits else name
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def get_upgrade_detail(upgrade_id: str) -> UpgradeDetail | None:
+    """Full structured detail for ``upgrade_id`` (``tower_id:code``), or None.
+
+    None only when the id names no real upgrade. A real upgrade on a tower with
+    no stats file (or an economy tower with no combat tiers) returns a detail
+    with identity + ``normal=None`` / empty sections and ``has_combat_stats``
+    False — callers can still surface the identity and signal missing data.
+    """
+    identity = btd6_upgrade_service.get_upgrade(upgrade_id)
+    if identity is None:
+        return None
+
+    stats = btd6_stats_service.get_tower_stats(identity.tower_id)
+    tier = stats.tier(identity.code) if stats is not None else None
+    game_version = stats.game_version if stats is not None else ""
+
+    if tier is None:
+        return UpgradeDetail(
+            identity=identity,
+            game_version=game_version,
+            normal=None,
+            attacks=(),
+            subtowers=(),
+            abilities=(),
+            buffs=(),
+            zones=(),
+        )
+
+    return UpgradeDetail(
+        identity=identity,
+        game_version=game_version,
+        normal=btd6_stats_service.normal_stats(tier),
+        attacks=tuple(_attack(a) for a in tier.get("attacks", [])),
+        subtowers=tuple(_subtower(s) for s in tier.get("subtowers", [])),
+        abilities=tuple(_ability(a) for a in tier.get("abilities", [])),
+        buffs=tuple(_buff_text(b) for b in tier.get("buffs", [])),
+        zones=tuple(_zone_text(z) for z in tier.get("zones", [])),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Grounding renderer
+# ---------------------------------------------------------------------------
+
+
+def _cap(line: str) -> str:
+    return line if len(line) <= _MAX_LINE else line[: _MAX_LINE - 1] + "…"
+
+
+def _projectile_bits(proj: ProjectileSpec) -> str:
+    bits: list[str] = []
+    if proj.damage is not None:
+        dmg = (
+            f"{proj.damage:,} dmg"
+            if isinstance(proj.damage, int)
+            else f"{proj.damage} dmg"
+        )
+        if proj.damage_type and proj.damage_type != "Normal":
+            note = f", {proj.cannot_pop}" if proj.cannot_pop else ""
+            dmg += f" ({proj.damage_type}{note})"
+        bits.append(dmg)
+    if proj.pierce is not None:
+        bits.append(
+            (
+                f"{proj.pierce:,} pierce"
+                if isinstance(proj.pierce, int)
+                else f"{proj.pierce} pierce"
+            ),
+        )
+    if proj.moab_bonus:
+        bits.append(f"+{proj.moab_bonus} vs MOAB-class")
+    return ", ".join(bits)
+
+
+def _attack_bits(attack: AttackSpec) -> str:
+    projs = attack.projectiles
+    if len(projs) == 1:
+        body = _projectile_bits(projs[0])
+    else:
+        body = "; ".join(
+            f"{p.name} ({pb})" for p in projs[:4] if (pb := _projectile_bits(p))
+        )
+    tail: list[str] = []
+    if attack.cooldown is not None:
+        tail.append(f"{attack.cooldown}s cooldown")
+    tail.append("sees Camo" if attack.can_see_camo else "no Camo detection")
+    return ", ".join([b for b in (body,) if b] + tail)
+
+
+def render_upgrade_grounding(detail: UpgradeDetail) -> list[str]:
+    """``[btd6_upgrade]`` grounding fact lines for one upgrade, AI-ready."""
+    idy = detail.identity
+    name = idy.canonical
+    path = _PATH_LABEL.get(idy.path, idy.path)
+    src = f" (source: bloonswiki{f' {detail.game_version}' if detail.game_version else ''})"
+    cost = f", cost ${idy.cost:,}" if idy.cost else ""
+    lines = [
+        _cap(
+            f"[btd6_upgrade] {name} = {idy.tower_name} {idy.crosspath} "
+            f"(tier {idy.tier}, {path} path){cost}.{src}",
+        ),
+    ]
+
+    if not detail.has_combat_stats:
+        if detail.normal is None:
+            lines.append(f"[btd6_upgrade] {name}: no per-tier combat stats on file.")
+        return lines
+
+    for attack in detail.attacks[:6]:
+        bits = _attack_bits(attack)
+        if bits:
+            label = "main attack" if attack.name == "Attack" else attack.name
+            lines.append(_cap(f"[btd6_upgrade] {name} — {label}: {bits}."))
+
+    for sub in detail.subtowers[:3]:
+        inner = "; ".join(b for a in sub.attacks[:2] if (b := _attack_bits(a)))
+        if inner:
+            lines.append(_cap(f"[btd6_upgrade] {name} — {sub.name} (minion): {inner}."))
+        else:
+            lines.append(f"[btd6_upgrade] {name} spawns {sub.name} (minion).")
+
+    if detail.abilities:
+        ability = detail.abilities[0]
+        ability_bits: list[str] = []
+        if ability.cooldown is not None:
+            ability_bits.append(f"{ability.cooldown}s cooldown")
+        if ability.lifespan is not None:
+            ability_bits.append(f"{ability.lifespan}s duration")
+        suffix = f": {', '.join(ability_bits)}" if ability_bits else ""
+        lines.append(f"[btd6_upgrade] {name} — activated ability{suffix}.")
+
+    for buff in detail.buffs[:4]:
+        lines.append(_cap(f"[btd6_upgrade] {name} — buff: {buff}."))
+
+    if detail.zones:
+        joined = "; ".join(detail.zones[:4])
+        lines.append(_cap(f"[btd6_upgrade] {name} — zones: {joined}."))
+
+    return lines
+
+
+def grounding_for_query(query: str) -> list[str]:
+    """Resolve ``query`` to an upgrade and render its grounding (the wiring seam).
+
+    Returns the fact lines for a confident match, a single clarification line
+    for an ambiguous reference, or ``[]`` for no match — so a caller can splice
+    the result straight into the grounding context.
+    """
+    res = btd6_upgrade_service.resolve_upgrade(query)
+    if res.match_type == "ambiguous":
+        names = ", ".join(c.canonical for c in res.candidates[:6])
+        return [
+            f"[btd6_upgrade] Ambiguous upgrade reference — did you mean: {names}?",
+        ]
+    if res.upgrade is None:
+        return []
+    detail = get_upgrade_detail(res.upgrade.upgrade_id)
+    return render_upgrade_grounding(detail) if detail is not None else []
+
+
+__all__ = [
+    "AbilitySpec",
+    "AttackSpec",
+    "ProjectileSpec",
+    "SubtowerSpec",
+    "UpgradeDetail",
+    "get_upgrade_detail",
+    "grounding_for_query",
+    "render_upgrade_grounding",
+]

--- a/tests/unit/services/test_btd6_context_grounding.py
+++ b/tests/unit/services/test_btd6_context_grounding.py
@@ -85,7 +85,8 @@ def test_render_fact_omits_url_fields_even_when_present_in_body():
     assert "https://" not in rendered.replace(
         # the only legitimate URL fragment is the source label itself,
         # but we use a plain domain there (no scheme).
-        "data.ninjakiwi.com", "",
+        "data.ninjakiwi.com",
+        "",
     )
 
 
@@ -273,3 +274,48 @@ async def test_build_caps_renderer_output_at_240_chars(monkeypatch):
     ctx = await btd6_context_service.build("text")
     assert len(ctx.facts) == 1
     assert len(ctx.facts[0]) <= 240
+
+
+# ---------------------------------------------------------------------------
+# build() upgrade grounding — the live failures from #444/#445 wired in
+# ---------------------------------------------------------------------------
+
+
+async def test_build_grounds_upgrade_by_abbreviation_without_tower():
+    # "POD" alone used to return no facts ("I don't have verified data for POD").
+    ctx = await btd6_context_service.build("POD cooldown")
+    blob = "\n".join(ctx.facts)
+    assert "[btd6_upgrade] Prince of Darkness" in blob
+    assert "Wizard Monkey 0-0-5" in blob
+    assert "0.275s cooldown" in blob
+
+
+async def test_build_grounds_upgrade_minion_pierce_detail():
+    ctx = await btd6_context_service.build("Prince of Darkness minion pierce?")
+    blob = "\n".join(ctx.facts)
+    reanimate = next(line for line in ctx.facts if "Reanimate" in line)
+    assert "1 pierce" in reanimate
+    assert "Undead Bloon buff" in blob
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ("BEZ", "Bloon Exclusion Zone"),
+        ("What are the stats for the MAD", "M.A.D"),
+        ("What are PMFC's stats?", "Plasma Monkey Fan Club"),
+        ("Prince of Darkness", "Prince of Darkness"),
+        ("050 dart", "Plasma Monkey Fan Club"),
+    ],
+)
+async def test_build_grounds_reported_upgrade_queries(query, expected):
+    ctx = await btd6_context_service.build(query)
+    assert any(
+        f.startswith("[btd6_upgrade]") and expected in f for f in ctx.facts
+    ), f"{query!r} did not ground {expected!r}: {ctx.facts}"
+
+
+async def test_build_ignores_non_upgrade_text():
+    # A plain greeting must not spuriously ground an upgrade.
+    ctx = await btd6_context_service.build("hello there")
+    assert not any(f.startswith("[btd6_upgrade]") for f in ctx.facts)

--- a/tests/unit/services/test_btd6_upgrade_detail_service.py
+++ b/tests/unit/services/test_btd6_upgrade_detail_service.py
@@ -1,0 +1,137 @@
+"""Structured upgrade-detail read model + grounding renderer.
+
+Pins the deep, per-attack/minion/buff extraction that the normal-stat view
+can't express — in particular the reported *"Prince of Darkness minion
+pierce?"* (1, from the Reanimate attack, not the main projectile) — and the
+resolve -> detail -> render grounding seam end to end.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from services import btd6_stats_service
+from services import btd6_upgrade_detail_service as det
+from services import btd6_upgrade_service as up
+
+
+@pytest.fixture(autouse=True)
+def _fresh():
+    up.reset_cache()
+    btd6_stats_service.reset_cache()
+    yield
+    up.reset_cache()
+    btd6_stats_service.reset_cache()
+
+
+def _attack(detail, name):
+    return next((a for a in detail.attacks if a.name == name), None)
+
+
+def test_prince_of_darkness_detail():
+    d = det.get_upgrade_detail("wizard_monkey:005")
+    assert d is not None
+    assert d.identity.canonical == "Prince of Darkness"
+    assert d.has_combat_stats
+    # The headline normal view keys off the highest-DAMAGE projectile, which for
+    # PoD is the reanimated BFB (100 dmg / 50 pierce) — a known quirk of that
+    # distilled view, and exactly why the per-attack detail below matters.
+    assert d.normal is not None
+    assert d.normal.cooldown == 0.275
+    assert (d.normal.damage, d.normal.pierce) == (100, 50)
+    # Every named attack stays addressable, including MOAB-reanimation.
+    names = {a.name for a in d.attacks}
+    assert {"Attack", "Reanimate", "MOAB"} <= names
+    # The actual main attack (1 dmg, 8 pierce) is not lost to the headline.
+    main = _attack(d, "Attack")
+    assert main.projectiles[0].damage == 1
+    assert main.projectiles[0].pierce == 8
+
+
+def test_prince_of_darkness_minion_pierce_is_one():
+    # The marquee failure: the answer lives on Reanimate, not the main attack.
+    d = det.get_upgrade_detail("wizard_monkey:005")
+    reanimate = _attack(d, "Reanimate")
+    assert reanimate is not None
+    assert reanimate.projectiles[0].pierce == 1
+    assert reanimate.projectiles[0].damage == 2
+
+
+def test_prince_of_darkness_buff_and_moab_projectiles():
+    d = det.get_upgrade_detail("wizard_monkey:005")
+    assert any("Undead Bloon buff" in b for b in d.buffs)
+    assert any("+3 damage" in b and "x1.5 lifespan" in b for b in d.buffs)
+    moab = _attack(d, "MOAB")
+    proj = {p.name: (p.damage, p.pierce) for p in moab.projectiles}
+    assert proj["MOAB"] == (40, 20)
+    assert proj["BFB"] == (100, 50)
+
+
+def test_subtower_minion_is_exposed():
+    # Alchemist 0-5-0 (Total Transformation) spawns Transformed Monkey.
+    d = det.get_upgrade_detail("alchemist:050")
+    assert d is not None
+    assert any(s.name == "Transformed Monkey" for s in d.subtowers)
+    assert "subtowers" in d.coverage
+
+
+def test_ability_and_zone_sections():
+    sup = det.get_upgrade_detail("super_monkey:050")  # The Anti-Bloon
+    assert sup is not None and sup.abilities
+    assert sup.abilities[0].cooldown == 30
+
+    druid = det.get_upgrade_detail("druid:050")  # Spirit of the Forest
+    assert druid is not None and druid.zones
+    assert any("Thorn zone" in z for z in druid.zones)
+
+
+def test_economy_upgrade_has_identity_but_no_combat():
+    # Monkey-Nomics (banana farm 0-5-0): real upgrade, no combat tiers.
+    d = det.get_upgrade_detail("banana_farm:050")
+    assert d is not None
+    assert d.identity.canonical == "Monkey-Nomics"
+    assert not d.has_combat_stats
+    assert d.attacks == ()
+
+
+def test_unknown_id_returns_none():
+    assert det.get_upgrade_detail("does_not:999") is None
+
+
+def test_render_grounding_surfaces_minion_pierce():
+    d = det.get_upgrade_detail("wizard_monkey:005")
+    lines = det.render_upgrade_grounding(d)
+    blob = "\n".join(lines)
+    assert all(line.startswith("[btd6_upgrade]") for line in lines)
+    # Identity line carries tower / crosspath / cost.
+    assert "Prince of Darkness = Wizard Monkey 0-0-5" in blob
+    assert "$26,500" in blob
+    # The Reanimate line makes "minion pierce" answerable.
+    reanimate_line = next(line for line in lines if "Reanimate" in line)
+    assert "1 pierce" in reanimate_line
+    assert "Undead Bloon buff" in blob
+
+
+def test_grounding_for_query_end_to_end():
+    # Natural-language query -> resolve -> detail -> grounding, no tower named.
+    lines = det.grounding_for_query("Prince of Darkness minion pierce?")
+    blob = "\n".join(lines)
+    assert "[btd6_upgrade] Prince of Darkness" in blob
+    assert "1 pierce" in blob
+
+    pmfc = det.grounding_for_query("PMFC stats")
+    assert any("Plasma Monkey Fan Club" in line for line in pmfc)
+
+    pod = "\n".join(det.grounding_for_query("POD cooldown"))
+    assert "0.275s cooldown" in pod
+
+
+def test_grounding_for_query_ambiguous_and_miss():
+    ambiguous = det.grounding_for_query("wizard lord phoenix vs prince of darkness")
+    assert len(ambiguous) == 1
+    assert "Ambiguous upgrade reference" in ambiguous[0]
+    assert "Wizard Lord Phoenix" in ambiguous[0]
+    assert "Prince of Darkness" in ambiguous[0]
+
+    assert det.grounding_for_query("what is the best tower") == []
+    assert det.grounding_for_query("") == []


### PR DESCRIPTION
## What this fixes
After #444 merged, the live bot **still** couldn't answer `POD`, `BEZ`, `MAD`, or `Prince of Darkness` — it returned *"I don't have verified data for POD."* Because #444 (resolver) and the first commit here (detail layer) were **purely additive**, nothing in the live AI path called them. This PR adds the detail layer **and wires it in**, so the reported queries resolve end‑to‑end.

## Two commits

**1 — Upgrade detail read model** (`services/btd6_upgrade_detail_service.py`)
`UpgradeDetail` joins `UpgradeIdentity` → per‑tier combat data: every named **attack** with its **projectiles**, spawned **subtowers** ("minions"), **abilities**, **buffs**, **zones**, plus a `coverage` list. Ships `render_upgrade_grounding()` and `grounding_for_query()` (resolve → detail → render; confident match → facts, ambiguous → one clarification line, miss → `[]`).

**2 — Wiring** (`btd6_context_service.build`)
A new isolated **Pass 3c** calls `grounding_for_query(message_text)` and appends `[btd6_upgrade]` facts. Lazy import + defensive try/except, consistent with the existing passes; runs outside the DB block so it works without live ingestion. `btd6_lookup` surfaces it for free (it wraps `build`).

## Now resolving live (example: Prince of Darkness)
```
[btd6_upgrade] Prince of Darkness = Wizard Monkey 0-0-5 (tier 5, bottom path), cost $26,500.
[btd6_upgrade] Prince of Darkness — main attack: 1 dmg, 8 pierce, 0.275s cooldown, sees Camo.
[btd6_upgrade] Prince of Darkness — Reanimate: 2 dmg, 1 pierce, 1.5s cooldown, no Camo detection.   ← minion pierce = 1
[btd6_upgrade] Prince of Darkness — buff: Undead Bloon buff: +3 damage, x1.5 lifespan.
```
…and `PMFC`, `POD`, `BEZ`, `MAD`, `Wizard Lord Phoenix`, `wizard 005` / `050 dart`.

## Tests
- Detail model (10): minion pierce = 1, MOAB reanimation, buffs, subtower/ability/zone sections, economy upgrade, ambiguity/miss seam.
- `build()` end‑to‑end (9): every reported failure (POD/BEZ/MAD/PMFC/full name/path notation) + the minion‑pierce detail + a greeting grounding no upgrade.

`check_quality.py --full` green (lint + mypy + **6943 tests**), `check_architecture --mode strict` 0 errors.

## ⚠️ Needs a redeploy
The screenshots are the running bot. Merging this fixes the code, but the **bot must be redeployed** to pick it up.

## Notes / your call
- **Curated alias list** (`_CURATED_ALIASES`) is maintainer‑owned — easy to extend.
- Existing quirk (not changed): the normal‑stat headline for Prince of Darkness shows **100 dmg / 50 pierce** (the reanimated BFB) as "tower damage" — misleading. The detail layer side‑steps it; fixing `_main_projectile` in `btd6_stats_service` is a separate call.

https://claude.ai/code/session_01EVXenpTc3mbfzeTMNCfUXk