### PR TITLE
feat(btd6): wire game-authored hero level descriptions into fixtures + grounding

### DIFF
--- a/disbot/data/btd6/stats/heroes/admiral_brickell.json
+++ b/disbot/data/btd6/stats/heroes/admiral_brickell.json
@@ -150,7 +150,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 1
+      "level": 1,
+      "description": "Drops powerful sea mines that seek out and destroy Bloons."
     },
     "2": {
       "placeableOnLand": false,
@@ -296,7 +297,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 2
+      "level": 2,
+      "description": "Increased attack speed."
     },
     "3": {
       "placeableOnLand": false,
@@ -448,7 +450,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 3
+      "level": 3,
+      "description": "Naval Tactics: greatly increases attack speed of Brickell and nearby Monkey Subs and Monkey Buccaneers for a short time."
     },
     "4": {
       "placeableOnLand": false,
@@ -600,7 +603,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 4
+      "level": 4,
+      "description": "More popping power for Sea Mines."
     },
     "5": {
       "placeableOnLand": false,
@@ -752,7 +756,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 5
+      "level": 5,
+      "description": "Naval Tactics increases popping power and allows affected Monkeys to hit all Bloon types except Camo."
     },
     "6": {
       "placeableOnLand": false,
@@ -904,7 +909,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 6
+      "level": 6,
+      "description": "Increases the damage of Sea Mines and Pistol attacks."
     },
     "7": {
       "placeableOnLand": false,
@@ -1060,7 +1066,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 7
+      "level": 7,
+      "description": "Blast Chain: Sea mines fire off quicker for a short time. Brickell gains increased attack range and Camo Bloon detection."
     },
     "8": {
       "placeableOnLand": false,
@@ -1216,7 +1223,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 8
+      "level": 8,
+      "description": "Naval Tactics allows affected Monkeys to hit Camo Bloons. Water towers in radius gain extra pierce."
     },
     "9": {
       "placeableOnLand": false,
@@ -1372,7 +1380,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 9
+      "level": 9,
+      "description": "Sea Mines do extra damage."
     },
     "10": {
       "placeableOnLand": false,
@@ -1532,7 +1541,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 10
+      "level": 10,
+      "description": "Mega Mine: deploys to any water area a devastating Mine that triggers on MOABs and stuns nearby Bloons. Mega Mines last 3 rounds."
     },
     "11": {
       "placeableOnLand": false,
@@ -1692,7 +1702,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 11
+      "level": 11,
+      "description": "Faster deploy speed and deploy rate for Sea Mines."
     },
     "12": {
       "placeableOnLand": false,
@@ -1852,7 +1863,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 12
+      "level": 12,
+      "description": "Pistol attack increased speed and damage, Sea Mines increased damage."
     },
     "13": {
       "placeableOnLand": false,
@@ -2012,7 +2024,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 13
+      "level": 13,
+      "description": "Mega Mine cooldown reduced."
     },
     "14": {
       "placeableOnLand": false,
@@ -2172,7 +2185,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 14
+      "level": 14,
+      "description": "Naval Tactics duration increased."
     },
     "15": {
       "placeableOnLand": false,
@@ -2332,7 +2346,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 15
+      "level": 15,
+      "description": "Enhanced Sea Mines have larger explosion, can damage Black Bloons and remove Camo property. Pistol does more damage."
     },
     "16": {
       "placeableOnLand": false,
@@ -2492,7 +2507,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 16
+      "level": 16,
+      "description": "Attack and Sea Mine deploy range increased slightly."
     },
     "17": {
       "placeableOnLand": false,
@@ -2652,7 +2668,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 17
+      "level": 17,
+      "description": "Sea Mines do greatly increased damage. Pistol does more damage."
     },
     "18": {
       "placeableOnLand": false,
@@ -2812,7 +2829,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 18
+      "level": 18,
+      "description": "Mega Mine cooldown reduced even further."
     },
     "19": {
       "placeableOnLand": false,
@@ -2972,7 +2990,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 19
+      "level": 19,
+      "description": "Naval Tactics affects all water based towers everywhere."
     },
     "20": {
       "placeableOnLand": false,
@@ -3132,7 +3151,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 20
+      "level": 20,
+      "description": "Mega Mine does massively increased damage and longer stun."
     }
   }
 }

--- a/disbot/data/btd6/stats/heroes/adora.json
+++ b/disbot/data/btd6/stats/heroes/adora.json
@@ -64,7 +64,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 1
+      "level": 1,
+      "description": "Divine Bolt seeks out and destroys."
     },
     "2": {
       "placeableOnLand": true,
@@ -124,7 +125,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 2
+      "level": 2,
+      "description": "Increased attack range."
     },
     "3": {
       "placeableOnLand": true,
@@ -206,7 +208,8 @@
           ]
         }
       ],
-      "level": 3
+      "level": 3,
+      "description": "The Long Arm of Light: Greatly increases attack range and power for a short time & damages all Bloon Types."
     },
     "4": {
       "placeableOnLand": true,
@@ -288,7 +291,8 @@
           ]
         }
       ],
-      "level": 4
+      "level": 4,
+      "description": "Shoots double Divine Bolts."
     },
     "5": {
       "placeableOnLand": true,
@@ -370,7 +374,8 @@
           ]
         }
       ],
-      "level": 5
+      "level": 5,
+      "description": "Divine bolts pierce through more Bloons."
     },
     "6": {
       "placeableOnLand": true,
@@ -452,7 +457,8 @@
           ]
         }
       ],
-      "level": 6
+      "level": 6,
+      "description": "Shoots 3 Divine Bolts at a time."
     },
     "7": {
       "placeableOnLand": true,
@@ -528,7 +534,8 @@
           ]
         }
       ],
-      "level": 7
+      "level": 7,
+      "description": "Blood Sacrifice: Sacrifice a targeted Tower to grant Adora large amounts of XP and boost her attack range and rate of fire for a short time."
     },
     "8": {
       "placeableOnLand": true,
@@ -604,7 +611,8 @@
           ]
         }
       ],
-      "level": 8
+      "level": 8,
+      "description": "Shoots 4 Divine Bolts at a time."
     },
     "9": {
       "placeableOnLand": true,
@@ -681,7 +689,8 @@
           ]
         }
       ],
-      "level": 9
+      "level": 9,
+      "description": "Increased attack range and increased damage to Fortified Bloons."
     },
     "10": {
       "placeableOnLand": true,
@@ -808,7 +817,8 @@
           "targetTypeStrong": true
         }
       ],
-      "level": 10
+      "level": 10,
+      "description": "Ball of Light: Brings forth a powerful ball of energy to strike down the Bloons."
     },
     "11": {
       "placeableOnLand": true,
@@ -935,7 +945,8 @@
           "targetTypeStrong": true
         }
       ],
-      "level": 11
+      "level": 11,
+      "description": "Adora increases attack speed."
     },
     "12": {
       "placeableOnLand": true,
@@ -1062,7 +1073,8 @@
           "targetTypeStrong": true
         }
       ],
-      "level": 12
+      "level": 12,
+      "description": "Shoots 5 Divine Bolts at a time."
     },
     "13": {
       "placeableOnLand": true,
@@ -1189,7 +1201,8 @@
           "targetTypeStrong": true
         }
       ],
-      "level": 13
+      "level": 13,
+      "description": "Divine Bolts pierce through even more Bloons. Increased damage to Fortified Bloons."
     },
     "14": {
       "placeableOnLand": true,
@@ -1316,7 +1329,8 @@
           "targetTypeStrong": true
         }
       ],
-      "level": 14
+      "level": 14,
+      "description": "Shoots 6 Divine Bolts at a time."
     },
     "15": {
       "placeableOnLand": true,
@@ -1443,7 +1457,8 @@
           "targetTypeStrong": true
         }
       ],
-      "level": 15
+      "level": 15,
+      "description": "Divine Bolts burn through an extra Bloon layer, plus Ball of Light deals more damage."
     },
     "16": {
       "placeableOnLand": true,
@@ -1583,7 +1598,8 @@
           "targetTypeStrong": true
         }
       ],
-      "level": 16
+      "level": 16,
+      "description": "Long Arm of Light becomes even more deadly."
     },
     "17": {
       "placeableOnLand": true,
@@ -1723,7 +1739,8 @@
           "targetTypeStrong": true
         }
       ],
-      "level": 17
+      "level": 17,
+      "description": "Adora increases attack speed even more."
     },
     "18": {
       "placeableOnLand": true,
@@ -1863,7 +1880,8 @@
           "targetTypeStrong": true
         }
       ],
-      "level": 18
+      "level": 18,
+      "description": "Shoots 8 Divine Bolts at a time."
     },
     "19": {
       "placeableOnLand": true,
@@ -2003,7 +2021,8 @@
           "targetTypeStrong": true
         }
       ],
-      "level": 19
+      "level": 19,
+      "description": "Increased attack range. Increased damage to Fortified Bloons."
     },
     "20": {
       "placeableOnLand": true,
@@ -2137,7 +2156,8 @@
           "targetTypeStrong": true
         }
       ],
-      "level": 20
+      "level": 20,
+      "description": "Ball of Light is greatly improved, plus increased rate of fire, range, and duration buffs from Sacrifices."
     }
   }
 }

--- a/disbot/data/btd6/stats/heroes/benjamin.json
+++ b/disbot/data/btd6/stats/heroes/benjamin.json
@@ -32,7 +32,8 @@
       "targetTypeClose": false,
       "targetTypeStrong": false,
       "cashPerRound": 90,
