### PR TITLE
feat(btd6): full maps cutover (3→89) + complete modes (2→13) + start zone decode

### DIFF
--- a/disbot/data/btd6/maps.json
+++ b/disbot/data/btd6/maps.json
@@ -1,31 +1,815 @@
 {
-  "data_version": "1.0",
-  "game_version": "41.3",
-  "source": "Bloons Wiki — representative sample (Module 3 of AI/BTD6 plan)",
+  "data_version": "2.0",
+  "game_version": "55.0",
+  "source": "BTD Mod Helper game data export",
   "maps": [
     {
-      "id": "logs",
-      "canonical": "Logs",
-      "aliases": ["log"],
+      "id": "alpine_run",
+      "canonical": "Alpine Run",
+      "aliases": [],
       "difficulty": "Beginner",
-      "description": "Single river-and-logs track. Heavy water coverage in places.",
-      "lines_of_sight_notes": "Open central area; water tile presence allows naval towers."
+      "description": "Beginner map.",
+      "lines_of_sight_notes": "No water tiles — land-only tower placement.",
+      "has_water": false
+    },
+    {
+      "id": "candy_falls",
+      "canonical": "Candy Falls",
+      "aliases": [],
+      "difficulty": "Beginner",
+      "description": "Beginner map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "carved",
+      "canonical": "Carved",
+      "aliases": [],
+      "difficulty": "Beginner",
+      "description": "Beginner map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
     },
     {
       "id": "cubism",
       "canonical": "Cubism",
-      "aliases": ["cube", "cubes"],
-      "difficulty": "Intermediate",
+      "aliases": [
+        "cube",
+        "cubes"
+      ],
+      "difficulty": "Beginner",
       "description": "Tight quartered paths with cubes obstructing line of sight.",
-      "lines_of_sight_notes": "Cubes block towers; consider towers that ignore LoS or place near gaps."
+      "lines_of_sight_notes": "Cubes block towers; consider towers that ignore LoS or place near gaps.",
+      "has_water": true
+    },
+    {
+      "id": "end_of_the_road",
+      "canonical": "End Of The Road",
+      "aliases": [],
+      "difficulty": "Beginner",
+      "description": "Beginner map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "four_circles",
+      "canonical": "Four Circles",
+      "aliases": [],
+      "difficulty": "Beginner",
+      "description": "Beginner map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "frozen_over",
+      "canonical": "Frozen Over",
+      "aliases": [],
+      "difficulty": "Beginner",
+      "description": "Beginner map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "hedge",
+      "canonical": "Hedge",
+      "aliases": [],
+      "difficulty": "Beginner",
+      "description": "Beginner map.",
+      "lines_of_sight_notes": "No water tiles — land-only tower placement.",
+      "has_water": false
+    },
+    {
+      "id": "in_the_loop",
+      "canonical": "In The Loop",
+      "aliases": [],
+      "difficulty": "Beginner",
+      "description": "Beginner map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "logs",
+      "canonical": "Logs",
+      "aliases": [
+        "log"
+      ],
+      "difficulty": "Beginner",
+      "description": "Single river-and-logs track. Heavy water coverage in places.",
+      "lines_of_sight_notes": "Open central area; water tile presence allows naval towers.",
+      "has_water": true
+    },
+    {
+      "id": "lotus_island",
+      "canonical": "Lotus Island",
+      "aliases": [],
+      "difficulty": "Beginner",
+      "description": "Beginner map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "middle_of_the_road",
+      "canonical": "Middle of the Road",
+      "aliases": [],
+      "difficulty": "Beginner",
+      "description": "Beginner map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "one_two_tree",
+      "canonical": "One Two Tree",
+      "aliases": [],
+      "difficulty": "Beginner",
+      "description": "Beginner map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "park_path",
+      "canonical": "Park Path",
+      "aliases": [],
+      "difficulty": "Beginner",
+      "description": "Beginner map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "resort",
+      "canonical": "Resort",
+      "aliases": [],
+      "difficulty": "Beginner",
+      "description": "Beginner map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "scrapyard",
+      "canonical": "Scrapyard",
+      "aliases": [],
+      "difficulty": "Beginner",
+      "description": "Beginner map.",
+      "lines_of_sight_notes": "No water tiles — land-only tower placement.",
+      "has_water": false
+    },
+    {
+      "id": "skates",
+      "canonical": "Skates",
+      "aliases": [],
+      "difficulty": "Beginner",
+      "description": "Beginner map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "skull_tweak",
+      "canonical": "Skull Tweak",
+      "aliases": [],
+      "difficulty": "Beginner",
+      "description": "Beginner map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "spa_pits",
+      "canonical": "Spa Pits",
+      "aliases": [],
+      "difficulty": "Beginner",
+      "description": "Beginner map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "the_cabin",
+      "canonical": "The Cabin",
+      "aliases": [],
+      "difficulty": "Beginner",
+      "description": "Beginner map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "three_mines_around",
+      "canonical": "Three Mines 'Round",
+      "aliases": [],
+      "difficulty": "Beginner",
+      "description": "Beginner map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "tinkerton",
+      "canonical": "Tinkerton",
+      "aliases": [],
+      "difficulty": "Beginner",
+      "description": "Beginner map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "town_centre",
+      "canonical": "Town Center",
+      "aliases": [],
+      "difficulty": "Beginner",
+      "description": "Beginner map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "tree_stump",
+      "canonical": "Tree Stump",
+      "aliases": [],
+      "difficulty": "Beginner",
+      "description": "Beginner map.",
+      "lines_of_sight_notes": "No water tiles — land-only tower placement.",
+      "has_water": false
+    },
+    {
+      "id": "tutorial",
+      "canonical": "Monkey Meadow",
+      "aliases": [],
+      "difficulty": "Beginner",
+      "description": "Beginner map.",
+      "lines_of_sight_notes": "No water tiles — land-only tower placement.",
+      "has_water": false
+    },
+    {
+      "id": "winter_park",
+      "canonical": "Winter Park",
+      "aliases": [],
+      "difficulty": "Beginner",
+      "description": "Beginner map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "adoras_temple",
+      "canonical": "Adora's Temple",
+      "aliases": [],
+      "difficulty": "Intermediate",
+      "description": "Intermediate map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "ancient_portal",
+      "canonical": "Ancient Portal",
+      "aliases": [],
+      "difficulty": "Intermediate",
+      "description": "Intermediate map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "balance",
+      "canonical": "Balance",
+      "aliases": [],
+      "difficulty": "Intermediate",
+      "description": "Intermediate map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "base_editor_map",
+      "canonical": "Base Editor Map",
+      "aliases": [],
+      "difficulty": "Intermediate",
+      "description": "Intermediate map.",
+      "lines_of_sight_notes": "No water tiles — land-only tower placement.",
+      "has_water": false
+    },
+    {
+      "id": "bazaar",
+      "canonical": "Bazaar",
+      "aliases": [],
+      "difficulty": "Intermediate",
+      "description": "Intermediate map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "bloonarius_prime",
+      "canonical": "Bloonarius Prime",
+      "aliases": [],
+      "difficulty": "Intermediate",
+      "description": "Intermediate map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "chutes",
+      "canonical": "Chutes",
+      "aliases": [],
+      "difficulty": "Intermediate",
+      "description": "Intermediate map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "covered_garden",
+      "canonical": "Covered Garden",
+      "aliases": [],
+      "difficulty": "Intermediate",
+      "description": "Intermediate map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "cracked",
+      "canonical": "Cracked",
+      "aliases": [],
+      "difficulty": "Intermediate",
+      "description": "Intermediate map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "downstream",
+      "canonical": "Downstream",
+      "aliases": [],
+      "difficulty": "Intermediate",
+      "description": "Intermediate map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "encrypted",
+      "canonical": "Encrypted",
+      "aliases": [],
+      "difficulty": "Intermediate",
+      "description": "Intermediate map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "firing_range",
+      "canonical": "Firing Range",
+      "aliases": [],
+      "difficulty": "Intermediate",
+      "description": "Intermediate map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "haunted",
+      "canonical": "Haunted",
+      "aliases": [],
+      "difficulty": "Intermediate",
+      "description": "Intermediate map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "karts_ndarts",
+      "canonical": "KartsNDarts",
+      "aliases": [],
+      "difficulty": "Intermediate",
+      "description": "Intermediate map.",
+      "lines_of_sight_notes": "No water tiles — land-only tower placement.",
+      "has_water": false
+    },
+    {
+      "id": "lost_crevasse",
+      "canonical": "Lost Crevasse",
+      "aliases": [],
+      "difficulty": "Intermediate",
+      "description": "Intermediate map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "luminous_cove",
+      "canonical": "Luminous Cove",
+      "aliases": [],
+      "difficulty": "Intermediate",
+      "description": "Intermediate map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "moon_landing",
+      "canonical": "Moon Landing",
+      "aliases": [],
+      "difficulty": "Intermediate",
+      "description": "Intermediate map.",
+      "lines_of_sight_notes": "No water tiles — land-only tower placement.",
+      "has_water": false
+    },
+    {
+      "id": "polyphemus",
+      "canonical": "Polyphemus",
+      "aliases": [],
+      "difficulty": "Intermediate",
+      "description": "Intermediate map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "protect_the_yacht",
+      "canonical": "Protect The Yacht",
+      "aliases": [],
+      "difficulty": "Intermediate",
+      "description": "Intermediate map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "quarry",
+      "canonical": "Quarry",
+      "aliases": [],
+      "difficulty": "Intermediate",
+      "description": "Intermediate map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "quiet_street",
+      "canonical": "Quiet Street",
+      "aliases": [],
+      "difficulty": "Intermediate",
+      "description": "Intermediate map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "rake",
+      "canonical": "Rake",
+      "aliases": [],
+      "difficulty": "Intermediate",
+      "description": "Intermediate map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "spice_islands",
+      "canonical": "Spice Islands",
+      "aliases": [],
+      "difficulty": "Intermediate",
+      "description": "Intermediate map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "spring_spring",
+      "canonical": "Spring Spring",
+      "aliases": [],
+      "difficulty": "Intermediate",
+      "description": "Intermediate map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "streambed",
+      "canonical": "Streambed",
+      "aliases": [],
+      "difficulty": "Intermediate",
+      "description": "Intermediate map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "sulfur_springs",
+      "canonical": "Sulfur Springs",
+      "aliases": [],
+      "difficulty": "Intermediate",
+      "description": "Intermediate map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "water_park",
+      "canonical": "Water Park",
+      "aliases": [],
+      "difficulty": "Intermediate",
+      "description": "Intermediate map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "another_brick",
+      "canonical": "Another Brick",
+      "aliases": [],
+      "difficulty": "Advanced",
+      "description": "Advanced map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "cargo",
+      "canonical": "Cargo",
+      "aliases": [],
+      "difficulty": "Advanced",
+      "description": "Advanced map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "castle_revenge",
+      "canonical": "Castle Revenge",
+      "aliases": [],
+      "difficulty": "Advanced",
+      "description": "Advanced map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
     },
     {
       "id": "cornfield",
       "canonical": "Cornfield",
-      "aliases": ["corn"],
-      "difficulty": "Beginner",
+      "aliases": [
+        "corn"
+      ],
+      "difficulty": "Advanced",
       "description": "Open field with a winding path. Forgiving placement.",
-      "lines_of_sight_notes": "Open layout; nearly any tower works."
+      "lines_of_sight_notes": "Open layout; nearly any tower works.",
+      "has_water": false
+    },
+    {
+      "id": "dark_path",
+      "canonical": "Dark Path",
+      "aliases": [],
+      "difficulty": "Advanced",
+      "description": "Advanced map.",
+      "lines_of_sight_notes": "No water tiles — land-only tower placement.",
+      "has_water": false
+    },
+    {
+      "id": "enchanted_glade",
+      "canonical": "Enchanted Glade",
+      "aliases": [],
+      "difficulty": "Advanced",
+      "description": "Advanced map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "erosion",
+      "canonical": "Erosion",
+      "aliases": [],
+      "difficulty": "Advanced",
+      "description": "Advanced map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "geared",
+      "canonical": "Geared",
+      "aliases": [],
+      "difficulty": "Advanced",
+      "description": "Advanced map.",
+      "lines_of_sight_notes": "No water tiles — land-only tower placement.",
+      "has_water": false
+    },
+    {
+      "id": "high_finance",
+      "canonical": "High Finance",
+      "aliases": [],
+      "difficulty": "Advanced",
+      "description": "Advanced map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "last_resort",
+      "canonical": "Last Resort",
+      "aliases": [],
+      "difficulty": "Advanced",
+      "description": "Advanced map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "mesa",
+      "canonical": "Mesa",
+      "aliases": [],
+      "difficulty": "Advanced",
+      "description": "Advanced map.",
+      "lines_of_sight_notes": "No water tiles — land-only tower placement.",
+      "has_water": false
+    },
+    {
+      "id": "midnight_mansion",
+      "canonical": "Midnight Mansion",
+      "aliases": [],
+      "difficulty": "Advanced",
+      "description": "Advanced map.",
+      "lines_of_sight_notes": "No water tiles — land-only tower placement.",
+      "has_water": false
+    },
+    {
+      "id": "mushroom_grotto",
+      "canonical": "Mushroom Grotto",
+      "aliases": [],
+      "difficulty": "Advanced",
+      "description": "Advanced map.",
+      "lines_of_sight_notes": "No water tiles — land-only tower placement.",
+      "has_water": false
+    },
+    {
+      "id": "off_the_coast",
+      "canonical": "Off The Coast",
+      "aliases": [],
+      "difficulty": "Advanced",
+      "description": "Advanced map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "party_parade",
+      "canonical": "Party Parade",
+      "aliases": [],
+      "difficulty": "Advanced",
+      "description": "Advanced map.",
+      "lines_of_sight_notes": "No water tiles — land-only tower placement.",
+      "has_water": false
+    },
+    {
+      "id": "pats_pond",
+      "canonical": "Pat's Pond",
+      "aliases": [],
+      "difficulty": "Advanced",
+      "description": "Advanced map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "peninsula",
+      "canonical": "Peninsula",
+      "aliases": [],
+      "difficulty": "Advanced",
+      "description": "Advanced map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "spillway",
+      "canonical": "Spillway",
+      "aliases": [],
+      "difficulty": "Advanced",
+      "description": "Advanced map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "sunken_columns",
+      "canonical": "Sunken Columns",
+      "aliases": [],
+      "difficulty": "Advanced",
+      "description": "Advanced map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "sunset_gulch",
+      "canonical": "Sunset Gulch",
+      "aliases": [],
+      "difficulty": "Advanced",
+      "description": "Advanced map.",
+      "lines_of_sight_notes": "No water tiles — land-only tower placement.",
+      "has_water": false
+    },
+    {
+      "id": "underground",
+      "canonical": "Underground",
+      "aliases": [],
+      "difficulty": "Advanced",
+      "description": "Advanced map.",
+      "lines_of_sight_notes": "No water tiles — land-only tower placement.",
+      "has_water": false
+    },
+    {
+      "id": "xfactor",
+      "canonical": "X Factor",
+      "aliases": [],
+      "difficulty": "Advanced",
+      "description": "Advanced map.",
+      "lines_of_sight_notes": "No water tiles — land-only tower placement.",
+      "has_water": false
+    },
+    {
+      "id": "blons",
+      "canonical": "Blons",
+      "aliases": [],
+      "difficulty": "Expert",
+      "description": "Expert map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "bloody_puddles",
+      "canonical": "Bloody Puddles",
+      "aliases": [],
+      "difficulty": "Expert",
+      "description": "Expert map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "dark_castle",
+      "canonical": "Dark Castle",
+      "aliases": [],
+      "difficulty": "Expert",
+      "description": "Expert map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "dark_dungeons",
+      "canonical": "Dark Dungeons",
+      "aliases": [],
+      "difficulty": "Expert",
+      "description": "Expert map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "flooded_valley",
+      "canonical": "Flooded Valley",
+      "aliases": [],
+      "difficulty": "Expert",
+      "description": "Expert map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "glacial_trail",
+      "canonical": "Glacial Trail",
+      "aliases": [],
+      "difficulty": "Expert",
+      "description": "Expert map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "infernal",
+      "canonical": "Infernal",
+      "aliases": [],
+      "difficulty": "Expert",
+      "description": "Expert map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "muddy_puddles",
+      "canonical": "Muddy Puddles",
+      "aliases": [],
+      "difficulty": "Expert",
+      "description": "Expert map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "ouch",
+      "canonical": "#Ouch",
+      "aliases": [],
+      "difficulty": "Expert",
+      "description": "Expert map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "quad",
+      "canonical": "Quad",
+      "aliases": [],
+      "difficulty": "Expert",
+      "description": "Expert map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "ravine",
+      "canonical": "Ravine",
+      "aliases": [],
+      "difficulty": "Expert",
+      "description": "Expert map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "sanctuary",
+      "canonical": "Sanctuary",
+      "aliases": [],
+      "difficulty": "Expert",
+      "description": "Expert map. Contains water.",
+      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
+      "has_water": true
+    },
+    {
+      "id": "tricky_tracks",
+      "canonical": "Tricky Tracks",
+      "aliases": [],
+      "difficulty": "Expert",
+      "description": "Expert map.",
+      "lines_of_sight_notes": "No water tiles — land-only tower placement.",
+      "has_water": false
+    },
+    {
+      "id": "workshop",
+      "canonical": "Workshop",
+      "aliases": [],
+      "difficulty": "Expert",
+      "description": "Expert map.",
+      "lines_of_sight_notes": "No water tiles — land-only tower placement.",
+      "has_water": false
     }
   ]
 }

