### PR TITLE
feat(btd6): start buff decode — 2 confirmed *SupportModel types

### DIFF
--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -9,6 +9,30 @@ works** (the traps we hit), and what is still un-decoded.
 
 ## ⭐ Next session — start here (updated 2026-06-04, end of v55 session)
 
+### Session log — buff decode started (2 confirmed types)
+
+- **Buffs — decode started, correctness-first (2 of 38).** `_buffs()` now emits a
+  `buffs[]` entry per top-level `*SupportModel`/`*BuffModel`, but **only writes a
+  number for types confirmed against the committed wiki value on a matching tier**:
+  - `RateSupportModel.multiplier` → `rateMultiplier` (Sniper Elite Defender: raw
+    `0.75` == wiki `0.75`).
+  - `PoplustSupportModel.ratePercentIncrease`/`piercePercentIncrease` →
+    `ratePercentage`/`piercePercentage` (Druid Poplust: `0.15`/`0.15`).
+  - Validated roster-wide: no tower has a raw value contradicting the committed
+    one. (Notably, `monkey_village` carries a raw `RateSupportModel 0.85` the wiki
+    omitted — game-data is richer, not wrong.)
+  - **Deferred (not yet confirmed):** `PierceSupportModel.pierce`→`pierceAdditive`
+    — the wiki's pierce buffs are `pierceMultiplier` from a *different* model, so
+    this needs same-tier confirmation before it's written. The other ~35 types
+    likewise await confirmation (or a renderer field, for the `SCHEMA_FIRST` set).
+  - Names: buff `name` is the dump's **internal** id (`buffLocsName`/`mutatorId`),
+    never a curated label — those aren't in the dump, so the audit aligns by name
+    and ignores ours (stays nothing-SUSPECT). Wired into `_map_tier`.
+- **Next buff step:** confirm one more type per pass (cross-check raw vs committed
+  on a matching tier), add to `_BUFF_FIELD_MAP`. The `SCHEMA_FIRST` types
+  (projectile speed/radius, freeze duration, banana-cash multiplier) need a new
+  field on `_BUFF_FIELDS` in `btd6_upgrade_detail_service` + its renderer first.
+
 ### Session log — maps + modes cutover + zone decode started
 
 - **Maps — full game-data cutover (3 → 89).** `parse_gamedata.py --maps` rebuilds
@@ -412,12 +436,10 @@ must not be treated as done. Verified against the v55 dump on 2026-06-03.
 | **Subtowers** (`subtowers[]`) | 3 spawn models: `AbilityCreateTower`/`CreateTower`/`MorphTower`(embedded) → Phoenix, Sentry, Spectre, totems, UAV | `MorphTowerModel` **named-ref** (Alchemist "Transformed Monkey") + `BeastHandlerPetModel` (Beast Handler) — 2 of ~4 mechanisms |
 | **Zones** (`zones[]`) — **started** | `_zones()` emits every top-level `*ZoneModel` as `{kind, name, + decodable numbers}` (e.g. Ice Arctic Wind → `speedScale 0.6`, `zoneRadius 25`); wired into `_map_tier`, audit-safe (internal names don't align with curated, so they're ignored) | the rest of the 28 types' specific effect fields; zones nested inside sub-towers; curated display names (not in the dump — stay wiki-owned); runtime `_zone_text` only renders damage-style zones |
 | **Projectile flattening completeness** | spawn-model coverage (under-emission 177→111) | 111 attacks still differ in projectile count vs wiki; flattening *style* (naming/grouping) differs |
