### PR TITLE
btd6: game-native names/descriptions + safe v55 overlay + cutover design

### DIFF
--- a/disbot/data/btd6/stats/desperado.json
+++ b/disbot/data/btd6/stats/desperado.json
@@ -1,8 +1,8 @@
 {
   "tower_id": "desperado",
   "canonical": "Desperado",
-  "game_version": "54.0",
-  "source": "bloonswiki.com (CC BY-NC-SA)",
+  "game_version": "55.0",
+  "source": "bloonswiki.com (CC BY-NC-SA); BTD Mod Helper game data v55.0 (numeric overlay)",
   "base_cost": 300,
   "category": "primary",
   "paragon_cost": null,
@@ -616,7 +616,7 @@
       "placeableOnLand": true,
       "placeableOnWater": false,
       "placeableOnTrack": false,
-      "range": 28,
+      "range": 80,
       "towerSelectionMenuThemeId": "Desperado",
       "attacks": [
         {
@@ -735,7 +735,7 @@
       "placeableOnLand": true,
       "placeableOnWater": false,
       "placeableOnTrack": false,
-      "range": 28,
+      "range": 80,
       "towerSelectionMenuThemeId": "Desperado",
       "attacks": [
         {
@@ -982,7 +982,7 @@
       "placeableOnLand": true,
       "placeableOnWater": false,
       "placeableOnTrack": false,
-      "range": 28,
+      "range": 80,
       "towerSelectionMenuThemeId": "Desperado",
       "attacks": [
         {
@@ -3392,7 +3392,7 @@
       "placeableOnLand": true,
       "placeableOnWater": false,
       "placeableOnTrack": false,
-      "range": 28,
+      "range": 80,
       "towerSelectionMenuThemeId": "Desperado",
       "attacks": [
         {
@@ -3515,7 +3515,7 @@
       "placeableOnLand": true,
       "placeableOnWater": false,
       "placeableOnTrack": false,
-      "range": 28,
+      "range": 80,
       "towerSelectionMenuThemeId": "Desperado",
       "attacks": [
         {
@@ -3642,7 +3642,7 @@
       "placeableOnLand": true,
       "placeableOnWater": false,
       "placeableOnTrack": false,
-      "range": 28,
+      "range": 80,
       "towerSelectionMenuThemeId": "Desperado",
       "attacks": [
         {
@@ -3769,7 +3769,7 @@
       "placeableOnLand": true,
       "placeableOnWater": false,
       "placeableOnTrack": false,
-      "range": 28,
+      "range": 80,
       "towerSelectionMenuThemeId": "Desperado",
       "attacks": [
         {
@@ -3905,7 +3905,7 @@
       "placeableOnLand": true,
       "placeableOnWater": false,
       "placeableOnTrack": false,
-      "range": 28,
+      "range": 80,
       "towerSelectionMenuThemeId": "Desperado",
       "attacks": [
         {
@@ -4160,7 +4160,7 @@
       "placeableOnLand": true,
       "placeableOnWater": false,
       "placeableOnTrack": false,
-      "range": 28,
+      "range": 80,
       "towerSelectionMenuThemeId": "Desperado",
       "attacks": [
         {
@@ -4423,7 +4423,7 @@
       "placeableOnLand": true,
       "placeableOnWater": false,
       "placeableOnTrack": false,
-      "range": 28,
+      "range": 80,
       "towerSelectionMenuThemeId": "Desperado",
       "attacks": [
         {
@@ -4686,7 +4686,7 @@
       "placeableOnLand": true,
       "placeableOnWater": false,
       "placeableOnTrack": false,
-      "range": 28,
+      "range": 80,
       "towerSelectionMenuThemeId": "Desperado",
       "attacks": [
         {
@@ -4958,7 +4958,7 @@
       "placeableOnLand": true,
       "placeableOnWater": false,
       "placeableOnTrack": false,
-      "range": 28,
+      "range": 80,
       "towerSelectionMenuThemeId": "Desperado",
       "attacks": [
         {
@@ -5246,7 +5246,7 @@
       "placeableOnLand": true,
       "placeableOnWater": false,
       "placeableOnTrack": false,
-      "range": 28,
+      "range": 80,
       "towerSelectionMenuThemeId": "Desperado",
       "attacks": [
         {
@@ -5542,7 +5542,7 @@
       "placeableOnLand": true,
       "placeableOnWater": false,
       "placeableOnTrack": false,
-      "range": 28,
+      "range": 80,
       "towerSelectionMenuThemeId": "Desperado",
       "attacks": [
         {
@@ -5838,7 +5838,7 @@
       "placeableOnLand": true,
       "placeableOnWater": false,
       "placeableOnTrack": false,
-      "range": 28,
+      "range": 80,
       "towerSelectionMenuThemeId": "Desperado",
       "attacks": [
         {

--- a/disbot/data/btd6/stats/heroes/admiral_brickell.json
+++ b/disbot/data/btd6/stats/heroes/admiral_brickell.json
@@ -440,7 +440,7 @@
       ],
       "abilities": [
         {
-          "name": "FirstAbility",
+          "name": "Naval Tactics",
           "cooldown": 50
         }
       ],
@@ -592,7 +592,7 @@
       ],
       "abilities": [
         {
-          "name": "FirstAbility",
+          "name": "Naval Tactics",
           "cooldown": 50
         }
       ],
@@ -744,7 +744,7 @@
       ],
       "abilities": [
         {
-          "name": "FirstAbility",
+          "name": "Naval Tactics",
           "cooldown": 50
         }
       ],
@@ -896,7 +896,7 @@
       ],
       "abilities": [
         {
-          "name": "FirstAbility",
+          "name": "Naval Tactics",
           "cooldown": 50
         }
       ],
@@ -1048,11 +1048,11 @@
       ],
       "abilities": [
         {
-          "name": "FirstAbility",
+          "name": "Naval Tactics",
           "cooldown": 50
         },
         {
-          "name": "BlastChainAbility",
+          "name": "Blast Chain Ability",
           "cooldown": 45
         }
       ],
@@ -1204,11 +1204,11 @@
       ],
       "abilities": [
         {
-          "name": "FirstAbility",
+          "name": "Naval Tactics",
           "cooldown": 50
         },
         {
-          "name": "BlastChainAbility",
+          "name": "Blast Chain Ability",
           "cooldown": 45
         }
       ],
@@ -1360,11 +1360,11 @@
       ],
       "abilities": [
         {
-          "name": "FirstAbility",
+          "name": "Naval Tactics",
           "cooldown": 50
         },
         {
-          "name": "BlastChainAbility",
+          "name": "Blast Chain Ability",
           "cooldown": 45
         }
       ],
@@ -1516,15 +1516,15 @@
       ],
       "abilities": [
         {
-          "name": "FirstAbility",
+          "name": "Naval Tactics",
           "cooldown": 50
         },
         {
-          "name": "SecondAbility",
+          "name": "Mega Mine",
           "cooldown": 60
         },
         {
-          "name": "BlastChainAbility",
+          "name": "Blast Chain Ability",
           "cooldown": 45
         }
       ],
@@ -1676,15 +1676,15 @@
       ],
       "abilities": [
         {
-          "name": "FirstAbility",
+          "name": "Naval Tactics",
           "cooldown": 50
         },
         {
-          "name": "SecondAbility",
+          "name": "Mega Mine",
           "cooldown": 60
         },
         {
-          "name": "BlastChainAbility",
+          "name": "Blast Chain Ability",
           "cooldown": 45
         }
       ],
@@ -1836,15 +1836,15 @@
       ],
       "abilities": [
         {
-          "name": "FirstAbility",
+          "name": "Naval Tactics",
           "cooldown": 50
         },
         {
-          "name": "SecondAbility",
+          "name": "Mega Mine",
           "cooldown": 60
         },
         {
-          "name": "BlastChainAbility",
+          "name": "Blast Chain Ability",
           "cooldown": 45
         }
       ],
@@ -1996,15 +1996,15 @@
       ],
       "abilities": [
         {
-          "name": "FirstAbility",
+          "name": "Naval Tactics",
           "cooldown": 50
         },
         {
-          "name": "SecondAbility",
+          "name": "Mega Mine",
           "cooldown": 50
         },
         {
-          "name": "BlastChainAbility",
+          "name": "Blast Chain Ability",
           "cooldown": 45
         }
       ],
@@ -2156,15 +2156,15 @@
       ],
       "abilities": [
         {
-          "name": "FirstAbility",
+          "name": "Naval Tactics",
           "cooldown": 50
         },
         {
-          "name": "SecondAbility",
+          "name": "Mega Mine",
           "cooldown": 50
         },
         {
-          "name": "BlastChainAbility",
+          "name": "Blast Chain Ability",
           "cooldown": 45
         }
       ],
@@ -2316,15 +2316,15 @@
       ],
       "abilities": [
         {
-          "name": "FirstAbility",
+          "name": "Naval Tactics",
           "cooldown": 50
         },
         {
-          "name": "SecondAbility",
+          "name": "Mega Mine",
           "cooldown": 50
         },
         {
-          "name": "BlastChainAbility",
+          "name": "Blast Chain Ability",
           "cooldown": 45
         }
       ],
@@ -2476,15 +2476,15 @@
       ],
       "abilities": [
         {
-          "name": "FirstAbility",
+          "name": "Naval Tactics",
           "cooldown": 50
         },
         {
-          "name": "SecondAbility",
+          "name": "Mega Mine",
           "cooldown": 50
         },
         {
-          "name": "BlastChainAbility",
+          "name": "Blast Chain Ability",
           "cooldown": 45
         }
       ],
@@ -2636,15 +2636,15 @@
       ],
       "abilities": [
         {
-          "name": "FirstAbility",
+          "name": "Naval Tactics",
           "cooldown": 50
         },
         {
-          "name": "SecondAbility",
+          "name": "Mega Mine",
           "cooldown": 50
         },
         {
-          "name": "BlastChainAbility",
+          "name": "Blast Chain Ability",
           "cooldown": 45
         }
       ],
@@ -2796,15 +2796,15 @@
       ],
       "abilities": [
         {
-          "name": "FirstAbility",
+          "name": "Naval Tactics",
           "cooldown": 50
         },
         {
-          "name": "SecondAbility",
+          "name": "Mega Mine",
           "cooldown": 40
         },
         {
-          "name": "BlastChainAbility",
+          "name": "Blast Chain Ability",
           "cooldown": 45
         }
       ],
@@ -2956,15 +2956,15 @@
       ],
       "abilities": [
         {
-          "name": "FirstAbility",
+          "name": "Naval Tactics",
           "cooldown": 50
         },
         {
-          "name": "SecondAbility",
+          "name": "Mega Mine",
           "cooldown": 40
         },
         {
-          "name": "BlastChainAbility",
+          "name": "Blast Chain Ability",
           "cooldown": 45
         }
       ],
@@ -3116,15 +3116,15 @@
       ],
       "abilities": [
         {
-          "name": "FirstAbility",
+          "name": "Naval Tactics",
           "cooldown": 50
         },
         {
-          "name": "SecondAbility",
+          "name": "Mega Mine",
           "cooldown": 40
         },
         {
-          "name": "BlastChainAbility",
+          "name": "Blast Chain Ability",
           "cooldown": 45
         }
       ],

--- a/disbot/data/btd6/stats/heroes/benjamin.json
+++ b/disbot/data/btd6/stats/heroes/benjamin.json
@@ -85,7 +85,7 @@
       ],
       "abilities": [
         {
-          "name": "BiohackAbility",
+          "name": "Biohack",
           "cooldown": 30
         }
       ],
@@ -119,7 +119,7 @@
       ],
       "abilities": [
         {
-          "name": "BiohackAbility",
+          "name": "Biohack",
           "cooldown": 30
         }
       ],
@@ -153,7 +153,7 @@
       ],
       "abilities": [
         {
-          "name": "BiohackAbility",
+          "name": "Biohack",
           "cooldown": 30
         }
       ],
@@ -187,7 +187,7 @@
       ],
       "abilities": [
         {
-          "name": "BiohackAbility",
+          "name": "Biohack",
           "cooldown": 30
         }
       ],
@@ -256,7 +256,7 @@
       ],
       "abilities": [
         {
-          "name": "BiohackAbility",
+          "name": "Biohack",
           "cooldown": 30
         }
       ],
@@ -325,7 +325,7 @@
       ],
       "abilities": [
         {
-          "name": "BiohackAbility",
+          "name": "Biohack",
           "cooldown": 30
         }
       ],
@@ -394,7 +394,7 @@
       ],
       "abilities": [
         {
-          "name": "BiohackAbility",
+          "name": "Biohack",
           "cooldown": 30
         }
       ],
@@ -463,11 +463,11 @@
       ],
       "abilities": [
         {
-          "name": "BiohackAbility",
+          "name": "Biohack",
           "cooldown": 30
         },
         {
-          "name": "SyphonFundingAbility",
+          "name": "Syphon Funding",
           "cooldown": 65
         }
       ],
@@ -536,11 +536,11 @@
       ],
       "abilities": [
         {
-          "name": "BiohackAbility",
+          "name": "Biohack",
           "cooldown": 30
         },
         {
-          "name": "SyphonFundingAbility",
+          "name": "Syphon Funding",
           "cooldown": 65
         }
       ],
@@ -609,11 +609,11 @@
       ],
       "abilities": [
         {
-          "name": "BiohackAbility",
+          "name": "Biohack",
           "cooldown": 30
         },
         {
-          "name": "SyphonFundingAbility",
+          "name": "Syphon Funding",
           "cooldown": 65
         }
       ],
@@ -682,11 +682,11 @@
       ],
       "abilities": [
         {
-          "name": "BiohackAbility",
+          "name": "Biohack",
           "cooldown": 30
         },
         {
-          "name": "SyphonFundingAbility",
+          "name": "Syphon Funding",
           "cooldown": 65
         }
       ],
@@ -755,11 +755,11 @@
       ],
       "abilities": [
         {
-          "name": "BiohackAbility",
+          "name": "Biohack",
           "cooldown": 30
         },
         {
-          "name": "SyphonFundingAbility",
+          "name": "Syphon Funding",
           "cooldown": 65
         }
       ],
@@ -828,11 +828,11 @@
       ],
       "abilities": [
         {
-          "name": "BiohackAbility",
+          "name": "Biohack",
           "cooldown": 30
         },
         {
-          "name": "SyphonFundingAbility",
+          "name": "Syphon Funding",
           "cooldown": 65
         }
       ],
