### PR TITLE
fix(btd6): surface per-upgrade descriptions into tower grounding

### DIFF
--- a/disbot/services/btd6_context_service.py
+++ b/disbot/services/btd6_context_service.py
@@ -335,7 +335,43 @@ def _render_fixture_tower(entry: Any) -> list[str]:
         )
 
     lines.extend(_render_paragon(getattr(entry, "id", ""), canonical))
+    lines.extend(_render_upgrade_descriptions(getattr(entry, "id", ""), canonical))
     lines.extend(_render_tower_stats(getattr(entry, "id", ""), canonical))
+    return lines
+
+
+def _render_upgrade_descriptions(tower_id: str, canonical: str) -> list[str]:
+    """Per-upgrade game-authored description prose as ``[btd6_upgrade]`` lines.
+
+    A tower's 15 upgrade cards each carry a localized description (extracted from
+    the dump). ``_render_tower`` lists upgrade NAMES + costs but not their prose,
+    so "list the upgrades and descriptions of X" / "what does <upgrade> do" had no
+    grounding and the model free-recalled it — which the faithfulness guard
+    rejected (live ``grounding_failed``). Surfaces every described card, bounded
+    by the 15-card max and emitted only for a specifically-named tower — the
+    tower analogue of :func:`_render_hero_descriptions`.
+    """
+    from services import btd6_stats_service
+
+    stats = btd6_stats_service.get_tower_stats(tower_id)
+    if stats is None:
+        return []
+    suffix = " (source: BTD6 in-game description)"
+    lines: list[str] = []
+    for up in stats.upgrades:
+        if not isinstance(up, dict):
+            continue
+        name = _sanitise(str(up.get("name", "") or ""))
+        desc = _sanitise(str(up.get("description", "") or ""))
+        if not name or not desc:
+            continue
+        # Budget the prose so the provenance suffix always survives (mirrors the
+        # per-level hero descriptions); _cap would otherwise chop the source off.
+        prefix = f"[btd6_upgrade] {canonical} {name}: "
+        budget = _FACT_TEXT_CAP - len(prefix) - len(suffix)
+        if budget < len(desc):
+            desc = desc[: max(budget - 1, 0)].rstrip() + "…"
+        lines.append(f"{prefix}{desc}{suffix}")
     return lines
 
 

--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -111,6 +111,24 @@ game-data dump clone**, so this session did the work that is verifiable here and
   - **Not broken (confirmed):** `btd6_cumulative_cost` arithmetic across Wizard/
     Heli/Buccaneer; `btd6_relic_lookup`/`btd6_bloon_filter` registered (see the
     capability-surface bullet above).
+- **Live bug-report round 3 (super monkey) — route≠outcome confirmed LIVE +
+  upgrade-descriptions FIXED.** `recent_audit` showed the super-monkey upgrade
+  refusals as `grounding_failed` on **`task=btd6.answer`** — so the question
+  *did* route to BTD6 and auto-ground, yet failed: **live proof that routing is
+  not the cause** (matches the `classify()` test). Two grounding gaps isolated:
+  - **Gap A — descriptions not surfaced (FIXED).** `build()` listed upgrade
+    NAMES + costs but **not** their game-authored descriptions (all 15 exist via
+    `get_upgrade_detail`), so "list all the upgrades and descriptions of X" had
+    no grounding → the model free-recalled → `grounding_failed`. Added
+    `_render_upgrade_descriptions` (mirrors `_render_hero_descriptions`): every
+    described card now grounds as a `[btd6_upgrade]` line. Verified in-sandbox
+    (super monkey: 15/15 attached). *Live-owed: the re-ask must now answer.*
+  - **Gap B — derived prices (still open).** "list upgrade prices" failed even
+    though MEDIUM prices are grounded, because the model elaborated into
+    *difficulty-scaled/cumulative* prices it didn't route through the cost tools
+    → `grounding_failed`. The derived-value family (finding §5.2); fix is the
+    auto-attached cost grounding, **scope still to confirm** (every tower Q vs
+    cost-intent only).
 - **Round "heaviest waves" ranker — FIXED.** `round_composition` now returns a
   pre-ranked `heaviest` (by count, with a bloon) / `heaviest_by_rbe` (by RBE,
   without), ranked over the **full** range before the detail cap, so the model

--- a/tests/unit/services/test_btd6_context_grounding.py
+++ b/tests/unit/services/test_btd6_context_grounding.py
@@ -319,6 +319,22 @@ async def test_build_grounds_reported_upgrade_queries(query, expected):
     ), f"{query!r} did not ground {expected!r}: {ctx.facts}"
 
 
