### PR TITLE
BTD6 AI answer faithfulness guard + deterministic enumeration

### DIFF
--- a/disbot/cogs/ai_cog.py
+++ b/disbot/cogs/ai_cog.py
@@ -323,10 +323,11 @@ class AICog(commands.Cog):
         else:
             interaction_router.register(AI_ROUTER_PREFIX, handle_ai_interaction)
 
-        # Register YouTube embed renderers. Idempotent — register() replaces
+        # Register response renderers. Idempotent — register() replaces
         # silently so repeated cog_load() is safe. VIDEO_QA is plain-text in M1.
         from core.runtime.ai import response_renderer_registry
         from views import youtube_renderers
+        from views.btd6 import answer_renderer as btd6_answer_renderer
 
         response_renderer_registry.register(
             AITask.VIDEO_DESCRIBE,
@@ -335,6 +336,12 @@ class AICog(commands.Cog):
         response_renderer_registry.register(
             AITask.VIDEO_COMPARE,
             youtube_renderers.render_compare,
+        )
+        # BTD6 answers render a verified-data embed when the reply resolved
+        # grounded facts; conversational replies fall through to plain text.
+        response_renderer_registry.register(
+            AITask.BTD6_ANSWER,
+            btd6_answer_renderer.render_btd6_answer,
         )
 
     async def cog_unload(self) -> None:

--- a/disbot/core/runtime/ai/natural_language_stage.py
+++ b/disbot/core/runtime/ai/natural_language_stage.py
@@ -837,9 +837,17 @@ async def _gather_feature_facts(req: FeatureFactRequest) -> FeatureFactsResult:
     """
     if req.task is AITask.BTD6_ANSWER:
         from services import btd6_context_service
+        from utils.btd6.answer_embed import BTD6RenderContext
 
         ctx = await btd6_context_service.build(req.text)
-        return FeatureFactsResult(facts=tuple(ctx.facts))
+        facts = tuple(ctx.facts)
+        return FeatureFactsResult(
+            facts=facts,
+            render_context=BTD6RenderContext(
+                facts=facts,
+                game_version=_btd6_game_version(),
+            ),
+        )
     if req.task in _VIDEO_TASKS:
         from services import youtube_context_service
 

--- a/disbot/core/runtime/ai/natural_language_stage.py
+++ b/disbot/core/runtime/ai/natural_language_stage.py
@@ -47,7 +47,11 @@ from services import (
 from services.ai_natural_language_policy import MessageContext
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from core.runtime.ai.contracts import AIResponse
+    from core.runtime.ai.providers.base import ToolHandler
+    from services import btd6_grounding_service
 
 _VIDEO_TASKS = frozenset({AITask.VIDEO_DESCRIBE, AITask.VIDEO_COMPARE, AITask.VIDEO_QA})
 
@@ -467,10 +471,14 @@ class AINaturalLanguageStage:
                 scope=_derive_scope(message),
             )
 
+            # BTD6 faithfulness ledger: approved BTD6 tool results are
+            # captured here so the post-generation verifier can ground the
+            # reply against them (alongside the auto-grounding facts).
+            ledger: list[str] = []
             # Show "Bot is typing…" while the provider call runs so a
             # multi-second reply does not look like a dropped message.
             async with _maybe_typing(message.channel):
-                response = await _invoke_gateway(stack, built, ctx)
+                response = await _invoke_gateway(stack, built, ctx, ledger=ledger)
         except Exception:
             logger.exception(
                 "ai_natural_language_stage: feature pipeline raised "
@@ -500,10 +508,20 @@ class AINaturalLanguageStage:
         if not reply_text:
             # Differentiate "provider degraded" (gateway/provider failure)
             # from "model returned empty text" (genuine skip) so operators
-            # can tell them apart in the audit table.
+            # can tell them apart in the audit table. A *healthy* empty reply
+            # to an in-domain BTD6 question is a no-data case: serve the
+            # deterministic, version-stamped refusal rather than silence.
+            # ``GROUNDING_FAILED`` is reserved for healthy paths — a provider
+            # outage stays ``PROVIDER_UNAVAILABLE``.
+            sent_refusal = False
             if response.degraded:
                 audit_decision = "degraded"
                 audit_reason = PolicyDenialReason.PROVIDER_UNAVAILABLE
+            elif routed.task is AITask.BTD6_ANSWER:
+                await _send_btd6_refusal(message)
+                sent_refusal = True
+                audit_decision = "denied"
+                audit_reason = PolicyDenialReason.GROUNDING_FAILED
             else:
                 audit_decision = "skipped"
                 audit_reason = PolicyDenialReason.NO_ROUTE_MATCHED
@@ -522,6 +540,9 @@ class AINaturalLanguageStage:
                 provider=response.provider or None,
                 model=response.model or None,
             )
+            if sent_refusal:
+                ctx.metadata["handled_by"] = STAGE_NAME
+                return StageResult(short_circuit=True)
             return StageResult()
 
         # Outbound redaction: scrub Discord snowflakes and other
@@ -532,6 +553,95 @@ class AINaturalLanguageStage:
         from core.runtime.ai.redaction import redact_text
 
         reply_text = redact_text(reply_text).value
+
+        # ---- BTD6 faithfulness guard ----------------------------------------
+        # A BTD6 answer (or a BTD6-themed general reply that names an entity)
+        # must not state names/numbers absent from the grounded payload
+        # (auto-grounding facts ∪ approved BTD6 tool results in ``ledger``).
+        # Reject + regenerate once with an explicit do-not-state constraint,
+        # then fall to the deterministic, version-stamped refusal. Numbers are
+        # only grounded on the BTD6 path; the general path runs the name guard
+        # only when the turn is BTD6-themed or names a distinctive multi-word
+        # entity (so "Benjamin Franklin" in ordinary chat is never refused).
+        from services import btd6_grounding_service
+
+        if routed.task is AITask.BTD6_ANSWER or (
+            routed.task is AITask.GENERAL_NL_ANSWER
+            and btd6_grounding_service.general_path_should_verify(raw_text, reply_text)
+        ):
+            verdict = btd6_grounding_service.validate_btd6_reply(
+                reply_text,
+                facts=tuple(feature.facts),
+                tool_results=tuple(ledger),
+                task=routed.task,
+            )
+            if not verdict.grounded:
+                async with _maybe_typing(message.channel):
+                    response = await _invoke_gateway(
+                        stack,
+                        built,
+                        ctx,
+                        ledger=ledger,
+                        grounding_constraint=_build_grounding_constraint(verdict),
+                    )
+                retry_text = redact_text((response.text or "").strip()).value
+                retry_verdict = (
+                    btd6_grounding_service.validate_btd6_reply(
+                        retry_text,
+                        facts=tuple(feature.facts),
+                        tool_results=tuple(ledger),
+                        task=routed.task,
+                    )
+                    if retry_text
+                    else None
+                )
+                if retry_text and retry_verdict is not None and retry_verdict.grounded:
+                    logger.info(
+                        "btd6_faithfulness: retry_rescued task=%s route=%s",
+                        routed.task.value,
+                        routed.route,
+                    )
+                    reply_text = retry_text
+                else:
+                    # Floor: deterministic refusal. A degraded retry is a
+                    # provider outage, NOT a grounding failure — keep the
+                    # audit honest so operators can tell them apart.
+                    if response.degraded:
+                        floor_decision = "degraded"
+                        floor_reason = PolicyDenialReason.PROVIDER_UNAVAILABLE
+                    else:
+                        floor_decision = "denied"
+                        floor_reason = PolicyDenialReason.GROUNDING_FAILED
+                    logger.warning(
+                        "btd6_faithfulness: blocked task=%s route=%s guard=%s "
+                        "names=%s numbers=%s retry_attempted=True "
+                        "retry_rescued=False degraded=%s",
+                        routed.task.value,
+                        routed.route,
+                        ",".join(verdict.notes),
+                        list(verdict.offending_names),
+                        list(verdict.offending_numbers),
+                        response.degraded,
+                    )
+                    await _send_btd6_refusal(message)
+                    await ai_decision_audit_service.record(
+                        guild_id=guild_id,
+                        channel_id=channel_id,
+                        category_id=category_id,
+                        user_id=user_id,
+                        message_id=message.id,
+                        task=routed.task.value,
+                        route=routed.route,
+                        decision=floor_decision,
+                        reason_code=floor_reason,
+                        policy_snapshot_hash=decision.policy_snapshot_hash,
+                        instruction_profile_ids=list(stack.instruction_profile_ids)
+                        or None,
+                        provider=response.provider or None,
+                        model=response.model or None,
+                    )
+                    ctx.metadata["handled_by"] = STAGE_NAME
+                    return StageResult(short_circuit=True)
 
         from core.runtime.ai import response_renderer_registry
 
@@ -806,10 +916,105 @@ def _derive_scope(message: discord.Message) -> AIScope:
     return AIScope.USER
 
 
+def _btd6_game_version() -> str:
+    """The game version the bot actually serves (e.g. "54.0"), for the stamp."""
+    try:
+        from services import btd6_data_service
+
+        return btd6_data_service.get_dataset().game_version or "the current"
+    except Exception:
+        return "the current"
+
+
+def _btd6_no_data_refusal() -> str:
+    """Deterministic, version-stamped BTD6 refusal — never model prose.
+
+    The single source for the floor string so every grounding refusal stamps
+    the same version. Never raises.
+    """
+    return (
+        "I don't have verified BTD6 data to answer that for the current game "
+        f"version ({_btd6_game_version()}). I won't state names or numbers I "
+        "can't ground in my data — try asking about a specific tower, hero, or "
+        "paragon."
+    )
+
+
+def _build_grounding_constraint(verdict: btd6_grounding_service.GroundingResult) -> str:
+    """A do-not-state constraint appended to the system prompt on the retry."""
+    bits: list[str] = []
+    if verdict.offending_names:
+        bits.append("names not in the data: " + ", ".join(verdict.offending_names))
+    if verdict.offending_numbers:
+        bits.append("numbers not in the data: " + ", ".join(verdict.offending_numbers))
+    detail = "; ".join(bits) if bits else "unsupported BTD6 claims"
+    return (
+        "GROUNDING CORRECTION: your previous reply contained "
+        f"{detail}. Do NOT state these. Use only BTD6 names and numbers present "
+        "in the provided data and tool results. If the data does not support an "
+        "answer, say you don't have that information."
+    )
+
+
+async def _send_btd6_refusal(message: discord.Message) -> None:
+    """Send the deterministic BTD6 refusal as a reply to ``message``."""
+    try:
+        await message.channel.send(
+            _btd6_no_data_refusal(),
+            allowed_mentions=discord.AllowedMentions.none(),
+            reference=message.to_reference(fail_if_not_exists=False),
+        )
+    except discord.HTTPException:
+        logger.warning(
+            "btd6_faithfulness: refusal send failed for message=%s",
+            getattr(message, "id", None),
+            exc_info=True,
+        )
+
+
+def _wrap_handlers_for_ledger(
+    handlers: Mapping[str, ToolHandler],
+    allowlist: frozenset[str],
+    ledger: list[str],
+) -> dict[str, ToolHandler]:
+    """Wrap approved BTD6 tool handlers so their results feed the ledger.
+
+    Only handlers whose name is in ``allowlist`` are wrapped; every other
+    handler is returned untouched. The captured string is the redacted,
+    JSON-encoded result — the same shape the gateway feeds back into the model
+    context — so the faithfulness verifier's trusted haystack contains exactly
+    the deterministic BTD6 facts the model saw, and never a server member count
+    or timestamp from an unrelated tool.
+    """
+    import json
+
+    from core.runtime.ai.redaction import redact_text
+
+    def _capture(handler: ToolHandler) -> ToolHandler:
+        async def wrapped(arguments: dict[str, object]) -> object:
+            result = await handler(arguments)
+            try:
+                encoded = json.dumps(result, default=str)
+            except (TypeError, ValueError):
+                encoded = str(result)
+            ledger.append(redact_text(encoded).value)
+            return result
+
+        return wrapped
+
+    return {
+        name: (_capture(handler) if name in allowlist else handler)
+        for name, handler in handlers.items()
+    }
+
+
 async def _invoke_gateway(
     stack: ai_instruction_service.InstructionStack,
     built: ai_context_service.BuiltContext,
     _ctx: MessagePipelineContext,
+    *,
+    ledger: list[str] | None = None,
+    grounding_constraint: str | None = None,
 ) -> AIResponse:
     """Run the AI gateway and return the full :class:`AIResponse`.
 
@@ -824,12 +1029,15 @@ async def _invoke_gateway(
     caller's scope permits; the gateway decides whether to actually offer
     them to the model. When off, ``tools`` is empty and ``tool_handlers``
     is ``None`` — byte-for-byte identical to the no-tools path.
-    """
-    from collections.abc import Mapping
 
+    ``ledger`` (BTD6 faithfulness): when supplied, approved BTD6 tool results
+    are appended to it (see :func:`_wrap_handlers_for_ledger`) so the caller
+    can ground the model's reply against them. ``grounding_constraint`` is
+    appended to the system prompt on the regenerate-once retry to tell the
+    model which names/numbers it must not restate.
+    """
     from core.runtime.ai.contracts import AIRequest, AIResponseMode, AIToolSpec
     from core.runtime.ai.feature_flags import ai_tools_enabled
-    from core.runtime.ai.providers.base import ToolHandler
     from services import ai_gateway, ai_tools
 
     ctx = built.request_context
@@ -849,10 +1057,20 @@ async def _invoke_gateway(
         )
         specs = registry.specs
         handlers = registry.handlers
+        if ledger is not None:
+            handlers = _wrap_handlers_for_ledger(
+                handlers,
+                ai_tools.BTD6_GROUNDING_TOOL_NAMES,
+                ledger,
+            )
+
+    system_prompt = stack.render_system_prompt()
+    if grounding_constraint:
+        system_prompt = f"{system_prompt}\n\n{grounding_constraint}"
 
     request = AIRequest(
         context=ctx,
-        system_prompt=stack.render_system_prompt(),
+        system_prompt=system_prompt,
         payload={"text": stack.render_payload_text()},
         mode=AIResponseMode.TEXT,
         tools=specs,

--- a/disbot/services/ai_task_router.py
+++ b/disbot/services/ai_task_router.py
@@ -17,6 +17,7 @@ import threading
 from dataclasses import dataclass
 
 from core.runtime.ai.contracts import AITask
+from utils.btd6.keywords import BTD6_CONTEXT_KEYWORDS
 
 _YOUTUBE_URL_RE = re.compile(
     r"(?:https?://)?(?:www\.)?(?:youtube\.com/(?:watch\?v=|shorts/)|youtu\.be/)([A-Za-z0-9_-]{11})",
@@ -68,48 +69,11 @@ def _has_question_intent(text: str) -> bool:
 # over-route. Those questions rely on the model's ``btd6_lookup`` tool call
 # (reliable on Claude after AI PR1); a curated distinctive-name pass is a
 # follow-up.
-_BTD6_KEYWORDS = (
-    "btd6",
-    "bloons",
-    "bloon",
-    "moab",
-    "ddt",
-    "bfb",
-    "zomg",
-    "tower",
-    "hero",
-    "monkey",
-    "chimps",
-    "round ",
-    "freeplay",
-    "deflation",
-    "apopalypse",
-    "impoppable",
-    "half cash",
-    "primary only",
-    "military only",
-    "magic only",
-    "support only",
-    "boss bloon",
-    "boss event",
-    "current boss",
-    "current race",
-    "current event",
-    "what boss",
-    "what race",
-    "what odyssey",
-    "active boss",
-    "active race",
-    "ninja kiwi",
-    "ninjakiwi",
-    "odyssey",
-    "contested territory",
-    "race ",
-    "banned hero",
-    "banned tower",
-    "obyn",
-    "desperado",
-)
+#
+# The curated tuple itself now lives in ``utils.btd6.keywords`` so the
+# natural-language answer guard reads the exact same list (no drift). Imported
+# back here under the original name; values are identical.
+_BTD6_KEYWORDS = BTD6_CONTEXT_KEYWORDS
 
 
 # ---------------------------------------------------------------------------

--- a/disbot/services/ai_tools.py
+++ b/disbot/services/ai_tools.py
@@ -1146,6 +1146,26 @@ class ToolRegistry:
     handlers: Mapping[str, ToolHandler]
 
 
+# Tools whose results are BTD6 *facts* and may therefore ground a BTD6 answer.
+# The natural-language stage captures ONLY these tools' outputs into the
+# faithfulness ledger — server/user/config tools (member counts, timestamps,
+# IDs) must never whitelist a hallucinated BTD6 name or number. Keep in sync
+# with the ``btd6_*`` specs above; ``tests/unit/services/test_ai_tools.py``
+# pins this set ⊆ the registered ``btd6_*`` tool names so it cannot drift.
+BTD6_GROUNDING_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "btd6_lookup",
+        "btd6_capability_lookup",
+        "btd6_superlative_lookup",
+        "btd6_difficulty_cost",
+        "btd6_paragon_calculate",
+        "btd6_paragon_requirements",
+        "btd6_paragon_stats_at_degree",
+        "btd6_ct_team_status",
+    },
+)
+
+
 def build_registry(
     *,
     scope: AIScope,
@@ -1216,4 +1236,4 @@ def build_registry(
     return ToolRegistry(specs=tuple(specs), handlers=handlers)
 
 
-__all__ = ["ToolRegistry", "build_registry"]
+__all__ = ["BTD6_GROUNDING_TOOL_NAMES", "ToolRegistry", "build_registry"]

--- a/disbot/services/ai_tools.py
+++ b/disbot/services/ai_tools.py
@@ -442,6 +442,56 @@ async def _btd6_lookup(arguments: dict[str, Any]) -> dict[str, Any]:
     return {"found": bool(facts), "facts": facts, "source": ctx.source_summary}
 
 
+# --- btd6_list_roster --------------------------------------------------
+
+_BTD6_LIST_ROSTER_SPEC = AIToolSpec(
+    name="btd6_list_roster",
+    description=(
+        "List the COMPLETE verified roster of a BTD6 entity kind — every hero, "
+        "tower, or paragon by name, with the exact count. Use for 'list all "
+        "heroes', 'which heroes are in the game', 'how many towers are there', "
+        "'name every paragon'. Returns the full canonical list so you never "
+        "guess a count or miss an entry — state the names from this list "
+        "verbatim. ``kind`` must be one of: heroes, towers, paragons."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "kind": {
+                "type": "string",
+                "enum": ["heroes", "towers", "paragons"],
+                "description": "Which roster to list.",
+            },
+        },
+        "required": ["kind"],
+        "additionalProperties": False,
+    },
+    min_scope=AIScope.USER,
+)
+
+
+async def _btd6_list_roster(arguments: dict[str, Any]) -> dict[str, Any]:
+    kind = str(arguments.get("kind") or "").strip().lower()
+    # Lazy import: keep the BTD6 data layer off the import path until used.
+    from services import btd6_data_service
+
+    if kind == "heroes":
+        names = [hero.canonical for hero in btd6_data_service.get_dataset().heroes]
+    elif kind == "towers":
+        names = [tower.canonical for tower in btd6_data_service.get_dataset().towers]
+    elif kind == "paragons":
+        from utils.btd6.paragon_math import PARAGONS
+
+        names = [paragon.name for paragon in PARAGONS]
+    else:
+        return {
+            "found": False,
+            "kind": kind,
+            "note": "kind must be one of: heroes, towers, paragons",
+        }
+    return {"found": True, "kind": kind, "count": len(names), "names": names}
+
+
 # --- btd6_capability_lookup --------------------------------------------
 
 _BTD6_CAPABILITY_SPEC = AIToolSpec(
@@ -1155,6 +1205,7 @@ class ToolRegistry:
 BTD6_GROUNDING_TOOL_NAMES: frozenset[str] = frozenset(
     {
         "btd6_lookup",
+        "btd6_list_roster",
         "btd6_capability_lookup",
         "btd6_superlative_lookup",
         "btd6_difficulty_cost",
@@ -1196,6 +1247,7 @@ def build_registry(
         (_USER_STANDING_SPEC, _make_user_standing(guild_id, actor_id, member)),
         (_SERVER_TIME_SPEC, _server_time),
         (_BTD6_LOOKUP_SPEC, _btd6_lookup),
+        (_BTD6_LIST_ROSTER_SPEC, _btd6_list_roster),
         (_BTD6_CAPABILITY_SPEC, _btd6_capability_lookup),
         (_BTD6_SUPERLATIVE_SPEC, _btd6_superlative_lookup),
         (_BTD6_DIFFICULTY_COST_SPEC, _btd6_difficulty_cost),

--- a/disbot/services/btd6_grounding_service.py
+++ b/disbot/services/btd6_grounding_service.py
@@ -15,12 +15,16 @@ output paths cannot fabricate stats by going around the validator.
 from __future__ import annotations
 
 import logging
+import threading
 from dataclasses import dataclass
 from typing import Any
 
-from core.runtime.ai.contracts import PolicyDenialReason
+from core.runtime.ai.contracts import AITask, PolicyDenialReason
 from core.runtime.ai.safety import claims_are_grounded
 from services import btd6_knowledge_api
+from utils.btd6 import name_guard
+from utils.btd6.keywords import has_btd6_context
+from utils.btd6.paragon_math import PARAGONS
 
 logger = logging.getLogger("bot.services.btd6_grounding")
 
@@ -31,6 +35,11 @@ class GroundingResult:
     reason_code: str  # 'none' or a PolicyDenialReason value
     used_fact_keys: tuple[str, ...]
     notes: tuple[str, ...] = ()
+    # Set by :func:`validate_btd6_reply` when a reply states BTD6 names or
+    # numbers absent from the grounded payload — surfaced to the regenerate
+    # constraint and the structured block-reply log.
+    offending_names: tuple[str, ...] = ()
+    offending_numbers: tuple[str, ...] = ()
 
 
 async def validate_answer(
@@ -141,4 +150,197 @@ async def validate_strategy_field(
     )
 
 
-__all__ = ["GroundingResult", "validate_answer", "validate_strategy_field"]
+# ---------------------------------------------------------------------------
+# Answer-path faithfulness verifier (the natural-language stage's backstop)
+# ---------------------------------------------------------------------------
+#
+# Realises the consumer this module's docstring already names — "the
+# natural-language stage's answer renderer (validates AI output before it
+# reaches the user)". ``validate_answer`` above is the legacy numeric-only
+# (and currently unwired) entry; ``validate_btd6_reply`` is the live one.
+
+_index_lock = threading.Lock()
+_NAME_INDEX: name_guard.NameMatchers | None = None
+_NAME_INDEX_KEY: tuple[str, str, int] | None = None
+
+
+def _name_index() -> name_guard.NameMatchers:
+    """Memoized BTD6 proper-name matchers, rebuilt when the dataset reloads.
+
+    Sourced entirely from :func:`btd6_data_service.get_dataset` (entities +
+    ``upgrade_paths``) plus :data:`paragon_math.PARAGONS`, so the index has no
+    coupling to the separate ``btd6_stats_service`` caches. Keyed on the
+    dataset's ``(data_version, game_version, id())`` so a ``reset_cache()``
+    (new object) forces a rebuild even when the version strings are unchanged.
+
+    Single-word tokens are restricted to distinctive hero names + aliases
+    (mirroring the router's discipline); generic single words — bloon colours
+    ("Red"/"Blue"), single-word tower names — are indexed only as multi-word
+    phrases or not at all, to avoid false positives on ordinary English.
+    """
+    global _NAME_INDEX, _NAME_INDEX_KEY
+    from services import btd6_data_service
+
+    try:
+        dataset = btd6_data_service.get_dataset()
+    except Exception:
+        logger.warning(
+            "btd6_grounding: dataset unavailable; using empty name index",
+            exc_info=True,
+        )
+        return name_guard.NameMatchers(multi=frozenset(), single=frozenset())
+
+    key = (dataset.data_version, dataset.game_version, id(dataset))
+    if _NAME_INDEX is not None and key == _NAME_INDEX_KEY:
+        return _NAME_INDEX
+    with _index_lock:
+        if _NAME_INDEX is not None and key == _NAME_INDEX_KEY:
+            return _NAME_INDEX
+
+        canonicals: set[str] = set()
+        aliases: set[str] = set()
+
+        # Heroes — distinctive enough for whole-word single-token matching.
+        for hero in dataset.heroes:
+            canonicals.add(hero.canonical)
+            aliases.update(hero.aliases)
+
+        # Other categories — only multi-word names (substring-safe). Single
+        # words here are generic (bloon colours, "Druid") and would
+        # false-positive on ordinary chat, so they are skipped.
+        for entry in (
+            *dataset.towers,
+            *dataset.maps,
+            *dataset.modes,
+            *dataset.bloons,
+            *dataset.ct_relics,
+        ):
+            if " " in entry.canonical:
+                canonicals.add(entry.canonical)
+            for alias in entry.aliases:
+                if " " in alias:
+                    aliases.add(alias)
+
+        # All 13 paragon proper names (every one is multi-word + distinctive).
+        for paragon in PARAGONS:
+            canonicals.add(paragon.name)
+
+        # Upgrade names live in the dataset (``upgrade_paths``); index the
+        # multi-word ones ("Sharp Shots", "Glaive Lord") — single-word upgrade
+        # names ("Juggernaut", "Crossbow") are ordinary words and skipped.
+        for tower in dataset.towers:
+            for path_upgrades in tower.upgrade_paths.values():
+                for upgrade in path_upgrades:
+                    if " " in upgrade:
+                        canonicals.add(upgrade)
+
+        index = name_guard.build_matchers(canonicals, aliases)
+        _NAME_INDEX = index
+        _NAME_INDEX_KEY = key
+        return index
+
+
+def _reset_for_tests() -> None:
+    """Clear the memoized name index.
+
+    Tests that swap BTD6 fixtures call this alongside
+    ``btd6_data_service.reset_cache()`` so a stale index cannot leak across
+    cases. (The index does not read ``btd6_stats_service``, so its cache is
+    irrelevant here.)
+    """
+    global _NAME_INDEX, _NAME_INDEX_KEY
+    with _index_lock:
+        _NAME_INDEX = None
+        _NAME_INDEX_KEY = None
+
+
+def general_path_should_verify(prompt: str, answer: str) -> bool:
+    """True when a ``GENERAL_NL_ANSWER`` reply should run the BTD6 name guard.
+
+    Fires when the turn is BTD6-themed (a curated context keyword in the prompt
+    or answer) OR the answer contains a distinctive **multi-word** BTD6 proper
+    name (every paragon, most towers/upgrades), which never occurs in ordinary
+    chat. A single common hero name on its own (e.g. "Benjamin") does NOT
+    trigger — that is the false-positive guard for ordinary conversation.
+    """
+    try:
+        if has_btd6_context(f"{prompt} {answer}"):
+            return True
+        return bool(name_guard.multiword_names_present(answer, _name_index()))
+    except Exception:
+        logger.warning(
+            "btd6_grounding: general_path_should_verify raised; skipping guard",
+            exc_info=True,
+        )
+        return False
+
+
+def validate_btd6_reply(
+    answer_text: str,
+    *,
+    facts: tuple[str, ...] = (),
+    tool_results: tuple[str, ...] = (),
+    task: AITask | None = None,
+) -> GroundingResult:
+    """Verify a model-authored reply against the grounded payload.
+
+    Trusted haystack = ``facts ∪ tool_results`` (deterministic auto-grounding
+    facts + approved BTD6 tool outputs). A reply is grounded when every indexed
+    BTD6 name it states is present in the haystack and — for
+    :attr:`AITask.BTD6_ANSWER` only — every numeric token is present too
+    (numbers are never grounded on the general path, where ordinary numerals
+    are legitimate). **Never raises**: any internal error returns a
+    not-grounded result so the caller fails closed to the refusal floor.
+    """
+    try:
+        matchers = _name_index()
+        haystack = " ".join((*facts, *tool_results))
+
+        allowed_names = name_guard.names_present(haystack, matchers)
+        answer_names = name_guard.names_present(answer_text, matchers)
+        offending_names = tuple(sorted(answer_names - allowed_names))
+
+        offending_numbers: tuple[str, ...] = ()
+        if task is AITask.BTD6_ANSWER:
+            offending_numbers = name_guard.offending_numbers(answer_text, haystack)
+
+        if not offending_names and not offending_numbers:
+            return GroundingResult(
+                grounded=True,
+                reason_code=PolicyDenialReason.NONE.value,
+                used_fact_keys=(),
+            )
+
+        notes: list[str] = []
+        if offending_names:
+            notes.append("entity_name_unsupported")
+        if offending_numbers:
+            notes.append("numeric_claim_unsupported")
+        return GroundingResult(
+            grounded=False,
+            reason_code=PolicyDenialReason.GROUNDING_FAILED.value,
+            used_fact_keys=(),
+            notes=tuple(notes),
+            offending_names=offending_names,
+            offending_numbers=offending_numbers,
+        )
+    except Exception:
+        logger.warning(
+            "btd6_grounding: validate_btd6_reply raised; failing closed",
+            exc_info=True,
+        )
+        return GroundingResult(
+            grounded=False,
+            reason_code=PolicyDenialReason.GROUNDING_FAILED.value,
+            used_fact_keys=(),
+            notes=("verifier_error",),
+        )
+
+
+__all__ = [
+    "GroundingResult",
+    "general_path_should_verify",
+    "validate_answer",
+    "validate_btd6_reply",
+    "validate_strategy_field",
+]

--- a/disbot/utils/btd6/answer_embed.py
+++ b/disbot/utils/btd6/answer_embed.py
@@ -1,0 +1,67 @@
+"""Pure deterministic embed builder for BTD6 answers.
+
+Renders the **code-grounded** facts the faithfulness verifier already validated
+the reply against into a compact embed, stamped with the served game version.
+The model's (verified, redacted) prose becomes the description; the digits and
+names in the data block come from the grounding facts, not the model — so the
+formatter is a defense *separate* from the verifier (acceptance criterion c).
+
+Returns ``None`` when there is nothing deterministic to anchor, so the stage
+falls through to the plain-text path for conversational BTD6 replies.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+import discord
+
+from utils.btd6 import grounding_format
+
+# The grounding prepends an internal provenance tag ("[btd6_tower] …") that is
+# not meant for users; strip it before display.
+_SOURCE_TAG_RE = re.compile(r"^\[btd6_[a-z0-9_]*\]\s*")
+
+_MAX_FACT_LINES = 10
+_MAX_FIELD_CHARS = 1000
+_MAX_DESC_CHARS = 3500
+
+
+@dataclass(frozen=True)
+class BTD6RenderContext:
+    """Deterministic render payload threaded via ``FeatureFactsResult``."""
+
+    facts: tuple[str, ...]
+    game_version: str
+
+
+def _clean_fact(line: str) -> str:
+    return grounding_format.sanitise(_SOURCE_TAG_RE.sub("", line or ""), cap=200)
+
+
+def build_answer_embed(reply_text: str, ctx: BTD6RenderContext) -> discord.Embed | None:
+    """Build the verified-data embed, or ``None`` when there is nothing to show."""
+    cleaned = [c for c in (_clean_fact(fact) for fact in ctx.facts) if c]
+    if not cleaned:
+        return None
+
+    description = grounding_format.sanitise(reply_text, cap=_MAX_DESC_CHARS)
+    embed = discord.Embed(description=description or None)
+
+    shown = cleaned[:_MAX_FACT_LINES]
+    block = "\n".join(f"• {line}" for line in shown)
+    if len(block) > _MAX_FIELD_CHARS:
+        block = block[: _MAX_FIELD_CHARS - 1].rstrip() + "…"
+
+    label = "Verified data"
+    if len(cleaned) > len(shown):
+        label = f"Verified data (showing {len(shown)} of {len(cleaned)})"
+    embed.add_field(name=label, value=block, inline=False)
+
+    version = ctx.game_version or "the current version"
+    embed.set_footer(text=f"BTD6 {version} · grounded data")
+    return embed
+
+
+__all__ = ["BTD6RenderContext", "build_answer_embed"]

--- a/disbot/utils/btd6/keywords.py
+++ b/disbot/utils/btd6/keywords.py
@@ -1,0 +1,81 @@
+"""Curated BTD6 context keywords — shared by the task router and the
+answer-faithfulness guard.
+
+Promoted verbatim from :mod:`services.ai_task_router` so the router's
+fast-path hint and the natural-language stage's general-path leak guard read
+**one** list (no drift). The router imports :data:`BTD6_CONTEXT_KEYWORDS` back
+as its private ``_BTD6_KEYWORDS`` — the values are identical, so the router's
+keyword tests are unaffected.
+
+Curated to avoid over-routing: bare ``event`` / ``active`` / ``leaderboard``
+are deliberately absent (they would over-route server events, "is the bot
+active", XP leaderboards). ``paragon`` is deliberately excluded — it is
+legitimate English ("a paragon of virtue"), so a bare substring would
+over-trigger; paragon questions usually name a tower or a (multi-word) paragon
+proper name, which the entity matcher / name index covers. ``obyn`` and
+``desperado`` are explicit because the entity-alias matcher provably misses
+them (the bare 4-char alias is length-filtered; single-word tower names are
+skipped as too generic).
+"""
+
+from __future__ import annotations
+
+BTD6_CONTEXT_KEYWORDS: tuple[str, ...] = (
+    "btd6",
+    "bloons",
+    "bloon",
+    "moab",
+    "ddt",
+    "bfb",
+    "zomg",
+    "tower",
+    "hero",
+    "monkey",
+    "chimps",
+    "round ",
+    "freeplay",
+    "deflation",
+    "apopalypse",
+    "impoppable",
+    "half cash",
+    "primary only",
+    "military only",
+    "magic only",
+    "support only",
+    "boss bloon",
+    "boss event",
+    "current boss",
+    "current race",
+    "current event",
+    "what boss",
+    "what race",
+    "what odyssey",
+    "active boss",
+    "active race",
+    "ninja kiwi",
+    "ninjakiwi",
+    "odyssey",
+    "contested territory",
+    "race ",
+    "banned hero",
+    "banned tower",
+    "obyn",
+    "desperado",
+)
+
+
+def has_btd6_context(text: str) -> bool:
+    """True when ``text`` contains any curated BTD6 context keyword.
+
+    Case-insensitive substring scan — the same test the router uses for its
+    fast-path. The answer guard uses it to decide whether a
+    ``GENERAL_NL_ANSWER`` reply that happens to name a BTD6 entity is actually
+    BTD6-themed (vs ordinary chat that merely shares a word with a hero name,
+    e.g. "Benjamin Franklin"). Distinctive multi-word BTD6 names trigger the
+    guard on their own and do not depend on this predicate.
+    """
+    lowered = (text or "").lower()
+    return any(keyword in lowered for keyword in BTD6_CONTEXT_KEYWORDS)
+
+
+__all__ = ["BTD6_CONTEXT_KEYWORDS", "has_btd6_context"]

--- a/disbot/utils/btd6/name_guard.py
+++ b/disbot/utils/btd6/name_guard.py
@@ -1,0 +1,163 @@
+"""Pure, common-word-safe BTD6 name and number matching for the answer guard.
+
+stdlib only — unit-testable in isolation. Mirrors the canonical/alias
+discipline the task router already uses in
+``ai_task_router._get_entity_aliases``: canonical proper names are matched
+whole-word (single tokens) or as substrings (multi-word phrases), while
+generic aliases are length-filtered and stop-listed so ordinary English words
+(``ice``, ``dart``, ``ace``) are never treated as BTD6 proper-name evidence.
+
+The caller (the grounding service) is responsible for passing a *safe* set of
+names — e.g. it does not pass single-word bloon colours ("Red", "Blue") as
+single tokens. This module only performs the mechanical split + matching.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+# Short alias/token forms that collide with ordinary English or chat. Even
+# when they survive the length filter they must never count as proper-name
+# evidence. Kept small and explicit.
+_ALIAS_STOPLIST: frozenset[str] = frozenset(
+    {
+        "ace",
+        "ice",
+        "dart",
+        "bomb",
+        "tack",
+        "glue",
+        "boat",
+        "sub",
+        "gun",
+        "hero",
+        "tower",
+        "round",
+        "boss",
+        "race",
+        "event",
+        "camo",
+        "lead",
+        "pink",
+        "blue",
+        "black",
+        "white",
+        "green",
+        "purple",
+        "yellow",
+    },
+)
+
+_WORD_RE = re.compile(r"[a-z0-9]+")
+_NUMBER_RE = re.compile(r"\d[\d,]*(?:\.\d+)?")
+
+
+@dataclass(frozen=True)
+class NameMatchers:
+    """Compiled matchers: multi-word phrases (substring) + single tokens."""
+
+    multi: frozenset[str]
+    single: frozenset[str]
+
+
+def build_matchers(
+    canonicals: Iterable[str],
+    aliases: Iterable[str],
+) -> NameMatchers:
+    """Split names into multi-word (substring) and single-token matchers.
+
+    * Canonicals are proper nouns: single-word forms are kept at length >= 3
+      (so distinctive short hero names like ``Psi`` / ``Adora`` survive),
+      multi-word forms become substring phrases.
+    * Aliases are generic: single-word forms are kept only at length > 4 and
+      when not stop-listed (mirrors the router's ``len(al) > 4`` rule).
+
+    Stop-listed tokens are removed from the single set unconditionally, even if
+    they arrived as a (short) canonical.
+    """
+    multi: set[str] = set()
+    single: set[str] = set()
+
+    for raw in canonicals:
+        name = (raw or "").strip().lower()
+        if not name:
+            continue
+        if " " in name:
+            multi.add(name)
+        elif len(name) >= 3:
+            single.add(name)
+
+    for raw in aliases:
+        alias = (raw or "").strip().lower()
+        if not alias:
+            continue
+        if " " in alias:
+            multi.add(alias)
+        elif len(alias) > 4 and alias not in _ALIAS_STOPLIST:
+            single.add(alias)
+
+    single -= _ALIAS_STOPLIST
+    return NameMatchers(multi=frozenset(multi), single=frozenset(single))
+
+
+def names_present(text: str, matchers: NameMatchers) -> set[str]:
+    """All indexed names that appear in ``text`` (whole-word + substring)."""
+    lowered = (text or "").lower()
+    found: set[str] = {phrase for phrase in matchers.multi if phrase in lowered}
+    if matchers.single:
+        tokens = set(_WORD_RE.findall(lowered))
+        found |= tokens & matchers.single
+    return found
+
+
+def multiword_names_present(text: str, matchers: NameMatchers) -> set[str]:
+    """Only the multi-word indexed names present in ``text``.
+
+    Multi-word BTD6 proper names (every paragon, most towers) are distinctive
+    enough to trigger the general-path guard on their own, without a separate
+    BTD6 context keyword.
+    """
+    lowered = (text or "").lower()
+    return {phrase for phrase in matchers.multi if phrase in lowered}
+
+
+def normalize_numbers(text: str) -> set[str]:
+    """Canonical numeric tokens in ``text``, thousands-separators stripped.
+
+    ``"48,210"`` and ``"48210"`` normalize to the same token so a grounded
+    comma-formatted value matches an answer that drops the comma (or vice
+    versa). Decimals are preserved.
+    """
+    return {match.replace(",", "") for match in _NUMBER_RE.findall(text or "")}
+
+
+def offending_numbers(answer: str, haystack: str) -> tuple[str, ...]:
+    """Numeric tokens in ``answer`` not present in ``haystack``.
+
+    Comma-normalized on both sides (so a grounded ``48,210`` covers an answer's
+    ``48210``). Uses a **substring** test, not exact-token membership — this
+    deliberately mirrors the leniency of
+    :func:`core.runtime.ai.safety.claims_are_grounded` so list markers and short
+    integers that appear inside a larger grounded number (``"5000"`` inside
+    ``"150000"``) do not false-positive. The trade is a known residual: a
+    fabricated number that is a substring of a real one passes.
+    """
+    hay = (haystack or "").replace(",", "")
+    out: list[str] = []
+    for raw in _NUMBER_RE.findall(answer or ""):
+        token = raw.replace(",", "")
+        if token and token not in hay:
+            out.append(token)
+    return tuple(out)
+
+
+__all__ = [
+    "NameMatchers",
+    "build_matchers",
+    "names_present",
+    "multiword_names_present",
+    "normalize_numbers",
+    "offending_numbers",
+]

--- a/disbot/views/btd6/answer_renderer.py
+++ b/disbot/views/btd6/answer_renderer.py
@@ -1,0 +1,40 @@
+"""Registered renderer for BTD6 answers — emits a verified-data embed.
+
+Runs in the natural-language stage **after** the faithfulness verifier, so the
+reply it formats is already grounded; the renderer never bypasses verification.
+Falls through to plain text (returns ``None``) when there is no deterministic
+data to anchor — e.g. a conversational BTD6 reply that resolved no entity.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from core.runtime.ai.redaction import redact_text
+from core.runtime.ai.response_renderer_registry import RenderedResponse
+from utils.btd6.answer_embed import BTD6RenderContext, build_answer_embed
+
+if TYPE_CHECKING:
+    from core.runtime.ai.contracts import AIResponse, AITask
+    from core.runtime.ai.feature_facts import FeatureFactRequest
+
+
+async def render_btd6_answer(
+    _task: AITask,
+    response: AIResponse,
+    _req: FeatureFactRequest,
+    render_context: object | None,
+) -> RenderedResponse | None:
+    if not isinstance(render_context, BTD6RenderContext):
+        return None
+    # The registry hands us the raw response, while the plain-text path sends a
+    # redacted reply — re-redact here so the embed never leaks a snowflake the
+    # plain path would have scrubbed. (Idempotent on already-clean text.)
+    text = redact_text(response.text or "").value
+    embed = build_answer_embed(text, render_context)
+    if embed is None:
+        return None
+    return RenderedResponse(content=None, embed=embed, allowed_mentions=None)
+
+
+__all__ = ["render_btd6_answer"]

--- a/tests/unit/runtime/ai/test_natural_language_stage.py
+++ b/tests/unit/runtime/ai/test_natural_language_stage.py
@@ -1258,3 +1258,283 @@ async def test_stage_continues_when_btd6_gather_raises(monkeypatch, stub_service
     assert captured["kwargs"]["bot_knowledge_blocks"] == ()
     assert len(stub_services) == 1
     assert stub_services[0]["decision"] == "replied"
+
+
+# ---------------------------------------------------------------------------
+# BTD6 faithfulness guard (PR1)
+# ---------------------------------------------------------------------------
+
+
+def _route_btd6(monkeypatch):
+    from core.runtime.ai import natural_language_stage as mod
+
+    monkeypatch.setattr(
+        mod.ai_task_router,
+        "classify",
+        lambda _t: SimpleNamespace(task=AITask.BTD6_ANSWER, route="btd6.answer"),
+    )
+
+
+def _stub_facts(monkeypatch, facts: tuple[str, ...]):
+    from core.runtime.ai import natural_language_stage as mod
+    from core.runtime.ai.feature_facts import FeatureFactsResult
+
+    monkeypatch.setattr(
+        mod,
+        "_gather_feature_facts",
+        AsyncMock(return_value=FeatureFactsResult(facts=facts, render_context=None)),
+    )
+
+
+def _sent_text(msg) -> str:
+    assert msg.channel.send.call_args is not None, "nothing was sent"
+    args, _ = msg.channel.send.call_args
+    return args[0] if args else ""
+
+
+@pytest.mark.asyncio
+async def test_btd6_hallucinated_roster_is_refused(monkeypatch, stub_services):
+    """The five-heroes repro: an ungrounded BTD6 roster never reaches the user;
+    the deterministic version-stamped refusal does, audited as denied /
+    GROUNDING_FAILED."""
+    from services import ai_gateway
+
+    _route_btd6(monkeypatch)
+    _stub_facts(monkeypatch, ())
+
+    calls: list[int] = []
+
+    async def fake_execute(_request):
+        calls.append(1)
+        return _make_response(
+            text="BTD6 has five heroes: Quincy, Gwen, Obyn, Geraldo, Adora."
+        )
+
+    monkeypatch.setattr(ai_gateway, "execute", fake_execute)
+
+    msg = _make_message()
+    msg.content = "<@bot> which heroes are in the game?"
+    await AINaturalLanguageStage().process(_make_ctx(msg))
+
+    sent = _sent_text(msg)
+    assert "five heroes" not in sent  # model text NOT served
+    assert "verified BTD6 data" in sent
+    assert "54.0" in sent  # version-stamped with what the bot serves
+    assert len(calls) == 2  # regenerate-once attempted
+    assert stub_services[-1]["decision"] == "denied"
+    assert stub_services[-1]["reason_code"] is PolicyDenialReason.GROUNDING_FAILED
+
+
+@pytest.mark.asyncio
+async def test_btd6_regenerate_once_rescues(monkeypatch, stub_services):
+    """First reply ungrounded, the constrained retry grounded → the grounded
+    reply is served and the gateway was called twice."""
+    from services import ai_gateway
+
+    _route_btd6(monkeypatch)
+    _stub_facts(monkeypatch, ("Quincy is a hero available from the start.",))
+
+    texts = iter(
+        ["The Glaive Dominus is the best hero.", "Quincy is a starter hero."]
+    )
+
+    async def fake_execute(_request):
+        return _make_response(text=next(texts))
+
+    monkeypatch.setattr(ai_gateway, "execute", fake_execute)
+
+    msg = _make_message()
+    msg.content = "<@bot> tell me about Quincy"
+    await AINaturalLanguageStage().process(_make_ctx(msg))
+
+    assert _sent_text(msg) == "Quincy is a starter hero."
+    assert stub_services[-1]["decision"] == "replied"
+
+
+@pytest.mark.asyncio
+async def test_btd6_grounded_answer_is_served(monkeypatch, stub_services):
+    from services import ai_gateway
+
+    _route_btd6(monkeypatch)
+    _stub_facts(monkeypatch, ("Quincy is a hero available from the start.",))
+
+    async def fake_execute(_request):
+        return _make_response(text="Quincy is a starter hero.")
+
+    monkeypatch.setattr(ai_gateway, "execute", fake_execute)
+
+    msg = _make_message()
+    msg.content = "<@bot> tell me about Quincy"
+    await AINaturalLanguageStage().process(_make_ctx(msg))
+
+    assert _sent_text(msg) == "Quincy is a starter hero."
+    assert stub_services[-1]["decision"] == "replied"
+
+
+@pytest.mark.asyncio
+async def test_btd6_healthy_empty_reply_is_refused(monkeypatch, stub_services):
+    """A healthy empty reply to a BTD6 question serves the refusal (denied /
+    GROUNDING_FAILED), not silence."""
+    from services import ai_gateway
+
+    _route_btd6(monkeypatch)
+    _stub_facts(monkeypatch, ())
+
+    async def fake_execute(_request):
+        return _make_response(text="", degraded=False, provider="deterministic")
+
+    monkeypatch.setattr(ai_gateway, "execute", fake_execute)
+
+    msg = _make_message()
+    msg.content = "<@bot> what's the best tower?"
+    await AINaturalLanguageStage().process(_make_ctx(msg))
+
+    assert "verified BTD6 data" in _sent_text(msg)
+    assert stub_services[-1]["decision"] == "denied"
+    assert stub_services[-1]["reason_code"] is PolicyDenialReason.GROUNDING_FAILED
+
+
+@pytest.mark.asyncio
+async def test_btd6_degraded_reply_is_not_a_grounding_failure(
+    monkeypatch, stub_services
+):
+    """A provider outage on a BTD6 question stays PROVIDER_UNAVAILABLE — it must
+    never be misclassified as a grounding failure (C2)."""
+    from services import ai_gateway
+
+    _route_btd6(monkeypatch)
+    _stub_facts(monkeypatch, ())
+
+    async def fake_execute(_request):
+        return _make_response(text=None, degraded=True, model="")
+
+    monkeypatch.setattr(ai_gateway, "execute", fake_execute)
+
+    msg = _make_message()
+    msg.content = "<@bot> what's the best tower?"
+    await AINaturalLanguageStage().process(_make_ctx(msg))
+
+    assert stub_services[-1]["decision"] == "degraded"
+    assert stub_services[-1]["reason_code"] is PolicyDenialReason.PROVIDER_UNAVAILABLE
+    msg.channel.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_btd6_verifier_crash_fails_closed(monkeypatch, stub_services):
+    """If the verifier index raises, the guard fails CLOSED to the refusal."""
+    from services import ai_gateway, btd6_grounding_service
+
+    _route_btd6(monkeypatch)
+    _stub_facts(monkeypatch, ())
+
+    def _boom():
+        raise RuntimeError("index broke")
+
+    monkeypatch.setattr(btd6_grounding_service, "_name_index", _boom)
+
+    async def fake_execute(_request):
+        return _make_response(text="some otherwise-harmless reply")
+
+    monkeypatch.setattr(ai_gateway, "execute", fake_execute)
+
+    msg = _make_message()
+    msg.content = "<@bot> tell me about towers"
+    await AINaturalLanguageStage().process(_make_ctx(msg))
+
+    assert "verified BTD6 data" in _sent_text(msg)
+    assert stub_services[-1]["decision"] == "denied"
+
+
+@pytest.mark.asyncio
+async def test_general_ordinary_name_is_not_refused(monkeypatch, stub_services):
+    """An ordinary general reply that shares a word with a hero name
+    ("Benjamin") must be served unchanged — the general-path guard only fires on
+    BTD6 context or a distinctive multi-word name."""
+    from services import ai_gateway
+
+    _stub_facts(monkeypatch, ())  # router stub already returns GENERAL_NL_ANSWER
+
+    async def fake_execute(_request):
+        return _make_response(
+            text="Benjamin Franklin (1706-1790) was an American polymath."
+        )
+
+    monkeypatch.setattr(ai_gateway, "execute", fake_execute)
+
+    msg = _make_message()
+    msg.content = "Who was Benjamin Franklin?"
+    await AINaturalLanguageStage().process(_make_ctx(msg))
+
+    assert "Benjamin Franklin" in _sent_text(msg)
+    assert stub_services[-1]["decision"] == "replied"
+
+
+@pytest.mark.asyncio
+async def test_general_numeric_answer_is_not_refused(monkeypatch, stub_services):
+    """Ordinary general numbers are never grounded (no BTD6 payload to ground
+    against)."""
+    from services import ai_gateway
+
+    _stub_facts(monkeypatch, ())
+
+    async def fake_execute(_request):
+        return _make_response(text="There are 7 continents.")
+
+    monkeypatch.setattr(ai_gateway, "execute", fake_execute)
+
+    msg = _make_message()
+    msg.content = "How many continents are there?"
+    await AINaturalLanguageStage().process(_make_ctx(msg))
+
+    assert _sent_text(msg) == "There are 7 continents."
+    assert stub_services[-1]["decision"] == "replied"
+
+
+@pytest.mark.asyncio
+async def test_general_path_btd6_leak_is_refused(monkeypatch, stub_services):
+    """A general reply that names a distinctive multi-word BTD6 entity it cannot
+    ground is refused even though the router missed it."""
+    from services import ai_gateway
+
+    _stub_facts(monkeypatch, ())
+
+    async def fake_execute(_request):
+        return _make_response(text="The Apex Plasma Master costs 5000000.")
+
+    monkeypatch.setattr(ai_gateway, "execute", fake_execute)
+
+    msg = _make_message()
+    msg.content = "tell me something cool"
+    await AINaturalLanguageStage().process(_make_ctx(msg))
+
+    assert "verified BTD6 data" in _sent_text(msg)
+    assert stub_services[-1]["decision"] == "denied"
+
+
+@pytest.mark.asyncio
+async def test_ledger_captures_only_btd6_tool_results():
+    """The faithfulness ledger captures approved BTD6 tool outputs (redacted)
+    and never an unrelated server/user tool's numbers (C1)."""
+    from core.runtime.ai.natural_language_stage import _wrap_handlers_for_ledger
+
+    async def btd6_handler(_args):
+        return {"cost": 48210, "name": "Dart Monkey"}
+
+    async def server_handler(_args):
+        return {"members": 235}
+
+    ledger: list[str] = []
+    wrapped = _wrap_handlers_for_ledger(
+        {"btd6_lookup": btd6_handler, "get_server_overview": server_handler},
+        frozenset({"btd6_lookup"}),
+        ledger,
+    )
+
+    await wrapped["btd6_lookup"]({})
+    await wrapped["get_server_overview"]({})
+
+    assert len(ledger) == 1
+    assert "48210" in ledger[0]
+    assert "235" not in " ".join(ledger)
+    # The non-BTD6 handler is returned untouched (not wrapped).
+    assert wrapped["get_server_overview"] is server_handler

--- a/tests/unit/services/test_ai_tools.py
+++ b/tests/unit/services/test_ai_tools.py
@@ -40,6 +40,18 @@ def test_build_registry_returns_specs_and_matching_handlers():
     assert isinstance(registry.specs, tuple)
 
 
+def test_btd6_grounding_tool_allowlist_matches_registered_btd6_tools():
+    """The faithfulness ledger allowlist must be exactly the registered
+    ``btd6_*`` tools — no non-BTD6 tool may ground a BTD6 answer, and no BTD6
+    tool may be silently dropped (drift guard for C1)."""
+    registry = build_registry(scope=AIScope.USER, guild_id=1, actor_id=2)
+    registered = {spec.name for spec in registry.specs}
+    btd6_registered = {name for name in registered if name.startswith("btd6_")}
+
+    assert ai_tools.BTD6_GROUNDING_TOOL_NAMES == btd6_registered
+    assert all(name.startswith("btd6_") for name in ai_tools.BTD6_GROUNDING_TOOL_NAMES)
+
+
 def test_scope_gating_is_least_privilege():
     assert _scope_allows(AIScope.USER, AIScope.USER) is True
     assert _scope_allows(AIScope.USER, AIScope.ADMIN) is False

--- a/tests/unit/services/test_ai_tools.py
+++ b/tests/unit/services/test_ai_tools.py
@@ -28,6 +28,7 @@ def test_build_registry_returns_specs_and_matching_handlers():
         "get_user_standing",
         "get_server_time",
         "btd6_lookup",
+        "btd6_list_roster",
         "btd6_capability_lookup",
         "btd6_superlative_lookup",
         "btd6_difficulty_cost",
@@ -50,6 +51,25 @@ def test_btd6_grounding_tool_allowlist_matches_registered_btd6_tools():
 
     assert ai_tools.BTD6_GROUNDING_TOOL_NAMES == btd6_registered
     assert all(name.startswith("btd6_") for name in ai_tools.BTD6_GROUNDING_TOOL_NAMES)
+
+
+async def test_btd6_list_roster_returns_full_verified_rosters():
+    """The enumeration tool returns the complete canonical roster + count so a
+    'list all heroes / paragons' question is answered, not guessed."""
+    heroes = await ai_tools._btd6_list_roster({"kind": "heroes"})
+    assert heroes["found"] is True
+    assert heroes["count"] == len(heroes["names"]) > 0
+    assert "Quincy" in heroes["names"]
+
+    paragons = await ai_tools._btd6_list_roster({"kind": "paragons"})
+    assert paragons["count"] == 13
+    assert "Apex Plasma Master" in paragons["names"]
+
+    towers = await ai_tools._btd6_list_roster({"kind": "towers"})
+    assert towers["found"] is True and towers["count"] > 0
+
+    bad = await ai_tools._btd6_list_roster({"kind": "bloons"})
+    assert bad["found"] is False
 
 
 def test_scope_gating_is_least_privilege():
@@ -282,6 +302,7 @@ def test_admin_scope_offers_all_read_only_tools():
         "get_user_standing",
         "get_server_time",
         "btd6_lookup",
+        "btd6_list_roster",
         "btd6_capability_lookup",
         "btd6_superlative_lookup",
         "btd6_difficulty_cost",

--- a/tests/unit/services/test_btd6_central_policy_integration.py
+++ b/tests/unit/services/test_btd6_central_policy_integration.py
@@ -221,13 +221,16 @@ def _stub_services_for_btd6(monkeypatch):
         mod.ai_conversation_service, "append", lambda *a, **kw: None,
     )
 
-    # Replace the feature-fact gather so we don't pull real BTD6 data.
+    # Replace the feature-fact gather so we don't pull real BTD6 data. The
+    # facts must *ground* the benign reply below ("Dart Monkey costs 200.")
+    # so these policy-focused tests exercise the reply path and not the BTD6
+    # faithfulness floor (which would otherwise refuse an ungrounded reply).
     from core.runtime.ai.feature_facts import FeatureFactsResult
 
-    async def _no_facts(_req):
-        return FeatureFactsResult(facts=())
+    async def _grounding_facts(_req):
+        return FeatureFactsResult(facts=("Dart Monkey costs 200.",))
 
-    monkeypatch.setattr(mod, "_gather_feature_facts", _no_facts)
+    monkeypatch.setattr(mod, "_gather_feature_facts", _grounding_facts)
 
     # Capture gateway call + return a benign reply.
     from services import ai_gateway

--- a/tests/unit/services/test_btd6_grounding_service.py
+++ b/tests/unit/services/test_btd6_grounding_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -11,7 +12,24 @@ _DISBOT = Path(__file__).parents[3] / "disbot"
 if str(_DISBOT) not in sys.path:
     sys.path.insert(0, str(_DISBOT))
 
-from services import btd6_grounding_service, btd6_knowledge_api  # noqa: E402
+from core.runtime.ai.contracts import AITask  # noqa: E402
+from services import (  # noqa: E402
+    btd6_data_service,
+    btd6_grounding_service,
+    btd6_knowledge_api,
+)
+from utils.btd6.paragon_math import PARAGONS  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_grounding_index():
+    """Reset the verifier index + dataset cache around every case so a stale
+    name index cannot leak across fixture changes (C4)."""
+    btd6_grounding_service._reset_for_tests()
+    btd6_data_service.reset_cache()
+    yield
+    btd6_grounding_service._reset_for_tests()
+    btd6_data_service.reset_cache()
 
 
 async def test_validate_answer_accepts_supported_numeric_claims():
@@ -68,3 +86,170 @@ async def test_validate_strategy_field_rejects_when_entity_unknown(monkeypatch):
     )
     assert result.grounded is False
     assert "entity_not_in_knowledge_api" in result.notes
+
+
+# ---------------------------------------------------------------------------
+# validate_btd6_reply — the live answer-path faithfulness verifier
+# ---------------------------------------------------------------------------
+
+
+def test_btd6_reply_blocks_unsupported_number():
+    v = btd6_grounding_service.validate_btd6_reply(
+        "Round 40 sends 999 ceramics.",
+        facts=("Round 40 sends 200 ceramics.",),
+        task=AITask.BTD6_ANSWER,
+    )
+    assert v.grounded is False
+    assert "999" in v.offending_numbers
+    assert "numeric_claim_unsupported" in v.notes
+
+
+def test_btd6_reply_accepts_supported_number():
+    v = btd6_grounding_service.validate_btd6_reply(
+        "Round 40 sends 200 ceramics.",
+        facts=("Round 40 sends 200 ceramics.",),
+        task=AITask.BTD6_ANSWER,
+    )
+    assert v.grounded is True
+
+
+def test_btd6_reply_comma_formatted_number_still_grounded():
+    # Grounding renders comma-formatted totals; the model may drop the comma.
+    v = btd6_grounding_service.validate_btd6_reply(
+        "The total RBE is 48210.",
+        facts=("total RBE 48,210 (hits to fully clear)",),
+        task=AITask.BTD6_ANSWER,
+    )
+    assert v.grounded is True
+
+
+def test_btd6_reply_tool_computed_number_grounds_via_ledger():
+    # A number present only in an approved tool result (the ledger) is trusted.
+    v = btd6_grounding_service.validate_btd6_reply(
+        "At degree 73 it deals 4521 damage.",
+        facts=(),
+        tool_results=('{"degree": 73, "damage": 4521}',),
+        task=AITask.BTD6_ANSWER,
+    )
+    assert v.grounded is True
+
+
+def test_btd6_reply_unrelated_number_does_not_whitelist():
+    # An unrelated number (e.g. a member count) must not ground a BTD6 claim.
+    v = btd6_grounding_service.validate_btd6_reply(
+        "The paragon costs 235000.",
+        facts=(),
+        tool_results=('{"members": 235}',),
+        task=AITask.BTD6_ANSWER,
+    )
+    assert v.grounded is False
+    assert "235000" in v.offending_numbers
+
+
+def test_btd6_reply_blocks_ungrounded_hero_names():
+    v = btd6_grounding_service.validate_btd6_reply(
+        "BTD6 has five heroes: Quincy, Gwen, Obyn, Geraldo, Adora.",
+        facts=(),
+        task=AITask.BTD6_ANSWER,
+    )
+    assert v.grounded is False
+    assert "entity_name_unsupported" in v.notes
+    assert "quincy" in v.offending_names
+
+
+def test_btd6_reply_accepts_grounded_hero_name():
+    v = btd6_grounding_service.validate_btd6_reply(
+        "Quincy is a starter hero.",
+        facts=("Quincy is a hero available from the start.",),
+        task=AITask.BTD6_ANSWER,
+    )
+    assert v.grounded is True
+
+
+def test_btd6_reply_blocks_ungrounded_upgrade_name():
+    # "Sharp Shots" is a real Dart Monkey upgrade — indexed, and ungrounded
+    # here because it is not in the (empty) payload.
+    v = btd6_grounding_service.validate_btd6_reply(
+        "Just buy Sharp Shots first.",
+        facts=(),
+        task=AITask.BTD6_ANSWER,
+    )
+    assert v.grounded is False
+    assert "sharp shots" in v.offending_names
+
+
+def test_general_path_skips_number_check_but_guards_names():
+    # On the general path ordinary numbers are never grounded …
+    v = btd6_grounding_service.validate_btd6_reply(
+        "There are 7 continents.",
+        facts=(),
+        task=AITask.GENERAL_NL_ANSWER,
+    )
+    assert v.grounded is True
+    # … but a leaked BTD6 entity name is still blocked.
+    v2 = btd6_grounding_service.validate_btd6_reply(
+        "The Glaive Dominus is a paragon.",
+        facts=(),
+        task=AITask.GENERAL_NL_ANSWER,
+    )
+    assert v2.grounded is False
+    assert "glaive dominus" in v2.offending_names
+
+
+def test_general_path_should_verify_predicate():
+    # Ordinary chat naming a hero must not trigger the guard.
+    assert (
+        btd6_grounding_service.general_path_should_verify(
+            "who was benjamin franklin", "Benjamin Franklin was a polymath."
+        )
+        is False
+    )
+    # A distinctive multi-word paragon name triggers it without a keyword.
+    assert (
+        btd6_grounding_service.general_path_should_verify(
+            "tell me", "The Apex Plasma Master costs 5000000."
+        )
+        is True
+    )
+    # A BTD6 context keyword triggers it.
+    assert (
+        btd6_grounding_service.general_path_should_verify(
+            "which heroes exist?", "There are several."
+        )
+        is True
+    )
+
+
+def test_reset_clears_name_index(monkeypatch):
+    # Build the index, then prove a dataset swap is reflected after reset
+    # (no stale stats/name leak — C4).
+    real = btd6_grounding_service._name_index()
+    assert real.single  # populated from the real dataset
+
+    fake = SimpleNamespace(
+        data_version="t1",
+        game_version="t",
+        towers=(),
+        heroes=(SimpleNamespace(canonical="Zztopkek", aliases=()),),
+        maps=(),
+        modes=(),
+        bloons=(),
+        ct_relics=(),
+    )
+    monkeypatch.setattr(btd6_data_service, "get_dataset", lambda: fake)
+    btd6_grounding_service._reset_for_tests()
+
+    rebuilt = btd6_grounding_service._name_index()
+    assert "zztopkek" in rebuilt.single
+    assert "quincy" not in rebuilt.single  # the old index did not leak through
+
+
+def test_enumeration_roster_is_subset_of_accepted_names():
+    # Deterministic paragon enumeration must never produce a name the verifier
+    # would later reject (drift guard, C8).
+    matchers = btd6_grounding_service._name_index()
+    for paragon in PARAGONS:
+        present = btd6_grounding_service.name_guard.names_present(
+            paragon.name, matchers
+        )
+        assert present, f"paragon {paragon.name!r} is not in the accepted index"

--- a/tests/unit/utils/test_btd6_answer_embed.py
+++ b/tests/unit/utils/test_btd6_answer_embed.py
@@ -1,0 +1,79 @@
+"""Tests for the deterministic BTD6 answer embed builder + renderer (PR2)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_DISBOT = Path(__file__).parents[3] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+from utils.btd6.answer_embed import BTD6RenderContext, build_answer_embed  # noqa: E402
+from views.btd6.answer_renderer import render_btd6_answer  # noqa: E402
+
+
+def test_embed_data_comes_from_facts_with_tag_stripped():
+    ctx = BTD6RenderContext(
+        facts=(
+            "[btd6_tower] Dart Monkey — base cost: 200 (medium)",
+            "[btd6_tower] top: Sharp Shots ($140)",
+        ),
+        game_version="54.0",
+    )
+    embed = build_answer_embed("Dart Monkey is a cheap starter.", ctx)
+    assert embed is not None
+    assert embed.description == "Dart Monkey is a cheap starter."
+    field = embed.fields[0]
+    # Provenance tag stripped; digits come from the grounded facts.
+    assert "[btd6_tower]" not in field.value
+    assert "base cost: 200" in field.value
+    assert "$140" in field.value
+    assert "54.0" in (embed.footer.text or "")
+
+
+def test_embed_truncation_label_reports_total():
+    facts = tuple(f"[btd6_tower] fact line {i}" for i in range(15))
+    embed = build_answer_embed("prose", BTD6RenderContext(facts=facts, game_version="54.0"))
+    assert embed is not None
+    assert "showing 10 of 15" in embed.fields[0].name
+
+
+def test_embed_none_when_no_anchorable_facts():
+    assert build_answer_embed("hi", BTD6RenderContext(facts=(), game_version="54.0")) is None
+    # Facts that clean down to nothing also fall through to plain text.
+    assert (
+        build_answer_embed("hi", BTD6RenderContext(facts=("[btd6_x] ",), game_version="54.0"))
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_renderer_returns_none_without_btd6_render_context():
+    resp = SimpleNamespace(text="hi")
+    assert await render_btd6_answer(None, resp, None, None) is None
+    assert await render_btd6_answer(None, resp, None, object()) is None
+
+
+@pytest.mark.asyncio
+async def test_renderer_builds_embed_and_redacts_text():
+    # A raw snowflake in the model text is scrubbed by the renderer's redaction.
+    resp = SimpleNamespace(text="See <@123456789012345678> — Dart Monkey costs 200.")
+    ctx = BTD6RenderContext(
+        facts=("[btd6_tower] Dart Monkey base cost 200",), game_version="54.0"
+    )
+    rendered = await render_btd6_answer(None, resp, None, ctx)
+    assert rendered is not None
+    assert rendered.content is None
+    assert rendered.embed is not None
+    assert "123456789012345678" not in (rendered.embed.description or "")
+
+
+@pytest.mark.asyncio
+async def test_renderer_falls_through_when_no_facts():
+    resp = SimpleNamespace(text="just chatting about bloons")
+    ctx = BTD6RenderContext(facts=(), game_version="54.0")
+    assert await render_btd6_answer(None, resp, None, ctx) is None

--- a/tests/unit/utils/test_btd6_name_guard.py
+++ b/tests/unit/utils/test_btd6_name_guard.py
@@ -1,0 +1,81 @@
+"""Pure unit tests for the BTD6 name/number matching primitives."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_DISBOT = Path(__file__).parents[3] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+from utils.btd6 import name_guard  # noqa: E402
+from utils.btd6.keywords import has_btd6_context  # noqa: E402
+
+
+def _matchers() -> name_guard.NameMatchers:
+    return name_guard.build_matchers(
+        canonicals={"Apex Plasma Master", "Dart Monkey", "Quincy", "Psi", "Adora"},
+        aliases={"q", "ado", "brickell", "ice"},
+    )
+
+
+def test_short_canonical_names_kept():
+    m = _matchers()
+    # Distinctive short hero canonicals survive (>= 3 chars).
+    assert "psi" in m.single
+    assert "adora" in m.single
+    assert "quincy" in m.single
+
+
+def test_generic_and_short_aliases_dropped():
+    m = _matchers()
+    # Ultra-short aliases (q, ado) and common-word aliases (ice) are not
+    # proper-name evidence.
+    assert "q" not in m.single
+    assert "ado" not in m.single
+    assert "ice" not in m.single
+    # A distinctive long alias survives.
+    assert "brickell" in m.single
+
+
+def test_multiword_names_are_substring_matchers():
+    m = _matchers()
+    assert "apex plasma master" in m.multi
+    assert "dart monkey" in m.multi
+    assert name_guard.multiword_names_present(
+        "the Apex Plasma Master is strong", m
+    ) == {"apex plasma master"}
+
+
+def test_names_present_whole_word_vs_substring():
+    m = _matchers()
+    # Whole-word for single tokens: "quincy" matches, "quincyish" does not.
+    assert "quincy" in name_guard.names_present("I picked Quincy today", m)
+    assert "quincy" not in name_guard.names_present("quincyish nonsense", m)
+    # Substring for multi-word phrases.
+    assert "dart monkey" in name_guard.names_present("a dart monkey wall", m)
+
+
+def test_normalize_numbers_strips_thousands_separators():
+    assert name_guard.normalize_numbers("48,210") == name_guard.normalize_numbers(
+        "48210"
+    )
+    assert name_guard.normalize_numbers("cost 1,000.50") == {"1000.50"}
+
+
+def test_offending_numbers_comma_normalized_substring():
+    # Grounded comma-formatted value covers a comma-free answer.
+    assert name_guard.offending_numbers("it is 48210", "total 48,210 rbe") == ()
+    # A genuinely absent value is flagged.
+    assert "999999" in name_guard.offending_numbers("it is 999999", "total 48,210")
+    # Substring leniency (mirrors claims_are_grounded): a short integer inside a
+    # larger grounded number is not flagged.
+    assert name_guard.offending_numbers("tier 5", "cost 150000") == ()
+
+
+def test_has_btd6_context_discriminates_ordinary_chat():
+    assert has_btd6_context("which heroes are in the game?") is True
+    assert has_btd6_context("what's the strongest tower?") is True
+    assert has_btd6_context("Who was Benjamin Franklin?") is False
+    assert has_btd6_context("tell me about the weather") is False


### PR DESCRIPTION
## Why

The BTD6 answer path ran: deterministic resolver → deterministic grounding → **Haiku authors the final prose** → **nothing checked the output before send**. `btd6_grounding_service.validate_answer()` had zero live callers, `claims_are_grounded()` was numeric-only, and there was no entity-name check anywhere. On a keyword-trigger miss the turn routed to `GENERAL_NL_ANSWER` and Haiku answered from training.

Live repro this makes impossible to *serve*: "which heroes are in the game?" → "BTD6 has five heroes: Quincy, Gwen, Obyn, Geraldo, Adora" — wrong count, 12 of 17 missing.

## What

Two commits (foundation, then the layer on top).

### PR1 — Faithfulness guard (root cause)
After generation, a BTD6 answer (or a BTD6-themed general reply that names an entity) is verified against the grounded payload — auto-grounding facts **plus the results of approved BTD6 tools** — and, on a violation, **regenerated once** under an explicit do-not-state constraint before falling to a deterministic, **version-stamped refusal** (stamped `54.0`, what the bot actually serves).

- `utils/btd6/name_guard.py` — pure, common-word-safe name/number matching (canonical vs alias split, comma-normalized numbers, multi-word trigger). Mirrors the router's existing discipline.
- `utils/btd6/keywords.py` — the router's curated BTD6 keyword list, promoted so the general-path guard and the router share **one** source (no drift; router tests unaffected).
- `btd6_grounding_service.validate_btd6_reply` + a dataset-keyed name index with a test reset seam; `general_path_should_verify` gates the general path on BTD6 context **or** a distinctive multi-word name, so ordinary chat ("Benjamin Franklin") is never refused.
- **BTD6-only ledger:** the stage captures only approved `btd6_*` tool results (redacted) — an unrelated server/user tool number can never whitelist a hallucinated BTD6 claim. A drift test pins the allowlist to the registered `btd6_*` tools.
- **Provider outages stay `PROVIDER_UNAVAILABLE`**; `GROUNDING_FAILED` is reserved for healthy replies / genuine no-data. (Preserves the existing degraded-vs-skipped audit distinction rather than collapsing it.)

### PR2 — Enumeration + deterministic rendering
- `ai_tools.btd6_list_roster` — returns the **complete** verified roster (heroes / towers / paragons) with an exact count, so "list all heroes" is answered from the dataset, not guessed. In the grounding allowlist, so its result grounds the answer.
- `utils/btd6/answer_embed.py` + `views/btd6/answer_renderer.py` — when a BTD6 answer resolved grounded facts, render a compact "verified data" embed (verified prose as description, code-grounded facts as the data block with the provenance tag stripped + re-redacted, footer-stamped with the served version). Falls through to plain text for conversational replies. A formatter defense **separate** from the verifier.

## Acceptance criteria
- **(a) five-heroes impossible** — empty/sparse payload ⇒ the named heroes are known-but-not-allowed ⇒ regenerate ⇒ refusal; `btd6_list_roster` makes the correct 17 *available*.
- **(b) computed-number exemption** — numbers verify against `facts ∪ approved-tool-results`; tool-computed values (paragon-at-degree, difficulty cost) pass via the ledger; general-path numbers are never grounded.
- **(c) separate defenses** — the verifier (PR1) and the enumeration tool + embed formatter (PR2) are independent.

## Verification
- `python3.10 scripts/check_quality.py --full` — **7178 passed**, 3 skipped (formatters + mypy + full pytest, CI parity on Python 3.10).
- `python3.10 scripts/check_architecture.py --mode strict` — **0 errors**.
- New tests: name-guard primitives; `validate_btd6_reply` (incl. the unrelated-tool-number and cache-reset cases); the five-heroes / regenerate-once / Benjamin-Franklin / provider-degraded stage flows; the ledger allowlist + enumeration tool; the embed builder + renderer.

## Notes / residuals (honest scope)
- The name index covers entities + paragons + multi-word upgrade names. Ability / subtower / buff / zone names exist at runtime in `btd6_upgrade_detail_service` but only per-tier; a global index is a named fast-follow. A fully-novel invented string (no index hit, no number) is the one residual — no proper-noun NER (false-positive cost). Policy wording matches what is actually enforced.
- Observability (blocked-reply tokens, retry-rescue) lands as structured logs, since the audit row has no free-form field; a per-answer version column in the audit schema is a possible follow-up.

https://claude.ai/code/session_01JXik78XDCPXJmVPuvz5NTY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXik78XDCPXJmVPuvz5NTY)_