@@ -901,11 +901,11 @@
       ],
       "abilities": [
         {
-          "name": "BiohackAbility",
+          "name": "Biohack",
           "cooldown": 30
         },
         {
-          "name": "SyphonFundingAbility",
+          "name": "Syphon Funding",
           "cooldown": 65
         }
       ],
@@ -974,11 +974,11 @@
       ],
       "abilities": [
         {
-          "name": "BiohackAbility",
+          "name": "Biohack",
           "cooldown": 30
         },
         {
-          "name": "SyphonFundingAbility",
+          "name": "Syphon Funding",
           "cooldown": 65
         }
       ],
@@ -1047,11 +1047,11 @@
       ],
       "abilities": [
         {
-          "name": "BiohackAbility",
+          "name": "Biohack",
           "cooldown": 30
         },
         {
-          "name": "SyphonFundingAbility",
+          "name": "Syphon Funding",
           "cooldown": 65
         }
       ],
@@ -1120,11 +1120,11 @@
       ],
       "abilities": [
         {
-          "name": "BiohackAbility",
+          "name": "Biohack",
           "cooldown": 30
         },
         {
-          "name": "SyphonFundingAbility",
+          "name": "Syphon Funding",
           "cooldown": 65
         }
       ],
@@ -1193,11 +1193,11 @@
       ],
       "abilities": [
         {
-          "name": "BiohackAbility",
+          "name": "Biohack",
           "cooldown": 30
         },
         {
-          "name": "SyphonFundingAbility",
+          "name": "Syphon Funding",
           "cooldown": 65
         }
       ],

--- a/disbot/data/btd6/stats/heroes/captain_churchill.json
+++ b/disbot/data/btd6/stats/heroes/captain_churchill.json
@@ -194,7 +194,7 @@
       ],
       "abilities": [
         {
-          "name": "ArmorPiercingShells",
+          "name": "Armor Piercing Shells",
           "cooldown": 30
         }
       ],
@@ -264,7 +264,7 @@
       ],
       "abilities": [
         {
-          "name": "ArmorPiercingShells",
+          "name": "Armor Piercing Shells",
           "cooldown": 30
         }
       ],
@@ -369,7 +369,7 @@
       ],
       "abilities": [
         {
-          "name": "ArmorPiercingShells",
+          "name": "Armor Piercing Shells",
           "cooldown": 30
         }
       ],
@@ -474,7 +474,7 @@
       ],
       "abilities": [
         {
-          "name": "ArmorPiercingShells",
+          "name": "Armor Piercing Shells",
           "cooldown": 30
         }
       ],
@@ -579,7 +579,7 @@
       ],
       "abilities": [
         {
-          "name": "ArmorPiercingShells",
+          "name": "Armor Piercing Shells",
           "cooldown": 30
         }
       ],
@@ -684,7 +684,7 @@
       ],
       "abilities": [
         {
-          "name": "ArmorPiercingShells",
+          "name": "Armor Piercing Shells",
           "cooldown": 30
         }
       ],
@@ -789,7 +789,7 @@
       ],
       "abilities": [
         {
-          "name": "ArmorPiercingShells",
+          "name": "Armor Piercing Shells",
           "cooldown": 30
         }
       ],
@@ -894,11 +894,11 @@
       ],
       "abilities": [
         {
-          "name": "ArmorPiercingShells",
+          "name": "Armor Piercing Shells",
           "cooldown": 30
         },
         {
-          "name": "MOABBarrage",
+          "name": "MOAB Barrage",
           "cooldown": 60
         }
       ],
@@ -1003,11 +1003,11 @@
       ],
       "abilities": [
         {
-          "name": "ArmorPiercingShells",
+          "name": "Armor Piercing Shells",
           "cooldown": 30
         },
         {
-          "name": "MOABBarrage",
+          "name": "MOAB Barrage",
           "cooldown": 60
         }
       ],
@@ -1112,11 +1112,11 @@
       ],
       "abilities": [
         {
-          "name": "ArmorPiercingShells",
+          "name": "Armor Piercing Shells",
           "cooldown": 30
         },
         {
-          "name": "MOABBarrage",
+          "name": "MOAB Barrage",
           "cooldown": 60
         }
       ],
@@ -1221,11 +1221,11 @@
       ],
       "abilities": [
         {
-          "name": "ArmorPiercingShells",
+          "name": "Armor Piercing Shells",
           "cooldown": 30
         },
         {
-          "name": "MOABBarrage",
+          "name": "MOAB Barrage",
           "cooldown": 60
         }
       ],
@@ -1330,11 +1330,11 @@
       ],
       "abilities": [
         {
-          "name": "ArmorPiercingShells",
+          "name": "Armor Piercing Shells",
           "cooldown": 30
         },
         {
-          "name": "MOABBarrage",
+          "name": "MOAB Barrage",
           "cooldown": 60
         }
       ],
@@ -1445,11 +1445,11 @@
       ],
       "abilities": [
         {
-          "name": "ArmorPiercingShells",
+          "name": "Armor Piercing Shells",
           "cooldown": 30
         },
         {
-          "name": "MOABBarrage",
+          "name": "MOAB Barrage",
           "cooldown": 60
         }
       ],
@@ -1560,11 +1560,11 @@
       ],
       "abilities": [
         {
-          "name": "ArmorPiercingShells",
+          "name": "Armor Piercing Shells",
           "cooldown": 30
         },
         {
-          "name": "MOABBarrage",
+          "name": "MOAB Barrage",
           "cooldown": 60
         }
       ],
@@ -1675,11 +1675,11 @@
       ],
       "abilities": [
         {
-          "name": "ArmorPiercingShells",
+          "name": "Armor Piercing Shells",
           "cooldown": 30
         },
         {
-          "name": "MOABBarrage",
+          "name": "MOAB Barrage",
           "cooldown": 60
         }
       ],
@@ -1790,11 +1790,11 @@
       ],
       "abilities": [
         {
-          "name": "ArmorPiercingShells",
+          "name": "Armor Piercing Shells",
           "cooldown": 30
         },
         {
-          "name": "MOABBarrage",
+          "name": "MOAB Barrage",
           "cooldown": 60
         }
       ],
@@ -1905,11 +1905,11 @@
       ],
       "abilities": [
         {
-          "name": "ArmorPiercingShells",
+          "name": "Armor Piercing Shells",
           "cooldown": 30
         },
         {
-          "name": "MOABBarrage",
+          "name": "MOAB Barrage",
           "cooldown": 60
         }
       ],
@@ -2020,11 +2020,11 @@
       ],
       "abilities": [
         {
-          "name": "ArmorPiercingShells",
+          "name": "Armor Piercing Shells",
           "cooldown": 30
         },
         {
-          "name": "MOABBarrage",
+          "name": "MOAB Barrage",
           "cooldown": 30
         }
       ],

--- a/disbot/data/btd6/stats/heroes/corvus.json
+++ b/disbot/data/btd6/stats/heroes/corvus.json
@@ -182,7 +182,7 @@
       ],
       "abilities": [
         {
-          "name": "SoulHarvestAbility",
+          "name": "Soul Harvest",
           "cooldown": 40
         }
       ],
@@ -248,7 +248,7 @@
       ],
       "abilities": [
         {
-          "name": "SoulHarvestAbility",
+          "name": "Soul Harvest",
           "cooldown": 39.5
         }
       ],
@@ -314,7 +314,7 @@
       ],
       "abilities": [
         {
-          "name": "SoulHarvestAbility",
+          "name": "Soul Harvest",
           "cooldown": 39
         }
       ],
@@ -380,7 +380,7 @@
       ],
       "abilities": [
         {
-          "name": "SoulHarvestAbility",
+          "name": "Soul Harvest",
           "cooldown": 38.5
         }
       ],
@@ -528,11 +528,11 @@
       ],
       "abilities": [
         {
-          "name": "SoulHarvestAbility",
+          "name": "Soul Harvest",
           "cooldown": 38
         },
         {
-          "name": "SpiritWalkAbility",
+          "name": "Spirit Walk",
           "cooldown": 20
         }
       ],
@@ -680,11 +680,11 @@
       ],
       "abilities": [
         {
-          "name": "SoulHarvestAbility",
+          "name": "Soul Harvest",
           "cooldown": 37.5
         },
         {
-          "name": "SpiritWalkAbility",
+          "name": "Spirit Walk",
           "cooldown": 20
         }
       ],
@@ -832,11 +832,11 @@
       ],
       "abilities": [
         {
-          "name": "SoulHarvestAbility",
+          "name": "Soul Harvest",
           "cooldown": 37
         },
         {
-          "name": "SpiritWalkAbility",
+          "name": "Spirit Walk",
           "cooldown": 20
         }
       ],
@@ -984,15 +984,15 @@
       ],
       "abilities": [
         {
-          "name": "SoulHarvestAbility",
+          "name": "Soul Harvest",
           "cooldown": 36.5
         },
         {
-          "name": "SpiritWalkAbility",
+          "name": "Spirit Walk",
           "cooldown": 20
         },
         {
-          "name": "DarkRitual",
+          "name": "Dark Ritual",
           "cooldown": 90
         }
       ],
@@ -1140,15 +1140,15 @@
       ],
       "abilities": [
         {
-          "name": "SoulHarvestAbility",
+          "name": "Soul Harvest",
           "cooldown": 36
         },
         {
-          "name": "SpiritWalkAbility",
+          "name": "Spirit Walk",
           "cooldown": 20
         },
         {
-          "name": "DarkRitual",
+          "name": "Dark Ritual",
           "cooldown": 90
         }
       ],
@@ -1296,15 +1296,15 @@
       ],
       "abilities": [
         {
-          "name": "SoulHarvestAbility",
+          "name": "Soul Harvest",
           "cooldown": 35.5
         },
         {
-          "name": "SpiritWalkAbility",
+          "name": "Spirit Walk",
           "cooldown": 20
         },
         {
-          "name": "DarkRitual",
+          "name": "Dark Ritual",
           "cooldown": 90
         }
       ],
@@ -1452,15 +1452,15 @@
       ],
       "abilities": [
         {
-          "name": "SoulHarvestAbility",
+          "name": "Soul Harvest",
           "cooldown": 35
         },
         {
-          "name": "SpiritWalkAbility",
+          "name": "Spirit Walk",
           "cooldown": 20
         },
         {
-          "name": "DarkRitual",
+          "name": "Dark Ritual",
           "cooldown": 90
         }
       ],
@@ -1608,15 +1608,15 @@
       ],
       "abilities": [
         {
-          "name": "SoulHarvestAbility",
+          "name": "Soul Harvest",
           "cooldown": 34.5
         },
         {
-          "name": "SpiritWalkAbility",
+          "name": "Spirit Walk",
           "cooldown": 20
         },
         {
-          "name": "DarkRitual",
+          "name": "Dark Ritual",
           "cooldown": 90
         }
       ],
@@ -1764,15 +1764,15 @@
       ],
       "abilities": [
         {
-          "name": "SoulHarvestAbility",
+          "name": "Soul Harvest",
           "cooldown": 34
         },
         {
-          "name": "SpiritWalkAbility",
+          "name": "Spirit Walk",
           "cooldown": 20
         },
         {
-          "name": "DarkRitual",
+          "name": "Dark Ritual",
           "cooldown": 90
         }
       ],
@@ -1920,15 +1920,15 @@
       ],
       "abilities": [
         {
-          "name": "SoulHarvestAbility",
+          "name": "Soul Harvest",
           "cooldown": 33.5
         },
         {
-          "name": "SpiritWalkAbility",
+          "name": "Spirit Walk",
           "cooldown": 20
         },
         {
-          "name": "DarkRitual",
+          "name": "Dark Ritual",
           "cooldown": 90
         }
       ],
@@ -2076,15 +2076,15 @@
       ],
       "abilities": [
         {
-          "name": "SoulHarvestAbility",
+          "name": "Soul Harvest",
           "cooldown": 33
         },
         {
-          "name": "SpiritWalkAbility",
+          "name": "Spirit Walk",
           "cooldown": 20
         },
         {
-          "name": "DarkRitual",
+          "name": "Dark Ritual",
           "cooldown": 90
         }
       ],