-      "level": 1
+      "level": 1,
+      "description": "Hacks in $90 every round."
     },
     "2": {
       "placeableOnLand": true,
@@ -60,7 +61,8 @@
       "targetTypeClose": false,
       "targetTypeStrong": false,
       "cashPerRound": 140,
-      "level": 2
+      "level": 2,
+      "description": "Generates $140 per round instead of $90."
     },
     "3": {
       "placeableOnLand": true,
@@ -94,7 +96,8 @@
       "targetTypeClose": false,
       "targetTypeStrong": false,
       "cashPerRound": 140,
-      "level": 3
+      "level": 3,
+      "description": "Biohack: 4 closest Monkeys pop an extra layer per attack for 6 seconds. Affected Monkeys can't attack for 2 seconds after effect ends."
     },
     "4": {
       "placeableOnLand": true,
@@ -128,7 +131,8 @@
       "targetTypeClose": false,
       "targetTypeStrong": false,
       "cashPerRound": 140,
-      "level": 4
+      "level": 4,
+      "description": "Cyber Security - Restores 5 lives at the end of each round."
     },
     "5": {
       "placeableOnLand": true,
@@ -162,7 +166,8 @@
       "targetTypeClose": false,
       "targetTypeStrong": false,
       "cashPerRound": 140,
-      "level": 5
+      "level": 5,
+      "description": "Bank Hack - all banks earn +5% income."
     },
     "6": {
       "placeableOnLand": true,
@@ -196,7 +201,8 @@
       "targetTypeClose": false,
       "targetTypeStrong": false,
       "cashPerRound": 140,
-      "level": 6
+      "level": 6,
+      "description": "Skimming - earns +$1 for every new Bloon spawned."
     },
     "7": {
       "placeableOnLand": true,
@@ -265,7 +271,8 @@
       "targetTypeClose": false,
       "targetTypeStrong": false,
       "cashPerRound": 140,
-      "level": 7
+      "level": 7,
+      "description": "Bloon Trojan - Every few seconds sends a Trojan software virus to random Bloon. Affected Bloon spawns no children when destroyed and produces 1 extra cash for every layer."
     },
     "8": {
       "placeableOnLand": true,
@@ -334,7 +341,8 @@
       "targetTypeClose": false,
       "targetTypeStrong": false,
       "cashPerRound": 250,
-      "level": 8
+      "level": 8,
+      "description": "Income increased to $250 per round."
     },
     "9": {
       "placeableOnLand": true,
@@ -403,7 +411,8 @@
       "targetTypeClose": false,
       "targetTypeStrong": false,
       "cashPerRound": 250,
-      "level": 9
+      "level": 9,
+      "description": "Bank hack increased to 12%."
     },
     "10": {
       "placeableOnLand": true,
@@ -476,7 +485,8 @@
       "targetTypeClose": false,
       "targetTypeStrong": false,
       "cashPerRound": 250,
-      "level": 10
+      "level": 10,
+      "description": "Syphon Funding: Downgrades most newly spawned Bloons by 1 rank. Cash per pop from affected Bloons is double. Lasts 10 seconds."
     },
     "11": {
       "placeableOnLand": true,
@@ -549,7 +559,8 @@
       "targetTypeClose": false,
       "targetTypeStrong": false,
       "cashPerRound": 1000,
-      "level": 11
+      "level": 11,
+      "description": "Income increased to $1000 per round."
     },
     "12": {
       "placeableOnLand": true,
@@ -622,7 +633,8 @@
       "targetTypeClose": false,
       "targetTypeStrong": false,
       "cashPerRound": 1000,
-      "level": 12
+      "level": 12,
+      "description": "Skimming increased to $2 per Bloon."
     },
     "13": {
       "placeableOnLand": true,
@@ -695,7 +707,8 @@
       "targetTypeClose": false,
       "targetTypeStrong": false,
       "cashPerRound": 1000,
-      "level": 13
+      "level": 13,
+      "description": "Biohack increases bonus damage and affects 6 Monkeys for 8 seconds."
     },
     "14": {
       "placeableOnLand": true,
@@ -768,7 +781,8 @@
       "targetTypeClose": false,
       "targetTypeStrong": false,
       "cashPerRound": 1000,
-      "level": 14
+      "level": 14,
+      "description": "Cyber Security adds 10 lives per round and can go up to 100 over starting lives."
     },
     "15": {
       "placeableOnLand": true,
@@ -841,7 +855,8 @@
       "targetTypeClose": false,
       "targetTypeStrong": false,
       "cashPerRound": 2500,
-      "level": 15
+      "level": 15,
+      "description": "Income increased to $2500 per round."
     },
     "16": {
       "placeableOnLand": true,
@@ -914,7 +929,8 @@
       "targetTypeClose": false,
       "targetTypeStrong": false,
       "cashPerRound": 2500,
-      "level": 16
+      "level": 16,
+      "description": "Bloon Trojan is sent more often and earns more cash."
     },
     "17": {
       "placeableOnLand": true,
@@ -987,7 +1003,8 @@
       "targetTypeClose": false,
       "targetTypeStrong": false,
       "cashPerRound": 5000,
-      "level": 17
+      "level": 17,
+      "description": "Income increased to $5000 per round."
     },
     "18": {
       "placeableOnLand": true,
@@ -1060,7 +1077,8 @@
       "targetTypeClose": false,
       "targetTypeStrong": false,
       "cashPerRound": 5000,
-      "level": 18
+      "level": 18,
+      "description": "Bloon Trojan can affect BFB and DDT Bloons."
     },
     "19": {
       "placeableOnLand": true,
@@ -1133,7 +1151,8 @@
       "targetTypeClose": false,
       "targetTypeStrong": false,
       "cashPerRound": 5000,
-      "level": 19
+      "level": 19,
+      "description": "Biohack lasts 9 seconds and affected Monkeys pop 3 extra layers instead of 2."
     },
     "20": {
       "placeableOnLand": true,
@@ -1206,7 +1225,8 @@
       "targetTypeClose": false,
       "targetTypeStrong": false,
       "cashPerRound": 5000,
-      "level": 20
+      "level": 20,
+      "description": "Syphon Funding lasts 20 seconds and cash per pop is triple normal for affected Bloons."
     }
   }
 }

--- a/disbot/data/btd6/stats/heroes/captain_churchill.json
+++ b/disbot/data/btd6/stats/heroes/captain_churchill.json
@@ -68,7 +68,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 1
+      "level": 1,
+      "description": "Piercing bombs shot from the tank can explode up to 3 times."
     },
     "2": {
       "placeableOnLand": true,
@@ -132,7 +133,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 2
+      "level": 2,
+      "description": "Increased popping power per shot."
     },
     "3": {
       "placeableOnLand": true,
@@ -202,7 +204,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 3
+      "level": 3,
+      "description": "Armor Piercing Shells: Shots can pop Black Bloons and do extra damage to Ceramic Bloons. Duration increases as Churchill levels."
     },
     "4": {
       "placeableOnLand": true,
@@ -272,7 +275,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 4
+      "level": 4,
+      "description": "Increased attack range."
     },
     "5": {
       "placeableOnLand": true,
@@ -377,7 +381,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 5
+      "level": 5,
+      "description": "Adds a fast firing machine gun attack to the tank."
     },
     "6": {
       "placeableOnLand": true,
@@ -482,7 +487,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 6
+      "level": 6,
+      "description": "Binoculars allow Churchill to pop Camo Bloons."
     },
     "7": {
       "placeableOnLand": true,
@@ -587,7 +593,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 7
+      "level": 7,
+      "description": "Weapons deal more damage and shells can explode more times."
     },
     "8": {
       "placeableOnLand": true,
@@ -692,7 +699,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 8
+      "level": 8,
+      "description": "Increased attack speed."
     },
     "9": {
       "placeableOnLand": true,
@@ -797,7 +805,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 9
+      "level": 9,
+      "description": "Shells can explode 5 times."
     },
     "10": {
       "placeableOnLand": true,
@@ -906,7 +915,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 10
+      "level": 10,
+      "description": "MOAB Barrage: Launches a barrage of shells at up to 10 MOAB-Class Bloons on screen, dealing massive damage each time."
     },
     "11": {
       "placeableOnLand": true,
@@ -1015,7 +1025,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 11
+      "level": 11,
+      "description": "Increased popping power per shell."
     },
     "12": {
       "placeableOnLand": true,
@@ -1124,7 +1135,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 12
+      "level": 12,
+      "description": "Weapons get additional increased damage and shells can explode 6 times."
     },
     "13": {
       "placeableOnLand": true,
@@ -1233,7 +1245,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 13
+      "level": 13,
+      "description": "Armor Piercing Shells pop 3 layers of Bloon and do extra damage to Ceramic and higher. MOAB Barrage damage increased."
     },
     "14": {
       "placeableOnLand": true,
@@ -1342,7 +1355,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 14
+      "level": 14,
+      "description": "Main Gun can pop 3 additional layers and Machine Gun can pop 1 additional layer per shot."
     },
     "15": {
       "placeableOnLand": true,
@@ -1457,7 +1471,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 15
+      "level": 15,
+      "description": "All attacks do extra damage vs Camo, Lead, Fortified, and Stunned Bloons."
     },
     "16": {
       "placeableOnLand": true,
@@ -1572,7 +1587,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 16
+      "level": 16,
+      "description": "Armor Piercing Shells do even more damage. MOAB Barrage damage increased."
     },
     "17": {
       "placeableOnLand": true,
@@ -1687,7 +1703,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 17
+      "level": 17,
+      "description": "Increased attack speed."
     },
     "18": {
       "placeableOnLand": true,
@@ -1802,7 +1819,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 18
+      "level": 18,
+      "description": "All shells pop 3 extra layers of Bloon and Machine Gun can pop 1 additional layer."
     },
     "19": {
       "placeableOnLand": true,
@@ -1917,7 +1935,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 19
+      "level": 19,
+      "description": "Shells can explode 7 times."
     },
     "20": {
       "placeableOnLand": true,
@@ -2032,7 +2051,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 20
+      "level": 20,
+      "description": "MOAB Barrage shells, Main Gun, and Machine Gun do massively increased damage per hit."
     }
   }
 }

--- a/disbot/data/btd6/stats/heroes/corvus.json
+++ b/disbot/data/btd6/stats/heroes/corvus.json
@@ -64,7 +64,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 1
+      "level": 1,
+      "description": "Haunted Bloons are weakened and explode when popped, adding Mana to the Mana Pool. The Spirit attacks Bloons anywhere on the map at Corvus' command. Learns: Spear, Nourishment, Repel."
     },
     "2": {
       "placeableOnLand": true,
@@ -124,7 +125,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 2
+      "level": 2,
+      "description": "The Spirit grows in size and can hit more Bloons."
     },
     "3": {
       "placeableOnLand": true,
@@ -190,7 +192,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 3
+      "level": 3,
+      "description": "Soul Harvest ability: Harvests nearby Bloons in an instant. Learns: Echo, Haste."
     },
     "4": {
       "placeableOnLand": true,
@@ -256,7 +259,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 4
+      "level": 4,
+      "description": "The Spirit does more damage. Learns: Soul Barrier, Trample"
     },
     "5": {
       "placeableOnLand": true,
@@ -322,7 +326,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 5
+      "level": 5,
+      "description": "Learns: Frostbound, Aggression, Vision"
     },
     "6": {
       "placeableOnLand": true,
@@ -388,7 +393,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 6
+      "level": 6,
+      "description": "Increased damage when Haunted Bloons explode. The Spirit does more damage. Learns: Ember"
     },
     "7": {
       "placeableOnLand": true,
@@ -540,7 +546,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 7
+      "level": 7,
+      "description": "Spirit Walk ability: Corvus can shift to a valid location. Learns: Ancestral Might, Malevolence"
     },
     "8": {
       "placeableOnLand": true,
@@ -692,7 +699,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 8
+      "level": 8,
+      "description": "Spiritual Balance means the Mana Pool fills faster when it is nearly empty. Haste gives increased speed and agility. Learns: Storm"
     },
     "9": {
       "placeableOnLand": true,
@@ -844,7 +852,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 9
+      "level": 9,
+      "description": "The Spirit's base damage increased and does extra damage to MOABs. Frostbound can hit MOABs. Soul Barrier can block more Bloons from leaking."
     },
     "10": {
       "placeableOnLand": true,
@@ -1000,7 +1009,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 10
+      "level": 10,
+      "description": "Dark Ritual ability: Harvests a huge number of Bloons near Corvus. Trample does more damage to more Bloons. Learns: Recovery"
     },
     "11": {
       "placeableOnLand": true,
@@ -1156,7 +1166,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 11
+      "level": 11,
+      "description": "Spiritual Attunement means the Spirit grows in power as the Mana Pool fills. Soul Harvest does more damage, and extra damage to Ceramic Bloons. Frostbound gains permafrost."
     },
     "12": {
       "placeableOnLand": true,
@@ -1312,7 +1323,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 12
+      "level": 12,
+      "description": "Increased damage when Haunted Bloons explode. Spear does more damage. Repel can push MOABs."
     },
     "13": {
       "placeableOnLand": true,
@@ -1468,7 +1480,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 13
+      "level": 13,
+      "description": "Ancestral Might does more damage. Learns: Overload"
     },
     "14": {
       "placeableOnLand": true,
@@ -1624,7 +1637,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 14
+      "level": 14,
+      "description": "The Spirit does more damage to Bloons. Malevolence does more damage and extra damage to Ceramic Bloons."
     },
     "15": {
       "placeableOnLand": true,
@@ -1780,7 +1794,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 15
+      "level": 15,
+      "description": "Ember's fire drops more often and does more damage. Nourishment gives more XP per Mana."
     },
     "16": {
       "placeableOnLand": true,
@@ -1936,7 +1951,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 16
+      "level": 16,
+      "description": "Corvus has increased range. The Spirit does more damage to Bloons."
     },
     "17": {
       "placeableOnLand": true,
@@ -2092,7 +2108,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 17
+      "level": 17,
+      "description": "Haunted Bloons are weaker, and explosions do more damage. Soul Barrier can block more Bloons from leaking."
     },
     "18": {
       "placeableOnLand": true,
@@ -2248,7 +2265,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 18
+      "level": 18,
+      "description": "Storm's energy blades hit more Bloons and do more damage. Spear does more damage."
     },
     "19": {
       "placeableOnLand": true,
@@ -2404,7 +2422,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 19
+      "level": 19,
+      "description": "Corvus can Haunt MOAB-Class Bloons. Trample does more damage to Bloons."
     },
     "20": {
       "placeableOnLand": true,
@@ -2560,7 +2579,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 20
+      "level": 20,
+      "description": "The Spirit base damage increases and does extra damage to MOABs. Ancestral Might does more damage. Overload does more damage."
     }
   }
 }

