### PR TITLE
docs(btd6): verify live findings vs code — capability surface + bug-report round 2

### DIFF
--- a/docs/btd6-absence-claim-guard-design.md
+++ b/docs/btd6-absence-claim-guard-design.md
@@ -20,11 +20,13 @@
 
 ---
 
-## Evidence update (2026-06-04) — this guard is DEPRIORITIZED
+## Evidence update (2026-06-04) — RE-ELEVATED (a pure repro surfaced; see Update 2)
 
 Two more live tests (maintainer) reshaped the diagnosis after this doc's first
-draft. **Build the fix the evidence points at; this general guard is not the
-next PR.**
+draft. **Build the fix the evidence points at first** — but a later round
+(Update 2) found the *pure* absence-claim repro that was missing, so this guard
+is **back on the table**, now with a concrete reproduction case and a hard new
+requirement (absence claims must be *logged*).
 
 1. **MOAB-bonus, when the upgrade is *named*, now ANSWERS.** Asked "list the
    damage multipliers of the MOAB Mauler," the bot resolves Bomb Shooter 0-3-0,
@@ -36,11 +38,11 @@ next PR.**
    gap that explicit naming bypasses. **MOAB is no longer the canonical failing
    case — downgraded.**
 
-2. **A *pure* absence-claim ("X has no Y" with no answer attached) has NOT been
-   reproduced live.** Every failure caught is one of two narrower things —
-   derived-value rejection (total-cost, confirmed) or *deny-then-answer* (below).
-   Building the general absence-claim gate for a mode that isn't occurring is
-   premature. This design stays a **provisional backstop**, not the next PR.
+2. **~~A *pure* absence-claim has NOT been reproduced live.~~ SUPERSEDED by
+   Update 2.** At this draft's time, every failure was derived-value rejection or
+   deny-then-answer, so the guard was deprioritized. **A later round found the
+   pure repro** — "Monkey Buccaneer does not have a paragon" (it does). See
+   Update 2; the guard is re-elevated.
 
 ### The behaviour that IS occurring — deny-then-answer (the mild cousin)
 
@@ -71,10 +73,43 @@ answer survives; the framing is misleadingly negative.
 |---|---|---|
 | Derived-value rejection (total-cost) | **confirmed** (audit `grounding_failed` + provider); fix **shipped** (`btd6_cumulative_cost`, #482) | live-verify the re-ask |
 | Deny-then-answer preamble | confirmed live ×3; **mild** | framing fix + live-verify (next) |
-| Pure absence-claim ("X has no Y") | **not reproduced** live | keep this design as a backstop; do **not** build yet |
+| Pure absence-claim ("X has no Y") | **REPRODUCED** (Update 2: false "no paragon") | design now (§1–§7) + the logging requirement below |
 
-The original problem statement and design (§1–§7) remain valid as the *backstop*
-for if/when a pure absence-claim does surface — read them in that light.
+The original problem statement and design (§1–§7) are the *backstop*; Update 2
+makes them current again.
+
+## Update 2 (2026-06-04, later) — the pure repro, and a new hard requirement
+
+Asked for Monkey Buccaneer pricing, the bot ended with **"Monkey Buccaneer does
+not have a paragon"** — stated as fact. **It is false** (Navarch of the Seas).
+This is the clean pure absence-claim the earlier round was missing: no ungrounded
+number or name, so the verifier passed it, yet it is flatly wrong.
+
+**Verified it is NOT a data bug (all-tower audit).** Every paragon-bearing tower
+is consistent — `monkey_buccaneer` carries `paragon_cost=550000` and the
+`navarch_of_the_seas` stats file exists; `btd6_context_service.build("…
+buccaneer")` **does** emit `[btd6_paragon] Monkey Buccaneer's Paragon (tier 6) is
+Navarch of the Seas, costing 550000`. So the linkage is correct. The false "no
+paragon" is the model **confabulating an absence** on a turn where that grounding
+line wasn't in front of it — the exact blind spot this doc describes.
+
+Two hard requirements this case adds to the design:
+
+- **Absence claims must be LOGGED.** `recent_audit` is a *denial* log — a
+  confidently-wrong *answer* the guard passed (like this one) leaves **no audit
+  row at all**. The single most dangerous failure type is currently invisible to
+  the very tool we diagnose everything else with. The backstop must **emit an
+  auditable signal whenever it inspects/permits an absence assertion**, or we can
+  never monitor the failure we're trying to kill.
+- **Verify against DATA, not user assertion.** When a user corrected the bot
+  ("it does have a paragon, Navarch"), it instantly produced a correct Navarch
+  table — good UX, but it flipped stance on a *claim*, not on its data. The same
+  reflex could fabricate the other direction (assert a paragon for a paragon-less
+  tower because a user said so). The gate must check the committed data, not
+  defer to the user's say-so.
+
+Scope stays **narrow**: a BTD6 unsupported-negative backstop on final generated
+answers, not a global pre-answer guard — and design-first, per the standing rule.
 
 ---
 

--- a/docs/btd6-derived-value-groundedness-finding.md
+++ b/docs/btd6-derived-value-groundedness-finding.md
@@ -110,6 +110,44 @@ difficulties, grounded by construction) — collapsing the fragile 16-call stitc
 model called *nothing* (pure tool-use-discipline) or called the lookup but
 freehand-scaled (the tool fixes the latter cleanly and de-risks the former).
 