--- a/disbot/data/btd6/modes.json
+++ b/disbot/data/btd6/modes.json
@@ -1,16 +1,117 @@
 {
-  "data_version": "1.0",
-  "game_version": "41.3",
-  "source": "Bloons Wiki — representative sample (Module 3 of AI/BTD6 plan)",
+  "data_version": "2.0",
+  "game_version": "55.0",
+  "source": "Curated (game modes are gameplay rules, not exported in the Mod Helper dump)",
   "modes": [
     {
       "id": "standard",
       "canonical": "Standard",
-      "aliases": ["easy_standard", "medium_standard", "hard_standard"],
+      "aliases": ["easy_standard", "medium_standard", "hard_standard", "normal"],
+      "starting_cash": 650,
+      "starting_lives": 150,
+      "description": "Default progression with all towers available. Round ranges by difficulty: Easy 1-40, Medium 1-60, Hard 1-80. Starting lives 200 (Easy) / 150 (Medium) / 100 (Hard).",
+      "restrictions": []
+    },
+    {
+      "id": "primary_only",
+      "canonical": "Primary Only",
+      "aliases": ["primary", "primary monkeys only"],
+      "starting_cash": 650,
+      "starting_lives": 200,
+      "description": "Easy-difficulty mode: only Primary-class towers may be placed.",
+      "restrictions": ["Only Primary-class towers (heroes still allowed)"]
+    },
+    {
+      "id": "deflation",
+      "canonical": "Deflation",
+      "aliases": ["deflate"],
+      "starting_cash": 20000,
+      "starting_lives": 200,
+      "description": "Easy-difficulty mode starting at round 31 with a fixed lump of cash and no income — win with what you can afford up front.",
+      "restrictions": [
+        "Starts at round 31",
+        "No income — popping bloons earns no cash",
+        "No selling towers"
+      ]
+    },
+    {
+      "id": "military_only",
+      "canonical": "Military Only",
+      "aliases": ["military"],
+      "starting_cash": 650,
+      "starting_lives": 150,
+      "description": "Medium-difficulty mode: only Military-class towers may be placed.",
+      "restrictions": ["Only Military-class towers (heroes still allowed)"]
+    },
+    {
+      "id": "apopalypse",
+      "canonical": "Apopalypse",
+      "aliases": ["apop", "apocalypse"],
+      "starting_cash": 650,
+      "starting_lives": 150,
+      "description": "Medium-difficulty mode: bloons stream in continuously with no round breaks and rounds cannot be started manually.",
+      "restrictions": ["Continuous bloon stream — no round breaks", "Cannot manually start rounds"]
+    },
+    {
+      "id": "reverse",
+      "canonical": "Reverse",
+      "aliases": ["reversed", "backwards"],
+      "starting_cash": 650,
+      "starting_lives": 150,
+      "description": "Medium-difficulty mode: bloons enter from the normal exit and travel the track in reverse.",
+      "restrictions": ["Bloons travel the track in reverse (enter from the exit)"]
+    },
+    {
+      "id": "magic_monkeys_only",
+      "canonical": "Magic Monkeys Only",
+      "aliases": ["magic", "magic only", "magic monkeys"],
       "starting_cash": 650,
       "starting_lives": 100,
-      "description": "Default progression. Rounds 1-40 (Easy), 3-60 (Medium), 3-80 (Hard).",
-      "restrictions": []
+      "description": "Hard-difficulty mode: only Magic-class towers may be placed.",
+      "restrictions": ["Only Magic-class towers (heroes still allowed)"]
+    },
+    {
+      "id": "double_hp_moabs",
+      "canonical": "Double HP MOABs",
+      "aliases": ["double moabs", "double hp", "dhm"],
+      "starting_cash": 650,
+      "starting_lives": 100,
+      "description": "Hard-difficulty mode: all MOAB-class bloons (MOAB, BFB, ZOMG, DDT, BAD) have double health.",
+      "restrictions": ["All MOAB-class bloons have double health"]
+    },
+    {
+      "id": "half_cash",
+      "canonical": "Half Cash",
+      "aliases": ["half", "halfcash"],
+      "starting_cash": 650,
+      "starting_lives": 100,
+      "description": "Hard-difficulty mode: all cash earned (from pops and income) is halved.",
+      "restrictions": ["All cash earned is halved"]
+    },
+    {
+      "id": "alternate_bloons_rounds",
+      "canonical": "Alternate Bloons Rounds",
+      "aliases": ["abr", "alternate", "alternate bloons"],
+      "starting_cash": 650,
+      "starting_lives": 100,
+      "description": "Hard-difficulty mode: rounds use an alternate, generally tougher bloon composition than the default round set.",
+      "restrictions": ["Uses the alternate (harder) round set"]
+    },
+    {
+      "id": "impoppable",
+      "canonical": "Impoppable",
+      "aliases": ["impop"],
+      "starting_cash": 650,
+      "starting_lives": 1,
+      "description": "Hard-difficulty endgame mode: rounds 6-100, 1 life, full bloon speed, higher tower prices, no continues and no Monkey Knowledge.",
+      "restrictions": [
+        "1 life",
+        "Rounds 6-100",
+        "Higher tower prices",
+        "100% bloon speed",
+        "No continues",
+        "No Monkey Knowledge"
+      ]
     },
     {
       "id": "chimps",
@@ -18,14 +119,24 @@
       "aliases": ["chimp", "chimp mode"],
       "starting_cash": 650,
       "starting_lives": 1,
-      "description": "Hard-mode endgame challenge. 1 life, no continues, no income towers, no powers.",
+      "description": "Hard-mode endgame challenge. The acronym: no Continues, Hearts lost (1 life), Income, Monkey knowledge, Powers, or Selling.",
       "restrictions": [
-        "No income (no banana farms or city)",
-        "No abilities outside what towers already provide",
-        "No powers / monkey knowledge bonuses",
         "No continues",
+        "1 life (any leak loses the run)",
+        "No income (no Banana Farm / Monkey City cash generation)",
+        "No Monkey Knowledge",
+        "No powers",
         "No selling towers"
       ]
+    },
+    {
+      "id": "sandbox",
+      "canonical": "Sandbox",
+      "aliases": ["practice", "freeplay sandbox"],
+      "starting_cash": 9999999,
+      "starting_lives": 9999999,
+      "description": "Practice mode with unlimited cash and lives for testing tower placements and interactions.",
+      "restrictions": ["Unlimited cash and lives (practice only — no rewards)"]
     }
   ]
 }

