### PR TITLE
BTD6: curated paragon abilities + make them AI-searchable

### DIFF
--- a/disbot/data/btd6/paragon_abilities.json
+++ b/disbot/data/btd6/paragon_abilities.json
@@ -1,0 +1,145 @@
+{
+  "_comment": "Curated paragon ability names + explanations. The fetched stats module (Module:BTD6_stats) carries ability cooldowns but no prose, and a few abilities are unnamed there ('Ability'); the names + descriptions here are paraphrased from each paragon's bloonswiki article and kept in this separate committed file so a stats re-fetch never clobbers them (same pattern as paragon_descriptions.json). 'kind' is 'activated' (player-triggered, has a cooldown) or 'passive' (always-on / auto-triggered).",
+  "source": "bloonswiki.com (CC BY-NC-SA), paraphrased",
+  "abilities": {
+    "apex_plasma_master": [],
+    "ascended_shadow": [
+      {
+        "name": "Grand Saboteur",
+        "kind": "passive",
+        "cooldown": null,
+        "description": "While on screen, passively debuffs every Bloon: all Bloons except BADs and Bosses move 50% slower, and all MOAB-class Bloons except Bosses have 25% less health per layer."
+      },
+      {
+        "name": "Camo support buffs",
+        "kind": "passive",
+        "cooldown": null,
+        "description": "Grants Camo detection to every tower on screen (including other Paragons), gives all other Ninja Monkeys +10 range, and grants Ninjas in range a free Shinobi Tactics stack."
+      }
+    ],
+    "ballistic_obliteration_missile_bunker": [
+      {
+        "name": "ISABM",
+        "kind": "activated",
+        "cooldown": 30,
+        "description": "Fires an Indomitable Surface-to-Air Ballistic Missile that seeks a target using the BOMB's targeting, ignoring line of sight and with infinite range. It moves slowly but turns sharply, drops a small pushback explosion every 0.25s, and detonates on its target or after 9 seconds; it cannot be reactivated until the missile expires."
+      },
+      {
+        "name": "Blitz Tactical Storm",
+        "kind": "passive",
+        "cooldown": 120,
+        "description": "Auto-triggers when you lose a life or Bloons try to leak: hits every Bloon on screen (including Camo), instantly destroying any Bloon type except MOAB Test and Golden Bloons, and dealing 20,000 damage to BADs and Bosses. Base cooldown 120s."
+      }
+    ],
+    "crucible_of_steel_and_flame": [
+      {
+        "name": "Maelstrom",
+        "kind": "activated",
+        "cooldown": 20,
+        "description": "Multiplies the lifespan of all its attacks by 2.5x and adds a Ring-of-Fire-style flame ring (high pierce, bonus Boss damage) for 9 seconds. Base cooldown 20s."
+      },
+      {
+        "name": "Meteor Impact",
+        "kind": "activated",
+        "cooldown": 60,
+        "description": "Calls down a meteor that pursues a Bloon by targeting priority and explodes into 32 homing fireballs that can re-hit Bloons. Base cooldown 60s."
+      }
+    ],
+    "glaive_dominus": [
+      {
+        "name": "Overcharge",
+        "kind": "activated",
+        "cooldown": 45,
+        "description": "Grants 10 stacks of Overcharge that sharply raise attack speed (up to +187%). One stack is lost every 3 seconds, fading over 30s, and it can be reactivated while charges remain. Base cooldown 45s."
+      }
+    ],
+    "goliath_doomship": [
+      {
+        "name": "Carpet Bomb",
+        "kind": "activated",
+        "cooldown": 60,
+        "description": "Saturates the track with bombing volleys: 12 non-homing missiles that pierce multiple Bloons and explode when they expire, plus 8 homing missiles that seek MOAB-class targets. Base cooldown 60s."
+      }
+    ],
+    "herald_of_everfrost": [
+      {
+        "name": "Eclipse of Fimbulwinter",
+        "kind": "activated",
+        "cooldown": 90,
+        "description": "Darkens the whole map for 25 seconds and applies three effects to every Bloon: a global slow (Bosses -5%, BADs -10%, others -30%), a freeze applied 5s in (10s, half-duration on BADs/Bosses), and a permafrost slow (regular -75%, MOAB-class -50%). Base cooldown 90s."
+      }
+    ],
+    "magus_perfectus": [
+      {
+        "name": "Phoenix Explosion",
+        "kind": "activated",
+        "cooldown": 40,
+        "description": "Internally 'Phoenix Rebirth'. Consumes all mana to detonate the Dark Phoenix, dealing damage over time within 100 units (every 0.5s for 30s) and spawning one Undead ZOMG per 9,000 mana spent (up to 10). Cannot damage Purple Bloons or Blastapopoulos. Base cooldown 40s."
+      },
+      {
+        "name": "Arcane Metamorphosis",
+        "kind": "activated",
+        "cooldown": 90,
+        "description": "Merges the Phoenix into the Magus, replacing the main attack with two stronger attacks: a twin flame cascade and one that leaves Walls of Fire on the track. Drains 4,000 mana per second while active. Base cooldown 90s."
+      }
+    ],
+    "master_builder": [
+      {
+        "name": "Mega Sentry",
+        "kind": "activated",
+        "cooldown": 20,
+        "description": "Places a Sentry Paragon sub-tower anywhere on the map, cycling Green (persistent laser), Red (plasma streams), then Blue (explosive missiles) on successive uses. Each Mega Sentry also periodically spawns temporary Modified Sentry Paragons. Base cooldown 20s."
+      },
+      {
+        "name": "Power Glove",
+        "kind": "activated",
+        "cooldown": 60,
+        "description": "A stronger Overclock that can target other Paragons (not itself) and also buffs nearby non-Paragon towers, granting +66.67% attack speed (plus +15% range to Villages and +66.67% production to Farms). Base cooldown 60s."
+      }
+    ],
+    "mega_massive_munitions_factory": [
+      {
+        "name": "Controlled Burst",
+        "kind": "activated",
+        "cooldown": 15,
+        "description": "Quadruples the main attack's speed for 15 seconds. Base cooldown 15s; usable once per round."
+      },
+      {
+        "name": "Spikeageddon",
+        "kind": "activated",
+        "cooldown": 75,
+        "description": "Launches up to 25 land mines across each path, spreading them from the exit toward the entrance to blanket the track in spikes. Base cooldown 75s."
+      }
+    ],
+    "nautic_siege_core": [
+      {
+        "name": "Final Strike",
+        "kind": "activated",
+        "cooldown": 240,
+        "description": "Begins a 15-second countdown (pausing between rounds) that disables its other attacks, then launches three Camo-capable missiles at First, Close, and Strong targets. Each impact deals heavy damage, a stunning aftershock (15s, except BADs/Bosses), and leaves radioactive fallout pools that burn passing Bloons. Base cooldown 240s."
+      }
+    ],
+    "navarch_of_the_seas": [
+      {
+        "name": "Grappling Hook",
+        "kind": "activated",
+        "cooldown": 30,
+        "description": "Fires a giant grappling hook that instantly takes down the strongest MOAB-class Bloon on screen, including BADs (but not Dreadrock Bloons). Base cooldown 30s, usable twice per round. Separate from its ten passive auto-grappling hooks."
+      }
+    ],
+    "root_of_all_nature": [
+      {
+        "name": "Primordial Wrath",
+        "kind": "activated",
+        "cooldown": 9,
+        "description": "Toggles between Elemental and Wrathful modes. In Wrathful mode the Paragon gains +35% range, 80% tighter shot spread, and an Avatar-of-Wrath-style damage boost that scales with on-screen leak damage (up to 5x). Short 9s cooldown."
+      },
+      {
+        "name": "Jungle's Bounty",
+        "kind": "passive",
+        "cooldown": null,
+        "description": "At the end of each round, when a BAD is popped, or when a Boss Skull is broken, generates 1 life and $120 cash, boosted by nearby Banana Farms and Storm Trees up to a $10,000 cap."
+      }
+    ]
+  }
+}

