### PR TITLE
feat(btd6): buff decode — 3 more confirmed types (5 of 38)

### DIFF
--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -34,6 +34,15 @@ works** (the traps we hit), and what is still un-decoded.
 
 ### Session log — buff decode started (2 confirmed types)
 
+- **Buffs — decode progressing, correctness-first (5 of 38).** Added three more
+  confirmed types this pass: `SubCommanderSupportModel` (pierce/damage add +
+  damage mult, Sub 0-0-5 = 4/0/2), `PiercePercentageSupportModel.percentIncrease`
+  → `pierceMultiplier` (Mermonkey 1.1/1.2/1.4), and `TradeEmpireBuffModel`
+  (cash-per-round + flat damage additives, Buccaneer 0-0-5). A roster-wide
+  value-discovery harness surfaced candidates; each was hand-vetted on its tower
+  (it does produce false positives from value coincidence — e.g.
+  `distanceMultiplier`→`lifespanMultiplier` — so the harness is a lead, not a
+  source of truth). Original 2-type slice below.
 - **Buffs — decode started, correctness-first (2 of 38).** `_buffs()` now emits a
   `buffs[]` entry per top-level `*SupportModel`/`*BuffModel`, but **only writes a
   number for types confirmed against the committed wiki value on a matching tier**:
@@ -459,7 +468,7 @@ must not be treated as done. Verified against the v55 dump on 2026-06-03.
 | **Subtowers** (`subtowers[]`) | 3 spawn models: `AbilityCreateTower`/`CreateTower`/`MorphTower`(embedded) → Phoenix, Sentry, Spectre, totems, UAV | `MorphTowerModel` **named-ref** (Alchemist "Transformed Monkey") + `BeastHandlerPetModel` (Beast Handler) — 2 of ~4 mechanisms |
 | **Zones** (`zones[]`) — **started** | `_zones()` emits every top-level `*ZoneModel` as `{kind, name, + decodable numbers}` (e.g. Ice Arctic Wind → `speedScale 0.6`, `zoneRadius 25`); wired into `_map_tier`, audit-safe (internal names don't align with curated, so they're ignored) | the rest of the 28 types' specific effect fields; zones nested inside sub-towers; curated display names (not in the dump — stay wiki-owned); runtime `_zone_text` only renders damage-style zones |
 | **Projectile flattening completeness** | spawn-model coverage (under-emission 177→111) | 111 attacks still differ in projectile count vs wiki; flattening *style* (naming/grouping) differs |