+### 5.2 Tower upgrade-cost tables — and routing is NOT the cause (tested)
+
+More live repros: "upgrade prices for heli", "monkey ace upgrades", "pricing of
+monkey buccaneer" refused; "what are all the upgrade costs of the heli", "what
+about buccaneer" returned full correct cumulative/all-difficulty tables. The
+intuitive theory — *the task router sometimes sends cost questions to general
+instead of BTD6* — was **tested and disproven** against `ai_task_router.classify`:
+
+| Phrasing | Route | Live |
+|---|---|---|
+| `monkey ace upgrades` | **btd6.answer** | **FAILED** |
+| `pricing of monkey buccaneer` | **btd6.answer** | **FAILED** |
+| `what are all the upgrade costs of the heli` | **general.nl_answer** | **WORKED** |
+| `upgrade prices for heli` | general.nl_answer | FAILED |
+
+**Route does not determine outcome** — questions route to BTD6 and still fail;
+route to general and still work. So the determinant is **whether the model
+invokes the deterministic cost tool** (`btd6_cumulative_cost` /
+`btd6_difficulty_cost`) for the *derived* numbers (cumulative totals,
+difficulty-scaled prices), which it does inconsistently (temperature-driven). The
+"Cumulative Cost" column in the working tables is literally `btd6_cumulative_cost`
+output; the failing turns free-generated the derived numbers → `grounding_failed`.
+
+**The fix is not in the router** (that was the wrong location). It is to **stop
+depending on the model to call the tool**: detect tower upgrade-cost intent and
+**auto-attach the deterministic cost grounding** (cumulative + all-difficulty
+facts, built from `btd6_data_service.cumulative_upgrade_costs` +
+`difficulty_costs`) into the BTD6 context, the same way #478 auto-grounds upgrade
+modifiers. The numbers are verifiable in-sandbox; the *efficacy* (model uses them,
+guard accepts) is live-owed — a pipeline change to confirm before shipping, so it
+is **proposed, not built blind** here.
+
+> The false **"no paragon"** claim (see the absence-claim doc, Update 2) is the
+> *same shape* on a different field: the paragon grounding line exists and is
+> correct, but on a turn where it wasn't surfaced the model confabulated an
+> absence. Auto-attaching tower grounding reliably (this section's fix) also
+> removes that false negative — the two fixes overlap.
+
 ## 6. Relationship to the absence-claim guard (the named edge)
 
 The absence-claim backstop proposed in `btd6-absence-claim-guard-design.md`

--- a/docs/btd6-derived-value-groundedness-finding.md
+++ b/docs/btd6-derived-value-groundedness-finding.md
@@ -91,6 +91,25 @@ passing genuinely-invented numbers). Option (b) is the real general fix and
 belongs in the same review as the absence-claim guard, because both ask the
 same question: *what does the guard count as grounded?*
 
+### 5.1 Next instance surfaced live — difficulty-scaled pricing ("buccaneer")
+
+"Pricing of monkey buccaneer" was refused live (`grounding_failed` + provider).
+**Verified it is not a data gap:** `btd6_context_service.build("pricing of monkey
+buccaneer")` returns **27 facts** with the base cost and upgrade prices, the same
+as sub/tack. So the *Medium* prices are grounded; what isn't is the **Easy /
+Hard / Impoppable** column the model emits in a "pricing across all difficulties"
+table — those are *derived* from Medium (×0.85 / ×1.08 / ×1.20, round-to-5) and
+are only grounded if the model calls `btd6_difficulty_cost` for **each** number.
+A full table is base + ~15 upgrades = ~16 calls; the model stitches it
+inconsistently (sub table rendered; buccaneer refused), so the guard rejects the
+ungrounded scaled prices. **Same root as total-cost: a derived value the model
+produced without routing through the deterministic tool.** The in-pattern fix is
+a single **all-difficulties tower-pricing tool** (1 call → per-upgrade × 4
+difficulties, grounded by construction) — collapsing the fragile 16-call stitch.
+**Owed first:** the buccaneer turn's tool-call trace, to confirm whether the
+model called *nothing* (pure tool-use-discipline) or called the lookup but
+freehand-scaled (the tool fixes the latter cleanly and de-risks the former).
+
 ## 6. Relationship to the absence-claim guard (the named edge)
 
 The absence-claim backstop proposed in `btd6-absence-claim-guard-design.md`