@@ -2232,15 +2232,15 @@
       ],
       "abilities": [
         {
-          "name": "SoulHarvestAbility",
+          "name": "Soul Harvest",
           "cooldown": 32.5
         },
         {
-          "name": "SpiritWalkAbility",
+          "name": "Spirit Walk",
           "cooldown": 20
         },
         {
-          "name": "DarkRitual",
+          "name": "Dark Ritual",
           "cooldown": 90
         }
       ],
@@ -2388,15 +2388,15 @@
       ],
       "abilities": [
         {
-          "name": "SoulHarvestAbility",
+          "name": "Soul Harvest",
           "cooldown": 32
         },
         {
-          "name": "SpiritWalkAbility",
+          "name": "Spirit Walk",
           "cooldown": 20
         },
         {
-          "name": "DarkRitual",
+          "name": "Dark Ritual",
           "cooldown": 90
         }
       ],
@@ -2544,15 +2544,15 @@
       ],
       "abilities": [
         {
-          "name": "SoulHarvestAbility",
+          "name": "Soul Harvest",
           "cooldown": 31.5
         },
         {
-          "name": "SpiritWalkAbility",
+          "name": "Spirit Walk",
           "cooldown": 20
         },
         {
-          "name": "DarkRitual",
+          "name": "Dark Ritual",
           "cooldown": 90
         }
       ],

--- a/disbot/data/btd6/stats/heroes/etienne.json
+++ b/disbot/data/btd6/stats/heroes/etienne.json
@@ -83,7 +83,7 @@
       ],
       "abilities": [
         {
-          "name": "DroneSwarmAbility",
+          "name": "Drone Swarm",
           "cooldown": 70
         }
       ],
@@ -116,7 +116,7 @@
       ],
       "abilities": [
         {
-          "name": "DroneSwarmAbility",
+          "name": "Drone Swarm",
           "cooldown": 70
         }
       ],
@@ -149,7 +149,7 @@
       ],
       "abilities": [
         {
-          "name": "DroneSwarmAbility",
+          "name": "Drone Swarm",
           "cooldown": 70
         }
       ],
@@ -182,7 +182,7 @@
       ],
       "abilities": [
         {
-          "name": "DroneSwarmAbility",
+          "name": "Drone Swarm",
           "cooldown": 55
         }
       ],
@@ -215,7 +215,7 @@
       ],
       "abilities": [
         {
-          "name": "DroneSwarmAbility",
+          "name": "Drone Swarm",
           "cooldown": 55
         }
       ],
@@ -277,7 +277,7 @@
       ],
       "abilities": [
         {
-          "name": "DroneSwarmAbility",
+          "name": "Drone Swarm",
           "cooldown": 55
         }
       ],
@@ -339,7 +339,7 @@
       ],
       "abilities": [
         {
-          "name": "DroneSwarmAbility",
+          "name": "Drone Swarm",
           "cooldown": 55
         }
       ],
@@ -401,11 +401,11 @@
       ],
       "abilities": [
         {
-          "name": "DroneSwarmAbility",
+          "name": "Drone Swarm",
           "cooldown": 55
         },
         {
-          "name": "UCAVAbility",
+          "name": "UCAV",
           "cooldown": 90
         }
       ],
@@ -467,11 +467,11 @@
       ],
       "abilities": [
         {
-          "name": "DroneSwarmAbility",
+          "name": "Drone Swarm",
           "cooldown": 55
         },
         {
-          "name": "UCAVAbility",
+          "name": "UCAV",
           "cooldown": 90
         }
       ],
@@ -533,11 +533,11 @@
       ],
       "abilities": [
         {
-          "name": "DroneSwarmAbility",
+          "name": "Drone Swarm",
           "cooldown": 55
         },
         {
-          "name": "UCAVAbility",
+          "name": "UCAV",
           "cooldown": 90
         }
       ],
@@ -599,11 +599,11 @@
       ],
       "abilities": [
         {
-          "name": "DroneSwarmAbility",
+          "name": "Drone Swarm",
           "cooldown": 55
         },
         {
-          "name": "UCAVAbility",
+          "name": "UCAV",
           "cooldown": 75
         }
       ],
@@ -665,11 +665,11 @@
       ],
       "abilities": [
         {
-          "name": "DroneSwarmAbility",
+          "name": "Drone Swarm",
           "cooldown": 55
         },
         {
-          "name": "UCAVAbility",
+          "name": "UCAV",
           "cooldown": 75
         }
       ],
@@ -731,11 +731,11 @@
       ],
       "abilities": [
         {
-          "name": "DroneSwarmAbility",
+          "name": "Drone Swarm",
           "cooldown": 55
         },
         {
-          "name": "UCAVAbility",
+          "name": "UCAV",
           "cooldown": 75
         }
       ],
@@ -797,11 +797,11 @@
       ],
       "abilities": [
         {
-          "name": "DroneSwarmAbility",
+          "name": "Drone Swarm",
           "cooldown": 50
         },
         {
-          "name": "UCAVAbility",
+          "name": "UCAV",
           "cooldown": 75
         }
       ],
@@ -863,11 +863,11 @@
       ],
       "abilities": [
         {
-          "name": "DroneSwarmAbility",
+          "name": "Drone Swarm",
           "cooldown": 50
         },
         {
-          "name": "UCAVAbility",
+          "name": "UCAV",
           "cooldown": 75
         }
       ],
@@ -929,11 +929,11 @@
       ],
       "abilities": [
         {
-          "name": "DroneSwarmAbility",
+          "name": "Drone Swarm",
           "cooldown": 50
         },
         {
-          "name": "UCAVAbility",
+          "name": "UCAV",
           "cooldown": 75
         }
       ],
@@ -995,11 +995,11 @@
       ],
       "abilities": [
         {
-          "name": "DroneSwarmAbility",
+          "name": "Drone Swarm",
           "cooldown": 50
         },
         {
-          "name": "UCAVAbility",
+          "name": "UCAV",
           "cooldown": 75
         }
       ],
@@ -1061,11 +1061,11 @@
       ],
       "abilities": [
         {
-          "name": "DroneSwarmAbility",
+          "name": "Drone Swarm",
           "cooldown": 50
         },
         {
-          "name": "UCAVAbility",
+          "name": "UCAV",
           "cooldown": 75
         }
       ],

--- a/disbot/data/btd6/stats/heroes/ezili.json
+++ b/disbot/data/btd6/stats/heroes/ezili.json
@@ -230,7 +230,7 @@
       ],
       "abilities": [
         {
-          "name": "HeartstopperAbility",
+          "name": "Heartstopper",
           "cooldown": 45
         }
       ],
@@ -318,7 +318,7 @@
       ],
       "abilities": [
         {
-          "name": "HeartstopperAbility",
+          "name": "Heartstopper",
           "cooldown": 45
         }
       ],
@@ -406,7 +406,7 @@
       ],
       "abilities": [
         {
-          "name": "HeartstopperAbility",
+          "name": "Heartstopper",
           "cooldown": 45
         }
       ],
@@ -496,7 +496,7 @@
       ],
       "abilities": [
         {
-          "name": "HeartstopperAbility",
+          "name": "Heartstopper",
           "cooldown": 45
         }
       ],
@@ -586,11 +586,11 @@
       ],
       "abilities": [
         {
-          "name": "HeartstopperAbility",
+          "name": "Heartstopper",
           "cooldown": 45
         },
         {
-          "name": "TotemAbility",
+          "name": "Sacrificial Totem",
           "cooldown": 90
         }
       ],
@@ -680,11 +680,11 @@
       ],
       "abilities": [
         {
-          "name": "HeartstopperAbility",
+          "name": "Heartstopper",
           "cooldown": 45
         },
         {
-          "name": "TotemAbility",
+          "name": "Sacrificial Totem",
           "cooldown": 90
         }
       ],
@@ -774,11 +774,11 @@
       ],
       "abilities": [
         {
-          "name": "HeartstopperAbility",
+          "name": "Heartstopper",
           "cooldown": 45
         },
         {
-          "name": "TotemAbility",
+          "name": "Sacrificial Totem",
           "cooldown": 90
         }
       ],
@@ -868,15 +868,15 @@
       ],
       "abilities": [
         {
-          "name": "HeartstopperAbility",
+          "name": "Heartstopper",
           "cooldown": 45
         },
         {
-          "name": "TotemAbility",
+          "name": "Sacrificial Totem",
           "cooldown": 90
         },
         {
-          "name": "HexAbility",
+          "name": "MOAB Hex",
           "cooldown": 60
         }
       ],
@@ -966,15 +966,15 @@
       ],
       "abilities": [
         {
-          "name": "HeartstopperAbility",
+          "name": "Heartstopper",
           "cooldown": 45
         },
         {
-          "name": "TotemAbility",
+          "name": "Sacrificial Totem",
           "cooldown": 90
         },
         {
-          "name": "HexAbility",
+          "name": "MOAB Hex",
           "cooldown": 60
         }
       ],
@@ -1064,15 +1064,15 @@
       ],
       "abilities": [
         {
-          "name": "HeartstopperAbility",
+          "name": "Heartstopper",
           "cooldown": 40
         },
         {
-          "name": "TotemAbility",
+          "name": "Sacrificial Totem",
           "cooldown": 90
         },
         {
-          "name": "HexAbility",
+          "name": "MOAB Hex",
           "cooldown": 60
         }
       ],
@@ -1162,15 +1162,15 @@
       ],
       "abilities": [
         {
-          "name": "HeartstopperAbility",
+          "name": "Heartstopper",
           "cooldown": 40
         },
         {
-          "name": "TotemAbility",
+          "name": "Sacrificial Totem",
           "cooldown": 90
         },
         {
-          "name": "HexAbility",
+          "name": "MOAB Hex",
           "cooldown": 60
         }
       ],
@@ -1260,15 +1260,15 @@
       ],
       "abilities": [
         {
-          "name": "HeartstopperAbility",
+          "name": "Heartstopper",
           "cooldown": 40
         },
         {
-          "name": "TotemAbility",
+          "name": "Sacrificial Totem",
           "cooldown": 90
         },
         {
-          "name": "HexAbility",
+          "name": "MOAB Hex",
           "cooldown": 60
         }
       ],
@@ -1358,15 +1358,15 @@
       ],
       "abilities": [
         {
-          "name": "HeartstopperAbility",
+          "name": "Heartstopper",
           "cooldown": 40
         },
         {
-          "name": "TotemAbility",
+          "name": "Sacrificial Totem",
           "cooldown": 90
         },
         {
-          "name": "HexAbility",
+          "name": "MOAB Hex",
           "cooldown": 60
         }
       ],
@@ -1456,15 +1456,15 @@
       ],
       "abilities": [
         {
-          "name": "HeartstopperAbility",
+          "name": "Heartstopper",
           "cooldown": 40
         },
         {
-          "name": "TotemAbility",
+          "name": "Sacrificial Totem",
           "cooldown": 90
         },
         {
-          "name": "HexAbility",
+          "name": "MOAB Hex",
           "cooldown": 60
         }
       ],
@@ -1554,15 +1554,15 @@
       ],
       "abilities": [
         {
-          "name": "HeartstopperAbility",
+          "name": "Heartstopper",
           "cooldown": 40
         },
         {
-          "name": "TotemAbility",
+          "name": "Sacrificial Totem",
           "cooldown": 90
         },
         {
-          "name": "HexAbility",
+          "name": "MOAB Hex",
           "cooldown": 60
         }
       ],
@@ -1652,15 +1652,15 @@
       ],
       "abilities": [
         {
-          "name": "HeartstopperAbility",
+          "name": "Heartstopper",
           "cooldown": 40
         },
         {
-          "name": "TotemAbility",
+          "name": "Sacrificial Totem",
           "cooldown": 90
         },
         {
-          "name": "HexAbility",
+          "name": "MOAB Hex",
           "cooldown": 60
         }
       ],
@@ -1750,15 +1750,15 @@
       ],
       "abilities": [
         {
-          "name": "HeartstopperAbility",
+          "name": "Heartstopper",
           "cooldown": 40
         },
         {
-          "name": "TotemAbility",
+          "name": "Sacrificial Totem",
           "cooldown": 90
         },
         {
-          "name": "HexAbility",
+          "name": "MOAB Hex",
           "cooldown": 60
         }
       ],
@@ -1848,15 +1848,15 @@
       ],
       "abilities": [
         {
-          "name": "HeartstopperAbility",
+          "name": "Heartstopper",
           "cooldown": 40
         },
         {
-          "name": "TotemAbility",
+          "name": "Sacrificial Totem",
           "cooldown": 90
         },
         {
-          "name": "HexAbility",
+          "name": "MOAB Hex",
           "cooldown": 40
         }
       ],

--- a/disbot/data/btd6/stats/heroes/obyn_greenfoot.json
+++ b/disbot/data/btd6/stats/heroes/obyn_greenfoot.json
@@ -161,7 +161,7 @@
       ],
       "abilities": [
         {
-          "name": "AbilityBrambles",
+          "name": "Brambles",
           "cooldown": 30
         }
       ],
@@ -247,7 +247,7 @@
       ],
       "abilities": [
         {
-          "name": "AbilityBrambles",
+          "name": "Brambles",
           "cooldown": 30
         }
       ],
@@ -339,7 +339,7 @@
       ],
       "abilities": [
         {
-          "name": "AbilityBrambles",
+          "name": "Brambles",
           "cooldown": 30
         }
       ],
@@ -425,7 +425,7 @@
       ],
       "abilities": [
         {
-          "name": "AbilityBrambles",
+          "name": "Brambles",
           "cooldown": 30
         }
       ],