-| **Buffs** (`buffs[]`) — **started (2 of 38)** | `_buffs()` decodes the two types **confirmed against committed wiki values on a matching tier**: `RateSupportModel.multiplier`→`rateMultiplier` (Sniper 0.75) and `PoplustSupportModel.ratePercentIncrease`/`piercePercentIncrease`→`ratePercentage`/`piercePercentage` (Druid 0.15/0.15). Wired into `_map_tier`, audit-safe (internal names) | the other 36 `*SupportModel`/`*BuffModel` types — each needs same-tier confirmation before its number is written (e.g. `PierceSupportModel.pierce`→`pierceAdditive` is **NOT** yet confirmed; the wiki's pierce buffs are `pierceMultiplier` from a different model). `SCHEMA_FIRST` types (projectile-speed/radius, freeze-duration, banana-cash) also need a new renderer field |
+| **Buffs** (`buffs[]`) — **started (5 of 38)** | `_buffs()` decodes the five types **confirmed exact against committed wiki values on a matching tier**: `RateSupportModel`→`rateMultiplier` (Sniper 0.75); `PoplustSupportModel`→`ratePercentage`/`piercePercentage` (Druid 0.15); `SubCommanderSupportModel`→`pierceAdditive`/`damageAdditive`/`damageMultiplier` (Sub 4/0/2); `PiercePercentageSupportModel.percentIncrease`→`pierceMultiplier` (Mermonkey 1.1/1.2/1.4); `TradeEmpireBuffModel`→cash-per-round + `damageAdditive[ForCeramic/ForMoabs]` (Bucc). Wired into `_map_tier`, audit-safe (internal names) | the other 33 `*SupportModel`/`*BuffModel` types — each needs same-tier confirmation before its number is written (e.g. `PierceSupportModel.pierce`→`pierceAdditive` is **NOT** confirmed; the wiki's pierce buffs are multipliers from a different model). `SCHEMA_FIRST` types (projectile-speed/radius, freeze-duration, banana-cash) also need a new renderer field. **A roster-wide value-discovery harness exists** but flags false positives from value coincidence (e.g. `distanceMultiplier`→`lifespanMultiplier`), so each candidate is still hand-vetted |
 | **Numeric overlay applied** | 3 files (Desperado range, mermonkey xp, ace cost), uniquely-keyed only | per-projectile/ability values cannot be safely overlaid (wiki↔dump name mismatch) |
 
 ### 🔴 Not started

--- a/scripts/parse_gamedata.py
+++ b/scripts/parse_gamedata.py
@@ -551,22 +551,42 @@ def _zones(model: dict) -> list[dict]:
     return out
 
 
-# Buff/support decode — start. A buff model's raw effect field → the committed
-# buff-schema field the runtime renders (``btd6_upgrade_detail_service._BUFF_FIELDS``).
-# ONLY mappings whose semantics are **confirmed against the committed wiki value
-# on a matching tier** belong here (correctness over coverage):
-#   * RateSupportModel.multiplier  → rateMultiplier   (Sniper 0-5-x: raw 0.75 == wiki 0.75)
-#   * PoplustSupportModel.ratePercentIncrease/piercePercentIncrease
-#                                  → ratePercentage / piercePercentage (Druid 0-0-5: 0.15/0.15)
-# The other ~36 *SupportModel/*BuffModel types are deferred until each is
-# likewise confirmed (e.g. PierceSupportModel.pierce was NOT confirmable — the
-# wiki's pierce buffs are multipliers from a different model). See
+# Buff/support decode. A buff model's raw effect field → the committed
+# buff-schema field (``btd6_upgrade_detail_service._BUFF_FIELDS`` + the cash
+# fields the wiki stores). ONLY mappings whose value is **confirmed exact
+# against the committed wiki buff on a matching tier** belong here (correctness
+# over coverage); each line below was verified field-by-field:
+#   * RateSupportModel.multiplier → rateMultiplier              (Sniper 0-5-x: 0.75)
+#   * PoplustSupportModel.{rate,pierce}PercentIncrease → {rate,pierce}Percentage
+#                                                              (Druid 0-0-5: 0.15/0.15)
+#   * SubCommanderSupportModel.{pierceIncrease,damageIncrease,damageScale}
+#       → pierceAdditive / damageAdditive / damageMultiplier   (Sub 0-0-5: 4/0/2)
+#   * PiercePercentageSupportModel.percentIncrease → pierceMultiplier
+#                                                  (Mermonkey 3/4/5-xx: 1.1/1.2/1.4)
+#   * TradeEmpireBuffModel.{cashPerRoundPerMechantship,cashPerRoundPerFavouredTrades,
+#       damageBuff,ceramicDamageBuff,moabDamageBuff}
+#       → same-name cash + damageAdditive[ForCeramic/ForMoabs] (Bucc 0-0-5: 10/20/1/1/1)
+# Other types stay deferred until each is likewise confirmed (e.g.
+# PierceSupportModel.pierce was NOT confirmable). See
 # ``btd6-gamedata-decode-status.md`` step 5 for the worklist + decode classes.
 _BUFF_FIELD_MAP: dict[str, dict[str, str]] = {
     "RateSupportModel": {"multiplier": "rateMultiplier"},
     "PoplustSupportModel": {
         "ratePercentIncrease": "ratePercentage",
         "piercePercentIncrease": "piercePercentage",
+    },
+    "SubCommanderSupportModel": {
+        "pierceIncrease": "pierceAdditive",
+        "damageIncrease": "damageAdditive",
+        "damageScale": "damageMultiplier",
+    },
+    "PiercePercentageSupportModel": {"percentIncrease": "pierceMultiplier"},
+    "TradeEmpireBuffModel": {
+        "cashPerRoundPerMechantship": "cashPerRoundPerMechantship",
+        "cashPerRoundPerFavouredTrades": "cashPerRoundPerFavouredTrades",
+        "damageBuff": "damageAdditive",
+        "ceramicDamageBuff": "damageAdditiveForCeramic",
+        "moabDamageBuff": "damageAdditiveForMoabs",
     },
 }
 

--- a/tests/unit/scripts/test_parse_gamedata.py
+++ b/tests/unit/scripts/test_parse_gamedata.py
@@ -925,3 +925,57 @@ def test_unconfirmed_buff_types_emit_nothing(mod):
         {"$type": _t("PierceSupportModel"), "pierce": 3.0, "buffLocsName": "X"}
     )
     assert "buffs" not in mod._map_tier(model)
+
+
+def test_buffs_subcommander_maps_three_fields(mod):
+    # Sub 0-0-5 Sub Commander: raw 4/0/2 == wiki pierceAdditive/damageAdditive/damageMultiplier.
+    model = _tower_model()
+    model["behaviors"].append(
+        {
+            "$type": _t("SubCommanderSupportModel"),
+            "buffLocsName": "SubCommanderBuff",
+            "pierceIncrease": 4,
+            "damageIncrease": 0,
+            "damageScale": 2.0,
+            "isGlobal": False,
+        }
+    )
+    buff = mod._map_tier(model)["buffs"][0]
+    assert buff["pierceAdditive"] == 4
+    assert buff["damageAdditive"] == 0
+    assert buff["damageMultiplier"] == 2
+
+
+def test_buffs_pierce_percentage_maps_to_pierce_multiplier(mod):
+    # Mermonkey: raw percentIncrease 1.4 == wiki pierceMultiplier 1.4.
+    model = _tower_model()
+    model["behaviors"].append(
+        {
+            "$type": _t("PiercePercentageSupportModel"),
+            "buffLocsName": "BuffMermonkeyPierce",
+            "percentIncrease": 1.4,
+        }
+    )
+    assert mod._map_tier(model)["buffs"][0]["pierceMultiplier"] == 1.4
+
+
+def test_buffs_trade_empire_cash_and_damage(mod):
+    # Buccaneer 0-0-5 Trade Empire: cash-per-round + flat damage additives.
+    model = _tower_model()
+    model["behaviors"].append(
+        {
+            "$type": _t("TradeEmpireBuffModel"),
+            "buffLocsName": "TradeEmpireBuff",
+            "cashPerRoundPerMechantship": 10.0,
+            "cashPerRoundPerFavouredTrades": 20.0,
+            "damageBuff": 1,
+            "ceramicDamageBuff": 1,
+            "moabDamageBuff": 1,
+        }
+    )
+    buff = mod._map_tier(model)["buffs"][0]
+    assert buff["cashPerRoundPerMechantship"] == 10
+    assert buff["cashPerRoundPerFavouredTrades"] == 20
+    assert buff["damageAdditive"] == 1
+    assert buff["damageAdditiveForCeramic"] == 1
+    assert buff["damageAdditiveForMoabs"] == 1


### PR DESCRIPTION
## Summary

Continues the correctness-first buff decode. Three more `*SupportModel`/`*BuffModel` types, each **verified field-by-field exact against the committed wiki buff on a matching tier**:

| Type | Mapping | Confirmation |
|---|---|---|
| `SubCommanderSupportModel` | `pierceIncrease→pierceAdditive`, `damageIncrease→damageAdditive`, `damageScale→damageMultiplier` | Sub 0-0-5: 4 / 0 / 2 |
| `PiercePercentageSupportModel` | `percentIncrease→pierceMultiplier` | Mermonkey 3/4/5-xx: 1.1 / 1.2 / 1.4 |
| `TradeEmpireBuffModel` | cash-per-round fields + `damageBuff→damageAdditive`, `ceramicDamageBuff→damageAdditiveForCeramic`, `moabDamageBuff→damageAdditiveForMoabs` | Buccaneer 0-0-5: 10 / 20 / 1 / 1 / 1 |

## Method (correctness over coverage)

I built a roster-wide **value-discovery harness** (for each committed buff field+value, find the raw model+field that matches on the same tower). It surfaces candidates but **produces false positives from value coincidence** — e.g. it suggested `PrinceOfDarknessZombieBuffModel.distanceMultiplier → lifespanMultiplier`, which is semantically wrong. So each candidate is **hand-vetted on its tower** before being written; the harness is a lead, not a source of truth. The remaining 33 types stay deferred pending the same confirmation.

## Safety
- `--audit` stays **nothing-SUSPECT** (buff names are the dump's internal ids, so the fidelity audit aligns by name and ignores them).
- No data cutover; mapper-side decode verified by tests.

## Tests / docs
3 hermetic tests added (55 mapper tests total); lint + architecture clean (no `disbot/` source touched, so mypy scope is unaffected). `btd6-gamedata-decode-status.md` updated: **buffs 2→5 of 38**, with the discovery-harness caveat recorded.

## Remaining
Buffs: 33 types (one+ confirmed per pass) + `SCHEMA_FIRST` renderer fields. Zones: the 28-type effect tail + sub-tower-nested zones. Then economy-attack suppression → the tower cutover.

https://claude.ai/code/session_01TJvgoQyKFxXrUUQ9iWsGhn

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJvgoQyKFxXrUUQ9iWsGhn)_