### PR TITLE
BTD6: seed Postgres from Discord (!btd6ops seed-data)

### DIFF
--- a/disbot/cogs/btd6_ops_cog.py
+++ b/disbot/cogs/btd6_ops_cog.py
@@ -26,6 +26,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from cogs.btd6 import _builders
+from core.runtime.interaction_helpers import safe_defer, safe_followup
 from services import btd6_ops_readiness_service, btd6_source_mutation
 from utils.db import btd6_sources as btd6_db
 from utils.discord_permissions import is_administrator_member, is_staff_member
@@ -73,6 +74,35 @@ async def _toggle_source(actor: object, source_key: str, *, enabled: bool) -> st
         return f"⚠️ {exc}"
     verb = "enabled" if enabled else "disabled"
     return f"✅ Source `{result.source_key}` {verb}."
+
+
+async def _seed_embed() -> discord.Embed:
+    """Seed the Postgres data store from the bundled files; report the result."""
+    from services import btd6_data_service
+
+    count = await btd6_data_service.seed_postgres_from_files()
+    if count == 0:
+        return discord.Embed(
+            title="🌱 BTD6 data seed",
+            description=(
+                "No bundled data files were found to seed. If the repo data has "
+                "already been removed, re-generate the fixtures first."
+            ),
+            color=discord.Color.orange(),
+        )
+    return discord.Embed(
+        title="🌱 BTD6 data seeded",
+        description=(
+            f"Upserted **{count}** blobs into the `btd6_data_blobs` table.\n\n"
+            "**Next steps:**\n"
+            "1. In Railway → your bot service → **Variables**, add "
+            "`BTD6_DATA_BACKEND` = `postgres` (the service redeploys).\n"
+            "2. Run `!btd6 status` — it should read "
+            "`Data source: postgres (…)`.\n\n"
+            "Safe to re-run any time (it upserts)."
+        ),
+        color=discord.Color.green(),
+    )
 
 
 class BTD6OpsCog(commands.Cog):
@@ -131,6 +161,14 @@ class BTD6OpsCog(commands.Cog):
             await ctx.send(_ADMIN_DENIED)
             return
         await ctx.send(await _toggle_source(ctx.author, source_key, enabled=False))
+
+    @btd6ops.command(name="seed-data")  # type: ignore[arg-type]
+    async def seed_data_prefix(self, ctx: commands.Context) -> None:
+        """Seed the Postgres data store from the bundled files (administrator)."""
+        if not is_administrator_member(ctx.author):
+            await ctx.send(_ADMIN_DENIED)
+            return
+        await ctx.send(embed=await _seed_embed())
 
     # ------------------------------------------------------------------
     # Slash surface — /btd6ops ... (mirrors the prefix surface)
@@ -198,6 +236,20 @@ class BTD6OpsCog(commands.Cog):
             return
         msg = await _toggle_source(interaction.user, source_key, enabled=False)
         await interaction.response.send_message(msg, ephemeral=True)
+
+    @btd6ops_app.command(
+        name="seed-data",
+        description="Seed the Postgres data store from the bundled files (admin).",
+    )
+    @app_commands.default_permissions(administrator=True)
+    async def seed_data_slash(self, interaction: discord.Interaction) -> None:
+        if not is_administrator_member(interaction.user):
+            await interaction.response.send_message(_ADMIN_DENIED, ephemeral=True)
+            return
+        # Reading files + upserting can take a moment — defer first.
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        await safe_followup(interaction, embed=await _seed_embed(), ephemeral=True)
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/disbot/services/btd6_data_service.py
+++ b/disbot/services/btd6_data_service.py
@@ -655,6 +655,36 @@ def data_source_label() -> str:
     return f"local:{DATA_ROOT}"
 
 
+async def seed_postgres_from_files(root: Path | None = None) -> int:
+    """Upsert every bundled BTD6 data file into ``btd6_data_blobs`` (idempotent).
+
+    Reads the committed files via a ``FileRawProvider`` (independent of whichever
+    backend is *active*) and writes each through ``utils.db.btd6_data``. Returns
+    the number of blobs seeded. Requires the DB pool to be initialised — it is,
+    once the bot is running, so this powers the ``!btd6ops seed-data`` command as
+    well as ``scripts/seed_btd6_data.py``.
+    """
+    import hashlib
+    import json
+
+    from utils.db import btd6_data
+
+    src = FileRawProvider(root) if root is not None else FileRawProvider()
+    seeded = 0
+    for name in src.list_names():
+        if name == "manifest.json":  # bucket artifact, not a fixture
+            continue
+        body = src.load(name)
+        if body is None:
+            continue
+        sha = hashlib.sha256(
+            json.dumps(body, sort_keys=True, ensure_ascii=False).encode("utf-8"),
+        ).hexdigest()
+        await btd6_data.upsert_blob(name, body, sha)
+        seeded += 1
+    return seeded
+
+
 def _load_file(name: str) -> dict[str, Any]:
     raw = _PROVIDER.load(name)
     if raw is None:

