### PR TITLE
BTD6: heaviest-waves fix + relic/bloon/cumulative-cost tools + absence-claim & derived-value design

### DIFF
--- a/disbot/services/ai_tools.py
+++ b/disbot/services/ai_tools.py
@@ -753,7 +753,10 @@ _BTD6_ROUND_COMPOSITION_SPEC = AIToolSpec(
         "round_start (and round_end for a range). Pass a bloon (e.g. 'purple', "
         "'ceramic', 'MOAB') to get its TOTAL across the range plus the per-round "
         "counts; omit it for each round's full spawn list + RBE. Do not count or "
-        "sum yourself — this returns the exact totals."
+        "sum yourself — this returns the exact totals. For 'heaviest / most / "
+        "which rounds have the most' questions, read the pre-ranked `heaviest` "
+        "(with a bloon, ranked by count) or `heaviest_by_rbe` (without, ranked "
+        "by RBE) — do NOT re-rank the per-round list yourself."
     ),
     parameters={
         "type": "object",
@@ -886,6 +889,205 @@ async def _btd6_mode_lookup(arguments: dict[str, Any]) -> dict[str, Any]:
         return {"found": True, "mode": _mode_dict(entry)}
     modes = btd6_data_service.get_dataset().modes
     return {"found": True, "count": len(modes), "modes": [_mode_dict(m) for m in modes]}
+
+
+# --- btd6_relic_lookup -------------------------------------------------------
+
+_BTD6_RELIC_LOOKUP_SPEC = AIToolSpec(
+    name="btd6_relic_lookup",
+    description=(
+        "BTD6 Contested Territory (CT) relic info: each relic's effect and "
+        "category (offense / economy / lives / powerup / utility). Pass a relic "
+        "name to look one up, a category to list that group, or omit both to "
+        "list every relic. Use for 'list the CT relics', 'which relics are "
+        "offense', 'what does the Super Monkey Storm relic do'."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "relic": {
+                "type": "string",
+                "description": "Relic name/abbrev (e.g. 'Super Monkey Storm', 'SMS'); omit to list.",
+            },
+            "category": {
+                "type": "string",
+                "description": "Filter the roster: offense / economy / lives / powerup / utility.",
+            },
+        },
+        "additionalProperties": False,
+    },
+    min_scope=AIScope.USER,
+)
+
+
+def _relic_dict(entry: Any) -> dict[str, Any]:
+    return {
+        "name": entry.canonical,
+        "category": entry.category,
+        "effect": entry.effect,
+        "abbrev": entry.abbrev,
+    }
+
+
+async def _btd6_relic_lookup(arguments: dict[str, Any]) -> dict[str, Any]:
+    from services import btd6_data_service
+
+    name = str(arguments.get("relic") or "").strip()
+    if name:
+        entry = btd6_data_service.resolve_relic(name)
+        if entry is None:
+            return {"found": False, "note": f"unknown relic: {name!r}"}
+        return {"found": True, "relic": _relic_dict(entry)}
+    relics = btd6_data_service.list_ct_relics()
+    category = str(arguments.get("category") or "").strip().lower()
+    if category:
+        relics = tuple(r for r in relics if r.category == category)
+        if not relics:
+            return {"found": False, "note": f"no relics in category {category!r}"}
+    return {
+        "found": True,
+        "count": len(relics),
+        "category": category or "all",
+        "relics": [_relic_dict(r) for r in relics],
+    }
+
+
+# --- btd6_bloon_filter -------------------------------------------------------
+
+_BTD6_BLOON_FILTER_SPEC = AIToolSpec(
+    name="btd6_bloon_filter",
+    description=(
+        "Filter the BTD6 bloon catalog by trait. Use for 'which bloons are camo "
+        "/ lead / fortified / regrow', 'which bloons are immune to Explosion', "
+        "'list the MOAB-class bloons'. Pass property (camo, lead, fortified, "
+        "regrow, black, moab-class), category (basic, special, moab_class, "
+        "modifier), and/or immune (a damage type: Explosion, Sharp, Cold, "
+        "Energy, Plasma, Fire …). Omit all to list every bloon. IMPORTANT: "
+        "camo / fortified / regrow are also MODIFIERS that can be applied to "
+        "other bloons in some rounds/modes — when the result carries a "
+        "`modifiers` entry, say so rather than implying only the listed bloons "
+        "ever carry the trait."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "property": {
+                "type": "string",
+                "description": "Trait tag, e.g. 'camo', 'lead', 'fortified', 'regrow', 'moab-class'.",
+            },
+            "category": {
+                "type": "string",
+                "description": "Bloon class: basic / special / moab_class / modifier.",
+            },
+            "immune": {
+                "type": "string",
+                "description": "Damage type the bloon resists, e.g. 'Explosion', 'Sharp', 'Cold'.",
+            },
+        },
+        "additionalProperties": False,
+    },
+    min_scope=AIScope.USER,
+)
+
+
+def _bloon_dict(entry: Any) -> dict[str, Any]:
+    return {
+        "name": entry.canonical,
+        "category": entry.category,
+        "properties": list(entry.properties),
+        "immune_to": list(entry.immune_to),
+        "description": entry.description,
+    }
+
+
+async def _btd6_bloon_filter(arguments: dict[str, Any]) -> dict[str, Any]:
+    from services import btd6_data_service
+
+    prop = str(arguments.get("property") or "").strip() or None
+    category = str(arguments.get("category") or "").strip() or None
+    immune = str(arguments.get("immune") or "").strip() or None
+    matches = btd6_data_service.filter_bloons(
+        bloon_property=prop,
+        category=category,
+        immune=immune,
+    )
+    # Split the inherently-tagged bloons from the modifier pseudo-entries so the
+    # model can answer faithfully ("DDT is inherently Camo; Camo is also a
+    # modifier other bloons can gain") instead of implying a closed set.
+    real = [b for b in matches if b.category != "modifier"]
+    modifiers = [b for b in matches if b.category == "modifier"]
+    if not matches:
+        return {
+            "found": False,
+            "filter": {"property": prop, "category": category, "immune": immune},
+            "note": "no bloons match that filter",
+        }
+    out: dict[str, Any] = {
+        "found": True,
+        "filter": {"property": prop, "category": category, "immune": immune},
+        "count": len(real),
+        "bloons": [_bloon_dict(b) for b in real],
+    }
+    if modifiers:
+        out["modifiers"] = [
+            {"name": m.canonical, "applies_broadly": True, "note": m.description}
+            for m in modifiers
+        ]
+    return out
+
+
+# --- btd6_cumulative_cost ----------------------------------------------------
+
+_BTD6_CUMULATIVE_COST_SPEC = AIToolSpec(
+    name="btd6_cumulative_cost",
+    description=(
+        "Total cumulative cost to REACH each BTD6 upgrade tier on a tower — the "
+        "tower base cost plus every earlier tier on that path, ALREADY SUMMED. "
+        "Use for 'total cost to reach <upgrade>', 'cost to get to tier 5', 'how "
+        "much for the whole path', 'base cost and all earlier upgrades "
+        "included'. Pass the tower and optionally difficulty (easy / medium / "
+        "hard / impoppable; default medium) and/or path (top / mid / bot). "
+        "Returns the exact running totals — do NOT add the per-tier prices "
+        "yourself: difficulty pricing rounds each purchase to $5 before "
+        "summing, so a sum-then-scale total is off by a few dollars. The "
+        "returned cumulative_cost IS the grounded answer."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "tower": {
+                "type": "string",
+                "description": "Tower name (e.g. 'Tack Shooter').",
+            },
+            "difficulty": {
+                "type": "string",
+                "description": "easy / medium / hard / impoppable (default medium).",
+            },
+            "path": {
+                "type": "string",
+                "description": "Limit to one path: top / mid / bot (omit for all three).",
+            },
+        },
+        "required": ["tower"],
+        "additionalProperties": False,
+    },
+    min_scope=AIScope.USER,
+)
+
+
+async def _btd6_cumulative_cost(arguments: dict[str, Any]) -> dict[str, Any]:
+    from services import btd6_data_service
+
+    tower = str(arguments.get("tower") or "").strip()
+    if not tower:
+        return {"found": False, "note": "tower is required"}
+    difficulty = str(arguments.get("difficulty") or "medium").strip() or "medium"
+    path = str(arguments.get("path") or "").strip() or None
+    return btd6_data_service.cumulative_upgrade_costs(
+        tower,
+        difficulty=difficulty,
+        path=path,
+    )
 
 
 # --- btd6_paragon_calculate --------------------------------------------------