@@ -511,7 +511,7 @@
       ],
       "abilities": [
         {
-          "name": "AbilityBrambles",
+          "name": "Brambles",
           "cooldown": 30
         }
       ],
@@ -597,7 +597,7 @@
       ],
       "abilities": [
         {
-          "name": "AbilityBrambles",
+          "name": "Brambles",
           "cooldown": 30
         }
       ],
@@ -683,7 +683,7 @@
       ],
       "abilities": [
         {
-          "name": "AbilityBrambles",
+          "name": "Brambles",
           "cooldown": 30
         }
       ],
@@ -769,11 +769,11 @@
       ],
       "abilities": [
         {
-          "name": "AbilityBrambles",
+          "name": "Brambles",
           "cooldown": 30
         },
         {
-          "name": "AbilityWallOfTrees",
+          "name": "Wall of Trees",
           "cooldown": 90
         }
       ],
@@ -859,11 +859,11 @@
       ],
       "abilities": [
         {
-          "name": "AbilityBrambles",
+          "name": "Brambles",
           "cooldown": 30
         },
         {
-          "name": "AbilityWallOfTrees",
+          "name": "Wall of Trees",
           "cooldown": 90
         }
       ],
@@ -949,11 +949,11 @@
       ],
       "abilities": [
         {
-          "name": "AbilityBrambles",
+          "name": "Brambles",
           "cooldown": 30
         },
         {
-          "name": "AbilityWallOfTrees",
+          "name": "Wall of Trees",
           "cooldown": 90
         }
       ],
@@ -1039,11 +1039,11 @@
       ],
       "abilities": [
         {
-          "name": "AbilityBrambles",
+          "name": "Brambles",
           "cooldown": 30
         },
         {
-          "name": "AbilityWallOfTrees",
+          "name": "Wall of Trees",
           "cooldown": 90
         }
       ],
@@ -1129,11 +1129,11 @@
       ],
       "abilities": [
         {
-          "name": "AbilityBrambles",
+          "name": "Brambles",
           "cooldown": 30
         },
         {
-          "name": "AbilityWallOfTrees",
+          "name": "Wall of Trees",
           "cooldown": 90
         }
       ],
@@ -1219,11 +1219,11 @@
       ],
       "abilities": [
         {
-          "name": "AbilityBrambles",
+          "name": "Brambles",
           "cooldown": 30
         },
         {
-          "name": "AbilityWallOfTrees",
+          "name": "Wall of Trees",
           "cooldown": 90
         }
       ],
@@ -1309,11 +1309,11 @@
       ],
       "abilities": [
         {
-          "name": "AbilityBrambles",
+          "name": "Brambles",
           "cooldown": 30
         },
         {
-          "name": "AbilityWallOfTrees",
+          "name": "Wall of Trees",
           "cooldown": 90
         }
       ],
@@ -1399,11 +1399,11 @@
       ],
       "abilities": [
         {
-          "name": "AbilityBrambles",
+          "name": "Brambles",
           "cooldown": 30
         },
         {
-          "name": "AbilityWallOfTrees",
+          "name": "Wall of Trees",
           "cooldown": 90
         }
       ],
@@ -1489,11 +1489,11 @@
       ],
       "abilities": [
         {
-          "name": "AbilityBrambles",
+          "name": "Brambles",
           "cooldown": 30
         },
         {
-          "name": "AbilityWallOfTrees",
+          "name": "Wall of Trees",
           "cooldown": 90
         }
       ],
@@ -1579,11 +1579,11 @@
       ],
       "abilities": [
         {
-          "name": "AbilityBrambles",
+          "name": "Brambles",
           "cooldown": 30
         },
         {
-          "name": "AbilityWallOfTrees",
+          "name": "Wall of Trees",
           "cooldown": 90
         }
       ],
@@ -1669,11 +1669,11 @@
       ],
       "abilities": [
         {
-          "name": "AbilityBrambles",
+          "name": "Brambles",
           "cooldown": 30
         },
         {
-          "name": "AbilityWallOfTrees",
+          "name": "Wall of Trees",
           "cooldown": 75
         }
       ],

--- a/disbot/data/btd6/stats/heroes/pat_fusty.json
+++ b/disbot/data/btd6/stats/heroes/pat_fusty.json
@@ -236,7 +236,7 @@
       ],
       "abilities": [
         {
-          "name": "AbilityRallyingRoar",
+          "name": "Rallying Roar",
           "cooldown": 45
         }
       ],
@@ -320,7 +320,7 @@
       ],
       "abilities": [
         {
-          "name": "AbilityRallyingRoar",
+          "name": "Rallying Roar",
           "cooldown": 45
         }
       ],
@@ -421,7 +421,7 @@
       ],
       "abilities": [
         {
-          "name": "AbilityRallyingRoar",
+          "name": "Rallying Roar",
           "cooldown": 45
         }
       ],
@@ -526,7 +526,7 @@
       ],
       "abilities": [
         {
-          "name": "AbilityRallyingRoar",
+          "name": "Rallying Roar",
           "cooldown": 45
         }
       ],
@@ -631,7 +631,7 @@
       ],
       "abilities": [
         {
-          "name": "AbilityRallyingRoar",
+          "name": "Rallying Roar",
           "cooldown": 45
         }
       ],
@@ -736,7 +736,7 @@
       ],
       "abilities": [
         {
-          "name": "AbilityRallyingRoar",
+          "name": "Rallying Roar",
           "cooldown": 45
         }
       ],
@@ -841,7 +841,7 @@
       ],
       "abilities": [
         {
-          "name": "AbilityRallyingRoar",
+          "name": "Rallying Roar",
           "cooldown": 45
         }
       ],
@@ -946,11 +946,11 @@
       ],
       "abilities": [
         {
-          "name": "AbilityRallyingRoar",
+          "name": "Rallying Roar",
           "cooldown": 45
         },
         {
-          "name": "AbilityBigSqueeze",
+          "name": "Big Squeeze",
           "cooldown": 20
         }
       ],
@@ -1055,11 +1055,11 @@
       ],
       "abilities": [
         {
-          "name": "AbilityRallyingRoar",
+          "name": "Rallying Roar",
           "cooldown": 45
         },
         {
-          "name": "AbilityBigSqueeze",
+          "name": "Big Squeeze",
           "cooldown": 20
         }
       ],
@@ -1164,11 +1164,11 @@
       ],
       "abilities": [
         {
-          "name": "AbilityRallyingRoar",
+          "name": "Rallying Roar",
           "cooldown": 45
         },
         {
-          "name": "AbilityBigSqueeze",
+          "name": "Big Squeeze",
           "cooldown": 20
         }
       ],
@@ -1273,11 +1273,11 @@
       ],
       "abilities": [
         {
-          "name": "AbilityRallyingRoar",
+          "name": "Rallying Roar",
           "cooldown": 45
         },
         {
-          "name": "AbilityBigSqueeze",
+          "name": "Big Squeeze",
           "cooldown": 20
         }
       ],
@@ -1382,11 +1382,11 @@
       ],
       "abilities": [
         {
-          "name": "AbilityRallyingRoar",
+          "name": "Rallying Roar",
           "cooldown": 45
         },
         {
-          "name": "AbilityBigSqueeze",
+          "name": "Big Squeeze",
           "cooldown": 20
         }
       ],
@@ -1491,11 +1491,11 @@
       ],
       "abilities": [
         {
-          "name": "AbilityRallyingRoar",
+          "name": "Rallying Roar",
           "cooldown": 45
         },
         {
-          "name": "AbilityBigSqueeze",
+          "name": "Big Squeeze",
           "cooldown": 20
         }
       ],
@@ -1600,11 +1600,11 @@
       ],
       "abilities": [
         {
-          "name": "AbilityRallyingRoar",
+          "name": "Rallying Roar",
           "cooldown": 45
         },
         {
-          "name": "AbilityBigSqueeze",
+          "name": "Big Squeeze",
           "cooldown": 20
         }
       ],
@@ -1709,11 +1709,11 @@
       ],
       "abilities": [
         {
-          "name": "AbilityRallyingRoar",
+          "name": "Rallying Roar",
           "cooldown": 45
         },
         {
-          "name": "AbilityBigSqueeze",
+          "name": "Big Squeeze",
           "cooldown": 20
         }
       ],
@@ -1818,11 +1818,11 @@
       ],
       "abilities": [
         {
-          "name": "AbilityRallyingRoar",
+          "name": "Rallying Roar",
           "cooldown": 45
         },
         {
-          "name": "AbilityBigSqueeze",
+          "name": "Big Squeeze",
           "cooldown": 20
         }
       ],
@@ -1927,11 +1927,11 @@
       ],
       "abilities": [
         {
-          "name": "AbilityRallyingRoar",
+          "name": "Rallying Roar",
           "cooldown": 45
         },
         {
-          "name": "AbilityBigSqueeze",
+          "name": "Big Squeeze",
           "cooldown": 20
         }
       ],
@@ -2036,11 +2036,11 @@
       ],
       "abilities": [
         {
-          "name": "AbilityRallyingRoar",
+          "name": "Rallying Roar",
           "cooldown": 45
         },
         {
-          "name": "AbilityBigSqueeze",
+          "name": "Big Squeeze",
           "cooldown": 20
         }
       ],

--- a/disbot/data/btd6/stats/heroes/psi.json
+++ b/disbot/data/btd6/stats/heroes/psi.json
@@ -155,7 +155,7 @@
       ],
       "abilities": [
         {
-          "name": "PsychicBlast",
+          "name": "Psychic Blast",
           "cooldown": 45
         }
       ],
@@ -231,7 +231,7 @@
       ],
       "abilities": [
         {
-          "name": "PsychicBlast",
+          "name": "Psychic Blast",
           "cooldown": 45
         }
       ],
@@ -307,7 +307,7 @@
       ],
       "abilities": [
         {
-          "name": "PsychicBlast",
+          "name": "Psychic Blast",
           "cooldown": 45
         }
       ],
@@ -383,7 +383,7 @@
       ],
       "abilities": [
         {
-          "name": "PsychicBlast",
+          "name": "Psychic Blast",
           "cooldown": 45
         }
       ],
@@ -459,7 +459,7 @@
       ],
       "abilities": [
         {
-          "name": "PsychicBlast",
+          "name": "Psychic Blast",
           "cooldown": 45
         }
       ],
@@ -554,7 +554,7 @@
       ],
       "abilities": [
         {
-          "name": "PsychicBlast",
+          "name": "Psychic Blast",
           "cooldown": 45
         }
       ],
@@ -741,7 +741,7 @@
       ],
       "abilities": [
         {
-          "name": "PsychicBlast",
+          "name": "Psychic Blast",
           "cooldown": 45
         }
       ],
@@ -909,11 +909,11 @@
       ],
       "abilities": [
         {
-          "name": "PsychicBlast",
+          "name": "Psychic Blast",
           "cooldown": 45
         },
         {
-          "name": "PsionicScream",
+          "name": "Psionic Scream",
           "cooldown": 60
         }
       ],
@@ -1081,11 +1081,11 @@
       ],
       "abilities": [
         {
-          "name": "PsychicBlast",
+          "name": "Psychic Blast",
           "cooldown": 45
         },
         {
-          "name": "PsionicScream",
+          "name": "Psionic Scream",
           "cooldown": 60
         }
       ],
@@ -1253,11 +1253,11 @@
       ],
       "abilities": [
         {
-          "name": "PsychicBlast",
+          "name": "Psychic Blast",
           "cooldown": 45
         },
         {
-          "name": "PsionicScream",
+          "name": "Psionic Scream",
           "cooldown": 60
         }
       ],
@@ -1425,11 +1425,11 @@
       ],
       "abilities": [
         {
-          "name": "PsychicBlast",
+          "name": "Psychic Blast",
           "cooldown": 45
         },
         {
-          "name": "PsionicScream",
+          "name": "Psionic Scream",
           "cooldown": 60
         }
       ],
@@ -1597,11 +1597,11 @@
       ],
       "abilities": [
         {
-          "name": "PsychicBlast",
+          "name": "Psychic Blast",
           "cooldown": 45
         },
         {
-          "name": "PsionicScream",
+          "name": "Psionic Scream",
           "cooldown": 60
         }
       ],
@@ -1769,11 +1769,11 @@
       ],
       "abilities": [
         {
-          "name": "PsychicBlast",
+          "name": "Psychic Blast",
           "cooldown": 45
         },
         {
-          "name": "PsionicScream",
+          "name": "Psionic Scream",
           "cooldown": 60
         }
       ],
@@ -1941,11 +1941,11 @@
       ],
       "abilities": [
         {
-          "name": "PsychicBlast",
+          "name": "Psychic Blast",
           "cooldown": 45
         },
         {
-          "name": "PsionicScream",
+          "name": "Psionic Scream",
           "cooldown": 60
         }
       ],
@@ -2186,11 +2186,11 @@
       ],
       "abilities": [
         {
-          "name": "PsychicBlast",
+          "name": "Psychic Blast",
           "cooldown": 45
         },
         {
-          "name": "PsionicScream",
+          "name": "Psionic Scream",
           "cooldown": 60
         }
       ],
@@ -2431,11 +2431,11 @@
       ],
       "abilities": [
         {
-          "name": "PsychicBlast",
+          "name": "Psychic Blast",
           "cooldown": 45
         },
         {
-          "name": "PsionicScream",
+          "name": "Psionic Scream",
           "cooldown": 60
         }
       ],
