### PR TITLE
btd6: map sub-towers (minion stats) + docs correctness pass

### DIFF
--- a/disbot/data/btd6/stats/heroes/etienne.json
+++ b/disbot/data/btd6/stats/heroes/etienne.json
@@ -281,6 +281,23 @@
           "cooldown": 55
         }
       ],
+      "subtowers": [
+        {
+          "name": "UAV",
+          "placeableOnLand": false,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 0,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
+        }
+      ],
       "targetTypeFirst": true,
       "targetTypeLast": false,
       "targetTypeClose": false,
@@ -341,6 +358,23 @@
         {
           "name": "Drone Swarm",
           "cooldown": 55
+        }
+      ],
+      "subtowers": [
+        {
+          "name": "UAV",
+          "placeableOnLand": false,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 0,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
         }
       ],
       "targetTypeFirst": true,
@@ -409,6 +443,23 @@
           "cooldown": 90
         }
       ],
+      "subtowers": [
+        {
+          "name": "UAV",
+          "placeableOnLand": false,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 0,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
+        }
+      ],
       "targetTypeFirst": true,
       "targetTypeLast": false,
       "targetTypeClose": false,
@@ -473,6 +524,23 @@
         {
           "name": "UCAV",
           "cooldown": 90
+        }
+      ],
+      "subtowers": [
+        {
+          "name": "UAV",
+          "placeableOnLand": false,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 0,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
         }
       ],
       "targetTypeFirst": true,
@@ -541,6 +609,23 @@
           "cooldown": 90
         }
       ],
+      "subtowers": [
+        {
+          "name": "UAV",
+          "placeableOnLand": false,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 0,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
+        }
+      ],
       "targetTypeFirst": true,
       "targetTypeLast": false,
       "targetTypeClose": false,
@@ -605,6 +690,23 @@
         {
           "name": "UCAV",
           "cooldown": 75
+        }
+      ],
+      "subtowers": [
+        {
+          "name": "UAV",
+          "placeableOnLand": false,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 0,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
         }
       ],
       "targetTypeFirst": true,
@@ -673,6 +775,23 @@
           "cooldown": 75
         }
       ],
+      "subtowers": [
+        {
+          "name": "UAV",
+          "placeableOnLand": false,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 0,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
+        }
+      ],
       "targetTypeFirst": true,
       "targetTypeLast": false,
       "targetTypeClose": false,
@@ -737,6 +856,23 @@
         {
           "name": "UCAV",
           "cooldown": 75
+        }
+      ],
+      "subtowers": [
+        {
+          "name": "UAV",
+          "placeableOnLand": false,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 0,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
         }
       ],
       "targetTypeFirst": true,
@@ -805,6 +941,23 @@
           "cooldown": 75
         }
       ],
+      "subtowers": [
+        {
+          "name": "UAV",
+          "placeableOnLand": false,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 0,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
+        }
+      ],
       "targetTypeFirst": true,
       "targetTypeLast": false,
       "targetTypeClose": false,
@@ -869,6 +1022,23 @@
         {
           "name": "UCAV",
           "cooldown": 75
+        }
+      ],
+      "subtowers": [
+        {
+          "name": "UAV",
+          "placeableOnLand": false,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 0,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
         }
       ],
       "targetTypeFirst": true,
@@ -937,6 +1107,23 @@
           "cooldown": 75
         }
       ],
+      "subtowers": [
+        {
+          "name": "UAV",
+          "placeableOnLand": false,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 0,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
+        }
+      ],
       "targetTypeFirst": true,
       "targetTypeLast": false,
       "targetTypeClose": false,
@@ -1003,6 +1190,23 @@
           "cooldown": 75
         }
       ],
+      "subtowers": [
+        {
+          "name": "UAV",
+          "placeableOnLand": false,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 0,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
+        }
+      ],
       "targetTypeFirst": true,
       "targetTypeLast": false,
       "targetTypeClose": false,
@@ -1067,6 +1271,23 @@
         {
           "name": "UCAV",
           "cooldown": 75
+        }
+      ],
+      "subtowers": [
+        {
+          "name": "UCAVPerma",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 0,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
         }
       ],
       "targetTypeFirst": true,

--- a/disbot/data/btd6/stats/heroes/ezili.json
+++ b/disbot/data/btd6/stats/heroes/ezili.json
@@ -594,6 +594,23 @@
           "cooldown": 90
         }
       ],
+      "subtowers": [
+        {
+          "name": "SacrificialTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 78,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 6,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
+        }
+      ],
       "targetTypeFirst": true,
       "targetTypeLast": true,
       "targetTypeClose": true,
@@ -688,6 +705,23 @@
           "cooldown": 90
         }
       ],
+      "subtowers": [
+        {
+          "name": "SacrificialTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 78,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 6,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
+        }
+      ],
       "targetTypeFirst": true,
       "targetTypeLast": true,
       "targetTypeClose": true,
@@ -780,6 +814,23 @@
         {
           "name": "Sacrificial Totem",
           "cooldown": 90
+        }
+      ],
+      "subtowers": [
+        {
+          "name": "SacrificialTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 78,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 6,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
         }
       ],
       "targetTypeFirst": true,
@@ -880,6 +931,23 @@
           "cooldown": 60
         }
       ],
+      "subtowers": [
+        {
+          "name": "SacrificialTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 78,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 6,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
+        }
+      ],
       "targetTypeFirst": true,
       "targetTypeLast": true,
       "targetTypeClose": true,
@@ -976,6 +1044,23 @@
         {
           "name": "MOAB Hex",
           "cooldown": 60
+        }
+      ],
+      "subtowers": [
+        {
+          "name": "SacrificialTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 78,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 6,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
         }
       ],
       "targetTypeFirst": true,
@@ -1076,6 +1161,23 @@
           "cooldown": 60
         }
       ],
+      "subtowers": [
+        {
+          "name": "SacrificialTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 78,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 6,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
+        }
+      ],
       "targetTypeFirst": true,
       "targetTypeLast": true,
       "targetTypeClose": true,
@@ -1172,6 +1274,23 @@
         {
           "name": "MOAB Hex",
           "cooldown": 60
+        }
+      ],
+      "subtowers": [
+        {
+          "name": "SacrificialTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 78,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 6,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
         }
       ],
       "targetTypeFirst": true,
@@ -1272,6 +1391,23 @@
           "cooldown": 60
         }
       ],
+      "subtowers": [
+        {
+          "name": "SacrificialTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 78,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 6,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
+        }
+      ],
       "targetTypeFirst": true,
       "targetTypeLast": true,
       "targetTypeClose": true,
@@ -1368,6 +1504,23 @@
         {
           "name": "MOAB Hex",
           "cooldown": 60
+        }
+      ],
+      "subtowers": [
+        {
+          "name": "SacrificialTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 78,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 6,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
         }
       ],
       "targetTypeFirst": true,
@@ -1468,6 +1621,23 @@
           "cooldown": 60
         }
       ],