--- a/docs/btd6-data-backends.md
+++ b/docs/btd6-data-backends.md
@@ -31,21 +31,26 @@ by repo-relative path (`towers.json`, `stats/dart_monkey.json`, …). At startup
 synchronous loaders then read from that dict (the async DB is never on a hot
 path).
 
-**Setup:**
+**Setup (no terminal needed — recommended):**
 
-1. The `btd6_data_blobs` table is created by migration `054` (runs
-   automatically on boot).
-2. Seed it from a checkout pointed at your deployment DB:
-   ```bash
-   # dry run (no DB):
-   python3.10 scripts/seed_btd6_data.py --dry-run
-   # seed (uses the bot's DSN env vars):
-   python3.10 scripts/seed_btd6_data.py
-   ```
-3. Set `BTD6_DATA_BACKEND=postgres` on Railway and redeploy.
-4. Verify: `!btd6 status` shows `Data source: postgres (<N> blobs)`.
-5. Refresh after a game patch: regenerate the fixtures, re-run the seed script
-   (it upserts).
+1. The `btd6_data_blobs` table is created by migration `054` automatically on
+   boot — nothing to do.
+2. In Discord, as a server **administrator**, run **`!btd6ops seed-data`**. The
+   bot loads its bundled data files into the table and replies with the count +
+   the next step. (Idempotent — safe to re-run, e.g. after a game-data update.)
+3. In **Railway → your bot service → Variables**, add `BTD6_DATA_BACKEND` =
+   `postgres`. Saving redeploys the service.
+4. Run **`!btd6 status`** — it should read `Data source: postgres (<N> blobs)`.
+
+⚠️ Order matters: **seed first** (step 2), *then* flip the variable (step 3). If
+you switch to `postgres` while the table is empty, BTD6 lookups report
+"unavailable" until you seed.
+
+**Alternative (CLI):** from a checkout with the deployment `DATABASE_URL`:
+```bash
+python3.10 scripts/seed_btd6_data.py --dry-run   # preview, no DB
+python3.10 scripts/seed_btd6_data.py             # seed
+```
 
 **Cutover — removing the data from the repo (gated):** once `!btd6 status`
 reads from Postgres and BTD6 lookups work, `git rm -r disbot/data/btd6/`

--- a/scripts/seed_btd6_data.py
+++ b/scripts/seed_btd6_data.py
@@ -67,17 +67,18 @@ def _print_summary(rows: list[tuple[str, Any, str]], root: Path) -> None:
         print(f"  … and {len(rows) - 10} more")
 
 
-async def seed(rows: list[tuple[str, Any, str]]) -> int:
+async def seed(root: Path) -> int:
+    # The DB write path lives in one place (btd6_data_service), shared with the
+    # in-app !btd6ops seed-data command.
+    from services import btd6_data_service
     from utils import db
-    from utils.db import btd6_data, pool
+    from utils.db import pool
 
     await db.init()
     try:
-        for name, body, sha in rows:
-            await btd6_data.upsert_blob(name, body, sha)
+        return await btd6_data_service.seed_postgres_from_files(root)
     finally:
         await pool.close()
-    return len(rows)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -100,7 +101,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.dry_run:
         return 0
 
-    count = asyncio.run(seed(rows))
+    count = asyncio.run(seed(root))
     print(f"seeded {count} blobs into btd6_data_blobs")
     return 0
 

--- a/tests/unit/cogs/test_btd6_ops_cog.py
+++ b/tests/unit/cogs/test_btd6_ops_cog.py
@@ -132,3 +132,51 @@ async def test_source_enable_prefix_allows_admin(monkeypatch) -> None:
     await BTD6OpsCog.source_enable_prefix.callback(cog, ctx, "nk_x")
     ctx.send.assert_awaited_once()
     assert "✅" in ctx.send.await_args.args[0]
+
+
+# ---------------------------------------------------------------------------
+# seed-data — administrator-gated Postgres seeding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_seed_data_prefix_denies_non_admin() -> None:
+    cog = BTD6OpsCog(bot=MagicMock())
+    ctx = MagicMock()
+    ctx.author = _actor(manage_guild=True)  # staff, but not administrator
+    ctx.send = AsyncMock()
+    await BTD6OpsCog.seed_data_prefix.callback(cog, ctx)
+    ctx.send.assert_awaited_once_with(_ADMIN_DENIED)
+
+
+@pytest.mark.asyncio
+async def test_seed_data_prefix_allows_admin(monkeypatch) -> None:
+    import discord
+
+    from cogs import btd6_ops_cog
+
+    async def _embed() -> discord.Embed:
+        return discord.Embed(title="🌱 BTD6 data seeded")
+
+    monkeypatch.setattr(btd6_ops_cog, "_seed_embed", _embed)
+    cog = BTD6OpsCog(bot=MagicMock())
+    ctx = MagicMock()
+    ctx.author = _actor(administrator=True)
+    ctx.send = AsyncMock()
+    await BTD6OpsCog.seed_data_prefix.callback(cog, ctx)
+    ctx.send.assert_awaited_once()
+    assert "embed" in ctx.send.await_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_seed_embed_reports_count(monkeypatch) -> None:
+    from cogs import btd6_ops_cog
+    from services import btd6_data_service
+
+    async def _seed(root=None) -> int:
+        return 42
+
+    monkeypatch.setattr(btd6_data_service, "seed_postgres_from_files", _seed)
+    embed = await btd6_ops_cog._seed_embed()
+    assert "42" in (embed.description or "")
+    assert "BTD6_DATA_BACKEND" in (embed.description or "")