--- a/disbot/data/btd6/stats/heroes/etienne.json
+++ b/disbot/data/btd6/stats/heroes/etienne.json
@@ -31,7 +31,8 @@
       "targetTypeLast": false,
       "targetTypeClose": false,
       "targetTypeStrong": false,
-      "level": 1
+      "level": 1,
+      "description": "Flies a deadly little drone around to shoot at the Bloons."
     },
     "2": {
       "placeableOnLand": true,
@@ -58,7 +59,8 @@
       "targetTypeLast": false,
       "targetTypeClose": false,
       "targetTypeStrong": false,
-      "level": 2
+      "level": 2,
+      "description": "Etienne's range increased and Monkeys in radius get 10% more range."
     },
     "3": {
       "placeableOnLand": true,
@@ -91,7 +93,8 @@
       "targetTypeLast": false,
       "targetTypeClose": false,
       "targetTypeStrong": false,
-      "level": 3
+      "level": 3,
+      "description": "Drone Swarm: Etienne launches 4 more temporary drones to wreak some Bloon popping havoc."
     },
     "4": {
       "placeableOnLand": true,
@@ -124,7 +127,8 @@
       "targetTypeLast": false,
       "targetTypeClose": false,
       "targetTypeStrong": false,
-      "level": 4
+      "level": 4,
+      "description": "Drones increase in popping power."
     },
     "5": {
       "placeableOnLand": true,
@@ -157,7 +161,8 @@
       "targetTypeLast": false,
       "targetTypeClose": false,
       "targetTypeStrong": false,
-      "level": 5
+      "level": 5,
+      "description": "Drone increased attack speed and infrared camera allows shooting of Camo Bloons."
     },
     "6": {
       "placeableOnLand": true,
@@ -190,7 +195,8 @@
       "targetTypeLast": false,
       "targetTypeClose": false,
       "targetTypeStrong": false,
-      "level": 6
+      "level": 6,
+      "description": "Drone Swarm ability cooldown reduced."
     },
     "7": {
       "placeableOnLand": true,
@@ -223,7 +229,8 @@
       "targetTypeLast": false,
       "targetTypeClose": false,
       "targetTypeStrong": false,
-      "level": 7
+      "level": 7,
+      "description": "Etienne now controls 2 drones at once."
     },
     "8": {
       "placeableOnLand": true,
@@ -302,7 +309,8 @@
       "targetTypeLast": false,
       "targetTypeClose": false,
       "targetTypeStrong": false,
-      "level": 8
+      "level": 8,
+      "description": "UAV: all Monkeys gain Camo Bloon detection."
     },
     "9": {
       "placeableOnLand": true,
@@ -381,7 +389,8 @@
       "targetTypeLast": false,
       "targetTypeClose": false,
       "targetTypeStrong": false,
-      "level": 9
+      "level": 9,
+      "description": "Drones pop an extra Bloon layer."
     },
     "10": {
       "placeableOnLand": true,
@@ -464,7 +473,8 @@
       "targetTypeLast": false,
       "targetTypeClose": false,
       "targetTypeStrong": false,
-      "level": 10
+      "level": 10,
+      "description": "UCAV: high altitude surveillance drone becomes devastating combat drone for a short time."
     },
     "11": {
       "placeableOnLand": true,
@@ -547,7 +557,8 @@
       "targetTypeLast": false,
       "targetTypeClose": false,
       "targetTypeStrong": false,
-      "level": 11
+      "level": 11,
+      "description": "Etienne gains a third drone to control."
     },
     "12": {
       "placeableOnLand": true,
@@ -630,7 +641,8 @@
       "targetTypeLast": false,
       "targetTypeClose": false,
       "targetTypeStrong": false,
-      "level": 12
+      "level": 12,
+      "description": "Drone upgrades! Increased popping power and flight speed."
     },
     "13": {
       "placeableOnLand": true,
@@ -713,7 +725,8 @@
       "targetTypeLast": false,
       "targetTypeClose": false,
       "targetTypeStrong": false,
-      "level": 13
+      "level": 13,
+      "description": "UCAV ability cooldown reduced."
     },
     "14": {
       "placeableOnLand": true,
@@ -796,7 +809,8 @@
       "targetTypeLast": false,
       "targetTypeClose": false,
       "targetTypeStrong": false,
-      "level": 14
+      "level": 14,
+      "description": "Drones damage increased greatly."
     },
     "15": {
       "placeableOnLand": true,
@@ -879,7 +893,8 @@
       "targetTypeLast": false,
       "targetTypeClose": false,
       "targetTypeStrong": false,
-      "level": 15
+      "level": 15,
+      "description": "UCAV damage output and duration greatly increased."
     },
     "16": {
       "placeableOnLand": true,
@@ -962,7 +977,8 @@
       "targetTypeLast": false,
       "targetTypeClose": false,
       "targetTypeStrong": false,
-      "level": 16
+      "level": 16,
+      "description": "Etienne's range, drone popping power, and Drone Swarm cooldown all improved. Monkeys in radius get 20% more range."
     },
     "17": {
       "placeableOnLand": true,
@@ -1045,7 +1061,8 @@
       "targetTypeLast": false,
       "targetTypeClose": false,
       "targetTypeStrong": false,
-      "level": 17
+      "level": 17,
+      "description": "UCAV damage output greatly increased again!"
     },
     "18": {
       "placeableOnLand": true,
@@ -1128,7 +1145,8 @@
       "targetTypeLast": false,
       "targetTypeClose": false,
       "targetTypeStrong": false,
-      "level": 18
+      "level": 18,
+      "description": "Drone damage increased."
     },
     "19": {
       "placeableOnLand": true,
@@ -1211,7 +1229,8 @@
       "targetTypeLast": false,
       "targetTypeClose": false,
       "targetTypeStrong": false,
-      "level": 19
+      "level": 19,
+      "description": "Etienne now controls four drones all the time!"
     },
     "20": {
       "placeableOnLand": true,
@@ -1294,7 +1313,8 @@
       "targetTypeLast": false,
       "targetTypeClose": false,
       "targetTypeStrong": false,
-      "level": 20
+      "level": 20,
+      "description": "Perma-UCAV: Surveillance drone becomes permanent UCAV. When activated becomes more powerful for a short time and can pop all Bloon types."
     }
   }
 }

--- a/disbot/data/btd6/stats/heroes/ezili.json
+++ b/disbot/data/btd6/stats/heroes/ezili.json
@@ -80,7 +80,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 1
+      "level": 1,
+      "description": "Ezili curses Bloons with dark voodoo power."
     },
     "2": {
       "placeableOnLand": true,
@@ -156,7 +157,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 2
+      "level": 2,
+      "description": "Increased attack range."
     },
     "3": {
       "placeableOnLand": true,
@@ -238,7 +240,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 3
+      "level": 3,
+      "description": "Heartstopper: allows Purple popping and prevents any regrow from happening for 10 seconds."
     },
     "4": {
       "placeableOnLand": true,
@@ -326,7 +329,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 4
+      "level": 4,
+      "description": "Ezili's main attack now curses multiple Bloons."
     },
     "5": {
       "placeableOnLand": true,
@@ -414,7 +418,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 5
+      "level": 5,
+      "description": "Increased attack speed."
     },
     "6": {
       "placeableOnLand": true,
@@ -504,7 +509,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 6
+      "level": 6,
+      "description": "Ezili's attack does far more damage to MOAB-Class Bloons."
     },
     "7": {
       "placeableOnLand": true,
@@ -615,7 +621,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 7
+      "level": 7,
+      "description": "Sacrificial Totem: A totem that gives Camo detection, extra pierce, attack range, attack speed, and projectile speed to nearby Monkeys, especially Wizard Monkeys. Drains 10 lives."
     },
     "8": {
       "placeableOnLand": true,
@@ -726,7 +733,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 8
+      "level": 8,
+      "description": "Damage over time lasts longer and damages faster."
     },
     "9": {
       "placeableOnLand": true,
@@ -837,7 +845,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 9
+      "level": 9,
+      "description": "Ezili's attack strips off Camo, Regrow and Fortified properties from non-MOAB class Bloons."
     },
     "10": {
       "placeableOnLand": true,
@@ -952,7 +961,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 10
+      "level": 10,
+      "description": "MOAB Hex: places a curse on a MOAB-Class Bloon, it takes damage every second until annihilated."
     },
     "11": {
       "placeableOnLand": true,
@@ -1067,7 +1077,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 11
+      "level": 11,
+      "description": "Increased attack range. Increases pierce of reanimated Bloons by 50%."
     },
     "12": {
       "placeableOnLand": true,
@@ -1182,7 +1193,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 12
+      "level": 12,
+      "description": "Heartstopper reduced cooldown and increased duration. Deals increased damage to MOABs."
     },
     "13": {
       "placeableOnLand": true,
@@ -1297,7 +1309,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 13
+      "level": 13,
+      "description": "Base attack has larger splash radius and increased pierce."
     },
     "14": {
       "placeableOnLand": true,
@@ -1412,7 +1425,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 14
+      "level": 14,
+      "description": "Heartstopper lasts much longer."
     },
     "15": {
       "placeableOnLand": true,
@@ -1527,7 +1541,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 15
+      "level": 15,
+      "description": "Damage over time lasts longer and damages faster."
     },
     "16": {
       "placeableOnLand": true,
@@ -1642,7 +1657,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 16
+      "level": 16,
+      "description": "Sacrificial Totem lasts longer and costs only 1 life to use. Main attack removes Camo from DDTs."
     },
     "17": {
       "placeableOnLand": true,
@@ -1757,7 +1773,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 17
+      "level": 17,
+      "description": "Base attack has larger splash radius and increased pierce."
     },
     "18": {
       "placeableOnLand": true,
@@ -1872,7 +1889,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 18
+      "level": 18,
+      "description": "Increased attack speed."
     },
     "19": {
       "placeableOnLand": true,
@@ -1987,7 +2005,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 19
+      "level": 19,
+      "description": "Dark voodoo curse pops more layers with each damage tick."
     },
     "20": {
       "placeableOnLand": true,
@@ -2102,7 +2121,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 20
+      "level": 20,
+      "description": "MOAB Hex works faster and can destroy BAD Bloons."
     }
   }
 }

