### PR TITLE
docs(btd6): capture phrasing-sensitivity cluster (PMFC + Mermonkey) — behaviour layer, not data

### DIFF
--- a/docs/btd6-absence-claim-guard-design.md
+++ b/docs/btd6-absence-claim-guard-design.md
@@ -111,6 +111,45 @@ Two hard requirements this case adds to the design:
 Scope stays **narrow**: a BTD6 unsupported-negative backstop on final generated
 answers, not a global pre-answer guard — and design-first, per the standing rule.
 
+## Update 3 (2026-06-04, later) — phrasing-sensitivity cluster (the next layer)
+
+After tonight's *data-reachability* fixes (descriptions #485, costs #486), the
+remaining failures are a different layer: **the answer outcome depends on how the
+question is phrased / resolved, not on whether the data exists.** Two clean A/B
+repros, both verified in-sandbox (the data is present in every case):
+
+- **PMFC damage type.** "What's the damage type of PMFC (0-5-DART)" → **answered**
+  ideally (main attack = Sharp, *and* "the ability-conversion damage isn't in my
+  data"). "What is the damage type when plasma monkey fan club ability is
+  activated" → **refused** — even though it resolved the upgrade and had the Sharp
+  fact in its grounding. Difference: the first resolved the **tower** (Dart
+  Monkey, 63 facts); the second resolved the **upgrade** (4 facts) and the
+  conceptual "when ability activated" framing pushed it to refuse wholesale.
+- **Mermonkey bottom path.** Full per-tier stats → answered; "what does mermonkey
+  bottom path do" → **refused despite 52 grounded facts**; "explain what the
+  bottom path does" (no tower named) → refused (0 facts, routed general).
+
+Three contributing mechanisms (all reproduced via `btd6_context_service.build`):
+
+1. **Conversational context isn't carried.** A follow-up with no entity ("explain
+   what the bottom path does") routes to `general.nl_answer` with 0 facts — the
+   tower from prior turns isn't fed to resolution.
+2. **Upgrade-resolution gives thin grounding.** Resolving to an upgrade (PMFC → 4
+   facts) attaches far less than resolving to the tower (Dart Monkey → 63), so a
+   conceptual question over the thin set has little to stand on.
+3. **Partial-answer vs. refuse is inconsistent.** The *ideal* is the PMFC tower
+   phrasing: answer the grounded part, flag the ungrounded part. The model
+   instead refuses wholesale when the framing emphasizes the ungrounded part —
+   the deny/absence reflex over **present** grounding.
+
+**These are behaviour/resolution-layer fixes, not reachability fixes** (the data
+is reachable — proven). They need design + live verification, so they are
+captured here, not built blind. They share this doc's root question and the
+derived-value finding's: *what does the model treat as answerable from the
+grounding it has?* Mechanism (3) is the highest-value and most general — "answer
+what's grounded, flag the rest" should be the default, never a wholesale refusal
+when relevant grounding is present.
+
 ---
 
 ## 1. The problem

--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -211,8 +211,19 @@ game-data dump clone**, so this session did the work that is verifiable here and
     are grounded by construction, with no dependence on the model calling a tool.
     Verified in-sandbox (super monkey: 17 lines; True Sun God Impoppable per-buy
     $600,000; numbers reconcile). *Live-owed: the re-ask must now answer.*
-- **Round "heaviest waves" ranker — FIXED.** `round_composition` now returns a
-  pre-ranked `heaviest` (by count, with a bloon) / `heaviest_by_rbe` (by RBE,
+- **Live bug-report round 4 (phrasing-sensitivity cluster) — diagnosed, NOT a
+  data gap.** With tonight's reachability fixes in, the remaining failures are a
+  behaviour layer: the answer depends on phrasing/resolution, not data presence.
+  Clean A/B repros (verified in-sandbox — data present in all): "PMFC (0-5-DART)"
+  answered ideally (Sharp + flagged the ability-conversion gap) while "...when
+  plasma monkey fan club ability is activated" refused with the Sharp fact in
+  hand; "what does mermonkey bottom path do" refused despite **52** grounded
+  facts; "explain what the bottom path does" (no tower named) routed general with
+  0 facts. Three mechanisms: (1) conversational context not carried into
+  resolution; (2) upgrade-resolution gives thin grounding (4 facts) vs tower
+  (63); (3) **partial-answer-vs-refuse** — the model refuses wholesale instead of
+  answering the grounded part + flagging the gap. Captured in the absence-claim
+  design **Update 3**; behaviour/resolution-layer, design-first, not built blind.
   without), ranked over the **full** range before the detail cap, so the model
   never re-sorts and a wide range can't truncate a heavy late round. Verified vs
   ground truth: ceramics r30–80 → `[(78,147),(74,135),(63,122),(76,60),(65,50),


### PR DESCRIPTION
Doc-only. Captures the live failure cluster from tonight's continued testing (Mermonkey + PMFC), with the in-sandbox diagnosis, so it isn't lost.

## The finding
With tonight's **data-reachability** fixes merged (descriptions #485, costs #486), the remaining refusals are a **different layer**: the answer depends on *how the question is phrased / resolved*, not on whether the data exists. Verified in-sandbox — the data is present in every case.

**Clean A/B repros:**
- **PMFC damage type.** "What's the damage type of PMFC (0-5-DART)" → answered *ideally* (main attack = Sharp, **and** "the ability-conversion damage isn't in my data"). "...when plasma monkey fan club ability is activated" → **refused**, even though it resolved the upgrade and had the Sharp fact in its 4 grounded facts. (First resolved the **tower** → 63 facts; second the **upgrade** → 4 facts + a conceptual framing that triggered a wholesale refusal.)
- **Mermonkey bottom path.** Per-tier stats → answered; "what does mermonkey bottom path do" → **refused despite 52 grounded facts**; "explain what the bottom path does" (no tower named) → refused (0 facts, routed `general`).

## Three mechanisms (reproduced via `btd6_context_service.build`)
1. **Conversational context not carried** — a follow-up with no entity routes to `general.nl_answer` with 0 facts.
2. **Upgrade-resolution gives thin grounding** — upgrade (4 facts) vs tower (63).
3. **Partial-answer vs. refuse is inconsistent** — the ideal is "answer the grounded part, flag the gap" (PMFC tower phrasing did exactly this); the model instead refuses wholesale when the framing emphasizes the ungrounded part.

## Why no code
These are **behaviour/resolution-layer** issues, not reachability gaps — the data is reachable (proven). They need design + live verification, so they're captured (absence-claim design **Update 3** + status-ledger bullet), not built blind. Mechanism (3) — "answer what's grounded, flag the rest, never refuse wholesale when relevant grounding is present" — is the highest-value, most general fix and the natural next target.

No code changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_012s22Kt2tbLGC5yXQf5eUgX)_