### PR TITLE
fix(btd6): full upgrade name beats embedded substring (Ultra-Juggernaut modifiers now reachable)

### DIFF
--- a/disbot/services/btd6_upgrade_service.py
+++ b/disbot/services/btd6_upgrade_service.py
@@ -76,6 +76,9 @@ class UpgradeResolution:
 _CURATED_ALIASES: dict[str, str] = {
     # Dart Monkey
     "pmfc": "Plasma Monkey Fan Club",
+    "ultra jug": "Ultra-Juggernaut",
+    "ultrajug": "Ultra-Juggernaut",
+    "ujug": "Ultra-Juggernaut",
     # Super Monkey
     "smfc": "Super Monkey Fan Club",
     "sun avatar": "Sun Avatar",
@@ -281,6 +284,48 @@ def _match_surfaces(
     return hits
 
 
+def _match_surfaces_keyed(
+    query_tokens: list[str],
+    index: dict[tuple[str, ...], UpgradeIdentity],
+) -> dict[str, tuple[str, ...]]:
+    """``{upgrade_id: longest matching surface}`` — like :func:`_match_surfaces`
+    but keeps the surface that matched (for sub-name absorption below).
+    """
+    token_set = set(query_tokens)
+    hits: dict[str, tuple[str, ...]] = {}
+    for surface, identity in index.items():
+        matched = (
+            surface[0] in token_set
+            if len(surface) == 1
+            else _contains_subsequence(query_tokens, list(surface))
+        )
+        if matched:
+            prev = hits.get(identity.upgrade_id)
+            if prev is None or len(surface) > len(prev):
+                hits[identity.upgrade_id] = surface
+    return hits
+
+
+def _absorb_subname_hits(hits: dict[str, tuple[str, ...]]) -> set[str]:
+    """Drop a hit whose surface is a contiguous sub-run of a *longer* hit's
+    surface, so an exact full name wins over a substring of it (``Ultra-
+    Juggernaut`` beats the embedded ``Juggernaut``). Two names that don't overlap
+    (``juggernaut`` vs ``prince of darkness``) are both kept — genuine ambiguity.
+    """
+    keep = set(hits)
+    items = list(hits.items())
+    for uid, surface in items:
+        for other_id, other in items:
+            if (
+                other_id != uid
+                and len(surface) < len(other)
+                and _contains_subsequence(list(other), list(surface))
+            ):
+                keep.discard(uid)
+                break
+    return keep
+
+
 def _single_path_code(query: str) -> str | None:
     """The first single-path tier code in ``query`` (e.g. ``005``), or None.
 
@@ -319,7 +364,10 @@ def resolve_upgrade(query: str) -> UpgradeResolution:
     if not tokens and not (query or "").strip():
         return UpgradeResolution(query=query or "", match_type="none")
 
-    name_hits = _match_surfaces(tokens, reg.name_index)
+    # Exact names first, with sub-name absorption: a query naming "Ultra-
+    # Juggernaut" matches both that and the embedded "Juggernaut" surface, but
+    # the longer, more-specific name wins rather than reading as ambiguous.
+    name_hits = _absorb_subname_hits(_match_surfaces_keyed(tokens, reg.name_index))
     if len(name_hits) == 1:
         return UpgradeResolution(query, "exact_name", reg.by_id[next(iter(name_hits))])
 

--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -68,6 +68,23 @@ must not be treated as done. Verified against the v55 dump on 2026-06-03.
 >    to **55.0**, justified by the audit (committed numbers are 0-SUSPECT /
 >    overwhelmingly CLEAN vs the v55 dump, i.e. already v55-accurate).
 
+> **More reachability fixes (2026-06-04, live testing).** Same "extracted ≠
+> reachable" lesson, two more instances:
+> 3. *`Ultra-Juggernaut` resolved as ambiguous*, so its damage modifiers (+20
+>    Lead / +8 Ceramic / +5 Fortified) never reached the model — it confabulated
+>    "no multipliers". Root cause: the upgrade resolver matched both the full name
+>    and the embedded `Juggernaut` substring → two name-hits → ambiguous. (The
+>    #476 test masked this by resolving the raw id, bypassing the resolver.)
+>    Fixed: `_absorb_subname_hits` drops a name-hit whose surface is a contiguous
+>    sub-run of a longer matching name, so the full name wins while genuinely
+>    distinct names ("X vs Y") stay ambiguous; added `ultra jug`/`ujug` aliases.
+> 4. *Per-round bloon composition is unreachable, not missing.* `rounds.json`
+>    already carries each round's `groups[]` (`bloon_id` + `count`), but there is
+>    **no tool** to answer a range aggregation ("how many purples r35–r70"), so
+>    the bot refuses. A `btd6_round_composition`-style query tool over the
+>    committed rounds is the fix — **next slice** (data exists; no extraction
+>    needed).
+
 ### ✅ Complete & verified
 
 | Item | Where | Evidence |

--- a/tests/unit/services/test_btd6_upgrade_service.py
+++ b/tests/unit/services/test_btd6_upgrade_service.py
@@ -100,6 +100,31 @@ def test_ambiguous_query_returns_candidates():
 
 @pytest.mark.parametrize(
     "query",
+    ["Ultra-Juggernaut", "ultra juggernaut", "the ultra juggernaut", "ultra jug", "ujug"],
+)
+def test_full_name_wins_over_embedded_substring(query):
+    # Regression: "Ultra-Juggernaut" matched both its own name AND the embedded
+    # "Juggernaut" surface, reading as ambiguous — so its damage modifiers never
+    # reached the model. The longer, more-specific name (or its alias) now wins.
+    res = up.resolve_upgrade(query)
+    assert res.found, query
+    assert res.upgrade.upgrade_id == "dart_monkey:500"
+    # The base "Juggernaut" still resolves to its own tier, unaffected.
+    assert up.resolve_upgrade("juggernaut").upgrade.upgrade_id == "dart_monkey:400"
+
+
+def test_two_distinct_full_names_stay_ambiguous():
+    # Absorption must NOT collapse genuinely distinct names that don't overlap.
+    res = up.resolve_upgrade("juggernaut vs prince of darkness")
+    assert res.match_type == "ambiguous"
+    assert {c.upgrade_id for c in res.candidates} == {
+        "dart_monkey:400",
+        "wizard_monkey:005",
+    }
+
+
+@pytest.mark.parametrize(
+    "query",
     [
         "",
         "   ",


### PR DESCRIPTION
## What & why

Live testing showed the bot still saying **Ultra-Juggernaut has "no damage multipliers"** — even though the data has `+20 vs Lead / +8 Ceramic / +5 Fortified` and #476 wired modifiers into the grounding. **The data was never the problem; the resolver was.**

### Root cause (a resolver bug my #476 test masked)
`grounding_for_query("ultra juggernaut")` matched **both** the full name surface `("ultra","juggernaut")` **and** the embedded substring `("juggernaut",)` → two name-hits → **`ambiguous`** → it returned a *"did you mean Juggernaut, Ultra-Juggernaut?"* clarification. So the modifier lines **never reached the model**, and it confabulated "no multipliers". (My #476 grounding test resolved the raw id `dart_monkey:500` directly, *bypassing* the resolver — so it passed while production was broken. Lesson logged.)

### Fix
- `_absorb_subname_hits` drops a name-hit whose surface is a **contiguous sub-run** of a longer matching name, so the **full name wins** (`Ultra-Juggernaut → 500`) while two **genuinely distinct** names (`juggernaut vs prince of darkness`) stay ambiguous (comparison preserved).
- Added curated aliases `ultra jug` / `ultrajug` / `ujug` (the user's exact phrasing — these resolved to `none` before).

Verified end-to-end via `build()`:
`[btd6_upgrade] Ultra-Juggernaut — main attack: … +20 vs Lead, +8 vs Ceramic, +5 vs Fortified …`

## Second issue diagnosed (not fixed here) — bloons per round
"list the amount of purples r35–r70" refuses. I checked: this is **also a reachability gap, not a data gap** — `rounds.json` already carries each round's `groups[]` (`bloon_id` + `count`), but there's **no tool** that does a range aggregation. The fix is a `btd6_round_composition`-style query tool over the committed rounds (no extraction needed) — scoped as the **next slice** and recorded in the status doc. Kept out of this PR to keep the resolver fix focused.

## Tests / CI
- New: full-name-beats-substring resolves `Ultra-Juggernaut` + all three aliases → `dart_monkey:500`; base `Juggernaut` still `dart_monkey:400`; `juggernaut vs prince of darkness` stays ambiguous.
- `python3.10 scripts/check_quality.py --full` → **7216 passed, 3 skipped**; `check_architecture --mode strict` clean.

https://claude.ai/code/session_01PtRrhCT9KCdukWnUzUEQH6

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtRrhCT9KCdukWnUzUEQH6)_