### PR TITLE
fix(btd6): ground hero/tower rosters so roster questions answer again (regression after #468)

### DIFF
--- a/disbot/services/btd6_context_service.py
+++ b/disbot/services/btd6_context_service.py
@@ -1159,6 +1159,75 @@ def _paragon_roster_facts(message_text: str) -> list[str]:
     return lines
 
 
+# Roster-intent verbs for the hero/tower roster grounding. Heroes and towers
+# have no ``_paragon_roster_facts`` equivalent, so a "list all heroes" / "which
+# towers" question reached the model with ZERO grounding facts — and the
+# answer-faithfulness guard then refused the model's (correct) roster as
+# ungrounded. Gated on the entity word so ordinary entity questions
+# ("dart monkey stats") never trip it.
+_ENTITY_ROSTER_VERBS = (
+    "list ",
+    "all ",
+    "which ",
+    "every ",
+    "how many",
+    "name the",
+    "name all",
+    "name every",
+    "what are the",
+    "what heroes",
+    "what towers",
+    "each ",
+)
+
+
+def _roster_lines(kind: str, names: list[str]) -> list[str]:
+    """Chunk a roster into <=230-char grounding lines tagged by ``kind``."""
+    if not names:
+        return []
+    plural = "heroes" if kind == "hero" else f"{kind}s"
+    head = (
+        f"[btd6_{kind}_roster] BTD6 has {len(names)} {plural} — the complete "
+        f"list (state these verbatim; never invent or omit one):"
+    )
+    lines = [head]
+    prefix = f"[btd6_{kind}_roster] "
+    line = prefix
+    for name in names:
+        addition = name if line == prefix else f", {name}"
+        if len(line) + len(addition) > 230:
+            lines.append(line)
+            line = prefix + name
+        else:
+            line += addition
+    lines.append(line)
+    return lines
+
+
+def _entity_roster_facts(message_text: str) -> list[str]:
+    """Ground the authoritative hero / tower roster for roster-level questions.
+
+    Mirrors :func:`_paragon_roster_facts` for the two catalogs that lacked it.
+    "which heroes are in the game" / "list all towers" otherwise produce no
+    grounding facts at all, so the model's correct roster reads as ungrounded
+    and is refused by the faithfulness guard. Pin the real roster + count so the
+    answer grounds — independent of ``AI_TOOLS_ENABLED`` and of whether the
+    model chooses to call ``btd6_list_roster``.
+    """
+    text = (message_text or "").lower()
+    if not any(verb in text for verb in _ENTITY_ROSTER_VERBS):
+        return []
+    from services import btd6_data_service
+
+    dataset = btd6_data_service.get_dataset()
+    out: list[str] = []
+    if "hero" in text:
+        out.extend(_roster_lines("hero", [h.canonical for h in dataset.heroes]))
+    if "tower" in text:
+        out.extend(_roster_lines("tower", [t.canonical for t in dataset.towers]))
+    return out
+
+
 def _paragon_name_facts(message_text: str, resolved_tower_ids: set[str]) -> list[str]:
     """Ground a paragon named directly (e.g. "what are Glaive Dominus's stats?").
 
@@ -1419,6 +1488,7 @@ async def build(message_text: str) -> BTD6Context:
         }
         facts.extend(_paragon_name_facts(message_text, resolved_tower_ids))
         facts.extend(_paragon_roster_facts(message_text))
+        facts.extend(_entity_roster_facts(message_text))
 
         # Pass 3c: upgrade grounding — an upgrade named in the text by name,
         # abbreviation / nickname (PMFC / POD / BEZ / Prince of Darkness), or

--- a/tests/unit/runtime/ai/test_natural_language_stage.py
+++ b/tests/unit/runtime/ai/test_natural_language_stage.py
@@ -1538,3 +1538,43 @@ async def test_ledger_captures_only_btd6_tool_results():
     assert "235" not in " ".join(ledger)
     # The non-BTD6 handler is returned untouched (not wrapped).
     assert wrapped["get_server_overview"] is server_handler
+
+
+@pytest.mark.asyncio
+async def test_btd6_roster_answer_is_served_when_grounded(monkeypatch, stub_services):
+    """Regression: a roster question grounded by the hero-roster facts must be
+    SERVED, not refused. In production it refused because heroes/towers had no
+    roster auto-grounding, so the model's correct list read as ungrounded."""
+    from services import ai_gateway
+
+    _route_btd6(monkeypatch)
+    _stub_facts(
+        monkeypatch,
+        (
+            "[btd6_hero_roster] BTD6 has 17 heroes — the complete list: Quincy, "
+            "Gwendolin, Striker Jones, Obyn Greenfoot, Captain Churchill, "
+            "Benjamin, Ezili, Pat Fusty, Adora, Admiral Brickell, Etienne, "
+            "Sauda, Psi, Geraldo, Corvus, Rosalia, Silas.",
+        ),
+    )
+
+    async def fake_execute(_request):
+        return _make_response(
+            text=(
+                "BTD6 has 17 heroes: Quincy, Gwendolin, Striker Jones, Obyn "
+                "Greenfoot, Captain Churchill, Benjamin, Ezili, Pat Fusty, Adora, "
+                "Admiral Brickell, Etienne, Sauda, Psi, Geraldo, Corvus, Rosalia, "
+                "Silas."
+            )
+        )
+
+    monkeypatch.setattr(ai_gateway, "execute", fake_execute)
+
+    msg = _make_message()
+    msg.content = "<@bot> which heroes are in the game?"
+    await AINaturalLanguageStage().process(_make_ctx(msg))
+
+    sent = _sent_text(msg)
+    assert "verified BTD6 data" not in sent  # NOT the refusal floor
+    assert "Quincy" in sent and "Silas" in sent  # the real roster is served
+    assert stub_services[-1]["decision"] == "replied"

--- a/tests/unit/services/test_btd6_context_grounding.py
+++ b/tests/unit/services/test_btd6_context_grounding.py
@@ -366,3 +366,28 @@ async def test_build_grounds_paragon_roster_and_excludes_heroes():
     # A specific-paragon question must NOT trigger the roster dump.
     specific = await btd6_context_service.build("Magus Perfectus cost")
     assert not any("paragon_roster" in f for f in specific.facts)
+
+
+async def test_build_grounds_hero_roster_for_roster_questions():
+    # Regression (post-#468 faithfulness guard): heroes had no roster grounding
+    # (only paragons did), so "which heroes are in the game" reached the guard
+    # with zero facts and was refused. Pin the hero roster so the answer grounds.
+    ctx = await btd6_context_service.build("which heroes are in the game?")
+    blob = "\n".join(f for f in ctx.facts if "hero_roster" in f)
+    assert "17 heroes" in blob
+    assert "Quincy" in blob and "Gwendolin" in blob and "Benjamin" in blob
+    # "list all heroes" must ground too; a specific-hero question must NOT.
+    listed = await btd6_context_service.build("list all heroes in btd6")
+    assert any("hero_roster" in f for f in listed.facts)
+    specific = await btd6_context_service.build("Quincy cost")
+    assert not any("hero_roster" in f for f in specific.facts)
+
+
+async def test_build_grounds_tower_roster_for_roster_questions():
+    ctx = await btd6_context_service.build("list all towers")
+    blob = "\n".join(f for f in ctx.facts if "tower_roster" in f)
+    assert "towers" in blob
+    assert "Dart Monkey" in blob
+    # A named-entity question ("dart monkey stats") must NOT dump the roster.
+    specific = await btd6_context_service.build("dart monkey stats")
+    assert not any("tower_roster" in f for f in specific.facts)


### PR DESCRIPTION
## The regression

After #468, BTD6 roster lookups that used to answer now uniformly refuse with the version-stamped faithfulness floor — `which heroes are in the game`, `list all heroes`, `list all towers` — even with `AI_TOOLS_ENABLED=true`.

## Diagnosis (verified in code, led with evidence)

I reproduced the decisive facts against source rather than reasoning from the symptom:

- **`btd6_context_service.build()` returns 0 grounding facts for hero/tower roster questions.** Paragons already had `_paragon_roster_facts` (so `list all paragons` works → 3 facts), but **heroes and towers had no equivalent** (`which heroes…` → 0, `how many towers` → 0). So the always-on guard from #468 sees the model's *correct* roster as ungrounded names and refuses.
- **`btd6_lookup` wraps the same `build()`**, so even with tools on the tool path returns `found=false` for rosters — which is why `AI_TOOLS_ENABLED=true` didn't help.
- **The ledger is NOT the bug.** The §8 "ledger doesn't fill through the real gateway loop" suspicion was ruled out: `gateway._build_dispatch` calls `tool_handlers[name]` — i.e. the ledger-wrapping handler — so approved tool results *do* reach the haystack when the model calls a tool. The gap was missing roster grounding, not ledger wiring.

## The fix

`_entity_roster_facts()` in `btd6_context_service` — mirrors `_paragon_roster_facts`, pinning the authoritative **17-hero / 25-tower** roster + count whenever a roster-intent question names `hero(es)`/`tower(s)`. It is **tool-independent**, so it works regardless of `AI_TOOLS_ENABLED` and of whether the model calls `btd6_list_roster`, and it also flows through `btd6_lookup` (same `build()`). Gated on the entity word so ordinary entity questions (`dart monkey stats`) never trip it.

Verified end-to-end: the failing queries now produce roster facts and a model's 17-hero answer grounds (`grounded=True`); `dart monkey stats` produces 0 roster facts.

## Tests (the coverage gap that let this ship)

- `test_build_grounds_hero_roster_for_roster_questions` / `…_tower_roster…` (+ negative cases).
- `test_btd6_roster_answer_is_served_when_grounded` — a stage-level regression asserting a grounded roster answer is **served, not refused**.

The original suite was green because the mocked-gateway tests supplied facts directly and never exercised the empty-grounding roster path — these new tests close that.

## Honest note on the 4th symptom

The `stats from wizard` refusal is **not** this bug: that query already grounds (28 facts) and plausible wizard answers **pass** the verifier in my repro. Its refusal is the guard correctly rejecting an ungrounded number the model added, or a grounding-completeness gap (the auto-grounding is cost/upgrade-focused, not per-tier combat stats). Tracked separately, not folded in here.

## Verification

`python3.10 scripts/check_quality.py --full` → **7181 passed**, 3 skipped. `python3.10 scripts/check_architecture.py --mode strict` → **0 errors**.

https://claude.ai/code/session_01JXik78XDCPXJmVPuvz5NTY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXik78XDCPXJmVPuvz5NTY)_