--- a/disbot/data/btd6/stats/heroes/geraldo.json
+++ b/disbot/data/btd6/stats/heroes/geraldo.json
@@ -57,7 +57,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 1
+      "level": 1,
+      "description": "Available Items! Shooty Turret, Stack of Old Nails, Creepy Idol, Jar of Pickles. Geraldo also has a short range magical attack."
     },
     "2": {
       "placeableOnLand": true,
@@ -110,7 +111,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 2
+      "level": 2,
+      "description": "New Item! Rare Quincy Action Figure - increases in value the longer you possess it!"
     },
     "3": {
       "placeableOnLand": true,
@@ -163,7 +165,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 3
+      "level": 3,
+      "description": "New Item! See Invisibility Potion - grants short term camo detection to a Monkey Tower or Hero. Geraldo's attack range increases."
     },
     "4": {
       "placeableOnLand": true,
@@ -216,7 +219,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 4
+      "level": 4,
+      "description": "New Item! Tube of Amaz-o-Glue - can be placed on the track to slow Bloons down."
     },
     "5": {
       "placeableOnLand": true,
@@ -269,7 +273,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 5
+      "level": 5,
+      "description": "New Item! Sharpening Stone - boosts the pierce of a Monkey Tower or Hero when doing sharp-type damage. Geraldo attacks faster."
     },
     "6": {
       "placeableOnLand": true,
@@ -322,7 +327,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 6
+      "level": 6,
+      "description": "New Item! Worn Hero's Cape - converts a Tier 2 or lower Dart Monkey into a Super Monkey! These converted Super Monkeys can only be upgraded to Tier 3."
     },
     "7": {
       "placeableOnLand": true,
@@ -375,7 +381,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 7
+      "level": 7,
+      "description": "New Item! Blade Trap - when a visible Bloon touches the trap, a Blade Maelstrom goes off. Geraldo's main attack increases in damage and pierce."
     },
     "8": {
       "placeableOnLand": true,
@@ -428,7 +435,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 8
+      "level": 8,
+      "description": "New Item! Bottle of 'Gerry's Fire' - 2.8 million Bloonville units of pure hot sauce fire! Gives a Monkey, Hero, or minion a fiery attack for 5 rounds."
     },
     "9": {
       "placeableOnLand": true,
@@ -481,7 +489,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 9
+      "level": 9,
+      "description": "New Item! Fertilizer - targeted Banana Farms increase production and get a cash bonus over several rounds. Geraldo's main attack blast radius increases."
     },
     "10": {
       "placeableOnLand": true,
@@ -534,7 +543,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 10
+      "level": 10,
+      "description": "New Item! Pet Rabbit - aww what a cute widdle bunny wabbit!"
     },
     "11": {
       "placeableOnLand": true,
@@ -587,7 +597,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 11
+      "level": 11,
+      "description": "New Item! Rejuv Potion - resets all Monkey Tower and Hero cooldowns, restores 50 lives. Geraldo's main attack pierce increases."
     },
     "12": {
       "placeableOnLand": true,
@@ -640,7 +651,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 12
+      "level": 12,
+      "description": "New Item! Genie Bottle - summons a plasma-powered Genie Monkey that lasts for 2 rounds. Creepy Idol can now apply an occasional short stun to passing visible MOAB-class Bloons."
     },
     "13": {
       "placeableOnLand": true,
@@ -693,7 +705,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 13
+      "level": 13,
+      "description": "Shooty Turret fires faster with increased damage, and Stack of Old Nails do more damage."
     },
     "14": {
       "placeableOnLand": true,
@@ -746,7 +759,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 14
+      "level": 14,
+      "description": "See Invisibility Potion grants additional range and lasts longer."
     },
     "15": {
       "placeableOnLand": true,
@@ -799,7 +813,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 15
+      "level": 15,
+      "description": "Sharpening Stone increases pierce even more, and Blade Trap creates a more powerful effect when triggered."
     },
     "16": {
       "placeableOnLand": true,
@@ -852,7 +867,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 16
+      "level": 16,
+      "description": "Stack of Old Nails becomes a Nail Mine, Jar of Pickles grants additional bonus damage vs. Fortified Bloons, and Gerry's Fire gains bonus burny damage and lasts 10 rounds."
     },
     "17": {
       "placeableOnLand": true,
@@ -905,7 +921,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 17
+      "level": 17,
+      "description": "Geraldo's main attack does more damage and Amaz-o-Glue now has a small effect on MOAB-class Bloons."
     },
     "18": {
       "placeableOnLand": true,
@@ -958,7 +975,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 18
+      "level": 18,
+      "description": "Genie gains a second close-target attack. When Creepy Idol expires, it covers nearby MOAB-class Bloons with a Mystical Shroud, causing damage when popped."
     },
     "19": {
       "placeableOnLand": true,
@@ -1011,7 +1029,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 19
+      "level": 19,
+      "description": "Geraldo's main attack greatly improved and See Invisibility Potion gains bonus damage to Camo Bloons."
     },
     "20": {
       "placeableOnLand": true,
@@ -1064,7 +1083,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 20
+      "level": 20,
+      "description": "New Item! Paragon Power Totem - adds paragon power to the next paragon created. Shop restocks fully! Geraldo's main attack does more damage."
     }
   }
 }

--- a/disbot/data/btd6/stats/heroes/gwendolin.json
+++ b/disbot/data/btd6/stats/heroes/gwendolin.json
@@ -57,7 +57,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 1
+      "level": 1,
+      "description": "Blasts Bloons with fire from her pyro gun."
     },
     "2": {
       "placeableOnLand": true,
@@ -110,7 +111,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 2
+      "level": 2,
+      "description": "Slightly increased popping power per shot."
     },
     "3": {
       "placeableOnLand": true,
@@ -212,7 +214,8 @@
           ]
         }
       ],
-      "level": 3
+      "level": 3,
+      "description": "Cocktail of Fire: Hurls a flask of flammable liquid, burning Bloons that pass through the fire."
     },
     "4": {
       "placeableOnLand": true,
@@ -322,7 +325,8 @@
           ]
         }
       ],
-      "level": 4
+      "level": 4,
+      "description": "Heat it up - Every 40 attacks Gwendolin creates a powerful blast wave of fire that pops Bloons and adds fire to nearby Monkeys’ attacks."
     },
     "5": {
       "placeableOnLand": true,
@@ -431,7 +435,8 @@
           ]
         }
       ],
-      "level": 5
+      "level": 5,
+      "description": "Increased popping power. 10% improved attack speed and radius for Ring of Fire, Signal Flare and Dragon's Breath."
     },
     "6": {
       "placeableOnLand": true,
@@ -558,7 +563,8 @@
           ]
         }
       ],
-      "level": 6
+      "level": 6,
+      "description": "Attacks cause a burn effect on target Bloon."
     },
     "7": {
       "placeableOnLand": true,
@@ -668,7 +674,8 @@
           ]
         }
       ],
-      "level": 7
+      "level": 7,
+      "description": "Heat it up has increased radius, Cocktail of Fire is more effective."
     },
     "8": {
       "placeableOnLand": true,
@@ -798,7 +805,8 @@
           ]
         }
       ],
-      "level": 8
+      "level": 8,
+      "description": "Shoots 2 blasts of fire per shot."
     },
     "9": {
       "placeableOnLand": true,
@@ -928,7 +936,8 @@
           ]
         }
       ],
-      "level": 9
+      "level": 9,
+      "description": "Initial hit per blast pops 1 extra layer. Gains increased burn damage and duration for every level."
     },
     "10": {
       "placeableOnLand": true,
@@ -1107,7 +1116,8 @@
           ]
         }
       ],
-      "level": 10
+      "level": 10,
+      "description": "Firestorm: Sets the whole screen alight, burning all Bloons and granting the Heat It Up buff to all Monkeys."
     },
     "11": {
       "placeableOnLand": true,
@@ -1259,7 +1269,8 @@
           ]
         }
       ],
-      "level": 11
+      "level": 11,
+      "description": "Increased attack range, and Cocktail of Fire is more effective."
     },
     "12": {
       "placeableOnLand": true,
@@ -1411,7 +1422,8 @@
           ]
         }
       ],
-      "level": 12
+      "level": 12,
+      "description": "Increased attack speed and increases damage of Heat it Up."
     },
     "13": {
       "placeableOnLand": true,
@@ -1541,7 +1553,8 @@
           ]
         }
       ],
-      "level": 13
+      "level": 13,
+      "description": "Greatly increased popping power, plus projectiles move faster and last longer."
     },
     "14": {
       "placeableOnLand": true,
@@ -1691,7 +1704,8 @@
           ]
         }
       ],
-      "level": 14
+      "level": 14,
+      "description": "Cocktail of Fire does extra damage and sets MOAB class Bloons alight."
     },
     "15": {
       "placeableOnLand": true,
@@ -1863,7 +1877,8 @@
           ]
         }
       ],
-      "level": 15
+      "level": 15,
+      "description": "Increased attack speed and increases damage of Heat it Up."
     },
     "16": {
       "placeableOnLand": true,
@@ -2131,7 +2146,8 @@
           ]
         }
       ],
-      "level": 16
+      "level": 16,
+      "description": "Firestorm has increased duration and does more damage. Purple Bloons are no longer immune to Gwendolin's attacks."
     },
     "17": {
       "placeableOnLand": true,
@@ -2322,7 +2338,8 @@
           ]
         }
       ],
-      "level": 17
+      "level": 17,
+      "description": "Heat it up empowers affected Monkeys to pop 1 extra layer, and do +2 damage to Lead Bloons."
     },
     "18": {
       "placeableOnLand": true,
@@ -2535,7 +2552,8 @@
           ]
         }
       ],
-      "level": 18
+      "level": 18,
+      "description": "Increased attack speed and increases damage of Heat it Up. 20% improved attack speed and radius for Ring of Fire, Signal Flare and Dragon's Breath."
     },
     "19": {
       "placeableOnLand": true,
@@ -2726,7 +2744,8 @@
           ]
         }
       ],
-      "level": 19
+      "level": 19,
+      "description": "Shoots 3 blasts of fire per shot."
     },
     "20": {
       "placeableOnLand": true,
@@ -2984,7 +3003,8 @@
           ]
         }
       ],
-      "level": 20
+      "level": 20,
+      "description": "Firestorm does hugely increased damage."
     }
   }
 }

--- a/disbot/data/btd6/stats/heroes/obyn_greenfoot.json
+++ b/disbot/data/btd6/stats/heroes/obyn_greenfoot.json
@@ -57,7 +57,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 1
+      "level": 1,
+      "description": "Sends wolf spirits to attack the Bloons."
     },
     "2": {
       "placeableOnLand": true,
@@ -110,7 +111,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 2
+      "level": 2,
+      "description": "Nature's Wrath - all Druids in range get +1 pierce."
     },
     "3": {
       "placeableOnLand": true,
@@ -169,7 +171,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 3
+      "level": 3,
+      "description": "Brambles: Creates a spiked bush on the track that can pop 50 Bloons. Lasts multiple rounds if not destroyed."
     },
     "4": {
       "placeableOnLand": true,
@@ -284,7 +287,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 4
+      "level": 4,
+      "description": "Every 18 seconds creates a totem that slows all Bloons near the totem by 30%. Less effective vs MOAB-class Bloons."
     },
     "5": {
       "placeableOnLand": true,
@@ -405,7 +409,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 5
+      "level": 5,
+      "description": "Increased attack speed. Druids of the Jungle have increased range. Grants bonus cash generation to Druids."
     },
     "6": {
       "placeableOnLand": true,
@@ -520,7 +525,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 6
+      "level": 6,
+      "description": "Increased popping power and projectiles move faster."
     },
     "7": {
       "placeableOnLand": true,
@@ -635,7 +641,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 7
+      "level": 7,
+      "description": "Brambles can pop 100 Bloons."
     },
     "8": {
       "placeableOnLand": true,
@@ -750,7 +757,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 8
+      "level": 8,
+      "description": "Nature's ward totems slow Bloons 40%. All Druids in range get Camo detection."
     },
     "9": {
       "placeableOnLand": true,
@@ -865,7 +873,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 9
+      "level": 9,
+      "description": "Obyn deals more damage. Druids of the Storm create larger storms more frequently."
     },
     "10": {
       "placeableOnLand": true,
@@ -984,7 +993,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 10
+      "level": 10,
+      "description": "Wall of Trees: Summons a wall of trees across the track that destroy all Bloons that enter. When full, the trees burst into money."
     },
     "11": {
       "placeableOnLand": true,
@@ -1103,7 +1113,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 11
+      "level": 11,
+      "description": "Nature's Clarity - all Magic Monkeys in range get +5 range and +2 pierce, and Druids get an additional +1 pierce."
     },
     "12": {
       "placeableOnLand": true,
@@ -1222,7 +1233,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 12
+      "level": 12,
+      "description": "Increased attack speed and Magic Monkeys cooldowns reduced by 5%."
     },
     "13": {
       "placeableOnLand": true,
@@ -1341,7 +1353,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 13
+      "level": 13,
+      "description": "Further increased popping power and projectile speed."
     },
     "14": {
       "placeableOnLand": true,
@@ -1460,7 +1473,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 14
+      "level": 14,
+      "description": "Attack pops extra layers."
     },
     "15": {
       "placeableOnLand": true,
@@ -1579,7 +1593,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 15
+      "level": 15,
+      "description": "Nature's Ward slows Bloons by 60%, and has reduced cooldown."
     },
     "16": {
       "placeableOnLand": true,
@@ -1698,7 +1713,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 16
+      "level": 16,
+      "description": "Brambles pop 500 Bloons each and can damage all Bloon types."
     },
     "17": {
       "placeableOnLand": true,
@@ -1817,7 +1833,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 17
+      "level": 17,
+      "description": "Increased attack speed."
     },
     "18": {
       "placeableOnLand": true,
@@ -1936,7 +1953,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 18
+      "level": 18,
+      "description": "Improved Wrath - all Druid of Wrath pops start each round at 200."
     },
     "19": {
       "placeableOnLand": true,
@@ -2055,7 +2073,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 19
+      "level": 19,
+      "description": "Attack pops extra layers."
     },
     "20": {
       "placeableOnLand": true,
@@ -2174,7 +2193,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 20
+      "level": 20,
+      "description": "Wall of Trees can hold a lot more Bloons, and has shorter cooldown."
     }
   }
 }

