### PR TITLE
fix(btd6): auto-attach all-difficulty + cumulative upgrade costs to tower grounding

### DIFF
--- a/disbot/services/btd6_context_service.py
+++ b/disbot/services/btd6_context_service.py
@@ -336,6 +336,7 @@ def _render_fixture_tower(entry: Any) -> list[str]:
 
     lines.extend(_render_paragon(getattr(entry, "id", ""), canonical))
     lines.extend(_render_upgrade_descriptions(getattr(entry, "id", ""), canonical))
+    lines.extend(_render_tower_costs(getattr(entry, "id", ""), canonical))
     lines.extend(_render_tower_stats(getattr(entry, "id", ""), canonical))
     return lines
 
@@ -372,6 +373,58 @@ def _render_upgrade_descriptions(tower_id: str, canonical: str) -> list[str]:
         if budget < len(desc):
             desc = desc[: max(budget - 1, 0)].rstrip() + "…"
         lines.append(f"{prefix}{desc}{suffix}")
+    return lines
+
+
+def _render_tower_costs(tower_id: str, canonical: str) -> list[str]:
+    """All-difficulty per-buy + cumulative upgrade costs as ``[btd6_cost]`` lines.
+
+    ``_render_tower`` carries only the Medium per-buy price, so a "pricing across
+    all difficulties" or "total cost to reach tier N" table emitted *derived*
+    numbers (difficulty-scaled / summed) absent from grounding — the faithfulness
+    guard rejected them (live ``grounding_failed``) on any turn where the model
+    didn't route through the cost tools, which it does inconsistently. Surfacing
+    every derived number as a grounded fact makes those tables answerable by
+    construction, independent of tool invocation. Reuses the tested
+    :func:`btd6_data_service.cumulative_upgrade_costs` (one pass per difficulty);
+    emitted for any named tower that has cost data.
+    """
+    from services import btd6_data_service
+    from utils.btd6 import difficulty_costs
+
+    diffs = difficulty_costs.DIFFICULTIES  # easy, medium, hard, impoppable
+    per = {
+        d: btd6_data_service.cumulative_upgrade_costs(tower_id, difficulty=d)
+        for d in diffs
+    }
+    if not per["medium"].get("found"):
+        return []
+    base = {d: per[d]["base_cost"] for d in diffs}
+    lines = [
+        _cap(
+            f"[btd6_cost] {canonical} pricing — Medium from fixture/btd6_data; "
+            "Easy/Hard/Impoppable = Medium ×0.85/1.08/1.20 rounded to $5; "
+            "'to reach' = tower base + all earlier tiers on that path.",
+        ),
+        _cap(
+            f"[btd6_cost] {canonical} base placement: Easy ${base['easy']:,}, "
+            f"Medium ${base['medium']:,}, Hard ${base['hard']:,}, "
+            f"Impoppable ${base['impoppable']:,}",
+        ),
+    ]
+    for pkey, tiers in per["medium"]["paths"].items():
+        by_tier = {d: {t["tier"]: t for t in per[d]["paths"][pkey]} for d in diffs}
+        for t in tiers:
+            tier = t["tier"]
+            b = {d: by_tier[d][tier]["upgrade_cost"] for d in diffs}
+            c = {d: by_tier[d][tier]["cumulative_cost"] for d in diffs}
+            lines.append(
+                _cap(
+                    f"[btd6_cost] {canonical} {t['name']} ({pkey} tier {tier}) — "
+                    f"buy E${b['easy']:,}/M${b['medium']:,}/H${b['hard']:,}/I${b['impoppable']:,}; "
+                    f"to reach E${c['easy']:,}/M${c['medium']:,}/H${c['hard']:,}/I${c['impoppable']:,}",
+                ),
+            )
     return lines
 
 

--- a/docs/btd6-derived-value-groundedness-finding.md
+++ b/docs/btd6-derived-value-groundedness-finding.md
@@ -138,9 +138,14 @@ depending on the model to call the tool**: detect tower upgrade-cost intent and
 **auto-attach the deterministic cost grounding** (cumulative + all-difficulty
 facts, built from `btd6_data_service.cumulative_upgrade_costs` +
 `difficulty_costs`) into the BTD6 context, the same way #478 auto-grounds upgrade
-modifiers. The numbers are verifiable in-sandbox; the *efficacy* (model uses them,
-guard accepts) is live-owed — a pipeline change to confirm before shipping, so it
-is **proposed, not built blind** here.
+modifiers.
+
+**SHIPPED** (`_render_tower_costs`, maintainer chose the broad scope — **every**
+resolved-tower question): each tower now grounds a `[btd6_cost]` block — base +
+each upgrade's per-buy (Easy/Med/Hard/Impop) and cumulative (base+priors) cost —
+so the all-difficulty and total-cost tables are grounded by construction, no tool
+call required. Numbers verified in-sandbox (reuses the tested cumulative engine);
+**efficacy (model uses them, guard accepts) is live-owed**.
 
 > The false **"no paragon"** claim (see the absence-claim doc, Update 2) is the
 > *same shape* on a different field: the paragon grounding line exists and is

--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -123,12 +123,17 @@ game-data dump clone**, so this session did the work that is verifiable here and
     `_render_upgrade_descriptions` (mirrors `_render_hero_descriptions`): every
     described card now grounds as a `[btd6_upgrade]` line. Verified in-sandbox
     (super monkey: 15/15 attached). *Live-owed: the re-ask must now answer.*