+      "subtowers": [
+        {
+          "name": "SacrificialTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 78,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 6,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
+        }
+      ],
       "targetTypeFirst": true,
       "targetTypeLast": true,
       "targetTypeClose": true,
@@ -1564,6 +1734,23 @@
         {
           "name": "MOAB Hex",
           "cooldown": 60
+        }
+      ],
+      "subtowers": [
+        {
+          "name": "SacrificialTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 78,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 6,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
         }
       ],
       "targetTypeFirst": true,
@@ -1664,6 +1851,23 @@
           "cooldown": 60
         }
       ],
+      "subtowers": [
+        {
+          "name": "SacrificialTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 78,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 6,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
+        }
+      ],
       "targetTypeFirst": true,
       "targetTypeLast": true,
       "targetTypeClose": true,
@@ -1762,6 +1966,23 @@
           "cooldown": 60
         }
       ],
+      "subtowers": [
+        {
+          "name": "SacrificialTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 78,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 6,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
+        }
+      ],
       "targetTypeFirst": true,
       "targetTypeLast": true,
       "targetTypeClose": true,
@@ -1858,6 +2079,23 @@
         {
           "name": "MOAB Hex",
           "cooldown": 40
+        }
+      ],
+      "subtowers": [
+        {
+          "name": "SacrificialTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 78,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 6,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
         }
       ],
       "targetTypeFirst": true,

--- a/disbot/data/btd6/stats/heroes/obyn_greenfoot.json
+++ b/disbot/data/btd6/stats/heroes/obyn_greenfoot.json
@@ -251,6 +251,35 @@
           "cooldown": 30
         }
       ],
+      "subtowers": [
+        {
+          "name": "NaturesWardTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 32,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [
+            {
+              "name": "SharedAttack",
+              "projectiles": [],
+              "count": 0,
+              "targetTypes": "Depends on targeting option",
+              "range": 32,
+              "attackThroughWalls": false,
+              "framesBeforeRetarget": 0,
+              "sharedGridRange": 0,
+              "filterInvisible": false
+            }
+          ],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
+        }
+      ],
       "targetTypeFirst": true,
       "targetTypeLast": true,
       "targetTypeClose": true,
@@ -343,6 +372,35 @@
           "cooldown": 30
         }
       ],
+      "subtowers": [
+        {
+          "name": "NaturesWardTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 32,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [
+            {
+              "name": "SharedAttack",
+              "projectiles": [],
+              "count": 0,
+              "targetTypes": "Depends on targeting option",
+              "range": 32,
+              "attackThroughWalls": false,
+              "framesBeforeRetarget": 0,
+              "sharedGridRange": 0,
+              "filterInvisible": false
+            }
+          ],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
+        }
+      ],
       "targetTypeFirst": true,
       "targetTypeLast": true,
       "targetTypeClose": true,
@@ -427,6 +485,35 @@
         {
           "name": "Brambles",
           "cooldown": 30
+        }
+      ],
+      "subtowers": [
+        {
+          "name": "NaturesWardTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 32,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [
+            {
+              "name": "SharedAttack",
+              "projectiles": [],
+              "count": 0,
+              "targetTypes": "Depends on targeting option",
+              "range": 32,
+              "attackThroughWalls": false,
+              "framesBeforeRetarget": 0,
+              "sharedGridRange": 0,
+              "filterInvisible": false
+            }
+          ],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
         }
       ],
       "targetTypeFirst": true,
@@ -515,6 +602,35 @@
           "cooldown": 30
         }
       ],
+      "subtowers": [
+        {
+          "name": "NaturesWardTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 32,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [
+            {
+              "name": "SharedAttack",
+              "projectiles": [],
+              "count": 0,
+              "targetTypes": "Depends on targeting option",
+              "range": 32,
+              "attackThroughWalls": false,
+              "framesBeforeRetarget": 0,
+              "sharedGridRange": 0,
+              "filterInvisible": false
+            }
+          ],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
+        }
+      ],
       "targetTypeFirst": true,
       "targetTypeLast": true,
       "targetTypeClose": true,
@@ -601,6 +717,35 @@
           "cooldown": 30
         }
       ],
+      "subtowers": [
+        {
+          "name": "NaturesWardTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 32,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [
+            {
+              "name": "SharedAttack",
+              "projectiles": [],
+              "count": 0,
+              "targetTypes": "Depends on targeting option",
+              "range": 32,
+              "attackThroughWalls": false,
+              "framesBeforeRetarget": 0,
+              "sharedGridRange": 0,
+              "filterInvisible": false
+            }
+          ],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
+        }
+      ],
       "targetTypeFirst": true,
       "targetTypeLast": true,
       "targetTypeClose": true,
@@ -685,6 +830,35 @@
         {
           "name": "Brambles",
           "cooldown": 30
+        }
+      ],
+      "subtowers": [
+        {
+          "name": "NaturesWardTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 32,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [
+            {
+              "name": "SharedAttack",
+              "projectiles": [],
+              "count": 0,
+              "targetTypes": "Depends on targeting option",
+              "range": 32,
+              "attackThroughWalls": false,
+              "framesBeforeRetarget": 0,
+              "sharedGridRange": 0,
+              "filterInvisible": false
+            }
+          ],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
         }
       ],
       "targetTypeFirst": true,
@@ -777,6 +951,35 @@
           "cooldown": 90
         }
       ],
+      "subtowers": [
+        {
+          "name": "NaturesWardTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 32,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [
+            {
+              "name": "SharedAttack",
+              "projectiles": [],
+              "count": 0,
+              "targetTypes": "Depends on targeting option",
+              "range": 32,
+              "attackThroughWalls": false,
+              "framesBeforeRetarget": 0,
+              "sharedGridRange": 0,
+              "filterInvisible": false
+            }
+          ],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
+        }
+      ],
       "targetTypeFirst": true,
       "targetTypeLast": true,
       "targetTypeClose": true,
@@ -865,6 +1068,35 @@
         {
           "name": "Wall of Trees",
           "cooldown": 90
+        }
+      ],
+      "subtowers": [
+        {
+          "name": "NaturesWardTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 32,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [
+            {
+              "name": "SharedAttack",
+              "projectiles": [],
+              "count": 0,
+              "targetTypes": "Depends on targeting option",
+              "range": 32,
+              "attackThroughWalls": false,
+              "framesBeforeRetarget": 0,
+              "sharedGridRange": 0,
+              "filterInvisible": false
+            }
+          ],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
         }
       ],
       "targetTypeFirst": true,
@@ -957,6 +1189,35 @@
           "cooldown": 90
         }
       ],
+      "subtowers": [
+        {
+          "name": "NaturesWardTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 32,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [
+            {
+              "name": "SharedAttack",
+              "projectiles": [],
+              "count": 0,
+              "targetTypes": "Depends on targeting option",
+              "range": 32,
+              "attackThroughWalls": false,
+              "framesBeforeRetarget": 0,
+              "sharedGridRange": 0,
+              "filterInvisible": false
+            }
+          ],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
+        }
+      ],
       "targetTypeFirst": true,
       "targetTypeLast": true,
       "targetTypeClose": true,