--- a/disbot/data/btd6/stats/heroes/pat_fusty.json
+++ b/disbot/data/btd6/stats/heroes/pat_fusty.json
@@ -82,7 +82,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 1
+      "level": 1,
+      "description": "Pat slams Bloons into the ground."
     },
     "2": {
       "placeableOnLand": true,
@@ -160,7 +161,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 2
+      "level": 2,
+      "description": "Increase radius of slam attack."
     },
     "3": {
       "placeableOnLand": true,
@@ -244,7 +246,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 3
+      "level": 3,
+      "description": "Rallying Roar: All nearby Monkeys can pop +1 layer for a short time."
     },
     "4": {
       "placeableOnLand": true,
@@ -328,7 +331,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 4
+      "level": 4,
+      "description": "Increased attack speed."
     },
     "5": {
       "placeableOnLand": true,
@@ -429,7 +433,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 5
+      "level": 5,
+      "description": "Sometimes does a powerful slap that pushes Bloons away from the exit."
     },
     "6": {
       "placeableOnLand": true,
@@ -534,7 +539,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 6
+      "level": 6,
+      "description": "Bloons struck by Pat are stunned for a short time."
     },
     "7": {
       "placeableOnLand": true,
@@ -639,7 +645,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 7
+      "level": 7,
+      "description": "Pat has increased pierce and deals more damage."
     },
     "8": {
       "placeableOnLand": true,
@@ -744,7 +751,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 8
+      "level": 8,
+      "description": "Increased attack speed."
     },
     "9": {
       "placeableOnLand": true,
@@ -849,7 +857,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 9
+      "level": 9,
+      "description": "Increased attack range, and Rallying Roar further increases damage of rallied Monkeys."
     },
     "10": {
       "placeableOnLand": true,
@@ -958,7 +967,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 10
+      "level": 10,
+      "description": "Big Squeeze: Grabs a MOAB, BFB, DDT (if visible), or ZOMG and crushes it to bits over 5 seconds."
     },
     "11": {
       "placeableOnLand": true,
@@ -1067,7 +1077,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 11
+      "level": 11,
+      "description": "Attack pops more layers."
     },
     "12": {
       "placeableOnLand": true,
@@ -1176,7 +1187,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 12
+      "level": 12,
+      "description": "Increased attack speed."
     },
     "13": {
       "placeableOnLand": true,
@@ -1285,7 +1297,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 13
+      "level": 13,
+      "description": "Attack stuns Bloons for longer and can stun MOAB-Class Bloons very briefly."
     },
     "14": {
       "placeableOnLand": true,
@@ -1394,7 +1407,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 14
+      "level": 14,
+      "description": "Rallying Roar increased duration and increased damage of rallied monkeys."
     },
     "15": {
       "placeableOnLand": true,
@@ -1503,7 +1517,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 15
+      "level": 15,
+      "description": "Slam and Slap attacks can hit more Bloons."
     },
     "16": {
       "placeableOnLand": true,
@@ -1612,7 +1627,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 16
+      "level": 16,
+      "description": "Pat deals much more damage to Ceramic Bloons."
     },
     "17": {
       "placeableOnLand": true,
@@ -1721,7 +1737,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 17
+      "level": 17,
+      "description": "Increased attack speed."
     },
     "18": {
       "placeableOnLand": true,
@@ -1830,7 +1847,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 18
+      "level": 18,
+      "description": "Increased pierce."
     },
     "19": {
       "placeableOnLand": true,
@@ -1939,7 +1957,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 19
+      "level": 19,
+      "description": "Attack pops more layers."
     },
     "20": {
       "placeableOnLand": true,
@@ -2048,7 +2067,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 20
+      "level": 20,
+      "description": "Big Squeeze can hug several big Bloons at once, with such intensity nearby Bloons are left stunned!"
     }
   }
 }

--- a/disbot/data/btd6/stats/heroes/psi.json
+++ b/disbot/data/btd6/stats/heroes/psi.json
@@ -55,7 +55,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 1
+      "level": 1,
+      "description": "Over any range or obstacle, Psi sets up deadly vibrations that completely destroy one Bloon at a time. Can target Camo."
     },
     "2": {
       "placeableOnLand": true,
@@ -106,7 +107,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 2
+      "level": 2,
+      "description": "The psionic vibrations destroy Bloons faster than normal."
     },
     "3": {
       "placeableOnLand": true,
@@ -163,7 +165,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 3
+      "level": 3,
+      "description": "Psychic Blast: Psi unleashes a wave of power that stuns nearby Bloons for a long time."
     },
     "4": {
       "placeableOnLand": true,
@@ -239,7 +242,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 4
+      "level": 4,
+      "description": "Psi's attack can hit another Bloon if very close to the targeted Bloon."
     },
     "5": {
       "placeableOnLand": true,
@@ -315,7 +319,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 5
+      "level": 5,
+      "description": "Attacks slightly faster."
     },
     "6": {
       "placeableOnLand": true,
@@ -391,7 +396,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 6
+      "level": 6,
+      "description": "Psi's powerful mind can penetrate through Lead Bloons."
     },
     "7": {
       "placeableOnLand": true,
@@ -467,7 +473,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 7
+      "level": 7,
+      "description": "Psychic Blast pulses twice. Psi can now destroy Ceramic Bloons."
     },
     "8": {
       "placeableOnLand": true,
@@ -562,7 +569,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 8
+      "level": 8,
+      "description": "Destructive Resonance causes Bloons destroyed by Psi's main attack to damage other Bloons nearby."
     },
     "9": {
       "placeableOnLand": true,
@@ -749,7 +757,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 9
+      "level": 9,
+      "description": "Split the Mind. Psi can now target two different Bloons at once."
     },
     "10": {
       "placeableOnLand": true,
@@ -921,7 +930,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 10
+      "level": 10,
+      "description": "Psionic Scream: Psi unleashes a silent scream that throws the Bloons into utter chaos."
     },
     "11": {
       "placeableOnLand": true,
@@ -1093,7 +1103,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 11
+      "level": 11,
+      "description": "Not even Purple Bloons can resist the power of Psi's mind attacks."
     },
     "12": {
       "placeableOnLand": true,
@@ -1265,7 +1276,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 12
+      "level": 12,
+      "description": "Psychic Blast pulses three times."
     },
     "13": {
       "placeableOnLand": true,
@@ -1437,7 +1449,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 13
+      "level": 13,
+      "description": "The psionic vibrations destroy Bloons even faster."
     },
     "14": {
       "placeableOnLand": true,
@@ -1609,7 +1622,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 14
+      "level": 14,
+      "description": "Psi's immense psychic power allows targeting and destruction of MOABs."
     },
     "15": {
       "placeableOnLand": true,
@@ -1781,7 +1795,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 15
+      "level": 15,
+      "description": "Destructive Resonance is more destructive."
     },
     "16": {
       "placeableOnLand": true,
@@ -1953,7 +1968,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 16
+      "level": 16,
+      "description": "The psionic vibrations destroy Bloons very fast. Psi can now target BFBs."
     },
     "17": {
       "placeableOnLand": true,
@@ -2198,7 +2214,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 17
+      "level": 17,
+      "description": "Split the Mind. Psi can now target three different Bloons at once."
     },
     "18": {
       "placeableOnLand": true,
@@ -2443,7 +2460,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 18
+      "level": 18,
+      "description": "Psi's attacks affect Bloons within a larger radius of the target Bloon."
     },
     "19": {
       "placeableOnLand": true,
@@ -2688,7 +2706,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 19
+      "level": 19,
+      "description": "Destructive Resonance is much much more destructive."
     },
     "20": {
       "placeableOnLand": true,
@@ -2933,7 +2952,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 20
+      "level": 20,
+      "description": "Psionic Scream holds and damages all Bloons on screen. Psi can now target DDTs and ZOMGs."
     }
   }
 }

--- a/disbot/data/btd6/stats/heroes/quincy.json
+++ b/disbot/data/btd6/stats/heroes/quincy.json
@@ -62,7 +62,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 1
+      "level": 1,
+      "description": "Quincy's arrows bounce to up to 3 different targets."
     },
     "2": {
       "placeableOnLand": true,
@@ -120,7 +121,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 2
+      "level": 2,
+      "description": "Base attack bounces to up to 4 targets."
     },
     "3": {
       "placeableOnLand": true,
@@ -195,7 +197,8 @@
           ]
         }
       ],
-      "level": 3
+      "level": 3,
+      "description": "Rapid Shot: Triple attack speed for a short time."
     },
     "4": {
       "placeableOnLand": true,
@@ -270,7 +273,8 @@
           ]
         }
       ],
-      "level": 4
+      "level": 4,
+      "description": "Slightly longer range."
     },
     "5": {
       "placeableOnLand": true,
@@ -345,7 +349,8 @@
           ]
         }
       ],
-      "level": 5
+      "level": 5,
+      "description": "Uses his sharp eyesight to shoot Camo Bloons."
     },
     "6": {
       "placeableOnLand": true,
@@ -423,7 +428,8 @@
           ]
         }
       ],
-      "level": 6
+      "level": 6,
+      "description": "Shoots 2 arrows at a time."
     },
     "7": {
       "placeableOnLand": true,
@@ -492,7 +498,8 @@
           ]
         }
       ],
-      "level": 7
+      "level": 7,
+      "description": "Fires exploding arrows every 3rd shot."
     },
     "8": {
       "placeableOnLand": true,
@@ -592,7 +599,8 @@
           ]
         }
       ],
-      "level": 8
+      "level": 8,
+      "description": "Arrows do triple damage to MOAB-Class Bloons."
     },
     "9": {
       "placeableOnLand": true,
@@ -671,7 +679,8 @@
           ]
         }
       ],
-      "level": 9
+      "level": 9,
+      "description": "Base attack bounces to up to 6 targets."
     },
     "10": {
       "placeableOnLand": true,
@@ -784,7 +793,8 @@
           "lifespan": 0
         }
       ],
-      "level": 10
+      "level": 10,
+      "description": "Storm of Arrows: Covers a large area in a deadly rain of arrows."
     },
     "11": {
       "placeableOnLand": true,
@@ -897,7 +907,8 @@
           "lifespan": 0
         }
       ],
-      "level": 11
+      "level": 11,
+      "description": "Increased attack speed."
     },
     "12": {
       "placeableOnLand": true,
@@ -1010,7 +1021,8 @@
           "lifespan": 0
         }
       ],
-      "level": 12
+      "level": 12,
+      "description": "Each arrow gets more popping power."
     },
     "13": {
       "placeableOnLand": true,
@@ -1089,7 +1101,8 @@
           ]
         }
       ],
-      "level": 13
+      "level": 13,
+      "description": "Small range increase and Rapid Shot lasts longer."
     },
     "14": {
       "placeableOnLand": true,
@@ -1189,7 +1202,8 @@
           ]
         }
       ],
-      "level": 14
+      "level": 14,
+      "description": "Arrows do quad damage to MOAB-Class Bloons."
     },
     "15": {
       "placeableOnLand": true,
@@ -1289,7 +1303,8 @@
           ]
         }
       ],
