### PR TITLE
docs(btd6): close v55 session — verify, small fixes (375/375 cards), decode-class registry, prioritized hand-off

### DIFF
--- a/disbot/data/btd6/stats/monkey_ace.json
+++ b/disbot/data/btd6/stats/monkey_ace.json
@@ -37,7 +37,8 @@
       "tier": 4,
       "name": "Operation: Dart Storm",
       "cost": 3300,
-      "xp": 8000
+      "xp": 8000,
+      "description": "Shoots 16 darts per volley, and twice as fast."
     },
     {
       "path": 1,

--- a/disbot/data/btd6/stats/wizard_monkey.json
+++ b/disbot/data/btd6/stats/wizard_monkey.json
@@ -117,7 +117,8 @@
       "tier": 4,
       "name": "Necromancer: Unpopped Army",
       "cost": 2800,
-      "xp": 10000
+      "xp": 10000,
+      "description": "Reanimate recently popped enemies as servants that can destroy Bloons of any type."
     },
     {
       "path": 3,

--- a/docs/btd6-data-backends.md
+++ b/docs/btd6-data-backends.md
@@ -65,7 +65,7 @@ file backend for ~6 MB of cosmetic savings, so we don't.)
 
 `btd6_data_service` (the 9 fixtures) and `btd6_stats_service` (the per-entity
 `stats/` tree, the 5.8 MB bulk) both read through the provider, so the whole
-data set honours `BTD6_DATA_BACKEND`. `!btd6ops seed-data` loads all 53 blobs
+data set honours `BTD6_DATA_BACKEND`. `!btd6ops seed-data` loads all 64 blobs
 into the table in one go.
 
 ## CI hermeticity

--- a/docs/btd6-decode-inventory-v55.md
+++ b/docs/btd6-decode-inventory-v55.md
@@ -98,85 +98,87 @@ Per-field verdict for everything the mapper already extracts. `SUSPECT` (>20% di
 
 The 'stat-based effect' half of the goal. These `$type`s are **inline behaviors in the tower models** (the dump has no `zones[]`/`buffs[]` arrays — those are our *output* schema). Ranked by occurrence: decode the headline effect number where one exists, else fall back to the textTable description (flagged).
 
+**Decode-class** (slice-2 registry, classification only — no numbers written): `SAFE_WRITE` = clear semantics + a committed buff-schema field; `SCHEMA_FIRST` = real number but the schema has no field yet (extend first); `DEFER` = ambiguous semantics; `DESCRIPTION_ONLY` = name/flag only (already covered by the upgrade description).
+
 ### 3a. Zone effect models — 28 distinct `$type`s
 
 > **Doc reconciliation:** `btd6-gamedata-decode-status.md` records "0 of 12 zone" — v55 actually has **28** distinct `*ZoneModel` `$type`s. The doc's 12 is an undercount; this report is the live ground truth.
 
-| Zone `$type` | Count | Decodable-number? | Has-curated-name? |
-|---|---|---|---|
-| `DiscountZoneModel` | 110 | no (name/flag only) | yes (buffLocsName) |
-| `SlowBloonsZoneModel` | 88 | no (name/flag only) | yes (model name) |
-| `AddBehaviorToBloonInZoneModel` | 69 | no (name/flag only) | via owning upgrade |
-| `ActivateRateSupportZoneModel` | 44 | geometry-only | yes (buffLocsName) |
-| `ActivateTowerDamageSupportZoneModel` | 36 | geometry-only | yes (buffLocsName) |
-| `CollectCashZoneModel` | 19 | no (name/flag only) | yes (model name) |
-| `DamageOverTimeZoneModel` | 19 | geometry-only | yes (model name) |
-| `BuffBlowbackZoneModel` | 18 | yes (multiplier) | via owning upgrade |
-| `CashbackZoneModel` | 17 | no (name/flag only) | yes (buffLocsName) |
-| `ActivatePierceSupportZoneModel` | 16 | geometry-only | yes (buffLocsName) |
-| `ActivateDamageModifierSupportZoneModel` | 16 | geometry-only | via owning upgrade |
-| `ActivateVisibilitySupportZoneModel` | 15 | geometry-only | yes (buffLocsName) |
-| `MoabShoveZoneModel` | 15 | geometry-only | via owning upgrade |
-| `ActivateTempTargetPrioSupportZoneModel` | 14 | geometry-only | via owning upgrade |
-| `ActivateIgnoreStunSupportZoneModel` | 12 | geometry-only | yes (buffLocsName) |
-| `BonusCashZoneModel` | 10 | yes (multiplier) | yes (model name) |
-| `NecromancerZoneModel` | 10 | no (name/flag only) | via owning upgrade |
-| `ActivateRangeSupportZoneModel` | 8 | yes (additive, multiplier) | via owning upgrade |
-| `BountyHunterZoneModel` | 5 | no (name/flag only) | yes (model name) |
-| `WindyZoneModel` | 3 | no (name/flag only) | via owning upgrade |
-| `ActivateSpreadSupportZoneModel` | 2 | geometry-only | via owning upgrade |
-| `ControlledRateZoneModel` | 2 | no (name/flag only) | via owning upgrade |
-| `ControlledStaminaDrainZoneModel` | 2 | no (name/flag only) | via owning upgrade |
-| `ControlledEffectZoneModel` | 2 | no (name/flag only) | via owning upgrade |
-| `ActivateAttackCollisionSupportZoneModel` | 1 | geometry-only | via owning upgrade |
-| `ActivateControlledZoneModel` | 1 | no (name/flag only) | via owning upgrade |
-| `DeActivateControlledZoneModel` | 1 | no (name/flag only) | via owning upgrade |
-| `SpikeParagonDamageZoneModel` | 1 | no (name/flag only) | via owning upgrade |
+| Zone `$type` | Count | Decodable-number? | Has-curated-name? | Decode-class |
+|---|---|---|---|---|
+| `DiscountZoneModel` | 110 | no (name/flag only) | yes (buffLocsName) | DESCRIPTION_ONLY |
+| `SlowBloonsZoneModel` | 88 | no (name/flag only) | yes (model name) | DESCRIPTION_ONLY |
+| `AddBehaviorToBloonInZoneModel` | 69 | no (name/flag only) | via owning upgrade | DESCRIPTION_ONLY |
+| `ActivateRateSupportZoneModel` | 44 | geometry-only | yes (buffLocsName) | DESCRIPTION_ONLY |
+| `ActivateTowerDamageSupportZoneModel` | 36 | geometry-only | yes (buffLocsName) | DESCRIPTION_ONLY |
+| `CollectCashZoneModel` | 19 | no (name/flag only) | yes (model name) | DESCRIPTION_ONLY |
+| `DamageOverTimeZoneModel` | 19 | geometry-only | yes (model name) | DESCRIPTION_ONLY |
+| `BuffBlowbackZoneModel` | 18 | yes (multiplier) | via owning upgrade | DEFER |
+| `CashbackZoneModel` | 17 | no (name/flag only) | yes (buffLocsName) | DESCRIPTION_ONLY |
+| `ActivatePierceSupportZoneModel` | 16 | geometry-only | yes (buffLocsName) | DESCRIPTION_ONLY |
+| `ActivateDamageModifierSupportZoneModel` | 16 | geometry-only | via owning upgrade | DESCRIPTION_ONLY |
+| `ActivateVisibilitySupportZoneModel` | 15 | geometry-only | yes (buffLocsName) | DESCRIPTION_ONLY |
+| `MoabShoveZoneModel` | 15 | geometry-only | via owning upgrade | DESCRIPTION_ONLY |
+| `ActivateTempTargetPrioSupportZoneModel` | 14 | geometry-only | via owning upgrade | DESCRIPTION_ONLY |
+| `ActivateIgnoreStunSupportZoneModel` | 12 | geometry-only | yes (buffLocsName) | DESCRIPTION_ONLY |
+| `BonusCashZoneModel` | 10 | yes (multiplier) | yes (model name) | SCHEMA_FIRST |
+| `NecromancerZoneModel` | 10 | no (name/flag only) | via owning upgrade | DESCRIPTION_ONLY |
+| `ActivateRangeSupportZoneModel` | 8 | yes (additive, multiplier) | via owning upgrade | DEFER |
+| `BountyHunterZoneModel` | 5 | no (name/flag only) | yes (model name) | DESCRIPTION_ONLY |
+| `WindyZoneModel` | 3 | no (name/flag only) | via owning upgrade | DESCRIPTION_ONLY |
+| `ActivateSpreadSupportZoneModel` | 2 | geometry-only | via owning upgrade | DESCRIPTION_ONLY |
+| `ControlledRateZoneModel` | 2 | no (name/flag only) | via owning upgrade | DESCRIPTION_ONLY |
+| `ControlledStaminaDrainZoneModel` | 2 | no (name/flag only) | via owning upgrade | DESCRIPTION_ONLY |
+| `ControlledEffectZoneModel` | 2 | no (name/flag only) | via owning upgrade | DESCRIPTION_ONLY |
+| `ActivateAttackCollisionSupportZoneModel` | 1 | geometry-only | via owning upgrade | DESCRIPTION_ONLY |
+| `ActivateControlledZoneModel` | 1 | no (name/flag only) | via owning upgrade | DESCRIPTION_ONLY |
+| `DeActivateControlledZoneModel` | 1 | no (name/flag only) | via owning upgrade | DESCRIPTION_ONLY |
+| `SpikeParagonDamageZoneModel` | 1 | no (name/flag only) | via owning upgrade | DESCRIPTION_ONLY |
 
 ### 3b. Buff / support effect models — 38 distinct `$type`s
 
 > **Doc reconciliation:** decode-status records "0 of 37 buff" — v55 has **38** distinct `*SupportModel`/`*BuffModel` `$type`s (the doc's 37 is close).
 
-| Buff/Support `$type` | Count | Decodable-number? | Has-curated-name? |
-|---|---|---|---|
-| `RangeSupportModel` | 163 | yes (additive, multiplier) | yes (buffLocsName) |
-| `PierceSupportModel` | 103 | yes (pierce) | yes (buffLocsName) |
-| `VisibilitySupportModel` | 94 | no (name/flag only) | yes (buffLocsName) |
-| `RateSupportModel` | 85 | yes (multiplier) | yes (buffLocsName) |
-| `PlacementAreaTypeRangeBuffModel` | 64 | no (name/flag only) | via owning upgrade |
-| `StartOfRoundRateBuffModel` | 41 | yes (modifier) | via owning upgrade |
-| `AddBehaviorToTowerSupportModel` | 39 | no (name/flag only) | yes (buffLocsName) |
-| `DroneSupportModel` | 38 | no (name/flag only) | yes (model name) |
-| `ProjectileSpeedSupportModel` | 30 | yes (multiplier) | yes (buffLocsName) |
-| `HeatItUpDamageBuffModel` | 28 | geometry-only | yes (buffLocsName) |
-| `MonkeyCityIncomeSupportModel` | 26 | no (name/flag only) | yes (buffLocsName) |
-| `DamageSupportModel` | 20 | no (name/flag only) | yes (model name) |
-| `AddBehaviorToTowerTypeSupportModel` | 19 | no (name/flag only) | yes (buffLocsName) |
-| `BananaCashIncreaseSupportModel` | 16 | yes (multiplier) | yes (buffLocsName) |
-| `PyrotechnicsSupportModel` | 16 | no (name/flag only) | yes (buffLocsName) |
-| `AbilityCooldownScaleSupportModel` | 16 | no (name/flag only) | yes (buffLocsName) |
-| `ObynGlobalSupportModel` | 16 | no (name/flag only) | via owning upgrade |
-| `FreezeDurationSupportModel` | 16 | yes (additive, multiplier) | yes (buffLocsName) |
-| `PiercePercentageSupportModel` | 15 | no (name/flag only) | yes (buffLocsName) |
-| `DamageTypeSupportModel` | 15 | no (name/flag only) | yes (buffLocsName) |
-| `BrickellFreezeMinesAbilityBuffModel` | 14 | yes (multiplier) | yes (buffLocsName) |
-| `SpiritTowerSupportModel` | 14 | no (name/flag only) | yes (model name) |
-| `ProjectileRadiusSupportModel` | 14 | yes (multiplier) | yes (model name) |
-| `CentralMarketBuffModel` | 10 | yes (multiplier) | yes (buffLocsName) |
-| `PoplustSupportModel` | 10 | no (name/flag only) | yes (buffLocsName) |
-| `EziliSupportModel` | 10 | no (name/flag only) | yes (model name) |
-| `GroundZeroBombBuffModel` | 10 | geometry-only | via owning upgrade |
-| `FreeUpgradeSupportModel` | 10 | no (name/flag only) | via owning upgrade |
-| `TradeEmpireBuffModel` | 6 | no (name/flag only) | yes (buffLocsName) |
-| `BananaCentralBuffModel` | 5 | yes (multiplier) | yes (buffLocsName) |
-| `SubCommanderSupportModel` | 5 | no (name/flag only) | yes (buffLocsName) |
-| `DamageModifierSupportModel` | 5 | no (name/flag only) | yes (model name) |
-| `TargetSupplierSupportModel` | 5 | no (name/flag only) | yes (model name) |
-| `PrinceOfDarknessZombieBuffModel` | 5 | no (name/flag only) | yes (buffLocsName) |
-| `DruidOfWrathBuffModel` | 3 | no (name/flag only) | via owning upgrade |
-| `ObynBuffModel` | 1 | no (name/flag only) | yes (buffLocsName) |
-| `MonkeySubParagonSupportModel` | 1 | no (name/flag only) | yes (buffLocsName) |
-| `GenericTowerBehaviorBuffModel` | 1 | no (name/flag only) | yes (buffLocsName) |
+| Buff/Support `$type` | Count | Decodable-number? | Has-curated-name? | Decode-class |
+|---|---|---|---|---|
+| `RangeSupportModel` | 163 | yes (additive, multiplier) | yes (buffLocsName) | DEFER |
+| `PierceSupportModel` | 103 | yes (pierce) | yes (buffLocsName) | SAFE_WRITE |
+| `VisibilitySupportModel` | 94 | no (name/flag only) | yes (buffLocsName) | DESCRIPTION_ONLY |
+| `RateSupportModel` | 85 | yes (multiplier) | yes (buffLocsName) | SAFE_WRITE |
+| `PlacementAreaTypeRangeBuffModel` | 64 | no (name/flag only) | via owning upgrade | DESCRIPTION_ONLY |
+| `StartOfRoundRateBuffModel` | 41 | yes (modifier) | via owning upgrade | DEFER |
+| `AddBehaviorToTowerSupportModel` | 39 | no (name/flag only) | yes (buffLocsName) | DESCRIPTION_ONLY |
+| `DroneSupportModel` | 38 | no (name/flag only) | yes (model name) | DESCRIPTION_ONLY |
+| `ProjectileSpeedSupportModel` | 30 | yes (multiplier) | yes (buffLocsName) | SCHEMA_FIRST |
+| `HeatItUpDamageBuffModel` | 28 | geometry-only | yes (buffLocsName) | DESCRIPTION_ONLY |
+| `MonkeyCityIncomeSupportModel` | 26 | no (name/flag only) | yes (buffLocsName) | DESCRIPTION_ONLY |
+| `DamageSupportModel` | 20 | no (name/flag only) | yes (model name) | DESCRIPTION_ONLY |
+| `AddBehaviorToTowerTypeSupportModel` | 19 | no (name/flag only) | yes (buffLocsName) | DESCRIPTION_ONLY |
+| `BananaCashIncreaseSupportModel` | 16 | yes (multiplier) | yes (buffLocsName) | SCHEMA_FIRST |
+| `PyrotechnicsSupportModel` | 16 | no (name/flag only) | yes (buffLocsName) | DESCRIPTION_ONLY |
+| `AbilityCooldownScaleSupportModel` | 16 | no (name/flag only) | yes (buffLocsName) | DESCRIPTION_ONLY |
+| `ObynGlobalSupportModel` | 16 | no (name/flag only) | via owning upgrade | DESCRIPTION_ONLY |
+| `FreezeDurationSupportModel` | 16 | yes (additive, multiplier) | yes (buffLocsName) | SCHEMA_FIRST |
+| `PiercePercentageSupportModel` | 15 | no (name/flag only) | yes (buffLocsName) | DESCRIPTION_ONLY |
+| `DamageTypeSupportModel` | 15 | no (name/flag only) | yes (buffLocsName) | DESCRIPTION_ONLY |
+| `BrickellFreezeMinesAbilityBuffModel` | 14 | yes (multiplier) | yes (buffLocsName) | DEFER |
+| `SpiritTowerSupportModel` | 14 | no (name/flag only) | yes (model name) | DESCRIPTION_ONLY |
+| `ProjectileRadiusSupportModel` | 14 | yes (multiplier) | yes (model name) | SCHEMA_FIRST |
+| `CentralMarketBuffModel` | 10 | yes (multiplier) | yes (buffLocsName) | SCHEMA_FIRST |
+| `PoplustSupportModel` | 10 | no (name/flag only) | yes (buffLocsName) | SAFE_WRITE |
+| `EziliSupportModel` | 10 | no (name/flag only) | yes (model name) | DESCRIPTION_ONLY |
+| `GroundZeroBombBuffModel` | 10 | geometry-only | via owning upgrade | DESCRIPTION_ONLY |
+| `FreeUpgradeSupportModel` | 10 | no (name/flag only) | via owning upgrade | DESCRIPTION_ONLY |
+| `TradeEmpireBuffModel` | 6 | no (name/flag only) | yes (buffLocsName) | DESCRIPTION_ONLY |
+| `BananaCentralBuffModel` | 5 | yes (multiplier) | yes (buffLocsName) | SCHEMA_FIRST |
+| `SubCommanderSupportModel` | 5 | no (name/flag only) | yes (buffLocsName) | DESCRIPTION_ONLY |
+| `DamageModifierSupportModel` | 5 | no (name/flag only) | yes (model name) | DESCRIPTION_ONLY |
+| `TargetSupplierSupportModel` | 5 | no (name/flag only) | yes (model name) | DESCRIPTION_ONLY |
+| `PrinceOfDarknessZombieBuffModel` | 5 | no (name/flag only) | yes (buffLocsName) | DESCRIPTION_ONLY |
+| `DruidOfWrathBuffModel` | 3 | no (name/flag only) | via owning upgrade | DESCRIPTION_ONLY |
+| `ObynBuffModel` | 1 | no (name/flag only) | yes (buffLocsName) | DESCRIPTION_ONLY |
+| `MonkeySubParagonSupportModel` | 1 | no (name/flag only) | yes (buffLocsName) | DESCRIPTION_ONLY |
+| `GenericTowerBehaviorBuffModel` | 1 | no (name/flag only) | yes (buffLocsName) | DESCRIPTION_ONLY |
 
 **Ranking summary:** 3/28 zone and 11/38 buff `$type`s carry a decodable effect number; the remainder are name/flag-only and fall back to the textTable description (partial-but-honest — show the words, never a guessed number).
 

--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -5,6 +5,93 @@ game-data dump** (`github.com/Btd6ModHelper/btd6-game-data`, v55.0). Start here
 to pick up the work: it records what's done, **how the dump's data actually
 works** (the traps we hit), and what is still un-decoded.
 
+---
+
+## ⭐ Next session — start here (updated 2026-06-04, end of v55 session)
+
+### Operating lesson (binding — survives the session boundary)
+
+**Green tests are not the verdict; live Discord behavior is.** "Done" means
+**extracted + reachable + answerable live, verified** — not committed, not
+test-green. **`extracted ≠ reachable ≠ answerable`** are three different states,
+and *most of this session's bugs lived in the gaps between them*: data was in a
+committed file (extracted) but a renderer dropped it or the resolver couldn't
+reach the entity (not reachable), or it reached the model but was mislabeled /
+the model asserted a false negative (not answerable). Verify the user-facing
+answer, not the unit test.
+
+### Prioritized tasks
+
+1. **Absence-claim guard — DESIGN FIRST, do NOT implement blind.** *The session's
+   most important discovery and the faithfulness mission's real frontier.* The
+   verifier catches ungrounded **numbers/names** but **not absence claims** — the
+   bot can fluently, version-stampedly say *"Ultra-Juggernaut has no damage
+   multipliers"* when it does, and nothing stops it. A fluent false "no" is worse
+   than a refusal: it looks authoritative. **Why next:** it is the core of the
+   faithfulness mission and currently wide open in *every* domain (auto-grounding
+   from #478 only mitigates the upgrade-modifier path). **How:** a design-doc +
+   Decisions task *before any code* — verifying a negative generally means
+   forcing a lookup before an absence assertion is allowed, which has latency and
+   false-positive costs that need a deliberate decision. **Definition of done:** a
+   written design proposal reviewed on the ChatGPT/Analysis side — **not** a
+   merged guard.
+
+2. **Finish the reachability sweep while the pattern is hot.** Two tool-gaps over
+   already-committed data, same shape as the rounds/maps/modes fixes that worked:
+   a **CT-relic roster/filter** tool (only named lookup today) and a
+   **bloon-property filter** ("which bloons are camo / lead / fortified?").
+   **Why next:** cheap, proven pattern, closes live refusals. **How:** read-only
+   service fn + tool spec/handler + add to `BTD6_GROUNDING_TOOL_NAMES`, each with
+   a **live** Discord confirmation of its example question. **Definition of done:**
+   reachable by tool **and answerable live** — not test-green.
+
+3. **Step 5 numeric slice 2 — registry-gated, one `$type` at a time. Never
+   bulk-write.** Use the **Decode-class** registry now in the inventory report
+   (`btd6-decode-inventory-v55.md` §3 / `_DECODE_CLASS`). Order: start with
+   `SAFE_WRITE` additive types (`PierceSupport`, `RateSupport`); do `SCHEMA_FIRST`
+   for `ProjectileSpeed` / `Visibility` etc. (extend the buff schema + dataclasses
+   + renderers + tests **before** writing any data); **DEFER** the ambiguous
+   `RangeSupport.multiplier` until examples prove its semantics. **Why next:** the
+   decoded-effect half of the end goal, now de-risked by the classification.
+   **How:** per `$type` — verify its number individually vs a committed example,
+   write additively (never clobber curated buffs), wire through the existing
+   `buffs[]`/`zones[]` grounding. **Definition of done per slice:** extracted +
+   committed + retrievable by tool + **verified live** + the per-`$type` number
+   verified individually + schema changes conform to the architecture /
+   registry-snapshot invariants (expect one to bite — conform, don't fight).
+
+4. **Subtower tail** — `MorphTowerModel` named-ref (Alchemist "Transformed
+   Monkey") + `BeastHandlerPetModel` (Beast Handler pets), still missing. **Why:**
+   required before any game-native tower cutover. **Definition of done:** both
+   spawn mechanisms emit subtowers, answerable live.
+
+### Verification status (this session)
+
+> **Live-Discord verification was NOT possible from the build sandbox** (no bot
+> session). The items below are **code/behavior-confirmed** through the real
+> service paths but **UNVERIFIED live** — the next session/maintainer must run
+> the exact checks in Discord before marking them done.
+
+| Item | Code-confirmed | UNVERIFIED-live — exact manual check |
+|---|---|---|
+| Refusal stamps v55 | `_btd6_game_version()` → `55.0` | Ask an ungroundable BTD6 question; the refusal must read "(55.0)", not 54.0. |
+| Damage modifiers ground | `grounding_for_query("ultra jug")` → "+20 damage vs Lead, +8 damage vs Ceramic, +5 damage vs Fortified" | Ask "what are Ultra-Juggernaut's damage multipliers / bonus vs Lead/Ceramic" — must return those numbers, not "no multipliers". |
+| Poplust % render | `_buff_text({ratePercentage:0.15})` → "15% attack speed" | Ask about Druid Poplust's buff — must read +15% (pierce/attack-speed), not +0.15%. |
+| Round/map/mode tools | `round_composition(35,70,'purple')`→290; Logs→Beginner; CHIMPS→cash 650 | Ask "how many purples in rounds 35-70" (→290), "which maps are beginner", "CHIMPS restrictions". |
+
+### Provenance decision (recorded, not auto-applied)
+
+Top-level fixtures stamp **55.0** (the user-facing dataset version, read by the
+refusal). The per-file `stats/*.json` `game_version` stays **mixed** (v46.3–55.0)
+on purpose — it is the *source vintage* (when those numbers were last sourced by
+the overlay), not a correctness claim. A blanket re-stamp to 55.0 was **declined**:
+the `--audit` is per-**field**, not per-file, so there is no clean per-file gate,
+and re-stamping unchanged bloonswiki files would falsely claim re-sourcing. A file
+is re-stamped only when `--overlay`/`--all` actually re-sources it. *(Open nit: 2
+economy files have an empty stamp — decide a value on the next real re-source.)*
+
+---
+
 > Companion docs — read alongside:
 > - **`btd6-gamedata-native-schema.md`** — *the game-native storage design & cutover map* (game data leads; how to store the game's structure displayably).
 > - **`btd6-gamedata-dictionary.md`** — *what data exists and where* (domains, the textTable linkage).
@@ -132,8 +219,6 @@ must not be treated as done. Verified against the v55 dump on 2026-06-03.
   `$type`s — report §3b. Close to the prior figure but not equal.)*
 - **Economy-tower attack suppression** (Banana Farm shows a nominal AttackModel).
 - **The towers cutover itself** — blocked on zones + buffs + the subtower tail.
-- **Descriptions consumed by the runtime** — extracted into upgrade data, but
-  not yet wired into grounding / the detail UI.
 - **Bloons / bosses game-native ingestion** (still wiki-sourced).
 - **Powers / Knowledge / Rounds (all modes) / IncomeSets ingestion.**
 - **Paragon overlay / cutover** (combat in a `base` node, not `tiers`/`levels`).

--- a/scripts/btd6_decode_inventory_report.py
+++ b/scripts/btd6_decode_inventory_report.py
@@ -184,6 +184,38 @@ _GEOMETRY_NUM = {
 # Dump keys that carry / resolve a display name for an effect node.
 _NAME_KEYS = {"buffLocsName", "locsName", "LocsKey", "displayName", "name"}
 
+# --- Step-5 decoder registry (CLASSIFICATION ONLY — writes no buff numbers) --
+# How each decodable-number effect `$type` should be handled in the slice-2
+# numeric write. This is scaffolding for that work; it does not extract or write
+# anything. Classes:
+#   SAFE_WRITE       - clear semantics + a committed buff-schema field exists
+#                      (verified vs a committed example or an unambiguous field).
+#   SCHEMA_FIRST     - real number, but NO field in the committed buff schema
+#                      (extend schema + dataclasses + renderers + tests first).
+#   DEFER            - ambiguous semantics; needs examples before any write.
+#   DESCRIPTION_ONLY - name/flag only; the upgrade description already covers it.
+# Everything not listed here is DESCRIPTION_ONLY by default.
+_DECODE_CLASS: dict[str, str] = {
+    # SAFE_WRITE — additive/multiplier maps cleanly onto _BUFF_FIELDS
+    "PierceSupportModel": "SAFE_WRITE",  # pierce -> pierceAdditive
+    "RateSupportModel": "SAFE_WRITE",  # multiplier -> rateMultiplier (x-cooldown)
+    "PoplustSupportModel": "SAFE_WRITE",  # *PercentIncrease -> *Percentage (verified)
+    # SCHEMA_FIRST — real number, no committed buff-schema field yet
+    "ProjectileSpeedSupportModel": "SCHEMA_FIRST",
+    "ProjectileRadiusSupportModel": "SCHEMA_FIRST",
+    "FreezeDurationSupportModel": "SCHEMA_FIRST",
+    "BananaCashIncreaseSupportModel": "SCHEMA_FIRST",  # economy
+    "CentralMarketBuffModel": "SCHEMA_FIRST",  # economy
+    "BananaCentralBuffModel": "SCHEMA_FIRST",  # economy
+    "BonusCashZoneModel": "SCHEMA_FIRST",  # economy zone
+    # DEFER — ambiguous magnitude/semantics until examples prove them
+    "RangeSupportModel": "DEFER",  # multiplier is an ambiguous fraction
+    "StartOfRoundRateBuffModel": "DEFER",  # bare "modifier"
+    "BrickellFreezeMinesAbilityBuffModel": "DEFER",  # niche
+    "BuffBlowbackZoneModel": "DEFER",  # knockback magnitude
+    "ActivateRangeSupportZoneModel": "DEFER",  # timed activated zone
+}
+
 
 def _dump_sha(dump: Path) -> str:
     """The pinned commit SHA of the dump clone (the report's cache key)."""
@@ -382,6 +414,14 @@ def build_report(dump: Path) -> str:
         "exists, else fall back to the textTable description (flagged).",
     )
     lines.append("")
+    lines.append(
+        "**Decode-class** (slice-2 registry, classification only — no numbers "
+        "written): `SAFE_WRITE` = clear semantics + a committed buff-schema field; "
+        "`SCHEMA_FIRST` = real number but the schema has no field yet (extend "
+        "first); `DEFER` = ambiguous semantics; `DESCRIPTION_ONLY` = name/flag "
+        "only (already covered by the upgrade description).",
+    )
+    lines.append("")
     zone_rows = tail["zone"]
     buff_rows = tail["buff"]
     lines.append(f"### 3a. Zone effect models — {len(zone_rows)} distinct `$type`s")
@@ -394,11 +434,23 @@ def build_report(dump: Path) -> str:
     )
     lines.append("")
     z_rows = [
-        [f"`{t}`", str(n), _decodable(nums), _has_name(names)]
+        [
+            f"`{t}`",
+            str(n),
+            _decodable(nums),
+            _has_name(names),
+            _DECODE_CLASS.get(t, "DESCRIPTION_ONLY"),
+        ]
         for t, n, nums, names in zone_rows
     ]
     lines += _md_table(
-        ["Zone `$type`", "Count", "Decodable-number?", "Has-curated-name?"],
+        [
+            "Zone `$type`",
+            "Count",
+            "Decodable-number?",
+            "Has-curated-name?",
+            "Decode-class",
+        ],
         z_rows,
     )
     lines.append("")
@@ -413,11 +465,23 @@ def build_report(dump: Path) -> str:
     )
     lines.append("")
     b_rows = [
-        [f"`{t}`", str(n), _decodable(nums), _has_name(names)]
+        [
+            f"`{t}`",
+            str(n),
+            _decodable(nums),
+            _has_name(names),
+            _DECODE_CLASS.get(t, "DESCRIPTION_ONLY"),
+        ]
         for t, n, nums, names in buff_rows
     ]
     lines += _md_table(
-        ["Buff/Support `$type`", "Count", "Decodable-number?", "Has-curated-name?"],
+        [
+            "Buff/Support `$type`",
+            "Count",
+            "Decodable-number?",
+            "Has-curated-name?",
+            "Decode-class",
+        ],
         b_rows,
     )
     lines.append("")

--- a/scripts/parse_gamedata.py
+++ b/scripts/parse_gamedata.py
@@ -1283,10 +1283,19 @@ def overlay_payload(committed: dict, mapped: dict, version: str) -> list[str]:
 # ---------------------------------------------------------------------------
 
 
-def apply_upgrade_descriptions(committed: dict, mapped: dict) -> list[str]:
+def apply_upgrade_descriptions(
+    committed: dict,
+    mapped: dict,
+    text_table: dict[str, str] | None = None,
+) -> list[str]:
     """Set each committed upgrade's ``description`` from the mapped (game) prose,
     aligned by ``(path, tier)``; return the list of changes. Names are frozen —
     a description write must never disturb a curated name.
+
+    Any upgrade the mapper didn't supply (the ~2 nodes it under-emits) falls back
+    to ``text_table["<curated name> Description"]`` — a reliable join because the
+    game localizes these by the same name the curated file uses. Editorial names
+    not in ``text_table`` simply no-op (never a guessed description).
     """
     names_before = collect_names(committed)
     mmap = {
@@ -1294,14 +1303,17 @@ def apply_upgrade_descriptions(committed: dict, mapped: dict) -> list[str]:
         for u in mapped.get("upgrades", []) or []
         if isinstance(u, dict)
     }
+    tt = text_table or {}
     changes: list[str] = []
     for up in committed.get("upgrades", []) or []:
         if not isinstance(up, dict):
             continue
         m = mmap.get((up.get("path"), up.get("tier")))
-        if not m:
-            continue
-        new = m.get("description")
+        new = m.get("description") if m else None
+        if not isinstance(new, str) or not new.strip():
+            # Fallback: the game's "<curated name> Description" string.
+            name = up.get("name")
+            new = tt.get(f"{name} Description") if isinstance(name, str) else None
         if not isinstance(new, str) or not new.strip():
             continue
         if up.get("description") != new:
@@ -1358,7 +1370,7 @@ def overlay_descriptions(dump: Path, *, dry_run: bool) -> dict[str, list[str]]:
             continue
         committed = json.loads(fp.read_text("utf-8"))
         mapped = map_tower(dump, tid, canonical, version).payload
-        changes = apply_upgrade_descriptions(committed, mapped)
+        changes = apply_upgrade_descriptions(committed, mapped, _text_table(dump))
         if changes:
             report[f"stats/{tid}.json"] = changes
             if not dry_run:

--- a/tests/unit/scripts/test_btd6_decode_inventory_report.py
+++ b/tests/unit/scripts/test_btd6_decode_inventory_report.py
@@ -143,3 +143,13 @@ def test_md_table_shapes_header_and_rows(mod):
 def test_dump_sha_unknown_outside_git(mod, tmp_path):
     # A non-git directory yields the documented sentinel, never a crash.
     assert mod._dump_sha(tmp_path) == "unknown"
+
+
+def test_decode_class_registry_is_classification_only(mod):
+    # Slice-2 scaffolding: the registry classifies but writes no numbers.
+    c = mod._DECODE_CLASS
+    assert c["PierceSupportModel"] == "SAFE_WRITE"
+    assert c["RateSupportModel"] == "SAFE_WRITE"
+    assert c["ProjectileSpeedSupportModel"] == "SCHEMA_FIRST"
+    assert c["RangeSupportModel"] == "DEFER"  # ambiguous multiplier
+    assert set(c.values()) <= {"SAFE_WRITE", "SCHEMA_FIRST", "DEFER", "DESCRIPTION_ONLY"}

--- a/tests/unit/scripts/test_parse_gamedata.py
+++ b/tests/unit/scripts/test_parse_gamedata.py
@@ -732,3 +732,18 @@ def test_apply_hero_descriptions_skips_empty(mod):
     mapped = {"levels": {"1": {"description": ""}}}
     assert mod.apply_hero_descriptions(committed, mapped) == []
     assert "description" not in committed["levels"]["1"]
+
+
+def test_apply_upgrade_descriptions_texttable_fallback_by_curated_name(mod):
+    # The 2 cards the mapper under-emits: fall back to the game's
+    # "<curated name> Description" when the mapped payload has none.
+    committed = {"upgrades": [{"path": 1, "tier": 4, "name": "Operation: Dart Storm"}]}
+    mapped = {"upgrades": []}  # mapper emitted nothing for this node
+    tt = {"Operation: Dart Storm Description": "Shoots 16 darts per volley."}
+    changes = mod.apply_upgrade_descriptions(committed, mapped, tt)
+    assert committed["upgrades"][0]["description"] == "Shoots 16 darts per volley."
+    assert len(changes) == 1
+    # An editorial name not in the textTable stays empty (never invented).
+    c2 = {"upgrades": [{"path": 3, "tier": 5, "name": "Reanimate"}]}
+    assert mod.apply_upgrade_descriptions(c2, {"upgrades": []}, tt) == []
+    assert "description" not in c2["upgrades"][0]

--- a/tests/unit/services/test_btd6_upgrade_detail_service.py
+++ b/tests/unit/services/test_btd6_upgrade_detail_service.py
@@ -169,13 +169,14 @@ def test_description_line_present_even_with_combat_stats():
     assert "in-game description" in lines[1]
 
 
-def test_missing_description_grounds_no_phantom_line():
-    # 2 of 375 cards have no textTable Description (the mapper under-emits the
-    # node). The grounding must simply omit the prose line — never invent one —
-    # while still surfacing the combat stats.
+def test_under_emitted_card_description_filled_via_texttable_fallback():
+    # The 2 cards the mapper under-emits (Ace "Operation: Dart Storm", Wizard
+    # "Necromancer: Unpopped Army") now get their description from the textTable
+    # "<curated name> Description" fallback — 375/375 cards carry prose.
     lines = det.grounding_for_query("Operation Dart Storm")
-    assert lines  # still grounds
-    assert not any("in-game description" in ln for ln in lines)
+    desc = [ln for ln in lines if "in-game description" in ln]
+    assert len(desc) == 1
+    assert "16 darts" in desc[0]
     assert any("main attack" in ln for ln in lines)
 
 


### PR DESCRIPTION
## What & why

The deliberately small **session-closing PR**: verify what this v55 session shipped, fix only genuinely small issues, and leave the docs so the next session starts from truth. **No new features, no step-5 numeric writes, no absence-claim guard** — anything bigger than small is documented as a task instead.

## Verified — code/behavior-confirmed, but UNVERIFIED **live**
I cannot reach Discord from the build sandbox, so per your instruction each item below is **code/behavior-confirmed** through the real service paths and recorded as **UNVERIFIED-live with the exact manual check** in the status doc (not marked "done"):

| Item | Code-confirmed |
|---|---|
| Refusal stamps v55 | `_btd6_game_version()` → `55.0` |
| Damage modifiers ground | `grounding_for_query("ultra jug")` → "+20 **damage** vs Lead, +8 vs Ceramic, +5 vs Fortified" |
| Poplust % render | `_buff_text({ratePercentage:0.15})` → "15% attack speed" |
| Round/map/mode tools | purples 35–70 → **290**; Logs → Beginner; CHIMPS → cash 650 |

## Small fixes
- **2 missing upgrade cards (373→375).** Confirmed mapper under-emission; the descriptions **exist in textTable under the curated name**, so `apply_upgrade_descriptions` now falls back to `"<curated name> Description"` (Ace "Operation: Dart Storm" → "Shoots 16 darts per volley…"; Wizard "Necromancer: Unpopped Army"). Editorial names not in textTable still no-op — never invented.
- **Stale seed count 53 → 64** (the real `build_rows` figure).

## Scaffolding (classification only — writes no buff numbers)
- **Decode-class registry** (`_DECODE_CLASS`): `SAFE_WRITE` / `SCHEMA_FIRST` / `DEFER` / `DESCRIPTION_ONLY` per decodable `$type`, now a column in `btd6-decode-inventory-v55.md` §3. De-risks slice 2.

## Confirmed against main (the two #480 items that were crowded out)
- Decoder registry **did not land in #480** → added here (classification only).
- Provenance normalization **did not land** → **decision recorded, not auto-applied**: per-file `stats/*.json` `game_version` stays *source-vintage*; the dataset stamp (55.0) is the user-facing version; no blanket re-stamp because `--audit` is per-**field**, not per-file (so there's no clean per-file gate, and re-stamping unchanged files would falsely claim re-sourcing).

## Docs hand-off (the important part)
Rewrote the **top** of `btd6-gamedata-decode-status.md` into a "Next session — start here":
- The **binding operating lesson** — *green tests ≠ verdict; `extracted ≠ reachable ≠ answerable`; "done" = answerable live, verified.*
- A **prioritized task list** with why / how / definition-of-done: **(1) absence-claim guard — DESIGN-FIRST, do not implement blind** (the session's key discovery: the guard catches false numbers but not false *negatives*); (2) finish the reachability sweep (CT-relic + bloon-property tools); (3) step-5 slice 2 — registry-gated, one `$type` at a time, never bulk-write; (4) subtower tail.
- The verification table + provenance decision.
- Removed the stale *"descriptions not wired into grounding"* line (#474/#475 disproved it).

## CI
`python3.10 scripts/check_quality.py --full` → **7221 passed, 3 skipped**; `check_architecture --mode strict` clean. Inventory report regenerates deterministically.

https://claude.ai/code/session_01PtRrhCT9KCdukWnUzUEQH6

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtRrhCT9KCdukWnUzUEQH6)_