### PR TITLE
feat(btd6): Maps hub button + correct difficulty/mode/modifier taxonomy

### DIFF
--- a/disbot/cogs/btd6/_embeds.py
+++ b/disbot/cogs/btd6/_embeds.py
@@ -215,18 +215,75 @@ def build_towers_embed() -> discord.Embed:
     return append_context_footer(embed, "btd6_tower:catalog")
 
 
-def build_modes_embed() -> discord.Embed:
+_MAP_DIFFICULTY_ORDER = ("Beginner", "Intermediate", "Advanced", "Expert")
+
+
+def build_maps_embed() -> discord.Embed:
+    """Map catalogue grouped by difficulty (all 89 from game data).
+
+    A water drop marks maps with water tiles (naval-tower placement) — the
+    ``has_water`` fact added in the maps cutover. One field per difficulty keeps
+    the full roster inside Discord's field limits.
+    """
     embed = discord.Embed(
-        title="🐵 BTD6 — Modes",
+        title="🗺️ BTD6 — Maps",
         color=discord.Color.green(),
     )
-    for mode in btd6_knowledge_service.list_modes():
+    maps = btd6_knowledge_service.list_maps()
+    by_difficulty: dict[str, list[str]] = {d: [] for d in _MAP_DIFFICULTY_ORDER}
+    for game_map in maps:
+        label = f"{game_map.canonical} 💧" if game_map.has_water else game_map.canonical
+        by_difficulty.setdefault(game_map.difficulty, []).append(label)
+    for difficulty in _MAP_DIFFICULTY_ORDER:
+        names = by_difficulty.get(difficulty) or []
+        if names:
+            embed.add_field(
+                name=f"{difficulty} ({len(names)})",
+                value=", ".join(names),
+                inline=False,
+            )
+    embed.set_footer(text="💧 = has water (naval towers placeable)")
+    from utils.btd6.context_footer import append_context_footer
+
+    return append_context_footer(embed, "btd6_diagnostics:maps_catalog")
+
+
+def build_modes_embed() -> discord.Embed:
+    """Difficulties, modes, and modifiers — grouped, mirroring the in-game
+    difficulty/mode select screens (difficulty sets lives/speed/prices; Standard
+    is the base mode in every difficulty; modifiers are opt-in cash/round changes).
+    """
+    embed = discord.Embed(
+        title="🐵 BTD6 — Difficulties & Modes",
+        color=discord.Color.green(),
+    )
+    modes = btd6_knowledge_service.list_modes()
+    difficulties = [m for m in modes if m.kind == "difficulty"]
+    play_modes = [m for m in modes if m.kind == "mode"]
+    modifiers = [m for m in modes if m.kind == "modifier"]
+
+    if difficulties:
+        embed.description = (
+            "**Difficulties** (set lives, bloon speed, prices)\n"
+            + "\n".join(
+                f"• **{d.canonical}** — {d.starting_lives} lives. {d.description}"
+                for d in difficulties
+            )
+        )
+    for mode in play_modes:
+        tag = (
+            f"  [{' / '.join(d.title() for d in mode.difficulties)}]"
+            if mode.difficulties
+            else ""
+        )
+        value = mode.description
+        if mode.restrictions:
+            value += "\n• " + "\n• ".join(mode.restrictions)
+        embed.add_field(name=f"{mode.canonical}{tag}", value=value[:1024], inline=False)
+    for mod in modifiers:
         embed.add_field(
-            name=mode.canonical,
-            value=(
-                f"Starting cash: {mode.starting_cash} • "
-                f"Lives: {mode.starting_lives}"
-            ),
+            name=f"⚙️ {mod.canonical} (modifier)",
+            value=mod.description[:1024],
             inline=False,
         )
     from utils.btd6.context_footer import append_context_footer