@@ -2676,11 +2676,11 @@
       ],
       "abilities": [
         {
-          "name": "PsychicBlast",
+          "name": "Psychic Blast",
           "cooldown": 45
         },
         {
-          "name": "PsionicScream",
+          "name": "Psionic Scream",
           "cooldown": 60
         }
       ],
@@ -2921,11 +2921,11 @@
       ],
       "abilities": [
         {
-          "name": "PsychicBlast",
+          "name": "Psychic Blast",
           "cooldown": 45
         },
         {
-          "name": "PsionicScream",
+          "name": "Psionic Scream",
           "cooldown": 60
         }
       ],

--- a/disbot/data/btd6/stats/heroes/rosalia.json
+++ b/disbot/data/btd6/stats/heroes/rosalia.json
@@ -80,7 +80,7 @@
       ],
       "abilities": [
         {
-          "name": "ScatterMissileAbility",
+          "name": "Scatter Missile",
           "cooldown": 45
         }
       ],
@@ -112,7 +112,7 @@
       ],
       "abilities": [
         {
-          "name": "ScatterMissileAbility",
+          "name": "Scatter Missile",
           "cooldown": 45
         }
       ],
@@ -144,7 +144,7 @@
       ],
       "abilities": [
         {
-          "name": "ScatterMissileAbility",
+          "name": "Scatter Missile",
           "cooldown": 45
         }
       ],
@@ -176,7 +176,7 @@
       ],
       "abilities": [
         {
-          "name": "ScatterMissileAbility",
+          "name": "Scatter Missile",
           "cooldown": 45
         }
       ],
@@ -208,11 +208,11 @@
       ],
       "abilities": [
         {
-          "name": "ScatterMissileAbility",
+          "name": "Scatter Missile",
           "cooldown": 45
         },
         {
-          "name": "FlightBoostAbility",
+          "name": "Flight Boost",
           "cooldown": 45
         }
       ],
@@ -244,11 +244,11 @@
       ],
       "abilities": [
         {
-          "name": "ScatterMissileAbility",
+          "name": "Scatter Missile",
           "cooldown": 45
         },
         {
-          "name": "FlightBoostAbility",
+          "name": "Flight Boost",
           "cooldown": 45
         }
       ],
@@ -280,11 +280,11 @@
       ],
       "abilities": [
         {
-          "name": "ScatterMissileAbility",
+          "name": "Scatter Missile",
           "cooldown": 45
         },
         {
-          "name": "FlightBoostAbility",
+          "name": "Flight Boost",
           "cooldown": 45
         }
       ],
@@ -316,15 +316,15 @@
       ],
       "abilities": [
         {
-          "name": "ScatterMissileAbility",
+          "name": "Scatter Missile",
           "cooldown": 45
         },
         {
-          "name": "FlightBoostAbility",
+          "name": "Flight Boost",
           "cooldown": 45
         },
         {
-          "name": "KineticChargeAbility",
+          "name": "Kinetic Charge",
           "cooldown": 75
         }
       ],
@@ -356,15 +356,15 @@
       ],
       "abilities": [
         {
-          "name": "ScatterMissileAbility",
+          "name": "Scatter Missile",
           "cooldown": 45
         },
         {
-          "name": "FlightBoostAbility",
+          "name": "Flight Boost",
           "cooldown": 45
         },
         {
-          "name": "KineticChargeAbility",
+          "name": "Kinetic Charge",
           "cooldown": 75
         }
       ],
@@ -396,15 +396,15 @@
       ],
       "abilities": [
         {
-          "name": "ScatterMissileAbility",
+          "name": "Scatter Missile",
           "cooldown": 45
         },
         {
-          "name": "FlightBoostAbility",
+          "name": "Flight Boost",
           "cooldown": 45
         },
         {
-          "name": "KineticChargeAbility",
+          "name": "Kinetic Charge",
           "cooldown": 75
         }
       ],
@@ -436,15 +436,15 @@
       ],
       "abilities": [
         {
-          "name": "ScatterMissileAbility",
+          "name": "Scatter Missile",
           "cooldown": 45
         },
         {
-          "name": "FlightBoostAbility",
+          "name": "Flight Boost",
           "cooldown": 45
         },
         {
-          "name": "KineticChargeAbility",
+          "name": "Kinetic Charge",
           "cooldown": 75
         }
       ],
@@ -476,15 +476,15 @@
       ],
       "abilities": [
         {
-          "name": "ScatterMissileAbility",
+          "name": "Scatter Missile",
           "cooldown": 45
         },
         {
-          "name": "FlightBoostAbility",
+          "name": "Flight Boost",
           "cooldown": 45
         },
         {
-          "name": "KineticChargeAbility",
+          "name": "Kinetic Charge",
           "cooldown": 75
         }
       ],
@@ -516,15 +516,15 @@
       ],
       "abilities": [
         {
-          "name": "ScatterMissileAbility",
+          "name": "Scatter Missile",
           "cooldown": 45
         },
         {
-          "name": "FlightBoostAbility",
+          "name": "Flight Boost",
           "cooldown": 45
         },
         {
-          "name": "KineticChargeAbility",
+          "name": "Kinetic Charge",
           "cooldown": 75
         }
       ],
@@ -556,15 +556,15 @@
       ],
       "abilities": [
         {
-          "name": "ScatterMissileAbility",
+          "name": "Scatter Missile",
           "cooldown": 30
         },
         {
-          "name": "FlightBoostAbility",
+          "name": "Flight Boost",
           "cooldown": 45
         },
         {
-          "name": "KineticChargeAbility",
+          "name": "Kinetic Charge",
           "cooldown": 60
         }
       ],
@@ -596,15 +596,15 @@
       ],
       "abilities": [
         {
-          "name": "ScatterMissileAbility",
+          "name": "Scatter Missile",
           "cooldown": 30
         },
         {
-          "name": "FlightBoostAbility",
+          "name": "Flight Boost",
           "cooldown": 45
         },
         {
-          "name": "KineticChargeAbility",
+          "name": "Kinetic Charge",
           "cooldown": 60
         }
       ],
@@ -636,15 +636,15 @@
       ],
       "abilities": [
         {
-          "name": "ScatterMissileAbility",
+          "name": "Scatter Missile",
           "cooldown": 30
         },
         {
-          "name": "FlightBoostAbility",
+          "name": "Flight Boost",
           "cooldown": 35
         },
         {
-          "name": "KineticChargeAbility",
+          "name": "Kinetic Charge",
           "cooldown": 60
         }
       ],
@@ -676,15 +676,15 @@
       ],
       "abilities": [
         {
-          "name": "ScatterMissileAbility",
+          "name": "Scatter Missile",
           "cooldown": 30
         },
         {
-          "name": "FlightBoostAbility",
+          "name": "Flight Boost",
           "cooldown": 35
         },
         {
-          "name": "KineticChargeAbility",
+          "name": "Kinetic Charge",
           "cooldown": 60
         }
       ],
@@ -716,15 +716,15 @@
       ],
       "abilities": [
         {
-          "name": "ScatterMissileAbility",
+          "name": "Scatter Missile",
           "cooldown": 30
         },
         {
-          "name": "FlightBoostAbility",
+          "name": "Flight Boost",
           "cooldown": 35
         },
         {
-          "name": "KineticChargeAbility",
+          "name": "Kinetic Charge",
           "cooldown": 60
         }
       ],

--- a/disbot/data/btd6/stats/heroes/silas.json
+++ b/disbot/data/btd6/stats/heroes/silas.json
@@ -212,7 +212,7 @@
       ],
       "abilities": [
         {
-          "name": "FrostbiteAbility",
+          "name": "Frostbite",
           "cooldown": 30
         }
       ],
@@ -325,7 +325,7 @@
       ],
       "abilities": [
         {
-          "name": "FrostbiteAbility",
+          "name": "Frostbite",
           "cooldown": 30
         }
       ],
@@ -438,7 +438,7 @@
       ],
       "abilities": [
         {
-          "name": "FrostbiteAbility",
+          "name": "Frostbite",
           "cooldown": 30
         }
       ],
@@ -551,7 +551,7 @@
       ],
       "abilities": [
         {
-          "name": "FrostbiteAbility",
+          "name": "Frostbite",
           "cooldown": 30
         }
       ],
@@ -664,11 +664,11 @@
       ],
       "abilities": [
         {
-          "name": "FrostbiteAbility",
+          "name": "Frostbite",
           "cooldown": 30
         },
         {
-          "name": "FrozenCascade",
+          "name": "Frozen Cascade",
           "cooldown": 60
         }
       ],
@@ -781,11 +781,11 @@
       ],
       "abilities": [
         {
-          "name": "FrostbiteAbility",
+          "name": "Frostbite",
           "cooldown": 30
         },
         {
-          "name": "FrozenCascade",
+          "name": "Frozen Cascade",
           "cooldown": 60
         }
       ],
@@ -898,11 +898,11 @@
       ],
       "abilities": [
         {
-          "name": "FrostbiteAbility",
+          "name": "Frostbite",
           "cooldown": 30
         },
         {
-          "name": "FrozenCascade",
+          "name": "Frozen Cascade",
           "cooldown": 60
         }
       ],
@@ -1015,15 +1015,15 @@
       ],
       "abilities": [
         {
-          "name": "FrostbiteAbility",
+          "name": "Frostbite",
           "cooldown": 30
         },
         {
-          "name": "FrozenCascade",
+          "name": "Frozen Cascade",
           "cooldown": 60
         },
         {
-          "name": "FrozenBurialAbility",
+          "name": "Frozen Burial",
           "cooldown": 90
         }
       ],
@@ -1136,15 +1136,15 @@
       ],
       "abilities": [
         {
-          "name": "FrostbiteAbility",
+          "name": "Frostbite",
           "cooldown": 30
         },
         {
-          "name": "FrozenCascade",
+          "name": "Frozen Cascade",
           "cooldown": 60
         },
         {
-          "name": "FrozenBurialAbility",
+          "name": "Frozen Burial",
           "cooldown": 90
         }
       ],
@@ -1257,15 +1257,15 @@
       ],
       "abilities": [
         {
-          "name": "FrostbiteAbility",
+          "name": "Frostbite",
           "cooldown": 30
         },
         {
-          "name": "FrozenCascade",
+          "name": "Frozen Cascade",
           "cooldown": 60
         },
         {
-          "name": "FrozenBurialAbility",
+          "name": "Frozen Burial",
           "cooldown": 90
         }
       ],
@@ -1378,15 +1378,15 @@
       ],
       "abilities": [
         {
-          "name": "FrostbiteAbility",
+          "name": "Frostbite",
           "cooldown": 30
         },
         {
-          "name": "FrozenCascade",
+          "name": "Frozen Cascade",
           "cooldown": 60
         },
         {
-          "name": "FrozenBurialAbility",
+          "name": "Frozen Burial",
           "cooldown": 90
         }
       ],
@@ -1499,15 +1499,15 @@
       ],
       "abilities": [
         {
-          "name": "FrostbiteAbility",
+          "name": "Frostbite",
           "cooldown": 30
         },
         {
-          "name": "FrozenCascade",
+          "name": "Frozen Cascade",
           "cooldown": 60
         },
         {
-          "name": "FrozenBurialAbility",
+          "name": "Frozen Burial",
           "cooldown": 90
         }
       ],
@@ -1620,15 +1620,15 @@
       ],
       "abilities": [
         {
-          "name": "FrostbiteAbility",
+          "name": "Frostbite",
           "cooldown": 30
         },
         {
-          "name": "FrozenCascade",
+          "name": "Frozen Cascade",
           "cooldown": 45
         },
         {
-          "name": "FrozenBurialAbility",
+          "name": "Frozen Burial",
           "cooldown": 75
         }
       ],
@@ -1741,15 +1741,15 @@
       ],
       "abilities": [
         {
-          "name": "FrostbiteAbility",
+          "name": "Frostbite",
           "cooldown": 30
         },
         {
-          "name": "FrozenCascade",
+          "name": "Frozen Cascade",
           "cooldown": 45
         },
         {
-          "name": "FrozenBurialAbility",
+          "name": "Frozen Burial",
           "cooldown": 75
         }
       ],
@@ -1862,15 +1862,15 @@
       ],
       "abilities": [
         {
-          "name": "FrostbiteAbility",
+          "name": "Frostbite",
           "cooldown": 30
         },
         {
-          "name": "FrozenCascade",
+          "name": "Frozen Cascade",
           "cooldown": 45
         },
         {
-          "name": "FrozenBurialAbility",
+          "name": "Frozen Burial",
           "cooldown": 75
         }
       ],
@@ -1983,15 +1983,15 @@
       ],
       "abilities": [
         {
-          "name": "FrostbiteAbility",
+          "name": "Frostbite",
           "cooldown": 30
         },
         {
-          "name": "FrozenCascade",
+          "name": "Frozen Cascade",
           "cooldown": 45
         },
         {
-          "name": "FrozenBurialAbility",
+          "name": "Frozen Burial",
           "cooldown": 75
         }
       ],
@@ -2104,15 +2104,15 @@
       ],
       "abilities": [
         {
-          "name": "FrostbiteAbility",
+          "name": "Frostbite",
           "cooldown": 30
         },
         {
-          "name": "FrozenCascade",
+          "name": "Frozen Cascade",
           "cooldown": 45
         },
         {
-          "name": "FrozenBurialAbility",
+          "name": "Frozen Burial",
           "cooldown": 75
         }
       ],