-      "level": 15
+      "level": 15,
+      "description": "Rapid Shot becomes x4 attack speed and cooldown is reduced."
     },
     "16": {
       "placeableOnLand": true,
@@ -1389,7 +1404,8 @@
           ]
         }
       ],
-      "level": 16
+      "level": 16,
+      "description": "More increased attack speed."
     },
     "17": {
       "placeableOnLand": true,
@@ -1468,7 +1484,8 @@
           ]
         }
       ],
-      "level": 17
+      "level": 17,
+      "description": "Arrows last 25% longer. Fires exploding arrows every 2nd shot."
     },
     "18": {
       "placeableOnLand": true,
@@ -1582,7 +1599,8 @@
           "lifespan": 0
         }
       ],
-      "level": 18
+      "level": 18,
+      "description": "Quincy attacks faster and Storm of Arrows is greatly enhanced."
     },
     "19": {
       "placeableOnLand": true,
@@ -1696,7 +1714,8 @@
           "lifespan": 0
         }
       ],
-      "level": 19
+      "level": 19,
+      "description": "Shoots 3 arrows at a time, and each arrow gets even more popping power."
     },
     "20": {
       "placeableOnLand": true,
@@ -1810,7 +1829,8 @@
           "lifespan": 0
         }
       ],
-      "level": 20
+      "level": 20,
+      "description": "Quincy attacks even faster. Storm of Arrows deals more damage per arrow and fires even more arrows."
     }
   }
 }

--- a/disbot/data/btd6/stats/heroes/rosalia.json
+++ b/disbot/data/btd6/stats/heroes/rosalia.json
@@ -30,7 +30,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 1
+      "level": 1,
+      "description": "Rosalia jets around her workshop equipped with a powerful laser."
     },
     "2": {
       "placeableOnLand": true,
@@ -56,7 +57,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 2
+      "level": 2,
+      "description": "Grenade attack unlocked! Switch between weapons to deal with all sorts of Bloons."
     },
     "3": {
       "placeableOnLand": true,
@@ -88,7 +90,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 3
+      "level": 3,
+      "description": "Scatter Missile ability: Rosalia's Workshop launches a missile that rains destruction from above."
     },
     "4": {
       "placeableOnLand": true,
@@ -120,7 +123,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 4
+      "level": 4,
+      "description": "Adrenaline Rush. Rosalia attacks faster the more Bloons are nearby!"
     },
     "5": {
       "placeableOnLand": true,
@@ -152,7 +156,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 5
+      "level": 5,
+      "description": "Rosalia’s attacks are improved, grenades can bounce multiple times, and weapons fire an enhanced shot every 10th attack."
     },
     "6": {
       "placeableOnLand": true,
@@ -184,7 +189,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 6
+      "level": 6,
+      "description": "Aircraft Efficiency. Monkey Aces and Heli Pilots placed near the workshop have all upgrade costs reduced."
     },
     "7": {
       "placeableOnLand": true,
@@ -220,7 +226,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 7
+      "level": 7,
+      "description": "Upgraded Jetpack! Rosalia hovers above the battlefield. Flight Boost ability: for a short time all nearby aircraft fly faster & Rosalia pursues Bloons over the whole map, using both weapons!"
     },
     "8": {
       "placeableOnLand": true,
@@ -256,7 +263,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 8
+      "level": 8,
+      "description": "Grenades deal more damage, and Laser deals much more damage to MOAB-Class Bloons."
     },
     "9": {
       "placeableOnLand": true,
@@ -292,7 +300,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 9
+      "level": 9,
+      "description": "Scatter Missile releases more mini-missiles when used."
     },
     "10": {
       "placeableOnLand": true,
@@ -332,7 +341,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 10
+      "level": 10,
+      "description": "Kinetic Charge ability: Charge attaches to a Bloon, harnessing energy when the target takes damage. Then releases accumulated energy in a huge detonation."
     },
     "11": {
       "placeableOnLand": true,
@@ -372,7 +382,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 11
+      "level": 11,
+      "description": "Adrenaline Rush. Maximum attack rate boost increased."
     },
     "12": {
       "placeableOnLand": true,
@@ -412,7 +423,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 12
+      "level": 12,
+      "description": "Grenades become much bouncier and Laser deals more damage!"
     },
     "13": {
       "placeableOnLand": true,
@@ -452,7 +464,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 13
+      "level": 13,
+      "description": "Rosalia’s attacks are improved with Bouncy Grenades now also creating cluster explosions, Lasers upgrading to Plasma, and even stronger enhanced 10th attacks."
     },
     "14": {
       "placeableOnLand": true,
@@ -492,7 +505,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 14
+      "level": 14,
+      "description": "Scatter Missile deals more damage, especially to MOABs!"
     },
     "15": {
       "placeableOnLand": true,
@@ -532,7 +546,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 15
+      "level": 15,
+      "description": "Laser attack deals much more damage to MOAB-Class Bloons, and Grenades deal more to Ceramic Bloons."
     },
     "16": {
       "placeableOnLand": true,
@@ -572,7 +587,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 16
+      "level": 16,
+      "description": "Kinetic Charge and Scatter Missile cooldowns reduced."
     },
     "17": {
       "placeableOnLand": true,
@@ -612,7 +628,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 17
+      "level": 17,
+      "description": "Adrenaline Rush. Maximum attack rate boost increased."
     },
     "18": {
       "placeableOnLand": true,
@@ -652,7 +669,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 18
+      "level": 18,
+      "description": "Flight Boost cooldown greatly reduced."
     },
     "19": {
       "placeableOnLand": true,
@@ -692,7 +710,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 19
+      "level": 19,
+      "description": "Rosalia’s attacks are improved, Grenades have larger clusters and Laser deals even more damage to MOAB-Class Bloons."
     },
     "20": {
       "placeableOnLand": true,
@@ -732,7 +751,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 20
+      "level": 20,
+      "description": "Guardian Automaton: The Anti-Bloon’s upgrade cost is reduced by 30%. Scatter Missile now fires triple the missiles, and Kinetic Charge damage is greatly increased."
     }
   }
 }

--- a/disbot/data/btd6/stats/heroes/sauda.json
+++ b/disbot/data/btd6/stats/heroes/sauda.json
@@ -58,7 +58,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 1
+      "level": 1,
+      "description": "Slashes with both swords at nearby Bloons. Can pop Camo."
     },
     "2": {
       "placeableOnLand": true,
@@ -112,7 +113,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 2
+      "level": 2,
+      "description": "Pops more Bloons per attack."
     },
     "3": {
       "placeableOnLand": true,
@@ -223,7 +225,8 @@
           ]
         }
       ],
-      "level": 3
+      "level": 3,
+      "description": "Leaping Sword Attack: Sauda's dramatic Lead popping leap attack slams down on her targeted Bloons."
     },
     "4": {
       "placeableOnLand": true,
@@ -312,7 +315,8 @@
           ]
         }
       ],
-      "level": 4
+      "level": 4,
+      "description": "Sauda's swords slice through 2 layers of Bloons."
     },
     "5": {
       "placeableOnLand": true,
@@ -401,7 +405,8 @@
           ]
         }
       ],
-      "level": 5
+      "level": 5,
+      "description": "Sauda attacks faster."
     },
     "6": {
       "placeableOnLand": true,
@@ -490,7 +495,8 @@
           ]
         }
       ],
-      "level": 6
+      "level": 6,
+      "description": "Increased attack range and popping power."
     },
     "7": {
       "placeableOnLand": true,
@@ -619,7 +625,8 @@
           ]
         }
       ],
-      "level": 7
+      "level": 7,
+      "description": "Sauda preys on the Bloons' weakness, doing extra damage if they are stunned, and she can now pop frozen Bloons."
     },
     "8": {
       "placeableOnLand": true,
@@ -720,7 +727,8 @@
           ]
         }
       ],
-      "level": 8
+      "level": 8,
+      "description": "Sauda attacks even faster."
     },
     "9": {
       "placeableOnLand": true,
@@ -856,7 +864,8 @@
           ]
         }
       ],
-      "level": 9
+      "level": 9,
+      "description": "Bloon Bleed: Sauda pops through 3 layers of Bloon with each strike, and causes a slow damage over time effect."
     },
     "10": {
       "placeableOnLand": true,
@@ -1030,7 +1039,8 @@
           ]
         }
       ],
-      "level": 10
+      "level": 10,
+      "description": "Sword Charge: Sauda slides along the whole track, devastating Bloons as she goes."
     },
     "11": {
       "placeableOnLand": true,
@@ -1232,7 +1242,8 @@
           ]
         }
       ],
-      "level": 11
+      "level": 11,
+      "description": "Sauda inflicts extra damage to any Bloon slowed, immobilized, or taking damage over time from other monkeys."
     },
     "12": {
       "placeableOnLand": true,
@@ -1396,7 +1407,8 @@
           ]
         }
       ],
-      "level": 12
+      "level": 12,
+      "description": "Leaping Sword Attack increases greatly in power."
     },
     "13": {
       "placeableOnLand": true,
@@ -1532,7 +1544,8 @@
           ]
         }
       ],
-      "level": 13
+      "level": 13,
+      "description": "Enchanted blades do more damage and allow Sauda to damage all Bloons."
     },
     "14": {
       "placeableOnLand": true,
@@ -1668,7 +1681,8 @@
           ]
         }
       ],
-      "level": 14
+      "level": 14,
+      "description": "Sauda attacks even faster, and Sword Charge sweeps all track paths two times!"
     },
     "15": {
       "placeableOnLand": true,
@@ -1870,7 +1884,8 @@
           ]
         }
       ],
-      "level": 15
+      "level": 15,
+      "description": "Increased attack range and popping power, and Leaping Sword Attack deals more damage."
     },
     "16": {
       "placeableOnLand": true,
@@ -2044,7 +2059,8 @@
           ]
         }
       ],
-      "level": 16
+      "level": 16,
+      "description": "Sword Charge greatly increased damage."
     },
     "17": {
       "placeableOnLand": true,
@@ -2180,7 +2196,8 @@
           ]
         }
       ],
-      "level": 17
+      "level": 17,
+      "description": "Sauda's sword attacks slice through many Bloon layers at once."
     },
     "18": {
       "placeableOnLand": true,
@@ -2316,7 +2333,8 @@
           ]
         }
       ],
-      "level": 18
+      "level": 18,
+      "description": "Sauda's swords attack with a blur of speed."
     },
     "19": {
       "placeableOnLand": true,
@@ -2518,7 +2536,8 @@
           ]
         }
       ],
-      "level": 19
+      "level": 19,
+      "description": "Enchanted Blades do extra damage to Regrow, Fortified, and Camo Bloons."
     },
     "20": {
       "placeableOnLand": true,
@@ -2720,7 +2739,8 @@
           ]
         }
       ],
-      "level": 20
+      "level": 20,
+      "description": "More powerful Sword Charge sweeps all track paths three times! Leaping Sword power greatly increased."
     }
   }
 }