@@ -1358,6 +1560,9 @@ BTD6_GROUNDING_TOOL_NAMES: frozenset[str] = frozenset(
         "btd6_round_composition",
         "btd6_map_lookup",
         "btd6_mode_lookup",
+        "btd6_relic_lookup",
+        "btd6_bloon_filter",
+        "btd6_cumulative_cost",
         "btd6_paragon_calculate",
         "btd6_paragon_requirements",
         "btd6_paragon_stats_at_degree",
@@ -1403,6 +1608,9 @@ def build_registry(
         (_BTD6_ROUND_COMPOSITION_SPEC, _btd6_round_composition),
         (_BTD6_MAP_LOOKUP_SPEC, _btd6_map_lookup),
         (_BTD6_MODE_LOOKUP_SPEC, _btd6_mode_lookup),
+        (_BTD6_RELIC_LOOKUP_SPEC, _btd6_relic_lookup),
+        (_BTD6_BLOON_FILTER_SPEC, _btd6_bloon_filter),
+        (_BTD6_CUMULATIVE_COST_SPEC, _btd6_cumulative_cost),
         (_PARAGON_CALCULATE_SPEC, _paragon_calculate),
         (_PARAGON_REQUIREMENTS_SPEC, _paragon_requirements),
         (_BTD6_PARAGON_STATS_AT_DEGREE_SPEC, _btd6_paragon_stats_at_degree),

--- a/disbot/services/btd6_data_service.py
+++ b/disbot/services/btd6_data_service.py
@@ -927,9 +927,57 @@ def resolve_bloon_id(name: str) -> str | None:
     return None
 
 
+# Natural words the model is likely to pass -> the committed ``properties`` tag,
+# so "moab" / "regrowth" resolve to the canonical trait. Tags already spelled
+# exactly (e.g. "camo", "lead") pass through the ``.get(..., default)`` below.
+_BLOON_PROPERTY_SYNONYMS: dict[str, str] = {
+    "moab": "moab-class",
+    "moab class": "moab-class",
+    "moab-class": "moab-class",
+    "regrowth": "regrow",
+}
+
+
+def filter_bloons(
+    *,
+    bloon_property: str | None = None,
+    category: str | None = None,
+    immune: str | None = None,
+) -> tuple[BloonEntry, ...]:
+    """Bloons matching ALL supplied filters, in catalog order (empty if none).
+
+    ``bloon_property`` matches a committed trait tag (``camo`` / ``lead`` /
+    ``fortified`` / ``regrow`` / ``moab-class`` …), accepting a natural word via
+    :data:`_BLOON_PROPERTY_SYNONYMS`; ``category`` matches the bloon class
+    (``basic`` / ``special`` / ``moab_class`` / ``modifier``); ``immune`` matches
+    a resisted damage-type name (``Explosion`` / ``Sharp`` / ``Cold`` …). Note
+    that ``camo`` / ``fortified`` / ``regrow`` are also ``modifier``-class
+    pseudo-entries — callers should surface those distinctly so an answer does
+    not imply only the inherently-tagged bloons can ever carry the trait.
+    """
+    out = list(get_dataset().bloons)
+    if bloon_property:
+        needle = bloon_property.strip().lower()
+        tag = _BLOON_PROPERTY_SYNONYMS.get(needle, needle)
+        out = [b for b in out if tag in b.properties]
+    if category:
+        cat = category.strip().lower()
+        out = [b for b in out if b.category == cat]
+    if immune:
+        dmg = immune.strip().lower()
+        out = [b for b in out if any(i.lower() == dmg for i in b.immune_to)]
+    return tuple(out)
+
+
 # Cap the per-round detail a round-composition query returns so a wide range
 # (e.g. "moabs in rounds 1-140") can't blow the grounding token budget.
 _ROUND_DETAIL_CAP = 40
+
+# How many "heaviest" rounds the tool ranks for the model. The tool ranks them
+# itself (so the model never re-sorts the per-round list — it did, badly) and
+# ranks from the FULL range, before _ROUND_DETAIL_CAP truncates the detail, so a
+# wide range can't hide a heavy late round out of the ranking.
+_HEAVIEST_CAP = 8
 
 
 def round_composition(
@@ -975,12 +1023,17 @@ def round_composition(
                 per_round.append({"round": entry.round_number, "count": count})
                 total += count
         record = get_bloon(bid)
+        # Rank the heaviest rounds here (count desc, ties by round asc) from the
+        # FULL list — before the detail cap — so the model never has to sort and
+        # a wide range can't truncate a heavy late round out of the ranking.
+        heaviest = sorted(per_round, key=lambda d: (-d["count"], d["round"]))
         out.update(
             {
                 "bloon": record.canonical if record else bid,
                 "bloon_id": bid,
                 "total": total,
                 "rounds_with_bloon": len(per_round),
+                "heaviest": heaviest[:_HEAVIEST_CAP],
                 "per_round": per_round[:_ROUND_DETAIL_CAP],
                 "truncated": len(per_round) > _ROUND_DETAIL_CAP,
             },
@@ -999,9 +1052,16 @@ def round_composition(
                     ],
                 },
             )
+        # Heaviest rounds by total RBE (children-inclusive), ranked over the full
+        # range so the cap on ``rounds`` can't hide a heavy late round either.
+        heaviest = sorted(
+            ({"round": r.round_number, "rbe": r.rbe or 0} for r in rounds),
+            key=lambda d: (-d["rbe"], d["round"]),
+        )
         out.update(
             {
                 "total_rbe": sum(r.rbe or 0 for r in rounds),
+                "heaviest_by_rbe": heaviest[:_HEAVIEST_CAP],
                 "rounds": detail,
                 "truncated": len(rounds) > _ROUND_DETAIL_CAP,
             },
@@ -1033,6 +1093,70 @@ def find_map(name: str) -> MapEntry | None:
 def find_mode(name: str) -> ModeEntry | None:
     """Resolve a game mode by name / alias / id (``"chimps"`` -> CHIMPS)."""
     return _find_by_surface(get_dataset().modes, name)
+
+
+def cumulative_upgrade_costs(
+    tower: str,
+    *,
+    difficulty: str = "medium",
+    path: str | None = None,
+) -> dict[str, Any]:
+    """Cumulative cost to REACH each upgrade tier on ``tower``: the tower base
+    plus every earlier tier on that path, already summed, per path.
+
+    Difficulty pricing scales and rounds **each purchase** to $5 *before*
+    summing, so a sum-then-scale total is wrong (e.g. Tack Shooter top path to
+    Inferno Ring on Easy is $42,760, not ``round5($50,310 x 0.85)`` = $42,765).
+    This returns the correct per-item running totals so the answer is a grounded
+    tool output, not a number the model has to derive. Medium by default.
+    """
+    from utils.btd6 import difficulty_costs
+
+    entry = _find_by_surface(get_dataset().towers, tower)
+    if entry is None:
+        return {"found": False, "note": f"unknown tower: {tower!r}"}
+    try:
+        diff = difficulty_costs.normalize_difficulty(difficulty)
+    except ValueError:
+        return {"found": False, "note": f"unknown difficulty: {difficulty!r}"}
+    paths = entry.upgrade_paths or {}
+    costs = entry.upgrade_costs or {}
+    wanted = path.strip().lower() if path else None
+    if wanted is not None and wanted not in paths:
+        return {"found": False, "note": f"unknown path: {path!r} (top/mid/bot)"}
+
+    base = difficulty_costs.cost_for_difficulty(entry.base_cost, diff)
+    out_paths: dict[str, list[dict[str, Any]]] = {}
+    for pkey, names in paths.items():
+        if wanted is not None and pkey != wanted:
+            continue
+        path_costs = costs.get(pkey, ())
+        running = base
+        tiers: list[dict[str, Any]] = []
+        for i, name in enumerate(names):
+            med = path_costs[i] if i < len(path_costs) else 0
+            step = difficulty_costs.cost_for_difficulty(med, diff) if med else 0
+            running += step
+            tiers.append(
+                {
+                    "tier": i + 1,
+                    "name": name,
+                    "upgrade_cost": step,
+                    "cumulative_cost": running,
+                },
+            )
+        out_paths[pkey] = tiers
+    return {
+        "found": True,
+        "tower": entry.canonical,
+        "difficulty": diff,
+        "base_cost": base,
+        "paths": out_paths,
+        "note": (
+            "cumulative_cost = tower base + all earlier tiers on that path at "
+            f"{diff} pricing (each purchase rounded to $5, then summed)."
+        ),
+    }
 
 
 def list_ct_relics() -> tuple[RelicEntry, ...]:

--- a/docs/btd6-absence-claim-guard-design.md
+++ b/docs/btd6-absence-claim-guard-design.md
@@ -1,0 +1,206 @@
+# BTD6 absence-claim guard — design proposal
+
+> **Status:** DESIGN PROPOSAL — *not* binding, *not* implemented. Written for
+> independent review (ChatGPT / Analysis side) before any guard code is merged,
+> per the v55 hand-off ("Task 1: DESIGN FIRST, do NOT implement blind").
+> The companion status ledger is `btd6-gamedata-decode-status.md`.
+>
+> **One-line ask of the reviewer:** does the layered design below (a cheap
+> retrieval fix + an absence-claim *gate* that never lets an *unresolved* empty
+> lookup license a "no") correctly close the false-negative hole without turning
+> every legitimate "I don't know" into a tool-loop? The crux is in §4.3.
+>
+> **Sibling finding (do NOT conflate):**
+> `btd6-derived-value-groundedness-finding.md` covers a *different* false-"no" —
+> the guard rejecting a value the model *derived* from grounded inputs
+> (total-cost). That one is diagnosed from the audit log and already has a
+> shipped first fix; this doc is the *absence-claim* family only. They share one
+> root question — *what does the guard count as grounded?* — and §5 below names
+> the edge where they meet.
+
+---
+
+## 1. The problem
+
+The faithfulness verifier catches **ungrounded positives** — a number or proper
+name in the answer that is not present in the grounding ledger (tool outputs +
+auto-grounded facts). It does **not** catch **absence claims**: the bot can
+fluently, version-stampedly assert *"X has no Y"* when X does have Y, and
+nothing stops it. A fluent false "no" is **worse than a refusal** — it looks
+authoritative, and the user believes it.
+
+This is structural, not a tuning miss. An absence sentence —
+
+> "The Bomb Shooter's middle path has **no** bonus damage vs MOAB-class bloons."
+
+— contains a real, groundable **subject** ("Bomb Shooter middle path") and a
+**negative-existential predicate** ("has no bonus damage vs MOABs"). There is no
+ungrounded positive token to flag. The claim asserts the *non-existence* of a
+fact, and you cannot verify non-existence by checking presence. The verifier
+would have to confirm that a lookup was actually attempted **and came back empty
+for a data reason** — which it does not do today.
+
+## 2. Diagnostic evidence (run this session, not assumed)
+
+The canonical reproduction is Bomb Shooter middle path MOAB bonus damage. Last
+session the bot refused/denied it. We pulled the real service paths
+(`btd6_upgrade_detail_service.grounding_for_query`,
+`btd6_upgrade_service.resolve_upgrade`) instead of theorising:
+
+| Query | `resolve_upgrade` | Grounding rendered |
+|---|---|---|
+| `moab mauler` | `exact_name` → `bomb_shooter:030` | "+15 damage vs MOAB-Class" ✅ |
+| `moab assassin` | `exact_name` → `bomb_shooter:040` | "+30 damage vs MOAB-Class" ✅ |
+| `moab eliminator` | `exact_name` → `bomb_shooter:050` | "+99 damage vs MOAB-Class" ✅ |
+| **`bomb shooter middle path`** | **`none`** | **`[]` — 0 lines** |
+
+**The data is extracted and reachable by name.** The MOAB bonus is core
+committed stat data, exactly where it should be. The failure is that the
+**path/line-level phrasing never resolves to the named tiers that hold it**, so
+nothing grounds, and the model fills the vacuum with a confident negative. This
+is the second branch of the hand-off's decision tree — *the false-negative /
+absence-claim hole, data sitting unqueried* — **not** an extraction gap.
+
+> **Settle it from the audit log, not this doc — still owed.** The table above
+> probed the *generic* phrasing `"bomb shooter middle path"`; the **live** query
+> string last session is unknown, and it matters: if the user actually named a
+> tier ("MOAB Mauler"), it resolves and grounds (shown above), so the live
+> failure could be *grounded-then-rejected* — the same shape as the total-cost
+> case in the sibling finding — rather than never-resolved. The `recent_audit`
+> row discriminates: **`provider=—`** ⇒ never-resolved (this absence-claim /
+> retrieval family); **`provider` populated + `grounding_failed`** ⇒
+> generated-then-rejected (sibling family). The maintainer must re-ask live and
+> read that one row. The total-cost row has been pulled (provider populated); the
+> MOAB row has **not** — it decides whether these are one bug or two.
+
+### 2.1 The milder sibling (same root, smaller blast radius)
+
+Asked for "damage **multipliers** per tier," the bot denied having them, then
+immediately printed a full per-tier damage table. It gated its "no" on the
+user's *word* ("multiplier") rather than on whether the **question was
+answerable** from data it already held under another label ("per-tier damage").
+Root cause is identical — *reasoning about whether data is labelled a certain
+way, vs. whether the question is answerable* — but here the subject **did**
+resolve and the data **was** in context, so the fix is narrower (see §4.4). Keep
+it noted but **do not conflate** it with the unresolved-subject case.
+
+## 3. Why #478 does not already cover this
+
+#478 auto-grounds a **resolved upgrade**'s modifiers into context (Pass 3c), so
+the data is present without an explicit tool call. That mitigates the hole on
+**one path only** — the upgrade-modifier path — and **only when the upgrade
+resolves**. It does nothing when:
+
+- the phrasing is path/line-level and resolves to `none` (the MOAB case itself);
+- the subject is a **round / map / mode / bloon / relic / paragon / CT** entity
+  (every non-upgrade domain is unguarded);
+- the asserted-absent attribute lives in a **different tool** than the one that
+  resolved the subject (cross-domain "does X have Y").
+
+**The general absence-claim hole is open in every domain.** #478 is a point
+mitigation, not the guard.
+
+## 4. Design
+
+The fix is **two layers**. Layer A is a cheap retrieval improvement that
+removes the most common trigger and should ship as its own small PR. Layer B is
+the actual guard and is what needs review.
+
+### 4.1 Layer A — path/line-aware resolution (retrieval, not a guard)
+
+Teach the upgrade resolver to expand **path/line references** to the set of
+tiers on that path and auto-ground them:
+
+- "bomb shooter **middle path**" → `bomb_shooter:0X0` tiers 3–5 (or all five) →
+  ground each tier's modifiers.
+- "**top path** dart monkey", "wizard **bottom path** tier 4", etc.
+
+This is the same shape as the rounds/maps/modes reachability fixes that worked
+(*extracted ≠ reachable*: surface a field, don't just hold the file). It is
+**not** an absence guard — it shrinks sub-mode A (never-resolved) so the guard
+fires rarely. Recommended first, separately, low risk.
+
+### 4.2 Layer B — the absence-claim gate
+
+Add a **negative-existential** claim type to the faithfulness verifier and gate
+it. For a draft sentence asserting *"E has no A" / "E lacks A" / "E doesn't have
+A" / "there is no A for E"* about a BTD6 subject E and attribute A:
+
+1. **Resolve E to ≥1 concrete catalog entity this turn.** "Middle path" expands
+   to its tiers (via Layer A); a tower name to the tower; etc.
+2. **If E does not resolve → the absence claim is rejected.** The model may not
+   say "E has no A" about a subject it could not identify. It must downgrade to a
+   *clarify/refuse* ("I couldn't pin down <E> — did you mean …?"), never a
+   confident negative.
+3. **If E resolves → check A against the resolved entity's full committed
+   record** (all tiers / all fields / all tools that own A for E), not against a
+   single tool's empty return. Only if A is genuinely absent from that record
+   may an absence be asserted — and then **phrased as bounded**: "the committed
+   data for <E> doesn't list <A>", not the absolute "E has no A".
+
+### 4.3 The crux — an empty *unresolved* lookup must never license a "no"
+
+The naive implementation of "force a lookup before allowing an absence claim,
+and if it returns empty, allow it" **ships the exact bug we are fixing.** In the
+MOAB case `resolve_upgrade("bomb shooter middle path")` returns empty for a
+**resolver** reason (the phrasing didn't match a named upgrade), **not** a
+**data** reason (the fact is genuinely absent). A guard that treats "lookup
+returned empty" as proof of absence would *confirm* the false negative and stamp
+it as verified.
+
+So the gate must distinguish:
+
+- **empty because the subject didn't resolve** → re-resolve (Layer A) or
+  refuse-to-assert; **never** license the "no";
+- **empty because A is absent from a fully-resolved E's record** → may license a
+  **bounded** "no".
+
+This distinction — *resolution status*, not *result emptiness* — is the whole
+design. A reviewer should attack it here first.
+
+### 4.4 The milder sibling (§2.1)
+
+For the resolved-but-mislabelled case, no resolution work is needed; the gate's
+step 3 already covers it: the subject resolved, and "damage" data **is** in the
+record, so an absence claim about "multipliers" fails the record check (the
+attribute *is* present, under a synonymous label). The remaining work is a small
+**attribute-synonym map** (multiplier ↔ per-tier damage, "bonus" ↔ modifier,
+etc.) so the record check matches the user's term to the held data. Low risk;
+can ride with Layer A.
+
+## 5. Costs and false-positives (confronted, not waved away)
+
+| Concern | Reality | Mitigation |
+|---|---|---|
+| **Latency** | An extra resolution/retrieval pass before an absence claim ships. | Gate **only** fires when the draft actually contains a negative-existential about a BTD6 subject; normal positive answers are untouched. Cap forced re-resolution to one pass. |
+| **False positives (blocking a true "no")** | "Dart Monkey has no camo detection at base" is a *true* negative we'd intercept. | If E resolves and A is verifiably absent from its record, the "no" is **permitted** (bounded form). The true-"no" path is allowed; only the *unverifiable* "no" is downgraded. |
+| **Unverifiable negatives (dataset gaps)** | If we genuinely don't model A for E, we cannot *prove* absence. | Enforce epistemic humility: emit "I don't have that for <E>", **not** "E has no A". This is the honest output and is exactly the false-confidence we're killing. |
+| **Detection precision** | Distinguishing a real absence assertion from incidental negation ("not recommended", "no need to") is fuzzy. | Tight negative-existential classifier scoped to BTD6 subject+attribute shape; over-broad detection inflates latency and blocks good answers, so err toward precision and lean on Layer A to reduce volume. |
+| **Tool-loop risk** | Forcing checks on genuinely out-of-domain subjects could loop. | The gate's terminal state for an unresolved subject is **clarify/refuse**, not "retry retrieval forever". One re-resolution attempt, then a scoped non-answer. |
+
+## 6. Recommendation
+
+1. **Ship Layer A first** (path/line-aware resolution + attribute-synonym map) as
+   a small reachability PR — it removes the canonical trigger and the §2.1
+   sibling with no guard machinery, and is verifiable live the same way the
+   round/map/mode tools were.
+2. **Review Layer B (the gate) before implementing.** The design stands or falls
+   on §4.3 (resolution-status, not result-emptiness). Land it only after the
+   reviewer is satisfied that an unresolved empty lookup can never license a "no",
+   and that the false-positive table above is acceptable.
+3. **Definition of done for this stage:** this proposal, reviewed — *not* a
+   merged guard.
+
+## 7. Open questions for the reviewer
+
+- Is **resolution-status** the right discriminator, or is there a cleaner signal
+  (e.g. provider-populated-but-empty vs. provider-absent in the audit ledger)
+  that the gate should key on instead?
+- Should Layer A expand a "path" to **all five tiers** or only the tiers that
+  carry the queried attribute (narrower grounding, but needs the attribute parsed
+  before resolution)?
+- Where should the negative-existential classifier live — in the existing claim
+  extractor, or as a pre-emission pass in the natural-language stage?
+- For cross-domain "does X have Y", how do we know **which** tool owns Y for E so
+  the record check is complete rather than checking one tool and declaring
+  absence?

--- a/docs/btd6-derived-value-groundedness-finding.md
+++ b/docs/btd6-derived-value-groundedness-finding.md
@@ -1,0 +1,112 @@
+# BTD6 derived-value groundedness — finding + fix
+
+> **Status:** FINDING with a shipped first fix. Distinct from — **do not conflate
+> with** — `btd6-absence-claim-guard-design.md`. That doc is about the model
+> asserting a false *"X has no Y"*; **this** is about the faithfulness guard
+> *rejecting a valid answer the model derived by arithmetic over grounded
+> inputs*. Cousins ("the bot says no when it could say yes"), different fixes.
+
+## 1. The finding — guard over-rejects derived-but-grounded numbers
+
+The faithfulness guard checks whether each number/name in a draft answer appears
+in the grounding ledger. It has **no notion that arithmetic over grounded inputs
+yields a grounded output** — provenance does not flow through computation. So a
+number that is *derived* from grounded values (a sum, a difference) looks
+identical to a number that is *ungrounded* (invented): neither appears literally
+in the source. The first should be allowed; the second refused. Today they are
+the same to the guard, and both are rejected.
+
+## 2. Evidence — the audit log settled it (maintainer pulled it live)
+
+Reproduction: the bot rendered Tack Shooter's full per-tier pricing across all
+paths and difficulties + paragon costs (a large, correct, version-stamped,
+grounded answer). The follow-up — *"now only list the total cost it would take
+to reach every upgrade, base cost and all earlier upgrade costs included"* —
+**refused**, stamped 55.0, "I don't have verified data."
+
+The `recent_audit` rows for that window:
+
+| Age | Decision | Reason | Provider/model | Read |
+|---|---|---|---|---|
+| 8m | `denied` | **`grounding_failed`** | **anthropic / claude-haiku-4-5** | the total-cost turn — **the bug** |
+| 3m | `denied` | `cooldown_active` | — | rate-limit (tposergaming "ice monkey"), *not* a faithfulness failure |
+| 0s | `denied` | `no_mention_required` | — | bot correctly stayed silent, *not* a failure |
+
+Per the hand-off's own rule, **`grounding_failed` with a populated
+provider/model = the model generated an answer and the guard rejected it** — not
+empty retrieval, not a missing tool, not a resolver gap. The model produced a
+total-cost answer; the guard killed it because the summed total is not a literal
+field in the grounding. (Two of the three recent "denials" are the system
+working as intended — the refusals are narrower than the screenshots felt.)
+
+## 3. Why the model cannot be trusted to just derive it either
+
+The cumulative cost is not a naïve sum. BTD6 prices are stored as **Medium**;
+other difficulties scale **per purchase** and round each to $5 *before* they are
+summed. So `sum-then-scale ≠ scale-then-sum`:
+
+- Tack Shooter top path → Inferno Ring, **Medium**: `260 + 150 + 300 + 600 +
+  3500 + 45500 = $50,310`.
+- Same on **Easy**, done right (per-item): `220 + 125 + 255 + 510 + 2975 +
+  38675 = $42,760`.
+- Same on Easy, done wrong (`round5($50,310 × 0.85)`): **$42,765** — off by $5.
+
+So even if the guard let a derived number through, a model deriving it freehand
+would sometimes be *wrong*. The right answer is **deterministic**, which points
+straight at the fix this project already favours.
+
+## 4. Fix — deterministic aggregation tool (grounded by construction)
+
+Two options were on the table:
+
+- **(a) A deterministic tool that computes the total**, so the number is a *tool
+  output* (grounded by construction) the guard accepts — the #468 "make it
+  deterministic so it's groundable" precedent.
+- (b) Teach the guard that a value whose components are all grounded is itself
+  grounded (provenance-through-arithmetic).
+
+**(a) is safer and in-pattern; shipped this session:** `btd6_cumulative_cost`
+(`btd6_data_service.cumulative_upgrade_costs`). Given a tower (+ optional
+difficulty / path) it returns each tier's `cumulative_cost` = base + all earlier
+tiers on that path, scaling **per purchase**. Registered in
+`BTD6_GROUNDING_TOOL_NAMES` so its output grounds the answer. The tool's
+description tells the model: *do not add the prices yourself — the returned
+`cumulative_cost` is the grounded answer.*
+
+**Verified (in-sandbox) against committed data and the live screenshot:** Tack
+Shooter top → Inferno Ring = **$50,310** Medium / **$42,760** Easy (test pins
+both, incl. the $42,760-not-$42,765 per-item-rounding case).
+**Owed:** the live Discord confirmation — re-ask the exact total-cost question;
+it must now answer with the tool's totals, not refuse.
+
+## 5. Scope — this is the first instance, not the whole class
+
+Option (a) fixes *cost* aggregation. The guard's derived-value blind spot is
+**broader**: any answer that is arithmetic over grounded inputs (cross-path cost,
+DPS from damage×rate×pierce, RBE deltas, "how much more does X cost than Y") can
+hit the same `grounding_failed`. Each is closed either by a deterministic tool
+(the cheap, in-pattern move, one at a time as they surface) **or** by option (b)
+(one guard change that covers them all, but riskier — it must not also start
+passing genuinely-invented numbers). Option (b) is the real general fix and
+belongs in the same review as the absence-claim guard, because both ask the
+same question: *what does the guard count as grounded?*
+
+## 6. Relationship to the absence-claim guard (the named edge)
+
+The absence-claim backstop proposed in `btd6-absence-claim-guard-design.md`
+inspects a generated negative and checks whether grounding supports it. The
+total-cost case exposes a real edge that design must name: **some false-negatives
+are not "no grounding exists" but "grounding exists yet requires derivation"** —
+a naïve supports/doesn't-support check passes the refusal as legitimate because
+it cannot see that the grounded inputs needed to be *summed*. So:
+
+- **MOAB / "X has no Y"** → absence-claim family (model asserts/refuses a
+  negative; fix = resolution-status gate, see the other doc).
+- **Total-cost** → derived-value family (guard rejects a valid derivation; fix =
+  deterministic tool now, provenance-through-arithmetic later).
+
+They share a root question (*what is grounded?*) but are separate fixes, and the
+audit `reason`/`provider` columns discriminate them turn-by-turn. **Still owed:**
+the MOAB audit row — `provider=—` means never-resolved (absence/retrieval);
+`provider` populated + `grounding_failed` means generated-then-rejected (same
+shape as total-cost). That one row decides whether these are one bug or two.

--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -20,6 +20,55 @@ reach the entity (not reachable), or it reached the model but was mislabeled /
 the model asserted a false negative (not answerable). Verify the user-facing
 answer, not the unit test.
 
+### Session log — 2026-06-04 (reachability + absence-claim diagnosis)
+
+Picked up the v55 hand-off. The build sandbox **cannot reach Discord and has no
+game-data dump clone**, so this session did the work that is verifiable here and
+*led the maintainer to the live checks* for the rest.
+
+- **Absence-claim diagnosis (Task 1) — settled with evidence, not priors.** Ran
+  the Bomb Shooter middle-path MOAB case through the real service paths. The
+  named tiers ground perfectly — MOAB Mauler `+15`, Assassin `+30`, Eliminator
+  `+99` *damage vs MOAB-Class* — but `resolve_upgrade("bomb shooter middle
+  path")` → `none`, **0 grounding lines**. So the live refusal was the
+  **false-negative / absence-claim hole** (data sitting unqueried because the
+  path-level phrasing doesn't resolve), **not** an extraction gap. Design
+  proposal written: **`btd6-absence-claim-guard-design.md`** (design only, for
+  ChatGPT/Analysis review — no guard merged).
+- **Derived-value false-"no" (sibling bug) — diagnosed from the live audit log
+  + first fix shipped.** The maintainer pulled `recent_audit` for the Tack
+  Shooter "total cost to reach every upgrade" refusal: `denied` ·
+  `grounding_failed` · provider=anthropic/haiku ⇒ **generated-then-rejected**.
+  The guard rejected a total it could not see was *summed from grounded prices*
+  (provenance doesn't flow through arithmetic). This is **distinct from** the
+  absence-claim hole. Fix shipped (the maintainer's preferred option a): a
+  deterministic **`btd6_cumulative_cost`** tool — the total is now a tool output,
+  grounded by construction. Verified vs the live screenshot (Tack Shooter top →
+  Inferno Ring = $50,310 Medium / $42,760 Easy, the per-item-rounding case).
+  Finding written up: **`btd6-derived-value-groundedness-finding.md`**.
+- **Round "heaviest waves" ranker — FIXED.** `round_composition` now returns a
+  pre-ranked `heaviest` (by count, with a bloon) / `heaviest_by_rbe` (by RBE,
+  without), ranked over the **full** range before the detail cap, so the model
+  never re-sorts and a wide range can't truncate a heavy late round. Verified vs
+  ground truth: ceramics r30–80 → `[(78,147),(74,135),(63,122),(76,60),(65,50),
+  (69,50),(55,45),(72,38)]` (was naming r55/r50 and skipping r76/r78/r74).
+- **Reachability sweep (Task 2) — both tools added.** `btd6_relic_lookup`
+  (CT-relic roster + category filter + named lookup) and `btd6_bloon_filter`
+  (trait / category / immunity filter). The bloon filter **distinguishes
+  inherently-tagged bloons from the `modifier` pseudo-entries** (camo / fortified
+  / regrow), so "which bloons are camo" answers "DDT — and Camo is also a
+  modifier other bloons can gain", not a misleading closed set. Both registered
+  in `BTD6_GROUNDING_TOOL_NAMES`; pin tests updated. *Code + local output
+  confirmed; live confirmation owed (see table).*
+- **⚠ Provenance trigger observed.** A successful upgrade answer surfaces
+  `(source: bloonswiki 54.0)` — a **user-facing per-file 54.0 source label**,
+  the exact condition the provenance note named as the trigger to revisit (the
+  refusal stamps 55.0; a hit stamps 54.0 → the user sees both). Not acted on
+  unilaterally; see the provenance section below for the proposed fix.
+- **Deferred with reason:** Task 3 (numeric slice 2) and Task 4 (subtower tail)
+  both require the **game-data dump** (absent in this sandbox) *and* live
+  numeric verification (impossible here). Teed up, not half-done — see tasks.
+
 ### Prioritized tasks
 
 1. **Absence-claim guard — DESIGN FIRST, do NOT implement blind.** *The session's
@@ -35,6 +84,11 @@ answer, not the unit test.
    false-positive costs that need a deliberate decision. **Definition of done:** a
    written design proposal reviewed on the ChatGPT/Analysis side — **not** a
    merged guard.
+   **Status (2026-06-04):** diagnosis done with evidence (path-level resolve →
+   `none`, named tiers ground fine ⇒ absence-claim hole, not extraction);
+   proposal written in `btd6-absence-claim-guard-design.md`. **Owed:** maintainer
+   reads `recent_audit` for the live MOAB turn to confirm the reason code, then
+   reviews the design. No guard code this stage, as specified.
 
 2. **Finish the reachability sweep while the pattern is hot.** Two tool-gaps over
    already-committed data, same shape as the rounds/maps/modes fixes that worked:
@@ -44,6 +98,10 @@ answer, not the unit test.
    service fn + tool spec/handler + add to `BTD6_GROUNDING_TOOL_NAMES`, each with
    a **live** Discord confirmation of its example question. **Definition of done:**
    reachable by tool **and answerable live** — not test-green.
+   **Status (2026-06-04):** ✅ code — `btd6_relic_lookup` + `btd6_bloon_filter`
+   landed, registered, pin-tested; the bloon filter handles the
+   camo/fortified/regrow modifier nuance faithfully. **Owed:** the three live
+   confirmations in the verification table.
 
 3. **Step 5 numeric slice 2 — registry-gated, one `$type` at a time. Never
    bulk-write.** Use the **Decode-class** registry now in the inventory report
@@ -59,25 +117,44 @@ answer, not the unit test.
    committed + retrievable by tool + **verified live** + the per-`$type` number
    verified individually + schema changes conform to the architecture /
    registry-snapshot invariants (expect one to bite — conform, don't fight).
+   **Status (2026-06-04):** ⛔ **blocked in this sandbox** — needs the game-data
+   dump clone (`--dump`, absent here) to source any number, *and* live numeric
+   verification (impossible here). Not started; the registry in
+   `btd6-decode-inventory-v55.md` §3 is ready for the next dump-equipped session.
 
 4. **Subtower tail** — `MorphTowerModel` named-ref (Alchemist "Transformed
    Monkey") + `BeastHandlerPetModel` (Beast Handler pets), still missing. **Why:**
    required before any game-native tower cutover. **Definition of done:** both
    spawn mechanisms emit subtowers, answerable live.
+   **Status (2026-06-04):** ⛔ **blocked** — same as Task 3 (the mapper needs the
+   dump to emit these subtowers). Deferred to a dump-equipped session.
 
-### Verification status (this session)
+### Verification status (live backlog)
 
-> **Live-Discord verification was NOT possible from the build sandbox** (no bot
-> session). The items below are **code/behavior-confirmed** through the real
-> service paths but **UNVERIFIED live** — the next session/maintainer must run
-> the exact checks in Discord before marking them done.
+> **The build sandbox still cannot reach Discord** — every "live" check below is
+> the maintainer's to run. Two carried-over items are now **✅ LIVE-CONFIRMED**
+> (maintainer); the rest remain **UNVERIFIED-live** and rest on code paths.
 
-| Item | Code-confirmed | UNVERIFIED-live — exact manual check |
+**Carried over from the v55 session:**
+
+| Item | Code-confirmed | Live status — exact manual check |
 |---|---|---|
-| Refusal stamps v55 | `_btd6_game_version()` → `55.0` | Ask an ungroundable BTD6 question; the refusal must read "(55.0)", not 54.0. |
-| Damage modifiers ground | `grounding_for_query("ultra jug")` → "+20 damage vs Lead, +8 damage vs Ceramic, +5 damage vs Fortified" | Ask "what are Ultra-Juggernaut's damage multipliers / bonus vs Lead/Ceramic" — must return those numbers, not "no multipliers". |
-| Poplust % render | `_buff_text({ratePercentage:0.15})` → "15% attack speed" | Ask about Druid Poplust's buff — must read +15% (pierce/attack-speed), not +0.15%. |
-| Round/map/mode tools | `round_composition(35,70,'purple')`→290; Logs→Beginner; CHIMPS→cash 650 | Ask "how many purples in rounds 35-70" (→290), "which maps are beginner", "CHIMPS restrictions". |
+| Refusal stamps v55 | `_btd6_game_version()` → `55.0` | **✅ LIVE-CONFIRMED** (maintainer): refusal reads "(55.0)". |
+| Round-composition math | `round_composition(30,80,'ceramic')`→873, 22 rounds | **✅ LIVE-CONFIRMED** (maintainer): 873 ceramics r30–80, reconciles. |
+| Damage modifiers ground | `grounding_for_query("ultra jug")` → "+20 damage vs Lead, +8 vs Ceramic, +5 vs Fortified" | UNVERIFIED — ask "Ultra-Juggernaut bonus vs Lead/Ceramic/Fortified"; must return those, not "no multipliers". |
+| Poplust % render | `_buff_text({ratePercentage:0.15})` → "15% attack speed" | UNVERIFIED — ask about Druid Poplust's buff; must read **+15%**, not +0.15%. |
+| Map / mode tools | Logs→Beginner; CHIMPS→cash 650 | UNVERIFIED — ask "which maps are beginner", "CHIMPS restrictions". |
+| 2 recovered upgrade cards | Ace "Operation: Dart Storm", Wizard "Necromancer: Unpopped Army" extract a description | UNVERIFIED — ask each; the description must render and **not** be invented. |
+
+**New this session (code + local output confirmed; live owed):**
+
+| Item | Local confirmation | UNVERIFIED-live — exact manual check |
+|---|---|---|
+| Heaviest-waves ranker fix | `heaviest` = `[(78,147),(74,135),(63,122),(76,60),(65,50),(69,50),(55,45),(72,38)]` | Ask "which rounds have the most ceramics in 30–80 / heaviest ceramic waves" — top should be r78/r74/r63, **not** r55/r50. |
+| `btd6_relic_lookup` | `category=economy` → 5 relics (Air and Sea, Box of Monkeys, El Dorado, Rounding Up, Starting Stash) | Ask "which CT relics are economy / list the relics / what does Super Monkey Storm do". |
+| `btd6_bloon_filter` | `property=camo` → DDT + "Camo property" modifier note; `category=moab_class` → 5 | Ask "which bloons are camo / lead", "list the MOAB-class bloons" — camo must note DDT **and** the broad modifier. |
+| `btd6_cumulative_cost` (derived-value fix) | Tack Shooter top → Inferno Ring = $50,310 Medium / $42,760 Easy | **Re-ask the refused turn:** "total cost to reach every Tack Shooter upgrade, base + all earlier costs" — must now answer with totals, not refuse (`grounding_failed`). |
+| MOAB middle-path absence | `resolve_upgrade("bomb shooter middle path")`→`none`; named tiers ground +15/+30/+99 | Ask the path-level question live, read `recent_audit`: expect empty retrieval / no upgrade provider (confirms the absence-claim hole, Task 1). |
 
 ### Provenance decision (recorded, not auto-applied)
 
@@ -89,6 +166,19 @@ the `--audit` is per-**field**, not per-file, so there is no clean per-file gate
 and re-stamping unchanged bloonswiki files would falsely claim re-sourcing. A file
 is re-stamped only when `--overlay`/`--all` actually re-sources it. *(Open nit: 2
 economy files have an empty stamp — decide a value on the next real re-source.)*
+
+> **⚠ Trigger fired (2026-06-04).** The "watch for it" condition has occurred: a
+> *successful* upgrade answer surfaces the per-file vintage as a user-facing
+> source label — `render_upgrade_grounding` emits `(source: bloonswiki
+> {game_version})`, and `bomb_shooter`'s stats file is stamped **54.0**, so a
+> live answer reads "MOAB Mauler … (source: bloonswiki **54.0**)" while a refusal
+> stamps **55.0**. A user can see both and reasonably ask "54 or 55?". This is a
+> *label* problem, not a re-stamp trigger — the 54.0 vintage is honest. **Proposed
+> minimal fix (maintainer to decide, not applied here):** make the user-facing
+> source label not read as a bare version that contradicts the dataset stamp —
+> e.g. `(source: bloonswiki, sourced v54.0)` or drop the version from the source
+> bit and let the dataset stamp own "what version is this". Do **not** blanket
+> re-stamp `stats/*.json`.
 
 ---
 

--- a/tests/unit/services/test_ai_tools.py
+++ b/tests/unit/services/test_ai_tools.py
@@ -35,6 +35,9 @@ def test_build_registry_returns_specs_and_matching_handlers():
         "btd6_round_composition",
         "btd6_map_lookup",
         "btd6_mode_lookup",
+        "btd6_relic_lookup",
+        "btd6_bloon_filter",
+        "btd6_cumulative_cost",
         "btd6_paragon_calculate",
         "btd6_paragon_requirements",
         "btd6_paragon_stats_at_degree",
@@ -312,6 +315,9 @@ def test_admin_scope_offers_all_read_only_tools():
         "btd6_round_composition",
         "btd6_map_lookup",
         "btd6_mode_lookup",
+        "btd6_relic_lookup",
+        "btd6_bloon_filter",
+        "btd6_cumulative_cost",
         "btd6_paragon_calculate",
         "btd6_paragon_requirements",
         "btd6_paragon_stats_at_degree",
@@ -627,7 +633,9 @@ async def test_btd6_capability_lookup_paragon_camo_split():
 async def test_btd6_round_composition_aggregates_a_bloon_over_a_range():
     # The live-refused question: "how many purples in rounds 35-70".
     h = build_registry(scope=AIScope.USER, guild_id=1, actor_id=2).handlers
-    r = await h["btd6_round_composition"]({"round_start": 35, "round_end": 70, "bloon": "purples"})
+    r = await h["btd6_round_composition"](
+        {"round_start": 35, "round_end": 70, "bloon": "purples"}
+    )
     assert r["found"] is True
     assert r["bloon"] == "Purple Bloon"
     assert r["total"] == 290
@@ -641,7 +649,9 @@ async def test_btd6_round_composition_single_round_full_list_and_errors():
     assert one["found"] is True and one["rounds"][0]["round"] == 63
     assert one["rounds"][0]["groups"]
     assert (await h["btd6_round_composition"]({"round_start": 999}))["found"] is False
-    assert (await h["btd6_round_composition"]({"round_start": 35, "bloon": "flarp"}))["found"] is False
+    assert (await h["btd6_round_composition"]({"round_start": 35, "bloon": "flarp"}))[
+        "found"
+    ] is False
     assert (await h["btd6_round_composition"]({"round_start": "x"}))["found"] is False
 
 
@@ -662,3 +672,90 @@ async def test_btd6_mode_lookup_single_and_roster():
     assert chimps["mode"]["restrictions"]
     roster = await h["btd6_mode_lookup"]({})
     assert roster["found"] is True and roster["count"] == len(roster["modes"]) >= 2
+
+
+async def test_btd6_round_composition_ranks_heaviest_rounds():
+    # Live bug: the model named r55/r50 the "heaviest" ceramic waves and skipped
+    # the larger r76/r78/r74. The tool now ranks them so the model never re-sorts.
+    h = build_registry(scope=AIScope.USER, guild_id=1, actor_id=2).handlers
+    r = await h["btd6_round_composition"](
+        {"round_start": 30, "round_end": 80, "bloon": "ceramic"},
+    )
+    counts = [e["count"] for e in r["heaviest"]]
+    assert counts == sorted(counts, reverse=True)  # genuinely ranked, not round order
+    assert [(e["round"], e["count"]) for e in r["heaviest"][:3]] == [
+        (78, 147),
+        (74, 135),
+        (63, 122),
+    ]
+    ranked = [e["round"] for e in r["heaviest"]]
+    assert ranked.index(76) < ranked.index(55)  # the exact miss from the live run
+    # Without a bloon, the heaviest rounds are ranked by RBE.
+    full = await h["btd6_round_composition"]({"round_start": 30, "round_end": 80})
+    rbes = [e["rbe"] for e in full["heaviest_by_rbe"]]
+    assert rbes == sorted(rbes, reverse=True)
+
+
+async def test_btd6_relic_lookup_single_category_and_roster():
+    h = build_registry(scope=AIScope.USER, guild_id=1, actor_id=2).handlers
+    sms = await h["btd6_relic_lookup"]({"relic": "Super Monkey Storm"})
+    assert sms["found"] is True and sms["relic"]["effect"]
+    offense = await h["btd6_relic_lookup"]({"category": "offense"})
+    assert offense["found"] is True
+    assert offense["count"] == len(offense["relics"]) >= 1
+    assert all(r["category"] == "offense" for r in offense["relics"])
+    roster = await h["btd6_relic_lookup"]({})
+    assert roster["found"] is True and roster["count"] == len(roster["relics"]) >= 24
+    assert (await h["btd6_relic_lookup"]({"relic": "nope-not-a-relic"}))[
+        "found"
+    ] is False
+    assert (await h["btd6_relic_lookup"]({"category": "bogus"}))["found"] is False
+
+
+async def test_btd6_bloon_filter_traits_and_modifier_note():
+    h = build_registry(scope=AIScope.USER, guild_id=1, actor_id=2).handlers
+    camo = await h["btd6_bloon_filter"]({"property": "camo"})
+    assert camo["found"] is True
+    assert "DDT" in {b["name"] for b in camo["bloons"]}  # inherently camo
+    # The Camo *modifier* is surfaced separately so the answer isn't a closed set.
+    assert camo.get("modifiers") and all(
+        m["applies_broadly"] for m in camo["modifiers"]
+    )
+    lead = await h["btd6_bloon_filter"]({"property": "lead"})
+    assert {"Lead Bloon", "DDT"} <= {b["name"] for b in lead["bloons"]}
+    moab = await h["btd6_bloon_filter"]({"property": "moab"})  # synonym -> moab-class
+    assert moab["count"] == 5
+    immune = await h["btd6_bloon_filter"]({"immune": "Explosion"})
+    assert {"Black Bloon", "DDT"} <= {b["name"] for b in immune["bloons"]}
+    assert (await h["btd6_bloon_filter"]({"property": "nonsense-tag"}))[
+        "found"
+    ] is False
+    roster = await h["btd6_bloon_filter"]({})
+    assert roster["count"] >= 1 and roster["bloons"]
+
+
+async def test_btd6_cumulative_cost_sums_base_plus_priors_per_difficulty():
+    # Live `grounding_failed` case: "total cost to reach every upgrade, base +
+    # all earlier costs". The model couldn't ground the derived sum; the tool
+    # makes the total a grounded output. Pinned to the published Tack Shooter
+    # table (top path -> Inferno Ring): Medium 50,310; Easy 42,760 (the per-item
+    # rounding makes sum-then-scale give the wrong 42,765).
+    h = build_registry(scope=AIScope.USER, guild_id=1, actor_id=2).handlers
+    med = await h["btd6_cumulative_cost"]({"tower": "Tack Shooter", "path": "top"})
+    assert med["found"] is True and med["difficulty"] == "medium"
+    top = med["paths"]["top"]
+    assert top[0]["cumulative_cost"] == 410  # 260 base + 150
+    assert top[-1]["name"] == "Inferno Ring"
+    assert top[-1]["cumulative_cost"] == 50310
+    easy = await h["btd6_cumulative_cost"](
+        {"tower": "Tack Shooter", "difficulty": "easy", "path": "top"},
+    )
+    assert easy["base_cost"] == 220
+    assert easy["paths"]["top"][-1]["cumulative_cost"] == 42760  # not 42765
+    # Whole-tower (all three paths) + error paths.
+    full = await h["btd6_cumulative_cost"]({"tower": "Tack Shooter"})
+    assert set(full["paths"]) == {"top", "mid", "bot"}
+    assert (await h["btd6_cumulative_cost"]({"tower": "nope"}))["found"] is False
+    assert (
+        await h["btd6_cumulative_cost"]({"tower": "Tack Shooter", "difficulty": "x"})
+    )["found"] is False


### PR DESCRIPTION
## Summary

Follow-up to the v55 game-data cutover: a reachability sweep plus the diagnosis of two live false-"no" failures. **Live Discord verification is still owed** — the build sandbox can't reach Discord — so every item below is verified **locally against committed data** and, where applicable, against the maintainer's **live screenshot / audit log**. The `## Live verification owed` checklist is the maintainer's to run.

## What changed

### Fix — round "heaviest waves" ranker
`round_composition` now ranks the heaviest rounds **in the tool** — `heaviest` (by count, with a bloon) / `heaviest_by_rbe` (by RBE, without) — computed over the **full** range *before* the detail cap, so the model never re-sorts and a wide range can't truncate a heavy late round. Fixes the live mis-ranking (it named r55/r50 as heaviest and skipped the larger r76/r78/r74 for ceramics r30–80). Verified: `heaviest` = `[(78,147),(74,135),(63,122),(76,60),(65,50),(69,50),(55,45),(72,38)]`.

### Reachability sweep (Task 2) — two new tools
- **`btd6_relic_lookup`** — CT-relic roster + category filter (`offense`/`economy`/`lives`/`powerup`/`utility`) + named lookup.
- **`btd6_bloon_filter`** — trait / category / immunity filter that **separates inherently-tagged bloons from the `modifier` pseudo-entries** (camo / fortified / regrow), so *"which bloons are camo"* answers faithfully (**DDT** *plus* the broadly-applicable Camo modifier), not a misleading closed set.

### Derived-value fix (from the maintainer's live audit log) — `btd6_cumulative_cost`
The Tack Shooter *"total cost to reach every upgrade"* refusal was diagnosed from `recent_audit` as `grounding_failed` + populated provider = **the guard rejecting a value the model derived by arithmetic over grounded prices**. Fix (the maintainer's preferred *option a*): a deterministic tool that returns each tier's cumulative cost (base + all earlier tiers on the path), scaling **per purchase** — so the total is a grounded-by-construction tool output. Verified vs the published table: Tack Shooter top → Inferno Ring = **$50,310** Medium / **$42,760** Easy (the per-item-rounding case where sum-then-scale wrongly gives $42,765).

All three new tools are registered in `BTD6_GROUNDING_TOOL_NAMES`; the pin tests (USER + ADMIN scope) are updated.

### Design / findings (no guard code merged this stage)
- **`docs/btd6-absence-claim-guard-design.md`** — the Bomb Shooter middle-path MOAB refusal is the *absence-claim hole*: named tiers ground `+15/+30/+99 vs MOAB-class`, but the path-level phrasing resolves to `none` → nothing grounds. Proposes a **resolution-status gate** (an *unresolved* empty lookup must never license a "no"). Design only, for ChatGPT/Analysis review.
- **`docs/btd6-derived-value-groundedness-finding.md`** — the total-cost case as a **distinct** bug (guard can't tell "ungrounded" from "derived over grounded"); explicitly *not conflated* with the absence-claim guard.
- **status doc** — session log, refreshed verification table, and the **per-file `54.0` user-facing source-label** provenance trigger now observed (proposed label fix recorded; no blanket re-stamp).

## Verification

- `python3.10 scripts/check_quality.py --full` → **7226 passed, 3 skipped**, mypy + black/isort/ruff clean.
- `python3.10 scripts/check_architecture.py --mode strict` → **0 errors**.

## Live verification owed (maintainer)
- [ ] "heaviest ceramic waves r30–80" → top is r78/r74/r63, **not** r55/r50.
- [ ] "which CT relics are economy" / "list relics" / "what does Super Monkey Storm do".
- [ ] "which bloons are camo / lead" / "list the MOAB-class bloons" — camo notes DDT **and** the broad modifier.
- [ ] Re-ask the refused **total-cost** turn — must now answer with totals, not `grounding_failed`.
- [ ] **MOAB audit row:** re-ask the middle-path question live and read `recent_audit` — `provider=—` ⇒ never-resolved (absence-claim family); `provider` populated + `grounding_failed` ⇒ generated-then-rejected (derived-value family). This one row decides whether MOAB and total-cost are one bug or two.

## Deferred (next, dump-equipped session)
Task 3 (numeric slice 2) and Task 4 (subtower tail) need the game-data **dump clone** (absent in this sandbox) *and* live numeric verification — teed up, not half-done.


---
_Generated by [Claude Code](https://claude.ai/code/session_012s22Kt2tbLGC5yXQf5eUgX)_