@@ -291,6 +348,7 @@ def build_test_intent_embed(text: str) -> discord.Embed:
 __all__ = [
     "build_diagnostics_embed",
     "build_heroes_embed",
+    "build_maps_embed",
     "build_modes_embed",
     "build_status_embed",
     "build_test_intent_embed",

--- a/disbot/data/btd6/modes.json
+++ b/disbot/data/btd6/modes.json
@@ -1,33 +1,72 @@
 {
-  "data_version": "2.0",
+  "data_version": "3.0",
   "game_version": "55.0",
-  "source": "Curated (game modes are gameplay rules, not exported in the Mod Helper dump)",
+  "source": "Curated from the in-game difficulty/mode select screens (rules are gameplay code, not exported in the Mod Helper dump)",
   "modes": [
+    {
+      "id": "easy",
+      "canonical": "Easy",
+      "kind": "difficulty",
+      "aliases": ["beginner_difficulty"],
+      "starting_cash": 650,
+      "starting_lives": 200,
+      "description": "Monkeys cost less, Bloons move a little slower, 200 lives. Beating round 40 awards a bronze medal.",
+      "difficulties": [],
+      "restrictions": []
+    },
+    {
+      "id": "medium",
+      "canonical": "Medium",
+      "kind": "difficulty",
+      "aliases": ["normal"],
+      "starting_cash": 650,
+      "starting_lives": 150,
+      "description": "Monkeys cost normal, Bloons move normal, 150 lives. Beating round 60 awards a silver medal.",
+      "difficulties": [],
+      "restrictions": []
+    },
+    {
+      "id": "hard",
+      "canonical": "Hard",
+      "kind": "difficulty",
+      "aliases": [],
+      "starting_cash": 650,
+      "starting_lives": 100,
+      "description": "Monkeys cost more, you start at round 3, Bloons move a little faster, 100 lives. Beating round 80 awards a gold medal.",
+      "difficulties": [],
+      "restrictions": []
+    },
     {
       "id": "standard",
       "canonical": "Standard",
-      "aliases": ["easy_standard", "medium_standard", "hard_standard", "normal"],
+      "kind": "mode",
+      "aliases": ["std"],
       "starting_cash": 650,
       "starting_lives": 150,
-      "description": "Default progression with all towers available. Round ranges by difficulty: Easy 1-40, Medium 1-60, Hard 1-80. Starting lives 200 (Easy) / 150 (Medium) / 100 (Hard).",
+      "description": "The base mode, available in every difficulty — all towers, no special rules. Lives/prices follow the chosen difficulty (Easy 200 / Medium 150 / Hard 100).",
+      "difficulties": ["easy", "medium", "hard"],
       "restrictions": []
     },
     {
       "id": "primary_only",
       "canonical": "Primary Only",
+      "kind": "mode",
       "aliases": ["primary", "primary monkeys only"],
       "starting_cash": 650,
       "starting_lives": 200,
       "description": "Easy-difficulty mode: only Primary-class towers may be placed.",
+      "difficulties": ["easy"],
       "restrictions": ["Only Primary-class towers (heroes still allowed)"]
     },
     {
       "id": "deflation",
       "canonical": "Deflation",
+      "kind": "mode",
       "aliases": ["deflate"],
       "starting_cash": 20000,
       "starting_lives": 200,
       "description": "Easy-difficulty mode starting at round 31 with a fixed lump of cash and no income — win with what you can afford up front.",
+      "difficulties": ["easy"],
       "restrictions": [
         "Starts at round 31",
         "No income — popping bloons earns no cash",
@@ -37,73 +76,89 @@
     {
       "id": "military_only",
       "canonical": "Military Only",
+      "kind": "mode",
       "aliases": ["military"],
       "starting_cash": 650,
       "starting_lives": 150,
       "description": "Medium-difficulty mode: only Military-class towers may be placed.",
+      "difficulties": ["medium"],
       "restrictions": ["Only Military-class towers (heroes still allowed)"]
     },
     {
       "id": "apopalypse",
       "canonical": "Apopalypse",
+      "kind": "mode",
       "aliases": ["apop", "apocalypse"],
       "starting_cash": 650,
       "starting_lives": 150,
       "description": "Medium-difficulty mode: bloons stream in continuously with no round breaks and rounds cannot be started manually.",
+      "difficulties": ["medium"],
       "restrictions": ["Continuous bloon stream — no round breaks", "Cannot manually start rounds"]
     },
     {
       "id": "reverse",
       "canonical": "Reverse",
+      "kind": "mode",
       "aliases": ["reversed", "backwards"],
       "starting_cash": 650,
       "starting_lives": 150,
       "description": "Medium-difficulty mode: bloons enter from the normal exit and travel the track in reverse.",
+      "difficulties": ["medium"],
       "restrictions": ["Bloons travel the track in reverse (enter from the exit)"]
     },
     {
       "id": "magic_monkeys_only",
       "canonical": "Magic Monkeys Only",
+      "kind": "mode",
       "aliases": ["magic", "magic only", "magic monkeys"],
       "starting_cash": 650,
       "starting_lives": 100,
       "description": "Hard-difficulty mode: only Magic-class towers may be placed.",
+      "difficulties": ["hard"],
       "restrictions": ["Only Magic-class towers (heroes still allowed)"]
     },
     {
       "id": "double_hp_moabs",
       "canonical": "Double HP MOABs",
+      "kind": "mode",
       "aliases": ["double moabs", "double hp", "dhm"],
       "starting_cash": 650,
       "starting_lives": 100,
       "description": "Hard-difficulty mode: all MOAB-class bloons (MOAB, BFB, ZOMG, DDT, BAD) have double health.",
+      "difficulties": ["hard"],
       "restrictions": ["All MOAB-class bloons have double health"]
     },
     {
       "id": "half_cash",
       "canonical": "Half Cash",
+      "kind": "mode",
       "aliases": ["half", "halfcash"],
       "starting_cash": 650,
       "starting_lives": 100,
       "description": "Hard-difficulty mode: all cash earned (from pops and income) is halved.",
+      "difficulties": ["hard"],
       "restrictions": ["All cash earned is halved"]
     },
     {
       "id": "alternate_bloons_rounds",
       "canonical": "Alternate Bloons Rounds",
+      "kind": "mode",
       "aliases": ["abr", "alternate", "alternate bloons"],
       "starting_cash": 650,
       "starting_lives": 100,
       "description": "Hard-difficulty mode: rounds use an alternate, generally tougher bloon composition than the default round set.",
+      "difficulties": ["hard"],
       "restrictions": ["Uses the alternate (harder) round set"]
     },
     {
       "id": "impoppable",
       "canonical": "Impoppable",
+      "kind": "mode",
       "aliases": ["impop"],
       "starting_cash": 650,
       "starting_lives": 1,
       "description": "Hard-difficulty endgame mode: rounds 6-100, 1 life, full bloon speed, higher tower prices, no continues and no Monkey Knowledge.",
+      "difficulties": ["hard"],
       "restrictions": [
         "1 life",
         "Rounds 6-100",
@@ -116,10 +171,12 @@
     {
       "id": "chimps",
       "canonical": "CHIMPS",
+      "kind": "mode",
       "aliases": ["chimp", "chimp mode"],
       "starting_cash": 650,
       "starting_lives": 1,
-      "description": "Hard-mode endgame challenge. The acronym: no Continues, Hearts lost (1 life), Income, Monkey knowledge, Powers, or Selling.",
+      "description": "Hard-difficulty challenge. The acronym: no Continues, Hearts lost (1 life), Income, Monkey knowledge, Powers, or Selling.",
+      "difficulties": ["hard"],
       "restrictions": [
         "No continues",
         "1 life (any leak loses the run)",
@@ -132,11 +189,39 @@
     {
       "id": "sandbox",
       "canonical": "Sandbox",
+      "kind": "mode",
       "aliases": ["practice", "freeplay sandbox"],
       "starting_cash": 9999999,
       "starting_lives": 9999999,
-      "description": "Practice mode with unlimited cash and lives for testing tower placements and interactions.",
+      "description": "Practice mode (available in every difficulty) with unlimited cash and lives for testing tower placements and interactions.",
+      "difficulties": ["easy", "medium", "hard"],
       "restrictions": ["Unlimited cash and lives (practice only — no rewards)"]
+    },
+    {
+      "id": "double_cash",
+      "canonical": "Double Cash Mode",
+      "kind": "modifier",
+      "aliases": ["double cash", "x2 cash", "2x cash"],
+      "description": "Modifier: get double in-game cash forever (can be de-activated). All cash earned — including the difficulty's starting cash — is ×2 (so Medium's 650 start becomes 1300). Single-player only.",
+      "difficulties": [],
+      "restrictions": [
+        "All in-game cash earned is doubled (×2)",
+        "Starting cash is doubled (e.g. Medium 650 → 1300)",
+        "Single player only; can be toggled off"
+      ]
+    },
+    {
+      "id": "fast_track",
+      "canonical": "Fast Track",
+      "kind": "modifier",
+      "aliases": ["fast track mode", "fast track pack", "fasttrack"],
+      "description": "Modifier: start roughly 1/4 of the way into the round count on any map, with the cash you would normally have accumulated by that round. Not available in competitive events or CHIMPS.",
+      "difficulties": [],
+      "restrictions": [
+        "Starts ~1/4 into the round count (relative to the map's round count, not a fixed round)",
+        "Begins with the cash you'd normally have by that round (no fixed amount)",
+        "Not available in competitive events or CHIMPS"
+      ]
     }
   ]
 }

--- a/disbot/services/ai_tools.py
+++ b/disbot/services/ai_tools.py
@@ -871,13 +871,18 @@ _BTD6_MODE_LOOKUP_SPEC = AIToolSpec(
 
 
 def _mode_dict(entry: Any) -> dict[str, Any]:
-    return {
+    out: dict[str, Any] = {
         "name": entry.canonical,
+        "kind": getattr(entry, "kind", "mode"),
         "starting_cash": entry.starting_cash,
         "starting_lives": entry.starting_lives,
         "description": entry.description,
         "restrictions": list(entry.restrictions),
     }
+    difficulties = getattr(entry, "difficulties", ())
+    if difficulties:
+        out["difficulties"] = list(difficulties)
+    return out
 
 
 async def _btd6_mode_lookup(arguments: dict[str, Any]) -> dict[str, Any]:

--- a/disbot/services/btd6_data_service.py
+++ b/disbot/services/btd6_data_service.py
@@ -98,10 +98,19 @@ class ModeEntry:
     id: str
     canonical: str
     aliases: tuple[str, ...]
-    starting_cash: int
-    starting_lives: int
     description: str
     restrictions: tuple[str, ...]
+    # None for modifiers (relative effect, no fixed value); set for
+    # difficulties and modes.
+    starting_cash: int | None = None
+    starting_lives: int | None = None
+    # BTD6 separates *difficulty* (Easy/Medium/Hard — sets lives/speed/prices),
+    # *mode* (Standard + the rule variants), and *modifier* (Double Cash, Fast
+    # Track — opt-in cash/round changes). ``kind`` tags which this row is.
+    kind: str = "mode"
+    # For a mode: which difficulties it is offered in (Standard/Sandbox span all,
+    # the specials are single-difficulty). Empty for difficulties/modifiers.
+    difficulties: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -221,12 +230,13 @@ _REQUIRED_MAP_FIELDS = (
     "description",
     "lines_of_sight_notes",
 )
+# starting_cash / starting_lives are optional: modifiers (Double Cash, Fast
+# Track) have no fixed value — their effect is relative (×2 cash, start ¼ into
+# the rounds), so those rows omit them.
 _REQUIRED_MODE_FIELDS = (
     "id",
     "canonical",
     "aliases",
-    "starting_cash",
-    "starting_lives",
     "description",
     "restrictions",
 )
@@ -415,10 +425,18 @@ def _parse_mode(raw: dict[str, Any]) -> ModeEntry:
         id=str(raw["id"]),
         canonical=str(raw["canonical"]),
         aliases=tuple(_normalise_alias(a) for a in raw["aliases"]),
-        starting_cash=int(raw["starting_cash"]),
-        starting_lives=int(raw["starting_lives"]),
         description=str(raw["description"]),
         restrictions=tuple(str(r) for r in raw["restrictions"]),
+        kind=str(raw.get("kind", "mode")),
+        difficulties=tuple(str(d) for d in raw.get("difficulties", [])),
+        starting_cash=(
+            int(raw["starting_cash"]) if raw.get("starting_cash") is not None else None
+        ),
+        starting_lives=(
+            int(raw["starting_lives"])
+            if raw.get("starting_lives") is not None
+            else None
+        ),
     )
 
 

--- a/disbot/services/btd6_response_builder.py
+++ b/disbot/services/btd6_response_builder.py
@@ -223,13 +223,17 @@ def for_map(game_map: MapEntry) -> BTD6Response:
 
 
 def for_mode(mode: ModeEntry) -> BTD6Response:
+    # Modifiers (Double Cash, Fast Track) have no fixed cash/lives — their effect
+    # is relative — so only state those numbers when the row carries them.
+    bits: list[str] = []
+    if mode.starting_cash is not None:
+        bits.append(f"Starting cash: {mode.starting_cash}.")
+    if mode.starting_lives is not None:
+        bits.append(f"Starting lives: {mode.starting_lives}.")
     return BTD6Response(
         title=f"{mode.canonical} mode",
         short_answer=mode.description,
-        why_it_matters=(
-            f"Starting cash: {mode.starting_cash}. "
-            f"Starting lives: {mode.starting_lives}."
-        ),
+        why_it_matters=" ".join(bits),
         recommended_options=mode.restrictions,
         confidence="high",
         sources=(_source_label(),),

--- a/disbot/views/btd6/panel.py
+++ b/disbot/views/btd6/panel.py
@@ -6,7 +6,7 @@ decorator side-effect on :class:`BTD6PanelView`; the persistent
 view registry then resolves the ``btd6`` subsystem when
 ``on_ready`` restores anchors.
 
-User actions: Ask / Towers / Heroes / Modes / Status. Staff actions
+User actions: Ask / Towers / Heroes / Maps / Modes / Status. Staff actions
 sit behind the **🛠️ Admin** button — opens an ephemeral
 :class:`views.btd6.admin_panel.BTD6AdminView` with manual fetch
 controls and diagnostics. Natural-language replies are owned by the
@@ -376,5 +376,28 @@ class BTD6PanelView(PersistentView):
             interaction,
             embed=embed,
             view=view,
+            ephemeral=True,
+        )
+
+    # Row 2 — info catalogs that don't fit rows 0/1 (both full at 5).
+    @discord.ui.button(
+        label="🗺️ Maps",
+        style=discord.ButtonStyle.secondary,
+        row=2,
+        custom_id="btd6:maps",
+    )
+    async def maps_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        # All 89 maps grouped by difficulty (with the has_water marker).
+        from cogs.btd6._embeds import build_maps_embed
+
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        await safe_followup(
+            interaction,
+            embed=build_maps_embed(),
             ephemeral=True,
         )

--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -9,6 +9,29 @@ works** (the traps we hit), and what is still un-decoded.
 
 ## ⭐ Next session — start here (updated 2026-06-04, end of v55 session)
 
+### Session log — Maps hub button + correct difficulty/mode/modifier taxonomy
+
+- **Maps button added** to the BTD6 hub (`views/btd6/panel.py`, row 2) →
+  `build_maps_embed()` lists all 89 maps grouped by difficulty with a 💧 water
+  marker (surfacing the `has_water` fact from the maps cutover).
+- **Modes corrected to the real BTD6 taxonomy** (from the in-game select
+  screens, screenshots verified). `ModeEntry` gained `kind`
+  (`difficulty`/`mode`/`modifier`) + `difficulties`:
+  - **Difficulties** (set lives/speed/prices): Easy 200 / Medium 150 / Hard 100
+    (Hard starts round 3); medal per round cap.
+  - **Modes**: Standard is the **base mode in every difficulty** (was wrongly
+    collapsed into "standard"); the specials are difficulty-scoped (Primary
+    Only/Deflation→Easy, Military/Apopalypse/Reverse→Medium, Magic/Double HP/
+    Half Cash/ABR/Impoppable/CHIMPS→Hard); Sandbox spans all.
+  - **Modifiers** (NEW finding — *are* extractable, as descriptions): Double
+    Cash and Fast Track. The dump's `textTable` carries their game-authored text
+    (`btd6_doublecashmode`/`btd6_fasttrackpack`), but their effect is **relative**
+    (Double Cash = ×2 cash forever; Fast Track = start ~¼ into the round count
+    with the cash you'd have there) — there is **no fixed starting-cash/round
+    constant** to extract, so `starting_cash`/`starting_lives` are now optional
+    (`None` for modifiers). Encoded honestly with the relative rule in
+    `restrictions`.
+
 ### Session log — buff decode started (2 confirmed types)
 
 - **Buffs — decode started, correctness-first (2 of 38).** `_buffs()` now emits a

--- a/tests/unit/cogs/test_btd6_embed_snapshots.py
+++ b/tests/unit/cogs/test_btd6_embed_snapshots.py
@@ -239,4 +239,4 @@ def test_modes_embed_title() -> None:
     from cogs.btd6._embeds import build_modes_embed
 
     embed = build_modes_embed()
-    assert embed.title == "🐵 BTD6 — Modes"
+    assert embed.title == "🐵 BTD6 — Difficulties & Modes"

--- a/tests/unit/views/btd6/test_btd6_panel_legacy_custom_ids.py
+++ b/tests/unit/views/btd6/test_btd6_panel_legacy_custom_ids.py
@@ -34,6 +34,7 @@ _NEW_CUSTOM_IDS = frozenset(
         "btd6:leaderboards",
         "btd6:paragon",
         "btd6:ct",
+        "btd6:maps",
     },
 )
 


### PR DESCRIPTION
## Summary

Addresses the live-testing feedback: **the missing Maps button** and the **modes taxonomy** (Easy/Hard missing; Standard is the base mode, not a difficulty).

### Maps button (the "bruh where is the maps button" fix)
- New **🗺️ Maps** button in the hub panel (row 2) → `build_maps_embed()` listing **all 89 maps grouped by difficulty**, with a **💧 marker** for water maps (surfacing the `has_water` fact). `has_water` is also wired through `MapEntry` → `btd6_map_lookup`.

### Modes — corrected to the real BTD6 structure (verified against the in-game select screens)
`ModeEntry` gains `kind` (`difficulty`/`mode`/`modifier`) and `difficulties`:
- **Difficulties** (set lives/speed/prices): Easy 200 / Medium 150 / Hard 100 (Hard starts round 3), medal per round cap. *(I had wrongly collapsed these.)*
- **Modes**: **Standard restored as the base mode present in every difficulty**; specials are difficulty-scoped (Primary Only/Deflation→Easy; Military/Apopalypse/Reverse→Medium; Magic/Double HP/Half Cash/ABR/Impoppable/CHIMPS→Hard); Sandbox spans all.
- **Modifiers** (Double Cash, Fast Track): answering *"are these extractable?"* — **yes, as game-authored `textTable` descriptions** (`btd6_doublecashmode`/`btd6_fasttrackpack`), but their effect is **relative** (Double Cash = ×2 cash forever; Fast Track = start ~¼ into the round count with the cash you'd have there). There is **no fixed starting-cash/round constant** in the data, so I made `starting_cash`/`starting_lives` optional (`None` for modifiers) and captured the relative rule in `restrictions` rather than invent numbers.

`build_modes_embed` regrouped: difficulties in the description, modes as fields tagged by difficulty, modifiers under ⚙️.

## Notes
- The earlier "only 2 modes showing" was just deployment lag — `list_modes()` returns the full set locally (now 18: 3 difficulties + 13 modes + 2 modifiers).
- Persistent-view note: the Maps button appears on **newly rendered** hub panels; existing posted anchors pick it up when re-posted.

## Tests
Full CI mirror green: **7236 passed, 3 skipped**, mypy + lint + architecture clean. Updated the modes-embed snapshot title and the panel custom_id allowlist (`btd6:maps`).

https://claude.ai/code/session_01TJvgoQyKFxXrUUQ9iWsGhn

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJvgoQyKFxXrUUQ9iWsGhn)_