--- a/disbot/data/btd6/stats/heroes/silas.json
+++ b/disbot/data/btd6/stats/heroes/silas.json
@@ -74,7 +74,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 1
+      "level": 1,
+      "description": "Silas attacks with magical ice. Hit Bloons are rimed. Already rimed Bloons are frozen. Already rimed and frozen Bloons burst in an icy explosion. Bloons are slowed near Silas."
     },
     "2": {
       "placeableOnLand": true,
@@ -144,7 +145,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 2
+      "level": 2,
+      "description": "Ice Monkeys in radius create orbiting Ice Fragment projectiles when they attack."
     },
     "3": {
       "placeableOnLand": true,
@@ -220,7 +222,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 3
+      "level": 3,
+      "description": "Frostbite ability: Silas can hit all Bloons while active. When hitting frozen Bloons, target takes extra damage based on remaining freeze time."
     },
     "4": {
       "placeableOnLand": true,
@@ -333,7 +336,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 4
+      "level": 4,
+      "description": "Ice Walls form on the track near Silas. Ice Walls push back and freeze Bloons. MOABs are frozen for less time."
     },
     "5": {
       "placeableOnLand": true,
@@ -446,7 +450,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 5
+      "level": 5,
+      "description": "White Bloons are less resistant to Ice attacks. Monkeys that freeze Bloons freeze them for longer."
     },
     "6": {
       "placeableOnLand": true,
@@ -559,7 +564,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 6
+      "level": 6,
+      "description": "Silas can attack Bloons in the range of Ice Monkeys anywhere."
     },
     "7": {
       "placeableOnLand": true,
@@ -676,7 +682,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 7
+      "level": 7,
+      "description": "Frozen Cascade ability: Creates a shattering blast of ice around Silas then other Ice Monkeys spreading out from Silas. Frozen Bloons take extra damage from ability."
     },
     "8": {
       "placeableOnLand": true,
@@ -793,7 +800,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 8
+      "level": 8,
+      "description": "Buffs the ranges of all Ice Monkeys & grants more Hero XP for each Tier 3 Ice Monkey."
     },
     "9": {
       "placeableOnLand": true,
@@ -910,7 +918,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 9
+      "level": 9,
+      "description": "Frozen Bloons damaged during Frostbite take more damage. Ice Fragment damage & pierce increased."
     },
     "10": {
       "placeableOnLand": true,
@@ -1031,7 +1040,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 10
+      "level": 10,
+      "description": "Frozen Burial ability: Immediately freezes and damages all Bloons, dealing far more damage to already frozen Bloons. Then fills the track with Ice Walls."
     },
     "11": {
       "placeableOnLand": true,
@@ -1152,7 +1162,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 11
+      "level": 11,
+      "description": "Slowing aura around Silas slows Bloons more, and can slow MOABs. Rime slows MOABs by more."
     },
     "12": {
       "placeableOnLand": true,
@@ -1273,7 +1284,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 12
+      "level": 12,
+      "description": "Ice Walls can hit more Bloons and last longer. Rime explosion does more damage."
     },
     "13": {
       "placeableOnLand": true,
@@ -1394,7 +1406,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 13
+      "level": 13,
+      "description": "Ice Monkey Tier 5s are cheaper, and you can build a 4th Tier 5 of any path. White Bloons lose all resistance to Ice attacks."
     },
     "14": {
       "placeableOnLand": true,
@@ -1515,7 +1528,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 14
+      "level": 14,
+      "description": "Ice Monkeys create more orbiting Ice Fragments when they attack."
     },
     "15": {
       "placeableOnLand": true,
@@ -1636,7 +1650,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 15
+      "level": 15,
+      "description": "Frozen Bloons take more damage from all abilities. Frostbite lasts longer, and Frozen Cascade and Frozen Burial have shorter cooldowns."
     },
     "16": {
       "placeableOnLand": true,
@@ -1757,7 +1772,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 16
+      "level": 16,
+      "description": "Rime explosion does even more damage, and orbiting Ice Fragments do more damage to frozen Bloons."
     },
     "17": {
       "placeableOnLand": true,
@@ -1878,7 +1894,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 17
+      "level": 17,
+      "description": "Tier 3 Ice Monkeys create even more orbiting Ice Fragments."
     },
     "18": {
       "placeableOnLand": true,
@@ -1999,7 +2016,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 18
+      "level": 18,
+      "description": "Slowing aura around Silas slows Bloons even more. Rimed Bloons take even more damage from Ice attacks, rime explosion damage increased even further."
     },
     "19": {
       "placeableOnLand": true,
@@ -2120,7 +2138,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 19
+      "level": 19,
+      "description": "Ice Walls have more pierce & lifespan. Ice Fragments pierce more and deal even more damage to frozen Bloons."
     },
     "20": {
       "placeableOnLand": true,
@@ -2241,7 +2260,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 20
+      "level": 20,
+      "description": "Frozen Bloons take even more damage during Frostbite. Silas creates Ice Walls more often. Monkeys that freeze Bloons freeze them yet longer again."
     }
   }
 }

--- a/disbot/data/btd6/stats/heroes/striker_jones.json
+++ b/disbot/data/btd6/stats/heroes/striker_jones.json
@@ -77,7 +77,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 1
+      "level": 1,
+      "description": "Striker Jones shoots a powerful bazooka to explode the Bloons and push them back on hit."
     },
     "2": {
       "placeableOnLand": true,
@@ -137,7 +138,8 @@
       "targetTypeLast": true,
       "targetTypeClose": true,
       "targetTypeStrong": true,
-      "level": 2
+      "level": 2,
+      "description": "Increased blast radius."
     },
     "3": {
       "placeableOnLand": true,
@@ -285,7 +287,8 @@
           ]
         }
       ],
-      "level": 3
+      "level": 3,
+      "description": "Concussive Shell: Shoots a guided shell following target priority, stunning whatever Bloon it hits."
     },
     "4": {
       "placeableOnLand": true,
@@ -444,7 +447,8 @@
           "filterInBaseTowerId": "Bomb Shooter, Mortar Monkey"
         }
       ],
-      "level": 4
+      "level": 4,
+      "description": "All Bomb Shooters and Mortar Monkeys on screen shoot 10% faster."
     },
     "5": {
       "placeableOnLand": true,
@@ -610,7 +614,8 @@
           "chance": 0.5
         }
       ],
-      "level": 5
+      "level": 5,
+      "description": "Makes all Black Bloons less resistant to explosive damage from all Monkeys."
     },
     "6": {
       "placeableOnLand": true,
@@ -776,7 +781,8 @@
           "chance": 0.5
         }
       ],
-      "level": 6
+      "level": 6,
+      "description": "Blast radius and pops for Jones' normal attacks increases greatly."
     },
     "7": {
       "placeableOnLand": true,
@@ -864,7 +870,8 @@
           "chance": 0.5
         }
       ],
-      "level": 7
+      "level": 7,
+      "description": "Pops 4 layers per shot and Mortar Monkeys blast radius increased by 10%. Target Focus: For 15 seconds Mortar Monkeys target touch/cursor with increased accuracy."
     },
     "8": {
       "placeableOnLand": true,
@@ -952,7 +959,8 @@
           "chance": 0.5
         }
       ],
-      "level": 8
+      "level": 8,
+      "description": "Towers near the hero get +5% range and +25% pierce."
     },
     "9": {
       "placeableOnLand": true,
@@ -1096,7 +1104,8 @@
           "chance": 0.5
         }
       ],
-      "level": 9
+      "level": 9,
+      "description": "Increased attack speed and increased Concussive Shell pierce, damage, and stun."
     },
     "10": {
       "placeableOnLand": true,
@@ -1248,7 +1257,8 @@
           "chance": 0.5
         }
       ],
-      "level": 10
+      "level": 10,
+      "description": "Artillery Command: Resets cooldown on all Bomb Shooters and Mortar Monkeys."
     },
     "11": {
       "placeableOnLand": true,
@@ -1400,7 +1410,8 @@
           "chance": 0.5
         }
       ],
-      "level": 11
+      "level": 11,
+      "description": "Increased attack speed."
     },
     "12": {
       "placeableOnLand": true,
@@ -1552,7 +1563,8 @@
           "chance": 0.5
         }
       ],
-      "level": 12
+      "level": 12,
+      "description": "Slightly increased attack range and pops 2 extra layers per shot."
     },
     "13": {
       "placeableOnLand": true,
@@ -1704,7 +1716,8 @@
           "chance": 0.5
         }
       ],
-      "level": 13
+      "level": 13,
+      "description": "Increased attack speed."
     },
     "14": {
       "placeableOnLand": true,
@@ -1848,7 +1861,8 @@
           "chance": 0.5
         }
       ],
-      "level": 14
+      "level": 14,
+      "description": "Concussive Shell affects a larger area and for a longer duration."
     },
     "15": {
       "placeableOnLand": true,
@@ -1992,7 +2006,8 @@
           "chance": 0.5
         }
       ],
-      "level": 15
+      "level": 15,
+      "description": "Concussive Shell cooldown reduced to 11 seconds."
     },
     "16": {
       "placeableOnLand": true,
@@ -2136,7 +2151,8 @@
           "chance": 0.5
         }
       ],
-      "level": 16
+      "level": 16,
+      "description": "Increased attack speed."
     },
     "17": {
       "placeableOnLand": true,
@@ -2280,7 +2296,8 @@
           "chance": 0.5
         }
       ],
-      "level": 17
+      "level": 17,
+      "description": "Increased range and pops 8 layers per shot."
     },
     "18": {
       "placeableOnLand": true,
@@ -2424,7 +2441,8 @@
           "chance": 0.5
         }
       ],
-      "level": 18
+      "level": 18,
+      "description": "All Bomb Shooters and Mortar Monkeys attack an additional 10% faster."
     },
     "19": {
       "placeableOnLand": true,
@@ -2568,7 +2586,8 @@
           "chance": 1
         }
       ],
-      "level": 19
+      "level": 19,
+      "description": "Increased attack speed and makes all Black Bloons vulnerable to explosive damage."
     },
     "20": {
       "placeableOnLand": true,
@@ -2720,7 +2739,8 @@
           "chance": 1
         }
       ],
-      "level": 20
+      "level": 20,
+      "description": "Artillery Command also gives double damage and pops per shot to all Bomb Shooters and Mortar Monkeys for 10 seconds."
     }
   }
 }

--- a/disbot/services/btd6_context_service.py
+++ b/disbot/services/btd6_context_service.py
@@ -563,8 +563,11 @@ def _normal_stat_bits(ns: Any) -> list[str]:
 
 
 # Headline hero levels for AI grounding — start, the two usual ability tiers,
-# and max. Keeps grounding bounded rather than dumping all 20 levels.
+# and max. Keeps the (verbose) stat lines bounded rather than dumping all 20.
 _HERO_GROUNDING_LEVELS: tuple[str, ...] = ("1", "3", "10", "20")
+# All hero levels, in order — used for the short per-level *description* lines
+# (which, unlike stats, are surfaced for every level a hero defines).
+_HERO_LEVEL_CODES_ALL: tuple[str, ...] = tuple(str(n) for n in range(1, 21))
 
 
 def _render_hero_stats(hero_id: str, canonical: str) -> list[str]:
@@ -593,6 +596,40 @@ def _render_hero_stats(hero_id: str, canonical: str) -> list[str]:
                 f"{_sanitise(', '.join(bits))} (source: bloonswiki)",
             ),
         )
+    return lines
+
+
+def _render_hero_descriptions(hero_id: str, canonical: str) -> list[str]:
+    """Per-level game-authored prose as ``[btd6_hero_level]`` grounding lines.
+
+    Heroes have no upgrade cards — they level 1..20, and the game stores a
+    description per level (e.g. *Ezili L11 → "+50% pierce to reanimated
+    Bloons"*). Unlike the verbose stat lines (bounded to 4 headline levels),
+    these are short, so every level a hero defines is surfaced — making
+    "what does <hero> level N do?" answerable for any N — bounded by the
+    20-level max and emitted only for a specifically-named hero.
+    """
+    from services import btd6_stats_service
+
+    stats = btd6_stats_service.get_hero_stats(hero_id)
+    if stats is None:
+        return []
+    suffix = " (source: BTD6 in-game description)"
+    lines: list[str] = []
+    for code in _HERO_LEVEL_CODES_ALL:
+        node = stats.level(code)
+        if not isinstance(node, dict):
+            continue
+        desc = _sanitise(node.get("description", "") or "")
+        if not desc:
+            continue
+        # Budget the prose so the provenance suffix always survives — _cap would
+        # otherwise chop the source label off a long description.
+        prefix = f"[btd6_hero_level] {canonical} Level {code}: "
+        budget = _FACT_TEXT_CAP - len(prefix) - len(suffix)
+        if budget < len(desc):
+            desc = desc[: max(budget - 1, 0)].rstrip() + "…"
+        lines.append(f"{prefix}{desc}{suffix}")
     return lines
 
 