--- a/disbot/services/ai_tools.py
+++ b/disbot/services/ai_tools.py
@@ -803,9 +803,10 @@ _BTD6_MAP_LOOKUP_SPEC = AIToolSpec(
     name="btd6_map_lookup",
     description=(
         "BTD6 map info: difficulty (Beginner / Intermediate / Advanced / Expert), "
-        "description, and line-of-sight notes. Pass a map name to look one up, or "
-        "omit it to list every map with its difficulty (use for 'which maps are "
-        "beginner', 'is Logs beginner', 'list the maps')."
+        "whether the map has water (naval-tower placement), description, and "
+        "line-of-sight notes. Pass a map name to look one up, or omit it to list "
+        "every map with its difficulty (use for 'which maps are beginner', 'is "
+        "Logs beginner', 'which maps have water', 'list the maps')."
     ),
     parameters={
         "type": "object",
@@ -827,6 +828,7 @@ def _map_dict(entry: Any) -> dict[str, Any]:
         "difficulty": entry.difficulty,
         "description": entry.description,
         "line_of_sight_notes": entry.lines_of_sight_notes,
+        "has_water": entry.has_water,
     }
 
 

--- a/disbot/services/btd6_data_service.py
+++ b/disbot/services/btd6_data_service.py
@@ -86,6 +86,8 @@ class MapEntry:
     difficulty: str
     description: str
     lines_of_sight_notes: str
+    # Whether the map has water tiles (naval-tower placement) — from game data.
+    has_water: bool = False
     # Attribution only; never surfaced. Blank rather than the deprecated
     # Fandom pages — populate from bloonswiki if a verified link is wanted.
     wiki_url: str = ""
@@ -402,6 +404,7 @@ def _parse_map(raw: dict[str, Any]) -> MapEntry:
         difficulty=str(raw["difficulty"]),
         description=str(raw["description"]),
         lines_of_sight_notes=str(raw["lines_of_sight_notes"]),
+        has_water=bool(raw.get("has_water", False)),
         wiki_url=str(raw.get("wiki_url", "")),
     )
 

