### PR TITLE
BTD6 data: keep as Postgres seed source, mark generated for a tidy repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# BTD6 deterministic data is served from Postgres at runtime (the
+# btd6_data_blobs table; see docs/btd6-data-backends.md). The committed JSON
+# under disbot/data/btd6/ is kept on purpose as the seed source
+# (!btd6ops seed-data), the default/local/CI backend, and a version-controlled
+# backup. Mark it generated so GitHub collapses it in diffs and excludes it
+# from the repo's language statistics.
+disbot/data/btd6/** linguist-generated=true

--- a/docs/btd6-data-backends.md
+++ b/docs/btd6-data-backends.md
@@ -52,19 +52,21 @@ python3.10 scripts/seed_btd6_data.py --dry-run   # preview, no DB
 python3.10 scripts/seed_btd6_data.py             # seed
 ```
 
-**Cutover — removing the data from the repo (gated):** once `!btd6 status`
-reads from Postgres and BTD6 lookups work, `git rm -r disbot/data/btd6/`
-(keeping the generator scripts) and commit. Do this only after the table is
-seeded **and** every consumer reads from PG (see the stats note below).
+**The committed files are kept on purpose.** Production reads from Postgres
+(`BTD6_DATA_BACKEND=postgres`), but the JSON under `disbot/data/btd6/` stays in
+the repo as: the seed source (`!btd6ops seed-data` reads it), the default
+backend for local dev + CI, and a version-controlled backup. They're marked
+`linguist-generated` in `.gitattributes`, so GitHub collapses them in diffs and
+drops them from language stats — the repo stays tidy without losing the safety
+net or the easy re-seed. (Deleting them would break `!btd6ops seed-data` and the
+file backend for ~6 MB of cosmetic savings, so we don't.)
 
 ## Scope note (fixtures vs the stats tree)
 
-`btd6_data_service` (the 7 fixtures) reads through the provider today, so it
-honours `BTD6_DATA_BACKEND` immediately. The per-entity `stats/` tree
-(`btd6_stats_service`, the 5.8 MB bulk) is migrated to the same provider/seam in
-the same series — the seed script already loads `stats/**` into the table, so
-the data is present; the repo-removal cutover waits until the stats loaders read
-from PG too.
+`btd6_data_service` (the 9 fixtures) and `btd6_stats_service` (the per-entity
+`stats/` tree, the 5.8 MB bulk) both read through the provider, so the whole
+data set honours `BTD6_DATA_BACKEND`. `!btd6ops seed-data` loads all 53 blobs
+into the table in one go.
 
 ## CI hermeticity
 


### PR DESCRIPTION
## What & why

You confirmed the seed worked (**53 blobs** = 9 fixtures + 44 stats, which I verified is the correct/complete count) and `!btd6 status` reads Postgres. For the repo "cleanup", you chose to **keep the data files** rather than delete them — the right call.

Production now reads from Postgres, but the committed JSON under `disbot/data/btd6/` is worth keeping as:
- the **seed source** — `!btd6ops seed-data` reads it (deleting it would make that command seed 0),
- the **default backend** for local dev + CI,
- a **version-controlled backup**.

Deleting it would trade those safety nets for ~6 MB of cosmetic savings — and the files are already invisible to CodeGraph (ignores JSON) and code search. So instead this just marks them **generated**, which gives the tidy feel with zero fragility:

- **`.gitattributes`**: `disbot/data/btd6/** linguist-generated=true` → GitHub collapses these files in pull-request diffs and drops them from the repo's language statistics. Verified with `git check-attr` (data files → `generated: true`; code files unaffected).
- **`docs/btd6-data-backends.md`**: records the keep-and-mark decision and that all 53 blobs seed in one `!btd6ops seed-data`.

No code changes; `check_quality.py` clean.

## Bottom line — the migration is complete
The bot serves BTD6 data from Postgres, it's queryable, refreshable via `!btd6ops seed-data` (re-run anytime; upserts), and the repo's tidy. Nothing else is required.

https://claude.ai/code/session_015ahLXjrjnVjqtTmfau5wa2

---
_Generated by [Claude Code](https://claude.ai/code/session_015ahLXjrjnVjqtTmfau5wa2)_