### PR TITLE
fix(btd6): correct percentage-buff rendering + buff/zone decode analysis (step 5 slice 1)

### DIFF
--- a/disbot/services/btd6_upgrade_detail_service.py
+++ b/disbot/services/btd6_upgrade_detail_service.py
@@ -176,32 +176,46 @@ def _ability(ability: dict[str, Any]) -> AbilitySpec:
     )
 
 
-# Buff field -> readable formatter. Only the headline effect fields; structural
-# fields (isGlobal, maxStackSize, filters) are intentionally omitted.
-_BUFF_FIELDS: tuple[tuple[str, str], ...] = (
-    ("damageAdditive", "+{} damage"),
-    ("damageMultiplier", "x{} damage"),
-    ("damageAdditiveForMoabs", "+{} damage vs MOAB-class"),
-    ("damageAdditiveForCeramic", "+{} damage vs Ceramic"),
-    ("damageAdditiveForBad", "+{} damage vs BAD"),
-    ("pierceAdditive", "+{} pierce"),
-    ("pierceMultiplier", "x{} pierce"),
-    ("piercePercentage", "+{}% pierce"),
-    ("rateMultiplier", "x{} attack cooldown"),
-    ("ratePercentage", "{}% attack speed"),
-    ("rangeAdditive", "+{} range"),
-    ("rangeMultiplier", "x{} range"),
-    ("rangePercentage", "+{}% range"),
-    ("lifespanMultiplier", "x{} lifespan"),
-    ("abilityCooldownMultiplier", "x{} ability cooldown"),
+# Buff field -> (readable formatter, scale). Only the headline effect fields;
+# structural fields (isGlobal, maxStackSize, filters) are intentionally omitted.
+# Percentage fields are stored as fractions in the data (0.15 = 15%), so they
+# carry a x100 scale — without it the render read "+0.15% pierce" (wrong: it is
+# +15%). The fraction is faithful to the dump (PoplustSupportModel
+# ``ratePercentIncrease: 0.15``); the percent is a display concern.
+_BUFF_FIELDS: tuple[tuple[str, str, int], ...] = (
+    ("damageAdditive", "+{} damage", 1),
+    ("damageMultiplier", "x{} damage", 1),
+    ("damageAdditiveForMoabs", "+{} damage vs MOAB-class", 1),
+    ("damageAdditiveForCeramic", "+{} damage vs Ceramic", 1),
+    ("damageAdditiveForBad", "+{} damage vs BAD", 1),
+    ("pierceAdditive", "+{} pierce", 1),
+    ("pierceMultiplier", "x{} pierce", 1),
+    ("piercePercentage", "+{}% pierce", 100),
+    ("rateMultiplier", "x{} attack cooldown", 1),
+    ("ratePercentage", "{}% attack speed", 100),
+    ("rangeAdditive", "+{} range", 1),
+    ("rangeMultiplier", "x{} range", 1),
+    ("rangePercentage", "+{}% range", 100),
+    ("lifespanMultiplier", "x{} lifespan", 1),
+    ("abilityCooldownMultiplier", "x{} ability cooldown", 1),
 )
+
+
+def _fmt_buff_num(value: Any) -> str:
+    """Whole floats as ints (``15.0`` -> ``15``), real fractions kept (``1.5``)."""
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    if isinstance(value, (int, float)):
+        return str(round(value, 4))
+    return str(value)
 
 
 def _buff_text(buff: dict[str, Any]) -> str:
     parts = [
-        tmpl.format(buff[field])
-        for field, tmpl in _BUFF_FIELDS
-        if buff.get(field) is not None
+        tmpl.format(_fmt_buff_num(buff[field] * scale))
+        for field, tmpl, scale in _BUFF_FIELDS
+        if isinstance(buff.get(field), (int, float))
+        and not isinstance(buff.get(field), bool)
     ]
     name = str(buff.get("name") or "").strip()
     body = ", ".join(parts) if parts else "buff"

--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -299,6 +299,33 @@ curator-supplied name is preserved, never regressed to an internal model string.
       `--audit` and (3). *Rationale: largest effort and the cutover blocker; uses
       (1) sizing and (3) name-joins.*
 
+   > **Decode analysis (2026-06-04, slice 1).** Deep investigation before any
+   > buff/zone *write*, with three inconsistencies flagged:
+   > - **Render bug FIXED.** Percentage buff fields are stored as fractions
+   >   (`0.15` = 15%, faithful to the dump's `*PercentIncrease`) but the renderer
+   >   read them literally → Poplust showed *"+0.15% pierce"* (≈100× too small).
+   >   `_buff_text` now scales `*Percentage` fields ×100 (61 committed buffs were
+   >   affected). This is the only *answerable* change in slice 1.
+   > - **The buff *prose* is already answerable** via the upgrade descriptions
+   >   (step 2) — `buffLocsName` does **not** resolve in `textTable` (it is a
+   >   buff-icon key), so step 5's only *added* value over step 2 is the
+   >   structured *numbers*.
+   > - **The numbers have mixed, per-`$type` semantics — not a uniform decode.**
+   >   Verified `PoplustSupportModel.ratePercentIncrease 0.15` == committed
+   >   `ratePercentage 0.15` (identity). But across types: `PierceSupport.pierce`
+   >   → `pierceAdditive` (clear); `RateSupport.multiplier 0.85` → `rateMultiplier`
+   >   (faithful ×-cooldown); `RangeSupport.multiplier 0.1` is an **ambiguous**
+   >   fraction (×0.1 is absurd, so it must mean +10% → `rangePercentage`); and
+   >   `ProjectileSpeedSupport` / `VisibilitySupport` have **no field in the
+   >   committed buff schema at all**. Crosspath files also list **cumulative**
+   >   buffs (need tier-diffing to attribute the granting tier) and contain
+   >   **duplicates** (need de-dupe). A bulk write would ship wrong numbers under
+   >   the faithfulness guard, so the numeric write is deferred to a per-`$type`,
+   >   verified slice (extend the buff schema for speed/visibility; map only
+   >   semantics proven against a committed example or an unambiguous field name).
+   >   *(The "37 buff / 12 zone" counts here are superseded by the SHA-pinned
+   >   report's 38 / 28 — see `btd6-decode-inventory-v55.md` §3.)*
+
 **Lower priority — post-#468 AI-answer enhancements (not roadmap-critical)**
 
 6. **Audit-schema version column** — *[new]* the §5 observability item deferred

--- a/tests/unit/services/test_btd6_upgrade_detail_service.py
+++ b/tests/unit/services/test_btd6_upgrade_detail_service.py
@@ -219,3 +219,30 @@ def test_modifiers_empty_when_none_present():
     main = _attack(d, "Attack")
     assert main is not None
     assert main.projectiles[0].modifiers == ()
+
+
+# --- buff percentage rendering (fraction -> percent) ------------------------
+
+
+def test_buff_percentage_fields_render_as_percent_not_fraction():
+    # Regression: committed percentage buffs store fractions (0.15 = 15%, faithful
+    # to the dump's *PercentIncrease), but the render read them as a literal "%",
+    # so Poplust showed "+0.15% pierce" (wrong) instead of "+15%".
+    text = det._buff_text(
+        {"name": "Poplust buff", "ratePercentage": 0.15, "piercePercentage": 0.15},
+    )
+    assert "+15% pierce" in text
+    assert "15% attack speed" in text
+    assert "0.15%" not in text
+
+
+def test_buff_additive_and_multiplier_fields_unscaled():
+    # Only *Percentage fields scale; additive/multiplier stay verbatim.
+    text = det._buff_text(
+        {"name": "Undead Bloon buff", "damageAdditive": 3, "lifespanMultiplier": 1.5},
+    )
+    assert text == "Undead Bloon buff: +3 damage, x1.5 lifespan"
+
+
+def test_buff_range_percentage_renders_whole_percent():
+    assert "+10% range" in det._buff_text({"name": "X", "rangePercentage": 0.1})


### PR DESCRIPTION
## What & why

**Step 5 (zone/buff effect decode), slice 1** — done thoroughly, with inconsistencies flagged. I investigated the full buff/zone decode before writing any numbers, **found and fixed a real rendering bug**, and documented exactly why the bulk numeric write must be a careful per-`$type` slice (not a rush) — shipping wrong numbers would violate the faithfulness discipline.

Anchor gate re-validated (SHA `a3348a89`, Dart 200 / Super 2500).

## Flagged inconsistency — FIXED (answerable now)
Percentage buff fields are stored as **fractions** (`0.15` = 15%, faithful to the dump's `*PercentIncrease`), but `_buff_text` rendered them literally — so **Poplust showed "+0.15% pierce"**, ~100× too small. Every percentage buff in the bot was wrong.

**Fix:** `_BUFF_FIELDS` now carries a per-field scale (×100 for the three `*Percentage` fields) and `_fmt_buff_num` formats whole floats as ints. **61 committed buffs across 13 towers** were affected; all values are fractions <1, so ×100 is **universally correct** (verified). Result: `Poplust buff: +15% pierce, 15% attack speed`. Additive/multiplier fields (e.g. `+3 damage`, `x1.5 lifespan`) are left verbatim.

Verified the dump→committed value is **identity**: `PoplustSupportModel.ratePercentIncrease 0.15` == committed `ratePercentage 0.15`.

## Why the numeric write is deferred (the thorough finding)
The runtime **already** reads `buffs[]`/`zones[]` off tier nodes — so the gap is pure extraction. But the extraction is genuinely subtle, and three findings make a bulk write unsafe right now:

1. **The buff *prose* is already answerable** via the upgrade descriptions (step 2). `buffLocsName` does **not** resolve in `textTable` (it's a buff-icon key), so step 5's *only* added value over step 2 is the structured **numbers**.
2. **Mixed per-`$type` semantics — not a uniform decode.** `PierceSupport.pierce` → `pierceAdditive` (clear); `RateSupport.multiplier 0.85` → `rateMultiplier` (faithful ×-cooldown); but `RangeSupport.multiplier 0.1` is an **ambiguous** fraction (×0.1 is absurd → must mean +10%); and `ProjectileSpeedSupport` / `VisibilitySupport` have **no field in the committed buff schema at all**.
3. **Crosspath files list *cumulative* buffs** (need tier-diffing to attribute the granting tier) and contain **duplicates** (need de-dupe).

A bulk write would ship wrong numbers under the #468 guard. So the numeric write becomes a **per-`$type` verified slice** (extend the buff schema for speed/visibility; map only semantics proven against a committed example or an unambiguous field name). Full analysis recorded in `docs/btd6-gamedata-decode-status.md`.

## Tests / CI
- New: percentage scaling (Poplust +15%, range +10%, no "0.15%"), additive/multiplier left verbatim.
- `python3.10 scripts/check_quality.py --full` → **7210 passed, 3 skipped**; `check_architecture --mode strict` clean.

## Next
Slice 2: the per-`$type` verified buff/zone *number* extraction + write (schema extension for the unrepresentable effects, crosspath tier-diff + de-dupe), wired through the existing `buffs[]`/`zones[]` grounding surface.

https://claude.ai/code/session_01PtRrhCT9KCdukWnUzUEQH6

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtRrhCT9KCdukWnUzUEQH6)_