--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -9,6 +9,27 @@ works** (the traps we hit), and what is still un-decoded.
 
 ## ⭐ Next session — start here (updated 2026-06-04, end of v55 session)
 
+### Session log — maps + modes cutover + zone decode started
+
+- **Maps — full game-data cutover (3 → 89).** `parse_gamedata.py --maps` rebuilds
+  `maps.json` from the dump's `Maps/<Difficulty>/` folders. Difficulty is taken
+  from the folder (authoritative — it corrected stale curated rows, e.g.
+  Cornfield was mis-tagged "Beginner", is actually **Advanced**); display names
+  from `textTable`; new `has_water` fact wired through `MapEntry` →
+  `btd6_map_lookup` (the bot can now answer "which maps have water"). Curated
+  prose (`description`/`lines_of_sight_notes`) is preserved where it existed.
+- **Modes — full set (2 → 13).** The dump has **no** game-mode rules (starting
+  cash/lives/restrictions are gameplay code, not exported assets — confirmed: only
+  `rogueData` carries `startingLives`, and `textTable` has mode *names* but not
+  cleanly-keyed descriptions). So `modes.json` is **curated** from established
+  facts: Standard, Primary/Military/Magic Only, Deflation, Apopalypse, Reverse,
+  Double HP MOABs, Half Cash, ABR, Impoppable, CHIMPS, Sandbox.
+- **Zones — decode started.** `_zones()` emits every top-level `*ZoneModel` as a
+  structured `{kind, name, + decodable numbers}` (Ice Arctic Wind →
+  `speedScale 0.6`, `zoneRadius 25`), wired into `_map_tier` and audit-safe.
+  Remaining: the per-type effect tail, zones nested in sub-towers, and curated
+  display names (not in the dump). See the 🟡 table.
+
 ### Operating lesson (binding — survives the session boundary)
 
 **Green tests are not the verdict; live Discord behavior is.** "Done" means
