### PR TITLE
feat(btd6): patch-notes diff assist + game-file-extraction plan

### DIFF
--- a/docs/btd6-game-file-extraction-plan.md
+++ b/docs/btd6-game-file-extraction-plan.md
@@ -1,0 +1,185 @@
+# BTD6 game-file extraction — plan & handoff
+
+> **Status:** PLAN ONLY — no extraction code written yet. Parked at the
+> **recon** step (the user runs it on their tablet; see § "Step 1").
+> This is a *roadmap* doc (read for context); when it disagrees with the
+> source, the source wins.
+>
+> **Last updated:** 2026-06-03 (session that shipped the Steam patch-notes
+> feed + the patch-notes diff tool — see § "What already shipped").
+
+---
+
+## Why this exists (the problem)
+
+The BTD6 cog's structured stats (`disbot/data/btd6/stats/*.json`) come from
+**bloonswiki.com** via `scripts/fetch_bloonswiki.py`. That source has two
+real weaknesses we hit head-on:
+
+1. **Timing lag.** After a game patch, bloonswiki updates *per-tower, over
+   hours-to-days*. Verified live on 2026-06-03: with BTD6 v55 released that
+   day, **zero** towers on the wiki were stamped `55.0` (newest was `54.0`;
+   many towers still at `53.0`/`52.2`).
+2. **Coverage gaps — the wiki simply doesn't have the data.**
+   - **Only 6 of 17 heroes** have per-level stat modules: `adora`,
+     `geraldo`, `gwendolin`, `quincy`, `sauda`, `striker_jones`. The other
+     **11 have no module**: `admiral_brickell`, `benjamin`,
+     `captain_churchill`, `corvus`, `etienne`, `ezili`, `obyn_greenfoot`,
+     `pat_fusty`, `psi`, `rosalia`, `silas`.
+   - **2 of 13 paragons** are hand-transcribed from prose (flagged
+     `is_prose_sourced`): **Root of all Nature** (Druid) and **Herald of
+     Everfrost** (Ice Monkey) — the wiki 404s their stats modules.
+
+## Why patch notes can't fix this (settled)
+
+Patch notes (Steam / r/btd6) are **deltas, not full state** — a changelog,
+not a snapshot. You cannot reconstruct a tower's complete stat block from
+them (no anchor for the unchanged ~95% of values; many lines are
+non-numeric "reworked"/"increased"). Worse for the gaps: a hero that isn't
+rebalanced appears in **zero** notes, so notes can never fill a hole the
+wiki has. Patch notes are good for *maintenance/verification*, not baseline
+construction.
+
+**Source accuracy ranking: game files > bloonswiki > patch notes.**
+Game-file extraction is the only source that is both **complete** (covers
+the 11 heroes + 2 paragons) and **day-one accurate** (no wiki lag).
+
+## What already shipped (the interim / maintenance layer)
+
+These handle "stay current between patches" while the wiki catches up; they
+do **not** replace the need for a complete source:
+
+- **PR #459 (merged):** Steam `ISteamNews/GetNewsForApp` ingestion (appid
+  `960090`, no API key) → `btd6_patch_notes` + a `btd6.version_detected`
+  event → `services/btd6_version_announce` posts to a configured channel
+  (`!btd6ops announcechannel`). Gives the *prose notes* + a "new version
+  dropped" signal immediately.
+- **PR #460 (open, CI green):** `scripts/btd6_patch_diff.py` — parses notes
+  text, verifies each `old > new` against the on-disk stat files, and
+  buckets changes (CLEAN/LIKELY/STALE/REVIEW/NO_FILE/SCOPE). Turns each
+  patch into a reviewable worklist; never auto-applies.
+
+---
+
+## The extraction approach
+
+BTD6 is **Unity / IL2CPP**. Gameplay data (towers, upgrades, bloons,
+rounds, **all heroes, all paragons**) ships as **AES-encrypted JSON
+`TextAsset`s** inside the Unity assets. The decryption key is a game
+constant (lives in the native binary — `libil2cpp.so` on Android,
+`GameAssembly.dll` on PC), so an **Android extraction yields identical data
+to PC**.
+
+Pipeline:
+
+1. **Locate** BTD6's asset files on the device.
+2. **Extract** the `TextAsset`s — Python **UnityPy**.
+3. **Decrypt** — AES with the community-known key. *This is the crux / the
+   one genuinely uncertain step.*
+4. **Validate** against known anchors before trusting anything (e.g. Dart
+   Monkey base cost = `200`, Super Monkey = `2500` — cross-check a handful
+   against the current committed files).
+5. **Map** the game-model JSON → our `stats/<id>.json` schema (a
+   `parse_gamedata`-style module, analogous to `parse_bloonswiki.py`).
+6. **Commit** with clear provenance; re-run each patch.
+
+**Payoff:** complete coverage (17/17 heroes, 13/13 paragons), exact, day-one.
+**Cost:** re-run per patch (assets change; occasionally the key/format
+shifts), and step 3 may need iteration.
+
+## Environment & device facts
+
+- **Claude runs in an ephemeral cloud sandbox** with *no game files and no
+  way to fetch them*. Claude **cannot run the extraction** — it builds the
+  tooling/mapper/tests and integrates; the **user runs extraction on their
+  device** and feeds back decrypted-JSON samples to iterate on.
+- **Device:** Samsung Galaxy Tab S11 Ultra (Android), keyboard + mouse.
+  **BTD6 is installed** (Play Store build). **NOT rooted.**
+- **On-device toolchain:** **Termux** (install from **F-Droid**, not Play
+  Store) → `pkg install python` → `pip install UnityPy` (may need native
+  deps: lz4 / brotli / Pillow build tools first).
+
+## Division of labor
+
+| Claude (in repo) | User (on tablet) |
+|---|---|
+| Extractor + decrypt + mapper scripts (`scripts/`) | Set up Termux + Python + UnityPy |
+| Schema mapping + validation harness + tests | Get at BTD6 asset files; run scripts |
+| Pipeline integration + provenance flags | Paste decrypted-JSON samples; iterate on decryption |
+
+---
+
+## Step 1 — RECON (do first, on the tablet, in Termux)
+
+Cheap, safe, no decryption. Tells us whether the gameplay data is **inside
+the APK** (easy, no scoped-storage problem) or in **external downloaded
+bundles** under `/sdcard/Android/data/...` (harder on Android 11+ without
+root). Paste the output back.
+
+```bash
+# 1. Confirm it's installed + the package name
+pm list packages | grep -iE "ninjakiwi|bloons"
+
+# 2. Where are the APK(s)?  (use the package id from step 1)
+pm path com.ninjakiwi.bloonstd6
+
+# 3. Pull the base APK and look for Unity data assets inside
+cp "$(pm path com.ninjakiwi.bloonstd6 | head -1 | cut -d: -f2)" ~/btd6.apk
+unzip -l ~/btd6.apk | grep -iE "bin/Data|\.unity3d|resources|\.assets|globalgamemanagers" | head -30
+
+# 4. Sizes — APK vs external data dir (external may be blocked; that's fine)
+du -h ~/btd6.apk
+ls -laR /sdcard/Android/data/com.ninjakiwi.bloonstd6/ 2>/dev/null | head -40
+```
+
+## Phased plan (after recon)
+
+- **Phase 0 — recon** (above): confirm format/location on the actual device.
+- **Phase 1 — extract**: UnityPy script to pull `TextAsset`s from the
+  confirmed location.
+- **Phase 2 — decrypt + validate**: apply the community AES key; confirm
+  against anchors. *Gate: do not proceed until anchors match.*
+- **Phase 3 — map**: game-model JSON → `stats/<id>.json` schema; start with
+  one tower end-to-end (e.g. dart_monkey) to prove the mapping, then a hero
+  the wiki lacks (e.g. `benjamin`) to prove the gap is closed.
+- **Phase 4 — integrate**: add as a data source (alongside/over bloonswiki),
+  stamp provenance, wire into the existing CSV→JSON / data-service flow.
+- **Phase 5 — maintain**: documented re-run procedure per patch.
+
+## Open questions / risks
+
+- **Scoped storage** (Android 11+): only an issue if data is *external* to
+  the APK. No root, so we'd need a SAF-capable file manager to copy the
+  app's `Android/data` to shared storage. Recon step 3/4 decides if this
+  even matters.
+- **Decryption key currency**: the community key may be stale if NK rotated
+  it recently — validated against anchors in Phase 2.
+- **Termux native deps**: UnityPy's lz4/brotli/Pillow may need manual
+  `pkg install` of build tooling on ARM64.
+- **Untestable in the sandbox**: Claude debugs partly blind; the user is the
+  eyes on real files.
+
+## Legal / licensing stance
+
+- The bot is **free, non-commercial, mostly private servers**; future
+  monetization is unrelated commissioned work (e.g. custom in-chat games),
+  **not** this BTD6 data. This is the lowest-risk category for personal
+  data-mining (same as how the wiki community sources its data).
+- Raw stat **numbers are facts** (not copyrightable). BTD6's EULA prohibits
+  reverse-engineering; extracting/decrypting assets is a gray area accepted
+  for personal/informational use.
+- **Do NOT commit** the AES key, the decryption routine sourced from the
+  binary, or wholesale decrypted asset dumps to the repo. Commit only the
+  **derived stat values** in our schema, with a `source` provenance note.
+- This *replaces* bloonswiki's CC-BY-NC-SA "NC matters if monetized" concern
+  with the EULA/RE one — acceptable given the non-commercial use above.
+
+## Pick-up checklist for next session
+
+1. Has the user run **Step 1 recon**? If yes, read their output → decide
+   APK-vs-external path.
+2. Confirm Termux + UnityPy install status on the tablet.
+3. Proceed to Phase 1 (extract) → Phase 2 (decrypt + **validate against
+   anchors**) before any mapping.
+4. Companion docs: `docs/btd6-data-pipeline.md` (the bloonswiki pipeline this
+   would augment/replace), `docs/btd6-data-backends.md`.