@@ -2225,15 +2225,15 @@
       ],
       "abilities": [
         {
-          "name": "FrostbiteAbility",
+          "name": "Frostbite",
           "cooldown": 30
         },
         {
-          "name": "FrozenCascade",
+          "name": "Frozen Cascade",
           "cooldown": 45
         },
         {
-          "name": "FrozenBurialAbility",
+          "name": "Frozen Burial",
           "cooldown": 75
         }
       ],

--- a/disbot/data/btd6/stats/mermonkey.json
+++ b/disbot/data/btd6/stats/mermonkey.json
@@ -1,8 +1,8 @@
 {
   "tower_id": "mermonkey",
   "canonical": "Mermonkey",
-  "game_version": "54.0",
-  "source": "bloonswiki.com (CC BY-NC-SA)",
+  "game_version": "55.0",
+  "source": "bloonswiki.com (CC BY-NC-SA); BTD Mod Helper game data v55.0 (numeric overlay)",
   "base_cost": 300,
   "category": "magic",
   "paragon_cost": null,
@@ -83,7 +83,7 @@
       "tier": 1,
       "name": "Echosense Precision",
       "cost": 200,
-      "xp": 150
+      "xp": 120
     },
     {
       "path": 3,

--- a/disbot/data/btd6/stats/monkey_ace.json
+++ b/disbot/data/btd6/stats/monkey_ace.json
@@ -1,8 +1,8 @@
 {
   "tower_id": "monkey_ace",
   "canonical": "Monkey Ace",
-  "game_version": "54.0",
-  "source": "bloonswiki.com (CC BY-NC-SA)",
+  "game_version": "55.0",
+  "source": "bloonswiki.com (CC BY-NC-SA); BTD Mod Helper game data v55.0 (numeric overlay)",
   "base_cost": 800,
   "category": "military",
   "paragon_cost": 900000,
@@ -110,7 +110,7 @@
       "path": 3,
       "tier": 5,
       "name": "Flying Fortress",
-      "cost": 85000,
+      "cost": 90000,
       "xp": 45000
     }
   ],

--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -6,6 +6,7 @@ to pick up the work: it records what's done, **how the dump's data actually
 works** (the traps we hit), and what is still un-decoded.
 
 > Companion docs — read alongside:
+> - **`btd6-gamedata-native-schema.md`** — *the game-native storage design & cutover map* (game data leads; how to store the game's structure displayably).
 > - **`btd6-gamedata-dictionary.md`** — *what data exists and where* (domains, the textTable linkage).
 > - **`btd6-game-file-extraction-plan.md`** — the mapper roadmap + the fidelity-audit findings.
 > - **`btd6-data-pipeline.md`** — the existing bloonswiki pipeline this augments.

--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -28,7 +28,8 @@ and the wiki's clean structure). See the dictionary's "source ladder".
 | PR | What |
 |---|---|
 | **#464** (merged) | **Fidelity-audit foundation.** `parse_gamedata.py --audit` maps every tower/hero/paragon in-memory and diffs each numeric/bool leaf vs the committed wiki data, classifying each field CLEAN / DELTA / SUSPECT. Float-tolerant (4 dp), aligns dict-lists by `name` and upgrades by `(path, tier)`. |
-| **#465** (open) | **Discovery tooling + dictionary + two real mapper bug fixes** (below): `btd6_gamedata_inventory.py`, `docs/btd6-gamedata-dictionary.md`, the `damageAddative` fix, and the spawn-model projectile fix. |
+| **#465** (merged) | **Discovery tooling + dictionary + two mapper bug fixes**: `btd6_gamedata_inventory.py`, `docs/btd6-gamedata-dictionary.md`, the `damageAddative` fix, and the spawn-model projectile fix. |
+| **(this PR)** | **Conservative numeric overlay** (`parse_gamedata.py --overlay`, `--dry-run`): refreshes only the *unambiguously-keyed* v55 values onto the curated files — top-level cost/category, upgrade cost/xp by `(path, tier)`, and **tier-level** `range`/`footprintRadius`. Found a real wiki bug (Desperado mid-path range 28, *below* its base 60 — corrected to v55's 80) plus mermonkey xp / ace cost. **Per-projectile/ability stats are deliberately NOT overlaid** (see the naming lesson below). |
 
 Two extraction bugs were found and fixed — **both the same failure mode: the
 data was always present; the mapper read the wrong field or the wrong place.**
@@ -72,6 +73,16 @@ data was always present; the mapper read the wrong field or the wrong place.**
 - **List ordering differs**: the mapper flattens sub-projectiles depth-first;
   the wiki groups/names them its own way. Align by `name` (+ damage signature),
   never by index. Same-name sub-projectiles are the main residual audit DELTAs.
+- **Projectile / ability *names* are NOT reliable keys across wiki↔dump** — the
+  single most dangerous thing for *writing* (overlay). The wiki calls a
+  projectile `"Projectile"` where the dump uses the id `"BaseProjectile"`, and
+  `"Projectile"`/`"Ability"` are reused for distinct nodes. Matching by name
+  therefore writes onto the **wrong** node: it would put Druid Superstorm's 100
+  dmg on the base dart, and Dark Knight's *Legend of the Night* 180s cooldown
+  on its *other* ability. So the overlay only touches **uniquely-keyed** values
+  (cost/category, upgrades by `(path,tier)`, tier-level `range`/`footprint`) and
+  leaves all per-projectile/ability stats curated. The audit may *report* a
+  per-projectile DELTA, but it is never safe to auto-*write* it.
 - **`immuneBloonProperties`** is a bitmask with bits we don't decode (9 vs 73
   can decode to the *same* type+immunity) — compare the *decoded* type, not the
   raw int.
@@ -96,10 +107,16 @@ data was always present; the mapper read the wrong field or the wrong place.**
 ## Not yet added / decoded (open items)
 
 **Mapper / data completeness**
-- **The safe overlay itself isn't applied yet.** The audit says *which* fields
-  are safe; PR-next refreshes audit-CLEAN/DELTA numbers onto the curated files
-  (names preserved via `LocsKey`/`displayName`, lists aligned by name+signature)
-  and updates the ~25 value-pinned tests for the v55 numbers.
+- **The overlay is applied, but only for uniquely-keyed fields** (cost/category,
+  upgrade cost/xp, tier-level `range`/`footprint`). **Expanding it to
+  per-projectile/ability stats is blocked** on reconciling wiki↔dump names (a
+  `"Projectile"` ↔ `"BaseProjectile"` map, or a signature match on the
+  *un*-changed fields), or restricting to provably-unambiguous tiers (exactly
+  one attack × one projectile). Until then those stats stay curated — the audit
+  shows them mostly CLEAN, so little is lost; the DELTAs are the risky ones.
+- **Paragons not yet overlaid** (their combat lives in a `base` node, not
+  `tiers`/`levels`; metadata is curated). Easy follow-up once the per-projectile
+  story is settled.
 - **Descriptions are unused.** Wiring `textTable` upgrade/ability/hero-level
   prose into our fixtures + AI grounding is the biggest untapped, authoritative
   win (would answer "what does Ezili L11 do?" from the game itself).

--- a/docs/btd6-gamedata-native-schema.md
+++ b/docs/btd6-gamedata-native-schema.md
@@ -1,0 +1,124 @@
+# BTD6 game-native storage — schema design & cutover map
+
+**Principle (set by the maintainer):** the **game data leads**; bloonswiki is a
+cross-check *reference*, not the source of truth. We store the game's **own
+structure** and resolve names from the **game's own** strings — we do **not**
+reshape the data to fit a wiki-derived schema. The one exception: don't fragment
+data into pieces the bot can't reassemble (keep the few bot-matching keys the
+dump doesn't expose — see "What stays curated").
+
+> Why now: the wiki files are v53, lag per-tower, rename/merge the game's
+> projectiles, and miss projectiles entirely. The game data is complete, v55,
+> and canonical. Verified wins from going game-native: Druid Superstorm shows
+> its **v55** storm (100 dmg, was a stale 150) with clean canonical ids instead
+> of 8 duplicate-named entries; Super Monkey Dark Knight's **two** abilities are
+> distinct again (`Legend of the Night` vs `ChampionDarkshift`); Psi's
+> `DestructiveResonance` (previously dropped) is present; upgrades carry the
+> game's own descriptions.
+>
+> Companion docs: `btd6-gamedata-decode-status.md` (status/lessons),
+> `btd6-gamedata-dictionary.md` (where each fact lives),
+> `btd6-game-file-extraction-plan.md` (the mapper).
+
+## The game's tower data structure (what we mirror)
+
+```
+Towers/<Name>/<Name>-NNN.json   (one file per crosspath state; NNN = tier digits)
+  └ behaviors[]
+      ├ AttackModel              range; one per distinct attack
+      │   └ weapons[]            rate; emission (count); ejectX/Y/Z
+      │       ├ projectile       ProjectileModel — id is the game-native name
+      │       │   └ behaviors[]
+      │       │       ├ DamageModel               damage, immuneBloonProperties
+      │       │       ├ DamageModifierForTagModel tag + damageAddative (the bonus)
+      │       │       ├ Travel*Model              speed, lifespan
+      │       │       ├ CreateProjectile*/Alternate/… → child projectiles
+      │       │       └ Create/Slow/Freeze/Stun…  → effects
+      │       └ behaviors[]      AlternateProjectileModel etc. (weapon-level spawns)
+      ├ AbilityModel             displayName (player-facing!), cooldown
+      ├ *ZoneModel               damage zones (Arctic Wind, DoT, …)
+      ├ buff models              inline (MonkeyFanClub, village range, …)
+      └ footprint / areaTypes / towerSet / targetTypes  (top-level)
+```
+
+Heroes: `<Hero> N.json` per level (same `behaviors[]` shape). Paragons:
+`<Name>-Paragon.json`, a single flat node. Bloons (incl. bosses):
+`Bloons/<Name>/<Name><tier>.json` `BloonModel`.
+
+## Names — all game-sourced (no wiki labels)
+
+| Thing | Game-native source | Status |
+|---|---|---|
+| Ability | `AbilityModel.displayName` ("Cocktail of Fire") | ✅ mapper does this |
+| Upgrade name + **description** | `UpgradeModel.LocsKey` → `textTable[LocsKey]` / `[LocsKey + " Description"]` | ✅ mapper does this |
+| Projectile | `ProjectileModel.id` (e.g. `BaseProjectile`, `LightningProj`) | ✅ canonical id |
+| Spawned subtower | nested `towerModel.name` ("Phoenix") | ✅ |
+| Tower / hero | catalog id + canonical | ✅ |
+| Zone (e.g. "Arctic Wind") | the zone model's `name` is empty → resolve via the **owning upgrade's** name (`LocsKey`) | ⏳ cutover |
+| Bloon / boss | `BloonModel.id` | ⏳ when bloons go game-native |
+
+The tag damage bonus lives in `damageAddative` (sic), not `damageMultiplier`;
+see the dictionary/decode-status docs for the field traps.
+
+## How the bot consumes it (the "displayable" constraint)
+
+The runtime is largely **name-agnostic**, which is what makes game-native
+storage drop-in:
+
+- **`btd6_stats_service.normal_stats`** — the glance view — picks the headline by
+  **highest-damage own-attack projectile** (`_main_projectile`), *not* by a name
+  like "Projectile". Reads `damage`, `damage_type`, `cannot_pop`, `pierce`,
+  `rate` (cooldown), tier `range`, `filterInvisible` (camo), and scans all nodes
+  (`_iter_dicts`) for specials (MOAB bonus, stun, income, ability cooldown,
+  knockback). → A game-native projectile set just works (and headlines the right
+  projectile).
+- **Pro view** (`utils/btd6/stats_embed`) — renders the full per-tier breakdown;
+  shows whatever projectiles/abilities are present.
+- **`btd6_upgrade_detail_service`** — surfaces *named* attacks/projectiles/
+  abilities/subtowers/buffs/zones; game-native names flow straight through.
+- **Grounding** (`btd6_context_service`) — renders fact lines from the same data.
+
+## What game-native storage requires (runtime adaptations for the cutover)
+
+These are the only places that assume *wiki* naming and need updating when the
+committed files become game-native:
+
+1. **`_main_projectile` reanimated-minion skip-list** (`_REANIMATED_MINION_NAMES`)
+   — hard-coded wiki names; re-key to the game ids/names so a reanimated blimp
+   still can't masquerade as the headline.
+2. **`_collect_specials`** keys on `"Stun" in name` and on `cashPerRound` etc. —
+   confirm the game-native node names still trip stun detection (the mapper's
+   effect nodes carry game names like `"Stun…"`); adjust if needed.
+3. **Curated prose** — tower/hero `description` (deliberately empty today) and
+   `paragon_descriptions.json` can be **superseded by `textTable` descriptions**
+   (game-authored, no CC concern). Decide per-entity; keep paragon overviews if
+   preferred.
+4. **Value-pinned tests** (~25) — update to the v55 numbers.
+
+## What stays curated (the bot-matching keys the dump doesn't expose)
+
+- **Paragon `cost` / `canonical` / `xp`** — the dump's `-Paragon.json` `cost` is
+  the base monkey's placement cost, not the paragon price; keep the curated
+  metadata (the mapper already preserves it).
+- **Catalog `towers.json` / `heroes.json`** — ids, aliases, the resolver
+  vocabulary the bot matches user text against.
+- **Bloon aliases** and any synthesized modifier entries used for matching.
+
+These are *keys for matching*, not game stats — exactly the "don't fragment what
+the bot can't reassemble" exception.
+
+## Cutover plan (phased)
+
+1. **Game-native names + descriptions in the mapper** — ability `displayName`,
+   upgrade `LocsKey` → name/description. ✅ **(this PR)** Generated heroes
+   re-emitted with real ability names.
+2. **Towers cutover** — adopt `parse_gamedata.py --all` output as the committed
+   tower stats (game-native ids/structure/values), do the runtime adaptations
+   above, update value-pinned tests. Audit (`--audit`) gates the numbers.
+3. **Heroes + paragons cutover** + wire `textTable` descriptions into grounding
+   and the detail UI (answers "what does upgrade/ability X do?" from the game).
+4. **Bloons / bosses** from `BloonModel`; then the other domains as needed.
+
+Until a phase lands, the conservative overlay (`--overlay`) keeps the
+uniquely-keyed numbers (cost/range/xp) current without touching the wiki
+structure.

--- a/scripts/parse_gamedata.py
+++ b/scripts/parse_gamedata.py
@@ -964,6 +964,101 @@ def render_audit(stats: dict[str, _FieldStat]) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Safe numeric overlay — refresh trusted v55 numbers onto the curated files
+# ---------------------------------------------------------------------------
+#
+# The committed tower/hero files are bloonswiki-sourced (v53) with curated names,
+# descriptions and structure. The overlay refreshes ONLY the audit-trusted
+# numeric / immunity leaves to their v55 values, in place, aligning lists by
+# name (and upgrades by (path, tier)) — it never adds or removes a projectile /
+# attack / upgrade, so the curated structure + names survive intact. Fields the
+# audit can't trust (``count``, the camo/blocker bools tangled in flatten order)
+# and all names/descriptions are left untouched.
+
+# Tier-/level-level scalar fields that are SAFE to overlay: each occurs once per
+# tier dict, so there is no alignment ambiguity. We deliberately do NOT overlay
+# per-projectile / per-attack / per-ability stats — projectile and ability names
+# are not reliable keys across the two sources (the wiki calls a projectile
+# "Projectile" where the dump calls it "BaseProjectile"; "Ability" is reused for
+# distinct abilities), so matching by name writes values onto the WRONG node
+# (verified: it would put the Superstorm's 100 dmg on Druid's base dart, and
+# Legend-of-the-Night's 180s cooldown on Dark Knight's other ability). Those
+# stats stay curated; the audit shows them mostly CLEAN anyway.
+_OVERLAY_FIELDS: frozenset[str] = frozenset({"range", "footprintRadius"})
+
+
+def _overlay_node(committed: Any, mapped: Any, changes: list[str], ctx: str) -> None:
+    """Refresh ``_OVERLAY_FIELDS`` scalar leaves of ``committed`` from ``mapped``.
+
+    Recurses **dicts only** — never lists. Lists (attacks/projectiles/abilities)
+    can't be aligned safely across the two sources (see ``_OVERLAY_FIELDS``), so
+    they are left entirely curated rather than risk a mis-keyed write.
+    """
+    if not (isinstance(committed, dict) and isinstance(mapped, dict)):
+        return
+    for key, cval in committed.items():
+        if key not in mapped:
+            continue
+        mval = mapped[key]
+        if key in _OVERLAY_FIELDS and _is_audit_scalar(cval) and _is_audit_scalar(mval):
+            if not _audit_equal(cval, mval) and type(cval) is not bool:
+                committed[key] = mval
+                changes.append(f"{ctx}.{key}: {cval!r} → {mval!r}")
+        elif isinstance(cval, dict):
+            _overlay_node(cval, mval, changes, f"{ctx}.{key}")
+
+
+def _overlay_upgrades(committed: dict, mapped: dict, changes: list[str]) -> None:
+    """Refresh upgrade ``cost`` / ``xp`` aligned by ``(path, tier)`` (keep names)."""
+    mmap = {
+        (u.get("path"), u.get("tier")): u
+        for u in mapped.get("upgrades", [])
+        if isinstance(u, dict)
+    }
+    for up in committed.get("upgrades", []) or []:
+        if not isinstance(up, dict):
+            continue
+        m = mmap.get((up.get("path"), up.get("tier")))
+        if not m:
+            continue
+        for field_name in ("cost", "xp"):
+            if field_name in up and field_name in m and up[field_name] != m[field_name]:
+                changes.append(
+                    f"upgrade[{up.get('path')}-{up.get('tier')}].{field_name}: "
+                    f"{up[field_name]!r} → {m[field_name]!r}",
+                )
+                up[field_name] = m[field_name]
+
+
+def overlay_payload(committed: dict, mapped: dict, version: str) -> list[str]:
+    """Overlay ``mapped`` v55 numbers onto a committed tower/hero ``dict`` in
+    place; return the list of changes made.
+    """
+    changes: list[str] = []
+    for key in ("base_cost", "category"):
+        if key in committed and key in mapped and committed[key] != mapped[key]:
+            changes.append(f"{key}: {committed[key]!r} → {mapped[key]!r}")
+            committed[key] = mapped[key]
+    if committed.get("upgrades") and mapped.get("upgrades"):
+        _overlay_upgrades(committed, mapped, changes)
+    for container in ("tiers", "levels"):
+        if container in committed and container in mapped:
+            _overlay_node(
+                committed[container],
+                mapped[container],
+                changes,
+                container,
+            )
+    if changes:
+        committed["game_version"] = version
+        prior = str(committed.get("source", ""))
+        stamp = f"BTD Mod Helper game data v{version} (numeric overlay)"
+        if "Mod Helper" not in prior:
+            committed["source"] = f"{prior}; {stamp}" if prior else stamp
+    return changes
+
+
+# ---------------------------------------------------------------------------
 # Anchors + CLI
 # ---------------------------------------------------------------------------
 
@@ -981,6 +1076,40 @@ def validate_anchors(dump: Path) -> list[str]:
         if cost != expected:
             errors.append(f"{folder}: cost {cost!r} != expected {expected}")
     return errors
+
+
+def overlay_all(dump: Path, *, dry_run: bool) -> dict[str, list[str]]:
+    """Overlay v55 numbers onto every curated tower + hero file. Returns
+    ``{relative_path: [change, …]}`` for files that changed (generated heroes are
+    already v55, so they no-op). Paragons are intentionally out of scope.
+    """
+    towers, heroes = build_allowlist(dump)
+    version = _dump_version(dump)
+    report: dict[str, list[str]] = {}
+
+    def apply(fp: Path, rel: str, mapped: dict) -> None:
+        if not fp.exists():
+            return
+        committed = json.loads(fp.read_text("utf-8"))
+        changes = overlay_payload(committed, mapped, version)
+        if changes:
+            report[rel] = changes
+            if not dry_run:
+                _write(fp, committed)
+
+    for tid, canonical in towers.items():
+        apply(
+            _STATS_DIR / f"{tid}.json",
+            f"stats/{tid}.json",
+            map_tower(dump, tid, canonical, version).payload,
+        )
+    for hid, canonical in heroes.items():
+        apply(
+            _STATS_DIR / "heroes" / f"{hid}.json",
+            f"stats/heroes/{hid}.json",
+            map_hero(dump, hid, canonical, version).payload,
+        )
+    return report
 
 
 def _write(path: Path, payload: dict) -> None:
@@ -1012,6 +1141,11 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="report per-field fidelity vs the committed wiki data (no writes)",
     )