@@ -381,22 +402,19 @@ must not be treated as done. Verified against the v55 dump on 2026-06-03.
 | Ability names via **`displayName`** | mapper | #466; 87/87 abilities carry it |
 | Upgrade **descriptions** via `LocsKey`→`textTable` (extraction) | mapper | #466; extracts wherever the game localizes one (≈422 player upgrade cards) |
 | Core per-tier numeric extraction: base_cost, category, upgrade cost/xp/path/tier, damage, pierce, rate, range, radius, speed, lifespan, immunities→type | mapper | audit: roster is DELTA/CLEAN, nothing SUSPECT |
+| **Maps — full game-data cutover (89)** | `parse_gamedata.py --maps` → `maps.json` | this session; difficulty from the dump's folder (corrects stale curated rows, e.g. Cornfield → Advanced), names via `textTable`, `has_water` wired into `MapEntry` + `btd6_map_lookup`. Curated prose preserved where present. 89 maps load + tests green |
+| **Modes — full set (13)** | curated `modes.json` | this session; the dump has **no** game-mode rules (cash/lives/restrictions live in game code, not assets), so authored from established facts: Standard, Primary/Military/Magic Only, Deflation, Apopalypse, Reverse, Double HP MOABs, Half Cash, ABR, Impoppable, CHIMPS, Sandbox |
 
 ### 🟡 Partial — NOT complete
 
 | Item | Done | Missing |
 |---|---|---|
 | **Subtowers** (`subtowers[]`) | 3 spawn models: `AbilityCreateTower`/`CreateTower`/`MorphTower`(embedded) → Phoenix, Sentry, Spectre, totems, UAV | `MorphTowerModel` **named-ref** (Alchemist "Transformed Monkey") + `BeastHandlerPetModel` (Beast Handler) — 2 of ~4 mechanisms |
+| **Zones** (`zones[]`) — **started** | `_zones()` emits every top-level `*ZoneModel` as `{kind, name, + decodable numbers}` (e.g. Ice Arctic Wind → `speedScale 0.6`, `zoneRadius 25`); wired into `_map_tier`, audit-safe (internal names don't align with curated, so they're ignored) | the rest of the 28 types' specific effect fields; zones nested inside sub-towers; curated display names (not in the dump — stay wiki-owned); runtime `_zone_text` only renders damage-style zones |
 | **Projectile flattening completeness** | spawn-model coverage (under-emission 177→111) | 111 attacks still differ in projectile count vs wiki; flattening *style* (naming/grouping) differs |
 | **Numeric overlay applied** | 3 files (Desperado range, mermonkey xp, ace cost), uniquely-keyed only | per-projectile/ability values cannot be safely overlaid (wiki↔dump name mismatch) |
 
 ### 🔴 Not started