--- a/tests/unit/cogs/test_btd6_ops_command_parity.py
+++ b/tests/unit/cogs/test_btd6_ops_command_parity.py
@@ -14,7 +14,7 @@ from discord import app_commands
 
 from cogs.btd6_ops_cog import BTD6OpsCog
 
-_EXPECTED = {"readiness", "runs", "source_enable", "source_disable"}
+_EXPECTED = {"readiness", "runs", "source_enable", "source_disable", "seed-data"}
 
 
 def _cog() -> BTD6OpsCog:

--- a/tests/unit/services/test_btd6_postgres_provider.py
+++ b/tests/unit/services/test_btd6_postgres_provider.py
@@ -134,3 +134,26 @@ def test_select_provider_file_default(monkeypatch):
     monkeypatch.setattr(config, "BTD6_DATA_BACKEND", "", raising=False)
     monkeypatch.setattr(config, "BTD6_DATA_BASE_URL", "", raising=False)
     assert isinstance(_select_provider(), FileRawProvider)
+
+
+@pytest.mark.asyncio
+async def test_seed_postgres_from_files_upserts_every_blob(monkeypatch):
+    """The seeder reads the bundled files and upserts each (DB mocked)."""
+    from services import btd6_data_service
+    from utils.db import btd6_data
+
+    calls: list[tuple] = []
+
+    async def fake_upsert(name, body, sha256=None):
+        calls.append((name, body, sha256))
+
+    monkeypatch.setattr(btd6_data, "upsert_blob", fake_upsert)
+
+    seeded = await btd6_data_service.seed_postgres_from_files()
+    assert seeded >= 7  # the committed fixtures (+ the stats tree)
+    names = {c[0] for c in calls}
+    assert "towers.json" in names
+    assert "manifest.json" not in names  # bucket artifact, excluded
+    assert all(isinstance(c[1], dict) for c in calls)  # parsed bodies
+    assert all(len(c[2]) == 64 for c in calls)  # sha256 hex provenance
+    assert len(calls) == seeded


### PR DESCRIPTION
## What & why

Makes the Postgres cutover doable **from Discord, no terminal/CLI** — because you don't code and are new to Railway, the CLI seed path (install Python, deps, Railway CLI, link the project) has a lot of failure points. Now an admin just runs one command and the bot loads its own bundled data into the `btd6_data_blobs` table.

Full CI mirror green (black/isort/ruff/mypy + **7045 tests**) and `check_architecture.py --mode strict` (0 errors).

## Changes
- **`services.btd6_data_service.seed_postgres_from_files()`** — reads the bundled data files via `FileRawProvider` (independent of whichever backend is active) and upserts each through `utils.db.btd6_data`. Idempotent; the single DB-write path, shared by the command and the script.
- **`btd6_ops_cog`: new admin-gated `seed-data`** (prefix `!btd6ops seed-data` + slash `/btd6ops seed-data`). Replies with the blob count + the next steps. Slash defers via `safe_defer` (INV-L) before the work, then `safe_followup`.
- **`scripts/seed_btd6_data.py`** now delegates to the service function (one writer, no duplicated loop).
- **`docs/btd6-data-backends.md`** leads with the no-terminal path; CLI kept as the alternative; spells out the seed-then-flip ordering.

## How you'll use it (after merging this)
1. Merge → Railway redeploys with the new command.
2. In your server, as an **administrator**, type **`!btd6ops seed-data`**. The bot replies e.g. *"Upserted 67 blobs…"*.
3. In **Railway → your bot service → Variables**, add `BTD6_DATA_BACKEND` = `postgres` (saving redeploys).
4. Type **`!btd6 status`** → it should say `Data source: postgres (…)`.

⚠️ Seed first, *then* set the variable — if you flip it while the table is empty, BTD6 lookups report "unavailable" until you seed. (Re-running `seed-data` any time is safe — it upserts.)

Once you confirm `!btd6 status` reads `postgres`, ping me and I'll do the repo-removal PR (add a small CI fixture subset + `git rm` the bulk data).

https://claude.ai/code/session_015ahLXjrjnVjqtTmfau5wa2

---
_Generated by [Claude Code](https://claude.ai/code/session_015ahLXjrjnVjqtTmfau5wa2)_