--- a/disbot/services/btd6_context_service.py
+++ b/disbot/services/btd6_context_service.py
@@ -362,7 +362,31 @@ def _render_paragon(tower_id: str, canonical: str) -> list[str]:
         # cost line above already establish the source, so keep this line lean
         # (the per-fact cap would otherwise truncate a trailing attribution).
         lines.append(_cap(f"[btd6_paragon] {name} — {_sanitise(pstats.description)}"))
+    if pstats is not None:
+        lines.extend(_render_paragon_abilities(name, pstats))
     lines.extend(_render_paragon_stats(tower_id, name))
+    return lines
+
+
+def _render_paragon_abilities(name: str, pstats: Any) -> list[str]:
+    """``[btd6_paragon]`` ability lines for a paragon (curated from bloonswiki).
+
+    One line per named ability so the assistant can answer "what does <ability>
+    do / what's its cooldown" without guessing. A paragon with no activated
+    ability (e.g. Apex Plasma Master) gets a single explicit line so the model
+    states that rather than inventing one.
+    """
+    abilities = getattr(pstats, "abilities", ()) or ()
+    if not abilities:
+        return [f"[btd6_paragon] {name} has no activated ability."]
+    lines: list[str] = []
+    for ability in abilities:
+        if ability.kind == "passive":
+            head = f"[btd6_paragon] {name} passive — {ability.name}"
+        else:
+            cd = f" ({ability.cooldown}s cooldown)" if ability.cooldown else ""
+            head = f"[btd6_paragon] {name} ability — {ability.name}{cd}"
+        lines.append(_cap(f"{head}: {_sanitise(ability.description)}"))
     return lines
 
 