-  - **Gap B — derived prices (still open).** "list upgrade prices" failed even
+  - **Gap B — derived prices (FIXED).** "list upgrade prices" failed even
     though MEDIUM prices are grounded, because the model elaborated into
     *difficulty-scaled/cumulative* prices it didn't route through the cost tools
-    → `grounding_failed`. The derived-value family (finding §5.2); fix is the
-    auto-attached cost grounding, **scope still to confirm** (every tower Q vs
-    cost-intent only).
+    → `grounding_failed`. Maintainer chose the broad scope (**every tower
+    question**). Added `_render_tower_costs`: every resolved tower now grounds a
+    `[btd6_cost]` block — base + each upgrade's **per-buy** (Easy/Med/Hard/Impop)
+    **and cumulative** (base+priors) cost, reusing the tested
+    `cumulative_upgrade_costs` engine. So the all-difficulty / total-cost tables
+    are grounded by construction, with no dependence on the model calling a tool.
+    Verified in-sandbox (super monkey: 17 lines; True Sun God Impoppable per-buy
+    $600,000; numbers reconcile). *Live-owed: the re-ask must now answer.*
 - **Round "heaviest waves" ranker — FIXED.** `round_composition` now returns a
   pre-ranked `heaviest` (by count, with a bloon) / `heaviest_by_rbe` (by RBE,
   without), ranked over the **full** range before the detail cap, so the model

--- a/tests/unit/services/test_btd6_context_grounding.py
+++ b/tests/unit/services/test_btd6_context_grounding.py
@@ -335,6 +335,22 @@ async def test_build_grounds_tower_upgrade_descriptions():
     assert all("(source: BTD6 in-game description)" in f for f in desc_lines)
 
 
+async def test_build_grounds_tower_costs_all_difficulties_and_cumulative():
+    # Live grounding_failed: "list upgrade prices for super monkey" — build()
+    # carried only the Medium per-buy price, so the model's all-difficulty /
+    # cumulative table emitted derived numbers that weren't grounded. Every
+    # derived number is now a [btd6_cost] line (header + base + 15 upgrades).
+    ctx = await btd6_context_service.build("list me upgrade prices for super monkey")
+    cost = [f for f in ctx.facts if f.startswith("[btd6_cost]")]
+    assert len(cost) == 17
+    blob = "\n".join(cost)
+    # base scales per the documented multipliers (Easy = round5(2500 * 0.85)).
+    assert "base placement: Easy $2,125, Medium $2,500" in blob
+    # True Sun God Impoppable per-buy = round5(500000 * 1.2) = 600,000 — the kind
+    # of derived figure that previously got rejected.
+    assert "True Sun God" in blob and "I$600,000" in blob
+
+
 async def test_build_ignores_non_upgrade_text():
     # A plain greeting must not spuriously ground an upgrade.
     ctx = await btd6_context_service.build("hello there")


### PR DESCRIPTION
Closes the derived-value **cost** gap — the `grounding_failed` on "list upgrade prices for super monkey" (and the buccaneer/ace/heli pricing failures before it). You chose the broad scope, so this attaches costs to **every** tower question.

## Why it failed
`build()`'s upgrade lines carry only the **Medium** per-buy price. When the model tabulated **Easy/Hard/Impoppable** or **"total cost to reach tier N"**, those numbers are *derived* (difficulty-scaled / summed) and weren't in grounding — so the faithfulness guard rejected the answer on any turn where the model didn't route through `btd6_cumulative_cost` / `btd6_difficulty_cost` (which it does inconsistently, temperature-driven). Confirmed live: the refusals were `grounding_failed` on `task=btd6.answer` — i.e. it auto-grounded and still failed, because the grounding lacked the derived numbers.

## Fix
`_render_tower_costs` (wired into `_render_tower`). Every resolved tower now grounds a `[btd6_cost]` block:
- a provenance/semantics header (Medium from fixture; E/H/I = Medium ×0.85/1.08/1.20 round-$5; "to reach" = base + earlier tiers),
- base placement across all four difficulties,
- per upgrade: **per-buy** (E/M/H/I) **and cumulative** (base+priors, E/M/H/I).

It **reuses the already-tested `cumulative_upgrade_costs`** engine (one pass per difficulty), so the arithmetic is the same one shipped in #482 — no new number math to trust. So the all-difficulty and total-cost tables are now grounded *by construction*, independent of whether the model calls a tool.

## Verified (in-sandbox)
- Super monkey: **17** `[btd6_cost]` lines; max line **167 chars** (< 240 per-fact cap); **52** total facts (< 80 tool cap).
- True Sun God Impoppable per-buy **$600,000** = round5(500000 × 1.2); base Easy **$2,125** = round5(2500 × 0.85); cumulative reconciles.
- `check_quality.py --full` → **7228 passed**; architecture **0 errors**. Test pins the behavior.

**Live-owed:** the re-ask ("upgrade prices / all difficulties / total cost to reach X") must now answer instead of refusing — that's the verdict.

> Bonus: this also reliably grounds the paragon line for tower questions, so the false "no paragon" (the absence-claim repro) is less likely to recur via this path too — the two issues overlapped.

---
_Generated by [Claude Code](https://claude.ai/code/session_012s22Kt2tbLGC5yXQf5eUgX)_