@@ -1045,6 +1306,35 @@
         {
           "name": "Wall of Trees",
           "cooldown": 90
+        }
+      ],
+      "subtowers": [
+        {
+          "name": "NaturesWardTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 32,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [
+            {
+              "name": "SharedAttack",
+              "projectiles": [],
+              "count": 0,
+              "targetTypes": "Depends on targeting option",
+              "range": 32,
+              "attackThroughWalls": false,
+              "framesBeforeRetarget": 0,
+              "sharedGridRange": 0,
+              "filterInvisible": false
+            }
+          ],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
         }
       ],
       "targetTypeFirst": true,
@@ -1137,6 +1427,35 @@
           "cooldown": 90
         }
       ],
+      "subtowers": [
+        {
+          "name": "NaturesWardTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 32,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [
+            {
+              "name": "SharedAttack",
+              "projectiles": [],
+              "count": 0,
+              "targetTypes": "Depends on targeting option",
+              "range": 32,
+              "attackThroughWalls": false,
+              "framesBeforeRetarget": 0,
+              "sharedGridRange": 0,
+              "filterInvisible": false
+            }
+          ],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
+        }
+      ],
       "targetTypeFirst": true,
       "targetTypeLast": true,
       "targetTypeClose": true,
@@ -1225,6 +1544,35 @@
         {
           "name": "Wall of Trees",
           "cooldown": 90
+        }
+      ],
+      "subtowers": [
+        {
+          "name": "NaturesWardTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 32,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [
+            {
+              "name": "SharedAttack",
+              "projectiles": [],
+              "count": 0,
+              "targetTypes": "Depends on targeting option",
+              "range": 32,
+              "attackThroughWalls": false,
+              "framesBeforeRetarget": 0,
+              "sharedGridRange": 0,
+              "filterInvisible": false
+            }
+          ],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
         }
       ],
       "targetTypeFirst": true,
@@ -1317,6 +1665,35 @@
           "cooldown": 90
         }
       ],
+      "subtowers": [
+        {
+          "name": "NaturesWardTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 32,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [
+            {
+              "name": "SharedAttack",
+              "projectiles": [],
+              "count": 0,
+              "targetTypes": "Depends on targeting option",
+              "range": 32,
+              "attackThroughWalls": false,
+              "framesBeforeRetarget": 0,
+              "sharedGridRange": 0,
+              "filterInvisible": false
+            }
+          ],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
+        }
+      ],
       "targetTypeFirst": true,
       "targetTypeLast": true,
       "targetTypeClose": true,
@@ -1405,6 +1782,35 @@
         {
           "name": "Wall of Trees",
           "cooldown": 90
+        }
+      ],
+      "subtowers": [
+        {
+          "name": "NaturesWardTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 32,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [
+            {
+              "name": "SharedAttack",
+              "projectiles": [],
+              "count": 0,
+              "targetTypes": "Depends on targeting option",
+              "range": 32,
+              "attackThroughWalls": false,
+              "framesBeforeRetarget": 0,
+              "sharedGridRange": 0,
+              "filterInvisible": false
+            }
+          ],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
         }
       ],
       "targetTypeFirst": true,
@@ -1497,6 +1903,35 @@
           "cooldown": 90
         }
       ],
+      "subtowers": [
+        {
+          "name": "NaturesWardTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 32,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [
+            {
+              "name": "SharedAttack",
+              "projectiles": [],
+              "count": 0,
+              "targetTypes": "Depends on targeting option",
+              "range": 32,
+              "attackThroughWalls": false,
+              "framesBeforeRetarget": 0,
+              "sharedGridRange": 0,
+              "filterInvisible": false
+            }
+          ],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
+        }
+      ],
       "targetTypeFirst": true,
       "targetTypeLast": true,
       "targetTypeClose": true,
@@ -1587,6 +2022,35 @@
           "cooldown": 90
         }
       ],
+      "subtowers": [
+        {
+          "name": "NaturesWardTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 32,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [
+            {
+              "name": "SharedAttack",
+              "projectiles": [],
+              "count": 0,
+              "targetTypes": "Depends on targeting option",
+              "range": 32,
+              "attackThroughWalls": false,
+              "framesBeforeRetarget": 0,
+              "sharedGridRange": 0,
+              "filterInvisible": false
+            }
+          ],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
+        }
+      ],
       "targetTypeFirst": true,
       "targetTypeLast": true,
       "targetTypeClose": true,
@@ -1675,6 +2139,35 @@
         {
           "name": "Wall of Trees",
           "cooldown": 75
+        }
+      ],
+      "subtowers": [
+        {
+          "name": "NaturesWardTotem",
+          "placeableOnLand": true,
+          "placeableOnWater": false,
+          "placeableOnTrack": false,
+          "range": 32,
+          "towerSelectionMenuThemeId": "Default",
+          "footprintRadius": 0,
+          "doesntBlockTowerPlacement": false,
+          "attacks": [
+            {
+              "name": "SharedAttack",
+              "projectiles": [],
+              "count": 0,
+              "targetTypes": "Depends on targeting option",
+              "range": 32,
+              "attackThroughWalls": false,
+              "framesBeforeRetarget": 0,
+              "sharedGridRange": 0,
+              "filterInvisible": false
+            }
+          ],
+          "targetTypeFirst": false,
+          "targetTypeLast": false,
+          "targetTypeClose": false,
+          "targetTypeStrong": false
         }
       ],
       "targetTypeFirst": true,

--- a/docs/btd6-data-pipeline.md
+++ b/docs/btd6-data-pipeline.md
@@ -1,8 +1,14 @@
 # BTD6 data & stats pipeline — working doc / handoff
 
-> **Status:** towers fully done (data → service → UI → AI). Heroes and economy
-> income are the remaining pieces. This is a *working/roadmap* doc, not a binding
-> contract — when it disagrees with the source, the source wins.
+> **This documents the bloonswiki pipeline that produced the *current* committed
+> stats (the v53 reference data).** The active direction is a **game-native
+> cutover** from the BTD Mod Helper dump — bloonswiki is now a cross-check
+> reference. For current status start at **`btd6-gamedata-decode-status.md`**.
+>
+> **Status (of *this* wiki pipeline):** towers done (data → service → UI → AI);
+> heroes/economy income were its remaining pieces. This is a *working/roadmap*
+> doc, not a binding contract — when it disagrees with the source, the source
+> wins.
 >
 > Tracking PR: **#374** (`claude/youthful-wozniak-gsu57`).
 

--- a/docs/btd6-game-file-extraction-plan.md
+++ b/docs/btd6-game-file-extraction-plan.md
@@ -3,15 +3,14 @@
 > **Picking up the work?** Start at **`btd6-gamedata-decode-status.md`** (status,
 > lessons & open items), then this roadmap and `btd6-gamedata-dictionary.md`.
 