+    ap.add_argument(
+        "--overlay",
+        action="store_true",
+        help="refresh trusted v55 numbers onto curated tower/hero files",
+    )
     ap.add_argument("--dry-run", action="store_true", help="print, do not write")
     args = ap.parse_args(argv)
 
@@ -1031,6 +1165,17 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.audit:
         print(render_audit(audit(dump)))
+        return 0
+
+    if args.overlay:
+        report = overlay_all(dump, dry_run=args.dry_run)
+        verb = "would change" if args.dry_run else "changed"
+        total = sum(len(v) for v in report.values())
+        print(f"overlay: {verb} {len(report)} file(s), {total} leaf value(s)\n")
+        for rel in sorted(report):
+            print(f"  {rel}  ({len(report[rel])} change(s))")
+            for change in report[rel]:
+                print(f"      {change}")
         return 0
 
     towers, heroes = build_allowlist(dump)

--- a/scripts/parse_gamedata.py
+++ b/scripts/parse_gamedata.py
@@ -373,7 +373,13 @@ def _clean_attack(attack: dict, index: int) -> dict:
 
 
 def _clean_ability(ability: dict, index: int) -> dict:
-    out: dict = {"name": _clean_name(ability.get("name"), f"Ability {index + 1}")}
+    # Prefer the game's own player-facing name (``displayName`` is already English
+    # — "Cocktail of Fire", "Firestorm") over the internal model name.
+    display = ability.get("displayName")
+    name = display if isinstance(display, str) and display else None
+    out: dict = {
+        "name": name or _clean_name(ability.get("name"), f"Ability {index + 1}"),
+    }
     if "cooldown" in ability:
         out["cooldown"] = _num(ability["cooldown"])
     # An ability fires its own AttackModels; surface their projectiles + bad dmg.
@@ -567,6 +573,7 @@ def _upgrades_for(tdir: Path, dump: Path) -> list[dict]:
             if isinstance(name, str) and name and name not in seen:
                 seen.add(name)
                 names.append(name)
+    tt = _text_table(dump)
     out: list[dict] = []
     for name in names:
         up = _read_upgrade(dump, name)
@@ -576,17 +583,41 @@ def _upgrades_for(tdir: Path, dump: Path) -> list[dict]:
         tier = up.get("tier")
         if not isinstance(path, int) or not isinstance(tier, int):
             continue
-        out.append(
-            {
-                "path": path + 1,
-                "tier": tier + 1,
-                "name": up.get("name", name),
-                "cost": _num(up.get("cost", 0)),
-                "xp": _num(up.get("xpCost", 0)),
-            },
-        )
+        entry = {
+            "path": path + 1,
+            "tier": tier + 1,
+            "name": up.get("name", name),
+            "cost": _num(up.get("cost", 0)),
+            "xp": _num(up.get("xpCost", 0)),
+        }
+        # Game-authored description ("what this upgrade grants"), resolved through
+        # the upgrade's localization key — the bot's most reliable upgrade prose.
+        locs = up.get("LocsKey")
+        if isinstance(locs, str) and locs:
+            description = tt.get(f"{locs} Description")
+            if isinstance(description, str) and description:
+                entry["description"] = description
+        out.append(entry)
     out.sort(key=lambda u: (u["path"], u["tier"]))
     return out
+
+
+_TEXT_TABLE_CACHE: dict[str, dict[str, str]] = {}
+
+
+def _text_table(dump: Path) -> dict[str, str]:
+    """The dump's ``textTable.json`` (game display strings + descriptions), cached
+    per dump path. Empty dict if absent — name/description lookups then no-op.
+    """
+    key = str(dump)
+    if key not in _TEXT_TABLE_CACHE:
+        fp = dump / "textTable.json"
+        try:
+            raw = json.loads(fp.read_text("utf-8")) if fp.exists() else {}
+        except (OSError, json.JSONDecodeError):
+            raw = {}
+        _TEXT_TABLE_CACHE[key] = {k: v for k, v in raw.items() if isinstance(v, str)}
+    return _TEXT_TABLE_CACHE[key]
 
 
 def _read_upgrade(dump: Path, upgrade_id: Any) -> dict | None:

--- a/tests/unit/scripts/test_parse_gamedata.py
+++ b/tests/unit/scripts/test_parse_gamedata.py
@@ -50,10 +50,14 @@ def _damage_model(damage: float, immune: int = 17) -> dict:
 
 
 def _projectile(
-    *, name="Projectile", pierce=2.0, radius=2.0, damage: float | None = 1.0
+    *,
+    name="Projectile",
+    pierce=2.0,
+    radius=2.0,
+    damage: float | None = 1.0,
 ) -> dict:
     behaviors: list[dict] = [
-        {"$type": _t("TravelStraitModel"), "speed": 300.0, "lifespan": 0.25}
+        {"$type": _t("TravelStraitModel"), "speed": 300.0, "lifespan": 0.25},
     ]
     if damage is not None:
         behaviors.insert(0, _damage_model(damage))
@@ -84,7 +88,7 @@ def _attack(projectile: dict, *, rate=0.95, rng=32.0, name="Attack") -> dict:
                 "fireWithoutTarget": False,
                 "fireBetweenRounds": False,
                 "name": "WeaponModel_Weapon",
-            }
+            },
         ],
     }
 
@@ -139,7 +143,7 @@ def test_sub_projectiles_are_flattened_as_siblings(mod):
     explosion = _projectile(name="Explosion", pierce=22.0, radius=12.0, damage=1.0)
     shell = _projectile(name="Projectile", pierce=1.0, radius=4.0, damage=None)
     shell["behaviors"].append(
-        {"$type": _t("CreateProjectileOnContactModel"), "projectile": explosion}
+        {"$type": _t("CreateProjectileOnContactModel"), "projectile": explosion},
     )
     attack = mod._clean_attack(_attack(shell), 0)
     names = [p["name"] for p in attack["projectiles"]]
