### PR TITLE
docs(btd6): reconcile decode-status after step-5 slice 1 + verification pass

### DIFF
--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -302,19 +302,37 @@ curator-supplied name is preserved, never regressed to an internal model string.
    **decoded-effect half** of the end goal. Each sub-step: decode the headline
    numeric where `--audit`-stable, else fall back to description-only (flagged).
    In order:
-   a. **Zones** — 12 `*ZoneModel` types (`SlowBloonsZone`, `DamageOverTimeZone`,
+   a. **Zones** — **28** `*ZoneModel` types (`SlowBloonsZone`, `DamageOverTimeZone`,
       shove/windy/necromancer + economy); the zone's own `name` is empty →
-      resolve via the owning upgrade's `LocsKey`.
-   b. **Buffs** — 37 `*SupportModel`/`*BuffModel` types; a common core
+      resolve via the owning upgrade's `LocsKey`. *(28, not 12 — see report §3a.)*
+   b. **Buffs** — **38** `*SupportModel`/`*BuffModel` types; a common core
       (Range/Pierce/Visibility/Rate/Speed/Cooldown/Damage support sharing
       `multiplier`/`additive` + `buffLocsName`→name) covers most; tail towers get
-      a name-only node.
+      a name-only node. *(38, not 37 — see report §3b.)*
    c. **Subtower tail** — `MorphTowerModel` named-ref (Alchemist) +
       `BeastHandlerPetModel` (the 2 remaining mechanisms).
    d. **Economy-tower attack suppression**, then the **towers cutover** (`--all`,
       runtime name-adaptations, update the ~25 value-pinned tests), gated by
       `--audit` and (3). *Rationale: largest effort and the cutover blocker; uses
       (1) sizing and (3) name-joins.*
+
+   > **Definition of done (binding, from the #476/#478 lessons).** A step-5 slice
+   > is done only when each effect is **extracted + committed + retrievable by a
+   > tool + the per-`$type` number verified individually** (never a bulk write).
+   > "Extracted ≠ reachable ≠ answerable": the data being in a committed file is
+   > not enough — a renderer/tool must surface it *and* the resolver must reach
+   > the entity (Ultra-Juggernaut's modifiers existed and grounded but were
+   > unreachable because the resolver read the name as ambiguous; #478). The
+   > schema extension for effects the current buff schema can't hold
+   > (`projectileSpeed`, `visibility`) **alters shape**, so expect an
+   > architecture / registry-snapshot invariant to bite — conform to it.
+   >
+   > **Ordering vs step 3:** the numeric-overlay envelope (`_OVERLAY_FIELDS =
+   > {range, footprintRadius}` + upgrade `cost`/`xp`) and step 5's
+   > `buffs[]`/`zones[]` are **field-disjoint**, and `overlay_payload` edits in
+   > place without stripping unrelated keys (verified) — so the two are
+   > order-safe on the same tower file (no half-populated entities); either may
+   > land first.
 
    > **Decode analysis (2026-06-04, slice 1).** Deep investigation before any
    > buff/zone *write*, with three inconsistencies flagged:
@@ -342,6 +360,15 @@ curator-supplied name is preserved, never regressed to an internal model string.
    >   semantics proven against a committed example or an unambiguous field name).
    >   *(The "37 buff / 12 zone" counts here are superseded by the SHA-pinned
    >   report's 38 / 28 — see `btd6-decode-inventory-v55.md` §3.)*
+   > - **Schema-coverage gap (slice-2 input).** Several committed buff fields are
+   >   already present but NOT in `_BUFF_FIELDS`, so they render as a bare
+   >   "buff": economy effects (`cashPerRoundPerFavouredTrades`,
+   >   `heroXpMultiplier`, `cashbackZoneMultiplier`, …). Slice 2 should widen the
+   >   schema to surface these too, not just speed/visibility.
+   >
+   > **Slice 1 shipped (#477):** the ×100 render fix only — **no buff/zone
+   > numbers were written**, so the 🔴 "0 of 28 / 0 of 38" below still stands for
+   > the *write*; only the rendering of the already-committed buffs is corrected.
 
 **Lower priority — post-#468 AI-answer enhancements (not roadmap-critical)**
 


### PR DESCRIPTION
## What & why

The verification + documentation pass requested in the step-5 review notes — done **before** proceeding to slice 2. Doc-only; reconciles `btd6-gamedata-decode-status.md` to the actual tree so the next session reads truth, not optimism.

## Verification results (all confirmed against the tree + runtime, not PR summaries)

**Task 1 — ×100 percentage fix, inclusion/exclusion proven:**
- **×100 = exactly the 3 `*Percentage` fields** (`pierce/rate/rangePercentage`); every scaled field ends in "Percentage", no unscaled one does.
- **Excluded = all additive + multiplier fields** → no additive field was scaled (the "+0.6 flat → 60" bug cannot occur).
- **Proof, not eyeball:** every committed percentage value ∈ (0,1) — `piercePercentage` 0.08–0.15, `rangePercentage` 0.075, `ratePercentage` 0.15; `all(0<v<1)` = True.

**Task 3 — step 3 / step 5 disjoint:** overlay envelope is `_OVERLAY_FIELDS = {range, footprintRadius}` + upgrade `cost`/`xp`; step 5 is `buffs[]`/`zones[]`. **Field-disjoint**, and `overlay_payload` preserves unrelated keys (verified by test) → order-safe on the same tower file.

**All PRs re-verified (tree + behavior):** #473 report/guard (report regenerates identical), #474 373/375 upgrade desc (grounds), #475 340/340 hero-level desc (Ezili L11 grounds), #476 modifiers + stamp 55.0 (Juggernaut +3 Ceramic grounds), #477 ×100 (Poplust "15% attack speed"), #478 resolver (ultra-jug +20 Lead reaches model). No stale RESOLVED banners in btd6 docs.

**Task 2 — live Discord:** I can't drive Discord from the sandbox, so these are **code+behavior-confirmed**, not live-channel-confirmed. The version stamp reads `55.0` in code and the renders/grounding verify through the real service paths; the live post-merge checks (Poplust "+15%", the re-asked modifier question, a fresh refusal showing 55.0) are deterministic and yours to confirm.

## Doc corrections
- Step-5 sub-items now carry the corrected **28 zone / 38 buff** `$type` counts (were 12 / 37).
- Added the **binding definition of done**: *extracted + committed + retrievable by a tool + per-`$type` number verified individually (never bulk)* — the "extracted ≠ reachable ≠ answerable" lesson.
- Recorded that slice 1 (#477) was **render-only** — no buff/zone numbers written, so 🔴 "0 of 28 / 0 of 38" still stands for the write.
- Flagged the **schema-coverage gap** (economy buff fields render as bare "buff") and the **step-3/5 disjointness** as slice-2 inputs.

## CI
Doc-only; doc-pinning tests green (49 passed); `check_quality --check-only` clean.

https://claude.ai/code/session_01PtRrhCT9KCdukWnUzUEQH6

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtRrhCT9KCdukWnUzUEQH6)_