+async def test_build_grounds_tower_upgrade_descriptions():
+    # Live `grounding_failed`: "list all the upgrades and descriptions of the
+    # super monkey" — build() listed upgrade NAMES + costs but not their prose,
+    # so the model free-recalled the descriptions and the guard rejected them.
+    # Every described card is now surfaced as a [btd6_upgrade] grounding line.
+    ctx = await btd6_context_service.build(
+        "list all the upgrades and descriptions of the super monkey",
+    )
+    desc_lines = [f for f in ctx.facts if f.startswith("[btd6_upgrade] Super Monkey ")]
+    assert len(desc_lines) == 15  # all three paths, five tiers each
+    blob = "\n".join(desc_lines)
+    assert "Laser Blasts: Shoots powerful blasts of laser" in blob
+    assert "True Sun God" in blob  # the tier-5 card is present, not dropped
+    assert all("(source: BTD6 in-game description)" in f for f in desc_lines)
+
+
 async def test_build_ignores_non_upgrade_text():
     # A plain greeting must not spuriously ground an upgrade.
     ctx = await btd6_context_service.build("hello there")
@@ -389,7 +405,9 @@ async def test_build_grounds_hero_roster_with_costs():
     # A realistic cost-listing answer now grounds end-to-end.
     answer = "BTD6 has 17 heroes: Quincy ($540), Gwendolin ($725), Benjamin ($1200)."
     verdict = btd6_grounding_service.validate_btd6_reply(
-        answer, facts=tuple(ctx.facts), task=AITask.BTD6_ANSWER,
+        answer,
+        facts=tuple(ctx.facts),
+        task=AITask.BTD6_ANSWER,
     )
     assert verdict.grounded is True
     # "list all heroes" must ground too; a specific-hero question must NOT.
@@ -420,9 +438,7 @@ def test_deterministic_roster_reply_lists_full_rosters():
         assert name in heroes
     assert "$540" in heroes  # Quincy's cost is code-built
 
-    primary = btd6_context_service.deterministic_roster_reply(
-        "list all primary towers"
-    )
+    primary = btd6_context_service.deterministic_roster_reply("list all primary towers")
     assert primary is not None and "Dart Monkey" in primary
     assert "Sniper Monkey" not in primary  # military tower excluded by category
 


### PR DESCRIPTION
## The live failure
`!ai why-no-response` showed "list all the upgrades and descriptions of the super monkey" denied with **`grounding_failed` · task=`btd6.answer` · provider=anthropic**. That `task=btd6.answer` is the key: the question **did** route to BTD6 and auto-ground, and **still failed** — live proof that routing is not the cause (matches the `classify()` test from #484).

## Root cause (verified in-sandbox)
`btd6_context_service.build()` lists upgrade **names + costs** but never their **descriptions** — even though all 15 super-monkey cards have game-authored descriptions reachable via `get_upgrade_detail` (e.g. *Laser Blasts → "Shoots powerful blasts of laser instead of darts."*). With no grounded descriptions, the model recalled them from memory → the faithfulness guard rejected the answer. Classic *extracted ≠ reachable*: the data exists, it just wasn't surfaced into the tower context.

## Fix
Adds `_render_upgrade_descriptions` — the tower analogue of the existing `_render_hero_descriptions` (which already does this per hero level). Every described upgrade card is surfaced as a `[btd6_upgrade]` grounding line, bounded by the 15-card max and the per-fact text cap, emitted only for a specifically-named tower.

**Verified in-sandbox:** super monkey now grounds **15/15** descriptions (facts 20 → 35); no truncation (auto-grounding path is uncapped, tool path caps at 80). Test pins the behavior. `check_quality.py --full` → **7227 passed**; architecture **0 errors**.

**Live-owed:** the re-ask must now answer with the descriptions instead of refusing — that's the verdict, per the standing rule.

## Not in this PR (the sibling failure)
"list upgrade **prices** for super monkey" failed for a *different* reason — the medium prices **are** grounded, but the model elaborated into **difficulty-scaled / cumulative** prices it didn't route through the cost tools (`grounding_failed`). That's the derived-value gap (derived-value finding §5.2); its fix is the auto-attached **cost** grounding, where the one open decision is scope (every tower question vs. cost-intent only). Say the word and I'll build it.

---
_Generated by [Claude Code](https://claude.ai/code/session_012s22Kt2tbLGC5yXQf5eUgX)_