--- a/scripts/btd6_patch_diff.py
+++ b/scripts/btd6_patch_diff.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3.10
+"""Propose BTD6 stat-file edits from patch-notes text — review, never apply.
+
+Patch notes (Steam / r/btd6) are *prose deltas*: "x5x Permacharge damage 8 > 10".
+The runtime stat files (``disbot/data/btd6/stats/*.json``) are the *full* state.
+This tool bridges the two as a **curation accelerator**: it parses every
+``old > new`` line, locates the target tower/hero file, checks whether the
+stated "old" value actually matches what's on disk, and buckets each change by
+how safely it could be applied. It writes nothing — bloonswiki (via
+``fetch_bloonswiki.py``) remains the authoritative source for the real numbers.
+
+Confidence buckets
+------------------
+* ``CLEAN``   — a cost field whose current value equals the note's "old".
+                Deterministic; safe to apply as a provisional patch.
+* ``LIKELY``  — a combat stat whose "old" value is present in the file and the
+                file is at a trusted baseline (>= v54). Needs field-locating.
+* ``STALE``   — the file's ``game_version`` predates the patch baseline, so the
+                note's "old" value can't be trusted to match. Use the wiki.
+* ``REVIEW``  — additive ("+4"), relative ("doubled"), reworks, or "old" not
+                found — a human must decide.
+* ``NO_FILE`` — the subject (e.g. a hero we don't carry stats for) has no file.
+* ``SCOPE``   — Powers / Bosses / Rogue / cosmetic: not a tower-stat file.
+
+Usage
+-----
+    python3.10 scripts/btd6_patch_diff.py --notes-file v55.txt
+    pbpaste | python3.10 scripts/btd6_patch_diff.py --notes-file -
+    python3.10 scripts/btd6_patch_diff.py --notes-file v55.txt --json > proposed.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_DATA = _REPO_ROOT / "disbot" / "data" / "btd6"
+
+# Patch notes assume roughly the previous full release as a baseline; a file
+# older than this can't be trusted to hold the note's stated "old" values.
+_MIN_TRUSTED_BASELINE = (54, 0)
+
+# "8 > 10", "$85,000 > $90,000", "600k > 650k", "6s > 18s", "+15 > +20".
+_TRANSITION_RE = re.compile(
+    r"(?P<old>[+\-]?\$?\d[\d,]*\.?\d*\s*[kKmMsS%]?)\s*(?:>|→|->)\s*"
+    r"(?P<new>[+\-]?\$?\d[\d,]*\.?\d*\s*[kKmMsS%]?)",
+)
+# Leading tier/level token of a change line.
+_TIER_RE = re.compile(
+    r"^\s*(?:\((?P<paren>Paragon)\)|(?P<code>xx\d|x\dx|\dxx|\d{3})|Lv\s?(?P<lv>\d+))",
+    re.IGNORECASE,
+)
+_BULLET_RE = re.compile(r"^\s*[*\-+]\s+")
+_COST_RE = re.compile(r"\b(price|cost)\b", re.IGNORECASE)
+
+# Section headers that scope subsequent lines out of tower-stat territory.
+_SCOPE_HEADERS = {"powers", "bosses", "rogue"}
+# Headers that merely precede real subjects (skip, don't treat as a subject).
+_PASSTHROUGH_HEADERS = {"balance changes", "hero balance"}
+
+
+@dataclass(frozen=True)
+class Subject:
+    name: str
+    kind: str  # "tower" | "hero" | "scope"
+    target_id: str | None
+
+
+@dataclass
+class Change:
+    subject: str
+    kind: str
+    target_id: str | None
+    tier: str | None
+    text: str
+    old_raw: str
+    new_raw: str
+
+
+@dataclass
+class Assessment:
+    bucket: str
+    subject: str
+    text: str
+    detail: str
+    file: str | None = None
+    field: str | None = None
+    old: float | None = None
+    new: float | None = None
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers (pure)
+# ---------------------------------------------------------------------------
+
+
+def to_number(raw: str) -> float | None:
+    """Normalise a note value (``$90,000`` / ``600k`` / ``18s`` / ``+4``)."""
+    s = raw.strip().lower().replace("$", "").replace(",", "").replace("+", "")
+    mult = 1.0
+    if s.endswith("k"):
+        mult, s = 1000.0, s[:-1]
+    elif s.endswith("m"):
+        mult, s = 1_000_000.0, s[:-1]
+    elif s.endswith(("s", "%")):
+        s = s[:-1]
+    try:
+        return float(s) * mult
+    except ValueError:
+        return None
+
+
+def extract_transition(text: str) -> tuple[str, str] | None:
+    """Return the last ``old > new`` pair in *text*, or ``None``.
+
+    Uses the *last* match so a leading tier code (``xx4 ... 8 > 6``) or a
+    descriptive number can't be mistaken for the transition.
+    """
+    matches = list(_TRANSITION_RE.finditer(text))
+    if not matches:
+        return None
+    last = matches[-1]
+    return last.group("old").strip(), last.group("new").strip()
+
+
+def parse_tier(text: str) -> str | None:
+    """Extract the leading tier/level token (``x5x``, ``Lv20``, ``Paragon``)."""
+    m = _TIER_RE.match(text)
+    if not m:
+        return None
+    if m.group("paren"):
+        return "Paragon"
+    if m.group("lv"):
+        return f"Lv{m.group('lv')}"
+    return m.group("code")
+
+
+def tier_to_path(code: str | None) -> tuple[int, int] | None:
+    """Map a single-upgrade code (``xx5``/``5xx``/``x4x``) to ``(path, tier)``.
+
+    Crosspath states like ``052`` are not single upgrades, so they return
+    ``None`` (cost lines never use that form).
+    """
+    if not code or len(code) != 3 or code.isdigit():
+        return None
+    for idx, ch in enumerate(code):
+        if ch.isdigit() and ch != "0":
+            return idx + 1, int(ch)
+    return None
+
+
+def build_index() -> dict[str, Subject]:
+    """Lowercased canonical+alias name -> Subject, from towers.json/heroes.json."""
+    index: dict[str, Subject] = {}
+
+    def add(entries: list[dict[str, Any]], kind: str) -> None:
+        for e in entries:
+            names = [e["canonical"], *(e.get("aliases") or [])]
+            for n in names:
+                index[str(n).lower()] = Subject(e["canonical"], kind, e["id"])
+
+    towers = json.loads((_DATA / "towers.json").read_text())
+    heroes = json.loads((_DATA / "heroes.json").read_text())
+    add(towers["towers"] if isinstance(towers, dict) else towers, "tower")
+    add(heroes["heroes"] if isinstance(heroes, dict) else heroes, "hero")
+    return index
+
+
+def resolve_subject(line: str, index: dict[str, Subject]) -> Subject | None:
+    """If *line* is a section/subject header, return the Subject it introduces."""
+    if _BULLET_RE.match(line):
+        return None
+    stripped = line.strip()
+    low = stripped.lower()
+    if low in _PASSTHROUGH_HEADERS:
+        return None
+    for header in _SCOPE_HEADERS:
+        if low == header or low.startswith(header + " "):
+            return Subject(stripped.split()[0], "scope", None)
+    # Longest known name that is a word-prefix of the line wins.
+    for name in sorted(index, key=len, reverse=True):
+        if low == name or low.startswith(name + " "):
+            return index[name]
+    return None
+
+
+def parse_notes(text: str, index: dict[str, Subject]) -> list[Change]:
+    """Walk the notes, attaching each ``old > new`` line to its subject."""
+    changes: list[Change] = []
+    subject: Subject | None = None
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+        if not line.strip():
+            continue
+        header = resolve_subject(line, index)
+        if header is not None:
+            subject = header
+            continue
+        if subject is None:
+            continue
+        body = _BULLET_RE.sub("", line).strip()
+        transition = extract_transition(body)
+        if transition is None:
+            continue
+        old_raw, new_raw = transition
+        changes.append(
+            Change(
+                subject=subject.name,
+                kind=subject.kind,
+                target_id=subject.target_id,
+                tier=parse_tier(body),
+                text=body,
+                old_raw=old_raw,
+                new_raw=new_raw,
+            ),
+        )
+    return changes
+
+
+# ---------------------------------------------------------------------------
+# Assessment (reads the stat files)
+# ---------------------------------------------------------------------------
+
+
+def _version_tuple(version: str) -> tuple[int, ...]:
+    parts: list[int] = []
+    for chunk in str(version).split("."):
+        if chunk.isdigit():
+            parts.append(int(chunk))
+        else:
+            break
+    return tuple(parts)
+
+
+def _collect_numbers(obj: Any, out: set[float]) -> None:
+    if isinstance(obj, bool):
+        return
+    if isinstance(obj, (int, float)):
+        out.add(float(obj))
+    elif isinstance(obj, dict):
+        for v in obj.values():
+            _collect_numbers(v, out)
+    elif isinstance(obj, list):
+        for v in obj:
+            _collect_numbers(v, out)
+
+
+def _stats_path(change: Change, stats_dir: Path) -> Path:
+    sub = "heroes/" if change.kind == "hero" else ""
+    return stats_dir / f"{sub}{change.target_id}.json"
+
+
+def _match_cost_field(
+    data: dict[str, Any],
+    change: Change,
+    old: float | None,
+) -> tuple[str, float] | None:
+    """Locate the cost field a cost-line targets.
+
+    Order: explicit paragon -> upgrade named in the note -> tier code -> a
+    unique cost field whose current value equals the stated "old". The last
+    fallback catches lines like "Upgrade cost 650k > 600k" whose paragon
+    context lives in the section prose rather than the bullet itself.
+    """
+    low = change.text.lower()
+    if "paragon" in low or change.tier == "Paragon":
+        if "paragon_cost" in data:
+            return "paragon_cost", float(data["paragon_cost"])
+    upgrades = data.get("upgrades") or []
+    for up in upgrades:
+        name = str(up.get("name", "")).lower()
+        if name and name in low:
+            return f"upgrades[{up['path']}-{up['tier']}].cost", float(up["cost"])
+    pt = tier_to_path(change.tier)
+    if pt is not None:
+        for up in upgrades:
+            if (up.get("path"), up.get("tier")) == pt:
+                return f"upgrades[{pt[0]}-{pt[1]}].cost", float(up["cost"])
+    if old is not None:
+        candidates: dict[str, float] = {}
+        if "paragon_cost" in data:
+            candidates["paragon_cost"] = float(data["paragon_cost"])
+        for up in upgrades:
+            candidates[f"upgrades[{up['path']}-{up['tier']}].cost"] = float(up["cost"])
+        hits = [(k, v) for k, v in candidates.items() if abs(v - old) < 1e-6]
+        if len(hits) == 1:
+            return hits[0]
+    return None
+
+
+def assess(change: Change, stats_dir: Path) -> Assessment:
+    base = Assessment(
+        bucket="REVIEW",
+        subject=change.subject,
+        text=change.text,
+        detail="",
+    )
+    old = to_number(change.old_raw)
+    new = to_number(change.new_raw)
+    base.old, base.new = old, new
+
+    if change.kind == "scope":
+        base.bucket = "SCOPE"
+        base.detail = "Powers/Bosses/Rogue — not a tower-stat file."
+        return base
+
+    path = _stats_path(change, stats_dir)
+    if change.target_id is None or not path.exists():
+        base.bucket = "NO_FILE"
+        base.detail = f"no stats file for {change.subject!r}"
+        return base
+    try:
+        base.file = str(path.relative_to(_REPO_ROOT))
+    except ValueError:
+        base.file = str(path)
+
+    if old is None or new is None:
+        base.detail = "non-numeric / additive change — decide manually"
+        return base
+
+    data = json.loads(path.read_text())
+    stale = _version_tuple(data.get("game_version", "0")) < _MIN_TRUSTED_BASELINE
+    version = data.get("game_version", "?")
+
+    if _COST_RE.search(change.text):
+        found = _match_cost_field(data, change, old)
+        if found is None:
+            base.detail = "cost line but no matching cost field found"
+            return base
+        base.field, current = found
+        if abs(current - old) < 1e-6:
+            base.bucket = "CLEAN"
+            base.detail = f"{base.field} = {current:g} matches old; set -> {new:g}"
+        elif stale:
+            base.bucket = "STALE"
+            base.detail = f"file v{version}; {base.field}={current:g} != old {old:g}"
+        else:
+            base.detail = f"{base.field}={current:g} != note old {old:g} — verify"
+        return base
+
+    # Combat stat: gauge applicability by whether "old" appears in the file.
+    numbers: set[float] = set()
+    _collect_numbers(data, numbers)
+    present = any(abs(n - old) < 1e-6 for n in numbers)
+    if stale:
+        base.bucket = "STALE"
+        base.detail = f"file v{version} predates baseline — old value unreliable" + (
+            "" if present else "; old value also absent"
+        )
+    elif present:
+        base.bucket = "LIKELY"
+        base.detail = (
+            f"old {old:g} present in file (v{version}); locate field + crosspaths"
+        )
+    else:
+        base.detail = f"old {old:g} not found in file (v{version}) — already changed or different field"
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+_BUCKET_ORDER = ("CLEAN", "LIKELY", "STALE", "REVIEW", "NO_FILE", "SCOPE")
+_BUCKET_BLURB = {
+    "CLEAN": "verified — current value matches the note's old; safe provisional apply",
+    "LIKELY": "old value present at a trusted baseline; needs field-locating",
+    "STALE": "file predates the patch baseline; use bloonswiki",
+    "REVIEW": "additive / relative / rework / not found — human decides",
+    "NO_FILE": "no stat file for this subject",
+    "SCOPE": "not a tower/hero stat (Powers/Bosses/Rogue/cosmetic)",
+}
+
+
+def render(assessments: list[Assessment]) -> str:
+    by_bucket: dict[str, list[Assessment]] = {b: [] for b in _BUCKET_ORDER}
+    for a in assessments:
+        by_bucket.setdefault(a.bucket, []).append(a)
+    lines: list[str] = ["", "BTD6 patch-notes → proposed stat edits (review only)", ""]
+    counts = ", ".join(f"{b}:{len(by_bucket[b])}" for b in _BUCKET_ORDER)
+    lines.append(f"  {counts}   (total {len(assessments)})")
+    lines.append("")
+    for b in _BUCKET_ORDER:
+        items = by_bucket[b]
+        if not items:
+            continue
+        lines.append(f"== {b} ({len(items)}) — {_BUCKET_BLURB[b]}")
+        for a in items:
+            head = f"  [{a.subject}] {a.text}"
+            lines.append(head if len(head) <= 100 else head[:97] + "...")
+            lines.append(f"      → {a.detail}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--notes-file",
+        required=True,
+        help="Path to the patch-notes text, or '-' for stdin.",
+    )
+    parser.add_argument(
+        "--stats-dir",
+        default=str(_DATA / "stats"),
+        help="Override the stats directory (default: disbot/data/btd6/stats).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable proposed edits as JSON.",
+    )
+    args = parser.parse_args(argv)
+
+    text = (
+        sys.stdin.read()
+        if args.notes_file == "-"
+        else Path(args.notes_file).read_text(encoding="utf-8")
+    )
+    index = build_index()
+    changes = parse_notes(text, index)
+    assessments = [assess(c, Path(args.stats_dir)) for c in changes]
+
+    if args.json:
+        print(json.dumps([asdict(a) for a in assessments], indent=2))
+    else:
+        print(render(assessments))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_btd6_patch_diff.py
+++ b/tests/unit/scripts/test_btd6_patch_diff.py
@@ -1,0 +1,226 @@
+"""Tests for ``scripts/btd6_patch_diff.py``.
+
+Covers the pure parsing helpers and the file-aware ``assess`` bucketing
+(CLEAN / LIKELY / STALE / NO_FILE / SCOPE) against crafted temp stat files,
+so the tool's verdicts are pinned independent of the live data snapshot.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO_ROOT / "scripts" / "btd6_patch_diff.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("btd6_patch_diff_under_test", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_to_number_units(mod):
+    assert mod.to_number("600k") == 600000
+    assert mod.to_number("$90,000") == 90000
+    assert mod.to_number("8") == 8
+    assert mod.to_number("1.5s") == 1.5
+    assert mod.to_number("+4") == 4
+    assert mod.to_number("44%") == 44
+    assert mod.to_number("reworked") is None
+
+
+def test_extract_transition_takes_last_pair(mod):
+    assert mod.extract_transition("xx4 darts damage 8 > 6") == ("8", "6")
+    # Two arrows (a boss HP line) — the real transition is the last pair.
+    assert mod.extract_transition("Tail HP > 12.5% > 10%") == ("12.5%", "10%")
+    assert mod.extract_transition("arrow form → uses unicode 5 → 9") == ("5", "9")
+    assert mod.extract_transition("reworked, no numbers") is None
+
+
+def test_parse_tier(mod):
+    assert mod.parse_tier("x5x Permacharge 8 > 10") == "x5x"
+    assert mod.parse_tier("(Paragon) Vinenado 6s > 18s") == "Paragon"
+    assert mod.parse_tier("Lv20 ball 15 > 20") == "Lv20"
+    assert mod.parse_tier("Main attack boss damage 300 > 100") is None
+
+
+def test_tier_to_path(mod):
+    assert mod.tier_to_path("xx5") == (3, 5)
+    assert mod.tier_to_path("5xx") == (1, 5)
+    assert mod.tier_to_path("x4x") == (2, 4)
+    assert mod.tier_to_path("052") is None  # crosspath state, not one upgrade
+    assert mod.tier_to_path(None) is None
+
+
+def test_parse_notes_attaches_changes_to_subject(mod):
+    index = {"bomb shooter": mod.Subject("Bomb Shooter", "tower", "bomb_shooter")}
+    text = (
+        "Bomb Shooter some prose about the change\n"
+        "* Paragon upgrade price 600k > 650k\n"
+        "* a reworked thing with no numbers\n"
+    )
+    changes = mod.parse_notes(text, index)
+    assert len(changes) == 1
+    assert changes[0].target_id == "bomb_shooter"
+    assert (changes[0].old_raw, changes[0].new_raw) == ("600k", "650k")
+
+
+def test_parse_notes_scopes_powers_section(mod):
+    index = {"bomb shooter": mod.Subject("Bomb Shooter", "tower", "bomb_shooter")}
+    text = "Powers\n* Hype Monkey Boost monkey money cost 400 > 300\n"
+    changes = mod.parse_notes(text, index)
+    assert len(changes) == 1
+    assert changes[0].kind == "scope"
+
+
+# ---------------------------------------------------------------------------
+# assess() bucketing against crafted stat files
+# ---------------------------------------------------------------------------
+
+
+def _write(tmp_path: Path, name: str, payload: dict) -> None:
+    target = tmp_path / name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_assess_clean_cost_match(mod, tmp_path):
+    _write(
+        tmp_path,
+        "bomb_shooter.json",
+        {"game_version": "54.0", "paragon_cost": 600000, "upgrades": []},
+    )
+    change = mod.Change(
+        subject="Bomb Shooter",
+        kind="tower",
+        target_id="bomb_shooter",
+        tier=None,
+        text="Paragon upgrade price 600k > 650k",
+        old_raw="600k",
+        new_raw="650k",
+    )
+    result = mod.assess(change, tmp_path)
+    assert result.bucket == "CLEAN"
+    assert result.field == "paragon_cost"
+
+
+def test_assess_clean_cost_value_fallback(mod, tmp_path):
+    # No "paragon" in the bullet and no tier code, but exactly one cost field
+    # equals the stated old -> still resolves CLEAN.
+    _write(
+        tmp_path,
+        "engineer_monkey.json",
+        {"game_version": "52.2", "paragon_cost": 650000, "upgrades": []},
+    )
+    change = mod.Change(
+        subject="Engineer Monkey",
+        kind="tower",
+        target_id="engineer_monkey",
+        tier=None,
+        text="Upgrade cost reduced: 650k > 600k",
+        old_raw="650k",
+        new_raw="600k",
+    )
+    result = mod.assess(change, tmp_path)
+    assert result.bucket == "CLEAN"
+    assert result.field == "paragon_cost"
+
+
+def test_assess_stale_baseline(mod, tmp_path):
+    _write(
+        tmp_path,
+        "wizard_monkey.json",
+        {"game_version": "52.2", "upgrades": [], "node": {"dmg": 1000}},
+    )
+    change = mod.Change(
+        subject="Wizard Monkey",
+        kind="tower",
+        target_id="wizard_monkey",
+        tier=None,
+        text="Flamethrower Boss bonus damage 1000 > 800",
+        old_raw="1000",
+        new_raw="800",
+    )
+    assert mod.assess(change, tmp_path).bucket == "STALE"
+
+
+def test_assess_likely_when_old_value_present(mod, tmp_path):
+    _write(
+        tmp_path,
+        "druid.json",
+        {"game_version": "54.0", "upgrades": [], "t": {"storm": {"damage": 150}}},
+    )
+    change = mod.Change(
+        subject="Druid",
+        kind="tower",
+        target_id="druid",
+        tier="5xx",
+        text="5xx storm damage 150 > 100",
+        old_raw="150",
+        new_raw="100",
+    )
+    assert mod.assess(change, tmp_path).bucket == "LIKELY"
+
+
+def test_assess_review_when_old_absent_and_fresh(mod, tmp_path):
+    _write(
+        tmp_path,
+        "druid.json",
+        {"game_version": "54.0", "upgrades": [], "t": {"storm": {"damage": 999}}},
+    )
+    change = mod.Change(
+        subject="Druid",
+        kind="tower",
+        target_id="druid",
+        tier="5xx",
+        text="5xx storm damage 150 > 100",
+        old_raw="150",
+        new_raw="100",
+    )
+    assert mod.assess(change, tmp_path).bucket == "REVIEW"
+
+
+def test_assess_no_file_for_uncarried_hero(mod, tmp_path):
+    change = mod.Change(
+        subject="Pat Fusty",
+        kind="hero",
+        target_id="pat_fusty",
+        tier="Lv1",
+        text="Lv1 tower range 24 > 27",
+        old_raw="24",
+        new_raw="27",
+    )
+    assert mod.assess(change, tmp_path).bucket == "NO_FILE"
+
+
+def test_assess_scope_is_out_of_scope(mod, tmp_path):
+    change = mod.Change(
+        subject="Powers",
+        kind="scope",
+        target_id=None,
+        tier=None,
+        text="Hype Monkey Boost monkey money cost 400 > 300",
+        old_raw="400",
+        new_raw="300",
+    )
+    assert mod.assess(change, tmp_path).bucket == "SCOPE"
+
+
+def test_build_index_resolves_real_catalog(mod):
+    index = mod.build_index()
+    assert index["dart monkey"].target_id == "dart_monkey"
+    assert index["engineer"].kind == "tower"


