### PR TITLE
fix(btd6): surface damage modifiers in AI grounding + stamp dataset v55

### DIFF
--- a/disbot/data/btd6/bloons.json
+++ b/disbot/data/btd6/bloons.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "data_version": "2.0",
-  "game_version": "54.0",
+  "game_version": "55.0",
   "source": "bloonswiki.com Cargo btd6_bloons (CC BY-NC-SA)",
   "bloons": [
     {

--- a/disbot/data/btd6/heroes.json
+++ b/disbot/data/btd6/heroes.json
@@ -1,6 +1,6 @@
 {
   "data_version": "1.0",
-  "game_version": "54.0",
+  "game_version": "55.0",
   "source": "hand-curated from public BTD6 reference data",
   "heroes": [
     {

--- a/disbot/data/btd6/towers.json
+++ b/disbot/data/btd6/towers.json
@@ -1,6 +1,6 @@
 {
   "data_version": "1.0",
-  "game_version": "54.0",
+  "game_version": "55.0",
   "source": "hand-curated from public BTD6 reference data",
   "towers": [
     {

--- a/disbot/services/btd6_upgrade_detail_service.py
+++ b/disbot/services/btd6_upgrade_detail_service.py
@@ -15,8 +15,11 @@ on the **Reanimate** attack's projectile, not the main one. This model keeps
 every attack/minion/buff addressable so those questions resolve.
 
 Purely additive and read-only: it reads the two services above and changes
-neither. Wiring :func:`grounding_for_query` into the AI grounding path is a
-separate, behaviour-changing step left for review.
+neither. :func:`grounding_for_query` is wired into the AI grounding path via
+``btd6_context_service.build`` (its fixture-fallback pass), and the per-projectile
+``modifiers`` surface the curated ``damageModifierFor*`` bonuses (e.g. *+3 vs
+Ceramic*) the UI embed already shows, so the model can ground bonus-damage
+answers instead of refusing them.
 """
 
 from __future__ import annotations
@@ -27,6 +30,7 @@ from typing import Any
 from services import btd6_stats_service, btd6_upgrade_service
 from services.btd6_stats_service import NormalStats
 from services.btd6_upgrade_service import UpgradeIdentity
+from utils.btd6.damage_types import DAMAGE_MODIFIER_LABELS
 
 _MAX_LINE = 320
 _PATH_LABEL = {"top": "top", "mid": "middle", "bot": "bottom"}
@@ -44,7 +48,11 @@ class ProjectileSpec:
     radius: float | None
     lifespan: float | None
     can_see_camo: bool
-    moab_bonus: int | None
+    # Additive damage bonuses vs bloon classes, as ``(label, +bonus)`` in a
+    # stable order (e.g. ``("Ceramic", 3)``). Surfaces the curated
+    # ``damageModifierFor*`` numbers the UI embed already shows, so the AI can
+    # ground "bonus damage vs Lead/Ceramic/Fortified" answers.
+    modifiers: tuple[tuple[str, int], ...]
 
 
 @dataclass(frozen=True)
@@ -117,6 +125,18 @@ def _camo(node: dict[str, Any]) -> bool:
     return not bool(node.get("filterInvisible"))
 
 
+def _modifiers(proj: dict[str, Any]) -> tuple[tuple[str, int], ...]:
+    """``(label, +bonus)`` for every non-zero ``damageModifierFor*`` on a
+    projectile, in the shared canonical order (mirrors the stats embed).
+    """
+    out: list[tuple[str, int]] = []
+    for field_name, label in DAMAGE_MODIFIER_LABELS:
+        value = proj.get(field_name)
+        if isinstance(value, (int, float)) and value:
+            out.append((label, int(value)))
+    return tuple(out)
+
+
 def _projectile(proj: dict[str, Any]) -> ProjectileSpec:
     return ProjectileSpec(
         name=str(proj.get("name") or "Projectile"),
@@ -127,7 +147,7 @@ def _projectile(proj: dict[str, Any]) -> ProjectileSpec:
         radius=proj.get("radius"),
         lifespan=proj.get("lifespan"),
         can_see_camo=_camo(proj),
-        moab_bonus=proj.get("damageModifierForMoabs"),
+        modifiers=_modifiers(proj),
     )
 
 
@@ -299,8 +319,8 @@ def _projectile_bits(proj: ProjectileSpec) -> str:
                 else f"{proj.pierce} pierce"
             ),
         )
-    if proj.moab_bonus:
-        bits.append(f"+{proj.moab_bonus} vs MOAB-class")
+    for label, bonus in proj.modifiers:
+        bits.append(f"+{bonus} vs {label}")
     return ", ".join(bits)
 
 

--- a/disbot/utils/btd6/damage_types.py
+++ b/disbot/utils/btd6/damage_types.py
@@ -34,6 +34,24 @@ _DAMAGE_TYPES: dict[int, tuple[str, str]] = {
 
 _UNKNOWN = ("Unknown", "Unknown immunities")
 
+# Additive damage-modifier field -> short label (the bloon class the bonus
+# applies to). The single source of truth shared by the stats embed (Discord
+# UI, ``utils.btd6.stats_embed``) and the AI grounding renderer
+# (``services.btd6_upgrade_detail_service``) so both surface the same set —
+# the bonus values live in the curated stats as ``damageModifierFor*`` (the
+# additive read from the dump's misspelled ``damageAddative``).
+DAMAGE_MODIFIER_LABELS: tuple[tuple[str, str], ...] = (
+    ("damageModifierForLead", "Lead"),
+    ("damageModifierForCeramic", "Ceramic"),
+    ("damageModifierForFortified", "Fortified"),
+    ("damageModifierForMoab", "MOABs"),
+    ("damageModifierForMoabs", "MOAB-Class"),
+    ("damageModifierForBoss", "Bosses"),
+    ("damageModifierForBad", "BADs"),
+    ("damageModifierForCamo", "Camo"),
+    ("damageModifierForStunned", "stunned"),
+)
+
 
 @dataclass(frozen=True)
 class DamageType:

--- a/disbot/utils/btd6/stats_embed.py
+++ b/disbot/utils/btd6/stats_embed.py
@@ -19,19 +19,11 @@ from typing import Any
 import discord
 
 from utils.btd6 import tier_codes
+from utils.btd6.damage_types import DAMAGE_MODIFIER_LABELS
 
 # Damage-modifier field -> short label (the bloon class the bonus applies to).
-_DAMAGE_MODIFIERS: tuple[tuple[str, str], ...] = (
-    ("damageModifierForLead", "Lead"),
-    ("damageModifierForCeramic", "Ceramic"),
-    ("damageModifierForFortified", "Fortified"),
-    ("damageModifierForMoab", "MOABs"),
-    ("damageModifierForMoabs", "MOAB-Class"),
-    ("damageModifierForBoss", "Bosses"),
-    ("damageModifierForBad", "BADs"),
-    ("damageModifierForCamo", "Camo"),
-    ("damageModifierForStunned", "stunned"),
-)
+# Shared with the AI grounding renderer via the single source in damage_types.
+_DAMAGE_MODIFIERS = DAMAGE_MODIFIER_LABELS
 
 _PUSH_MULTIPLIERS: tuple[tuple[str, str], ...] = (
     ("pushMultiplierForMoab", "MOAB"),

--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -52,6 +52,22 @@ must not be treated as done. Verified against the v55 dump on 2026-06-03.
 > (`live_entities=() ct_relics=()`), so a pricing answer's grounding cannot carry
 > CT lines. Base is solid; data work proceeded.
 
+> **Retrieval-surface + version-stamp fixes (2026-06-03, from live Discord
+> testing).** Two issues surfaced that were *not* data gaps:
+> 1. *Damage modifiers were extracted but unreachable.* The committed stats carry
+>    per-projectile `damageModifierFor*` (e.g. Juggernaut +3 vs Ceramic, +2 vs
+>    Fortified) and the Discord embed renders them, but the **AI grounding
+>    renderer** (`btd6_upgrade_detail_service`) only emitted `moab_bonus`, so the
+>    model couldn't ground "bonus vs Lead/Ceramic/Fortified" and refused.
+>    Fixed: `ProjectileSpec.modifiers` now carries all bonuses (shared
+>    `utils.btd6.damage_types.DAMAGE_MODIFIER_LABELS`, deduped with the embed) and
+>    `_projectile_bits` emits them. *Lesson: extracted ≠ reachable ≠ answerable —
+>    a tool/renderer must surface a field, not just the file containing it.*
+> 2. *Stale dataset version stamp.* The refusal stamped "54.0" — read from the
+>    dataset `game_version` (`towers/heroes/bloons.json`), the single source. Bumped
+>    to **55.0**, justified by the audit (committed numbers are 0-SUSPECT /
+>    overwhelmingly CLEAN vs the v55 dump, i.e. already v55-accurate).
+
 ### ✅ Complete & verified
 
 | Item | Where | Evidence |

--- a/tests/unit/services/test_btd6_upgrade_detail_service.py
+++ b/tests/unit/services/test_btd6_upgrade_detail_service.py
@@ -177,3 +177,45 @@ def test_missing_description_grounds_no_phantom_line():
     assert lines  # still grounds
     assert not any("in-game description" in ln for ln in lines)
     assert any("main attack" in ln for ln in lines)
+
+
+# --- damage modifiers in grounding (bonus vs bloon class) -------------------
+
+
+def test_projectile_carries_damage_modifiers():
+    # Juggernaut (4-0-0) gets +3 vs Ceramic, +2 vs Fortified — the curated
+    # damageModifierFor* numbers must reach the read model, not just MOAB bonus.
+    d = det.get_upgrade_detail("dart_monkey:400")  # Juggernaut = top path tier 4
+    assert d is not None
+    main = _attack(d, "Attack")
+    assert main is not None
+    mods = dict(main.projectiles[0].modifiers)
+    assert mods.get("Ceramic") == 3
+    assert mods.get("Fortified") == 2
+
+
+def test_grounding_surfaces_bonus_vs_bloon_class():
+    # The retrieval-gap regression: the bot could recite the prose ("crushes
+    # Ceramic/Fortified") but not the numbers. Now the numbers ground.
+    blob = "\n".join(det.grounding_for_query("Juggernaut"))
+    assert "+3 vs Ceramic" in blob
+    assert "+2 vs Fortified" in blob
+
+
+def test_grounding_surfaces_lead_bonus_on_ultra_juggernaut():
+    # "Ultra-Juggernaut" resolves ambiguous by name (Juggernaut substring), so
+    # render the id (0-0-5 top path = "500") directly.
+    blob = "\n".join(
+        det.render_upgrade_grounding(det.get_upgrade_detail("dart_monkey:500")),
+    )
+    assert "+20 vs Lead" in blob
+    assert "+8 vs Ceramic" in blob
+
+
+def test_modifiers_empty_when_none_present():
+    # The base dart (tier-1 top) has no damage modifiers — no phantom bonus lines.
+    d = det.get_upgrade_detail("dart_monkey:100")
+    assert d is not None
+    main = _attack(d, "Attack")
+    assert main is not None
+    assert main.projectiles[0].modifiers == ()


### PR DESCRIPTION
## What & why

Two issues surfaced by live Discord testing (screenshots). **Neither is a data gap** — a full data-verification pass confirmed the committed files are complete and correct (25 towers / 17 heroes / 13 paragons, 713 clean descriptions, 0 SUSPECT in the audit). These are a *retrieval-surface* gap and a *stale label*.

### 1. Damage modifiers were extracted but unreachable (the substantive fix)
The bot fluently recited Juggernaut's prose ("pops Lead, crushes Ceramic/Fortified") but **refused** the next question — "list any damage multipliers or bonus damage vs certain bloons" — even though the numbers are right there in the committed stats (`damageModifierForCeramic: 3`, `damageModifierForFortified: 2`) and the **Discord embed already renders them**.

Root cause (confirmed): the AI grounding renderer `btd6_upgrade_detail_service` extracted **only** `moab_bonus` from each projectile and dropped Lead/Ceramic/Fortified/Camo/Boss. So `btd6_lookup` ran, the grounding came back **without** the modifier numbers, and the faithfulness guard correctly refused them. This is the project's recurring lesson in miniature: **extracted ≠ reachable ≠ answerable** — a renderer must surface a field, not just the file that holds it.

**Fix:** `ProjectileSpec.modifiers` now carries every `damageModifierFor*` bonus and `_projectile_bits` emits `+N vs <class>`. The `(field → label)` mapping is promoted to a single shared source — `utils.btd6.damage_types.DAMAGE_MODIFIER_LABELS` — and the stats embed now points at it too (dedupe, no drift between UI and AI).

Result (verified end-to-end through `build()`):
`[btd6_upgrade] Juggernaut — main attack: 2 dmg, 60 pierce, +3 vs Ceramic, +2 vs Fortified, 1s cooldown …`

### 2. Stale dataset version stamp
The refusal stamped "54.0". It's **not a hardcoded constant** — it reads the dataset `game_version` (`towers/heroes/bloons.json`, the single source, also `btd6_knowledge_service.game_version()`). Bumped to **55.0**, justified by the audit: the committed numbers are **0-SUSPECT / overwhelmingly CLEAN vs the v55 dump** — i.e. already v55-accurate, alongside the v55 anchors and descriptions. (The per-file provenance labels still vary; the *dataset* stamp now reflects the version the data is reconciled against.)

## Diagnostic note on the screenshots
- "Juggernaut bare refused, disambiguated form answered" → confirmed a **name-resolution** miss, not missing data (the entity grounds fully once resolved). Not changed here.
- The multipliers refusal maps to the *"extracted but not reachable"* branch — the tool was wired and ran; the renderer dropped the fields. Fixed above (does not require step 5).

## Tests / CI
- New: per-projectile modifier extraction + grounding (Juggernaut +3 Ceramic / +2 Fortified, Ultra-Juggernaut +20 Lead / +8 Ceramic, and empty-when-none).
- `python3.10 scripts/check_quality.py --full` → **7207 passed, 3 skipped**; `check_architecture --mode strict` clean.

## Scope
Faithfulness guard untouched (it behaved correctly throughout — it refused ungrounded numbers, which is the point). Zone/buff effect decode (step 5) remains a genuine *data* gap, separate from this *reachability* fix.

https://claude.ai/code/session_01PtRrhCT9KCdukWnUzUEQH6

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtRrhCT9KCdukWnUzUEQH6)_