@@ -965,15 +989,28 @@ def _paragon_name_facts(message_text: str, resolved_tower_ids: set[str]) -> list
 
     text = (message_text or "").lower()
     out: list[str] = []
+    grounded: set[str] = set(resolved_tower_ids)
     for paragon in paragon_math.PARAGONS:
         # Strip a parenthetical (e.g. "… (B.O.M.B.)") and match the bare name.
         name = paragon.name.split(" (")[0].strip().lower()
         if not name or name not in text:
             continue
         pstats = btd6_stats_service.get_paragon_stats(paragon.paragon_id)
-        if pstats is None or pstats.tower_id in resolved_tower_ids:
+        if pstats is None or pstats.tower_id in grounded:
             continue
+        grounded.add(pstats.tower_id)
         out.extend(_render_paragon(pstats.tower_id, pstats.tower_canonical))
+
+    # A paragon ABILITY named directly (e.g. "Spikeageddon cooldown", "what does
+    # Final Strike do") — the names are distinctive, so a full-name substring
+    # match grounds the owning paragon (and its ability lines) without false hits.
+    for paragon_id in btd6_stats_service.list_paragon_ids():
+        pstats = btd6_stats_service.get_paragon_stats(paragon_id)
+        if pstats is None or pstats.tower_id in grounded:
+            continue
+        if any(ab.name and ab.name.lower() in text for ab in pstats.abilities):
+            grounded.add(pstats.tower_id)
+            out.extend(_render_paragon(pstats.tower_id, pstats.tower_canonical))
     return out
 
 

--- a/disbot/services/btd6_stats_service.py
+++ b/disbot/services/btd6_stats_service.py
@@ -119,6 +119,16 @@ class HeroStats:
 
 
 @dataclass(frozen=True)
