### PR TITLE
fix(btd6): deterministic roster floor so list questions always answer

### DIFF
--- a/disbot/core/runtime/ai/natural_language_stage.py
+++ b/disbot/core/runtime/ai/natural_language_stage.py
@@ -518,10 +518,13 @@ class AINaturalLanguageStage:
                 audit_decision = "degraded"
                 audit_reason = PolicyDenialReason.PROVIDER_UNAVAILABLE
             elif routed.task is AITask.BTD6_ANSWER:
-                await _send_btd6_refusal(message)
+                # Healthy but empty on an in-domain BTD6 question: serve the
+                # deterministic roster for a list request, else the refusal.
+                audit_decision, audit_reason = await _serve_btd6_floor(
+                    message,
+                    raw_text,
+                )
                 sent_refusal = True
-                audit_decision = "denied"
-                audit_reason = PolicyDenialReason.GROUNDING_FAILED
             else:
                 audit_decision = "skipped"
                 audit_reason = PolicyDenialReason.NO_ROUTE_MATCHED
@@ -603,15 +606,10 @@ class AINaturalLanguageStage:
                     )
                     reply_text = retry_text
                 else:
-                    # Floor: deterministic refusal. A degraded retry is a
-                    # provider outage, NOT a grounding failure — keep the
-                    # audit honest so operators can tell them apart.
-                    if response.degraded:
-                        floor_decision = "degraded"
-                        floor_reason = PolicyDenialReason.PROVIDER_UNAVAILABLE
-                    else:
-                        floor_decision = "denied"
-                        floor_reason = PolicyDenialReason.GROUNDING_FAILED
+                    # Floor. A degraded retry is a provider outage, NOT a
+                    # grounding failure — keep that audit honest. A healthy
+                    # grounding failure serves the deterministic roster for a
+                    # list request ("list all heroes"), else the no-data refusal.
                     logger.warning(
                         "btd6_faithfulness: blocked task=%s route=%s guard=%s "
                         "names=%s numbers=%s retry_attempted=True "
@@ -623,7 +621,15 @@ class AINaturalLanguageStage:
                         list(verdict.offending_numbers),
                         response.degraded,
                     )
-                    await _send_btd6_refusal(message)
+                    if response.degraded:
+                        await _send_btd6_refusal(message)
+                        floor_decision = "degraded"
+                        floor_reason = PolicyDenialReason.PROVIDER_UNAVAILABLE
+                    else:
+                        floor_decision, floor_reason = await _serve_btd6_floor(
+                            message,
+                            raw_text,
+                        )
                     await ai_decision_audit_service.record(
                         guild_id=guild_id,
                         channel_id=channel_id,
@@ -970,6 +976,47 @@ async def _send_btd6_refusal(message: discord.Message) -> None:
             getattr(message, "id", None),
             exc_info=True,
         )