### PR DESCRIPTION
Two pieces of the same BTD6 data-accuracy effort.

## 1. `scripts/btd6_patch_diff.py` — patch-notes → proposed-stat-edit assist (review-only)

Parses BTD6 patch-notes text, resolves each `old > new` change's target tower/hero stat file, **verifies the "old" value against what's on disk**, and buckets each change by how safely it could be applied:

| Bucket | Meaning |
|---|---|
| `CLEAN` | a cost field whose current value matches the note's "old" — safe provisional apply |
| `LIKELY` | combat stat whose "old" is present at a trusted (≥v54) baseline — needs field-locating |
| `STALE` | file `game_version` predates the patch — deltas can't be trusted; use the wiki |
| `REVIEW` | additive (`+4`), relative ("doubled"), reworked, or "old" not found |
| `NO_FILE` | a subject we don't carry stats for (e.g. Churchill, Pat Fusty) |
| `SCOPE` | Powers / Bosses / Rogue / cosmetic — not a tower-stat file |

Writes nothing — `fetch_bloonswiki.py` stays authoritative. On the real v55 notes it finds **3 CLEAN** cost changes, flags Wizard/Engineer/Adora **STALE** (files at v52.2), and scopes Powers/Bosses/Rogue out. Tested in `tests/unit/scripts/test_btd6_patch_diff.py`.

```bash
python3.10 scripts/btd6_patch_diff.py --notes-file v55.txt      # readable report
python3.10 scripts/btd6_patch_diff.py --notes-file - --json     # stdin → JSON
```

## 2. `docs/btd6-game-file-extraction-plan.md` — plan & handoff (docs only)

A cross-session roadmap for the *real* fix to BTD6 data accuracy: extracting the game's own (Unity/IL2CPP, AES-encrypted) data — the only source that's both **complete** (covers the 11 heroes + 2 paragons bloonswiki lacks) and **day-one accurate** (no wiki lag). Records the reasoning (patch notes are deltas, not state; source ranking game files > wiki > notes), the Android/Termux/UnityPy approach, the sandbox-vs-device division of labor, the recon step we're parked at, phased plan, risks, and the non-commercial legal stance (commit derived stat values only — never keys or decrypted dumps). **Plan only — no extraction code yet.**

Follow-up to #459 (Steam patch-notes feed + new-version announcements), which provides the interim "stay current between patches" layer this plan builds beyond.

`check_quality --full` green (7100 passed); docs tests green (49 passed).

https://claude.ai/code/session_01QvEkZ2L1bGq9eXNrEN7sTs