+class ParagonAbility:
+    """One named paragon ability (activated or passive), curated from the wiki."""
+
+    name: str
+    kind: str  # "activated" | "passive"
+    cooldown: int | None  # seconds, for activated abilities
+    description: str
+
+
+@dataclass(frozen=True)
 class ParagonStats:
     """All stored stats for one paragon (lazy-loaded).
 
@@ -142,6 +152,7 @@ class ParagonStats:
     base: dict[str, Any]
     source: str = ""
     description: str = ""
+    abilities: tuple[ParagonAbility, ...] = ()
 
     @property
     def has_combat_stats(self) -> bool:
@@ -226,6 +237,10 @@ _PARAGON_DESCRIPTIONS_PATH = (
     Path(__file__).resolve().parents[1] / "data" / "btd6" / "paragon_descriptions.json"
 )
 _PARAGON_DESCRIPTIONS: dict[str, str] | None = None
+_PARAGON_ABILITIES_PATH = (
+    Path(__file__).resolve().parents[1] / "data" / "btd6" / "paragon_abilities.json"
+)
+_PARAGON_ABILITIES: dict[str, tuple[ParagonAbility, ...]] | None = None
 
 
 def _descriptions() -> dict[str, str]:
@@ -245,6 +260,35 @@ def _descriptions() -> dict[str, str]:
     return _PARAGON_DESCRIPTIONS
 
 
+def _abilities() -> dict[str, tuple[ParagonAbility, ...]]:
+    """Curated paragon ability names + explanations (paraphrased; cached).
+
+    Like the overviews, kept in a separate committed file (the fetched stats
+    module carries cooldowns but no prose, and a few abilities are unnamed
+    there) so a stats re-fetch never clobbers it.
+    """
+    global _PARAGON_ABILITIES
+    if _PARAGON_ABILITIES is None:
+        index: dict[str, tuple[ParagonAbility, ...]] = {}
+        try:
+            data = json.loads(_PARAGON_ABILITIES_PATH.read_text(encoding="utf-8"))
+            for paragon_id, rows in (data.get("abilities") or {}).items():
+                index[paragon_id] = tuple(
+                    ParagonAbility(
+                        name=str(row.get("name", "")),
+                        kind=str(row.get("kind", "activated")),
+                        cooldown=row.get("cooldown"),
+                        description=str(row.get("description", "")),
+                    )
+                    for row in rows
+                    if row.get("name")
+                )
+        except (OSError, ValueError):
+            index = {}
+        _PARAGON_ABILITIES = index
+    return _PARAGON_ABILITIES
+
+
 def _load_paragon(paragon_id: str) -> ParagonStats | None:
     path = PARAGON_STATS_ROOT / f"{paragon_id}.json"
     if not path.exists():
@@ -262,6 +306,7 @@ def _load_paragon(paragon_id: str) -> ParagonStats | None:
         base=data.get("base", {}),
         source=str(data.get("source", "")),
         description=_descriptions().get(data.get("paragon_id", paragon_id), ""),
+        abilities=_abilities().get(data.get("paragon_id", paragon_id), ()),
     )
 
 
@@ -300,12 +345,13 @@ def get_paragon_stats_by_tower(tower_id: str) -> ParagonStats | None:
 
 def reset_cache() -> None:
     """Test seam: drop the loaded-stats caches."""
-    global _PARAGON_BY_TOWER, _PARAGON_DESCRIPTIONS
+    global _PARAGON_BY_TOWER, _PARAGON_DESCRIPTIONS, _PARAGON_ABILITIES
     _CACHE.clear()
     _HERO_CACHE.clear()
     _PARAGON_CACHE.clear()
     _PARAGON_BY_TOWER = None
     _PARAGON_DESCRIPTIONS = None
+    _PARAGON_ABILITIES = None
 
 
 # ---------------------------------------------------------------------------
@@ -414,6 +460,7 @@ def normal_stats(tier: dict[str, Any]) -> NormalStats:
 __all__ = [
     "HeroStats",
     "NormalStats",
+    "ParagonAbility",
     "ParagonStats",
     "TowerStats",
     "get_hero_stats",

--- a/tests/unit/services/test_btd6_context_grounding.py
+++ b/tests/unit/services/test_btd6_context_grounding.py
@@ -319,3 +319,30 @@ async def test_build_ignores_non_upgrade_text():
     # A plain greeting must not spuriously ground an upgrade.
     ctx = await btd6_context_service.build("hello there")
     assert not any(f.startswith("[btd6_upgrade]") for f in ctx.facts)
+
+
+# ---------------------------------------------------------------------------
+# build() paragon ability grounding (curated from bloonswiki)
+# ---------------------------------------------------------------------------
+
+
+async def test_build_grounds_paragon_abilities_by_paragon_name():
+    ctx = await btd6_context_service.build("Magus Perfectus abilities")
+    blob = "\n".join(ctx.facts)
+    assert "Phoenix Explosion" in blob
+    assert "Arcane Metamorphosis" in blob
+    assert "40s cooldown" in blob
+
+
+async def test_build_grounds_paragon_by_ability_name():
+    # Naming only the ability grounds the owning paragon — searchable abilities.
+    ctx = await btd6_context_service.build("what is Spikeageddon's cooldown")
+    assert any(
+        "Mega Massive Munitions Factory" in f and "Spikeageddon" in f and "75s" in f
+        for f in ctx.facts
+    ), ctx.facts
+
+
+async def test_build_states_apex_plasma_master_has_no_ability():
+    ctx = await btd6_context_service.build("does Apex Plasma Master have an ability")
+    assert any("no activated ability" in f for f in ctx.facts)

--- a/tests/unit/services/test_btd6_stats_service.py
+++ b/tests/unit/services/test_btd6_stats_service.py
@@ -52,6 +52,35 @@ def test_normal_stats_bloon_crush_flips_to_normal_and_stuns():
     assert any("Stun" in s for s in ns.specials)
 
 
+def test_paragon_abilities_load_named_with_cooldowns():
+    mp = svc.get_paragon_stats("magus_perfectus")
+    assert [a.name for a in mp.abilities] == ["Phoenix Explosion", "Arcane Metamorphosis"]
+    assert mp.abilities[0].kind == "activated"
+    assert mp.abilities[0].cooldown == 40
+    assert "Phoenix Rebirth" in mp.abilities[0].description  # internal-name note kept
+    # Apex Plasma Master genuinely has no activated ability — curated as empty.
+    assert svc.get_paragon_stats("apex_plasma_master").abilities == ()
+
+
+def test_every_paragon_has_curated_abilities_with_real_names():
+    # The curated file must cover every paragon and never leave a generic name:
+    # the stats module had four unnamed 'Ability' nodes (Glaive Dominus, Goliath
+    # Doomship, Nautic Siege Core, Navarch) which must now carry real names.
+    ids = set(svc.list_paragon_ids())
+    assert set(svc._abilities()) == ids  # exactly the 13 paragons, no stray ids
+    for pid in (
+        "glaive_dominus",
+        "goliath_doomship",
+        "nautic_siege_core",
+        "navarch_of_the_seas",
+        "herald_of_everfrost",  # was prose-only, no abilities at all before
+        "root_of_all_nature",
+    ):
+        abilities = svc.get_paragon_stats(pid).abilities
+        assert abilities, pid
+        assert all(a.name and a.name != "Ability" for a in abilities), pid
+
+
 def test_normal_stats_excludes_reanimated_minions_for_prince_of_darkness():
     # Prince of Darkness (wizard 0-0-5) fires reanimated "MOAB"/"BFB" projectiles
     # (40/100 dmg). Those are minions, not the tower's hit, so the headline must


### PR DESCRIPTION
## What & why
Paragon abilities couldn't ground anything: the fetched stats module (`Module:BTD6_stats`) carries ability **cooldowns but no prose**, four abilities were left unnamed (`"Ability"`), and the two prose-sourced paragons (Herald of Everfrost, Root of all Nature) had **no abilities at all**. So "what does Spikeageddon do?" or "Magus Perfectus abilities" had nothing verified to answer from.

I researched all 13 paragon articles on bloonswiki and curated their abilities into the data, then wired them into grounding and made them searchable by name.

## Data — `data/btd6/paragon_abilities.json` (new)
Every paragon's abilities as `name + kind (activated/passive) + cooldown + paraphrased description`, kept in a **separate committed file** so a stats re-fetch never clobbers it (same pattern as `paragon_descriptions.json`, same CC BY-NC-SA attribution).
- **13 paragons, 19 abilities.**
- The 4 previously-unnamed `"Ability"` nodes now have real names — **Overcharge** (Glaive Dominus), **Carpet Bomb** (Goliath Doomship), **Final Strike** (Nautic Siege Core), **Grappling Hook** (Navarch).
- The 2 prose-only paragons gained their abilities — **Eclipse of Fimbulwinter** (Herald), **Primordial Wrath** (Root).
- **Apex Plasma Master** is recorded as having *no activated ability* (it genuinely has none) so the bot states that instead of inventing one.
- Cooldowns reconcile with the stats module across the board.

## Code
- `btd6_stats_service`: `ParagonAbility` model + cached loader; `ParagonStats.abilities`.
- `btd6_context_service`:
  - `_render_paragon` emits an ability line per ability for any paragon query.
  - `_paragon_name_facts` now also grounds a paragon when an **ability is named directly** — so `"Spikeageddon cooldown"` → Mega Massive Munitions Factory, `"what does Final Strike do"` → Nautic Siege Core. That's the "searchable abilities" part.

## Example grounding
```
[btd6_paragon] Magus Perfectus ability — Phoenix Explosion (40s cooldown): Internally 'Phoenix Rebirth'. Consumes all mana to detonate the Dark Phoenix …
[btd6_paragon] Magus Perfectus ability — Arcane Metamorphosis (90s cooldown): Merges the Phoenix into the Magus, replacing the main attack …
[btd6_paragon] Apex Plasma Master has no activated ability.
```

## Tests
Abilities load with real names + cooldowns; the curated file covers exactly the 13 paragons (no stray/typo'd ids); `build()` grounds abilities both by paragon name and by ability name; Apex grounds the explicit "no ability" line.

`check_quality.py --full` green (lint + mypy + **6949 tests**), `check_architecture --mode strict` 0 errors.

> Sourcing note: descriptions are paraphrased from bloonswiki (not verbatim), fetched via the same pipeline UA the repo already uses. Like the earlier PRs, the live bot needs a redeploy to pick this up.

https://claude.ai/code/session_01EVXenpTc3mbfzeTMNCfUXk

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVXenpTc3mbfzeTMNCfUXk)_