### PR TITLE
feat(btd6): round/map/mode query tools + unambiguous "+N damage vs X" modifier label

### DIFF
--- a/disbot/services/ai_tools.py
+++ b/disbot/services/ai_tools.py
@@ -742,6 +742,152 @@ async def _btd6_difficulty_cost(arguments: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+# --- btd6_round_composition --------------------------------------------------
+
+_BTD6_ROUND_COMPOSITION_SPEC = AIToolSpec(
+    name="btd6_round_composition",
+    description=(
+        "Exact BTD6 bloon composition for a round or a round RANGE (standard "
+        "rounds 1-140). Use for 'how many purples in rounds 35-70', 'what spawns "
+        "in round 63', 'which rounds have MOABs', 'RBE of round 80'. Pass "
+        "round_start (and round_end for a range). Pass a bloon (e.g. 'purple', "
+        "'ceramic', 'MOAB') to get its TOTAL across the range plus the per-round "
+        "counts; omit it for each round's full spawn list + RBE. Do not count or "
+        "sum yourself — this returns the exact totals."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "round_start": {
+                "type": "integer",
+                "description": "First round (1-140). For a single round, set only this.",
+            },
+            "round_end": {
+                "type": "integer",
+                "description": "Last round of the range (inclusive); omit for one round.",
+            },
+            "bloon": {
+                "type": "string",
+                "description": "Bloon to count, e.g. 'purple', 'ceramic', 'MOAB'. Omit for full composition.",
+            },
+        },
+        "required": ["round_start"],
+        "additionalProperties": False,
+    },
+    min_scope=AIScope.USER,
+)
+
+
+async def _btd6_round_composition(arguments: dict[str, Any]) -> dict[str, Any]:
+    from services import btd6_data_service
+
+    try:
+        start = int(arguments.get("round_start"))
+    except (TypeError, ValueError):
+        return {"found": False, "note": "round_start must be an integer (1-140)"}
+    raw_end = arguments.get("round_end")
+    try:
+        end = int(raw_end) if raw_end is not None else None
+    except (TypeError, ValueError):
+        end = None
+    bloon = str(arguments.get("bloon") or "").strip() or None
+    return btd6_data_service.round_composition(start, end, bloon)
+
+
+# --- btd6_map_lookup ---------------------------------------------------------
+
+_BTD6_MAP_LOOKUP_SPEC = AIToolSpec(
+    name="btd6_map_lookup",
+    description=(
+        "BTD6 map info: difficulty (Beginner / Intermediate / Advanced / Expert), "
+        "description, and line-of-sight notes. Pass a map name to look one up, or "
+        "omit it to list every map with its difficulty (use for 'which maps are "
+        "beginner', 'is Logs beginner', 'list the maps')."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "map": {
+                "type": "string",
+                "description": "Map name (e.g. 'Logs'); omit to list all maps.",
+            },
+        },
+        "additionalProperties": False,
+    },
+    min_scope=AIScope.USER,
+)
+
+
+def _map_dict(entry: Any) -> dict[str, Any]:
+    return {
+        "name": entry.canonical,
+        "difficulty": entry.difficulty,
+        "description": entry.description,
+        "line_of_sight_notes": entry.lines_of_sight_notes,
+    }
+
+
+async def _btd6_map_lookup(arguments: dict[str, Any]) -> dict[str, Any]:
+    from services import btd6_data_service
+
+    name = str(arguments.get("map") or "").strip()
+    if name:
+        entry = btd6_data_service.find_map(name)
+        if entry is None:
+            return {"found": False, "note": f"unknown map: {name!r}"}
+        return {"found": True, "map": _map_dict(entry)}
+    maps = btd6_data_service.get_dataset().maps
+    return {"found": True, "count": len(maps), "maps": [_map_dict(m) for m in maps]}
+
+
+# --- btd6_mode_lookup --------------------------------------------------------
+
+_BTD6_MODE_LOOKUP_SPEC = AIToolSpec(
+    name="btd6_mode_lookup",
+    description=(
+        "BTD6 game mode info: starting cash, starting lives, and rule restrictions "
+        "(e.g. CHIMPS = no Continues, Hearts lost, Income, Monkey knowledge, "
+        "Powers, Selling). Pass a mode name to look one up, or omit it to list all "
+        "modes (use for 'what are CHIMPS restrictions', 'CHIMPS starting cash', "
+        "'list game modes')."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "mode": {
+                "type": "string",
+                "description": "Mode name (e.g. 'CHIMPS'); omit to list all modes.",
+            },
+        },
+        "additionalProperties": False,
+    },
+    min_scope=AIScope.USER,
+)
+
+
+def _mode_dict(entry: Any) -> dict[str, Any]:
+    return {
+        "name": entry.canonical,
+        "starting_cash": entry.starting_cash,
+        "starting_lives": entry.starting_lives,
+        "description": entry.description,
+        "restrictions": list(entry.restrictions),
+    }
+
+
+async def _btd6_mode_lookup(arguments: dict[str, Any]) -> dict[str, Any]:
+    from services import btd6_data_service
+
+    name = str(arguments.get("mode") or "").strip()
+    if name:
+        entry = btd6_data_service.find_mode(name)
+        if entry is None:
+            return {"found": False, "note": f"unknown mode: {name!r}"}
+        return {"found": True, "mode": _mode_dict(entry)}
+    modes = btd6_data_service.get_dataset().modes
+    return {"found": True, "count": len(modes), "modes": [_mode_dict(m) for m in modes]}
+
+
 # --- btd6_paragon_calculate --------------------------------------------------
 
 _PARAGON_CALCULATE_SPEC = AIToolSpec(
@@ -1209,6 +1355,9 @@ BTD6_GROUNDING_TOOL_NAMES: frozenset[str] = frozenset(
         "btd6_capability_lookup",
         "btd6_superlative_lookup",
         "btd6_difficulty_cost",
+        "btd6_round_composition",
+        "btd6_map_lookup",
+        "btd6_mode_lookup",
         "btd6_paragon_calculate",
         "btd6_paragon_requirements",
         "btd6_paragon_stats_at_degree",
@@ -1251,6 +1400,9 @@ def build_registry(
         (_BTD6_CAPABILITY_SPEC, _btd6_capability_lookup),
         (_BTD6_SUPERLATIVE_SPEC, _btd6_superlative_lookup),
         (_BTD6_DIFFICULTY_COST_SPEC, _btd6_difficulty_cost),
+        (_BTD6_ROUND_COMPOSITION_SPEC, _btd6_round_composition),
+        (_BTD6_MAP_LOOKUP_SPEC, _btd6_map_lookup),
+        (_BTD6_MODE_LOOKUP_SPEC, _btd6_mode_lookup),
         (_PARAGON_CALCULATE_SPEC, _paragon_calculate),
         (_PARAGON_REQUIREMENTS_SPEC, _paragon_requirements),
         (_BTD6_PARAGON_STATS_AT_DEGREE_SPEC, _btd6_paragon_stats_at_degree),

--- a/disbot/services/btd6_data_service.py
+++ b/disbot/services/btd6_data_service.py
@@ -907,6 +907,134 @@ def get_bloon(bloon_id: str) -> BloonEntry | None:
     return None
 
 
+def resolve_bloon_id(name: str) -> str | None:
+    """Map a bloon name / alias / plural to its id (``"purples"`` -> ``"purple"``).
+
+    Matches id, canonical, or any committed alias; falls back to stripping a
+    trailing plural ``s`` so unlisted plurals still resolve. ``None`` if no match.
+    """
+    key = (name or "").strip().lower()
+    if not key:
+        return None
+    for bloon in get_dataset().bloons:
+        surfaces = {
+            bloon.id,
+            bloon.canonical.lower(),
+            *(a.lower() for a in bloon.aliases),
+        }
+        if key in surfaces or (key.endswith("s") and key[:-1] in surfaces):
+            return bloon.id
+    return None
+
+
+# Cap the per-round detail a round-composition query returns so a wide range
+# (e.g. "moabs in rounds 1-140") can't blow the grounding token budget.
+_ROUND_DETAIL_CAP = 40
+
+
+def round_composition(
+    round_start: int,
+    round_end: int | None = None,
+    bloon: str | None = None,
+) -> dict[str, Any]:
+    """Bloon composition for a round or inclusive round range (standard rounds).
+
+    With ``bloon``: the total count of that bloon across the range plus the
+    per-round counts (only rounds where it appears). Without: each round's
+    spawn groups + RBE. Lists are capped at :data:`_ROUND_DETAIL_CAP`.
+    """
+    lo = round_start
+    hi = round_start if round_end is None else round_end
+    if lo > hi:
+        lo, hi = hi, lo
+    rounds = [r for r in get_dataset().rounds if lo <= r.round_number <= hi]
+    if not rounds:
+        return {
+            "found": False,
+            "note": f"no standard rounds in {lo}-{hi} (valid 1-140)",
+        }
+
+    out: dict[str, Any] = {
+        "found": True,
+        "round_start": lo,
+        "round_end": hi,
+        "roundset": "default",
+        "rounds_in_range": len(rounds),
+    }
+    if bloon:
+        bid = resolve_bloon_id(bloon)
+        if bid is None:
+            return {"found": False, "note": f"unknown bloon: {bloon!r}"}
+        per_round: list[dict[str, int]] = []
+        total = 0
+        for entry in rounds:
+            count = sum(
+                int(g.get("count", 0)) for g in entry.groups if g.get("bloon_id") == bid
+            )
+            if count:
+                per_round.append({"round": entry.round_number, "count": count})
+                total += count
+        record = get_bloon(bid)
+        out.update(
+            {
+                "bloon": record.canonical if record else bid,
+                "bloon_id": bid,
+                "total": total,
+                "rounds_with_bloon": len(per_round),
+                "per_round": per_round[:_ROUND_DETAIL_CAP],
+                "truncated": len(per_round) > _ROUND_DETAIL_CAP,
+            },
+        )
+    else:
+        detail = []
+        for entry in rounds[:_ROUND_DETAIL_CAP]:
+            detail.append(
+                {
+                    "round": entry.round_number,
+                    "rbe": entry.rbe,
+                    "danger": entry.danger,
+                    "groups": [
+                        {"bloon": g.get("bloon_id"), "count": int(g.get("count", 0))}
+                        for g in entry.groups
+                    ],
+                },
+            )
+        out.update(
+            {
+                "total_rbe": sum(r.rbe or 0 for r in rounds),
+                "rounds": detail,
+                "truncated": len(rounds) > _ROUND_DETAIL_CAP,
+            },
+        )
+    return out
+
+
+def _find_by_surface(entries: tuple, name: str):
+    """First entry whose id / canonical / alias matches ``name`` (case-insensitive)."""
+    key = (name or "").strip().lower()
+    if not key:
+        return None
+    for entry in entries:
+        surfaces = {
+            entry.id,
+            entry.canonical.lower(),
+            *(a.lower() for a in entry.aliases),
+        }
+        if key in surfaces:
+            return entry
+    return None
+
+
+def find_map(name: str) -> MapEntry | None:
+    """Resolve a map by name / alias / id (``"logs"`` -> the Logs entry)."""
+    return _find_by_surface(get_dataset().maps, name)
+
+
+def find_mode(name: str) -> ModeEntry | None:
+    """Resolve a game mode by name / alias / id (``"chimps"`` -> CHIMPS)."""
+    return _find_by_surface(get_dataset().modes, name)
+
+
 def list_ct_relics() -> tuple[RelicEntry, ...]:
     """Every Contested Territory relic in the catalog (possibly empty)."""
     return get_dataset().ct_relics

--- a/disbot/services/btd6_upgrade_detail_service.py
+++ b/disbot/services/btd6_upgrade_detail_service.py
@@ -334,7 +334,9 @@ def _projectile_bits(proj: ProjectileSpec) -> str:
             ),
         )
     for label, bonus in proj.modifiers:
-        bits.append(f"+{bonus} vs {label}")
+        # Say "damage" explicitly: next to "210 pierce" a bare "+20 vs Lead" was
+        # misread by the model as bonus pierce — these are additive damage.
+        bits.append(f"+{bonus} damage vs {label}")
     return ", ".join(bits)
 
 

--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -81,9 +81,23 @@ must not be treated as done. Verified against the v55 dump on 2026-06-03.
 > 4. *Per-round bloon composition is unreachable, not missing.* `rounds.json`
 >    already carries each round's `groups[]` (`bloon_id` + `count`), but there is
 >    **no tool** to answer a range aggregation ("how many purples r35–r70"), so
->    the bot refuses. A `btd6_round_composition`-style query tool over the
->    committed rounds is the fix — **next slice** (data exists; no extraction
->    needed).
+>    the bot refuses. **Fixed:** `btd6_round_composition` tool
+>    (`btd6_data_service.round_composition`) — "purples r35–70" → 290.
+> 5. *Maps & modes were committed + seeded but had no grounding render AND no
+>    tool* — "which maps are beginner?" / "CHIMPS restrictions?" refused.
+>    **Fixed:** `btd6_map_lookup` / `btd6_mode_lookup` (single + roster), which
+>    bypass the missing render via the grounding-tool ledger.
+> 6. *Damage modifiers were mislabeled in grounding.* `_projectile_bits` emitted
+>    "+20 vs Lead" right after "210 pierce", and the model read it as bonus
+>    *pierce*. Now "+20 **damage** vs Lead" — unambiguous.
+>
+> **Tool-use-discipline note (open):** the model sometimes asserts a confident
+> *false negative* ("Ultra-Juggernaut has no damage multipliers") **without**
+> calling the lookup. The faithfulness guard catches ungrounded *numbers/names*
+> but NOT *absence* claims, so these slip through. Mitigations now in place:
+> (a) #478 makes the upgrade resolve so its modifiers auto-ground (Pass 3c) — the
+> data is in context without a tool call; (b) the clearer "+N damage vs X" label.
+> A guard that catches absence claims is a larger, separate change.
 
 ### ✅ Complete & verified
 

--- a/tests/unit/services/test_ai_tools.py
+++ b/tests/unit/services/test_ai_tools.py
@@ -32,6 +32,9 @@ def test_build_registry_returns_specs_and_matching_handlers():
         "btd6_capability_lookup",
         "btd6_superlative_lookup",
         "btd6_difficulty_cost",
+        "btd6_round_composition",
+        "btd6_map_lookup",
+        "btd6_mode_lookup",
         "btd6_paragon_calculate",
         "btd6_paragon_requirements",
         "btd6_paragon_stats_at_degree",
@@ -306,6 +309,9 @@ def test_admin_scope_offers_all_read_only_tools():
         "btd6_capability_lookup",
         "btd6_superlative_lookup",
         "btd6_difficulty_cost",
+        "btd6_round_composition",
+        "btd6_map_lookup",
+        "btd6_mode_lookup",
         "btd6_paragon_calculate",
         "btd6_paragon_requirements",
         "btd6_paragon_stats_at_degree",
@@ -613,3 +619,46 @@ async def test_btd6_capability_lookup_paragon_camo_split():
     # Only camo is verified per-paragon.
     bad = await h({"capability": "lead_popping", "entity": "paragon"})
     assert bad["found"] is False
+
+
+# --- btd6_round_composition / map / mode (committed-data query tools) --------
+
+
+async def test_btd6_round_composition_aggregates_a_bloon_over_a_range():
+    # The live-refused question: "how many purples in rounds 35-70".
+    h = build_registry(scope=AIScope.USER, guild_id=1, actor_id=2).handlers
+    r = await h["btd6_round_composition"]({"round_start": 35, "round_end": 70, "bloon": "purples"})
+    assert r["found"] is True
+    assert r["bloon"] == "Purple Bloon"
+    assert r["total"] == 290
+    assert r["rounds_with_bloon"] >= 1
+    assert all({"round", "count"} <= set(pr) for pr in r["per_round"])
+
+
+async def test_btd6_round_composition_single_round_full_list_and_errors():
+    h = build_registry(scope=AIScope.USER, guild_id=1, actor_id=2).handlers
+    one = await h["btd6_round_composition"]({"round_start": 63})
+    assert one["found"] is True and one["rounds"][0]["round"] == 63
+    assert one["rounds"][0]["groups"]
+    assert (await h["btd6_round_composition"]({"round_start": 999}))["found"] is False
+    assert (await h["btd6_round_composition"]({"round_start": 35, "bloon": "flarp"}))["found"] is False
+    assert (await h["btd6_round_composition"]({"round_start": "x"}))["found"] is False
+
+
+async def test_btd6_map_lookup_single_and_roster():
+    h = build_registry(scope=AIScope.USER, guild_id=1, actor_id=2).handlers
+    logs = await h["btd6_map_lookup"]({"map": "Logs"})
+    assert logs["found"] is True and logs["map"]["difficulty"] == "Beginner"
+    roster = await h["btd6_map_lookup"]({})
+    assert roster["found"] is True and roster["count"] == len(roster["maps"]) >= 3
+    assert (await h["btd6_map_lookup"]({"map": "nope"}))["found"] is False
+
+
+async def test_btd6_mode_lookup_single_and_roster():
+    h = build_registry(scope=AIScope.USER, guild_id=1, actor_id=2).handlers
+    chimps = await h["btd6_mode_lookup"]({"mode": "CHIMPS"})
+    assert chimps["found"] is True
+    assert chimps["mode"]["starting_lives"] == 1
+    assert chimps["mode"]["restrictions"]
+    roster = await h["btd6_mode_lookup"]({})
+    assert roster["found"] is True and roster["count"] == len(roster["modes"]) >= 2

--- a/tests/unit/services/test_btd6_upgrade_detail_service.py
+++ b/tests/unit/services/test_btd6_upgrade_detail_service.py
@@ -198,8 +198,8 @@ def test_grounding_surfaces_bonus_vs_bloon_class():
     # The retrieval-gap regression: the bot could recite the prose ("crushes
     # Ceramic/Fortified") but not the numbers. Now the numbers ground.
     blob = "\n".join(det.grounding_for_query("Juggernaut"))
-    assert "+3 vs Ceramic" in blob
-    assert "+2 vs Fortified" in blob
+    assert "+3 damage vs Ceramic" in blob
+    assert "+2 damage vs Fortified" in blob
 
 
 def test_grounding_surfaces_lead_bonus_on_ultra_juggernaut():
@@ -208,8 +208,8 @@ def test_grounding_surfaces_lead_bonus_on_ultra_juggernaut():
     blob = "\n".join(
         det.render_upgrade_grounding(det.get_upgrade_detail("dart_monkey:500")),
     )
-    assert "+20 vs Lead" in blob
-    assert "+8 vs Ceramic" in blob
+    assert "+20 damage vs Lead" in blob
+    assert "+8 damage vs Ceramic" in blob
 
 
 def test_modifiers_empty_when_none_present():


### PR DESCRIPTION
## What & why

From live testing: "how many purples in rounds 35–70" and "which maps are beginner?" refused, and the bot rendered Ultra-Juggernaut's `+20 vs Lead` damage bonus as "+20 **pierce** vs Lead". All three are **reachability/labeling gaps, not data gaps** — and a sweep of the tool surface (your "any other missing tools" ask) found maps/modes in the same boat.

## New query tools (data was committed + seeded, but had no tool)
- **`btd6_round_composition`** — per-round or **range** bloon composition over `rounds.json`. With a `bloon`, returns its **total across the range + per-round counts** ("purples r35–70" → **290**); otherwise each round's groups + RBE. Backed by `btd6_data_service.round_composition` + `resolve_bloon_id` (handles plurals: "purples"→purple, "MOABs"→moab). Capped so a wide range can't blow the token budget.
- **`btd6_map_lookup`** / **`btd6_mode_lookup`** — single + roster. Surfaces map difficulty ("is Logs beginner?") and mode rules (CHIMPS restrictions/cash/lives). Maps/modes had **no grounding render either**, so a tool is the only path — it grounds via the ledger.

All three registered in the catalog **and** `BTD6_GROUNDING_TOOL_NAMES`; the existing drift-guard test keeps the two in sync.

## Labeling fix (the "+20 pierce vs Lead" bug)
`_projectile_bits` now emits **"+N damage vs `<class>`"** (was "+N vs `<class>`"). Next to "210 pierce" the bare form was misread by the model as bonus *pierce* — these are additive **damage**. Modifier assertions updated.

## On "why did it refuse to use the tool / insist there are no multipliers"
Your screenshot caught a real pattern: the model asserted a confident **false negative** ("no damage multipliers") *without* calling `btd6_lookup`. The faithfulness guard catches ungrounded **numbers/names** but **not absence claims**, so these slip through. Mitigations now in place: **#478** makes the upgrade resolve so its modifiers **auto-ground** (no tool call needed), and this PR makes the label unambiguous. A guard that catches *absence* claims is a larger, separate change — flagged in the doc.

## Tests / CI
- Round aggregation (290), single round, range/unknown-bloon errors; map/mode single + roster; registry + grounding-allowlist drift guards updated.
- `python3.10 scripts/check_quality.py --full` → **7220 passed, 3 skipped**; `check_architecture --mode strict` clean.

## Other gaps found (not in this PR)
The sweep also flagged: a **CT-relic roster/filter** tool (only named lookup today) and a **bloon-property filter** ("which bloons are camo?"). Both are tool gaps with committed data — good follow-ons.

https://claude.ai/code/session_01PtRrhCT9KCdukWnUzUEQH6

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtRrhCT9KCdukWnUzUEQH6)_