### PR TITLE
BTD6 data backend: add Postgres (btd6_data_blobs) for fixtures + stats

### DIFF
--- a/disbot/config.py
+++ b/disbot/config.py
@@ -183,14 +183,18 @@ PARAGON_API_KEY = os.getenv("PARAGON_API_KEY", "")
 # ==========================
 # BTD6 deterministic data source (services/btd6_data_service.py)
 # ==========================
-# Where the BTD6 fixture JSON (towers/heroes/maps/modes/rounds, …) is read
-# from. Unset (the default) → the committed files under ``disbot/data/btd6/``.
-# Set to a PUBLIC-READ object-store/CDN base URL (Cloudflare R2 / S3 / GCS) to
-# serve the fixtures from the cloud instead: at startup the bot fetches
-# ``{BTD6_DATA_BASE_URL}/<fixture>.json`` into ``BTD6_DATA_CACHE_DIR`` and reads
-# from that cache (see ``docs/btd6-cloud-data.md``). No secret required for a
-# public bucket. Populate the bucket with ``scripts/upload_btd6_data.py``.
+# Backend for the BTD6 fixture JSON + per-entity stats tree. See
+# ``docs/btd6-data-backends.md``.
+#   ""/"file"  → committed files under ``disbot/data/btd6/`` (default).
+#   "postgres" → the ``btd6_data_blobs`` table (recommended when you already
+#                run Postgres; seed with ``scripts/seed_btd6_data.py``). No new
+#                infra / external dependency — reuses the bot's DB.
+#   "cloud"    → a PUBLIC-READ object store / CDN at ``BTD6_DATA_BASE_URL``
+#                (seed with ``scripts/upload_btd6_data.py``).
+BTD6_DATA_BACKEND = os.getenv("BTD6_DATA_BACKEND", "")
+# Cloud backend only: PUBLIC-READ base URL of the bucket/CDN. Setting this with
+# no explicit BTD6_DATA_BACKEND still implies the cloud backend (back-compat).
 BTD6_DATA_BASE_URL = os.getenv("BTD6_DATA_BASE_URL", "")
-# Local cache dir for cloud-fetched fixtures. Empty → a temp dir is used
+# Cloud backend only: local cache dir for fetched fixtures. Empty → a temp dir
 # (ephemeral; re-warmed each boot).
 BTD6_DATA_CACHE_DIR = os.getenv("BTD6_DATA_CACHE_DIR", "")