-
-- **Zones** (`zones[]`) — **0 of 28** zone model types mapped. *(Corrected
-  2026-06-03: this doc previously said "0 of 12". The v55 dump carries **28**
-  distinct `*ZoneModel` `$type`s inline in tower behaviors — see the SHA-pinned
-  report `docs/btd6-decode-inventory-v55.md` §3a, the live ground truth. The
-  old "12" was an undercount; do not inherit it.)*
 - **Buffs** (`buffs[]`) — **0 of 38** buff/support model types mapped.
   *(Corrected from "37"; the dump has 38 distinct `*SupportModel`/`*BuffModel`
   `$type`s — report §3b. Close to the prior figure but not equal.)*

--- a/docs/btd6-gamedata-dictionary.md
+++ b/docs/btd6-gamedata-dictionary.md
@@ -47,7 +47,7 @@ knowing where, and which encoding to trust.
 | **Knowledge/** | 134 | `KnowledgeModel` | Monkey Knowledge tree (meta-upgrade mods) | ✗ |
 | **Bosses/** | 7 | `BossData` | **cosmetic only** — portraits/music/icons + `LocsKey`. Boss *stats* are in **Bloons/**, not here | ✗ |
 | **Buffs/** | 91 | `BuffIndicatorModel` | **UI icons only** — buff *effects* are inline in the tower models | ✗ |
-| **Maps/** | 89 | `MapDetails` | map metadata | ✗ |
+| **Maps/** | 89 | `MapDetails` | map metadata: `difficulty` (== folder), `hasWater`, `theme` | ✓ (`--maps` → all 89; difficulty + `has_water`) |
 | **Artifacts/**, **GeraldoItems/** | 568, 16 | `ItemArtifactData` / mods | Rogue Legends artifacts, Geraldo's shop | ✗ |
 | **Achievements/**, **TrophyStoreItems/**, **Skins/**, **BloonOverlays/**, **Mods/** | — | — | cosmetics / achievements / game-mode mods | ✗ |
 

--- a/scripts/parse_gamedata.py
+++ b/scripts/parse_gamedata.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -502,6 +503,52 @@ def _subtowers(model: dict) -> list[dict]:
     return out
 
 
+# Effect numbers we can decode directly off a ``*ZoneModel``. Only a few of the
+# 28 zone types carry one (slow %, cash multiplier, radius); the rest are
+# name/flag-only and fall back to a curated/textTable description (decode-status
+# step 5). We never fabricate a player-facing zone name — the dump's are
+# internal (``"SlowBloonsZoneModel_NonMoabs"``); curated names ("Arctic Wind")
+# stay owned by the wiki layer, so the audit aligns by name and ignores ours.
+_ZONE_NUMERIC_FIELDS: tuple[str, ...] = (
+    "speedScale",
+    "speedChange",
+    "multiplier",
+    "cashMultiplier",
+    "zoneRadius",
+    "radius",
+    "range",
+    "lifespan",
+)
+
+
+def _zones(model: dict) -> list[dict]:
+    """Start of zone decoding: each ``*ZoneModel`` in the tier's top-level
+    behaviors → a structured entry (kind + internal name + any decodable
+    effect number / bloon tag). Presence-and-number only; display names and the
+    long DESCRIPTION_ONLY tail are deferred (see ``btd6-gamedata-decode-status``).
+    """
+    out: list[dict] = []
+    for behavior in model.get("behaviors", []) or []:
+        if not isinstance(behavior, dict):
+            continue
+        short = _short_type(behavior)
+        if not short.endswith("ZoneModel"):
+            continue
+        entry: dict = {
+            "kind": short[: -len("Model")],
+            "name": _clean_name(behavior.get("name"), short),
+        }
+        for field_name in _ZONE_NUMERIC_FIELDS:
+            value = behavior.get(field_name)
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                entry[field_name] = _num(value)
+        tag = behavior.get("bloonTag")
+        if isinstance(tag, str) and tag:
+            entry["bloonTag"] = tag
+        out.append(entry)
+    return out
+
+
 def _map_tier(model: dict, _subtower: bool = False) -> dict:
     """A full tower-state model file → one cleaned tier node."""
     tier: dict = {}
@@ -528,6 +575,9 @@ def _map_tier(model: dict, _subtower: bool = False) -> dict:
         subtowers = _subtowers(model)
         if subtowers:
             tier["subtowers"] = subtowers
+    zones = _zones(model)
+    if zones:
+        tier["zones"] = zones
     tier.update(_target_types(model))
     income = _income(model)
     if income:
@@ -1444,6 +1494,105 @@ def overlay_all(dump: Path, *, dry_run: bool) -> dict[str, list[str]]:
     return report
 
 
+# ---------------------------------------------------------------------------
+# Maps — the dump's Maps/<Difficulty>/<Name>.json (MapDetails)
+# ---------------------------------------------------------------------------
+#
+# The dump organises every map under a difficulty folder and stores a small
+# MapDetails per map: ``difficulty`` (int, == folder), ``hasWater`` (naval
+# placement), ``theme``, ``isDebug``/``IsStandard`` (filter non-player maps).
+# Display names come from ``textTable`` (``"MushroomGrotto" -> "Mushroom
+# Grotto"``). The rich prose (``description`` / ``lines_of_sight_notes``) is
+# curated, so we *preserve* any existing curated text and derive a factual
+# fallback from ``hasWater`` for newly-added maps.
+
+_MAP_DIFFICULTY_DIRS = ("Beginner", "Intermediate", "Advanced", "Expert")
+
+
+def _snake(name: str) -> str:
+    """``"MushroomGrotto"`` / ``"#Ouch!"`` → ``"mushroom_grotto"`` / ``"ouch"``."""
+    spaced = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", name)
+    return re.sub(r"[^0-9a-zA-Z]+", "_", spaced).strip("_").lower()
+
+
+def _decamel(name: str) -> str:
+    """Fallback display name when ``textTable`` lacks one: split CamelCase."""
+    spaced = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", " ", name)
+    return re.sub(r"[^0-9a-zA-Z]+", " ", spaced).strip() or name
+
+
+def _map_los(has_water: bool) -> str:
+    return (
+        "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed."
+        if has_water
+        else "No water tiles — land-only tower placement."
+    )
+
+
+def _existing_maps() -> dict[str, dict]:
+    """Committed maps keyed by id — to preserve curated description / LoS / aliases."""
+    fp = _DATA_ROOT / "maps.json"
+    if not fp.exists():
+        return {}
+    try:
+        raw = json.loads(fp.read_text("utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return {
+        m["id"]: m for m in raw.get("maps", []) if isinstance(m, dict) and m.get("id")
+    }
+
+
+def map_maps(dump: Path, version: str) -> tuple[list[dict], list[str]]:
+    """Every player map across the four difficulty folders → catalog rows.
+
+    Difficulty comes from the folder (authoritative — it even corrects stale
+    curated rows, e.g. Cornfield is Advanced, not the catalog's old "Beginner").
+    """
+    tt = _text_table(dump)
+    prior = _existing_maps()
+    rows: list[dict] = []
+    warnings: list[str] = []
+    seen: set[str] = set()
+    for difficulty in _MAP_DIFFICULTY_DIRS:
+        ddir = dump / "Maps" / difficulty
+        if not ddir.is_dir():
+            warnings.append(f"missing Maps/{difficulty}")
+            continue
+        for fp in sorted(ddir.glob("*.json")):
+            try:
+                raw = json.loads(fp.read_text("utf-8"))
+            except (OSError, json.JSONDecodeError):
+                warnings.append(f"unreadable {fp.name}")
+                continue
+            if raw.get("isDebug"):
+                continue  # non-player / debug map
+            stem = fp.stem
+            mid = _snake(stem)
+            if mid in seen:
+                warnings.append(f"duplicate map id {mid!r} ({stem})")
+                continue
+            seen.add(mid)
+            has_water = bool(raw.get("hasWater"))
+            old = prior.get(mid, {})
+            rows.append(
+                {
+                    "id": mid,
+                    "canonical": tt.get(stem) or _decamel(stem),
+                    "aliases": list(old.get("aliases", [])),
+                    "difficulty": difficulty,
+                    # Curated prose wins where present; otherwise a factual derive.
+                    "description": old.get("description")
+                    or f"{difficulty} map.{' Contains water.' if has_water else ''}",
+                    "lines_of_sight_notes": old.get("lines_of_sight_notes")
+                    or _map_los(has_water),
+                    "has_water": has_water,
+                },
+            )
+    rows.sort(key=lambda m: (_MAP_DIFFICULTY_DIRS.index(m["difficulty"]), m["id"]))
+    return rows, warnings
+
+
 def _write(path: Path, payload: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
@@ -1482,6 +1631,11 @@ def main(argv: list[str] | None = None) -> int:
         "--descriptions",
         action="store_true",
         help="write game-authored textTable upgrade descriptions onto tower files",
+    )
+    ap.add_argument(
+        "--maps",
+        action="store_true",
+        help="rebuild maps.json from the dump's Maps/ folders (all difficulties)",
     )
     ap.add_argument("--dry-run", action="store_true", help="print, do not write")
     args = ap.parse_args(argv)
@@ -1522,6 +1676,24 @@ def main(argv: list[str] | None = None) -> int:
         print(f"descriptions: {verb} {len(report)} file(s), {total} description(s)\n")
         for rel in sorted(report):
             print(f"  {rel}  ({len(report[rel])} change(s))")
+        return 0
+
+    if args.maps:
+        version = _dump_version(dump)
+        rows, warnings = map_maps(dump, version)
+        payload = {
+            "data_version": "2.0",
+            "game_version": version,
+            "source": _SOURCE,
+            "maps": rows,
+        }
+        if args.dry_run:
+            print(json.dumps(payload, indent=2, ensure_ascii=False)[:1500])
+        else:
+            _write(_DATA_ROOT / "maps.json", payload)
+            print(f"wrote maps.json ({len(rows)} maps)")
+        for w in warnings:
+            print(f"  warning: {w}")
         return 0
 
     towers, heroes = build_allowlist(dump)

--- a/tests/unit/scripts/test_parse_gamedata.py
+++ b/tests/unit/scripts/test_parse_gamedata.py
@@ -243,7 +243,9 @@ def test_subtower_does_not_recurse_into_nested_spawns(mod):
 def test_subtower_name_strips_trailing_level(mod):
     assert mod._clean_subtower_name({"name": "MasquedMacaque 10"}) == "MasquedMacaque"
     assert mod._clean_subtower_name({"name": "Phoenix"}) == "Phoenix"
-    assert mod._clean_subtower_name({"displayName": "Sun God", "name": "X"}) == "Sun God"
+    assert (
+        mod._clean_subtower_name({"displayName": "Sun God", "name": "X"}) == "Sun God"
+    )
 
 
 def test_tier_placement_target_and_footprint(mod):
@@ -747,3 +749,122 @@ def test_apply_upgrade_descriptions_texttable_fallback_by_curated_name(mod):
     c2 = {"upgrades": [{"path": 3, "tier": 5, "name": "Reanimate"}]}
     assert mod.apply_upgrade_descriptions(c2, {"upgrades": []}, tt) == []
     assert "description" not in c2["upgrades"][0]
+
+
+# --- maps (synthetic Maps/<Difficulty>/<Name>.json on tmp_path) --------------
+
+
+def test_snake_and_decamel(mod):
+    assert mod._snake("MushroomGrotto") == "mushroom_grotto"
+    assert mod._snake("#Ouch!") == "ouch"
+    assert mod._snake("Logs") == "logs"
+    assert mod._decamel("CastleRevenge") == "Castle Revenge"
+    assert mod._decamel("HighFinance") == "High Finance"
+
+
+def _map_details(*, difficulty: int, has_water: bool, debug: bool = False) -> dict:
+    return {
+        "$type": "Il2Cpp….MapDetails, Assembly-CSharp",
+        "difficulty": difficulty,
+        "hasWater": has_water,
+        "theme": 0,
+        "isDebug": debug,
+        "IsStandard": True,
+    }
+
+
+def _make_maps_dump(tmp_path: Path) -> Path:
+    dump = tmp_path / "dump"
+    (dump / "Towers").mkdir(
+        parents=True
+    )  # map_maps doesn't need it, but be dump-shaped
+    _write(
+        dump / "Maps" / "Beginner" / "Logs.json",
+        _map_details(difficulty=0, has_water=True),
+    )
+    _write(
+        dump / "Maps" / "Advanced" / "MushroomGrotto.json",
+        _map_details(difficulty=2, has_water=False),
+    )
+    _write(
+        dump / "Maps" / "Expert" / "DebugMap.json",
+        _map_details(difficulty=3, has_water=False, debug=True),
+    )
+    (dump / "Maps" / "Intermediate").mkdir(parents=True)  # present but empty
+    _write(
+        dump / "textTable.json", {"MushroomGrotto": "Mushroom Grotto", "Logs": "Logs"}
+    )
+    return dump
+
+
+def test_map_maps_extracts_difficulty_water_and_names(mod, tmp_path, monkeypatch):
+    monkeypatch.setattr(mod, "_existing_maps", dict)  # isolate from committed prose
+    dump = _make_maps_dump(tmp_path)
+    rows, warnings = mod.map_maps(dump, "55.0")
+    assert warnings == []
+    by_id = {r["id"]: r for r in rows}
+    # debug map filtered out
+    assert "debug_map" not in by_id and len(rows) == 2
+    assert by_id["logs"]["difficulty"] == "Beginner"
+    assert by_id["logs"]["has_water"] is True
+    assert "naval" in by_id["logs"]["lines_of_sight_notes"].lower()
+    # difficulty comes from the folder; display name from textTable
+    assert by_id["mushroom_grotto"]["difficulty"] == "Advanced"
+    assert by_id["mushroom_grotto"]["canonical"] == "Mushroom Grotto"
+    assert by_id["mushroom_grotto"]["has_water"] is False
+    assert "no water" in by_id["mushroom_grotto"]["lines_of_sight_notes"].lower()
+
+
+def test_map_maps_preserves_curated_prose(mod, tmp_path, monkeypatch):
+    dump = _make_maps_dump(tmp_path)
+    # Pretend a curated row already exists for logs with hand-written prose.
+    monkeypatch.setattr(
+        mod,
+        "_existing_maps",
+        lambda: {
+            "logs": {
+                "id": "logs",
+                "description": "Single river-and-logs track.",
+                "lines_of_sight_notes": "Open central area.",
+                "aliases": ["log"],
+            }
+        },
+    )
+    rows, _ = mod.map_maps(dump, "55.0")
+    logs = next(r for r in rows if r["id"] == "logs")
+    assert logs["description"] == "Single river-and-logs track."  # curated kept
+    assert logs["aliases"] == ["log"]
+    assert logs["difficulty"] == "Beginner"  # but difficulty still from the dump
+
+
+# --- zones (first decode slice) ---------------------------------------------
+
+
+def test_zones_decode_slow_and_radius(mod):
+    # Mirrors Ice Monkey's Arctic Wind in the v55 dump (slow to 60% speed, r=25).
+    model = _tower_model()
+    model["behaviors"].append(
+        {
+            "$type": _t("SlowBloonsZoneModel"),
+            "name": "SlowBloonsZoneModel",
+            "speedScale": 0.6,
+            "zoneRadius": 25.0,
+            "bloonTag": "Moabs",
+        }
+    )
+    tier = mod._map_tier(model)
+    assert tier["zones"] == [
+        {
+            # name is the dump's internal label (no curated "Arctic Wind" exists)
+            "kind": "SlowBloonsZone",
+            "name": "SlowBloonsZoneModel",
+            "speedScale": 0.6,
+            "zoneRadius": 25,
+            "bloonTag": "Moabs",
+        }
+    ]
+
+
+def test_zones_absent_when_no_zone_models(mod):
+    # A plain attacker has no zones[] key at all (not an empty list).
+    assert "zones" not in mod._map_tier(_tower_model())


### PR DESCRIPTION
## Summary

Closes the two thin domains flagged in the coverage review, and makes a start on the zone decode.

### Maps — full game-data cutover (3 → **89**)
- New `parse_gamedata.py --maps` rebuilds `maps.json` from the dump's `Maps/<Difficulty>/` folders.
- **Difficulty comes from the folder** (authoritative) — this even *corrects stale curated data*: Cornfield was mis-tagged "Beginner", it's actually **Advanced**.
- Display names via `textTable` (`"MushroomGrotto"` → `"Mushroom Grotto"`).
- New **`has_water`** fact wired through `MapEntry` → `_parse_map` → `btd6_map_lookup`, so the bot can now answer *"which maps have water / allow naval towers"*.
- Curated `description` / `lines_of_sight_notes` prose is **preserved** where it existed (merge by id); factual LoS derived from `hasWater` for the new maps.

### Modes — completed the set (2 → **13**)
The dump has **no** game-mode rules — starting cash/lives/restrictions live in game code, not exported assets (verified: only `rogueData` carries `startingLives`, and `textTable` lacks cleanly-keyed mode descriptions). So `modes.json` is **curated** from established facts, with honest provenance: Standard, Primary/Military/Magic Only, Deflation, Apopalypse, Reverse, Double HP MOABs, Half Cash, ABR, Impoppable, CHIMPS, Sandbox.

### Zones — decode **started**
`_zones()` emits every top-level `*ZoneModel` as `{kind, name, + decodable numbers}` (e.g. Ice Monkey's Arctic Wind → `speedScale 0.6`, `zoneRadius 25`), wired into `_map_tier`. **Audit-safe**: internal zone names don't align with the wiki's curated ones, so the fidelity audit ignores them (stays nothing-SUSPECT). The remaining 28-type effect tail, sub-tower-nested zones, and curated display names are documented as follow-ups.

## Verification
- 89 maps + 13 modes load and resolve by alias through `btd6_data_service`.
- `--audit` still reports **nothing SUSPECT**.
- Full CI mirror green: **7233 passed, 3 skipped**, lint + mypy + architecture clean.
- 49 hermetic mapper tests (synthetic fixtures, no vendored dump), incl. new maps + zones coverage.

Docs updated: `btd6-gamedata-decode-status.md` (completion tables + session log) and `btd6-gamedata-dictionary.md` (Maps row).

https://claude.ai/code/session_01TJvgoQyKFxXrUUQ9iWsGhn

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJvgoQyKFxXrUUQ9iWsGhn)_