+
+
+async def _serve_btd6_floor(
+    message: discord.Message,
+    raw_text: str,
+) -> tuple[str, PolicyDenialReason]:
+    """Floor for a healthy BTD6 answer that produced no groundable reply.
+
+    For a clear roster-LIST request ("list all heroes", "list all towers") send
+    the deterministic, code-built roster — the model cannot restate 17+ costs
+    verbatim, so a single mismatch refused the whole list; the roster *is* the
+    source, so it always answers. Otherwise send the version-stamped no-data
+    refusal. Returns the ``(decision, reason_code)`` to audit.
+    """
+    roster: str | None = None
+    try:
+        from services import btd6_context_service
+
+        roster = btd6_context_service.deterministic_roster_reply(raw_text)
+    except Exception:
+        logger.warning("btd6 deterministic roster build failed", exc_info=True)
+
+    if roster:
+        try:
+            reference = message.to_reference(fail_if_not_exists=False)
+            for index, chunk in enumerate(_split_for_discord(roster)):
+                await message.channel.send(
+                    chunk,
+                    allowed_mentions=discord.AllowedMentions.none(),
+                    reference=reference if index == 0 else None,
+                )
+        except discord.HTTPException:
+            logger.warning(
+                "btd6 roster send failed for message=%s",
+                getattr(message, "id", None),
+                exc_info=True,
+            )
+        return "replied", PolicyDenialReason.NONE
+
+    await _send_btd6_refusal(message)
+    return "denied", PolicyDenialReason.GROUNDING_FAILED
 
 
 def _wrap_handlers_for_ledger(

--- a/disbot/services/btd6_context_service.py
+++ b/disbot/services/btd6_context_service.py
@@ -1265,6 +1265,114 @@ def _entity_roster_facts(message_text: str) -> list[str]:
     return out
 
 
+# Strategy / opinion words → the user wants a recommendation, not an
+# enumeration. The model handles those; the deterministic roster must NOT fire.
+_ROSTER_STRATEGY_WORDS = (
+    "best",
+    "worst",
+    "should",
+    "good for",
+    "recommend",
+    "better",
+    " vs ",
+    "versus",
+    "against",
+    "counter",
+    "strateg",
+    "tier list",
+    "for round",
+)
+
+# Phrases that clearly request a complete enumeration.
+_ROSTER_LIST_INTENT = (
+    "list",
+    "how many",
+    "name all",
+    "name every",
+    "name the",
+    "are there",
+    "in the game",
+    "exist",
+    "all of the",
+    "what are all",
+)
+
+
+def deterministic_roster_reply(message_text: str) -> str | None:
+    """A clean, code-built roster for a clear LIST request, or ``None``.
+
+    Heroes / towers / paragons enumerated deterministically from the dataset,
+    so the answer is always correct and never tripped by the faithfulness guard
+    (it *is* the source). The natural-language stage sends this as the floor for
+    a roster-list question — the model cannot reliably restate 17+ costs
+    verbatim, so a single mismatched cost refused the whole list. Returns
+    ``None`` for strategy/opinion questions ("which hero is best") so those
+    still reach the model, and for anything that is not a clear enumeration.
+    """
+    text = (message_text or "").lower()
+    if any(word in text for word in _ROSTER_STRATEGY_WORDS):
+        return None
+    is_list = any(phrase in text for phrase in _ROSTER_LIST_INTENT) or (
+        "all " in text or "every " in text
+    )
+    if not is_list:
+        return None
+
+    from services import btd6_data_service
+
+    dataset = btd6_data_service.get_dataset()
+
+    if "paragon" in text:
+        from utils.btd6 import paragon_math
+
+        lines = [
+            f"• **{paragon.name}** — {paragon.tower} "
+            f"(${paragon.base_price_medium:,})"
+            for paragon in paragon_math.PARAGONS
+        ]
+        return (
+            f"**BTD6 Paragons ({len(lines)})** — one per eligible tower, "
+            "base price on medium:\n" + "\n".join(lines)
+        )
+
+    if "hero" in text:
+        lines = [
+            (
+                f"• **{hero.canonical}** — ${hero.base_cost}"
+                if getattr(hero, "base_cost", None)
+                else f"• **{hero.canonical}**"
+            )
+            for hero in dataset.heroes
+        ]
+        return (
+            f"**BTD6 Heroes ({len(lines)})** — base placement cost (medium):"
+            "\n" + "\n".join(lines)
+        )
+
+    if "tower" in text:
+        cats = [c for c in ("primary", "military", "magic", "support") if c in text]
+        towers = [t for t in dataset.towers if not cats or t.category in cats]
+        if not towers:
+            return None
+        if cats:
+            label = "/".join(c.capitalize() for c in cats)
+            body = "\n".join(f"• **{t.canonical}** — ${t.base_cost}" for t in towers)
+            return (
+                f"**BTD6 {label} Towers ({len(towers)})** — base cost "
+                "(medium):\n" + body
+            )
+        out: list[str] = [f"**BTD6 Towers ({len(towers)})** — base cost (medium):"]
+        for cat in ("primary", "military", "magic", "support"):
+            group = [t for t in towers if t.category == cat]
+            if not group:
+                continue
+            out.append(f"__{cat.capitalize()}__")
+            out.extend(f"• **{t.canonical}** — ${t.base_cost}" for t in group)
+        return "\n".join(out)
+
+    return None
+
+
 def _paragon_name_facts(message_text: str, resolved_tower_ids: set[str]) -> list[str]:
     """Ground a paragon named directly (e.g. "what are Glaive Dominus's stats?").
 

--- a/tests/unit/runtime/ai/test_natural_language_stage.py
+++ b/tests/unit/runtime/ai/test_natural_language_stage.py
@@ -1293,10 +1293,13 @@ def _sent_text(msg) -> str:
 
 
 @pytest.mark.asyncio
-async def test_btd6_hallucinated_roster_is_refused(monkeypatch, stub_services):
-    """The five-heroes repro: an ungrounded BTD6 roster never reaches the user;
-    the deterministic version-stamped refusal does, audited as denied /
-    GROUNDING_FAILED."""
+async def test_btd6_roster_question_serves_deterministic_list(
+    monkeypatch, stub_services
+):
+    """The five-heroes repro: the ungrounded roster never reaches the user, but a
+    roster-LIST question is answered with the deterministic, COMPLETE roster (the
+    model can't restate 17 costs verbatim, so the code-built list is the floor) —
+    audited as replied, not refused."""
     from services import ai_gateway
 
     _route_btd6(monkeypatch)
@@ -1317,12 +1320,15 @@ async def test_btd6_hallucinated_roster_is_refused(monkeypatch, stub_services):
     await AINaturalLanguageStage().process(_make_ctx(msg))
 
     sent = _sent_text(msg)
-    assert "five heroes" not in sent  # model text NOT served
-    assert "verified BTD6 data" in sent
-    assert "54.0" in sent  # version-stamped with what the bot serves
-    assert len(calls) == 2  # regenerate-once attempted
-    assert stub_services[-1]["decision"] == "denied"
-    assert stub_services[-1]["reason_code"] is PolicyDenialReason.GROUNDING_FAILED
+    assert "five heroes" not in sent  # the hallucination is NOT served
+    assert "verified BTD6 data" not in sent  # NOT the refusal floor
+    # The complete deterministic roster is served — including heroes the
+    # hallucination omitted.
+    assert "17" in sent
+    assert "Benjamin" in sent and "Sauda" in sent and "Silas" in sent
+    assert len(calls) == 2  # regenerate-once is still attempted first
+    assert stub_services[-1]["decision"] == "replied"
+    assert stub_services[-1]["reason_code"] is PolicyDenialReason.NONE
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_btd6_context_grounding.py
+++ b/tests/unit/services/test_btd6_context_grounding.py
@@ -404,3 +404,33 @@ async def test_build_grounds_tower_roster_with_costs_and_category():
     # A named-entity question ("dart monkey stats") must NOT dump the roster.
     specific = await btd6_context_service.build("dart monkey stats")
     assert not any("tower_roster" in f for f in specific.facts)
+
+
+def test_deterministic_roster_reply_lists_full_rosters():
+    # The model can't restate 17+ costs verbatim, so a list request floors to a
+    # code-built roster that is always correct (it IS the source).
+    heroes = btd6_context_service.deterministic_roster_reply("list all heroes")
+    assert heroes is not None
+    assert "17" in heroes
+    for name in ("Quincy", "Benjamin", "Sauda", "Silas"):
+        assert name in heroes
+    assert "$540" in heroes  # Quincy's cost is code-built
+
+    primary = btd6_context_service.deterministic_roster_reply(
+        "list all primary towers"
+    )
+    assert primary is not None and "Dart Monkey" in primary
+    assert "Sniper Monkey" not in primary  # military tower excluded by category
+
+    paragons = btd6_context_service.deterministic_roster_reply("list all paragons")
+    assert paragons is not None and "Apex Plasma Master" in paragons
+
+
+def test_deterministic_roster_reply_skips_strategy_and_specific_questions():
+    # Recommendation/opinion questions must reach the model, not dump a roster.
+    assert btd6_context_service.deterministic_roster_reply("which hero is best") is None
+    assert (
+        btd6_context_service.deterministic_roster_reply("what tower should I use")
+        is None
+    )
+    assert btd6_context_service.deterministic_roster_reply("dart monkey stats") is None


### PR DESCRIPTION
## Root cause (from your `recent_audit`)

Your audit was the decisive evidence: roster questions were `denied / grounding_failed` on `btd6.answer` even **after** #471 deployed (a fresh failure at 10:37 PM). So #471's cost grounding wasn't enough. I reproduced why:

> A verbose hero list grounds *until* the model states **one** cost that doesn't exactly match the dataset — then the whole 17-hero list is refused (`offending_numbers=('1075',)`).

The costs in #471 are actually correct (dataset `base_cost` == stats `base_cost` == the medium cost Haiku states for the heroes it gets right). The real problem is structural: **requiring all 17 costs to match verbatim is unsatisfiable** — Haiku fills some from memory, and any single mismatch refuses the list.

## Fix: deterministic roster floor

`btd6_context_service.deterministic_roster_reply(text)` — for a clear **list** request (`list all heroes/towers/paragons`, `which heroes are there`, `how many towers`, with `primary/military/magic/support` category filtering) returns a clean bullet-list built straight from the dataset, with costs. It **is** the source, so the guard can never refuse it. Returns `None` for strategy/opinion questions (`which hero is best`, `what tower should I use`) so those still reach the model.

The BTD6 floor in the natural-language stage (both the healthy-empty and the post-retry grounding-failure paths) now sends that roster for a list request — audited `replied / NONE` — instead of the no-data refusal. Non-list questions and provider outages are unchanged.

Example output (clean, "sortlike", what you asked for):
```
**BTD6 Heroes (17)** — base placement cost (medium):
• Quincy — $540
• Gwendolin — $725
…
**BTD6 Towers (25)** — base cost (medium):
__Primary__
• Dart Monkey — $200
…
```

## What is preserved

The faithfulness guard is untouched for everything else — ungrounded stats/names on a *specific* tower/hero/paragon answer are still blocked. This only changes the **floor for clear roster-list questions** from "refuse" to "serve the correct complete list." The five-heroes repro now serves the real 17, not a refusal.

## Verification

`python3.10 scripts/check_quality.py --full` → **7177 passed**. `python3.10 scripts/check_architecture.py --mode strict` → **0 errors**. New tests: `deterministic_roster_reply` lists full rosters / skips strategy questions; the stage serves the deterministic 17-hero list (not a refusal) for the five-heroes repro.

(Note: this is a real code fix, not a redeploy issue — your Railway auto-deploy confirmed the bot was on the latest build and still failing.)

https://claude.ai/code/session_01JXik78XDCPXJmVPuvz5NTY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXik78XDCPXJmVPuvz5NTY)_