--- a/disbot/migrations/054_btd6_data_blobs.sql
+++ b/disbot/migrations/054_btd6_data_blobs.sql
@@ -1,0 +1,24 @@
+-- Migration 054: BTD6 deterministic data blobs (Postgres data backend).
+--
+-- A static reference blob store for the BTD6 fixtures + per-entity stats tree
+-- that otherwise live under disbot/data/btd6/. Rows are keyed by repo-relative
+-- path, e.g. 'towers.json', 'stats/dart_monkey.json', 'paragon_abilities.json'.
+--
+-- services.btd6_data_provider.PostgresRawProvider loads these into memory with
+-- one query at startup (the asyncpg pool + migrations are ready before any cog
+-- loads) when BTD6_DATA_BACKEND=postgres; btd6_data_service / btd6_stats_service
+-- then read from that warmed cache, so the synchronous loaders never touch the
+-- async DB on a hot path. Seed / refresh via scripts/seed_btd6_data.py.
+--
+-- body is JSONB (validated, round-tripped as a dict by the jsonb codec).
+-- sha256 records the provenance of the source file (informational, not a
+-- runtime integrity gate).
+--
+-- Forward-only and idempotent.
+
+CREATE TABLE IF NOT EXISTS btd6_data_blobs (
+    name        TEXT PRIMARY KEY,
+    body        JSONB NOT NULL,
+    sha256      TEXT,
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/disbot/services/btd6_data_provider.py
+++ b/disbot/services/btd6_data_provider.py
@@ -71,6 +71,15 @@ class FileRawProvider:
             return None
         return json.loads(path.read_text(encoding="utf-8"))
 
+    def list_names(self, prefix: str = "") -> tuple[str, ...]:
+        """Repo-relative ``*.json`` names under ``prefix`` (the glob seam)."""
+        if not self._root.is_dir():
+            return ()
+        names = (
+            p.relative_to(self._root).as_posix() for p in self._root.rglob("*.json")
+        )
+        return tuple(sorted(n for n in names if n.startswith(prefix)))
+
 
 def _sha256(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
@@ -139,6 +148,11 @@ class CloudRawProvider:
 
     def load(self, name: str) -> dict[str, Any] | None:
         return self._cache.load(name)
+
+    def list_names(self, prefix: str = "") -> tuple[str, ...]:
+        # Lists the warmed cache dir. Note: cloud warm only fetches the
+        # fixtures, so the stats/ tree is not available on the cloud backend.
+        return FileRawProvider(self._cache_dir).list_names(prefix)
 
     async def warm_cache(
         self,

--- a/disbot/services/btd6_data_provider.py
+++ b/disbot/services/btd6_data_provider.py
@@ -216,3 +216,74 @@ class CloudRawProvider:
         from services.btd6_fetch_service import fetch_url_bytes
 
         return await fetch_url_bytes(url, timeout=self._timeout)
+
+
+class PostgresRawProvider:
+    """Serve BTD6 fixtures from the ``btd6_data_blobs`` Postgres table.
+
+    Warms the whole blob set into memory with one query at startup — the bot's
+    asyncpg pool + migrations are ready before any cog loads (``bot1.main``
+    calls ``db.init()`` before ``bot.start()``) — then serves *sync* ``load``
+    reads from that dict, so the synchronous ``get_dataset`` / stats loaders
+    never touch the async DB on a hot path.
+
+    Reuses the dependency the bot already hard-requires: no new external
+    service, no new failure mode, no public URL or credential. If the table is
+    unseeded, ``is_available`` reports ``False`` and the caller degrades.
+
+    ``fetch_all`` is an injectable ``async () -> list[(name, body)]`` (tests
+    pass a fake to avoid a real DB); ``None`` uses ``utils.db.btd6_data``.
+    """
+
+    def __init__(
+        self,
+        *,
+        fetch_all: Callable[[], Awaitable[list[tuple[str, Any]]]] | None = None,
+    ) -> None:
+        self._fetch_all = fetch_all
+        self._data: dict[str, Any] = {}
+        self._available = False
+        self._warmed = False
+
+    def is_available(self) -> bool:
+        return self._available
+
+    def source_label(self) -> str:
+        if not self._warmed:
+            return "postgres (not warmed)"
+        if not self._available:
+            return "postgres (unavailable — btd6_data_blobs unseeded?)"
+        return f"postgres ({len(self._data)} blobs)"
+
+    def load(self, name: str) -> dict[str, Any] | None:
+        return self._data.get(name)
+
+    def list_names(self, prefix: str = "") -> tuple[str, ...]:
+        """Stored blob names under ``prefix`` (the file glob's DB equivalent)."""
+        return tuple(sorted(n for n in self._data if n.startswith(prefix)))
+
+    async def warm_cache(
+        self,
+        *,
+        required: Iterable[str] = (),
+        optional: Iterable[str] = (),  # noqa: ARG002 - parity with the seam
+    ) -> bool:
+        required = tuple(required)
+        fetch_all = self._fetch_all
+        if fetch_all is None:
+            from utils.db import btd6_data
+
+            fetch_all = btd6_data.fetch_all_blobs
+        data: dict[str, Any] = {}
+        for name, body in await fetch_all():
+            # Defensive: the jsonb codec yields dicts, but coerce text too.
+            data[name] = body if isinstance(body, (dict, list)) else json.loads(body)
+        self._data = data
+        self._available = all(n in self._data for n in required)
+        self._warmed = True
+        if not self._available:
+            logger.warning(
+                "BTD6 postgres data unavailable: required fixtures missing from "
+                "btd6_data_blobs — seed with scripts/seed_btd6_data.py",
+            )
+        return self._available

--- a/disbot/services/btd6_data_service.py
+++ b/disbot/services/btd6_data_service.py
@@ -32,6 +32,7 @@ from services.btd6_data_provider import (
     BTD6RawProvider,
     CloudRawProvider,
     FileRawProvider,
+    PostgresRawProvider,
 )
 
 
@@ -551,22 +552,38 @@ def _default_cache_dir() -> Path:
 
 
 def _select_provider() -> BTD6RawProvider:
-    """Pick the raw-fixture backend from config (no network I/O at import).
+    """Pick the raw-fixture backend from config (no network/DB I/O at import).
 
-    ``BTD6_DATA_BASE_URL`` set → :class:`CloudRawProvider` (warmed at startup
-    via :func:`warm_provider`); otherwise the committed local files via
-    ``FileRawProvider``. Provider *selection* is cheap; the actual fetch
-    happens later in ``warm_provider`` so import stays side-effect-free.
+    ``BTD6_DATA_BACKEND`` selects explicitly:
+
+    * ``postgres`` → :class:`PostgresRawProvider` (the ``btd6_data_blobs``
+      table; recommended for a deployment that already runs Postgres);
+    * ``cloud`` → :class:`CloudRawProvider` (a public-read object store at
+      ``BTD6_DATA_BASE_URL``);
+    * ``file`` / unset → the committed local files via ``FileRawProvider``.
+
+    Back-compat: ``BTD6_DATA_BASE_URL`` set with no explicit backend still
+    implies ``cloud``. Provider *selection* is cheap; the actual fetch happens
+    later in :func:`warm_provider`, so import stays side-effect-free.
     """
     try:
-        from config import BTD6_DATA_BASE_URL, BTD6_DATA_CACHE_DIR
+        from config import (
+            BTD6_DATA_BACKEND,
+            BTD6_DATA_BASE_URL,
+            BTD6_DATA_CACHE_DIR,
+        )
     except Exception:  # noqa: BLE001 - config always importable in the app
         return FileRawProvider()
+    backend = (BTD6_DATA_BACKEND or "").strip().lower()
     base_url = (BTD6_DATA_BASE_URL or "").strip()
-    if not base_url:
-        return FileRawProvider()
-    cache_dir = (BTD6_DATA_CACHE_DIR or "").strip() or _default_cache_dir()
-    return CloudRawProvider(base_url, cache_dir)
+
+    if backend == "postgres":
+        return PostgresRawProvider()
+    if backend == "cloud" or (not backend and base_url):
+        if base_url:
+            cache_dir = (BTD6_DATA_CACHE_DIR or "").strip() or _default_cache_dir()
+            return CloudRawProvider(base_url, cache_dir)
+    return FileRawProvider()
 
 
 _PROVIDER: BTD6RawProvider = _select_provider()

--- a/disbot/services/btd6_data_service.py
+++ b/disbot/services/btd6_data_service.py
@@ -604,6 +604,23 @@ def get_provider() -> BTD6RawProvider:
     return _PROVIDER
 
 
+def read_blob(name: str) -> dict[str, Any] | None:
+    """Read one raw blob through the active provider, or ``None`` if absent.
+
+    ``name`` is relative to the BTD6 data root (e.g. ``"stats/dart_monkey.json"``
+    or ``"paragon_abilities.json"``). Lets ``btd6_stats_service`` read the
+    per-entity stats tree through the same backend as the fixtures so it honours
+    ``BTD6_DATA_BACKEND`` too.
+    """
+    return _PROVIDER.load(name)
+
+
+def list_blob_names(prefix: str = "") -> tuple[str, ...]:
+    """Available blob names under ``prefix`` (the provider-aware glob seam)."""
+    lister = getattr(_PROVIDER, "list_names", None)
+    return lister(prefix) if lister is not None else ()
+
+
 async def warm_provider() -> bool:
     """Populate the active provider's cache if it supports warming (cloud).
 

--- a/disbot/services/btd6_stats_service.py
+++ b/disbot/services/btd6_stats_service.py
@@ -17,7 +17,6 @@ Pure data access — no Discord, no network (the bot never fetches at runtime;
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -182,11 +181,23 @@ _PARAGON_CACHE: dict[str, ParagonStats | None] = {}
 _PARAGON_BY_TOWER: dict[str, str] | None = None
 
 
+def _read_blob(relpath: str) -> dict | None:
+    """Read one stats blob through the active BTD6 data backend.
+
+    Routes the per-entity stats reads through the same provider as the
+    fixtures (``btd6_data_service``), so the stats tree honours
+    ``BTD6_DATA_BACKEND`` (file / postgres / cloud) too. Lazy import keeps the
+    module load order independent.
+    """
+    from services import btd6_data_service
+
+    return btd6_data_service.read_blob(relpath)
+
+
 def _load(tower_id: str) -> TowerStats | None:
-    path = STATS_ROOT / f"{tower_id}.json"
-    if not path.exists():
+    data = _read_blob(f"stats/{tower_id}.json")
+    if data is None:
         return None
-    data = json.loads(path.read_text(encoding="utf-8"))
     return TowerStats(
         tower_id=data.get("tower_id", tower_id),
         canonical=data.get("canonical", ""),
@@ -208,10 +219,9 @@ def get_tower_stats(tower_id: str) -> TowerStats | None:
 
 
 def _load_hero(hero_id: str) -> HeroStats | None:
-    path = HERO_STATS_ROOT / f"{hero_id}.json"
-    if not path.exists():
+    data = _read_blob(f"stats/heroes/{hero_id}.json")
+    if data is None:
         return None
-    data = json.loads(path.read_text(encoding="utf-8"))
     return HeroStats(
         hero_id=data.get("hero_id", hero_id),
         canonical=data.get("canonical", ""),
@@ -233,13 +243,10 @@ def get_hero_stats(hero_id: str) -> HeroStats | None:
     return _HERO_CACHE[hero_id]
 
 
-_PARAGON_DESCRIPTIONS_PATH = (
-    Path(__file__).resolve().parents[1] / "data" / "btd6" / "paragon_descriptions.json"
-)
+# Paragon overviews + ability prose live in their own committed blobs
+# (paragon_descriptions.json / paragon_abilities.json) so a stats re-fetch
+# never clobbers them; read through the provider via ``_read_blob``.
 _PARAGON_DESCRIPTIONS: dict[str, str] | None = None
-_PARAGON_ABILITIES_PATH = (
-    Path(__file__).resolve().parents[1] / "data" / "btd6" / "paragon_abilities.json"
-)
 _PARAGON_ABILITIES: dict[str, tuple[ParagonAbility, ...]] | None = None
 
 
@@ -250,13 +257,8 @@ def _descriptions() -> dict[str, str]:
     """
     global _PARAGON_DESCRIPTIONS
     if _PARAGON_DESCRIPTIONS is None:
-        try:
-            data = json.loads(
-                _PARAGON_DESCRIPTIONS_PATH.read_text(encoding="utf-8"),
-            )
-            _PARAGON_DESCRIPTIONS = dict(data.get("descriptions", {}))
-        except (OSError, ValueError):
-            _PARAGON_DESCRIPTIONS = {}
+        data = _read_blob("paragon_descriptions.json")
+        _PARAGON_DESCRIPTIONS = dict(data.get("descriptions", {})) if data else {}
     return _PARAGON_DESCRIPTIONS
 
 
@@ -270,30 +272,26 @@ def _abilities() -> dict[str, tuple[ParagonAbility, ...]]:
     global _PARAGON_ABILITIES
     if _PARAGON_ABILITIES is None:
         index: dict[str, tuple[ParagonAbility, ...]] = {}
-        try:
-            data = json.loads(_PARAGON_ABILITIES_PATH.read_text(encoding="utf-8"))
-            for paragon_id, rows in (data.get("abilities") or {}).items():
-                index[paragon_id] = tuple(
-                    ParagonAbility(
-                        name=str(row.get("name", "")),
-                        kind=str(row.get("kind", "activated")),
-                        cooldown=row.get("cooldown"),
-                        description=str(row.get("description", "")),
-                    )
-                    for row in rows
-                    if row.get("name")
+        data = _read_blob("paragon_abilities.json")
+        for paragon_id, rows in ((data or {}).get("abilities") or {}).items():
+            index[paragon_id] = tuple(
+                ParagonAbility(
+                    name=str(row.get("name", "")),
+                    kind=str(row.get("kind", "activated")),
+                    cooldown=row.get("cooldown"),
+                    description=str(row.get("description", "")),
                 )
-        except (OSError, ValueError):
-            index = {}
+                for row in rows
+                if row.get("name")
+            )
         _PARAGON_ABILITIES = index
     return _PARAGON_ABILITIES
 
 
 def _load_paragon(paragon_id: str) -> ParagonStats | None:
-    path = PARAGON_STATS_ROOT / f"{paragon_id}.json"
-    if not path.exists():
+    data = _read_blob(f"stats/paragons/{paragon_id}.json")
+    if data is None:
         return None
-    data = json.loads(path.read_text(encoding="utf-8"))
     return ParagonStats(
         paragon_id=data.get("paragon_id", paragon_id),
         tower_id=data.get("tower_id", ""),
@@ -317,11 +315,21 @@ def get_paragon_stats(paragon_id: str) -> ParagonStats | None:
     return _PARAGON_CACHE[paragon_id]
 
 
+_PARAGON_PREFIX = "stats/paragons/"
+_JSON_SUFFIX = ".json"
+
+
 def list_paragon_ids() -> tuple[str, ...]:
-    """All paragon ids that have a committed stats file (sorted)."""
-    if not PARAGON_STATS_ROOT.exists():
-        return ()
-    return tuple(sorted(p.stem for p in PARAGON_STATS_ROOT.glob("*.json")))
+    """All paragon ids that have a stats blob in the active backend (sorted)."""
+    from services import btd6_data_service
+
+    names = btd6_data_service.list_blob_names(_PARAGON_PREFIX)
+    ids = [
+        name[len(_PARAGON_PREFIX) : -len(_JSON_SUFFIX)]
+        for name in names
+        if name.endswith(_JSON_SUFFIX)
+    ]
+    return tuple(sorted(ids))
 
 
 def _paragon_index() -> dict[str, str]:

--- a/disbot/utils/db/btd6_data.py
+++ b/disbot/utils/db/btd6_data.py
@@ -1,0 +1,60 @@
+"""DB access for the BTD6 deterministic-data blob store (``btd6_data_blobs``).
+
+Backs ``services.btd6_data_provider.PostgresRawProvider``: a static reference
+blob store (fixtures + the per-entity stats tree) keyed by repo-relative path.
+The bot already hard-depends on Postgres, so serving BTD6 reference data from
+the same DB adds no new external dependency or failure mode.
+
+Writes here are seed/refresh operations for operator-controlled reference data
+(not an audited domain mutation), driven by ``scripts/seed_btd6_data.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from utils.db import pool
+
+
+async def fetch_all_blobs() -> list[tuple[str, Any]]:
+    """Return ``(name, body)`` for every stored blob in one query.
+
+    ``body`` is whatever the jsonb codec yields (a dict); the provider
+    coerces defensively in case a row round-trips as text.
+    """
+    rows = await pool.get().fetch(
+        "SELECT name, body FROM btd6_data_blobs ORDER BY name",
+    )
+    return [(row["name"], row["body"]) for row in rows]
+
+
+async def fetch_blob(name: str) -> Any | None:
+    """Return one blob's body, or ``None`` when absent."""
+    row = await pool.get().fetchrow(
+        "SELECT body FROM btd6_data_blobs WHERE name = $1",
+        name,
+    )
+    return row["body"] if row is not None else None
+
+
+async def count_blobs() -> int:
+    """Number of stored blobs (0 when the table is unseeded)."""
+    row = await pool.get().fetchrow("SELECT COUNT(*) AS n FROM btd6_data_blobs")
+    return int(row["n"]) if row is not None else 0
+
+
+async def upsert_blob(name: str, body: Any, sha256: str | None = None) -> None:
+    """Insert or update one blob. ``body`` is a JSON-serialisable object."""
+    await pool.get().execute(
+        """
+        INSERT INTO btd6_data_blobs (name, body, sha256, updated_at)
+        VALUES ($1, $2, $3, NOW())
+        ON CONFLICT (name) DO UPDATE
+           SET body = EXCLUDED.body,
+               sha256 = EXCLUDED.sha256,
+               updated_at = NOW()
+        """,
+        name,
+        body,
+        sha256,
+    )

--- a/docs/btd6-data-backends.md
+++ b/docs/btd6-data-backends.md
@@ -1,0 +1,70 @@
+# BTD6 data backends
+
+The BTD6 deterministic data (fixtures: towers/heroes/maps/modes/rounds/bloons/
+ct_relics, plus the per-entity `stats/` tree + paragon descriptions/abilities)
+is read through one swappable seam — `services/btd6_data_provider.py`
+(`BTD6RawProvider`). Every read funnels through `btd6_data_service._load_file`,
+so the backend is a one-line config switch with **zero** changes to the ~14
+dataset consumers.
+
+Pick the backend with `BTD6_DATA_BACKEND`:
+
+| Value | Backend | When |
+|---|---|---|
+| `""` / `file` | Committed files under `disbot/data/btd6/` (`FileRawProvider`) | Default; local dev. |
+| `postgres` | The `btd6_data_blobs` table (`PostgresRawProvider`) | **Recommended in production** — you already run Postgres. |
+| `cloud` | A public-read object store / CDN (`CloudRawProvider`) | If you want the data on a bucket/CDN. See `docs/btd6-cloud-data.md`. |
+
+All backends share the same startup contract: the BTD6 mother cog's `cog_load`
+calls `btd6_data_service.warm_provider()` (a no-op for `file`) **before**
+starting ingestion; if required data is unavailable it logs, skips the
+supervisor, and leaves the panel working rather than crashing. `!btd6 status` /
+`!btd6 diagnostics` show the active source + availability.
+
+## Postgres backend (recommended)
+
+**Why:** it reuses the database the bot already hard-depends on — no new
+external service, failure mode, public URL, or credential. The fixtures are
+static, read-once-into-memory reference data, so they live as JSONB blobs keyed
+by repo-relative path (`towers.json`, `stats/dart_monkey.json`, …). At startup
+`PostgresRawProvider` loads the whole set with one query into memory; the
+synchronous loaders then read from that dict (the async DB is never on a hot
+path).
+
+**Setup:**
+
+1. The `btd6_data_blobs` table is created by migration `054` (runs
+   automatically on boot).
+2. Seed it from a checkout pointed at your deployment DB:
+   ```bash
+   # dry run (no DB):
+   python3.10 scripts/seed_btd6_data.py --dry-run
+   # seed (uses the bot's DSN env vars):
+   python3.10 scripts/seed_btd6_data.py
+   ```
+3. Set `BTD6_DATA_BACKEND=postgres` on Railway and redeploy.
+4. Verify: `!btd6 status` shows `Data source: postgres (<N> blobs)`.
+5. Refresh after a game patch: regenerate the fixtures, re-run the seed script
+   (it upserts).
+
+**Cutover — removing the data from the repo (gated):** once `!btd6 status`
+reads from Postgres and BTD6 lookups work, `git rm -r disbot/data/btd6/`
+(keeping the generator scripts) and commit. Do this only after the table is
+seeded **and** every consumer reads from PG (see the stats note below).
+
+## Scope note (fixtures vs the stats tree)
+
+`btd6_data_service` (the 7 fixtures) reads through the provider today, so it
+honours `BTD6_DATA_BACKEND` immediately. The per-entity `stats/` tree
+(`btd6_stats_service`, the 5.8 MB bulk) is migrated to the same provider/seam in
+the same series — the seed script already loads `stats/**` into the table, so
+the data is present; the repo-removal cutover waits until the stats loaders read
+from PG too.
+
+## CI hermeticity
+
+Unit tests never touch a real backend: they drive the loader via
+`set_provider(FileRawProvider(<dir>))` or an injected `fetch_all` for the
+Postgres provider (`tests/unit/services/test_btd6_postgres_provider.py`). Before
+removing the committed fixtures, add a minimal subset under `tests/fixtures/btd6/`
+and inject it via a conftest autouse fixture so CI stays offline.

--- a/docs/btd6-data-tuning-handoff.md
+++ b/docs/btd6-data-tuning-handoff.md
@@ -9,9 +9,10 @@ data**, never from a hallucinated prior. When it lacks a fact it should say so
 (and that "stick to verified data, don't cave to 'you're wrong'" behaviour is
 **intentional** — do not soften it).
 
-> **Data source:** fixtures default to `disbot/data/btd6/` but can be served
-> from a public-read object store by setting `BTD6_DATA_BASE_URL` — see
-> **`docs/btd6-cloud-data.md`**. The read seam is
+> **Data source:** fixtures default to `disbot/data/btd6/` but the backend is
+> swappable via `BTD6_DATA_BACKEND` (`file` / `postgres` / `cloud`) — see
+> **`docs/btd6-data-backends.md`** (Postgres is the recommended production
+> backend; it reuses the DB the bot already depends on). The read seam is
 > `services/btd6_data_provider.py`; everything funnels through
 > `btd6_data_service._load_file`, so the backend swap is invisible to consumers.
 

--- a/scripts/seed_btd6_data.py
+++ b/scripts/seed_btd6_data.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Seed the BTD6 deterministic data tree into Postgres (``btd6_data_blobs``).
+
+One-shot operator tool for the Postgres data backend. Walks
+``disbot/data/btd6/`` (the fixtures + the per-entity ``stats/`` subtree) and
+upserts each ``*.json`` file as a row keyed by repo-relative path. Run it
+against your deployment database, then set ``BTD6_DATA_BACKEND=postgres`` (see
+``docs/btd6-data-backends.md``).
+
+Usage::
+
+    # Inspect what would be seeded (no DB connection):
+    python3.10 scripts/seed_btd6_data.py --dry-run
+
+    # Seed into the configured database (uses the bot's DSN env vars):
+    python3.10 scripts/seed_btd6_data.py
+
+Writes go through ``utils.db.btd6_data`` (the sanctioned DB layer), the same
+path the bot reads from.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_ROOT = REPO_ROOT / "disbot" / "data" / "btd6"
+MANIFEST_NAME = "manifest.json"
+
+# Make ``from utils import db`` resolve the same way the bot does.
+if str(REPO_ROOT / "disbot") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "disbot"))
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def build_rows(root: Path) -> list[tuple[str, Any, str]]:
+    """Return ``(name, body, sha256)`` for every ``*.json`` under ``root``.
+
+    ``manifest.json`` is excluded. ``body`` is the parsed JSON object; the
+    sha256 is over the original file bytes (provenance).
+    """
+    rows: list[tuple[str, Any, str]] = []
+    for path in sorted(root.rglob("*.json")):
+        rel = path.relative_to(root).as_posix()
+        if rel == MANIFEST_NAME:
+            continue
+        raw = path.read_bytes()
+        rows.append((rel, json.loads(raw), _sha256(raw)))
+    return rows
+
+
+def _print_summary(rows: list[tuple[str, Any, str]], root: Path) -> None:
+    print(f"BTD6 data root: {root}")
+    print(f"Files: {len(rows)}")
+    for name, _body, sha in rows[:10]:
+        print(f"  {name:40s} {sha[:12]}")
+    if len(rows) > 10:
+        print(f"  … and {len(rows) - 10} more")
+
+
+async def seed(rows: list[tuple[str, Any, str]]) -> int:
+    from utils import db
+    from utils.db import btd6_data, pool
+
+    await db.init()
+    try:
+        for name, body, sha in rows:
+            await btd6_data.upsert_blob(name, body, sha)
+    finally:
+        await pool.close()
+    return len(rows)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=DEFAULT_ROOT)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Build + print the row summary; no DB connection, no write.",
+    )
+    args = parser.parse_args(argv)
+
+    root: Path = args.root
+    if not root.is_dir():
+        print(f"data root not found: {root}", file=sys.stderr)
+        return 2
+
+    rows = build_rows(root)
+    _print_summary(rows, root)
+    if args.dry_run:
+        return 0
+
+    count = asyncio.run(seed(rows))
+    print(f"seeded {count} blobs into btd6_data_blobs")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_seed_btd6_data.py
+++ b/tests/unit/scripts/test_seed_btd6_data.py
@@ -1,0 +1,53 @@
+"""Tests for ``scripts/seed_btd6_data.py`` (offline paths only).
+
+The actual seed needs a database; here we exercise the pure row builder and
+``--dry-run`` against the real data tree — no DB connection.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "seed_btd6_data.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("seed_btd6_data", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load_module()
+
+
+def test_build_rows_parses_and_hashes(tmp_path):
+    (tmp_path / "a.json").write_text('{"x": 1}', encoding="utf-8")
+    sub = tmp_path / "stats"
+    sub.mkdir()
+    (sub / "b.json").write_text('{"y": 2}', encoding="utf-8")
+
+    rows = mod.build_rows(tmp_path)
+    by_name = {name: (body, sha) for name, body, sha in rows}
+    assert set(by_name) == {"a.json", "stats/b.json"}
+    assert by_name["a.json"][0] == {"x": 1}  # parsed body
+    assert len(by_name["a.json"][1]) == 64  # sha256 hex
+
+
+def test_build_rows_excludes_manifest(tmp_path):
+    (tmp_path / "a.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "manifest.json").write_text("{}", encoding="utf-8")
+    assert {name for name, _b, _s in mod.build_rows(tmp_path)} == {"a.json"}
+
+
+def test_dry_run_on_real_data():
+    assert mod.main(["--dry-run"]) == 0
+
+
+def test_rows_on_real_data_include_fixtures():
+    rows = mod.build_rows(mod.DEFAULT_ROOT)
+    names = {name for name, _b, _s in rows}
+    assert "towers.json" in names
+    assert len(rows) >= 7

--- a/tests/unit/services/test_btd6_postgres_provider.py
+++ b/tests/unit/services/test_btd6_postgres_provider.py
@@ -1,0 +1,136 @@
+"""Tests for the BTD6 Postgres raw-fixture provider + backend selection.
+
+The DB layer is mocked via an injected ``fetch_all``, so these run offline —
+no real Postgres — mirroring how the rest of the codebase tests DB-touching
+code. Drives ``get_dataset`` end-to-end through the warmed blob cache.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from services.btd6_data_provider import (
+    DATA_ROOT,
+    FileRawProvider,
+    PostgresRawProvider,
+)
+from services.btd6_data_service import (
+    _OPTIONAL_FIXTURES,
+    _REQUIRED_FIXTURES,
+    _select_provider,
+    data_available,
+    get_dataset,
+    get_provider,
+    reset_cache,
+    set_provider,
+    warm_provider,
+)
+
+
+def _blobs_from_disk(*, skip=()):
+    """``(name, body-dict)`` rows mimicking ``btd6_data_blobs`` (jsonb codec)."""
+    rows = []
+    for name in (*_REQUIRED_FIXTURES, *_OPTIONAL_FIXTURES):
+        if name in skip:
+            continue
+        path = DATA_ROOT / name
+        if path.exists():
+            rows.append((name, json.loads(path.read_text(encoding="utf-8"))))
+    return rows
+
+
+def _fetch_all(rows):
+    async def fetch():
+        return list(rows)
+
+    return fetch
+
+
+@pytest.fixture(autouse=True)
+def _restore_provider():
+    original = get_provider()
+    reset_cache()
+    yield
+    set_provider(original)
+    reset_cache()
+
+
+@pytest.mark.asyncio
+async def test_warm_populates_and_drives_get_dataset():
+    provider = PostgresRawProvider(fetch_all=_fetch_all(_blobs_from_disk()))
+    ok = await provider.warm_cache(
+        required=_REQUIRED_FIXTURES,
+        optional=_OPTIONAL_FIXTURES,
+    )
+    assert ok is True
+    assert provider.is_available() is True
+    assert "blobs" in provider.source_label()
+    towers = provider.load("towers.json")
+    assert towers is not None and "towers" in towers
+
+    set_provider(provider)
+    reset_cache()
+    assert get_dataset().towers  # end-to-end through the warmed cache
+
+
+@pytest.mark.asyncio
+async def test_unseeded_table_is_unavailable():
+    provider = PostgresRawProvider(fetch_all=_fetch_all([]))
+    ok = await provider.warm_cache(required=_REQUIRED_FIXTURES)
+    assert ok is False
+    assert provider.is_available() is False
+    assert "unavailable" in provider.source_label()
+
+
+@pytest.mark.asyncio
+async def test_coerces_text_bodies():
+    # A row that round-trips as JSON *text* (no codec) must still parse.
+    rows = [
+        (n, json.dumps(json.loads((DATA_ROOT / n).read_text(encoding="utf-8"))))
+        for n in _REQUIRED_FIXTURES
+    ]
+    provider = PostgresRawProvider(fetch_all=_fetch_all(rows))
+    assert await provider.warm_cache(required=_REQUIRED_FIXTURES) is True
+    towers = provider.load("towers.json")
+    assert towers is not None and towers["towers"]
+
+
+@pytest.mark.asyncio
+async def test_list_names_prefix():
+    rows = [
+        ("towers.json", {}),
+        ("stats/dart_monkey.json", {}),
+        ("stats/heroes/quincy.json", {}),
+    ]
+    provider = PostgresRawProvider(fetch_all=_fetch_all(rows))
+    await provider.warm_cache()
+    assert provider.list_names("stats/") == (
+        "stats/dart_monkey.json",
+        "stats/heroes/quincy.json",
+    )
+    assert provider.list_names("stats/heroes/") == ("stats/heroes/quincy.json",)
+
+
+@pytest.mark.asyncio
+async def test_warm_provider_integrates_postgres():
+    set_provider(PostgresRawProvider(fetch_all=_fetch_all(_blobs_from_disk())))
+    assert await warm_provider() is True
+    assert data_available() is True
+    assert get_dataset().heroes
+
+
+def test_select_provider_postgres(monkeypatch):
+    import config
+
+    monkeypatch.setattr(config, "BTD6_DATA_BACKEND", "postgres", raising=False)
+    assert isinstance(_select_provider(), PostgresRawProvider)
+
+
+def test_select_provider_file_default(monkeypatch):
+    import config
+
+    monkeypatch.setattr(config, "BTD6_DATA_BACKEND", "", raising=False)
+    monkeypatch.setattr(config, "BTD6_DATA_BASE_URL", "", raising=False)
+    assert isinstance(_select_provider(), FileRawProvider)

--- a/tests/unit/services/test_btd6_stats_backend.py
+++ b/tests/unit/services/test_btd6_stats_backend.py
@@ -1,0 +1,77 @@
+"""btd6_stats_service reads the per-entity stats tree through the active
+BTD6 data backend (so the stats tree honours ``BTD6_DATA_BACKEND``).
+
+Drives the stats loaders off an injected Postgres provider — no filesystem,
+no real DB — proving the stats reads no longer go straight to disk.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from services import btd6_data_service as ds
+from services import btd6_stats_service as ss
+from services.btd6_data_provider import PostgresRawProvider
+
+
+def _fetch_all(rows):
+    async def fetch():
+        return list(rows)
+
+    return fetch
+
+
+@pytest.fixture(autouse=True)
+def _restore():
+    original = ds.get_provider()
+    ds.reset_cache()
+    ss.reset_cache()
+    yield
+    ds.set_provider(original)
+    ds.reset_cache()
+    ss.reset_cache()
+
+
+async def _install(rows):
+    provider = PostgresRawProvider(fetch_all=_fetch_all(rows))
+    await provider.warm_cache()
+    ds.set_provider(provider)
+    ds.reset_cache()
+    ss.reset_cache()
+
+
+@pytest.mark.asyncio
+async def test_tower_stats_read_from_provider():
+    blob = {
+        "tower_id": "dart_monkey",
+        "canonical": "Dart Monkey",
+        "game_version": "47.0",
+        "base_cost": 200,
+        "category": "primary",
+        "upgrades": [],
+        "tiers": {},
+    }
+    await _install([("stats/dart_monkey.json", blob)])
+
+    stats = ss.get_tower_stats("dart_monkey")
+    assert stats is not None
+    assert stats.canonical == "Dart Monkey"
+    assert stats.base_cost == 200
+    # A tower with no blob degrades to None (unchanged contract).
+    assert ss.get_tower_stats("does_not_exist") is None
+
+
+@pytest.mark.asyncio
+async def test_list_paragon_ids_read_from_provider():
+    rows = [
+        ("stats/paragons/wizard_lord_phoenix.json", {"paragon_id": "wizard_lord_phoenix"}),
+        ("stats/paragons/apex_plasma_master.json", {"paragon_id": "apex_plasma_master"}),
+        ("stats/dart_monkey.json", {"tower_id": "dart_monkey"}),
+        ("towers.json", {"towers": []}),
+    ]
+    await _install(rows)
+
+    assert ss.list_paragon_ids() == (
+        "apex_plasma_master",
+        "wizard_lord_phoenix",
+    )


### PR DESCRIPTION
## What & why

Pivots the BTD6 data backend from a cloud bucket to **Postgres**, per the follow-up discussion: it reuses the database the bot already hard-depends on, so there's no new external dependency, failure mode, public URL, or credential — and at ~6 MB of static, read-once-into-memory reference data, the choice is operational, where "you already run PG" wins. The provider seam from the prior series (merged in #455) made this a drop-in.

Opt-in: default stays the committed files, so this is a **no-op until `BTD6_DATA_BACKEND=postgres`** is set. Two commits, both green against the full CI mirror (black/isort/ruff/mypy + pytest, **7041 passing**) and `check_architecture.py --mode strict` (0 errors).

## Commit 1 — fixtures via `btd6_data_blobs`
- **Migration `054`**: `btd6_data_blobs(name PK, body JSONB, sha256, updated_at)` — a static reference blob store keyed by repo-relative path (`towers.json`, `stats/dart_monkey.json`, …).
- **`utils/db/btd6_data.py`**: `fetch_all_blobs` / `fetch_blob` / `count_blobs` / `upsert_blob` via the sanctioned `pool` layer.
- **`PostgresRawProvider`**: warms the whole blob set into memory with **one query** at startup (the pool + migrations run before any cog loads — verified `bot1.main` calls `db.init()` before `bot.start()`), then serves sync `load()` from that dict, so the async DB is never on a hot path. Reports seeding state via `is_available()`/`source_label()` (shown on `!btd6 status`/`diagnostics`); degrades gracefully if unseeded.
- **Backend selector**: `BTD6_DATA_BACKEND = file | postgres | cloud` (default `file`); `BTD6_DATA_BASE_URL` alone still implies `cloud` (back-compat with #455).
- **`scripts/seed_btd6_data.py`**: walks `data/btd6` and upserts every `*.json` (fixtures **+** the `stats/` tree) into the table; offline `--dry-run` needs no DB.

## Commit 2 — stats tree via the same provider
- `btd6_stats_service`'s 6 file-read sites + the paragon glob now go through `btd6_data_service.read_blob` / `list_blob_names` (providers gained `list_names(prefix)` as the glob seam). For `postgres`, the single startup warm already holds stats in memory (no per-entity DB hit); for `file` it reads disk on demand as before.
- This is what lets the **whole `disbot/data/btd6` tree leave the repo** (the 5.8 MB bulk is the stats tree).

## Your steps (gated cutover — same division of labor as before)
1. Migration `054` creates the table automatically on boot.
2. Seed your Railway DB: `python3.10 scripts/seed_btd6_data.py` (`--dry-run` first to preview).
3. Set `BTD6_DATA_BACKEND=postgres`, redeploy, verify `!btd6 status` shows `Data source: postgres (<N> blobs)`.
4. Then `git rm -r disbot/data/btd6/` (keep the generator scripts) — the audit-cleanliness payoff. Add a `tests/fixtures/btd6/` subset first so CI stays offline (noted in `docs/btd6-data-backends.md`).

Refresh after a game patch = regenerate fixtures + re-run the seed (it upserts) — no redeploy needed.

## Notes
- The cloud backend (#455) stays as a dormant, selectable option — nothing wasted; prune it later if you like.
- `docs/btd6-data-backends.md` is the new umbrella (file/postgres/cloud, Postgres recommended); the cloud deep-dive remains in `docs/btd6-cloud-data.md`.
- Verified here with mocked DB (injected `fetch_all`) end-to-end through `get_dataset` + the stats loaders; the real seed + `!btd6 status` need your DB to confirm in situ.

https://claude.ai/code/session_015ahLXjrjnVjqtTmfau5wa2

---
_Generated by [Claude Code](https://claude.ai/code/session_015ahLXjrjnVjqtTmfau5wa2)_