@@ -216,7 +220,7 @@ def test_tower_set_maps_to_category(mod):
 def test_income_field_is_surfaced(mod):
     model = _tower_model()
     model["behaviors"].append(
-        {"$type": _t("PerRoundCashBonusTowerModel"), "cashPerRound": 4000.0}
+        {"$type": _t("PerRoundCashBonusTowerModel"), "cashPerRound": 4000.0},
     )
     tier = mod._map_tier(model)
     assert tier["cashPerRound"] == 4000
@@ -239,7 +243,7 @@ def _make_dump(tmp_path: Path) -> Path:
             "$type": _t("UpgradePathModel"),
             "tower": "TestTower-100",
             "upgrade": "Big Darts",
-        }
+        },
     ]
     _write(tdir / "TestTower.json", base)
     # a single crosspath state file
@@ -247,7 +251,19 @@ def _make_dump(tmp_path: Path) -> Path:
     # the upgrade definition (path/tier are 0-indexed in the dump)
     _write(
         dump / "Upgrades" / "Big Darts.json",
-        {"name": "Big Darts", "cost": 140, "xpCost": 0, "path": 0, "tier": 0},
+        {
+            "name": "Big Darts",
+            "cost": 140,
+            "xpCost": 0,
+            "path": 0,
+            "tier": 0,
+            "LocsKey": "Big Darts",
+        },
+    )
+    # game localization: upgrade display strings + descriptions
+    _write(
+        dump / "textTable.json",
+        {"Big Darts": "Big Darts", "Big Darts Description": "Darts are bigger."},
     )
     return dump
 
@@ -264,9 +280,17 @@ def test_map_tower_end_to_end(mod, tmp_path):
     assert p["source"] == mod._SOURCE
     # base file → tier 000, plus the -100 state.
     assert set(p["tiers"]) == {"000", "100"}
-    # upgrade resolved with 0-indexed → 1-indexed path/tier.
+    # upgrade resolved with 0-indexed → 1-indexed path/tier, plus the game's own
+    # description resolved through its LocsKey.
     assert p["upgrades"] == [
-        {"path": 1, "tier": 1, "name": "Big Darts", "cost": 140, "xp": 0}
+        {
+            "path": 1,
+            "tier": 1,
+            "name": "Big Darts",
+            "cost": 140,
+            "xp": 0,
+            "description": "Darts are bigger.",
+        },
     ]
 
 
@@ -274,7 +298,8 @@ def test_validate_anchors(mod, tmp_path):
     dump = tmp_path / "dump"
     _write(dump / "Towers" / "DartMonkey" / "DartMonkey.json", _tower_model(cost=200.0))
     _write(
-        dump / "Towers" / "SuperMonkey" / "SuperMonkey.json", _tower_model(cost=2500.0)
+        dump / "Towers" / "SuperMonkey" / "SuperMonkey.json",
+        _tower_model(cost=2500.0),
     )
     assert mod.validate_anchors(dump) == []
     # A moved anchor must fail loudly.
@@ -295,7 +320,12 @@ def test_overlay_refreshes_tier_range_but_not_projectile_stats(mod):
             "030": {
                 "range": 28,
                 "attacks": [
-                    {"name": "Attack", "projectiles": [{"name": "Projectile", "damage": 1, "pierce": 2}]},
+                    {
+                        "name": "Attack",
+                        "projectiles": [
+                            {"name": "Projectile", "damage": 1, "pierce": 2},
+                        ],
+                    },
                 ],
             },
         },
@@ -307,7 +337,12 @@ def test_overlay_refreshes_tier_range_but_not_projectile_stats(mod):
             "030": {
                 "range": 80,
                 "attacks": [
-                    {"name": "Attack", "projectiles": [{"name": "BaseProjectile", "damage": 100, "pierce": 200}]},
+                    {
+                        "name": "Attack",
+                        "projectiles": [
+                            {"name": "BaseProjectile", "damage": 100, "pierce": 200},
+                        ],
+                    },
                 ],
             },
         },
@@ -339,7 +374,9 @@ def test_overlay_refreshes_upgrade_cost_xp_keyed_by_path_tier(mod):
     mod.overlay_payload(committed, mapped, "55.0")
 
     def up(path, tier):
-        return next(u for u in committed["upgrades"] if (u["path"], u["tier"]) == (path, tier))
+        return next(
+            u for u in committed["upgrades"] if (u["path"], u["tier"]) == (path, tier)
+        )
 
     assert up(3, 5)["cost"] == 90000  # refreshed despite reversed order
     assert up(1, 1)["xp"] == 40
@@ -347,10 +384,35 @@ def test_overlay_refreshes_upgrade_cost_xp_keyed_by_path_tier(mod):
 
 
 def test_overlay_no_change_leaves_version_and_source(mod):
-    committed = {"base_cost": 200, "category": "primary", "game_version": "54.0", "source": "w", "tiers": {}}
-    changes = mod.overlay_payload(committed, {"base_cost": 200, "category": "primary", "tiers": {}}, "55.0")
+    committed = {
+        "base_cost": 200,
+        "category": "primary",
+        "game_version": "54.0",
+        "source": "w",
+        "tiers": {},
+    }
+    changes = mod.overlay_payload(
+        committed,
+        {"base_cost": 200, "category": "primary", "tiers": {}},
+        "55.0",
+    )
     assert changes == []
     assert committed["game_version"] == "54.0"  # untouched when nothing moved
+
+
+def test_ability_uses_game_display_name(mod):
+    ability = {
+        "$type": _t("AbilityModel"),
+        "name": "AbilityModel_Ability",
+        "displayName": "Cocktail of Fire",
+        "cooldown": 15.0,
+    }
+    assert mod._clean_ability(ability, 0)["name"] == "Cocktail of Fire"
+
+
+def test_ability_falls_back_to_internal_name_without_display_name(mod):
+    ability = {"$type": _t("AbilityModel"), "name": "AbilityModel_Ability"}
+    assert mod._clean_ability(ability, 0)["name"] == "Ability"
 
 
 def test_pascal_name_mapping(mod):
@@ -409,7 +471,11 @@ def test_audit_equal_bools_compared_by_identity(mod):
 
 
 def test_align_named_pairs_by_name_not_index(mod):
-    committed = [{"name": "Projectile", "r": 4}, {"name": "Frag"}, {"name": "Explosion"}]
+    committed = [
+        {"name": "Projectile", "r": 4},
+        {"name": "Frag"},
+        {"name": "Explosion"},
+    ]
     mapped = [{"name": "Projectile", "r": 4}, {"name": "Explosion"}, {"name": "Frag"}]
     pairs = mod._align_named(committed, mapped)
     assert [n for n, _, _ in pairs] == ["Projectile", "Frag", "Explosion"]
@@ -425,7 +491,9 @@ def test_align_named_falls_back_on_duplicate_or_missing_names(mod):
 
 def test_walk_audit_tallies_named_alignment(mod):
     stats: dict = {}
-    committed = {"projectiles": [{"name": "A", "pierce": 10}, {"name": "B", "pierce": 5}]}
+    committed = {
+        "projectiles": [{"name": "A", "pierce": 10}, {"name": "B", "pierce": 5}],
+    }
     mapped = {"projectiles": [{"name": "B", "pierce": 5}, {"name": "A", "pierce": 7}]}
     mod._walk_audit(committed, mapped, "root", stats, "ctx")
     # A.pierce differs (10 vs 7), B.pierce matches → 1 diff / 2 total, despite

--- a/tests/unit/scripts/test_parse_gamedata.py
+++ b/tests/unit/scripts/test_parse_gamedata.py
@@ -282,6 +282,77 @@ def test_validate_anchors(mod, tmp_path):
     assert mod.validate_anchors(dump)
 
 
+def test_overlay_refreshes_tier_range_but_not_projectile_stats(mod):
+    # The safety property: tier-level scalars refresh, per-projectile stats do
+    # NOT — projectile names aren't reliable keys across wiki/dump, so writing
+    # them by name would scramble values (Druid base dart vs storm).
+    committed = {
+        "base_cost": 200,
+        "category": "primary",
+        "game_version": "54.0",
+        "source": "bloonswiki.com",
+        "tiers": {
+            "030": {
+                "range": 28,
+                "attacks": [
+                    {"name": "Attack", "projectiles": [{"name": "Projectile", "damage": 1, "pierce": 2}]},
+                ],
+            },
+        },
+    }
+    mapped = {
+        "base_cost": 200,
+        "category": "primary",
+        "tiers": {
+            "030": {
+                "range": 80,
+                "attacks": [
+                    {"name": "Attack", "projectiles": [{"name": "BaseProjectile", "damage": 100, "pierce": 200}]},
+                ],
+            },
+        },
+    }
+    changes = mod.overlay_payload(committed, mapped, "55.0")
+    assert committed["tiers"]["030"]["range"] == 80  # tier scalar refreshed
+    proj = committed["tiers"]["030"]["attacks"][0]["projectiles"][0]
+    assert proj["damage"] == 1 and proj["pierce"] == 2  # projectile LEFT CURATED
+    assert committed["game_version"] == "55.0"
+    assert "Mod Helper" in committed["source"]
+    assert any("range" in c for c in changes)
+
+
+def test_overlay_refreshes_upgrade_cost_xp_keyed_by_path_tier(mod):
+    committed = {
+        "tiers": {},
+        "upgrades": [
+            {"path": 3, "tier": 5, "name": "Flying Fortress", "cost": 85000, "xp": 0},
+            {"path": 1, "tier": 1, "name": "Sharp", "cost": 100, "xp": 50},
+        ],
+    }
+    mapped = {
+        "tiers": {},
+        "upgrades": [  # different order — must align by (path, tier), not index
+            {"path": 1, "tier": 1, "cost": 100, "xp": 40},
+            {"path": 3, "tier": 5, "cost": 90000, "xp": 0},
+        ],
+    }
+    mod.overlay_payload(committed, mapped, "55.0")
+
+    def up(path, tier):
+        return next(u for u in committed["upgrades"] if (u["path"], u["tier"]) == (path, tier))
+
+    assert up(3, 5)["cost"] == 90000  # refreshed despite reversed order
+    assert up(1, 1)["xp"] == 40
+    assert up(3, 5)["name"] == "Flying Fortress"  # curated name preserved
+
+
+def test_overlay_no_change_leaves_version_and_source(mod):
+    committed = {"base_cost": 200, "category": "primary", "game_version": "54.0", "source": "w", "tiers": {}}
+    changes = mod.overlay_payload(committed, {"base_cost": 200, "category": "primary", "tiers": {}}, "55.0")
+    assert changes == []
+    assert committed["game_version"] == "54.0"  # untouched when nothing moved
+
+
 def test_pascal_name_mapping(mod):
     assert mod._pascal("Captain Churchill") == "CaptainChurchill"
     assert mod._pascal("Dart Monkey") == "DartMonkey"


### PR DESCRIPTION
Advances the BTD6 data work toward the maintainer's direction: **game data leads; store the game's own structure and names, don't reshape to a wiki schema.**

## 1. Game-native names + descriptions (the enabler)

The data was already game-native in structure; the missing piece was *names*. Now sourced from the game itself:
- **Abilities** use `AbilityModel.displayName` ("Cocktail of Fire", "Naval Tactics") instead of internal model names. This also **disambiguates** same-internal-name abilities — Super Monkey Dark Knight now shows its two distinct abilities (`Legend of the Night` cd 180, `ChampionDarkshift` cd 20), which is exactly what made name-based alignment unsafe before.
- **Upgrades** carry a game-authored **description** via `UpgradeModel.LocsKey` → `textTable["<LocsKey> Description"]` (e.g. *"Guided Magic: Magic shots last longer and seek out the Bloons, even behind cover."*).
- The 11 generated heroes re-emit with real ability names (`FirstAbility` → `Naval Tactics`).

## 2. New design doc: `btd6-gamedata-native-schema.md`

The comprehensive map the maintainer asked for — how the game stores tower data, where every name comes from (`displayName`/`LocsKey`/projectile id), **how the bot consumes it** (the runtime is name-agnostic: `normal_stats` picks the highest-damage projectile, so game-native ids drop in — and even fix stale headlines, e.g. Druid Superstorm `150 → 100` v55), the runtime adaptations a full cutover needs, and **what stays curated** (paragon cost metadata, catalog ids — the bot-matching keys the dump doesn't expose).

## 3. Safe v55 numeric overlay (`--overlay`)

Conservative refresh of only *unambiguously-keyed* values (cost/category, upgrade cost/xp by `(path,tier)`, tier-level `range`/`footprint`). A dry-run review caught — and the overlay now refuses — name-based per-projectile writes that would corrupt data (Druid base dart ← storm's 100 dmg; Dark Knight's wrong ability cooldown). Applied: Desperado mid-path range `28 → 80` (a wiki bug — range below base), mermonkey xp, ace cost.

## Verification

```
python3.10 scripts/parse_gamedata.py --dump <clone> --overlay --dry-run   # review before write
python3.10 scripts/parse_gamedata.py --dump <clone> --audit               # numeric fidelity
python3.10 scripts/check_quality.py --full                                # lint + mypy + 7138 tests ✓
```

Tests cover game-native ability names, upgrade descriptions, the overlay safety property (projectile stats untouched), and `(path,tier)` upgrade keying. No raw dump vendored.

https://claude.ai/code/session_01X2NEkqzPYr4bQLfepBLbV3