@@ -681,7 +718,9 @@ def _render_fixture_hero(entry: Any) -> list[str]:
             ),
         )
 
-    lines.extend(_render_hero_stats(getattr(entry, "id", ""), canonical))
+    hero_id = getattr(entry, "id", "")
+    lines.extend(_render_hero_stats(hero_id, canonical))
+    lines.extend(_render_hero_descriptions(hero_id, canonical))
     return lines
 
 

--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -226,12 +226,19 @@ curator-supplied name is preserved, never regressed to an internal model string.
      purpose — these are **verbatim, derived** game strings that SHOULD refresh
      on every dump re-pull, unlike the curated/paraphrased paragon prose the
      sidecar exists to protect.
-   - *Follow-on (not done):* **ability descriptions** are effectively covered
-     because abilities are granted by upgrade tiers (the `AbilityModel.description`
-     field is empty in the dump). **Hero-level descriptions**
-     (`"<Hero> Level N Description"` in `textTable`, e.g. *Ezili L11 → "+50%
-     pierce to reanimated Bloons"*) are a **separate** extraction the mapper does
-     not yet do — a clean next slice.
+   - **Ability descriptions** are effectively covered because abilities are
+     granted by upgrade tiers (the `AbilityModel.description` field is empty in
+     the dump).
+   - **Hero-level descriptions** — ✅ **done (2026-06-03).** `map_hero` now reads
+     `textTable "<InternalHero> Level N Description"` per level; the same
+     `--descriptions` writer (`apply_hero_descriptions`) populates all **340**
+     committed hero levels (17 heroes × 20), names-frozen. The runtime grounds
+     them via `btd6_context_service._render_hero_descriptions` →
+     `[btd6_hero_level] <Hero> Level N: <prose> (source: BTD6 in-game
+     description)`, surfaced per named hero (all defined levels, so e.g. *Ezili
+     L11 → "+50% pierce to reanimated Bloons"* is answerable). The renderer
+     budgets the prose so the provenance suffix is never truncated by the
+     240-char fact cap.
 
 3. **Name-preservation guard** — ✅ **done (2026-06-03).** `parse_gamedata.py`
    now carries `collect_names` / `name_downgrades` / `assert_names_preserved`

--- a/scripts/parse_gamedata.py
+++ b/scripts/parse_gamedata.py
@@ -752,6 +752,7 @@ def map_hero(dump: Path, hero_id: str, canonical: str, version: str) -> MapResul
     warnings: list[str] = []
     base = json.loads(base_fp.read_text("utf-8"))
 
+    tt = _text_table(dump)
     levels: dict[str, dict] = {}
     for level in range(1, 21):
         # Heroes: one file per level, named "<Folder> N.json" (level 1 is base).
@@ -763,6 +764,11 @@ def map_hero(dump: Path, hero_id: str, canonical: str, version: str) -> MapResul
             continue
         node = _map_tier(model)
         node["level"] = level
+        # Game-authored "what this level grants" prose, keyed by the internal
+        # hero name (the dump's textTable prefix == the folder name).
+        description = tt.get(f"{folder} Level {level} Description")
+        if isinstance(description, str) and description:
+            node["description"] = description
         levels[str(level)] = node
     if not levels:
         warnings.append("no level files found")
@@ -1313,12 +1319,37 @@ def apply_upgrade_descriptions(committed: dict, mapped: dict) -> list[str]:
     return changes
 
 
-def overlay_descriptions(dump: Path, *, dry_run: bool) -> dict[str, list[str]]:
-    """Write game-authored upgrade descriptions onto every curated tower file.
-    Heroes (no upgrades) and paragons (curated sidecar prose) are out of scope.
-    Returns ``{relative_path: [change, …]}`` for files that changed.
+def apply_hero_descriptions(committed: dict, mapped: dict) -> list[str]:
+    """Set each committed hero level's ``description`` from the mapped (game)
+    prose, aligned by level key; return the list of changes. Names are frozen.
     """
-    towers, _heroes = build_allowlist(dump)
+    names_before = collect_names(committed)
+    mlevels = mapped.get("levels", {}) or {}
+    changes: list[str] = []
+    for code, node in (committed.get("levels", {}) or {}).items():
+        if not isinstance(node, dict):
+            continue
+        new = (mlevels.get(code) or {}).get("description")
+        if not isinstance(new, str) or not new.strip():
+            continue
+        if node.get("description") != new:
+            verb = "set" if not node.get("description") else "refreshed"
+            node["description"] = new
+            changes.append(f"level[{code}].description {verb}")
+    assert_names_preserved(
+        names_before,
+        collect_names(committed),
+        label="hero-descriptions",
+    )
+    return changes
+
+
+def overlay_descriptions(dump: Path, *, dry_run: bool) -> dict[str, list[str]]:
+    """Write game-authored descriptions onto curated tower files (per-upgrade)
+    and hero files (per-level). Paragons (curated sidecar prose) are out of
+    scope. Returns ``{relative_path: [change, …]}`` for files that changed.
+    """
+    towers, heroes = build_allowlist(dump)
     version = _dump_version(dump)
     report: dict[str, list[str]] = {}
     for tid, canonical in towers.items():
@@ -1330,6 +1361,17 @@ def overlay_descriptions(dump: Path, *, dry_run: bool) -> dict[str, list[str]]:
         changes = apply_upgrade_descriptions(committed, mapped)
         if changes:
             report[f"stats/{tid}.json"] = changes
+            if not dry_run:
+                _write(fp, committed)
+    for hid, canonical in heroes.items():
+        fp = _STATS_DIR / "heroes" / f"{hid}.json"
+        if not fp.exists():
+            continue
+        committed = json.loads(fp.read_text("utf-8"))
+        mapped = map_hero(dump, hid, canonical, version).payload
+        changes = apply_hero_descriptions(committed, mapped)
+        if changes:
+            report[f"stats/heroes/{hid}.json"] = changes
             if not dry_run:
                 _write(fp, committed)
     return report

--- a/tests/unit/scripts/test_parse_gamedata.py
+++ b/tests/unit/scripts/test_parse_gamedata.py
@@ -701,3 +701,34 @@ def test_apply_upgrade_descriptions_never_downgrades_a_name(mod):
     mapped = {"upgrades": []}
     mod.apply_upgrade_descriptions(committed, mapped)  # no-op, name intact
     assert committed["name"] == "Druid"
+
+
+# --- hero per-level description overlay (step 4b) ---------------------------
+
+
+def test_apply_hero_descriptions_aligns_by_level(mod):
+    committed = {
+        "levels": {
+            "1": {"level": 1, "range": 30},
+            "11": {"level": 11, "range": 35},
+        },
+    }
+    mapped = {
+        "levels": {
+            "1": {"description": "Curses Bloons with dark voodoo power."},
+            "11": {"description": "Increases pierce of reanimated Bloons by 50%."},
+            "12": {"description": "unmatched level — ignored"},
+        },
+    }
+    changes = mod.apply_hero_descriptions(committed, mapped)
+    assert committed["levels"]["1"]["description"].startswith("Curses Bloons")
+    assert "50%" in committed["levels"]["11"]["description"]
+    assert committed["levels"]["1"]["range"] == 30  # stats untouched
+    assert len(changes) == 2
+
+
+def test_apply_hero_descriptions_skips_empty(mod):
+    committed = {"levels": {"1": {"level": 1}}}
+    mapped = {"levels": {"1": {"description": ""}}}
+    assert mod.apply_hero_descriptions(committed, mapped) == []
+    assert "description" not in committed["levels"]["1"]

--- a/tests/unit/services/test_btd6_context_grounding.py
+++ b/tests/unit/services/test_btd6_context_grounding.py
@@ -438,3 +438,32 @@ def test_deterministic_roster_reply_skips_strategy_and_specific_questions():
         is None
     )
     assert btd6_context_service.deterministic_roster_reply("dart monkey stats") is None
+
+
+# --- hero per-level game descriptions (step 4b) -----------------------------
+
+
+def test_render_hero_descriptions_grounds_every_defined_level():
+    lines = btd6_context_service._render_hero_descriptions("ezili", "Ezili")
+    # Ezili defines all 20 levels; each grounds one tagged, sourced line.
+    assert len(lines) == 20
+    assert all(ln.startswith("[btd6_hero_level] Ezili Level ") for ln in lines)
+    assert all("(source: BTD6 in-game description)" in ln for ln in lines)
+
+
+def test_render_hero_descriptions_surfaces_the_l11_showcase():
+    # The doc's marquee case: Ezili L11 grants +50% pierce to reanimated Bloons.
+    lines = btd6_context_service._render_hero_descriptions("ezili", "Ezili")
+    l11 = next(ln for ln in lines if "Level 11:" in ln)
+    assert "reanimated Bloons by 50%" in l11
+
+
+def test_render_hero_descriptions_empty_for_unknown_hero():
+    assert btd6_context_service._render_hero_descriptions("not_a_hero", "Nope") == []
+
+
+async def test_build_grounds_hero_level_descriptions():
+    ctx = await btd6_context_service.build("what does Ezili do at level 11?")
+    levels = [f for f in ctx.facts if "[btd6_hero_level] Ezili Level 11:" in f]
+    assert len(levels) == 1
+    assert "reanimated Bloons by 50%" in levels[0]


### PR DESCRIPTION
## What & why

The clean follow-on to #474. Heroes have **no upgrade cards** — they level 1→20, and the game stores per-level prose as `textTable "<InternalHero> Level N Description"` (e.g. *Ezili L11 → "Increased attack range. Increases pierce of reanimated Bloons by 50%."*). The mapper extracted hero *stats* but not these descriptions; this wires them end-to-end, completing the "in-game description" coverage for heroes and mirroring the upgrade-description pattern.

Anchor gate re-validated (SHA `a3348a89`, Dart 200 / Super 2500); the data write is names-frozen by the #473 guard.

## Data (inline, refreshes per dump)
- `map_hero` now reads `"<folder> Level N Description"` per level. The `--descriptions` writer gains `apply_hero_descriptions`, and `overlay_descriptions` extends to hero files.
- **340/340** hero levels (17 heroes × 20) now carry the game prose, names-frozen via `assert_names_preserved`. Inline (derived/verbatim → should refresh on every dump re-pull), not a curated sidecar — same rationale as the upgrade cards.
- Towers are untouched (their descriptions landed in #474); the data diff is hero-only.

## Runtime
- `btd6_context_service._render_hero_descriptions` reads `HeroStats.levels` and emits
  `[btd6_hero_level] <Hero> Level N: <prose> (source: BTD6 in-game description)`, wired into `_render_fixture_hero` so it grounds per **named** hero.
- **Design choice:** unlike the verbose stat lines (bounded to 4 headline levels), the descriptions are short, so I surface *every* defined level for the named hero. This makes "what does `<hero>` level N do?" answerable for any N — a 1/3/10/20 subset would miss the doc's showcase (Ezili L11). Bounded per-named-hero (≤20 short lines).
- The renderer **budgets the prose length** so the `(source: …)` provenance suffix is never chopped by the 240-char fact cap (a latent truncation bug in the naive `prefix+desc+suffix` form).

Verified end-to-end: `build("what does Ezili do at level 11?")` grounds the L11 line.

## Tests / CI
- New: hero level-description join (mapper, `(level)`-aligned + name-freeze + empty/unmatched skip); grounding incl. the L11 showcase, the all-levels count, and the unknown-hero case.
- `python3.10 scripts/check_quality.py --full` → **7203 passed, 3 skipped**; `check_architecture --mode strict` clean.

## Scope
Faithfulness guard, towers cutover, and cosmetic skip-domains untouched. With this, the **in-game-description half** of the end goal is complete for upgrades + abilities-via-upgrades + hero levels. **Next:** step 5 — zone/buff effect decode (the "stat-based effect" half), using the ranked worklist from #473.

https://claude.ai/code/session_01PtRrhCT9KCdukWnUzUEQH6

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtRrhCT9KCdukWnUzUEQH6)_