--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -58,6 +58,35 @@ game-data dump clone**, so this session did the work that is verifiable here and
   answer framing fix** (a prompt change, live-verify next session) becomes the
   milder concrete item. Captured in the evidence-update section of
   `btd6-absence-claim-guard-design.md`.
+- **Capability-surface verification (vs the bot's live self-report).** The bot
+  was asked to "list all your tools" and another reviewer flagged possible
+  doc/code drift. Verified against the real registry (`build_registry`):
+  **17 tools at USER scope, 22 at ADMIN** (with guild+member). Findings:
+  - **`btd6_relic_lookup` + `btd6_bloon_filter` + `btd6_cumulative_cost` ARE in
+    the live registry** — i.e. **this session's #482 work is registered and the
+    model sees it**, not pre-existing and not doc drift. The status doc already
+    lists them; **docs are current**, correcting the "docs undercount what's
+    shipped" read (that reviewer pre-dated #482).
+  - **Self-knowledge ≠ registry (over-claim):** the bot listed `lookup_member`
+    and `list_all_members`, which are gated behind `ai_server_member_lookup_
+    enabled` (**default False**) and were **NOT** in its toolset. There is **no
+    deterministic "list my tools" path** — the self-report is model-generated, so
+    it can (and did) name tools it doesn't currently hold. *(If that guild has the
+    member flag ON, the list is accurate — maintainer to confirm the flag.)*
+  - **Buccaneer pricing `grounding_failed` is NOT a data gap.** Verified
+    `btd6_context_service.build("pricing of monkey buccaneer")` → **found, 27
+    facts** incl. base 400 and upgrade prices ($275/$425/$3350…), identical shape
+    to sub/tack. So it is **not** "the general lookup grounds some towers and not
+    others" (correcting that reviewer's hypothesis). The medium prices are
+    groundable; the live refusal is **tool-invocation / derived-difficulty-price
+    grounding** — same family as total-cost (either the lookup wasn't invoked that
+    turn, or the model emitted Easy/Hard/Impoppable prices without calling
+    `btd6_difficulty_cost`, so the *scaled* numbers were ungrounded → rejected).
+    **Discriminator owed:** the buccaneer turn's tool-call trace. **Proposed fix:**
+    a deterministic all-difficulties tower-pricing tool (1 call → the full
+    per-upgrade × 4-difficulty table, grounded by construction), the same pattern
+    as `btd6_cumulative_cost`, replacing the fragile lookup + N×difficulty_cost
+    stitch. *Not built yet — pending the tool-trace so we fix the real mechanism.*
 - **Round "heaviest waves" ranker — FIXED.** `round_composition` now returns a
   pre-ranked `heaviest` (by count, with a bloon) / `heaviest_by_rbe` (by RBE,
   without), ranked over the **full** range before the detail cap, so the model

--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -87,6 +87,30 @@ game-data dump clone**, so this session did the work that is verifiable here and
     per-upgrade × 4-difficulty table, grounded by construction), the same pattern
     as `btd6_cumulative_cost`, replacing the fragile lookup + N×difficulty_cost
     stitch. *Not built yet — pending the tool-trace so we fix the real mechanism.*