-> **Status:** MAPPER BUILT (PR 1) + **FIDELITY AUDIT (PR 1.5, this PR).**
-> `scripts/parse_gamedata.py` maps the dump and now also self-audits
-> (`--audit`) against the committed wiki data. **PR 1.5 reframes the plan** —
-> see "Fidelity audit findings (PR 1.5)" below — because investigating the
-> cutover surfaced that the real blocker is **mapper fidelity**, not the P1/P2
-> the section further down assumed. A blind overlay would corrupt correct data.
-> The revised path is: **PR 1.5 audit foundation → PR 2 safe overlay (CLEAN/
-> DELTA fields only) → PR 3 per-entity gaps + new domains (Bosses/Powers).**
-> This is a *roadmap* doc — when it disagrees with the source, the source wins.
+> **Status (historical roadmap — authoritative status is now
+> `btd6-gamedata-decode-status.md`).** The mapper (`parse_gamedata.py`) maps the
+> dump and self-audits (`--audit`). The plan was later **re-directed by the
+> maintainer to a game-native cutover** (game data leads; store the game's own
+> structure — see `btd6-gamedata-native-schema.md`), with the conservative
+> `--overlay` as an interim safe refresh. Bosses are in `Bloons/` (not a
+> separate domain). This is a *roadmap* doc — when it disagrees with the source
+> or the decode-status doc, those win.
 >
 > **Last verified:** 2026-06-03, in-sandbox, against
 > `Btd6ModHelper/btd6-game-data` commit `a3348a89` (dumped 2026-06-02, v55.0).
@@ -95,8 +94,12 @@ audit flags as systematically divergent stay curated.
   `--tower`/`--hero`/`--all`/`--validate-anchors`/`--dry-run`). Hermetic tests in
   `tests/unit/scripts/test_parse_gamedata.py` (synthetic `TowerModel` fixtures,
   no vendored dump).
-- **`dart_monkey` round-trips exactly** to the committed wiki-sourced file
-  (15 upgrades, 64 crosspath tiers, every projectile value identical).
+- `dart_monkey` maps to the **same shape** (15 upgrades, 64 crosspath tiers).
+  *(The original "every projectile value identical" claim is no longer true and
+  was always approximate — the mapper now produces v55 values, tag bonuses via
+  `damageAddative`, and a different sub-projectile flatten order; per-field
+  fidelity vs the wiki is what `--audit` measures, and it is DELTA/CLEAN, not
+  byte-identical.)*
 - **11 wiki-missing heroes now have per-level stats** (`stats/heroes/*.json`):
   admiral_brickell, benjamin, captain_churchill, corvus, etienne, ezili,
   obyn_greenfoot, pat_fusty, psi, rosalia, silas. Runtime/UI/AI pick them up
@@ -108,30 +111,43 @@ audit flags as systematically divergent stay curated.
 - `areaTypes` entries: `1=water, 2=land, 4=track` → `placeableOn*`.
 - `footprint` is a **top-level** model (not in `behaviors[]`) → `footprintRadius`.
 - Combat damage often lives on a **child** projectile, not the thrown one
-  (bomb → `CreateProjectileOnContactModel` → "Explosion"). The mapper recurses
-  `CreateProjectile*Model` and flattens children as sibling projectiles
-  (depth-capped), matching the wiki's "Projectile" + "Explosion" shape.
+  (bomb → "Explosion"). The mapper flattens children as sibling projectiles
+  (depth-capped). *(Updated since PR 1: it detects a child projectile by its own
+  `ProjectileModel` `$type` under **any** field, on both projectile and weapon
+  behaviors — not just `CreateProjectile*` — and de-dupes, after the under-
+  emission fix. See `btd6-gamedata-decode-status.md`.)*
 - Upgrades: each tower-state file lists only the upgrades reachable from it, so
   the full 15 are the **union across all crosspath files**; cost/xp/path/tier
   come from `Upgrades/<name>.json` (`path`/`tier` 0-indexed → +1).
 - Version stamp = the dump's git **commit message** (`55.0`).
 - Names: model names are `"<Class>_<Display>_"` → strip prefix + trailing `_`.
 
-**Deferred to PR 2 (the tower cutover):** three mapper features are needed
-before replacing the tower files without regression —
-1. **Subtowers / minions** — `subtowers[]` (alchemist Transformed Monkey, wizard
-   Reanimate/Prince of Darkness). Read by `btd6_upgrade_detail_service`; the
-   spawn mechanism is a separate tower model referenced from an attack — not yet
-   mapped.
-2. **Damage zones** — `zones[]` (wizard wall of fire, etc.), also read by the
-   upgrade-detail service.
-3. **Economy-tower attack suppression** — the raw model gives Banana Farm a
+**Mapper features needed before the tower cutover (current status — see
+`btd6-gamedata-decode-status.md` for the authoritative roadmap):**
+1. **Subtowers / minions** — `subtowers[]`. 🟡 **Partially done.** Nested
+   `TowerModel`s spawned via `AbilityCreateTowerModel` / `CreateTowerModel` /
+   `MorphTowerModel` (embedded) are mapped (Phoenix, Sentry, Spectre, totems,
+   UAV). Still missing: `MorphTowerModel` **named-ref** (Alchemist "Transformed
+   Monkey") and `BeastHandlerPetModel` (Beast Handler).
+2. **Damage zones** — `zones[]` (12 model types). 🔴 **Not yet mapped.**
+3. **Buffs** — `buffs[]` (37 support/buff model types). 🔴 **Not yet mapped.**
+4. **Economy-tower attack suppression** — the raw model gives Banana Farm a
    nominal `AttackModel`, so `has_combat_stats` trips true; needs a "no real
-   damage ⇒ not combat" filter so the Pro button/embed stay off.
+   damage ⇒ not combat" filter so the Pro button/embed stay off. 🔴 Not done.
    Also: tower files must carry `paragon_cost`/`paragon_name` (catalog metadata,
    not cleanly in the dump) — preserve like the paragon `cost`/`canonical`.
 
 ### ⚠ Two hard prerequisites the v55 cutover is BLOCKED on (verified PR 2 session)
+
+> **RESOLVED / RE-SCOPED — keep for history, but the claims below are outdated.**
+> **P1 (names) is solved:** abilities carry `displayName`; upgrades resolve name
+> + description via `LocsKey` → `textTable`; subtowers use the nested tower name.
+> The framing "textTable not keyed by the internal model name → must find the
+> link" was right about the symptom but the link (`displayName`/`LocsKey`)
+> exists and the mapper now uses it. **P2 is partially done:** subtowers ✅
+> (common spawn models), zones 🔴 (12 types) + buffs 🔴 (37 types) remain — and
+> the count was 12+37, not "~10". See `btd6-gamedata-decode-status.md` for the
+> authoritative status.
 
 Attempting the hero/paragon refresh surfaced two blockers that make *any*
 wholesale v55 cutover regress trusted, human-facing data unless solved first.

--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -15,25 +15,65 @@ works** (the traps we hit), and what is still un-decoded.
 > - `scripts/parse_gamedata.py --audit` — per-field fidelity vs our committed data (CLEAN / DELTA / SUSPECT).
 > - `scripts/btd6_gamedata_inventory.py` — domain/model-type/text-linkage discovery.
 
-## What this effort is (and isn't)
+## What this effort is
 
 The dump is the game's **complete** exported model, so for our needs (stats,
 names, descriptions, what an upgrade grants) **nothing is missing** — the work