+| **Buffs** (`buffs[]`) — **started (2 of 38)** | `_buffs()` decodes the two types **confirmed against committed wiki values on a matching tier**: `RateSupportModel.multiplier`→`rateMultiplier` (Sniper 0.75) and `PoplustSupportModel.ratePercentIncrease`/`piercePercentIncrease`→`ratePercentage`/`piercePercentage` (Druid 0.15/0.15). Wired into `_map_tier`, audit-safe (internal names) | the other 36 `*SupportModel`/`*BuffModel` types — each needs same-tier confirmation before its number is written (e.g. `PierceSupportModel.pierce`→`pierceAdditive` is **NOT** yet confirmed; the wiki's pierce buffs are `pierceMultiplier` from a different model). `SCHEMA_FIRST` types (projectile-speed/radius, freeze-duration, banana-cash) also need a new renderer field |
 | **Numeric overlay applied** | 3 files (Desperado range, mermonkey xp, ace cost), uniquely-keyed only | per-projectile/ability values cannot be safely overlaid (wiki↔dump name mismatch) |
 
 ### 🔴 Not started
-- **Buffs** (`buffs[]`) — **0 of 38** buff/support model types mapped.
-  *(Corrected from "37"; the dump has 38 distinct `*SupportModel`/`*BuffModel`
-  `$type`s — report §3b. Close to the prior figure but not equal.)*
 - **Economy-tower attack suppression** (Banana Farm shows a nominal AttackModel).
 - **The towers cutover itself** — blocked on zones + buffs + the subtower tail.
 - **Bloons / bosses game-native ingestion** (still wiki-sourced).

--- a/scripts/parse_gamedata.py
+++ b/scripts/parse_gamedata.py
@@ -23,8 +23,10 @@ is *runtime-compatible* with what ``parse_bloonswiki`` produces but **game-
 native**, not identical to it: names come from the game (``displayName`` for
 abilities, ``LocsKey`` → ``textTable`` for upgrade names/descriptions, the game
 ``id`` for projectiles), sub-projectiles are grouped the game's way, and
-``subtowers[]`` are produced; ``zones[]`` / ``buffs[]`` are not yet. The runtime
-is largely name-agnostic, so this drops in. Heroes are one file per level
+``subtowers[]`` are produced; ``zones[]`` and ``buffs[]`` decode is **in
+progress** (top-level ``*ZoneModel`` + confirmed ``*SupportModel`` types — see
+``_zones`` / ``_buffs`` and ``btd6-gamedata-decode-status.md`` step 5). The
+runtime is largely name-agnostic, so this drops in. Heroes are one file per level
 (``<Hero> N.json``); paragons are a single flat ``<Name>-Paragon.json`` node.
 
 Provenance: every emitted file is stamped ``source: "BTD Mod Helper game data
@@ -549,6 +551,58 @@ def _zones(model: dict) -> list[dict]:
     return out
 
 
+# Buff/support decode — start. A buff model's raw effect field → the committed
+# buff-schema field the runtime renders (``btd6_upgrade_detail_service._BUFF_FIELDS``).
+# ONLY mappings whose semantics are **confirmed against the committed wiki value
+# on a matching tier** belong here (correctness over coverage):
+#   * RateSupportModel.multiplier  → rateMultiplier   (Sniper 0-5-x: raw 0.75 == wiki 0.75)
+#   * PoplustSupportModel.ratePercentIncrease/piercePercentIncrease
+#                                  → ratePercentage / piercePercentage (Druid 0-0-5: 0.15/0.15)
+# The other ~36 *SupportModel/*BuffModel types are deferred until each is
+# likewise confirmed (e.g. PierceSupportModel.pierce was NOT confirmable — the
+# wiki's pierce buffs are multipliers from a different model). See
+# ``btd6-gamedata-decode-status.md`` step 5 for the worklist + decode classes.
+_BUFF_FIELD_MAP: dict[str, dict[str, str]] = {
+    "RateSupportModel": {"multiplier": "rateMultiplier"},
+    "PoplustSupportModel": {
+        "ratePercentIncrease": "ratePercentage",
+        "piercePercentIncrease": "piercePercentage",
+    },
+}
+
+
+def _buffs(model: dict) -> list[dict]:
+    """Start of buff decoding: each confirmed ``*SupportModel``/``*BuffModel`` in
+    the tier's top-level behaviors → a structured entry with its decoded effect
+    field(s). ``name`` is the dump's **internal** identifier (``buffLocsName`` /
+    ``mutatorId``), never a player-facing label — curated names ("Poplust buff")
+    are not in the dump and stay wiki-owned, so the fidelity audit aligns by name
+    and ignores ours. Only confirmed types emit a number (see ``_BUFF_FIELD_MAP``).
+    """
+    out: list[dict] = []
+    for behavior in model.get("behaviors", []) or []:
+        if not isinstance(behavior, dict):
+            continue
+        short = _short_type(behavior)
+        field_map = _BUFF_FIELD_MAP.get(short)
+        if field_map is None:
+            continue  # type not yet confirmed — deferred, never guess a number
+        entry: dict = {
+            "kind": short[: -len("Model")],
+            "name": behavior.get("buffLocsName")
+            or behavior.get("mutatorId")
+            or short[: -len("Model")],
+        }
+        for raw_field, schema_field in field_map.items():
+            value = behavior.get(raw_field)
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                entry[schema_field] = _num(value)
+        if "isGlobal" in behavior:
+            entry["isGlobal"] = bool(behavior["isGlobal"])
+        out.append(entry)
+    return out
+
+
 def _map_tier(model: dict, _subtower: bool = False) -> dict:
     """A full tower-state model file → one cleaned tier node."""
     tier: dict = {}
@@ -578,6 +632,9 @@ def _map_tier(model: dict, _subtower: bool = False) -> dict:
     zones = _zones(model)
     if zones:
         tier["zones"] = zones
+    buffs = _buffs(model)
+    if buffs:
+        tier["buffs"] = buffs
     tier.update(_target_types(model))
     income = _income(model)
     if income:

--- a/tests/unit/scripts/test_parse_gamedata.py
+++ b/tests/unit/scripts/test_parse_gamedata.py
@@ -868,3 +868,60 @@ def test_zones_decode_slow_and_radius(mod):
 def test_zones_absent_when_no_zone_models(mod):
     # A plain attacker has no zones[] key at all (not an empty list).
     assert "zones" not in mod._map_tier(_tower_model())
+
+
+# --- buffs (first decode slice — confirmed types only) ----------------------
+
+
+def test_buffs_rate_support_maps_to_rate_multiplier(mod):
+    # Mirrors Sniper 0-5-x Elite Defender: raw multiplier 0.75 == wiki rateMultiplier.
+    model = _tower_model()
+    model["behaviors"].append(
+        {
+            "$type": _t("RateSupportModel"),
+            "name": "RateSupportModel_Support_",
+            "buffLocsName": "EliteSniperBuff",
+            "multiplier": 0.75,
+            "isGlobal": True,
+        }
+    )
+    tier = mod._map_tier(model)
+    assert tier["buffs"] == [
+        {
+            "kind": "RateSupport",
+            "name": "EliteSniperBuff",  # internal id, never a curated label
+            "rateMultiplier": 0.75,
+            "isGlobal": True,
+        }
+    ]
+
+
+def test_buffs_poplust_maps_percent_increase_fields(mod):
+    model = _tower_model()
+    model["behaviors"].append(
+        {
+            "$type": _t("PoplustSupportModel"),
+            "name": "",
+            "buffLocsName": "PoplustBuff",
+            "ratePercentIncrease": 0.15,
+            "piercePercentIncrease": 0.15,
+        }
+    )
+    buffs = mod._map_tier(model)["buffs"]
+    assert buffs == [
+        {
+            "kind": "PoplustSupport",
+            "name": "PoplustBuff",
+            "ratePercentage": 0.15,
+            "piercePercentage": 0.15,
+        }
+    ]
+
+
+def test_unconfirmed_buff_types_emit_nothing(mod):
+    # PierceSupportModel is deferred (not yet confirmed vs wiki) → no guess.
+    model = _tower_model()
+    model["behaviors"].append(
+        {"$type": _t("PierceSupportModel"), "pierce": 3.0, "buffLocsName": "X"}
+    )
+    assert "buffs" not in mod._map_tier(model)


### PR DESCRIPTION
## Summary

First slice of the **buff decode** (the `buffs[]` half of the step-5 effect tail). Deliberately small and **correctness-first** — speed isn't the goal here.

`_buffs()` emits a `buffs[]` entry per top-level `*SupportModel`/`*BuffModel`, but **only writes a decoded number for types confirmed against the committed wiki value on a matching tier**:

| Buff type | Mapping | Confirmation |
|---|---|---|
| `RateSupportModel` | `multiplier` → `rateMultiplier` | Sniper Elite Defender: raw `0.75` == wiki `0.75` |
| `PoplustSupportModel` | `ratePercentIncrease`/`piercePercentIncrease` → `ratePercentage`/`piercePercentage` | Druid Poplust: `0.15`/`0.15` |

I ran a **roster-wide cross-check** (raw vs committed) before writing either mapping — no tower has a raw value contradicting the committed one. (Aside: `monkey_village` carries a raw `RateSupportModel 0.85` the wiki *omitted* — game-data is richer, not wrong.)

## What I deliberately did NOT do (correctness over coverage)

- `PierceSupportModel.pierce → pierceAdditive` looked obvious but is **not confirmable**: the wiki's pierce buffs are `pierceMultiplier` from a *different* model, so I left it deferred rather than guess.
- The other ~35 buff/support types await the same per-type confirmation; the `SCHEMA_FIRST` set (projectile speed/radius, freeze duration, banana-cash) also needs a new renderer field first.

## Safety

- Buff `name` is the dump's **internal** id (`buffLocsName`/`mutatorId`), never a curated label — so the fidelity `--audit` aligns by name and ignores ours. **`--audit` stays nothing-SUSPECT.**
- No data cutover; this builds the mapper-side decode (verified by tests).

## Tests / docs

- 3 new hermetic tests (both confirmed mappings + a deferred-type no-op); 52 mapper tests pass. Full CI mirror green; architecture clean.
- `btd6-gamedata-decode-status.md` updated: **buffs 🔴→🟡 (2 of 38)**, with a session log recording what was done and the per-type confirmation worklist that remains.

## Remaining after this PR
Zones: the 28-type effect tail + sub-tower-nested zones. Buffs: the other 36 types (one confirmed mapping per pass) + `SCHEMA_FIRST` renderer fields. Then economy-attack suppression → the full tower cutover.

https://claude.ai/code/session_01TJvgoQyKFxXrUUQ9iWsGhn

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJvgoQyKFxXrUUQ9iWsGhn)_