+- **Live bug-report round 2 (maintainer + friends) — verified, two hypotheses
+  corrected.** Three reported issues:
+  - **Paragon false "no paragon" (Buccaneer).** Maintainer hypothesised a broken
+    tower→paragon linkage. **All-tower audit disproves it:** every paragon-bearing
+    tower is consistent (`monkey_buccaneer`→`paragon_cost=550000`→`navarch_of_the_
+    seas`), and `build("…buccaneer")` **emits** the correct `[btd6_paragon]`
+    Navarch line. So **no data fix** — the false "no paragon" is the model
+    confabulating an absence when that grounding wasn't surfaced → it's the **pure
+    absence-claim repro** (absence-claim design Update 2), not a linkage bug.
+  - **Upgrade-cost routing.** Maintainer hypothesised the *task router* branches
+    cost intent to general vs the cost tool. **Tested `classify()` — disproven:**
+    route ≠ outcome (`monkey ace upgrades`/`pricing of monkey buccaneer` route to
+    `btd6.answer` yet failed; `what are all the upgrade costs of the heli` routes
+    to `general.nl_answer` yet worked). Real mechanism: inconsistent model
+    invocation of the deterministic cost tools for *derived* numbers — the
+    derived-value family (finding §5.2). Fix is **auto-attached cost grounding**,
+    not a router change.
+  - **Absence-claim guard RE-ELEVATED** — the paragon case is the pure repro, and
+    a new hard requirement landed: **absence claims leave no audit row** (recent_
+    audit is denial-only), so the guard must emit an auditable signal. See the
+    absence-claim design Update 2.
+  - **Not broken (confirmed):** `btd6_cumulative_cost` arithmetic across Wizard/
+    Heli/Buccaneer; `btd6_relic_lookup`/`btd6_bloon_filter` registered (see the
+    capability-surface bullet above).
 - **Round "heaviest waves" ranker — FIXED.** `round_composition` now returns a
   pre-ranked `heaviest` (by count, with a bloon) / `heaviest_by_rbe` (by RBE,
   without), ranked over the **full** range before the detail cap, so the model


### PR DESCRIPTION
Doc-only. Verifies live findings against the **real registry, data, and routing code** rather than taking diagnoses at face value. Two rounds in this PR.

## Round 1 — capability-surface verification
- Registry: **17 tools at USER, 22 at ADMIN**. #482's `btd6_relic_lookup` / `btd6_bloon_filter` / `btd6_cumulative_cost` are registered and model-visible — reachability sweep **shipped this session**, docs current (not drift).
- **Self-knowledge ≠ registry:** the bot listed `lookup_member` / `list_all_members`, gated behind `ai_server_member_lookup_enabled` (**default False**) and not in its toolset. No deterministic "list my tools" path — the self-report is model-generated and can over-claim. *(Confirm the flag for that guild.)*
- **Buccaneer pricing ≠ data gap:** `build("pricing of monkey buccaneer")` → **27 grounded facts** incl. prices, same as sub/tack. The failure is tool-invocation / derived-difficulty-price grounding.

## Round 2 — bug report (paragon / routing / absence), two hypotheses corrected
- **Paragon false "no paragon" (Buccaneer) — NOT a data bug.** The requested all-tower audit **disproves** a linkage bug: every paragon-bearing tower is consistent (`monkey_buccaneer` → `paragon_cost=550000` → `navarch_of_the_seas`), and `build("…buccaneer")` **emits** `[btd6_paragon] … Navarch of the Seas, costing 550000`. So **no data fix** — it's the model confabulating an absence when that grounding wasn't surfaced → the **pure absence-claim repro**.
- **Upgrade-cost routing — NOT the task router.** Tested `ai_task_router.classify`: **route ≠ outcome** (`monkey ace upgrades` / `pricing of monkey buccaneer` → `btd6.answer` yet **failed**; `what are all the upgrade costs of the heli` → `general.nl_answer` yet **worked**). Real mechanism: inconsistent model invocation of the deterministic cost tools for *derived* numbers (cumulative / difficulty-scaled). Fix is **auto-attached cost grounding**, not a router change.
- **Absence-claim guard RE-ELEVATED.** The paragon case is the pure repro the earlier round was missing, plus a new hard requirement: **absence claims leave no audit row** (`recent_audit` is denial-only) → the guard must emit an auditable signal; and verify against **data, not user assertion**.

## What's NOT broken (confirmed)
`btd6_cumulative_cost` arithmetic (Wizard/Heli/Buccaneer); the registered reachability tools; the paragon data linkage (all 13 paragon-towers consistent).

## No code changed
This is verification + design. The two real fixes — **auto-attached tower-cost grounding** (derived-value §5.2) and the **absence-claim backstop** (design Update 2) — are pipeline/guard changes whose *efficacy* is live-owed, so they're proposed precisely, not built blind. Say the word on the cost-grounding fix and I'll build it (numbers verifiable in-sandbox; efficacy live-verified after).

## Docs
`btd6-absence-claim-guard-design.md` (Update 2), `btd6-derived-value-groundedness-finding.md` (§5.2), `btd6-gamedata-decode-status.md`.