-is decoding *where* each fact lives and *which field* to trust. The plan is a
-**numeric overlay onto the curated wiki files** (refresh audit-trusted numbers
-+ resolve names), **not** a wholesale rebuild (which would lose curated names
-and the wiki's clean structure). See the dictionary's "source ladder".
+is decoding *where* each fact lives and *which field* to trust, then storing it.
 
-## Done this session
+**Direction (set by the maintainer): the game data leads.** We store the game's
+**own structure** and names (`displayName` / `LocsKey` → `textTable` / projectile
+ids), with bloonswiki as a cross-check *reference* only — see
+`btd6-gamedata-native-schema.md`. The end state is a **game-native cutover**
+(adopt the mapper's output as the committed stats). The conservative
+`--overlay` (uniquely-keyed numbers only) is an *interim* safe refresh that
+keeps the curated files current without regressing them until the cutover's
+prerequisites (full subtower/zone/buff mapping) are done. *(An earlier framing
+in this doc — "numeric overlay, not a rebuild" — was superseded by that
+direction.)*
 
-| PR | What |
-|---|---|
-| **#464** (merged) | **Fidelity-audit foundation.** `parse_gamedata.py --audit` maps every tower/hero/paragon in-memory and diffs each numeric/bool leaf vs the committed wiki data, classifying each field CLEAN / DELTA / SUSPECT. Float-tolerant (4 dp), aligns dict-lists by `name` and upgrades by `(path, tier)`. |
-| **#465** (merged) | **Discovery tooling + dictionary + two mapper bug fixes**: `btd6_gamedata_inventory.py`, `docs/btd6-gamedata-dictionary.md`, the `damageAddative` fix, and the spawn-model projectile fix. |
-| **(this PR)** | **Conservative numeric overlay** (`parse_gamedata.py --overlay`, `--dry-run`): refreshes only the *unambiguously-keyed* v55 values onto the curated files — top-level cost/category, upgrade cost/xp by `(path, tier)`, and **tier-level** `range`/`footprintRadius`. Found a real wiki bug (Desperado mid-path range 28, *below* its base 60 — corrected to v55's 80) plus mermonkey xp / ace cost. **Per-projectile/ability stats are deliberately NOT overlaid** (see the naming lesson below). |
+## Completion status (verified)
 
-Two extraction bugs were found and fixed — **both the same failure mode: the
-data was always present; the mapper read the wrong field or the wrong place.**
+Only items confirmed **100% complete** are marked ✅. Anything partial is 🟡 and
+must not be treated as done. Verified against the v55 dump on 2026-06-03.
+
+### ✅ Complete & verified
+
+| Item | Where | Evidence |
+|---|---|---|
+| Fidelity-audit harness | `parse_gamedata.py --audit` | #464; tested; CLEAN/DELTA/SUSPECT per field |
+| Discovery / inventory tool | `btd6_gamedata_inventory.py` | #465; tested |
+| Data-domain dictionary (17 domains *identified*) | `btd6-gamedata-dictionary.md` | #465 |
+| **`damageAddative`** tag-bonus extraction | mapper | #465; `damageModifierFor*` now audit-CLEAN (exact wiki match) |
+| Conservative numeric **overlay engine** (uniquely-keyed only) | `parse_gamedata.py --overlay` | #466; tested. *Engine* complete; scope intentionally limited |
+| Ability names via **`displayName`** | mapper | #466; 87/87 abilities carry it |
+| Upgrade **descriptions** via `LocsKey`→`textTable` (extraction) | mapper | #466; extracts wherever the game localizes one (≈422 player upgrade cards) |
+| Core per-tier numeric extraction: base_cost, category, upgrade cost/xp/path/tier, damage, pierce, rate, range, radius, speed, lifespan, immunities→type | mapper | audit: roster is DELTA/CLEAN, nothing SUSPECT |
+
+### 🟡 Partial — NOT complete
+
+| Item | Done | Missing |
+|---|---|---|
+| **Subtowers** (`subtowers[]`) | 3 spawn models: `AbilityCreateTower`/`CreateTower`/`MorphTower`(embedded) → Phoenix, Sentry, Spectre, totems, UAV | `MorphTowerModel` **named-ref** (Alchemist "Transformed Monkey") + `BeastHandlerPetModel` (Beast Handler) — 2 of ~4 mechanisms |
+| **Projectile flattening completeness** | spawn-model coverage (under-emission 177→111) | 111 attacks still differ in projectile count vs wiki; flattening *style* (naming/grouping) differs |
+| **Numeric overlay applied** | 3 files (Desperado range, mermonkey xp, ace cost), uniquely-keyed only | per-projectile/ability values cannot be safely overlaid (wiki↔dump name mismatch) |
+
+### 🔴 Not started
+
+- **Zones** (`zones[]`) — **0 of 12** zone model types mapped.
+- **Buffs** (`buffs[]`) — **0 of 37** buff/support model types mapped.
+- **Economy-tower attack suppression** (Banana Farm shows a nominal AttackModel).
+- **The towers cutover itself** — blocked on zones + buffs + the subtower tail.
+- **Descriptions consumed by the runtime** — extracted into upgrade data, but
+  not yet wired into grounding / the detail UI.
+- **Bloons / bosses game-native ingestion** (still wiki-sourced).
+- **Powers / Knowledge / Rounds (all modes) / IncomeSets ingestion.**
+- **Paragon overlay / cutover** (combat in a `base` node, not `tiers`/`levels`).
+
+## Two extraction bugs found & fixed this program
+
+**Both the same failure mode: the data was always present; the mapper read the
+wrong field or the wrong place.**
 
 1. **Tag damage bonus** (Juggernaut "+20 vs Lead") read from the wrong field.
    `DamageModifierForTagModel.damageMultiplier` is a neutral `1.0` in all but 2
@@ -95,55 +135,48 @@ data was always present; the mapper read the wrong field or the wrong place.**
   *word* may still appear in description prose; the *label-on-that-object* does
   not.)
 
-## Decoded & trusted now
+## Next increments (toward the cutover)
 
-- **Towers/heroes/paragons**: base cost, category, upgrade cost/xp/path/tier,
-  per-tier/level damage, pierce, rate, range, radius, speed, lifespan,
-  `immuneBloonProperties` → damage type, and **tag damage modifiers** (via
-  `damageAddative`). Ability names via `displayName`.
-- After the fixes the whole roster is **DELTA or CLEAN — nothing SUSPECT**; the
-  DELTAs are explained: genuine v55 changes (the dump is newer than the v53
-  wiki), benign representation differences, or flattening *style*.
+The towers cutover is **gated** on completing the structural map. In order:
 
-## Not yet added / decoded (open items)
+1. **Zones** — map the 12 `*ZoneModel` types (`SlowBloonsZone` slow, `Damage
+   OverTimeZone` damage/interval, shove/windy/necromancer + economy). The zone's
+   own `name` is empty → resolve via the owning upgrade's `LocsKey`.
+2. **Buffs** — map the 37 `*SupportModel`/`*BuffModel` types: a common core
+   (`Range`/`Pierce`/`Visibility`/`Rate`/`Speed`/`Cooldown`/`Damage` support, all
+   sharing `multiplier`/`additive` + `buffLocsName`→name) covers most; tail
+   towers get a name-only node.
+3. **Subtower tail** — `MorphTowerModel` named-ref (Alchemist) + `BeastHandler
+   PetModel`.
+4. **Economy-tower attack suppression**, then the towers **cutover** (adopt
+   `--all`, runtime name-adaptations, update value-pinned tests), gated by
+   `--audit`.
 
-**Mapper / data completeness**
-- **The overlay is applied, but only for uniquely-keyed fields** (cost/category,
-  upgrade cost/xp, tier-level `range`/`footprint`). **Expanding it to
-  per-projectile/ability stats is blocked** on reconciling wiki↔dump names (a
-  `"Projectile"` ↔ `"BaseProjectile"` map, or a signature match on the
-  *un*-changed fields), or restricting to provably-unambiguous tiers (exactly
-  one attack × one projectile). Until then those stats stay curated — the audit
-  shows them mostly CLEAN, so little is lost; the DELTAs are the risky ones.
-- **Paragons not yet overlaid** (their combat lives in a `base` node, not
-  `tiers`/`levels`; metadata is curated). Easy follow-up once the per-projectile
-  story is settled.
-- **Descriptions are unused.** Wiring `textTable` upgrade/ability/hero-level
-  prose into our fixtures + AI grounding is the biggest untapped, authoritative
-  win (would answer "what does Ezili L11 do?" from the game itself).
-- **Buff / zone / subtower *effect* models** (~30 zone + ~25 buff `$type`s,
-  inline in tower models): map headline numeric effects where `--audit`-stable;
-  lean on the description for the rest. `btd6_upgrade_detail_service` already
-  reads `buffs[]`/`zones[]`/`subtowers[]`.
-- **`count`** (projectiles per shot): no single exact dump field
-  (`len(weapons)` and `emission.count` both diverge ~1/3 of tiers); stays
-  curated, never overlaid.
-- **Residual projectile flattening style**: 111 attacks still differ in
-  projectile count vs the wiki and 72 have duplicate names — the wiki
-  names/groups sub-projectiles differently. Data is present; only grouping/names
-  differ. Closing it fully means matching the wiki's naming, low priority.
-- **The 2 `damageMultiplier != 1` cases** roster-wide are not emitted (we only
-  read the additive). Negligible; revisit if a tower needs a multiplicative tag
-  bonus.
+Smaller open notes: `count` has no exact dump field (stays curated); the 2
+roster-wide `damageMultiplier != 1` tag cases aren't emitted (we read the
+additive); `textTable` descriptions are extracted but not yet *consumed* by
+grounding/UI.
 
-**New domains (in the dump, not yet ingested)**
-- **Bloons incl. bosses** from `BloonModel` (`maxHealth`/`speed`/`radius`/
-  `armourMultiplier`/children) — we currently source bloons from the wiki.
-- **Powers** (`Powers/`: Banana Farmer, Cash Drop…), **Knowledge** (Monkey
-  Knowledge), **Rounds for all modes + IncomeSets** (the dump has every mode +
-  income curves; we have only standard wiki rounds).
+## Dump areas NOT yet examined (be honest about coverage)
 
-**Freshness**
+Verified **deeply**: `Towers/` (attacks, projectiles, abilities, subtowers,
+damage modifiers, costs/upgrades) and `Upgrades/` + `textTable.json` linkage.
+
+**Not examined / only counted — do not assume:**
+- **Domains never opened:** `Achievements/`, `Artifacts/`, `BloonOverlays/`,
+  `GeraldoItems/`, `Knowledge/`, `Maps/`, `Mods/`, `Skins/`, `TrophyStoreItems/`.
+- **Only counted / single-sample (structure not mapped):** `Rounds/` (5181
+  files, counted), `IncomeSets/` (7, counted), `Powers/` (1 sampled), `Bloons/`
+  (Bloonarius sampled + the `BloonModel` field list seen via the inventory tool;
+  not all 235 bloons verified, children/immunity decode unverified).
+- **Loose files unread:** `frontierData.json`, `rogueData.json`, `resources.json`.
+  `paragonDegreeData.json` is *referenced* (we derive degrees) but never
+  cross-checked against the dump's constants.
+- **Within `Towers/` (examined domain) still undecoded:** the 12 **zone** + 37
+  **buff** model types (identified, fields not extracted); status-effect /
+  targeting / income behavior models beyond what `_map_tier` reads.
+
+## Freshness
 - Re-pull the dump per patch; re-validate anchors (Dart 200, Super 2500) and
   re-run `--audit`. Use the Steam patch-notes feed (#459) as the "time to
   re-pull" signal.

--- a/docs/btd6-gamedata-dictionary.md
+++ b/docs/btd6-gamedata-dictionary.md
@@ -104,7 +104,7 @@ Loose files: **`textTable.json`** (12,127 keys — every name & description),
 
 ## Open decode items (for the overlay / gaps PRs)
 
-- **Buff / zone effect models** (~30 zone + ~25 buff `$type`s, inline in tower
+- **Buff / zone effect models** (12 zone + 37 buff `$type`s, inline in tower
   models): map the headline numeric effect fields where `--audit`-stable; lean
   on the textTable description for the rest. (`btd6_upgrade_detail_service`
   already reads `buffs[]`/`zones[]`/`subtowers[]`.)

--- a/docs/btd6-gamedata-native-schema.md
+++ b/docs/btd6-gamedata-native-schema.md
@@ -125,14 +125,14 @@ the common cases; 2 mechanisms remain tower-specific.
 | `MorphTowerModel` (**named ref**) | name → other file | **Alchemist** "Transformed Monkey" | ⏳ needs file resolution |
 | `BeastHandlerPetModel` | tower-specific | **Beast Handler** beasts | ⏳ tower-specific |
 
-**Zones** (`*ZoneModel`, ~18 types) — ⏳ **not yet mapped.** Headline ones to
+**Zones** (`*ZoneModel`, 12 types) — ⏳ **not yet mapped.** Headline ones to
 extract: `SlowBloonsZoneModel` (`zoneRadius`, `speedScale`→slow, `filters`),
 `DamageOverTimeZoneModel` (damage, interval), `NecromancerZoneModel`,
 `MoabShoveZoneModel`, `WindyZoneModel`; the cash/discount zones
 (`DiscountZoneModel`, `CollectCashZoneModel`, `CashbackZoneModel`) are economy.
 The zone model's own `name` is empty → resolve via the owning upgrade (`LocsKey`).
 
-**Buffs** (`*SupportModel` / `*BuffModel`, ~40 types) — ⏳ **not yet mapped.** A
+**Buffs** (`*SupportModel` / `*BuffModel`, 37 types) — ⏳ **not yet mapped.** A
 common core covers most: `RangeSupportModel` (10 towers), `PierceSupportModel`
 (8), `VisibilitySupportModel` (8, camo), `RateSupportModel` (7),
 `ProjectileSpeed`/`AbilityCooldown`/`Damage` support — all share

--- a/docs/btd6-gamedata-native-schema.md
+++ b/docs/btd6-gamedata-native-schema.md
@@ -107,12 +107,50 @@ committed files become game-native:
 These are *keys for matching*, not game stats — exactly the "don't fragment what
 the bot can't reassemble" exception.
 
+## Structural completeness — subtowers / zones / buffs (the cutover gate)
+
+The curated files carry `subtowers[]`, `zones[]`, `buffs[]` (read by
+`btd6_upgrade_detail_service`). **The mapper must produce all of these before a
+towers cutover, or it silently regresses them.** Complete map of where each
+lives + status:
+
+**Subtowers** — a nested `TowerModel` (mapped like a tier). 3 spawn models cover
+the common cases; 2 mechanisms remain tower-specific.
+
+| Spawn model | Field | Examples | Status |
+|---|---|---|---|
+| `AbilityCreateTowerModel` | `towerModel` | Wizard Phoenix, Adora Ball of Light | ✅ mapped |
+| `CreateTowerModel` | `tower` | Engineer Sentry, Etienne UAV, hero totems, Super Monkey Spectre/Sun-Avatar | ✅ mapped |
+| `MorphTowerModel` (embedded) | `towerModel` | Druid Masqued Macaque | ✅ mapped |
+| `MorphTowerModel` (**named ref**) | name → other file | **Alchemist** "Transformed Monkey" | ⏳ needs file resolution |
+| `BeastHandlerPetModel` | tower-specific | **Beast Handler** beasts | ⏳ tower-specific |
+
+**Zones** (`*ZoneModel`, ~18 types) — ⏳ **not yet mapped.** Headline ones to
+extract: `SlowBloonsZoneModel` (`zoneRadius`, `speedScale`→slow, `filters`),
+`DamageOverTimeZoneModel` (damage, interval), `NecromancerZoneModel`,
+`MoabShoveZoneModel`, `WindyZoneModel`; the cash/discount zones
+(`DiscountZoneModel`, `CollectCashZoneModel`, `CashbackZoneModel`) are economy.
+The zone model's own `name` is empty → resolve via the owning upgrade (`LocsKey`).
+
+**Buffs** (`*SupportModel` / `*BuffModel`, ~40 types) — ⏳ **not yet mapped.** A
+common core covers most: `RangeSupportModel` (10 towers), `PierceSupportModel`
+(8), `VisibilitySupportModel` (8, camo), `RateSupportModel` (7),
+`ProjectileSpeed`/`AbilityCooldown`/`Damage` support — all share
+`multiplier`/`additive` + **`buffLocsName`** (→ `textTable` for the name). The
+long tail is tower-specific (`ObynBuffModel`, `EziliSupportModel`,
+`MonkeyFanClubModel`, `TradeEmpireBuffModel`, …) — map the common core well,
+emit a name-only node (via `buffLocsName`) for the tail.
+
 ## Cutover plan (phased)
 
 1. **Game-native names + descriptions in the mapper** — ability `displayName`,
-   upgrade `LocsKey` → name/description. ✅ **(this PR)** Generated heroes
-   re-emitted with real ability names.
-2. **Towers cutover** — adopt `parse_gamedata.py --all` output as the committed
+   upgrade `LocsKey` → name/description. ✅ Generated heroes re-emitted with real
+   ability names.
+2. **Subtowers** — common spawn models → minion stats. ✅ **(this PR)** Generated
+   heroes (obyn/etienne/ezili) re-emitted with their totems/UAV.
+3. **Zones + buffs** — map per the table above (+ the alchemist/beast subtower
+   tail). This *completes the structural map* and unblocks the cutover.
+4. **Towers cutover** — adopt `parse_gamedata.py --all` output as the committed
    tower stats (game-native ids/structure/values), do the runtime adaptations
    above, update value-pinned tests. Audit (`--audit`) gates the numbers.
 3. **Heroes + paragons cutover** + wire `textTable` descriptions into grounding

--- a/scripts/parse_gamedata.py
+++ b/scripts/parse_gamedata.py
@@ -435,7 +435,70 @@ def _target_types(model: dict) -> dict:
     }
 
 
-def _map_tier(model: dict) -> dict:
+# Models that spawn a sub-tower / minion, and the field holding its TowerModel:
+# AbilityCreateTower (Phoenix, Adora's Ball of Light) / MorphTower (Druid's
+# Masqued Macaque) use ``towerModel``; CreateTower (Engineer sentries, Etienne's
+# UAV, hero totems) uses ``tower``.
+_SUBTOWER_SPAWN_TYPES = {
+    "AbilityCreateTowerModel",
+    "MorphTowerModel",
+    "CreateTowerModel",
+}
+
+
+def _find_spawn_models(node: Any) -> list[dict]:
+    """Every sub-tower-spawn model reachable from ``node``, WITHOUT descending
+    into the towers they spawn (those nested towers carry their own spawns, which
+    are not this tower's minions).
+    """
+    out: list[dict] = []
+    if isinstance(node, dict):
+        if _short_type(node) in _SUBTOWER_SPAWN_TYPES:
+            out.append(node)
+            for key, value in node.items():
+                if key not in ("towerModel", "tower"):
+                    out.extend(_find_spawn_models(value))
+            return out
+        for value in node.values():
+            out.extend(_find_spawn_models(value))
+    elif isinstance(node, list):
+        for value in node:
+            out.extend(_find_spawn_models(value))
+    return out
+
+
+def _clean_subtower_name(nested: dict) -> str:
+    display = nested.get("displayName")
+    if isinstance(display, str) and display:
+        return display
+    name = str(nested.get("name") or "Minion")
+    # strip a trailing level/index ("MasquedMacaque 10" -> "MasquedMacaque").
+    head, _, tail = name.rpartition(" ")
+    return head if head and tail.isdigit() else name
+
+
+def _subtowers(model: dict) -> list[dict]:
+    """Spawned sub-towers ("minions") as cleaned tier nodes + their lifespan.
+
+    Each nested ``TowerModel`` is mapped like any tier (its attacks/abilities),
+    so questions like "Prince of Darkness minion pierce" resolve. ``_subtower``
+    short-circuits the recursion so a minion's own (rare) spawns don't nest.
+    """
+    out: list[dict] = []
+    for spawn in _find_spawn_models(model):
+        nested = spawn.get("towerModel") or spawn.get("tower")
+        if not isinstance(nested, dict):
+            continue
+        node: dict = {"name": _clean_subtower_name(nested)}
+        node.update(_map_tier(nested, _subtower=True))
+        for src, dst in (("towerLifetime", "lifespan"), ("towerLifetimeFrames", None)):
+            if dst and src in spawn:
+                node[dst] = _num(spawn[src])
+        out.append(node)
+    return out
+
+
+def _map_tier(model: dict, _subtower: bool = False) -> dict:
     """A full tower-state model file → one cleaned tier node."""
     tier: dict = {}
     tier.update(_placement(model))
@@ -457,6 +520,10 @@ def _map_tier(model: dict) -> dict:
     abilities = _behaviors(model, "AbilityModel")
     if abilities:
         tier["abilities"] = [_clean_ability(a, i) for i, a in enumerate(abilities)]
+    if not _subtower:
+        subtowers = _subtowers(model)
+        if subtowers:
+            tier["subtowers"] = subtowers
     tier.update(_target_types(model))
     income = _income(model)
     if income:

--- a/scripts/parse_gamedata.py
+++ b/scripts/parse_gamedata.py
@@ -18,10 +18,14 @@ version: a tower folder holds the base model (``<Name>.json``, tiers ``000``)
 plus one *complete* model file per crosspath state (``<Name>-NNN.json``, all
 64). Each file's ``behaviors[]`` carry ``$type``-tagged models; we walk
 ``AttackModel → weapons[] → projectile → behaviors[DamageModel/Travel…]`` and
-flatten to the same cleaned shape ``parse_bloonswiki`` produces from the wiki's
-copy of the model, so the runtime (``btd6_stats_service`` et al.) reads it
-unchanged. Heroes are one file per level (``<Hero> N.json``); paragons are a
-single flat ``<Name>-Paragon.json`` node.
+emit a cleaned shape the runtime (``btd6_stats_service`` et al.) reads — which
+is *runtime-compatible* with what ``parse_bloonswiki`` produces but **game-
+native**, not identical to it: names come from the game (``displayName`` for
+abilities, ``LocsKey`` → ``textTable`` for upgrade names/descriptions, the game
+``id`` for projectiles), sub-projectiles are grouped the game's way, and
+``subtowers[]`` are produced; ``zones[]`` / ``buffs[]`` are not yet. The runtime
+is largely name-agnostic, so this drops in. Heroes are one file per level
+(``<Hero> N.json``); paragons are a single flat ``<Name>-Paragon.json`` node.
 
 Provenance: every emitted file is stamped ``source: "BTD Mod Helper game data
 export"`` and the dump's ``_last_updated``/commit version. We commit only the

--- a/tests/unit/scripts/test_parse_gamedata.py
+++ b/tests/unit/scripts/test_parse_gamedata.py
@@ -198,6 +198,54 @@ def test_attack_name_strips_class_prefix_and_trailing_underscore(mod):
     assert attack["name"] == "Attack"  # from "AttackModel_Attack_"
 
 
+def test_subtower_mapped_from_spawn_model(mod):
+    # A minion spawned by a CreateTowerModel (inside an ability) is mapped like a
+    # tier — its attacks/projectiles surface so "minion pierce" questions resolve.
+    minion = _tower_model(
+        attacks=[_attack(_projectile(name="Sting", damage=4.0, pierce=3.0))],
+    )
+    minion["name"] = "Hornet"
+    host = _tower_model()
+    host["behaviors"].append(
+        {
+            "$type": _t("AbilityModel"),
+            "name": "AbilityModel_Ability",
+            "behaviors": [
+                {
+                    "$type": _t("CreateTowerModel"),
+                    "tower": minion,
+                    "towerLifetime": 10.0,
+                },
+            ],
+        },
+    )
+    tier = mod._map_tier(host)
+    assert "subtowers" in tier
+    sub = tier["subtowers"][0]
+    assert sub["name"] == "Hornet"
+    assert sub["lifespan"] == 10
+    assert sub["attacks"][0]["projectiles"][0]["damage"] == 4
+
+
+def test_subtower_does_not_recurse_into_nested_spawns(mod):
+    # _find_spawn_models must not descend into a spawned tower's own spawns.
+    inner = _tower_model()
+    inner["name"] = "Inner"
+    outer = _tower_model()
+    outer["name"] = "Outer"
+    outer["behaviors"].append({"$type": _t("CreateTowerModel"), "tower": inner})
+    host = _tower_model()
+    host["behaviors"].append({"$type": _t("CreateTowerModel"), "tower": outer})
+    tier = mod._map_tier(host)
+    assert [s["name"] for s in tier.get("subtowers", [])] == ["Outer"]  # not "Inner"
+
+
+def test_subtower_name_strips_trailing_level(mod):
+    assert mod._clean_subtower_name({"name": "MasquedMacaque 10"}) == "MasquedMacaque"
+    assert mod._clean_subtower_name({"name": "Phoenix"}) == "Phoenix"
+    assert mod._clean_subtower_name({"displayName": "Sun God", "name": "X"}) == "Sun God"
+
+
 def test_tier_placement_target_and_footprint(mod):
     tier = mod._map_tier(_tower_model(area=(2,)))
     assert tier["placeableOnLand"] is True


### PR DESCRIPTION
## 1. Map sub-towers game-natively

The mapper produced no `subtowers`/`zones`/`buffs` while the curated files (and `btd6_upgrade_detail_service`) carry them — a cutover would silently regress that data. This closes the subtower half: nested `TowerModel`s spawned via `AbilityCreateTowerModel`/`CreateTowerModel`/`MorphTowerModel` (embedded) → Wizard Phoenix, Engineer Sentry, Super Monkey Spectre/Sun-Avatar, Druid Masqued Macaque, hero minions (Adora Ball of Light, Etienne UAV, Obyn/Ezili totems). Tail still open: Alchemist named-`MorphTower` ref + `BeastHandlerPetModel`.

## 2. Docs correctness pass (remove stale assumptions; honest roadmap)

Audited every BTD6-data doc + the mapper docstring against the verified v55 state:
- **`btd6-gamedata-decode-status.md`** — replaced the superseded "numeric overlay, *not* a rebuild" framing with the maintainer's **game-native-leads** direction; added a precise **completion-status** section (only 100%-verified items marked ✅; subtowers / projectile-completeness / overlay-applied flagged 🟡 PARTIAL; zones / buffs / cutover / descriptions-wiring / new-domains 🔴 not-started); added a **"dump areas NOT yet examined"** section.
- Corrected zone/buff counts everywhere to the **verified 12 zone / 37 buff** model types (earlier "~18/~30/~25/~40" counted non-player folders).
- **`btd6-game-file-extraction-plan.md`** — fixed "dart_monkey round-trips exactly", the "recurses CreateProjectile*Model" description, the "subtowers not yet mapped" deferral, and bannered the old P1/P2 "hard prerequisites" as RESOLVED/RE-SCOPED.
- mapper docstring + `btd6-data-pipeline.md` — clarified output is game-native (not "identical to the wiki shape"); the wiki pipeline is now the v53 reference.

## Verification

```
python3.10 scripts/check_quality.py --full   # lint + mypy + 7141 tests ✓
```
No code logic changed in the docs pass. Subtower tests cover mapping from a spawn model, non-recursion into nested spawns, and name cleanup.

https://claude.ai/code/session_01X2NEkqzPYr4bQLfepBLbV3