### PR TITLE
docs(btd6): refine false-negative hand-off — deprioritize absence guard, name deny-then-answer

### DIFF
--- a/docs/btd6-absence-claim-guard-design.md
+++ b/docs/btd6-absence-claim-guard-design.md
@@ -20,6 +20,64 @@
 
 ---
 
+## Evidence update (2026-06-04) — this guard is DEPRIORITIZED
+
+Two more live tests (maintainer) reshaped the diagnosis after this doc's first
+draft. **Build the fix the evidence points at; this general guard is not the
+next PR.**
+
+1. **MOAB-bonus, when the upgrade is *named*, now ANSWERS.** Asked "list the
+   damage multipliers of the MOAB Mauler," the bot resolves Bomb Shooter 0-3-0,
+   states +15 vs MOAB-class, gives base stats (1 dmg / 22 pierce / 0.825s),
+   explains the +15 → 16 stack, lists the MOAB-class set, and correctly calls it
+   a flat bonus, not a multiplier — a fully-grounded answer (every number is in
+   `grounding_for_query("moab mauler")`, verified). So the "middle path" refusal
+   does **not** reproduce once a tier is named; it was a resolver/query-shaping
+   gap that explicit naming bypasses. **MOAB is no longer the canonical failing
+   case — downgraded.**
+
+2. **A *pure* absence-claim ("X has no Y" with no answer attached) has NOT been
+   reproduced live.** Every failure caught is one of two narrower things —
+   derived-value rejection (total-cost, confirmed) or *deny-then-answer* (below).
+   Building the general absence-claim gate for a mode that isn't occurring is
+   premature. This design stays a **provisional backstop**, not the next PR.
+
+### The behaviour that IS occurring — deny-then-answer (the mild cousin)
+
+Three live instances now (MOAB "multipliers"; Bomb Shooter "multipliers per
+tier"; this MOAB answer): the model **answers correctly but prepends a false
+"I don't have `<X>`"** because the user's *word* ("multiplier") is not a literal
+field name — even though the flat +15 bonus *is* the answer, relabelled. The
+answer survives; the framing is misleadingly negative.
+
+- **Severity:** mild (the answer is correct; only the preamble is wrong) — vs
+  the severe derived-value case where the guard kills the answer outright.
+- **Mechanism (prompt, not guard):** `ai_instruction_service` already says
+  *"ALWAYS run the lookup before telling the user you lack a figure … only
+  report missing after found=false"* (good — covers hard refusals) **and** *"if a
+  specific figure still cannot be verified, give your general answer but flag
+  that one number"* (a hedge-then-answer pattern). The model **over-applies the
+  hedge-then-answer pattern** to a figure that is answerable under a *different
+  label* — it flags "multiplier" as missing, then answers with the bonus.
+- **Proposed fix (next session; prompt change → must live-verify; NOT now):** a
+  framing clarification that a differently-*labelled* equivalent (a flat bonus
+  answers "multiplier"; a per-tier table answers "scaling") is **not** a missing
+  figure to disclaim — answer the substance directly, and only flag a figure
+  that is genuinely absent after a `found=false` lookup.
+
+### Revised priority
+
+| Problem | Status | Next |
+|---|---|---|
+| Derived-value rejection (total-cost) | **confirmed** (audit `grounding_failed` + provider); fix **shipped** (`btd6_cumulative_cost`, #482) | live-verify the re-ask |
+| Deny-then-answer preamble | confirmed live ×3; **mild** | framing fix + live-verify (next) |
+| Pure absence-claim ("X has no Y") | **not reproduced** live | keep this design as a backstop; do **not** build yet |
+
+The original problem statement and design (§1–§7) remain valid as the *backstop*
+for if/when a pure absence-claim does surface — read them in that light.
+
+---
+
 ## 1. The problem
 
 The faithfulness verifier catches **ungrounded positives** — a number or proper

--- a/docs/btd6-derived-value-groundedness-finding.md
+++ b/docs/btd6-derived-value-groundedness-finding.md
@@ -106,7 +106,15 @@ it cannot see that the grounded inputs needed to be *summed*. So:
   deterministic tool now, provenance-through-arithmetic later).
 
 They share a root question (*what is grounded?*) but are separate fixes, and the
-audit `reason`/`provider` columns discriminate them turn-by-turn. **Still owed:**
-the MOAB audit row — `provider=—` means never-resolved (absence/retrieval);
-`provider` populated + `grounding_failed` means generated-then-rejected (same
-shape as total-cost). That one row decides whether these are one bug or two.
+audit `reason`/`provider` columns discriminate them turn-by-turn.
+
+**Update (post-#482):** the MOAB row chase is now moot — asked with the upgrade
+*named*, the bot **answers** (+15 vs MOAB-class), so the MOAB *refusal* no longer
+reproduces and a *pure* absence-claim hasn't surfaced live. What MOAB now shows
+instead is the **deny-then-answer** preamble (it opens "I don't have a
+'multiplier' figure", then answers) — the **mild cousin** of this derived-value
+bug: in the severe case the guard kills the answer; in the mild case the model
+just narrates a false "I don't have it" before giving the grounded answer. Both
+come from conflating *"this exact labelled figure isn't a field"* with *"I can't
+answer."* See the evidence-update + revised-priority table in
+`btd6-absence-claim-guard-design.md`.

--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -46,6 +46,18 @@ game-data dump clone**, so this session did the work that is verifiable here and
   grounded by construction. Verified vs the live screenshot (Tack Shooter top →
   Inferno Ring = $50,310 Medium / $42,760 Easy, the per-item-rounding case).
   Finding written up: **`btd6-derived-value-groundedness-finding.md`**.
+- **Refined after two more live tests (post-#482).** Asked "list the damage
+  multipliers of the MOAB Mauler," the bot now **answers correctly** (resolves
+  0-3-0, +15 vs MOAB-class, base stats, flat-bonus-not-multiplier) — so MOAB is
+  **downgraded** as the canonical failing case. A *pure* absence-claim ("X has no
+  Y", no answer) has **not** been reproduced; live failures keep landing on two
+  narrower modes: derived-value rejection (severe, fixed) and **deny-then-answer**
+  (mild — the model prepends a false "I don't have a 'multiplier' figure" then
+  answers, because the user's word isn't a literal field; seen ×3). So the
+  **absence-claim guard is deprioritized to a backstop** and the **deny-then-
+  answer framing fix** (a prompt change, live-verify next session) becomes the
+  milder concrete item. Captured in the evidence-update section of
+  `btd6-absence-claim-guard-design.md`.
 - **Round "heaviest waves" ranker — FIXED.** `round_composition` now returns a
   pre-ranked `heaviest` (by count, with a bloon) / `heaviest_by_rbe` (by RBE,
   without), ranked over the **full** range before the detail cap, so the model
@@ -89,6 +101,11 @@ game-data dump clone**, so this session did the work that is verifiable here and
    proposal written in `btd6-absence-claim-guard-design.md`. **Owed:** maintainer
    reads `recent_audit` for the live MOAB turn to confirm the reason code, then
    reviews the design. No guard code this stage, as specified.
+   **Update (post-#482):** MOAB now answers when named, and no *pure*
+   absence-claim has reproduced live → this guard is **deprioritized to a
+   backstop**. The live failures are two narrower modes (derived-value rejection
+   — fixed; deny-then-answer preamble — framing fix next). See the evidence-update
+   section of `btd6-absence-claim-guard-design.md`.
 
 2. **Finish the reachability sweep while the pattern is hot.** Two tool-gaps over
    already-committed data, same shape as the rounds/maps/modes fixes that worked:
@@ -154,7 +171,7 @@ game-data dump clone**, so this session did the work that is verifiable here and
 | `btd6_relic_lookup` | `category=economy` → 5 relics (Air and Sea, Box of Monkeys, El Dorado, Rounding Up, Starting Stash) | Ask "which CT relics are economy / list the relics / what does Super Monkey Storm do". |
 | `btd6_bloon_filter` | `property=camo` → DDT + "Camo property" modifier note; `category=moab_class` → 5 | Ask "which bloons are camo / lead", "list the MOAB-class bloons" — camo must note DDT **and** the broad modifier. |
 | `btd6_cumulative_cost` (derived-value fix) | Tack Shooter top → Inferno Ring = $50,310 Medium / $42,760 Easy | **Re-ask the refused turn:** "total cost to reach every Tack Shooter upgrade, base + all earlier costs" — must now answer with totals, not refuse (`grounding_failed`). |
-| MOAB middle-path absence | `resolve_upgrade("bomb shooter middle path")`→`none`; named tiers ground +15/+30/+99 | Ask the path-level question live, read `recent_audit`: expect empty retrieval / no upgrade provider (confirms the absence-claim hole, Task 1). |
+| MOAB bonus (named) | named tiers ground +15/+30/+99; generic "middle path"→`none` | **✅ LIVE (maintainer):** "list the MOAB Mauler's multipliers" now answers (+15, flat-bonus-not-multiplier). Caveat: it prepends a false "I don't have a multiplier figure" — the deny-then-answer mild bug, tracked separately. |
 
 ### Provenance decision (recorded, not auto-applied)
 


### PR DESCRIPTION
Doc-only follow-up to #482, capturing the refined diagnosis from two more live tests (maintainer) that landed **after** #482's docs were written. It corrects framing that just merged into `main`.

## Why
#482's docs framed the Bomb Shooter middle-path MOAB case as *the* canonical absence-claim failure and treated the general absence-claim guard as the top design task. Two fresh live tests revise both — worth fixing in `main` so the next session reads accurate framing.

## What the new evidence shows
1. **MOAB-bonus answers when the upgrade is named.** "List the MOAB Mauler's multipliers" → the bot resolves 0-3-0, states **+15 vs MOAB-class**, gives base stats, explains the +15 → 16 stack, and correctly calls it a flat bonus, not a multiplier. Verified: every number is in `grounding_for_query("moab mauler")`. The "middle path" refusal was a resolver/query-shaping gap that explicit naming bypasses → **MOAB downgraded** as the canonical case.
2. **No *pure* absence-claim ("X has no Y", no answer) has reproduced live.** The live failures keep landing on two narrower modes, so the general guard is **deprioritized to a backstop** — don't build it for a mode that isn't occurring.
3. **The behaviour that IS occurring: deny-then-answer.** The model answers correctly but prepends a false *"I don't have a 'multiplier' figure"* because the user's word isn't a literal field name (seen ×3: MOAB multipliers, Bomb Shooter multipliers-per-tier, this one). Mild (answer survives; only the preamble is wrong). **Mechanism is the prompt, not the guard:** `ai_instruction_service`'s *"if a figure can't be verified, give your general answer but flag that one number"* hedge-then-answer pattern, over-applied to a figure that's answerable under a different label. Proposed fix is a **next-session, live-verified prompt clarification** — not done here.

## Revised priority (now in the docs)
| Problem | Status |
|---|---|
| Derived-value rejection (total-cost) | confirmed (audit `grounding_failed`+provider); fix **shipped** in #482 (`btd6_cumulative_cost`) |
| Deny-then-answer preamble | confirmed live ×3; mild; framing fix next |
| Pure absence-claim ("X has no Y") | **not reproduced**; design kept as backstop, not built |

## Changes (docs only)
- `btd6-absence-claim-guard-design.md` — evidence-update + revised-priority section; §1–§7 retained as the backstop design.
- `btd6-derived-value-groundedness-finding.md` — relationship section reconciled (MOAB row chase now moot; deny-then-answer named as the mild cousin).
- `btd6-gamedata-decode-status.md` — session log, Task 1 status, verification table.

No code changes. If you'd rather fold this into the next working session than carry a second PR, say so and I'll close it — the content stands either way.

---
_Generated by [Claude Code](https://claude.ai/code/session_012s22Kt2tbLGC5yXQf5eUgX)_