### PR TITLE
btd6: complete all six Frontier Legends bloon mechanics

### DIFF
--- a/disbot/data/btd6/bloons.json
+++ b/disbot/data/btd6/bloons.json
@@ -340,7 +340,10 @@
           "modifiers": []
         }
       ],
-      "properties": [],
+      "properties": [
+        "weak-to-fire-explosion",
+        "detonates"
+      ],
       "rbe": 55,
       "health": 30,
       "layers": 7,
@@ -350,7 +353,7 @@
         "dynamites",
         "dynamite bloon"
       ],
-      "description": ""
+      "description": "Frontier Legends DLC. Below 10 HP it turns unstable and detonates after a 3s countdown, stunning towers in the blast for 6s. Takes +1 damage from fire and explosion attacks."
     },
     {
       "id": "aura",
@@ -385,7 +388,9 @@
           "modifiers": []
         }
       ],
-      "properties": [],
+      "properties": [
+        "speed-aura"
+      ],
       "rbe": 85,
       "health": 40,
       "layers": 6,
@@ -395,7 +400,7 @@
         "auras",
         "aura bloon"
       ],
-      "description": ""
+      "description": "Frontier Legends DLC. Projects an aura (40-unit radius) that gives other Bloons inside it a 1.35x speed boost."
     },
     {
       "id": "glass",
@@ -428,7 +433,9 @@
           ]
         }
       ],
-      "properties": [],
+      "properties": [
+        "reflects-immune-projectiles"
+      ],
       "rbe": 89,
       "health": 20,
       "layers": 9,
@@ -438,7 +445,7 @@
         "glasss",
         "glass bloon"
       ],
-      "description": ""
+      "description": "Frontier Legends DLC. Reflects projectiles of the damage types it is immune to (Energy, Plasma, Acid). Among the fastest Bloons in the game."
     },
     {
       "id": "ceramic",
@@ -489,7 +496,9 @@
         }
       ],
       "properties": [
-        "knockback-immune"
+        "knockback-immune",
+        "movement-impairment-immune",
+        "stuns-attackers"
       ],
       "rbe": 138,
       "health": 100,
@@ -500,7 +509,7 @@
         "retributions",
         "retribution bloon"
       ],
-      "description": ""
+      "description": "Frontier Legends DLC. Every 5 hits it takes, it stuns that attacker for 1.5s; on pop it stuns the finishing tower for 6s. Immune to all movement impairment, like the BAD."
     },
     {
       "id": "ringleader",
@@ -515,7 +524,9 @@
           "modifiers": []
         }
       ],
-      "properties": [],
+      "properties": [
+        "projectile-barrier"
+      ],
       "rbe": 171,
       "health": 30,
       "layers": 9,
@@ -525,7 +536,7 @@
         "ringleaders",
         "ringleader bloon"
       ],
-      "description": ""
+      "description": "Frontier Legends DLC. Projects an 80-HP barrier that blocks shots and cuts their pierce to 0 for sheltered Bloons, which are then speed-capped. Regenerates 6s after breaking."
     },
     {
       "id": "diamond",

--- a/disbot/data/btd6/bloons.json
+++ b/disbot/data/btd6/bloons.json
@@ -543,6 +543,8 @@
         }
       ],
       "properties": [
+        "damage-capped",
+        "pierce-reduction",
         "knockback-immune"
       ],
       "rbe": 194,
@@ -554,7 +556,8 @@
         "diamonds",
         "diamond bloon"
       ],
-      "description": ""
+      "description": "Frontier Legends DLC. Each projectile that hits it loses 5 pierce. Immune to all movement impairment (slow, blowback, knockback, stun). Pops into 1 Fortified Ceramic Bloon.",
+      "popped_by": "any damage type, but each hit deals only 1 damage — always exactly 80 hits to pop regardless of attack power"
     },
     {
       "id": "moab",


### PR DESCRIPTION
## Problem

The bot confidently asserted **wrong** Diamond Bloon mechanics (*"they take normal damage"*) and argued the point — because the Diamond fixture had stats but an **empty description** and no recorded mechanics, so the AI filled the gap from a bad prior. Investigation showed **all six Frontier Legends DLC bloons** had the same gap: Dynamite, Aura, Glass, Retribution, Ringleader, Diamond.

## Fix

Completed the mechanics for all six (paraphrased from **bloonswiki.com**, CC BY-NC-SA), so the AI answers from verified data:

- **Diamond** — every hit is capped to 1 damage → **always exactly 80 hits to pop** regardless of attack power; projectiles lose 5 pierce; immune to all movement impairment; pops into 1 Fortified Ceramic.
- **Dynamite** — below 10 HP it counts down 3s then detonates, stunning towers in the blast for 6s; takes **+1 damage from fire/explosion**.
- **Aura** — projects a 40-unit aura giving nearby bloons a **1.35× speed boost**.
- **Glass** — **reflects projectiles** of the damage types it's immune to (Energy, Plasma, Acid); among the fastest bloons.
- **Retribution** — every 5 hits **stuns that attacker 1.5s**; on pop stuns the finishing tower 6s; immune to all movement impairment like the BAD.
- **Ringleader** — projects an **80-HP barrier** that blocks shots and cuts pierce to 0 for sheltered bloons (which are then speed-capped); regenerates.

Each entry gains a `description` (+ `popped_by` for Diamond) and a couple of trait `properties`. The **numeric fields** (health, RBE, children, layers, speed, and Glass's damage-type immunities) were already correct and are **unchanged**. Every rendered `[btd6_bloon]` grounding line stays within the 240-char fact cap (verified).

## Behavior note (intentionally unchanged)

The bot's tendency to *stick to its verified data and not cave to "you're wrong"* is left as-is — per maintainer direction, that's correct anti-hallucination behavior. The fix is the data, not the confidence.

## Gates
- `python3.10 scripts/check_quality.py --full` → **6987 passed**, 3 skipped
- `python3.10 scripts/check_architecture.py --mode strict` → exit 0

https://claude.ai/code/session_01EVXenpTc3mbfzeTMNCfUXk